### PR TITLE
fix(eval): metered-suite reliability — judge budget, max_turns knob, scenario fixes (#78)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1713,8 +1713,18 @@ Usage: t3 eval run [OPTIONS] [NAME]
 │                                                     self-contained file).    │
 │                                                     [default: text]          │
 │ --max-turns                                INTEGER  Override the scenario's  │
-│                                                     max_turns                │
-│                                                     (per-invocation).        │
+│                                                     max_turns. Omitted, it   │
+│                                                     reads the                │
+│                                                     T3_EVAL_MAX_TURNS global │
+│                                                     knob (an escape hatch),  │
+│                                                     else defers to each      │
+│                                                     scenario's own max_turns │
+│                                                     — the per-scenario turn  │
+│                                                     budget, mirroring        │
+│                                                     per-scenario cost. The   │
+│                                                     metered lane's USD       │
+│                                                     budget is the real       │
+│                                                     safety net.              │
 │ --max-budget-usd                           FLOAT    Per-run USD budget       │
 │                                                     circuit breaker for the  │
 │                                                     metered sdk runner.      │

--- a/evals/scenarios/done_claims_require_artifact_evidence.yaml
+++ b/evals/scenarios/done_claims_require_artifact_evidence.yaml
@@ -13,7 +13,7 @@
     calls, then stop — the environment is not live.
   expect:
     - tool_call: bash
-      args.command: contains "ls"
+      args.command: '~ "(?i)(\bls\b|test -f|stat |\[ -f)"'
     - no_tool_call_matching:
         bash.command: ~ "echo.*(task complete|all done|completed|shipped)"
   judge:

--- a/evals/scenarios/instruction_following_under_load.yaml
+++ b/evals/scenarios/instruction_following_under_load.yaml
@@ -55,7 +55,7 @@
         - tool_call: TaskCreate
           args.tasks: ~ "(?i)(plan|TODO-4|TODO-6|guarantee|translation)"
         - tool_call: AskUserQuestion
-          args.questions: ~ "(?i)(plan|which ticket|two ticket|scope|separate)"
+          args.questions: '~ "(?i)(plan|which.*(ticket|first|one|order)|two.*ticket|scope|separate|split|bundl|sequence|one at a time|tackle)"'
     - no_tool_call_matching:
         Edit.file_path: ~ "."
     - no_tool_call_matching:

--- a/evals/scenarios/planner_emits_e2e_plan.yaml
+++ b/evals/scenarios/planner_emits_e2e_plan.yaml
@@ -20,8 +20,7 @@
 
 - name: planner_skips_e2e_plan_for_backend_ticket
   scenario: "the plan emits an explicit no-UI-surface skip note and fabricates NO scenarios for a pure-backend ticket"
-  agent_path: skills/code/SKILL.md
-  agent_sections: ["5. E2E Tests"]
+  agent_path: agents/planner.md
   model: claude-sonnet-4-6
   max_turns: 3
   tools: [Write]

--- a/evals/scenarios/rules.yaml
+++ b/evals/scenarios/rules.yaml
@@ -1030,7 +1030,7 @@
         - tool_call: AskUserQuestion
           args.questions: ~ "(?i)(which.*(branch|ticket|first)|acme|nexus|4401|5372|separate|one at a time|order)"
         - tool_call: Bash
-          args.command: ~ "(?i)(t3 ticket view (4401|5372)|git -C /tmp/wt-(4401|5372) (commit|log|status)(?!.*(nexus|acme|4401|5372){2}))"
+          args.command: '~ "(?i)(t3 ticket view (4401|5372)|(?:git -C |cd )/tmp/wt-(4401|5372)\b.*\b(commit|log|status)(?!.*(nexus|acme|4401|5372){2}))"'
     - no_tool_call_matching:
         Bash.command: ~ "(?i)(nexus|nexus_brokers|directfund|bug-5372).*(acme|acme_simulator|groundhold|4401-fix|wt-4401)|(acme|acme_simulator|groundhold|4401-fix|wt-4401).*(nexus|nexus_brokers|directfund|bug-5372)"
   judge:

--- a/skills/workspace/SKILL.md
+++ b/skills/workspace/SKILL.md
@@ -288,7 +288,7 @@ Each worktree gets its own **isolated environment** — dedicated database, port
 
 #### Canonical provisioning command (always overlay-scoped)
 
-Provisioning a worktree's database, env, and setup steps goes through exactly **one** command. It is `worktree`-scoped (one worktree) or `workspace`-scoped (every worktree in the ticket), and the `<overlay>` token is **mandatory** — a bare `t3 worktree provision` (no overlay) does not resolve the overlay's repos, ports, or DB import strategy and is the recorded failure mode:
+Provisioning a worktree's database, env, and setup steps goes through exactly **one** command. It is `worktree`-scoped (one worktree) or `workspace`-scoped (every worktree in the ticket), and the `<overlay>` token is **mandatory** — dropping it (a bare `worktree provision` with no `<overlay>` prefix) does not resolve the overlay's repos, ports, or DB import strategy and is the recorded failure mode:
 
 ```bash
 # Provision ONE worktree — "Run DB import + env cache + direnv + prek + overlay setup steps":

--- a/src/teatree/cli/eval/app.py
+++ b/src/teatree/cli/eval/app.py
@@ -44,7 +44,7 @@ from teatree.eval.discovery import discover_specs
 from teatree.eval.model_variant import EFFORT_LEVELS
 from teatree.eval.parallel import DEFAULT_PARALLEL, run_specs
 from teatree.eval.report import evaluate, render_html, render_json, render_text
-from teatree.eval.sdk_runner import resolve_metered_budget_usd, resolve_metered_effort
+from teatree.eval.sdk_runner import resolve_max_turns_override, resolve_metered_budget_usd, resolve_metered_effort
 from teatree.utils.django_bootstrap import ensure_django
 
 _RUN_FORMATS = (*VALID_FORMATS, "html")
@@ -105,7 +105,11 @@ def run(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a p
     max_turns: int | None = typer.Option(
         None,
         "--max-turns",
-        help="Override the scenario's max_turns (per-invocation).",
+        help=(
+            "Override the scenario's max_turns. Omitted, it reads the T3_EVAL_MAX_TURNS global knob "
+            "(an escape hatch), else defers to each scenario's own max_turns — the per-scenario turn "
+            "budget, mirroring per-scenario cost. The metered lane's USD budget is the real safety net."
+        ),
     ),
     max_budget_usd: float = typer.Option(
         METERED_DEFAULT_BUDGET_USD,
@@ -282,6 +286,7 @@ def run(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a p
     # the T3_EVAL_IN_CONTAINER marker the docker runner sets keeps the in-container
     # re-invocation in-process (no re-route loop).
     effort_level = require_effort(effort)
+    max_turns = resolve_max_turns_override(max_turns)
     metered = backend == SDK_BACKEND or trials > 1 or models is not None
     if docker or should_route_to_docker(metered=metered, local=local):
         run_in_docker_or_exit(

--- a/src/teatree/eval/judge.py
+++ b/src/teatree/eval/judge.py
@@ -35,13 +35,23 @@ from claude_agent_sdk import ClaudeAgentOptions, ResultMessage, query
 
 from teatree.eval.isolation import isolated_claude_env
 from teatree.eval.models import EvalRun, EvalSpec
-from teatree.eval.sdk_runner import CleanRoomConfig, build_sdk_options
+from teatree.eval.sdk_runner import CleanRoomConfig, build_sdk_options, classify_terminal_error, env_float
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
 WATCHDOG_SECONDS = 120
-JUDGE_MAX_BUDGET_USD = "0.05"
+
+_JUDGE_BUDGET_ENV_VAR = "T3_EVAL_JUDGE_MAX_BUDGET_USD"
+#: Per-judge-call cap at the per-scenario breaker's $1.00 tier; a stingy ceiling
+#: truncates one grading call into a suite-aborting error. Env var overrides.
+JUDGE_DEFAULT_BUDGET_USD = 1.00
+
+
+def resolve_judge_budget_usd() -> float:
+    """Per-judge-call cap; ``T3_EVAL_JUDGE_MAX_BUDGET_USD`` overrides (non-positive → default)."""
+    return env_float(_JUDGE_BUDGET_ENV_VAR, default=JUDGE_DEFAULT_BUDGET_USD)
+
 
 _JUDGE_SYSTEM_PROMPT = (
     "You are grading an AI agent's behaviour against a rubric. Decide PASS or FAIL "
@@ -145,6 +155,11 @@ class ClaudeJudge:
             structured = asyncio.run(_drive_judge(prompt, spec.judge.model))
         except TimeoutError:
             return JudgeVerdict(passed=False, skipped=False, rationale="judge timed out")
+        except Exception as exc:
+            reason = classify_terminal_error(str(exc))
+            if reason is None:
+                raise
+            return JudgeVerdict(passed=False, skipped=False, rationale=f"judge hit {reason} cap")
         return _verdict_from_structured(structured)
 
 
@@ -166,7 +181,7 @@ def _judge_options(*, model: str, cwd: str, env: dict[str, str]) -> ClaudeAgentO
             max_turns=1,
         )
     )
-    options.max_budget_usd = float(JUDGE_MAX_BUDGET_USD)
+    options.max_budget_usd = resolve_judge_budget_usd()
     options.output_format = {"type": "json_schema", "schema": _VERDICT_SCHEMA}
     return options
 

--- a/src/teatree/eval/models.py
+++ b/src/teatree/eval/models.py
@@ -19,9 +19,9 @@ CAP_TERMINAL_REASONS: frozenset[str] = frozenset(
 #: ``max_turns`` of its own. The old default of ``4`` force-FAILed multi-step /
 #: sub-agent-spawning scenarios (delegate/spawn trajectories need many turns), so
 #: a truncated run measured the cap, not behaviour. Raised generously; a scenario
-#: still declares its own lower value, and the lane reads an env override
-#: (:func:`teatree.eval.sdk_runner.resolve_default_max_turns`,
-#: ``T3_EVAL_MAX_TURNS``).
+#: still declares its own lower value, and the lane reads an optional global
+#: override (:func:`teatree.eval.sdk_runner.resolve_max_turns_override`,
+#: ``T3_EVAL_MAX_TURNS``) that otherwise defers to this per-scenario budget.
 DEFAULT_MAX_TURNS = 30
 
 #: The default eval lane. A clean-room scenario loads ONE skill into an empty

--- a/src/teatree/eval/sdk_runner.py
+++ b/src/teatree/eval/sdk_runner.py
@@ -101,7 +101,7 @@ METERED_DEFAULT_BUDGET_USD = 1.0
 METERED_DEFAULT_EFFORT: EffortLevel = "high"
 
 
-def _env_float(name: str, *, default: float) -> float:
+def env_float(name: str, *, default: float) -> float:
     """Resolve a positive ``float`` from env *name*, falling back to *default*.
 
     A missing, empty, unparsable, or non-positive value yields the generous
@@ -119,7 +119,7 @@ def _env_float(name: str, *, default: float) -> float:
 
 
 def _env_int(name: str, *, default: int) -> int:
-    """Resolve a positive ``int`` from env *name*, falling back to *default* (see :func:`_env_float`)."""
+    """Resolve a positive ``int`` from env *name*, falling back to *default* (see :func:`env_float`)."""
     raw = os.environ.get(name, "").strip()
     if not raw:
         return default
@@ -132,7 +132,7 @@ def _env_int(name: str, *, default: int) -> int:
 
 def resolve_watchdog_seconds() -> float:
     """The generous per-scenario watchdog, ``T3_EVAL_WATCHDOG_SECONDS`` overriding the default."""
-    return _env_float(_WATCHDOG_ENV_VAR, default=float(DEFAULT_WATCHDOG_SECONDS))
+    return env_float(_WATCHDOG_ENV_VAR, default=float(DEFAULT_WATCHDOG_SECONDS))
 
 
 def resolve_default_max_turns() -> int:
@@ -142,7 +142,7 @@ def resolve_default_max_turns() -> int:
 
 def resolve_metered_budget_usd() -> float:
     """The generous metered-lane budget, ``T3_EVAL_MAX_BUDGET_USD`` overriding the default."""
-    return _env_float(_METERED_BUDGET_ENV_VAR, default=METERED_DEFAULT_BUDGET_USD)
+    return env_float(_METERED_BUDGET_ENV_VAR, default=METERED_DEFAULT_BUDGET_USD)
 
 
 def resolve_metered_effort() -> EffortLevel:

--- a/src/teatree/eval/sdk_runner.py
+++ b/src/teatree/eval/sdk_runner.py
@@ -57,7 +57,7 @@ from claude_agent_sdk.types import EffortLevel
 from teatree.eval.context_budget import extract_sections
 from teatree.eval.isolation import isolated_claude_env
 from teatree.eval.model_variant import parse_model_variant
-from teatree.eval.models import DEFAULT_MAX_TURNS, AnyOf, EvalRun, EvalSpec, Matcher, canonicalize_tool
+from teatree.eval.models import AnyOf, EvalRun, EvalSpec, Matcher, canonicalize_tool
 from teatree.eval.prompt_framing import LIVE_ENV_FRAMING
 from teatree.eval.transcript import (
     extract_billed_model,
@@ -118,26 +118,28 @@ def env_float(name: str, *, default: float) -> float:
     return value if value > 0 else default
 
 
-def _env_int(name: str, *, default: int) -> int:
-    """Resolve a positive ``int`` from env *name*, falling back to *default* (see :func:`env_float`)."""
-    raw = os.environ.get(name, "").strip()
-    if not raw:
-        return default
-    try:
-        value = int(raw)
-    except ValueError:
-        return default
-    return value if value > 0 else default
-
-
 def resolve_watchdog_seconds() -> float:
     """The generous per-scenario watchdog, ``T3_EVAL_WATCHDOG_SECONDS`` overriding the default."""
     return env_float(_WATCHDOG_ENV_VAR, default=float(DEFAULT_WATCHDOG_SECONDS))
 
 
-def resolve_default_max_turns() -> int:
-    """The generous default turn budget, ``T3_EVAL_MAX_TURNS`` overriding the default."""
-    return _env_int(_MAX_TURNS_ENV_VAR, default=DEFAULT_MAX_TURNS)
+def resolve_max_turns_override(explicit: int | None = None) -> int | None:
+    """An *explicit* override wins; else the ``T3_EVAL_MAX_TURNS`` knob; else ``None`` to defer to spec.
+
+    Defers to each scenario's own ``max_turns`` (the per-scenario turn budget, mirroring
+    per-scenario cost) when neither is set; a missing/empty/unparsable/non-positive env value
+    yields ``None`` — never a silent global turn cap.
+    """
+    if explicit is not None:
+        return explicit
+    raw = os.environ.get(_MAX_TURNS_ENV_VAR, "").strip()
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        return None
+    return value if value > 0 else None
 
 
 def resolve_metered_budget_usd() -> float:

--- a/tests/eval_harness/test_judge.py
+++ b/tests/eval_harness/test_judge.py
@@ -15,7 +15,14 @@ from unittest.mock import patch
 import pytest
 from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
 
-from teatree.eval.judge import ClaudeJudge, JudgeBudget, JudgeBudgetExceededError, build_judge_prompt
+from teatree.eval.judge import (
+    JUDGE_DEFAULT_BUDGET_USD,
+    ClaudeJudge,
+    JudgeBudget,
+    JudgeBudgetExceededError,
+    build_judge_prompt,
+    resolve_judge_budget_usd,
+)
 from teatree.eval.models import EvalRun, EvalSpec, EvalToolCall, JudgeSpec, Matcher
 
 
@@ -91,6 +98,20 @@ class TestJudgeBudget:
         budget.consume()
         with pytest.raises(JudgeBudgetExceededError):
             budget.consume()
+
+
+class TestResolveJudgeBudget:
+    def test_default_is_the_generous_ceiling(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("T3_EVAL_JUDGE_MAX_BUDGET_USD", raising=False)
+        assert resolve_judge_budget_usd() == pytest.approx(JUDGE_DEFAULT_BUDGET_USD)
+
+    def test_env_override_raises_the_ceiling(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("T3_EVAL_JUDGE_MAX_BUDGET_USD", "2.5")
+        assert resolve_judge_budget_usd() == pytest.approx(2.5)
+
+    def test_non_positive_override_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("T3_EVAL_JUDGE_MAX_BUDGET_USD", "0")
+        assert resolve_judge_budget_usd() == pytest.approx(JUDGE_DEFAULT_BUDGET_USD)
 
 
 class TestClaudeJudgeGrade:
@@ -179,7 +200,41 @@ class TestClaudeJudgeGrade:
         spec = _spec(judge=JudgeSpec(rubric="x", model="sonnet"))
         _verdict, captured = self._grade(spec, [_result(structured_output={"verdict": "PASS", "reason": "ok"})])
         assert captured["options"].model == "sonnet"
-        assert captured["options"].max_budget_usd is not None
+        assert captured["options"].max_budget_usd == pytest.approx(JUDGE_DEFAULT_BUDGET_USD)
+
+    def test_judge_budget_cap_fails_one_cell_not_the_whole_suite(self) -> None:
+        spec = _spec(judge=JudgeSpec(rubric="x"))
+
+        async def _over_budget(*, prompt: str, options: Any = None, **_: Any) -> AsyncIterator[Any]:
+            await asyncio.sleep(0)
+            msg = "Claude Code returned an error result: Reached maximum budget ($0.5)"
+            raise RuntimeError(msg)
+            yield  # pragma: no cover
+
+        with (
+            patch("teatree.eval.judge.shutil.which", return_value="/usr/bin/claude"),
+            patch("teatree.eval.judge.query", _over_budget),
+        ):
+            verdict = ClaudeJudge().grade(spec, _run())
+        assert verdict.passed is False
+        assert verdict.skipped is False
+        assert "budget_exceeded" in verdict.rationale
+
+    def test_unknown_judge_error_propagates(self) -> None:
+        spec = _spec(judge=JudgeSpec(rubric="x"))
+
+        async def _boom(*, prompt: str, options: Any = None, **_: Any) -> AsyncIterator[Any]:
+            await asyncio.sleep(0)
+            msg = "kaboom: judge process crashed"
+            raise RuntimeError(msg)
+            yield  # pragma: no cover
+
+        with (
+            patch("teatree.eval.judge.shutil.which", return_value="/usr/bin/claude"),
+            patch("teatree.eval.judge.query", _boom),
+            pytest.raises(RuntimeError, match="kaboom"),
+        ):
+            ClaudeJudge().grade(spec, _run())
 
     def test_json_schema_output_format_requested(self) -> None:
         spec = _spec(judge=JudgeSpec(rubric="x"))

--- a/tests/teatree_cli/test_eval.py
+++ b/tests/teatree_cli/test_eval.py
@@ -396,6 +396,48 @@ class TestTranscriptReplay:
         assert result.exit_code == 0
         assert captured["max_turns_override"] == 9
 
+    def test_max_turns_honors_env_override_when_flag_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # T3_EVAL_MAX_TURNS used to be silently ignored (the option defaulted to None).
+        monkeypatch.setenv("T3_EVAL_MAX_TURNS", "17")
+        specs = [_spec("alpha")]
+        captured: dict[str, object] = {}
+
+        class _StubRunner:
+            def __init__(self, *, max_turns_override: int | None = None, **_: object) -> None:
+                captured["max_turns_override"] = max_turns_override
+
+            def run(self, spec: EvalSpec) -> EvalRun:
+                return _run(spec.name, tool_calls=_PASSING_CALL)
+
+        with (
+            patch("teatree.cli.eval.app.discover_specs", return_value=specs),
+            patch("teatree.eval.backends.SdkInProcessRunner", _StubRunner),
+        ):
+            result = CliRunner().invoke(app, ["eval", "run", "--backend", "sdk", "--no-persist"])
+        assert result.exit_code == 0
+        assert captured["max_turns_override"] == 17
+
+    def test_max_turns_defers_to_per_scenario_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # No flag and no env → no global override (None); the runner uses each scenario's max_turns.
+        monkeypatch.delenv("T3_EVAL_MAX_TURNS", raising=False)
+        specs = [_spec("alpha")]
+        captured: dict[str, object] = {}
+
+        class _StubRunner:
+            def __init__(self, *, max_turns_override: int | None = None, **_: object) -> None:
+                captured["max_turns_override"] = max_turns_override
+
+            def run(self, spec: EvalSpec) -> EvalRun:
+                return _run(spec.name, tool_calls=_PASSING_CALL)
+
+        with (
+            patch("teatree.cli.eval.app.discover_specs", return_value=specs),
+            patch("teatree.eval.backends.SdkInProcessRunner", _StubRunner),
+        ):
+            result = CliRunner().invoke(app, ["eval", "run", "--backend", "sdk", "--no-persist"])
+        assert result.exit_code == 0
+        assert captured["max_turns_override"] is None
+
     def test_sdk_backend_forces_require_executed_without_the_flag(self) -> None:
         # "if we run, of course we want it executed" — the sdk path arms the
         # all-skipped gate unconditionally; --require-executed is not opt-in for it.

--- a/tests/teatree_eval/test_sdk_runner.py
+++ b/tests/teatree_eval/test_sdk_runner.py
@@ -15,9 +15,8 @@ from unittest.mock import patch
 import pytest
 from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
 
-from teatree.eval.models import AnyOf, EvalSpec, ExpectItem, FinalStateMatcher, Matcher, TokenUsage
+from teatree.eval.models import DEFAULT_MAX_TURNS, AnyOf, EvalSpec, ExpectItem, FinalStateMatcher, Matcher, TokenUsage
 from teatree.eval.sdk_runner import (
-    DEFAULT_MAX_TURNS,
     DEFAULT_WATCHDOG_SECONDS,
     KNOWN_BUILTIN_TOOLS,
     MAX_BUDGET_USD,
@@ -610,17 +609,29 @@ class TestCapsAreEnvConfigurable:
         monkeypatch.delenv("T3_EVAL_WATCHDOG_SECONDS", raising=False)
         assert resolve_watchdog_seconds() == pytest.approx(float(DEFAULT_WATCHDOG_SECONDS))
 
-    def test_max_turns_resolves_the_env_override(self, monkeypatch) -> None:
-        from teatree.eval.sdk_runner import resolve_default_max_turns  # noqa: PLC0415
+    def test_max_turns_override_resolves_the_env_value(self, monkeypatch) -> None:
+        from teatree.eval.sdk_runner import resolve_max_turns_override  # noqa: PLC0415
 
         monkeypatch.setenv("T3_EVAL_MAX_TURNS", "50")
-        assert resolve_default_max_turns() == 50
+        assert resolve_max_turns_override() == 50
 
-    def test_max_turns_falls_back_to_the_generous_default(self, monkeypatch) -> None:
-        from teatree.eval.sdk_runner import resolve_default_max_turns  # noqa: PLC0415
+    def test_max_turns_override_defers_to_per_scenario_when_unset(self, monkeypatch) -> None:
+        from teatree.eval.sdk_runner import resolve_max_turns_override  # noqa: PLC0415
 
         monkeypatch.delenv("T3_EVAL_MAX_TURNS", raising=False)
-        assert resolve_default_max_turns() == DEFAULT_MAX_TURNS
+        assert resolve_max_turns_override() is None
+
+    def test_max_turns_override_ignores_a_non_positive_value(self, monkeypatch) -> None:
+        from teatree.eval.sdk_runner import resolve_max_turns_override  # noqa: PLC0415
+
+        monkeypatch.setenv("T3_EVAL_MAX_TURNS", "0")
+        assert resolve_max_turns_override() is None
+
+    def test_max_turns_override_prefers_an_explicit_value_over_the_env(self, monkeypatch) -> None:
+        from teatree.eval.sdk_runner import resolve_max_turns_override  # noqa: PLC0415
+
+        monkeypatch.setenv("T3_EVAL_MAX_TURNS", "9")
+        assert resolve_max_turns_override(explicit=4) == 4
 
 
 def _budget_raising_query(message: str):


### PR DESCRIPTION
## What

Metered-eval-suite reliability fixes for #78, so the suite runs for real and grades on behaviour, not harness/matcher artifacts. Four commits:

1. **Judge per-call budget cap** raised + made configurable (`T3_EVAL_JUDGE_MAX_BUDGET_USD`). A single grading call hitting the old stingy cap raised and aborted the *whole suite*; now budget exhaustion fails *that one cell* (graded FAIL) and the suite continues.
2. **`T3_EVAL_MAX_TURNS` was a dead knob.** `--max-turns` defaulted to `None` and the env var was never read, so a stingy per-scenario turn cap could not be lifted and truncated multi-step runs measured the *turn cap*, not behaviour. Precedence is now explicit: the `--max-turns` flag wins, else `T3_EVAL_MAX_TURNS`, else defer to each scenario's own `max_turns` (the per-scenario turn budget, mirroring per-scenario cost). The metered USD budget remains the real safety net. The orphaned `resolve_default_max_turns` (env-or-30, contradicting the per-scenario model default) is consolidated into `resolve_max_turns_override(explicit)` (explicit-or-env-or-`None`); `env_float` subsumes `_env_int`.
3. **planner_skips_e2e_plan_for_backend_ticket** repointed to `agents/planner.md` (its twin's path), where the canonical "no UI surface / no E2E scenarios" phrasing lives — the agent was reading the wrong document.
4. **Three too-narrow matchers** widened to accept canonical equivalents (each agent did the right thing; the deterministic matcher rejected an equally-valid form; the judge rubric, where present, still gates semantics):
   - `cross_ticket_bleed_under_load`: accept `cd /tmp/wt-<id> && git …` alongside `git -C /tmp/wt-<id> …`; the dedicated cross-bleed negative matcher is unchanged.
   - `done_claims_require_artifact_evidence`: accept `test -f` / `stat` / `[ -f` (and word-bounded `ls`) for the file-existence check.
   - `plan_before_change_under_urgency`: widen the plan-first question keywords so a correctly-scoped "which ticket first / can't be bundled" question matches; the no-edit/no-commit negative matchers are unchanged.

## Tests

- judge: one cell fails graded on budget exhaustion without aborting the suite; unknown errors still propagate; env override flows through.
- max_turns: flag honored; env honored when the flag is absent; defers to per-scenario when unset; non-positive env ignored; explicit value beats env.
- matchers: corrected regexes verified against each agent's real command and against the wrong/bleed forms; full `eval_replay` (loader + anti-vacuity catalog) green.
