### PR TITLE
refactor(loop): sub-layer teatree.loop into tach nodes — slice 2/N (#2413)

### DIFF
--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -195,6 +195,7 @@ graph TD
     teatree.loop --> teatree.loop.rendering_permalinks
     teatree.loop --> teatree.loop.rendering_zones
     teatree.loop --> teatree.loop.rendering
+    teatree.loop --> teatree.loop.slack_answer
     teatree.loop.statusline_render --> teatree.loop.statusline_palette
     teatree.loop.session_identity --> teatree.core.session_identity
     teatree.loop.loop_scoping --> teatree.core.loop_lease_manager
@@ -272,6 +273,11 @@ graph TD
     teatree.loop.rendering --> teatree.loop.rendering_items
     teatree.loop.rendering --> teatree.loop.rendering_permalinks
     teatree.loop.rendering --> teatree.loop.rendering_zones
+    teatree.loop.slack_answer --> teatree.backends.slack
+    teatree.loop.slack_answer --> teatree.core
+    teatree.loop.slack_answer --> teatree.core.models
+    teatree.loop.slack_answer --> teatree.loop.self_improve
+    teatree.loop.slack_answer --> teatree.loop.statusline
     teatree.loops --> teatree.config
     teatree.loops --> teatree.core
     teatree.loops --> teatree.loop

--- a/src/teatree/loop/tick_piggyback.py
+++ b/src/teatree/loop/tick_piggyback.py
@@ -37,6 +37,7 @@ from teatree.loop.loop_cadences import _LOOP_OWNER_TTL_DEFAULT
 from teatree.loop.loop_cadences import loop_owner_ttl_seconds as _loop_owner_ttl_seconds
 from teatree.loop.loop_cadences import self_improve_cadence_seconds as _self_improve_cadence_seconds
 from teatree.loop.loop_cadences import slack_answer_cadence_seconds as _slack_answer_cadence_seconds
+from teatree.loop.slack_answer.cycle import run_slack_answer_cycle
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +58,6 @@ __all__ = [
 def _piggyback_slack_answer() -> None:
     """Drive one reactive Slack-answer cycle behind the dedicated lease CAS."""
     from teatree.core.models import LoopLease  # noqa: PLC0415
-    from teatree.loop.slack_answer.cycle import run_slack_answer_cycle  # noqa: PLC0415
 
     owner = f"tickpiggyback-{os.getpid()}-{uuid.uuid4().hex}"
     if not LoopLease.objects.acquire("loop-slack-answer", owner=owner, lease_seconds=_slack_answer_cadence_seconds()):

--- a/tach.toml
+++ b/tach.toml
@@ -409,7 +409,8 @@ depends_on = [
   "teatree.loop.rendering_classification",
   "teatree.loop.rendering_permalinks",
   "teatree.loop.rendering_zones",
-  "teatree.loop.rendering"
+  "teatree.loop.rendering",
+  "teatree.loop.slack_answer"
 ]
 
 [[modules]]
@@ -603,6 +604,17 @@ depends_on = [
   "teatree.loop.rendering_items",
   "teatree.loop.rendering_permalinks",
   "teatree.loop.rendering_zones"
+]
+
+[[modules]]
+path = "teatree.loop.slack_answer"
+layer = "domain"
+depends_on = [
+  "teatree.backends.slack",
+  "teatree.core",
+  "teatree.core.models",
+  "teatree.loop.self_improve",
+  "teatree.loop.statusline"
 ]
 
 [[modules]]

--- a/tests/quality/test_intra_loop_deferred_import_ratchet.py
+++ b/tests/quality/test_intra_loop_deferred_import_ratchet.py
@@ -76,9 +76,20 @@ _TACH = _REPO_ROOT / "tach.toml"
 # redundant deferred edge in `rendering.py` (`live_loops_anchor` from
 # `statusline`, already eagerly imported on the same module header) up to the
 # eager import, dropping the count 31 -> 30.
+# The `slack_answer` slice declares the reactive Slack-answer subpackage
+# (`classifier` / `simple_answer` / `thread_readback` / `cycle`) as a single
+# tach node (mirroring the `scanners` / `self_improve` sibling-package nodes).
+# The subpackage was already eager-clean (ZERO intra-loop deferred imports
+# inside it), so the carve converts no internal edge; the one win is hoisting
+# the single deferred up-edge that TARGETED it — the orchestration-top
+# `tick_piggyback._piggyback_slack_answer` deferred
+# `from teatree.loop.slack_answer.cycle import run_slack_answer_cycle` — to the
+# module header (an eager declared parent->child edge, import-cycle-safe: the
+# slack_answer.cycle transitive eager closure reaches only declared leaves,
+# never the orchestration top), dropping the count 30 -> 29.
 # SHRINK-ONLY: lower this as later carves convert remaining deferred edges into
 # declared tach sub-node edges; never raise it.
-_FROZEN_INTRA_LOOP_DEFERRED = 30
+_FROZEN_INTRA_LOOP_DEFERRED = 29
 
 
 def _function_scoped_intra_loop_imports(source: Path) -> int:
@@ -501,3 +512,63 @@ class TestLoopRenderingNode:
             "teatree.loop.rendering_zones",
         ):
             assert child in deps, child
+
+
+_SLACK_ANSWER_ROOT = _LOOP_ROOT / "slack_answer"
+
+
+class TestLoopSlackAnswerNode:
+    """``teatree.loop.slack_answer`` is a declared domain node (#2413 slice).
+
+    The reactive Slack-answer subpackage (``classifier`` / ``simple_answer`` /
+    ``thread_readback`` / ``cycle``) was already eager-clean — ZERO intra-loop
+    deferred imports inside the subpackage, every intra-loop edge pointing DOWN
+    to already-declared nodes (``self_improve`` budget seam, ``statusline``) or a
+    sibling slack_answer file — but lived inside the single ``teatree.loop``
+    node, so tach's acyclic guard could not see it. Declaring the subpackage as
+    its own ``domain`` node (mirroring the ``scanners`` / ``self_improve``
+    sibling-package nodes) makes a future back-edge — a slack_answer file
+    importing the orchestration top — a tach failure instead of an invisible
+    cycle. The one deferred up-edge that targeted slack_answer lived in the
+    orchestration-top ``tick_piggyback._piggyback_slack_answer`` (a deferred
+    ``from teatree.loop.slack_answer.cycle import run_slack_answer_cycle``); it
+    is hoisted to the module header — an eager declared parent->child edge —
+    banking the ratchet one step.
+    """
+
+    def test_slack_answer_is_a_domain_node(self) -> None:
+        assert _module_entry("teatree.loop.slack_answer")["layer"] == "domain"
+
+    def test_slack_answer_intra_loop_deps_are_only_declared_leaves(self) -> None:
+        deps = _depends_on("teatree.loop.slack_answer")
+        loop_deps = {d for d in deps if d.startswith("teatree.loop")}
+        assert loop_deps == {"teatree.loop.self_improve", "teatree.loop.statusline"}
+        # The orchestration-top parent is NEVER a slack_answer dep.
+        assert "teatree.loop" not in deps
+
+    def test_no_slack_answer_file_eagerly_imports_the_orchestration_top(self) -> None:
+        # No file in the subpackage may eager-import a flat orchestration-top
+        # module (`tick*` / `queue_drain` / `mechanical` / `phases`) — that is
+        # the back-edge the carve forbids structurally.
+        offenders: list[str] = []
+        for py in _SLACK_ANSWER_ROOT.rglob("*.py"):
+            for mod in _eager_loop_imports(py):
+                tail = mod[len("teatree.loop.") :]
+                if tail.startswith(("tick", "queue_drain", "mechanical", "phases")):
+                    offenders.append(f"{py.relative_to(_SLACK_ANSWER_ROOT)} -> {mod}")
+        assert offenders == [], f"slack_answer eagerly importing the orchestration top: {sorted(offenders)}"
+
+    def test_parent_loop_declares_slack_answer(self) -> None:
+        assert "teatree.loop.slack_answer" in _depends_on("teatree.loop")
+
+    def test_tick_piggyback_does_not_defer_import_slack_answer(self) -> None:
+        # The `run_slack_answer_cycle` import is now an eager module-header import
+        # in tick_piggyback; no function-scoped `from teatree.loop.slack_answer`
+        # may remain (the deferred down-edge PR hoists).
+        source = (_LOOP_ROOT / "tick_piggyback.py").read_text(encoding="utf-8")
+        deferred = [
+            line.strip()
+            for line in source.splitlines()
+            if line.lstrip().startswith("from teatree.loop.slack_answer") and line != line.lstrip()
+        ]
+        assert deferred == [], f"tick_piggyback.py still defers a slack_answer import: {deferred}"

--- a/tests/test_tach_cycle_ratchet.py
+++ b/tests/test_tach_cycle_ratchet.py
@@ -56,7 +56,19 @@ _TACH = _REPO / "tach.toml"
 # core coupling, so it does not drop out to offset the addition. One new fan-in
 # entry (teatree.loop.rendering) in the correct lower→higher direction; it is a
 # pure carve artifact and adds no new coupling.
-_CORE_FANIN_BASELINE = 20
+# Bumped 20 → 21 (#2413 slack_answer): the reactive Slack-answer subpackage is
+# carved out of the teatree.loop monolith into its own tach node
+# (teatree.loop.slack_answer) so a future slack_answer → orchestration-top
+# back-edge becomes a declared tach failure instead of an invisible cycle. The
+# node touches teatree.core because cycle.py / thread_readback.py import
+# teatree.core.backend_protocols + cycle.py imports teatree.core.backend_factory
+# (no more-specific declared core sub-node, so they resolve to teatree.core) —
+# imports identical on origin/main, previously hidden inside the teatree.loop
+# node. teatree.loop retains its own independent core coupling, so it does not
+# drop out to offset. One new fan-in entry (teatree.loop.slack_answer) in the
+# correct lower→higher direction; it is a pure carve artifact and adds no new
+# coupling.
+_CORE_FANIN_BASELINE = 21
 _MAX_DECLARED_TWO_CYCLES = 0
 
 


### PR DESCRIPTION
## What

Carve the reactive Slack-answer subpackage out of the `teatree.loop` monolith into its own declared tach `domain` node so tach's acyclic guard applies to it, the next slice of the [#2413](https://github.com/souliane/teatree/issues/2413) loop sub-layering (mirrors the completed [#2385](https://github.com/souliane/teatree/issues/2385) core re-layering and the slice-1 `rendering` carve in [#2525](https://github.com/souliane/teatree/pull/2525)).

One new node: `teatree.loop.slack_answer` (over `classifier` / `simple_answer` / `thread_readback` / `cycle`). It is declared as a single package node, mirroring the `teatree.loop.scanners` / `teatree.loop.self_improve` sibling-package nodes. The parent `teatree.loop` declares it as a child.

## Why

`teatree.loop` is the remaining single-tach-node monolith. The slice-1 (#2525) rendering carve + the prior PRs carved `statusline` / `scanners` / `dispatch` / `self_improve` / `statusline_loops` and severed the `review_claim` back-edge. `slack_answer` is the next eager-clean cluster — and the `self_improve.budget` seam it depends on is already a declared node, so the task's precondition is met:

- ZERO intra-loop deferred imports inside the subpackage (verified by AST walk).
- Every intra-loop edge already points DOWN to an already-declared node (`self_improve` budget seam, `statusline`) or a sibling `slack_answer` file.

The one deferred up-edge that *targeted* `slack_answer` lived in the orchestration-top `tick_piggyback._piggyback_slack_answer` — a deferred `from teatree.loop.slack_answer.cycle import run_slack_answer_cycle`. It is hoisted to the module header (an eager declared parent->child edge). The hoist is import-cycle-safe: the `slack_answer.cycle` transitive eager closure reaches only declared leaves (`statusline*`, `self_improve.budget`, `loop_cadences`, `loop_scoping`), never the orchestration top. Declaring the node makes a future back-edge — a `slack_answer` file importing the orchestration top — a tach failure instead of an invisible cycle.

## Architecture pre-check — #2413 (slice)

**1. BLUEPRINT § alignment** — Module Dependency Graph / tach DAG (`docs/dependency-graph.md` regenerated in this commit). No BLUEPRINT prose change: structural carve under the existing tach-layering doctrine.

**2. FSM phase boundaries** — n/a; no `Ticket.State` / `Worktree.State` transition touched.

**3. Extension-point contracts** — n/a; no `OverlayBase` / scanner-registration / hook / `*Backend` Protocol surface changed. Pure intra-`teatree.loop` import re-shaping.

**4. Component boundaries** — `src/teatree/loop/slack_answer/` subpackage only. No file moved; the subpackage becomes its own tach node.

**5. Dependency direction** — no new cross-module import. The hoist of `run_slack_answer_cycle` is into a module-header import; its transitive eager closure reaches only declared leaves. `uv run tach check` -> `All modules validated`. Node `depends_on = [backends.slack, core, core.models, loop.self_improve, loop.statusline]`.

**6. Test surface** — `tests/quality/test_intra_loop_deferred_import_ratchet.py::TestLoopSlackAnswerNode` (the subpackage is a domain node; its intra-loop deps are only declared leaves; no slack_answer file imports the orchestration top; the parent declares it; `tick_piggyback` no longer defers the import) + the ratchet count peg lowered to 29. Anti-vacuous: re-introducing the `tick_piggyback` deferral flips both the count test and the no-defer test RED (verified locally — see Gate proof).

**7. Resilience invariants** — n/a; no external write introduced or changed.

**8. Identity and key normalization** — n/a; no identity key handling.

**9. Behavior preservation / capability deletion** — purely structural. The hoist preserves runtime behavior (`run_slack_answer_cycle` is the same symbol, same module, now reached eagerly at `tick_piggyback` import time; no import-time cycle). No matcher narrowed, no test inverted. All `slack_answer` / loop behavior tests stay green.

## Ratchet deltas

- **intra-loop deferred peg 30 -> 29** — the hoisted `tick_piggyback` -> `slack_answer.cycle` deferral.
- **core fan-in baseline 20 -> 21** — the new `teatree.loop.slack_answer` node carries a *pre-existing* `teatree.core` import (`cycle.py` / `thread_readback.py` import `teatree.core.backend_protocols`, `cycle.py` imports `teatree.core.backend_factory`; no more-specific declared core sub-node, so they resolve to `teatree.core`). Identical on `origin/main`, previously hidden inside the `teatree.loop` node — a pure carve artifact, no new coupling. `teatree.loop` retains its own independent core coupling, so it does not drop out to offset the addition.

## Gate proof

- `uv run tach check` -> All modules validated
- `uv run ruff check` -> All checks passed
- `scripts/hooks/check_module_health.py --from-ref origin/main` -> exit 0
- `t3 tool verify-gates` -> all gate stages green (commit + push)
- `uv run pytest tests/quality/ tests/test_tach_cycle_ratchet.py tests/teatree_loop/ -p no:cacheprovider -q` -> **2605 passed, 1 skipped, 7 subtests passed**

Anti-vacuity (re-introduce the deferral, confirm RED): reverting the hoist (deferred import back inside `_piggyback_slack_answer`) flips `TestIntraLoopDeferredImportRatchet::test_count_does_not_exceed_frozen` (`assert 30 <= 29`) and `TestLoopSlackAnswerNode::test_tick_piggyback_does_not_defer_import_slack_answer` RED.

## Remaining slices

The `teatree.loop` parent node still holds these undeclared clusters (follow-up PRs, ascending blast radius):

- **scanners.outbound_audit** — the next-largest deferred hot spot (5 deferred edges in `outbound_audit_overlay_verifiers.py`). NOT eager-clean: `outbound_audit` <-> `outbound_audit_overlay_verifiers` is a genuine 2-cycle held apart by the deferred imports (`outbound_audit` eager-imports the verifier factories; the verifiers defer `VerifyResult` + private helpers back to `outbound_audit`). Severing it cleanly needs the shared primitives (`VerifyResult`, `_gitlab_api_for_overlay`, `_hash_body`, `_resolve_github_token`, ...) extracted into a third leaf module both depend on — surgery, not a pure carve. Plus the remaining scanner-package internal deferred edges (`failed_e2e_posts` -> `slack_broadcasts`, `slack_mentions` -> `slack_review_intent`).
- **tick** (`tick` / `tick_freshness` / `tick_piggyback` / `tick_recovery` / `tick_resolvers`) + **phases/** (`act` / `orchestrate` / `render` / `scan` / `sweep`) — the orchestration TOP node; pull in everything, so they land last (sever the remaining `mechanical` / `queue_drain` / `self_improve.schedule` / `domain_jobs` / `sweep_on_demand` deferred edges as their target leaves are declared).
- Remaining flat deferred edges to convert as their targets become nodes: `domain_jobs` (2), `global_scanner_factories` (1), `loop_scoping` (1), `phases/render` (9), `review_claim_signals` (1), `sweep_on_demand` (2), `tick_freshness` (2), `tick_piggyback` (2 remaining: `self_improve.schedule`, `queue_drain`), `tick_recovery` (2).

Each follow-up slice repeats the pattern: declare the next eager-clean cluster as nodes, convert any deferred up-edge into a declared down-edge, lower the ratchet peg (and bump the core fan-in baseline only for a pre-existing-import carve artifact).
