### PR TITLE
fix(eval): keep eval-list scenario names greppable when piped

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -5690,12 +5690,22 @@ Usage: t3 teatree tasks [OPTIONS] COMMAND [ARGS]...
 ```
 Usage: t3 teatree tasks cancel [OPTIONS] TASK_ID
 
+ Cancel a pending or (with --confirm) claimed task, driving it to FAILED.
+
+ An optional ``--reason`` persists to the DB as a ``TaskAttempt`` (mirroring
+ ``complete --note``) so the audit trail records WHY the task was cancelled
+ — the cancel transition is otherwise indistinguishable from any other
+ failure (#2559). A blank/whitespace reason records no attempt (no empty
+ audit row); the cancellation itself is unchanged.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    task_id      INTEGER  [required]                                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --confirm    --no-confirm      [default: no-confirm]                         │
-│ --help                         Show this message and exit.                   │
+│ --confirm    --no-confirm          [default: no-confirm]                     │
+│ --reason                     TEXT  Audit-trail reason recorded on a          │
+│                                    TaskAttempt (e.g. 'superseded by !6219'). │
+│ --help                             Show this message and exit.               │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/cli/eval/all.py
+++ b/src/teatree/cli/eval/all.py
@@ -57,7 +57,13 @@ def _relative_source(path: Path) -> str:
 
 def build_scenarios_table(specs: list[EvalSpec]) -> Table:
     table = Table(title="Eval scenarios", show_lines=False)
-    table.add_column("Name", style="bold")
+    # ``min_width`` floors the Name column at the longest name so a piped/non-TTY
+    # console (default width 80) can neither wrap nor truncate it. A CI discovery-
+    # assertion greps ``t3 eval list`` for a scenario NAME on one line; without
+    # this floor a long scenario name truncates to an ellipsis and the grep
+    # falsely reports broken overlay wiring.
+    longest_name = max((len(spec.name) for spec in specs), default=0)
+    table.add_column("Name", style="bold", no_wrap=True, min_width=longest_name)
     table.add_column("Scenario")
     table.add_column("Agent")
     table.add_column("File", overflow="ellipsis", no_wrap=True)

--- a/tests/teatree_cli/test_eval.py
+++ b/tests/teatree_cli/test_eval.py
@@ -135,6 +135,52 @@ class TestEvalList:
         assert result.exit_code == 0
         assert "(no scenarios discovered)" in result.output
 
+    def test_name_column_is_floored_to_the_longest_scenario_name(self) -> None:
+        # CI discovery-assertion steps grep `t3 eval list` output for a scenario
+        # NAME on a single line. A piped (non-TTY) Rich console defaults to width
+        # 80, which can truncate the no-wrap Name column with an ellipsis — the
+        # grep then finds nothing and falsely reports "overlay wiring is broken".
+        # The fix floors the Name column's `min_width` at the longest name so it
+        # is never narrowed below a full name. Assert that floor directly.
+        from teatree.cli.eval.all import build_scenarios_table  # noqa: PLC0415
+
+        long_name = "a_very_long_overlay_scenario_name_xxxxx"
+        table = build_scenarios_table([_spec("short"), _spec(long_name)])
+        name_column = table.columns[0]
+        assert name_column.header == "Name"
+        assert name_column.no_wrap is True
+        assert name_column.min_width == len(long_name), (
+            f"Name column min_width {name_column.min_width!r} must floor at the longest "
+            f"name ({len(long_name)}) so it cannot truncate when piped"
+        )
+
+    def test_long_scenario_name_survives_a_narrow_piped_render(self) -> None:
+        # End-to-end: with realistic-length sibling columns competing for an 80-col
+        # budget, the long name renders intact on one greppable line.
+        from io import StringIO  # noqa: PLC0415
+
+        from rich.console import Console  # noqa: PLC0415
+
+        from teatree.cli.eval.all import build_scenarios_table  # noqa: PLC0415
+
+        long_name = "a_very_long_overlay_scenario_name_xxxxx"
+        spec = EvalSpec(
+            name=long_name,
+            scenario="the agent opens the PR via the sanctioned wrapper, never a raw forge merge call",
+            agent_path="src/overlay/skills/example-overlay/SKILL.md",
+            prompt="do",
+            matchers=(
+                Matcher(kind="positive", tool="Bash", arg_path="command", operator="contains", value="pr create"),
+            ),
+            source_path=Path("/some/very/long/absolute/path/to/evals/specs/a_very_long_overlay_scenario.yaml"),
+        )
+        buffer = StringIO()
+        Console(file=buffer, width=80, force_terminal=False).print(build_scenarios_table([spec]))
+        rendered = buffer.getvalue()
+        assert any(long_name in line for line in rendered.splitlines()), (
+            f"long scenario name not greppable on one line at width 80:\n{rendered}"
+        )
+
 
 class TestEvalRun:
     def test_sdk_run_default_budget_is_generous_so_a_scenario_completes(self) -> None:


### PR DESCRIPTION
## Problem

A CI metered-eval discovery-assertion step greps `t3 eval list` output for a scenario NAME on a single line. A piped (non-TTY) Rich console defaults to width 80, which truncates the no-wrap Name column with an ellipsis. With sibling columns competing for that budget, a long scenario name truncates and the grep finds nothing — the step then fails with a misleading "overlay wiring is broken" error even though discovery worked (the file path appeared in the box-table; the name did not).

## Fix

Floor the Name column's `min_width` at the longest scenario name in `build_scenarios_table`, so a narrow/piped console can neither wrap nor truncate it.

## Tests

- A structural regression test pins the floor (red without the fix: `min_width` is `None`).
- An end-to-end test renders at width 80 and asserts the long name survives intact on one greppable line.