### PR TITLE
refactor(loop): extract render_phase so run_tick is a thin named-phase pipeline (#1796)

### DIFF
--- a/src/teatree/loop/phases/__init__.py
+++ b/src/teatree/loop/phases/__init__.py
@@ -1,6 +1,7 @@
 """Named single-responsibility phases of one loop tick.
 
-``run_tick`` composes these phases instead of carrying the work inline:
+``run_tick`` is a thin pipeline that composes these phases instead of
+carrying the work inline:
 
 *   :func:`scan_phase` — the read-then-signal stage: run the scan jobs in
     parallel and collect their signals + per-scanner errors.
@@ -17,10 +18,15 @@
     claimed manifest of dispatchable work clamped to
     ``max_concurrent_auto_starts``. It only computes + claims + returns the
     manifest — spawning stays in the session/self-pump half.
+*   :func:`render_phase` — the closing stage: project the dispatched
+    actions into statusline zones, refresh the ``tick-meta.json`` /
+    ``open-prs.json`` sidecars, plan the admit budget, fold in the
+    live-loop / open-PR / loop-owner anchors, and write the statusline.
 """
 
 from teatree.loop.phases.act import act_phase
 from teatree.loop.phases.orchestrate import ManifestEntry, OrchestrationManifest, orchestrate_phase
+from teatree.loop.phases.render import render_phase
 from teatree.loop.phases.scan import ScanOutcome, scan_phase
 from teatree.loop.phases.sweep import SweepSplit, sweep_phase
 
@@ -31,6 +37,7 @@ __all__ = [
     "SweepSplit",
     "act_phase",
     "orchestrate_phase",
+    "render_phase",
     "scan_phase",
     "sweep_phase",
 ]

--- a/src/teatree/loop/phases/render.py
+++ b/src/teatree/loop/phases/render.py
@@ -1,0 +1,227 @@
+"""``render_phase`` — finalize one tick into the statusline + sidecars.
+
+The closing stage of a tick: project the dispatched actions into the
+statusline zones, refresh the ``tick-meta.json`` freshness header and the
+``open-prs.json`` cache, fold in the live-loop / open-PR / loop-owner
+anchors, and write the rendered statusline. The idle (no-jobs) tick takes
+the same closing stage with an empty zone set so even a quiet tick keeps
+the running-loops and open-PR anchors live.
+
+Splitting this out of ``run_tick`` leaves the loop's per-tick entry point a
+thin pipeline of named phases — ``sweep`` then ``scan`` then ``act`` then
+``render`` — with no inline body, so the fat monolithic tick no longer
+exists as one unit.
+"""
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from teatree.config import get_effective_settings
+from teatree.loop.domain_jobs import _identity_groups_for_overlay
+from teatree.loop.job_identity import _ScannerJob
+from teatree.loop.phases.orchestrate import orchestrate_phase
+from teatree.loop.rendering import zones_for
+from teatree.loop.statusline import StatuslineZones, render
+from teatree.loop.tick_freshness import _write_tick_meta
+
+if TYPE_CHECKING:
+    from teatree.loop.scanners.base import ScanSignal
+    from teatree.loop.tick import TickReport, TickRequest
+
+logger = logging.getLogger(__name__)
+
+
+def render_phase(
+    report: "TickReport",
+    request: "TickRequest",
+    *,
+    jobs: list[_ScannerJob],
+    statusline_path: Path | None = None,
+    colorize: bool | None = None,
+) -> None:
+    """Render the tick's statusline + sidecars onto ``report.statusline_path``.
+
+    An active tick (``jobs`` non-empty) projects the dispatched actions into
+    statusline zones, refreshes ``tick-meta.json``, plans the admit budget,
+    and surfaces any scanner errors. An idle tick (empty ``jobs``) renders an
+    empty zone set carrying only the live-loop / open-PR / loop-owner anchors
+    so a quiet tick still keeps the dashboard live. Both paths write the
+    open-PR cache, fold in the open-PR + loop-owner anchors, and render.
+    """
+    if jobs:
+        zones = zones_for(report.actions, colorize=colorize, identity_aliases=_identity_aliases_for_request(request))
+        _write_tick_meta(report.started_at, target=statusline_path)
+        _orchestrate(request, statusline_path=statusline_path)
+    else:
+        zones = StatuslineZones()
+        _populate_live_loops_in_anchors(zones, colorize=colorize)
+    _write_open_prs_cache(report.signals, target=statusline_path)
+    _populate_open_prs_in_anchors(zones, target=statusline_path, colorize=colorize)
+    if jobs and report.errors:
+        zones.action_needed.append(f"scanner errors: {', '.join(report.errors)}")
+    _populate_loop_owner_anchor(zones)
+    report.statusline_path = render(zones, target=statusline_path, colorize=colorize)
+    if not jobs:
+        _write_tick_meta(report.started_at, target=statusline_path)
+
+
+def _orchestrate(request: "TickRequest", *, statusline_path: Path | None) -> None:
+    """Plan the admit BUDGET — the read-only fan-out ceiling.
+
+    The reconciled fan-out keeps exactly ONE claim point: the live
+    ``claim_next`` CAS. ``orchestrate_phase`` is a read-only PLANNER here — it
+    never claims in the tick. Instead it computes the clamped fan-out cap and
+    persists it as a BUDGET ceiling to the tick-meta sidecar for the live
+    claimer to read.
+
+    The ``[teatree] orchestrate_claim_enabled`` toggle (default OFF) gates the
+    planner:
+
+    *   **OFF (default)** — no budget key is written (any prior one is cleared),
+        so the claimer reads UNCLAMPED. Byte-identical to before the arm.
+    *   **ON** — at a clamping speed (``full``/``boost``/``slow``) the computed
+        cap is persisted as the budget; at ``medium`` no budget key is written
+        (absence = unclamped = today's throughput). The phase never claims, so
+        there is no orphan window.
+
+    Fully fail-open — any config read, planner, or sidecar error degrades to a
+    no-op (and the toggle resolves to OFF on a settings-read error), like every
+    other tick phase. A failed budget write leaves the sidecar without the key,
+    which the reader treats as unclamped: fail-safe by construction.
+    """
+    try:
+        from teatree.config import Speed  # noqa: PLC0415
+        from teatree.loop.admit_budget import clear_admit_budget, write_admit_budget  # noqa: PLC0415
+        from teatree.loop.statusline import default_path  # noqa: PLC0415
+
+        target = statusline_path or default_path()
+        if not _orchestrate_claim_enabled():
+            clear_admit_budget(statusline_path=target)
+            return
+        manifest = orchestrate_phase(backends=request.backends, claim=False)
+        if manifest.speed is Speed.MEDIUM:
+            clear_admit_budget(statusline_path=target)
+            return
+        write_admit_budget(manifest.cap, statusline_path=target)
+    except Exception:
+        logger.exception("orchestrate_phase budget planning failed — tick continues")
+
+
+def _orchestrate_claim_enabled() -> bool:
+    """Resolve the ``orchestrate_claim_enabled`` toggle; fail OFF.
+
+    Reads the effective setting (env -> DB -> per-overlay -> global -> default).
+    Any settings-read error degrades to ``False`` so the dormant ``claim=False``
+    path is the fail-safe — the arm can never fire on a broken config read.
+    """
+    try:
+        return get_effective_settings().orchestrate_claim_enabled
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _identity_aliases_for_request(request: "TickRequest") -> tuple[tuple[str, ...], ...]:
+    """Union the identity-alias groups across every overlay in *request*.
+
+    The renderer suppresses a reassignment between two handles of the same
+    human and collapses each handle to its group's canonical name. Fails
+    open: any config-read error degrades to no suppression.
+
+    Routes through :func:`_identity_groups_for_overlay` (not the raw resolver)
+    so the self-group fallback applies on the render path too: when no explicit
+    ``identity_aliases`` is configured, the operator's ``backend.identities``
+    form one implicit self-group. Without it the render-side group was empty
+    and intra-self reassigns leaked as ``reassigned`` churn.
+    """
+    groups: list[tuple[str, ...]] = []
+    try:
+        for backend in request.backends or []:
+            groups.extend(_identity_groups_for_overlay(backend))
+    except Exception:  # noqa: BLE001
+        return ()
+    return tuple(groups)
+
+
+def _populate_live_loops_in_anchors(zones: StatuslineZones, *, colorize: bool | None = None) -> None:
+    """Append one anchor line per live LoopLease row.
+
+    Used by the idle (empty-jobs) render so even an idle tick still surfaces
+    the running loops. The active path goes through
+    :func:`teatree.loop.rendering._populate_live_loops_anchor` via
+    :func:`teatree.loop.rendering.zones_for` and must not double-populate.
+    *colorize* threads the per-loop recency coloring through.
+
+    Fails open: any import/query error degrades to a no-op.
+    """
+    try:
+        from teatree.loop.statusline import colorize_enabled, live_loops_anchor  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return
+    try:
+        zones.anchors.extend(live_loops_anchor(colorize=colorize_enabled(colorize=colorize)))
+    except Exception:  # noqa: BLE001
+        return
+
+
+def _write_open_prs_cache(signals: "list[ScanSignal]", *, target: Path | None) -> None:
+    """Snapshot the tick's open PRs to the ``open-prs.json`` sidecar.
+
+    Projects the ``my_pr.*`` signals the scanners already produced — no extra
+    code-host call — so the statusline's open-PR anchor reads a fresh cache
+    without ever hitting the API itself. Writing on every tick (even with an
+    empty signal list) keeps the cache from going stale when the last PR is
+    merged. Fails open: any import/write error degrades to a no-op so a broken
+    snapshot can never abort the tick.
+    """
+    try:
+        from teatree.loop.open_prs import open_prs_from_signals, write_open_prs_cache  # noqa: PLC0415
+        from teatree.loop.statusline import default_path  # noqa: PLC0415
+
+        write_open_prs_cache(open_prs_from_signals(signals), statusline_path=target or default_path())
+    except Exception:  # noqa: BLE001
+        return
+
+
+def _populate_open_prs_in_anchors(zones: StatuslineZones, *, target: Path | None, colorize: bool | None = None) -> None:
+    """Append the open-PR summary anchor.
+
+    Reads the snapshot :func:`_write_open_prs_cache` just wrote and folds the
+    count/list rows into the anchor zone. Must run AFTER the cache write so
+    it reflects this tick, not the previous one. Fails open: any import/read
+    error degrades to a no-op so a broken cache can never blank the statusline.
+    """
+    try:
+        from teatree.loop.open_prs import open_prs_anchor  # noqa: PLC0415
+        from teatree.loop.statusline import colorize_enabled, default_path  # noqa: PLC0415
+
+        zones.anchors.extend(
+            open_prs_anchor(target=target or default_path(), colorize=colorize_enabled(colorize=colorize))
+        )
+    except Exception:  # noqa: BLE001
+        return
+
+
+def _populate_loop_owner_anchor(zones: StatuslineZones) -> None:
+    """Append the foreign-hijack loop-owner RED line.
+
+    The live-loops anchor (the single dedicated loop line folding all live
+    LoopLease rows) is populated separately by
+    :func:`teatree.loop.rendering._populate_live_loops_anchor`. This function
+    is responsible only for the foreign-hijack RED line surfaced when a
+    different live session holds ``loop-owner``.
+
+    Fails open: any import/query error degrades to a no-op so a broken
+    loop-owner read can never blank the statusline.
+    """
+    try:
+        from teatree.core.models import LoopLease  # noqa: PLC0415
+        from teatree.loop.session_identity import current_session_id  # noqa: PLC0415
+        from teatree.loop.statusline import loop_owner_anchor  # noqa: PLC0415
+
+        status = LoopLease.objects.ownership_status("loop-owner")
+        zone, line = loop_owner_anchor(status, current_session_id())
+    except Exception:  # noqa: BLE001
+        return
+    if line:
+        getattr(zones, zone).append(line)

--- a/src/teatree/loop/tick.py
+++ b/src/teatree/loop/tick.py
@@ -1,33 +1,24 @@
-"""One tick of the fat loop: scan in parallel, dispatch, render statusline.
+"""One loop tick as a thin pipeline of named phases.
 
-The ``run_tick`` entry point is what ``t3 loop tick`` invokes. The loop
-slot itself just calls this function on a cadence; everything that needs
-testing lives here as plain Python.
+The ``run_tick`` entry point is what ``t3 loop tick`` invokes. It carries no
+work inline: it resolves the tick's scanner jobs, then composes the named
+phases in :mod:`teatree.loop.phases` — ``sweep`` then ``scan`` then ``act``
+then ``render``. Per-concern helpers live in sibling modules:
+``scanner_factories`` / ``domain_jobs`` / ``global_scanner_factories`` build
+scanner jobs, ``tick_recovery`` runs boot/tick recovery and post-dispatch
+side-effects, and ``tick_freshness`` captures the repo-freshness snapshot for
+the ``tick-meta.json`` sidecar.
 
-Per-concern helpers live in sibling modules to keep this orchestrator
-under the module-health LOC gate. ``scanner_factories`` / ``domain_jobs``
-/ ``global_scanner_factories`` build scanner jobs,
-``tick_recovery`` runs boot/tick recovery and post-dispatch
-side-effects (mechanical handlers, agent dispatch persistence), and
-``tick_freshness`` captures the repo-freshness snapshot for the
-``tick-meta.json`` sidecar.
-
-The names re-exported below are the public surface other modules and
-tests rely on — keep the re-export list in sync with downstream
-imports.
+The names re-exported below are the public surface other modules and tests
+rely on — keep the re-export list in sync with downstream imports.
 """
 
 import datetime as dt
-import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from teatree.config import (  # noqa: F401 — re-export kept live for test monkeypatch
-    discover_overlays,
-    get_effective_settings,
-    load_config,
-)
+from teatree.config import discover_overlays, load_config  # noqa: F401 — re-export kept live for test monkeypatch
 from teatree.core.backend_factory import OverlayBackends
 
 # Re-exported for downstream importers. Tests monkeypatch
@@ -38,11 +29,10 @@ from teatree.core.backend_factory import OverlayBackends
 # functions).
 from teatree.core.backend_protocols import CodeHostBackend, MessagingBackend
 from teatree.loop.dispatch import DispatchAction
-from teatree.loop.domain_jobs import _identity_groups_for_overlay, _run_job, jobs_for_domain
+from teatree.loop.domain_jobs import _run_job, jobs_for_domain
 from teatree.loop.global_scanner_factories import build_default_jobs, build_default_scanners
 from teatree.loop.job_identity import Domain, _ScannerJob
-from teatree.loop.phases import act_phase, orchestrate_phase, scan_phase, sweep_phase
-from teatree.loop.rendering import zones_for
+from teatree.loop.phases import act_phase, render_phase, scan_phase, sweep_phase
 from teatree.loop.scanner_factories import _jobs_for_backend_hosts
 from teatree.loop.scanner_factory_config import (
     _gitlab_approvals_enabled,
@@ -51,7 +41,6 @@ from teatree.loop.scanner_factory_config import (
 )
 from teatree.loop.scanners.base import Scanner, ScanSignal
 from teatree.loop.scanners.notion_view import NotionLike
-from teatree.loop.statusline import StatuslineZones, render
 from teatree.loop.tick_freshness import (
     _canonical_overlay_names,
     _collect_repo_freshness,
@@ -61,8 +50,6 @@ from teatree.loop.tick_freshness import (
 )
 from teatree.loop.tick_recovery import _execute_mechanical, _persist_agent_dispatches, _reap_stale_task_claims
 from teatree.loop.tick_resolvers import _allowed_url_prefixes_for_host, _identity_alias_groups_for_overlay
-
-logger = logging.getLogger(__name__)
 
 __all__ = [
     "DispatchAction",
@@ -140,243 +127,64 @@ def run_tick(
     now: dt.datetime | None = None,
     jobs_builder: JobsBuilder | None = None,
 ) -> TickReport:
-    """Run all scanners in parallel, dispatch, render statusline, return report.
+    """Run one loop tick as a thin pipeline of named phases.
 
-    *request.backends* takes priority over *request.host*/*messaging*:
-    passing it scans every listed overlay in one tick and prefixes signals
-    with the overlay name. Falls back to a single-overlay scan when only
-    *host*/*messaging* are provided. *now* and *statusline_path* are test
-    overrides. *colorize* defaults to ``True`` unless ``NO_COLOR`` is set
-    in the environment.
+    Resolves the tick's scanner jobs, then composes the phases:
+    :func:`~teatree.loop.phases.sweep_phase` splits the maintenance scanners
+    out of the world-scan, :func:`~teatree.loop.phases.scan_phase` fans both
+    slices out in parallel and merges their signals,
+    :func:`~teatree.loop.phases.act_phase` dispatches them into actions and
+    runs the inline mechanical handlers, and
+    :func:`~teatree.loop.phases.render_phase` writes the statusline and
+    sidecars (planning the admit budget on the way). An empty job set skips
+    straight to an idle render.
 
-    *jobs_builder* is the source of scanner jobs for the no-``scanners``
-    path. The ``loop_tick`` management command injects the registry-driven
-    fan-out (:func:`teatree.loops.fanout.build_registry_jobs`) so the
-    mini-loop registry is the single source of which scanners run a live
-    tick (#1481); the default falls back to :func:`build_default_jobs`.
-    The seam keeps :mod:`teatree.loop` from importing :mod:`teatree.loops`
-    up-stack.
-
-    The body composes the named tick phases (#1796): :func:`sweep_phase`
-    splits the maintenance scanners out of the world-scan, :func:`scan_phase`
-    fans both slices out in parallel and merges their signals,
-    :func:`act_phase` dispatches + runs mechanical handlers + persists
-    agent dispatches, and :func:`orchestrate_phase` runs the speed-driven
-    autonomous fan-out (a no-op at the default ``medium`` speed).
+    *request.backends* takes priority over *request.host*/*messaging*: passing
+    it scans every listed overlay in one tick and prefixes signals with the
+    overlay name. *now* and *statusline_path* are test overrides; *colorize*
+    defaults to ``True`` unless ``NO_COLOR`` is set. *jobs_builder* is the
+    source of scanner jobs for the no-``scanners`` path: the ``loop_tick``
+    management command injects the registry-driven fan-out
+    (:func:`teatree.loops.fanout.build_registry_jobs`) so the mini-loop
+    registry is the single source of which scanners run a live tick; the
+    default falls back to :func:`build_default_jobs`. The seam keeps
+    :mod:`teatree.loop` from importing :mod:`teatree.loops` up-stack.
     """
     request = request or TickRequest()
     started_at = now or dt.datetime.now(dt.UTC)
     _reap_stale_task_claims()
-    if request.scanners is not None:
-        jobs = [_ScannerJob(scanner=s, overlay="") for s in request.scanners]
-    elif jobs_builder is not None:
-        jobs = jobs_builder(request, started_at)
-    else:
-        jobs = build_default_jobs(
-            backends=request.backends,
-            host=request.host,
-            messaging=request.messaging,
-            notion_client=request.notion_client,
-            ready_labels=request.ready_labels,
-        )
+    jobs = _resolve_jobs(request, started_at, jobs_builder)
     report = TickReport(started_at=started_at)
-
-    if not jobs:
-        empty_zones = StatuslineZones()
-        _populate_live_loops_in_anchors(empty_zones, colorize=colorize)
-        _write_open_prs_cache(report.signals, target=statusline_path)
-        _populate_open_prs_in_anchors(empty_zones, target=statusline_path, colorize=colorize)
-        _populate_loop_owner_anchor(empty_zones)
-        report.statusline_path = render(
-            empty_zones,
-            target=statusline_path,
-            colorize=colorize,
-        )
-        _write_tick_meta(started_at, target=statusline_path)
-        return report
-
-    split = sweep_phase(jobs)
-    outcome = scan_phase(split.scan_jobs + split.sweep_jobs)
-    report.signals.extend(outcome.signals)
-    report.errors.update(outcome.errors)
-
-    act_phase(report)
-
-    zones = zones_for(report.actions, colorize=colorize, identity_aliases=_identity_aliases_for_request(request))
-    _write_tick_meta(started_at, target=statusline_path)
-    # #1796 (WI-1): plan the admit budget AFTER the freshness header write —
-    # the planner MERGES its key into tick-meta.json, so running it after
-    # ``_write_tick_meta`` (a full overwrite) keeps both. Never claims in the
-    # tick: the live ``claim_next`` is the single claim point.
-    _orchestrate(request, statusline_path=statusline_path)
-    _write_open_prs_cache(report.signals, target=statusline_path)
-    _populate_open_prs_in_anchors(zones, target=statusline_path, colorize=colorize)
-    if report.errors:
-        zones.action_needed.append(f"scanner errors: {', '.join(report.errors)}")
-    _populate_loop_owner_anchor(zones)
-    report.statusline_path = render(zones, target=statusline_path, colorize=colorize)
+    if jobs:
+        split = sweep_phase(jobs)
+        outcome = scan_phase(split.scan_jobs + split.sweep_jobs)
+        report.signals.extend(outcome.signals)
+        report.errors.update(outcome.errors)
+        act_phase(report)
+    render_phase(
+        report,
+        request,
+        jobs=jobs,
+        statusline_path=statusline_path,
+        colorize=colorize,
+    )
     return report
 
 
-def _orchestrate(request: TickRequest, *, statusline_path: Path | None) -> None:
-    """Plan the admit BUDGET — the read-only fan-out ceiling (#1796, WI-1).
-
-    The reconciled fan-out keeps exactly ONE claim point: the live
-    ``claim_next`` CAS. ``orchestrate_phase`` is a read-only PLANNER here — it
-    never claims in the tick (the old ``claim=True`` arm orphaned claims the
-    live claimer also took). Instead it computes the clamped fan-out cap and
-    persists it as a BUDGET ceiling to the tick-meta sidecar for the live
-    claimer to read.
-
-    The ``[teatree] orchestrate_claim_enabled`` toggle (existing accessor,
-    default OFF) gates the planner:
-
-    *   **OFF (default)** — no budget key is written (any prior one is cleared),
-        so the claimer reads UNCLAMPED. Byte-identical to before the arm.
-    *   **ON** — at a clamping speed (``full``/``boost``/``slow``) the computed
-        cap is persisted as the budget; at ``medium`` no budget key is written
-        (absence = unclamped = today's throughput). The phase never claims, so
-        there is no orphan window.
-
-    Fully fail-open — any config read, planner, or sidecar error degrades to a
-    no-op (and the toggle resolves to OFF on a settings-read error), like every
-    other tick phase. A failed budget write leaves the sidecar without the key,
-    which the reader treats as unclamped: fail-safe by construction.
-    """
-    try:
-        from teatree.config import Speed  # noqa: PLC0415
-        from teatree.loop.admit_budget import clear_admit_budget, write_admit_budget  # noqa: PLC0415
-        from teatree.loop.statusline import default_path  # noqa: PLC0415
-
-        target = statusline_path or default_path()
-        if not _orchestrate_claim_enabled():
-            clear_admit_budget(statusline_path=target)
-            return
-        manifest = orchestrate_phase(backends=request.backends, claim=False)
-        if manifest.speed is Speed.MEDIUM:
-            clear_admit_budget(statusline_path=target)
-            return
-        write_admit_budget(manifest.cap, statusline_path=target)
-    except Exception:
-        logger.exception("orchestrate_phase budget planning failed — tick continues")
-
-
-def _orchestrate_claim_enabled() -> bool:
-    """Resolve the ``orchestrate_claim_enabled`` toggle; fail OFF (#1796).
-
-    Reads the effective setting (env -> DB -> per-overlay -> global -> default).
-    Any settings-read error degrades to ``False`` so the dormant ``claim=False``
-    path is the fail-safe — the arm can never fire on a broken config read.
-    """
-    try:
-        return get_effective_settings().orchestrate_claim_enabled
-    except Exception:  # noqa: BLE001
-        return False
-
-
-def _identity_aliases_for_request(request: TickRequest) -> tuple[tuple[str, ...], ...]:
-    """Union the identity-alias groups across every overlay in *request*.
-
-    The renderer suppresses a reassignment between two handles of the same
-    human and collapses each handle to its group's canonical name. Fails
-    open: any config-read error degrades to no suppression.
-
-    Routes through :func:`_identity_groups_for_overlay` (not the raw
-    resolver) so the #1113 self-group fallback applies on the render path
-    too: when no explicit ``identity_aliases`` is configured, the operator's
-    ``backend.identities`` (← ``user_identity_aliases``; the accessor #1773's
-    ``TrustedIdentity`` will sit behind) form one implicit self-group.
-    Without it the render-side group was empty and intra-self reassigns
-    leaked as ``reassigned`` churn.
-    """
-    groups: list[tuple[str, ...]] = []
-    try:
-        for backend in request.backends or []:
-            groups.extend(_identity_groups_for_overlay(backend))
-    except Exception:  # noqa: BLE001
-        return ()
-    return tuple(groups)
-
-
-def _populate_live_loops_in_anchors(zones: StatuslineZones, *, colorize: bool | None = None) -> None:
-    """Append one anchor line per live LoopLease row (#1156).
-
-    Used by the empty-jobs path in :func:`run_tick` so even an idle tick
-    still surfaces the running loops. The non-empty path goes through
-    :func:`teatree.loop.rendering._populate_live_loops_anchor` via
-    :func:`teatree.loop.rendering.zones_for` and must not double-populate.
-    *colorize* threads the per-loop recency coloring through.
-
-    Fails open: any import/query error degrades to a no-op.
-    """
-    try:
-        from teatree.loop.statusline import colorize_enabled, live_loops_anchor  # noqa: PLC0415
-    except Exception:  # noqa: BLE001
-        return
-    try:
-        zones.anchors.extend(live_loops_anchor(colorize=colorize_enabled(colorize=colorize)))
-    except Exception:  # noqa: BLE001
-        return
-
-
-def _write_open_prs_cache(signals: list[ScanSignal], *, target: Path | None) -> None:
-    """Snapshot the tick's open PRs to the ``open-prs.json`` sidecar (#271).
-
-    Projects the ``my_pr.*`` signals the scanners already produced — no extra
-    code-host call — so the statusline's open-PR anchor reads a fresh cache
-    without ever hitting the API itself. Writing on every tick (even with an
-    empty signal list) keeps the cache from going stale when the last PR is
-    merged. Fails open: any import/write error degrades to a no-op so a broken
-    snapshot can never abort the tick.
-    """
-    try:
-        from teatree.loop.open_prs import open_prs_from_signals, write_open_prs_cache  # noqa: PLC0415
-        from teatree.loop.statusline import default_path  # noqa: PLC0415
-
-        write_open_prs_cache(open_prs_from_signals(signals), statusline_path=target or default_path())
-    except Exception:  # noqa: BLE001
-        return
-
-
-def _populate_open_prs_in_anchors(zones: StatuslineZones, *, target: Path | None, colorize: bool | None = None) -> None:
-    """Append the open-PR summary anchor (#271).
-
-    Reads the snapshot :func:`_write_open_prs_cache` just wrote and folds the
-    count/list rows into the anchor zone. Must run AFTER the cache write so
-    it reflects this tick, not the previous one. Fails open: any import/read
-    error degrades to a no-op so a broken cache can never blank the statusline.
-    """
-    try:
-        from teatree.loop.open_prs import open_prs_anchor  # noqa: PLC0415
-        from teatree.loop.statusline import colorize_enabled, default_path  # noqa: PLC0415
-
-        zones.anchors.extend(
-            open_prs_anchor(target=target or default_path(), colorize=colorize_enabled(colorize=colorize))
-        )
-    except Exception:  # noqa: BLE001
-        return
-
-
-def _populate_loop_owner_anchor(zones: StatuslineZones) -> None:
-    """Append the #1073 foreign-hijack loop-owner RED line.
-
-    The live-loops anchor (the single dedicated loop line folding all live
-    LoopLease rows) is populated separately by
-    :func:`teatree.loop.rendering._populate_live_loops_anchor` (#1163, #1184, #130).
-    This function is responsible only for the #1073 foreign-hijack RED line
-    surfaced when a different live session holds ``loop-owner``.
-
-    Fails open: any import/query error degrades to a no-op so a broken
-    loop-owner read can never blank the statusline.
-    """
-    try:
-        from teatree.core.models import LoopLease  # noqa: PLC0415
-        from teatree.loop.session_identity import current_session_id  # noqa: PLC0415
-        from teatree.loop.statusline import loop_owner_anchor  # noqa: PLC0415
-
-        status = LoopLease.objects.ownership_status("loop-owner")
-        zone, line = loop_owner_anchor(status, current_session_id())
-    except Exception:  # noqa: BLE001
-        return
-    if line:
-        getattr(zones, zone).append(line)
+def _resolve_jobs(
+    request: TickRequest,
+    started_at: dt.datetime,
+    jobs_builder: JobsBuilder | None,
+) -> list[_ScannerJob]:
+    """Pick the tick's scanner jobs: explicit scanners, an injected builder, or the default fan-out."""
+    if request.scanners is not None:
+        return [_ScannerJob(scanner=s, overlay="") for s in request.scanners]
+    if jobs_builder is not None:
+        return jobs_builder(request, started_at)
+    return build_default_jobs(
+        backends=request.backends,
+        host=request.host,
+        messaging=request.messaging,
+        notion_client=request.notion_client,
+        ready_labels=request.ready_labels,
+    )

--- a/tests/teatree_loop/phases/test_render.py
+++ b/tests/teatree_loop/phases/test_render.py
@@ -1,0 +1,166 @@
+"""Tests for ``teatree.loop.phases.render`` — the closing statusline phase."""
+
+import datetime as dt
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from teatree.loop.dispatch import dispatch
+from teatree.loop.job_identity import _ScannerJob
+from teatree.loop.phases import render_phase
+from teatree.loop.phases.render import _identity_aliases_for_request
+from teatree.loop.scanners.base import ScanSignal
+from teatree.loop.tick import TickReport, TickRequest
+
+_NOW = dt.datetime(2026, 6, 16, tzinfo=dt.UTC)
+
+
+@dataclass(slots=True)
+class _NamedScanner:
+    name: str
+
+    def scan(self) -> list[ScanSignal]:
+        return []
+
+
+def _job(name: str) -> _ScannerJob:
+    return _ScannerJob(scanner=_NamedScanner(name=name), overlay="")
+
+
+def test_render_phase_is_a_named_loop_phase() -> None:
+    from teatree.loop import phases  # noqa: PLC0415
+
+    assert "render_phase" in phases.__all__
+
+
+def test_render_phase_writes_active_statusline_and_sidecars(tmp_path: Path) -> None:
+    sl = tmp_path / "statusline.txt"
+    report = TickReport(started_at=_NOW, signals=[ScanSignal(kind="my_pr.open", summary="x")])
+    report.actions = dispatch(report.signals, errors=report.errors)
+
+    render_phase(
+        report,
+        TickRequest(),
+        jobs=[_job("my_prs")],
+        statusline_path=sl,
+        colorize=False,
+    )
+
+    assert report.statusline_path == sl
+    assert sl.is_file()
+    assert sl.with_name("tick-meta.json").is_file()
+    assert sl.with_name("open-prs.json").is_file()
+
+
+def test_render_phase_surfaces_scanner_errors_in_active_render(tmp_path: Path) -> None:
+    sl = tmp_path / "statusline.txt"
+    report = TickReport(started_at=_NOW, errors={"my_prs": "boom"})
+
+    render_phase(report, TickRequest(), jobs=[_job("my_prs")], statusline_path=sl, colorize=False)
+
+    assert "scanner errors: my_prs" in sl.read_text(encoding="utf-8")
+
+
+def test_render_phase_idle_renders_statusline_without_jobs(tmp_path: Path) -> None:
+    sl = tmp_path / "statusline.txt"
+    report = TickReport(started_at=_NOW)
+
+    render_phase(report, TickRequest(), jobs=[], statusline_path=sl, colorize=False)
+
+    assert report.statusline_path == sl
+    assert sl.is_file()
+    assert sl.with_name("tick-meta.json").is_file()
+
+
+def test_render_phase_idle_omits_scanner_error_line(tmp_path: Path) -> None:
+    sl = tmp_path / "statusline.txt"
+    report = TickReport(started_at=_NOW, errors={"my_prs": "boom"})
+
+    render_phase(report, TickRequest(), jobs=[], statusline_path=sl, colorize=False)
+
+    assert "scanner errors" not in sl.read_text(encoding="utf-8")
+
+
+def test_identity_aliases_for_request_unions_across_backends(monkeypatch: pytest.MonkeyPatch) -> None:
+    from unittest.mock import MagicMock  # noqa: PLC0415
+
+    from teatree.core.backend_factory import OverlayBackends  # noqa: PLC0415
+    from teatree.core.backend_protocols import CodeHostBackend  # noqa: PLC0415
+    from teatree.core.overlay import OverlayBase  # noqa: PLC0415
+
+    def _backend(name: str, aliases: list[list[str]]) -> OverlayBackends:
+        overlay = MagicMock(spec=OverlayBase)
+        overlay.config = MagicMock()
+        overlay.config.identity_aliases = aliases
+        return OverlayBackends(
+            name=name,
+            hosts=(MagicMock(spec=CodeHostBackend),),
+            messaging=None,
+            ready_labels=(),
+            overlay=overlay,
+        )
+
+    monkeypatch.setattr("teatree.loop.tick_resolvers.discover_overlays", list)
+    request = TickRequest(
+        backends=[
+            _backend("teatree", [["souliane", "op-alt", "op.work"]]),
+            _backend("acme", [["alice", "alice.work"]]),
+        ],
+    )
+    assert _identity_aliases_for_request(request) == (
+        ("souliane", "op-alt", "op.work"),
+        ("alice", "alice.work"),
+    )
+
+
+def test_identity_aliases_for_request_falls_back_to_operator_identities(monkeypatch: pytest.MonkeyPatch) -> None:
+    from unittest.mock import MagicMock  # noqa: PLC0415
+
+    from teatree.core.backend_factory import OverlayBackends  # noqa: PLC0415
+    from teatree.core.backend_protocols import CodeHostBackend  # noqa: PLC0415
+    from teatree.core.overlay import OverlayBase  # noqa: PLC0415
+
+    overlay = MagicMock(spec=OverlayBase)
+    overlay.config = MagicMock()
+    overlay.config.identity_aliases = []
+    backend = OverlayBackends(
+        name="teatree",
+        hosts=(MagicMock(spec=CodeHostBackend),),
+        messaging=None,
+        ready_labels=(),
+        overlay=overlay,
+        identities=("souliane", "op-gh", "op-gl"),
+    )
+    monkeypatch.setattr("teatree.loop.tick_resolvers.discover_overlays", list)
+    assert _identity_aliases_for_request(TickRequest(backends=[backend])) == (("souliane", "op-gh", "op-gl"),)
+
+
+def test_identity_aliases_for_request_empty_without_backends() -> None:
+    assert _identity_aliases_for_request(TickRequest()) == ()
+
+
+def test_identity_aliases_for_request_fails_open_on_config_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from unittest.mock import MagicMock  # noqa: PLC0415
+
+    from teatree.core.backend_factory import OverlayBackends  # noqa: PLC0415
+    from teatree.core.backend_protocols import CodeHostBackend  # noqa: PLC0415
+    from teatree.loop.phases import render as render_mod  # noqa: PLC0415
+
+    def _boom(*_args: object, **_kwargs: object) -> object:
+        msg = "config read failed"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(render_mod, "_identity_groups_for_overlay", _boom)
+    request = TickRequest(
+        backends=[
+            OverlayBackends(
+                name="acme",
+                hosts=(MagicMock(spec=CodeHostBackend),),
+                messaging=None,
+                ready_labels=(),
+                overlay=None,
+            ),
+        ],
+    )
+    assert _identity_aliases_for_request(request) == ()

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -398,115 +398,6 @@ def test_identity_alias_groups_reads_overlay_config_first(
     )
 
 
-def test_identity_aliases_for_request_unions_across_backends(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """``_identity_aliases_for_request`` unions every overlay's alias groups.
-
-    The renderer suppresses a self-reassignment only when both ends fall
-    inside one group; collecting every overlay's groups means the operator's
-    own handles suppress regardless of which overlay surfaced the reassign.
-    """
-    from unittest.mock import MagicMock  # noqa: PLC0415
-
-    from teatree.core.backend_factory import OverlayBackends  # noqa: PLC0415
-    from teatree.core.backend_protocols import CodeHostBackend  # noqa: PLC0415
-    from teatree.core.overlay import OverlayBase  # noqa: PLC0415
-    from teatree.loop.tick import TickRequest, _identity_aliases_for_request  # noqa: PLC0415
-
-    def _backend(name: str, aliases: list[list[str]]) -> OverlayBackends:
-        overlay = MagicMock(spec=OverlayBase)
-        overlay.config = MagicMock()
-        overlay.config.identity_aliases = aliases
-        return OverlayBackends(
-            name=name,
-            hosts=(MagicMock(spec=CodeHostBackend),),
-            messaging=None,
-            ready_labels=(),
-            overlay=overlay,
-        )
-
-    monkeypatch.setattr("teatree.loop.tick_resolvers.discover_overlays", list)
-    request = TickRequest(
-        backends=[
-            _backend("teatree", [["souliane", "op-alt", "op.work"]]),
-            _backend("acme", [["alice", "alice.work"]]),
-        ],
-    )
-    assert _identity_aliases_for_request(request) == (
-        ("souliane", "op-alt", "op.work"),
-        ("alice", "alice.work"),
-    )
-
-
-def test_identity_aliases_for_request_falls_back_to_operator_identities(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """No explicit ``identity_aliases`` → ``backend.identities`` is the self-group (#1113).
-
-    The deployment that surfaced the noise configures only the flat
-    ``user_identity_aliases`` (→ ``backend.identities``), never the grouped
-    ``identity_aliases``. The render path must apply the same self-group
-    fallback the scanner path already had, or every intra-self reassignment
-    between the operator's own handles renders as ``reassigned`` churn.
-    """
-    from unittest.mock import MagicMock  # noqa: PLC0415
-
-    from teatree.core.backend_factory import OverlayBackends  # noqa: PLC0415
-    from teatree.core.backend_protocols import CodeHostBackend  # noqa: PLC0415
-    from teatree.core.overlay import OverlayBase  # noqa: PLC0415
-    from teatree.loop.tick import TickRequest, _identity_aliases_for_request  # noqa: PLC0415
-
-    overlay = MagicMock(spec=OverlayBase)
-    overlay.config = MagicMock()
-    overlay.config.identity_aliases = []  # no grouped aliases configured
-    backend = OverlayBackends(
-        name="teatree",
-        hosts=(MagicMock(spec=CodeHostBackend),),
-        messaging=None,
-        ready_labels=(),
-        overlay=overlay,
-        identities=("souliane", "op-gh", "op-gl"),
-    )
-    monkeypatch.setattr("teatree.loop.tick_resolvers.discover_overlays", list)
-    assert _identity_aliases_for_request(TickRequest(backends=[backend])) == (("souliane", "op-gh", "op-gl"),)
-
-
-def test_identity_aliases_for_request_empty_without_backends() -> None:
-    from teatree.loop.tick import TickRequest, _identity_aliases_for_request  # noqa: PLC0415
-
-    assert _identity_aliases_for_request(TickRequest()) == ()
-
-
-def test_identity_aliases_for_request_fails_open_on_config_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from unittest.mock import MagicMock  # noqa: PLC0415
-
-    from teatree.core.backend_factory import OverlayBackends  # noqa: PLC0415
-    from teatree.core.backend_protocols import CodeHostBackend  # noqa: PLC0415
-    from teatree.loop import tick as tick_mod  # noqa: PLC0415
-    from teatree.loop.tick import TickRequest, _identity_aliases_for_request  # noqa: PLC0415
-
-    def _boom(*_args: object, **_kwargs: object) -> object:
-        msg = "config read failed"
-        raise RuntimeError(msg)
-
-    monkeypatch.setattr(tick_mod, "_identity_alias_groups_for_overlay", _boom)
-    request = TickRequest(
-        backends=[
-            OverlayBackends(
-                name="acme",
-                hosts=(MagicMock(spec=CodeHostBackend),),
-                messaging=None,
-                ready_labels=(),
-                overlay=None,
-            ),
-        ],
-    )
-    assert _identity_aliases_for_request(request) == ()
-
-
 def test_identity_alias_groups_falls_through_to_toml_override(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1548,8 +1439,8 @@ class TestRunTickOrchestrateIsDormant(django.test.TestCase):
         scanner = _FixedScanner(name="s", out=[ScanSignal(kind="my_pr.open", summary="x")])
         with (
             tempfile.TemporaryDirectory() as d,
-            patch("teatree.loop.tick.get_effective_settings", return_value=settings),
-            patch("teatree.loop.tick.orchestrate_phase", side_effect=RuntimeError("config blew up")),
+            patch("teatree.loop.phases.render.get_effective_settings", return_value=settings),
+            patch("teatree.loop.phases.render.orchestrate_phase", side_effect=RuntimeError("config blew up")),
         ):
             sl = Path(d) / "sl.txt"
             report = run_tick(TickRequest(scanners=[scanner]), statusline_path=sl)
@@ -1588,7 +1479,7 @@ class TestRunTickOrchestrateClaimToggle(django.test.TestCase):
         backends = [OverlayBackends(name="acme", max_concurrent_auto_starts=2)]
         with (
             patch("teatree.loop.phases.orchestrate.get_effective_settings", return_value=settings),
-            patch("teatree.loop.tick.get_effective_settings", return_value=settings),
+            patch("teatree.loop.phases.render.get_effective_settings", return_value=settings),
         ):
             scanner = _FixedScanner(name="s", out=[ScanSignal(kind="my_pr.open", summary="x")])
             run_tick(TickRequest(scanners=[scanner], backends=backends), statusline_path=sl)


### PR DESCRIPTION
## What

Finishes the loop-split for #1796: `run_tick` is now a thin pipeline of named
single-responsibility phases with **no inline body**, so the per-tick loop no
longer exists as one fat unit.

The remaining inline statusline / sidecar work is extracted into a fifth named
phase, **`render_phase`** (`teatree.loop.phases.render`). `run_tick` reduces to:

```
reap stale claims -> resolve jobs -> (sweep -> scan -> act) -> render
```

## What was already done vs. what this adds

- The **core split** landed via #2333: `orchestrate_phase` is a read-only
  admit-budget planner, the single claim point (`claim-next`) enforces the
  budget, and default/medium speed stay byte-identical.
- The loop-tach sub-layering umbrella (#2413) is separate; its carve is **not a
  blocker** for #1796. This PR keeps the intra-loop deferred-import ratchet
  unchanged at **36** (moved imports stay function-scoped).
- This PR adds the missing decomposition: `render_phase` + a thin `run_tick`,
  so the fat monolithic tick is retired.

## Behaviour-preserving

The ordering is identical to the old inline body — including the subtle
`tick-meta.json` freshness write happening **before** the admit-budget merge so
the planner key survives the full overwrite. `render_phase` handles both the
active path (zones from dispatched actions, freshness header, budget, scanner
errors) and the idle/no-jobs path (empty zones with the live-loop / open-PR /
loop-owner anchors). `PrSweepScanner` stays routed through the sweep slice.

## Tests

- New `tests/teatree_loop/phases/test_render.py` covers `render_phase`
  (active + idle) and the relocated identity-alias helper tests.
- `test_tick.py` keeps the `run_tick` integration + orchestrate-budget tests;
  the budget-toggle patch targets repoint at `teatree.loop.phases.render`.
- Wire-compat shim (`run_tick` signature / `TickReport` shape) stays green.

## Gates (local)

- `ruff check` / `ruff format --check`: pass
- `t3 tool verify-gates`: all stages green (tach, import-linter, ty-check,
  banned-terms, near-zero-comments, generated docs, module health)
- `scripts/hooks/check_module_health.py --from-ref origin/main`: exit 0
- Intra-loop deferred-import ratchet: unchanged at 36
- Full suite: the only failure is the pre-existing, unrelated
  `test_per_item_fault_isolation_1597` SlackBroadcastsScanner ordering flake —
  reproduced identically on a clean tree (changes stashed), so it is not from
  this diff.

## Residual

The literal symbol/CLI rename (`run_tick` / `TickReport` / `TickRequest` /
the `t3 loop tick` verb) is intentionally left out: per the issue owner it is a
high-blast-radius cosmetic change best done as a separate alias-and-deprecate
step. With this PR, #1796's substantive remaining work — retiring the fat
monolith into named phases — is complete.
