### PR TITLE
fix(e2e): support QA target selection

### DIFF
--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -117,7 +117,7 @@ class Command(TyperCommand):
         absent, ``test_dir`` implies ``project`` and ``project_path`` implies
         ``external`` for compatibility.
 
-        ``--target dev|local`` selects the dual-env target and is forwarded to
+        ``--target dev|qa|local`` selects the dual-env target and is forwarded to
         whichever runner handles the overlay (see ``external`` for semantics).
         ``--branch``/``--ref`` overrides the ``external`` runner's specs ref.
 
@@ -282,9 +282,11 @@ class Command(TyperCommand):
         linked_ticket: Ticket | None,
     ) -> tuple[str | None, str | None, dict[str, str] | None]:
         """Build the per-target trio passed to ``_build_e2e_env``."""
-        if resolved_target == "dev":
+        if resolved_target in {"dev", "qa"}:
             if not os.environ.get("BASE_URL"):
-                self.stderr.write("--target dev requires BASE_URL (the deployed environment URL) to be set.")
+                self.stderr.write(
+                    f"--target {resolved_target} requires BASE_URL (the deployed environment URL) to be set.",
+                )
                 raise SystemExit(1)
             return None, None, None
 
@@ -319,16 +321,14 @@ class Command(TyperCommand):
     def _resolve_target(self, target: str) -> str:
         """Resolve the dual-env target deterministically.
 
-        ``dev`` / ``local`` are explicit. Empty means back-compat inference:
-        a pre-set ``BASE_URL`` env var means a remote target (``dev``),
-        otherwise ``local``. The result is exported verbatim as
-        ``T3_E2E_TARGET`` so the spec never re-derives it from a host regex.
+        Explicit values are ``dev`` / ``qa`` / ``local``. Empty preserves the
+        back-compat inference: ``BASE_URL`` means remote ``dev``, else ``local``.
         """
         normalized = target.strip().lower()
-        if normalized in {"dev", "local"}:
+        if normalized in {"dev", "qa", "local"}:
             return normalized
         if normalized:
-            self.stderr.write(f"--target must be 'dev' or 'local', got {target!r}.")
+            self.stderr.write(f"--target must be 'dev', 'qa', or 'local', got {target!r}.")
             raise SystemExit(2)
         return "dev" if os.environ.get("BASE_URL") else "local"
 
@@ -358,17 +358,13 @@ class Command(TyperCommand):
         ``--branch``/``--ref`` overrides the ``--repo`` clone's specs ref (the
         ``[e2e_repos.<name>].branch`` default) to run from an open MR's branch.
 
-        ``--target dev|local`` selects the dual-env target deterministically:
-
-        - ``dev``: keep the pre-set ``BASE_URL`` (deployed env), no port scan.
-        - ``local``: always discover the local frontend, even if a stray
-            ``BASE_URL`` is exported (``--target local`` never hits a
-            deployed env silently).
-        - empty: back-compat — infer ``dev`` if ``BASE_URL`` is set,
-            else ``local``.
+        ``--target dev|qa|local`` is deterministic: remote targets keep the
+        pre-set ``BASE_URL`` and never scan local ports; ``local`` always
+        discovers the local frontend even if a stray ``BASE_URL`` is exported.
+        Empty preserves back-compat: infer ``dev`` if ``BASE_URL`` is set, else ``local``.
 
         The resolved value is exported as ``T3_E2E_TARGET`` so a dual-mode
-        spec branches on ``process.env.T3_E2E_TARGET === 'dev'`` rather than
+        spec branches on ``process.env.T3_E2E_TARGET`` rather than
         re-deriving the target from a ``BASE_URL`` host regex.
 
         Discovers the frontend port from docker-compose (or local process)
@@ -439,7 +435,7 @@ class Command(TyperCommand):
     ) -> str:
         """Run E2E tests from the project's own test directory.
 
-        ``--target dev|local`` is exported as ``T3_E2E_TARGET`` for the in-repo
+        ``--target dev|qa|local`` is exported as ``T3_E2E_TARGET`` for the in-repo
         suite (same contract as the ``external`` runner); empty falls back to
         ``BASE_URL``-based inference.
 

--- a/tests/teatree_core/management_commands/test_e2e.py
+++ b/tests/teatree_core/management_commands/test_e2e.py
@@ -718,32 +718,38 @@ class TestE2eExternal(TestCase):
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_dev_target_does_not_export_compose_project_name(self) -> None:
-        """The dev target hits a deployed env — no local stack to point at.
+    def test_remote_targets_do_not_export_compose_project_name(self) -> None:
+        """DEV/QA targets hit deployed envs — no local stack to point at.
 
         ``COMPOSE_PROJECT_NAME`` must not leak into a dev run (no local
         docker stack exists; a stray value would mis-scope any incidental
         ``docker compose`` call the spec makes on dev).
         """
-        with tempfile.TemporaryDirectory() as tmp:
-            private_dir = Path(tmp) / "private"
-            private_dir.mkdir()
+        for target, base_url in [
+            ("dev", "https://dev.example.com"),
+            ("qa", "https://qa.example.com"),
+        ]:
+            with self.subTest(target=target), tempfile.TemporaryDirectory() as tmp:
+                private_dir = Path(tmp) / "private"
+                private_dir.mkdir()
 
-            mock_result = MagicMock(returncode=0)
-            with (
-                patch.dict(
-                    "os.environ",
-                    {"T3_PRIVATE_TESTS": str(private_dir), "BASE_URL": "https://dev.example.com"},
-                    clear=False,
-                ),
-                patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
-            ):
-                os.environ.pop("COMPOSE_PROJECT_NAME", None)
-                result = cast("str", call_command("e2e", "external", target="dev"))
+                mock_result = MagicMock(returncode=0)
+                with (
+                    patch.dict(
+                        "os.environ",
+                        {"T3_PRIVATE_TESTS": str(private_dir), "BASE_URL": base_url},
+                        clear=False,
+                    ),
+                    patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
+                ):
+                    os.environ.pop("COMPOSE_PROJECT_NAME", None)
+                    result = cast("str", call_command("e2e", "external", target=target))
 
-        assert "passed" in result
-        env = mock_run.call_args[1]["env"]
-        assert "COMPOSE_PROJECT_NAME" not in env
+                assert "passed" in result
+                env = mock_run.call_args[1]["env"]
+                assert env["BASE_URL"] == base_url
+                assert env["T3_E2E_TARGET"] == target
+                assert "COMPOSE_PROJECT_NAME" not in env
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -1288,7 +1294,14 @@ class TestE2EResolveTarget(TestCase):
 
     def test_explicit_values_are_normalized(self) -> None:
         cmd = e2e_mod.Command()
-        for raw, expected in [("dev", "dev"), ("local", "local"), ("DEV", "dev"), (" Local ", "local")]:
+        for raw, expected in [
+            ("dev", "dev"),
+            ("qa", "qa"),
+            ("local", "local"),
+            ("DEV", "dev"),
+            (" QA ", "qa"),
+            (" Local ", "local"),
+        ]:
             with self.subTest(raw=raw):
                 assert cmd._resolve_target(raw) == expected
 
@@ -1310,7 +1323,7 @@ class TestE2EResolveTarget(TestCase):
             patch.object(e2e_runners_mod, "_find_env_cache", return_value=None),
         ):
             get_overlay.return_value.get_e2e_env_extras.return_value = {}
-            env = e2e_mod._build_e2e_env("http://localhost:4200", headed=False, target="local")
-        assert env["T3_E2E_TARGET"] == "local"
-        assert env["BASE_URL"] == "http://localhost:4200"
+            env = e2e_mod._build_e2e_env("https://tenant-qa.example.com", headed=False, target="qa")
+        assert env["T3_E2E_TARGET"] == "qa"
+        assert env["BASE_URL"] == "https://tenant-qa.example.com"
         assert env["CI"] == "1"


### PR DESCRIPTION
## Summary
- accept `--target qa` alongside `dev` and `local`
- treat QA as a deployed remote target that preserves BASE_URL and avoids local compose routing
- add regression coverage for target normalization, env export, and no COMPOSE_PROJECT_NAME leakage

## Verification
- uv run pytest --no-cov tests/teatree_core/management_commands/test_e2e.py::TestE2EResolveTarget tests/teatree_core/management_commands/test_e2e.py::TestE2eExternal::test_remote_targets_do_not_export_compose_project_name -q
- uv run ruff check src/teatree/core/management/commands/e2e.py tests/teatree_core/management_commands/test_e2e.py
- uv run ty check src/teatree/core/management/commands/e2e.py tests/teatree_core/management_commands/test_e2e.py
- git diff --check
- commit hooks
