### PR TITLE
fix(eval): structural negative-matcher-pairing gate + #2192 follow-up nits

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -1130,7 +1130,13 @@ Supported matcher operators:
   prevent the scenario from being satisfied vacuously by a no-op
   transcript.
 - `no_tool_call_matching: { <tool>.<arg>: ~ "<regex>" }` — no matching
-  tool call may exist.
+  tool call may exist. A negative matcher MUST be paired with a positive
+  anchor (a `tool_call` / `any_of` / `final_state` matcher) in the same
+  `expect` list — a negative-only scenario is satisfied by a no-op agent and
+  guards nothing. `tests/eval_replay/test_scenarios_anti_vacuous.py`
+  (`test_no_scenario_has_a_negative_matcher_without_a_positive_anchor`,
+  predicate in `teatree.eval.matcher_vacuity`) makes the unpaired shape a
+  fast structural RED, alongside the runtime no-op gate.
 - `any_of: [ <tool_call branch>, ... ]` — a disjunction of positive
   `tool_call` branches; the entry passes when **any** branch holds. Use it
   to pin a rule that a documented set of equally-valid actions satisfies —

--- a/src/teatree/core/migrations/0066_sessionauditrecord.py
+++ b/src/teatree/core/migrations/0066_sessionauditrecord.py
@@ -34,7 +34,9 @@ class CreateModelIfTableAbsent(migrations.CreateModel):
         from_state: ProjectState,
         to_state: ProjectState,
     ) -> None:
-        existing = set(schema_editor.connection.introspection.table_names(schema_editor.connection.cursor()))
+        # ``table_names()`` opens and closes its own cursor in a context manager
+        # when none is passed -- do not hand it a cursor we would leak (#2279).
+        existing = set(schema_editor.connection.introspection.table_names())
         if _AUDIT_TABLE in existing:
             return
         super().database_forwards(app_label, schema_editor, from_state, to_state)

--- a/src/teatree/eval/conversation_audit.py
+++ b/src/teatree/eval/conversation_audit.py
@@ -46,7 +46,7 @@ from pathlib import Path
 
 from teatree.core.models import EvalVerdict, InvariantOutcome, SessionAuditRecord
 from teatree.eval.audit_persistence import persist_audit
-from teatree.eval.corpus_grade import assert_independent_oracle, grade
+from teatree.eval.corpus_grade import CircularOracleError, assert_independent_oracle, grade
 from teatree.eval.corpus_loader import CORPUS_DIR, discover_corpus
 from teatree.eval.corpus_models import CorpusLabel
 from teatree.eval.gate_failures import GateVerdict, classify_gate_failure, extract_gate_failures
@@ -185,7 +185,10 @@ def _graded_record(
     *,
     judge: JudgeGrader | None,
 ) -> SessionAuditRecord:
-    assert_independent_oracle(label)
+    try:
+        assert_independent_oracle(label, judge_present=judge is not None)
+    except CircularOracleError:
+        return _circular_fail_record(audit_input, label, analysis)
     if _needs_judge_but_absent(label, judge):
         return _unjudged_record(audit_input, label, analysis)
     result = grade(label, audit_input.events, judge=judge)
@@ -219,6 +222,29 @@ def _needs_judge_but_absent(label: CorpusLabel, judge: JudgeGrader | None) -> bo
     if judge is not None:
         return False
     return label.oracle == "judge" or (label.oracle == "both" and not label.matchers)
+
+
+def _circular_fail_record(audit_input: AuditInput, label: CorpusLabel, analysis: _Analysis) -> SessionAuditRecord:
+    """A FAIL record for a circular matcher oracle — mirrors ``cli/eval/corpus.py::_grade_row``.
+
+    A label graded only by matchers whose labeller authored the rule cannot
+    disagree with the rule, so it FAILs (never silently passes) and is always
+    nominated: a human (with an independent judge) should re-grade it. Degrading
+    to a record rather than letting :class:`CircularOracleError` crash the whole
+    batch keeps one bad label from aborting every other session's audit.
+    """
+    return SessionAuditRecord(
+        session_id=audit_input.session_id,
+        corpus_entry_id=label.entry_id,
+        outcome_axis=label.outcome_axis,
+        expected_outcome=label.expected_outcome,
+        predicted_outcome=_predicted_outcome(label, EvalVerdict.FAIL),
+        verdict=EvalVerdict.FAIL,
+        oracle=label.oracle,
+        invariant_results=analysis.invariant_outcomes,
+        gate_failure_slugs=analysis.gate_slugs,
+        nominated_for_label=True,
+    )
 
 
 def _unjudged_record(audit_input: AuditInput, label: CorpusLabel, analysis: _Analysis) -> SessionAuditRecord:

--- a/src/teatree/eval/matcher_vacuity.py
+++ b/src/teatree/eval/matcher_vacuity.py
@@ -1,0 +1,63 @@
+"""Structural vacuity guard: a negative matcher must have a positive anchor.
+
+A behavioral scenario graded ONLY by negative matchers (``no_tool_call_matching``)
+is vacuously satisfied by a no-op agent: a do-nothing agent trivially never makes
+the forbidden tool call, so the scenario reads green while guarding nothing
+(#2441). The runtime ``_noop`` gate in ``test_scenarios_anti_vacuous.py`` already
+catches this by replaying every spec against a no-op transcript; this module is
+the *structural* sibling that makes the vacuous shape a fast, fixture-free RED —
+the offending ``expect`` list is flagged at load time, before any fixture runs.
+
+A **positive anchor** is any matcher that forces the agent to *do* something a
+no-op cannot satisfy:
+
+*   a positive :class:`~teatree.eval.models.Matcher` (a matching tool call must
+    exist),
+*   an :class:`~teatree.eval.models.AnyOf` (a disjunction of positive
+    alternatives — at least one matching call must exist), or
+*   a :class:`~teatree.eval.models.FinalStateMatcher` (the final assistant
+    message must carry specific content).
+
+A scenario carrying at least one negative matcher and no positive anchor is the
+vacuous class this guard flags. A matcherless (judge-only) scenario carries no
+negative matcher, so it is exempt — there is nothing to pair.
+"""
+
+from teatree.eval.models import AnyOf, EvalSpec, ExpectItem, FinalStateMatcher, Matcher
+
+
+def is_positive_anchor(matcher: ExpectItem) -> bool:
+    """Whether ``matcher`` forces the agent to act (breaking no-op vacuity).
+
+    A positive ``Matcher``, an ``AnyOf`` disjunction, and a ``FinalStateMatcher``
+    each require the agent to produce something a do-nothing run cannot. A
+    negative ``Matcher`` is satisfied by inaction, so it is NOT an anchor.
+    """
+    if isinstance(matcher, AnyOf | FinalStateMatcher):
+        return True
+    return isinstance(matcher, Matcher) and matcher.kind == "positive"
+
+
+def has_negative_matcher(spec: EvalSpec) -> bool:
+    """Whether ``spec`` carries at least one negative (``no_tool_call_matching``) matcher."""
+    return any(isinstance(m, Matcher) and m.kind == "negative" for m in spec.matchers)
+
+
+def has_positive_anchor(spec: EvalSpec) -> bool:
+    """Whether ``spec`` has at least one positive anchor in its ``expect`` list."""
+    return any(is_positive_anchor(m) for m in spec.matchers)
+
+
+def is_negative_only(spec: EvalSpec) -> bool:
+    """Whether ``spec`` carries a negative matcher but no positive anchor — the vacuous class."""
+    return has_negative_matcher(spec) and not has_positive_anchor(spec)
+
+
+def negative_only_specs(specs: list[EvalSpec]) -> list[EvalSpec]:
+    """The offenders: specs with a negative matcher and no positive anchor.
+
+    A negative-only scenario is satisfied by a no-op agent, so it guards nothing.
+    The gate (``test_scenarios_anti_vacuous.py``) consumes this and fails loud,
+    naming each offender, so the vacuous shape can never reach the suite green.
+    """
+    return [spec for spec in specs if is_negative_only(spec)]

--- a/src/teatree/eval/transcript.py
+++ b/src/teatree/eval/transcript.py
@@ -50,6 +50,14 @@ _DATE_SUFFIX_RE = re.compile(r"-\d{8}$")
 #: normalized UP to the canonical full id at the same chokepoint a dated
 #: ``model_usage`` key is normalized DOWN — otherwise ``opus`` never matches the
 #: ``claude-opus-4-8`` usage key and fallback detection / the cost split break.
+#:
+#: GENERATION BUMP: these full ids are the current model generation and will
+#: stale on the next generation. They are the same ids the sibling eval-layer
+#: defaults carry — ``eval.loader.DEFAULT_MODEL`` / ``DEFAULT_JUDGE_MODEL``,
+#: ``eval.sdk_runner.FALLBACK_MODEL``, and ``eval.models.EvalSpec.model`` /
+#: ``JudgeSpec.model``. Bump all of those together; ``core.cost.PRICE_TABLE``
+#: keys on the short tier name (``opus``), so it prices a dated bump correctly
+#: without a new entry and is NOT part of this set.
 _SHORT_ALIAS_TO_BASE: dict[str, str] = {
     "opus": "claude-opus-4-8",
     "sonnet": "claude-sonnet-4-6",

--- a/tests/eval_replay/test_scenarios_anti_vacuous.py
+++ b/tests/eval_replay/test_scenarios_anti_vacuous.py
@@ -32,7 +32,8 @@ import pytest
 
 from teatree.eval.backends import SubscriptionTranscriptRunner
 from teatree.eval.discovery import discover_specs
-from teatree.eval.models import EvalSpec, Matcher
+from teatree.eval.matcher_vacuity import negative_only_specs
+from teatree.eval.models import AnyOf, EvalSpec, FinalStateMatcher, Matcher
 from teatree.eval.report import evaluate
 from teatree.eval.sdk_runner import load_agent_definition
 
@@ -306,6 +307,68 @@ def test_noop_gate_flags_an_only_negative_scenario(tmp_path: Path) -> None:
             "the no-op gate must NOT flag a scenario with a positive matcher — a no-op "
             "transcript cannot satisfy a required tool call, so it is non-vacuous."
         )
+
+
+def test_no_scenario_has_a_negative_matcher_without_a_positive_anchor() -> None:
+    """Structural gate: a negative matcher must be paired with a positive anchor (#2441).
+
+    A scenario graded ONLY by negative matchers (``no_tool_call_matching``) is
+    vacuously satisfied by a no-op agent — a do-nothing run trivially never makes
+    the forbidden tool call, so the scenario reads green while guarding nothing.
+    The runtime ``_noop`` gate above
+    (:func:`test_no_scenario_is_satisfied_by_a_noop_transcript`) already catches
+    this by replaying every spec against a no-op transcript; this is the
+    *structural* sibling that makes the vacuous shape a fast, fixture-free RED.
+
+    A negative matcher is non-vacuous only when paired with a positive anchor — a
+    positive ``tool_call``/``any_of`` matcher or a ``final_state`` matcher that
+    forces the agent to *do* something the no-op cannot. The gate fails loud,
+    naming each offender, so the negative-only shape can never reach the suite
+    green.
+    """
+    offenders = negative_only_specs(discover_specs())
+    assert not offenders, (
+        "behavioral scenario(s) carry a negative matcher (`no_tool_call_matching`) but no "
+        "positive anchor, so a no-op agent satisfies them — they are vacuous. Pair each "
+        "negative matcher with a positive `tool_call`/`any_of`/`final_state` matcher that "
+        "requires the expected action for each:\n"
+        + "\n".join(f"  - {spec.name} ({spec.source_path.name})" for spec in offenders)
+    )
+
+
+def test_negative_only_gate_flags_an_only_negative_scenario() -> None:
+    """Anti-vacuity proof for the structural negative-pairing gate (#2441).
+
+    A synthetic scenario whose only matchers are NEGATIVE must be flagged by the
+    gate predicate; a scenario that pairs a negative with a positive anchor (and a
+    judge-only scenario carrying no matcher at all) must NOT. If the gate were
+    weakened — e.g. predicate reverted to ``return []`` — the first assertion
+    fails, so the proof exercises the real predicate, not a re-implementation.
+    """
+    negative = Matcher(kind="negative", tool="Bash", arg_path="command", operator="~", value="forbidden")
+    positive = Matcher(kind="positive", tool="Bash", arg_path="command", operator="~", value="git push")
+
+    only_negative = _fake_spec(name="__synthetic_negative_only__", matchers=(negative,))
+    paired_with_positive = _fake_spec(name="__synthetic_paired_positive__", matchers=(positive, negative))
+    paired_with_any_of = _fake_spec(
+        name="__synthetic_paired_any_of__", matchers=(AnyOf(alternatives=(positive,)), negative)
+    )
+    paired_with_final = _fake_spec(
+        name="__synthetic_paired_final__", matchers=(FinalStateMatcher(operator="~", value="(?i)done"), negative)
+    )
+    judge_only = _fake_spec(name="__synthetic_judge_only_vac__", matchers=())
+
+    flagged = negative_only_specs(
+        [only_negative, paired_with_positive, paired_with_any_of, paired_with_final, judge_only]
+    )
+    assert only_negative in flagged, (
+        "the negative-pairing gate must FLAG an only-negative scenario (a no-op agent satisfies it); "
+        "it did not — the vacuity guard is weakened."
+    )
+    assert paired_with_positive not in flagged, "a negative paired with a positive matcher must NOT be flagged."
+    assert paired_with_any_of not in flagged, "a negative paired with an any_of anchor must NOT be flagged."
+    assert paired_with_final not in flagged, "a negative paired with a final_state anchor must NOT be flagged."
+    assert judge_only not in flagged, "a judge-only (matcherless) scenario carries no negative matcher to pair."
 
 
 def test_every_declared_agent_section_resolves_against_its_skill() -> None:

--- a/tests/teatree_eval/test_conversation_audit.py
+++ b/tests/teatree_eval/test_conversation_audit.py
@@ -20,7 +20,6 @@ from teatree.eval.conversation_audit import (
     classify_behavior_pattern,
     run_conversation_audit,
 )
-from teatree.eval.corpus_grade import CircularOracleError
 from teatree.eval.corpus_loader import discover_corpus
 from teatree.eval.corpus_models import CorpusLabel
 from teatree.eval.report import JudgeOutcome
@@ -89,7 +88,10 @@ class TestAuditCorpusMatchedSession(TestCase):
         assert record.expected_outcome == "backgrounded"
         assert record.predicted_outcome == "not_backgrounded"
 
-    def test_refuses_a_circular_matcher_oracle(self) -> None:
+    def test_circular_matcher_oracle_degrades_to_a_fail_record_not_a_crash(self) -> None:
+        # A circular matcher oracle must degrade to a FAIL record, mirroring
+        # `cli/eval/corpus.py::_grade_row`, NOT propagate CircularOracleError
+        # out of audit_session as an uncaught crash (#2279 nit 1).
         circular = CorpusLabel(
             entry_id="circ",
             labelled_by="human:author",
@@ -104,8 +106,48 @@ class TestAuditCorpusMatchedSession(TestCase):
             rule_author="human:author",
         )
         events = parse_session_jsonl(_BG_VIOLATING)
-        with pytest.raises(CircularOracleError):
-            audit_session(AuditInput(session_id="s", events=events, label=circular))
+        record = audit_session(AuditInput(session_id="s", events=events, label=circular))
+        assert record.verdict == EvalVerdict.FAIL
+        assert record.corpus_entry_id == "circ"
+        assert record.predicted_outcome == "not_ok"
+        assert record.nominated_for_label is True
+
+    def test_both_oracle_with_a_judge_is_not_refused_as_circular(self) -> None:
+        # assert_independent_oracle treats a `both` oracle as matcher-only ONLY
+        # when no judge is present. A `both` label graded WITH a judge has an
+        # independent grader, so it must NOT be refused — passing
+        # judge_present=judge is not None is what conveys that (#2279 nit 1).
+        both_same_author = CorpusLabel(
+            entry_id="both-judge",
+            labelled_by="human:author",
+            labelled_at="2026-06-09",
+            expected_behavior="x",
+            outcome_axis="ax",
+            expected_outcome="ok",
+            confidence="high",
+            oracle="both",
+            matchers=_label("background_ci_watch").matchers,
+            judge=_label("faithful_explanation").judge,
+            rule_author="human:author",
+        )
+        events = parse_session_jsonl(
+            _assistant(
+                {
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": {"command": "gh run watch", "run_in_background": True},
+                }
+            )
+            + "\n"
+        )
+
+        def _judge(spec: object, run: object) -> JudgeOutcome:
+            return JudgeOutcome(passed=True, skipped=False, rationale="independent grader")
+
+        record = audit_session(AuditInput(session_id="s-both", events=events, label=both_same_author), judge=_judge)
+        assert record.verdict == EvalVerdict.PASS
+        assert record.predicted_outcome == "ok"
 
 
 class TestAuditUnlabelledSession(TestCase):

--- a/tests/teatree_eval/test_matcher_vacuity.py
+++ b/tests/teatree_eval/test_matcher_vacuity.py
@@ -1,0 +1,135 @@
+"""Structural guard: a negative matcher must be paired with a positive anchor.
+
+A behavioral scenario graded ONLY by negative matchers
+(``no_tool_call_matching``) is vacuously satisfied by a no-op agent — an agent
+that does nothing trivially never makes the forbidden tool call, so the scenario
+reads green while guarding nothing (#2441). The existing ``_noop`` runtime gate
+(``test_scenarios_anti_vacuous.py``) catches this by replaying every spec against
+a no-op transcript; this module is the *structural* sibling that makes the
+vacuous shape a fast, fixture-free RED — a negative matcher with no positive
+anchor in the same ``expect`` list is flagged at load time.
+
+A "positive anchor" is any matcher that forces the agent to *do* something the
+no-op cannot satisfy: a positive :class:`~teatree.eval.models.Matcher`, an
+:class:`~teatree.eval.models.AnyOf` (a disjunction of positive alternatives), or
+a :class:`~teatree.eval.models.FinalStateMatcher` (which requires the final
+assistant message to carry specific content).
+"""
+
+from pathlib import Path
+
+from teatree.eval.matcher_vacuity import (
+    has_negative_matcher,
+    has_positive_anchor,
+    is_negative_only,
+    is_positive_anchor,
+    negative_only_specs,
+)
+from teatree.eval.models import AnyOf, EvalSpec, FinalStateMatcher, Matcher
+
+_POSITIVE = Matcher(kind="positive", tool="Bash", arg_path="command", operator="~", value="git push")
+_NEGATIVE = Matcher(kind="negative", tool="Bash", arg_path="command", operator="~", value="--no-verify")
+_ANY_OF = AnyOf(alternatives=(_POSITIVE,))
+_FINAL = FinalStateMatcher(operator="~", value="(?i)done")
+
+
+def _spec(*matchers: object) -> EvalSpec:
+    return EvalSpec(
+        name="__synthetic__",
+        scenario="synthetic",
+        agent_path="skills/rules/SKILL.md",
+        prompt="synthetic",
+        matchers=tuple(matchers),
+        source_path=Path("synthetic.yaml"),
+    )
+
+
+class TestIsPositiveAnchor:
+    def test_positive_matcher_is_an_anchor(self) -> None:
+        assert is_positive_anchor(_POSITIVE) is True
+
+    def test_negative_matcher_is_not_an_anchor(self) -> None:
+        assert is_positive_anchor(_NEGATIVE) is False
+
+    def test_any_of_is_an_anchor(self) -> None:
+        assert is_positive_anchor(_ANY_OF) is True
+
+    def test_final_state_matcher_is_an_anchor(self) -> None:
+        assert is_positive_anchor(_FINAL) is True
+
+
+class TestHasPositiveAnchor:
+    def test_positive_plus_negative_pair_has_an_anchor(self) -> None:
+        assert has_positive_anchor(_spec(_POSITIVE, _NEGATIVE)) is True
+
+    def test_negative_only_has_no_anchor(self) -> None:
+        assert has_positive_anchor(_spec(_NEGATIVE)) is False
+
+    def test_two_negatives_only_has_no_anchor(self) -> None:
+        assert has_positive_anchor(_spec(_NEGATIVE, _NEGATIVE)) is False
+
+    def test_any_of_paired_with_negative_has_an_anchor(self) -> None:
+        assert has_positive_anchor(_spec(_ANY_OF, _NEGATIVE)) is True
+
+    def test_final_state_paired_with_negative_has_an_anchor(self) -> None:
+        assert has_positive_anchor(_spec(_FINAL, _NEGATIVE)) is True
+
+    def test_matcherless_judge_only_spec_has_no_anchor_but_is_not_negative_only(self) -> None:
+        # A matcherless (judge-only) spec carries no negative matcher, so it is
+        # exempt from the pairing rule — ``negative_only_specs`` must not flag it.
+        spec = _spec()
+        assert has_positive_anchor(spec) is False
+        assert spec not in negative_only_specs([spec])
+
+
+class TestHasNegativeMatcher:
+    def test_negative_matcher_is_detected(self) -> None:
+        assert has_negative_matcher(_spec(_NEGATIVE)) is True
+
+    def test_positive_only_has_no_negative_matcher(self) -> None:
+        assert has_negative_matcher(_spec(_POSITIVE)) is False
+
+    def test_anchors_alone_are_not_negative_matchers(self) -> None:
+        # any_of / final_state are positive anchors, never negative matchers.
+        assert has_negative_matcher(_spec(_ANY_OF, _FINAL)) is False
+
+
+class TestIsNegativeOnly:
+    def test_negative_only_spec_is_negative_only(self) -> None:
+        assert is_negative_only(_spec(_NEGATIVE)) is True
+
+    def test_paired_spec_is_not_negative_only(self) -> None:
+        assert is_negative_only(_spec(_POSITIVE, _NEGATIVE)) is False
+
+    def test_positive_only_spec_is_not_negative_only(self) -> None:
+        assert is_negative_only(_spec(_POSITIVE)) is False
+
+    def test_judge_only_spec_is_not_negative_only(self) -> None:
+        assert is_negative_only(_spec()) is False
+
+
+class TestNegativeOnlySpecs:
+    def test_flags_a_negative_only_spec(self) -> None:
+        offender = _spec(_NEGATIVE)
+        assert offender in negative_only_specs([offender])
+
+    def test_does_not_flag_a_paired_spec(self) -> None:
+        paired = _spec(_POSITIVE, _NEGATIVE)
+        assert paired not in negative_only_specs([paired])
+
+    def test_does_not_flag_a_positive_only_spec(self) -> None:
+        positive_only = _spec(_POSITIVE)
+        assert positive_only not in negative_only_specs([positive_only])
+
+    def test_does_not_flag_a_judge_only_spec(self) -> None:
+        judge_only = _spec()
+        assert judge_only not in negative_only_specs([judge_only])
+
+    def test_returns_every_offender_in_a_mixed_catalog(self) -> None:
+        bad_one = _spec(_NEGATIVE)
+        bad_two = _spec(_NEGATIVE, _NEGATIVE)
+        good = _spec(_POSITIVE, _NEGATIVE)
+        offenders = negative_only_specs([bad_one, good, bad_two])
+        assert bad_one in offenders
+        assert bad_two in offenders
+        assert good not in offenders

--- a/tests/test_migration_0066_sessionauditrecord.py
+++ b/tests/test_migration_0066_sessionauditrecord.py
@@ -1,0 +1,48 @@
+"""Regression tests for ``core.0066_sessionauditrecord``.
+
+souliane/teatree#2192: the ``teatree_session_audit`` table was renamed across
+two healed migration forks, so a persistent DB that applied an earlier name
+already holds the table while the renamed migration still looks pending. The
+:class:`CreateModelIfTableAbsent` subclass keeps the model in migration STATE
+but no-ops the DATABASE create when the table is already present — idempotent
+for a fresh DB, a recorder-only no-op for an old-name DB.
+
+The idempotency path runs an introspection ``table_names`` lookup (#2279 nit 2:
+its cursor is now managed by ``table_names`` itself, not leaked). These tests
+exercise that path: a re-run against an already-created table is a no-op, not a
+``table "teatree_session_audit" already exists`` crash.
+"""
+
+import importlib
+
+from django.db import connection
+from django.test import TransactionTestCase
+
+_migration_module = importlib.import_module("teatree.core.migrations.0066_sessionauditrecord")
+
+
+class CreateModelIfTableAbsentMigrationTest(TransactionTestCase):
+    """0066 must no-op the DB create when the audit table already exists."""
+
+    _OPERATION = _migration_module.CreateModelIfTableAbsent
+    _TABLE = _migration_module._AUDIT_TABLE
+
+    def _create_operation(self) -> object:
+        migration = _migration_module.Migration("0066_sessionauditrecord", "core")
+        return migration.operations[0]
+
+    def test_database_forwards_is_a_noop_when_the_table_already_exists(self) -> None:
+        # The table already exists (the test DB is at HEAD). Re-running the create
+        # operation's database_forwards must introspect the live tables, see the
+        # audit table present, and return without re-issuing CREATE TABLE (which
+        # would raise "table already exists").
+        with connection.schema_editor() as schema_editor:
+            existing = set(schema_editor.connection.introspection.table_names())
+            assert self._TABLE in existing
+
+            operation = self._create_operation()
+            assert isinstance(operation, self._OPERATION)
+            operation.database_forwards("core", schema_editor, None, None)
+
+            still_one = [t for t in schema_editor.connection.introspection.table_names() if t == self._TABLE]
+            assert still_one == [self._TABLE]


### PR DESCRIPTION
Closes #2441 and #2279.

## What

### #2441 — negative-only matcher is vacuous (structural gate)
A negative matcher (no_tool_call_matching) with no positive anchor in the same expect list is satisfied by a no-op agent and guards nothing. New teatree.eval.matcher_vacuity predicate flags the negative-only shape; a catalog-wide structural gate (test_no_scenario_has_a_negative_matcher_without_a_positive_anchor in test_scenarios_anti_vacuous.py) makes it a fast, fixture-free RED alongside the existing runtime no-op gate. A positive anchor is a positive tool_call, an any_of, or a final_state matcher. Anti-vacuity proof (test_negative_only_gate_flags_an_only_negative_scenario) confirms the gate flags a synthetic negative-only spec and does not flag a paired one. The live catalog is clean today, so this is regression-prevention.

The issue's matcher-isolation variant (each matcher independently the sole cause of a fail-direction RED) was measured to flag ~134 of 148 multi-matcher scenarios and would demand per-matcher fixtures, far beyond the bounded ask. Scoped to the negative-pairing structural lint per the task; the dynamic no-op gate covers the runtime side.

### #2279 — three #2192 cold-review follow-ups
1. LOW — conversation_audit._graded_record now passes judge_present=judge is not None to assert_independent_oracle and catches CircularOracleError into a degraded FAIL record, matching cli/eval/corpus.py::_grade_row. A both-oracle audited WITH a judge is no longer wrongly refused; a circular matcher oracle degrades to a FAIL record instead of crashing the whole batch.
2. NIT — migration 0066 no longer leaks a cursor: table_names() manages its own context-managed cursor when passed none. New idempotency test pins the already-exists no-op path.
3. NIT — transcript._SHORT_ALIAS_TO_BASE now points at the sibling eval-layer model-id defaults (eval.loader, eval.sdk_runner.FALLBACK_MODEL, eval.models) that must bump together on the next model generation.

## Tests
New test_matcher_vacuity.py (22 tests, 100% module coverage) and test_migration_0066_sessionauditrecord.py; updated test_conversation_audit.py (circular oracle degrades not crashes; new both-with-judge test) and test_scenarios_anti_vacuous.py (catalog gate + anti-vacuity proof). Each new gate test was observed to flag a synthetic offender; the circular-oracle and both-with-judge tests were observed RED on the pre-fix code.

## Architecture pre-check — #2441 / #2279
1. BLUEPRINT alignment: n/a (eval-harness tooling); doctrine home evals/README.md updated to document the negative-pairing requirement.
2. FSM phase boundaries: n/a, no transition touched.
3. Extension-point contracts: none (no OverlayBase hook / scanner / Backend Protocol).
4. Component boundaries: new predicate in src/teatree/eval/ (sibling of skip_guard.py); the gate that consumes it lives with the other catalog-vacuity gates in tests/eval_replay/.
5. Dependency direction: matcher_vacuity imports only teatree.eval.models (a leaf); no backwards edge.
6. Test surface: a named assertion per behaviour (predicate unit tests, catalog gate + anti-vacuity proof, circular-oracle degradation + both-with-judge, migration idempotency).
7. Resilience invariants: nit-1 improves resilience (a circular-oracle label no longer crashes the audit batch); no new external write.
8. Identity/key normalization: n/a.
9. Behavior preservation: the circular-oracle test changed from asserting a raise to asserting a degraded FAIL record — an intended behavior change (degrade, not crash), not a narrowing of a safety matcher; no must-block test inverted; the new structural gate only ADDS coverage.

## Coordination
PR #2505 (ac/eval-doc-quick-playbook) renames SubscriptionTranscriptRunner to TranscriptRunner and edits the same import line in test_scenarios_anti_vacuous.py. This branch is based on origin/main's current name; a trivial textual conflict on that one import line is expected at merge.