### PR TITLE
fix(provision): per-repo branch resolution so split-branch repos provision as siblings (#33)

### DIFF
--- a/src/teatree/core/models/types.py
+++ b/src/teatree/core/models/types.py
@@ -51,6 +51,11 @@ class TicketExtra(TypedDict, total=False):
     reopened_from: str
     visual_qa: VisualQASummary
     branch: str
+    # #33 per-repo branch override map (repo → branch). A ticket whose repos
+    # live on DIFFERENT branches maps each one here; ``branch`` stays the
+    # single ticket-dir name so every repo provisions as a SIBLING in one dir.
+    # Repos absent from the map fall back to ``branch``.
+    branches: dict[str, str]
     description: str
     provision: dict[str, str]
     shipping_skipped: str

--- a/src/teatree/core/runners/provision.py
+++ b/src/teatree/core/runners/provision.py
@@ -23,6 +23,13 @@ class WorktreeProvisioner(RunnerBase):
     Reads ``ticket.repos`` and ``ticket.extra['branch']`` (set by the CLI at
     scope time) and materialises one ``Worktree`` row + on-disk git worktree
     per repo. Idempotent: re-running over an existing layout is a no-op.
+
+    #33: a ticket whose repos live on DIFFERENT branches maps each repo to its
+    own branch in ``ticket.extra['branches']`` (repo → branch); a repo absent
+    from the map falls back to ``extra['branch']``. The ticket DIR is always
+    ``extra['branch']`` regardless, so every repo provisions as a SIBLING in
+    one dir even when the repos are on split per-repo branches — this is what
+    lets an e2e / workspace-ticket stack compose split branches together.
     """
 
     def __init__(self, ticket: Ticket) -> None:
@@ -39,6 +46,12 @@ class WorktreeProvisioner(RunnerBase):
         if not branch:
             return RunnerResult(ok=False, detail="ticket.extra['branch'] not set — call scope() first")
 
+        # #33: a ticket whose repos live on DIFFERENT branches maps each one
+        # in ``extra['branches']``. The ticket DIR is always ``branch`` so all
+        # repos provision as SIBLINGS in one dir; only the per-repo git branch
+        # differs. Repos absent from the map fall back to ``branch``.
+        branches = dict(extra.get("branches") or {})
+
         workspace = _workspace_dir()
         ticket_dir = workspace / branch
         ticket_dir.mkdir(parents=True, exist_ok=True)
@@ -52,21 +65,23 @@ class WorktreeProvisioner(RunnerBase):
                 provisioned[repo_name] = (existing.extra or {})["worktree_path"]
                 continue
 
+            repo_branch = branches.get(repo_name, branch)
+
             worktree = existing or Worktree.objects.create(
                 ticket=ticket,
                 repo_path=repo_name,
-                branch=branch,
+                branch=repo_branch,
                 overlay=ticket.overlay,
             )
 
-            created = self._create(workspace, repo_name, ticket_dir, branch)
+            created = self._create(workspace, repo_name, ticket_dir, repo_branch)
             if created is None:
                 worktree.delete()
                 failed.append(repo_name)
                 continue
 
             wt_path, clone_path = created
-            worktree.branch = branch
+            worktree.branch = repo_branch
             worktree.extra = {
                 **(worktree.extra or {}),
                 "worktree_path": wt_path,

--- a/tests/teatree_core/test_runners_provision.py
+++ b/tests/teatree_core/test_runners_provision.py
@@ -221,6 +221,145 @@ class TestWorktreeProvisioner(TestCase):
         assert "branch" in result.detail.lower()
 
 
+class TestWorktreeProvisionerPerRepoBranches(TestCase):
+    """#33: a ticket whose repos live on DIFFERENT branches.
+
+    A ``ticket.extra['branches']`` map (repo → branch) lets each repo
+    provision on its own branch while all repos still land as SIBLINGS in
+    the ONE ticket dir (``extra['branch']``). Repos not listed in the map
+    fall back to ``extra['branch']``. Single-branch tickets (no map) are
+    unchanged. This unblocks composing split per-repo branches into one
+    e2e/workspace-ticket stack.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _tmp_workspace(self, tmp_path: Path) -> None:
+        self.workspace = tmp_path / "workspace"
+        self.workspace.mkdir()
+
+    def _patch_workspace_dir(self) -> Any:
+        return patch("teatree.core.runners.provision._workspace_dir", return_value=self.workspace)
+
+    def _make_clones(self, *repos: str) -> None:
+        for repo in repos:
+            repo_dir = self.workspace / repo
+            repo_dir.mkdir()
+            (repo_dir / ".git").mkdir()
+
+    def _run_capturing_branches(self, ticket: Ticket) -> tuple[Any, dict[str, str], list[str]]:
+        """Run the provisioner, capturing the branch passed to each ``git worktree add``."""
+        branch_by_dest: dict[str, str] = {}
+        created_paths: list[str] = []
+
+        def fake_worktree_add(repo: str, path: str, branch: str, *, create_branch: bool = True) -> bool:
+            del repo, create_branch
+            branch_by_dest[path] = branch
+            created_paths.append(path)
+            Path(path).mkdir(parents=True, exist_ok=True)
+            return True
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            self._patch_workspace_dir(),
+            patch("teatree.core.runners.provision.git.worktree_add", side_effect=fake_worktree_add),
+            patch("teatree.core.runners.provision.git.pull_ff_only", return_value=True),
+        ):
+            result = WorktreeProvisioner(ticket).run()
+        return result, branch_by_dest, created_paths
+
+    def test_multi_branch_repos_provision_as_siblings_on_their_branches(self) -> None:
+        # The #8099 shape: two repos on two different fix branches, composed
+        # into ONE ticket dir as siblings.
+        self._make_clones("repo-a", "repo-b")
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://example.com/issues/8099",
+            repos=["repo-a", "repo-b"],
+            extra={
+                "branch": "8099-child-allowance",
+                "branches": {
+                    "repo-a": "fix/8099-child-allowance-resource",
+                    "repo-b": "fix/8099-child-allowance-document-translations",
+                },
+                "description": "x",
+            },
+        )
+
+        result, branch_by_dest, _ = self._run_capturing_branches(ticket)
+
+        assert result.ok is True, result.detail
+
+        ticket_dir = self.workspace / "8099-child-allowance"
+        path_a = str(ticket_dir / "repo-a")
+        path_b = str(ticket_dir / "repo-b")
+
+        # Both repos land as SIBLINGS in the ONE ticket dir.
+        assert Path(path_a).parent == ticket_dir
+        assert Path(path_b).parent == ticket_dir
+
+        # Each repo is provisioned on ITS OWN branch from the map.
+        assert branch_by_dest[path_a] == "fix/8099-child-allowance-resource"
+        assert branch_by_dest[path_b] == "fix/8099-child-allowance-document-translations"
+
+        # The Worktree rows record the per-repo branch, not the ticket-dir name.
+        wt_a = Worktree.objects.get(ticket=ticket, repo_path="repo-a")
+        wt_b = Worktree.objects.get(ticket=ticket, repo_path="repo-b")
+        assert wt_a.branch == "fix/8099-child-allowance-resource"
+        assert wt_b.branch == "fix/8099-child-allowance-document-translations"
+        assert (wt_a.extra or {}).get("worktree_path") == path_a
+        assert (wt_b.extra or {}).get("worktree_path") == path_b
+
+    def test_repo_absent_from_map_falls_back_to_ticket_branch(self) -> None:
+        # The #1038 shape: one repo on a feature branch, a sibling not listed
+        # in the map falls back to the shared ticket branch.
+        self._make_clones("repo-a", "repo-b")
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://example.com/issues/1038",
+            repos=["repo-a", "repo-b"],
+            extra={
+                "branch": "1038-multi-repo",
+                "branches": {"repo-a": "fix/1038-special"},
+                "description": "x",
+            },
+        )
+
+        result, branch_by_dest, _ = self._run_capturing_branches(ticket)
+
+        assert result.ok is True, result.detail
+        ticket_dir = self.workspace / "1038-multi-repo"
+        path_a = str(ticket_dir / "repo-a")
+        path_b = str(ticket_dir / "repo-b")
+
+        assert branch_by_dest[path_a] == "fix/1038-special"
+        assert branch_by_dest[path_b] == "1038-multi-repo"
+
+        wt_b = Worktree.objects.get(ticket=ticket, repo_path="repo-b")
+        assert wt_b.branch == "1038-multi-repo"
+
+    def test_single_branch_ticket_unchanged(self) -> None:
+        # No ``branches`` map → every repo uses ``extra['branch']`` exactly
+        # as before (the unchanged single-branch path).
+        self._make_clones("repo-a", "repo-b")
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://example.com/issues/77",
+            repos=["repo-a", "repo-b"],
+            extra={"branch": "77-feature", "description": "x"},
+        )
+
+        result, branch_by_dest, _ = self._run_capturing_branches(ticket)
+
+        assert result.ok is True, result.detail
+        ticket_dir = self.workspace / "77-feature"
+        assert branch_by_dest[str(ticket_dir / "repo-a")] == "77-feature"
+        assert branch_by_dest[str(ticket_dir / "repo-b")] == "77-feature"
+
+        for repo in ("repo-a", "repo-b"):
+            wt = Worktree.objects.get(ticket=ticket, repo_path=repo)
+            assert wt.branch == "77-feature"
+
+
 class TestWorktreeProvisionerStampsScopedIdentity(TestCase):
     """#762 source-fix: public souliane/* worktrees get a local noreply identity.
 


### PR DESCRIPTION
Closes #33.

## Problem

`WorktreeProvisioner.run()` resolved `ticket.extra['branch']` once and used it
for **every** repo. A ticket whose repos live on **different** branches could
not provision them as siblings in one ticket dir — each repo would have needed
the same branch. This blocked:

- multi-branch tickets (one repo on a feature branch, a sibling on another), and
- composing a multi-repo E2E stack whose repos each sit on their own fix branch.

## Fix

Add an optional `ticket.extra['branches']` map (`repo -> branch`). The
provisioner resolves each repo's branch from the map, falling back to
`extra['branch']` for repos not listed. The ticket **dir** stays `extra['branch']`
regardless, so every repo lands as a **sibling** in one dir even on split
per-repo branches — which is what lets an e2e / workspace-ticket stack compose
split branches together.

Single-branch tickets (no map) are unchanged. The overlay-side per-repo attach
path (`WorktreeAdopter`) already takes an explicit per-repo branch, so no
overlay change is needed.

## Architecture pre-check — #33

**1. BLUEPRINT § alignment** — §6 Overlay System / worktree provisioning. Additive
optional `extra` key; no contract change (the BLUEPRINT-updated pre-commit gate
passed with no required edit).

**2. FSM phase boundaries** — n/a. No `Ticket.State` / `Worktree.State` transition
changes; this runs inside the existing `start` provisioning step.

**3. Extension-point contracts** — n/a. No `OverlayBase` / scanner / hook / Protocol
surface touched.

**4. Component boundaries** — `src/teatree/core/runners/provision.py` (runner) +
`src/teatree/core/models/types.py` (the `TicketExtra` TypedDict). Both the
existing homes for this logic.

**5. Dependency direction** — no new imports; `tach` / import-linter passed.

**6. Test surface** — `tests/teatree_core/test_runners_provision.py::TestWorktreeProvisionerPerRepoBranches`:
a multi-branch ticket provisions both repos as siblings on their respective
branches; a repo absent from the map falls back to the ticket branch; a
single-branch ticket is unchanged.

**7. Resilience invariants** — n/a (no new external write; `provision` map write
still routes through the existing locked `merge_extra` RMW).

**8. Identity and key normalization** — the per-repo branch is keyed by the same
`repo_name` the provisioner already iterates; no bare-vs-qualified normalization
introduced.

**9. Behavior preservation / capability deletion** — purely additive. The
single-branch path is preserved and pinned by `test_single_branch_ticket_unchanged`.

## Tests (TDD, anti-vacuous)

RED was observed with the per-repo resolution reverted (the two multi-branch
tests fail; the single-branch test stays green), GREEN with it. Full provisioning
+ e2e-workitem suites pass (82 tests). The full regression suite is green apart
from two unrelated hook-router subprocess-timeout flakes that pass in isolation.
