### PR TITLE
fix(core): poison-pill guard on worktree start/verify for unknown overlay

### DIFF
--- a/src/teatree/core/worktree_tasks.py
+++ b/src/teatree/core/worktree_tasks.py
@@ -39,6 +39,25 @@ class WorktreeTransitionResult(TypedDict, total=False):
     detail: str
 
 
+def _unknown_overlay_reason(worktree: Worktree, *, verb: str) -> str | None:
+    """Return why *worktree*'s overlay is unresolvable, or ``None`` when it resolves.
+
+    The shared poison-pill guard (souliane/teatree#1975, mirroring #1959/#1969):
+    a worktree whose effective overlay (its own field, falling back to the
+    ticket's) names a non-empty overlay that no longer resolves can never run a
+    runner that constructs ``get_overlay_for_worktree`` — it raises ``Overlay
+    not found`` on every re-fire, crashing the FSM worker forever. The workers
+    short-circuit to a recorded ``ok=False`` instead of raising. A blank overlay
+    is the ambient single-overlay default and stays dispatchable (``None``).
+    """
+    from teatree.core.overlay_loader import resolve_overlay_name  # noqa: PLC0415
+
+    effective_overlay = worktree.overlay or worktree.ticket.overlay
+    if effective_overlay and resolve_overlay_name(effective_overlay) is None:
+        return f"unknown overlay {effective_overlay!r}: worktree {worktree.pk} cannot be {verb}"
+    return None
+
+
 @task()
 def execute_worktree_provision(worktree_id: int) -> WorktreeTransitionResult:
     """Run heavy provisioning side-effects for a single worktree.
@@ -58,11 +77,9 @@ def execute_worktree_provision(worktree_id: int) -> WorktreeTransitionResult:
     ticket's) names a non-empty overlay that no longer resolves can never
     provision — ``get_overlay_for_worktree`` raises ``Overlay not found``
     every re-fire. Fail it permanently with a recorded result instead of
-    raising forever. A blank overlay is the ambient single-overlay default
-    and stays dispatchable.
+    raising forever (:func:`_unknown_overlay_reason`). A blank overlay is the
+    ambient single-overlay default and stays dispatchable.
     """
-    from teatree.core.overlay_loader import resolve_overlay_name  # noqa: PLC0415
-
     with transaction.atomic():
         worktree = Worktree.objects.select_for_update().select_related("ticket").get(pk=worktree_id)
         if worktree.state != Worktree.State.PROVISIONED:
@@ -73,9 +90,8 @@ def execute_worktree_provision(worktree_id: int) -> WorktreeTransitionResult:
             )
             return {"worktree_id": worktree_id, "skipped": True, "state": str(worktree.state)}
 
-        effective_overlay = worktree.overlay or worktree.ticket.overlay
-        if effective_overlay and resolve_overlay_name(effective_overlay) is None:
-            reason = f"unknown overlay {effective_overlay!r}: worktree {worktree_id} cannot be provisioned"
+        reason = _unknown_overlay_reason(worktree, verb="provisioned")
+        if reason is not None:
             logger.warning("execute_worktree_provision: %s", reason)
             return {"worktree_id": worktree_id, "ok": False, "detail": reason}
 
@@ -96,9 +112,16 @@ def execute_worktree_start(worktree_id: int) -> WorktreeTransitionResult:
     overlay pre-run steps, and starts ``docker compose up -d``. State stays
     in ``SERVICES_UP`` even on failure so re-firing ``start_services()``
     replays the docker cycle.
+
+    Poison-pill guard at parity with ``execute_worktree_provision``
+    (:func:`_unknown_overlay_reason`): ``WorktreeStartRunner`` resolves the
+    overlay in its ``__init__`` (``get_overlay_for_worktree``), so a worktree
+    whose overlay was uninstalled would raise ``Overlay not found`` on every
+    re-fire. Short-circuit to a recorded ``ok=False`` before constructing the
+    runner so one bad worktree never crashes its FSM worker forever.
     """
     with transaction.atomic():
-        worktree = Worktree.objects.select_for_update().get(pk=worktree_id)
+        worktree = Worktree.objects.select_for_update().select_related("ticket").get(pk=worktree_id)
         if worktree.state != Worktree.State.SERVICES_UP:
             logger.info(
                 "execute_worktree_start skipped for worktree %s: state=%s (not SERVICES_UP)",
@@ -106,6 +129,11 @@ def execute_worktree_start(worktree_id: int) -> WorktreeTransitionResult:
                 worktree.state,
             )
             return {"worktree_id": worktree_id, "skipped": True, "state": str(worktree.state)}
+
+        reason = _unknown_overlay_reason(worktree, verb="started")
+        if reason is not None:
+            logger.warning("execute_worktree_start: %s", reason)
+            return {"worktree_id": worktree_id, "ok": False, "detail": reason}
 
         result = WorktreeStartRunner(worktree).run()
         if not result.ok:
@@ -162,9 +190,16 @@ def execute_worktree_verify(worktree_id: int) -> WorktreeTransitionResult:
     Fired by ``Worktree.verify()``'s on_commit. Health checks are
     best-effort — failures are reported in the result detail but the
     worker does not bounce the FSM back to SERVICES_UP.
+
+    Poison-pill guard at parity with ``execute_worktree_provision``
+    (:func:`_unknown_overlay_reason`): ``WorktreeVerifyRunner`` resolves the
+    overlay in its ``__init__`` (``get_overlay_for_worktree``), so a worktree
+    whose overlay was uninstalled would raise ``Overlay not found`` on every
+    re-fire. Short-circuit to a recorded ``ok=False`` before constructing the
+    runner.
     """
     with transaction.atomic():
-        worktree = Worktree.objects.select_for_update().get(pk=worktree_id)
+        worktree = Worktree.objects.select_for_update().select_related("ticket").get(pk=worktree_id)
         if worktree.state != Worktree.State.READY:
             logger.info(
                 "execute_worktree_verify skipped for worktree %s: state=%s (not READY)",
@@ -172,6 +207,11 @@ def execute_worktree_verify(worktree_id: int) -> WorktreeTransitionResult:
                 worktree.state,
             )
             return {"worktree_id": worktree_id, "skipped": True, "state": str(worktree.state)}
+
+        reason = _unknown_overlay_reason(worktree, verb="verified")
+        if reason is not None:
+            logger.warning("execute_worktree_verify: %s", reason)
+            return {"worktree_id": worktree_id, "ok": False, "detail": reason}
 
         result = WorktreeVerifyRunner(worktree).run()
         if not result.ok:

--- a/tests/teatree_core/test_worktree_tasks.py
+++ b/tests/teatree_core/test_worktree_tasks.py
@@ -46,6 +46,24 @@ class _WorktreeTaskTest(TestCase):
             extra={"worktree_path": "/tmp/wt"},
         )
 
+    def _unknown_overlay_worktree(self, *, state: Worktree.State) -> Worktree:
+        """A worktree whose overlay is no longer registered (uninstalled/foreign).
+
+        ``resolve_overlay_name("ghost-overlay")`` returns ``None`` under the
+        ``{"test": CommandOverlay()}`` registry, so a worker that constructs its
+        runner would call ``get_overlay_for_worktree`` and raise ``Overlay not
+        found`` on every re-fire.
+        """
+        ticket = Ticket.objects.create(overlay="ghost-overlay", issue_url="https://example.com/ghost")
+        return Worktree.objects.create(
+            ticket=ticket,
+            overlay="ghost-overlay",
+            repo_path="repo",
+            branch="feat-x",
+            state=state,
+            extra={"worktree_path": "/tmp/wt"},
+        )
+
 
 class TestExecuteWorktreeProvision(_WorktreeTaskTest):
     def test_skips_when_state_is_not_provisioned(self) -> None:
@@ -92,6 +110,24 @@ class TestExecuteWorktreeStart(_WorktreeTaskTest):
             result = execute_worktree_start.call(wt.pk)
         assert result == {"worktree_id": wt.pk, "ok": False, "detail": "docker-error"}
 
+    def test_unknown_overlay_fails_permanently_not_raises(self) -> None:
+        """An unregistered overlay degrades to a recorded ``ok=False`` — never raises.
+
+        Parity with ``execute_worktree_provision``'s poison-pill guard
+        (souliane/teatree#1975). The real start runner resolves the overlay in
+        its ``__init__`` (``get_overlay_for_worktree``), which raises ``Overlay
+        not found`` on every re-fire for a worktree whose overlay was
+        uninstalled. The runner is left UNMOCKED so the test reproduces the
+        actual production raise; the worker must short-circuit BEFORE
+        constructing the runner so one bad worktree never crashes its FSM
+        worker forever.
+        """
+        wt = self._unknown_overlay_worktree(state=Worktree.State.SERVICES_UP)
+        result = execute_worktree_start.call(wt.pk)
+        assert result["worktree_id"] == wt.pk
+        assert result["ok"] is False
+        assert "ghost-overlay" in result["detail"]
+
 
 class TestExecuteWorktreeVerify(_WorktreeTaskTest):
     def test_skips_when_state_is_not_ready(self) -> None:
@@ -114,6 +150,23 @@ class TestExecuteWorktreeVerify(_WorktreeTaskTest):
             runner.return_value.run.return_value = RunnerResult(ok=False, detail="sick")
             result = execute_worktree_verify.call(wt.pk)
         assert result == {"worktree_id": wt.pk, "ok": False, "detail": "sick"}
+
+    def test_unknown_overlay_fails_permanently_not_raises(self) -> None:
+        """An unregistered overlay degrades to a recorded ``ok=False`` — never raises.
+
+        Parity with ``execute_worktree_provision``'s poison-pill guard
+        (souliane/teatree#1975). The real verify runner resolves the overlay in
+        its ``__init__`` (``get_overlay_for_worktree``), which raises ``Overlay
+        not found`` on every re-fire for a worktree whose overlay was
+        uninstalled. The runner is left UNMOCKED so the test reproduces the
+        actual production raise; the worker must short-circuit BEFORE
+        constructing the runner.
+        """
+        wt = self._unknown_overlay_worktree(state=Worktree.State.READY)
+        result = execute_worktree_verify.call(wt.pk)
+        assert result["worktree_id"] == wt.pk
+        assert result["ok"] is False
+        assert "ghost-overlay" in result["detail"]
 
 
 class TestExecuteWorktreeTeardown(_WorktreeTaskTest):


### PR DESCRIPTION
## Summary

A loop-tick / FSM worker could **raise forever** instead of degrading to a
per-unit failed outcome when a worktree's overlay is no longer registered
(uninstalled, or a foreign/unregistered overlay).

`execute_worktree_provision` already poison-guards this case (souliane/teatree#1975):
`WorktreeProvisionRunner.__init__` calls `get_overlay_for_worktree`, which raises
`ImproperlyConfigured: Overlay '<name>' not found` on every at-least-once
re-fire, so the worker short-circuits to a recorded `ok=False` instead.

`execute_worktree_start` and `execute_worktree_verify` were **missing the same
guard** — `WorktreeStartRunner` / `WorktreeVerifyRunner` also resolve the overlay
in `__init__` via `get_overlay_for_worktree`, so a worktree whose overlay was
uninstalled raised `ImproperlyConfigured` on every re-fire and crashed its FSM
worker forever. This is the asymmetry that left start/verify fragile while the
pull/self_update scanners (e.g. `self_update <repo> outcome=failed reason=pull:...`)
degrade gracefully.

## Fix

- Extract the guard into a shared `_unknown_overlay_reason(worktree, *, verb)`
  helper (one source of truth for all three workers).
- Apply it to `execute_worktree_start` and `execute_worktree_verify` at parity
  with `execute_worktree_provision`: a worktree whose effective overlay (its own
  field, falling back to the ticket's) no longer resolves returns
  `{ok: False, detail: "unknown overlay ..."}` with a logged reason — never a raise.
- Add `select_related("ticket")` to the start/verify selects so the fallback to
  `ticket.overlay` needs no extra query inside the locked transaction.

A blank overlay stays the ambient single-overlay default and remains
dispatchable; a known/registered overlay is unaffected (runner constructed and
run as before).

## Tests (TDD — RED before GREEN)

`tests/teatree_core/test_worktree_tasks.py`:
- `TestExecuteWorktreeStart::test_unknown_overlay_fails_permanently_not_raises`
- `TestExecuteWorktreeVerify::test_unknown_overlay_fails_permanently_not_raises`

Both use a worktree whose overlay is unregistered and leave the runner UNMOCKED
so the test reproduces the real production raise. RED before the fix
(`ImproperlyConfigured: Overlay 'ghost-overlay' not found` from `overlay_loader.py:62`);
GREEN after (`{ok: False}`, no raise). Anti-vacuity verified by reverting only
the source fix with the tests in place — both go RED.

Full module: 18 passed. Related slices (`test_tasks`, `test_overlay_loader`,
`models/test_worktree`, `test_worktree_env_multi_overlay`): 114 passed.
`ruff` / `ruff format` / `tach` / `ty` all clean; all pre-commit hooks pass.

## Architecture pre-check — loop-tick robustness (unknown-overlay poison-pill on start/verify)

### 1. BLUEPRINT § alignment
§4 (Domain Models — Worktree FSM transitions provision/start_services/verify/teardown).
Hardens the FSM task workers so one bad unit degrades to a recorded `ok=False`
outcome instead of raising forever. No FSM graph change.

### 2. FSM phase boundaries
No new phases/transitions. Change is inside the `post_transition` workers backing
`Worktree.start_services()` (→ SERVICES_UP) and `Worktree.verify()` (→ READY),
bringing them to parity with the provision worker's existing guard.

### 3. Extension-point contracts
Touches consumers of `OverlayBase` only indirectly via `get_overlay_for_worktree`.
No `OverlayBase` hook signature change; no scanner/hook registration change. The
runner constructors keep calling `get_overlay_for_worktree`; the guard is hoisted
to the worker, before the runner is constructed.

### 4. Component boundaries
`src/teatree/core/worktree_tasks.py` — the FSM task workers, the at-least-once
delivery boundary where "fail permanently with a recorded result vs raise forever"
is decided. No new module.

### 5. Dependency direction
Reuses the already-imported `resolve_overlay_name` from
`teatree.core.overlay_loader`. No new cross-module import; no backwards edge.
`uv run tach check` → All modules validated.

### 6. Test surface
See Tests above — assertion per behaviour (`ok=False`, reason names the overlay,
no raise); FSM-state-guarded (SERVICES_UP / READY).

### 7. Resilience invariants
idempotency: the guard returns the same `ok=False` on every re-fire with no state
mutation — at-least-once safe. No new transport/heartbeat surface. This is the
degrade-to-failed contract the resilient pull/self_update scanners already model.

### 8. Identity and key normalization
Overlay name has bare-vs-canonical forms; `resolve_overlay_name` is the single
canonical resolver (same one the provision worker uses). The guard canonicalizes
the worktree's effective overlay UP and treats an unresolvable name as the
poison-pill — no stripping.

### 9. Behavior preservation / capability deletion
n/a — purely additive guard. Blank overlay stays dispatchable; known overlay
unaffected; no must-block test inverted; no matcher narrowed.

Maker != checker — opening for review, not merging.
