### PR TITLE
refactor(tests): remove deprecated on-behalf gate test aliases

### DIFF
--- a/tests/teatree_core/_on_behalf_gate_helpers.py
+++ b/tests/teatree_core/_on_behalf_gate_helpers.py
@@ -25,10 +25,6 @@ Two flavours are exported because the consumers differ:
     var for the lifetime of the test using pytest's ``monkeypatch``
     fixture, so an autouse fixture can call it without context-manager
     scoping.
-
-The legacy names ``on_behalf_gate_off`` and ``_GATE_OFF_TOML`` remain as
-deprecated aliases pointing at the new helpers so existing import sites
-keep working through the deprecation window.
 """
 
 import os
@@ -72,8 +68,3 @@ def disable_on_behalf_gate(
     cfg.write_text(_MODE_IMMEDIATE_TOML, encoding="utf-8")
     monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
     monkeypatch.setenv("T3_ON_BEHALF_POST_MODE", _MODE_IMMEDIATE_ENV)
-
-
-# Deprecated legacy aliases — kept so existing import sites keep working.
-_GATE_OFF_TOML = _MODE_IMMEDIATE_TOML
-on_behalf_gate_off = mode_immediate_cm

--- a/tests/teatree_core/test_signals.py
+++ b/tests/teatree_core/test_signals.py
@@ -10,7 +10,7 @@ import teatree.core.signals as signals_mod
 from teatree.core.models import PullRequest, Session, Task, Ticket
 from teatree.core.models.transition import TicketTransition
 from tests.teatree_agents._sdk_fake import fake_sdk, success_stream
-from tests.teatree_core._on_behalf_gate_helpers import on_behalf_gate_off
+from tests.teatree_core._on_behalf_gate_helpers import mode_immediate_cm
 from tests.teatree_core.conftest import CommandOverlay
 
 
@@ -185,7 +185,7 @@ class TestSlackReactionsOnTransition(TestCase):
             called.append((t, name))
             return 1
 
-        with on_behalf_gate_off(), _patch_transition_publisher(_fake):
+        with mode_immediate_cm(), _patch_transition_publisher(_fake):
             ticket.mark_merged()
             ticket.save()
 
@@ -199,7 +199,7 @@ class TestSlackReactionsOnTransition(TestCase):
             msg = "slack down"
             raise RuntimeError(msg)
 
-        with on_behalf_gate_off(), _patch_transition_publisher(_boom):
+        with mode_immediate_cm(), _patch_transition_publisher(_boom):
             ticket.mark_merged()
             ticket.save()
 
@@ -214,7 +214,7 @@ class TestSlackReactionsOnTransition(TestCase):
             names.append(name)
             return 0
 
-        with on_behalf_gate_off(), _patch_transition_publisher(_record):
+        with mode_immediate_cm(), _patch_transition_publisher(_record):
             ticket.rework()
             ticket.save()
 
@@ -228,7 +228,7 @@ class TestSlackReactionsOnTransition(TestCase):
         original = reaction_dispatch._publisher
         reaction_dispatch._publisher = None
         try:
-            with on_behalf_gate_off():
+            with mode_immediate_cm():
                 ticket.mark_merged()
                 ticket.save()
         finally:
@@ -269,7 +269,7 @@ class TestApprovalReactionOnTransition(TestCase):
             calls.append((pull_request,))
             return 1
 
-        with on_behalf_gate_off(), _patch_approval_publisher(_fake):
+        with mode_immediate_cm(), _patch_approval_publisher(_fake):
             pr.approve()
             pr.save()
 
@@ -326,7 +326,7 @@ class TestApprovalReactionOnTransition(TestCase):
             msg = "slack down"
             raise RuntimeError(msg)
 
-        with on_behalf_gate_off(), _patch_approval_publisher(_boom):
+        with mode_immediate_cm(), _patch_approval_publisher(_boom):
             pr.approve()
             pr.save()
 
@@ -338,7 +338,7 @@ class TestApprovalReactionOnTransition(TestCase):
         calls: list[object] = []
 
         with (
-            on_behalf_gate_off(),
+            mode_immediate_cm(),
             _patch_approval_publisher(lambda p: calls.append(p) or 0),
         ):
             pr.mark_merged()
@@ -379,7 +379,7 @@ class TestApprovalReactionOnTransition(TestCase):
         ticket = Ticket.objects.create(overlay="test", state=Ticket.State.IN_REVIEW, extra={})
         # No patching — the real code path must not raise (even with the
         # gate on, the transition itself must always succeed).
-        with on_behalf_gate_off():
+        with mode_immediate_cm():
             ticket.mark_merged()
             ticket.save()
         ticket.refresh_from_db()
@@ -407,7 +407,7 @@ class TestApprovalReactionOnTransition(TestCase):
         )
         assert row is not None
 
-        with on_behalf_gate_off(), _patch_approval_publisher(lambda _pr: 1):
+        with mode_immediate_cm(), _patch_approval_publisher(lambda _pr: 1):
             pr.approve()
             pr.save()
 


### PR DESCRIPTION
Closes #1921.

## Problem
The test layer kept back-compat shims `on_behalf_gate_off` and `_GATE_OFF_TOML` after a rename, against the clean-cutover doctrine (no back-compat aliases in tests).

## Fix
Delete both shims and the docstring paragraph documenting them from `tests/teatree_core/_on_behalf_gate_helpers.py`; update every caller in `test_signals.py` to the canonical `mode_immediate_cm` / `_MODE_IMMEDIATE_TOML`. Pure rename, behavior unchanged. `grep -rn 'on_behalf_gate_off|_GATE_OFF_TOML|ON_BEHALF_GATE_OFF_TOML' .` returns zero hits.

## Gate proof
`pytest tests/teatree_core/test_signals.py` — 21 passed. `ruff` / `tach` / module-health clean. `t3 tool verify-gates` exits 0 once the pre-existing review-skill leak (#2527) lands; the feature diff touches only the two test files.