### PR TITLE
fix(ci): resolve the CI service from the repo's owning overlay

### DIFF
--- a/src/teatree/cli/ci.py
+++ b/src/teatree/cli/ci.py
@@ -21,14 +21,39 @@ class CICommands:
 
     @staticmethod
     def get_ci_service() -> CIService | None:
-        """Get CI service — tries overlay first, falls back to env vars."""
+        """Resolve the CI service: active overlay, then the repo's owning overlay, then env vars.
+
+        ``ensure_django()`` runs first so the overlay registry and the backend
+        provider are loaded; without it the active and repo-resolution paths
+        both yield nothing and the command falls through to env-only.
+        """
+        ensure_django()
         try:
             from teatree.core.backend_factory import ci_service_from_overlay  # noqa: PLC0415
 
             result = ci_service_from_overlay()
             if result is not None:
                 return result
-        except Exception:  # noqa: BLE001, S110 — fallback to env-based config
+        except Exception:  # noqa: BLE001, S110 — fall through to repo/env resolution
+            pass
+
+        # No active overlay (no session / ``T3_OVERLAY_NAME``): resolve the
+        # overlay that owns the current repo by its origin remote, so ``t3 ci``
+        # works from any overlay repo. A multi-overlay install makes the active
+        # path raise "Multiple overlays" — exactly the bare-repo case.
+        try:
+            from teatree.core.backend_registry import get_backend_provider  # noqa: PLC0415
+            from teatree.core.overlay_loader import get_overlay_for_repo  # noqa: PLC0415
+
+            overlay = get_overlay_for_repo(".")
+            if overlay is not None:
+                service = get_backend_provider().get_ci_service(
+                    gitlab_token=overlay.config.get_gitlab_token(),
+                    gitlab_url=overlay.config.gitlab_url,
+                )
+                if service is not None:
+                    return service
+        except Exception:  # noqa: BLE001, S110 — fall through to env resolution
             pass
 
         token = os.environ.get("GITLAB_TOKEN", "")

--- a/tests/test_cli_ci.py
+++ b/tests/test_cli_ci.py
@@ -1,5 +1,7 @@
 """Tests for CI-related CLI commands extracted from test_cli.py."""
 
+import shutil
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,10 +12,46 @@ import teatree.core.backend_factory as backend_factory_mod
 import teatree.core.overlay_loader as overlay_loader_mod
 import teatree.utils.git as git_mod
 import teatree.utils.run as utils_run_mod
+from teatree.backends.gitlab.ci import GitLabCIService
 from teatree.cli import app
 from teatree.cli.ci import CICommands
+from teatree.core.overlay import OverlayBase, OverlayConfig
 
 runner = CliRunner()
+_GIT = shutil.which("git") or "git"
+
+
+class _RepoOwningConfig(OverlayConfig):
+    def get_gitlab_token(self) -> str:
+        return "gl-test-token"
+
+
+class _RepoOwningOverlay(OverlayBase):
+    """Owns ``group/repo`` and carries a GitLab token."""
+
+    config = _RepoOwningConfig()
+
+    def get_repos(self):
+        return []
+
+    def get_provision_steps(self, worktree):
+        return []
+
+    def get_workspace_repos(self) -> list[str]:
+        return ["group/repo"]
+
+
+class _UnrelatedOverlay(OverlayBase):
+    """A second registered overlay so active resolution is ambiguous."""
+
+    def get_repos(self):
+        return []
+
+    def get_provision_steps(self, worktree):
+        return []
+
+    def get_workspace_repos(self) -> list[str]:
+        return ["other/thing"]
 
 
 # ── CICommands.get_ci_service() ──────────────────────────────────────
@@ -21,16 +59,38 @@ runner = CliRunner()
 
 class TestGetCIService:
     def test_from_env(self, monkeypatch):
-        """Creates service from env when overlay fails."""
+        """Creates service from env when overlay + repo resolution find nothing."""
         monkeypatch.setenv("GITLAB_TOKEN", "token")
-        with patch.object(backend_factory_mod, "ci_service_from_overlay", side_effect=Exception("no django")):
+        with (
+            patch.object(backend_factory_mod, "ci_service_from_overlay", side_effect=Exception("no django")),
+            patch.object(overlay_loader_mod, "get_overlay_for_repo", return_value=None),
+        ):
             service = CICommands.get_ci_service()
             assert service is not None
 
     def test_no_token(self, monkeypatch):
         monkeypatch.delenv("GITLAB_TOKEN", raising=False)
-        with patch.object(backend_factory_mod, "ci_service_from_overlay", side_effect=Exception("no django")):
+        with (
+            patch.object(backend_factory_mod, "ci_service_from_overlay", side_effect=Exception("no django")),
+            patch.object(overlay_loader_mod, "get_overlay_for_repo", return_value=None),
+        ):
             assert CICommands.get_ci_service() is None
+
+    def test_resolves_service_from_repo_owning_overlay(self, tmp_path, monkeypatch):
+        """Resolve the CI service via the repo's owning overlay when no overlay is active."""
+        subprocess.run([_GIT, "-C", str(tmp_path), "init", "-q"], check=True, capture_output=True)
+        subprocess.run(
+            [_GIT, "-C", str(tmp_path), "remote", "add", "origin", "git@gitlab.com:group/repo.git"],
+            check=True,
+            capture_output=True,
+        )
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+        monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+        overlays = {"a": _RepoOwningOverlay(), "b": _UnrelatedOverlay()}
+        with patch.object(overlay_loader_mod, "_discover_overlays", return_value=overlays):
+            service = CICommands.get_ci_service()
+        assert isinstance(service, GitLabCIService)
 
 
 # ── CICommands.get_ci_project() ──────────────────────────────────────


### PR DESCRIPTION
## Why

`t3 ci` only resolved a CI service from the *active* overlay (a live session, or `T3_OVERLAY_NAME`). Run from a bare checkout with no active overlay, the active path yielded nothing and the command fell straight through to env-only resolution — so `t3 ci` did not work from an overlay's own repo unless GITLAB_TOKEN happened to be set in the environment.

## What

`CICommands.get_ci_service()` now resolves in three ordered steps:

1. the active overlay (`ci_service_from_overlay()`), as before;
2. **new:** when there is no active overlay, the overlay that *owns the current repo* — matched by the repo's origin slug against each overlay's workspace repos (`get_overlay_for_repo(".")`), using that overlay's configured token and GitLab URL;
3. the existing `GITLAB_TOKEN` / `GITLAB_URL` environment fallback.

So `t3 ci` works from any overlay repo, while a multi-overlay install no longer breaks the active path with a "Multiple overlays" error in the bare-repo case.

## Tests

Adds `test_resolves_service_from_repo_owning_overlay` (real git repo under tmp_path, two overlays, asserts the owning overlay's service is selected) and updates the env-fallback tests to patch `get_overlay_for_repo` → None so they exercise the pure-env path.