### PR TITLE
chore(prek): re-pin ac-django skills rev to the merged main commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -186,7 +186,7 @@ repos:
   # (resolved via `uvx --from ast-grep-cli==0.42.3`). The pyproject hook
   # grandfathers the three existing complexity-ignore entries via --grandfather.
   - repo: https://github.com/souliane/skills
-    rev: 29c0a2c62e95203783e860536ce38cec4375de39
+    rev: 08a9715af678766fde6ce61a6fce288ade1eba88
     hooks:
       - id: ac-django-no-pytest-django-db
         files: ^tests/.*\.py$


### PR DESCRIPTION
## What

Re-pin the `ac-django` prek hooks in `.pre-commit-config.yaml` to the squash-merge commit on `souliane/skills` main: `08a9715a`.

[#2484](https://github.com/souliane/teatree/pull/2484) merged pinning `souliane/skills@29c0a2c6`, an intermediate branch commit. [souliane/skills#48](https://github.com/souliane/skills/pull/48) has since squash-merged to skills `main` as `08a9715a` with `--delete-branch`, so the branch and its commits are orphaned. This re-pins to the reachable `main` commit — the correct, durable pin.

The squash preserves the tree, so `08a9715a`'s content is identical to the merged branch head and behaviour is unchanged. This just points `rev:` at the reachable `main` commit instead of an orphaned sha.

## Change

One line: `rev: 29c0a2c6…` → `rev: 08a9715a…`. No rule-behaviour change.

## Verification

All four ac-django hooks resolve and run green on the current tree at the new sha:

```
ac-django · no @pytest.mark.django_db (use django.test.TestCase) ......... Passed
ac-django · no @pytest.mark.parametrize inside a TestCase ................ Passed
ac-django · no C901/PLR09xx noqa suppressions ........................... Passed
ac-django · no NEW C901/PLR09xx in a pyproject ruff ignore list ......... Passed
```
