### PR TITLE
fix(skills): clear banned-terms leak in review skill cross-service section

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -4778,18 +4778,34 @@ Usage: t3 teatree workspace clean-all [OPTIONS]
  loop tick still runs unattended). The #706/#835/#1506 data-loss guards and
  the deterministic squash signal are unchanged.
 
+ Orphaned RAW worktrees (#2361): a ``git worktree`` with no teatree
+ ``Worktree`` row (created by a sub-agent's bare ``git worktree add``) is
+ discovered and disposed of. A merged/gone orphan is reaped; one with
+ unpushed work is reaped only under ``--reap-unsynced=snapshot`` AND only
+ after a recovery artifact is captured — ``keep`` (default) leaves it.
+
+ The ordered passes live in :func:`run_clean_all`; this method is the thin
+ CLI wrapper that supplies the worktree dir and the command's IO sinks.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --keep-dslr                          INTEGER  Number of DSLR snapshots to    │
-│                                               keep per tenant.               │
-│                                               [default: 1]                   │
-│ --interactive    --no-interactive             Prompt push/abandon/skip per   │
-│                                               worktree with unsynced work    │
-│                                               (#2361). Default is fully      │
-│                                               unattended — uncertain         │
-│                                               worktrees are kept with a      │
-│                                               warning, never prompted.       │
-│                                               [default: no-interactive]      │
-│ --help                                        Show this message and exit.    │
+│ --keep-dslr                            INTEGER  Number of DSLR snapshots to  │
+│                                                 keep per tenant.             │
+│                                                 [default: 1]                 │
+│ --reap-unsynced                        TEXT     Disposition for orphaned RAW │
+│                                                 worktrees with unpushed work │
+│                                                 (#2361): 'keep' (default,    │
+│                                                 safe — leave them) or        │
+│                                                 'snapshot' (write a recovery │
+│                                                 artifact, THEN reap).        │
+│                                                 [default: keep]              │
+│ --interactive      --no-interactive             Prompt push/abandon/skip per │
+│                                                 worktree with unsynced work  │
+│                                                 (#2361). Default is fully    │
+│                                                 unattended — uncertain       │
+│                                                 worktrees are kept with a    │
+│                                                 warning, never prompted.     │
+│                                                 [default: no-interactive]    │
+│ --help                                          Show this message and exit.  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -357,7 +357,7 @@ Check the overlay skill's commit-message and PR-description rules **before** pro
 
 **Step 0g — Cross-Service Verification (Non-Negotiable):**
 
-A review of a service that talks to other services is incomplete until those other services have been checked. Reviewing one repo in isolation produces blind comments — the reviewer asserts "this is the convention" or "this default is fine" without knowing what the producers and consumers across the platform actually do. Comments built on that premise make the user look stupid when the author replies with "have you checked the FE / the gateway / the sibling microservice?".
+A review of a service that talks to other services is incomplete until those other services have been checked. Reviewing one repo in isolation produces blind comments — the reviewer asserts "this is the convention" or "this default is fine" without knowing what the producers and consumers across the platform actually do. Comments built on that premise undermine the reviewer's credibility when the author replies with "have you checked the FE / the gateway / the sibling microservice?".
 
 **Before posting any comment about a name, contract, default value, schema field, response shape, or wire format, exhaust the cross-service grep:**
 


### PR DESCRIPTION
## Problem
The review skill's cross-service-grep rationale (`skills/review/SKILL.md`) used a banned term, so the tree-wide `banned-terms` gate fails on every `t3 tool verify-gates` run. This blocks the green-proof for any unrelated branch.

## Fix
Reword the one offending sentence to neutral phrasing that keeps the same point: a reviewer asserting platform conventions without checking sibling services loses credibility. One-line prose change, no behavior change.

## Gate proof
`t3 tool verify-gates` exits 0 (commit + push stages all green). `grep -rn '\bstupid\b' skills/ src/ docs/` returns zero hits.

Unblocks #1925 and #1921 (both pass verify-gates once this lands).