### PR TITLE
fix(worktree-first): close staged-edit gate gap + content-safe pull_main_clone self-heal (#2614)

### DIFF
--- a/scripts/hooks/refuse-main-clone-commit.sh
+++ b/scripts/hooks/refuse-main-clone-commit.sh
@@ -1,11 +1,24 @@
 #!/usr/bin/env bash
-# Pre-commit hook: enforce worktree-first (#638).
+# Pre-commit hook: enforce worktree-first (#638, staged-edit gap #2614).
 #
 # Refuses a commit when it is attempted from a *main clone* (a checkout
-# whose ``.git`` is a directory) while on a non-default branch. Feature
-# work belongs in a worktree, never in the shared main clone — branches
-# and commits landing there pollute shared state and risk committing to
-# the wrong place. Worktrees (``.git`` is a file) are always allowed.
+# whose ``.git`` is a directory) in either of two worktree-first
+# violations:
+#
+#   1. the clone is on a non-default branch (feature work landing in the
+#      shared clone), or
+#   2. the clone is on the default branch but has *tracked working-tree
+#      changes staged for commit* (the #2614 incident — an agent
+#      ``git add``-staged a hand-edit directly in the managed main clone
+#      while it sat on ``main``; the branch-only gate exited 0 and the
+#      staged edit committed into the shared clone, later leaving a stale
+#      byte-identical duplicate that blocked ``pull_main_clone``).
+#
+# Feature work belongs in a worktree, never in the shared main clone —
+# branches and commits landing there pollute shared state and risk
+# committing to the wrong place. Worktrees (``.git`` is a file) are
+# always allowed, and a clean default-branch tree (the fast-forward
+# merge-keeping flow stages nothing) stays allowed.
 #
 # The default branch is detected from ``origin/HEAD`` so this works for
 # teatree (``main``) and overlays whose default is ``development``
@@ -36,6 +49,19 @@ default_branch=${default_branch:-main}
 if [ "${current}" != "${default_branch}" ]; then
   echo "✗ refuse: main clone is on '${current}' (default is '${default_branch}') — develop in a worktree."
   echo "  Run: t3 <overlay> workspace ticket <issue_url>"
+  echo "  (worktree-first is non-negotiable — see /t3:rules § Worktree-First Work)"
+  exit 1
+fi
+
+# On the default branch but with tracked changes staged for commit: the
+# #2614 staged-edit gap. ``git diff --cached --name-only`` lists paths
+# staged in the index against HEAD; a non-empty list is a tracked
+# working-tree change staged directly in the managed main clone. Refuse
+# independent of branch state — the staged state IS the violation.
+if [ -n "$(git diff --cached --name-only 2>/dev/null)" ]; then
+  echo "✗ refuse: tracked changes are staged directly in the main clone (on '${current}') — develop in a worktree."
+  echo "  Run: t3 <overlay> workspace ticket <issue_url>, move the change there, and discard the staged copy here:"
+  echo "       git restore --staged --worktree -- <path>"
   echo "  (worktree-first is non-negotiable — see /t3:rules § Worktree-First Work)"
   exit 1
 fi

--- a/src/teatree/loop/scanners/pull_main_clone.py
+++ b/src/teatree/loop/scanners/pull_main_clone.py
@@ -19,11 +19,19 @@ the remote — fast-forwards it. An already-current clone is a no-op
 current clone never spams.
 
 The scanner is a strict superset of nothing destructive: it only ever
-``pull --ff-only``. A non-default-branch checkout, a tracked-dirty
-working tree, or a non-fast-forward remote is a *skip with a reason*,
-never a reset / force / stash. This is the same safe primitive as
-:class:`teatree.loop.scanners.self_update.SelfUpdateScanner`; the two
-scanners walk disjoint clone sets (editable installs vs. work-repo
+``pull --ff-only``. A non-default-branch checkout or a non-fast-forward
+remote is a *skip with a reason*, never a reset / force / stash. A
+tracked-dirty working tree is normally a skip too, with ONE content-safe
+exception (#2614): when EVERY dirty path's blob is provably byte-identical
+to ``origin/<default>`` (the change already landed upstream via a proper
+PR — an empty ``git diff origin/<default> -- <path>`` for both the
+worktree and the index), the stale duplicate is auto-discarded and the FF
+pull proceeds. This is data-loss-free by that precondition; any path whose
+blob DIFFERS from origin keeps the whole skip-with-warning — genuine local
+work is never reset, forced, or stashed. This mirrors the prove-then-act
+discipline of :mod:`teatree.cli._update_reconcile` (#2607). It is the same
+safe primitive as :class:`teatree.loop.scanners.self_update.SelfUpdateScanner`;
+the two scanners walk disjoint clone sets (editable installs vs. work-repo
 clones) on independent cadence ledgers.
 
 Decision ladder per clone (per tick):
@@ -32,10 +40,12 @@ Decision ladder per clone (per tick):
 2. repo path missing on disk? → ``failed`` (logged + signal emitted)
 3. ``git fetch origin`` fails? → ``failed``
 4. on a non-default branch? → ``skipped`` (``branch=<name>``)
-5. tracked-dirty working tree? → ``skipped`` (``dirty_tracked``)
-6. up to date already? → ``up_to_date``
-7. ``git pull --ff-only`` advances HEAD? → ``updated``
-8. ``git pull --ff-only`` refuses (non-ff divergence)? → ``failed``
+5. tracked-dirty working tree, every dirty blob == ``origin/<default>``?
+    → auto-discard the stale duplicate(s), then fall through (#2614 self-heal)
+6. tracked-dirty working tree, any dirty blob differs? → ``skipped`` (``dirty_tracked``)
+7. up to date already? → ``up_to_date``
+8. ``git pull --ff-only`` advances HEAD? → ``updated``
+9. ``git pull --ff-only`` refuses (non-ff divergence)? → ``failed``
 
 The post-pass :class:`PullMainCloneMarker` row records the outcome + the
 new HEAD SHA so the cadence gate can short-circuit cheaply on the next
@@ -211,6 +221,9 @@ def _pre_pull_gate(*, repo: Path, pre_sha: str) -> _PullOutcome | None:
         )
     dirty = _tracked_dirty_paths(repo)
     if dirty:
+        if _all_dirty_blobs_match_origin(repo=repo, default_branch=default_branch, dirty=dirty):
+            _discard_paths(repo=repo, paths=dirty)
+            return None
         return _PullOutcome(
             outcome="skipped",
             reason=f"dirty_tracked:{','.join(dirty)[:80]}",
@@ -243,6 +256,67 @@ def _tracked_dirty_paths(repo: Path) -> list[str]:
     """Return paths with uncommitted *tracked* changes — untracked are not blockers."""
     result = _git(repo, "status", "--porcelain")
     return [line[3:] for line in result.stdout.splitlines() if line and not line.startswith("??")]
+
+
+def _all_dirty_blobs_match_origin(*, repo: Path, default_branch: str, dirty: list[str]) -> bool:
+    """True iff discarding EVERY dirty path is provably data-loss-free vs ``origin/<default>`` (#2614).
+
+    The content-safe self-heal precondition. Discarding a path resets both its
+    working-tree blob and its index blob to HEAD, after which the FF pull advances
+    HEAD to ``origin/<default>``. So discarding is data-loss-free for a path iff
+    every blob it would drop is already either upstream or HEAD-about-to-become-
+    upstream. Concretely, a path qualifies only when BOTH conditions hold.
+
+    Working-tree condition: its working-tree blob is byte-identical to
+    ``origin/<default>`` — the visible content the operator sees is already
+    upstream (an EMPTY ``git diff origin/<default> -- <path>``). This is the
+    issue's named check.
+
+    Index condition: its index blob is byte-identical to ``origin/<default>`` (a
+    staged duplicate — the exact incident shape) OR to HEAD (nothing staged
+    beyond HEAD, i.e. an unstaged-only modification) — so the staged blob, if
+    any, also carries no content that is not already upstream.
+
+    Either condition being indeterminate means the path is NOT provably safe, so
+    the WHOLE set fails and the caller keeps the safe skip — never a partial reset.
+    A ``git diff --quiet`` exit >1 (a git error) is treated as not-clean
+    (fail-closed): an inconclusive content check never authorizes a discard.
+    """
+    target = f"origin/{default_branch}"
+    for path in dirty:
+        worktree_vs_origin = _diff_is_empty(repo, target, path)
+        if not worktree_vs_origin:
+            return False
+        index_vs_origin = _diff_is_empty(repo, target, path, cached=True)
+        index_vs_head = _diff_is_empty(repo, "HEAD", path, cached=True)
+        if not (index_vs_origin or index_vs_head):
+            return False
+    return True
+
+
+def _diff_is_empty(repo: Path, target: str, path: str, *, cached: bool = False) -> bool:
+    """True iff ``git diff --quiet [<--cached>] <target> -- <path>`` reports no diff.
+
+    ``--quiet`` exits 0 == no diff, 1 == diff present, >1 == error. Only a clean
+    exit 0 is treated as an empty diff; a git error (>1) is treated as a present
+    diff so an inconclusive check never authorizes a discard (fail-closed).
+    """
+    args = ["diff", "--quiet"]
+    if cached:
+        args.append("--cached")
+    args += [target, "--", path]
+    return _git(repo, *args).returncode == 0
+
+
+def _discard_paths(*, repo: Path, paths: list[str]) -> None:
+    """Discard staged + working-tree changes for *paths*, restoring them to HEAD.
+
+    Reached ONLY after :func:`_all_dirty_blobs_match_origin` proved every path's
+    blob is byte-identical to ``origin/<default>`` — so the discarded content is
+    already upstream and the ensuing FF pull re-materialises it. Data-loss-free
+    by that precondition; this helper never runs against a differing blob.
+    """
+    _git(repo, "restore", "--staged", "--worktree", "--", *paths)
 
 
 __all__ = ["PullMainCloneScanner"]

--- a/tests/teatree_loop/test_pull_main_clone_scanner.py
+++ b/tests/teatree_loop/test_pull_main_clone_scanner.py
@@ -116,6 +116,42 @@ def _make_tracked_dirty(clone: Path) -> None:
     (clone / "a.txt").write_text("a-modified")
 
 
+def _seed_origin_changing_a_in_second_commit(origin_dir: Path) -> None:
+    """Bare origin whose second commit *changes* ``a.txt`` content.
+
+    Models the #2614 incident's upstream side: a path's new content lands on
+    ``origin/main`` via a proper PR (second commit). A clone parked at the
+    first commit can then carry a dirty working copy of that same path whose
+    blob is byte-identical to the upstream version — a stale duplicate.
+    """
+    env = _git_env()
+    seed = origin_dir.parent / f"_seed_{origin_dir.name}"
+    seed.mkdir()
+    _run("git", "init", "--initial-branch=main", str(seed), cwd=origin_dir.parent, env=env)
+    (seed / "a.txt").write_text("a-original")
+    (seed / "c.txt").write_text("c-original")
+    _run("git", "add", "a.txt", "c.txt", cwd=seed, env=env)
+    _run("git", "commit", "-m", "first", cwd=seed, env=env)
+    (seed / "a.txt").write_text("a-upstream-v2")
+    (seed / "b.txt").write_text("b")
+    _run("git", "add", "a.txt", "b.txt", cwd=seed, env=env)
+    _run("git", "commit", "-m", "second changes a.txt", cwd=seed, env=env)
+    _run("git", "init", "--bare", "--initial-branch=main", str(origin_dir), cwd=origin_dir.parent, env=env)
+    _run("git", "remote", "add", "origin", str(origin_dir), cwd=seed, env=env)
+    _run("git", "push", "-u", "origin", "main", cwd=seed, env=env)
+
+
+def _origin_blob_for(clone: Path, path: str) -> str:
+    """The content ``origin/main`` holds for *path* — the byte-identical target."""
+    env = _git_env()
+    return _run("git", "show", f"origin/main:{path}", cwd=clone, env=env).stdout
+
+
+def _stage_path(clone: Path, path: str) -> None:
+    env = _git_env()
+    _run("git", "add", path, cwd=clone, env=env)
+
+
 def _make_diverged_non_ff(clone: Path) -> str:
     """Put a local commit on the clone's default branch so the pull is non-ff.
 
@@ -136,6 +172,13 @@ def _head_sha(clone: Path) -> str:
     return _run("git", "rev-parse", "HEAD", cwd=clone, env=env).stdout.strip()
 
 
+def _tracked_dirty(clone: Path) -> bool:
+    """True iff the clone has uncommitted *tracked* changes (staged or unstaged)."""
+    env = _git_env()
+    porcelain = _run("git", "status", "--porcelain", cwd=clone, env=env).stdout
+    return any(line and not line.startswith("??") for line in porcelain.splitlines())
+
+
 def _origin_head(origin: Path, parent: Path) -> str:
     return _run("git", "-C", str(origin), "rev-parse", "main", cwd=parent).stdout.strip()
 
@@ -151,6 +194,11 @@ class PullMainCloneScannerBehaviorTests(TestCase):
         self._tmp = Path(self._make_tempdir())
         self.origin = self._tmp / "origin.git"
         _seed_origin_with_two_commits(self.origin)
+        # A second origin whose second commit *changes* a.txt — used by the
+        # #2614 self-heal cases that need an upstream-evolved tracked path.
+        self._tmp_changing = Path(self._make_tempdir())
+        self.origin_changing = self._tmp_changing / "origin.git"
+        _seed_origin_changing_a_in_second_commit(self.origin_changing)
 
     def _make_tempdir(self) -> str:
         d = tempfile.mkdtemp(prefix="pull_main_clone_scanner_")
@@ -202,6 +250,108 @@ class PullMainCloneScannerBehaviorTests(TestCase):
         signal = signals[0]
         assert signal.kind == "pull_main_clone.skipped"
         assert "dirty" in signal.payload["reason"] or "tracked" in signal.payload["reason"]
+
+    def test_byte_identical_dirty_blob_is_auto_healed_then_pulled(self) -> None:
+        """#2614 self-heal: a dirty path whose blob == ``origin/main``'s is discarded, then ff-pulled.
+
+        The stale-duplicate incident — the path's content already merged upstream
+        via a proper PR, leaving the local working copy byte-identical to
+        ``origin/main``. Discarding it is provably data-loss-free (the content is
+        already upstream), so the scanner auto-discards and proceeds with the FF
+        pull instead of skipping the tick forever.
+        """
+        clone = self._tmp_changing / "acme-backend"
+        old_sha = _clone_trailing_by_one_commit(origin=self.origin_changing, clone=clone)
+        # Make a.txt byte-identical to origin/main's version: a stale duplicate.
+        (clone / "a.txt").write_text(_origin_blob_for(clone, "a.txt"))
+        origin_head = _origin_head(self.origin_changing, self._tmp_changing)
+        assert old_sha != origin_head
+
+        signals = self._scanner(repos=[("acme:acme-backend", clone)]).scan()
+
+        assert _head_sha(clone) == origin_head, "scanner did not ff-pull after auto-healing the duplicate"
+        assert not _tracked_dirty(clone), "the stale duplicate was not discarded"
+        assert len(signals) == 1
+        assert signals[0].kind == "pull_main_clone.updated"
+
+    def test_byte_identical_staged_dirty_blob_is_auto_healed_then_pulled(self) -> None:
+        """The exact incident shape — the duplicate was ``git add``-staged, not just unstaged."""
+        clone = self._tmp_changing / "acme-backend"
+        old_sha = _clone_trailing_by_one_commit(origin=self.origin_changing, clone=clone)
+        (clone / "a.txt").write_text(_origin_blob_for(clone, "a.txt"))
+        _stage_path(clone, "a.txt")
+        origin_head = _origin_head(self.origin_changing, self._tmp_changing)
+        assert old_sha != origin_head
+
+        signals = self._scanner(repos=[("acme:acme-backend", clone)]).scan()
+
+        assert _head_sha(clone) == origin_head, "scanner did not ff-pull after auto-healing the staged duplicate"
+        assert not _tracked_dirty(clone), "the staged stale duplicate was not discarded"
+        assert len(signals) == 1
+        assert signals[0].kind == "pull_main_clone.updated"
+
+    def test_genuinely_different_dirty_blob_keeps_skip_and_warning(self) -> None:
+        """A dirty path whose blob DIFFERS from ``origin/main`` keeps the safe skip — never reset.
+
+        The data-loss guard: genuine local work whose content is NOT upstream must
+        be preserved. The scanner skips with the ``dirty_tracked`` warning exactly
+        as before — it never resets, forces, or stashes a differing blob.
+        """
+        clone = self._tmp_changing / "acme-backend"
+        old_sha = _clone_trailing_by_one_commit(origin=self.origin_changing, clone=clone)
+        (clone / "a.txt").write_text("genuine-local-work-not-upstream")
+
+        signals = self._scanner(repos=[("acme:acme-backend", clone)]).scan()
+
+        assert _head_sha(clone) == old_sha, "scanner moved HEAD despite genuine local work"
+        assert (clone / "a.txt").read_text() == "genuine-local-work-not-upstream", "genuine work was clobbered"
+        assert len(signals) == 1
+        signal = signals[0]
+        assert signal.kind == "pull_main_clone.skipped"
+        assert "dirty" in signal.payload["reason"] or "tracked" in signal.payload["reason"]
+
+    def test_mixed_dirty_one_identical_one_genuine_keeps_skip(self) -> None:
+        """A mix — one duplicate path + one genuine path — keeps the safe skip; nothing reset.
+
+        The self-heal acts ONLY when *every* dirty path is provably upstream. A
+        single genuinely-different path keeps the whole skip-with-warning, so the
+        duplicate path is left untouched too — never a partial reset.
+        """
+        clone = self._tmp_changing / "acme-backend"
+        old_sha = _clone_trailing_by_one_commit(origin=self.origin_changing, clone=clone)
+        # a.txt is a byte-identical duplicate of origin/main; c.txt is genuine work.
+        (clone / "a.txt").write_text(_origin_blob_for(clone, "a.txt"))
+        (clone / "c.txt").write_text("genuine-local-edit-not-upstream")
+
+        signals = self._scanner(repos=[("acme:acme-backend", clone)]).scan()
+
+        assert _head_sha(clone) == old_sha, "scanner moved HEAD despite one genuine dirty path"
+        assert (clone / "c.txt").read_text() == "genuine-local-edit-not-upstream", "genuine work was clobbered"
+        assert len(signals) == 1
+        assert signals[0].kind == "pull_main_clone.skipped"
+
+    def test_worktree_matches_origin_but_staged_blob_differs_keeps_skip(self) -> None:
+        """Worktree == origin, but a *staged* blob differs from BOTH origin and HEAD → skip.
+
+        The data-loss edge the index check guards: the visible working-tree blob
+        is byte-identical to ``origin/main``, yet the index carries a third,
+        genuinely-different staged blob. Discarding would drop that staged work,
+        so the self-heal must NOT fire — the whole set keeps the safe skip.
+        """
+        clone = self._tmp_changing / "acme-backend"
+        old_sha = _clone_trailing_by_one_commit(origin=self.origin_changing, clone=clone)
+        # Stage a genuinely-different blob, THEN make the worktree match origin.
+        (clone / "a.txt").write_text("staged-genuine-work-differs-from-everything")
+        _stage_path(clone, "a.txt")
+        (clone / "a.txt").write_text(_origin_blob_for(clone, "a.txt"))
+
+        signals = self._scanner(repos=[("acme:acme-backend", clone)]).scan()
+
+        assert _head_sha(clone) == old_sha, "scanner moved HEAD despite a differing staged blob"
+        index_blob = _run("git", "show", ":a.txt", cwd=clone, env=_git_env()).stdout
+        assert index_blob == "staged-genuine-work-differs-from-everything", "staged work was clobbered"
+        assert len(signals) == 1
+        assert signals[0].kind == "pull_main_clone.skipped"
 
     def test_feature_branch_checkout_is_skipped(self) -> None:
         """A main clone parked on a feature branch is skipped — work-in-flight is sacred."""

--- a/tests/test_refuse_main_clone_commit.py
+++ b/tests/test_refuse_main_clone_commit.py
@@ -82,6 +82,48 @@ class TestRefuseMainCloneCommit:
         assert "worktree" in combined.lower()
         assert "t3" in combined
 
+    def test_refuses_staged_tracked_edit_on_default_branch_in_main_clone(self, tmp_path: Path) -> None:
+        """The #2614 gap: a tracked edit staged on the *default* branch slips the branch-only gate.
+
+        The original incident — an agent ``git add``-staged a hand-edit directly
+        in the managed main clone while it was still on ``main``. The branch-only
+        gate exits 0 because the branch matches the default, so the staged edit
+        commits into the shared clone. The worktree-first invariant must cover the
+        staged state, not just the commit-on-a-feature-branch transition.
+        """
+        repo = _make_main_clone(tmp_path)
+        (repo / "f.txt").write_text("staged-edit", encoding="utf-8")
+        _git(repo, "add", "f.txt")
+
+        result = _run_hook(repo)
+
+        assert result.returncode == 1
+        combined = result.stdout + result.stderr
+        assert "worktree" in combined.lower()
+
+    def test_allows_default_branch_in_main_clone_with_no_staged_changes(self, tmp_path: Path) -> None:
+        """Clean default-branch state stays allowed — only a *staged tracked* change refuses.
+
+        A fast-forward ``git pull`` of the managed main clone (the merge-keeping
+        flow) stages nothing, so the gate must not fire on a clean default-branch
+        tree. Guards against the staged-edit gate over-blocking the legit path.
+        """
+        repo = _make_main_clone(tmp_path)
+        result = _run_hook(repo)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_allows_staged_tracked_edit_in_a_worktree(self, tmp_path: Path) -> None:
+        """A staged tracked edit in a *worktree* is fine — the gate is main-clone-only."""
+        repo = _make_main_clone(tmp_path)
+        wt = tmp_path / "wt"
+        _git(repo, "worktree", "add", "-b", "ac/staged-feature", str(wt))
+        (wt / "f.txt").write_text("worktree-staged-edit", encoding="utf-8")
+        _git(wt, "add", "f.txt")
+
+        result = _run_hook(wt)
+
+        assert result.returncode == 0, result.stdout + result.stderr
+
     def test_refuses_from_a_subdirectory_of_the_main_clone(self, tmp_path: Path) -> None:
         """Refuse from a subdirectory of the main clone.
 


### PR DESCRIPTION
Closes #2614.

## What

Two worktree-first invariant gaps let a stale duplicate edit in a managed main clone block the loop's FF pull indefinitely. The incident: an agent hand-edited and `git add`-staged a file directly in the managed main clone (a worktree-first violation). The commit-time gate only fired on a non-default branch, so a staged-but-uncommitted edit on the default branch slipped under it. The same content later merged via a proper PR, leaving the local staged copy a stale byte-identical duplicate. The clone sat 1 commit behind origin/main and `pull_main_clone` skipped every tick with `dirty_tracked:<file>`.

## Sub-item 1 - close the staged-edit gate gap

`scripts/hooks/refuse-main-clone-commit.sh` was a branch-only gate. After the existing branch check, it now also refuses a commit when `git diff --cached --name-only` is non-empty in a managed main clone - i.e. there are tracked working-tree changes staged for commit - independent of branch state. A clean default-branch tree (the fast-forward merge-keeping flow stages nothing) and any staged edit inside a worktree stay allowed.

## Sub-item 2 - content-safe self-heal of pull_main_clone (data-loss-free subset only)

`src/teatree/loop/scanners/pull_main_clone.py` now self-heals the `dirty_tracked` skip in exactly one provably-safe case: when EVERY dirty path's blob is byte-identical to `origin/<default>`. Proven by an empty `git diff --quiet` against `origin/<default>` for the working tree AND (an empty diff against `origin/<default>` OR against `HEAD`) for the index - so both the visible blob and any staged blob carry no content that is not already upstream. When the precondition holds, the stale duplicate is discarded (`git restore --staged --worktree`) and the FF pull proceeds. Any path whose blob differs from origin keeps the current skip-with-warning; genuine local work is never reset, forced, or stashed. Follows the prove-then-act precedent of `cli/_update_reconcile.py` (#2607). A `git diff --quiet` error exit is treated as not-clean (fail-closed).

## Acceptance criteria -> diff

- *A tracked file staged in a managed main clone is refused independent of commit/branch state* -> `scripts/hooks/refuse-main-clone-commit.sh` (staged-tracked-changes check).
- *pull_main_clone auto-discards + ff-pulls ONLY when the blob is provably identical to origin; otherwise keeps the skip-with-warning* -> `_all_dirty_blobs_match_origin` + `_discard_paths` + `_diff_is_empty` in `pull_main_clone.py`.
- *Regression tests for both paths* -> see below.

## Regression tests (RED before, GREEN after)

- staged-edit refusal: `tests/test_refuse_main_clone_commit.py::test_refuses_staged_tracked_edit_on_default_branch_in_main_clone` (+ two anti-over-block guards).
- byte-identical auto-heal: `test_byte_identical_dirty_blob_is_auto_healed_then_pulled` and `test_byte_identical_staged_dirty_blob_is_auto_healed_then_pulled`.
- genuinely-different keep-and-warn: `test_genuinely_different_dirty_blob_keeps_skip_and_warning`, `test_mixed_dirty_one_identical_one_genuine_keeps_skip`, and `test_worktree_matches_origin_but_staged_blob_differs_keeps_skip`.

100% line+branch coverage on `pull_main_clone.py`.

## Architecture pre-check - #2614

### 1. BLUEPRINT alignment
Touches the worktree-first invariant surface (`/t3:rules` Worktree-First Work) and the loop scanner ladder. No BLUEPRINT section change needed - the gate purpose is unchanged, only widened; the scanner's documented decision ladder is updated in its module docstring.

### 2. FSM phase boundaries
n/a - no `Ticket.State` / `Worktree.State` transition.

### 3. Extension-point contracts
n/a - `PullMainCloneScanner.scan()` signature unchanged; the hook's wiring (`.pre-commit-config.yaml`) is unchanged.

### 4. Component boundaries
Hook logic stays in `scripts/hooks/`; scanner logic stays in `src/teatree/loop/scanners/`. No straddle.

### 5. Dependency direction
No new cross-module imports - only new module-private helpers reusing the existing `_git` primitive. tach gate passed in the pre-commit run.

### 6. Test surface
Each behaviour has a named test asserting the observable contract (refused exit code; HEAD advanced + dirty discarded; HEAD unchanged + work preserved + skip signal). All observed RED before the fix and GREEN after.

### 7. Resilience invariants
The only writes are local git ops. Idempotent (a clean clone is a no-op `up_to_date`; a re-run after heal is `up_to_date`). The content gate is fail-closed on an inconclusive `git diff`. No external transport.

### 8. Identity and key normalization
n/a - no bare-vs-qualified identity.

### 9. Behavior preservation / capability deletion
Purely additive on both surfaces. The hook keeps the existing non-default-branch refusal and the clean-default-branch allow; the new staged check is an added refusal path. The scanner keeps the existing skip-with-warning for differing blobs; the self-heal is a new narrowly-gated branch that never widens the destructive surface (it discards only provably-upstream content). No must-block test inverted; no matcher narrowed.

NOT merged - awaiting independent cold-review.
