### PR TITLE
fix(eval): forward under-load ratchet into docker

### DIFF
--- a/src/teatree/cli/eval/app.py
+++ b/src/teatree/cli/eval/app.py
@@ -330,6 +330,7 @@ def run(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a p
             models=models,
             backend=backend,
             require_executed=require_executed,
+            gate_under_load_ratchet=gate_under_load_ratchet,
             parallel=parallel,
             transcript_html=transcript_html,
         ),

--- a/src/teatree/cli/eval/run_docker.py
+++ b/src/teatree/cli/eval/run_docker.py
@@ -34,6 +34,7 @@ class RunDockerArgs:
     models: str | None
     backend: str
     require_executed: bool
+    gate_under_load_ratchet: bool
     parallel: int
     transcript_html: Path | None = None
 
@@ -66,6 +67,7 @@ class RunDockerArgs:
             ["--models", self.models] if self.models is not None else [],
             ["--backend", self.backend] if self.backend != TRANSCRIPT_BACKEND else [],
             ["--require-executed"] if self.require_executed else [],
+            ["--gate-under-load-ratchet"] if self.gate_under_load_ratchet else [],
             ["--parallel", str(self.parallel)] if self.parallel != DEFAULT_PARALLEL else [],
             ["--transcript-html", self._container_transcript_path()] if self.transcript_html is not None else [],
         ]

--- a/tests/teatree_cli/eval/test_run_docker.py
+++ b/tests/teatree_cli/eval/test_run_docker.py
@@ -31,6 +31,7 @@ def _args(**overrides: object) -> RunDockerArgs:
         "models": None,
         "backend": "sdk",
         "require_executed": True,
+        "gate_under_load_ratchet": False,
         "parallel": 1,
     }
     base.update(overrides)
@@ -51,6 +52,10 @@ class TestTranscriptHtmlPassthrough:
         # The container is ephemeral, so the run stays --no-persist regardless of
         # the new artifact flag — the artifact is the durable output, not the ledger.
         assert "--no-persist" in _args(transcript_html=Path("/tmp/x.html")).passthrough()
+
+    def test_forwards_under_load_ratchet_gate(self) -> None:
+        passthrough = _args(gate_under_load_ratchet=True).passthrough()
+        assert "--gate-under-load-ratchet" in passthrough
 
 
 class TestDispatchMountsHostParentDir:

--- a/tests/teatree_cli/test_eval.py
+++ b/tests/teatree_cli/test_eval.py
@@ -2061,6 +2061,11 @@ class TestEvalRunDocker:
         forwarded = run_docker.call_args.args[0]
         assert forwarded[forwarded.index("--max-budget-usd") + 1] == "1.5"
 
+    def test_forwards_under_load_ratchet_gate_into_the_container(self) -> None:
+        with patch("teatree.cli.eval.run_docker.run_eval_in_docker", return_value=0) as run_docker:
+            CliRunner().invoke(app, ["eval", "run", "--trials", "3", "--gate-under-load-ratchet", "--docker"])
+        assert "--gate-under-load-ratchet" in run_docker.call_args.args[0]
+
     def test_propagates_container_exit_code(self) -> None:
         with patch("teatree.cli.eval.run_docker.run_eval_in_docker", return_value=1):
             result = CliRunner().invoke(app, ["eval", "run", "--backend", "sdk", "--docker"])


### PR DESCRIPTION
## Summary
- Forward the under-load ratchet floor into Docker-based AI eval runs.
- Cover the CLI and Docker command wiring with regression tests.

## Validation
- Confirmed clean worktree before push.
- Confirmed HEAD: 85245c6f0 fix(eval): forward under-load ratchet into docker.
- Push hooks passed.