### PR TITLE
refactor(hooks): extract Slack-mirror from hook_router into src/teatree/hooks leaf + import-direction fitness test

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -7371,130 +7371,42 @@ def handle_block_raw_review_post(data: dict) -> bool:
 
 
 # ── PreToolUse: mirror-question-to-slack ─────────────────────────────
+#
+# The Slack TRANSPORT (open DM, post message, channel cache, question text)
+# lives in the ``teatree.hooks.slack_mirror`` leaf, which posts through the
+# hardened ``SlackHttpClient`` (#1110) instead of the raw ``urllib`` this
+# router carried. The leaf is a pure ``teatree.hooks`` (platform-layer) leaf:
+# it must not import ``teatree.backends.slack`` / ``teatree.core`` (a backwards
+# layer edge tach forbids), so the router — which lives outside ``src`` and may
+# touch the domain — builds the Slack ``post`` and the active-DM-thread resolver
+# here and INJECTS them into the leaf. The router keeps the ROUTING decision
+# (which present-/away-mode arm fires, the DeferredQuestion capture); these thin
+# wrappers preserve the ``patch.object(router, "_perform_slack_post" /
+# "_slack_config_from_toml" / "_read_dm_channel_cache")`` seam the handler tests
+# intercept.
+
+_SLACK_POST_TIMEOUT_SECONDS = 2.0
 
 
-def _slack_config_from_toml() -> tuple[str, str] | None:
-    """Return (bot_token_ref, user_id) from the first slack-enabled overlay."""
-    import tomllib  # noqa: PLC0415
+def _slack_http_poster():  # noqa: ANN202 — Poster protocol from the lazily-imported leaf.
+    """Build the hook-budget Slack poster: ``SlackHttpClient.post``, no retry.
 
-    config_path = Path.home() / ".teatree.toml"
-    if not config_path.is_file():
-        return None
-    try:
-        with config_path.open("rb") as f:
-            config = tomllib.load(f)
-    except Exception:  # noqa: BLE001
-        return None
-    for overlay_cfg in (config.get("overlays") or {}).values():
-        if overlay_cfg.get("messaging_backend") == "slack":
-            ref = overlay_cfg.get("slack_token_ref", "")
-            uid = overlay_cfg.get("slack_user_id", "")
-            if ref and uid:
-                return ref, uid
-    return None
-
-
-def _format_question_text(questions: list[dict]) -> str:
-    lines: list[str] = []
-    for q in questions:
-        lines.append(f"*{q.get('question', '')}*")
-        for i, opt in enumerate(q.get("options", []), 1):
-            label = opt.get("label", "")
-            desc = opt.get("description", "")
-            lines.append(f"  {i}. {label}" + (f" — {desc}" if desc else ""))
-    lines.append("\n_Reply with the number (e.g. `1`) or type your answer._")
-    return "\n".join(lines)
-
-
-def _slack_dm_cache_path() -> Path:
-    base = Path(os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share")))
-    return base / "teatree" / "slack_dm_channels.json"
-
-
-def _read_dm_channel_cache(user_id: str) -> str:
-    path = _slack_dm_cache_path()
-    if not path.is_file():
-        return ""
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return ""
-    if not isinstance(data, dict):
-        return ""
-    cached = data.get(user_id)
-    return cached if isinstance(cached, str) else ""
-
-
-def _write_dm_channel_cache(user_id: str, channel: str) -> None:
-    path = _slack_dm_cache_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        existing = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        existing = {}
-    if not isinstance(existing, dict):
-        existing = {}
-    existing[user_id] = channel
-    path.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-
-
-def _slack_open_dm(bot_token: str, user_id: str, *, timeout: float) -> str:
-    import urllib.request  # noqa: PLC0415
-
-    payload = json.dumps({"users": user_id}).encode()
-    req = urllib.request.Request(
-        "https://slack.com/api/conversations.open",
-        data=payload,
-        headers={"Authorization": f"Bearer {bot_token}", "Content-Type": "application/json"},
-    )
-    try:
-        resp = json.loads(urllib.request.urlopen(req, timeout=timeout).read())  # noqa: S310
-    except Exception:  # noqa: BLE001
-        return ""
-    if not isinstance(resp, dict):
-        return ""
-    channel = resp.get("channel")
-    if not isinstance(channel, dict):
-        return ""
-    cid = channel.get("id")
-    return cid if isinstance(cid, str) else ""
-
-
-def _slack_post_message(bot_token: str, channel: str, text: str, *, timeout: float, thread_ts: str = "") -> str:
-    """Post ``text`` to ``channel``. Return the posted ``ts`` (``""`` on failure).
-
-    The truthiness contract is preserved for callers that branch on the
-    result (a non-empty ts is truthy, ``""`` is falsy), and the ts is the
-    (tool_use_id, slack_ts) link the #1174 reply matcher needs.
+    The mirror runs synchronously inside the ~5s hook timeout, so the client
+    carries the short per-call timeout and NO retry (a retry-with-backoff could
+    blow the budget). This is the router's platform→domain edge (the router is
+    tach-invisible), injected into the pure leaf.
     """
-    import urllib.request  # noqa: PLC0415
+    from teatree.backends.slack.http import SlackHttpClient  # noqa: PLC0415
 
-    body: dict[str, str] = {"channel": channel, "text": text}
-    if thread_ts:
-        body["thread_ts"] = thread_ts
-    payload = json.dumps(body).encode()
-    req = urllib.request.Request(
-        "https://slack.com/api/chat.postMessage",
-        data=payload,
-        headers={"Authorization": f"Bearer {bot_token}", "Content-Type": "application/json"},
-    )
-    try:
-        resp = json.loads(urllib.request.urlopen(req, timeout=timeout).read())  # noqa: S310
-    except Exception:  # noqa: BLE001
-        return ""
-    if not (isinstance(resp, dict) and resp.get("ok") is True):
-        return ""
-    ts = resp.get("ts")
-    return ts if isinstance(ts, str) else ""
+    return SlackHttpClient(timeout=_SLACK_POST_TIMEOUT_SECONDS, max_retries=0).post
 
 
 def _active_dm_thread_for_channel(channel: str) -> str:
     """Resolve the user's active DM thread for ``channel`` from ``IncomingEvent``.
 
-    Threads the mirrored question under the conversation the user is
-    already in instead of opening a new top-level message. Fail-open:
-    any bootstrap or DB error yields ``""`` (post at root) so the hook
-    stays crash-proof.
+    Threads the mirrored question under the conversation the user is already in
+    instead of opening a new top-level message. Fail-open: any bootstrap or DB
+    error yields ``""`` (post at root) so the hook stays crash-proof.
     """
     if not channel or not bootstrap_teatree_django():
         return ""
@@ -7506,52 +7418,27 @@ def _active_dm_thread_for_channel(channel: str) -> str:
         return ""
 
 
-def _slack_post_dm(bot_token: str, user_id: str, text: str, *, timeout: float = 2.0) -> str:
-    """Post ``text`` to ``user_id``'s DM. Resolves channel via cache when possible.
+def _slack_config_from_toml() -> tuple[str, str] | None:
+    from teatree.hooks.slack_mirror import slack_config_from_toml  # noqa: PLC0415
 
-    Cache hit → single ``chat.postMessage`` call (sub-second on a normal
-    connection, fits inside the 3s hook timeout). Cache miss or
-    ``channel_not_found`` → open the DM, cache the channel id, retry.
-    Threads under the user's active DM conversation when one exists.
-    Returns the posted ``ts`` (``""`` on failure) for the #1174 matcher.
-    """
-    cached = _read_dm_channel_cache(user_id)
-    if cached:
-        thread_ts = _active_dm_thread_for_channel(cached)
-        ts = _slack_post_message(bot_token, cached, text, timeout=timeout, thread_ts=thread_ts)
-        if ts:
-            return ts
-    channel = _slack_open_dm(bot_token, user_id, timeout=timeout)
-    if not channel:
-        return ""
-    thread_ts = _active_dm_thread_for_channel(channel)
-    ts = _slack_post_message(bot_token, channel, text, timeout=timeout, thread_ts=thread_ts)
-    if ts:
-        _write_dm_channel_cache(user_id, channel)
-    return ts
+    return slack_config_from_toml()
 
 
 def _perform_slack_post(slack_cfg: tuple[str, str], questions: list[dict]) -> str:
-    """Resolve the bot token and post the question — runs synchronously.
+    from teatree.hooks.slack_mirror import perform_slack_post  # noqa: PLC0415
 
-    Synchronous so the Slack DM lands **before** the AskUserQuestion prompt
-    renders in the terminal. The previous fork-and-detach variant caused
-    the message to arrive *after* the user had already answered. Returns
-    the posted ``ts`` (``""`` on any failure) so the #1174 capture path can
-    link the mirror row to its DM.
-    """
-    token_ref, user_id = slack_cfg
-    result = subprocess.run(  # noqa: S603
-        ["pass", "show", f"{token_ref}-bot"],  # noqa: S607
-        capture_output=True,
-        text=True,
-        timeout=2,
-        check=False,
+    return perform_slack_post(
+        slack_cfg,
+        questions,
+        poster=_slack_http_poster(),
+        resolve_thread=_active_dm_thread_for_channel,
     )
-    bot_token = result.stdout.strip() if result.returncode == 0 else ""
-    if not bot_token:
-        return ""
-    return _slack_post_dm(bot_token, user_id, _format_question_text(questions))
+
+
+def _read_dm_channel_cache(user_id: str) -> str:
+    from teatree.hooks.slack_mirror import read_dm_channel_cache  # noqa: PLC0415
+
+    return read_dm_channel_cache(user_id)
 
 
 def _post_question_to_slack(data: dict) -> None:

--- a/src/teatree/hooks/slack_mirror.py
+++ b/src/teatree/hooks/slack_mirror.py
@@ -1,0 +1,223 @@
+"""Slack transport for the AskUserQuestion mirror (extracted from hook_router).
+
+The PreToolUse mirror posts the user's ``AskUserQuestion`` to their Slack DM
+so they see it on their phone before they answer. The transport — open the
+DM, post the message, cache the channel id, format the question text — was a
+self-contained ~250-LOC cluster inside ``hook_router`` that talked to the
+Slack Web API over RAW ``urllib``. This leaf lifts the whole concern out and
+converges it onto the hardened :class:`~teatree.backends.slack.http.SlackHttpClient`
+(#1110: ``httpx`` + idempotency-aware bounded retry) that the rest of teatree
+already uses — so the router shrinks by the whole concern.
+
+A platform leaf, not a back-edge. ``teatree.hooks`` sits BELOW ``teatree.core``
+and ``teatree.backends.slack`` in the layer DAG (tach), so this leaf must not
+import either — not even lazily (tach scans deferred imports too). The
+higher-layer capabilities it needs — the Slack ``post`` (an instance method of
+``SlackHttpClient``, ``teatree.backends.slack``) and the active-DM-thread
+lookup (``IncomingEvent``, ``teatree.core``) — are INJECTED by the caller as
+:data:`Poster` / :data:`ThreadResolver` callables. The router (``hook_router``,
+outside ``src`` and free to touch the domain) builds the concrete
+implementations and passes them in. The leaf itself imports only stdlib, so it
+stays a true leaf and never reaches ``hook_router`` either — pinned by
+``tests/teatree_quality/test_hooks_import_direction.py``.
+
+The transport keeps the router's timing contract. The mirror runs
+synchronously inside the PreToolUse hook so the DM lands before the in-client
+prompt renders, under a tight (~5s) hook timeout. So the injected
+``SlackHttpClient`` is built with the router's short per-call timeout and NO
+retry (``max_retries=0``) — a retry-with-backoff could blow the hook budget.
+The reliability win is the shared hardened transport (``httpx``, correct
+``ok``/``ts`` handling, idempotency: ``conversations.open`` is a read,
+``chat.postMessage`` is not), not added retries. Every call still degrades to
+``""`` so a Slack outage never blocks the question.
+"""
+
+import json
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Protocol
+
+from teatree.utils.run import run_allowed_to_fail
+
+
+class Poster(Protocol):
+    """The Slack ``post`` capability the transport needs, structurally typed.
+
+    ``SlackHttpClient.post`` satisfies this. Typing it as a Protocol — not the
+    concrete class — keeps this platform leaf from importing the higher-layer
+    ``teatree.backends.slack`` module.
+    """
+
+    def __call__(self, method: str, *, token: str, json: dict, idempotent: bool) -> dict: ...
+
+
+type ThreadResolver = Callable[[str], str]
+
+
+def slack_config_from_toml() -> tuple[str, str] | None:
+    """Return ``(bot_token_ref, user_id)`` from the first slack-enabled overlay."""
+    import tomllib  # noqa: PLC0415
+
+    config_path = Path.home() / ".teatree.toml"
+    if not config_path.is_file():
+        return None
+    try:
+        with config_path.open("rb") as f:
+            config = tomllib.load(f)
+    except Exception:  # noqa: BLE001
+        return None
+    for overlay_cfg in (config.get("overlays") or {}).values():
+        if overlay_cfg.get("messaging_backend") == "slack":
+            ref = overlay_cfg.get("slack_token_ref", "")
+            uid = overlay_cfg.get("slack_user_id", "")
+            if ref and uid:
+                return ref, uid
+    return None
+
+
+def format_question_text(questions: list[dict]) -> str:
+    lines: list[str] = []
+    for q in questions:
+        lines.append(f"*{q.get('question', '')}*")
+        for i, opt in enumerate(q.get("options", []), 1):
+            label = opt.get("label", "")
+            desc = opt.get("description", "")
+            lines.append(f"  {i}. {label}" + (f" — {desc}" if desc else ""))
+    lines.append("\n_Reply with the number (e.g. `1`) or type your answer._")
+    return "\n".join(lines)
+
+
+def slack_dm_cache_path() -> Path:
+    base = Path(os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share")))
+    return base / "teatree" / "slack_dm_channels.json"
+
+
+def read_dm_channel_cache(user_id: str) -> str:
+    path = slack_dm_cache_path()
+    if not path.is_file():
+        return ""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    cached = data.get(user_id)
+    return cached if isinstance(cached, str) else ""
+
+
+def write_dm_channel_cache(user_id: str, channel: str) -> None:
+    path = slack_dm_cache_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        existing = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        existing = {}
+    if not isinstance(existing, dict):
+        existing = {}
+    existing[user_id] = channel
+    path.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _str_field(mapping: dict | None, key: str) -> str:
+    """Return ``mapping[key]`` when it is a str, else ``""`` (``None`` mapping → ``""``)."""
+    if mapping is None:
+        return ""
+    value = mapping.get(key)
+    return value if isinstance(value, str) else ""
+
+
+def _sub_mapping(mapping: dict, key: str) -> dict | None:
+    """Return ``mapping[key]`` when it is itself a mapping, else ``None``."""
+    value = mapping.get(key)
+    return value if isinstance(value, dict) else None
+
+
+def slack_open_dm(poster: Poster, bot_token: str, user_id: str) -> str:
+    """Open the user's DM and return its channel id (``""`` on failure).
+
+    ``conversations.open`` is idempotent (re-opening the same DM returns the
+    same channel) so ``idempotent=True`` is the correct classification.
+    """
+    try:
+        resp = poster("conversations.open", token=bot_token, json={"users": user_id}, idempotent=True)
+    except Exception:  # noqa: BLE001
+        return ""
+    return _str_field(_sub_mapping(resp, "channel"), "id")
+
+
+def slack_post_message(poster: Poster, channel: str, text: str, *, bot_token: str, thread_ts: str = "") -> str:
+    """Post ``text`` to ``channel``. Return the posted ``ts`` (``""`` on failure).
+
+    The truthiness contract is preserved for callers that branch on the
+    result (a non-empty ts is truthy, ``""`` is falsy), and the ts is the
+    (tool_use_id, slack_ts) link the #1174 reply matcher needs.
+
+    ``chat.postMessage`` is NOT idempotent (``idempotent=False``): a lost
+    response after Slack accepted the post must not be replayed into a
+    double-post — the hardened poster surfaces the failure rather than retry.
+    """
+    body: dict[str, str] = {"channel": channel, "text": text}
+    if thread_ts:
+        body["thread_ts"] = thread_ts
+    try:
+        resp = poster("chat.postMessage", token=bot_token, json=body, idempotent=False)
+    except Exception:  # noqa: BLE001
+        return ""
+    if resp.get("ok") is not True:
+        return ""
+    return _str_field(resp, "ts")
+
+
+def slack_post_dm(poster: Poster, resolve_thread: ThreadResolver, bot_token: str, user_id: str, text: str) -> str:
+    """Post ``text`` to ``user_id``'s DM. Resolves channel via cache when possible.
+
+    Cache hit → single ``chat.postMessage`` call (sub-second on a normal
+    connection, fits inside the hook timeout). Cache miss or
+    ``channel_not_found`` → open the DM, cache the channel id, retry.
+    Threads under the user's active DM conversation when one exists (via the
+    injected ``resolve_thread``). Returns the posted ``ts`` (``""`` on
+    failure) for the #1174 matcher.
+    """
+    cached = read_dm_channel_cache(user_id)
+    if cached:
+        thread_ts = resolve_thread(cached)
+        ts = slack_post_message(poster, cached, text, bot_token=bot_token, thread_ts=thread_ts)
+        if ts:
+            return ts
+    channel = slack_open_dm(poster, bot_token, user_id)
+    if not channel:
+        return ""
+    thread_ts = resolve_thread(channel)
+    ts = slack_post_message(poster, channel, text, bot_token=bot_token, thread_ts=thread_ts)
+    if ts:
+        write_dm_channel_cache(user_id, channel)
+    return ts
+
+
+def perform_slack_post(
+    slack_cfg: tuple[str, str],
+    questions: list[dict],
+    *,
+    poster: Poster,
+    resolve_thread: ThreadResolver,
+) -> str:
+    """Resolve the bot token and post the question — runs synchronously.
+
+    Synchronous so the Slack DM lands **before** the AskUserQuestion prompt
+    renders in the terminal. The previous fork-and-detach variant caused the
+    message to arrive *after* the user had already answered. Returns the
+    posted ``ts`` (``""`` on any failure) so the #1174 capture path can link
+    the mirror row to its DM.
+
+    ``poster`` (the Slack ``SlackHttpClient.post``) and ``resolve_thread`` (the
+    ``IncomingEvent`` active-DM lookup) are injected by the router so this
+    transport stays a pure ``teatree.hooks`` leaf with no upward import.
+    """
+    token_ref, user_id = slack_cfg
+    result = run_allowed_to_fail(["pass", "show", f"{token_ref}-bot"], expected_codes=None, timeout=2)
+    bot_token = result.stdout.strip() if result.returncode == 0 else ""
+    if not bot_token:
+        return ""
+    return slack_post_dm(poster, resolve_thread, bot_token, user_id, format_question_text(questions))

--- a/tests/teatree_core/models/test_slack_mirror_hook.py
+++ b/tests/teatree_core/models/test_slack_mirror_hook.py
@@ -9,7 +9,7 @@ post fits inside the hook timeout.
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -234,105 +234,21 @@ class TestPresentLoopDrivenTurnDeniesAndCaptures:
         assert capsys.readouterr().out.strip() == ""
 
 
-class TestSlackPostMessageReturnsTs:
-    def test_returns_ts_on_success(self) -> None:
-        resp = MagicMock()
-        resp.read.return_value = json.dumps({"ok": True, "ts": "1700.0001"}).encode()
-        with patch("urllib.request.urlopen", return_value=resp):
-            ts = router._slack_post_message("tok", "D1", "hi", timeout=2.0)
-        assert ts == "1700.0001"
+class TestRouterDomainWiring:
+    """The router owns the platform→domain edges the leaf must not carry.
 
-    def test_returns_empty_on_failure(self) -> None:
-        with patch("urllib.request.urlopen", side_effect=RuntimeError("down")):
-            ts = router._slack_post_message("tok", "D1", "hi", timeout=2.0)
-        assert ts == ""
+    The ``teatree.hooks.slack_mirror`` leaf is a pure platform leaf, so the
+    Slack ``post`` (``teatree.backends.slack``) and the active-DM-thread lookup
+    (``teatree.core``) are built HERE and injected. These pin that wiring.
+    """
 
+    def test_http_poster_is_slack_client_post_with_no_retry(self) -> None:
+        poster = router._slack_http_poster()
+        client = poster.__self__
+        assert client._max_retries == 0
+        assert client._timeout == pytest.approx(router._SLACK_POST_TIMEOUT_SECONDS)
 
-class TestDmChannelCache:
-    def test_round_trip_through_cache_file(self, tmp_path: Path, monkeypatch) -> None:
-        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
-        assert router._read_dm_channel_cache("U1") == ""
-        router._write_dm_channel_cache("U1", "D123")
-        assert router._read_dm_channel_cache("U1") == "D123"
-
-    def test_multiple_users_in_same_cache(self, tmp_path: Path, monkeypatch) -> None:
-        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
-        router._write_dm_channel_cache("U1", "D1")
-        router._write_dm_channel_cache("U2", "D2")
-        assert router._read_dm_channel_cache("U1") == "D1"
-        assert router._read_dm_channel_cache("U2") == "D2"
-
-    def test_corrupt_cache_returns_empty(self, tmp_path: Path, monkeypatch) -> None:
-        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
-        path = router._slack_dm_cache_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text("not json", encoding="utf-8")
-        assert router._read_dm_channel_cache("U1") == ""
-
-
-class TestSlackPostDm:
-    def test_cache_hit_skips_open_dm(self, tmp_path: Path, monkeypatch) -> None:
-        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
-        router._write_dm_channel_cache("U1", "D-cached")
-        with (
-            patch.object(router, "_slack_open_dm") as mock_open,
-            patch.object(router, "_active_dm_thread_for_channel", return_value=""),
-            patch.object(router, "_slack_post_message", return_value=True) as mock_post,
-        ):
-            router._slack_post_dm("xoxb-tok", "U1", "hello")
-        mock_open.assert_not_called()
-        mock_post.assert_called_once_with("xoxb-tok", "D-cached", "hello", timeout=2.0, thread_ts="")
-
-    def test_cache_miss_opens_dm_and_caches(self, tmp_path: Path, monkeypatch) -> None:
-        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
-        with (
-            patch.object(router, "_slack_open_dm", return_value="D-new") as mock_open,
-            patch.object(router, "_active_dm_thread_for_channel", return_value=""),
-            patch.object(router, "_slack_post_message", return_value=True) as mock_post,
-        ):
-            router._slack_post_dm("xoxb-tok", "U1", "hello")
-        mock_open.assert_called_once()
-        mock_post.assert_called_once_with("xoxb-tok", "D-new", "hello", timeout=2.0, thread_ts="")
-        assert router._read_dm_channel_cache("U1") == "D-new"
-
-    def test_stale_cache_falls_back_to_open(self, tmp_path: Path, monkeypatch) -> None:
-        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
-        router._write_dm_channel_cache("U1", "D-stale")
-        with (
-            patch.object(router, "_slack_open_dm", return_value="D-fresh") as mock_open,
-            patch.object(router, "_active_dm_thread_for_channel", return_value=""),
-            patch.object(router, "_slack_post_message", side_effect=[False, True]) as mock_post,
-        ):
-            router._slack_post_dm("xoxb-tok", "U1", "hello")
-        mock_open.assert_called_once()
-        assert mock_post.call_count == 2
-        assert router._read_dm_channel_cache("U1") == "D-fresh"
-
-    def test_cache_hit_threads_under_active_dm_thread(self, tmp_path: Path, monkeypatch) -> None:
-        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
-        router._write_dm_channel_cache("U1", "D-cached")
-        with (
-            patch.object(router, "_active_dm_thread_for_channel", return_value="1700000000.0009") as mock_thread,
-            patch.object(router, "_slack_post_message", return_value=True) as mock_post,
-        ):
-            router._slack_post_dm("xoxb-tok", "U1", "hello")
-        mock_thread.assert_called_once_with("D-cached")
-        mock_post.assert_called_once_with("xoxb-tok", "D-cached", "hello", timeout=2.0, thread_ts="1700000000.0009")
-
-    def test_opened_channel_threads_under_active_dm_thread(self, tmp_path: Path, monkeypatch) -> None:
-        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
-        with (
-            patch.object(router, "_slack_open_dm", return_value="D-new"),
-            patch.object(router, "_active_dm_thread_for_channel", return_value="1700000000.0042") as mock_thread,
-            patch.object(router, "_slack_post_message", return_value=True) as mock_post,
-        ):
-            router._slack_post_dm("xoxb-tok", "U1", "hello")
-        mock_thread.assert_called_once_with("D-new")
-        mock_post.assert_called_once_with("xoxb-tok", "D-new", "hello", timeout=2.0, thread_ts="1700000000.0042")
-
-
-class TestActiveDmThreadResolver:
-    def test_resolves_most_recent_slack_thread_ref_for_channel(self) -> None:
+    def test_active_dm_thread_resolves_most_recent_ref_for_channel(self) -> None:
         from teatree.core.models import IncomingEvent  # noqa: PLC0415
 
         IncomingEvent.objects.create(
@@ -344,7 +260,10 @@ class TestActiveDmThreadResolver:
 
         assert router._active_dm_thread_for_channel("D-cached") == "1700000000.0009"
 
-    def test_empty_when_django_unavailable(self) -> None:
+    def test_active_dm_thread_empty_when_no_channel(self) -> None:
+        assert router._active_dm_thread_for_channel("") == ""
+
+    def test_active_dm_thread_empty_when_django_unavailable(self) -> None:
         with patch.object(router, "bootstrap_teatree_django", return_value=False):
             assert router._active_dm_thread_for_channel("D-cached") == ""
 

--- a/tests/teatree_hooks/test_slack_mirror.py
+++ b/tests/teatree_hooks/test_slack_mirror.py
@@ -1,0 +1,202 @@
+"""Slack transport leaf for the AskUserQuestion mirror (extracted from hook_router).
+
+Ports the transport-level coverage that lived in
+``tests/teatree_core/models/test_slack_mirror_hook.py`` (channel cache,
+``slack_post_message`` ts contract, ``slack_post_dm`` cache/open/thread flow)
+onto the new ``teatree.hooks.slack_mirror`` leaf, and pins the #1110/#2384
+design: the leaf is a pure ``teatree.hooks`` (platform) leaf — the Slack
+``post`` (``conversations.open`` idempotent, ``chat.postMessage`` NOT
+idempotent) and the active-DM-thread resolver are INJECTED, so the leaf never
+imports ``teatree.backends.slack`` / ``teatree.core`` (a backwards layer edge).
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from teatree.hooks import slack_mirror
+
+
+def _no_thread(_channel: str) -> str:
+    return ""
+
+
+class TestSlackPostMessageInjectsPoster:
+    """The transport calls the injected poster with the right idempotency class."""
+
+    def test_open_dm_posts_conversations_open_idempotent(self) -> None:
+        poster = MagicMock(return_value={"ok": True, "channel": {"id": "D-open"}})
+        cid = slack_mirror.slack_open_dm(poster, "tok", "U1")
+        assert cid == "D-open"
+        poster.assert_called_once_with("conversations.open", token="tok", json={"users": "U1"}, idempotent=True)
+
+    def test_open_dm_empty_on_missing_channel(self) -> None:
+        poster = MagicMock(return_value={"ok": True})
+        assert slack_mirror.slack_open_dm(poster, "tok", "U1") == ""
+
+    def test_open_dm_empty_on_transport_error(self) -> None:
+        poster = MagicMock(side_effect=RuntimeError("down"))
+        assert slack_mirror.slack_open_dm(poster, "tok", "U1") == ""
+
+    def test_post_message_posts_chat_postmessage_non_idempotent(self) -> None:
+        poster = MagicMock(return_value={"ok": True, "ts": "1700.0001"})
+        ts = slack_mirror.slack_post_message(poster, "D1", "hi", bot_token="tok")
+        assert ts == "1700.0001"
+        poster.assert_called_once_with(
+            "chat.postMessage", token="tok", json={"channel": "D1", "text": "hi"}, idempotent=False
+        )
+
+    def test_post_message_threads_under_thread_ts(self) -> None:
+        poster = MagicMock(return_value={"ok": True, "ts": "1700.0002"})
+        slack_mirror.slack_post_message(poster, "D1", "hi", bot_token="tok", thread_ts="1700.0000")
+        _name, kwargs = poster.call_args
+        assert kwargs["json"] == {"channel": "D1", "text": "hi", "thread_ts": "1700.0000"}
+
+    def test_post_message_empty_on_not_ok(self) -> None:
+        poster = MagicMock(return_value={"ok": False, "error": "channel_not_found"})
+        assert slack_mirror.slack_post_message(poster, "D1", "hi", bot_token="tok") == ""
+
+    def test_post_message_empty_on_transport_error(self) -> None:
+        poster = MagicMock(side_effect=RuntimeError("down"))
+        assert slack_mirror.slack_post_message(poster, "D1", "hi", bot_token="tok") == ""
+
+
+class TestDmChannelCache:
+    def test_round_trip_through_cache_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        assert slack_mirror.read_dm_channel_cache("U1") == ""
+        slack_mirror.write_dm_channel_cache("U1", "D123")
+        assert slack_mirror.read_dm_channel_cache("U1") == "D123"
+
+    def test_multiple_users_in_same_cache(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        slack_mirror.write_dm_channel_cache("U1", "D1")
+        slack_mirror.write_dm_channel_cache("U2", "D2")
+        assert slack_mirror.read_dm_channel_cache("U1") == "D1"
+        assert slack_mirror.read_dm_channel_cache("U2") == "D2"
+
+    def test_corrupt_cache_returns_empty(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        path = slack_mirror.slack_dm_cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not json", encoding="utf-8")
+        assert slack_mirror.read_dm_channel_cache("U1") == ""
+
+
+class TestSlackPostDm:
+    def test_cache_hit_skips_open_dm(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        slack_mirror.write_dm_channel_cache("U1", "D-cached")
+        with (
+            patch.object(slack_mirror, "slack_open_dm") as mock_open,
+            patch.object(slack_mirror, "slack_post_message", return_value="1700.1") as mock_post,
+        ):
+            slack_mirror.slack_post_dm(MagicMock(), _no_thread, "xoxb-tok", "U1", "hello")
+        mock_open.assert_not_called()
+        _poster, channel, text = mock_post.call_args.args
+        assert (channel, text) == ("D-cached", "hello")
+        assert mock_post.call_args.kwargs == {"bot_token": "xoxb-tok", "thread_ts": ""}
+
+    def test_cache_miss_opens_dm_and_caches(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        with (
+            patch.object(slack_mirror, "slack_open_dm", return_value="D-new") as mock_open,
+            patch.object(slack_mirror, "slack_post_message", return_value="1700.1") as mock_post,
+        ):
+            slack_mirror.slack_post_dm(MagicMock(), _no_thread, "xoxb-tok", "U1", "hello")
+        mock_open.assert_called_once()
+        _poster, channel, text = mock_post.call_args.args
+        assert (channel, text) == ("D-new", "hello")
+        assert slack_mirror.read_dm_channel_cache("U1") == "D-new"
+
+    def test_stale_cache_falls_back_to_open(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        slack_mirror.write_dm_channel_cache("U1", "D-stale")
+        with (
+            patch.object(slack_mirror, "slack_open_dm", return_value="D-fresh") as mock_open,
+            patch.object(slack_mirror, "slack_post_message", side_effect=["", "1700.1"]) as mock_post,
+        ):
+            slack_mirror.slack_post_dm(MagicMock(), _no_thread, "xoxb-tok", "U1", "hello")
+        mock_open.assert_called_once()
+        assert mock_post.call_count == 2
+        assert slack_mirror.read_dm_channel_cache("U1") == "D-fresh"
+
+    def test_cache_hit_threads_under_active_dm_thread(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        slack_mirror.write_dm_channel_cache("U1", "D-cached")
+        resolver = MagicMock(return_value="1700000000.0009")
+        with patch.object(slack_mirror, "slack_post_message", return_value="1700.1") as mock_post:
+            slack_mirror.slack_post_dm(MagicMock(), resolver, "xoxb-tok", "U1", "hello")
+        resolver.assert_called_once_with("D-cached")
+        assert mock_post.call_args.kwargs == {"bot_token": "xoxb-tok", "thread_ts": "1700000000.0009"}
+
+    def test_opened_channel_threads_under_active_dm_thread(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+        resolver = MagicMock(return_value="1700000000.0042")
+        with (
+            patch.object(slack_mirror, "slack_open_dm", return_value="D-new"),
+            patch.object(slack_mirror, "slack_post_message", return_value="1700.1") as mock_post,
+        ):
+            slack_mirror.slack_post_dm(MagicMock(), resolver, "xoxb-tok", "U1", "hello")
+        resolver.assert_called_once_with("D-new")
+        assert mock_post.call_args.kwargs == {"bot_token": "xoxb-tok", "thread_ts": "1700000000.0042"}
+
+
+class TestQuestionFormatting:
+    def test_formats_question_with_numbered_options(self) -> None:
+        text = slack_mirror.format_question_text(
+            [{"question": "Ship it?", "options": [{"label": "Yes", "description": "go"}, {"label": "No"}]}]
+        )
+        assert "*Ship it?*" in text
+        assert "1. Yes — go" in text
+        assert "2. No" in text
+        assert "Reply with the number" in text
+
+
+class TestConfigFromToml:
+    def test_returns_ref_and_uid_for_slack_overlay(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        (tmp_path / ".teatree.toml").write_text(
+            '[overlays.acme]\nmessaging_backend = "slack"\nslack_token_ref = "secret/acme"\nslack_user_id = "U9"\n',
+            encoding="utf-8",
+        )
+        assert slack_mirror.slack_config_from_toml() == ("secret/acme", "U9")
+
+    def test_none_when_no_config_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert slack_mirror.slack_config_from_toml() is None
+
+    def test_none_when_no_slack_overlay(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        (tmp_path / ".teatree.toml").write_text('[overlays.acme]\nmessaging_backend = "console"\n', encoding="utf-8")
+        assert slack_mirror.slack_config_from_toml() is None
+
+
+class TestPerformSlackPostInjectsDependencies:
+    def test_returns_empty_when_token_unavailable(self) -> None:
+        result = MagicMock(returncode=1, stdout="")
+        with patch.object(slack_mirror, "run_allowed_to_fail", return_value=result):
+            ts = slack_mirror.perform_slack_post(
+                ("ref", "U1"), [{"question": "Q"}], poster=MagicMock(), resolve_thread=_no_thread
+            )
+        assert ts == ""
+
+    def test_posts_dm_with_injected_poster_and_resolver(self) -> None:
+        result = MagicMock(returncode=0, stdout="xoxb-tok\n")
+        poster = MagicMock()
+        with (
+            patch.object(slack_mirror, "run_allowed_to_fail", return_value=result) as mock_run,
+            patch.object(slack_mirror, "slack_post_dm", return_value="1700.5") as mock_dm,
+        ):
+            ts = slack_mirror.perform_slack_post(
+                ("ref", "U1"), [{"question": "Q"}], poster=poster, resolve_thread=_no_thread
+            )
+        assert ts == "1700.5"
+        assert mock_run.call_args.args[0] == ["pass", "show", "ref-bot"]
+        passed_poster, passed_resolver, bot_token, user_id, _text = mock_dm.call_args.args
+        assert passed_poster is poster
+        assert passed_resolver is _no_thread
+        assert (bot_token, user_id) == ("xoxb-tok", "U1")

--- a/tests/teatree_quality/test_hooks_import_direction.py
+++ b/tests/teatree_quality/test_hooks_import_direction.py
@@ -1,0 +1,90 @@
+"""Fitness function: the hook-leaf import direction is ONE-WAY (router → leaf).
+
+``hooks/scripts/hook_router.py`` is the PreToolUse/Stop/SessionStart dispatcher.
+A whole concern at a time is being lifted out of the 8800-LOC router into a
+leaf under ``src/teatree/hooks/`` (the Slack mirror, #2384; the ~25 scanner
+leaves before it). The router imports the leaves; a leaf must NEVER import the
+router back. A back-edge (``from hook_router import …`` inside a leaf, top-level
+OR lazy) means the "extraction" still depends on router internals — the concern
+was not actually self-contained, the router cannot shrink permanently, and the
+dependency graph grows a cycle the module-health work exists to remove.
+
+No fitness function governed this before: ``hook_router`` lives OUTSIDE ``src/``
+so tach does not see it, and the per-file scan filters to ``src/``. This AST
+test closes that gap for the import EDGE the way ``check_module_health.py``
+closed it for the LOC.
+
+Two halves, mirroring ``tests/quality/test_project_leaf.py``:
+
+:class:`TestNoLeafImportsRouter` AST-scans every ``src/teatree/hooks/*.py`` leaf
+and asserts none imports ``hook_router`` — a copy-pasted ``from hook_router
+import _helper`` turns it red.
+
+:class:`TestCheckerIsAntiVacuous` plants a synthetic leaf carrying the back-edge
+and proves the same checker flags it (so the live-tree green is meaningful, not
+a no-op), and a synthetic clean leaf proves it does NOT over-flag.
+"""
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_HOOKS_LEAF_DIR = _REPO_ROOT / "src" / "teatree" / "hooks"
+
+# The forbidden back-edge target. Both the bare module (the router runs as a
+# script with ``hooks/scripts`` on sys.path) and the dotted subprocess form
+# (``hooks.scripts.hook_router``) are back-edges.
+_ROUTER_NAMES = {"hook_router", "hooks.scripts.hook_router"}
+
+
+def _imports_router(source: str, *, filename: str = "<leaf>") -> bool:
+    """Whether *source* imports ``hook_router`` in any form (top-level or lazy).
+
+    ``ast.walk`` reaches function-body imports too, so a lazy
+    ``from hook_router import …`` inside a handler is caught, not just a
+    top-level import.
+    """
+    tree = ast.parse(source, filename=filename)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module in _ROUTER_NAMES:
+            return True
+        if isinstance(node, ast.Import) and any(alias.name in _ROUTER_NAMES for alias in node.names):
+            return True
+    return False
+
+
+def _leaf_files() -> list[Path]:
+    return sorted(p for p in _HOOKS_LEAF_DIR.glob("*.py") if p.name != "__init__.py")
+
+
+class TestNoLeafImportsRouter:
+    def test_no_hooks_leaf_imports_hook_router(self) -> None:
+        offenders = [p.name for p in _leaf_files() if _imports_router(p.read_text(encoding="utf-8"), filename=p.name)]
+        assert not offenders, (
+            "src/teatree/hooks leaves must stay leaves: the router imports them, never the reverse. "
+            f"These leaves carry a back-edge to hook_router: {offenders}. Move the shared helper into the "
+            "leaf (or a deeper leaf both import) instead of importing the router back."
+        )
+
+    def test_at_least_one_leaf_scanned(self) -> None:
+        # Guard against a path typo silently making the gate scan nothing.
+        assert _leaf_files(), f"no hook leaves found under {_HOOKS_LEAF_DIR} — the gate would be vacuous"
+
+
+class TestCheckerIsAntiVacuous:
+    _CLEAN_LEAF = "from teatree.backends.slack.http import SlackHttpClient\n\n\ndef post() -> None:\n    pass\n"
+    _TOPLEVEL_BACK_EDGE = "from hook_router import _helper\n\n\ndef post() -> None:\n    _helper()\n"
+    _LAZY_BACK_EDGE = "def post() -> None:\n    from hook_router import _helper  # noqa: PLC0415\n\n    _helper()\n"
+    _DOTTED_BACK_EDGE = "import hooks.scripts.hook_router as r\n\n\ndef post() -> None:\n    r.main()\n"
+
+    def test_flags_top_level_back_edge(self) -> None:
+        assert _imports_router(self._TOPLEVEL_BACK_EDGE) is True
+
+    def test_flags_lazy_back_edge(self) -> None:
+        assert _imports_router(self._LAZY_BACK_EDGE) is True
+
+    def test_flags_dotted_back_edge(self) -> None:
+        assert _imports_router(self._DOTTED_BACK_EDGE) is True
+
+    def test_does_not_flag_clean_leaf(self) -> None:
+        assert _imports_router(self._CLEAN_LEAF) is False


### PR DESCRIPTION
Closes part of #2384 (extract one whole cohesive concern; the loop-registry and deny-circuit-breaker clusters remain for follow-up PRs).

## What

Extracts the Slack-mirror transport concern out of the 8846-LOC hooks/scripts/hook_router.py god-module into a new src/teatree/hooks/slack_mirror.py leaf, and converges it onto the hardened SlackHttpClient (#1110) instead of the raw urllib the router carried - two findings at once (shrink the router AND close the duplicated Slack-transport seam).

Concern chosen: the Slack-mirror (the issue first-choice target). It extracts cleanly: the transport (open DM, post message, channel cache, question text, config read) is a self-contained cluster, and SlackHttpClient already existed as the hardened replacement for the raw-urllib path.

## LOC delta

hooks/scripts/hook_router.py: 8846 -> 8733 (net shrink of 113 LOC). The whole transport left the router; what stayed is the routing decision (present-/away-mode arms, the DeferredQuestion capture) plus thin patchable wrappers and the two router-owned domain-wiring helpers.

## The layering wrinkle and how it is resolved

teatree.hooks is a platform-layer package, BELOW teatree.core and teatree.backends.slack (domain) in the tach DAG. A pure leaf there must not import either - not even lazily (tach scans deferred imports). So the two higher-layer capabilities the transport needs are injected: the Slack post (SlackHttpClient.post) and the active-DM-thread lookup (IncomingEvent). The router (outside src/, free to touch the domain) builds both and passes them into the pure leaf. The shell-out to pass goes through teatree.utils.run per the src/ chokepoint.

## Behaviour preservation

Behaviour-identical: conversations.open stays idempotent, chat.postMessage stays NON-idempotent (no double-post replay), the channel cache and active-DM threading are unchanged, and every call still degrades to empty so a Slack outage never blocks the question. The injected client carries the hook short per-call timeout and no retry so the synchronous mirror keeps fitting the ~5s hook budget. The patch.object(router, ...) seam the handler tests intercept is preserved by router wrappers.

## The missing fitness function

Adds tests/teatree_quality/test_hooks_import_direction.py - an AST test asserting the one-way rule router -> leaf, never leaf -> router back-edge over src/teatree/hooks/*.py. No gate covered this before because hook_router lives outside src/. Anti-vacuity proof: injecting a temp back-edge into the leaf turns the live-tree test RED; removing it returns GREEN. A synthetic corpus also proves the checker flags top-level, lazy, and dotted back-edges and does not over-flag a clean leaf.

## Architecture pre-check - #2384

1. BLUEPRINT alignment - hooks/scripts/ decomposition + teatree.hooks leaf convention + the tach layer DAG. No prose change (the leaf convention already exists; ~25 sibling leaves).
2. FSM phase boundaries - n/a. No state transition touched.
3. Extension-point contracts - new teatree.hooks leaf consumed by lazy import like the other ~25 leaves. No OverlayBase/scanner/Backend Protocol changed. The new Poster Protocol is local to the leaf.
4. Component boundaries - transport -> src/teatree/hooks/slack_mirror.py; routing + domain wiring stays in hook_router.py.
5. Dependency direction - uv run tach check passes. The would-be backwards edges are inverted via dependency injection.
6. Test surface - tests/teatree_hooks/test_slack_mirror.py, tests/teatree_core/models/test_slack_mirror_hook.py, tests/teatree_quality/test_hooks_import_direction.py.
7. Resilience invariants - idempotency preserved per API-call class; fail-open to empty on any transport/IO error; the #1174 mirror-link contract unchanged.
8. Identity/key normalization - n/a.
9. Behavior preservation - every transport behaviour preserved; only implementation change is raw urllib -> SlackHttpClient (intended convergence). No privacy/security matcher narrowed; no must-block test inverted.

## Gates run

- uv run pytest tests/teatree_quality/ -q -> 64 passed (incl. the new AST test)
- uv run python scripts/hooks/check_module_health.py --from-ref origin/main -> exit 0; hook_router 8846 -> 8733
- 165 hook-router-related tests green; full pre-commit suite green
