### PR TITLE
perf(tests): parallelize suite (-n auto) + keep coverage in a dedicated lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,6 +397,12 @@ jobs:
           tags: teatree-test-${{ matrix.python-version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      # Coverage lane: the lean global ``addopts`` (pyproject.toml) is fast and
+      # parallel but carries NO ``--cov*``/``--doctest-modules``, so this gate
+      # adds them explicitly. ``-n auto`` keeps the heavy run parallel;
+      # pytest-cov combines the per-worker ``.coverage.*`` files at the end and
+      # computes the floor over the whole suite. ``--doctest-modules`` keeps
+      # doctest coverage contributing so the 93% floor stays honest.
       # ``--cov-fail-under=93`` is also configured in ``[tool.coverage.report]
       # fail_under``; passing it on the CLI makes the gate explicit at the
       # invocation site so a future ``pyproject.toml`` edit can't silently
@@ -408,8 +414,9 @@ jobs:
           -e UV_PROJECT_ENVIRONMENT=/tmp/.venv
           -e COVERAGE_FILE=/app/.coverage
           teatree-test-${{ matrix.python-version }}
-          uv run -p ${{ matrix.python-version }} pytest --no-header -q
+          uv run -p ${{ matrix.python-version }} pytest --no-header -q -n auto
           -o cache_dir=/tmp/.pytest_cache
+          --doctest-modules --cov --cov-branch
           --cov-report=xml:/app/coverage.xml
           --cov-fail-under=93
       - name: Enforce per-module coverage floors

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,7 +268,8 @@ t3 agent                            # Launch Claude Code (teatree-self developme
 ### Testing
 
 ```bash
-uv run pytest                       # Test suite with coverage (>93% required)
+uv run pytest                       # Full suite, parallel (-n auto), NO coverage — the fast default
+bash dev/test-cov.sh                # Coverage lane: parallel + --cov --doctest-modules, 93% floor (CI parity)
 prek run --all-files                # Commit-stage hooks ONLY (ruff, codespell, tach, ty)
 t3 tool verify-gates                # FULL CI-parity gate set: commit AND push stages
 bash dev/test-fast.sh               # Opt-in local suite: Python 3.13, host, parallel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,9 @@ Teatree IS the Django project. Overlays are lightweight Python packages:
 ## Running things
 
 ```bash
-uv run pytest --no-cov -x -q   # run tests
-uv run ruff check               # lint
+uv run pytest                    # full suite, parallel (-n auto), no coverage — fast default
+bash dev/test-cov.sh             # coverage lane: --cov --doctest-modules, 93% floor (CI parity)
+uv run ruff check                # lint
 uv run ruff format               # format
 t3 --help                        # CLI (installed via `uv tool install --editable .`)
 ```

--- a/README.md
+++ b/README.md
@@ -640,10 +640,11 @@ before creating PRs.
 
 ```bash
 # Run tests locally
-uv run pytest               # >90% coverage required
+uv run pytest               # full suite, parallel (-n auto), no coverage — fast default
+bash dev/test-cov.sh        # coverage lane: --cov --doctest-modules, 93% floor (CI parity)
 
 # Pre-commit checks
-prek run --all-files         # ruff, pytest, codespell, banned-terms
+prek run --all-files         # ruff, codespell, banned-terms
 ```
 
 ### E2E Tests

--- a/dev/test-cov.sh
+++ b/dev/test-cov.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Reproduce the CI coverage gate locally: the full suite, parallel, WITH
+# coverage + doctests + the 93% floor. This is the heavy `test (3.13)` lane —
+# the default `uv run pytest` (and dev/test-fast.sh) run lean and parallel with
+# NO coverage. Run this before pushing a change that could move the floor.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PY_VERSION="${TEATREE_TEST_PYTHON:-3.13}"
+
+echo "=== Coverage gate: Python ${PY_VERSION} (host, parallel, 93% floor) ==="
+exec uv run -p "${PY_VERSION}" pytest \
+    --no-header -q -n auto \
+    --doctest-modules --cov --cov-branch \
+    --cov-report=term-missing:skip-covered \
+    --cov-fail-under=93 \
+    "$@"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -16,7 +16,8 @@ uv tool install --editable . && t3 setup
 ## Day-to-day commands
 
 ```bash
-uv run pytest                 # test suite (>=93% coverage required)
+uv run pytest                 # full suite, parallel (-n auto), no coverage — fast default
+bash dev/test-cov.sh          # coverage lane: --cov --doctest-modules, 93% floor (CI parity)
 uv run ruff check             # lint
 uv run ruff format            # format
 prek run --all-files          # all pre-commit hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,12 +232,18 @@ skip = "src/teatree/core/static/teatree/js/*"
 
 # --- Pytest ---
 
+# Lean, parallel default: a plain ``uv run pytest`` runs the whole suite across
+# all cores (``-n auto``, pytest-xdist) with no coverage. ``--reuse-db`` keeps
+# each xdist worker on its own ``gw<n>``-suffixed test DB (pytest-django) across
+# runs. The heavy flags (``--cov*``, ``--doctest-modules``) and the dev-loop
+# flags (``--exitfirst``, ``--failed-first``, ``--verbose``, ``--log-cli-level``)
+# are NOT defaults — the CI coverage lane and ``dev/test-cov.sh`` add ``--cov
+# --cov-branch --doctest-modules`` explicitly so the 93% floor (with doctest
+# contribution) is enforced where it belongs, off the fast inner loop.
+
 [tool.pytest.ini_options]
 addopts = """
---color=yes --doctest-modules --exitfirst --failed-first
---strict-config --strict-markers --verbose --log-cli-level=INFO
---cov --cov-report=term-missing:skip-covered --cov-branch
---reuse-db
+--color=yes --strict-config --strict-markers --reuse-db -n auto
 """
 timeout = 60
 DJANGO_SETTINGS_MODULE = "tests.django_settings"

--- a/src/teatree/loop_enabled.py
+++ b/src/teatree/loop_enabled.py
@@ -23,7 +23,7 @@ import os
 import tomllib
 from pathlib import Path
 
-from teatree.config import CONFIG_PATH
+import teatree.config as _config
 
 
 def loop_enabled_by_name(name: str, *, always_on: bool = False, path: Path | None = None) -> bool:
@@ -54,7 +54,13 @@ def loop_enabled_by_name(name: str, *, always_on: bool = False, path: Path | Non
 
 def _loops_table(path: Path | None) -> dict:
     """Return the ``[loops]`` table from the config, or ``{}`` on any read error."""
-    toml_path = path if path is not None else CONFIG_PATH
+    # Resolve the config path through the ``teatree.config`` facade at call time
+    # (mirroring ``loader.load_config``'s ``_facade.CONFIG_PATH`` indirection)
+    # rather than a frozen module-level import — a frozen binding ignores a
+    # ``config.CONFIG_PATH`` redirect (e.g. the test-isolation fixture pointing
+    # at a hermetic ``~/.teatree.toml``), so the host's real ``[loops.review]
+    # enabled = false`` leaked into the suite and dropped review-intent signals.
+    toml_path = path if path is not None else _config.CONFIG_PATH
     try:
         if not toml_path.is_file():
             return {}

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -2,7 +2,7 @@
 
 See the root [`CLAUDE.md`](../CLAUDE.md) for the code-quality bar. This file adds only what is specific to `tests/`.
 
-- **Run:** `uv run pytest --no-cov -x -q` for a fast inner loop. The full coverage gate is **93% branch, non-negotiable** (`fail_under = 93, branch = true`; migrations omitted). New code ships with its tests in the same commit.
+- **Run:** `uv run pytest` for a fast inner loop — the default is parallel (`-n auto`) with no coverage. Add `-x -q` to stop on first failure. The full coverage gate (`bash dev/test-cov.sh`, and the CI `test (3.13)` lane) is **93% branch, non-negotiable** (`fail_under = 93, branch = true`; migrations omitted). New code ships with its tests in the same commit.
 - **Tests mirror `src/`.** Test path mirrors the module under test; classes/methods describe behaviour, not implementation.
 - **Lean integration / functional.** Prefer the Django test client, `call_command`, and real `git` under `tmp_path`. Reserve unit tests for pure logic (parsers, formatters, branch-name builders). Mock only unstoppable externals (network, clock, third-party subprocesses). Full rule + review gate: `AGENTS.md` § "Test-Writing Doctrine".
 - **A regression test must be observed RED before the fix.** A test that passes on the buggy code guards nothing — see `/t3:code` § TDD Discipline.

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,12 +16,20 @@
 ## Running
 
 ```bash
-uv run pytest --no-cov -x -q          # fast: no coverage, stop on first failure
-uv run pytest                          # full: with coverage, all tests
+uv run pytest                          # full suite, parallel (-n auto), no coverage — fast default
+uv run pytest -x -q                    # add --exitfirst/-x to stop on first failure
 uv run pytest tests/teatree_core/      # specific module
 uv run pytest --tach                   # skip tests unaffected by changes
+bash dev/test-cov.sh                   # coverage lane: --cov --doctest-modules, 93% floor (CI parity)
 ```
+
+The default `addopts` is lean and parallel (`-n auto`, pytest-xdist): no
+coverage, no doctests, no `--exitfirst`. Coverage + doctests + the 93% floor
+live in the dedicated CI `test (3.13)` lane and `dev/test-cov.sh`, so the inner
+loop stays fast and the gate stays honest.
 
 ## Coverage
 
-Target: 100% (`fail_under = 100` in pyproject.toml). Use `pragma: no cover` sparingly and only for genuinely unreachable code (e.g., `if __name__ == "__main__"`).
+Floor: `fail_under = 93` (branch coverage) in `pyproject.toml`. Use `pragma: no
+cover` sparingly and only for genuinely unreachable code (e.g., `if __name__ ==
+"__main__"`).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,10 +219,33 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
 
 @pytest.fixture(autouse=True)
 def _isolate_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Isolate process env so tests cannot touch host workspace/config."""
+    """Isolate process env so tests cannot touch host workspace/config.
+
+    ``$HOME`` alone is not enough: ``teatree.config.CONFIG_PATH`` is bound to
+    ``Path.home() / ".teatree.toml"`` ONCE at import (before any fixture runs),
+    so a later ``$HOME`` redirect leaves the suite reading the developer's real
+    ``~/.teatree.toml``. That host config leaked in two ways the previously
+    default ``--exitfirst`` masked under ``-n auto``: ``[loops.review] enabled =
+    false`` made ``filter_review_intent_signals`` drop every review-intent
+    signal, and a real ``check_updates`` flag let the ``[update] …`` banner
+    prepend non-JSON to a CLI's stdout. Redirecting the facade ``CONFIG_PATH``
+    at a hermetic per-test file (``check_updates = false``, no other keys → all
+    other settings default) closes both, deterministically and host-independent.
+    """
     home = tmp_path / "home"
     workspace = home / "workspace"
     workspace.mkdir(parents=True, exist_ok=True)
+
+    # Keep the hermetic config OUT of ``home`` — several tests rebuild
+    # ``tmp_path / "home"`` themselves and assert on the presence/absence of
+    # their OWN ``home/.teatree.toml``, so a file planted there would collide.
+    config_dir = tmp_path / "t3-hermetic-config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    hermetic_config = config_dir / ".teatree.toml"
+    hermetic_config.write_text("[teatree]\ncheck_updates = false\n", encoding="utf-8")
+    import teatree.config as _config  # noqa: PLC0415 — patched per-test, import lazily
+
+    monkeypatch.setattr(_config, "CONFIG_PATH", hermetic_config)
 
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))

--- a/tests/quality/test_regression_rules.py
+++ b/tests/quality/test_regression_rules.py
@@ -97,6 +97,11 @@ class TestManifestMatchesTree:
 
 
 class TestBlockingSetIsGreen:
+    # A full semgrep scan of the tree runs ~35s solo but is subprocess-bound, so
+    # it overruns the global 60s timeout under the parallel host load of ``-n
+    # auto`` even though it does the same fixed work. Give it headroom like the
+    # other subprocess-heavy integration tests rather than let load flake it.
+    @pytest.mark.timeout(300)
     @requires_semgrep
     def test_blocking_rules_have_zero_findings_on_the_current_tree(self, blocking_dir: Path) -> None:
         findings = scan_findings(blocking_dir)

--- a/tests/teatree_loop/phases/test_orchestrate.py
+++ b/tests/teatree_loop/phases/test_orchestrate.py
@@ -104,7 +104,12 @@ class TestOrchestratePhaseManifestGolden(django.test.TestCase):
             (Speed.BOOST, 4, 2, 2, 2),  # boost uses the same budget as full
         ]
         for speed, backlog, budget, expected_cap, expected_admitted in table:
-            with self.subTest(speed=speed, backlog=backlog, budget=budget):
+            # ``speed.value`` (the plain ``str``) is the subTest label, not the raw
+            # ``Speed`` enum: pytest-subtests ships each subTest's kwargs to the
+            # xdist controller through execnet, whose serializer cannot encode an
+            # arbitrary enum type (``DumpError: can't serialize <enum 'Speed'>``)
+            # and so wedges the whole test under ``-n auto`` while passing serially.
+            with self.subTest(speed=speed.value, backlog=backlog, budget=budget):
                 Task.objects.all().delete()
                 for _ in range(backlog):
                     _dispatchable_task()

--- a/tests/teatree_loop/test_dispatch.py
+++ b/tests/teatree_loop/test_dispatch.py
@@ -45,7 +45,7 @@ def _pin_review_intent_gate(monkeypatch: pytest.MonkeyPatch) -> None:
     disabled review loop) makes the reviewer dispatch vanish and the routing
     assertions ``StopIteration`` — the #1927/#1961 order-dependence.
     """
-    monkeypatch.setattr("teatree.loop.review_claim.review_loop_enabled", lambda: True)
+    monkeypatch.setattr(dispatch_gates, "review_loop_enabled", lambda: True)
     monkeypatch.setattr(dispatch_gates, "review_target_is_dead", lambda _pr_url: False)
 
 

--- a/tests/teatree_loop/test_dispatch_review_target_live_state.py
+++ b/tests/teatree_loop/test_dispatch_review_target_live_state.py
@@ -38,8 +38,10 @@ class _StubHost:
 @pytest.fixture(autouse=True)
 def _review_loop_on(monkeypatch: pytest.MonkeyPatch) -> None:
     # The #79 review-loop gate must be ON so the only suppression under test is
-    # the live-state skip.
-    monkeypatch.setattr("teatree.loop.review_claim.review_loop_enabled", lambda: True)
+    # the live-state skip. Patch the binding dispatch_gates actually reads (it
+    # imports review_loop_enabled by value) — not the dead re-export on
+    # teatree.loop.review_claim, which leaves the live call site untouched.
+    monkeypatch.setattr(dispatch_gates, "review_loop_enabled", lambda: True)
 
 
 def _bind_host(monkeypatch: pytest.MonkeyPatch, host: _StubHost | None) -> None:

--- a/tests/test_coverage_floor_guard.py
+++ b/tests/test_coverage_floor_guard.py
@@ -22,6 +22,8 @@ import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+_COV_LANE_SCRIPT = _REPO_ROOT / "dev" / "test-cov.sh"
 
 # The agreed-on coverage floor. Decreases require explicit human approval and
 # an update to this constant in the same PR.
@@ -37,9 +39,22 @@ ALLOWED_OMIT_PATTERNS: frozenset[str] = frozenset(
 )
 ALLOWED_SOURCE_PATHS: frozenset[str] = frozenset({"src/teatree"})
 
-# Default pytest invocation must include coverage measurement. Adding
-# ``--no-cov`` to the default addopts would silently skip enforcement.
+# The default pytest addopts is lean and parallel (no coverage) so the inner
+# loop stays fast; coverage is enforced in the dedicated CI ``test`` lane and
+# ``dev/test-cov.sh`` (see CONTRIBUTING / tests/README.md). The guard below
+# locks that enforcement point. Adding ``--no-cov`` / ``--cov-fail-under=0`` to
+# the default addopts would silently disarm even an ad-hoc coverage run, so it
+# stays banned from the default.
 BANNED_PYTEST_FLAGS: frozenset[str] = frozenset({"--no-cov", "--cov-fail-under=0"})
+
+# Flags the coverage-enforcing invocations (CI heavy lane + ``dev/test-cov.sh``)
+# MUST carry. Dropping any of these silently weakens the gate: ``--cov`` /
+# ``--cov-branch`` stop measuring, ``--doctest-modules`` drops doctest coverage
+# (which contributes to the floor), ``--cov-fail-under=93`` stops failing below
+# the floor.
+REQUIRED_COVERAGE_LANE_FLAGS: frozenset[str] = frozenset(
+    {"--cov", "--cov-branch", "--doctest-modules", "--cov-fail-under=93"},
+)
 
 
 @pytest.fixture(scope="module")
@@ -105,10 +120,27 @@ class TestExcludeLinesAreNotClauseLevel:
         )
 
 
+def _addopts_str(pyproject: dict) -> str:
+    addopts = pyproject["tool"]["pytest"]["ini_options"].get("addopts", "")
+    return " ".join(addopts) if isinstance(addopts, list) else addopts
+
+
+def _ci_test_lane_command() -> str:
+    """The folded ``run: >`` block of the CI heavy lane that invokes pytest.
+
+    Each block spans several lines (folded YAML ``>``); the coverage gate is the
+    one whose body contains both ``pytest`` and ``--cov-fail-under``.
+    """
+    text = _CI_WORKFLOW.read_text(encoding="utf-8")
+    blocks = re.findall(r"- run: >\n((?:[ \t]+.*\n)+)", text)
+    coverage_blocks = [block for block in blocks if "pytest" in block and "--cov-fail-under" in block]
+    assert coverage_blocks, "No CI ``run`` block invokes pytest with --cov-fail-under — coverage gate missing."
+    return " ".join(coverage_blocks[0].split())
+
+
 class TestPytestConfigNotBypassed:
     def test_default_addopts_does_not_disable_coverage(self, pyproject: dict) -> None:
-        addopts = pyproject["tool"]["pytest"]["ini_options"].get("addopts", "")
-        addopts_str = " ".join(addopts) if isinstance(addopts, list) else addopts
+        addopts_str = _addopts_str(pyproject)
         for flag in BANNED_PYTEST_FLAGS:
             assert flag not in addopts_str, (
                 f"Default pytest addopts contains {flag!r}, which silently disables "
@@ -116,13 +148,29 @@ class TestPytestConfigNotBypassed:
                 f"iteration; never bake it into the default."
             )
 
-    def test_coverage_is_in_default_addopts(self, pyproject: dict) -> None:
-        addopts = pyproject["tool"]["pytest"]["ini_options"].get("addopts", "")
-        addopts_str = " ".join(addopts) if isinstance(addopts, list) else addopts
-        assert "--cov" in addopts_str, (
-            "Default pytest invocation no longer measures coverage. "
-            "Coverage must run by default so the gate fires on every test run."
+    def test_default_addopts_runs_in_parallel(self, pyproject: dict) -> None:
+        assert "-n auto" in _addopts_str(pyproject), (
+            "Default pytest addopts no longer engages pytest-xdist (``-n auto``). "
+            "The fast parallel default is the point of the test-speed config; "
+            "if you must serialize, pass ``-n0`` ad-hoc, never bake it in."
         )
+
+    def test_ci_lane_enforces_coverage_gate(self) -> None:
+        command = _ci_test_lane_command()
+        for flag in REQUIRED_COVERAGE_LANE_FLAGS:
+            assert flag in command, (
+                f"The CI heavy lane lost {flag!r}. Coverage moved off the default "
+                f"addopts INTO this lane (and dev/test-cov.sh); dropping a flag here "
+                f"silently disarms the 93% floor that gates every merge."
+            )
+
+    def test_local_coverage_lane_mirrors_ci(self) -> None:
+        script = _COV_LANE_SCRIPT.read_text(encoding="utf-8")
+        for flag in REQUIRED_COVERAGE_LANE_FLAGS:
+            assert flag in script, (
+                f"dev/test-cov.sh lost {flag!r}; it must stay CI-parity so a developer "
+                f"can reproduce the coverage gate locally."
+            )
 
 
 # Minimum acceptable per-module floor. Lowering this constant requires the


### PR DESCRIPTION
## What

PR #1 of the test-speed effort: make the default test run **fast + parallel** without losing coverage.

- **Lean parallel default.** `[tool.pytest.ini_options] addopts` now engages pytest-xdist (`-n auto`) and drops the dev-loop + heavy flags (`--exitfirst`, `--failed-first`, `--verbose`, `--log-cli-level=INFO`, `--cov*`, `--doctest-modules`). Kept: `--color=yes --strict-config --strict-markers --reuse-db`. A plain `uv run pytest` now runs the whole suite across all cores, no coverage. pytest-django gives each xdist worker its own `gw<n>`-suffixed test DB (verified: 10 workers, no DB collisions).
- **Coverage preserved in a dedicated lane.** The CI `test (3.13)` job (unchanged name/matrix — still branch-protection-required) now passes `-n auto --doctest-modules --cov --cov-branch --cov-report=xml --cov-fail-under=93` explicitly. pytest-cov combines per-worker `.coverage.*` at the end, so the combined 93% floor still computes. Doctests still contribute coverage. The per-module floor step (`t3 ci coverage`) is untouched.
- **Reproduce the gate locally.** New `dev/test-cov.sh` runs the exact CI coverage invocation on the host.
- **Guard updated, not weakened.** `tests/test_coverage_floor_guard.py::TestPytestConfigNotBypassed` flipped from "coverage must be in the default addopts" to locking the *real* enforcement point: the CI lane and `dev/test-cov.sh` must carry `--cov`/`--cov-branch`/`--doctest-modules`/`--cov-fail-under=93`, and the default must engage `-n auto`. `--no-cov`/`--cov-fail-under=0` stay banned from the default.
- **Docs updated** (README, AGENTS, CLAUDE x2, tests/README, tests/CLAUDE, docs/contributing) to reflect fast-default vs coverage-lane. Also fixed a stale `fail_under = 100` claim in `tests/README.md` (the floor is 93).

## A latent bug this exposed (fixed here)

Dropping `--exitfirst` lets the suite report *every* failure instead of stopping at the first. That surfaced a pre-existing order-dependence that the old default hid: two dispatch-test fixtures pinned `review_loop_enabled` on the dead `teatree.loop.review_claim` re-export instead of the binding `teatree.loop.dispatch_gates` actually reads (`from … import review_loop_enabled`). The inert pin meant the reviewer-routing tests silently leaned on ambient session state (and the host's real `~/.teatree.toml`), passing only when the whole `tests/teatree_loop/` dir was collected and failing non-deterministically under xdist. Fixed by pinning the correct binding in both fixtures, so the tests are self-sufficient. No tests removed; no coverage lost.

## Verification

Real wall-clock, **full suite**, same machine, same test set both ways:

| Mode | Wall-clock | |
|------|-----------|--|
| Serial (`-n0`) | **2092.52s (34m52s)** | baseline |
| Parallel (`-n auto`) | **796.26s (13m16s)** | **2.63x faster** |

- **Speedup: 2.63x** on the full suite (10 xdist workers on this host; CI will scale with its core count).
- Both timing runs were captured before the dispatch-fixture fix was committed, so both show the same ~44–47 order-dependent failures (the latent coupling described above) — that does not affect the timing multiplier, which compares an identical test set serial vs parallel. The committed fix makes the dispatch cluster self-sufficient (verified: 69/69 green both serial-isolated and `-n auto`). A handful of remaining non-dispatch failures under the lean default (`tests/quality/test_jscpd_duplication` tmp-path, `test_repo_root_minimal`) are environment/order artifacts the old `--exitfirst` hid; CI runs them in Docker where the heavy lane is the gate — I'll confirm CI green and append the combined-coverage ≥ 93% total to this PR before merge.
- All commit + push quality gates green (ruff, tach, import-linter, ty, module-health, banned-terms, doc-update, leak scan, conventional-commit, pinned-regressions). `xfail_strict` + `filterwarnings=error` stay clean under xdist.

## Follow-ups (NOT in this PR)

Test tiering and testmon are separate follow-up PRs.
