### PR TITLE
fix(eval): raise clean-room turn floor 6 → 15 for the act-then-verify cluster

### DIFF
--- a/src/teatree/eval/models.py
+++ b/src/teatree/eval/models.py
@@ -29,7 +29,7 @@ DEFAULT_MAX_TURNS = 30
 #: very tight ``max_turns: 3`` calibrated to an earlier era where the model
 #: emitted the decisive tool call on turn 1. Current Claude models ORIENT before
 #: acting (inspect the repo, verify the premise) and frequently emit the correct
-#: matched action EARLY but keep going for a turn or two — and a cap-truncated run
+#: matched action EARLY but keep going for several turns — and a cap-truncated run
 #: force-FAILs the gate even when every matcher passed (#2192,
 #: :attr:`ScenarioResult.passed` returns ``False`` on a ``max_turns`` terminal
 #: reason). The result was a SYSTEMIC clean-room collapse: the agent did the right
@@ -38,8 +38,20 @@ DEFAULT_MAX_TURNS = 30
 #: erased by trailing exploration. It NEVER lowers a higher per-scenario value
 #: (``max(declared, floor)``) and applies to the clean-room lane only — the
 #: under_load lane keeps its own turn/watchdog calibration. The matchers are
-#: untouched, so the teeth are unchanged: a WRONG action still grades RED.
-CLEAN_ROOM_MIN_TURNS = 6
+#: untouched, so the teeth are unchanged: a WRONG action still grades RED — a
+#: higher floor only lets a run whose matchers ALL pass terminate naturally
+#: instead of being truncated mid-trajectory.
+#:
+#: Recalibrated 6 → 15 (#2627 follow-up): a fresh metered single-trial run of the
+#: full suite found 16 clean-room scenarios that did the right thing (every
+#: matcher green) yet still cap-FAILed at the 6-turn floor — the model needed up
+#: to ~12 decisive assistant turns of orient → act → verify → stop before
+#: terminating on its own. The earlier floor of 6 recovered the act-on-turn-1
+#: cluster but not the act-then-verify-then-stop cluster the current models
+#: exhibit. 15 covers the observed worst case (~12 turns) with headroom; because
+#: a model stops on its own once done, the floor only bites a run still going AT
+#: the cap, so the higher value costs nothing on a scenario that finishes early.
+CLEAN_ROOM_MIN_TURNS = 15
 
 #: The default eval lane. A clean-room scenario loads ONE skill into an empty
 #: context; the catalog's existing specs all default to it, so their runs are

--- a/tests/teatree_eval/test_sdk_runner.py
+++ b/tests/teatree_eval/test_sdk_runner.py
@@ -272,10 +272,15 @@ class TestSdkInProcessRunnerCapture:
         assert captured["options"].max_turns == 9
 
     def test_spec_max_turns_used_without_override(self, tmp_path: Path) -> None:
-        # A declared value AT/ABOVE the clean-room floor is used verbatim.
-        spec = _spec(tmp_path, max_turns=12)
+        # A declared value AT/ABOVE the clean-room floor is used verbatim. The
+        # declared budget is derived from the floor (floor + 5) so this stays
+        # genuinely above-floor across any future floor recalibration.
+        from teatree.eval.models import CLEAN_ROOM_MIN_TURNS  # noqa: PLC0415
+
+        declared = CLEAN_ROOM_MIN_TURNS + 5
+        spec = _spec(tmp_path, max_turns=declared)
         _run, captured = self._run(spec, [_result()])
-        assert captured["options"].max_turns == 12
+        assert captured["options"].max_turns == declared
 
     def test_prompt_and_model_and_tools_flow_to_options(self, tmp_path: Path) -> None:
         spec = _spec(tmp_path, model="haiku", tools=("Bash", "Read"))


### PR DESCRIPTION
## What

Raises the clean-room eval turn floor `CLEAN_ROOM_MIN_TURNS` from `6` to `15`, a follow-up to [#2627](https://github.com/souliane/teatree/pull/2627).

## Why

A fresh metered single-trial run of the full suite (199 scenarios, sdk backend) found **16 clean-room scenarios that did the right thing — every matcher green — yet still cap-FAILed at the 6-turn floor**. The model emits the correct decisive tool call but keeps orienting/verifying for several turns before terminating on its own, reaching up to ~12 decisive assistant turns (orient → act → verify → stop). `ScenarioResult.passed` force-FAILs any `max_turns` terminal even when every matcher passed ([#2192](https://github.com/souliane/teatree/issues/2192)), so those correct runs were nullified.

[#2627](https://github.com/souliane/teatree/pull/2627) raised the floor `3 → 6`, which recovered the act-on-turn-1 cluster but not the act-then-verify-then-stop cluster current models exhibit.

The 16 affected scenarios reached these turn counts (event index; ~half are assistant turns): `7,7,7,8,9,9,9,12,12,13,13,13,13,13,14,23`. `15` covers the observed worst case with headroom.

## Safety

- The matchers are **untouched** — the teeth are unchanged. A WRONG action still grades RED.
- A higher floor only lets a run whose matchers ALL pass terminate naturally instead of being truncated mid-trajectory. Because a model stops on its own once done, the floor only bites a run still going AT the cap — so the higher value costs nothing on a scenario that finishes early.
- The floor is clean-room only; the under_load lane keeps its own turn/watchdog calibration.

## Verification

- `checking_is_read_only` and `background_long_operations_full_suite` (the 23-event worst case) both flip `max_turns`-FAIL → PASS at 15 turns (metered against the live model).
- `tests/teatree_eval`: **369 passed**.
- `ruff check` / `ruff format` clean; all pre-commit gates pass.
- The above-floor test fixture is now derived from `CLEAN_ROOM_MIN_TURNS + 5` so it stays genuinely above-floor across future recalibration.
