### PR TITLE
fix(hooks): fail closed on an unreadable commit/post body, private repo included (#1415)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -3278,10 +3278,12 @@ def _banned_terms_gate_enabled() -> bool:
 
     Fails OPEN to enabled on a missing/broken config so the gate keeps its
     protective default; an explicit ``[teatree] banned_terms_gate_enabled =
-    false`` is the one-line kill-switch (NEVER-LOCKOUT) the user flips to
-    disable the gate while its body-resolution over-block (an allowlisted
-    private-repo commit hard-blocked because the body could not be read) is
-    fixed properly. See :func:`_teatree_bool_setting` for the shared semantics.
+    false`` is the one-line kill-switch (NEVER-LOCKOUT) the user flips if the
+    gate's fail-closed behaviour (e.g. a private-repo commit blocked because the
+    gate could not read its body, #1415) ever proves too aggressive for a
+    session. The per-call ``--allow-banned-term`` / ``ALLOW_BANNED_TERM=1``
+    override is the narrower escape. See :func:`_teatree_bool_setting` for the
+    shared semantics.
     """
     return _teatree_bool_setting("banned_terms_gate_enabled", default=True)
 
@@ -3366,39 +3368,31 @@ def _emit_banned_term_deny(
     return emit_pretooluse_deny(banned_terms_scanner.format_block_message(term))
 
 
-def _banned_term_marker_blocks(term: str, command: str, cwd_repo: "Path | None") -> bool | None:
+def _banned_term_marker_blocks(term: str) -> bool | None:
     """Decide a fail-closed MARKER term, or ``None`` when ``term`` is a real banned term.
 
-    ``scan_text`` returns either a configured banned term or a fail-closed
-    marker (an unresolvable body, an unavailable scanner). For a real term this
-    returns ``None`` so the caller takes the destination-aware banned-term path.
+    ``scan_text`` returns either a configured banned term or one of three
+    fail-closed markers (an unreadable body file, an unavailable ``$VAR``/stdin
+    body source #2369, an unavailable scanner #1954). A real term returns
+    ``None`` so the caller takes the destination-aware banned-term path.
 
-    For the two unreadable-body markers the decision is destination-aware: an
-    UNREADABLE body file (a ``git commit -F <path>`` whose file does not exist
-    at cold-hook scan time, a missing ``--body-file``) OR an UNAVAILABLE body
-    source (an unexpanded ``$VAR`` / a stdin body, #2369) hard-blocks on a PUBLIC
-    surface — an unscanned body must never slip into public history — but a
-    ``git commit`` landing in a PRIVATE repo (or a pure private gh/glab post) is
-    not a public surface, so the unread body cannot leak and the gate downgrades
-    to a warn (#1415). The payload-driven carve-out fails closed on the sentinel,
-    so a body-INDEPENDENT private-destination check decides it here. The
-    SCANNER-unavailable marker stays hard-blocking on every surface (#1954).
+    Every marker HARD-BLOCKS on EVERY surface, a private repo included (#1415):
+    the gate cannot prove an unread body is leak-free, and the "private"
+    classification is itself a guess (a probe under different auth, a stale
+    ``private_repos`` allowlist), so a body it could not read must never slip a
+    leak through on a destination guess (this matches the scanner module's own
+    contract and the SCANNER-unavailable marker). The never-lockout escape is the
+    ``--allow-banned-term`` / ``ALLOW_BANNED_TERM=1`` override or the
+    ``banned_terms_gate_enabled = false`` kill-switch, not a silent allow; a
+    legitimate commit can also pass its body inline (``-m``) or as a readable
+    ``--body-file <abspath>``. The own-domain-word carve-out on a READABLE body
+    is unaffected (it lives on :func:`_emit_banned_term_deny`).
     """
-    from teatree.hooks import banned_terms_scanner, publish_surface  # noqa: PLC0415
+    from teatree.hooks import banned_terms_scanner  # noqa: PLC0415
 
     marker_message = banned_terms_scanner.marker_deny_message(term)
     if marker_message is None:
         return None
-    unreadable_body_markers = {
-        banned_terms_scanner.UNRESOLVABLE_BODY_MARKER,
-        banned_terms_scanner.UNAVAILABLE_BODY_SOURCE_MARKER,
-    }
-    if term in unreadable_body_markers and publish_surface.command_targets_private_only(command, cwd_repo):
-        sys.stderr.write(
-            "WARNING: banned-terms gate (#1415) — could not read the commit/post body, but the "
-            "destination is a private repo; downgraded to warn. A private-repo body is not a public leak.\n"
-        )
-        return False
     return emit_pretooluse_deny(marker_message)
 
 
@@ -3436,7 +3430,7 @@ def _run_banned_terms_pretool(data: dict) -> bool:
     term = None if skipped else banned_terms_scanner.scan_text(payload)
     if term is None:
         return False
-    marker_decision = _banned_term_marker_blocks(term, command, cwd_repo)
+    marker_decision = _banned_term_marker_blocks(term)
     if marker_decision is not None:
         return marker_decision
     return _emit_banned_term_deny(tool_name, command, payload, term, cwd_repo)

--- a/tests/teatree_hooks/test_banned_terms_hook.py
+++ b/tests/teatree_hooks/test_banned_terms_hook.py
@@ -682,28 +682,33 @@ def test_fm4_help_invocation_does_not_block(
         assert captured.out == "", command
 
 
-# ── #1415: unreadable commit body on a PRIVATE repo must downgrade ────────────
+# ── #1415: unreadable commit body fails CLOSED, private repo included ─────────
 #
 # An UNREADABLE ``git commit -F <file>`` body (the file does not exist at cold-
-# hook scan time -- the agent's standard "write the body file, commit it in the
-# next call" idiom, or a relative path the reset hook cwd cannot reach) produced
-# the fail-closed sentinel and HARD-BLOCKED with "The publish body could not be
-# read", even when the commit lands in a known-PRIVATE repo. A private-repo
-# commit is not a public surface -- the body lands in private history regardless
-# of whether the gate could read it -- so an unread body cannot leak and must
-# downgrade to warn. The payload-driven carve-out fails closed on the sentinel,
-# so the fix routes the unreadable-body marker through a body-INDEPENDENT
-# private-destination check. The PUBLIC-surface fail-closed protection is
-# preserved by the paired anti-vacuity guards above (FM3) and below.
+# hook scan time) yields the fail-closed sentinel. It MUST hard-block on EVERY
+# surface, a known-PRIVATE landing repo included: the gate cannot prove an unread
+# body is leak-free, and the "private" classification is itself a guess (a probe
+# resolved under different auth, a stale ``private_repos`` allowlist), so a body
+# the gate could not read must never slip a leak through on the strength of that
+# guess. This matches the scanner module's own contract -- both unreadable-body
+# markers BLOCK there -- and the long-standing SCANNER-unavailable behaviour, so
+# all three markers behave the same. The never-lockout escape for a genuine
+# private-repo commit is the explicit ``--allow-banned-term`` /
+# ``ALLOW_BANNED_TERM=1`` override or the ``banned_terms_gate_enabled = false``
+# kill-switch, or simply passing the body inline (``-m``) or as a readable
+# ``--body-file <abspath>``. The carve-out for a private repo's OWN domain words
+# on a READABLE body is unaffected (it lives on the real-banned-term path).
 
 
-def test_live_hook_allows_unreadable_commit_body_file_in_private_worktree(
+def test_live_hook_blocks_unreadable_commit_body_file_in_private_worktree(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # RED→GREEN (#1415): a ``git commit -F <nonexistent file>`` whose harness cwd
-    # IS a known-private worktree must DOWNGRADE to warn, not hard-block on
-    # "publish body could not be read". The body is unreadable at scan time, but
-    # the commit lands in the repo's own private history -- not a public leak.
+    # MUST-BLOCK (#1415): a ``git commit -F <nonexistent file>`` whose harness cwd
+    # IS a known-private worktree must HARD-BLOCK -- the body is unreadable at scan
+    # time, so the gate cannot verify it is leak-free and fails CLOSED rather than
+    # waving an unverifiable body through on the destination guess. (This case
+    # previously downgraded to a warn; the downgrade was removed so an unreadable
+    # body fails closed uniformly, a private repo included.)
     home = Path(os.environ["HOME"])
     _write_home_config(home, _SUBSTRING_TERM_CONFIG, monkeypatch, tmp_path)
     monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
@@ -717,6 +722,34 @@ def test_live_hook_allows_unreadable_commit_body_file_in_private_worktree(
     blocked = handle_banned_terms_pretool(data)
     captured = capsys.readouterr()
 
+    assert blocked is True
+    decision = json.loads(captured.out)
+    assert decision["permissionDecision"] == "deny"
+
+
+def test_live_hook_allows_readable_clean_commit_body_file_in_private_worktree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # MUST-NOT-BLOCK (#1415) — the normal/available case: a ``git commit -F
+    # <file>`` whose body file EXISTS and is leak-free must be allowed. The
+    # fail-closed tightening above fires only when the body is UNVERIFIABLE; a
+    # readable clean body is scanned normally and passes, so the common commit
+    # flow is never over-blocked.
+    home = Path(os.environ["HOME"])
+    _write_home_config(home, _SUBSTRING_TERM_CONFIG, monkeypatch, tmp_path)
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
+
+    worktree = _private_worktree(tmp_path)
+    body = worktree / "COMMIT_MSG.txt"
+    body.write_text("feat(core): tidy the resolver\n\nA perfectly clean message.\n", encoding="utf-8")
+    data = {
+        "tool_name": "Bash",
+        "tool_input": {"command": f"git commit -F {body}"},
+        "cwd": str(worktree),
+    }
+    blocked = handle_banned_terms_pretool(data)
+    captured = capsys.readouterr()
+
     assert blocked is False
     assert captured.out == ""  # no deny JSON
 
@@ -724,10 +757,9 @@ def test_live_hook_allows_unreadable_commit_body_file_in_private_worktree(
 def test_live_hook_blocks_unreadable_commit_body_file_in_public_repo(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # ANTI-VACUITY guard for the private-downgrade above: the SAME unreadable
-    # ``git commit -F <nonexistent file>`` landing in a PUBLIC repo (cwd == that
-    # public repo) must STILL hard-block. The downgrade is private-only; an
-    # unscanned body must never slip into public history.
+    # Pairs with the private-repo block above: the SAME unreadable ``git commit
+    # -F <nonexistent file>`` landing in a PUBLIC repo (cwd == that public repo)
+    # also hard-blocks. An unscanned body must never slip into public history.
     home = Path(os.environ["HOME"])
     _write_home_config(home, _SUBSTRING_TERM_CONFIG, monkeypatch, tmp_path)
     monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
@@ -749,10 +781,10 @@ def test_live_hook_blocks_unreadable_commit_body_file_in_public_repo(
 def test_live_hook_blocks_unreadable_commit_body_file_in_unknown_visibility_repo(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # ANTI-VACUITY guard #2: an unreadable commit body whose landing repo is
+    # Unknown-visibility case: an unreadable commit body whose landing repo is
     # NEITHER allowlisted NOR probe-resolvable (the common cold-hook unknown
-    # state) must STILL hard-block. Default-deny on unknown visibility is
-    # preserved -- the downgrade fires only for a PROVABLY-private destination.
+    # state) must hard-block too -- the same fail-closed result as the private
+    # and public cases above, since an unread body is never verifiable.
     home = Path(os.environ["HOME"])
     _write_home_config(home, _SUBSTRING_TERM_CONFIG, monkeypatch, tmp_path)
     monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)

--- a/tests/teatree_hooks/test_banned_terms_scanner.py
+++ b/tests/teatree_hooks/test_banned_terms_scanner.py
@@ -1600,17 +1600,19 @@ class TestPrivateRepoCarveOut:
         assert blocked is True
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
 
-    def test_commit_bodyfile_genuinely_missing_on_private_repo_downgrades(
+    def test_commit_bodyfile_genuinely_missing_on_private_repo_still_blocks(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
         # A ``-F`` path that exists NOWHERE (not in cwd, not in the repo dir) is a
-        # genuinely unresolvable body. On a known-PRIVATE landing repo this must
-        # DOWNGRADE to warn, not hard-block (#1415): the commit lands in private
-        # history regardless of whether the gate could read the body, so an unread
-        # body cannot leak. The #1207 fail-closed sentinel contract is preserved
-        # only where it protects against a leak -- a PUBLIC destination (the paired
-        # public guards below + ``test_public_repo_commit_bodyfile_relative_path_
-        # still_blocks``); a private destination is not a public surface.
+        # genuinely unresolvable body. On a known-PRIVATE landing repo this MUST
+        # still hard-block (#1415): the gate cannot prove an unread body is leak-
+        # free, and the "private" classification is itself a guess (a stale
+        # allowlist, a probe under different auth), so an unverifiable body must
+        # never slip a leak through on the strength of that guess. The #1207 fail-
+        # closed sentinel contract now holds on EVERY surface; the never-lockout
+        # escape is the ``--allow-banned-term`` / ``ALLOW_BANNED_TERM=1`` override
+        # or the kill-switch. (The carve-out for a private repo's own domain word
+        # on a READABLE body is unaffected -- see the readable-body tests above.)
         repo = _private_repo(tmp_path)
         monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
         monkeypatch.chdir(tmp_path)
@@ -1620,16 +1622,16 @@ class TestPrivateRepoCarveOut:
             "cwd": str(tmp_path),
         }
         blocked = handle_banned_terms_pretool(data)
-        assert blocked is False  # downgraded to warn, not denied
-        assert capsys.readouterr().out == ""  # no deny JSON on stdout
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
 
     def test_commit_bodyfile_genuinely_missing_on_public_repo_still_blocks(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        # ANTI-VACUITY guard for the private downgrade above: the SAME genuinely-
-        # missing ``-F`` path landing in a PUBLIC repo must STILL fail closed --
-        # an unscannable body must never slip into public history. This preserves
-        # the #1207 fail-closed sentinel contract on the public surface.
+        # Pairs with the private-repo block above: the SAME genuinely-missing
+        # ``-F`` path landing in a PUBLIC repo also fails closed -- an unscannable
+        # body must never slip into public history. This preserves the #1207
+        # fail-closed sentinel contract, which now holds on every surface.
         repo = tmp_path / "pub"
         repo.mkdir()
         _git(repo, "init", "-b", "main")
@@ -1768,19 +1770,20 @@ class TestPrivateRepoCarveOut:
         assert capsys.readouterr().out == ""
 
 
-# #1415 (still-over-blocking residue): a ``git commit`` whose effective first
-# action is NOT the literal first word -- it sits behind a NON-``cd`` leading
-# segment (a ``cat > <bodyfile> <<EOF … EOF`` heredoc-writer, the agent's
-# standard body-file idiom; or any ``true &&`` / setup preamble) -- was
-# mis-classified. ``is_git_commit_command`` only skips a leading ``cd``/``pushd``
-# prefix, so a heredoc-writer or ``&&``-chained preamble made it return False and
-# BOTH carve-out dispatch sites (the real-banned-term ``carve_out_applies`` and
-# the unreadable-body ``command_targets_private_only``) fell through to
-# ``command_is_pure_private_gh_glab_post``, which returns False for a commit. The
-# allowlisted-private commit then HARD-BLOCKED even though it lands in private
+# #1415: a ``git commit`` whose effective first action is NOT the literal first
+# word -- it sits behind a NON-``cd`` leading segment (a ``cat > <bodyfile>
+# <<EOF … EOF`` heredoc-writer, the agent's standard body-file idiom; or any
+# ``true &&`` / setup preamble) -- was mis-classified. ``is_git_commit_command``
+# only skips a leading ``cd``/``pushd`` prefix, so a heredoc-writer or
+# ``&&``-chained preamble made it return False and the real-banned-term carve-out
+# (``carve_out_applies``) fell through to ``command_is_pure_private_gh_glab_post``,
+# which returns False for a commit -- so a private repo's own domain word on a
+# READABLE body behind such a prefix HARD-BLOCKED even though it lands in private
 # history. The per-segment proof in ``commit_branch_downgrades`` still preserves
 # the genuine block (a chained PUBLIC post defeats the downgrade), so the fix is
 # to recognise a ``git commit`` segment regardless of leading benign segments.
+# (An UNREADABLE body behind such a prefix is a separate case: it fails CLOSED on
+# every surface, a private repo included -- see the unreadable-body tests below.)
 class TestGitCommitSegmentBehindNonCdPrefix:
     def test_heredoc_bodyfile_private_commit_with_banned_term_downgrades(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
@@ -1817,22 +1820,24 @@ class TestGitCommitSegmentBehindNonCdPrefix:
         assert blocked is True
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
 
-    def test_prefix_segment_private_commit_unreadable_body_downgrades(
+    def test_prefix_segment_private_commit_unreadable_body_still_blocks(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
         # The reported production shape distilled: a ``git -C <worktree> commit
         # -F <bodyfile>`` whose body is UNREADABLE at scan time (the marker
-        # fires), sitting behind a non-``cd`` leading segment. The commit lands
-        # in the allowlisted-private worktree, so the unread body cannot leak and
-        # it must DOWNGRADE, not hard-block with "publish body could not be read".
+        # fires), sitting behind a non-``cd`` leading segment, landing in the
+        # allowlisted-private worktree. The body is unverifiable, so it MUST fail
+        # CLOSED (#1415) -- an unread body never slips a leak through on the
+        # destination guess. (The readable-body own-domain-word carve-out behind
+        # the same prefix still downgrades -- see the heredoc test above.)
         repo = _private_repo(tmp_path)
         monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
         monkeypatch.chdir(tmp_path)
         cmd = f"true && git -C {repo} commit -F does_not_exist.txt"
         data = {"tool_name": "Bash", "tool_input": {"command": cmd}, "cwd": str(tmp_path)}
         blocked = handle_banned_terms_pretool(data)
-        assert blocked is False  # downgraded to warn, not denied
-        assert capsys.readouterr().out == ""  # no deny JSON on stdout
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
 
     def test_prefix_segment_public_commit_unreadable_body_still_blocks(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
## What

Closes the unavailable-body fail-open in the banned-terms posting gate (#1415).

When `scan_text` could not read a publish body, it returned one of two
unreadable-body markers (`UNRESOLVABLE_BODY_MARKER` for a missing/unreadable
`--body-file`/`-F` file, `UNAVAILABLE_BODY_SOURCE_MARKER` for an unexpanded
`$VAR` or a stdin body). The router (`_banned_term_marker_blocks`) then
**downgraded those to a warn whenever the destination resolved to a private
repo** — only the scanner-unavailable marker hard-blocked everywhere.

This change makes all three markers hard-block on every surface, a private
repo included.

## Why

The downgrade waved an *unverifiable* body through on the strength of a
destination guess. The "private" classification is itself a guess in-hook (a
`gh`/`glab` probe resolved under different auth, a stale `private_repos`
allowlist), so a body the gate could not read could still slip a leak through.
Failing closed here matches the scanner module's own documented contract (both
unreadable-body markers are already described there as blocking) and the
long-standing scanner-unavailable behaviour, so all three markers now behave
the same.

This reverses the private-repo downgrade introduced for the unreadable-body
case (PR #2286). Flagging that explicitly so the design call gets a second
look: the trade-off is that a genuinely-unreadable body on a private repo now
blocks instead of warning.

### Never-lockout preserved

The escapes are unchanged: the per-call `--allow-banned-term` /
`ALLOW_BANNED_TERM=1` override and the `banned_terms_gate_enabled = false`
kill-switch. In practice the body-file resolution retry (#2284) means a normal
commit's `-F` file resolves and scans fine; the marker only fires when the body
is genuinely unreadable or comes from `$VAR`/stdin — and the deny message tells
the operator to pass the body inline (`-m`) or as a readable `--body-file
<abspath>`. The readable-body carve-out for a private repo's own domain words
is untouched (it lives on the real-banned-term path, not the marker path), and
the `gh`/`glab` private-destination *skip* is also untouched, so normal private
posts are not over-blocked.

## Tests

- `test_banned_terms_hook.py::test_live_hook_blocks_unreadable_commit_body_file_in_private_worktree`
  — must-BLOCK (was the must-allow downgrade test; flipped).
- `test_banned_terms_hook.py::test_live_hook_allows_readable_clean_commit_body_file_in_private_worktree`
  — new must-NOT-block for the normal/available case.
- `test_banned_terms_scanner.py::test_commit_bodyfile_genuinely_missing_on_private_repo_still_blocks`
  and `::test_prefix_segment_private_commit_unreadable_body_still_blocks` — the
  scanner-integration siblings, flipped to block.
- The public-repo and unknown-visibility anti-vacuity guards are unchanged and
  still block.

Full `tests/teatree_hooks/` suite green (1446 passed); `tests/teatree_quality/`
green (64 passed); `t3 tool verify-gates` exits 0 (all commit + push stages).
