### PR TITLE
fix(merge): auto-tear-down worktree on keystone merge success

### DIFF
--- a/src/teatree/core/signals.py
+++ b/src/teatree/core/signals.py
@@ -27,6 +27,17 @@ _TICKET_TRANSITION_TASKS: dict[str, str] = {
     "retrospect": "execute_retrospect",
 }
 
+# Transitions whose teardown is provably-merged and may force-bypass the #706
+# unsynced-commit guard. ``reconcile_merged`` is fired ONLY by the merge keystone
+# (``merge.execution.record_merge_and_advance``) AFTER the irreversible forge
+# merge confirmed — a squash-merge lands a new SHA on main and deletes the source
+# ref, leaving the local branch reading as "on no remote", so a non-force
+# teardown would refuse and strand the worktree. ``mark_merged`` is intentionally
+# excluded: it can advance the FSM to MERGED without a confirmed forge merge
+# (manual advance, async ship never drained #707/#708), so its teardown keeps the
+# data-loss guard on.
+_FORCE_TEARDOWN_TRANSITIONS: frozenset[str] = frozenset({"reconcile_merged"})
+
 _WORKTREE_TRANSITION_TASKS: dict[str, str] = {
     "provision": "execute_worktree_provision",
     "start_services": "execute_worktree_start",
@@ -236,7 +247,14 @@ def _enqueue_ticket_transition_task(
 
     executor = getattr(tasks_mod, executor_name)
     ticket_pk = int(instance.pk)
-    transaction.on_commit(lambda: executor.enqueue(ticket_pk))
+    if name in _FORCE_TEARDOWN_TRANSITIONS:
+        # The keystone-confirmed merge path force-bypasses the #706 unsynced
+        # guard so a squash-merged/deleted-remote branch never strands the
+        # worktree. The recovery-capture backstop (#835/#1506) still protects
+        # any genuine work-to-lose under force.
+        transaction.on_commit(lambda: executor.enqueue(ticket_pk, force=True))
+    else:
+        transaction.on_commit(lambda: executor.enqueue(ticket_pk))
 
 
 def _enqueue_worktree_transition_task(

--- a/src/teatree/core/tasks.py
+++ b/src/teatree/core/tasks.py
@@ -201,7 +201,7 @@ def execute_retrospect(ticket_id: int) -> TransitionResult:
 
 
 @task()
-def execute_teardown(ticket_id: int) -> TransitionResult:
+def execute_teardown(ticket_id: int, *, force: bool = False) -> TransitionResult:
     """Tear down worktrees for a MERGED ticket.
 
     Idempotency: the worker takes a row lock and re-checks state before running.
@@ -212,6 +212,18 @@ def execute_teardown(ticket_id: int) -> TransitionResult:
     detail but do not advance the ticket. The ticket stays in MERGED until
     the operator either fixes the underlying issue and re-enqueues, or moves
     on with ``retrospect()`` once the residual state is acceptable.
+
+    ``force`` controls the #706 unsynced-commit data-loss guard. The default
+    ``False`` keeps the guard on for the ``mark_merged`` path — the FSM can read
+    MERGED there without a confirmed forge merge (a manual advance, or async ship
+    that never drained #707/#708), so a branch with commits on no remote must not
+    be destroyed. The merge keystone fires this with ``force=True`` (from
+    ``reconcile_merged``): the PR merge is provably confirmed on the forge before
+    the FSM reaches MERGED, so a squash-merge that landed a new SHA on main and
+    deleted the source ref — leaving the local branch reading as "on no remote" —
+    must not block cleanup. The #835/#1506 recovery-capture backstop still runs
+    under force, so even the bypass captures a restorable bundle before the
+    destructive remove.
     """
     with transaction.atomic():
         ticket = Ticket.objects.select_for_update().get(pk=ticket_id)
@@ -223,7 +235,7 @@ def execute_teardown(ticket_id: int) -> TransitionResult:
             )
             return {"ticket_id": ticket_id, "skipped": True, "state": str(ticket.state)}
 
-        result = WorktreeTeardown(ticket).run()
+        result = WorktreeTeardown(ticket, force=force).run()
         if not result.ok:
             logger.warning("Teardown reported errors for ticket %s: %s", ticket_id, result.detail)
             return {"ticket_id": ticket_id, "ok": False, "detail": result.detail}

--- a/tests/teatree_core/test_merge_execution.py
+++ b/tests/teatree_core/test_merge_execution.py
@@ -8,12 +8,15 @@ teatree model / FSM / DB write is real.
 """
 
 import json
+import shutil
+import subprocess
 from collections.abc import Callable
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from django.db import OperationalError
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from teatree.core.merge import (
@@ -29,7 +32,20 @@ from teatree.core.merge import (
     merge_ticket_pr,
     record_merge_and_advance,
 )
-from teatree.core.models import ClearRequest, MergeAudit, MergeClear, Session, Ticket
+from teatree.core.models import ClearRequest, MergeAudit, MergeClear, Session, Ticket, Worktree
+from tests.teatree_core.conftest import CommandOverlay
+
+_GIT = shutil.which("git") or "git"
+
+_IMMEDIATE_BACKEND = {
+    "TASKS": {
+        "default": {
+            "BACKEND": "django_tasks.backends.immediate.ImmediateBackend",
+        },
+    },
+}
+
+_MOCK_OVERLAY = {"t3-teatree": CommandOverlay()}
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
@@ -1111,3 +1127,127 @@ class TestTransientMergeRetry(TestCase):
             execute_bound_merge(slug="souliane/teatree", pr_id=859, expected_head_oid=_SHA)
 
         assert attempts["merge"] >= 3, "an empty/truncated merge response was not retried"
+
+
+def _run_git(*args: str, cwd: Path) -> None:
+    subprocess.run([_GIT, "-C", str(cwd), *args], check=True, capture_output=True)
+
+
+class TestMergeKeystoneTearsDownWorktree(TestCase):
+    """A successful ``ticket merge`` automatically tears down the ticket's worktree(s).
+
+    Post-merge teardown must never be a manual step: when the §17.4 keystone
+    advances the Ticket FSM to MERGED, the ``post_transition`` receiver enqueues
+    ``execute_teardown`` which removes the git worktree, deletes the branch,
+    drops the per-worktree DB, and reaps the Worktree row.
+
+    The shape modelled here is the real post-squash-merge state: the source
+    branch carries commits on NO remote (a squash-merge lands a new SHA on main
+    and the forge deletes the source ref), so the #706 data-loss guard would
+    refuse a plain teardown. Because the work is provably merged at this point,
+    the keystone tears down with the force-equivalent bypass so the
+    squash-merged/deleted-remote branch never blocks cleanup. Best-effort: a
+    teardown that errors must never fail or roll back the already-successful
+    merge.
+
+    Only the ``gh`` merge subprocess is stubbed; the git worktree, the FSM, the
+    signal wiring, and the teardown worker are all real.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _tmp_workspace(self, tmp_path: Path) -> None:
+        self.workspace = tmp_path / "workspace"
+        self.workspace.mkdir()
+        # Bare repo acts as the shared remote (origin).
+        self.remote = tmp_path / "remote.git"
+        self.remote.mkdir()
+        _run_git("init", "-q", "--bare", "-b", "main", cwd=self.remote)
+
+        # Mirror the real layout: the source clone lives at
+        # ``$T3_WORKSPACE_DIR/souliane/teatree`` (matching the ``repo_path``).
+        self.repo_main = self.workspace / "souliane" / "teatree"
+        self.repo_main.mkdir(parents=True)
+        _run_git("init", "-q", "-b", "main", cwd=self.repo_main)
+        _run_git("config", "user.email", "t@t", cwd=self.repo_main)
+        _run_git("config", "user.name", "t", cwd=self.repo_main)
+        _run_git("remote", "add", "origin", str(self.remote), cwd=self.repo_main)
+        _run_git("commit", "--allow-empty", "-q", "-m", "initial", cwd=self.repo_main)
+        _run_git("push", "-q", "origin", "main", cwd=self.repo_main)
+        _run_git("fetch", "-q", "origin", cwd=self.repo_main)
+
+        self.branch = "ac-teatree-859-merge"
+        self.wt_path = self.workspace / self.branch / "teatree"
+        _run_git("worktree", "add", "-q", "-b", self.branch, str(self.wt_path), cwd=self.repo_main)
+        # The post-squash-merge shape: a commit on the branch that exists on NO
+        # remote (the source ref was deleted by the forge after the squash-merge).
+        (self.wt_path / "file.txt").write_text("merged work", encoding="utf-8")
+        _run_git("add", "file.txt", cwd=self.wt_path)
+        _run_git("config", "user.email", "t@t", cwd=self.wt_path)
+        _run_git("config", "user.name", "t", cwd=self.wt_path)
+        _run_git("commit", "-q", "-m", "merged work", cwd=self.wt_path)
+
+    def _merged_ticket_with_worktree(self) -> Ticket:
+        ticket = Ticket.objects.create(
+            overlay="t3-teatree",
+            issue_url="https://github.com/souliane/teatree/issues/859",
+            state=Ticket.State.IN_REVIEW,
+        )
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="t3-teatree",
+            repo_path="souliane/teatree",
+            branch=self.branch,
+            extra={"worktree_path": str(self.wt_path)},
+        )
+        return ticket
+
+    def _merge(self, clear: MergeClear) -> MergeOutcome:
+        # ``execute_teardown`` is enqueued via ``transaction.on_commit`` in the
+        # post_transition receiver, so under ``TestCase``'s outer transaction the
+        # callback only fires inside ``captureOnCommitCallbacks(execute=True)``.
+        with (
+            override_settings(**_IMMEDIATE_BACKEND),
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.cleanup.load_config") as cleanup_config,
+            patch("teatree.core.cleanup.get_overlay_for_worktree") as cleanup_overlay,
+            patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_GhStub()),
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            cleanup_config.return_value.user.workspace_dir = self.workspace
+            cleanup_overlay.return_value.get_cleanup_steps.return_value = []
+            cleanup_overlay.return_value.config.teardown_removes_pass_entries = False
+            return merge_ticket_pr(clear=clear, executing_loop_identity="merge-loop")
+
+    def test_successful_merge_tears_down_the_worktree(self) -> None:
+        ticket = self._merged_ticket_with_worktree()
+        clear = _clear(ticket, slug="souliane/teatree")
+
+        outcome = self._merge(clear)
+
+        ticket.refresh_from_db()
+        assert outcome.ticket_state == Ticket.State.MERGED
+        assert ticket.state == Ticket.State.MERGED
+        # The git worktree is gone from disk and the Worktree row is reaped.
+        assert not self.wt_path.exists(), "the merged ticket's git worktree was not torn down"
+        assert not Worktree.objects.filter(branch=self.branch).exists()
+
+    def test_teardown_error_does_not_fail_the_merge(self) -> None:
+        # Best-effort: a teardown step that errors (a DB drop timeout, an overlay
+        # cleanup hook failure) must NEVER fail or roll back the already-successful
+        # merge — the ticket stays MERGED and the merge outcome stands.
+        ticket = self._merged_ticket_with_worktree()
+        clear = _clear(ticket, slug="souliane/teatree")
+
+        with patch(
+            "teatree.core.cleanup._drop_worktree_db",
+            side_effect=lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("dropdb timed out")),
+        ):
+            outcome = self._merge(clear)
+
+        ticket.refresh_from_db()
+        clear.refresh_from_db()
+        # The merge succeeded and stands despite the teardown step error.
+        assert outcome.ticket_state == Ticket.State.MERGED
+        assert ticket.state == Ticket.State.MERGED
+        assert clear.consumed_at is not None
+        assert MergeAudit.objects.filter(clear=clear).exists()

--- a/tests/teatree_core/test_signals.py
+++ b/tests/teatree_core/test_signals.py
@@ -510,3 +510,37 @@ class TestLogTicketTransitionFaultIsolation(TestCase):
             ticket.save()
 
         assert any("audit table gone" in line for line in captured.output)
+
+
+class TestTeardownForceThreadedByTransition(TestCase):
+    """The keystone-merge teardown force-bypasses the #706 guard; ``mark_merged`` does not.
+
+    The post_transition receiver maps both ``mark_merged`` and ``reconcile_merged``
+    to ``execute_teardown``. Only ``reconcile_merged`` — fired exclusively by the
+    merge keystone after the forge confirmed the merge — may force-bypass the
+    unsynced-commit guard so a squash-merged/deleted-remote branch never strands
+    the worktree. ``mark_merged`` can advance the FSM to MERGED without a confirmed
+    forge merge (manual advance, async ship never drained #707/#708), so it keeps
+    the guard on (``force=False``).
+    """
+
+    def _force_kwarg_for(self, transition_name: str) -> object:
+        import teatree.core.tasks as tasks_mod  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.IN_REVIEW)
+        with (
+            patch.object(tasks_mod, "execute_teardown") as teardown,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            getattr(ticket, transition_name)()
+            ticket.save()
+        teardown.enqueue.assert_called_once()
+        return teardown.enqueue.call_args.kwargs.get("force", "absent")
+
+    def test_reconcile_merged_enqueues_teardown_with_force_true(self) -> None:
+        assert self._force_kwarg_for("reconcile_merged") is True
+
+    def test_mark_merged_enqueues_teardown_with_force_false(self) -> None:
+        # ``mark_merged`` enqueues without ``force=True`` — the data-loss guard
+        # stays on for the non-keystone path.
+        assert self._force_kwarg_for("mark_merged") == "absent"


### PR DESCRIPTION
## Problem
After `t3 teatree ticket merge` (the §17.4 keystone merge), the merged ticket's git worktree was left behind, requiring a manual `worktree teardown --force` afterward — which itself trips the #706 unsynced-commit guard, because a squash-merge lands a new SHA on main and the forge deletes the source branch, so the local commits read as "on no remote".

## Root cause
The merge→teardown wiring already exists: `reconcile_merged` (the keystone's confirmed-merge FSM transition) fires a `post_transition` receiver that enqueues `execute_teardown` via `on_commit`. But it ran `WorktreeTeardown(ticket)` with `force=False`, so `cleanup._raise_if_unpushed` (#706) refused on the merged/deleted-branch shape and stranded the worktree on disk.

## Fix
Thread a `force` flag from the receiver to the worker, scoped to the provably-merged keystone transition only:
- `_FORCE_TEARDOWN_TRANSITIONS = {"reconcile_merged"}` in `signals.py`; that path enqueues `execute_teardown(ticket_pk, force=True)`.
- `mark_merged` is deliberately excluded (it can reach MERGED without a confirmed forge merge — manual advance, or an undrained async ship), so it keeps the #706 guard on.
- The #835/#1506 recovery-capture backstop still bundles a restorable copy before any destructive remove, so genuine work is never silently lost.

## Properties
- Triggers only after the irreversible forge merge + MERGED lands (`reconcile_merged`, post-commit).
- Multi-repo safe (unchanged: iterates `ticket.worktrees.all()`).
- Best-effort: a teardown error returns `ok=False` and logs, but the keystone already committed in a separate transaction — the merge result stands and the ticket stays MERGED. Pinned by a test.
- Idempotent (re-checks `state==MERGED` under `select_for_update`; per-row delete makes re-fire a no-op) and cwd-safe (keystone runs from the primary clone; teardown decoupled via `on_commit`).

## Tests (TDD, anti-vacuous)
`tests/teatree_core/test_merge_execution.py::TestMergeKeystoneTearsDownWorktree` (successful merge tears down the worktree; a teardown error does not fail the merge) and `test_signals.py::TestTeardownForceThreadedByTransition` (force=True only for `reconcile_merged`). Authored RED-first; proven green→red→green on both the force-threading and the teardown-mapping dimensions.
