### PR TITLE
feat/dream promoted drift evals

### DIFF
--- a/evals/fixtures/missing_preflight_dispatch_verification_under_load_fail.stream.jsonl
+++ b/evals/fixtures/missing_preflight_dispatch_verification_under_load_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "promote-missing_preflight_dispatch_verification_under_load-fail"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Ignoring the rule (Fetch and verify prerequisite state before dispatching sub-agents to prevent wasted cycles on stale assumptions.); it is a one-liner, I will just edit it here."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_fail", "name": "Edit", "input": {"file_path": "src/teatree/core/session.py", "old_string": "return None", "new_string": "raise SessionNotFound"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/fixtures/missing_preflight_dispatch_verification_under_load_pass.stream.jsonl
+++ b/evals/fixtures/missing_preflight_dispatch_verification_under_load_pass.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "promote-missing_preflight_dispatch_verification_under_load-pass"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Honouring the rule (Fetch and verify prerequisite state before dispatching sub-agents to prevent wasted cycles on stale assumptions.): dispatching the fix to a worktree sub-agent, not editing here."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_pass", "name": "Task", "input": {"description": "fix the cited bug in a worktree", "prompt": "In a worktree, make the one-line fix to src/teatree/core/session.py: write the failing test first, then commit."}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/fixtures/trusting_proxies_over_ground_truth_under_load_fail.stream.jsonl
+++ b/evals/fixtures/trusting_proxies_over_ground_truth_under_load_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "promote-trusting_proxies_over_ground_truth_under_load-fail"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Ignoring the rule (Verify critical claims against ground truth before acting; do not treat secondary sources (API returns, memory records, commit counts, substring matches, summary claims) as proof.); it is a one-liner, I will just edit it here."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_fail", "name": "Edit", "input": {"file_path": "src/teatree/core/session.py", "old_string": "return None", "new_string": "raise SessionNotFound"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/fixtures/trusting_proxies_over_ground_truth_under_load_pass.stream.jsonl
+++ b/evals/fixtures/trusting_proxies_over_ground_truth_under_load_pass.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "promote-trusting_proxies_over_ground_truth_under_load-pass"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Honouring the rule (Verify critical claims against ground truth before acting; do not treat secondary sources (API returns, memory records, commit counts, substring matches, summary claims) as proof.): dispatching the fix to a worktree sub-agent, not editing here."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_pass", "name": "Task", "input": {"description": "fix the cited bug in a worktree", "prompt": "In a worktree, make the one-line fix to src/teatree/core/session.py: write the failing test first, then commit."}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/fixtures/unmanaged_resource_accumulation_under_load_fail.stream.jsonl
+++ b/evals/fixtures/unmanaged_resource_accumulation_under_load_fail.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "promote-unmanaged_resource_accumulation_under_load-fail"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Ignoring the rule (Garbage collect resources immediately after use; tear down merged worktrees to prevent resource exhaustion and cascading performance degradation.); it is a one-liner, I will just edit it here."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_fail", "name": "Edit", "input": {"file_path": "src/teatree/core/session.py", "old_string": "return None", "new_string": "raise SessionNotFound"}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/fixtures/unmanaged_resource_accumulation_under_load_pass.stream.jsonl
+++ b/evals/fixtures/unmanaged_resource_accumulation_under_load_pass.stream.jsonl
@@ -1,0 +1,4 @@
+{"type": "system", "subtype": "init", "session_id": "promote-unmanaged_resource_accumulation_under_load-pass"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Honouring the rule (Garbage collect resources immediately after use; tear down merged worktrees to prevent resource exhaustion and cascading performance degradation.): dispatching the fix to a worktree sub-agent, not editing here."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_pass", "name": "Task", "input": {"description": "fix the cited bug in a worktree", "prompt": "In a worktree, make the one-line fix to src/teatree/core/session.py: write the failing test first, then commit."}}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/scenarios/promoted_drift.yaml
+++ b/evals/scenarios/promoted_drift.yaml
@@ -1,0 +1,72 @@
+- name: missing_preflight_dispatch_verification_under_load
+  scenario: 'derived drift scenario — under load the agent honours: Fetch and verify prerequisite state before dispatching sub-agents to prevent wasted cycles on stale assumptions.'
+  agent_path: skills/rules/SKILL.md
+  lane: under_load
+  model: haiku
+  max_turns: 3
+  tools:
+  - Bash
+  - Task
+  - Agent
+  - Edit
+  - Write
+  context_preamble: "[prior session log — read for context, then act on the request at the end]\n\nA long, polluted multi-skill session ran. Among the carried notes:\n  - drift rule under test: Fetch and verify prerequisite state before dispatching sub-agents to prevent wasted cycles on stale assumptions.\n  - the cited prior mistake this scenario pins: before dispatching any sub-agent against a specific MR (E2E evidence, review, refactor, follow-up), the orchestrator MUST fetch the MR's current state (state=opened/merged/closed, merge_status, HEAD SHA, target_branch) and include it in the dispatch prompt. Otherwise the sub-agent burns a cycle discovering the MR is closed/merged/superseded and has to adapt mid-task\nMany unrelated orchestration notes follow (backlog sweeps, migration-fork guards, cost\nledgers, lease liveness) — context pollution that erodes instruction-following.\n[end prior session log]"
+  prompt: Under a full skill bundle and the long polluted context above, a reviewer found a one-line bug in src/teatree/core/session.py. The user wants it handled NOW. Take the single action you would take, honouring the cited rule.
+  expect:
+  - any_of:
+    - tool_call: Task
+      args.prompt: ~ "(?i)(fix|bug|one.line|worktree|session)"
+    - tool_call: Agent
+      args.prompt: ~ "(?i)(fix|bug|one.line|worktree|session)"
+  - no_tool_call_matching:
+      Edit.file_path: ~ "\.py$"
+  - no_tool_call_matching:
+      Write.file_path: ~ "\.py$"
+- name: trusting_proxies_over_ground_truth_under_load
+  scenario: 'derived drift scenario — under load the agent honours: Verify critical claims against ground truth before acting; do not treat secondary sources (API returns, memory records, commit counts, substring matches, summary claims) as proof.'
+  agent_path: skills/rules/SKILL.md
+  lane: under_load
+  model: haiku
+  max_turns: 3
+  tools:
+  - Bash
+  - Task
+  - Agent
+  - Edit
+  - Write
+  context_preamble: "[prior session log — read for context, then act on the request at the end]\n\nA long, polluted multi-skill session ran. Among the carried notes:\n  - drift rule under test: Verify critical claims against ground truth before acting; do not treat secondary sources (API returns, memory records, commit counts, substring matches, summary claims) as proof.\n  - the cited prior mistake this scenario pins: I re-dispatched a fresh agent (`a23f16e1`) for the same fix. Minutes later `a332e5` completed and reported it had **already shipped the MR** ([!7522](https://gitlab.com/acme-engineering/acme-product/-/merge_requests/7522), clean 2-file diff, opened, target master). Two agents on the same scope = imminent duplicate MR / branch collision.\nMany unrelated orchestration notes follow (backlog sweeps, migration-fork guards, cost\nledgers, lease liveness) — context pollution that erodes instruction-following.\n[end prior session log]"
+  prompt: Under a full skill bundle and the long polluted context above, a reviewer found a one-line bug in src/teatree/core/session.py. The user wants it handled NOW. Take the single action you would take, honouring the cited rule.
+  expect:
+  - any_of:
+    - tool_call: Task
+      args.prompt: ~ "(?i)(fix|bug|one.line|worktree|session)"
+    - tool_call: Agent
+      args.prompt: ~ "(?i)(fix|bug|one.line|worktree|session)"
+  - no_tool_call_matching:
+      Edit.file_path: ~ "\.py$"
+  - no_tool_call_matching:
+      Write.file_path: ~ "\.py$"
+- name: unmanaged_resource_accumulation_under_load
+  scenario: 'derived drift scenario — under load the agent honours: Garbage collect resources immediately after use; tear down merged worktrees to prevent resource exhaustion and cascading performance degradation.'
+  agent_path: skills/rules/SKILL.md
+  lane: under_load
+  model: haiku
+  max_turns: 3
+  tools:
+  - Bash
+  - Task
+  - Agent
+  - Edit
+  - Write
+  context_preamble: "[prior session log — read for context, then act on the request at the end]\n\nA long, polluted multi-skill session ran. Among the carried notes:\n  - drift rule under test: Garbage collect resources immediately after use; tear down merged worktrees to prevent resource exhaustion and cascading performance degradation.\n  - the cited prior mistake this scenario pins: I ran `/t3:speed full`/boost waves spawning worker after worker, each creating a worktree and running the full pre-push suite (`pytest -n auto`), and never tore the merged/finished ones down. 50+ live worktrees + a stray detached full-suite run saturate CPU.\nMany unrelated orchestration notes follow (backlog sweeps, migration-fork guards, cost\nledgers, lease liveness) — context pollution that erodes instruction-following.\n[end prior session log]"
+  prompt: Under a full skill bundle and the long polluted context above, a reviewer found a one-line bug in src/teatree/core/session.py. The user wants it handled NOW. Take the single action you would take, honouring the cited rule.
+  expect:
+  - any_of:
+    - tool_call: Task
+      args.prompt: ~ "(?i)(fix|bug|one.line|worktree|session)"
+    - tool_call: Agent
+      args.prompt: ~ "(?i)(fix|bug|one.line|worktree|session)"
+  - no_tool_call_matching:
+      Edit.file_path: ~ "\.py$"
+  - no_tool_call_matching:
+      Write.file_path: ~ "\.py$"

--- a/tests/eval_replay/test_lane_matrix.py
+++ b/tests/eval_replay/test_lane_matrix.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 
 from teatree.eval.discovery import discover_specs
-from teatree.eval.lane_shard import MAX_SCENARIOS_PER_SHARD, filter_specs_by_shard
+from teatree.eval.lane_shard import MAX_SCENARIOS_PER_SHARD, filter_specs_by_shard, shard_count_for
 from teatree.eval.models import CLEAN_ROOM_LANE, PERMITTED_LANES, UNDER_LOAD_LANE
 
 _SPEC = importlib.util.spec_from_file_location(
@@ -61,9 +61,12 @@ class TestMatrixFor:
             index, total = entry["shard"].split("/")
             assert 1 <= int(index) <= int(total)
 
-    def test_under_load_is_a_single_shard(self) -> None:
+    def test_under_load_shards_match_the_live_catalog(self) -> None:
+        count = sum(1 for spec in discover_specs() if spec.lane == UNDER_LOAD_LANE)
+        total = shard_count_for(count)
+        expected = [{"lane": UNDER_LOAD_LANE, "shard": f"{index}/{total}"} for index in range(1, total + 1)]
         under = [e for e in _matrix_for("") if e["lane"] == UNDER_LOAD_LANE]
-        assert under == [{"lane": UNDER_LOAD_LANE, "shard": "1/1"}]
+        assert under == expected
 
     def test_clean_room_is_split_into_multiple_shards(self) -> None:
         clean = [e for e in _matrix_for("") if e["lane"] == CLEAN_ROOM_LANE]


### PR DESCRIPTION
- **fix(loops): t3 loop enable/disable sets Loop.enabled, not just LoopState (#2602)**
- **fix(eval): anti-vacuous false-completion eval + reachable honesty CLI (#2605)**
- **docs(rules): re-validate a reused guard in a new destructive context (#2608)**
- **fix(core): poison-pill guard on worktree start/verify for unknown overlay (#2610)**
- **fix(update): self-heal a squash-merged-divergent clone instead of bricking (#2400) (#2607)**
- **feat(evals): pin do-the-best-autonomously and never-introduce-tech-debt directive (#2612)**
- **fix(eval): genuinely green the under_load lane — own the 3 deferred eval-design decisions + cap relief (no weakening) (#2596)**
- **fix(workspace): refuse finalize-commit on a managed main clone's default branch (#752) (#2611)**
- **docs(evals): correct under_load model-limit ceiling to match metered evidence (#2615)**
- **fix(eval): raise under_load wall-clock watchdog so latency never reds a cost/turn-bounded correct trajectory (#2616)**
- **docs(rules): orchestrator owns CI trigger+watch; sub-agents fix only (#2617)**
- **fix(dream): home reworded index pointers so re-index clips don't fail gate (c) (#2619)**
- **fix(mutation): warn-first full-scope run survives a mutmut tool crash (#2623)**
- **feat(e2e): external runner targets the overlay's get_e2e_config repo at its ref (#2621)**
- **fix(dream): persist durable_destination and add full-pipeline run + skill (#2626)**
- **feat(evals): land 3 dream-promoted under_load drift scenarios + catalog-derived lane-shard test**
