### PR TITLE
fix(loop): suppress non-actionable tick output + add terse/TTS-ready output rule (#2417)

### DIFF
--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -47,6 +47,7 @@ Use `Ctrl+F`/`grep` to jump to a rule. Sections are grouped below by theme; numb
 14c. [Render the Title Inline, Never a Bare/Link-Only Id](#render-the-title-inline-never-a-barelink-only-id-non-negotiable)
 14b. [ID Namespace Disambiguation](#id-namespace-disambiguation-non-negotiable)
 14a. [Lead a Completion Report With the Assigned-Work Status](#lead-a-completion-report-with-the-assigned-work-status)
+14d. [Keep Turn Output Terse and TTS-Ready](#keep-turn-output-terse-and-tts-ready)
 15. [No AI Signature on Posts Made on the User's Behalf](#no-ai-signature-on-posts-made-on-the-users-behalf-non-negotiable)
 15a. [Ask Before Posting on the User's Behalf](#ask-before-posting-on-the-users-behalf-non-negotiable)
 16. [Never Post PR Comments from Parallel Agents](#never-post-pr-comments-from-parallel-agents-non-negotiable)
@@ -201,6 +202,26 @@ In a multi-agent / multi-loop environment, another agent may have advanced a sha
 ## Lead a Completion Report With the Assigned-Work Status
 
 When reporting back on assigned work, the reader's first need is an unambiguous answer to **"is the assigned work done, and where is it?"** — deliverable status, branch/PR/HEAD, gate results. Out-of-scope observations, systemic findings, or follow-up recommendations surfaced along the way must be **clearly separated and subordinate**: a labelled trailing section, never positioned so they displace, precede, or read as a substitute for the deliverable status. A correct systemic analysis that buries the "done?" answer reads as "did the analysis instead of the work" — the coordinator concludes nothing shipped and spends a round-trip re-asking for what was already finished. Separate the two concerns physically; lead with the in-scope status every time.
+
+## Keep Turn Output Terse and TTS-Ready
+
+Every turn response must be short enough to speak aloud without losing the listener. The whole turn output — not just a summary — should fit TTS comfortably.
+
+**Required:**
+
+- Lead with the answer or the action taken. The first sentence is the payload; context and reasoning follow only if necessary.
+- One sentence per point. No long prose paragraphs.
+- No decorative markdown (headers, horizontal rules, nested bullet trees, bold-for-structure) when speaking. Plain sentences work for speech; heading hierarchies do not.
+- Suppress routine status noise. "N signals, N actions" and "still running" progress reports are not actionable → omit them unless something changed that the user must act on.
+- Background work: report on completion or decision only, not on each in-progress tick.
+
+**Anti-patterns:**
+
+- A multi-paragraph narrative of what was done, what was found, and what comes next — when the answer is "done, here is the PR link".
+- A section-headed summary where every item is restated twice (once as a heading, once as prose).
+- A tick report that says "everything is fine" in 8 lines when silence would be correct.
+
+**TTS cap:** If `t3 speak` is active (`[teatree.speak] local = "all"`), the per-turn text passed to `clean_for_speech` is capped at 600 characters. Write turns that fit without truncation by default — the cap is a hard backstop, not a target. A turn that requires aggressive truncation before it fits TTS was too verbose to start.
 
 ## Context Transparency
 

--- a/src/teatree/core/management/commands/loop_tick.py
+++ b/src/teatree/core/management/commands/loop_tick.py
@@ -278,9 +278,6 @@ class Command(TyperCommand):
                 )
             )
             return
-        self.stdout.write(
-            f"OK    [{name}] {len(outcome.dispatched_loops)} loop(s) dispatched, {outcome.actions_count} action(s)."
-        )
         for loop_name, message in outcome.errors.items():
             self.stdout.write(f"WARN  {loop_name}: {message}")
 
@@ -401,10 +398,6 @@ class Command(TyperCommand):
         result = _report_to_dict(report)
         if json_output:
             self.stdout.write(json.dumps(result, indent=2))
-        else:
-            self.stdout.write(f"OK    {report.signal_count} signal(s), {report.action_count} action(s).")
-            if report.errors:
-                for name, message in report.errors.items():
-                    self.stdout.write(f"WARN  {name}: {message}")
-            if report.statusline_path:
-                self.stdout.write(f"      statusline → {report.statusline_path}")
+        elif report.errors:
+            for name, message in report.errors.items():
+                self.stdout.write(f"WARN  {name}: {message}")

--- a/tests/teatree_core/test_loop_tick_command.py
+++ b/tests/teatree_core/test_loop_tick_command.py
@@ -51,7 +51,7 @@ class TestReportToDict(TestCase):
 
 
 class TestLoopTickCommand(TestCase):
-    def test_text_output(self) -> None:
+    def test_quiet_exit_when_no_errors(self) -> None:
         report = _build_report(statusline_path=Path("/tmp/sl.txt"))
         stdout = StringIO()
         with (
@@ -60,9 +60,19 @@ class TestLoopTickCommand(TestCase):
         ):
             call_command("loop_tick", stdout=stdout)
 
+        assert stdout.getvalue() == ""
+
+    def test_text_output_with_errors(self) -> None:
+        report = _build_report(statusline_path=Path("/tmp/sl.txt"), errors={"my_prs": "RuntimeError: x"})
+        stdout = StringIO()
+        with (
+            patch("teatree.core.backend_factory.iter_overlay_backends", return_value=[]),
+            patch("teatree.loop.tick.run_tick", return_value=report),
+        ):
+            call_command("loop_tick", stdout=stdout)
+
         output = stdout.getvalue()
-        assert "1 signal(s)" in output
-        assert "statusline" in output
+        assert "WARN  my_prs" in output
 
     def test_drains_deferred_reinstall_before_running_scanners(self) -> None:
         """#1760: the deferred-reinstall drain is the FIRST owner-tick step.

--- a/tests/teatree_loop/test_tick_piggyback.py
+++ b/tests/teatree_loop/test_tick_piggyback.py
@@ -128,7 +128,8 @@ class TestTickPiggybackSlackAnswer:
         row.refresh_from_db()
         assert row.eyes_reacted_at is None
         assert backend.reactions == []
-        assert "OK" in out.getvalue()
+        # Quiet-exit contract (#2417): a non-actionable tick emits no WARN line.
+        assert "WARN" not in out.getvalue()
 
     def test_tick_piggyback_throttled_within_cadence(self) -> None:
         """Two ticks inside the cadence window → exactly one eyes reaction."""


### PR DESCRIPTION
Closes #2417.

## What

- loop_tick fat-tick and scoped-tick human-readable paths no longer emit a summary line on every clean tick. Warnings still appear when errors occur. JSON output is unchanged.
- skills/rules/SKILL.md gains a terse/TTS-ready output rule: lead with the answer, one sentence per point, suppress routine noise, report background work on completion only, stay within the 600-char TTS cap by default.

## Why

Routine summary lines surface on every tick even when nothing changed. With TTS active, these are spoken aloud as noise. Silent clean ticks and WARN-on-error is the right default.

## Test plan

- test_quiet_exit_when_no_errors: clean tick produces no stdout
- test_text_output_with_errors: WARN lines still appear on errors
- All 32 tests in tests/teatree_core/test_loop_tick_command.py pass
- All 64 tests/teatree_quality/ tests pass
- check_module_health.py --from-ref origin/main exits 0
