### PR TITLE
fix(e2e): refuse a stills-only manifest unless --allow-no-video (#2226)

### DIFF
--- a/src/teatree/core/management/commands/_test_plan.py
+++ b/src/teatree/core/management/commands/_test_plan.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TypedDict
 
+from teatree.core import test_plan_validation as _tpv
 from teatree.core.backend_factory import code_host_from_overlay
 from teatree.core.backend_protocols import CodeHostBackend
 from teatree.core.management.commands._test_plan_render import (
@@ -45,7 +46,6 @@ from teatree.core.on_behalf_gate_recorded import (
 )
 from teatree.core.on_behalf_post_receipt import notify_user_on_behalf_post
 from teatree.core.resolve import WorktreeNotFoundError, resolve_worktree
-from teatree.core.test_plan_validation import TestPlanImageValidationError, validate_test_plan_images
 from teatree.types import RawAPIDict
 
 # Re-exports so callers/tests import the test-plan surface from one module.
@@ -166,7 +166,9 @@ class TestPlanFlags:
     it. ``skip_validation`` is the user-authorised bypass of the image preflight
     (red-box / duplicate gates) — the agent never sets it on its own. ``body_file``
     is a path to a pre-authored markdown body to post directly without upload or
-    manifest processing; mutually exclusive with ``manifest``.
+    manifest processing; mutually exclusive with ``manifest``. ``allow_no_video``
+    is the user-authorised escape for the stills-only gate (a manifest with
+    screenshots but no video on any present side is refused without it).
     """
 
     ticket: str = ""
@@ -177,6 +179,7 @@ class TestPlanFlags:
     skip_validation: bool = False
     body_file: str = ""
     template: str = ""
+    allow_no_video: bool = False
 
 
 def _resolve_worktree_or_none() -> Worktree | None:
@@ -217,26 +220,25 @@ def _resolve_ticket(ticket: str, worktree: Worktree | None, *, manifest_ticket: 
     return resolved
 
 
-def _manifest_image_paths(manifest: TestPlanManifest) -> list[Path]:
-    """Every screenshot path the manifest references, across both sides + all workflows."""
-    return [
-        Path(image) for side in (manifest.dev, manifest.local) for wf in side.workflows.values() for image in wf.images
-    ]
+def _preflight_images(manifest: TestPlanManifest, *, skip: bool, allow_no_video: bool) -> None:
+    """Run the deterministic media preflight; re-raise a hard failure for the single catch arm.
 
-
-def _preflight_images(manifest: TestPlanManifest, *, skip: bool) -> None:
-    """Run the deterministic image preflight; re-raise a hard failure for the single catch arm.
-
-    Refuses (fail-loud) on a missing red box or a byte-identical duplicate by
+    Refuses (fail-loud) on a missing red box, a byte-identical duplicate, or a
+    stills-only manifest (screenshots but no video on any present side) by
     re-raising the :class:`TestPlanImageValidationError` as an
     :class:`TestPlanValidationError` so the command's existing single
     ``except TestPlanValidationError`` arm exits non-zero before any upload.
     Staleness warnings never refuse — they are logged loudly and the post
-    proceeds. ``skip`` is the user-authorised bypass (runs nothing dangerous).
+    proceeds. ``skip`` bypasses the image gates; ``allow_no_video`` is the
+    stills-only escape (both user-authorised, the agent never sets them itself).
     """
+    wfs = [wf for side in (manifest.dev, manifest.local) if side.present for wf in side.workflows.values()]
     try:
-        warnings = validate_test_plan_images(_manifest_image_paths(manifest), skip=skip)
-    except TestPlanImageValidationError as exc:
+        warnings = _tpv.validate_test_plan_images([img for wf in wfs for img in wf.images], skip=skip)
+        _tpv.refuse_stills_only(
+            has_image=any(wf.images for wf in wfs), has_video=any(wf.video for wf in wfs), allow_no_video=allow_no_video
+        )
+    except _tpv.TestPlanImageValidationError as exc:
         raise TestPlanValidationError(str(exc)) from exc
     for warning in warnings:
         _log.warning(warning)
@@ -259,7 +261,7 @@ def build_validated_post(flags: TestPlanFlags) -> TestPlanPost:
     worktree = _resolve_worktree_or_none()
     base_dir = Path(flags.manifest_dir) if flags.manifest_dir else None
     manifest = parse_manifest(flags.manifest, base_dir=base_dir)
-    _preflight_images(manifest, skip=flags.skip_validation)
+    _preflight_images(manifest, skip=flags.skip_validation, allow_no_video=flags.allow_no_video)
     ticket = _resolve_ticket(flags.ticket, worktree, manifest_ticket=manifest.ticket)
     issue_url = str(ticket.issue_url)
 
@@ -354,6 +356,7 @@ def run_post_test_plan(  # noqa: PLR0913 — the CLI flags map 1:1 to a single s
     write_err: Callable[[str], None],
     body_file: str = "",
     template: str = "",
+    allow_no_video: bool = False,
 ) -> PostTestPlanResult:
     """Read the manifest (or body file), resolve the host, validate, and post-or-update the note.
 
@@ -385,10 +388,6 @@ def run_post_test_plan(  # noqa: PLR0913 — the CLI flags map 1:1 to a single s
         worktree = _resolve_worktree_or_none()
         try:
             resolved_ticket = _resolve_ticket(ticket, worktree)
-        except TestPlanValidationError as err:
-            write_err(str(err))
-            raise SystemExit(1) from err
-        try:
             result = post_body_file_comment(
                 host,
                 issue_url=str(resolved_ticket.issue_url),
@@ -411,6 +410,7 @@ def run_post_test_plan(  # noqa: PLR0913 — the CLI flags map 1:1 to a single s
         manifest_dir=manifest_dir,
         skip_validation=skip_validation,
         template=template,
+        allow_no_video=allow_no_video,
     )
     try:
         post = build_validated_post(flags)
@@ -418,10 +418,8 @@ def run_post_test_plan(  # noqa: PLR0913 — the CLI flags map 1:1 to a single s
     except (TestPlanValidationError, OnBehalfPostBlockedError) as err:
         write_err(str(err))
         raise SystemExit(1) from err
-    write_out(
-        f"  Test plan {result['action']} ({', '.join(result['envs'])}) "
-        f"on {post.issue_url} (comment {result['comment_id']}).",
-    )
+    envs = ", ".join(result["envs"])
+    write_out(f"  Test plan {result['action']} ({envs}) on {post.issue_url} (comment {result['comment_id']}).")
     return result
 
 

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -31,17 +31,14 @@ _build_e2e_env = _runners.build_e2e_env
 
 
 # Shared typer.Option declarations for ``post-test-plan`` and its deprecated alias.
-_MRS_OPTION = typer.Option(
-    None,
-    "--mrs",
-    help="MR/PR URL(s) the test plan covers (repeat or comma-separate). Supplements the manifest's 'mrs'.",
-)
-_SKIP_VALIDATION_OPTION = typer.Option(
-    default=False,
-    help="User-authorised bypass of the image preflight (red-box / duplicate gates). Not for routine use.",
-)
+_MRS_HELP = "MR/PR URL(s) the test plan covers (repeat or comma-separate). Supplements the manifest's 'mrs'."
+_MRS_OPTION = typer.Option(None, "--mrs", help=_MRS_HELP)
+_SKIP_HELP = "User-authorised bypass of the image preflight (red-box / duplicate gates). Not for routine use."
+_SKIP_VALIDATION_OPTION = typer.Option(default=False, help=_SKIP_HELP)
 _TEMPLATE_HELP = "Body template: capture-matrix (default), browser-click-first, or link-api. Overrides the manifest's."
 _TEMPLATE_OPTION = typer.Option("", "--template", help=_TEMPLATE_HELP)
+_NO_VIDEO_HELP = "Post a stills-only manifest (screenshots, no video). Refused by default — capture video:'on' instead."
+_ALLOW_NO_VIDEO_OPTION = typer.Option(default=False, help=_NO_VIDEO_HELP)
 
 
 @dataclass
@@ -511,6 +508,7 @@ class Command(TyperCommand):
         skip_validation: bool = _SKIP_VALIDATION_OPTION,
         body_file: str = "",
         template: str = _TEMPLATE_OPTION,
+        allow_no_video: bool = _ALLOW_NO_VIDEO_OPTION,
     ) -> _test_plan.PostTestPlanResult:
         """Post (or update) the ticket's single test-plan note from a manifest.
 
@@ -520,8 +518,9 @@ class Command(TyperCommand):
         issue; ``--title`` overrides the heading; ``--template``
         (``capture-matrix`` / ``browser-click-first`` / ``link-api``) selects
         the body shape, overriding the manifest's ``template``;
-        ``--skip-validation`` bypasses the image preflight; ``--body-file`` posts
-        a pre-authored body verbatim (no upload; mutually exclusive with
+        ``--skip-validation`` bypasses the image preflight; ``--allow-no-video``
+        permits a stills-only manifest (refused by default); ``--body-file``
+        posts a pre-authored body verbatim (no upload; mutually exclusive with
         ``--manifest``). See :mod:`._test_plan`. ``post-evidence`` is a hidden,
         deprecated alias.
         """
@@ -535,6 +534,7 @@ class Command(TyperCommand):
             write_err=self.stderr.write,
             body_file=body_file,
             template=template,
+            allow_no_video=allow_no_video,
         )
 
     @command(name="retract-evidence")
@@ -561,16 +561,16 @@ class Command(TyperCommand):
         skip_validation: bool = _SKIP_VALIDATION_OPTION,
         body_file: str = "",
         template: str = _TEMPLATE_OPTION,
+        allow_no_video: bool = _ALLOW_NO_VIDEO_OPTION,
     ) -> _test_plan.PostTestPlanResult:
         """Deprecated alias for ``post-test-plan`` (renamed; kept one release for back-compat)."""
-        return _test_plan.run_post_test_plan(
+        return self.post_test_plan(
             manifest=manifest,
             ticket=ticket,
             title=title,
             mrs=mrs,
             skip_validation=skip_validation,
-            write_out=self.stdout.write,
-            write_err=self.stderr.write,
             body_file=body_file,
             template=template,
+            allow_no_video=allow_no_video,
         )

--- a/src/teatree/core/test_plan_validation.py
+++ b/src/teatree/core/test_plan_validation.py
@@ -148,3 +148,21 @@ def validate_test_plan_images(images: list[Path], *, skip: bool = False) -> list
     _refuse_images_without_red_box(images)
     _refuse_duplicate_images(images)
     return _staleness_warnings(images)
+
+
+def refuse_stills_only(*, has_image: bool, has_video: bool, allow_no_video: bool) -> None:
+    """Refuse a stills-only test plan: screenshots present, no video on any workflow.
+
+    A test plan with screenshots but zero video across every present-side
+    workflow is below the documented evidence bar (a recorded video is the
+    minimum proof a flow actually ran). ``allow_no_video=True`` is the
+    user-authorised escape. A no-media (steps-only) manifest never reaches here
+    — ``has_image`` is False — so this composes with the steps-or-media gate.
+    """
+    if allow_no_video or has_video or not has_image:
+        return
+    msg = (
+        "Test plan refused: no video on any workflow (stills-only). A test plan with zero "
+        "video is below the evidence bar — capture with video:'on', or pass --allow-no-video."
+    )
+    raise TestPlanImageValidationError(msg)

--- a/tests/teatree_core/e2e_command/test_post_test_plan.py
+++ b/tests/teatree_core/e2e_command/test_post_test_plan.py
@@ -28,6 +28,7 @@ import pytest
 from django.core.management import call_command
 from django.test import TestCase
 
+from teatree.core import test_plan_validation as _validation
 from teatree.core.backend_protocols import UploadVerification
 from teatree.core.management.commands import _test_plan
 from teatree.core.management.commands import _test_plan_render as _render
@@ -481,6 +482,72 @@ class TestParseManifest:
         assert "Search" not in parsed.steps
 
 
+class TestRefuseStillsOnly:
+    """The stills-only validator: screenshots present + no video anywhere → refuse."""
+
+    def test_stills_only_refused(self) -> None:
+        with pytest.raises(_validation.TestPlanImageValidationError, match="no video"):
+            _validation.refuse_stills_only(has_image=True, has_video=False, allow_no_video=False)
+
+    def test_stills_only_passes_with_allow_no_video(self) -> None:
+        _validation.refuse_stills_only(has_image=True, has_video=False, allow_no_video=True)
+
+    def test_with_video_passes(self) -> None:
+        _validation.refuse_stills_only(has_image=True, has_video=True, allow_no_video=False)
+
+    def test_no_image_is_not_stills_only(self) -> None:
+        # A steps-only / no-media manifest never trips this gate (#2269 owns it).
+        _validation.refuse_stills_only(has_image=False, has_video=False, allow_no_video=False)
+
+
+class TestNoVideoGateAtCommand(TestCase):
+    """``build_validated_post`` refuses a stills-only manifest unless ``--allow-no-video``."""
+
+    @pytest.fixture(autouse=True)
+    def _inject(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        self._tmp = tmp_path
+        monkeypatch.setattr(
+            _test_plan,
+            "resolve_worktree",
+            MagicMock(side_effect=_test_plan.WorktreeNotFoundError("none")),
+        )
+
+    def _ticket(self) -> None:
+        from teatree.core.models import Ticket  # noqa: PLC0415
+
+        Ticket.objects.create(overlay="test", issue_url=_ISSUE_URL)
+
+    def _manifest(self, *, video: bool) -> str:
+        local: dict[str, object] = {"images": [str(_red_boxed_png(self._tmp / "a.png"))]}
+        if video:
+            local["video"] = _write_webm(self._tmp / "v.webm", b"V")
+        return json.dumps(
+            {
+                "ticket": "8521",
+                "local": {"commits": {"client": "aabb"}},
+                "workflows": [{"workflow": "Login", "local": local}],
+            },
+        )
+
+    def test_stills_only_manifest_is_refused(self) -> None:
+        self._ticket()
+        flags = _test_plan.TestPlanFlags(ticket="", manifest=self._manifest(video=False))
+        with pytest.raises(_test_plan.TestPlanValidationError, match="no video"):
+            _test_plan.build_validated_post(flags)
+
+    def test_stills_only_manifest_passes_with_allow_no_video(self) -> None:
+        self._ticket()
+        flags = _test_plan.TestPlanFlags(ticket="", manifest=self._manifest(video=False), allow_no_video=True)
+        post = _test_plan.build_validated_post(flags)
+        assert post.issue_url == _ISSUE_URL
+
+    def test_manifest_with_a_video_passes(self) -> None:
+        self._ticket()
+        flags = _test_plan.TestPlanFlags(ticket="", manifest=self._manifest(video=True))
+        post = _test_plan.build_validated_post(flags)
+        assert post.issue_url == _ISSUE_URL
+
+
 class TestManifestPathResolution:
     """Relative image/video paths resolve against the manifest file's directory (#friction)."""
 
@@ -556,7 +623,7 @@ class TestTicketFallbackFromManifest(TestCase):
                 "workflows": [{"workflow": "Login", "local": {"images": [str(img)]}}],
             },
         )
-        flags = _test_plan.TestPlanFlags(ticket="", manifest=manifest)
+        flags = _test_plan.TestPlanFlags(ticket="", manifest=manifest, allow_no_video=True)
         post = _test_plan.build_validated_post(flags)
         assert post.issue_url == _ISSUE_URL
 
@@ -568,7 +635,7 @@ class TestTicketFallbackFromManifest(TestCase):
                 "workflows": [{"workflow": "Login", "local": {"images": [str(img)]}}],
             },
         )
-        flags = _test_plan.TestPlanFlags(ticket="", manifest=manifest)
+        flags = _test_plan.TestPlanFlags(ticket="", manifest=manifest, allow_no_video=True)
         with pytest.raises(_test_plan.TestPlanResolutionError, match="Could not determine the ticket"):
             _test_plan.build_validated_post(flags)
 
@@ -855,6 +922,7 @@ class TestImagePreflightAtCommand(_EvidenceTestBase):
                     ticket=_ISSUE_URL,
                     manifest=self._no_red_box_manifest(),
                     skip_validation=True,
+                    allow_no_video=True,
                 ),
             )
         assert result["action"] == "created"


### PR DESCRIPTION
## Summary

`e2e post-test-plan` (and its deprecated `post-evidence` alias) now refuses a manifest whose every present-side workflow has an empty `video` slot while at least one screenshot exists — a stills-only note is below the documented evidence bar (#272: video + full scope + side-by-side). The escape is an explicit `--allow-no-video` flag.

Closes #2226.

## How it works

- The new gate is `refuse_stills_only` in `test_plan_validation.py`, the deterministic pre-post validator module that already holds the red-box and duplicate gates.
- It runs from `_preflight_images` right after the image preflight, so it shares the wrap-into-`TestPlanValidationError` arm and the no-host-side-effect contract (a failure burns no on-behalf approval and writes no note).
- It takes primitives (`has_image`, `has_video`, `allow_no_video`), so the validator module stays decoupled from the manifest type and the dependency graph is unchanged.
- `--allow-no-video` is threaded from the CLI flag through `TestPlanFlags` and `run_post_test_plan` into `_preflight_images`.

## Composes with #2269 (zero-media gate)

#2269 rejects a manifest with no steps and no media. This change adds the no-video check on top, but only fires when stills exist: a steps-only or no-media manifest has `has_image=False` and never trips the new gate, so #2269 still governs that case. A manifest with at least one video on any present side passes both.

## Architecture pre-check — #2226

1. **BLUEPRINT § alignment** — E2E evidence model (#272); tightens the evidence bar into a tool property rather than agent vigilance.
2. **FSM phase boundaries** — n/a (a pre-post validator, no state transition).
3. **Extension-point contracts** — n/a (no OverlayBase / scanner / hook / Protocol surface).
4. **Component boundaries** — gate in `test_plan_validation.py` (core validators); flag plumbing in `_test_plan.py` and `e2e.py`; no new module.
5. **Dependency direction** — validator takes primitives, no manifest import added; tach validated.
6. **Test surface** — `TestRefuseStillsOnly` (unit truth table) + `TestNoVideoGateAtCommand` (through `build_validated_post`: refuse / `--allow-no-video` escape / video-passes). Anti-vacuity verified by neutering the gate and observing both refuse tests go red.
7. **Resilience invariants** — n/a (pure validation before any external write).
8. **Identity and key normalization** — n/a.
9. **Behavior preservation** — purely additive; #2269 accept/reject preserved. The existing zero-media tests that asserted images-only acceptance no longer assert through the gate (the gate moved to `build_validated_post`); no must-block test inverted.

## Module-health note

`_test_plan.py` and `e2e.py` were at the LOC cap, so the additions are offset by behaviour-preserving compaction: merged the body-file branch's two adjacent `try/except` (the resolution error is a subclass of the post error) into one; collapsed the success-message f-string and the `typer.Option` help declarations; the deprecated `post-evidence` now delegates to `self.post_test_plan` instead of duplicating the call body.

## Verification

- `tests/teatree_core/e2e_command/` + `tests/teatree_core/test_test_plan_validation.py` + pr-command + on-behalf suites green (261 passed).
- `uv run ruff check`, `uv run ruff format --check`, `uv run ty check`, `uv run tach check` all pass.

## Open questions & assumptions

- "Stills-only" is scoped to: at least one screenshot present AND no video on any present side. A no-media (steps-only) manifest is out of scope since #2269 governs it and there are no stills to flag.
- The issue offered a hard fail or a warn-loud; implemented as a hard refuse with an `--allow-no-video` escape, matching the acceptance criteria.
