### PR TITLE
fix(eval): grade a CLI-mislabeled success result GREEN, not error

### DIFF
--- a/src/teatree/eval/sdk_runner.py
+++ b/src/teatree/eval/sdk_runner.py
@@ -278,6 +278,23 @@ class _TerminalResultError(Exception):
         self.cause = cause
 
 
+class _SuccessMislabelResultError(Exception):
+    """A finished SUCCESS the CLI mislabeled by exiting non-zero on a ``"success"`` subtype.
+
+    The captured ``result`` event already reads ``subtype="success"`` but also
+    carries a stray ``is_error=True`` (the CLI exited non-zero), so grading the
+    trajectory as-is would force a finished, all-matchers-pass run to FAIL on the
+    flag alone. Carries the captured trajectory so the runner can grade the REAL
+    messages and clear ``is_error`` — the same correction
+    :meth:`SdkInProcessRunner._terminal_capped_run` applies to a capped run.
+    """
+
+    def __init__(self, *, messages: list[Message], cause: Exception) -> None:
+        super().__init__(str(cause))
+        self.messages = messages
+        self.cause = cause
+
+
 class ClaudeCliMissingError(RuntimeError):
     """Raised when ``claude`` is not on PATH while the all-skipped gate is armed.
 
@@ -424,6 +441,8 @@ class SdkInProcessRunner:
             return self._terminal_run(spec, terminal_reason="timeout")
         except _TerminalResultError as terminal:
             return self._terminal_capped_run(spec, terminal)
+        except _SuccessMislabelResultError as mislabel:
+            return self._success_mislabel_run(spec, mislabel)
         return _eval_run_from_messages(spec, messages)
 
     def _terminal_capped_run(self, spec: EvalSpec, terminal: _TerminalResultError) -> EvalRun:
@@ -455,6 +474,22 @@ class SdkInProcessRunner:
             is_error=False,
             cost_usd=cost,
         )
+
+    @staticmethod
+    def _success_mislabel_run(spec: EvalSpec, mislabel: _SuccessMislabelResultError) -> EvalRun:
+        """Grade a finished SUCCESS the CLI mislabeled by exiting non-zero.
+
+        The captured ``result`` event reads ``subtype="success"`` but carries a
+        stray ``is_error=True`` (the CLI exited non-zero on the success subtype).
+        Grade the REAL trajectory via :func:`_eval_run_from_messages` so the
+        matchers decide pass/fail, then clear ``is_error`` — exactly the correction
+        :meth:`_terminal_capped_run` applies — so a finished, all-matchers-pass run
+        is not forced to FAIL on the flag alone (:attr:`ScenarioResult.passed` fails
+        on ``is_error`` BEFORE consulting matchers). The ``terminal_reason`` already
+        reads ``success`` and is left untouched — this is a finished run, not a cap.
+        """
+        graded = _eval_run_from_messages(spec, mislabel.messages)
+        return dataclasses.replace(graded, is_error=False)
 
     async def _drive(self, spec: EvalSpec, *, system_prompt: str, max_turns: int) -> list[Message]:
         variant = parse_model_variant(spec.model)
@@ -522,9 +557,10 @@ async def _collect(prompt: str, options: ClaudeAgentOptions) -> list[Message]:
     ``AssistantMessage`` (with its tool calls) the agent produced before hitting
     the cap. On a KNOWN terminal cap the partial list is re-raised inside a
     :class:`_TerminalResultError` for the runner to grade; a SUCCESS mislabeled as
-    an error result (the CLI exited non-zero on a ``"success"`` subtype) is graded
-    from the captured messages, not raised; any other error re-raises unchanged so
-    a genuine crash is never swallowed.
+    an error result (the CLI exited non-zero on a ``"success"`` subtype) is
+    re-raised inside a :class:`_SuccessMislabelResultError` so the runner grades the
+    captured messages AND clears the stray ``is_error``; any other error re-raises
+    unchanged so a genuine crash is never swallowed.
     """
     messages: list[Message] = []
     try:
@@ -535,7 +571,7 @@ async def _collect(prompt: str, options: ClaudeAgentOptions) -> list[Message]:
             messages.append(message)  # noqa: PERF401 — partial list must survive a mid-iteration Exception
     except Exception as exc:
         if is_success_result_error(str(exc)):
-            return messages
+            raise _SuccessMislabelResultError(messages=messages, cause=exc) from exc
         reason = classify_terminal_error(str(exc))
         if reason is None:
             raise

--- a/tests/teatree_eval/test_sdk_runner.py
+++ b/tests/teatree_eval/test_sdk_runner.py
@@ -869,15 +869,17 @@ class TestSuccessResultIsNotAnError:
         assert is_success_result_error("Claude Code returned an error result: error_max_turns") is False
 
     def test_success_labeled_error_after_a_result_grades_as_a_normal_run(self, tmp_path: Path) -> None:
-        # The SUCCESS ResultMessage reached the consumer before the spurious error,
-        # so the run grades from the captured trajectory: success, not error.
+        # The production case: the CLI exits non-zero on a ``"success"`` subtype, so
+        # the captured ``result`` event carries BOTH ``subtype="success"`` AND
+        # ``is_error=True``. The run must still grade from the captured trajectory as
+        # a success — ``is_error`` cleared — not be forced to FAIL on the stray flag.
         spec = _spec(tmp_path)
         messages = [
             AssistantMessage(
                 content=[ToolUseBlock(id="t1", name="Bash", input={"command": "git worktree add ../wt HEAD"})],
                 model="haiku",
             ),
-            _result(subtype="success", total_cost_usd=0.0321),
+            _result(subtype="success", is_error=True, total_cost_usd=0.0321),
         ]
         query = _yield_then_raise_query(messages, "Claude Code returned an error result: success")
         run = self._run_with_query(spec, query)
@@ -888,8 +890,9 @@ class TestSuccessResultIsNotAnError:
         assert run.cost_usd == pytest.approx(0.0321)
 
     def test_success_labeled_run_grades_through_report_evaluate(self, tmp_path: Path) -> None:
-        # The deliverable shape: a success-labeled run produces a normal graded
-        # ScenarioResult (not a crash), with the matcher deciding pass/fail.
+        # The deliverable shape: a success-labeled run whose captured result carries
+        # the stray ``is_error=True`` still produces a normal graded ScenarioResult
+        # (not a forced FAIL), with the matcher deciding pass/fail.
         from teatree.eval.report import evaluate  # noqa: PLC0415
 
         spec = _spec(tmp_path)
@@ -898,7 +901,7 @@ class TestSuccessResultIsNotAnError:
                 content=[ToolUseBlock(id="t1", name="Bash", input={"command": "git worktree add ../wt HEAD"})],
                 model="haiku",
             ),
-            _result(subtype="success", total_cost_usd=0.01),
+            _result(subtype="success", is_error=True, total_cost_usd=0.01),
         ]
         query = _yield_then_raise_query(messages, "Claude Code returned an error result: success")
         run = self._run_with_query(spec, query)


### PR DESCRIPTION
## Summary

Fixes an eval **grader** defect that false-REDs a passing metered scenario.

A metered run can finish with a `result` event whose subtype reads `"success"` while the bundled `claude` CLI exits non-zero, so the captured `result` carries a stray `is_error=True`. `is_success_result_error()` already recognizes this and returns the captured messages instead of raising — but the success-mislabel path then graded through `_eval_run_from_messages`, which re-extracts `is_error=True` from the synthesized success result. `ScenarioResult.passed` fails the run on `is_error` **before** consulting the matchers, so a finished run whose matchers ALL pass was graded `passed=false`.

The capped-run path (`_terminal_capped_run`) already clears `is_error` on its synthesized run for exactly this reason; the success-mislabel path did not. This is a grader correctness fix, not a behavior change: the matchers still gate behavior — only the stray flag no longer fails a finished, all-matchers-pass run.

## What changed

- `_collect` now re-raises a dedicated `_SuccessMislabelResultError` (carrying the captured trajectory) for the success-mislabel case, instead of returning the messages indistinguishably from a clean success.
- `run()` catches it and grades via the new `_success_mislabel_run`, which grades the real trajectory through `_eval_run_from_messages` then clears `is_error` — mirroring `_terminal_capped_run`. `terminal_reason` already reads `success` and is left untouched (this is a finished run, not a cap).
- De-vacuumed the two `TestSuccessResultIsNotAnError` fixtures: they built the success `ResultMessage` with the `_result` helper default `is_error=False`, so they never exercised the production case. Rebuilt with `is_error=True` so each is RED without the fix and GREEN with it.

## Anti-vacuity verification

With the final code but the `is_error` clear reverted, both de-vacuumed tests go RED:

```
FAILED test_success_labeled_error_after_a_result_grades_as_a_normal_run - assert True is False
FAILED test_success_labeled_run_grades_through_report_evaluate - assert False is True
```

Restoring the clear makes them GREEN. The genuine-error path (`test_a_genuine_error_result_still_propagates`) and the capped path are untouched and pass.

Eval suite: `360 passed`. The two affected modules and their DB-serialization siblings pass in isolation.

## Architecture pre-check

### 1. BLUEPRINT § alignment
Grader correctness inside the eval lane (`src/teatree/eval/`). No FSM/overlay/Protocol surface touched; no BLUEPRINT section contradicted.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition.

### 3. Extension-point contracts
n/a — no `OverlayBase`, scanner, hook, or `*Backend` Protocol touched.

### 4. Component boundaries
Stays in `src/teatree/eval/sdk_runner.py`. The new private exception and handler sit alongside the existing `_TerminalResultError` / `_terminal_capped_run` pair — same module, same seam.

### 5. Dependency direction
No new cross-module import (the new exception and handler are local to `sdk_runner.py`). No backwards edge introduced.

### 6. Test surface
`tests/teatree_eval/test_sdk_runner.py::TestSuccessResultIsNotAnError` — the two de-vacuumed fixtures assert `run.is_error is False` and `result.passed is True` for a `subtype="success" + is_error=True` captured result; both observed RED pre-fix.

### 7. Resilience invariants
n/a — no external write. Pure in-process grading correction.

### 8. Identity and key normalization
n/a — no identity with bare vs qualified forms.

### 9. Behavior preservation / capability deletion
Only the success-mislabel grading path changed (the bug). No must-block test inverted; the genuine-error propagation and capped paths are preserved. No privacy/leak/security matcher narrowed.
