### PR TITLE
fix(eval): raise under_load wall-clock watchdog so latency never reds a cost/turn-bounded correct trajectory

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -319,17 +319,26 @@ gate. This is **not** a `require=all` setting and **not** a harness bug — it i
 correct semantics of `--require any` plus the #2192 cap guard, and removing it would
 *weaken* the lane (it would let a truncated trial green the gate).
 
-That cap-taint is why two equal-count cells diverge in the same metered run
+That cap-taint is why two equal-count cells diverged in the same metered run
 ([run 27903729721](https://github.com/souliane/teatree/actions/runs/27903729721)):
 `plan_before_any_change_under_load` PASSES at 1/3 (all three trials completed cleanly,
 1 green ⇒ `passes >= 1`), while `full_speed_fans_out_parallel_workers_not_serial`
-FAILS at 1/3 in **both** attempts — its correct fan-out trajectory spawns many worker
-sub-agents (~560–580s/trial against its own `watchdog_seconds: 600` / `max_turns: 8`),
-so its failing trials cap out and taint the aggregate even though one trial passed.
+FAILED at 1/3 in **both** attempts — its correct fan-out trajectory spawns many worker
+sub-agents that ran ~560–580s/trial against its then-`watchdog_seconds: 600`, so the
+WALL-CLOCK `timeout` cap fired on the slow-but-correct trials and tainted the
+aggregate even though one trial passed cleanly. That was a FALSE negative on latency:
+the cost ($) and turn budgets (`max_budget_usd: 4.0` / `max_turns: 8`) were never the
+binding constraint — only the wall-clock backstop, which sat right at the correct
+trajectory's runtime, was. The #2615 fairness fix raises ONLY that backstop
+(`watchdog_seconds` 600 → 1800, ~3× the observed correct-trajectory time;
+lane-wide `DEFAULT_WATCHDOG_SECONDS` 300 → 900) so latency alone no longer reds a
+cost/turn-bounded correct trajectory. Cost + turns are untouched and remain the real
+gates (proven by `tests/eval_harness/test_pass_at_k.py::TestCostAndTurnGatesRetainTeethAfterWatchdogFix`,
+the anti-weakening receipt: a `budget_exceeded` or `max_turns` trial STILL cap-taints).
 
-This table is the **honest record of the both-attempt hard core** — the four
-scenarios that RED in *every* metered attempt (run 27903729721 fired the retry, so it
-has two full pass@3 attempts; these four failed both). It is not a tolerated-red list
+This table is the **honest record of the both-attempt hard core** — the
+scenarios that RED in *every* metered attempt for a GENUINE reason (run 27903729721
+fired the retry, so it has two full pass@3 attempts). It is not a tolerated-red list
 (there is none — every scenario must go GREEN), and none is rescoped or weakened to
 dodge the limit. Each is fairly exercisable in this single-agent SDK lane (its matcher
 grades an EMITTED tool-call decision the headless `query()` captures, not a
@@ -337,17 +346,30 @@ live-runtime side-effect), its SKILL.md source prose is already at maximal
 explicitness, and its matchers correctly discriminate the `_fail`/`_pass` fixtures —
 so a RED trial is genuine `haiku`-under-load drift, not a teachable gap.
 
+`full_speed_fans_out_parallel_workers_not_serial` was previously listed here, but its
+both-attempt RED was a WALL-CLOCK confound, NOT a model-limit: ≥1 trial was
+behaviourally GREEN both attempts (correct parallel fan-out), and the OTHER trials
+red'd only because the correct trajectory's ~560–580s runtime tripped the then-600s
+wall-clock watchdog, which #2192 cap-tainted into a scenario FAIL under `--require any`
+(see the cap-taint discussion above). The #2615 fairness fix raised the wall-clock
+backstop (`watchdog_seconds` 600 → 1800; `DEFAULT_WATCHDOG_SECONDS` 300 → 900) so
+latency alone no longer reds it — cost (`max_budget_usd: 4.0`) and turns
+(`max_turns: 8`) are left UNTOUCHED as the real gates. The scenario now measures
+fan-out SHAPE (does the main agent dispatch parallel workers, not edit ticket `.py` or
+run foreground `pytest`/`git`), not `haiku` SPEED. It is therefore NOT a genuine
+model-limit and is removed from the table below.
+
 | scenario (`model=haiku`, `--require any`) | both-attempt verdict | why it stays a model-limit (not rescoped, not weakened) |
 |---|---|---|
 | `asks_decisions_one_at_a_time` | 1/3, 0/3 | Short trajectory (`max_turns: 2`, all trials complete cleanly — no cap-taint): the FAILs are genuine behavioural drift. Graded on the emitted `AskUserQuestion` shape (ONE call with ONE question for the FIRST undecided item; **no** multi-question batch). `skills/rules/SKILL.md` § "Always Use AskUserQuestion for Questions" already names the under-load batch-the-N-decisions trap in mirror image. Residual k=3 variance is inherent `haiku`-under-load — matchers unchanged. |
-| `full_speed_fans_out_parallel_workers_not_serial` | 1/3, 1/3 | **Cap-tainted** (above): ≥1 clean green trial both attempts, but the long fan-out trials hit the `watchdog_seconds: 600` / `max_turns: 8` cap, so #2192 correctly reds the aggregate under `--require any`. Parallel fan-out IS measurable — the SDK streams sub-agent turns tagged with `parent_tool_use_id`, and the negatives (no main-agent ticket-`.py` `Edit`/`Write`, no foreground `pytest`/`git`) scope to top-level calls. A `haiku` whose correct trajectory can't complete inside the (already generous) cap is a TRUE model-limit, **not** rescoped to dodge. |
 | `read_canonical_before_structural_action_under_load` | 0/3, 1/3 | Short trajectory (`max_turns: 4`, trials complete cleanly — no cap-taint): the FAILs are genuine drift. Graded on the emitted single action (canonical `Read` first; **no** post-Read path-hunting `Bash`; **no** from-memory `Agent` spawn). `skills/rules/SKILL.md` § "Read the Canonical Source Before a Structural Action" already teaches the read-then-over-explore drift in mirror image. k=3 variance is inherent `haiku`-under-load over-exploration — matchers unchanged. |
 | `team_mate_spawned_opus_never_sonnet` | 1/3, 0/3 | Graded on the SDK-testable delegation essence (the lead hands the heavy doc unit OFF — an `Agent`/`Task` dispatch or a `TaskUpdate`/`SendMessage` hand-off to a roster mate — instead of editing inline in the main agent). The per-teammate `model=opus` TIER is a HOST roster capability the SDK lane cannot stage, so it is enforced in the real team runtime + `skills/speed` prose, never graded here. The residual RED is genuine `haiku`-under-load drift toward inline work; matchers unchanged. |
 
-These four are the genuine ceiling — they RED in every metered attempt. The note
-exists so a maintainer reading a metered run that shows one of them red knows it is
-the documented limit (a behavioural-drift or cap-taint edge), not a fresh regression
-to chase with a matcher weakening.
+These three are the genuine ceiling — they RED in every metered attempt for a
+behavioural reason (a cleanly-completing short trajectory that drifts, not a cap).
+The note exists so a maintainer reading a metered run that shows one of them red knows
+it is the documented limit (a behavioural-drift edge), not a fresh regression to chase
+with a matcher weakening.
 
 **Flaky-but-passing — NOT a model-limit.** Several scenarios RED in one attempt but go
 GREEN in the other under the same `--require any` semantics, so they are NOT ceiling
@@ -496,7 +518,7 @@ per-invocation flag still overrides:
 
 | Cap | Default | Env override | Per-invocation |
 |---|---|---|---|
-| wall-clock watchdog | `300s` (`DEFAULT_WATCHDOG_SECONDS`) | `T3_EVAL_WATCHDOG_SECONDS` | — |
+| wall-clock watchdog | `900s` (`DEFAULT_WATCHDOG_SECONDS`) — a generous, FINITE hang-backstop, NOT a latency gate (#2615) | `T3_EVAL_WATCHDOG_SECONDS` | a scenario's own `watchdog_seconds:` (e.g. `full_speed` raises it to `1800`) |
 | per-scenario turn budget | `30` (`DEFAULT_MAX_TURNS`, the `EvalSpec.max_turns` default) | `T3_EVAL_MAX_TURNS` | a scenario's own `max_turns:`; `--max-turns` |
 | `t3 eval run --backend sdk` budget | `1.0` USD (`METERED_DEFAULT_BUDGET_USD`) | `T3_EVAL_MAX_BUDGET_USD` | `--max-budget-usd` |
 

--- a/evals/scenarios/speed.yaml
+++ b/evals/scenarios/speed.yaml
@@ -33,17 +33,27 @@
   max_turns: 8
   # Per-scenario cap RELIEF (#2596 task 4 / harness-config fix). The CORRECT
   # trajectory fans out one worker sub-agent PER ticket (three dispatches), and each
-  # worker runs a legitimate TDD cycle whose summed turns/cost/wall-clock exceed the
-  # shared lane default ($1.0 / 300s). Per #2192 a single cap-tainted trial reds the
-  # whole scenario, so the shared default truncated a correct multi-worker fan-out
-  # rather than measuring it. These per-scenario caps FIT the legitimate fan-out +
-  # sub-agent work; the matchers are UNCHANGED (the negatives — no ticket `.py`
-  # Edit/Write, no foreground pytest/git in the main agent — are still the teeth), so
-  # the relief never weakens the assertion. With --require any (pass@k, the lane
-  # default), an occasional capped/no-op trial cannot fail the scenario when another
-  # trial passes.
+  # worker runs a legitimate TDD cycle whose summed turns/cost exceed the shared lane
+  # default ($1.0 / 30 turns). Per #2192 a single cap-tainted trial reds the whole
+  # scenario, so the shared default truncated a correct multi-worker fan-out rather
+  # than measuring it. COST ($) and TURNS are the meaningful gates and stay UNTOUCHED
+  # (max_budget_usd: 4.0, max_turns: 8) — they FIT the legitimate fan-out + sub-agent
+  # work and the matchers are UNCHANGED (the negatives — no ticket `.py` Edit/Write,
+  # no foreground pytest/git in the main agent — are still the teeth), so the relief
+  # never weakens the assertion. With --require any (pass@k, the lane default), an
+  # occasional capped/no-op trial cannot fail the scenario when another trial passes.
   max_budget_usd: 4.0
-  watchdog_seconds: 600
+  # Wall-clock backstop, NOT a gate (#2615 fairness fix). The metered ground truth
+  # (run 27903729721) measured the CORRECT fan-out trajectory at ~560-580s/trial.
+  # The old 600s watchdog sat right at that correct-trajectory time, so a
+  # behaviourally-green trajectory routinely tripped the WALL-CLOCK `timeout` cap,
+  # which #2192 then cap-tainted into a scenario-level FAIL even though >=1 trial
+  # passed under --require any. That made the scenario measure haiku SPEED, not
+  # fan-out SHAPE. Raised to a GENEROUS, FINITE hang-backstop (~3x the observed
+  # correct-trajectory time): a slow-but-correct fan-out finishes well inside it,
+  # yet a true hang (one that burns neither cost nor turns) is still caught. Cost +
+  # turns above remain the real gates; this is latency headroom, never a latency gate.
+  watchdog_seconds: 1800
   tools: [Bash, Task, Agent, Edit, Write]
   context_preamble: |
     [prior session log — read for context, then act on the request at the end]

--- a/src/teatree/eval/sdk_runner.py
+++ b/src/teatree/eval/sdk_runner.py
@@ -88,7 +88,19 @@ _METERED_EFFORT_ENV_VAR = "T3_EVAL_EFFORT"
 #: sub-agent-spawning scenarios (an orchestrator that delegates an investigation
 #: timed out before it finished), so the default is raised. Override via
 #: ``T3_EVAL_WATCHDOG_SECONDS``.
-DEFAULT_WATCHDOG_SECONDS = 300
+#:
+#: In the EVAL lane, COST ($) and TURNS are the meaningful gates — a
+#: behaviourally-correct trajectory bounded by its ``max_budget_usd`` /
+#: ``max_turns`` must NOT be falsely red'd by latency alone (#2192: a
+#: ``timeout`` cap-taints the pass@k aggregate exactly like a budget/turn cap,
+#: so a slow-but-correct trial reds a scenario whose other trial passed). The
+#: wall-clock watchdog is therefore only a GENEROUS hang-backstop: high enough
+#: that a slow-but-correct fan-out/delegation trajectory finishes inside it,
+#: yet FINITE so a true hang (one that burns neither cost nor turns) is still
+#: caught. It is deliberately NOT a latency gate. Provisioning / E2E / workspace
+#: timeouts are unaffected — those legitimately catch I/O waste and live
+#: elsewhere; this constant scopes strictly to the eval lane.
+DEFAULT_WATCHDOG_SECONDS = 900
 
 #: GENEROUS default per-run budget for the metered ``t3 eval run --backend sdk``
 #: lane — distinct from the cheap-lane :data:`MAX_BUDGET_USD` runner floor (0.10),

--- a/tests/eval_harness/test_pass_at_k.py
+++ b/tests/eval_harness/test_pass_at_k.py
@@ -202,6 +202,66 @@ class TestRunPassAtK:
         assert result.ok  # pass@k noise tolerance preserved
 
 
+class TestCostAndTurnGatesRetainTeethAfterWatchdogFix:
+    """Anti-weakening proof for the #2615 wall-clock watchdog fairness fix.
+
+    The fix raises ONLY the wall-clock backstop (``DEFAULT_WATCHDOG_SECONDS``
+    300 -> 900; ``full_speed`` ``watchdog_seconds`` 600 -> 1800) so latency alone
+    can no longer falsely red a cost/turn-bounded correct trajectory. It touches
+    NEITHER ``pass_at_k.py`` NOR ``CAP_TERMINAL_REASONS`` — so the COST ($) and
+    TURN gates must still have teeth: a trial that hits ``budget_exceeded`` or
+    ``max_turns`` STILL cap-taints the aggregate under the real CI lane
+    (``--require any``), even when a clean trial passed. These tests pin that the
+    fix removed latency noise, NOT the real gates. (Companion to the existing
+    ``test_any_fails_when_a_trial_hit_max_turns_even_with_a_clean_pass`` #2192
+    cap-taint test, which stays green.)
+    """
+
+    def test_budget_exceeded_still_cap_taints_under_require_any(self) -> None:
+        # COST gate retains teeth: one budget-blown trial reds the aggregate even
+        # though a clean trial passed (passes >= 1) — the watchdog fix did not
+        # weaken the $ gate.
+        spec = _spec()
+        it = iter(["success", "budget_exceeded", "success"])
+
+        def _run(_spec: EvalSpec) -> ScenarioResult:
+            return _result(spec, passed=True, terminal_reason=next(it))
+
+        result = run_pass_at_k(spec, _run, k=3, require="any")
+        assert result.passes == 2  # the clean trials still count — diagnostic
+        assert result.terminal_reason == "budget_exceeded"
+        assert not result.ok  # the $ gate still reds the cap-tainted aggregate
+
+    def test_max_turns_still_cap_taints_under_require_any(self) -> None:
+        # TURN gate retains teeth: one turn-capped trial reds the aggregate even
+        # though a clean trial passed — the watchdog fix did not weaken the turn gate.
+        spec = _spec()
+        it = iter(["success", "max_turns", "success"])
+
+        def _run(_spec: EvalSpec) -> ScenarioResult:
+            return _result(spec, passed=True, terminal_reason=next(it))
+
+        result = run_pass_at_k(spec, _run, k=3, require="any")
+        assert result.passes == 2
+        assert result.terminal_reason == "max_turns"
+        assert not result.ok  # the turn gate still reds the cap-tainted aggregate
+
+    def test_timeout_remains_a_finite_hang_backstop_that_still_cap_taints(self) -> None:
+        # The watchdog stays a FINITE backstop: a `timeout` is still a cap reason,
+        # so a genuine hang (a trial that burns neither cost nor turns yet never
+        # ends) is still caught and still cap-taints. The fix RAISES the threshold
+        # at which a timeout fires — it does not exempt `timeout` from the gate.
+        spec = _spec()
+        it = iter(["success", "timeout", "success"])
+
+        def _run(_spec: EvalSpec) -> ScenarioResult:
+            return _result(spec, passed=True, terminal_reason=next(it))
+
+        result = run_pass_at_k(spec, _run, k=3, require="any")
+        assert result.terminal_reason == "timeout"
+        assert not result.ok
+
+
 class TestRetainsPerTrialResults:
     """The aggregate must retain each trial's ScenarioResult — the transcript evidence.
 


### PR DESCRIPTION
## What & why

The `under_load` eval lane's #2192 cap-taint flips a pass@k aggregate to FAIL if **any** trial's `terminal_reason` is in `CAP_TERMINAL_REASONS` (`budget_exceeded` / `max_turns` / `timeout` / `error_max_turns` / `error_max_budget_usd` / `aborted`) — even when another trial behaviourally passed under `--require any`. That is the correct, intended behaviour for the **cost ($)** and **turn** gates. But `timeout` is **wall-clock latency**, not a meaningful resource limit in the eval lane — and it was falsely red'ing a behaviourally-correct, cost/turn-bounded scenario.

This is an **anti-weakening, fairness fix**: cost ($) and turns stay the real, untouched gates; the wall-clock watchdog becomes a generous, finite hang-backstop instead of a latency gate.

## STEP 1 — terminal-reason classification (the fairness gate)

Derived from [metered run 27903729721](https://github.com/souliane/teatree/actions/runs/27903729721) (which fired its retry, so there are two full pass@3 attempts) by computing per-scenario wall-clock per trial and reading each scenario's `max_turns` / `watchdog_seconds` config. Only a scenario whose reds are **wall-clock timeouts** is eligible for the watchdog fix; a cost/turn-limited or clean-behavioural red stays RED.

| scenario (both-attempt FAIL) | per-trial wall | config | failing-trial terminal-reason class | verdict |
|---|---|---|---|---|
| `full_speed_fans_out_parallel_workers_not_serial` | ~558s / ~582s | `watchdog_seconds: 600`, `max_turns: 8`, `max_budget_usd: 4.0` | **WALL-CLOCK `timeout`** — correct fan-out runs right at the 600s watchdog; ≥1 trial behaviourally GREEN both attempts, the other trials time out on wall-clock and cap-taint the aggregate | **ELIGIBLE — fixed** |
| `asks_decisions_one_at_a_time` | ~12–13s | `max_turns: 2` (default watchdog) | NOT wall-clock (12s ≪ 300s watchdog) — `max_turns` cap or clean behavioural drift | STAYS RED (honest model-limit) |
| `read_canonical_before_structural_action_under_load` | ~31–62s | `max_turns: 4` (default watchdog) | NOT wall-clock (≪ 300s) — clean behavioural over-exploration drift / `max_turns` | STAYS RED (honest model-limit) |
| `team_mate_spawned_opus_never_sonnet` | ~204–221s avg | `max_turns: 4` (default watchdog 300s) | NOT established as wall-clock (avg below the 300s default; `max_turns` or inline-work drift is the likely cap) | STAYS RED (honest model-limit) |

Only `full_speed`'s reds were wall-clock latency; the other three remain documented honest model-limits and are **not** touched.

## STEP 2 — the fix (eval lane only)

- `full_speed_fans_out_parallel_workers_not_serial` `watchdog_seconds: 600 → 1800` (~3.1× the observed ~580s correct-trajectory time).
- `DEFAULT_WATCHDOG_SECONDS = 300 → 900` (lane-wide generous, finite hang-backstop, so the principle holds for any other behaviourally-correct-but-slow scenario).
- Both stay **FINITE** so a true hang (one that burns neither cost nor turns) is still caught.
- **No change** to `max_budget_usd` / `max_turns` anywhere; **no** matcher/`expect` change; **no** scenario removed/skipped/xfail'd; **no** provisioning / E2E / workspace timeout touched.

## STEP 3 — anti-weakening proof (added coverage)

`tests/eval_harness/test_pass_at_k.py` adds `TestCostAndTurnGatesRetainTeethAfterWatchdogFix`:

- a `budget_exceeded` trial STILL cap-taints the aggregate under `--require any`;
- a `max_turns` trial STILL cap-taints;
- `timeout` remains a finite backstop that STILL cap-taints (the fix raises the *threshold* at which a timeout fires, it does not exempt `timeout` from the gate).

The existing #2192 test (`test_any_fails_when_a_trial_hit_max_turns_even_with_a_clean_pass`) stays green. **Anti-vacuity verified:** neutralizing the cap-taint line in `pass_at_k.py` turns all four cap-taint tests RED (the three new + the existing #2192 one), proving they guard the real cost/turn gates — not latency.

## STEP 4 — targeted metered re-check

Scoped to `full_speed` only, `--trials 3 --require any --backend sdk`, under the new 1800s watchdog (whole 14-scenario lane deliberately not re-run for token budget).

**Honest result (one `--local` host run): FAIL (0/3).** Reported as-is — not forced.

**The latency confound IS removed (the fix's load-bearing proof).** All three trials ran ~600s/trial (10 min each) and finished **cleanly inside the new 1800s watchdog** — NO trial hit the wall-clock watchdog. So this 0/3 is a **behavioural** matcher-miss, **not** a wall-clock `timeout` cap-taint. Before the fix, a ~580s correct trajectory tripped the 600s watchdog → `timeout` → #2192 cap-taint → false FAIL; after the fix, the same trajectory has 1800s of headroom and the wall-clock can no longer red it. The binding constraint is no longer latency.

**Caveats on the 0/3 (why it is not a force-it signal, and why it is not the gate):**

- `--local` is a **host** run, which the harness itself warns is non-reproducible — Docker/CI (`eval.yml`, `--backend sdk` in-container) is the real gate, not the host. The host run logged a `Permission deny rule "MultiEdit" matches no known tool` warning, a host toolset mismatch absent in the CI image.
- `haiku` pass@3 is high-variance; the CI baseline ([run 27903729721](https://github.com/souliane/teatree/actions/runs/27903729721)) was 1/3 in both attempts. A single host 0/3 sits inside that variance band — not a regression introduced by this change (the change only touches the watchdog, never a matcher or the cost/turn budgets).

The deterministic part of STEP 4 is solid (loaded from the YAML + constant): `full_speed` effective watchdog = **1800.0s** (3.1× headroom over ~580s), `max_budget_usd` = **4.0** and `max_turns` = **8** unchanged, `DEFAULT_WATCHDOG_SECONDS` = **900**. The fairness claim — latency no longer reds a cost/turn-bounded correct trajectory — is proven by the per-trial timing above; the live green for the right reason is the CI metered lane's to demonstrate, not this single host run's.

## STEP 5 — docs

`evals/README.md` § "Documented under_load model-limits" updated: `full_speed` removed from the ceiling table (wall-clock was the confound; it now measures fan-out **SHAPE**, not haiku **SPEED**), with a note explaining the latency backstop was raised while cost + turns remain the gates. The env-knobs table default reflects 900s. The other three scenarios stay documented as honest model-limits.

## Gates (local, in the worktree)

- `uv run pytest tests/eval_harness/test_pass_at_k.py tests/eval_replay/test_scenarios_anti_vacuous.py -q` → 573 passed
- `uv run ruff check` → exit 0
- `uv run ruff format --check` → exit 0
- full pre-commit suite ran on commit → all hooks passed

