### PR TITLE
fix(eval): isolate the substrate-floor helper from the DB+env config tiers

### DIFF
--- a/src/teatree/eval/regression_corpus_predicates.py
+++ b/src/teatree/eval/regression_corpus_predicates.py
@@ -34,25 +34,41 @@ _SHA_B = "b" * 40
 
 @contextmanager
 def _staged_overlay_autonomy(overlay_name: str, autonomy: str) -> Iterator[None]:
-    """Run the block with a hermetic ``~/.teatree.toml`` pinning *overlay_name* to *autonomy*.
+    """Run the block with a hermetic config pinning *overlay_name* to *autonomy*.
 
     An eval-isolation helper for assertions whose outcome depends on the
-    overlay's effective autonomy (the substrate-merge carve-out). Swaps
-    ``teatree.config.CONFIG_PATH`` at the single seam ``get_effective_settings``
-    reads, so the resolved autonomy is deterministic regardless of the
-    developer's live config, and restores it on exit.
+    overlay's effective autonomy (the substrate-merge carve-out). It pins all
+    three tiers ``get_effective_settings`` layers so the resolved autonomy is the
+    staged value regardless of the developer's live config: it swaps
+    ``teatree.config.CONFIG_PATH`` to a hermetic ``~/.teatree.toml`` holding only
+    the staged autonomy, and neutralises the DB override tier (#1775) and the env
+    tier to ``{}`` for the block so a live ``ConfigSetting`` row on the host (an
+    overlay such as ``t3-teatree`` pinned to ``full``) or a ``T3_*`` env var
+    cannot win over the staged TOML.
+
+    Without the DB-tier pin the hermetic file is silently overridden by the host
+    database (the DB tier wins over the file tier), so the substrate floor check
+    read the host's live autonomy instead of the staged ``babysit`` and failed on
+    any host carrying a per-overlay autonomy override. All seams are restored on
+    exit.
     """
+    from unittest.mock import patch  # noqa: PLC0415
+
     from teatree import config as config_module  # noqa: PLC0415
 
     with tempfile.TemporaryDirectory() as raw:
         cfg = Path(raw) / ".teatree.toml"
         cfg.write_text(f'[teatree]\n[overlays.{overlay_name}]\nautonomy = "{autonomy}"\n', encoding="utf-8")
-        original = config_module.CONFIG_PATH
+        original_path = config_module.CONFIG_PATH
         config_module.CONFIG_PATH = cfg
         try:
-            yield
+            with (
+                patch("teatree.config.resolution._db_setting_overrides", return_value={}),
+                patch("teatree.config.resolution._env_setting_overrides", return_value={}),
+            ):
+                yield
         finally:
-            config_module.CONFIG_PATH = original
+            config_module.CONFIG_PATH = original_path
 
 
 def _check_branch_currency_conflict_only() -> bool:

--- a/tests/teatree_eval/test_regression_corpus_predicates.py
+++ b/tests/teatree_eval/test_regression_corpus_predicates.py
@@ -13,6 +13,10 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
+from teatree.config.resolution import get_effective_settings
+from teatree.config.settings import Autonomy
+from teatree.core.models import ConfigSetting
+from teatree.core.overlay_loader import infer_overlay_for_url
 from teatree.eval import regression_corpus_predicates as predicates
 
 
@@ -78,3 +82,33 @@ class TestPredicatesAreAntiVacuous(TestCase):
         with patch("teatree.hooks._repo_visibility.slug_is_allowlisted_private", return_value=True):
             # A matcher that flags the public alias-glued slug → must-not-match leg fails.
             assert predicates._check_private_repo_allowlist_path_segment_match() is False
+
+
+class TestStagedAutonomyHermeticAgainstDbTier(TestCase):
+    """The substrate-floor helper pins autonomy regardless of a live DB override (#1775 host leak).
+
+    The DB config override tier (#1775) wins over the file tier, so a host
+    carrying a per-overlay ``autonomy`` ``ConfigSetting`` row silently overrode
+    the hermetic TOML the floor check stages — the floor then read the host's
+    live autonomy instead of the staged value and failed on that host. The
+    helper must neutralise the DB (and env) tier so the staged TOML is
+    authoritative. Both tests go RED on the pre-fix helper (the seeded ``full``
+    row leaks past the staged ``babysit``).
+    """
+
+    def _pin_overlay_autonomy_full_in_db(self) -> str:
+        overlay_name = infer_overlay_for_url("souliane/teatree") or "t3-teatree"
+        ConfigSetting.objects.set_value("autonomy", Autonomy.FULL.value, scope=overlay_name)
+        return overlay_name
+
+    def test_staged_babysit_wins_over_db_full_override(self) -> None:
+        overlay_name = self._pin_overlay_autonomy_full_in_db()
+        with predicates._staged_overlay_autonomy(overlay_name, "babysit"):
+            resolved = get_effective_settings(overlay_name).autonomy
+        assert resolved is Autonomy.BABYSIT
+
+    def test_substrate_floor_holds_with_live_full_db_override(self) -> None:
+        self._pin_overlay_autonomy_full_in_db()
+        # The below-full floor must still BLOCK a human-less substrate CLEAR even
+        # though the host DB pins this overlay to full.
+        assert predicates._check_merge_precondition_substrate_human_authorize() is True


### PR DESCRIPTION
## What

`_staged_overlay_autonomy` (the helper the pinned-regressions **substrate-merge human-authorize floor** check uses to pin an overlay's autonomy hermetically) only swapped the **file tier** (`CONFIG_PATH`). The #1775 / #2450 **DB config override tier** — and the env tier — win over the file tier in `get_effective_settings`, so a host carrying a per-overlay `autonomy` `ConfigSetting` row (e.g. `t3-teatree` pinned to `full`) leaked past the staged `babysit`. The floor check then read the host's live autonomy and the pre-push `eval-pinned-regressions` hook failed on that host.

The helper now neutralises the DB and env override tiers for the staged block, so the hermetic TOML is authoritative — matching its documented contract of determinism regardless of live host config.

## Why it only failed locally

CI runs against a fresh, override-free DB, so `_db_setting_overrides` returns `{}` there and the floor check has always passed in CI. The failure was confined to developer hosts that have set a per-overlay `autonomy` override via `t3 teatree config_setting set` — exactly what the per-overlay settings work (#2450) made possible. This is the host-config-leak class flagged during that migration.

## Test

`TestStagedAutonomyHermeticAgainstDbTier` seeds a live `autonomy=full` `ConfigSetting` row and asserts both the staged-`babysit` resolution and the substrate floor predicate hold. Both go **RED on the pre-fix helper** (the seeded `full` leaks past the staged `babysit`) and green with the fix — anti-vacuous, verified by stashing the source fix and observing the failure.

docs: n/a — eval-isolation infra, no user-visible change

## Open questions & assumptions

- none
