### PR TITLE
fix(loop): make the Stop self-pump work probe budget-aware so it advances (TODO #100)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -3097,9 +3097,16 @@ Usage: t3 loop pending-spawn [OPTIONS]
  Stop-hook self-pump); the ``/loop`` slot should drive dispatch with
  ``claim-next``, not this + ``spawn-claim``.
 
+ ``--claimable-only`` (TODO #100) makes the probe budget-aware: it
+ reports work ONLY when a unit ``claim-next`` could actually claim,
+ so the Stop-hook self-pump stops re-offering a PENDING unit that a
+ full in-flight admit budget will always refuse.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --json          Emit pending list as JSON.                                   │
-│ --help          Show this message and exit.                                  │
+│ --json                    Emit pending list as JSON.                         │
+│ --claimable-only          Report work ONLY when a claim could land (honour   │
+│                           the admit budget).                                 │
+│ --help                    Show this message and exit.                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -5653,18 +5653,18 @@ _SELF_PUMP_PREVIEW = 5
 
 
 def _consolidated_pending_work() -> list[dict]:
-    """Return the loop's pending-spawn work via ``t3 loop pending-spawn --json``.
+    """Return the loop's CLAIMABLE pending work via ``t3 loop pending-spawn``.
 
-    Pure read of the existing dispatch seam — no new state. ``[]`` on any
-    failure (no ``t3``, timeout, non-zero, malformed) so the self-pump
-    fails safe to "idle" rather than spinning on a broken read.
+    ``--claimable-only`` (TODO #100) makes the probe budget-aware so a unit
+    a full in-flight budget will refuse never re-arms the self-pump (the
+    un-advanceable re-offer). ``[]`` on any failure so it fails safe to idle.
     """
     t3_bin = shutil.which("t3")
     if not t3_bin:
         return []
     try:
         result = subprocess.run(  # noqa: S603
-            [t3_bin, "loop", "pending-spawn", "--json"],
+            [t3_bin, "loop", "pending-spawn", "--json", "--claimable-only"],
             capture_output=True,
             text=True,
             timeout=_SELF_PUMP_PENDING_TIMEOUT,

--- a/src/teatree/cli/loop.py
+++ b/src/teatree/cli/loop.py
@@ -117,6 +117,11 @@ def status_command() -> None:
 def pending_spawn_command(
     *,
     json_output: bool = typer.Option(False, "--json", help="Emit pending list as JSON."),
+    claimable_only: bool = typer.Option(
+        False,
+        "--claimable-only",
+        help="Report work ONLY when a claim could land (honour the admit budget).",
+    ),
 ) -> None:
     """List pending Tasks (read-only probe; legacy — prefer ``claim-next``).
 
@@ -128,6 +133,11 @@ def pending_spawn_command(
     and as a non-mutating "is there pending work?" probe (e.g. the
     Stop-hook self-pump); the ``/loop`` slot should drive dispatch with
     ``claim-next``, not this + ``spawn-claim``.
+
+    ``--claimable-only`` (TODO #100) makes the probe budget-aware: it
+    reports work ONLY when a unit ``claim-next`` could actually claim,
+    so the Stop-hook self-pump stops re-offering a PENDING unit that a
+    full in-flight admit budget will always refuse.
     """
     ensure_django()
 
@@ -136,6 +146,8 @@ def pending_spawn_command(
     kwargs: dict[str, bool] = {}
     if json_output:
         kwargs["json_output"] = True
+    if claimable_only:
+        kwargs["claimable_only"] = True
     call_command("loop_dispatch", "pending-spawn", **kwargs)
 
 

--- a/src/teatree/core/management/commands/loop_dispatch.py
+++ b/src/teatree/core/management/commands/loop_dispatch.py
@@ -191,6 +191,13 @@ class Command(TyperCommand):
             bool,
             typer.Option("--json", help="Emit the pending list as JSON instead of a table."),
         ] = False,
+        claimable_only: Annotated[
+            bool,
+            typer.Option(
+                "--claimable-only",
+                help="Report work ONLY when a claim could land (honour the admit budget).",
+            ),
+        ] = False,
     ) -> None:
         """List pending Tasks the ``/loop`` slot should spawn in-session.
 
@@ -198,9 +205,22 @@ class Command(TyperCommand):
         ``subagent`` field tells the slot which subagent_type to pass
         to its ``Agent`` tool; an empty string means the role+phase pair
         has no registered subagent (operator triage).
+
+        ``--claimable-only`` (TODO #100) applies the SAME admit-budget gate
+        ``claim-next`` applies, so the probe answers "is there a unit a claim
+        could actually take?" rather than "is there any dispatchable PENDING
+        row?". The Stop-hook self-pump uses it: without the gate the probe
+        reports an un-advanceable unit (one held back by a full in-flight
+        budget) forever, so the self-pump re-offers a unit ``claim-next``
+        would always refuse — it never advances or stops. The gate
+        fails OPEN (unclamped) on an absent / stale / unreadable budget,
+        identical to the claimer.
         """
-        pending = Task.objects.filter(status=Task.Status.PENDING).select_related("ticket").order_by("pk")
-        payload = [_task_to_dict(task) for task in pending if _subagent_for(task)]
+        if claimable_only and _admit_budget_exhausted():
+            payload: list[dict[str, Any]] = []
+        else:
+            pending = Task.objects.filter(status=Task.Status.PENDING).select_related("ticket").order_by("pk")
+            payload = [_task_to_dict(task) for task in pending if _subagent_for(task)]
         if json_output:
             self.stdout.write(json.dumps(payload, indent=2))
             return

--- a/tests/teatree_cli/test_cli_loop.py
+++ b/tests/teatree_cli/test_cli_loop.py
@@ -50,6 +50,45 @@ class TestTickCommandDelegation:
         call_mock.assert_called_once_with("loop_tick")
 
 
+class TestPendingSpawnCommandDelegation:
+    # [skill-load-ok: pure CLI delegation test, no web framework involved]
+    """``t3 loop pending-spawn`` forwards its flags to the management command.
+
+    TODO #100: ``--claimable-only`` makes the Stop-hook self-pump's probe
+    budget-aware so it stops re-offering an un-advanceable PENDING unit.
+    """
+
+    def test_no_flags_calls_with_empty_kwargs(self) -> None:
+        with (
+            patch("django.setup"),
+            patch("django.core.management.call_command") as call_mock,
+        ):
+            result = runner.invoke(loop_app, ["pending-spawn"])
+
+        assert result.exit_code == 0
+        call_mock.assert_called_once_with("loop_dispatch", "pending-spawn")
+
+    def test_json_flag_forwarded(self) -> None:
+        with (
+            patch("django.setup"),
+            patch("django.core.management.call_command") as call_mock,
+        ):
+            result = runner.invoke(loop_app, ["pending-spawn", "--json"])
+
+        assert result.exit_code == 0
+        call_mock.assert_called_once_with("loop_dispatch", "pending-spawn", json_output=True)
+
+    def test_claimable_only_flag_forwarded(self) -> None:
+        with (
+            patch("django.setup"),
+            patch("django.core.management.call_command") as call_mock,
+        ):
+            result = runner.invoke(loop_app, ["pending-spawn", "--json", "--claimable-only"])
+
+        assert result.exit_code == 0
+        call_mock.assert_called_once_with("loop_dispatch", "pending-spawn", json_output=True, claimable_only=True)
+
+
 class TestStatusCommand:
     def test_returns_one_when_no_statusline_file_yet(self, tmp_path: Path) -> None:
         with patch("teatree.cli.loop.default_path", return_value=tmp_path / "missing.txt"):

--- a/tests/teatree_core/test_loop_dispatch_command.py
+++ b/tests/teatree_core/test_loop_dispatch_command.py
@@ -397,6 +397,111 @@ class TestClaimNextAdmitBudgetGate(_LoopDispatchTest):
         assert Task.objects.filter(status=Task.Status.PENDING).count() == 2
 
 
+class TestPendingSpawnClaimableOnly(_LoopDispatchTest):
+    """``pending-spawn --claimable-only`` mirrors what ``claim-next`` would take.
+
+    TODO #100: the Stop-hook self-pump probes ``pending-spawn`` to decide
+    "is there work to continue the loop?". The legacy probe reports EVERY
+    dispatchable PENDING task regardless of the admit budget, but
+    ``claim-next`` refuses once the in-flight CLAIMED WIP reaches the
+    ceiling. So when the budget is exhausted, the probe reports the same
+    PENDING unit forever while ``claim-next`` claims nothing — the
+    self-pump re-offers a unit it can never advance. ``--claimable-only``
+    applies the same admit-budget gate the claimer applies, so the probe
+    reports work ONLY when a claim could actually land.
+    """
+
+    def _claim_in_flight(self, n: int) -> list[Task]:
+        claimed: list[Task] = []
+        for i in range(n):
+            task = self._author_task(url=f"https://example.com/issues/inflight/{i}")
+            task.claim(claimed_by="other-worker")
+            claimed.append(task)
+        return claimed
+
+    def _run_pending_claimable(self, sl: Path) -> list[dict]:
+        stdout = StringIO()
+        with patch("teatree.core.management.commands.loop_dispatch.default_path", return_value=sl):
+            call_command("loop_dispatch", "pending-spawn", "--json", "--claimable-only", stdout=stdout)
+        return json.loads(stdout.getvalue())
+
+    def test_budget_exhausted_reports_no_claimable_work(self) -> None:
+        # THE anti-vacuous core (RED on the pre-fix code): budget B, B already
+        # in flight, one more PENDING → claim-next would refuse → the
+        # claimable-only probe must report ZERO so the self-pump stops
+        # re-offering the un-advanceable unit.
+        from teatree.loop.admit_budget import write_admit_budget  # noqa: PLC0415
+
+        with tempfile.TemporaryDirectory() as d:
+            sl = Path(d) / "statusline.txt"
+            self._claim_in_flight(2)
+            self._author_task(url="https://example.com/issues/pending")
+            write_admit_budget(2, statusline_path=sl)
+            payload = self._run_pending_claimable(sl)
+        assert payload == []
+        # The legacy probe (no gate) still reports the un-advanceable unit —
+        # proving the gate is what changed the answer, not the data.
+        legacy = StringIO()
+        call_command("loop_dispatch", "pending-spawn", "--json", stdout=legacy)
+        assert len(json.loads(legacy.getvalue())) == 1
+
+    def test_under_budget_reports_the_claimable_unit(self) -> None:
+        # Control: in-flight 1 < budget 2 → a claim could land → the probe
+        # reports the PENDING unit (it did not just blanket-suppress).
+        from teatree.loop.admit_budget import write_admit_budget  # noqa: PLC0415
+
+        with tempfile.TemporaryDirectory() as d:
+            sl = Path(d) / "statusline.txt"
+            self._claim_in_flight(1)
+            self._author_task(url="https://example.com/issues/pending")
+            write_admit_budget(2, statusline_path=sl)
+            payload = self._run_pending_claimable(sl)
+        assert len(payload) == 1
+        assert payload[0]["issue_url"] == "https://example.com/issues/pending"
+
+    def test_no_budget_key_reports_all_dispatchable_unclamped(self) -> None:
+        # Absence of a budget (medium / toggle-off) is UNCLAMPED — the probe
+        # reports the pending unit exactly as the legacy probe does today.
+        with tempfile.TemporaryDirectory() as d:
+            sl = Path(d) / "statusline.txt"
+            self._author_task(url="https://example.com/issues/a")
+            payload = self._run_pending_claimable(sl)
+        assert len(payload) == 1
+
+    def test_budget_read_error_fails_open_unclamped(self) -> None:
+        # A budget-read failure must NEVER clamp the probe — fail open so a
+        # broken sidecar read can never wedge the self-pump into idle.
+        with tempfile.TemporaryDirectory() as d:
+            sl = Path(d) / "statusline.txt"
+            self._author_task(url="https://example.com/issues/a")
+            stdout = StringIO()
+            with (
+                patch("teatree.core.management.commands.loop_dispatch.default_path", return_value=sl),
+                patch(
+                    "teatree.core.management.commands.loop_dispatch.read_admit_budget",
+                    side_effect=RuntimeError("sidecar exploded"),
+                ),
+            ):
+                call_command("loop_dispatch", "pending-spawn", "--json", "--claimable-only", stdout=stdout)
+            assert len(json.loads(stdout.getvalue())) == 1
+
+    def test_default_probe_is_unchanged_no_gate(self) -> None:
+        # Without --claimable-only the legacy probe is byte-identical: it
+        # reports the un-advanceable unit even at a full budget (the legacy
+        # callers must not change behaviour).
+        from teatree.loop.admit_budget import write_admit_budget  # noqa: PLC0415
+
+        with tempfile.TemporaryDirectory() as d:
+            sl = Path(d) / "statusline.txt"
+            self._claim_in_flight(2)
+            self._author_task(url="https://example.com/issues/pending")
+            write_admit_budget(2, statusline_path=sl)
+            stdout = StringIO()
+            with patch("teatree.core.management.commands.loop_dispatch.default_path", return_value=sl):
+                call_command("loop_dispatch", "pending-spawn", "--json", stdout=stdout)
+        assert len(json.loads(stdout.getvalue())) == 1
+
+
 class TestSpawnClaim(_LoopDispatchTest):
     def test_claims_pending_task(self) -> None:
         task = self._reviewer_task()

--- a/tests/test_loop_self_pump_hook.py
+++ b/tests/test_loop_self_pump_hook.py
@@ -27,6 +27,7 @@ import sys
 import time
 from collections.abc import Iterator
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -596,6 +597,70 @@ class TestStopHookFailsSafeWithoutTeatree:
 
         assert result is None
         assert _decision(capsys) == {}
+
+
+class TestConsolidatedPendingWorkIsClaimAware:
+    """TODO #100: the self-pump's work probe must be claim/budget-aware.
+
+    The self-pump re-offered the SAME unit every interval because its
+    probe (``t3 loop pending-spawn``) reported EVERY dispatchable PENDING
+    task regardless of the admit budget, while ``claim-next`` refuses once
+    the in-flight WIP hits the ceiling. So a unit held back by a full
+    budget showed as "pending work" forever and the pump re-offered it,
+    never advancing. The probe must invoke ``--claimable-only`` so it
+    answers "is there a unit a claim could actually take?".
+    """
+
+    def _run_with_fake_t3(
+        self, monkeypatch: pytest.MonkeyPatch, *, stdout: str, returncode: int = 0
+    ) -> tuple[list[dict], list[str]]:
+        captured: list[str] = []
+
+        def _fake_run(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
+            captured.extend(cmd)
+            return SimpleNamespace(returncode=returncode, stdout=stdout)
+
+        monkeypatch.setattr(router.shutil, "which", lambda _name: "/usr/bin/t3")
+        monkeypatch.setattr(router.subprocess, "run", _fake_run)
+        result = router._consolidated_pending_work()
+        return result, captured
+
+    def test_probe_passes_claimable_only_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The must-not-re-offer contract: the probe is invoked with
+        # --claimable-only so a budget-blocked unit never re-arms the pump.
+        _result, cmd = self._run_with_fake_t3(
+            monkeypatch,
+            stdout=json.dumps([{"task_id": 1, "subagent": "x", "phase": "coding", "issue_url": "u"}]),
+        )
+        assert cmd[:2] == ["/usr/bin/t3", "loop"]
+        assert "pending-spawn" in cmd
+        assert "--claimable-only" in cmd
+
+    def test_empty_claimable_result_makes_owner_not_pump(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # ADVANCE-OR-STOP: when the budget-aware probe reports nothing
+        # claimable (budget exhausted), the owner does NOT re-offer — the
+        # session stops instead of looping on the un-advanceable unit.
+        _own_loop("owner-1")
+        self._run_with_fake_t3(monkeypatch, stdout="[]")  # primes which/run fakes
+        result = handle_loop_self_pump({"session_id": "owner-1"})
+        assert _decision(capsys) == {}
+        assert result is not True
+
+    def test_claimable_work_still_pumps(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Control: a genuinely claimable unit still pumps — the fix narrowed
+        # the probe, it did not disable the pump.
+        _own_loop("owner-1")
+        stdout = json.dumps([{"task_id": 5, "subagent": "x", "phase": "coding", "issue_url": "u"}])
+        monkeypatch.setattr(router.shutil, "which", lambda _name: "/usr/bin/t3")
+        monkeypatch.setattr(router.subprocess, "run", lambda *_a, **_k: SimpleNamespace(returncode=0, stdout=stdout))
+
+        result = handle_loop_self_pump({"session_id": "owner-1"})
+        assert _decision(capsys).get("decision") == "block"
+        assert result is True
 
 
 class TestWiredIntoRouter:


### PR DESCRIPTION
## What

The Stop-hook self-pump re-offered the same loop unit every interval instead of advancing. Its work-detection probe `_consolidated_pending_work` shelled out to `t3 loop pending-spawn`, which lists **every** dispatchable PENDING task regardless of the admit budget, while `claim-next` refuses once the in-flight CLAIMED WIP reaches the ceiling. So a PENDING unit held back by a full in-flight budget showed as "pending work" forever and the pump re-armed on it every interval, while `claim-next` claimed nothing — the loop never advanced or stopped.

## How

- Add `--claimable-only` to `loop_dispatch pending-spawn` (and thread it through `t3 loop pending-spawn`). It applies the **same** `_admit_budget_exhausted()` gate the claimer applies, so the probe answers "is there a unit a claim could actually take?" rather than "is there any dispatchable PENDING row?".
- The self-pump's probe now invokes `--claimable-only`, so a budget-exhausted state reports nothing and the session stops instead of re-offering an un-advanceable unit.
- The gate fails OPEN (unclamped) on an absent / stale / unreadable budget, so today's drain throughput is byte-identical, and the legacy probe (no flag) is unchanged.

## Tests

Symmetric, both verified RED before the fix:
- **must-advance**: under-budget reports the claimable unit; the owner still pumps.
- **must-not-re-offer**: budget-exhausted reports nothing; the owner stops; the probe is invoked with `--claimable-only`.

Command-level (`TestPendingSpawnClaimableOnly`), self-pump-level (`TestConsolidatedPendingWorkIsClaimAware`), and CLI delegation (`TestPendingSpawnCommandDelegation`). Full regression suite green (one unrelated pre-existing `jscpd` infra error — Node `jscpd` tool absent in this env — outside the diff).

## Architecture pre-check — TODO #100

### 1. BLUEPRINT § alignment
§5.6 Loop Topology / §17.4 (orchestrator-decides / loop-executes). The admit budget the orchestrate phase persists (`#1796`) must gate the self-pump's *work-detection*, not just the claim — the probe and the claimer now share one budget view.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition. The change is at the dispatch-queue read seam.

### 3. Extension-point contracts
n/a — no `OverlayBase` / scanner / hook-surface / Protocol change. A new optional CLI flag on an existing read command.

### 4. Component boundaries
- `src/teatree/core/management/commands/loop_dispatch.py` — the gate (`claimable_only and _admit_budget_exhausted()`), reusing the existing `_admit_budget_exhausted()` the claimer already uses.
- `src/teatree/cli/loop.py` — flag pass-through (CLI coordination only).
- `hooks/scripts/hook_router.py` — the self-pump probe passes `--claimable-only` (string change, net-zero LOC on the capped god-module).

### 5. Dependency direction
No new imports; reuses `_admit_budget_exhausted` already in the command module. No backwards edge.

### 6. Test surface
- `tests/teatree_core/test_loop_dispatch_command.py::TestPendingSpawnClaimableOnly` — budget-exhausted reports `[]`, under-budget reports the unit, no-budget unclamped, read-error fails open, legacy probe unchanged.
- `tests/test_loop_self_pump_hook.py::TestConsolidatedPendingWorkIsClaimAware` — probe invoked with `--claimable-only`; empty claimable ⇒ owner does not pump; claimable work ⇒ owner still pumps.
- `tests/teatree_cli/test_cli_loop.py::TestPendingSpawnCommandDelegation` — flag forwarded to the management command.

### 7. Resilience invariants
Idempotency: the probe is a pure read (no mutation), so repeated firing is a no-op on state — the fix removes the spurious re-arm. Fallback / fail-open: the budget gate fails OPEN (unclamped) on absent/stale/unreadable budget, so a broken sidecar can never wedge the pump into idle.

### 8. Identity and key normalization
n/a — no bare-vs-qualified identity in play.

### 9. Behavior preservation / capability deletion
Purely additive: the legacy `pending-spawn` (no flag) is byte-identical (covered by `test_default_probe_is_unchanged_no_gate`). The only behaviour *removed* is the un-advanceable re-offer, which was the bug.
