### PR TITLE
fix(tools): issue commands never trigger MR gate; repo-keyed validation skips unowned repos

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -2339,7 +2339,6 @@ def _extract_api_mr_fields(command: str) -> tuple[str, str] | None:
         else:
             key = m.group("key2")
             value = (m.group("qval") if m.group("q") else m.group("bval")) or ""
-        # GitHub's PR description field is ``body``; map it onto ``description``.
         fields["description" if key == "body" else key] = value
     if not fields:
         return None
@@ -2385,7 +2384,6 @@ def _extract_mr_fields(data: dict) -> tuple[str, str] | None:
 
     if tool_name == "Bash":
         command = tool_input.get("command", "")
-        # Use \s+ (not plain `in`) so double-space variants are caught (F1).
         if re.search(r"\bglab\s+mr\s+(?:create|update)\b", command):
             title_match = _MR_TITLE_FLAG_RE.search(command)
             title = title_match.group("val") if title_match else ""

--- a/src/teatree/cli/tools.py
+++ b/src/teatree/cli/tools.py
@@ -118,7 +118,7 @@ def validate_mr(
             errors = _validation_errors_fail_closed(target_overlay, title, description)
             if errors:
                 _deny_with_errors(errors)
-            return
+        return
 
     try:
         overlay = get_overlay()

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -746,6 +746,113 @@ class TestValidateMrTargetRepoKeyed:
         assert result.exit_code == 0, result.output
 
 
+class TestValidateMrTeatreeRepoNeverGetsExternalConvention:
+    """`t3 tool validate-mr --repo souliane/teatree` always uses teatree's convention.
+
+    When ``get_overlay_for_repo("souliane/teatree")`` returns ``None`` (the
+    registered overlay set doesn't own that repo), the command must NOT fall
+    through to the cwd-keyed ``get_overlay()`` path — that path could return an
+    unrelated overlay whose narrower title-type set rejects titles perfectly
+    valid under teatree's broader convention. The fix returns early (skip) when
+    ``--repo`` was provided but maps to no known overlay.
+    """
+
+    def _register(self, monkeypatch: pytest.MonkeyPatch, overlays: dict):
+        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+        return patch("teatree.core.overlay_loader._discover_overlays", return_value=overlays)
+
+    def test_chore_title_accepted_for_teatree_repo_even_when_strict_overlay_is_active(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        overlays = {
+            "t3-teatree": _AcceptingOverlay(["souliane/teatree"]),
+            "strict-overlay": _RejectingOverlay(["acme-org/acme-product"], ["MR title type 'chore' is not allowed"]),
+        }
+        with self._register(monkeypatch, overlays):
+            result = runner.invoke(
+                app,
+                [
+                    "tool",
+                    "validate-mr",
+                    "--title",
+                    "chore: fix typo in README",
+                    "--description",
+                    "chore: fix typo in README",
+                    "--repo",
+                    "souliane/teatree",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+
+    def test_chore_title_allowed_for_teatree_repo_when_only_strict_overlay_registered(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        overlays = {
+            "strict-overlay": _RejectingOverlay(["acme-org/acme-product"], ["MR title type 'chore' is not allowed"]),
+        }
+        with self._register(monkeypatch, overlays):
+            result = runner.invoke(
+                app,
+                [
+                    "tool",
+                    "validate-mr",
+                    "--title",
+                    "chore: fix typo in README",
+                    "--description",
+                    "chore: fix typo in README",
+                    "--repo",
+                    "souliane/teatree",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+
+    def test_chore_title_rejected_for_strict_repo_when_strict_overlay_is_active(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        overlays = {
+            "t3-teatree": _AcceptingOverlay(["souliane/teatree"]),
+            "strict-overlay": _RejectingOverlay(["acme-org/acme-product"], ["MR title type 'chore' is not allowed"]),
+        }
+        with self._register(monkeypatch, overlays):
+            result = runner.invoke(
+                app,
+                [
+                    "tool",
+                    "validate-mr",
+                    "--title",
+                    "chore: fix typo",
+                    "--description",
+                    "chore: fix typo",
+                    "--repo",
+                    "acme-org/acme-product",
+                ],
+            )
+        assert result.exit_code == 1, result.output
+        assert "chore" in result.output
+
+    def test_teatree_title_with_teatree_exclusive_type_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        overlays = {
+            "t3-teatree": _AcceptingOverlay(["souliane/teatree"]),
+            "strict-overlay": _RejectingOverlay(["acme-org/acme-product"], ["not allowed"]),
+        }
+        with self._register(monkeypatch, overlays):
+            for title_type in ("docs", "test", "refactor"):
+                result = runner.invoke(
+                    app,
+                    [
+                        "tool",
+                        "validate-mr",
+                        "--title",
+                        f"{title_type}: something",
+                        "--description",
+                        f"{title_type}: something",
+                        "--repo",
+                        "souliane/teatree",
+                    ],
+                )
+                assert result.exit_code == 0, f"Expected {title_type}: to pass for souliane/teatree\n{result.output}"
+
+
 class TestToMarkdownCommand:
     """`t3 tool to-markdown` converts an attachment to Markdown via markitdown.
 

--- a/tests/test_validate_mr_metadata_hook.py
+++ b/tests/test_validate_mr_metadata_hook.py
@@ -280,6 +280,54 @@ class TestMrTargetRepoIsThreadedToValidator:
         assert "--repo" not in argv
 
 
+class TestIssueCommandsAreNeverMrMutations:
+    """``gh issue`` / ``glab issue`` commands are not MR mutations — the gate must never fire.
+
+    Issue creation is a distinct forge operation with its own title conventions
+    (free-form). Applying the MR-metadata gate to an issue create/comment would
+    reject any issue title that does not match the MR conventional-commit format,
+    misfiring every time an agent files a bug or feature request.
+
+    The guard must be EXPLICIT and EARLY: matching on ``glab mr`` or ``gh api
+    .../pulls`` is insufficient because those patterns could grow — the gate must
+    positively exclude the entire ``gh issue`` / ``glab issue`` surface before
+    any MR-pattern check runs.
+    """
+
+    def test_gh_issue_create_is_never_an_mr_mutation(self):
+        cmd = "gh issue create --repo souliane/teatree --title 'chore: cleanup' --body 'context'"
+        result = router._extract_mr_fields({"tool_name": "Bash", "tool_input": {"command": cmd}})
+        assert result is None
+
+    def test_glab_issue_create_is_never_an_mr_mutation(self):
+        cmd = "glab issue create --repo org/repo --title 'chore: cleanup' --description 'context'"
+        result = router._extract_mr_fields({"tool_name": "Bash", "tool_input": {"command": cmd}})
+        assert result is None
+
+    def test_gh_issue_comment_is_never_an_mr_mutation(self):
+        cmd = "gh issue comment 42 --repo souliane/teatree --body 'follow-up note'"
+        result = router._extract_mr_fields({"tool_name": "Bash", "tool_input": {"command": cmd}})
+        assert result is None
+
+    def test_glab_issue_note_is_never_an_mr_mutation(self):
+        cmd = "glab issue note 42 --message 'follow-up note'"
+        result = router._extract_mr_fields({"tool_name": "Bash", "tool_input": {"command": cmd}})
+        assert result is None
+
+    def test_glab_mr_create_bad_title_still_blocks(self, monkeypatch, capsys):
+        monkeypatch.delenv("T3_MR_VALIDATE_SCRIPT", raising=False)
+        monkeypatch.setattr(router.shutil, "which", lambda _: "/usr/local/bin/t3")
+        rejected = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="Title is invalid.")
+        with patch.object(router.subprocess, "run", return_value=rejected):
+            blocked = handle_validate_mr_metadata(
+                {
+                    "tool_name": "Bash",
+                    "tool_input": {"command": "glab mr create --title 'bad title' --description 'bad'"},
+                }
+            )
+        assert blocked is True
+
+
 class TestEnvVarOverrideStillWorks:
     """An explicitly-set T3_MR_VALIDATE_SCRIPT remains the override path."""
 


### PR DESCRIPTION
## Summary

- `gh issue create` and `glab issue create` commands were never MR mutations — the gate correctly passed them through already. This PR adds `TestIssueCommandsAreNeverMrMutations` to pin that invariant explicitly.
- `t3 tool validate-mr --repo <slug>` was falling through to the cwd-keyed single-overlay path when the given `--repo` matched no registered overlay. This let a strict overlay active in the CWD (one with a narrower title-type set) reject valid titles targeting an unrelated repo. The fix gates the single-overlay cwd path behind `repo` being absent: an explicit `--repo` that maps to no known overlay now returns early (skip), never applying an unrelated overlay's convention.

## Test plan

- `TestIssueCommandsAreNeverMrMutations` (5 tests): `gh`/`glab` issue subcommands return `None` from `_extract_mr_fields`; a real `glab mr create` bad title still blocks.
- `TestValidateMrTeatreeRepoNeverGetsExternalConvention` (4 tests): `chore:` title passes for `souliane/teatree` even when only a strict overlay is registered; strict overlay still rejects `chore:` for its own repos; teatree-exclusive types (`docs`, `test`, `refactor`) pass for `souliane/teatree`.
