### PR TITLE
fix(e2e): render browser-click-first steps when a manifest has no media

### DIFF
--- a/src/teatree/core/management/commands/_test_plan_render.py
+++ b/src/teatree/core/management/commands/_test_plan_render.py
@@ -464,13 +464,14 @@ def _dev_gap_clause(side: SideState) -> str:
 
 
 def _workflow_names(state: TestPlanState) -> list[str]:
-    """The ordered union of workflow names across both sides (dev order, then new local)."""
-    names: list[str] = []
-    for side in (state["dev"], state["local"]):
-        for name in side.get("workflows", {}):
-            if name not in names:
-                names.append(name)
-    return names
+    """Ordered union of both sides' media-bearing workflows and the steps-only ones.
+
+    A steps-only manifest (steps recorded, no screenshots/video) keeps its
+    workflows in ``state["steps"]``, never in either side — so they must be
+    enumerated here too or their steps never render.
+    """
+    sources = (state["dev"].get("workflows", {}), state["local"].get("workflows", {}), state.get("steps", {}))
+    return list(dict.fromkeys(name for source in sources for name in source))
 
 
 def _cells(side: SideState, workflow: str) -> tuple[str, list[str]]:

--- a/tests/teatree_core/e2e_command/test_post_test_plan.py
+++ b/tests/teatree_core/e2e_command/test_post_test_plan.py
@@ -1183,6 +1183,67 @@ class TestBrowserClickFirstTemplate(TestCase):
         assert "Not deployed yet" in visible
 
 
+class TestBrowserClickFirstStepsWithoutMedia(TestCase):
+    """A steps-only manifest (steps, no screenshots/video) must still render the steps."""
+
+    def _steps_only_state(self) -> _render.TestPlanState:
+        return {
+            "ticket": "8521",
+            "title": "Login flow",
+            "mrs": [],
+            "dev": _empty_side(env="dev"),
+            "local": {"commits": {"client": "aabb"}, "workflows": {}},
+            "steps": {"Login": ["Open the app", "Click Login", "Expect dashboard"]},
+            "template": "browser-click-first",
+        }
+
+    def test_renders_steps_when_no_media(self) -> None:
+        body = _render.render_body(self._steps_only_state())
+        visible = body.split("-->")[-1]
+        assert "### Login" in visible
+        assert "1. Open the app" in visible
+        assert "2. Click Login" in visible
+        assert "3. Expect dashboard" in visible
+
+    def test_renders_steps_when_no_media_via_production_path(self) -> None:
+        manifest = _render.parse_manifest(
+            json.dumps(
+                {
+                    "ticket": "8521",
+                    "template": "browser-click-first",
+                    "local": {"commits": {"client": "aabb"}},
+                    "workflows": [{"workflow": "Login", "steps": ["Open the app", "Click Login"]}],
+                }
+            )
+        )
+        merged = _render.merge_state(
+            _render.empty_state(ticket="8521", title="t"),
+            manifest=manifest,
+            title="Login flow",
+            embeds={"dev": {}, "local": {}},
+        )
+        body = _render.render_body(merged)
+        visible = body.split("-->")[-1]
+        assert "### Login" in visible
+        assert "1. Open the app" in visible
+        assert "2. Click Login" in visible
+
+    def test_media_and_steps_both_render(self) -> None:
+        state: _render.TestPlanState = {
+            "ticket": "8521",
+            "title": "Login flow",
+            "mrs": [],
+            "dev": _empty_side(env="dev"),
+            "local": _local_side({"Login": {"video_md": "", "image_md": ["![s1](/uploads/s/s1.png)"]}}),
+            "steps": {"Login": ["Open the app", "Click Login"]},
+            "template": "browser-click-first",
+        }
+        body = _render.render_body(state)
+        visible = body.split("-->")[-1]
+        assert "1. Open the app" in visible
+        assert "![s1](/uploads/s/s1.png)" in visible
+
+
 class TestLinkApiTemplate(TestCase):
     def _state(self) -> _render.TestPlanState:
         return {


### PR DESCRIPTION
The browser-click-first test-plan renderer dropped a manifest steps when the manifest carried steps but no media (no screenshots, no video on any side). The posted body showed only the header and the Local-tested line, the actual numbered step lines never appeared.

Root cause: _render_browser_click_first enumerates _workflow_names(state), which keyed off the media-bearing sides only. A steps-only manifest stores its workflows in state[steps], which that enumeration never consulted, so steps-only workflows were skipped entirely. This became reachable in normal use once #2351 made steps-only manifests valid (the zero-media gate now accepts a manifest whose content is steps or blocked_workflows).

Fix: _workflow_names now includes steps-only workflows (the ordered union of both sides media-bearing workflows plus state[steps]). This is the single enumeration shared by all three render paths (browser-click-first, capture-matrix, link-api), so steps already stored in state now render. The zero-media gate (#2351) is untouched.

Tests (real parse_manifest / render_body, no mocks): a steps-only browser-click-first manifest renders a body containing the heading and the numbered step lines (RED on pre-fix code, GREEN after); a manifest with media plus steps still renders both (no regression). Anti-vacuousness verified by reverting the fix and confirming the steps-only tests go RED.

Architecture pre-check: tactical single-call-site bug fix (one function, no Protocol / FSM / extension-point surface); the nine-check gate does not apply. The file stays at 499 LOC (the comprehension form offsets the added enumeration source).

Verification: pytest tests/teatree_core/e2e_command/test_post_test_plan.py = 83 passed; ruff check and ruff format --check clean; ty check clean; pre-commit hooks (incl. module-health) all passed.