### PR TITLE
perf(tests): cut the two longest-pole slow tests in the CI suite

### DIFF
--- a/tests/teatree_agents/_sdk_fake.py
+++ b/tests/teatree_agents/_sdk_fake.py
@@ -80,6 +80,13 @@ class FakeSdkClient:
         import asyncio  # noqa: PLC0415
 
         for message in self._messages:
+            # Model the real SDK: once ``interrupt()`` lands the server stops
+            # streaming, so the consumer never sees the remaining messages. The
+            # fake used to drain the whole canned list regardless, so a watchdog
+            # test with a long stream paid the full per-message ``delay`` even
+            # though the run was interrupted on the first heartbeat tick.
+            if self.interrupted:
+                return
             if self._delay:
                 await asyncio.sleep(self._delay)
             yield message

--- a/tests/teatree_agents/test_headless.py
+++ b/tests/teatree_agents/test_headless.py
@@ -701,13 +701,20 @@ class TestRunHeadlessRecordsStuckLoop(TestCase):
         task.renew_lease = lambda **_kw: None
 
         watchdog = LoopWatchdog(max_runtime_seconds=0, max_turns=200, max_cost_usd=0.0)
+        # A long never-terminating stream: the watchdog must interrupt it on the
+        # turns breach (500 > 200) at the first heartbeat tick, NOT drain the
+        # whole list. The interrupt cuts the stream short, so the run finishes in
+        # ~one heartbeat — proving the watchdog stops a runaway rather than
+        # waiting it out.
         messages = [_assistant_text("step") for _ in range(1000)]
+        start = time.monotonic()
         with (
             _fake_sdk(messages, delay=0.05, task_usage=TaskUsage(turns=500, cost_usd=0.0)),
             patch.object(headless_mod.LoopWatchdog, "from_settings", return_value=watchdog),
             patch.object(headless_mod, "_HEARTBEAT_INTERVAL", 0.02),
         ):
             attempt = run_headless(task, phase="coding", overlay_skill_metadata={})
+        elapsed = time.monotonic() - start
 
         task.refresh_from_db()
         assert attempt.exit_code != 0
@@ -715,6 +722,10 @@ class TestRunHeadlessRecordsStuckLoop(TestCase):
         assert "turns" in attempt.error
         assert "500" in attempt.error
         assert task.status == Task.Status.FAILED
+        # The interrupt cut the 1000-message stream short instead of streaming
+        # all 50s of it (1000 * 0.05s delay) — a generous bound that still fails
+        # loudly if the watchdog stops interrupting the stream.
+        assert elapsed < 10, f"watchdog did not cut the runaway stream short: {elapsed:.1f}s"
 
 
 class TestTicketBudget(TestCase):

--- a/tests/test_loop_ownership_transfer.py
+++ b/tests/test_loop_ownership_transfer.py
@@ -264,8 +264,11 @@ class TestConcurrentFreshClaimIsAtomic:
     directive and one non-owner ("stay idle") directive. On the pre-fix
     write-only-lock the read sits outside the flock so both children
     claim — the assertions below then trip, demonstrating this test
-    guards the fix. Repeated over many rounds because the bad interleave
-    is timing-dependent.
+    guards the fix. Repeated over several rounds because the bad interleave
+    is timing-dependent; each round spawns a fresh pair of simultaneously-
+    starting children, so a handful of rounds reliably hits the TOCTOU
+    window without the per-round subprocess + ``hook_router`` reload cost
+    of a larger sweep.
 
     The class-level ``timeout(300)`` overrides the project-wide 60s cap.
     That cap is a wall-clock budget, but this test asserts a *correctness*
@@ -278,7 +281,7 @@ class TestConcurrentFreshClaimIsAtomic:
     """
 
     def test_simultaneous_fresh_starts_never_both_claim(self, tmp_path: Path) -> None:
-        rounds = 12
+        rounds = 5
         for rnd in range(rounds):
             reg_dir = str(tmp_path / f"data-{rnd}")
             Path(reg_dir).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## What

The `test (3.13)` lane is a parallel (`-n auto`) run, so its wall-clock is set by the few serial-bound tests that pin one xdist worker far longer than the rest. Profiling with `--durations` surfaced two such tests whose runtime was pure inflation — neither covers any `src/` line the rest of the suite does not already exercise.

### 1. `FakeSdkClient` ignored `interrupt()` (the big one)

The in-process SDK test double (`tests/teatree_agents/_sdk_fake.py`) drained its **whole** canned message list even after `interrupt()` landed. The real `ClaudeSDKClient` stops streaming on interrupt, so this was a fidelity gap: the watchdog test `test_records_stuck_loop_failure_with_observed_deltas` fed 1000 messages at 0.05s each and streamed all ~50s of them, even though the watchdog interrupts the runaway on the first heartbeat tick.

Fix: the fake now stops streaming once `interrupted` — a more faithful model of the real SDK. The test gained an `elapsed < 10` assertion that **guards the speedup against regression** (reverting the fake's interrupt-honouring makes it go RED at ~52s — verified).

- `test_records_stuck_loop_failure_with_observed_deltas`: **57.4s -> 5.5s** (isolated, host).

### 2. `test_simultaneous_fresh_starts_never_both_claim` round count

This probabilistic TOCTOU detector spawned **12 rounds** of two `hook_router`-reloading subprocesses to hit a timing-dependent double-claim window. Five simultaneous-start rounds reliably hit it; each round still asserts exactly-one-owner, so the invariant under test is unchanged — only the repetition count drops.

- `test_simultaneous_fresh_starts_never_both_claim`: **29.9s -> 8.3s** (isolated, host).

## Before / after wall-clock (changed files, isolated on host)

| Test | Before | After |
|---|---|---|
| `test_headless.py::...records_stuck_loop_failure_with_observed_deltas` | 57.4s | 5.5s |
| full `test_headless.py` (70 tests) | ~64s | 7.0s |
| `test_loop_ownership_transfer.py::...never_both_claim` | 29.9s | 8.3s |
| full `test_loop_ownership_transfer.py` (9 tests) | ~32s | 7.9s |

Combined serial saving ~73s, all on the parallel suite's critical-path tail.

## Coverage

Test-only change; no `src/` line stops being exercised. The watchdog interrupt path and `handle_session_start_bootstrap` are still covered (confirmed via a targeted `--cov=teatree.agents.headless` run — the interrupt branch executes). The 93% branch floor is untouched; `--doctest-modules` scope is deliberately left alone (zero doctests exist, but it still contributes import-line coverage that the floor depends on).

## Architecture pre-check

Tactical, test-only change (three test files, no `src/`, no FSM transition, no Protocol or extension-point surface) — the nine-check gate does not apply. The one design judgement (make the test double honour `interrupt()`) improves fidelity to the real SDK rather than weakening any assertion.

## Verification

- `tests/teatree_agents/` (303 tests), the three changed files, and all five `_sdk_fake` consumer files: green.
- `ruff check` / `ruff format --check` / `ty check`: clean.
- Anti-regression confirmed: reverting the fake's interrupt-honouring turns the new `elapsed < 10` assertion RED at ~52s.