### PR TITLE
chore(prek): adopt ac-django ast-grep hooks (inline ast-grep-ignore grandfathering)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -179,6 +179,28 @@ repos:
         files: '^(src/teatree|docs)/'
         pass_filenames: true
 
+  # Phase 6b - ac-django testing conventions (ast-grep; grandfathered INLINE via
+  # rule-scoped `# ast-grep-ignore: <rule-id>` comments — no baseline file, no
+  # count cap. The colon form is used over the bracket form so it coexists with
+  # ruff's ERA001 preview rule.) ast-grep is pinned to 0.42.3 by the hook wrapper
+  # (resolved via `uvx --from ast-grep-cli==0.42.3`). The pyproject hook
+  # grandfathers the three existing complexity-ignore entries via --grandfather.
+  - repo: https://github.com/souliane/skills
+    rev: 29c0a2c62e95203783e860536ce38cec4375de39
+    hooks:
+      - id: ac-django-no-pytest-django-db
+        files: ^tests/.*\.py$
+      - id: ac-django-testcase-no-pytest-parametrize
+        files: ^tests/.*\.py$
+      - id: ac-django-no-complexity-suppressions
+        files: ^(src/teatree/.*\.py|tests/.*\.py)$
+      - id: ac-django-no-pyproject-complexity
+        files: ^pyproject\.toml$
+        args:
+          - --grandfather=C901@lint.per-file-ignores.scripts/**/*.py
+          - --grandfather=PLR0912@lint.per-file-ignores.scripts/**/*.py
+          - --grandfather=PLR0904@lint.per-file-ignores.tests/**/*.py
+
   # Phase 7 - Project-specific
   - repo: local
     hooks:

--- a/src/teatree/backends/github/client.py
+++ b/src/teatree/backends/github/client.py
@@ -174,6 +174,7 @@ def _gh_api_patch(endpoint: str, payload: dict[str, object], *, token: str = "")
     return json.loads(result.stdout)
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 class GitHubCodeHost:  # noqa: PLR0904 — method count reflects the CodeHostBackend Protocol surface, not poor encapsulation.
     """CodeHost implementation backed by the ``gh`` CLI."""
 

--- a/src/teatree/backends/gitlab/client.py
+++ b/src/teatree/backends/gitlab/client.py
@@ -112,6 +112,7 @@ def get_client(*, token: str = "", base_url: str = "") -> GitLabAPI:
     )
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 class GitLabCodeHost:  # noqa: PLR0904 — method count reflects the CodeHostBackend Protocol surface, not poor encapsulation.
     def __init__(
         self,

--- a/src/teatree/backends/slack/bot.py
+++ b/src/teatree/backends/slack/bot.py
@@ -151,6 +151,7 @@ class _SlackInbound:
         return self._reactions.snapshot()
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 class SlackBotBackend:  # noqa: PLR0904 — method count reflects the MessagingBackend Protocol surface, not poor encapsulation.
     """MessagingBackend backed by a Slack bot token, optionally with a user token.
 
@@ -173,6 +174,7 @@ class SlackBotBackend:  # noqa: PLR0904 — method count reflects the MessagingB
     setup/provision path leaves it ``False`` so a wrong paste errors loudly.
     """
 
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def __init__(  # noqa: PLR0913 — Slack credential facade; each kwarg is a distinct documented token/identity/config slot, not an internal design smell.
         self,
         *,

--- a/src/teatree/cli/codex.py
+++ b/src/teatree/cli/codex.py
@@ -31,6 +31,7 @@ _PR_URL_RE = re.compile(r"^https?://(?:[^/]+/)+(?P<slug>[^/]+/[^/]+)/pulls?/(?P<
 
 
 @codex_app.command("review")
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def review(  # noqa: PLR0913, PLR0917 — typer command: every param is a CLI flag mapped 1:1 to the public ``codex review`` surface (pr_url/head-sha/path/overlay/force/json). The arg list IS the CLI contract.
     pr_url: str = typer.Argument(..., help="PR URL, e.g. https://github.com/owner/repo/pull/123"),
     head_sha: str = typer.Option(..., "--head-sha", help="Current head SHA of the PR."),

--- a/src/teatree/cli/eval/all.py
+++ b/src/teatree/cli/eval/all.py
@@ -277,6 +277,7 @@ STRICT_HELP = (
 )
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def run_full_suite(  # noqa: PLR0913 — the single eval-suite chokepoint: each keyword-only param maps 1:1 to a public bare-`t3 eval` / `t3 eval all` flag. The arg list IS the CLI contract.
     *,
     backend: str,

--- a/src/teatree/cli/eval/all_command.py
+++ b/src/teatree/cli/eval/all_command.py
@@ -16,6 +16,7 @@ from teatree.eval.backends import SUBSCRIPTION_BACKEND
 from teatree.eval.parallel import DEFAULT_PARALLEL
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def all_lanes(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a public `t3 eval all` flag. The arg list IS the CLI contract.
     backend: str = typer.Option(
         SUBSCRIPTION_BACKEND,

--- a/src/teatree/cli/eval/app.py
+++ b/src/teatree/cli/eval/app.py
@@ -89,6 +89,7 @@ def list_scenarios() -> None:
 
 
 @eval_app.command("run")
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def run(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a public ``t3 eval run`` flag. The arg list IS the CLI contract.
     name: str | None = typer.Argument(None, help="Scenario name to run (omit to run all)."),
     lane: str | None = typer.Option(
@@ -452,6 +453,7 @@ eval_app.command("history")(history_command)
 
 
 @eval_app.callback(invoke_without_command=True)
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def default(  # noqa: PLR0913, PLR0917 — typer callback: each param maps 1:1 to a public bare-``t3 eval`` flag. The arg list IS the CLI contract.
     ctx: typer.Context,
     backend: str = typer.Option(

--- a/src/teatree/cli/eval/benchmark.py
+++ b/src/teatree/cli/eval/benchmark.py
@@ -36,6 +36,7 @@ from teatree.utils.django_bootstrap import ensure_django
 BENCHMARK_DEFAULT_BUDGET_USD = 2.0
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def benchmark(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a public ``t3 eval benchmark`` flag.
     models: str = typer.Option(
         ...,
@@ -142,6 +143,7 @@ def benchmark(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 
         raise typer.Exit(code=1)
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def _dispatch_to_docker(  # noqa: PLR0913 — each kwarg is one benchmark flag threaded into the container.
     *,
     models: str,
@@ -174,6 +176,7 @@ def _dispatch_to_docker(  # noqa: PLR0913 — each kwarg is one benchmark flag t
         raise typer.Exit(code=2) from None
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def _docker_passthrough(  # noqa: PLR0913 — each kwarg is one benchmark flag threaded into the container.
     *,
     models: str,

--- a/src/teatree/cli/eval/multi_trial.py
+++ b/src/teatree/cli/eval/multi_trial.py
@@ -37,6 +37,7 @@ from teatree.eval.sdk_runner import MAX_BUDGET_USD
 MAX_MATRIX_CELL_RETRIES = 2
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def run_pass_at_k_lane(  # noqa: PLR0913 — each kwarg threads one `eval run` CLI flag through the pass@k path.
     specs: list[EvalSpec],
     *,
@@ -126,6 +127,7 @@ def run_pass_at_k_lane(  # noqa: PLR0913 — each kwarg threads one `eval run` C
     return failed
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def run_model_matrix_lane(  # noqa: PLR0913 — each kwarg threads one `eval run` CLI flag through the matrix path.
     specs: list[EvalSpec],
     *,
@@ -205,6 +207,7 @@ def parse_model_tags(models: str) -> list[str]:
     return [variant.tag for variant in variants]
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def collect_matrix_rows(  # noqa: PLR0913 — each kwarg threads one matrix/benchmark CLI flag through the shared loop.
     specs: list[EvalSpec],
     model_tags: list[str],

--- a/src/teatree/cli/eval/run_docker.py
+++ b/src/teatree/cli/eval/run_docker.py
@@ -88,6 +88,7 @@ def run_in_docker_or_exit(
     args.dispatch()
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def route_to_docker_if_needed(  # noqa: PLR0913 — each kwarg is one durable-history flag forwarded with the run args.
     args: RunDockerArgs,
     *,

--- a/src/teatree/cli/eval/run_modes.py
+++ b/src/teatree/cli/eval/run_modes.py
@@ -263,6 +263,7 @@ class CostBoundsGate:
         return result.failed
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def finalize_single_run(  # noqa: PLR0913 — each kwarg threads one `eval run` flag through the persist+gate tail.
     results: list[ScenarioResult],
     *,

--- a/src/teatree/cli/review/commands.py
+++ b/src/teatree/cli/review/commands.py
@@ -72,6 +72,7 @@ def _parse_evidence(raw: str) -> "FindingEvidence | None":
 
 
 @review_app.command(name="post-draft-note")
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def post_draft_note(  # noqa: PLR0913 — typer command: every param is a CLI flag mapped 1:1 to the public `review post-draft-note` surface (repo/mr/note/file/line/general/evidence-json + the #126 gate escapes). The `--general` flag is load-bearing — it closes the #72 silent-degradation foot-gun by making the inline-vs-general decision explicit. `--evidence-json` is load-bearing — it's the #1280 structured-evidence CLI plumbing.
     repo: str = typer.Argument(help="GitLab project path (e.g., my-org/my-repo)"),
     mr: int = typer.Argument(help="Merge request IID"),
@@ -140,6 +141,7 @@ def post_draft_note(  # noqa: PLR0913 — typer command: every param is a CLI fl
 
 
 @review_app.command(name="post-comment")
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def post_comment(  # noqa: PLR0913 — typer command: every param is a CLI flag mapped 1:1 to the public ``review post-comment`` surface (repo/mr/note/file/line/live/evidence-json). ``--live`` is load-bearing — its absence is the safe-by-default draft path (#1207). ``--evidence-json`` is load-bearing — it's the #1280 structured-evidence CLI plumbing.
     repo: str = typer.Argument(help="GitLab project path (e.g., my-org/my-repo)"),
     mr: int = typer.Argument(help="Merge request IID"),

--- a/src/teatree/cli/review/post_impl.py
+++ b/src/teatree/cli/review/post_impl.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
     from teatree.cli.review.service import ReviewService
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def post_draft_note_impl(  # noqa: PLR0913 — every kwarg maps 1:1 to a public CLI flag on `review post-draft-note`.
     service: "ReviewService",
     repo: str,
@@ -95,6 +96,7 @@ def post_draft_note_impl(  # noqa: PLR0913 — every kwarg maps 1:1 to a public 
     ), 1
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def post_comment_impl(  # noqa: PLR0913 — every kwarg maps 1:1 to a public CLI flag on `review post-comment`.
     service: "ReviewService",
     repo: str,
@@ -190,6 +192,7 @@ def publish_draft_notes_impl(service: "ReviewService", repo: str, mr: int, *, en
     return f"Failed: HTTP {status}", 1
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def reply_to_discussion_impl(  # noqa: PLR0913 — extracted ReviewService publish body; args mirror the method (#1280).
     service: "ReviewService", repo: str, mr: int, discussion_id: str, body: str, *, encoded: str
 ) -> tuple[str, int]:
@@ -220,6 +223,7 @@ def reply_to_discussion_impl(  # noqa: PLR0913 — extracted ReviewService publi
     return f"OK reply_note_id={note_id}", 0
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def resolve_discussion_impl(  # noqa: PLR0913 — extracted ReviewService publish body; args mirror the method (#1280).
     service: "ReviewService", repo: str, mr: int, discussion_id: str, *, resolved: bool, encoded: str
 ) -> tuple[str, int]:
@@ -250,6 +254,7 @@ def resolve_discussion_impl(  # noqa: PLR0913 — extracted ReviewService publis
     return f"Failed: HTTP {status}", 1
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def update_note_impl(  # noqa: PLR0913 — extracted ReviewService publish body; args mirror the method (#1280).
     service: "ReviewService", repo: str, mr: int, note_id: int, body: str, *, encoded: str
 ) -> tuple[str, int]:

--- a/src/teatree/cli/review/service.py
+++ b/src/teatree/cli/review/service.py
@@ -166,6 +166,7 @@ class ReviewService:
 
         return post_draft_note_impl(self, repo, mr, note, file=file, line=line)
 
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def post_draft_note(  # noqa: PLR0913 — public service method whose params map 1:1 to the ``t3 review post-draft-note`` CLI flags; ``evidence`` is the #1280 structured-evidence record and the ``allow_*`` overrides are the #126 documented escapes — all must stay kwargs on this surface.
         self,
         repo: str,
@@ -214,6 +215,7 @@ class ReviewService:
             repo, mr, "post_draft_note", lambda: self._post_draft_note_impl(repo, mr, note, file=file, line=line)
         )
 
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def _run_pre_publish_gates(  # noqa: PLR0913
         self,
         *,
@@ -267,6 +269,7 @@ class ReviewService:
 
         return post_comment_impl(self, repo, mr, note, file=file, line=line)
 
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def post_comment(  # noqa: PLR0913 — public service method whose params map 1:1 to the ``t3 review post-comment`` CLI flags; ``live`` (#1207 default-flip), ``evidence`` (#1280) and the ``allow_*`` escapes (#126) must stay kwargs on this surface.
         self,
         repo: str,

--- a/src/teatree/cli/review/shape_gate.py
+++ b/src/teatree/cli/review/shape_gate.py
@@ -114,6 +114,7 @@ def _count_words(body: str) -> int:
     return len(body.split())
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def check_review_shape(  # noqa: PLR0913 — gate entry-point; each kwarg is a documented gate input (MR coordinate + body + inline flag + the #126 override).
     *,
     api: "GitLabHTTPClient",

--- a/src/teatree/cli/review/todo_gate.py
+++ b/src/teatree/cli/review/todo_gate.py
@@ -156,6 +156,7 @@ class InlineAnchor(NamedTuple):
     line: int
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def check_todo_anchor(  # noqa: PLR0913 — gate entry-point; each kwarg is a documented gate input (MR coordinate + body + anchor + the #126 override).
     *,
     api: "GitLabHTTPClient",

--- a/src/teatree/core/backend_protocols.py
+++ b/src/teatree/core/backend_protocols.py
@@ -166,6 +166,7 @@ class UploadVerification:
     detail: str = ""
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 @runtime_checkable  # noqa: PLR0904 — method count IS the code-host capability surface, mirrored by the concrete backends.
 class CodeHostBackend(Protocol):
     """Pull/merge requests + issue fetch — the canonical code-host concern.

--- a/src/teatree/core/checking.py
+++ b/src/teatree/core/checking.py
@@ -320,6 +320,7 @@ def _accumulate_overlays(
     return merged_items, in_flight_items, failed_items, earliest_since
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def gather_checking_report(  # noqa: PLR0913 — read-report entry-point; each kwarg is a documented window/scope input.
     *,
     since: datetime,

--- a/src/teatree/core/gates/privacy_gate.py
+++ b/src/teatree/core/gates/privacy_gate.py
@@ -62,6 +62,7 @@ _DEFAULT_QUOTE_PATTERNS: tuple[tuple[str, str], ...] = (
 )
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def scan_for_publication(  # noqa: PLR0913 — gate entry-point; each kwarg is a documented input.
     *,
     text: str,

--- a/src/teatree/core/management/commands/_test_plan.py
+++ b/src/teatree/core/management/commands/_test_plan.py
@@ -340,6 +340,7 @@ def post_body_file_comment(
     return PostTestPlanResult(issue_url=issue_url, comment_id=comment_id, envs=[], action=action)
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def run_post_test_plan(  # noqa: PLR0913 — the CLI flags map 1:1 to a single shared entry point.
     *,
     manifest: str,

--- a/src/teatree/core/management/commands/db.py
+++ b/src/teatree/core/management/commands/db.py
@@ -139,6 +139,7 @@ class Command(TyperCommand):
         self.stdout.write(f"Applied {len(applied)} migration(s): {', '.join(applied)}")
 
     @command()
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def refresh(  # noqa: PLR0913 — django-typer command: every param is a CLI flag mapped 1:1 to the public `db refresh` surface (path/dslr/dump/force/fresh-dump/user-authorized); the arg list IS the CLI contract, not an internal design smell (same rationale as ticket.py:clear).
         self,
         path: str = typer.Option("", help="Worktree path (auto-detects from PWD if empty)."),

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -82,6 +82,7 @@ class PlaywrightOptions:
 
 class Command(TyperCommand):
     @command()
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def run(  # noqa: PLR0913
         self,
         work_item: Annotated[
@@ -332,6 +333,7 @@ class Command(TyperCommand):
         return "dev" if os.environ.get("BASE_URL") else "local"
 
     @command()
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def external(  # noqa: PLR0913
         self,
         test_path: str = "",
@@ -499,6 +501,7 @@ class Command(TyperCommand):
         raise SystemExit(rc)
 
     @command(name="post-test-plan")
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def post_test_plan(  # noqa: PLR0913 — CLI entrypoint; each flag is a distinct user-facing option
         self,
         *,
@@ -552,6 +555,7 @@ class Command(TyperCommand):
         )
 
     @command(name="post-evidence", hidden=True, deprecated=True)
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def post_evidence(  # noqa: PLR0913 — CLI entrypoint, each flag is a distinct user-facing option
         self,
         *,

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -177,6 +177,7 @@ class Command(TyperCommand):
     # introspecting these kwargs; bundling them into a dataclass would delete
     # the flags. Same targeted-noqa-for-framework-reality pattern as the
     # repo's PLC0415 (import-in-function) and SLF001 (framework internals).
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def create(  # noqa: PLR0913
         self,
         ticket_id: str,

--- a/src/teatree/core/management/commands/retro.py
+++ b/src/teatree/core/management/commands/retro.py
@@ -90,6 +90,7 @@ class Command(TyperCommand):
         return json.dumps(self._run(pr_url, classification=classification, repo=repo, label=label))
 
     @command(name="gate-failures")
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def gate_failures(  # noqa: PLR0913 — django-typer command: every param is a CLI flag mapped 1:1 to the public --file/--session/--escalate/--repo/--pr-url/--label surface (same rationale as `ticket clear`), not an internal design smell.
         self,
         *,

--- a/src/teatree/core/management/commands/review.py
+++ b/src/teatree/core/management/commands/review.py
@@ -74,6 +74,7 @@ class Command(TyperCommand):
         """``t3 <overlay> review`` group root."""
 
     @command()
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def record(  # noqa: PLR0913 — django-typer command: every param maps 1:1 to a ReviewVerdict field, the arg list IS the public CLI surface (same rationale as `ticket clear`).
         self,
         pr_id: int,

--- a/src/teatree/core/management/commands/ticket.py
+++ b/src/teatree/core/management/commands/ticket.py
@@ -463,6 +463,7 @@ class Command(RubricCommands, TyperCommand):
         return {"ticket_id": int(ticket.pk), "context": edited}
 
     @command()
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def clear(  # noqa: PLR0913 — django-typer command: every param is a CLI flag mapped 1:1 to a §17.4.2 CLEAR field; the arg list IS the public CLI surface (same rationale as the file-wide PLR6301 ignore), not an internal design smell.
         self,
         pr_id: int,
@@ -716,6 +717,7 @@ class Command(RubricCommands, TyperCommand):
         return {"error": f"No code host could be resolved for {issue_url}"}
 
     @command(name="create-sub")
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def create_sub(  # noqa: PLR0913 — django-typer command: every param is a CLI flag mapped 1:1 to the public --parent/--title/--description/--description-file/--labels/--type surface (same rationale as `clear`), not an internal design smell.
         self,
         *,

--- a/src/teatree/core/merge/execution.py
+++ b/src/teatree/core/merge/execution.py
@@ -156,6 +156,7 @@ def _reconcile_if_already_merged(
     )
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def assert_merge_preconditions(  # noqa: PLR0913 — §17.4.3 gate entry-point; each kwarg is a documented step input.
     *,
     clear: object,

--- a/src/teatree/core/models/assess_finding.py
+++ b/src/teatree/core/models/assess_finding.py
@@ -47,6 +47,7 @@ class AssessFinding(models.Model):
         return f"assess-finding<{self.pk}:{self.repo}:{self.file_path}>"
 
     @classmethod
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def record(  # noqa: PLR0913 — model-level ledger record API; each kwarg is a documented field.
         cls,
         *,

--- a/src/teatree/core/models/audit_run.py
+++ b/src/teatree/core/models/audit_run.py
@@ -101,6 +101,7 @@ class SessionAuditRecord(models.Model):
         return f"session-audit<{self.pk}:{self.session_id}:{self.corpus_entry_id}={self.verdict}>"
 
     @classmethod
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def record(  # noqa: PLR0913 — audit-ledger create API; each kwarg is a documented field.
         cls,
         *,

--- a/src/teatree/core/models/consolidated_memory.py
+++ b/src/teatree/core/models/consolidated_memory.py
@@ -108,6 +108,7 @@ class ConsolidatedMemory(models.Model):
         return f"consolidated-memory<{self.pk}:{self.status}:{self.rule[:40]}>"
 
     @classmethod
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def record_cluster(  # noqa: PLR0913 — guarded ledger factory: each kwarg is a documented column, kwargs-only.
         cls,
         *,

--- a/src/teatree/core/models/deferred_question.py
+++ b/src/teatree/core/models/deferred_question.py
@@ -100,6 +100,7 @@ class DeferredQuestion(models.Model):
         return self.answered_at is None and self.dismissed_at is None
 
     @classmethod
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def record(  # noqa: PLR0913 — guarded factory: each kwarg is a documented column, kwargs-only.
         cls,
         question: str,

--- a/src/teatree/core/models/eval_run.py
+++ b/src/teatree/core/models/eval_run.py
@@ -131,6 +131,7 @@ class EvalRunManager(models.Manager["EvalRunRecord"]):
     def latest_baseline(self) -> "EvalRunRecord | None":
         return self.get_queryset().latest_baseline()
 
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def record(  # noqa: PLR0913 — run-ledger create API; each kwarg is a documented run attribute.
         self,
         *,
@@ -206,6 +207,7 @@ class EvalRunRecord(models.Model):
         self.is_baseline = True
         self.save(update_fields=["is_baseline"])
 
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def record_scenario(  # noqa: PLR0913 — per-scenario ledger record API; each kwarg is a documented field.
         self,
         *,

--- a/src/teatree/core/models/review_verdict.py
+++ b/src/teatree/core/models/review_verdict.py
@@ -160,6 +160,7 @@ class ReviewVerdict(models.Model):
         return f"review-verdict<{self.slug}#{self.pr_id}@{self.reviewed_sha[:8]} {self.verdict}>"
 
     @classmethod
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def record(  # noqa: PLR0913 — the §17.4.2-mirroring field set IS the public record contract, same rationale as MergeClear.issue's ClearRequest.
         cls,
         *,

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     from teatree.core.models.worktree import Worktree
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method count reflects the lifecycle state graph, not poor encapsulation.
     class State(models.TextChoices):
         NOT_STARTED = "not_started", "Not started"

--- a/src/teatree/core/notify.py
+++ b/src/teatree/core/notify.py
@@ -51,6 +51,7 @@ class NotifyKind(enum.StrEnum):
     INFO = "info"
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def notify_user(  # noqa: PLR0913 — single notification egress; each kwarg is a documented opt-in / test override.
     text: str,
     *,

--- a/src/teatree/core/on_behalf_egress.py
+++ b/src/teatree/core/on_behalf_egress.py
@@ -79,6 +79,7 @@ class OnBehalfSlackEgress:
             return False
         return bool(self._messaging._is_self_dm(channel))  # type: ignore[attr-defined]  # noqa: SLF001
 
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def react(  # noqa: PLR0913 — colleague-egress chokepoint; each kwarg is a documented gate/route/audit input, kwargs-only.
         self,
         *,
@@ -117,6 +118,7 @@ class OnBehalfSlackEgress:
             )
         return response
 
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def post(  # noqa: PLR0913 — colleague-egress chokepoint; each kwarg is a documented gate/route/audit input, kwargs-only.
         self,
         *,

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -412,6 +412,7 @@ class OverlayMetadata:
 # ── Overlay base class ───────────────────────────────────────────────
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count reflects surface, not poor encapsulation.
     django_app: str | None = None
     config: OverlayConfig = OverlayConfig()
@@ -482,6 +483,7 @@ class OverlayBase(ABC):  # noqa: PLR0904 — overlay extension API; hook count r
         """
         return variant
 
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def db_import(  # noqa: PLR0913 — overlay extension-point contract; each kwarg is a documented hook input, not poor design.
         self,
         worktree: "Worktree",

--- a/src/teatree/core/provision_timebox.py
+++ b/src/teatree/core/provision_timebox.py
@@ -136,6 +136,7 @@ def _emit_heartbeats(
         heartbeat(f"still running `{step}`… ({elapsed_min:.1f}m elapsed)")
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def run_timeboxed_step(  # noqa: PLR0913 — each kwarg is a documented opt-in / test seam.
     name: str,
     cmd: Sequence[str],

--- a/src/teatree/core/safe_kill.py
+++ b/src/teatree/core/safe_kill.py
@@ -197,6 +197,7 @@ def _refusal(detail: str, pid: int, identity: TargetIdentity, liveness: Liveness
     )
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def safe_kill(  # noqa: PLR0913 — single safe-kill egress; each kwarg is a documented boundary injection / test override, kwargs-only.
     pid: int,
     *,

--- a/src/teatree/core/step_runner.py
+++ b/src/teatree/core/step_runner.py
@@ -68,6 +68,7 @@ class ProvisionReport:
         return "\n".join(lines)
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def run_step(  # noqa: PLR0913
     name: str,
     cmd: list[str],

--- a/src/teatree/eval/backends.py
+++ b/src/teatree/eval/backends.py
@@ -58,6 +58,7 @@ class UnknownBackendError(ValueError):
     """Raised for a ``--backend`` value outside :data:`KNOWN_BACKENDS`."""
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def make_runner(  # noqa: PLR0913 — each kwarg threads one runner-construction knob (turns / budget / effort / require / transcript-dir) from the `t3 eval run` CLI; the list IS the backend contract.
     backend: str,
     *,

--- a/src/teatree/eval/persistence.py
+++ b/src/teatree/eval/persistence.py
@@ -110,6 +110,7 @@ def _judge_rationale(result: ScenarioResult) -> str:
     return result.judge.rationale
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def persist_run(  # noqa: PLR0913 — run-ledger boundary; each kwarg is a documented run attribute.
     results: list[ScenarioResult],
     *,

--- a/src/teatree/loop/self_improve/budget.py
+++ b/src/teatree/loop/self_improve/budget.py
@@ -126,6 +126,7 @@ class BudgetVerdict:
         return cls(ok=True, reason="")
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def precheck_budget(  # noqa: PLR0913  # each kwarg is a BLUEPRINT § 5.7 guardrail input; kwargs-only.
     *,
     ram_used_percent: float | None = None,

--- a/src/teatree/messaging/notify_with_fallback.py
+++ b/src/teatree/messaging/notify_with_fallback.py
@@ -295,6 +295,7 @@ def _record_fallback_failure(
     )
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def _upsert_botping(  # noqa: PLR0913 — one typed write site for the BotPing audit row; each field is explicit.
     *,
     idempotency_key: str,

--- a/src/teatree/skill_support/loading.py
+++ b/src/teatree/skill_support/loading.py
@@ -128,6 +128,7 @@ class SkillLoadingPolicy:
             logger.warning("Companion skill %r not installed — skipping", comp)
         return resolved
 
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def select_for_agent_launch(  # noqa: PLR0913
         self,
         *,
@@ -183,6 +184,7 @@ class SkillLoadingPolicy:
             ask_user=ask_user,
         )
 
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def select_for_prompt_hook(  # noqa: PLR0913
         self,
         *,
@@ -215,6 +217,7 @@ class SkillLoadingPolicy:
             advisory_skills=advisory,
         )
 
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def select_for_runtime_phase(  # noqa: PLR0913
         self,
         *,

--- a/tests/cli_codex/test_codex_review.py
+++ b/tests/cli_codex/test_codex_review.py
@@ -8,6 +8,7 @@ from typer.testing import CliRunner
 from teatree.cli.codex import codex_app
 from teatree.core.models.codex_review_marker import CodexReviewMarker
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/eval_harness/test_matrix.py
+++ b/tests/eval_harness/test_matrix.py
@@ -19,6 +19,7 @@ def _spec(name: str) -> EvalSpec:
     )
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def _row(  # noqa: PLR0913 — test-data builder: each kwarg maps 1:1 to a MatrixRow field a case varies.
     scenario: str,
     model: str,

--- a/tests/eval_harness/test_pass_at_k.py
+++ b/tests/eval_harness/test_pass_at_k.py
@@ -20,6 +20,7 @@ def _spec() -> EvalSpec:
     )
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def _result(  # noqa: PLR0913 — test-data builder: each kwarg maps 1:1 to an EvalRun field a case varies.
     spec: EvalSpec,
     *,

--- a/tests/eval_harness/test_persistence.py
+++ b/tests/eval_harness/test_persistence.py
@@ -30,6 +30,7 @@ def _spec(matchers: tuple[Matcher | AnyOf | FinalStateMatcher, ...]) -> EvalSpec
     )
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def _run(  # noqa: PLR0913 — test-data builder mirroring the EvalRun dataclass fields.
     tool_calls: tuple[EvalToolCall, ...],
     *,

--- a/tests/eval_replay/test_report.py
+++ b/tests/eval_replay/test_report.py
@@ -39,6 +39,7 @@ def _spec(
     )
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def _run(  # noqa: PLR0913 — test-data builder mirroring the EvalRun dataclass fields.
     *,
     spec_name: str = "scenario_one",

--- a/tests/integration/slack_bridge_e2e/test_askuserquestion_roundtrip.py
+++ b/tests/integration/slack_bridge_e2e/test_askuserquestion_roundtrip.py
@@ -24,6 +24,7 @@ from teatree.loop.scanners.askuserquestion_reply import AskUserQuestionReplyScan
 from teatree.loop.scanners.slack_dm_inbound import SlackDmInboundScanner
 from tests.integration.slack_bridge_e2e.conftest import FakeSlackTransport, _own_loop
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = [pytest.mark.django_db, pytest.mark.integration]
 
 _QUESTION = {

--- a/tests/integration/slack_bridge_e2e/test_backend_error_paths.py
+++ b/tests/integration/slack_bridge_e2e/test_backend_error_paths.py
@@ -8,6 +8,7 @@ from teatree.core.models import PendingChatInjection
 from teatree.loop.scanners.slack_dm_inbound import SlackDmInboundScanner
 from tests.integration.slack_bridge_e2e.conftest import FakeSlackTransport
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = [pytest.mark.django_db, pytest.mark.integration]
 
 

--- a/tests/integration/slack_bridge_e2e/test_inbound.py
+++ b/tests/integration/slack_bridge_e2e/test_inbound.py
@@ -10,6 +10,7 @@ from teatree.core.models import PendingChatInjection
 from teatree.loop.scanners.slack_dm_inbound import SlackDmInboundScanner
 from tests.integration.slack_bridge_e2e.conftest import FakeSlackTransport, _own_loop
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = [pytest.mark.django_db, pytest.mark.integration]
 
 

--- a/tests/integration/slack_bridge_e2e/test_outbound.py
+++ b/tests/integration/slack_bridge_e2e/test_outbound.py
@@ -18,6 +18,7 @@ from teatree.notify import NotifyKind, notify_user
 from teatree.types import SpeakConfig
 from tests.integration.slack_bridge_e2e.conftest import FakeSlackTransport, _FakeConfig
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = [pytest.mark.django_db, pytest.mark.integration]
 
 

--- a/tests/integration/slack_bridge_e2e/test_routing.py
+++ b/tests/integration/slack_bridge_e2e/test_routing.py
@@ -11,6 +11,7 @@ from teatree.core import backend_factory
 from teatree.core.backend_factory import iter_overlay_backends, messaging_from_overlay
 from tests.integration.slack_bridge_e2e.conftest import FakeSlackTransport, _FakeConfig
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = [pytest.mark.django_db, pytest.mark.integration]
 
 

--- a/tests/integration/slack_bridge_e2e/test_thread_reply_eyes_reaction.py
+++ b/tests/integration/slack_bridge_e2e/test_thread_reply_eyes_reaction.py
@@ -20,6 +20,7 @@ from teatree.loop.scanners.slack_dm_inbound import SlackDmInboundScanner
 from teatree.loop.slack_answer.cycle import run_slack_answer_cycle
 from tests.integration.slack_bridge_e2e.conftest import FakeSlackTransport
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = [pytest.mark.django_db, pytest.mark.integration]
 
 _ROOT_TS = "1700000000.0001"

--- a/tests/messaging/test_notify_with_fallback.py
+++ b/tests/messaging/test_notify_with_fallback.py
@@ -18,6 +18,7 @@ import pytest
 from teatree.core.models import BotPing
 from teatree.messaging.notify_with_fallback import NotifyTransport, notify_with_fallback
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _FALLBACK_TARGET = "teatree.messaging.notify_with_fallback.messaging_from_overlay"

--- a/tests/teatree_agents/test_honesty_escalation_routing.py
+++ b/tests/teatree_agents/test_honesty_escalation_routing.py
@@ -27,6 +27,7 @@ from django.utils import timezone
 from teatree.agents.model_tiering import resolve_spawn_model
 from teatree.core.models.honesty_escalation import _DEFAULT_TTL, HonestyEscalation
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 SESSION = "11111111-2222-3333-4444-555555555555"

--- a/tests/teatree_backends/test_slack_react_only_gate.py
+++ b/tests/teatree_backends/test_slack_react_only_gate.py
@@ -125,6 +125,7 @@ class TestAddReactionRaisesOnSlackError:
         assert slack_reactions.add_reactions_for_transition(ticket, "mark_merged") == 0
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestReactCommandSurfaceMissingScope:
     """``t3 slack react`` exits non-zero on a Slack ``ok:false`` (e.g. ``missing_scope``).

--- a/tests/teatree_cli/eval/test_audit.py
+++ b/tests/teatree_cli/eval/test_audit.py
@@ -38,6 +38,7 @@ _VIOLATING = _assistant_tool("Bash", {"command": "git push --force origin main"}
 _CLEAN = _assistant_tool("Bash", {"command": "ls"})
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestEvalAudit:
     def test_audits_recent_sessions_and_persists(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/teatree_cli/eval/test_label.py
+++ b/tests/teatree_cli/eval/test_label.py
@@ -67,6 +67,7 @@ def _label_yaml(entry_id: str, *, labelled_by: str = "human:rev", rule_author: s
     )
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestLabelNominate:
     def test_lists_nominated_records_with_slugs(self) -> None:
@@ -86,6 +87,7 @@ class TestLabelNominate:
         assert "(no records nominated for labelling)" in result.output
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestLabelAdd:
     def test_scaffolds_session_copy_and_label_template(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/teatree_cli/review/test_review_inline_post.py
+++ b/tests/teatree_cli/review/test_review_inline_post.py
@@ -25,6 +25,7 @@ import pytest
 from teatree.cli.review.post_impl import post_comment_impl
 from teatree.core.models import OutboundClaim
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_cli/test_cli_loop.py
+++ b/tests/teatree_cli/test_cli_loop.py
@@ -442,6 +442,7 @@ class TestSlackAnswerStartCommand:
         call.assert_called_once_with("loop_slack_answer", json_output=True)
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestLoopOwnerCli:
     """``t3 loop claim/owner/release`` end-to-end through the mgmt command (#1073)."""

--- a/tests/teatree_cli/test_eval.py
+++ b/tests/teatree_cli/test_eval.py
@@ -795,6 +795,7 @@ class TestEvalBackend:
         assert "metered in-process Agent-SDK runner" in result.output
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestEvalPersistAndHistory:
     def test_persists_and_history_lists_it(self) -> None:
@@ -889,6 +890,7 @@ def _per_scenario_cost_runner(costs: dict[str, float]) -> type:
     return _PerScenarioCostRunner
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestEvalCostRegressionGate:
     def _record_baseline(self, specs: list[EvalSpec], *, cost_usd: float) -> None:
@@ -958,6 +960,7 @@ class TestEvalCostRegressionGate:
         assert "no cost baseline" in result.output
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestEvalCostBoundsGate:
     """`--gate-cost-bounds` — the declarative absolute-ceiling gate.
@@ -1047,6 +1050,7 @@ class TestEvalCostBoundsGate:
         assert "ephemeral container" in result.output
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestEvalModelMatrix:
     def test_matrix_runs_each_model_and_renders_columns(self) -> None:
@@ -1137,6 +1141,7 @@ class TestEvalModelMatrix:
         assert "executed 0" in result.output
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestEvalModelVariantMatrix:
     """`--models` accepts `model@effort` variants; the tag is the identity string."""
@@ -1248,6 +1253,7 @@ class _EffortCapturingRunner:
         return _run(spec.name, tool_calls=_PASSING_CALL, cost_usd=0.20)
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestEvalBenchmark:
     def _invoke(self, args: list[str], *, specs: list[EvalSpec], runner: type = _BenchmarkRunner):
@@ -1488,6 +1494,7 @@ class _CostRunner:
         return _run(spec.name, tool_calls=_PASSING_CALL, cost_usd=type(self).cost)
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestMatrixCostRegressionGate:
     """`--gate-cost-regression` must NOT be silently inert for `--models`/`--trials`."""
@@ -1641,6 +1648,7 @@ def _prose_report(*, weakest: str = "beta") -> ProseJudgeReport:
 
 
 @contextmanager
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def _patch_all_lanes(  # noqa: PLR0913 — one keyword per free lane the `eval all` run patches; the list IS the lane set.
     specs: list[EvalSpec],
     *,

--- a/tests/teatree_cli/test_on_behalf_egress_cli_bypass_closed.py
+++ b/tests/teatree_cli/test_on_behalf_egress_cli_bypass_closed.py
@@ -16,6 +16,7 @@ from django.core.management import call_command
 
 from teatree.types import RawAPIDict
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _DM_CHANNEL = "D_SELF"

--- a/tests/teatree_cli/test_review_after_receipt_notify.py
+++ b/tests/teatree_cli/test_review_after_receipt_notify.py
@@ -26,6 +26,7 @@ import pytest
 from teatree.cli.review import ReviewService
 from teatree.core.models import BotPing
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_cli/test_review_approve_already_approved.py
+++ b/tests/teatree_cli/test_review_approve_already_approved.py
@@ -22,6 +22,7 @@ import pytest
 
 from teatree.cli.review import ReviewService
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_cli/test_review_approve_gate.py
+++ b/tests/teatree_cli/test_review_approve_gate.py
@@ -22,6 +22,7 @@ import pytest
 from teatree.cli.review import ReviewService
 from teatree.core.models import OnBehalfApproval
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_cli/test_review_authorize.py
+++ b/tests/teatree_cli/test_review_authorize.py
@@ -40,6 +40,7 @@ from teatree.config import OnBehalfPostMode
 from teatree.core.models.live_post_approval import LivePostApproval
 from teatree.core.models.on_behalf_approval import OnBehalfApproval
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _runner = CliRunner()

--- a/tests/teatree_cli/test_review_authorize_deferred.py
+++ b/tests/teatree_cli/test_review_authorize_deferred.py
@@ -30,6 +30,7 @@ from typer.testing import CliRunner
 
 from teatree.cli import app
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _runner = CliRunner()

--- a/tests/teatree_cli/test_review_default_to_draft.py
+++ b/tests/teatree_cli/test_review_default_to_draft.py
@@ -41,6 +41,7 @@ from teatree.cli.review import ReviewService
 from teatree.config import OnBehalfPostMode
 from teatree.core.models import BotPing, LivePostApproval
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _runner = CliRunner()

--- a/tests/teatree_cli/test_review_evidence_gate.py
+++ b/tests/teatree_cli/test_review_evidence_gate.py
@@ -31,6 +31,7 @@ from teatree.cli.review import ReviewService
 from teatree.cli.review.evidence_gate import FindingEvidence, check_finding_evidence, looks_like_evidence_claim
 from teatree.config import OnBehalfPostMode
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_cli/test_review_live_approval_eval.py
+++ b/tests/teatree_cli/test_review_live_approval_eval.py
@@ -31,6 +31,7 @@ from teatree.config import OnBehalfPostMode
 from teatree.core.models.live_post_approval import LivePostApproval
 from teatree.core.models.on_behalf_approval import OnBehalfApproval
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _runner = CliRunner()

--- a/tests/teatree_cli/test_review_on_behalf_gate.py
+++ b/tests/teatree_cli/test_review_on_behalf_gate.py
@@ -45,6 +45,7 @@ from teatree.cli.review import ReviewService
 from teatree.config import OnBehalfPostMode
 from teatree.core.models import BotPing, OnBehalfApproval
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _runner = CliRunner()

--- a/tests/teatree_cli/test_review_outbound_claim.py
+++ b/tests/teatree_cli/test_review_outbound_claim.py
@@ -14,6 +14,7 @@ import pytest
 from teatree.cli.review import ReviewService
 from teatree.core.models import OnBehalfApproval, OutboundClaim
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_cli/test_review_post_impl_non_diffnote.py
+++ b/tests/teatree_cli/test_review_post_impl_non_diffnote.py
@@ -25,6 +25,7 @@ import pytest
 from teatree.cli.review.post_impl import post_comment_impl
 from teatree.core.models import OutboundClaim
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_cli/test_review_run.py
+++ b/tests/teatree_cli/test_review_run.py
@@ -28,6 +28,7 @@ from typer.testing import CliRunner
 
 from teatree.cli.review import review_app
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 type JSONObject = dict[str, object]

--- a/tests/teatree_cli/test_review_shape_gate.py
+++ b/tests/teatree_cli/test_review_shape_gate.py
@@ -27,6 +27,7 @@ import pytest
 from teatree.cli.review import ReviewService
 from teatree.config import OnBehalfPostMode
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _AUTHOR_CAROL = "carol"

--- a/tests/teatree_cli/test_review_todo_gate.py
+++ b/tests/teatree_cli/test_review_todo_gate.py
@@ -23,6 +23,7 @@ import pytest
 from teatree.cli.review import ReviewService
 from teatree.config import OnBehalfPostMode
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_cli/test_review_verify_after_post.py
+++ b/tests/teatree_cli/test_review_verify_after_post.py
@@ -25,6 +25,7 @@ import pytest
 from teatree.cli.review import ReviewService
 from teatree.core.models import OutboundClaim
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/management/test_honesty_command.py
+++ b/tests/teatree_core/management/test_honesty_command.py
@@ -13,6 +13,7 @@ from django.core.management import call_command
 
 from teatree.core.models import HonestyEscalation
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _SESSION = "99999999-aaaa-bbbb-cccc-dddddddddddd"

--- a/tests/teatree_core/management/test_questions_command_atomicity.py
+++ b/tests/teatree_core/management/test_questions_command_atomicity.py
@@ -24,6 +24,7 @@ from django.core.management import call_command
 
 from teatree.core.models.deferred_question import DeferredQuestion, DeferredQuestionAudit
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db(transaction=True)
 
 

--- a/tests/teatree_core/management_commands/_overlays.py
+++ b/tests/teatree_core/management_commands/_overlays.py
@@ -118,6 +118,7 @@ class FullOverlay(OverlayBase):
     def get_db_import_strategy(self, worktree: Worktree) -> DbImportStrategy:
         return {"kind": "test", "source_database": "test_db"}
 
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def db_import(  # noqa: PLR0913 — mirrors the OverlayBase.db_import extension-point contract.
         self,
         worktree: Worktree,
@@ -241,6 +242,7 @@ class PostDbStepsOverlay(FullOverlay):
 class FailingImportOverlay(FullOverlay):
     """Overlay where db_import always fails — tests error reporting."""
 
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def db_import(  # noqa: PLR0913 — mirrors the OverlayBase.db_import extension-point contract.
         self,
         worktree: Worktree,
@@ -276,6 +278,7 @@ class RemotePathRecordingOverlay(FullOverlay):
         super().__init__()
         self.calls: dict[str, object] = {}
 
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def db_import(  # noqa: PLR0913 — mirrors the OverlayBase.db_import extension-point contract.
         self,
         worktree: Worktree,

--- a/tests/teatree_core/management_commands/test_availability.py
+++ b/tests/teatree_core/management_commands/test_availability.py
@@ -12,6 +12,7 @@ from teatree.core.availability import MODE_AWAY, MODE_PRESENT, load_override
 from teatree.core.management.commands.availability import Command as AvailabilityCommand
 from teatree.core.models.deferred_question import DeferredQuestion
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/management_commands/test_checking.py
+++ b/tests/teatree_core/management_commands/test_checking.py
@@ -26,6 +26,7 @@ from teatree.core.models.merge_clear import ClearRequest, MergeAudit, MergeClear
 from teatree.core.models.ticket import Ticket
 from teatree.core.overlay import OverlayBase, OverlayMetadata
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _SHA = "b" * 40

--- a/tests/teatree_core/management_commands/test_cost.py
+++ b/tests/teatree_core/management_commands/test_cost.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from teatree.core.models import Session, Task, TaskAttempt
 from tests.factories import TicketFactory
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/management_commands/test_dogfood.py
+++ b/tests/teatree_core/management_commands/test_dogfood.py
@@ -24,6 +24,7 @@ from django.core.management import call_command
 
 from teatree.loop.dogfood_smoke import SmokeOutcomeKind, SmokeReport, SmokeStep, StepResult
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/management_commands/test_handover.py
+++ b/tests/teatree_core/management_commands/test_handover.py
@@ -10,6 +10,7 @@ from django.core.management import call_command
 
 from teatree.core.models import LoopLease, SessionHandover
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/management_commands/test_info_artifacts.py
+++ b/tests/teatree_core/management_commands/test_info_artifacts.py
@@ -16,6 +16,7 @@ from django.core.management import call_command
 
 from teatree.core.models import E2eMandatoryRun, PlanArtifact, Session, Task, Ticket, Worktree
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/management_commands/test_mr_reminder.py
+++ b/tests/teatree_core/management_commands/test_mr_reminder.py
@@ -22,6 +22,7 @@ from teatree.config_mr_reminder import MrReminderConfig
 from teatree.core.management.commands import mr_reminder as command_module
 from teatree.core.on_behalf_egress import OnBehalfPostBlockedError
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _CONFIG = MrReminderConfig(

--- a/tests/teatree_core/management_commands/test_notify.py
+++ b/tests/teatree_core/management_commands/test_notify.py
@@ -16,6 +16,7 @@ from django.core.management import CommandError, call_command
 
 from teatree.core.models import BotPing
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/management_commands/test_notify_post_react.py
+++ b/tests/teatree_core/management_commands/test_notify_post_react.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.core.management import call_command
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/management_commands/test_notify_post_speaks.py
+++ b/tests/teatree_core/management_commands/test_notify_post_speaks.py
@@ -33,6 +33,7 @@ from django.core.management import call_command
 from teatree.backends.slack.bot import SlackBotBackend
 from teatree.types import LocalPlayback, SpeakConfig
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _DM_CHANNEL = "D_ME"

--- a/tests/teatree_core/management_commands/test_pending_chat.py
+++ b/tests/teatree_core/management_commands/test_pending_chat.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 
 from teatree.core.models import PendingChatInjection
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/management_commands/test_questions_resurface.py
+++ b/tests/teatree_core/management_commands/test_questions_resurface.py
@@ -20,6 +20,7 @@ from teatree.core.models import BotPing
 from teatree.core.models.deferred_question import DeferredQuestion
 from teatree.core.notify import _resurface_text
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/management_commands/test_review_advance_loop.py
+++ b/tests/teatree_core/management_commands/test_review_advance_loop.py
@@ -15,6 +15,7 @@ from django.test import TestCase
 
 from teatree.core.models import ReviewLoop, Task, Ticket
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _SLUG = "acme/repo"

--- a/tests/teatree_core/management_commands/test_review_record_triggers_sweep.py
+++ b/tests/teatree_core/management_commands/test_review_record_triggers_sweep.py
@@ -22,6 +22,7 @@ from django.test import TestCase
 
 from teatree.loop.scanners.pr_sweep import MergeAttempt
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _SLUG = "souliane/teatree"

--- a/tests/teatree_core/management_commands/test_review_status.py
+++ b/tests/teatree_core/management_commands/test_review_status.py
@@ -22,6 +22,7 @@ from django.test import TestCase
 from teatree.core.models import MergeClear, ReviewVerdict
 from tests.factories import TicketFactory
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _REVIEWED = "a" * 40

--- a/tests/teatree_core/management_commands/test_ticket_short_describe.py
+++ b/tests/teatree_core/management_commands/test_ticket_short_describe.py
@@ -148,6 +148,7 @@ class TestClaudeSummarizer:
         assert spawn_calls == []
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestDescribeOne(TestCase):
     def test_missing_ticket_emits_noop_and_exits_one(self) -> None:
@@ -180,6 +181,7 @@ class TestDescribeOne(TestCase):
         assert ticket.short_description == "dogfood smoke scanner"
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestDescribeAllMissing(TestCase):
     def test_skips_tickets_without_title(self) -> None:
@@ -211,6 +213,7 @@ class TestDescribeAllMissing(TestCase):
         assert any("DONE  described 2 ticket(s)" in line for line in captured)
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestCommandDescribeMethod(TestCase):
     """Cover the ``Command.describe`` argument-validation branches directly."""

--- a/tests/teatree_core/models/test_auto_review_dispatch.py
+++ b/tests/teatree_core/models/test_auto_review_dispatch.py
@@ -5,6 +5,7 @@ import pytest
 from teatree.core.models import AutoReviewDispatch, Task, Ticket
 from teatree.core.models.auto_review_dispatch import build_review_contract
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 SLUG = "souliane/teatree"

--- a/tests/teatree_core/models/test_inject_answered_questions.py
+++ b/tests/teatree_core/models/test_inject_answered_questions.py
@@ -13,6 +13,7 @@ import pytest
 import hooks.scripts.hook_router as router
 from teatree.core.models.deferred_question import DeferredQuestion
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/models/test_session_repo_lists.py
+++ b/tests/teatree_core/models/test_session_repo_lists.py
@@ -17,6 +17,7 @@ import pytest
 
 from teatree.core.models import Session, Ticket
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/models/test_slack_mirror_hook.py
+++ b/tests/teatree_core/models/test_slack_mirror_hook.py
@@ -16,6 +16,7 @@ import pytest
 import hooks.scripts.hook_router as router
 from teatree.core.models.deferred_question import DeferredQuestion
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/sync/_overlays.py
+++ b/tests/teatree_core/sync/_overlays.py
@@ -19,6 +19,7 @@ from teatree.core.overlay import OverlayBase, OverlayConfig, ProvisionStep
 class SyncConfig(OverlayConfig):
     """Configurable overlay config for sync tests."""
 
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def __init__(  # noqa: PLR0913
         self,
         *,

--- a/tests/teatree_core/test_answered_at_gate_stop_hook.py
+++ b/tests/teatree_core/test_answered_at_gate_stop_hook.py
@@ -27,6 +27,7 @@ from django.utils import timezone
 from hooks.scripts.hook_router import _HANDLERS, handle_enforce_answered_questions
 from teatree.core.models import PendingChatInjection
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/test_anti_vacuity_gate.py
+++ b/tests/teatree_core/test_anti_vacuity_gate.py
@@ -28,6 +28,7 @@ from teatree.core.gates.anti_vacuity_gate import (
 )
 from teatree.core.models import Ticket
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _SHA = "a" * 40

--- a/tests/teatree_core/test_availability_transition_drain.py
+++ b/tests/teatree_core/test_availability_transition_drain.py
@@ -23,6 +23,7 @@ from teatree.core.availability import MODE_AWAY, MODE_PRESENT, load_override, wr
 from teatree.core.models import BotPing
 from teatree.core.models.deferred_question import DeferredQuestion
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/test_clear_issuance_and_human_substrate.py
+++ b/tests/teatree_core/test_clear_issuance_and_human_substrate.py
@@ -37,6 +37,7 @@ from django.test import TestCase
 from teatree.core.merge import MergePreconditionError, assert_merge_preconditions, merge_ticket_pr
 from teatree.core.models import MergeAudit, MergeClear, Ticket
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _SHA = "c" * 40

--- a/tests/teatree_core/test_deferred_question_mirror.py
+++ b/tests/teatree_core/test_deferred_question_mirror.py
@@ -15,6 +15,7 @@ from django.utils import timezone
 
 from teatree.core.models.deferred_question import DeferredQuestion
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/test_deferred_question_model.py
+++ b/tests/teatree_core/test_deferred_question_model.py
@@ -9,6 +9,7 @@ import pytest
 
 from teatree.core.models.deferred_question import DeferredQuestion, DeferredQuestionAudit, DeferredQuestionError
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/test_honesty_escalation_backstop.py
+++ b/tests/teatree_core/test_honesty_escalation_backstop.py
@@ -24,6 +24,7 @@ from teatree.config import UserSettings
 from teatree.core.gates.rubric_gate import RubricNotSatisfiedError, check_rubric_satisfied
 from teatree.core.models import HonestyEscalation, Rubric, Session, Ticket
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _SHA = "a" * 40

--- a/tests/teatree_core/test_is_non_reviewer_role.py
+++ b/tests/teatree_core/test_is_non_reviewer_role.py
@@ -17,6 +17,7 @@ from teatree.core.merge import MergePreconditionError, merge_ticket_pr
 from teatree.core.models import MergeClear, Ticket
 from teatree.core.models.merge_clear import ClearIssuanceError, ClearRequest, is_non_reviewer_role
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _SHA = "d" * 40

--- a/tests/teatree_core/test_lifecycle_anti_vacuity.py
+++ b/tests/teatree_core/test_lifecycle_anti_vacuity.py
@@ -14,6 +14,7 @@ from django.test import TestCase
 
 from teatree.core.models import Ticket
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _SHA = "a" * 40

--- a/tests/teatree_core/test_lifecycle_review_context.py
+++ b/tests/teatree_core/test_lifecycle_review_context.py
@@ -30,6 +30,7 @@ from teatree.core.management.commands.lifecycle import ReviewContextError
 from teatree.core.models import Session, Ticket
 from teatree.core.models.task import Task
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/test_lifecycle_review_skill_evidence.py
+++ b/tests/teatree_core/test_lifecycle_review_skill_evidence.py
@@ -26,6 +26,7 @@ from teatree.core.gates.review_skill_gate import configured_review_skill, record
 from teatree.core.management.commands.lifecycle import ReviewSkillEvidenceError
 from teatree.core.models import Session, Ticket
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/test_lifecycle_reviewer_attestation.py
+++ b/tests/teatree_core/test_lifecycle_reviewer_attestation.py
@@ -20,6 +20,7 @@ from django.test import TestCase
 from teatree.core.management.commands.lifecycle import ReviewerAttestationError
 from teatree.core.models import MergeClear, Session, Ticket
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -399,6 +399,7 @@ class TestSessionTodoRendering(TestCase):
     """The session-scoped renderer prints two labeled sections, never merged."""
 
     @staticmethod
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def _row(  # noqa: PLR0913 — test-data builder mirroring the TaskRow TypedDict fields.
         task_id: int,
         *,
@@ -589,6 +590,7 @@ class DbOverlay(CommandOverlay):
     def get_db_import_strategy(self, worktree: Worktree) -> DbImportStrategy | None:
         return DbImportStrategy(kind="dslr", source_database="development-acme")
 
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def db_import(  # noqa: PLR0913 — mirrors the OverlayBase.db_import extension-point contract.
         self,
         worktree: Worktree,

--- a/tests/teatree_core/test_merge_anti_vacuity_gate.py
+++ b/tests/teatree_core/test_merge_anti_vacuity_gate.py
@@ -23,6 +23,7 @@ from teatree.core.merge import MergePreconditionError, merge_ticket_pr
 from teatree.core.models import MergeClear, Ticket
 from tests.teatree_core.test_merge_execution import _GhStub
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _SHA = "a" * 40

--- a/tests/teatree_core/test_merge_candidate_working_repos.py
+++ b/tests/teatree_core/test_merge_candidate_working_repos.py
@@ -37,6 +37,7 @@ from teatree.core.merge import MergePreconditionError, merge_ticket_pr, pr_slug_
 from teatree.core.models import MergeClear
 from teatree.core.overlay import OverlayBase
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _RIGHT_SHA = "a" * 40  # the reviewed SHA on the working-repo PR

--- a/tests/teatree_core/test_merge_clear_verdict_must_be_merge_safe.py
+++ b/tests/teatree_core/test_merge_clear_verdict_must_be_merge_safe.py
@@ -25,6 +25,7 @@ from teatree.core.merge import MergePreconditionError, merge_ticket_pr
 from teatree.core.models import MergeAudit, MergeClear
 from tests.factories import _FORTY_HEX, MergeClearFactory, TicketFactory
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _GREEN = '[{"status": "COMPLETED", "conclusion": "SUCCESS"}]'

--- a/tests/teatree_core/test_merge_execution.py
+++ b/tests/teatree_core/test_merge_execution.py
@@ -31,6 +31,7 @@ from teatree.core.merge import (
 )
 from teatree.core.models import ClearRequest, MergeAudit, MergeClear, Session, Ticket
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _SHA = "a" * 40

--- a/tests/teatree_core/test_merge_execution_cross_repo.py
+++ b/tests/teatree_core/test_merge_execution_cross_repo.py
@@ -28,6 +28,7 @@ from teatree.config import OverlayEntry
 from teatree.core.merge import MergePreconditionError, merge_ticket_pr
 from teatree.core.models import MergeClear
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _RIGHT_SHA = "a" * 40  # the reviewed SHA on the cross-repo PR

--- a/tests/teatree_core/test_merge_execution_gitlab.py
+++ b/tests/teatree_core/test_merge_execution_gitlab.py
@@ -31,6 +31,7 @@ from teatree.core.merge import (
 )
 from teatree.core.models import MergeAudit, MergeClear, Ticket
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _SHA = "a" * 40
@@ -57,6 +58,7 @@ def _clear(ticket: Ticket, **overrides: object) -> MergeClear:
 class _GlabStub:
     """Scripted ``glab`` responses keyed by URL substring; records argv per call."""
 
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def __init__(  # noqa: PLR0913 — test stub mirrors the response surface; each field models one wire-API field.
         self,
         *,

--- a/tests/teatree_core/test_merge_head_guard.py
+++ b/tests/teatree_core/test_merge_head_guard.py
@@ -27,6 +27,7 @@ from teatree.core.merge import merge_ticket_pr, restore_caller_branch
 from teatree.core.merge.head_guard import _capture_head, _restore_head
 from teatree.core.models import MergeClear, Ticket
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _SHA = "a" * 40

--- a/tests/teatree_core/test_merge_repo_resolution.py
+++ b/tests/teatree_core/test_merge_repo_resolution.py
@@ -30,6 +30,7 @@ from teatree.core.merge import (
 )
 from teatree.core.models import MergeClear, Ticket
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _SHA = "a" * 40

--- a/tests/teatree_core/test_merge_same_sha_candidate_ambiguity.py
+++ b/tests/teatree_core/test_merge_same_sha_candidate_ambiguity.py
@@ -27,6 +27,7 @@ from django.test import TestCase
 
 from teatree.core.merge import MergePreconditionError, pr_slug_resolution
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _REVIEWED_SHA = "a" * 40  # the reviewed SHA carried by the CLEAR

--- a/tests/teatree_core/test_merge_unknown_repo_scope.py
+++ b/tests/teatree_core/test_merge_unknown_repo_scope.py
@@ -22,6 +22,7 @@ from django.test import TestCase
 from teatree.core.models import MergeClear, Ticket
 from teatree.core.overlay import OverlayBase, OverlayConfig
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _SHA = "a" * 40

--- a/tests/teatree_core/test_on_behalf_approval.py
+++ b/tests/teatree_core/test_on_behalf_approval.py
@@ -10,6 +10,7 @@ import pytest
 
 from teatree.core.models.on_behalf_approval import OnBehalfApproval, OnBehalfApprovalError, OnBehalfAudit
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/test_on_behalf_autodraft_dm.py
+++ b/tests/teatree_core/test_on_behalf_autodraft_dm.py
@@ -28,6 +28,7 @@ from teatree.config import OnBehalfPostMode
 from teatree.core.models import BotPing
 from teatree.core.on_behalf_gate_recorded import require_on_behalf_approval
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/test_on_behalf_gate_recorded.py
+++ b/tests/teatree_core/test_on_behalf_gate_recorded.py
@@ -31,6 +31,7 @@ from teatree.core.on_behalf_gate_recorded import (
     require_on_behalf_approval,
 )
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/test_on_behalf_post_receipt.py
+++ b/tests/teatree_core/test_on_behalf_post_receipt.py
@@ -28,6 +28,7 @@ import pytest
 from teatree.core.models import BotPing
 from teatree.core.on_behalf_post_receipt import notify_user_on_behalf_post
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/test_on_behalf_receipt_autonomy_notify.py
+++ b/tests/teatree_core/test_on_behalf_receipt_autonomy_notify.py
@@ -20,6 +20,7 @@ import pytest
 from teatree.core.models import BotPing
 from teatree.core.on_behalf_post_receipt import notify_user_on_behalf_post
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/test_on_behalf_target_canonicalization.py
+++ b/tests/teatree_core/test_on_behalf_target_canonicalization.py
@@ -29,6 +29,7 @@ import pytest
 
 from teatree.core.models.on_behalf_approval import OnBehalfApproval, OnBehalfAudit
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 # The same MR expressed in the three surface forms the consume call sites

--- a/tests/teatree_core/test_pending_chat_injection_hook.py
+++ b/tests/teatree_core/test_pending_chat_injection_hook.py
@@ -25,6 +25,7 @@ import hooks.scripts.hook_router as router
 from hooks.scripts.hook_router import _OWNER_LOOP, _write_loop_registry, handle_inject_pending_chat
 from teatree.core.models import PendingChatInjection
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/test_pending_chat_injection_is_question.py
+++ b/tests/teatree_core/test_pending_chat_injection_is_question.py
@@ -13,6 +13,7 @@ import pytest
 from teatree.core.models import PendingChatInjection
 from teatree.core.models.pending_chat_injection import _classify_is_question
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/test_pending_chat_injection_model.py
+++ b/tests/teatree_core/test_pending_chat_injection_model.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 
 from teatree.core.models import PendingChatInjection
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/test_pending_reinstall_model.py
+++ b/tests/teatree_core/test_pending_reinstall_model.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 
 from teatree.core.models.pending_reinstall import PendingReinstall
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/test_red_card_signal_model.py
+++ b/tests/teatree_core/test_red_card_signal_model.py
@@ -14,6 +14,7 @@ import pytest
 
 from teatree.core.models import RedCardIntent, RedCardSignal
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/test_reference_linkifier.py
+++ b/tests/teatree_core/test_reference_linkifier.py
@@ -128,6 +128,7 @@ class TestReferenceResolverConstruction:
         assert resolver.resolve_issue_for_slug("other/repo", 9) == "https://github.com/other/repo/issues/9"
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestReferenceResolverDbHit:
     def test_pull_request_url_wins_over_construction(self) -> None:

--- a/tests/teatree_core/test_reply_transport_on_behalf_gate.py
+++ b/tests/teatree_core/test_reply_transport_on_behalf_gate.py
@@ -36,6 +36,7 @@ def _gate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, mode: OnBehalfPost
 _BLOCKING_MODES = [OnBehalfPostMode.ASK, OnBehalfPostMode.DRAFT_OR_ASK]
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestReplyTransportOnBehalfGate:
     @pytest.fixture(autouse=True)
@@ -120,6 +121,7 @@ def _notify_backend() -> MagicMock:
     return backend
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestReplyTransportAfterReceiptDm:
     """#949: a SENT on-behalf reply fires one after-receipt DM; post_dm does not."""
@@ -220,6 +222,7 @@ class _FlakyReplier(_BaseReplier):
         return "https://example.com/posted"
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestRedeliverReusesReservation:
     """#1879: a failed redeliver rolls back the consume — the approval is reused, not burned per retry."""

--- a/tests/teatree_core/test_review_assignment_model.py
+++ b/tests/teatree_core/test_review_assignment_model.py
@@ -6,6 +6,7 @@ import pytest
 
 from teatree.core.models import ReviewAssignment, ReviewIntent
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/test_review_verdict_model.py
+++ b/tests/teatree_core/test_review_verdict_model.py
@@ -12,6 +12,7 @@ from django.test import TestCase
 
 from teatree.core.models import Finding, MergeClear, ReviewVerdict, ReviewVerdictError
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _SHA = "a" * 40

--- a/tests/teatree_core/test_rubric_gate_merge_precondition.py
+++ b/tests/teatree_core/test_rubric_gate_merge_precondition.py
@@ -27,6 +27,7 @@ from teatree.core.merge import MergePreconditionError, merge_ticket_pr
 from teatree.core.models import MergeClear, Rubric, RubricCriterion, Ticket
 from tests.teatree_core.test_merge_execution import _GhStub
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _SHA = "a" * 40

--- a/tests/teatree_core/test_rubric_model.py
+++ b/tests/teatree_core/test_rubric_model.py
@@ -12,6 +12,7 @@ from django.test import TestCase
 
 from teatree.core.models import Rubric, RubricCriterion, RubricError, Ticket
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _SHA = "a" * 40

--- a/tests/teatree_core/test_session_identity.py
+++ b/tests/teatree_core/test_session_identity.py
@@ -24,6 +24,7 @@ from django.utils import timezone
 from teatree.core.models import LoopLease
 from teatree.core.session_identity import current_session_id, current_session_pid
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_core/test_stop_hook_output_schema.py
+++ b/tests/teatree_core/test_stop_hook_output_schema.py
@@ -28,6 +28,7 @@ import pytest
 from hooks.scripts.hook_router import handle_consideration_gate, handle_enforce_answered_questions
 from teatree.core.models import PendingChatInjection
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_eval/test_benchmark.py
+++ b/tests/teatree_eval/test_benchmark.py
@@ -9,6 +9,7 @@ from teatree.eval.matrix import MatrixRow
 from teatree.eval.models import TokenUsage
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def _row(  # noqa: PLR0913 — test-data builder: each kwarg maps 1:1 to a MatrixRow field a case varies.
     scenario: str,
     model: str,

--- a/tests/teatree_eval/test_cost_fit.py
+++ b/tests/teatree_eval/test_cost_fit.py
@@ -20,6 +20,7 @@ def _billed(usage: TokenUsage, *, base_in: float, out: float) -> float:
     return base_in * usage.effective_billed_input + out * usage.output
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def _cell(  # noqa: PLR0913 — test-data builder: one kwarg per TokenUsage/rate field a case varies.
     inp: int, cc: int, cr: int, out: int, *, base_in: float, out_rate: float
 ) -> CostCell:

--- a/tests/teatree_eval/test_sdk_runner.py
+++ b/tests/teatree_eval/test_sdk_runner.py
@@ -75,6 +75,7 @@ def _fake_query(messages: list[Any]):
     return _query, captured
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def _result(  # noqa: PLR0913 — test-data builder: each kwarg maps 1:1 to a ResultMessage field a case varies.
     *,
     subtype: str = "success",

--- a/tests/teatree_loop/self_improve/test_action_ladder.py
+++ b/tests/teatree_loop/self_improve/test_action_ladder.py
@@ -25,6 +25,7 @@ from teatree.loop.self_improve.detectors import (
 )
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def _report(  # noqa: PLR0913  # test helper: each kwarg maps 1:1 to a DetectorReport field.
     *,
     detector: str = "dispatch_gap",

--- a/tests/teatree_loop/self_improve/test_record_firing_atomicity.py
+++ b/tests/teatree_loop/self_improve/test_record_firing_atomicity.py
@@ -20,6 +20,7 @@ from teatree.core.models.self_improve_firing import SelfImproveFiring
 from teatree.loop.self_improve.detectors.base import DetectorReport
 from teatree.loop.self_improve.persistence import record_firing
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/slack_answer/test_coalescing.py
+++ b/tests/teatree_loop/slack_answer/test_coalescing.py
@@ -17,6 +17,7 @@ from teatree.core.models import PendingChatInjection
 from teatree.loop.slack_answer.cycle import _COALESCE_WINDOW_SECONDS, _coalesce, run_slack_answer_cycle
 from teatree.types import RawAPIDict
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/slack_answer/test_cycle.py
+++ b/tests/teatree_loop/slack_answer/test_cycle.py
@@ -23,6 +23,7 @@ from teatree.core.models import PendingChatInjection, Task, Ticket
 from teatree.loop.slack_answer.cycle import run_slack_answer_cycle
 from teatree.types import RawAPIDict
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/slack_answer/test_cycle_internals.py
+++ b/tests/teatree_loop/slack_answer/test_cycle_internals.py
@@ -24,6 +24,7 @@ from teatree.loop.slack_answer.cycle import (
 )
 from teatree.types import RawAPIDict
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/slack_answer/test_drain_answer_concurrency.py
+++ b/tests/teatree_loop/slack_answer/test_drain_answer_concurrency.py
@@ -18,6 +18,7 @@ from teatree.core.models import PendingChatInjection
 from teatree.loop.slack_answer.cycle import run_slack_answer_cycle
 from teatree.types import RawAPIDict
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/slack_answer/test_loop_slack_answer_command.py
+++ b/tests/teatree_loop/slack_answer/test_loop_slack_answer_command.py
@@ -22,6 +22,7 @@ from teatree.types import RawAPIDict
 
 runner = CliRunner()
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/slack_answer/test_simple_answer.py
+++ b/tests/teatree_loop/slack_answer/test_simple_answer.py
@@ -14,6 +14,7 @@ import pytest
 from teatree.core.models import PendingChatInjection
 from teatree.loop.slack_answer.simple_answer import NEEDS_WORK_SENTINEL, build_simple_answer
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/slack_answer/test_slack_answer_no_prose_ack.py
+++ b/tests/teatree_loop/slack_answer/test_slack_answer_no_prose_ack.py
@@ -28,6 +28,7 @@ from teatree.core.models import PendingChatInjection, Task
 from teatree.loop.slack_answer.cycle import run_slack_answer_cycle
 from teatree.types import RawAPIDict
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/test_askuserquestion_reply_scanner.py
+++ b/tests/teatree_loop/test_askuserquestion_reply_scanner.py
@@ -21,6 +21,7 @@ from teatree.core.models.deferred_question import DeferredQuestion
 from teatree.loop.scanners.askuserquestion_reply import AskUserQuestionReplyScanner
 from teatree.types import RawAPIDict
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _CHANNEL = "D-user"

--- a/tests/teatree_loop/test_availability_anchor.py
+++ b/tests/teatree_loop/test_availability_anchor.py
@@ -33,6 +33,7 @@ class TestAvailabilitySegment:
         assert availability_segment(Resolution(mode="???", source="default")) == ""
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestAvailabilitySegmentRidesLoopLineLive:
     @pytest.fixture

--- a/tests/teatree_loop/test_bug_fixes.py
+++ b/tests/teatree_loop/test_bug_fixes.py
@@ -25,6 +25,7 @@ from teatree.loop.scanners.codex_review import _decode_pr
 from teatree.loop.scanners.slack_broadcasts import MrState, SlackBroadcastsScanner
 from teatree.types import RawAPIDict
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 # ---------------------------------------------------------------------------

--- a/tests/teatree_loop/test_codex_review_scanner.py
+++ b/tests/teatree_loop/test_codex_review_scanner.py
@@ -29,6 +29,7 @@ from teatree.loop.scanners.codex_review import (
     _decode_pr,
 )
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/test_on_behalf_egress_bypass_closed.py
+++ b/tests/teatree_loop/test_on_behalf_egress_bypass_closed.py
@@ -27,6 +27,7 @@ from teatree.loop.scanners.review_request_merge_react import react_merge_on_post
 from teatree.loop.scanners.slack_broadcasts import MrState, SlackBroadcastsScanner
 from teatree.types import RawAPIDict
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _DM_CHANNEL = "D_SELF"

--- a/tests/teatree_loop/test_pr_sweep_scanner.py
+++ b/tests/teatree_loop/test_pr_sweep_scanner.py
@@ -35,6 +35,7 @@ from teatree.loop.scanners.pr_sweep_adapters import (
     _decode_pr,
 )
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 
@@ -75,6 +76,7 @@ def _issue_clear(*, pr_id: int = 6230, sha: str = HEAD) -> MergeClear:
     )
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def _open_pr(  # noqa: PLR0913 — test helper: each kwarg maps 1:1 to a PrSummary field the cases vary.
     *,
     pr_id: int = 6230,
@@ -162,6 +164,7 @@ class FakeReviewDispatcher:
         return self.returns
 
 
+# ast-grep-ignore: ac-django-no-complexity-suppressions
 def _scanner(  # noqa: PLR0913 — test helper: each kwarg maps 1:1 to a PrSweepScanner constructor flag the cases vary.
     *,
     api: FakePrApiClient,

--- a/tests/teatree_loop/test_pull_main_clone_scanner.py
+++ b/tests/teatree_loop/test_pull_main_clone_scanner.py
@@ -35,6 +35,7 @@ from django.utils import timezone
 from teatree.core.models.pull_main_clone_marker import PullMainCloneMarker
 from teatree.loop.scanners.pull_main_clone import PullMainCloneScanner
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/test_queue_drain.py
+++ b/tests/teatree_loop/test_queue_drain.py
@@ -29,6 +29,7 @@ from teatree.loop.queue_drain import (
     stale_threshold_hours,
 )
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 DB_BACKEND = {"TASKS": {"default": {"BACKEND": "django_tasks_db.backend.DatabaseBackend"}}}
@@ -87,6 +88,7 @@ class TestExpireStaleReadyJobs:
         assert DBTaskResult.objects.get().status == TaskResultStatus.RUNNING
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db(transaction=True)
 class TestDrainReadyBatch:
     def test_drains_and_runs_a_ready_job(self) -> None:
@@ -134,6 +136,7 @@ class TestDrainReadyBatch:
         assert a_worker_is_running() is False
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db(transaction=True)
 class TestExpireThenDrain:
     def test_stale_heavy_job_is_expired_before_it_can_run(self) -> None:
@@ -174,6 +177,7 @@ class TestThresholdConfig:
         assert stale_threshold_hours() == 1
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db(transaction=True)
 class TestPiggybackWiring:
     def test_piggyback_runs_expire_then_drain_behind_the_lease(self) -> None:

--- a/tests/teatree_loop/test_red_card_scanner.py
+++ b/tests/teatree_loop/test_red_card_scanner.py
@@ -21,6 +21,7 @@ from teatree.core.models import RedCardSignal
 from teatree.loop.scanners.red_card import RedCardScanner
 from teatree.types import RawAPIDict
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/test_rendering.py
+++ b/tests/teatree_loop/test_rendering.py
@@ -620,6 +620,7 @@ class TestSlackUserReplyNeverRendersVerbatim:
         assert "some text" not in blob, repr(blob)
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestTicketExtraPrsResolvesMrToTicket:
     """#1113 Defect 3 — bare manually-opened MR buckets under its ticket.
@@ -666,6 +667,7 @@ class TestTicketExtraPrsResolvesMrToTicket:
         assert "\n[t3-teatree] !145" not in blob, repr(blob)
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestPostedReviewRequestPermalinkNotInChip:
     """#1377: the chip is bare — review-permalink suffix removed from the chip.
@@ -714,6 +716,7 @@ class TestPostedReviewRequestPermalinkNotInChip:
         assert "(review" not in blob, repr(blob)
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestNoAgentsLineInInFlight:
     """The ``[ov] agents: …`` row is gone post-#1156.

--- a/tests/teatree_loop/test_rendering_permalinks.py
+++ b/tests/teatree_loop/test_rendering_permalinks.py
@@ -93,6 +93,7 @@ def test_enrich_pr_refs_with_permalinks_replaces_only_matching_urls() -> None:
     assert refs[1].review_permalink == ""
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestBuildReviewPostPermalinksDB:
     def test_resolves_row_into_canonical_permalink(self) -> None:

--- a/tests/teatree_loop/test_resource_pressure_mechanical.py
+++ b/tests/teatree_loop/test_resource_pressure_mechanical.py
@@ -29,6 +29,7 @@ from teatree.core.models.resource_pressure_marker import ResourcePressureMarker
 from teatree.loop import mechanical_resources
 from teatree.loop.mechanical_resources import free_resources
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _GIB = 1024 * 1024 * 1024

--- a/tests/teatree_loop/test_resource_pressure_scanner.py
+++ b/tests/teatree_loop/test_resource_pressure_scanner.py
@@ -28,6 +28,7 @@ from teatree.loop.scanners.resource_pressure import (
     read_ram_avail_gb,
 )
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _GIB = 1024 * 1024 * 1024

--- a/tests/teatree_loop/test_review_claim_discipline.py
+++ b/tests/teatree_loop/test_review_claim_discipline.py
@@ -37,6 +37,7 @@ from teatree.loop.scanners.slack_broadcasts import MrState, SlackBroadcastsScann
 from teatree.types import RawAPIDict
 from tests.teatree_core._on_behalf_gate_helpers import disable_on_behalf_gate
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/test_review_claim_loop_state.py
+++ b/tests/teatree_loop/test_review_claim_loop_state.py
@@ -17,6 +17,7 @@ from teatree.core.models import LoopState
 from teatree.loop.loop_state_db import loop_held_in_db
 from teatree.loop.review_claim import review_loop_enabled
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/test_review_react_self_authored_skip_1838.py
+++ b/tests/teatree_loop/test_review_react_self_authored_skip_1838.py
@@ -100,6 +100,7 @@ def _seed(*, reacted: bool) -> ReviewRequestPost:
     )
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestSelfAuthoredReactSkipMatrix:
     """author x state x already-reacted: react only on (colleague, merged, not-reacted)."""

--- a/tests/teatree_loop/test_self_update_reinstall.py
+++ b/tests/teatree_loop/test_self_update_reinstall.py
@@ -22,6 +22,7 @@ from teatree.core.models.ticket import Ticket
 from teatree.loop.self_update_reinstall import DrainOutcome, drain_pending_reinstall
 from teatree.self_update import ReinstallResult
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/test_self_update_scanner.py
+++ b/tests/teatree_loop/test_self_update_scanner.py
@@ -34,6 +34,7 @@ from teatree.core.models.self_update_marker import SelfUpdateMarker
 from teatree.loop.scanners.self_update import SelfUpdateScanner
 from teatree.loop.scanners.self_update_ci import CiVerdict, MainCiStatus
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/test_slack_dm_inbound.py
+++ b/tests/teatree_loop/test_slack_dm_inbound.py
@@ -15,6 +15,7 @@ from teatree.core.models import PendingChatInjection
 from teatree.loop.scanners.slack_dm_inbound import SlackDmInboundScanner
 from teatree.types import RawAPIDict
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/test_slack_dm_inbound_self_filter.py
+++ b/tests/teatree_loop/test_slack_dm_inbound_self_filter.py
@@ -29,6 +29,7 @@ from teatree.core.models import PendingChatInjection
 from teatree.loop.scanners.slack_dm_inbound import SlackDmInboundScanner
 from teatree.types import RawAPIDict
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 _OWN_USER_ID = "U_BOT_SELF"

--- a/tests/teatree_loop/test_slack_review_intent.py
+++ b/tests/teatree_loop/test_slack_review_intent.py
@@ -20,6 +20,7 @@ from teatree.core.models import ReviewAssignment, ReviewIntent
 from teatree.loop.scanners.slack_review_intent import SlackReviewIntentScanner
 from teatree.types import RawAPIDict
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/test_statusline_cost_chip.py
+++ b/tests/teatree_loop/test_statusline_cost_chip.py
@@ -18,6 +18,7 @@ from teatree.loop.rendering import cost_chip_lines
 from teatree.loop.tick_freshness import _write_tick_meta
 from tests.factories import TicketFactory
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/test_statusline_mr_format.py
+++ b/tests/teatree_loop/test_statusline_mr_format.py
@@ -85,6 +85,7 @@ class TestMrChipIsBare:
         assert "(1 notes)" not in blob, repr(blob)
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestMergedMrsNotShown:
     """``build_review_post_permalinks`` filters out MERGED PullRequests (Culprit A)."""
@@ -126,6 +127,7 @@ class TestMergedMrsNotShown:
         assert merged_pr_url not in permalinks, permalinks
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestTracker404StripsClickableUrl:
     """A tracker_404 ticket renders without a clickable URL (Culprit B)."""

--- a/tests/teatree_loop/test_statusline_multiloop.py
+++ b/tests/teatree_loop/test_statusline_multiloop.py
@@ -41,6 +41,7 @@ def _make_lease(name: str, *, expires_in: timedelta, session_id: str = "sess-A")
     )
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestLiveLoopsAnchor:
     """``live_loops_anchor()`` returns one per-loop-named summary line."""
@@ -92,6 +93,7 @@ class TestLiveLoopsAnchor:
         assert "loop:owner" not in joined, repr(joined)
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestForeignHijackStillRed:
     """The #1073 foreign-hijack RED line is preserved through every refit."""
@@ -108,6 +110,7 @@ class TestForeignHijackStillRed:
         assert "NOT this session" in line
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestPopulateLoopsAnchorIntegration:
     """The rendering layer emits the consolidated line for live LoopLease rows."""

--- a/tests/teatree_loop/test_statusline_per_loop_scoping.py
+++ b/tests/teatree_loop/test_statusline_per_loop_scoping.py
@@ -99,6 +99,7 @@ class TestPerLoopChunkScoping:
         assert scoped == failopen, (scoped, failopen)
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestOwnedPerLoopSlotsQuery:
     """``owned_per_loop_slots`` reads the real ``loop:<name>`` ownership from the DB."""

--- a/tests/teatree_loop/test_statusline_short_description.py
+++ b/tests/teatree_loop/test_statusline_short_description.py
@@ -37,6 +37,7 @@ def _render_blob(actions: list[DispatchAction]) -> str:
     )
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestShortDescriptionInScanner:
     """``ActiveTicketsScanner`` prefers ``ticket.short_description`` over ``issue_title``."""
@@ -89,6 +90,7 @@ class TestShortDescriptionTruncation:
         assert long_title not in blob, repr(blob)
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestEveryActiveTicketHasDescriptionChunk:
     """The scanner + renderer emit a description chunk for every active ticket."""

--- a/tests/teatree_loop/test_tick_piggyback.py
+++ b/tests/teatree_loop/test_tick_piggyback.py
@@ -24,6 +24,7 @@ from teatree.core.models import LoopLease, PendingChatInjection, SelfImproveFiri
 from teatree.core.models.pull_request import PullRequest
 from teatree.types import RawAPIDict
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/test_todo_sweep_mechanical.py
+++ b/tests/teatree_loop/test_todo_sweep_mechanical.py
@@ -24,6 +24,7 @@ from teatree.core.overlay import OverlayBase
 from teatree.loop.mechanical import todo_completion
 from teatree.types import RawAPIDict
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_loop/test_todo_sweep_scanner.py
+++ b/tests/teatree_loop/test_todo_sweep_scanner.py
@@ -27,6 +27,7 @@ from teatree.core.overlay import OverlayBase
 from teatree.loop.scanners.todo_sweep import TodoSweepScanner
 from teatree.types import RawAPIDict
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/teatree_teams/test_no_migration.py
+++ b/tests/teatree_teams/test_no_migration.py
@@ -21,6 +21,7 @@ def _pending_task() -> Task:
     return Task.objects.create(ticket=ticket, session=session, status=Task.Status.PENDING)
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestClaimedByAcceptsTeamSlot:
     def test_claim_next_pending_accepts_a_team_role_slot(self) -> None:

--- a/tests/teatree_teams/test_roles.py
+++ b/tests/teatree_teams/test_roles.py
@@ -102,6 +102,7 @@ class TestTeamRoleEnum:
         assert TeamRole.REVIEWER.claim_filter is None
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestClaimFilterPartition:
     """The maker claim filters partition the backlog along the overlay seam."""
@@ -143,6 +144,7 @@ class TestTaskClaimFilter:
     def test_reviewer_has_no_task_claim_filter(self) -> None:
         assert TeamRole.REVIEWER.task_claim_filter is None
 
+    # ast-grep-ignore: ac-django-no-pytest-django-db
     @pytest.mark.django_db
     def test_task_filter_partitions_tasks_along_the_overlay_seam(self) -> None:
         from teatree.core.models import Session, Task  # noqa: PLC0415

--- a/tests/test_away_mode_hook.py
+++ b/tests/test_away_mode_hook.py
@@ -23,6 +23,7 @@ from teatree.core import availability
 from teatree.core.availability import LIVE_TURN_FRESHNESS, PresenceHeartbeat
 from teatree.core.models.deferred_question import DeferredQuestion
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/test_cli_review.py
+++ b/tests/test_cli_review.py
@@ -19,6 +19,7 @@ runner = CliRunner()
 # records a ``BotPing`` row — both touch the ORM. The gate-mechanics
 # tests below therefore need DB access (the after-receipt DM is an
 # intrinsic side effect of the publish path, not test scaffolding).
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 
@@ -903,6 +904,7 @@ class TestApprove:
             assert result.exit_code == 1
             assert "Failed: HTTP 403" in result.output
 
+    # ast-grep-ignore: ac-django-no-pytest-django-db
     @pytest.mark.django_db
     def test_approve_blocked_by_on_behalf_gate(self, tmp_path, monkeypatch):
         """Gate ON + no recorded approval → approve refuses without an API call (#1013)."""
@@ -949,6 +951,7 @@ class TestApprove:
             assert result.exit_code == 1
             assert "Failed: HTTP 404" in result.output
 
+    # ast-grep-ignore: ac-django-no-pytest-django-db
     @pytest.mark.django_db
     def test_unapprove_blocked_by_on_behalf_gate(self, tmp_path, monkeypatch):
         """Gate ON + no recorded approval → unapprove refuses without an API call (#1013)."""

--- a/tests/test_close_trailer_scanner.py
+++ b/tests/test_close_trailer_scanner.py
@@ -197,6 +197,7 @@ ban_close_trailers_on_namespaces = "not-a-list"
         assert config.user.ban_close_trailers_on_namespaces == []
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestShipExecutorIntegration:
     """``ShipExecutor._build_pr_spec`` applies the scanner before opening the PR."""

--- a/tests/test_contrib_overlay.py
+++ b/tests/test_contrib_overlay.py
@@ -245,6 +245,7 @@ class TestGetProvisionSteps(TestCase):
         assert overlay.get_provision_steps(bare_worktree) == []
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestInstallOverlaysEditableStep:
     """Integration tests for the install-overlays-editable provision step."""

--- a/tests/test_github_backend.py
+++ b/tests/test_github_backend.py
@@ -985,6 +985,7 @@ from teatree.core.models import OutboundClaim  # noqa: E402
 from teatree.loop.scanners.outbound_audit import _hash_body  # noqa: E402
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestGitHubCommentOutboundClaim:
     """``post_pr_comment`` / ``post_issue_comment`` record an OutboundClaim (#1198).

--- a/tests/test_loop_resilience_fixes.py
+++ b/tests/test_loop_resilience_fixes.py
@@ -297,6 +297,7 @@ class TestF4GitlabApprovalsNoPhantomBlankOverlayTicket(TestCase):
     or pass the scanner's real overlay.
     """
 
+    # ast-grep-ignore: ac-django-no-pytest-django-db
     pytestmark = pytest.mark.django_db
 
     def test_no_phantom_blank_overlay_ticket_created(self) -> None:

--- a/tests/test_loop_state_self_pump_hook.py
+++ b/tests/test_loop_state_self_pump_hook.py
@@ -24,6 +24,7 @@ import hooks.scripts.hook_router as router
 import hooks.scripts.loop_state_self_pump_gate as gate
 from hooks.scripts.hook_router import _OWNER_LOOP, _write_loop_registry, handle_loop_self_pump
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
 
 

--- a/tests/test_overlay_db_import_contract.py
+++ b/tests/test_overlay_db_import_contract.py
@@ -178,6 +178,7 @@ class _FixedWithExplicitParam(OverlayBase):
     def get_provision_steps(self, worktree):
         return []
 
+    # ast-grep-ignore: ac-django-no-complexity-suppressions
     def db_import(  # noqa: PLR0913 — deliberately mirrors the 6-arg core OverlayBase.db_import contract.
         self,
         worktree,

--- a/tests/test_slack_listen.py
+++ b/tests/test_slack_listen.py
@@ -137,6 +137,7 @@ class TestStatusCommand:
         assert "running" in result.stdout
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestCheckCommand:
     def test_exits_1_when_queue_empty(self) -> None:
@@ -329,6 +330,7 @@ class TestListenCommand:
             assert held == pid_file
 
 
+# ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestReactCommand:
     """``t3 slack react`` routes through the on-behalf egress (#960/#1750)."""


### PR DESCRIPTION
## What

Adopt the `ac-django` testing-convention prek hooks from `souliane/skills` (companion branch `ac/ac-django-prek-hooks`, head `29c0a2c6`).

The hooks are now **ast-grep** YAML rules; existing violations are grandfathered **INLINE** with ast-grep's native `# ast-grep-ignore` comment — **no baseline file, no count cap**. Every new, un-ignored occurrence fails; every existing one carries an inline ignore.

- Wires `souliane/skills@29c0a2c6` into `.pre-commit-config.yaml` (Phase 6b), enabling four hook ids:
  - `ac-django-no-pytest-django-db` (ast-grep)
  - `ac-django-testcase-no-pytest-parametrize` (ast-grep)
  - `ac-django-no-complexity-suppressions` (ast-grep — the noqa comment surface)
  - `ac-django-no-pyproject-complexity` (standalone — the `pyproject.toml` ruff ignore-list surface, which ast-grep 0.42.3 cannot parse)
- ast-grep is **pinned to 0.42.3** by the hook wrapper (resolved via `uvx --from ast-grep-cli==0.42.3 ast-grep`, system fallback).

## Grandfathering applied to this tree

- **165** existing `pytest.mark.django_db` uses across **141** test files — both the `@pytest.mark.django_db` decorator and module-level `pytestmark = pytest.mark.django_db` (and list) assignments — each gets `# ast-grep-ignore: ac-django-no-pytest-django-db`.
- **86** existing `C901`/`PLR09xx` `noqa` lines (**19** in `tests/`, **67** in `src/teatree/`) each get `# ast-grep-ignore: ac-django-no-complexity-suppressions`.
- The **3** existing `pyproject.toml` complexity-ignore entries are grandfathered inline in the hook args via `--grandfather code@location` (no baseline file).
- `ac-django-testcase-no-pytest-parametrize` has **zero** occurrences, so no ignores are added.

The diff is purely additive: every `src/`/`tests/` change is one inline ignore comment; no removals, no other edits.

## ast-grep-ignore comment form

The rule-scoped **colon** form `# ast-grep-ignore: <rule-id>` is used rather than the bracket form `[<rule-id>]`. Both are ast-grep's native rule-scoped ignore; the colon form additionally coexists with ruff's `ERA001` (commented-out-code) preview rule, which the bracket form trips (the `[...]` reads as a subscript). This keeps the tree clean under teatree's `ALL` + `preview` ruff config with zero ruff-config changes.

## Verification

- All four ac-django hooks green on the current tree (`prek run ... --all-files`).
- A new un-ignored `@pytest.mark.django_db` fails the hook; a new non-grandfathered pyproject complexity entry fails the pyproject hook.
- `ruff check`, `ty check`, comment-density, module-health, and the repo-root-minimal tests all green (`.ac-django/` is gone — root allowlist unchanged).
