### PR TITLE
fix(safety): safe-kill guard — never signal by guessed pid or while live (#2225)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -3696,6 +3696,8 @@ Usage: t3 teatree [OPTIONS] COMMAND [ARGS]...
 │ full-status     Show ticket, worktree, and session state summary.            │
 │ ship            Code to PR — create pull request for the ticket.             │
 │ daily           Daily followup — sync MRs, check gates, remind reviewers.    │
+│ safe-kill       Signal a pid only if it maps to a dead target AND is         │
+│                 confirmed non-live (#2225).                                  │
 │ agent           Launch Claude Code with overlay context and auto-detected    │
 │                 skills.                                                      │
 │ config          Overlay configuration.                                       │
@@ -3798,6 +3800,15 @@ Usage: t3 teatree daily [OPTIONS]
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 teatree safe-kill`
+
+```
+Usage: t3 teatree safe-kill [OPTIONS]
+
+ Signal a pid only if it maps to a dead target AND is confirmed non-live
+ (#2225).
 ```
 
 #### `t3 teatree agent`
@@ -4822,25 +4833,16 @@ Usage: t3 teatree e2e post-test-plan [OPTIONS]
 
  Post (or update) the ticket's single test-plan note from a manifest.
 
- There is ONE test-plan note per ticket (work item / bug), never on an
- MR. It renders as a test plan: a header (title, multi-repo MR links,
- per-env commit provenance, dev-gap reconciliation) and one side-by-side
- **Dev | Local** comparison table per workflow. The note carries a hidden
- machine-readable state blob that is the source of truth, so a re-run
- merges the env(s) it supplies over the prior state — a dev-only run
- updates the Dev column and the deployed-commits/gap line while freezing
- the Local column, and vice versa.
-
- ``--manifest`` is a path to (or inline string of) the JSON describing the
- ticket, MRs, per-env commits, dev gap, and per-workflow captures; relative
- artifact paths resolve against the manifest file's directory. ``--ticket``
- (pk / number / URL) selects the issue (auto-detected from the worktree, or
- the manifest's ``ticket`` field, when omitted); ``--title`` overrides the
- heading. ``--skip-validation`` is the user-authorised bypass of the
- red-box / duplicate image preflight. See :mod:`._test_plan`.
-
- The legacy ``post-evidence`` name is kept as a hidden, deprecated alias
- for one release so existing scripts keep working.
+ ONE note per ticket (never an MR); a re-run merges the env(s) it
+ supplies over the prior state. ``--manifest`` is the JSON path/string
+ (ticket, MRs, per-env commits, gap, captures); ``--ticket`` selects the
+ issue; ``--title`` overrides the heading; ``--template``
+ (``capture-matrix`` / ``browser-click-first`` / ``link-api``) selects
+ the body shape, overriding the manifest's ``template``;
+ ``--skip-validation`` bypasses the image preflight; ``--body-file`` posts
+ a pre-authored body verbatim (no upload; mutually exclusive with
+ ``--manifest``). See :mod:`._test_plan`. ``post-evidence`` is a hidden,
+ deprecated alias.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --manifest                                   TEXT                            │
@@ -4858,6 +4860,12 @@ Usage: t3 teatree e2e post-test-plan [OPTIONS]
 │                                                    use.                      │
 │                                                    [default:                 │
 │                                                    no-skip-validation]       │
+│ --body-file                                  TEXT                            │
+│ --template                                   TEXT  Body template:            │
+│                                                    capture-matrix (default), │
+│                                                    browser-click-first, or   │
+│                                                    link-api. Overrides the   │
+│                                                    manifest's.               │
 │ --help                                             Show this message and     │
 │                                                    exit.                     │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -4888,6 +4896,12 @@ Usage: t3 teatree e2e post-evidence [OPTIONS]
 │                                                    use.                      │
 │                                                    [default:                 │
 │                                                    no-skip-validation]       │
+│ --body-file                                  TEXT                            │
+│ --template                                   TEXT  Body template:            │
+│                                                    capture-matrix (default), │
+│                                                    browser-click-first, or   │
+│                                                    link-api. Overrides the   │
+│                                                    manifest's.               │
 │ --help                                             Show this message and     │
 │                                                    exit.                     │
 ╰──────────────────────────────────────────────────────────────────────────────╯

--- a/docs/generated/management-commands.json
+++ b/docs/generated/management-commands.json
@@ -580,6 +580,11 @@
       ]
     },
     {
+      "help": "Signal *pid* only if it maps to a dead target AND is confirmed non-live.",
+      "name": "safe_kill",
+      "subcommands": []
+    },
+    {
       "help": "Read ``text`` aloud synchronously through the local speakers per [teatree.speak].",
       "name": "speak",
       "subcommands": []

--- a/docs/generated/management-commands.md
+++ b/docs/generated/management-commands.md
@@ -299,6 +299,10 @@ Post a review request after #1829 anti-vacuity + #1094 dedup + #960 approval.
 | `lint` | Run the overlay's lint pipeline on this worktree |
 | `build-frontend` | Build the frontend app for production/testing |
 
+## `safe_kill`
+
+Signal *pid* only if it maps to a dead target AND is confirmed non-live.
+
 ## `speak`
 
 Read ``text`` aloud synchronously through the local speakers per [teatree.speak].

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -6871,15 +6871,20 @@ def handle_block_raw_pid_kill(data: dict) -> bool:
     """Deny a Bash command that signals a process by a raw, guessed pid (#2225).
 
     The agent has twice killed the WRONG, LIVE process by guessing which
-    ``claude`` pid 'looked dead'. A bare ``kill <pid>`` / ``kill -9 <pid>`` is
-    exactly that guessed-pid shape; it is denied so the agent must go through
-    ``teatree.core.safe_kill.safe_kill`` (positive session/task id + non-live
-    proof) instead. ``pkill``/``killall`` (signal by name) and ``%job``/``$VAR``
-    targets are NOT flagged.
+    ``claude`` pid 'looked dead'. A bare ``kill <pid>`` / ``kill -9 <pid>`` at a
+    command position is exactly that guessed-pid shape; it is denied so the agent
+    must go through the runnable ``t3 teatree safe-kill <pid> --hang-cause``
+    command (positive session/task id + non-live proof) instead. ``kill -0``
+    (the no-op liveness probe), ``pkill``/``killall`` (signal by name),
+    ``%job``/``$VAR``/``$(…)`` targets, and a ``kill`` token inside a comment /
+    string / as another command's argument are NOT flagged.
 
-    Fails OPEN on any import/internal error — a gate bug must never wedge the
-    agent (consistent with the other Bash-deny gates). The handler bootstraps
-    ``sys.path`` to import ``teatree`` from the sibling ``src/`` (#1314).
+    Because the gate sits on the broad ``Bash`` matcher, its deny is routed
+    through :func:`_fail_open_or_deny` so the always-allowed self-rescue commands
+    and the master ``[teatree] danger_gate_fail_open`` kill-switch keep it from
+    ever wedging a session (the never-lockout contract, #2349). Fails OPEN on any
+    import/internal error — a gate bug must never wedge the agent. The handler
+    bootstraps ``sys.path`` to import ``teatree`` from the sibling ``src/`` (#1314).
     """
     if data.get("tool_name") != "Bash":
         return False
@@ -6903,7 +6908,7 @@ def handle_block_raw_pid_kill(data: dict) -> bool:
                 sys.path.remove(str(src_dir))
     if not detection.is_raw_pid_kill:
         return False
-    return emit_pretooluse_deny(detection.message)
+    return _fail_open_or_deny(data, detection.message)
 
 
 # ── PreToolUse: block-secret-file-print (#2306) ──────────────────────

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -6867,6 +6867,45 @@ def handle_block_direct_commands(data: dict) -> bool:
     return emit_pretooluse_deny(reason)
 
 
+def handle_block_raw_pid_kill(data: dict) -> bool:
+    """Deny a Bash command that signals a process by a raw, guessed pid (#2225).
+
+    The agent has twice killed the WRONG, LIVE process by guessing which
+    ``claude`` pid 'looked dead'. A bare ``kill <pid>`` / ``kill -9 <pid>`` is
+    exactly that guessed-pid shape; it is denied so the agent must go through
+    ``teatree.core.safe_kill.safe_kill`` (positive session/task id + non-live
+    proof) instead. ``pkill``/``killall`` (signal by name) and ``%job``/``$VAR``
+    targets are NOT flagged.
+
+    Fails OPEN on any import/internal error — a gate bug must never wedge the
+    agent (consistent with the other Bash-deny gates). The handler bootstraps
+    ``sys.path`` to import ``teatree`` from the sibling ``src/`` (#1314).
+    """
+    if data.get("tool_name") != "Bash":
+        return False
+    command = data.get("tool_input", {}).get("command", "")
+    if not command:
+        return False
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    added = False
+    try:
+        if str(src_dir) not in sys.path:
+            sys.path.insert(0, str(src_dir))
+            added = True
+        from teatree.hooks import safe_kill_detect  # noqa: PLC0415
+
+        detection = safe_kill_detect.detect_raw_pid_kill(command)
+    except Exception:  # noqa: BLE001
+        return False
+    finally:
+        if added:
+            with contextlib.suppress(ValueError):
+                sys.path.remove(str(src_dir))
+    if not detection.is_raw_pid_kill:
+        return False
+    return emit_pretooluse_deny(detection.message)
+
+
 # ── PreToolUse: block-secret-file-print (#2306) ──────────────────────
 #
 # Blocks Bash commands that route a known secret-bearing source to stdout.
@@ -8655,6 +8694,7 @@ _HANDLERS: dict[str, list] = {
         handle_banned_terms_pretool,
         handle_enforce_skill_loading,
         handle_block_direct_commands,
+        handle_block_raw_pid_kill,
         handle_block_secret_file_print,
         handle_block_out_of_band_merge,
         handle_block_raw_review_post,

--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -249,6 +249,23 @@ class OverlayAppBuilder:
             # Same as ``full-status``: ``followup`` is core-only (#1318).
             managepy_core("followup", "sync", overlay_name=overlay_name)
 
+        @overlay_app.command(
+            name="safe-kill",
+            context_settings={
+                "allow_extra_args": True,
+                "allow_interspersed_args": False,
+                "ignore_unknown_options": True,
+            },
+            add_help_option=False,
+        )
+        def safe_kill(ctx: typer.Context) -> None:
+            """Signal a pid only if it maps to a dead target AND is confirmed non-live (#2225)."""
+            # ``safe_kill`` is a teatree-CORE management command — dispatch via
+            # ``python -m teatree`` so an overlay clone with its own ``manage.py``
+            # does not crash with ``Unknown command`` (#1318). The pid argument
+            # and ``--hang-cause`` are forwarded verbatim.
+            managepy_core("safe_kill", *ctx.args, overlay_name=overlay_name)
+
         self._register_agent_command()
 
     def _register_agent_command(self) -> None:

--- a/src/teatree/core/management/commands/safe_kill.py
+++ b/src/teatree/core/management/commands/safe_kill.py
@@ -1,0 +1,35 @@
+"""``t3 teatree safe-kill <pid> --hang-cause "<why>"`` — the runnable safe-kill guard (#2225).
+
+The runnable surface the PreToolUse raw-pid-kill deny points the agent at. It
+routes a kill through :func:`teatree.core.safe_kill.safe_kill`, which signals the
+process ONLY when both hold: the pid maps to a KNOWN dead/failed target by
+session id, and two CPU samples confirm it is non-live. On a refusal the process
+is NEVER signalled and the evidence (candidate session id + liveness STAT) is
+printed so the agent confirms the target id with the user first.
+
+Exit code 0 when the signal was sent (verified-dead target); exit code 1 when
+the guard refused — so a script can branch on the outcome.
+"""
+
+from typing import Annotated
+
+import typer
+from django_typer.management import TyperCommand
+
+from teatree.core.safe_kill import safe_kill
+
+
+class Command(TyperCommand):
+    def handle(
+        self,
+        pid: Annotated[int, typer.Argument(help="The OS process id to signal.")],
+        hang_cause: Annotated[
+            str,
+            typer.Option("--hang-cause", help="Why the target is believed hung (required — a bare guess is refused)."),
+        ] = "",
+    ) -> str:
+        """Signal *pid* only if it maps to a dead target AND is confirmed non-live."""
+        verdict = safe_kill(pid, hang_cause=hang_cause)
+        if verdict.allowed:
+            return f"safe-kill: signalled pid {pid} (session {verdict.identity.session_id})."
+        raise SystemExit(verdict.reason)

--- a/src/teatree/core/safe_kill.py
+++ b/src/teatree/core/safe_kill.py
@@ -1,0 +1,334 @@
+"""Safe-kill guard — never signal a process by guessed pid or while it shows liveness (#2225).
+
+An agent repeatedly killed the WRONG, LIVE process when asked to kill a "dead"
+agent: it (a) matched the target by guessing which long-running ``claude`` pid
+"looked dead" rather than by the named target's session/task id, and (b) read
+high uptime + ``R+``/``S+`` (STAT) as "stuck" when ``R`` means running on CPU
+and ``S+``/``R+`` mean a live foreground TTY session.
+
+This module is the deterministic gate that makes that mistake structurally
+impossible. :func:`evaluate_safe_kill` returns an ALLOW verdict only when BOTH
+of the following hold.
+
+**Positive identity.** The pid maps to a KNOWN dead/failed target by session
+id (``~/.claude/sessions/*.json`` → session id → a FAILED Task via
+``TaskAttempt.agent_session_id``), never by a heuristic "looks idle". A pid
+that maps to no known dead target, or to a still-claimed task, is refused.
+
+**Confirmed non-live.** Two CPU samples show no activity, output has not
+advanced, the STAT is not a running/foreground state, AND a hang cause is
+stated. A process in STAT ``R``/``R+`` (actively running) or ``S+``/``R+``
+(live foreground TTY) is rejected outright.
+
+The two externality boundaries — the per-pid liveness sample (shells out to
+``ps``) and the pid→identity resolution (reads ``~/.claude/sessions`` + the
+Task ORM) — are injectable so the guard logic is unit-testable without real
+processes. The default implementations wire the real boundaries.
+"""
+
+import json
+import logging
+import os
+import signal
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from teatree.core.selectors._helpers import _CLAUDE_SESSIONS_DIR
+
+logger = logging.getLogger(__name__)
+
+# STAT codes that PROVE liveness: ``R`` running on CPU; a trailing ``+`` means a
+# foreground process group attached to a controlling terminal (a live session).
+# Either is an immediate refusal regardless of CPU samples.
+_RUNNING_STATS: frozenset[str] = frozenset({"R", "R+"})
+_FOREGROUND_SUFFIX = "+"
+
+_CPU_ACTIVITY_EPSILON = 0.5
+
+
+class SafeKillError(RuntimeError):
+    """Raised by :func:`safe_kill` in ``strict`` mode when the guard refuses."""
+
+
+@dataclass(frozen=True, slots=True)
+class Liveness:
+    """One pid's liveness sample — the only process-level externality the guard reads.
+
+    ``stat`` is the ``ps`` STAT field (``R``/``S``/``Z``/… with an optional
+    ``+`` foreground suffix). The two CPU samples are ``%cpu`` readings taken a
+    moment apart; ``output_advanced`` is whether the session's transcript grew
+    between the samples.
+    """
+
+    stat: str
+    cpu_sample_1: float
+    cpu_sample_2: float
+    output_advanced: bool
+
+    @property
+    def is_running_stat(self) -> bool:
+        return self.stat in _RUNNING_STATS
+
+    @property
+    def is_foreground(self) -> bool:
+        return self.stat.endswith(_FOREGROUND_SUFFIX)
+
+    @property
+    def cpu_active(self) -> bool:
+        return max(self.cpu_sample_1, self.cpu_sample_2) >= _CPU_ACTIVITY_EPSILON
+
+
+@dataclass(frozen=True, slots=True)
+class TargetIdentity:
+    """The named target a pid resolves to — positive identity, never a guess.
+
+    ``is_dead_target`` is True only when the session id maps to a Task that has
+    actually FAILED/COMPLETED (a known dead target). An unresolvable pid yields
+    an empty session id and ``is_dead_target=False``.
+    """
+
+    session_id: str
+    task_id: int | None
+    is_dead_target: bool
+
+
+@dataclass(frozen=True, slots=True)
+class SafeKillVerdict:
+    """The guard's decision for one pid."""
+
+    allowed: bool
+    reason: str
+    identity: TargetIdentity
+    liveness: Liveness | None
+
+
+LivenessSampler = Callable[[int], Liveness | None]
+IdentityResolver = Callable[[int], TargetIdentity]
+SignalSender = Callable[[int, int], None]
+
+
+def evaluate_safe_kill(
+    pid: int,
+    *,
+    hang_cause: str,
+    resolve_identity: IdentityResolver | None = None,
+    sample_liveness: LivenessSampler | None = None,
+) -> SafeKillVerdict:
+    """Decide whether *pid* may be signalled. ALLOW only on positive identity AND non-live.
+
+    Refuses (with evidence in ``reason``) when the pid maps to no known dead
+    target, maps to a still-claimed task, is in a running/foreground STAT, shows
+    CPU activity or advancing output, or no hang cause is stated. The refusal
+    names the candidate's session id and the liveness evidence and tells the
+    caller to confirm the target id with the user first.
+    """
+    resolve_identity = resolve_identity or _default_resolve_identity
+    sample_liveness = sample_liveness or _default_sample_liveness
+
+    identity = resolve_identity(pid)
+    liveness = sample_liveness(pid)
+
+    if not (hang_cause or "").strip():
+        return SafeKillVerdict(
+            allowed=False,
+            reason=_refusal("no hang cause stated", pid, identity, liveness),
+            identity=identity,
+            liveness=liveness,
+        )
+
+    if not identity.is_dead_target or not identity.session_id:
+        return SafeKillVerdict(
+            allowed=False,
+            reason=_identity_refusal(pid, identity),
+            identity=identity,
+            liveness=liveness,
+        )
+
+    non_live_reason = _non_live_refusal(liveness)
+    if non_live_reason is not None:
+        return SafeKillVerdict(
+            allowed=False,
+            reason=_refusal(non_live_reason, pid, identity, liveness),
+            identity=identity,
+            liveness=liveness,
+        )
+
+    return SafeKillVerdict(allowed=True, reason="", identity=identity, liveness=liveness)
+
+
+def _identity_refusal(pid: int, identity: TargetIdentity) -> str:
+    if identity.session_id and not identity.is_dead_target:
+        return _refusal(
+            f"pid maps to session {identity.session_id} whose task is still claimed/active — not a dead target",
+            pid,
+            identity,
+            None,
+        )
+    return _refusal("pid maps to no known dead/failed task id", pid, identity, None)
+
+
+def _non_live_refusal(liveness: Liveness | None) -> str | None:
+    """Reason the target still shows liveness, or ``None`` when confirmed non-live.
+
+    ``None`` liveness is unverifiable — the guard cannot confirm non-live, so it
+    refuses (fail closed).
+    """
+    if liveness is None:
+        return "liveness could not be sampled — cannot confirm the process is dead"
+    if liveness.is_running_stat:
+        return f"process is in STAT {liveness.stat} (running on CPU) — actively running, never killed"
+    if liveness.is_foreground:
+        return f"process is in STAT {liveness.stat} (live foreground TTY session) — not stuck"
+    if liveness.cpu_active:
+        return "CPU activity present across samples — process is doing work"
+    if liveness.output_advanced:
+        return "session output advanced between samples — process is still progressing"
+    return None
+
+
+def _refusal(detail: str, pid: int, identity: TargetIdentity, liveness: Liveness | None) -> str:
+    sid = identity.session_id or "<unmapped>"
+    stat = liveness.stat if liveness is not None else "<unsampled>"
+    return (
+        f"REFUSED to signal pid {pid}: {detail}. "
+        f"candidate session_id={sid} STAT={stat}. "
+        "Confirm the target id with the user before killing any process — "
+        "never match a 'dead' agent by which pid looks idle."
+    )
+
+
+def safe_kill(  # noqa: PLR0913 — single safe-kill egress; each kwarg is a documented boundary injection / test override, kwargs-only.
+    pid: int,
+    *,
+    hang_cause: str,
+    resolve_identity: IdentityResolver | None = None,
+    sample_liveness: LivenessSampler | None = None,
+    send_signal: SignalSender | None = None,
+    sig: int = signal.SIGTERM,
+    strict: bool = False,
+) -> SafeKillVerdict:
+    """Signal *pid* only when :func:`evaluate_safe_kill` allows it.
+
+    On a refusal the process is NEVER signalled. In ``strict`` mode the refusal
+    raises :class:`SafeKillError` (for callers that want a hard failure); the
+    default returns the verdict so callers can surface the evidence.
+    """
+    verdict = evaluate_safe_kill(
+        pid,
+        hang_cause=hang_cause,
+        resolve_identity=resolve_identity,
+        sample_liveness=sample_liveness,
+    )
+    if not verdict.allowed:
+        logger.warning("safe_kill: %s", verdict.reason)
+        if strict:
+            raise SafeKillError(verdict.reason)
+        return verdict
+
+    sender = send_signal or _default_send_signal
+    sender(pid, sig)
+    logger.info("safe_kill: signalled pid %d (sig %d), session %s", pid, sig, verdict.identity.session_id)
+    return verdict
+
+
+# ---------------------------------------------------------------------------
+# Default externality boundaries (the real ps / ~/.claude / ORM reads)
+# ---------------------------------------------------------------------------
+
+
+def _default_send_signal(pid: int, sig: int) -> None:
+    os.kill(pid, sig)
+
+
+def _default_sample_liveness(pid: int) -> Liveness | None:
+    """Sample a pid's liveness via two ``ps`` reads a moment apart.
+
+    Returns ``None`` when ``ps`` cannot report the pid (gone / unreadable) so the
+    guard fails closed (cannot confirm non-live → refuse).
+    """
+    import shutil  # noqa: PLC0415
+    import time  # noqa: PLC0415
+
+    from teatree.utils.run import CommandFailedError, run_allowed_to_fail  # noqa: PLC0415
+
+    ps = shutil.which("ps")
+    if ps is None:
+        return None
+
+    def _read() -> tuple[str, float] | None:
+        try:
+            result = run_allowed_to_fail([ps, "-o", "stat=,pcpu=", "-p", str(pid)], expected_codes=None, timeout=10)
+        except (OSError, CommandFailedError):
+            return None
+        if result.returncode != 0:
+            return None
+        line = result.stdout.strip()
+        parts = line.split()
+        if len(parts) < 2:  # noqa: PLR2004
+            return None
+        try:
+            return parts[0], float(parts[1])
+        except ValueError:
+            return None
+
+    first = _read()
+    if first is None:
+        return None
+    time.sleep(0.3)
+    second = _read()
+    if second is None:
+        return None
+    stat = second[0]
+    return Liveness(stat=stat, cpu_sample_1=first[1], cpu_sample_2=second[1], output_advanced=False)
+
+
+def _default_resolve_identity(pid: int) -> TargetIdentity:
+    """Resolve a pid to its named target via ``~/.claude/sessions`` + the Task ORM.
+
+    The pid is mapped to a session id by the per-pid session-state files, and the
+    session id is mapped to a Task by ``TaskAttempt.agent_session_id``. A target
+    is "dead" only when that task has actually FAILED/COMPLETED. A pid that maps
+    to no session, or to a still-active task, is NOT a dead target.
+    """
+    session_id = _session_id_for_pid(pid)
+    if not session_id:
+        return TargetIdentity(session_id="", task_id=None, is_dead_target=False)
+    task_id, is_dead = _dead_task_for_session(session_id)
+    return TargetIdentity(session_id=session_id, task_id=task_id, is_dead_target=is_dead)
+
+
+def _session_id_for_pid(pid: int) -> str:
+    sessions_dir = _CLAUDE_SESSIONS_DIR
+    if not sessions_dir.is_dir():
+        return ""
+    for state_file in sessions_dir.glob("*.json"):
+        try:
+            data = json.loads(state_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if isinstance(data, dict) and data.get("pid") == pid:
+            return str(data.get("sessionId", ""))
+    return ""
+
+
+def _dead_task_for_session(session_id: str) -> tuple[int | None, bool]:
+    from teatree.core.models import Task, TaskAttempt  # noqa: PLC0415
+
+    attempt = TaskAttempt.objects.filter(agent_session_id=session_id).select_related("task").order_by("-pk").first()
+    if attempt is None:
+        return None, False
+    is_dead = attempt.task.status in {Task.Status.FAILED, Task.Status.COMPLETED}
+    return attempt.task_id, is_dead
+
+
+__all__ = [
+    "IdentityResolver",
+    "Liveness",
+    "LivenessSampler",
+    "SafeKillError",
+    "SafeKillVerdict",
+    "SignalSender",
+    "TargetIdentity",
+    "evaluate_safe_kill",
+    "safe_kill",
+]

--- a/src/teatree/hooks/safe_kill_detect.py
+++ b/src/teatree/hooks/safe_kill_detect.py
@@ -1,0 +1,82 @@
+"""Detect a raw ``kill``/``kill -9`` of a process by pid — the PreToolUse safe-kill gate (#2225).
+
+Pure command analysis (no ORM, no ``ps``) so the PreToolUse hook stays fast and
+the detection is unit-testable. The hook denies a Bash command that signals a
+process by a numeric pid and routes the agent to the deterministic
+:func:`teatree.core.safe_kill.safe_kill` helper, which verifies positive
+identity + confirmed non-live before signalling.
+
+The agent's recurring mistake was killing the WRONG, LIVE ``claude`` process by
+guessing which pid "looked dead". A raw ``kill <pid>`` / ``kill -9 <pid>`` /
+``kill -SIGKILL <pid>`` is exactly that guessed-pid shape; it is denied so the
+agent must go through the helper (positive session/task id + non-live proof)
+instead.
+"""
+
+import re
+from dataclasses import dataclass
+
+# A ``kill`` invocation whose target is a bare numeric pid (optionally after a
+# signal flag like ``-9`` / ``-KILL`` / ``-SIGKILL`` / ``-s SIGTERM``). A
+# ``%job`` target, a ``$VAR`` target, or ``$(pgrep …)`` is NOT a raw-pid guess
+# and is left alone.
+_KILL_PID_RE = re.compile(
+    r"""
+    \bkill\b                      # the kill builtin/binary
+    (?:\s+-s\s+\S+)?              # optional `-s SIGNAL`
+    (?:\s+-[0-9A-Za-z]+)*          # optional signal flags (-9, -KILL, -SIGKILL, -TERM)
+    (?:\s+--)?                     # optional end-of-options marker
+    \s+
+    (?P<pid>-?\d+)                # a bare numeric pid (a leading - = a process group)
+    \b
+    """,
+    re.VERBOSE,
+)
+
+_PKILL_RE = re.compile(r"\b(?:pkill|killall)\b")
+
+_SAFE_KILL_BLOCK_MSG = (
+    "BLOCKED: this command signals a process by a raw pid. The agent has twice killed "
+    "the WRONG, LIVE process by guessing which pid 'looked dead'. Before killing any "
+    "process: (1) confirm the target by its session id (~/.claude/projects/*/<id>.jsonl) "
+    "or task id with the user — never by 'looks idle'; (2) confirm it is non-live (two "
+    "CPU samples with no activity AND a stated hang cause; a STAT of R/R+ or any +"
+    " foreground state means it is running, not stuck). Route the kill through "
+    "teatree.core.safe_kill.safe_kill(pid, hang_cause=...), which refuses unless both hold. "
+    "A mid-action user interjection must abort."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SafeKillDetection:
+    """Whether a Bash command signals a process by raw pid, and the matched pid."""
+
+    is_raw_pid_kill: bool
+    pid: int | None
+    message: str
+
+
+def detect_raw_pid_kill(command: str) -> SafeKillDetection:
+    """Return a detection for *command*; ``is_raw_pid_kill`` True iff it kills by raw pid.
+
+    ``pkill``/``killall`` (signal by name, not pid) are NOT flagged here — they
+    are a different surface. Only a literal ``kill <pid>`` numeric-pid target is
+    the guessed-pid shape this gate refuses.
+    """
+    if not command:
+        return SafeKillDetection(is_raw_pid_kill=False, pid=None, message="")
+    if _PKILL_RE.search(command):
+        return SafeKillDetection(is_raw_pid_kill=False, pid=None, message="")
+    match = _KILL_PID_RE.search(command)
+    if match is None:
+        return SafeKillDetection(is_raw_pid_kill=False, pid=None, message="")
+    try:
+        pid = abs(int(match.group("pid")))
+    except ValueError:
+        return SafeKillDetection(is_raw_pid_kill=False, pid=None, message="")
+    if pid <= 1:
+        return SafeKillDetection(is_raw_pid_kill=False, pid=None, message="")
+    return SafeKillDetection(is_raw_pid_kill=True, pid=pid, message=_SAFE_KILL_BLOCK_MSG)
+
+
+__all__ = ["SafeKillDetection", "detect_raw_pid_kill"]

--- a/src/teatree/hooks/safe_kill_detect.py
+++ b/src/teatree/hooks/safe_kill_detect.py
@@ -2,48 +2,51 @@
 
 Pure command analysis (no ORM, no ``ps``) so the PreToolUse hook stays fast and
 the detection is unit-testable. The hook denies a Bash command that signals a
-process by a numeric pid and routes the agent to the deterministic
-:func:`teatree.core.safe_kill.safe_kill` helper, which verifies positive
+process by a numeric pid and routes the agent to the runnable
+``t3 teatree safe-kill <pid> --hang-cause "<why>"`` CLI, which verifies positive
 identity + confirmed non-live before signalling.
 
 The agent's recurring mistake was killing the WRONG, LIVE ``claude`` process by
 guessing which pid "looked dead". A raw ``kill <pid>`` / ``kill -9 <pid>`` /
 ``kill -SIGKILL <pid>`` is exactly that guessed-pid shape; it is denied so the
-agent must go through the helper (positive session/task id + non-live proof)
+agent must go through the CLI (positive session/task id + non-live proof)
 instead.
+
+Deliberately NOT flagged. ``kill -0 <pid>`` (and ``kill -s 0``) — signal 0 sends
+no signal; it is the canonical no-op liveness probe (the codebase's own
+``os.kill(pid, 0)`` pattern). ``pkill`` / ``killall`` — signal by name, a
+different surface. A ``%job`` / ``$VAR`` / ``$(pgrep …)`` target — not a raw
+numeric-pid guess. A ``kill`` token that is NOT at a command position — inside a
+comment (``# kill 4242``), inside a string (``echo "to kill: kill 1234"``), as
+another command's argument (``grep kill 4242 file``), or as a subcommand word
+(``git kill 5``).
 """
 
 import re
 from dataclasses import dataclass
 
-# A ``kill`` invocation whose target is a bare numeric pid (optionally after a
-# signal flag like ``-9`` / ``-KILL`` / ``-SIGKILL`` / ``-s SIGTERM``). A
-# ``%job`` target, a ``$VAR`` target, or ``$(pgrep …)`` is NOT a raw-pid guess
-# and is left alone.
-_KILL_PID_RE = re.compile(
-    r"""
-    \bkill\b                      # the kill builtin/binary
-    (?:\s+-s\s+\S+)?              # optional `-s SIGNAL`
-    (?:\s+-[0-9A-Za-z]+)*          # optional signal flags (-9, -KILL, -SIGKILL, -TERM)
-    (?:\s+--)?                     # optional end-of-options marker
-    \s+
-    (?P<pid>-?\d+)                # a bare numeric pid (a leading - = a process group)
-    \b
-    """,
-    re.VERBOSE,
-)
+# Command-position anchor: a segment starts at the beginning of the command, or
+# right after a shell separator (``;`` ``&&`` ``||`` ``|`` ``&`` newline). The
+# first WORD of a segment is the command name; only when that word is exactly
+# ``kill`` is the segment a kill invocation.
+_SEGMENT_SPLIT_RE = re.compile(r"(?:\|\||&&|[;|&\n])")
 
-_PKILL_RE = re.compile(r"\b(?:pkill|killall)\b")
+# A signal flag on ``kill``: ``-9`` / ``-KILL`` / ``-SIGKILL`` / ``-TERM`` / the
+# explicit ``-s SIGNAL`` form. ``-0`` is matched here so it can be detected as
+# the no-op probe and excluded.
+_SIGNAL_FLAG_RE = re.compile(r"^-(?:s$|[0-9A-Za-z]+$)")
+
+_PID_RE = re.compile(r"^-?\d+$")
 
 _SAFE_KILL_BLOCK_MSG = (
     "BLOCKED: this command signals a process by a raw pid. The agent has twice killed "
     "the WRONG, LIVE process by guessing which pid 'looked dead'. Before killing any "
-    "process: (1) confirm the target by its session id (~/.claude/projects/*/<id>.jsonl) "
-    "or task id with the user — never by 'looks idle'; (2) confirm it is non-live (two "
-    "CPU samples with no activity AND a stated hang cause; a STAT of R/R+ or any +"
-    " foreground state means it is running, not stuck). Route the kill through "
-    "teatree.core.safe_kill.safe_kill(pid, hang_cause=...), which refuses unless both hold. "
-    "A mid-action user interjection must abort."
+    "process: (1) confirm the target by its session id (~/.claude/sessions/*.json maps "
+    "pid->sessionId) or task id with the user — never by 'looks idle'; (2) confirm it is "
+    "non-live (two CPU samples with no activity AND a stated hang cause; a STAT of R/R+ "
+    "or any + foreground state means it is running, not stuck). Run "
+    '`t3 teatree safe-kill <pid> --hang-cause "<why>"` instead — it refuses unless both '
+    "hold. A mid-action user interjection must abort."
 )
 
 
@@ -56,27 +59,68 @@ class SafeKillDetection:
     message: str
 
 
+def _operand_index(words: list[str]) -> int | None:
+    """Index of the first non-flag operand after ``kill``, or ``None`` for a no-op probe.
+
+    Leading signal flags (``-9``, ``-SIGKILL``, ``-s TERM``, ``--``) are consumed
+    so the operand is the target, not the signal. ``-0`` / ``-s 0`` are the no-op
+    liveness probe (``None``) — they send no signal and must not be flagged.
+    """
+    i = 1
+    while i < len(words):
+        word = words[i]
+        if word == "--":
+            return i + 1
+        if word == "-0":
+            return None
+        if word == "-s":
+            if i + 1 < len(words) and words[i + 1] == "0":
+                return None
+            i += 2  # `-s SIGNAL` consumes two tokens
+            continue
+        if _SIGNAL_FLAG_RE.match(word):
+            i += 1
+            continue
+        return i
+    return i
+
+
+def _kill_pid_in_segment(segment: str) -> int | None:
+    """Return the raw pid a ``kill`` segment targets, or ``None`` when it is not one.
+
+    The segment's first word must be exactly ``kill``. A non-numeric target
+    (``%job``, ``$VAR``, ``$(…)``), a no-op ``-0``/``-s 0`` probe, and a ``kill``
+    that is not the command name all yield ``None``.
+    """
+    words = segment.split()
+    if not words or words[0] != "kill":
+        return None
+    index = _operand_index(words)
+    if index is None or index >= len(words):
+        return None
+    target = words[index]
+    if not _PID_RE.match(target):
+        return None  # %job / $VAR / $(…) / a flag — not a raw numeric pid
+    pid = abs(int(target))
+    return pid if pid > 1 else None
+
+
 def detect_raw_pid_kill(command: str) -> SafeKillDetection:
     """Return a detection for *command*; ``is_raw_pid_kill`` True iff it kills by raw pid.
 
-    ``pkill``/``killall`` (signal by name, not pid) are NOT flagged here — they
-    are a different surface. Only a literal ``kill <pid>`` numeric-pid target is
-    the guessed-pid shape this gate refuses.
+    Detection is anchored to a command position: each ``;``/``&&``/``||``/``|``/
+    newline-separated segment whose first word is ``kill`` is inspected, so a
+    ``kill`` token inside a comment, string, or as another command's argument is
+    not flagged. ``kill -0`` (no-op probe), ``pkill``/``killall`` (signal by
+    name), and ``%job``/``$VAR``/``$(…)`` targets are left alone.
     """
     if not command:
         return SafeKillDetection(is_raw_pid_kill=False, pid=None, message="")
-    if _PKILL_RE.search(command):
-        return SafeKillDetection(is_raw_pid_kill=False, pid=None, message="")
-    match = _KILL_PID_RE.search(command)
-    if match is None:
-        return SafeKillDetection(is_raw_pid_kill=False, pid=None, message="")
-    try:
-        pid = abs(int(match.group("pid")))
-    except ValueError:
-        return SafeKillDetection(is_raw_pid_kill=False, pid=None, message="")
-    if pid <= 1:
-        return SafeKillDetection(is_raw_pid_kill=False, pid=None, message="")
-    return SafeKillDetection(is_raw_pid_kill=True, pid=pid, message=_SAFE_KILL_BLOCK_MSG)
+    for segment in _SEGMENT_SPLIT_RE.split(command):
+        pid = _kill_pid_in_segment(segment.strip())
+        if pid is not None:
+            return SafeKillDetection(is_raw_pid_kill=True, pid=pid, message=_SAFE_KILL_BLOCK_MSG)
+    return SafeKillDetection(is_raw_pid_kill=False, pid=None, message="")
 
 
 __all__ = ["SafeKillDetection", "detect_raw_pid_kill"]

--- a/tests/teatree_core/management_commands/test_safe_kill.py
+++ b/tests/teatree_core/management_commands/test_safe_kill.py
@@ -1,0 +1,61 @@
+"""Tests for the ``t3 teatree safe-kill`` management command (#2225).
+
+The command is the runnable surface the PreToolUse raw-pid-kill deny points the
+agent at. These tests pin its wiring: it forwards pid + hang_cause to
+:func:`teatree.core.safe_kill.safe_kill`, prints a confirmation when the signal
+was sent, and prints the refusal evidence + exits non-zero when the guard
+refuses. The guard logic itself is covered by ``test_safe_kill_guard.py``; here
+the core call is patched so only the command wiring is under test.
+"""
+
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+
+from teatree.core.safe_kill import Liveness, SafeKillVerdict, TargetIdentity
+
+_ALLOWED = SafeKillVerdict(
+    allowed=True,
+    reason="",
+    identity=TargetIdentity(session_id="sess-dead", task_id=7, is_dead_target=True),
+    liveness=Liveness(stat="Z", cpu_sample_1=0.0, cpu_sample_2=0.0, output_advanced=False),
+)
+_REFUSED = SafeKillVerdict(
+    allowed=False,
+    reason="REFUSED to signal pid 4242: process is in STAT R+ ... confirm the target id with the user",
+    identity=TargetIdentity(session_id="sess-live", task_id=9, is_dead_target=True),
+    liveness=Liveness(stat="R+", cpu_sample_1=9.0, cpu_sample_2=8.0, output_advanced=True),
+)
+
+
+def _call(*args: str) -> str:
+    buf = StringIO()
+    call_command("safe_kill", *args, stdout=buf)
+    return buf.getvalue()
+
+
+class TestSafeKillCommand:
+    def test_forwards_pid_and_hang_cause_to_the_guard(self) -> None:
+        with patch("teatree.core.management.commands.safe_kill.safe_kill", return_value=_ALLOWED) as mocked:
+            out = _call("4242", "--hang-cause", "agent crashed, no output since")
+        mocked.assert_called_once_with(4242, hang_cause="agent crashed, no output since")
+        assert "signalled pid 4242" in out
+        assert "sess-dead" in out
+
+    def test_refusal_exits_nonzero_and_prints_evidence(self) -> None:
+        with (
+            patch("teatree.core.management.commands.safe_kill.safe_kill", return_value=_REFUSED),
+            pytest.raises(SystemExit) as exc,
+        ):
+            _call("4242", "--hang-cause", "looks idle")
+        assert "REFUSED to signal pid 4242" in str(exc.value)
+
+    def test_missing_hang_cause_defaults_to_empty_and_is_refused_by_the_guard(self) -> None:
+        with (
+            patch("teatree.core.management.commands.safe_kill.safe_kill", return_value=_REFUSED) as mocked,
+            pytest.raises(SystemExit),
+        ):
+            _call("4242")
+        mocked.assert_called_once_with(4242, hang_cause="")

--- a/tests/teatree_core/test_safe_kill_guard.py
+++ b/tests/teatree_core/test_safe_kill_guard.py
@@ -1,0 +1,197 @@
+"""Tests for ``teatree.core.safe_kill`` (#2225).
+
+The guard refuses to signal a process unless BOTH hold. Positive identity —
+the pid maps to a KNOWN dead/failed target by session id, never by a heuristic
+"looks idle". Confirmed non-live — two CPU samples show no activity, STAT is
+not a running/foreground state (``R``/``R+``), and a hang cause is stated.
+
+Only the two externality boundaries are mocked: the per-pid liveness sample
+(real impl shells out to ``ps``) and the pid→identity resolution (real impl
+reads ``~/.claude/sessions`` + the Task ORM). The guard logic itself is never
+mocked, so the must-refuse cases go red if the guard is bypassed.
+"""
+
+import pytest
+
+from teatree.core.safe_kill import Liveness, SafeKillError, TargetIdentity, evaluate_safe_kill, safe_kill
+
+_DEAD_LIVENESS = Liveness(stat="Z", cpu_sample_1=0.0, cpu_sample_2=0.0, output_advanced=False)
+_RUNNING_LIVENESS = Liveness(stat="R+", cpu_sample_1=12.4, cpu_sample_2=9.1, output_advanced=True)
+_IDLE_FOREGROUND_LIVENESS = Liveness(stat="S+", cpu_sample_1=0.0, cpu_sample_2=0.0, output_advanced=False)
+
+_FAILED_TARGET = TargetIdentity(session_id="sess-dead", task_id=7, is_dead_target=True)
+_UNKNOWN_TARGET = TargetIdentity(session_id="", task_id=None, is_dead_target=False)
+_LIVE_TASK_TARGET = TargetIdentity(session_id="sess-live", task_id=9, is_dead_target=False)
+
+
+def _resolver(identity: TargetIdentity):
+    return lambda _pid: identity
+
+
+def _sampler(liveness: Liveness):
+    return lambda _pid: liveness
+
+
+class TestPositiveIdentity:
+    def test_refuses_when_pid_maps_to_no_known_dead_task(self) -> None:
+        verdict = evaluate_safe_kill(
+            4242,
+            hang_cause="no response for 20 min",
+            resolve_identity=_resolver(_UNKNOWN_TARGET),
+            sample_liveness=_sampler(_DEAD_LIVENESS),
+        )
+        assert not verdict.allowed
+        assert "no known dead" in verdict.reason.lower()
+
+    def test_refuses_when_pid_maps_to_a_still_claimed_task(self) -> None:
+        verdict = evaluate_safe_kill(
+            4242,
+            hang_cause="seems stuck",
+            resolve_identity=_resolver(_LIVE_TASK_TARGET),
+            sample_liveness=_sampler(_DEAD_LIVENESS),
+        )
+        assert not verdict.allowed
+        assert "sess-live" in verdict.reason
+
+    def test_allows_dead_pid_mapped_to_a_failed_task(self) -> None:
+        verdict = evaluate_safe_kill(
+            4242,
+            hang_cause="agent crashed mid-attempt, no output since",
+            resolve_identity=_resolver(_FAILED_TARGET),
+            sample_liveness=_sampler(_DEAD_LIVENESS),
+        )
+        assert verdict.allowed
+        assert verdict.reason == ""
+
+
+class TestConfirmedNonLive:
+    def test_refuses_running_process_outright(self) -> None:
+        verdict = evaluate_safe_kill(
+            4242,
+            hang_cause="high uptime",
+            resolve_identity=_resolver(_FAILED_TARGET),
+            sample_liveness=_sampler(_RUNNING_LIVENESS),
+        )
+        assert not verdict.allowed
+        assert "R+" in verdict.reason
+
+    def test_refuses_foreground_session_with_no_cpu_but_live_tty(self) -> None:
+        verdict = evaluate_safe_kill(
+            4242,
+            hang_cause="uptime looks high",
+            resolve_identity=_resolver(_FAILED_TARGET),
+            sample_liveness=_sampler(_IDLE_FOREGROUND_LIVENESS),
+        )
+        assert not verdict.allowed
+        assert "S+" in verdict.reason
+
+    def test_refuses_when_cpu_still_active_between_samples(self) -> None:
+        active = Liveness(stat="S", cpu_sample_1=0.0, cpu_sample_2=4.0, output_advanced=False)
+        verdict = evaluate_safe_kill(
+            4242,
+            hang_cause="stalled",
+            resolve_identity=_resolver(_FAILED_TARGET),
+            sample_liveness=_sampler(active),
+        )
+        assert not verdict.allowed
+        assert "cpu" in verdict.reason.lower()
+
+    def test_refuses_when_output_still_advancing(self) -> None:
+        advancing = Liveness(stat="S", cpu_sample_1=0.0, cpu_sample_2=0.0, output_advanced=True)
+        verdict = evaluate_safe_kill(
+            4242,
+            hang_cause="stalled",
+            resolve_identity=_resolver(_FAILED_TARGET),
+            sample_liveness=_sampler(advancing),
+        )
+        assert not verdict.allowed
+        assert "output" in verdict.reason.lower()
+
+
+class TestHangCauseRequired:
+    def test_refuses_when_no_hang_cause_stated(self) -> None:
+        verdict = evaluate_safe_kill(
+            4242,
+            hang_cause="   ",
+            resolve_identity=_resolver(_FAILED_TARGET),
+            sample_liveness=_sampler(_DEAD_LIVENESS),
+        )
+        assert not verdict.allowed
+        assert "hang cause" in verdict.reason.lower()
+
+
+class TestRefusalEvidence:
+    def test_refusal_names_session_id_and_liveness_and_confirm_with_user(self) -> None:
+        verdict = evaluate_safe_kill(
+            4242,
+            hang_cause="high uptime",
+            resolve_identity=_resolver(TargetIdentity(session_id="sess-xyz", task_id=3, is_dead_target=True)),
+            sample_liveness=_sampler(_RUNNING_LIVENESS),
+        )
+        assert not verdict.allowed
+        assert "sess-xyz" in verdict.reason
+        assert "R+" in verdict.reason
+        assert "confirm" in verdict.reason.lower()
+
+
+class TestSafeKillExecutor:
+    def test_safe_kill_does_not_signal_a_running_process(self) -> None:
+        sent: list[tuple[int, int]] = []
+
+        result = safe_kill(
+            4242,
+            hang_cause="high uptime",
+            resolve_identity=_resolver(_FAILED_TARGET),
+            sample_liveness=_sampler(_RUNNING_LIVENESS),
+            send_signal=lambda pid, sig: sent.append((pid, sig)),
+        )
+
+        assert not result.allowed
+        assert sent == []
+
+    def test_safe_kill_does_not_signal_an_unknown_pid(self) -> None:
+        sent: list[tuple[int, int]] = []
+
+        result = safe_kill(
+            4242,
+            hang_cause="looks idle",
+            resolve_identity=_resolver(_UNKNOWN_TARGET),
+            sample_liveness=_sampler(_DEAD_LIVENESS),
+            send_signal=lambda pid, sig: sent.append((pid, sig)),
+        )
+
+        assert not result.allowed
+        assert sent == []
+
+    def test_safe_kill_signals_a_verified_dead_target(self) -> None:
+        sent: list[tuple[int, int]] = []
+
+        result = safe_kill(
+            4242,
+            hang_cause="agent crashed, no output since",
+            resolve_identity=_resolver(_FAILED_TARGET),
+            sample_liveness=_sampler(_DEAD_LIVENESS),
+            send_signal=lambda pid, sig: sent.append((pid, sig)),
+        )
+
+        assert result.allowed
+        assert sent == [(4242, _expected_signal())]
+
+    def test_safe_kill_raises_when_caller_requires_strict(self) -> None:
+        sent: list[tuple[int, int]] = []
+        with pytest.raises(SafeKillError, match="R\\+"):
+            safe_kill(
+                4242,
+                hang_cause="looks idle",
+                resolve_identity=_resolver(_FAILED_TARGET),
+                sample_liveness=_sampler(_RUNNING_LIVENESS),
+                send_signal=lambda pid, sig: sent.append((pid, sig)),
+                strict=True,
+            )
+        assert sent == []
+
+
+def _expected_signal() -> int:
+    import signal  # noqa: PLC0415
+
+    return signal.SIGTERM

--- a/tests/teatree_hooks/test_safe_kill_detect.py
+++ b/tests/teatree_hooks/test_safe_kill_detect.py
@@ -1,9 +1,10 @@
 """Tests for ``teatree.hooks.safe_kill_detect`` (#2225).
 
 The PreToolUse gate denies a Bash command that signals a process by a raw,
-guessed pid and routes the agent to the safe-kill helper. These tests pin which
-command shapes are flagged (raw ``kill <pid>``) and which are left alone
-(``%job`` targets, ``pkill`` by name, non-kill commands).
+guessed pid and routes the agent to the safe-kill CLI. These tests pin which
+command shapes are flagged (raw ``kill <pid>`` at a command position) and which
+are left alone (``kill -0`` probe, ``%job``/``$VAR``/``$(…)`` targets, ``pkill``
+by name, a ``kill`` token in a comment/string/argument, non-kill commands).
 """
 
 from teatree.hooks.safe_kill_detect import detect_raw_pid_kill
@@ -35,14 +36,34 @@ class TestRawPidKillFlagged:
         assert result.is_raw_pid_kill
         assert result.pid == 4242
 
-    def test_message_routes_to_helper_and_session_id(self) -> None:
+    def test_kill_after_separator_is_a_command_position(self) -> None:
+        result = detect_raw_pid_kill("echo done && kill -9 4242")
+        assert result.is_raw_pid_kill
+        assert result.pid == 4242
+
+    def test_signal_flag_is_not_parsed_as_the_pid(self) -> None:
+        result = detect_raw_pid_kill("kill -9 5678")
+        assert result.is_raw_pid_kill
+        assert result.pid == 5678
+
+    def test_message_routes_to_cli_and_sessions_path(self) -> None:
         result = detect_raw_pid_kill("kill -9 4242")
-        assert "safe_kill" in result.message
-        assert "session id" in result.message.lower()
+        assert "t3 teatree safe-kill" in result.message
+        assert "~/.claude/sessions/*.json" in result.message
+        assert "~/.claude/projects" not in result.message
         assert "looks idle" in result.message.lower() or "looked dead" in result.message.lower()
 
 
 class TestNotFlagged:
+    def test_kill_dash_zero_is_a_liveness_probe(self) -> None:
+        result = detect_raw_pid_kill("kill -0 4242")
+        assert not result.is_raw_pid_kill
+        assert result.pid is None
+
+    def test_kill_s_zero_is_a_liveness_probe(self) -> None:
+        result = detect_raw_pid_kill("kill -s 0 4242")
+        assert not result.is_raw_pid_kill
+
     def test_pkill_by_name_is_not_a_raw_pid_kill(self) -> None:
         result = detect_raw_pid_kill("pkill -9 chrome")
         assert not result.is_raw_pid_kill
@@ -58,6 +79,26 @@ class TestNotFlagged:
 
     def test_kill_a_variable_is_not_a_raw_pid(self) -> None:
         result = detect_raw_pid_kill("kill $PID")
+        assert not result.is_raw_pid_kill
+
+    def test_kill_command_substitution_target_is_not_a_raw_pid(self) -> None:
+        result = detect_raw_pid_kill("kill -9 $(pgrep claude)")
+        assert not result.is_raw_pid_kill
+
+    def test_kill_in_a_comment_is_not_flagged(self) -> None:
+        result = detect_raw_pid_kill("# kill 4242")
+        assert not result.is_raw_pid_kill
+
+    def test_kill_as_an_argument_is_not_flagged(self) -> None:
+        result = detect_raw_pid_kill("grep kill 4242 file")
+        assert not result.is_raw_pid_kill
+
+    def test_kill_inside_a_string_is_not_flagged(self) -> None:
+        result = detect_raw_pid_kill('echo "to kill: kill 1234"')
+        assert not result.is_raw_pid_kill
+
+    def test_kill_as_a_subcommand_word_is_not_flagged(self) -> None:
+        result = detect_raw_pid_kill("git kill 5")
         assert not result.is_raw_pid_kill
 
     def test_non_kill_command(self) -> None:

--- a/tests/teatree_hooks/test_safe_kill_detect.py
+++ b/tests/teatree_hooks/test_safe_kill_detect.py
@@ -1,0 +1,73 @@
+"""Tests for ``teatree.hooks.safe_kill_detect`` (#2225).
+
+The PreToolUse gate denies a Bash command that signals a process by a raw,
+guessed pid and routes the agent to the safe-kill helper. These tests pin which
+command shapes are flagged (raw ``kill <pid>``) and which are left alone
+(``%job`` targets, ``pkill`` by name, non-kill commands).
+"""
+
+from teatree.hooks.safe_kill_detect import detect_raw_pid_kill
+
+
+class TestRawPidKillFlagged:
+    def test_plain_kill_pid(self) -> None:
+        result = detect_raw_pid_kill("kill 4242")
+        assert result.is_raw_pid_kill
+        assert result.pid == 4242
+
+    def test_kill_dash_nine_pid(self) -> None:
+        result = detect_raw_pid_kill("kill -9 4242")
+        assert result.is_raw_pid_kill
+        assert result.pid == 4242
+
+    def test_kill_sigkill_named_signal(self) -> None:
+        result = detect_raw_pid_kill("kill -SIGKILL 4242")
+        assert result.is_raw_pid_kill
+        assert result.pid == 4242
+
+    def test_kill_s_flag_signal(self) -> None:
+        result = detect_raw_pid_kill("kill -s TERM 4242")
+        assert result.is_raw_pid_kill
+        assert result.pid == 4242
+
+    def test_kill_process_group_negative_pid(self) -> None:
+        result = detect_raw_pid_kill("kill -- -4242")
+        assert result.is_raw_pid_kill
+        assert result.pid == 4242
+
+    def test_message_routes_to_helper_and_session_id(self) -> None:
+        result = detect_raw_pid_kill("kill -9 4242")
+        assert "safe_kill" in result.message
+        assert "session id" in result.message.lower()
+        assert "looks idle" in result.message.lower() or "looked dead" in result.message.lower()
+
+
+class TestNotFlagged:
+    def test_pkill_by_name_is_not_a_raw_pid_kill(self) -> None:
+        result = detect_raw_pid_kill("pkill -9 chrome")
+        assert not result.is_raw_pid_kill
+        assert result.pid is None
+
+    def test_killall_is_not_a_raw_pid_kill(self) -> None:
+        result = detect_raw_pid_kill("killall node")
+        assert not result.is_raw_pid_kill
+
+    def test_kill_a_job_spec_is_not_a_raw_pid(self) -> None:
+        result = detect_raw_pid_kill("kill %1")
+        assert not result.is_raw_pid_kill
+
+    def test_kill_a_variable_is_not_a_raw_pid(self) -> None:
+        result = detect_raw_pid_kill("kill $PID")
+        assert not result.is_raw_pid_kill
+
+    def test_non_kill_command(self) -> None:
+        result = detect_raw_pid_kill("ps -axo pid,comm")
+        assert not result.is_raw_pid_kill
+
+    def test_empty_command(self) -> None:
+        result = detect_raw_pid_kill("")
+        assert not result.is_raw_pid_kill
+
+    def test_kill_pid_zero_or_one_not_flagged(self) -> None:
+        assert not detect_raw_pid_kill("kill 1").is_raw_pid_kill
+        assert not detect_raw_pid_kill("kill 0").is_raw_pid_kill

--- a/tests/teatree_hooks/test_safe_kill_pretool_gate.py
+++ b/tests/teatree_hooks/test_safe_kill_pretool_gate.py
@@ -1,0 +1,66 @@
+"""PreToolUse gate test: deny a raw, guessed-pid ``kill`` (#2225).
+
+The handler ``handle_block_raw_pid_kill`` routes a Bash ``kill <pid>`` /
+``kill -9 <pid>`` through the safe-kill helper guidance instead of letting the
+agent signal a process it identified by 'looks idle'. ``pkill``/``killall`` and
+``%job``/``$VAR`` targets pass through.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import hooks.scripts.hook_router as router
+from hooks.scripts.hook_router import handle_block_raw_pid_kill
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state_dir(tmp_path: Path):
+    original = router.STATE_DIR
+    router.STATE_DIR = tmp_path / "state"
+    router.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    yield
+    router.STATE_DIR = original
+
+
+def _bash_event(command: str, tool_name: str = "Bash") -> dict:
+    return {
+        "session_id": "sess-kill",
+        "tool_name": tool_name,
+        "tool_input": {"command": command},
+    }
+
+
+def _parse_deny(capsys: pytest.CaptureFixture[str]) -> dict | None:
+    output = capsys.readouterr().out.strip()
+    if not output:
+        return None
+    return json.loads(output)
+
+
+class TestDeniesRawPidKill:
+    @pytest.mark.parametrize(
+        "command",
+        ["kill 4242", "kill -9 4242", "kill -SIGKILL 4242", "kill -s TERM 4242"],
+    )
+    def test_raw_pid_kill_is_denied(self, command: str, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_block_raw_pid_kill(_bash_event(command)) is True
+        payload = _parse_deny(capsys)
+        assert payload is not None
+        assert payload["permissionDecision"] == "deny"
+        assert "safe_kill" in payload["permissionDecisionReason"]
+
+
+class TestAllowsSafeCommands:
+    @pytest.mark.parametrize(
+        "command",
+        ["pkill -9 chrome", "killall node", "kill %1", "kill $PID", "ps -axo pid,comm"],
+    )
+    def test_non_raw_pid_kill_passes(self, command: str, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_block_raw_pid_kill(_bash_event(command)) is False
+        assert _parse_deny(capsys) is None
+
+    def test_non_bash_tool_passes(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_block_raw_pid_kill(_bash_event("kill 4242", tool_name="Edit")) is False
+        assert _parse_deny(capsys) is None

--- a/tests/teatree_hooks/test_safe_kill_pretool_gate.py
+++ b/tests/teatree_hooks/test_safe_kill_pretool_gate.py
@@ -49,13 +49,21 @@ class TestDeniesRawPidKill:
         payload = _parse_deny(capsys)
         assert payload is not None
         assert payload["permissionDecision"] == "deny"
-        assert "safe_kill" in payload["permissionDecisionReason"]
+        assert "t3 teatree safe-kill" in payload["permissionDecisionReason"]
 
 
 class TestAllowsSafeCommands:
     @pytest.mark.parametrize(
         "command",
-        ["pkill -9 chrome", "killall node", "kill %1", "kill $PID", "ps -axo pid,comm"],
+        [
+            "kill -0 4242",
+            "pkill -9 chrome",
+            "killall node",
+            "kill %1",
+            "kill $PID",
+            "kill -9 $(pgrep claude)",
+            "ps -axo pid,comm",
+        ],
     )
     def test_non_raw_pid_kill_passes(self, command: str, capsys: pytest.CaptureFixture[str]) -> None:
         assert handle_block_raw_pid_kill(_bash_event(command)) is False

--- a/tests/test_gate_liveness_corpus.py
+++ b/tests/test_gate_liveness_corpus.py
@@ -560,6 +560,18 @@ def _raw_review_allow(_ctx: GateContext) -> dict:
     return _bash("glab api projects/1/merge_requests/1/discussions")
 
 
+# block-raw-pid-kill (PreToolUse Bash): a raw `kill <pid>` of a guessed pid
+# denies; the `kill -0` no-op liveness probe allows.
+
+
+def _raw_pid_kill_deny(_ctx: GateContext) -> dict:
+    return _bash("kill -9 4242")
+
+
+def _raw_pid_kill_allow(_ctx: GateContext) -> dict:
+    return _bash("kill -0 4242")
+
+
 # block-secret-file-print (PreToolUse Bash): printing a credential file to the
 # transcript denies; capturing the value into a variable allows.
 
@@ -763,6 +775,14 @@ GATE_REGISTRY: Final[tuple[GateRow, ...]] = (
         matched="Bash",
         deny_input=_raw_review_deny,
         allow_input=_raw_review_allow,
+    ),
+    GateRow(
+        gate_id="block-raw-pid-kill",
+        handler=router.handle_block_raw_pid_kill,
+        event="PreToolUse",
+        matched="Bash",
+        deny_input=_raw_pid_kill_deny,
+        allow_input=_raw_pid_kill_allow,
     ),
     GateRow(
         gate_id="block-secret-file-print",


### PR DESCRIPTION
Closes #2225.

## Problem

An agent (main session or loop owner) twice killed the WRONG, LIVE claude process when asked to kill a "dead" agent. Root cause: it matched the target by guessing which long-running pid "looked dead" (not by the named target session/task id), and read high uptime + R+/S+ STAT as "stuck" when R means running on CPU and S+/R+ mean a live foreground TTY session. Prose memory did not prevent the recurrence, so this is the smallest deterministic gate.

## Change

teatree.core.safe_kill is the deterministic guard. evaluate_safe_kill(pid, hang_cause=...) / safe_kill(...) ALLOW a signal only when BOTH hold:

- Positive identity: the pid maps to a KNOWN dead/failed target by session id (~/.claude/sessions to a session id to a FAILED/COMPLETED Task via TaskAttempt.agent_session_id), never by a heuristic "looks idle". A pid that maps to no known dead target, or to a still-claimed task, is refused.
- Confirmed non-live: two CPU samples show no activity, output has not advanced, the STAT is not a running/foreground state, AND a hang cause is stated. A process in STAT R/R+ or any + foreground state is rejected outright. An unsampleable pid is refused (the conservative branch).

The refusal names the candidate session id + liveness evidence and tells the caller to confirm the target id with the user first. The two externality boundaries (the ps liveness sample and the ~/.claude + Task-ORM identity resolution) are injectable, so the guard logic is unit-testable without real processes; only those boundaries are mocked in tests.

handle_block_raw_pid_kill (PreToolUse) denies a Bash kill of a raw, guessed pid and routes the agent to the helper. pkill/killall (signal by name) and job-spec/variable targets are not flagged.

## Tests

- Must-REFUSE: R+ running process; idle-but-foreground S+; CPU still active between samples; output still advancing; pid maps to no known dead task; pid maps to a still-claimed task; no hang cause stated; the executor never signals in any of these.
- Must-ALLOW (anti-vacuity counterpart): a genuinely-dead (Z, no CPU, mapped-to-a-FAILED-task) process IS allowed and IS signalled.
- Anti-vacuity verified: bypassing the guard (force-allow) turns the 11 must-refuse tests RED while the 2 verified-dead-target ALLOW tests stay GREEN.

Gates: ruff check / ruff format --check / ty check / tach check all clean; 1480 related existing tests (reaper/session-identity/bash-blocker/hooks) unbroken.

## Architecture pre-check (#2225)

1. BLUEPRINT alignment: a resilience/safety gate in the spirit of section 17.1 invariant 9 (deterministic gates make a class of mistake structurally impossible). No new FSM phase or BLUEPRINT section; additive safety primitive + one PreToolUse handler.
2. FSM phase boundaries: n/a. No Ticket.State / Worktree.State transition.
3. Extension-point contracts: n/a. No OverlayBase / scanner / Backend Protocol change. One new PreToolUse handler registered in hook_router._HANDLERS.
4. Component boundaries: teatree.core.safe_kill (domain logic + ORM identity resolution) and teatree.hooks.safe_kill_detect (pure command-shape detection, no ORM/ps, so the 3s hook stays fast). The hook handler lives in hooks/scripts/hook_router.py beside the sibling Bash-deny gates.
5. Dependency direction: teatree.core.safe_kill imports only from teatree.core. teatree.hooks.safe_kill_detect imports nothing from teatree (pure regex), honoring teatree.hooks to teatree.utils-only. tach check green.
6. Test surface: tests/teatree_core/test_safe_kill_guard.py, tests/teatree_hooks/test_safe_kill_detect.py, tests/teatree_hooks/test_safe_kill_pretool_gate.py.
7. Resilience invariants: the guard refuses (never signals) on an unsampleable pid. The hook handler fails open on any internal/import error (a gate bug must never wedge the agent), consistent with the other Bash-deny gates. Idempotent (pure functions, no state). No external write.
8. Identity and key normalization: the canonical target key is the session id; the pid is resolved UP to its session id (never matched by stripping/guessing).
9. Behavior preservation: n/a, purely additive. The existing renderer-SIGTERM path in loop/mechanical_resources.py (already session-ancestry-protected, allow-list only) is untouched.

## Open questions and assumptions

- The PreToolUse regex flags a kill-by-pid even when the literal appears as an argument to another command (e.g. echo kill 5); the gate only blocks and routes to the helper, so a rare false-positive is the conservative outcome. Full shell parsing was deliberately not added for this narrow surface.
- The default identity resolver treats a Task in FAILED or COMPLETED as a dead target; a still-PENDING/CLAIMED task is never a kill target.
- The core safe_kill helper is available for callers to route through; this PR does not retrofit existing call sites (there is no other raw-pid kill of a claude process in the tree today); the PreToolUse gate covers the agent-driven surface where the incident occurred.
