### PR TITLE
fix(eval): clarify durable gate routing

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -14,7 +14,7 @@
 #   * schedule  — once a week (Monday 06:00 UTC). Guarded: the scheduled run
 #     SKIPS CLEANLY (exit 0, with a clear log line) when NO PR merged in the
 #     lookback window since the last run — nothing new to test, no API spend.
-#   * workflow_dispatch — manual, on-demand, with a `backend` input (default sdk)
+#   * workflow_dispatch — manual, on-demand, always on the sdk backend
 #     and an optional `lane` input. ALWAYS runs (force) — the no-PR guard is
 #     bypassed for a manual run.
 #
@@ -44,9 +44,9 @@
 #   run inside the ephemeral `--docker` container this workflow uses (the
 #   in-container run is forced `--no-persist`). The cost gate is wired into the
 #   PERSISTED metered path in `.gitlab-ci.yml` (no `--docker`), where the ledger
-#   lives on the runner — keeping the cost gate weekly/manual and off the per-PR
-#   path. A maintainer can also run it on the host against the accumulated
-#   ledger: `t3 eval run --backend sdk --gate-cost-bounds`.
+#   lives on the runner via `--local` — keeping the cost gate weekly/manual and
+#   off the per-PR path. A maintainer can also run it on the host against the
+#   accumulated ledger: `t3 eval run --backend sdk --local --gate-cost-bounds`.
 #
 # AUTH — CLAUDE_CODE_OAUTH_TOKEN (the everywhere-portable path)
 #   The metered backend authenticates from `CLAUDE_CODE_OAUTH_TOKEN`, the
@@ -85,11 +85,6 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch:
     inputs:
-      backend:
-        description: "AI-lane backend for the manual run (sdk = metered in-process Agent SDK)."
-        required: false
-        default: sdk
-        type: string
       lane:
         description: "Eval lane subset to run (clean_room | under_load); empty = every lane."
         required: false
@@ -222,9 +217,10 @@ jobs:
       # ships the Claude CLI) — "all metered eval in Docker" holds in CI too. The runner has
       # Docker, so the run builds (cached) and runs the suite in-container; the host's
       # CLAUDE_CODE_OAUTH_TOKEN is forwarded in via docker's `-e` pass-through.
-      # `--backend` keeps CI on the metered in-process Agent-SDK path explicitly (sdk default;
-      # a workflow_dispatch run may override it via the backend input). Auth is the
-      # OAuth token (`CLAUDE_CODE_OAUTH_TOKEN`) — the June-15-safe everywhere path.
+      # `--backend sdk` keeps CI on the metered in-process Agent-SDK path explicitly.
+      # This workflow always runs `--trials 3`, which cannot be served by the
+      # transcript backend, so there is intentionally no backend input. Auth is
+      # the OAuth token (`CLAUDE_CODE_OAUTH_TOKEN`) — the June-15-safe everywhere path.
       # `--require-executed` is passed UNCONDITIONALLY (never key-gated): a collected-but-
       # all-skipped run exits non-zero, so the suite can never pass green with zero coverage.
       # The end-of-run cost summary (report.py `_cost_summary`) prints the API spend.
@@ -241,7 +237,6 @@ jobs:
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          EVAL_BACKEND: ${{ inputs.backend || 'sdk' }}
           # This leg meters exactly ONE shard of ONE lane (the matrix values), so the
           # per-shard subset is at most 14 scenarios — the proven-to-fit under_load
           # size — and fits the 2x80min budget where the full 181 (and a single
@@ -272,7 +267,7 @@ jobs:
           # the file is simply overwritten with the last attempt's results — no
           # staleness.
           command: |
-            uv run t3 eval run --trials 3 --require any --backend "$EVAL_BACKEND" \
+            uv run t3 eval run --trials 3 --require any --backend sdk \
               --lane "$EVAL_LANE" --shard "$EVAL_SHARD" \
               --require-executed --gate-under-load-ratchet --docker \
               --transcript-html "$RUNNER_TEMP/eval-transcripts.html"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,10 @@ variables:
     - uv run python -m teatree migrate --no-input
     # `--backend sdk` keeps CI on the metered claude -p path explicitly (auth via
     # CLAUDE_CODE_OAUTH_TOKEN); LOCAL `t3 eval run` defaults to the subscription
-    # backend (no API spend). Mirrors the GitHub eval workflow.
+    # backend (no API spend). Mirrors the GitHub eval workflow's fresh lane.
+    # `--local` is intentional here: the cost-bounds gate must persist/read the
+    # runner DB on this host, while the default Docker route is ephemeral and
+    # rejects durable-history gates.
     # `--require-executed` is passed UNCONDITIONALLY (never key-gated): a
     # collected-but-all-skipped run exits non-zero, so the suite can never pass
     # green with zero behavioral coverage (souliane/teatree#1811).
@@ -79,7 +82,7 @@ variables:
     # but a NEW under_load failure outside the baseline — or a baselined scenario
     # that now PASSES — fails the run loud. It reads the IN-MEMORY results, so it
     # is weekly/manual like the cost gate, off the per-MR path.
-    - uv run t3 eval run --trials 3 --require any --backend sdk --require-executed --gate-cost-bounds --gate-under-load-ratchet
+    - uv run t3 eval run --trials 3 --require any --backend sdk --local --require-executed --gate-cost-bounds --gate-under-load-ratchet
 
 # Scheduled pre-check: skip the weekly eval cleanly when nothing new merged in
 # the lookback window. Writes a `RUN_EVAL` dotenv flag the eval-weekly rule reads.

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1367,8 +1367,8 @@ Usage: t3 eval benchmark [OPTIONS]
  ``--trials k`` (each cell's score becomes a k-trial pass-rate).
 
  The benchmark is metered, so it defaults to running in the CI container; pass
- ``--local`` for a quick host check (NOT the reproducible gate). The container
- is ephemeral, so a Docker-routed run is forced ``--no-persist``.
+ ``--local`` for an explicit host run. The container is ephemeral, so a
+ Docker-routed run is forced ``--no-persist``.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ *  --models                            TEXT     Comma-separated model@effort │
@@ -1637,7 +1637,7 @@ Usage: t3 eval run [OPTIONS] [NAME]
  (which spawns the ``claude`` CLI as its child), authed by the subscription's
  ``CLAUDE_CODE_OAUTH_TOKEN`` (NOT an API key); CI passes ``--backend sdk``
  explicitly via the standalone ``eval.yml`` job. ``--trials``/``--models``
- always use the fresh-run ``sdk`` runner regardless of ``--backend``.
+ require the fresh-run ``sdk`` runner and reject the transcript backend.
 
  ``--require-executed`` fails the run when the suite collected scenarios but
  executed none (every scenario skipped — typically ``claude`` not on PATH /
@@ -1651,6 +1651,9 @@ Usage: t3 eval run [OPTIONS] [NAME]
  the
  token authenticates the SDK's ``claude`` child inside a clean container and
  never lands on the command line.
+
+ ``--local`` is the explicit host escape for durable-history gates that must
+ persist/read the runner DB, or for a quick host check.
 
  ``--parallel N`` runs N scenarios concurrently (each SDK scenario run is
  I/O-bound, so a bounded worker pool cuts the suite's wall-clock from
@@ -1852,13 +1855,11 @@ Usage: t3 eval run [OPTIONS] [NAME]
 │                                                     subscription-covered     │
 │                                                     (CLAUDE_CODE_OAUTH_TOKE… │
 │                                                     NOT API-billed; runs     │
-│                                                     in-container via         │
-│                                                     --docker locally or in   │
-│                                                     the standalone eval.yml  │
-│                                                     CI job). --trials and    │
-│                                                     --models always use the  │
-│                                                     fresh-run sdk runner     │
-│                                                     regardless of this flag. │
+│                                                     in-container by default  │
+│                                                     or directly on the host  │
+│                                                     with --local). --trials  │
+│                                                     and --models require     │
+│                                                     --backend sdk.           │
 │                                                     [default: transcript]    │
 │ --transcript-dir                           PATH     Directory of             │
 │                                                     <scenario>.jsonl         │
@@ -1886,6 +1887,15 @@ Usage: t3 eval run [OPTIONS] [NAME]
 │                                                     the container; this      │
 │                                                     forces it for the        │
 │                                                     transcript lane too.     │
+│ --local                                             Run the fresh sdk lane   │
+│                                                     directly on the host     │
+│                                                     instead of Docker. Use   │
+│                                                     for durable-history      │
+│                                                     gates that must          │
+│                                                     persist/read the runner  │
+│                                                     DB; otherwise Docker     │
+│                                                     remains the reproducible │
+│                                                     path.                    │
 │ --parallel                                 INTEGER  Run this many scenarios  │
 │                                                     concurrently (each SDK   │
 │                                                     scenario run is          │
@@ -1929,11 +1939,7 @@ Usage: t3 eval prepare-transcript [OPTIONS] [NAME]
  The eval CLI is a plain process with no in-session ``Agent`` tool, so it
  cannot itself drive a subscription-covered turn. This command prints, per
  scenario, the agent definition, prompt, and the transcript path the
- ``transcript`` backend will read. The ``/t3:running-evals`` skill is the
- in-session driver: for each entry it dispatches an ``Agent`` sub-agent on the
- prompt, then runs ``t3 eval capture-subagent <scenario>`` to copy the
- sub-agent's JSONL to that path, and finally grades with
- ``t3 eval run --backend transcript``.
+ ``transcript`` backend will read.
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │   name      [NAME]  Scenario name to prepare (omit to prepare all).          │

--- a/evals/README.md
+++ b/evals/README.md
@@ -99,7 +99,7 @@ installed editable from a clone; the eval harness ships inside it.
   env, never the command line. To break the
   re-route loop, the docker runner sets `T3_EVAL_IN_CONTAINER=1` on the
   container — the metered command runs in-process when that marker is present.
-  Run the metered lane locally with:
+  Run the metered lane through the default container with:
 
   ```bash
   CLAUDE_CODE_OAUTH_TOKEN=… t3 eval run --backend sdk --require-executed
@@ -107,13 +107,13 @@ installed editable from a clone; the eval harness ships inside it.
 
   (no `--docker` needed — it is the default; `--docker` is still accepted to
   force the container for the transcript lane too).
-- **`benchmark --local` — the explicit host escape (a quick check, NOT the gate).**
-  `t3 eval benchmark --local` runs the fresh-run lane on the host for a fast local
-  check. It prints a loud WARNING: a host run is not the reproducible regression
-  gate (the host's login state biases the result and isolation strips subscription
-  auth) — use Docker / CI for regression. With docker missing, the run raises
-  `DockerUnavailableError` with guidance, so it is impossible to ACCIDENTALLY run
-  the fresh-run lane on the host.
+- **`--local` — the explicit host escape.** `t3 eval run --backend sdk --local`
+  and `t3 eval benchmark --local` run the fresh-run lane on the host. Use it for
+  durable-history gates that must persist/read the runner DB (for example the
+  GitLab weekly cost-bounds gate), or for a fast host check. It prints a loud
+  WARNING so the host path is never accidental. With docker missing, the default
+  fresh-run route raises `DockerUnavailableError` with guidance, so it is
+  impossible to ACCIDENTALLY run the fresh-run lane on the host.
 
 - **Prek (deterministic gates).** The two deterministic lanes are wired into
   prek under their explicit names: the sub-second `eval-skill-triggers` hook
@@ -164,9 +164,9 @@ t3 eval run --format json                   # JSON output
 t3 eval run --format html > report.html     # self-contained HTML report (single-trial; inline CSS, no external assets)
 t3 eval run worktree_first --max-turns 5    # override max_turns
 t3 eval run --no-persist                     # run without recording to the ledger
-t3 eval run --trials 3                        # pass@k: 3 trials, pass if any passes
-t3 eval run --trials 3 --require all          # pass^k: regression gate, all must pass
-t3 eval run --models opus,sonnet,haiku        # model-regression matrix (per-model columns)
+t3 eval run --backend sdk --trials 3          # pass@k: 3 trials, pass if any passes
+t3 eval run --backend sdk --trials 3 --require all  # pass^k: regression gate, all must pass
+t3 eval run --backend sdk --models opus,sonnet,haiku  # model-regression matrix (per-model columns)
 t3 eval run --judge                           # also grade judge-opted scenarios with an LLM judge
 t3 eval run --baseline                        # persist + mark this run as its model's baseline
 t3 eval run --gate-regressions               # persist + fail on a drop vs each model's baseline
@@ -218,7 +218,7 @@ A single-trial `t3 eval run` picks one of two backends; **the default is
 | Backend | Spend | Who runs it | What it does |
 |---|---|---|---|
 | `transcript` (default) | $0 extra (reuses a recorded run) | local / manual | grades an already-recorded `<scenario>.jsonl` transcript off disk — runs no model |
-| `sdk` | subscription-covered (NOT API-billed) | CI (standalone `eval.yml`) + local `--backend sdk` (DEFAULTS to the container) | RUNS the model fresh in-process via the Agent SDK + grades the run, in a container by default (`--local` for a host check) |
+| `sdk` | subscription-covered (NOT API-billed) | CI (standalone `eval.yml`) + local `--backend sdk` (DEFAULTS to the container) | RUNS the model fresh in-process via the Agent SDK + grades the run, in a container by default (`--local` for durable-history gates / host checks) |
 
 The free, no-model commands — `skill-triggers`, `pinned-regressions`, and
 `transcript-replay` — never invoke any model and are unaffected by the backend.
@@ -378,16 +378,15 @@ model, so it DEFAULTS to running inside the CI container (`dev/Dockerfile.test`)
 exactly like `t3 eval run` / `t3 eval benchmark`. `--free-only` runs only the
 host-safe deterministic lanes (no model) and stays on the host.
 
-`--trials`/`--models` always force the fresh-run `sdk` runner regardless of
-`--backend` (a multi-trial / matrix run cannot be served from a single saved
-transcript); combining them with the `transcript` default prints a one-line
-notice on stderr.
+`--trials`/`--models` require the fresh-run `sdk` runner (a multi-trial / matrix
+run cannot be served from a single saved transcript). Combining them with the
+`transcript` default is an explicit usage error; pass `--backend sdk`.
 
 **CI stays on the fresh-run path explicitly.** The standalone eval jobs in
 `.github/workflows/eval.yml` and `.gitlab-ci.yml` pass `--backend sdk` so CI runs
-the budgeted Agent-SDK path while LOCAL defaults to `transcript`. (CI also passes
-`--trials 3`, which already forces the sdk runner; the explicit `--backend sdk` is
-the debuggable statement of that intent.) `--require-executed` is passed
+the budgeted Agent-SDK path while LOCAL defaults to `transcript`. CI also passes
+`--trials 3`, so the explicit `--backend sdk` is required and debuggable.
+`--require-executed` is passed
 unconditionally so a missing CLI/key fails the job loud — never an all-skipped
 green.
 
@@ -570,10 +569,11 @@ scenario NOT listed is un-bounded. The gate engine is the pure, unit-tested
 CLI wiring (`cli/eval/run_modes.py::CostBoundsGate`) reads the just-persisted
 run's `EvalRunRecord.costs_by_scenario()`. It needs the durable ledger, so —
 like `--gate-cost-regression`/`--baseline` — it is rejected at the `--docker`
-boundary (the ephemeral container is `--no-persist`); it is wired into the
-PERSISTED metered path in `.gitlab-ci.yml` (no `--docker`), keeping the cost gate
-weekly/manual and off the per-PR path. Run it on the host against the accumulated
-ledger with `t3 eval run --backend sdk --gate-cost-bounds`.
+boundary (the ephemeral container is `--no-persist`) and with explicit
+`--no-persist`. It is wired into the PERSISTED metered path in `.gitlab-ci.yml`
+with `--local`, keeping the cost gate weekly/manual and off the per-PR path. Run
+it on the host against the accumulated ledger with
+`t3 eval run --backend sdk --local --gate-cost-bounds`.
 
 ### Model matrix
 

--- a/src/teatree/cli/eval/app.py
+++ b/src/teatree/cli/eval/app.py
@@ -1,6 +1,5 @@
 """``t3 eval`` — behavioral eval harness commands."""
 
-import json
 import sys
 from pathlib import Path
 
@@ -9,7 +8,12 @@ from rich.console import Console
 
 from teatree.cli._format_opts import VALID_FORMATS, require_valid_format
 from teatree.cli.eval.all import STRICT_HELP, build_scenarios_table, hint_missing_transcripts, run_full_suite
-from teatree.cli.eval.app_helpers import reject_unsupported_run_output, require_effort, require_spec
+from teatree.cli.eval.app_helpers import (
+    reject_unsupported_run_output,
+    require_effort,
+    require_sdk_backend_for_fresh_run,
+    require_spec,
+)
 from teatree.cli.eval.audit import audit
 from teatree.cli.eval.benchmark import benchmark
 from teatree.cli.eval.capture_subagent import capture_subagent
@@ -18,16 +22,17 @@ from teatree.cli.eval.history import history_command
 from teatree.cli.eval.label import label_app
 from teatree.cli.eval.lane_filter import filter_specs_by_lane
 from teatree.cli.eval.lanes import coverage, pinned_regressions, skill_triggers
+from teatree.cli.eval.metered_routing import warn_local_metered
 from teatree.cli.eval.multi_trial import run_model_matrix_lane, run_pass_at_k_lane
 from teatree.cli.eval.negative_control import negative_control
+from teatree.cli.eval.prepare_transcript import prepare_transcript
 from teatree.cli.eval.run_docker import RunDockerArgs, route_to_docker_if_needed
 from teatree.cli.eval.run_modes import (
     DEFAULT_COST_REGRESSION_TOLERANCE,
     RunGuards,
-    build_transcript_manifest,
     finalize_single_run,
     make_grader,
-    render_transcript_text,
+    require_persist_for_history_gates,
 )
 from teatree.cli.eval.skill_command_lane import skill_command_validity
 from teatree.cli.eval.skill_prose_lane import skill_prose_judge
@@ -224,8 +229,8 @@ def run(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a p
             "already-recorded run by grading its on-disk transcript, $0 extra; see "
             "`t3 eval prepare-transcript`) or 'sdk' (RUN the model fresh in-process via the "
             "Agent SDK, subscription-covered (CLAUDE_CODE_OAUTH_TOKEN), NOT API-billed; runs "
-            "in-container via --docker locally or in the standalone eval.yml CI job). --trials "
-            "and --models always use the fresh-run sdk runner regardless of this flag."
+            "in-container by default or directly on the host with --local). --trials and "
+            "--models require --backend sdk."
         ),
     ),
     transcript_dir: Path | None = typer.Option(
@@ -249,6 +254,14 @@ def run(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a p
         help=(
             "Force running inside the CI image (dev/Dockerfile.test) for ANY backend. The sdk "
             "lane ALREADY defaults to the container; this forces it for the transcript lane too."
+        ),
+    ),
+    local: bool = typer.Option(  # noqa: FBT001 — typer boolean flag, not a positional bool foot-gun.
+        False,
+        "--local",
+        help=(
+            "Run the fresh sdk lane directly on the host instead of Docker. Use for durable-history "
+            "gates that must persist/read the runner DB; otherwise Docker remains the reproducible path."
         ),
     ),
     parallel: int = typer.Option(
@@ -290,7 +303,7 @@ def run(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a p
     (which spawns the ``claude`` CLI as its child), authed by the subscription's
     ``CLAUDE_CODE_OAUTH_TOKEN`` (NOT an API key); CI passes ``--backend sdk``
     explicitly via the standalone ``eval.yml`` job. ``--trials``/``--models``
-    always use the fresh-run ``sdk`` runner regardless of ``--backend``.
+    require the fresh-run ``sdk`` runner and reject the transcript backend.
 
     ``--require-executed`` fails the run when the suite collected scenarios but
     executed none (every scenario skipped — typically ``claude`` not on PATH /
@@ -304,6 +317,9 @@ def run(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a p
     token authenticates the SDK's ``claude`` child inside a clean container and
     never lands on the command line.
 
+    ``--local`` is the explicit host escape for durable-history gates that must
+    persist/read the runner DB, or for a quick host check.
+
     ``--parallel N`` runs N scenarios concurrently (each SDK scenario run is
     I/O-bound, so a bounded worker pool cuts the suite's wall-clock from
     Nxlatency toward ~latency). Default 1 = today's sequential behaviour.
@@ -316,6 +332,14 @@ def run(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a p
     effort_level = require_effort(effort)
     max_turns = resolve_max_turns_override(max_turns)
     metered = backend == SDK_BACKEND or trials > 1 or models is not None
+    require_sdk_backend_for_fresh_run(backend=backend, trials=trials, models=models)
+    require_persist_for_history_gates(
+        persist=persist,
+        baseline=baseline,
+        gate_regressions=gate_regressions,
+        gate_cost_regression=gate_cost_regression,
+        gate_cost_bounds=gate_cost_bounds,
+    )
     route_to_docker_if_needed(
         RunDockerArgs(
             name=name,
@@ -335,12 +359,15 @@ def run(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a p
             transcript_html=transcript_html,
         ),
         docker=docker,
+        local=local,
         metered=metered,
         baseline=baseline,
         gate_regressions=gate_regressions,
         gate_cost_regression=gate_cost_regression,
         gate_cost_bounds=gate_cost_bounds,
     )
+    if local:
+        warn_local_metered(metered=metered)
     ensure_django()
     require_valid_format(output_format, _RUN_FORMATS)
     reject_unsupported_run_output(
@@ -363,13 +390,6 @@ def run(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a p
     # the transcript backend's legitimate pre-transcript all-skip.
     sdk_metered = backend == SDK_BACKEND or trials > 1 or models is not None
     require_executed = require_executed or sdk_metered
-    if (trials > 1 or models is not None) and backend == TRANSCRIPT_BACKEND:
-        typer.echo(
-            "note: --trials/--models force the fresh-run in-process Agent-SDK runner "
-            "(subscription-covered); the 'transcript' default does not apply to multi-trial / "
-            "matrix runs",
-            err=True,
-        )
     if models is not None:
         run_model_matrix_lane(
             specs,
@@ -453,34 +473,7 @@ def run(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a p
         sys.exit(1)
 
 
-@eval_app.command("prepare-transcript")
-def prepare_transcript(
-    name: str | None = typer.Argument(None, help="Scenario name to prepare (omit to prepare all)."),
-    transcript_dir: Path | None = typer.Option(
-        None,
-        "--transcript-dir",
-        help="Where `t3 eval capture-subagent` writes each <scenario>.jsonl transcript (default: cwd).",
-    ),
-    output_format: str = typer.Option("text", "--format", help="Manifest format: text or json."),
-) -> None:
-    """Emit the per-scenario prompts for a LOCAL transcript-backend eval run.
-
-    The eval CLI is a plain process with no in-session ``Agent`` tool, so it
-    cannot itself drive a subscription-covered turn. This command prints, per
-    scenario, the agent definition, prompt, and the transcript path the
-    ``transcript`` backend will read. The ``/t3:running-evals`` skill is the
-    in-session driver: for each entry it dispatches an ``Agent`` sub-agent on the
-    prompt, then runs ``t3 eval capture-subagent <scenario>`` to copy the
-    sub-agent's JSONL to that path, and finally grades with
-    ``t3 eval run --backend transcript``.
-    """
-    ensure_django()
-    require_valid_format(output_format)
-    specs = discover_specs() if name is None else [require_spec(name)]
-    manifest = build_transcript_manifest(specs, transcript_dir or Path.cwd())
-    typer.echo(json.dumps(manifest, indent=2) if output_format == "json" else render_transcript_text(manifest))
-
-
+eval_app.command("prepare-transcript")(prepare_transcript)
 eval_app.command("history")(history_command)
 
 

--- a/src/teatree/cli/eval/app_helpers.py
+++ b/src/teatree/cli/eval/app_helpers.py
@@ -11,6 +11,7 @@ from typing import cast
 import typer
 from claude_agent_sdk.types import EffortLevel
 
+from teatree.eval.backends import SDK_BACKEND
 from teatree.eval.discovery import discover_specs, find_spec
 from teatree.eval.model_variant import EFFORT_LEVELS
 from teatree.eval.models import EvalSpec
@@ -33,6 +34,19 @@ def require_effort(effort: str) -> EffortLevel:
         typer.echo(f"unknown --effort {effort!r}; known levels: {', '.join(EFFORT_LEVELS)}", err=True)
         raise typer.Exit(code=2)
     return cast("EffortLevel", effort)
+
+
+def require_sdk_backend_for_fresh_run(*, backend: str, trials: int, models: str | None) -> None:
+    """Reject fresh-run-only shapes unless the caller explicitly opts into sdk."""
+    if trials == 1 and models is None:
+        return
+    if backend == SDK_BACKEND:
+        return
+    typer.echo(
+        f"--trials/--models require a fresh metered run; pass --backend sdk instead of --backend {backend!r}.",
+        err=True,
+    )
+    raise typer.Exit(code=2)
 
 
 def reject_unsupported_run_output(

--- a/src/teatree/cli/eval/benchmark.py
+++ b/src/teatree/cli/eval/benchmark.py
@@ -9,9 +9,8 @@ compare to fable@medium on pass-rate and cost".
 
 The benchmark is metered, so it defaults to running IN the CI container
 (``dev/Dockerfile.test``) — a metered run must never accidentally bill the host.
-``--local`` is the explicit host escape (a quick check, NOT the reproducible
-gate); the ``T3_EVAL_IN_CONTAINER=1`` marker the docker runner sets makes the
-in-container re-invocation run in-process.
+``--local`` is the explicit host escape; the ``T3_EVAL_IN_CONTAINER=1`` marker
+the docker runner sets makes the in-container re-invocation run in-process.
 """
 
 import typer
@@ -94,8 +93,8 @@ def benchmark(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 
     ``--trials k`` (each cell's score becomes a k-trial pass-rate).
 
     The benchmark is metered, so it defaults to running in the CI container; pass
-    ``--local`` for a quick host check (NOT the reproducible gate). The container
-    is ephemeral, so a Docker-routed run is forced ``--no-persist``.
+    ``--local`` for an explicit host run. The container is ephemeral, so a
+    Docker-routed run is forced ``--no-persist``.
     """
     if should_route_to_docker(metered=True, local=local):
         _dispatch_to_docker(

--- a/src/teatree/cli/eval/docker.py
+++ b/src/teatree/cli/eval/docker.py
@@ -4,9 +4,9 @@ Reuses ``dev/Dockerfile.test`` (the image the CI test job builds) so a container
 run reproduces CI's environment exactly. The fresh-run AI lane (``t3 eval run
 --backend sdk``) and ``t3 eval benchmark`` default to running IN the container —
 the reproducible gate must never accidentally run a model on the host. The free /
-deterministic lanes stay host-default; ``t3 eval benchmark --local`` is the
-explicit host escape hatch for a quick check. No PyPI — the image installs the
-working tree via the mounted repo and ``uv``.
+deterministic lanes stay host-default; ``--local`` is the explicit host escape
+hatch for durable-history gates or quick checks. No PyPI — the image installs
+the working tree via the mounted repo and ``uv``.
 
 The fresh-run AI lane drives the in-process ``claude-agent-sdk`` (NOT ``claude -p``)
 inside the container, authenticated by the subscription's ``CLAUDE_CODE_OAUTH_TOKEN``

--- a/src/teatree/cli/eval/metered_routing.py
+++ b/src/teatree/cli/eval/metered_routing.py
@@ -1,9 +1,9 @@
 """Docker-by-default routing decision for the metered eval + benchmark lanes.
 
 The metered ``sdk`` lane and ``t3 eval benchmark`` default to running IN the CI
-container (``dev/Dockerfile.test``): a metered run bills the API, so the
-reproducible gate must never accidentally run on the host. The free /
-deterministic / subscription lanes spawn no agent and stay host-default.
+container (``dev/Dockerfile.test``): a metered run bills the API, so it must
+never accidentally run on the host. The free / deterministic / subscription
+lanes spawn no agent and stay host-default.
 
 Two predicates break the re-route loop and gate the host escape:
 
@@ -13,8 +13,8 @@ Two predicates break the re-route loop and gate the host escape:
     it is already in the container OR ``--local`` was passed; otherwise it routes
     back through :func:`~teatree.cli.eval.docker.run_eval_in_docker`.
 
-:func:`warn_local_metered` prints the loud "a host metered run is not the
-reproducible gate" warning for the ``--local`` escape.
+:func:`warn_local_metered` prints the loud host-run warning for the ``--local``
+escape.
 """
 
 import os
@@ -41,18 +41,17 @@ def should_route_to_docker(*, metered: bool, local: bool) -> bool:
 
 
 def warn_local_metered(*, metered: bool) -> None:
-    """Print the loud host-run warning for a ``--local`` metered run (no-op otherwise).
+    """Print the host-run warning for a ``--local`` metered run (no-op otherwise).
 
-    A ``--local`` metered run is a quick host check, NOT the reproducible gate —
-    isolation strips the subscription auth and the host's login state biases the
-    result. The regression gate runs in Docker / CI. Silent for a non-metered lane.
+    A ``--local`` metered run is an explicit host escape. Use it for durable
+    history gates that must persist/read the runner DB, or for quick host checks;
+    Docker remains the reproducible default when no durable ledger is needed.
     """
     if not metered:
         return
     print(  # noqa: T201 — loud, intentional operator warning on stderr.
-        "WARNING: --local runs the metered eval on the HOST. A host run is NOT the "
-        "reproducible regression gate (host login state biases the result, isolation "
-        "strips subscription auth) — use Docker / CI for the gate. This is a quick "
-        "local check only.",
+        "WARNING: --local runs the metered eval on the HOST. Use this only for "
+        "durable-history gates that need the runner DB, or for a quick host check; "
+        "Docker remains the reproducible default when no durable ledger is needed.",
         file=sys.stderr,
     )

--- a/src/teatree/cli/eval/multi_trial.py
+++ b/src/teatree/cli/eval/multi_trial.py
@@ -22,6 +22,7 @@ from teatree.cli.eval.run_modes import (
     UnderLoadRatchetGate,
     persist_matrix_run,
     persist_pass_at_k_run,
+    require_persist_for_history_gates,
     with_model,
 )
 from teatree.eval.backends import SDK_BACKEND, EvalRunner, make_runner
@@ -109,6 +110,13 @@ def run_pass_at_k_lane(  # noqa: PLR0913 — each kwarg threads one `eval run` C
     if require not in {"any", "all"}:
         typer.echo(f"unknown --require {require!r}; use 'any' or 'all'", err=True)
         raise typer.Exit(code=2)
+    require_persist_for_history_gates(
+        persist=persist,
+        baseline=baseline,
+        gate_regressions=gate_regressions,
+        gate_cost_regression=gate_cost_regression,
+        gate_cost_bounds=gate_cost_bounds,
+    )
     runner = make_runner(
         SDK_BACKEND,
         max_turns_override=max_turns,
@@ -219,6 +227,13 @@ def run_model_matrix_lane(  # noqa: PLR0913 — each kwarg threads one `eval run
     a scenario's own) still win over this lane default at the runner's seam.
     """
     model_list = parse_model_tags(models)
+    require_persist_for_history_gates(
+        persist=persist,
+        baseline=baseline,
+        gate_regressions=gate_regressions,
+        gate_cost_regression=gate_cost_regression,
+        gate_cost_bounds=gate_cost_bounds,
+    )
     runner = make_runner(
         SDK_BACKEND,
         max_turns_override=max_turns,

--- a/src/teatree/cli/eval/prepare_transcript.py
+++ b/src/teatree/cli/eval/prepare_transcript.py
@@ -1,0 +1,35 @@
+"""Transcript preparation command for the transcript eval backend."""
+
+import json
+from pathlib import Path
+
+import typer
+
+from teatree.cli._format_opts import require_valid_format
+from teatree.cli.eval.app_helpers import require_spec
+from teatree.cli.eval.run_modes import build_transcript_manifest, render_transcript_text
+from teatree.eval.discovery import discover_specs
+from teatree.utils.django_bootstrap import ensure_django
+
+
+def prepare_transcript(
+    name: str | None = typer.Argument(None, help="Scenario name to prepare (omit to prepare all)."),
+    transcript_dir: Path | None = typer.Option(
+        None,
+        "--transcript-dir",
+        help="Where `t3 eval capture-subagent` writes each <scenario>.jsonl transcript (default: cwd).",
+    ),
+    output_format: str = typer.Option("text", "--format", help="Manifest format: text or json."),
+) -> None:
+    """Emit the per-scenario prompts for a LOCAL transcript-backend eval run.
+
+    The eval CLI is a plain process with no in-session ``Agent`` tool, so it
+    cannot itself drive a subscription-covered turn. This command prints, per
+    scenario, the agent definition, prompt, and the transcript path the
+    ``transcript`` backend will read.
+    """
+    ensure_django()
+    require_valid_format(output_format)
+    specs = discover_specs() if name is None else [require_spec(name)]
+    manifest = build_transcript_manifest(specs, transcript_dir or Path.cwd())
+    typer.echo(json.dumps(manifest, indent=2) if output_format == "json" else render_transcript_text(manifest))

--- a/src/teatree/cli/eval/run_docker.py
+++ b/src/teatree/cli/eval/run_docker.py
@@ -113,6 +113,7 @@ def route_to_docker_if_needed(  # noqa: PLR0913 — each kwarg is one durable-hi
     args: RunDockerArgs,
     *,
     docker: bool,
+    local: bool,
     metered: bool,
     baseline: bool,
     gate_regressions: bool,
@@ -126,7 +127,7 @@ def route_to_docker_if_needed(  # noqa: PLR0913 — each kwarg is one durable-hi
     ``--no-persist``, then the run is dispatched into the container (which exits
     the process).
     """
-    if not (docker or should_route_to_docker(metered=metered, local=False)):
+    if not (docker or should_route_to_docker(metered=metered, local=local)):
         return
     run_in_docker_or_exit(
         args,

--- a/src/teatree/cli/eval/run_modes.py
+++ b/src/teatree/cli/eval/run_modes.py
@@ -158,6 +158,32 @@ def persist_matrix_run(
 DEFAULT_COST_REGRESSION_TOLERANCE = 0.20
 
 
+def require_persist_for_history_gates(
+    *,
+    persist: bool,
+    baseline: bool,
+    gate_regressions: bool,
+    gate_cost_regression: bool,
+    gate_cost_bounds: bool,
+) -> None:
+    if persist:
+        return
+    enabled = [
+        flag
+        for flag, active in (
+            ("--baseline", baseline),
+            ("--gate-regressions", gate_regressions),
+            ("--gate-cost-regression", gate_cost_regression),
+            ("--gate-cost-bounds", gate_cost_bounds),
+        )
+        if active
+    ]
+    if not enabled:
+        return
+    typer.echo(f"{enabled[0]} requires --persist; remove --no-persist or drop {enabled[0]}.", err=True)
+    raise typer.Exit(code=2)
+
+
 class RegressionGates:
     """Per-model baseline diffs that turn a regressed run RED at the CLI boundary.
 
@@ -323,9 +349,16 @@ def finalize_single_run(  # noqa: PLR0913 — each kwarg threads one `eval run` 
     Returns ``True`` when the process should exit non-zero: any scenario
     failed, OR a score regression, OR a cost regression beyond tolerance, OR a
     declarative cost-bounds violation (over ceiling / configured-but-uncosted).
-    With ``--no-persist`` the gates have no durable record to read and are
-    skipped — only the scenario pass/fail decides the exit.
+    With ``--no-persist`` durable-history gates are rejected before this point:
+    silently skipping them would turn a requested gate into a no-op.
     """
+    require_persist_for_history_gates(
+        persist=persist,
+        baseline=baseline,
+        gate_regressions=gate_regressions,
+        gate_cost_regression=gate_cost_regression,
+        gate_cost_bounds=gate_cost_bounds,
+    )
     regressed = False
     cost_regressed = False
     cost_bounds_failed = False
@@ -357,7 +390,7 @@ def render_transcript_text(manifest: list[dict[str, str]]) -> str:
         (
             f"scenario: {entry['scenario']}  (model {entry['model']})\n"
             f"  agent:        {entry['agent_path']}\n"
-            f"  capture to:   {entry['transcript_path']}  (via `t3 eval capture-subagent {entry['scenario']}`)\n"
+            f"  capture to:   {entry['transcript_path']}\n"
             f"  prompt:       {entry['prompt']}\n"
         )
         for entry in manifest

--- a/tests/teatree_cli/eval/test_eval_workflow_config.py
+++ b/tests/teatree_cli/eval/test_eval_workflow_config.py
@@ -1,0 +1,18 @@
+"""Static checks for the standalone metered eval GitHub workflow."""
+
+from pathlib import Path
+
+_WORKFLOW = Path(__file__).resolve().parents[3] / ".github" / "workflows" / "eval.yml"
+
+
+class TestMeteredEvalWorkflow:
+    def test_manual_workflow_does_not_expose_a_backend_input_for_trials(self) -> None:
+        text = _WORKFLOW.read_text(encoding="utf-8")
+        assert "backend:" not in text
+        assert "inputs.backend" not in text
+        assert "EVAL_BACKEND" not in text
+
+    def test_metered_command_pins_sdk_backend(self) -> None:
+        text = _WORKFLOW.read_text(encoding="utf-8")
+        assert '--backend "$EVAL_BACKEND"' not in text
+        assert "--backend sdk" in text

--- a/tests/teatree_cli/test_eval.py
+++ b/tests/teatree_cli/test_eval.py
@@ -513,7 +513,7 @@ class TestEvalPassAtK:
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
             patch("teatree.eval.backends.SdkInProcessRunner", _StubRunner),
         ):
-            result = CliRunner().invoke(app, ["eval", "run", "--trials", "3", "--no-persist"])
+            result = CliRunner().invoke(app, ["eval", "run", "--backend", "sdk", "--trials", "3", "--no-persist"])
         assert result.exit_code == 0, result.output
         assert "PASS alpha (3/3 trials" in result.output
 
@@ -532,14 +532,18 @@ class TestEvalPassAtK:
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
             patch("teatree.eval.backends.SdkInProcessRunner", _StubRunner),
         ):
-            result = CliRunner().invoke(app, ["eval", "run", "--trials", "2", "--require", "all", "--no-persist"])
+            result = CliRunner().invoke(
+                app, ["eval", "run", "--backend", "sdk", "--trials", "2", "--require", "all", "--no-persist"]
+            )
         assert result.exit_code == 1
         assert "FAIL alpha (1/2 trials" in result.output
 
     def test_bad_require_exits_code_2(self) -> None:
         specs = [_spec("alpha")]
         with patch("teatree.cli.eval.app.discover_specs", return_value=specs):
-            result = CliRunner().invoke(app, ["eval", "run", "--trials", "2", "--require", "most", "--no-persist"])
+            result = CliRunner().invoke(
+                app, ["eval", "run", "--backend", "sdk", "--trials", "2", "--require", "most", "--no-persist"]
+            )
         assert result.exit_code == 2
         assert "unknown --require" in result.output
 
@@ -556,7 +560,9 @@ class TestEvalPassAtK:
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
             patch("teatree.eval.backends.SdkInProcessRunner", _StubRunner),
         ):
-            result = CliRunner().invoke(app, ["eval", "run", "--trials", "2", "--format", "json", "--no-persist"])
+            result = CliRunner().invoke(
+                app, ["eval", "run", "--backend", "sdk", "--trials", "2", "--format", "json", "--no-persist"]
+            )
         assert result.exit_code == 0, result.output
         output = result.output
         payload = json.loads(output[output.index("{") : output.rindex("}") + 1])
@@ -579,7 +585,7 @@ class TestEvalPassAtK:
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
             patch("teatree.eval.backends.SdkInProcessRunner", _StubRunner),
         ):
-            result = CliRunner().invoke(app, ["eval", "run", "--trials", "2", "--no-persist"])
+            result = CliRunner().invoke(app, ["eval", "run", "--backend", "sdk", "--trials", "2", "--no-persist"])
         assert result.exit_code != 0, result.output
         assert "SKIP alpha" in result.output
         assert "executed 0" in result.output
@@ -648,7 +654,9 @@ class TestEvalRequireExecuted:
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
             patch("teatree.eval.backends.SdkInProcessRunner", _SkippingRunner),
         ):
-            result = CliRunner().invoke(app, ["eval", "run", "--trials", "3", "--require-executed", "--no-persist"])
+            result = CliRunner().invoke(
+                app, ["eval", "run", "--backend", "sdk", "--trials", "3", "--require-executed", "--no-persist"]
+            )
         assert result.exit_code != 0, result.output
         assert "executed 0" in result.output
 
@@ -660,7 +668,7 @@ class TestEvalRequireExecuted:
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
             patch("teatree.eval.backends.SdkInProcessRunner", _SkippingRunner),
         ):
-            result = CliRunner().invoke(app, ["eval", "run", "--trials", "3", "--no-persist"])
+            result = CliRunner().invoke(app, ["eval", "run", "--backend", "sdk", "--trials", "3", "--no-persist"])
         assert result.exit_code != 0, result.output
         assert "executed 0" in result.output
 
@@ -677,7 +685,9 @@ class TestEvalRequireExecuted:
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
             patch("teatree.eval.backends.SdkInProcessRunner", _PassingRunner),
         ):
-            result = CliRunner().invoke(app, ["eval", "run", "--trials", "3", "--require-executed", "--no-persist"])
+            result = CliRunner().invoke(
+                app, ["eval", "run", "--backend", "sdk", "--trials", "3", "--require-executed", "--no-persist"]
+            )
         assert result.exit_code == 0, result.output
         assert "PASS alpha" in result.output
 
@@ -782,17 +792,14 @@ class TestEvalBackend:
         assert str(tmp_path / "worktree_first.jsonl") in result.output
         assert "prepare-transcript" in result.output
 
-    def test_trials_with_default_backend_warns_metered(self, tmp_path: Path) -> None:
-        # `--trials` forces the fresh-run sdk runner even under the transcript
-        # default; the user is told so.
+    def test_trials_with_default_backend_is_rejected(self) -> None:
+        # `--trials` cannot be served from a single saved transcript. The caller
+        # must opt into the fresh metered lane explicitly with `--backend sdk`.
         specs = [_spec("alpha")]
-        with (
-            patch("teatree.cli.eval.app.discover_specs", return_value=specs),
-            patch("teatree.eval.backends.SdkInProcessRunner", _PassRunner),
-        ):
+        with patch("teatree.cli.eval.app.discover_specs", return_value=specs):
             result = CliRunner().invoke(app, ["eval", "run", "--trials", "2", "--no-persist"])
-        assert result.exit_code == 0, result.output
-        assert "fresh-run in-process Agent-SDK runner" in result.output
+        assert result.exit_code == 2, result.output
+        assert "pass --backend sdk" in result.output
 
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
@@ -1049,6 +1056,45 @@ class TestEvalCostBoundsGate:
         run_docker.assert_not_called()
         assert "ephemeral container" in result.output
 
+    def test_no_persist_is_rejected_for_cost_bounds(self) -> None:
+        specs = [_spec("alpha")]
+        with (
+            patch("teatree.cli.eval.app.discover_specs", return_value=specs),
+            patch("teatree.eval.backends.SdkInProcessRunner", _cost_runner(0.05)),
+        ):
+            result = CliRunner().invoke(app, ["eval", "run", "--backend", "sdk", "--gate-cost-bounds", "--no-persist"])
+        assert result.exit_code == 2, result.output
+        assert "--gate-cost-bounds requires --persist" in result.output
+
+    def test_gitlab_weekly_cost_bounds_command_runs_on_host_with_local_escape(self, tmp_path: Path) -> None:
+        specs = [_spec("alpha")]
+        body = "default_margin: 0.25\nscenarios:\n  alpha:\n    bound_usd: 1.00\n"
+        command = [
+            "eval",
+            "run",
+            "--trials",
+            "3",
+            "--require",
+            "any",
+            "--backend",
+            "sdk",
+            "--local",
+            "--require-executed",
+            "--gate-cost-bounds",
+            "--gate-under-load-ratchet",
+        ]
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("teatree.cli.eval.app.discover_specs", return_value=specs),
+            patch("teatree.eval.backends.SdkInProcessRunner", _cost_runner(0.05)),
+            patch("teatree.eval.persistence.current_git_sha", return_value=""),
+            patch("teatree.cli.eval.run_docker.run_eval_in_docker") as run_docker,
+            self._bounds_file(tmp_path, body),
+        ):
+            result = CliRunner().invoke(app, command)
+        assert result.exit_code == 0, result.output
+        run_docker.assert_not_called()
+
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
@@ -1059,7 +1105,9 @@ class TestEvalModelMatrix:
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
             patch("teatree.eval.backends.SdkInProcessRunner", _PassRunner),
         ):
-            result = CliRunner().invoke(app, ["eval", "run", "--models", "opus,haiku", "--no-persist"])
+            result = CliRunner().invoke(
+                app, ["eval", "run", "--backend", "sdk", "--models", "opus,haiku", "--no-persist"]
+            )
         assert result.exit_code == 0, result.output
         assert "opus" in result.output
         assert "haiku" in result.output
@@ -1073,7 +1121,7 @@ class TestEvalModelMatrix:
             patch("teatree.eval.backends.SdkInProcessRunner", _PassRunner),
         ):
             result = CliRunner().invoke(
-                app, ["eval", "run", "--models", "opus,haiku", "--format", "json", "--no-persist"]
+                app, ["eval", "run", "--backend", "sdk", "--models", "opus,haiku", "--format", "json", "--no-persist"]
             )
         payload = json.loads(result.output[result.output.index("{") : result.output.rindex("}") + 1])
         assert payload["models"] == ["opus", "haiku"]
@@ -1092,7 +1140,9 @@ class TestEvalModelMatrix:
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
             patch("teatree.eval.backends.SdkInProcessRunner", _FailOnHaiku),
         ):
-            result = CliRunner().invoke(app, ["eval", "run", "--models", "opus,haiku", "--no-persist"])
+            result = CliRunner().invoke(
+                app, ["eval", "run", "--backend", "sdk", "--models", "opus,haiku", "--no-persist"]
+            )
         assert result.exit_code == 1, result.output
         assert "opus: 1 passed" in result.output
         assert "haiku: 0 passed, 1 failed" in result.output
@@ -1100,7 +1150,7 @@ class TestEvalModelMatrix:
     def test_empty_models_exits_code_2(self) -> None:
         specs = [_spec("alpha")]
         with patch("teatree.cli.eval.app.discover_specs", return_value=specs):
-            result = CliRunner().invoke(app, ["eval", "run", "--models", " , ", "--no-persist"])
+            result = CliRunner().invoke(app, ["eval", "run", "--backend", "sdk", "--models", " , ", "--no-persist"])
         assert result.exit_code == 2
         assert "--models was empty" in result.output
 
@@ -1111,7 +1161,7 @@ class TestEvalModelMatrix:
             patch("teatree.eval.backends.SdkInProcessRunner", _PassRunner),
             patch("teatree.eval.persistence.current_git_sha", return_value=""),
         ):
-            CliRunner().invoke(app, ["eval", "run", "--models", "opus,haiku"])
+            CliRunner().invoke(app, ["eval", "run", "--backend", "sdk", "--models", "opus,haiku"])
             history = CliRunner().invoke(app, ["eval", "history", "--format", "json"])
         payload = json.loads(history.output[history.output.index("{") : history.output.rindex("}") + 1])
         assert payload["runs"][0]["model"] == "opus,haiku"
@@ -1123,7 +1173,7 @@ class TestEvalModelMatrix:
             patch("teatree.eval.backends.SdkInProcessRunner", _SkippingRunner),
         ):
             result = CliRunner().invoke(
-                app, ["eval", "run", "--models", "opus,haiku", "--require-executed", "--no-persist"]
+                app, ["eval", "run", "--backend", "sdk", "--models", "opus,haiku", "--require-executed", "--no-persist"]
             )
         assert result.exit_code != 0, result.output
         assert "executed 0" in result.output
@@ -1136,9 +1186,18 @@ class TestEvalModelMatrix:
             patch("teatree.cli.eval.app.discover_specs", return_value=specs),
             patch("teatree.eval.backends.SdkInProcessRunner", _SkippingRunner),
         ):
-            result = CliRunner().invoke(app, ["eval", "run", "--models", "opus,haiku", "--no-persist"])
+            result = CliRunner().invoke(
+                app, ["eval", "run", "--backend", "sdk", "--models", "opus,haiku", "--no-persist"]
+            )
         assert result.exit_code != 0, result.output
         assert "executed 0" in result.output
+
+    def test_no_persist_is_rejected_for_history_gates(self) -> None:
+        specs = [_spec("alpha")]
+        with patch("teatree.cli.eval.app.discover_specs", return_value=specs):
+            result = CliRunner().invoke(app, ["eval", "run", "--backend", "sdk", "--gate-regressions", "--no-persist"])
+        assert result.exit_code == 2, result.output
+        assert "--gate-regressions requires --persist" in result.output
 
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
@@ -1154,7 +1213,15 @@ class TestEvalModelVariantMatrix:
         ):
             result = CliRunner().invoke(
                 app,
-                ["eval", "run", "--models", "claude-opus-4-8@xhigh,claude-fable-5@medium", "--no-persist"],
+                [
+                    "eval",
+                    "run",
+                    "--backend",
+                    "sdk",
+                    "--models",
+                    "claude-opus-4-8@xhigh,claude-fable-5@medium",
+                    "--no-persist",
+                ],
             )
         assert result.exit_code == 0, result.output
         assert "claude-opus-4-8@xhigh" in result.output
@@ -1167,7 +1234,7 @@ class TestEvalModelVariantMatrix:
             patch("teatree.eval.backends.SdkInProcessRunner", _PassRunner),
             patch("teatree.eval.persistence.current_git_sha", return_value=""),
         ):
-            CliRunner().invoke(app, ["eval", "run", "--models", "opus@xhigh,opus@medium"])
+            CliRunner().invoke(app, ["eval", "run", "--backend", "sdk", "--models", "opus@xhigh,opus@medium"])
             history = CliRunner().invoke(app, ["eval", "history", "--format", "json"])
         payload = json.loads(history.output[history.output.index("{") : history.output.rindex("}") + 1])
         assert payload["runs"][0]["model"] == "opus@xhigh,opus@medium"
@@ -1175,7 +1242,9 @@ class TestEvalModelVariantMatrix:
     def test_unknown_effort_exits_code_2_with_known_levels(self) -> None:
         specs = [_spec("alpha")]
         with patch("teatree.cli.eval.app.discover_specs", return_value=specs):
-            result = CliRunner().invoke(app, ["eval", "run", "--models", "opus@turbo", "--no-persist"])
+            result = CliRunner().invoke(
+                app, ["eval", "run", "--backend", "sdk", "--models", "opus@turbo", "--no-persist"]
+            )
         assert result.exit_code == 2
         assert "unknown effort 'turbo'" in result.output
         assert "xhigh" in result.output
@@ -1183,7 +1252,9 @@ class TestEvalModelVariantMatrix:
     def test_html_format_is_rejected_for_a_matrix_run(self) -> None:
         specs = [_spec("alpha")]
         with patch("teatree.cli.eval.app.discover_specs", return_value=specs):
-            result = CliRunner().invoke(app, ["eval", "run", "--models", "opus", "--format", "html", "--no-persist"])
+            result = CliRunner().invoke(
+                app, ["eval", "run", "--backend", "sdk", "--models", "opus", "--format", "html", "--no-persist"]
+            )
         assert result.exit_code == 2
         assert "only supported for a single-trial run" in result.output
 
@@ -1508,7 +1579,7 @@ class TestMatrixCostRegressionGate:
             patch("teatree.eval.backends.SdkInProcessRunner", _Cheap),
             patch("teatree.eval.persistence.current_git_sha", return_value=""),
         ):
-            CliRunner().invoke(app, ["eval", "run", "--models", model, "--baseline"])
+            CliRunner().invoke(app, ["eval", "run", "--backend", "sdk", "--models", model, "--baseline"])
 
     def test_models_lane_fails_on_a_cost_blowup(self) -> None:
         self._cheap_baseline("opus")
@@ -1521,7 +1592,9 @@ class TestMatrixCostRegressionGate:
             patch("teatree.eval.backends.SdkInProcessRunner", _Spendy),
             patch("teatree.eval.persistence.current_git_sha", return_value=""),
         ):
-            result = CliRunner().invoke(app, ["eval", "run", "--models", "opus", "--gate-cost-regression"])
+            result = CliRunner().invoke(
+                app, ["eval", "run", "--backend", "sdk", "--models", "opus", "--gate-cost-regression"]
+            )
         assert result.exit_code == 1, result.output
         assert "COST REGRESSED" in result.output
 
@@ -1532,7 +1605,9 @@ class TestMatrixCostRegressionGate:
             patch("teatree.eval.backends.SdkInProcessRunner", _CostRunner),
             patch("teatree.eval.persistence.current_git_sha", return_value=""),
         ):
-            result = CliRunner().invoke(app, ["eval", "run", "--models", "opus", "--gate-cost-regression"])
+            result = CliRunner().invoke(
+                app, ["eval", "run", "--backend", "sdk", "--models", "opus", "--gate-cost-regression"]
+            )
         # cost fell (0.05 < 0.10), no regression
         assert result.exit_code == 0, result.output
         assert "COST REGRESSED" not in result.output
@@ -1546,7 +1621,7 @@ class TestMatrixCostRegressionGate:
             patch("teatree.eval.backends.SdkInProcessRunner", _Cheap),
             patch("teatree.eval.persistence.current_git_sha", return_value=""),
         ):
-            CliRunner().invoke(app, ["eval", "run", "--trials", "2", "--baseline"])
+            CliRunner().invoke(app, ["eval", "run", "--backend", "sdk", "--trials", "2", "--baseline"])
 
         class _Spendy(_CostRunner):
             cost = 1.00
@@ -1556,7 +1631,9 @@ class TestMatrixCostRegressionGate:
             patch("teatree.eval.backends.SdkInProcessRunner", _Spendy),
             patch("teatree.eval.persistence.current_git_sha", return_value=""),
         ):
-            result = CliRunner().invoke(app, ["eval", "run", "--trials", "2", "--gate-cost-regression"])
+            result = CliRunner().invoke(
+                app, ["eval", "run", "--backend", "sdk", "--trials", "2", "--gate-cost-regression"]
+            )
         assert result.exit_code == 1, result.output
         assert "COST REGRESSED" in result.output
 
@@ -1564,15 +1641,16 @@ class TestMatrixCostRegressionGate:
 class TestPrepareTranscript:
     def test_emits_prompt_and_transcript_path(self, tmp_path: Path) -> None:
         specs = [_spec("alpha")]
-        with patch("teatree.cli.eval.app.discover_specs", return_value=specs):
+        with patch("teatree.cli.eval.prepare_transcript.discover_specs", return_value=specs):
             result = CliRunner().invoke(app, ["eval", "prepare-transcript", "--transcript-dir", str(tmp_path)])
         assert result.exit_code == 0, result.output
         assert "alpha" in result.output
         assert str(tmp_path / "alpha.jsonl") in result.output
+        assert "capture-subagent" not in result.output
 
     def test_json_format_lists_manifest(self, tmp_path: Path) -> None:
         specs = [_spec("alpha")]
-        with patch("teatree.cli.eval.app.discover_specs", return_value=specs):
+        with patch("teatree.cli.eval.prepare_transcript.discover_specs", return_value=specs):
             result = CliRunner().invoke(
                 app,
                 ["eval", "prepare-transcript", "--format", "json", "--transcript-dir", str(tmp_path)],
@@ -2029,7 +2107,7 @@ class TestEvalRunDocker:
 
     def test_forwards_scenario_name_and_trials(self) -> None:
         with patch("teatree.cli.eval.run_docker.run_eval_in_docker", return_value=0) as run_docker:
-            CliRunner().invoke(app, ["eval", "run", "alpha", "--trials", "3", "--docker"])
+            CliRunner().invoke(app, ["eval", "run", "alpha", "--backend", "sdk", "--trials", "3", "--docker"])
         assert run_docker.call_args.args[0] == [
             "run",
             "alpha",
@@ -2041,6 +2119,8 @@ class TestEvalRunDocker:
             "3",
             "--require",
             "any",
+            "--backend",
+            "sdk",
             "--no-persist",
         ]
 
@@ -2063,7 +2143,9 @@ class TestEvalRunDocker:
 
     def test_forwards_under_load_ratchet_gate_into_the_container(self) -> None:
         with patch("teatree.cli.eval.run_docker.run_eval_in_docker", return_value=0) as run_docker:
-            CliRunner().invoke(app, ["eval", "run", "--trials", "3", "--gate-under-load-ratchet", "--docker"])
+            CliRunner().invoke(
+                app, ["eval", "run", "--backend", "sdk", "--trials", "3", "--gate-under-load-ratchet", "--docker"]
+            )
         assert "--gate-under-load-ratchet" in run_docker.call_args.args[0]
 
     def test_propagates_container_exit_code(self) -> None:
@@ -2114,7 +2196,7 @@ class TestEvalRunMeteredDockerByDefault:
             patch.dict("os.environ", {}, clear=True),
             patch("teatree.cli.eval.run_docker.run_eval_in_docker", return_value=0) as run_docker,
         ):
-            result = CliRunner().invoke(app, ["eval", "run", "alpha", "--trials", "3"])
+            result = CliRunner().invoke(app, ["eval", "run", "alpha", "--backend", "sdk", "--trials", "3"])
         assert result.exit_code == 0, result.output
         run_docker.assert_called_once()
 

--- a/tests/test_eval_ci_manual_trigger.py
+++ b/tests/test_eval_ci_manual_trigger.py
@@ -4,8 +4,8 @@ The metered ``claude -p`` suite lives in a standalone workflow
 (``.github/workflows/eval.yml`` / a GitLab schedule + manual job) so a PR
 pipeline neither runs nor displays a metered-eval check. These tests pin the
 weekly schedule and the on-demand manual trigger on both mirrors: GitHub
-``schedule`` + ``workflow_dispatch`` (with an optional backend input), and a
-GitLab schedule + ``when: manual`` eval job.
+``schedule`` + ``workflow_dispatch`` (with the SDK backend fixed in the
+workflow command), and a GitLab schedule + ``when: manual`` eval job.
 """
 
 from pathlib import Path
@@ -58,11 +58,15 @@ class TestGitHubEvalTriggers:
             f"The metered eval must run weekly (a pinned day-of-week), not daily; got {crons}."
         )
 
-    def test_backend_input_defaults_to_sdk(self) -> None:
+    def test_backend_is_fixed_to_sdk_for_trials(self) -> None:
         inputs = cast("dict[str, Any]", _gh_on()["workflow_dispatch"]["inputs"])
-        assert inputs["backend"]["default"] == "sdk", (
-            "The optional `backend` input should default to sdk (the metered CI path)."
+        assert "backend" not in inputs, "`--trials 3` is always a fresh metered SDK run."
+
+        commands = "\n".join(
+            step.get("with", {}).get("command", "") for step in cast("list[dict[str, Any]]", _gh_eval_job()["steps"])
         )
+        assert "--trials 3" in commands
+        assert "--backend sdk" in commands
 
     def test_eval_job_runs_the_suite(self) -> None:
         for step in cast("list[dict[str, Any]]", _gh_eval_job()["steps"]):


### PR DESCRIPTION
## What
- Clarify eval routing so durable cost/ratchet gates run through the intended backend instead of silently falling into incompatible Docker paths.
- Update workflow docs/generated CLI reference and eval README to describe the supported gate/run-mode combinations.
- Add regression tests for workflow/backend selection and multi-trial gate behavior.

## Why
- Weekly eval gates must be executable and meaningful; unreachable gates give false confidence.

## Verification
- `uv run pytest --no-cov -q tests/teatree_cli/test_eval.py tests/teatree_cli/eval/test_metered_routing.py tests/teatree_cli/eval/test_run_docker.py tests/teatree_cli/eval/test_eval_workflow_config.py` — 207 passed
- `uv run pytest --no-cov -q tests/teatree_cli/eval` — 118 passed
- `uv run ruff check --no-fix ...`
- `uv run tach check`
- `git diff --check`

Open questions & assumptions:
- none