### PR TITLE
fix(hooks): unify env-prefix regex across banned-terms detection and t3-review extraction

### DIFF
--- a/src/teatree/hooks/_t3_review_post.py
+++ b/src/teatree/hooks/_t3_review_post.py
@@ -22,9 +22,10 @@ invocation gets the same scanning as a bare ``t3`` leader, consistent with how
 the surrounding parser normalises a segment's leader.
 """
 
-import re
 from pathlib import PurePosixPath
 from typing import Final
+
+from teatree.hooks._publish_detection import _ENV_ASSIGNMENT_RE
 
 # The ``t3 review`` posting verbs whose BODY is the positional ``NOTE``
 # argument rather than a ``--body``/``--message`` flag.
@@ -43,22 +44,19 @@ _T3_REVIEW_VALUE_FLAGS: Final[frozenset[str]] = frozenset({"--file", "--line", "
 # that itself starts with ``-``; everything after it is a positional.
 _END_OF_OPTIONS: Final[str] = "--"
 
-# Matches a leading ``KEY=value`` environment assignment, mirroring
-# :func:`_command_parser._first_two_words` so the leader is found the same way.
-_ENV_ASSIGNMENT_PATTERN: Final[str] = r"[A-Z_][A-Z0-9_]*=.*"
-
 
 def _t3_leader_index(words: list[str]) -> int | None:
     """Return the index of the ``t3`` executable word, or ``None``.
 
     The leader is canonicalised up to the ``t3`` executable: leading
-    ``KEY=value`` env assignments are skipped (as in
-    :func:`_command_parser._first_two_words`) and a path-form leader is reduced
-    to its basename, so ``t3``, ``./t3``, ``/usr/local/bin/t3`` and
-    ``FOO=bar t3`` all resolve to the ``t3`` executable.
+    ``KEY=value`` env assignments are skipped via the same permissive
+    :data:`_publish_detection._ENV_ASSIGNMENT_RE` the publish-detection layer
+    uses to classify the segment, and a path-form leader is reduced to its
+    basename, so ``t3``, ``./t3``, ``/usr/local/bin/t3``, ``FOO=bar t3`` and
+    ``foo=bar t3`` all resolve to the ``t3`` executable.
     """
     for i, word in enumerate(words):
-        if re.fullmatch(_ENV_ASSIGNMENT_PATTERN, word):
+        if _ENV_ASSIGNMENT_RE.fullmatch(word):
             continue
         return i if PurePosixPath(word).name == "t3" else None
     return None

--- a/tests/teatree_hooks/test_banned_terms_scanner.py
+++ b/tests/teatree_hooks/test_banned_terms_scanner.py
@@ -404,6 +404,17 @@ class TestT3ReviewPostBodyIsPositionalNote:
         assert payload is not None
         assert "acmecorp" in payload
 
+    def test_lowercase_env_prefixed_t3_leader_note_is_surfaced(self) -> None:
+        # A lowercase env name (``foo=bar t3 ...``) is a valid bash assignment.
+        # The publish-detection layer strips it with the permissive env-prefix
+        # regex and classifies the segment as a review post, so the NOTE
+        # extractor must use the SAME permissive regex — an uppercase-only
+        # pattern left the leader unresolved and the banned term in the
+        # positional NOTE slipped through unscanned.
+        payload = self._payload('foo=bar t3 teatree review post-comment my-org/repo 7 "acmecorp note"')
+        assert payload is not None
+        assert "acmecorp" in payload
+
     def test_path_form_t3_leader_note_is_surfaced(self) -> None:
         # G2 RED guard: a path-form ``t3`` leader (``./t3``) was not recognised
         # as a review post, so the positional NOTE escaped scanning.


### PR DESCRIPTION
Closes #2360.

## Problem
`_t3_review_post._ENV_ASSIGNMENT_PATTERN` was uppercase-only (`[A-Z_][A-Z0-9_]*=.*`) while the canonical `_publish_detection._ENV_ASSIGNMENT_RE` is permissive (`[A-Za-z_][A-Za-z0-9_]*=.*`). For a lowercase-env-prefixed leader (e.g. `foo=bar t3 review post-comment ... \"<note>\"`, valid bash), detection engaged but `_t3_leader_index` returned `None`, so the positional note was never scanned and a banned term in it slipped through.

## Fix
`_t3_leader_index` now imports and reuses the canonical `_ENV_ASSIGNMENT_RE` from `_publish_detection` (single source of truth); the narrow duplicate pattern is removed. Detection and extraction now strip the identical env-prefix set.

## Test
Added an anti-vacuous regression test (RED before / GREEN after): a lowercase-env-prefixed `t3 review post-comment` whose positional note carries a banned term is now surfaced/scanned.

## Gate proof
Targeted tests pass; `ruff check` / `ruff format --check` / `tach check` / module-health all clean. `t3 tool verify-gates` exits 0 once the pre-existing review-skill leak (#2527) lands; the feature diff itself touches only the two hook/test files.

Follow-up (out of scope): a third copy of the same env regex exists inline in `_command_parser._first_two_words`; candidate for the same unification.