### PR TITLE
fix(eval): fail pass@k on unmetered sdk runs

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -4999,7 +4999,7 @@ Usage: t3 teatree e2e run [OPTIONS] [WORK_ITEM]
  absent, ``test_dir`` implies ``project`` and ``project_path`` implies
  ``external`` for compatibility.
 
- ``--target dev|local`` selects the dual-env target and is forwarded to
+ ``--target dev|qa|local`` selects the dual-env target and is forwarded to
  whichever runner handles the overlay (see ``external`` for semantics).
  ``--branch``/``--ref`` overrides the ``external`` runner's specs ref.
 
@@ -5065,17 +5065,14 @@ Usage: t3 teatree e2e external [OPTIONS]
  ``--branch``/``--ref`` overrides the ``--repo`` clone's specs ref (the
  ``.branch`` default) to run from an open MR's branch.
 
- ``--target dev|local`` selects the dual-env target deterministically:
-
- - ``dev``: keep the pre-set ``BASE_URL`` (deployed env), no port scan.
- - ``local``: always discover the local frontend, even if a stray
-     ``BASE_URL`` is exported (``--target local`` never hits a
-     deployed env silently).
- - empty: back-compat — infer ``dev`` if ``BASE_URL`` is set,
-     else ``local``.
+ ``--target dev|qa|local`` is deterministic: remote targets keep the
+ pre-set ``BASE_URL`` and never scan local ports; ``local`` always
+ discovers the local frontend even if a stray ``BASE_URL`` is exported.
+ Empty preserves back-compat: infer ``dev`` if ``BASE_URL`` is set, else
+ ``local``.
 
  The resolved value is exported as ``T3_E2E_TARGET`` so a dual-mode
- spec branches on ``process.env.T3_E2E_TARGET === 'dev'`` rather than
+ spec branches on ``process.env.T3_E2E_TARGET`` rather than
  re-deriving the target from a ``BASE_URL`` host regex.
 
  Discovers the frontend port from docker-compose (or local process)
@@ -5118,7 +5115,7 @@ Usage: t3 teatree e2e project [OPTIONS]
 
  Run E2E tests from the project's own test directory.
 
- ``--target dev|local`` is exported as ``T3_E2E_TARGET`` for the in-repo
+ ``--target dev|qa|local`` is exported as ``T3_E2E_TARGET`` for the in-repo
  suite (same contract as the ``external`` runner); empty falls back to
  ``BASE_URL``-based inference.
 

--- a/evals/scenarios/rules.yaml
+++ b/evals/scenarios/rules.yaml
@@ -465,7 +465,7 @@
               non-blank, non-comment lines; the 500-line cap applies to new files
               only; over-cap grandfathered files may only shrink vs HEAD baseline.
               The ratchet is enforced by scripts/hooks/check_module_health.py.
-    11:17:40  orchestrator: a long aside on the review-crew rule — maker is never
+    11:17:40  orchestrator: a long aside on the independent-review rule — maker is never
               checker; the reviewer sub-agent is always spawned in a fresh worktree
               with no memory of the maker's session; it reads only the diff and the
               test output; it cannot see the maker's internal monologue. This is
@@ -483,7 +483,7 @@
     10:56:45  orchestrator: a reminder on the maker-not-checker rule — the agent that
               makes a PR never reviews it; the reviewer is always a cold, independent
               sub-agent in its own worktree with no memory of the maker's session;
-              this invariant is enforced by the review crew configuration.
+              this invariant is enforced by the independent reviewer configuration.
     10:57:58  orchestrator: end of prior-session log. The user has a new request.
 
     [end prior session log]

--- a/src/teatree/cli/eval/multi_trial.py
+++ b/src/teatree/cli/eval/multi_trial.py
@@ -170,6 +170,11 @@ def run_pass_at_k_lane(  # noqa: PLR0913 — each kwarg threads one `eval run` C
     RunGuards.executed(
         executed=sum(1 for r in results if not r.skipped), collected=len(specs), required=require_executed
     )
+    RunGuards.sdk_metered_total(
+        backend=SDK_BACKEND,
+        executed=sum(1 for r in results if not r.skipped),
+        total_cost_usd=sum(r.cost_usd for r in results),
+    )
     regressed = False
     cost_regressed = False
     cost_bounds_failed = False

--- a/tests/teatree_cli/test_eval.py
+++ b/tests/teatree_cli/test_eval.py
@@ -517,6 +517,23 @@ class TestEvalPassAtK:
         assert result.exit_code == 0, result.output
         assert "PASS alpha (3/3 trials" in result.output
 
+    def test_trials_zero_cost_execution_fails_loud(self) -> None:
+        specs = [_spec("alpha")]
+
+        class _StubRunner:
+            def __init__(self, *_, **__) -> None: ...
+
+            def run(self, spec: EvalSpec) -> EvalRun:
+                return _run(spec.name, tool_calls=_PASSING_CALL, cost_usd=0.0)
+
+        with (
+            patch("teatree.cli.eval.app.discover_specs", return_value=specs),
+            patch("teatree.eval.backends.SdkInProcessRunner", _StubRunner),
+        ):
+            result = CliRunner().invoke(app, ["eval", "run", "--backend", "sdk", "--trials", "3", "--no-persist"])
+        assert result.exit_code == 1, result.output
+        assert "metered $0.00" in result.output
+
     def test_require_all_fails_when_a_trial_fails(self) -> None:
         specs = [_spec("alpha")]
         calls = {"n": 0}


### PR DESCRIPTION
## Summary

- fail pass@k eval lanes when SDK trials execute without metered usage
- keep infra/quota/auth SDK failures from being counted as behavioral eval reds
- remove the committed banned `review-crew` term from eval scenario text

## Verification

- RED proof before implementation: `TestEvalPassAtK::test_trials_zero_cost_execution_fails_loud` failed because zero-cost SDK trials exited 0 and reported PASS
- `uv run pytest tests/teatree_cli/test_eval.py::TestEvalPassAtK::test_trials_zero_cost_execution_fails_loud tests/teatree_cli/test_eval.py::TestEvalPassAtK::test_trials_aggregates_and_reports_pass_rate tests/teatree_cli/test_eval.py::TestTranscriptReplay::test_executed_but_unmetered_sdk_run_fails_loud -q`
- `uv run ruff check src/teatree/cli/eval/multi_trial.py tests/teatree_cli/test_eval.py`
- `uv run ruff format --check src/teatree/cli/eval/multi_trial.py tests/teatree_cli/test_eval.py`
- `uv run pytest tests/teatree_cli/test_eval.py tests/eval_replay/test_skip_guard.py -q`
- `uv run tach check`
- `TEATREE_BANNED_BRANDS='review-crew' uv run t3 banned-terms scan-tree --repo-root . --require-brands`
- `uv run pytest --no-cov -x -q` -> 19033 passed, 43 skipped, 5 xfailed, 90 subtests passed
