### PR TITLE
fix(cli): surface db approve as a core-dispatched subcommand (#953)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -4606,6 +4606,9 @@ Usage: t3 teatree workspace ticket [OPTIONS] ISSUE_URL
 
  Idempotent: re-running over an already-started ticket merges new repos
  into ``ticket.repos`` so the next ``execute_provision`` picks them up.
+ Per-repo branches (#33): a ``--repos`` token may carry its branch as
+ ``repo:branch`` so split-branch repos provision as siblings in one dir
+ (the dir is ``extra['branch']``; a bare token falls back to it).
 
  Filesystem-evidence double-dispatch guard (#2217): before materialising a
  worktree for issue ``N``, refuse when a *foreign* ``N-*`` worktree dir
@@ -5328,6 +5331,8 @@ Usage: t3 teatree db [OPTIONS] COMMAND [ARGS]...
 │ migrate          Apply pending migrations to the runtime self-DB             │
 │                  (non-destructive self-rescue).                              │
 │ refresh          Re-import the worktree database from dump/DSLR.             │
+│ approve          Record a single-use DbApproval that satisfies the #777      │
+│                  fresh-dump gate without a TTY (#953).                       │
 │ restore-ci       Restore database from the latest CI dump.                   │
 │ reset-passwords  Reset all user passwords to a known dev value.              │
 │ query            Run a read-only SQL query against the control DB; emit rows │
@@ -5410,6 +5415,39 @@ Usage: t3 teatree db refresh [OPTIONS]
 │                                               interactive-TTY approval is    │
 │                                               required instead.              │
 │ --help                                        Show this message and exit.    │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree db approve`
+
+```
+Usage: t3 teatree db approve [OPTIONS] OP TENANT
+
+ Record a single-use ``DbApproval`` that satisfies the #777 gate without a TTY
+ (#953/#126).
+
+ The recorded-approval channel is the no-TTY satisfier for
+ ``db refresh --fresh-dump``: a chat-only operator records the
+ approval here, then the agent re-runs ``db refresh --fresh-dump
+ --user-authorized <id>`` which consumes the row single-use. The
+ scope is normalized identically at record and consume, so the
+ recorded ``(op, tenant)`` matches the gate's expected scope (named
+ in its refusal message) regardless of case/whitespace.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    op          TEXT  The DB op to authorize (e.g. `fresh-dump`).           │
+│                        [required]                                            │
+│ *    tenant      TEXT  The tenant / source database the op is scoped to.     │
+│                        [required]                                            │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --approver        TEXT  Id of the human user recording the approval.      │
+│                            Refused if it names a maker/coding-agent/loop     │
+│                            role — the executing agent can never              │
+│                            self-authorize the op (#953, mirrors MergeClear   │
+│                            §17.8 / approve-on-behalf #960).                  │
+│                            [required]                                        │
+│    --help                  Show this message and exit.                       │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/cli/django_groups.py
+++ b/src/teatree/cli/django_groups.py
@@ -109,15 +109,20 @@ DJANGO_GROUPS: dict[str, DjangoGroup] = {
         [
             ("migrate", "Apply pending migrations to the runtime self-DB (non-destructive self-rescue)."),
             ("refresh", "Re-import the worktree database from dump/DSLR."),
+            ("approve", "Record a single-use DbApproval that satisfies the #777 fresh-dump gate without a TTY (#953)."),
             ("restore-ci", "Restore database from the latest CI dump."),
             ("reset-passwords", "Reset all user passwords to a known dev value."),
             ("query", "Run a read-only SQL query against the control DB; emit rows as JSON."),
             ("shell", "Drop into a Django shell against the resolved (gate) control DB."),
         ],
         # `migrate` migrates the teatree-core control DB the merge gate reads,
-        # so it must run in the runtime process (#126); its siblings keep
-        # routing through the overlay manage.py.
-        core_subcommands=frozenset({"migrate"}),
+        # so it must run in the runtime process (#126). `approve` records a
+        # DbApproval row in that same teatree-core control DB (the gate reads it
+        # at consume time), so it must also run in the runtime process rather
+        # than route through an overlay manage.py whose self-DB lacks the row.
+        # Their siblings (refresh/restore-ci/reset-passwords) keep routing
+        # through the overlay manage.py for the overlay's db_import strategy.
+        core_subcommands=frozenset({"migrate", "approve"}),
     ),
     "pr": DjangoGroup(
         "Pull request helpers.",

--- a/tests/teatree_core/test_overlay_core_dispatch.py
+++ b/tests/teatree_core/test_overlay_core_dispatch.py
@@ -194,6 +194,32 @@ class TestDbMigrateCoreDispatch:
         cmd = run_streamed.call_args.args[0]
         assert "manage.py" in " ".join(cmd), f"db refresh must route through the overlay manage.py, got {cmd!r}"
 
+    def test_db_approve_is_surfaced_and_core_dispatched(self) -> None:
+        # The #953 ``db approve`` command (records a DbApproval in the
+        # teatree-core control DB) must be both listed as a ``db`` subcommand
+        # AND opt into per-subcommand core dispatch — otherwise ``t3 <overlay>
+        # db approve`` returns "No such command 'approve'" (the gap this test
+        # pins) and a recorded approval never reaches the gate's control DB.
+        entry = DJANGO_GROUPS["db"]
+        sub_names = {name for name, _ in entry.subcommands}
+        assert "approve" in sub_names, f"db.approve must be a listed db subcommand (#953), got {sorted(sub_names)}"
+        assert "approve" in getattr(entry, "core_subcommands", frozenset()), (
+            f"db.approve must opt into per-subcommand core dispatch (#953/#126), got {entry!r}"
+        )
+
+    def test_db_approve_uses_core_dispatch(self, overlay_clone_path: Path) -> None:
+        runner = CliRunner()
+        app = _build_overlay_app(overlay_clone_path)
+        with patch("teatree.cli.overlay.run_streamed") as run_streamed:
+            result = runner.invoke(app, ["db", "approve", "fresh-dump", "acme-tenant", "--approver", "souliane"])
+        assert result.exit_code == 0, result.output
+        cmd = run_streamed.call_args.args[0]
+        assert "-m" in cmd, f"db approve must dispatch via python -m teatree, got {cmd!r}"
+        assert "teatree" in cmd, f"db approve must dispatch via python -m teatree, got {cmd!r}"
+        assert "manage.py" not in " ".join(cmd), f"db approve must NOT route through manage.py, got {cmd!r}"
+        assert "db" in cmd
+        assert "approve" in cmd
+
 
 class TestShortcutCoreDispatch:
     """``full-status`` and ``daily`` shortcut to followup commands — same dispatch rule."""


### PR DESCRIPTION
## Problem

`t3 <overlay> db approve` returned `No such command 'approve'` even though the #953 `approve` command exists in `teatree.core.management.commands.db`. The `db` `DjangoGroup` whitelist in `src/teatree/cli/django_groups.py` never listed the `approve` subcommand, so the CLI bridge refused to forward it. This blocked the recorded-approval (no-TTY) channel of the fresh-dump gate.

## Fix

- Add `approve` to the `db` group's `subcommands` list (so it is surfaced).
- Add `approve` to `core_subcommands` alongside `migrate`: the command records a `DbApproval` row in the teatree-core control DB that the gate reads at consume time, so it must dispatch via `python -m teatree`, not through an overlay `manage.py` whose self-DB lacks the row.
- TDD regression tests: `approve` is both surfaced and core-dispatched.

## Verification

`uv run pytest tests/teatree_core/test_overlay_core_dispatch.py` — 15 passed (2 new).