### PR TITLE
ci: adopt django-upgrade codemod (prek hook, target 5.2)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,15 @@ repos:
         args: ["--locked", "--all-packages"]
 
   # Phase 2 - Formatters
+  # django-upgrade rewrites deprecated Django patterns to the target-version idiom.
+  # It runs before the formatters so ruff reformats its output to project style.
+  # Target is the supported floor (django>=X.Y in pyproject.toml) so rewrites stay
+  # compatible with every Django version the project supports.
+  - repo: https://github.com/adamchainz/django-upgrade
+    rev: 1db0cbd209d6c4dc78191593942e6269fae99e8d  # 1.30.0
+    hooks:
+      - id: django-upgrade
+        args: [--target-version, "5.2"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: fa93bc3224c614a0e9786d3e2d3d48edcca246eb  # v0.15.1
     hooks:

--- a/src/teatree/core/models/eval_run.py
+++ b/src/teatree/core/models/eval_run.py
@@ -391,7 +391,7 @@ class EvalScenarioResult(models.Model):
     scenario_name = models.CharField(max_length=128)
     trial = models.IntegerField(default=0)
     model = models.CharField(max_length=64, blank=True, default="")
-    verdict = models.CharField(max_length=8, choices=EvalVerdict.choices)
+    verdict = models.CharField(max_length=8, choices=EvalVerdict)
     score = models.FloatField(default=0.0)
     trials = models.PositiveSmallIntegerField(default=1)
     terminal_reason = models.CharField(max_length=128, blank=True, default="")

--- a/src/teatree/core/models/loop_state.py
+++ b/src/teatree/core/models/loop_state.py
@@ -110,7 +110,7 @@ class LoopState(models.Model):
     """One row per mini-loop name carrying its durable control-plane status."""
 
     name = models.CharField(max_length=64, unique=True)
-    status = models.CharField(max_length=16, choices=LoopStatus.choices, default=LoopStatus.ENABLED)
+    status = models.CharField(max_length=16, choices=LoopStatus, default=LoopStatus.ENABLED)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/tests/teatree_core/test_github_webhook_view.py
+++ b/tests/teatree_core/test_github_webhook_view.py
@@ -75,8 +75,7 @@ class TestGitHubWebhookView(TestCase):
             reverse("teatree:github_webhook"),
             data=body,
             content_type="application/json",
-            HTTP_X_GITHUB_EVENT="ping",
-            HTTP_X_GITHUB_DELIVERY="ping-1",
+            headers={"x-github-event": "ping", "x-github-delivery": "ping-1"},
         )
 
         assert response.status_code == 401
@@ -99,9 +98,7 @@ class TestGitHubWebhookViewWithoutSecret(TestCase):
             reverse("teatree:github_webhook"),
             data=b"{}",
             content_type="application/json",
-            HTTP_X_GITHUB_EVENT="ping",
-            HTTP_X_GITHUB_DELIVERY="x",
-            HTTP_X_HUB_SIGNATURE_256="sha256=x",
+            headers={"x-github-event": "ping", "x-github-delivery": "x", "x-hub-signature-256": "sha256=x"},
         )
 
         assert response.status_code == 503

--- a/tests/teatree_core/test_slack_webhook_view.py
+++ b/tests/teatree_core/test_slack_webhook_view.py
@@ -183,8 +183,7 @@ class TestSlackWebhookViewWithoutSecret(TestCase):
             reverse("teatree:slack_webhook"),
             data=body,
             content_type="application/json",
-            HTTP_X_SLACK_REQUEST_TIMESTAMP="1",
-            HTTP_X_SLACK_SIGNATURE="v0=x",
+            headers={"x-slack-request-timestamp": "1", "x-slack-signature": "v0=x"},
         )
 
         assert response.status_code == 503

--- a/tests/test_django_upgrade_hook.py
+++ b/tests/test_django_upgrade_hook.py
@@ -1,0 +1,82 @@
+"""Pins the ``django-upgrade`` pre-commit hook wiring.
+
+``django-upgrade`` (adamchainz/django-upgrade) is a codemod that auto-rewrites
+deprecated Django patterns to the idioms of a target Django version. It is wired
+as a prek/pre-commit hook so every new Python file is upgraded on commit.
+
+These tests pin three invariants so a future edit can't silently break the hook:
+
+- the hook with id ``django-upgrade`` is present in ``.pre-commit-config.yaml``;
+- it pins a concrete upstream ``rev`` (never a floating branch);
+- its ``--target-version`` equals the *minimum* supported Django version parsed
+    from ``pyproject.toml`` — the floor, so rewrites stay compatible with every
+    Django the project supports.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PRECOMMIT_CONFIG = _REPO_ROOT / ".pre-commit-config.yaml"
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+
+def _load_precommit_repos() -> list[dict[str, Any]]:
+    config = yaml.safe_load(_PRECOMMIT_CONFIG.read_text(encoding="utf-8"))
+    return cast("list[dict[str, Any]]", config["repos"])
+
+
+def _django_upgrade_repo() -> dict[str, Any] | None:
+    for repo in _load_precommit_repos():
+        if any(hook.get("id") == "django-upgrade" for hook in repo.get("hooks", [])):
+            return repo
+    return None
+
+
+def _django_floor_version() -> str:
+    """The minimum supported Django version from the ``django>=X.Y`` pin."""
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    deps: list[str] = data["project"]["dependencies"]
+    django_pin = next(dep for dep in deps if re.match(r"^django\b", dep))
+    match = re.search(r">=\s*(\d+\.\d+)", django_pin)
+    assert match, f"Could not parse a '>=X.Y' floor from the Django pin: {django_pin!r}"
+    return match.group(1)
+
+
+class TestDjangoUpgradeHook:
+    def test_hook_is_wired(self) -> None:
+        repo = _django_upgrade_repo()
+        assert repo is not None, "No repo wiring a 'django-upgrade' hook in .pre-commit-config.yaml."
+        assert "adamchainz/django-upgrade" in repo["repo"], (
+            "The django-upgrade hook must come from adamchainz/django-upgrade."
+        )
+
+    def test_rev_is_pinned(self) -> None:
+        repo = _django_upgrade_repo()
+        assert repo is not None
+        rev = str(repo.get("rev", "")).strip()
+        assert rev, "django-upgrade must pin a concrete release tag."
+        assert rev not in {"main", "master", "HEAD"}, (
+            f"django-upgrade must pin a concrete release tag, not a floating ref: {rev!r}."
+        )
+
+    def test_target_version_matches_django_floor(self) -> None:
+        repo = _django_upgrade_repo()
+        assert repo is not None
+        hook = next(h for h in repo["hooks"] if h.get("id") == "django-upgrade")
+        args = [str(arg) for arg in hook.get("args", [])]
+        assert "--target-version" in args, (
+            "django-upgrade must pass an explicit --target-version so rewrites are "
+            "deterministic and compatible with the supported floor."
+        )
+        target = args[args.index("--target-version") + 1]
+        floor = _django_floor_version()
+        assert target == floor, (
+            f"django-upgrade --target-version ({target!r}) must equal the minimum "
+            f"supported Django version from pyproject ({floor!r}); rewrites keyed to a "
+            "higher target can emit code that breaks on the supported floor."
+        )


### PR DESCRIPTION
## What

Adopt the [django-upgrade](https://github.com/adamchainz/django-upgrade)
codemod as a prek/pre-commit hook and apply its one-time auto-fixes.

Closes #2495.

## Why

django-upgrade auto-rewrites deprecated Django patterns to the idioms of a
target Django version, deterministically and offline. Wiring it as a hook keeps
the codebase on current Django idioms with zero manual effort and stops new
deprecations from accumulating — any newly-added file is upgraded before it
lands.

`--target-version` is pinned to `5.2`, the **floor** of the supported range
(`django>=5.2,<6.1` in `pyproject.toml`), so rewrites stay compatible with every
supported Django version.

## Commits (auto-fixes kept separate from wiring)

1. `ci: wire django-upgrade codemod as a prek hook (target 5.2)` — the hook in
   the Formatters phase before `ruff-format` (so ruff reformats the codemod's
   output), pinned to `1.30.0`, plus a regression test pinning the hook id, the
   pinned rev, and that `--target-version` equals the Django floor from
   pyproject.
2. `refactor: apply django-upgrade auto-fixes (target 5.2)` — the one-time
   sweep: `CharField(choices=Enum.choices)` → `CharField(choices=Enum)` in two
   models, and `HTTP_X_*` test-client kwargs → `headers={...}` in two webhook
   view tests.

## Test evidence

- New `tests/test_django_upgrade_hook.py` — 3 passed (RED before wiring, GREEN
  after).
- Affected modules: `test_github_webhook_view.py` + `test_slack_webhook_view.py`
  — 16 passed; model coverage (`-k eval_run or loop_state ...`) — 80 passed.
- `tests/teatree_quality/` — 66 passed.
- `scripts/hooks/check_module_health.py --from-ref origin/main` — clean (exit 0).
- Clean-sweep verification: `django-upgrade --target-version 5.2` over every
  tracked `.py` produces **zero** further changes; working tree clean.
- All prek commit + push gates passed on both commits.

## Architecture pre-check — #2495

## 1. BLUEPRINT § alignment
n/a — CI/tooling config change (`.pre-commit-config.yaml`) plus a one-time
mechanical codemod sweep. No BLUEPRINT section governs the lint-hook chain.

## 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition.

## 3. Extension-point contracts
n/a — no `OverlayBase`, scanner, hook-router, or `*Backend` Protocol surface
touched. The two `src/` edits are mechanical model-field rewrites with identical
runtime behavior (Django accepts the enum class directly since 5.0).

## 4. Component boundaries
`.pre-commit-config.yaml` (the lint/format hook chain) and a top-level
`tests/test_django_upgrade_hook.py` (mirrors the sibling `test_ci_audit_uses_pip_audit.py`
config-pinning test). Auto-fixes land in the existing files they belong to.

## 5. Dependency direction
No imports added to `src/`. `uv run tach check` passes (ran in the commit hook
chain).

## 6. Test surface
`tests/test_django_upgrade_hook.py` asserts: hook id `django-upgrade` is wired
from `adamchainz/django-upgrade`; a concrete pinned `rev` (not a floating ref);
`--target-version` equals the Django floor parsed from `pyproject.toml`. The
last assertion regresses if the pin or target drifts from the supported floor.

## 7. Resilience invariants
n/a — no external write, no DB row outside the request cycle, no fs write under
a watched path.

## 8. Identity and key normalization
n/a — no bare/qualified identity forms introduced.

## 9. Behavior preservation / capability deletion
Purely additive plus behavior-preserving codemod. The `choices=Enum.choices` →
`choices=Enum` rewrite is semantically identical (Django 5.0+ normalizes the
enum class to `.choices` internally — covered tests stay green). The
`HTTP_X_* → headers={...}` rewrite is the documented equivalent test-client
kwarg (Django 4.2+). No matcher narrowed; no must-block test inverted.
