### PR TITLE
refactor(utils): extract pure remote-URL parsing into git_remote

### DIFF
--- a/src/teatree/core/management/commands/_ensure_pr.py
+++ b/src/teatree/core/management/commands/_ensure_pr.py
@@ -23,7 +23,7 @@ from teatree.core.backend_protocols import BackendResolutionError, PullRequestSp
 from teatree.core.gates.open_questions_gate import warn_if_open_questions_missing
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.runners.ship import overlay_pr_labels, sanitize_close_keywords, should_close_ticket
-from teatree.utils import git
+from teatree.utils import git, git_remote
 from teatree.utils.run import CommandFailedError
 
 
@@ -109,7 +109,7 @@ def create_or_defer_pr(repo_path: str, branch_name: str) -> EnsurePrResult:
     warn_if_open_questions_missing(description)
 
     remote = git.remote_url(repo=repo_path)
-    repo_slug = git.slug_from_remote(remote)
+    repo_slug = git_remote.slug_from_remote(remote)
     assignee = host.current_user() or git.config_value(key="user.name")
 
     try:

--- a/src/teatree/core/merge/pr_slug_resolution.py
+++ b/src/teatree/core/merge/pr_slug_resolution.py
@@ -14,7 +14,7 @@ from teatree.core.merge.ci_rollup import fetch_live_head_sha
 from teatree.core.merge.errors import MergePreconditionError
 from teatree.core.overlay_loader import get_all_overlays
 from teatree.project import find_project_root
-from teatree.utils import git
+from teatree.utils import git, git_remote
 from teatree.utils.url_slug import slug_from_issue_or_pr_url
 
 logger = logging.getLogger(__name__)
@@ -192,13 +192,13 @@ def normalize_repo_slug(value: str) -> str:
     fully-qualified key — never an under-qualified form matched by stripping
     the registered slug down.
 
-    Delegates to :func:`teatree.utils.git.slug_from_remote`, the pure string
+    Delegates to :func:`teatree.utils.git_remote.slug_from_remote`, the pure string
     parser that strips the host prefix from a bare ``owner/repo`` (no-op), an
     HTTPS/SSH URL, and a ``host-alias`` SSH URL, dropping any trailing ``.git``.
     A value that yields no ``owner/repo`` shape (empty, a single path segment,
     an unparsable string) returns ``""`` so the caller drops it.
     """
-    slug = git.slug_from_remote(value)
+    slug = git_remote.slug_from_remote(value)
     return slug if _looks_like_owner_repo(slug) else ""
 
 

--- a/src/teatree/core/reference_linkifier.py
+++ b/src/teatree/core/reference_linkifier.py
@@ -116,7 +116,7 @@ class ReferenceResolver:
     @staticmethod
     def _repo_context(overlay: "OverlayBase") -> tuple[str, str]:
         """Return ``(owner/repo slug, web_base)`` from the overlay's first repo remote."""
-        from teatree.utils import git  # noqa: PLC0415
+        from teatree.utils import git, git_remote  # noqa: PLC0415
 
         try:
             repos = overlay.get_repos()
@@ -128,9 +128,9 @@ class ReferenceResolver:
             except Exception as exc:  # noqa: BLE001 — a repo without a resolvable remote is skipped
                 logger.debug("reference_linkifier remote lookup failed for repo %r: %s", repo, exc)
                 continue
-            slug = git.slug_from_remote(remote)
+            slug = git_remote.slug_from_remote(remote)
             if slug:
-                return slug, git.web_base_from_remote(remote)
+                return slug, git_remote.web_base_from_remote(remote)
         return "", ""
 
     def resolve_mr(self, iid: int, *, slug: str = "") -> str | None:

--- a/src/teatree/utils/forge.py
+++ b/src/teatree/utils/forge.py
@@ -8,7 +8,7 @@ regardless of which PATs an overlay happens to carry (#2025).
 
 from typing import Literal
 
-from teatree.utils.git import web_base_from_remote
+from teatree.utils.git_remote import web_base_from_remote
 
 
 def forge_from_remote(remote_url: str) -> Literal["github", "gitlab", ""]:

--- a/src/teatree/utils/git.py
+++ b/src/teatree/utils/git.py
@@ -1,11 +1,6 @@
 import os
-import re
 
 from teatree.utils.run import CommandFailedError, run_allowed_to_fail, run_checked
-
-_REMOTE_HOST_RE = re.compile(r"^(?:git@[^:]+:|https?://[^/]+/|ssh://[^/]+/|git://[^/]+/)")
-_SSH_HOST_RE = re.compile(r"^(?:ssh://)?git@([^:/]+)[:/]")
-_HTTP_HOST_RE = re.compile(r"^(https?)://([^/]+)/")
 
 # ── Low-level runners ───────────────────────────────────────────────
 
@@ -257,36 +252,6 @@ def worktree_add_at_ref(repo: str, path: str, ref: str) -> bool:
 
 def remote_url(repo: str = ".", remote: str = "origin") -> str:
     return run(repo=repo, args=["remote", "get-url", remote])
-
-
-def slug_from_remote(remote_url: str) -> str:
-    """Extract the ``org/repo`` (or ``ns/group/repo``) slug from a git remote URL.
-
-    Pure string helper (no git invocation). Lives in ``utils`` so both
-    ``core`` and the management commands can use it without a layering
-    violation.
-    """
-    if not remote_url:
-        return ""
-    return _REMOTE_HOST_RE.sub("", remote_url.strip()).removesuffix(".git")
-
-
-def web_base_from_remote(remote_url: str) -> str:
-    """Derive the host web origin (``https://host``) from a git remote URL.
-
-    Handles ``git@host:slug.git``, ``ssh://git@host/slug`` and
-    ``https://host/slug`` forms. Returns ``""`` when no host can be parsed.
-    """
-    if not remote_url:
-        return ""
-    text = remote_url.strip()
-    ssh_match = _SSH_HOST_RE.match(text)
-    if ssh_match:
-        return f"https://{ssh_match.group(1)}"
-    http_match = _HTTP_HOST_RE.match(text)
-    if http_match:
-        return f"{http_match.group(1)}://{http_match.group(2)}"
-    return ""
 
 
 def remote_slug(repo: str = ".", remote: str = "origin") -> str:

--- a/src/teatree/utils/git_remote.py
+++ b/src/teatree/utils/git_remote.py
@@ -1,0 +1,47 @@
+"""Pure remote-URL parsing/formatting helpers — no git invocation, no I/O.
+
+This is the side-effect-free partition of git-remote handling, split out of
+:mod:`teatree.utils.git` (which holds the subprocess-invoking git operations).
+Every function here takes a remote-URL string and returns a derived string
+(slug or web origin) with no process spawn, so both ``core`` and the management
+commands can use them without pulling in the runner machinery or risking a
+layering violation. The invoking counterpart — ``remote_url`` /
+``remote_slug``, which actually shell out to ``git remote get-url`` — stays in
+:mod:`teatree.utils.git`.
+"""
+
+import re
+
+_REMOTE_HOST_RE = re.compile(r"^(?:git@[^:]+:|https?://[^/]+/|ssh://[^/]+/|git://[^/]+/)")
+_SSH_HOST_RE = re.compile(r"^(?:ssh://)?git@([^:/]+)[:/]")
+_HTTP_HOST_RE = re.compile(r"^(https?)://([^/]+)/")
+
+
+def slug_from_remote(remote_url: str) -> str:
+    """Extract the ``org/repo`` (or ``ns/group/repo``) slug from a git remote URL.
+
+    Pure string helper (no git invocation). Lives in ``utils`` so both
+    ``core`` and the management commands can use it without a layering
+    violation.
+    """
+    if not remote_url:
+        return ""
+    return _REMOTE_HOST_RE.sub("", remote_url.strip()).removesuffix(".git")
+
+
+def web_base_from_remote(remote_url: str) -> str:
+    """Derive the host web origin (``https://host``) from a git remote URL.
+
+    Handles ``git@host:slug.git``, ``ssh://git@host/slug`` and
+    ``https://host/slug`` forms. Returns ``""`` when no host can be parsed.
+    """
+    if not remote_url:
+        return ""
+    text = remote_url.strip()
+    ssh_match = _SSH_HOST_RE.match(text)
+    if ssh_match:
+        return f"https://{ssh_match.group(1)}"
+    http_match = _HTTP_HOST_RE.match(text)
+    if http_match:
+        return f"{http_match.group(1)}://{http_match.group(2)}"
+    return ""

--- a/tests/teatree_utils/test_git_remote.py
+++ b/tests/teatree_utils/test_git_remote.py
@@ -1,0 +1,38 @@
+from teatree.utils import git_remote
+
+
+class TestSlugFromRemote:
+    def test_github_ssh(self) -> None:
+        assert git_remote.slug_from_remote("git@github.com:acme/widgets.git") == "acme/widgets"
+
+    def test_github_https(self) -> None:
+        assert git_remote.slug_from_remote("https://github.com/acme/widgets.git") == "acme/widgets"
+
+    def test_gitlab_nested_namespace(self) -> None:
+        assert git_remote.slug_from_remote("git@gitlab.com:acme/team/backend.git") == "acme/team/backend"
+
+    def test_no_dot_git_suffix(self) -> None:
+        assert git_remote.slug_from_remote("https://github.com/acme/widgets") == "acme/widgets"
+
+    def test_empty_returns_empty(self) -> None:
+        assert git_remote.slug_from_remote("") == ""
+
+
+class TestWebBaseFromRemote:
+    def test_ssh_form(self) -> None:
+        assert git_remote.web_base_from_remote("git@github.com:acme/widgets.git") == "https://github.com"
+
+    def test_ssh_url_form(self) -> None:
+        assert git_remote.web_base_from_remote("ssh://git@gitlab.com/acme/widgets.git") == "https://gitlab.com"
+
+    def test_https_form(self) -> None:
+        assert git_remote.web_base_from_remote("https://gitlab.com/acme/widgets") == "https://gitlab.com"
+
+    def test_self_hosted_host_preserved(self) -> None:
+        assert git_remote.web_base_from_remote("git@git.example.org:acme/widgets.git") == "https://git.example.org"
+
+    def test_empty_returns_empty(self) -> None:
+        assert git_remote.web_base_from_remote("") == ""
+
+    def test_unparsable_host_returns_empty(self) -> None:
+        assert git_remote.web_base_from_remote("not-a-remote-url") == ""

--- a/tests/utils/test_git_core.py
+++ b/tests/utils/test_git_core.py
@@ -315,37 +315,3 @@ def test_worktree_add_with_and_without_create_branch(monkeypatch: pytest.MonkeyP
     assert git.worktree_add("/tmp/r", "/tmp/wt2", "feat-1", create_branch=False) is True
     assert "-b" not in calls[-1]
     assert "feat-1" in calls[-1]
-
-
-class TestSlugFromRemote:
-    def test_github_ssh(self) -> None:
-        assert git.slug_from_remote("git@github.com:acme/widgets.git") == "acme/widgets"
-
-    def test_github_https(self) -> None:
-        assert git.slug_from_remote("https://github.com/acme/widgets.git") == "acme/widgets"
-
-    def test_gitlab_nested_namespace(self) -> None:
-        assert git.slug_from_remote("git@gitlab.com:acme/team/backend.git") == "acme/team/backend"
-
-    def test_no_dot_git_suffix(self) -> None:
-        assert git.slug_from_remote("https://github.com/acme/widgets") == "acme/widgets"
-
-    def test_empty_returns_empty(self) -> None:
-        assert git.slug_from_remote("") == ""
-
-
-class TestWebBaseFromRemote:
-    def test_ssh_form(self) -> None:
-        assert git.web_base_from_remote("git@github.com:acme/widgets.git") == "https://github.com"
-
-    def test_ssh_url_form(self) -> None:
-        assert git.web_base_from_remote("ssh://git@gitlab.com/acme/widgets.git") == "https://gitlab.com"
-
-    def test_https_form(self) -> None:
-        assert git.web_base_from_remote("https://gitlab.com/acme/widgets") == "https://gitlab.com"
-
-    def test_self_hosted_host_preserved(self) -> None:
-        assert git.web_base_from_remote("git@git.example.org:acme/widgets.git") == "https://git.example.org"
-
-    def test_empty_returns_empty(self) -> None:
-        assert git.web_base_from_remote("") == ""


### PR DESCRIPTION
Bounded behavior-preserving slice of the utils/git module-health tech-debt. Extracts the two pure remote-URL parsing helpers (slug_from_remote, web_base_from_remote) plus the three host-matching regexes they own into a new cohesive src/teatree/utils/git_remote.py. git.py shrinks 37 to 35 public functions and 324 to 296 LOC, satisfying the shrink-only module-health ratchet (check_module_health.py --from-ref origin/main exits 0). The git-invoking ops and the GitRepo wrapper stay; the 35 verb functions are NOT folded onto a class here (separate larger ticket). All four callers updated to git_remote with zero stale references (verified by a repo-wide rg sweep across plain, attribute, and import forms): pr_slug_resolution.py, reference_linkifier.py, _ensure_pr.py, forge.py. The two test classes move to tests/teatree_utils/test_git_remote.py (the mirror dir, so the move does not add to the test-path-mirror baseline). A full PR description with the nine-check architecture pre-check, before/after table, and verification log follows in a comment. Verification: tests/teatree_quality green (55 passed), tach check validated, ruff and ty clean on touched files, consumer suites green.