### PR TITLE
feat(statusline): show Agent-Teams mates in the header roster

### DIFF
--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -13,7 +13,9 @@
 #     `/effort` level rendered beside it — from the payload if present, else the
 #     saved settings default), context-window %,
 #     5-hour and 7-day rate-limit usage, skills loaded this session, a compact
-#     summary of this session's harness TODO list, and a
+#     summary of this session's harness TODO list, the live Agent-Teams roster
+#     (the ACTIVE mates of the team this session leads, read from the harness
+#     team config), and a
 #     per-session loop-owner badge — the skills and TODO summaries are
 #     populated by hook_router.py into ${state_dir}/<session_id>.skills and
 #     ${state_dir}/<session_id>.todos (the TODO file is materialised from the
@@ -469,11 +471,71 @@ fi
 
 g_updates="$_freshness_segment"
 
+# Agent-Teams roster: the live mates of the team THIS session leads, rendered
+# compactly so the lead sees who is on the bench without the harness's inline
+# ``@mate · shift+↑/↓`` switcher being the only surface. The team config lives
+# at ``<teams_dir>/<team>/config.json`` (teams_dir =
+# ``${CLAUDE_CONFIG_DIR:-$HOME/.claude}/teams`` unless overridden by
+# TEATREE_CLAUDE_TEAMS_DIR), keyed by team NAME not session — so we resolve the
+# team by matching ``leadSessionId`` to this session and list ACTIVE members
+# (``isActive == true``) other than the lead. Each mate is painted in its own
+# ``color`` (the harness teammate color) when known, else neutral. Fails open
+# (renders nothing, never errors) on no jq, no session id, no teams dir, no
+# matching team, or any read/parse failure — a colleague who never runs a team
+# sees exactly the statusline they always did.
+_team_segment=""
+if command -v jq >/dev/null 2>&1 && [ -n "${session_id:-}" ]; then
+    _teams_dir="${TEATREE_CLAUDE_TEAMS_DIR:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/teams}"
+    if [ -d "$_teams_dir" ]; then
+        _mates_raw=""
+        for _team_cfg in "$_teams_dir"/*/config.json; do
+            [ -r "$_team_cfg" ] || continue
+            # Only the team THIS session leads — its leadSessionId is ours. The
+            # roster is rendered for the lead's terminal; a non-lead session
+            # leads no team and so renders no roster.
+            _is_my_team=$(jq -r --arg sid "$session_id" \
+                'if (.leadSessionId // "") == $sid then "1" else "" end' \
+                "$_team_cfg" 2>/dev/null)
+            [ "$_is_my_team" = "1" ] || continue
+            # One ``<color>\t<name>`` line per ACTIVE non-lead member. The lead
+            # is excluded by agentId (it equals leadAgentId) so it never lists
+            # itself even if a future config stamps it isActive.
+            _mates_raw=$(jq -r '
+                (.leadAgentId // "") as $lead
+                | [ .members[]?
+                    | select(((.isActive == true)) and ((.agentId // "") != $lead))
+                    | "\(.color // "")\t\(.name // "")" ]
+                | .[]' "$_team_cfg" 2>/dev/null)
+            break
+        done
+        if [ -n "$_mates_raw" ]; then
+            _mate_chips=""
+            while IFS=$'\t' read -r _mate_color _mate_name; do
+                [ -n "$_mate_name" ] || continue
+                case "$_mate_color" in
+                    red) _mc="$_RED" ;;
+                    green) _mc="$_GRN" ;;
+                    yellow) _mc="$_YLW" ;;
+                    blue) _mc="$_BLU" ;;
+                    magenta|purple|pink) _mc="$_MAG" ;;
+                    cyan) _mc="$_CYN" ;;
+                    *) _mc="$_GRN" ;;
+                esac
+                [ -n "$_mate_chips" ] && _mate_chips="${_mate_chips}${isep}"
+                _mate_chips="${_mate_chips}${_mc}${_mate_name}${_RST}"
+            done <<< "$_mates_raw"
+            [ -n "$_mate_chips" ] && _team_segment="${_LBL}mates:${_RST} ${_mate_chips}"
+        fi
+    fi
+fi
+g_team="$_team_segment"
+
 # Join all groups with the between-group separator. There is no loop group
 # (#130) — loop/tick info has exactly one home, the dedicated loop line in
-# the zones file cat'd below.
+# the zones file cat'd below. The mates roster (g_team) rides the header as its
+# own group, after resource, so it never crowds out model/ctx/usage.
 header=""
-for _g in g_context g_usage g_updates g_resource; do
+for _g in g_context g_usage g_updates g_resource g_team; do
     _val=$(eval "printf '%s' \"\${$_g}\"")
     [ -z "$_val" ] && continue
     if [ -z "$header" ]; then

--- a/tests/test_claude_statusline.py
+++ b/tests/test_claude_statusline.py
@@ -51,6 +51,10 @@ def _run(
         env["TEATREE_STATUSLINE_FILE"] = str(statusline_file)
     if registry_dir is not None:
         env["T3_LOOP_REGISTRY_DIR"] = str(registry_dir)
+    # Isolate the Agent-Teams config dir so the developer's real ~/.claude/teams
+    # roster never bleeds into these tests: the mates zone resolves its teams dir
+    # from CLAUDE_CONFIG_DIR (already pinned to state_dir above), so a team config
+    # is discovered ONLY when a test plants it under ``state_dir/teams/``.
     if cpu is not None:
         loadavg_file, ncpu = cpu
         env["TEATREE_STATUSLINE_LOADAVG_FILE"] = str(loadavg_file)
@@ -1007,3 +1011,195 @@ class TestLoopOwnerBadge:
         assert result.returncode == 0, result.stderr
         plain = _strip_ansi(result.stdout)
         assert "loop-owner" not in plain, plain
+
+
+class TestTeamRoster:
+    """The Agent-Teams ``mates:`` zone in the header.
+
+    The statusline reads the harness team config at display time and lists the
+    ACTIVE mates of the team THIS session leads (``leadSessionId`` == ours),
+    excluding the lead itself. It fails open — renders nothing, never errors —
+    whenever there is no session id, no teams dir, no team this session leads,
+    or any read/parse failure, so a colleague who never runs a team sees the
+    statusline they always did.
+    """
+
+    def _write_team(
+        self,
+        state_dir: Path,
+        *,
+        team: str,
+        lead_session_id: str,
+        members: list[dict],
+        lead_agent_id: str = "team-lead",
+    ) -> None:
+        # The mates zone resolves its teams dir from CLAUDE_CONFIG_DIR, which
+        # ``_run`` pins to ``state_dir`` — so the config lives at
+        # ``state_dir/teams/<team>/config.json``, the real default path.
+        team_path = state_dir / "teams" / team
+        team_path.mkdir(parents=True, exist_ok=True)
+        (team_path / "config.json").write_text(
+            json.dumps(
+                {
+                    "name": team,
+                    "leadAgentId": lead_agent_id,
+                    "leadSessionId": lead_session_id,
+                    "members": members,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_lists_active_mates_for_lead_session(self, tmp_path: Path) -> None:
+        """Lead session → ``mates: alice · bob``; lead + inactive members excluded."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        self._write_team(
+            state_dir,
+            team="my-team",
+            lead_session_id="lead-sess",
+            lead_agent_id="team-lead@my-team",
+            members=[
+                {"agentId": "team-lead@my-team", "name": "team-lead", "isActive": None},
+                {"agentId": "alice@my-team", "name": "alice", "color": "blue", "isActive": True},
+                {"agentId": "bob@my-team", "name": "bob", "color": "magenta", "isActive": True},
+                {"agentId": "carol@my-team", "name": "carol", "color": "green", "isActive": False},
+            ],
+        )
+
+        result = _run(
+            {"session_id": "lead-sess", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        header = plain.splitlines()[0]
+        assert "mates: alice · bob" in header, header
+        # The lead never lists itself, and an inactive member is omitted.
+        assert "team-lead" not in header, header
+        assert "carol" not in header, header
+
+    def test_mate_painted_in_its_color(self, tmp_path: Path) -> None:
+        """A mate's ``color`` drives its SGR — blue for alice."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        self._write_team(
+            state_dir,
+            team="t",
+            lead_session_id="ls",
+            lead_agent_id="lead@t",
+            members=[
+                {"agentId": "lead@t", "name": "lead", "isActive": None},
+                {"agentId": "alice@t", "name": "alice", "color": "blue", "isActive": True},
+            ],
+        )
+
+        result = _run(
+            {"session_id": "ls", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        # Blue SGR present in the raw (non-stripped) output for the mate chip.
+        assert "\033[1;34m" in result.stdout, "expected blue SGR for color=blue mate"
+
+    def test_no_zone_for_non_lead_session(self, tmp_path: Path) -> None:
+        """A session that leads NO team renders no ``mates:`` zone (fail-open)."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        self._write_team(
+            state_dir,
+            team="other-team",
+            lead_session_id="someone-else",
+            members=[
+                {"agentId": "alice", "name": "alice", "color": "blue", "isActive": True},
+            ],
+        )
+
+        result = _run(
+            {"session_id": "not-the-lead", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "mates:" not in plain, plain
+
+    def test_no_zone_when_teams_dir_absent(self, tmp_path: Path) -> None:
+        """No teams dir at all → no ``mates:`` zone, clean exit (fail-open)."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        # No team config planted — state_dir/teams does not exist.
+
+        result = _run(
+            {"session_id": "any-sess", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "mates:" not in plain, plain
+
+    def test_no_zone_when_no_active_mates(self, tmp_path: Path) -> None:
+        """Lead session whose only members are the lead / inactive → no zone."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        self._write_team(
+            state_dir,
+            team="lonely",
+            lead_session_id="solo-sess",
+            lead_agent_id="lead@lonely",
+            members=[
+                {"agentId": "lead@lonely", "name": "lead", "isActive": None},
+                {"agentId": "gone@lonely", "name": "gone", "color": "red", "isActive": False},
+            ],
+        )
+
+        result = _run(
+            {"session_id": "solo-sess", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "mates:" not in plain, plain
+
+    def test_no_zone_when_no_session_id(self, tmp_path: Path) -> None:
+        """No session_id → cannot resolve the lead's team → no zone."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        self._write_team(
+            state_dir,
+            team="t",
+            lead_session_id="",
+            members=[{"agentId": "alice", "name": "alice", "isActive": True}],
+        )
+
+        result = _run(
+            {"model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "mates:" not in plain, plain
+
+    def test_malformed_team_config_fails_open(self, tmp_path: Path) -> None:
+        """A corrupt config.json → no crash, no zone (fail-open)."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        team_path = state_dir / "teams" / "broken"
+        team_path.mkdir(parents=True)
+        (team_path / "config.json").write_text("{ not valid json", encoding="utf-8")
+
+        result = _run(
+            {"session_id": "lead-sess", "model": {"display_name": "Claude Opus"}},
+            state_dir=state_dir,
+        )
+
+        assert result.returncode == 0, result.stderr
+        plain = _strip_ansi(result.stdout)
+        assert "mates:" not in plain, plain
+        # The rest of the header still renders — the bad config did not blank it.
+        assert "model=Claude Opus" in plain, plain


### PR DESCRIPTION
## What

Render the live Agent-Teams roster in the teatree statusline header as a `mates:` zone, beside model / ctx / usage / resource.

The hook reads the harness team config (`${CLAUDE_CONFIG_DIR:-$HOME/.claude}/teams/<team>/config.json`, overridable via `TEATREE_CLAUDE_TEAMS_DIR`), resolves the team **this** session leads by matching `leadSessionId` to the session id, and lists the ACTIVE members (`isActive == true`) other than the lead — each painted in its own `color`.

Example header:

```
model=Opus │ ram=72% 17.5/24G · cpu=64% · disk=88% 56G free │ mates: overlay-maker
```

## Why

When Agent Teams runs, the mates were not surfaced in the statusline at all (a grep showed zero team references). This brings them back into the header so the lead sees who is on the bench at a glance, rather than relying solely on the harness's inline `@mate · shift+↑/↓` switcher.

## How

- New `g_team` header group, joined after `g_resource` so it never crowds out model/ctx/usage on a narrow terminal.
- Team resolution is per-session (`leadSessionId == session_id`) — a non-lead session leads no team and renders no roster, mirroring how the loop-owner badge is resolved per-session.
- Each mate's harness `color` maps to the existing SGR palette; unknown colors fall back to neutral green.

## Fail-open contract

Renders nothing and never errors on any of: no `jq`, no session id, no teams dir, no team this session leads, no active mates, or a malformed/unreadable config. A colleague who never runs a team sees exactly the statusline they always did.

## Tests

`tests/test_claude_statusline.py::TestTeamRoster` (mirrors the loop-owner-badge class):

- lead session lists active mates; the lead and inactive members are excluded
- a mate's `color` drives its SGR
- every fail-open path (non-lead session, absent teams dir, no active mates, no session id, malformed config) renders no zone and exits 0

The teams dir resolves from `CLAUDE_CONFIG_DIR` (already pinned to the test's state dir in `_run`), so no new test-helper parameter was needed. The positive rendering tests were observed RED against the pre-change script.

## Inline switcher — investigation result

The task also asked whether the inline `@mate · shift+↑/↓` switcher can be **removed via config** (keeping mates visible/active). Verdict after inspecting the installed Claude Code binary and docs: **no supported toggle exists.** The only teammate config knobs are `teammateMode` (`tmux` / `in-process` / `auto` — controls *where* mates execute, not switcher visibility) and `teammateDefaultModel`. The switcher (the `teammateFooterIndex` footer) renders whenever there are active teammates and has no settings.json key, env var, or flag to hide it independently. So the switcher is left as-is; this statusline roster is the deliverable.
