### PR TITLE
feat(config): auto-migrate TOML settings into the DB store on t3 setup (#938)

### DIFF
--- a/docs/blueprint/configuration.md
+++ b/docs/blueprint/configuration.md
@@ -12,8 +12,11 @@ Detail behind [BLUEPRINT.md](https://github.com/souliane/teatree/blob/main/BLUEP
 # approval gates, on_behalf_post_mode, repo_mode, the cadence/threshold dials,
 # … — are DB-home and live in the ConfigSetting store; a value for one of them
 # left in [teatree] / [overlays.<name>] is IGNORED on read. Set them with
-# `t3 <overlay> config_setting set` (see below), and migrate an existing config
-# once with `t3 <overlay> config_setting import`.
+# `t3 <overlay> config_setting set` (see below). `t3 setup` auto-migrates an
+# existing config into the store on every run (non-clobbering: it seeds only keys
+# absent from the store, so a value you later change via `config_setting set`
+# survives); `t3 <overlay> config_setting import` is the manual equivalent (it
+# refreshes every operational key from the file).
 [teatree]
 workspace_dir = "~/workspace"
 privacy = "strict"
@@ -64,7 +67,7 @@ t3 <overlay> config_setting set mode auto                                  # glo
 t3 <overlay> config_setting set require_human_approval_to_merge false --overlay myproject
 t3 <overlay> config_setting set on_behalf_post_mode immediate
 t3 <overlay> config_setting set user_identity_aliases '["handle-a", "handle-b"]'
-t3 <overlay> config_setting import                                         # one-time: migrate a pre-partition [teatree] block
+t3 <overlay> config_setting import                                         # manual one-time migrate (refreshes from file); `t3 setup` runs the non-clobbering auto-migration
 ```
 
 **Cross-repo "my open MRs" reminder** (`t3 <overlay> mr_reminder`): generalises a

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -7087,8 +7087,15 @@ Usage: t3 teatree config_setting import [OPTIONS]
  and unknown keys are skipped — only operational settings move. The upsert
  makes a re-run idempotent.
 
+ ``--no-clobber`` seeds only keys ABSENT from the store and leaves an
+ existing row untouched — the mode ``t3 setup`` runs on every update so a
+ value the user changed via ``config_setting set`` survives. Without it
+ (the default), a re-import refreshes every operational key from the file.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --help          Show this message and exit.                                  │
+│ --no-clobber          Seed only keys absent from the store; never overwrite  │
+│                       an existing DB row.                                    │
+│ --help                Show this message and exit.                            │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/cli/setup.py
+++ b/src/teatree/cli/setup.py
@@ -17,7 +17,7 @@ from teatree.cli.slack_dm_provisioning import provision_all_overlay_dm_channels
 from teatree.cli.slack_provision import slack_provision
 from teatree.cli.slack_setup import slack_bot_setup
 from teatree.cli.slack_user_token_setup import slack_user_token_setup
-from teatree.self_update import current_editable_source, ensure_self_db_migrated
+from teatree.self_update import current_editable_source, ensure_self_db_migrated, seed_db_config_from_toml
 from teatree.utils.run import CompletedProcess, run_allowed_to_fail
 
 # Re-exported here so external callers and tests see a single import path for
@@ -603,6 +603,17 @@ def run(
     )
 
     self_db_unmigrated = ensure_self_db_migrated(quiet=True)
+
+    # The #938 dual-read migration (TODO-75): once the self-DB is migrated (so the
+    # ``ConfigSetting`` table exists), seed the DB config store from any operational
+    # keys still in ``~/.teatree.toml`` — global ``[teatree]`` keys into the global
+    # scope, ``[overlays.<name>]`` keys into that overlay's scope. ``--no-clobber``
+    # means it only seeds keys absent from the store, so a value the user set via
+    # ``config_setting set`` survives every later ``t3 setup``. Best-effort: a
+    # failure is a WARN, never fatal (the TOML stays readable, the resolver falls
+    # through), so the config seed never aborts setup.
+    if not self_db_unmigrated:
+        seed_db_config_from_toml()
 
     # Suggest (never apply) the recommended per-user auto-mode authorizations.
     # Teatree ships no classifier whitelist of its own — see

--- a/src/teatree/core/config_migration.py
+++ b/src/teatree/core/config_migration.py
@@ -1,0 +1,127 @@
+"""TOML -> ``ConfigSetting`` import service — the #938 dual-read migration (TODO-75).
+
+The reusable seam that seeds the DB override store from the existing
+``~/.teatree.toml`` so the cutover to the #1775 DB/TOML hard partition does not
+lose a user's pre-partition config. Both callers share it:
+
+*   ``t3 <overlay> config_setting import`` — the manual one-time migration, with
+    its original CLOBBER semantics (re-import refreshes every operational key
+    from the file, overwriting any stale DB row).
+*   ``t3 setup`` — the AUTOMATIC migration. It runs on every update, so it calls
+    with ``clobber=False``: it seeds only keys ABSENT from the store and never
+    overwrites a value the user has since changed via ``config_setting set``.
+
+Every ``[teatree]`` key that is a registered ``OVERLAY_OVERRIDABLE_SETTINGS``
+(= DB-home) field is coerced through that registry's parser and upserted into the
+GLOBAL scope; every operational key under an ``[overlays.<name>]`` table is
+upserted into THAT overlay's scope — the DB twin of the per-overlay TOML override
+(#1775). Bootstrap-file-only keys (``private_repos`` / ``DATABASE_URL`` / …), the
+overlay's own ``path`` / ``url`` discovery keys, and unknown keys are skipped:
+only operational settings move.
+
+The service returns a structured :class:`ConfigImportResult` rather than writing
+to a stream, so the management command renders it and ``t3 setup`` logs a one-line
+summary from the same outcome.
+"""
+
+from dataclasses import dataclass, field
+
+from teatree.config import OVERLAY_OVERRIDABLE_SETTINGS
+from teatree.core.models import ConfigSetting
+
+GLOBAL_SCOPE = ""
+
+
+def _scope_label(scope: str) -> str:
+    """Human label for a scope: ``global`` for the empty scope else ``overlay '<name>'``."""
+    return "global" if not scope else f"overlay {scope!r}"
+
+
+@dataclass
+class ConfigImportResult:
+    """Outcome of a TOML -> ``ConfigSetting`` import pass.
+
+    ``imported`` counts rows newly written (a key with no prior row in its
+    scope). ``overwritten`` counts existing rows replaced (clobber mode only).
+    ``preserved`` counts rows left untouched because a value already existed and
+    the caller asked not to clobber. ``skipped`` counts file keys that are not
+    operational DB-home settings (bootstrap / discovery / unknown / invalid).
+    ``rows`` records ``(scope, key)`` for every row written or overwritten so the
+    summary can name what moved; ``skipped_reasons`` records the loud-skip lines
+    for invalid values.
+    """
+
+    imported: int = 0
+    overwritten: int = 0
+    preserved: int = 0
+    skipped: int = 0
+    rows: list[tuple[str, str]] = field(default_factory=list)
+    skipped_reasons: list[str] = field(default_factory=list)
+
+    @property
+    def changed(self) -> int:
+        """Rows actually written this pass (new + overwritten)."""
+        return self.imported + self.overwritten
+
+    def summary(self) -> str:
+        """One-line human summary naming the count and the scopes touched."""
+        if not self.rows:
+            return f"imported {self.changed} setting(s) into the DB store"
+        scopes = sorted({_scope_label(scope) for scope, _ in self.rows})
+        return f"imported {self.changed} setting(s) into the DB store [{', '.join(scopes)}]"
+
+
+def import_toml_into_db(raw: dict, *, clobber: bool = True) -> ConfigImportResult:
+    """Seed the ``ConfigSetting`` store from a raw config dict; return the outcome.
+
+    Walks the global ``[teatree]`` table into the global scope and each
+    ``[overlays.<name>]`` table into that overlay's scope. With *clobber* (the
+    default, the manual ``config_setting import`` semantics) an existing row is
+    overwritten from the file value. With ``clobber=False`` (the ``t3 setup``
+    auto-migration) a key that already has a row in its scope is left untouched
+    and counted as ``preserved`` — so a value the user changed via
+    ``config_setting set`` survives every later ``t3 setup``.
+    """
+    result = ConfigImportResult()
+    teatree_table = raw.get("teatree")
+    if isinstance(teatree_table, dict):
+        _import_table(teatree_table, GLOBAL_SCOPE, clobber=clobber, result=result)
+    overlays = raw.get("overlays")
+    if isinstance(overlays, dict):
+        for overlay_name, overlay_cfg in overlays.items():
+            if isinstance(overlay_cfg, dict):
+                _import_table(overlay_cfg, overlay_name, clobber=clobber, result=result)
+    return result
+
+
+def _import_table(table: dict, scope: str, *, clobber: bool, result: ConfigImportResult) -> None:
+    """Upsert every operational key in *table* into *scope*, mutating *result*.
+
+    A key registered in ``OVERLAY_OVERRIDABLE_SETTINGS`` is coerced through its
+    registry parser and (per *clobber*) written or preserved; every other key is
+    skipped. An invalid value is recorded loud and skipped — never fatal — so one
+    bad key cannot abort the migration of the rest.
+    """
+    for key, raw_value in table.items():
+        parser = OVERLAY_OVERRIDABLE_SETTINGS.get(key)
+        if parser is None:
+            result.skipped += 1
+            continue
+        try:
+            canonical = parser(raw_value)
+        except (ValueError, TypeError, AttributeError) as exc:
+            result.skipped += 1
+            result.skipped_reasons.append(
+                f"skipped {key!r} [{_scope_label(scope)}]: invalid value {raw_value!r}: {exc}"
+            )
+            continue
+        existed = ConfigSetting.objects.get_effective(key, scope=scope) is not None
+        if existed and not clobber:
+            result.preserved += 1
+            continue
+        ConfigSetting.objects.set_value(key, canonical, scope=scope)
+        result.rows.append((scope, key))
+        if existed:
+            result.overwritten += 1
+        else:
+            result.imported += 1

--- a/src/teatree/core/management/commands/config_setting.py
+++ b/src/teatree/core/management/commands/config_setting.py
@@ -28,6 +28,7 @@ import typer
 from django_typer.management import TyperCommand, command
 
 from teatree.config import OVERLAY_OVERRIDABLE_SETTINGS, get_effective_settings, load_config
+from teatree.core.config_migration import import_toml_into_db
 from teatree.core.models import ConfigSetting
 
 _OverlayOption = Annotated[
@@ -144,35 +145,18 @@ class Command(TyperCommand):
         fallback = getattr(get_effective_settings(overlay or None), key, None)
         self.stdout.write(f"  {key} = {fallback!r}  [source: file/env]")
 
-    def _import_table(self, table: dict, scope: str) -> int:
-        """Upsert every operational key in *table* into *scope*; return the count moved.
-
-        A key registered in ``OVERLAY_OVERRIDABLE_SETTINGS`` (= DB-home) is coerced
-        through its registry parser and upserted into *scope* (``""`` = global, a
-        name = that overlay's scope). Bootstrap-file-only keys, the overlay's own
-        ``path`` / ``url`` discovery keys, and unknown keys are skipped — only
-        operational settings move. The upsert makes a re-run idempotent.
-        """
-        scope_label = "global" if not scope else f"overlay {scope!r}"
-        imported = 0
-        for key, raw_value in table.items():
-            parser = OVERLAY_OVERRIDABLE_SETTINGS.get(key)
-            if parser is None:
-                continue
-            try:
-                canonical = parser(raw_value)
-            except (ValueError, TypeError, AttributeError) as exc:
-                self.stderr.write(f"  skipping {key!r} [{scope_label}]: invalid value {raw_value!r}: {exc}")
-                continue
-            ConfigSetting.objects.set_value(key, canonical, scope=scope)
-            imported += 1
-            self.stdout.write(
-                f"  imported {key} = {ConfigSetting.objects.get_effective(key, scope=scope)!r}  [{scope_label}]"
-            )
-        return imported
-
     @command(name="import")
-    def import_toml(self) -> None:
+    def import_toml(
+        self,
+        *,
+        no_clobber: Annotated[
+            bool,
+            typer.Option(
+                "--no-clobber",
+                help="Seed only keys absent from the store; never overwrite an existing DB row.",
+            ),
+        ] = False,
+    ) -> None:
         """Seed the DB store from the operational toml keys (one-time migration).
 
         The dual-read migration step (#938): every ``[teatree]`` key that is a
@@ -185,15 +169,16 @@ class Command(TyperCommand):
         ``DATABASE_URL`` / …), the overlay's own ``path`` / ``url`` discovery keys,
         and unknown keys are skipped — only operational settings move. The upsert
         makes a re-run idempotent.
+
+        ``--no-clobber`` seeds only keys ABSENT from the store and leaves an
+        existing row untouched — the mode ``t3 setup`` runs on every update so a
+        value the user changed via ``config_setting set`` survives. Without it
+        (the default), a re-import refreshes every operational key from the file.
         """
-        raw = load_config().raw
-        teatree_table = raw.get("teatree", {})
-        imported = 0
-        if isinstance(teatree_table, dict):
-            imported += self._import_table(teatree_table, scope="")
-        overlays = raw.get("overlays", {})
-        if isinstance(overlays, dict):
-            for overlay_name, overlay_cfg in overlays.items():
-                if isinstance(overlay_cfg, dict):
-                    imported += self._import_table(overlay_cfg, scope=overlay_name)
-        self.stdout.write(f"  imported {imported} operational setting(s) into the DB store")
+        result = import_toml_into_db(load_config().raw, clobber=not no_clobber)
+        for reason in result.skipped_reasons:
+            self.stderr.write(f"  {reason}")
+        for scope, key in result.rows:
+            stored = ConfigSetting.objects.get_effective(key, scope=scope)
+            self.stdout.write(f"  imported {key} = {stored!r}  [{_scope_label(scope)}]")
+        self.stdout.write(f"  {result.summary()}")

--- a/src/teatree/self_update.py
+++ b/src/teatree/self_update.py
@@ -212,10 +212,42 @@ def ensure_self_db_migrated(*, quiet: bool = False) -> bool:
     return False
 
 
+def seed_db_config_from_toml() -> None:
+    """Seed the DB config store from ``~/.teatree.toml`` — the #938 auto-migration (TODO-75).
+
+    Runs ``python -m teatree config_setting import --no-clobber`` in the *running*
+    interpreter so it targets the exact self-DB the runtime ``t3`` resolves (the
+    #126 rule the self-DB migrate follows), with the same stripped
+    ``DJANGO_SETTINGS_MODULE`` env (#959). ``--no-clobber`` is load-bearing:
+    ``t3 setup`` runs on every update, so the migration must only seed keys absent
+    from the store and never overwrite a value the user has since changed via
+    ``config_setting set``.
+
+    Best-effort, NOT fail-closed: a failure is a single WARN and the function
+    returns. The TOML remains readable and the dual-read resolver falls through to
+    the dataclass default, so a failed config seed must not abort ``t3 setup`` —
+    unlike the self-DB migrate, which is fail-closed because the merge gate (#870)
+    depends on it.
+    """
+    result = run_allowed_to_fail(
+        _self_db_migrate_cmd("config_setting", "import", "--no-clobber"),
+        env=_self_db_migrate_env(),
+        expected_codes=None,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "(no output)"
+        typer.echo(f"WARN  config DB seed skipped — {detail}")
+        return
+    summary = result.stdout.strip().splitlines()
+    if summary:
+        typer.echo(f"OK    config DB store: {summary[-1].strip()}")
+
+
 __all__ = [
     "ReinstallResult",
     "SubprocessRunner",
     "current_editable_source",
     "ensure_self_db_migrated",
     "reinstall_running_editable",
+    "seed_db_config_from_toml",
 ]

--- a/tests/cli_setup/test_self_db_migrate.py
+++ b/tests/cli_setup/test_self_db_migrate.py
@@ -39,6 +39,7 @@ def _run_setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, migrate_retur
         patch.object(setup_module, "_run_apm_install", return_value=True),
         patch.object(setup_module, "_install_claude_plugin", return_value=True),
         patch.object(setup_module, "ensure_self_db_migrated", return_value=migrate_returns) as mock_migrate,
+        patch.object(setup_module, "seed_db_config_from_toml") as mock_seed,
         patch("teatree.config.load_config") as mock_load,
     ):
         mock_load.return_value.user.contribute = False
@@ -49,17 +50,35 @@ def _run_setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, migrate_retur
         except typer.Exit as exc:
             raised.append(exc.exit_code)
 
-    return mock_migrate, raised
+    return mock_migrate, mock_seed, raised
 
 
 class TestSetupRunsSelfDbMigrations:
     def test_setup_invokes_self_db_migrate_quietly(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        mock_migrate, raised = _run_setup(tmp_path, monkeypatch)
+        mock_migrate, _mock_seed, raised = _run_setup(tmp_path, monkeypatch)
         mock_migrate.assert_called_once_with(quiet=True)
         assert raised == []
 
     def test_setup_exits_nonzero_when_self_db_left_unmigrated(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        _mock_migrate, raised = _run_setup(tmp_path, monkeypatch, migrate_returns=True)
+        _mock_migrate, _mock_seed, raised = _run_setup(tmp_path, monkeypatch, migrate_returns=True)
+        assert raised == [1]
+
+
+class TestSetupSeedsDbConfigFromToml:
+    """``t3 setup`` runs the #938 dual-read auto-migration after the self-DB migrate (TODO-75)."""
+
+    def test_setup_seeds_db_config_after_a_clean_migrate(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _mock_migrate, mock_seed, raised = _run_setup(tmp_path, monkeypatch)
+        mock_seed.assert_called_once_with()
+        assert raised == []
+
+    def test_setup_skips_seed_when_self_db_left_unmigrated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The ``ConfigSetting`` table may not exist on an unmigrated self-DB, so the
+        # seed is skipped — the setup still exits non-zero on the unmigrated DB.
+        _mock_migrate, mock_seed, raised = _run_setup(tmp_path, monkeypatch, migrate_returns=True)
+        mock_seed.assert_not_called()
         assert raised == [1]

--- a/tests/teatree_core/management/test_config_setting_command.py
+++ b/tests/teatree_core/management/test_config_setting_command.py
@@ -242,6 +242,21 @@ class TestConfigSettingImport(TestCase):
         call_command("config_setting", "import", stdout=StringIO())
         assert ConfigSetting.objects.filter(key="mode", scope="myproj").count() == 1
 
+    def test_import_no_clobber_preserves_a_db_set_value(self) -> None:
+        # The ``t3 setup`` auto-migration mode: a value the user changed via
+        # ``config_setting set`` must survive a later import of a stale TOML value.
+        ConfigSetting.objects.set_value("mode", "auto")
+        self.config_path.write_text('[teatree]\nmode = "interactive"\n', encoding="utf-8")
+        call_command("config_setting", "import", "--no-clobber", stdout=StringIO())
+        assert ConfigSetting.objects.get_effective("mode") == "auto"
+
+    def test_import_default_clobbers_a_db_set_value(self) -> None:
+        # Without --no-clobber the manual import refreshes from the file.
+        ConfigSetting.objects.set_value("mode", "auto")
+        self.config_path.write_text('[teatree]\nmode = "interactive"\n', encoding="utf-8")
+        call_command("config_setting", "import", stdout=StringIO())
+        assert ConfigSetting.objects.get_effective("mode") == "interactive"
+
 
 class TestConfigSettingOverlayScope(TestCase):
     """``--overlay`` scoping on set / clear / get / list (per-overlay + global)."""

--- a/tests/teatree_core/test_config_migration.py
+++ b/tests/teatree_core/test_config_migration.py
@@ -1,0 +1,109 @@
+"""TOML -> ``ConfigSetting`` import service (#938 dual-read migration, TODO-75).
+
+The reusable seam both the ``config_setting import`` management command and the
+``t3 setup`` auto-migration call. Integration-first against the real DB: a raw
+config dict is walked, coerced through the ``OVERLAY_OVERRIDABLE_SETTINGS``
+registry, and upserted into the store — global ``[teatree]`` keys into the
+global scope, ``[overlays.<name>]`` operational keys into that overlay's scope.
+
+The new capability over the original in-command logic is the NON-CLOBBER mode:
+``t3 setup`` runs on every update, so the auto-migration must never overwrite a
+value the user has since changed via ``config_setting set`` — it seeds only keys
+absent from the store and leaves present rows untouched.
+"""
+
+from django.test import TestCase
+
+from teatree.core.config_migration import import_toml_into_db
+from teatree.core.models import ConfigSetting
+
+
+class TestImportTomlIntoDb(TestCase):
+    def test_seeds_global_operational_keys(self) -> None:
+        raw = {"teatree": {"issue_implementer_enabled": True, "issue_implementer_max_concurrent": 4}}
+        result = import_toml_into_db(raw)
+        assert ConfigSetting.objects.get_effective("issue_implementer_enabled") is True
+        assert ConfigSetting.objects.get_effective("issue_implementer_max_concurrent") == 4
+        assert result.imported == 2
+
+    def test_skips_bootstrap_and_unknown_keys(self) -> None:
+        raw = {"teatree": {"private_repos": ["acme/secret"], "not_a_real_setting": "x", "mode": "auto"}}
+        result = import_toml_into_db(raw)
+        assert ConfigSetting.objects.filter(key="private_repos").exists() is False
+        assert ConfigSetting.objects.filter(key="not_a_real_setting").exists() is False
+        assert ConfigSetting.objects.get_effective("mode") == "auto"
+        assert result.imported == 1
+        assert result.skipped >= 2
+
+    def test_walks_per_overlay_table_into_overlay_scope(self) -> None:
+        raw = {
+            "teatree": {"mode": "interactive"},
+            "overlays": {"myproj": {"path": "~/p", "mode": "auto"}},
+        }
+        import_toml_into_db(raw)
+        assert ConfigSetting.objects.get_effective("mode") == "interactive"
+        assert ConfigSetting.objects.get_effective("mode", scope="myproj") == "auto"
+
+    def test_skips_non_setting_overlay_keys(self) -> None:
+        raw = {"overlays": {"myproj": {"path": "~/p", "url": "git@x"}}}
+        import_toml_into_db(raw)
+        assert ConfigSetting.objects.filter(scope="myproj").exists() is False
+
+    def test_clobber_default_overwrites_existing_row(self) -> None:
+        ConfigSetting.objects.set_value("mode", "interactive")
+        result = import_toml_into_db({"teatree": {"mode": "auto"}})
+        assert ConfigSetting.objects.get_effective("mode") == "auto"
+        assert result.overwritten == 1
+
+    def test_clobber_is_idempotent(self) -> None:
+        raw = {"teatree": {"issue_implementer_max_concurrent": 4}}
+        import_toml_into_db(raw)
+        import_toml_into_db(raw)
+        assert ConfigSetting.objects.filter(key="issue_implementer_max_concurrent").count() == 1
+
+    def test_no_clobber_leaves_existing_row_untouched(self) -> None:
+        # A value the user set via ``config_setting set`` must survive a re-run of
+        # the auto-migration: no-clobber seeds only absent keys.
+        ConfigSetting.objects.set_value("mode", "auto")
+        result = import_toml_into_db({"teatree": {"mode": "interactive"}}, clobber=False)
+        assert ConfigSetting.objects.get_effective("mode") == "auto"
+        assert result.imported == 0
+        assert result.preserved == 1
+
+    def test_no_clobber_still_seeds_absent_keys(self) -> None:
+        # No-clobber is seed-if-absent, not a global skip: a key with no DB row yet
+        # is still imported.
+        ConfigSetting.objects.set_value("mode", "auto")
+        raw = {"teatree": {"mode": "interactive", "issue_implementer_enabled": True}}
+        result = import_toml_into_db(raw, clobber=False)
+        assert ConfigSetting.objects.get_effective("mode") == "auto"
+        assert ConfigSetting.objects.get_effective("issue_implementer_enabled") is True
+        assert result.imported == 1
+        assert result.preserved == 1
+
+    def test_no_clobber_per_overlay_seed_if_absent(self) -> None:
+        ConfigSetting.objects.set_value("mode", "auto", scope="myproj")
+        raw = {"overlays": {"myproj": {"mode": "interactive", "issue_implementer_enabled": True}}}
+        result = import_toml_into_db(raw, clobber=False)
+        assert ConfigSetting.objects.get_effective("mode", scope="myproj") == "auto"
+        assert ConfigSetting.objects.get_effective("issue_implementer_enabled", scope="myproj") is True
+        assert result.imported == 1
+        assert result.preserved == 1
+
+    def test_invalid_value_is_skipped_not_fatal(self) -> None:
+        # A TOML value that JSON-shapes but is invalid for the setting's type is
+        # skipped with a recorded reason — never an exception aborting the import.
+        raw = {"teatree": {"mode": "not_a_mode", "issue_implementer_enabled": True}}
+        result = import_toml_into_db(raw)
+        assert ConfigSetting.objects.filter(key="mode").exists() is False
+        assert ConfigSetting.objects.get_effective("issue_implementer_enabled") is True
+        assert result.imported == 1
+        assert any("mode" in line for line in result.skipped_reasons)
+
+    def test_result_rows_describe_each_imported_setting(self) -> None:
+        raw = {"teatree": {"mode": "auto"}, "overlays": {"myproj": {"mode": "interactive"}}}
+        result = import_toml_into_db(raw)
+        rendered = result.summary()
+        assert "global" in rendered
+        assert "myproj" in rendered
+        assert "2" in rendered

--- a/tests/test_self_update.py
+++ b/tests/test_self_update.py
@@ -21,6 +21,7 @@ from teatree.self_update import (
     current_editable_source,
     ensure_self_db_migrated,
     reinstall_running_editable,
+    seed_db_config_from_toml,
 )
 
 
@@ -335,6 +336,60 @@ class TestSelfDbMigrate:
 
         assert failed is True
         assert "self-DB" in capsys.readouterr().out
+
+
+class TestSeedDbConfigFromToml:
+    """The ``t3 setup`` auto-migration (#938, TODO-75): seed the DB store from TOML.
+
+    Runs ``python -m teatree config_setting import --no-clobber`` in the runtime
+    interpreter, mirroring the self-DB migrate shape. Best-effort: a failure is a
+    WARN, never fail-closed — the TOML stays readable and the dual-read resolver
+    falls through, unlike the self-DB migrate the merge gate depends on.
+    """
+
+    def test_runs_no_clobber_import_in_runtime_interpreter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[list[str]] = []
+
+        def _run(cmd: list[str], **_kw: object) -> _Proc:
+            calls.append(cmd)
+            return _Proc(0, "  imported 0 setting(s) into the DB store", "")
+
+        monkeypatch.setattr(self_update_mod, "run_allowed_to_fail", _run)
+
+        seed_db_config_from_toml()
+
+        assert len(calls) == 1
+        cmd = calls[0]
+        assert cmd[0] == self_update_mod.sys.executable, "must use the running interpreter"
+        assert cmd[1:4] == ["-m", "teatree", "config_setting"], f"got {cmd!r}"
+        assert "import" in cmd
+        assert "--no-clobber" in cmd, "the setup auto-migration must never clobber a DB-set value"
+        assert "--directory" not in cmd, "must NOT route through `uv --directory <clone>`"
+
+    def test_does_not_inherit_caller_settings_module(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "worktree_only.settings_local")
+        captured: list[dict[str, str]] = []
+
+        def _run(cmd: list[str], *, env: dict[str, str] | None = None, **_kw: object) -> _Proc:
+            captured.append(dict(env or {}))
+            return _Proc(0, "", "")
+
+        monkeypatch.setattr(self_update_mod, "run_allowed_to_fail", _run)
+
+        seed_db_config_from_toml()
+
+        assert captured, "import subprocess was not invoked"
+        assert captured[0].get("DJANGO_SETTINGS_MODULE") == "teatree.settings"
+
+    def test_failure_is_a_warn_not_fail_closed(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr(self_update_mod, "run_allowed_to_fail", lambda *a, **k: _Proc(1, "", "boom"))
+
+        # Best-effort: returns without raising, unlike the fail-closed self-DB migrate.
+        seed_db_config_from_toml()
+
+        assert "config" in capsys.readouterr().out.lower()
 
 
 class TestReinstallResult:


### PR DESCRIPTION
## Summary

Closes the #938 dual-read migration (follow-up to #1775/#938). The per-overlay + global
TOML -> `ConfigSetting` import already shipped as a manual `config_setting import`, but the
user had to know to run it. This wires a **non-clobbering auto-migration into `t3 setup`** so a
pre-partition `~/.teatree.toml` seeds the DB store on every install/update without the manual
step.

### What changed

- **New service** `teatree.core.config_migration.import_toml_into_db(raw, *, clobber=True)` —
  the reusable TOML -> `ConfigSetting` seam, returning a structured `ConfigImportResult`. Walks
  the global `[teatree]` table into the global scope and each `[overlays.<name>]` table into that
  overlay's scope; skips bootstrap/discovery/unknown keys and records loud-skip reasons for
  invalid values (never fatal).
- **`config_setting import`** delegates to the service (existing behaviour preserved) and gains a
  `--no-clobber` flag.
- **`t3 setup`** runs `python -m teatree config_setting import --no-clobber` in the runtime
  interpreter after the self-DB migrate (mirroring `ensure_self_db_migrated`'s #126/#959 pattern).
  Best-effort: a failure is a WARN, never a hard stop — the TOML stays readable and the dual-read
  resolver falls through, unlike the self-DB migrate the merge gate depends on.

The auto-migration is **non-clobbering**: `t3 setup` runs on every update, so it seeds only keys
absent from the store and never overwrites a value the user changed via `config_setting set`.

### Tests

- `tests/teatree_core/test_config_migration.py` — the service: global+overlay seed, skips
  bootstrap/unknown keys, clobber idempotence, no-clobber preserves a DB-set value while still
  seeding absent keys, invalid-value skip, structured-result summary. The no-clobber guard was
  observed RED (reverted, confirmed failing) before being restored.
- `tests/teatree_core/management/test_config_setting_command.py` — `import --no-clobber` preserves
  a DB-set value; default `import` still clobbers. Existing import tests stay green (delegation).
- `tests/test_self_update.py` — `seed_db_config_from_toml` runs the runtime-interpreter
  `--no-clobber` import with a stripped `DJANGO_SETTINGS_MODULE`, and a failure is a WARN.
- `tests/cli_setup/test_self_db_migrate.py` — `t3 setup` invokes the seed after a clean migrate
  and skips it when the self-DB is left unmigrated.

`5553 passed` across `tests/teatree_core/ tests/config/ tests/cli_setup/ tests/test_self_update.py`.

## Architecture pre-check — TODO-75 (#938)

### 1. BLUEPRINT § alignment
Config DB/TOML partition (#1775 §17.4 "canonical tier is the DB") + #938 dual-read migration.
`docs/blueprint/configuration.md` updated for the auto-migration step.

### 2. FSM phase boundaries
n/a — no `Ticket`/`Worktree` state transition.

### 3. Extension-point contracts
n/a — no `OverlayBase` / scanner / hook / Protocol change. The import reads `load_config().raw`
and the `OVERLAY_OVERRIDABLE_SETTINGS` registry, both already consumed by the resolver.

### 4. Component boundaries
`core/config_migration` (ORM-touching import service), `core/management/commands/config_setting`
(delegates + `--no-clobber` flag), `cli/setup` (subprocess wiring). No straddle.

### 5. Dependency direction
`core/config_migration` imports `teatree.config` + `teatree.core.models` (at/below `core`).
`cli/setup` reaches the migration via a runtime-interpreter subprocess (no static core import),
the same shape as `self_update`. `uv run tach check` green.

### 6. Test surface
Per behaviour, see Tests above. The no-clobber guard, the delegation, the subprocess command
shape, and the setup wiring each have a named assertion.

### 7. Resilience invariants
External write = DB rows. verify-by-re-read: the command re-reads `get_effective` per imported
key. idempotency: `(scope,key)` upsert + no-clobber make a re-run a strict no-op for present
keys. The setup wiring is best-effort (WARN on failure) so a failed config seed never aborts
`t3 setup`, unlike the fail-closed self-DB migrate.

### 8. Identity and key normalization
Overlay scope keys reuse the resolver's existing canonical-alias-tolerant resolution
(`_load_overlay_rows`); the import writes the scope name verbatim as in `[overlays.<name>]`
(existing behaviour). No new normalization seam.

### 9. Behavior preservation / capability deletion
The manual `config_setting import` keeps its exact clobber (refresh-from-file) semantics —
`--no-clobber` is additive and OFF by default for the manual command, so every existing import
test stays green. No must-block test inverted; no matcher narrowed. Purely additive.

## Open questions & assumptions

- The auto-migration is wired into the `t3 setup` callback after `ensure_self_db_migrated` and
  is skipped when the self-DB is left unmigrated (the `ConfigSetting` table may not exist yet).
- Assumed the explicit task instruction `gh pr create --base main --fill` over the FSM
  `t3 teatree pr create` path, since this is a workflow-script TODO (not a ticket-based FSM flow)
  and the change is test/config/docs only (no display impact, E2E gate n/a).
