### PR TITLE
test(evals): enforce clickable links for Slack/GitHub references (#2693)

### DIFF
--- a/evals/fixtures/comm_github_issue_clickable_not_bare_hash_fail.stream.jsonl
+++ b/evals/fixtures/comm_github_issue_clickable_not_bare_hash_fail.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-gh-issue-fail-01", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Start with issue #61."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/fixtures/comm_github_issue_clickable_not_bare_hash_noop.stream.jsonl
+++ b/evals/fixtures/comm_github_issue_clickable_not_bare_hash_noop.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-gh-issue-noop-01", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "ok"}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/fixtures/comm_github_issue_clickable_not_bare_hash_pass.stream.jsonl
+++ b/evals/fixtures/comm_github_issue_clickable_not_bare_hash_pass.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-gh-issue-pass-01", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Start with [#61](https://github.com/souliane/teatree/issues/61)."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/fixtures/comm_github_pr_clickable_not_bare_hash_fail.stream.jsonl
+++ b/evals/fixtures/comm_github_pr_clickable_not_bare_hash_fail.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-gh-pr-fail-01", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "PR #4120 is ready for review."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/fixtures/comm_github_pr_clickable_not_bare_hash_noop.stream.jsonl
+++ b/evals/fixtures/comm_github_pr_clickable_not_bare_hash_noop.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-gh-pr-noop-01", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "ok"}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/fixtures/comm_github_pr_clickable_not_bare_hash_pass.stream.jsonl
+++ b/evals/fixtures/comm_github_pr_clickable_not_bare_hash_pass.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-gh-pr-pass-01", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "PR [#4120](https://github.com/souliane/teatree/pull/4120) is ready for review."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/fixtures/comm_slack_permalink_not_bare_ts_fail.stream.jsonl
+++ b/evals/fixtures/comm_slack_permalink_not_bare_ts_fail.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-slack-permalink-fail-01", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Posted in #the-review-crew at ts=1716234567.123456."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/fixtures/comm_slack_permalink_not_bare_ts_noop.stream.jsonl
+++ b/evals/fixtures/comm_slack_permalink_not_bare_ts_noop.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-slack-permalink-noop-01", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "ok"}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/fixtures/comm_slack_permalink_not_bare_ts_pass.stream.jsonl
+++ b/evals/fixtures/comm_slack_permalink_not_bare_ts_pass.stream.jsonl
@@ -1,0 +1,3 @@
+{"type": "system", "subtype": "init", "session_id": "fixt-slack-permalink-pass-01", "model": "claude-sonnet-4-6"}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Posted in [#the-review-crew](https://acme.slack.com/archives/C123ABC/p1716234567123456)."}]}}
+{"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/scenarios/clickable_references.yaml
+++ b/evals/scenarios/clickable_references.yaml
@@ -20,3 +20,58 @@
     # markdown link with no URL, and a hostless path all fail (see the
     # _fail / _noop fixtures, which carry a bare id).
     - final_state: '~ "(\[!?7551\]\(https?://\S+7551\)|https?://\S+/(merge_requests|pull|mr|issues)/7551)"'
+
+- name: comm_slack_permalink_not_bare_ts
+  scenario: "a reference to a Slack message in the agent's message is a clickable permalink, not a bare ts"
+  agent_path: skills/rules/SKILL.md
+  agent_sections: ["Clickable References"]
+  model: claude-sonnet-4-6
+  max_turns: 3
+  # final_state asserts the message text — no tool is exercised; the loader
+  # forbids an empty `tools` list, so the harmless default ([Bash]) is passed.
+  tools: [Bash]
+  prompt: >-
+    Write the one-line message you'd send to point the user at the Slack
+    message you posted in #the-review-crew. You have both the raw ts
+    (1716234567.123456) and its permalink
+    (https://acme.slack.com/archives/C123ABC/p1716234567123456). Output only
+    that message — reference the Slack message as a clickable link, never the
+    bare ts.
+  expect:
+    # Positive anchor on the FINAL message: requires the Slack permalink URL
+    # (host slack.com, .../archives/.../p<ts>). A bare ts=1716234567.123456 with
+    # no permalink fails (see the _fail / _noop fixtures).
+    - final_state: '~ "https?://\S+slack\.com/archives/\S*p1716234567123456"'
+
+- name: comm_github_issue_clickable_not_bare_hash
+  scenario: "a reference to a GitHub issue in the agent's message is a clickable link, not a bare #N"
+  agent_path: skills/rules/SKILL.md
+  agent_sections: ["Clickable References"]
+  model: claude-sonnet-4-6
+  max_turns: 3
+  tools: [Bash]
+  prompt: >-
+    Write the one-line message you'd send to tell the user that GitHub issue #61
+    (https://github.com/souliane/teatree/issues/61) is the one to start with.
+    Output only that message — reference the issue as a clickable link, never a
+    bare #61.
+  expect:
+    # Positive anchor: requires an issue/pull URL ending in /61. A bare "issue
+    # #61" with no link fails (see the _fail / _noop fixtures).
+    - final_state: '~ "https?://\S+/(issues|pull)/61\b"'
+
+- name: comm_github_pr_clickable_not_bare_hash
+  scenario: "a reference to a GitHub PR in the agent's message is a clickable link, not a bare #N"
+  agent_path: skills/rules/SKILL.md
+  agent_sections: ["Clickable References"]
+  model: claude-sonnet-4-6
+  max_turns: 3
+  tools: [Bash]
+  prompt: >-
+    Write the one-line message you'd send to tell the user that PR #4120
+    (https://github.com/souliane/teatree/pull/4120) is ready for review. Output
+    only that message — reference the PR as a clickable link, never a bare #4120.
+  expect:
+    # Positive anchor: requires a pull/merge_requests URL ending in /4120. A bare
+    # "PR #4120" with no link fails (see the _fail / _noop fixtures).
+    - final_state: '~ "https?://\S+/(pull|merge_requests)/4120\b"'


### PR DESCRIPTION
test(evals): enforce clickable links for Slack/GitHub references (#2693)

Append three anti-vacuous eval scenarios to clickable_references.yaml that
enforce CLICKABLE links for third-party references instead of bare ids:

- comm_slack_permalink_not_bare_ts — a Slack message reference must be a
  clickable permalink (.../archives/.../p<ts>), never a bare ts.
- comm_github_issue_clickable_not_bare_hash — a GitHub issue reference must
  be a clickable link (/issues|/pull ending in the number), never a bare #N.
- comm_github_pr_clickable_not_bare_hash — a GitHub PR reference must be a
  clickable link (/pull|/merge_requests ending in the number), never a bare #N.

Each scenario grades with a single positive final_state regex anchor on the
agent's final message, and ships its three anti-vacuous fixtures
(_pass/_fail/_noop) under evals/fixtures/.

Test plan (anti-vacuity replay gates):

  uv run pytest tests/eval_replay/test_scenarios_anti_vacuous.py \
    -k "comm_slack_permalink or comm_github_issue or comm_github_pr"
  -> 9 passed

Per scenario:
- _fail fixture (bare id)        -> scenario RED
- _pass fixture (clickable link) -> scenario GREEN
- _noop fixture ("ok")           -> scenario RED

Full eval_replay suite (discovery + anti-vacuity): 1955 passed, 28 skipped,
no discovery error (no duplicate names, no malformed YAML).

Open questions & assumptions:
- agent_path/agent_sections/model match the existing
  comm_uses_clickable_links_not_bare_ids scenario exactly (skills/rules/SKILL.md,
  "Clickable References", claude-sonnet-4-6) — verified against the live tree.

Closes #2693