### PR TITLE
fix(core): scope local-stack cap by ticket overlay (#1397)

### DIFF
--- a/src/teatree/core/gates/local_stack_gate.py
+++ b/src/teatree/core/gates/local_stack_gate.py
@@ -157,13 +157,19 @@ def check_local_stack_limit(candidate: Worktree, *, limit: int | None = None) ->
     if effective_limit <= 0:
         return
 
-    candidate_ticket_pk = candidate.ticket.pk
+    # Scope blockers by the TICKET's overlay, not ``Worktree.overlay``. A row
+    # auto-detected via cwd (``resolve_worktree``) can carry ``Worktree.overlay=''``
+    # while its ticket carries the real overlay; counting by the ticket overlay
+    # holds the cap even for such rows so an empty ``Worktree.overlay`` cannot
+    # smuggle a second stack past the limit (#1397 defense-in-depth).
+    candidate_ticket = candidate.ticket
+    overlay = candidate_ticket.overlay or candidate.overlay
     counted_blockers = list(
         Worktree.objects.filter(
-            overlay=candidate.overlay,
+            ticket__overlay=overlay,
             state__in=_BLOCKING_STATES,
         )
-        .exclude(ticket__pk=candidate_ticket_pk)
+        .exclude(ticket__pk=candidate_ticket.pk)
         .order_by("ticket__pk", "pk"),
     )
     blockers = [b for b in counted_blockers if not _reconcile_phantom_blocker(b)]
@@ -175,10 +181,10 @@ def check_local_stack_limit(candidate: Worktree, *, limit: int | None = None) ->
     blocker_list = "\n  - ".join(labels)
     msg = (
         f"max_concurrent_local_stacks={effective_limit} for overlay "
-        f"{candidate.overlay!r} would be exceeded by starting "
+        f"{overlay!r} would be exceeded by starting "
         f"{_blocker_label(candidate)}.\n"
         f"Currently running:\n  - {blocker_list}\n"
-        f"Run `t3 {candidate.overlay or '<overlay>'} worktree teardown <path>` "
+        f"Run `t3 {overlay or '<overlay>'} worktree teardown <path>` "
         "on one of the above before starting a new stack."
     )
     raise LocalStackLimitExceededError(msg)

--- a/src/teatree/core/migrations/0088_backfill_worktree_overlay_from_ticket.py
+++ b/src/teatree/core/migrations/0088_backfill_worktree_overlay_from_ticket.py
@@ -1,0 +1,37 @@
+"""Backfill ``Worktree.overlay`` from the ticket where it was left empty (#1397).
+
+The cwd auto-detect path (``resolve_worktree`` → ``get_or_create``) materialised
+worktree rows with ``overlay=''`` because its ``defaults`` never set ``overlay``,
+even though the row's ticket carried the real overlay. A blank ``Worktree.overlay``
+made the per-overlay ``max_concurrent_local_stacks`` gate miss those rows when it
+scoped its blocker query by ``Worktree.overlay`` — letting a second stack breach
+the cap. The source fix sets ``overlay`` on new rows; this backfills the existing
+rows so the data is correct everywhere.
+
+Forward: copy ``ticket.overlay`` onto every worktree whose ``overlay`` is empty
+and whose ticket has a non-empty overlay. Irreversible (a no-op reverse) — the
+pre-fix blank state carried no information to restore to.
+"""
+
+from django.db import migrations
+
+
+def _backfill_overlay(apps, schema_editor) -> None:
+    worktree_model = apps.get_model("core", "Worktree")
+    to_fix = list(
+        worktree_model.objects.filter(overlay="").exclude(ticket__overlay="").select_related("ticket"),
+    )
+    for worktree in to_fix:
+        worktree.overlay = worktree.ticket.overlay
+    if to_fix:
+        worktree_model.objects.bulk_update(to_fix, ["overlay"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0087_pause_all_loops"),
+    ]
+
+    operations = [
+        migrations.RunPython(_backfill_overlay, migrations.RunPython.noop),
+    ]

--- a/src/teatree/core/migrations/max_migration.txt
+++ b/src/teatree/core/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0087_pause_all_loops
+0088_backfill_worktree_overlay_from_ticket

--- a/src/teatree/core/resolve.py
+++ b/src/teatree/core/resolve.py
@@ -199,6 +199,7 @@ def _auto_register_from_git(cwd: str, ticket_hint: Ticket | None = None) -> Work
         ticket=ticket,
         repo_path=repo_name,
         defaults={
+            "overlay": ticket.overlay,
             "branch": branch,
             "extra": {"worktree_path": str(cwd_path)},
         },

--- a/tests/teatree_core/test_resolve.py
+++ b/tests/teatree_core/test_resolve.py
@@ -513,6 +513,27 @@ class TestAutoRegisterReusesExistingWorktree(TestCase):
         assert result.extra["worktree_path"] == str(wt_dir)
         assert result.ticket.issue_url == "auto:feat/new"
 
+    def test_new_worktree_inherits_ticket_overlay(self) -> None:
+        """A newly auto-registered worktree gets ``overlay`` from its ticket (#1397).
+
+        Bug: ``get_or_create`` did not set ``overlay`` in its defaults, so a
+        cwd-auto-detected worktree was created with ``Worktree.overlay=''`` even
+        when its ticket carried the real overlay — which let the per-overlay
+        ``max_concurrent_local_stacks`` gate miss the row and breach the cap.
+        """
+        ticket = Ticket.objects.create(
+            issue_url="https://example.com/t3-heavy/issues/777",
+            overlay="t3-heavy",
+        )
+        wt_dir = self._make_git_worktree("my-repo")
+
+        with patch("teatree.core.resolve.git.current_branch", return_value="feat/branch"):
+            result = _auto_register_from_git(str(wt_dir), ticket_hint=ticket)
+
+        assert result is not None
+        assert result.ticket_id == ticket.pk
+        assert result.overlay == "t3-heavy"
+
     def test_does_not_match_worktree_for_different_repo(self) -> None:
         """A Worktree for the same branch but a different repo must not be reused."""
         ticket = Ticket.objects.create(issue_url="https://gitlab.com/org/repo/-/issues/123")

--- a/tests/test_max_concurrent_local_stacks.py
+++ b/tests/test_max_concurrent_local_stacks.py
@@ -226,6 +226,50 @@ class TestLocalStackGateCrossOverlay(TestCase):
         del heavy_blocker
 
 
+class TestLocalStackGateEmptyWorktreeOverlayStillBlocks(TestCase):
+    """A live blocker whose ``Worktree.overlay`` is empty must still be counted by ticket overlay.
+
+    The cwd auto-detect path (``resolve_worktree`` → ``get_or_create``) used to
+    materialise worktree rows with ``overlay=''`` even though their ticket
+    carried the real overlay. Scoping the gate's blocker query by
+    ``Worktree.overlay`` then missed those rows, so a fresh start saw zero
+    blockers and breached the cap. The gate must scope by the TICKET's overlay
+    so an empty ``Worktree.overlay`` cannot smuggle a second stack past the cap.
+    """
+
+    def test_blocker_with_empty_overlay_but_matching_ticket_overlay_blocks(self) -> None:
+        blocker_ticket = Ticket.objects.create(
+            issue_url="https://example.com/t3-heavy/issues/9001",
+            overlay="t3-heavy",
+        )
+        # The bug: a live stack auto-detected via cwd → Worktree.overlay='' even
+        # though ticket.overlay carried the real overlay (this models the live
+        # running stack whose Worktree.overlay was left blank).
+        blocker = Worktree.objects.create(
+            overlay="",
+            ticket=blocker_ticket,
+            repo_path="backend",
+            branch="9001-feat",
+            state=Worktree.State.SERVICES_UP,
+            extra={"worktree_path": "/ws/9001-feat/backend"},
+        )
+        candidate_ticket = Ticket.objects.create(
+            issue_url="https://example.com/t3-heavy/issues/9002",
+            overlay="t3-heavy",
+        )
+        candidate = Worktree.objects.create(
+            overlay="t3-heavy",
+            ticket=candidate_ticket,
+            repo_path="backend",
+            branch="9002-feat",
+            state=Worktree.State.PROVISIONED,
+        )
+        with pytest.raises(LocalStackLimitExceededError) as exc:
+            check_local_stack_limit(candidate, limit=1)
+        assert "/ws/9001-feat/backend" in str(exc.value)
+        del blocker
+
+
 class TestLocalStackGateMultiRepoTicket(TestCase):
     """A multi-repo ticket is one logical stack, not N (one per repo)."""
 

--- a/tests/test_migration_0088_backfill_worktree_overlay.py
+++ b/tests/test_migration_0088_backfill_worktree_overlay.py
@@ -1,0 +1,91 @@
+"""Regression tests for ``core.0088_backfill_worktree_overlay_from_ticket``.
+
+souliane/teatree#1397: worktree rows auto-detected via cwd were created with
+``overlay=''`` while their ticket carried the real overlay, so the per-overlay
+``max_concurrent_local_stacks`` gate missed them. 0088 backfills
+``Worktree.overlay`` from ``ticket.overlay`` for every row left blank.
+
+These tests pin the backfill behaviour: a blank-overlay worktree whose ticket
+has an overlay is filled; a worktree whose ticket has no overlay is left blank;
+a worktree that already carries an overlay is untouched.
+"""
+
+import importlib
+
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase
+
+# The migration module starts with a digit so it cannot be imported via the
+# normal ``from ... import`` syntax; use ``importlib`` directly.
+_migration_module = importlib.import_module(
+    "teatree.core.migrations.0088_backfill_worktree_overlay_from_ticket",
+)
+
+
+class BackfillWorktreeOverlayMigrationTest(TransactionTestCase):
+    """0088 must copy ``ticket.overlay`` onto blank ``Worktree.overlay`` rows."""
+
+    _BEFORE = ("core", "0087_pause_all_loops")
+    _AFTER = ("core", "0088_backfill_worktree_overlay_from_ticket")
+
+    def _migrate(self, target: tuple[str, str]) -> "object":
+        executor = MigrationExecutor(connection)
+        executor.migrate([target])
+        executor.loader.build_graph()
+        return executor.loader.project_state([target]).apps
+
+    def _restore_head(self) -> None:
+        """Re-apply every core migration so TransactionTestCase teardown flushes the real schema."""
+        executor = MigrationExecutor(connection)
+        executor.loader.build_graph()
+        core_leaves = [node for node in executor.loader.graph.leaf_nodes() if node[0] == "core"]
+        executor.migrate(core_leaves)
+
+    def _make_worktree(self, apps: "object", *, overlay: str, ticket_overlay: str, branch: str) -> "object":
+        ticket_model = apps.get_model("core", "Ticket")
+        worktree_model = apps.get_model("core", "Worktree")
+        ticket = ticket_model.objects.create(
+            issue_url=f"https://example.com/{ticket_overlay or 'x'}/issues/{branch}",
+            overlay=ticket_overlay,
+        )
+        return worktree_model.objects.create(
+            overlay=overlay,
+            ticket=ticket,
+            repo_path="backend",
+            branch=branch,
+            state="services_up",
+        )
+
+    def test_blank_overlay_is_backfilled_from_ticket(self) -> None:
+        apps = self._migrate(self._BEFORE)
+        worktree = self._make_worktree(apps, overlay="", ticket_overlay="t3-heavy", branch="1-feat")
+
+        _migration_module._backfill_overlay(apps, connection.schema_editor())
+
+        worktree.refresh_from_db()
+        assert worktree.overlay == "t3-heavy"
+
+        self._restore_head()
+
+    def test_blank_overlay_with_blank_ticket_overlay_stays_blank(self) -> None:
+        apps = self._migrate(self._BEFORE)
+        worktree = self._make_worktree(apps, overlay="", ticket_overlay="", branch="2-feat")
+
+        _migration_module._backfill_overlay(apps, connection.schema_editor())
+
+        worktree.refresh_from_db()
+        assert worktree.overlay == ""
+
+        self._restore_head()
+
+    def test_existing_overlay_is_left_untouched(self) -> None:
+        apps = self._migrate(self._BEFORE)
+        worktree = self._make_worktree(apps, overlay="t3-teatree", ticket_overlay="t3-heavy", branch="3-feat")
+
+        _migration_module._backfill_overlay(apps, connection.schema_editor())
+
+        worktree.refresh_from_db()
+        assert worktree.overlay == "t3-teatree"
+
+        self._restore_head()


### PR DESCRIPTION
## Summary

The per-overlay `max_concurrent_local_stacks` cap (which exists to stop a memory-constrained host OOMing when two docker stacks run at once) could be **breached**. Audit found the live running stack and ~56 of 111 worktree rows carrying `overlay=''`.

Root cause: the gate `check_local_stack_limit` scoped its blocker query by `Worktree.overlay`, but the cwd auto-detect path (`resolve_worktree` → `get_or_create`) materialised worktree rows with `overlay=''` because its `defaults` never set `overlay`. A live stack auto-detected this way carried `Worktree.overlay=''` while its ticket carried the real overlay. A fresh `worktree start` then filtered `overlay='<real>'`, saw zero blockers, was allowed, and started a second stack past the cap. The provision runner set `overlay` correctly; only the auto-detect path (exactly what a sub-agent hits when it `cd`s into a `git worktree` and runs `worktree start`) was broken.

## Changes

- **Source (`src/teatree/core/resolve.py`):** `get_or_create` defaults now set `overlay=ticket.overlay`, so auto-detected worktrees carry the correct overlay. One-line, minimal diff.
- **Defense-in-depth (`src/teatree/core/gates/local_stack_gate.py`):** the gate scopes the blocker count by the ticket's overlay (`ticket__overlay`) rather than `Worktree.overlay`, so the cap holds even when a row's `Worktree.overlay` is empty.
- **Backfill (`migration 0084`):** copies `ticket.overlay` onto every worktree row left with `overlay=''` where the ticket has an overlay.

## Tests (RED before, GREEN after)

- `tests/test_max_concurrent_local_stacks.py::TestLocalStackGateEmptyWorktreeOverlayStillBlocks` — guards the gate fix: a live blocker with empty `Worktree.overlay` but matching ticket overlay must refuse the start. Observed failing on the pre-fix gate (did not raise), passing after.
- `tests/teatree_core/test_resolve.py::...::test_new_worktree_inherits_ticket_overlay` — guards the source fix: a newly auto-registered worktree inherits its ticket's overlay. Observed failing on the pre-fix resolve (empty overlay), passing after.
- `tests/test_migration_0084_backfill_worktree_overlay.py` — three cases: blank backfilled from ticket, blank-ticket-overlay stays blank, existing overlay untouched.

## Architecture pre-check — local-stack overlay cap breach

### 1. BLUEPRINT § alignment
Touches the `max_concurrent_local_stacks` gate behaviour (workspace lifecycle / local-stack governance). No contract or section change — the cap semantics are preserved; the fix makes the gate honour them when a row's overlay is blank.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition added or moved. The gate is a pre-`start_services` check, unchanged in placement.

### 3. Extension-point contracts
n/a — no `OverlayBase` hook, scanner registration, or Protocol surface changed.

### 4. Component boundaries
`resolve.py` (worktree resolution) and `core/gates/local_stack_gate.py` (the gate) — both already own this behaviour. The backfill is a standard `core/migrations/` data migration. No straddling.

### 5. Dependency direction
No new cross-module import. The gate query gains `ticket__overlay` (a relation already in scope); resolve.py adds a dict key. `uv run tach check` → all modules validated.

### 6. Test surface
Gate fix: assert the gate raises `LocalStackLimitExceededError` for an empty-`Worktree.overlay` live blocker whose ticket overlay matches. Source fix: assert `result.overlay == ticket.overlay` on auto-register. Migration: assert backfill copies/skips/preserves correctly.

### 7. Resilience invariants
No external write. The backfill migration is idempotent (filters `overlay=''`; re-run is a no-op) and reverse is a documented no-op (the pre-fix blank carried no information to restore).

### 8. Identity and key normalization
The overlay identity now resolves UP to the ticket's overlay as the canonical source at both the write boundary (resolve.py defaults) and the read boundary (gate scoping), instead of trusting a possibly-blank `Worktree.overlay`. No strip/split-to-match.

### 9. Behavior preservation / capability deletion
Purely additive / corrective. The gate still refuses the same cases it did before plus the previously-missed empty-overlay case; cross-overlay isolation (`TestLocalStackGateCrossOverlay`) and all existing gate tests stay green. No must-block test inverted.

Closes #1397 follow-up (cap-breach via empty `Worktree.overlay`).
