### PR TITLE
fix: widen module-health ratchet beyond src/ + resync t3 update deps on drift

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -4839,8 +4839,9 @@ Usage: t3 teatree e2e post-test-plan [OPTIONS]
  issue; ``--title`` overrides the heading; ``--template``
  (``capture-matrix`` / ``browser-click-first`` / ``link-api``) selects
  the body shape, overriding the manifest's ``template``;
- ``--skip-validation`` bypasses the image preflight; ``--body-file`` posts
- a pre-authored body verbatim (no upload; mutually exclusive with
+ ``--skip-validation`` bypasses the image preflight; ``--allow-no-video``
+ permits a stills-only manifest (refused by default); ``--body-file``
+ posts a pre-authored body verbatim (no upload; mutually exclusive with
  ``--manifest``). See :mod:`._test_plan`. ``post-evidence`` is a hidden,
  deprecated alias.
 
@@ -4866,6 +4867,13 @@ Usage: t3 teatree e2e post-test-plan [OPTIONS]
 │                                                    browser-click-first, or   │
 │                                                    link-api. Overrides the   │
 │                                                    manifest's.               │
+│ --allow-no-video     --no-allow-no-video           Post a stills-only        │
+│                                                    manifest (screenshots, no │
+│                                                    video). Refused by        │
+│                                                    default — capture         │
+│                                                    video:'on' instead.       │
+│                                                    [default:                 │
+│                                                    no-allow-no-video]        │
 │ --help                                             Show this message and     │
 │                                                    exit.                     │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -4902,6 +4910,13 @@ Usage: t3 teatree e2e post-evidence [OPTIONS]
 │                                                    browser-click-first, or   │
 │                                                    link-api. Overrides the   │
 │                                                    manifest's.               │
+│ --allow-no-video     --no-allow-no-video           Post a stills-only        │
+│                                                    manifest (screenshots, no │
+│                                                    video). Refused by        │
+│                                                    default — capture         │
+│                                                    video:'on' instead.       │
+│                                                    [default:                 │
+│                                                    no-allow-no-video]        │
 │ --help                                             Show this message and     │
 │                                                    exit.                     │
 ╰──────────────────────────────────────────────────────────────────────────────╯

--- a/scripts/hooks/check_module_health.py
+++ b/scripts/hooks/check_module_health.py
@@ -9,6 +9,11 @@ Files already over the cap at HEAD are grandfathered but ratcheted: they may
 only SHRINK. A commit that grows an over-cap file (LOC or public-function
 count) is blocked, so a god-module can never re-accrete after a split (#1983).
 
+Scope is the first-party Python tree: ``src/`` plus the ``hooks/`` and
+``scripts/`` hook/tool code (``_FIRST_PARTY_PREFIXES``). Tests and
+third-party/vendored paths are excluded. One shared predicate (``_is_first_party``)
+gates both the staged-mode and diff-mode file scans so the two never diverge.
+
 Two entry paths share one ratchet predicate. The default (no args) path runs
 per-commit over staged files (``git diff --cached``) — the prek commit hook,
 where a merge commit is exempt because a merge brings both parents' growth into
@@ -33,6 +38,18 @@ MAX_MODULE_FUNCTIONS = 10
 _RENAME_FIELDS = 2
 _SINGLE_PATH_FIELD = 1
 
+# First-party Python the ratchet scans. ``src/`` is the package; ``hooks/`` and
+# ``scripts/`` are the first-party hook/tool code — where the 6388-LOC
+# ``hooks/scripts/hook_router.py`` lives, the single largest first-party file,
+# previously invisible to the gate while small ``src/`` modules were forced to
+# split. One shared predicate keeps staged-mode and diff-mode scope identical.
+_FIRST_PARTY_PREFIXES = ("src/", "hooks/", "scripts/")
+
+
+def _is_first_party(path: str) -> bool:
+    return path.startswith(_FIRST_PARTY_PREFIXES)
+
+
 _DICT_OBJECT_PATTERNS = [
     "dict[str, object]",
     "Dict[str, object]",
@@ -56,7 +73,7 @@ def _staged_python_files() -> list[str]:
         text=True,
         check=False,
     )
-    return [f for f in result.stdout.strip().splitlines() if f.startswith("src/")]
+    return [f for f in result.stdout.strip().splitlines() if _is_first_party(f)]
 
 
 def _head_paths() -> dict[str, str]:
@@ -241,7 +258,7 @@ def _range_python_files(merge_base: str) -> list[str]:
         text=True,
         check=False,
     )
-    return [f for f in result.stdout.strip().splitlines() if f.startswith("src/")]
+    return [f for f in result.stdout.strip().splitlines() if _is_first_party(f)]
 
 
 def _range_paths(merge_base: str) -> dict[str, str]:

--- a/src/teatree/cli/update.py
+++ b/src/teatree/cli/update.py
@@ -13,7 +13,10 @@ For teatree core (``$T3_REPO``) and every registered overlay repo, this:
     running editable ``t3`` must never silently rot behind origin). A
     tracked-dirty tree is refused loudly. Untracked-only files do not block.
 4. Otherwise ``git pull --ff-only`` — fast-forward only, never merge/rebase.
-5. Reinstalls advanced editable installs, then runs ``t3 setup``.
+5. Reinstalls editable installs + runs ``t3 setup`` when a repo advanced this
+    run OR when the tool venv is missing a declared dep — gated on actual
+    dep-closure drift, NOT only a same-run advance, so an out-of-band ff-merge
+    that added a top-level dependency still re-syncs the venv (#2377).
 6. Probes the teatree self-DB (``python -m teatree migrate --check`` in the
     *runtime* interpreter) and applies pending migrations non-destructively
     — gated on *migrations actually pending*, NOT on whether a repo advanced
@@ -39,6 +42,7 @@ from pathlib import Path
 import typer
 
 from teatree.self_update import ReinstallResult, SubprocessRunner, ensure_self_db_migrated, reinstall_running_editable
+from teatree.utils.dep_drift import editable_source_path, find_missing_dependencies
 from teatree.utils.run import CompletedProcess, run_allowed_to_fail
 
 __all__ = [
@@ -384,17 +388,48 @@ def _git_toplevel(path: Path) -> Path | None:
     return Path(result.stdout.strip()).resolve()
 
 
+def _declared_deps_missing() -> list[str]:
+    """Return declared deps absent from the *running* interpreter's env, or [].
+
+    Mirrors :func:`teatree.cli.dep_drift_repair.repair_dep_drift`'s detection:
+    the running ``t3``'s editable source supplies the ``pyproject.toml`` whose
+    ``[project].dependencies`` are compared against the dists installed in the
+    interpreter that actually executes ``t3``. Empty when the install is
+    non-editable (no editable source to diff against) or when nothing is
+    missing.
+    """
+    source = editable_source_path()
+    if source is None:
+        return []
+    pyproject = source / "pyproject.toml"
+    if not pyproject.is_file():
+        return []
+    return find_missing_dependencies(pyproject)
+
+
 def _reinstall_and_resetup(updated: list[RepoUpdate]) -> None:
-    """Reinstall editable installs whose source advanced, then re-run setup.
+    """Reinstall editable installs, then re-run setup, on advance OR dep drift.
 
     Reinstalling re-anchors the running ``t3`` (and overlay code) on the new
     sources; ``t3 setup`` afterwards re-syncs skill symlinks/config.  Both run
     through the audited subprocess wrapper; failures are surfaced but do not by
     themselves fail the run — the per-repo git outcome already did its job.
+
+    The re-sync runs when a repo advanced this run OR when the tool venv is
+    missing a declared dependency (#2377). An out-of-band ff-merge that added a
+    top-level dep advances the SHA without any repo advancing *during this run*,
+    so the bare advance flag would skip the reinstall and leave the venv stale —
+    the keystone path then crashes with ``ModuleNotFoundError``. The drift probe
+    mirrors the #929 self-DB migrate, which is likewise decoupled from the
+    per-run advance flag and gated on the actual drift it must repair.
     """
-    if not any(r.status is UpdateStatus.UPDATED for r in updated):
-        typer.echo("No repo advanced — skipping reinstall + setup.")
+    advanced = any(r.status is UpdateStatus.UPDATED for r in updated)
+    missing = _declared_deps_missing()
+    if not advanced and not missing:
+        typer.echo("No repo advanced and tool deps in sync — skipping reinstall + setup.")
         return
+    if not advanced and missing:
+        typer.echo(f"No repo advanced, but tool deps drifted ({', '.join(missing)}) — resyncing.")
 
     if not shutil.which("uv"):
         typer.echo("WARN  `uv` not on PATH — skipping editable reinstall.")

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -25,6 +25,7 @@ from teatree.cli.update import (
     RepoUpdate,
     UpdateStatus,
     _collect_repos,
+    _declared_deps_missing,
     _git_toplevel,
     _reinstall_and_resetup,
     update_repo,
@@ -512,16 +513,17 @@ class TestReinstallAndResetup:
     skip when nothing advanced, and surface the seam's outcome.
     """
 
-    def test_noop_when_nothing_advanced(
+    def test_noop_when_nothing_advanced_and_deps_in_sync(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
         called: list[bool] = []
         monkeypatch.setattr(update_mod, "reinstall_running_editable", lambda: called.append(True))
+        monkeypatch.setattr(update_mod, "_declared_deps_missing", list)
 
         _reinstall_and_resetup([RepoUpdate("core", UpdateStatus.UP_TO_DATE)])
 
         assert "skipping reinstall + setup" in capsys.readouterr().out
-        assert called == [], "the reinstall seam must not run when nothing advanced"
+        assert called == [], "the reinstall seam must not run when nothing advanced and deps are in sync"
 
     def test_reports_success_when_advanced(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
@@ -564,6 +566,57 @@ class TestReinstallAndResetup:
         _reinstall_and_resetup([RepoUpdate("core", UpdateStatus.UPDATED, old_sha="a", new_sha="b")])
 
         assert "reinstall/setup reported a problem: setup: boom" in capsys.readouterr().out
+
+    def test_resyncs_when_no_repo_advanced_but_dep_missing(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # #2377: an out-of-band ff-merge advanced the SHA + added a top-level
+        # dependency, so NO repo advances *this run* yet the tool venv is
+        # missing the new dep. The reinstall seam (the only mocked external)
+        # MUST still fire — the bare advance flag would have skipped it.
+        reinstalled: list[bool] = []
+        monkeypatch.setattr(update_mod.shutil, "which", lambda _name: "/usr/bin/uv")
+        monkeypatch.setattr(update_mod, "_declared_deps_missing", lambda: ["django-linear-migrations"])
+        monkeypatch.setattr(
+            update_mod,
+            "reinstall_running_editable",
+            lambda: reinstalled.append(True) or ReinstallResult(ok=True, reinstalled=True),
+        )
+
+        _reinstall_and_resetup([RepoUpdate("core", UpdateStatus.UP_TO_DATE)])
+
+        out = capsys.readouterr().out
+        assert reinstalled == [True], "the reinstall seam must run on dep drift even with no repo advance"
+        assert "django-linear-migrations" in out
+        assert "resyncing" in out.lower()
+
+
+class TestDeclaredDepsMissing:
+    """The drift probe that decouples the dep re-sync from the per-run flag (#2377).
+
+    Detection reuses ``teatree.utils.dep_drift`` against the running ``t3``'s
+    editable source; the only thing stubbed is that source resolution, which
+    reaches into the host install metadata.
+    """
+
+    def test_non_editable_install_reports_no_drift(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(update_mod, "editable_source_path", lambda: None)
+
+        assert _declared_deps_missing() == []
+
+    def test_missing_pyproject_reports_no_drift(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setattr(update_mod, "editable_source_path", lambda: tmp_path)
+
+        assert _declared_deps_missing() == []
+
+    def test_reports_declared_dep_absent_from_env(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\ndependencies = ["a-dep-that-is-not-installed-xyz>=1.0"]\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(update_mod, "editable_source_path", lambda: tmp_path)
+
+        assert _declared_deps_missing() == ["a-dep-that-is-not-installed-xyz"]
 
 
 class TestSelfDbMigrationOnUpdate:

--- a/tests/test_module_health_ratchet.py
+++ b/tests/test_module_health_ratchet.py
@@ -9,6 +9,7 @@ HEAD LOC is its ceiling — so the ratchet may hard-fail (it never fires on the
 existing state, only on a regression).
 """
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -26,6 +27,17 @@ def _src(loc: int) -> str:
 
 def _fn_src(n_funcs: int) -> str:
     return "\n".join(f"def fn_{i}():\n    return {i}" for i in range(n_funcs)) + "\n"
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],  # noqa: S607
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
 
 
 class TestLocShrinkRatchet:
@@ -183,3 +195,74 @@ class TestFunctionCountShrinkRatchet:
         monkeypatch.setattr("sys.argv", ["check_module_health.py"])
 
         assert mod.main() == 0
+
+
+class TestFirstPartyScopeBeyondSrc:
+    """The ratchet scans first-party hook/tool code outside ``src/`` too.
+
+    ``hooks/scripts/hook_router.py`` (the largest first-party file) lives
+    outside ``src/``; a ``src/``-only filter left it — and every other file
+    under ``hooks/`` and ``scripts/`` — invisible to the gate, so it could grow
+    without bound. Widening the scope grandfathers each at its HEAD ceiling
+    (shrink-only) yet now catches growth past it. These tests exercise the real
+    ``_staged_python_files`` filter against a git repo under ``tmp_path``.
+    """
+
+    def _init_repo(self, tmp_path: Path) -> None:
+        _git(tmp_path, "init", "-b", "main")
+        _git(tmp_path, "config", "user.email", "t@e.st")  # privacy-scan:allow (fake test git-config email, not PII)
+        _git(tmp_path, "config", "user.name", "Tester")
+
+    def _commit_over_cap(self, tmp_path: Path, relpath: str) -> None:
+        target = tmp_path / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(_src(_OVER_CAP), encoding="utf-8")
+        _git(tmp_path, "add", relpath)
+        _git(tmp_path, "commit", "-m", "seed over-cap file")
+
+    def test_hooks_scripts_file_growing_past_peg_is_flagged(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        relpath = "hooks/scripts/big_tool.py"
+        self._init_repo(tmp_path)
+        self._commit_over_cap(tmp_path, relpath)
+        # Grow the over-cap file and stage it: the ratchet must catch growth.
+        (tmp_path / relpath).write_text(_src(_OVER_CAP_GREW), encoding="utf-8")
+        _git(tmp_path, "add", relpath)
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("sys.argv", ["check_module_health.py"])
+
+        assert mod.main() == 1
+
+    def test_hooks_scripts_file_held_steady_is_allowed(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        relpath = "hooks/scripts/big_tool.py"
+        self._init_repo(tmp_path)
+        self._commit_over_cap(tmp_path, relpath)
+        # Restage the same content (no growth) — grandfathered ceiling holds.
+        (tmp_path / relpath).write_text(f"{_src(_OVER_CAP)}# touch\n", encoding="utf-8")
+        _git(tmp_path, "add", relpath)
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("sys.argv", ["check_module_health.py"])
+
+        assert mod.main() == 0
+
+    def test_scripts_file_growing_past_peg_is_flagged(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        relpath = "scripts/big_tool.py"
+        self._init_repo(tmp_path)
+        self._commit_over_cap(tmp_path, relpath)
+        (tmp_path / relpath).write_text(_src(_OVER_CAP_GREW), encoding="utf-8")
+        _git(tmp_path, "add", relpath)
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("sys.argv", ["check_module_health.py"])
+
+        assert mod.main() == 1
+
+    def test_first_party_predicate_scopes_src_hooks_scripts_only(self) -> None:
+        assert mod._is_first_party("src/teatree/cli/update.py")
+        assert mod._is_first_party("hooks/scripts/hook_router.py")
+        assert mod._is_first_party("scripts/privacy_scan.py")
+        assert not mod._is_first_party("tests/test_module_health_ratchet.py")
+        assert not mod._is_first_party("docs/blueprint/overview.md")


### PR DESCRIPTION
Two verified, low-effort, small-blast fixes from an architectural review.

## Fix A — widen the module-health ratchet beyond `src/`

`scripts/hooks/check_module_health.py` filtered scanned files to `f.startswith("src/")` at both the staged-mode and diff-mode (`--from-ref` CI twin) sites, so `hooks/scripts/hook_router.py` — the largest first-party file (8842 raw lines / 6388 non-blank-non-comment) — was invisible to the gate while small `src/` modules were forced to split.

- Scope is now the first-party tree (`src/`, `hooks/`, `scripts/`) via one shared `_is_first_party` predicate used by both scan sites, so staged-mode and diff-mode never diverge. Tests and third-party/vendored paths stay excluded.
- The ratchet is HEAD-pegged shrink-only: widening scope **grandfathers** each newly-scoped over-cap file at its current ceiling (`hook_router.py` 6388, `scripts/eval/corpus_gen/catalog.py` 1017, `scripts/eval/corpus_gen/per_skill.py` 740) and blocks **growth only** — it does not hard-fail the existing tree. The CI-twin diff-mode run against the current tree exits 0.
- Anti-vacuity: `test_hooks_scripts_file_growing_past_peg_is_flagged` is RED on the pre-widen (`src/`-only) filter — the file is out of scope so its growth is not caught (`assert 0 == 1`) — and GREEN after.

## Fix B — decouple `t3 update` dep-resync from the per-run UPDATED flag (closes #2377)

`_reinstall_and_resetup` returned early unless a repo advanced **during this run**, so an out-of-band ff-merge that advanced the SHA and added a top-level dependency left the tool venv missing that dep — the keystone path then crashed with `ModuleNotFoundError` (observed 2026-06-14 with `django-linear-migrations`).

- The UPDATED short-circuit is replaced with a DRIFT PROBE: `_declared_deps_missing()` (reusing `teatree.utils.dep_drift.find_missing_dependencies` against the running `t3`'s editable source) triggers the reinstall/resetup even when no repo advanced this run. Existing advance behavior is preserved. This mirrors the #929 probe-gated self-DB migrate, which is likewise decoupled from the same flag; deps sync before the migrate so it never imports a declared-but-uninstalled app.
- Anti-vacuity: `test_resyncs_when_no_repo_advanced_but_dep_missing` is RED on the pre-fix short-circuit (the reinstall seam never runs → `assert [] == [True]`) and GREEN after. Only the subprocess reinstall external is mocked.

## Architecture pre-check

**1. BLUEPRINT § alignment** — Fix A: the module-health ratchet (codebase-audit fitness function); Fix B: §17.4 keystone merge path currency, mirrors #929/#2134 self-update doctrine in `cli/update.py`.

**2. FSM phase boundaries** — n/a, no `Ticket.State`/`Worktree.State` transitions.

**3. Extension-point contracts** — n/a, no `OverlayBase` / scanner / hook-surface / `*Backend` Protocol change. Fix A changes a hook script's internal file-scope predicate only.

**4. Component boundaries** — Fix A in `scripts/hooks/` (hook handler); Fix B in `src/teatree/cli/` (Typer command, no business logic) reusing `src/teatree/utils/dep_drift.py`.

**5. Dependency direction** — Fix B adds `teatree.cli.update → teatree.utils.dep_drift` (downward `cli → utils`, same edge `cli/dep_drift_repair.py` already uses). `uv run tach check`: all modules validated.

**6. Test surface** — Fix A: `TestFirstPartyScopeBeyondSrc` (real git under `tmp_path` exercising the actual `_staged_python_files` filter) + predicate scope test. Fix B: `TestReinstallAndResetup::test_resyncs_when_no_repo_advanced_but_dep_missing` + `TestDeclaredDepsMissing` (non-editable / missing-pyproject / dep-absent branches).

**7. Resilience invariants** — Fix B is a read-only probe gating an existing audited-subprocess reinstall; idempotent (re-running when deps are in sync is a no-op skip). No new external write.

**8. Identity and key normalization** — n/a; no bare-vs-qualified identity introduced.

**9. Behavior preservation / capability deletion** — Fix A widens (never narrows) the gate's coverage; no must-block test inverted. Fix B preserves the existing advance-triggered reinstall and only *adds* the drift trigger. No capability removed.

Closes #2377