### PR TITLE
fix(loop): scope review-sweep auto-review-arm to our own PRs (#2210)

### DIFF
--- a/src/teatree/loop/scanner_factories.py
+++ b/src/teatree/loop/scanner_factories.py
@@ -309,6 +309,9 @@ def _pr_sweep_scanner_for(backend: OverlayBackends, *, slack_user_id: str) -> Pr
         solo_overlay=solo_overlay,
         auto_review_dispatch=auto_review_dispatch,
         review_dispatcher=AutoReviewTaskDispatcher() if auto_review_dispatch else None,
+        # #2210: scope the review-arm to the operator's own PRs — a colleague's
+        # open PR in a watched repo must never be auto-scheduled for review.
+        self_identities=backend.identities,
     )
 
 

--- a/src/teatree/loop/scanners/pr_sweep.py
+++ b/src/teatree/loop/scanners/pr_sweep.py
@@ -54,6 +54,7 @@ from teatree.loop.scanners.pr_sweep_decision import (
     classify_checks,
     find_actionable_clear,
     has_independent_cold_review,
+    pr_authored_by_self,
     pr_ticket_under_external_delivery,
     red_checks_are_all_repo_state,
 )
@@ -213,6 +214,11 @@ class PrSweepScanner:
     #: ``_evaluate_solo_overlay`` so it is never armed here in practice.
     auto_review_dispatch: bool = False
     review_dispatcher: "ReviewDispatcher | None" = None
+    #: #2210: the operator's own forge identities. The review-arm is scoped to
+    #: PRs authored by one of these — ``list_open_prs`` returns colleagues' PRs
+    #: too, and a colleague's PR must never be auto-scheduled for review. Empty
+    #: means no PR is confirmable as ours, so nothing is armed (fail closed).
+    self_identities: tuple[str, ...] = ()
     name: str = "pr_sweep"
 
     def scan(self) -> list[ScanSignal]:
@@ -416,17 +422,22 @@ class PrSweepScanner:
     def _enqueue_review(self, pr: PrSummary) -> bool:
         """Enqueue the claimable review task for *pr*; return whether one was armed.
 
-        Best-effort: a missing dispatcher, the flag being off, or any enqueue
-        error all degrade to ``False`` (the flag-level signal still fires) so a
-        DB hiccup never aborts the sweep.
+        Best-effort: a missing dispatcher, the flag being off, any enqueue error,
+        or a PR not authored by us all degrade to ``False`` (the flag-level signal
+        still fires) so a DB hiccup never aborts the sweep.
 
-        #2104: skips the review-arm when the PR's ticket is under active
-        EXTERNAL delivery — a hand-dispatched reviewer is already on it, so a
-        loop-armed review would collide. The same unit-level delivery-ownership
-        predicate ``schedule_planning`` consults; the loop's own FSM never
-        stamps the lease, so a genuinely unowned green PR still gets armed.
+        #2210: scoped to PRs the operator authored. ``list_open_prs`` returns
+        every open PR in a watched repo, colleagues' included; auto-scheduling a
+        colleague's PR for review wastes a dispatch and risks an unattended
+        review note on their work. A non-self / unconfirmable author is not armed.
+
+        #2104: skips the review-arm when the PR's ticket is under active EXTERNAL
+        delivery — a hand-dispatched reviewer is already on it. The loop's own FSM
+        never stamps that lease, so a genuinely unowned own green PR still arms.
         """
         if not self.auto_review_dispatch or self.review_dispatcher is None:
+            return False
+        if not pr_authored_by_self(author=pr.author, self_identities=self.self_identities):
             return False
         if pr_ticket_under_external_delivery(slug=pr.slug, pr_id=pr.number, pr_url=pr.url):
             return False

--- a/src/teatree/loop/scanners/pr_sweep_adapters.py
+++ b/src/teatree/loop/scanners/pr_sweep_adapters.py
@@ -33,6 +33,13 @@ class GhPrJson(TypedDict, total=False):
     statusCheckRollup: list[object]
     mergeable: str
     mergeStateStatus: str
+    author: "GhAuthorJson"
+
+
+class GhAuthorJson(TypedDict, total=False):
+    """Shape of the ``GhPrJson.author`` block — the PR author identity."""
+
+    login: str
 
 
 class GhReviewJson(TypedDict, total=False):
@@ -53,6 +60,14 @@ class GhCheckJson(TypedDict, total=False):
 
 def _as_str(value: object) -> str:
     return value if isinstance(value, str) else ""
+
+
+def _author_login(raw: GhPrJson) -> str:
+    """Read the PR author's login from the ``gh pr list --json author`` block."""
+    author = raw.get("author")
+    if isinstance(author, dict):
+        return _as_str(author.get("login"))
+    return ""
 
 
 def _decode_pr(*, slug: str, raw: GhPrJson) -> PrSummary:
@@ -77,6 +92,7 @@ def _decode_pr(*, slug: str, raw: GhPrJson) -> PrSummary:
         title=title,
         is_conflicted=_gh_is_conflicted(raw),
         behind_main=_gh_is_behind_main(raw),
+        author=_author_login(raw),
     )
 
 
@@ -160,7 +176,7 @@ class GhPrApiClient:
             "--limit",
             "100",
             "--json",
-            "number,headRefOid,isDraft,url,title,reviews,statusCheckRollup,mergeable,mergeStateStatus",
+            "number,headRefOid,isDraft,url,title,reviews,statusCheckRollup,mergeable,mergeStateStatus,author",
         ]
         rc, out, err = self._run_gh(argv)
         if rc == _GH_NOT_INSTALLED_RC:

--- a/src/teatree/loop/scanners/pr_sweep_decision.py
+++ b/src/teatree/loop/scanners/pr_sweep_decision.py
@@ -8,13 +8,34 @@ orchestration and under the module-health LOC cap (same split rationale as
 ``pr_sweep_adapters``).
 """
 
+from collections.abc import Iterable
+
 from teatree.core.models.merge_clear import MergeClear
+from teatree.core.review_candidate import author_is_self
 from teatree.loop.scanners.pr_sweep_types import (
     REPO_STATE_CHECK_NAMES,
     REQUIRED_CHECK_NAME,
     UV_AUDIT_CHECK_NAME,
     CheckResult,
 )
+
+
+def pr_authored_by_self(*, author: str, self_identities: Iterable[str]) -> bool:
+    """True iff *author* is one of the operator's own forge identities (#2210).
+
+    The loop's review-sweep walks every open PR in a watched repo via
+    ``list_open_prs`` — colleagues' PRs included. Only the operator's own PRs
+    should be auto-scheduled for a cold review; a colleague's PR is theirs to
+    review (auto-scheduling it wastes a dispatch and risks an unattended
+    review note on their work). Reuses the single self-author signal
+    :func:`teatree.core.review_candidate.author_is_self` — an empty *author*
+    or an empty identity set never matches, so an unconfirmable author fails
+    closed (no arm) rather than being treated as ours.
+    """
+    identities = tuple(self_identities)
+    if not author or not identities:
+        return False
+    return author_is_self(author, current_user=identities[0], self_identities=identities)
 
 
 def classify_checks(checks: tuple[CheckResult, ...]) -> str:

--- a/src/teatree/loop/scanners/pr_sweep_types.py
+++ b/src/teatree/loop/scanners/pr_sweep_types.py
@@ -62,7 +62,13 @@ class CheckResult:
 
 @dataclass(frozen=True, slots=True)
 class PrSummary:
-    """Decoded subset of a PR's ``gh`` payload the sweep needs."""
+    """Decoded subset of a PR's ``gh`` payload the sweep needs.
+
+    ``author`` is the PR author's forge login (GitHub ``author.login``); it
+    scopes the loop's auto-review-arm to PRs the user authored so a
+    colleague's open PR in a watched repo is never auto-scheduled for review
+    (#2210). Empty when the payload omits the author — treated as "not ours".
+    """
 
     slug: str
     number: int
@@ -74,6 +80,7 @@ class PrSummary:
     title: str = ""
     is_conflicted: bool = False
     behind_main: bool = False
+    author: str = ""
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/teatree_loop/test_autonomy_loop_wiring.py
+++ b/tests/teatree_loop/test_autonomy_loop_wiring.py
@@ -37,7 +37,12 @@ def _stage_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, toml: str) ->
     monkeypatch.setattr("importlib.metadata.entry_points", lambda **_kw: [])
 
 
-def _backend(*, name: str, repos: tuple[str, ...] = ("acme/repo",)) -> OverlayBackends:
+def _backend(
+    *,
+    name: str,
+    repos: tuple[str, ...] = ("acme/repo",),
+    identities: tuple[str, ...] = (),
+) -> OverlayBackends:
     config = MagicMock(spec=OverlayConfig)
     config.get_github_token = lambda: ""
     metadata = MagicMock(spec=OverlayMetadata)
@@ -51,6 +56,7 @@ def _backend(*, name: str, repos: tuple[str, ...] = ("acme/repo",)) -> OverlayBa
         messaging=None,
         ready_labels=(),
         overlay=overlay,
+        identities=identities,
     )
 
 
@@ -212,3 +218,24 @@ class TestPrSweepSoloOverlayGate:
         assert scanner.solo_overlay is True
         assert scanner.auto_review_dispatch is False
         assert scanner.review_dispatcher is None
+
+    def test_self_identities_threaded_from_backend(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """#2210: the operator's identity set is wired so the review-arm is own-PR scoped.
+
+        ``backend.identities`` (the multi-alias self set) must reach the
+        scanner — without it ``pr_authored_by_self`` has no identity set to
+        match against and (fail-closed) would arm nothing, defeating #68.
+        """
+        _stage_config(
+            tmp_path,
+            monkeypatch,
+            '[teatree]\n[overlays.t3-teatree]\nautonomy = "full"\n',
+        )
+        backend = _backend(name="t3-teatree", identities=("souliane", "souliane-alt"))
+        scanner = _pr_sweep_scanner_for(backend, slack_user_id="")
+        assert scanner is not None
+        assert scanner.self_identities == ("souliane", "souliane-alt")

--- a/tests/teatree_loop/test_pr_sweep_scanner.py
+++ b/tests/teatree_loop/test_pr_sweep_scanner.py
@@ -42,6 +42,8 @@ SLUG = "souliane/teatree"
 HEAD = "feedfacecafebabe1234567890abcdef12345678"
 STALE = "deadbeef00000000000000000000000000000000"
 MAIN_SHA = "abcdef1234567890abcdef1234567890abcdef12"
+SELF_LOGIN = "souliane"
+COLLEAGUE_LOGIN = "a-teammate"
 
 
 def _green_required() -> CheckResult:
@@ -81,6 +83,7 @@ def _open_pr(  # noqa: PLR0913 — test helper: each kwarg maps 1:1 to a PrSumma
     changes_requested: bool = False,
     checks: tuple[CheckResult, ...] = (),
     behind_main: bool = False,
+    author: str = SELF_LOGIN,
 ) -> PrSummary:
     return PrSummary(
         slug=SLUG,
@@ -92,6 +95,7 @@ def _open_pr(  # noqa: PLR0913 — test helper: each kwarg maps 1:1 to a PrSumma
         url=f"https://github.com/{SLUG}/pull/{pr_id}",
         title=f"PR {pr_id}",
         behind_main=behind_main,
+        author=author,
     )
 
 
@@ -167,6 +171,7 @@ def _scanner(  # noqa: PLR0913 — test helper: each kwarg maps 1:1 to a PrSweep
     solo_overlay: bool = False,
     auto_review_dispatch: bool = False,
     dispatcher: FakeReviewDispatcher | None = None,
+    self_identities: tuple[str, ...] = (SELF_LOGIN,),
 ) -> tuple[PrSweepScanner, NullMergeNotifier]:
     notifier = notifier or NullMergeNotifier()
     return (
@@ -179,6 +184,7 @@ def _scanner(  # noqa: PLR0913 — test helper: each kwarg maps 1:1 to a PrSweep
             solo_overlay=solo_overlay,
             auto_review_dispatch=auto_review_dispatch,
             review_dispatcher=dispatcher,
+            self_identities=self_identities,
         ),
         notifier,
     )
@@ -860,6 +866,136 @@ class TestAutoReviewDispatch:
 
         assert signals[0].kind == "pr_sweep.flag_no_review"
         assert signals[0].payload["review_dispatched"] is False
+
+
+class TestReviewArmScopedToOwnPrs:
+    """The loop review-sweep auto-arms a review ONLY for PRs the operator authored (#2210).
+
+    ``list_open_prs`` returns every open PR in a watched repo — colleagues'
+    included. Before #2210 the solo-overlay ``flag_no_review`` path armed a
+    reviewing task for ANY green+clean PR with no CLEAR, so a teammate's MR
+    in a customer repo was auto-scheduled for a cold review (wasted dispatch +
+    an unattended review note on their work). The arm is now gated on
+    ``author_is_self``: a colleague's PR is excluded, the operator's own PR is
+    still armed.
+    """
+
+    def test_colleague_pr_is_not_armed_for_review(self) -> None:
+        # RED before the fix: the colleague's green+clean PR with no CLEAR flowed
+        # through _evaluate_solo_overlay -> _flag_no_review -> _enqueue_review and
+        # armed a reviewing task. The flag-level signal still fires (operator
+        # triage), but no review is dispatched on the teammate's PR.
+        dispatcher = FakeReviewDispatcher()
+        api = FakePrApiClient(prs_by_slug={SLUG: [_open_pr(author=COLLEAGUE_LOGIN)]})
+        scanner, _ = _scanner(
+            api=api,
+            keystone=FakeKeystone(),
+            solo_overlay=True,
+            auto_review_dispatch=True,
+            dispatcher=dispatcher,
+            self_identities=(SELF_LOGIN,),
+        )
+
+        signals = scanner.scan()
+
+        assert dispatcher.calls == []
+        assert signals[0].kind == "pr_sweep.flag_no_review"
+        assert signals[0].payload["review_dispatched"] is False
+
+    def test_own_pr_is_still_armed_for_review(self) -> None:
+        # The symmetric must-still-fire: a PR authored by the operator (default
+        # author=SELF_LOGIN) is armed exactly as before.
+        dispatcher = FakeReviewDispatcher()
+        api = FakePrApiClient(prs_by_slug={SLUG: [_open_pr(author=SELF_LOGIN)]})
+        scanner, _ = _scanner(
+            api=api,
+            keystone=FakeKeystone(),
+            solo_overlay=True,
+            auto_review_dispatch=True,
+            dispatcher=dispatcher,
+            self_identities=(SELF_LOGIN,),
+        )
+
+        signals = scanner.scan()
+
+        assert dispatcher.calls == [(SLUG, 6230, HEAD, f"https://github.com/{SLUG}/pull/6230", "teatree")]
+        assert signals[0].kind == "pr_sweep.flag_no_review"
+        assert signals[0].payload["review_dispatched"] is True
+
+    def test_own_pr_under_secondary_alias_is_armed(self) -> None:
+        # Multi-identity: a PR authored under a secondary github login is still
+        # the operator's own work and is armed (reuses the full identity set).
+        dispatcher = FakeReviewDispatcher()
+        api = FakePrApiClient(prs_by_slug={SLUG: [_open_pr(author="souliane-alt")]})
+        scanner, _ = _scanner(
+            api=api,
+            keystone=FakeKeystone(),
+            solo_overlay=True,
+            auto_review_dispatch=True,
+            dispatcher=dispatcher,
+            self_identities=(SELF_LOGIN, "souliane-alt"),
+        )
+
+        signals = scanner.scan()
+
+        assert dispatcher.calls == [(SLUG, 6230, HEAD, f"https://github.com/{SLUG}/pull/6230", "teatree")]
+        assert signals[0].payload["review_dispatched"] is True
+
+    def test_unknown_author_is_not_armed(self) -> None:
+        # Fail closed: a PR whose author the payload omitted is not provably ours,
+        # so it is not auto-scheduled for review.
+        dispatcher = FakeReviewDispatcher()
+        api = FakePrApiClient(prs_by_slug={SLUG: [_open_pr(author="")]})
+        scanner, _ = _scanner(
+            api=api,
+            keystone=FakeKeystone(),
+            solo_overlay=True,
+            auto_review_dispatch=True,
+            dispatcher=dispatcher,
+            self_identities=(SELF_LOGIN,),
+        )
+
+        signals = scanner.scan()
+
+        assert dispatcher.calls == []
+        assert signals[0].payload["review_dispatched"] is False
+
+    def test_colleague_pr_with_recorded_verdict_still_merges(self) -> None:
+        # The author scope gates only the review-ARM, not the merge path. A
+        # colleague PR with a recorded independent cold-review at head still
+        # merges (the verdict is authoritative); the arm gate never runs.
+        _record_cold_review()
+        dispatcher = FakeReviewDispatcher()
+        api = FakePrApiClient(prs_by_slug={SLUG: [_open_pr(author=COLLEAGUE_LOGIN)]})
+        scanner, _ = _scanner(
+            api=api,
+            keystone=FakeKeystone(),
+            solo_overlay=True,
+            auto_review_dispatch=True,
+            dispatcher=dispatcher,
+            self_identities=(SELF_LOGIN,),
+        )
+
+        signals = scanner.scan()
+
+        assert dispatcher.calls == []
+        assert signals[0].kind == "pr_sweep.merged"
+
+
+class TestDecodeAuthor:
+    """``_decode_pr`` reads the PR author login from ``gh pr list --json author`` (#2210)."""
+
+    def test_author_login_decoded(self) -> None:
+        pr = _decode_pr(slug=SLUG, raw={"number": 1, "headRefOid": HEAD, "author": {"login": "souliane"}})
+        assert pr.author == "souliane"
+
+    def test_missing_author_decodes_to_empty(self) -> None:
+        pr = _decode_pr(slug=SLUG, raw={"number": 1, "headRefOid": HEAD})
+        assert pr.author == ""
+
+    def test_malformed_author_decodes_to_empty(self) -> None:
+        pr = _decode_pr(slug=SLUG, raw={"number": 1, "headRefOid": HEAD, "author": "not-a-dict"})
+        assert pr.author == ""
 
 
 class TestConflictFlag:


### PR DESCRIPTION
## Architecture pre-check — #2210

**1. BLUEPRINT § alignment** — §5.6 Loop Topology (scanner → dispatch → persistence) and the Three-Orthogonal-Repo-Axes rule (`/t3:rules`): the *collaboration* axis (`author_is_self`) decides self-vs-colleague. This change applies that axis to the loop review-sweep's auto-review-arm. No BLUEPRINT contradiction; no new section needed.

**2. FSM phase boundaries** — n/a. No `Ticket.State` / `Worktree.State` transition is added or moved. The change gates whether a `reviewing`-phase `Task` is *created*, upstream of any transition.

**3. Extension-point contracts** — touches `PrSweepScanner` (one consumer: `_pr_sweep_scanner_for` in `scanner_factories.py`) and `PrSummary` (decoded in `pr_sweep_adapters._decode_pr`; constructed in tests). No `OverlayBase` / hook / `*Backend` Protocol surface changed.

**4. Component boundaries** — logic in `src/teatree/loop/scanners/` (scanner + leaf types + decision predicates + I/O adapters), wiring in `scanner_factories.py`. No straddling.

**5. Dependency direction** — `pr_sweep_decision` now imports `teatree.core.review_candidate.author_is_self` (loop → core, the allowed direction). No backwards edge. `uv run tach check` clean.

**6. Test surface** — `TestReviewArmScopedToOwnPrs` (colleague excluded, own armed, secondary alias armed, unknown-author excluded, colleague-with-verdict still merges), `TestDecodeAuthor` (login decode / missing / malformed), and a factory wiring test (`self_identities` threaded from `backend.identities`).

**7. Resilience invariants** — no new external write. The arm path is best-effort (a missing dispatcher / enqueue error degrades to "not armed"); idempotency is unchanged (`AutoReviewDispatch` dedups per head). verify-by-re-read / fallback / heartbeat n/a (no egress added).

**8. Identity and key normalization** — author identity matched via the single source-of-truth `author_is_self` against the full self-identity set (no `split`/`strip` to force a match). An empty/unconfirmable author never matches (conservative).

**9. Behavior preservation / capability deletion** — additive. The merge path, the conflict flag, the CLEAR path, and the external-delivery suppression are untouched. The only behavior *narrowed* is the auto-review-**arm**, which is the bug: it previously armed any author's PR. No must-block test inverted; no privacy/security matcher narrowed.

---

## The bug

The loop PR-sweep (`PrSweepScanner`) walks every open PR in a watched repo via `list_open_prs` — colleagues' PRs included. On a full-autonomy solo overlay the `flag_no_review` path armed a claimable `reviewing` task for any green-and-clean PR with no `MergeClear`, so a teammate's MR in a customer repo was auto-scheduled for a cold review. That wasted a dispatch, risked an unattended review note on a colleague's work, and kept the Stop-hook self-pump non-idle (forcing manual cancels each tick).

## The fix

The review-arm is now gated on author: a PR is auto-scheduled for review only when its author is one of the operator's own forge identities.

- `PrSummary` carries the decoded author login (`author.login` from `gh pr list --json author`).
- `pr_sweep_decision.pr_authored_by_self` reuses the single self-author signal `teatree.core.review_candidate.author_is_self` — no new heuristic.
- `PrSweepScanner._enqueue_review` skips the arm when the PR is not authored by us (placed before the existing external-delivery suppression).
- The scanner is wired with `backend.identities` (the multi-alias self set) at the factory.

Scope is the review-**arm** only. The merge path is untouched, so a colleague's PR with a recorded independent cold-review at head still merges. An empty or unconfirmable author is not armed (conservative).

## Anti-vacuity (RED on pre-fix code)

With the author guard reverted in `_enqueue_review`, the new must-not-arm tests fail (the pre-fix code arms the colleague / unknown-author PR):

```
FAILED TestReviewArmScopedToOwnPrs::test_colleague_pr_is_not_armed_for_review
  AssertionError: assert [('souliane/teatree', 6230, ...)] == []
FAILED TestReviewArmScopedToOwnPrs::test_unknown_author_is_not_armed
  AssertionError: assert [('souliane/teatree', 6230, ...)] == []
```

The symmetric must-still-fire (own PR, including a secondary alias) stays armed. With the fix restored, all 135 tests across the changed files + the tree-wide quality gates (`tests/teatree_quality/`) pass; `uv run ruff check` and `uv run ty check` are clean on the touched files.

Closes #2210
