### PR TITLE
fix(hooks): resolve gh/glab api field body value before the leak scan

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -7228,11 +7228,11 @@ _REVIEW_POST_BODY_FLAG_RE = re.compile(
 )
 _REVIEW_POST_DENY_REASON = (
     "BLOCKED: raw `glab api`/`gh api` POST to a review discussion/notes/comments "
-    "endpoint bypasses the sanctioned review-post CLI. Use "
-    "`t3 <overlay> review post-comment` (draft by default, #1207) or "
-    "`t3 <overlay> review post-draft-note` — the CLI enforces draft-default, "
-    "dedup, and on-behalf approval, which a direct REST write skips entirely. "
-    "Read-only `glab api`/`gh api` GETs are unaffected."
+    "endpoint bypasses the sanctioned review-post CLI. To CREATE a note use "
+    "`t3 <overlay> review post-comment` (draft by default, #1207) or `post-draft-note`; "
+    "to EDIT or REMOVE an existing one use `t3 <overlay> review update-note` or "
+    "`delete-discussion` — the CLI enforces draft-default, dedup, and on-behalf approval, "
+    "which a direct REST write skips. Read-only `glab api`/`gh api` GETs are unaffected."
 )
 
 

--- a/src/teatree/hooks/_command_parser.py
+++ b/src/teatree/hooks/_command_parser.py
@@ -385,7 +385,7 @@ def _handle_api_input(arg: str, payloads: list[str]) -> None:
     payloads.extend(_json_body_fields(content))
 
 
-def _walk_api_fields(words: list[str], payloads: list[str]) -> None:
+def _walk_api_fields(words: list[str], payloads: list[str], base: "Path | None") -> None:
     """Extract ``-f``/``-F``/``--field``/``--raw-field`` ``body=`` assignments.
 
     Also handles ``--input <file>`` / ``--input -`` (stdin → fail closed)
@@ -398,7 +398,7 @@ def _walk_api_fields(words: list[str], payloads: list[str]) -> None:
     while i < n:
         word = words[i]
         if word in field_flags and i + 1 < n:
-            _handle_field_assignment(words[i + 1], payloads)
+            _handle_field_assignment(words[i + 1], payloads, base)
             i += 2
             continue
         if word == "--input" and i + 1 < n:
@@ -411,17 +411,25 @@ def _walk_api_fields(words: list[str], payloads: list[str]) -> None:
         i += 1
 
 
-def _handle_field_assignment(arg: str, payloads: list[str]) -> None:
-    """Parse a ``-F body=value`` style argument and append the value.
+def _handle_field_assignment(arg: str, payloads: list[str], base: "Path | None") -> None:
+    """Parse a ``-F body=value`` style argument and append the resolved value.
 
     The ``body=`` prefix is required — other field names (``title=``,
-    etc.) are not body-bearing and are ignored.
+    etc.) are not body-bearing and are ignored. The value is resolved through
+    :func:`_body_file_resolution.resolve_inline_body_value` — the SAME path the
+    ``--body``/``-m``/positional-NOTE handling uses — so a ``-f body=$(cat
+    <path>)`` / ``-f body=$VAR`` field is scanned against the resolved file/var
+    content rather than the literal ``$(cat …)`` / ``$VAR`` token (a leak inside
+    the referenced file would otherwise slip onto a public repo). An
+    unresolvable indirection yields the fail-closed sentinel.
     """
+    from teatree.hooks._body_file_resolution import resolve_inline_body_value  # noqa: PLC0415
+
     if "=" not in arg:
         return
     name, _, value = arg.partition("=")
     if name == "body":
-        payloads.append(value)
+        payloads.append(resolve_inline_body_value(value, base))
 
 
 # ── Command-segment walking ─────────────────────────────────────────
@@ -463,7 +471,7 @@ def _walk_command_segment(segment: list[Token], payloads: list[str], ctx: "BodyF
     walk_body_file_flags(words, payloads, leader=first, ctx=ctx)
     # ``gh api`` / ``glab api`` field assignments.
     if first in {"gh", "glab"}:
-        _walk_api_fields(words, payloads)
+        _walk_api_fields(words, payloads, ctx.base)
     if first == "curl":
         _walk_curl_args(words, payloads)
 

--- a/tests/teatree_hooks/test_quote_scanner.py
+++ b/tests/teatree_hooks/test_quote_scanner.py
@@ -297,6 +297,14 @@ class TestBypassClosures:
         assert payload is not None
         assert "User mandate" in payload
 
+    def test_gh_api_field_body_cat_substitution_file_is_scanned(self, tmp_path: Path) -> None:
+        body_path = tmp_path / "note.md"
+        body_path.write_text("## User mandate\nship it", encoding="utf-8")
+        cmd = f'gh api repos/x/y/issues/1/comments -f body="$(cat {body_path})"'
+        payload = extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert "User mandate" in payload
+
     # --- CRITICAL #5: curl data-flag JSON parsing ---
 
     def test_curl_data_flag_json_text_field_is_parsed(self) -> None:

--- a/tests/test_hook_router_raw_review_post.py
+++ b/tests/test_hook_router_raw_review_post.py
@@ -80,6 +80,8 @@ class TestDeniesRawReviewWrites:
         reason = deny["permissionDecisionReason"]
         assert "review post-comment" in reason
         assert "post-draft-note" in reason
+        assert "update-note" in reason
+        assert "delete-discussion" in reason
         assert "draft" in reason
         assert "dedup" in reason
         assert "on-behalf approval" in reason


### PR DESCRIPTION
fix(hooks): resolve gh/glab api field body value before the leak scan

The api field-assignment handler appended a gh/glab api field body value to the publish-scan payload as the raw argv token. A field body written as a cat command-substitution or a shell-variable reference therefore scanned the unexpanded token, not the resolved file or variable content, so banned content inside the referenced file could reach a PUBLIC repo. The api field path was the only body surface not already routed through the inline-body resolver.

Route the field body value through resolve_inline_body_value (the same path the long-body, short-message, and positional-NOTE handling already use), threading the cold-hook cwd base in for the relative cat fallback. A substitution resolves to the file content (now scanned), an absent variable blocks, a present variable resolves to its value, and a plain inline field body still passes through unchanged.

Separately, the raw-api review-post deny message named only the note-create commands; add a pointer to the review update-note and delete-discussion commands for editing or removing an existing note.

Open questions and assumptions:
- assumed: the long --field/--raw-field forms share the body path with the short -f/-F forms, so all four flags are now resolved (they already shared the one handler).
- assumed: a plain literal field body must keep passing through unchanged; verified the resolver returns it verbatim.

docs: n/a - gate-internal bug fix preserving the existing publish contract.