### PR TITLE
refactor(pricing): single source for Anthropic cache multipliers

### DIFF
--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -31,6 +31,7 @@ graph TD
     teatree.skill_support --> teatree.project
     teatree.core --> teatree.types
     teatree.core --> teatree.paths
+    teatree.core --> teatree.pricing
     teatree.core --> teatree.project
     teatree.core --> teatree.config
     teatree.core --> teatree.utils
@@ -115,6 +116,7 @@ graph TD
     teatree.cli.eval --> teatree.claude_sessions
     teatree.eval --> teatree.core
     teatree.eval --> teatree.hooks
+    teatree.eval --> teatree.pricing
     teatree.eval --> teatree.utils
     teatree.eval --> teatree.trigger_parser
     teatree.eval --> teatree.claude_sessions
@@ -173,6 +175,7 @@ graph TD
     teatree.quality --> teatree.utils
     teatree.paths
     teatree.types
+    teatree.pricing
     teatree.templates
     teatree.claude_sessions
     teatree.overlay_init

--- a/src/teatree/core/cost.py
+++ b/src/teatree/core/cost.py
@@ -18,12 +18,10 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 
+from teatree.pricing import CACHE_READ_MULTIPLIER, CACHE_WRITE_MULTIPLIER
+
 _PER_MTOK = 1_000_000
 _DECEMBER = 12
-
-# Cache multipliers over the model's input price (Anthropic published rates).
-_CACHE_READ_MULTIPLIER = 0.1
-_CACHE_WRITE_MULTIPLIER = 1.25
 
 
 @dataclass(frozen=True, slots=True)
@@ -35,11 +33,11 @@ class ModelPrice:
 
     @property
     def cache_read_per_mtok(self) -> float:
-        return self.input_per_mtok * _CACHE_READ_MULTIPLIER
+        return self.input_per_mtok * CACHE_READ_MULTIPLIER
 
     @property
     def cache_write_per_mtok(self) -> float:
-        return self.input_per_mtok * _CACHE_WRITE_MULTIPLIER
+        return self.input_per_mtok * CACHE_WRITE_MULTIPLIER
 
     def cost(
         self,

--- a/src/teatree/eval/cost_fit.py
+++ b/src/teatree/eval/cost_fit.py
@@ -31,6 +31,7 @@ import dataclasses
 import math
 
 from teatree.eval.models import TokenUsage
+from teatree.pricing import CACHE_READ_MULTIPLIER
 
 #: Fewer clean cells than this and the 2-parameter fit is under-determined /
 #: over-fit — degrade to ``None`` rather than report a fabricated rate.
@@ -41,10 +42,6 @@ _MIN_CLEAN_CELLS = 4
 #: the fit is numerically meaningless. This happens on small slices and when
 #: output variance is tiny. Degrade to ``None``.
 _MAX_CONDITION_NUMBER = 1e8
-
-#: Anthropic's fixed cache-read multiplier — the rate the warm-equivalent prices
-#: ALL cacheable input at (both reads and the would-be-cold writes).
-_CACHE_READ_MULTIPLIER = 0.10
 
 
 @dataclasses.dataclass(frozen=True)
@@ -108,7 +105,7 @@ def warm_equivalent_cost(cells: list[CostCell]) -> float | None:
 
 def _warm_input(usage: TokenUsage) -> float:
     """Cacheable input priced as if fully warm: ``input + 0.10*(cache_creation + cache_read)``."""
-    return usage.input + _CACHE_READ_MULTIPLIER * (usage.cache_creation + usage.cache_read)
+    return usage.input + CACHE_READ_MULTIPLIER * (usage.cache_creation + usage.cache_read)
 
 
 def _condition_number(s11: float, s12: float, s22: float) -> float:

--- a/src/teatree/eval/models.py
+++ b/src/teatree/eval/models.py
@@ -4,6 +4,8 @@ import dataclasses
 from pathlib import Path
 from typing import Any
 
+from teatree.pricing import CACHE_READ_MULTIPLIER, CACHE_WRITE_MULTIPLIER
+
 #: Terminal reasons that mark a cap-truncated / aborted run — a run whose billed
 #: cost does NOT match the clean billed identity (it paid a partial-or-cap cost).
 #: A clean completion (``success``/``end_turn``/empty) is NOT in this set. The
@@ -137,14 +139,6 @@ class EvalToolCall:
     turn: int
 
 
-#: Anthropic's fixed cache-pricing multipliers on input tokens, relative to the
-#: model's base input rate: uncached input bills 1.00x, a 5-minute cache *write*
-#: bills 1.25x, and a cache *read* bills 0.10x. They are a property of the API,
-#: not of any model, so they are constants here — see :class:`TokenUsage`.
-_CACHE_WRITE_MULTIPLIER = 1.25
-_CACHE_READ_MULTIPLIER = 0.10
-
-
 @dataclasses.dataclass(frozen=True)
 class TokenUsage:
     """One run's token usage, split by cache class, with billed-input derivations.
@@ -185,7 +179,7 @@ class TokenUsage:
     @property
     def effective_billed_input(self) -> float:
         """The API's billed-input regressor: ``input + 1.25*cache_creation + 0.10*cache_read``."""
-        return self.input + _CACHE_WRITE_MULTIPLIER * self.cache_creation + _CACHE_READ_MULTIPLIER * self.cache_read
+        return self.input + CACHE_WRITE_MULTIPLIER * self.cache_creation + CACHE_READ_MULTIPLIER * self.cache_read
 
     def __add__(self, other: "TokenUsage") -> "TokenUsage":
         return TokenUsage(

--- a/src/teatree/pricing.py
+++ b/src/teatree/pricing.py
@@ -1,0 +1,14 @@
+"""Anthropic fixed cache-pricing multipliers — the single source of truth.
+
+The cache multipliers are a property of the Anthropic API, not of any model:
+relative to a model's base input rate, uncached input bills 1.00x, a cache
+*read* bills 0.10x, and a 5-minute cache *write* bills 1.25x. Every cost path
+(per-attempt SDK cost, the benchmark warm-equivalent fit, the billed-input
+regressor) imports these constants from here so the rates can never drift.
+"""
+
+#: A cache *read* bills 0.1x the model's base input rate.
+CACHE_READ_MULTIPLIER = 0.1
+
+#: A 5-minute cache *write* bills 1.25x the model's base input rate.
+CACHE_WRITE_MULTIPLIER = 1.25

--- a/tach.toml
+++ b/tach.toml
@@ -54,6 +54,11 @@ layer = "foundation"
 depends_on = []
 
 [[modules]]
+path = "teatree.pricing"
+layer = "foundation"
+depends_on = []
+
+[[modules]]
 path = "teatree.teams"
 layer = "domain"
 depends_on = ["teatree.core", "teatree.config", "teatree.agents", "teatree.skill_support", "teatree.utils"]
@@ -134,6 +139,7 @@ layer = "domain"
 depends_on = [
   "teatree.types",
   "teatree.paths",
+  "teatree.pricing",
   "teatree.project",
   "teatree.config",
   "teatree.utils",
@@ -279,7 +285,7 @@ depends_on = []
 [[modules]]
 path = "teatree.eval"
 layer = "integration"
-depends_on = ["teatree.core", "teatree.hooks", "teatree.utils", "teatree.trigger_parser", "teatree.claude_sessions"]
+depends_on = ["teatree.core", "teatree.hooks", "teatree.pricing", "teatree.utils", "teatree.trigger_parser", "teatree.claude_sessions"]
 
 [[modules]]
 path = "teatree.core.management"

--- a/tests/test_pricing_ssot.py
+++ b/tests/test_pricing_ssot.py
@@ -1,0 +1,42 @@
+"""Conformance: the Anthropic cache-pricing multipliers live in exactly one module.
+
+The read (0.1x) and write (1.25x) cache multipliers are a fixed property of the
+Anthropic API, not of any model. They were once defined independently in three
+places (``core.cost``, ``eval.cost_fit``, ``eval.models``); the SSOT is
+:mod:`teatree.pricing`. This gate greps ``src/teatree`` for any other definition
+so a fourth copy can never re-accrete.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from teatree.pricing import CACHE_READ_MULTIPLIER, CACHE_WRITE_MULTIPLIER
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "teatree"
+_SSOT = _SRC / "pricing.py"
+
+#: An assignment of a name that ends in ``CACHE_READ_MULTIPLIER`` or
+#: ``CACHE_WRITE_MULTIPLIER`` (with or without a leading underscore prefix).
+_DEFINITION = re.compile(r"^_?CACHE_(?:READ|WRITE)_MULTIPLIER\s*=", re.MULTILINE)
+
+
+def _definition_sites() -> list[Path]:
+    return [path for path in _SRC.rglob("*.py") if _DEFINITION.search(path.read_text(encoding="utf-8"))]
+
+
+class TestSingleSource:
+    def test_multipliers_defined_in_exactly_one_module(self) -> None:
+        sites = _definition_sites()
+        assert sites == [_SSOT], "cache multipliers must be defined only in teatree.pricing; found " + ", ".join(
+            str(p.relative_to(_SRC.parents[1])) for p in sites
+        )
+
+
+class TestValues:
+    def test_read_multiplier_is_one_tenth(self) -> None:
+        assert pytest.approx(0.1) == CACHE_READ_MULTIPLIER
+
+    def test_write_multiplier_is_one_and_a_quarter(self) -> None:
+        assert pytest.approx(1.25) == CACHE_WRITE_MULTIPLIER


### PR DESCRIPTION
## The debt

Arch-review finding #9: the Anthropic cache-pricing multipliers (cache read 0.1x, cache write 1.25x) were triplicated. Three modules each defined their own private constants:

- `src/teatree/core/cost.py` — `_CACHE_READ_MULTIPLIER` / `_CACHE_WRITE_MULTIPLIER`
- `src/teatree/eval/cost_fit.py` — `_CACHE_READ_MULTIPLIER` (read only)
- `src/teatree/eval/models.py` — `_CACHE_READ_MULTIPLIER` / `_CACHE_WRITE_MULTIPLIER`

The multipliers are a fixed property of the Anthropic API, not of any model, so three independent copies could drift apart unnoticed.

## The fix

Created one foundation leaf module `src/teatree/pricing.py` exporting `CACHE_READ_MULTIPLIER = 0.1` and `CACHE_WRITE_MULTIPLIER = 1.25` (docstring: Anthropic fixed cache multipliers), imported it in all three consumers, and deleted their local copies. Values are byte-identical (`cost_fit`'s `0.10` == `0.1`), so this is a pure SSOT extraction with zero value change.

`teatree.pricing` is declared as a `foundation`-layer module with no dependencies in `tach.toml`, and added to the `depends_on` of `teatree.core` and `teatree.eval`. `docs/dependency-graph.md` was regenerated by the pre-commit hook.

## Anti-vacuity / RED evidence

Added `tests/test_pricing_ssot.py` with a conformance test that greps `src/teatree` and asserts the cache multipliers are defined in **exactly one** module.

- **RED before extraction:** the test imports from `teatree.pricing`, which did not exist on the pre-fix tree, so it failed at collection with `ModuleNotFoundError: No module named 'teatree.pricing'`.
- **The uniqueness assertion is anti-vacuous:** on the pre-fix tree the definition grep found **5 assignment lines across 3 modules** (`core/cost.py:25,26`, `eval/models.py:144,145`, `eval/cost_fit.py:47`). Re-injecting any stray definition makes the gate see 2 sites again — proven by a simulated re-accretion before push. Post-fix it collapses to the single `pricing.py` site.

## Architecture pre-check

**1. BLUEPRINT § alignment** — Module Dependency Graph / tach-enforced DAG. New foundation leaf, no backwards edge. `docs/dependency-graph.md` regenerated.

**2. FSM phase boundaries** — n/a, no `Ticket.State` / `Worktree.State` transition.

**3. Extension-point contracts** — n/a, no `OverlayBase` / scanner / hook / `*Backend` Protocol surface touched.

**4. Component boundaries** — new module is a `foundation`-layer constants leaf; `teatree.core` (domain) and `teatree.eval` (integration) consume it. No straddling.

**5. Dependency direction** — `teatree.pricing` has zero dependencies; the new edges (`core -> pricing`, `eval -> pricing`) point from higher layers down to foundation. `uv run tach check` -> `All modules validated!`.

**6. Test surface** — `tests/test_pricing_ssot.py::TestSingleSource` (multipliers defined in exactly one module) + `TestValues` (the two values). `test_tach_modules_declared_hook` would have flagged the new single-file module had it been left undeclared.

**7. Resilience invariants** — n/a, no external write.

**8. Identity and key normalization** — n/a.

**9. Behavior preservation / capability deletion** — replaces three local constant definitions with imports of byte-identical values; no behavior dropped. The cost / model-tiering / eval-cost test suites pass unchanged (339 eval+core tests, 69 cost-focused tests).

## Verification

All run on the worktree before push:

- `tests/test_pricing_ssot.py` + cost/cost-fit/model-tiering/cost-reporting suites — green
- `uv run pytest tests/teatree_quality/` (module-health, test-path-mirror, test-shape) — 55 passed
- `uv run python scripts/hooks/check_module_health.py --from-ref origin/main` — exit 0
- `uv run tach check` — all modules validated
- `uv run ruff check` + `uv run ty check` on touched files — clean
- `tests/teatree_eval/` + cost tests — 339 passed
