### PR TITLE
fix(deps): floor pydantic-settings to 2.14.2 to clear advisory GHSA-4xgf-cpjx-pc3j

### DIFF
--- a/dist/sbom.json
+++ b/dist/sbom.json
@@ -527,7 +527,7 @@
     },
     {
       "bom-ref": "requirements-L106",
-      "description": "requirements line 106: pydantic-settings==2.14.1",
+      "description": "requirements line 106: pydantic-settings==2.14.2",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -536,9 +536,9 @@
         }
       ],
       "name": "pydantic-settings",
-      "purl": "pkg:pypi/pydantic-settings@2.14.1",
+      "purl": "pkg:pypi/pydantic-settings@2.14.2",
       "type": "library",
-      "version": "2.14.1"
+      "version": "2.14.2"
     },
     {
       "bom-ref": "requirements-L108",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -507,6 +507,13 @@ unresolved-attribute = "ignore"
 managed = true
 package = true
 
+# Floor a transitive dependency above a published advisory without promoting it
+# to a direct dependency. `pydantic-settings` is pulled in by `mcp`; versions
+# >= 2.12.0, < 2.14.2 carry GHSA-4xgf-cpjx-pc3j (NestedSecretsSettingsSource
+# follows symlinks outside secrets_dir). Patched in 2.14.2. Drop the entry once
+# `mcp` floors it itself.
+constraint-dependencies = [ "pydantic-settings>=2.14.2" ]
+
 # --- uv audit advisory lane (souliane/teatree#2292) ---
 # Allowlist for accepted advisories surfaced by the NON-BLOCKING `uv audit`
 # preview lane (CI job `uv-audit-advisory`). The advisory lane never reds the

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,9 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 
+[manifest]
+constraints = [{ name = "pydantic-settings", specifier = ">=2.14.2" }]
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -1976,16 +1979,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Floors the transitive dependency `pydantic-settings` to `2.14.2` to clear the published advisory **GHSA-4xgf-cpjx-pc3j** (medium), which started failing the blocking `uv-audit` (pip-audit) CI gate on every open PR.

## Why

`pydantic-settings` is pulled in transitively via `mcp`. Versions `>= 2.12.0, < 2.14.2` carry GHSA-4xgf-cpjx-pc3j: `NestedSecretsSettingsSource` follows symlinks outside `secrets_dir`, enabling local file read and bypassing `secrets_dir_max_size`. Patched in `2.14.2`.

Because the advisory was published after the lockfile resolved `2.14.1`, the `uv-audit` job began reding builds on PRs whose diffs do not touch dependencies at all. Merging this unblocks every open PR at once.

## How

- Add a `[tool.uv] constraint-dependencies` floor `pydantic-settings>=2.14.2` (keeps it transitive — not promoted to a direct dependency).
- `uv lock` re-resolves: `pydantic-settings 2.14.1 -> 2.14.2` (only package line changed in the lockfile).

## Verification

Reproduced the exact CI audit locally on the bumped tree:

```
uv export --no-default-groups --all-extras --format requirements-txt --no-emit-workspace --no-header --quiet > requirements.audit.txt
uvx pip-audit --strict --vulnerability-service osv --disable-pip -r requirements.audit.txt
# -> No known vulnerabilities found  (exit 0)
```

Drop the constraint once `mcp` floors `pydantic-settings` itself.
