### PR TITLE
fix(workspace): cleanup sweeps fail open per-row on an unloadable overlay (#2472)

### DIFF
--- a/src/teatree/core/management/commands/_workspace_cleanup.py
+++ b/src/teatree/core/management/commands/_workspace_cleanup.py
@@ -11,11 +11,18 @@ from fnmatch import fnmatch
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from django.core.exceptions import ImproperlyConfigured
+
 from teatree.config import get_effective_settings
-from teatree.core.cleanup import _branch_tree_matches_squash, _ref_captured_by_merge, _remote_tracking_ref_exists
+from teatree.core.cleanup import (
+    _branch_tree_matches_squash,
+    _ref_captured_by_merge,
+    _remote_tracking_ref_exists,
+    cleanup_worktree,
+)
 from teatree.core.clone_paths import resolve_clone_path
 from teatree.core.management.commands._workspace_reap import reap_one_worktree
-from teatree.core.models import Worktree
+from teatree.core.models import Ticket, Worktree
 from teatree.core.worktree_env import CACHE_DIRNAME, CACHE_FILENAME, write_env_cache
 from teatree.utils import git
 from teatree.utils.db import drop_db
@@ -591,4 +598,32 @@ def _fix_drift(drift: "Drift") -> list[str]:
         for m in drift.missing_dbs
     )
 
+    fixes.extend(
+        f"unresolvable overlay {u.overlay!r} on wt#{u.worktree_pk} — not installed here; "
+        f"reinstall it or remove the row (its docker/DB can't be reconciled without the overlay)"
+        for u in drift.unresolvable_overlays
+    )
+
     return fixes
+
+
+def clean_merged_worktrees() -> list[str]:
+    """Tear down every worktree whose ticket is already MERGED.
+
+    Fails open per row: a worktree whose overlay is not installed in this
+    environment is SKIPPED (recorded) rather than aborting the whole sweep
+    (#2472); a teardown ``RuntimeError`` is reported as FAILED. Errors are
+    surfaced inline — no suppression.
+    """
+    cleaned: list[str] = []
+    for ticket in Ticket.objects.filter(state=Ticket.State.MERGED):
+        for wt in Worktree.objects.filter(ticket=ticket):
+            try:
+                cleaned.append(str(cleanup_worktree(wt, strict_hygiene=False)))
+            except ImproperlyConfigured as exc:
+                cleaned.append(f"SKIPPED {wt.repo_path} ({wt.branch}): overlay not installed here — {exc}")
+            except RuntimeError as exc:
+                cleaned.append(f"FAILED {wt.repo_path} ({wt.branch}): {exc}")
+    if not cleaned:
+        return ["No merged tickets have lingering worktrees."]
+    return cleaned

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -12,7 +12,6 @@ from django_fsm import can_proceed
 from django_typer.management import TyperCommand, command
 
 from teatree.config import load_config
-from teatree.core.cleanup import cleanup_worktree
 from teatree.core.dev_repo import resolve_repo_names
 from teatree.core.gates.local_stack_gate import acquire_or_enqueue
 from teatree.core.gates.orphan_guard import find_orphans_in_workspace
@@ -22,6 +21,7 @@ from teatree.core.management.commands._workspace_cleanup import (
     _die,
     _fix_drift,
     _raise_on_cleanup_failures,
+    clean_merged_worktrees,
     drop_orphan_databases,
     drop_orphaned_stashes,
     is_clean_ignored,
@@ -456,20 +456,7 @@ class Command(TyperCommand):
         cleanup silently failed and stale docker containers, branches, or
         databases linger. Errors are surfaced inline — no suppression.
         """
-        cleaned: list[str] = []
-        merged_tickets = Ticket.objects.filter(state=Ticket.State.MERGED)
-        for ticket in merged_tickets:
-            worktrees = list(Worktree.objects.filter(ticket=ticket))
-            if not worktrees:
-                continue
-            for wt in worktrees:
-                try:
-                    cleaned.append(str(cleanup_worktree(wt, strict_hygiene=False)))
-                except RuntimeError as exc:
-                    cleaned.append(f"FAILED {wt.repo_path} ({wt.branch}): {exc}")
-        if not cleaned:
-            return ["No merged tickets have lingering worktrees."]
-        return cleaned
+        return clean_merged_worktrees()
 
     @command()
     def doctor(

--- a/src/teatree/core/reconcile.py
+++ b/src/teatree/core/reconcile.py
@@ -13,6 +13,8 @@ and refuses when drift is present.
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from django.core.exceptions import ImproperlyConfigured
+
 from teatree.config import load_config
 from teatree.core.clone_paths import resolve_clone_path
 from teatree.core.models import Ticket, Worktree
@@ -78,6 +80,21 @@ class MissingDB:
 
 
 @dataclass(frozen=True, slots=True)
+class UnresolvableOverlay:
+    """Worktree row references an overlay not installed in this environment.
+
+    Surfacing-only: the overlay's docker/DB stores can't be reconciled without
+    the overlay, but recording the finding keeps the sweep from aborting on the
+    row — the overlay-independent checks still apply, and other tickets are
+    still reconciled.
+    """
+
+    worktree_pk: int
+    overlay: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
 class Drift:
     """Bundle of per-store findings for a ticket.
 
@@ -93,6 +110,7 @@ class Drift:
     missing_env_caches: list[MissingEnvCache] = field(default_factory=list)
     env_cache_drifts: list[EnvCacheDrift] = field(default_factory=list)
     missing_dbs: list[MissingDB] = field(default_factory=list)
+    unresolvable_overlays: list[UnresolvableOverlay] = field(default_factory=list)
 
     @property
     def has_drift(self) -> bool:
@@ -105,6 +123,7 @@ class Drift:
                 self.missing_env_caches,
                 self.env_cache_drifts,
                 self.missing_dbs,
+                self.unresolvable_overlays,
             ),
         )
 
@@ -118,6 +137,10 @@ class Drift:
             *(f"missing-env-cache: wt#{d.worktree_pk} {d.cache_path}" for d in self.missing_env_caches),
             *(f"env-cache-drift: wt#{d.worktree_pk} {d.cache_path}" for d in self.env_cache_drifts),
             *(f"missing-db: wt#{d.worktree_pk} {d.db_name}" for d in self.missing_dbs),
+            *(
+                f"unresolvable-overlay: wt#{u.worktree_pk} {u.overlay!r} ({u.reason})"
+                for u in self.unresolvable_overlays
+            ),
         ]
         return "\n".join(lines) or "(no drift)"
 
@@ -162,7 +185,13 @@ def _find_worktree_paths_on_disk(repo_main: Path) -> set[str]:
 
 
 def _reconcile_worktree_row(drift: Drift, wt: Worktree) -> None:
-    """Append findings for a single ``Worktree`` row to *drift*."""
+    """Append findings for a single ``Worktree`` row to *drift*.
+
+    The overlay-independent missing-dir check always runs. The overlay-dependent
+    stores (env cache, DB, containers) are isolated: a row whose overlay is not
+    installed in this environment degrades to an :class:`UnresolvableOverlay`
+    finding instead of aborting the whole sweep.
+    """
     extra = wt.extra or {}
     wt_path_str = extra.get("worktree_path", "")
     wt_path = Path(wt_path_str) if wt_path_str else None
@@ -170,6 +199,16 @@ def _reconcile_worktree_row(drift: Drift, wt: Worktree) -> None:
     if wt_path and not wt_path.is_dir():
         drift.missing_worktree_dirs.append(MissingWorktreeDir(worktree_pk=wt.pk, path=wt_path))
 
+    try:
+        _reconcile_overlay_dependent_stores(drift, wt)
+    except ImproperlyConfigured as exc:
+        drift.unresolvable_overlays.append(
+            UnresolvableOverlay(worktree_pk=wt.pk, overlay=wt.overlay or wt.ticket.overlay, reason=str(exc)),
+        )
+
+
+def _reconcile_overlay_dependent_stores(drift: Drift, wt: Worktree) -> None:
+    """Append findings whose detection needs the worktree's overlay (env cache, DB, containers)."""
     if render_env_cache(wt) is not None:
         drifted, cache_path = detect_drift(wt)
         if drifted and cache_path is not None:

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -1869,7 +1869,9 @@ class TestWorkspaceCleanMerged(TestCase):
         other = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/71")
         Worktree.objects.create(overlay="test", ticket=other, repo_path="repo2", branch="ac-repo2-71")
 
-        with patch.object(workspace_mod, "cleanup_worktree", return_value="Cleaned: repo (ac-repo-70)") as mock_cleanup:
+        with patch.object(
+            ws_cleanup_mod, "cleanup_worktree", return_value="Cleaned: repo (ac-repo-70)"
+        ) as mock_cleanup:
             cleaned = cast("list[str]", call_command("workspace", "clean-merged"))
 
         assert cleaned == ["Cleaned: repo (ac-repo-70)"]
@@ -1890,10 +1892,26 @@ class TestWorkspaceCleanMerged(TestCase):
         )
         Worktree.objects.create(overlay="test", ticket=merged, repo_path="repo", branch="ac-repo-72")
 
-        with patch.object(workspace_mod, "cleanup_worktree", side_effect=RuntimeError("docker down failed")):
+        with patch.object(ws_cleanup_mod, "cleanup_worktree", side_effect=RuntimeError("docker down failed")):
             cleaned = cast("list[str]", call_command("workspace", "clean-merged"))
 
         assert any("FAILED" in c and "docker down failed" in c for c in cleaned)
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_skips_worktree_whose_overlay_is_not_installed(self) -> None:
+        # A merged row for an overlay not installed in this environment must be
+        # SKIPPED per row, not abort the whole sweep (#2472).
+        merged = Ticket.objects.create(
+            overlay="t3-ghost",
+            issue_url="https://example.com/issues/73",
+            state=Ticket.State.MERGED,
+        )
+        Worktree.objects.create(overlay="t3-ghost", ticket=merged, repo_path="repo", branch="ac-repo-73")
+
+        cleaned = cast("list[str]", call_command("workspace", "clean-merged"))
+
+        assert any("SKIPPED" in c and "overlay" in c.lower() for c in cleaned)
 
 
 def _subprocess_side_effect(gh_stdout: str, glab_stdout: str):

--- a/tests/teatree_core/test_reconcile.py
+++ b/tests/teatree_core/test_reconcile.py
@@ -11,11 +11,42 @@ from django.test import TestCase
 import teatree.core.overlay_loader as overlay_loader_mod
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay import OverlayBase
-from teatree.core.reconcile import Drift, EnvCacheDrift, MissingEnvCache, MissingWorktreeDir, reconcile_ticket
+from teatree.core.reconcile import (
+    Drift,
+    EnvCacheDrift,
+    MissingEnvCache,
+    MissingWorktreeDir,
+    UnresolvableOverlay,
+    reconcile_all,
+    reconcile_ticket,
+)
 from teatree.core.worktree_env import write_env_cache
 from tests.teatree_core.conftest import CommandOverlay
 
 _COMMAND = {"test": CommandOverlay()}
+
+
+def _make_ghost(tmp: str, *, dir_name: str = "ticket-ghost") -> tuple[Ticket, Worktree, Path]:
+    """A provisioned worktree whose overlay name is not registered anywhere.
+
+    ``get_overlay_for_worktree`` raises ``ImproperlyConfigured`` for it, the
+    same way a row for an overlay uninstalled in this environment does.
+    """
+    ticket_dir = Path(tmp) / dir_name
+    ticket_dir.mkdir()
+    wt_path = ticket_dir / "backend"
+    wt_path.mkdir()
+    ticket = Ticket.objects.create(overlay="t3-ghost", issue_url="https://ex.com/ghost")
+    wt = Worktree.objects.create(
+        overlay="t3-ghost",
+        ticket=ticket,
+        repo_path="backend",
+        branch="ghost",
+        db_name="",
+        extra={"worktree_path": str(wt_path)},
+        state=Worktree.State.PROVISIONED,
+    )
+    return ticket, wt, wt_path
 
 
 class _PgUserOverlay(CommandOverlay):
@@ -178,3 +209,55 @@ class TestReconcileMissingDbUsesWorktreePgUser(TestCase):
             drift = reconcile_ticket(ticket)
         assert len(drift.missing_dbs) == 1
         assert drift.missing_dbs[0].db_name == "wt_99"
+
+
+class TestReconcileUnresolvableOverlay(TestCase):
+    """A row whose overlay is not installed here must not abort the sweep (#2472)."""
+
+    _PATCHES: ClassVar[tuple] = ()
+
+    def _patches(self):
+        return (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value=_COMMAND),
+            patch("teatree.core.reconcile._find_docker_containers", return_value=[]),
+            patch("teatree.core.reconcile._find_worktree_paths_on_disk", return_value=set()),
+            patch("teatree.core.reconcile.db_exists", return_value=True),
+        )
+
+    def test_records_unresolvable_overlay_instead_of_raising(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            for ctx in self._patches():
+                self.enterContext(ctx)
+            ticket, wt, _ = _make_ghost(tmp)
+            drift = reconcile_ticket(ticket)
+        assert len(drift.unresolvable_overlays) == 1
+        assert isinstance(drift.unresolvable_overlays[0], UnresolvableOverlay)
+        assert drift.unresolvable_overlays[0].worktree_pk == wt.pk
+        assert drift.unresolvable_overlays[0].overlay == "t3-ghost"
+        assert drift.has_drift
+        assert "unresolvable-overlay" in drift.format()
+
+    def test_still_detects_missing_dir_for_unresolvable_overlay(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            for ctx in self._patches():
+                self.enterContext(ctx)
+            ticket, _, wt_path = _make_ghost(tmp)
+            shutil.rmtree(wt_path)
+            drift = reconcile_ticket(ticket)
+        assert len(drift.missing_worktree_dirs) == 1
+        assert len(drift.unresolvable_overlays) == 1
+
+    def test_reconcile_all_isolates_the_unresolvable_ticket(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            for ctx in self._patches():
+                self.enterContext(ctx)
+            ghost_ticket, _, _ = _make_ghost(tmp)
+            ok_ticket, ok_wt, ok_path = _make(tmp)
+            write_env_cache(ok_wt)
+            shutil.rmtree(ok_path)
+            drifts = reconcile_all()
+        # The ghost ticket is surfaced (unresolvable) AND the installed-overlay
+        # ticket is still reconciled — the sweep no longer aborts on the ghost.
+        assert ghost_ticket.pk in drifts
+        assert ok_ticket.pk in drifts
+        assert len(drifts[ok_ticket.pk].missing_worktree_dirs) == 1


### PR DESCRIPTION
## What

Fixes #2472. In a checkout where only some overlays are installed, a single
`Worktree`/`Ticket` row referencing an overlay that isn't registered here aborted
the **whole** cleanup sweep:

```
ImproperlyConfigured: Overlay '<name>' not found. Available: t3-teatree
```

Both `t3 teatree workspace doctor` (reconcile) and `t3 teatree workspace clean-merged`
resolve each row's overlay, so one stray row poisoned the entire run — no other
ticket's drift could be reconciled or reaped.

## Fix

Make both sweeps fail **open per row** on an unloadable overlay — the same
defensive pattern `infer_overlay_for_url` / `get_overlay_for_repo` already use:

- **reconcile**: split the overlay-dependent stores (env cache, DB, containers)
  out of `_reconcile_worktree_row` into `_reconcile_overlay_dependent_stores`;
  on `ImproperlyConfigured` record a typed `UnresolvableOverlay` finding and keep
  the overlay-independent missing-dir check. `reconcile_all` now completes and
  still surfaces/fixes drift on every installed-overlay ticket; `doctor --fix`
  reports the unresolvable rows.
- **clean-merged**: also catch the unloadable-overlay case per worktree and
  record a `SKIPPED` line instead of aborting.

The `clean-merged` loop moves to `_workspace_cleanup.clean_merged_worktrees` so
`workspace.py` stays under the module-health LOC cap (extract, don't grow); the
command drops its now-unused `cleanup_worktree` / `ImproperlyConfigured` imports.

## Tests (RED before the fix)

A ghost overlay name reproduces the exact `ImproperlyConfigured` abort path:

- `reconcile_ticket` records an `UnresolvableOverlay` finding without raising,
  and still detects a missing worktree dir on the same row.
- `reconcile_all` isolates the ghost ticket while reconciling a second,
  installed-overlay ticket's drift.
- `clean-merged` emits a `SKIPPED` line for the ghost-overlay merged worktree.

## Gates (local, from this worktree)

- `ruff check` / `ruff format --check`: clean
- `uv run pytest` (reconcile + workspace + cleanup + cli_doctor): 318 passed
- `t3 tool verify-gates`: all stages green (incl. module-health, ty-check,
  banned-terms, near-zero-comments, generated docs)
- `scripts/hooks/check_module_health.py --from-ref origin/main`: exit 0

## Out of scope (separate follow-up)

`t3 teatree worktree teardown` aborts on a cosmetic stale-hook post-step
(`ModuleNotFoundError: teatree.core.provision_timebox` when the worktree branch
predates that module) and leaves the DB row orphaned. Tracking separately.
