### PR TITLE
fix(hooks): protect .teatree-active from the stale-state sweep

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -241,10 +241,11 @@ _SWEEP_SENTINEL = ".last-sweep"
 # that ages past the retention window. Sweeping it would make
 # ``_session_has_loop`` return False and re-emit the loop-registration nag for a
 # session that is already running the loop. ``.teatree-active`` is the same
-# class: it is touched once by ``handle_track_skill_usage`` when a teatree-
-# activating skill loads, never refreshed, and ``statusline.sh`` gates the
-# WHOLE statusline on its presence (exits blank when absent). Sweeping it makes
-# a long-lived session's statusline silently go blank. The throttle-and-recreate
+# class: it is touched by ``handle_track_skill_usage`` when a teatree-activating
+# skill loads — in a normal session that happens at the start and is not
+# repeated for the life of the session — and ``statusline.sh`` gates the WHOLE
+# statusline on its presence (exits blank when absent). Sweeping it makes a
+# long-lived session's statusline silently go blank. The throttle-and-recreate
 # markers (``loop-pending`` / ``pump-armed`` / ``mr_refreshed`` …) are NOT
 # listed: their absence is the safe default and they are re-armed on demand.
 _SWEEP_PROTECTED_SUFFIXES = frozenset({"crons", "teatree-active"})

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -240,10 +240,14 @@ _SWEEP_SENTINEL = ".last-sweep"
 # long-lived session that never changes its crons keeps an unmodified ``.crons``
 # that ages past the retention window. Sweeping it would make
 # ``_session_has_loop`` return False and re-emit the loop-registration nag for a
-# session that is already running the loop. The throttle-and-recreate markers
-# (``loop-pending`` / ``pump-armed`` / ``mr_refreshed`` …) are NOT listed: their
-# absence is the safe default and they are re-armed on demand.
-_SWEEP_PROTECTED_SUFFIXES = frozenset({"crons"})
+# session that is already running the loop. ``.teatree-active`` is the same
+# class: it is touched once by ``handle_track_skill_usage`` when a teatree-
+# activating skill loads, never refreshed, and ``statusline.sh`` gates the
+# WHOLE statusline on its presence (exits blank when absent). Sweeping it makes
+# a long-lived session's statusline silently go blank. The throttle-and-recreate
+# markers (``loop-pending`` / ``pump-armed`` / ``mr_refreshed`` …) are NOT
+# listed: their absence is the safe default and they are re-armed on demand.
+_SWEEP_PROTECTED_SUFFIXES = frozenset({"crons", "teatree-active"})
 
 
 def _sweep_stale_state_files() -> None:

--- a/tests/test_statusline_state_sweep.py
+++ b/tests/test_statusline_state_sweep.py
@@ -103,7 +103,7 @@ class TestSweepProtectsLiveReaderFiles:
         _sweep_stale_state_files()
         assert teatree_active.exists(), (
             "an active session's .teatree-active gates the statusline by presence and "
-            "is touched once; it must survive the sweep"
+            "is not re-touched for the life of a normal session; it must survive the sweep"
         )
         assert not ephemeral.exists(), (
             "an unprotected re-armed-on-demand marker of the same age must still be swept "

--- a/tests/test_statusline_state_sweep.py
+++ b/tests/test_statusline_state_sweep.py
@@ -97,6 +97,19 @@ class TestSweepProtectsLiveReaderFiles:
         _sweep_stale_state_files()
         assert router._session_has_loop("live-session")
 
+    def test_aged_teatree_active_survives_while_ephemeral_is_swept(self) -> None:
+        teatree_active = _touch("live-session.teatree-active", age_seconds=_STATE_FILE_MAX_AGE_SECONDS + 3600)
+        ephemeral = _touch("live-session.loop-pending", age_seconds=_STATE_FILE_MAX_AGE_SECONDS + 3600)
+        _sweep_stale_state_files()
+        assert teatree_active.exists(), (
+            "an active session's .teatree-active gates the statusline by presence and "
+            "is touched once; it must survive the sweep"
+        )
+        assert not ephemeral.exists(), (
+            "an unprotected re-armed-on-demand marker of the same age must still be swept "
+            "(proves the test is not vacuously protecting everything)"
+        )
+
 
 class TestEnsureStateDirRunsSweep:
     def test_ensure_state_dir_invokes_sweep(self) -> None:


### PR DESCRIPTION
Closes #2390

## Summary

The loop statusline silently went blank mid-session for any long-lived session.

`hooks/scripts/statusline.sh` gates the WHOLE statusline on the presence of `${state_dir}/${session_id}.teatree-active` (exits 0 / blank when absent). That marker is `touch()`ed exactly once by `handle_track_skill_usage` when a teatree-activating skill loads, and its mtime never refreshes for the life of the session. `_sweep_stale_state_files` deletes every state file older than `_STATE_FILE_MAX_AGE_SECONDS` except the suffixes in `_SWEEP_PROTECTED_SUFFIXES`, which held only `"crons"`. So once a session aged past the retention window, the sweep deleted `.teatree-active` and the statusline blanked — while `.active`/`.skills`/`.todos` survived because their mtimes refresh on activity.

This is the exact presence-gated, touch-once, never-refreshed class the protected-suffixes comment already documents for `.crons`. `.teatree-active` was simply never added to the set.

## Fix

- Add `teatree-active` to `_SWEEP_PROTECTED_SUFFIXES` and extend the comment block to name it alongside `crons` as a presence-gated, touch-once, never-refreshed marker (`statusline.sh` is its live reader).

## Proactive audit (sweep the class, not the instance)

Enumerated every distinct state-file suffix and how each is read:

- Presence-gated (read by `.is_file()`/`.exists()` to gate behaviour): `teatree-active` (statusline.sh), `crons` (`_session_has_loop`), `loop-pending` (`_session_in_loop_bootstrap`).
- `loop-pending` / `pump-armed` / `mr_refreshed` are throttle-and-recreate: unlinked on consume and re-armed on demand, so their absence is the safe default — intentionally NOT protected (matches the existing comment).
- `active`/`skills`/`agents`/`todos`/`reads`/`pending`/`no-commit` are line-appended on ongoing activity, so their mtimes refresh; not touch-once.
- `todo-nudged` is a once-per-session nudge throttle; its absence merely re-emits a harmless nudge.

Conclusion: `teatree-active` and `crons` are the only two touch-once, presence-gated, never-refreshed markers. No other suffix needs protection.

## Regression test (anti-vacuity)

`tests/test_statusline_state_sweep.py::TestSweepProtectsLiveReaderFiles::test_aged_teatree_active_survives_while_ephemeral_is_swept`:

- Creates an aged `.teatree-active` and an aged `.loop-pending` (same age, both past the window).
- Asserts the protected `.teatree-active` STILL EXISTS after the sweep.
- Asserts the unprotected `.loop-pending` IS deleted in the same run (proves the test is not vacuously protecting everything).

RED proof (revert the `_SWEEP_PROTECTED_SUFFIXES` change only): the `.teatree-active` assertion FAILS — `assert teatree_active.exists()` → `AssertionError ... assert False ... where False = exists()` (the aged marker was deleted by the sweep). With the fix restored: GREEN, all 10 tests in the module pass.

## Secondary (follow-up, not fixed here)

The zones file the loop LINE renders can go stale because the dynamic-ScheduleWakeup loop does not run `t3 loop tick` (which is what rewrites the zones). That makes the loop *line* stale, not the whole statusline *blank* — a separate concern, left as a follow-up.

## Architecture pre-check — #2390

## 1. BLUEPRINT alignment
Tactical bug fix in `hooks/scripts/` (a hook handler). No BLUEPRINT section governs the per-session state-file retention policy; the fix preserves the existing `_SWEEP_PROTECTED_SUFFIXES` contract, only widening its membership.

## 2. FSM phase boundaries
n/a — no `Ticket.State`/`Worktree.State` transition.

## 3. Extension-point contracts
n/a — no `OverlayBase` / scanner / hook-event / Protocol surface changed.

## 4. Component boundaries
`hooks/scripts/hook_router.py` — the state-file sweep lives with the other per-session state machinery. Correct module; no straddle.

## 5. Dependency direction
One constant changed plus a comment; no import added. `tach check` and `import-linter` green.

## 6. Test surface
`tests/test_statusline_state_sweep.py` — the existing module that mirrors the sweep. New test asserts protected-survives + unprotected-swept (observed RED before the fix).

## 7. Resilience invariants
n/a — no external write. The sweep itself remains best-effort / crash-proof (swallows OSError), unchanged.

## 8. Identity and key normalization
n/a — the suffix is matched by the existing `entry.name.rsplit(".", 1)[-1]` extraction, unchanged; no new key form.

## 9. Behavior preservation / capability deletion
Purely additive — one suffix added to a protected set. No behaviour removed, no matcher narrowed, no must-block test inverted. The sweep still deletes every unprotected aged file exactly as before (asserted by the new test's second assertion and the pre-existing retention tests).
