### PR TITLE
refactor(core): sever models→parent-core deferred up-edges via signal+registry injection (PR-2a of #2385)

### DIFF
--- a/src/teatree/core/apps.py
+++ b/src/teatree/core/apps.py
@@ -7,6 +7,8 @@ class CoreConfig(AppConfig):
     verbose_name = "TeaTree Core"
 
     def ready(self) -> None:  # noqa: PLR6301
+        from teatree.core.model_registries import populate_model_registries  # noqa: PLC0415
         from teatree.core.signals import register_signals  # noqa: PLC0415
 
+        populate_model_registries()
         register_signals()

--- a/src/teatree/core/backend_protocols.py
+++ b/src/teatree/core/backend_protocols.py
@@ -12,7 +12,10 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Protocol, TypedDict, runtime_checkable
 
+from teatree.core.modelkit.review_state import ReviewState
 from teatree.types import RawAPIDict
+
+__all__ = ["ReviewState"]
 
 
 class BackendResolutionError(Exception):
@@ -41,27 +44,6 @@ class ApprovalState(TypedDict):
     approvals_left: int
     approved_by: list[str]
     unresolved_resolvable: int
-
-
-class ReviewState(StrEnum):
-    """A reviewer's current state on a single pull/merge request.
-
-    Used by ``CodeHostBackend.get_review_state`` and by
-    ``ReviewerPrsScanner`` to detect approval dismissals — e.g. when a
-    forge invalidates a prior approval on force-push, or when a reviewer
-    is re-requested after being dismissed.
-    """
-
-    NONE = "none"
-    PENDING = "pending"
-    APPROVED = "approved"
-    CHANGES_REQUESTED = "changes_requested"
-    DISMISSED = "dismissed"
-    # The reviewer concluded an external review with no postable/approvable
-    # action (e.g. a bot MR there is nothing to comment on or approve).
-    # Distinct from APPROVED so the dedup never hides a future genuine
-    # review, yet terminal so the reviewing task stops re-queueing (#1077).
-    REVIEWED_NO_ACTION = "reviewed_no_action"
 
 
 class PrOpenState(StrEnum):

--- a/src/teatree/core/cost.py
+++ b/src/teatree/core/cost.py
@@ -300,3 +300,18 @@ class CostReport:
             for tier, amount in sorted(self.breakdown.per_tier_usd.items(), key=lambda kv: -kv[1]):
                 lines.append(f"    {tier}: ${amount:,.2f}")
         return lines
+
+
+def register_cost_factories() -> None:
+    """Register the cost dataclasses the ``TaskAttempt`` queryset reaches DOWN to (#2385).
+
+    ``cost.py`` depends ON the models indirectly and must NOT move into
+    ``modelkit`` (it would break PR-1's ``depends_on == []`` leaf test), so the
+    models can't import it without an intra-core up-edge. The registry inverts
+    the edge: the model fetches ``AttemptUsage`` / ``CostBreakdown`` by name at
+    call time.
+    """
+    from teatree.core.modelkit.gate_registry import register  # noqa: PLC0415
+
+    register("cost", "AttemptUsage", AttemptUsage)
+    register("cost", "CostBreakdown", CostBreakdown)

--- a/src/teatree/core/gates/dod_gate.py
+++ b/src/teatree/core/gates/dod_gate.py
@@ -43,6 +43,7 @@ from typing import TYPE_CHECKING
 from django.core.exceptions import ImproperlyConfigured
 
 from teatree.core.e2e_workitem import load_recipe
+from teatree.core.modelkit.gate_registry import register_gate
 from teatree.core.models.errors import InvalidTransitionError
 from teatree.core.overlay_loader import frontend_repos_for_overlay
 
@@ -303,3 +304,6 @@ def _now_iso() -> str:
     from django.utils import timezone  # noqa: PLC0415
 
     return timezone.now().isoformat()
+
+
+register_gate("local_e2e_dod", check_local_e2e_dod)

--- a/src/teatree/core/gates/fix_dod_gate.py
+++ b/src/teatree/core/gates/fix_dod_gate.py
@@ -44,6 +44,7 @@ loop's outer atomic rolls the advance back and the FSM stays put.
 import logging
 from typing import TYPE_CHECKING, Final
 
+from teatree.core.modelkit.gate_registry import register_gate
 from teatree.core.models.errors import InvalidTransitionError
 
 if TYPE_CHECKING:
@@ -130,3 +131,6 @@ def check_fix_record_dod(ticket: "Ticket") -> None:
         f"`t3 <overlay> ticket fix-record-override <id> --reason '<why>'`."
     )
     raise FixRecordDodError(msg)
+
+
+register_gate("fix_record_dod", check_fix_record_dod)

--- a/src/teatree/core/gates/plan_gate.py
+++ b/src/teatree/core/gates/plan_gate.py
@@ -11,6 +11,7 @@ gate has one non-bypassable chokepoint and is independently testable.
 
 from typing import TYPE_CHECKING
 
+from teatree.core.modelkit.gate_registry import register_gate
 from teatree.core.models.errors import NoPlanArtifactError
 
 if TYPE_CHECKING:
@@ -57,3 +58,6 @@ def check_plan_artifact(ticket: "Ticket") -> bool:
         f'mark it with `t3 <overlay> ticket skip-planning <id> --reason "<why>"`.'
     )
     raise NoPlanArtifactError(msg)
+
+
+register_gate("plan_artifact", check_plan_artifact)

--- a/src/teatree/core/gates/review_context_gate.py
+++ b/src/teatree/core/gates/review_context_gate.py
@@ -35,6 +35,7 @@ non-zero exit.
 from typing import TYPE_CHECKING
 
 from teatree.config import get_effective_settings
+from teatree.core.modelkit.gate_registry import register_gate
 from teatree.core.models.types import ReviewContext
 
 if TYPE_CHECKING:
@@ -92,3 +93,18 @@ def check_review_context(ticket: "Ticket") -> None:
         f"checked>` once the retrieval is done, then retry."
     )
     raise ReviewContextError(msg)
+
+
+def review_context_satisfied(ticket: "Ticket") -> bool:
+    """Whether the ``-> reviewing`` deep-retrieval precondition is met (#2385).
+
+    The boolean ``review()`` FSM condition. NO-OP (``True``) when the
+    ``require_review_context`` knob is off, else true only when a complete
+    ``review_context`` artifact is recorded.
+    """
+    if not review_context_required():
+        return True
+    return is_complete(recorded_review_context(ticket))
+
+
+register_gate("review_context_satisfied", review_context_satisfied)

--- a/src/teatree/core/gates/spec_coverage_gate.py
+++ b/src/teatree/core/gates/spec_coverage_gate.py
@@ -49,6 +49,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from teatree.config import get_effective_settings
+from teatree.core.modelkit.gate_registry import register_gate
 from teatree.core.models.errors import InvalidTransitionError
 
 if TYPE_CHECKING:
@@ -167,3 +168,6 @@ def check_spec_coverage(ticket: "Ticket") -> None:
         f"`extra['spec_coverage_override']`."
     )
     raise SpecCoverageDodError(msg)
+
+
+register_gate("spec_coverage", check_spec_coverage)

--- a/src/teatree/core/model_registries.py
+++ b/src/teatree/core/model_registries.py
@@ -1,0 +1,48 @@
+"""App-ready population of the model-callable registries (#2385 PR-2a).
+
+The models are the lowest stratum of ``teatree.core``; gates, the overlay
+resolvers, and the cost layer all depend ON the models. A model that imported
+them directly would form an intra-``core`` up-edge (invisible to tach inside the
+single ``core`` node). The edge is inverted through
+``teatree.core.modelkit.gate_registry``: the higher modules register their
+callables here, and the models fetch them by name at call time.
+
+``CoreConfig.ready`` calls :func:`populate_model_registries` exactly where the
+ordering matters — register gates → register resolvers → register cost — before
+``register_signals`` runs. The registry dicts are idempotent (a re-registration
+overwrites the same key), so a second ``ready()`` (test re-entry, in-process
+``call_command``) is a no-op, not a duplicate-key error.
+"""
+
+
+def _infer_overlay_for_url(url: str) -> str:
+    # Re-read the module attribute at call time so a test patching
+    # ``teatree.core.overlay_loader.infer_overlay_for_url`` is still seen by the
+    # model that fetches this resolver from the registry (#2385).
+    from teatree.core.overlay_loader import infer_overlay_for_url  # noqa: PLC0415
+
+    return infer_overlay_for_url(url)
+
+
+def _resolve_overlay_name(name: str) -> str | None:
+    from teatree.core.overlay_loader import resolve_overlay_name  # noqa: PLC0415
+
+    return resolve_overlay_name(name)
+
+
+def populate_model_registries() -> None:
+    """Import every gate (self-registering) and register the resolvers + cost factories."""
+    # Importing a gate module runs its module-level ``register_gate(...)`` call.
+    from teatree.core.cost import register_cost_factories  # noqa: PLC0415
+    from teatree.core.gates import (  # noqa: F401, PLC0415
+        dod_gate,
+        fix_dod_gate,
+        plan_gate,
+        review_context_gate,
+        spec_coverage_gate,
+    )
+    from teatree.core.modelkit.gate_registry import register_resolver  # noqa: PLC0415
+
+    register_resolver("infer_overlay_for_url", _infer_overlay_for_url)
+    register_resolver("resolve_overlay_name", _resolve_overlay_name)
+    register_cost_factories()

--- a/src/teatree/core/modelkit/gate_registry.py
+++ b/src/teatree/core/modelkit/gate_registry.py
@@ -1,0 +1,63 @@
+"""Call-time registry for model-callable functions that live ABOVE the models.
+
+``teatree.core.models`` is the lowest stratum of ``core``; gates, overlay
+resolvers, and the cost layer all depend ON the models, so a model that called
+them directly would form an intra-``core`` up-edge (invisible to tach inside the
+single ``core`` node — #2385). The registry inverts the edge: the higher module
+registers its callable here at app-ready time, and the model fetches it by name
+at call time. The model imports only this leaf (``depends_on = []``), never the
+higher module.
+
+One namespaced dict. ``register(kind, name, fn)`` is idempotent — re-registering
+the same ``(kind, name)`` overwrites with the new callable, so a second
+``AppConfig.ready()`` (test re-entry, ``call_command`` in-process) is a no-op
+rather than a duplicate-key error. ``get(kind, name)`` raises a clear
+:class:`KeyError` when the registration step never ran, surfacing a wiring bug
+loudly instead of silently degrading the FSM gate.
+"""
+
+from collections.abc import Callable
+from typing import Final
+
+GATE: Final = "gate"
+RESOLVER: Final = "resolver"
+
+_REGISTRY: dict[tuple[str, str], Callable[..., object]] = {}
+
+
+def register(kind: str, name: str, fn: Callable[..., object]) -> None:
+    """Register *fn* under ``(kind, name)``; idempotent on re-registration."""
+    _REGISTRY[kind, name] = fn
+
+
+def get(kind: str, name: str) -> Callable[..., object]:
+    """Return the callable registered under ``(kind, name)``.
+
+    Raises :class:`KeyError` when nothing is registered — a registration step
+    that never ran is a wiring bug, not a silent fallback.
+    """
+    try:
+        return _REGISTRY[kind, name]
+    except KeyError:
+        msg = (
+            f"no {kind!r} registered under {name!r}; the registering package "
+            f"(its app-ready import) did not run. Registered {kind}s: "
+            f"{sorted(n for k, n in _REGISTRY if k == kind)}"
+        )
+        raise KeyError(msg) from None
+
+
+def register_gate(name: str, fn: Callable[..., object]) -> None:
+    register(GATE, name, fn)
+
+
+def get_gate(name: str) -> Callable[..., object]:
+    return get(GATE, name)
+
+
+def register_resolver(name: str, fn: Callable[..., object]) -> None:
+    register(RESOLVER, name, fn)
+
+
+def get_resolver(name: str) -> Callable[..., object]:
+    return get(RESOLVER, name)

--- a/src/teatree/core/modelkit/review_state.py
+++ b/src/teatree/core/modelkit/review_state.py
@@ -1,0 +1,34 @@
+"""Reviewer state vocabulary — a pure leaf the models read without an up-edge.
+
+``Ticket`` records ``last_review_state`` from this enum; before #2385 PR-2a it
+imported ``ReviewState`` from ``teatree.core.backend_protocols`` via a deferred
+function-scoped import (an intra-``core`` up-edge, since the models are the
+lowest stratum). Moving the enum DOWN into ``modelkit`` (``depends_on = []``)
+lets the models import it at module level with no up-edge. ``backend_protocols``
+re-exports it (identity-preserved) so every external consumer — the github /
+gitlab backends, the reviewer scanner, the loop — keeps importing the same
+object from the same path.
+"""
+
+from enum import StrEnum
+
+
+class ReviewState(StrEnum):
+    """A reviewer's current state on a single pull/merge request.
+
+    Used by ``CodeHostBackend.get_review_state`` and by
+    ``ReviewerPrsScanner`` to detect approval dismissals — e.g. when a
+    forge invalidates a prior approval on force-push, or when a reviewer
+    is re-requested after being dismissed.
+    """
+
+    NONE = "none"
+    PENDING = "pending"
+    APPROVED = "approved"
+    CHANGES_REQUESTED = "changes_requested"
+    DISMISSED = "dismissed"
+    # The reviewer concluded an external review with no postable/approvable
+    # action (e.g. a bot MR there is nothing to comment on or approve).
+    # Distinct from APPROVED so the dedup never hides a future genuine
+    # review, yet terminal so the reviewing task stops re-queueing (#1077).
+    REVIEWED_NO_ACTION = "reviewed_no_action"

--- a/src/teatree/core/models/task.py
+++ b/src/teatree/core/models/task.py
@@ -1,11 +1,12 @@
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from django.db import models, transaction
 from django.utils import timezone
 from django_fsm import FSMField
 
 from teatree.core.managers import TaskManager
+from teatree.core.modelkit.gate_registry import get
 from teatree.core.models.errors import InvalidTransitionError
 from teatree.core.models.session import Session
 from teatree.core.models.ticket import Ticket
@@ -478,7 +479,7 @@ class TaskAttemptQuerySet(models.QuerySet):
 
     def usages(self) -> "list[AttemptUsage]":
         """Map each attempt to the :class:`AttemptUsage` the cost layer reads."""
-        from teatree.core.cost import AttemptUsage  # noqa: PLC0415
+        AttemptUsage = cast("type[AttemptUsage]", get("cost", "AttemptUsage"))  # noqa: N806
 
         return [
             AttemptUsage(
@@ -501,7 +502,7 @@ class TaskAttemptQuerySet(models.QuerySet):
 
     def cost_breakdown(self) -> "CostBreakdown":
         """SDK-equivalent spend across the attempts in this queryset."""
-        from teatree.core.cost import CostBreakdown  # noqa: PLC0415
+        CostBreakdown = cast("type[CostBreakdown]", get("cost", "CostBreakdown"))  # noqa: N806
 
         return CostBreakdown.from_usages(self.usages())
 

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -10,6 +10,8 @@ from django_fsm import FSMField, TransitionNotAllowed, transition
 
 from teatree.config import Mode, get_effective_settings, load_config
 from teatree.core.managers import TicketManager
+from teatree.core.modelkit.gate_registry import get_gate, get_resolver
+from teatree.core.modelkit.review_state import ReviewState
 from teatree.core.models.errors import DirtyWorktreeError, InvalidTransitionError
 from teatree.core.models.types import validated_ticket_extra
 from teatree.utils import git, redis_container
@@ -19,9 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 def _check_plan_artifact(ticket: object) -> bool:
-    from teatree.core.gates.plan_gate import check_plan_artifact  # noqa: PLC0415
-
-    return check_plan_artifact(ticket)  # type: ignore[arg-type]
+    return bool(get_gate("plan_artifact")(ticket))
 
 
 def _auto_ship_enabled() -> bool:
@@ -152,9 +152,7 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
 
     def _infer_overlay(self) -> str:
         """Derive overlay name from ``issue_url`` (see ``infer_overlay_for_url``)."""
-        from teatree.core.overlay_loader import infer_overlay_for_url  # noqa: PLC0415
-
-        return infer_overlay_for_url(self.issue_url)
+        return str(get_resolver("infer_overlay_for_url")(self.issue_url))
 
     def apply_inferred_overlay(self, inferred: str) -> bool:
         """Persist ``inferred`` overlay on a conclusive change (True when changed).
@@ -173,9 +171,7 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
 
     def has_dispatchable_overlay(self) -> bool:
         """False only for a non-empty overlay that no longer resolves (#1959 poison-pill)."""
-        from teatree.core.overlay_loader import resolve_overlay_name  # noqa: PLC0415
-
-        return not (self.overlay and resolve_overlay_name(self.overlay) is None)
+        return not (self.overlay and get_resolver("resolve_overlay_name")(self.overlay) is None)
 
     def mark_remote_missing(self) -> None:
         """Targeted UPDATE to set remote_missing; skips the FSM and save() overhead (#1875)."""
@@ -223,11 +219,11 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         provisioning worker failed, the operator can re-call ``start()``
         without rolling back through ``rework``. The worker's own state guard
         prevents duplicate work when provisioning already succeeded.
-        """
-        from teatree.core.tasks import execute_provision  # noqa: PLC0415
 
-        ticket_pk = int(self.pk)
-        transaction.on_commit(lambda: execute_provision.enqueue(ticket_pk))
+        The ``execute_provision`` enqueue is the ``post_transition`` receiver's
+        job (``teatree.core.signals``), keyed on the transition name — the body
+        stays free of the task up-edge (#2385).
+        """
 
     @transition(
         field=state,
@@ -559,8 +555,6 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         won't re-spawn the reviewer agent for the same PR until either the
         SHA moves or the forge dismisses the approval.
         """
-        from teatree.core.backend_protocols import ReviewState  # noqa: PLC0415
-
         sha = str(self._extra().get("reviewed_sha", ""))
         if self.issue_url and sha:
             # #800 N3: canonical locked RMW — a concurrent pr_urls /
@@ -610,8 +604,6 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         ``last_review_state`` (the existing #959 reset) so a new revision is
         still reviewed — no lost obligation.
         """
-        from teatree.core.backend_protocols import ReviewState  # noqa: PLC0415
-
         sha = str(self._extra().get("reviewed_sha", ""))
         if self.issue_url and sha:
             self.merge_extra(set_keys={"reviewed_sha": sha, "last_review_state": ReviewState.REVIEWED_NO_ACTION.value})
@@ -640,14 +632,9 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         raise a :class:`InvalidTransitionError` subclass so the loop's outer
         atomic rolls the advance back and the FSM stays put.
         """
-        from teatree.core.gates.dod_gate import check_local_e2e_dod  # noqa: PLC0415
-        from teatree.core.tasks import execute_ship  # noqa: PLC0415
-
         self._refuse_if_worktree_dirty("shipping")
-        check_local_e2e_dod(self)
+        get_gate("local_e2e_dod")(self)
         self._consume_pending_phase_tasks("shipping")
-        ticket_pk = int(self.pk)
-        transaction.on_commit(lambda: execute_ship.enqueue(ticket_pk))
 
     @transition(field=state, source=State.SHIPPED, target=State.IN_REVIEW)
     def request_review(self) -> None:
@@ -667,11 +654,10 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         previous teardown reported errors, the operator can re-call
         ``mark_merged()`` to retry. The worker is best-effort and does not
         advance the FSM, so retries are safe.
-        """
-        from teatree.core.tasks import execute_teardown  # noqa: PLC0415
 
-        ticket_pk = int(self.pk)
-        transaction.on_commit(lambda: execute_teardown.enqueue(ticket_pk))
+        The ``execute_teardown`` enqueue is the ``post_transition`` receiver's
+        job (``teatree.core.signals``), keyed on the transition name (#2385).
+        """
 
     @transition(
         field=state,
@@ -694,12 +680,9 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
 
         Schedules the same teardown work as ``mark_merged`` so a
         keystone-driven reconcile cleans up worktrees identically to the
-        normal IN_REVIEW → MERGED path.
+        normal IN_REVIEW → MERGED path — the ``post_transition`` receiver
+        enqueues ``execute_teardown`` for this transition too (#2385).
         """
-        from teatree.core.tasks import execute_teardown  # noqa: PLC0415
-
-        ticket_pk = int(self.pk)
-        transaction.on_commit(lambda: execute_teardown.enqueue(ticket_pk))
 
     @transition(field=state, source=[State.MERGED, State.RETROSPECTED], target=State.RETROSPECTED)
     def retrospect(self) -> None:
@@ -714,11 +697,10 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         previous retro worker failed, the operator can re-call ``retrospect()``
         to retry. The worker's own state guard skips when retrospection
         already produced its artifacts.
-        """
-        from teatree.core.tasks import execute_retrospect  # noqa: PLC0415
 
-        ticket_pk = int(self.pk)
-        transaction.on_commit(lambda: execute_retrospect.enqueue(ticket_pk))
+        The ``execute_retrospect`` enqueue is the ``post_transition`` receiver's
+        job (``teatree.core.signals``), keyed on the transition name (#2385).
+        """
 
     @transition(field=state, source=State.RETROSPECTED, target=State.DELIVERED)
     def mark_delivered(self) -> None:
@@ -729,11 +711,8 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         have a backing test when ``require_spec_coverage`` is on — done is not a
         partial subset of the spec (#2232). A refusal keeps the FSM at RETROSPECTED.
         """
-        from teatree.core.gates.fix_dod_gate import check_fix_record_dod  # noqa: PLC0415
-        from teatree.core.gates.spec_coverage_gate import check_spec_coverage  # noqa: PLC0415
-
-        check_fix_record_dod(self)
-        check_spec_coverage(self)
+        get_gate("fix_record_dod")(self)
+        get_gate("spec_coverage")(self)
 
     @transition(field=state, source=[State.CODED, State.TESTED, State.REVIEWED], target=State.STARTED)
     def rework(self) -> None:
@@ -1038,15 +1017,7 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         the FSM regardless of entry path. NO-OP (returns ``True``) when the knob
         is off (opt-in default preserved).
         """
-        from teatree.core.gates.review_context_gate import (  # noqa: PLC0415
-            is_complete,
-            recorded_review_context,
-            review_context_required,
-        )
-
-        if not review_context_required():
-            return True
-        return is_complete(recorded_review_context(self))
+        return bool(get_gate("review_context_satisfied")(self))
 
     def append_context(self, entry: str) -> str:
         r"""Append a timestamped block to the durable per-ticket knowledge store (#627).

--- a/src/teatree/core/models/worktree.py
+++ b/src/teatree/core/models/worktree.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import ClassVar, cast
 
-from django.db import models, transaction
+from django.db import models
 from django_fsm import FSMField, transition
 
 from teatree.config import load_config as _load_config
@@ -47,6 +47,12 @@ class Worktree(models.Model):
     # re-capture. Null = no E2E run has touched it.
     last_e2e_run = models.DateTimeField(null=True, blank=True)
 
+    # Transient (non-DB) carrier for the pre-blank ``(db_name, extra)`` snapshot
+    # the ``teardown`` body captures, read by the post_transition receiver that
+    # enqueues ``execute_worktree_teardown`` (#2385). Default empty so a row
+    # that never tore down still reads safely.
+    teardown_snapshot: "tuple[str, WorktreeExtra]" = ("", WorktreeExtra())
+
     objects = WorktreeManager()
 
     class Meta:
@@ -77,12 +83,12 @@ class Worktree(models.Model):
         checks all run in a worker. Source ``[CREATED, PROVISIONED]`` makes
         re-firing idempotent — a previous worker that crashed mid-import
         can be retried without going back to CREATED.
-        """
-        from teatree.core.worktree_tasks import execute_worktree_provision  # noqa: PLC0415
 
+        The ``execute_worktree_provision`` enqueue is the ``post_transition``
+        receiver's job (``teatree.core.signals``), keyed on the transition
+        name — the body stays free of the worktree-tasks up-edge (#2385).
+        """
         self.db_name = self._build_db_name()
-        worktree_pk = int(self.pk)
-        transaction.on_commit(lambda: execute_worktree_provision.enqueue(worktree_pk))
 
     @transition(field=state, source=[State.PROVISIONED, State.SERVICES_UP, State.READY], target=State.SERVICES_UP)
     def start_services(self, *, services: list[str] | None = None) -> None:
@@ -92,18 +98,18 @@ class Worktree(models.Model):
         then ``execute_worktree_start`` enqueued after commit drives the
         actual ``docker compose up``. Source allows re-firing from
         SERVICES_UP / READY so a partially-failed boot can be retried.
+
+        The ``execute_worktree_start`` enqueue is the ``post_transition``
+        receiver's job (``teatree.core.signals``), keyed on the transition
+        name (#2385).
         """
         from django.utils import timezone  # noqa: PLC0415
-
-        from teatree.core.worktree_tasks import execute_worktree_start  # noqa: PLC0415
 
         if services is not None:
             extra = self._extra()
             extra["services"] = services
             self.extra = extra
         self.last_used_at = timezone.now()
-        worktree_pk = int(self.pk)
-        transaction.on_commit(lambda: execute_worktree_start.enqueue(worktree_pk))
 
     @transition(field=state, source=[State.SERVICES_UP, State.READY], target=State.READY)
     def verify(self, *, urls: dict[str, str] | None = None) -> None:
@@ -113,18 +119,18 @@ class Worktree(models.Model):
         URLs, then ``execute_worktree_verify`` enqueued after commit runs
         the overlay's health checks. Source allows re-firing from READY so
         verify can be re-run without bouncing through SERVICES_UP.
+
+        The ``execute_worktree_verify`` enqueue is the ``post_transition``
+        receiver's job (``teatree.core.signals``), keyed on the transition
+        name (#2385).
         """
         from django.utils import timezone  # noqa: PLC0415
-
-        from teatree.core.worktree_tasks import execute_worktree_verify  # noqa: PLC0415
 
         extra = self._extra()
         if urls:
             extra["urls"] = urls
         self.extra = extra
         self.last_used_at = timezone.now()
-        worktree_pk = int(self.pk)
-        transaction.on_commit(lambda: execute_worktree_verify.enqueue(worktree_pk))
 
     @transition(field=state, source=[State.PROVISIONED, State.SERVICES_UP, State.READY], target=State.PROVISIONED)
     def db_refresh(self) -> None:
@@ -151,11 +157,11 @@ class Worktree(models.Model):
         here, then ``execute_worktree_stop`` enqueued after commit drives the
         actual ``docker compose down``. Source ``[SERVICES_UP, READY]`` — a
         worktree must be running to be stopped.
-        """
-        from teatree.core.worktree_tasks import execute_worktree_stop  # noqa: PLC0415
 
-        worktree_pk = int(self.pk)
-        transaction.on_commit(lambda: execute_worktree_stop.enqueue(worktree_pk))
+        The ``execute_worktree_stop`` enqueue is the ``post_transition``
+        receiver's job (``teatree.core.signals``), keyed on the transition
+        name (#2385).
+        """
 
     @transition(field=state, source="*", target=State.CREATED)
     def teardown(self) -> None:
@@ -168,15 +174,18 @@ class Worktree(models.Model):
         remove``, branch delete) using the captured snapshot, then
         deletes the Worktree row, so the FSM ``CREATED`` state lasts
         only until the worker fires.
-        """
-        from teatree.core.worktree_tasks import execute_worktree_teardown  # noqa: PLC0415
 
-        worktree_pk = int(self.pk)
-        snapshot_db_name = self.db_name
-        snapshot_extra = dict(self.extra or {})
+        The body BLANKS ``db_name`` / ``extra`` here, so the
+        ``post_transition`` receiver (``teatree.core.signals``) cannot read
+        them off the live row — it would enqueue a teardown with an empty
+        DB name and never drop the database. The PRE-BLANK values are
+        stashed on the transient :attr:`teardown_snapshot` attribute, which
+        the receiver reads to enqueue ``execute_worktree_teardown`` with the
+        correct snapshot (#2385).
+        """
+        self.teardown_snapshot = (self.db_name, self._extra())
         self.db_name = ""
         self.extra = {}
-        transaction.on_commit(lambda: execute_worktree_teardown.enqueue(worktree_pk, snapshot_db_name, snapshot_extra))
 
     def _build_db_name(self) -> str:
         ticket = cast("Ticket", self.ticket)

--- a/src/teatree/core/signals.py
+++ b/src/teatree/core/signals.py
@@ -1,16 +1,38 @@
 import logging
 
+from django.db import transaction
 from django.db.models.signals import post_save
 from django_fsm.signals import post_transition
 
 from teatree.core.models.pull_request import PullRequest
 from teatree.core.models.task import Task
 from teatree.core.models.ticket import Ticket
+from teatree.core.models.worktree import Worktree
 from teatree.core.on_behalf_gate_recorded import OnBehalfPostBlockedError, require_on_behalf_approval
 from teatree.core.on_behalf_post_receipt import notify_user_on_behalf_post
 from teatree.core.reaction_dispatch import get_reaction_publisher
 
 logger = logging.getLogger(__name__)
+
+# Transition name -> the ``@task`` worker its enqueue used to live in the FSM
+# body (#2385: the body's intra-core up-edge into ``teatree.core.tasks`` is
+# severed; the enqueue is keyed here, looked up + enqueued after commit by the
+# post_transition receiver so the state change and the queued work still land
+# atomically). ``reconcile_merged`` mirrors ``mark_merged`` — both tear down.
+_TICKET_TRANSITION_TASKS: dict[str, str] = {
+    "start": "execute_provision",
+    "ship": "execute_ship",
+    "mark_merged": "execute_teardown",
+    "reconcile_merged": "execute_teardown",
+    "retrospect": "execute_retrospect",
+}
+
+_WORKTREE_TRANSITION_TASKS: dict[str, str] = {
+    "provision": "execute_worktree_provision",
+    "start_services": "execute_worktree_start",
+    "verify": "execute_worktree_verify",
+    "stop_services": "execute_worktree_stop",
+}
 
 
 def _log_ticket_transition(
@@ -193,8 +215,93 @@ def _auto_enqueue_headless_task(
         logger.exception("Failed to auto-enqueue headless task %s", instance.pk)
 
 
+def _enqueue_ticket_transition_task(
+    sender: type,  # noqa: ARG001
+    instance: Ticket,
+    name: str,
+    **_kwargs: object,
+) -> None:
+    """Enqueue the ``@task`` worker a ticket FSM transition body used to enqueue.
+
+    The deferred import of the executor is call-time (mirroring
+    ``_auto_enqueue_headless_task``), so a test patching ``tasks_mod.execute_*``
+    still sees its stub. ``transaction.on_commit`` preserves the body's
+    "state change + queued work land atomically" guarantee — the worker fires
+    only after the transition's save commits.
+    """
+    executor_name = _TICKET_TRANSITION_TASKS.get(name)
+    if executor_name is None:
+        return
+    from teatree.core import tasks as tasks_mod  # noqa: PLC0415
+
+    executor = getattr(tasks_mod, executor_name)
+    ticket_pk = int(instance.pk)
+    transaction.on_commit(lambda: executor.enqueue(ticket_pk))
+
+
+def _enqueue_worktree_transition_task(
+    sender: type,  # noqa: ARG001
+    instance: Worktree,
+    name: str,
+    **_kwargs: object,
+) -> None:
+    """Enqueue the per-worktree ``@task`` worker a worktree FSM body used to enqueue.
+
+    ``teardown`` is handled separately (``_enqueue_worktree_teardown_task``)
+    because its body BLANKS ``db_name`` / ``extra`` before this receiver fires,
+    so the worker needs the pre-blank snapshot, not the live (now-empty) row.
+    """
+    executor_name = _WORKTREE_TRANSITION_TASKS.get(name)
+    if executor_name is None:
+        return
+    from teatree.core import worktree_tasks as worktree_tasks_mod  # noqa: PLC0415
+
+    executor = getattr(worktree_tasks_mod, executor_name)
+    worktree_pk = int(instance.pk)
+    transaction.on_commit(lambda: executor.enqueue(worktree_pk))
+
+
+def _enqueue_worktree_teardown_task(
+    sender: type,  # noqa: ARG001
+    instance: Worktree,
+    name: str,
+    **_kwargs: object,
+) -> None:
+    """Enqueue ``execute_worktree_teardown`` with the PRE-BLANK snapshot (#2385 trap).
+
+    ``Worktree.teardown()`` blanks ``db_name`` / ``extra`` on the row in its
+    body, so reading them here would enqueue a teardown that never drops the
+    database. The body stashes the pre-blank ``(db_name, extra)`` on the
+    transient ``teardown_snapshot`` attribute; this receiver reads it and passes
+    the non-blank values to the worker.
+    """
+    if name != "teardown":
+        return
+    from teatree.core import worktree_tasks as worktree_tasks_mod  # noqa: PLC0415
+
+    worktree_pk = int(instance.pk)
+    snapshot_db_name, snapshot_extra = instance.teardown_snapshot
+    executor = worktree_tasks_mod.execute_worktree_teardown
+    transaction.on_commit(lambda: executor.enqueue(worktree_pk, snapshot_db_name, snapshot_extra))
+
+
 def register_signals() -> None:
     post_transition.connect(_log_ticket_transition, sender=Ticket, dispatch_uid="ticket_transition_audit")
+    post_transition.connect(
+        _enqueue_ticket_transition_task,
+        sender=Ticket,
+        dispatch_uid="ticket_transition_task_enqueue",
+    )
+    post_transition.connect(
+        _enqueue_worktree_transition_task,
+        sender=Worktree,
+        dispatch_uid="worktree_transition_task_enqueue",
+    )
+    post_transition.connect(
+        _enqueue_worktree_teardown_task,
+        sender=Worktree,
+        dispatch_uid="worktree_teardown_task_enqueue",
+    )
     post_transition.connect(
         _add_slack_reactions_on_transition,
         sender=Ticket,

--- a/tests/quality/test_intra_core_deferred_import_ratchet.py
+++ b/tests/quality/test_intra_core_deferred_import_ratchet.py
@@ -34,11 +34,16 @@ _CORE_ROOT = _REPO_ROOT / "src" / "teatree" / "core"
 _MODELS_ROOT = _CORE_ROOT / "models"
 _TACH = _REPO_ROOT / "tach.toml"
 
-# Measured in-worktree after the PR-1 modelkit carve (the three moved files stay
-# under teatree.core.*, so the count is unchanged from the #2385 plan's HEAD
-# measurement). SHRINK-ONLY: lower this as PR-2/PR-3 convert deferred edges into
-# declared tach edges; never raise it.
-_FROZEN_INTRA_CORE_DEFERRED = 217
+# Measured in-worktree after PR-2a severed the 21 deferred up-edges from
+# core/models/ into the parent-core packages (gates/tasks/worktree_tasks/
+# overlay_loader/cost/backend_protocols). The net drop from PR-1's 217 is 11,
+# not 21: the signal receivers + the registry-population functions (incl. the
+# resolver wrappers that re-read the overlay_loader module attribute at call
+# time so a test patch is still seen) hold a handful of call-time
+# `from teatree.core import ...` (deferred so the model modules never import
+# them at boot — no AppRegistryNotReady). SHRINK-ONLY: lower this as PR-2b/PR-3
+# convert remaining deferred edges into declared tach sub-node edges; never raise it.
+_FROZEN_INTRA_CORE_DEFERRED = 206
 
 
 def _function_scoped_intra_core_imports(source: Path) -> int:

--- a/tests/quality/test_models_no_parent_core_up_edges.py
+++ b/tests/quality/test_models_no_parent_core_up_edges.py
@@ -1,0 +1,88 @@
+"""Fitness gate: ``core/models/`` has ZERO imports into parent-core packages (#2385 PR-2a).
+
+PR-2a severed the 21 deferred (function-scoped) up-edges from ``teatree.core.models``
+into the parent-core packages that depend ON the models — ``gates``, ``tasks``,
+``worktree_tasks``, ``overlay_loader``, ``cost``, and ``backend_protocols``. They
+were inverted through the ``post_transition`` signal layer (tasks / worktree_tasks)
+and the ``modelkit.gate_registry`` (gates / resolvers / cost), and ``ReviewState``
+was moved DOWN into ``modelkit``.
+
+This gate is the structural guard that keeps an up-edge from creeping back: any
+``import`` / ``from ... import`` inside ``core/models/`` whose target is one of the
+forbidden parent-core modules — at ANY scope, module-level or function-scoped — is a
+violation. Anti-vacuous: re-introducing any one severed edge (e.g. a deferred
+``from teatree.core.tasks import execute_ship`` inside ``ship()``) turns this red.
+"""
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MODELS_ROOT = _REPO_ROOT / "src" / "teatree" / "core" / "models"
+
+# The parent-core packages that depend ON the models — a models import of any of
+# these is the up-edge PR-2a severed. ``backend_protocols`` is included because
+# ``ReviewState`` now lives in ``modelkit``; the models must read it from there,
+# not from ``backend_protocols`` (which re-exports it but sits above the models).
+_FORBIDDEN_PREFIXES = (
+    "teatree.core.gates",
+    "teatree.core.tasks",
+    "teatree.core.worktree_tasks",
+    "teatree.core.overlay_loader",
+    "teatree.core.cost",
+    "teatree.core.backend_protocols",
+)
+
+
+def _is_forbidden(module: str) -> bool:
+    return any(module == p or module.startswith(p + ".") for p in _FORBIDDEN_PREFIXES)
+
+
+def _type_checking_import_lines(tree: ast.Module) -> set[int]:
+    """Line numbers of imports nested under an ``if TYPE_CHECKING:`` block.
+
+    A type-only import is erased at runtime (annotation strings), so it is NOT
+    an up-edge — it cannot form an intra-core cycle or trigger
+    ``AppRegistryNotReady``. tach ignores it too. The gate guards RUNTIME edges.
+    """
+    lines: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.If):
+            test = node.test
+            is_type_checking = (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING") or (
+                isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
+            )
+            if is_type_checking:
+                for child in ast.walk(node):
+                    if isinstance(child, ast.Import | ast.ImportFrom):
+                        lines.add(child.lineno)
+    return lines
+
+
+def _forbidden_imports(source: Path) -> list[str]:
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+    type_only = _type_checking_import_lines(tree)
+    hits: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import | ast.ImportFrom) and node.lineno in type_only:
+            continue
+        if isinstance(node, ast.ImportFrom) and node.module and _is_forbidden(node.module):
+            hits.append(f"{source.relative_to(_REPO_ROOT)}:{node.lineno}  from {node.module} import ...")
+        elif isinstance(node, ast.Import):
+            hits.extend(
+                f"{source.relative_to(_REPO_ROOT)}:{node.lineno}  import {alias.name}"
+                for alias in node.names
+                if _is_forbidden(alias.name)
+            )
+    return hits
+
+
+class TestModelsHaveNoParentCoreUpEdges:
+    def test_no_models_import_into_forbidden_parent_core(self) -> None:
+        hits = [hit for py in sorted(_MODELS_ROOT.rglob("*.py")) for hit in _forbidden_imports(py)]
+        assert not hits, (
+            "a teatree.core.models module imports a parent-core package that depends ON the "
+            "models — the #2385 PR-2a up-edge reappeared. Invert it via the post_transition "
+            "signal layer (tasks/worktree_tasks) or modelkit.gate_registry (gates/resolvers/"
+            "cost), or read ReviewState from teatree.core.modelkit.review_state:\n" + "\n".join(hits)
+        )

--- a/tests/teatree_core/models/test_worktree.py
+++ b/tests/teatree_core/models/test_worktree.py
@@ -1,9 +1,84 @@
 """Worktree model tests (souliane/teatree#443 split of test_models.py)."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 from django.test import TestCase
 
 from teatree.core.models import Ticket, Worktree
+
+
+class TestWorktreeTransitionSignals(TestCase):
+    """The worktree FSM bodies enqueue their workers via post_transition (#2385)."""
+
+    def test_provision_enqueues_worker_after_commit(self) -> None:
+        from teatree.core import worktree_tasks as worktree_tasks_mod  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(issue_url="https://example.com/issues/77", variant="acme")
+        worktree = Worktree.objects.create(ticket=ticket, repo_path="/tmp/be", branch="b")
+        fake = MagicMock()
+        with (
+            patch.object(worktree_tasks_mod, "execute_worktree_provision", fake),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            worktree.provision()
+            worktree.save()
+        fake.enqueue.assert_called_once_with(worktree.pk)
+
+    def test_start_services_enqueues_worker_after_commit(self) -> None:
+        from teatree.core import worktree_tasks as worktree_tasks_mod  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(issue_url="https://example.com/issues/78")
+        worktree = Worktree.objects.create(ticket=ticket, repo_path="/tmp/be", branch="b")
+        worktree.provision()
+        worktree.save()
+        fake = MagicMock()
+        with (
+            patch.object(worktree_tasks_mod, "execute_worktree_start", fake),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            worktree.start_services(services=["backend"])
+            worktree.save()
+        fake.enqueue.assert_called_once_with(worktree.pk)
+
+    def test_teardown_enqueues_worker_with_pre_blank_snapshot(self) -> None:
+        """The receiver must enqueue the pre-blank db_name/extra, not the blanked row.
+
+        ``teardown()`` blanks ``db_name`` / ``extra`` IN THE BODY before the
+        post_transition receiver fires. The receiver reads the transient
+        ``teardown_snapshot`` so the worker still gets the values it needs to
+        drop the database and remove the worktree — a regression that read the
+        live (blanked) row would enqueue ``snapshot_db_name=""``.
+        """
+        from teatree.core import worktree_tasks as worktree_tasks_mod  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(issue_url="https://example.com/issues/79", variant="acme")
+        worktree = Worktree.objects.create(ticket=ticket, repo_path="/tmp/be", branch="b")
+        worktree.provision()
+        worktree.save()
+        worktree.refresh_from_db()
+        pre_blank_db = worktree.db_name
+        assert pre_blank_db == "wt_79_acme"
+        worktree.extra = {"worktree_path": "/tmp/wt-79", "services": ["backend"]}
+        worktree.save()
+
+        fake = MagicMock()
+        with (
+            patch.object(worktree_tasks_mod, "execute_worktree_teardown", fake),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            worktree.teardown()
+            worktree.save()
+
+        fake.enqueue.assert_called_once()
+        call_args = fake.enqueue.call_args
+        assert call_args.args[0] == worktree.pk
+        assert call_args.args[1] == pre_blank_db
+        assert call_args.args[2] == {"worktree_path": "/tmp/wt-79", "services": ["backend"]}
+        # And the row itself is blanked as before.
+        worktree.refresh_from_db()
+        assert worktree.db_name == ""
+        assert worktree.extra == {}
 
 
 class TestWorktree(TestCase):

--- a/tests/teatree_core/test_dod_gate.py
+++ b/tests/teatree_core/test_dod_gate.py
@@ -30,6 +30,7 @@ from teatree.core.gates.dod_gate import (
     is_ui_visible,
     override_reason,
 )
+from teatree.core.modelkit import gate_registry
 from teatree.core.models import Ticket, Worktree
 from tests.teatree_core.models._shared import _advance_ticket_to_tested, _complete_phase_task, _init_repo_with_branch
 
@@ -297,9 +298,13 @@ class TestShipTransitionDodGate(TestCase):
         """
         wt = self._reviewed_ui_ticket()
         ticket = wt.ticket
+        # ship() fetches the gate from the registry (#2385); neutralise the
+        # registered callable in the shared registry dict so the model's
+        # module-bound ``get_gate`` reads the no-op.
+        neutralised = {**gate_registry._REGISTRY, ("gate", "local_e2e_dod"): lambda _ticket: None}
         with (
             _patch_overlay(["frontend"]),
-            patch.object(dod_gate, "check_local_e2e_dod", return_value=None),
+            patch.object(gate_registry, "_REGISTRY", neutralised),
             self.captureOnCommitCallbacks(execute=False),
         ):
             ticket.ship()

--- a/tests/teatree_core/test_model_registries.py
+++ b/tests/teatree_core/test_model_registries.py
@@ -1,0 +1,57 @@
+"""The model-callable registries: lookup, idempotent re-population, re-ready safety (#2385)."""
+
+import pytest
+
+from teatree.core.model_registries import populate_model_registries
+from teatree.core.modelkit import gate_registry
+
+
+class TestGateRegistry:
+    def test_register_then_get_round_trips(self) -> None:
+        def fn() -> str:
+            return "x"
+
+        gate_registry.register("gate", "round_trip_probe", fn)
+        assert gate_registry.get("gate", "round_trip_probe") is fn
+
+    def test_register_is_idempotent_last_write_wins(self) -> None:
+        gate_registry.register("gate", "idem_probe", lambda: "first")
+        gate_registry.register("gate", "idem_probe", lambda: "second")
+        assert gate_registry.get("gate", "idem_probe")() == "second"
+
+    def test_get_unregistered_raises_clear_keyerror(self) -> None:
+        with pytest.raises(KeyError, match="no 'gate' registered under 'never_registered'"):
+            gate_registry.get("gate", "never_registered")
+
+    def test_gate_resolver_cost_helpers_share_one_namespaced_dict(self) -> None:
+        gate_registry.register_gate("kind_probe", lambda: "g")
+        gate_registry.register_resolver("kind_probe", lambda: "r")
+        # Same name, different kind -> two distinct entries, no collision.
+        assert gate_registry.get_gate("kind_probe")() == "g"
+        assert gate_registry.get_resolver("kind_probe")() == "r"
+
+
+class TestPopulateModelRegistries:
+    def test_all_model_callables_registered_after_setup(self) -> None:
+        # Django setup already ran populate via CoreConfig.ready; assert the full set.
+        assert gate_registry.get_gate("plan_artifact") is not None
+        assert gate_registry.get_gate("local_e2e_dod") is not None
+        assert gate_registry.get_gate("fix_record_dod") is not None
+        assert gate_registry.get_gate("spec_coverage") is not None
+        assert gate_registry.get_gate("review_context_satisfied") is not None
+        assert gate_registry.get_resolver("infer_overlay_for_url") is not None
+        assert gate_registry.get_resolver("resolve_overlay_name") is not None
+        assert gate_registry.get("cost", "AttemptUsage") is not None
+        assert gate_registry.get("cost", "CostBreakdown") is not None
+
+    def test_re_population_is_a_noop_not_a_duplicate_key_error(self) -> None:
+        # Mirrors a second AppConfig.ready (test re-entry, in-process call_command).
+        populate_model_registries()
+        populate_model_registries()
+        # Still exactly one entry per (kind, name) — re-population overwrites,
+        # it never duplicates — and the gate is still the live bare function.
+        keys = [k for k in gate_registry._REGISTRY if k == ("gate", "plan_artifact")]
+        assert keys == [("gate", "plan_artifact")]
+        from teatree.core.gates.plan_gate import check_plan_artifact  # noqa: PLC0415
+
+        assert gate_registry.get_gate("plan_artifact") is check_plan_artifact


### PR DESCRIPTION
PR-2a of the #2385 core re-layering: the cycle surgery that severs the deferred up-edges from `core/models/` into the parent-core packages, so a later PR (PR-2b) can declare `teatree.core.models` / `managers` as tach nodes. PR-2a itself declares **NO tach node** and makes **no `tach.toml` change** — it is intra-`core` only. Built on PR-1 (modelkit carve + intra-core ratchet at main `67d6c443`).

## The 21 severed up-edges, by category

| Category | Count | Edges | Mechanism |
|---|---|---|---|
| **tasks** | 5 | `ticket.start` / `ship` / `mark_merged` / `reconcile_merged` / `retrospect` | `on_commit(execute_*.enqueue)` moved OUT of the FSM transition bodies into a `post_transition` receiver in `core/signals.py`, keyed on the transition name; the receiver wraps the enqueue in `transaction.on_commit` so the "state change + queued work land atomically" guarantee is preserved |
| **worktree_tasks** | 5 | `worktree.provision` / `start_services` / `verify` / `stop_services` / `teardown` | same `post_transition` mechanism |
| **gates** | 5 | `plan_artifact` / `local_e2e_dod` / `fix_record_dod` / `spec_coverage` / `review_context_satisfied` | gates depend ON the models, so the edge inverts via the new `modelkit.gate_registry` (`register_gate`/`get_gate`, module-level dict, idempotent); each gate self-registers at import; models call `get_gate(name)(ticket)` |
| **overlay_loader** | 2 | `infer_overlay_for_url` / `resolve_overlay_name` | same registry (`register_resolver`/`get_resolver`); the registered values are named wrappers that re-read the module attribute at call time so a test patch is still seen |
| **cost** | 2 | `AttemptUsage` / `CostBreakdown` | registry-injected (`get("cost", …)`); `cost.py` stays where it is — moving it down would break PR-1's modelkit `depends_on == []` leaf test |
| **backend_protocols.ReviewState** | 2 | `mark_reviewed_externally` / `mark_review_no_action` | the `ReviewState` StrEnum **moved DOWN** into `modelkit/review_state.py` and is **re-exported from `backend_protocols`** (identity-preserved) so the github / gitlab / loop consumers are untouched |

## Mechanism

Registries populate at app-ready time (`core/apps.py:ready` → `populate_model_registries()`: register gates → register resolvers → register cost → then `register_signals()`). The registry dicts are idempotent on a second `ready()` (test re-entry, in-process `call_command`). **No top-level import flips inside model modules** — the model imports only `modelkit` (`depends_on = []`) at module level, so Django boots with **no `AppRegistryNotReady`**.

## Worktree-teardown snapshot fix (the highest-risk trap)

`Worktree.teardown()` blanks `db_name` / `extra` **ON THE INSTANCE** in the body BEFORE the `post_transition` receiver fires. Reading the live row in the receiver would enqueue a teardown with an empty DB name that never drops the database. The body stashes the pre-blank `(db_name, extra)` on a transient `teardown_snapshot` attribute; the dedicated receiver reads it and passes the NON-BLANK values to `execute_worktree_teardown`. Pinned by an anti-vacuous test — verified red when the receiver reads the blanked row (`'' != 'wt_79_acme'`).

## Ratchet

The intra-`core` deferred-import count drops **217 → 206** (net 11, not 21: the signal receivers + the registry-population functions hold a handful of call-time `from teatree.core import …`, deferred so the model modules never import them at boot). `_FROZEN_INTRA_CORE_DEFERRED` set to the **MEASURED 206** (plan estimated 196 — measured, not assumed).

## New fitness gate

`tests/quality/test_models_no_parent_core_up_edges.py`: `core/models/` has ZERO runtime imports into `{gates, tasks, worktree_tasks, overlay_loader, cost, backend_protocols}`. Anti-vacuous — re-introducing any one severed edge turns it red (verified). `TYPE_CHECKING`-guarded imports are excluded (erased at runtime, not edges).

## Architecture pre-check — #2385 PR-2a

**1. BLUEPRINT § alignment** — §4 (Domain Models, FSM invariant: transition bodies stay pure; state change + `on_commit(enqueue)` lands atomically) and §5.6 (Loop Topology / signals). The atomic guarantee is preserved — the enqueue now fires from a `post_transition` receiver wrapped in `transaction.on_commit`, not the body. No BLUEPRINT contradiction; no doc change needed.

**2. FSM phase boundaries** — No new phase, no source/target change. The 10 FSM transitions whose bodies enqueued workers keep identical observable behaviour (provision/ship/teardown/retrospect still enqueue after commit) — only the enqueue's home moved from the body to the signal layer.

**3. Extension-point contracts** — `ReviewState` re-exported identity-preserved from `backend_protocols` — every consumer (github `payloads`/`client`, gitlab `client`, loop `persistence`/`reviewer_prs`) imports the same object from the same path; verified identity-equal across all three. No Protocol surface changed.

**4. Component boundaries** — New leaf `core/modelkit/gate_registry.py` + `core/modelkit/review_state.py` (lowest stratum, `depends_on = []`). New `core/model_registries.py` (app-ready aggregator). Receivers in the existing `core/signals.py`. No straddling.

**5. Dependency direction** — All new edges point DOWN: models → `modelkit`; gates/overlay_loader/cost → register INTO `modelkit.gate_registry`. `uv run tach check` green. The 21 up-edges are gone; the fitness gate enforces they cannot return.

**6. Test surface** — Per behaviour: ticket/worktree transition enqueue (`test_worktree.py` + existing `test_phase_dispatch.py`), teardown pre-blank snapshot (anti-vacuous), registry lookup/idempotency/re-population (`test_model_registries.py`), gate load-bearing (`test_dod_gate.py` re-pointed to the registry), fitness gate, ratchet at 206.

**7. Resilience invariants** — Idempotency: registry `register` overwrites the same key (re-`ready()` is a no-op). The `on_commit` enqueue preserves the atomic commit-then-enqueue. `get()` raises a clear `KeyError` naming the missing registration (fail-loud, not silent degrade).

**8. Identity and key normalization** — Registry keyed on the fully-qualified `(kind, name)` tuple — `("gate", "plan_artifact")` differs from `("resolver", "plan_artifact")`; they share one namespaced dict with no collision. `ReviewState` identity is the canonical object, re-exported, never re-defined.

**9. Behavior preservation / capability deletion** — No capability removed. The teardown blanking behaviour is preserved exactly (row still ends blanked); the snapshot just travels to the receiver instead of into a body-local `on_commit` closure. No privacy/security matcher touched. No must-block test inverted.

NO tach node is declared yet — that is **PR-2b**.

Relates-to #2385
