### PR TITLE
fix(dream): home reworded index pointers so re-index clips don't fail gate (c)

### DIFF
--- a/src/teatree/loops/dream/gates.py
+++ b/src/teatree/loops/dream/gates.py
@@ -54,6 +54,13 @@ if TYPE_CHECKING:
 
 _INDEX_NAME = "MEMORY.md"
 _HEADING_RE = re.compile(r"^#{1,6}\s")
+#: The memory-file an index line POINTS AT — the ``](name.md)`` markdown link
+#: target the re-index writes (``- [name.md](name.md) — summary``). Anchored on
+#: the link href, not any ``.md`` token, so a ``.md`` filename merely mentioned
+#: in the free-text summary never counts as the line's target — only a reworded
+#: pointer to a still-present memory homes the line; a genuinely lost pointer
+#: stays unhomed even if its summary name-drops a surviving memory.
+_MEMORY_REF_RE = re.compile(r"]\(([\w.\-/]+\.md)\)")
 
 #: Load-warning thresholds for the rendered ``MEMORY.md`` index (gate d). The
 #: index is one short line per memory; past these the index has stopped being a
@@ -156,6 +163,17 @@ class DreamQaReport:
 
 def _normalize(text: str) -> str:
     return " ".join(text.split()).lower()
+
+
+def _line_targets_live_memory(line: str, snapshot: MemorySnapshot) -> bool:
+    """Whether a pruned index *line* still points at a memory file present after the pass.
+
+    The re-index phase rewrites an index line whenever a curated summary is
+    clipped/reworded — the line TEXT changes but the pointer (and its memory
+    file) survives. Such a line is NOT a lost lesson, so it must count as homed;
+    only a pointer to a memory that actually vanished stays unhomed.
+    """
+    return any(ref in snapshot.memories for ref in _MEMORY_REF_RE.findall(line))
 
 
 def snapshot_memory_dir(memory_dir: Path) -> MemorySnapshot:
@@ -280,12 +298,24 @@ class Gate:
         size drop, no schema growth, no clusters) fails. Independently, any index
         line the pass PRUNED must have a confirmed durable home — a prune with no
         home fails.
+
+        A pruned line is homed when it is in *homed_index_lines* (the durable
+        destination the caller supplies — e.g. a lesson still findable after the
+        pass), OR it still points at a memory file that survived the pass. The
+        latter case is the re-index merely rewording/clipping a curated summary:
+        the line text changes but the pointer is not lost, so it must not count as
+        a prune. Without it every summary clip looked like a lost prune and the
+        pass never stamped success (#2545 staleness defect).
         """
         size_reduced = snapshot_after.byte_size < snapshot_before.byte_size
         schema_grew = schema_after > schema_before
         distilled = clusters_recorded > 0
         pruned_lines = snapshot_before.index_lines - snapshot_after.index_lines
-        unhomed = sorted(line for line in pruned_lines if line not in homed_index_lines)
+        unhomed = sorted(
+            line
+            for line in pruned_lines
+            if line not in homed_index_lines and not _line_targets_live_memory(line, snapshot_after)
+        )
         consolidated = size_reduced or schema_grew or distilled
         passed = consolidated and not unhomed
         if not consolidated:

--- a/tests/teatree_loops/dream/test_gates.py
+++ b/tests/teatree_loops/dream/test_gates.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from django.test import SimpleTestCase, TestCase
 
 from teatree.core.models import DreamQaProbe
-from teatree.loops.dream import gates
+from teatree.loops.dream import gates, reindex
 from teatree.loops.dream.decay import ArchivedMemory
 from teatree.loops.dream.gates import (
     DreamQaReport,
@@ -168,6 +168,47 @@ class TestGateC(SimpleTestCase):
             before, after, schema_before=0, schema_after=0, homed_index_lines=set(), clusters_recorded=2
         )
         assert not result.passed  # consolidation happened but a pruned line is orphaned
+
+    def test_homes_a_reworded_pointer_to_a_surviving_memory(self) -> None:
+        # Re-index (phase 5) clips a long curated summary to <=200 chars: the index
+        # LINE text changes, but feedback_x.md still exists and is still pointed at —
+        # the pointer was reworded, not lost. A reworded pointer is NOT a lost lesson,
+        # so the consolidation gate must NOT flag it as an unhomed prune (#2545 defect:
+        # this perpetually blocked the success marker, keeping staleness firing).
+        long_line = "- [feedback_x.md](feedback_x.md) — BINDING: " + "do the best autonomously; " * 12
+        clipped_line = "- [feedback_x.md](feedback_x.md) — BINDING: do the best autonomously"
+        before = _snapshot({"feedback_x.md": "real body, no summary verbatim"}, index=long_line + "\n")
+        after = _snapshot({"feedback_x.md": "real body, no summary verbatim"}, index=clipped_line + "\n")
+        result = Gate.consolidation_happened(
+            before, after, schema_before=0, schema_after=0, homed_index_lines=set(), clusters_recorded=3
+        )
+        assert result.passed
+
+    def test_a_pruned_pointer_to_a_vanished_memory_is_still_unhomed(self) -> None:
+        # The fix must NOT excuse a genuine loss: feedback_x.md is GONE from the set
+        # and its lesson is not findable elsewhere -> the pruned pointer stays unhomed.
+        line = "- [feedback_x.md](feedback_x.md) — a real lesson"
+        before = _snapshot({"feedback_x.md": "the lesson body", "a.md": "x" * 100}, index=line + "\n- a\n")
+        after = _snapshot({"a.md": "x" * 100}, index="- a\n")  # feedback_x.md archived/deleted
+        result = Gate.consolidation_happened(
+            before, after, schema_before=0, schema_after=0, homed_index_lines=set(), clusters_recorded=3
+        )
+        assert not result.passed
+
+    def test_summary_name_dropping_a_live_memory_does_not_home_a_gone_target(self) -> None:
+        # The pruned line's link TARGET (gone_x.md) vanished, but its free-text summary
+        # mentions a DIFFERENT, surviving memory's filename. Homing keys on the link
+        # target only, never a .md token in the summary — else a real loss is masked.
+        line = "- [gone_x.md](gone_x.md) — superseded; see feedback_live.md for context"
+        before = _snapshot(
+            {"gone_x.md": "the lost lesson", "feedback_live.md": "x" * 50},
+            index=line + "\n- [feedback_live.md](feedback_live.md) — live\n",
+        )
+        after = _snapshot({"feedback_live.md": "x" * 50}, index="- [feedback_live.md](feedback_live.md) — live\n")
+        result = Gate.consolidation_happened(
+            before, after, schema_before=0, schema_after=0, homed_index_lines=set(), clusters_recorded=3
+        )
+        assert not result.passed  # gone_x.md is gone; the summary's mention of a live file must not home it
 
 
 class TestGateD(SimpleTestCase):
@@ -338,6 +379,28 @@ class TestRunAcceptancePass(TestCase):
         snap = _snapshot({"a.md": "name: a\nfact ONE\n"}, index="- fact ONE\n")
         run_acceptance_pass(snap, snap, overlay="acme", archived=[], schema_before=0, schema_after=1, persist=False)
         assert DreamQaProbe.objects.count() == 0
+
+    def test_reindex_clipping_a_long_curated_summary_still_passes(self) -> None:
+        # End-to-end #2545 staleness defect: re-index (phase 5) clips a >200-char
+        # curated MEMORY.md summary, the gate flagged the old long line as an unhomed
+        # prune, and the success marker was never stamped (last_succeeded_at froze).
+        # The pointer still targets the live memory file, so the pass must PASS.
+        d = Path(tempfile.mkdtemp()) / "memory"
+        d.mkdir()
+        long_summary = "BINDING: " + "do the best autonomously and never introduce tech debt; " * 8
+        (d / "feedback_x.md").write_text(
+            f"---\nname: feedback_x\ndescription: {long_summary}\nmetadata:\n  type: feedback\n---\n\nbody\n",
+            encoding="utf-8",
+        )
+        long_index = reindex.render_index(d).replace("feedback_x.md) — ", "feedback_x.md) — " + "EXTRA " * 40, 1)
+        (d / "MEMORY.md").write_text(long_index, encoding="utf-8")
+        before = snapshot_memory_dir(d)
+        reindex.reindex_memory(d, dry_run=False)  # re-clips -> rewrites the long line
+        after = snapshot_memory_dir(d)
+        report = run_acceptance_pass(
+            before, after, overlay="acme", archived=[], schema_before=0, schema_after=0, clusters_recorded=3
+        )
+        assert report.passed, [g.detail for g in report.gate_results if not g.passed]
 
 
 class TestReportRender(SimpleTestCase):


### PR DESCRIPTION
fix(dream): home reworded index pointers so re-index clips don't fail gate (c)

## What
The section-4 consolidation acceptance gate (c) now treats a pruned MEMORY.md
index line as homed when it still targets a memory file present after the pass —
a re-index that merely reworded or clipped a curated summary no longer reads as a
lost prune. Homing keys on the ](name.md) markdown link target only, never a bare
.md token in the summary text, so a genuinely lost pointer is never masked by a
summary that name-drops a surviving memory.

## Why
The gate false-failed on every pass whenever a MEMORY.md summary exceeded the
200-char re-index clip (routine), so DreamRunMarker was never stamped succeeded
and the 48h staleness alarm fired perpetually (last_succeeded_at had frozen at
2026-06-17). A genuinely lost memory (file gone and lesson not findable) still
fails the gate, so anti-vacuity holds.

Verified on the real memory set: t3 dream run reports "all acceptance gates
passed", the marker advances to now, and t3 doctor no longer reports the dream
staleness warning.

Regression tests, observed RED before the fix:
- a reworded pointer to a surviving memory is homed
- a pointer to a vanished memory stays unhomed (loss guard intact)
- end-to-end run_acceptance_pass over a real re-index summary clip passes
- a summary name-dropping a live memory does not home a gone target

Closes #2618