### PR TITLE
test: close git-fixture default-branch scanner blind spot (#2359 class A)

### DIFF
--- a/tests/quality/fixtures/git_fixture_default_branch/must_flag/bare_init_binary_variable.py.txt
+++ b/tests/quality/fixtures/git_fixture_default_branch/must_flag/bare_init_binary_variable.py.txt
@@ -1,0 +1,9 @@
+import subprocess
+
+
+def setup(p):
+    # The argv's executable element is a binary-name variable, not the literal
+    # ``"git"``. The vector is still a git call and the bare init still assumes
+    # the ambient default branch — it must be flagged.
+    subprocess.run([_GIT, "init", "-q", str(p)], check=True)
+    subprocess.run([_GIT, "-C", str(p), "worktree", "add", str(p / "wt"), "main"], check=True)

--- a/tests/quality/fixtures/git_fixture_default_branch/must_not_flag/binary_variable_born_and_non_git.py.txt
+++ b/tests/quality/fixtures/git_fixture_default_branch/must_not_flag/binary_variable_born_and_non_git.py.txt
@@ -1,0 +1,11 @@
+import subprocess
+
+
+def setup(p):
+    # A born branch via a binary-name variable is safe.
+    subprocess.run([_GIT, "init", "-q", "-b", "main", str(p)], check=True)
+    # A non-init verb whose -m message is literally "init" must not be read as
+    # the verb, even when the executable is a binary-name variable.
+    subprocess.run([GIT, "-C", str(p), "commit", "-q", "-m", "init"], check=True)
+    # A non-git binary that happens to take an "init" subcommand is not a git fixture.
+    subprocess.run([NODE, "init"], check=True)

--- a/tests/quality/test_git_fixture_default_branch.py
+++ b/tests/quality/test_git_fixture_default_branch.py
@@ -72,6 +72,15 @@ _VALUE_TAKING_GLOBAL_FLAGS = ("-C", "--git-dir", "--work-tree", "--namespace", "
 # ``run_git(repo, "init", …)``, ``self._git(repo, "init", …)``).
 _GIT_HELPER_NAMES = ("_git", "run_git", "_run_git")
 
+# A subprocess argv whose executable element is one of these variables is a git
+# call even though the literal ``"git"`` string is absent — fixtures bind the
+# binary once (``_GIT = shutil.which("git") or "git"``) and pass it positionally
+# (``subprocess.run([_GIT, "init", "-q"], …)``). Without this the bare init
+# evades the scanner entirely (the souliane/teatree#2359 blind spot). Compared
+# case-folded and leading-underscore-stripped, so ``_GIT`` / ``GIT`` / ``git_bin``
+# all match.
+_GIT_BINARY_VAR_NAMES = ("git", "git_bin")
+
 _FIXTURES = Path(__file__).resolve().parent / "fixtures" / "git_fixture_default_branch"
 _MUST_FLAG = sorted((_FIXTURES / "must_flag").glob("*.py.txt"))
 _MUST_NOT_FLAG = sorted((_FIXTURES / "must_not_flag").glob("*.py.txt"))
@@ -100,12 +109,30 @@ def _call_args(node: ast.Call) -> list[str | None]:
     return [_arg_value(a) for a in node.args]
 
 
+def _is_git_binary_var(node: ast.expr) -> bool:
+    """Whether *node* is a ``Name`` bound to the git binary (``_GIT``, ``GIT``, ``git_bin``).
+
+    Fixtures resolve the binary once and pass it positionally, so the argv's
+    executable element is a variable rather than the literal ``"git"`` — case-
+    insensitive so ``_GIT`` / ``GIT`` and the lower-case helper bindings match.
+    """
+    return isinstance(node, ast.Name) and node.id.lower().lstrip("_") in _GIT_BINARY_VAR_NAMES
+
+
 def _git_list_args(node: ast.List) -> list[str | None] | None:
-    """Arg vector after the literal ``"git"`` element, or ``None`` if not a git vector."""
+    """Arg vector after the git executable element, or ``None`` if not a git vector.
+
+    The executable is either the literal ``"git"`` string anywhere in the list,
+    or — when the list leads with one — a ``Name`` bound to the git binary
+    (``[_GIT, "init", …]``). The latter is the souliane/teatree#2359 blind spot:
+    a bare init built with a binary-name variable carries no ``"git"`` literal.
+    """
     elems = [_arg_value(e) for e in node.elts]
-    if "git" not in elems:
-        return None
-    return elems[elems.index("git") + 1 :]
+    if "git" in elems:
+        return elems[elems.index("git") + 1 :]
+    if node.elts and _is_git_binary_var(node.elts[0]):
+        return elems[1:]
+    return None
 
 
 def _has_born_or_bare_flag(args: list[str | None]) -> bool:
@@ -269,6 +296,27 @@ class TestScanner:
         src = 'subprocess.run(["git", "init", "-q", str(p)], check=True)\n'
         findings = scan_source(src, Path("x.py"))
         assert len(findings) == 1
+
+    def test_bare_init_with_git_binary_variable_is_flagged(self) -> None:
+        src = 'subprocess.run([_GIT, "init", "-q", str(p)], check=True)\n'
+        findings = scan_source(src, Path("x.py"))
+        assert len(findings) == 1
+
+    def test_bare_init_with_git_binary_variable_and_runtime_dash_c_is_flagged(self) -> None:
+        src = 'subprocess.run([_GIT, "-C", str(p), "init", "-q"], check=True)\n'
+        assert len(scan_source(src, Path("x.py"))) == 1
+
+    def test_born_init_with_git_binary_variable_is_not_flagged(self) -> None:
+        src = 'subprocess.run([_GIT, "init", "-q", "-b", "main", str(p)], check=True)\n'
+        assert scan_source(src, Path("x.py")) == []
+
+    def test_git_binary_variable_commit_with_init_message_is_not_flagged(self) -> None:
+        src = 'subprocess.run([GIT, "-C", str(p), "commit", "-q", "-m", "init"], check=True)\n'
+        assert scan_source(src, Path("x.py")) == []
+
+    def test_non_git_binary_variable_list_is_not_flagged(self) -> None:
+        src = 'subprocess.run([NODE, "init"], check=True)\n'
+        assert scan_source(src, Path("x.py")) == []
 
     def test_init_with_dash_b_is_not_flagged(self) -> None:
         src = 'subprocess.run(["git", "init", "-q", "-b", "main", str(p)], check=True)\n'

--- a/tests/teatree_backends/test_loader.py
+++ b/tests/teatree_backends/test_loader.py
@@ -31,7 +31,7 @@ _GIT = shutil.which("git") or "git"
 
 def _git_repo_with_origin(path: Path, origin_url: str) -> str:
     path.mkdir(parents=True, exist_ok=True)
-    subprocess.run([_GIT, "-C", str(path), "init", "-q"], check=True, capture_output=True)
+    subprocess.run([_GIT, "-C", str(path), "init", "-q", "-b", "main"], check=True, capture_output=True)
     subprocess.run(
         [_GIT, "-C", str(path), "remote", "add", "origin", origin_url],
         check=True,
@@ -323,5 +323,5 @@ class TestGetCodeHostForRepo:
         _stub_token(overlay, gitlab="gl-tok")
         path = tmp_path / "no-origin"
         path.mkdir()
-        subprocess.run([_GIT, "-C", str(path), "init", "-q"], check=True, capture_output=True)
+        subprocess.run([_GIT, "-C", str(path), "init", "-q", "-b", "main"], check=True, capture_output=True)
         assert isinstance(get_code_host_for_repo(overlay, str(path)), GitLabCodeHost)

--- a/tests/teatree_core/test_backend_factory.py
+++ b/tests/teatree_core/test_backend_factory.py
@@ -328,7 +328,7 @@ _GIT = shutil.which("git") or "git"
 
 
 def _git_origin(path: Path, origin_url: str) -> str:
-    subprocess.run([_GIT, "-C", str(path), "init", "-q"], check=True, capture_output=True)
+    subprocess.run([_GIT, "-C", str(path), "init", "-q", "-b", "main"], check=True, capture_output=True)
     subprocess.run([_GIT, "-C", str(path), "remote", "add", "origin", origin_url], check=True, capture_output=True)
     return str(path)
 
@@ -419,7 +419,7 @@ class TestCodeHostForRepoFromOverlay:
         """A TOML overlay + a repo with no origin remote → the GitHub-first default."""
         path = tmp_path / "no-origin"
         path.mkdir()
-        subprocess.run([_GIT, "-C", str(path), "init", "-q"], check=True, capture_output=True)
+        subprocess.run([_GIT, "-C", str(path), "init", "-q", "-b", "main"], check=True, capture_output=True)
         cfg = _toml_only_config(
             {"private-x": {"path": "~/workspace/private-x", "github_token_ref": "github/private-x/pat"}},
         )

--- a/tests/teatree_core/test_dev_repo.py
+++ b/tests/teatree_core/test_dev_repo.py
@@ -18,7 +18,7 @@ _GIT = "git"
 def _init_repo(path: Path, origin_slug: str) -> Path:
     """Create a git repo at *path* with an ``origin`` pointing at *origin_slug*."""
     path.mkdir(parents=True, exist_ok=True)
-    subprocess.run([_GIT, "-C", str(path), "init", "-q"], check=True)
+    subprocess.run([_GIT, "-C", str(path), "init", "-q", "-b", "main"], check=True)
     subprocess.run(
         [_GIT, "-C", str(path), "remote", "add", "origin", f"git@github.com:{origin_slug}.git"],
         check=True,

--- a/tests/test_cli_ci.py
+++ b/tests/test_cli_ci.py
@@ -78,7 +78,7 @@ class TestGetCIService:
 
     def test_resolves_service_from_repo_owning_overlay(self, tmp_path, monkeypatch):
         """Resolve the CI service via the repo's owning overlay when no overlay is active."""
-        subprocess.run([_GIT, "-C", str(tmp_path), "init", "-q"], check=True, capture_output=True)
+        subprocess.run([_GIT, "-C", str(tmp_path), "init", "-q", "-b", "main"], check=True, capture_output=True)
         subprocess.run(
             [_GIT, "-C", str(tmp_path), "remote", "add", "origin", "git@gitlab.com:group/repo.git"],
             check=True,

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -554,7 +554,7 @@ class TestValidateMrMultipleOverlays:
         # the deny path (no regression in rejection when resolution is sharp).
         repo = tmp_path / "alpha"
         repo.mkdir()
-        subprocess.run([_GIT, "init", "-q"], cwd=repo, check=True)
+        subprocess.run([_GIT, "init", "-q", "-b", "main"], cwd=repo, check=True)
         subprocess.run([_GIT, "remote", "add", "origin", "git@github.com:acme/alpha.git"], cwd=repo, check=True)
         monkeypatch.chdir(repo)
         overlays = {

--- a/tests/test_comment_density_gate.py
+++ b/tests/test_comment_density_gate.py
@@ -332,7 +332,7 @@ class TestPrePushHook:
     def _init_repo(self, tmp_path: Path) -> Path:
         repo = tmp_path / "repo"
         repo.mkdir()
-        subprocess.run([GIT, "init", "-q"], cwd=repo, check=True)
+        subprocess.run([GIT, "init", "-q", "-b", "main"], cwd=repo, check=True)
         subprocess.run([GIT, "config", "user.email", "t@example.com"], cwd=repo, check=True)
         subprocess.run([GIT, "config", "user.name", "t"], cwd=repo, check=True)
         return repo

--- a/tests/test_overlay_loader.py
+++ b/tests/test_overlay_loader.py
@@ -239,7 +239,7 @@ class TestInferOverlayForUrl:
 def _init_repo_with_origin(path: Path, origin_url: str) -> None:
     """Create a real git repo at ``path`` with ``origin`` set to ``origin_url``."""
     path.mkdir(parents=True, exist_ok=True)
-    subprocess.run([_GIT, "init", "-q"], cwd=path, check=True)
+    subprocess.run([_GIT, "init", "-q", "-b", "main"], cwd=path, check=True)
     subprocess.run([_GIT, "remote", "add", "origin", origin_url], cwd=path, check=True)
 
 
@@ -299,7 +299,7 @@ class TestGetOverlayForRepo:
     def test_repo_without_origin_returns_none(self, tmp_path):
         repo = tmp_path / "no-origin"
         repo.mkdir()
-        subprocess.run([_GIT, "init", "-q"], cwd=repo, check=True)
+        subprocess.run([_GIT, "init", "-q", "-b", "main"], cwd=repo, check=True)
         overlays = {"a": _RepoOverlay(["acme/widgets"])}
         with patch("teatree.core.overlay_loader.get_all_overlays", return_value=overlays):
             assert get_overlay_for_repo(str(repo)) is None


### PR DESCRIPTION
test: close git-fixture default-branch scanner blind spot (#2359 class A)

## What

Extend the #2359 class-A fitness function so its argv scanner recognises a git
call whose executable element is a binary-name variable (_GIT / GIT / git_bin),
not only a vector carrying the literal git string. Born the branch (-b main) at
the ten bare-init sites the now-complete scanner surfaces, and add scanner units
plus must-flag/must-not-flag corpus fixtures for the binary-variable form.

## Why

PR #2362 swept the literal-git bare-init sites and added the fitness function
(tests/quality/test_git_fixture_default_branch.py), but its _git_list_args only
matched vectors containing the literal git string. Fixtures that bind the binary
once (_GIT = shutil.which git or git) and pass it positionally
(subprocess.run with a leading _GIT element) carried no git literal, so ten
bare-init sites evaded the gate entirely — the blind spot that lets the class
silently return (#2359 acceptance criterion C). A future fixture using that argv
form plus a literal main reference would reintroduce the exit-128-on-master flake
with no guard firing.

The live-tree gate is clean after the fix, the touched fixtures pass under a
forced init.defaultBranch=master, and the full suite is green (18913 passed).

## Open questions & assumptions

- The ten surfaced sites do not reference a literal main/master after the bare
  init today, so they are not runtime-flaky on their own; borning the branch
  makes them deterministic and satisfies the scanner. Class B (order-dependent
  shared-state pollution) is tracked separately on #2359 and out of scope here.

## Architecture pre-check — #2359 (class A)

## 1. BLUEPRINT § alignment
Architectural-fitness concern (deterministic structural test). Touches no BLUEPRINT FSM/overlay section; the change lives entirely in the test fitness function and its real-git fixtures.

## 2. FSM phase boundaries
n/a — no Ticket.State / Worktree.State transition.

## 3. Extension-point contracts
n/a — no OverlayBase / scanner-registration / hook / *Backend Protocol surface touched.

## 4. Component boundaries
tests/quality/ (the fitness-function home) + the real-git fixture files under tests/. No src/ production code.

## 5. Dependency direction
n/a — test-only change; no new src import edges. ruff clean, module-health --from-ref origin/main exit 0.

## 6. Test surface
- Scanner units: a bare git init whose executable is a binary-name variable (_GIT/GIT/git_bin) is flagged; the born (-b main) form, the commit-with-"init"-message form, and a non-git binary are not. Proven anti-vacuous (1 finding with the fix, 0 with _git_list_args reverted to literal-"git"-only).
- Corpus: must_flag/bare_init_binary_variable + must_not_flag/binary_variable_born_and_non_git.
- Live-tree gate (TestLiveTree) returns 0 findings once the ten surfaced sites born the branch.

## 7. Resilience invariants
n/a — no external write.

## 8. Identity and key normalization
The git-binary executable name is canonicalized UP (case-folded, leading-underscore-stripped) before the membership check, so _GIT / GIT / git_bin all resolve to the same key — no strip-to-match information loss.

## 9. Behavior preservation / capability deletion
Purely additive to the scanner: the literal-"git" branch is unchanged; the binary-variable branch is a new recognition path. No must-block test inverted; no matcher narrowed.
