### PR TITLE
fix(review): cold-review checkout lands on exact pushed head, never a stale tree

### DIFF
--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -78,6 +78,8 @@ git merge-base --is-ancestor origin/main HEAD || git merge origin/main --no-edit
 
 Run this **before** the cleanup checklist. Resolve any conflicts the same way you would on a normal merge — no rebase, no stash.
 
+**Cold-review checkout — fetch the exact pushed head, never `git worktree add <branch>` (Non-Negotiable).** A cold-review sub-agent reviewing a PR on a fresh checkout must NOT run `git worktree add <dir> origin/<branch>` (or the local-branch form). When that branch is already checked out in another worktree on the same machine, `worktree add` fails and the agent silently falls back to a pre-existing (stale) checkout — reviewing a tree one commit behind the pushed head and producing a spurious CHANGES_NEEDED (souliane/teatree#2132). Use the verify-or-fail helper `teatree.utils.review_checkout.add_review_worktree_at_head(repo, ref=<branch>, expected_sha=<pr-head-sha>)`: it fetches the ref into a guaranteed-unique temp dir, checks it out with `git worktree add --detach FETCH_HEAD` (cannot collide with a branch worktree), and asserts the materialised HEAD equals the PR head SHA — hard-failing with `StaleReviewCheckoutError` rather than ever falling back to a stale tree. Remove the returned worktree with `teatree.utils.git.worktree_remove` when the review is done.
+
 Cleanup checklist:
 
 - [ ] No code duplication introduced

--- a/src/teatree/utils/review_checkout.py
+++ b/src/teatree/utils/review_checkout.py
@@ -1,0 +1,67 @@
+"""Provision a cold-review worktree at the EXACT pushed head, or hard-fail (#2132).
+
+The cold-review bug: a reviewer told to ``git worktree add <dir> origin/<branch>``
+hit a collision when that branch was already checked out in another worktree on
+the same machine. The ``worktree add`` failed and the agent silently fell back to
+a pre-existing checkout one commit behind the pushed head, reviewing a stale tree
+and producing a spurious CHANGES_NEEDED.
+
+:func:`add_review_worktree_at_head` is the verify-or-fail seam the review path
+uses instead of a raw ``worktree add <branch>``: a detached ``FETCH_HEAD``
+checkout that cannot collide with a branch worktree, plus a head-SHA assertion
+that raises rather than ever returning a tree it could not prove is the reviewed
+head.
+"""
+
+import tempfile
+
+from teatree.utils.git import head_sha, worktree_remove
+from teatree.utils.run import run_checked
+
+
+class StaleReviewCheckoutError(RuntimeError):
+    """The review worktree's HEAD did not match the expected PR head SHA.
+
+    Raised by :func:`add_review_worktree_at_head` instead of silently falling
+    back to a possibly-stale tree — a cold review must run against the exact
+    pushed head or not at all (#2132).
+    """
+
+
+def add_review_worktree_at_head(
+    repo: str,
+    *,
+    ref: str,
+    expected_sha: str,
+    remote: str = "origin",
+    base_dir: str | None = None,
+) -> str:
+    """Materialise a review worktree at the EXACT pushed head, or hard-fail (#2132).
+
+    Forecloses both halves of the stale-checkout path:
+
+    1. It fetches ``ref`` from ``remote`` and checks it out with ``git worktree
+    add --detach <dir> FETCH_HEAD`` into a guaranteed-unique temp dir under
+    ``base_dir`` (default: the system temp dir). A detached ``FETCH_HEAD``
+    checkout binds no branch, so it can never collide with an existing branch
+    worktree — the failure mode that triggered the stale fallback disappears.
+    2. After the add, it asserts ``git rev-parse HEAD`` equals ``expected_sha``
+    and raises :class:`StaleReviewCheckoutError` on any divergence, removing the
+    bad worktree first. It never returns a tree it could not prove is the
+    reviewed head.
+
+    Returns the absolute path of the worktree to review. The caller removes it
+    with :func:`teatree.utils.git.worktree_remove` when the review is done.
+    """
+    run_checked(["git", "-C", repo, "fetch", remote, ref])
+    worktree_dir = tempfile.mkdtemp(prefix="t3-review-", dir=base_dir)
+    run_checked(["git", "-C", repo, "worktree", "add", "--detach", worktree_dir, "FETCH_HEAD"])
+    actual_sha = head_sha(worktree_dir)
+    if actual_sha != expected_sha:
+        worktree_remove(repo=repo, path=worktree_dir)
+        message = (
+            f"review checkout HEAD {actual_sha[:12]} != expected PR head {expected_sha[:12]} "
+            f"(ref {ref!r}); refusing to review a divergent tree"
+        )
+        raise StaleReviewCheckoutError(message)
+    return worktree_dir

--- a/tests/teatree_utils/test_review_checkout.py
+++ b/tests/teatree_utils/test_review_checkout.py
@@ -1,0 +1,119 @@
+"""Review-checkout helper lands on the EXACT pushed head, never a stale tree (#2132).
+
+The cold-review bug: a reviewer was told ``git worktree add <dir> origin/<branch>``;
+the branch was already checked out in another worktree, so ``worktree add`` failed
+and the agent silently fell back to a pre-existing (stale, one commit behind)
+checkout — producing a spurious CHANGES_NEEDED.
+
+:func:`add_review_worktree_at_head` forecloses both halves:
+
+1. it fetches the ref and adds a ``--detach FETCH_HEAD`` worktree in a
+guaranteed-unique temp dir, so it can never collide with a branch worktree;
+2. it asserts the materialised HEAD equals the expected PR head SHA and
+HARD-FAILS (raises :class:`StaleReviewCheckoutError`) on divergence — it never
+falls back to a stale tree.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from teatree.utils.git import head_sha
+from teatree.utils.review_checkout import StaleReviewCheckoutError, add_review_worktree_at_head
+from tests._git_repo import make_git_repo, run_git
+
+
+@pytest.fixture
+def origin_and_clone(tmp_path: Path) -> tuple[Path, Path]:
+    """A bare ``origin`` with a ``feature`` branch, plus a clone that tracks it."""
+    origin = make_git_repo(tmp_path / "origin.git", bare=True)
+
+    seed = make_git_repo(tmp_path / "seed")
+    (seed / "README.md").write_text("base\n")
+    run_git(seed, "add", "-A")
+    run_git(seed, "commit", "-q", "-m", "base")
+    run_git(seed, "remote", "add", "origin", str(origin))
+    run_git(seed, "push", "-q", "origin", "main")
+    run_git(seed, "checkout", "-q", "-b", "feature")
+    (seed / "README.md").write_text("first head\n")
+    run_git(seed, "commit", "-q", "-am", "feature first head")
+    run_git(seed, "push", "-q", "origin", "feature")
+
+    clone = make_git_repo(tmp_path / "clone", initial_commit=False)
+    run_git(clone, "remote", "add", "origin", str(origin))
+    run_git(clone, "fetch", "-q", "origin")
+    return origin, clone
+
+
+def _push_new_head(seed_repo: Path) -> str:
+    """Advance ``feature`` by one commit and push; return the new head SHA."""
+    (seed_repo / "README.md").write_text("real pushed head\n")
+    run_git(seed_repo, "commit", "-q", "-am", "feature real head")
+    run_git(seed_repo, "push", "-q", "origin", "feature")
+    return run_git(seed_repo, "rev-parse", "HEAD")
+
+
+class TestAddReviewWorktreeAtHead:
+    def test_lands_on_exact_head_when_branch_already_checked_out_elsewhere(
+        self, origin_and_clone: tuple[Path, Path], tmp_path: Path
+    ) -> None:
+        """The collision case: ``feature`` is checked out in another worktree.
+
+        A plain ``git worktree add <dir> feature`` would fail (branch already
+        checked out) and tempt a stale fallback. ``--detach FETCH_HEAD`` must
+        land on the exact pushed head regardless.
+        """
+        _origin, clone = origin_and_clone
+        seed = tmp_path / "seed"
+
+        # Another worktree already has ``feature`` checked out — the collision.
+        colliding = tmp_path / "colliding-wt"
+        run_git(clone, "worktree", "add", str(colliding), "-b", "feature", "origin/feature")
+
+        pushed_head = _push_new_head(seed)
+
+        review_root = tmp_path / "review-roots"
+        review_root.mkdir()
+        wt = add_review_worktree_at_head(str(clone), ref="feature", expected_sha=pushed_head, base_dir=str(review_root))
+
+        assert head_sha(wt) == pushed_head
+        assert (Path(wt) / "README.md").read_text() == "real pushed head\n"
+
+    def test_hard_fails_on_divergence_never_returns_stale_tree(
+        self, origin_and_clone: tuple[Path, Path], tmp_path: Path
+    ) -> None:
+        """A mismatch between the materialised HEAD and the expected SHA raises."""
+        _origin, clone = origin_and_clone
+        seed = tmp_path / "seed"
+        pushed_head = _push_new_head(seed)
+
+        wrong_expected = "0" * 40
+        review_root = tmp_path / "review-roots"
+        review_root.mkdir()
+
+        with pytest.raises(StaleReviewCheckoutError) as exc:
+            add_review_worktree_at_head(
+                str(clone), ref="feature", expected_sha=wrong_expected, base_dir=str(review_root)
+            )
+        assert pushed_head[:12] in str(exc.value)
+        assert wrong_expected[:12] in str(exc.value)
+
+    def test_unique_dir_per_call_no_collision_across_invocations(
+        self, origin_and_clone: tuple[Path, Path], tmp_path: Path
+    ) -> None:
+        """Two calls for the same ref produce two distinct worktree dirs."""
+        _origin, clone = origin_and_clone
+        seed = tmp_path / "seed"
+        pushed_head = _push_new_head(seed)
+
+        review_root = tmp_path / "review-roots"
+        review_root.mkdir()
+        first = add_review_worktree_at_head(
+            str(clone), ref="feature", expected_sha=pushed_head, base_dir=str(review_root)
+        )
+        second = add_review_worktree_at_head(
+            str(clone), ref="feature", expected_sha=pushed_head, base_dir=str(review_root)
+        )
+        assert first != second
+        assert head_sha(first) == pushed_head
+        assert head_sha(second) == pushed_head


### PR DESCRIPTION
## What

A cold-review sub-agent told to `git worktree add <dir> origin/<branch>` could review a **stale** checkout. When that branch was already checked out in another worktree on the same machine, the `worktree add` failed and the agent silently fell back to a pre-existing checkout one commit behind the pushed head — reviewing a stale tree and producing a spurious CHANGES_NEEDED on a clean PR (false-blocks a clean PR, wastes a review cycle).

## The fix

New cohesive module `teatree.utils.review_checkout` with `add_review_worktree_at_head(repo, ref, expected_sha)`, the verify-or-fail seam the review path now uses instead of a raw `worktree add <branch>`. It implements **both** safeguards from the ticket:

1. **Detached `FETCH_HEAD` checkout in a unique temp dir.** It fetches the ref and runs `git worktree add --detach <dir> FETCH_HEAD` under a `mkdtemp` dir. A detached `FETCH_HEAD` checkout binds no branch, so it can never collide with an existing branch worktree — the failure that triggered the stale fallback disappears.
2. **Head-SHA assertion + hard-fail.** After the add it asserts `git rev-parse HEAD == expected_sha` and raises `StaleReviewCheckoutError` (removing the bad worktree first) on any divergence. It never returns a tree it could not prove is the reviewed head — there is no silent fallback path.

The review skill prose now points at this helper instead of the collision-prone `git worktree add <branch>` form.

## Why a new module

`teatree.utils.git` is grandfathered over the module-health public-function cap (over-cap files may only shrink), so the helper lives in its own cohesive `review_checkout` module — same `utils` layer, no new dependency edges (`tach check` green).

## Architecture pre-check — #2132

**1. BLUEPRINT § alignment** — review/checkout provisioning; no BLUEPRINT invariant changes (a `utils` helper + skill-prose wiring).

**2. FSM phase boundaries** — n/a, no `Ticket.State` / `Worktree.State` transition.

**3. Extension-point contracts** — n/a, no `OverlayBase` / scanner / hook / Protocol surface touched.

**4. Component boundaries** — `src/teatree/utils/review_checkout.py` (a small cohesive module for the review-checkout concern; `git.py` is over-cap and may only shrink).

**5. Dependency direction** — imports only from sibling `utils` modules (`teatree.utils.git`, `teatree.utils.run`); no backwards edge. `tach check` green.

**6. Test surface** — `tests/teatree_utils/test_review_checkout.py`: collision-survival, divergence-hard-fail, and per-call uniqueness, each against a real `tmp_path` git repo with two worktrees.

**7. Resilience invariants** — verify-by-re-read: the helper re-reads `rev-parse HEAD` after the add and asserts it equals the expected SHA; idempotency: each call gets its own `mkdtemp` dir so repeated calls never collide; fail-closed: divergence raises rather than returning a stale tree.

**8. Identity and key normalization** — n/a, no bare/qualified identity forms.

**9. Behavior preservation / capability deletion** — purely additive; no existing behavior removed, no must-block test inverted.

## Anti-vacuity RED evidence

Both new regression tests were observed RED on pre-fix code (real `tmp_path` git repo, two worktrees):

- Reverting `--detach FETCH_HEAD` to the local-branch add form makes `test_lands_on_exact_head_when_branch_already_checked_out_elsewhere` go RED with `fatal: 'feature' is already used by worktree at <colliding-wt>` — the exact ticket collision.
- Removing the divergence hard-fail makes `test_hard_fails_on_divergence_never_returns_stale_tree` go RED with `DID NOT RAISE StaleReviewCheckoutError`.

Restoring the fix returns both to GREEN. Full suite: `tests/teatree_utils/` 37 passed, `tests/teatree_quality/` 55 passed; `ruff check` and `ty check` clean on touched files; `tach check` green.

## Open questions & assumptions

- The worktree-add guidance lived in skill prose, not code (no programmatic review-worktree creation existed yet). This PR adds the reusable helper + tests and wires the prose to call it, per the ticket's "if it's purely prose, still add the helper + tests and update the prose" path.

Closes #2132
