### PR TITLE
fix(cli): autonomy/speed set+show work in the unbootstrapped CLI process (#2631)

### DIFF
--- a/src/teatree/cli/autonomy.py
+++ b/src/teatree/cli/autonomy.py
@@ -29,9 +29,19 @@ gate, the never-lockout posture, and the substrate recorded-approver
 keystone all stay in force under every tier. It only decides *whether to
 ask the user*, never *whether the work is correct*.
 
-This writes through the ``ConfigSetting`` ORM (autonomy's authoritative tier),
-so it ensures Django is configured first; ``show`` is a pure resolver read.
+The ``autonomy`` value is DB-home, so ``set`` writes a ``ConfigSetting`` row.
+But the typer overlay app is assembled in the ``t3`` console-script process,
+which has NOT run ``django.setup()`` — so touching the ``ConfigSetting`` ORM
+in-process crashes with ``ImproperlyConfigured`` the moment the model layer
+imports (souliane/teatree#2622). ``set`` therefore delegates the write to the
+``config_setting`` management command via :func:`teatree.cli.overlay.managepy_core`
+— the same ``python -m teatree`` subprocess seam every other DB-touching overlay
+command (``followup``, ``safe_kill``, …) uses, where ``django.setup()`` runs
+once per process. ``show`` is a pure resolver read whose DB tier fails safe to
+the default, so it needs no bootstrap.
 """
+
+import json
 
 import typer
 
@@ -48,13 +58,23 @@ def _active_overlay_name() -> str | None:
 
 
 def _write_setting_row(value: str, *, scope: str = "") -> None:
-    # Django/ORM imports are inline so building the overlay app (which loads this
-    # module) never eagerly imports the model layer before settings are configured.
-    from teatree.core.models import ConfigSetting  # noqa: PLC0415
-    from teatree.utils.django_bootstrap import ensure_django  # noqa: PLC0415
+    """Persist the ``autonomy`` row via the ``config_setting`` management command.
 
-    ensure_django()
-    ConfigSetting.objects.set_value(AUTONOMY_KEY, value, scope=scope)
+    Delegates to the ``python -m teatree config_setting set`` subprocess seam
+    (:func:`teatree.cli.overlay.managepy_core`) so the ORM write runs in a process
+    where ``django.setup()`` has been called — never in the unbootstrapped
+    console-script process that assembled the typer app (#2622). The management
+    command parses its ``value`` as JSON and validates it through the same
+    registry parser the resolver uses on read, so the value is JSON-encoded here.
+    An empty ``scope`` addresses the GLOBAL store; a name scopes the row to that
+    overlay.
+    """
+    from teatree.cli.overlay import managepy_core  # noqa: PLC0415
+
+    args = ["config_setting", "set", AUTONOMY_KEY, json.dumps(value)]
+    if scope:
+        args += ["--overlay", scope]
+    managepy_core(*args, overlay_name=scope)
 
 
 def _set_global_autonomy(level: Autonomy) -> str:
@@ -81,7 +101,16 @@ def register_autonomy_commands(overlay_app: typer.Typer) -> None:
     def show() -> None:
         """Show the effective autonomy tier (env > per-overlay > global > default)."""
         from teatree.config import get_effective_settings  # noqa: PLC0415
+        from teatree.utils.django_bootstrap import ensure_django  # noqa: PLC0415
 
+        # ``get_effective_settings`` reads the ``ConfigSetting`` DB tier via the
+        # app registry, which fails SAFE to ``{}`` when Django is not configured.
+        # In the ``t3`` console-script process ``django.setup()`` has NOT run, so
+        # without this bootstrap the DB tier is silently skipped and ``show``
+        # reports the dataclass DEFAULT instead of the persisted tier (#2622). It
+        # is idempotent, so a test/loop process that already configured Django is
+        # unaffected.
+        ensure_django()
         typer.echo(get_effective_settings().autonomy.value)
 
     @autonomy_group.command(name="set")

--- a/src/teatree/cli/speed.py
+++ b/src/teatree/cli/speed.py
@@ -10,9 +10,19 @@ persisted in one place rather than hand-edited.
 ``ConfigSetting`` store, so ``set`` writes a GLOBAL-scope DB row (a value in
 ``[teatree]`` TOML is ignored on read). ``show`` reports the effective value
 (env / overlay-row / global-row / default resolved via
-:func:`teatree.config.get_effective_settings`). ``set`` writes through the ORM,
-so it ensures Django is configured first.
+:func:`teatree.config.get_effective_settings`).
+
+The typer overlay app is assembled in the ``t3`` console-script process, which
+has NOT run ``django.setup()`` (souliane/teatree#2622). So ``set`` delegates the
+ORM write to the ``config_setting`` management command via the same
+``python -m teatree`` subprocess seam every other DB-touching overlay command
+uses (:func:`teatree.cli.overlay.managepy_core`), and ``show`` bootstraps Django
+before the resolver read — otherwise its ``ConfigSetting`` DB tier fails SAFE to
+``{}`` and ``show`` silently reports the dataclass default instead of the
+persisted dial.
 """
+
+import json
 
 import typer
 
@@ -22,13 +32,16 @@ SPEED_KEY = "speed"
 
 
 def _set_speed(level: Speed) -> None:
-    # Django/ORM imports are inline so building the overlay app (which loads this
-    # module) never eagerly imports the model layer before settings are configured.
-    from teatree.core.models import ConfigSetting  # noqa: PLC0415
-    from teatree.utils.django_bootstrap import ensure_django  # noqa: PLC0415
+    """Persist the GLOBAL-scope ``speed`` row via the ``config_setting`` management command.
 
-    ensure_django()
-    ConfigSetting.objects.set_value(SPEED_KEY, level.value)
+    Delegates to ``python -m teatree config_setting set`` (:func:`teatree.cli.overlay.managepy_core`)
+    so the ORM write runs in a process where ``django.setup()`` has been called,
+    never in the unbootstrapped console-script process (#2622). The management
+    command parses ``value`` as JSON, so the canonical value is JSON-encoded here.
+    """
+    from teatree.cli.overlay import managepy_core  # noqa: PLC0415
+
+    managepy_core("config_setting", "set", SPEED_KEY, json.dumps(level.value))
 
 
 def register_speed_commands(overlay_app: typer.Typer) -> None:
@@ -39,7 +52,13 @@ def register_speed_commands(overlay_app: typer.Typer) -> None:
     def show() -> None:
         """Show the effective speed (env > per-overlay > global > default)."""
         from teatree.config import get_effective_settings  # noqa: PLC0415
+        from teatree.utils.django_bootstrap import ensure_django  # noqa: PLC0415
 
+        # ``get_effective_settings`` reads the ``ConfigSetting`` DB tier via the
+        # app registry, which fails SAFE to ``{}`` when Django is not configured —
+        # so without this bootstrap the console-script ``show`` reports the
+        # dataclass DEFAULT instead of the persisted dial (#2622). Idempotent.
+        ensure_django()
         typer.echo(get_effective_settings().speed.value)
 
     @speed_group.command(name="set")

--- a/tests/test_cli_autonomy.py
+++ b/tests/test_cli_autonomy.py
@@ -15,10 +15,14 @@ Integration-first: the ``set`` write is asserted on the persisted
 so the gates collapse — and the safety floor does NOT.
 """
 
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 import typer
+from django.core.management import call_command
 from django.test import TestCase
 from typer.testing import CliRunner
 
@@ -33,6 +37,34 @@ def _app() -> typer.Typer:
     app = typer.Typer()
     register_autonomy_commands(app)
     return app
+
+
+def _in_process_managepy_core(*args: str, overlay_name: str = "") -> None:
+    """In-process stand-in for the ``config_setting`` subprocess seam.
+
+    The real ``set`` path delegates the ORM write to a ``python -m teatree
+    config_setting set`` subprocess (#2622) so it runs where ``django.setup()``
+    has been called. A subprocess is an unstoppable external the test-doctrine
+    permits mocking: in-process tests replace ONLY the subprocess boundary with
+    a ``call_command`` against the same management command and the test DB, so
+    the typer command's resolution logic and the real delegation arg shape are
+    still exercised, and the row lands where the assertions can read it. The
+    actual unbootstrapped-process behaviour is proven separately by
+    :class:`TestAutonomySetBootstrapsDjangoInRealProcess`.
+    """
+    call_command(*args)
+
+
+@pytest.fixture(autouse=True)
+def _stub_subprocess_write(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Route the ``autonomy set`` subprocess delegation in-process for the CliRunner tests.
+
+    ``_write_setting_row`` imports ``managepy_core`` lazily from
+    ``teatree.cli.overlay`` (to avoid a circular import at module load), so the
+    patch target is the source module attribute, not a re-export on
+    ``teatree.cli.autonomy``.
+    """
+    monkeypatch.setattr("teatree.cli.overlay.managepy_core", _in_process_managepy_core)
 
 
 class TestAutonomySetGlobal(TestCase):
@@ -211,3 +243,102 @@ class TestAutonomyKnobCollapsesGatesNotFloor(TestCase):
         assert settings.on_behalf_post_mode is OnBehalfPostMode.DRAFT_OR_ASK
         assert settings.require_human_approval_to_merge is True
         assert settings.require_human_approval_to_answer is True
+
+
+_UNBOOTSTRAPPED_CLI_DRIVER = """
+import sys
+from typer.testing import CliRunner
+import typer
+from teatree.cli.autonomy import register_autonomy_commands
+
+app = typer.Typer()
+register_autonomy_commands(app)
+result = CliRunner().invoke(app, sys.argv[1:])
+sys.stdout.write(result.output)
+if result.exception is not None and not isinstance(result.exception, SystemExit):
+    import traceback
+    traceback.print_exception(type(result.exception), result.exception, result.exception.__traceback__)
+raise SystemExit(result.exit_code)
+"""
+"""A subprocess driver that exercises the ``autonomy`` typer commands without
+``django.setup()`` — reproducing the real ``t3`` console-script condition
+cheaply. It imports ONLY ``teatree.cli.autonomy`` + Typer (not the whole
+``teatree.cli`` app tree), so it stays fast, but it still never configures
+Django before invoking the command — the exact condition #2622 fires under."""
+
+
+@pytest.mark.timeout(180)
+class TestAutonomySetBootstrapsDjangoInRealProcess:
+    """``autonomy set`` / ``show`` work from a process where Django is NOT pre-configured.
+
+    No in-process DB: each case spawns a clean subprocess against its OWN
+    isolated ``XDG_DATA_HOME`` SQLite control DB and asserts only on subprocess
+    output — so the class needs neither ``TestCase`` nor ``@pytest.mark.django_db``.
+
+    The in-process :class:`~typer.testing.CliRunner` tests above all run inside
+    pytest, where ``django.setup()`` has already configured settings — so they
+    cannot observe souliane/teatree#2622: the real ``t3`` console-script process
+    never runs ``django.setup()`` before dispatching the typer overlay app, so
+    the ``set`` body crashed with ``ImproperlyConfigured: Requested setting
+    INSTALLED_APPS …`` the moment it touched the ``ConfigSetting`` ORM, and
+    ``show`` silently reported the dataclass default (its DB tier fails safe to
+    ``{}`` when Django is unconfigured).
+
+    The subprocess invokes ``register_autonomy_commands`` directly in a process
+    with no ``DJANGO_SETTINGS_MODULE`` — RED on the unbootstrapped code, GREEN
+    once ``set`` delegates to the subprocess seam and ``show`` bootstraps Django.
+    """
+
+    _REPO_ROOT = Path(__file__).resolve().parents[1]
+    _SRC_ROOT = _REPO_ROOT / "src"
+
+    def _clean_env(self, data_home: Path) -> dict[str, str]:
+        env = {k: v for k, v in os.environ.items() if k != "DJANGO_SETTINGS_MODULE"}
+        env["XDG_DATA_HOME"] = str(data_home)
+        env["PYTHONPATH"] = os.pathsep.join([str(self._SRC_ROOT), env.get("PYTHONPATH", "")]).rstrip(os.pathsep)
+        return env
+
+    def _migrate(self, env: dict[str, str]) -> None:
+        # The ``config_setting`` write needs the ``ConfigSetting`` table; migrate
+        # the isolated control DB once up front (this step DOES configure Django).
+        subprocess.run(
+            [sys.executable, "-m", "teatree", "migrate", "--no-input"],
+            cwd=str(self._REPO_ROOT),
+            env={**env, "DJANGO_SETTINGS_MODULE": "teatree.settings"},
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    def _autonomy(self, env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
+        """Invoke the ``autonomy`` typer subgroup in an UNbootstrapped subprocess."""
+        return subprocess.run(
+            [sys.executable, "-c", _UNBOOTSTRAPPED_CLI_DRIVER, "autonomy", *args],
+            cwd=str(self._REPO_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_set_global_then_show_round_trips_without_improperly_configured(self, tmp_path: Path) -> None:
+        env = self._clean_env(tmp_path / "xdg")
+        self._migrate(env)
+        result = self._autonomy(env, "set", "notify", "--global")
+        combined = result.stdout + result.stderr
+        # The bug surfaced as this exact exception class from the ORM touch.
+        assert "ImproperlyConfigured" not in combined, combined
+        assert "settings are not configured" not in combined, combined
+        assert result.returncode == 0, combined
+        # And the value actually persisted — round-tripped through ``show`` (which
+        # would silently report the ``babysit`` default if it skipped the DB tier).
+        shown = self._autonomy(env, "show")
+        assert shown.stdout.strip() == Autonomy.NOTIFY.value, shown.stdout + shown.stderr
+
+    def test_set_per_overlay_persists_without_improperly_configured(self, tmp_path: Path) -> None:
+        env = self._clean_env(tmp_path / "xdg")
+        self._migrate(env)
+        result = self._autonomy(env, "set", "notify", "--overlay", "t3-teatree")
+        combined = result.stdout + result.stderr
+        assert "ImproperlyConfigured" not in combined, combined
+        assert result.returncode == 0, combined

--- a/tests/test_cli_speed.py
+++ b/tests/test_cli_speed.py
@@ -8,7 +8,14 @@ through the typer ``CliRunner`` against the same ``speed`` subgroup the overlay
 app builder attaches via :func:`teatree.cli.speed.register_speed_commands`.
 """
 
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
 import typer
+from django.core.management import call_command
 from django.test import TestCase
 from typer.testing import CliRunner
 
@@ -23,6 +30,31 @@ def _app() -> typer.Typer:
     app = typer.Typer()
     register_speed_commands(app)
     return app
+
+
+def _in_process_managepy_core(*args: str, overlay_name: str = "") -> None:
+    """In-process stand-in for the ``config_setting`` subprocess seam (see #2622).
+
+    The real ``set`` path delegates the ORM write to a ``python -m teatree
+    config_setting set`` subprocess so it runs where ``django.setup()`` has been
+    called. A subprocess is an unstoppable external the test-doctrine permits
+    mocking: in-process tests replace ONLY the subprocess boundary with a
+    ``call_command`` against the same management command and the test DB, so the
+    write lands where the assertions can read it. The actual unbootstrapped-process
+    behaviour is proven separately by :class:`TestSpeedSetBootstrapsDjangoInRealProcess`.
+    """
+    call_command(*args)
+
+
+@pytest.fixture(autouse=True)
+def _stub_subprocess_write(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Route the ``speed set`` subprocess delegation in-process for the CliRunner tests.
+
+    ``_set_speed`` imports ``managepy_core`` lazily from ``teatree.cli.overlay``
+    (to avoid a circular import at module load), so the patch target is the
+    source module attribute.
+    """
+    monkeypatch.setattr("teatree.cli.overlay.managepy_core", _in_process_managepy_core)
 
 
 class TestSpeedSet(TestCase):
@@ -72,3 +104,87 @@ class TestSpeedShow(TestCase):
         # ``show`` is a pure resolver read — no row is written or cleared.
         assert ConfigSetting.objects.count() == 1
         assert ConfigSetting.objects.get_effective("speed") == Speed.SLOW.value
+
+
+_UNBOOTSTRAPPED_CLI_DRIVER = """
+import sys
+from typer.testing import CliRunner
+import typer
+from teatree.cli.speed import register_speed_commands
+
+app = typer.Typer()
+register_speed_commands(app)
+result = CliRunner().invoke(app, sys.argv[1:])
+sys.stdout.write(result.output)
+if result.exception is not None and not isinstance(result.exception, SystemExit):
+    import traceback
+    traceback.print_exception(type(result.exception), result.exception, result.exception.__traceback__)
+raise SystemExit(result.exit_code)
+"""
+"""A subprocess driver that exercises the ``speed`` typer commands without
+``django.setup()`` — reproducing the real ``t3`` console-script condition
+cheaply (imports only ``teatree.cli.speed`` + Typer, not the whole CLI tree)."""
+
+
+@pytest.mark.timeout(180)
+class TestSpeedSetBootstrapsDjangoInRealProcess:
+    """``speed set`` / ``show`` work from a process where Django is NOT pre-configured.
+
+    No in-process DB: each case spawns a clean subprocess against its OWN
+    isolated ``XDG_DATA_HOME`` SQLite control DB and asserts only on subprocess
+    output — so the class needs neither ``TestCase`` nor ``@pytest.mark.django_db``.
+
+    The in-process :class:`~typer.testing.CliRunner` tests above all run inside
+    pytest, where ``django.setup()`` has already configured settings, so they
+    cannot observe souliane/teatree#2622: the real ``t3`` console-script process
+    never runs ``django.setup()`` before dispatching the typer overlay app, so
+    ``set`` crashed with ``ImproperlyConfigured`` the moment it touched the
+    ``ConfigSetting`` ORM, and ``show`` silently reported the dataclass default
+    (its DB tier fails safe to ``{}`` when Django is unconfigured).
+
+    The subprocess invokes ``register_speed_commands`` directly in a process with
+    no ``DJANGO_SETTINGS_MODULE`` — RED on the unbootstrapped code, GREEN once
+    ``set`` delegates to the subprocess seam and ``show`` bootstraps Django.
+    """
+
+    _REPO_ROOT = Path(__file__).resolve().parents[1]
+    _SRC_ROOT = _REPO_ROOT / "src"
+
+    def _clean_env(self, data_home: Path) -> dict[str, str]:
+        env = {k: v for k, v in os.environ.items() if k != "DJANGO_SETTINGS_MODULE"}
+        env["XDG_DATA_HOME"] = str(data_home)
+        env["PYTHONPATH"] = os.pathsep.join([str(self._SRC_ROOT), env.get("PYTHONPATH", "")]).rstrip(os.pathsep)
+        return env
+
+    def _migrate(self, env: dict[str, str]) -> None:
+        subprocess.run(
+            [sys.executable, "-m", "teatree", "migrate", "--no-input"],
+            cwd=str(self._REPO_ROOT),
+            env={**env, "DJANGO_SETTINGS_MODULE": "teatree.settings"},
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    def _speed(self, env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
+        """Invoke the ``speed`` typer subgroup in an UNbootstrapped subprocess."""
+        return subprocess.run(
+            [sys.executable, "-c", _UNBOOTSTRAPPED_CLI_DRIVER, "speed", *args],
+            cwd=str(self._REPO_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_set_then_show_round_trips_without_improperly_configured(self, tmp_path: Path) -> None:
+        env = self._clean_env(tmp_path / "xdg")
+        self._migrate(env)
+        result = self._speed(env, "set", "boost")
+        combined = result.stdout + result.stderr
+        assert "ImproperlyConfigured" not in combined, combined
+        assert "settings are not configured" not in combined, combined
+        assert result.returncode == 0, combined
+        # ``show`` must read the persisted dial, not silently fall back to the default.
+        shown = self._speed(env, "show")
+        assert shown.stdout.strip() == Speed.BOOST.value, shown.stdout + shown.stderr


### PR DESCRIPTION
## Problem

`t3 <overlay> autonomy set <level>` crashed with:

```
django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS,
but settings are not configured. You must either define DJANGO_SETTINGS_MODULE
or call settings.configure() before accessing settings.
```

The `t3` console-script process assembles the typer overlay app **without** running `django.setup()`. The `autonomy set` body touched the `ConfigSetting` ORM in-process — and importing `teatree.core.models` defines Django model classes that read `INSTALLED_APPS`, so `set` crashed before any value was written. The per-overlay trust switch could not be changed at all.

`autonomy show` shared the **same root cause** with a silent failure mode: its `ConfigSetting` DB tier fails safe to `{}` when Django is unconfigured (`_load_global_rows`/`_load_overlay_rows` swallow the unconfigured read), so `show` reported the dataclass default (`babysit`) instead of the persisted value — the switch looked stuck even after a (hypothetical) successful write.

`t3 <overlay> speed set` had the **identical** bug (same registration shape via `register_speed_commands`) — confirmed reproducing the same `ImproperlyConfigured` crash — so it is fixed in kind (scope the class, not one call site).

## Fix

Follow the established pattern where every DB-touching overlay command delegates to a management command via the `python -m teatree` subprocess seam (`followup`, `safe_kill`, …), where `django.setup()` runs once per process:

- **`set`** routes the write through the existing `config_setting` management command via `managepy_core` — it already validates `autonomy`/`speed` through the same registry parser the resolver uses on read, and writes the canonical value.
- **`show`** calls `ensure_django()` (the sanctioned single bootstrap entry point) before the resolver read, so its DB tier is actually consulted instead of silently failing safe to the default.

No in-process ORM touch remains in either command body, so the crash class is eliminated.

## Tests (TDD: RED → GREEN)

Added a subprocess regression test per file that drives the typer subgroup in a clean subprocess (no `DJANGO_SETTINGS_MODULE`, isolated `XDG_DATA_HOME` SQLite DB) — the exact unbootstrapped-process condition the bug fires under. Observed RED (`ImproperlyConfigured: Requested setting INSTALLED_APPS`) on the pre-fix code, GREEN after, with the `set → show` round-trip asserting the persisted value is read back.

The existing in-process `CliRunner` tests could not catch this — pytest's `TestCase` pre-configures Django, masking the unbootstrapped condition. They now route their write through the same `config_setting` management-command seam in-process (mocking only the subprocess boundary, an unstoppable external), preserving all prior write-semantics and gate-collapse coverage.

Touched-test evidence: `tests/test_cli_autonomy.py` + `tests/test_cli_speed.py` — 25 passed. Ruff + the full pre-commit gate suite pass.

Closes #2631
