### PR TITLE
test(migrations): add E005 multi-leaf-graph regression test (#2277)

### DIFF
--- a/tests/teatree_core/test_linear_migrations.py
+++ b/tests/teatree_core/test_linear_migrations.py
@@ -13,15 +13,23 @@ from pathlib import Path
 
 import django.conf
 from django.core.checks import run_checks
+from django.db.migrations.loader import MigrationLoader
 from django.test import SimpleTestCase
 
 _CORE_MIGRATIONS_DIR = Path(__file__).resolve().parents[2] / "src" / "teatree" / "core" / "migrations"
 _MAX_MIGRATION_TXT = _CORE_MIGRATIONS_DIR / "max_migration.txt"
+_SIBLING_LEAF = _CORE_MIGRATIONS_DIR / "0001_sibling_leaf_fork.py"
 
 
 def _real_latest_migration() -> str:
     names = sorted(p.stem for p in _CORE_MIGRATIONS_DIR.glob("[0-9]*.py"))
     return names[-1]
+
+
+def _core_leaf_parent() -> str:
+    loader = MigrationLoader(None, ignore_no_migrations=True)
+    leaf = max(node for node in loader.graph.leaf_nodes() if node[0] == "core")
+    return next(parent.key[1] for parent in loader.graph.node_map[leaf].parents)
 
 
 class LinearMigrationsCheckTest(SimpleTestCase):
@@ -33,6 +41,7 @@ class LinearMigrationsCheckTest(SimpleTestCase):
             self._original_content = _MAX_MIGRATION_TXT.read_text()
 
     def tearDown(self) -> None:
+        _SIBLING_LEAF.unlink(missing_ok=True)
         if self._original_content is None:
             _MAX_MIGRATION_TXT.unlink(missing_ok=True)
         else:
@@ -63,6 +72,19 @@ class LinearMigrationsCheckTest(SimpleTestCase):
         _MAX_MIGRATION_TXT.write_text("0001_initial\n")
         errors = self._dlm_errors()
         assert "dlm.E004" in errors, f"stale max_migration.txt must yield dlm.E004; got {errors}"
+
+    def test_multiple_leaf_nodes_raises_e005(self) -> None:
+        parent = _core_leaf_parent()
+        _SIBLING_LEAF.write_text(
+            "from django.db import migrations\n\n\n"
+            "class Migration(migrations.Migration):\n"
+            f'    dependencies = [("core", "{parent}")]\n'
+            "    operations: list = []\n"
+        )
+        errors = self._dlm_errors()
+        assert "dlm.E005" in errors, (
+            f"a forked migration graph (two leaf nodes off {parent!r}) must yield dlm.E005; got {errors}"
+        )
 
     def test_dlm_installed_in_apps(self) -> None:
         assert "django_linear_migrations" in django.conf.settings.INSTALLED_APPS, (


### PR DESCRIPTION
## Summary

The django-linear-migrations adoption (#2355) added system checks that fail loudly on forked migration graphs (#2277). The test suite covered E001 (missing `max_migration.txt`), E002 (merge-conflict residue), and E004 (stale leaf), but not **E005** — the headline #2277 scenario: an actual multiple-leaf-nodes graph fork (two migrations each depending on the same parent → two leaf nodes). The mechanism works, but the primary scenario had no regression test locking it.

This adds a single regression test, `test_multiple_leaf_nodes_raises_e005`, that:

- Materializes a genuine two-leaf graph fork by writing a sibling migration depending on the same parent as the current `core` leaf. The parent is derived dynamically from the loader graph (`_core_leaf_parent()`), so the test stays correct as migrations accrue.
- Asserts `dlm.E005` is reported by the live `check --tag models` run (real check, no mocks — mirroring the existing E001/E002/E004 tests' harness).
- Cleans the sibling migration file up in `tearDown`, alongside the existing `max_migration.txt` restoration.

## Anti-vacuity

Confirmed locally: dropping `django_linear_migrations` from `INSTALLED_APPS` makes the check stop reporting and the new test fails (`got []`). Restoring it returns the suite to green. This matches the existing `test_dlm_installed_in_apps` anti-vacuity pattern in the same file.

## Verification

- `pytest tests/teatree_core/test_linear_migrations.py --no-cov -q` — 6 passed (5 existing + new).
- `ruff check` / `ruff format --check` — clean.
- `ty check` — clean.

## Architecture pre-check — #2277

### 1. BLUEPRINT § alignment
Test-only change reinforcing an existing deterministic migration-graph guard. No BLUEPRINT section is contradicted or extended.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition involved.

### 3. Extension-point contracts
n/a — no `OverlayBase` / scanner / hook / Protocol surface touched. The test exercises the upstream django-linear-migrations system check via Django's check framework only.

### 4. Component boundaries
`tests/teatree_core/` — a unit test alongside the existing migration-graph check tests. Correct home; no straddling.

### 5. Dependency direction
One import added in test code (`django.db.migrations.loader.MigrationLoader`). No production import added, no backwards edge. `tach` passed in pre-commit.

### 6. Test surface
The behaviour locked: a forked migration graph with two leaf nodes off the same parent yields `dlm.E005`. Asserted directly against the live check output. Proven anti-vacuous (red without the app in `INSTALLED_APPS`).

### 7. Resilience invariants
n/a — no external write; the test mutates only a throwaway file under the migrations dir and restores it in `tearDown`.

### 8. Identity and key normalization
n/a — no identity/key normalization. The leaf parent is read from the canonical loader graph rather than parsed from a filename.

### 9. Behavior preservation / capability deletion
n/a — purely additive. No existing test inverted, no matcher narrowed.
