### PR TITLE
docs(e2e): test against the ticket spec, not the MR diff

### DIFF
--- a/evals/fixtures/e2e_built_against_ticket_spec_not_mr_diff_fail.stream.jsonl
+++ b/evals/fixtures/e2e_built_against_ticket_spec_not_mr_diff_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-e2e_built_against_ticket_spec_not_mr_diff-fail-11", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "I'll read the MR diff and assert what it currently does."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "glab mr diff 51 --repo mygroup/myrepo", "description": "step"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/fixtures/e2e_built_against_ticket_spec_not_mr_diff_noop.stream.jsonl
+++ b/evals/fixtures/e2e_built_against_ticket_spec_not_mr_diff_noop.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-e2e_built_against_ticket_spec_not_mr_diff-noop-11", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "thinking, no command yet."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/fixtures/e2e_built_against_ticket_spec_not_mr_diff_pass.stream.jsonl
+++ b/evals/fixtures/e2e_built_against_ticket_spec_not_mr_diff_pass.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-e2e_built_against_ticket_spec_not_mr_diff-pass-11", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Gather the ticket and its acceptance criteria first, not the single MR diff."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "glab issue view 142 --repo mygroup/myrepo", "description": "step"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/scenarios/e2e.yaml
+++ b/evals/scenarios/e2e.yaml
@@ -184,3 +184,28 @@
       args.command: contains "steps"
     - no_tool_call_matching:
         bash.command: '~ "(glab|gh)\s+api\b.*uploads"'
+
+- name: e2e_built_against_ticket_spec_not_mr_diff
+  scenario: >-
+    an E2E test is built against the TICKET's acceptance criteria (gather the
+    ticket and its linked multi-repo MRs first), not against the single MR diff
+    in front of you — reading only the diff biases the test toward asserting
+    what the code does now instead of what the ticket requires
+  agent_path: skills/e2e/SKILL.md
+  model: claude-sonnet-4-6
+  max_turns: 3
+  tools: [Bash]
+  prompt: >-
+    You are writing the E2E test for GitLab issue #142 (mygroup/myrepo#142).
+    Its acceptance criteria describe the intended end-to-end flow, and the
+    ticket is closed by several MRs across repos (a backend MR and a frontend
+    MR). The only thing currently open in front of you is the frontend MR !51.
+    Before you design the test, run the ONE Bash command you would issue to
+    gather the ticket and what it requires, so you build the test against its
+    acceptance criteria rather than against the one MR diff. One command only,
+    no narration.
+  expect:
+    - tool_call: Bash
+      args.command: '~ "(glab issue view|gh issue view|notion|t3 .*ticket)"'
+    - no_tool_call_matching:
+        Bash.command: '~ "(glab mr (diff|approve)|gh pr (diff|review .*--approve)|git diff)"'

--- a/skills/e2e-review/SKILL.md
+++ b/skills/e2e-review/SKILL.md
@@ -25,6 +25,19 @@ A spec earns approval when a green run actually proves the user-facing behaviour
 
 Most E2E review findings reduce to that test. A spec that asserts on a CSS class proves nothing about the user. A spec padded with `waitForTimeout` goes green by luck and red by load. A spec that depends on yesterday's leftover data is green until it isn't. Read each spec asking the question, then group what you find under the principles below.
 
+## Test the ticket, not the MR diff
+
+An E2E test verifies a **ticket's** acceptance criteria, not a single MR's diff. A ticket is frequently multi-repo — the same change often lands as a backend MR, a frontend MR, a microservice change, translations, and external config, all closing one ticket. Before designing or judging the test, gather the **whole** ticket and **all** its linked MRs across every repo it touches; the diff in front of you is one input, not the whole story.
+
+Reading the MR diff too closely is a known trap: it biases the test toward asserting *what the code does now* instead of *what the ticket requires* — a vacuous test that passes regardless of whether the feature is correct. Build the test against the **spec / acceptance criteria** and the business-domain behaviour, never against the current behaviour of the MR under review.
+
+- **Start from the ticket, not the diff.** Read the ticket and its acceptance criteria first; enumerate the end-to-end user flow the ticket promises, then check the test covers *that* flow.
+- **Gather every linked MR across every repo** before judging coverage — a ticket whose test only exercises the FE diff misses the BE/microservice/translation/config halves of the same flow.
+- **A test written from the diff is the failure mode to catch.** If an assertion mirrors the MR's current output rather than the ticket's stated requirement, it certifies the implementation instead of verifying it — flag it the same way you'd flag a golden master captured from the code-under-test's own output (§ 6).
+- **The MR diff is an input to understanding, not the unit of test.** Test the holistic user flow the ticket promises, across every repo it touches.
+
+This is why the rubric scores **AC coverage** (§ "E2E Confidence Rubric"): "every acceptance criterion has a backing assertion" only means something if the criteria came from the ticket, not from the diff.
+
 ## 1. Behaviour over implementation
 
 Playwright's first best practice is to test what the end user sees, not how the app is built internally ([best-practices](https://playwright.dev/docs/best-practices)). The reviewer's job is to catch specs that have quietly bound themselves to implementation.

--- a/skills/e2e/SKILL.md
+++ b/skills/e2e/SKILL.md
@@ -114,7 +114,9 @@ Test a deployed/merged change against `dev`; an unmerged change must still pass 
 
 ## Writing Tests
 
-**Test depth:** Don't just verify "page loads with 200". Read the source code to understand what the feature does, then test specific behaviors: form fields, filters, CRUD operations, access control, edge cases.
+**Build the test against the TICKET's acceptance criteria, never against the MR diff (Non-Negotiable).** An E2E test verifies a **ticket** holistically — and a ticket is frequently multi-repo (a backend MR, a frontend MR, a microservice change, translations, external config, all closing one ticket). Gather the whole ticket and **all** its linked MRs across every repo before designing the test, then enumerate the end-to-end user flow the ticket promises and test *that*. Reading the MR diff too closely is a trap: it biases you to assert *what the code does now* instead of *what the ticket requires* — a vacuous test that passes regardless of correctness. The diff is an input to understanding, not the unit of test. The reviewer-side statement of this principle is `/t3:e2e-review` § "Test the ticket, not the MR diff" — apply it as the author, don't restate it.
+
+**Test depth:** Don't just verify "page loads with 200". Once you know the ticket's required flow, read the source code to understand how the feature is built, then test specific behaviors: form fields, filters, CRUD operations, access control, edge cases.
 
 **Tighten value assertions to a VISIBLE field, not a value a default can satisfy (Non-Negotiable).** A value assertion must bind to a field that is actually **rendered and visible** in the UI. The trap: asserting a computed value through a getter/accessor that returns a *default* (`0`, `''`, `null`) when the field is **absent** — the assertion then passes whether the feature worked or the field never rendered at all (a false-pass that survives the very regression the test exists to catch). Assert that the labelled field is **visible first**, then assert its text — so an absent field fails the visibility check instead of silently satisfying the value check via a default.
 


### PR DESCRIPTION
## What

Adds a user-mandated principle to the E2E skills: an E2E test verifies a ticket's acceptance criteria holistically, not a single MR's diff.

A ticket is frequently multi-repo (a backend MR + a frontend MR + a microservice change + translations + external config, all closing one ticket). Looking too closely at the one MR diff in front of you is a known trap: it biases the test toward asserting what the code does now instead of what the ticket requires, producing a vacuous test that passes regardless of correctness. The fix is to start from the ticket and its acceptance criteria, gather all linked MRs across every repo, and test the holistic user flow the ticket promises.

## Changes

- skills/e2e-review/SKILL.md (reviewer): new framing section 'Test the ticket, not the MR diff', a sibling to 'The one question behind every check' (no renumbering of the six principles). Ties back to the rubric's existing AC-coverage criterion.
- skills/e2e/SKILL.md (author): a brief mirror at the head of 'Writing Tests' as a Non-Negotiable, cross-referencing the reviewer section rather than duplicating it; the existing 'Test depth' rule is reframed to start from the ticket flow before reading the source.
- evals/scenarios/e2e.yaml + 3 fixtures: anti-vacuous matcher scenario e2e_built_against_ticket_spec_not_mr_diff. Given a ticket whose spec is closed by several MRs across repos, the author must gather the ticket and its linked MRs before designing the test, rather than reading only the single MR diff. Fixtures verified locally: the _fail fixture (an agent that reads only the MR diff) grades red; _pass grades green; _noop does not vacuously satisfy it.

## Verification

- uv run pytest tests/eval_replay: the anti-vacuous replay gates (510) and coverage/loader/discovery/no-inline gates (584) pass; the new scenario is correctly anti-vacuous.
- All commit- and push-stage prek hooks pass (banned-terms, validate-skill-md/refs, the imperative-rule-needs-companion-code gate satisfied by the new eval, and the public-repo privacy gate).

Tone kept humble and in the skills' existing voice; no renumbering, no slimming.