### PR TITLE
fix(test-plan): emit per-workflow How-to-test steps in the link-api template (#2645)

### DIFF
--- a/src/teatree/core/management/commands/_test_plan_render.py
+++ b/src/teatree/core/management/commands/_test_plan_render.py
@@ -562,10 +562,11 @@ def _render_browser_click_first(state: TestPlanState) -> list[str]:
 
 
 def _render_link_api(state: TestPlanState) -> list[str]:
-    """``link-api`` template: link_md + code_md per workflow, no table, no images."""
+    """``link-api`` template: How-to-test steps then link_md + code_md per workflow, no table, no images."""
     lines: list[str] = []
     for workflow in _workflow_names(state):
         lines.extend((f"### {workflow}", ""))
+        lines.extend(_test_plan_block(state, workflow))
         for side in (state["dev"], state["local"]):
             embed = side.get("workflows", {}).get(workflow, {})
             link_md = embed.get("link_md", "") if embed else ""

--- a/tests/teatree_core/e2e_command/test_post_test_plan.py
+++ b/tests/teatree_core/e2e_command/test_post_test_plan.py
@@ -1353,6 +1353,78 @@ class TestLinkApiTemplate(TestCase):
         assert "| Dev | Local |" not in body
 
 
+class TestLinkApiStepsRendered(TestCase):
+    """A steps-only ``link-api`` manifest (steps, no link/code embeds) must render the steps."""
+
+    def _steps_only_state(self) -> _render.TestPlanState:
+        return {
+            "ticket": "8521",
+            "title": "API check",
+            "mrs": [],
+            "dev": _empty_side(env="dev"),
+            "local": {"commits": {"client": "aabb"}, "workflows": {}},
+            "steps": {"Create user": ["POST /users", "Assert 201", "GET /users/1"]},
+            "template": "link-api",
+        }
+
+    def test_renders_how_to_test_steps_when_no_media(self) -> None:
+        body = _render.render_body(self._steps_only_state())
+        visible = body.split("-->")[-1]
+        assert "### Create user" in visible
+        assert "**How to test:**" in visible
+        assert "1. POST /users" in visible
+        assert "2. Assert 201" in visible
+        assert "3. GET /users/1" in visible
+
+    def test_renders_steps_via_production_path(self) -> None:
+        manifest = _render.parse_manifest(
+            json.dumps(
+                {
+                    "ticket": "8521",
+                    "template": "link-api",
+                    "local": {"commits": {"client": "aabb"}},
+                    "workflows": [{"workflow": "Create user", "steps": ["POST /users", "Assert 201"]}],
+                }
+            )
+        )
+        merged = _render.merge_state(
+            _render.empty_state(ticket="8521", title="t"),
+            manifest=manifest,
+            title="API check",
+            embeds={"dev": {}, "local": {}},
+        )
+        body = _render.render_body(merged)
+        visible = body.split("-->")[-1]
+        assert "### Create user" in visible
+        assert "1. POST /users" in visible
+        assert "2. Assert 201" in visible
+
+    def test_renders_steps_alongside_link_and_code(self) -> None:
+        state: _render.TestPlanState = {
+            "ticket": "8521",
+            "title": "API check",
+            "mrs": [],
+            "dev": _empty_side(env="dev"),
+            "local": _local_side(
+                {
+                    "Create user": {
+                        "video_md": "",
+                        "image_md": [],
+                        "link_md": "[POST /users](https://gitlab.com/org/repo/-/issues/8521)",
+                        "code_md": '```json\n{"id": 1}\n```',
+                    }
+                }
+            ),
+            "steps": {"Create user": ["POST /users", "Assert 201"]},
+            "template": "link-api",
+        }
+        body = _render.render_body(state)
+        visible = body.split("-->")[-1]
+        assert "1. POST /users" in visible
+        assert "[POST /users]" in visible
+        assert "```json" in visible
+
+
 class TestNeverEmptyRender(TestCase):
     def test_raises_on_empty_state(self) -> None:
         state: _render.TestPlanState = {


### PR DESCRIPTION
fix(test-plan): emit per-workflow How-to-test steps in the link-api template (#2645)

The link-api template rendered only each workflow's link_md/code_md, so a steps-only manifest (steps, no media, the natural backend/API-flow shape) produced empty workflow bodies. Reuse the shared _test_plan_block helper, as _workflow_table already does, to emit the numbered How-to-test list right after the heading.

## What
`_render_link_api` now reuses the shared `_test_plan_block` helper (as `_workflow_table` already does), so each workflow emits its numbered "How to test:" list right after the heading.

## Why
A steps-only `link-api` manifest (per-workflow `steps`, no media — the natural backend/API-flow shape) previously rendered empty workflow bodies: the template emitted only `link_md`/`code_md`, so the persisted steps were never shown.

## How to test
`tests/teatree_core/e2e_command/test_post_test_plan.py` adds a regression test asserting a steps-only `link-api` manifest now renders the `**How to test:**` block. Run: `uv run pytest tests/teatree_core/e2e_command/test_post_test_plan.py`.

Open questions & assumptions:
- none

docs: n/a — bug fix restoring intended template output; no command/flag/setting/skill change.

Closes #2645
