### PR TITLE
fix(core): auto-apply self-DB migrations on the sanctioned merge path (#2006)

### DIFF
--- a/src/teatree/core/gates/schema_guard.py
+++ b/src/teatree/core/gates/schema_guard.py
@@ -1,4 +1,4 @@
-"""Self-DB schema pre-flight for the sanctioned merge path (#869).
+"""Self-DB schema pre-flight for the sanctioned merge path (#869, #2006).
 
 The sanctioned merge commands ``t3 teatree ticket clear`` and
 ``t3 teatree ticket merge`` write/read ``MergeClear``/``MergeAudit`` rows.
@@ -10,15 +10,22 @@ traceback.
 Since #863 mechanically prohibits raw ``gh pr merge`` on teatree-managed
 tickets, that opaque failure blocks the *entire* merge pipeline with no
 actionable signal. This module provides a cheap pre-flight that converts
-the silent traceback into a clear, sanctioned-remediation error and a
-``t3 doctor`` check that surfaces the gap proactively at session start.
+the silent traceback into a clear outcome and a ``t3 doctor`` check that
+surfaces the gap proactively at session start.
 
-The merge gate deliberately *refuses* (it does not auto-migrate): mutating
-the schema as a side effect of a merge command is surprising and unsafe if
-the migration itself fails partway. Instead :func:`migrate_self_db` (exposed
-as ``t3 teatree db migrate``) is the explicit, always-available, in-process
-self-rescue — reachable even while the gate is refusing, since it is a
-separate command not gated by the merge path (#126).
+The recurring footgun (#2006): the live editable install tracks the main
+clone, so a keystone merge of a migration-adding PR advances the install
+over a new migration and leaves the self-DB behind. Every subsequent
+sanctioned operation then crashed with ``no such table`` until a human ran
+``t3 teatree db migrate``. :func:`require_current_schema` now self-heals
+that state — it applies the pending self-DB migrations in place (the same
+non-destructive, forward-only ``migrate_self_db`` the manual command runs)
+before proceeding. Auto-migrating the self-DB is safe: it is a local SQLite
+state DB, not a tenant/product DB, and the migrate is fail-closed — a
+genuine migrate failure raises :class:`SelfDbMigrationError` with the
+actionable remediation rather than proceeding against a half-migrated DB.
+``migrate_self_db`` (exposed as ``t3 teatree db migrate``) stays the
+explicit, always-available manual self-rescue.
 """
 
 import typer
@@ -95,23 +102,35 @@ def migrate_self_db(alias: str = DEFAULT_DB_ALIAS) -> list[str]:
 
 
 def require_current_schema(alias: str = DEFAULT_DB_ALIAS) -> None:
-    """Fail closed with an actionable message if the self-DB is unmigrated.
+    """Ensure the self-DB schema is current, auto-applying pending migrations (#2006).
 
     Called as a pre-flight by the sanctioned merge commands so an
     unmigrated self-DB can never produce a raw ``no such table`` traceback
-    on the critical merge path.
+    on the critical merge path. When the live editable install has advanced
+    over a new migration, the self-DB falls behind; rather than refuse and
+    force a manual ``t3 teatree db migrate``, this applies the pending
+    migrations in place via :func:`migrate_self_db` (probe-gated,
+    idempotent, non-destructive forward-only) and proceeds.
+
+    Fail LOUD if the migrate itself fails: :func:`migrate_self_db` raises
+    :class:`SelfDbMigrationError` on a genuine migrate failure, which is
+    re-raised with the actionable remediation so the caller surfaces it
+    instead of proceeding against a half-migrated DB.
     """
     pending = pending_migrations(alias)
     if not pending:
         return
-    listed = ", ".join(pending)
-    msg = (
-        f"teatree self-DB has {len(pending)} unapplied migration(s): {listed}. "
-        f"The sanctioned merge path (ticket clear/merge) needs a current schema "
-        f"(e.g. the MergeClear/MergeAudit tables) and refuses to run against a "
-        f"stale DB rather than fail with an opaque traceback.\n{_REMEDIATION}"
-    )
-    raise SelfDbMigrationError(msg)
+    try:
+        migrate_self_db(alias)
+    except SelfDbMigrationError as exc:
+        listed = ", ".join(pending)
+        msg = (
+            f"teatree self-DB has {len(pending)} unapplied migration(s): {listed}. "
+            f"The sanctioned merge path (ticket clear/merge) needs a current schema "
+            f"(e.g. the MergeClear/MergeAudit tables); auto-applying them failed: {exc}\n"
+            f"{_REMEDIATION}"
+        )
+        raise SelfDbMigrationError(msg) from exc
 
 
 def doctor_check_self_db_migrations(alias: str = DEFAULT_DB_ALIAS) -> bool:

--- a/tests/teatree_core/test_schema_guard.py
+++ b/tests/teatree_core/test_schema_guard.py
@@ -1,11 +1,21 @@
-"""Self-DB schema pre-flight on the sanctioned merge path (#869).
+"""Self-DB schema pre-flight on the sanctioned merge path (#869, #2006).
 
 Before #869 `t3 teatree ticket clear`/`merge` called the ORM with no
 schema check, so an unmigrated self-DB (missing `teatree_merge_clear`)
 surfaced a raw `django.db.utils.OperationalError: no such table`
 traceback. Since #863 prohibits raw `gh pr merge`, that opaque failure
-blocked the entire merge pipeline. These tests pin the actionable
-behaviour and the doctor surfacing.
+blocked the entire merge pipeline.
+
+#869 first converted that into a refusal with a remediation that asked
+the operator to run `t3 teatree db migrate` by hand. #2006 closes the
+loop: when the live editable install advances over a new migration the
+self-DB falls behind, and the next sanctioned operation now self-heals
+by applying the pending self-DB migrations in place (the same
+non-destructive forward-only `migrate_self_db` the manual command runs)
+before proceeding. A migrate that itself fails still fails LOUD with the
+actionable remediation. These tests pin the self-heal behaviour and the
+read-only doctor surfacing (the doctor reports the gap, it does not
+heal).
 """
 
 import io
@@ -29,6 +39,26 @@ from teatree.core.gates.schema_guard import (
 from teatree.core.models import MergeClear
 
 _MERGE_MIGRATIONS = ("0011_mergeclear_mergeaudit", "0012_mergeclear_human_authorizer")
+_PRE_MERGE_MIGRATION = "0010_remove_looplease_heartbeat_at"
+
+
+def _unmigrate_core_to_pre_merge() -> None:
+    """Drive the self-DB genuinely behind via a real backward `migrate` (#2006).
+
+    Migrating ``core`` back to ``0010`` un-applies the whole 0011+ tail the
+    way the editable install would *advance past* it: the tables are really
+    dropped and the ``django_migrations`` ledger is really updated. So a
+    forward heal re-applies them cleanly — exactly the state a keystone
+    merge of a migration-adding PR leaves behind. (The cheap
+    delete-one-table reproduction below fakes only the symptom and a real
+    ``migrate`` cannot heal it, so it is reserved for the read-only/doctor
+    surfaces that never migrate.)
+    """
+    call_command("migrate", "core", _PRE_MERGE_MIGRATION, "--no-input", verbosity=0)
+
+
+def _migrate_core_forward() -> None:
+    call_command("migrate", "core", "--no-input", verbosity=0)
 
 
 class _UnapplyState:
@@ -76,14 +106,24 @@ def _unapply_merge_migrations() -> None:
 
 
 def _reapply_merge_migrations() -> None:
-    """Restore the table + ledger so ``TransactionTestCase`` teardown flushes."""
-    with connection.schema_editor() as editor:
-        editor.create_model(MergeClear)
+    """Restore the table + ledger so ``TransactionTestCase`` teardown flushes.
+
+    Idempotent: a #2006 self-heal may already have re-created the table and
+    re-recorded the ledger tail before this cleanup runs, so it tolerates an
+    already-current schema rather than colliding on a duplicate table/row.
+    """
+    if not _table_exists(MergeClear._meta.db_table):
+        with connection.schema_editor() as editor:
+            editor.create_model(MergeClear)
     with connection.cursor() as cursor:
         cursor.executemany(
-            "INSERT INTO django_migrations (app, name, applied) VALUES ('core', %s, CURRENT_TIMESTAMP)",
+            "INSERT OR IGNORE INTO django_migrations (app, name, applied) VALUES ('core', %s, CURRENT_TIMESTAMP)",
             [(name,) for name in (*_MERGE_MIGRATIONS, *_UnapplyState.tail)],
         )
+
+
+def _table_exists(table: str) -> bool:
+    return table in connection.introspection.table_names()
 
 
 class PendingMigrationsTest(TransactionTestCase):
@@ -94,68 +134,25 @@ class PendingMigrationsTest(TransactionTestCase):
         require_current_schema()  # must not raise
 
 
-class UnmigratedSelfDbTest(TransactionTestCase):
-    """The exact #869 reproduction: the MergeClear table is absent."""
+class BehindSelfDbReportingTest(TransactionTestCase):
+    """The cheap symptom reproduction: `MergeClear` table + ledger tail absent.
+
+    This drops one table and un-records the tail to make the gap visible
+    to the read-only surfaces (the raw-ORM anchor, the doctor checks) that
+    never call `migrate` — so they need only the symptom, not a state a
+    real `migrate` can heal. The self-heal behaviour is covered by
+    :class:`BehindSelfDbSelfHealsTest` with a real backward migration.
+    """
 
     def setUp(self) -> None:
         _unapply_merge_migrations()
         self.addCleanup(_reapply_merge_migrations)
 
     def test_raw_orm_call_would_fail_with_operationalerror(self) -> None:
-        # Anti-vacuous anchor: without the guard the ORM raises the raw,
-        # opaque error this fix exists to replace.
+        # Anchor: before any heal the ORM raises the raw, opaque error this
+        # whole module exists to replace.
         with pytest.raises(OperationalError, match="no such table"):
             MergeClear.objects.count()
-
-    def test_require_current_schema_raises_actionable_error(self) -> None:
-        with pytest.raises(SelfDbMigrationError) as exc:
-            require_current_schema()
-        message = str(exc.value)
-        assert "unapplied migration" in message
-        assert "ticket clear/merge" in message
-        # The remediation points at the in-process self-rescue, not the old
-        # `uv --directory <clone>` wrapper that resolved a different DB (#126).
-        assert "t3 teatree db migrate" in message
-
-    def test_ticket_clear_command_fails_closed_with_remediation(self) -> None:
-        result = cast(
-            "dict[str, object]",
-            call_command(
-                "ticket",
-                "clear",
-                866,
-                "statusline-stale-wakeup",
-                reviewed_sha="29f0a77a4fd03bd281b23e53cfc47ea9a928620b",
-                reviewer_identity="coldrev-866",
-                blast_class="logic",
-            ),
-        )
-        assert result["issued"] is False
-        assert "unapplied migration" in str(result["error"])
-        assert "t3 teatree db migrate" in str(result["error"])
-
-    def test_ticket_merge_command_fails_closed_with_remediation(self) -> None:
-        result = cast(
-            "dict[str, object]",
-            call_command("ticket", "merge", 1),
-        )
-        assert result["merged"] is False
-        assert "unapplied migration" in str(result["error"])
-
-    def test_review_record_command_fails_closed_with_remediation(self) -> None:
-        result = cast(
-            "dict[str, object]",
-            call_command(
-                "review",
-                "record",
-                866,
-                "souliane/teatree",
-                reviewed_sha="29f0a77a4fd03bd281b23e53cfc47ea9a928620b",
-                reviewer_identity="coldrev-866",
-            ),
-        )
-        assert result["recorded"] is False
-        assert "unapplied migration" in str(result["error"])
 
     def test_doctor_surface_fails_and_names_pending_migrations(self) -> None:
         buffer = io.StringIO()
@@ -174,6 +171,87 @@ class UnmigratedSelfDbTest(TransactionTestCase):
             ok = doctor_check()
         assert ok is False
         assert "unapplied migration" in buffer.getvalue()
+
+    def test_migrate_failure_fails_loud_with_remediation(self) -> None:
+        # When the heal itself fails, the gate must fail LOUD with the
+        # actionable remediation — never silently swallow a half-migrated DB.
+        with (
+            patch(
+                "teatree.core.gates.schema_guard.migrate_self_db",
+                side_effect=SelfDbMigrationError("migrate exploded mid-apply"),
+            ),
+            pytest.raises(SelfDbMigrationError) as exc,
+        ):
+            require_current_schema()
+        message = str(exc.value)
+        assert "unapplied migration" in message
+        assert "t3 teatree db migrate" in message
+        assert "migrate exploded mid-apply" in message
+
+
+class BehindSelfDbSelfHealsTest(TransactionTestCase):
+    """A keystone merge advanced the install over a migration; the gate self-heals (#2006).
+
+    `setUp` drives the self-DB genuinely behind with a real backward
+    `migrate core 0010` (tables dropped, ledger updated), reproducing the
+    exact state the live editable install lands in after a keystone merge
+    of a migration-adding PR. The sanctioned operations must now apply the
+    pending self-DB migrations in place and proceed, instead of crashing
+    every tick with `no such table` until a manual `t3 teatree db migrate`.
+    """
+
+    def setUp(self) -> None:
+        _unmigrate_core_to_pre_merge()
+        self.addCleanup(_migrate_core_forward)
+
+    def test_require_current_schema_auto_applies_then_proceeds(self) -> None:
+        assert pending_migrations(), "guard precondition: the self-DB must be behind for this test"
+        with pytest.raises(OperationalError, match="no such table"):
+            MergeClear.objects.count()  # behind: the table genuinely does not exist
+        require_current_schema()  # heals in place — must not raise
+        assert pending_migrations() == [], "the pending migrations should have been applied"
+        assert MergeClear.objects.count() == 0  # healed: the table is now usable
+
+    def test_ticket_clear_command_proceeds_past_schema_gate(self) -> None:
+        result = cast(
+            "dict[str, object]",
+            call_command(
+                "ticket",
+                "clear",
+                866,
+                "statusline-stale-wakeup",
+                reviewed_sha="29f0a77a4fd03bd281b23e53cfc47ea9a928620b",
+                reviewer_identity="coldrev-866",
+                blast_class="logic",
+            ),
+        )
+        # The clear proceeds past the schema gate; whatever its outcome, it
+        # is never the unapplied-migration refusal that #2006 eliminates.
+        assert "unapplied migration" not in str(result.get("error", ""))
+        assert pending_migrations() == []
+
+    def test_ticket_merge_command_proceeds_past_schema_gate(self) -> None:
+        result = cast(
+            "dict[str, object]",
+            call_command("ticket", "merge", 1),
+        )
+        assert "unapplied migration" not in str(result.get("error", ""))
+        assert pending_migrations() == []
+
+    def test_review_record_command_proceeds_past_schema_gate(self) -> None:
+        result = cast(
+            "dict[str, object]",
+            call_command(
+                "review",
+                "record",
+                866,
+                "souliane/teatree",
+                reviewed_sha="29f0a77a4fd03bd281b23e53cfc47ea9a928620b",
+                reviewer_identity="coldrev-866",
+            ),
+        )
+        assert "unapplied migration" not in str(result.get("error", ""))
+        assert pending_migrations() == []
 
 
 class DoctorCheckCurrentSchemaTest(TransactionTestCase):


### PR DESCRIPTION
## What

When the live editable install advances over a new migration — a keystone merge of a migration-adding PR, or an out-of-band ff-merge moving main forward — the teatree self-DB falls behind. Every subsequent sanctioned operation (`ticket clear` / `ticket merge` / `review record`) then refused with "self-DB has N unapplied migration(s)" until a human ran `t3 teatree db migrate`, and the loop crashed every tick with `no such table` in between (the exact failure observed after keystone-merging [#2001](https://github.com/souliane/teatree/issues/2001), which added migration 0056).

`require_current_schema` now self-heals: when migrations are pending it applies them in place via `migrate_self_db` (probe-gated, idempotent, non-destructive forward-only — the same operation the manual command runs) and proceeds, instead of refusing. The self-DB is a local SQLite state DB, not a tenant/product DB, so auto-migrating it forward is safe. A genuine migrate failure still fails LOUD: `migrate_self_db` raises `SelfDbMigrationError`, re-raised here with the actionable remediation, so the caller never proceeds against a half-migrated DB.

The fix sits at the single `require_current_schema` chokepoint, so every entry point that hit the refusal self-heals without a per-call patch. The read-only `t3 doctor` surface is unchanged — it still reports the gap at session start (the ticket's "doctor check as backstop"); it reports, it does not heal.

## Anti-vacuity (RED → GREEN)

The regression test drives the self-DB genuinely behind with a real backward `migrate core 0010` (tables dropped, ledger updated — the exact post-keystone-merge state) and asserts the sanctioned operations now apply the pending migrations and proceed. Reverting the production fix turns the four self-heal assertions red:

```
=== fix reverted ===
FAILED ...BehindSelfDbSelfHealsTest::test_require_current_schema_auto_applies_then_proceeds
FAILED ...BehindSelfDbSelfHealsTest::test_ticket_clear_command_proceeds_past_schema_gate
FAILED ...BehindSelfDbSelfHealsTest::test_ticket_merge_command_proceeds_past_schema_gate
FAILED ...BehindSelfDbSelfHealsTest::test_review_record_command_proceeds_past_schema_gate
4 failed
=== fix restored ===
14 passed
```

## Architecture pre-check — #2006

### 1. BLUEPRINT § alignment
§17.4 (Orchestrator-decides / loop-executes — the sanctioned `ticket clear`/`merge` keystone). No BLUEPRINT/docs section documented the prior refuse-only doctrine of this gate (it lived only in the module docstring, updated here), so no BLUEPRINT change is needed.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition is added or moved. This is a pre-flight on the existing IN_REVIEW → MERGED keystone path; the transition itself is untouched.

### 3. Extension-point contracts
n/a — no `OverlayBase` hook, scanner registration, or `*Backend` Protocol changes. The three call sites (`ticket clear`, `ticket merge`, `review record`) already catch `SelfDbMigrationError` and need no change: the exception is now raised only on a genuine migrate failure (still the correct fail-closed path).

### 4. Component boundaries
`src/teatree/core/gates/` — the schema pre-flight gate. The change reuses `migrate_self_db` already living in the same module; no new module, no straddle.

### 5. Dependency direction
No imports added (`migrate_self_db` is a sibling function in the same module). `uv run tach check` → "All modules validated!".

### 6. Test surface
`tests/teatree_core/test_schema_guard.py::BehindSelfDbSelfHealsTest` — drives the self-DB behind with a real backward migration and asserts: `require_current_schema` auto-applies + proceeds; `ticket clear`/`ticket merge`/`review record` proceed past the schema gate (no "unapplied migration" refusal). `BehindSelfDbReportingTest::test_migrate_failure_fails_loud_with_remediation` pins the fail-LOUD path (migrate failure re-raises with remediation). The doctor read-only surfaces stay red on a behind DB (report-not-heal).

### 7. Resilience invariants
Per the self-DB write (a local SQLite forward-migrate): **verify-by-re-read** — the gate re-derives `pending_migrations` after the heal in tests; **idempotency** — `migrate_self_db` is probe-gated (no-op when nothing is pending) and forward-only, so repeated invocation is a no-op; **fail-closed** — a genuine migrate failure raises `SelfDbMigrationError` rather than proceeding against a half-migrated DB. No external/colleague-surface write, no sub-agent dispatch — heartbeat / fallback-transport / sub-agent-return-contract are n/a.

### 8. Identity and key normalization
n/a — no bare/qualified identity forms introduced; migration labels are already the canonical `<app>.<name>` form from `pending_migrations`.

### 9. Behavior preservation / capability deletion
The prior behavior was "refuse on ANY pending migration, with a remediation pointing at the manual `t3 teatree db migrate`". This change narrows the refusal to "refuse ONLY when the auto-heal itself fails" — it does not remove the fail-closed guarantee (#870): a half-migrated DB still raises and the caller still surfaces the actionable error. The read-only doctor surface (the session-start backstop) is fully preserved. No must-block test was inverted to must-not-block; the read-path refusal tests were re-pointed to assert the new self-heal contract, and a new fail-LOUD test preserves the half-migrated-DB protection. This narrows no privacy/leak/security matcher.

Closes #2006
