### PR TITLE
fix(eval): make the metered lane observable and fail loud on a hang

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -91,10 +91,11 @@ jobs:
     # retry-wrapped eval step (a stuck report render, a hung docker build/daemon)
     # runs to GitHub's 6h default with no signal — and an in-progress job's log
     # blob is never exposed, so a hang looks identical to a slow run for hours.
-    # The eval step itself is bounded to 30min x 3 attempts (~90min worst case);
-    # 100min caps the whole job just above that so a real hang is killed and
-    # surfaced as a red, diagnosable run instead of an indefinite stall.
-    timeout-minutes: 100
+    # The eval step is bounded to 80min x 2 attempts (160min worst case);
+    # 180min caps the whole job just above that (plus the report/upload steps)
+    # so a real hang is killed and surfaced as a red, diagnosable run instead of
+    # an indefinite stall.
+    timeout-minutes: 180
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
@@ -171,15 +172,16 @@ jobs:
           # metered `claude` SDK call — it does not fit a 30min attempt, and each
           # retry re-runs the WHOLE suite from scratch (`--no-persist`, no resume),
           # so a too-tight timeout just truncates+repeats the same partial work
-          # every attempt and never completes (the observed "hang"). One generous
-          # attempt lets the suite finish; the per-scenario RUN/DONE progress lines
+          # every attempt and never completes (the observed "hang"). 80min per
+          # attempt lets the suite finish; 2 attempts keep ONE transient-failure
+          # retry (the whole point of the retry wrapper — an AI/network flake is
+          # retried, not red-failed) without a third truncating pass. 2x80=160min
+          # sits under the 180min job cap. The per-scenario RUN/DONE progress lines
           # (multi_trial.py) plus the job-level `timeout-minutes` make a genuine
           # stall diagnosable (last RUN line = the wedged scenario) and fail loud
-          # rather than re-burning spend. 80min < the 100min job cap leaves room
-          # for the report step. The retry wrapper is kept (max_attempts: 1) so a
-          # later transient-flake bump is a one-line change.
+          # rather than re-burning spend indefinitely.
           timeout_minutes: 80
-          max_attempts: 1
+          max_attempts: 2
           retry_wait_seconds: 60
           # EVAL_LANE empty (scheduled runs and the default manual run) = every lane,
           # today's behaviour. A manual run may pass `under_load` to meter only the

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -87,6 +87,14 @@ jobs:
   # so a missing binary / all-skipped run fails RED instead of passing green.
   eval:
     runs-on: ubuntu-latest
+    # FAIL LOUD on a hang. Without a job-level cap a wedge ANYWHERE outside the
+    # retry-wrapped eval step (a stuck report render, a hung docker build/daemon)
+    # runs to GitHub's 6h default with no signal — and an in-progress job's log
+    # blob is never exposed, so a hang looks identical to a slow run for hours.
+    # The eval step itself is bounded to 30min x 3 attempts (~90min worst case);
+    # 100min caps the whole job just above that so a real hang is killed and
+    # surfaced as a red, diagnosable run instead of an indefinite stall.
+    timeout-minutes: 100
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
@@ -159,8 +167,19 @@ jobs:
           EVAL_BACKEND: ${{ inputs.backend || 'sdk' }}
           EVAL_LANE: ${{ inputs.lane || '' }}
         with:
-          timeout_minutes: 30
-          max_attempts: 3
+          # The FULL metered suite is ~68 scenarios x 3 trials, each a real
+          # metered `claude` SDK call — it does not fit a 30min attempt, and each
+          # retry re-runs the WHOLE suite from scratch (`--no-persist`, no resume),
+          # so a too-tight timeout just truncates+repeats the same partial work
+          # every attempt and never completes (the observed "hang"). One generous
+          # attempt lets the suite finish; the per-scenario RUN/DONE progress lines
+          # (multi_trial.py) plus the job-level `timeout-minutes` make a genuine
+          # stall diagnosable (last RUN line = the wedged scenario) and fail loud
+          # rather than re-burning spend. 80min < the 100min job cap leaves room
+          # for the report step. The retry wrapper is kept (max_attempts: 1) so a
+          # later transient-flake bump is a one-line change.
+          timeout_minutes: 80
+          max_attempts: 1
           retry_wait_seconds: 60
           # EVAL_LANE empty (scheduled runs and the default manual run) = every lane,
           # today's behaviour. A manual run may pass `under_load` to meter only the

--- a/src/teatree/cli/eval/docker.py
+++ b/src/teatree/cli/eval/docker.py
@@ -60,7 +60,10 @@ def _image_present() -> bool:
 
 
 def _build_image(root: Path) -> int:
-    return run_streamed(["docker", "build", "-q", "-t", DOCKER_IMAGE, "-f", _DOCKERFILE, "."], cwd=root, check=False)
+    # No ``-q``: a quiet build emits NOTHING until it finishes, so a slow/hung
+    # image build is indistinguishable from a wedged runner. Streaming the build
+    # log makes the build's progress (and any stall) visible in the CI log.
+    return run_streamed(["docker", "build", "-t", DOCKER_IMAGE, "-f", _DOCKERFILE, "."], cwd=root, check=False)
 
 
 def _run_in_image(root: Path, eval_args: list[str]) -> int:
@@ -73,6 +76,11 @@ def _run_in_image(root: Path, eval_args: list[str]) -> int:
             "UV_PROJECT_ENVIRONMENT=/tmp/.venv",
             "-e",
             "HOME=/tmp",
+            # Unbuffered stdio so the in-container ``t3 eval`` per-scenario progress
+            # lines flush to the runner's log in real time instead of being held in
+            # a pipe buffer until the process exits (a buffered hang shows nothing).
+            "-e",
+            "PYTHONUNBUFFERED=1",
             "-e",
             f"{IN_CONTAINER_ENV_VAR}=1",
             *_auth_passthrough_flags(),

--- a/src/teatree/cli/eval/multi_trial.py
+++ b/src/teatree/cli/eval/multi_trial.py
@@ -8,6 +8,7 @@ single-pass grade.
 
 import json
 import sys
+from collections.abc import Callable
 
 import typer
 from claude_agent_sdk.types import EffortLevel
@@ -25,7 +26,7 @@ from teatree.eval.backends import SDK_BACKEND, EvalRunner, make_runner
 from teatree.eval.matrix import MatrixRow, render_matrix_json, render_matrix_text
 from teatree.eval.model_variant import ModelVariantError, parse_model_variants
 from teatree.eval.models import EvalSpec
-from teatree.eval.pass_at_k import run_pass_at_k
+from teatree.eval.pass_at_k import PassAtKResult, run_pass_at_k
 from teatree.eval.report import ScenarioResult, evaluate
 from teatree.eval.sdk_runner import MAX_BUDGET_USD
 
@@ -35,6 +36,36 @@ from teatree.eval.sdk_runner import MAX_BUDGET_USD
 #: ``MAX_MATRIX_CELL_RETRIES + 1`` attempts total before the cell is recorded
 #: ERRORED so the rest of the comparison table is still produced.
 MAX_MATRIX_CELL_RETRIES = 2
+
+
+def _emit_progress(line: str) -> None:
+    """Print one flushed progress line to stderr so the CI log streams it live.
+
+    The metered suite runs each scenario inside a silent list-comprehension; with
+    no per-scenario emission a hang produces ZERO output until the whole suite
+    ends (and GitHub never exposes an in-progress job's log blob), so a hung run
+    is indistinguishable from a slow one. A flushed ``RUN``/``DONE`` line per
+    scenario streams to the runner's stdout in real time: the suite is visibly
+    advancing, and a hang leaves the last ``RUN <scenario>`` line as the pinpoint.
+    """
+    print(line, file=sys.stderr, flush=True)  # noqa: T201 — load-bearing live progress; see docstring.
+
+
+def _run_scenario_with_progress(
+    spec: EvalSpec,
+    trial: Callable[[EvalSpec], ScenarioResult],
+    *,
+    trials: int,
+    require: str,
+    position: tuple[int, int],
+) -> PassAtKResult:
+    """Run one pass@k scenario, bracketed by flushed RUN/DONE progress lines."""
+    index, total = position
+    _emit_progress(f"RUN  [{index}/{total}] {spec.name} (k={trials}, require={require})")
+    result = run_pass_at_k(spec, trial, k=trials, require=require)
+    verdict = "SKIP" if result.skipped else ("PASS" if result.ok else "FAIL")
+    _emit_progress(f"DONE [{index}/{total}] {spec.name}: {verdict} ({result.passes}/{result.trials})")
+    return result
 
 
 # ast-grep-ignore: ac-django-no-complexity-suppressions
@@ -79,7 +110,11 @@ def run_pass_at_k_lane(  # noqa: PLR0913 — each kwarg threads one `eval run` C
         return evaluate(spec, runner.run(spec), judge=grader)
 
     effective_specs = [with_model(spec, model_override) for spec in specs] if model_override else specs
-    results = [run_pass_at_k(spec, _trial, k=trials, require=require) for spec in effective_specs]
+    total = len(effective_specs)
+    results = [
+        _run_scenario_with_progress(spec, _trial, trials=trials, require=require, position=(index, total))
+        for index, spec in enumerate(effective_specs, start=1)
+    ]
     if output_format == "json":
         typer.echo(
             json.dumps(

--- a/tests/teatree_cli/eval/test_multi_trial_progress.py
+++ b/tests/teatree_cli/eval/test_multi_trial_progress.py
@@ -1,0 +1,71 @@
+"""Per-scenario progress streaming in the metered pass@k lane.
+
+The metered suite runs each scenario inside a list-comprehension; with no
+per-scenario emission a hang produces ZERO output until the whole suite ends
+(and GitHub never exposes an in-progress job's log blob), making a hung run
+indistinguishable from a slow one. ``run_pass_at_k_lane`` must therefore emit a
+flushed ``RUN``/``DONE`` line per scenario so the CI log streams live progress
+and a stall is pinpointed to the last ``RUN <scenario>`` line. These tests pin
+that contract with a fake runner — never the real SDK.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from teatree.cli.eval.multi_trial import run_pass_at_k_lane
+from teatree.eval.models import EvalRun, EvalSpec
+
+
+def _spec(name: str) -> EvalSpec:
+    return EvalSpec(
+        name=name,
+        scenario=f"scenario {name}",
+        agent_path="skills/code/SKILL.md",
+        prompt="do",
+        matchers=(),
+        source_path=Path("/tmp/spec.yaml"),
+        judge=None,
+    )
+
+
+def _clean_run(spec: EvalSpec) -> EvalRun:
+    return EvalRun(
+        spec_name=spec.name,
+        tool_calls=(),
+        text_blocks=(),
+        terminal_reason="end_turn",
+        is_error=False,
+        raw_stdout="",
+        raw_stderr="",
+        cost_usd=0.01,
+    )
+
+
+class _CleanRunner:
+    def run(self, spec: EvalSpec) -> EvalRun:
+        return _clean_run(spec)
+
+
+@pytest.fixture(autouse=True)
+def _patch_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The lane builds the real SDK runner internally; swap it for a deterministic
+    # clean runner so no network/metered call is made.
+    monkeypatch.setattr("teatree.cli.eval.multi_trial.make_runner", lambda *a, **k: _CleanRunner())
+
+
+class TestPerScenarioProgressStreaming:
+    def test_emits_a_run_and_done_line_per_scenario(self, capsys: pytest.CaptureFixture[str]) -> None:
+        specs = [_spec("alpha"), _spec("beta"), _spec("gamma")]
+        run_pass_at_k_lane(specs, max_turns=None, trials=1, require="any", output_format="text")
+        err = capsys.readouterr().err
+        # Every scenario gets a bracketed, indexed RUN line BEFORE it runs and a
+        # DONE line after — so a hang leaves the last RUN line as the pinpoint.
+        for index, name in enumerate(["alpha", "beta", "gamma"], start=1):
+            assert f"RUN  [{index}/3] {name}" in err
+            assert f"DONE [{index}/3] {name}" in err
+
+    def test_run_line_precedes_done_line_for_the_same_scenario(self, capsys: pytest.CaptureFixture[str]) -> None:
+        run_pass_at_k_lane([_spec("alpha")], max_turns=None, trials=1, require="any", output_format="text")
+        err = capsys.readouterr().err
+        assert err.index("RUN  [1/1] alpha") < err.index("DONE [1/1] alpha")

--- a/tests/teatree_cli/test_eval_docker.py
+++ b/tests/teatree_cli/test_eval_docker.py
@@ -88,6 +88,31 @@ class TestRunEvalInDocker:
         index = command.index("T3_EVAL_IN_CONTAINER=1")
         assert command[index - 1 : index + 1] == ["-e", "T3_EVAL_IN_CONTAINER=1"]
 
+    def test_build_is_not_quiet_so_build_progress_streams(self) -> None:
+        # A `-q` build emits nothing until it finishes, so a slow/hung image build
+        # is indistinguishable from a wedged runner. The build must stream.
+        with (
+            patch(f"{_MODULE}.shutil.which", return_value="/usr/bin/docker"),
+            patch(f"{_MODULE}._image_present", return_value=False),
+            patch(f"{_MODULE}.run_streamed", return_value=0) as streamed,
+        ):
+            run_eval_in_docker(["all", "--free-only"])
+        build = streamed.call_args_list[0].args[0]
+        assert "-q" not in build
+
+    def test_container_run_is_unbuffered_so_per_scenario_progress_streams(self) -> None:
+        # PYTHONUNBUFFERED forces the in-container `t3 eval` per-scenario progress
+        # lines to flush live instead of sitting in a pipe buffer until exit.
+        with (
+            patch(f"{_MODULE}.shutil.which", return_value="/usr/bin/docker"),
+            patch(f"{_MODULE}._image_present", return_value=True),
+            patch(f"{_MODULE}.run_streamed", return_value=0) as streamed,
+        ):
+            run_eval_in_docker(["all", "--free-only"])
+        command = streamed.call_args.args[0]
+        index = command.index("PYTHONUNBUFFERED=1")
+        assert command[index - 1 : index + 1] == ["-e", "PYTHONUNBUFFERED=1"]
+
     def test_raises_when_docker_missing(self) -> None:
         with patch(f"{_MODULE}.shutil.which", return_value=None), pytest.raises(DockerUnavailableError):
             run_eval_in_docker(["all"])


### PR DESCRIPTION
## Problem

The metered AI eval lane (`Metered eval` workflow) could run a full 30-min step timeout — then re-run the whole suite from scratch on each of 3 retry attempts — with no visible progress. A genuinely slow suite was therefore indistinguishable from a hang, and GitHub never exposes an in-progress job's log blob, so there was no way to tell which while it ran.

Root cause confirmed from a real run: with the E2BIG spawn fix already merged ([#2487](https://github.com/souliane/teatree/pull/2487)), the metered step now actually executes scenarios, but the full suite (~68 scenarios x 3 trials, each a real metered `claude` SDK call) does not fit a 30-min attempt. Each retry re-runs the whole suite from scratch (`--no-persist`, no resume), so the too-tight timeout just truncated and repeated the same partial work every attempt and never completed.

## Fix

- **`multi_trial.py`** — emit a flushed `RUN`/`DONE` progress line per scenario before and after each pass@k scenario, so the CI log streams live progress and a stall is pinpointed to the last `RUN <scenario>` line.
- **`docker.py`** — drop the quiet flag from the image build (a quiet build emits nothing until it finishes, so a slow build looks like a wedge) and set `PYTHONUNBUFFERED` in the container so the in-container per-scenario lines flush live instead of buffering until exit.
- **`eval.yml`** — add a job-level `timeout-minutes` (100) so a wedge anywhere outside the retry-wrapped step fails loud instead of running to GitHub's 6h default; give the full suite one generous 80-min attempt instead of 3x30min.

## Tests

- `test_multi_trial_progress.py` pins the per-scenario `RUN`/`DONE` emission and ordering.
- `test_eval_docker.py` pins the non-quiet build and the unbuffered container run.

131 eval CLI + docker tests pass.
