### PR TITLE
refactor(notify): make cross-package notify helpers public

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -5370,12 +5370,16 @@ Usage: t3 teatree tasks claim [OPTIONS]
 ```
 Usage: t3 teatree tasks complete [OPTIONS] TASK_ID
 
- Mark a claimed task COMPLETED for work finished out-of-band (#1031).
+ Mark a claimed or failed task COMPLETED for work finished out-of-band.
 
  Drives the Task FSM ``claimed → completed`` (releasing the lease and
  auto-advancing the ticket). Idempotent: completing an already-completed
- task is a no-op with exit 0. Rejects a task in any non-``claimed`` state
- (``pending``, ``failed``) with a clear error.
+ task is a no-op with exit 0.
+
+ A ``failed`` task whose work later landed out-of-band is resolved the same
+ way (``failed → completed``), but ONLY with a mandatory evidence ``--note``
+ — the pointer to where that work landed (#1949). Without it there is no
+ record of why a failed task was marked done. A ``pending`` task is rejected.
 
  Fail-closed evidence gate (#1280): when ``--note`` ASSERTS an external
  outcome (merged / posted / shipped / deployed) it must also carry a

--- a/src/teatree/cli/review/live_approval.py
+++ b/src/teatree/cli/review/live_approval.py
@@ -326,9 +326,9 @@ def register(review_app: typer.Typer) -> None:
             LivePostApprovalError,
             canonical_mr_scope,
         )
-        from teatree.core.notify import _resolve_user_id  # noqa: PLC0415
+        from teatree.core.notify import resolve_user_id  # noqa: PLC0415
 
-        user_id = _resolve_user_id()
+        user_id = resolve_user_id()
         if not user_id:
             typer.echo("Refused: no Slack user_id configured — set `teatree.slack_user_id` first")
             raise typer.Exit(code=1)

--- a/src/teatree/core/notify.py
+++ b/src/teatree/core/notify.py
@@ -86,7 +86,7 @@ def notify_user(  # noqa: PLR0913 — single notification egress; each kwarg is 
         return already
 
     resolved_backend = backend if backend is not None else messaging_from_overlay()
-    resolved_user_id = user_id if user_id is not None else _resolve_user_id()
+    resolved_user_id = user_id if user_id is not None else resolve_user_id()
 
     if resolved_backend is None or not resolved_user_id:
         _record_noop(
@@ -101,12 +101,12 @@ def notify_user(  # noqa: PLR0913 — single notification egress; each kwarg is 
     if gate is not None:
         return gate
 
-    payload_text = _maybe_linkify(text) if linkify else text
+    payload_text = maybe_linkify(text) if linkify else text
 
     channel, posted_ts, failure = _deliver_dm(
         resolved_backend,
         user_id=resolved_user_id,
-        text=_format(payload_text, kind_value),
+        text=format_notification(payload_text, kind_value),
     )
     if failure:
         # Any non-delivery — empty channel from ``open_dm`` (Slack
@@ -218,7 +218,7 @@ def _maybe_stamp_answered(*, idempotency_key: str, answering_slack_ts: str) -> N
         if match is None:
             return
         ts = match.group(1)
-    # Deferred import (mirrors ``_resolve_user_id`` / ``_maybe_linkify``
+    # Deferred import (mirrors ``resolve_user_id`` / ``maybe_linkify``
     # in this module): the answer-stamp is an opt-in side path; keeping
     # the model import out of ``teatree.core.notify`` import time avoids
     # perturbing the module-import graph that the on-behalf gate and
@@ -353,7 +353,7 @@ def _feature_enabled() -> bool:
     return bool(getattr(settings_, "notify_user_via_bot", True))
 
 
-def _resolve_user_id() -> str:
+def resolve_user_id() -> str:
     """Resolve the Slack user id to DM (overlay override → global → empty).
 
     Mirrors ``backend_factory._messaging_from_toml`` (which reads the
@@ -376,7 +376,7 @@ def resolve_user_channel() -> str:
     """Resolve the Slack DM channel id the user reads (overlay override → global → empty).
 
     The canonical resolver for the ``slack_user_channel`` config key,
-    walking the SAME overlay→global→empty order :func:`_resolve_user_id`
+    walking the SAME overlay→global→empty order :func:`resolve_user_id`
     uses for ``slack_user_id``. Both DM-channel call sites (the bot→user
     DM path and the live-post-approval CLI verifier) consult this single
     helper, so a change to the resolution order can never drift between
@@ -397,7 +397,7 @@ def resolve_user_channel() -> str:
     return str(teatree_cfg.get("slack_user_channel", ""))
 
 
-def _maybe_linkify(text: str) -> str:
+def maybe_linkify(text: str) -> str:
     """Apply :func:`slack_linkify` using the active overlay's resolvers, if any.
 
     Failure to resolve the overlay or to query a resolver is non-fatal —
@@ -419,7 +419,7 @@ def _maybe_linkify(text: str) -> str:
     )
 
 
-def _format(text: str, kind: NotifyKind) -> str:
+def format_notification(text: str, kind: NotifyKind) -> str:
     """Prefix the DM with a kind marker for easy scan-reading on mobile."""
     prefix = {
         NotifyKind.ANSWER: ":speech_balloon: *answer*",

--- a/src/teatree/core/on_behalf_post_receipt.py
+++ b/src/teatree/core/on_behalf_post_receipt.py
@@ -42,7 +42,7 @@ def notify_user_on_behalf_post(
     across retries (mirrors the ``on_behalf_autodraft:`` convention).
     ``destination`` is the human-readable place the post landed (a review
     channel, an ``org/repo!7`` ref). ``artifact_url`` is the clickable
-    permalink/URL of the post; ``notify_user``'s ``_maybe_linkify``
+    permalink/URL of the post; ``notify_user``'s ``maybe_linkify``
     converts the ``[label](url)`` form to Slack ``<url|label>``.
     ``summary`` is the one-line description of what was posted.
 

--- a/src/teatree/core/speak.py
+++ b/src/teatree/core/speak.py
@@ -223,7 +223,7 @@ def _is_noise_line(line: str) -> bool:
 
     *   **Notify kind marker** — once its emphasis sigils are gone the line is
         only ``info``/``answer``/``question`` (the three ``NotifyKind`` values),
-        the DM preamble :func:`teatree.core.notify._format` prepends.
+        the DM preamble :func:`teatree.core.notify.format_notification` prepends.
     *   **Log level line** — it leads with a level token (``INFO:``, ``[DEBUG]``,
         ``WARNING -``) as a distinct leading token. The same words mid-sentence
         ("the info you asked for") are prose and survive — the level must LEAD.

--- a/src/teatree/messaging/notify_with_fallback.py
+++ b/src/teatree/messaging/notify_with_fallback.py
@@ -30,7 +30,7 @@ from django.db import DatabaseError, IntegrityError, transaction
 from teatree.core.backend_factory import messaging_from_overlay
 from teatree.core.backend_protocols import MessagingBackend
 from teatree.core.models import BotPing
-from teatree.core.notify import NotifyKind, _format, _maybe_linkify, _resolve_user_id
+from teatree.core.notify import NotifyKind, format_notification, maybe_linkify, resolve_user_id
 from teatree.notify import notify_user
 
 logger = logging.getLogger(__name__)
@@ -148,7 +148,7 @@ def _deliver_via_fallback(
     primary_failure = "primary notify_user did not deliver"
 
     backend = messaging_from_overlay()
-    resolved_user_id = user_id if user_id is not None else _resolve_user_id()
+    resolved_user_id = user_id if user_id is not None else resolve_user_id()
     if backend is None or not resolved_user_id:
         _record_fallback_failure(
             idempotency_key=idempotency_key,
@@ -158,7 +158,7 @@ def _deliver_via_fallback(
         )
         return NotifyResult(delivered=False, transport=NotifyTransport.NONE)
 
-    payload_text = _format(_maybe_linkify(text) if linkify else text, kind)
+    payload_text = format_notification(maybe_linkify(text) if linkify else text, kind)
     channel, posted_ts, send_failure = _direct_send(backend, user_id=resolved_user_id, text=payload_text)
     if send_failure:
         _record_fallback_failure(

--- a/tests/integration/slack_bridge_e2e/conftest.py
+++ b/tests/integration/slack_bridge_e2e/conftest.py
@@ -135,7 +135,7 @@ def _isolate_bundled_overlay_module() -> Iterator[None]:
     """Drop the ``teatree.contrib.t3_teatree.overlay`` module + cache after each test.
 
     The fortress tests reach :func:`teatree.core.notify.notify_user`
-    (directly or via the management-command tick), whose ``_maybe_linkify``
+    (directly or via the management-command tick), whose ``maybe_linkify``
     path calls ``overlay_loader.get_overlay`` → ``_discover_overlays``.
     The first call imports ``teatree.contrib.t3_teatree.overlay``, whose
     ``TeatreeOverlay`` class evaluates

--- a/tests/teatree_cli/test_review_live_approval_eval.py
+++ b/tests/teatree_cli/test_review_live_approval_eval.py
@@ -201,7 +201,7 @@ class TestLivePostApprovalAuthorizationMatrix:
         cfg = self.tmp_path / ".teatree.toml"
         cfg.write_text(f'[teatree]\non_behalf_post_mode = "{OnBehalfPostMode.IMMEDIATE.value}"\n', encoding="utf-8")
         self.monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
-        self.monkeypatch.setattr("teatree.core.notify._resolve_user_id", lambda: "")
+        self.monkeypatch.setattr("teatree.core.notify.resolve_user_id", lambda: "")
 
         result = _runner.invoke(
             app,

--- a/tests/teatree_core/test_notify.py
+++ b/tests/teatree_core/test_notify.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 from django.db import OperationalError
 from django.test import TestCase
 
+from teatree.core import notify as notify_module
 from teatree.core.models import BotPing, IncomingEvent
 from teatree.notify import NotifyKind, notify_user
 
@@ -544,3 +545,27 @@ class TestNotifyUserLinkify(TestCase):
 
         assert sent is True
         backend.open_dm.assert_called_once_with("U0DEMOUSER1")
+
+
+class TestPublicHelperSurface:
+    """The three cross-package helpers are public names, not underscored privates.
+
+    ``teatree.messaging.notify_with_fallback`` and the live-approval CLI
+    reach for these helpers across the package boundary, so they are part
+    of the module's public surface and must not carry a leading underscore.
+    """
+
+    def test_public_helpers_are_importable(self) -> None:
+        assert callable(notify_module.format_notification)
+        assert callable(notify_module.maybe_linkify)
+        assert callable(notify_module.resolve_user_id)
+
+    def test_old_private_names_are_gone(self) -> None:
+        assert not hasattr(notify_module, "_format")
+        assert not hasattr(notify_module, "_maybe_linkify")
+        assert not hasattr(notify_module, "_resolve_user_id")
+
+    def test_format_notification_prefixes_kind_marker(self) -> None:
+        out = notify_module.format_notification("hello", NotifyKind.INFO)
+        assert "hello" in out
+        assert "info" in out.lower()

--- a/tests/teatree_core/test_on_behalf_post_receipt.py
+++ b/tests/teatree_core/test_on_behalf_post_receipt.py
@@ -81,7 +81,7 @@ class TestAfterReceiptDm:
         sent = _post_message_text(backend.post_message.call_args)
         assert "review channel C-eng" in sent
         assert "LGTM on org/repo!7" in sent
-        # _maybe_linkify converts [label](url) → <url|label>; the artifact
+        # maybe_linkify converts [label](url) → <url|label>; the artifact
         # URL must be present in the rendered Slack link.
         assert "https://gitlab.example/org/repo/-/merge_requests/7#note_42" in sent
 

--- a/tests/teatree_core/test_resolve_user_channel.py
+++ b/tests/teatree_core/test_resolve_user_channel.py
@@ -2,7 +2,7 @@
 
 Before this resolver existed, the live-post-approval CLI carried its own
 private ``_user_channel`` copy of the overlay→global→empty config walk
-that :func:`teatree.core.notify._resolve_user_id` already implemented for
+that :func:`teatree.core.notify.resolve_user_id` already implemented for
 ``slack_user_id``. Two copies of the same resolution order is a
 config-trap-via-drift: a fix to one (a new precedence rule, a typo'd key)
 silently diverges from the other.
@@ -11,7 +11,7 @@ These tests pin the contract of the canonical
 :func:`teatree.core.notify.resolve_user_channel`:
 
 * it reads ``slack_user_channel`` with the SAME overlay→global→empty order
-    :func:`_resolve_user_id` uses for ``slack_user_id``;
+    :func:`resolve_user_id` uses for ``slack_user_id``;
 * the live-post-approval CLI resolves the channel through it (no private
     duplicate), so both DM-channel call sites agree on one channel id.
 """
@@ -28,7 +28,7 @@ def _write_cfg(tmp_path, monkeypatch, body: str) -> None:
 
 
 class TestResolveUserChannel:
-    """``resolve_user_channel`` mirrors ``_resolve_user_id`` resolution order."""
+    """``resolve_user_channel`` mirrors ``resolve_user_id`` resolution order."""
 
     def test_global_channel_is_read(self, tmp_path, monkeypatch) -> None:
         monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
@@ -77,7 +77,7 @@ class TestResolveUserChannel:
             'slack_user_channel = "D-OVERLAY"\n',
         )
 
-        assert notify._resolve_user_id() == "U-OVERLAY"
+        assert notify.resolve_user_id() == "U-OVERLAY"
         assert notify.resolve_user_channel() == "D-OVERLAY"
 
 

--- a/tests/teatree_core/test_speak.py
+++ b/tests/teatree_core/test_speak.py
@@ -169,7 +169,7 @@ class TestFiltersStatusLogNoise:
     The TTS chokepoint :func:`clean_for_speech` is the ONE place every spoken
     string flows through (the Stop-hook in-client read and the DM local leg).
     A bot->user INFO DM is prefixed with a ``:information_source: *info*`` kind
-    marker line (:func:`teatree.core.notify._format`), and assistant turns /
+    marker line (:func:`teatree.core.notify.format_notification`), and assistant turns /
     DM bodies routinely carry log-status lines (``INFO:`` / ``DEBUG`` levels,
     bare emoji-shortcode status markers). Read verbatim these voice as gibberish
     -- ``:information_source:`` reads as "information source", the kind marker as

--- a/tests/teatree_loop/test_undelivered_notify_scanner.py
+++ b/tests/teatree_loop/test_undelivered_notify_scanner.py
@@ -63,7 +63,7 @@ class TestUndeliveredNotifyScanner(TestCase):
 
         with (
             patch("teatree.core.notify.messaging_from_overlay", return_value=_FakeBackend()),
-            patch("teatree.core.notify._resolve_user_id", return_value="U_ME"),
+            patch("teatree.core.notify.resolve_user_id", return_value="U_ME"),
         ):
             signals = UndeliveredNotifyScanner().scan()
 

--- a/tests/test_hook_router_self_dm_mcp.py
+++ b/tests/test_hook_router_self_dm_mcp.py
@@ -69,7 +69,7 @@ messaging_backend = "slack"
 """
 
 # No overlay table at all — only the global [teatree] slack_user_id. The U-form
-# must still deny via the global fallback (mirrors notify._resolve_user_id).
+# must still deny via the global fallback (mirrors notify.resolve_user_id).
 _CONFIG_GLOBAL_USER_ONLY = """
 [teatree]
 mode = "auto"
@@ -140,7 +140,7 @@ class TestDeniesSelfDmWrites:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
         # No overlay table — only the global [teatree] slack_user_id. The U-form
-        # must still deny (mirrors notify._resolve_user_id overlay→global order).
+        # must still deny (mirrors notify.resolve_user_id overlay→global order).
         _patch_home(tmp_path / "home2", _CONFIG_GLOBAL_USER_ONLY, monkeypatch)
         verdict = router.handle_block_self_dm_via_mcp(
             _event(_SEND, {"channel": "U0GLOBALUSER", "text": "report"}, session_id="s1g")


### PR DESCRIPTION
## The debt

`messaging/notify_with_fallback.py` and `cli/review/live_approval.py` imported three underscored privates from `core/notify.py` across the package boundary:

```python
from teatree.core.notify import NotifyKind, _format, _maybe_linkify, _resolve_user_id
```

A leading underscore signals "internal to this module". Importing it from another package is reaching past the public surface — the names are de-facto public API but spelled as if they were not, so a future refactor that treats them as private (rename/inline) silently breaks the consumers. This is the "reaching past the public surface" tech-debt class.

## The fix

Pure mechanical rename, no behavior change. The three helpers drop the leading underscore:

| old | new |
|---|---|
| `_format` | `format_notification` |
| `_maybe_linkify` | `maybe_linkify` |
| `_resolve_user_id` | `resolve_user_id` |

Every caller, docstring, and comment referent is updated: `core/notify.py` (definitions + internal call sites + two docstring mentions), `messaging/notify_with_fallback.py` (import + two call sites), `cli/review/live_approval.py` (deferred import + call), `core/on_behalf_post_receipt.py` and `core/speak.py` (docstring `:func:` references), plus the string `mock.patch` targets and `:func:`/comment references in the test suite.

Intentionally untouched (a different surface): the Slack backend's own `resolve_user_id(handle)` and noop backend method, gitlab's `resolve_user_id_by_username`, and `utils/run.py`'s unrelated `_format()` exception method.

## Zero stale refs

An exhaustive `rg` sweep across all surface forms (plain, dotted attribute, `notify._x()`, string patch targets, `:func:` docstring refs) returns zero stale references to the three renamed helpers in `src/` and `tests/`. The deterministic `tests/quality/test_patch_targets_resolve.py` gate (resolves every constant `mock.patch` string target against the live module tree) passes, confirming no dead string patch targets survive.

## Anti-vacuity / RED evidence

New conformance test `TestPublicHelperSurface` in `tests/teatree_core/test_notify.py` pins the public names exist and the old privates are gone. Observed RED on pre-fix code (rename reverted via `git stash`):

```
FAILED test_public_helpers_are_importable
  AttributeError: module 'teatree.core.notify' has no attribute 'format_notification'
FAILED test_old_private_names_are_gone
  (the old private names still present)
FAILED test_format_notification_prefixes_kind_marker
  AttributeError: ... no attribute 'format_notification'
```

GREEN after the rename.

## Verification gates (all green)

- `tests/teatree_core/test_notify.py`, `tests/messaging/test_notify_with_fallback.py`, and every other touched test file — 170 passed
- `tests/teatree_quality/` (module-health, test-path-mirror, test-shape) — 55 passed
- `tests/quality/test_patch_targets_resolve.py` — 20 passed
- `scripts/hooks/check_module_health.py --from-ref origin/main` — exit 0
- `uv run ruff check` + `uv run ty check` on all touched files — clean
- `uv run tach check` — all modules validated

## Open questions & assumptions

- Assumption: the three helpers are the only `core/notify.py` privates reached across the package boundary; the cross-package importers are `messaging/notify_with_fallback.py` and `cli/review/live_approval.py`, both confirmed by repo-wide grep.
- No behavior change is intended; this is a rename only.
