### PR TITLE
fix(hooks): allow markdown backtick inline-code in resolved publish bodies (#1415)

### DIFF
--- a/src/teatree/hooks/_body_file_resolution.py
+++ b/src/teatree/hooks/_body_file_resolution.py
@@ -68,11 +68,18 @@ def resolve_inline_body_value(value: str, base: Path | None) -> str:
     - anything else -- returned verbatim (a normal inline body).
 
     A value the resolver returns verbatim that STILL carries an unexpanded
-    command-substitution marker (a mixed ``"prefix $(cat x)"`` the single-form
-    matchers above do not fully resolve) yields the fail-closed sentinel: the
-    embedded substitution's content is unreadable, so passing the literal would
-    let a leak inside it slip. Resolution is never a bypass -- an unresolvable
-    source always fails closed.
+    ``$(...)`` command-substitution marker (a mixed ``"prefix $(cat x)"`` the
+    single-form matchers above do not fully resolve) yields the fail-closed
+    sentinel: the embedded substitution's content is unreadable, so passing the
+    literal would let a leak inside it slip. Resolution is never a bypass -- an
+    unresolvable ``$(...)`` source always fails closed.
+
+    A backtick is NOT a fail-closed trigger. The extracted value is a literal
+    argv element the gate only SCANS (never re-feeds to a shell), so a markdown
+    inline-code span (a function name / flag / path in backticks, the common
+    case in real PR/issue bodies) is inert data fully present in the value and
+    fully scanned -- blocking on it was a pure false positive that forced
+    ``--body-file``/heredoc workarounds.
     """
     cat_match = _CAT_SUBST_RE.match(value)
     if cat_match is not None:
@@ -83,7 +90,7 @@ def resolve_inline_body_value(value: str, base: Path | None) -> str:
     if var_match is not None:
         resolved = os.environ.get(var_match.group("name"))
         return resolved if resolved is not None else FAIL_CLOSED_SENTINEL
-    if "$(" in value or "`" in value:
+    if "$(" in value:
         return FAIL_CLOSED_SENTINEL
     return value
 

--- a/tests/teatree_hooks/test_banned_terms_scanner.py
+++ b/tests/teatree_hooks/test_banned_terms_scanner.py
@@ -679,6 +679,70 @@ class TestEnvVarBodyResolution:
         assert FAIL_CLOSED_SENTINEL in payload
 
 
+class TestMarkdownBacktickBodyResolves:
+    """A ``--body`` with markdown inline-code backticks resolves to the body verbatim.
+
+    Markdown PR/issue bodies routinely carry inline-code spans (a function
+    name, a flag, a path in single backticks). The extracted ``--body`` value
+    is a literal argv element the gate only SCANS -- it is never re-fed to a
+    shell -- so a backtick is inert data, not a live command substitution. The
+    resolver must return such a body so the banned-terms scan runs against the
+    real text, rather than fail-closing on the presence of any backtick (which
+    forced agents into ``--body-file``/heredoc workarounds).
+    """
+
+    def test_gh_body_with_backtick_inline_code_resolves_verbatim(self) -> None:
+        body = "renamed the `resolve_inline_body_value` helper in the parser"
+        cmd = f'gh pr create -R o/r --title t --body "{body}"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "resolve_inline_body_value" in payload
+        assert FAIL_CLOSED_SENTINEL not in payload
+
+    def test_glab_description_with_backtick_inline_code_resolves_verbatim(self) -> None:
+        body = "set `enabled = true` then run `t3 worktree start`"
+        cmd = f'glab mr create -R o/r --title t --description "{body}"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "t3 worktree start" in payload
+        assert FAIL_CLOSED_SENTINEL not in payload
+
+    def test_backtick_body_still_blocks_a_banned_term(self) -> None:
+        # The fix only stops fail-closing on the backtick; the banned-terms scan
+        # is untouched, so a real term inside a backtick body is still surfaced.
+        body = "ship `the feature` to acmecorp next week"
+        cmd = f'gh pr create -R o/r --title t --body "{body}"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "acmecorp" in payload
+        assert FAIL_CLOSED_SENTINEL not in payload
+
+
+class TestMixedCommandSubstitutionBodyStillFailsClosed:
+    """A body whose ``$(...)`` substitution content the gate cannot read fails closed.
+
+    Backticks being inert data does NOT relax the genuine
+    command-substitution guard. A mixed ``"prefix $(cat <path>)"`` body's
+    substitution content is unread (only the exact ``$(cat <path>)`` form is
+    resolved), so passing the literal would let a leak inside it slip -- it
+    still fails closed.
+    """
+
+    def test_mixed_dollar_paren_cat_subst_fails_closed(self) -> None:
+        body = "release notes header $(cat /no/such/secret-xyz.md)"
+        cmd = f'gh pr create -R o/r --title t --body "{body}"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert FAIL_CLOSED_SENTINEL in payload
+
+    def test_bare_dollar_paren_subst_fails_closed(self) -> None:
+        body = "$(printf nope)"
+        cmd = f'gh pr create -R o/r --title t --body "{body}"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert FAIL_CLOSED_SENTINEL in payload
+
+
 class TestReadOnlyCommandsAreNotPublishes:
     """A read-only command that merely QUOTES a publish substring is NOT a post.
 


### PR DESCRIPTION
## Summary

The inline body resolver in _body_file_resolution.py (resolve_inline_body_value) refused to resolve a publish body whenever the value contained a backtick, treating a markdown inline-code span as if it were a live shell command substitution. Legitimate markdown PR/issue bodies routinely contain inline-code, so the publish gate over-blocked normal posting and agents were forced into body-file or heredoc workarounds.

## Root cause

The extracted body value is a literal argv element. The gate only scans this value for banned terms and secrets; it is never re-fed to a shell (the harness runs the original command string verbatim). So a backtick in the extracted value is inert data, fully present in the value and fully scanned. The blanket backtick guard was a pure false positive.

The genuine concern the guard exists for is an unexpanded command substitution whose embedded content the resolver cannot read. That concern is real for the dollar-paren command-substitution shape only, where unread substitution content could hide a leak.

## Fix

Narrow the guard to the genuine dollar-paren command-substitution shape and stop refusing backticks. The banned-terms scan itself is untouched: a real banned term inside a backtick body is still surfaced and blocked.

## Tests

Added to tests/teatree_hooks/test_banned_terms_scanner.py, integration-leaning through extract_publish_payload:

- must-ALLOW: a body with markdown inline-code backticks resolves and proceeds to the banned-terms scan (verified red on the prior code, green after the fix; anti-vacuous check confirmed by reverting the fix).
- must-still-BLOCK: a banned term inside a backtick body is still surfaced; a mixed and a bare dollar-paren command substitution are still refused.

## Architecture pre-check

1. BLUEPRINT alignment: pre-publish gate body resolution (hooks layer); no BLUEPRINT section changes.
2. FSM phase boundaries: not applicable.
3. Extension-point contracts: not applicable.
4. Component boundaries: change stays in src/teatree/hooks/, the gate layer.
5. Dependency direction: no new imports; no backwards edge.
6. Test surface: extract_publish_payload assertions named above.
7. Resilience invariants: read-only inspection of a command string; no external write.
8. Identity and key normalization: not applicable.
9. Behavior preservation: a single-call-site narrowing of a false-positive guard, not a privacy or leak matcher narrowing. The banned-terms and secret scans are unchanged; the dollar-paren command-substitution refusal path is preserved (pinned by the must-still-BLOCK tests). No must-block test was inverted.
