### PR TITLE
fix(mutation): warn-first full-scope run survives a mutmut tool crash

### DIFF
--- a/src/teatree/cli/mutation.py
+++ b/src/teatree/cli/mutation.py
@@ -26,6 +26,7 @@ from teatree.quality.mutation import registry_pyproject_path
 from teatree.quality.mutation_run import (
     BaselineRatchet,
     MutationOutcome,
+    MutationToolCrashError,
     load_baseline_per_module,
     load_settings,
     run_scoped,
@@ -81,7 +82,16 @@ def run(
 ) -> None:
     """Mutate the safety modules a PR touches; fail when survivors exceed the baseline."""
     settings = load_settings()
-    outcome = run_scoped(target=target, all_modules=all_modules)
+    try:
+        outcome = run_scoped(target=target, all_modules=all_modules)
+    except MutationToolCrashError as exc:
+        # Warn-first: a mutmut tool crash (timeout / process failure) is an
+        # environment artifact, not a test gap. The full-scope mutation job is
+        # advisory (NOT a branch-protection required check), so a crash must
+        # print a WARNING and exit 0 — it can never block a merge. A genuine
+        # survivors-over-baseline regression is reached below and still exits 1.
+        _console.print(f"[yellow]WARNING: {exc} Treating the run as inconclusive and passing (warn-first).[/yellow]")
+        return
     _report(outcome, baseline=settings.baseline_total)
 
     if update_baseline:

--- a/src/teatree/quality/mutation_run.py
+++ b/src/teatree/quality/mutation_run.py
@@ -33,7 +33,7 @@ from teatree.quality.mutation import (
     scope_modules,
 )
 from teatree.utils import git
-from teatree.utils.run import run_allowed_to_fail
+from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to_fail
 
 _MODES = frozenset({"warn", "block"})
 # mutmut result statuses that mean the suite did NOT catch the mutant.
@@ -72,6 +72,19 @@ class ZeroMutantsError(RuntimeError):
     a crash, an empty results DB, or a mutmut invocation that silently failed.
     Treating that as a pass is fake-green: the gate exits 0 having tested
     nothing. This is raised so the gate fails LOUD instead.
+    """
+
+
+class MutationToolCrashError(RuntimeError):
+    """The mutmut tool itself crashed — a wall-clock timeout or a process failure.
+
+    Distinct from :class:`ZeroMutantsError` (mutmut ran but classified nothing)
+    and from a survivors-over-baseline regression (mutmut ran and the suite has a
+    real test gap). A tool crash is an environment artifact — the same class of
+    signal as a per-mutant ``timeout``/``segfault`` the runner already treats as
+    *inconclusive*, just at the whole-run level. The warn-first ``t3 mutation
+    run`` CLI catches this and exits 0 with a printed WARNING so the advisory
+    full-scope job can never block a merge; a genuine regression still exits 1.
     """
 
 
@@ -366,6 +379,11 @@ def _run_mutmut(modules: Sequence[str], *, tests_dir: Sequence[str], repo: str, 
     pytest_ini.write_text(_MUTANTS_PYTEST_INI, encoding="utf-8")
     env = _mutmut_env()
     try:
+        # ``expected_codes=None`` accepts any mutmut RETURN code (mutmut exits
+        # non-zero when mutants survive — a normal outcome we classify). A
+        # wall-clock TimeoutExpired or a results-query CommandFailedError is a
+        # tool CRASH, not a return code: translate it to MutationToolCrashError
+        # so the warn-first CLI treats it as inconclusive, not a test gap.
         run_allowed_to_fail([*_MUTMUT_CMD, "run"], expected_codes=None, cwd=repo, env=env, timeout=timeout)
         # ``results --all=1`` lists killed mutants too — without it mutmut hides
         # them, so the kill-proof could not observe a kill. ``--all`` is a
@@ -377,6 +395,16 @@ def _run_mutmut(modules: Sequence[str], *, tests_dir: Sequence[str], repo: str, 
             env=env,
             timeout=60,
         )
+    except TimeoutExpired as exc:
+        detail = (
+            f"mutmut timed out after {exc.timeout:g}s — the mutation run did not finish (tool crash, not a test gap)."
+        )
+        raise MutationToolCrashError(detail) from exc
+    except CommandFailedError as exc:
+        detail = (
+            f"mutmut crashed (rc={exc.returncode}) — the mutation run did not complete (tool crash, not a test gap)."
+        )
+        raise MutationToolCrashError(detail) from exc
     finally:
         config_path.unlink(missing_ok=True)
         pytest_ini.unlink(missing_ok=True)

--- a/tests/quality/test_mutation_run.py
+++ b/tests/quality/test_mutation_run.py
@@ -17,12 +17,14 @@ from teatree.quality.mutation_run import (
     MutationOutcome,
     MutationResult,
     MutationSettings,
+    MutationToolCrashError,
     build_mutmut_config,
     load_baseline_per_module,
     load_settings,
     parse_results,
     run_scoped,
 )
+from teatree.utils.run import CommandFailedError, TimeoutExpired
 
 
 class TestBuildMutmutConfig:
@@ -336,6 +338,43 @@ class TestZeroMutantsFailsLoud:
         )
         outcome = run_scoped(changed_files=("README.md",), settings=self._SETTINGS, registry=self._REGISTRY)
         assert outcome.is_no_op
+
+
+class TestMutmutToolCrashIsWarnFirst:
+    """A mutmut tool crash surfaces as :class:`MutationToolCrashError`.
+
+    A wall-clock timeout / process failure is an environment artifact, not a test
+    gap — distinct from a genuine survivors-over-baseline regression and from the
+    fake-green :class:`ZeroMutantsError` guard, both of which stay failures. The
+    warn-first CLI catches this type and exits 0.
+    """
+
+    def _cfg(self, monkeypatch: pytest.MonkeyPatch, raises: Exception) -> None:
+        def _raise(*_args: object, **_kwargs: object) -> object:
+            raise raises
+
+        monkeypatch.setattr(mutation_run, "run_allowed_to_fail", _raise)
+
+    def test_subprocess_timeout_raises_tool_crash(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        self._cfg(monkeypatch, TimeoutExpired(cmd=["mutmut", "run"], timeout=540))
+        with pytest.raises(MutationToolCrashError, match="timed out"):
+            mutation_run._run_mutmut(("src/teatree/a.py",), tests_dir=("tests/",), repo=str(tmp_path), timeout=540)
+
+    def test_subprocess_command_failure_raises_tool_crash(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        self._cfg(monkeypatch, CommandFailedError(["mutmut", "results"], 2, "", "boom"))
+        with pytest.raises(MutationToolCrashError):
+            mutation_run._run_mutmut(("src/teatree/a.py",), tests_dir=("tests/",), repo=str(tmp_path), timeout=540)
+
+    def test_tool_crash_cleans_up_the_scoped_config(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        self._cfg(monkeypatch, TimeoutExpired(cmd=["mutmut", "run"], timeout=540))
+        with pytest.raises(MutationToolCrashError):
+            mutation_run._run_mutmut(("src/teatree/a.py",), tests_dir=("tests/",), repo=str(tmp_path), timeout=540)
+        # The generated setup.cfg / pytest.ini must not survive a crash — a stale
+        # config would make the next run refuse with FileExistsError.
+        assert not (tmp_path / "setup.cfg").exists()
+        assert not (tmp_path / "pytest.ini").exists()
 
 
 class TestLoadSettings:

--- a/tests/teatree_cli/test_mutation_cli.py
+++ b/tests/teatree_cli/test_mutation_cli.py
@@ -13,7 +13,7 @@ from typer.testing import CliRunner
 
 from teatree.cli import app
 from teatree.cli import mutation as mutation_cli
-from teatree.quality.mutation_run import MutationOutcome
+from teatree.quality.mutation_run import MutationOutcome, MutationToolCrashError
 
 runner = CliRunner()
 
@@ -85,6 +85,42 @@ class TestRunVerdict:
         result = runner.invoke(app, ["mutation", "run"])
         assert result.exit_code == 0
         assert "below the baseline" in result.output
+
+
+class TestWarnFirstOnToolCrash:
+    """A mutmut tool crash warns and exits 0; a real regression still fails.
+
+    A tool crash (timeout / process failure) is an environment artifact, not a
+    test gap — it prints a WARNING and exits 0 so the advisory full-scope job can
+    never block a merge. A real survivors-over-baseline regression stays a failure.
+    """
+
+    def _crash(self, monkeypatch: pytest.MonkeyPatch, error: Exception) -> None:
+        def _raise(**_kwargs: object) -> MutationOutcome:
+            raise error
+
+        monkeypatch.setattr(mutation_cli, "run_scoped", _raise)
+
+    def test_mutmut_timeout_warns_and_exits_zero(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        _point_at(monkeypatch, _pyproject(tmp_path, baseline=[("src/teatree/a.py", 0)]))
+        self._crash(monkeypatch, MutationToolCrashError("mutmut run timed out after 540s"))
+        result = runner.invoke(app, ["mutation", "run", "--all"])
+        assert result.exit_code == 0
+        assert "WARNING" in result.output
+
+    def test_regression_still_fails_even_with_warn_first(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        # The warn-first crash path must NOT swallow a real mutation-score
+        # regression: survivors over baseline still exits 1.
+        _point_at(monkeypatch, _pyproject(tmp_path, baseline=[("src/teatree/a.py", 1)]))
+        outcome = MutationOutcome(
+            scoped_modules=("src/teatree/a.py",),
+            survived=("teatree.a.f__mutmut_1", "teatree.a.g__mutmut_2"),
+            killed=(),
+            inconclusive=(),
+        )
+        _stub_run(monkeypatch, outcome)
+        result = runner.invoke(app, ["mutation", "run", "--all"])
+        assert result.exit_code == 1
 
 
 class TestUpdateBaseline:


### PR DESCRIPTION
## What

Make the warn-first full-scope mutation run (`t3 mutation run --all`) survive a `mutmut` tool crash:

- New `MutationToolCrashError` in `src/teatree/quality/mutation_run.py`. `_run_mutmut` now translates a `subprocess.TimeoutExpired` (wall-clock cap) and a `CommandFailedError` (process failure) from the `mutmut` subprocess into it, with the scoped `setup.cfg`/`pytest.ini` still cleaned up in `finally`.
- The `t3 mutation run` CLI (`src/teatree/cli/mutation.py`) catches `MutationToolCrashError`, prints a WARNING, and exits 0.
- A genuine survivors-over-baseline regression (`BaselineRatchet.verdict` → 1) and the fake-green `ZeroMutantsError` guard both stay failures — unchanged.
- Regression tests (observed RED before the fix): runner-level (`TestMutmutToolCrashIsWarnFirst`) and CLI-level (`TestWarnFirstOnToolCrash`, including the "regression still fails" assertion).

## Why

`run_allowed_to_fail([...mutmut run], expected_codes=None, ..., timeout=540)` accepts any RETURN code (mutmut exits non-zero when mutants survive — a normal outcome we classify), but a wall-clock timeout raises `subprocess.TimeoutExpired`, which is not a return code. That exception propagated out of `run_scoped()` → the CLI → a non-zero exit, so the advisory job's CI run conclusion became "failure".

The §17.4.3 step-3 live required-checks merge gate reads the forge's full status-check rollup (which includes non-required advisory checks), so a "failed" advisory mutation job blocked an otherwise-mergeable PR even when all branch-protection required checks were green. The full-scope mutation job is documented warn-first and is not a required check — it must never be able to block a merge.

A whole-run tool crash is the same class of signal as a per-mutant `timeout`/`segfault` the runner already treats as inconclusive (never a test gap), just at the run level. This is the self-consistent fix: this PR's own `mutation-full` job now passes on a timeout while a real mutation-score regression still fails CI.

Closes #2622
