### PR TITLE
fix(skill-support): scope overlay companion-skill load gate to overlay work

### DIFF
--- a/src/teatree/skill_support/loading.py
+++ b/src/teatree/skill_support/loading.py
@@ -297,16 +297,18 @@ class SkillLoadingPolicy:
         companion_skills: list[str] | None = None,
     ) -> list[str]:
         ordered: list[str] = []
-        overlay_skill = self._overlay_skill_for_context(
+        overlay_in_scope = self._overlay_in_scope(
             cwd=cwd,
             overlay_skill_metadata=overlay_skill_metadata,
             overlay_active=overlay_active,
             lifecycle_skill=lifecycle_skill,
         )
-        if overlay_skill:
-            ordered.append(overlay_skill)
+        if overlay_in_scope:
+            skill_path = str(overlay_skill_metadata.get("skill_path", "")).strip()
+            if skill_path:
+                ordered.append(skill_path)
         ordered.extend(self.detect_framework_skills(cwd))
-        if companion_skills:
+        if overlay_in_scope and companion_skills:
             ordered.extend(s for s in companion_skills if isinstance(s, str) and s)
         return ordered
 
@@ -321,17 +323,43 @@ class SkillLoadingPolicy:
         skill_path = str(overlay_skill_metadata.get("skill_path", "")).strip()
         if not skill_path:
             return ""
-        if overlay_active:
-            return skill_path
-        if not lifecycle_skill:
+        if not SkillLoadingPolicy._overlay_in_scope(
+            cwd=cwd,
+            overlay_skill_metadata=overlay_skill_metadata,
+            overlay_active=overlay_active,
+            lifecycle_skill=lifecycle_skill,
+        ):
             return ""
+        return skill_path
+
+    @staticmethod
+    def _overlay_in_scope(
+        *,
+        cwd: Path,
+        overlay_skill_metadata: OverlaySkillMetadata,
+        overlay_active: bool,
+        lifecycle_skill: str,
+    ) -> bool:
+        """Whether an overlay repo is actually in scope for this task.
+
+        The overlay companion skills (and the overlay's own skill) are
+        required ONLY for overlay work — when the resolved overlay is active
+        for the session, or the cwd's git remote matches one of the overlay's
+        ``remote_patterns``. Teatree-core-only work (no overlay-active, no
+        matching remote) is NOT overlay work, so its companion-skill load
+        gate must not fire.
+        """
+        if overlay_active:
+            return True
+        if not lifecycle_skill:
+            return False
         patterns_object = overlay_skill_metadata.get("remote_patterns", [])
         if not isinstance(patterns_object, list):
-            return ""
+            return False
         patterns = [pattern for pattern in patterns_object if isinstance(pattern, str) and pattern]
         if not patterns:
-            return ""
-        return skill_path if _matches_any_remote(cwd, patterns) else ""
+            return False
+        return _matches_any_remote(cwd, patterns)
 
     @staticmethod
     def detect_framework_skills(cwd: Path) -> list[str]:

--- a/tests/teatree_skill_support/test_skill_loading.py
+++ b/tests/teatree_skill_support/test_skill_loading.py
@@ -371,6 +371,93 @@ def test_overlay_remote_no_match(tmp_path: Path, monkeypatch):
     assert result == ""
 
 
+# ── overlay-companion skills are scoped to overlay work ─────────────
+
+
+_OVERLAY_META = {"skill_path": "t3:acme", "remote_patterns": ["*acme-product*"]}
+_COMPANIONS = ["t3-acme-review", "acme-conventions"]
+
+
+def test_companion_skills_required_when_overlay_active(tmp_path: Path):
+    # Overlay work in scope (overlay_active) → companion skills ARE required,
+    # alongside the overlay's own skill.
+    policy = SkillLoadingPolicy()
+    result = policy.select_for_runtime_phase(
+        cwd=tmp_path,
+        phase="coding",
+        overlay_skill_metadata=_OVERLAY_META,
+        companion_skills=_COMPANIONS,
+    )
+    assert "t3:acme" in result.skills
+    assert "t3-acme-review" in result.skills
+    assert "acme-conventions" in result.skills
+
+
+def test_companion_skills_required_when_remote_matches_overlay(tmp_path: Path, monkeypatch):
+    # Overlay-repo intent (the cwd's remote matches the overlay's patterns) →
+    # the overlay skill AND its companion skills are required.
+    monkeypatch.setattr(
+        "teatree.skill_support.loading._matches_any_remote",
+        lambda _cwd, _patterns: True,
+    )
+    policy = SkillLoadingPolicy()
+    result = policy.select_for_prompt_hook(
+        cwd=tmp_path,
+        intent="code",
+        overlay_skill_metadata=_OVERLAY_META,
+        loaded_skills=set(),
+        companion_skills=_COMPANIONS,
+    )
+    assert "t3:acme" in result.skills
+    assert "t3-acme-review" in result.skills
+    assert "acme-conventions" in result.skills
+
+
+def test_companion_skills_not_required_for_core_only_work(tmp_path: Path, monkeypatch):
+    # Teatree-core-only intent: overlay NOT active and the cwd's remote does NOT
+    # match the overlay's patterns. The overlay companion skills must NOT be
+    # required — they are scoped to overlay work, not core work.
+    monkeypatch.setattr(
+        "teatree.skill_support.loading._matches_any_remote",
+        lambda _cwd, _patterns: False,
+    )
+    policy = SkillLoadingPolicy()
+    result = policy.select_for_prompt_hook(
+        cwd=tmp_path,
+        intent="code",
+        overlay_skill_metadata=_OVERLAY_META,
+        loaded_skills=set(),
+        companion_skills=_COMPANIONS,
+    )
+    assert "t3:acme" not in result.skills
+    assert "t3-acme-review" not in result.skills
+    assert "acme-conventions" not in result.skills
+    # The framework/lifecycle skill is unaffected — core work still gets `code`.
+    assert "code" in result.skills
+
+
+def test_framework_detection_independent_of_overlay_scope(tmp_path: Path, monkeypatch):
+    # Framework skills are detected from the cwd, not gated on overlay scope:
+    # a teatree-core dir with a Django manage.py still yields `ac-django` even
+    # though the overlay companions are correctly withheld.
+    (tmp_path / "manage.py").touch()
+    monkeypatch.setattr(
+        "teatree.skill_support.loading._matches_any_remote",
+        lambda _cwd, _patterns: False,
+    )
+    policy = SkillLoadingPolicy()
+    result = policy.select_for_prompt_hook(
+        cwd=tmp_path,
+        intent="code",
+        overlay_skill_metadata=_OVERLAY_META,
+        loaded_skills=set(),
+        companion_skills=_COMPANIONS,
+    )
+    assert "ac-django" in result.skills
+    assert "t3-acme-review" not in result.skills
+    assert "acme-conventions" not in result.skills
+
+
 # ── detect_framework_skills ─────────────────────────────────────────
 
 

--- a/tests/test_companion_skills_overlay.py
+++ b/tests/test_companion_skills_overlay.py
@@ -58,10 +58,20 @@ class TestOverlayConfigCompanionSkillsField:
         assert second.companion_skills == []
 
 
+# An overlay whose remote_patterns match the cwd → the prompt-hook path resolves
+# the overlay as in-scope, so its companion skills are required. Without a
+# matching remote, the overlay is NOT in scope and the companions are withheld.
+_IN_SCOPE_OVERLAY_META = {"skill_path": "t3:acme", "remote_patterns": ["*acme*"]}
+
+
 class TestSelectForPromptHookEmitsCompanionSkills:
     """``select_for_prompt_hook`` emits the overlay's ``companion_skills``."""
 
-    def test_prompt_hook_includes_overlay_companion_skills(self, tmp_path: Path) -> None:
+    def test_prompt_hook_includes_overlay_companion_skills(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "teatree.skill_support.loading._matches_any_remote",
+            lambda _cwd, _patterns: True,
+        )
         config = _config_with_companions(["ac-django", "ac-python"])
         trigger_index: list[dict[str, object]] = [
             {"skill": "code", "companions": [], "requires": []},
@@ -70,7 +80,7 @@ class TestSelectForPromptHookEmitsCompanionSkills:
         result = policy.select_for_prompt_hook(
             cwd=tmp_path,
             intent="code",
-            overlay_skill_metadata={},
+            overlay_skill_metadata=_IN_SCOPE_OVERLAY_META,
             loaded_skills=set(),
             trigger_index=trigger_index,
             companion_skills=config.companion_skills,
@@ -81,9 +91,14 @@ class TestSelectForPromptHookEmitsCompanionSkills:
     def test_prompt_hook_dedupes_overlay_companions_with_framework_detect(
         self,
         tmp_path: Path,
+        monkeypatch,
     ) -> None:
         # Even if framework detection would also pick ``ac-django`` (manage.py
         # present), the overlay-declared companion must not appear twice.
+        monkeypatch.setattr(
+            "teatree.skill_support.loading._matches_any_remote",
+            lambda _cwd, _patterns: True,
+        )
         (tmp_path / "manage.py").touch()
         config = _config_with_companions(["ac-django", "ac-python"])
         trigger_index: list[dict[str, object]] = [
@@ -93,7 +108,7 @@ class TestSelectForPromptHookEmitsCompanionSkills:
         result = policy.select_for_prompt_hook(
             cwd=tmp_path,
             intent="code",
-            overlay_skill_metadata={},
+            overlay_skill_metadata=_IN_SCOPE_OVERLAY_META,
             loaded_skills=set(),
             trigger_index=trigger_index,
             companion_skills=config.companion_skills,


### PR DESCRIPTION
## What

Gate the overlay companion-skill load requirement on whether an overlay repo is
actually in scope for the task, so it no longer false-fires on teatree-core-only
work.

## Why

The skill-loading policy gated the overlay's own skill on whether an overlay
repo was actually in scope (overlay active, or the cwd's git remote matches the
overlay's remote_patterns) but added the overlay's companion_skills
unconditionally. On teatree-core-only work the overlay skill was correctly
withheld while its companion skills were still demanded, so the PreToolUse gate
blocked the first Bash/Edit/Write until irrelevant overlay companion skills
loaded.

Extract the in-scope decision into _overlay_in_scope and gate both the overlay
skill and its companion skills on it. Framework-skill detection stays
cwd-derived and independent of overlay scope.

Adds a symmetric fitness test: core-only intent does NOT require the overlay
companion skills; overlay-active / matching-remote intent DOES.

## Architecture pre-check

1. BLUEPRINT alignment: skill-loading policy (the UserPromptSubmit/PreToolUse
   skill-load gate); no section contradicted, behaviour narrowed not widened.
2. FSM phase boundaries: n/a — no Ticket/Worktree state transition.
3. Extension-point contracts: consumers of the policy
   (select_for_prompt_hook, select_for_runtime_phase, select_for_agent_launch)
   all route through _base_detected_skills; one shared predicate, no contract
   surface changed.
4. Component boundaries: change stays in teatree.skill_support.loading.
5. Dependency direction: no new imports; no backwards edge (tach + import-linter
   pre-commit hooks pass).
6. Test surface: tests/teatree_skill_support/test_skill_loading.py pins the
   asymmetry (core-only -> companions withheld; overlay-active / matching-remote
   -> companions required); tests/test_companion_skills_overlay.py updated to
   the corrected scoped behaviour.
7. Resilience invariants: n/a — pure in-process selection, no external write.
8. Identity/key normalization: n/a.
9. Behavior preservation: the only behaviour removed is the unconditional
   companion-skill demand on non-overlay work — the bug itself; the overlay
   skill's existing scope gate is unchanged and still pinned by its tests.

## Open questions & assumptions

- Assumes "overlay in scope" is fully captured by overlay_active OR a cwd-remote
  match against the overlay's remote_patterns — the same signal the overlay's
  own skill already used. No new scope signal introduced.

Closes #2415

