### PR TITLE
fix(enforcement): gate 12 diff-coverage measures branch diff vs base, not the worktree

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -2449,15 +2449,19 @@ Usage: t3 tool diff-coverage [OPTIONS]
 
  Per-diff coverage + mutation/revert gate (BLUEPRINT §17.6 gate 12, #836).
 
- Measures coverage on the *diff's* added production lines (not the global
- ``fail_under``) and requires every new/changed production symbol to be
- imported by a changed test (the test-a-local-copy anti-vacuity check).
- Exits non-zero when a new line is uncovered or a symbol is unreferenced.
+ Measures coverage on the *branch's* added production lines — the committed
+ diff against its merge-base with ``--base`` (default ``origin/main``), NOT the
+ clone's working tree, so unrelated uncommitted edits never enter the gate.
+ Requires every new/changed production symbol to be imported by a changed test
+ (the test-a-local-copy anti-vacuity check). Exits non-zero when a new line is
+ uncovered or a symbol is unreferenced.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --repo                 PATH  Repo root (default: cwd)                        │
 │                              [default: <bound method PathBase.cwd of <class  │
 │                              'pathlib._local.Path'>>]                        │
+│ --base                 TEXT  Ref to diff against (merge-base..HEAD)          │
+│                              [default: origin/main]                          │
 │ --coverage-file        PATH  Path to .coverage data file                     │
 │                              [default: .coverage]                            │
 │ --json                       Emit machine-readable JSON.                     │

--- a/src/teatree/cli/enforcement_tools.py
+++ b/src/teatree/cli/enforcement_tools.py
@@ -59,18 +59,21 @@ def _coverage_is_stale(coverage_file: Path, repo: Path) -> bool:
 def diff_coverage(
     *,
     repo: Path = typer.Option(Path.cwd, "--repo", help="Repo root (default: cwd)"),
+    base: str = typer.Option("origin/main", "--base", help="Ref to diff against (merge-base..HEAD)"),
     coverage_file: Path = typer.Option(Path(".coverage"), "--coverage-file", help="Path to .coverage data file"),
     output_json: bool = typer.Option(False, "--json", help="Emit machine-readable JSON."),
 ) -> None:
     """Per-diff coverage + mutation/revert gate (BLUEPRINT §17.6 gate 12, #836).
 
-    Measures coverage on the *diff's* added production lines (not the global
-    ``fail_under``) and requires every new/changed production symbol to be
-    imported by a changed test (the test-a-local-copy anti-vacuity check).
-    Exits non-zero when a new line is uncovered or a symbol is unreferenced.
+    Measures coverage on the *branch's* added production lines — the committed
+    diff against its merge-base with ``--base`` (default ``origin/main``), NOT the
+    clone's working tree, so unrelated uncommitted edits never enter the gate.
+    Requires every new/changed production symbol to be imported by a changed test
+    (the test-a-local-copy anti-vacuity check). Exits non-zero when a new line is
+    uncovered or a symbol is unreferenced.
     """
     from teatree.utils.diff_coverage import measure_diff_coverage  # noqa: PLC0415
-    from teatree.utils.git import full_worktree_diff  # noqa: PLC0415
+    from teatree.utils.git import branch_diff  # noqa: PLC0415
 
     if not coverage_file.exists():
         typer.echo(
@@ -86,7 +89,7 @@ def diff_coverage(
             err=True,
         )
 
-    diff = full_worktree_diff(str(repo))
+    diff = branch_diff(str(repo), base)
     report = measure_diff_coverage(diff, coverage_data_file=coverage_file, repo_root=repo)
     if output_json:
         typer.echo(

--- a/src/teatree/utils/git.py
+++ b/src/teatree/utils/git.py
@@ -28,6 +28,7 @@ from teatree.utils.git_branch import (
     head_sha,
 )
 from teatree.utils.git_commit import (
+    branch_diff,
     commit,
     commit_messages,
     first_commit_message,
@@ -54,6 +55,7 @@ __all__ = [
     "DETACHED_HEAD",
     "GitRepo",
     "branch_delete",
+    "branch_diff",
     "branch_merged",
     "bundle_create",
     "check",

--- a/src/teatree/utils/git_commit.py
+++ b/src/teatree/utils/git_commit.py
@@ -13,6 +13,18 @@ def merge_base(repo: str = ".", target: str = "origin/main") -> str:
     return run_strict(repo=repo, args=["merge-base", target, "HEAD"])
 
 
+def branch_diff(repo: str = ".", target: str = "origin/main") -> str:
+    """Diff of this branch's commits against their merge-base with *target*.
+
+    Measures what the branch actually changes (``<merge-base>..HEAD``), so a
+    per-diff gate sees the PR's committed lines and never the clone's unrelated
+    uncommitted edits. Prefixes are forced (``a/``/``b/``) so the unified-diff
+    parser is independent of a user's ``diff.noprefix`` config.
+    """
+    base = merge_base(repo, target)
+    return run(repo=repo, args=["diff", base, "HEAD", "--src-prefix=a/", "--dst-prefix=b/"])
+
+
 def rev_count(repo: str = ".", range_spec: str = "") -> int:
     out = run_strict(repo=repo, args=["rev-list", "--count", range_spec])
     return int(out)

--- a/tests/teatree_utils/test_branch_diff.py
+++ b/tests/teatree_utils/test_branch_diff.py
@@ -1,0 +1,81 @@
+"""branch_diff measures the branch's committed diff vs base, never the worktree.
+
+Regression for Gate 12: ``t3 tool diff-coverage`` shelled ``full_worktree_diff``,
+so the PR-create gate measured the clone's *uncommitted* working tree instead of
+the branch's committed ``<merge-base>..HEAD`` diff — denying legit PRs over
+unrelated dirt and missing the very lines the PR adds (they live in HEAD, absent
+from ``git diff HEAD``).
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from teatree.cli.enforcement_tools import diff_coverage
+from teatree.utils.git import branch_diff, full_worktree_diff
+from teatree.utils.git_run import run_strict
+
+
+def _git(repo: Path, *args: str) -> None:
+    run_strict(repo=str(repo), args=list(args))
+
+
+def _added_lines(diff: str) -> str:
+    """The diff's added lines only (so a context line is never mistaken for a change)."""
+    return "\n".join(line for line in diff.splitlines() if line.startswith("+") and not line.startswith("+++"))
+
+
+def _repo_with_committed_branch_and_worktree_dirt(tmp_path: Path) -> Path:
+    repo = tmp_path / "clone"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "t")
+    (repo / "mod.py").write_text("def base():\n    return 1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "base")
+
+    _git(repo, "checkout", "-q", "-b", "feature")
+    (repo / "mod.py").write_text("def base():\n    return 1\n\n\ndef feature():\n    return 2\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "feat")
+
+    # Unrelated working-tree dirt: an uncommitted edit + a brand-new untracked file.
+    (repo / "mod.py").write_text(
+        "def base():\n    return 1\n\n\ndef feature():\n    return 2\n\n\ndef dirty():\n    return 3\n"
+    )
+    (repo / "untracked.py").write_text("def untracked():\n    return 4\n")
+    return repo
+
+
+def test_branch_diff_is_committed_diff_vs_base_not_worktree(tmp_path: Path) -> None:
+    repo = _repo_with_committed_branch_and_worktree_dirt(tmp_path)
+
+    committed = _added_lines(branch_diff(str(repo), "main"))
+    assert "def feature" in committed
+    assert "def dirty" not in committed
+    assert "def untracked" not in committed
+
+    # Anti-vacuity: full_worktree_diff (the old source) adds the exact opposite —
+    # it misses the committed line and surfaces the dirt — so a revert to worktree
+    # diffing flips every assertion above. (def feature is only a context line in
+    # the worktree diff, never an added one.)
+    worktree = _added_lines(full_worktree_diff(str(repo)))
+    assert "def feature" not in worktree
+    assert "def dirty" in worktree
+    assert "def untracked" in worktree
+
+
+def test_diff_coverage_cli_uses_branch_diff_not_worktree(tmp_path: Path) -> None:
+    with (
+        patch("teatree.utils.git.branch_diff", return_value="") as branch,
+        patch("teatree.utils.git.full_worktree_diff") as worktree,
+    ):
+        diff_coverage(
+            repo=tmp_path,
+            base="origin/main",
+            coverage_file=tmp_path / ".coverage",
+            output_json=True,
+        )
+
+    branch.assert_called_once_with(str(tmp_path), "origin/main")
+    worktree.assert_not_called()

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -86,7 +86,7 @@ class TestToolCommands:
 
     def test_diff_coverage_passes_exit_zero(self, tmp_path):
         with (
-            patch("teatree.utils.git.full_worktree_diff", return_value=""),
+            patch("teatree.utils.git.branch_diff", return_value=""),
             patch("teatree.utils.diff_coverage.measure_diff_coverage") as mock,
         ):
             mock.return_value = MagicMock(passes=lambda: True, summary=lambda: "clean")
@@ -100,7 +100,7 @@ class TestToolCommands:
             unreferenced_symbols=["widget"],
         )
         with (
-            patch("teatree.utils.git.full_worktree_diff", return_value="diff"),
+            patch("teatree.utils.git.branch_diff", return_value="diff"),
             patch("teatree.utils.diff_coverage.measure_diff_coverage", return_value=report),
         ):
             result = runner.invoke(app, ["tool", "diff-coverage", "--repo", str(tmp_path), "--json"])
@@ -116,7 +116,7 @@ class TestToolCommands:
         # measured nothing) without changing exit semantics.
         report = MagicMock(passes=lambda: True, summary=lambda: "clean")
         with (
-            patch("teatree.utils.git.full_worktree_diff", return_value=""),
+            patch("teatree.utils.git.branch_diff", return_value=""),
             patch("teatree.utils.diff_coverage.measure_diff_coverage", return_value=report),
         ):
             absent = str(tmp_path / "absent.coverage")
@@ -134,7 +134,7 @@ class TestToolCommands:
         cov.write_text("", encoding="utf-8")
         report = MagicMock(passes=lambda: True, summary=lambda: "clean")
         with (
-            patch("teatree.utils.git.full_worktree_diff", return_value=""),
+            patch("teatree.utils.git.branch_diff", return_value=""),
             patch("teatree.utils.diff_coverage.measure_diff_coverage", return_value=report),
         ):
             result = runner.invoke(
@@ -154,7 +154,7 @@ class TestToolCommands:
         os.utime(cov, (past, past))
         report = MagicMock(passes=lambda: True, summary=lambda: "clean")
         with (
-            patch("teatree.utils.git.full_worktree_diff", return_value="diff --git a/src.py b/src.py\n+x = 1"),
+            patch("teatree.utils.git.branch_diff", return_value="diff --git a/src.py b/src.py\n+x = 1"),
             patch("teatree.utils.diff_coverage.measure_diff_coverage", return_value=report),
         ):
             result = runner.invoke(


### PR DESCRIPTION
## What

`t3 tool diff-coverage` (BLUEPRINT §17.6 gate 12) shelled `full_worktree_diff` — `git add -A -N` + `git diff HEAD`, the #835 data-loss-guard capture of the **working tree**. So the `gh pr create`/`gh pr ready` gate (`handle_block_uncovered_diff`) measured the clone's *uncommitted* dirt instead of the branch's committed diff: unrelated main-clone edits denied legit PRs, and the lines the PR actually adds were missed (they live in HEAD, absent from `git diff HEAD`).

## Fix

- Add `branch_diff(repo, target="origin/main")` in `git_commit.py`: `git diff <merge-base target>..HEAD` with forced `a/`,`b/` prefixes (config-independent parsing). Re-exported via `utils/git`.
- Point the `diff-coverage` CLI at it, with a `--base` option (default `origin/main`); updated docstring + regenerated `cli-reference`.
- `worktree_snapshot`'s data-loss-guard use of `full_worktree_diff` is unchanged (the one legitimate caller).

## Tests

- Real-git regression contrasting `branch_diff` (committed diff vs base) with `full_worktree_diff` (worktree dirt), asserting on **added** lines so a context line is never mistaken for a change.
- CLI-wiring test asserting `diff-coverage` calls `branch_diff`, not `full_worktree_diff` — **RED on the pre-fix source** ("branch_diff called 0 times").
- Repointed the existing diff-coverage CLI tests to `branch_diff` (no stale references).

489 passed across the touched git-utils + Gate 12 test set; `ruff check`/`format` clean.