### PR TITLE
feat(statusline): render the session effort level next to the model

### DIFF
--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -9,7 +9,9 @@
 #     line lives at the top of that file (live_loops_anchor) — the header
 #     this hook builds carries NO loop/tick info (#130): loop state has
 #     exactly one home, the loop line.
-#  2. Live per-session info from Claude's stdin JSON: model, context-window %,
+#  2. Live per-session info from Claude's stdin JSON: model (with the session's
+#     `/effort` level rendered beside it — from the payload if present, else the
+#     saved settings default), context-window %,
 #     5-hour and 7-day rate-limit usage, skills loaded this session, a compact
 #     summary of this session's harness TODO list, and a
 #     per-session loop-owner badge — the skills and TODO summaries are
@@ -31,6 +33,7 @@ state_dir="${TEATREE_CLAUDE_STATUSLINE_STATE_DIR:-/tmp/claude-statusline}"
 
 session_id=""
 model=""
+effort=""
 ctx_pct=""
 five_hour_pct=""
 five_hour_resets_at=""
@@ -41,6 +44,12 @@ if ! [ -t 0 ] && command -v jq >/dev/null 2>&1; then
     if [ -n "$input" ]; then
         session_id=$(printf '%s' "$input" | jq -r '.session_id // empty')
         model=$(printf '%s' "$input" | jq -r '.model.display_name // empty')
+        # The session's reasoning-effort (the `/effort` setting). The harness
+        # statusline payload does not currently carry it, but read it here first
+        # so the segment upgrades for free if a future payload exposes `.effort`
+        # (or `.model.effort`); otherwise it falls back to the saved settings
+        # default below.
+        effort=$(printf '%s' "$input" | jq -r '.effort // .model.effort // empty')
         ctx_pct=$(printf '%s' "$input" | jq -r '.context_window.used_percentage // empty' | cut -d. -f1)
         five_hour_pct=$(printf '%s' "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty' | cut -d. -f1)
         five_hour_resets_at=$(printf '%s' "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
@@ -155,6 +164,18 @@ osc8_link() {
     printf '%s' "${_OSC8};${1}${_ST}${2}${_OSC8};${_ST}"
 }
 
+# The saved `/effort` default from the harness settings file
+# (${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json .effortLevel). This is the
+# fallback when the live statusline payload carries no effort field. Prints the
+# value or nothing; fails open (empty) on a missing file / absent key / no jq so
+# a broken settings file never blanks the statusline.
+effort_from_settings() {
+    command -v jq >/dev/null 2>&1 || return
+    local cfg="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
+    [ -r "$cfg" ] || return
+    jq -r '.effortLevel // empty' "$cfg" 2>/dev/null
+}
+
 # Visual grouping: within a group, segments are joined by a mid-dot; between
 # groups we use a vertical bar so the eye can pick out context vs usage vs
 # loops vs updates vs resource at a glance.
@@ -191,8 +212,18 @@ if command -v jq >/dev/null 2>&1 && [ -n "${session_id:-}" ]; then
     fi
 fi
 
+# Effort level (`/effort`): the live payload field above, else the saved
+# settings default. Rendered as a short `· <effort>` suffix on the model chunk
+# (e.g. `model=fable-5 · medium`); omitted entirely when unknown so the segment
+# stays honest and leaves no dangling separator.
+if [ -z "$effort" ]; then
+    effort=$(effort_from_settings)
+fi
 if [ -n "$model" ]; then
     g_context="${_LBL}model=${_RST}${_GRN}${model}${_RST}"
+    if [ -n "$effort" ]; then
+        g_context="${g_context}${_LBL} · ${_RST}${_GRN}${effort}${_RST}"
+    fi
 fi
 if [ -n "$ctx_pct" ] && [ "$ctx_pct" != "empty" ]; then
     [ -n "$g_context" ] && g_context="${g_context}${isep}"

--- a/tests/test_claude_statusline.py
+++ b/tests/test_claude_statusline.py
@@ -43,6 +43,10 @@ def _run(
     env = os.environ.copy()
     env["T3_LOOPS_AUTO_LOAD"] = "1"
     env["TEATREE_CLAUDE_STATUSLINE_STATE_DIR"] = str(state_dir)
+    # Isolate the harness config dir onto the test's state dir so the developer's
+    # real ~/.claude/settings.json effortLevel never bleeds into these tests; the
+    # effort tests plant a settings.json here to drive the fallback (#2214).
+    env["CLAUDE_CONFIG_DIR"] = str(state_dir)
     if statusline_file is not None:
         env["TEATREE_STATUSLINE_FILE"] = str(statusline_file)
     if registry_dir is not None:
@@ -292,6 +296,98 @@ class TestStatuslineHook:
         plain = _strip_ansi(result.stdout)
         assert "skills:" not in plain
         assert "rogue" not in plain
+
+
+class TestEffortSegment:
+    """The session's effort level (`/effort`) renders next to the model (#2214).
+
+    The harness statusline stdin JSON carries the model but not the effort
+    level; the saved ``/effort`` default lives in the harness settings file
+    (``$CLAUDE_CONFIG_DIR/settings.json`` → ``effortLevel``). The hook reads it
+    there as a fallback and renders ``model=<m> · <effort>``. The segment is
+    omitted entirely when no effort can be resolved, so it never fabricates a
+    value or leaves a dangling separator.
+    """
+
+    def _write_settings(self, state_dir: Path, effort: str | None) -> None:
+        body: dict = {} if effort is None else {"effortLevel": effort}
+        (state_dir / "settings.json").write_text(json.dumps(body), encoding="utf-8")
+
+    def test_renders_effort_next_to_model_from_settings(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        self._write_settings(state_dir, "medium")
+
+        result = _run(
+            {"session_id": "s-eff", "model": {"display_name": "fable-5"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "model=fable-5 · medium" in plain, plain
+
+    def test_omits_effort_when_settings_has_no_effort_level(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        self._write_settings(state_dir, None)
+
+        result = _run(
+            {"session_id": "s-no-eff", "model": {"display_name": "fable-5"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "model=fable-5" in plain, plain
+        # No effort resolved → no suffix, no dangling separator after the model.
+        assert "fable-5 ·" not in plain, plain
+
+    def test_omits_effort_when_settings_file_absent(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        # No settings.json planted in state_dir → effortLevel unreadable.
+
+        result = _run(
+            {"session_id": "s-missing-cfg", "model": {"display_name": "fable-5"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "model=fable-5" in plain, plain
+        assert "fable-5 ·" not in plain, plain
+
+    def test_stdin_effort_field_takes_precedence_over_settings(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        self._write_settings(state_dir, "low")
+
+        result = _run(
+            {"session_id": "s-stdin-eff", "model": {"display_name": "fable-5"}, "effort": "max"},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "model=fable-5 · max" in plain, plain
+        assert "· low" not in plain, plain
+
+    def test_effort_segment_omitted_when_model_absent(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        self._write_settings(state_dir, "high")
+
+        result = _run(
+            {"session_id": "s-no-model"},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        # No model → no model segment → no orphan effort token.
+        assert "model=" not in plain, plain
+        assert "high" not in plain, plain
 
 
 class TestSkillsNamespaceGrouping:


### PR DESCRIPTION
## Summary

The Claude Code statusline rendered the model (and loop/PR state) but not the session reasoning-effort level — the `/effort` setting (low / medium / high / xhigh / max). This adds the effort level next to the model, e.g. `model=fable-5 · medium`. The segment is short and is omitted entirely when no effort can be resolved.

Closes #2214

## How it works

- `hooks/scripts/statusline.sh` reuses the existing `g_context` model-segment chokepoint — no parallel statusline path. The effort value is appended as a short `· <effort>` suffix on the model chunk.
- Effort is sourced in two steps:
  1. The harness statusline stdin JSON (`.effort`, then `.model.effort`). The current harness payload does NOT carry an effort field, but reading it first means the segment upgrades for free if a future payload exposes one.
  2. Fallback to the saved `/effort` default in the harness settings file — `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json` `.effortLevel`, which is exactly where the `/effort` slash command persists the choice.
- The segment is omitted when neither source yields a value, so it never fabricates an effort or leaves a dangling ` · ` separator. It degrades to omission on a missing settings file, an absent key, or no `jq`, like every other statusline segment.

## Harness payload vs. settings fallback

The harness statusline stdin JSON carries `model.display_name`, `context_window`, `rate_limits`, and `session_id`, but no observed effort field. The authoritative source today is the settings file `effortLevel` key, which `/effort` writes. The `.effort` / `.model.effort` reads are a forward-compatible no-op until/unless the harness starts sending one.

Staleness caveat: a mid-session `/effort` change that the harness has not persisted to `settings.json` would render the previous saved value. The segment is honest about unknown (omitted) but cannot detect that specific staleness; if a future payload exposes effort, the `.effort` read already prefers it over the saved default.

## Anti-vacuity

The regression tests were observed RED on the pre-fix script:

- With the effort feature absent, `test_renders_effort_next_to_model_from_settings` and `test_stdin_effort_field_takes_precedence_over_settings` fail — the model segment renders `model=fable-5` with no ` · <effort>` suffix.
- With a deliberately-injected dangling-separator bug (always append the separator even when effort is empty), the OMIT controls (`test_omits_effort_when_settings_has_no_effort_level`, `test_omits_effort_when_settings_file_absent`) fail — proving they guard against a fabricated value / trailing separator rather than passing vacuously.

All 42 tests in `tests/test_claude_statusline.py` pass after the fix; the `tests/teatree_quality/test_test_path_mirror.py` baseline gate stays green.

## Architecture pre-check — #2214

1. **BLUEPRINT § alignment** — Tactical addition to the Claude Code statusline hook (a `hooks/` artifact). No BLUEPRINT section governs the header exact segment set; the contract is documented inline + in `hooks/CLAUDE.md`.
2. **FSM phase boundaries** — n/a (no Ticket/Worktree state transition).
3. **Extension-point contracts** — n/a (no OverlayBase / scanner / hook-router / Protocol surface; the statusline hook is a leaf invoked by the harness).
4. **Component boundaries** — `hooks/scripts/statusline.sh` only; reuses the existing model-segment chokepoint.
5. **Dependency direction** — no Python imports added; shell-only change.
6. **Test surface** — `tests/test_claude_statusline.py::TestEffortSegment`: settings-fallback render, omit-when-no-effortLevel, omit-when-settings-absent, stdin-precedence-over-settings, omit-when-model-absent.
7. **Resilience invariants** — only two read-only sources; no external write. Degrades to omitting the segment on any read error so a broken settings file never blanks the statusline.
8. **Identity and key normalization** — n/a (single scalar value).
9. **Behavior preservation / capability deletion** — purely additive; the model segment renders identically when effort is unknown.