### PR TITLE
fix(worktree): teardown survives a base missing an optional step module (#2664)

### DIFF
--- a/src/teatree/core/step_runner.py
+++ b/src/teatree/core/step_runner.py
@@ -11,6 +11,8 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from teatree.utils.run import run_allowed_to_fail
+
 logger = logging.getLogger(__name__)
 
 
@@ -90,10 +92,17 @@ def run_step(  # noqa: PLR0913
     silently (souliane/teatree#2220). With ``check=False`` a non-zero exit
     stays benign (the historical contract), while a timeout / command-not-found
     is still surfaced as a failure.
-    """
-    from teatree.core.provision_timebox import run_timeboxed_step  # noqa: PLC0415
 
-    result = run_timeboxed_step(name, cmd, cwd=cwd, env=env, timeout=timeout)
+    The time-box enhancement is *optional*. ``worktree teardown`` runs the
+    worktree's OWN checkout (``uv --directory <worktree> run``), whose base may
+    predate ``provision_timebox`` (#2220); the lazy import then raised
+    ``ModuleNotFoundError`` and aborted the whole teardown, skipping the steps
+    ordered after it — orphaning the DB, the ``Worktree`` row, and containers
+    (souliane/teatree#2664). When the module is absent, degrade to a plain
+    time-box-free subprocess run that keeps the same ``StepResult`` contract,
+    never abort the caller.
+    """
+    result = _timeboxed_step(name, cmd, cwd=cwd, env=env, timeout=timeout)
     if result.success or check:
         return result
     if result.error.startswith(("timed out", "command not found")):
@@ -105,6 +114,64 @@ def run_step(  # noqa: PLR0913
         stdout=result.stdout,
         stderr=result.stderr,
     )
+
+
+def _timeboxed_step(
+    name: str,
+    cmd: list[str],
+    *,
+    cwd: str | Path | None,
+    env: dict[str, str] | None,
+    timeout: int | None,
+) -> StepResult:
+    """Run via the time-box enhancement, falling back to a plain subprocess.
+
+    The enhancement (timeout ceiling + heartbeat + forked-migration alert) is
+    layered on plain subprocess execution; when its module is unimportable on a
+    stale base it is simply absent, so the plain run is the correct degradation
+    (souliane/teatree#2664).
+    """
+    try:
+        from teatree.core.provision_timebox import run_timeboxed_step  # noqa: PLC0415
+    except ImportError:
+        logger.warning("provision_timebox unavailable for step %r — plain subprocess run", name)
+        return _plain_subprocess_step(name, cmd, cwd=cwd, env=env, timeout=timeout)
+    return run_timeboxed_step(name, cmd, cwd=cwd, env=env, timeout=timeout)
+
+
+def _plain_subprocess_step(
+    name: str,
+    cmd: list[str],
+    *,
+    cwd: str | Path | None,
+    env: dict[str, str] | None,
+    timeout: int | None,
+) -> StepResult:
+    """Time-box-free subprocess run with the same :class:`StepResult` contract.
+
+    Mirrors :func:`teatree.core.provision_timebox.run_timeboxed_step`'s outcomes
+    minus the timeout ceiling / heartbeat / migration alert: a timeout surfaces
+    a ``"timed out"`` error, a missing binary a ``"command not found"`` error,
+    and a non-zero exit a captured failure — so every ``run_step`` consumer
+    classifies the result identically whether or not the enhancement is present.
+    """
+    start = time.monotonic()
+    try:
+        proc = run_allowed_to_fail(cmd, cwd=cwd, env=env, expected_codes=None, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        duration = time.monotonic() - start
+        return StepResult(name=name, success=False, duration=duration, error=f"timed out after {timeout}s")
+    except OSError as exc:
+        duration = time.monotonic() - start
+        target = getattr(exc, "filename", None) or (cmd[0] if cmd else str(exc))
+        return StepResult(name=name, success=False, duration=duration, error=f"command not found: {target}")
+    duration = time.monotonic() - start
+    if proc.returncode != 0:
+        error = proc.stderr.strip()[:500] if proc.stderr else f"exit code {proc.returncode}"
+        return StepResult(
+            name=name, success=False, duration=duration, stdout=proc.stdout, stderr=proc.stderr, error=error
+        )
+    return StepResult(name=name, success=True, duration=duration, stdout=proc.stdout, stderr=proc.stderr)
 
 
 def run_callable_step(name: str, fn: Callable[[], object]) -> StepResult:
@@ -196,9 +263,15 @@ def _alert_on_migration_conflict(result: StepResult) -> None:
     :func:`run_step`'s subprocess time-box. A forked migration graph hit by
     such a step is diagnosed by its symptom — "rebase/renumber needed" — and
     surfaced out-of-band, instead of leaving the agent to discover the grind
-    (souliane/teatree#2220). Best-effort: the alert never breaks provisioning.
+    (souliane/teatree#2220). Best-effort: the alert never breaks provisioning —
+    including when the executing base predates ``provision_timebox`` itself
+    (souliane/teatree#2664), in which case there is no alert path and the call is
+    a no-op.
     """
-    from teatree.core.provision_timebox import alert_provision_user, detect_migration_conflict  # noqa: PLC0415
+    try:
+        from teatree.core.provision_timebox import alert_provision_user, detect_migration_conflict  # noqa: PLC0415
+    except ImportError:
+        return
 
     conflict = detect_migration_conflict(f"{result.stdout}\n{result.stderr}\n{result.error}")
     if conflict is not None:

--- a/src/teatree/core/step_runner.py
+++ b/src/teatree/core/step_runner.py
@@ -15,6 +15,16 @@ from teatree.utils.run import run_allowed_to_fail
 
 logger = logging.getLogger(__name__)
 
+_PROVISION_TIMEBOX_MODULE = "teatree.core.provision_timebox"
+
+# Fallback hard ceiling (seconds) for the degraded plain-subprocess path, which
+# runs only when ``provision_timebox`` is ABSENT and so cannot consult its
+# configurable ``resolve_step_timeout_seconds()``. Matches that module's
+# ``DEFAULT_STEP_TIMEOUT_SECONDS`` so a ``timeout=None`` step still aborts on a
+# ceiling instead of hanging forever — the "never hang" invariant the time-box
+# exists for (souliane/teatree#2220) holds on the degraded path too.
+_PLAIN_STEP_TIMEOUT_FALLBACK_SECONDS = 1800
+
 
 @dataclass(frozen=True, slots=True)
 class StepResult:
@@ -127,13 +137,22 @@ def _timeboxed_step(
     """Run via the time-box enhancement, falling back to a plain subprocess.
 
     The enhancement (timeout ceiling + heartbeat + forked-migration alert) is
-    layered on plain subprocess execution; when its module is unimportable on a
-    stale base it is simply absent, so the plain run is the correct degradation
-    (souliane/teatree#2664).
+    layered on plain subprocess execution; when the ``provision_timebox`` module
+    itself is absent on a stale base it is simply not there, so the plain run is
+    the correct degradation (souliane/teatree#2664).
+
+    The catch is narrowed to the module's OWN absence — keyed on
+    ``ModuleNotFoundError.name`` — so a *present* ``provision_timebox`` that
+    fails to import because of a real internal/transitive-import bug (its
+    ``.name`` is the missing DEPENDENCY, not this module) re-raises and surfaces
+    via the normal failure path, instead of silently disabling the time-box for
+    every healthy install.
     """
     try:
         from teatree.core.provision_timebox import run_timeboxed_step  # noqa: PLC0415
-    except ImportError:
+    except ModuleNotFoundError as exc:
+        if exc.name != _PROVISION_TIMEBOX_MODULE:
+            raise
         logger.warning("provision_timebox unavailable for step %r — plain subprocess run", name)
         return _plain_subprocess_step(name, cmd, cwd=cwd, env=env, timeout=timeout)
     return run_timeboxed_step(name, cmd, cwd=cwd, env=env, timeout=timeout)
@@ -150,17 +169,20 @@ def _plain_subprocess_step(
     """Time-box-free subprocess run with the same :class:`StepResult` contract.
 
     Mirrors :func:`teatree.core.provision_timebox.run_timeboxed_step`'s outcomes
-    minus the timeout ceiling / heartbeat / migration alert: a timeout surfaces
-    a ``"timed out"`` error, a missing binary a ``"command not found"`` error,
-    and a non-zero exit a captured failure — so every ``run_step`` consumer
-    classifies the result identically whether or not the enhancement is present.
+    minus the heartbeat / migration alert: a timeout surfaces a ``"timed out"``
+    error, a missing binary a ``"command not found"`` error, and a non-zero exit
+    a captured failure — so every ``run_step`` consumer classifies the result
+    identically whether or not the enhancement is present. A ``None`` timeout
+    resolves to :data:`_PLAIN_STEP_TIMEOUT_FALLBACK_SECONDS` (never an unbounded
+    ``subprocess.run``) so the "never hang" invariant holds on this path too.
     """
+    ceiling = timeout if timeout is not None else _PLAIN_STEP_TIMEOUT_FALLBACK_SECONDS
     start = time.monotonic()
     try:
-        proc = run_allowed_to_fail(cmd, cwd=cwd, env=env, expected_codes=None, timeout=timeout)
+        proc = run_allowed_to_fail(cmd, cwd=cwd, env=env, expected_codes=None, timeout=ceiling)
     except subprocess.TimeoutExpired:
         duration = time.monotonic() - start
-        return StepResult(name=name, success=False, duration=duration, error=f"timed out after {timeout}s")
+        return StepResult(name=name, success=False, duration=duration, error=f"timed out after {ceiling}s")
     except OSError as exc:
         duration = time.monotonic() - start
         target = getattr(exc, "filename", None) or (cmd[0] if cmd else str(exc))
@@ -266,11 +288,15 @@ def _alert_on_migration_conflict(result: StepResult) -> None:
     (souliane/teatree#2220). Best-effort: the alert never breaks provisioning —
     including when the executing base predates ``provision_timebox`` itself
     (souliane/teatree#2664), in which case there is no alert path and the call is
-    a no-op.
+    a no-op. The catch is narrowed to the module's OWN absence (keyed on
+    ``ModuleNotFoundError.name``) so a *present* module with a real internal
+    import bug re-raises rather than silently suppressing the alert.
     """
     try:
         from teatree.core.provision_timebox import alert_provision_user, detect_migration_conflict  # noqa: PLC0415
-    except ImportError:
+    except ModuleNotFoundError as exc:
+        if exc.name != _PROVISION_TIMEBOX_MODULE:
+            raise
         return
 
     conflict = detect_migration_conflict(f"{result.stdout}\n{result.stderr}\n{result.error}")

--- a/tests/teatree_core/_provision_timebox_stub.py
+++ b/tests/teatree_core/_provision_timebox_stub.py
@@ -1,0 +1,34 @@
+"""Shared test seam: make ``provision_timebox`` unimportable (souliane/teatree#2664).
+
+Models a worktree torn down from a STALE base — one created before
+``provision_timebox`` was added (souliane/teatree#2220). Teardown runs the
+worktree's OWN checkout (``uv --directory <worktree> run``), so its interpreter
+cannot import the module the orchestrating ``t3`` added later; the lazy import in
+``run_step`` then raised ``ModuleNotFoundError`` and aborted the whole teardown.
+"""
+
+import builtins
+from typing import Self
+from unittest.mock import patch
+
+_PROVISION_TIMEBOX = "teatree.core.provision_timebox"
+
+
+class provision_timebox_unimportable:  # noqa: N801 — context-manager reads as a verb at the call site
+    """Context manager: ``import teatree.core.provision_timebox`` raises ModuleNotFoundError."""
+
+    _real_import = builtins.__import__
+
+    def __enter__(self) -> Self:
+        self._patch = patch.object(builtins, "__import__", self._raising_import)
+        self._patch.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._patch.stop()
+
+    def _raising_import(self, name: str, *args: object, **kwargs: object) -> object:
+        if name == _PROVISION_TIMEBOX:
+            msg = f"No module named '{_PROVISION_TIMEBOX}'"
+            raise ModuleNotFoundError(msg, name=name)
+        return self._real_import(name, *args, **kwargs)

--- a/tests/teatree_core/_provision_timebox_stub.py
+++ b/tests/teatree_core/_provision_timebox_stub.py
@@ -1,10 +1,21 @@
-"""Shared test seam: make ``provision_timebox`` unimportable (souliane/teatree#2664).
+"""Shared test seams modelling ``provision_timebox`` import failures (souliane/teatree#2664).
 
-Models a worktree torn down from a STALE base — one created before
-``provision_timebox`` was added (souliane/teatree#2220). Teardown runs the
-worktree's OWN checkout (``uv --directory <worktree> run``), so its interpreter
-cannot import the module the orchestrating ``t3`` added later; the lazy import in
-``run_step`` then raised ``ModuleNotFoundError`` and aborted the whole teardown.
+Two distinct, oft-confused failure shapes.
+
+``provision_timebox_unimportable`` models the module ITSELF being absent — a
+worktree torn down from a STALE base created before ``provision_timebox`` was
+added in #2220. Teardown runs the worktree's OWN checkout (``uv --directory
+<worktree> run``), so its interpreter cannot import the module the orchestrating
+``t3`` added later. The lazy import raises a ``ModuleNotFoundError`` whose
+``.name`` IS ``teatree.core.provision_timebox``, and ``run_step`` must degrade to
+a plain subprocess run.
+
+``provision_timebox_internally_broken`` models the module being PRESENT but its
+own body hitting a broken transitive import (a missing dependency). Python
+surfaces a ``ModuleNotFoundError`` whose ``.name`` is the missing DEPENDENCY, not
+``provision_timebox``. ``run_step`` must NOT swallow this — silently degrading
+would disable the timeout/heartbeat/alert for every healthy install and mask the
+real bug — so it must PROPAGATE.
 """
 
 import builtins
@@ -13,9 +24,13 @@ from unittest.mock import patch
 
 _PROVISION_TIMEBOX = "teatree.core.provision_timebox"
 
+#: ``.name`` of the error a present-but-broken ``provision_timebox`` would raise
+#: from its own body (a missing transitive dependency, NOT this module).
+BROKEN_DEPENDENCY_NAME = "some_missing_transitive_dep"
+
 
 class provision_timebox_unimportable:  # noqa: N801 — context-manager reads as a verb at the call site
-    """Context manager: ``import teatree.core.provision_timebox`` raises ModuleNotFoundError."""
+    """Context manager: ``import teatree.core.provision_timebox`` raises ModuleNotFoundError (module absent)."""
 
     _real_import = builtins.__import__
 
@@ -31,4 +46,29 @@ class provision_timebox_unimportable:  # noqa: N801 — context-manager reads as
         if name == _PROVISION_TIMEBOX:
             msg = f"No module named '{_PROVISION_TIMEBOX}'"
             raise ModuleNotFoundError(msg, name=name)
+        return self._real_import(name, *args, **kwargs)
+
+
+class provision_timebox_internally_broken:  # noqa: N801 — context-manager reads as a verb at the call site
+    """Context manager: importing ``provision_timebox`` fails on its OWN broken transitive import.
+
+    The module is present, so the error's ``.name`` is the missing DEPENDENCY —
+    exactly what Python raises when a present module's body executes a
+    ``from <missing_dep> import ...`` line.
+    """
+
+    _real_import = builtins.__import__
+
+    def __enter__(self) -> Self:
+        self._patch = patch.object(builtins, "__import__", self._raising_import)
+        self._patch.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._patch.stop()
+
+    def _raising_import(self, name: str, *args: object, **kwargs: object) -> object:
+        if name == _PROVISION_TIMEBOX:
+            msg = f"No module named '{BROKEN_DEPENDENCY_NAME}'"
+            raise ModuleNotFoundError(msg, name=BROKEN_DEPENDENCY_NAME)
         return self._real_import(name, *args, **kwargs)

--- a/tests/teatree_core/cleanup/test_cleanup_worktree.py
+++ b/tests/teatree_core/cleanup/test_cleanup_worktree.py
@@ -17,6 +17,7 @@ from teatree.core.cleanup import cleanup_worktree
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay import OverlayBase, ProvisionStep, RunCommands
 from teatree.utils.run import CommandFailedError
+from tests.teatree_core._provision_timebox_stub import provision_timebox_unimportable
 
 _patch_config = patch("teatree.core.cleanup.load_config")
 _patch_git = patch("teatree.core.cleanup.git")
@@ -704,6 +705,73 @@ class TestCleanupWorktree(TestCase):
 
         mock_git.worktree_remove.assert_called_once()
         mock_git.branch_delete.assert_called_once()
+
+
+class TestCleanupWorktreeSurvivesMissingProvisionTimebox(TestCase):
+    """souliane/teatree#2664 — teardown completes ALL steps on a stale base.
+
+    The benign prek hook-cleanup path (``_remove_git_worktree`` →
+    ``prek_hook.remove_stale_hooks`` → ``_shared_hooks_dir`` → ``run_step``)
+    drags in a lazy ``import teatree.core.provision_timebox``. When the executing
+    checkout's base predates that module the import raised ``ModuleNotFoundError``
+    and aborted ``cleanup_worktree`` mid-stream — every step ordered AFTER the
+    abort (DB drop, pass-entry removal, ``Worktree`` row delete) was SKIPPED,
+    leaving an orphaned DB and DB row. The fix makes the abort impossible, so the
+    later steps run.
+    """
+
+    def _make_worktree(self, *, db_name: str = "wt_2664") -> Worktree:
+        ticket = Ticket.objects.create(
+            issue_url="https://gitlab.com/org/repo/-/issues/2664",
+            state=Ticket.State.IN_REVIEW,
+        )
+        return Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="org/repo",
+            branch="fix-2664",
+            db_name=db_name,
+            extra={"worktree_path": "/tmp/wt/org/repo"},
+        )
+
+    @_patch_overlay
+    @_patch_config
+    def test_db_drop_and_row_delete_still_run_when_module_absent(
+        self,
+        mock_config: MagicMock,
+        mock_overlay: MagicMock,
+    ) -> None:
+        """The prek hook-cleanup import failing must not skip the later teardown steps.
+
+        ``git`` is NOT wholesale-mocked here: the real ``cleanup.git`` runs so
+        ``prek_hook.remove_stale_hooks`` genuinely reaches ``run_step`` (the
+        abort site) against a tmp worktree path with no checkout. The assertion
+        is anti-vacuous — it pins that the DB-drop step IS invoked and the
+        ``Worktree`` row IS deleted, the two steps the abort skipped, not merely
+        that no exception escaped.
+        """
+        _mock_workspace(mock_config)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_overlay.return_value.reap_worktree_external_resources.return_value = []
+
+        wt = self._make_worktree(db_name="wt_2664")
+        wt_id = wt.pk
+
+        with (
+            patch("teatree.core.cleanup.git") as mock_git,
+            patch("teatree.core.cleanup.drop_db") as mock_drop,
+            patch("teatree.core.runners.worktree_start.docker_compose_down"),
+            provision_timebox_unimportable(),
+        ):
+            _no_unpushed(mock_git)
+            mock_git.status_porcelain.return_value = ""
+            mock_git.unsynced_commits.return_value = []
+            result = cleanup_worktree(wt, strict_hygiene=False)
+
+        mock_drop.assert_called_once()
+        assert mock_drop.call_args.args == ("wt_2664",)
+        assert not Worktree.objects.filter(pk=wt_id).exists()
+        assert result.clean is True
 
 
 class TestCleanupWorktreeLoudTeardown(TestCase):

--- a/tests/teatree_core/test_step_runner.py
+++ b/tests/teatree_core/test_step_runner.py
@@ -9,6 +9,7 @@ from django.test import TestCase
 
 from teatree.core.overlay import ProvisionStep
 from teatree.core.step_runner import ProvisionReport, StepResult, run_callable_step, run_provision_steps, run_step
+from tests.teatree_core._provision_timebox_stub import provision_timebox_unimportable
 
 
 class TestStepResult(TestCase):
@@ -99,6 +100,64 @@ class TestRunStep(TestCase):
         result = run_step("missing", ["nonexistent_binary_xyz123"])
         assert result.success is False
         assert "command not found" in result.error
+
+
+class TestRunStepSurvivesMissingProvisionTimebox(TestCase):
+    """souliane/teatree#2664 — ``run_step`` degrades when ``provision_timebox`` is absent.
+
+    Teardown runs the WORKTREE's own checkout (``uv --directory <worktree>
+    run``). A worktree whose base predates ``provision_timebox`` (#2220) cannot
+    import it, so the lazy ``from teatree.core.provision_timebox import
+    run_timeboxed_step`` in ``run_step`` raised ``ModuleNotFoundError`` and
+    aborted the whole teardown runner mid-stream — skipping every step ordered
+    after the abort (DB drop, ``Worktree`` row delete, docker down). The
+    optional time-box enhancement must degrade to a plain subprocess run, never
+    abort the caller.
+    """
+
+    @patch("teatree.utils.run.subprocess")
+    def test_run_step_does_not_raise_when_module_absent(self, mock_sp: MagicMock) -> None:
+        mock_sp.run.return_value = MagicMock(returncode=0, stdout="hooks\n", stderr="")
+        mock_sp.TimeoutExpired = subprocess.TimeoutExpired
+
+        with provision_timebox_unimportable():
+            result = run_step("git-hooks-path", ["git", "rev-parse", "--git-path", "hooks"], check=False)
+
+        assert result.success is True
+        assert result.name == "git-hooks-path"
+        assert "hooks" in result.stdout
+
+    @patch("teatree.utils.run.subprocess")
+    def test_run_step_soft_fail_stays_benign_when_module_absent(self, mock_sp: MagicMock) -> None:
+        mock_sp.run.return_value = MagicMock(returncode=1, stdout="", stderr="ignored")
+        mock_sp.TimeoutExpired = subprocess.TimeoutExpired
+
+        with provision_timebox_unimportable():
+            result = run_step("soft-fail", ["false"], check=False)
+
+        assert result.success is True
+
+    @patch("teatree.utils.run.subprocess")
+    def test_run_step_command_not_found_surfaced_when_module_absent(self, mock_sp: MagicMock) -> None:
+        mock_sp.run.side_effect = FileNotFoundError("no such file: nope")
+        mock_sp.TimeoutExpired = subprocess.TimeoutExpired
+
+        with provision_timebox_unimportable():
+            result = run_step("missing", ["nope"], check=False)
+
+        assert result.success is False
+        assert "command not found" in result.error
+
+    @patch("teatree.utils.run.subprocess")
+    def test_run_step_timeout_surfaced_when_module_absent(self, mock_sp: MagicMock) -> None:
+        mock_sp.run.side_effect = subprocess.TimeoutExpired(cmd=["slow"], timeout=1)
+        mock_sp.TimeoutExpired = subprocess.TimeoutExpired
+
+        with provision_timebox_unimportable():
+            result = run_step("slow", ["sleep", "999"], timeout=1, check=False)
+
+        assert result.success is False
+        assert "timed out" in result.error
 
 
 class TestRunCallableStep(TestCase):

--- a/tests/teatree_core/test_step_runner.py
+++ b/tests/teatree_core/test_step_runner.py
@@ -9,7 +9,11 @@ from django.test import TestCase
 
 from teatree.core.overlay import ProvisionStep
 from teatree.core.step_runner import ProvisionReport, StepResult, run_callable_step, run_provision_steps, run_step
-from tests.teatree_core._provision_timebox_stub import provision_timebox_unimportable
+from tests.teatree_core._provision_timebox_stub import (
+    BROKEN_DEPENDENCY_NAME,
+    provision_timebox_internally_broken,
+    provision_timebox_unimportable,
+)
 
 
 class TestStepResult(TestCase):
@@ -158,6 +162,20 @@ class TestRunStepSurvivesMissingProvisionTimebox(TestCase):
 
         assert result.success is False
         assert "timed out" in result.error
+
+    def test_run_step_propagates_when_module_present_but_internally_broken(self) -> None:
+        """A present ``provision_timebox`` failing on its OWN broken import must NOT be swallowed.
+
+        The catch is narrowed to the module's own absence (``ModuleNotFoundError.name`` ==
+        ``teatree.core.provision_timebox``). A present-but-internally-broken module raises a
+        ``ModuleNotFoundError`` whose ``.name`` is the missing DEPENDENCY, so ``run_step`` must
+        re-raise it rather than silently degrading to a plain run — which would disable the
+        timeout/heartbeat/alert for every healthy install and mask the real bug.
+        """
+        with provision_timebox_internally_broken(), pytest.raises(ModuleNotFoundError) as exc_info:
+            run_step("probe", ["true"], check=False)
+
+        assert exc_info.value.name == BROKEN_DEPENDENCY_NAME
 
 
 class TestRunCallableStep(TestCase):


### PR DESCRIPTION
fix(worktree): teardown survives a base missing an optional step module (#2664)

closes #2664

## What

`t3 <overlay> worktree teardown [--force]` aborted with a Python traceback
ending in `ModuleNotFoundError: No module named 'teatree.core.provision_timebox'`.
The git worktree dir often still got removed, so it LOOKED non-fatal — but the
step runner aborted mid-teardown, so every step ordered AFTER the failing import
(DB drop, overlay pass-entry removal, external-resource reap, the `Worktree` row
delete) was SKIPPED, leaving orphaned DBs / rows / containers.

This makes `run_step` degrade gracefully: when `teatree.core.provision_timebox`
is unimportable, it falls back to a plain time-box-free subprocess run that keeps
the same `StepResult` contract, instead of aborting the whole caller.
`_alert_on_migration_conflict` degrades the same way.

## Why

Teardown runs the WORKTREE's OWN checkout (`uv --directory <worktree> run …`).
A worktree whose base predates `provision_timebox` (added in #2220) cannot import
it, so the lazy `from teatree.core.provision_timebox import run_timeboxed_step` at
`step_runner.py` raised `ModuleNotFoundError`. The abort surfaced on a *benign*
hook-cleanup path that has nothing to do with the time-box feature:

```
cleanup.py  cleanup_worktree
  -> cleanup.py  _remove_git_worktree
    -> prek_hook.py  remove_stale_hooks
      -> prek_hook.py  _shared_hooks_dir
        -> step_runner.py  run_step
          -> import teatree.core.provision_timebox   # ModuleNotFoundError
```

This is a **class bug** — any module added after a worktree's base was created
(a rename, a new optional step module) breaks teardown the same way. The fix
targets the class: the time-box enhancement (timeout ceiling + heartbeat +
forked-migration alert) is *optional*, layered on plain subprocess execution, so
an absent module degrades to the plain run rather than aborting. No special-casing
of the `provision_timebox` name.

## Step order proof (which steps the abort skipped)

`cleanup_worktree`'s order: `docker_compose_down` -> overlay cleanup steps ->
`_remove_git_worktree` (the abort site) -> `_drop_worktree_db` ->
`_remove_overlay_pass_entry` -> `reap_external_resources` -> `worktree.delete()`.
The abort in `_remove_git_worktree` (the prek hook cleanup) therefore skipped the
DB drop, the overlay pass-entry removal, the external-resource reap, and the
`Worktree` row delete — exactly the orphaned-DB / orphaned-row / orphaned-container
class the ticket describes.

## Test plan (RED -> GREEN, anti-vacuous)

Two layers, both observed RED on the pre-fix code and GREEN after.

**Unit (`tests/teatree_core/test_step_runner.py::TestRunStepSurvivesMissingProvisionTimebox`)** —
patches `import teatree.core.provision_timebox` to raise `ModuleNotFoundError`
(modelling the stale base) and asserts `run_step` does NOT raise and still
classifies success / soft-fail / command-not-found / timeout identically.

- RED before fix — failing assertion: the `run_step` call itself raised, never
  reaching the assert:
  `ModuleNotFoundError: No module named 'teatree.core.provision_timebox'`
  at the lazy import inside `run_step`.
- GREEN after fix — the 4 absent-module tests pass; the degradation logs
  `provision_timebox unavailable for step '…' — plain subprocess run`.

**Narrowed-catch guard (`test_run_step_propagates_when_module_present_but_internally_broken`)** —
the degradation must fire ONLY when `provision_timebox` itself is absent, never
when a *present* module fails to import on its OWN broken transitive dependency
(which would silently disable the timeout/heartbeat/alert for every healthy
install and mask the real bug). The catch is keyed on `ModuleNotFoundError.name`:
a present-but-broken module's error names the missing DEPENDENCY, so it
re-raises. The test asserts:

```python
with provision_timebox_internally_broken(), pytest.raises(ModuleNotFoundError) as exc_info:
    run_step("probe", ["true"], check=False)
assert exc_info.value.name == BROKEN_DEPENDENCY_NAME
```

- RED before narrowing — with the catch widened back to a bare
  `except ModuleNotFoundError:` (no `.name` guard) the broken module is swallowed:
  `Failed: DID NOT RAISE <class 'ModuleNotFoundError'>` (the log shows
  `provision_timebox unavailable for step 'probe' — plain subprocess run`).
- GREEN after narrowing — the broken-dependency `ModuleNotFoundError` propagates
  out of `run_step` and the assertion on `.name` passes.

**Integration (`tests/teatree_core/cleanup/test_cleanup_worktree.py::TestCleanupWorktreeSurvivesMissingProvisionTimebox`)** —
runs `cleanup_worktree` with the real `cleanup.git` reaching
`prek_hook.remove_stale_hooks` -> `run_step` (the genuine abort path) while
`provision_timebox` is unimportable. The assertion is anti-vacuous: it pins that
the **DB-drop step is invoked** (`mock_drop.assert_called_once()`, args
`("wt_2664",)`) and the **`Worktree` row is deleted**
(`assert not Worktree.objects.filter(pk=wt_id).exists()`) — the two steps the
abort skipped — not merely that no exception escaped.

- RED before fix — the `cleanup_worktree(...)` call raised
  `ModuleNotFoundError: No module named 'teatree.core.provision_timebox'`
  via `cleanup.py:634 -> cleanup.py:452 -> prek_hook.py:84 -> prek_hook.py:16 -> step_runner.py:94`
  (the exact live traceback from the ticket), so `mock_drop` was never called and
  the row survived.
- GREEN after fix — the call completes, `mock_drop` is invoked, the row is deleted,
  `result.clean is True`.

**Anti-vacuity re-confirmed** twice — (a) widening `_timeboxed_step` back to
re-raise on the absent module turned the absent-module + integration tests RED;
(b) widening the catch back to bare `except ModuleNotFoundError:` turned the
new propagation test RED (`DID NOT RAISE`). Restoring the narrowed catch returned
all to GREEN.

### Plain-subprocess "never hang" ceiling

The degraded `_plain_subprocess_step` runs only when `provision_timebox` is
absent, so it cannot consult that module's configurable
`resolve_step_timeout_seconds()`. A `timeout=None` would otherwise pass straight
to `subprocess.run(timeout=None)` and hang forever — breaking the very "never
hang" invariant the time-box exists for. The plain path now resolves `None` to a
`step_runner`-local `_PLAIN_STEP_TIMEOUT_FALLBACK_SECONDS` (1800s, matching the
module's `DEFAULT_STEP_TIMEOUT_SECONDS`), so the invariant holds on the degraded
path too.

### Commands

```
# unit + integration regression (the new tests, incl. the propagation guard)
uv run pytest tests/teatree_core/test_step_runner.py \
  tests/teatree_core/cleanup/test_cleanup_worktree.py \
  --no-migrations --reuse-db        # 59 passed

# touched-surface regression (with migrations) — no regressions
uv run pytest tests/teatree_core/test_step_runner.py tests/teatree_core/cleanup/ \
  tests/teatree_core/test_provision_timebox.py tests/teatree_core/test_prek_hook.py \
  tests/teatree_core/test_prek_install_during_provision.py \
  tests/teatree_core/test_provisioning_contract.py --reuse-db   # 149 passed

uv run tach check                                   # All modules validated
uv run ty check src/teatree/core/step_runner.py     # All checks passed
uv run python manage.py makemigrations --check --dry-run   # No changes detected
```

## Architecture pre-check

**1. BLUEPRINT § alignment** — Touches the worktree-lifecycle teardown path
(§ workspace lifecycle / cleanup). No contract change; restores the documented
`cleanup_worktree` invariant "collect-and-surface, never crash mid-teardown
leaving other resources orphaned (#877)" for the `ModuleNotFoundError` case it
did not previously cover.

**2. FSM phase boundaries** — n/a. No `Ticket.State` / `Worktree.State`
transition changed; the FSM teardown path is unchanged, the runner just no longer
aborts.

**3. Extension-point contracts** — n/a. `run_step` / `StepResult` public shapes
unchanged. Consumers (`prek_hook`, `provision_timebox`, overlay provision steps)
keep the same `StepResult` outcomes.

**4. Component boundaries** — Stays in `src/teatree/core/step_runner.py`. The fix
is two private helpers (`_timeboxed_step`, `_plain_subprocess_step`) on the
existing module; no new module.

**5. Dependency direction** — Adds a module-level `from teatree.utils.run import
run_allowed_to_fail` to `step_runner` — a downward edge (utils is below core);
`provision_timebox` already imports the same helper. `uv run tach check` clean.

**6. Test surface** — `TestRunStepSurvivesMissingProvisionTimebox` (5 cases:
the 4 absent-module degradations — success / soft-fail / command-not-found /
timeout — plus `test_run_step_propagates_when_module_present_but_internally_broken`,
which pins that a present-but-broken module's `ModuleNotFoundError` PROPAGATES and
is not swallowed) and `TestCleanupWorktreeSurvivesMissingProvisionTimebox` (the
LATER-steps-run assertion). The propagation test fails if the catch is ever
re-widened; the degradation tests fail if the absent-module fallback regresses.

**7. Resilience invariants** — No new external write. The change *improves*
resilience: the teardown runner no longer aborts on an absent optional module, so
the later teardown steps (DB drop, row delete) always run (fallback-transport /
graceful-degradation). The plain run preserves the same `StepResult` so callers
classify outcomes identically (idempotent contract).

**8. Identity and key normalization** — n/a.

**9. Behavior preservation / capability deletion** — Purely additive degradation.
The time-box enhancement is unchanged when `provision_timebox` IS importable
(the normal install case): `_timeboxed_step` calls `run_timeboxed_step` exactly as
before. No existing behavior removed; no privacy/security matcher narrowed; no
must-block test inverted.

## Open questions & assumptions

- **assumed** — Fix direction (1) (resilient step runner) is preferred over (2)
  (drive teardown from the orchestrating install) because it closes the class
  bug at the smallest blast radius and with the least coupling change; (2) remains
  a valid larger follow-up if teardown should never run the worktree's base at all.
- **decided** — the catch breadth is `ModuleNotFoundError` narrowed by
  `.name == "teatree.core.provision_timebox"` (NOT a bare `ImportError` or a bare
  `ModuleNotFoundError`). Only the module's OWN absence on a stale base degrades to
  the plain run; a *present* `provision_timebox` that fails to import on a real
  internal/transitive-import bug raises a `ModuleNotFoundError` whose `.name` is the
  missing DEPENDENCY, so it re-raises and surfaces normally. The earlier
  "`ImportError`… a partially broken module is still surfaced" assumption was wrong —
  a bare catch would have swallowed it and silently disabled the time-box for every
  healthy install; that gap is now closed and guarded by
  `test_run_step_propagates_when_module_present_but_internally_broken`.

