### PR TITLE
fix(update): self-heal a squash-merged-divergent clone instead of bricking (#2400)

### DIFF
--- a/src/teatree/cli/_update_reconcile.py
+++ b/src/teatree/cli/_update_reconcile.py
@@ -1,0 +1,225 @@
+"""Content-safe self-heal of a clone whose ff-pull failed on squash-merge divergence (#2400).
+
+``t3 update`` (``teatree.cli.update``) does a per-clone ``git pull --ff-only``.
+When a clone's local commits already landed *squash-merged* upstream (their
+patches are on ``origin/<default>`` under a new SHA), the clone shows ``[ahead
+N, behind M]`` and ``--ff-only`` aborts. :func:`reconcile_squash_merged`
+self-heals it — but only when the unique commits are provably already upstream.
+
+The subject classifier
+(:func:`teatree.core.branch_classification.classify_branch_commits`) is only a
+cheap PRE-FILTER: it buckets ``squash_merged`` by canonicalized-subject
+membership alone, with no content/patch-id/tree check, so a genuine commit can
+slip past it (subject collision, amended content, evil-merge). The destructive
+``git reset --hard`` is authorized by an AUTHORITATIVE *content* gate instead —
+``git cherry`` (patch-id) plus a merge-commit check — never by subject. A
+recoverable backup ref is created at the pre-reset HEAD as defense-in-depth.
+
+This module is a leaf helper of ``teatree.cli.update``: it imports the result
+types and small git helpers from there; ``update`` calls
+:func:`reconcile_squash_merged` via a function-local import to break the cycle.
+"""
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import typer
+
+from teatree.core.branch_classification import classify_branch_commits
+
+if TYPE_CHECKING:
+    from teatree.cli.update import RepoUpdate
+
+# How many commit shas to list in a divergence warning before eliding —
+# mirrors the clean-all reaper's preview cap (``core.cleanup._SUBJECT_PREVIEW_LIMIT``).
+_SUBJECT_PREVIEW_LIMIT = 3
+
+# A full git sha is 40 hex chars; below this a "sha" is a fail-safe diagnostic
+# string (e.g. "(git cherry failed …)") that must be surfaced verbatim, not sliced.
+_SHORT_SHA_LEN = 7
+
+
+def _cherry_not_upstream(repo: Path, target: str) -> list[str]:
+    """Return the sha(s) of unique non-merge commits whose patch is NOT upstream.
+
+    ``git cherry <target> HEAD`` compares each commit reachable from HEAD but
+    not from ``target`` by **patch-id** (content), not by SHA or subject: a
+    ``-`` prefix means the patch already landed upstream (typical squash-merge),
+    a ``+`` prefix means the patch is genuinely un-upstreamed work. This is the
+    authoritative content check the subject classifier cannot do — a genuine
+    commit whose subject merely collides with an upstream subject (vector B) or
+    an amended commit that added content after the original was squashed
+    (vector C) both show ``+`` here even though the subject matcher buckets them
+    ``squash_merged``. Returns the ``+`` sha(s); an empty list means every
+    non-merge unique commit is patch-equivalent upstream.
+    """
+    from teatree.cli.update import _git  # noqa: PLC0415
+
+    result = _git(repo, "cherry", target, "HEAD", expected_codes=None)
+    if result.returncode != 0:
+        # A failed `git cherry` is inconclusive — degrade safely by reporting an
+        # opaque genuine sha so the caller refuses the reset (never reaps work
+        # on an uncertain content check).
+        return ["(git cherry failed — content check inconclusive)"]
+    plus: list[str] = []
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("+"):
+            plus.append(stripped[1:].strip())
+    return plus
+
+
+def _merge_commits_in_range(repo: Path, target: str) -> list[str]:
+    """Return merge-commit sha(s) reachable from HEAD but not from ``target``.
+
+    ``git rev-list --merges <target>..HEAD`` lists merge commits unique to the
+    branch. A merge commit can carry content present in neither parent (an
+    evil-merge, vector D) and has no single patch-id ``git cherry`` can compare,
+    so its content cannot be cheaply proven already-upstream. Any merge commit
+    in the unique range therefore blocks the reset conservatively.
+    """
+    from teatree.cli.update import _git  # noqa: PLC0415
+
+    result = _git(repo, "rev-list", "--merges", f"{target}..HEAD", expected_codes=None)
+    if result.returncode != 0:
+        return ["(git rev-list --merges failed — merge check inconclusive)"]
+    return [sha.strip() for sha in result.stdout.splitlines() if sha.strip()]
+
+
+def _create_reconcile_backup_ref(repo: Path, head_sha: str) -> str:
+    """Create a recoverable ref at *head_sha* before a reconcile reset; return its name.
+
+    Defense-in-depth (#2400): even with the content gate, a reset is destructive,
+    so the pre-reset HEAD is captured under a ``refs/t3-reconcile-backup/<sha>``
+    ref. ``git update-ref`` force-creates (overwrites) the ref, so a re-run on the
+    same HEAD never fails on a name clash. The ref keeps the old commits
+    reachable (not just in the reflog), making any future misclassification
+    trivially recoverable via ``git reset --hard <ref>``.
+    """
+    from teatree.cli.update import _git  # noqa: PLC0415
+
+    ref = f"refs/t3-reconcile-backup/{head_sha}"
+    _git(repo, "update-ref", ref, head_sha, expected_codes=None)
+    return ref
+
+
+def reconcile_squash_merged(name: str, repo: Path, old_sha: str, pull_stderr: str) -> "RepoUpdate":
+    """Self-heal a clone whose ff-pull failed purely on squash-merged divergence (#2400).
+
+    The recurring brick: a clone shows ``[ahead N, behind M]`` because its
+    local-unique commits were squash-merged upstream — their patches already landed
+    under a NEW SHA on ``origin/<default>``. ``git pull --ff-only`` then aborts with
+    "Not possible to fast-forward", bricking the clone's update.
+
+    This is reached ONLY after the precondition gate confirmed the clone is on its
+    default branch with an upstream (a feature-branch checkout short-circuits to
+    SKIPPED earlier), so a reconcile here always acts on the default branch.
+
+    Data-loss-free by construction. The subject classifier
+    (:func:`classify_branch_commits`) is only a cheap PRE-FILTER — it must NOT
+    authorize the destructive ``git reset --hard``, because it buckets by
+    canonicalized-subject membership alone with NO content/patch-id/tree check: a
+    genuine un-upstreamed commit whose subject collides with an unrelated upstream
+    subject (vector B), an amended commit that added content after the original
+    squash (vector C), or a merge commit carrying unique content (vector D) all
+    slip past it. So before any reset an AUTHORITATIVE content gate runs — the
+    reset proceeds ONLY if (1) ``git cherry`` reports every unique non-merge
+    commit as patch-equivalent upstream (no ``+`` line) AND (2) there are no merge
+    commits in the unique range. If either fails the clone is kept and a LOUD
+    multi-line warning names the genuine sha(s), so genuine work is never
+    destroyed. Immediately before the authorized reset a recoverable
+    ``refs/t3-reconcile-backup/<sha>`` ref is created at the pre-reset HEAD (and
+    named in the log) for trivial recovery.
+    """
+    from teatree.cli.update import (  # noqa: PLC0415
+        RepoUpdate,
+        UpdateStatus,
+        _commit_count,
+        _current_branch,
+        _default_branch,
+        _git,
+        _short_sha,
+    )
+
+    default_branch = _default_branch(repo)
+    target = f"origin/{default_branch}" if default_branch else "origin/main"
+    branch = _current_branch(repo)
+    classification = classify_branch_commits(str(repo), branch, target=target)
+
+    if classification.genuinely_ahead:
+        return _refuse_reconcile(
+            name,
+            repo,
+            target,
+            reason="genuine un-upstreamed commit(s)",
+            shas=[c.sha for c in classification.genuinely_ahead],
+        )
+
+    # AUTHORITATIVE content gate — the subject classifier above is only a cheap
+    # pre-filter; the reset is authorized solely by content, never by subject.
+    cherry_plus = _cherry_not_upstream(repo, target)
+    if cherry_plus:
+        return _refuse_reconcile(
+            name,
+            repo,
+            target,
+            reason="commit(s) whose patch is NOT upstream (subject collision / amended content)",
+            shas=cherry_plus,
+        )
+    merge_shas = _merge_commits_in_range(repo, target)
+    if merge_shas:
+        return _refuse_reconcile(
+            name,
+            repo,
+            target,
+            reason="merge commit(s) that may carry content not provably upstream",
+            shas=merge_shas,
+        )
+
+    dropped = len(classification.squash_merged) + len(classification.merge_commits)
+    head_sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    backup_ref = _create_reconcile_backup_ref(repo, head_sha)
+    reset = _git(repo, "reset", "--hard", target, expected_codes=None)
+    if reset.returncode != 0:
+        return RepoUpdate(
+            name,
+            UpdateStatus.FAILED,
+            reason=f"git pull --ff-only failed: {pull_stderr} (reconcile reset failed: {reset.stderr.strip()})",
+        )
+    plural = "commit" if dropped == 1 else "commits"
+    typer.echo(
+        f"OK    reconciled squash-merged clone {repo} -> {target} "
+        f"(dropped {dropped} already-upstream duplicate {plural}; "
+        f"pre-reset HEAD {head_sha[:7]} backed up at {backup_ref} — recover with "
+        f"git -C {repo} reset --hard {backup_ref})"
+    )
+    new_sha = _short_sha(repo)
+    advanced = _commit_count(repo, old_sha, new_sha) if new_sha != old_sha else 0
+    return RepoUpdate(name, UpdateStatus.UPDATED, old_sha=old_sha, new_sha=new_sha, advanced=advanced)
+
+
+def _refuse_reconcile(name: str, repo: Path, target: str, *, reason: str, shas: list[str]) -> "RepoUpdate":
+    """Emit the loud refuse-and-keep warning and return a hard FAILED outcome.
+
+    The single loud-warn path for every reason the reconcile must NOT reset —
+    subject-classified genuine work, ``git cherry`` ``+`` patches, and merge
+    commits in the unique range all funnel here, so genuine work is surfaced
+    identically and never destroyed.
+    """
+    from teatree.cli.update import RepoUpdate, UpdateStatus  # noqa: PLC0415
+
+    preview = shas[:_SUBJECT_PREVIEW_LIMIT]
+    listed = ", ".join(sha[:7] if len(sha) >= _SHORT_SHA_LEN else sha for sha in preview)
+    if len(shas) > _SUBJECT_PREVIEW_LIMIT:
+        listed += ", …"
+    typer.echo("")
+    typer.echo(f"!! WARNING: {name} has diverged from {target} with {reason}.")
+    typer.echo(f"!! Commit(s) NOT provably on {target}: {listed}")
+    typer.echo(f"!! Refusing to reconcile {repo} — pushing them to a new branch preserves the work.")
+    typer.echo(f"!! Fix: git -C {repo} push origin HEAD:refs/heads/<a-new-branch>, then re-run `t3 update`.")
+    typer.echo("")
+    return RepoUpdate(
+        name,
+        UpdateStatus.FAILED,
+        reason=(f"diverged with {len(shas)} {reason} ({listed}) — push them to a new branch, then re-run `t3 update`"),
+    )

--- a/src/teatree/cli/update.py
+++ b/src/teatree/cli/update.py
@@ -16,14 +16,22 @@ For teatree core (``$T3_REPO``) and every registered overlay repo, this:
     When the ff-pull aborts on divergence ("Not possible to fast-forward")
     because the clone's local commits already landed *squash-merged* upstream
     (the recurring overlay brick — ``[ahead N, behind M]`` with N already-upstream
-    duplicates), the clone SELF-HEALS: it reuses the clean-all reaper's
-    classifier (``core.branch_classification.classify_branch_commits``) and, only
-    when EVERY local-unique commit is an already-upstream duplicate (zero
-    genuinely-ahead work), ``git reset --hard origin/<default>`` reconciles it
-    (#2400). ANY genuine un-upstreamed commit blocks the reset and is surfaced
-    loudly — genuine work is never destroyed. Data-loss-free by classifier proof;
-    only ever resets on the default branch (guard 4 is upheld by the step-3 gate,
+    duplicates), the clone SELF-HEALS. The subject classifier
+    (``core.branch_classification.classify_branch_commits``) is only a cheap
+    PRE-FILTER — it must NOT authorize the destructive reset (it matches by
+    canonicalized subject alone, with no content check). Before any
+    ``git reset --hard origin/<default>`` an AUTHORITATIVE content gate runs:
+    the reset proceeds ONLY when ``git cherry origin/<default> HEAD`` reports
+    every unique non-merge commit as patch-equivalent upstream (no ``+`` line)
+    AND ``git rev-list --merges`` finds no merge commit in the unique range.
+    Either failure blocks the reset and is surfaced loudly — genuine work
+    (subject collisions, amended content, evil-merges) is never destroyed
+    (#2400). Immediately before the authorized reset a recoverable
+    ``refs/t3-reconcile-backup/<sha>`` ref is created at the pre-reset HEAD (and
+    named in the log) so a future misclassification is trivially recoverable.
+    Only ever resets on the default branch (guard 4 is upheld by the step-3 gate,
     which short-circuits a feature-branch checkout before the pull is reached).
+    The content-gated reconcile itself lives in ``cli/_update_reconcile.py``.
 5. Reinstalls editable installs + runs ``t3 setup`` when a repo advanced this
     run OR when the tool venv is missing a declared dep — gated on actual
     dep-closure drift, NOT only a same-run advance, so an out-of-band ff-merge
@@ -52,7 +60,6 @@ from pathlib import Path
 
 import typer
 
-from teatree.core.branch_classification import classify_branch_commits
 from teatree.self_update import ReinstallResult, SubprocessRunner, ensure_self_db_migrated, reinstall_running_editable
 from teatree.utils.dep_drift import editable_source_path, find_missing_dependencies
 from teatree.utils.run import CompletedProcess, run_allowed_to_fail
@@ -80,10 +87,6 @@ update_app = typer.Typer(
 _CORE_REPO_NAME = "teatree"
 _RUNNING_REPO_NAME = "teatree (running)"
 _PRIMARY_REPO_NAMES = frozenset({_CORE_REPO_NAME, _RUNNING_REPO_NAME})
-
-# How many commit subjects to list in a divergence warning before eliding —
-# mirrors the clean-all reaper's preview cap (``core.cleanup._SUBJECT_PREVIEW_LIMIT``).
-_SUBJECT_PREVIEW_LIMIT = 3
 
 
 class UpdateStatus(enum.Enum):
@@ -308,77 +311,6 @@ def _precondition_block(name: str, repo: Path, *, is_primary: bool) -> RepoUpdat
     return None
 
 
-def _reconcile_squash_merged(name: str, repo: Path, old_sha: str, pull_stderr: str) -> RepoUpdate:
-    """Self-heal a clone whose ff-pull failed purely on squash-merged divergence (#2400).
-
-    The recurring brick: an overlay clone shows ``[ahead N, behind M]`` because its
-    local-unique commits were squash-merged upstream — their patches already landed
-    under a NEW SHA on ``origin/<default>``. ``git pull --ff-only`` then aborts with
-    "Not possible to fast-forward", bricking the overlay's update (and, downstream,
-    leaving the overlay unregistered).
-
-    This is reached ONLY after :func:`_precondition_block` confirmed the clone is on
-    its default branch with an upstream (guard 4: a feature-branch checkout never gets
-    here — it short-circuits to SKIPPED earlier), so a reconcile here always acts on
-    the default branch.
-
-    The disposition reuses the clean-all reaper's classifier
-    (:func:`teatree.core.branch_classification.classify_branch_commits`) — the single
-    source of truth for "squash-merged duplicate vs genuinely-ahead work". The branch
-    is the current default branch; the target is the freshly-fetched
-    ``origin/<default>``.
-
-    Data-loss-free by construction. Zero genuinely-ahead commits (every
-    local-unique commit a squash-merged / merge duplicate) → ``git reset --hard
-    origin/<default>`` fast-forwards in the behind commits too, and a clear
-    reconcile log line names the dropped duplicate count. ANY genuinely-ahead
-    commit (real un-upstreamed work) → NEVER reset: the clone is kept and a LOUD
-    multi-line warning names the genuine sha(s) plus a remediation hint, mirroring
-    :func:`_check_clean`'s shape, so genuine work is never destroyed.
-    """
-    default_branch = _default_branch(repo)
-    target = f"origin/{default_branch}" if default_branch else "origin/main"
-    branch = _current_branch(repo)
-    classification = classify_branch_commits(str(repo), branch, target=target)
-
-    if classification.genuinely_ahead:
-        preview = classification.genuinely_ahead[:_SUBJECT_PREVIEW_LIMIT]
-        listed = ", ".join(f"{c.sha[:7]} {c.subject}" for c in preview)
-        if len(classification.genuinely_ahead) > _SUBJECT_PREVIEW_LIMIT:
-            listed += ", …"
-        typer.echo("")
-        typer.echo(f"!! WARNING: {name} has diverged from {target} with genuine un-upstreamed commit(s).")
-        typer.echo(f"!! Genuine commit(s) NOT on {target}: {listed}")
-        typer.echo(f"!! Refusing to reconcile {repo} — pushing them to a new branch preserves the work.")
-        typer.echo(f"!! Fix: git -C {repo} push origin HEAD:refs/heads/<a-new-branch>, then re-run `t3 update`.")
-        typer.echo("")
-        return RepoUpdate(
-            name,
-            UpdateStatus.FAILED,
-            reason=(
-                f"diverged with {len(classification.genuinely_ahead)} genuine un-upstreamed "
-                f"commit(s) ({listed}) — push them to a new branch, then re-run `t3 update`"
-            ),
-        )
-
-    dropped = len(classification.squash_merged) + len(classification.merge_commits)
-    reset = _git(repo, "reset", "--hard", target, expected_codes=None)
-    if reset.returncode != 0:
-        return RepoUpdate(
-            name,
-            UpdateStatus.FAILED,
-            reason=f"git pull --ff-only failed: {pull_stderr} (reconcile reset failed: {reset.stderr.strip()})",
-        )
-    plural = "commit" if dropped == 1 else "commits"
-    typer.echo(
-        f"OK    reconciled squash-merged clone {repo} -> {target} "
-        f"(dropped {dropped} already-upstream duplicate {plural})"
-    )
-    new_sha = _short_sha(repo)
-    advanced = _commit_count(repo, old_sha, new_sha) if new_sha != old_sha else 0
-    return RepoUpdate(name, UpdateStatus.UPDATED, old_sha=old_sha, new_sha=new_sha, advanced=advanced)
-
-
 def update_repo(name: str, repo: Path, *, is_primary: bool = False) -> RepoUpdate:
     """Fetch and fast-forward *repo* to its default branch, or skip safely.
 
@@ -393,10 +325,15 @@ def update_repo(name: str, repo: Path, *, is_primary: bool = False) -> RepoUpdat
 
     A failed ``git pull --ff-only`` is NOT always terminal: when the divergence
     is purely already-upstream squash-merged duplicates (zero genuinely-ahead
-    work), the clone self-heals via :func:`_reconcile_squash_merged` (#2400) —
-    ``git reset --hard origin/<default>``, data-loss-free by classifier proof.
-    Genuine un-upstreamed work blocks the reconcile and is surfaced loudly.
+    work), the clone self-heals via
+    :func:`teatree.cli._update_reconcile.reconcile_squash_merged` (#2400) —
+    ``git reset --hard origin/<default>``, authorized by an AUTHORITATIVE
+    *content* gate (``git cherry`` patch-id + a merge-commit check), never by
+    subject. Genuine un-upstreamed work blocks the reconcile and is surfaced
+    loudly, and a recoverable backup ref is created before any reset.
     """
+    from teatree.cli._update_reconcile import reconcile_squash_merged  # noqa: PLC0415
+
     blocked = _precondition_block(name, repo, is_primary=is_primary)
     if blocked is not None:
         return blocked
@@ -404,7 +341,7 @@ def update_repo(name: str, repo: Path, *, is_primary: bool = False) -> RepoUpdat
     old_sha = _short_sha(repo)
     pull = _git(repo, "pull", "--ff-only", expected_codes=None)
     if pull.returncode != 0:
-        return _reconcile_squash_merged(name, repo, old_sha, pull.stderr.strip())
+        return reconcile_squash_merged(name, repo, old_sha, pull.stderr.strip())
 
     new_sha = _short_sha(repo)
     if new_sha == old_sha:

--- a/src/teatree/cli/update.py
+++ b/src/teatree/cli/update.py
@@ -13,6 +13,17 @@ For teatree core (``$T3_REPO``) and every registered overlay repo, this:
     running editable ``t3`` must never silently rot behind origin). A
     tracked-dirty tree is refused loudly. Untracked-only files do not block.
 4. Otherwise ``git pull --ff-only`` — fast-forward only, never merge/rebase.
+    When the ff-pull aborts on divergence ("Not possible to fast-forward")
+    because the clone's local commits already landed *squash-merged* upstream
+    (the recurring overlay brick — ``[ahead N, behind M]`` with N already-upstream
+    duplicates), the clone SELF-HEALS: it reuses the clean-all reaper's
+    classifier (``core.branch_classification.classify_branch_commits``) and, only
+    when EVERY local-unique commit is an already-upstream duplicate (zero
+    genuinely-ahead work), ``git reset --hard origin/<default>`` reconciles it
+    (#2400). ANY genuine un-upstreamed commit blocks the reset and is surfaced
+    loudly — genuine work is never destroyed. Data-loss-free by classifier proof;
+    only ever resets on the default branch (guard 4 is upheld by the step-3 gate,
+    which short-circuits a feature-branch checkout before the pull is reached).
 5. Reinstalls editable installs + runs ``t3 setup`` when a repo advanced this
     run OR when the tool venv is missing a declared dep — gated on actual
     dep-closure drift, NOT only a same-run advance, so an out-of-band ff-merge
@@ -41,6 +52,7 @@ from pathlib import Path
 
 import typer
 
+from teatree.core.branch_classification import classify_branch_commits
 from teatree.self_update import ReinstallResult, SubprocessRunner, ensure_self_db_migrated, reinstall_running_editable
 from teatree.utils.dep_drift import editable_source_path, find_missing_dependencies
 from teatree.utils.run import CompletedProcess, run_allowed_to_fail
@@ -68,6 +80,10 @@ update_app = typer.Typer(
 _CORE_REPO_NAME = "teatree"
 _RUNNING_REPO_NAME = "teatree (running)"
 _PRIMARY_REPO_NAMES = frozenset({_CORE_REPO_NAME, _RUNNING_REPO_NAME})
+
+# How many commit subjects to list in a divergence warning before eliding —
+# mirrors the clean-all reaper's preview cap (``core.cleanup._SUBJECT_PREVIEW_LIMIT``).
+_SUBJECT_PREVIEW_LIMIT = 3
 
 
 class UpdateStatus(enum.Enum):
@@ -292,17 +308,94 @@ def _precondition_block(name: str, repo: Path, *, is_primary: bool) -> RepoUpdat
     return None
 
 
+def _reconcile_squash_merged(name: str, repo: Path, old_sha: str, pull_stderr: str) -> RepoUpdate:
+    """Self-heal a clone whose ff-pull failed purely on squash-merged divergence (#2400).
+
+    The recurring brick: an overlay clone shows ``[ahead N, behind M]`` because its
+    local-unique commits were squash-merged upstream — their patches already landed
+    under a NEW SHA on ``origin/<default>``. ``git pull --ff-only`` then aborts with
+    "Not possible to fast-forward", bricking the overlay's update (and, downstream,
+    leaving the overlay unregistered).
+
+    This is reached ONLY after :func:`_precondition_block` confirmed the clone is on
+    its default branch with an upstream (guard 4: a feature-branch checkout never gets
+    here — it short-circuits to SKIPPED earlier), so a reconcile here always acts on
+    the default branch.
+
+    The disposition reuses the clean-all reaper's classifier
+    (:func:`teatree.core.branch_classification.classify_branch_commits`) — the single
+    source of truth for "squash-merged duplicate vs genuinely-ahead work". The branch
+    is the current default branch; the target is the freshly-fetched
+    ``origin/<default>``.
+
+    Data-loss-free by construction. Zero genuinely-ahead commits (every
+    local-unique commit a squash-merged / merge duplicate) → ``git reset --hard
+    origin/<default>`` fast-forwards in the behind commits too, and a clear
+    reconcile log line names the dropped duplicate count. ANY genuinely-ahead
+    commit (real un-upstreamed work) → NEVER reset: the clone is kept and a LOUD
+    multi-line warning names the genuine sha(s) plus a remediation hint, mirroring
+    :func:`_check_clean`'s shape, so genuine work is never destroyed.
+    """
+    default_branch = _default_branch(repo)
+    target = f"origin/{default_branch}" if default_branch else "origin/main"
+    branch = _current_branch(repo)
+    classification = classify_branch_commits(str(repo), branch, target=target)
+
+    if classification.genuinely_ahead:
+        preview = classification.genuinely_ahead[:_SUBJECT_PREVIEW_LIMIT]
+        listed = ", ".join(f"{c.sha[:7]} {c.subject}" for c in preview)
+        if len(classification.genuinely_ahead) > _SUBJECT_PREVIEW_LIMIT:
+            listed += ", …"
+        typer.echo("")
+        typer.echo(f"!! WARNING: {name} has diverged from {target} with genuine un-upstreamed commit(s).")
+        typer.echo(f"!! Genuine commit(s) NOT on {target}: {listed}")
+        typer.echo(f"!! Refusing to reconcile {repo} — pushing them to a new branch preserves the work.")
+        typer.echo(f"!! Fix: git -C {repo} push origin HEAD:refs/heads/<a-new-branch>, then re-run `t3 update`.")
+        typer.echo("")
+        return RepoUpdate(
+            name,
+            UpdateStatus.FAILED,
+            reason=(
+                f"diverged with {len(classification.genuinely_ahead)} genuine un-upstreamed "
+                f"commit(s) ({listed}) — push them to a new branch, then re-run `t3 update`"
+            ),
+        )
+
+    dropped = len(classification.squash_merged) + len(classification.merge_commits)
+    reset = _git(repo, "reset", "--hard", target, expected_codes=None)
+    if reset.returncode != 0:
+        return RepoUpdate(
+            name,
+            UpdateStatus.FAILED,
+            reason=f"git pull --ff-only failed: {pull_stderr} (reconcile reset failed: {reset.stderr.strip()})",
+        )
+    plural = "commit" if dropped == 1 else "commits"
+    typer.echo(
+        f"OK    reconciled squash-merged clone {repo} -> {target} "
+        f"(dropped {dropped} already-upstream duplicate {plural})"
+    )
+    new_sha = _short_sha(repo)
+    advanced = _commit_count(repo, old_sha, new_sha) if new_sha != old_sha else 0
+    return RepoUpdate(name, UpdateStatus.UPDATED, old_sha=old_sha, new_sha=new_sha, advanced=advanced)
+
+
 def update_repo(name: str, repo: Path, *, is_primary: bool = False) -> RepoUpdate:
     """Fetch and fast-forward *repo* to its default branch, or skip safely.
 
-    Never stashes, resets, or clobbers.  For an *overlay* repo a non-default
+    Never stashes or clobbers genuine work.  For an *overlay* repo a non-default
     branch or a missing upstream yields a soft :class:`UpdateStatus.SKIPPED`.
     For the *primary*/running clone (``is_primary=True``) those same states are
     a fail-loud currency hazard — the editable ``t3`` the agent runs would
     silently diverge from origin/main — so they yield
     :class:`UpdateStatus.FAILED` plus a prominent warning (#2134).  An
     untracked-only tree is NOT dirt — the ff-pull proceeds.  A failed ``git
-    fetch`` / ``git pull`` always yields :class:`UpdateStatus.FAILED`.
+    fetch`` always yields :class:`UpdateStatus.FAILED`.
+
+    A failed ``git pull --ff-only`` is NOT always terminal: when the divergence
+    is purely already-upstream squash-merged duplicates (zero genuinely-ahead
+    work), the clone self-heals via :func:`_reconcile_squash_merged` (#2400) —
+    ``git reset --hard origin/<default>``, data-loss-free by classifier proof.
+    Genuine un-upstreamed work blocks the reconcile and is surfaced loudly.
     """
     blocked = _precondition_block(name, repo, is_primary=is_primary)
     if blocked is not None:
@@ -311,7 +404,7 @@ def update_repo(name: str, repo: Path, *, is_primary: bool = False) -> RepoUpdat
     old_sha = _short_sha(repo)
     pull = _git(repo, "pull", "--ff-only", expected_codes=None)
     if pull.returncode != 0:
-        return RepoUpdate(name, UpdateStatus.FAILED, reason=f"git pull --ff-only failed: {pull.stderr.strip()}")
+        return _reconcile_squash_merged(name, repo, old_sha, pull.stderr.strip())
 
     new_sha = _short_sha(repo)
     if new_sha == old_sha:

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -20,6 +20,7 @@ import typer
 import teatree.cli.setup as setup_mod
 import teatree.config as config_mod
 from teatree.cli import update as update_mod
+from teatree.cli._update_reconcile import _cherry_not_upstream, _merge_commits_in_range
 from teatree.cli.update import (
     ReinstallResult,
     RepoUpdate,
@@ -648,20 +649,27 @@ class TestSelfDbMigrationOnUpdate:
             update_mod._run_update()
 
 
-def _squash_merge_into_remote(tmp_path: Path, bare: Path, *, local_subject: str, file_content: str) -> str:
+def _squash_merge_into_remote(
+    tmp_path: Path, bare: Path, *, local_subject: str, file_content: str, filename: str = "feature.txt"
+) -> str:
     """Apply *file_content* under a NEW squash commit on the remote ``main``.
 
     Models a forge squash-merge: the local branch's work (subject
     *local_subject*) lands on ``origin/main`` as a single NEW commit whose
     subject carries the canonical ``(#NNN)`` suffix the PR-merge adds — so the
     classifier matches it by subject, not by SHA. Returns the remote head sha.
+
+    *filename* lets a multi-commit scenario land each local commit's patch
+    under a distinct path, so the upstream commit is patch-equivalent to the
+    local one (``git cherry`` reports ``-``) — a true per-commit squash-merge,
+    not a content-divergent approximation.
     """
     work = tmp_path / f"squash-{local_subject.replace(' ', '-')}"
     _git(tmp_path, "clone", str(bare), str(work))
     _git(work, "config", "user.email", "t@e.st")  # privacy-scan:allow (fake test git-config email, not PII)
     _git(work, "config", "user.name", "Tester")
-    (work / "feature.txt").write_text(file_content)
-    _git(work, "add", "feature.txt")
+    (work / filename).write_text(file_content)
+    _git(work, "add", filename)
     # The squash commit's subject = the local subject + the (#NNN) suffix the
     # forge adds on merge — exactly the shape _canonicalize_subject strips.
     _git(work, "commit", "-m", f"{local_subject} (#42)")
@@ -684,21 +692,30 @@ class TestUpdateReconcilesSquashMergedClone:
     def test_update_reconciles_squash_merged_clone(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         bare = _make_remote(tmp_path)
         clone = _clone(tmp_path, bare)
-        # Local commit (the work that will be squash-merged upstream).
-        (clone / "feature.txt").write_text("the feature\n")
-        _git(clone, "add", "feature.txt")
-        _git(clone, "commit", "-m", "add the feature")
-        # A second local commit, also destined to land squashed (ahead 2).
-        (clone / "feature.txt").write_text("the feature\nrefined\n")
-        _git(clone, "add", "feature.txt")
-        _git(clone, "commit", "-m", "refine the feature")
-        # Upstream squash-merges that work (one new commit) AND moves on with
-        # unrelated commits → the clone is now [ahead 2, behind M].
+        # Two local commits, each a self-contained patch (distinct file) so each
+        # lands PATCH-EQUIVALENT upstream — a true per-commit squash-merge that
+        # `git cherry` confirms with a leading '-'.
+        (clone / "first.txt").write_text("the first feature\n")
+        _git(clone, "add", "first.txt")
+        _git(clone, "commit", "-m", "add the first feature")
+        (clone / "second.txt").write_text("the second feature\n")
+        _git(clone, "add", "second.txt")
+        _git(clone, "commit", "-m", "add the second feature")
+        # Upstream squash-merges each commit (verbatim patch, new SHA) AND moves
+        # on with unrelated commits → the clone is now [ahead 2, behind M].
         _squash_merge_into_remote(
-            tmp_path, bare, local_subject="add the feature", file_content="the feature\nrefined\n"
+            tmp_path,
+            bare,
+            local_subject="add the first feature",
+            file_content="the first feature\n",
+            filename="first.txt",
         )
         _squash_merge_into_remote(
-            tmp_path, bare, local_subject="refine the feature", file_content="the feature\nrefined\nagain\n"
+            tmp_path,
+            bare,
+            local_subject="add the second feature",
+            file_content="the second feature\n",
+            filename="second.txt",
         )
         _advance_remote(tmp_path, bare, commits=2)
 
@@ -809,6 +826,161 @@ class TestUpdateReconcilesSquashMergedClone:
         assert result.status is UpdateStatus.FAILED
         assert result.is_error is True
         assert "reconcile reset failed" in result.reason
+
+    def test_reconcile_refuses_subject_colliding_genuine_commit(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Vector B: a GENUINE un-upstreamed file change whose subject happens to
+        # collide with an unrelated upstream commit of the same canonicalized
+        # subject (a routine "chore: update dependencies" — exactly what a retro
+        # commit looks like). The subject classifier buckets it ``squash_merged``,
+        # but its PATCH is not upstream → the content gate must refuse the reset,
+        # warn loudly naming the genuine sha, and preserve the file.
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        # Genuine local work with a routine, collision-prone subject.
+        (clone / "genuine.txt").write_text("genuine un-upstreamed content\n")
+        _git(clone, "add", "genuine.txt")
+        _git(clone, "commit", "-m", "chore: update dependencies")
+        genuine_sha = _git(clone, "rev-parse", "HEAD")
+        # Upstream has an UNRELATED commit with the same canonicalized subject
+        # (different content), then moves on — so the clone is [ahead 1, behind M].
+        _squash_merge_into_remote(
+            tmp_path, bare, local_subject="chore: update dependencies", file_content="totally unrelated upstream\n"
+        )
+        _advance_remote(tmp_path, bare, commits=1)
+
+        result = update_repo("ovl", clone)
+
+        # Subject collides → subject classifier says "squash-merged", but the
+        # patch is NOT upstream → content gate refuses the reset.
+        assert result.status is UpdateStatus.FAILED
+        assert _git(clone, "rev-parse", "HEAD") == genuine_sha
+        assert (clone / "genuine.txt").read_text() == "genuine un-upstreamed content\n"
+        out = capsys.readouterr().out
+        assert "WARNING" in out
+        assert genuine_sha[:7] in out
+
+    def test_reconcile_refuses_amended_commit_adding_content(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Vector C: a commit was squash-merged upstream, then AMENDED locally to
+        # add NEW content while keeping the same subject. Subject still matches an
+        # upstream subject → subject classifier says ``squash_merged``, but the
+        # amended patch carries content that never reached origin → the content
+        # gate must refuse the reset and preserve the amendment.
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        (clone / "feature.txt").write_text("the feature\n")
+        _git(clone, "add", "feature.txt")
+        _git(clone, "commit", "-m", "add the feature")
+        # Upstream squash-merges the ORIGINAL content under a new sha.
+        _squash_merge_into_remote(tmp_path, bare, local_subject="add the feature", file_content="the feature\n")
+        _advance_remote(tmp_path, bare, commits=1)
+        # Locally AMEND to add new content the squash never captured, same subject.
+        (clone / "feature.txt").write_text("the feature\nplus a NEW amended line\n")
+        _git(clone, "add", "feature.txt")
+        _git(clone, "commit", "--amend", "-m", "add the feature")
+        amended_sha = _git(clone, "rev-parse", "HEAD")
+
+        result = update_repo("ovl", clone)
+
+        assert result.status is UpdateStatus.FAILED
+        assert _git(clone, "rev-parse", "HEAD") == amended_sha
+        assert (clone / "feature.txt").read_text() == "the feature\nplus a NEW amended line\n"
+        out = capsys.readouterr().out
+        assert "WARNING" in out
+        assert amended_sha[:7] in out
+
+    def test_reconcile_refuses_merge_commit_with_unique_content(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Vector D (evil-merge): a merge commit carrying unique content not in
+        # either parent. Merge commits are bucketed safe by ``merge_commits`` and
+        # carry no patch-id, so the subject/patch classifier sees nothing genuine
+        # to refuse on. The content gate must conservatively refuse any reset
+        # while a merge commit exists in the unique range, preserving the content.
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        # A side branch with a squash-merged-upstream commit subject.
+        _git(clone, "checkout", "-b", "side")
+        (clone / "feature.txt").write_text("the feature\n")
+        _git(clone, "add", "feature.txt")
+        _git(clone, "commit", "-m", "add the feature")
+        _git(clone, "checkout", "main")
+        # Merge the side branch with --no-ff AND inject unique content into the
+        # merge commit itself (the evil-merge: content in neither parent).
+        _git(clone, "merge", "--no-ff", "--no-commit", "side")
+        (clone / "evil.txt").write_text("merge-only content in neither parent\n")
+        _git(clone, "add", "evil.txt")
+        _git(clone, "commit", "-m", "Merge branch 'side'")
+        merge_sha = _git(clone, "rev-parse", "HEAD")
+        # Upstream squash-merges only the feature subject, then moves on.
+        _squash_merge_into_remote(tmp_path, bare, local_subject="add the feature", file_content="the feature\n")
+        _advance_remote(tmp_path, bare, commits=1)
+
+        result = update_repo("ovl", clone)
+
+        # A merge commit in the unique range → conservative refuse, never reset.
+        assert result.status is UpdateStatus.FAILED
+        assert _git(clone, "rev-parse", "HEAD") == merge_sha
+        assert (clone / "evil.txt").read_text() == "merge-only content in neither parent\n"
+        out = capsys.readouterr().out
+        assert "WARNING" in out
+
+    def test_reconcile_creates_recoverable_backup_ref(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        # Vector A defense-in-depth: a legit squash-merge still reconciles to
+        # origin, AND a recoverable backup ref/tag pointing at the OLD HEAD now
+        # exists and is named in the reconcile log line — so any future
+        # misclassification is trivially recoverable, not just via the reflog.
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        (clone / "feature.txt").write_text("the feature\n")
+        _git(clone, "add", "feature.txt")
+        _git(clone, "commit", "-m", "add the feature")
+        pre_reset_head = _git(clone, "rev-parse", "HEAD")
+        _squash_merge_into_remote(tmp_path, bare, local_subject="add the feature", file_content="the feature\n")
+        _advance_remote(tmp_path, bare, commits=1)
+
+        result = update_repo("ovl", clone)
+
+        # The legit squash-merge still reconciles to origin/main.
+        assert result.status is UpdateStatus.UPDATED
+        assert _git(clone, "rev-parse", "HEAD") == _git(clone, "rev-parse", "origin/main")
+        # A backup ref at the OLD HEAD now exists and is recoverable.
+        backup_refs = _git(clone, "for-each-ref", "--format=%(refname)", "refs/t3-reconcile-backup/").splitlines()
+        assert backup_refs, "expected a t3-reconcile-backup ref pointing at the old HEAD"
+        recovered = {_git(clone, "rev-parse", ref) for ref in backup_refs}
+        assert pre_reset_head in recovered
+        # The backup ref name AND the pre-reset HEAD sha are surfaced in the log.
+        out = capsys.readouterr().out
+        assert "t3-reconcile-backup" in out
+        assert pre_reset_head[:7] in out
+
+
+class TestContentGateFailsSafe:
+    """An inconclusive content check must REFUSE the reset, never authorize it.
+
+    Both gate probes (``git cherry`` and ``git rev-list --merges``) fail safe:
+    a non-zero git exit (a corrupt ref, a missing target) is inconclusive, so
+    the helper reports an opaque genuine "sha" and the caller keeps the
+    conservative refuse — ambiguity never reaps real work.
+    """
+
+    def test_cherry_failure_reports_a_genuine_blocker(self, tmp_path: Path) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        # An unresolvable target makes `git cherry` exit non-zero (rc 128).
+        blockers = _cherry_not_upstream(clone, "origin/does-not-exist")
+        assert blockers, "an inconclusive git cherry must report a blocker, not an empty pass"
+        assert "inconclusive" in blockers[0]
+
+    def test_rev_list_merges_failure_reports_a_genuine_blocker(self, tmp_path: Path) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        blockers = _merge_commits_in_range(clone, "origin/does-not-exist")
+        assert blockers, "an inconclusive git rev-list --merges must report a blocker, not an empty pass"
+        assert "inconclusive" in blockers[0]
 
 
 class TestRunCallback:

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -407,21 +407,26 @@ class TestUpdateRepoHardFailures:
         assert "origin/head" in result.reason.lower()
         assert result.is_error is False
 
-    def test_non_fast_forward_pull_is_a_hard_failure(self, tmp_path: Path) -> None:
-        # Local default branch has a committed divergence from the remote, so
-        # `git pull --ff-only` cannot fast-forward → FAILED (never rebased).
+    def test_non_fast_forward_pull_with_genuine_work_is_a_hard_failure(self, tmp_path: Path) -> None:
+        # Local default branch has a GENUINE committed divergence from the remote
+        # (real un-upstreamed work), so `git pull --ff-only` cannot fast-forward.
+        # The reconcile classifier (#2400) sees genuinely-ahead work → FAILED
+        # (never rebased, never reset — the genuine commit is preserved).
         bare = _make_remote(tmp_path)
         clone = _clone(tmp_path, bare)
         _advance_remote(tmp_path, bare)
         (clone / "f.txt").write_text("divergent local commit\n")
         _git(clone, "add", "f.txt")
         _git(clone, "commit", "-m", "local divergence")
+        local_head = _git(clone, "rev-parse", "HEAD")
 
         result = update_repo("clone", clone)
 
         assert result.status is UpdateStatus.FAILED
         assert result.is_error is True
-        assert "ff-only" in result.reason.lower()
+        assert "genuine" in result.reason.lower()
+        # Data-loss-free: the genuine commit is preserved, never reset away.
+        assert _git(clone, "rev-parse", "HEAD") == local_head
 
 
 class TestGitToplevel:
@@ -641,6 +646,169 @@ class TestSelfDbMigrationOnUpdate:
 
         with pytest.raises((SystemExit, click.exceptions.Exit)):
             update_mod._run_update()
+
+
+def _squash_merge_into_remote(tmp_path: Path, bare: Path, *, local_subject: str, file_content: str) -> str:
+    """Apply *file_content* under a NEW squash commit on the remote ``main``.
+
+    Models a forge squash-merge: the local branch's work (subject
+    *local_subject*) lands on ``origin/main`` as a single NEW commit whose
+    subject carries the canonical ``(#NNN)`` suffix the PR-merge adds — so the
+    classifier matches it by subject, not by SHA. Returns the remote head sha.
+    """
+    work = tmp_path / f"squash-{local_subject.replace(' ', '-')}"
+    _git(tmp_path, "clone", str(bare), str(work))
+    _git(work, "config", "user.email", "t@e.st")  # privacy-scan:allow (fake test git-config email, not PII)
+    _git(work, "config", "user.name", "Tester")
+    (work / "feature.txt").write_text(file_content)
+    _git(work, "add", "feature.txt")
+    # The squash commit's subject = the local subject + the (#NNN) suffix the
+    # forge adds on merge — exactly the shape _canonicalize_subject strips.
+    _git(work, "commit", "-m", f"{local_subject} (#42)")
+    _git(work, "push", "origin", "main")
+    return _git(work, "rev-parse", "HEAD")
+
+
+class TestUpdateReconcilesSquashMergedClone:
+    """A clone whose local commits already landed squash-merged self-heals (#2400).
+
+    The recurring `t3 update` brick: an overlay clone is ``[ahead N, behind M]``
+    because its local commits were squash-merged upstream (their patches landed
+    under a new SHA on origin/main). ``git pull --ff-only`` then ABORTS with "Not
+    possible to fast-forward", failing the whole overlay update. When EVERY
+    local-unique commit is an already-upstream duplicate (zero genuinely-ahead
+    work), the update reconciles the clone to origin/main — data-loss-free by
+    construction.
+    """
+
+    def test_update_reconciles_squash_merged_clone(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        # Local commit (the work that will be squash-merged upstream).
+        (clone / "feature.txt").write_text("the feature\n")
+        _git(clone, "add", "feature.txt")
+        _git(clone, "commit", "-m", "add the feature")
+        # A second local commit, also destined to land squashed (ahead 2).
+        (clone / "feature.txt").write_text("the feature\nrefined\n")
+        _git(clone, "add", "feature.txt")
+        _git(clone, "commit", "-m", "refine the feature")
+        # Upstream squash-merges that work (one new commit) AND moves on with
+        # unrelated commits → the clone is now [ahead 2, behind M].
+        _squash_merge_into_remote(
+            tmp_path, bare, local_subject="add the feature", file_content="the feature\nrefined\n"
+        )
+        _squash_merge_into_remote(
+            tmp_path, bare, local_subject="refine the feature", file_content="the feature\nrefined\nagain\n"
+        )
+        _advance_remote(tmp_path, bare, commits=2)
+
+        result = update_repo("ovl", clone)
+
+        # Reconciled: HEAD == origin/main, no error.
+        assert result.status is UpdateStatus.UPDATED
+        assert result.is_error is False
+        assert _git(clone, "rev-parse", "HEAD") == _git(clone, "rev-parse", "origin/main")
+        # A clear, non-silent reconcile log line naming the dropped duplicates.
+        out = capsys.readouterr().out
+        assert "reconcil" in out.lower()
+        assert str(clone) in out
+        assert "2" in out  # dropped 2 already-upstream duplicate commits
+
+    def test_update_keeps_clone_with_genuine_unique_commit(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # One squash-merged duplicate AND one genuine un-upstreamed commit. The
+        # reconcile path must NOT reset — genuine work is never destroyed — and
+        # must surface a loud warning naming the genuine sha.
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        (clone / "feature.txt").write_text("the feature\n")
+        _git(clone, "add", "feature.txt")
+        _git(clone, "commit", "-m", "add the feature")
+        # Genuine work that was NEVER upstreamed.
+        (clone / "genuine.txt").write_text("real un-upstreamed work\n")
+        _git(clone, "add", "genuine.txt")
+        _git(clone, "commit", "-m", "genuine local work nobody has")
+        genuine_sha = _git(clone, "rev-parse", "HEAD")
+        # Upstream squash-merges only the FIRST commit, then moves on (behind M).
+        _squash_merge_into_remote(tmp_path, bare, local_subject="add the feature", file_content="the feature\n")
+        _advance_remote(tmp_path, bare, commits=2)
+
+        result = update_repo("ovl", clone)
+
+        # Genuine work blocks the reconcile → hard FAILED, never reset.
+        assert result.status is UpdateStatus.FAILED
+        # NOT reset — the genuine commit is still HEAD, content preserved.
+        assert _git(clone, "rev-parse", "HEAD") == genuine_sha
+        assert (clone / "genuine.txt").read_text() == "real un-upstreamed work\n"
+        # A loud warning naming the genuine sha (short form is what users grep).
+        out = capsys.readouterr().out
+        assert "WARNING" in out
+        assert genuine_sha[:7] in out
+
+    def test_update_does_not_reset_off_main_branch(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        # Guard 4: even when every local-unique commit is a squash-merged
+        # duplicate, a clone parked on a FEATURE branch (not its default branch)
+        # must never be reset by the reconcile path — it is intentionally off
+        # main. The default-branch precondition gate keeps it a skip/warn.
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        _git(clone, "checkout", "-b", "feature/intentional")
+        (clone / "feature.txt").write_text("the feature\n")
+        _git(clone, "add", "feature.txt")
+        _git(clone, "commit", "-m", "add the feature")
+        feature_head = _git(clone, "rev-parse", "HEAD")
+        _squash_merge_into_remote(tmp_path, bare, local_subject="add the feature", file_content="the feature\n")
+        _advance_remote(tmp_path, bare, commits=1)
+
+        result = update_repo("ovl", clone)
+
+        # Off-default-branch is a soft skip for an overlay — never a reset.
+        assert result.status is UpdateStatus.SKIPPED
+        assert _git(clone, "rev-parse", "HEAD") == feature_head
+        assert _git(clone, "rev-parse", "--abbrev-ref", "HEAD") == "feature/intentional"
+
+    def test_genuine_divergence_warning_elides_a_long_commit_list(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # More genuine commits than the preview cap → the warning lists the cap
+        # and elides the remainder with a trailing ellipsis.
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        for n in range(5):
+            (clone / "genuine.txt").write_text(f"genuine work {n}\n")
+            _git(clone, "add", "genuine.txt")
+            _git(clone, "commit", "-m", f"genuine commit number {n} nobody upstreamed")
+        _advance_remote(tmp_path, bare, commits=1)
+
+        result = update_repo("ovl", clone)
+
+        assert result.status is UpdateStatus.FAILED
+        out = capsys.readouterr().out
+        assert "…" in out  # the elision marker for the over-cap remainder
+        assert "5 genuine" in result.reason  # all five are counted in the reason
+
+    def test_reconcile_reset_failure_is_a_hard_failure(self, tmp_path: Path) -> None:
+        # A real reset failure: an unremovable index.lock makes `git reset
+        # --hard` abort. The reconcile must surface BOTH the original ff-only
+        # stderr and the reset failure, and stay FAILED (never a green claim).
+        bare = _make_remote(tmp_path)
+        clone = _clone(tmp_path, bare)
+        (clone / "feature.txt").write_text("the feature\n")
+        _git(clone, "add", "feature.txt")
+        _git(clone, "commit", "-m", "add the feature")
+        _squash_merge_into_remote(tmp_path, bare, local_subject="add the feature", file_content="the feature\n")
+        _advance_remote(tmp_path, bare, commits=1)
+        # Fetch so origin/main is current and the ff-pull will diverge; then
+        # plant an index.lock so the reconcile `reset --hard` cannot proceed.
+        _git(clone, "fetch", "origin")
+        (clone / ".git" / "index.lock").write_text("")
+
+        result = update_repo("ovl", clone)
+
+        assert result.status is UpdateStatus.FAILED
+        assert result.is_error is True
+        assert "reconcile reset failed" in result.reason
 
 
 class TestRunCallback:


### PR DESCRIPTION
## What

`t3 update` self-heals a clone whose `git pull --ff-only` aborts purely on squash-merged divergence (`[ahead N, behind M]` where the local commits already landed upstream under a new SHA). The original #2400 implementation authorized `git reset --hard origin/<default>` whenever the subject classifier (`classify_branch_commits`) reported zero genuinely-ahead commits.

## Data-loss bug fixed (adversarial-review HOLD)

The subject classifier buckets `squash_merged` purely by canonicalized-subject membership in the last 500 upstream subjects — **no content/patch-id/tree check**. So a genuine un-upstreamed commit whose subject merely collides with an upstream subject was misclassified `squash_merged`, and the reset destroyed it. Three reproduced data-loss vectors:

- **B (subject collision):** a genuine file change with a routine subject (`chore: update dependencies`, `docs: update skills` — exactly what retro commits look like) colliding with an unrelated upstream commit of the same canonicalized subject.
- **C (amended adds content):** a commit amended to add new content after the original was squashed upstream; subject unchanged → misclassified.
- **D (evil-merge):** a merge commit carrying unique content in neither parent; merge commits are bucketed safe by subject and carry no patch-id.

## The fix — content gate, not subject gate

The subject classifier stays as a cheap **pre-filter**, but it no longer authorizes the reset. Before any reset an **authoritative content gate** runs; the reset proceeds ONLY when BOTH hold:

1. `git cherry origin/<default> HEAD` reports every unique non-merge commit as patch-equivalent upstream (no `+` line). Any `+` commit → refuse + loud warn naming the sha(s). Closes B and C.
2. `git rev-list --merges origin/<default>..HEAD` is empty. Any merge commit → refuse + warn (a merge cannot be cheaply proven to introduce no unique content). Closes D.

Both probes degrade safely: a non-zero git exit is inconclusive and reports a blocker, so an uncertain content check refuses rather than reaps.

## Defense-in-depth — recoverable backup ref

Immediately before the authorized reset a recoverable `refs/t3-reconcile-backup/<sha>` ref is force-created at the pre-reset HEAD, and the backup ref name + pre-reset HEAD sha are surfaced in the reconcile log line — so any future misclassification is trivially recoverable (not just via the reflog).

## Tests (real temp git repos, no git mocks; all observed RED before the fix)

- `test_reconcile_refuses_subject_colliding_genuine_commit` (vector B)
- `test_reconcile_refuses_amended_commit_adding_content` (vector C)
- `test_reconcile_refuses_merge_commit_with_unique_content` (vector D)
- `test_reconcile_creates_recoverable_backup_ref` (vector A still resets + backup ref exists/named)
- `test_update_reconciles_squash_merged_clone` (vector A) stays green — now models a true per-commit patch-equivalent squash-merge
- two safe-degradation tests cover the inconclusive-git-exit branches

Full `tests/test_cli_update.py`: 51 passed. Full regression suite: 19405 passed.

## Architecture pre-check

- **BLUEPRINT § alignment:** n/a — bug fix within `t3 update`'s existing reconcile path; no model/endpoint/command/config change.
- **Component boundaries:** the content-gated reconcile is extracted to `cli/_update_reconcile.py` (a leaf helper of `cli/update.py`) to keep `update.py` under the module-health LOC cap. `update.py` calls it via a function-local import (established `# noqa: PLC0415` pattern in this file) to break the import cycle; the leaf imports the result types + git helpers back from `update.py`.
- **Dependency direction:** `tach check` + import-linter green.
- **Behavior preservation:** no privacy/security matcher narrowed; no must-block test inverted. The legit-squash-merge vector-A behavior is preserved (still reconciles) — its test now models a genuinely patch-equivalent squash-merge rather than a content-divergent approximation.
