### PR TITLE
fix(e2e): install managed external repo dependencies

### DIFF
--- a/src/teatree/core/management/commands/_e2e_runners.py
+++ b/src/teatree/core/management/commands/_e2e_runners.py
@@ -104,6 +104,23 @@ def clone_or_update_e2e_repo(repo: E2ERepo, branch_override: str = "") -> Path:
     return cache_path / repo.e2e_dir
 
 
+def ensure_external_e2e_dependencies(playwright_root: Path) -> None:
+    """Install dependencies for a TeaTree-managed external Playwright checkout.
+
+    ``--repo`` clones live under TeaTree's cache, so the runner owns making them
+    executable. User-provided ``T3_PRIVATE_TESTS`` directories remain
+    user-managed and do not go through this helper.
+    """
+    package_json = playwright_root / "package.json"
+    if not package_json.is_file():
+        return
+    node_modules = playwright_root / "node_modules"
+    if node_modules.is_dir() and any(node_modules.iterdir()):
+        return
+    install_cmd = ["npm", "ci"] if (playwright_root / "package-lock.json").is_file() else ["npm", "install"]
+    run_checked(install_cmd, cwd=playwright_root)
+
+
 def resolve_private_tests_path() -> Path | None:
     """Resolve the private tests directory from env or config."""
     from teatree.config import load_config  # noqa: PLC0415
@@ -133,9 +150,11 @@ def resolve_external_specs_path(repo: str, branch: str) -> Path:
         if repo not in repos_by_name:
             raise E2eSpecsResolutionError.repo_not_in_config(repo)
         try:
-            return clone_or_update_e2e_repo(repos_by_name[repo], branch)
+            playwright_root = clone_or_update_e2e_repo(repos_by_name[repo], branch)
         except E2eBranchNotFoundError as exc:
             raise E2eSpecsResolutionError(str(exc), exit_code=1) from exc
+        ensure_external_e2e_dependencies(playwright_root)
+        return playwright_root
     if branch:
         raise E2eSpecsResolutionError.branch_needs_repo()
     private_tests_path = resolve_private_tests_path()

--- a/tests/teatree_core/management_commands/test_e2e.py
+++ b/tests/teatree_core/management_commands/test_e2e.py
@@ -1144,6 +1144,32 @@ class TestCloneOrUpdateE2eRepo(TestCase):
                 e2e_mod._clone_or_update_e2e_repo(repo, "no-such-branch")
             assert "no-such-branch" in str(exc_info.value)
 
+    def test_ensure_external_e2e_dependencies_runs_npm_ci_for_locked_project(self) -> None:
+        """Managed external clones install their Playwright project deps before running."""
+        with tempfile.TemporaryDirectory() as tmp:
+            playwright_root = Path(tmp) / "clone" / "e2e"
+            playwright_root.mkdir(parents=True)
+            (playwright_root / "package.json").write_text('{"scripts":{}}\n')
+            (playwright_root / "package-lock.json").write_text("{}\n")
+
+            with patch.object(e2e_runners_mod, "run_checked") as mock_run:
+                e2e_runners_mod.ensure_external_e2e_dependencies(playwright_root)
+
+            mock_run.assert_called_once_with(["npm", "ci"], cwd=playwright_root)
+
+    def test_ensure_external_e2e_dependencies_skips_populated_node_modules(self) -> None:
+        """A populated dependency directory is reused instead of reinstalling on every run."""
+        with tempfile.TemporaryDirectory() as tmp:
+            playwright_root = Path(tmp) / "clone" / "e2e"
+            package_dir = playwright_root / "node_modules" / "@playwright"
+            package_dir.mkdir(parents=True)
+            (playwright_root / "package.json").write_text('{"scripts":{}}\n')
+
+            with patch.object(e2e_runners_mod, "run_checked") as mock_run:
+                e2e_runners_mod.ensure_external_e2e_dependencies(playwright_root)
+
+            mock_run.assert_not_called()
+
 
 # ── e2e external --repo ───────────────────────────────────────────────
 
@@ -1190,14 +1216,45 @@ class TestE2eExternalRepo(TestCase):
                 patch.dict("os.environ", {"T3_ORIG_CWD": str(wt_dir)}),
                 patch.object(e2e_runners_mod, "load_e2e_repos", return_value=[repo]),
                 patch.object(e2e_runners_mod, "clone_or_update_e2e_repo", return_value=playwright_root),
+                patch.object(e2e_runners_mod, "ensure_external_e2e_dependencies") as mock_install,
                 patch.object(e2e_disc_mod, "get_service_port", return_value=4200),
                 patch.object(utils_run_mod, "Popen", _popen_for(mock_result)) as mock_run,
             ):
                 result = cast("str", call_command("e2e", "external", repo="demo-svc"))
 
         assert "passed" in result
+        mock_install.assert_called_once_with(playwright_root)
         run_cwd = mock_run.call_args[1]["cwd"]
         assert str(run_cwd) == str(playwright_root)
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_private_tests_path_does_not_auto_install_dependencies(self) -> None:
+        """User-managed ``T3_PRIVATE_TESTS`` checkouts remain outside TeaTree's install policy."""
+        with tempfile.TemporaryDirectory() as tmp:
+            private_dir = Path(tmp) / "private"
+            private_dir.mkdir()
+            wt_dir = Path(tmp) / "worktree"
+            wt_dir.mkdir()
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/private-e2e")
+            Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="backend",
+                branch="feature",
+                extra={"worktree_path": str(wt_dir)},
+                state=Worktree.State.SERVICES_UP,
+            )
+
+            with (
+                patch.dict("os.environ", {"T3_ORIG_CWD": str(wt_dir), "T3_PRIVATE_TESTS": str(private_dir)}),
+                patch.object(e2e_runners_mod, "ensure_external_e2e_dependencies") as mock_install,
+                patch.object(e2e_disc_mod, "get_service_port", return_value=4200),
+                patch.object(utils_run_mod, "Popen", _popen_for(MagicMock(returncode=0))),
+            ):
+                call_command("e2e", "external")
+
+        mock_install.assert_not_called()
 
     def _run_external_capturing_ref(self, captured: dict[str, str], **call_kwargs: object) -> None:
         """Drive ``e2e external --repo`` with a stubbed clone that records the ref override."""


### PR DESCRIPTION
## Summary
- install dependencies for TeaTree-managed external E2E repo clones before running Playwright
- keep user-managed T3_PRIVATE_TESTS directories outside the install policy
- add regression coverage for locked projects, populated node_modules, and private-test non-install behavior

## Validation
- uv run pytest tests/teatree_core/management_commands/test_e2e.py -q --no-cov
- uv run ruff check src/teatree/core/management/commands/_e2e_runners.py tests/teatree_core/management_commands/test_e2e.py
- manually validated a managed external repo with Playwright --list using a private overlay configuration