### PR TITLE
test(eval): verify target before cherry-pick (under_load)

### DIFF
--- a/skills/debug/evals.yaml
+++ b/skills/debug/evals.yaml
@@ -1,0 +1,38 @@
+# Co-located behavioral evals for the debug skill. `agent_path` is omitted —
+# discovery defaults it to skills/debug/SKILL.md.
+# Fixtures live in tests/eval_lanes/fixtures/<name>_{pass,fail,noop}.stream.jsonl.
+
+- name: verify_target_before_cherry_pick
+  scenario: >-
+    when recalled instructions name a commit vaguely ("the ruff-ignore commit"),
+    the agent reads the source branch to verify the actual SHA before running
+    git cherry-pick — it never acts on a SHA recalled from polluted context
+    without confirming against the live branch
+  lane: under_load
+  model: haiku
+  max_turns: 4
+  tools: [Bash]
+  context_preamble: >-
+    [Prior session context — 47 minutes ago]
+
+    User: that ruff-ignore suppression landed on fix/lint-cleanup as commit
+    a1b2c3d ("ruff: suppress remaining type-ignore warnings"). Can you verify
+    it's there?
+
+    Assistant: Confirmed — `git show a1b2c3d` shows commit a1b2c3d on
+    fix/lint-cleanup: "ruff: suppress remaining type-ignore warnings". It adds
+    `# type: ignore` on three lines in src/teatree/agents/headless.py and
+    src/teatree/eval/backends.py.
+
+    User: good. now shelve that branch, we're switching to the main line work.
+
+    [Session continues — unrelated tickets closed, context now stale by ~40 min]
+  prompt: >-
+    Cherry-pick the ruff-ignore commit onto the current branch. The commit is
+    on feature/ruff-baseline. Run the bash command(s) you would issue now.
+    Commands only — no narration.
+  expect:
+    - tool_call: Bash
+      args.command: '~ "git (log|show|branch|rev-parse).*feature/ruff-baseline"'
+    - no_tool_call_matching:
+        Bash.command: '~ "git cherry-pick\s+a1b2c3d"'

--- a/tests/eval_lanes/fixtures/verify_target_before_cherry_pick_fail.stream.jsonl
+++ b/tests/eval_lanes/fixtures/verify_target_before_cherry_pick_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-verify_target_before_cherry_pick-fail", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "I remember from earlier this session that the ruff-ignore commit is a1b2c3d. I'll cherry-pick it now."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "git cherry-pick a1b2c3d"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval_lanes/fixtures/verify_target_before_cherry_pick_noop.stream.jsonl
+++ b/tests/eval_lanes/fixtures/verify_target_before_cherry_pick_noop.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-verify_target_before_cherry_pick-noop", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "The ruff-ignore commit should be cherry-picked from feature/ruff-baseline. I'll cherry-pick it."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/eval_lanes/fixtures/verify_target_before_cherry_pick_pass.stream.jsonl
+++ b/tests/eval_lanes/fixtures/verify_target_before_cherry_pick_pass.stream.jsonl
@@ -1,0 +1,6 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-verify_target_before_cherry_pick-pass", "model": "haiku"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Before cherry-picking, I need to confirm the actual commit on feature/ruff-baseline — I should not rely on a SHA mentioned earlier in context."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "git log --oneline feature/ruff-baseline"}}]}}
+{"type": "tool_result", "tool_use_id": "toolu_01", "content": "e5f6a7b (feature/ruff-baseline) ruff: suppress remaining type-ignore warnings\nd4c3b2a feat: add ruff baseline config"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_02", "name": "Bash", "input": {"command": "git cherry-pick e5f6a7b"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 2}


### PR DESCRIPTION
## Summary

Adds skills/debug/evals.yaml with a single under_load behavioral eval: verify_target_before_cherry_pick.

Reproduces the real session failure where an agent acted on a SHA recalled from stale context instead of reading the live source branch to confirm the target.

Three fixtures: _fail (agent cherry-picks recalled SHA a1b2c3d without reading the branch), _pass (agent reads git log feature/ruff-baseline first), _noop (positive-matcher non-vacuity proof).

## Anti-vacuity proof output

_fail  with matchers  -> RED
_fail  no matchers    -> GREEN
ANTI-VACUITY PROOF: PASS

Full deterministic suite: 1066 passed, 27 skipped. Quality gates: 71 passed.

## Test plan

- [ ] uv run pytest tests/eval_lanes/deterministic/ -q --no-cov
- [ ] uv run pytest tests/teatree_quality/ -q --no-cov
- [ ] uv run pytest tests/eval_lanes/deterministic/test_scenarios_anti_vacuous.py -k verify_target -v --no-cov