### PR TITLE
fix(config): only warn on a genuine DB-home TOML conflict, aggregated to one line

### DIFF
--- a/docs/blueprint/configuration.md
+++ b/docs/blueprint/configuration.md
@@ -217,10 +217,14 @@ partition so an existing install's DB-home keys keep applying (they are otherwis
 ignored on read).
 
 A DB-home key left in `[teatree]` / `[overlays.<name>]` after the migration is
-ignored on read, but no longer silently: `load_config` emits one `WARNING`
-(logger `teatree.config`) per offending key naming the key, its TOML location, and
-the `config_setting set` / `import` path — so the dropped value is visible rather
-than a confusing no-op.
+ignored on read. This is loud only when it actually **conflicts** with the store:
+`load_config` warns (logger `teatree.config`) for a DB-home key set to a value that
+DIFFERS from its `ConfigSetting` row — the one case where the silently-ignored TOML
+value disagrees with what is in effect. All such conflicts collapse into a SINGLE
+`WARNING` naming every offending key, its TOML location, and the `config_setting
+import` path. A DB-home key that is absent from the store (being migrated away) or
+that agrees with it resolves to the same effective value and stays silent — so a
+cleaned config emits zero per-key noise rather than one line per DB-homed key.
 
 Bootstrap-readable settings (`DATABASE_URL` / data-dir / `DJANGO_SETTINGS_MODULE`
 / the offline `private_repos` allowlist) are explicitly out of scope — they must

--- a/src/teatree/config/loader.py
+++ b/src/teatree/config/loader.py
@@ -123,8 +123,17 @@ def _parse_toml_value(key: str, value: object) -> object:
         return _UNPARSEABLE_TOML_VALUE
 
 
-def _conflicting_db_home_keys(toml_table: dict[str, Any], db_overrides: dict[str, Any]) -> list[str]:
-    """Return the DB-home keys in *toml_table* whose value CONFLICTS with the DB.
+def _db_home_keys_in(toml_table: dict[str, Any]) -> list[str]:
+    """The DB-home keys present in *toml_table* (a cheap, static, no-DB check)."""
+    from teatree.config.homes import SETTING_HOMES, SettingHome  # noqa: PLC0415
+
+    return [key for key in toml_table if SETTING_HOMES.get(key) is SettingHome.DB]
+
+
+def _conflicting_db_home_keys(
+    toml_table: dict[str, Any], db_home_keys: list[str], db_overrides: dict[str, Any]
+) -> list[str]:
+    """Return the *db_home_keys* whose TOML value CONFLICTS with the DB.
 
     A conflict is a key present in BOTH the TOML table and the ``ConfigSetting``
     store with DIFFERING (parser-normalized) values — the only case where the
@@ -133,15 +142,11 @@ def _conflicting_db_home_keys(toml_table: dict[str, Any], db_overrides: dict[str
     (being migrated away), or present but AGREEING, is silent: it resolves to the
     same effective value, so warning about it is the noise this path removes.
     """
-    from teatree.config.homes import SETTING_HOMES, SettingHome  # noqa: PLC0415
-
     conflicts: list[str] = []
-    for key, toml_value in toml_table.items():
-        if SETTING_HOMES.get(key) is not SettingHome.DB:
-            continue
+    for key in db_home_keys:
         if key not in db_overrides:
             continue
-        if _parse_toml_value(key, toml_value) != db_overrides[key]:
+        if _parse_toml_value(key, toml_table[key]) != db_overrides[key]:
             conflicts.append(key)
     return conflicts
 
@@ -162,24 +167,37 @@ def _warn_db_home_keys_in_toml(raw: dict, path: Path) -> None:
     The home registry and DB readers are imported lazily (the loader -> resolution
     edge the module docstring describes) to avoid the loader/resolution/discovery
     import cycle at module load and to keep the DB read off the hot import path.
-    """
-    from teatree.config.resolution import _db_global_overrides, _db_overlay_overrides  # noqa: PLC0415
 
+    The DB is read ONLY when a table actually carries a DB-home key. The common
+    post-migration file (every DB-home key already moved into the store) has none,
+    so ``load_config`` touches no connection — keeping it leak-free off the hot path
+    rather than opening a stray default-alias connection on every call.
+    """
     offenders: list[str] = []
 
     teatree = raw.get("teatree")
     if isinstance(teatree, dict):
-        global_db = _db_global_overrides()
-        offenders.extend(f"[teatree] {key}" for key in _conflicting_db_home_keys(teatree, global_db))
+        db_home_keys = _db_home_keys_in(teatree)
+        if db_home_keys:
+            from teatree.config.resolution import _db_global_overrides  # noqa: PLC0415
+
+            global_db = _db_global_overrides()
+            offenders.extend(f"[teatree] {key}" for key in _conflicting_db_home_keys(teatree, db_home_keys, global_db))
 
     overlays = raw.get("overlays")
     if isinstance(overlays, dict):
         for overlay_name, overlay_cfg in overlays.items():
             if not isinstance(overlay_cfg, dict):
                 continue
+            db_home_keys = _db_home_keys_in(overlay_cfg)
+            if not db_home_keys:
+                continue
+            from teatree.config.resolution import _db_overlay_overrides  # noqa: PLC0415
+
             overlay_db = _db_overlay_overrides(overlay_name)
             offenders.extend(
-                f"[overlays.{overlay_name}] {key}" for key in _conflicting_db_home_keys(overlay_cfg, overlay_db)
+                f"[overlays.{overlay_name}] {key}"
+                for key in _conflicting_db_home_keys(overlay_cfg, db_home_keys, overlay_db)
             )
 
     if offenders:

--- a/src/teatree/config/loader.py
+++ b/src/teatree/config/loader.py
@@ -24,6 +24,7 @@ need effective values must use ``get_effective_settings``, not the bare
 import logging
 import tomllib
 from pathlib import Path
+from typing import Any
 
 import teatree.config as _facade
 from teatree.config.settings import E2ERepo, TeaTreeConfig, UserSettings, _default_handover_mirror_path, _parse_str_list
@@ -97,52 +98,99 @@ def _load_toml(path: Path) -> dict:
             raise ValueError(msg) from exc
 
 
-def _warn_db_home_keys_in_toml(raw: dict, path: Path) -> None:
-    """Emit a loud WARN for any DB-home key left in ``[teatree]`` / ``[overlays.<name>]``.
+# Sentinel for a TOML value that cannot be coerced to its setting's type. It never
+# equals a parsed DB value, so a malformed TOML value still counts as a conflict.
+_UNPARSEABLE_TOML_VALUE = object()
 
-    Under the #1775 hard partition a DB-home key in the TOML file is IGNORED on
-    read (its home is the ``ConfigSetting`` store), so silently dropping it would
-    leave the operator wondering why ``mode = "auto"`` in their file did nothing.
-    This makes the drop VISIBLE — one WARNING per offending key, naming the key,
-    its TOML location, and the one-time ``config_setting import`` migration path.
 
-    The home registry is imported lazily (the same deferral ``homes`` uses) to
-    avoid a ``settings -> loader -> homes -> settings`` import cycle at module load.
+def _parse_toml_value(key: str, value: object) -> object:
+    """Coerce a raw TOML scalar through the same parser the DB store uses for *key*.
+
+    Both sides of a conflict comparison must be normalized the same way (a TOML
+    ``"auto"`` and a stored ``"auto"`` both become ``Mode.AUTO``) so the check
+    compares semantic values, not representations. A parse failure means the TOML
+    value is malformed for the setting's type — treated as "not equal" so the
+    conflict still surfaces rather than being swallowed.
+    """
+    from teatree.config.settings import OVERLAY_OVERRIDABLE_SETTINGS  # noqa: PLC0415
+
+    parser = OVERLAY_OVERRIDABLE_SETTINGS.get(key)
+    if parser is None:
+        return value
+    try:
+        return parser(value)
+    except (ValueError, TypeError, AttributeError):
+        return _UNPARSEABLE_TOML_VALUE
+
+
+def _conflicting_db_home_keys(toml_table: dict[str, Any], db_overrides: dict[str, Any]) -> list[str]:
+    """Return the DB-home keys in *toml_table* whose value CONFLICTS with the DB.
+
+    A conflict is a key present in BOTH the TOML table and the ``ConfigSetting``
+    store with DIFFERING (parser-normalized) values — the only case where the
+    TOML value is silently ignored *and* disagrees with the setting's real home,
+    so the operator is genuinely surprised. A DB-home key absent from the DB store
+    (being migrated away), or present but AGREEING, is silent: it resolves to the
+    same effective value, so warning about it is the noise this path removes.
     """
     from teatree.config.homes import SETTING_HOMES, SettingHome  # noqa: PLC0415
 
-    db_home_keys = {name for name, home in SETTING_HOMES.items() if home is SettingHome.DB}
+    conflicts: list[str] = []
+    for key, toml_value in toml_table.items():
+        if SETTING_HOMES.get(key) is not SettingHome.DB:
+            continue
+        if key not in db_overrides:
+            continue
+        if _parse_toml_value(key, toml_value) != db_overrides[key]:
+            conflicts.append(key)
+    return conflicts
+
+
+def _warn_db_home_keys_in_toml(raw: dict, path: Path) -> None:
+    """Emit ONE aggregated WARN for DB-home keys whose TOML value CONFLICTS with the DB.
+
+    Under the #1775 hard partition a DB-home key in the TOML file is IGNORED on
+    read (its home is the ``ConfigSetting`` store). After an install migrates such
+    keys into the store the TOML is clean, so warning on every DB-home key that
+    *appears* in the file produced ~100 lines of noise per command. The signal that
+    actually matters is a CONFLICT: the key is set to a different value in BOTH the
+    TOML and the DB, so the silently-ignored TOML value disagrees with what is in
+    effect. Those are aggregated into a SINGLE warning naming every offending key
+    and the one-time ``config_setting import`` migration path. A DB-home key that is
+    absent from the DB, or agrees with it, is silent.
+
+    The home registry and DB readers are imported lazily (the loader -> resolution
+    edge the module docstring describes) to avoid the loader/resolution/discovery
+    import cycle at module load and to keep the DB read off the hot import path.
+    """
+    from teatree.config.resolution import _db_global_overrides, _db_overlay_overrides  # noqa: PLC0415
+
+    offenders: list[str] = []
 
     teatree = raw.get("teatree")
     if isinstance(teatree, dict):
-        for key in teatree:
-            if key in db_home_keys:
-                _logger.warning(
-                    "Config key '[teatree] %s' in %s is a DB-home setting (#1775) and is IGNORED on read; "
-                    "set it with `t3 <overlay> config_setting set %s ...` or migrate once with "
-                    "`t3 <overlay> config_setting import`.",
-                    key,
-                    path,
-                    key,
-                )
+        global_db = _db_global_overrides()
+        offenders.extend(f"[teatree] {key}" for key in _conflicting_db_home_keys(teatree, global_db))
 
     overlays = raw.get("overlays")
     if isinstance(overlays, dict):
         for overlay_name, overlay_cfg in overlays.items():
             if not isinstance(overlay_cfg, dict):
                 continue
-            for key in overlay_cfg:
-                if key in db_home_keys:
-                    _logger.warning(
-                        "Config key '[overlays.%s] %s' in %s is a DB-home setting (#1775) and is IGNORED on read; "
-                        "set it with `t3 <overlay> config_setting set %s ... --overlay %s` or migrate once with "
-                        "`t3 <overlay> config_setting import`.",
-                        overlay_name,
-                        key,
-                        path,
-                        key,
-                        overlay_name,
-                    )
+            overlay_db = _db_overlay_overrides(overlay_name)
+            offenders.extend(
+                f"[overlays.{overlay_name}] {key}" for key in _conflicting_db_home_keys(overlay_cfg, overlay_db)
+            )
+
+    if offenders:
+        _logger.warning(
+            "Config keys in %s are DB-home settings (#1775) set to a DIFFERENT value than the "
+            "ConfigSetting store, and are IGNORED on read: %s. Resolve the conflict by removing them "
+            "from the file (the DB value is authoritative) or migrate once with "
+            "`t3 <overlay> config_setting import`.",
+            path,
+            ", ".join(offenders),
+        )
 
 
 def load_config(path: Path | None = None) -> TeaTreeConfig:

--- a/tests/config/test_load_config.py
+++ b/tests/config/test_load_config.py
@@ -77,35 +77,6 @@ def test_agent_signature_defaults_off(tmp_path: Path) -> None:
     assert load_config(config_path).user.agent_signature is False
 
 
-def test_db_home_key_in_teatree_table_warns(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-    # A DB-home key left in [teatree] is IGNORED on read (its home is the DB),
-    # but the drop must be VISIBLE — a loud WARN naming the key + the migration
-    # path, never a silent no-op (#1775 in-PR add C).
-    config_path = tmp_path / ".teatree.toml"
-    _write_toml(config_path, '[teatree]\nmode = "auto"\nrepo_mode = "solo"\n')
-    with caplog.at_level("WARNING", logger="teatree.config"):
-        load_config(config_path)
-    warnings = "\n".join(r.getMessage() for r in caplog.records)
-    assert "mode" in warnings
-    assert "repo_mode" in warnings
-    assert "config_setting import" in warnings
-
-
-def test_db_home_key_in_overlay_table_warns(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
-    # A DB-home key under [overlays.<name>] is ignored on read just like the
-    # global table — the WARN must name the overlay-scoped key too.
-    config_path = tmp_path / ".teatree.toml"
-    _write_toml(
-        config_path,
-        '[teatree]\n\n[overlays.myproj]\npath = "~/p"\nrequire_human_approval_to_merge = false\n',
-    )
-    with caplog.at_level("WARNING", logger="teatree.config"):
-        load_config(config_path)
-    warnings = "\n".join(r.getMessage() for r in caplog.records)
-    assert "require_human_approval_to_merge" in warnings
-    assert "myproj" in warnings
-
-
 def test_toml_home_and_raw_keys_do_not_warn(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     # TOML-home carve-out fields, overlay discovery/messaging keys, and raw
     # bootstrap keys are legitimate in the file — they must NOT trip the WARN.
@@ -120,6 +91,92 @@ def test_toml_home_and_raw_keys_do_not_warn(tmp_path: Path, caplog: pytest.LogCa
         load_config(config_path)
     warnings = "\n".join(r.getMessage() for r in caplog.records if "ignored on read" in r.getMessage().lower())
     assert warnings == ""
+
+
+class TestDbHomeTomlConflictWarning(TestCase):
+    """The #1775 DB-home-key-in-TOML warning is QUIET by default.
+
+    After the migration cleaned the TOML of DB-homed keys, the load path used
+    to emit one WARNING per DB-home key present in the file (~100 lines per
+    command — unusable noise). The contract is now: a DB-home key that lives
+    correctly in the DB (and is absent from / agrees with the TOML) is silent;
+    a genuine conflict (the key set to a *different* value in BOTH the TOML and
+    the DB store) warns, aggregated to a single line.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+        self.config_path = tmp_path / ".teatree.toml"
+        self.caplog = caplog
+        monkeypatch.setattr(config_facade, "CONFIG_PATH", self.config_path)
+        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+
+    def _load_and_collect(self) -> list[str]:
+        with self.caplog.at_level("WARNING", logger="teatree.config"):
+            load_config(self.config_path)
+        return [r.getMessage() for r in self.caplog.records if "ignored on read" in r.getMessage().lower()]
+
+    def test_clean_db_home_config_produces_zero_warnings(self) -> None:
+        # The core fix: a TOML that carries NO DB-home key (every DB-home setting
+        # lives in the DB store, where it belongs) emits ZERO per-key warnings,
+        # even with many DB rows present.
+        ConfigSetting.objects.set_value("mode", "auto")
+        ConfigSetting.objects.set_value("repo_mode", "solo")
+        ConfigSetting.objects.set_value("contribute", value=True)
+        _write_toml(self.config_path, '[teatree]\nworkspace_dir = "~/ws"\nprivacy = "strict"\n')
+        assert self._load_and_collect() == []
+
+    def test_db_home_key_in_toml_without_db_row_is_silent(self) -> None:
+        # A DB-home key still in the TOML but with NO DB row is being migrated
+        # away — it is no longer a per-key warning (the noise the fix removes).
+        _write_toml(self.config_path, '[teatree]\nmode = "auto"\nrepo_mode = "solo"\n')
+        assert self._load_and_collect() == []
+
+    def test_db_home_key_in_toml_agreeing_with_db_is_silent(self) -> None:
+        # Present in BOTH toml and DB but the values AGREE — not a conflict, silent.
+        ConfigSetting.objects.set_value("mode", "auto")
+        _write_toml(self.config_path, '[teatree]\nmode = "auto"\n')
+        assert self._load_and_collect() == []
+
+    def test_genuine_conflict_warns_once(self) -> None:
+        # Present in BOTH toml and DB with DIFFERING values: the TOML value is
+        # silently ignored (the DB is its home), so the conflict is surfaced.
+        ConfigSetting.objects.set_value("mode", "interactive")
+        _write_toml(self.config_path, '[teatree]\nmode = "auto"\n')
+        warnings = self._load_and_collect()
+        # Aggregated to a single line — never one warning per offending key.
+        assert len(warnings) == 1
+        assert "mode" in warnings[0]
+        assert "config_setting import" in warnings[0]
+
+    def test_multiple_conflicts_aggregate_to_one_line(self) -> None:
+        # Many conflicting keys collapse to ONE warning naming each key — never
+        # ~100 lines, one per key (the regression this fix targets).
+        ConfigSetting.objects.set_value("mode", "interactive")
+        ConfigSetting.objects.set_value("repo_mode", "collaborative")
+        ConfigSetting.objects.set_value("contribute", value=False)
+        _write_toml(
+            self.config_path,
+            '[teatree]\nmode = "auto"\nrepo_mode = "solo"\ncontribute = true\n',
+        )
+        warnings = self._load_and_collect()
+        assert len(warnings) == 1
+        assert "mode" in warnings[0]
+        assert "repo_mode" in warnings[0]
+        assert "contribute" in warnings[0]
+
+    def test_overlay_scoped_conflict_warns_once(self) -> None:
+        # An overlay-scoped DB row conflicting with [overlays.<name>] is surfaced
+        # against that overlay's DB scope, aggregated to a single line.
+        ConfigSetting.objects.set_value("require_human_approval_to_merge", value=True, scope="myproj")
+        _write_toml(
+            self.config_path,
+            '[teatree]\n\n[overlays.myproj]\npath = "~/p"\nrequire_human_approval_to_merge = false\n',
+        )
+        warnings = self._load_and_collect()
+        assert len(warnings) == 1
+        assert "require_human_approval_to_merge" in warnings[0]
+        assert "myproj" in warnings[0]
 
 
 class TestDbHomeGlobalResolution(TestCase):


### PR DESCRIPTION
## What

After the #1775 config-in-DB migration, `load_config` emitted **one `WARNING` per
DB-home key** that merely *appeared* in `[teatree]` / `[overlays.<name>]` — roughly
100 lines of noise on every `t3` command, even after the TOML had been cleaned of
the DB-homed keys. This makes the warn path quiet by default and surfaces only the
signal that actually matters.

The new behavior in `_warn_db_home_keys_in_toml`:

- A DB-home key **absent from the `ConfigSetting` store** (being migrated away) or
  one whose TOML value **agrees** with the store is **silent** — both resolve to the
  same effective value, so warning is pure noise.
- A **genuine conflict** (a DB-home key present in BOTH the TOML and the DB with
  differing, parser-normalized values — the case where the silently-ignored TOML
  value disagrees with what is in effect) **warns**.
- All conflicts collapse into a **single aggregated `WARNING`** naming every
  offending key + the `config_setting import` migration path — never one line per key.

Values are compared parser-normalized (a TOML `"auto"` and a stored `"auto"` both
become `Mode.AUTO`), so the check is semantic, not representational. A malformed
TOML value is treated as a conflict (surfaced, never swallowed).

## Why

The unconditional per-key warning made `t3` output unusable: ~100 WARNING lines
on every command. The drop of a DB-home TOML value is only worth surfacing when it
actually disagrees with the setting's real home — that is the genuine surprise an
operator needs to know about.

## Test evidence

- New `TestDbHomeTomlConflictWarning` in `tests/config/test_load_config.py`:
  clean DB-home config -> zero warnings; key absent-from-DB -> silent;
  key agreeing-with-DB -> silent; genuine conflict -> one aggregated line;
  multiple conflicts -> one line naming each key; overlay-scoped conflict -> one line.
  Observed RED on the pre-fix code (the over-warning + `assert 3 == 1`), GREEN after.
- `uv run pytest tests/config/` -> 255 passed. `tests/teatree_quality/` -> 66 passed.
- `tach check` clean; `check_module_health.py --from-ref origin/main` exit 0;
  `ruff check` / `ruff format --check` clean; full prek suite green on commit.
- Manual: loading the real cleaned `~/.teatree.toml` emits **zero** per-key warnings;
  an injected `mode` conflict (DB `interactive` vs TOML `auto`) produces exactly one
  aggregated line naming only `[teatree] mode`, with a co-present DB-rowless
  `repo_mode` correctly staying silent.

## Architecture pre-check

**1. BLUEPRINT § alignment** — `docs/blueprint/configuration.md` (the #1775 DB/TOML
hard-partition config section). The stale "one WARNING per offending key" prose is
updated in the same change to describe the conflict-only, single-aggregated-line
behavior.

**2. FSM phase boundaries** — n/a (no `Ticket`/`Worktree` state transition).

**3. Extension-point contracts** — n/a (no `OverlayBase` hook, scanner, or Protocol
surface touched). Reuses the existing DB-home readers `_db_global_overrides` /
`_db_overlay_overrides` and the `OVERLAY_OVERRIDABLE_SETTINGS` parser registry.

**4. Component boundaries** — `src/teatree/config/loader.py` (config layer). The new
helpers (`_parse_toml_value`, `_conflicting_db_home_keys`) sit next to the existing
warn entry point; no new module.

**5. Dependency direction** — no backwards edge. The DB readers are reached via a
lazy in-function import of `teatree.config.resolution` (the loader -> resolution
deferral the module docstring already documents, to avoid the
loader/resolution/discovery import cycle). `tach check` clean.

**6. Test surface** — `tests/config/test_load_config.py::TestDbHomeTomlConflictWarning`
asserts: zero warnings on a clean DB-home config, silence for absent/agreeing keys,
a single aggregated warning on a genuine conflict (global + overlay scope), and the
one-line aggregation across multiple conflicts. Each fix-guarding assertion was
observed RED on the pre-fix code.

**7. Resilience invariants** — no external write; the path only emits a log line.
The DB read is fail-safe (`_db_*_overrides` -> `{}` on any unconfigured/early read),
so a pre-Django or DB-unreachable `load_config` simply finds no conflicts and stays
silent — never raises in the hot config path.

**8. Identity / key normalization** — keys are the canonical `UserSettings` field
names on both sides (TOML table key == `ConfigSetting.key`); no qualifier stripping.
Values are canonicalized UP through the shared parser registry before comparison.

**9. Behavior preservation / capability deletion** — the removed capability is the
*unconditional* per-key warning. It is replaced, not silently narrowed: the visible
signal is preserved for the case that matters (a genuine conflict) and intentionally
dropped for the no-op cases (absent / agreeing) that produced the noise. No
privacy/leak/security matcher is involved; no must-block test was inverted — the two
old unconditional-warn tests are replaced by the conflict-scoped suite above.
