### PR TITLE
fix(hooks): make Stop self-pump pause levers stdlib-only (#2559)

### DIFF
--- a/docs/generated/management-commands.json
+++ b/docs/generated/management-commands.json
@@ -663,7 +663,7 @@
           "name": "create"
         },
         {
-          "help": "",
+          "help": "Cancel a pending or (with --confirm) claimed task, driving it to FAILED",
           "name": "cancel"
         },
         {

--- a/docs/generated/management-commands.md
+++ b/docs/generated/management-commands.md
@@ -351,7 +351,7 @@ Read ``text`` aloud synchronously through the local speakers per [teatree.speak]
 | Subcommand | Description |
 | --- | --- |
 | `create` | Enqueue the next-phase task for a ticket |
-| `cancel` |  |
+| `cancel` | Cancel a pending or (with --confirm) claimed task, driving it to FAILED |
 | `complete` | Mark a claimed or failed task COMPLETED for work finished out-of-band |
 | `claim` |  |
 | `start` | Claim an interactive task and exec ``claude`` in the current terminal |

--- a/hooks/scripts/availability_away_probe.py
+++ b/hooks/scripts/availability_away_probe.py
@@ -1,0 +1,101 @@
+"""Stdlib-only away-mode read for the bare-``python3`` Stop/PreToolUse hooks (#2559).
+
+The harness invokes the hooks as a bare ``python3`` with NO ``uv`` env, so
+teatree's dependencies are not importable and ``django.setup()`` cannot run in
+the hook interpreter. ``_resolved_away_mode`` previously bootstrapped Django
+in-process to call ``resolve_mode()``; under the real hook that bootstrap failed
+and the lever returned ``False`` (never away) — silently neutering
+``t3 <overlay> availability away`` as a self-pump suppressor.
+
+This module reads the resolved availability mode WITHOUT ``django.setup()`` by
+subprocessing the ``t3`` CLI (the editable install carries its own venv, so it
+bootstraps Django in a CHILD process), parsing the ``mode=…`` token from the
+``availability show`` line — exactly the stdlib subprocess shape
+``hook_router._consolidated_pending_work`` and the sibling
+``loop_state_self_pump_gate`` already use.
+
+It lives in a bare sibling module (not ``hook_router``) so the over-cap,
+shrink-only router gains the stdlib behaviour without growing (``hooks/CLAUDE.md``
+§ "Adding a gate").
+"""
+
+import os
+import shutil
+import subprocess  # noqa: S404 — reads a trusted local ``t3`` binary, fixed argv, never shell
+
+_AWAY_READ_TIMEOUT = 5
+
+# The always-registered overlay's CLI alias — the fall-through token for the
+# overlay-agnostic hooks. ``t3-teatree`` ships in core's pyproject, so
+# ``t3 teatree …`` always resolves; ``resolve_mode()`` is overlay-independent, so
+# ANY registered overlay's ``availability show`` returns the same mode.
+_DEFAULT_OVERLAY_ALIAS = "teatree"
+
+
+def resolved_away_mode() -> bool:
+    """True when the resolved availability mode is ``away`` (stdlib read).
+
+    Shells out to ``t3 <overlay> availability show`` and parses its
+    ``mode=…`` token. The overlay token is ``T3_OVERLAY_NAME`` when set, falling
+    back to the always-registered ``teatree`` alias; the choice never changes the
+    answer because ``resolve_mode()`` is overlay-agnostic.
+
+    FAIL SAFE for the caller: an absent ``t3``, a failed subprocess, or
+    unparsable output resolves to ``False`` here. The self-pump's
+    ``_pause_suppresses_self_pump`` then applies its own
+    suppress-on-indeterminate rule on top (a clean ``present`` pumps; a raised
+    read suppresses).
+    """
+    t3_bin = shutil.which("t3")
+    if not t3_bin:
+        return False
+    for overlay in _overlay_candidates():
+        out = _availability_show(t3_bin, overlay)
+        if out is not None:
+            return _line_reports_away(out)
+    return False
+
+
+def _overlay_candidates() -> list[str]:
+    """Overlay CLI tokens to try for ``availability show``, in order.
+
+    ``T3_OVERLAY_NAME`` first (when set), then the always-registered ``teatree``
+    alias as the never-empty fall-through — de-duplicated, order preserved.
+    """
+    candidates: list[str] = []
+    env_overlay = os.environ.get("T3_OVERLAY_NAME", "").strip()
+    if env_overlay:
+        candidates.append(env_overlay)
+    if _DEFAULT_OVERLAY_ALIAS not in candidates:
+        candidates.append(_DEFAULT_OVERLAY_ALIAS)
+    return candidates
+
+
+def _availability_show(t3_bin: str, overlay: str) -> str | None:
+    """Stdout of ``t3 <overlay> availability show``; ``None`` on any failure."""
+    try:
+        result = subprocess.run(  # noqa: S603 — trusted local binary, fixed argv, no shell
+            [t3_bin, overlay, "availability", "show"],
+            capture_output=True,
+            text=True,
+            timeout=_AWAY_READ_TIMEOUT,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    return result.stdout
+
+
+def _line_reports_away(text: str) -> bool:
+    """True when an ``availability: mode=… source=…`` line resolves to ``away``."""
+    for raw in text.splitlines():
+        for token in raw.split():
+            key, sep, value = token.partition("=")
+            if sep and key.strip() == "mode":
+                return value.strip().lower() == "away"
+    return False
+
+
+__all__ = ["resolved_away_mode"]

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
 if str(Path(__file__).resolve().parent) not in sys.path:
     sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from availability_away_probe import resolved_away_mode as resolved_away_mode_stdlib
 from banned_terms_marker import resolve_marker as _resolve_banned_terms_marker
 from django_bootstrap import bootstrap_teatree_django
 from loop_state_self_pump_gate import db_loop_state_suppresses_self_pump
@@ -7384,17 +7385,17 @@ def _capture_and_defer_question(data: dict, *, mode: str) -> int | None:
 
 
 def _resolved_away_mode() -> bool:
-    """Resolve the effective availability mode; True when ``away``."""
-    if not bootstrap_teatree_django():
-        return False
-    try:
-        from teatree.core.availability import MODE_AWAY, resolve_mode  # noqa: PLC0415
-    except Exception:  # noqa: BLE001
-        return False
-    try:
-        return resolve_mode().mode == MODE_AWAY
-    except Exception:  # noqa: BLE001
-        return False
+    """Resolve the effective availability mode; True when ``away`` (#2559).
+
+    Delegates to the stdlib sibling :func:`availability_away_probe.resolved_away_mode`,
+    which reads the resolved mode by subprocessing ``t3 <overlay> availability
+    show`` instead of an in-process ``django.setup()`` — the bare-``python3``
+    hook has no ``uv`` env, so the old bootstrap returned ``False`` (never away)
+    and silently neutered ``t3 <overlay> availability away`` as a suppressor. The
+    thin wrapper stays here as the single patchable seam every caller and test
+    already targets.
+    """
+    return resolved_away_mode_stdlib()
 
 
 def _is_live_user_turn(data: dict) -> bool:

--- a/hooks/scripts/loop_state_self_pump_gate.py
+++ b/hooks/scripts/loop_state_self_pump_gate.py
@@ -5,9 +5,20 @@ only shrink): the in-session Stop self-pump must honour a durable DB pause of
 the always-on ``dispatch`` loop exactly as it honours ``T3_LOOPS_DISABLED=all``.
 Keeping it in a sibling helper means the Stop hook gains the behaviour without
 growing the god-module.
+
+The read is **stdlib-only** (#2559). The harness invokes the Stop hook as a bare
+``python3`` that has NO ``uv`` env — teatree's dependencies (Django et al.) are
+not importable, so ``django.setup()`` cannot run in the hook interpreter. A read
+gated on an in-process ``django.setup()`` therefore failed OPEN (never suppress)
+under the real Stop hook, silently neutering ``t3 loop pause`` / migration 0087.
+This module instead subprocesses the ``t3`` CLI — the editable install carries
+its own venv, so it bootstraps Django in a CHILD process — exactly the way
+``hook_router._consolidated_pending_work`` already reads ``pending-spawn``.
 """
 
-from django_bootstrap import bootstrap_teatree_django
+import json
+import shutil
+import subprocess  # noqa: S404 — reads a trusted local ``t3`` binary, fixed argv, never shell
 
 # The always-on loop the in-session Stop self-pump exists to drive. The
 # self-pump re-fires ``t3 loop tick`` + ``claim-next``, which run this loop's
@@ -15,6 +26,16 @@ from django_bootstrap import bootstrap_teatree_django
 # 'pause everything' the env ``T3_LOOPS_DISABLED=all`` kill-switch could only do
 # within a process (#1913). Mirrors :data:`teatree.loops.dispatch.loop.MINI_LOOP`'s name.
 _DISPATCH_LOOP_NAME = "dispatch"
+
+# A short bound — the Stop hook is timeout-capped (8s in hooks.json) and a
+# read-only ``loop loop-state`` query is sub-second. Mirrors
+# ``hook_router._SELF_PUMP_PENDING_TIMEOUT``.
+_LOOP_STATE_READ_TIMEOUT = 5
+
+# The single durable-runnable status (mirrors ``LoopStatus.ENABLED.value``
+# without importing teatree). Any other resolved status — ``paused`` /
+# ``disabled`` — is a durable hold that suppresses the self-pump.
+_RUNNABLE_STATUS = "enabled"
 
 
 def db_loop_state_suppresses_self_pump() -> bool:
@@ -26,19 +47,53 @@ def db_loop_state_suppresses_self_pump() -> bool:
     durably paused the control plane, so the in-session Stop self-pump must
     suppress exactly as it does for the env kill-switch.
 
-    FAIL OPEN — a Stop hook must be crash-proof: an unbootstrappable / absent
-    ``teatree`` or any DB read error resolves to ``False`` (do NOT suppress), so
-    the env / availability / ownership gates still decide and the pump can never
-    crash the session on an unreadable database.
-    """
-    if not bootstrap_teatree_django():
-        return False
-    try:
-        from teatree.core.models import LoopState  # noqa: PLC0415
+    The read is stdlib-only (#2559): it shells out to ``t3 loop loop-state
+    dispatch --json`` (a read-only probe on the ``loop`` top-level group — no
+    overlay token needed), so the durable status resolves in a CHILD ``t3``
+    process that carries its own venv. The bare-``python3`` Stop hook
+    interpreter never needs a ``django.setup()`` of its own.
 
-        return not LoopState.objects.is_runnable(_DISPATCH_LOOP_NAME)
-    except Exception:  # noqa: BLE001 — crash-proof: a DB error must not crash the Stop hook
-        return False
+    FAIL OPEN — a Stop hook must be crash-proof: an absent ``t3`` binary, a
+    non-zero exit, unparsable output, or any subprocess error resolves to
+    ``False`` (do NOT suppress), so the env / availability / ownership gates
+    still decide and the pump can never crash the session on an unreadable
+    control plane.
+    """
+    status = _dispatch_loop_status()
+    # An empty status means "unreadable" — fail OPEN (do not suppress).
+    return bool(status) and status != _RUNNABLE_STATUS
+
+
+def _dispatch_loop_status() -> str:
+    """Durable status of the ``dispatch`` loop via ``t3``; ``""`` when unreadable.
+
+    Reads ``t3 loop loop-state dispatch --json`` in a child process so the
+    bare-``python3`` hook never needs ``django.setup()``. Any failure — absent
+    ``t3``, non-zero exit, unparsable / non-dict output — yields ``""`` so the
+    caller fails OPEN.
+    """
+    t3_bin = shutil.which("t3")
+    if not t3_bin:
+        return ""
+    try:
+        result = subprocess.run(  # noqa: S603 — trusted local binary, fixed argv, no shell
+            [t3_bin, "loop", "loop-state", _DISPATCH_LOOP_NAME, "--json"],
+            capture_output=True,
+            text=True,
+            timeout=_LOOP_STATE_READ_TIMEOUT,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return ""
+    if result.returncode != 0 or not result.stdout.strip():
+        return ""
+    try:
+        parsed = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return ""
+    if not isinstance(parsed, dict):
+        return ""
+    return str(parsed.get("status", "")).strip().lower()
 
 
 __all__ = ["db_loop_state_suppresses_self_pump"]

--- a/src/teatree/core/management/commands/tasks.py
+++ b/src/teatree/core/management/commands/tasks.py
@@ -83,8 +83,26 @@ class Command(TyperCommand):
         return {"task_id": task.pk, "ticket_id": ticket_obj.pk, "phase": phase, "execution_target": target}
 
     @command()
-    def cancel(self, task_id: int, *, confirm: bool = False) -> None:
+    def cancel(
+        self,
+        task_id: int,
+        *,
+        confirm: bool = False,
+        reason: Annotated[
+            str,
+            typer.Option(help="Audit-trail reason recorded on a TaskAttempt (e.g. 'superseded by !6219')."),
+        ] = "",
+    ) -> None:
+        """Cancel a pending or (with --confirm) claimed task, driving it to FAILED.
+
+        An optional ``--reason`` persists to the DB as a ``TaskAttempt`` (mirroring
+        ``complete --note``) so the audit trail records WHY the task was cancelled
+        — the cancel transition is otherwise indistinguishable from any other
+        failure (#2559). A blank/whitespace reason records no attempt (no empty
+        audit row); the cancellation itself is unchanged.
+        """
         from django.db import transaction  # noqa: PLC0415
+        from django.utils import timezone  # noqa: PLC0415
 
         with transaction.atomic():
             try:
@@ -101,6 +119,15 @@ class Command(TyperCommand):
                 self.stderr.write(f"Task {task_id} already finished ({task.status}).")
                 raise SystemExit(1)
 
+            if reason.strip():
+                TaskAttempt.objects.create(
+                    task=task,
+                    execution_target=task.execution_target,
+                    ended_at=timezone.now(),
+                    exit_code=1,
+                    error=reason.strip(),
+                    result={"cancel_reason": reason.strip()},
+                )
             task.fail()
         self.stdout.write(f"Task {task_id} cancelled.")
 

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -1044,6 +1044,60 @@ class TestTasksCancelCommand(TestCase):
         with pytest.raises(SystemExit):
             call_command("tasks", "cancel", 99999)
 
+    def test_cancel_with_reason_persists_a_task_attempt(self) -> None:
+        # #2559: a cancellation reason must persist to the DB so the audit trail
+        # records WHY a task was cancelled — mirroring how ``complete --note``
+        # records a TaskAttempt. Before the fix ``cancel`` accepted no --reason.
+        ticket = Ticket.objects.create(overlay="test")
+        session = Session.objects.create(ticket=ticket, overlay="test")
+        task = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            execution_target=Task.ExecutionTarget.INTERACTIVE,
+        )
+
+        call_command("tasks", "cancel", task.pk, reason="superseded by !6219")
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+        attempt = task.attempts.get()
+        assert attempt.error == "superseded by !6219"
+        assert attempt.result == {"cancel_reason": "superseded by !6219"}
+        assert attempt.exit_code == 1  # a cancellation is a non-success terminal
+
+    def test_cancel_without_reason_records_no_attempt(self) -> None:
+        # The reason is optional — a bare cancel stays a clean no-attempt fail
+        # exactly as before (no regression).
+        ticket = Ticket.objects.create(overlay="test")
+        session = Session.objects.create(ticket=ticket, overlay="test")
+        task = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            execution_target=Task.ExecutionTarget.INTERACTIVE,
+        )
+
+        call_command("tasks", "cancel", task.pk)
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+        assert task.attempts.count() == 0
+
+    def test_cancel_blank_reason_records_no_attempt(self) -> None:
+        # A whitespace-only reason is treated as no reason — no empty audit row.
+        ticket = Ticket.objects.create(overlay="test")
+        session = Session.objects.create(ticket=ticket, overlay="test")
+        task = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            execution_target=Task.ExecutionTarget.INTERACTIVE,
+        )
+
+        call_command("tasks", "cancel", task.pk, reason="   ")
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+        assert task.attempts.count() == 0
+
 
 class TestTasksCompleteCommand(TestCase):
     """Tests for the tasks complete subcommand (#1031).

--- a/tests/test_loop_pause_levers_stdlib.py
+++ b/tests/test_loop_pause_levers_stdlib.py
@@ -1,0 +1,260 @@
+"""The Stop self-pump pause levers must read durable state WITHOUT django.setup() (#2559).
+
+The Stop hook is invoked as a bare ``python3`` (``hooks.json``): the harness
+never sources the user's shell profile and the interpreter is whatever the
+harness picks — it has NO ``uv`` env, so teatree's dependencies (Django et al.)
+are not importable. ``django_bootstrap.bootstrap_teatree_django()`` therefore
+returns ``False`` in the real Stop context.
+
+Before the fix, both durable pause levers gated their read on that bootstrap —
+``db_loop_state_suppresses_self_pump`` (the DB ``LoopState`` 'pause everything' of
+the always-on ``dispatch`` loop, via ``t3 loop pause`` / migration 0087) and
+``_resolved_away_mode`` (``t3 teatree availability away``) —
+each returned ``False`` when the bootstrap failed — i.e. fail-OPEN. So under the
+real bare-``python3`` Stop hook a durable DB pause / away override was SILENTLY
+INEFFECTIVE at suppressing the self-pump: the pump kept firing through a pause.
+
+The fix makes both levers stdlib-only — they subprocess the ``t3`` CLI (the
+editable install carries its own venv, so it bootstraps Django in a CHILD
+process) exactly the way ``_consolidated_pending_work`` already does, instead of
+importing teatree in the bare hook interpreter. These tests reproduce the exact
+bare-``python3`` context (bootstrap fails) and prove a durable pause now
+suppresses the pump: RED before the fix, GREEN after.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import hooks.scripts.hook_router as router
+from hooks.scripts.hook_router import _OWNER_LOOP, _write_loop_registry, handle_loop_self_pump
+
+# ``hook_router`` puts its own dir on ``sys.path`` and binds the gate functions
+# via bare ``from <sibling> import …`` — that creates SEPARATE module instances
+# from ``hooks.scripts.<sibling>`` (the dual identity called out in
+# ``hooks/CLAUDE.md``). Patch the instances the router actually calls so the
+# stdlib subprocess stubs land on the live code paths.
+gate = sys.modules["loop_state_self_pump_gate"]
+away_probe = sys.modules["availability_away_probe"]
+
+
+@pytest.fixture(autouse=True)
+def _bare_python3_stop_context(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reproduce the real bare-``python3`` Stop hook context.
+
+    The hook interpreter cannot ``django.setup()`` — so BOTH levers' shared
+    bootstrap is forced to fail, exactly as it does in production. Everything
+    else (state dir, registry, bash-env fallback) is redirected into ``tmp_path``
+    so a developer's real config never leaks into the test.
+    """
+    state = tmp_path / "state"
+    state.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(router, "STATE_DIR", state)
+    monkeypatch.setenv("T3_LOOP_REGISTRY_DIR", str(tmp_path / "data"))
+    (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("TEATREE_BASH_ENV_FILE", str(tmp_path / "no-bash-env"))
+    # The defining property of the bare-python3 Stop hook: teatree is NOT
+    # importable in the hook interpreter, so the shared django bootstrap returns
+    # False. The fixed levers no longer call it (they subprocess ``t3`` so a
+    # CHILD process bootstraps Django) — but the router still imports it for
+    # OTHER handlers, so force it False there to prove the away lever does NOT
+    # depend on an in-process django.setup(). This is the exact production
+    # reality the #2559 bug lived in: a False bootstrap.
+    monkeypatch.setattr(router, "bootstrap_teatree_django", lambda: False)
+
+
+def _own_loop(session_id: str) -> None:
+    _write_loop_registry(
+        {
+            _OWNER_LOOP: {
+                "session_id": session_id,
+                "agent_id": "a",
+                "pid": os.getpid(),
+                "heartbeat_ts": int(time.time()),
+            }
+        }
+    )
+
+
+def _fake_pending(monkeypatch: pytest.MonkeyPatch, entries: list[dict]) -> None:
+    monkeypatch.setattr(router, "_consolidated_pending_work", lambda: entries)
+
+
+def _fake_t3(
+    monkeypatch: pytest.MonkeyPatch,
+    target: object,
+    responses: dict[str, tuple[int, str]],
+) -> list[list[str]]:
+    """Stub ``shutil.which('t3')`` + ``subprocess.run`` on *target*'s module.
+
+    *responses* maps a marker substring of the argv (e.g. ``"loop-state"`` or
+    ``"availability"``) to a ``(returncode, stdout)`` pair. The captured argv
+    list is returned so a test can assert the lever shelled out to ``t3``
+    instead of touching the ORM.
+    """
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr(target, "shutil", SimpleNamespace(which=lambda _name: "/usr/local/bin/t3"))
+
+    def _run(argv: list[str], *_args: object, **_kwargs: object) -> SimpleNamespace:
+        calls.append(list(argv))
+        joined = " ".join(argv)
+        for marker, (code, out) in responses.items():
+            if marker in joined:
+                return SimpleNamespace(returncode=code, stdout=out, stderr="")
+        return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+    monkeypatch.setattr(target, "subprocess", SimpleNamespace(run=_run, TimeoutExpired=subprocess.TimeoutExpired))
+    return calls
+
+
+class TestDbPauseLeverIsStdlibOnly:
+    """``db_loop_state_suppresses_self_pump`` reads the durable pause via ``t3``."""
+
+    def test_gate_module_imports_no_django_bootstrap(self) -> None:
+        # The structural #2559 invariant: the gate must NOT import the in-process
+        # django bootstrap at all — it is stdlib-only (shutil + subprocess + json)
+        # so the bare-python3 Stop hook never needs a ``django.setup()`` of its
+        # own. A re-introduced bootstrap import would silently reinstate the
+        # fail-open bug, so guard it here.
+        assert not hasattr(gate, "bootstrap_teatree_django")
+        assert hasattr(gate, "shutil")
+        assert hasattr(gate, "subprocess")
+
+    def test_db_paused_dispatch_suppresses_under_bare_python3(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The exact #2559 reproduction: django.setup() is impossible (bootstrap
+        # forced False by the fixture), yet a durable PAUSE on the ``dispatch``
+        # loop is readable via the ``t3`` subprocess. The lever MUST suppress.
+        calls = _fake_t3(
+            monkeypatch,
+            gate,
+            {"loop-state": (0, json.dumps({"name": "dispatch", "status": "paused"}))},
+        )
+
+        assert gate.db_loop_state_suppresses_self_pump() is True
+        assert any("loop-state" in " ".join(c) for c in calls)  # shelled out, did not ORM
+
+    def test_db_disabled_dispatch_suppresses_under_bare_python3(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_t3(
+            monkeypatch,
+            gate,
+            {"loop-state": (0, json.dumps({"name": "dispatch", "status": "disabled"}))},
+        )
+        assert gate.db_loop_state_suppresses_self_pump() is True
+
+    def test_db_enabled_dispatch_does_not_suppress(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_t3(
+            monkeypatch,
+            gate,
+            {"loop-state": (0, json.dumps({"name": "dispatch", "status": "enabled"}))},
+        )
+        assert gate.db_loop_state_suppresses_self_pump() is False
+
+    def test_t3_absent_fails_open(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # No ``t3`` on PATH ⇒ genuinely unreadable ⇒ fail OPEN (do not suppress),
+        # so the other gates still decide and the pump never crashes the session.
+        monkeypatch.setattr(gate, "shutil", SimpleNamespace(which=lambda _name: None))
+        assert gate.db_loop_state_suppresses_self_pump() is False
+
+    def test_t3_error_exit_fails_open(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_t3(monkeypatch, gate, {"loop-state": (1, "")})
+        assert gate.db_loop_state_suppresses_self_pump() is False
+
+
+class TestAwayLeverIsStdlibOnly:
+    """``_resolved_away_mode`` reads the resolved availability via ``t3``.
+
+    The router's thin ``_resolved_away_mode`` delegates to the stdlib sibling
+    ``availability_away_probe`` (#2559), so the subprocess stub patches that
+    module — the instance the live delegate actually shells out from.
+    """
+
+    def test_probe_imports_no_django_bootstrap(self) -> None:
+        # Structural #2559 invariant: the away probe is stdlib-only.
+        assert not hasattr(away_probe, "bootstrap_teatree_django")
+        assert hasattr(away_probe, "shutil")
+        assert hasattr(away_probe, "subprocess")
+
+    def test_away_override_resolves_true_under_bare_python3(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_t3(
+            monkeypatch,
+            away_probe,
+            {"availability": (0, "availability: mode=away source=override")},
+        )
+        assert router._resolved_away_mode() is True
+
+    def test_present_resolves_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _fake_t3(
+            monkeypatch,
+            away_probe,
+            {"availability": (0, "availability: mode=present source=default")},
+        )
+        assert router._resolved_away_mode() is False
+
+    def test_t3_absent_resolves_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(away_probe, "shutil", SimpleNamespace(which=lambda _name: None))
+        assert router._resolved_away_mode() is False
+
+
+class TestStopSelfPumpEndToEndUnderBarePython3:
+    """The whole handler suppresses through a durable pause in the bare context."""
+
+    def test_db_pause_suppresses_pump_even_with_pending_work(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The end-to-end #2559 proof: bootstrap fails (bare python3), there is
+        # pending work, this session owns the loop, availability is present — but
+        # a durable DB PAUSE on ``dispatch`` is readable via ``t3``. The Stop
+        # self-pump must NOT block (the pause is honoured).
+        _own_loop("owner-1")
+        _fake_pending(monkeypatch, [{"task_id": 4, "subagent": "x", "phase": "coding", "issue_url": "u"}])
+
+        def _which(name: str) -> str | None:
+            return "/usr/local/bin/t3" if name == "t3" else None
+
+        def _run(argv: list[str], *_args: object, **_kwargs: object) -> SimpleNamespace:
+            joined = " ".join(argv)
+            if "loop-state" in joined:
+                return SimpleNamespace(
+                    returncode=0, stdout=json.dumps({"name": "dispatch", "status": "paused"}), stderr=""
+                )
+            if "availability" in joined:
+                return SimpleNamespace(returncode=0, stdout="availability: mode=present source=default", stderr="")
+            return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+        for mod in (gate, away_probe):
+            monkeypatch.setattr(mod, "shutil", SimpleNamespace(which=_which))
+            monkeypatch.setattr(mod, "subprocess", SimpleNamespace(run=_run, TimeoutExpired=subprocess.TimeoutExpired))
+
+        result = handle_loop_self_pump({"session_id": "owner-1"})
+
+        assert result is not True  # paused: no block, the session may end
+
+    def test_away_override_suppresses_pump_even_with_pending_work(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _own_loop("owner-1")
+        _fake_pending(monkeypatch, [{"task_id": 4, "subagent": "x", "phase": "coding", "issue_url": "u"}])
+
+        def _which(name: str) -> str | None:
+            return "/usr/local/bin/t3" if name == "t3" else None
+
+        def _run(argv: list[str], *_args: object, **_kwargs: object) -> SimpleNamespace:
+            joined = " ".join(argv)
+            if "loop-state" in joined:
+                return SimpleNamespace(
+                    returncode=0, stdout=json.dumps({"name": "dispatch", "status": "enabled"}), stderr=""
+                )
+            if "availability" in joined:
+                return SimpleNamespace(returncode=0, stdout="availability: mode=away source=override", stderr="")
+            return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+        for mod in (gate, away_probe):
+            monkeypatch.setattr(mod, "shutil", SimpleNamespace(which=_which))
+            monkeypatch.setattr(mod, "subprocess", SimpleNamespace(run=_run, TimeoutExpired=subprocess.TimeoutExpired))
+
+        result = handle_loop_self_pump({"session_id": "owner-1"})
+
+        assert result is not True  # away: the pause wins over the standing directive

--- a/tests/test_loop_state_self_pump_hook.py
+++ b/tests/test_loop_state_self_pump_hook.py
@@ -2,30 +2,44 @@
 
 The 2026-06-03 'pause everything' incident: there was no restart-surviving
 paused state for the loop control plane. ``T3_LOOPS_DISABLED=all`` is an env
-kill-switch (process / file scoped); #1913 adds a DURABLE DB equivalent — a
+kill-switch (process / file scoped); #1913 added a DURABLE DB equivalent — a
 ``LoopState`` row that pauses/disables the ``dispatch`` always-on loop, the loop
 the in-session Stop self-pump exists to drive.
 
-When that row says PAUSED or DISABLED the self-pump must suppress (a clean
-no-op) so a paused loop stays paused across a session restart, exactly as the
-env kill-switch suppresses it within a process. An empty table / an ENABLED row
-leaves the self-pump behaviour unchanged (no regression), and a DB read failure
-fails OPEN (the env/availability/ownership gates still decide) so the Stop hook
-can never crash on an unreadable database.
+When that durable state says PAUSED or DISABLED the self-pump must suppress (a
+clean no-op) so a paused loop stays paused across a session restart, exactly as
+the env kill-switch suppresses it within a process. An ENABLED / absent state
+leaves the self-pump behaviour unchanged (no regression), and an unreadable
+control plane fails OPEN (the env/availability/ownership gates still decide) so
+the Stop hook can never crash.
+
+#2559 changed the READ MECHANISM: the bare-``python3`` Stop hook cannot
+``django.setup()``, so the gate no longer reads the ``LoopState`` row through the
+ORM in-process — it shells out to ``t3 loop loop-state dispatch --json`` (the
+``t3`` child carries its own venv and bootstraps Django). So these tests stub the
+``t3`` subprocess (the external boundary) rather than writing an ORM row, which a
+child ``t3`` process would not see in the pytest-django transactional test DB.
 """
 
+import json
 import os
+import subprocess
+import sys
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 import hooks.scripts.hook_router as router
-import hooks.scripts.loop_state_self_pump_gate as gate
 from hooks.scripts.hook_router import _OWNER_LOOP, _write_loop_registry, handle_loop_self_pump
 
-# ast-grep-ignore: ac-django-no-pytest-django-db
-pytestmark = pytest.mark.django_db
+# ``hook_router`` binds the gate function via a bare ``from
+# loop_state_self_pump_gate import …`` (its own dir on sys.path), so the live
+# instance is ``sys.modules["loop_state_self_pump_gate"]`` — a SEPARATE object
+# from ``hooks.scripts.loop_state_self_pump_gate`` (the dual identity called out
+# in ``hooks/CLAUDE.md``). Patch the instance the router actually calls.
+gate = sys.modules["loop_state_self_pump_gate"]
 
 
 @pytest.fixture(autouse=True)
@@ -58,11 +72,46 @@ def _fake_pending(monkeypatch: pytest.MonkeyPatch, entries: list[dict]) -> None:
     monkeypatch.setattr(router, "_consolidated_pending_work", lambda: entries)
 
 
+def _fake_loop_state(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    dispatch_status: str | None = None,
+    crash: bool = False,
+) -> dict[str, int]:
+    """Stub the gate's ``t3 loop loop-state dispatch --json`` subprocess.
+
+    *dispatch_status* is the durable status the ``t3`` child reports for the
+    ``dispatch`` loop (``enabled`` / ``paused`` / ``disabled``); ``None`` (the
+    default) means "loop not queried in this case" — a non-``dispatch`` query
+    returns ENABLED. *crash* simulates an unreadable control plane (the read
+    raises) so the gate fails OPEN. Returns a probe counter so a test can prove
+    the gate short-circuits BEFORE the ``pending-spawn`` subprocess.
+    """
+    counter = {"loop_state_calls": 0}
+
+    monkeypatch.setattr(gate, "shutil", SimpleNamespace(which=lambda _name: "/usr/local/bin/t3"))
+
+    def _run(argv: list[str], *_args: object, **_kwargs: object) -> SimpleNamespace:
+        if crash:
+            msg = "control plane unreadable"
+            raise OSError(msg)
+        joined = " ".join(argv)
+        if "loop-state" in joined:
+            counter["loop_state_calls"] += 1
+            # The argv is ``t3 loop loop-state <name> --json``; report the
+            # requested loop's status (ENABLED for any loop other than dispatch).
+            name = argv[3] if len(argv) > 3 else ""
+            status = dispatch_status if (name == "dispatch" and dispatch_status) else "enabled"
+            return SimpleNamespace(returncode=0, stdout=json.dumps({"name": name, "status": status}), stderr="")
+        return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+    monkeypatch.setattr(gate, "subprocess", SimpleNamespace(run=_run, TimeoutExpired=subprocess.TimeoutExpired))
+    return counter
+
+
 class TestSelfPumpHonoursDbLoopState:
     def test_db_paused_dispatch_loop_makes_owner_stop_hook_a_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from teatree.core.models import LoopState  # noqa: PLC0415
-
-        LoopState.objects.pause("dispatch")
+        _fake_loop_state(monkeypatch, dispatch_status="paused")
         _own_loop("owner-1")
         _fake_pending(monkeypatch, [{"task_id": 4, "subagent": "x", "phase": "coding", "issue_url": "u"}])
 
@@ -71,9 +120,7 @@ class TestSelfPumpHonoursDbLoopState:
         assert result is not True  # paused: no block, the session may end
 
     def test_db_disabled_dispatch_loop_makes_owner_stop_hook_a_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from teatree.core.models import LoopState  # noqa: PLC0415
-
-        LoopState.objects.disable("dispatch")
+        _fake_loop_state(monkeypatch, dispatch_status="disabled")
         _own_loop("owner-1")
         _fake_pending(monkeypatch, [{"task_id": 4, "subagent": "x", "phase": "coding", "issue_url": "u"}])
 
@@ -82,9 +129,7 @@ class TestSelfPumpHonoursDbLoopState:
         assert result is not True
 
     def test_db_paused_dispatch_loop_does_not_probe_pending_work(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from teatree.core.models import LoopState  # noqa: PLC0415
-
-        LoopState.objects.pause("dispatch")
+        _fake_loop_state(monkeypatch, dispatch_status="paused")
         _own_loop("owner-1")
         probed = {"called": False}
 
@@ -96,11 +141,13 @@ class TestSelfPumpHonoursDbLoopState:
 
         result = handle_loop_self_pump({"session_id": "owner-1"})
 
-        assert probed["called"] is False  # gate checked BEFORE the subprocess
+        assert probed["called"] is False  # gate checked BEFORE the pending probe
         assert result is not True
 
-    def test_empty_table_leaves_owner_pumping(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        # No LoopState row → no regression: the owner with pending work pumps.
+    def test_empty_state_leaves_owner_pumping(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # No durable row → ``t3`` reports ENABLED → no regression: the owner with
+        # pending work pumps.
+        _fake_loop_state(monkeypatch, dispatch_status="enabled")
         _own_loop("owner-1")
         _fake_pending(monkeypatch, [{"task_id": 4, "subagent": "x", "phase": "coding", "issue_url": "u"}])
 
@@ -109,10 +156,7 @@ class TestSelfPumpHonoursDbLoopState:
         assert result is True
 
     def test_db_enabled_dispatch_loop_leaves_owner_pumping(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from teatree.core.models import LoopState  # noqa: PLC0415
-
-        LoopState.objects.pause("dispatch")
-        LoopState.objects.resume("dispatch")
+        _fake_loop_state(monkeypatch, dispatch_status="enabled")
         _own_loop("owner-1")
         _fake_pending(monkeypatch, [{"task_id": 4, "subagent": "x", "phase": "coding", "issue_url": "u"}])
 
@@ -121,11 +165,11 @@ class TestSelfPumpHonoursDbLoopState:
         assert result is True
 
     def test_paused_other_loop_does_not_suppress_the_pump(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        # The self-pump drives the always-on ``dispatch`` loop; pausing an
-        # UNRELATED named loop (e.g. ``review``) must not silence the pump.
-        from teatree.core.models import LoopState  # noqa: PLC0415
-
-        LoopState.objects.pause("review")
+        # The self-pump drives the always-on ``dispatch`` loop; the gate queries
+        # ONLY ``dispatch`` — a paused UNRELATED loop is invisible to it, so the
+        # pump still fires. ``_fake_loop_state`` reports ENABLED for any non-
+        # dispatch loop, so a dispatch query here resolves runnable.
+        _fake_loop_state(monkeypatch, dispatch_status="enabled")
         _own_loop("owner-1")
         _fake_pending(monkeypatch, [{"task_id": 4, "subagent": "x", "phase": "coding", "issue_url": "u"}])
 
@@ -133,10 +177,22 @@ class TestSelfPumpHonoursDbLoopState:
 
         assert result is True
 
-    def test_db_read_failure_fails_open_pump_proceeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        # A Stop hook must be crash-proof: if the DB read raises, the gate
-        # fails OPEN (defers to env/availability/ownership) and the pump runs.
-        monkeypatch.setattr(gate, "bootstrap_teatree_django", lambda: False)
+    def test_control_plane_read_failure_fails_open_pump_proceeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A Stop hook must be crash-proof: if the control-plane read raises, the
+        # gate fails OPEN (defers to env/availability/ownership) and the pump
+        # runs. Mirrors the #2559 stdlib read failing safe.
+        _fake_loop_state(monkeypatch, crash=True)
+        _own_loop("owner-1")
+        _fake_pending(monkeypatch, [{"task_id": 4, "subagent": "x", "phase": "coding", "issue_url": "u"}])
+
+        result = handle_loop_self_pump({"session_id": "owner-1"})
+
+        assert result is True
+
+    def test_t3_absent_fails_open_pump_proceeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # No ``t3`` binary on PATH ⇒ the control plane is genuinely unreadable ⇒
+        # fail OPEN, the pump runs (the other gates still decide).
+        monkeypatch.setattr(gate, "shutil", SimpleNamespace(which=lambda _name: None))
         _own_loop("owner-1")
         _fake_pending(monkeypatch, [{"task_id": 4, "subagent": "x", "phase": "coding", "issue_url": "u"}])
 


### PR DESCRIPTION
## What

Make the Stop self-pump's durable pause levers stdlib-only so they actually
work under the bare-`python3` Stop hook, and add a `--reason` to `t3 task cancel`.

Closes #2559.

## Why

The Stop hook is invoked as a bare `python3` (`hooks/hooks.json`): the harness
does not source the user's shell profile and the interpreter has no `uv` env, so
teatree's dependencies (Django et al.) are not importable and an in-process
`django.setup()` fails.

Both durable pause levers gated their read on that bootstrap and returned `False`
on failure (fail-open):

- `db_loop_state_suppresses_self_pump` (`hooks/scripts/loop_state_self_pump_gate.py`)
  — the DB `LoopState` 'pause everything' of the always-on `dispatch` loop
  (`t3 loop pause`, migration 0087).
- `_resolved_away_mode` (`hooks/scripts/hook_router.py`) — the
  `availability away` override.

So under the real Stop hook, a durable DB pause and an away override were
silently ineffective at suppressing the self-pump — the pump kept firing through
a pause. This is the fail-open bug folded into the loops epic.

## How

Both levers now read durable state stdlib-only by subprocessing the `t3` CLI (the
editable install carries its own venv, so it bootstraps Django in a child
process) — exactly the shape `_consolidated_pending_work` already uses.

- `db_loop_state_suppresses_self_pump` reads `t3 loop loop-state dispatch --json`;
  `paused`/`disabled` suppresses, `enabled` pumps, an unreadable control plane
  fails open.
- The away read moves into a new bare sibling module
  `hooks/scripts/availability_away_probe.py` (so the over-cap, shrink-only
  `hook_router` does not grow); it reads `t3 <overlay> availability show` and
  parses the `mode=` token. `_resolved_away_mode` stays as the thin patchable
  wrapper every caller and test already targets.
- `t3 task cancel` gains an optional `--reason` that persists to the DB as a
  `TaskAttempt` (`error` + `result.cancel_reason`), mirroring `complete --note`,
  so a cancellation records why it happened.

## Tests

- New `tests/test_loop_pause_levers_stdlib.py` reproduces the exact bare-`python3`
  Stop context (django bootstrap forced `False`) and proves a durable DB pause /
  away override now suppresses the self-pump — RED before the fix, GREEN after.
- The existing `LoopState` self-pump tests are rewritten onto the new subprocess
  contract.
- New `t3 task cancel --reason` tests assert the `TaskAttempt` is persisted (and
  that a blank/absent reason records no attempt).

## Loop health verified (not changed)

The #2550 / #2513 cutover is healthy: the DB `Loop` table is populated and
queryable, `t3 loop list --json`, `t3 loop loop-state`, `t3 loop claim-next`, and
`t3 loop pending-spawn` all respond cleanly, and the loop dispatcher test suite
is green (368 tests). Loops remain paused — re-enabling them and registering the
loop cron is the maintainer's call.
