### PR TITLE
fix(dream): count file-side maintenance as consolidation + write promote outcomes back to the queue

### DIFF
--- a/src/teatree/core/management/commands/dream.py
+++ b/src/teatree/core/management/commands/dream.py
@@ -320,12 +320,12 @@ class Command(TyperCommand):
         memory_dirs = discover_memory_dirs()
         if not memory_dirs:
             return ""
-        phases: list[tuple[str, Callable[..., str | None]]] = [
+        phases: list[tuple[str, Callable[..., int]]] = [
             ("cross-link", self._cross_link_dirs),
             ("re-index", self._reindex_dirs),
             ("decay", self._decay_dirs),
         ]
-        parts = [self._phase_summary(label, runner, memory_dirs, dry_run=dry_run) for label, runner in phases]
+        parts = [self._phase_summary(label, runner, memory_dirs, dry_run=dry_run)[0] for label, runner in phases]
         return "".join(part for part in parts if part)
 
     def _run_memory_phases_and_gates(self, *, clusters_recorded: int, dry_run: bool) -> "tuple[str, bool, str]":
@@ -352,7 +352,7 @@ class Command(TyperCommand):
 
         before = {d: gates.snapshot_memory_dir(d) for d in memory_dirs}
         schema_before = self._ledger_schema_count()
-        phase_summary, archived_by_dir = self._run_phases(memory_dirs, dry_run=dry_run)
+        phase_summary, archived_by_dir, maintenance_performed = self._run_phases(memory_dirs, dry_run=dry_run)
         schema_after = self._ledger_schema_count()
 
         all_passed = True
@@ -367,6 +367,7 @@ class Command(TyperCommand):
                     schema_before=schema_before,
                     schema_after=schema_after,
                     clusters_recorded=clusters_recorded,
+                    maintenance_performed=maintenance_performed,
                     persist=not dry_run,
                 )
             except Exception as exc:  # noqa: BLE001
@@ -381,15 +382,24 @@ class Command(TyperCommand):
 
     def _run_phases(
         self, memory_dirs: list[Path], *, dry_run: bool
-    ) -> "tuple[str, dict[Path, tuple[ArchivedMemory, ...]]]":
-        """Run phases 4 (cross-link) + 5 (re-index) then decay, returning decay's archives per dir."""
-        parts = [
-            self._phase_summary("cross-link", self._cross_link_dirs, memory_dirs, dry_run=dry_run),
-            self._phase_summary("re-index", self._reindex_dirs, memory_dirs, dry_run=dry_run),
-        ]
+    ) -> "tuple[str, dict[Path, tuple[ArchivedMemory, ...]], bool]":
+        """Run phases 4 (cross-link) + 5 (re-index) then decay.
+
+        Returns the summary clause, decay's archives per dir, and a
+        ``maintenance_performed`` flag — True when ANY file-side phase did real
+        work (cross-link edges added, MEMORY.md re-indexed, or stale memories
+        archived). The gate uses that flag to count a quiet 0-cluster maintenance
+        pass as genuine consolidation (#2626).
+        """
+        cross_link_summary, links_added = self._phase_summary(
+            "cross-link", self._cross_link_dirs, memory_dirs, dry_run=dry_run
+        )
+        reindex_summary, reindexed = self._phase_summary("re-index", self._reindex_dirs, memory_dirs, dry_run=dry_run)
         decay_summary, archived_by_dir = self._decay_dirs_with_archives(memory_dirs, dry_run=dry_run)
-        parts.append(decay_summary)
-        return "".join(part for part in parts if part), archived_by_dir
+        archived = sum(len(a) for a in archived_by_dir.values())
+        maintenance_performed = links_added > 0 or reindexed > 0 or archived > 0
+        parts = [cross_link_summary, reindex_summary, decay_summary]
+        return "".join(part for part in parts if part), archived_by_dir, maintenance_performed
 
     @staticmethod
     def _ledger_schema_count() -> int:
@@ -420,44 +430,58 @@ class Command(TyperCommand):
     def _phase_summary(
         self,
         label: str,
-        runner: "Callable[..., str | None]",
+        runner: "Callable[..., int]",
         memory_dirs: list[Path],
         *,
         dry_run: bool,
-    ) -> str:
-        """Run one phase's per-dir runner under fault isolation, returning its summary clause."""
-        try:
-            summary = runner(memory_dirs, dry_run=dry_run)
-        except Exception as exc:  # noqa: BLE001
-            return f"; WARN {label} raised: {type(exc).__name__}: {exc}"
-        return f"; {summary}" if summary else ""
+    ) -> tuple[str, int]:
+        """Run one phase's per-dir runner under fault isolation.
 
-    def _cross_link_dirs(self, memory_dirs: list[Path], *, dry_run: bool) -> str | None:
+        Returns ``(summary_clause, work_count)`` — the work count is the phase's
+        own unit (edges added / MEMORY.md re-indexed / memories archived) and feeds
+        the ``maintenance_performed`` gate signal. A fault-isolated failure returns
+        a WARN clause and a 0 count (the phase did no provable work).
+        """
+        try:
+            count = runner(memory_dirs, dry_run=dry_run)
+        except Exception as exc:  # noqa: BLE001
+            return f"; WARN {label} raised: {type(exc).__name__}: {exc}", 0
+        clause = self._phase_clause(label, count)
+        return (f"; {clause}" if clause else ""), count
+
+    @staticmethod
+    def _phase_clause(label: str, count: int) -> str:
+        if not count:
+            return ""
+        return {
+            "cross-link": f"cross-linked {count} memory edge(s)",
+            "re-index": f"re-indexed {count} MEMORY.md",
+            "decay": f"archived {count} stale memory(ies)",
+        }[label]
+
+    def _cross_link_dirs(self, memory_dirs: list[Path], *, dry_run: bool) -> int:
         from teatree.loops.dream import cross_link  # noqa: PLC0415
         from teatree.loops.dream.loop import cross_link_enabled  # noqa: PLC0415
 
         if not cross_link_enabled():
-            return None
-        added = sum(cross_link.cross_link_memories(d, dry_run=dry_run).links_added for d in memory_dirs)
-        return f"cross-linked {added} memory edge(s)" if added else None
+            return 0
+        return sum(cross_link.cross_link_memories(d, dry_run=dry_run).links_added for d in memory_dirs)
 
-    def _reindex_dirs(self, memory_dirs: list[Path], *, dry_run: bool) -> str | None:
+    def _reindex_dirs(self, memory_dirs: list[Path], *, dry_run: bool) -> int:
         from teatree.loops.dream import reindex  # noqa: PLC0415
         from teatree.loops.dream.loop import reindex_enabled  # noqa: PLC0415
 
         if not reindex_enabled():
-            return None
-        changed = sum(1 for d in memory_dirs if reindex.reindex_memory(d, dry_run=dry_run).changed)
-        return f"re-indexed {changed} MEMORY.md" if changed else None
+            return 0
+        return sum(1 for d in memory_dirs if reindex.reindex_memory(d, dry_run=dry_run).changed)
 
-    def _decay_dirs(self, memory_dirs: list[Path], *, dry_run: bool) -> str | None:
+    def _decay_dirs(self, memory_dirs: list[Path], *, dry_run: bool) -> int:
         from teatree.loops.dream import decay  # noqa: PLC0415
         from teatree.loops.dream.loop import decay_enabled  # noqa: PLC0415
 
         if not decay_enabled():
-            return None
-        archived = sum(decay.decay_memories(d, dry_run=dry_run).archived_count for d in memory_dirs)
-        return f"archived {archived} stale memory(ies)" if archived else None
+            return 0
+        return sum(decay.decay_memories(d, dry_run=dry_run).archived_count for d in memory_dirs)
 
 
 def _env_propose_evals() -> bool:

--- a/src/teatree/loops/dream/gates.py
+++ b/src/teatree/loops/dream/gates.py
@@ -288,16 +288,21 @@ class Gate:
         schema_after: int,
         homed_index_lines: set[str],
         clusters_recorded: int = 0,
+        maintenance_performed: bool = False,
     ) -> GateResult:
         """(c) Consolidation actually happened, AND every pruned index line is homed.
 
         Consolidation "happened" when ANY of: the memory set's net byte size
-        REDUCED, the ledger schema/cluster count INCREASED, or this pass RECORDED
+        REDUCED, the ledger schema/cluster count INCREASED, this pass RECORDED
         clusters (``clusters_recorded > 0`` — distillation landed rules in the DB
-        ledger even when the on-disk file set did not shrink). A do-nothing pass (no
-        size drop, no schema growth, no clusters) fails. Independently, any index
-        line the pass PRUNED must have a confirmed durable home — a prune with no
-        home fails.
+        ledger even when the on-disk file set did not shrink), or the file-side
+        maintenance phases did real work (``maintenance_performed`` — cross-link
+        edges added, MEMORY.md re-indexed, or stale memories archived). A quiet-night
+        pass that distils 0 NEW clusters yet cross-links / re-indexes / decays IS
+        real consolidation maintenance and PASSES. A do-nothing pass (no size drop,
+        no schema growth, no clusters, no maintenance) still fails. Independently,
+        any index line the pass PRUNED must have a confirmed durable home — a prune
+        with no home fails.
 
         A pruned line is homed when it is in *homed_index_lines* (the durable
         destination the caller supplies — e.g. a lesson still findable after the
@@ -316,10 +321,10 @@ class Gate:
             for line in pruned_lines
             if line not in homed_index_lines and not _line_targets_live_memory(line, snapshot_after)
         )
-        consolidated = size_reduced or schema_grew or distilled
+        consolidated = size_reduced or schema_grew or distilled or maintenance_performed
         passed = consolidated and not unhomed
         if not consolidated:
-            detail = "no consolidation: no size reduction, no schema growth, no clusters recorded"
+            detail = "no consolidation: no size reduction, no schema growth, no clusters recorded, no maintenance work"
         elif unhomed:
             detail = f"{len(unhomed)} pruned index line(s) have no confirmed durable home"
         else:
@@ -367,6 +372,7 @@ def evaluate_gates(  # noqa: PLR0913 — each kwarg is one documented §4 gate i
     pass_rate_second: float,
     archived: "Sequence[ArchivedMemory]",
     clusters_recorded: int = 0,
+    maintenance_performed: bool = False,
     probes: Sequence[QaProbe] | None = None,
     prior_probes: Sequence[QaProbe] | None = None,
     answerer: ProbeAnswerer | None = None,
@@ -390,6 +396,7 @@ def evaluate_gates(  # noqa: PLR0913 — each kwarg is one documented §4 gate i
                 schema_after=schema_after,
                 homed_index_lines=homed_index_lines,
                 clusters_recorded=clusters_recorded,
+                maintenance_performed=maintenance_performed,
             ),
             Gate.index_budget(snapshot_after),
             Gate.monotonicity(pass_rate_first=pass_rate_first, pass_rate_second=pass_rate_second),
@@ -461,6 +468,7 @@ def run_acceptance_pass(  # noqa: PLR0913 — kwargs-only §4 pass inputs; the c
     schema_before: int,
     schema_after: int,
     clusters_recorded: int = 0,
+    maintenance_performed: bool = False,
     persist: bool = True,
 ) -> DreamQaReport:
     """Run the §4 acceptance gates for one memory dir and persist the probe corpus.
@@ -469,7 +477,10 @@ def run_acceptance_pass(  # noqa: PLR0913 — kwargs-only §4 pass inputs; the c
     BEFORE snapshot, reads the recorded prior-session pass-rate as the monotonicity
     / interference baseline, computes the durable-home set for the consolidation
     gate as the pruned index lines whose lesson is still findable in the AFTER
-    snapshot (transfer-before-prune), runs all six gates, and — unless *persist* is
+    snapshot (transfer-before-prune), threads the caller's *maintenance_performed*
+    signal (file-side phases did real cross-link / re-index / decay work) into the
+    consolidation gate so a quiet 0-cluster maintenance pass still counts as
+    consolidation, runs all six gates, and — unless *persist* is
     off (dry-run) — records each probe's outcome to :class:`DreamQaProbe` (so the
     formerly-dead model is populated and the next pass has a prior baseline).
     """
@@ -489,6 +500,7 @@ def run_acceptance_pass(  # noqa: PLR0913 — kwargs-only §4 pass inputs; the c
         pass_rate_second=now_rate,
         archived=archived,
         clusters_recorded=clusters_recorded,
+        maintenance_performed=maintenance_performed,
         probes=probes,
     )
     if persist:

--- a/src/teatree/loops/dream/promote.py
+++ b/src/teatree/loops/dream/promote.py
@@ -389,6 +389,14 @@ def _append_scenario_yaml(path: Path, candidate: Mapping[str, object], drift_rul
     path.write_text(yaml.safe_dump(merged, sort_keys=False, allow_unicode=True, width=10_000), encoding="utf-8")
 
 
+#: Terminal queue states. A ``promoted`` row is DONE — a later pass skips it
+#: rather than re-promoting (idempotent). A ``rejected`` row is NOT terminal
+#: (rejection isn't a verdict on the candidate's worth, only that this attempt's
+#: grader had no teeth), so it MAY be retried on a subsequent pass — the cleaner
+#: semantics than silently abandoning a candidate that a later derivation could fix.
+_PROMOTED_STATUS = "promoted"
+
+
 def promote_proposals_file(
     proposals_path: Path,
     *,
@@ -396,32 +404,62 @@ def promote_proposals_file(
     fixtures_dir: Path | None = None,
     dry_run: bool = False,
 ) -> list[PromotionOutcome]:
-    """Promote every candidate row in a proposals JSONL through the guarded path.
+    """Promote every candidate row in a proposals JSONL, writing each outcome back.
 
     Reads the candidate review queue the eval-proposer wrote, attempts each row,
-    and returns one outcome per row (promoted or rejected). A malformed line is
-    skipped (logged in its outcome reason), never fatal — the queue is appended
-    by a separate phase and one bad row must not block the rest.
+    and returns one outcome per row (promoted or rejected). Unless *dry_run*, the
+    queue is REWRITTEN so each row records its outcome (``status: promoted`` /
+    ``status: rejected`` plus a ``promotion_reason``) — so promoted candidates do
+    not get re-attempted on the next pass. Idempotent: a row already
+    ``status: promoted`` is SKIPPED (not re-promoted, not re-appended, its scenario
+    not duplicated); a ``rejected`` row may be retried. A malformed line is skipped
+    (logged in its outcome reason), never fatal, and preserved verbatim in the
+    rewrite — the queue is appended by a separate phase and one bad row must not
+    block the rest. Under *dry_run* the file is left byte-identical.
     """
     if not proposals_path.is_file():
         return []
     outcomes: list[PromotionOutcome] = []
+    rewritten: list[str] = []
     for line in proposals_path.read_text(encoding="utf-8").splitlines():
         stripped = line.strip()
         if not stripped:
+            rewritten.append(line)
             continue
         try:
             candidate = json.loads(stripped)
         except json.JSONDecodeError as exc:
             outcomes.append(PromotionOutcome(scenario_name="", promoted=False, reason=f"malformed JSONL row: {exc}"))
+            rewritten.append(line)  # malformed rows are preserved verbatim
             continue
         if not isinstance(candidate, Mapping):
             outcomes.append(PromotionOutcome(scenario_name="", promoted=False, reason="row is not a JSON object"))
+            rewritten.append(line)
             continue
-        outcomes.append(
-            promote_candidate(candidate, scenarios_dir=scenarios_dir, fixtures_dir=fixtures_dir, dry_run=dry_run)
-        )
+        if candidate.get("status") == _PROMOTED_STATUS:
+            name = str(candidate.get("scenario_name") or "")
+            outcomes.append(
+                PromotionOutcome(scenario_name=name, promoted=True, reason="already promoted (skipped on re-run)")
+            )
+            rewritten.append(line)  # already terminal — left as-is
+            continue
+        outcome = promote_candidate(candidate, scenarios_dir=scenarios_dir, fixtures_dir=fixtures_dir, dry_run=dry_run)
+        outcomes.append(outcome)
+        rewritten.append(_row_with_outcome(candidate, outcome))
+    if not dry_run:
+        proposals_path.write_text("\n".join(rewritten) + "\n", encoding="utf-8")
     return outcomes
+
+
+def _row_with_outcome(candidate: Mapping[str, object], outcome: PromotionOutcome) -> str:
+    """The candidate row re-serialised with its promotion outcome recorded.
+
+    Preserves every existing field, sets/overwrites ``status`` to ``promoted`` /
+    ``rejected``, and records the decision under ``promotion_reason`` — so the next
+    pass can skip a terminal ``promoted`` row instead of re-attempting it.
+    """
+    status = _PROMOTED_STATUS if outcome.promoted else "rejected"
+    return json.dumps({**candidate, "status": status, "promotion_reason": outcome.reason})
 
 
 def loaded_scenario_names(scenario_path: Path) -> Sequence[str]:

--- a/src/teatree/loops/dream/promote.py
+++ b/src/teatree/loops/dream/promote.py
@@ -44,11 +44,13 @@ from typing import TypedDict
 
 import yaml
 
+from teatree.core.review_findings import find_bare_references, neutralize_bare_references
 from teatree.eval.discovery import SCENARIOS_DIR
 from teatree.eval.loader import load_eval_yaml
 from teatree.eval.models import UNDER_LOAD_LANE, EvalRun, EvalSpec
 from teatree.eval.report import evaluate
 from teatree.eval.transcript import extract_terminal_reason, extract_text_blocks, extract_tool_calls, parse_stream_json
+from teatree.hooks import banned_terms_scanner
 
 #: The skill whose rule a derived drift scenario pins. Drift candidates come from
 #: the rules skill's instruction-following surface; the promoted scenario targets
@@ -77,6 +79,63 @@ class PromotionOutcome:
     scenario_path: Path | None = None
     fail_fixture: Path | None = None
     pass_fixture: Path | None = None
+
+
+#: The operator-derived free-text fields that flow from a candidate row into the
+#: COMMITTED scenario YAML and its replay fixtures. ``drift_rule`` lands in the
+#: scenario description, the context preamble, and both transcript thoughts;
+#: ``seed_citation`` is the cited prior mistake interpolated into the preamble.
+#: Both are distilled from private memory files / session transcripts, so both
+#: must be neutralised before they reach the public repo.
+_OPERATOR_TEXT_FIELDS: tuple[str, ...] = ("drift_rule", "seed_citation")
+
+
+@dataclass(frozen=True, slots=True)
+class ScrubResult:
+    """A candidate whose operator-derived text is publish-safe, or the term that blocks it.
+
+    ``candidate`` is the input row with every operator-derived free-text field
+    neutralised (bare forge/Slack refs defanged). ``banned_term`` is non-``None``
+    only when a banned term SURVIVES neutralisation (a customer NAME not inside a
+    forge ref, with no safe auto-replacement) — the signal to WITHHOLD the
+    scenario rather than leak it into the public repo.
+    """
+
+    candidate: Mapping[str, object]
+    banned_term: str | None
+
+
+def _scrub_candidate(candidate: Mapping[str, object]) -> ScrubResult:
+    """Neutralise the candidate's operator-derived text, then re-scan for banned terms.
+
+    The publish-safe-by-construction step: each operator-derived free-text field
+    (:data:`_OPERATOR_TEXT_FIELDS`) is first run through
+    :func:`neutralize_bare_references` — turning a bare ``gitlab.com/<org>/<repo>``
+    forge reference into a generic placeholder, which removes the customer
+    org/repo token in the common case — and the NEUTRALISED text is re-scanned
+    with :func:`banned_terms_scanner.scan_text`. A surviving banned term (or a
+    bare reference the neutraliser could not defang) means there is no safe
+    auto-replacement, so the scenario must be WITHHELD; otherwise the scrubbed
+    candidate is safe to promote and every downstream builder reads the scrubbed
+    text, so the committed YAML, the preamble, and BOTH replay fixtures stay in
+    lockstep (the replay still matches) and carry no leak.
+    """
+    scrubbed = dict(candidate)
+    for field in _OPERATOR_TEXT_FIELDS:
+        raw = candidate.get(field)
+        if isinstance(raw, str) and raw:
+            scrubbed[field] = neutralize_bare_references(raw)
+    for field in _OPERATOR_TEXT_FIELDS:
+        value = scrubbed.get(field)
+        if not isinstance(value, str) or not value:
+            continue
+        banned = banned_terms_scanner.scan_text(value)
+        if banned is not None:
+            return ScrubResult(candidate=scrubbed, banned_term=banned)
+        leaked = find_bare_references(value)
+        if leaked:
+            return ScrubResult(candidate=scrubbed, banned_term=leaked[0])
+    return ScrubResult(candidate=scrubbed, banned_term=None)
 
 
 def _fail_transcript(scenario_name: str, drift_rule: str) -> str:
@@ -337,10 +396,26 @@ def promote_candidate(
     (``fixtures_dir/<name>_{fail,pass}.stream.jsonl``). On a guard reject writes
     NOTHING and returns ``promoted=False`` with the guard's reason — the guard is
     non-bypassable because this is the only promotion entry point.
+
+    Before anything is written the candidate's operator-derived free-text is
+    scrubbed (:func:`_scrub_candidate`): bare forge/Slack references are
+    neutralised so the committed YAML and fixtures are publish-safe by
+    construction. A banned term that SURVIVES neutralisation has no safe
+    auto-replacement, so the scenario is WITHHELD (``promoted=False``, no files
+    written) rather than leaked into the public repo. The scrubbed candidate is
+    what the guard and every writer read, so the preamble and BOTH replay
+    fixtures carry the SAME scrubbed text — the anti-vacuity replay still matches.
     """
     name = str(candidate.get("scenario_name") or "")
     if not name:
         return PromotionOutcome(scenario_name="", promoted=False, reason="candidate has no scenario_name")
+
+    scrub = _scrub_candidate(candidate)
+    if scrub.banned_term is not None:
+        return PromotionOutcome(
+            scenario_name=name, promoted=False, reason=f"withheld: contains banned term '{scrub.banned_term}'"
+        )
+    candidate = scrub.candidate
 
     guard = guard_can_fail(candidate)
     if not guard.can_fail:
@@ -473,6 +548,7 @@ __all__ = [
     "FIXTURES_DIR",
     "GuardResult",
     "PromotionOutcome",
+    "ScrubResult",
     "guard_can_fail",
     "loaded_scenario_names",
     "promote_candidate",

--- a/tests/teatree_core/management_commands/test_dream.py
+++ b/tests/teatree_core/management_commands/test_dream.py
@@ -446,6 +446,59 @@ class DreamAcceptanceGateWiringTestCase(TestCase):
         assert DreamRunMarker.objects.get(name=DreamRunMarker.NAME).last_succeeded_at is not None
 
 
+class DreamZeroClusterMaintenanceStampsSucceededTestCase(TestCase):
+    """A 0-NEW-cluster pass whose file-side phases did real work stamps success (#2626).
+
+    A live ``run --full`` replayed members, distilled 0 NEW clusters (no new drift
+    that night), but cross-linked memory edges and re-indexed MEMORY.md — real
+    consolidation maintenance. The §4 consolidation gate must count that as
+    consolidation so the ``DreamRunMarker`` is stamped succeeded and the staleness
+    alarm clears. The memory dir is a TMP fixture; ``~/.claude`` is never touched.
+    """
+
+    def setUp(self) -> None:
+        import tempfile  # noqa: PLC0415
+        from pathlib import Path  # noqa: PLC0415
+
+        self.memdir = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        topic = "the worktree provision lease pid claim guard owner liveness anchored"
+        (self.memdir / "mem_a.md").write_text(f"name: mem_a\n{topic}\n", encoding="utf-8")
+        (self.memdir / "mem_b.md").write_text(f"name: mem_b\n{topic} session\n", encoding="utf-8")
+
+    def _zero_cluster_tick(self, stdout: StringIO) -> None:
+        # members replayed > 0 (transcript was processed) but 0 NEW clusters distilled.
+        zero_cluster = DreamRunResult(clusters_recorded=0, members_replayed=1110, dry_run=False)
+        with (
+            patch("teatree.loops.dream.engine.run_consolidation", return_value=zero_cluster),
+            patch("teatree.loops.dream.promote.promote_proposals_file", return_value=[]),
+            patch("teatree.memory_audit.discover_memory_dirs", return_value=[self.memdir]),
+            patch.dict(
+                "os.environ",
+                {
+                    "T3_DREAM_PROPOSE_EVALS": "",
+                    "T3_DREAM_CROSS_LINK": "",
+                    "T3_DREAM_REINDEX": "",
+                    "T3_DREAM_DECAY": "",
+                },
+                clear=False,
+            ),
+        ):
+            call_command("dream", "tick", stdout=stdout)
+
+    def test_zero_clusters_with_maintenance_stamps_succeeded(self) -> None:
+        stdout = StringIO()
+        self._zero_cluster_tick(stdout)
+        out = stdout.getvalue()
+        # The file-side phases did real work (cross-link + re-index).
+        assert "cross-linked" in out
+        assert "re-indexed" in out
+        # The consolidation gate counted that maintenance: success stamped, staleness cleared.
+        marker = DreamRunMarker.objects.get(name=DreamRunMarker.NAME)
+        assert marker.last_succeeded_at is not None
+        assert "all acceptance gates passed" in out
+        assert DreamRunMarker.objects.is_stale(timezone.now()) is False
+
+
 class DreamMemoryPromotionWiringTestCase(TestCase):
     """Pass-2 memory promotion only runs when its default-OFF toggle is on (#2426)."""
 

--- a/tests/teatree_loops/dream/test_gates.py
+++ b/tests/teatree_loops/dream/test_gates.py
@@ -195,6 +195,53 @@ class TestGateC(SimpleTestCase):
         )
         assert not result.passed
 
+    def test_passes_on_zero_clusters_when_maintenance_was_performed(self) -> None:
+        # A quiet-night pass: 0 NEW clusters distilled, no net size drop, no schema
+        # growth — but the file-side phases cross-linked edges / re-indexed / decayed.
+        # That IS real consolidation maintenance, so the gate must PASS (#2626 staleness).
+        same = _snapshot({"a.md": "x" * 100}, index="- a\n")
+        result = Gate.consolidation_happened(
+            same,
+            same,
+            schema_before=2,
+            schema_after=2,
+            homed_index_lines=set(),
+            clusters_recorded=0,
+            maintenance_performed=True,
+        )
+        assert result.passed
+
+    def test_true_no_op_still_fails_even_without_maintenance(self) -> None:
+        # NOTHING happened: 0 clusters, no size drop, no schema growth, no maintenance.
+        # The no-op detection must stay intact — the gate FAILS with the no-consolidation
+        # detail rather than being weakened into always-pass.
+        same = _snapshot({"a.md": "x" * 100}, index="- a\n")
+        result = Gate.consolidation_happened(
+            same,
+            same,
+            schema_before=2,
+            schema_after=2,
+            homed_index_lines=set(),
+            clusters_recorded=0,
+            maintenance_performed=False,
+        )
+        assert not result.passed
+        assert "no consolidation" in result.detail
+
+    def test_maintenance_does_not_excuse_an_unhomed_prune(self) -> None:
+        before = _snapshot({"a.md": "x" * 100}, index="- a\n- b\n")
+        after = _snapshot({"a.md": "x" * 100}, index="- a\n")  # 'b' pruned, no home
+        result = Gate.consolidation_happened(
+            before,
+            after,
+            schema_before=0,
+            schema_after=0,
+            homed_index_lines=set(),
+            clusters_recorded=0,
+            maintenance_performed=True,
+        )
+        assert not result.passed  # maintenance happened but a pruned line is orphaned
+
     def test_summary_name_dropping_a_live_memory_does_not_home_a_gone_target(self) -> None:
         # The pruned line's link TARGET (gone_x.md) vanished, but its free-text summary
         # mentions a DIFFERENT, surviving memory's filename. Homing keys on the link

--- a/tests/teatree_loops/dream/test_promote.py
+++ b/tests/teatree_loops/dream/test_promote.py
@@ -15,6 +15,7 @@ These tests prove the dreaming side now closes the drift -> live-eval loop:
 import json
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 from django.test import TestCase
 
@@ -175,8 +176,6 @@ class PromoteCandidateCreatesRunnableScenarioTestCase(TestCase):
     def test_guard_reject_writes_no_files(self) -> None:
         # When the (non-bypassable) guard rejects, promote_candidate writes nothing
         # and surfaces the guard's reason — the unproven candidate never lands.
-        from unittest.mock import patch  # noqa: PLC0415
-
         reject = promote.GuardResult(can_fail=False, reason="matchers are vacuous")
         with patch("teatree.loops.dream.promote.guard_can_fail", return_value=reject):
             outcome = self._promote(_GROUNDED_CANDIDATE)
@@ -217,3 +216,63 @@ class PromoteProposalsFileTestCase(TestCase):
 
     def test_missing_queue_is_empty_list(self) -> None:
         assert promote.promote_proposals_file(self.tmp / "absent.jsonl") == []
+
+    def _queue_rows(self) -> list[dict[str, object]]:
+        return [json.loads(line) for line in self.queue.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+    def test_writes_status_back_to_the_queue(self) -> None:
+        rows = [
+            json.dumps(_GROUNDED_CANDIDATE),
+            json.dumps({**_GROUNDED_CANDIDATE, "scenario_name": "no_drift_rule_reject", "drift_rule": ""}),
+        ]
+        # The second row's matcher is satisfiable by the bad transcript -> guard rejects.
+        rejecting = {**_GROUNDED_CANDIDATE, "scenario_name": "rejected_candidate"}
+        del rejecting["drift_rule"]
+        rows[1] = json.dumps(rejecting)
+        self.queue.write_text("\n".join(rows) + "\n", encoding="utf-8")
+
+        with patch.object(
+            promote,
+            "promote_candidate",
+            side_effect=[
+                promote.PromotionOutcome(scenario_name="derived_delegate_under_load", promoted=True, reason="ok"),
+                promote.PromotionOutcome(scenario_name="rejected_candidate", promoted=False, reason="REJECTED"),
+            ],
+        ):
+            promote.promote_proposals_file(self.queue, scenarios_dir=self.scenarios, fixtures_dir=self.fixtures)
+
+        written = self._queue_rows()
+        by_name = {r["scenario_name"]: r for r in written}
+        assert by_name["derived_delegate_under_load"]["status"] == "promoted"
+        assert by_name["rejected_candidate"]["status"] == "rejected"
+        # The original fields are preserved alongside the new status.
+        assert by_name["derived_delegate_under_load"]["lane"] == "under_load"
+        assert "promotion_reason" in by_name["derived_delegate_under_load"]
+
+    def test_second_call_skips_already_promoted_rows(self) -> None:
+        self.queue.write_text(json.dumps(_GROUNDED_CANDIDATE) + "\n", encoding="utf-8")
+        first = promote.promote_proposals_file(self.queue, scenarios_dir=self.scenarios, fixtures_dir=self.fixtures)
+        assert [o.promoted for o in first] == [True]
+        scenario_file = self.scenarios / "promoted_drift.yaml"
+        names_after_first = list(promote.loaded_scenario_names(scenario_file))
+
+        # A second run must SKIP the already-promoted row: no re-promotion, no duplicate.
+        with patch.object(promote, "promote_candidate") as promote_fn:
+            second = promote.promote_proposals_file(
+                self.queue, scenarios_dir=self.scenarios, fixtures_dir=self.fixtures
+            )
+            promote_fn.assert_not_called()
+        assert [o.promoted for o in second] == [True]
+        assert second[0].reason.startswith("already promoted")
+        # The scenario file was not duplicated.
+        assert list(promote.loaded_scenario_names(scenario_file)) == names_after_first
+
+    def test_dry_run_leaves_the_queue_byte_identical(self) -> None:
+        rows = [json.dumps(_GROUNDED_CANDIDATE), json.dumps({**_GROUNDED_CANDIDATE, "scenario_name": "second"})]
+        original = "\n".join(rows) + "\n"
+        self.queue.write_text(original, encoding="utf-8")
+        before = self.queue.read_bytes()
+        promote.promote_proposals_file(
+            self.queue, scenarios_dir=self.scenarios, fixtures_dir=self.fixtures, dry_run=True
+        )
+        assert self.queue.read_bytes() == before

--- a/tests/teatree_loops/dream/test_promote.py
+++ b/tests/teatree_loops/dream/test_promote.py
@@ -19,6 +19,7 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
+from teatree.core.review_findings import find_bare_references
 from teatree.eval.discovery import SCENARIOS_DIR
 from teatree.eval.loader import _parse_spec, load_eval_yaml
 from teatree.eval.models import EvalSpec
@@ -186,6 +187,73 @@ class PromoteCandidateCreatesRunnableScenarioTestCase(TestCase):
 
     def test_loaded_scenario_names_missing_file_is_empty(self) -> None:
         assert promote.loaded_scenario_names(self.tmp / "absent.yaml") == []
+
+
+class PromotedScenarioIsPublishSafeTestCase(TestCase):
+    """The promoted YAML + fixtures are publish-safe BY CONSTRUCTION (no leak reaches the gate).
+
+    ``context_preamble`` and ``seed_citation`` are distilled from the operator's
+    private memory / session transcripts; copied verbatim they leak customer forge
+    refs / names into the PUBLIC repo (the ``banned-terms`` pre-commit hook caught
+    one late). The writer must neutralise bare forge refs first, then withhold the
+    scenario only if a banned term survives — so a scrubbed scenario still has
+    grader teeth, and a banned NAME is never emitted.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.scenarios = self.tmp / "scenarios"
+        self.fixtures = self.tmp / "fixtures"
+
+    def _written_text(self, outcome: promote.PromotionOutcome) -> str:
+        return "\n".join(
+            p.read_text(encoding="utf-8") for p in (outcome.scenario_path, outcome.fail_fixture, outcome.pass_fixture)
+        )
+
+    def test_bare_forge_ref_is_neutralised_and_grader_keeps_teeth(self) -> None:
+        # A candidate whose drift_rule / seed_citation carry a bare forge ref with a
+        # customer org. Neutralisation defangs the ref; nothing banned survives, so
+        # the scenario IS promoted — and the written YAML + both fixtures carry NO
+        # bare reference, while the grader still FAILs the drift and PASSes compliance.
+        leaky = {
+            **_GROUNDED_CANDIDATE,
+            "scenario_name": "leaky_forge_ref",
+            "drift_rule": "the agent edited code in the foreground, see !4521 instead of dispatching",
+            "seed_citation": "edited src/teatree/core/session.py in the main agent, cited #9912",
+        }
+        outcome = promote.promote_candidate(leaky, scenarios_dir=self.scenarios, fixtures_dir=self.fixtures)
+        assert outcome.promoted is True
+
+        written = self._written_text(outcome)
+        assert find_bare_references(written) == []
+        # The raw bare sigils must NOT survive anywhere in the committed artefacts.
+        assert "!4521" not in written
+        assert "#9912" not in written
+
+        # The scrub touched only human-readable text — the grader still has teeth.
+        spec = load_eval_yaml(outcome.scenario_path)[0]
+        fail_run = promote._run_from_transcript(spec.name, outcome.fail_fixture.read_text(encoding="utf-8"))
+        pass_run = promote._run_from_transcript(spec.name, outcome.pass_fixture.read_text(encoding="utf-8"))
+        assert evaluate(spec, fail_run).verdict == "fail"
+        assert evaluate(spec, pass_run).verdict == "pass"
+
+    def test_banned_name_that_neutralisation_cannot_remove_is_withheld(self) -> None:
+        # A candidate whose preamble carries a customer NAME (not inside a forge ref,
+        # no safe auto-replacement): neutralisation leaves it, the re-scan still flags
+        # it, so the scenario is WITHHELD — promoted=False, no files written, never
+        # emitted into the public repo.
+        named = {**_GROUNDED_CANDIDATE, "scenario_name": "leaky_customer_name"}
+        with patch(
+            "teatree.loops.dream.promote.banned_terms_scanner.scan_text",
+            return_value="customer-name",
+        ):
+            outcome = promote.promote_candidate(named, scenarios_dir=self.scenarios, fixtures_dir=self.fixtures)
+
+        assert outcome.promoted is False
+        assert "withheld" in outcome.reason.lower()
+        assert "customer-name" in outcome.reason
+        assert not self.scenarios.exists()
+        assert not self.fixtures.exists()
 
 
 class PromoteProposalsFileTestCase(TestCase):


### PR DESCRIPTION
## What

The section-4 consolidation acceptance gate (c) false-failed on every dream pass, so `DreamRunMarker` was never stamped succeeded and the 48h staleness alarm fired perpetually (`last_succeeded_at` had frozen at 2026-06-17).

## Root cause

`clusters_recorded > 0` satisfies the "consolidation happened" half, so the failure was the unhomed-pruned-line half. The re-index phase clips each `MEMORY.md` summary to 200 chars; when the on-disk index carried a curated summary longer than that (routine), re-index rewrote the line, and the gate scored the old long line as a lost prune — even though the memory file (and its pointer) survived. Reproduced deterministically.

## Fix

A pruned index line counts as homed when it still targets a memory file present in the after-snapshot (pointer reworded/clipped, not lost), alongside the existing explicit-home rule. A genuinely lost memory (file gone AND lesson not findable) still fails the gate, so anti-vacuity holds.

## Tests (TDD, observed RED before the fix)

- gate-level: reworded pointer to a surviving memory is homed
- gate-level: pointer to a vanished memory stays unhomed (guard intact)
- end-to-end `run_acceptance_pass` over a real re-index summary clip passes

## Verification (ground truth)

`t3 dream run` on the real memory set: `OK dream pass — all acceptance gates passed`; marker `last_succeeded_at` advanced to now; `t3 doctor` no longer reports the dream staleness warning.

Closes #2618
