### PR TITLE
fix(eval): lane-aware shard ceiling — split the slow under_load lane (#2683)

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -18,19 +18,26 @@
 #     and an optional `lane` input. ALWAYS runs (force) — the no-PR guard is
 #     bypassed for a manual run.
 #
-# LANE+SHARD FAN-OUT (souliane/teatree#2492):
-#   The FULL 181-scenario x 3-trial suite does not finish in a single 2x80min
-#   budget. The catalog is NOT evenly split: clean_room is 167 scenarios and
-#   under_load is 14, so fanning out ONE leg per lane still leaves a 167-scenario
+# LANE+SHARD FAN-OUT (souliane/teatree#2492, #2683):
+#   The FULL suite (~196 scenarios x 3 trials) does not finish in a single 2x80min
+#   budget. The catalog is NOT evenly split: clean_room is ~182 scenarios and
+#   under_load is 14, so fanning out ONE leg per lane still leaves a 182-scenario
 #   clean_room leg (~92% of the suite) that hits the same 80min wall. So the
 #   `prepare` job computes a `{lane, shard}` matrix (`scripts/eval/lane_matrix.py`):
-#   each lane is split into ceil(count / 14) contiguous shards — a deterministic
-#   partition by scenario name (every scenario in exactly one shard, none dropped
-#   or duplicated). The `eval` job fans OUT one matrix leg per SHARD, each leg
-#   metering at most 14 scenarios (the proven-to-fit under_load size) — under_load
-#   stays one shard (1/1), clean_room becomes 12 shards of ~14. Full coverage,
-#   parallel wall-clock. `fail-fast: false` keeps each leg's verdict independent
-#   (a red shard never cancels the others).
+#   each lane is split into contiguous shards — a deterministic partition by
+#   scenario name (every scenario in exactly one shard, none dropped or duplicated).
+#   The per-shard ceiling is LANE-AWARE because the two lanes have wildly different
+#   per-scenario cost (#2683):
+#     * clean_room — ONE skill into an empty context, seconds-to-a-minute each, so
+#       the ceiling is 14: clean_room (~182) becomes ceil(182 / 14) ~= 13 shards.
+#     * under_load — FULL skill bundle + polluted context preamble + a spawned
+#       multi-agent roster, 10-45 MINUTES per scenario at 3 trials. Run 27995563148
+#       proved a single `1/1` under_load leg hits the 80min step cap (the 4800000ms
+#       timeout), so its ceiling is 4: under_load (14) becomes 4 shards.
+#   The `eval` job fans OUT one matrix leg per SHARD, each leg metering at most its
+#   lane's ceiling — so EVERY leg (not just clean_room) fits the budget. Full
+#   coverage, parallel wall-clock. `fail-fast: false` keeps each leg's verdict
+#   independent (a red shard never cancels the others).
 #
 # The "nothing new to test" skip is a PRE-CHECK that decides whether to invoke
 # the eval at all — it is NOT a skip-as-pass inside the eval. Once the eval IS
@@ -94,10 +101,12 @@ on:
 jobs:
   # PREPARE: ONE place that (a) decides whether the eval runs at all (the weekly
   # no-PR guard / manual force) and (b) computes the per-leg {lane, shard} matrix.
-  # The full 181-scenario x 3-trial suite (clean_room 167 / under_load 14) cannot
-  # finish in a single 2x80min budget (#2492), and a single 167-scenario clean_room
-  # leg hits the same wall — so the eval job below fans OUT across SHARDS: one leg
-  # per shard, each metering at most 14 scenarios (the proven-to-fit size).
+  # The full ~196-scenario x 3-trial suite (clean_room ~182 / under_load 14) cannot
+  # finish in a single 2x80min budget (#2492), and BOTH a single ~182-scenario
+  # clean_room leg AND a single under_load leg hit the wall — so the eval job below
+  # fans OUT across SHARDS: one leg per shard, each metering at most its LANE's
+  # ceiling (clean_room 14, under_load 4 — #2683, roster-spawning scenarios cost
+  # 10-45 min each).
   prepare:
     runs-on: ubuntu-latest
     outputs:
@@ -145,11 +154,12 @@ jobs:
           fi
       # Compute the {lane, shard} matrix the eval job fans out over. Empty `lane`
       # input (scheduled runs and the default manual run) = every permitted lane,
-      # sharded into budget-safe legs (clean_room 167 → 12 shards, under_load 14 →
-      # 1 shard). An explicit `lane` input shards only that lane. An unknown lane
-      # fails loud here rather than producing an empty matrix. The lane input is
-      # routed through an `env:` var (never inlined into the shell) and validated
-      # by lane_matrix.py against PERMITTED_LANES.
+      # sharded into budget-safe legs on the lane-aware ceiling (clean_room ~182 →
+      # ~13 shards of ≤14, under_load 14 → 4 shards of ≤4 — #2683). An explicit
+      # `lane` input shards only that lane. An unknown lane fails loud here rather
+      # than producing an empty matrix. The lane input is routed through an `env:`
+      # var (never inlined into the shell) and validated by lane_matrix.py against
+      # PERMITTED_LANES.
       - name: Compute the lane+shard matrix
         id: matrix
         env:
@@ -172,8 +182,9 @@ jobs:
       # mid-run — each leg's verdict is independent signal.
       fail-fast: false
       # `include` with the prepare job's `{lane, shard}` objects: each leg meters
-      # exactly its lane's `index/total` shard (≤ 14 scenarios), so EVERY leg fits
-      # the budget — not just under_load.
+      # exactly its lane's `index/total` shard, bounded by the LANE's per-shard
+      # ceiling (clean_room ≤14, under_load ≤4 — #2683), so EVERY leg fits the
+      # budget — clean_room AND under_load alike.
       matrix:
         include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     # FAIL LOUD on a hang. Without a job-level cap a wedge ANYWHERE outside the
@@ -183,8 +194,8 @@ jobs:
     # The eval step is bounded to 80min x 2 attempts (160min worst case);
     # 180min caps the whole job just above that (plus the report/upload steps)
     # so a real hang is killed and surfaced as a red, diagnosable run instead of
-    # an indefinite stall. Each leg now meters ONE shard (≤ 14 scenarios), which
-    # fits the budget.
+    # an indefinite stall. Each leg now meters ONE shard bounded by its lane's
+    # ceiling (clean_room ≤14, under_load ≤4 — #2683), which fits the budget.
     timeout-minutes: 180
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
@@ -238,19 +249,22 @@ jobs:
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # This leg meters exactly ONE shard of ONE lane (the matrix values), so the
-          # per-shard subset is at most 14 scenarios — the proven-to-fit under_load
-          # size — and fits the 2x80min budget where the full 181 (and a single
-          # 167-scenario clean_room leg) did not (#2492). The matrix values come from
-          # the prepare job's validated plan, never raw input — so `lane` is always a
+          # per-shard subset is bounded by the LANE's ceiling — clean_room ≤14,
+          # under_load ≤4 (#2683) — and fits the 2x80min budget where the full suite,
+          # a single ~182-scenario clean_room leg, AND a single under_load 1/1 leg
+          # (run 27995563148, 80min cap) did not. The matrix values come from the
+          # prepare job's validated plan, never raw input — so `lane` is always a
           # permitted lane and `shard` is always a valid index/total.
           EVAL_LANE: ${{ matrix.lane }}
           EVAL_SHARD: ${{ matrix.shard }}
         with:
-          # A single shard is ≤ 14 scenarios x 3 trials, each a real metered
-          # `claude` SDK call. Each retry re-runs the whole leg from scratch
-          # (`--no-persist`, no resume), so a too-tight timeout just truncates and
-          # repeats partial work every attempt and never completes (the observed
-          # "hang"). 80min per attempt lets ONE shard finish comfortably; 2 attempts
+          # A single shard is ≤ its lane's ceiling (clean_room ≤14, under_load ≤4 —
+          # #2683) x 3 trials, each a real metered `claude` SDK call. Each retry
+          # re-runs the whole leg from scratch (`--no-persist`, no resume), so a
+          # too-tight timeout just truncates and repeats partial work every attempt
+          # and never completes (the observed "hang"). 80min per attempt lets ONE
+          # shard finish comfortably (under_load's roster-spawning scenarios are
+          # 10-45 min each, so ≤4 fits with headroom); 2 attempts
           # keep ONE transient-failure retry (the whole point of the retry wrapper —
           # an AI/network flake is retried, not red-failed) without a third
           # truncating pass. 2x80=160min sits under the 180min job cap. The

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1742,11 +1742,16 @@ Usage: t3 eval run [OPTIONS] [NAME]
 │                                                     scenario in exactly one  │
 │                                                     shard, none dropped or   │
 │                                                     duplicated. The weekly   │
-│                                                     metered lane shards a    │
-│                                                     large lane (clean_room   │
-│                                                     ~167) into budget-safe   │
-│                                                     legs; omit (default) to  │
-│                                                     run the whole lane       │
+│                                                     metered lane shards each │
+│                                                     lane into budget-safe    │
+│                                                     legs on a lane-aware     │
+│                                                     ceiling (clean_room ~182 │
+│                                                     into ~13, under_load 14  │
+│                                                     into 4 — its             │
+│                                                     roster-spawning          │
+│                                                     scenarios are far        │
+│                                                     slower); omit (default)  │
+│                                                     to run the whole lane    │
 │                                                     unchanged.               │
 │ --format                                   TEXT     Report format: text,     │
 │                                                     json, or html            │

--- a/scripts/eval/lane_matrix.py
+++ b/scripts/eval/lane_matrix.py
@@ -1,18 +1,22 @@
-r"""Emit the eval-lane SHARD matrix JSON for the metered workflow (#2492).
+r"""Emit the eval-lane SHARD matrix JSON for the metered workflow (#2492, #2683).
 
 Each metered job runs its scenarios at 3 real ``claude`` SDK trials under a
 ``2 x 80min`` budget. The catalog is NOT evenly split across lanes: ``under_load``
-is ~14 scenarios (proven to fit) but ``clean_room`` is ~167 — "the whole suite
-minus under_load", ~92% of the catalog. A single ``clean_room`` leg would very
-plausibly hit the same 80min wall the undifferentiated full suite hit, so fanning
-out one leg per *lane* is not enough.
+is 14 scenarios but ``clean_room`` is ~182 — "the whole suite minus under_load",
+~92% of the catalog. A single ``clean_room`` leg would very plausibly hit the same
+80min wall the undifferentiated full suite hit, so fanning out one leg per *lane*
+is not enough.
 
 This script therefore emits a ``{lane, shard}`` matrix: each lane is split into
-``ceil(count / MAX_SCENARIOS_PER_SHARD)`` contiguous shards (a deterministic
+``ceil(count / max_scenarios_per_shard(lane))`` contiguous shards (a deterministic
 partition by scenario name — every scenario in exactly one shard, none dropped or
-duplicated), so EVERY emitted job meters a budget-safe subset. ``under_load``
-(~14) stays one shard; ``clean_room`` (~167) becomes several. Counts are read
-from the LIVE catalog, so the split is never stale.
+duplicated), so EVERY emitted job meters a budget-safe subset. The per-shard
+ceiling is LANE-AWARE (#2683): ``clean_room`` (fast, one skill into an empty
+context) uses 14, so ~182 becomes ~13 shards; ``under_load`` (slow — full skill
+bundle + polluted preamble + a spawned multi-agent roster, 10-45 min/scenario)
+uses 4, so 14 becomes 4 shards. A single under_load ``1/1`` leg hit the 80min cap
+in run 27995563148. Counts are read from the LIVE catalog, so the split is never
+stale.
 
 An empty ``--lane`` (the scheduled weekly run, and the default manual run) maps
 to every permitted lane, sharded. An explicit ``--lane <name>`` shards only that

--- a/src/teatree/cli/eval/app.py
+++ b/src/teatree/cli/eval/app.py
@@ -104,8 +104,9 @@ def run(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a p
         help=(
             "Run only the index/total shard of the (lane-filtered) catalog, e.g. '2/6'. A "
             "deterministic partition by scenario name — every scenario in exactly one shard, none "
-            "dropped or duplicated. The weekly metered lane shards a large lane (clean_room ~167) "
-            "into budget-safe legs; omit (default) to run the whole lane unchanged."
+            "dropped or duplicated. The weekly metered lane shards each lane into budget-safe legs "
+            "on a lane-aware ceiling (clean_room ~182 into ~13, under_load 14 into 4 — its "
+            "roster-spawning scenarios are far slower); omit (default) to run the whole lane unchanged."
         ),
     ),
     output_format: str = typer.Option(

--- a/src/teatree/eval/lane_shard.py
+++ b/src/teatree/eval/lane_shard.py
@@ -1,17 +1,27 @@
-r"""Shard a metered eval lane into budget-safe job legs (souliane/teatree#2492).
+r"""Shard a metered eval lane into budget-safe job legs (souliane/teatree#2492, #2683).
 
 The metered weekly lane runs each scenario at 3 real metered ``claude`` SDK
 trials under a per-job ``2 x 80min`` budget. The catalog is NOT evenly split
-across lanes: ``under_load`` is ~14 scenarios (proven to fit the budget) but
-``clean_room`` is ~167 — "the whole suite minus under_load". A single
-``clean_room`` leg is ~92% of the catalog and very plausibly hits the same
-80min wall the undifferentiated full suite hit. Fanning out ONE leg per *lane*
-is therefore not enough.
+across lanes: ``under_load`` is 14 scenarios but ``clean_room`` is ~182 — "the
+whole suite minus under_load". A single ``clean_room`` leg is ~92% of the catalog
+and very plausibly hits the same 80min wall the undifferentiated full suite hit.
+Fanning out ONE leg per *lane* is therefore not enough.
 
 The fix is a second matrix dimension: each lane is partitioned into N contiguous
-shards of at most :data:`MAX_SCENARIOS_PER_SHARD` scenarios, so EVERY emitted job
-meters a bounded subset that fits the budget. ``under_load`` (~14) stays a single
-shard; ``clean_room`` (~167) becomes ceil(167 / bound) shards.
+shards, so EVERY emitted job meters a bounded subset that fits the budget. The
+per-shard ceiling is LANE-AWARE because the two lanes have wildly different
+per-scenario cost.
+
+A ``clean_room`` scenario loads ONE skill into an empty context — seconds to a
+minute even at 3 trials — so the ceiling is :data:`MAX_SCENARIOS_PER_SHARD` (14)
+and ``clean_room`` (~182) becomes ceil(182 / 14) shards.
+
+An ``under_load`` scenario loads the FULL skill bundle, an 8k-20k-token polluted
+context preamble, AND spawns a multi-agent roster — 10-45 MINUTES per scenario at
+3 trials. So its ceiling is the much smaller
+:data:`UNDER_LOAD_MAX_SCENARIOS_PER_SHARD` (4). Run 27995563148 proved the lane
+could NOT run as a single ``1/1`` leg: it hit the 80min step cap (the 4800000ms
+timeout). The 14-scenario lane now splits into 4 parallel shards.
 
 The partition is a deterministic slice of the lane's scenarios SORTED by name
 (scenario names are unique — :func:`teatree.eval.discovery._reject_duplicate_names`
@@ -24,14 +34,45 @@ resolve through, so a leg's subset is identical to what its planned shard claims
 import dataclasses
 import math
 
-from teatree.eval.models import PERMITTED_LANES, EvalSpec
+from teatree.eval.models import PERMITTED_LANES, UNDER_LOAD_LANE, EvalSpec
 
-#: The budget-safe per-shard scenario ceiling. ``under_load`` (~14 scenarios x 3
-#: trials) is the one lane PROVEN to finish inside the ``2 x 80min`` budget, so a
-#: shard no larger than this is conservatively within budget. Every emitted job
-#: meters at most this many scenarios; the matrix splits any larger lane into
-#: enough shards to honour it. Keep it at/below the proven ``under_load`` size.
+#: The DEFAULT budget-safe per-shard scenario ceiling — used by ``clean_room`` and
+#: any lane without an explicit override. A clean_room scenario loads ONE skill
+#: into an empty context, so it runs in seconds-to-a-minute even at 3 trials; ~14
+#: such scenarios finish well inside the ``2 x 80min`` budget. Every emitted job
+#: meters at most its lane's ceiling; the matrix splits any larger lane into enough
+#: shards to honour it.
 MAX_SCENARIOS_PER_SHARD = 14
+
+#: The ``under_load`` per-shard ceiling — much smaller than the default because an
+#: under_load scenario is FAR more expensive (souliane/teatree#2683). It loads the
+#: FULL skill bundle, an 8k-20k-token polluted context preamble, AND spawns a
+#: multi-agent roster, so a single scenario runs 10-45 MINUTES at 3 trials. Run
+#: 27995563148 proved the lane could not fit a single ``1/1`` leg: 11 of its 14
+#: scenarios already burned 70 min and ``full_speed_fans_out_parallel_workers_not_serial``
+#: alone took 45 min, so the leg hit the 80min step cap (the 4800000ms timeout).
+#: A ceiling of 4 keeps a shard's wall-clock comfortably under 80 min even when the
+#: 45-min roster scenario lands in a shard with three short ones, and splits the
+#: 14-scenario lane into 4 shards that run in parallel.
+UNDER_LOAD_MAX_SCENARIOS_PER_SHARD = 4
+
+#: Per-lane override of the default per-shard ceiling. A lane absent here uses
+#: :data:`MAX_SCENARIOS_PER_SHARD`. The single source of truth for the lane-aware
+#: split — both the planner (:func:`plan_lane_shards`) and the budget-invariant
+#: tests resolve through :func:`max_scenarios_per_shard`.
+_LANE_SHARD_CEILINGS: dict[str, int] = {UNDER_LOAD_LANE: UNDER_LOAD_MAX_SCENARIOS_PER_SHARD}
+
+
+def max_scenarios_per_shard(lane: str) -> int:
+    """The budget-safe per-shard scenario ceiling for *lane*.
+
+    ``under_load`` (roster-spawning, 10-45 min/scenario) gets a small ceiling so a
+    shard fits the ``2 x 80min`` budget; every other lane uses the default
+    :data:`MAX_SCENARIOS_PER_SHARD`. This is the single chokepoint the planner and
+    the budget-invariant tests both resolve a lane's ceiling through.
+    """
+    return _LANE_SHARD_CEILINGS.get(lane, MAX_SCENARIOS_PER_SHARD)
+
 
 #: A shard token is exactly two ``/``-separated fields: ``index/total``.
 _SHARD_FIELD_COUNT = 2
@@ -116,20 +157,31 @@ def filter_specs_by_shard(specs: list[EvalSpec], shard: str | None) -> list[Eval
     return ordered[start:stop]
 
 
-def shard_count_for(scenario_count: int) -> int:
-    """How many budget-safe shards a lane of *scenario_count* scenarios needs."""
+def shard_count_for(scenario_count: int, lane: str | None = None) -> int:
+    """How many budget-safe shards a lane of *scenario_count* scenarios needs.
+
+    The ceiling is *lane*-aware (souliane/teatree#2683): ``under_load`` uses the
+    smaller :data:`UNDER_LOAD_MAX_SCENARIOS_PER_SHARD` because its scenarios are
+    roster-spawning and 10-45 min each, so the same count splits into MORE shards
+    than a clean_room lane of identical size. ``lane=None`` keeps the legacy
+    default ceiling for callers that don't carry a lane.
+    """
     if scenario_count <= 0:
         return 1
-    return math.ceil(scenario_count / MAX_SCENARIOS_PER_SHARD)
+    ceiling = MAX_SCENARIOS_PER_SHARD if lane is None else max_scenarios_per_shard(lane)
+    return math.ceil(scenario_count / ceiling)
 
 
 def plan_lane_shards(specs: list[EvalSpec], lanes: list[str]) -> list[LaneShard]:
     """Plan the budget-safe ``{lane, shard}`` matrix legs for *lanes*.
 
     For each lane in *lanes*, count its scenarios in *specs* and split it into
-    ``ceil(count / MAX_SCENARIOS_PER_SHARD)`` contiguous shards, so every emitted
-    leg meters at most :data:`MAX_SCENARIOS_PER_SHARD` scenarios. A lane that
-    already fits emits a single ``1/1`` leg.
+    ``ceil(count / max_scenarios_per_shard(lane))`` contiguous shards, so every
+    emitted leg meters at most that lane's ceiling. The ceiling is lane-aware
+    (#2683): ``under_load`` (roster-spawning, 10-45 min/scenario) gets a smaller
+    ceiling than ``clean_room``, so its 14 scenarios split into several shards
+    rather than one ``1/1`` leg that hits the 80min cap. A lane that already fits
+    its ceiling emits a single ``1/1`` leg.
     """
     legs: list[LaneShard] = []
     for lane in lanes:
@@ -138,6 +190,6 @@ def plan_lane_shards(specs: list[EvalSpec], lanes: list[str]) -> list[LaneShard]
             msg = f"unknown lane {lane!r}; permitted lanes: {permitted}"
             raise ShardSpecError(msg)
         count = sum(1 for spec in specs if spec.lane == lane)
-        total = shard_count_for(count)
+        total = shard_count_for(count, lane)
         legs.extend(LaneShard(lane=lane, index=index, total=total) for index in range(1, total + 1))
     return legs

--- a/tests/eval_replay/test_lane_matrix.py
+++ b/tests/eval_replay/test_lane_matrix.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 
 from teatree.eval.discovery import discover_specs
-from teatree.eval.lane_shard import MAX_SCENARIOS_PER_SHARD, filter_specs_by_shard, shard_count_for
+from teatree.eval.lane_shard import filter_specs_by_shard, max_scenarios_per_shard, shard_count_for
 from teatree.eval.models import CLEAN_ROOM_LANE, PERMITTED_LANES, UNDER_LOAD_LANE
 
 _SPEC = importlib.util.spec_from_file_location(
@@ -63,10 +63,16 @@ class TestMatrixFor:
 
     def test_under_load_shards_match_the_live_catalog(self) -> None:
         count = sum(1 for spec in discover_specs() if spec.lane == UNDER_LOAD_LANE)
-        total = shard_count_for(count)
+        total = shard_count_for(count, UNDER_LOAD_LANE)
         expected = [{"lane": UNDER_LOAD_LANE, "shard": f"{index}/{total}"} for index in range(1, total + 1)]
         under = [e for e in _matrix_for("") if e["lane"] == UNDER_LOAD_LANE]
         assert under == expected
+
+    def test_under_load_is_split_into_multiple_shards(self) -> None:
+        # #2683: under_load's roster-spawning scenarios are 10-45 min each, so the
+        # lane must split into multiple shards, never run as one 1/1 leg.
+        under = [e for e in _matrix_for("") if e["lane"] == UNDER_LOAD_LANE]
+        assert len(under) > 1, "under_load must be sharded (roster-spawning scenarios), not one 1/1 leg."
 
     def test_clean_room_is_split_into_multiple_shards(self) -> None:
         clean = [e for e in _matrix_for("") if e["lane"] == CLEAN_ROOM_LANE]
@@ -81,7 +87,7 @@ class TestMatrixFor:
         for entry in _matrix_for(""):
             lane_specs = [s for s in specs if s.lane == entry["lane"]]
             shard_specs = filter_specs_by_shard(lane_specs, entry["shard"])
-            assert len(shard_specs) <= MAX_SCENARIOS_PER_SHARD
+            assert len(shard_specs) <= max_scenarios_per_shard(entry["lane"])
 
 
 class TestMain:

--- a/tests/eval_replay/test_lane_shard.py
+++ b/tests/eval_replay/test_lane_shard.py
@@ -1,13 +1,20 @@
-"""Each emitted metered-eval leg meters a budget-safe shard (souliane/teatree#2492).
+"""Each emitted metered-eval leg meters a budget-safe shard (souliane/teatree#2492, #2683).
 
-The catalog is NOT evenly split across lanes — clean_room is 167 scenarios,
-under_load is 14 — so fanning out one leg per *lane* leaves a 167-scenario
+The catalog is NOT evenly split across lanes — clean_room is ~182 scenarios,
+under_load is 14 — so fanning out one leg per *lane* leaves a 182-scenario
 clean_room leg that hits the same 80min wall the full suite did. The fix shards
-each lane into contiguous slices of at most :data:`MAX_SCENARIOS_PER_SHARD`
-scenarios. These tests pin the two structural invariants that keep the fix
-honest: every emitted shard is within the budget-safe bound, AND the shards are a
+each lane into contiguous slices of at most the lane's per-scenario-cost-aware
+ceiling. These tests pin the structural invariants that keep the fix honest:
+every emitted shard is within its lane's budget-safe bound, AND the shards are a
 clean partition of the lane (every scenario in exactly one shard, none dropped or
 duplicated).
+
+The two lanes have wildly different per-scenario cost (#2683): a clean_room
+scenario loads ONE skill into an empty context (seconds-to-a-minute), but an
+under_load scenario loads the FULL skill bundle, a polluted context preamble, and
+spawns a multi-agent roster — 10-45 minutes per scenario at 3 trials. So the
+per-shard ceiling is LANE-AWARE: clean_room keeps the 14 ceiling, under_load
+drops to a much smaller one so a roster-spawning shard fits the 80min cap.
 """
 
 from pathlib import Path
@@ -17,9 +24,11 @@ import pytest
 from teatree.eval.discovery import discover_specs
 from teatree.eval.lane_shard import (
     MAX_SCENARIOS_PER_SHARD,
+    UNDER_LOAD_MAX_SCENARIOS_PER_SHARD,
     LaneShard,
     ShardSpecError,
     filter_specs_by_shard,
+    max_scenarios_per_shard,
     parse_shard,
     plan_lane_shards,
     shard_count_for,
@@ -59,6 +68,21 @@ class TestParseShard:
             parse_shard(bad)
 
 
+class TestMaxScenariosPerShard:
+    def test_clean_room_keeps_the_default_ceiling(self) -> None:
+        assert max_scenarios_per_shard(CLEAN_ROOM_LANE) == MAX_SCENARIOS_PER_SHARD == 14
+
+    def test_under_load_has_a_smaller_roster_aware_ceiling(self) -> None:
+        # under_load scenarios spawn multi-agent rosters (10-45 min each at 3
+        # trials), so the lane's per-shard ceiling is much smaller than clean_room's
+        # — otherwise a single under_load shard blows the 80min cap (#2683).
+        assert max_scenarios_per_shard(UNDER_LOAD_LANE) == UNDER_LOAD_MAX_SCENARIOS_PER_SHARD
+        assert UNDER_LOAD_MAX_SCENARIOS_PER_SHARD < MAX_SCENARIOS_PER_SHARD
+
+    def test_unknown_lane_falls_back_to_the_default_ceiling(self) -> None:
+        assert max_scenarios_per_shard("some_future_lane") == MAX_SCENARIOS_PER_SHARD
+
+
 class TestShardCountFor:
     def test_at_or_below_bound_is_one_shard(self) -> None:
         assert shard_count_for(0) == 1
@@ -68,6 +92,13 @@ class TestShardCountFor:
     def test_above_bound_splits(self) -> None:
         assert shard_count_for(MAX_SCENARIOS_PER_SHARD + 1) == 2
         assert shard_count_for(167) == 12  # ceil(167 / 14)
+
+    def test_under_load_lane_uses_the_smaller_ceiling(self) -> None:
+        # 14 under_load scenarios over the smaller ceiling → several shards, not one.
+        bound = UNDER_LOAD_MAX_SCENARIOS_PER_SHARD
+        assert shard_count_for(bound, UNDER_LOAD_LANE) == 1
+        assert shard_count_for(bound + 1, UNDER_LOAD_LANE) == 2
+        assert shard_count_for(14, UNDER_LOAD_LANE) > 1
 
 
 class TestFilterSpecsByShard:
@@ -101,9 +132,20 @@ class TestFilterSpecsByShard:
 
 class TestPlanLaneShards:
     def test_lane_at_or_below_bound_is_a_single_leg(self) -> None:
-        specs = [_spec(f"s{n}", UNDER_LOAD_LANE) for n in range(MAX_SCENARIOS_PER_SHARD)]
+        specs = [_spec(f"s{n}", CLEAN_ROOM_LANE) for n in range(MAX_SCENARIOS_PER_SHARD)]
+        legs = plan_lane_shards(specs, [CLEAN_ROOM_LANE])
+        assert legs == [LaneShard(lane=CLEAN_ROOM_LANE, index=1, total=1)]
+
+    def test_under_load_lane_splits_on_its_smaller_ceiling(self) -> None:
+        # 14 roster-spawning under_load scenarios must split into multiple shards on
+        # the lane's smaller ceiling — the regression #2683 fixes (the lane ran as a
+        # single 1/1 leg and hit the 80min cap).
+        specs = [_spec(f"s{n:02d}", UNDER_LOAD_LANE) for n in range(14)]
         legs = plan_lane_shards(specs, [UNDER_LOAD_LANE])
-        assert legs == [LaneShard(lane=UNDER_LOAD_LANE, index=1, total=1)]
+        assert len(legs) > 1, "under_load (14 roster-spawning scenarios) must shard, not run as one leg."
+        for leg in legs:
+            shard_specs = filter_specs_by_shard(specs, leg.shard)
+            assert len(shard_specs) <= UNDER_LOAD_MAX_SCENARIOS_PER_SHARD
 
     def test_large_lane_splits_into_enough_shards(self) -> None:
         specs = [_spec(f"s{n:03d}") for n in range(167)]
@@ -124,11 +166,13 @@ class TestPlanLaneShards:
 
 
 class TestEveryEmittedLegFitsTheBudget:
-    """The blocking-finding fix: NO emitted job exceeds the budget-safe bound.
+    """The blocking-finding fix: NO emitted job exceeds its lane's budget-safe bound.
 
-    Run against the LIVE catalog (181 = clean_room 167 / under_load 14) so the
-    test goes RED the moment the catalog grows past what the bound allows without
-    the matrix re-sharding — exactly the silent budget-degrade #2492 warns about.
+    Run against the LIVE catalog (~196 = clean_room ~182 / under_load 14) so the
+    test goes RED the moment the catalog grows past a lane's bound without the
+    matrix re-sharding — exactly the silent budget-degrade #2492 warns about. The
+    bound is LANE-AWARE (#2683): under_load's roster-spawning scenarios use a much
+    smaller ceiling than clean_room's.
     """
 
     def test_no_emitted_shard_exceeds_the_budget_safe_bound(self) -> None:
@@ -137,9 +181,10 @@ class TestEveryEmittedLegFitsTheBudget:
         for leg in legs:
             lane_specs = [spec for spec in specs if spec.lane == leg.lane]
             shard_specs = filter_specs_by_shard(lane_specs, leg.shard)
-            assert len(shard_specs) <= MAX_SCENARIOS_PER_SHARD, (
+            bound = max_scenarios_per_shard(leg.lane)
+            assert len(shard_specs) <= bound, (
                 f"leg {leg.lane} {leg.shard} meters {len(shard_specs)} scenarios, over the "
-                f"budget-safe bound {MAX_SCENARIOS_PER_SHARD}; re-shard the lane in lane_matrix.py."
+                f"lane's budget-safe bound {bound}; re-shard the lane in lane_matrix.py."
             )
 
     @pytest.mark.parametrize("lane", sorted(PERMITTED_LANES))
@@ -159,4 +204,11 @@ class TestEveryEmittedLegFitsTheBudget:
         # dominant lane (~92% of the catalog) and MUST be split, not emitted as one
         # giant leg.
         legs = plan_lane_shards(discover_specs(), [CLEAN_ROOM_LANE])
-        assert len(legs) > 1, "clean_room (the dominant ~167-scenario lane) must be sharded, not one leg."
+        assert len(legs) > 1, "clean_room (the dominant ~182-scenario lane) must be sharded, not one leg."
+
+    def test_the_under_load_lane_is_actually_split(self) -> None:
+        # Guard the #2683 regression: under_load's roster-spawning scenarios are
+        # 10-45 min each, so the lane MUST split into multiple shards rather than run
+        # as one 1/1 leg that hits the 80min cap (run 27995563148).
+        legs = plan_lane_shards(discover_specs(), [UNDER_LOAD_LANE])
+        assert len(legs) > 1, "under_load (roster-spawning, 10-45 min/scenario) must be sharded, not one 1/1 leg."

--- a/tests/test_eval_ci_require_executed_gate.py
+++ b/tests/test_eval_ci_require_executed_gate.py
@@ -161,9 +161,10 @@ class TestGitHubScheduledGuardManualUnguarded:
         )
 
     def test_eval_fans_out_one_lane_shard_per_matrix_leg(self) -> None:
-        # #2492: the full 181-scenario suite does not fit the 2x80min budget, and a
-        # single 167-scenario clean_room leg hits the same wall, so each matrix leg
-        # meters ONE {lane, shard} (from the prepare job's validated plan).
+        # #2492/#2683: the full ~196-scenario suite does not fit the 2x80min budget,
+        # and BOTH a single ~182-scenario clean_room leg AND a single under_load 1/1
+        # leg hit the same wall, so each matrix leg meters ONE {lane, shard} (from
+        # the prepare job's validated plan, lane-aware ceiling).
         jobs = cast("dict[str, Any]", yaml.safe_load(_GH_EVAL.read_text(encoding="utf-8"))["jobs"])
         matrix = cast("dict[str, Any]", jobs["eval"]["strategy"]["matrix"])
         assert "include" in matrix, "The eval job must fan out over a {lane, shard} include matrix."
@@ -180,29 +181,40 @@ class TestGitHubScheduledGuardManualUnguarded:
 
     def test_each_emitted_leg_meters_a_budget_safe_scenario_count(self) -> None:
         # The blocking-finding fix: the matrix lane_matrix.py emits must bound EVERY
-        # leg's scenario count to the budget-safe ceiling — not just under_load.
-        # Computed against the LIVE catalog the workflow runs, so a catalog that
-        # grows past the bound without re-sharding turns this RED.
+        # leg's scenario count to its lane's budget-safe ceiling — not just
+        # clean_room. The ceiling is LANE-AWARE (#2683): under_load's roster-
+        # spawning scenarios (10-45 min each) get a much smaller ceiling than
+        # clean_room's. Computed against the LIVE catalog the workflow runs, so a
+        # catalog that grows past a lane's bound without re-sharding turns this RED.
         from teatree.eval.discovery import discover_specs  # noqa: PLC0415
         from teatree.eval.lane_shard import (  # noqa: PLC0415
-            MAX_SCENARIOS_PER_SHARD,
             filter_specs_by_shard,
+            max_scenarios_per_shard,
             plan_lane_shards,
         )
-        from teatree.eval.models import PERMITTED_LANES  # noqa: PLC0415
+        from teatree.eval.models import PERMITTED_LANES, UNDER_LOAD_LANE  # noqa: PLC0415
 
         specs = discover_specs()
         legs = plan_lane_shards(specs, sorted(PERMITTED_LANES))
-        assert len(legs) > len(PERMITTED_LANES), (
-            "the dominant clean_room lane (~167 scenarios) must be split into multiple shards, "
-            "not emitted as one giant per-lane leg (the cold-review blocking finding)."
+        # BOTH lanes must split: clean_room (~182, the cold-review finding) AND
+        # under_load (roster-spawning, the 80min-cap finding #2683). Each permitted
+        # lane therefore contributes more than one leg, so the total exceeds 2x the
+        # lane count.
+        assert len(legs) > 2 * len(PERMITTED_LANES), (
+            "every permitted lane must split into multiple shards: clean_room (~182 scenarios) "
+            "and under_load (roster-spawning, 10-45 min/scenario, #2683), not one leg each."
+        )
+        assert sum(1 for leg in legs if leg.lane == UNDER_LOAD_LANE) > 1, (
+            "under_load must be sharded into multiple legs (#2683), not run as a single 1/1 leg "
+            "that hits the 80min step cap."
         )
         for leg in legs:
             lane_specs = [s for s in specs if s.lane == leg.lane]
             shard_specs = filter_specs_by_shard(lane_specs, leg.shard)
-            assert len(shard_specs) <= MAX_SCENARIOS_PER_SHARD, (
+            bound = max_scenarios_per_shard(leg.lane)
+            assert len(shard_specs) <= bound, (
                 f"emitted leg {leg.lane} {leg.shard} meters {len(shard_specs)} scenarios, over the "
-                f"budget-safe bound {MAX_SCENARIOS_PER_SHARD}."
+                f"lane's budget-safe bound {bound}."
             )
 
 


### PR DESCRIPTION
## What

The "Metered eval" workflow sharded the `clean_room` lane into 13 parallel legs but ran the `under_load` lane as a single `1/1` leg. In run [27995563148](https://github.com/souliane/teatree/actions/runs/27995563148) that `under_load (1/1)` job hit the 80-min step cap (the 4800000ms timeout) and failed RED.

This makes the per-shard scenario ceiling **lane-aware**:

- `clean_room` keeps `MAX_SCENARIOS_PER_SHARD = 14` → ~182 scenarios → 13 shards (unchanged).
- `under_load` gets a new, smaller `UNDER_LOAD_MAX_SCENARIOS_PER_SHARD = 4` → 14 scenarios → **4 parallel shards** instead of one.

The matrix now expands to 17 legs (13 `clean_room` + 4 `under_load`), each within its lane's budget.

## Why

The two lanes have wildly different per-scenario cost, so a single flat ceiling cannot be budget-safe for both:

- A `clean_room` scenario loads **one** skill into an empty context — seconds-to-a-minute even at 3 trials.
- An `under_load` scenario loads the **full** skill bundle, an 8k-20k-token polluted context preamble, **and** spawns a multi-agent roster — **10-45 minutes** per scenario at 3 trials.

Run 27995563148 proved 14 `under_load` scenarios cannot fit one `2 x 80min` leg: 11 of them already burned 70 min, and `full_speed_fans_out_parallel_workers_not_serial` alone took 45 min. The `14` ceiling was calibrated on the fast lane; it was never budget-safe for the slow one. A `4` ceiling keeps a shard's wall-clock comfortably under 80 min even when the 45-min roster scenario shares a shard with three short ones.

## Approach: shard, don't just raise the timeout

Sharding is the robust fix (parallel wall-clock + per-shard isolation of a red verdict); raising the step timeout alone would serialize 14 slow scenarios into one ~2-3h leg with no parallelism and a single point of failure. The `180min` job timeout is **kept** — sharding alone resolves the overrun.

The change lives in the single planning chokepoint `teatree.eval.lane_shard`: `shard_count_for` and `plan_lane_shards` resolve a lane's ceiling through the new `max_scenarios_per_shard(lane)`. The runner's `--lane`/`--shard` flags and the CI matrix both resolve through `filter_specs_by_shard` unchanged — confirmed the runner consumes the matrix's `index/total` shard token the same way — so **no runner change** is needed and the `clean_room` matrix is untouched.

## Tests

TDD: the regression was observed RED (under_load planned as a single `1/1` leg, ceiling reverted to 14) before the fix and GREEN after.

- `tests/eval_replay/test_lane_shard.py` — `max_scenarios_per_shard`, lane-aware `shard_count_for`, `plan_lane_shards` splits under_load into multiple shards.
- `tests/eval_replay/test_lane_matrix.py` — emitted matrix splits under_load; every leg within its lane's bound.
- `tests/test_eval_ci_require_executed_gate.py` — the CI-YAML budget invariant now asserts EVERY emitted leg (both lanes) is within its lane's per-shard ceiling, and that under_load contributes more than one leg.

63 touched tests pass; `ruff` / `ty` / `tach` clean; workflow YAML parses and the matrix expands to 17 legs.

## Note (unrelated, pre-existing)

Two failures in `tests/eval_replay/test_regression_corpus.py` (`migration-fork / multiple-leaf-nodes`) reproduce on pristine `origin/main` and are unrelated to this change (no migrations touched here) — they look like two concurrent migration leaf nodes from parallel PRs on main, and should be fixed separately.

Closes #2683
