### PR TITLE
fix(core): resolve path-only overlay owned_repos for the scope gate

### DIFF
--- a/src/teatree/core/gates/owned_repo_guard.py
+++ b/src/teatree/core/gates/owned_repo_guard.py
@@ -103,7 +103,31 @@ def require_owned_or_approved(cwd: Path, overlay: "OverlayBase", *, approved: bo
         raise UnownedRepoError(_remediation(target))
 
 
-def classify_push_for_overlays(cwd: Path, overlays: dict[str, "OverlayBase"]) -> PushScopeVerdict:
+def _opted_in_scopes(
+    overlays: dict[str, "OverlayBase"],
+    path_only_scopes: "list[dict[str, list[str]]] | None",
+) -> list[dict[str, list[str]]]:
+    """The opted-in ``owned_repos`` of instantiable AND path-only overlays.
+
+    A path-only TOML overlay is skipped by ``get_all_overlays()`` so its scope
+    never reaches *overlays*; its opted-in ``owned_repos`` arrive separately
+    via *path_only_scopes* (already filtered to opted-in + non-empty). Both are
+    pooled into one list of scope dicts the verdict functions match against.
+    """
+    instantiable = [
+        overlay.config.owned_repos
+        for overlay in overlays.values()
+        if overlay.config.require_owned_repo_approval and overlay.config.owned_repos
+    ]
+    return instantiable + list(path_only_scopes or [])
+
+
+def classify_push_for_overlays(
+    cwd: Path,
+    overlays: dict[str, "OverlayBase"],
+    *,
+    path_only_scopes: "list[dict[str, list[str]]] | None" = None,
+) -> PushScopeVerdict:
     """Classify a push from *cwd* against every registered overlay's scope.
 
     Mirrors the §7 verdict structure for the multi-overlay PreToolUse push
@@ -114,20 +138,19 @@ def classify_push_for_overlays(cwd: Path, overlays: dict[str, "OverlayBase"]) ->
         (``require_owned_repo_approval`` AND non-empty ``owned_repos``), AND
     *   NO opted-in overlay owns the cwd repo's ``(host, namespace)``.
 
-    Otherwise :attr:`PushScopeVerdict.ALLOW`: no overlay opted in (back-compat),
-    or some opted-in overlay owns the repo. The polarity is fail-CLOSED on the
-    clean unknown verdict; a resolver EXCEPTION is the caller's fail-open
-    concern, not this pure function's.
+    *path_only_scopes* carries the opted-in ``owned_repos`` of PATH-ONLY
+    overlays (``path`` but no ``class``), which ``get_all_overlays()`` skips —
+    so a repo a path-only overlay owns is in scope. Otherwise
+    :attr:`PushScopeVerdict.ALLOW`: no overlay opted in (back-compat), or some
+    opted-in overlay owns the repo. The polarity is fail-CLOSED on the clean
+    unknown verdict; a resolver EXCEPTION is the caller's fail-open concern,
+    not this pure function's.
     """
-    opted_in = [
-        overlay
-        for overlay in overlays.values()
-        if overlay.config.require_owned_repo_approval and overlay.config.owned_repos
-    ]
-    if not opted_in:
+    scopes = _opted_in_scopes(overlays, path_only_scopes)
+    if not scopes:
         return PushScopeVerdict.ALLOW
     identity = repo_identity_for_cwd(cwd)
-    if any(host_aware_owns(overlay.config.owned_repos, identity) for overlay in opted_in):
+    if any(host_aware_owns(owned, identity) for owned in scopes):
         return PushScopeVerdict.ALLOW
     return PushScopeVerdict.REQUIRE_APPROVAL
 
@@ -140,16 +163,23 @@ def classify_active_push(cwd: Path) -> PushScopeVerdict:
     (never-lockout on the internal-exception axis, distinct from the clean
     unknown verdict above which fails closed).
     """
-    from teatree.core.overlay_loader import get_all_overlays  # noqa: PLC0415
+    from teatree.core.overlay_loader import OverlayConfigResolver, get_all_overlays  # noqa: PLC0415
 
     try:
         overlays = get_all_overlays()
+        path_only_scopes = OverlayConfigResolver.path_only_owned_scopes()
     except Exception:  # noqa: BLE001 — broken overlay must not wedge a push; fail OPEN.
         return PushScopeVerdict.ALLOW
-    return classify_push_for_overlays(cwd, overlays)
+    return classify_push_for_overlays(cwd, overlays, path_only_scopes=path_only_scopes)
 
 
-def merge_scope_verdict(host: str, slug: str, overlays: dict[str, "OverlayBase"]) -> PushScopeVerdict:
+def merge_scope_verdict(
+    host: str,
+    slug: str,
+    overlays: dict[str, "OverlayBase"],
+    *,
+    path_only_scopes: "list[dict[str, list[str]]] | None" = None,
+) -> PushScopeVerdict:
     """Classify a keystone-merge target ``(host, slug)`` against every overlay's scope.
 
     The merge keystone carries the namespace as a bare ``slug`` (no host); the
@@ -158,23 +188,23 @@ def merge_scope_verdict(host: str, slug: str, overlays: dict[str, "OverlayBase"]
     some overlay opted in AND the target is identifiably out-of-scope (host
     known, namespace owned by no opted-in overlay). ALLOW otherwise.
 
+    *path_only_scopes* carries the opted-in ``owned_repos`` of PATH-ONLY
+    overlays (skipped by ``get_all_overlays()``), so a merge target a path-only
+    overlay owns is in scope.
+
     An UNRESOLVABLE host (no issue/PR URL to recover it from) is the
     *uncertainty* axis, NOT a clean unknown verdict — the merge cannot be
     classified, so it fails OPEN (never-lockout), exactly as the push gate
     allows an unresolvable cwd. The merge keystone's other gates (independent
     cold-review, SHA-binding, substrate authorization) remain in force.
     """
-    opted_in = [
-        overlay
-        for overlay in overlays.values()
-        if overlay.config.require_owned_repo_approval and overlay.config.owned_repos
-    ]
-    if not opted_in:
+    scopes = _opted_in_scopes(overlays, path_only_scopes)
+    if not scopes:
         return PushScopeVerdict.ALLOW
     identity = identity_from_host_and_slug(host, slug)
     if not identity.host:
         return PushScopeVerdict.ALLOW
-    if any(host_aware_owns(overlay.config.owned_repos, identity) for overlay in opted_in):
+    if any(host_aware_owns(owned, identity) for owned in scopes):
         return PushScopeVerdict.ALLOW
     return PushScopeVerdict.REQUIRE_APPROVAL
 
@@ -203,10 +233,15 @@ def merge_clear_refusal(clear: "_MergeClearLike", *, approved: bool) -> MergeKey
     if approved:
         return None
     try:
-        from teatree.core.overlay_loader import get_all_overlays  # noqa: PLC0415
+        from teatree.core.overlay_loader import OverlayConfigResolver, get_all_overlays  # noqa: PLC0415
 
         issue_url = str(getattr(clear.ticket, "issue_url", "") or "")
-        verdict = merge_scope_verdict(issue_url, clear.slug, get_all_overlays())
+        verdict = merge_scope_verdict(
+            issue_url,
+            clear.slug,
+            get_all_overlays(),
+            path_only_scopes=OverlayConfigResolver.path_only_owned_scopes(),
+        )
     except Exception:  # noqa: BLE001 — a resolver error must never wedge a merge; fail OPEN.
         return None
     if verdict is not PushScopeVerdict.REQUIRE_APPROVAL:

--- a/src/teatree/core/overlay_loader.py
+++ b/src/teatree/core/overlay_loader.py
@@ -8,8 +8,9 @@ of whether the overlay was registered via ``pip install`` (entry point) or
 import importlib
 import logging
 import os
+from collections.abc import Callable
 from functools import lru_cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar, TypeVar
 from urllib.parse import urlparse
 
 from django.core.exceptions import ImproperlyConfigured
@@ -21,9 +22,12 @@ if TYPE_CHECKING:
     from teatree.core.models import Ticket, Worktree
     from teatree.core.overlay import OverlayBase
 
+_FieldT = TypeVar("_FieldT", list[str], dict[str, list[str]])
+
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "OverlayConfigResolver",
     "frontend_repos_for_overlay",
     "get_all_overlay_names",
     "get_all_overlays",
@@ -167,42 +171,113 @@ def get_all_overlay_names() -> list[str]:
     return sorted(names)
 
 
-def frontend_repos_for_overlay(name: str | None) -> list[str]:
-    """The overlay's configured frontend repos, resolvable for path-only overlays.
+class OverlayConfigResolver:
+    """Resolve a per-overlay config field, path-only-symmetrically.
 
     An instantiable overlay (entry-point package, or a TOML table carrying a
-    ``class``) answers from ``overlay.config.frontend_repos``. A **path-only**
+    ``class``) answers from its ``OverlayConfig`` attribute. A **path-only**
     TOML overlay — registered with a ``path`` but no Python ``class`` — cannot
     be instantiated as :class:`OverlayBase` in the teatree process (it is
     reached through the CLI subprocess bridge), so ``get_overlay`` raises
     ``Overlay not found`` for it even though it is a known, registered overlay.
-    For that case the frontend repos are read straight from the
-    ``[overlays.<name>]`` TOML table — the same config surface
-    :func:`get_all_overlay_names` already trusts for path-only entries.
+    For that case the field is read straight from the ``[overlays.<name>]``
+    TOML table — the same config surface :func:`get_all_overlay_names` already
+    trusts for path-only entries.
 
-    A blank ``name`` is the ambient single-overlay default and routes through
-    ``get_overlay(None)``. A name that resolves to no registered overlay (a
-    removed overlay, a typo, a synthetic tag) raises ``ImproperlyConfigured``
-    so a safety-gate caller can keep its fail-closed posture for a genuinely
-    unknown overlay instead of silently inferring an empty repo set.
+    Every field a gate resolves per overlay (frontend repos for the local-E2E
+    gate, ``owned_repos`` for the fail-CLOSED scope gate) is registered in
+    :attr:`RESOLVABLE_FIELDS` so a path-only overlay can never carry a field
+    one of those gates reads through ``get_all_overlays()`` alone (where it is
+    invisible). The symmetry fitness test pins that registry.
     """
-    from teatree.config import load_config  # noqa: PLC0415
 
-    resolved = _canonical_overlay_name(name) if name else None
-    try:
-        overlay = get_overlay(resolved)
-    except ImproperlyConfigured:
-        canonical = resolve_overlay_name(name) if name else None
-        if canonical is None:
-            raise
-        table = load_config().raw.get("overlays", {}).get(canonical, {})
-        repos = table.get("frontend_repos") or []
-        return [str(r) for r in repos]
-    config = overlay.config
-    if not hasattr(config, "frontend_repos"):
-        msg = f"overlay {name!r} config has no frontend_repos"
-        raise ImproperlyConfigured(msg)
-    return list(config.frontend_repos or [])
+    @classmethod
+    def _resolve(cls, name: str | None, attr: str, empty: _FieldT) -> _FieldT:
+        """Return *attr* for overlay *name*, from its config or its raw TOML table.
+
+        A blank *name* is the ambient single-overlay default and routes through
+        ``get_overlay(None)``. A name that resolves to no registered overlay
+        (a removed overlay, a typo, a synthetic tag) raises
+        ``ImproperlyConfigured`` so a safety-gate caller keeps its fail-closed
+        posture for a genuinely unknown overlay instead of silently inferring
+        the empty value.
+        """
+        from teatree.config import load_config  # noqa: PLC0415
+
+        resolved = _canonical_overlay_name(name) if name else None
+        try:
+            overlay = get_overlay(resolved)
+        except ImproperlyConfigured:
+            canonical = resolve_overlay_name(name) if name else None
+            if canonical is None:
+                raise
+            table = load_config().raw.get("overlays", {}).get(canonical, {})
+            return table.get(attr) or empty
+        config = overlay.config
+        if not hasattr(config, attr):
+            msg = f"overlay {name!r} config has no {attr}"
+            raise ImproperlyConfigured(msg)
+        return getattr(config, attr) or empty
+
+    @classmethod
+    def frontend_repos(cls, name: str | None) -> list[str]:
+        """The overlay's configured frontend repos, resolvable for path-only overlays."""
+        return [str(r) for r in cls._resolve(name, "frontend_repos", [])]
+
+    @classmethod
+    def owned_repos(cls, name: str | None) -> dict[str, list[str]]:
+        """The overlay's forge-host-keyed ``owned_repos`` (SCOPE axis), path-only-symmetric.
+
+        The SCOPE-axis twin of :meth:`frontend_repos`. A path-only overlay's
+        ``owned_repos`` is otherwise invisible to the fail-CLOSED owned-repo
+        gate, which iterates only instantiable overlays. The dict is returned
+        verbatim (the same shape ``apply_toml_overrides`` would ``setattr``),
+        defaulting to ``{}`` when undeclared and raising ``ImproperlyConfigured``
+        for a genuinely unknown overlay so the gate's fail-closed posture holds.
+        """
+        return dict(cls._resolve(name, "owned_repos", {}))
+
+    @classmethod
+    def path_only_owned_scopes(cls) -> list[dict[str, list[str]]]:
+        """The opted-in ``owned_repos`` of every path-only overlay.
+
+        A path-only overlay (``path``, no ``class``) opts into the scope gate
+        the same way an instantiable one does — ``require_owned_repo_approval``
+        True with a non-empty ``owned_repos`` — but lives only in the raw TOML
+        table. This yields each such scope so the push and merge classifiers
+        can honor a repo a path-only overlay owns. Overlays that did not opt in,
+        carry an empty ``owned_repos``, or are instantiable (already covered by
+        ``get_all_overlays()``) are excluded.
+        """
+        from teatree.config import load_config  # noqa: PLC0415
+
+        instantiable = set(_discover_overlays())
+        overlays_cfg = load_config().raw.get("overlays", {})
+        scopes: list[dict[str, list[str]]] = []
+        for name, cfg in overlays_cfg.items():
+            if name in instantiable or not cfg.get("path"):
+                continue
+            owned = cfg.get("owned_repos") or {}
+            if cfg.get("require_owned_repo_approval") and owned:
+                scopes.append(dict(owned))
+        return scopes
+
+    RESOLVABLE_FIELDS: ClassVar[dict[str, Callable[[str | None], object]]] = {}
+
+
+OverlayConfigResolver.RESOLVABLE_FIELDS = {
+    "frontend_repos": OverlayConfigResolver.frontend_repos,
+    "owned_repos": OverlayConfigResolver.owned_repos,
+}
+
+
+def frontend_repos_for_overlay(name: str | None) -> list[str]:
+    """The overlay's configured frontend repos, resolvable for path-only overlays.
+
+    Thin module-level wrapper over :meth:`OverlayConfigResolver.frontend_repos`,
+    kept for the existing local-E2E gate caller (``core.gates.dod_gate``).
+    """
+    return OverlayConfigResolver.frontend_repos(name)
 
 
 def resolve_overlay_name(name: str) -> str | None:

--- a/tests/teatree_core/gates/test_owned_repo_guard.py
+++ b/tests/teatree_core/gates/test_owned_repo_guard.py
@@ -12,7 +12,13 @@ from pathlib import Path
 
 import pytest
 
-from teatree.core.gates.owned_repo_guard import UnownedRepoError, require_owned_or_approved
+from teatree.core.gates.owned_repo_guard import (
+    PushScopeVerdict,
+    UnownedRepoError,
+    classify_push_for_overlays,
+    merge_scope_verdict,
+    require_owned_or_approved,
+)
 from teatree.core.overlay import OverlayBase, OverlayConfig
 from teatree.core.review_candidate import should_review_candidate
 
@@ -105,3 +111,52 @@ class TestOrthogonalToCollaboration:
     def test_owned_repo_with_self_author_is_not_a_review_candidate(self) -> None:
         own_pr = {"user": {"login": "souliane"}, "state": "open"}
         assert should_review_candidate(own_pr, current_user="souliane") is False
+
+
+_ACME_PATH_ONLY = {"github.com": ["acme-eng"]}
+
+
+class TestPathOnlyOwnedScope:
+    """A path-only overlay's opted-in ``owned_repos`` is honored by the gate.
+
+    A path-only TOML overlay cannot be instantiated, so it never appears in
+    ``get_all_overlays()`` and its ``owned_repos`` is invisible to a gate that
+    only iterates instantiable overlays. The push and merge classifiers accept
+    the path-only opted-in scopes alongside the instantiable overlays so a
+    repo owned by a path-only overlay is in scope (ALLOW) and one owned by
+    neither is held (REQUIRE_APPROVAL). Before the fix the classifiers had no
+    ``path_only_scopes`` parameter at all, so this is a TypeError RED.
+    """
+
+    def test_repo_owned_only_by_a_path_only_overlay_is_allowed(self, tmp_path: Path) -> None:
+        repo = _repo(tmp_path / "acme", "git@github.com:acme-eng/widget.git")
+        verdict = classify_push_for_overlays(repo, {}, path_only_scopes=[_ACME_PATH_ONLY])
+        assert verdict is PushScopeVerdict.ALLOW
+
+    def test_repo_owned_by_no_scope_including_path_only_requires_approval(self, tmp_path: Path) -> None:
+        repo = _repo(tmp_path / "other", "git@github.com:randomuser/randomrepo.git")
+        verdict = classify_push_for_overlays(repo, {}, path_only_scopes=[_ACME_PATH_ONLY])
+        assert verdict is PushScopeVerdict.REQUIRE_APPROVAL
+
+    def test_no_opted_in_scope_at_all_allows(self, tmp_path: Path) -> None:
+        repo = _repo(tmp_path / "none", "git@github.com:randomuser/randomrepo.git")
+        verdict = classify_push_for_overlays(repo, {}, path_only_scopes=[])
+        assert verdict is PushScopeVerdict.ALLOW
+
+    def test_merge_target_owned_by_path_only_overlay_is_allowed(self) -> None:
+        verdict = merge_scope_verdict(
+            "https://github.com/acme-eng/widget/pull/3",
+            "acme-eng/widget",
+            {},
+            path_only_scopes=[_ACME_PATH_ONLY],
+        )
+        assert verdict is PushScopeVerdict.ALLOW
+
+    def test_merge_target_owned_by_no_scope_requires_approval(self) -> None:
+        verdict = merge_scope_verdict(
+            "https://github.com/randomuser/randomrepo/pull/3",
+            "randomuser/randomrepo",
+            {},
+            path_only_scopes=[_ACME_PATH_ONLY],
+        )
+        assert verdict is PushScopeVerdict.REQUIRE_APPROVAL

--- a/tests/teatree_quality/test_overlay_field_resolution_symmetry.py
+++ b/tests/teatree_quality/test_overlay_field_resolution_symmetry.py
@@ -1,0 +1,76 @@
+# test-path: cross-cutting — architecture fitness function over overlay config-field resolution.
+"""Fitness test: per-overlay config-field resolution is path-only-symmetric.
+
+Every overlay config field that the codebase resolves *per overlay* for an
+INSTANTIABLE overlay (an entry-point package or a ``class``-carrying TOML
+table) must ALSO resolve for a PATH-ONLY overlay (a ``path`` but no Python
+``class``) — or be explicitly rejected at load. A path-only overlay is skipped
+by ``get_all_overlays()``, so any field consumed through that dict alone is
+invisible for it. A scope/visibility field that is invisible for a path-only
+overlay silently breaks the gate that consumes it (e.g. the fail-CLOSED
+owned-repo gate cannot see a path-only overlay's ``owned_repos``).
+
+The single source of truth is ``OverlayConfigResolver.RESOLVABLE_FIELDS`` —
+the registry of ``field-name -> resolver``. This test asserts each registered
+resolver answers a path-only overlay's TOML-declared value from the raw
+``[overlays.<name>]`` table, exactly as it answers an instantiable overlay
+from its ``config``. The anti-vacuity: before ``owned_repos`` has a resolver,
+``owned_repos`` is missing from the registry and this test goes RED on the
+asymmetry assertion below.
+"""
+
+from contextlib import ExitStack
+from unittest.mock import patch
+
+import teatree.config as config_mod
+from teatree.config import TeaTreeConfig
+from teatree.core.overlay_loader import OverlayConfigResolver
+
+# Fields that gate SCOPE (owned vs unknown) or VISIBILITY decisions per overlay.
+# Every one of these MUST have a path-only-symmetric resolver, because a
+# path-only overlay legitimately declares them in its TOML table and the gates
+# that read them fail-CLOSED (scope) or scan-as-public (visibility) when blind.
+_SCOPE_AND_VISIBILITY_FIELDS = {"frontend_repos", "owned_repos"}
+
+
+def _make_config(overlays: dict) -> TeaTreeConfig:
+    return TeaTreeConfig(raw={"overlays": overlays})
+
+
+def _patch_landscape(overlays: dict, discovered: dict | None) -> ExitStack:
+    stack = ExitStack()
+    stack.enter_context(patch.object(config_mod, "load_config", return_value=_make_config(overlays)))
+    stack.enter_context(patch("teatree.core.overlay_loader._discover_overlays", return_value=discovered or {}))
+    return stack
+
+
+def test_every_scope_and_visibility_field_has_a_path_only_resolver() -> None:
+    """The asymmetry guard: no scope/visibility field may lack a path-only resolver."""
+    registered = set(OverlayConfigResolver.RESOLVABLE_FIELDS)
+    missing = _SCOPE_AND_VISIBILITY_FIELDS - registered
+    assert not missing, (
+        f"scope/visibility field(s) {sorted(missing)} have no per-overlay resolver; "
+        "a path-only overlay's value for them is invisible to the gate that consumes it"
+    )
+
+
+def test_each_resolver_answers_a_path_only_overlay_from_its_toml_table() -> None:
+    """Each registered resolver reads a path-only overlay's declared value, never raises."""
+    declared = {
+        "frontend_repos": ["acme-web", "acme-admin"],
+        "owned_repos": {"github.com": ["acme-eng"]},
+    }
+    for field, resolver in OverlayConfigResolver.RESOLVABLE_FIELDS.items():
+        value = declared[field]
+        overlays = {"t3-path": {"path": "~/x/t3-path", field: value}}
+        with _patch_landscape(overlays, discovered={}):
+            assert resolver("t3-path") == value, f"path-only resolver for {field!r} did not read its TOML value"
+
+
+def test_each_resolver_defaults_empty_for_a_path_only_overlay_without_the_field() -> None:
+    """A path-only overlay that omits the field resolves to the field's empty default, not a raise."""
+    empties = {"frontend_repos": [], "owned_repos": {}}
+    for field, resolver in OverlayConfigResolver.RESOLVABLE_FIELDS.items():
+        overlays = {"t3-path": {"path": "~/x/t3-path", "protected_branches": ["development"]}}
+        with _patch_landscape(overlays, discovered={}):
+            assert resolver("t3-path") == empties[field], f"path-only resolver for {field!r} did not default empty"

--- a/tests/test_overlay_loader.py
+++ b/tests/test_overlay_loader.py
@@ -14,6 +14,7 @@ import teatree.config as config_mod
 from teatree.config import TeaTreeConfig
 from teatree.core.overlay import OverlayBase
 from teatree.core.overlay_loader import (
+    OverlayConfigResolver,
     _discover_toml_overlays,
     frontend_repos_for_overlay,
     get_overlay_for_repo,
@@ -21,6 +22,9 @@ from teatree.core.overlay_loader import (
     infer_overlay_for_url,
     resolve_overlay_name,
 )
+
+owned_repos_for_overlay = OverlayConfigResolver.owned_repos
+path_only_owned_scopes = OverlayConfigResolver.path_only_owned_scopes
 
 _GIT = shutil.which("git") or "git"
 
@@ -487,6 +491,89 @@ class TestFrontendReposForOverlay:
 
         with self._patch_landscape({}, discovered={}), pytest.raises(ImproperlyConfigured):
             frontend_repos_for_overlay("removed-or-typo")
+
+
+class TestOwnedReposForOverlay:
+    """``owned_repos_for_overlay`` resolves a path-only overlay's SCOPE dict.
+
+    The SCOPE-axis twin of ``frontend_repos_for_overlay``. A path-only TOML
+    overlay (``path`` but no ``class``) is skipped by ``get_all_overlays()``,
+    so its forge-host-keyed ``owned_repos`` is invisible to the fail-CLOSED
+    owned-repo gate. This resolver answers from the ``[overlays.<name>]`` raw
+    TOML table for a path-only overlay (defaulting to ``{}`` when undeclared),
+    answers from ``config.owned_repos`` for an instantiable overlay, and
+    raises ``ImproperlyConfigured`` for a genuinely unknown overlay so the
+    gate's fail-closed posture survives.
+    """
+
+    def _patch_landscape(self, overlays: dict, discovered: dict | None):
+        from contextlib import ExitStack  # noqa: PLC0415
+
+        stack = ExitStack()
+        stack.enter_context(patch.object(config_mod, "load_config", return_value=_make_config(overlays)))
+        stack.enter_context(patch("teatree.core.overlay_loader._discover_overlays", return_value=discovered or {}))
+        return stack
+
+    def test_path_only_overlay_with_no_owned_repos_resolves_empty_dict(self):
+        overlays = {"t3-path": {"path": "~/x/t3-path", "protected_branches": ["development"]}}
+        with self._patch_landscape(overlays, discovered={}):
+            assert owned_repos_for_overlay("t3-path") == {}
+
+    def test_path_only_overlay_with_declared_owned_repos_resolves_them(self):
+        owned = {"github.com": ["acme-eng"], "gitlab.acme.internal": ["*"]}
+        overlays = {"t3-path": {"path": "~/x/t3-path", "owned_repos": owned}}
+        with self._patch_landscape(overlays, discovered={}):
+            assert owned_repos_for_overlay("t3-path") == owned
+
+    def test_instantiable_overlay_answers_from_its_config(self):
+        overlay = _StubOverlay()
+        overlay.config.owned_repos = {"github.com": ["souliane"]}
+        with self._patch_landscape({}, discovered={"t3-stub": overlay}):
+            assert owned_repos_for_overlay("t3-stub") == {"github.com": ["souliane"]}
+
+    def test_genuinely_unknown_overlay_raises_for_fail_closed(self):
+        from django.core.exceptions import ImproperlyConfigured  # noqa: PLC0415
+
+        with self._patch_landscape({}, discovered={}), pytest.raises(ImproperlyConfigured):
+            owned_repos_for_overlay("removed-or-typo")
+
+
+class TestPathOnlyOwnedScopes:
+    """``path_only_owned_scopes`` yields opted-in path-only overlay scopes."""
+
+    def _patch_landscape(self, overlays: dict, discovered: dict | None):
+        from contextlib import ExitStack  # noqa: PLC0415
+
+        stack = ExitStack()
+        stack.enter_context(patch.object(config_mod, "load_config", return_value=_make_config(overlays)))
+        stack.enter_context(patch("teatree.core.overlay_loader._discover_overlays", return_value=discovered or {}))
+        return stack
+
+    def test_opted_in_path_only_overlay_yields_its_owned_repos(self):
+        owned = {"github.com": ["acme-eng"]}
+        overlays = {
+            "t3-path": {"path": "~/x/t3-path", "owned_repos": owned, "require_owned_repo_approval": True},
+        }
+        with self._patch_landscape(overlays, discovered={}):
+            assert path_only_owned_scopes() == [owned]
+
+    def test_path_only_overlay_not_opted_in_is_excluded(self):
+        overlays = {"t3-path": {"path": "~/x/t3-path", "owned_repos": {"github.com": ["acme-eng"]}}}
+        with self._patch_landscape(overlays, discovered={}):
+            assert path_only_owned_scopes() == []
+
+    def test_opted_in_but_empty_owned_repos_is_excluded(self):
+        overlays = {"t3-path": {"path": "~/x/t3-path", "require_owned_repo_approval": True}}
+        with self._patch_landscape(overlays, discovered={}):
+            assert path_only_owned_scopes() == []
+
+    def test_instantiable_overlay_is_not_yielded_by_path_only_scopes(self):
+        overlay = _StubOverlay()
+        overlay.config.owned_repos = {"github.com": ["souliane"]}
+        overlay.config.require_owned_repo_approval = True
+        overlays = {"t3-stub": {"class": "tests.test_overlay_loader:_StubOverlay"}}
+        with self._patch_landscape(overlays, discovered={"t3-stub": overlay}):
+            assert path_only_owned_scopes() == []
 
 
 # ── Test helpers ─────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Resolve a path-only TOML overlay's `owned_repos` for the fail-CLOSED owned-repo
scope gate, closing a latent resolution gap.

A path-only overlay (a `path` but no Python `class`) is skipped by
`get_all_overlays()`, which returns only instantiable overlays. So while
`frontend_repos_for_overlay` already had a raw-TOML fallback for path-only
overlays, the parallel SCOPE-axis field `owned_repos` did not — the
owned-repo gate (`core/gates/owned_repo_guard.py`) could never see a path-only
overlay's `owned_repos`. The SCOPE axis was asymmetric with the
VISIBILITY/frontend axis for this class of overlay.

## Why (the debt)

This is arch-review finding #6 — a latent gap left by the earlier scope-gate
work. `frontend_repos_for_overlay` (path-only raw-TOML fallback) and the
forge-host-keyed `owned_repos` model both existed, but nothing bridged a
path-only overlay's `owned_repos` into the gate, which iterates only
instantiable overlays. `REQUIRE_OWNED_REPO_APPROVAL` ships False, so the gate
is inert today; this fixes the resolution gap without changing that posture.

## The fix

- `OverlayConfigResolver.owned_repos(name)` — the SCOPE-axis twin of
  `frontend_repos_for_overlay`. Reads from the `[overlays.<name>]` raw TOML
  table for a path-only overlay, from `config.owned_repos` for an instantiable
  one, defaults to `{}` when undeclared, and raises `ImproperlyConfigured` for
  a genuinely unknown overlay so the gate's fail-closed posture survives.
- The two field resolvers move into `OverlayConfigResolver` (with a
  `RESOLVABLE_FIELDS` registry), so the public module-level function count in
  `overlay_loader.py` stays at the module-health cap (10).
  `frontend_repos_for_overlay` remains a thin wrapper for its existing
  `core/gates/dod_gate.py` caller.
- `OverlayConfigResolver.path_only_owned_scopes()` yields the opted-in
  (`require_owned_repo_approval` plus non-empty `owned_repos`) scopes of
  path-only overlays.
- `classify_push_for_overlays` and `merge_scope_verdict` gain a
  `path_only_scopes` parameter and pool those scopes with the instantiable
  overlays. The never-lockout wrappers (`classify_active_push`,
  `merge_clear_refusal`) feed the path-only scopes and keep their
  fail-open-on-exception posture intact.

## Anti-vacuity / RED evidence

Every new test was observed RED on pre-fix code:

- symmetry module errored RED: `ImportError: cannot import name 'OverlayConfigResolver'`.
- dropping `owned_repos` from `RESOLVABLE_FIELDS` re-fires the asymmetry guard
  RED: `AssertionError: scope/visibility field(s) ['owned_repos'] have no per-overlay resolver`.
- gate test RED: `TypeError: classify_push_for_overlays() got an unexpected keyword argument 'path_only_scopes'`.
- resolver tests RED: `ImportError` on the new names during collection.

The symmetry fitness test (`tests/teatree_quality/test_overlay_field_resolution_symmetry.py`)
pins the registry so a future scope/visibility field cannot ship without a
path-only-symmetric resolver.

## Architecture pre-check

1. BLUEPRINT § — Three orthogonal repo axes (SCOPE/VISIBILITY/COLLABORATION);
   makes SCOPE resolvable for path-only overlays as VISIBILITY/frontend already is.
2. FSM — n/a, no state transition.
3. Extension-point contracts — `frontend_repos_for_overlay` consumer
   (`core/gates/dod_gate.py`) unchanged; gate classifiers gain path-only scopes.
4. Component boundaries — fits `overlay_loader.py` (resolution) and
   `gates/owned_repo_guard.py` (verdict); no new module.
5. Dependency direction — `owned_repo_guard` already imports `overlay_loader`
   lazily; no new backwards edge; `tach check` clean.
6. Test surface — resolver tests, gate path-only tests, the symmetry fitness test.
7. Resilience — fail-OPEN-on-exception preserved in the wrappers; pure reads,
   idempotent; no external write.
8. Identity/normalization — `owned_repos` returned verbatim (same shape
   `apply_toml_overrides` would set); no qualifier stripping.
9. Behavior preservation — `frontend_repos_for_overlay` behaviour preserved
   exactly; purely additive on the gate side; no must-block test inverted.

## Verification

- New + changed tests green; `tests/teatree_quality/` green.
- `check_module_health.py --from-ref origin/main` exit 0 (public fn count held at 10).
- `ruff check`, `ty check`, `tach check` clean.
