### PR TITLE
chore(hooks): bump ac-django skill hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -195,7 +195,7 @@ repos:
   # (resolved via `uvx --from ast-grep-cli==0.42.3`). The pyproject hook
   # grandfathers the three existing complexity-ignore entries via --grandfather.
   - repo: https://github.com/souliane/skills
-    rev: 08a9715af678766fde6ce61a6fce288ade1eba88
+    rev: 92d6cfa57e08b44c27573b09183256834df59a8b
     hooks:
       - id: ac-django-no-pytest-django-db
         files: ^tests/.*\.py$


### PR DESCRIPTION
## What
- Bump the pinned `souliane/skills` hook revision to `92d6cfa57e08b44c27573b09183256834df59a8b`.

## Why
- Pulls in two upstream hook fixes:
  - `astgrep_scan.py` no longer crashes on evaluated `list[str] | None` under the cached hook runtime.
  - `pyproject_complexity.py` no longer depends on `tomllib` in script hook environments.

## Verification
- `prek run ac-django-no-pytest-django-db --all-files`
- `prek run ac-django-testcase-no-pytest-parametrize --all-files`
- `prek run ac-django-no-complexity-suppressions --all-files`
- `prek run ac-django-no-pyproject-complexity --all-files`
- `prek run check-yaml --files .pre-commit-config.yaml`
- `git diff --check`

Open questions & assumptions:
- none