### PR TITLE
fix(ship): honor pr_title_override/--title in ship_preview preflight

### DIFF
--- a/src/teatree/core/management/commands/_pr_preview.py
+++ b/src/teatree/core/management/commands/_pr_preview.py
@@ -16,7 +16,13 @@ from typing import TypedDict
 
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay_loader import get_overlay
-from teatree.core.runners.ship import overlay_pr_labels, sanitize_close_keywords, should_close_ticket
+from teatree.core.runners.ship import (
+    PrTitleInputs,
+    overlay_pr_labels,
+    resolve_pr_title,
+    sanitize_close_keywords,
+    should_close_ticket,
+)
 from teatree.utils import git
 
 
@@ -34,57 +40,60 @@ class PrValidationError(TypedDict):
     details: list[str]
 
 
-def ship_preview(ticket: Ticket, worktree: Worktree) -> tuple[str, str, str]:
-    """Return ``(repo_path, title, description)`` previewed from the last commit.
+def ship_preview(ticket: Ticket, worktree: Worktree, *, title: str = "") -> tuple[str, str, str]:
+    """Return ``(repo_path, title, description)`` for the PR that will ship.
 
-    The title is PRODUCED by the overlay (``metadata.build_pr_title``), not
-    copied verbatim from the commit subject: an overlay enforcing a title
-    grammar assembles a canonical title from the branch + subject + ticket so
-    a non-canonical subject can never reach the MR. The default overlay hook
-    returns the subject unchanged, preserving prior behaviour.
+    The title is resolved through ``runners.ship.resolve_pr_title`` — the SAME
+    helper ``ShipExecutor._build_pr_spec`` uses — so the preview (and the
+    ``pr create`` preflight built on it) validate the title that will actually
+    ship, not a title regenerated from the commit subject. An explicit
+    ``--title`` (the ``title`` arg) wins, then a title pinned on
+    ``extra['pr_title_override']``, then the overlay-PRODUCED title
+    (``metadata.build_pr_title``, returning the subject unchanged by default),
+    then the ``Resolve <issue_url>`` fallback.
+
+    Honoring the override here is parity with ``_build_pr_spec``: ignoring it
+    made the preflight apply an overlay's title grammar (e.g. a customer-MR
+    requiring a GitLab issue URL) to the wrong title, false-failing a tooling
+    PR whose pinned title satisfied the grammar.
 
     The TITLE is sanitized first, then the description's first line is built
-    from that exact sanitized string. Applying close-keyword sanitization only
-    to the description (the old behaviour) silently diverged it from the title
-    whenever the title carried a close-keyword (e.g. the ``Resolve <url>``
-    fallback, or a ``fix: resolve X`` subject) — the title/description
-    divergence class. Reusing the sanitized title makes the first line ==
-    title by construction.
+    from that exact sanitized string, so the title and the description's first
+    line can never diverge (the release-notes-pipeline divergence guard).
     """
     repo_path = (worktree.extra or {}).get("worktree_path", "") or worktree.repo_path
     subject, body = git.last_commit_message(repo=repo_path)
     overlay = get_overlay()
-    generated = overlay.metadata.build_pr_title(
-        branch=worktree.branch or "",
-        subject=subject,
-        body=body or "",
-        issue_url=ticket.issue_url or "",
+    resolved = resolve_pr_title(
+        ticket,
+        ticket.extra or {},
+        PrTitleInputs(branch=worktree.branch or "", subject=subject, body=body or "", title_override=title),
     )
     close_ticket = should_close_ticket(
         ticket.extra or {},
         setting_enabled=overlay.config.mr_close_ticket,
     )
-    title = sanitize_close_keywords(generated or f"Resolve {ticket.issue_url}", close_ticket=close_ticket)
+    sanitized_title = sanitize_close_keywords(resolved, close_ticket=close_ticket)
     raw_body = sanitize_close_keywords(body, close_ticket=close_ticket) if body else ""
-    description = f"{title}\n\n{raw_body}" if raw_body else title
-    return repo_path, title, description
+    description = f"{sanitized_title}\n\n{raw_body}" if raw_body else sanitized_title
+    return repo_path, sanitized_title, description
 
 
-def ship_dry_run(ticket: Ticket, worktree: Worktree) -> ShipDryRun:
-    repo_path, title, description = ship_preview(ticket, worktree)
+def ship_dry_run(ticket: Ticket, worktree: Worktree, *, title: str = "") -> ShipDryRun:
+    repo_path, resolved_title, description = ship_preview(ticket, worktree, title=title)
     return ShipDryRun(
         dry_run=True,
         repo=repo_path,
         branch=worktree.branch,
-        title=title,
+        title=resolved_title,
         description=description,
         labels=overlay_pr_labels(),
     )
 
 
-def validate_pr_metadata(ticket: Ticket, worktree: Worktree) -> PrValidationError | None:
-    _, title, description = ship_preview(ticket, worktree)
-    validation = get_overlay().metadata.validate_pr(title, description)
+def validate_pr_metadata(ticket: Ticket, worktree: Worktree, *, title: str = "") -> PrValidationError | None:
+    _, resolved_title, description = ship_preview(ticket, worktree, title=title)
+    validation = get_overlay().metadata.validate_pr(resolved_title, description)
     if validation["errors"]:
         return PrValidationError(error="PR validation failed", details=validation["errors"])
     return None

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -108,6 +108,7 @@ def _run_ship_gates(
     worktree: Worktree,
     *,
     skip_visual_qa: str = "",
+    title: str = "",
 ) -> (
     ShippingGateFailure
     | VisualQAGateFailure
@@ -123,6 +124,12 @@ def _run_ship_gates(
     The branch-currency gate (#940) runs FIRST: a stale base would
     otherwise poison the visual-QA gate (it would render the
     pre-merge tree) and the cold reviewer's SHA attestation.
+
+    ``title`` is the explicit ``--title`` override: it has not yet been
+    persisted to ``extra['pr_title_override']`` (that happens at ship time,
+    after the gates pass), so it is threaded into ``validate_pr_metadata``
+    here — otherwise the preflight would validate the regenerated commit
+    subject rather than the title that will actually ship.
     """
     currency_error = _run_branch_currency_gate(ticket, worktree)
     if currency_error is not None:
@@ -147,7 +154,7 @@ def _run_ship_gates(
     e2e_error = _run_e2e_mandatory_gate(ticket)
     if e2e_error is not None:
         return e2e_error
-    return validate_pr_metadata(ticket, worktree)
+    return validate_pr_metadata(ticket, worktree, title=title)
 
 
 def _dispatch_ship(
@@ -164,7 +171,7 @@ def _dispatch_ship(
     inline; the default enqueues it for a worker (#708).
     """
     if dry_run:
-        return ship_dry_run(ticket, worktree)
+        return ship_dry_run(ticket, worktree, title=title)
     if sync:
         return _ship_sync(ticket, title)
     return _enqueue_ship(ticket, title)
@@ -275,7 +282,7 @@ class Command(TyperCommand):
             return no_commits
 
         if not skip_validation:
-            gate_failure = _run_ship_gates(ticket, ship_worktree, skip_visual_qa=skip_visual_qa)
+            gate_failure = _run_ship_gates(ticket, ship_worktree, skip_visual_qa=skip_visual_qa, title=title)
             if gate_failure is not None:
                 return gate_failure
         else:
@@ -290,7 +297,7 @@ class Command(TyperCommand):
             # not slip onto GitLab via the bypass; only the explicit
             # --skip-mr-format-check opt-in disables the format check too.
             if not skip_mr_format_check:
-                format_error = validate_pr_metadata(ticket, ship_worktree)
+                format_error = validate_pr_metadata(ticket, ship_worktree, title=title)
                 if format_error is not None:
                     return format_error
 

--- a/src/teatree/core/runners/ship.py
+++ b/src/teatree/core/runners/ship.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from collections.abc import Iterable, Mapping
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, NamedTuple, cast
 
 from teatree.config import get_effective_settings
 from teatree.core.backend_factory import code_host_for_repo_from_overlay
@@ -74,6 +74,46 @@ def should_close_ticket(extra: Mapping[str, object] | None, *, setting_enabled: 
         return False
     more_prs_coming = bool(extra and extra.get("more_prs_coming"))
     return not more_prs_coming
+
+
+class PrTitleInputs(NamedTuple):
+    """The commit/worktree-derived inputs an overlay PRODUCES a title from.
+
+    Grouped so ``resolve_pr_title`` keeps a small signature and both call sites
+    (the ship and the preview) assemble the same shape.
+    """
+
+    branch: str
+    subject: str
+    body: str
+    title_override: str = ""
+
+
+def resolve_pr_title(ticket: "Ticket", extra: Mapping[str, object] | None, inputs: PrTitleInputs) -> str:
+    """Resolve the title a PR will SHIP with — the single source of truth.
+
+    Both ``ShipExecutor._build_pr_spec`` (the actual ship) and ``ship_preview``
+    (the ``pr create`` preflight) call this, so the title the preflight
+    validates is always the title that will actually ship — they can no longer
+    drift. Precedence: an explicit ``--title`` (``inputs.title_override``) wins;
+    then a title pinned on ``extra['pr_title_override']``; then the
+    overlay-PRODUCED title (``metadata.build_pr_title``, which returns the
+    subject unchanged by default); then the ``Resolve <issue_url>`` fallback.
+
+    The returned title is NOT yet close-keyword-sanitized — each caller applies
+    ``sanitize_close_keywords`` so the description's first line is built from the
+    same sanitized string (the title/description divergence guard).
+    """
+    pinned = inputs.title_override or str((extra or {}).get("pr_title_override") or "")
+    if pinned:
+        return pinned
+    generated = get_overlay().metadata.build_pr_title(
+        branch=inputs.branch,
+        subject=inputs.subject,
+        body=inputs.body or "",
+        issue_url=ticket.issue_url or "",
+    )
+    return generated or f"Resolve {ticket.issue_url}"
 
 
 def overlay_pr_labels() -> list[str]:
@@ -369,18 +409,17 @@ class ShipExecutor(RunnerBase):
         branch: str,
         extra: "TicketExtra",
     ) -> PullRequestSpec:
-        title_override = str(extra.get("pr_title_override") or "")
         subject, body = git.last_commit_message(repo=repo_path)
         overlay = get_overlay()
-        # PRODUCE the title from structured data unless the user pinned one
-        # via --title. The overlay default returns the subject unchanged.
-        generated = overlay.metadata.build_pr_title(
-            branch=branch,
-            subject=subject,
-            body=body or "",
-            issue_url=ticket.issue_url or "",
+        # PRODUCE the title via the shared resolver so the ship and the
+        # ``ship_preview`` preflight agree on what will ship: a pinned
+        # ``--title`` / ``extra['pr_title_override']`` wins, else the
+        # overlay-produced title, else the ``Resolve <url>`` fallback.
+        title = resolve_pr_title(
+            ticket,
+            extra,
+            PrTitleInputs(branch=branch, subject=subject, body=body or ""),
         )
-        title = title_override or generated or f"Resolve {ticket.issue_url}"
         close_ticket = should_close_ticket(
             extra,
             setting_enabled=overlay.config.mr_close_ticket,

--- a/tests/teatree_core/test_pr_preview.py
+++ b/tests/teatree_core/test_pr_preview.py
@@ -4,12 +4,13 @@ Split out of ``test_pr_command`` alongside the ``_pr_preview`` module split:
 test files mirror the production module path.
 """
 
+from typing import TypedDict
 from unittest.mock import patch
 
 from django.test import TestCase
 
 from teatree.core.management.commands import _pr_preview
-from teatree.core.management.commands._pr_preview import ship_preview
+from teatree.core.management.commands._pr_preview import ship_preview, validate_pr_metadata
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay import OverlayMetadata
 from tests.teatree_core.conftest import CommandOverlay
@@ -26,6 +27,36 @@ class _GeneratingMetadata(OverlayMetadata):
 
 class _GenOverlay(CommandOverlay):
     metadata = _GeneratingMetadata()
+
+
+class _ValidationResult(TypedDict):
+    errors: list[str]
+    warnings: list[str]
+
+
+class _IssueUrlFirstLineMetadata(OverlayMetadata):
+    """Customer-MR grammar: the title MUST reference a GitLab issue URL.
+
+    Mirrors a downstream customer overlay's ``validate_pr``, which rejects any
+    title that does not carry a ``…/-/issues/<n>`` reference. A
+    tooling/non-customer PR with an explicit ``--title`` / ``pr_title_override``
+    must validate the title that will actually ship — not the regenerated
+    commit subject — so the override clears (or, for a tooling title, fails)
+    the preflight against the title it will actually use.
+    """
+
+    def validate_pr(self, title: str, description: str) -> _ValidationResult:
+        _ = description
+        if "/-/issues/" not in title:
+            return _ValidationResult(
+                errors=[f"PR title must reference a GitLab issue URL (got: {title!r})"],
+                warnings=[],
+            )
+        return _ValidationResult(errors=[], warnings=[])
+
+
+class _CustomerGrammarOverlay(CommandOverlay):
+    metadata = _IssueUrlFirstLineMetadata()
 
 
 class TestShipPreviewTitleDescriptionInvariant(TestCase):
@@ -142,3 +173,154 @@ class TestShipPreviewUsesOverlayGeneratedTitle(TestCase):
             _, title, description = ship_preview(ticket, ticket.worktrees.first())
         assert title == "fix(corridor): canonical generated title [none] (proj#119)"
         assert description.split("\n", 1)[0] == title
+
+
+class TestShipPreviewHonorsTitleOverride(TestCase):
+    """``ship_preview`` must use the pinned title, not the regenerated subject.
+
+    Parity with ``ShipExecutor._build_pr_spec`` (``runners/ship.py``): a title
+    pinned via ``ticket.extra['pr_title_override']`` (or an explicit ``--title``)
+    is the title that will actually ship, so the preview — and therefore the
+    preflight validation built on it — must reflect it. Regenerating the title
+    from the last commit subject and ignoring the override makes the preflight
+    validate a title that is NOT the one that ships.
+    """
+
+    def _ticket_with_worktree(self, *, extra: dict[str, str] | None = None) -> Ticket:
+        ticket = Ticket.objects.create(
+            overlay="test",
+            state=Ticket.State.REVIEWED,
+            issue_url="https://github.com/souliane/teatree/issues/298",
+            extra=extra or {},
+        )
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="/tmp/backend",
+            branch="298-fix-thing",
+            extra={"worktree_path": "/tmp/backend"},
+        )
+        return ticket
+
+    def test_pr_title_override_replaces_regenerated_subject(self) -> None:
+        ticket = self._ticket_with_worktree(extra={"pr_title_override": "fix(scope): pinned title (#298)"})
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(
+                _pr_preview.git,
+                "last_commit_message",
+                return_value=("chore: some unrelated subject (#298)", "Body."),
+            ),
+        ):
+            _, title, description = ship_preview(ticket, ticket.worktrees.first())
+        assert title == "fix(scope): pinned title (#298)"
+        assert description.split("\n", 1)[0] == title
+
+    def test_explicit_title_argument_replaces_regenerated_subject(self) -> None:
+        ticket = self._ticket_with_worktree()
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(
+                _pr_preview.git,
+                "last_commit_message",
+                return_value=("chore: some unrelated subject (#298)", "Body."),
+            ),
+        ):
+            _, title, description = ship_preview(
+                ticket, ticket.worktrees.first(), title="fix(scope): explicit flag title (#298)"
+            )
+        assert title == "fix(scope): explicit flag title (#298)"
+        assert description.split("\n", 1)[0] == title
+
+    def test_explicit_title_argument_wins_over_stored_override(self) -> None:
+        ticket = self._ticket_with_worktree(extra={"pr_title_override": "fix(scope): stored title (#298)"})
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(
+                _pr_preview.git,
+                "last_commit_message",
+                return_value=("chore: subject (#298)", "Body."),
+            ),
+        ):
+            _, title, _ = ship_preview(ticket, ticket.worktrees.first(), title="fix(scope): flag wins (#298)")
+        assert title == "fix(scope): flag wins (#298)"
+
+
+class TestValidatePrMetadataHonorsTitleOverride(TestCase):
+    """The preflight must validate the title that will actually ship.
+
+    The customer-MR grammar (``_IssueUrlFirstLineMetadata``) rejects any title
+    that does not reference a GitLab issue URL. A tooling PR's commit subject
+    (``fix(scope): …``) lacks that reference, so regenerating the title from the
+    subject false-fails the preflight — the bug a downstream customer PR hit.
+    With an explicit ``--title`` (or ``pr_title_override``) carrying the issue
+    URL, the preflight must validate THAT title and pass.
+    """
+
+    def _ticket_with_worktree(self, *, extra: dict[str, str] | None = None) -> Ticket:
+        ticket = Ticket.objects.create(
+            overlay="test",
+            state=Ticket.State.REVIEWED,
+            issue_url="https://gitlab.example.com/group/repo/-/issues/298",
+            extra=extra or {},
+        )
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="/tmp/backend",
+            branch="298-fix-thing",
+            extra={"worktree_path": "/tmp/backend"},
+        )
+        return ticket
+
+    def test_regenerated_subject_false_fails_customer_grammar(self) -> None:
+        # Documents the bug: with NO override, the title is the commit subject,
+        # which the customer grammar rejects.
+        ticket = self._ticket_with_worktree()
+        with (
+            patch(
+                "teatree.core.overlay_loader._discover_overlays",
+                return_value={"test": _CustomerGrammarOverlay()},
+            ),
+            patch.object(
+                _pr_preview.git,
+                "last_commit_message",
+                return_value=("fix(scope): tooling change with no issue url (#298)", "Body."),
+            ),
+        ):
+            error = validate_pr_metadata(ticket, ticket.worktrees.first())
+        assert error is not None
+
+    def test_explicit_title_with_issue_url_passes_preflight(self) -> None:
+        ticket = self._ticket_with_worktree()
+        pinned = "https://gitlab.example.com/group/repo/-/issues/298 fix(scope): tooling change"
+        with (
+            patch(
+                "teatree.core.overlay_loader._discover_overlays",
+                return_value={"test": _CustomerGrammarOverlay()},
+            ),
+            patch.object(
+                _pr_preview.git,
+                "last_commit_message",
+                return_value=("fix(scope): tooling change with no issue url (#298)", "Body."),
+            ),
+        ):
+            error = validate_pr_metadata(ticket, ticket.worktrees.first(), title=pinned)
+        assert error is None
+
+    def test_stored_override_with_issue_url_passes_preflight(self) -> None:
+        pinned = "https://gitlab.example.com/group/repo/-/issues/298 fix(scope): tooling change"
+        ticket = self._ticket_with_worktree(extra={"pr_title_override": pinned})
+        with (
+            patch(
+                "teatree.core.overlay_loader._discover_overlays",
+                return_value={"test": _CustomerGrammarOverlay()},
+            ),
+            patch.object(
+                _pr_preview.git,
+                "last_commit_message",
+                return_value=("fix(scope): tooling change with no issue url (#298)", "Body."),
+            ),
+        ):
+            error = validate_pr_metadata(ticket, ticket.worktrees.first())
+        assert error is None

--- a/tests/teatree_core/test_runners_ship.py
+++ b/tests/teatree_core/test_runners_ship.py
@@ -906,6 +906,64 @@ class TestShipExecutorHonorsAutoCloseSetting(TestCase):
         assert "Closes #873" not in description
 
 
+class TestShipExecutorHonorsTitleOverride(TestCase):
+    """The ship path PRODUCES the title via the shared ``resolve_pr_title``.
+
+    A title pinned on ``extra['pr_title_override']`` is what ships — the same
+    title ``ship_preview`` previews and the preflight validates. This is the
+    ship-side half of the title-resolution parity; ``test_pr_preview`` covers
+    the preview/preflight side.
+    """
+
+    def _ticket_with_extra(self, extra: dict) -> Ticket:
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://github.com/souliane/teatree/issues/298",
+            extra=extra,
+        )
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="/tmp/repo298",
+            branch="298-fix-thing",
+            extra={"worktree_path": "/tmp/repo298"},
+        )
+        return ticket
+
+    def _capture_pr_title(self, ticket: Ticket) -> str:
+        host = MagicMock()
+        host.create_pr.return_value = {"html_url": "https://github.com/souliane/teatree/pull/1"}
+        host.current_user.return_value = "souliane"
+        cfg = MagicMock()
+        cfg.config.mr_close_ticket = True
+        cfg.config.pr_auto_labels = []
+        cfg.metadata.build_pr_title.side_effect = lambda *, branch, subject, body, issue_url: subject
+        with (
+            patch("teatree.core.runners.ship.code_host_for_repo_from_overlay", return_value=host),
+            patch("teatree.core.runners.ship.get_overlay", return_value=cfg),
+            patch("teatree.core.runners.ship.overlay_pr_labels", return_value=[]),
+            patch("teatree.core.runners.ship.git.branch_merged", return_value=False),
+            patch("teatree.core.runners.ship.git.push"),
+            patch(
+                "teatree.core.runners.ship.git.last_commit_message",
+                return_value=("chore: unrelated subject (#298)", "Body."),
+            ),
+            patch("teatree.core.runners.ship.git.config_value", return_value="souliane"),
+        ):
+            ShipExecutor(ticket).run()
+        return host.create_pr.call_args[0][0].title
+
+    def test_pr_title_override_is_the_shipped_title(self) -> None:
+        ticket = self._ticket_with_extra({"pr_title_override": "fix(scope): pinned title (#298)"})
+        title = self._capture_pr_title(ticket)
+        assert title == "fix(scope): pinned title (#298)"
+
+    def test_no_override_falls_back_to_subject(self) -> None:
+        ticket = self._ticket_with_extra({})
+        title = self._capture_pr_title(ticket)
+        assert title == "chore: unrelated subject (#298)"
+
+
 class TestOverlayPrLabels:
     def test_default_overlay_returns_empty(self) -> None:
         with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):


### PR DESCRIPTION
## What

`ship_preview` / `validate_pr_metadata` (the `pr create` preflight) regenerated the PR title from the last commit subject and **ignored** `--title` and `ticket.extra['pr_title_override']` — unlike `ShipExecutor._build_pr_spec` (the actual ship), which honors the override. So the preflight validated a title that is **not** the one that ships. On an overlay with a customer-MR title grammar (e.g. a title that must reference a GitLab issue URL), the regenerated tooling-PR subject false-failed the grammar even though the pinned override satisfied it.

## Why

The fix gives the preflight parity with the ship so both validate and produce the same title.

- Extract a single shared `resolve_pr_title()` in `runners/ship.py` (precedence: explicit `--title` > `extra['pr_title_override']` > overlay-produced `build_pr_title` > `Resolve <issue_url>` fallback).
- Both call sites resolve the title through it — `_build_pr_spec` (ship) and `ship_preview` (preflight) — so they can no longer drift.
- Thread the explicit `--title` through `_run_ship_gates` and the `--skip-validation` path into `validate_pr_metadata`, since `--title` is not yet persisted to `extra['pr_title_override']` when the preflight runs.
- The title/description divergence guard is preserved: the description's first line is still built from the same sanitized title.

## Tests (TDD, anti-vacuous)

- `tests/teatree_core/test_pr_preview.py`: `ship_preview` uses `pr_title_override` / explicit `--title` (red before the fix — it regenerated from the commit subject); a tooling PR with an override title carrying an issue URL passes the preflight that previously false-failed the customer-MR grammar.
- `tests/teatree_core/test_runners_ship.py`: the ship path (`_build_pr_spec`) ships the override via the same shared helper.
- Anti-vacuity verified by neutralizing `resolve_pr_title`'s override branch and observing all override tests go red, then restoring.

## Architecture pre-check

1. **BLUEPRINT alignment**: §4 ShipExecutor / `pr create` gates. No FSM change.
2. **FSM phase boundaries**: n/a — no `Ticket.State` transition added or moved.
3. **Extension-point contracts**: reads `OverlayMetadata.build_pr_title` / `validate_pr` (unchanged); no ABC surface change, no overlay update needed.
4. **Component boundaries**: shared helper in `runners/ship.py` (core); `_pr_preview.py` (commands) imports it, matching the existing edge.
5. **Dependency direction**: commands -> core only; `uv run tach check` green.
6. **Test surface**: see Tests above. Anti-vacuous (red before / green after).
7. **Resilience invariants**: n/a — no new external write; pure title resolution, idempotent.
8. **Identity/key normalization**: n/a.
9. **Behavior preservation**: overlay-produced title, sanitization, the title/description divergence guard, and the `Resolve <url>` fallback are all preserved; the only added behavior is honoring the override for parity.
