### PR TITLE
fix(hooks): scan only the staged diff in the banned-terms commit gate (#1415)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -173,7 +173,7 @@ repos:
       - id: banned-terms
         name: banned-terms
         language: script
-        entry: scripts/hooks/check-banned-terms.sh --config ~/.teatree.toml
+        entry: scripts/hooks/check-banned-terms.sh --diff-only --config ~/.teatree.toml
         types: [text]
         exclude: |
           (?x)^(

--- a/skills/workspace/references/scripts-and-functions.md
+++ b/skills/workspace/references/scripts-and-functions.md
@@ -100,6 +100,6 @@ Scripts that are not part of the CLI — run directly:
 
 These run via `prek`, not via the CLI:
 
-- `check-banned-terms.sh` — reject banned terms in public repos
+- `check-banned-terms.sh` — reject banned terms. The pre-commit entry passes `--diff-only`, so it scans only the staged diff's ADDED lines per file (a pre-existing committed banned term no longer blocks an unrelated commit; a newly-added one still does). Without the flag (the posting gate's body scan, the parity test) it scans the whole file.
 - `check_skill_versions.py` — sync SKILL.md versions with pyproject.toml
 - `update_readme_skills.py` — regenerate skill index in README

--- a/src/teatree/hooks/banned_terms_cli.py
+++ b/src/teatree/hooks/banned_terms_cli.py
@@ -24,6 +24,16 @@ Usage mirrors the old shell behaviour exactly::
 The TOML term list is read from the first section carrying a ``banned_terms``
 array (matching the old shell extractor), and the email carve-out lives in
 ``term_match`` so it, too, is shared rather than duplicated.
+
+``--diff-only`` scopes the scan to the staged DIFF's ADDED lines per file (the
+pre-commit hook entry passes it). Without it, the whole file is scanned — the
+mode the posting gate (``banned_terms_scanner`` writes the body to a temp file
+and scans it whole) and the parity meta-test rely on. The diff-only mode fixes
+the #1415 over-block: staging a one-line edit to a file that ALREADY carries a
+committed banned term used to block the commit on the untouched committed line.
+The pre-push public-leak gate (``refuse-public-push-with-leak.sh``) re-scans
+commit messages before they reach a public remote, so a pre-existing committed
+term is still caught before it leaves the machine.
 """
 
 import argparse
@@ -31,7 +41,14 @@ import sys
 import tomllib
 from pathlib import Path
 
-from teatree.hooks.term_match import file_matches
+from teatree.hooks.term_match import file_matches as _file_matches
+from teatree.hooks.term_match import line_matches, strip_emails
+from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to_fail
+
+# How long to wait for ``git diff`` before treating the staged diff as
+# unresolvable and falling back to a full-file scan. A hook that hangs blocks
+# the commit, so the budget is deliberately tight.
+_GIT_DIFF_TIMEOUT_S = 10
 
 
 def _load_terms(config: Path) -> tuple[str, ...]:
@@ -52,9 +69,83 @@ def _load_terms(config: Path) -> tuple[str, ...]:
     return ()
 
 
+def staged_added_lines(repo: Path, file: str) -> list[str] | None:
+    """Return *file*'s ADDED lines from the staged diff, or ``None`` on failure.
+
+    Runs ``git diff --cached -U0 --diff-filter=ACMR -- <file>`` from *repo* and
+    keeps the body of each ``+`` line (dropping the ``+++`` file header; ``-U0``
+    emits no context lines). An EMPTY list means the file has no staged
+    additions; ``None`` is the distinct sentinel for "could not resolve the
+    staged diff" (not a git repo, git missing, a non-zero exit, a timeout) so
+    the caller can fall back to a full-file scan and NEVER fail open on a
+    security gate.
+    """
+    try:
+        result = run_allowed_to_fail(
+            ["git", "diff", "--cached", "-U0", "--diff-filter=ACMR", "--", file],
+            expected_codes=(0,),
+            cwd=repo,
+            timeout=_GIT_DIFF_TIMEOUT_S,
+        )
+    except (CommandFailedError, TimeoutExpired, OSError):
+        return None
+    return [line[1:] for line in result.stdout.splitlines() if line.startswith("+") and not line.startswith("+++")]
+
+
+def _diff_only_report(files: list[str], terms: tuple[str, ...], repo: Path) -> list[str]:
+    """Build the BANNED TERM report scanning only each file's staged ADDED lines.
+
+    When the staged diff cannot be resolved for a file (``staged_added_lines``
+    returns ``None``), fall back to that file's FULL-file scan — failing closed,
+    never open. The added-line scan applies the same per-line email carve-out
+    and whole-token matcher (:mod:`teatree.hooks.term_match`) the full scan uses,
+    so the two paths agree on every line they both see.
+    """
+    report: list[str] = []
+    for file in files:
+        path = Path(file)
+        added = staged_added_lines(repo, file)
+        if added is None:
+            if not path.is_file():
+                continue
+            hits = _file_matches(str(path), terms)
+            if not hits:
+                continue
+            report.append(f"BANNED TERM in {file}:")
+            report.extend(f"  {line_number}:{line}" for line_number, _term, line in hits)
+            continue
+        flagged = [line for line in added if line_matches(strip_emails(line), terms)]
+        if not flagged:
+            continue
+        report.append(f"BANNED TERM in {file}:")
+        report.extend(f"  +:{line}" for line in flagged)
+    return report
+
+
+def _full_file_report(files: list[str], terms: tuple[str, ...]) -> list[str]:
+    """Build the BANNED TERM report scanning each staged file in full."""
+    report: list[str] = []
+    for file in files:
+        path = Path(file)
+        if not path.is_file():
+            continue
+        hits = _file_matches(str(path), terms)
+        if not hits:
+            continue
+        report.append(f"BANNED TERM in {file}:")
+        report.extend(f"  {line_number}:{line}" for line_number, _term, line in hits)
+    return report
+
+
 def main(argv: list[str]) -> int:  # pragma: no cover — CLI entry point (orchestrates tested helpers)
     parser = argparse.ArgumentParser(description="Reject files containing banned terms.")
     parser.add_argument("--config", required=True, help="TOML file with a banned_terms array.")
+    parser.add_argument(
+        "--diff-only",
+        action="store_true",
+        help="Scan only the staged diff's added lines per file (pre-commit hook mode), "
+        "so a pre-existing committed banned term does not block an unrelated commit.",
+    )
     parser.add_argument("files", nargs="*", help="Files to scan.")
     args = parser.parse_args(argv)
 
@@ -65,16 +156,10 @@ def main(argv: list[str]) -> int:  # pragma: no cover — CLI entry point (orche
     if not terms:
         return 0  # no terms ⇒ no-op
 
-    report: list[str] = []
-    for file in args.files:
-        path = Path(file)
-        if not path.is_file():
-            continue
-        hits = file_matches(str(path), terms)
-        if not hits:
-            continue
-        report.append(f"BANNED TERM in {file}:")
-        report.extend(f"  {line_number}:{line}" for line_number, _term, line in hits)
+    if args.diff_only:
+        report = _diff_only_report(args.files, terms, Path.cwd())
+    else:
+        report = _full_file_report(args.files, terms)
 
     if report:
         report.extend(("", f"Banned terms: {','.join(terms)}", "These terms must not appear in this repo."))

--- a/src/teatree/hooks/banned_terms_cli.py
+++ b/src/teatree/hooks/banned_terms_cli.py
@@ -73,12 +73,22 @@ def staged_added_lines(repo: Path, file: str) -> list[str] | None:
     """Return *file*'s ADDED lines from the staged diff, or ``None`` on failure.
 
     Runs ``git diff --cached -U0 --diff-filter=ACMR -- <file>`` from *repo* and
-    keeps the body of each ``+`` line (dropping the ``+++`` file header; ``-U0``
-    emits no context lines). An EMPTY list means the file has no staged
-    additions; ``None`` is the distinct sentinel for "could not resolve the
-    staged diff" (not a git repo, git missing, a non-zero exit, a timeout) so
-    the caller can fall back to a full-file scan and NEVER fail open on a
-    security gate.
+    keeps the body of each ``+`` line inside a hunk (``-U0`` emits no context
+    lines). An EMPTY list means the file has no staged additions; ``None`` is
+    the distinct sentinel for "could not resolve the staged diff" (not a git
+    repo, git missing, a non-zero exit, a timeout) so the caller can fall back
+    to a full-file scan and NEVER fail open on a security gate.
+
+    The extraction is HUNK-AWARE, not prefix-matching. The ``--- ``/``+++ ``
+    file headers appear exactly once per file, BEFORE the first ``@@`` hunk
+    header; ADDED content lines only appear inside a hunk body. A naive
+    ``not line.startswith("+++")`` filter would silently drop a real added
+    content line whose own text begins with ``++`` — git renders that as the
+    add-marker ``+`` plus ``++text`` = ``+++text`` — so a banned term staged on
+    such a line would slip the commit gate (fail-open diff-evasion). Tracking
+    hunk state instead keeps ``++text``/``+++text``/``+++ text`` content lines
+    (they live in a hunk body) while never seeing the ``+++ b/<file>`` header
+    (it is pre-hunk).
     """
     try:
         result = run_allowed_to_fail(
@@ -89,7 +99,16 @@ def staged_added_lines(repo: Path, file: str) -> list[str] | None:
         )
     except (CommandFailedError, TimeoutExpired, OSError):
         return None
-    return [line[1:] for line in result.stdout.splitlines() if line.startswith("+") and not line.startswith("+++")]
+    added: list[str] = []
+    in_hunk = False
+    for line in result.stdout.splitlines():
+        if line.startswith("diff --git"):
+            in_hunk = False  # back to per-file headers; ``+++ b/<file>`` is pre-hunk
+        elif line.startswith("@@"):
+            in_hunk = True  # hunk body begins; subsequent ``+`` lines are added content
+        elif in_hunk and line.startswith("+"):
+            added.append(line[1:])
+    return added
 
 
 def _diff_only_report(files: list[str], terms: tuple[str, ...], repo: Path) -> list[str]:

--- a/tests/teatree_hooks/test_banned_terms_cli_diff_only.py
+++ b/tests/teatree_hooks/test_banned_terms_cli_diff_only.py
@@ -1,0 +1,338 @@
+"""The commit gate scans the staged DIFF's added lines, not the whole file.
+
+The ``banned-terms`` pre-commit hook used to scan every staged FILE in full
+(:func:`teatree.hooks.term_match.file_matches`), so staging a one-line change
+to a file that ALREADY carried a committed banned term blocked the commit on
+the pre-existing line the diff never touched — the recurring #1415 over-block
+(a ``BLUEPRINT.md`` edit blocked because a far-away committed line names a
+private term).
+
+The ``--diff-only`` mode scopes the commit hook to the staged diff's ADDED
+(``+``) lines per file. A pre-existing committed banned-term line no longer
+blocks an unrelated commit, while a NEWLY-ADDED banned-term line still blocks.
+The default (no flag) keeps the full-file scan the posting gate and the parity
+meta-test depend on — only the pre-commit hook entry passes ``--diff-only``.
+
+All terms here are SYNTHETIC (``acme`` stands in for a real single-token
+customer term); no real configured value appears in this public source.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from teatree.hooks import banned_terms_cli
+from teatree.hooks.banned_terms_cli import _diff_only_report, _full_file_report, _load_terms, staged_added_lines
+
+_TERMS = ("acme",)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],  # noqa: S607
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        env={
+            **os.environ,
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@example.com",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@example.com",
+        },
+    )
+
+
+def _write_config(tmp_path: Path) -> Path:
+    config = tmp_path / "config.toml"
+    config.write_text("[teatree]\nbanned_terms = " + repr(list(_TERMS)) + "\n", encoding="utf-8")
+    return config
+
+
+def _run_cli(repo: Path, config: Path, *files: str, diff_only: bool = False) -> subprocess.CompletedProcess[str]:
+    """Invoke the banned_terms_cli module exactly as the pre-commit hook does.
+
+    Runs with ``cwd=repo`` (prek runs hooks from the repo root and passes
+    repo-relative paths) so the staged diff resolves against the right repo.
+    """
+    argv = ["--config", str(config)]
+    if diff_only:
+        argv.append("--diff-only")
+    argv.extend(files)
+    return subprocess.run(
+        [sys.executable, "-m", "teatree.hooks.banned_terms_cli", *argv],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _init_repo_with_committed_banned_line(tmp_path: Path) -> tuple[Path, Path]:
+    """A repo whose committed ``doc.md`` carries a pre-existing banned-term line.
+
+    Returns ``(repo, config)``. Line 1 holds the banned term ``acme``; line 2
+    is a clean line. The banned line is already committed, so it is NOT in any
+    later staged diff.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    doc = repo / "doc.md"
+    doc.write_text("acme reference on a pre-existing committed line\nclean line two\n", encoding="utf-8")
+    _git(repo, "add", "doc.md")
+    _git(repo, "commit", "-m", "seed: committed doc with a pre-existing term line")
+    config = _write_config(tmp_path)
+    return repo, config
+
+
+# ── (a) pre-existing committed banned line + staged change to a DIFFERENT line ──
+# RED before the fix: full-file scan flags the committed line-1 term and blocks.
+# GREEN after: diff-only scans only the staged added line, which is clean.
+
+
+def test_diff_only_allows_commit_when_banned_term_only_on_preexisting_line(tmp_path: Path) -> None:
+    repo, config = _init_repo_with_committed_banned_line(tmp_path)
+    doc = repo / "doc.md"
+    # Stage a change to line 2 only — line 1 (the banned term) is untouched.
+    doc.write_text("acme reference on a pre-existing committed line\nedited clean line two\n", encoding="utf-8")
+    _git(repo, "add", "doc.md")
+
+    result = _run_cli(repo, config, "doc.md", diff_only=True)
+
+    assert result.returncode == 0, f"diff-only must ALLOW an unrelated edit; got:\n{result.stdout}\n{result.stderr}"
+
+
+def test_full_file_scan_still_blocks_the_same_preexisting_line(tmp_path: Path) -> None:
+    # ANTI-VACUITY for (a): WITHOUT --diff-only, the SAME staged tree still
+    # blocks on the committed line-1 term. Proves the allow above measures the
+    # diff-only narrowing, not a CLI that stopped flagging this file at all.
+    repo, config = _init_repo_with_committed_banned_line(tmp_path)
+    doc = repo / "doc.md"
+    doc.write_text("acme reference on a pre-existing committed line\nedited clean line two\n", encoding="utf-8")
+    _git(repo, "add", "doc.md")
+
+    result = _run_cli(repo, config, "doc.md", diff_only=False)
+
+    assert result.returncode == 1
+    assert "BANNED TERM in doc.md" in result.stdout
+
+
+# ── (b) staged change that ADDS a new banned-term line → still BLOCKED ──
+# Must stay green under --diff-only: the gate is narrowed to the diff, NOT gutted.
+
+
+def test_diff_only_blocks_commit_that_adds_a_new_banned_term_line(tmp_path: Path) -> None:
+    repo, config = _init_repo_with_committed_banned_line(tmp_path)
+    doc = repo / "doc.md"
+    # Add a NEW line carrying the banned term (line 1 stays untouched).
+    doc.write_text(
+        "acme reference on a pre-existing committed line\nclean line two\nnewly added acme leak line\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "doc.md")
+
+    result = _run_cli(repo, config, "doc.md", diff_only=True)
+
+    assert result.returncode == 1, "a newly-added banned-term line must STILL block"
+    assert "BANNED TERM in doc.md" in result.stdout
+    assert "newly added acme leak line" in result.stdout
+
+
+def test_diff_only_blocks_brand_new_file_with_banned_term(tmp_path: Path) -> None:
+    # A brand-new staged file is all added lines, so diff-only blocks it the
+    # same as a full-file scan would — no committed baseline to exempt.
+    repo, config = _init_repo_with_committed_banned_line(tmp_path)
+    new_file = repo / "new.md"
+    new_file.write_text("a fresh file introducing acme\n", encoding="utf-8")
+    _git(repo, "add", "new.md")
+
+    result = _run_cli(repo, config, "new.md", diff_only=True)
+
+    assert result.returncode == 1
+    assert "BANNED TERM in new.md" in result.stdout
+
+
+def test_diff_only_allows_when_only_clean_lines_are_added(tmp_path: Path) -> None:
+    repo, config = _init_repo_with_committed_banned_line(tmp_path)
+    doc = repo / "doc.md"
+    doc.write_text(
+        "acme reference on a pre-existing committed line\nclean line two\na perfectly clean new line\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "doc.md")
+
+    result = _run_cli(repo, config, "doc.md", diff_only=True)
+
+    assert result.returncode == 0, result.stdout
+
+
+def test_diff_only_falls_back_to_full_scan_outside_a_git_repo(tmp_path: Path) -> None:
+    # FAIL-CLOSED: if the staged diff cannot be resolved (no git repo / git
+    # error), diff-only must NOT fail open. It falls back to the full-file scan
+    # so a banned term in the file is still caught.
+    config = _write_config(tmp_path)
+    loose = tmp_path / "loose.md"
+    loose.write_text("acme in a file with no git repo around it\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "teatree.hooks.banned_terms_cli", "--config", str(config), "--diff-only", "loose.md"],
+        cwd=tmp_path,  # not a git repo
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1, "outside a git repo, diff-only must fall back to a full scan, not fail open"
+    assert "BANNED TERM in loose.md" in result.stdout
+
+
+# ── helper-level unit tests: staged added-line extraction ──
+
+
+def test_staged_added_lines_returns_only_added_lines(tmp_path: Path) -> None:
+    repo, _config = _init_repo_with_committed_banned_line(tmp_path)
+    doc = repo / "doc.md"
+    doc.write_text(
+        "acme reference on a pre-existing committed line\nclean line two\nbrand new line added\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "doc.md")
+
+    added = staged_added_lines(repo, "doc.md")
+
+    assert added == ["brand new line added"]
+
+
+def test_staged_added_lines_empty_when_no_staged_change(tmp_path: Path) -> None:
+    repo, _config = _init_repo_with_committed_banned_line(tmp_path)
+
+    # Nothing staged for doc.md → no added lines.
+    assert staged_added_lines(repo, "doc.md") == []
+
+
+def test_staged_added_lines_returns_none_outside_git_repo(tmp_path: Path) -> None:
+    # A None return is the sentinel "could not resolve the staged diff" — the
+    # caller falls back to a full-file scan (fail closed), never fail open.
+    assert staged_added_lines(tmp_path, "doc.md") is None
+
+
+# ── helper-level unit tests: in-process report builders ──
+
+
+def test_diff_only_report_flags_only_added_banned_line(tmp_path: Path) -> None:
+    repo, _config = _init_repo_with_committed_banned_line(tmp_path)
+    doc = repo / "doc.md"
+    doc.write_text(
+        "acme reference on a pre-existing committed line\nclean line two\nadded acme line\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "doc.md")
+
+    report = _diff_only_report(["doc.md"], _TERMS, repo)
+
+    assert report == ["BANNED TERM in doc.md:", "  +:added acme line"]
+
+
+def test_diff_only_report_clean_added_line_is_empty(tmp_path: Path) -> None:
+    repo, _config = _init_repo_with_committed_banned_line(tmp_path)
+    doc = repo / "doc.md"
+    doc.write_text(
+        "acme reference on a pre-existing committed line\nclean line two\nperfectly clean addition\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "doc.md")
+
+    assert _diff_only_report(["doc.md"], _TERMS, repo) == []
+
+
+def test_diff_only_report_carves_out_email_only_added_line(tmp_path: Path) -> None:
+    # The added-line scan applies the same email carve-out the full scan does:
+    # a term that appears ONLY inside an author email address is not a leak.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    doc = repo / "doc.md"
+    doc.write_text("Author: someone <dev@acme.example>\n", encoding="utf-8")
+    _git(repo, "add", "doc.md")
+
+    assert _diff_only_report(["doc.md"], _TERMS, repo) == []
+
+
+def test_diff_only_report_falls_back_to_full_scan_when_diff_unresolvable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # When staged_added_lines returns None (could not resolve the staged diff),
+    # the per-file fallback scans the whole file — fail closed, the banned term
+    # is still caught. Drive the None branch directly so the fallback is
+    # exercised regardless of the ambient git state.
+    monkeypatch.setattr(banned_terms_cli, "staged_added_lines", lambda _repo, _file: None)
+    doc = tmp_path / "doc.md"
+    doc.write_text("acme on a line in a file the diff could not resolve\n", encoding="utf-8")
+
+    report = _diff_only_report([str(doc)], _TERMS, tmp_path)
+
+    assert report[0] == f"BANNED TERM in {doc}:"
+    assert any("acme on a line" in line for line in report)
+
+
+def test_diff_only_report_fallback_skips_missing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Fallback path (None diff) with a non-existent file → skipped, no report
+    # entry, no crash.
+    monkeypatch.setattr(banned_terms_cli, "staged_added_lines", lambda _repo, _file: None)
+
+    assert _diff_only_report([str(tmp_path / "does-not-exist.md")], _TERMS, tmp_path) == []
+
+
+def test_diff_only_report_fallback_clean_existing_file_is_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Fallback path (None diff) with an EXISTING clean file → no hits, empty.
+    monkeypatch.setattr(banned_terms_cli, "staged_added_lines", lambda _repo, _file: None)
+    clean = tmp_path / "clean.md"
+    clean.write_text("a perfectly clean file with no banned term\n", encoding="utf-8")
+
+    assert _diff_only_report([str(clean)], _TERMS, tmp_path) == []
+
+
+def test_full_file_report_clean_file_is_empty(tmp_path: Path) -> None:
+    clean = tmp_path / "clean.md"
+    clean.write_text("nothing banned here at all\n", encoding="utf-8")
+
+    assert _full_file_report([str(clean)], _TERMS) == []
+
+
+def test_load_terms_reads_first_banned_terms_array(tmp_path: Path) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text('[teatree]\nbanned_terms = ["acme", "  ", "widget"]\n', encoding="utf-8")
+
+    # Whitespace-only entries are dropped; the rest are stripped.
+    assert _load_terms(config) == ("acme", "widget")
+
+
+def test_load_terms_empty_on_unreadable_or_termless_config(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.toml"
+    assert _load_terms(missing) == ()
+
+    no_terms = tmp_path / "no_terms.toml"
+    no_terms.write_text("[teatree]\nother = 1\n", encoding="utf-8")
+    assert _load_terms(no_terms) == ()
+
+
+def test_full_file_report_flags_committed_line(tmp_path: Path) -> None:
+    repo, _config = _init_repo_with_committed_banned_line(tmp_path)
+    doc = repo / "doc.md"
+
+    report = _full_file_report([str(doc)], _TERMS)
+
+    assert report[0] == f"BANNED TERM in {doc}:"
+    assert any("pre-existing committed line" in line for line in report)
+
+
+def test_full_file_report_skips_missing_file(tmp_path: Path) -> None:
+    assert _full_file_report([str(tmp_path / "missing.md")], _TERMS) == []

--- a/tests/teatree_hooks/test_banned_terms_cli_diff_only.py
+++ b/tests/teatree_hooks/test_banned_terms_cli_diff_only.py
@@ -192,6 +192,70 @@ def test_diff_only_falls_back_to_full_scan_outside_a_git_repo(tmp_path: Path) ->
     assert "BANNED TERM in loose.md" in result.stdout
 
 
+# ── (c) diff-evasion: a banned term on a content line that begins with ``+`` ──
+# In ``git diff --cached -U0`` output an ADDED content line is rendered as the
+# add-marker ``+`` followed by the line's own text. So a staged content line
+# ``++acme`` appears as ``+++acme``, ``+++acme`` as ``++++acme``, and ``+++ acme``
+# as ``++++ acme``. A naive ``not line.startswith("+++")`` filter (meant only to
+# drop the unified-diff ``+++ <file>`` header) ALSO drops these real content
+# lines, so a banned term staged on such a line slips the commit gate (fail-open
+# diff-evasion). The hunk-aware parse keeps them — they live inside a hunk body,
+# whereas the ``+++ b/<file>`` header is pre-hunk and never collected.
+
+
+@pytest.mark.parametrize(
+    "content_line",
+    [
+        "++acme glued evasion line",  # rendered as +++acme... in the diff
+        "+++acme triple evasion line",  # rendered as ++++acme...
+        "+++ acme spaced evasion line",  # rendered as ++++ acme... — defeats a "+++ " match too
+    ],
+)
+def test_diff_only_blocks_added_content_line_starting_with_plus(tmp_path: Path, content_line: str) -> None:
+    repo, config = _init_repo_with_committed_banned_line(tmp_path)
+    doc = repo / "doc.md"
+    # Add a NEW content line whose own text begins with ``+`` and carries the
+    # banned term. The committed line 1 stays untouched.
+    doc.write_text(
+        f"acme reference on a pre-existing committed line\nclean line two\n{content_line}\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "doc.md")
+
+    result = _run_cli(repo, config, "doc.md", diff_only=True)
+
+    assert result.returncode == 1, (
+        f"a banned term on an added content line beginning with '+' must STILL block "
+        f"(diff-evasion); got:\n{result.stdout}\n{result.stderr}"
+    )
+    assert "BANNED TERM in doc.md" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "content_line",
+    [
+        "++acme glued evasion line",
+        "+++acme triple evasion line",
+        "+++ acme spaced evasion line",
+    ],
+)
+def test_staged_added_lines_keeps_content_line_starting_with_plus(tmp_path: Path, content_line: str) -> None:
+    # Helper-level proof: the extractor returns the full content line verbatim
+    # (leading ``+`` chars preserved), never confusing it with the ``+++`` file
+    # header. This is the unit guard for the diff-evasion regression above.
+    repo, _config = _init_repo_with_committed_banned_line(tmp_path)
+    doc = repo / "doc.md"
+    doc.write_text(
+        f"acme reference on a pre-existing committed line\nclean line two\n{content_line}\n",
+        encoding="utf-8",
+    )
+    _git(repo, "add", "doc.md")
+
+    added = staged_added_lines(repo, "doc.md")
+
+    assert added == [content_line]
+
+
 # ── helper-level unit tests: staged added-line extraction ──
 
 


### PR DESCRIPTION
fix(hooks): scan only the staged diff in the banned-terms commit gate (#1415)

## What

The banned-terms pre-commit hook now passes --diff-only to
teatree.hooks.banned_terms_cli, scoping the scan to each staged file's
staged-diff ADDED (+) lines instead of the whole file. A pre-existing,
already-committed banned-term line no longer blocks an unrelated commit; a
newly-added banned-term line still blocks. Without the flag the CLI keeps its
full-file scan -- the mode the posting gate (banned_terms_scanner writes the
body to a temp file and scans it whole) and the parity meta-test depend on, so
neither is weakened.

## Why

A commit touching one line of a file was blocked whenever ANY other line in
that file carried a banned term -- even a pre-existing committed line the diff
never touched (e.g. a BLUEPRINT.md edit blocked because a far-away committed
line names a private term). This is the recurring #1415 over-block. The fix is
surgical: only the commit/file-staging scan is narrowed; the PreToolUse publish
gate that scans the body being posted via gh/glab/t3 review post-comment keeps
scanning the full body. Existing escapes (ALLOW_BANNED_TERM=1) and term
resolution are unchanged. The pre-push public-leak gate
(refuse-public-push-with-leak.sh) still re-scans commit messages before they
reach a public remote, so a pre-existing committed term is caught before it
leaves the machine.

## Open questions & assumptions

- prek runs the hook from the repo root and passes repo-relative file paths, so
  git diff --cached resolves against the right repo and Path(file) resolves for
  the full-file fallback. If the staged diff cannot be resolved (no git repo,
  git missing, a timeout), staged_added_lines returns None and the per-file scan
  falls back to a full-file scan -- conservative, never permissive.

## Architecture pre-check

1. BLUEPRINT alignment -- egress-leak gate family. The commit-side
   check-banned-terms.sh is the matcher shared by the posting gate (#1415) and
   full-tree backstop (#1570); only its commit-hook invocation is narrowed.
   Skill doc scripts-and-functions.md updated to match.
2. FSM phase boundaries -- n/a (no state transition).
3. Extension-point contracts -- n/a (no OverlayBase/scanner/Protocol change).
4. Component boundaries -- banned_terms_cli.py (CLI orchestration) gains
   --diff-only; the shell hook already forwards its args; the matcher stays in
   teatree.hooks.term_match.
5. Dependency direction -- adds teatree.hooks -> teatree.utils.run (allowed by
   tach); tach check green.
6. Test surface -- test_banned_terms_cli_diff_only.py: real-git tmp_path cases
   (a) allow on pre-existing-only term, (b) block on newly-added term, plus
   fallback/anti-vacuity/helper coverage.
7. Resilience invariants -- idempotent (re-scan is a no-op); conservative
   fallback to full-file scan when the diff is unresolvable; bounded git timeout.
8. Identity/key normalization -- n/a.
9. Behavior preservation -- full-file scan stays the DEFAULT; diff-only is the
   opt-in commit-hook narrowing. The publish gate's full-body scan and the
   parity meta-test are unchanged. No must-block test inverted; anti-vacuity
   guards prove the gate is not gutted.