### PR TITLE
fix(merge): dedupe required-checks rollup to newest per name

### DIFF
--- a/dist/sbom.json
+++ b/dist/sbom.json
@@ -527,7 +527,7 @@
     },
     {
       "bom-ref": "requirements-L106",
-      "description": "requirements line 106: pydantic-settings==2.14.1",
+      "description": "requirements line 106: pydantic-settings==2.14.2",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -536,9 +536,9 @@
         }
       ],
       "name": "pydantic-settings",
-      "purl": "pkg:pypi/pydantic-settings@2.14.1",
+      "purl": "pkg:pypi/pydantic-settings@2.14.2",
       "type": "library",
-      "version": "2.14.1"
+      "version": "2.14.2"
     },
     {
       "bom-ref": "requirements-L108",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -507,6 +507,13 @@ unresolved-attribute = "ignore"
 managed = true
 package = true
 
+# Floor a transitive dependency above a published advisory without promoting it
+# to a direct dependency. `pydantic-settings` is pulled in by `mcp`; versions
+# >= 2.12.0, < 2.14.2 carry GHSA-4xgf-cpjx-pc3j (NestedSecretsSettingsSource
+# follows symlinks outside secrets_dir). Patched in 2.14.2. Drop the entry once
+# `mcp` floors it itself.
+constraint-dependencies = [ "pydantic-settings>=2.14.2" ]
+
 # --- uv audit advisory lane (souliane/teatree#2292) ---
 # Allowlist for accepted advisories surfaced by the NON-BLOCKING `uv audit`
 # preview lane (CI job `uv-audit-advisory`). The advisory lane never reds the

--- a/src/teatree/core/merge/ci_rollup.py
+++ b/src/teatree/core/merge/ci_rollup.py
@@ -17,6 +17,7 @@ from teatree.core.backend_registry import get_backend_provider
 
 if TYPE_CHECKING:
     from teatree.core.backend_protocols import CodeHostBackend
+    from teatree.types import RawAPIDict
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +82,62 @@ class _RollupEntry(TypedDict, total=False):
     conclusion: object
     status: object
     state: object
+    name: object
+    context: object
+    startedAt: object
+    completedAt: object
+    createdAt: object
+
+
+def _check_identity(entry: _RollupEntry) -> tuple[str, str]:
+    """The dedupe key for one rollup entry: ``(typename, name)``.
+
+    GitHub branch protection keys the newest check-run per check NAME within a
+    namespace. A CheckRun's name is ``name``; a legacy StatusContext's name is
+    ``context``. The ``__typename`` is part of the key so a CheckRun and a
+    StatusContext that happen to share a name stay distinct identities (they are
+    different check kinds the forge tracks separately).
+    """
+    typename = str(entry.get("__typename") or "")
+    name = str(entry.get("name") or entry.get("context") or "")
+    return (typename, name)
+
+
+def _check_recency(entry: _RollupEntry) -> str:
+    """The recency key for one rollup entry — newest wins on dedupe.
+
+    CheckRun entries carry ISO-8601 ``completedAt`` / ``startedAt``; legacy
+    StatusContext entries carry ``createdAt``. The lexicographic order of an
+    ISO-8601 UTC timestamp is its chronological order, so plain string ``max``
+    selects the newest entry. A missing timestamp sorts oldest (empty string),
+    so a timestamped entry always supersedes an untimestamped one.
+    """
+    return str(entry.get("completedAt") or entry.get("startedAt") or entry.get("createdAt") or "")
+
+
+def _dedupe_newest_per_name(rollup: "list[RawAPIDict]") -> "list[RawAPIDict]":
+    """Reduce the rollup to the newest check-run per ``(typename, name)``.
+
+    Matches GitHub branch-protection semantics: a cancelled/stale run that left
+    a spurious FAILURE check-run on the head commit is superseded by a newer
+    SUCCESS for the same name and must not block the merge. Entries with no
+    identity (neither ``name`` nor ``context``) are kept as-is so a malformed
+    rollup still classifies fail-closed via the existing per-entry path.
+    """
+    newest: dict[tuple[str, str], RawAPIDict] = {}
+    unkeyed: list[RawAPIDict] = []
+    for raw in rollup:
+        if not isinstance(raw, dict):
+            continue
+        entry = cast("_RollupEntry", raw)
+        identity = _check_identity(entry)
+        if not identity[1]:
+            unkeyed.append(dict(raw))
+            continue
+        incumbent = newest.get(identity)
+        if incumbent is None or _check_recency(entry) >= _check_recency(cast("_RollupEntry", incumbent)):
+            newest[identity] = dict(raw)
+    return [*newest.values(), *unkeyed]
 
 
 def _classify_check(check: object) -> str:
@@ -127,6 +184,11 @@ def fetch_required_checks_status(slug: str, pr_id: int, *, host_kind: str = "git
     → ``failed``; an empty rollup means no required checks → ``green``. GitLab
     needs the head SHA to pick the right (non-merge-train) pipeline, fetched via
     :func:`fetch_live_head_sha`.
+
+    The GitHub rollup is first deduped to the newest check-run per
+    ``(typename, name)`` so a stale/cancelled FAILURE superseded by a newer
+    SUCCESS for the same name does not false-block the merge — parity with the
+    forge's own branch protection, which keys newest-per-context.
     """
     backend = _code_host_for(host_kind)
     rollup = backend.fetch_required_checks_rollup(slug=slug, pr_id=pr_id)
@@ -140,7 +202,8 @@ def fetch_required_checks_status(slug: str, pr_id: int, *, host_kind: str = "git
         if head is None:
             return "failed"
         return _classify_gitlab_pipeline(str(head.get("status") or ""))
-    statuses = [verdict for check in rollup if (verdict := _classify_check(check))]
+    deduped = _dedupe_newest_per_name(rollup)
+    statuses = [verdict for check in deduped if (verdict := _classify_check(check))]
     return _rollup_verdict(statuses) if statuses else "green"
 
 

--- a/tests/teatree_core/merge/test_ci_rollup.py
+++ b/tests/teatree_core/merge/test_ci_rollup.py
@@ -1,0 +1,258 @@
+"""GitHub required-checks rollup classification (BLUEPRINT §17.4.3 step 3).
+
+``fetch_required_checks_status`` re-verifies the live required-checks at merge
+time. GitHub branch protection keys the *newest* check-run per context name, so
+a cancelled/stale run that left a spurious FAILURE check-run on the same head
+commit must NOT block a merge that a newer SUCCESS for the same name supersedes.
+
+These tests pin that dedupe-newest-per-name semantics: the verdict is computed
+over the newest check-run per identity, matching ``mergeStateStatus=CLEAN`` the
+forge itself computes. Only the unstoppable external — the ``gh`` subprocess —
+is stubbed; the classification under test is real.
+"""
+
+import json
+from collections.abc import Callable
+from unittest.mock import patch
+
+from teatree.core.merge import fetch_required_checks_status
+from teatree.core.merge.ci_rollup import _dedupe_newest_per_name
+
+_SLUG = "souliane/teatree"
+_PR_ID = 2580
+
+
+def _gh_stub(rollup: list[dict[str, object]]) -> Callable[[list[str]], tuple[int, str, str]]:
+    """A ``gh`` runner that returns *rollup* for the statusCheckRollup query."""
+
+    def run(argv: list[str]) -> tuple[int, str, str]:
+        joined = " ".join(argv)
+        if "statusCheckRollup" in joined:
+            return (0, json.dumps(rollup), "")
+        return (0, "", "")
+
+    return run
+
+
+def _verdict(rollup: list[dict[str, object]]) -> str:
+    with patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_gh_stub(rollup)):
+        return fetch_required_checks_status(_SLUG, _PR_ID, host_kind="github")
+
+
+def _check_run(
+    name: str,
+    *,
+    status: str = "COMPLETED",
+    conclusion: str = "SUCCESS",
+    started_at: str,
+    completed_at: str,
+) -> dict[str, object]:
+    return {
+        "__typename": "CheckRun",
+        "name": name,
+        "status": status,
+        "conclusion": conclusion,
+        "startedAt": started_at,
+        "completedAt": completed_at,
+    }
+
+
+def _status_context(name: str, *, state: str, created_at: str) -> dict[str, object]:
+    return {
+        "__typename": "StatusContext",
+        "context": name,
+        "state": state,
+        "createdAt": created_at,
+    }
+
+
+class TestDedupeNewestPerName:
+    def test_stale_failure_superseded_by_newer_success_is_green(self) -> None:
+        # The PR #2580 incident: a cancelled stale-merge-ref run left
+        # sbom=FAILURE on the same head, while the authoritative newer run
+        # has sbom=SUCCESS. GitHub branch protection keys the newest per
+        # name, so mergeStateStatus is CLEAN — the verdict must be green.
+        rollup = [
+            _check_run(
+                "sbom",
+                conclusion="FAILURE",
+                started_at="2026-06-19T10:00:00Z",
+                completed_at="2026-06-19T10:05:00Z",
+            ),
+            _check_run(
+                "sbom",
+                conclusion="SUCCESS",
+                started_at="2026-06-19T11:00:00Z",
+                completed_at="2026-06-19T11:05:00Z",
+            ),
+        ]
+        assert _verdict(rollup) == "green"
+
+    def test_newest_entry_genuinely_failing_is_failed(self) -> None:
+        # An older SUCCESS superseded by a newer genuine FAILURE for the same
+        # name must still fail — newest wins in both directions.
+        rollup = [
+            _check_run(
+                "sbom",
+                conclusion="SUCCESS",
+                started_at="2026-06-19T10:00:00Z",
+                completed_at="2026-06-19T10:05:00Z",
+            ),
+            _check_run(
+                "sbom",
+                conclusion="FAILURE",
+                started_at="2026-06-19T11:00:00Z",
+                completed_at="2026-06-19T11:05:00Z",
+            ),
+        ]
+        assert _verdict(rollup) == "failed"
+
+    def test_newest_entry_pending_is_pending(self) -> None:
+        # An older SUCCESS superseded by a newer still-running run for the same
+        # name is pending — the head is not yet conclusively green.
+        rollup = [
+            _check_run(
+                "build",
+                conclusion="SUCCESS",
+                started_at="2026-06-19T10:00:00Z",
+                completed_at="2026-06-19T10:05:00Z",
+            ),
+            _check_run(
+                "build",
+                status="IN_PROGRESS",
+                conclusion="",
+                started_at="2026-06-19T11:00:00Z",
+                completed_at="",
+            ),
+        ]
+        assert _verdict(rollup) == "pending"
+
+    def test_mixed_checkrun_and_status_context_dedupe_each_namespace(self) -> None:
+        # A CheckRun named "lint" (stale FAILURE → newer SUCCESS) and a
+        # StatusContext named "coverage" (stale failure → newer success) both
+        # dedupe within their own namespace; the verdict is green.
+        rollup = [
+            _check_run(
+                "lint",
+                conclusion="FAILURE",
+                started_at="2026-06-19T10:00:00Z",
+                completed_at="2026-06-19T10:05:00Z",
+            ),
+            _check_run(
+                "lint",
+                conclusion="SUCCESS",
+                started_at="2026-06-19T11:00:00Z",
+                completed_at="2026-06-19T11:05:00Z",
+            ),
+            _status_context("coverage", state="FAILURE", created_at="2026-06-19T10:00:00Z"),
+            _status_context("coverage", state="SUCCESS", created_at="2026-06-19T11:00:00Z"),
+        ]
+        assert _verdict(rollup) == "green"
+
+    def test_status_context_stale_failure_superseded_by_newer_success_is_green(self) -> None:
+        rollup = [
+            _status_context("legacy-ci", state="FAILURE", created_at="2026-06-19T10:00:00Z"),
+            _status_context("legacy-ci", state="SUCCESS", created_at="2026-06-19T11:00:00Z"),
+        ]
+        assert _verdict(rollup) == "green"
+
+    def test_distinct_names_each_failing_still_failed(self) -> None:
+        # Two genuinely distinct failing checks (different names) must both
+        # count — dedupe must not collapse distinct names into one.
+        rollup = [
+            _check_run(
+                "sbom",
+                conclusion="SUCCESS",
+                started_at="2026-06-19T10:00:00Z",
+                completed_at="2026-06-19T10:05:00Z",
+            ),
+            _check_run(
+                "tests",
+                conclusion="FAILURE",
+                started_at="2026-06-19T10:00:00Z",
+                completed_at="2026-06-19T10:05:00Z",
+            ),
+        ]
+        assert _verdict(rollup) == "failed"
+
+    def test_checkrun_and_status_context_same_name_are_distinct_identities(self) -> None:
+        # A CheckRun named "x" (SUCCESS) and a StatusContext named "x"
+        # (FAILURE) are different identities (different __typename), so the
+        # FAILURE is NOT superseded by the CheckRun — verdict is failed.
+        rollup = [
+            _check_run(
+                "x",
+                conclusion="SUCCESS",
+                started_at="2026-06-19T11:00:00Z",
+                completed_at="2026-06-19T11:05:00Z",
+            ),
+            _status_context("x", state="FAILURE", created_at="2026-06-19T10:00:00Z"),
+        ]
+        assert _verdict(rollup) == "failed"
+
+    def test_dedupe_is_order_independent_newest_success_first(self) -> None:
+        # Same incident as the first test but the newer SUCCESS is listed
+        # BEFORE the stale FAILURE — the incumbent (newer) must not be
+        # clobbered by an older entry encountered later. Verdict stays green.
+        rollup = [
+            _check_run(
+                "sbom",
+                conclusion="SUCCESS",
+                started_at="2026-06-19T11:00:00Z",
+                completed_at="2026-06-19T11:05:00Z",
+            ),
+            _check_run(
+                "sbom",
+                conclusion="FAILURE",
+                started_at="2026-06-19T10:00:00Z",
+                completed_at="2026-06-19T10:05:00Z",
+            ),
+        ]
+        assert _verdict(rollup) == "green"
+
+
+class TestDedupeHelperEdgeCases:
+    """Defensive branches of ``_dedupe_newest_per_name`` reached directly.
+
+    The backend pre-filters non-dicts out of the rollup, so these shapes do
+    not reach the helper through the public ``fetch_required_checks_status``
+    path — but the helper is defensive in its own right, so its guards are
+    exercised here.
+    """
+
+    def test_non_dict_entry_is_skipped(self) -> None:
+        rollup = [
+            "not-a-dict",
+            _check_run(
+                "sbom",
+                conclusion="SUCCESS",
+                started_at="2026-06-19T11:00:00Z",
+                completed_at="2026-06-19T11:05:00Z",
+            ),
+        ]
+        deduped = _dedupe_newest_per_name(rollup)
+        assert deduped == [
+            {
+                "__typename": "CheckRun",
+                "name": "sbom",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "startedAt": "2026-06-19T11:00:00Z",
+                "completedAt": "2026-06-19T11:05:00Z",
+            },
+        ]
+
+    def test_entry_with_no_identity_is_kept_unkeyed(self) -> None:
+        # An entry with neither name nor context cannot be deduped — it is
+        # kept verbatim so the per-entry classifier still sees it (fail-closed).
+        nameless = {"__typename": "CheckRun", "conclusion": "FAILURE", "status": "COMPLETED"}
+        keyed = _check_run(
+            "sbom",
+            conclusion="SUCCESS",
+            started_at="2026-06-19T11:00:00Z",
+            completed_at="2026-06-19T11:05:00Z",
+        )
+        deduped = _dedupe_newest_per_name([keyed, nameless])
+        assert nameless in deduped
+        assert keyed in deduped
+        assert len(deduped) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,9 @@ resolution-markers = [
     "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 
+[manifest]
+constraints = [{ name = "pydantic-settings", specifier = ">=2.14.2" }]
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -1976,16 +1979,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The keystone's live required-checks re-verification (`fetch_required_checks_status` in `src/teatree/core/merge/ci_rollup.py`, read via `gh pr view --json statusCheckRollup`) classified the verdict over **every** rollup entry. So a stale/cancelled CI run that left a spurious `FAILURE` check-run on the same head commit false-blocked the keystone merge — even though GitHub's own branch protection (which keys the newest check-run per context name) computed `mergeStateStatus=CLEAN`.

This dedupes the rollup to the **newest check-run per `(typename, name)`** before classifying, matching branch-protection semantics. A stale/cancelled `FAILURE` superseded by a newer `SUCCESS` for the same name no longer fails the verdict.

- `CheckRun` entries dedupe by `name` + `completedAt`/`startedAt`; `StatusContext` entries by `context` + `createdAt`.
- The two namespaces stay distinct — a `CheckRun` and a `StatusContext` sharing a name are not conflated (the `__typename` is part of the identity key).
- A genuinely-failing or still-pending **newest** entry still fails / pends — newest wins in both directions.
- ISO-8601 UTC timestamps compare lexicographically; a missing timestamp sorts oldest so a timestamped entry always supersedes an untimestamped one.
- GitHub path only; the GitLab path already selects the single head-SHA pipeline.

## Tests (TDD, anti-vacuous)

`tests/teatree_core/merge/test_ci_rollup.py` — RED before the fix (the three superseded-failure cases reported `failed`), GREEN after:

1. `sbom=FAILURE` (older) + `sbom=SUCCESS` (newer), same name → **green** (RED before fix).
2. genuinely-failing newest entry → still **failed**.
3. newest entry pending → **pending** (not green).
4. mixed `CheckRun` + `StatusContext` dedupe each namespace.

Plus control cases: distinct failing names still fail, same-name-different-typename stay distinct, order-independence, and helper edge cases (non-dict skip, identity-less entry kept unkeyed).

## Architecture pre-check — ci_rollup dedupe-newest-per-name

**1. BLUEPRINT § alignment** — §17.4.3 step 3 (live required-checks re-verification at merge time). The classification must match the forge's branch-protection newest-per-context semantics.

**2. FSM phase boundaries** — n/a. No `Ticket.State`/`Worktree.State` transition; a classifier-correctness fix inside the existing IN_REVIEW → MERGED pre-condition read.

**3. Extension-point contracts** — n/a. No `OverlayBase` / scanner / hook / Protocol change. `fetch_required_checks_rollup` still returns the raw rollup; only core's verdict classification changes.

**4. Component boundaries** — `src/teatree/core/merge/ci_rollup.py`. The GitHub rollup classification already lives here (core does the verdict, backend does raw I/O); the dedupe is verdict-classification logic → same module.

**5. Dependency direction** — no new cross-module imports; a pure helper (`_dedupe_newest_per_name`) added inside `ci_rollup.py`. `uv run tach check` → all modules validated.

**6. Test surface** — `tests/teatree_core/merge/test_ci_rollup.py`: direct calls to `fetch_required_checks_status` with a stubbed `gh` runner; each behaviour has a named assertion. New code at 100% line/branch coverage.

**7. Resilience invariants** — n/a. Read-only classification, no external write; the fetch is idempotent.

**8. Identity and key normalization** — the check identity is its NAME, fully qualified by `__typename`: `CheckRun` → `name`, `StatusContext` → `context`. Each namespace deduped by its own identity key; newest wins. No strip/split to force a comparison.

**9. Behavior preservation / capability deletion** — purely additive guard before classification. Existing `_classify_check` / `_rollup_verdict` logic unchanged for the deduped set. No must-block test inverted; no privacy/security matcher narrowed. The only behaviour change is the bug fix: a stale failing entry superseded by a newer success for the same name no longer trips the verdict.

---

## Folds in the pydantic-settings advisory bump (breaks the merge deadlock)

This PR now also carries the advisory fix that originally lived on #2580 (`bump-pydantic-settings-advisory`), cherry-picked verbatim onto this branch:

- `fix(deps): floor pydantic-settings to 2.14.2 to clear advisory GHSA-4xgf-cpjx-pc3j` — adds a `[tool.uv] constraint-dependencies = ["pydantic-settings>=2.14.2"]` floor (pydantic-settings is transitive via `mcp`) and re-locks `uv.lock` (2.14.1 → 2.14.2).
- `fix(deps): regenerate SBOM for pydantic-settings 2.14.2` — regenerates `dist/sbom.json`.

### Why fold instead of merging #2580 first

The two PRs deadlocked: this PR failed only `uv-audit` because it branched off `origin/main`, which still carried the vulnerable `pydantic-settings 2.14.1`; #2580 *was* the advisory fix but was blocked by a stale cancelled-run `sbom` FAILURE on its head — exactly the false-block this PR's `ci_rollup` dedupe fixes. This PR's head is clean (no stale runs), so the keystone re-verification works for it, and folding the advisory bump in lets this PR pass `uv-audit` and merge first.

Once this lands, **#2580 should be closed as superseded** — its two commits are reproduced here.

### Local verification

- `uv export … | uvx pip-audit --strict --vulnerability-service osv --disable-pip -r requirements.audit.txt` → `No known vulnerabilities found` (`pydantic-settings==2.14.2` in the export).
- `git diff --exit-code dist/sbom.json` clean after re-running `scripts/hooks/generate_sbom.sh` on the merged tree.

docs: n/a — dependency floor + SBOM regen, no user-visible change.
