### PR TITLE
fix(loops): preserve custom rows during script backfill

### DIFF
--- a/src/teatree/core/migrations/0080_loop_backfill_prompt_script.py
+++ b/src/teatree/core/migrations/0080_loop_backfill_prompt_script.py
@@ -3,29 +3,62 @@
 ``arch_review`` keeps its prompt — it is the one loop whose instruction lives in
 the prompt. Every other seeded loop moves to the shared script entry point:
 ``script`` is set and ``prompt`` cleared, so each row holds exactly one of the
-two. Reversible — the reverse restores each moved row's seed prompt.
+two. The migration only touches known seeded loop names that still have their
+expected seeded prompt/script state, so custom or operator-edited rows are left
+alone. Reversible — the reverse restores each moved row's seed prompt only from
+the expected script state.
 """
 
 from django.db import migrations
 
 _SCRIPT_ENTRY_POINT = "src/teatree/loops/run.py"
 _PROMPT_LOOPS = frozenset({"arch_review"})
+_SEEDED_LOOP_NAMES = frozenset(
+    {
+        "inbox",
+        "idle_stack_reaper",
+        "local_stack_queue",
+        "resource_pressure",
+        "dispatch",
+        "tickets",
+        "review",
+        "ship",
+        "pane_reaper",
+        "issue_implementer",
+        "housekeeping",
+        "audit",
+        "followup",
+        "arch_review",
+        "dogfood",
+        "eval_local",
+        "news",
+        "dream",
+        "slack_answer",
+    },
+)
+_SCRIPT_LOOP_NAMES = _SEEDED_LOOP_NAMES - _PROMPT_LOOPS
+
+
+def _seed_prompt(name):
+    return f"Run a sub-agent to run the {name} loop."
 
 
 def _backfill(apps, schema_editor) -> None:
-    loop_model = apps.get_model("core", "Loop")
-    for loop in loop_model.objects.exclude(name__in=_PROMPT_LOOPS):
-        loop.script = _SCRIPT_ENTRY_POINT
-        loop.prompt = ""
-        loop.save(update_fields=["script", "prompt"])
+    Loop = apps.get_model("core", "Loop")
+    for name in _SCRIPT_LOOP_NAMES:
+        Loop.objects.filter(name=name, prompt=_seed_prompt(name), script="").update(
+            script=_SCRIPT_ENTRY_POINT,
+            prompt="",
+        )
 
 
 def _restore(apps, schema_editor) -> None:
-    loop_model = apps.get_model("core", "Loop")
-    for loop in loop_model.objects.exclude(name__in=_PROMPT_LOOPS):
-        loop.prompt = f"Run a sub-agent to run the {loop.name} loop."
-        loop.script = ""
-        loop.save(update_fields=["script", "prompt"])
+    Loop = apps.get_model("core", "Loop")
+    for name in _SCRIPT_LOOP_NAMES:
+        Loop.objects.filter(name=name, prompt="", script=_SCRIPT_ENTRY_POINT).update(
+            prompt=_seed_prompt(name),
+            script="",
+        )
 
 
 class Migration(migrations.Migration):

--- a/src/teatree/core/migrations/0083_loop_script_requires_delay.py
+++ b/src/teatree/core/migrations/0083_loop_script_requires_delay.py
@@ -1,0 +1,34 @@
+"""Require script loops to carry an interval.
+
+The model-level clean() invariant already rejects ``script`` loops with a null
+``delay_seconds``. Backfill any pre-existing invalid rows to a conservative
+60-second interval, then enforce the same rule at the database layer.
+"""
+
+from django.db import migrations, models
+
+_SCRIPT_LOOP_DEFAULT_DELAY_SECONDS = 60
+
+
+def _backfill_script_loop_delay(apps, schema_editor) -> None:
+    Loop = apps.get_model("core", "Loop")
+    Loop.objects.filter(script__gt="", delay_seconds__isnull=True).update(
+        delay_seconds=_SCRIPT_LOOP_DEFAULT_DELAY_SECONDS,
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0082_consolidatedmemory_disposition_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(_backfill_script_loop_delay, migrations.RunPython.noop),
+        migrations.AddConstraint(
+            model_name="loop",
+            constraint=models.CheckConstraint(
+                condition=models.Q(script="") | models.Q(delay_seconds__isnull=False),
+                name="loop_script_requires_delay",
+            ),
+        ),
+    ]

--- a/src/teatree/core/migrations/max_migration.txt
+++ b/src/teatree/core/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0082_consolidatedmemory_disposition_and_more
+0083_loop_script_requires_delay

--- a/src/teatree/core/models/loop.py
+++ b/src/teatree/core/models/loop.py
@@ -76,6 +76,10 @@ class Loop(models.Model):
                 condition=models.Q(prompt="", script__gt="") | models.Q(prompt__gt="", script=""),
                 name="loop_prompt_xor_script",
             ),
+            models.CheckConstraint(
+                condition=models.Q(script="") | models.Q(delay_seconds__isnull=False),
+                name="loop_script_requires_delay",
+            ),
         ]
 
     def __str__(self) -> str:

--- a/tests/teatree_core/models/test_loop.py
+++ b/tests/teatree_core/models/test_loop.py
@@ -44,7 +44,7 @@ class TestLoopAdditiveFields(TestCase):
         assert loop.overlay == ""
 
     def test_script_only_loop_round_trips(self) -> None:
-        Loop.objects.create(name="demo-script", prompt="", script="src/teatree/loops/run.py")
+        Loop.objects.create(name="demo-script", delay_seconds=60, prompt="", script="src/teatree/loops/run.py")
         reloaded = Loop.objects.get(name="demo-script")
         assert reloaded.script == "src/teatree/loops/run.py"
         assert reloaded.prompt == ""
@@ -59,7 +59,7 @@ class TestLoopAdditiveFields(TestCase):
 
 
 class TestLoopNullableDelay(TestCase):
-    """``delay_seconds`` is nullable so a script loop need not carry an interval."""
+    """``delay_seconds`` is nullable for prompt loops that run every tick."""
 
     def test_delay_seconds_may_be_null(self) -> None:
         Loop.objects.create(name="demo-null", prompt="do x", delay_seconds=None)
@@ -111,6 +111,10 @@ class TestLoopPromptScriptXor(TestCase):
     def test_db_constraint_rejects_neither(self) -> None:
         with pytest.raises(IntegrityError), transaction.atomic():
             Loop.objects.create(name="demo-neither-db", delay_seconds=60, prompt="", script="")
+
+    def test_db_constraint_rejects_script_without_delay(self) -> None:
+        with pytest.raises(IntegrityError), transaction.atomic():
+            Loop.objects.create(name="demo-script-no-delay-db", delay_seconds=None, prompt="", script="run.py")
 
 
 class TestLoopIntervalCadence(TestCase):

--- a/tests/test_migration_0079_0081_loop_script_fields.py
+++ b/tests/test_migration_0079_0081_loop_script_fields.py
@@ -15,6 +15,7 @@ from django.test import TransactionTestCase
 class LoopScriptFieldMigrationTest(TransactionTestCase):
     _PRE_SEED = ("core", "0077_loop")
     _SEED = ("core", "0078_seed_loops")
+    _SCRIPT_FIELDS = ("core", "0079_loop_script_fields")
     _AFTER_BACKFILL = ("core", "0080_loop_backfill_prompt_script")
     _HEAD = ("core", "0081_loop_prompt_xor_script")
 
@@ -55,6 +56,20 @@ class LoopScriptFieldMigrationTest(TransactionTestCase):
         dispatch = loop.objects.get(name="dispatch")
         assert dispatch.prompt == ""
         assert dispatch.script == "src/teatree/loops/run.py"
+        self._restore_head()
+
+    def test_backfill_leaves_custom_loop_present_before_0080_unchanged(self) -> None:
+        self._migrate(self._PRE_SEED)
+        apps = self._migrate(self._SCRIPT_FIELDS)
+        loop = apps.get_model("core", "Loop")
+        loop.objects.create(name="custom_user_loop", prompt="Run my custom loop.", delay_seconds=42)
+
+        apps = self._migrate(self._AFTER_BACKFILL)
+        custom_loop = apps.get_model("core", "Loop").objects.get(name="custom_user_loop")
+
+        assert custom_loop.prompt == "Run my custom loop."
+        assert custom_loop.script == ""
+        assert custom_loop.delay_seconds == 42
         self._restore_head()
 
     def test_reverse_to_seed_state_restores_every_prompt(self) -> None:

--- a/tests/test_migration_0083_loop_script_requires_delay.py
+++ b/tests/test_migration_0083_loop_script_requires_delay.py
@@ -1,0 +1,46 @@
+"""Migration tests for the script-loop delay invariant."""
+
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase
+
+
+class LoopScriptDelayMigrationTest(TransactionTestCase):
+    _BEFORE = ("core", "0082_consolidatedmemory_disposition_and_more")
+    _AFTER = ("core", "0083_loop_script_requires_delay")
+
+    def _migrate(self, target: tuple[str, str]) -> "object":
+        executor = MigrationExecutor(connection)
+        executor.migrate([target])
+        executor.loader.build_graph()
+        return executor.loader.project_state([target]).apps
+
+    def _restore_head(self) -> None:
+        executor = MigrationExecutor(connection)
+        executor.loader.build_graph()
+        core_leaves = [node for node in executor.loader.graph.leaf_nodes() if node[0] == "core"]
+        executor.migrate(core_leaves)
+
+    def test_backfill_sets_delay_on_existing_script_loop_without_delay(self) -> None:
+        apps = self._migrate(self._BEFORE)
+        loop = apps.get_model("core", "Loop")
+        loop.objects.create(name="custom_script_loop", prompt="", script="custom.py", delay_seconds=None)
+
+        apps = self._migrate(self._AFTER)
+        custom_loop = apps.get_model("core", "Loop").objects.get(name="custom_script_loop")
+
+        assert custom_loop.delay_seconds == 60
+        self._restore_head()
+
+    def test_backfill_leaves_prompt_loop_without_delay_unchanged(self) -> None:
+        apps = self._migrate(self._BEFORE)
+        loop = apps.get_model("core", "Loop")
+        loop.objects.create(name="custom_prompt_loop", prompt="Run custom prompt.", script="", delay_seconds=None)
+
+        apps = self._migrate(self._AFTER)
+        custom_loop = apps.get_model("core", "Loop").objects.get(name="custom_prompt_loop")
+
+        assert custom_loop.prompt == "Run custom prompt."
+        assert custom_loop.script == ""
+        assert custom_loop.delay_seconds is None
+        self._restore_head()


### PR DESCRIPTION
## Summary
- restrict loop script backfill migration to seeded loops in the expected seeded state
- add regression coverage that custom loops present before 0080 are unchanged
- enforce the script-loop delay invariant at the database layer after backfilling existing invalid rows

## Tests
- uv run pytest tests/test_migration_0079_0081_loop_script_fields.py tests/test_migration_0083_loop_script_requires_delay.py tests/teatree_core/models/test_loop.py -q
- uv run pytest tests/teatree_core/test_linear_migrations.py -q -n0
- uv run ruff check --no-fix touched files
- uv run ruff format --check touched files
- rg checks for pytest.mark.django_db, pytest.mark.parametrize, and complexity suppressions on touched files returned no matches; skipped the three ac-django ast-grep commit hooks because their cached hook environment crashes before scanning
