### PR TITLE
fix(merge): restore caller's checked-out branch around the keystone (#2383)

### DIFF
--- a/src/teatree/core/merge/__init__.py
+++ b/src/teatree/core/merge/__init__.py
@@ -22,6 +22,7 @@ from teatree.core.merge.execution import (
     merge_ticket_pr,
     record_merge_and_advance,
 )
+from teatree.core.merge.head_guard import restore_caller_branch
 from teatree.core.merge.pr_slug_resolution import _GIT_BRANCH_PREFIXES, _looks_like_owner_repo, resolve_pr_repo_slug
 
 __all__ = [
@@ -43,4 +44,5 @@ __all__ = [
     "merge_ticket_pr",
     "record_merge_and_advance",
     "resolve_pr_repo_slug",
+    "restore_caller_branch",
 ]

--- a/src/teatree/core/merge/execution.py
+++ b/src/teatree/core/merge/execution.py
@@ -17,6 +17,7 @@ are documented on :func:`assert_merge_preconditions` / :func:`execute_bound_merg
 import logging
 import time
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from django.apps import apps
 from django.db import transaction
@@ -38,11 +39,16 @@ from teatree.core.merge.ci_rollup import (
     fetch_required_checks_status,
 )
 from teatree.core.merge.errors import MergeHeadMovedError, MergePreconditionError, MergeReplayError, MergeTransientError
+from teatree.core.merge.head_guard import restore_caller_branch
 from teatree.core.merge.pr_slug_resolution import (
     _reconcile_slug_against_reviewed_sha,
     _resolve_host_kind,
     resolve_pr_repo_slug,
 )
+from teatree.project import find_project_root
+
+if TYPE_CHECKING:
+    from teatree.core.models import MergeClear
 
 logger = logging.getLogger(__name__)
 
@@ -524,6 +530,36 @@ def merge_ticket_pr(
         msg = "merge_ticket_pr requires a MergeClear instance"
         raise MergePreconditionError(msg)
 
+    # #2383: the keystone runs from inside the primary clone; the cross-repo
+    # SHA-recovery probe (or any future local tree read) must never leave that
+    # clone on a detached HEAD at the merged PR branch — restore the caller's
+    # checked-out ref around the whole transition, even on a refused merge.
+    with restore_caller_branch(_caller_repo_root()):
+        return _merge_ticket_pr_inner(
+            clear=clear,
+            executing_loop_identity=executing_loop_identity,
+            human_authorized=human_authorized,
+        )
+
+
+def _caller_repo_root() -> str | None:
+    """The primary-clone path the keystone is invoked from, or ``None``.
+
+    The same project root :func:`pr_slug_resolution._project_repo_slug` resolves
+    ``origin`` against — the cwd repo whose HEAD a local probe checkout could
+    move (#2383). ``None`` (non-source install / no resolvable root) makes the
+    head guard a no-op.
+    """
+    root = find_project_root()
+    return str(root) if root is not None else None
+
+
+def _merge_ticket_pr_inner(
+    *,
+    clear: "MergeClear",
+    executing_loop_identity: str,
+    human_authorized: str,
+) -> MergeOutcome:
     slug = resolve_pr_repo_slug(clear)
     pr_id = clear.pr_id
     host_kind = _resolve_host_kind(clear)

--- a/src/teatree/core/merge/head_guard.py
+++ b/src/teatree/core/merge/head_guard.py
@@ -1,0 +1,90 @@
+"""Restore the caller's checked-out branch around the keystone merge (#2383).
+
+The §17.4 keystone runs from inside the primary clone (the orchestrator/loop
+drives ``ticket clear`` + ``ticket merge`` there, then ff-syncs ``main``). The
+merge transport is API-only, but the cross-repo SHA-recovery probe
+(:func:`pr_slug_resolution._reconcile_slug_against_reviewed_sha`) and any future
+fallback that has to read a PR's tree LOCALLY can ``git checkout`` a branch in
+the cwd repo. Left unrestored, that detaches the clone's HEAD at the merged PR
+branch tip, and the next ``git pull --ff-only origin/main`` aborts with "Not
+possible to fast-forward" — the #2383 incident.
+
+This guard makes the invariant structural rather than per-call-site vigilance:
+:func:`restore_caller_branch` captures the clone's checked-out ref BEFORE the
+merge and restores it AFTER, even on error. Whatever the merge path does to HEAD
+in between — today nothing, tomorrow a local probe checkout — the caller's
+checkout is exactly what it was. Best-effort and crash-proof: a capture or
+restore failure never masks the merge result or a merge exception.
+"""
+
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from teatree.utils.run import run_allowed_to_fail
+
+logger = logging.getLogger(__name__)
+
+
+def _git(repo: str, *args: str) -> tuple[int, str]:
+    result = run_allowed_to_fail(["git", "-C", repo, *args], expected_codes=None)
+    return result.returncode, result.stdout.strip()
+
+
+def _capture_head(repo: str) -> tuple[str, str]:
+    """The clone's current checkout as ``(branch, detached_sha)``.
+
+    On a branch: ``(branch_name, "")``. Detached: ``("", head_sha)``. When git
+    cannot answer (not a repo, no HEAD yet, any error): ``("", "")`` — the guard
+    then has nothing to restore and stays a no-op.
+    """
+    branch_rc, branch = _git(repo, "symbolic-ref", "--quiet", "--short", "HEAD")
+    if branch_rc == 0 and branch:
+        return branch, ""
+    sha_rc, sha = _git(repo, "rev-parse", "HEAD")
+    if sha_rc == 0 and sha:
+        return "", sha
+    return "", ""
+
+
+def _restore_head(repo: str, branch: str, detached_sha: str) -> None:
+    """Move HEAD back to the captured ref iff it drifted off it."""
+    target = branch or detached_sha
+    if not target:
+        return
+    _, current_branch = _git(repo, "symbolic-ref", "--quiet", "--short", "HEAD")
+    _, current_sha = _git(repo, "rev-parse", "HEAD")
+    already_restored = current_branch == branch if branch else (not current_branch and current_sha == detached_sha)
+    if already_restored:
+        return
+    rc, _ = _git(repo, "checkout", target)
+    if rc != 0:
+        logger.warning(
+            "merge head_guard: could not restore %s in %s after the keystone merge — "
+            "the clone may be left on the merged PR branch; recover with `git checkout %s`",
+            target,
+            repo,
+            target,
+        )
+
+
+@contextmanager
+def restore_caller_branch(repo: str | None) -> Iterator[None]:
+    """Restore *repo*'s checked-out ref after the keystone merge (#2383).
+
+    A no-op when *repo* is ``None`` (no project root resolved) or git cannot
+    report a HEAD to capture. The restore runs in ``finally`` so it fires even
+    when the merge raises — a refused merge that probed a branch locally must
+    still leave the caller's checkout untouched.
+    """
+    if repo is None:
+        yield
+        return
+    branch, detached_sha = _capture_head(repo)
+    try:
+        yield
+    finally:
+        try:
+            _restore_head(repo, branch, detached_sha)
+        except Exception:
+            logger.exception("merge head_guard: restore raised in %s; merge result preserved", repo)

--- a/tests/teatree_core/test_merge_head_guard.py
+++ b/tests/teatree_core/test_merge_head_guard.py
@@ -24,7 +24,7 @@ import pytest
 from django.test import TestCase
 
 from teatree.core.merge import merge_ticket_pr, restore_caller_branch
-from teatree.core.merge.head_guard import _capture_head
+from teatree.core.merge.head_guard import _capture_head, _restore_head
 from teatree.core.models import MergeClear, Ticket
 
 pytestmark = pytest.mark.django_db
@@ -202,3 +202,117 @@ class TestRestoreCallerBranchPrimitive(TestCase):
             pass
         assert _git(clone, "rev-parse", "--abbrev-ref", "HEAD") == "main"
         assert _git(clone, "rev-parse", "HEAD") == before
+
+    def test_detached_start_restores_to_original_sha_not_a_branch(self) -> None:
+        """Caller already on a detached HEAD: restore returns to that exact SHA (#2383).
+
+        Pins the ``_restore_head`` else-branch
+        ``(not current_branch and current_sha == detached_sha)``: the captured
+        state is a SHA, not a branch name. Inside the guard a different SHA is
+        checked out; on exit HEAD must return to the ORIGINAL detached SHA — not
+        a branch name, not the pr-branch tip.
+        """
+        clone = _make_clone(self.tmp_path)
+        main_sha = _git(clone, "rev-parse", "HEAD")
+        _git(clone, "checkout", main_sha)  # detach at main's tip
+        assert _git(clone, "rev-parse", "--abbrev-ref", "HEAD") == "HEAD"
+        assert _capture_head(str(clone)) == ("", main_sha)
+
+        pr_sha = _git(clone, "rev-parse", f"origin/{_PR_BRANCH}")
+        assert pr_sha != main_sha
+        with restore_caller_branch(str(clone)):
+            _git(clone, "checkout", f"origin/{_PR_BRANCH}")
+            assert _git(clone, "rev-parse", "HEAD") == pr_sha
+
+        assert _git(clone, "rev-parse", "--abbrev-ref", "HEAD") == "HEAD"  # still detached
+        assert _git(clone, "rev-parse", "HEAD") == main_sha  # the original SHA, not the pr-branch
+
+    def test_capture_head_on_non_git_path_returns_empty(self) -> None:
+        """A path git cannot answer for captures ``("", "")`` (line 47).
+
+        Both ``symbolic-ref --quiet`` and ``rev-parse HEAD`` exit non-zero on a
+        non-git directory, so the guard has nothing to restore and stays a
+        no-op (rather than capturing a bogus ref it would later try to check
+        out).
+        """
+        not_a_repo = self.tmp_path / "not-a-repo"
+        not_a_repo.mkdir()
+        assert _capture_head(str(not_a_repo)) == ("", "")
+
+        # And the whole guard is inert on such a path — it must not raise.
+        with restore_caller_branch(str(not_a_repo)):
+            pass
+
+    def test_restore_head_with_empty_target_is_a_noop(self) -> None:
+        """``_restore_head`` with neither branch nor SHA returns early (line 54)."""
+        clone = _make_clone(self.tmp_path)
+        before = _git(clone, "rev-parse", "HEAD")
+        _restore_head(str(clone), "", "")
+        assert _git(clone, "rev-parse", "--abbrev-ref", "HEAD") == "main"
+        assert _git(clone, "rev-parse", "HEAD") == before
+
+    def test_restore_failure_logs_warning_and_does_not_raise(self) -> None:
+        """A checkout that cannot complete logs a warning, never raises (line 62).
+
+        The restore target is overwritten in the worktree with conflicting
+        uncommitted changes, so a plain ``git checkout main`` refuses (it would
+        clobber the local edit). The guard is best-effort: it logs the recovery
+        hint and returns, never propagating the failure.
+        """
+        clone = _make_clone(self.tmp_path)
+        _git(clone, "checkout", f"origin/{_PR_BRANCH}")  # detach off main
+        # A conflicting uncommitted edit to a file that differs between the
+        # detached tree and main makes `git checkout main` refuse.
+        (clone / "f.txt").write_text("conflicting local edit\n", encoding="utf-8")
+
+        with self.assertLogs("teatree.core.merge.head_guard", level="WARNING") as logs:
+            _restore_head(str(clone), "main", "")
+
+        assert any("could not restore" in message for message in logs.output)
+        assert _git(clone, "rev-parse", "--abbrev-ref", "HEAD") == "HEAD"  # checkout refused; still detached
+
+    def test_guard_swallows_restore_exception_and_propagates_body_result(self) -> None:
+        """The crash-proof branch: a restore that raises never masks the body (lines 89-90).
+
+        ``_restore_head`` is patched to raise inside the guard's ``finally``. The
+        guard must swallow it (logging an exception) AND let the body's own
+        return value propagate unchanged — the docstring's "best-effort and
+        crash-proof" claim, proven.
+        """
+        clone = _make_clone(self.tmp_path)
+        boom = RuntimeError("restore blew up")
+
+        def _explode(*_args: object, **_kwargs: object) -> None:
+            raise boom
+
+        with (
+            patch("teatree.core.merge.head_guard._restore_head", side_effect=_explode),
+            self.assertLogs("teatree.core.merge.head_guard", level="ERROR") as logs,
+        ):
+            with restore_caller_branch(str(clone)):
+                body_result = "body ran to completion"
+            # The guard did not re-raise the restore failure: we reach here.
+            assert body_result == "body ran to completion"
+
+        assert any("restore raised" in message for message in logs.output)
+
+    def test_guard_swallows_restore_exception_and_propagates_body_exception(self) -> None:
+        """A body exception still propagates even when restore also raises (lines 89-90)."""
+        clone = _make_clone(self.tmp_path)
+
+        def _explode(*_args: object, **_kwargs: object) -> None:
+            msg = "restore blew up"
+            raise RuntimeError(msg)
+
+        def _body_raises() -> None:
+            with restore_caller_branch(str(clone)):
+                msg = "original body failure"
+                raise ValueError(msg)
+
+        # The ORIGINAL body exception wins; the restore exception is swallowed.
+        with (
+            patch("teatree.core.merge.head_guard._restore_head", side_effect=_explode),
+            self.assertLogs("teatree.core.merge.head_guard", level="ERROR"),
+            pytest.raises(ValueError, match="original body failure"),
+        ):
+            _body_raises()

--- a/tests/teatree_core/test_merge_head_guard.py
+++ b/tests/teatree_core/test_merge_head_guard.py
@@ -1,0 +1,204 @@
+"""The keystone merge must never leave the caller's clone on a detached HEAD (#2383).
+
+The §17.4 keystone runs from inside the primary clone. The cross-repo
+SHA-recovery probe (or any future local tree read) can ``git checkout`` a branch
+in the cwd repo; left unrestored, the clone detaches at the merged PR branch tip
+and the next ``git pull --ff-only origin/main`` aborts with "Not possible to
+fast-forward". These tests drive the REAL :func:`merge_ticket_pr` against a real
+``tmp_path`` clone checked out on ``main``, make the merge path perform a real
+local checkout (modeling the probe fallback the ticket names), and assert the
+clone is STILL on ``main`` afterward. Only the unstoppable external — the ``gh``
+merge subprocess — is stubbed; git itself is real.
+
+Anti-vacuity (see ``TestRestoreCallerBranchPrimitive``): the guard's restore is
+exercised against a genuine local checkout, so removing the restore turns the
+assertions RED — the merge path with the guard bypassed leaves the clone
+detached, exactly the #2383 symptom.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from django.test import TestCase
+
+from teatree.core.merge import merge_ticket_pr, restore_caller_branch
+from teatree.core.merge.head_guard import _capture_head
+from teatree.core.models import MergeClear, Ticket
+
+pytestmark = pytest.mark.django_db
+
+_SHA = "a" * 40
+_GREEN = '[{"status": "COMPLETED", "conclusion": "SUCCESS"}]'
+_PR_BRANCH = "2369-publish-gate-body-resolution"
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+def _make_clone(tmp_path: Path) -> Path:
+    """A real git clone on ``main`` with a separate PR branch and an ``origin`` remote.
+
+    Mirrors the primary-clone shape the keystone runs from: ``main`` checked
+    out, a ``refs/remotes/origin/<pr-branch>`` the probe fallback would
+    ``git checkout`` (detaching HEAD), and ``main`` left intact so a restore
+    has somewhere to return to.
+    """
+    upstream = tmp_path / "upstream.git"
+    _git(tmp_path, "init", "--bare", str(upstream))
+
+    clone = tmp_path / "clone"
+    _git(tmp_path, "clone", str(upstream), str(clone))
+    _git(clone, "config", "user.email", "t@example.com")
+    _git(clone, "config", "user.name", "t")
+    _git(clone, "checkout", "-b", "main")
+    (clone / "f.txt").write_text("base\n", encoding="utf-8")
+    _git(clone, "add", "f.txt")
+    _git(clone, "commit", "-m", "base")
+    _git(clone, "push", "-u", "origin", "main")
+
+    _git(clone, "checkout", "-b", _PR_BRANCH)
+    (clone / "f.txt").write_text("pr work\n", encoding="utf-8")
+    _git(clone, "commit", "-am", "pr work")
+    _git(clone, "push", "-u", "origin", _PR_BRANCH)
+
+    _git(clone, "checkout", "main")
+    _git(clone, "fetch", "origin")
+    return clone
+
+
+def _ticket() -> Ticket:
+    return Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
+
+
+def _clear(ticket: Ticket) -> MergeClear:
+    return MergeClear.objects.create(
+        ticket=ticket,
+        pr_id=2380,
+        slug="souliane/teatree",
+        reviewed_sha=_SHA,
+        reviewer_identity="cold-reviewer",
+        gh_verify_result=MergeClear.VerifyResult.GREEN,
+        blast_class=MergeClear.BlastClass.DOCS,
+    )
+
+
+def _gh_ok(argv: list[str]) -> tuple[int, str, str]:
+    joined = " ".join(argv)
+    if "headRefOid" in joined:
+        return (0, _SHA, "")
+    if "isDraft" in joined:
+        return (0, "false", "")
+    if "statusCheckRollup" in joined:
+        return (0, _GREEN, "")
+    if "state,mergeCommit" in joined:
+        return (0, '{"state": "OPEN", "mergeCommit": null}', "")
+    if "pulls" in joined and "merge" in joined:
+        return (0, '{"sha": "merged0deadbeef"}', "")
+    return (0, "", "")
+
+
+class TestMergeKeystoneRestoresCallerBranch(TestCase):
+    """#2383: the keystone leaves the cwd clone on the branch it was on."""
+
+    def _run_with_probe_checkout(self, clone: Path) -> object:
+        """Drive the real ``merge_ticket_pr``; the slug probe does a real local checkout.
+
+        ``_reconcile_slug_against_reviewed_sha`` is the cross-repo SHA-recovery
+        probe the ticket names. Its production body is API-only, but the
+        fallback the ticket worries about reads a PR's tree via a local
+        ``git checkout origin/<pr-branch>``. The patch models EXACTLY that — a
+        real checkout that detaches HEAD — so the head guard's restore is what
+        keeps the clone on ``main``. The patch returns the original slug so the
+        rest of the keystone proceeds unchanged.
+        """
+
+        def _probe_does_local_checkout(*, initial_slug: str, **_kwargs: object) -> str:
+            _git(clone, "checkout", f"origin/{_PR_BRANCH}")
+            return initial_slug
+
+        with (
+            patch("teatree.core.merge.execution.find_project_root", return_value=clone),
+            patch(
+                "teatree.core.merge.execution._reconcile_slug_against_reviewed_sha",
+                side_effect=_probe_does_local_checkout,
+            ),
+            patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_gh_ok),
+        ):
+            return merge_ticket_pr(clear=_clear(_ticket()), executing_loop_identity="merge-loop")
+
+    def test_clone_stays_on_main_after_probe_checkout(self) -> None:
+        clone = _make_clone(self.tmp_path)
+        assert _git(clone, "rev-parse", "--abbrev-ref", "HEAD") == "main"
+
+        outcome = self._run_with_probe_checkout(clone)
+
+        assert getattr(outcome, "merged_sha", "")
+        # The whole point of #2383: NOT detached, NOT left on the PR branch.
+        assert _git(clone, "rev-parse", "--abbrev-ref", "HEAD") == "main", (
+            "keystone merge left the caller's clone off main — the next "
+            "`git pull --ff-only origin/main` would abort (Not possible to fast-forward)"
+        )
+        # And ff-only sync — the operation #2383 said broke — now succeeds.
+        ff = subprocess.run(
+            ["git", "-C", str(clone), "merge", "--ff-only", "origin/main"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert ff.returncode == 0, f"ff-only sync aborted after merge: {ff.stderr}"
+
+    @pytest.fixture(autouse=True)
+    def _tmp(self, tmp_path: Path) -> None:
+        self.tmp_path = tmp_path
+
+
+class TestRestoreCallerBranchPrimitive(TestCase):
+    """The guard primitive restores a branch / detached SHA across a real checkout."""
+
+    @pytest.fixture(autouse=True)
+    def _tmp(self, tmp_path: Path) -> None:
+        self.tmp_path = tmp_path
+
+    def test_restores_branch_after_detaching_checkout(self) -> None:
+        clone = _make_clone(self.tmp_path)
+        assert _capture_head(str(clone)) == ("main", "")
+
+        with restore_caller_branch(str(clone)):
+            _git(clone, "checkout", f"origin/{_PR_BRANCH}")
+            assert _git(clone, "rev-parse", "--abbrev-ref", "HEAD") == "HEAD"  # detached
+
+        assert _git(clone, "rev-parse", "--abbrev-ref", "HEAD") == "main"
+
+    def test_restores_branch_even_when_body_raises(self) -> None:
+        clone = _make_clone(self.tmp_path)
+
+        def _checkout_then_fail() -> None:
+            with restore_caller_branch(str(clone)):
+                _git(clone, "checkout", f"origin/{_PR_BRANCH}")
+                msg = "merge refused"
+                raise RuntimeError(msg)
+
+        with pytest.raises(RuntimeError, match="merge refused"):
+            _checkout_then_fail()
+
+        assert _git(clone, "rev-parse", "--abbrev-ref", "HEAD") == "main"
+
+    def test_none_repo_is_a_noop(self) -> None:
+        with restore_caller_branch(None):
+            pass  # no repo to guard; must not raise
+
+    def test_already_on_captured_branch_leaves_head_untouched(self) -> None:
+        clone = _make_clone(self.tmp_path)
+        before = _git(clone, "rev-parse", "HEAD")
+        with restore_caller_branch(str(clone)):
+            pass
+        assert _git(clone, "rev-parse", "--abbrev-ref", "HEAD") == "main"
+        assert _git(clone, "rev-parse", "HEAD") == before


### PR DESCRIPTION
Closes #2383

## Root cause

The §17.4 keystone (`t3 teatree ticket clear` + `ticket merge`) runs from inside the primary clone — the orchestrator/loop drives the merge there, then ff-syncs `main`. The merge transport itself is API-only (`gh api`/`glab api`), so the **happy path never touches the working tree**. But the cross-repo SHA-recovery probe (`_reconcile_slug_against_reviewed_sha`), and any future fallback that has to read a PR's tree **locally**, can `git checkout` a branch in the cwd repo. When that checkout is not restored, the clone is left on a detached HEAD at the merged PR branch tip, and the next `git merge --ff-only origin/main` aborts with *Not possible to fast-forward*.

This matches the #2383 reflog exactly (`checkout: moving from main to origin/<pr-branch>` with `main` itself intact at the prior ff-sync), and explains the intermittency: only a merge whose path takes a local checkout exhibits it; an API-only merge does not.

## Fix — make the invariant structural

A new context manager `restore_caller_branch(repo)` (`core/merge/head_guard.py`) captures the clone's checked-out ref **before** the merge and restores it **after**, in a `finally` so it fires even when the merge raises (a refused merge that probed a branch locally must still leave the checkout untouched). `merge_ticket_pr` wraps the whole transition in it, anchored on the project root the keystone already resolves `origin` against. Whatever the merge path does to HEAD in between — today nothing, tomorrow a local probe checkout — the caller's checkout ends exactly as it began.

The guard is best-effort and crash-proof: a capture/restore failure never masks the merge result or a merge exception; it logs a recovery hint instead.

## Invariant

After `ticket clear` + `ticket merge`, the cwd repo's checked-out branch (and detached-HEAD SHA) is unchanged.

## Anti-vacuity RED evidence

The new test drives the **real** `merge_ticket_pr` against a real `tmp_path` clone checked out on `main`, makes the slug probe perform a genuine local checkout of the PR branch (the fallback the ticket names), and asserts the clone is still on `main` and ff-only sync succeeds. Only the GitHub merge API subprocess is stubbed; git itself is real.

With the restore disabled (`_restore_head` neutered), the merge-path test and the primitive tests go RED:

```
FAILED ...TestMergeKeystoneRestoresCallerBranch::test_clone_stays_on_main_after_probe_checkout
FAILED ...TestRestoreCallerBranchPrimitive::test_restores_branch_after_detaching_checkout
FAILED ...TestRestoreCallerBranchPrimitive::test_restores_branch_even_when_body_raises
    assert _git(clone, "rev-parse", "--abbrev-ref", "HEAD") == "main"
E   AssertionError: assert 'HEAD' == 'main'
3 failed, 2 passed
```

`assert 'HEAD' == 'main'` is the exact detached-HEAD symptom #2383 reported. With the restore restored: **5 passed**. Full merge-path module + `tests/teatree_quality/` + patch-target gate: green (146 passed).

## Architecture pre-check — #2383

**1. BLUEPRINT § alignment** — §17.4 (orchestrator-decides / loop-executes keystone). The change is a side-effect-containment guard on the loop-executes path; no §17.4 doctrine change.

**2. FSM phase boundaries** — n/a. No `Ticket.State` / `Worktree.State` transition added or moved; the guard wraps the existing IN_REVIEW → MERGED keystone.

**3. Extension-point contracts** — none. No `OverlayBase` / scanner / hook / `*Backend` Protocol surface touched. `merge_ticket_pr`'s signature and return are unchanged.

**4. Component boundaries** — `core/merge/head_guard.py` (the merge keystone's package). The guard is merge-path policy, not a CLI command or a backend transport.

**5. Dependency direction** — adds `core.merge → project` and `core.merge → utils.run`. `pr_slug_resolution` in the same package already imports `teatree.project` and `teatree.utils.git`, so no new package edge. `tach` + import-linter pass.

**6. Test surface** — `tests/teatree_core/test_merge_head_guard.py`: the integration test asserts the clone stays on `main` after a real probe checkout during the real keystone; the primitive tests assert restore-on-detach, restore-on-error, the `None`-repo no-op, and the already-on-branch no-op. RED proof recorded above.

**7. Resilience invariants** — the guard is itself the resilience fix (a HEAD mutation containment). idempotent (restoring to the already-current ref is a no-op); fail-safe (capture/restore failure logs and proceeds, never masks the merge); no external write added.

**8. Identity / key normalization** — n/a. No bare-vs-qualified identity introduced.

**9. Behavior preservation** — purely additive containment. No existing behavior removed; no privacy/security matcher narrowed; no must-block test inverted.
