### PR TITLE
fix(e2e): expose selected spec path to overlays

### DIFF
--- a/src/teatree/core/management/commands/_e2e_runners.py
+++ b/src/teatree/core/management/commands/_e2e_runners.py
@@ -8,6 +8,7 @@ directory, and building the Playwright environment dict.
 """
 
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
 import typer
@@ -53,6 +54,25 @@ class E2eSpecsResolutionError(RuntimeError):
     def no_private_tests(cls) -> "E2eSpecsResolutionError":
         msg = "private_tests not configured in ~/.teatree.toml / T3_PRIVATE_TESTS, or directory missing."
         return cls(msg, exit_code=1)
+
+
+@dataclass(frozen=True)
+class E2eEnvContext:
+    test_path: str = ""
+    compose_project: str | None = None
+    env_cache_override: dict[str, str] | None = None
+
+
+def make_e2e_env_context(
+    test_path: str,
+    compose_project: str | None,
+    env_cache_override: dict[str, str] | None,
+) -> E2eEnvContext:
+    return E2eEnvContext(
+        test_path=test_path,
+        compose_project=compose_project,
+        env_cache_override=env_cache_override,
+    )
 
 
 def clone_or_update_e2e_repo(repo: E2ERepo, branch_override: str = "") -> Path:
@@ -129,8 +149,7 @@ def build_e2e_env(
     *,
     headed: bool,
     target: str,
-    compose_project: str | None = None,
-    env_cache_override: dict[str, str] | None = None,
+    context: E2eEnvContext | None = None,
 ) -> dict[str, str]:
     """Build environment dict for Playwright: ``BASE_URL``, overlay extras, ``CI``.
 
@@ -142,32 +161,39 @@ def build_e2e_env(
     ``process.env.T3_E2E_TARGET === 'dev'`` instead of re-deriving the target
     from a ``BASE_URL`` host regex.
 
-    *compose_project* is the teatree-managed docker-compose project of the
-    resolved worktree (``compose_project(worktree)``) for a local target. It
-    is exported as ``COMPOSE_PROJECT_NAME`` — the variable ``docker compose``
-    natively honours — so a spec that resolves the backend via a bare
-    ``docker compose port web 8000`` / ``docker compose exec -T web`` (run
-    from the backend repo dir, no ``-p``) deterministically targets the
-    teatree stack whose ``web`` container has the restored-Postgres
-    ``DATABASE_URL`` injected, instead of defaulting to the directory
-    basename and missing it. ``None`` (dev target) leaves it unset.
+    *context.test_path* is the selected Playwright spec path. When present, it is
+    threaded into the env cache visible to overlays as
+    ``T3_E2E_TEST_PATH`` so overlay manifests can derive per-spec extras.
+
+    *context.compose_project* is the teatree-managed docker-compose project
+    of the resolved worktree (``compose_project(worktree)``) for a local
+    target. It is exported as ``COMPOSE_PROJECT_NAME`` — the variable
+    ``docker compose`` natively honours — so a spec that resolves the backend
+    via a bare ``docker compose port web 8000`` / ``docker compose exec -T
+    web`` (run from the backend repo dir, no ``-p``) deterministically
+    targets the teatree stack whose ``web`` container has the
+    restored-Postgres ``DATABASE_URL`` injected, instead of defaulting to the
+    directory basename and missing it. ``None`` (dev target) leaves it unset.
 
     Overlay-specific env vars (e.g. ``CUSTOMER``) come from
     :meth:`OverlayBase.get_e2e_env_extras` — core only knows about ``BASE_URL``,
-    ``T3_E2E_TARGET``, ``COMPOSE_PROJECT_NAME`` and ``CI``.
+    ``T3_E2E_TARGET``, ``COMPOSE_PROJECT_NAME``, ``T3_E2E_TEST_PATH`` and ``CI``.
     """
     env = {**os.environ}
+    context = context or E2eEnvContext()
     if frontend_url is not None:
         env["BASE_URL"] = frontend_url
     env["T3_E2E_TARGET"] = target
-    if compose_project:
-        env["COMPOSE_PROJECT_NAME"] = compose_project
+    if context.compose_project:
+        env["COMPOSE_PROJECT_NAME"] = context.compose_project
 
-    if env_cache_override is not None:
-        env_cache = env_cache_override
+    if context.env_cache_override is not None:
+        env_cache = context.env_cache_override
     else:
         envfile = _find_env_cache(_get_user_cwd())
         env_cache = _parse_env_file(envfile) if envfile is not None else {}
+    if context.test_path:
+        env_cache = {**env_cache, "T3_E2E_TEST_PATH": context.test_path}
     for key, value in get_overlay().get_e2e_env_extras(env_cache).items():
         env.setdefault(key, value)
 

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -409,8 +409,7 @@ class Command(TyperCommand):
             frontend_url,
             headed=headed,
             target=resolved_target,
-            compose_project=worktree_compose_project,
-            env_cache_override=env_cache_override,
+            context=_runners.make_e2e_env_context(test_path, worktree_compose_project, env_cache_override),
         )
 
         self.stdout.write(f"  Running from: {private_tests_path}")

--- a/tests/teatree_core/management_commands/test_e2e.py
+++ b/tests/teatree_core/management_commands/test_e2e.py
@@ -537,6 +537,16 @@ class TestE2eExternal(TestCase):
         overrides.
         """
         with tempfile.TemporaryDirectory() as tmp:
+            captured_env_caches: list[dict[str, str]] = []
+
+            def get_e2e_env_extras(self: object, env_cache: dict[str, str]) -> dict[str, str]:
+                _ = self
+                captured_env_caches.append(dict(env_cache))
+                return {
+                    "CUSTOMER": env_cache.get("WT_VARIANT", ""),
+                    "SPEC_PATH_SEEN": env_cache.get("T3_E2E_TEST_PATH", ""),
+                }
+
             tmp_path = Path(tmp)
             backend_wt_dir = tmp_path / "backend-worktree"
             backend_wt_dir.mkdir()
@@ -588,16 +598,30 @@ class TestE2eExternal(TestCase):
                     clear=False,
                 ),
                 patch.object(e2e_disc_mod, "get_service_port", return_value=62674),
+                patch.object(import_string(FULL_OVERLAY), "get_e2e_env_extras", get_e2e_env_extras),
                 patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
             ):
                 os.environ.pop("BASE_URL", None)
                 result = cast(
                     "str",
-                    call_command("e2e", "external", target="local", linked_to=backend_ticket.pk),
+                    call_command(
+                        "e2e",
+                        "external",
+                        test_path="tests/specs/loan-flow.spec.ts",
+                        target="local",
+                        linked_to=backend_ticket.pk,
+                    ),
                 )
 
             assert "passed" in result
             env = mock_run.call_args[1]["env"]
+            assert captured_env_caches == [
+                {
+                    "WT_VARIANT": "tenant-child",
+                    "TICKET_DIR": str(backend_wt_dir.parent),
+                    "T3_E2E_TEST_PATH": "tests/specs/loan-flow.spec.ts",
+                },
+            ]
             # Frontend discovered via the linked backend worktree's project.
             assert env["BASE_URL"] == "http://localhost:62674"
             # COMPOSE_PROJECT_NAME points at the backend worktree's project,
@@ -607,6 +631,7 @@ class TestE2eExternal(TestCase):
             # the linked backend worktree's, so overlay-derived extras (e.g.
             # CUSTOMER=<variant>) reach the spec.
             assert env["CUSTOMER"] == "tenant-child"
+            assert env["SPEC_PATH_SEEN"] == "tests/specs/loan-flow.spec.ts"
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)


### PR DESCRIPTION
## What
- Pass the selected Playwright spec path into overlay e2e env derivation as `T3_E2E_TEST_PATH`.
- Preserve linked-worktree env cache behavior for local e2e runs.
- Add a regression test covering tenant extras plus spec-path propagation.

## Verification
- `uv run pytest tests/teatree_core/management_commands/test_e2e.py -q` — 54 passed, 4 subtests passed
- `uv run ruff check --no-fix src/teatree/core/management/commands/_e2e_runners.py src/teatree/core/management/commands/e2e.py tests/teatree_core/management_commands/test_e2e.py`
- `uv run ruff format --check src/teatree/core/management/commands/_e2e_runners.py src/teatree/core/management/commands/e2e.py tests/teatree_core/management_commands/test_e2e.py`
- `git diff --check`
- commit hooks passed