### PR TITLE
fix(hooks): actionable message for variable/stdin publish bodies (#2369)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -3422,9 +3422,10 @@ def _banned_term_marker_blocks(term: str, command: str, cwd_repo: "Path | None")
     marker (an unresolvable body, an unavailable scanner). For a real term this
     returns ``None`` so the caller takes the destination-aware banned-term path.
 
-    For the UNRESOLVABLE-body marker the decision is destination-aware: an
+    For the two unreadable-body markers the decision is destination-aware: an
     UNREADABLE body file (a ``git commit -F <path>`` whose file does not exist
-    at cold-hook scan time, a missing ``--body-file``) hard-blocks on a PUBLIC
+    at cold-hook scan time, a missing ``--body-file``) OR an UNAVAILABLE body
+    source (an unexpanded ``$VAR`` / a stdin body, #2369) hard-blocks on a PUBLIC
     surface — an unscanned body must never slip into public history — but a
     ``git commit`` landing in a PRIVATE repo (or a pure private gh/glab post) is
     not a public surface, so the unread body cannot leak and the gate downgrades
@@ -3437,9 +3438,11 @@ def _banned_term_marker_blocks(term: str, command: str, cwd_repo: "Path | None")
     marker_message = banned_terms_scanner.marker_deny_message(term)
     if marker_message is None:
         return None
-    if term == banned_terms_scanner.UNRESOLVABLE_BODY_MARKER and publish_surface.command_targets_private_only(
-        command, cwd_repo
-    ):
+    unreadable_body_markers = {
+        banned_terms_scanner.UNRESOLVABLE_BODY_MARKER,
+        banned_terms_scanner.UNAVAILABLE_BODY_SOURCE_MARKER,
+    }
+    if term in unreadable_body_markers and publish_surface.command_targets_private_only(command, cwd_repo):
         sys.stderr.write(
             "WARNING: banned-terms gate (#1415) — could not read the commit/post body, but the "
             "destination is a private repo; downgraded to warn. A private-repo body is not a public leak.\n"

--- a/src/teatree/hooks/_body_file_resolution.py
+++ b/src/teatree/hooks/_body_file_resolution.py
@@ -27,7 +27,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
 
-from teatree.hooks._command_parser import FAIL_CLOSED_SENTINEL, attached_value, read_file_arg
+from teatree.hooks._command_parser import (
+    FAIL_CLOSED_SENTINEL,
+    UNAVAILABLE_BODY_SOURCE_SENTINEL,
+    attached_value,
+    read_file_arg,
+)
 from teatree.hooks._shell_lexer import Token, TokenKind, split_commands
 
 # Long options that point at a FILE whose content we should read. If the
@@ -64,7 +69,10 @@ def resolve_inline_body_value(value: str, base: Path | None) -> str:
         ``base``-relative fallback for the cold-hook reset cwd). An unreadable
         path yields the fail-closed sentinel.
     - ``$VAR`` / ``${VAR}`` -- the environment variable's value when present in
-        the hook subprocess env; absent yields the fail-closed sentinel.
+        the hook subprocess env; absent yields the UNAVAILABLE-body-source
+        sentinel (the value does not exist before the command runs, so the gate
+        renders the actionable "write the body to an absolute file" message,
+        #2369).
     - anything else -- returned verbatim (a normal inline body).
 
     A value the resolver returns verbatim that STILL carries an unexpanded
@@ -89,7 +97,7 @@ def resolve_inline_body_value(value: str, base: Path | None) -> str:
     var_match = _VAR_REF_RE.match(value)
     if var_match is not None:
         resolved = os.environ.get(var_match.group("name"))
-        return resolved if resolved is not None else FAIL_CLOSED_SENTINEL
+        return resolved if resolved is not None else UNAVAILABLE_BODY_SOURCE_SENTINEL
     if "$(" in value:
         return FAIL_CLOSED_SENTINEL
     return value

--- a/src/teatree/hooks/_command_parser.py
+++ b/src/teatree/hooks/_command_parser.py
@@ -84,23 +84,55 @@ _T3_PUBLISH_SUBSTRINGS: Final[tuple[str, ...]] = (
 FAIL_CLOSED_SENTINEL: Final[str] = "[teatree-gate] pre-publish scanner could not resolve a body source; failing closed"
 
 
+# A SECOND fail-closed sentinel for the body sources that are FUNDAMENTALLY
+# unavailable at PreToolUse -- an unexpanded ``$VAR`` (the value is not in the
+# hook env) and a stdin body (``gh api --input -``, ``git commit -F -``). The
+# generic :data:`FAIL_CLOSED_SENTINEL` covers a missing/unreadable FILE, where
+# the actionable advice is "the file is missing"; these two cases need the
+# OPPOSITE advice (write the body to an absolute file and pass ``--body-file
+# <abspath>``), so they carry a distinct sentinel the gate maps to a distinct,
+# actionable message (#2369). The block is identical -- both sentinels fail
+# closed -- only the operator-facing reason differs. It too must not self-match
+# any quote-scanner HIGH pattern.
+UNAVAILABLE_BODY_SOURCE_SENTINEL: Final[str] = (
+    "[teatree-gate] pre-publish body source is unavailable before the command runs; failing closed"
+)
+
+
 def is_fail_closed_sentinel(text: str) -> bool:
     """Return True iff ``text`` carries an INJECTED fail-closed sentinel.
 
-    The parser emits the sentinel as its own discrete payload fragment for
-    every unresolvable/ambiguous body source, and the fragments are joined
-    by newlines — so a genuinely-injected sentinel is always a standalone
-    newline-delimited line equal to :data:`FAIL_CLOSED_SENTINEL`. The gate
-    fails closed on that NAMED reason (#126).
+    The parser emits a sentinel as its own discrete payload fragment for every
+    unresolvable/ambiguous body source, and the fragments are joined by newlines
+    — so a genuinely-injected sentinel is always a standalone newline-delimited
+    line equal to :data:`FAIL_CLOSED_SENTINEL` or
+    :data:`UNAVAILABLE_BODY_SOURCE_SENTINEL`. The gate fails closed on either
+    NAMED reason (#126/#2369); both spellings are recognised here so every
+    downstream gate (quote-scanner, AI-signature, banned-terms) keeps failing
+    closed regardless of which body-source class injected the sentinel.
 
-    A body that merely MENTIONS the sentinel as inert prose inside a
+    A body that merely MENTIONS a sentinel as inert prose inside a
     properly-quoted argument value (a commit message or PR body that
     DISCUSSES the gate) embeds the phrase mid-line, not as a standalone
     line. That is not a quoting hazard — the argument is correctly quoted —
     so the line-exact test allows it while every genuine injection (the
     sentinel on its own line) still fails closed (#1213).
     """
-    return any(line.strip() == FAIL_CLOSED_SENTINEL for line in text.split("\n"))
+    sentinels = {FAIL_CLOSED_SENTINEL, UNAVAILABLE_BODY_SOURCE_SENTINEL}
+    return any(line.strip() in sentinels for line in text.split("\n"))
+
+
+def is_unavailable_body_source_sentinel(text: str) -> bool:
+    """Return True iff ``text`` carries an injected UNAVAILABLE-body-source sentinel.
+
+    Distinguishes the ``$VAR`` / stdin class (fundamentally unavailable before
+    the command runs) from a missing/unreadable FILE, so the gate can render the
+    actionable "write the body to an absolute file and use ``--body-file
+    <abspath>``" message for it instead of the misleading "body file is missing"
+    one (#2369). Line-exact for the same inert-prose reason as
+    :func:`is_fail_closed_sentinel`.
+    """
+    return any(line.strip() == UNAVAILABLE_BODY_SOURCE_SENTINEL for line in text.split("\n"))
 
 
 def _segment_is_t3_publish(words: list[str]) -> bool:
@@ -334,9 +366,16 @@ def _walk_body_flags(words: list[str], payloads: list[str], base: "Path | None")
 
 
 def _handle_api_input(arg: str, payloads: list[str]) -> None:
-    """Read a ``--input`` argument: stdin or missing file → fail closed."""
+    """Read a ``--input`` argument: stdin or missing file → fail closed.
+
+    A literal ``-`` is a STDIN body the PreToolUse hook cannot read before the
+    command runs, so it carries :data:`UNAVAILABLE_BODY_SOURCE_SENTINEL` and the
+    gate renders the actionable "write the body to an absolute file" message
+    (#2369). A NAMED file that does not exist is a missing FILE, so it keeps the
+    generic :data:`FAIL_CLOSED_SENTINEL` whose "body file is missing" advice fits.
+    """
     if arg == "-":
-        payloads.append(FAIL_CLOSED_SENTINEL)
+        payloads.append(UNAVAILABLE_BODY_SOURCE_SENTINEL)
         return
     content = read_file_arg(arg)
     if content is None:

--- a/src/teatree/hooks/banned_terms_scanner.py
+++ b/src/teatree/hooks/banned_terms_scanner.py
@@ -42,6 +42,7 @@ from teatree.hooks._command_parser import extract_secret_scan_text as _extract_s
 from teatree.hooks._command_parser import first_segment_words as _first_segment_words
 from teatree.hooks._command_parser import is_fail_closed_sentinel as _is_fail_closed_sentinel
 from teatree.hooks._command_parser import is_publish_command as _is_publish_command
+from teatree.hooks._command_parser import is_unavailable_body_source_sentinel as _is_unavailable_body_source_sentinel
 from teatree.hooks._publish_detection import segment_word_lists_raw as _segment_word_lists_raw
 from teatree.hooks.term_match import matched_term as _matched_token_term
 from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to_fail
@@ -55,6 +56,16 @@ _OVERRIDE_ENV = "ALLOW_BANNED_TERM"
 # to emit a message MUST check for this marker explicitly and use
 # ``format_unresolvable_body_message`` — it is NOT a configured banned term.
 UNRESOLVABLE_BODY_MARKER: str = "<unresolvable-publish-body>"
+
+# Marker returned by ``scan_text`` when the body source is FUNDAMENTALLY
+# unavailable before the command runs — an unexpanded ``$VAR`` or a stdin body
+# (``--input -``, ``git commit -F -``). Distinct from
+# ``UNRESOLVABLE_BODY_MARKER`` (a missing FILE) so the gate renders the
+# actionable "write the body to an absolute file and use ``--body-file
+# <abspath>``" message instead of the misleading "body file is missing" one
+# (#2369). The gate BLOCKS on it the same way — an unscannable body never
+# publishes unscanned — only the operator-facing reason differs.
+UNAVAILABLE_BODY_SOURCE_MARKER: str = "<unavailable-publish-body-source>"
 
 # Marker returned by ``scan_text`` when the shell scanner could NOT run — a
 # crashing interpreter (an old system ``python3`` below the repo's >= 3.13
@@ -218,13 +229,16 @@ def scan_text(text: str, *, config_path: Path | None = None) -> str | None:
     exit means a banned term was found; the matched term is parsed back
     out of the script's ``BANNED TERM in <file>:`` report.
 
-    A body the parser could not resolve carries the fail-closed sentinel
-    (``FAIL_CLOSED_SENTINEL``). It is recognised EXPLICITLY as a match and
-    BLOCKS -- the sentinel is not a configured banned term, so delegating it
-    to ``check-banned-terms.sh`` would return clean and a PUBLIC file-body post
-    whose body the gate cannot read would slip through unread. The sibling
-    ``quote_scanner`` already blocks on this same sentinel; this closes the
-    banned-terms parity gap.
+    A body the parser could not resolve carries a fail-closed sentinel. It is
+    recognised EXPLICITLY as a match and BLOCKS -- the sentinel is not a
+    configured banned term, so delegating it to ``check-banned-terms.sh`` would
+    return clean and a PUBLIC body the gate cannot read would slip through
+    unread. Two sentinel classes map to two markers so the caller can render the
+    right operator advice (#2369): a FUNDAMENTALLY-unavailable body source (an
+    unexpanded ``$VAR`` / a stdin body) yields
+    :data:`UNAVAILABLE_BODY_SOURCE_MARKER`, and a missing/unreadable FILE yields
+    :data:`UNRESOLVABLE_BODY_MARKER`. Both BLOCK; only the message differs. The
+    sibling ``quote_scanner`` blocks on both sentinels too.
 
     Returns ``None`` only on a genuine no-op (no config, no script — there is
     nothing to scan, matching the shell hook's own no-op contract). A scanner
@@ -235,6 +249,8 @@ def scan_text(text: str, *, config_path: Path | None = None) -> str | None:
     """
     if not text:
         return None
+    if _is_unavailable_body_source_sentinel(text):
+        return UNAVAILABLE_BODY_SOURCE_MARKER
     if _is_fail_closed_sentinel(text):
         return UNRESOLVABLE_BODY_MARKER
     return _run_shell_scanner(text, config_path)
@@ -337,6 +353,26 @@ def format_unresolvable_body_message() -> str:
     )
 
 
+def format_unavailable_body_source_message() -> str:
+    """Render the PreToolUse deny reason when the publish body source is unavailable.
+
+    The body comes from an unexpanded shell variable (``--body "$VAR"``) or a
+    stdin stream (``gh api --input -``, ``git commit -F -``), neither of which
+    exists for the gate to scan BEFORE the command runs. The fail-closed
+    direction is correct — an unscanned body must not publish — but the operator
+    advice is the OPPOSITE of the missing-file message: write the body to an
+    absolute on-disk file and pass ``--body-file <abspath>`` so the gate can read
+    and scan it (#2369).
+    """
+    return (
+        "BLOCKED: banned-terms posting gate (#1415/#2369). The publish body comes from an "
+        "unexpanded variable or stdin, which the gate cannot scan before the command runs. "
+        "Write the body to an absolute file and post it with --body-file <abspath> (the gate "
+        "reads an absolute body file regardless of cwd), or pass the body inline with "
+        "-m/--body/--message."
+    )
+
+
 def format_scanner_unavailable_message() -> str:
     """Render the PreToolUse deny reason when the banned-terms scanner could not run.
 
@@ -358,11 +394,14 @@ def marker_deny_message(term: str) -> str | None:
     """Return the deny reason for a fail-closed marker, or ``None`` for a real term.
 
     ``scan_text`` returns either a configured banned term or one of the
-    fail-closed markers (an unresolvable body, an unavailable scanner). The
-    markers are NOT configured terms, so the caller must render a dedicated
-    message instead of ``format_block_message``. A real term returns ``None``
-    here so the caller takes its destination-aware banned-term path.
+    fail-closed markers (an unavailable body source, an unresolvable body, an
+    unavailable scanner). The markers are NOT configured terms, so the caller
+    must render a dedicated message instead of ``format_block_message``. A real
+    term returns ``None`` here so the caller takes its destination-aware
+    banned-term path.
     """
+    if term == UNAVAILABLE_BODY_SOURCE_MARKER:
+        return format_unavailable_body_source_message()
     if term == UNRESOLVABLE_BODY_MARKER:
         return format_unresolvable_body_message()
     if term == SCANNER_UNAVAILABLE_MARKER:

--- a/tests/teatree_hooks/test_banned_terms_scanner.py
+++ b/tests/teatree_hooks/test_banned_terms_scanner.py
@@ -25,7 +25,12 @@ import pytest
 import hooks.scripts.hook_router as router
 from hooks.scripts.hook_router import handle_banned_terms_pretool
 from teatree.hooks import _command_parser, _repo_visibility, banned_terms_scanner
-from teatree.hooks._command_parser import FAIL_CLOSED_SENTINEL
+from teatree.hooks._command_parser import (
+    FAIL_CLOSED_SENTINEL,
+    UNAVAILABLE_BODY_SOURCE_SENTINEL,
+    is_unavailable_body_source_sentinel,
+)
+from teatree.hooks.banned_terms_scanner import format_unavailable_body_source_message
 
 
 @pytest.fixture
@@ -672,11 +677,16 @@ class TestEnvVarBodyResolution:
         assert "acmecorp" in payload
 
     def test_absent_env_var_fails_closed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # An absent $VAR is a FUNDAMENTALLY-unavailable body source (the value
+        # does not exist before the command runs), so it carries the distinct
+        # unavailable sentinel (#2369) — still fails closed, with the actionable
+        # "write the body to an absolute file" advice rather than "missing file".
         monkeypatch.delenv("PUBLISH_BODY_ABSENT", raising=False)
         cmd = 'glab mr create -R o/r --title t --description "$PUBLISH_BODY_ABSENT"'
         payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
         assert payload is not None
-        assert FAIL_CLOSED_SENTINEL in payload
+        assert UNAVAILABLE_BODY_SOURCE_SENTINEL in payload
+        assert banned_terms_scanner.scan_text(payload) == banned_terms_scanner.UNAVAILABLE_BODY_SOURCE_MARKER
 
 
 class TestMarkdownBacktickBodyResolves:
@@ -1887,3 +1897,144 @@ class TestGitCommitSegmentBehindNonCdPrefix:
         blocked = handle_banned_terms_pretool(data)
         assert blocked is True
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+
+class TestAbsoluteBodyFileResolvesRegardlessOfCwd:
+    """An absolute ``--body-file`` written by a prior step is read at scan time (#2369 case 1).
+
+    The cold PreToolUse hook subprocess's cwd has often reset away from the
+    worktree, but an ABSOLUTE path is cwd-independent, so the gate reads and
+    scans the real body. A clean absolute body file PASSES; the same flag with a
+    banned term in the file still BLOCKS (the read does not weaken the scan).
+    """
+
+    def _run_from_cwd(self, cwd: Path, command: str) -> bool:
+        return handle_banned_terms_pretool({"tool_name": "Bash", "tool_input": {"command": command}, "cwd": str(cwd)})
+
+    def test_clean_absolute_body_file_passes_from_reset_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        body_file = tmp_path / "issue_body.md"
+        body_file.write_text("A perfectly clean issue body.\n", encoding="utf-8")
+        monkeypatch.chdir(tmp_path.parent)
+        blocked = self._run_from_cwd(
+            tmp_path.parent, f"gh issue create --repo someone/public --title t --body-file {body_file}"
+        )
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_banned_absolute_body_file_still_blocks(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        body_file = tmp_path / "issue_body.md"
+        body_file.write_text("This affects acmecorp's deployment.\n", encoding="utf-8")
+        blocked = self._run_from_cwd(
+            tmp_path, f"gh issue create --repo someone/public --title t --body-file {body_file}"
+        )
+        assert blocked is True
+        decision = json.loads(capsys.readouterr().out)
+        assert decision["permissionDecision"] == "deny"
+        assert "acmecorp" in decision["permissionDecisionReason"]
+
+
+class TestUnavailableBodySourceMessage:
+    """``$VAR`` / stdin bodies fail closed with an ACTIONABLE message (#2369 cases 2/3).
+
+    The body comes from an unexpanded variable or a stdin stream, neither of
+    which the gate can read before the command runs. The block direction is
+    preserved (an unscanned body must not publish), but the message is the
+    actionable "write the body to an absolute file and use --body-file" rather
+    than the misleading "the body file is missing" one.
+    """
+
+    def _reason(self, capsys: pytest.CaptureFixture[str]) -> str:
+        return json.loads(capsys.readouterr().out)["permissionDecisionReason"]
+
+    def test_unexpanded_var_body_yields_unavailable_marker(self) -> None:
+        cmd = 'gh pr create --repo o/r --title t --body "$PR_BODY_ABSENT"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert banned_terms_scanner.scan_text(payload) == banned_terms_scanner.UNAVAILABLE_BODY_SOURCE_MARKER
+
+    def test_stdin_input_body_yields_unavailable_marker(self) -> None:
+        cmd = "gh api repos/o/r/issues -X POST --input -"
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert banned_terms_scanner.scan_text(payload) == banned_terms_scanner.UNAVAILABLE_BODY_SOURCE_MARKER
+
+    def test_unexpanded_var_body_blocks_with_actionable_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        blocked = handle_banned_terms_pretool(
+            _bash('gh pr create --repo someone/public --title t --body "$PR_BODY_ABSENT"')
+        )
+        assert blocked is True
+        reason = self._reason(capsys)
+        assert "unexpanded variable or stdin" in reason
+        assert "--body-file <abspath>" in reason
+        # The block is preserved but the misleading missing-file advice is gone.
+        assert "the body file is missing" not in reason
+
+    def test_stdin_body_blocks_with_actionable_message(self, capsys: pytest.CaptureFixture[str]) -> None:
+        blocked = handle_banned_terms_pretool(_bash("gh api repos/someone/public/issues -X POST --input -"))
+        assert blocked is True
+        reason = self._reason(capsys)
+        assert "unexpanded variable or stdin" in reason
+        assert "--body-file <abspath>" in reason
+
+    def test_message_differs_from_missing_file_message(self) -> None:
+        # The two body-unavailable classes render DISTINCT, non-empty messages so
+        # the agent is told the right next step for each.
+        unavailable = format_unavailable_body_source_message()
+        missing_file = banned_terms_scanner.format_unresolvable_body_message()
+        assert unavailable != missing_file
+        assert "unexpanded variable or stdin" in unavailable
+        assert "the body file is missing" not in unavailable
+
+    def test_unavailable_marker_still_fails_closed_on_public_surface(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # CONTROL: the gate must NOT weaken — an unavailable body source on a
+        # public surface STILL denies (never silently allows the unscanned post).
+        blocked = handle_banned_terms_pretool(
+            _bash('gh issue create --repo someone/public --title t --body "$BODY_NOT_SET"')
+        )
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+    def test_unavailable_marker_downgrades_on_private_destination(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Destination-aware parity with the missing-file marker: a $VAR body
+        # posted to a provably-private target is not a public leak, so it
+        # downgrades to a warn rather than hard-blocking.
+        blocked = handle_banned_terms_pretool(
+            _bash('gh issue create -R internalcorp/svc --title t --body "$BODY_NOT_SET"')
+        )
+        assert blocked is False
+
+
+class TestSentinelRecognition:
+    """``is_fail_closed_sentinel`` recognises BOTH sentinel spellings (#2369).
+
+    Every downstream gate (quote-scanner, AI-signature, banned-terms) keeps
+    failing closed regardless of which body-source class injected the sentinel,
+    while ``is_unavailable_body_source_sentinel`` distinguishes the $VAR/stdin
+    class so the gate can render the right operator advice.
+    """
+
+    def test_generic_sentinel_line_is_fail_closed(self) -> None:
+        assert _command_parser.is_fail_closed_sentinel(FAIL_CLOSED_SENTINEL)
+        assert not is_unavailable_body_source_sentinel(FAIL_CLOSED_SENTINEL)
+
+    def test_unavailable_sentinel_line_is_both(self) -> None:
+        assert _command_parser.is_fail_closed_sentinel(UNAVAILABLE_BODY_SOURCE_SENTINEL)
+        assert is_unavailable_body_source_sentinel(UNAVAILABLE_BODY_SOURCE_SENTINEL)
+
+    def test_unavailable_sentinel_as_one_joined_line_is_recognised(self) -> None:
+        payload = f"t\n{UNAVAILABLE_BODY_SOURCE_SENTINEL}"
+        assert _command_parser.is_fail_closed_sentinel(payload)
+        assert is_unavailable_body_source_sentinel(payload)
+
+    def test_inert_prose_naming_either_sentinel_mid_line_is_not_a_match(self) -> None:
+        prose = f"the gate emits the {UNAVAILABLE_BODY_SOURCE_SENTINEL} marker when unavailable"
+        assert not _command_parser.is_fail_closed_sentinel(prose)
+        assert not is_unavailable_body_source_sentinel(prose)
+
+    def test_clean_text_is_neither_sentinel(self) -> None:
+        assert not _command_parser.is_fail_closed_sentinel("a normal clean body")
+        assert not is_unavailable_body_source_sentinel("a normal clean body")


### PR DESCRIPTION
## What

The publish gates fail-close every body source they cannot read before the command runs, but emitted ONE message for all of them — the misleading "the body file is missing or unresolvable" — even for the two classes that are fundamentally unavailable at PreToolUse: an unexpanded `--body "$VAR"` and a stdin body (`gh api --input -`, `git commit -F -`). The old advice ("use an inline body") is exactly what `--body "$VAR"` already is.

A second sentinel (`UNAVAILABLE_BODY_SOURCE_SENTINEL`) is emitted by the variable and stdin paths, distinct from the missing-FILE sentinel. `is_fail_closed_sentinel` recognises both spellings so every downstream gate (quote-scanner, AI-signature, banned-terms) keeps failing closed regardless of class; a new `is_unavailable_body_source_sentinel` distinguishes the variable/stdin class so the banned-terms gate renders an actionable message — write the body to an absolute file and post it with `--body-file <abspath>` (the gate reads an absolute body file regardless of cwd). The block direction is unchanged; only the operator advice differs, and the private-destination downgrade is extended to the new marker for parity with the missing-file marker.

## Per-ticket scope

- **#2369 case 1** (clean absolute `--body-file` read regardless of the cold-hook cwd): already works through the existing absolute-path resolution; pinned by a regression test (`TestAbsoluteBodyFileResolvesRegardlessOfCwd`).
- **#2369 cases 2/3** (variable / stdin): keep failing closed, with the new actionable message replacing the misleading one.
- **#2270 / #2278** (t3 review post-comment positional body + `--file` anchor collision): already fixed on main by [#2358](https://github.com/souliane/teatree/pull/2358) (`_t3_review_post.py` extracts the positional NOTE and suppresses the body-file walker for review segments). Verified still green; closing the still-open issues here.

## Anti-vacuity / controls

- RED before fix: the marker / actionable-message tests fail on pre-fix code (no marker symbol; the variable body mapped to the missing-file message).
- CONTROL — no weakening: a variable/stdin body on a public surface STILL denies; a clean absolute `--body-file` passes while a banned one still BLOCKS; the gate-liveness corpus + never-lockout contract + test-path-mirror all stay green.
- Dogfood evidence: committing/PR-creating this very change tripped the gates on `--body-file "$VAR"` / `mktemp`-path / heredoc-stdin shapes — the exact friction the ticket describes — which is why this PR body is an inline literal.

## Architecture pre-check — #2369/#2270/#2278

1. **BLUEPRINT §**: pre-publish gate chain (banned-terms #1415, quote-scanner #1213); no § change.
2. **FSM**: n/a.
3. **Extension points**: no OverlayBase/scanner/Protocol change; same `handle_banned_terms_pretool` GateRow, same `emit_pretooluse_deny` / `_fail_open_or_deny` routing.
4. **Component boundaries**: all inside the hooks layer (`_command_parser`, `_body_file_resolution`, `banned_terms_scanner`, `hook_router`).
5. **Dependency direction**: no new edges; `tach check` clean.
6. **Test surface**: `tests/teatree_hooks/test_banned_terms_scanner.py` — TestUnavailableBodySourceMessage, TestAbsoluteBodyFileResolvesRegardlessOfCwd, TestSentinelRecognition; updated TestEnvVarBodyResolution.
7. **Resilience**: PreToolUse deny is a pure decision (idempotent block); anti-vacuity RED observed.
8. **Identity/key normalization**: n/a.
9. **Behavior preservation**: no capability removed — still BLOCKS every unresolvable/unavailable body on a public surface; no must-block test inverted; private-repo downgrade extended (not narrowed).

Closes #2369
Closes #2270
Closes #2278