### PR TITLE
fix(review): refuse multi-finding general notes; add --force-general escape (#72)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -640,6 +640,13 @@ Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE
  both half-specified-inline and contradictory invocations before any
  GitLab API call is attempted.
 
+ A deliberate ``--general`` note that crams 2+ distinct per-line
+ findings (``foo.py:42``/``bar.ts:9`` cites, or a numbered per-file
+ list) is refused by the #72-round-2 gate
+ (:func:`teatree.cli.review.general_inline_gate.check_general_inline_findings`)
+ — post each one inline instead. Pass ``--force-general`` to override
+ for a genuinely MR-wide (verdict-only) note.
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
 │                         [required]                                           │
@@ -689,6 +696,17 @@ Usage: t3 review post-draft-note [OPTIONS] REPO MR NOTE
 │                                      author-marked TODO/FIXME genuinely must │
 │                                      be addressed in THIS MR; the gate still │
 │                                      refuses by default.                     │
+│ --force-general                      Escape the multi-finding general-note   │
+│                                      gate (souliane/teatree#72) for ONE post │
+│                                      — the documented over-deny escape       │
+│                                      (#126). A general note referencing 2+   │
+│                                      distinct file:line locations (or a      │
+│                                      numbered per-file finding list) is      │
+│                                      refused by default because those are N  │
+│                                      inline findings that should each be     │
+│                                      posted inline. Use this ONLY for a      │
+│                                      genuinely MR-wide note (a verdict-only  │
+│                                      summary with no per-line findings).     │
 │ --help                               Show this message and exit.             │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -715,9 +733,13 @@ Usage: t3 review post-comment [OPTIONS] REPO MR [NOTE]
  content, mirroring how ``gh``/``glab`` comment commands accept a body
  file.
 
- ``--allow-long-review`` / ``--allow-todo-blocker`` are the documented
- per-post escapes for the colleague-MR shape and TODO-anchor gates
- respectively (#126), mirroring the sibling override flags.
+ ``--allow-long-review`` / ``--allow-todo-blocker`` / ``--force-general``
+ are the documented per-post escapes for the colleague-MR shape, the
+ TODO-anchor, and the multi-finding general-note (#72) gates
+ respectively (#126), mirroring the sibling override flags. A general
+ note referencing 2+ distinct ``file:line`` locations (or a numbered
+ per-file finding list) is refused by default — post each one inline
+ instead, or pass ``--force-general`` for a genuinely MR-wide note.
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    repo      TEXT     GitLab project path (e.g., my-org/my-repo)           │
@@ -786,6 +808,18 @@ Usage: t3 review post-comment [OPTIONS] REPO MR [NOTE]
 │                                        TODO/FIXME genuinely must be          │
 │                                        addressed in THIS MR; the gate still  │
 │                                        refuses by default.                   │
+│ --force-general                        Escape the multi-finding general-note │
+│                                        gate (souliane/teatree#72) for ONE    │
+│                                        post — the documented over-deny       │
+│                                        escape (#126). A general note         │
+│                                        referencing 2+ distinct file:line     │
+│                                        locations (or a numbered per-file     │
+│                                        finding list) is refused by default   │
+│                                        because those are N inline findings   │
+│                                        that should each be posted inline.    │
+│                                        Use this ONLY for a genuinely MR-wide │
+│                                        note (a verdict-only summary with no  │
+│                                        per-line findings).                   │
 │ --help                                 Show this message and exit.           │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```

--- a/src/teatree/cli/review/commands.py
+++ b/src/teatree/cli/review/commands.py
@@ -57,6 +57,14 @@ _ALLOW_TODO_BLOCKER_HELP = (
     "refuses by default."
 )
 
+_FORCE_GENERAL_HELP = (
+    "Escape the multi-finding general-note gate (souliane/teatree#72) for ONE post — "
+    "the documented over-deny escape (#126). A general note referencing 2+ distinct "
+    "file:line locations (or a numbered per-file finding list) is refused by default "
+    "because those are N inline findings that should each be posted inline. Use this "
+    "ONLY for a genuinely MR-wide note (a verdict-only summary with no per-line findings)."
+)
+
 
 def _parse_evidence(raw: str) -> "FindingEvidence | None":
     """Build a :class:`FindingEvidence` from a CLI JSON string, or ``None`` when omitted."""
@@ -73,7 +81,7 @@ def _parse_evidence(raw: str) -> "FindingEvidence | None":
 
 @review_app.command(name="post-draft-note")
 # ast-grep-ignore: ac-django-no-complexity-suppressions
-def post_draft_note(  # noqa: PLR0913 — typer command: every param is a CLI flag mapped 1:1 to the public `review post-draft-note` surface (repo/mr/note/file/line/general/evidence-json + the #126 gate escapes). The `--general` flag is load-bearing — it closes the #72 silent-degradation foot-gun by making the inline-vs-general decision explicit. `--evidence-json` is load-bearing — it's the #1280 structured-evidence CLI plumbing.
+def post_draft_note(  # noqa: PLR0913 — typer command: every param is a CLI flag mapped 1:1 to the public `review post-draft-note` surface (repo/mr/note/file/line/general/evidence-json + the #126 gate escapes incl. --force-general). The `--general` flag is load-bearing — it closes the #72 silent-degradation foot-gun by making the inline-vs-general decision explicit. `--force-general` is the #72-round-2 escape for a genuinely MR-wide note that the multi-finding general-note gate would otherwise refuse. `--evidence-json` is load-bearing — it's the #1280 structured-evidence CLI plumbing.
     repo: str = typer.Argument(help="GitLab project path (e.g., my-org/my-repo)"),
     mr: int = typer.Argument(help="Merge request IID"),
     note: str = typer.Argument(help="Comment text (markdown)"),
@@ -100,6 +108,7 @@ def post_draft_note(  # noqa: PLR0913 — typer command: every param is a CLI fl
     evidence_json: str = typer.Option("", "--evidence-json", help=_EVIDENCE_JSON_HELP),
     allow_long_review: bool = typer.Option(False, "--allow-long-review", help=_ALLOW_LONG_REVIEW_HELP),
     allow_todo_blocker: bool = typer.Option(False, "--allow-todo-blocker", help=_ALLOW_TODO_BLOCKER_HELP),
+    force_general: bool = typer.Option(False, "--force-general", help=_FORCE_GENERAL_HELP),
 ) -> None:
     """Post a draft note on a GitLab MR (inline or general).
 
@@ -111,6 +120,13 @@ def post_draft_note(  # noqa: PLR0913 — typer command: every param is a CLI fl
     :func:`teatree.cli.review.drafts.validate_inline_or_general` refuses
     both half-specified-inline and contradictory invocations before any
     GitLab API call is attempted.
+
+    A deliberate ``--general`` note that crams 2+ distinct per-line
+    findings (``foo.py:42``/``bar.ts:9`` cites, or a numbered per-file
+    list) is refused by the #72-round-2 gate
+    (:func:`teatree.cli.review.general_inline_gate.check_general_inline_findings`)
+    — post each one inline instead. Pass ``--force-general`` to override
+    for a genuinely MR-wide (verdict-only) note.
     """
     import sys  # noqa: PLC0415
 
@@ -134,6 +150,7 @@ def post_draft_note(  # noqa: PLR0913 — typer command: every param is a CLI fl
         evidence=evidence,
         allow_long_review=allow_long_review,
         allow_todo_blocker=allow_todo_blocker,
+        force_general=force_general,
     )
     typer.echo(msg)
     if code:
@@ -156,7 +173,7 @@ _BODY_FILE_OPTION_HELP = (
 
 @review_app.command(name="post-comment")
 # ast-grep-ignore: ac-django-no-complexity-suppressions
-def post_comment(  # noqa: PLR0913 — typer command: every param is a CLI flag mapped 1:1 to the public ``review post-comment`` surface (repo/mr/note/file/line/live/evidence-json + the #32 body-source flags). ``--live`` is load-bearing — its absence is the safe-by-default draft path (#1207). ``--evidence-json`` is load-bearing — it's the #1280 structured-evidence CLI plumbing. ``--body``/``--body-file`` are the #32 scannable body-source flags.
+def post_comment(  # noqa: PLR0913 — typer command: every param is a CLI flag mapped 1:1 to the public ``review post-comment`` surface (repo/mr/note/file/line/live/evidence-json + the #32 body-source flags + the #126 gate escapes incl. --force-general). ``--live`` is load-bearing — its absence is the safe-by-default draft path (#1207). ``--force-general`` is the #72-round-2 escape for a genuinely MR-wide note that the multi-finding general-note gate would otherwise refuse. ``--evidence-json`` is load-bearing — it's the #1280 structured-evidence CLI plumbing. ``--body``/``--body-file`` are the #32 scannable body-source flags.
     repo: str = typer.Argument(help="GitLab project path (e.g., my-org/my-repo)"),
     mr: int = typer.Argument(help="Merge request IID"),
     note: str | None = typer.Argument(
@@ -181,6 +198,7 @@ def post_comment(  # noqa: PLR0913 — typer command: every param is a CLI flag 
     evidence_json: str = typer.Option("", "--evidence-json", help=_EVIDENCE_JSON_HELP),
     allow_long_review: bool = typer.Option(False, "--allow-long-review", help=_ALLOW_LONG_REVIEW_HELP),
     allow_todo_blocker: bool = typer.Option(False, "--allow-todo-blocker", help=_ALLOW_TODO_BLOCKER_HELP),
+    force_general: bool = typer.Option(False, "--force-general", help=_FORCE_GENERAL_HELP),
 ) -> None:
     """Post a comment on a GitLab MR — DRAFT by default, ``--live`` requires Slack approval.
 
@@ -198,9 +216,13 @@ def post_comment(  # noqa: PLR0913 — typer command: every param is a CLI flag 
     content, mirroring how ``gh``/``glab`` comment commands accept a body
     file.
 
-    ``--allow-long-review`` / ``--allow-todo-blocker`` are the documented
-    per-post escapes for the colleague-MR shape and TODO-anchor gates
-    respectively (#126), mirroring the sibling override flags.
+    ``--allow-long-review`` / ``--allow-todo-blocker`` / ``--force-general``
+    are the documented per-post escapes for the colleague-MR shape, the
+    TODO-anchor, and the multi-finding general-note (#72) gates
+    respectively (#126), mirroring the sibling override flags. A general
+    note referencing 2+ distinct ``file:line`` locations (or a numbered
+    per-file finding list) is refused by default — post each one inline
+    instead, or pass ``--force-general`` for a genuinely MR-wide note.
     """
     from teatree.cli.review.body_source import PostBodyError, resolve_post_body  # noqa: PLC0415
 
@@ -221,6 +243,7 @@ def post_comment(  # noqa: PLR0913 — typer command: every param is a CLI flag 
         evidence=evidence,
         allow_long_review=allow_long_review,
         allow_todo_blocker=allow_todo_blocker,
+        force_general=force_general,
     )
     typer.echo(msg)
     if code:

--- a/src/teatree/cli/review/general_inline_gate.py
+++ b/src/teatree/cli/review/general_inline_gate.py
@@ -1,0 +1,142 @@
+"""General-note carrying inline findings gate (souliane/teatree#72, round 2).
+
+The #72 fix (:func:`teatree.cli.review.drafts.validate_inline_or_general`)
+closed the *half-specified* foot-gun: a ``post-draft-note`` that named a
+``--file`` without a ``--line`` (or vice versa) used to silently degrade
+into a general (MR-wide) note. That validator stops the degradation at the
+typer-wrapper boundary.
+
+This module closes the *other half* of the same discipline, observed on
+!6281: under time pressure a reviewer crammed two distinct per-line
+findings into ONE general note instead of posting each one inline. The
+#72 validator never fired (the call WAS a deliberate ``--general`` post),
+so the multi-finding general note went through.
+
+The gate runs only on the **general** path of a publishing method (no
+``file``+``line`` anchor) and refuses the post — before any GitLab call —
+when the body looks like a multi-point per-line review, i.e. it either:
+
+* references **2+ distinct ``path.ext:line`` locations** (a concrete
+    file:line cite for each finding), OR
+* reads as a **numbered finding list where 2+ items each name a file**
+    (``1. foo.py: ...`` / ``2. bar.ts:14 ...``).
+
+Both shapes say "these are N inline findings". The remediation steers the
+agent to post each one inline with
+``t3 review post-draft-note <repo> <mr> "<note>" --file <path> --line <n>``
+(one per finding), and offers the documented per-call escape
+``--force-general`` for a genuinely MR-wide note (a verdict-only summary
+with no per-line findings) — mirroring the sibling ``--allow-long-review``
+/ ``--allow-todo-blocker`` overrides on the same flow.
+
+Sibling gates on the same ``_run_pre_publish_gates`` chain:
+
+* :mod:`teatree.cli.review.shape_gate` — colleague-MR prose-size cap.
+* :mod:`teatree.cli.review.todo_gate` — author-marked TODO anchor.
+
+This gate is independent of both. It is forge-neutral: it inspects only
+the comment body and the inline-anchor flag, never the network.
+"""
+
+import re
+
+# A ``path.ext:line`` location cite: a dotted file path (so a bare ``foo``
+# or a sentence word does not match — the ``.ext`` is required) followed by
+# ``:<digits>``. The path segment allows directory separators, dashes,
+# underscores, and dots (``a/b-c_d.py``); the extension is 1-8 letters so
+# ``module.py:10`` matches but ``ratio 3:2`` or ``12:30`` (a time) does not.
+_FILE_LINE_RE = re.compile(
+    r"\b[\w./-]+\.[A-Za-z]{1,8}:\d+\b",
+)
+
+# A numbered-list item that names a file: ``1. foo.py`` / ``2) bar/baz.ts``.
+# The leading marker is ``<digits>`` followed by ``.`` or ``)`` at a line
+# start (optionally indented); the item text must contain a dotted file
+# path token somewhere on that line.
+_NUMBERED_ITEM_RE = re.compile(
+    r"^\s*\d+[.)]\s+.*\b[\w./-]+\.[A-Za-z]{1,8}\b",
+    re.MULTILINE,
+)
+
+MIN_DISTINCT_FINDINGS = 2
+
+
+def _distinct_file_line_cites(body: str) -> set[str]:
+    """Return the set of distinct ``path.ext:line`` location cites in ``body``.
+
+    Distinct-by-text: ``foo.py:10`` and ``foo.py:10`` collapse to one, but
+    ``foo.py:10`` and ``foo.py:42`` (two findings in the same file) and
+    ``foo.py:10`` and ``bar.ts:3`` (two files) each count as two — the
+    multi-finding signal is "more than one place the reviewer is pointing
+    at", whether same file or not.
+    """
+    return {m.group(0) for m in _FILE_LINE_RE.finditer(body)}
+
+
+def _numbered_file_items(body: str) -> int:
+    """Count numbered-list items (``1.`` / ``2)``) that each name a file.
+
+    A numbered list where each item cites a file is the other shape of a
+    multi-point per-line review even when the items omit explicit line
+    numbers (``1. foo.py: rename …`` / ``2. bar.py: guard …``).
+    """
+    return sum(1 for _ in _NUMBERED_ITEM_RE.finditer(body))
+
+
+def looks_like_inline_findings(body: str) -> bool:
+    """Whether ``body`` reads as 2+ inline findings crammed into one note.
+
+    True when EITHER the body references
+    :data:`MIN_DISTINCT_FINDINGS`+ distinct ``path.ext:line`` locations OR
+    a numbered finding list has :data:`MIN_DISTINCT_FINDINGS`+ items that
+    each name a file. Both are the "this should have been N inline notes"
+    shape (!6281).
+    """
+    if not body:
+        return False
+    if len(_distinct_file_line_cites(body)) >= MIN_DISTINCT_FINDINGS:
+        return True
+    return _numbered_file_items(body) >= MIN_DISTINCT_FINDINGS
+
+
+def check_general_inline_findings(*, body: str, inline: bool, force_general: bool = False) -> str:
+    """Return a non-empty refusal when a GENERAL note carries multiple inline findings.
+
+    Returns ``""`` (proceed) when any of these hold:
+
+    * ``force_general`` is set — the documented per-call escape for a
+        genuinely MR-wide note (verdict-only, no per-line findings),
+        surfaced on the CLI as ``--force-general`` and mirroring the
+        sibling ``--allow-long-review`` / ``--allow-todo-blocker`` overrides.
+    * ``inline`` is true — the post IS being anchored inline
+        (``--file``/``--line`` supplied), so it is not the general-note
+        cramming this gate targets. The #72 validator already governs the
+        inline-vs-general split.
+    * ``body`` does not look like 2+ inline findings.
+
+    Otherwise returns a clear refusal naming the finding count and the
+    inline per-finding command the agent should use instead. The caller
+    short-circuits the GitLab API call with ``(message, 1)`` — the same
+    shape the sibling gates use.
+    """
+    if force_general or inline:
+        return ""
+    if not looks_like_inline_findings(body):
+        return ""
+    cites = _distinct_file_line_cites(body)
+    numbered = _numbered_file_items(body)
+    count = max(len(cites), numbered)
+    return _refusal(count)
+
+
+def _refusal(count: int) -> str:
+    """Build the actionable refusal naming the finding count and the inline command."""
+    return (
+        f"Refusing general note: this looks like {count} inline findings (it references "
+        f"{count}+ distinct file:line locations or a numbered per-file finding list). "
+        "Post them INLINE — one per finding — with:\n"
+        '  t3 review post-draft-note <repo> <mr> "<note>" --file <path> --line <n>\n'
+        "Cramming distinct per-line findings into one general note is the !6281 shape "
+        "the #72 discipline guards against. Pass --force-general to override ONLY for a "
+        "genuinely MR-wide note (a verdict-only summary with no per-line findings)."
+    )

--- a/src/teatree/cli/review/service.py
+++ b/src/teatree/cli/review/service.py
@@ -36,6 +36,7 @@ from teatree.cli.review.approval import identity_has_reviewed
 from teatree.cli.review.diff import find_added_line, resolve_inline_position
 from teatree.cli.review.drafts import register as _register_drafts
 from teatree.cli.review.evidence_gate import FindingEvidence, check_finding_evidence
+from teatree.cli.review.general_inline_gate import check_general_inline_findings
 from teatree.cli.review.on_behalf import (
     check_on_behalf,
     check_on_behalf_issue,
@@ -178,6 +179,7 @@ class ReviewService:
         evidence: FindingEvidence | None = None,
         allow_long_review: bool = False,
         allow_todo_blocker: bool = False,
+        force_general: bool = False,
     ) -> tuple[str, int]:
         """Post a draft note. Returns (message, exit_code).
 
@@ -193,10 +195,10 @@ class ReviewService:
         to AUTO_DRAFT (publish + DM the user the publish/delete commands);
         under IMMEDIATE it publishes with no DM. The remaining pre-publish
         gates in :meth:`_run_pre_publish_gates` still apply: colleague-MR
-        shape (#1114), TODO-anchor (#1186), and structured-evidence (#1280,
-        requires ``evidence`` on ``missing/wrong/broken`` finding bodies).
-        ``allow_long_review`` / ``allow_todo_blocker`` are the documented
-        per-call escapes for the shape and TODO-anchor gates (#126).
+        shape (#1114), multi-finding general-note (#72), TODO-anchor
+        (#1186), and structured-evidence (#1280). ``allow_long_review`` /
+        ``allow_todo_blocker`` / ``force_general`` are the #126 per-call
+        escapes for the shape, TODO-anchor, and general-note gates.
         """
         refusal = self._run_pre_publish_gates(
             repo=repo,
@@ -208,6 +210,7 @@ class ReviewService:
             evidence=evidence,
             allow_long_review=allow_long_review,
             allow_todo_blocker=allow_todo_blocker,
+            force_general=force_general,
         )
         if refusal:
             return refusal, 1
@@ -228,29 +231,30 @@ class ReviewService:
         evidence: FindingEvidence | None,
         allow_long_review: bool = False,
         allow_todo_blocker: bool = False,
+        force_general: bool = False,
     ) -> str:
-        """Run on-behalf (#960) → shape (#1114) → TODO-anchor (#1186) → evidence (#1280); first refusal or ``""``.
+        """Run the pre-publish gate chain; return the first refusal or ``""``.
 
-        ``allow_long_review`` / ``allow_todo_blocker`` are the #126 documented
-        escapes: each lets exactly one sibling gate proceed for a
-        legitimately-authorized action. They never relax the on-behalf or
-        evidence gates.
+        Order: on-behalf (#960) → shape (#1114) → general-inline (#72) →
+        TODO-anchor (#1186) → evidence (#1280). ``allow_long_review`` /
+        ``allow_todo_blocker`` / ``force_general`` are the #126 per-call
+        escapes for the shape, TODO-anchor, and multi-finding general-note
+        gates respectively; none relaxes the on-behalf or evidence gates.
         """
         blocked = check_on_behalf(repo, mr, action)
         if blocked:
             return blocked
         encoded = repo.replace("/", "%2F")
         api = self._get_api()
+        inline = bool(file and line)
         shape_error = check_review_shape(
-            api=api,
-            encoded_repo=encoded,
-            mr=mr,
-            body=note,
-            inline=bool(file and line),
-            allow_long_review=allow_long_review,
+            api=api, encoded_repo=encoded, mr=mr, body=note, inline=inline, allow_long_review=allow_long_review
         )
         if shape_error:
             return shape_error
+        general_inline_error = check_general_inline_findings(body=note, inline=inline, force_general=force_general)
+        if general_inline_error:
+            return general_inline_error
         todo_error = check_todo_anchor(
             api=api,
             encoded_repo=encoded,
@@ -282,6 +286,7 @@ class ReviewService:
         evidence: FindingEvidence | None = None,
         allow_long_review: bool = False,
         allow_todo_blocker: bool = False,
+        force_general: bool = False,
     ) -> tuple[str, int]:
         """Post an MR comment — DRAFT by default; ``--live`` needs a Slack-recorded LivePostApproval (#1207).
 
@@ -297,9 +302,9 @@ class ReviewService:
         ``evidence`` kwarg must carry a verified
         :class:`~teatree.cli.review.evidence_gate.FindingEvidence` record.
 
-        ``allow_long_review`` / ``allow_todo_blocker`` are the #126
-        documented per-call escapes for the colleague-MR shape and the
-        TODO-anchor gates respectively.
+        ``allow_long_review`` / ``allow_todo_blocker`` / ``force_general``
+        are the #126 per-call escapes for the colleague-MR shape, the
+        TODO-anchor, and the multi-finding general-note (#72) gates.
         """
         from teatree.cli.review.authorize import resolve_live_authorization  # noqa: PLC0415
         from teatree.cli.review.default_draft import check_live_post, notify_draft_created  # noqa: PLC0415
@@ -314,6 +319,7 @@ class ReviewService:
                 evidence=evidence,
                 allow_long_review=allow_long_review,
                 allow_todo_blocker=allow_todo_blocker,
+                force_general=force_general,
             )
             if code == 0:
                 notify_draft_created(repo=repo, mr=mr, body=note, message=msg)
@@ -335,6 +341,7 @@ class ReviewService:
             evidence=evidence,
             allow_long_review=allow_long_review,
             allow_todo_blocker=allow_todo_blocker,
+            force_general=force_general,
         )
         if refusal:
             return refusal, 1

--- a/tests/teatree_cli/test_review_general_inline_gate.py
+++ b/tests/teatree_cli/test_review_general_inline_gate.py
@@ -1,0 +1,336 @@
+"""Multi-finding general-note gate (souliane/teatree#72, round 2).
+
+The #72 fix stopped a half-specified inline (``--file`` without ``--line``)
+from silently degrading into a general note. This gate closes the other
+half observed on !6281: a deliberate ``--general`` note that crams 2+
+distinct per-line findings into one MR-wide note instead of posting each
+inline.
+
+The gate runs only on the general (non-inline) path and refuses before any
+GitLab call when the body references 2+ distinct ``path.ext:line`` locations
+OR a numbered per-file finding list. ``--force-general`` is the documented
+escape for a genuinely MR-wide (verdict-only) note. Inline posts are
+unaffected.
+
+Every service-level test pins the on-behalf gate to IMMEDIATE and the
+shape gate to a colleague-agnostic pass so any blocking is attributable to
+the gate under test.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from teatree.cli import app
+from teatree.cli.review import ReviewService
+from teatree.cli.review.general_inline_gate import check_general_inline_findings, looks_like_inline_findings
+from teatree.config import OnBehalfPostMode
+from teatree.core.models import ConfigSetting
+
+# ast-grep-ignore: ac-django-no-pytest-django-db
+pytestmark = pytest.mark.django_db
+
+_AUTHOR_ALICE = "alice"
+
+
+def _gate_immediate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the on-behalf gate to IMMEDIATE so it does NOT also block the call.
+
+    Mirrors the sibling ``test_review_shape_gate`` helper: the gate under
+    test is independent of the on-behalf gate, so IMMEDIATE keeps the latter
+    silent. ``on_behalf_post_mode`` is DB-home (#1775); an empty config file
+    keeps the active-config path pinned to ``tmp_path``.
+    """
+    cfg = tmp_path / ".teatree.toml"
+    cfg.write_text("[teatree]\n", encoding="utf-8")
+    monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
+    ConfigSetting.objects.set_value("on_behalf_post_mode", OnBehalfPostMode.IMMEDIATE.value)
+
+
+class _StubAPI:
+    """In-memory stand-in for ``GitLabAPI`` — records every network call."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, Any]] = []
+
+    def post_json(self, endpoint: str, payload: object) -> dict[str, object]:
+        self.calls.append(("post_json", endpoint, payload))
+        return {"id": 1, "notes": [{"type": "DiffNote"}], "line_code": "abc123_10_10"}
+
+    def get_json(self, endpoint: str) -> object:
+        self.calls.append(("get_json", endpoint, None))
+        return {}
+
+    def delete(self, endpoint: str) -> int:
+        self.calls.append(("delete", endpoint, None))
+        return 204
+
+    def current_username(self) -> str:
+        return _AUTHOR_ALICE
+
+
+def _service_with_stub() -> tuple[ReviewService, _StubAPI]:
+    """Build a ReviewService backed by the recording stub API."""
+    service = ReviewService(token="t")
+    stub = _StubAPI()
+    service._get_api = lambda: stub  # type: ignore[method-assign]
+    return service, stub
+
+
+class TestGeneralNoteMultiFindingGate:
+    """A general note carrying 2+ inline findings is refused before any POST.
+
+    Every test pins the on-behalf gate to IMMEDIATE and the shape gate's
+    MR-author lookup to the current identity (own MR) so the shape gate is
+    a no-op and any blocking is attributable to this gate.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _ctx(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _gate_immediate(tmp_path, monkeypatch)
+        self.monkeypatch = monkeypatch
+        # Own-MR → shape gate is a no-op; isolates this gate.
+        from teatree.cli.review import shape_gate as shape_mod  # noqa: PLC0415
+
+        monkeypatch.setattr(shape_mod, "fetch_mr_author", lambda api, encoded_repo, mr: _AUTHOR_ALICE)
+
+    def test_general_note_with_two_file_line_cites_is_refused(self) -> None:
+        """RED → GREEN: a general note citing 2 distinct file:line locations is refused.
+
+        The !6281 shape: two distinct per-line findings crammed into one
+        MR-wide note. The gate must refuse before any GitLab POST and steer
+        to per-finding inline posts.
+        """
+        service, stub = _service_with_stub()
+        body = (
+            "Two issues found:\n"
+            "- handlers/auth.py:42 swallows the exception silently.\n"
+            "- models/user.py:118 leaks the password hash in __repr__."
+        )
+
+        msg, code = service.post_comment("org/repo", 7, body)
+
+        assert code == 1, f"expected refuse, got code={code} msg={msg!r}"
+        assert "inline findings" in msg, f"steering must name the inline-findings shape: {msg!r}"
+        assert "--file" in msg, f"steering must point at the inline command: {msg!r}"
+        assert "--line" in msg, f"steering must point at the inline command: {msg!r}"
+        assert "--force-general" in msg, f"steering must name the override: {msg!r}"
+        assert stub.calls == [], "gate must block BEFORE any GitLab POST"
+
+    def test_general_note_with_numbered_per_file_list_is_refused(self) -> None:
+        """A numbered finding list where each item names a file is refused.
+
+        The line-number-less variant of the multi-finding shape: a numbered
+        list (``1. foo.py …`` / ``2. bar.py …``) is still N inline findings.
+        """
+        service, stub = _service_with_stub()
+        body = (
+            "1. cli/run.py: the retry loop never resets the backoff.\n"
+            "2. core/models.py: the on_commit hook fires before the save commits."
+        )
+
+        msg, code = service.post_comment("org/repo", 7, body)
+
+        assert code == 1, f"expected refuse, got code={code} msg={msg!r}"
+        assert "inline findings" in msg
+        assert stub.calls == [], "gate must block BEFORE any GitLab POST"
+
+    def test_verdict_only_general_note_is_allowed(self) -> None:
+        """A genuinely MR-wide verdict-only note (no per-line findings) passes.
+
+        The control: an MR-wide summary with no concrete file:line cite and
+        no numbered per-file list must NOT be caught — the gate is precise,
+        not a blanket ban on general notes.
+        """
+        service, stub = _service_with_stub()
+        body = "LGTM overall — the approach is sound and the tests cover the new path. Approving."
+
+        msg, code = service.post_comment("org/repo", 7, body)
+
+        assert code == 0, f"verdict-only general note must pass: code={code} msg={msg!r}"
+        assert any(c[0] == "post_json" for c in stub.calls), "API POST must fire on an accepted general note"
+
+    def test_single_file_line_cite_general_note_is_allowed(self) -> None:
+        """A general note with a SINGLE file:line cite passes (1 finding, not multi).
+
+        One cited location is a single finding — legitimately a one-line
+        MR-wide note. The gate fires only at 2+ distinct locations.
+        """
+        service, stub = _service_with_stub()
+        body = "The regression is at handlers/auth.py:42 — the except clause swallows it."
+
+        msg, code = service.post_comment("org/repo", 7, body)
+
+        assert code == 0, f"single-cite general note must pass: code={code} msg={msg!r}"
+        assert any(c[0] == "post_json" for c in stub.calls)
+
+    def test_force_general_overrides_the_refusal(self) -> None:
+        """``force_general=True`` lets the 2+ file:line general note proceed.
+
+        The documented escape: a reviewer who genuinely wants the multi-cite
+        body as one MR-wide note passes ``--force-general`` and the post
+        proceeds, mirroring the sibling ``--allow-long-review`` override.
+        """
+        service, stub = _service_with_stub()
+        body = "- handlers/auth.py:42 issue one.\n- models/user.py:118 issue two."
+
+        msg, code = service.post_comment("org/repo", 7, body, force_general=True)
+
+        assert code == 0, f"override must let the post proceed: code={code} msg={msg!r}"
+        assert any(c[0] == "post_json" for c in stub.calls), "API POST must fire when --force-general is set"
+
+    def test_inline_post_with_multi_cite_body_is_unaffected(self) -> None:
+        """An inline (``file``+``line``) post is NOT subject to this gate.
+
+        Even if an inline body happens to mention 2+ file:line locations
+        (e.g. "this duplicates the logic at other.py:10 and other.py:20"),
+        the post IS being anchored inline, so the #72-round-2 general gate
+        does not fire — the post proceeds to the inline path.
+        """
+        service, stub = _service_with_stub()
+        from teatree.cli.review import service as review_mod  # noqa: PLC0415
+
+        self.monkeypatch.setattr(
+            review_mod,
+            "resolve_inline_position",
+            lambda api, encoded, mr, file, line: ({"new_path": file, "new_line": line}, ""),
+        )
+        body = "Duplicates the logic at other.py:10 and other.py:20 — extract a helper."
+
+        msg, code = service.post_comment("org/repo", 7, body, file="x.py", line=10)
+
+        assert code == 0, f"inline post must be unaffected: code={code} msg={msg!r}"
+        assert any(c[0] == "post_json" for c in stub.calls)
+
+    def test_post_draft_note_general_with_multi_cite_is_refused(self) -> None:
+        """The gate also fires on ``post_draft_note`` (the #72 sibling path).
+
+        ``post-draft-note --general`` is the path the #72 validator governs
+        for the inline-vs-general split; this gate adds the multi-finding
+        refusal on the same general path.
+        """
+        service, stub = _service_with_stub()
+        body = "- a.py:1 finding one.\n- b.py:2 finding two."
+
+        msg, code = service.post_draft_note("org/repo", 7, body)
+
+        assert code == 1, f"expected refuse on post_draft_note general: code={code} msg={msg!r}"
+        assert "inline findings" in msg
+        assert stub.calls == [], "gate must block BEFORE any GitLab POST"
+
+
+class TestGeneralInlineGateUnit:
+    """Direct unit coverage of the pure gate functions (no DB, no API)."""
+
+    def test_force_general_short_circuits_to_proceed(self) -> None:
+        """The override returns ``""`` (proceed) regardless of body shape."""
+        body = "- a.py:1 one.\n- b.py:2 two."
+        assert check_general_inline_findings(body=body, inline=False, force_general=True) == ""
+
+    def test_inline_flag_short_circuits_to_proceed(self) -> None:
+        """An inline post short-circuits to proceed — this gate is general-only."""
+        body = "- a.py:1 one.\n- b.py:2 two."
+        assert check_general_inline_findings(body=body, inline=True) == ""
+
+    def test_empty_body_proceeds(self) -> None:
+        """An empty body is not a multi-finding note — proceed."""
+        assert check_general_inline_findings(body="", inline=False) == ""
+        assert looks_like_inline_findings("") is False
+
+    def test_two_distinct_file_line_cites_detected(self) -> None:
+        """2 distinct file:line cites trip the detector."""
+        assert looks_like_inline_findings("see a.py:10 and b.ts:3") is True
+
+    def test_same_file_two_lines_counts_as_two(self) -> None:
+        """Two findings in the SAME file (different lines) count as two."""
+        assert looks_like_inline_findings("a.py:10 and also a.py:42") is True
+
+    def test_single_cite_is_not_multi(self) -> None:
+        """A single file:line cite is one finding — not multi."""
+        assert looks_like_inline_findings("only a.py:10 here") is False
+
+    def test_duplicate_cite_collapses_to_one(self) -> None:
+        """The same cite repeated is distinct-by-text → one location, not two."""
+        assert looks_like_inline_findings("a.py:10 ... and again a.py:10") is False
+
+    def test_time_and_ratio_do_not_false_positive(self) -> None:
+        """``12:30`` (a time) and ``3:2`` (a ratio) are not file:line cites.
+
+        The detector requires a dotted ``path.ext`` before the ``:line``,
+        so bare ``number:number`` tokens do not register as findings.
+        """
+        assert looks_like_inline_findings("meeting at 12:30 and a 3:2 ratio") is False
+
+    def test_numbered_list_two_files_detected(self) -> None:
+        """A 2-item numbered list each naming a file (no line numbers) trips it."""
+        body = "1. foo.py rename the helper.\n2. bar.ts guard the null."
+        assert looks_like_inline_findings(body) is True
+
+    def test_numbered_list_one_file_is_not_multi(self) -> None:
+        """A single numbered item naming a file is one finding — not multi."""
+        body = "1. foo.py rename the helper."
+        assert looks_like_inline_findings(body) is False
+
+    def test_paren_numbered_markers_detected(self) -> None:
+        """``1)`` / ``2)`` paren-style numbered markers also count."""
+        body = "1) a.py do this.\n2) b.py do that."
+        assert looks_like_inline_findings(body) is True
+
+
+_runner = CliRunner()
+
+
+class TestForceGeneralReachesGateViaCLI:
+    """The ``--force-general`` flag is plumbed through the typer commands.
+
+    Drives the full ``t3 review post-comment`` / ``post-draft-note`` typer
+    surface (not just the service method) so a regression that drops the
+    flag from the CLI wiring turns this red. The GitLab token + API are
+    stubbed so the command runs end to end without network.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _ctx(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _gate_immediate(tmp_path, monkeypatch)
+        self.stub = _StubAPI()
+        monkeypatch.setattr(ReviewService, "get_gitlab_token", staticmethod(lambda: "t"))
+        monkeypatch.setattr(ReviewService, "_get_api", lambda _self: self.stub)
+        # Own MR → shape gate no-op; isolates this gate end to end.
+        from teatree.cli.review import shape_gate as shape_mod  # noqa: PLC0415
+
+        monkeypatch.setattr(shape_mod, "fetch_mr_author", lambda api, encoded_repo, mr: _AUTHOR_ALICE)
+        # The default-draft path DMs the user on success — stub the notify
+        # transport so the CLI invocation does not touch a real backend.
+        monkeypatch.setattr(
+            "teatree.cli.review.default_draft.notify_draft_created",
+            lambda **_kwargs: None,
+        )
+
+    # Two findings naming distinct files, fed via -m/--body so the body
+    # (which would naturally start with a list marker) is not parsed as an
+    # option by typer. The shape is the multi-cite signal regardless.
+    _MULTI = "first at a.py:1 finding one; second at b.py:2 finding two."
+
+    def test_post_comment_general_multi_cite_refused_via_cli(self) -> None:
+        """``post-comment`` with a 2-cite general body is refused at the CLI."""
+        result = _runner.invoke(app, ["review", "post-comment", "org/repo", "7", "-m", self._MULTI])
+        assert result.exit_code == 1, result.output
+        assert "inline findings" in result.output
+        assert self.stub.calls == [], "gate must block BEFORE any GitLab POST"
+
+    def test_post_comment_force_general_proceeds_via_cli(self) -> None:
+        """``--force-general`` on ``post-comment`` lets the multi-cite note proceed."""
+        result = _runner.invoke(app, ["review", "post-comment", "org/repo", "7", "-m", self._MULTI, "--force-general"])
+        assert result.exit_code == 0, result.output
+        assert any(c[0] == "post_json" for c in self.stub.calls), "POST must fire with --force-general"
+
+    def test_post_draft_note_force_general_proceeds_via_cli(self) -> None:
+        """``--force-general`` on ``post-draft-note --general`` lets the multi-cite note proceed."""
+        result = _runner.invoke(
+            app,
+            ["review", "post-draft-note", "org/repo", "7", self._MULTI, "--general", "--force-general"],
+        )
+        assert result.exit_code == 0, result.output
+        assert any(c[0] == "post_json" for c in self.stub.calls), "POST must fire with --force-general"


### PR DESCRIPTION
## Summary

Closes the other half of the #72 inline-vs-general discipline. The original #72 fix (`validate_inline_or_general`) stopped a **half-specified** inline (`--file` without `--line`) from silently degrading into a general note. This adds the mirror guard observed on !6281: a **deliberate** `--general` note that crams 2+ distinct per-line findings into one MR-wide note instead of posting each one inline.

## What it does

A new sibling gate, `teatree.cli.review.general_inline_gate.check_general_inline_findings`, runs on the **general** (non-inline) path of `_run_pre_publish_gates` — the same chain the `shape_gate` (#1114), `todo_gate` (#1186), and evidence gate (#1280) run in. It refuses **before any GitLab call** when the body looks like a multi-point per-line review, i.e. it either:

- references **2+ distinct `path.ext:line` locations** (a concrete file:line cite per finding), OR
- reads as a **numbered finding list where 2+ items each name a file** (`1. foo.py: …` / `2. bar.ts:14 …`).

The detector is non-fuzzy: the `path.ext:line` regex requires a dotted file path before the `:line`, so `12:30` (a time) and `3:2` (a ratio) do not register; distinct-by-text de-dup means the same cite repeated counts once, while two findings in the same file (different lines) count as two. The steering message names the finding count and points at the per-finding inline command:

```
t3 review post-draft-note <repo> <mr> "<note>" --file <path> --line <n>
```

The #72 validator behaviour is unchanged. Inline posts (`--file`/`--line` supplied) are unaffected — they short-circuit the gate, since the #72 validator already governs the inline-vs-general split there.

## Configuration

No new settings, models, endpoints, or migrations. The change adds **one per-call CLI flag**, consistent with the existing per-call escapes on the same flow (`--allow-long-review` #1114, `--allow-todo-blocker` #1186):

- **`--force-general`** on `t3 review post-comment` and `t3 review post-draft-note` — the documented over-deny escape (#126). The multi-finding general-note gate refuses by default; pass `--force-general` **only** for a genuinely MR-wide note (a verdict-only summary with no per-line findings). It threads through `ReviewService.post_comment(..., force_general=...)` and `post_draft_note(..., force_general=...)` into `_run_pre_publish_gates`.

The gate has **no environment variable and no config-setting knob** — it is a structural pre-publish guard, on by default, escaped per-call like its siblings.

## Architecture pre-check — #72 (round 2)

1. **BLUEPRINT § alignment** — review-CLI pre-publish gate chain; sibling of `shape_gate` (#1114), `todo_gate` (#1186), evidence gate (#1280). No architectural element added (no model/endpoint/command), so no BLUEPRINT change — same as the sibling gates, which are self-documenting in code.
2. **FSM phase boundaries** — n/a, no `Ticket.State`/`Worktree.State` transition.
3. **Extension-point contracts** — n/a, no `OverlayBase`/scanner/Protocol change.
4. **Component boundaries** — new gate in `src/teatree/cli/review/general_inline_gate.py` (pure functions, mirrors the sibling gate modules); service wiring in `service.py`; CLI flag in `commands.py`.
5. **Dependency direction** — single new intra-package import (`service.py` → `general_inline_gate`); `uv run tach check` ✅ All modules validated.
6. **Test surface** — `tests/teatree_cli/test_review_general_inline_gate.py`: 2-cite general refused; numbered per-file list refused; verdict-only general allowed; single-cite general allowed; `--force-general` overrides; inline post unaffected; both `post_comment` and `post_draft_note` paths; full unit coverage of the detector (time/ratio non-false-positive, dup-collapse, paren markers); CLI-level `--force-general` plumbing via `CliRunner`.
7. **Resilience invariants** — refuse-before-write gate, no external write introduced; pure idempotent function.
8. **Identity/key normalization** — n/a.
9. **Behavior preservation** — purely additive; the #72 validator is untouched; no privacy/security matcher narrowed; no must-block test inverted.

## Test evidence

RED→GREEN was verified anti-vacuously: with the gate call neutralized in `_run_pre_publish_gates`, exactly the 4 refusal tests (3 service-level + 1 CLI) go red while the 17 allow-path / override / inline-unaffected / unit tests stay green; restoring the gate turns all green.

```
tests/teatree_cli/test_review_general_inline_gate.py … 21 passed
src/teatree/cli/review/general_inline_gate.py  25 stmts  0 miss  100.0% coverage
uv run pytest tests/teatree_cli/  → 966 passed, 2 xfailed
uv run ruff check / format        → clean
uv run tach check                 → All modules validated
```
