### PR TITLE
refactor(utils): fold over-cap git.py into cohesive sibling modules

### DIFF
--- a/src/teatree/utils/git.py
+++ b/src/teatree/utils/git.py
@@ -1,352 +1,102 @@
-import os
-
-from teatree.utils.run import CommandFailedError, run_allowed_to_fail, run_checked
-
-# ── Low-level runners ───────────────────────────────────────────────
-
-
-def run(*, repo: str = ".", args: list[str]) -> str:
-    result = run_allowed_to_fail(["git", "-C", repo, *args], expected_codes=None)
-    return result.stdout.strip()
-
-
-def run_strict(*, repo: str = ".", args: list[str]) -> str:
-    result = run_checked(["git", "-C", repo, *args])
-    return result.stdout.strip()
-
-
-def check(*, repo: str = ".", args: list[str]) -> bool:
-    return run_allowed_to_fail(["git", "-C", repo, *args], expected_codes=None).returncode == 0
-
-
-# ── High-level operations ────────────────────────────────────────────
-
-
-def merge_base(repo: str = ".", target: str = "origin/main") -> str:
-    return run_strict(repo=repo, args=["merge-base", target, "HEAD"])
-
-
-def rev_count(repo: str = ".", range_spec: str = "") -> int:
-    out = run_strict(repo=repo, args=["rev-list", "--count", range_spec])
-    return int(out)
-
-
-def log_oneline(repo: str = ".", range_spec: str = "") -> str:
-    return run(repo=repo, args=["log", "--oneline", range_spec])
-
-
-def unsynced_commits(repo: str, branch: str, target: str = "origin/main") -> list[str]:
-    output = run(repo=repo, args=["log", branch, "--not", target, "--oneline"])
-    return [line for line in output.splitlines() if line.strip()]
-
-
-def commits_absent_from_all_remotes(repo: str, ref: str) -> list[str]:
-    """Return ``ref`` commits not reachable from ANY ``refs/remotes/*`` ref.
-
-    The data-loss guard for worktree teardown (#706). ``ref`` is any revision
-    git accepts — a branch name, or the literal ``HEAD`` when probing a worktree
-    directory directly (robust to a DB-vs-git branch drift and to detached HEAD).
-    Unlike :func:`unsynced_commits` (which compares against ``origin/main`` only
-    and therefore flags pushed-but-unmerged branches), ``--not --remotes`` is
-    empty whenever the tip was pushed anywhere — to its own remote tracking ref,
-    to main, or captured by a squash-merge that was itself pushed. A non-empty
-    result means these commits exist on NO remote: removing the worktree would
-    destroy them irrecoverably. Returns ``"<sha> <subject>"`` lines (newest
-    first).
-
-    **Fails closed.** Uses :func:`run_strict` so a non-zero ``git log`` exit
-    (invalid/missing ref, corrupt repo, any git error) raises
-    ``CommandFailedError`` rather than yielding an empty list. For a data-loss
-    guard, "we couldn't determine whether the commits are pushed" must block
-    teardown, not allow it. The legitimate empty case (``git log`` exits 0 with
-    no output because the ref genuinely has nothing absent from remotes)
-    still returns ``[]`` and allows teardown.
-    """
-    output = run_strict(repo=repo, args=["log", ref, "--not", "--remotes", "--oneline"])
-    return [line for line in output.splitlines() if line.strip()]
-
-
-def status_porcelain(repo: str = ".") -> str:
-    return run(repo=repo, args=["status", "--porcelain"])
-
-
-def status_porcelain_strict(repo: str = ".") -> str:
-    """Like :func:`status_porcelain` but raises on a non-zero ``git status`` exit.
-
-    :func:`status_porcelain` swallows git errors and returns whatever (possibly
-    empty) stdout it got, so an inconclusive status (lock contention, corrupt
-    index, missing dir) is indistinguishable from a genuinely clean tree. For a
-    data-loss decision that must fail closed, use this variant: a git error
-    raises ``CommandFailedError`` so the caller can treat "couldn't determine"
-    as "might be dirty" rather than "clean".
-    """
-    return run_strict(repo=repo, args=["status", "--porcelain"])
-
-
-def soft_reset(repo: str = ".", target: str = "") -> None:
-    run_strict(repo=repo, args=["reset", "--soft", target])
-
-
-def commit(repo: str = ".", message: str = "") -> None:
-    run_strict(repo=repo, args=["commit", "-m", message])
-
-
-def fetch(repo: str = ".", remote: str = "origin", ref: str = "") -> None:
-    args = ["fetch", remote]
-    if ref:
-        args.append(ref)
-    run(repo=repo, args=args)
-
-
-def rebase(repo: str = ".", target: str = "") -> None:
-    run_strict(repo=repo, args=["rebase", target])
-
-
-def merge_no_edit(repo: str = ".", target: str = "") -> bool:
-    """``git merge --no-edit <target>`` — returns ``True`` on success.
-
-    The branch-currency gate's primitive (#940). Fast-forward is
-    preferred (the default ``git merge`` posture); a non-FF merge with
-    an empty editor commit is created when fast-forward isn't possible.
-    A conflict yields ``False`` — the caller is expected to call
-    :func:`merge_abort` to restore the worktree.
-    """
-    return check(repo=repo, args=["merge", "--no-edit", target])
-
-
-def merge_abort(repo: str = ".") -> None:
-    """``git merge --abort`` — best-effort restore of the pre-merge tree.
-
-    A no-op when no merge is in progress (the command exits non-zero
-    but does no harm), so safe to call unconditionally as part of the
-    branch-currency gate's conflict-cleanup path.
-    """
-    check(repo=repo, args=["merge", "--abort"])
-
-
-def worktree_remove(repo: str = ".", path: str = "") -> bool:
-    return check(repo=repo, args=["worktree", "remove", "--force", path])
-
-
-def branch_delete(repo: str = ".", branch: str = "") -> bool:
-    return check(repo=repo, args=["branch", "-D", branch])
-
-
-def pull_ff_only(repo: str = ".") -> bool:
-    return check(repo=repo, args=["pull", "--ff-only"])
-
-
-def push(repo: str = ".", remote: str = "origin", branch: str = "") -> None:
-    args = ["push", "--set-upstream", remote]
-    if branch:
-        args.append(branch)
-    run_strict(repo=repo, args=args)
-
-
-def bundle_create(repo: str, bundle_path: str, branch: str) -> None:
-    """Write a self-contained ``git bundle`` of ``branch`` to ``bundle_path``.
-
-    A bundle carries every commit reachable from the branch tip and is
-    restorable with ``git clone <bundle>`` / ``git fetch <bundle>`` — preferred
-    over relocating a worktree directory, which leaves git's worktree admin
-    pointing at a stale path. Raises ``CommandFailedError`` on failure (the
-    caller must not believe a recovery artifact exists when it does not).
-    """
-    run_strict(repo=repo, args=["bundle", "create", bundle_path, branch])
-
-
-def git_env_without_overrides() -> dict[str, str]:
-    """Process env with every ``GIT_*`` variable stripped.
-
-    A git hook (pre-commit, pre-push) runs under an outer ``git`` that exports
-    ``GIT_DIR``/``GIT_INDEX_FILE``/``GIT_WORK_TREE``. Inherited by a child
-    ``git -C <other-repo>`` call these hijack it onto the outer repo, so a
-    command meant for another repo silently operates on the ambient one. Any
-    ``git`` call that targets an explicit repo from inside a possible hook
-    context must run with this env so it stays hermetic.
-    """
-    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
-
-
-def full_worktree_diff(repo: str) -> str:
-    """Return a single patch covering staged, unstaged, AND untracked changes.
-
-    ``git diff HEAD`` alone omits untracked files. Marking them intent-to-add
-    (``git add -N``) makes them appear in the diff as new-file hunks (without
-    staging their content), so a single ``git apply`` of the returned patch
-    restores edits and brand-new files alike. The intent-to-add marks are
-    harmless: the worktree is about to be removed.
-
-    The prefixes are forced explicitly with ``--src-prefix=a/
-    --dst-prefix=b/``: ``git diff`` otherwise honours the caller's git config,
-    and a user with ``diff.noprefix=true`` (common) would get a patch with no
-    ``a/``/``b/`` prefixes that a plain ``git apply`` cannot restore — total
-    loss of the captured work, the exact #835 scenario. Forcing the prefixes
-    keeps the patch standard and ``git apply``-able regardless of user config.
-    """
-    env = git_env_without_overrides()
-    run_checked(["git", "-C", repo, "add", "-A", "-N"], env=env)
-    result = run_checked(
-        ["git", "-C", repo, "diff", "HEAD", "--binary", "--src-prefix=a/", "--dst-prefix=b/"],
-        env=env,
-    )
-    return result.stdout
-
-
-# ── Discovery ────────────────────────────────────────────────────────
-
-
-def default_branch(repo: str = ".") -> str:
-    ref = run(repo=repo, args=["symbolic-ref", "refs/remotes/origin/HEAD"])
-    branch = ref.replace("refs/remotes/origin/", "")
-    if branch:
-        return branch
-
-    for candidate in ("main", "master", "development"):
-        if check(repo=repo, args=["show-ref", "--verify", "--quiet", f"refs/remotes/origin/{candidate}"]):
-            return candidate
-
-    msg = f"Could not detect default branch for {repo}"
-    raise RuntimeError(msg)
-
-
-def branch_merged(repo: str, branch: str, target: str = "origin/main") -> bool:
-    output = run(repo=repo, args=["branch", "--merged", target])
-    return any(line.strip() == branch for line in output.splitlines())
-
-
-DETACHED_HEAD = "HEAD"
-
-
-def current_branch(repo: str = ".") -> str:
-    """Return the branch checked out in ``repo``, or ``DETACHED_HEAD`` when detached.
-
-    ``rev-parse --abbrev-ref HEAD`` resolves the symbolic branch name on a
-    branch and the literal string ``HEAD`` (``DETACHED_HEAD``) when the worktree
-    is in detached HEAD. The teardown seam uses this to resolve a worktree's
-    EFFECTIVE branch from git rather than trusting a possibly-drifted DB
-    ``Worktree.branch`` row.
-    """
-    return run(repo=repo, args=["rev-parse", "--abbrev-ref", "HEAD"])
-
-
-def head_sha(repo: str = ".") -> str:
-    """Return the full 40-char SHA of ``HEAD`` (the code-under-test SHA).
-
-    Used by the e2e work-item provenance recorder (#794) so a run records
-    the *exact* commit it tested, not a branch name that drifts.
-    """
-    return run_strict(repo=repo, args=["rev-parse", "HEAD"])
-
-
-def worktree_add_at_ref(repo: str, path: str, ref: str) -> bool:
-    """Materialise a detached worktree at an explicit ``ref`` (SHA or branch).
-
-    The e2e ladder (#794) provisions each repo at a resolved ref — a recorded
-    last-green SHA or ``origin/main`` — not only at a branch HEAD. ``git
-    worktree add <path> <ref>`` checks out ``ref`` in a detached HEAD, which
-    is exactly what running the e2e against a recorded SHA-set requires.
-    """
-    return check(repo=repo, args=["worktree", "add", "--detach", path, ref])
-
-
-def remote_url(repo: str = ".", remote: str = "origin") -> str:
-    return run(repo=repo, args=["remote", "get-url", remote])
-
-
-def remote_slug(repo: str = ".", remote: str = "origin") -> str:
-    if "/" in repo and not repo.startswith("/") and ":" not in repo and "@" not in repo:
-        return repo
-    url = remote_url(repo=repo, remote=remote)
-    if not url:
-        return ""
-    cleaned = url.rstrip("/")
-    cleaned = cleaned.removesuffix(".git")
-    if "@" in cleaned and ":" in cleaned and "://" not in cleaned:
-        return cleaned.split(":", 1)[1]
-    if "://" in cleaned:
-        host_and_path = cleaned.split("://", 1)[1].split("/", 1)
-        if len(host_and_path) > 1:
-            return host_and_path[1]
-    return ""
-
-
-def config_value(repo: str = ".", key: str = "") -> str:
-    return run(repo=repo, args=["config", key])
-
-
-def last_commit_message(repo: str = ".") -> tuple[str, str]:
-    output = run(repo=repo, args=["log", "-1", "--format=%s%n%n%b"])
-    lines = output.split("\n", 1)
-    subject = lines[0].strip()
-    body = lines[1].strip() if len(lines) > 1 else ""
-    return subject, body
-
-
-def first_commit_message(repo: str = ".", range_spec: str = "") -> tuple[str, str]:
-    """Return ``(subject, body)`` of the OLDEST commit in *range_spec*.
-
-    The canonical PR title for a branch is its first (oldest) own commit —
-    the same commit a squash-merge keeps as the squash title. Unlike
-    :func:`last_commit_message` (which reads ``HEAD`` and so can pick up the
-    default branch's head when the wrong ref is checked out), this sources
-    explicitly from a range like ``origin/main..my-branch`` and is therefore
-    independent of the working tree. An empty/missing range, or a range with
-    no commits, yields ``("", "")`` so the caller can fall back safely
-    instead of mislabelling the PR.
-
-    A ``%x1f`` unit separator splits subject from body and a ``%x1e`` record
-    separator splits commits, so a body containing blank lines never bleeds
-    into the next commit.
-    """
-    if not range_spec:
-        return "", ""
-    unit_sep, record_sep = "\x1f", "\x1e"
-    output = run(repo=repo, args=["log", "--reverse", range_spec, f"--format=%s{unit_sep}%b{record_sep}"])
-    records = [chunk for chunk in output.split(record_sep) if chunk.strip()]
-    if not records:
-        return "", ""
-    subject, _, body = records[0].lstrip("\n").partition(unit_sep)
-    return subject.strip(), body.strip()
-
-
-def commit_messages(repo: str = ".", range_spec: str = "") -> list[str]:
-    """Return the full message (subject + body) of each commit in *range_spec*.
-
-    Commits are separated by an ASCII record separator so a body that
-    itself contains blank lines never splits one commit into two. An
-    empty/missing range yields ``[]`` (nothing to scan, not an error) —
-    a close-keyword gate over zero commits must pass, not blow up.
-    """
-    if not range_spec:
-        return []
-    sep = "\x1e"
-    output = run(repo=repo, args=["log", range_spec, f"--format=%B{sep}"])
-    return [chunk.strip() for chunk in output.split(sep) if chunk.strip()]
-
-
-def worktree_add(repo: str, path: str, branch: str, *, create_branch: bool = True) -> bool:
-    args = ["worktree", "add"]
-    if create_branch:
-        args.extend(["-b", branch])
-    args.append(path)
-    if not create_branch:
-        args.append(branch)
-    try:
-        run_checked(["git", "-C", repo, *args])
-    except CommandFailedError:
-        return False
-    return True
-
-
-# ── GitRepo class ────────────────────────────────────────────────────
+"""Git operations facade — re-exports the cohesive sibling modules.
+
+The git surface is partitioned by concern across sibling modules under
+``teatree.utils``:
+
+- :mod:`teatree.utils.git_run` — low-level ``git -C`` runners + ``GIT_*`` env helper.
+- :mod:`teatree.utils.git_branch` — branch/ref discovery.
+- :mod:`teatree.utils.git_commit` — commit/log/rev-list/message ops.
+- :mod:`teatree.utils.git_status` — working-tree status + diff capture.
+- :mod:`teatree.utils.git_sync` — fetch/rebase/merge/pull/push.
+- :mod:`teatree.utils.git_worktree` — worktree management + teardown guards.
+- :mod:`teatree.utils.git_remote_ops` — invoking remote/config ops.
+
+This module keeps the :class:`GitRepo` OOP wrapper and re-exports the full
+public surface so every ``from teatree.utils.git import ...`` and ``git.<fn>``
+attribute access keeps resolving unchanged, with identity preserved
+(``git.merge_base is git_commit.merge_base``). Re-exporting (not redefining)
+the names is what guarantees that identity: a test that patches ``git.<fn>``
+still drives a production caller reading ``git.<fn>``.
+"""
+
+from teatree.utils.git_branch import (
+    DETACHED_HEAD,
+    branch_delete,
+    branch_merged,
+    current_branch,
+    default_branch,
+    head_sha,
+)
+from teatree.utils.git_commit import (
+    commit,
+    commit_messages,
+    first_commit_message,
+    last_commit_message,
+    log_oneline,
+    merge_base,
+    rev_count,
+    soft_reset,
+    unsynced_commits,
+)
+from teatree.utils.git_remote_ops import config_value, remote_slug, remote_url
+from teatree.utils.git_run import check, git_env_without_overrides, run, run_strict
+from teatree.utils.git_status import full_worktree_diff, status_porcelain, status_porcelain_strict
+from teatree.utils.git_sync import fetch, merge_abort, merge_no_edit, pull_ff_only, push, rebase
+from teatree.utils.git_worktree import (
+    bundle_create,
+    commits_absent_from_all_remotes,
+    worktree_add,
+    worktree_add_at_ref,
+    worktree_remove,
+)
+
+__all__ = [
+    "DETACHED_HEAD",
+    "GitRepo",
+    "branch_delete",
+    "branch_merged",
+    "bundle_create",
+    "check",
+    "commit",
+    "commit_messages",
+    "commits_absent_from_all_remotes",
+    "config_value",
+    "current_branch",
+    "default_branch",
+    "fetch",
+    "first_commit_message",
+    "full_worktree_diff",
+    "git_env_without_overrides",
+    "head_sha",
+    "last_commit_message",
+    "log_oneline",
+    "merge_abort",
+    "merge_base",
+    "merge_no_edit",
+    "pull_ff_only",
+    "push",
+    "rebase",
+    "remote_slug",
+    "remote_url",
+    "rev_count",
+    "run",
+    "run_strict",
+    "soft_reset",
+    "status_porcelain",
+    "status_porcelain_strict",
+    "unsynced_commits",
+    "worktree_add",
+    "worktree_add_at_ref",
+    "worktree_remove",
+]
 
 
 class GitRepo:
     """OOP wrapper — encapsulates repo path, delegates to module-level functions.
 
-    Module-level functions remain the canonical implementation so that
-    ``patch.object(git_mod, "run", ...)`` in tests intercepts all call paths.
+    The module-level functions (re-exported above) remain the canonical
+    implementation so that ``patch.object(git_mod, "run", ...)`` in tests
+    intercepts all call paths.
     """
 
     def __init__(self, path: str = ".") -> None:

--- a/src/teatree/utils/git_branch.py
+++ b/src/teatree/utils/git_branch.py
@@ -1,0 +1,54 @@
+"""Branch and ref discovery: default branch, merged-state, current branch, HEAD.
+
+The branch/ref-shaped partition of :mod:`teatree.utils.git`. Every function
+here resolves or mutates a branch/ref by shelling out through the
+:mod:`teatree.utils.git_run` runners.
+"""
+
+from teatree.utils.git_run import check, run, run_strict
+
+DETACHED_HEAD = "HEAD"
+
+
+def default_branch(repo: str = ".") -> str:
+    ref = run(repo=repo, args=["symbolic-ref", "refs/remotes/origin/HEAD"])
+    branch = ref.replace("refs/remotes/origin/", "")
+    if branch:
+        return branch
+
+    for candidate in ("main", "master", "development"):
+        if check(repo=repo, args=["show-ref", "--verify", "--quiet", f"refs/remotes/origin/{candidate}"]):
+            return candidate
+
+    msg = f"Could not detect default branch for {repo}"
+    raise RuntimeError(msg)
+
+
+def branch_merged(repo: str, branch: str, target: str = "origin/main") -> bool:
+    output = run(repo=repo, args=["branch", "--merged", target])
+    return any(line.strip() == branch for line in output.splitlines())
+
+
+def current_branch(repo: str = ".") -> str:
+    """Return the branch checked out in ``repo``, or ``DETACHED_HEAD`` when detached.
+
+    ``rev-parse --abbrev-ref HEAD`` resolves the symbolic branch name on a
+    branch and the literal string ``HEAD`` (``DETACHED_HEAD``) when the worktree
+    is in detached HEAD. The teardown seam uses this to resolve a worktree's
+    EFFECTIVE branch from git rather than trusting a possibly-drifted DB
+    ``Worktree.branch`` row.
+    """
+    return run(repo=repo, args=["rev-parse", "--abbrev-ref", "HEAD"])
+
+
+def head_sha(repo: str = ".") -> str:
+    """Return the full 40-char SHA of ``HEAD`` (the code-under-test SHA).
+
+    Used by the e2e work-item provenance recorder (#794) so a run records
+    the *exact* commit it tested, not a branch name that drifts.
+    """
+    return run_strict(repo=repo, args=["rev-parse", "HEAD"])
+
+
+def branch_delete(repo: str = ".", branch: str = "") -> bool:
+    return check(repo=repo, args=["branch", "-D", branch])

--- a/src/teatree/utils/git_commit.py
+++ b/src/teatree/utils/git_commit.py
@@ -1,0 +1,85 @@
+"""Commit, log, rev-list and message-parsing operations.
+
+The commit/history partition of :mod:`teatree.utils.git`. Reads from the commit
+graph (merge-base, rev-count, log, message extraction) and the two local
+history mutators (soft-reset, commit), all via the
+:mod:`teatree.utils.git_run` runners.
+"""
+
+from teatree.utils.git_run import run, run_strict
+
+
+def merge_base(repo: str = ".", target: str = "origin/main") -> str:
+    return run_strict(repo=repo, args=["merge-base", target, "HEAD"])
+
+
+def rev_count(repo: str = ".", range_spec: str = "") -> int:
+    out = run_strict(repo=repo, args=["rev-list", "--count", range_spec])
+    return int(out)
+
+
+def log_oneline(repo: str = ".", range_spec: str = "") -> str:
+    return run(repo=repo, args=["log", "--oneline", range_spec])
+
+
+def unsynced_commits(repo: str, branch: str, target: str = "origin/main") -> list[str]:
+    output = run(repo=repo, args=["log", branch, "--not", target, "--oneline"])
+    return [line for line in output.splitlines() if line.strip()]
+
+
+def soft_reset(repo: str = ".", target: str = "") -> None:
+    run_strict(repo=repo, args=["reset", "--soft", target])
+
+
+def commit(repo: str = ".", message: str = "") -> None:
+    run_strict(repo=repo, args=["commit", "-m", message])
+
+
+def last_commit_message(repo: str = ".") -> tuple[str, str]:
+    output = run(repo=repo, args=["log", "-1", "--format=%s%n%n%b"])
+    lines = output.split("\n", 1)
+    subject = lines[0].strip()
+    body = lines[1].strip() if len(lines) > 1 else ""
+    return subject, body
+
+
+def first_commit_message(repo: str = ".", range_spec: str = "") -> tuple[str, str]:
+    """Return ``(subject, body)`` of the OLDEST commit in *range_spec*.
+
+    The canonical PR title for a branch is its first (oldest) own commit —
+    the same commit a squash-merge keeps as the squash title. Unlike
+    :func:`last_commit_message` (which reads ``HEAD`` and so can pick up the
+    default branch's head when the wrong ref is checked out), this sources
+    explicitly from a range like ``origin/main..my-branch`` and is therefore
+    independent of the working tree. An empty/missing range, or a range with
+    no commits, yields ``("", "")`` so the caller can fall back safely
+    instead of mislabelling the PR.
+
+    A ``%x1f`` unit separator splits subject from body and a ``%x1e`` record
+    separator splits commits, so a body containing blank lines never bleeds
+    into the next commit.
+    """
+    if not range_spec:
+        return "", ""
+    unit_sep, record_sep = "\x1f", "\x1e"
+    output = run(repo=repo, args=["log", "--reverse", range_spec, f"--format=%s{unit_sep}%b{record_sep}"])
+    records = [chunk for chunk in output.split(record_sep) if chunk.strip()]
+    if not records:
+        return "", ""
+    subject, _, body = records[0].lstrip("\n").partition(unit_sep)
+    return subject.strip(), body.strip()
+
+
+def commit_messages(repo: str = ".", range_spec: str = "") -> list[str]:
+    """Return the full message (subject + body) of each commit in *range_spec*.
+
+    Commits are separated by an ASCII record separator so a body that
+    itself contains blank lines never splits one commit into two. An
+    empty/missing range yields ``[]`` (nothing to scan, not an error) —
+    a close-keyword gate over zero commits must pass, not blow up.
+    """
+    if not range_spec:
+        return []
+    sep = "\x1e"
+    output = run(repo=repo, args=["log", range_spec, f"--format=%B{sep}"])
+    return [chunk.strip() for chunk in output.split(sep) if chunk.strip()]

--- a/src/teatree/utils/git_remote_ops.py
+++ b/src/teatree/utils/git_remote_ops.py
@@ -1,0 +1,34 @@
+"""Invoking remote/config operations that shell out to git.
+
+The remote partition of :mod:`teatree.utils.git` that actually spawns a
+process — ``git remote get-url`` / ``git config`` — distinct from the pure,
+no-I/O URL parsing in :mod:`teatree.utils.git_remote`. Runs through the
+:mod:`teatree.utils.git_run` runners.
+"""
+
+from teatree.utils.git_run import run
+
+
+def remote_url(repo: str = ".", remote: str = "origin") -> str:
+    return run(repo=repo, args=["remote", "get-url", remote])
+
+
+def remote_slug(repo: str = ".", remote: str = "origin") -> str:
+    if "/" in repo and not repo.startswith("/") and ":" not in repo and "@" not in repo:
+        return repo
+    url = remote_url(repo=repo, remote=remote)
+    if not url:
+        return ""
+    cleaned = url.rstrip("/")
+    cleaned = cleaned.removesuffix(".git")
+    if "@" in cleaned and ":" in cleaned and "://" not in cleaned:
+        return cleaned.split(":", 1)[1]
+    if "://" in cleaned:
+        host_and_path = cleaned.split("://", 1)[1].split("/", 1)
+        if len(host_and_path) > 1:
+            return host_and_path[1]
+    return ""
+
+
+def config_value(repo: str = ".", key: str = "") -> str:
+    return run(repo=repo, args=["config", key])

--- a/src/teatree/utils/git_run.py
+++ b/src/teatree/utils/git_run.py
@@ -1,0 +1,40 @@
+"""Low-level git subprocess runners shared by every git-concern module.
+
+This is the primitive partition of :mod:`teatree.utils.git`: the three thin
+``git -C <repo> ...`` runners (lenient, strict, boolean) plus the ``GIT_*``
+env-stripping helper. Every sibling git module (``git_branch``, ``git_commit``,
+``git_status``, ``git_sync``, ``git_worktree``, ``git_remote_ops``) imports its
+runners from here, so the runners live in exactly one place and a test that
+patches the subprocess boundary (``teatree.utils.run``) intercepts all of them.
+"""
+
+import os
+
+from teatree.utils.run import run_allowed_to_fail, run_checked
+
+
+def run(*, repo: str = ".", args: list[str]) -> str:
+    result = run_allowed_to_fail(["git", "-C", repo, *args], expected_codes=None)
+    return result.stdout.strip()
+
+
+def run_strict(*, repo: str = ".", args: list[str]) -> str:
+    result = run_checked(["git", "-C", repo, *args])
+    return result.stdout.strip()
+
+
+def check(*, repo: str = ".", args: list[str]) -> bool:
+    return run_allowed_to_fail(["git", "-C", repo, *args], expected_codes=None).returncode == 0
+
+
+def git_env_without_overrides() -> dict[str, str]:
+    """Process env with every ``GIT_*`` variable stripped.
+
+    A git hook (pre-commit, pre-push) runs under an outer ``git`` that exports
+    ``GIT_DIR``/``GIT_INDEX_FILE``/``GIT_WORK_TREE``. Inherited by a child
+    ``git -C <other-repo>`` call these hijack it onto the outer repo, so a
+    command meant for another repo silently operates on the ambient one. Any
+    ``git`` call that targets an explicit repo from inside a possible hook
+    context must run with this env so it stays hermetic.
+    """
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}

--- a/src/teatree/utils/git_status.py
+++ b/src/teatree/utils/git_status.py
@@ -1,0 +1,51 @@
+"""Working-tree status reads and the full-worktree diff capture.
+
+The status/diff partition of :mod:`teatree.utils.git`. Holds the porcelain
+status reads (lenient and fail-closed) and the data-loss-guard diff capture
+(#835), all via the :mod:`teatree.utils.git_run` runners.
+"""
+
+from teatree.utils.git_run import git_env_without_overrides, run, run_strict
+from teatree.utils.run import run_checked
+
+
+def status_porcelain(repo: str = ".") -> str:
+    return run(repo=repo, args=["status", "--porcelain"])
+
+
+def status_porcelain_strict(repo: str = ".") -> str:
+    """Like :func:`status_porcelain` but raises on a non-zero ``git status`` exit.
+
+    :func:`status_porcelain` swallows git errors and returns whatever (possibly
+    empty) stdout it got, so an inconclusive status (lock contention, corrupt
+    index, missing dir) is indistinguishable from a genuinely clean tree. For a
+    data-loss decision that must fail closed, use this variant: a git error
+    raises ``CommandFailedError`` so the caller can treat "couldn't determine"
+    as "might be dirty" rather than "clean".
+    """
+    return run_strict(repo=repo, args=["status", "--porcelain"])
+
+
+def full_worktree_diff(repo: str) -> str:
+    """Return a single patch covering staged, unstaged, AND untracked changes.
+
+    ``git diff HEAD`` alone omits untracked files. Marking them intent-to-add
+    (``git add -N``) makes them appear in the diff as new-file hunks (without
+    staging their content), so a single ``git apply`` of the returned patch
+    restores edits and brand-new files alike. The intent-to-add marks are
+    harmless: the worktree is about to be removed.
+
+    The prefixes are forced explicitly with ``--src-prefix=a/
+    --dst-prefix=b/``: ``git diff`` otherwise honours the caller's git config,
+    and a user with ``diff.noprefix=true`` (common) would get a patch with no
+    ``a/``/``b/`` prefixes that a plain ``git apply`` cannot restore — total
+    loss of the captured work, the exact #835 scenario. Forcing the prefixes
+    keeps the patch standard and ``git apply``-able regardless of user config.
+    """
+    env = git_env_without_overrides()
+    run_checked(["git", "-C", repo, "add", "-A", "-N"], env=env)
+    result = run_checked(
+        ["git", "-C", repo, "diff", "HEAD", "--binary", "--src-prefix=a/", "--dst-prefix=b/"],
+        env=env,
+    )
+    return result.stdout

--- a/src/teatree/utils/git_sync.py
+++ b/src/teatree/utils/git_sync.py
@@ -1,0 +1,52 @@
+"""Remote-sync operations: fetch, rebase, merge, pull, push.
+
+The sync partition of :mod:`teatree.utils.git`. Every function moves the local
+ref relative to a remote (or merges/rebases onto a target), all via the
+:mod:`teatree.utils.git_run` runners.
+"""
+
+from teatree.utils.git_run import check, run, run_strict
+
+
+def fetch(repo: str = ".", remote: str = "origin", ref: str = "") -> None:
+    args = ["fetch", remote]
+    if ref:
+        args.append(ref)
+    run(repo=repo, args=args)
+
+
+def rebase(repo: str = ".", target: str = "") -> None:
+    run_strict(repo=repo, args=["rebase", target])
+
+
+def merge_no_edit(repo: str = ".", target: str = "") -> bool:
+    """``git merge --no-edit <target>`` — returns ``True`` on success.
+
+    The branch-currency gate's primitive (#940). Fast-forward is
+    preferred (the default ``git merge`` posture); a non-FF merge with
+    an empty editor commit is created when fast-forward isn't possible.
+    A conflict yields ``False`` — the caller is expected to call
+    :func:`merge_abort` to restore the worktree.
+    """
+    return check(repo=repo, args=["merge", "--no-edit", target])
+
+
+def merge_abort(repo: str = ".") -> None:
+    """``git merge --abort`` — best-effort restore of the pre-merge tree.
+
+    A no-op when no merge is in progress (the command exits non-zero
+    but does no harm), so safe to call unconditionally as part of the
+    branch-currency gate's conflict-cleanup path.
+    """
+    check(repo=repo, args=["merge", "--abort"])
+
+
+def pull_ff_only(repo: str = ".") -> bool:
+    return check(repo=repo, args=["pull", "--ff-only"])
+
+
+def push(repo: str = ".", remote: str = "origin", branch: str = "") -> None:
+    args = ["push", "--set-upstream", remote]
+    if branch:
+        args.append(branch)
+    run_strict(repo=repo, args=args)

--- a/src/teatree/utils/git_worktree.py
+++ b/src/teatree/utils/git_worktree.py
@@ -1,0 +1,76 @@
+"""Worktree management and the teardown data-loss guards.
+
+The worktree partition of :mod:`teatree.utils.git`. Holds worktree add/remove,
+the #706 "absent from all remotes" guard, and the bundle-recovery primitive,
+all via the :mod:`teatree.utils.git_run` runners.
+"""
+
+from teatree.utils.git_run import check, run_strict
+from teatree.utils.run import CommandFailedError, run_checked
+
+
+def commits_absent_from_all_remotes(repo: str, ref: str) -> list[str]:
+    """Return ``ref`` commits not reachable from ANY ``refs/remotes/*`` ref.
+
+    The data-loss guard for worktree teardown (#706). ``ref`` is any revision
+    git accepts — a branch name, or the literal ``HEAD`` when probing a worktree
+    directory directly (robust to a DB-vs-git branch drift and to detached HEAD).
+    Unlike :func:`unsynced_commits` (which compares against ``origin/main`` only
+    and therefore flags pushed-but-unmerged branches), ``--not --remotes`` is
+    empty whenever the tip was pushed anywhere — to its own remote tracking ref,
+    to main, or captured by a squash-merge that was itself pushed. A non-empty
+    result means these commits exist on NO remote: removing the worktree would
+    destroy them irrecoverably. Returns ``"<sha> <subject>"`` lines (newest
+    first).
+
+    **Fails closed.** Uses :func:`run_strict` so a non-zero ``git log`` exit
+    (invalid/missing ref, corrupt repo, any git error) raises
+    ``CommandFailedError`` rather than yielding an empty list. For a data-loss
+    guard, "we couldn't determine whether the commits are pushed" must block
+    teardown, not allow it. The legitimate empty case (``git log`` exits 0 with
+    no output because the ref genuinely has nothing absent from remotes)
+    still returns ``[]`` and allows teardown.
+    """
+    output = run_strict(repo=repo, args=["log", ref, "--not", "--remotes", "--oneline"])
+    return [line for line in output.splitlines() if line.strip()]
+
+
+def worktree_remove(repo: str = ".", path: str = "") -> bool:
+    return check(repo=repo, args=["worktree", "remove", "--force", path])
+
+
+def worktree_add_at_ref(repo: str, path: str, ref: str) -> bool:
+    """Materialise a detached worktree at an explicit ``ref`` (SHA or branch).
+
+    The e2e ladder (#794) provisions each repo at a resolved ref — a recorded
+    last-green SHA or ``origin/main`` — not only at a branch HEAD. ``git
+    worktree add <path> <ref>`` checks out ``ref`` in a detached HEAD, which
+    is exactly what running the e2e against a recorded SHA-set requires.
+    """
+    return check(repo=repo, args=["worktree", "add", "--detach", path, ref])
+
+
+def worktree_add(repo: str, path: str, branch: str, *, create_branch: bool = True) -> bool:
+    args = ["worktree", "add"]
+    if create_branch:
+        args.extend(["-b", branch])
+    args.append(path)
+    if not create_branch:
+        args.append(branch)
+    try:
+        run_checked(["git", "-C", repo, *args])
+    except CommandFailedError:
+        return False
+    return True
+
+
+def bundle_create(repo: str, bundle_path: str, branch: str) -> None:
+    """Write a self-contained ``git bundle`` of ``branch`` to ``bundle_path``.
+
+    A bundle carries every commit reachable from the branch tip and is
+    restorable with ``git clone <bundle>`` / ``git fetch <bundle>`` — preferred
+    over relocating a worktree directory, which leaves git's worktree admin
+    pointing at a stale path. Raises ``CommandFailedError`` on failure (the
+    caller must not believe a recovery artifact exists when it does not).
+    """
+    run_strict(repo=repo, args=["bundle", "create", bundle_path, branch])

--- a/tests/teatree_core/management_commands/test_close_keyword_gate.py
+++ b/tests/teatree_core/management_commands/test_close_keyword_gate.py
@@ -22,6 +22,7 @@ import teatree.core.management.commands.pr as pr_mod
 from teatree.core.management.commands._close_keyword_gate import _scan_sources, _suggest_rewrite
 from teatree.core.models import Session, Ticket, Worktree
 from teatree.utils import git as git_mod
+from teatree.utils import git_commit as git_commit_mod
 from tests.teatree_core.management_commands._overlays import (
     FORBID_CLOSE_KEYWORDS_OVERLAY,
     FULL_OVERLAY,
@@ -221,7 +222,7 @@ class TestCommitMessagesHelper(TestCase):
 
     def test_splits_on_record_separator_keeping_multiline_bodies(self) -> None:
         raw = "feat: a\n\nbody line 1\n\nbody line 2\x1e\nfix: b\n\nFixes #1\x1e\n"
-        with patch.object(git_mod, "run", return_value=raw):
+        with patch.object(git_commit_mod, "run", return_value=raw):
             assert git_mod.commit_messages(repo="/tmp/wt", range_spec="origin/main..feat") == [
                 "feat: a\n\nbody line 1\n\nbody line 2",
                 "fix: b\n\nFixes #1",

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -25,6 +25,7 @@ import teatree.core.overlay_loader as overlay_loader_mod
 import teatree.core.runners.provision as provision_mod
 import teatree.utils.db as db_mod
 import teatree.utils.git as git_mod
+import teatree.utils.git_commit as git_commit_mod
 import teatree.utils.run as utils_run_mod
 from teatree.config import load_config
 from teatree.core.management.commands._workspace_ticket_intake import build_branch_name
@@ -2006,6 +2007,7 @@ class TestPruneBranches(TestCase):
             patch.object(ws_cleanup_mod, "worktree_map", return_value=wt_map),
             patch.object(ws_cleanup_mod, "worktree_branches", return_value={"gone-branch"}),
             patch.object(git_mod, "run", side_effect=fake_run),
+            patch.object(git_commit_mod, "run", side_effect=fake_run),
             patch.object(git_mod, "current_branch", return_value="main"),
             patch.object(git_mod, "default_branch", return_value="main"),
             # Squash-merged: the content is on the remote, nothing absent (#710).

--- a/tests/teatree_utils/test_git_repo_wrapper.py
+++ b/tests/teatree_utils/test_git_repo_wrapper.py
@@ -6,6 +6,9 @@ from unittest.mock import patch
 import pytest
 
 from teatree.utils import git as git_mod
+from teatree.utils import git_branch as git_branch_mod
+from teatree.utils import git_remote_ops as git_remote_ops_mod
+from teatree.utils import git_sync as git_sync_mod
 from teatree.utils.git import GitRepo
 
 
@@ -80,13 +83,13 @@ class TestDefaultBranchDetection:
             # show-ref --verify --quiet refs/remotes/origin/<name>
             return args[-1] == "refs/remotes/origin/main"
 
-        monkeypatch.setattr(git_mod, "run", fake_run)
-        monkeypatch.setattr(git_mod, "check", fake_check)
+        monkeypatch.setattr(git_branch_mod, "run", fake_run)
+        monkeypatch.setattr(git_branch_mod, "check", fake_check)
         assert git_mod.default_branch("/r") == "main"
 
     def test_raises_when_no_default_branch_detectable(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(git_mod, "run", lambda **_: "")
-        monkeypatch.setattr(git_mod, "check", lambda **_: False)
+        monkeypatch.setattr(git_branch_mod, "run", lambda **_: "")
+        monkeypatch.setattr(git_branch_mod, "check", lambda **_: False)
         with pytest.raises(RuntimeError, match="Could not detect default branch"):
             git_mod.default_branch("/r")
 
@@ -99,14 +102,14 @@ class TestPush:
             recorded.append(args)
             return ""
 
-        monkeypatch.setattr(git_mod, "run_strict", fake_run_strict)
+        monkeypatch.setattr(git_sync_mod, "run_strict", fake_run_strict)
         git_mod.push("/r", remote="origin", branch="feat")
         assert recorded == [["push", "--set-upstream", "origin", "feat"]]
 
     def test_push_without_branch_only_sets_upstream(self, monkeypatch: pytest.MonkeyPatch) -> None:
         recorded: list[list[str]] = []
         monkeypatch.setattr(
-            git_mod,
+            git_sync_mod,
             "run_strict",
             lambda *, repo, args: recorded.append(args) or "",
         )
@@ -116,30 +119,30 @@ class TestPush:
 
 class TestBranchMerged:
     def test_matches_branch_in_merged_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(git_mod, "run", lambda **_: "  main\n  feat\n* dev")
+        monkeypatch.setattr(git_branch_mod, "run", lambda **_: "  main\n  feat\n* dev")
         assert git_mod.branch_merged("/r", "feat") is True
 
     def test_returns_false_when_branch_not_in_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(git_mod, "run", lambda **_: "  main\n  other")
+        monkeypatch.setattr(git_branch_mod, "run", lambda **_: "  main\n  other")
         assert git_mod.branch_merged("/r", "feat") is False
 
 
 class TestRemoteSlug:
     def test_returns_slug_for_ssh_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(git_mod, "remote_url", lambda **_: "git@github.com:org/repo.git")
+        monkeypatch.setattr(git_remote_ops_mod, "remote_url", lambda **_: "git@github.com:org/repo.git")
         assert git_mod.remote_slug(repo="/r") == "org/repo"
 
     def test_returns_slug_for_https_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(git_mod, "remote_url", lambda **_: "https://gitlab.com/org/repo.git")
+        monkeypatch.setattr(git_remote_ops_mod, "remote_url", lambda **_: "https://gitlab.com/org/repo.git")
         assert git_mod.remote_slug(repo="/r") == "org/repo"
 
     def test_returns_empty_when_remote_url_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(git_mod, "remote_url", lambda **_: "")
+        monkeypatch.setattr(git_remote_ops_mod, "remote_url", lambda **_: "")
         assert git_mod.remote_slug(repo="/r") == ""
 
     def test_passes_through_when_repo_already_slug_shaped(self) -> None:
         assert git_mod.remote_slug(repo="org/repo") == "org/repo"
 
     def test_returns_empty_for_unparseable_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(git_mod, "remote_url", lambda **_: "noscheme")
+        monkeypatch.setattr(git_remote_ops_mod, "remote_url", lambda **_: "noscheme")
         assert git_mod.remote_slug(repo="/r") == ""


### PR DESCRIPTION
## What

Behaviour-preserving decomposition of the over-cap god-module
`src/teatree/utils/git.py` — continuation of the same fold #2404 (git_remote
extract) and #2405 (dispatch split) performed. Pure-move refactor: every
function body is moved AST-identical (verified: zero body mismatches against
`origin/main`), nothing rewritten.

## Split — concern modules under `src/teatree/utils/`

- **`git_run.py`** — low-level `git -C` runners + `GIT_*` env helper
  (`run`, `run_strict`, `check`, `git_env_without_overrides`). The shared
  primitive every other git module shells out through.
- **`git_branch.py`** — branch/ref discovery (`default_branch`, `branch_merged`,
  `current_branch`, `branch_delete`, `head_sha`, `DETACHED_HEAD`).
- **`git_commit.py`** — commit/log/rev-list/message ops (`merge_base`,
  `rev_count`, `log_oneline`, `unsynced_commits`, `soft_reset`, `commit`,
  `last_commit_message`, `first_commit_message`, `commit_messages`).
- **`git_status.py`** — working-tree status + diff capture (`status_porcelain`,
  `status_porcelain_strict`, `full_worktree_diff`).
- **`git_sync.py`** — fetch/rebase/merge/pull/push (`fetch`, `rebase`,
  `merge_no_edit`, `merge_abort`, `pull_ff_only`, `push`).
- **`git_worktree.py`** — worktree management + teardown data-loss guards
  (`worktree_remove`, `worktree_add`, `worktree_add_at_ref`,
  `commits_absent_from_all_remotes`, `bundle_create`).
- **`git_remote_ops.py`** — invoking remote/config ops that shell out
  (`remote_url`, `remote_slug`, `config_value`). Kept distinct from the
  existing PURE `git_remote.py` (no-I/O URL parsing) whose contract is unchanged.
- **`git.py`** — keeps the `GitRepo` OOP wrapper class and re-exports the full
  public surface via an explicit `__all__`, preserving identity
  (`git.merge_base is git_commit.merge_base`). Every existing
  `from teatree.utils.git import ...` and `git.<fn>` attribute access keeps
  working unchanged, so the 50+ importers are untouched.

## Public-fn count + LOC (git.py)

| | before (origin/main) | after |
|---|---|---|
| public module-level functions | 35 | **0** (≤10 cap) |
| LOC | 425 | **175** |

git.py is net-shrunk on both axes. Module-health `--from-ref origin/main`
exits 0.

## Patch-target / monkeypatch seam relocation

Most call sites read git functions off the re-exported `git` namespace
(`git.run(...)`), so their patches stay valid unchanged. The seams that patch a
runner (`git_mod.run`/`run_strict`/`remote_url`) to drive a MOVED function —
where the bare runner now resolves in the moved function's own module — were
re-pointed to the new module home:

- `test_git_repo_wrapper.py` — `TestDefaultBranchDetection` / `TestBranchMerged`
  → `git_branch.run`/`check`; `TestPush` → `git_sync.run_strict`;
  `TestRemoteSlug` → `git_remote_ops.remote_url`.
- `test_close_keyword_gate.py` — `commit_messages` → `git_commit.run`.
- `test_workspace.py` — the squash-merge prune path reaches the real
  `unsynced_commits` body → also patch `git_commit.run`.

`tests/quality/test_patch_targets_resolve.py` is green (every string patch
target resolves against the live module tree).

## Verification

- `uv run tach check` — green.
- `tests/teatree_utils/`, `tests/utils/test_git_*`, `tests/test_cli_tools.py`,
  `tests/teatree_core/.../test_workspace.py`, `test_close_keyword_gate.py`,
  `test_standup.py`, `test_e2e_workitem.py`, `test_cli_ci.py` — all green.
- `tests/quality/` + `tests/teatree_quality/` — green except the pre-existing
  `test_semgrep_is_invocable` timeout (semgrep not installed locally — env gap,
  not a regression; the test touches no git module).
- `scripts/hooks/check_module_health.py --from-ref origin/main` — exit 0.

## Architecture pre-check

1. **BLUEPRINT § alignment** — module-health/fitness ratchet maintenance; pure
   move, no behaviour/FSM/Protocol change.
2. **FSM phase boundaries** — n/a.
3. **Extension-point contracts** — n/a; re-export preserves the full surface +
   identity, so all consumers are unchanged.
4. **Component boundaries** — all new modules in the `teatree.utils` tach node,
   grouped by git-concern cohesion.
5. **Dependency direction** — siblings → `git_run`; `git.py` → siblings
   (re-export); no back-edge. tach green.
6. **Test surface** — existing behaviour tests (subprocess-boundary patches /
   real tmp_path repos) are immune to the move; relocated seams covered above;
   `test_patch_targets_resolve` is the deterministic backstop.
7. **Resilience invariants** — fail-closed data-loss guards moved byte-identical;
   their regression tests still pin them.
8. **Identity/key normalization** — n/a.
9. **Behavior preservation** — purely structural; AST-identical bodies verified,
   nothing dropped, no must-block test inverted.