### PR TITLE
fix(hooks): source blueprint-sync commit type robustly so fix/refactor exemption fires (#35)

### DIFF
--- a/scripts/hooks/check_blueprint_sync.py
+++ b/scripts/hooks/check_blueprint_sync.py
@@ -9,6 +9,15 @@ files under ``docs/blueprint/`` (e.g. ``configuration.md``,
 ``loop-topology.md``) — the appendices ARE the BLUEPRINT, so updating one of
 them satisfies the sync requirement just as the monolith does.
 
+The ``fix:``/``refactor:`` exemption only fires if the hook can read the commit
+*type*, which lives in the commit message. The commit message is sourced
+robustly: from ``argv[1]`` when prek hands it the commit-message file at the
+``commit-msg`` stage, otherwise from git's canonical ``COMMIT_EDITMSG``. A
+positional argument that is a staged *source* path (handed at the pre-commit
+stage or by ``prek run --all-files``) is never mistaken for the commit message —
+that coupling was the bug behind task #35, where a ``fix(db)`` commit was gated
+because the first line of a staged source file was read as the "commit type".
+
 See: souliane/teatree#8
 """
 
@@ -21,6 +30,11 @@ import sys
 # extracted helper) does not alter the external contracts BLUEPRINT documents
 # — the same reasoning that exempts ``fix``.
 _EXEMPT_PREFIXES = ("test", "docs", "style", "chore", "ci", "fix", "refactor")
+
+# Filenames git uses to hold an in-progress commit message. ``argv[1]`` is read
+# as the commit message only when it ends in one of these — a staged ``src/``
+# path never matches, so it can never be mis-read as the commit type.
+_COMMIT_MSG_FILENAMES = ("COMMIT_EDITMSG", "MERGE_MSG", "SQUASH_MSG")
 
 
 def _staged_files() -> list[str]:
@@ -43,15 +57,53 @@ def _is_blueprint(path: str) -> bool:
     return path == "BLUEPRINT.md" or (path.startswith("docs/blueprint/") and path.endswith(".md"))
 
 
-def _commit_message() -> str:
-    min_args = 2
-    if len(sys.argv) < min_args:
-        return ""
+def _looks_like_commit_msg_file(path: str) -> bool:
+    """True when ``path`` is a git commit-message file, not a staged source path.
+
+    Git (and prek at the ``commit-msg`` stage) hands the hook a path ending in
+    one of git's known commit-message filenames. A staged ``src/`` path handed
+    at another stage ends in ``.py`` / ``.md`` / etc. and never matches, so it
+    is never read as the commit message.
+    """
+    return pathlib.PurePath(path).name in _COMMIT_MSG_FILENAMES
+
+
+def _git_commit_editmsg_path() -> str:
+    """Git's canonical path to the in-progress commit message (worktree-aware)."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--git-path", "COMMIT_EDITMSG"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip()
+
+
+def _read_first_line(path: str) -> str:
     try:
-        with pathlib.Path(sys.argv[1]).open(encoding="utf-8") as fh:
+        with pathlib.Path(path).open(encoding="utf-8") as fh:
             return fh.readline().strip()
     except OSError:
         return ""
+
+
+def _commit_message() -> str:
+    """The first line of the commit message, sourced robustly.
+
+    Prefer ``argv[1]`` when it is genuinely the commit-message file git handed
+    the hook at the ``commit-msg`` stage; otherwise fall back to git's canonical
+    ``COMMIT_EDITMSG``. This keeps the commit type available to the exemption
+    regardless of how the hook is invoked, and never reads a staged source path
+    handed as ``argv[1]`` as if it were the commit message (task #35).
+    """
+    min_args = 2
+    if len(sys.argv) >= min_args and _looks_like_commit_msg_file(sys.argv[1]):
+        return _read_first_line(sys.argv[1])
+
+    editmsg = _git_commit_editmsg_path()
+    if editmsg:
+        return _read_first_line(editmsg)
+    return ""
 
 
 def main() -> int:
@@ -74,7 +126,7 @@ def main() -> int:
         print("    If this change adds/removes/renames endpoints, models,")
         print("    commands, or config, please update BLUEPRINT.md too.")
         print()
-        print("    To skip: use a fix/test/docs/style/chore/ci commit type.")
+        print("    To skip: use a fix/refactor/test/docs/style/chore/ci commit type.")
         print()
         return 1
 

--- a/tests/test_check_blueprint_sync_hook.py
+++ b/tests/test_check_blueprint_sync_hook.py
@@ -1,10 +1,19 @@
 """Tests for the BLUEPRINT-sync commit-msg hook (souliane/teatree#8).
 
 The hook fails when ``src/`` changes without a corresponding BLUEPRINT update,
-unless the commit type is exempt (test/docs/style/chore/ci/fix). The
+unless the commit type is exempt (test/docs/style/chore/ci/fix/refactor). The
 "BLUEPRINT" is the top-level ``BLUEPRINT.md`` plus its split appendix files
 under ``docs/blueprint/`` — updating an appendix satisfies the requirement just
 as the monolith does (teatree#2237: the appendices ARE the BLUEPRINT).
+
+The exemption depends on the hook reading the *commit message*. The hook must
+therefore source the commit type robustly — from the commit-message file git
+hands it at the ``commit-msg`` stage, and never from a staged source filename it
+might be handed at another invocation (pre-commit stage / ``prek run
+--all-files``). The latter coupling is the bug behind task #35: a positional
+argument that is a ``src/`` path was mis-read as the commit message, so the
+``fix:``/``refactor:`` exemption could never match and a ``fix(db)`` commit was
+gated.
 """
 
 from pathlib import Path
@@ -41,6 +50,78 @@ class TestIsBlueprint:
         assert hook._is_blueprint(path) is False
 
 
+class TestLooksLikeCommitMsgFile:
+    """A commit-message file is distinguished from a staged source filename.
+
+    The commit-type source must read git's commit-message file, never a staged
+    source filename a non-commit-msg invocation might hand the hook as argv[1].
+    """
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            ".git/COMMIT_EDITMSG",
+            "/repo/.git/COMMIT_EDITMSG",
+            "/repo/.git/worktrees/wt/COMMIT_EDITMSG",
+            ".git/MERGE_MSG",
+        ],
+    )
+    def test_commit_msg_files_are_recognized(self, path: str) -> None:
+        assert hook._looks_like_commit_msg_file(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "src/teatree/config_agent.py",
+            "scripts/hooks/check_blueprint_sync.py",
+            "BLUEPRINT.md",
+            "docs/blueprint/configuration.md",
+            "tests/test_check_blueprint_sync_hook.py",
+        ],
+    )
+    def test_source_filenames_are_not_commit_msg_files(self, path: str) -> None:
+        assert hook._looks_like_commit_msg_file(path) is False
+
+
+class TestCommitMessage:
+    def test_reads_message_from_commit_msg_argv(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        msg_file = tmp_path / "COMMIT_EDITMSG"
+        msg_file.write_text("fix(db): a thing\n", encoding="utf-8")
+        monkeypatch.setattr(hook.sys, "argv", ["check_blueprint_sync.py", str(msg_file)])
+        assert hook._commit_message() == "fix(db): a thing"
+
+    def test_ignores_staged_source_filename_argv_and_falls_back_to_git_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # The regression: a non-commit-msg argv (a staged src path, as handed at
+        # the pre-commit stage / `prek run --all-files`) must NOT be read as the
+        # commit message. The hook falls back to git's canonical COMMIT_EDITMSG.
+        src_file = tmp_path / "src" / "teatree" / "foo.py"
+        src_file.parent.mkdir(parents=True)
+        src_file.write_text("import pathlib\n", encoding="utf-8")
+
+        canonical = tmp_path / "COMMIT_EDITMSG"
+        canonical.write_text("fix(db): a thing\n", encoding="utf-8")
+        monkeypatch.setattr(hook, "_git_commit_editmsg_path", lambda: str(canonical))
+
+        monkeypatch.setattr(hook.sys, "argv", ["check_blueprint_sync.py", "src/teatree/foo.py"])
+        # Must read the real commit message from git's canonical path, not the
+        # first line of the staged source file.
+        assert hook._commit_message() == "fix(db): a thing"
+
+    def test_no_argv_falls_back_to_git_canonical_path(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        canonical = tmp_path / "COMMIT_EDITMSG"
+        canonical.write_text("refactor(core): extract helper\n", encoding="utf-8")
+        monkeypatch.setattr(hook, "_git_commit_editmsg_path", lambda: str(canonical))
+        monkeypatch.setattr(hook.sys, "argv", ["check_blueprint_sync.py"])
+        assert hook._commit_message() == "refactor(core): extract helper"
+
+    def test_missing_message_everywhere_returns_empty(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        monkeypatch.setattr(hook, "_git_commit_editmsg_path", lambda: str(tmp_path / "nope"))
+        monkeypatch.setattr(hook.sys, "argv", ["check_blueprint_sync.py"])
+        assert hook._commit_message() == ""
+
+
 class TestMain:
     def _run(
         self,
@@ -49,10 +130,17 @@ class TestMain:
         *,
         message: str,
         staged: list[str],
+        argv_is_src: bool = False,
     ) -> int:
         msg_file = tmp_path / "COMMIT_EDITMSG"
         msg_file.write_text(message + "\n", encoding="utf-8")
-        monkeypatch.setattr(hook.sys, "argv", ["check_blueprint_sync.py", str(msg_file)])
+        # Git's canonical commit-msg path always carries the real message.
+        monkeypatch.setattr(hook, "_git_commit_editmsg_path", lambda: str(msg_file))
+        if argv_is_src:
+            # Simulate the buggy invocation: a staged src path as argv[1].
+            monkeypatch.setattr(hook.sys, "argv", ["check_blueprint_sync.py", "src/teatree/x.py"])
+        else:
+            monkeypatch.setattr(hook.sys, "argv", ["check_blueprint_sync.py", str(msg_file)])
         monkeypatch.setattr(hook, "_staged_files", lambda: staged)
         return hook.main()
 
@@ -94,6 +182,17 @@ class TestMain:
         )
         assert rc == 0
 
+    def test_refactor_commit_type_passes_without_blueprint(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        rc = self._run(
+            monkeypatch,
+            tmp_path,
+            message="refactor(core): extract helper",
+            staged=["src/teatree/config_agent.py"],
+        )
+        assert rc == 0
+
     def test_no_src_change_passes(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         rc = self._run(
             monkeypatch,
@@ -102,3 +201,34 @@ class TestMain:
             staged=["docs/blueprint/configuration.md"],
         )
         assert rc == 0
+
+    def test_fix_commit_exempt_even_when_argv_is_staged_src_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # Task #35 regression: when the hook is handed a staged src path as
+        # argv[1] (pre-commit stage / `prek run --all-files`) instead of the
+        # commit-message file, the fix: exemption must STILL fire by sourcing
+        # the commit type from git's canonical COMMIT_EDITMSG.
+        rc = self._run(
+            monkeypatch,
+            tmp_path,
+            message="fix(db): reconcile renumbered migration records",
+            staged=["src/teatree/db.py"],
+            argv_is_src=True,
+        )
+        assert rc == 0
+
+    def test_feat_commit_still_gated_when_argv_is_staged_src_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # The fix must not over-correct: a feat commit needing a BLUEPRINT
+        # update is still gated even when argv[1] is a staged src path, because
+        # the commit type is sourced from git's canonical COMMIT_EDITMSG.
+        rc = self._run(
+            monkeypatch,
+            tmp_path,
+            message="feat(db): a new capability",
+            staged=["src/teatree/db.py"],
+            argv_is_src=True,
+        )
+        assert rc == 1


### PR DESCRIPTION
## Summary

The `blueprint-sync` commit-msg hook read its commit type from `argv[1]` unconditionally, assuming prek always handed it the commit-message file. When the hook is invoked at a stage where `argv[1]` is a staged **source** path instead (the pre-commit stage, or `prek run --all-files`), it read that source file's first line as the "commit type". The documented `fix:`/`refactor:` exemption could therefore never fire, and a `fix(db)` commit with `src/` changes was gated incorrectly.

The fix makes the commit type available to the hook regardless of how it is invoked:

- `argv[1]` is read as the commit message **only when it is genuinely a git commit-message file** (`COMMIT_EDITMSG` / `MERGE_MSG` / `SQUASH_MSG`).
- Otherwise the hook falls back to git's canonical, worktree-aware `COMMIT_EDITMSG` path (`git rev-parse --git-path COMMIT_EDITMSG`).
- A staged source path handed as `argv[1]` is never mistaken for the commit message.

This also removes a latent correctness bug: previously a staged file whose first line happened to start with `fix` could spuriously exempt a `feat:` commit, and vice-versa. The decision is now always made on the real commit type.

## TDD (anti-vacuous)

Regression tests observed **RED** before the fix, **GREEN** after:

- `test_fix_commit_exempt_even_when_argv_is_staged_src_path` — a `fix(db)` commit handed a `src/` path as `argv[1]` is exempted (was gated on the buggy code).
- `test_feat_commit_still_gated_when_argv_is_staged_src_path` — a `feat(db)` commit needing a BLUEPRINT update is still gated (the fix does not over-correct).
- `test_ignores_staged_source_filename_argv_and_falls_back_to_git_path` / `test_no_argv_falls_back_to_git_canonical_path` — `_commit_message()` sources the type from git's canonical path, not a staged filename.

The bug was reproduced against the pre-fix `_commit_message` (rc=1 = gated) and confirmed fixed (rc=0) for the same `fix(db)` scenario.

## Architecture pre-check — task #35

### 1. BLUEPRINT § alignment
n/a — `scripts/hooks/check_blueprint_sync.py` is a commit-time quality gate, not a BLUEPRINT-documented runtime contract. No `src/`, no FSM, no Protocol surface is touched.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition.

### 3. Extension-point contracts
n/a — no `OverlayBase` / scanner / hook-router / `*Backend` Protocol change.

### 4. Component boundaries
`scripts/hooks/` — a prek hook handler. Correct home; no business logic moved.

### 5. Dependency direction
No new cross-module imports (stdlib `pathlib` / `subprocess` / `sys` only). No tach edge affected.

### 6. Test surface
`tests/test_check_blueprint_sync_hook.py` (mirrors the script). New behaviours: commit-msg-file recognition (`_looks_like_commit_msg_file`), robust commit-message sourcing (`_commit_message`), and the two task-#35 regression cases in `TestMain`.

### 7. Resilience invariants
No external write. The git subprocess fails open to an empty path → empty message → the hook proceeds (gates `src/` without an exemption), the same conservative direction as before.

### 8. Identity and key normalization
n/a — no bare-vs-qualified identity. The commit-msg-file check matches the filename `name` against a fixed set; it canonicalizes nothing it later strips.

### 9. Behavior preservation / capability deletion
Purely additive on the happy path: the commit-msg stage still reads `argv[1]` exactly as before. The change only adds a correct fallback for the non-commit-msg-stage invocation. The `fix/refactor/...` exemption set and the BLUEPRINT-path matcher are unchanged. No must-block test was inverted.
