### PR TITLE
fix(statusline): wire via top-level settings.json statusLine, drop dead plugin block

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,14 +311,18 @@ The cadence is configurable via `T3_LOOP_CADENCE` (seconds), or by setting
 the loop, run `/loop unregister t3-loop` in the Claude Code session.
 
 **Wire up the Claude Code statusline hook** so the rendered file actually shows
-in the bottom bar. Either enable the `t3` plugin (the plugin's `settings.json`
-registers the hook automatically), or add it to `~/.claude/settings.json`:
+in the bottom bar. This is a top-level `statusLine` key in
+`~/.claude/settings.json` — enabling the `t3` plugin does **not** wire it for
+you: a plugin's `settings.json` only honours the `agent` and
+`subagentStatusLine` keys, so a `statusLine` declared there is silently ignored.
+Point the command at an absolute path to the script (the user-level settings
+file does not expand `${CLAUDE_PLUGIN_ROOT}`):
 
 ```json
 {
   "statusLine": {
     "type": "command",
-    "command": "~/workspace/souliane/teatree/hooks/scripts/statusline.sh"
+    "command": "bash /absolute/path/to/teatree/hooks/scripts/statusline.sh"
   }
 }
 ```

--- a/settings.json
+++ b/settings.json
@@ -1,16 +1,4 @@
 {
-  "hooks": {
-    "statusLine": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/statusline.sh"
-          }
-        ]
-      }
-    ]
-  },
   "permissions": {
     "allow": [
       "Skill(t3:*)",


### PR DESCRIPTION
fix(statusline): wire via top-level settings.json statusLine, drop dead plugin block

## What

- README: correct the statusline wiring instructions. The statusline is a **top-level `statusLine` key** in `~/.claude/settings.json`, pointing at an **absolute path** to the script — enabling the `t3` plugin does NOT wire it.
- `settings.json`: remove the dead `hooks.statusLine` block. A Claude Code plugin `settings.json` only honours the `agent` and `subagentStatusLine` keys, so a `statusLine` declared there is silently ignored — it never wired the bar.

## Why

The old docs implied enabling the plugin was enough, and the plugin `settings.json` carried a `hooks.statusLine` block that looked functional but was a no-op (plugins cannot register a statusLine; the user settings file does not expand `${CLAUDE_PLUGIN_ROOT}`). Both pointed users at a path that never works.

## Scope

Docs + settings only. The `permissions` block is unchanged — **105 allow + 33 deny**, still valid JSON. No code paths touched.

Relates to [#2624](https://github.com/souliane/teatree/issues/2624) — the portable `t3 setup`/`doctor` installer + validator for the top-level `statusLine` (the durable fix) is tracked there and stays open; this is the docs/dead-block correction.

docs: README updated (statusline wiring section) — covered in this diff.

## Open questions & assumptions

- assumed: README uses a `/absolute/path/to/teatree` placeholder rather than a concrete path, since the script location is install-specific.
- assumed: docs-only + dead-block removal here; the portable installer/validator is tracked separately in [#2624](https://github.com/souliane/teatree/issues/2624), so this uses Relates-to (not Closes) to keep that issue open.
