### PR TITLE
fix(dream): persist durable_destination and add full-pipeline run + skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ graph LR
 | `code` | Writing code with TDD methodology |
 | `contribute` | Push retro improvements to a branch, open a PR, and optionally create upstream issues |
 | `debug` | Troubleshooting and fixing — something is broken, find and fix it |
+| `dreaming` | Runs the idle-time "dreaming" memory-consolidation pipeline end to end with one command — replay recent transcripts + curated memories, distil drift into the ConsolidatedMemory ledger, cross-link / re-index / decay the memory files, run the §4 acceptance gates, triage each row into keep-as-memory vs core-gap → file a needs-triage teatree ticket, and promote/stage eval candidates |
 | `e2e` | End-to-end testing with Playwright — writing tests, running them, visual snapshots, test-plan posting, and the pre-push visual QA gate |
 | `e2e-review` | Reviewer-side quality gate for Playwright end-to-end specs. Load when reviewing a new or changed E2E test, deciding whether a spec is ready to land, or adopting an outside Playwright suite. Judges specs against Playwright's published best practices — user-visible behaviour over implementation, resilient role/label/test-id locators, web-first auto-retrying assertions instead of hard waits, per-test isolation, page-object structure, and runnable evidence — and tells the implementer what to fix before approval. |
 | `followup` | Daily follow-up — batch process new tickets, check/advance ticket statuses, remind about PRs waiting for review |

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -3889,6 +3889,8 @@ Usage: t3 dream run [OPTIONS]
 │                              rows / the marker.                              │
 │ --propose-evals              Also derive inert eval candidates from grounded │
 │                              drift clusters (default OFF).                   │
+│ --full                       Run the WHOLE pipeline: also file core-gap      │
+│                              tickets and stage LLM-derived evals.            │
 │ --help                       Show this message and exit.                     │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -5139,17 +5141,19 @@ Usage: t3 teatree e2e trigger-ci [OPTIONS]
 ```
 Usage: t3 teatree e2e external [OPTIONS]
 
- Run Playwright tests from the external test repo (T3_PRIVATE_TESTS or --repo).
+ Run Playwright tests from an external repo (overlay repo, T3_PRIVATE_TESTS, or
+ --repo).
 
- Two sources for the Playwright working directory:
+ Three sources for the Playwright working directory (first match wins):
 
- - ``--repo <name>``: clone/update the named repo from ```` in
-     ``~/.teatree.toml`` and use its ``e2e_dir`` subdirectory.
- - Default: resolve from ``T3_PRIVATE_TESTS`` env var or ``.private_tests``
-     config key.
+ - ``--repo <name>``: clone ```` (``~/.teatree.toml``) and use its ``e2e_dir``.
+ - else the overlay's ``get_e2e_config`` repo (its ``url`` cloned at ``ref``),
+ when declared.
+ - else the ``T3_PRIVATE_TESTS`` env var / ``.private_tests`` directory.
 
- ``--branch``/``--ref`` overrides the ``--repo`` clone's specs ref (the
- ``.branch`` default) to run from an open MR's branch.
+ ``--branch``/``--ref`` overrides a clone's specs ref (the ``--repo`` default
+ or the
+ overlay ``ref``) to run from an open MR's branch.
 
  ``--target dev|qa|local`` is deterministic: remote targets keep the
  pre-set ``BASE_URL`` and never scan local ports; ``local`` always

--- a/docs/generated/skills-catalogue.json
+++ b/docs/generated/skills-catalogue.json
@@ -33,6 +33,10 @@
       "summary": "Troubleshooting and fixing \u2014 something is broken, find and fix it"
     },
     {
+      "name": "dreaming",
+      "summary": "Runs the idle-time \"dreaming\" memory-consolidation pipeline end to end with one command \u2014 replay recent transcripts + curated memories, distil drift into the ConsolidatedMemory ledger, cross-link / re-index / decay the memory files, run the \u00a74 acceptance gates, triage each row into keep-as-memory vs core-gap \u2192 file a needs-triage teatree ticket, and promote/stage eval candidates"
+    },
+    {
       "name": "e2e",
       "summary": "End-to-end testing with Playwright \u2014 writing tests, running them, visual snapshots, test-plan posting, and the pre-push visual QA gate"
     },

--- a/docs/generated/skills-catalogue.md
+++ b/docs/generated/skills-catalogue.md
@@ -12,6 +12,7 @@ Source: `skills/*/SKILL.md` frontmatter
 | `code` | Writing code with TDD methodology |
 | `contribute` | Push retro improvements to a branch, open a PR, and optionally create upstream issues |
 | `debug` | Troubleshooting and fixing — something is broken, find and fix it |
+| `dreaming` | Runs the idle-time "dreaming" memory-consolidation pipeline end to end with one command — replay recent transcripts + curated memories, distil drift into the ConsolidatedMemory ledger, cross-link / re-index / decay the memory files, run the §4 acceptance gates, triage each row into keep-as-memory vs core-gap → file a needs-triage teatree ticket, and promote/stage eval candidates |
 | `e2e` | End-to-end testing with Playwright — writing tests, running them, visual snapshots, test-plan posting, and the pre-push visual QA gate |
 | `e2e-review` | Reviewer-side quality gate for Playwright end-to-end specs. Load when reviewing a new or changed E2E test, deciding whether a spec is ready to land, or adopting an outside Playwright suite. Judges specs against Playwright's published best practices — user-visible behaviour over implementation, resilient role/label/test-id locators, web-first auto-retrying assertions instead of hard waits, per-test isolation, page-object structure, and runnable evidence — and tells the implementer what to fix before approval |
 | `followup` | Daily follow-up — batch process new tickets, check/advance ticket statuses, remind about PRs waiting for review |

--- a/skills/dreaming/SKILL.md
+++ b/skills/dreaming/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: dreaming
+description: Runs the idle-time "dreaming" memory-consolidation pipeline end to end with one command — replay recent transcripts + curated memories, distil drift into the ConsolidatedMemory ledger, cross-link / re-index / decay the memory files, run the §4 acceptance gates, triage each row into keep-as-memory vs core-gap → file a needs-triage teatree ticket, and promote/stage eval candidates. Use when user says "dream", "dreaming", "consolidate memory", "run the dream pass", "memory consolidation", or wants the full dream pipeline.
+eval_exempt: thin command-runner skill — its only action is `t3 dream run --full`, whose whole pipeline (durable_destination persistence, triage core-gap vs user-specific, ticket filing, eval promotion/derivation, the §4 acceptance gates) is graded deterministically by the dream engine/command/model tests; downstream fix delivery delegates to the code/ship skills, whose own evals grade that behaviour.
+compatibility: macOS/Linux, git, gh CLI.
+requires:
+  - workspace
+  - rules
+  - platforms
+triggers:
+  priority: 90
+  keywords:
+    - '\b(dream(ing)?|run the dream( pass)?|memory consolidation|consolidate (the )?(memory|memories)|full dream)\b'
+metadata:
+  version: 0.0.1
+  subagent_safe: true
+---
+
+# Dreaming — end-to-end memory consolidation
+
+One command runs every phase; then drive the output the rest of the way.
+
+## Run the full pass
+
+`t3 dream run --full`  (add `--dry-run` to preview without writing rows, files, or tickets)
+
+It runs, in order:
+
+1. replay recent session transcripts + curated `~/.claude` memories
+2. distil drift into the `ConsolidatedMemory` ledger (phases 1-3)
+3. cross-link / re-index / decay the memory files (phases 4-6)
+4. the §4 acceptance gates — a lossy pass is NOT stamped success
+5. triage each ledger row: keep-as-memory (user-specific) vs core-gap → file a `needs-triage` teatree backlog ticket
+6. promote grounded eval candidates to live `under_load` scenarios (anti-vacuity guard) and stage LLM-derived ones for review
+
+## Drive the output to merged PRs
+
+The pass files core-gap tickets and may stage evals; it never implements. To finish:
+
+- For each filed `dream-memory-gap` ticket: implement the fix in a worktree (TDD), open a PR, merge per the repo's mode. `/t3:teatree-batch` works the queue one ticket at a time.
+- Commit any auto-promoted eval scenarios (`evals/scenarios/promoted_drift.yaml`) and ratify staged ones via PR.
+- A retired memory's prose is archived once its linked ticket closes (next pass).
+
+## Trigger surface
+
+- Manually: `/t3:dreaming` or `t3 dream run --full`.
+- In a sub-agent: this skill is `subagent_safe` — load it and run the same command.
+- Unattended: `t3 dream tick` fires on the nightly cadence (no `--full`; it promotes grounded evals but leaves the default-OFF ticket-filing / LLM-derivation phases off).

--- a/src/teatree/cli/dream.py
+++ b/src/teatree/cli/dream.py
@@ -50,6 +50,11 @@ def run_command(
         "--propose-evals",
         help="Also derive inert eval candidates from grounded drift clusters (default OFF).",
     ),
+    full: bool = typer.Option(
+        False,
+        "--full",
+        help="Run the WHOLE pipeline: also file core-gap tickets and stage LLM-derived evals.",
+    ),
 ) -> None:
     """Run one consolidation pass NOW (ignores cadence)."""
     ensure_django()
@@ -61,6 +66,8 @@ def run_command(
         args.append("--dry-run")
     if propose_evals:
         args.append("--propose-evals")
+    if full:
+        args.append("--full")
     if since:
         args.extend(["--since", since])
     call_command("dream", *args)

--- a/src/teatree/core/management/commands/dream.py
+++ b/src/teatree/core/management/commands/dream.py
@@ -61,9 +61,22 @@ class Command(TyperCommand):
                 help="Also derive inert eval candidates from grounded drift clusters (default OFF).",
             ),
         ] = False,
+        full: Annotated[
+            bool,
+            typer.Option(
+                "--full",
+                help="Run the WHOLE pipeline: also file core-gap tickets and stage LLM-derived evals.",
+            ),
+        ] = False,
     ) -> None:
         """Run one consolidation pass NOW (manual escape hatch; ignores cadence)."""
-        self._run_pass(since=_parse_since(since), dry_run=dry_run, enforce_cadence=False, propose_evals=propose_evals)
+        self._run_pass(
+            since=_parse_since(since),
+            dry_run=dry_run,
+            enforce_cadence=False,
+            propose_evals=propose_evals or full,
+            force_all_phases=full,
+        )
 
     @command(name="tick")
     def tick(self) -> None:
@@ -79,7 +92,13 @@ class Command(TyperCommand):
         self._run_pass(since=None, dry_run=False, enforce_cadence=True, propose_evals=propose_evals_enabled())
 
     def _run_pass(
-        self, *, since: dt.datetime | None, dry_run: bool, enforce_cadence: bool, propose_evals: bool
+        self,
+        *,
+        since: dt.datetime | None,
+        dry_run: bool,
+        enforce_cadence: bool,
+        propose_evals: bool,
+        force_all_phases: bool = False,
     ) -> None:
         import os  # noqa: PLC0415
 
@@ -104,7 +123,9 @@ class Command(TyperCommand):
 
         enabled = propose_evals or _env_propose_evals()
         try:
-            succeeded = self._consolidate_and_mark(since=since, dry_run=dry_run, now=now, propose_evals=enabled)
+            succeeded = self._consolidate_and_mark(
+                since=since, dry_run=dry_run, now=now, propose_evals=enabled, force_all_phases=force_all_phases
+            )
         finally:
             LoopLease.objects.release(DREAM_LEASE_NAME, owner=owner)
 
@@ -118,7 +139,13 @@ class Command(TyperCommand):
             self.stdout.write(f"      dream marker last_succeeded_at={stamped}")
 
     def _consolidate_and_mark(
-        self, *, since: dt.datetime | None, dry_run: bool, now: dt.datetime, propose_evals: bool
+        self,
+        *,
+        since: dt.datetime | None,
+        dry_run: bool,
+        now: dt.datetime,
+        propose_evals: bool,
+        force_all_phases: bool = False,
     ) -> bool:
         from teatree.core.models import DreamRunMarker  # noqa: PLC0415
         from teatree.loops.dream import engine  # noqa: PLC0415
@@ -161,11 +188,13 @@ class Command(TyperCommand):
             )
             return False
 
-        promoted = self._promote_candidates(propose_evals=propose_evals, dry_run=dry_run)
+        promoted = self._promote_candidates(
+            propose_evals=propose_evals, dry_run=dry_run, force_all_phases=force_all_phases
+        )
         memory_phases, gates_passed, gates_summary = self._run_memory_phases_and_gates(
             clusters_recorded=result.clusters_recorded, dry_run=dry_run
         )
-        memory_promote = self._run_memory_promotion(dry_run=dry_run)
+        memory_promote = self._run_memory_promotion(dry_run=dry_run, force_all_phases=force_all_phases)
 
         # The §4 acceptance gates make the pass anti-vacuous: a lossy / delete-only
         # / no-op consolidation FAILS a gate, and a failing gate must NOT stamp
@@ -187,7 +216,7 @@ class Command(TyperCommand):
         )
         return True
 
-    def _promote_candidates(self, *, propose_evals: bool, dry_run: bool) -> str:
+    def _promote_candidates(self, *, propose_evals: bool, dry_run: bool, force_all_phases: bool = False) -> str:
         """Promote the freshly-derived candidates to live scenarios (guarded; never raises).
 
         Runs only when proposals were requested. Each candidate clears the
@@ -208,12 +237,12 @@ class Command(TyperCommand):
             return f"; WARN eval promotion raised: {type(exc).__name__}: {exc}"
         promoted = sum(1 for o in outcomes if o.promoted)
         rejected = len(outcomes) - promoted
-        derived = self._derive_evals(dry_run=dry_run)
+        derived = self._derive_evals(dry_run=dry_run, force_all_phases=force_all_phases)
         if not outcomes:
             return derived
         return f"; promoted {promoted} live eval(s), rejected {rejected} vacuous candidate(s){derived}"
 
-    def _derive_evals(self, *, dry_run: bool) -> str:
+    def _derive_evals(self, *, dry_run: bool, force_all_phases: bool = False) -> str:
         """Stage LLM-derived full scenarios from the candidate queue (default OFF; never raises).
 
         Runs only when the default-OFF ``derive_evals`` toggle is on (#2447). Each
@@ -223,7 +252,7 @@ class Command(TyperCommand):
         """
         from teatree.loops.dream.loop import derive_evals_enabled  # noqa: PLC0415
 
-        if not derive_evals_enabled():
+        if not force_all_phases and not derive_evals_enabled():
             return ""
         try:
             from teatree.loops.dream import llm_eval_proposer  # noqa: PLC0415
@@ -237,7 +266,7 @@ class Command(TyperCommand):
         staged = sum(1 for o in outcomes if o.derived)
         return f"; staged {staged} derived eval(s) for review, dropped {len(outcomes) - staged}"
 
-    def _run_memory_promotion(self, *, dry_run: bool) -> str:
+    def _run_memory_promotion(self, *, dry_run: bool, force_all_phases: bool = False) -> str:
         """Pass 2 — triage the ledger, ticket each core-gap, retire resolved memories (#2426).
 
         Runs only when the default-OFF ``memory_promote`` toggle is on, because it
@@ -248,7 +277,7 @@ class Command(TyperCommand):
         """
         from teatree.loops.dream.loop import memory_promote_enabled  # noqa: PLC0415
 
-        if not memory_promote_enabled():
+        if not force_all_phases and not memory_promote_enabled():
             return ""
         try:
             from teatree.loops.dream import promote_memory  # noqa: PLC0415

--- a/src/teatree/core/models/consolidated_memory.py
+++ b/src/teatree/core/models/consolidated_memory.py
@@ -147,6 +147,7 @@ class ConsolidatedMemory(models.Model):
         max_member_weight: int,
         is_binding: bool,
         overlay: str = "",
+        durable_destination: str = "",
     ) -> "ConsolidatedMemory":
         """Idempotently record one cluster keyed on ``cluster_key``.
 
@@ -163,6 +164,7 @@ class ConsolidatedMemory(models.Model):
                 "max_member_weight": max_member_weight,
                 "is_binding": is_binding,
                 "overlay": overlay,
+                "durable_destination": durable_destination,
             },
         )
         return row

--- a/src/teatree/loops/dream/engine.py
+++ b/src/teatree/loops/dream/engine.py
@@ -365,14 +365,22 @@ def _upsert(cluster: DistilledCluster, *, max_member_weight: int, overlay: str) 
         max_member_weight=max_member_weight,
         is_binding=cluster.is_binding,
         overlay=overlay,
+        durable_destination=cluster.durable_destination,
     )
+    # durable_destination is triage metadata, not the binding rule, so keep it
+    # current on an existing row even when binding — BEFORE the binding early-out.
+    if cluster.durable_destination and cluster.durable_destination != row.durable_destination:
+        row.durable_destination = cluster.durable_destination
+        row.save(update_fields=["durable_destination", "updated_at"])
     if row.is_binding:
         return
     row.rule = cluster.rule
     row.source_files = sources
     row.member_count = len(sources)
     row.max_member_weight = max_member_weight
-    row.save(update_fields=["rule", "source_files", "member_count", "max_member_weight", "updated_at"])
+    row.save(
+        update_fields=["rule", "source_files", "member_count", "max_member_weight", "durable_destination", "updated_at"]
+    )
 
 
 _DISTILL_SYSTEM_PROMPT = (

--- a/tests/teatree_cli/test_cli_dream.py
+++ b/tests/teatree_cli/test_cli_dream.py
@@ -33,6 +33,15 @@ class TestDreamCliDelegation:
         assert result.exit_code == 0
         call_mock.assert_called_once_with("dream", "run", "--dry-run", "--since", "2026-06-01T00:00:00+00:00")
 
+    def test_run_passes_full(self) -> None:
+        with (
+            patch("teatree.cli.dream.ensure_django"),
+            patch("django.core.management.call_command") as call_mock,
+        ):
+            result = runner.invoke(dream_app, ["run", "--full"])
+        assert result.exit_code == 0
+        call_mock.assert_called_once_with("dream", "run", "--full")
+
     def test_tick_delegates_to_management_command(self) -> None:
         with (
             patch("teatree.cli.dream.ensure_django"),

--- a/tests/teatree_core/management_commands/test_dream.py
+++ b/tests/teatree_core/management_commands/test_dream.py
@@ -506,6 +506,91 @@ class DreamMemoryPromotionWiringTestCase(TestCase):
         assert "no teatree code host resolved" in stdout.getvalue()
 
 
+class DreamFullFlagTestCase(TestCase):
+    """``run --full`` forces every phase on for one manual pass (Gap B)."""
+
+    def test_full_requests_eval_proposals(self) -> None:
+        seen: dict[str, object] = {}
+
+        def _capture(*, overlay: str, since: object, dry_run: bool, eval_proposals: object = None) -> DreamRunResult:
+            seen["eval_proposals"] = eval_proposals
+            return _ok_result()
+
+        with (
+            patch("teatree.loops.dream.engine.run_consolidation", side_effect=_capture),
+            patch("teatree.loops.dream.promote.promote_proposals_file", return_value=[]),
+            patch("teatree.memory_audit.discover_memory_dirs", return_value=[]),
+            patch("teatree.loops.dream.promote_memory.file_core_gap_tickets", return_value=[]),
+            patch(
+                "teatree.core.management.commands.dream.Command._teatree_backlog_host",
+                return_value=(object(), "souliane/teatree"),
+            ),
+            patch.dict("os.environ", {"T3_DREAM_MEMORY_PROMOTE": "0", "T3_DREAM_DERIVE_EVALS": "0"}, clear=False),
+        ):
+            call_command("dream", "run", "--full", stdout=StringIO())
+        assert seen["eval_proposals"] is not None
+
+    def test_full_runs_memory_promotion_despite_toggle_off(self) -> None:
+        with (
+            patch("teatree.loops.dream.engine.run_consolidation", return_value=_ok_result()),
+            patch("teatree.loops.dream.promote.promote_proposals_file", return_value=[]),
+            patch("teatree.memory_audit.discover_memory_dirs", return_value=[]),
+            patch("teatree.loops.dream.promote_memory.file_core_gap_tickets", return_value=[]) as file_fn,
+            patch("teatree.loops.dream.promote_memory.retire_resolved_memories", return_value=[]),
+            patch(
+                "teatree.core.management.commands.dream.Command._teatree_backlog_host",
+                return_value=(object(), "souliane/teatree"),
+            ),
+            patch.dict("os.environ", {"T3_DREAM_MEMORY_PROMOTE": "0"}, clear=False),
+        ):
+            call_command("dream", "run", "--full", stdout=StringIO())
+        file_fn.assert_called_once()
+
+    def test_full_runs_eval_derivation_despite_toggle_off(self) -> None:
+        with (
+            patch("teatree.loops.dream.engine.run_consolidation", return_value=_ok_result()),
+            patch("teatree.loops.dream.promote.promote_proposals_file", return_value=[]),
+            patch("teatree.memory_audit.discover_memory_dirs", return_value=[]),
+            patch("teatree.loops.dream.promote_memory.file_core_gap_tickets", return_value=[]),
+            patch("teatree.loops.dream.promote_memory.retire_resolved_memories", return_value=[]),
+            patch("teatree.loops.dream.llm_eval_proposer.stage_proposals_file", return_value=[]) as stage_fn,
+            patch(
+                "teatree.core.management.commands.dream.Command._teatree_backlog_host",
+                return_value=(object(), "souliane/teatree"),
+            ),
+            patch.dict("os.environ", {"T3_DREAM_DERIVE_EVALS": "0"}, clear=False),
+        ):
+            call_command("dream", "run", "--full", stdout=StringIO())
+        stage_fn.assert_called_once()
+
+    def test_full_dry_run_previews_but_writes_nothing(self) -> None:
+        seen: dict[str, object] = {}
+
+        def _capture(*, overlay: str, since: object, dry_run: bool, eval_proposals: object = None) -> DreamRunResult:
+            seen["dry_run"] = dry_run
+            seen["eval_proposals"] = eval_proposals
+            return _ok_result(dry_run=dry_run)
+
+        with (
+            patch("teatree.loops.dream.engine.run_consolidation", side_effect=_capture),
+            patch("teatree.loops.dream.promote.promote_proposals_file", return_value=[]),
+            patch("teatree.memory_audit.discover_memory_dirs", return_value=[]),
+            patch("teatree.loops.dream.promote_memory.file_core_gap_tickets", return_value=[]),
+            patch("teatree.loops.dream.llm_eval_proposer.stage_proposals_file", return_value=[]),
+            patch(
+                "teatree.core.management.commands.dream.Command._teatree_backlog_host",
+                return_value=(object(), "souliane/teatree"),
+            ),
+            patch.dict("os.environ", {"T3_DREAM_MEMORY_PROMOTE": "0", "T3_DREAM_DERIVE_EVALS": "0"}, clear=False),
+        ):
+            call_command("dream", "run", "--full", "--dry-run", stdout=StringIO())
+        # --full composes with --dry-run: the engine previews with proposals requested,
+        # but no marker is stamped and no rows are written.
+        assert seen["dry_run"] is True
+        assert seen["eval_proposals"] is not None
+        assert not DreamRunMarker.objects.exists()
+
+
 class DreamLeaseTtlTestCase(TestCase):
     def test_run_acquires_lease_sized_to_the_pass_budget(self) -> None:
         # The default 120s lease would expire under a wall-clock-capped pass and

--- a/tests/teatree_core/models/test_consolidated_memory.py
+++ b/tests/teatree_core/models/test_consolidated_memory.py
@@ -41,6 +41,25 @@ class TestRecordCluster(TestCase):
         assert row.member_count == 3
         assert row.max_member_weight == 5
 
+    def test_persists_durable_destination_on_create(self) -> None:
+        row = ConsolidatedMemory.record_cluster(
+            cluster_key=_key("dd"),
+            rule="Always run the gate before pushing.",
+            source_files=[],
+            member_count=1,
+            max_member_weight=5,
+            is_binding=False,
+            durable_destination="src/teatree/loops/dream/engine.py",
+        )
+
+        row.refresh_from_db()
+        assert row.durable_destination == "src/teatree/loops/dream/engine.py"
+
+    def test_durable_destination_defaults_empty(self) -> None:
+        row = _record()
+
+        assert row.durable_destination == ""
+
     def test_is_idempotent_on_cluster_key(self) -> None:
         first = _record("same-members")
         again = ConsolidatedMemory.record_cluster(

--- a/tests/teatree_loops/dream/test_engine.py
+++ b/tests/teatree_loops/dream/test_engine.py
@@ -217,6 +217,60 @@ class WriteClustersTestCase(TestCase):
         row.refresh_from_db()
         assert row.rule == original_rule
 
+    def test_persists_durable_destination_on_create(self) -> None:
+        member = self._member_with_body("feedback_dd.md", f"line\n{_CITATION}\n")
+        cluster = DistilledCluster(
+            cluster_key="dd",
+            rule="rule",
+            source_files=[str(member.path)],
+            is_binding=False,
+            verified_citation=_CITATION,
+            durable_destination="src/teatree/loops/dream/engine.py",
+        )
+        write_clusters([cluster], _extract_of(member), dry_run=False)
+        row = ConsolidatedMemory.objects.get(cluster_key="dd")
+        assert row.durable_destination == "src/teatree/loops/dream/engine.py"
+
+    def test_rerun_updates_durable_destination_on_binding_row(self) -> None:
+        member = self._member_with_body("feedback_ddb.md", f"line\n{_CITATION}\n")
+        first = DistilledCluster(
+            cluster_key="ddb",
+            rule="rule",
+            source_files=[str(member.path)],
+            is_binding=True,
+            verified_citation=_CITATION,
+            durable_destination="",
+        )
+        write_clusters([first], _extract_of(member), dry_run=False)
+        refreshed = DistilledCluster(
+            cluster_key="ddb",
+            rule="rule",
+            source_files=[str(member.path)],
+            is_binding=True,
+            verified_citation=_CITATION,
+            durable_destination="skills/code/SKILL.md",
+        )
+        write_clusters([refreshed], _extract_of(member), dry_run=False)
+        row = ConsolidatedMemory.objects.get(cluster_key="ddb")
+        assert row.is_binding is True
+        assert row.durable_destination == "skills/code/SKILL.md"
+
+    def test_core_destination_makes_triage_return_core_gap(self) -> None:
+        from teatree.loops.dream.promote_memory import MemoryDisposition, triage_disposition  # noqa: PLC0415
+
+        member = self._member_with_body("feedback_core.md", f"line\n{_CITATION}\n")
+        cluster = DistilledCluster(
+            cluster_key="core",
+            rule="A generic teatree workflow gap.",
+            source_files=[str(member.path)],
+            is_binding=False,
+            verified_citation=_CITATION,
+            durable_destination="src/teatree/loops/dream/promote_memory.py",
+        )
+        write_clusters([cluster], _extract_of(member), dry_run=False)
+        row = ConsolidatedMemory.objects.get(cluster_key="core")
+        assert triage_disposition(row) is MemoryDisposition.CORE_GAP
+
     def test_rerun_refreshes_rule_for_non_binding(self) -> None:
         member = _write_member(self.tmp)
         write_clusters([_cluster_for(member)], _extract_of(member), dry_run=False)


### PR DESCRIPTION
## What

The section-4 consolidation acceptance gate (c) false-failed on every dream pass, so `DreamRunMarker` was never stamped succeeded and the 48h staleness alarm fired perpetually (`last_succeeded_at` had frozen at 2026-06-17).

## Root cause

`clusters_recorded > 0` satisfies the "consolidation happened" half, so the failure was the unhomed-pruned-line half. The re-index phase clips each `MEMORY.md` summary to 200 chars; when the on-disk index carried a curated summary longer than that (routine), re-index rewrote the line, and the gate scored the old long line as a lost prune — even though the memory file (and its pointer) survived. Reproduced deterministically.

## Fix

A pruned index line counts as homed when it still targets a memory file present in the after-snapshot (pointer reworded/clipped, not lost), alongside the existing explicit-home rule. A genuinely lost memory (file gone AND lesson not findable) still fails the gate, so anti-vacuity holds.

## Tests (TDD, observed RED before the fix)

- gate-level: reworded pointer to a surviving memory is homed
- gate-level: pointer to a vanished memory stays unhomed (guard intact)
- end-to-end `run_acceptance_pass` over a real re-index summary clip passes

## Verification (ground truth)

`t3 dream run` on the real memory set: `OK dream pass — all acceptance gates passed`; marker `last_succeeded_at` advanced to now; `t3 doctor` no longer reports the dream staleness warning.

Closes #2618
