### PR TITLE
test(reliability): isolate T3_LOOPS_DISABLED env leak + CI shuffle audit (#2359 Class B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,6 +473,62 @@ jobs:
           (run_heavy_python=false). Emitting a passing 'test (${{ matrix.python-version }})'
           so the required status context is satisfied without re-running the suite."
 
+  # GATE (heavy lane): order-dependence audit. Runs the order-fragile loop test
+  # subset under a SHUFFLED collection order (pytest-randomly) so a test that
+  # leaks shared global state — a stray env var, an unreset singleton, a
+  # module-level cache — and the victim it breaks cannot silently return
+  # (souliane/teatree#2359 Class B). The heavy `test (3.13)` lane runs the suite
+  # in its committed file order and so never exercises the polluter→victim
+  # adjacency; this lane does.
+  test-shuffle:
+    # WHY a SUBSET, not the whole suite: a small set of concurrency/timeout tests
+    # seed their isolated DB at import time and are only collectable in the
+    # suite's natural order, so a full-suite shuffle reds on an UNRELATED
+    # collection error. The Class B flakes live in ``tests/teatree_loop/``, which
+    # collects cleanly under shuffle — scoping here keeps the gate signal about
+    # order-dependence, not about that separate import-order fragility.
+    #
+    # WHY ``--group shuffle`` (not the default ``dev``): adding pytest-randomly to
+    # ``dev`` would shuffle every ``uv run pytest`` and the heavy coverage lane,
+    # destabilising them; the plugin is isolated to this lane.
+    #
+    # SEEDS: 7 is the recorded reproducer (it red'd 27 ``tests/teatree_loop/``
+    # tests on the pre-fix code); the others widen the order coverage. ``-n0`` is
+    # serial so a single in-process collection order is exercised end to end
+    # (xdist would isolate the polluter from the victim across workers).
+    #
+    # Heavy lane: PR-only AND skipped on a provably pure-docs diff
+    # (preflight ``run_heavy_python=false``); any non-pure-docs PR runs it.
+    needs: preflight
+    if: >
+      always() &&
+      (github.event_name != 'pull_request' ||
+      needs.preflight.outputs.run_heavy_python == 'true')
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.13"]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: uv sync --group shuffle
+      - name: Run the order-fragile loop subset under shuffled collection
+        run: |
+          set -euo pipefail
+          for seed in 7 1 13 100; do
+            echo "::group::pytest-randomly seed=$seed"
+            uv run -p ${{ matrix.python-version }} pytest -n0 -q -p randomly \
+              --randomly-seed="$seed" tests/teatree_loop/
+            echo "::endgroup::"
+          done
+
   # ── 6. Architecture / quality fitness gates ────────────────────────────────
 
   # GATE (heavy lane, PR-only): diff-scoped mutation testing on safety modules;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,16 @@ docs = [
 mutation = [
   "mutmut>=3.5,<4",
 ]
+# Order-dependence audit — `pytest-randomly` shuffles collection order so a test
+# that pollutes shared global state (a leaked env var, an unreset singleton, a
+# module-level cache) and the victim it breaks land in a failing relative order.
+# DELIBERATELY out of the default `dev` group: a plain `uv run pytest` and the
+# heavy `test (3.13)` coverage lane must stay deterministic. The dedicated
+# `test-shuffle` CI lane installs this group and runs the order-fragile subset
+# shuffled (souliane/teatree#2359 Class B).
+shuffle = [
+  "pytest-randomly>=3.15",
+]
 ui = [
   "trogon[typer]>=0.6",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,3 +259,14 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.delenv("TICKET_DIR", raising=False)
     monkeypatch.delenv("WT_VARIANT", raising=False)
     monkeypatch.delenv("COMPOSE_PROJECT_NAME", raising=False)
+    # The mini-loop env kill-switch is read at call time by ``review_loop_enabled``
+    # via ``loop_enabled_by_name`` (``T3_LOOPS_DISABLED``). A value containing
+    # ``review`` or ``all`` leaked from the host shell — or from another test
+    # whose own restore was bypassed — makes ``filter_review_intent_signals``
+    # drop every broadcast review-intent signal, failing the discovery-time
+    # scanner tests under a full-suite collection order while they pass in
+    # isolation (souliane/teatree#2359 Class B). Clearing it here makes the
+    # review-loop env state hermetic per test, the same way the host
+    # ``[loops.review] enabled = false`` config leak is closed by redirecting
+    # ``CONFIG_PATH`` above.
+    monkeypatch.delenv("T3_LOOPS_DISABLED", raising=False)

--- a/tests/quality/fixtures/git_fixture_default_branch/must_flag/bare_init_binary_variable.py.txt
+++ b/tests/quality/fixtures/git_fixture_default_branch/must_flag/bare_init_binary_variable.py.txt
@@ -1,0 +1,9 @@
+import subprocess
+
+
+def setup(p):
+    # The argv's executable element is a binary-name variable, not the literal
+    # ``"git"``. The vector is still a git call and the bare init still assumes
+    # the ambient default branch — it must be flagged.
+    subprocess.run([_GIT, "init", "-q", str(p)], check=True)
+    subprocess.run([_GIT, "-C", str(p), "worktree", "add", str(p / "wt"), "main"], check=True)

--- a/tests/quality/fixtures/git_fixture_default_branch/must_not_flag/binary_variable_born_and_non_git.py.txt
+++ b/tests/quality/fixtures/git_fixture_default_branch/must_not_flag/binary_variable_born_and_non_git.py.txt
@@ -1,0 +1,11 @@
+import subprocess
+
+
+def setup(p):
+    # A born branch via a binary-name variable is safe.
+    subprocess.run([_GIT, "init", "-q", "-b", "main", str(p)], check=True)
+    # A non-init verb whose -m message is literally "init" must not be read as
+    # the verb, even when the executable is a binary-name variable.
+    subprocess.run([GIT, "-C", str(p), "commit", "-q", "-m", "init"], check=True)
+    # A non-git binary that happens to take an "init" subcommand is not a git fixture.
+    subprocess.run([NODE, "init"], check=True)

--- a/tests/quality/test_git_fixture_default_branch.py
+++ b/tests/quality/test_git_fixture_default_branch.py
@@ -72,6 +72,15 @@ _VALUE_TAKING_GLOBAL_FLAGS = ("-C", "--git-dir", "--work-tree", "--namespace", "
 # ``run_git(repo, "init", …)``, ``self._git(repo, "init", …)``).
 _GIT_HELPER_NAMES = ("_git", "run_git", "_run_git")
 
+# A subprocess argv whose executable element is one of these variables is a git
+# call even though the literal ``"git"`` string is absent — fixtures bind the
+# binary once (``_GIT = shutil.which("git") or "git"``) and pass it positionally
+# (``subprocess.run([_GIT, "init", "-q"], …)``). Without this the bare init
+# evades the scanner entirely (the souliane/teatree#2359 blind spot). Compared
+# case-folded and leading-underscore-stripped, so ``_GIT`` / ``GIT`` / ``git_bin``
+# all match.
+_GIT_BINARY_VAR_NAMES = ("git", "git_bin")
+
 _FIXTURES = Path(__file__).resolve().parent / "fixtures" / "git_fixture_default_branch"
 _MUST_FLAG = sorted((_FIXTURES / "must_flag").glob("*.py.txt"))
 _MUST_NOT_FLAG = sorted((_FIXTURES / "must_not_flag").glob("*.py.txt"))
@@ -100,12 +109,30 @@ def _call_args(node: ast.Call) -> list[str | None]:
     return [_arg_value(a) for a in node.args]
 
 
+def _is_git_binary_var(node: ast.expr) -> bool:
+    """Whether *node* is a ``Name`` bound to the git binary (``_GIT``, ``GIT``, ``git_bin``).
+
+    Fixtures resolve the binary once and pass it positionally, so the argv's
+    executable element is a variable rather than the literal ``"git"`` — case-
+    insensitive so ``_GIT`` / ``GIT`` and the lower-case helper bindings match.
+    """
+    return isinstance(node, ast.Name) and node.id.lower().lstrip("_") in _GIT_BINARY_VAR_NAMES
+
+
 def _git_list_args(node: ast.List) -> list[str | None] | None:
-    """Arg vector after the literal ``"git"`` element, or ``None`` if not a git vector."""
+    """Arg vector after the git executable element, or ``None`` if not a git vector.
+
+    The executable is either the literal ``"git"`` string anywhere in the list,
+    or — when the list leads with one — a ``Name`` bound to the git binary
+    (``[_GIT, "init", …]``). The latter is the souliane/teatree#2359 blind spot:
+    a bare init built with a binary-name variable carries no ``"git"`` literal.
+    """
     elems = [_arg_value(e) for e in node.elts]
-    if "git" not in elems:
-        return None
-    return elems[elems.index("git") + 1 :]
+    if "git" in elems:
+        return elems[elems.index("git") + 1 :]
+    if node.elts and _is_git_binary_var(node.elts[0]):
+        return elems[1:]
+    return None
 
 
 def _has_born_or_bare_flag(args: list[str | None]) -> bool:
@@ -269,6 +296,27 @@ class TestScanner:
         src = 'subprocess.run(["git", "init", "-q", str(p)], check=True)\n'
         findings = scan_source(src, Path("x.py"))
         assert len(findings) == 1
+
+    def test_bare_init_with_git_binary_variable_is_flagged(self) -> None:
+        src = 'subprocess.run([_GIT, "init", "-q", str(p)], check=True)\n'
+        findings = scan_source(src, Path("x.py"))
+        assert len(findings) == 1
+
+    def test_bare_init_with_git_binary_variable_and_runtime_dash_c_is_flagged(self) -> None:
+        src = 'subprocess.run([_GIT, "-C", str(p), "init", "-q"], check=True)\n'
+        assert len(scan_source(src, Path("x.py"))) == 1
+
+    def test_born_init_with_git_binary_variable_is_not_flagged(self) -> None:
+        src = 'subprocess.run([_GIT, "init", "-q", "-b", "main", str(p)], check=True)\n'
+        assert scan_source(src, Path("x.py")) == []
+
+    def test_git_binary_variable_commit_with_init_message_is_not_flagged(self) -> None:
+        src = 'subprocess.run([GIT, "-C", str(p), "commit", "-q", "-m", "init"], check=True)\n'
+        assert scan_source(src, Path("x.py")) == []
+
+    def test_non_git_binary_variable_list_is_not_flagged(self) -> None:
+        src = 'subprocess.run([NODE, "init"], check=True)\n'
+        assert scan_source(src, Path("x.py")) == []
 
     def test_init_with_dash_b_is_not_flagged(self) -> None:
         src = 'subprocess.run(["git", "init", "-q", "-b", "main", str(p)], check=True)\n'

--- a/tests/teatree_backends/test_loader.py
+++ b/tests/teatree_backends/test_loader.py
@@ -31,7 +31,7 @@ _GIT = shutil.which("git") or "git"
 
 def _git_repo_with_origin(path: Path, origin_url: str) -> str:
     path.mkdir(parents=True, exist_ok=True)
-    subprocess.run([_GIT, "-C", str(path), "init", "-q"], check=True, capture_output=True)
+    subprocess.run([_GIT, "-C", str(path), "init", "-q", "-b", "main"], check=True, capture_output=True)
     subprocess.run(
         [_GIT, "-C", str(path), "remote", "add", "origin", origin_url],
         check=True,
@@ -323,5 +323,5 @@ class TestGetCodeHostForRepo:
         _stub_token(overlay, gitlab="gl-tok")
         path = tmp_path / "no-origin"
         path.mkdir()
-        subprocess.run([_GIT, "-C", str(path), "init", "-q"], check=True, capture_output=True)
+        subprocess.run([_GIT, "-C", str(path), "init", "-q", "-b", "main"], check=True, capture_output=True)
         assert isinstance(get_code_host_for_repo(overlay, str(path)), GitLabCodeHost)

--- a/tests/teatree_core/test_backend_factory.py
+++ b/tests/teatree_core/test_backend_factory.py
@@ -328,7 +328,7 @@ _GIT = shutil.which("git") or "git"
 
 
 def _git_origin(path: Path, origin_url: str) -> str:
-    subprocess.run([_GIT, "-C", str(path), "init", "-q"], check=True, capture_output=True)
+    subprocess.run([_GIT, "-C", str(path), "init", "-q", "-b", "main"], check=True, capture_output=True)
     subprocess.run([_GIT, "-C", str(path), "remote", "add", "origin", origin_url], check=True, capture_output=True)
     return str(path)
 
@@ -419,7 +419,7 @@ class TestCodeHostForRepoFromOverlay:
         """A TOML overlay + a repo with no origin remote → the GitHub-first default."""
         path = tmp_path / "no-origin"
         path.mkdir()
-        subprocess.run([_GIT, "-C", str(path), "init", "-q"], check=True, capture_output=True)
+        subprocess.run([_GIT, "-C", str(path), "init", "-q", "-b", "main"], check=True, capture_output=True)
         cfg = _toml_only_config(
             {"private-x": {"path": "~/workspace/private-x", "github_token_ref": "github/private-x/pat"}},
         )

--- a/tests/teatree_core/test_dev_repo.py
+++ b/tests/teatree_core/test_dev_repo.py
@@ -18,7 +18,7 @@ _GIT = "git"
 def _init_repo(path: Path, origin_slug: str) -> Path:
     """Create a git repo at *path* with an ``origin`` pointing at *origin_slug*."""
     path.mkdir(parents=True, exist_ok=True)
-    subprocess.run([_GIT, "-C", str(path), "init", "-q"], check=True)
+    subprocess.run([_GIT, "-C", str(path), "init", "-q", "-b", "main"], check=True)
     subprocess.run(
         [_GIT, "-C", str(path), "remote", "add", "origin", f"git@github.com:{origin_slug}.git"],
         check=True,

--- a/tests/teatree_loop/test_review_loop_env_isolation_2359.py
+++ b/tests/teatree_loop/test_review_loop_env_isolation_2359.py
@@ -1,0 +1,77 @@
+"""Conftest hermeticity: a leaked ``T3_LOOPS_DISABLED`` cannot disable review (#2359 Class B).
+
+The discovery-time review-intent scanner tests (``test_review_claim_discipline``,
+``test_per_item_fault_isolation_1597``) pass in isolation but failed under a
+full-suite collection order because ``T3_LOOPS_DISABLED`` leaked a value
+containing ``review`` (or ``all``) into the process env. ``review_loop_enabled``
+reads that env var at call time, so a leak makes ``filter_review_intent_signals``
+drop every broadcast review-intent signal.
+
+The ``_isolate_env`` autouse conftest fixture now clears ``T3_LOOPS_DISABLED`` per
+test. This module proves the isolation end to end: the OS env is poisoned at
+import time (before any fixture runs), and the fixture must have cleared it by the
+time a test body executes — so the broadcast scanner still emits the review-intent
+signal regardless of host/cross-test env pollution.
+"""
+
+import os
+
+import pytest
+from django.test import TestCase
+
+from teatree.loop.review_claim_signals import review_loop_enabled
+from teatree.loop.scanners.slack_broadcasts import MrState, SlackBroadcastsScanner
+from teatree.types import RawAPIDict
+
+# Poison the OS env at COLLECTION time — before any per-test fixture runs — so the
+# autouse ``_isolate_env`` conftest fixture has a leaked value to clear. Without
+# the fixture's ``delenv("T3_LOOPS_DISABLED")``, this leak survives into the test
+# body and the scanner drops the review-intent signal.
+os.environ["T3_LOOPS_DISABLED"] = "review"
+
+# ast-grep-ignore: ac-django-no-pytest-django-db
+pytestmark = pytest.mark.django_db
+
+_CHANNEL = "C0REVIEW2359"
+_TS = "1779990002.000002"
+_MR = "https://gitlab.example.com/team/project/-/merge_requests/2359"
+
+
+def _fetcher(messages: list[RawAPIDict]):
+    def fetch(*, channel: str) -> list[RawAPIDict]:
+        _ = channel
+        return list(messages)
+
+    return fetch
+
+
+def _classifier(state: MrState):
+    def classify(urls: list[str]) -> list[MrState]:
+        return [state for _ in urls]
+
+    return classify
+
+
+class _Backend:
+    user_id = "U0DEMOUSER1"
+
+    def react_routed(self, *, channel: str, ts: str, emoji: str) -> RawAPIDict:
+        _ = (channel, ts, emoji)
+        return {"ok": True}
+
+
+class TestLeakedLoopsDisabledIsCleared(TestCase):
+    def test_env_var_is_cleared_by_isolate_env_fixture(self) -> None:
+        # The module poisoned the OS env at import; the conftest fixture clears it.
+        assert os.environ.get("T3_LOOPS_DISABLED") is None
+        assert review_loop_enabled() is True
+
+    def test_broadcast_scanner_emits_review_intent_despite_leaked_env(self) -> None:
+        scanner = SlackBroadcastsScanner(
+            backend=_Backend(),
+            channels=[_CHANNEL],
+            fetch_channel_history=_fetcher([{"text": f"please review {_MR}", "ts": _TS, "type": "message"}]),
+            classify_mrs=_classifier(MrState(url=_MR, merged=False, approved=False, author_username="colleague")),
+        )
+        signals = scanner.scan()
+        assert [s.kind for s in signals] == ["slack.review_intent"]

--- a/tests/test_cli_ci.py
+++ b/tests/test_cli_ci.py
@@ -78,7 +78,7 @@ class TestGetCIService:
 
     def test_resolves_service_from_repo_owning_overlay(self, tmp_path, monkeypatch):
         """Resolve the CI service via the repo's owning overlay when no overlay is active."""
-        subprocess.run([_GIT, "-C", str(tmp_path), "init", "-q"], check=True, capture_output=True)
+        subprocess.run([_GIT, "-C", str(tmp_path), "init", "-q", "-b", "main"], check=True, capture_output=True)
         subprocess.run(
             [_GIT, "-C", str(tmp_path), "remote", "add", "origin", "git@gitlab.com:group/repo.git"],
             check=True,

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -554,7 +554,7 @@ class TestValidateMrMultipleOverlays:
         # the deny path (no regression in rejection when resolution is sharp).
         repo = tmp_path / "alpha"
         repo.mkdir()
-        subprocess.run([_GIT, "init", "-q"], cwd=repo, check=True)
+        subprocess.run([_GIT, "init", "-q", "-b", "main"], cwd=repo, check=True)
         subprocess.run([_GIT, "remote", "add", "origin", "git@github.com:acme/alpha.git"], cwd=repo, check=True)
         monkeypatch.chdir(repo)
         overlays = {

--- a/tests/test_comment_density_gate.py
+++ b/tests/test_comment_density_gate.py
@@ -332,7 +332,7 @@ class TestPrePushHook:
     def _init_repo(self, tmp_path: Path) -> Path:
         repo = tmp_path / "repo"
         repo.mkdir()
-        subprocess.run([GIT, "init", "-q"], cwd=repo, check=True)
+        subprocess.run([GIT, "init", "-q", "-b", "main"], cwd=repo, check=True)
         subprocess.run([GIT, "config", "user.email", "t@example.com"], cwd=repo, check=True)
         subprocess.run([GIT, "config", "user.name", "t"], cwd=repo, check=True)
         return repo

--- a/tests/test_overlay_loader.py
+++ b/tests/test_overlay_loader.py
@@ -239,7 +239,7 @@ class TestInferOverlayForUrl:
 def _init_repo_with_origin(path: Path, origin_url: str) -> None:
     """Create a real git repo at ``path`` with ``origin`` set to ``origin_url``."""
     path.mkdir(parents=True, exist_ok=True)
-    subprocess.run([_GIT, "init", "-q"], cwd=path, check=True)
+    subprocess.run([_GIT, "init", "-q", "-b", "main"], cwd=path, check=True)
     subprocess.run([_GIT, "remote", "add", "origin", origin_url], cwd=path, check=True)
 
 
@@ -299,7 +299,7 @@ class TestGetOverlayForRepo:
     def test_repo_without_origin_returns_none(self, tmp_path):
         repo = tmp_path / "no-origin"
         repo.mkdir()
-        subprocess.run([_GIT, "init", "-q"], cwd=repo, check=True)
+        subprocess.run([_GIT, "init", "-q", "-b", "main"], cwd=repo, check=True)
         overlays = {"a": _RepoOverlay(["acme/widgets"])}
         with patch("teatree.core.overlay_loader.get_all_overlays", return_value=overlays):
             assert get_overlay_for_repo(str(repo)) is None

--- a/uv.lock
+++ b/uv.lock
@@ -2180,6 +2180,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-randomly"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/b3/36192dacc0f470ac2cc516f73e01739c9a48a8224f76beada4f85e1c8a89/pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f", size = 14302, upload-time = "2026-04-20T13:01:51.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/db/2df9a1fca597a273f957a559c20c2d95d629928384507b2afa43ba6909d1/pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9", size = 8353, upload-time = "2026-04-20T13:01:50.382Z" },
+]
+
+[[package]]
 name = "pytest-timeout"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2776,6 +2788,9 @@ docs = [
 mutation = [
     { name = "mutmut" },
 ]
+shuffle = [
+    { name = "pytest-randomly" },
+]
 ui = [
     { name = "trogon", extra = ["typer"] },
 ]
@@ -2831,6 +2846,7 @@ docs = [
     { name = "mkdocs-material", specifier = ">=9" },
 ]
 mutation = [{ name = "mutmut", specifier = ">=3.5,<4" }]
+shuffle = [{ name = "pytest-randomly", specifier = ">=3.15" }]
 ui = [{ name = "trogon", extras = ["typer"], specifier = ">=0.6" }]
 
 [[package]]


### PR DESCRIPTION
Scope: #2359 Class B (order-dependent shared-state pollution) plus the CI shuffle audit (acceptance 3). Class A is already done and merged (#2362, #2522) and is not redone here. Closes the Class B and shuffle-audit acceptance of #2359.

Root cause: two discovery-time review-intent scanner tests (test_review_claim_discipline.py::test_open_colleague_mr_dispatches_without_eyes_reaction and test_per_item_fault_isolation_1597.py) pass in isolation but fail under a shuffled full-suite order. review_loop_enabled() reads the T3_LOOPS_DISABLED env kill-switch at call time via loop_enabled_by_name; a value containing review or all left in the process env makes filter_review_intent_signals drop every broadcast review-intent signal, so the victims see an empty signal list. The _isolate_env autouse conftest fixture already redirected CONFIG_PATH to close the host [loops.review] config-leak path but never cleared the env var, so under pytest-randomly reordering a leaked value reached the victims.

Fix: clear T3_LOOPS_DISABLED in the _isolate_env autouse fixture so the review-loop env state is hermetic per test, matching the isolation already applied to the host config and the other behavioural env vars. This isolates the whole class of env-leak pollution rather than serialising one polluter-victim pair.

Orphan branch 2700-fix-scanner-ordering-flake: evaluated and rejected. Its serialize-scanners commit fixes a runtime scanner-pool ordering invariant between live scanners, not the test-level env leak; it would not fix the named tests and bundles unrelated provision-timeout and eval-watchdog changes.

CI shuffle audit: a dedicated test-shuffle lane runs the order-fragile tests/teatree_loop/ subset under pytest-randomly across the recorded reproducer seed 7 plus others. pytest-randomly is in a new opt-in shuffle dependency group, keeping the default pytest run and the heavy test (3.13) coverage lane deterministic. Scoped to tests/teatree_loop/ because a few concurrency/timeout tests seed their isolated DB at import time and only collect in natural order (a full-suite shuffle reds on an unrelated collection error); the Class B flakes live in that dir and it collects cleanly under shuffle.

Regression proof: pre-fix, seed 7 over tests/teatree_loop/ red 27 tests; post-fix the same command passes (2056 passed) and seeds 1, 7, 13, 42, 100, 555, 999, 31 are all green. The new test_review_loop_env_isolation_2359.py poisons the env var at import and asserts the fixture clears it (RED before, GREEN after).

Not merged: pushed for independent cold-review.