### PR TITLE
docs(rules): re-validate a reused guard in a new destructive context

### DIFF
--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -96,6 +96,7 @@ Use `Ctrl+F`/`grep` to jump to a rule. Sections are grouped below by theme; numb
 41. [Session Scope Management](#session-scope-management)
 42. [Skill Auto-Loading Must Work](#skill-auto-loading-must-work)
 43. [Escalate Honesty-Critical Verification to the Most-Honest Model](#escalate-honesty-critical-verification-to-the-most-honest-model)
+44. [Re-Validate a Reused Guard in a New Destructive Context](#re-validate-a-reused-guard-in-a-new-destructive-context)
 
 ## Invoke Skills Before ANY Response
 
@@ -924,3 +925,7 @@ t3 <overlay> honesty escalate --reason <user_asked|self_assessed_dishonest|accus
 ```
 
 The escalation is **situational and auto-clears** — it is NOT a standing reviewer-model change. It is session-scoped, idempotent (re-firing the same trigger is a no-op), and bounded by a 6-hour safety-net TTL; the primary clear is an honest, verified-complete landing (a fully-passed rubric grade). Rationale: models learn honesty over time, so the most-honest model is the right one to _verify_ a moment the agent's own honesty is in question. The firing is yours to judge (it is prompt-level, SDK-portable — not a CLI-only flag); the consequence (raise → kill-switch → auto-clear) is deterministic. Trigger #4 also has a deterministic backstop: when the rubric done-gate refuses a merge, it records the `shipped_incomplete` escalation for you.
+
+## Re-Validate a Reused Guard in a New Destructive Context
+
+A guard or classifier that is safe for gating one action is not automatically safe for authorizing another. Before reusing an existing guard to authorize a NEW destructive operation (`git reset --hard`, force-delete, force-push, `DROP`/`DELETE`), re-validate that the guard's safety property actually holds for THIS operation — e.g. subject-matching is sufficient to clean up a forge-merged branch, but only content-equivalence (patch-id) is safe before resetting a branch. In a sub-agent brief, never assert a safety property you have not verified; require the implementer to prove the property holds in the new context, and route any change that introduces a destructive operation through an adversarial review that specifically attacks the data-loss path.


### PR DESCRIPTION
## What

Adds one cross-cutting design-principle rule to `skills/rules/SKILL.md` (#44): **Re-Validate a Reused Guard in a New Destructive Context**, and the matching index entry.

## Why

A guard or classifier that is safe for gating one action is not automatically safe for authorizing another. Reusing an existing guard to authorize a NEW destructive operation (`git reset --hard`, force-delete, force-push, `DROP`/`DELETE`) without re-validating its safety property in the new context is a data-loss path. Concretely: subject-matching is sufficient to *recognize* a forge-merged branch, but only content-equivalence (patch-id) is safe before *resetting* or *force-deleting* a branch — a subject collision (e.g. two `docs: update skills` commits) is harmless for recognition but destructive for reset/delete.

The rule also requires that, in a sub-agent brief, the implementer never assert an unverified safety property, that they prove the property holds in the new context, and that any change introducing a destructive operation goes through an adversarial review attacking the data-loss path.

This is the cross-cutting rule companion to the audit issue filed for `classify_branch_commits` content-safety.

## Architecture pre-check — docs(rules)

Tactical docs-only change (one skill prose file + its index entry). Adds no module, no Protocol surface, no FSM transition, no extension-point contract. The nine-check architecture gate does not apply — no `src/` is touched.

## Test surface

Prose rule; the deterministic gates that guard it (skill frontmatter validity, skill-reference resolution, the imperative-rule-needs-companion-code gate #140, banned-terms, and the public-repo leak gate) all pass under `t3 tool verify-gates` (commit + push stages green).
