### PR TITLE
fix(hooks): route the publish gate visibility probe to the right forge for bare repo slugs

### DIFF
--- a/src/teatree/hooks/_repo_visibility.py
+++ b/src/teatree/hooks/_repo_visibility.py
@@ -301,6 +301,13 @@ def probe_visibility(slug: str) -> str | None:
     tool is unavailable, the slug is unrecognised, or the probe errors.
     ``None`` is the fail-safe "unknown" -- the caller then treats the repo as
     NOT private and the gate stays hard-blocking.
+
+    The forge is resolved from the slug's host segment: a first ``/``-segment
+    containing a dot (``gitlab.com/...`` -> ``glab``, ``github.com/...`` ->
+    ``gh``). A BARE ``owner/repo`` slug carries no host, so callers that know
+    the forge from the publish tool qualify the slug UP to its canonical host
+    form first (:func:`forge_qualified_slug`) -- a ``glab`` post therefore
+    probes via ``glab`` instead of being mis-routed to the GitHub default.
     """
     parts = slug.split("/")
     if len(parts) < _MIN_SLUG_PARTS:
@@ -312,6 +319,33 @@ def probe_visibility(slug: str) -> str | None:
     if host.startswith("github") or not host:
         return _probe_gh(repo_path)
     return None
+
+
+# Canonical host for each forge, used to qualify a BARE ``owner/repo`` slug UP
+# to its host-prefixed form so the host-keyed probe routes to the right tool.
+_FORGE_CANONICAL_HOST: Final[dict[str, str]] = {"github": "github.com", "gitlab": "gitlab.com"}
+
+
+def forge_qualified_slug(slug: str, forge: str) -> str:
+    """Return ``slug`` host-qualified with ``forge``'s canonical host, if it is bare.
+
+    A bare ``owner/repo`` slug (no leading dotted host segment) carries no forge
+    of its own, so the host-keyed :func:`probe_visibility` defaults it to the
+    GitHub probe -- which can never confirm a GitLab repo private. When the
+    publish TOOL pins the forge (``glab`` -> ``gitlab``, ``gh`` -> ``github``),
+    qualifying the slug UP to ``<host>/owner/repo`` routes the probe to the right
+    tool. An already host-qualified slug, an unknown forge, or an empty slug is
+    returned unchanged -- the host segment then governs the route, and the
+    allowlist match is host-qualification-symmetric so qualifying never changes
+    an allowlist verdict.
+    """
+    canonical_host = _FORGE_CANONICAL_HOST.get(forge)
+    if not canonical_host or not slug:
+        return slug
+    head = slug.split("/", 1)[0]
+    if "." in head:
+        return slug
+    return f"{canonical_host}/{slug}"
 
 
 def slug_is_private(slug: str) -> bool:

--- a/src/teatree/hooks/publish_destination.py
+++ b/src/teatree/hooks/publish_destination.py
@@ -53,6 +53,7 @@ from teatree.hooks._publish_detection import segment_is_api_read as _segment_is_
 from teatree.hooks._publish_detection import segment_is_api_write as _segment_is_api_write
 from teatree.hooks._repo_visibility import (
     _config_path,
+    forge_qualified_slug,
     slug_for_cwd,
     slug_is_allowlisted_private,
     slug_is_private,
@@ -77,10 +78,23 @@ class Destination:
     a ``gh``/``glab api`` URL path, ``url`` for a forge URL positional, ``env``
     for ``GH_REPO``, ``cwd`` for the current-repo fallback) so a caller can log
     the provenance without re-parsing.
+
+    ``forge`` records which forge the PUBLISH TOOL targets (``github`` for a
+    ``gh`` command, ``gitlab`` for a ``glab`` command, ``""`` when unknown). A
+    bare ``owner/repo`` slug carries no host segment, so the visibility probe
+    cannot tell GitHub from GitLab from the slug alone and defaulted every
+    flagless target to the GitHub probe -- an internal/private GitLab MR was
+    then probed via ``gh``, never confirmed private, and the gate over-fired.
+    The tool word is known at resolution time, so ``forge`` carries it to
+    :func:`is_public_destination`, which forwards it to the probe (see
+    :func:`_repo_visibility.slug_is_private`). A host-qualified slug already
+    pins the forge from its host segment, so the hint only matters for the
+    bare-slug case.
     """
 
     slug: str
     via: str
+    forge: str = ""
 
 
 # ``gh api [/]repos/<owner>/<repo>/...`` -- the slug is the path segment after
@@ -154,6 +168,21 @@ _API_BOOLEAN_FLAGS: Final[frozenset[str]] = frozenset(
 _SKIP_INERT_LEADERS: Final[frozenset[str]] = frozenset({"cd", "pushd", "popd", "echo", "printf", "true", ":", "git"})
 
 
+def _forge_for_tool(tool: str) -> str:
+    """Map a publish tool word to its forge: ``gh`` -> github, ``glab`` -> gitlab.
+
+    The forge is what lets the visibility probe pick ``gh`` vs ``glab`` for a
+    BARE ``owner/repo`` slug that carries no host segment of its own. An
+    unrecognised leader yields ``""`` (no hint; the probe falls back to the
+    slug's own host or the GitHub default).
+    """
+    if tool == "gh":
+        return "github"
+    if tool == "glab":
+        return "gitlab"
+    return ""
+
+
 def _api_url_arg(words: list[str]) -> str | None:
     """Return the first non-flag positional after ``gh``/``glab`` ``api``, or ``None``.
 
@@ -192,24 +221,25 @@ def _destination_from_api(words: list[str], tool: str) -> Destination | None:
     url = _api_url_arg(words)
     if url is None:
         return None
+    forge = _forge_for_tool(tool)
     if tool == "gh":
         match = _GH_API_REPOS_RE.match(url)
-        return Destination(slug=match.group(1), via="api") if match else None
+        return Destination(slug=match.group(1), via="api", forge=forge) if match else None
     match = _GLAB_API_PROJECTS_RE.match(url)
     if match:
-        return Destination(slug=match.group(1).replace("%2F", "/").replace("%2f", "/"), via="api")
+        return Destination(slug=match.group(1).replace("%2F", "/").replace("%2f", "/"), via="api", forge=forge)
     return None
 
 
-def _destination_from_current_repo(cwd: Path | None) -> Destination | None:
+def _destination_from_current_repo(cwd: Path | None, forge: str) -> Destination | None:
     """Resolve a flagless create/comment command's target from the git remote."""
     if cwd is None:
         return None
     slug = slug_for_cwd(cwd)
-    return Destination(slug=slug, via="cwd") if slug else None
+    return Destination(slug=slug, via="cwd", forge=forge) if slug else None
 
 
-def _destination_from_forge_url(words: list[str]) -> Destination | None:
+def _destination_from_forge_url(words: list[str], forge: str) -> Destination | None:
     """Resolve the target from the FIRST forge URL positional in ``words``, or ``None``.
 
     ``gh issue comment https://github.com/owner/repo/issues/5`` names its target
@@ -220,7 +250,7 @@ def _destination_from_forge_url(words: list[str]) -> Destination | None:
     for word in words:
         match = _FORGE_URL_SLUG_RE.search(word)
         if match:
-            return Destination(slug=match.group("slug").removesuffix(".git"), via="url")
+            return Destination(slug=match.group("slug").removesuffix(".git"), via="url", forge=forge)
     return None
 
 
@@ -231,15 +261,16 @@ def _flagless_destination(words: list[str], tool: str, cwd: Path | None) -> Dest
     default, then a forge URL positional in the args, then the current repo for a
     create/comment/note verb. ``None`` when none of these resolves a target.
     """
+    forge = _forge_for_tool(tool)
     if "api" in words:
         return _destination_from_api(words, tool)
     if tool == "gh" and os.environ.get("GH_REPO", "").strip():
-        return Destination(slug=os.environ["GH_REPO"].strip(), via="env")
-    url_dest = _destination_from_forge_url(words)
+        return Destination(slug=os.environ["GH_REPO"].strip(), via="env", forge=forge)
+    url_dest = _destination_from_forge_url(words, forge)
     if url_dest is not None:
         return url_dest
     if len(words) >= 3 and (words[1], words[2]) in _CURRENT_REPO_VERBS:  # noqa: PLR2004
-        return _destination_from_current_repo(cwd)
+        return _destination_from_current_repo(cwd, forge)
     return None
 
 
@@ -255,7 +286,7 @@ def _destination_from_words(words: list[str], cwd: Path | None) -> Destination |
         return None
     explicit = _extract_repo_flag(words)
     if explicit:
-        return Destination(slug=explicit, via="flag")
+        return Destination(slug=explicit, via="flag", forge=_forge_for_tool(words[0]))
     return _flagless_destination(words, words[0], cwd)
 
 
@@ -387,8 +418,11 @@ def is_public_destination(dest: Destination | None, *, config_path: Path | None 
         ``--repo``/``-R`` flag, the ``api`` URL path, or the cwd remote) rather
         than the harness cwd is what lets a post FROM a public clone TO a
         provably-private repo skip the public-leak scan instead of over-blocking.
-        The probe returns ``None`` (unknown -- tool absent in-hook or auth
-        differs) for an unresolvable target, which stays PUBLIC.
+        The publish tool's forge (``dest.forge`` -- ``github`` for ``gh``,
+        ``gitlab`` for ``glab``) is forwarded to the probe so a BARE GitLab slug
+        is probed via ``glab`` rather than mis-routed to the GitHub default; the
+        probe returns ``None`` (unknown -- tool absent in-hook or auth differs)
+        for an unresolvable target, which stays PUBLIC.
 
     Every OTHER target stays PUBLIC and is SCANNED: a genuinely-public
     non-teatree repo (a user's other public repos), a third-party repo, an
@@ -409,7 +443,11 @@ def is_public_destination(dest: Destination | None, *, config_path: Path | None 
         return False
     if slug_is_allowlisted_private(slug, config_path):
         return False
-    return not slug_is_private(slug)
+    # Qualify a BARE slug UP to its forge's canonical host so the host-keyed
+    # probe routes to the right tool: a ``glab`` post probes via ``glab``, not
+    # the GitHub default. A host-qualified slug is unchanged.
+    probe_slug = forge_qualified_slug(slug, dest.forge)
+    return not slug_is_private(probe_slug)
 
 
 def _api_write_targets_internal_repo(words: list[str], *, config_path: Path | None = None) -> bool:

--- a/tests/teatree_hooks/test_publish_destination.py
+++ b/tests/teatree_hooks/test_publish_destination.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import pytest
 
-from teatree.hooks import publish_destination
+from teatree.hooks import _repo_visibility, publish_destination
 
 
 def _git(cwd: Path, *args: str) -> None:
@@ -439,4 +439,81 @@ class TestInternalDenylistScoping:
         # at all keeps scanning -- an unparsable target is never a silent bypass.
         cfg = _config(tmp_path, ["internal-eng"])
         cmd = "curl -d x https://example.com"
+        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False
+
+
+class TestForgeAwareVisibility:
+    """The probe must use the PUBLISH TOOL's forge, not guess from the bare slug.
+
+    A ``glab`` post always targets GitLab and a ``gh`` post always targets
+    GitHub. Resolving a bare ``owner/repo`` slug's forge from its host segment
+    (which a bare slug lacks) defaulted every flagless GitLab target to the
+    GitHub probe, so an internal/private GitLab MR (``glab mr create -R
+    ns/repo``) was probed via ``gh``, never confirmed private, and the gate
+    over-fired. Threading the tool's forge to the probe is the fix: the gate
+    must SKIP a private GitLab/GitHub target resolved purely by the live probe
+    (no allowlist entry), while a genuinely-public GitHub repo still scans.
+    """
+
+    def test_destination_records_glab_forge(self) -> None:
+        dest = publish_destination.resolve_publish_destination("glab mr create -R internalcorp/svc --title x")
+        assert dest is not None
+        assert dest.forge == "gitlab"
+
+    def test_destination_records_gh_forge(self) -> None:
+        dest = publish_destination.resolve_publish_destination("gh pr create -R someowner/repo --title x")
+        assert dest is not None
+        assert dest.forge == "github"
+
+    def test_private_gitlab_target_uses_glab_probe_and_skips(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # MUST-NOT-FIRE: a bare GitLab slug from ``glab mr create`` must be
+        # probed via ``glab`` (the tool's forge) and skipped when private, even
+        # with NO allowlist entry. The bug probed it via ``gh`` -> None -> PUBLIC.
+        cfg = _config(tmp_path, [])
+        calls: list[tuple[str, str]] = []
+
+        def fake_glab(repo_path: str) -> str:
+            calls.append(("glab", repo_path))
+            return "PRIVATE"
+
+        def fake_gh(repo_path: str) -> None:
+            calls.append(("gh", repo_path))
+
+        monkeypatch.setattr(_repo_visibility, "_probe_glab", fake_glab)
+        monkeypatch.setattr(_repo_visibility, "_probe_gh", fake_gh)
+        monkeypatch.setattr(_repo_visibility, "_read_visibility_cache", lambda *_a, **_k: None)
+        monkeypatch.setattr(_repo_visibility, "_write_visibility_cache", lambda *_a, **_k: None)
+
+        cmd = "glab mr create -R internalcorp/private-svc --title x --description y"
+        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is True
+        assert ("glab", "internalcorp/private-svc") in calls
+        assert ("gh", "internalcorp/private-svc") not in calls
+
+    def test_private_github_target_uses_gh_probe_and_skips(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # MUST-NOT-FIRE: a private GitHub repo, resolved purely by the ``gh``
+        # probe with no allowlist entry, must skip the public-leak scan.
+        cfg = _config(tmp_path, [])
+        monkeypatch.setattr(_repo_visibility, "_probe_gh", lambda repo_path: "PRIVATE")
+        monkeypatch.setattr(_repo_visibility, "_probe_glab", lambda repo_path: None)
+        monkeypatch.setattr(_repo_visibility, "_read_visibility_cache", lambda *_a, **_k: None)
+        monkeypatch.setattr(_repo_visibility, "_write_visibility_cache", lambda *_a, **_k: None)
+
+        cmd = "gh pr create -R someowner/private-repo --title x --body y"
+        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is True
+
+    def test_public_github_target_still_scans(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # MUST-FIRE: a genuinely-public GitHub repo (souliane/teatree itself) the
+        # ``gh`` probe confirms PUBLIC stays SCANNED -- the forge fix must not
+        # relax the public-surface default.
+        cfg = _config(tmp_path, [])
+        monkeypatch.setattr(_repo_visibility, "_probe_gh", lambda repo_path: "PUBLIC")
+        monkeypatch.setattr(_repo_visibility, "_probe_glab", lambda repo_path: None)
+        monkeypatch.setattr(_repo_visibility, "_read_visibility_cache", lambda *_a, **_k: None)
+        monkeypatch.setattr(_repo_visibility, "_write_visibility_cache", lambda *_a, **_k: None)
+
+        cmd = "gh pr create -R souliane/teatree --title x --body y"
         assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False


### PR DESCRIPTION
fix(hooks): route the publish gate visibility probe to the right forge for bare repo slugs

## What

Probe a publish target visibility with the correct forge for a bare owner/repo slug, so the destination-aware publish gate stops over-firing on a post to an internal/private remote.

## Why

The gate scans only PUBLIC targets and skips a provably-internal/private one via a host-keyed probe. A bare owner/repo slug (the -R/--repo flag, a forge URL positional, or a flagless create) carries no host segment, so every bare GitLab target defaulted to the GitHub probe, which can never confirm a GitLab repo private. A glab post to an internal/private GitLab remote was then classified PUBLIC and the gate blocked a legitimate post carrying the remote own domain terms by design. A bare private GitHub slug had the same fragility when the in-hook probe was the only signal.

## How

The publish tool names the forge (gh to github, glab to gitlab). Record it on Destination at resolution time and qualify a bare slug UP to its forge canonical host (forge_qualified_slug) before the probe, so a glab post probes via glab and a gh post via gh. A host-qualified slug is unchanged, and the allowlist match is host-qualification-symmetric, so qualifying never changes an allowlist verdict. A genuinely-public repo the probe confirms PUBLIC still scans: the fail-closed public-surface default is preserved.

## Tests

New TestForgeAwareVisibility in tests/teatree_hooks/test_publish_destination.py, all observed RED before the fix: must-NOT-fire on a private GitLab target resolved purely by the glab probe (no allowlist entry, gh probe never called); must-NOT-fire on a private GitHub target via the gh probe; must-FIRE on a genuinely-public GitHub repo. Full tests/teatree_hooks/ (1445), tests/teatree_quality/ (64), module-health (--from-ref origin/main), tach, ruff, ty all green.

## Open questions and assumptions

Assumes gh posts always target GitHub and glab posts always target GitLab: the tool word is the authoritative forge for the bare-slug case.
