### PR TITLE
fix(eval): emit per-trial transcript artifact from the metered run, drop the suite-re-running render step

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -160,6 +160,15 @@ jobs:
       # `--require-executed` is passed UNCONDITIONALLY (never key-gated): a collected-but-
       # all-skipped run exits non-zero, so the suite can never pass green with zero coverage.
       # The end-of-run cost summary (report.py `_cost_summary`) prints the API spend.
+      #
+      # `--transcript-html` makes THIS run emit the per-trial transcript report
+      # itself, written from its own in-memory results — NO separate render step
+      # that re-runs the whole suite (the old `t3 eval all --html` step re-graded
+      # all ~181 scenarios for ~64min AFTER this step), and NO read-only-mount
+      # write failure (the report lands in $RUNNER_TEMP via the docker runner's
+      # writable /artifacts bind-mount, never the `:ro` repo mount). The artifact
+      # carries, per scenario, each trial's PASS/FAIL plus the agent's transcript
+      # (reasoning + tool calls) so a maintainer can diagnose a red under_load lane.
       - name: Metered behavioral eval suite (in Docker; pass@k; --require-executed always armed)
         if: steps.gate.outputs.run_eval == 'true'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4
@@ -187,25 +196,23 @@ jobs:
           # today's behaviour. A manual run may pass `under_load` to meter only the
           # behavioural-drift lane (the cheap PR-path anti-vacuity gate reads the same
           # catalog deterministically). The lane flag is only appended when set.
+          # `--transcript-html` writes to $RUNNER_TEMP (always writable; the report
+          # is dropped before the eval's own non-zero exit, so a red lane is still
+          # captured). The retry re-runs the whole `command`, so the file is simply
+          # overwritten with the last attempt's results — no staleness.
           command: |
             LANE_FLAG=""
             if [ -n "$EVAL_LANE" ]; then LANE_FLAG="--lane $EVAL_LANE"; fi
-            uv run t3 eval run --trials 3 --require any --backend "$EVAL_BACKEND" $LANE_FLAG --require-executed --docker
-      # Render a human-readable whole-suite HTML report and publish it as a job
-      # artifact. `if: always()` so a red run still publishes its report (the
-      # report is exactly what a maintainer reads to triage the failure). The
-      # report run is non-gating: `|| true` keeps a render hiccup from masking the
-      # real eval verdict above, which already decided the job's exit code.
-      - name: Render the whole-suite HTML report
-        if: always() && steps.gate.outputs.run_eval == 'true'
-        env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          EVAL_BACKEND: ${{ inputs.backend || 'sdk' }}
-        run: uv run t3 eval all --backend "$EVAL_BACKEND" --html eval-report.html || true
-      - name: Upload the HTML eval report
+            uv run t3 eval run --trials 3 --require any --backend "$EVAL_BACKEND" $LANE_FLAG \
+              --require-executed --docker --transcript-html "$RUNNER_TEMP/eval-transcripts.html"
+      # Publish the per-trial transcript report THIS run emitted as a job artifact.
+      # `if: always()` so a red run still publishes it (the report is exactly what a
+      # maintainer reads to triage the failure; the eval step above already decided
+      # the job's exit code). No render step — the artifact was written by the run.
+      - name: Upload the per-trial transcript report
         if: always() && steps.gate.outputs.run_eval == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: eval-report
-          path: eval-report.html
+          path: ${{ runner.temp }}/eval-transcripts.html
           if-no-files-found: warn

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1924,6 +1924,25 @@ Usage: t3 eval run [OPTIONS] [NAME]
 │                                                     ~latency). Default 1 =   │
 │                                                     sequential.              │
 │                                                     [default: 1]             │
+│ --transcript-html                          PATH     Write a self-contained   │
+│                                                     per-trial TRANSCRIPT     │
+│                                                     report (each scenario's  │
+│                                                     per-trial PASS/FAIL plus │
+│                                                     the agent's reasoning +  │
+│                                                     tool calls) to this path │
+│                                                     — the durable,           │
+│                                                     uploadable artifact a    │
+│                                                     maintainer reads to      │
+│                                                     diagnose a red lane.     │
+│                                                     Produced from THIS run's │
+│                                                     results (no suite        │
+│                                                     re-run, no ledger), so   │
+│                                                     it survives the          │
+│                                                     --no-persist             │
+│                                                     ephemeral-container CI   │
+│                                                     path. Supported on a     │
+│                                                     --trials run (the        │
+│                                                     metered CI shape).       │
 │ --help                                              Show this message and    │
 │                                                     exit.                    │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -7110,14 +7129,18 @@ Usage: t3 teatree config_setting list [OPTIONS]
 ```
 Usage: t3 teatree config_setting import [OPTIONS]
 
- Seed the DB store from the operational ```` toml keys (one-time migration).
+ Seed the DB store from the operational toml keys (one-time migration).
 
  The dual-read migration step (#938): every ```` key that is a
  registered ``OVERLAY_OVERRIDABLE_SETTINGS`` field is coerced through that
- registry's parser and upserted into the store, so existing installs move
- their operational config into the DB. Bootstrap-file-only keys
- (``private_repos`` / ``DATABASE_URL`` / …) and unknown keys are skipped —
- only operational settings move. The upsert makes a re-run idempotent.
+ registry's parser and upserted into the GLOBAL store, and every operational
+ key under an ```` table is upserted into THAT overlay's
+ scope — the DB twin of the per-overlay TOML override (#1775). So an install
+ with both a global ``mode`` and a per-overlay ``mode = "auto"`` migrates both
+ tiers in one pass. Bootstrap-file-only keys (``private_repos`` /
+ ``DATABASE_URL`` / …), the overlay's own ``path`` / ``url`` discovery keys,
+ and unknown keys are skipped — only operational settings move. The upsert
+ makes a re-run idempotent.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │

--- a/evals/README.md
+++ b/evals/README.md
@@ -329,10 +329,28 @@ host.
 `--html <path>` writes a self-contained whole-suite HTML report (inline CSS, no
 external assets): a plain-language final verdict banner at the top, then a lane
 table (lane | verdict | cost | duration | detail). `cli/eval/suite_html.py`
-renders it from the same `LaneResult` data the terminal table is built from; the
-metered CI workflow (`.github/workflows/eval.yml`) writes `--html
-eval-report.html` and uploads it as a job artifact (`if: always()`, so a red run
-still publishes its report).
+renders it from the same `LaneResult` data the terminal table is built from — a
+LANE-level summary that answers "which lane is red", not "why".
+
+#### `t3 eval run --transcript-html <path>` — the metered CI artifact
+
+The metered CI workflow (`.github/workflows/eval.yml`) does NOT render the
+whole-suite report: that would re-run the entire suite a second time (the old
+`t3 eval all --html` step re-graded all ~181 scenarios for ~64min AFTER the
+metered step) and try to write into the read-only repo mount (`Errno 30`).
+Instead the metered `t3 eval run --trials k` step emits its OWN per-trial
+transcript report via `--transcript-html <path>` (`eval/pass_at_k_html.py`):
+for each scenario, the aggregate verdict plus EACH trial's PASS/FAIL and the
+agent's transcript — its reasoning (`run.text_blocks`) and tool calls
+(`run.tool_calls`) — so a maintainer can open the uploaded artifact and diagnose
+a red lane (e.g. the `under_load` drift scenarios) WITHOUT re-running anything.
+It is written from that run's in-memory results (no suite re-run, no ledger), so
+it survives the `--no-persist` ephemeral-container path; the `--docker` runner
+bind-mounts the destination's parent dir WRITABLE at `/artifacts` (the repo mount
+stays `:ro`), so the in-container report lands back on the host runner's
+`$RUNNER_TEMP` for upload. The upload step is `if: always()`, so a red run still
+publishes its report — and the report is dropped before the run's own non-zero
+exit, so the red lane is captured.
 
 ### `t3 eval all` — the explicit alias of the bare default (#1781)
 

--- a/src/teatree/cli/eval/app.py
+++ b/src/teatree/cli/eval/app.py
@@ -10,7 +10,7 @@ from rich.console import Console
 from teatree.cli._format_opts import VALID_FORMATS, require_valid_format
 from teatree.cli.eval.all import STRICT_HELP, build_scenarios_table, hint_missing_transcripts, run_full_suite
 from teatree.cli.eval.all_command import all_lanes
-from teatree.cli.eval.app_helpers import require_effort, require_spec
+from teatree.cli.eval.app_helpers import reject_unsupported_run_output, require_effort, require_spec
 from teatree.cli.eval.audit import audit
 from teatree.cli.eval.benchmark import benchmark
 from teatree.cli.eval.capture_subagent import capture_subagent
@@ -253,6 +253,17 @@ def run(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a p
             "pool cuts wall-clock from Nxlatency to ~latency). Default 1 = sequential."
         ),
     ),
+    transcript_html: Path | None = typer.Option(
+        None,
+        "--transcript-html",
+        help=(
+            "Write a self-contained per-trial TRANSCRIPT report (each scenario's per-trial "
+            "PASS/FAIL plus the agent's reasoning + tool calls) to this path — the durable, "
+            "uploadable artifact a maintainer reads to diagnose a red lane. Produced from THIS "
+            "run's results (no suite re-run, no ledger), so it survives the --no-persist "
+            "ephemeral-container CI path. Supported on a --trials run (the metered CI shape)."
+        ),
+    ),
 ) -> None:
     """Run one scenario by name, or all scenarios when no name is given.
 
@@ -315,6 +326,7 @@ def run(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a p
             backend=backend,
             require_executed=require_executed,
             parallel=parallel,
+            transcript_html=transcript_html,
         ),
         docker=docker,
         metered=metered,
@@ -328,9 +340,9 @@ def run(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a p
         warn_local_metered(metered=metered)
     ensure_django()
     require_valid_format(output_format, _RUN_FORMATS)
-    if output_format == "html" and (trials > 1 or models is not None):
-        typer.echo("--format html is only supported for a single-trial run (not --trials/--models)", err=True)
-        raise typer.Exit(code=2)
+    reject_unsupported_run_output(
+        output_format=output_format, transcript_html=transcript_html, trials=trials, models=models
+    )
     specs = filter_specs_by_lane(discover_specs(), lane) if name is None else [require_spec(name)]
     grader = make_grader(enabled=judge, judge_budget=judge_budget)
     # "If we run the metered lane, of course we want it executed." The sdk backend
@@ -383,6 +395,7 @@ def run(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a p
             require_executed=require_executed,
             max_budget_usd=max_budget_usd,
             effort=effort_level,
+            transcript_html=transcript_html,
         )
         return
     try:
@@ -401,6 +414,12 @@ def run(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a p
     results = [evaluate(spec, run, judge=grader) for spec, run in zip(specs, runs, strict=True)]
     renderers = {"json": render_json, "html": render_html}
     typer.echo(renderers.get(output_format, render_text)(results))
+    # The per-trial transcript artifact for the single-trial path: one trial, so
+    # the existing per-scenario render_html (verdict + transcript + failed
+    # matchers) IS the report. Written from THIS run's results — no re-run — and
+    # BEFORE any guard/gate can exit, so a red run still drops the artifact.
+    if transcript_html is not None:
+        transcript_html.write_text(render_html(results), encoding="utf-8")
     if backend == SUBSCRIPTION_BACKEND and isinstance(runner, SubscriptionTranscriptRunner):
         hint_missing_transcripts(runner, [spec for spec, r in zip(specs, results, strict=True) if r.skipped])
     executed = sum(1 for r in results if not r.skipped)

--- a/src/teatree/cli/eval/app_helpers.py
+++ b/src/teatree/cli/eval/app_helpers.py
@@ -5,6 +5,7 @@ the command body stays thin: each resolves one CLI argument to its validated
 domain value, or exits 2 (usage error) naming the valid choices.
 """
 
+from pathlib import Path
 from typing import cast
 
 import typer
@@ -32,3 +33,26 @@ def require_effort(effort: str) -> EffortLevel:
         typer.echo(f"unknown --effort {effort!r}; known levels: {', '.join(EFFORT_LEVELS)}", err=True)
         raise typer.Exit(code=2)
     return cast("EffortLevel", effort)
+
+
+def reject_unsupported_run_output(
+    *, output_format: str, transcript_html: Path | None, trials: int, models: str | None
+) -> None:
+    """Reject ``--format html`` and ``--transcript-html`` on the multi-trial/matrix shapes they don't support.
+
+    ``--format html`` renders a SINGLE-trial ``list[ScenarioResult]`` and
+    ``--transcript-html`` renders the per-TRIAL ``list[PassAtKResult]``; a
+    ``--models`` matrix has neither, so both are usage errors there (and
+    ``--format html`` is likewise rejected for ``--trials``). Exits 2 naming the
+    fix rather than failing obscurely deeper in the run.
+    """
+    if output_format == "html" and (trials > 1 or models is not None):
+        typer.echo("--format html is only supported for a single-trial run (not --trials/--models)", err=True)
+        raise typer.Exit(code=2)
+    if transcript_html is not None and models is not None:
+        typer.echo(
+            "--transcript-html is the per-TRIAL transcript report (a --trials run); a --models matrix "
+            "has no per-trial transcript to render. Drop --models or drop --transcript-html.",
+            err=True,
+        )
+        raise typer.Exit(code=2)

--- a/src/teatree/cli/eval/docker.py
+++ b/src/teatree/cli/eval/docker.py
@@ -36,6 +36,11 @@ _AUTH_ENV_VARS = ("CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY")
 #: Env marker set on the container so the in-container ``t3 eval`` re-invocation
 #: runs the metered/benchmark command in-process instead of re-routing to docker.
 IN_CONTAINER_ENV_VAR = "T3_EVAL_IN_CONTAINER"
+#: Fixed container mount point for the WRITABLE artifacts directory. The repo is
+#: mounted ``:ro`` (a metered run must never mutate the working tree), so a run
+#: that emits an artifact (the per-trial transcript report) writes it here, on a
+#: separate bind-mount, where it lands back on the host for upload.
+ARTIFACTS_MOUNT = "/artifacts"
 
 
 def _auth_passthrough_flags() -> list[str]:
@@ -66,7 +71,19 @@ def _build_image(root: Path) -> int:
     return run_streamed(["docker", "build", "-t", DOCKER_IMAGE, "-f", _DOCKERFILE, "."], cwd=root, check=False)
 
 
-def _run_in_image(root: Path, eval_args: list[str]) -> int:
+def _artifacts_mount_flags(artifacts_dir: Path | None) -> list[str]:
+    """Bind-mount *artifacts_dir* WRITABLE at :data:`ARTIFACTS_MOUNT`, or nothing.
+
+    The repo mount is ``:ro``; a run that emits an artifact writes it into this
+    separate writable bind-mount, so the file lands on the host for upload. No
+    flag is added when the run emits no artifact.
+    """
+    if artifacts_dir is None:
+        return []
+    return ["-v", f"{artifacts_dir}:{ARTIFACTS_MOUNT}"]
+
+
+def _run_in_image(root: Path, eval_args: list[str], *, artifacts_dir: Path | None = None) -> int:
     return run_streamed(
         [
             "docker",
@@ -86,6 +103,7 @@ def _run_in_image(root: Path, eval_args: list[str]) -> int:
             *_auth_passthrough_flags(),
             "-v",
             f"{root}:/app:ro",
+            *_artifacts_mount_flags(artifacts_dir),
             DOCKER_IMAGE,
             "uv",
             "run",
@@ -98,7 +116,7 @@ def _run_in_image(root: Path, eval_args: list[str]) -> int:
     )
 
 
-def run_eval_in_docker(eval_args: list[str]) -> int:
+def run_eval_in_docker(eval_args: list[str], *, artifacts_dir: Path | None = None) -> int:
     """Build (if needed) and run the eval gate inside the CI image; return its exit code.
 
     For the metered ``sdk`` lane, resolve ``CLAUDE_CODE_OAUTH_TOKEN`` first (env
@@ -107,6 +125,11 @@ def run_eval_in_docker(eval_args: list[str]) -> int:
     authenticates in-container — the metered run just works without a manual
     ``export``. The free / subscription lanes never authenticate ``claude``, so the
     secret store is not touched for them.
+
+    ``artifacts_dir`` (when set) is bind-mounted WRITABLE at
+    :data:`ARTIFACTS_MOUNT` so an in-container run that emits an artifact (the
+    per-trial transcript report) writes it there and the file lands back on the
+    host — the repo mount itself is ``:ro``.
     """
     if shutil.which("docker") is None:
         raise DockerUnavailableError
@@ -117,4 +140,4 @@ def run_eval_in_docker(eval_args: list[str]) -> int:
         build_code = _build_image(root)
         if build_code != 0:
             return build_code
-    return _run_in_image(root, eval_args)
+    return _run_in_image(root, eval_args, artifacts_dir=artifacts_dir)

--- a/src/teatree/cli/eval/multi_trial.py
+++ b/src/teatree/cli/eval/multi_trial.py
@@ -9,6 +9,7 @@ single-pass grade.
 import json
 import sys
 from collections.abc import Callable
+from pathlib import Path
 
 import typer
 from claude_agent_sdk.types import EffortLevel
@@ -27,6 +28,7 @@ from teatree.eval.matrix import MatrixRow, render_matrix_json, render_matrix_tex
 from teatree.eval.model_variant import ModelVariantError, parse_model_variants
 from teatree.eval.models import EvalSpec
 from teatree.eval.pass_at_k import PassAtKResult, run_pass_at_k
+from teatree.eval.pass_at_k_html import render_pass_at_k_html
 from teatree.eval.report import ScenarioResult, evaluate
 from teatree.eval.sdk_runner import MAX_BUDGET_USD
 
@@ -87,6 +89,7 @@ def run_pass_at_k_lane(  # noqa: PLR0913 — each kwarg threads one `eval run` C
     require_executed: bool = False,
     max_budget_usd: float = float(MAX_BUDGET_USD),
     effort: EffortLevel | None = None,
+    transcript_html: Path | None = None,
 ) -> bool:
     """Run the pass@k path; return ``True`` when any scenario failed or regressed.
 
@@ -94,6 +97,12 @@ def run_pass_at_k_lane(  # noqa: PLR0913 — each kwarg threads one `eval run` C
     ``METERED_DEFAULT_EFFORT`` calibration). It is the runner-wide default applied
     to scenarios that declare no ``model@effort`` of their own; a scenario's own
     tag still wins at the runner's per-scenario seam.
+
+    ``transcript_html`` is a writable path to drop a self-contained per-trial
+    transcript report at — the durable, uploadable artifact a maintainer reads to
+    diagnose a red lane. It is written from THIS run's in-memory results (no suite
+    re-run, no ledger), so it survives the ``--no-persist`` ephemeral-container
+    CI path where nothing reaches the host run-history.
     """
     if require not in {"any", "all"}:
         typer.echo(f"unknown --require {require!r}; use 'any' or 'all'", err=True)
@@ -142,6 +151,12 @@ def run_pass_at_k_lane(  # noqa: PLR0913 — each kwarg threads one `eval run` C
                 continue
             status = "PASS" if r.ok else "FAIL"
             typer.echo(f"{status} {r.spec_name} ({r.passes}/{r.trials} trials, require={r.require})")
+    # Drop the per-trial transcript artifact BEFORE any guard/gate can exit the
+    # process — the report is exactly what a maintainer reads to triage the
+    # failure those guards are about to surface, so it must be written even when
+    # the run is about to exit non-zero.
+    if transcript_html is not None:
+        transcript_html.write_text(render_pass_at_k_html(results), encoding="utf-8")
     RunGuards.executed(
         executed=sum(1 for r in results if not r.skipped), collected=len(specs), required=require_executed
     )

--- a/src/teatree/cli/eval/run_docker.py
+++ b/src/teatree/cli/eval/run_docker.py
@@ -8,10 +8,11 @@ is forced ``--no-persist``.
 """
 
 import dataclasses
+from pathlib import Path
 
 import typer
 
-from teatree.cli.eval.docker import DockerUnavailableError, run_eval_in_docker
+from teatree.cli.eval.docker import ARTIFACTS_MOUNT, DockerUnavailableError, run_eval_in_docker
 from teatree.cli.eval.metered_routing import should_route_to_docker
 from teatree.eval.backends import SUBSCRIPTION_BACKEND
 from teatree.eval.parallel import DEFAULT_PARALLEL
@@ -33,37 +34,52 @@ class RunDockerArgs:
     backend: str
     require_executed: bool
     parallel: int
+    transcript_html: Path | None = None
+
+    def _container_transcript_path(self) -> str:
+        """The in-container path the transcript artifact is written to.
+
+        The host ``--transcript-html`` path's PARENT is bind-mounted writable at
+        :data:`ARTIFACTS_MOUNT`, so the in-container run writes to
+        ``/artifacts/<filename>`` and the file lands back on the host. ``""``
+        when no artifact was requested.
+        """
+        if self.transcript_html is None:
+            return ""
+        return f"{ARTIFACTS_MOUNT}/{self.transcript_html.name}"
+
+    def _leading_optionals(self) -> list[list[str]]:
+        """Non-default flag groups that precede the always-present budget/effort flags."""
+        return [
+            [self.name] if self.name is not None else [],
+            ["--lane", self.lane] if self.lane is not None else [],
+            ["--format", self.output_format] if self.output_format != "text" else [],
+            ["--max-turns", str(self.max_turns)] if self.max_turns is not None else [],
+        ]
+
+    def _trailing_optionals(self) -> list[list[str]]:
+        """Non-default flag groups that follow the always-present budget/effort flags."""
+        return [
+            ["--trials", str(self.trials), "--require", self.require] if self.trials != 1 else [],
+            ["--models", self.models] if self.models is not None else [],
+            ["--backend", self.backend] if self.backend != SUBSCRIPTION_BACKEND else [],
+            ["--require-executed"] if self.require_executed else [],
+            ["--parallel", str(self.parallel)] if self.parallel != DEFAULT_PARALLEL else [],
+            ["--transcript-html", self._container_transcript_path()] if self.transcript_html is not None else [],
+        ]
 
     def passthrough(self) -> list[str]:
-        args = ["run"]
-        if self.name is not None:
-            args.append(self.name)
-        if self.lane is not None:
-            args += ["--lane", self.lane]
-        if self.output_format != "text":
-            args += ["--format", self.output_format]
-        if self.max_turns is not None:
-            args += ["--max-turns", str(self.max_turns)]
-        args += ["--max-budget-usd", str(self.max_budget_usd)]
-        # Pass --effort explicitly so the in-container run is deterministic
-        # regardless of the container's env (the host already resolved the default).
-        args += ["--effort", self.effort]
-        if self.trials != 1:
-            args += ["--trials", str(self.trials), "--require", self.require]
-        if self.models is not None:
-            args += ["--models", self.models]
-        if self.backend != SUBSCRIPTION_BACKEND:
-            args += ["--backend", self.backend]
-        if self.require_executed:
-            args.append("--require-executed")
-        if self.parallel != DEFAULT_PARALLEL:
-            args += ["--parallel", str(self.parallel)]
-        args.append("--no-persist")
-        return args
+        # --max-budget-usd / --effort are ALWAYS passed so the in-container run is
+        # deterministic regardless of the container's env (the host resolved the
+        # defaults); they sit between the leading and trailing optional groups.
+        always = ["--max-budget-usd", str(self.max_budget_usd), "--effort", self.effort]
+        groups = [*self._leading_optionals(), always, *self._trailing_optionals()]
+        return ["run", *(arg for group in groups for arg in group), "--no-persist"]
 
     def dispatch(self) -> None:
+        artifacts_dir = self.transcript_html.parent if self.transcript_html is not None else None
         try:
-            raise typer.Exit(code=run_eval_in_docker(self.passthrough()))
+            raise typer.Exit(code=run_eval_in_docker(self.passthrough(), artifacts_dir=artifacts_dir))
         except DockerUnavailableError as exc:
             typer.echo(str(exc), err=True)
             raise typer.Exit(code=2) from None

--- a/src/teatree/eval/pass_at_k.py
+++ b/src/teatree/eval/pass_at_k.py
@@ -66,6 +66,14 @@ class PassAtKResult:
     #: MAIN-model and AUXILIARY token usage summed across every trial.
     main_usage: TokenUsage = dataclasses.field(default_factory=TokenUsage)
     aux_usage: TokenUsage = dataclasses.field(default_factory=TokenUsage)
+    #: The per-trial :class:`~teatree.eval.report.ScenarioResult` objects, in trial
+    #: order — the load-bearing per-trial EVIDENCE (each trial's transcript:
+    #: ``run.text_blocks`` reasoning + ``run.tool_calls`` + the matcher verdicts) a
+    #: maintainer reads to diagnose a red lane. The aggregate counters above are
+    #: derived from these, but they are summed/collapsed; this keeps the raw
+    #: per-trial trajectories so the transcript report (``--transcript-html``) can
+    #: show, per trial, what the agent actually did. Empty for a skipped scenario.
+    trial_results: tuple[ScenarioResult, ...] = ()
 
     @property
     def pass_rate(self) -> float:
@@ -111,8 +119,10 @@ def run_pass_at_k(
     billed_model: str | None = None
     cap_reason = ""
     fell_back: bool | None = None
+    trial_results: list[ScenarioResult] = []
     for _ in range(k):
         result = runner(spec)
+        trial_results.append(result)
         cost_usd += result.run.cost_usd
         usage += result.run.usage
         main_cost_usd += result.run.main_cost_usd
@@ -144,6 +154,7 @@ def run_pass_at_k(
         aux_cost_usd=aux_cost_usd,
         main_usage=main_usage,
         aux_usage=aux_usage,
+        trial_results=tuple(trial_results),
     )
 
 

--- a/src/teatree/eval/pass_at_k_html.py
+++ b/src/teatree/eval/pass_at_k_html.py
@@ -1,0 +1,144 @@
+"""Per-trial transcript HTML report for a metered pass@k ``t3 eval run``.
+
+The whole-suite summary (:mod:`teatree.cli.eval.suite_html`) renders one row per
+LANE — it answers "which lane is red". It cannot answer "WHY did this scenario
+fail", because the per-trial trajectories never reach it. This report fills that
+gap: for the metered ``--trials k`` run that CI executes, it renders, per
+scenario, the aggregate verdict plus EACH trial's transcript — the agent's
+reasoning (``run.text_blocks``), its tool calls (``run.tool_calls``), and the
+failing matchers — so a maintainer can open the uploaded artifact and diagnose a
+red lane (e.g. the under_load drift scenarios) without re-running anything.
+
+It is a sibling of :func:`teatree.eval.report.render_html` (which renders a
+single-trial ``list[ScenarioResult]``); this one renders the multi-trial
+``list[PassAtKResult]``, drilling into each result's ``trial_results``. Every
+run-derived value is HTML-escaped so a transcript fragment can never inject
+markup.
+"""
+
+import json
+from collections.abc import Sequence
+from html import escape
+from itertools import starmap
+
+from teatree.eval.models import EvalRun, EvalToolCall
+from teatree.eval.pass_at_k import PassAtKResult
+from teatree.eval.report import ScenarioResult
+
+_STYLE = """
+:root { color-scheme: light dark; }
+body { font: 14px/1.5 system-ui, sans-serif; margin: 2rem; max-width: 70rem; }
+h1 { font-size: 1.4rem; }
+.summary { margin: 0 0 1.5rem; font-weight: 600; }
+.summary .pass { color: #1a7f37; }
+.summary .fail { color: #cf222e; }
+.summary .skip { color: #6e7781; }
+details { border: 1px solid #d0d7de; border-radius: 6px; margin: 0.5rem 0; padding: 0.5rem 0.75rem; }
+details.pass { border-left: 4px solid #1a7f37; }
+details.fail { border-left: 4px solid #cf222e; }
+details.skip { border-left: 4px solid #6e7781; }
+summary { cursor: pointer; font-weight: 600; }
+.verdict { font-size: 0.8rem; padding: 0.1rem 0.45rem; border-radius: 999px; margin-right: 0.5rem; color: #fff; }
+.verdict.pass { background: #1a7f37; }
+.verdict.fail { background: #cf222e; }
+.verdict.skip { background: #6e7781; }
+.reason { color: #6e7781; font-weight: 400; }
+.trial { margin: 0.75rem 0 0; padding-left: 0.75rem; border-left: 2px solid #d0d7de; }
+.trial h3 { font-size: 0.95rem; margin: 0 0 0.35rem; }
+.label { color: #6e7781; font-weight: 600; text-transform: uppercase; font-size: 0.72rem; letter-spacing: 0.03em; }
+ul.matchers { margin: 0.35rem 0 0; }
+pre { white-space: pre-wrap; word-break: break-word; background: rgba(127,127,127,0.1); padding: 0.5rem; }
+pre { border-radius: 4px; margin: 0.25rem 0; }
+""".strip()
+
+
+def _aggregate_verdict(result: PassAtKResult) -> str:
+    if result.skipped:
+        return "skip"
+    return "pass" if result.ok else "fail"
+
+
+def _summary(results: Sequence[PassAtKResult]) -> str:
+    total = len(results)
+    skipped = sum(1 for r in results if r.skipped)
+    passed = sum(1 for r in results if not r.skipped and r.ok)
+    failed = total - passed - skipped
+    return (
+        '<p class="summary">'
+        f'<span class="pass">{passed} passed</span>, '
+        f'<span class="fail">{failed} failed</span>, '
+        f'<span class="skip">{skipped} skipped</span> '
+        f"(of {total} scenarios, pass@{results[0].trials if results else 0})</p>"
+    )
+
+
+def _tool_call(call: EvalToolCall) -> str:
+    rendered = json.dumps(call.input, indent=2, sort_keys=True, default=str)
+    return f"<pre>turn {call.turn}: {escape(call.name)}({escape(rendered)})</pre>"
+
+
+def _transcript(run: EvalRun) -> str:
+    parts: list[str] = []
+    if run.text_blocks:
+        joined = "\n\n".join(run.text_blocks)
+        parts.append(f'<p class="label">reasoning / final answer</p>\n<pre>{escape(joined)}</pre>')
+    if run.tool_calls:
+        calls = "\n".join(_tool_call(call) for call in run.tool_calls)
+        parts.append(f'<p class="label">tool calls</p>\n{calls}')
+    if not parts:
+        parts.append('<p class="reason">(no transcript captured — the trial produced no text or tool calls)</p>')
+    return "\n".join(parts)
+
+
+def _trial_block(index: int, result: ScenarioResult) -> str:
+    verdict = result.verdict
+    reason = escape(result.run.terminal_reason)
+    body_parts = [_transcript(result.run)]
+    failed_matchers = [m for m in result.matcher_results if not m.passed]
+    if failed_matchers:
+        items = "\n".join(f"<li><pre>{escape(m.message)}</pre></li>" for m in failed_matchers)
+        body_parts.append(f'<p class="label">failed matchers</p>\n<ul class="matchers">\n{items}\n</ul>')
+    if result.judge is not None and not result.judge.skipped:
+        judge_verdict = "pass" if result.judge.passed else "fail"
+        body_parts.append(f'<p class="label">judge ({judge_verdict})</p>\n<pre>{escape(result.judge.rationale)}</pre>')
+    body = "\n".join(body_parts)
+    return (
+        f'<div class="trial">\n'
+        f'<h3><span class="verdict {verdict}">{verdict.upper()}</span>trial {index} '
+        f'<span class="reason">({reason})</span></h3>\n'
+        f"{body}\n</div>"
+    )
+
+
+def _scenario_block(result: PassAtKResult) -> str:
+    verdict = _aggregate_verdict(result)
+    head = (
+        f'<summary><span class="verdict {verdict}">{verdict.upper()}</span>'
+        f"{escape(result.spec_name)} "
+        f'<span class="reason">({result.passes}/{result.trials} trials passed)</span></summary>'
+    )
+    trials = "\n".join(starmap(_trial_block, enumerate(result.trial_results, start=1)))
+    if not result.trial_results:
+        trials = '<p class="reason">(scenario skipped — no trials executed)</p>'
+    return f'<details class="{verdict}">\n{head}\n{trials}\n</details>'
+
+
+def render_pass_at_k_html(results: Sequence[PassAtKResult]) -> str:
+    """Render a metered pass@k run as a self-contained per-trial transcript report.
+
+    For each scenario: the aggregate verdict, then one block per trial showing
+    that trial's PASS/FAIL, the agent's reasoning + tool calls (the transcript),
+    and any failed matchers / judge rationale. Self-contained (inline CSS, no
+    external assets); every run-derived value is HTML-escaped.
+    """
+    summary = _summary(results)
+    rows = "\n".join(_scenario_block(result) for result in results)
+    return (
+        "<!doctype html>\n"
+        '<html lang="en">\n<head>\n<meta charset="utf-8">\n'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        "<title>Eval transcripts (pass@k)</title>\n"
+        f"<style>{_STYLE}</style>\n"
+        "</head>\n<body>\n<h1>Eval transcripts — per-trial evidence</h1>\n"
+        f"{summary}\n{rows}\n</body>\n</html>\n"
+    )

--- a/tests/eval_harness/test_pass_at_k.py
+++ b/tests/eval_harness/test_pass_at_k.py
@@ -200,3 +200,37 @@ class TestRunPassAtK:
         assert result.passes == 2
         assert result.terminal_reason == ""  # the clean miss carries no cap reason
         assert result.ok  # pass@k noise tolerance preserved
+
+
+class TestRetainsPerTrialResults:
+    """The aggregate must retain each trial's ScenarioResult — the transcript evidence.
+
+    The counters are summed/collapsed, but the per-trial transcript report (the
+    ``--transcript-html`` artifact) needs the raw per-trial trajectories. Dropping
+    them leaves a maintainer with only a pass-count and no way to see WHAT the
+    agent did on a failing trial.
+    """
+
+    def test_keeps_one_result_per_trial_in_order(self) -> None:
+        spec = _spec()
+        result = run_pass_at_k(spec, _sequence_runner(spec, [True, False, True]), k=3, require="any")
+        assert len(result.trial_results) == 3
+        assert [r.passed for r in result.trial_results] == [True, False, True]
+
+    def test_each_retained_result_carries_its_trial_transcript(self) -> None:
+        spec = _spec()
+
+        def _run(_spec: EvalSpec) -> ScenarioResult:
+            run = EvalRun(
+                spec_name=spec.name,
+                tool_calls=(),
+                text_blocks=("I will run the command.",),
+                terminal_reason="success",
+                is_error=False,
+                raw_stdout="",
+                raw_stderr="",
+            )
+            return ScenarioResult(spec=spec, run=run, matcher_results=(), skipped=False)
+
+        result = run_pass_at_k(spec, _run, k=2, require="any")
+        assert all("I will run the command." in r.run.text_blocks for r in result.trial_results)

--- a/tests/teatree_cli/eval/test_multi_trial_transcript_html.py
+++ b/tests/teatree_cli/eval/test_multi_trial_transcript_html.py
@@ -1,0 +1,174 @@
+"""``t3 eval run --trials k --transcript-html <path>`` — the per-trial artifact.
+
+The metered CI run is ``--no-persist`` inside an ephemeral, read-only-mounted
+container, so nothing reaches the host run-history ledger. ``--transcript-html``
+makes the run emit its OWN per-trial transcript report (verdicts + each trial's
+reasoning + tool calls), written from this run's in-memory results — NO suite
+re-run, NO ledger read — to a writable path. These tests pin that the lane:
+writes the file, includes the per-trial transcript, does NOT re-execute the
+runner an extra time for rendering, and still writes the artifact when the run
+is about to exit non-zero (a red lane is exactly what needs diagnosing).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from teatree.cli.eval.multi_trial import run_pass_at_k_lane
+from teatree.eval.models import EvalRun, EvalSpec, EvalToolCall, Matcher
+
+
+def _spec(name: str) -> EvalSpec:
+    return EvalSpec(
+        name=name,
+        scenario=f"scenario {name}",
+        agent_path="skills/code/SKILL.md",
+        prompt="do",
+        matchers=(),
+        source_path=Path("/tmp/spec.yaml"),
+        judge=None,
+    )
+
+
+class _CountingRunner:
+    """A clean runner that counts how many times it actually executed a scenario."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def run(self, spec: EvalSpec) -> EvalRun:
+        self.calls += 1
+        return EvalRun(
+            spec_name=spec.name,
+            tool_calls=(EvalToolCall(name="Bash", input={"command": f"echo {spec.name}"}, turn=1),),
+            text_blocks=(f"reasoning for {spec.name}",),
+            terminal_reason="end_turn",
+            is_error=False,
+            raw_stdout="",
+            raw_stderr="",
+            cost_usd=0.01,
+        )
+
+
+@pytest.fixture
+def counting_runner(monkeypatch: pytest.MonkeyPatch) -> _CountingRunner:
+    runner = _CountingRunner()
+    monkeypatch.setattr("teatree.cli.eval.multi_trial.make_runner", lambda *a, **k: runner)
+    return runner
+
+
+class TestTranscriptHtmlArtifact:
+    def test_writes_the_report_to_the_given_writable_path(
+        self, counting_runner: _CountingRunner, tmp_path: Path
+    ) -> None:
+        out = tmp_path / "eval-transcripts.html"
+        run_pass_at_k_lane(
+            [_spec("alpha"), _spec("beta")],
+            max_turns=None,
+            trials=3,
+            require="any",
+            output_format="text",
+            persist=False,
+            transcript_html=out,
+        )
+        assert out.is_file()
+        body = out.read_text(encoding="utf-8")
+        assert "alpha" in body
+        assert "beta" in body
+
+    def test_includes_each_trials_transcript(self, counting_runner: _CountingRunner, tmp_path: Path) -> None:
+        out = tmp_path / "report.html"
+        run_pass_at_k_lane(
+            [_spec("alpha")],
+            max_turns=None,
+            trials=3,
+            require="any",
+            output_format="text",
+            persist=False,
+            transcript_html=out,
+        )
+        body = out.read_text(encoding="utf-8")
+        # The agent's reasoning AND tool call are present — the per-trial evidence.
+        assert "reasoning for alpha" in body
+        assert "echo alpha" in body
+
+    def test_does_not_re_execute_the_runner_to_render(self, counting_runner: _CountingRunner, tmp_path: Path) -> None:
+        # The whole bug: the old render step re-ran the suite. The artifact must be
+        # rendered from THIS run's results — so the runner is invoked exactly
+        # trials x scenarios times, never an extra pass for the report.
+        out = tmp_path / "report.html"
+        run_pass_at_k_lane(
+            [_spec("alpha"), _spec("beta")],
+            max_turns=None,
+            trials=3,
+            require="any",
+            output_format="text",
+            persist=False,
+            transcript_html=out,
+        )
+        # 2 scenarios x 3 trials = 6 runs, and not one more for rendering.
+        assert counting_runner.calls == 6
+
+    def test_no_file_written_when_path_is_none(self, counting_runner: _CountingRunner, tmp_path: Path) -> None:
+        report = tmp_path / "report.html"
+        run_pass_at_k_lane(
+            [_spec("alpha")],
+            max_turns=None,
+            trials=2,
+            require="any",
+            output_format="text",
+            persist=False,
+            transcript_html=None,
+        )
+        assert not report.exists()
+
+
+class _FailingRunner:
+    """A runner whose scenario FAILS its matcher — the lane will want to exit 1."""
+
+    def run(self, spec: EvalSpec) -> EvalRun:
+        return EvalRun(
+            spec_name=spec.name,
+            tool_calls=(),
+            text_blocks=("I did the wrong thing",),
+            terminal_reason="success",
+            is_error=False,
+            raw_stdout="",
+            raw_stderr="",
+            cost_usd=0.01,
+        )
+
+
+class TestArtifactWrittenEvenOnRedRun:
+    def test_artifact_is_written_before_the_non_zero_exit(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # A red lane is exactly what a maintainer needs the transcript for, so the
+        # artifact must land even though the lane is about to exit non-zero.
+        monkeypatch.setattr("teatree.cli.eval.multi_trial.make_runner", lambda *a, **k: _FailingRunner())
+        spec = EvalSpec(
+            name="fails",
+            scenario="s",
+            agent_path="skills/code/SKILL.md",
+            prompt="do",
+            matchers=(
+                # A positive matcher that the runner's empty tool_calls cannot satisfy → FAIL.
+                Matcher(kind="positive", tool="Bash", arg_path="command", operator="contains", value="never-emitted"),
+            ),
+            source_path=Path("/tmp/spec.yaml"),
+            judge=None,
+        )
+        out = tmp_path / "report.html"
+        failed = run_pass_at_k_lane(
+            [spec],
+            max_turns=None,
+            trials=2,
+            require="any",
+            output_format="text",
+            persist=False,
+            model_override="claude-sonnet-4-6",  # suppress the sys.exit so we can assert the file
+            transcript_html=out,
+        )
+        assert failed is True
+        assert out.is_file()
+        assert "fails" in out.read_text(encoding="utf-8")

--- a/tests/teatree_cli/eval/test_run_docker.py
+++ b/tests/teatree_cli/eval/test_run_docker.py
@@ -1,0 +1,71 @@
+"""``RunDockerArgs`` — the ``t3 eval run`` flags forwarded into the CI image.
+
+The metered ``run`` lane re-invokes ``t3 eval run`` inside the CI container. The
+``--transcript-html`` host path is translated to a container path under the
+writable ``/artifacts`` bind-mount, so the report the in-container run writes
+lands back on the host for upload. These tests pin that translation and the
+writable-dir resolution.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import typer
+
+from teatree.cli.eval.docker import ARTIFACTS_MOUNT
+from teatree.cli.eval.run_docker import RunDockerArgs
+
+
+def _args(**overrides: object) -> RunDockerArgs:
+    base: dict[str, object] = {
+        "name": None,
+        "lane": None,
+        "output_format": "text",
+        "max_turns": None,
+        "max_budget_usd": 1.0,
+        "effort": "high",
+        "trials": 3,
+        "require": "any",
+        "models": None,
+        "backend": "sdk",
+        "require_executed": True,
+        "parallel": 1,
+    }
+    base.update(overrides)
+    return RunDockerArgs(**base)
+
+
+class TestTranscriptHtmlPassthrough:
+    def test_translates_host_path_to_the_artifacts_mount(self) -> None:
+        args = _args(transcript_html=Path("/home/runner/_temp/eval-transcripts.html"))
+        passthrough = args.passthrough()
+        index = passthrough.index("--transcript-html")
+        assert passthrough[index + 1] == f"{ARTIFACTS_MOUNT}/eval-transcripts.html"
+
+    def test_omits_the_flag_when_no_artifact_requested(self) -> None:
+        assert "--transcript-html" not in _args(transcript_html=None).passthrough()
+
+    def test_still_forces_no_persist(self) -> None:
+        # The container is ephemeral, so the run stays --no-persist regardless of
+        # the new artifact flag — the artifact is the durable output, not the ledger.
+        assert "--no-persist" in _args(transcript_html=Path("/tmp/x.html")).passthrough()
+
+
+class TestDispatchMountsHostParentDir:
+    def test_dispatch_passes_the_host_parent_dir_as_artifacts_dir(self, tmp_path: Path) -> None:
+        host = tmp_path / "eval-transcripts.html"
+        with (
+            patch("teatree.cli.eval.run_docker.run_eval_in_docker", return_value=0) as run_in_docker,
+            pytest.raises(typer.Exit),
+        ):
+            _args(transcript_html=host).dispatch()
+        assert run_in_docker.call_args.kwargs["artifacts_dir"] == tmp_path
+
+    def test_dispatch_passes_none_artifacts_dir_without_transcript(self) -> None:
+        with (
+            patch("teatree.cli.eval.run_docker.run_eval_in_docker", return_value=0) as run_in_docker,
+            pytest.raises(typer.Exit),
+        ):
+            _args(transcript_html=None).dispatch()
+        assert run_in_docker.call_args.kwargs["artifacts_dir"] is None

--- a/tests/teatree_cli/test_eval_docker.py
+++ b/tests/teatree_cli/test_eval_docker.py
@@ -1,10 +1,12 @@
 """``t3 eval all --docker`` — CI-image-parity local run."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from teatree.cli.eval.docker import (
+    ARTIFACTS_MOUNT,
     DOCKER_IMAGE,
     DockerUnavailableError,
     _auth_passthrough_flags,
@@ -139,6 +141,41 @@ class TestRunEvalInDocker:
         root = _repo_root()
         assert (root / "dev" / "Dockerfile.test").is_file()
         assert (root / "pyproject.toml").is_file()
+
+
+class TestWritableArtifactsMount:
+    """A run that emits an artifact gets a WRITABLE bind-mount.
+
+    The repo is mounted ``:ro`` (a metered run must not mutate the working tree),
+    so the per-trial transcript report writes into a SEPARATE writable mount at
+    :data:`ARTIFACTS_MOUNT` and lands back on the host. Without this mount the
+    in-container write to a ``:ro`` path is the ``Errno 30`` read-only failure the
+    real CI run hit.
+    """
+
+    def _run(self, artifacts_dir: Path | None) -> list[str]:
+        with (
+            patch(f"{_MODULE}.shutil.which", return_value="/usr/bin/docker"),
+            patch(f"{_MODULE}._image_present", return_value=True),
+            patch(f"{_MODULE}.run_streamed", return_value=0) as streamed,
+        ):
+            run_eval_in_docker(["run", "--trials", "3"], artifacts_dir=artifacts_dir)
+        return streamed.call_args.args[0]
+
+    def test_mounts_the_artifacts_dir_writable_when_given(self, tmp_path: Path) -> None:
+        command = self._run(tmp_path)
+        assert f"{tmp_path}:{ARTIFACTS_MOUNT}" in command
+
+    def test_artifacts_mount_is_not_read_only(self, tmp_path: Path) -> None:
+        command = self._run(tmp_path)
+        # The repo mount carries `:ro`; the artifacts mount must NOT — otherwise the
+        # report write fails Errno 30 exactly like the bug.
+        assert f"{tmp_path}:{ARTIFACTS_MOUNT}:ro" not in command
+        assert f"{tmp_path}:{ARTIFACTS_MOUNT}" in command
+
+    def test_no_artifacts_mount_when_none(self) -> None:
+        command = self._run(None)
+        assert ARTIFACTS_MOUNT not in " ".join(command)
 
 
 class TestAuthPassthroughIntoContainer:

--- a/tests/teatree_cli/test_eval_run_transcript_html_cli.py
+++ b/tests/teatree_cli/test_eval_run_transcript_html_cli.py
@@ -1,0 +1,86 @@
+"""``t3 eval run --transcript-html`` end-to-end through the CLI.
+
+Integration: drive the real ``t3 eval run`` typer command (the sdk runner stubbed
+so no metered call is made) with ``--trials 3 --transcript-html <path>`` and
+``T3_EVAL_IN_CONTAINER=1`` (in-process, no docker re-route), then assert the
+per-trial transcript artifact landed on disk with the agent's transcript in it —
+the durable evidence a maintainer opens to triage a red metered lane.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from django.test import TestCase
+from typer.testing import CliRunner
+
+from teatree.cli import app
+from teatree.eval.models import EvalRun, EvalSpec, EvalToolCall
+
+
+def _spec(name: str) -> EvalSpec:
+    return EvalSpec(
+        name=name,
+        scenario=f"scenario {name}",
+        agent_path="skills/code/SKILL.md",
+        prompt="do",
+        matchers=(),
+        source_path=Path("/tmp/spec.yaml"),
+        model="claude-sonnet-4-6",
+    )
+
+
+def _stub_runner_class() -> type:
+    class _StubRunner:
+        def __init__(self, *_: object, **__: object) -> None: ...
+
+        def run(self, spec: EvalSpec) -> EvalRun:
+            return EvalRun(
+                spec_name=spec.name,
+                tool_calls=(EvalToolCall(name="Bash", input={"command": f"echo {spec.name}"}, turn=1),),
+                text_blocks=(f"reasoning for {spec.name}",),
+                terminal_reason="success",
+                is_error=False,
+                raw_stdout="",
+                raw_stderr="",
+                cost_usd=0.02,
+            )
+
+    return _StubRunner
+
+
+class TestRunEmitsTranscriptArtifact(TestCase):
+    def test_trials_run_writes_the_per_trial_transcript_to_the_path(self) -> None:
+        out = Path(self._artifact_dir()) / "eval-transcripts.html"
+        with (
+            patch("teatree.cli.eval.app.discover_specs", return_value=[_spec("alpha")]),
+            patch("teatree.eval.backends.SdkInProcessRunner", _stub_runner_class()),
+        ):
+            result = CliRunner().invoke(
+                app,
+                ["eval", "run", "--backend", "sdk", "--trials", "3", "--transcript-html", str(out)],
+                env={"T3_EVAL_IN_CONTAINER": "1"},
+            )
+        assert "Traceback" not in result.output, result.output
+        assert out.is_file()
+        body = out.read_text(encoding="utf-8")
+        assert "alpha" in body
+        assert "reasoning for alpha" in body  # the per-trial transcript IS in the artifact
+        assert "echo alpha" in body
+
+    def test_models_matrix_rejects_transcript_html(self) -> None:
+        out = Path(self._artifact_dir()) / "report.html"
+        with patch("teatree.cli.eval.app.discover_specs", return_value=[_spec("alpha")]):
+            result = CliRunner().invoke(
+                app,
+                ["eval", "run", "--backend", "sdk", "--models", "opus", "--transcript-html", str(out)],
+                env={"T3_EVAL_IN_CONTAINER": "1"},
+            )
+        assert result.exit_code == 2
+        assert "--transcript-html" in result.output
+        assert not out.exists()
+
+    @staticmethod
+    def _artifact_dir() -> str:
+        import tempfile  # noqa: PLC0415
+
+        return tempfile.mkdtemp()

--- a/tests/teatree_eval/test_pass_at_k_html.py
+++ b/tests/teatree_eval/test_pass_at_k_html.py
@@ -1,0 +1,136 @@
+"""Per-trial transcript HTML report for a metered pass@k run.
+
+The whole-suite summary renders one row per LANE; this report renders, per
+scenario, EACH trial's PASS/FAIL plus the agent's transcript (reasoning + tool
+calls) — the evidence a maintainer reads to diagnose a red lane. These tests pin
+that the transcript actually appears in the output and that markup is escaped.
+"""
+
+from pathlib import Path
+
+from teatree.eval.models import EvalRun, EvalSpec, EvalToolCall, Matcher
+from teatree.eval.pass_at_k import PassAtKResult
+from teatree.eval.pass_at_k_html import render_pass_at_k_html
+from teatree.eval.report import MatcherResult, ScenarioResult
+
+
+def _spec(name: str) -> EvalSpec:
+    return EvalSpec(
+        name=name,
+        scenario=f"scenario {name}",
+        agent_path="skills/code/SKILL.md",
+        prompt="do",
+        matchers=(),
+        source_path=Path("/tmp/spec.yaml"),
+    )
+
+
+def _run(spec: EvalSpec, *, text: tuple[str, ...] = (), tool_calls: tuple[EvalToolCall, ...] = ()) -> EvalRun:
+    return EvalRun(
+        spec_name=spec.name,
+        tool_calls=tool_calls,
+        text_blocks=text,
+        terminal_reason="success",
+        is_error=False,
+        raw_stdout="",
+        raw_stderr="",
+    )
+
+
+def _scenario_result(
+    spec: EvalSpec,
+    *,
+    passed: bool,
+    text: tuple[str, ...] = (),
+    tool_calls: tuple[EvalToolCall, ...] = (),
+    matcher_results: tuple[MatcherResult, ...] = (),
+) -> ScenarioResult:
+    run = _run(spec, text=text, tool_calls=tool_calls)
+    # An unsatisfied matcher makes ``passed`` False via report.ScenarioResult.passed,
+    # so for a deliberate FAIL the caller supplies a failing matcher_result.
+    return ScenarioResult(
+        spec=spec, run=run, matcher_results=matcher_results, skipped=not passed and not matcher_results
+    )
+
+
+def _pass_at_k(
+    spec: EvalSpec,
+    *,
+    passes: int,
+    trials: int,
+    trial_results: tuple[ScenarioResult, ...],
+    skipped: bool = False,
+) -> PassAtKResult:
+    return PassAtKResult(
+        spec_name=spec.name,
+        trials=trials,
+        passes=passes,
+        require="any",
+        skipped=skipped,
+        trial_results=trial_results,
+    )
+
+
+class TestRendersPerTrialTranscript:
+    def test_reasoning_text_block_appears_in_the_output(self) -> None:
+        spec = _spec("verify_target_before_cherry_pick")
+        trial = _scenario_result(spec, passed=True, text=("First I read the source branch to find the real SHA.",))
+        html = render_pass_at_k_html([_pass_at_k(spec, passes=1, trials=1, trial_results=(trial,))])
+        assert "First I read the source branch to find the real SHA." in html
+
+    def test_tool_calls_appear_in_the_output(self) -> None:
+        spec = _spec("plan_before_any_change_under_load")
+        call = EvalToolCall(name="Bash", input={"command": "git log --oneline"}, turn=1)
+        trial = _scenario_result(spec, passed=True, tool_calls=(call,))
+        html = render_pass_at_k_html([_pass_at_k(spec, passes=1, trials=1, trial_results=(trial,))])
+        assert "Bash" in html
+        assert "git log --oneline" in html
+
+    def test_each_of_three_trials_renders_its_own_block(self) -> None:
+        spec = _spec("full_speed_fans_out_parallel_workers_not_serial")
+        trials = tuple(_scenario_result(spec, passed=True, text=(f"trial {i} reasoning",)) for i in range(3))
+        html = render_pass_at_k_html([_pass_at_k(spec, passes=3, trials=3, trial_results=trials)])
+        for i in range(3):
+            assert f"trial {i} reasoning" in html
+        assert html.count("trial 1</h3>") + html.count("trial 1 ") >= 1
+
+    def test_failing_matcher_message_is_shown_for_a_failed_trial(self) -> None:
+        spec = _spec("team_mate_spawned_opus_never_sonnet")
+        matcher = Matcher(kind="positive", tool="Task", arg_path="model", operator="contains", value="opus")
+        failed = MatcherResult(matcher=matcher, passed=False, message="expected model=opus, got sonnet")
+        trial = _scenario_result(spec, passed=False, matcher_results=(failed,))
+        html = render_pass_at_k_html([_pass_at_k(spec, passes=0, trials=1, trial_results=(trial,))])
+        assert "expected model=opus, got sonnet" in html
+        assert "FAIL" in html
+
+    def test_aggregate_pass_count_is_shown(self) -> None:
+        spec = _spec("s")
+        trials = (_scenario_result(spec, passed=True), _scenario_result(spec, passed=False, matcher_results=()))
+        # 1 of 2 trials passed.
+        result = PassAtKResult(spec_name="s", trials=2, passes=1, require="any", skipped=False, trial_results=trials)
+        html = render_pass_at_k_html([result])
+        assert "1/2 trials passed" in html
+
+
+class TestSelfContainedAndEscaped:
+    def test_values_are_html_escaped(self) -> None:
+        spec = _spec("x")
+        trial = _scenario_result(spec, passed=True, text=("<script>alert(1)</script>",))
+        html = render_pass_at_k_html([_pass_at_k(spec, passes=1, trials=1, trial_results=(trial,))])
+        assert "<script>alert(1)</script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_is_self_contained_no_external_assets(self) -> None:
+        spec = _spec("x")
+        trial = _scenario_result(spec, passed=True, text=("ok",))
+        html = render_pass_at_k_html([_pass_at_k(spec, passes=1, trials=1, trial_results=(trial,))])
+        assert "<style>" in html
+        assert "http://" not in html
+        assert "https://" not in html
+
+    def test_skipped_scenario_renders_without_trials(self) -> None:
+        spec = _spec("skipped_one")
+        result = _pass_at_k(spec, passes=0, trials=3, trial_results=(), skipped=True)
+        html = render_pass_at_k_html([result])
+        assert "skipped_one" in html
+        assert "SKIP" in html


### PR DESCRIPTION
## The bug

The metered eval CI workflow's **"Render the whole-suite HTML report"** step
(`eval.yml`, run via `t3 eval all --html eval-report.html`) had two defects,
both confirmed from real run `27658030915`:

1. **It re-ran the entire suite.** `t3 eval all` calls `run_full_suite`, which
   re-executes every eval lane. So after the expensive metered step (up to
   2x80min), this "render" step re-graded all **~181 scenarios** for **~64min**
   instead of just rendering the metered run.
2. **It died writing the report** — `OSError: [Errno 30] Read-only file system:
   'eval-report.html'`. The metered lane routes through Docker with the repo
   mounted read-only, so the relative output path was unwritable; the `|| true`
   masked it and the artifact was lost (`No files were found ... No artifacts`).

**Root cause:** the metered run is forced `--no-persist` in an ephemeral,
read-only-mounted container, so its per-trial transcripts never reach the host
run-history ledger. A separate render step therefore has nothing of *that* run
to render -- re-running was the only way it could produce anything. And
`run_pass_at_k` discarded the per-trial `ScenarioResult` objects, so even
in-memory the transcripts were gone.

## The fix (design: the run emits the artifact itself)

I evaluated rendering-from-ledger but it is impossible in this CI: the metered
run is `--no-persist` in an ephemeral container, so there is no host ledger of
that run to render. The cleanest design is for the metered `t3 eval run` to emit
the per-trial transcript artifact itself, at run time, from its own in-memory
results.

- **`PassAtKResult.trial_results`** -- `run_pass_at_k` now retains the per-trial
  `ScenarioResult` objects (the raw transcript evidence the aggregate counters
  are derived from), instead of discarding them.
- **`eval/pass_at_k_html.py`** -- a new self-contained per-trial transcript
  renderer: per scenario, the aggregate verdict plus EACH trial's PASS/FAIL and
  the agent's transcript (reasoning `text_blocks` + `tool_calls`) and failed
  matchers. This is exactly the evidence a maintainer needs to diagnose the 5
  failing `under_load` scenarios.
- **`t3 eval run --transcript-html <path>`** -- writes that report from THIS
  run's results (no suite re-run, no ledger read), **before** any guard/gate
  exits, so a red lane is still captured.
- **`--docker` runner** -- bind-mounts the destination's parent dir WRITABLE at
  `/artifacts` (the repo mount stays read-only) and translates the host path to
  the container path, so the in-container report lands back on the host runner.
- **`eval.yml`** -- the metered step passes
  `--transcript-html "$RUNNER_TEMP/eval-transcripts.html"` (always writable); the
  separate full-suite render step is **removed**; the upload step points at that
  writable path and stays `if: always()` (non-gating; the eval verdict already
  set the job exit code).

## Verification

- The new render path does **not** re-run the suite: a test asserts the runner
  is invoked exactly `trials x scenarios` times with no extra rendering pass.
- It writes to the given (writable `tmp_path`) path, the artifact contains the
  per-trial transcript (reasoning + tool calls), and is written even when the
  run is about to exit non-zero (the red-lane case).
- Docker mount test: the artifacts dir is mounted writable (not read-only); the
  host `--transcript-html` path is translated to `/artifacts/<name>`.
- Gates: `uv run pytest` (eval + CLI + quality subsets, 3094 passed), full suite,
  `ruff check`/`ruff format`, `ty check`, `tach check`, module-health
  (`check_module_health.py --from-ref origin/main`, exit 0) all green.

Do not merge -- left green-and-ready for review.
