### PR TITLE
feat(config): add missing_issue_ref_policy setting and resolver

### DIFF
--- a/docs/blueprint/configuration.md
+++ b/docs/blueprint/configuration.md
@@ -21,6 +21,7 @@ notify_on_post_on_behalf = true            # DM the user after every on-behalf p
 user_identity_aliases = []                 # cross-platform handles for the same human (#975/#976); consumed by TicketDispositionScanner + multi-identity scanning
 statusline_chain = []                      # extra statusline scripts (glob patterns) chained after the loop's zones
 repo_mode = ""                             # solo/collaborative working mode (#550 item 4); "" = auto-detect from git shortlog history
+missing_issue_ref_policy = "find_existing_then_ask"  # when a commit/MR needs an issue ref and none is in hand: find_existing_then_ask (default — recover the original issue first, then ASK on colleague-facing repos / CREATE on the user's own repos, never a dummy) | create (opt-in: auto-create even on colleague repos) | dummy (opt-in: placeholder ref even on colleague repos)
 claude_chrome = true                       # spawn `claude` with --chrome so sessions can drive the browser
 agent_signature = false                    # never append agent identity (Co-Authored-By, "Sent using …") to user-on-behalf posts
 max_concurrent_local_stacks = 0            # #1397: cap on concurrent locally-running stacks per overlay (0 = unbounded, default)
@@ -108,7 +109,7 @@ The env var `T3_MODE` overrides the toml setting. Unknown values raise
 A subset of `[teatree]` keys can be overridden per-overlay in
 `[overlays.<name>]`. The resolution chain (first match wins):
 
-1. `T3_*` env var (wired one-offs in `ENV_SETTING_OVERRIDES`: `T3_MODE`, `T3_SPEED`, `T3_ON_BEHALF_POST_MODE`, `T3_REVIEW_SKILL`).
+1. `T3_*` env var (wired one-offs in `ENV_SETTING_OVERRIDES`: `T3_MODE`, `T3_SPEED`, `T3_ON_BEHALF_POST_MODE`, `T3_MISSING_ISSUE_POLICY`, `T3_REVIEW_SKILL`).
 2. **DB override tier** — a `ConfigSetting` row whose `key` is an overridable setting ([#1775](https://github.com/souliane/teatree/issues/1775), the first slice of "move config to the database").
 3. Active overlay's override from `[overlays.<name>]`.
 4. Global `[teatree]` value.
@@ -193,6 +194,7 @@ below mirrors it; consult the dataclass for type signatures and defaults.
 | `require_human_approval_to_answer` | Training-wheel for `t3:answerer`: drafts + DMs, posts only on confirm |
 | `ask_before_post_on_behalf` | Legacy boolean pre-gate over on-behalf posts (kept for back-compat — prefer `on_behalf_post_mode`) |
 | `on_behalf_post_mode` | Tri-state pre-gate (#960) over colleague-VISIBLE posts: `draft_or_ask` / `ask` / `immediate`, scoped per overlay so a client overlay can stay `ask` while a personal one runs `immediate`. Drafts (`post-draft-note`) are colleague-invisible and exempt under every mode — they never need approval |
+| `missing_issue_ref_policy` | What to do when a commit/MR needs an issue ref and none is in hand: `find_existing_then_ask` (default) / `create` / `dummy`. Scoped per overlay so a colleague-facing client overlay stays on the never-create default while a personal one can opt into `create`. The default always recovers the original existing issue first, then ASKs on a colleague-facing repo and CREATEs on the user's own repo — never a dummy. `create` / `dummy` are opt-in and authorise auto-create / a placeholder ref on colleague repos too. Resolved by `teatree.missing_issue_policy.resolve_missing_issue_verdict`; `T3_MISSING_ISSUE_POLICY` env wins; agent prose in `skills/ship/SKILL.md` § 0a |
 | `on_behalf_auto_actions` | Allowlist of on-behalf actions that PROCEED even under `ask`/`draft_or_ask` (default `["post_e2e_evidence"]`): the user's own-ticket self-documentation, not a colleague-facing voice, so they never need per-post approval. Clear to `[]` to re-gate test plan; env `T3_ON_BEHALF_AUTO_ACTIONS` (comma-separated) wins |
 | `notify_user_via_bot` | Whether the bot→operator `notify_user(...)` channel (#963) DMs the user via the overlay's Slack bot (out of scope for the on-behalf gates — see config.py for the boundary) |
 | `notify_on_post_on_behalf` | DM the user after every on-behalf post (#949) — per-overlay because noise tolerance differs |

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -185,6 +185,7 @@ graph TD
     teatree.visual_qa --> teatree.utils
     teatree.identity --> teatree.config
     teatree.on_behalf_gate --> teatree.config
+    teatree.missing_issue_policy --> teatree.config
     teatree.notify --> teatree.core
     teatree.messaging --> teatree.core
     teatree.messaging --> teatree.notify

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -45,8 +45,30 @@ When the active overlay has `require_ticket = True`, refuse to commit or push wi
 
 - **Detection:** check `overlay.config.require_ticket`. Overlays that dogfood their own workflow enable this flag.
 - **Every commit must include** an issue reference. Default to a ticket-URL parenthetical at the end of the subject line (`type(scope): description (TICKET_URL)`) — that is the linking mechanism the active overlay's `OverlayMetadata.validate_pr(title, description)` enforces (surfaced as the `t3 tool validate-mr` CLI command and the PreToolUse hook in § "PR / MR Creation"). When the active overlay sets `mr_close_ticket = True` (the teatree overlay does), the ship path keeps `Closes/Fixes #<number>` so a merged PR auto-closes its issue **by default** — `should_close_ticket` rewrites it to `Relates to #N` only when `Ticket.extra['more_prs_coming']` is set (a declared partial, or an umbrella with remaining tracked scope). Overlays that leave `mr_close_ticket = False` (the class default) never auto-close.
-- **If no ticket context exists:** ask "Which ticket is this for?" Do not proceed without a ticket reference.
+- **If no ticket context exists:** ask "Which ticket is this for?" Do not proceed without a ticket reference. The full procedure for resolving a missing reference — and when you may create one vs. when you must ask — is the **Missing Issue Reference Policy** in § 0a below.
 - **Exception:** commits from `/t3:retro` (format `fix(<skill>): ...`) are exempt — retro findings are small tactical fixes committed directly on the current branch.
+
+### 0a. Missing Issue Reference Policy (Non-Negotiable)
+
+When a commit or MR/PR needs an issue/ticket reference and you have none in hand, **never improvise** — do not invent a dummy/placeholder reference, and do not auto-file an issue on a tracker you do not own. Follow this two-step policy. It is encoded in the `[teatree] missing_issue_ref_policy` setting (`T3_MISSING_ISSUE_POLICY` env var, per-overlay overridable) and resolved deterministically by `teatree.missing_issue_policy.resolve_missing_issue_verdict(colleague_facing=…, existing_found=…)`; this prose is the agent-facing contract the setting enforces.
+
+1. **Find the ORIGINAL existing issue first (always, every policy tier).** Before anything else, look for the issue that already covers this work — the one that introduced the bug, or the one that left the scope unimplemented. Search the repo's issues (open **and** closed) and the introducing commit's linked issue:
+
+   ```bash
+   git log -S '<the buggy line/symbol>' --oneline       # find the introducing commit
+   git show <introducing-sha> --format='%s%n%b' | grep -iE '#[0-9]+'  # its linked issue
+   gh issue list --search '<keywords>' --state all       # GitHub
+   glab issue list --search '<keywords>'                 # GitLab
+   ```
+
+   If you find it, **use that reference** — it is the canonical one. Do not open a new issue that duplicates an existing one.
+
+2. **If no existing issue is found, the fallback depends on the repo class** (the same colleague-facing-vs-own distinction the [`../rules/SKILL.md`](../rules/SKILL.md) § "Three Orthogonal Repo Axes" tracks):
+
+   - **Colleague-facing / external repos** (a shared product repo of an org — one the user does **not** own): under the default policy you must **ASK the user** for the reference (via `AskUserQuestion`). NEVER auto-create an issue and NEVER use a dummy/placeholder reference on a tracker the user does not control.
+   - **The user's own repos** (teatree itself, the user's solo overlay repos): creating an issue is allowed without asking — the user owns the tracker, so a created issue is self-bookkeeping, not noise on a colleague's surface.
+
+**Default (`find_existing_then_ask`):** find-existing-first, then ask on colleague repos / create on own repos, never a dummy. `create` and `dummy` are **opt-in only** (`[teatree] missing_issue_ref_policy = "create"` / `"dummy"`, or per-overlay) — they authorise auto-create / a placeholder reference even on a colleague-facing repo, and are OFF by default. When the resolver returns `ASK_USER`, surface the blocker and wait — do not fill the gap yourself.
 
 ### 1. Commit
 
@@ -231,6 +253,8 @@ The gate verifies the required phases (`testing`, `reviewing`, `retro`) were rec
 3. You explicitly state the bypass and the reason in the response, so the user can stop you if the assumption is wrong.
 
 If `t3 <overlay> pr create` errors, **fix the error** (create the missing session, run the reviewer, set the missing env var) — do not work around it with raw `gh`/`glab`. Treating the CLI as optional is the same anti-pattern as "Fix the CLI, Never Work Around It" in [`../workspace/SKILL.md`](../workspace/SKILL.md), applied to the shipping flow.
+
+**If the PR/MR needs an issue reference and you have none, do NOT improvise a dummy ref or auto-file on a tracker you do not own** — follow § 0a "Missing Issue Reference Policy": recover the original existing issue first, then ask on a colleague-facing repo (or create on the user's own repo) per the resolved `missing_issue_ref_policy`.
 
 #### Scope-Match Gate Before `Closes/Fixes #N` (Non-Negotiable)
 

--- a/src/teatree/config/__init__.py
+++ b/src/teatree/config/__init__.py
@@ -21,7 +21,7 @@ from teatree.config.discovery import (
     discover_active_overlay,
     discover_overlays,
 )
-from teatree.config.enums import Autonomy, Mode, OnBehalfPostMode, Speed, TeamsDisplay
+from teatree.config.enums import Autonomy, MissingIssuePolicy, Mode, OnBehalfPostMode, Speed, TeamsDisplay
 from teatree.config.loader import (
     CONFIG_PATH,
     _load_toml,
@@ -70,6 +70,7 @@ __all__ = [
     "OVERLAY_OVERRIDABLE_SETTINGS",
     "Autonomy",
     "E2ERepo",
+    "MissingIssuePolicy",
     "Mode",
     "MrReminderConfig",
     "OnBehalfPostMode",

--- a/src/teatree/config/enums.py
+++ b/src/teatree/config/enums.py
@@ -248,3 +248,72 @@ class OnBehalfPostMode(StrEnum):
             valid = ", ".join(m.value for m in cls)
             msg = f"Invalid on_behalf_post_mode {value!r}; valid values: {valid}"
             raise ValueError(msg) from exc
+
+
+class MissingIssuePolicy(StrEnum):
+    """What to do when a commit/MR needs an issue reference and none is in hand.
+
+    The recurring failure this setting encodes: the agent is about to make a
+    commit or open an MR/PR that links to an issue/ticket, but it has no
+    reference. The correct behaviour is NOT to improvise — it is to first
+    recover the ORIGINAL existing issue (the one that introduced the bug or
+    left the scope unimplemented, found by searching the repo's issues and the
+    introducing commit's linked issue) and use THAT. Only when no existing
+    issue is found does the policy decide the fallback, and the fallback differs
+    by repo class:
+
+    *   On a **colleague-facing / external** repo (a shared product repo of an
+        org, not one the user owns), the agent must NEVER auto-create an issue
+        and never use a placeholder/dummy reference — it must ASK the user. A
+        fabricated issue or a dummy ref on a colleague-facing repo pollutes a
+        shared tracker the user does not control.
+    *   On the **user's own** repo (teatree itself, the user's solo overlay
+        repos), creating an issue is allowed without asking — the user owns the
+        tracker, so a created issue is self-bookkeeping, not noise on a
+        colleague's surface.
+
+    Tiers (default :attr:`FIND_EXISTING_THEN_ASK`, the conservative choice):
+
+    *   :attr:`FIND_EXISTING_THEN_ASK` (default) — search for the original
+        existing issue first; if none is found, ASK on a colleague-facing repo
+        and CREATE on the user's own repo. Never a dummy ref. This is the
+        never-improvise default.
+    *   :attr:`CREATE` — opt-in. After the existing-issue search comes up empty,
+        the agent is authorised to auto-create an issue even on a
+        colleague-facing repo. The user has accepted the agent filing issues on
+        the shared tracker.
+    *   :attr:`DUMMY` — opt-in. After the existing-issue search comes up empty,
+        the agent is authorised to use a placeholder/dummy reference even on a
+        colleague-facing repo. The most permissive tier — the user accepts a
+        non-real ref rather than a stop-and-ask.
+
+    ``create`` and ``dummy`` are opt-in only; the default is OFF for
+    colleague-facing repos (it never auto-creates and never uses a dummy there).
+    Read from ``[teatree] missing_issue_ref_policy``; per-overlay overridable
+    via ``[overlays.<name>].missing_issue_ref_policy``; the
+    ``T3_MISSING_ISSUE_POLICY`` env var wins over both. Resolved by
+    :func:`teatree.missing_issue_policy.resolve_missing_issue_verdict`, and the
+    agent-facing prose lives in ``skills/ship/SKILL.md`` § "Missing Issue
+    Reference Policy".
+    """
+
+    FIND_EXISTING_THEN_ASK = "find_existing_then_ask"
+    CREATE = "create"
+    DUMMY = "dummy"
+
+    @classmethod
+    def parse(cls, value: str) -> "MissingIssuePolicy":
+        """Parse a missing-issue-policy string; invalid values raise ``ValueError``.
+
+        Mirrors :meth:`Mode.parse`: the conservative default
+        (:attr:`FIND_EXISTING_THEN_ASK`) is applied by the caller when the
+        setting is absent, so a typo never silently opts the agent into
+        auto-creating or dummy-referencing on a colleague-facing repo.
+        """
+        normalised = value.strip().lower()
+        try:
+            return cls(normalised)
+        except ValueError as exc:
+            valid = ", ".join(m.value for m in cls)
+            msg = f"Invalid missing_issue_ref_policy {value!r}; valid values: {valid}"
+            raise ValueError(msg) from exc

--- a/src/teatree/config/loader.py
+++ b/src/teatree/config/loader.py
@@ -22,7 +22,7 @@ import tomllib
 from pathlib import Path
 
 import teatree.config as _facade
-from teatree.config.enums import Autonomy, Mode, Speed, TeamsDisplay
+from teatree.config.enums import Autonomy, MissingIssuePolicy, Mode, Speed, TeamsDisplay
 from teatree.config.resolution import (
     _resolve_enum_setting,
     _resolve_on_behalf_post_mode,
@@ -230,6 +230,12 @@ def load_config(path: Path | None = None) -> TeaTreeConfig:
         statusline_chain=[str(s) for s in teatree.get("statusline_chain", [])],
         user_identity_aliases=_file_str_list(teatree.get("user_identity_aliases", [])),
         repo_mode=str(teatree.get("repo_mode", "")),
+        missing_issue_ref_policy=_resolve_enum_setting(
+            teatree,
+            "missing_issue_ref_policy",
+            MissingIssuePolicy,
+            MissingIssuePolicy.FIND_EXISTING_THEN_ASK,
+        ),
         architectural_review_disabled=bool(teatree.get("architectural_review_disabled", False)),
         architectural_review_skill=str(teatree.get("architectural_review_skill", "ac-reviewing-codebase")),
         architectural_review_cadence_hours=int(teatree.get("architectural_review_cadence_hours", 168)),

--- a/src/teatree/config/settings.py
+++ b/src/teatree/config/settings.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from teatree.config.enums import Autonomy, Mode, OnBehalfPostMode, Speed, TeamsDisplay
+from teatree.config.enums import Autonomy, MissingIssuePolicy, Mode, OnBehalfPostMode, Speed, TeamsDisplay
 from teatree.config_mr_reminder import MrReminderConfig
 from teatree.paths import DATA_DIR
 from teatree.types import DEFAULT_MR_TITLE_REGEX, SlackVoiceClassifierMode, SpeakConfig
@@ -301,6 +301,7 @@ OVERLAY_OVERRIDABLE_SETTINGS: dict[str, Callable[[Any], Any]] = {
     "require_human_approval_to_answer": _parse_strict_bool,
     "ask_before_post_on_behalf": _parse_strict_bool,
     "on_behalf_post_mode": OnBehalfPostMode.parse,
+    "missing_issue_ref_policy": MissingIssuePolicy.parse,
     "on_behalf_auto_actions": _parse_str_list,
     "notify_user_via_bot": _parse_strict_bool,
     "notify_on_post_on_behalf": _parse_strict_bool,
@@ -376,6 +377,7 @@ ENV_SETTING_OVERRIDES: dict[str, tuple[str, Callable[[str], Any]]] = {
     "T3_MODE": ("mode", Mode.parse),
     "T3_SPEED": ("speed", Speed.parse),
     "T3_ON_BEHALF_POST_MODE": ("on_behalf_post_mode", OnBehalfPostMode.parse),
+    "T3_MISSING_ISSUE_POLICY": ("missing_issue_ref_policy", MissingIssuePolicy.parse),
     "T3_ON_BEHALF_AUTO_ACTIONS": ("on_behalf_auto_actions", _parse_env_str_list),
     "T3_REVIEW_SKILL": ("review_skill", str),
     "T3_ISSUE_IMPLEMENTER_ENABLED": ("issue_implementer_enabled", _parse_env_bool),
@@ -629,6 +631,17 @@ class UserSettings:
     # ask-first-vs-fix-proactively decision lives in one place, not in
     # every skill.
     repo_mode: str = ""
+    # What to do when a commit/MR needs an issue reference and the agent has
+    # none. Default ``FIND_EXISTING_THEN_ASK``: always recover the ORIGINAL
+    # existing issue first; if none is found, ASK the user on a colleague-
+    # facing/external repo and CREATE on the user's own repo — never a dummy
+    # ref. ``CREATE`` / ``DUMMY`` are opt-in tiers that authorise auto-create /
+    # placeholder-ref on a colleague-facing repo too. Per-overlay overridable
+    # via ``[overlays.<name>].missing_issue_ref_policy``; ``T3_MISSING_ISSUE_POLICY``
+    # env wins over both. Resolved by
+    # ``teatree.missing_issue_policy.resolve_missing_issue_verdict``; the agent
+    # prose lives in ``skills/ship/SKILL.md`` § "Missing Issue Reference Policy".
+    missing_issue_ref_policy: MissingIssuePolicy = MissingIssuePolicy.FIND_EXISTING_THEN_ASK
     # #1136 / #1152 Periodic architectural-review scanner — CORE
     # always-on (not per-overlay opt-in). The cadence applies uniformly
     # to every overlay's worktrees because it is a teatree-platform

--- a/src/teatree/missing_issue_policy.py
+++ b/src/teatree/missing_issue_policy.py
@@ -1,0 +1,110 @@
+"""Missing-issue-reference policy — verdict resolver.
+
+Single source of truth for the policy that decides what teatree does when a
+commit or MR/PR needs an issue reference and the agent has none in hand. The
+recurring failure this resolver replaces is the agent *improvising* — inventing
+a dummy ref, or auto-filing an issue on a colleague's tracker — when it should
+instead recover the ORIGINAL existing issue and, failing that, defer the
+fallback to a repo-class-aware policy.
+
+The policy has two ordered steps:
+
+1.  **Find existing first (always).** Before anything else the agent looks for
+    the ORIGINAL existing issue that introduced the bug or left the scope
+    unimplemented — searching the repo's open/closed issues and the
+    introducing commit's linked issue — and uses THAT. This step is
+    unconditional: every tier of the setting tries it first. When an existing
+    issue is found the verdict is :attr:`MissingIssueVerdict.USE_EXISTING`,
+    independent of the policy tier and the repo class.
+
+2.  **Fallback when none is found**, decided by the
+    :class:`~teatree.config.MissingIssuePolicy` setting and the repo class
+    (colleague-facing/external vs the user's own):
+
+    *   :attr:`~teatree.config.MissingIssuePolicy.FIND_EXISTING_THEN_ASK`
+        (default) — on a colleague-facing repo the agent must NEVER auto-create
+        and never use a dummy ref; it :attr:`~MissingIssueVerdict.ASK_USER`. On
+        the user's own repo, creating is allowed
+        (:attr:`~MissingIssueVerdict.CREATE`).
+    *   :attr:`~teatree.config.MissingIssuePolicy.CREATE` (opt-in) — auto-create
+        is authorised even on a colleague-facing repo
+        (:attr:`~MissingIssueVerdict.CREATE`).
+    *   :attr:`~teatree.config.MissingIssuePolicy.DUMMY` (opt-in) — a
+        placeholder/dummy ref is authorised even on a colleague-facing repo
+        (:attr:`~MissingIssueVerdict.DUMMY`).
+
+The colleague-vs-own distinction is the SCOPE/collaboration axis the rest of
+teatree already tracks (``owned_repos`` / ``author_is_self``); this resolver
+takes it as the ``colleague_facing`` argument the caller supplies rather than
+re-deriving it, keeping this module a thin layer depending only on
+:mod:`teatree.config` so it can be imported from anywhere (``teatree.cli``,
+``teatree.core``) without a circular dependency — exactly the shape of
+:mod:`teatree.on_behalf_gate`.
+
+The setting is ``[teatree] missing_issue_ref_policy`` (default
+:attr:`~teatree.config.MissingIssuePolicy.FIND_EXISTING_THEN_ASK`, per-overlay
+overridable, env override via ``T3_MISSING_ISSUE_POLICY``). Resolution follows
+the standard env → active-overlay → global → default chain via
+:func:`teatree.config.get_effective_settings`. The agent-facing prose lives in
+``skills/ship/SKILL.md`` § "Missing Issue Reference Policy".
+"""
+
+from enum import StrEnum
+
+from teatree.config import MissingIssuePolicy, get_effective_settings
+
+
+class MissingIssueVerdict(StrEnum):
+    """The outcomes :func:`resolve_missing_issue_verdict` returns."""
+
+    #: The ORIGINAL existing issue was found — use it (every tier, every repo).
+    USE_EXISTING = "use_existing"
+    #: No existing issue; stop and ASK the user (the conservative colleague-repo
+    #: outcome under the default policy). Never create, never dummy.
+    ASK_USER = "ask_user"
+    #: No existing issue; auto-create an issue (own repo under the default
+    #: policy, or any repo when the operator opted into ``create``).
+    CREATE = "create"
+    #: No existing issue; use a placeholder/dummy ref (only when the operator
+    #: opted into ``dummy``).
+    DUMMY = "dummy"
+
+
+def resolve_missing_issue_verdict(*, colleague_facing: bool, existing_found: bool) -> MissingIssueVerdict:
+    """Return the verdict for a missing issue ref under the effective policy.
+
+    ``existing_found`` is whether the always-first search for the ORIGINAL
+    existing issue succeeded; when it did, the verdict is
+    :attr:`MissingIssueVerdict.USE_EXISTING` regardless of the policy tier or
+    the repo class. ``colleague_facing`` is whether the target repo is a
+    colleague-facing / external repo (a shared product repo the user does not
+    own) vs the user's own repo (teatree, the user's solo overlay repos).
+
+    When no existing issue is found, the fallback is decided by the resolved
+    :class:`~teatree.config.MissingIssuePolicy`:
+
+    *   :attr:`~teatree.config.MissingIssuePolicy.FIND_EXISTING_THEN_ASK`
+        (default) → :attr:`MissingIssueVerdict.ASK_USER` on a colleague-facing
+        repo (never auto-create, never dummy), :attr:`MissingIssueVerdict.CREATE`
+        on the user's own repo.
+    *   :attr:`~teatree.config.MissingIssuePolicy.CREATE` (opt-in) →
+        :attr:`MissingIssueVerdict.CREATE` on any repo.
+    *   :attr:`~teatree.config.MissingIssuePolicy.DUMMY` (opt-in) →
+        :attr:`MissingIssueVerdict.DUMMY` on any repo.
+
+    Resolution follows the standard env (``T3_MISSING_ISSUE_POLICY``) →
+    active-overlay → global → default chain via
+    :func:`teatree.config.get_effective_settings`.
+    """
+    if existing_found:
+        return MissingIssueVerdict.USE_EXISTING
+
+    policy = get_effective_settings().missing_issue_ref_policy
+    if policy is MissingIssuePolicy.DUMMY:
+        return MissingIssueVerdict.DUMMY
+    if policy is MissingIssuePolicy.CREATE:
+        return MissingIssueVerdict.CREATE
+    # FIND_EXISTING_THEN_ASK (default): never auto-create or dummy on a
+    # colleague-facing repo — ASK the user. Creating is allowed on the user's
+    # own repo (the user owns the tracker, so it is self-bookkeeping).
+    return MissingIssueVerdict.ASK_USER if colleague_facing else MissingIssueVerdict.CREATE

--- a/tach.toml
+++ b/tach.toml
@@ -427,6 +427,11 @@ layer = "platform"
 depends_on = ["teatree.config"]
 
 [[modules]]
+path = "teatree.missing_issue_policy"
+layer = "platform"
+depends_on = ["teatree.config"]
+
+[[modules]]
 path = "teatree.notify"
 layer = "integration"
 depends_on = ["teatree.core"]

--- a/tests/test_missing_issue_policy.py
+++ b/tests/test_missing_issue_policy.py
@@ -1,0 +1,133 @@
+"""Tests for the missing-issue-reference policy resolver.
+
+Integration-first per the Test-Writing Doctrine: real TOML fixtures under
+``tmp_path`` with ``teatree.config.CONFIG_PATH`` monkeypatched to them.
+No mocks — ``load_config`` / ``get_effective_settings`` exercised end-to-end.
+
+The policy decides what teatree does when a commit/MR needs an issue
+reference and the agent has none in hand: it always tries to recover the
+ORIGINAL existing issue first, and on a colleague-facing repo it never
+auto-creates or uses a dummy ref (it asks the user) unless the operator
+opted into ``create`` / ``dummy``.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from teatree.config import ENV_SETTING_OVERRIDES, OVERLAY_OVERRIDABLE_SETTINGS, MissingIssuePolicy, load_config
+from teatree.missing_issue_policy import MissingIssueVerdict, resolve_missing_issue_verdict
+
+
+@pytest.fixture
+def config_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    cfg = tmp_path / ".teatree.toml"
+    monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
+    return cfg
+
+
+def _write(cfg: Path, body: str) -> None:
+    cfg.write_text(body, encoding="utf-8")
+
+
+class TestDefaultPolicy:
+    """The default is find-existing-then-ask — never auto-create, never dummy."""
+
+    def test_default_when_no_config_is_find_existing_then_ask(self, config_file: Path) -> None:
+        assert load_config().user.missing_issue_ref_policy is MissingIssuePolicy.FIND_EXISTING_THEN_ASK
+
+    def test_default_when_section_present_but_unset(self, config_file: Path) -> None:
+        _write(config_file, "[teatree]\n")
+        assert load_config().user.missing_issue_ref_policy is MissingIssuePolicy.FIND_EXISTING_THEN_ASK
+
+    def test_default_on_colleague_repo_asks_after_search(self, config_file: Path) -> None:
+        # Colleague-facing repo, no existing issue found → must ASK, never create/dummy.
+        assert (
+            resolve_missing_issue_verdict(colleague_facing=True, existing_found=False) is MissingIssueVerdict.ASK_USER
+        )
+
+    def test_default_on_colleague_repo_uses_found_existing(self, config_file: Path) -> None:
+        # The original existing issue was found → always use it, on any repo.
+        assert (
+            resolve_missing_issue_verdict(colleague_facing=True, existing_found=True)
+            is MissingIssueVerdict.USE_EXISTING
+        )
+
+    def test_default_on_own_repo_allows_create_after_search(self, config_file: Path) -> None:
+        # On the user's OWN repo, creating is allowed even under the default policy.
+        assert resolve_missing_issue_verdict(colleague_facing=False, existing_found=False) is MissingIssueVerdict.CREATE
+
+    def test_default_on_own_repo_uses_found_existing(self, config_file: Path) -> None:
+        assert (
+            resolve_missing_issue_verdict(colleague_facing=False, existing_found=True)
+            is MissingIssueVerdict.USE_EXISTING
+        )
+
+
+class TestExplicitCreatePolicy:
+    """``create`` is opt-in: it authorises auto-create on colleague repos too."""
+
+    def test_create_on_colleague_repo_creates(self, config_file: Path) -> None:
+        _write(config_file, '[teatree]\nmissing_issue_ref_policy = "create"\n')
+        assert resolve_missing_issue_verdict(colleague_facing=True, existing_found=False) is MissingIssueVerdict.CREATE
+
+    def test_create_still_prefers_found_existing(self, config_file: Path) -> None:
+        _write(config_file, '[teatree]\nmissing_issue_ref_policy = "create"\n')
+        assert (
+            resolve_missing_issue_verdict(colleague_facing=True, existing_found=True)
+            is MissingIssueVerdict.USE_EXISTING
+        )
+
+
+class TestExplicitDummyPolicy:
+    """``dummy`` is opt-in: it authorises a placeholder ref on colleague repos too."""
+
+    def test_dummy_on_colleague_repo_uses_dummy(self, config_file: Path) -> None:
+        _write(config_file, '[teatree]\nmissing_issue_ref_policy = "dummy"\n')
+        assert resolve_missing_issue_verdict(colleague_facing=True, existing_found=False) is MissingIssueVerdict.DUMMY
+
+    def test_dummy_still_prefers_found_existing(self, config_file: Path) -> None:
+        _write(config_file, '[teatree]\nmissing_issue_ref_policy = "dummy"\n')
+        assert (
+            resolve_missing_issue_verdict(colleague_facing=True, existing_found=True)
+            is MissingIssueVerdict.USE_EXISTING
+        )
+
+
+class TestPerOverlayOverride:
+    def test_per_overlay_override_wins_over_global(self, config_file: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A trusted overlay can opt into ``create`` without flipping the global."""
+        _write(
+            config_file,
+            "[teatree]\n"
+            'missing_issue_ref_policy = "find_existing_then_ask"\n'
+            "[overlays.trusted]\n"
+            'overlay_class = "x.Y"\n'
+            'missing_issue_ref_policy = "create"\n',
+        )
+        monkeypatch.setenv("T3_OVERLAY_NAME", "trusted")
+        assert resolve_missing_issue_verdict(colleague_facing=True, existing_found=False) is MissingIssueVerdict.CREATE
+
+
+class TestEnvOverride:
+    def test_env_var_wins_over_global(self, config_file: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write(config_file, '[teatree]\nmissing_issue_ref_policy = "find_existing_then_ask"\n')
+        monkeypatch.setenv("T3_MISSING_ISSUE_POLICY", "dummy")
+        assert resolve_missing_issue_verdict(colleague_facing=True, existing_found=False) is MissingIssueVerdict.DUMMY
+
+
+class TestInvalidValue:
+    def test_typo_raises_loud(self, config_file: Path) -> None:
+        _write(config_file, '[teatree]\nmissing_issue_ref_policy = "auto_create"\n')
+        with pytest.raises(ValueError, match="missing_issue_ref_policy"):
+            load_config()
+
+
+class TestRegistryMembership:
+    """The setting is opted into the per-overlay and env override tiers."""
+
+    def test_in_overlay_overridable_registry(self) -> None:
+        assert "missing_issue_ref_policy" in OVERLAY_OVERRIDABLE_SETTINGS
+
+    def test_in_env_override_registry(self) -> None:
+        assert ENV_SETTING_OVERRIDES["T3_MISSING_ISSUE_POLICY"][0] == "missing_issue_ref_policy"


### PR DESCRIPTION
## What

Adds a durable teatree setting + policy for **what to do when a commit/MR needs an issue/ticket reference but the agent has none in hand**, so the agent never improvises a placeholder ref or auto-files an issue on a tracker the user does not own.

- **New setting** `[teatree] missing_issue_ref_policy` (env `T3_MISSING_ISSUE_POLICY`, per-overlay overridable), a `MissingIssuePolicy` enum with three tiers. Default `find_existing_then_ask`.
- **New resolver** `teatree.missing_issue_policy.resolve_missing_issue_verdict(colleague_facing=…, existing_found=…)` — a thin `teatree.config`-only layer mirroring `teatree.on_behalf_gate`, returning `USE_EXISTING` / `ASK_USER` / `CREATE` / `DUMMY`.
- **Agent prose** in `skills/ship/SKILL.md` § 0a "Missing Issue Reference Policy", cross-referenced from the ticket-required gate (§ 0) and the PR-create step (§ 5).

## Why

The same correction kept being made by hand: when no issue reference is available, the agent would improvise (invent a dummy ref, or auto-file on a shared tracker). Encoding the policy in a setting + resolver + skill prose makes the behaviour deterministic and configurable instead of relying on remembered vigilance.

## The policy

1. **Find the ORIGINAL existing issue first (always, every tier).** Search the repo's issues (open and closed) and the introducing commit's linked issue, and use that. → `USE_EXISTING`.
2. **If none is found, the fallback is repo-class-aware:**
   - On a **colleague-facing / external** repo (a shared product repo the user does not own): the default **ASKs the user** — never auto-create, never a dummy ref. → `ASK_USER`.
   - On the **user's own** repo (teatree itself, the user's solo overlay repos): creating is allowed. → `CREATE`.
3. `create` and `dummy` are **opt-in only** (default OFF for colleague repos): they authorise auto-create / a placeholder ref on a colleague-facing repo too.

Resolution follows the standard env → active-overlay → global → default chain via `get_effective_settings()`, identical to `on_behalf_post_mode`.

## Tests

`tests/test_missing_issue_policy.py` (15 tests, 100% coverage of the new module): default verdict on colleague vs own repos; each explicit override (`create`, `dummy`); per-overlay override wins; env override wins; the conservative default never auto-creates/dummies on a colleague repo (verified RED before the conditional was added — flipping the colleague branch to `CREATE` turns the default-colleague-ASK test red); a typo raises loud; registry membership in both the overridable and env tiers.

## Architecture pre-check

### 1. BLUEPRINT § alignment
Settings-system addition; mirrors the on-behalf pre-gate. A per-overlay overridable `UserSettings` field + a thin policy resolver, exactly like `on_behalf_post_mode` / `resolve_on_behalf_verdict`. No FSM transition. `docs/blueprint/configuration.md` updated (TOML example, per-overlay overridable table, env-override list).

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition.

### 3. Extension-point contracts
None. No `OverlayBase` hook, scanner, or Protocol surface changed. The colleague-vs-own distinction is supplied by the caller as a `colleague_facing` argument (the existing SCOPE/collaboration axis), so no `owned_repos` schema change.

### 4. Component boundaries
`config/enums.py` (new `MissingIssuePolicy`), `config/settings.py` (field + registry entries), `config/loader.py` (FILE-tier read via `_resolve_enum_setting`), new top-level `missing_issue_policy.py` (resolver). Each lands in the same module its sibling (`on_behalf_post_mode` / `on_behalf_gate`) uses.

### 5. Dependency direction
`teatree.missing_issue_policy` depends only on `teatree.config` (registered in `tach.toml` at the `platform` layer, like `teatree.on_behalf_gate`). No backwards edge; `tach check` green; `docs/dependency-graph.md` regenerated.

### 6. Test surface
`tests/test_missing_issue_policy.py` — see Tests above. Each verdict path and each override tier has a named assertion.

### 7. Resilience invariants
Pure read of effective settings; no external write. n/a.

### 8. Identity and key normalization
n/a — flat enum setting; no bare-vs-qualified identity.

### 9. Behavior preservation / capability deletion
Purely additive — no existing behavior removed. The default is the conservative never-auto-create-on-colleague-repos, never-dummy verdict.

## Open questions and assumptions

- none
