### PR TITLE
fix(hooks): stop the quote-scanner flagging inert prose that names the sentinel (#1213)

### DIFF
--- a/src/teatree/hooks/_command_parser.py
+++ b/src/teatree/hooks/_command_parser.py
@@ -85,14 +85,22 @@ FAIL_CLOSED_SENTINEL: Final[str] = "[teatree-gate] pre-publish scanner could not
 
 
 def is_fail_closed_sentinel(text: str) -> bool:
-    """Return True iff ``text`` carries the injected fail-closed sentinel.
+    """Return True iff ``text`` carries an INJECTED fail-closed sentinel.
 
-    Callers fail closed on a NAMED reason rather than rely on the
-    sentinel accidentally tripping a content pattern (#126). The sentinel
-    can be one of several concatenated payload fragments, so a substring
-    test is used rather than equality.
+    The parser emits the sentinel as its own discrete payload fragment for
+    every unresolvable/ambiguous body source, and the fragments are joined
+    by newlines — so a genuinely-injected sentinel is always a standalone
+    newline-delimited line equal to :data:`FAIL_CLOSED_SENTINEL`. The gate
+    fails closed on that NAMED reason (#126).
+
+    A body that merely MENTIONS the sentinel as inert prose inside a
+    properly-quoted argument value (a commit message or PR body that
+    DISCUSSES the gate) embeds the phrase mid-line, not as a standalone
+    line. That is not a quoting hazard — the argument is correctly quoted —
+    so the line-exact test allows it while every genuine injection (the
+    sentinel on its own line) still fails closed (#1213).
     """
-    return FAIL_CLOSED_SENTINEL in text
+    return any(line.strip() == FAIL_CLOSED_SENTINEL for line in text.split("\n"))
 
 
 def _segment_is_t3_publish(words: list[str]) -> bool:

--- a/src/teatree/hooks/quote_scanner.py
+++ b/src/teatree/hooks/quote_scanner.py
@@ -261,19 +261,23 @@ def scan_text(text: str, *, blocklist_path: Path | None = None) -> ScanResult:
     matching so a single regex catches all typographic forms.
 
     A body the parser could not resolve carries the fail-closed sentinel
-    (``FAIL_CLOSED_SENTINEL``). That sentinel is recognised EXPLICITLY as
-    a HIGH finding rather than relying on it tripping a content pattern —
-    the old wording self-matched ``the-user-said-colon`` and produced a
-    bogus user-quote finding on a body the scanner never saw (#126). The
-    sentinel is excised before content matching so the fail-closed marker
-    text itself can never produce a second, content-shaped finding.
+    (``FAIL_CLOSED_SENTINEL``) as its own discrete payload line. That line
+    is recognised EXPLICITLY as a HIGH finding rather than relying on it
+    tripping a content pattern — the old wording self-matched
+    ``the-user-said-colon`` and produced a bogus user-quote finding on a
+    body the scanner never saw (#126). Only the standalone sentinel LINES
+    are excised before content matching, so a prose body fragment that
+    merely names the sentinel on a different line is still scanned, while
+    the marker text itself can never produce a second content-shaped
+    finding. Inert prose that names the sentinel mid-line never trips the
+    fail-closed branch at all (#1213).
     """
     result = ScanResult()
     if not text:
         return result
     if _is_fail_closed_sentinel(text):
         result.findings.append(Finding(name="fail-closed-sentinel", severity=HIGH, excerpt="unresolved body source"))
-        text = text.replace(_FAIL_CLOSED_SENTINEL, "")
+        text = "\n".join(line for line in text.split("\n") if line.strip() != _FAIL_CLOSED_SENTINEL)
         if not text.strip():
             return result
     normalized = _normalize_quotes(text)

--- a/tests/teatree_hooks/test_quote_scanner.py
+++ b/tests/teatree_hooks/test_quote_scanner.py
@@ -966,6 +966,70 @@ class TestFailClosedSentinelNoSelfMatch:
         assert {f.name for f in scan.findings} == {"fail-closed-sentinel"}
 
 
+class TestSentinelProseIsNotAFailClosedMatch:
+    """Inert prose that NAMES the sentinel is not the fail-closed condition (#1213).
+
+    The gate exists to block an unresolvable/ambiguous body source — the
+    parser injects the sentinel as its own discrete payload fragment for
+    that. A commit message or PR body that merely DISCUSSES the gate (and so
+    contains the sentinel phrase inside a properly-quoted argument value) is
+    not a quoting hazard: the argument is correctly quoted, the phrase is
+    documentation. It must pass.
+    """
+
+    def test_commit_message_naming_the_sentinel_phrase_is_allowed(self) -> None:
+        # A commit whose -m message quotes the full sentinel string as prose.
+        body = f"fix(hooks): stop the quote-scanner flagging inert prose that names the {FAIL_CLOSED_SENTINEL} marker"
+        cmd = f"git commit -m {body!r}"
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert not is_fail_closed_sentinel(payload)
+        scan = scan_text(payload)
+        assert not scan.has_high
+
+    def test_pr_body_naming_the_sentinel_phrase_is_allowed(self) -> None:
+        # A gh pr create whose --body documents the gate, quoting the sentinel.
+        body = (
+            "This PR explains why the scanner fails closed. The injected marker is "
+            f"{FAIL_CLOSED_SENTINEL} and the gate refuses the post when it appears."
+        )
+        cmd = f"gh pr create --title fix --body {body!r}"
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert not is_fail_closed_sentinel(payload)
+        scan = scan_text(payload)
+        assert not scan.has_high
+
+    def test_scan_text_on_mid_line_sentinel_prose_has_no_finding(self) -> None:
+        prose = (
+            "We document the behaviour: when the scanner cannot resolve a body it "
+            f"emits {FAIL_CLOSED_SENTINEL} and blocks. End of explanation."
+        )
+        assert not is_fail_closed_sentinel(prose)
+        scan = scan_text(prose)
+        assert {f.name for f in scan.findings} == set()
+
+    def test_genuine_injected_sentinel_still_blocks(self) -> None:
+        # The parser injects the sentinel as its own line — that must still fire.
+        cmd = "gh api repos/o/r/issues --input -"
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert is_fail_closed_sentinel(payload)
+        scan = scan_text(payload)
+        assert scan.has_high
+        assert {f.name for f in scan.findings} == {"fail-closed-sentinel"}
+
+    def test_genuine_sentinel_blocks_even_alongside_a_clean_body_fragment(self) -> None:
+        # A clean body on one segment + an unresolvable body on another: the
+        # sentinel rides its own line and the gate still fails closed.
+        cmd = 'gh issue create --body "a clean note" && gh api repos/o/r/issues --input -'
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert is_fail_closed_sentinel(payload)
+        scan = scan_text(payload)
+        assert scan.has_high
+
+
 class TestHeredocToFileDashF:
     """``cat > path <<EOF … EOF; git commit -F path`` resolves the body (#126)."""
 


### PR DESCRIPTION
## Summary

The #1213 pre-publish quote-scanner gate refused ordinary publish commands whose
message or body merely DISCUSSED the gate. The fail-closed marker was recognised
by a loose substring test, so a `git commit -m "..."` or `gh pr create --body
"..."` whose text named the marker phrase inside a properly-quoted argument
self-tripped the fail-closed branch and was blocked — forcing a `QUOTE_OK=1`
workaround on inert prose.

A correctly-quoted string argument that happens to contain the words is not a
quoting hazard, so it now passes. The genuine condition the gate guards — an
unresolvable or ambiguous body source — still fails closed.

## Root cause

The parser injects the marker as its own discrete payload fragment for every
unresolvable/ambiguous body source, and the fragments are joined by newlines —
so a real injection is always a standalone newline-delimited line. The old
predicate matched any substring occurrence, which cannot tell an injected marker
apart from a body fragment that merely names the phrase mid-line.

## Fix

- Recognise the marker only as a line-exact match (the parser's injection shape)
  instead of any substring occurrence.
- `scan_text` excises only the standalone marker lines, so a clean body fragment
  alongside a genuine injection is still scanned.
- The predicate is shared with the banned-terms scanner, which had the same
  prose false positive; both gates are fixed in lockstep.

## What still blocks (protection preserved)

Every genuinely unresolvable body source still fails closed, since the marker
there rides its own line:

- `gh api --input -` (stdin) and `--input <missing-file>`
- an absent `--body-file $VAR` / `--body "$(cat <missing>)"`
- a missing `git commit -F <path>`
- `curl -d @file`

## Tests

- must-ALLOW (RED on main, GREEN after fix): a `git commit -m` and a `gh pr
  create --body` whose text names the marker as prose pass the scanner with no
  HIGH finding.
- must-still-BLOCK (green throughout): the genuine fail-closed injections above
  still produce the HIGH finding.
- Anti-vacuous: reverting the predicate reproduces the false positive (the
  must-allow tests go red).
- Full hooks suite (quote-scanner, banned-terms, publish-surface/destination,
  golden corpus) green; the regression corpus, privacy gate, and mutation-kill
  proof green; ruff check/format, ty, and tach all green.

## Architecture pre-check — #1213

1. BLUEPRINT § alignment: the #1213 leak-prevention gate; a detection-predicate
   refinement, no FSM/Overlay surface.
2. FSM phase boundaries: n/a.
3. Extension-point contracts: the shared `is_fail_closed_sentinel` predicate is
   consumed by both `quote_scanner` and `banned_terms_scanner`; both benefit.
4. Component boundaries: `hooks/_command_parser.py` (predicate) and
   `hooks/quote_scanner.py` (excision). No new module.
5. Dependency direction: no import added; tach green.
6. Test surface: must-allow + must-still-block in
   `tests/teatree_hooks/test_quote_scanner.py`, observed red→green.
7. Resilience invariants: read-only detection pass; idempotent; fail-closed
   protection preserved, not weakened.
8. Identity and key normalization: canonicalizes the match to the parser's
   injection shape (a line-exact form) rather than a loose substring.
9. Behavior preservation / capability deletion: this narrows a safety-gate
   matcher (substring to line-exact). The only dropped case is inert prose
   naming the marker inside a properly-quoted argument — never a quoting hazard,
   so dropping the block there is the bug fix. Every genuine injection is
   preserved; no must-block test is inverted. The true target of the protection
   is unchanged, so no user sign-off is required.

## Open questions & assumptions

- Assumes the parser always emits the marker as its own discrete payload
  fragment; verified across every injection site that the marker lands on a
  standalone line in the joined payload.
