### PR TITLE
fix(cli): re-expose every workspace subcommand on the overlay group

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -4611,19 +4611,27 @@ Usage: t3 teatree workspace [OPTIONS] COMMAND [ARGS]...
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ ticket        Create or update a ticket and trigger worktree provisioning.   │
-│ provision     Provision every worktree in the current ticket workspace.      │
-│ start         Start docker for every worktree in the current ticket          │
-│               workspace.                                                     │
-│ ready         Run readiness probes for every worktree in the ticket          │
-│               workspace.                                                     │
-│ teardown      Tear down every worktree in the current ticket workspace.      │
-│ finalize      Squash worktree commits and rebase on the default branch.      │
-│ doctor        Detect state drift across every store; optionally fix it.      │
-│ clean-merged  Tear down every worktree whose ticket is already MERGED.       │
-│ clean-all     Prune merged worktrees, stale branches, orphaned stashes,      │
-│               orphan DBs, old DSLR snapshots.                                │
-│ list-orphans  List orphan branches (commits not on main, no open PR).        │
+│ ticket          Create or update a ticket and trigger worktree provisioning. │
+│ provision       Provision every worktree in the current ticket workspace.    │
+│ start           Start docker for every worktree in the current ticket        │
+│                 workspace.                                                   │
+│ ready           Run readiness probes for every worktree in the ticket        │
+│                 workspace.                                                   │
+│ teardown        Tear down every worktree in the current ticket workspace.    │
+│ finalize        Squash worktree commits and rebase on the default branch.    │
+│ doctor          Detect state drift across every store; optionally fix it.    │
+│ clean-merged    Tear down every worktree whose ticket is already MERGED.     │
+│ clean-all       Prune merged worktrees, stale branches, orphaned stashes,    │
+│                 orphan DBs, old DSLR snapshots.                              │
+│ list-orphans    List orphan branches (commits not on main, no open PR).      │
+│ landscape       Survey in-flight PRs/MRs and local unsynced work before      │
+│                 planning (read-only).                                        │
+│ reap-stale      Tear down ABANDONED docker stacks no live worktree owns      │
+│                 (age-guarded).                                               │
+│ reclaim-disk    Reclaim disk via zero-data-loss docker prunes (builder +     │
+│                 dangling images + unreferenced volumes).                     │
+│ stamp-identity  Stamp the repo's local git identity to the GitHub noreply    │
+│                 form (public-push safety).                                   │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -4866,6 +4874,87 @@ Usage: t3 teatree workspace list-orphans [OPTIONS]
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree workspace landscape`
+
+```
+Usage: t3 teatree workspace landscape [OPTIONS]
+
+ Survey what is already in flight or settled before planning (#2541).
+
+ The intake landscape survey the ``/t3:ticket`` step runs and the planner
+ consumes: the operator's open PRs/MRs, the local worktrees carrying
+ uncommitted or unpushed work, and a per-issue close/merge/supersede
+ recommendation against the in-flight PR landscape. Forge or git probes
+ that cannot complete degrade to ``warnings`` rather than aborting — a
+ missed in-flight branch is worse than a noisy warning. Emits a
+ JSON-serialisable survey so the planner plans against reality instead of
+ re-deriving it.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree workspace reap-stale`
+
+```
+Usage: t3 teatree workspace reap-stale [OPTIONS]
+
+ Tear down ABANDONED docker stacks no live worktree owns (age-guarded, #2207).
+
+ The on-demand twin of the automatic pre-start/pre-provision sweep: an
+ unowned compose project is reaped only when its newest container
+ lifecycle event is older than the threshold, so a parallel session's
+ fresh hand-rolled stack is never touched. ``clean-all`` remains the
+ blunt deep clean (every unowned project, regardless of age).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --min-age-minutes                    INTEGER  Override the stale threshold   │
+│                                               (minutes); 0 uses the          │
+│                                               configured                     │
+│                                               stale_stack_min_age_minutes.   │
+│                                               [default: 0]                   │
+│ --dry-run            --no-dry-run             List the stacks that would be  │
+│                                               reaped without removing.       │
+│                                               [default: no-dry-run]          │
+│ --help                                        Show this message and exit.    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree workspace reclaim-disk`
+
+```
+Usage: t3 teatree workspace reclaim-disk [OPTIONS]
+
+ Free disk via the three safe Docker prunes, then STOP — engine:
+ ``teatree.docker.reclaim`` (#2246).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --dry-run    --no-dry-run      Plan the reclaim set without removing         │
+│                                anything.                                     │
+│                                [default: no-dry-run]                         │
+│ --help                         Show this message and exit.                   │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree workspace stamp-identity`
+
+```
+Usage: t3 teatree workspace stamp-identity [OPTIONS]
+
+ Stamp the scoped noreply git identity onto an existing souliane clone (#762).
+
+ Fixes public souliane/* clones/worktrees created before the
+ provisioner source-fix (new worktrees are stamped at creation).
+ Idempotent. Refuses non-souliane / private remotes so the private overlay's
+ legitimate real-identity attribution is never touched.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --repo        TEXT  [default: .]                                             │
+│ --help              Show this message and exit.                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -5690,12 +5779,22 @@ Usage: t3 teatree tasks [OPTIONS] COMMAND [ARGS]...
 ```
 Usage: t3 teatree tasks cancel [OPTIONS] TASK_ID
 
+ Cancel a pending or (with --confirm) claimed task, driving it to FAILED.
+
+ An optional ``--reason`` persists to the DB as a ``TaskAttempt`` (mirroring
+ ``complete --note``) so the audit trail records WHY the task was cancelled
+ — the cancel transition is otherwise indistinguishable from any other
+ failure (#2559). A blank/whitespace reason records no attempt (no empty
+ audit row); the cancellation itself is unchanged.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    task_id      INTEGER  [required]                                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --confirm    --no-confirm      [default: no-confirm]                         │
-│ --help                         Show this message and exit.                   │
+│ --confirm    --no-confirm          [default: no-confirm]                     │
+│ --reason                     TEXT  Audit-trail reason recorded on a          │
+│                                    TaskAttempt (e.g. 'superseded by !6219'). │
+│ --help                             Show this message and exit.               │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/cli/django_groups.py
+++ b/src/teatree/cli/django_groups.py
@@ -66,6 +66,13 @@ DJANGO_GROUPS: dict[str, DjangoGroup] = {
             ("clean-merged", "Tear down every worktree whose ticket is already MERGED."),
             ("clean-all", "Prune merged worktrees, stale branches, orphaned stashes, orphan DBs, old DSLR snapshots."),
             ("list-orphans", "List orphan branches (commits not on main, no open PR)."),
+            ("landscape", "Survey in-flight PRs/MRs and local unsynced work before planning (read-only)."),
+            ("reap-stale", "Tear down ABANDONED docker stacks no live worktree owns (age-guarded)."),
+            (
+                "reclaim-disk",
+                "Reclaim disk via zero-data-loss docker prunes (builder + dangling images + unreferenced volumes).",
+            ),
+            ("stamp-identity", "Stamp the repo's local git identity to the GitHub noreply form (public-push safety)."),
         ],
     ),
     "run": DjangoGroup(

--- a/tests/teatree_core/test_workspace_group_wiring.py
+++ b/tests/teatree_core/test_workspace_group_wiring.py
@@ -1,0 +1,49 @@
+"""The ``t3 <overlay> workspace`` group must re-expose every core subcommand.
+
+The overlay CLI bridges ``t3 <overlay> workspace <sub>`` through the static
+``DJANGO_GROUPS['workspace']`` catalogue in :mod:`teatree.cli.django_groups`.
+That catalogue is hand-maintained, so a core ``@command`` added to the
+``workspace`` management command without a matching catalogue entry is silently
+unreachable through ``t3 <overlay>`` — the documented
+``t3 <overlay> workspace reclaim-disk`` was exactly this gap.
+
+These tests pin the catalogue to the management command's actual registered
+subcommands so the next omission turns the suite red instead of shipping a
+documented-but-unreachable command.
+"""
+
+import pytest
+from django.test import SimpleTestCase
+
+from teatree.cli.django_groups import DJANGO_GROUPS
+from teatree.core.management.commands.workspace import Command
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:In Typer, only the parameter 'autocompletion' is supported.*:DeprecationWarning",
+)
+
+
+def _catalogue_subcommands() -> set[str]:
+    return {name for name, _help in DJANGO_GROUPS["workspace"].subcommands}
+
+
+def _core_subcommands() -> set[str]:
+    """Every subcommand the core ``workspace`` management command registers."""
+    return {
+        (cmd.name or (cmd.callback.__name__ if cmd.callback else "")).replace("_", "-")
+        for cmd in Command.typer_app.registered_commands
+        if cmd.name or cmd.callback
+    }
+
+
+class WorkspaceGroupWiringTest(SimpleTestCase):
+    def test_reclaim_disk_is_wired(self) -> None:
+        assert "reclaim-disk" in _catalogue_subcommands()
+
+    def test_catalogue_covers_every_core_subcommand(self) -> None:
+        missing = _core_subcommands() - _catalogue_subcommands()
+        assert not missing, f"workspace group omits core subcommands: {sorted(missing)}"
+
+    def test_catalogue_lists_no_phantom_subcommand(self) -> None:
+        phantom = _catalogue_subcommands() - _core_subcommands()
+        assert not phantom, f"workspace group lists subcommands core does not define: {sorted(phantom)}"


### PR DESCRIPTION
## Summary

The overlay CLI bridges `t3 <overlay> workspace <sub>` through the static
`DJANGO_GROUPS['workspace']` catalogue in `teatree.cli.django_groups`. That
catalogue is hand-maintained and had drifted from the core `workspace`
management command: it omitted `reclaim-disk`, `reap-stale`, `landscape`, and
`stamp-identity`. The documented `t3 <overlay> workspace reclaim-disk` (the
sanctioned disk-reclaim path the `/t3:workspace` skill tells the agent to run)
was therefore unreachable through the overlay — `No such command 'reclaim-disk'`.

This adds the four missing entries and pins the catalogue to the management
command's actually-registered subcommands, so the next omission fails the suite
instead of shipping a documented-but-unreachable command.

## Architecture pre-check

### 1. BLUEPRINT § alignment
`§6 Overlay System` / the overlay CLI proxy layer. The catalogue
(`DJANGO_GROUPS`) is the static description of every `t3 <overlay> <group> <sub>`
tree; this restores parity between the `workspace` group and the core command it
proxies. No BLUEPRINT change needed — `reclaim-disk` is already documented at
§ "Safe disk reclaim" (#2246) and the generated management-commands doc already
lists it (it reads the core command directly).

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition touched.

### 3. Extension-point contracts
No `OverlayBase`/scanner/hook/Protocol surface changed. The catalogue feeds
`OverlayAppBuilder._bridge_subcommand`, which forwards each listed subcommand to
the overlay `manage.py workspace <sub>`. The `workspace` group has no
`core_dispatch`, so the four new leaves route through the overlay's manage.py
(correct — none needs the control DB).

### 4. Component boundaries
`src/teatree/cli/django_groups.py` — the data catalogue. Pure data change, no
business logic.

### 5. Dependency direction
No new import. `tach` boundary unaffected (data-only edit to an existing module).

### 6. Test surface
`tests/teatree_core/test_workspace_group_wiring.py`:
- `test_reclaim_disk_is_wired` — the documented command is in the catalogue.
- `test_catalogue_covers_every_core_subcommand` — anti-vacuous: compares the
  catalogue against `Command.typer_app.registered_commands`, so any future core
  subcommand added without a catalogue entry turns this red.
- `test_catalogue_lists_no_phantom_subcommand` — the catalogue never lists a
  command core does not define.

Observed RED before the fix (catalogue omitted `landscape`, `reap-stale`,
`reclaim-disk`, `stamp-identity`), GREEN after. The integration backstop
`test_cli_command_literals_resolve.py` + introspection confirm all four resolve
as overlay proxy leaves (`t3 <overlay> workspace reclaim-disk` resolves).

### 7. Resilience invariants
n/a — no external write introduced.

### 8. Identity and key normalization
n/a.

### 9. Behavior preservation / capability deletion
Purely additive — four catalogue entries added, nothing removed or narrowed.
