### PR TITLE
feat(ci): add bypass-proof module-health ratchet CI twin (#2010)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@
 # JOB GROUPS (in order of appearance below)
 #   1. Lane routing          — preflight
 #   2. Fast static checks    — lint, blueprint-cross-pr
-#   3. Docs integrity        — doc-update-gate, comment-density-warning,
-#                              docs-drift
+#   3. Docs integrity        — doc-update-gate, module-health-gate,
+#                              comment-density-warning, docs-drift
 #   4. Signal & ratchet      — test-shape (advisory),
 #                              test-path-mirror (ratchet gate)
 #   5. Test suite            — test, test-shim
@@ -210,6 +210,39 @@ jobs:
           git fetch --no-tags origin "${BASE_REF}"
           git reset --soft FETCH_HEAD
       - run: uv run python scripts/hooks/check_doc_update.py
+
+  # GATE (PR-only): re-runs the module-health LOC/function ratchet on the PR's
+  # full base..head diff so a prek-bypassing or merge-routed module growth still
+  # trips the gate.
+  module-health-gate:
+    # Deterministic module-health ratchet twin (souliane/teatree#2010). The
+    # prek commit hook runs check_module_health.py per-commit against staged
+    # files; CI re-runs the SAME ratchet on the PR's WHOLE base..head range so
+    # an agent that bypasses prek (or routes growth through a merge) still trips
+    # the gate. Computed once over the range (NOT per-commit), so the
+    # merge-commit false-positive the staged-mode exemption guards against never
+    # arises here. PR-only: push/schedule have no base to diff against, and the
+    # prek hook covers the per-commit case.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          # fetch-depth: 0 so `origin/<base>...HEAD` resolves.
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.13"
+      - run: uv sync
+      - name: Module-health ratchet over the PR diff
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch --no-tags origin "${BASE_REF}"
+          uv run python scripts/hooks/check_module_health.py --from-ref "origin/${BASE_REF}"
 
   # ADVISORY (PR-only): warns about comment-dense files; always exits 0 so it
   # never blocks a PR — signal only.

--- a/scripts/hooks/check_module_health.py
+++ b/scripts/hooks/check_module_health.py
@@ -9,11 +9,19 @@ Files already over the cap at HEAD are grandfathered but ratcheted: they may
 only SHRINK. A commit that grows an over-cap file (LOC or public-function
 count) is blocked, so a god-module can never re-accrete after a split (#1983).
 
-Runs on every commit against staged files only.
+Two entry paths share one ratchet predicate. The default (no args) path runs
+per-commit over staged files (``git diff --cached``) — the prek commit hook,
+where a merge commit is exempt because a merge brings both parents' growth into
+one commit and the per-commit comparison would false-flag it (#1983 exemption).
+The ``--from-ref <base>`` path runs over the PR's whole ``base..HEAD`` range —
+the bypass-proof CI twin (#2010); the range is computed once base-to-head, NOT
+per-commit, so the merge-commit false-positive the staged-mode exemption works
+around never arises and no merge exemption is needed in this mode.
 
 See: souliane/teatree codebase audit findings
 """
 
+import argparse
 import ast
 import pathlib
 import re
@@ -83,29 +91,43 @@ def _count_loc(filepath: str) -> int:
         return 0
 
 
-def _count_loc_at_head(filepath: str) -> int:
+def _show_at_ref(filepath: str, ref: str) -> str | None:
     result = subprocess.run(
-        ["git", "show", f"HEAD:{filepath}"],
+        ["git", "show", f"{ref}:{filepath}"],
         capture_output=True,
         text=True,
         check=False,
     )
     if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def _count_loc_at_ref(filepath: str, ref: str) -> int:
+    source = _show_at_ref(filepath, ref)
+    if source is None:
         return 0
-    return sum(1 for line in result.stdout.splitlines() if line.strip() and not line.strip().startswith("#"))
+    return sum(1 for line in source.splitlines() if line.strip() and not line.strip().startswith("#"))
+
+
+def _count_module_level_functions_at_ref(filepath: str, ref: str) -> list[str]:
+    source = _show_at_ref(filepath, ref)
+    if source is None:
+        return []
+    return _public_module_functions(source)
+
+
+def _count_loc_at_head(filepath: str) -> int:
+    return _count_loc_at_ref(filepath, "HEAD")
 
 
 def _count_module_level_functions_at_head(filepath: str) -> list[str]:
-    result = subprocess.run(
-        ["git", "show", f"HEAD:{filepath}"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        return []
+    return _count_module_level_functions_at_ref(filepath, "HEAD")
+
+
+def _public_module_functions(source: str) -> list[str]:
     try:
-        tree = ast.parse(result.stdout)
+        tree = ast.parse(source)
     except SyntaxError:
         return []
     return [
@@ -118,15 +140,9 @@ def _count_module_level_functions_at_head(filepath: str) -> list[str]:
 def _count_module_level_functions(filepath: str) -> list[str]:
     try:
         source = pathlib.Path(filepath).read_text(encoding="utf-8")
-        tree = ast.parse(source)
-    except (OSError, SyntaxError):
+    except OSError:
         return []
-
-    return [
-        node.name
-        for node in ast.iter_child_nodes(tree)
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and not node.name.startswith("_")
-    ]
+    return _public_module_functions(source)
 
 
 def _added_line_numbers(filepath: str, head_path: str) -> set[int] | None:
@@ -166,7 +182,117 @@ def _find_dict_object_annotations(filepath: str) -> list[tuple[int, str]]:
     return findings
 
 
-def main() -> int:
+def _file_violations(filepath: str, prev_loc: int, prev_funcs: list[str], added_lines: set[int] | None) -> list[str]:
+    """Apply the shrink ratchet to one file's current vs previous state.
+
+    ``prev_loc`` / ``prev_funcs`` are the file's measurements at the comparison
+    baseline (HEAD for staged-mode, the base ref for diff-mode); the current
+    side always reads the working tree, which is the PR head in both contexts.
+    """
+    violations: list[str] = []
+
+    loc = _count_loc(filepath)
+    if loc > MAX_LOC:
+        if prev_loc <= MAX_LOC:
+            violations.append(f"  {filepath}: {loc} LOC (max {MAX_LOC}). Split by concern.")
+        elif loc > prev_loc:
+            violations.append(
+                f"  {filepath}: {loc} LOC, up from {prev_loc} (over the {MAX_LOC} cap). "
+                f"Over-cap files may only shrink — split by concern or move code out."
+            )
+
+    public_functions = _count_module_level_functions(filepath)
+    if len(public_functions) > MAX_MODULE_FUNCTIONS:
+        names = ", ".join(public_functions[:5])
+        if len(prev_funcs) <= MAX_MODULE_FUNCTIONS:
+            violations.append(
+                f"  {filepath}: {len(public_functions)} public module-level functions "
+                f"(max {MAX_MODULE_FUNCTIONS}). Move to a class. Examples: {names}"
+            )
+        elif len(public_functions) > len(prev_funcs):
+            violations.append(
+                f"  {filepath}: {len(public_functions)} public module-level functions, "
+                f"up from {len(prev_funcs)} (over the {MAX_MODULE_FUNCTIONS} cap). "
+                f"Over-cap files may only shrink — move a function to a class. Examples: {names}"
+            )
+
+    for line_num, _line in _find_dict_object_annotations(filepath):
+        if added_lines is None or line_num in added_lines:
+            violations.append(f"  {filepath}:{line_num}: dict[str, object] — use a dataclass or TypedDict instead")
+
+    return violations
+
+
+def _range_python_files(base_ref: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{base_ref}...HEAD", "--", "*.py"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return [f for f in result.stdout.strip().splitlines() if f.startswith("src/")]
+
+
+def _range_paths(base_ref: str) -> dict[str, str]:
+    """Map each changed path in ``base..HEAD`` to its pre-rename path at the base ref."""
+    result = subprocess.run(
+        ["git", "diff", "--name-status", "-M", "--diff-filter=ACMR", f"{base_ref}...HEAD", "--", "*.py"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    mapping: dict[str, str] = {}
+    for line in result.stdout.strip().splitlines():
+        status, *paths = line.split("\t")
+        if status.startswith("R") and len(paths) == _RENAME_FIELDS:
+            old_path, new_path = paths
+            mapping[new_path] = old_path
+        elif len(paths) == _SINGLE_PATH_FIELD:
+            mapping[paths[0]] = paths[0]
+    return mapping
+
+
+def _range_added_line_numbers(filepath: str, base_path: str, base_ref: str) -> set[int] | None:
+    paths = [base_path, filepath] if base_path != filepath else [filepath]
+    result = subprocess.run(
+        ["git", "diff", "-U0", "-M", f"{base_ref}...HEAD", "--", *paths],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if not result.stdout:
+        return None
+    added: set[int] = set()
+    for match in re.finditer(r"@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", result.stdout):
+        start = int(match.group(1))
+        count = int(match.group(2)) if match.group(2) else 1
+        added.update(range(start, start + count))
+    return added
+
+
+def run_diff_mode(base_ref: str) -> int:
+    """Ratchet the whole ``base_ref..HEAD`` range (the bypass-proof CI twin, #2010).
+
+    The PR diff is taken once over the range, NOT per-commit, so the
+    merge-commit false-positive the staged-mode exemption guards against never
+    arises here — no merge exemption is needed in this mode.
+    """
+    base_paths = _range_paths(base_ref)
+    violations: list[str] = []
+    for filepath in _range_python_files(base_ref):
+        base_path = base_paths.get(filepath, filepath)
+        violations.extend(
+            _file_violations(
+                filepath,
+                _count_loc_at_ref(base_path, base_ref),
+                _count_module_level_functions_at_ref(base_path, base_ref),
+                _range_added_line_numbers(filepath, base_path, base_ref),
+            )
+        )
+    return _report(violations)
+
+
+def _run_staged() -> int:
     if _is_merge_commit():
         return 0
 
@@ -176,49 +302,22 @@ def main() -> int:
 
     head_paths = _head_paths()
     violations: list[str] = []
-
     for filepath in files:
         head_path = head_paths.get(filepath, filepath)
-        loc = _count_loc(filepath)
-        if loc > MAX_LOC:
-            prev_loc = _count_loc_at_head(head_path)
-            # A file newly crossing the cap is blocked outright. A file already
-            # over the cap at HEAD is grandfathered but ratcheted: it may only
-            # shrink. Growth is a regression that re-accretes the god-module.
-            if prev_loc <= MAX_LOC:
-                violations.append(f"  {filepath}: {loc} LOC (max {MAX_LOC}). Split by concern.")
-            elif loc > prev_loc:
-                violations.append(
-                    f"  {filepath}: {loc} LOC, up from {prev_loc} (over the {MAX_LOC} cap). "
-                    f"Over-cap files may only shrink — split by concern or move code out."
-                )
+        violations.extend(
+            _file_violations(
+                filepath,
+                _count_loc_at_head(head_path),
+                _count_module_level_functions_at_head(head_path),
+                _added_line_numbers(filepath, head_path),
+            )
+        )
+    return _report(violations)
 
-        public_functions = _count_module_level_functions(filepath)
-        if len(public_functions) > MAX_MODULE_FUNCTIONS:
-            prev_count = len(_count_module_level_functions_at_head(head_path))
-            names = ", ".join(public_functions[:5])
-            if prev_count <= MAX_MODULE_FUNCTIONS:
-                violations.append(
-                    f"  {filepath}: {len(public_functions)} public module-level functions "
-                    f"(max {MAX_MODULE_FUNCTIONS}). Move to a class. Examples: {names}"
-                )
-            elif len(public_functions) > prev_count:
-                violations.append(
-                    f"  {filepath}: {len(public_functions)} public module-level functions, "
-                    f"up from {prev_count} (over the {MAX_MODULE_FUNCTIONS} cap). "
-                    f"Over-cap files may only shrink — move a function to a class. Examples: {names}"
-                )
 
-        added_lines = _added_line_numbers(filepath, head_path)
-        dict_hits = _find_dict_object_annotations(filepath)
-        for line_num, _line in dict_hits:
-            # Only flag lines that were added or modified in this commit
-            if added_lines is None or line_num in added_lines:
-                violations.append(f"  {filepath}:{line_num}: dict[str, object] — use a dataclass or TypedDict instead")
-
+def _report(violations: list[str]) -> int:
     if not violations:
         return 0
-
     print("Module health violations:")
     print()
     for v in violations:
@@ -231,6 +330,21 @@ def main() -> int:
         "before the commit lands."
     )
     return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--from-ref",
+        default=None,
+        help="Run the ratchet over the whole <ref>..HEAD range (CI twin) instead of staged files.",
+    )
+    # Tolerated, ignored: prek's commit-msg stage passes the message file path.
+    parser.add_argument("ignored_commit_msg_file", nargs="?", default=None)
+    args = parser.parse_args(argv)
+    if args.from_ref is not None:
+        return run_diff_mode(args.from_ref)
+    return _run_staged()
 
 
 if __name__ == "__main__":

--- a/scripts/hooks/check_module_health.py
+++ b/scripts/hooks/check_module_health.py
@@ -223,9 +223,20 @@ def _file_violations(filepath: str, prev_loc: int, prev_funcs: list[str], added_
     return violations
 
 
-def _range_python_files(base_ref: str) -> list[str]:
+def _merge_base(base_ref: str) -> str:
     result = subprocess.run(
-        ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{base_ref}...HEAD", "--", "*.py"],
+        ["git", "merge-base", base_ref, "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    sha = result.stdout.strip()
+    return sha or base_ref
+
+
+def _range_python_files(merge_base: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{merge_base}..HEAD", "--", "*.py"],
         capture_output=True,
         text=True,
         check=False,
@@ -233,10 +244,10 @@ def _range_python_files(base_ref: str) -> list[str]:
     return [f for f in result.stdout.strip().splitlines() if f.startswith("src/")]
 
 
-def _range_paths(base_ref: str) -> dict[str, str]:
-    """Map each changed path in ``base..HEAD`` to its pre-rename path at the base ref."""
+def _range_paths(merge_base: str) -> dict[str, str]:
+    """Map each changed path in ``merge_base..HEAD`` to its pre-change path at the merge-base."""
     result = subprocess.run(
-        ["git", "diff", "--name-status", "-M", "--diff-filter=ACMR", f"{base_ref}...HEAD", "--", "*.py"],
+        ["git", "diff", "--name-status", "-M", "--diff-filter=ACMR", f"{merge_base}..HEAD", "--", "*.py"],
         capture_output=True,
         text=True,
         check=False,
@@ -252,10 +263,10 @@ def _range_paths(base_ref: str) -> dict[str, str]:
     return mapping
 
 
-def _range_added_line_numbers(filepath: str, base_path: str, base_ref: str) -> set[int] | None:
+def _range_added_line_numbers(filepath: str, base_path: str, merge_base: str) -> set[int] | None:
     paths = [base_path, filepath] if base_path != filepath else [filepath]
     result = subprocess.run(
-        ["git", "diff", "-U0", "-M", f"{base_ref}...HEAD", "--", *paths],
+        ["git", "diff", "-U0", "-M", f"{merge_base}..HEAD", "--", *paths],
         capture_output=True,
         text=True,
         check=False,
@@ -273,20 +284,28 @@ def _range_added_line_numbers(filepath: str, base_path: str, base_ref: str) -> s
 def run_diff_mode(base_ref: str) -> int:
     """Ratchet the whole ``base_ref..HEAD`` range (the bypass-proof CI twin, #2010).
 
+    Resolves the merge-base of ``base_ref`` and ``HEAD`` ONCE and uses it as the
+    single comparison reference for both the changed-file diff AND the baseline
+    LOC/function reads. Reading the baseline at the literal ``base_ref`` tip while
+    diffing three-dot (merge-base relative) disagrees when main has diverged and
+    independently edited a file — main's own edits then get mis-attributed to the
+    branch and a legitimate ratchet-compliant shrink false-blocks.
+
     The PR diff is taken once over the range, NOT per-commit, so the
     merge-commit false-positive the staged-mode exemption guards against never
     arises here — no merge exemption is needed in this mode.
     """
-    base_paths = _range_paths(base_ref)
+    merge_base = _merge_base(base_ref)
+    base_paths = _range_paths(merge_base)
     violations: list[str] = []
-    for filepath in _range_python_files(base_ref):
+    for filepath in _range_python_files(merge_base):
         base_path = base_paths.get(filepath, filepath)
         violations.extend(
             _file_violations(
                 filepath,
-                _count_loc_at_ref(base_path, base_ref),
-                _count_module_level_functions_at_ref(base_path, base_ref),
-                _range_added_line_numbers(filepath, base_path, base_ref),
+                _count_loc_at_ref(base_path, merge_base),
+                _count_module_level_functions_at_ref(base_path, merge_base),
+                _range_added_line_numbers(filepath, base_path, merge_base),
             )
         )
     return _report(violations)

--- a/tests/test_module_health_ci_twin.py
+++ b/tests/test_module_health_ci_twin.py
@@ -48,7 +48,7 @@ def _git(repo: Path, *args: str) -> str:
 def _init_repo(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     repo.mkdir()
-    _git(repo, "init", "-q")
+    _git(repo, "init", "-q", "-b", "main")
     _git(repo, "config", "user.email", "t@example.com")
     _git(repo, "config", "user.name", "Test")
     _git(repo, "config", "commit.gpgsign", "false")

--- a/tests/test_module_health_ci_twin.py
+++ b/tests/test_module_health_ci_twin.py
@@ -111,6 +111,30 @@ class TestDiffModeRatchet:
         monkeypatch.chdir(repo)
         assert mod.run_diff_mode(base) == 0
 
+    def test_diverged_base_ratchets_against_merge_base_not_base_tip(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Main diverged and independently shrank the file; the branch's own shrink must pass.
+
+        Fork point: big.py = OVER_CAP. main (base_ref) independently shrinks it to
+        OVER_CAP - 100; the feature branch shrinks it to OVER_CAP - 50 (a legitimate
+        ratchet-COMPLIANT shrink vs the fork point). Ratcheting against the LITERAL
+        base tip would report "up from OVER_CAP - 100" and false-block; ratcheting
+        against the merge-base (the fork point) sees a shrink and passes.
+        """
+        repo = _init_repo(tmp_path)
+        fork_point = _commit_file(repo, "src/big.py", _src(_OVER_CAP), "fork: over-cap file")
+
+        _git(repo, "checkout", "-q", "-b", "mainline")
+        _commit_file(repo, "src/big.py", _src(_OVER_CAP - 100), "mainline: independent shrink")
+
+        _git(repo, "checkout", "-q", fork_point)
+        _git(repo, "checkout", "-q", "-b", "feature")
+        _commit_file(repo, "src/big.py", _src(_OVER_CAP - 50), "feature: legitimate shrink")
+
+        monkeypatch.chdir(repo)
+        assert mod.run_diff_mode("mainline") == 0
+
 
 class TestDiffModeArgv:
     """``--from-ref`` selects diff-mode; bare argv keeps staged-mode."""

--- a/tests/test_module_health_ci_twin.py
+++ b/tests/test_module_health_ci_twin.py
@@ -1,0 +1,155 @@
+"""base..head diff-mode for the module-health ratchet — the CI twin (#2010).
+
+The prek hook runs ``check_module_health.py`` per-commit against staged files.
+The CI lint job runs the prek commit stage, but no dedicated CI job re-runs the
+ratchet on the PR's FULL diff. A prek-bypassing or merge-routed module growth
+lands silently. The diff-mode (``--from-ref <base>``) lets the CI twin invoke
+the ratchet on the whole ``base..HEAD`` range — not per-commit, so the
+merge-commit false-positive the staged-mode exemption works around never fires.
+
+These tests build a real ``tmp_path`` git repo (base commit + head commit) and
+drive the diff-mode end to end, plus a structural assertion that the CI job
+exists and invokes the script with the diff flag.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import yaml
+
+import scripts.hooks.check_module_health as mod
+
+_OVER_CAP = mod.MAX_LOC + 200
+_OVER_CAP_GREW = _OVER_CAP + 50
+_OVER_CAP_SHRANK = _OVER_CAP - 50
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+_GIT_BIN = shutil.which("git") or "/usr/bin/git"
+
+
+def _src(loc: int) -> str:
+    return "\n".join(f"a_{i} = {i}" for i in range(loc)) + "\n"
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        [_GIT_BIN, "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "commit.gpgsign", "false")
+    return repo
+
+
+def _commit_file(repo: Path, relpath: str, content: str, message: str) -> str:
+    target = repo / relpath
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    _git(repo, "add", relpath)
+    _git(repo, "commit", "-q", "-m", message)
+    return _git(repo, "rev-parse", "HEAD").strip()
+
+
+def _load_ci_jobs() -> dict[str, Any]:
+    return cast("dict[str, Any]", yaml.safe_load(_CI_WORKFLOW.read_text(encoding="utf-8"))["jobs"])
+
+
+class TestDiffModeRatchet:
+    """base..head diff-mode applies the same shrink ratchet over the PR range."""
+
+    def test_over_cap_file_that_grows_across_range_is_flagged(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        base = _commit_file(repo, "src/big.py", _src(_OVER_CAP), "base: over-cap file")
+        _commit_file(repo, "src/big.py", _src(_OVER_CAP_GREW), "head: grow the over-cap file")
+
+        monkeypatch.chdir(repo)
+        assert mod.run_diff_mode(base) == 1
+
+    def test_over_cap_file_within_ratchet_across_range_passes(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        base = _commit_file(repo, "src/big.py", _src(_OVER_CAP), "base: over-cap file")
+        _commit_file(repo, "src/big.py", _src(_OVER_CAP_SHRANK), "head: shrink the over-cap file")
+
+        monkeypatch.chdir(repo)
+        assert mod.run_diff_mode(base) == 0
+
+    def test_file_newly_crossing_cap_across_range_is_flagged(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        base = _commit_file(repo, "src/grower.py", _src(mod.MAX_LOC - 50), "base: under cap")
+        _commit_file(repo, "src/grower.py", _src(_OVER_CAP), "head: cross the cap")
+
+        monkeypatch.chdir(repo)
+        assert mod.run_diff_mode(base) == 1
+
+    def test_unchanged_over_cap_file_outside_range_is_not_flagged(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        base = _commit_file(repo, "src/legacy.py", _src(_OVER_CAP), "base: grandfathered over-cap")
+        _commit_file(repo, "src/other.py", _src(10), "head: unrelated small file")
+
+        monkeypatch.chdir(repo)
+        assert mod.run_diff_mode(base) == 0
+
+
+class TestDiffModeArgv:
+    """``--from-ref`` selects diff-mode; bare argv keeps staged-mode."""
+
+    def test_from_ref_argv_runs_diff_mode(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        repo = _init_repo(tmp_path)
+        base = _commit_file(repo, "src/big.py", _src(_OVER_CAP), "base: over-cap file")
+        _commit_file(repo, "src/big.py", _src(_OVER_CAP_GREW), "head: grow the over-cap file")
+
+        monkeypatch.chdir(repo)
+        monkeypatch.setattr("sys.argv", ["check_module_health.py", "--from-ref", base])
+        assert mod.main() == 1
+
+
+class TestCiTwinJobStructure:
+    """The CI job exists and invokes the script on the PR's base..head range."""
+
+    def test_module_health_gate_job_exists(self) -> None:
+        assert "module-health-gate" in _load_ci_jobs(), (
+            "ci.yml must define a module-health-gate job that re-runs the ratchet "
+            "on the PR's full diff (the bypass-proof CI twin)."
+        )
+
+    def test_job_invokes_script_with_from_ref(self) -> None:
+        job = _load_ci_jobs()["module-health-gate"]
+        runs = " ".join(step.get("run", "") for step in job["steps"] if isinstance(step, dict))
+        assert "check_module_health.py" in runs, "module-health-gate must invoke check_module_health.py."
+        assert "--from-ref" in runs, (
+            "module-health-gate must pass --from-ref so the ratchet runs on the base..head range, not per-commit."
+        )
+
+    def test_job_is_pr_only_with_full_history(self) -> None:
+        job = _load_ci_jobs()["module-health-gate"]
+        assert job.get("if") == "github.event_name == 'pull_request'", (
+            "module-health-gate must be PR-only — there is no base to diff on push/schedule."
+        )
+        checkout = next(
+            step for step in job["steps"] if isinstance(step, dict) and "checkout" in str(step.get("uses", ""))
+        )
+        assert checkout.get("with", {}).get("fetch-depth") == 0, (
+            "module-health-gate must checkout with fetch-depth: 0 so origin/<base>...HEAD resolves."
+        )


### PR DESCRIPTION
## Summary

`scripts/hooks/check_module_health.py` (the module-health LOC/function ratchet) ran only as a local commit-msg prek hook. The CI `lint` job runs the prek commit stage, but no dedicated CI job re-ran the ratchet on the PR's full diff — unlike `doc-update-gate` / `comment-density-warning` / `blueprint-cross-pr`, each of which has a bypass-proof CI twin. A prek-bypassing or merge-routed module growth could land silently.

This adds:

1. A `--from-ref <base>` diff-mode on `check_module_health.py` that runs the ratchet over the whole `base..HEAD` range — computed **once over the range, not per-commit**, so the merge-commit false-positive the staged-mode `_is_merge_commit()` exemption guards against never arises (no merge exemption needed in this mode). Staged-mode and diff-mode share one ratchet predicate (`_file_violations`); the HEAD-reading helpers are generalized to read any ref and the existing `_count_*_at_head` names delegate to the generalized form, so the existing tests that monkeypatch them by name are unaffected.
2. A PR-only `module-health-gate` CI job in `.github/workflows/ci.yml`, modelled on the `doc-update-gate` twin (`fetch-depth: 0`, `origin/<base>` resolution, `git fetch` + invoke), that runs the diff-mode on the PR range.
3. A docstring note in `check_module_health.py` stating merge commits are exempt (staged-mode) and why the diff-mode needs no merge exemption.

## Anti-vacuity

`tests/test_module_health_ci_twin.py` builds a real `tmp_path` git repo (base commit + head commit) and drives the diff-mode end to end:

- A module grown past its ratchet across `base..HEAD` then diff-mode FLAGS it (exit 1). Observed RED before `--from-ref` existed (AttributeError: no attribute `run_diff_mode`), green after. The ratchet was then temporarily neutered (`_file_violations` returning no violations early) and the two flag tests went RED again, confirming they guard the ratchet (the shrink/within-ratchet controls correctly stayed green expecting exit 0).
- Control: a module within ratchet (shrinks) across the range then passes (exit 0).
- A file newly crossing the cap across the range then flagged.
- An unchanged over-cap file outside the range then not flagged.

## CI job verification

Structural assertions (`TestCiTwinJobStructure`) parse `ci.yml` and assert the `module-health-gate` job exists, invokes `check_module_health.py --from-ref`, is PR-only, and checks out with `fetch-depth: 0`. The yaml job runtime behaviour is not unit-tested (yaml jobs are not); the job mirrors the existing `doc-update-gate` twin wiring exactly. The diff-mode logic the job invokes IS unit-tested end-to-end above, and was smoke-tested locally against a real `git` range (`--from-ref <base>` on a grown over-cap file then exit 1 with the expected message).

## Architecture pre-check — #2010

**1. BLUEPRINT § alignment** — Tactical CI/hook hardening; no BLUEPRINT § owns the module-health ratchet (a `scripts/hooks/` artifact governed by the CI legend at the top of `ci.yml`, which is updated to list the new gate). Mirrors the existing twins.

**2. FSM phase boundaries** — n/a, no state transition.

**3. Extension-point contracts** — n/a, no OverlayBase/scanner/hook-router/Protocol surface; the script is invoked by argv.

**4. Component boundaries** — `check_module_health.py` keeps its single responsibility; the new diff-mode is a sibling entry path reusing the same ratchet predicate (one source of truth for the verdict). The CI job lives beside the other PR-only docs/quality twins.

**5. Dependency direction** — no new `src/` imports; the script uses only stdlib (`argparse`, `ast`, `pathlib`, `re`, `subprocess`). No tach edge.

**6. Test surface** — `tests/test_module_health_ci_twin.py`: diff-mode flag/control tests (real `tmp_path` git repo) + structural CI-job assertions.

**7. Resilience invariants** — read-only gate, no external write. Idempotent over the same range. The range helpers degrade like the staged helpers; the job mirrors the doc-update twin deterministic shape.

**8. Identity and key normalization** — n/a; paths compared as-is, rename detection (`-M`) follows moves (matches staged-mode `_head_paths`).

**9. Behavior preservation / capability deletion** — purely additive. Staged-mode `main()` behaviour is unchanged for the default argv; the trailing ignored positional preserves prek commit-msg-stage invocation. No must-block test inverted.

## Open questions & assumptions

- Assumed the CI job should mirror `doc-update-gate` (PR-only, `fetch-depth: 0`, `git fetch origin <base>`) rather than the `git reset --soft FETCH_HEAD` staging trick the doc-update/comment-density jobs use — because the ticket explicitly asks for a `--from-ref` base..head diff-mode (the blueprint-cross-pr `--ci --base-ref` shape), which reads the range directly without rewriting the index.

Closes #2010
