### PR TITLE
refactor(core): declare models + managers tach nodes — core cycle now structurally enforced (PR-2b of #2385)

### DIFF
--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -4,6 +4,8 @@
 graph TD
     teatree.project --> teatree.paths
     teatree.teams --> teatree.core
+    teatree.teams --> teatree.core.models
+    teatree.teams --> teatree.core.loop_lease_manager
     teatree.teams --> teatree.config
     teatree.teams --> teatree.agents
     teatree.teams --> teatree.skill_support
@@ -42,9 +44,22 @@ graph TD
     teatree.core --> teatree.on_behalf_gate
     teatree.core --> teatree.slack_mrkdwn
     teatree.core --> teatree.core.modelkit
+    teatree.core --> teatree.core.models.errors
+    teatree.core --> teatree.core.models
+    teatree.core.loop_lease_manager --> teatree.utils
+    teatree.core.managers --> teatree.config
+    teatree.core.managers --> teatree.utils
+    teatree.core.managers --> teatree.core.modelkit
+    teatree.core.managers --> teatree.core.models.errors
+    teatree.core.managers --> teatree.core.loop_lease_manager
+    teatree.core.managers --> teatree.core.session_handover_manager
+    teatree.core.models --> teatree.core.modelkit
+    teatree.core.models --> teatree.core.managers
+    teatree.core.models --> teatree.core.models.errors
     teatree.agents --> teatree.types
     teatree.agents --> teatree.core
     teatree.agents --> teatree.core.modelkit
+    teatree.agents --> teatree.core.models
     teatree.agents --> teatree.skill_support
     teatree.agents --> teatree.utils
     teatree.agents --> teatree.config
@@ -65,11 +80,13 @@ graph TD
     teatree.backends.slack --> teatree.types
     teatree.backends.slack --> teatree.utils
     teatree.backends.slack --> teatree.core
+    teatree.backends.slack --> teatree.core.models
     teatree.backends.slack --> teatree.identity
     teatree.backends.slack --> teatree.url_classify
     teatree.backends.gitlab --> teatree.types
     teatree.backends.gitlab --> teatree.utils
     teatree.backends.gitlab --> teatree.core
+    teatree.backends.gitlab --> teatree.core.models
     teatree.backends.gitlab --> teatree.backends.errors
     teatree.backends.gitlab --> teatree.backends.types
     teatree.backends.gitlab --> teatree.backends.forge_merge_rpc
@@ -77,6 +94,7 @@ graph TD
     teatree.backends.github --> teatree.types
     teatree.backends.github --> teatree.utils
     teatree.backends.github --> teatree.core
+    teatree.backends.github --> teatree.core.models
     teatree.backends.github --> teatree.backends.errors
     teatree.backends.github --> teatree.backends.types
     teatree.backends.github --> teatree.backends.forge_merge_rpc
@@ -184,6 +202,8 @@ graph TD
     teatree.claude_sessions
     teatree.overlay_init
     teatree.core.modelkit
+    teatree.core.models.errors
+    teatree.core.session_handover_manager
     teatree.backends.errors
     teatree.backends.types
     teatree.cli._format_opts

--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -1,7 +1,8 @@
 import logging
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
+from django.apps import apps
 from django.db import IntegrityError, models, transaction
 from django.db.models import Q
 from django.utils import timezone
@@ -16,13 +17,16 @@ from teatree.core.loop_lease_manager import (
     is_per_loop_owner_slot,
     per_loop_owner_slot,
 )
-from teatree.core.models.errors import RedisSlotsExhaustedError
+from teatree.core.modelkit.errors import RedisSlotsExhaustedError
 from teatree.core.session_handover_manager import SessionHandoverManager, SessionHandoverQuerySet
 from teatree.utils import redis_container
 
 if TYPE_CHECKING:
+    from teatree.core.models.incoming_event import IncomingEvent
+    from teatree.core.models.reply_dispatch import ReplyDispatch
     from teatree.core.models.task import Task
     from teatree.core.models.ticket import Ticket
+    from teatree.core.models.worktree import Worktree
 
 __all__ = [
     "GLOBAL_OWNER_SLOT",
@@ -67,12 +71,12 @@ class TicketQuerySet(_OverlayFilterMixin, models.QuerySet):
         identifier set (#694) — callers naturally pass the forge issue number
         and must not silently hit ``DoesNotExist``.
         """
-        from teatree.core.models.ticket import Ticket  # noqa: PLC0415
+        ticket_model = cast("type[Ticket]", apps.get_model("core", "Ticket"))
 
         if ref.isdigit():
             try:
                 return self.get(pk=int(ref))
-            except Ticket.DoesNotExist:
+            except ticket_model.DoesNotExist:
                 # No such pk — fall back to issue_url. Match either a forge
                 # URL ending in /<ref> or a bare-number issue_url stored as
                 # just the issue number (#707), keeping the match exact.
@@ -83,15 +87,15 @@ class TicketQuerySet(_OverlayFilterMixin, models.QuerySet):
         ticket = self.filter(issue_url=ref).first()
         if ticket is None:
             msg = f"No ticket matching {ref!r} (looked up by pk and issue_url)"
-            raise Ticket.DoesNotExist(msg)
+            raise ticket_model.DoesNotExist(msg)
         return ticket
 
     def in_flight(self, overlay: str | None = None) -> models.QuerySet:
-        from teatree.core.models.ticket import Ticket  # noqa: PLC0415
+        ticket_model = cast("type[Ticket]", apps.get_model("core", "Ticket"))
 
         return (
             self.for_overlay(overlay)
-            .exclude(state__in=[Ticket.State.DELIVERED, Ticket.State.IGNORED])
+            .exclude(state__in=[ticket_model.State.DELIVERED, ticket_model.State.IGNORED])
             .filter(Q(extra__tracker_status__isnull=True) | ~Q(extra__tracker_status="Done"))
             .order_by("pk")
         )
@@ -188,11 +192,11 @@ class WorktreeQuerySet(_OverlayFilterMixin, models.QuerySet):
 
         Matches the worktrees panel one-to-one so the KPI count and table size agree.
         """
-        from teatree.core.models.ticket import Ticket  # noqa: PLC0415
+        ticket_model = cast("type[Ticket]", apps.get_model("core", "Ticket"))
 
         return (
             self.for_overlay(overlay)
-            .exclude(ticket__state__in=[Ticket.State.DELIVERED, Ticket.State.IGNORED])
+            .exclude(ticket__state__in=[ticket_model.State.DELIVERED, ticket_model.State.IGNORED])
             .order_by("pk")
         )
 
@@ -207,11 +211,11 @@ class WorktreeQuerySet(_OverlayFilterMixin, models.QuerySet):
         """
         from django.utils import timezone  # noqa: PLC0415
 
-        from teatree.core.models.worktree import Worktree  # noqa: PLC0415
+        worktree_model = cast("type[Worktree]", apps.get_model("core", "Worktree"))
 
         return self.filter(
             ticket_id=ticket_pk,
-            state__in=[Worktree.State.SERVICES_UP, Worktree.State.READY],
+            state__in=[worktree_model.State.SERVICES_UP, worktree_model.State.READY],
         ).update(last_e2e_run=now or timezone.now())
 
 
@@ -225,12 +229,12 @@ class IncomingEventQuerySet(models.QuerySet):
         return self.filter(processed_at__isnull=True)
 
     def active_dm_thread(self, *, channel: str) -> str:
-        from teatree.core.models.incoming_event import IncomingEvent  # noqa: PLC0415
+        incoming_event_model = cast("type[IncomingEvent]", apps.get_model("core", "IncomingEvent"))
 
         if not channel:
             return ""
         latest = (
-            self.filter(source=IncomingEvent.Source.SLACK, channel_ref=channel)
+            self.filter(source=incoming_event_model.Source.SLACK, channel_ref=channel)
             .order_by("-received_at", "-pk")
             .values_list("thread_ref", flat=True)
             .first()
@@ -242,11 +246,11 @@ class ReplyDispatchQuerySet(models.QuerySet):
     def due_for_retry(self, now: datetime | None = None) -> models.QuerySet:
         from django.utils import timezone  # noqa: PLC0415
 
-        from teatree.core.models.reply_dispatch import ReplyDispatch  # noqa: PLC0415
+        reply_dispatch_model = cast("type[ReplyDispatch]", apps.get_model("core", "ReplyDispatch"))
 
         moment = now or timezone.now()
         return (
-            self.filter(status=ReplyDispatch.Status.FAILED)
+            self.filter(status=reply_dispatch_model.Status.FAILED)
             .exclude(action_name="dead_letter_alert")
             .filter(models.Q(next_retry_at__isnull=True) | models.Q(next_retry_at__lte=moment))
             .order_by("next_retry_at", "pk")
@@ -276,9 +280,10 @@ class TaskQuerySet(models.QuerySet):
         rest of the system honours.
         """
         from teatree.core.modelkit.phases import phase_spellings  # noqa: PLC0415
-        from teatree.core.models.task import Task  # noqa: PLC0415
 
-        return self.filter(phase__in=phase_spellings(phase), status=Task.Status.COMPLETED)
+        task_model = cast("type[Task]", apps.get_model("core", "Task"))
+
+        return self.filter(phase__in=phase_spellings(phase), status=task_model.Status.COMPLETED)
 
     def pending_in_phase(self, phase: str) -> models.QuerySet:
         """Non-terminal tasks whose phase normalizes to ``phase`` (#769).
@@ -291,22 +296,23 @@ class TaskQuerySet(models.QuerySet):
         status set.
         """
         from teatree.core.modelkit.phases import phase_spellings  # noqa: PLC0415
-        from teatree.core.models.task import Task  # noqa: PLC0415
+
+        task_model = cast("type[Task]", apps.get_model("core", "Task"))
 
         return self.filter(
             phase__in=phase_spellings(phase),
-            status__in=[Task.Status.PENDING, Task.Status.CLAIMED],
+            status__in=[task_model.Status.PENDING, task_model.Status.CLAIMED],
         )
 
     def claimable_for_headless(self, overlay: str | None = None) -> models.QuerySet:
-        from teatree.core.models.task import Task  # noqa: PLC0415
+        task_model = cast("type[Task]", apps.get_model("core", "Task"))
 
-        return self._claimable_for_target(Task.ExecutionTarget.HEADLESS, overlay)
+        return self._claimable_for_target(task_model.ExecutionTarget.HEADLESS, overlay)
 
     def claimable_for_interactive(self, overlay: str | None = None) -> models.QuerySet:
-        from teatree.core.models.task import Task  # noqa: PLC0415
+        task_model = cast("type[Task]", apps.get_model("core", "Task"))
 
-        return self._claimable_for_target(Task.ExecutionTarget.INTERACTIVE, overlay)
+        return self._claimable_for_target(task_model.ExecutionTarget.INTERACTIVE, overlay)
 
     def claim_next_pending(
         self,
@@ -341,10 +347,10 @@ class TaskQuerySet(models.QuerySet):
         semantics are byte-identical with or without it.
         Returns the claimed task, or ``None`` when nothing is claimable.
         """
-        from teatree.core.models.task import Task  # noqa: PLC0415
+        task_model = cast("type[Task]", apps.get_model("core", "Task"))
 
         now = timezone.now()
-        candidates = self.filter(status=Task.Status.PENDING)
+        candidates = self.filter(status=task_model.Status.PENDING)
         if extra_filter is not None:
             candidates = candidates.filter(extra_filter)
         with transaction.atomic():
@@ -355,8 +361,8 @@ class TaskQuerySet(models.QuerySet):
             # the row PENDING wins; a concurrent tick updates 0 rows. The
             # session attribution rides the SET clause only — the WHERE
             # predicate is the status CAS token and stays untouched by it.
-            claimed_count = self.filter(pk=oldest_pk, status=Task.Status.PENDING).update(
-                status=Task.Status.CLAIMED,
+            claimed_count = self.filter(pk=oldest_pk, status=task_model.Status.PENDING).update(
+                status=task_model.Status.CLAIMED,
                 claimed_by=claimed_by,
                 claimed_by_session=claimed_by_session,
                 claimed_at=now,
@@ -393,12 +399,12 @@ class TaskQuerySet(models.QuerySet):
         and the losers update 0 rows. Runs *before* ``reap_stale_claims``
         in the tick so a recoverable orphan is taken over, not failed.
         """
-        from teatree.core.models.task import Task  # noqa: PLC0415
+        task_model = cast("type[Task]", apps.get_model("core", "Task"))
 
         now = timezone.now()
         with transaction.atomic():
-            return self.filter(status=Task.Status.CLAIMED, lease_expires_at__lt=now).update(
-                status=Task.Status.PENDING,
+            return self.filter(status=task_model.Status.CLAIMED, lease_expires_at__lt=now).update(
+                status=task_model.Status.PENDING,
                 claimed_at=None,
                 claimed_by="",
                 claimed_by_session="",
@@ -443,11 +449,11 @@ class TaskQuerySet(models.QuerySet):
         # backend-agnostic lesson), so this stays a plain ordered scan.
         from django_fsm import TransitionNotAllowed  # noqa: PLC0415
 
-        from teatree.core.models.task import Task  # noqa: PLC0415
+        task_model = cast("type[Task]", apps.get_model("core", "Task"))
 
         replayed = 0
         seen: set[int] = set()
-        for task in self.filter(status=Task.Status.COMPLETED).select_related("ticket").order_by("-pk"):
+        for task in self.filter(status=task_model.Status.COMPLETED).select_related("ticket").order_by("-pk"):
             if task.ticket_id in seen:
                 continue
             seen.add(task.ticket_id)
@@ -478,12 +484,12 @@ class TaskQuerySet(models.QuerySet):
         no-op) because the conditional UPDATE is itself atomic — the
         same shape as ``claim_next_pending`` / ``LoopLease.acquire``.
         """
-        from teatree.core.models.task import Task  # noqa: PLC0415
+        task_model = cast("type[Task]", apps.get_model("core", "Task"))
 
         now = timezone.now()
         with transaction.atomic():
-            return self.filter(status=Task.Status.CLAIMED, lease_expires_at__lt=now).update(
-                status=Task.Status.FAILED,
+            return self.filter(status=task_model.Status.CLAIMED, lease_expires_at__lt=now).update(
+                status=task_model.Status.FAILED,
                 claimed_at=None,
                 claimed_by="",
                 claimed_by_session="",
@@ -500,10 +506,12 @@ class TaskQuerySet(models.QuerySet):
         lease has expired is excluded — the reaper will reclaim it and it is
         not truly in flight.
         """
-        from teatree.core.models.task import Task  # noqa: PLC0415
+        task_model = cast("type[Task]", apps.get_model("core", "Task"))
 
         now = timezone.now()
-        return self.filter(status=Task.Status.CLAIMED, lease_expires_at__gt=now).filter(dispatchable_filter).count()
+        return (
+            self.filter(status=task_model.Status.CLAIMED, lease_expires_at__gt=now).filter(dispatchable_filter).count()
+        )
 
     def active_claim_exists(self) -> bool:
         """True iff some task is CLAIMED with a still-live lease.
@@ -515,19 +523,19 @@ class TaskQuerySet(models.QuerySet):
         An expired lease is not in-flight (the worker is gone; the reaper /
         reclaimer will sweep it).
         """
-        from teatree.core.models.task import Task  # noqa: PLC0415
+        task_model = cast("type[Task]", apps.get_model("core", "Task"))
 
         now = timezone.now()
-        return self.filter(status=Task.Status.CLAIMED, lease_expires_at__gt=now).exists()
+        return self.filter(status=task_model.Status.CLAIMED, lease_expires_at__gt=now).exists()
 
     def _claimable_for_target(self, target: str, overlay: str | None = None) -> models.QuerySet:
-        from teatree.core.models.task import Task  # noqa: PLC0415
+        task_model = cast("type[Task]", apps.get_model("core", "Task"))
 
         now = timezone.now()
         qs = (
             self.filter(
                 execution_target=target,
-                status__in=[Task.Status.PENDING, Task.Status.CLAIMED],
+                status__in=[task_model.Status.PENDING, task_model.Status.CLAIMED],
             )
             .filter(Q(lease_expires_at__isnull=True) | Q(lease_expires_at__lte=now))
             .order_by("pk")

--- a/src/teatree/core/modelkit/errors.py
+++ b/src/teatree/core/modelkit/errors.py
@@ -1,0 +1,2 @@
+class RedisSlotsExhaustedError(RuntimeError):
+    """All configured Redis DB slots are in use by active tickets."""

--- a/src/teatree/core/models/errors.py
+++ b/src/teatree/core/models/errors.py
@@ -18,7 +18,3 @@ class DirtyWorktreeError(InvalidTransitionError):
     change first. No auto-stash — worktrees share ``.git`` so a stash is
     repo-global (the foreign-stash hazard, near-miss class #806).
     """
-
-
-class RedisSlotsExhaustedError(RuntimeError):
-    """All configured Redis DB slots are in use by active tickets."""

--- a/tach.toml
+++ b/tach.toml
@@ -61,7 +61,7 @@ depends_on = []
 [[modules]]
 path = "teatree.teams"
 layer = "domain"
-depends_on = ["teatree.core", "teatree.config", "teatree.agents", "teatree.skill_support", "teatree.utils"]
+depends_on = ["teatree.core", "teatree.core.models", "teatree.core.loop_lease_manager", "teatree.config", "teatree.agents", "teatree.skill_support", "teatree.utils"]
 
 [[modules]]
 path = "teatree.config"
@@ -149,7 +149,9 @@ depends_on = [
   "teatree.hooks",
   "teatree.on_behalf_gate",
   "teatree.slack_mrkdwn",
-  "teatree.core.modelkit"
+  "teatree.core.modelkit",
+  "teatree.core.models.errors",
+  "teatree.core.models"
 ]
 
 [[modules]]
@@ -158,12 +160,49 @@ layer = "domain"
 depends_on = []
 
 [[modules]]
+path = "teatree.core.models.errors"
+layer = "domain"
+depends_on = []
+
+[[modules]]
+path = "teatree.core.session_handover_manager"
+layer = "domain"
+depends_on = []
+
+[[modules]]
+path = "teatree.core.loop_lease_manager"
+layer = "domain"
+depends_on = ["teatree.utils"]
+
+[[modules]]
+path = "teatree.core.managers"
+layer = "domain"
+depends_on = [
+  "teatree.config",
+  "teatree.utils",
+  "teatree.core.modelkit",
+  "teatree.core.models.errors",
+  "teatree.core.loop_lease_manager",
+  "teatree.core.session_handover_manager"
+]
+
+[[modules]]
+path = "teatree.core.models"
+layer = "domain"
+depends_on = [
+  "teatree.core.modelkit",
+  "teatree.core.managers",
+  "teatree.core.models.errors"
+]
+
+[[modules]]
 path = "teatree.agents"
 layer = "domain"
 depends_on = [
   "teatree.types",
   "teatree.core",
   "teatree.core.modelkit",
+  "teatree.core.models",
   "teatree.skill_support",
   "teatree.utils",
   "teatree.config",
@@ -208,6 +247,7 @@ depends_on = [
   "teatree.types",
   "teatree.utils",
   "teatree.core",
+  "teatree.core.models",
   "teatree.identity",
   "teatree.url_classify"
 ]
@@ -219,6 +259,7 @@ depends_on = [
   "teatree.types",
   "teatree.utils",
   "teatree.core",
+  "teatree.core.models",
   "teatree.backends.errors",
   "teatree.backends.types",
   "teatree.backends.forge_merge_rpc",
@@ -232,6 +273,7 @@ depends_on = [
   "teatree.types",
   "teatree.utils",
   "teatree.core",
+  "teatree.core.models",
   "teatree.backends.errors",
   "teatree.backends.types",
   "teatree.backends.forge_merge_rpc"

--- a/tests/quality/test_intra_core_deferred_import_ratchet.py
+++ b/tests/quality/test_intra_core_deferred_import_ratchet.py
@@ -34,16 +34,15 @@ _CORE_ROOT = _REPO_ROOT / "src" / "teatree" / "core"
 _MODELS_ROOT = _CORE_ROOT / "models"
 _TACH = _REPO_ROOT / "tach.toml"
 
-# Measured in-worktree after PR-2a severed the 21 deferred up-edges from
-# core/models/ into the parent-core packages (gates/tasks/worktree_tasks/
-# overlay_loader/cost/backend_protocols). The net drop from PR-1's 217 is 11,
-# not 21: the signal receivers + the registry-population functions (incl. the
-# resolver wrappers that re-read the overlay_loader module attribute at call
-# time so a test patch is still seen) hold a handful of call-time
-# `from teatree.core import ...` (deferred so the model modules never import
-# them at boot — no AppRegistryNotReady). SHRINK-ONLY: lower this as PR-2b/PR-3
-# convert remaining deferred edges into declared tach sub-node edges; never raise it.
-_FROZEN_INTRA_CORE_DEFERRED = 206
+# Measured in-worktree after PR-2b converted the 17 deferred
+# `from teatree.core.models.X import Y` imports inside `managers.py` into
+# call-time `apps.get_model("core", "Y")` lookups (AppRegistry-safe,
+# tach-invisible) and declared `teatree.core.models` / `teatree.core.managers`
+# as tach sub-nodes — the core cycle is now structurally forbidden, not merely
+# severed. The drop from PR-2a's 206 is exactly those 17 converted imports.
+# SHRINK-ONLY: lower this as PR-3 converts remaining deferred edges into
+# declared tach sub-node edges; never raise it.
+_FROZEN_INTRA_CORE_DEFERRED = 189
 
 
 def _function_scoped_intra_core_imports(source: Path) -> int:
@@ -78,6 +77,33 @@ def _count_all() -> int:
 def _module_entry(path: str) -> dict[str, object]:
     data = tomllib.loads(_TACH.read_text(encoding="utf-8"))
     return next(m for m in data["modules"] if m["path"] == path)
+
+
+def _runtime_models_imports(source: Path) -> list[str]:
+    """Lines importing ``teatree.core.models*`` outside an ``if TYPE_CHECKING`` block."""
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+    parents: dict[ast.AST, ast.AST] = {}
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            parents[child] = node
+
+    def under_type_checking(node: ast.AST) -> bool:
+        cur = parents.get(node)
+        while cur is not None:
+            if isinstance(cur, ast.If):
+                test = cur.test
+                if isinstance(test, ast.Name) and test.id == "TYPE_CHECKING":
+                    return True
+            cur = parents.get(cur)
+        return False
+
+    return [
+        f"{source.name}:{node.lineno}"
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        and (node.module or "").startswith("teatree.core.models")
+        and not under_type_checking(node)
+    ]
 
 
 def _model_files_importing(dotted: str) -> list[str]:
@@ -144,3 +170,57 @@ class TestCoreModelkitLayer:
     def test_fibonacci_leaf_lives_under_modelkit_not_gates(self) -> None:
         assert (_CORE_ROOT / "modelkit" / "fibonacci.py").is_file()
         assert not (_CORE_ROOT / "gates" / "fibonacci.py").exists()
+
+
+class TestCoreModelManagerNodes:
+    """Pins the PR-2b carve of the ``models`` / ``managers`` tach sub-nodes.
+
+    ``teatree.core.models`` and ``teatree.core.managers`` are declared tach
+    sub-nodes, so the core models↔managers cycle is structurally forbidden by
+    ``forbid_circular_dependencies`` rather than merely severed.
+
+    ``models`` depends on ``managers`` (the eager ``objects = XManager()`` edge),
+    one-way: ``managers`` may never depend on ``models`` (the pure exception leaf
+    ``models.errors`` is its own node so the ``RedisSlotsExhaustedError`` edge does
+    not pull ``managers`` into the full ``models`` node). The two manager-layer
+    helper leaves (``loop_lease_manager`` / ``session_handover_manager``, split out
+    of ``managers``) are declared below ``managers`` so it never reaches back up
+    into the parent ``teatree.core`` node.
+    """
+
+    def test_models_declared_depending_on_managers_one_way(self) -> None:
+        entry = _module_entry("teatree.core.models")
+        deps = entry.get("depends_on", [])
+        assert entry["layer"] == "domain"
+        assert "teatree.core.managers" in deps
+
+    def test_managers_never_depends_on_the_models_node(self) -> None:
+        entry = _module_entry("teatree.core.managers")
+        deps = entry.get("depends_on", [])
+        assert entry["layer"] == "domain"
+        assert "teatree.core.models" not in deps
+        assert "teatree.core" not in deps
+
+    def test_models_errors_is_a_pure_leaf_node(self) -> None:
+        entry = _module_entry("teatree.core.models.errors")
+        assert entry["layer"] == "domain"
+        assert entry.get("depends_on", []) == []
+
+    def test_parent_core_declares_models_and_errors_children(self) -> None:
+        parent = _module_entry("teatree.core")
+        deps = parent.get("depends_on", [])
+        assert "teatree.core.models" in deps
+        assert "teatree.core.models.errors" in deps
+
+    def test_managers_has_no_runtime_models_import(self) -> None:
+        # The 17 deferred `from teatree.core.models.X import Y` imports inside
+        # manager methods became `apps.get_model("core", "Y")`; the lone top-level
+        # `RedisSlotsExhaustedError` import moved to the modelkit leaf. A runtime
+        # `from teatree.core.models...` import in managers.py (top-level OR
+        # function-scoped, but not TYPE_CHECKING-guarded) resurrects the forbidden
+        # managers→models edge.
+        offenders = _runtime_models_imports(_CORE_ROOT / "managers.py")
+        assert not offenders, (
+            "managers.py imports the teatree.core.models node at runtime "
+            "(use apps.get_model instead):\n" + "\n".join(offenders)
+        )

--- a/tests/teatree_core/test_redis_slots.py
+++ b/tests/teatree_core/test_redis_slots.py
@@ -16,8 +16,8 @@ import pytest
 from django.test import TestCase
 
 from teatree.config import load_config
+from teatree.core.modelkit.errors import RedisSlotsExhaustedError
 from teatree.core.models import Ticket
-from teatree.core.models.errors import RedisSlotsExhaustedError
 from teatree.core.models.worktree import Worktree
 
 REDIS_DB_COUNT = load_config().user.redis_db_count

--- a/tests/teatree_core/test_redis_slots_concurrent.py
+++ b/tests/teatree_core/test_redis_slots_concurrent.py
@@ -32,8 +32,8 @@ from pathlib import Path
 import pytest
 from django.db import connections
 
+from teatree.core.modelkit.errors import RedisSlotsExhaustedError
 from teatree.core.models import Ticket
-from teatree.core.models.errors import RedisSlotsExhaustedError
 from teatree.settings import SQLITE_WRITE_SERIALIZATION_OPTIONS
 
 


### PR DESCRIPTION
PR-2b completes the #2385 core re-layering. PR-1 carved the `modelkit` leaf; PR-2a severed the 21 `models`->parent-core deferred up-edges via signal+registry injection. PR-2b declares `teatree.core.models` and `teatree.core.managers` as tach sub-nodes so the core `models`<->`managers` cycle is **structurally forbidden** by `forbid_circular_dependencies`, not merely severed. This completes the core re-layering.

## apps.get_model conversion

The 17 deferred `from teatree.core.models.X import Y` imports inside `managers.py` manager methods became call-time `apps.get_model("core", "Y")` lookups (AppRegistry-safe, tach-invisible, resolves the model lazily by name), wrapped in `cast("type[X]", ...)` so the type checker keeps the precise `X.Status` / `X.State` attributes. Following the codebase convention, each result is a lowercase `<model>_model` local (`task_model`, `ticket_model`, …). After this, `managers.py` has no `teatree.core.models` import in any runtime form (only the TYPE_CHECKING forward-reference imports remain, which tach ignores).

The lone top-level `RedisSlotsExhaustedError` import (a pure exception, not a Django model — `apps.get_model` does not apply) moved to a new `teatree.core.modelkit.errors` leaf, so `managers.py` now imports only `modelkit` / `django` / `stdlib` / the manager-layer helpers.

## Node declarations (tach.toml)

All `layer = "domain"`:

- `teatree.core.models.errors` -> `depends_on = []` — pure exception leaf (zero imports), shared by both `models` and `managers`. Declared as its own leaf node (not a moved class) so the `RedisSlotsExhaustedError` edge does not pull `managers` into the full `models` node — minimal blast radius (tach.toml only), mirroring PR-1's `modelkit` carve and the `backends.errors`/`types` shared-primitive split.
- `teatree.core.session_handover_manager` -> `depends_on = []`
- `teatree.core.loop_lease_manager` -> `depends_on = ["teatree.utils"]`
  These two are "split out of `managers`" helper leaves; declaring them below `managers` keeps `managers` from reaching back up into the parent `teatree.core` node (the second cycle source, distinct from the deferred model imports).
- `teatree.core.managers` -> `depends_on = [config, utils, modelkit, models.errors, loop_lease_manager, session_handover_manager]`
- `teatree.core.models` -> `depends_on = [modelkit, managers, models.errors]` — the eager `objects = XManager()` edge, one-way, legal.
- parent `teatree.core` -> adds `models`, `models.errors`.

## External depends_on added

`tach check` flagged exactly these top-level `teatree.core.models` importers (trusted tach, not the plan's estimate):

- `teatree.agents` -> `teatree.core.models`
- `teatree.backends.github` -> `teatree.core.models`
- `teatree.backends.gitlab` -> `teatree.core.models`
- `teatree.backends.slack` -> `teatree.core.models`
- `teatree.teams` -> `teatree.core.models` **and** `teatree.core.loop_lease_manager`

(Other model importers — `cli`, `loop`, `eval`, `messaging`, … — use deferred/function-scoped imports, which this project's tach config does not enforce, so they need no edge.)

## Ratchet

`_FROZEN_INTRA_CORE_DEFERRED` lowered **206 -> 189** (the 17 converted imports drop out of the AST ratchet — measured in-worktree). Added `TestCoreModelManagerNodes` pinning the new node declarations, the one-way `models`->`managers` edge, the `models.errors` pure-leaf node, and the absence of any runtime `managers`->`models` import.

`docs/dependency-graph.md` regenerated from the updated tach.toml (the pre-commit generator).

## tach-cycle-detection proof (the guard has teeth)

Reverting one `apps.get_model("core", "Task")` back to a top-level `from teatree.core.models.task import Task` in `managers.py` makes `tach check` fail. Attempting to "fix" it by adding `teatree.core.models` to `managers`' `depends_on` produces:

```
Circular dependency detected for module 'teatree.core.managers'
Circular dependency detected for module 'teatree.core.models'
Resolve circular dependencies.
```

The cycle is now structurally impossible, not merely severed. Reverted.

## Verification

- `python -c "import django; django.setup()"` (settings `teatree.settings`) — BOOT OK, no `AppRegistryNotReady`.
- `tach check` — GREEN with `models` + `managers` declared.
- `tests/teatree_core/` — 3516 passed (one `--no-migrations`-only artifact in `test_schema_guard`, passes with migrations); behaviour preserved.
- `tests/quality/ tests/teatree_quality/` — 353 passed, 1 skipped; the lone failure is `test_regression_rules.py::TestSemgrepEngine::test_semgrep_is_invocable` (a pre-existing local semgrep timeout — this PR touches nothing in that file).
- `scripts/hooks/check_module_health.py --from-ref origin/main` — exit 0.
- `ty-check` + `ruff` — green (cast wraps preserve typing; `<model>_model` locals satisfy N806).

References #2385.
