### PR TITLE
fix(hooks): recognize git commit per-segment in carve-out fallbacks (#2215)

### DIFF
--- a/src/teatree/hooks/_commit_carve_out.py
+++ b/src/teatree/hooks/_commit_carve_out.py
@@ -213,20 +213,20 @@ def own_slug_term_downgrades(command: str, term: str, cwd: Path | None, *, confi
     The landing repo must still clear :func:`commit_branch_downgrades` -- be
     PROVABLY private (allowlist or probe) or a genuinely-unresolvable LOCAL
     commit -- so a resolvable PUBLIC/UNKNOWN landing keeps the hard block (the
-    commit could genuinely land in a public repo; never a leak). The SAME
-    per-segment chain proof runs, so an own-slug term never relaxes a chained
-    PUBLIC post: ``is_git_commit_command`` matches the FIRST segment only and
-    the scanner reports the FIRST matched term, so a chained ``&& gh issue
-    create --repo <PUBLIC>`` still defeats the downgrade.
+    commit could genuinely land in a public repo; never a leak). The commit is
+    recognised PER SEGMENT (:func:`command_has_git_commit_segment`), so the
+    chained worktree idiom ``cd <wt> && git add -A && git commit -m …`` -- whose
+    ``git commit`` is a LATER segment, not the command's first action -- still
+    qualifies (#2215). The SAME per-segment chain proof runs, so an own-slug
+    term never relaxes a chained PUBLIC post: a chained ``&& gh issue create
+    --repo <PUBLIC>`` fails the proof and defeats the downgrade.
 
     The over-block this closes (#1958): the org PREFIX of a multi-token private
     slug now qualifies as the repo's own identity, so an own-org work-item URL
     whose scanner-reported token is the prefix downgrades on the repo's OWN
     private commit exactly as the whole-slug spelling already did.
     """
-    from teatree.hooks.publish_surface import is_git_commit_command  # noqa: PLC0415
-
-    if not is_git_commit_command(command):
+    if not command_has_git_commit_segment(command):
         return False
     if not _repo_visibility.term_is_own_repo_slug(term, config_path):
         return False

--- a/src/teatree/hooks/publish_surface.py
+++ b/src/teatree/hooks/publish_surface.py
@@ -542,9 +542,13 @@ def visibility_unknown_for_block(
     Returns ``None`` when every resolvable target is allowlisted-private or
     genuinely PUBLIC (a public target is correctly blocked, not "unknown" --
     emitting the add-to-allowlist hint there would be misleading).
+
+    The commit is recognised PER SEGMENT, so the chained worktree idiom
+    ``cd <wt> && git add -A && git commit …`` -- whose ``git commit`` is a
+    LATER segment -- still surfaces the commit-target hint (#2215).
     """
     slugs: list[str] = []
-    if is_git_commit_command(command) and cwd is not None:
+    if _commit_carve_out.command_has_git_commit_segment(command) and cwd is not None:
         slugs.append(_repo_visibility.slug_for_cwd(cwd))
     slugs.extend(
         _segment_target_slug(words, cwd) for words in _command_segments(command) if _segment_is_posting_verb(words)

--- a/tests/teatree_hooks/test_publish_surface.py
+++ b/tests/teatree_hooks/test_publish_surface.py
@@ -740,6 +740,48 @@ class TestCarveOutApplies:
             is True
         )
 
+    # A chained ``cd <wt> && git add -A && git commit -m …`` is the agent's
+    # standard worktree-commit idiom: the ``git commit`` sits in a LATER
+    # segment, not the command's first action. It must be recognised as a
+    # commit so the private-repo carve-out applies, exactly as the plain
+    # ``git commit`` above does (#2215).
+    def test_chained_cd_add_commit_downgrades(self, private_cfg: Path, private_repo: Path) -> None:
+        body = "fix the acmewidget refinery"
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                f'cd {private_repo} && git add -A && git commit -m "{body}"',
+                body,
+                private_repo,
+                config_path=private_cfg,
+            )
+            is True
+        )
+
+    # SAFETY TEST: a chained commit must NOT vouch for a publish segment in the
+    # same chain. A ``cd <wt> && git add && git commit … && gh issue create
+    # --repo <PUBLIC>`` carries a foreign term to a PUBLIC repo; the per-segment
+    # chain proof must still defeat it even though the commit segment alone
+    # would downgrade (#2215, the #2034 per-segment concern).
+    def test_chained_commit_then_public_gh_post_stays_blocked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = _config(tmp_path, ["acmecorp-engineering"])
+        private_repo = _repo_with_remote(tmp_path / "wt", "git@gitlab.com:acmecorp-engineering/acmecorp-product.git")
+        # No probe tool -> the public --repo slug is unknown -> NOT private.
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        assert (
+            publish_surface.carve_out_applies(
+                "Bash",
+                f'cd {private_repo} && git add -A && git commit -m "acmewidget fix" '
+                '&& gh issue create --repo souliane/teatree --title x --body "someforeignbank"',
+                "acmewidget fix",
+                private_repo,
+                config_path=cfg,
+            )
+            is False
+        )
+
     # SAFETY TEST: This test is load-bearing. A commit whose CUMULATIVE
     # ``-C`` landing dir is a PUBLIC repo must stay hard-blocked even when the
     # bare last ``-C`` segment, resolved alone, would name a private repo.
@@ -1387,6 +1429,45 @@ class TestOwnSlugTermDowngrades:
                 config_path=cfg,
             )
             is True
+        )
+
+    # (a) The own-slug downgrade must also fire on the chained worktree-commit
+    # idiom ``cd <wt> && git add -A && git commit -m …`` where the ``git
+    # commit`` sits in a LATER segment, not the command's first action. Without
+    # per-segment recognition the chained commit is not seen as a commit and a
+    # legitimate own-slug commit is hard-blocked as if it were a publish (#2215).
+    def test_own_org_slug_term_chained_cd_add_commit_downgrades(self, cfg: Path, private_repo: Path) -> None:
+        assert (
+            publish_surface.own_slug_term_downgrades(
+                f"cd {private_repo} && git add -A "
+                '&& git commit -m "ref https://gitlab.com/acmecorp-engineering/acmecorp-product/-/issues/7"',
+                "acmecorp-engineering",
+                private_repo,
+                config_path=cfg,
+            )
+            is True
+        )
+
+    # (b) SAFETY: the chained own-slug commit must NOT vouch for a chained
+    # PUBLIC gh post. The per-segment chain proof must still defeat a
+    # ``cd <wt> && git add && git commit … && gh issue create --repo <PUBLIC>``
+    # so the chained-commit recognition never weakens the gate (#2215, #2034).
+    def test_chained_own_slug_commit_then_public_gh_post_stays_blocked(
+        self, tmp_path: Path, cfg: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        private_worktree = _repo_with_remote(
+            tmp_path / "wt", "git@gitlab.com:acmecorp-engineering/acmecorp-product.git"
+        )
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "bin"))
+        assert (
+            publish_surface.own_slug_term_downgrades(
+                f'cd {private_worktree} && git add -A && git commit -m "acmecorp-engineering ref" '
+                '&& gh issue create --repo souliane/teatree --title x --body "someforeignbank"',
+                "acmecorp-engineering",
+                private_worktree,
+                config_path=cfg,
+            )
+            is False
         )
 
     # (a) An unresolvable LOCAL commit (cwd not in any repo) tripping on its
@@ -2390,6 +2471,23 @@ class TestProbeEnvResolution:
             f"gh issue create --repo {_PRIV_SLUG} --body x", repo, config_path=cfg
         )
         assert slug is None
+
+    def test_visibility_unknown_returns_commit_slug_for_chained_commit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The add-to-allowlist diagnostic must see the chained worktree-commit
+        # idiom ``cd <wt> && git add -A && git commit …`` and report the
+        # unresolvable target slug, exactly as it does for a plain commit. With
+        # only first-action recognition the chained commit is invisible to the
+        # hint and the operator gets no offline-allowlist guidance (#2215).
+        cfg = _config(tmp_path, [])  # not allowlisted
+        repo = _repo_with_remote(tmp_path / "r", _PRIV_REMOTE)
+        monkeypatch.setenv("PATH", _git_only_bin(tmp_path / "gitonly"))
+        monkeypatch.setattr(_repo_visibility, "_PROBE_PATH_EXTRA", ())
+        slug = publish_surface.visibility_unknown_for_block(
+            f'cd {repo} && git add -A && git commit -m "x"', repo, config_path=cfg
+        )
+        assert slug == publish_surface.slug_for_cwd(repo)
 
     def test_visibility_unknown_returns_none_when_genuinely_public(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

Fixes #2215. The banned-terms publish gate's private-repo commit carve-out had two fallback paths that recognized a git commit only as the command's effective FIRST action (`is_git_commit_command`): `own_slug_term_downgrades` and `visibility_unknown_for_block`. A chained worktree idiom — change into the worktree, then `git add`, then `git commit` — puts the commit verb in a LATER segment, so both fallbacks failed to see it. The result: an own-slug-term commit to an allowlisted-private repo was hard-blocked as if it were an external publish, and the add-to-allowlist diagnostic missed the commit target.

The primary `carve_out_applies` dispatch already routes through the per-segment recognizer `command_has_git_commit_segment`. These two fallbacks were the only remaining whole-command `is_git_commit_command` callers. Both now route through the same per-segment recognizer.

## Safety

Unchanged. The per-segment chain proof in `commit_branch_downgrades` still scans every segment, so a chained public gh/glab post fails the proof and keeps the hard-block. A commit segment never vouches for a publish segment in the same chain. `is_git_commit_command`'s first-action semantic is preserved (it is still used per-segment internally); no must-block test was inverted.

## Tests

- must-ALLOW: `cd <wt> && git add -A && git commit -m "..."` is recognized as a commit so the carve-out applies (both the domain-word and own-slug paths) and the visibility hint surfaces the commit target.
- must-still-BLOCK: `cd <wt> && git add && git commit ... && gh issue create --repo <PUBLIC> ...` still hard-blocks on the publish segment.

The two new RED tests were observed to fail on pre-fix code and pass after the fix; the chained-to-public must-block cases stay green.

## Architecture pre-check

- BLUEPRINT publish gates (#126/#1415) — private-repo commit carve-out.
- FSM: n/a (no `Ticket.State` transition).
- Extension points: n/a (internal hook helpers; no `OverlayBase`/scanner/Protocol surface).
- Component boundaries: `src/teatree/hooks/` (PreToolUse gate helpers).
- Dependency direction: no new edge; `publish_surface` already imports `_commit_carve_out`; the removed lazy import inverts no DAG edge.
- Behavior preservation: purely additive recognition; no must-block test inverted.
