### PR TITLE
fix(cleanup): gate clean-all force-delete on content-equivalence, not subject-match (#2609)

### DIFF
--- a/src/teatree/cli/_update_reconcile.py
+++ b/src/teatree/cli/_update_reconcile.py
@@ -11,9 +11,13 @@ The subject classifier
 cheap PRE-FILTER: it buckets ``squash_merged`` by canonicalized-subject
 membership alone, with no content/patch-id/tree check, so a genuine commit can
 slip past it (subject collision, amended content, evil-merge). The destructive
-``git reset --hard`` is authorized by an AUTHORITATIVE *content* gate instead —
-``git cherry`` (patch-id) plus a merge-commit check — never by subject. A
-recoverable backup ref is created at the pre-reset HEAD as defense-in-depth.
+``git reset --hard`` is authorized by the AUTHORITATIVE *content* gate instead —
+:func:`teatree.core.branch_classification.content_equivalence_blockers`
+(``git cherry`` patch-id plus a merge-commit check, failing CLOSED on any
+inconclusive git probe) — never by subject. That is the SAME shared helper the
+clean-all force-delete path consumes (#2609): one content-equivalence authorizer,
+two destructive callers. A recoverable backup ref is created at the pre-reset
+HEAD as defense-in-depth.
 
 This module is a leaf helper of ``teatree.cli.update``: it imports the result
 types and small git helpers from there; ``update`` calls
@@ -25,7 +29,7 @@ from typing import TYPE_CHECKING
 
 import typer
 
-from teatree.core.branch_classification import classify_branch_commits
+from teatree.core.branch_classification import classify_branch_commits, content_equivalence_blockers
 
 if TYPE_CHECKING:
     from teatree.cli.update import RepoUpdate
@@ -37,53 +41,6 @@ _SUBJECT_PREVIEW_LIMIT = 3
 # A full git sha is 40 hex chars; below this a "sha" is a fail-safe diagnostic
 # string (e.g. "(git cherry failed …)") that must be surfaced verbatim, not sliced.
 _SHORT_SHA_LEN = 7
-
-
-def _cherry_not_upstream(repo: Path, target: str) -> list[str]:
-    """Return the sha(s) of unique non-merge commits whose patch is NOT upstream.
-
-    ``git cherry <target> HEAD`` compares each commit reachable from HEAD but
-    not from ``target`` by **patch-id** (content), not by SHA or subject: a
-    ``-`` prefix means the patch already landed upstream (typical squash-merge),
-    a ``+`` prefix means the patch is genuinely un-upstreamed work. This is the
-    authoritative content check the subject classifier cannot do — a genuine
-    commit whose subject merely collides with an upstream subject (vector B) or
-    an amended commit that added content after the original was squashed
-    (vector C) both show ``+`` here even though the subject matcher buckets them
-    ``squash_merged``. Returns the ``+`` sha(s); an empty list means every
-    non-merge unique commit is patch-equivalent upstream.
-    """
-    from teatree.cli.update import _git  # noqa: PLC0415
-
-    result = _git(repo, "cherry", target, "HEAD", expected_codes=None)
-    if result.returncode != 0:
-        # A failed `git cherry` is inconclusive — degrade safely by reporting an
-        # opaque genuine sha so the caller refuses the reset (never reaps work
-        # on an uncertain content check).
-        return ["(git cherry failed — content check inconclusive)"]
-    plus: list[str] = []
-    for line in result.stdout.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("+"):
-            plus.append(stripped[1:].strip())
-    return plus
-
-
-def _merge_commits_in_range(repo: Path, target: str) -> list[str]:
-    """Return merge-commit sha(s) reachable from HEAD but not from ``target``.
-
-    ``git rev-list --merges <target>..HEAD`` lists merge commits unique to the
-    branch. A merge commit can carry content present in neither parent (an
-    evil-merge, vector D) and has no single patch-id ``git cherry`` can compare,
-    so its content cannot be cheaply proven already-upstream. Any merge commit
-    in the unique range therefore blocks the reset conservatively.
-    """
-    from teatree.cli.update import _git  # noqa: PLC0415
-
-    result = _git(repo, "rev-list", "--merges", f"{target}..HEAD", expected_codes=None)
-    if result.returncode != 0:
-        return ["(git rev-list --merges failed — merge check inconclusive)"]
-    return [sha.strip() for sha in result.stdout.splitlines() if sha.strip()]
 
 
 def _create_reconcile_backup_ref(repo: Path, head_sha: str) -> str:
@@ -122,10 +79,12 @@ def reconcile_squash_merged(name: str, repo: Path, old_sha: str, pull_stderr: st
     genuine un-upstreamed commit whose subject collides with an unrelated upstream
     subject (vector B), an amended commit that added content after the original
     squash (vector C), or a merge commit carrying unique content (vector D) all
-    slip past it. So before any reset an AUTHORITATIVE content gate runs — the
-    reset proceeds ONLY if (1) ``git cherry`` reports every unique non-merge
-    commit as patch-equivalent upstream (no ``+`` line) AND (2) there are no merge
-    commits in the unique range. If either fails the clone is kept and a LOUD
+    slip past it. So before any reset the AUTHORITATIVE
+    :func:`content_equivalence_blockers` gate runs — the SAME shared helper the
+    clean-all force-delete path consumes (#2609). The reset proceeds ONLY when it
+    reports zero blockers (every unique non-merge commit is patch-equivalent
+    upstream AND there are no merge commits in the unique range); any blocker — or
+    an inconclusive git probe (it fails CLOSED) — keeps the clone and a LOUD
     multi-line warning names the genuine sha(s), so genuine work is never
     destroyed. Immediately before the authorized reset a recoverable
     ``refs/t3-reconcile-backup/<sha>`` ref is created at the pre-reset HEAD (and
@@ -157,23 +116,17 @@ def reconcile_squash_merged(name: str, repo: Path, old_sha: str, pull_stderr: st
 
     # AUTHORITATIVE content gate — the subject classifier above is only a cheap
     # pre-filter; the reset is authorized solely by content, never by subject.
-    cherry_plus = _cherry_not_upstream(repo, target)
-    if cherry_plus:
+    # The SAME shared helper guards the clean-all force-delete path (#2609): a
+    # ``git cherry`` patch-id check plus a merge-commit check, failing CLOSED on
+    # any inconclusive git probe.
+    blockers = content_equivalence_blockers(str(repo), branch, target)
+    if blockers:
         return _refuse_reconcile(
             name,
             repo,
             target,
-            reason="commit(s) whose patch is NOT upstream (subject collision / amended content)",
-            shas=cherry_plus,
-        )
-    merge_shas = _merge_commits_in_range(repo, target)
-    if merge_shas:
-        return _refuse_reconcile(
-            name,
-            repo,
-            target,
-            reason="merge commit(s) that may carry content not provably upstream",
-            shas=merge_shas,
+            reason="commit(s) whose content is NOT upstream (subject collision / amended / evil-merge)",
+            shas=blockers,
         )
 
     dropped = len(classification.squash_merged) + len(classification.merge_commits)

--- a/src/teatree/core/branch_classification.py
+++ b/src/teatree/core/branch_classification.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from teatree.utils import git
-from teatree.utils.run import TimeoutExpired, run_allowed_to_fail
+from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to_fail
 
 _PR_SUFFIX_RE = re.compile(r"(?:\s*\(#\d+\))+$")
 _RELEASE_NOTE_SUFFIX_RE = re.compile(r"\s*\[[^\]]*\]\s*\([^)]+\)\s*$")
@@ -110,6 +110,59 @@ def classify_branch_commits(repo: str, branch: str, target: str = "origin/main")
         else:
             classification.genuinely_ahead.append(commit)
     return classification
+
+
+def content_equivalence_blockers(repo: str, branch: str, target: str = "origin/main") -> list[str]:
+    """Return the commit(s) on ``branch`` NOT provably content-equivalent to ``target``.
+
+    The AUTHORITATIVE content gate every destructive caller must pass before
+    destroying ``branch`` (#2609). :func:`classify_branch_commits` buckets by
+    canonicalized SUBJECT alone — fine to *recognize* a forge-squash-merged
+    candidate, but unsafe to *authorize* a destroy: a genuine un-upstreamed
+    commit whose subject collides with an already-upstreamed subject (a routine
+    ``docs: update skills``), an amended commit that added content after the
+    original squash, or a merge commit carrying unique content all slip past it.
+    This proves equivalence by CONTENT instead, so an empty list is positive
+    proof that destroying ``branch`` loses nothing.
+
+    Two authoritative checks, both contributing blockers. ``git cherry <target>
+    <branch>`` compares each unique commit by **patch-id** (content), not SHA or
+    subject: a ``-`` prefix means the patch already landed upstream
+    (squash-merge), a ``+`` prefix means it is genuinely un-upstreamed — the ``+``
+    sha(s) are blockers. ``git rev-list --merges <target>..<branch>`` lists merge
+    commits unique to the branch; a merge commit can carry content in neither
+    parent (an evil-merge) and has no single patch-id ``git cherry`` can compare,
+    so any merge commit in the unique range blocks conservatively.
+
+    **Fails CLOSED.** A failed ``git cherry`` / ``git rev-list`` (unresolvable
+    target, corrupt repo, any git error) is inconclusive — the helper returns an
+    opaque ``"(... inconclusive)"`` blocker so the caller REFUSES the destroy.
+    Destruction requires a POSITIVE proof of content-equivalence; ambiguity never
+    authorizes it.
+    """
+    blockers: list[str] = []
+    try:
+        cherry = git.run_strict(repo=repo, args=["cherry", target, branch])
+    except CommandFailedError:
+        return ["(git cherry failed — content check inconclusive)"]
+    blockers.extend(line[1:].strip() for line in cherry.splitlines() if line.strip().startswith("+"))
+    try:
+        merges = git.run_strict(repo=repo, args=["rev-list", "--merges", f"{target}..{branch}"])
+    except CommandFailedError:
+        return [*blockers, "(git rev-list --merges failed — merge check inconclusive)"]
+    blockers.extend(sha.strip() for sha in merges.splitlines() if sha.strip())
+    return blockers
+
+
+def branch_content_upstream(repo: str, branch: str, target: str = "origin/main") -> bool:
+    """Whether every commit on ``branch`` is provably content-equivalent to ``target``.
+
+    The boolean view of :func:`content_equivalence_blockers`: ``True`` only when
+    the content gate found NO blocker, so destroying ``branch`` loses nothing.
+    ``False`` on any blocker AND on any inconclusive git error (the helper fails
+    closed) — destruction requires positive proof.
+    """
+    return not content_equivalence_blockers(repo, branch, target)
 
 
 def _pr_merge_commit_sha(repo: str, branch: str) -> str:

--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -28,6 +28,7 @@ from teatree.core.branch_classification import (
     _branch_tree_matches_squash,
     _pr_merge_commit_sha,
     classify_branch_commits,
+    content_equivalence_blockers,
     probe_host_cli,
 )
 from teatree.core.clone_paths import resolve_clone_path
@@ -56,6 +57,10 @@ logger = logging.getLogger(__name__)
 
 
 _SUBJECT_PREVIEW_LIMIT = 3
+
+# A full git sha is 40 hex chars; below this a "sha" is a fail-closed diagnostic
+# string (e.g. "(git cherry failed …)") surfaced verbatim, not sliced.
+_SHORT_SHA_LEN = 7
 
 
 @dataclass(slots=True)
@@ -150,24 +155,34 @@ def _effective_target(repo_main: str, wt_path: str, worktree: Worktree) -> _Effe
 
 
 def _raise_if_genuinely_ahead(repo_main: str, worktree: Worktree, target: _EffectiveTarget) -> None:
-    """Raise ``RuntimeError`` when the branch carries commits not on ``origin/main``.
+    """Raise ``RuntimeError`` when the branch carries work not provably on ``origin/main``.
 
     Operates on ``target`` (the effective branch resolved from git), not the
     possibly-drifted DB ``Worktree.branch`` slug. The ``origin/main``-relative
-    classification needs a named branch reachable from the main clone, so it runs
-    against the main clone using the effective label; a detached HEAD has no named
-    branch to classify and is skipped (the #706 data-loss guard already covered
-    its unpushed commits via the worktree-dir probe).
+    check needs a named branch reachable from the main clone, so it runs against
+    the main clone using the effective label; a detached HEAD has no named branch
+    and is skipped (the #706 data-loss guard already covered its unpushed commits
+    via the worktree-dir probe).
 
-    Merge commits and squash-merged commits are ignored — only ``genuinely_ahead``
-    work blocks cleanup. Two fallbacks run before refusing, both confirming the
-    work already shipped: first the PR's merge commit tree is compared against the
-    branch tip (an empty diff means the cumulative content is captured in the
-    squash, typical for post-merge retro commits); then, for branches that
-    diverged so far the squash tree no longer matches, the forge is asked
-    canonically whether the branch's PR is merged (#1578). The error message
-    lists up to ``_SUBJECT_PREVIEW_LIMIT`` commit subjects so the caller can
-    decide whether to push or abandon.
+    **Content-equivalence authorizes the destroy, not subject-match (#2609).**
+    :func:`classify_branch_commits` is a cheap SUBJECT recognizer — it cannot
+    authorize a force-delete, because a genuine un-upstreamed commit whose subject
+    collides with an already-upstreamed subject (a routine ``docs: update skills``)
+    drains into ``squash_merged`` and would falsely empty ``genuinely_ahead``. The
+    AUTHORITATIVE gate is :func:`content_equivalence_blockers` (``git cherry``
+    patch-id + a merge-commit check): an empty blocker list is positive proof every
+    commit's CONTENT is already upstream, so the worktree is safe to remove. It
+    fails CLOSED — any inconclusive git probe reports a blocker and the cleanup is
+    refused.
+
+    Two positive merged-evidence fallbacks override a non-empty blocker list, both
+    confirming the work already shipped despite a patch-id mismatch: the PR's merge
+    commit tree compared against the branch tip (an empty diff means the cumulative
+    content is captured in the squash, typical for post-merge retro commits), and
+    the forge's canonical PR-merged report (#1578, for branches diverged so far the
+    squash tree no longer matches). The error message lists up to
+    ``_SUBJECT_PREVIEW_LIMIT`` blockers so the caller can decide whether to push or
+    abandon.
     """
     branch = target.branch_to_delete
     if branch is None:
@@ -175,24 +190,23 @@ def _raise_if_genuinely_ahead(repo_main: str, worktree: Worktree, target: _Effec
         # #706 unpushed guard already probed HEAD in the worktree dir, so any
         # work-to-lose was caught there.
         return
-    unsynced = git.unsynced_commits(repo_main, branch)
-    if not unsynced:
+    if not git.unsynced_commits(repo_main, branch):
         return
-    classification = classify_branch_commits(repo_main, branch)
-    if not classification.genuinely_ahead:
+    blockers = content_equivalence_blockers(repo_main, branch)
+    if not blockers:
         return
     if _branch_tree_matches_squash(repo_main, branch):
         return
     if _branch_pr_is_merged(repo_main, branch):
         return
-    preview = classification.genuinely_ahead[:_SUBJECT_PREVIEW_LIMIT]
-    subjects = ", ".join(c.subject for c in preview)
-    if len(classification.genuinely_ahead) > _SUBJECT_PREVIEW_LIMIT:
-        subjects += ", …"
+    preview = blockers[:_SUBJECT_PREVIEW_LIMIT]
+    listed = ", ".join(sha[:_SHORT_SHA_LEN] if len(sha) >= _SHORT_SHA_LEN else sha for sha in preview)
+    if len(blockers) > _SUBJECT_PREVIEW_LIMIT:
+        listed += ", …"
     msg = (
         f"{worktree.repo_path} ({target.label}): "
-        f"refused cleanup — {len(classification.genuinely_ahead)} unsynced commit(s) "
-        f"not on origin/main: {subjects}. "
+        f"refused cleanup — {len(blockers)} commit(s) not provably on origin/main "
+        f"(content not upstream): {listed}. "
         "Push them to a new branch or pass force=True."
     )
     raise RuntimeError(msg)

--- a/tests/teatree_core/cleanup/test_cleanup_worktree.py
+++ b/tests/teatree_core/cleanup/test_cleanup_worktree.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.test import TestCase
 
-from teatree.core.cleanup import BranchClassification, BranchCommit, cleanup_worktree
+from teatree.core.cleanup import cleanup_worktree
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay import OverlayBase, ProvisionStep, RunCommands
 from teatree.utils.run import CommandFailedError
@@ -21,7 +21,11 @@ from teatree.utils.run import CommandFailedError
 _patch_config = patch("teatree.core.cleanup.load_config")
 _patch_git = patch("teatree.core.cleanup.git")
 _patch_overlay = patch("teatree.core.cleanup.get_overlay_for_worktree")
-_patch_classify = patch("teatree.core.cleanup.classify_branch_commits")
+# The origin/main hygiene gate is now authorized by the CONTENT gate (#2609),
+# not subject-match — so a test that drives the gate patches
+# ``content_equivalence_blockers``, the helper every destructive caller funnels
+# through, rather than the cheap ``classify_branch_commits`` recognizer.
+_patch_content = patch("teatree.core.cleanup.content_equivalence_blockers")
 # Pin the #2205 merged-evidence override to False so tests that set
 # ``commits_absent_from_all_remotes`` to a non-empty list still hit the
 # data-loss guard rather than silently passing through the squash-merge override.
@@ -29,14 +33,18 @@ _patch_ref_tree = patch("teatree.core.cleanup._ref_captured_by_merge", return_va
 
 
 def _no_unpushed(mock_git: MagicMock) -> None:
-    """Default the #706 data-loss guard helper to "nothing unpushed".
+    """Default the #706 + #2609 hygiene gates to "nothing to lose" on the wholesale git mock.
 
-    Tests exercising unrelated cleanup behaviour share the wholesale ``git``
-    mock; without this the guard sees a truthy ``MagicMock`` and refuses
-    spuriously. Tests that target the guard override the return value after
+    Tests exercising unrelated cleanup behaviour share the wholesale ``cleanup.git``
+    mock; without this the #706 guard sees a truthy ``MagicMock`` and refuses
+    spuriously. The #2609 content gate (``content_equivalence_blockers``) lives in
+    ``branch_classification`` and runs real ``git`` — so it is short-circuited here
+    by defaulting ``unsynced_commits`` to empty (a fully-synced branch never reaches
+    the content gate). Tests that target a guard override the relevant value after
     calling this.
     """
     mock_git.commits_absent_from_all_remotes.return_value = []
+    mock_git.unsynced_commits.return_value = []
 
 
 def _mock_workspace(mock_config: MagicMock) -> None:
@@ -265,124 +273,120 @@ class TestCleanupWorktree(TestCase):
 
         assert not Worktree.objects.filter(pk=wt_id).exists()
 
-    @_patch_classify
+    @_patch_content
     @_patch_overlay
     @_patch_git
     @_patch_config
-    def test_raises_when_genuinely_ahead_commits_present(
+    def test_raises_when_content_not_upstream(
         self,
         mock_config: MagicMock,
         mock_git: MagicMock,
         mock_overlay: MagicMock,
-        mock_classify: MagicMock,
+        mock_content: MagicMock,
     ) -> None:
+        """A commit the content gate cannot prove upstream blocks cleanup (#2609)."""
         _mock_workspace(mock_config)
         _no_unpushed(mock_git)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
         mock_git.status_porcelain.return_value = ""
         mock_git.unsynced_commits.return_value = ["abc123 chore: cve fix"]
-        mock_classify.return_value = BranchClassification(
-            genuinely_ahead=[BranchCommit(sha="abc123", subject="chore: cve fix", is_merge=False)]
-        )
+        mock_content.return_value = ["abc123"]  # patch NOT upstream → blocker
 
         wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
         with (
-            patch("teatree.core.branch_classification._pr_merge_commit_sha", return_value=""),
-            pytest.raises(RuntimeError, match="unsynced commit"),
+            patch("teatree.core.cleanup._branch_tree_matches_squash", return_value=False),
+            patch("teatree.core.cleanup._branch_pr_is_merged", return_value=False),
+            pytest.raises(RuntimeError, match="content not upstream"),
         ):
             cleanup_worktree(wt)
 
         mock_git.worktree_remove.assert_not_called()
         mock_git.branch_delete.assert_not_called()
 
-    @_patch_classify
+    @_patch_content
     @_patch_overlay
     @_patch_git
     @_patch_config
-    def test_cleans_when_genuinely_ahead_tree_matches_pr_squash_commit(
+    def test_cleans_when_content_not_upstream_but_tree_matches_pr_squash_commit(
         self,
         mock_config: MagicMock,
         mock_git: MagicMock,
         mock_overlay: MagicMock,
-        mock_classify: MagicMock,
+        mock_content: MagicMock,
     ) -> None:
         """Post-merge follow-ups tree-equal to PR squash are safe to clean.
 
-        Genuinely-ahead commits whose cumulative tree matches the PR's squash
-        commit are still safe to remove because their content is already in
-        main. Reproduces the common case where an agent pushes retro/docs
-        commits AFTER the PR was squash-merged; those commits' net effect
-        is already captured by the squash tree.
+        The content gate reports a blocker (the patch-id differs from the squash),
+        but the cumulative tree matches the PR's squash commit, so the content is
+        already in main. Reproduces the common case where an agent pushes
+        retro/docs commits AFTER the PR was squash-merged.
         """
         _mock_workspace(mock_config)
         _no_unpushed(mock_git)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
         mock_git.status_porcelain.return_value = ""
         mock_git.unsynced_commits.return_value = ["abc123 retro: post-merge docs"]
-        mock_classify.return_value = BranchClassification(
-            genuinely_ahead=[BranchCommit(sha="abc123", subject="retro: post-merge docs", is_merge=False)]
-        )
+        mock_content.return_value = ["abc123"]  # patch differs from squash → blocker
 
         wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
         # The squash-tree match (PR merge commit tree == branch tip) is the
-        # safe-to-remove signal — control it at cleanup's call site.
+        # positive merged-evidence override — control it at cleanup's call site.
         with patch("teatree.core.cleanup._branch_tree_matches_squash", return_value=True):
             cleanup_worktree(wt)
 
         mock_git.worktree_remove.assert_called_once()
         mock_git.branch_delete.assert_called_once()
 
-    @_patch_classify
+    @_patch_content
     @_patch_overlay
     @_patch_git
     @_patch_config
-    def test_raises_when_genuinely_ahead_tree_differs_from_pr_squash_commit(
+    def test_raises_when_content_not_upstream_and_tree_differs_from_pr_squash_commit(
         self,
         mock_config: MagicMock,
         mock_git: MagicMock,
         mock_overlay: MagicMock,
-        mock_classify: MagicMock,
+        mock_content: MagicMock,
     ) -> None:
-        """Genuinely ahead commits whose tree differs from the squash carry real work."""
+        """A content blocker whose tree differs from the squash carries real work."""
         _mock_workspace(mock_config)
         _no_unpushed(mock_git)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
         mock_git.status_porcelain.return_value = ""
         mock_git.unsynced_commits.return_value = ["abc123 feat: new work"]
-        mock_classify.return_value = BranchClassification(
-            genuinely_ahead=[BranchCommit(sha="abc123", subject="feat: new work", is_merge=False)]
-        )
-        mock_git.check.return_value = False  # git diff --quiet returns 1 → tree differs
+        mock_content.return_value = ["abc123"]
 
         wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
         with (
-            patch("teatree.core.branch_classification._pr_merge_commit_sha", return_value="squash123"),
-            pytest.raises(RuntimeError, match="unsynced commit"),
+            patch("teatree.core.cleanup._branch_tree_matches_squash", return_value=False),
+            patch("teatree.core.cleanup._branch_pr_is_merged", return_value=False),
+            pytest.raises(RuntimeError, match="content not upstream"),
         ):
             cleanup_worktree(wt)
 
-    @_patch_classify
+    @_patch_content
     @_patch_overlay
     @_patch_git
     @_patch_config
-    def test_cleans_when_only_squash_merged_and_merge_commits(
+    def test_cleans_when_content_is_proven_upstream(
         self,
         mock_config: MagicMock,
         mock_git: MagicMock,
         mock_overlay: MagicMock,
-        mock_classify: MagicMock,
+        mock_content: MagicMock,
     ) -> None:
-        """Branches whose only "unsynced" commits are squash-merged or merge commits are safe to clean."""
+        """Branches whose commits are content-equivalent upstream are safe to clean.
+
+        The content gate returns no blocker (every unique commit is patch-equivalent
+        upstream, or only merge/squash-merged commits remain), so the worktree is
+        removed without any forge query.
+        """
         _mock_workspace(mock_config)
         _no_unpushed(mock_git)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
         mock_git.status_porcelain.return_value = ""
         mock_git.unsynced_commits.return_value = ["abc123 feat: squashed on main"]
-        mock_classify.return_value = BranchClassification(
-            squash_merged=[BranchCommit(sha="abc123", subject="feat: squashed on main", is_merge=False)],
-            merge_commits=[BranchCommit(sha="mrg001", subject="Merge branch 'main'", is_merge=True)],
-            genuinely_ahead=[],
-        )
+        mock_content.return_value = []  # content proven upstream
 
         wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
         cleanup_worktree(wt)
@@ -390,37 +394,34 @@ class TestCleanupWorktree(TestCase):
         mock_git.worktree_remove.assert_called_once()
         mock_git.branch_delete.assert_called_once()
 
-    @_patch_classify
+    @_patch_content
     @_patch_overlay
     @_patch_git
     @_patch_config
-    def test_reaps_genuinely_ahead_branch_when_forge_says_pr_merged(
+    def test_reaps_content_blocked_branch_when_forge_says_pr_merged(
         self,
         mock_config: MagicMock,
         mock_git: MagicMock,
         mock_overlay: MagicMock,
-        mock_classify: MagicMock,
+        mock_content: MagicMock,
     ) -> None:
         """#1578 — a long-diverged branch whose PR the forge reports MERGED is reaped.
 
-        The subject-match classifier reports ``genuinely_ahead`` and the squash
-        tree no longer matches the branch tip (the branch diverged long ago), so
-        the prior guards refuse. The canonical forge PR-state check overrides:
-        a merged PR is the ground truth that the work shipped.
+        The content gate reports a blocker (the squash created a new SHA so the
+        patch-id no longer matches) and the squash tree no longer matches the
+        branch tip, so the prior signals refuse. The canonical forge PR-state
+        check overrides: a merged PR is the ground truth that the work shipped.
         """
         _mock_workspace(mock_config)
         _no_unpushed(mock_git)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
         mock_git.status_porcelain.return_value = ""
         mock_git.unsynced_commits.return_value = ["abc123 feat: shipped via squash long ago"]
-        mock_classify.return_value = BranchClassification(
-            genuinely_ahead=[BranchCommit(sha="abc123", subject="feat: shipped via squash long ago", is_merge=False)]
-        )
-        mock_git.check.return_value = False  # tree differs — branch tip diverged from squash
+        mock_content.return_value = ["abc123"]
 
         wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
         with (
-            patch("teatree.core.branch_classification._pr_merge_commit_sha", return_value="squash123"),
+            patch("teatree.core.cleanup._branch_tree_matches_squash", return_value=False),
             patch("teatree.core.cleanup._branch_pr_is_merged", return_value=True),
         ):
             cleanup_worktree(wt)
@@ -428,38 +429,35 @@ class TestCleanupWorktree(TestCase):
         mock_git.worktree_remove.assert_called_once()
         mock_git.branch_delete.assert_called_once()
 
-    @_patch_classify
+    @_patch_content
     @_patch_overlay
     @_patch_git
     @_patch_config
-    def test_refuses_genuinely_ahead_branch_when_no_merged_pr(
+    def test_refuses_content_blocked_branch_when_no_merged_pr(
         self,
         mock_config: MagicMock,
         mock_git: MagicMock,
         mock_overlay: MagicMock,
-        mock_classify: MagicMock,
+        mock_content: MagicMock,
     ) -> None:
-        """#1578 load-bearing safety test — real pending work (no merged PR) is still refused.
+        """#1578/#2609 load-bearing safety test — real pending work (no merged PR) is still refused.
 
-        The forge canonically reports no merged PR for the branch, so the
-        conservative refuse-and-report stands: genuinely-ahead work is never
-        auto-discarded.
+        The content gate reports a blocker and the forge canonically reports no
+        merged PR, so the conservative refuse-and-report stands: genuine work is
+        never auto-discarded on a subject match alone.
         """
         _mock_workspace(mock_config)
         _no_unpushed(mock_git)
         mock_overlay.return_value.get_cleanup_steps.return_value = []
         mock_git.status_porcelain.return_value = ""
         mock_git.unsynced_commits.return_value = ["abc123 feat: genuine unpushed work"]
-        mock_classify.return_value = BranchClassification(
-            genuinely_ahead=[BranchCommit(sha="abc123", subject="feat: genuine unpushed work", is_merge=False)]
-        )
-        mock_git.check.return_value = False  # tree differs — not captured by any squash
+        mock_content.return_value = ["abc123"]
 
         wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
         with (
-            patch("teatree.core.branch_classification._pr_merge_commit_sha", return_value=""),
+            patch("teatree.core.cleanup._branch_tree_matches_squash", return_value=False),
             patch("teatree.core.cleanup._branch_pr_is_merged", return_value=False),
-            pytest.raises(RuntimeError, match="unsynced commit"),
+            pytest.raises(RuntimeError, match="content not upstream"),
         ):
             cleanup_worktree(wt)
 
@@ -621,7 +619,7 @@ class TestCleanupWorktree(TestCase):
         mock_git.worktree_remove.assert_called_once()
         mock_git.commits_absent_from_all_remotes.assert_not_called()
 
-    @_patch_classify
+    @_patch_content
     @_patch_overlay
     @_patch_git
     @_patch_config
@@ -630,12 +628,14 @@ class TestCleanupWorktree(TestCase):
         mock_config: MagicMock,
         mock_git: MagicMock,
         mock_overlay: MagicMock,
-        mock_classify: MagicMock,
+        mock_content: MagicMock,
     ) -> None:
         """Pushed-but-unmerged branch is refused under strict hygiene (default).
 
         The origin/main hygiene gate still blocks it — the sync-backend /
-        clean-all contract is unchanged.
+        clean-all contract is unchanged. A branch pushed to its own ref survives
+        the #706 data-loss guard, but its content is not on origin/main, so the
+        content gate refuses it.
         """
         _mock_workspace(mock_config)
         _no_unpushed(mock_git)
@@ -643,19 +643,18 @@ class TestCleanupWorktree(TestCase):
         mock_git.status_porcelain.return_value = ""
         mock_git.commits_absent_from_all_remotes.return_value = []  # pushed → data-loss guard passes
         mock_git.unsynced_commits.return_value = ["abc123 feat: pushed not merged"]
-        mock_classify.return_value = BranchClassification(
-            genuinely_ahead=[BranchCommit(sha="abc123", subject="feat: pushed not merged", is_merge=False)]
-        )
+        mock_content.return_value = ["abc123"]  # content not on origin/main
 
         wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
         with (
-            patch("teatree.core.branch_classification._pr_merge_commit_sha", return_value=""),
-            pytest.raises(RuntimeError, match="unsynced commit"),
+            patch("teatree.core.cleanup._branch_tree_matches_squash", return_value=False),
+            patch("teatree.core.cleanup._branch_pr_is_merged", return_value=False),
+            pytest.raises(RuntimeError, match="content not upstream"),
         ):
             cleanup_worktree(wt, strict_hygiene=True)
         mock_git.worktree_remove.assert_not_called()
 
-    @_patch_classify
+    @_patch_content
     @_patch_overlay
     @_patch_git
     @_patch_config
@@ -664,12 +663,13 @@ class TestCleanupWorktree(TestCase):
         mock_config: MagicMock,
         mock_git: MagicMock,
         mock_overlay: MagicMock,
-        mock_classify: MagicMock,
+        mock_content: MagicMock,
     ) -> None:
         """Pushed-but-unmerged branch is allowed when strict hygiene is off.
 
         This is the automated FSM teardown contract — a branch pushed to its
-        own remote ref passes; only the data-loss guard still applies.
+        own remote ref passes; only the data-loss guard still applies. The
+        content hygiene gate is skipped entirely, so it is never consulted.
         """
         _mock_workspace(mock_config)
         _no_unpushed(mock_git)
@@ -677,13 +677,12 @@ class TestCleanupWorktree(TestCase):
         mock_git.status_porcelain.return_value = ""
         mock_git.commits_absent_from_all_remotes.return_value = []  # pushed
         mock_git.unsynced_commits.return_value = ["abc123 feat: pushed not merged"]
-        mock_classify.return_value = BranchClassification(
-            genuinely_ahead=[BranchCommit(sha="abc123", subject="feat: pushed not merged", is_merge=False)]
-        )
+        mock_content.return_value = ["abc123"]  # would block under strict hygiene
 
         wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
         cleanup_worktree(wt, strict_hygiene=False)
         mock_git.worktree_remove.assert_called_once()
+        mock_content.assert_not_called()
 
     @_patch_overlay
     @_patch_git

--- a/tests/teatree_core/cleanup/test_content_equivalence.py
+++ b/tests/teatree_core/cleanup/test_content_equivalence.py
@@ -1,0 +1,263 @@
+"""Content-equivalence authorization for the destructive clean-all paths (#2609).
+
+``classify_branch_commits`` buckets a branch's commits ``squash_merged`` purely
+by canonicalized-SUBJECT membership in the last N upstream subjects, with NO
+content/patch-id check. Subject-matching is fine to *recognize* a forge-squash-
+merged candidate (a squash creates a new SHA), but it is unsafe to *authorize*
+a destroy: a genuine un-upstreamed commit whose subject collides with an
+already-upstreamed subject (e.g. a routine ``docs: update skills``) is
+misclassified ``squash_merged`` and would be force-deleted.
+
+#2607 guarded its reset path (``cli/_update_reconcile``) with a ``git cherry``
+content gate. These tests pin the SAME content gate on the clean-all force-DELETE
+path (``core.cleanup._raise_if_genuinely_ahead``) and assert the shared helper
+fails CLOSED on any git error — destruction requires positive proof of content
+equivalence.
+
+Real ``git`` under ``tmp_path`` (Test-Writing Doctrine): a true subject
+collision cannot be modeled with a mock that returns canned classifications,
+because the whole point is that the subject matcher LIES about the content.
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from django.test import TestCase
+
+from teatree.core.branch_classification import branch_content_upstream, content_equivalence_blockers
+from teatree.core.cleanup import CleanupResult, cleanup_worktree
+from teatree.core.models import Ticket, Worktree
+from tests.teatree_core.cleanup._shared import _GIT, _clean_env, _run_git
+
+
+def _clone_repo(src: Path, dest: Path, *bare: str) -> None:
+    subprocess.run(
+        [_GIT, "clone", *bare, "-q", str(src), str(dest)],
+        check=True,
+        capture_output=True,
+        env=_clean_env(),
+    )
+
+
+def _git_out(*args: str, cwd: Path) -> str:
+    return subprocess.run(
+        [_GIT, "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_clean_env(),
+    ).stdout.strip()
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _run_git("init", "-q", "-b", "main", cwd=path)
+    _run_git("config", "user.email", "t@t", cwd=path)
+    _run_git("config", "user.name", "t", cwd=path)
+
+
+class TestContentEquivalenceHelper(TestCase):
+    """The shared content-equivalence helper — patch-id authorization, fail-closed."""
+
+    @pytest.fixture(autouse=True)
+    def _repo(self, tmp_path: Path) -> None:
+        self.bare = tmp_path / "remote.git"
+        seed = tmp_path / "seed"
+        _init_repo(seed)
+        (seed / "f.txt").write_text("v1\n")
+        _run_git("add", "f.txt", cwd=seed)
+        _run_git("commit", "-q", "-m", "initial", cwd=seed)
+        _clone_repo(seed, self.bare, "--bare")
+        self.clone = tmp_path / "clone"
+        _clone_repo(self.bare, self.clone)
+        _run_git("config", "user.email", "t@t", cwd=self.clone)
+        _run_git("config", "user.name", "t", cwd=self.clone)
+
+    def _advance_upstream(self, *, subject: str, filename: str, content: str) -> None:
+        """Land *content* on the bare remote's main under *subject* (a NEW sha)."""
+        work = self.clone.parent / f"upstream-{filename}"
+        _clone_repo(self.bare, work)
+        _run_git("config", "user.email", "t@t", cwd=work)
+        _run_git("config", "user.name", "t", cwd=work)
+        (work / filename).write_text(content)
+        _run_git("add", filename, cwd=work)
+        _run_git("commit", "-q", "-m", subject, cwd=work)
+        _run_git("push", "-q", "origin", "main", cwd=work)
+        _run_git("fetch", "-q", "origin", cwd=self.clone)
+
+    def test_subject_collision_genuine_commit_is_a_blocker(self) -> None:
+        """A genuine commit whose subject collides with an upstream subject is NOT proven upstream.
+
+        The local commit and the upstream commit share the subject
+        ``docs: update skills`` but carry DIFFERENT content, so ``git cherry``
+        reports the local patch as ``+`` (not upstream). The helper must list it
+        as a blocker — content equivalence does NOT hold.
+        """
+        (self.clone / "genuine.txt").write_text("genuine local content\n")
+        _run_git("add", "genuine.txt", cwd=self.clone)
+        _run_git("commit", "-q", "-m", "docs: update skills", cwd=self.clone)
+        genuine_sha = _git_out("rev-parse", "HEAD", cwd=self.clone)
+        # Upstream has an UNRELATED commit with the SAME subject, different content.
+        self._advance_upstream(
+            subject="docs: update skills (#999)", filename="upstream.txt", content="totally different\n"
+        )
+
+        blockers = content_equivalence_blockers(str(self.clone), "main", "origin/main")
+
+        assert blockers, "subject-colliding genuine commit must be a content-equivalence blocker"
+        assert genuine_sha in blockers
+        assert branch_content_upstream(str(self.clone), "main", "origin/main") is False
+
+    def test_genuinely_upstreamed_branch_has_no_blockers(self) -> None:
+        """A commit whose patch already landed upstream (real squash-merge) is proven upstream."""
+        (self.clone / "feature.txt").write_text("the feature\n")
+        _run_git("add", "feature.txt", cwd=self.clone)
+        _run_git("commit", "-q", "-m", "add the feature", cwd=self.clone)
+        # Upstream squash-merges the SAME patch (verbatim content) under a new sha.
+        self._advance_upstream(subject="add the feature (#42)", filename="feature.txt", content="the feature\n")
+
+        blockers = content_equivalence_blockers(str(self.clone), "main", "origin/main")
+
+        assert blockers == [], "a patch-equivalent (squash-merged) commit must not block"
+        assert branch_content_upstream(str(self.clone), "main", "origin/main") is True
+
+    def test_merge_commit_in_range_is_a_blocker(self) -> None:
+        """A merge commit (no single patch-id) conservatively blocks — it may carry unique content."""
+        _run_git("checkout", "-q", "-b", "side", cwd=self.clone)
+        (self.clone / "feature.txt").write_text("the feature\n")
+        _run_git("add", "feature.txt", cwd=self.clone)
+        _run_git("commit", "-q", "-m", "add the feature", cwd=self.clone)
+        _run_git("checkout", "-q", "main", cwd=self.clone)
+        _run_git("merge", "-q", "--no-ff", "--no-edit", "side", cwd=self.clone)
+        # Upstream squash-merges only the feature subject, then is unrelated.
+        self._advance_upstream(subject="add the feature (#42)", filename="feature.txt", content="the feature\n")
+
+        blockers = content_equivalence_blockers(str(self.clone), "main", "origin/main")
+
+        assert blockers, "a merge commit in the unique range must conservatively block"
+        assert branch_content_upstream(str(self.clone), "main", "origin/main") is False
+
+    def test_fails_closed_on_git_error(self) -> None:
+        """An inconclusive content check (unresolvable target) REFUSES — never an empty pass."""
+        blockers = content_equivalence_blockers(str(self.clone), "main", "origin/does-not-exist")
+
+        assert blockers, "an inconclusive git probe must report a blocker, not an empty pass"
+        assert any("inconclusive" in b for b in blockers)
+        assert branch_content_upstream(str(self.clone), "main", "origin/does-not-exist") is False
+
+
+class TestCleanAllRefusesSubjectCollision(TestCase):
+    """The clean-all force-DELETE path must REQUIRE content-equivalence (#2609).
+
+    The data-loss scenario: a branch with a GENUINE un-upstreamed commit whose
+    subject collides with an upstream subject. ``classify_branch_commits`` drains
+    it into ``squash_merged`` so ``genuinely_ahead`` is empty, and the branch is
+    PUSHED to its own remote ref (so the #706 ``_raise_if_unpushed`` guard
+    passes). Before this fix ``_raise_if_genuinely_ahead`` returned early on the
+    empty ``genuinely_ahead`` and the worktree was force-deleted — destroying the
+    genuine commit. The content gate must refuse.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _workspace(self, tmp_path: Path) -> None:
+        self.workspace = tmp_path / "workspace"
+        self.workspace.mkdir()
+        # A bare "origin" so the feature branch can be pushed (passes #706).
+        self.bare = tmp_path / "origin.git"
+        seed = tmp_path / "seed"
+        _init_repo(seed)
+        (seed / "base.txt").write_text("base\n")
+        _run_git("add", "base.txt", cwd=seed)
+        _run_git("commit", "-q", "-m", "initial", cwd=seed)
+        _clone_repo(seed, self.bare, "--bare")
+        self.repo_main = self.workspace / "myrepo"
+        _clone_repo(self.bare, self.repo_main)
+        _run_git("config", "user.email", "t@t", cwd=self.repo_main)
+        _run_git("config", "user.name", "t", cwd=self.repo_main)
+
+    def _advance_origin(self, *, subject: str, filename: str, content: str) -> None:
+        work = self.workspace.parent / f"adv-{filename}"
+        _clone_repo(self.bare, work)
+        _run_git("config", "user.email", "t@t", cwd=work)
+        _run_git("config", "user.name", "t", cwd=work)
+        (work / filename).write_text(content)
+        _run_git("add", filename, cwd=work)
+        _run_git("commit", "-q", "-m", subject, cwd=work)
+        _run_git("push", "-q", "origin", "main", cwd=work)
+        _run_git("fetch", "-q", "origin", cwd=self.repo_main)
+
+    def _make_pushed_worktree(self, *, branch: str, subject: str, content: str) -> tuple[Worktree, Path, str]:
+        wt_path = self.workspace / branch / "myrepo"
+        _run_git("worktree", "add", "-q", "-b", branch, str(wt_path), cwd=self.repo_main)
+        (wt_path / "genuine.txt").write_text(content)
+        _run_git("add", "genuine.txt", cwd=wt_path)
+        _run_git("commit", "-q", "-m", subject, cwd=wt_path)
+        # Push the branch to its own remote ref so the #706 unpushed guard passes —
+        # the work survives on the remote, but is genuinely NOT on origin/main.
+        _run_git("push", "-q", "origin", f"{branch}:{branch}", cwd=wt_path)
+        head = _git_out("rev-parse", "HEAD", cwd=wt_path)
+        ticket = Ticket.objects.create(
+            issue_url="https://example.com/issues/2609",
+            state=Ticket.State.IN_REVIEW,
+        )
+        worktree = Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="myrepo",
+            branch=branch,
+            extra={"worktree_path": str(wt_path)},
+        )
+        return worktree, wt_path, head
+
+    def _cleanup(self, worktree: Worktree) -> CleanupResult:
+        with (
+            patch("teatree.core.cleanup.load_config") as mock_config,
+            patch("teatree.core.cleanup.get_overlay_for_worktree") as mock_overlay,
+        ):
+            mock_config.return_value.user.workspace_dir = self.workspace
+            mock_overlay.return_value.get_cleanup_steps.return_value = []
+            return cleanup_worktree(worktree, strict_hygiene=True)
+
+    def test_refuses_to_force_delete_subject_colliding_genuine_work(self) -> None:
+        """RED before #2609 — the genuine commit drains into squash_merged by subject and is destroyed.
+
+        The local genuine commit's subject collides with an unrelated upstream
+        subject (``docs: update skills``), so ``genuinely_ahead`` is empty and the
+        old guard returned early → force-delete. The content gate must refuse.
+        """
+        worktree, wt_path, head = self._make_pushed_worktree(
+            branch="2609-genuine", subject="docs: update skills", content="genuine un-upstreamed content\n"
+        )
+        # Upstream has the SAME canonicalized subject under DIFFERENT content.
+        self._advance_origin(subject="docs: update skills (#999)", filename="other.txt", content="unrelated upstream\n")
+        _run_git("fetch", "-q", "origin", cwd=self.repo_main)
+
+        with pytest.raises(RuntimeError, match="origin/main"):
+            self._cleanup(worktree)
+
+        # The worktree, branch, and the genuine commit all survive.
+        assert wt_path.exists(), "worktree directory was destroyed despite genuine un-upstreamed work"
+        assert head == _git_out("rev-parse", head, cwd=self.repo_main)
+        assert Worktree.objects.filter(pk=worktree.pk).exists()
+
+    def test_deletes_genuinely_upstreamed_branch(self) -> None:
+        """A branch whose commit is content-equivalent upstream (real squash-merge) IS cleaned.
+
+        Confirms the content gate does not over-block normal cleanup: when the
+        local patch already landed verbatim on origin/main, the helper passes and
+        the worktree is removed.
+        """
+        worktree, wt_path, _head = self._make_pushed_worktree(
+            branch="2609-merged", subject="add the feature", content="the feature\n"
+        )
+        # Upstream squash-merges the SAME patch verbatim (the genuine.txt content).
+        self._advance_origin(subject="add the feature (#42)", filename="genuine.txt", content="the feature\n")
+        _run_git("fetch", "-q", "origin", cwd=self.repo_main)
+
+        result = self._cleanup(worktree)
+
+        assert result.clean is True, f"unexpected errors cleaning a squash-merged branch: {result.errors}"
+        assert not wt_path.exists(), "worktree should have been removed for a content-upstream branch"
+        assert not Worktree.objects.filter(pk=worktree.pk).exists()

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -1657,14 +1657,10 @@ class TestWorkspaceCleanAll(TestCase):
             def _unsynced(_repo: str, branch: str) -> list[str]:
                 return ["abc123 chore: unpushed"] if branch == "ac-frontend-360-ticket" else []
 
-            def _classify(_repo: str, branch: str, target: str = "origin/main") -> cleanup_mod.BranchClassification:
-                if branch == "ac-frontend-360-ticket":
-                    return cleanup_mod.BranchClassification(
-                        genuinely_ahead=[
-                            cleanup_mod.BranchCommit(sha="abc123", subject="chore: unpushed", is_merge=False),
-                        ],
-                    )
-                return cleanup_mod.BranchClassification()
+            def _blockers(_repo: str, branch: str, target: str = "origin/main") -> list[str]:
+                # The frontend branch's commit content is NOT on origin/main —
+                # the authoritative content gate (#2609) refuses its force-delete.
+                return ["abc123"] if branch == "ac-frontend-360-ticket" else []
 
             mock_config = MagicMock()
             mock_config.user.workspace_dir = workspace
@@ -1672,7 +1668,9 @@ class TestWorkspaceCleanAll(TestCase):
                 patch.object(cleanup_mod, "load_config", return_value=mock_config),
                 patch.object(cleanup_mod, "git") as mock_git,
                 patch.object(cleanup_mod, "get_overlay_for_worktree") as mock_overlay,
-                patch.object(cleanup_mod, "classify_branch_commits", side_effect=_classify),
+                patch.object(cleanup_mod, "content_equivalence_blockers", side_effect=_blockers),
+                patch.object(cleanup_mod, "_branch_tree_matches_squash", return_value=False),
+                patch.object(cleanup_mod, "_branch_pr_is_merged", return_value=False),
                 # Isolate the recovery-capture seam — the fake repos (.git is a
                 # bare dir) can't satisfy a real ``git bundle``; this test
                 # targets the origin/main hygiene refusal, not capture.
@@ -1683,7 +1681,7 @@ class TestWorkspaceCleanAll(TestCase):
                 mock_git.unsynced_commits.side_effect = _unsynced
                 # Both branches are pushed to their own remote ref, so the
                 # #706 data-loss guard passes; this test targets the stricter
-                # origin/main hygiene refusal on the frontend branch.
+                # origin/main content hygiene refusal on the frontend branch.
                 mock_git.commits_absent_from_all_remotes.return_value = []
                 # No drift: each on-disk worktree's effective branch is its DB
                 # slug. The hygiene classification runs against that real branch.
@@ -1694,7 +1692,7 @@ class TestWorkspaceCleanAll(TestCase):
                 cleaned = cast("list[str]", call_command("workspace", "clean-all"))
 
             assert any("Cleaned: backend" in c for c in cleaned)
-            assert any("ac-frontend-360-ticket" in c and "unsynced" in c.lower() for c in cleaned)
+            assert any("ac-frontend-360-ticket" in c and "content not upstream" in c.lower() for c in cleaned)
             assert Worktree.objects.filter(branch="ac-backend-360-ticket").count() == 0
             assert Worktree.objects.filter(branch="ac-frontend-360-ticket").count() == 1
 
@@ -1732,13 +1730,6 @@ class TestWorkspaceCleanAll(TestCase):
                 extra={"worktree_path": str(stuck_wt_dir)},
             )
 
-            def _classify(_repo: str, branch: str, target: str = "origin/main") -> cleanup_mod.BranchClassification:
-                return cleanup_mod.BranchClassification(
-                    genuinely_ahead=[
-                        cleanup_mod.BranchCommit(sha="abc123", subject="chore: unpushed", is_merge=False),
-                    ],
-                )
-
             stdin_read_msg = "clean-all read stdin in a non-interactive context (#279)"
 
             def _input_must_not_be_called(*_a: object, **_k: object) -> str:
@@ -1755,7 +1746,11 @@ class TestWorkspaceCleanAll(TestCase):
                 patch.object(cleanup_mod, "load_config", return_value=mock_config),
                 patch.object(cleanup_mod, "git") as mock_git,
                 patch.object(cleanup_mod, "get_overlay_for_worktree") as mock_overlay,
-                patch.object(cleanup_mod, "classify_branch_commits", side_effect=_classify),
+                # The content gate (#2609) reports the branch as not provably
+                # upstream → clean-all refuses it without a stdin prompt.
+                patch.object(cleanup_mod, "content_equivalence_blockers", return_value=["abc123"]),
+                patch.object(cleanup_mod, "_branch_tree_matches_squash", return_value=False),
+                patch.object(cleanup_mod, "_branch_pr_is_merged", return_value=False),
                 patch.object(cleanup_mod, "capture_recovery_artifact", return_value=None),
             ):
                 mock_overlay.return_value.get_cleanup_steps.return_value = []
@@ -1766,7 +1761,7 @@ class TestWorkspaceCleanAll(TestCase):
                 mock_git.current_branch.side_effect = lambda _wt: "ac-frontend-279-ticket"
                 cleaned = cast("list[str]", call_command("workspace", "clean-all"))
 
-            assert any("ac-frontend-279-ticket" in c and "unsynced" in c.lower() for c in cleaned)
+            assert any("ac-frontend-279-ticket" in c and "content not upstream" in c.lower() for c in cleaned)
             assert Worktree.objects.filter(branch="ac-frontend-279-ticket").count() == 1
 
     @_no_prune

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -20,7 +20,6 @@ import typer
 import teatree.cli.setup as setup_mod
 import teatree.config as config_mod
 from teatree.cli import update as update_mod
-from teatree.cli._update_reconcile import _cherry_not_upstream, _merge_commits_in_range
 from teatree.cli.update import (
     ReinstallResult,
     RepoUpdate,
@@ -31,6 +30,7 @@ from teatree.cli.update import (
     _reinstall_and_resetup,
     update_repo,
 )
+from teatree.core.branch_classification import branch_content_upstream, content_equivalence_blockers
 
 
 def _git(cwd: Path, *args: str) -> str:
@@ -961,26 +961,21 @@ class TestUpdateReconcilesSquashMergedClone:
 class TestContentGateFailsSafe:
     """An inconclusive content check must REFUSE the reset, never authorize it.
 
-    Both gate probes (``git cherry`` and ``git rev-list --merges``) fail safe:
-    a non-zero git exit (a corrupt ref, a missing target) is inconclusive, so
-    the helper reports an opaque genuine "sha" and the caller keeps the
-    conservative refuse — ambiguity never reaps real work.
+    The shared :func:`content_equivalence_blockers` gate (``git cherry`` patch-id
+    + a merge-commit check) fails CLOSED: an unresolvable target makes both probes
+    exit non-zero (inconclusive), so the helper reports an opaque blocker and the
+    caller keeps the conservative refuse — ambiguity never reaps real work. This is
+    the SAME helper the clean-all force-delete path consumes (#2609).
     """
 
-    def test_cherry_failure_reports_a_genuine_blocker(self, tmp_path: Path) -> None:
+    def test_inconclusive_probe_reports_a_blocker(self, tmp_path: Path) -> None:
         bare = _make_remote(tmp_path)
         clone = _clone(tmp_path, bare)
         # An unresolvable target makes `git cherry` exit non-zero (rc 128).
-        blockers = _cherry_not_upstream(clone, "origin/does-not-exist")
-        assert blockers, "an inconclusive git cherry must report a blocker, not an empty pass"
+        blockers = content_equivalence_blockers(str(clone), "main", "origin/does-not-exist")
+        assert blockers, "an inconclusive content probe must report a blocker, not an empty pass"
         assert "inconclusive" in blockers[0]
-
-    def test_rev_list_merges_failure_reports_a_genuine_blocker(self, tmp_path: Path) -> None:
-        bare = _make_remote(tmp_path)
-        clone = _clone(tmp_path, bare)
-        blockers = _merge_commits_in_range(clone, "origin/does-not-exist")
-        assert blockers, "an inconclusive git rev-list --merges must report a blocker, not an empty pass"
-        assert "inconclusive" in blockers[0]
+        assert branch_content_upstream(str(clone), "main", "origin/does-not-exist") is False
 
 
 class TestRunCallback:


### PR DESCRIPTION
Closes #2609.

## Problem

`classify_branch_commits` / `_canonicalize_subject` bucket a branch's unsynced commits as `squash_merged` purely by canonicalized-SUBJECT membership in the last N (`-n 500`) upstream subjects — no patch-id / content / tree check. Subject-matching is fine to *recognize* a forge-squash-merged candidate (a squash creates a new SHA), but it is unsafe to *authorize* a destroy: a genuine un-upstreamed commit whose subject collides with an already-upstreamed subject (e.g. a routine `docs: update skills` on the clone's default branch matching an already-upstreamed `docs: update skills`) is misclassified `squash_merged` and would be destroyed.

#2607 already guarded ITS reset path (`cli/_update_reconcile.py`) with a content gate. The gap: the clean-all force-DELETE path (`core/cleanup.py`) was NOT. `_raise_if_genuinely_ahead` returned early when `genuinely_ahead` was emptied by subject-match (every unsynced commit drained into `squash_merged`/`merge_commits`), reaching the force-delete with NO content check. Its fallbacks (`_branch_tree_matches_squash`, `_branch_pr_is_merged`) ran only as overrides when `genuinely_ahead` was non-empty, so a pure subject collision slipped through.

## The fix — one shared content-equivalence helper, two destructive callers

A single shared helper in `core/branch_classification.py` that every destructive caller must pass before destroying anything:

- `content_equivalence_blockers(repo, branch, target)` — `git cherry` (patch-id) `+` lines plus any merge commit in the `target..branch` range. An empty list is positive proof every commit's content is already upstream. **Fails CLOSED**: any inconclusive git probe (`run_strict` raises) returns an opaque blocker so the caller refuses.
- `branch_content_upstream(...)` — the boolean view (`not content_equivalence_blockers(...)`).

Subject-match stays the cheap *recognizer*; content-equivalence is the *authorization* to destroy.

### Each destructive caller now gated

- **clean-all branch + worktree force-delete** (`cleanup._raise_if_genuinely_ahead`, reached by `_remove_git_worktree` under the clean-all `strict_hygiene=True` default): now requires `content_equivalence_blockers` to confirm before the force-delete. The `_branch_tree_matches_squash` / `_branch_pr_is_merged` signals stay as positive merged-evidence overrides for long-diverged squash-merges where patch-id no longer matches.
- **#2607 reset path** (`_update_reconcile.reconcile_squash_merged`) DRY'd onto the same helper, replacing its local `_cherry_not_upstream` + `_merge_commits_in_range`. Its backup-ref defense-in-depth and no-merge-commit conservatism are preserved.

The `strict_hygiene=False` teardown paths (`clean_merged` for FSM-MERGED tickets; the squash-merged-row reaper, which already runs `is_squash_merged`'s own `git cherry` content check) are NOT the subject-only-authorized hazard and are unchanged; the always-on #706 `_raise_if_unpushed` data-loss guard still protects them.

## Test proof (TDD, real `git` under `tmp_path`)

`tests/teatree_core/cleanup/test_content_equivalence.py`:

- **subject-collision genuine work is NOT destroyed** — a genuine un-upstreamed commit whose subject collides with an unrelated upstream subject (different content); clean-all force-delete REFUSES. Observed RED before the fix (`DID NOT RAISE` — the worktree would be force-deleted), GREEN after.
- **genuinely-upstreamed branch IS deleted** — a real squash-merge (verbatim patch upstream); clean-all removes it. Confirms no over-blocking.
- **fail-closed on git error** — an unresolvable target makes the content probe inconclusive; the helper refuses.

The existing #2607 vector tests (subject collision, amended content, evil-merge, fail-safe) in `tests/test_cli_update.py` stay green against the shared helper. Full regression suite: 19888 passed, 44 skipped, 5 xfailed, 0 failures.

## Architecture pre-check

**BLUEPRINT §:** data-loss teardown guards; /t3:rules "Re-Validate a Reused Guard in a New Destructive Context".
**FSM:** n/a — no state transition.
**Extension points:** none — module-level function in `core.branch_classification`.
**Component boundaries:** helper lives beside `classify_branch_commits` (its cheap recognizer); both destructive callers already import from `branch_classification`.
**Dependency direction:** `tach check` passed — no new cross-module edge (the helper uses the existing `teatree.utils.git` runner).
**Resilience:** the destroy is the write; fail-CLOSED on any git error; a refusal is an idempotent no-op; #2607 backup-ref preserved.
**Behavior preservation:** the DRY of `_cherry_not_upstream` + `_merge_commits_in_range` preserves the patch-id check, the merge-commit check, the inconclusive fail-closed string, the loud refuse-warning, and the backup ref. No must-block test inverted.

## Follow-up (not in scope, noted)

`_workspace_cleanup.is_squash_merged` / `_branch_captured_upstream` is a third `git cherry` content helper (bool, ANDs with a forge query, no merge-commit conservatism). It already content-gates its path, so it is not a data-loss hazard — fully unifying it onto the shared helper would change its forge-AND semantics and is left as a separate decision.

NOT merged — awaiting independent cold-review.
