### PR TITLE
fix(eval): pass clean-room system prompt by file, not argv (E2BIG)

### DIFF
--- a/src/teatree/eval/judge.py
+++ b/src/teatree/eval/judge.py
@@ -35,7 +35,13 @@ from claude_agent_sdk import ClaudeAgentOptions, ResultMessage, query
 
 from teatree.eval.isolation import isolated_claude_env
 from teatree.eval.models import EvalRun, EvalSpec
-from teatree.eval.sdk_runner import CleanRoomConfig, build_sdk_options, classify_terminal_error, env_float
+from teatree.eval.sdk_runner import (
+    CleanRoomConfig,
+    build_sdk_options,
+    classify_terminal_error,
+    env_float,
+    is_success_result_error,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -188,9 +194,16 @@ def _judge_options(*, model: str, cwd: str, env: dict[str, str]) -> ClaudeAgentO
 
 async def _judge_result(prompt: str, options: ClaudeAgentOptions) -> StructuredVerdict | None:
     structured: StructuredVerdict | None = None
-    async for message in query(prompt=prompt, options=options):
-        if isinstance(message, ResultMessage):
-            structured = StructuredVerdict.from_structured_output(message.structured_output)
+    try:
+        async for message in query(prompt=prompt, options=options):
+            if isinstance(message, ResultMessage):
+                structured = StructuredVerdict.from_structured_output(message.structured_output)
+    except Exception as exc:
+        # A SUCCESS mislabeled as an error result (the CLI exited non-zero on a
+        # "success" subtype) must not crash the judge: the verdict-bearing
+        # ResultMessage already arrived, so return what was captured.
+        if not is_success_result_error(str(exc)):
+            raise
     return structured
 
 

--- a/src/teatree/eval/sdk_runner.py
+++ b/src/teatree/eval/sdk_runner.py
@@ -6,9 +6,10 @@ achieved with ``--bare`` / ``isolated_claude_env`` and a wall of explicit flags:
 
 *   ``setting_sources=[]`` — no ``user`` / ``project`` / ``local`` settings, so
     the developer's ``~/.claude``/project settings never bias a result;
-*   ``system_prompt=<plain spec system prompt str>`` — the scenario's agent
+*   ``system_prompt=<spilled to a --system-prompt-file>`` — the scenario's agent
     definition is the WHOLE system prompt (not the ``claude_code`` preset), so no
-    built-in system prompt leaks in;
+    built-in system prompt leaks in; it is passed by FILE, not argv, so a
+    whole-skill prompt never blows ``ARG_MAX`` (E2BIG) at the spawn;
 *   ``settings='{"hooks":{}}'`` and ``strict_mcp_config`` — no hooks, no MCP;
 *   ``cwd=<isolated temp>`` + ``env`` from :func:`isolated_claude_env` — ``HOME``
     and the config-dir vars point at a ``.claude``-free temp directory so
@@ -57,8 +58,10 @@ from claude_agent_sdk.types import EffortLevel
 from teatree.eval.context_budget import extract_sections
 from teatree.eval.isolation import isolated_claude_env
 from teatree.eval.model_variant import parse_model_variant
-from teatree.eval.models import AnyOf, EvalRun, EvalSpec, Matcher, canonicalize_tool
+from teatree.eval.models import EvalRun, EvalSpec
 from teatree.eval.prompt_framing import LIVE_ENV_FRAMING
+from teatree.eval.system_prompt_file import spill_system_prompt
+from teatree.eval.toolset import compute_available_tools, compute_disallowed_tools
 from teatree.eval.transcript import (
     extract_billed_model,
     extract_cost_usd,
@@ -159,104 +162,6 @@ def resolve_metered_effort() -> EffortLevel:
     return raw if raw in EFFORT_LEVELS else METERED_DEFAULT_EFFORT  # type: ignore[return-value]
 
 
-#: The COMPLETE set of the bundled ``claude`` CLI's built-in tool names (24,
-#: from ``strings`` on the binary). A metered run will SPIRAL into any built-in a
-#: scenario did not declare — tool-hunting (``ToolSearch``), punting
-#: (``AskUserQuestion``), notifying (``PushNotification``) — burning ``max_turns``
-#: on exploration the matchers never asked for (a false fail). The toolset is
-#: restricted by TWO belt-and-suspenders mechanisms that always agree:
-#:
-#: 1. the PRIMARY ``--tools`` allowlist (``ClaudeAgentOptions.tools``) =
-#:    :func:`compute_available_tools` — the model SEES only the listed tools,
-#:    independent of ``permission_mode``;
-#: 2. DEFENSE-IN-DEPTH: the ``--disallowedTools`` complement
-#:    (:func:`compute_disallowed_tools`) = this complete set MINUS the available
-#:    set — exhaustive even if a CLI build ignored ``--tools``. Because the set is
-#:    complete, no built-in (PushNotification etc.) can leak past the denylist.
-#:
-#: ``Skill`` is deliberately ABSENT — it is left untouched so a scenario can always
-#: load a skill (the CLI auto-appends ``Skill`` to the allowlist anyway).
-KNOWN_BUILTIN_TOOLS: tuple[str, ...] = (
-    "Agent",
-    "AskUserQuestion",
-    "Bash",
-    "BashOutput",
-    "Edit",
-    "EnterPlanMode",
-    "ExitPlanMode",
-    "Glob",
-    "Grep",
-    "KillBash",
-    "KillShell",
-    "ListMcpResources",
-    "Monitor",
-    "MultiEdit",
-    "NotebookEdit",
-    "PushNotification",
-    "Read",
-    "ReadMcpResource",
-    "Task",
-    "TodoWrite",
-    "ToolSearch",
-    "WebFetch",
-    "WebSearch",
-    "Write",
-)
-
-
-def _matcher_referenced_tools(spec: EvalSpec) -> set[str]:
-    """The canonical tool names every MATCHER in *spec* references.
-
-    Collects ``Matcher.tool`` (positive AND negative) and each
-    ``AnyOf.alternatives`` entry's tool; ``FinalStateMatcher`` references no tool.
-    A negative matcher's tool is included on PURPOSE: removing the tool a
-    ``no_tool_call_matching`` assertion guards would make that assertion pass
-    vacuously, hiding the misbehaviour it tests — so it must stay available.
-    """
-    referenced: set[str] = set()
-    for matcher in spec.matchers:
-        if isinstance(matcher, Matcher):
-            referenced.add(canonicalize_tool(matcher.tool))
-        elif isinstance(matcher, AnyOf):
-            referenced.update(canonicalize_tool(alt.tool) for alt in matcher.alternatives)
-    return referenced
-
-
-def _available_tool_set(spec: EvalSpec) -> set[str]:
-    """The canonical set of tools the model is ALLOWED to see for *spec*.
-
-    The union of the scenario's declared ``spec.tools`` (canonicalized the SAME
-    way the grader canonicalizes, so the lowercase ``bash`` alias matches ``Bash``)
-    and every matcher-referenced tool. A matcher-referenced tool is always
-    available so a negative assertion can still observe the misbehaviour it tests.
-    The single source of truth for BOTH the allowlist and the denylist-complement.
-    """
-    return {canonicalize_tool(tool) for tool in spec.tools} | _matcher_referenced_tools(spec)
-
-
-def compute_available_tools(spec: EvalSpec) -> tuple[str, ...]:
-    """The ``--tools`` ALLOWLIST for *spec* — the model sees ONLY these tools.
-
-    The PRIMARY toolset restriction: ``canonicalize(spec.tools)`` unioned with
-    every matcher-referenced tool, sorted and deterministic. Independent of
-    ``permission_mode``. Empty when a scenario declares no tools and references
-    none — :func:`build_sdk_options` renders that as ``tools=None`` (the CLI
-    default toolset), never an empty ``--tools ""`` (no tools).
-    """
-    return tuple(sorted(_available_tool_set(spec)))
-
-
-def compute_disallowed_tools(spec: EvalSpec) -> tuple[str, ...]:
-    """The built-in tools to REMOVE from the model's toolset for *spec* (denylist).
-
-    DEFENSE-IN-DEPTH complement of :func:`compute_available_tools` within the
-    complete :data:`KNOWN_BUILTIN_TOOLS`: a built-in is disallowed unless it is in
-    the available set. Because the set is complete, this is exhaustive even if a
-    CLI build ignored ``--tools``. Sorted for a deterministic, idempotent set.
-    """
-    return tuple(sorted(set(KNOWN_BUILTIN_TOOLS) - _available_tool_set(spec)))
-
-
 #: Resolved at import so the existing ``patch("…WATCHDOG_SECONDS", 0.01)`` test seam
 #: keeps working; the env override is read here once, generous by default.
 WATCHDOG_SECONDS = resolve_watchdog_seconds()
@@ -288,6 +193,14 @@ _TERMINAL_MARKERS: tuple[tuple[str, str], ...] = (
     ("maximum budget", BUDGET_EXCEEDED_REASON),
     ("maximum number of turns", MAX_TURNS_REASON),
 )
+#: The SDK wraps the CLI's non-zero exit as ``"Claude Code returned an error
+#: result: <subtype-or-errors>"`` (``claude_agent_sdk/_internal/query.py`` L342)
+#: whenever a ``result`` event carried ``is_error=True`` — but the descriptive
+#: field it falls back to is the ``subtype``, which the CLI sometimes reports as
+#: ``"success"`` even while exiting non-zero. That is a SUCCESSFUL terminus
+#: mislabeled, NOT a cap and NOT a crash: the captured trajectory already holds
+#: the success ``result`` event, so the run is graded normally instead of raised.
+_SUCCESS_RESULT_MARKER = "returned an error result: success"
 #: The cap the SDK reports in the budget message — ``Reached maximum budget
 #: ($0.1)`` — is the partial-cost floor when no metered ``result`` event was
 #: produced. (max-turns carries no ``($X)``; its cost comes from a captured
@@ -313,6 +226,18 @@ def classify_terminal_error(message: str) -> str | None:
         if marker in message:
             return reason
     return None
+
+
+def is_success_result_error(message: str) -> bool:
+    """``True`` when the SDK's error-result *message* actually describes a SUCCESS.
+
+    The CLI can exit non-zero while its ``result`` event subtype reads
+    ``"success"``; the SDK then raises ``"...returned an error result: success"``.
+    Treating that as a genuine error would crash a finished run, so the runner
+    recognizes it and grades the captured trajectory normally (the success
+    ``result`` event is already in the captured messages).
+    """
+    return _SUCCESS_RESULT_MARKER in message
 
 
 def _budget_amount_from_message(message: str) -> float | None:
@@ -399,11 +324,17 @@ def build_sdk_options(config: CleanRoomConfig) -> ClaudeAgentOptions:
     """Build the clean-room :class:`ClaudeAgentOptions` shared by runner and judge.
 
     Reproduces the deleted runner's virgin configuration: empty
-    ``setting_sources`` (no personal context), a plain-string ``system_prompt``
-    (the scenario's own definition, never the ``claude_code`` preset), empty
-    hooks via ``settings``, ``strict_mcp_config``, ``bypassPermissions``, and the
+    ``setting_sources`` (no personal context), the scenario's own definition as
+    the WHOLE system prompt (never the ``claude_code`` preset), empty hooks via
+    ``settings``, ``strict_mcp_config``, ``bypassPermissions``, and the
     ``max_budget_usd`` circuit breaker. ``cwd``/``env`` come from
     :func:`isolated_claude_env`; ``add_dirs`` grants the scenario its workspace.
+
+    The system prompt is spilled to a file under ``cwd`` and passed as a
+    :class:`SystemPromptFile` (``--system-prompt-file``), NOT as a plain string
+    (``--system-prompt <text>``): a whole-skill system prompt sent via argv blows
+    ``ARG_MAX`` (E2BIG) at spawn, failing the run before any scenario executes.
+    The file path keeps the argv bounded regardless of skill size.
 
     The ``--tools`` allowlist is the PRIMARY toolset restriction: an empty
     ``available_tools`` is passed as ``tools=None`` (the CLI default toolset), NOT
@@ -414,7 +345,7 @@ def build_sdk_options(config: CleanRoomConfig) -> ClaudeAgentOptions:
     available = list(config.available_tools) if config.available_tools else None
     return ClaudeAgentOptions(
         setting_sources=[],
-        system_prompt=config.system_prompt,
+        system_prompt=spill_system_prompt(config.system_prompt, config.cwd),
         settings=EMPTY_SETTINGS,
         strict_mcp_config=True,
         cwd=config.cwd,
@@ -590,8 +521,10 @@ async def _collect(prompt: str, options: ClaudeAgentOptions) -> list[Message]:
     as they arrive — instead of an all-or-nothing comprehension — keeps every
     ``AssistantMessage`` (with its tool calls) the agent produced before hitting
     the cap. On a KNOWN terminal cap the partial list is re-raised inside a
-    :class:`_TerminalResultError` for the runner to grade; any other error
-    re-raises unchanged so a genuine crash is never swallowed.
+    :class:`_TerminalResultError` for the runner to grade; a SUCCESS mislabeled as
+    an error result (the CLI exited non-zero on a ``"success"`` subtype) is graded
+    from the captured messages, not raised; any other error re-raises unchanged so
+    a genuine crash is never swallowed.
     """
     messages: list[Message] = []
     try:
@@ -601,6 +534,8 @@ async def _collect(prompt: str, options: ClaudeAgentOptions) -> list[Message]:
             # mid-stream terminal raise, which is the exact bug this fixes.
             messages.append(message)  # noqa: PERF401 — partial list must survive a mid-iteration Exception
     except Exception as exc:
+        if is_success_result_error(str(exc)):
+            return messages
         reason = classify_terminal_error(str(exc))
         if reason is None:
             raise

--- a/src/teatree/eval/system_prompt_file.py
+++ b/src/teatree/eval/system_prompt_file.py
@@ -1,0 +1,51 @@
+"""Pass a clean-room system prompt to the CLI by file, never by argv.
+
+A whole-skill system prompt is hundreds of KB. The SDK renders a plain-string
+``system_prompt`` as a single ``--system-prompt <text>`` argv argument, which
+blows ``ARG_MAX`` (``[Errno 7] Argument list too long``, E2BIG) the moment a
+skill grows past the OS limit — failing the metered eval lane before any
+scenario runs. Spilling the prompt to a file and pointing the CLI at it with
+``--system-prompt-file <path>`` keeps the argv bounded regardless of skill size.
+"""
+
+from pathlib import Path
+
+from claude_agent_sdk.types import SystemPromptFile
+
+#: Filename for the system-prompt spilled into the isolated ``cwd``. Dot-prefixed
+#: so it is not a natural workspace file the scenario would glob/read; it dies
+#: with the ``isolated_claude_env`` ``TemporaryDirectory`` that brackets the spawn.
+_SYSTEM_PROMPT_FILENAME = ".t3-eval-system-prompt.txt"
+
+
+def spill_system_prompt(system_prompt: str, cwd: str) -> SystemPromptFile:
+    """Write *system_prompt* into *cwd* and return the SDK ``--system-prompt-file`` ref.
+
+    *cwd* is the ``isolated_claude_env`` temp dir that outlives the ``query``
+    spawn, so the file is cleaned up with it — no separate lifetime to manage.
+    """
+    path = Path(cwd) / _SYSTEM_PROMPT_FILENAME
+    path.write_text(system_prompt, encoding="utf-8")
+    return {"type": "file", "path": str(path)}
+
+
+def resolve_system_prompt(system_prompt: str | SystemPromptFile | None) -> str:
+    """Return the system-prompt TEXT whichever transport the options carry.
+
+    The clean-room options spill the prompt to a ``--system-prompt-file`` (a
+    :class:`SystemPromptFile`); this reads it back so callers (and tests) can
+    assert on the actual content the CLI receives regardless of whether it is an
+    inline string or a file reference. Must be called while the spilled file still
+    exists (inside the ``isolated_claude_env`` scope).
+    """
+    if system_prompt is None:
+        return ""
+    if isinstance(system_prompt, str):
+        return system_prompt
+    return Path(system_prompt["path"]).read_text(encoding="utf-8")
+
+
+__all__ = [
+    "resolve_system_prompt",
+    "spill_system_prompt",
+]

--- a/src/teatree/eval/toolset.py
+++ b/src/teatree/eval/toolset.py
@@ -1,0 +1,109 @@
+"""Derive a scenario's clean-room toolset (allowlist + denylist complement).
+
+A metered run will SPIRAL into any built-in a scenario did not declare —
+tool-hunting (``ToolSearch``), punting (``AskUserQuestion``), notifying
+(``PushNotification``) — burning ``max_turns`` on exploration the matchers never
+asked for (a false fail). The toolset is restricted by TWO belt-and-suspenders
+mechanisms that always agree.
+
+The PRIMARY ``--tools`` allowlist (``ClaudeAgentOptions.tools``) is
+:func:`compute_available_tools`: the model SEES only the listed tools,
+independent of ``permission_mode``. The DEFENSE-IN-DEPTH ``--disallowedTools``
+complement is :func:`compute_disallowed_tools` = :data:`KNOWN_BUILTIN_TOOLS`
+MINUS the available set — exhaustive even if a CLI build ignored ``--tools``.
+"""
+
+from teatree.eval.models import AnyOf, EvalSpec, Matcher, canonicalize_tool
+
+#: The COMPLETE set of the bundled ``claude`` CLI's built-in tool names (24,
+#: from ``strings`` on the binary). Because the set is complete, no built-in
+#: (PushNotification etc.) can leak past the denylist.
+#:
+#: ``Skill`` is deliberately ABSENT — it is left untouched so a scenario can always
+#: load a skill (the CLI auto-appends ``Skill`` to the allowlist anyway).
+KNOWN_BUILTIN_TOOLS: tuple[str, ...] = (
+    "Agent",
+    "AskUserQuestion",
+    "Bash",
+    "BashOutput",
+    "Edit",
+    "EnterPlanMode",
+    "ExitPlanMode",
+    "Glob",
+    "Grep",
+    "KillBash",
+    "KillShell",
+    "ListMcpResources",
+    "Monitor",
+    "MultiEdit",
+    "NotebookEdit",
+    "PushNotification",
+    "Read",
+    "ReadMcpResource",
+    "Task",
+    "TodoWrite",
+    "ToolSearch",
+    "WebFetch",
+    "WebSearch",
+    "Write",
+)
+
+
+def _matcher_referenced_tools(spec: EvalSpec) -> set[str]:
+    """The canonical tool names every MATCHER in *spec* references.
+
+    Collects ``Matcher.tool`` (positive AND negative) and each
+    ``AnyOf.alternatives`` entry's tool; ``FinalStateMatcher`` references no tool.
+    A negative matcher's tool is included on PURPOSE: removing the tool a
+    ``no_tool_call_matching`` assertion guards would make that assertion pass
+    vacuously, hiding the misbehaviour it tests — so it must stay available.
+    """
+    referenced: set[str] = set()
+    for matcher in spec.matchers:
+        if isinstance(matcher, Matcher):
+            referenced.add(canonicalize_tool(matcher.tool))
+        elif isinstance(matcher, AnyOf):
+            referenced.update(canonicalize_tool(alt.tool) for alt in matcher.alternatives)
+    return referenced
+
+
+def _available_tool_set(spec: EvalSpec) -> set[str]:
+    """The canonical set of tools the model is ALLOWED to see for *spec*.
+
+    The union of the scenario's declared ``spec.tools`` (canonicalized the SAME
+    way the grader canonicalizes, so the lowercase ``bash`` alias matches ``Bash``)
+    and every matcher-referenced tool. A matcher-referenced tool is always
+    available so a negative assertion can still observe the misbehaviour it tests.
+    The single source of truth for BOTH the allowlist and the denylist-complement.
+    """
+    return {canonicalize_tool(tool) for tool in spec.tools} | _matcher_referenced_tools(spec)
+
+
+def compute_available_tools(spec: EvalSpec) -> tuple[str, ...]:
+    """The ``--tools`` ALLOWLIST for *spec* — the model sees ONLY these tools.
+
+    The PRIMARY toolset restriction: ``canonicalize(spec.tools)`` unioned with
+    every matcher-referenced tool, sorted and deterministic. Independent of
+    ``permission_mode``. Empty when a scenario declares no tools and references
+    none — ``build_sdk_options`` renders that as ``tools=None`` (the CLI default
+    toolset), never an empty ``--tools ""`` (no tools).
+    """
+    return tuple(sorted(_available_tool_set(spec)))
+
+
+def compute_disallowed_tools(spec: EvalSpec) -> tuple[str, ...]:
+    """The built-in tools to REMOVE from the model's toolset for *spec* (denylist).
+
+    DEFENSE-IN-DEPTH complement of :func:`compute_available_tools` within the
+    complete :data:`KNOWN_BUILTIN_TOOLS`: a built-in is disallowed unless it is in
+    the available set. Because the set is complete, this is exhaustive even if a
+    CLI build ignored ``--tools``. Sorted for a deterministic, idempotent set.
+    """
+    return tuple(sorted(set(KNOWN_BUILTIN_TOOLS) - _available_tool_set(spec)))
+
+
+__all__ = [
+    "KNOWN_BUILTIN_TOOLS",
+    "compute_available_tools",
+    "compute_disallowed_tools",
+]

--- a/tests/eval_harness/test_virgin_isolation.py
+++ b/tests/eval_harness/test_virgin_isolation.py
@@ -31,6 +31,7 @@ from teatree.eval.isolation import isolated_claude_env
 from teatree.eval.judge import ClaudeJudge
 from teatree.eval.models import EvalRun, EvalSpec, EvalToolCall, JudgeSpec, Matcher
 from teatree.eval.sdk_runner import SdkInProcessRunner
+from teatree.eval.system_prompt_file import resolve_system_prompt
 
 
 def _runner_spec(tmp_path: Path) -> EvalSpec:
@@ -95,6 +96,10 @@ def _capturing_query(messages: list[Any]) -> tuple[Any, dict[str, Any]]:
         await asyncio.sleep(0)
         captured["prompt"] = prompt
         captured["options"] = options
+        # The clean-room options spill the system prompt to a --system-prompt-file
+        # under the isolated cwd (deleted on context exit); resolve it to text HERE
+        # while the file still exists so post-hoc assertions see the actual content.
+        captured["system_prompt_text"] = resolve_system_prompt(options.system_prompt) if options else ""
         for message in messages:
             yield message
 
@@ -157,8 +162,12 @@ class TestRunnerIsolation:
     def test_options_use_plain_system_prompt_not_preset(self, tmp_path: Path) -> None:
         captured = self._run(_runner_spec(tmp_path), tmp_path)
         system_prompt = captured["options"].system_prompt
-        assert isinstance(system_prompt, str)
-        assert system_prompt.startswith("# fake skill")
+        # The clean-room prompt is spilled to a --system-prompt-file ref (so a
+        # whole-skill prompt never blows ARG_MAX via argv), NOT the claude_code
+        # preset — its resolved content is the scenario's own definition.
+        assert isinstance(system_prompt, dict)
+        assert system_prompt["type"] == "file"
+        assert captured["system_prompt_text"].startswith("# fake skill")
         assert captured["options"].settings == '{"hooks":{}}'
 
     def test_options_carry_sanitized_env_and_neutral_cwd(self, tmp_path: Path) -> None:
@@ -253,7 +262,7 @@ class TestCanaryNeverReachesChild:
         assert Path(options.env["HOME"]) != fake_home
         assert not (Path(options.env["HOME"]) / ".claude" / "CLAUDE.md").exists()
         assert Path(options.cwd) != project
-        assert CANARY not in options.system_prompt
+        assert CANARY not in captured["system_prompt_text"]
 
     @pytest.mark.skipif(
         shutil.which("claude") is None or not os.environ.get("ANTHROPIC_API_KEY"),

--- a/tests/teatree_eval/test_sdk_runner.py
+++ b/tests/teatree_eval/test_sdk_runner.py
@@ -18,7 +18,6 @@ from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUse
 from teatree.eval.models import DEFAULT_MAX_TURNS, AnyOf, EvalSpec, ExpectItem, FinalStateMatcher, Matcher, TokenUsage
 from teatree.eval.sdk_runner import (
     DEFAULT_WATCHDOG_SECONDS,
-    KNOWN_BUILTIN_TOOLS,
     MAX_BUDGET_USD,
     WATCHDOG_SECONDS,
     BudgetExceededError,
@@ -27,9 +26,10 @@ from teatree.eval.sdk_runner import (
     SdkInProcessRunner,
     build_sdk_options,
     classify_terminal_error,
-    compute_available_tools,
-    compute_disallowed_tools,
+    is_success_result_error,
 )
+from teatree.eval.system_prompt_file import resolve_system_prompt, spill_system_prompt
+from teatree.eval.toolset import KNOWN_BUILTIN_TOOLS, compute_available_tools, compute_disallowed_tools
 from teatree.eval.transcript import _USAGE_KEY_TO_FIELD
 
 
@@ -64,6 +64,11 @@ def _fake_query(messages: list[Any]):
         await asyncio.sleep(0)
         captured["prompt"] = prompt
         captured["options"] = options
+        # The clean-room options spill the system prompt to a --system-prompt-file
+        # under the isolated cwd, which is deleted when the context exits; resolve
+        # it to text HERE, while the file still exists, so post-hoc assertions can
+        # inspect the actual prompt content the CLI receives.
+        captured["system_prompt_text"] = resolve_system_prompt(options.system_prompt) if options else ""
         for message in messages:
             yield message
 
@@ -399,7 +404,7 @@ class TestSdkInProcessRunnerAgentDefinition:
             agent_sections=("Background Long Operations",),
         )
         captured = self._run(spec, workspace=tmp_path)
-        system_prompt = captured["options"].system_prompt
+        system_prompt = captured["system_prompt_text"]
         assert "Background >15s work." in system_prompt
         assert "fifty other rules here." not in system_prompt
 
@@ -418,7 +423,7 @@ class TestSdkInProcessRunnerAgentDefinition:
         captured = self._run(spec, workspace=tmp_path)
         from teatree.eval.prompt_framing import LIVE_ENV_FRAMING  # noqa: PLC0415
 
-        assert captured["options"].system_prompt == full + LIVE_ENV_FRAMING
+        assert captured["system_prompt_text"] == full + LIVE_ENV_FRAMING
 
     def test_runner_appends_live_environment_framing(self, tmp_path: Path) -> None:
         # The clean-room runner appends the live-environment framing so the model
@@ -437,7 +442,7 @@ class TestSdkInProcessRunnerAgentDefinition:
             source_path=tmp_path / "spec.yaml",
         )
         captured = self._run(spec, workspace=tmp_path)
-        system_prompt = captured["options"].system_prompt
+        system_prompt = captured["system_prompt_text"]
         assert system_prompt.endswith(LIVE_ENV_FRAMING)
         assert "issuing the actual tool call" in system_prompt
         assert "never print the command as text" in system_prompt
@@ -491,7 +496,7 @@ class TestSdkInProcessRunnerMessageMapping:
             patch("teatree.eval.sdk_runner.query", query),
         ):
             SdkInProcessRunner(workspace=tmp_path).run(spec)
-        assert captured["options"].system_prompt.strip()
+        assert captured["system_prompt_text"].strip()
 
     def test_relative_agent_path_not_found_raises(self, tmp_path: Path, monkeypatch) -> None:
         # No candidate resolves (cwd and teatree-root both miss) -> the loop
@@ -743,6 +748,171 @@ class TestClassifyTerminalError:
     def test_returns_none_for_a_genuine_error(self) -> None:
         assert classify_terminal_error("Claude Code returned an error result: error_during_execution") is None
         assert classify_terminal_error("some other RuntimeError about a socket") is None
+
+
+#: A whole-skill system prompt is hundreds of KB; the metered lane crashed with
+#: ``[Errno 7] Argument list too long`` (E2BIG) because the SDK rendered it as a
+#: single ``--system-prompt <text>`` argv token. 200 KB reproduces that scale.
+_HUGE_SYSTEM_PROMPT = "# Big Skill\n\n" + ("x" * 200_000)
+#: A single argv token this large is what blew ARG_MAX. The fixed transport must
+#: keep every token well under it (the prompt now travels as a file path).
+_ARGV_TOKEN_CEILING = 8_192
+
+
+class TestLargeSystemPromptDoesNotBlowArgMax:
+    """A 200 KB system prompt must not become a giant argv token (E2BIG regression).
+
+    The metered ``eval`` job failed before any scenario with
+    ``CLIConnectionError: Failed to start Claude Code: [Errno 7] Argument list
+    too long`` because the clean-room options carried the whole skill as a
+    plain-string ``system_prompt``, which the SDK transport renders as
+    ``--system-prompt <whole-skill>`` — one argv argument over the OS limit. The
+    fix spills the prompt to a file and passes ``--system-prompt-file <path>``, so
+    no single argv token grows with skill size.
+    """
+
+    def test_build_sdk_options_spills_a_huge_prompt_to_a_file(self, tmp_path: Path) -> None:
+        config = CleanRoomConfig(
+            system_prompt=_HUGE_SYSTEM_PROMPT,
+            workspace=tmp_path,
+            cwd=str(tmp_path),
+            env={},
+            allowed_tools=("Bash",),
+            model="haiku",
+            max_turns=3,
+        )
+        options = build_sdk_options(config)
+        # The prompt is a file reference, not an inline string the transport would
+        # pass via argv.
+        assert isinstance(options.system_prompt, dict)
+        assert options.system_prompt["type"] == "file"
+        assert resolve_system_prompt(options.system_prompt) == _HUGE_SYSTEM_PROMPT
+
+    def test_sdk_command_has_no_arg_over_the_ceiling_for_a_huge_prompt(self, tmp_path: Path) -> None:
+        # Exercise the REAL SDK transport arg builder: with the old inline-string
+        # prompt this produced a single 200 KB argv token (E2BIG); the file-based
+        # transport keeps every token small.
+        from claude_agent_sdk._internal.transport.subprocess_cli import SubprocessCLITransport  # noqa: PLC0415
+
+        config = CleanRoomConfig(
+            system_prompt=_HUGE_SYSTEM_PROMPT,
+            workspace=tmp_path,
+            cwd=str(tmp_path),
+            env={},
+            allowed_tools=("Bash",),
+            model="haiku",
+            max_turns=3,
+        )
+        options = build_sdk_options(config)
+        transport = SubprocessCLITransport(prompt="hi", options=options)
+        transport._cli_path = "/usr/local/bin/claude"
+        command = transport._build_command()
+        # No single argv token carries the prompt body, and the prompt text itself
+        # appears in NO argv argument — it travels only inside the spilled file.
+        assert all(len(arg) < _ARGV_TOKEN_CEILING for arg in command)
+        assert not any(_HUGE_SYSTEM_PROMPT in arg for arg in command)
+        # It is passed by reference, not value.
+        assert "--system-prompt-file" in command
+
+    def test_spill_round_trips_content_and_keeps_the_path_short(self, tmp_path: Path) -> None:
+        ref = spill_system_prompt(_HUGE_SYSTEM_PROMPT, str(tmp_path))
+        assert ref["type"] == "file"
+        assert len(ref["path"]) < _ARGV_TOKEN_CEILING
+        assert resolve_system_prompt(ref) == _HUGE_SYSTEM_PROMPT
+
+    def test_runner_starts_a_huge_prompt_scenario_without_oserror(self, tmp_path: Path) -> None:
+        # End-to-end at the runner boundary: a scenario whose skill is 200 KB runs
+        # through the runner (SDK mocked) and produces a normal EvalRun — no
+        # OSError/E2BIG at the spawn boundary.
+        agent = tmp_path / "huge_skill.md"
+        agent.write_text(_HUGE_SYSTEM_PROMPT, encoding="utf-8")
+        spec = EvalSpec(
+            name="huge",
+            scenario="a 200KB skill must not blow ARG_MAX at spawn",
+            agent_path=str(agent),
+            prompt="do the one thing.",
+            matchers=(Matcher(kind="positive", tool="Bash", arg_path="command", operator="contains", value="x"),),
+            source_path=tmp_path / "spec.yaml",
+            tools=("Bash",),
+        )
+        query, captured = _fake_query([_result()])
+        with (
+            patch("teatree.eval.sdk_runner.shutil.which", return_value="/usr/local/bin/claude"),
+            patch("teatree.eval.sdk_runner.query", query),
+        ):
+            run = SdkInProcessRunner(workspace=tmp_path).run(spec)
+        assert run.terminal_reason == "success"
+        assert run.is_error is False
+        assert _HUGE_SYSTEM_PROMPT in captured["system_prompt_text"]
+
+
+class TestSuccessResultIsNotAnError:
+    """A ``result`` mislabeled ``error_result: success`` must grade as a success.
+
+    The metered run also raised ``Exception: Claude Code returned an error result:
+    success`` at the end: the CLI exits non-zero while its ``result`` event subtype
+    reads ``"success"``, and the SDK wraps that as a bare error Exception. The
+    runner must recognize this SUCCESS terminus and grade the captured trajectory
+    normally instead of crashing the whole run.
+    """
+
+    def _run_with_query(self, spec: EvalSpec, query, **kwargs: Any):
+        with (
+            patch("teatree.eval.sdk_runner.shutil.which", return_value="/usr/local/bin/claude"),
+            patch("teatree.eval.sdk_runner.query", query),
+        ):
+            return SdkInProcessRunner(workspace=spec.source_path.parent, **kwargs).run(spec)
+
+    def test_is_success_result_error_recognizes_the_marker(self) -> None:
+        assert is_success_result_error("Claude Code returned an error result: success") is True
+        assert is_success_result_error("Claude Code returned an error result: error_max_turns") is False
+
+    def test_success_labeled_error_after_a_result_grades_as_a_normal_run(self, tmp_path: Path) -> None:
+        # The SUCCESS ResultMessage reached the consumer before the spurious error,
+        # so the run grades from the captured trajectory: success, not error.
+        spec = _spec(tmp_path)
+        messages = [
+            AssistantMessage(
+                content=[ToolUseBlock(id="t1", name="Bash", input={"command": "git worktree add ../wt HEAD"})],
+                model="haiku",
+            ),
+            _result(subtype="success", total_cost_usd=0.0321),
+        ]
+        query = _yield_then_raise_query(messages, "Claude Code returned an error result: success")
+        run = self._run_with_query(spec, query)
+        assert run.terminal_reason == "success"
+        assert run.is_error is False
+        assert len(run.tool_calls) == 1
+        assert run.tool_calls[0].input["command"].startswith("git worktree add")
+        assert run.cost_usd == pytest.approx(0.0321)
+
+    def test_success_labeled_run_grades_through_report_evaluate(self, tmp_path: Path) -> None:
+        # The deliverable shape: a success-labeled run produces a normal graded
+        # ScenarioResult (not a crash), with the matcher deciding pass/fail.
+        from teatree.eval.report import evaluate  # noqa: PLC0415
+
+        spec = _spec(tmp_path)
+        messages = [
+            AssistantMessage(
+                content=[ToolUseBlock(id="t1", name="Bash", input={"command": "git worktree add ../wt HEAD"})],
+                model="haiku",
+            ),
+            _result(subtype="success", total_cost_usd=0.01),
+        ]
+        query = _yield_then_raise_query(messages, "Claude Code returned an error result: success")
+        run = self._run_with_query(spec, query)
+        result = evaluate(spec, run)
+        assert result.skipped is False
+        assert result.passed is True
+        assert result.verdict == "pass"
+
+    def test_a_genuine_error_result_still_propagates(self, tmp_path: Path) -> None:
+        # Anti-vacuity: only the "success" subtype is rescued. A real error subtype
+        # is NOT swallowed by the success path — it stays a propagating crash.
+        spec = _spec(tmp_path)
+        query = _yield_then_raise_query([], "Claude Code returned an error result: error_during_execution")
+        with pytest.raises(Exception, match="error_during_execution"):
+            self._run_with_query(spec, query)
 
 
 class TestSdkInProcessRunnerMaxTurnsCapturesTrajectory:


### PR DESCRIPTION
The metered AI-eval lane (eval GitHub Actions job) failed before running any scenario with a CLIConnectionError reporting Errno 7 (Argument list too long, E2BIG). The clean-room SDK options carried the whole skill as a plain-string system_prompt, which the SDK transport renders as a single --system-prompt argv token over the OS ARG_MAX limit. A second bug surfaced at the end of a run: a CLI result event whose subtype reads success while the process exits non-zero was wrapped by the SDK as a bare error Exception and crashed the run.

Fix: (1) E2BIG — spill the system prompt to a file under the isolated cwd and pass it as a SystemPromptFile (--system-prompt-file path), so no single argv token grows with skill size; the file lives in the isolated_claude_env temp dir that already brackets the spawn. build_sdk_options is shared by the runner, the judge, and ticket_short_describe, so all three inherit the fix. (2) success-as-error — the runner and judge now recognize the success-labeled error-result terminus as a SUCCESS and grade the captured trajectory normally instead of re-raising. (3) Module health — extracted the system-prompt-file transport (system_prompt_file.py) and the toolset allow/deny computation (toolset.py) into leaf modules so sdk_runner.py stays under the LOC and public-function caps.

Regression tests: TestLargeSystemPromptDoesNotBlowArgMax (a 200 KB system prompt produces no argv token over the ceiling, exercising the real SDK arg builder SubprocessCLITransport._build_command, and the runner starts without OSError) and TestSuccessResultIsNotAnError (a success-labeled result grades to a normal passing ScenarioResult; a genuine error subtype still propagates). Both were observed RED on the unfixed code before the fix.

Gates green: tests/teatree_eval, tests/eval_harness, tests/eval_replay (1772+ passed); t3 eval pinned-regressions 15/15; tests/teatree_quality, module-health, tach, ruff.