### PR TITLE
feat(e2e): rubric-scored verify<->review loop to a confidence threshold

### DIFF
--- a/docs/blueprint/configuration.md
+++ b/docs/blueprint/configuration.md
@@ -15,6 +15,7 @@ mode = "interactive"                       # global default — confirm before p
 loop_cadence_seconds = 720                 # /loop tick interval (default 12 min)
 require_human_approval_to_merge = true     # training-wheel for `auto` overlays: push + PR create autonomous, merge stays gated
 require_human_approval_to_answer = true    # training-wheel: t3:answerer drafts + DMs for approval, posts only on confirm
+e2e_confidence_threshold = 90              # rubric score (0-100) a Playwright spec must reach to be VERIFIED by the /t3:e2e verify<->review loop; the single knob both /t3:e2e-review (rubric) and /t3:e2e (loop) read
 on_behalf_post_mode = "draft_or_ask"       # tri-state pre-gate (#960) over colleague-VISIBLE posts; drafts (post-draft-note) are exempt under every mode: draft_or_ask (default) | ask (both BLOCK every colleague-visible action, EXEMPT drafts) | immediate (gate off)
 on_behalf_auto_actions = ["post_e2e_evidence"]  # on-behalf actions that PROCEED even under ask/draft_or_ask (own-ticket self-documentation, not a colleague voice); clear to [] to re-gate test plan
 notify_on_post_on_behalf = true            # DM the user after every on-behalf post (#949)
@@ -204,6 +205,7 @@ below mirrors it; consult the dataclass for type signatures and defaults.
 | `architectural_review_cadence_hours` | Per-overlay cadence floor for the architectural-review scanner |
 | `architectural_review_after_merge_count` | Per-overlay merge-count trigger for the architectural-review scanner |
 | `review_skill` | #1539: per-ticket deep-review skill (env `T3_REVIEW_SKILL`). Empty (default) ⇒ reviewing-phase gate is a NO-OP; when set, `visit-phase … reviewing` needs a `review_skill_run` artifact. |
+| `e2e_confidence_threshold` | Rubric score (0-100, default `90`) a Playwright spec must reach to be VERIFIED by the `/t3:e2e` verify↔review loop (`/t3:e2e` § "Verify–Review Loop to Threshold"). The single knob both the `/t3:e2e-review` E2E Confidence Rubric and the loop read, so "the threshold" is one resolved value. A stricter client overlay raises it (e.g. `95`); a fast dogfood overlay lowers it. Documentation-driven today (the loop is agent prose, not a deterministic gate) — the typed field is the shared source of truth for the doc value and any future programmatic consumer. |
 | `scanning_news_disabled` | Escape hatch for the daily `t3:scanning-news` scanner (#1191) — registered as overridable, but the live scanner reads the global `[teatree]` value (the news-scan is anchored on the `teatree` overlay placeholder ticket; per-overlay overrides are accepted in the registry but not yet consumed by `_scanning_news_scanner` in `loop/global_scanner_factories.py`) |
 | `scanning_news_skill` | Override which skill the scanner dispatches (default `/t3:scanning-news`) — same registry/consumer gap as above |
 | `scanning_news_cadence_hours` | Cadence floor for the news-scanning scanner — same registry/consumer gap as above |

--- a/skills/e2e-review/SKILL.md
+++ b/skills/e2e-review/SKILL.md
@@ -88,6 +88,54 @@ Translate findings into the team's severity language, scaled to impact:
 
 Post findings through the normal review path in `/t3:review` (draft-by-default, one terse anchored note on a colleague's MR, the on-behalf/autonomy gates) — this skill does not introduce its own posting mechanics.
 
+## E2E Confidence Rubric
+
+The severity verdict above is the human-review language; the **rubric** is the machine-scoreable form of the same judgement, so the verify↔review loop in `/t3:e2e` § "Verify–Review Loop to Threshold" has a number to gate on. The reviewer scores a spec (or a spec + its run) 0–100 and returns a structured verdict. The score exists for one purpose: to decide whether the spec has earned **VERIFIED** or must loop back for another verify pass — never to dress up a brittle spec as "90% good enough".
+
+### Two hard gates (either failing caps the score to HOLD)
+
+A hard gate is not a weighted criterion — it is a precondition. If either fails, the spec **cannot** be VERIFIED no matter how high the weighted criteria score; the verdict is **HOLD** (loop back) or, when the gate is an external impossibility, **BLOCKED** (see below). Check both before scoring the weighted criteria.
+
+- **HARD GATE H1 — Non-vacuous green.** The spec actually **ran** — not `test.skip`/`test.fixme`/`test.only`-dropped, not flag-gated off, not an empty body. Every **precondition** assertion passed for the *right reason*: the role-gated/RBAC precheck (e.g. the resolved `/api/me` role and group memberships from § "Writing Tests" in `/t3:e2e`) asserted the test account's real identity before the behaviour assertion, so a green can't come from an unexpected identity. Real assertions fired (web-first `expect(...)`, not a swallowed `isVisible()` read). For a **regression** spec, the anti-vacuity proof holds: revert the production fix → the spec goes **red** (the full rule is `../review/SKILL.md`; apply it, don't restate it). A spec that goes green with the fix reverted, or whose precondition never fired, fails H1.
+- **HARD GATE H2 — Evidence integrity.** The green came from the **deployed environment** (dev/staging) **or** a teatree-managed local stack — never a stale local build, golden test PDFs (`build/test-results/`, `src/test/resources/`), `pdftotext` of a locally-rendered document, or a `localhost` screenshot. This is the `/t3:e2e` § "Evidence Source Integrity" rule in gate form: if the evidence backing the green violates that rule, H2 fails regardless of how clean the spec reads.
+
+### Weighted criteria (sum = 100)
+
+Scored only once both hard gates pass. Each is the rubric form of one of the six principles above:
+
+| Criterion | Weight | What full marks looks like |
+|---|---:|---|
+| **Behaviour over implementation** | 25 | Every assertion maps to a ticket acceptance criterion and checks a user-visible outcome (rendered text, URL, enabled/disabled control) — not a CSS class, store state, or DOM-structure detail. |
+| **AC coverage / completeness** | 20 | **Every** acceptance criterion in the ticket has at least one backing assertion. A green run exercises the whole requirement, not a convenient subset. A missing AC is the most common reason a VERIFIED score is wrong. |
+| **Locator resilience** | 15 | `getByRole`/`getByLabel`/`getByText`/`getByTestId`; no brittle CSS/XPath where a user-facing handle exists; strict single-match (no `.first()`/`.nth()` dodging a strict-mode violation). |
+| **Wait discipline** | 15 | Condition-based waits + web-first auto-retrying assertions only; **zero** fixed `waitForTimeout`/`sleep`; `expect.poll`/`toPass` for eventual conditions. |
+| **Isolation & deterministic data** | 15 | Per-test storage/data; own setup + teardown; unique (timestamp/uuid) names; parallel-safe — no cross-test ordering dependency, no race on a shared row. |
+| **Reproducibility** | 10 | Stable green across re-runs (not flaky); a green on one run reproduces on the next, in parallel, in random order. |
+
+### Threshold and verdict
+
+The reviewer returns a structured result:
+
+```
+{score: <0-100>, threshold: <configured, default 90>, verdict: VERIFIED | HOLD | BLOCKED, findings: [...]}
+```
+
+- **VERIFIED** — `score ≥ threshold` **AND both hard gates pass**. The spec has earned the clean test plan; the loop exits.
+- **HOLD** — below threshold, or a hard gate failed for a reason the maker can fix (a missing-AC assertion, a brittle locator, a fixed sleep, a vacuous precondition). The `findings` are the punch-list the next verify pass works through; the loop continues.
+- **BLOCKED** — a hard gate fails for a reason **no spec edit can fix** (see below).
+
+The threshold is configurable — `[teatree] e2e_confidence_threshold`, default **90**, per-overlay overridable (see `/t3:e2e` § "Verify–Review Loop to Threshold" → Configuration). A stricter overlay raises it; the rubric and the loop read the same knob.
+
+### BLOCKED — when 100% confidence is genuinely unreachable
+
+Some features cannot reach a high score by construction, and forcing one would loop forever:
+
+- A result observable **only via a browser dialog** (a native `alert`/`confirm`, an OS file picker, a print preview) with **no API, no DOM node, and no spec assertion** that can capture it.
+- A feature whose data exists **only on a DEV-only catalog** the local DSLR dump legitimately lacks (the `/t3:e2e` § "Documented limitation — some features are DEV-only on local" case) **and** which is not deployed where it could be asserted.
+- An **infra-gated** feature: no broker/test account exists and a local stack cannot substitute; a broken login with no available fix.
+
+For these, the terminal verdict is **`BLOCKED(<named-gate>)`** — name the specific gate (`BLOCKED(no-api-for-browser-dialog)`, `BLOCKED(dev-only-catalog-not-on-local)`, `BLOCKED(no-broker-account)`) and record the manual evidence that *was* gathered (the human-observed dialog, the DEV screenshot) as a noted limitation. A BLOCKED is **not** a forced low score that re-loops: it terminates the loop and surfaces the named gate to the user. Never convert a genuine BLOCKED into a caveated VERIFIED, and never let it spin the loop to MAX_ITERATIONS.
+
 ## Adopting an outside Playwright suite
 
 When the change isn't a single spec but an externally-authored suite being migrated into the team's tree, review it as a **conversion**, not just a pass/fail gate. The same six principles are the conformance target; the difference is the suite arrived with someone else's conventions baked in.

--- a/skills/e2e/SKILL.md
+++ b/skills/e2e/SKILL.md
@@ -302,6 +302,40 @@ Each test file can have a sibling `.md` with the same basename — a single sour
 |--------|-----|-------------|---------|
 | [PROJ-1234](url) | [#5678](url) | Initial: feature X | [Plan + images](url) |
 
+## Verify–Review Loop to Threshold
+
+A single E2E pass is not self-driving: it can go green vacuously, miss an acceptance criterion, or be brittle in a way a static read of the green line never shows. The fix is to **iterate** `/t3:e2e` and `/t3:e2e-review` until the spec earns a rubric-scored confidence threshold — with a hard stop so it can never spin forever. This is the in-skill, iterative expression of the orchestrator's lifecycle chain: `/t3:e2e` is the `test`/e2e phase, `/t3:e2e-review` is the `e2e_reviewing` phase, and `/next` is the edge between them.
+
+> `/next` = the orchestrator advancing the FSM to the next phase and spawning that phase's sub-agent. The e2e ↔ e2e-review chaining IS this `/next` edge fired repeatedly: `e2e --/next--> e2e_reviewing`, and on HOLD, `e2e_reviewing --/next--> e2e` again.
+
+### The loop as FSM edges (max 5 iterations per ticket)
+
+1. **`test` / e2e phase — `/t3:e2e`.** Run the spec — against **DEV** if the feature is deployed there, else a **local stack** restored from the DEV dump (§ "Dual-Env Testing" and § "Replicating a DEV object to local"). On failure, **bug-hunt**: browser console first (§ "Browser Console First"), then screenshot sanity (§ "Screenshot Sanity Check"), driving the page with Claude in Chrome where it helps. **Codify every confirmed finding into a committed Playwright spec** — a browser observation that isn't captured as a durable assertion is lost; the bug-hunt's output is *new committed test code*, not a note. If a real **product bug** surfaces, fix it. Opportunistically **consolidate** duplicated/outside specs into the canonical suite via the `/t3:e2e-review` § "Adopting an outside Playwright suite" conversion method. Then `/next`.
+2. **→ `e2e_reviewing` phase — `/t3:e2e-review`.** Score the spec (and its run) with the **E2E Confidence Rubric** (`/t3:e2e-review` § "E2E Confidence Rubric"): both hard gates, then the six weighted criteria, returning `{score, threshold, verdict, findings}`.
+3. **VERIFIED** — `score ≥ threshold` AND both hard gates pass. `/next` advances toward `ship`: commit the specs, open/merge the e2e PR, and **post the clean test plan** (§ "Post Testing Evidence on the Ticket"), recording the rubric score alongside the run. **If the ticket also changed product code**, the normal `review` phase (code review, maker ≠ checker) sits between `e2e_reviewing` and `ship`; for a **pure test-adding ticket**, `e2e_reviewing → ship` directly. An optional `review-request` follows. Exit the loop.
+4. **BLOCKED** — a **hard external gate** blocks (no broker account and local can't substitute; a broken login with no available fix; a result observable nowhere programmatically — the rubric's `BLOCKED(<named-gate>)`). Terminal: surface the **named gate** to the user, post **nothing caveated**, exit. Do not loop.
+5. **HOLD** — below threshold (and fixable). The FSM loops **back to the `test`/e2e phase** (`e2e_reviewing --/next--> e2e`): a fresh `/t3:e2e` that applies the top rubric `findings` — fix spec brittleness, add the missing-AC assertions, fix the bug, de-flake — then re-scores. Re-loop.
+
+### Terminal states (never loop forever)
+
+- **VERIFIED** (`score ≥ threshold`, both hard gates pass) — the clean test plan is posted, the rubric score recorded.
+- **BLOCKED(named gate)** — a genuinely-unreachable feature (manual-only/no-API, infra-gated). The named gate is surfaced to the user; no caveated note is posted.
+- **MAX_ITERATIONS** (5 verify↔review rounds without VERIFIED) — stop and report the **best score reached** and the **precise remaining gap** (the specific rubric criteria/findings still short of threshold). Do not silently keep looping.
+
+Never post a caveated note as a substitute for reaching the threshold: a note that says "verified, except…" is not a VERIFIED — it is a HOLD or a BLOCKED wearing a green coat. The whole point of the threshold is that 100% confidence is unreachable for some tickets, so the loop terminates honestly (BLOCKED or MAX_ITERATIONS) rather than pretending.
+
+### Configuration
+
+The pass bar is the **`[teatree] e2e_confidence_threshold`** setting in `~/.teatree.toml` — an integer 0–100, **default 90**, **per-overlay overridable** via `[overlays.<name>].e2e_confidence_threshold` (a stricter client overlay can raise it; a fast dogfood overlay can lower it). It is the single knob both the rubric (`/t3:e2e-review`) and this loop read, so "the threshold" means one value, resolved through the usual env → DB → per-overlay → global → default chain.
+
+```toml
+[teatree]
+e2e_confidence_threshold = 90   # rubric score a spec must reach to be VERIFIED (0-100)
+
+[overlays.client-x]
+e2e_confidence_threshold = 95   # stricter bar for a client overlay
+```
+
 ## Re-Read Before Debugging
 
 When an E2E test fails or the environment misbehaves, **re-read this skill** before spending more than 2 minutes on ad-hoc debugging. Skill guidance loaded early in a session gets compressed out of context.

--- a/src/teatree/config/loader.py
+++ b/src/teatree/config/loader.py
@@ -245,6 +245,7 @@ def load_config(path: Path | None = None) -> TeaTreeConfig:
         require_anti_vacuity_attestation=bool(teatree.get("require_anti_vacuity_attestation", False)),
         require_rubric_verification=bool(teatree.get("require_rubric_verification", False)),
         require_spec_coverage=bool(teatree.get("require_spec_coverage", False)),
+        e2e_confidence_threshold=int(teatree.get("e2e_confidence_threshold", 90)),
         scanning_news_disabled=bool(teatree.get("scanning_news_disabled", False)),
         scanning_news_skill=str(teatree.get("scanning_news_skill", "scanning-news")),
         scanning_news_cadence_hours=int(teatree.get("scanning_news_cadence_hours", 24)),

--- a/src/teatree/config/settings.py
+++ b/src/teatree/config/settings.py
@@ -316,6 +316,7 @@ OVERLAY_OVERRIDABLE_SETTINGS: dict[str, Callable[[Any], Any]] = {
     "require_anti_vacuity_attestation": _parse_strict_bool,
     "require_rubric_verification": _parse_strict_bool,
     "require_spec_coverage": _parse_strict_bool,
+    "e2e_confidence_threshold": _parse_strict_int,
     "scanning_news_disabled": _parse_strict_bool,
     "scanning_news_skill": _parse_strict_str,
     "scanning_news_cadence_hours": _parse_strict_int,
@@ -677,6 +678,16 @@ class UserSettings:
     # test — done cannot be declared on a partial subset. Default false = NO-OP.
     # Per-overlay overridable.
     require_spec_coverage: bool = False
+    # E2E confidence threshold (0-100): the rubric score a Playwright spec must
+    # reach to be VERIFIED by the verify<->review loop. The single knob both the
+    # `e2e-review` rubric (`/t3:e2e-review` § "E2E Confidence Rubric") and the
+    # `e2e` loop (`/t3:e2e` § "Verify-Review Loop to Threshold") read, so "the
+    # threshold" is one resolved value. Default 90; a stricter client overlay
+    # raises it, a fast dogfood overlay lowers it. Documentation-only knob today
+    # (the loop is agent-driven prose, not a deterministic gate) — this field is
+    # the typed home so the doc value and any future programmatic consumer share
+    # one source of truth. Per-overlay overridable.
+    e2e_confidence_threshold: int = 90
     # #1191 Periodic scanning-news scanner — CORE always-on with a daily
     # cadence (24h). Companion to the `scanning-news` skill (#1190): the
     # loop fires a `scanning_news` task daily so the news-scan workflow

--- a/tests/config/test_load_config.py
+++ b/tests/config/test_load_config.py
@@ -546,6 +546,50 @@ class TestRequireReviewContextSetting:
         assert load_config(config_path).user.require_review_context is True
 
 
+class TestE2EConfidenceThresholdSetting:
+    """The verify<->review loop's rubric pass bar loads from toml; default 90.
+
+    The single knob both the `/t3:e2e-review` rubric and the `/t3:e2e`
+    verify<->review loop read. Per-overlay overridable so a stricter client
+    overlay can raise the bar; resolved through the usual override chain.
+    """
+
+    def test_default_is_90(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".teatree.toml"
+        _write_toml(config_path, "[teatree]\n")
+        assert load_config(config_path).user.e2e_confidence_threshold == 90
+
+    def test_default_with_no_config_file(self, tmp_path: Path) -> None:
+        assert load_config(tmp_path / "absent.toml").user.e2e_confidence_threshold == 90
+
+    def test_reads_toml_int(self, tmp_path: Path) -> None:
+        config_path = tmp_path / ".teatree.toml"
+        _write_toml(config_path, "[teatree]\ne2e_confidence_threshold = 95\n")
+        assert load_config(config_path).user.e2e_confidence_threshold == 95
+
+    def test_per_overlay_override_wins_over_global(
+        self,
+        config_file: Path,
+        elsewhere: Path,
+        no_installed_overlays: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        del elsewhere, no_installed_overlays
+        monkeypatch.setenv("T3_OVERLAY_NAME", "client-x")
+        _write_toml(
+            config_file,
+            """
+[teatree]
+e2e_confidence_threshold = 90
+
+[overlays.client-x]
+class = "x.y:Z"
+e2e_confidence_threshold = 98
+""",
+        )
+        assert get_effective_settings().e2e_confidence_threshold == 98
+
+
 class TestAutoUpdateSettings:
     """#1760: CI-green gate + deferred-reinstall flags load from toml + env."""
 


### PR DESCRIPTION
Add a self-driving E2E verification loop that iterates /t3:e2e and /t3:e2e-review until a rubric-scored confidence threshold is met, with a hard stop so it can never spin forever.

What:
- skills/e2e-review/SKILL.md: new E2E Confidence Rubric section. A 0-100 weighted score with two mandatory hard gates (H1 non-vacuous green; H2 evidence integrity) that cap the score to HOLD if either fails, six weighted criteria summing to 100 (behaviour-over-implementation 25, AC coverage 20, locator resilience 15, wait discipline 15, isolation 15, reproducibility 10), and a structured {score, threshold, verdict, findings} return. VERIFIED at score >= threshold (default 90) with both gates passing; a genuinely-not-automatable feature terminates as BLOCKED(named-gate) with manual evidence noted rather than looping forever.
- skills/e2e/SKILL.md: new Verify-Review Loop to Threshold section framed as FSM edges: test/e2e (/t3:e2e, bug-hunt + codify findings into committed specs + consolidate duplicated suites) to e2e_reviewing (/t3:e2e-review, score with the rubric) via /next; VERIFIED to ship (with the normal review phase in between when product code changed); HOLD loops back to test/e2e; BLOCKED and MAX_ITERATIONS(=5) terminate. Plus a Configuration block for the threshold knob.
- config: add e2e_confidence_threshold (int, default 90, per-overlay overridable) to UserSettings, the overridable-settings registry (_parse_strict_int), and load_config; mirrors the existing simple-int-field pattern. Test + docs/blueprint/configuration.md updated.

Why: a single E2E pass can go green vacuously, miss an acceptance criterion, or be brittle in a way the green line never shows. Full confidence is unreachable for some tickets (manual-only features whose result is on no API; infra-gated features), so the loop needs a rubric-scored threshold AND a stop condition: it terminates honestly as VERIFIED, BLOCKED(named gate), or MAX_ITERATIONS rather than posting a caveated note or spinning forever.

Tests / gates: new TestE2EConfidenceThresholdSetting in tests/config/test_load_config.py (default 90, no-file default, toml read, per-overlay override); the tier-parity fitness functions confirm the new overridable key has a UserSettings field and is wired in load_config. prek run --all-files green (tach, import-linter, ty-check, codespell, markdownlint, SKILL frontmatter + skill-reference validation, jscpd, module-health, regression detectors). Full tests/config/ suite (247) + the e2e-skill doc-invariant test pass.