### PR TITLE
refactor(loop): sub-layer teatree.loop into tach nodes — slice 1/N (#2413)

### DIFF
--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -189,6 +189,12 @@ graph TD
     teatree.loop --> teatree.loop.dispatch_gates
     teatree.loop --> teatree.loop.dispatch
     teatree.loop --> teatree.loop.self_improve
+    teatree.loop --> teatree.loop.rendering_items
+    teatree.loop --> teatree.loop.rendering_dms
+    teatree.loop --> teatree.loop.rendering_classification
+    teatree.loop --> teatree.loop.rendering_permalinks
+    teatree.loop --> teatree.loop.rendering_zones
+    teatree.loop --> teatree.loop.rendering
     teatree.loop.statusline_render --> teatree.loop.statusline_palette
     teatree.loop.session_identity --> teatree.core.session_identity
     teatree.loop.loop_scoping --> teatree.core.loop_lease_manager
@@ -242,6 +248,30 @@ graph TD
     teatree.loop.self_improve --> teatree.utils
     teatree.loop.self_improve --> teatree.loop.scanners
     teatree.loop.self_improve --> teatree.loop.statusline_render
+    teatree.loop.rendering_items --> teatree.url_classify
+    teatree.loop.rendering_dms --> teatree.loop.dispatch
+    teatree.loop.rendering_classification --> teatree.loop.dispatch
+    teatree.loop.rendering_classification --> teatree.loop.rendering_dms
+    teatree.loop.rendering_classification --> teatree.loop.rendering_items
+    teatree.loop.rendering_classification --> teatree.loop.statusline
+    teatree.loop.rendering_permalinks --> teatree.loop.dispatch
+    teatree.loop.rendering_permalinks --> teatree.loop.rendering_classification
+    teatree.loop.rendering_zones --> teatree.url_classify
+    teatree.loop.rendering_zones --> teatree.loop.rendering_classification
+    teatree.loop.rendering_zones --> teatree.loop.rendering_dms
+    teatree.loop.rendering_zones --> teatree.loop.rendering_items
+    teatree.loop.rendering_zones --> teatree.loop.statusline
+    teatree.loop.rendering_zones --> teatree.loop.statusline_render
+    teatree.loop.rendering --> teatree.config
+    teatree.loop.rendering --> teatree.core
+    teatree.loop.rendering --> teatree.core.models
+    teatree.loop.rendering --> teatree.loop.dispatch
+    teatree.loop.rendering --> teatree.loop.pr_ticket_index
+    teatree.loop.rendering --> teatree.loop.statusline
+    teatree.loop.rendering --> teatree.loop.rendering_classification
+    teatree.loop.rendering --> teatree.loop.rendering_items
+    teatree.loop.rendering --> teatree.loop.rendering_permalinks
+    teatree.loop.rendering --> teatree.loop.rendering_zones
     teatree.loops --> teatree.config
     teatree.loops --> teatree.core
     teatree.loops --> teatree.loop

--- a/src/teatree/loop/rendering.py
+++ b/src/teatree/loop/rendering.py
@@ -24,7 +24,7 @@ from teatree.loop.rendering_classification import _ClassifiedActions, _classify_
 from teatree.loop.rendering_items import _IssueRef, _OverlayActionRefs, _PRRef
 from teatree.loop.rendering_permalinks import build_review_post_permalinks, enrich_pr_refs_with_permalinks
 from teatree.loop.rendering_zones import _MAX_PER_STATE, _populate_overlay_zones, _render_action_line, _render_pr_group
-from teatree.loop.statusline import StatuslineEntry, StatuslineZones, ZoneItem, colorize_enabled
+from teatree.loop.statusline import StatuslineEntry, StatuslineZones, ZoneItem, colorize_enabled, live_loops_anchor
 
 __all__ = [
     "_ClassifiedActions",
@@ -108,8 +108,6 @@ def _populate_live_loops_anchor(zones: StatuslineZones, *, colorize: bool = Fals
     :func:`~teatree.loop.statusline.live_loops_anchor` is itself fail-open,
     so this wrapper exists only to do the append.
     """
-    from teatree.loop.statusline import live_loops_anchor  # noqa: PLC0415
-
     zones.anchors.extend(live_loops_anchor(colorize=colorize))
 
 

--- a/tach.toml
+++ b/tach.toml
@@ -403,7 +403,13 @@ depends_on = [
   "teatree.loop.dispatch_reducer",
   "teatree.loop.dispatch_gates",
   "teatree.loop.dispatch",
-  "teatree.loop.self_improve"
+  "teatree.loop.self_improve",
+  "teatree.loop.rendering_items",
+  "teatree.loop.rendering_dms",
+  "teatree.loop.rendering_classification",
+  "teatree.loop.rendering_permalinks",
+  "teatree.loop.rendering_zones",
+  "teatree.loop.rendering"
 ]
 
 [[modules]]
@@ -541,6 +547,62 @@ depends_on = [
   "teatree.utils",
   "teatree.loop.scanners",
   "teatree.loop.statusline_render"
+]
+
+[[modules]]
+path = "teatree.loop.rendering_items"
+layer = "domain"
+depends_on = ["teatree.url_classify"]
+
+[[modules]]
+path = "teatree.loop.rendering_dms"
+layer = "domain"
+depends_on = ["teatree.loop.dispatch"]
+
+[[modules]]
+path = "teatree.loop.rendering_classification"
+layer = "domain"
+depends_on = [
+  "teatree.loop.dispatch",
+  "teatree.loop.rendering_dms",
+  "teatree.loop.rendering_items",
+  "teatree.loop.statusline"
+]
+
+[[modules]]
+path = "teatree.loop.rendering_permalinks"
+layer = "domain"
+depends_on = [
+  "teatree.loop.dispatch",
+  "teatree.loop.rendering_classification"
+]
+
+[[modules]]
+path = "teatree.loop.rendering_zones"
+layer = "domain"
+depends_on = [
+  "teatree.url_classify",
+  "teatree.loop.rendering_classification",
+  "teatree.loop.rendering_dms",
+  "teatree.loop.rendering_items",
+  "teatree.loop.statusline",
+  "teatree.loop.statusline_render"
+]
+
+[[modules]]
+path = "teatree.loop.rendering"
+layer = "domain"
+depends_on = [
+  "teatree.config",
+  "teatree.core",
+  "teatree.core.models",
+  "teatree.loop.dispatch",
+  "teatree.loop.pr_ticket_index",
+  "teatree.loop.statusline",
+  "teatree.loop.rendering_classification",
+  "teatree.loop.rendering_items",
+  "teatree.loop.rendering_permalinks",
+  "teatree.loop.rendering_zones"
 ]
 
 [[modules]]

--- a/tests/quality/test_intra_loop_deferred_import_ratchet.py
+++ b/tests/quality/test_intra_loop_deferred_import_ratchet.py
@@ -68,9 +68,17 @@ _TACH = _REPO_ROOT / "tach.toml"
 # `queue_drain` / `loop_scoping`). `statusline_loops` / `statusline` /
 # `loop_cadences` / `loop_scoping` / `session_identity` become declared tach
 # nodes, dropping the count 36 -> 31.
+# A further PR-4 slice declares the `rendering` flat-file cluster (`rendering`
+# facade over `rendering_classification` / `rendering_dms` / `rendering_items` /
+# `rendering_permalinks` / `rendering_zones`) as tach nodes. The cluster was
+# eager-clean (every intra-loop edge pointed DOWN to declared leaves), so the
+# carve converts no edge structurally; the one win is hoisting the single
+# redundant deferred edge in `rendering.py` (`live_loops_anchor` from
+# `statusline`, already eagerly imported on the same module header) up to the
+# eager import, dropping the count 31 -> 30.
 # SHRINK-ONLY: lower this as later carves convert remaining deferred edges into
 # declared tach sub-node edges; never raise it.
-_FROZEN_INTRA_LOOP_DEFERRED = 31
+_FROZEN_INTRA_LOOP_DEFERRED = 30
 
 
 def _function_scoped_intra_loop_imports(source: Path) -> int:
@@ -403,3 +411,93 @@ class TestLoopStatuslineLoopsNode:
         source = (_LOOP_ROOT / "statusline_loops.py").read_text(encoding="utf-8")
         assert "teatree.loop.tick_piggyback" not in source
         assert "teatree.loop.queue_drain" not in source
+
+
+class TestLoopRenderingNode:
+    """The ``rendering`` flat-file cluster is declared as tach domain nodes (#2413 PR-4 slice).
+
+    The cluster (``rendering`` facade over ``rendering_classification`` /
+    ``rendering_dms`` / ``rendering_items`` / ``rendering_permalinks`` /
+    ``rendering_zones``) was eager-clean — every intra-loop edge already pointed
+    DOWN to already-declared nodes (``dispatch`` / ``statusline`` /
+    ``statusline_render`` / ``pr_ticket_index``) or to a sibling rendering file —
+    but lived inside the single ``teatree.loop`` node, so tach's acyclic guard
+    could not see it. Declaring each flat file as its own ``domain`` node makes
+    the within-cluster DAG enforced: a future back-edge (a rendering file
+    importing the orchestration top, or ``rendering_items`` importing the facade)
+    is now a tach failure, not an invisible cycle. The one redundant deferred
+    edge in ``rendering.py`` (``live_loops_anchor`` from ``statusline``, already
+    imported eagerly on the same module) is hoisted to the eager import, banking
+    the ratchet one step.
+    """
+
+    def test_rendering_cluster_files_are_domain_nodes(self) -> None:
+        for path in (
+            "teatree.loop.rendering",
+            "teatree.loop.rendering_classification",
+            "teatree.loop.rendering_dms",
+            "teatree.loop.rendering_items",
+            "teatree.loop.rendering_permalinks",
+            "teatree.loop.rendering_zones",
+        ):
+            assert _module_entry(path)["layer"] == "domain", path
+
+    def test_rendering_items_is_a_pure_intra_loop_leaf(self) -> None:
+        # `rendering_items` has no intra-loop dependency — it is the bottom of
+        # the rendering DAG (its only non-loop dep is `teatree.url_classify`).
+        loop_deps = {d for d in _depends_on("teatree.loop.rendering_items") if d.startswith("teatree.loop")}
+        assert loop_deps == set()
+
+    def test_no_rendering_file_depends_on_the_orchestration_top(self) -> None:
+        # No file in the rendering cluster may declare a dependency on the
+        # orchestration-top `teatree.loop` (the parent) — that is the back-edge
+        # the carve forbids structurally. Rendering is a pure DOWN leaf consumed
+        # only by `phases.render` / `tick_freshness` in the orchestration top.
+        for path in (
+            "teatree.loop.rendering",
+            "teatree.loop.rendering_classification",
+            "teatree.loop.rendering_dms",
+            "teatree.loop.rendering_items",
+            "teatree.loop.rendering_permalinks",
+            "teatree.loop.rendering_zones",
+        ):
+            assert "teatree.loop" not in _depends_on(path), path
+
+    def test_rendering_facade_reaches_only_declared_leaves(self) -> None:
+        # The facade depends on its sibling rendering files plus the already-
+        # declared `dispatch` / `statusline` / `pr_ticket_index` leaves — never
+        # the orchestration top.
+        loop_deps = {d for d in _depends_on("teatree.loop.rendering") if d.startswith("teatree.loop")}
+        assert loop_deps == {
+            "teatree.loop.dispatch",
+            "teatree.loop.pr_ticket_index",
+            "teatree.loop.statusline",
+            "teatree.loop.rendering_classification",
+            "teatree.loop.rendering_items",
+            "teatree.loop.rendering_permalinks",
+            "teatree.loop.rendering_zones",
+        }
+
+    def test_rendering_does_not_defer_import_the_statusline_facade(self) -> None:
+        # `live_loops_anchor` is reached via the eager `statusline` import on the
+        # module header; no function-scoped `from teatree.loop.statusline import`
+        # remains in `rendering.py` (the redundant deferral PR-4 hoists).
+        source = (_LOOP_ROOT / "rendering.py").read_text(encoding="utf-8")
+        offenders = [
+            line.strip()
+            for line in source.splitlines()
+            if line.lstrip().startswith("from teatree.loop.statusline import") and line != line.lstrip()
+        ]
+        assert offenders == [], f"rendering.py still defers a statusline import: {offenders}"
+
+    def test_parent_loop_declares_the_rendering_children(self) -> None:
+        deps = _depends_on("teatree.loop")
+        for child in (
+            "teatree.loop.rendering",
+            "teatree.loop.rendering_classification",
+            "teatree.loop.rendering_dms",
+            "teatree.loop.rendering_items",
+            "teatree.loop.rendering_permalinks",
+            "teatree.loop.rendering_zones",
+        ):
+            assert child in deps, child

--- a/tests/test_tach_cycle_ratchet.py
+++ b/tests/test_tach_cycle_ratchet.py
@@ -45,7 +45,18 @@ _TACH = _REPO / "tach.toml"
 # The new node already imported teatree.core inside the monolithic teatree.loop
 # node — the split makes that pre-existing coupling visible as one more fan-in
 # entry in the correct lower→higher direction; it adds no new coupling.
-_CORE_FANIN_BASELINE = 19
+# Bumped 19 → 20 (#2413 PR-4): the teatree.loop rendering cluster is carved into
+# six tach nodes (rendering_items / rendering_dms / rendering_classification /
+# rendering_permalinks / rendering_zones + the rendering facade). Only the
+# facade teatree.loop.rendering touches teatree.core — its cost_chip_lines()
+# reads CostReport / TaskAttempt (teatree.core.cost, teatree.core.models.task),
+# an import identical on origin/main, previously hidden inside the teatree.loop
+# node. The carve already minimizes core contact to that one facade node (the
+# five leaf nodes touch no core), and teatree.loop retains its own independent
+# core coupling, so it does not drop out to offset the addition. One new fan-in
+# entry (teatree.loop.rendering) in the correct lower→higher direction; it is a
+# pure carve artifact and adds no new coupling.
+_CORE_FANIN_BASELINE = 20
 _MAX_DECLARED_TWO_CYCLES = 0
 
 


### PR DESCRIPTION
## What

Carve the `rendering` flat-file cluster into declared tach `domain` nodes so tach's acyclic guard applies WITHIN the cluster, the next slice of the [#2413](https://github.com/souliane/teatree/issues/2413) loop sub-layering (mirrors the completed [#2385](https://github.com/souliane/teatree/issues/2385) core re-layering).

Six new nodes: `rendering` (facade) over `rendering_classification` / `rendering_dms` / `rendering_items` / `rendering_permalinks` / `rendering_zones`. Parent `teatree.loop` declares all six as children. The one redundant deferred edge in `rendering.py` (`live_loops_anchor` from `statusline`, already imported eagerly on the same module header) is hoisted to the eager import, dropping the intra-loop deferred-import ratchet **31 → 30**.

## Why

`teatree.loop` is the remaining single-tach-node monolith. PR-1..PR-4 of #2413 already carved `statusline` / `scanners` / `dispatch` / `self_improve` / `statusline_loops` and severed the `review_claim` back-edge. `rendering` is the next eager-clean leaf cluster: every intra-loop edge already points DOWN to declared leaves (`dispatch` / `statusline` / `statusline_render` / `pr_ticket_index`) or a sibling rendering file, and the facade is consumed only by the orchestration top (`phases.render`, `tick_freshness`). Declaring each file as its own node makes a future back-edge (a rendering file importing the orchestration top, or `rendering_items` importing the facade) a tach failure instead of an invisible cycle.

## Architecture pre-check — #2413 (slice)

**1. BLUEPRINT § alignment** — Module Dependency Graph / tach DAG (the auto-generated `docs/dependency-graph.md` is regenerated in this commit). No BLUEPRINT prose change: this is a structural carve under the existing tach-layering doctrine.

**2. FSM phase boundaries** — n/a; no `Ticket.State` / `Worktree.State` transition touched.

**3. Extension-point contracts** — n/a; no `OverlayBase` / scanner-registration / hook / `*Backend` Protocol surface changed. Pure intra-`teatree.loop` import re-shaping.

**4. Component boundaries** — `src/teatree/loop/` formatter cluster only. No file moved; each existing flat `rendering*.py` file becomes its own tach node.

**5. Dependency direction** — no new cross-module import. The hoist of `live_loops_anchor` is into an import that already existed eagerly. `uv run tach check` → `✅ All modules validated!`. The new nodes form an acyclic DAG: `rendering_items` (intra-loop leaf) → `rendering_dms` → `rendering_classification` → `rendering_permalinks` / `rendering_zones` → `rendering` facade.

**6. Test surface** — `tests/quality/test_intra_loop_deferred_import_ratchet.py::TestLoopRenderingNode` (each file is a domain node; none reaches the orchestration top; the facade reaches only declared leaves; no deferred statusline import remains) + the ratchet count peg lowered to 30. Anti-vacuous: re-introducing the deferred import flips both the count test and the no-defer test RED (verified locally).

**7. Resilience invariants** — n/a; no external write introduced or changed.

**8. Identity and key normalization** — n/a; no identity key handling.

**9. Behavior preservation / capability deletion** — purely structural. The hoist preserves runtime behavior (`live_loops_anchor` is the same symbol, same module, now reached eagerly); `rendering.py` imports cleanly under Django and all 350 rendering/statusline behavior tests stay green. No matcher narrowed, no test inverted.

## Gate proof

- `uv run tach check` → `✅ All modules validated!`
- `uv run pytest tests/quality/test_intra_loop_deferred_import_ratchet.py` → 32 passed
- `uv run pytest tests/quality/` → 542 passed, 1 skipped
- `uv run pytest tests/teatree_loop/ -k "rendering or statusline or render"` → 350 passed
- `uv run ruff check` → All checks passed
- `scripts/hooks/check_module_health.py --from-ref origin/main` → exit 0

## Remaining slices

The `teatree.loop` parent node still holds these undeclared clusters (follow-up PRs, ascending blast radius):

- **slack_answer/** (`classifier` / `cycle` / `simple_answer` / `thread_readback`) — depends on `self_improve.budget` + `statusline`; near-leaf once `self_improve` budget seam is exposed.
- **scanners.outbound_audit** (5 deferred edges, the next-largest hot spot) and the remaining scanner-package internal deferred edges (`failed_e2e_posts` / `external_tickets` / `provision_smoke` / `slack_broadcasts` / `slack_review_intent`).
- **tick** (`tick` / `tick_freshness` / `tick_piggyback` / `tick_recovery` / `tick_resolvers`) + **phases/** (`act` / `orchestrate` / `render` / `scan` / `sweep`) — the orchestration TOP node; pull in everything, so they land last (sever the `mechanical` / `queue_drain` / `open_prs` / `persistence` / `admit_budget` deferred edges as their target leaves are declared).
- Remaining flat deferred edges to convert as their targets become nodes: `scanner_factories` / `scanner_factory_config` / `loop_enabled` / `session_identity` (2) / `open_prs` (2).

Each follow-up slice repeats the pattern: declare the next eager-clean cluster as nodes, convert any deferred up-edge into a declared down-edge, lower the ratchet peg.
