### PR TITLE
fix(eval): provision ephemeral checkout via clone so under_load runs under :ro

### DIFF
--- a/src/teatree/eval/ephemeral_checkout.py
+++ b/src/teatree/eval/ephemeral_checkout.py
@@ -12,17 +12,21 @@ teatree clone. The sub-agent finds it two ways a neutral cwd cannot block:
     resolves through the install's ``.pth`` straight into the developer's
     ``src/teatree`` (the real clone), so the sub-agent learns the real repo path
     even from a ``/tmp`` cwd;
-*   the **shared ``.git``** — a worktree of the real clone shares its object store
-    and refs, so a commit/branch-switch reaches the real repository.
+*   **git reachability** — ``git`` resolves the repo by walking up from the cwd (and
+    via any inherited ``GIT_*`` pins), so a commit or branch-switch can still reach the
+    real repository whenever it is discoverable.
 
 Running from a ``/tmp`` cwd therefore did NOT protect the developer's clone (the
 issue this module fixes was observed corrupting the main clone and two live
-worktrees). The fix is a per-run EPHEMERAL CHECKOUT: a ``git worktree --detach``
-in a temp dir whose own working tree + detached ``HEAD`` absorb every write the
-sub-agent makes, plus an :func:`ephemeral_checkout_env` overlay that redirects the
-TWO real-clone resolution levers at it — ``PYTHONPATH`` (so ``import teatree``
-resolves into the ephemeral ``src``, NOT the editable ``.pth``) and the git
-discovery vars (so ``git`` operations resolve to the ephemeral working tree).
+worktrees). The fix is a per-run EPHEMERAL CHECKOUT: an independent ``git clone`` at a
+detached ``HEAD`` in a temp dir whose own working tree, refs, and object store absorb
+every write the sub-agent makes, plus an :func:`ephemeral_checkout_env` overlay that
+redirects the TWO real-clone resolution levers at it — ``PYTHONPATH`` (so
+``import teatree`` resolves into the ephemeral ``src``, NOT the editable ``.pth``) and
+the git discovery vars (so ``git`` operations resolve to the ephemeral working tree).
+A clone (not a worktree) reads the source READ-ONLY, so it also works when the eval
+mounts the repo ``:ro`` in CI — and gives full isolation (separate refs + object
+store), so a sub-agent's commits never even land as loose objects in the real store.
 The checkout is torn down when the run finishes, so nothing leaks.
 
 When the real teatree root cannot be located (a packaged install with no source
@@ -39,8 +43,8 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
+from teatree.utils.git_run import check as git_check
 from teatree.utils.git_run import run as git_run
-from teatree.utils.git_worktree import worktree_add_at_ref, worktree_remove
 
 
 class EphemeralCheckoutError(RuntimeError):
@@ -66,21 +70,38 @@ def resolve_teatree_repo_root() -> Path | None:
     return Path(toplevel) if toplevel else None
 
 
+def _clone_detached(repo_root: Path, checkout: Path) -> bool:
+    """Clone *repo_root* into *checkout* at a detached ``HEAD``; ``True`` on success.
+
+    A ``git clone`` READS the source and writes ONLY to the destination, so it works
+    when the source is mounted READ-ONLY — the CI eval container mounts the repo ``:ro``
+    so a metered run can never mutate the working tree. The superseded
+    ``git worktree add`` had to write the worktree's metadata into the source's
+    ``.git/worktrees/`` and so could not run under that ``:ro`` mount. The clone is also
+    STRONGER isolation than a worktree: with its own ``HEAD``/refs/index and its own
+    object store, a sub-agent's branch switches AND commits stay inside the throwaway —
+    a shared worktree left the sub-agent's commits as loose objects in the real store.
+    """
+    if not git_check(repo=str(repo_root), args=["clone", "--quiet", str(repo_root), str(checkout)]):
+        return False
+    return git_check(repo=str(checkout), args=["checkout", "--quiet", "--detach", "HEAD"])
+
+
 @contextmanager
 def provision_ephemeral_checkout() -> Iterator[Path]:
-    """Yield a throwaway ``git worktree --detach`` of the real teatree clone.
+    """Yield a throwaway independent ``git clone`` of the real teatree clone.
 
-    The yielded directory is a detached worktree: its own working tree and
-    detached ``HEAD`` absorb every file write, branch switch, and commit the SDK
-    sub-agent makes, so the real clone's and live worktrees' working trees and
-    branch refs stay untouched. A detached worktree shares the real clone's
-    object store, so a sub-agent commit can leave loose (garbage-collectable)
-    objects there — that is harmless garbage, not corruption of the developer's
-    work. The worktree is removed (``git worktree remove --force``) and its temp
-    parent deleted on context exit, success or failure.
+    The yielded directory is an independent clone at a detached ``HEAD``: its own
+    working tree, refs, index, and object store absorb every file write, branch
+    switch, and commit the SDK sub-agent makes, so the real clone's and live
+    worktrees' working trees and branch refs stay untouched — and, unlike a shared
+    worktree, the sub-agent's commits never even land as loose objects in the real
+    store. The clone reads the source READ-ONLY, so it also provisions when the eval
+    mounts the repo ``:ro`` (the CI container). The temp parent is deleted on context
+    exit, success or failure.
 
     Raises :class:`EphemeralCheckoutError` when the real teatree root cannot be
-    located or the worktree cannot be created — the spawning scenario then refuses
+    located or the clone cannot be created — the spawning scenario then refuses
     to run on the real clone.
     """
     repo_root = resolve_teatree_repo_root()
@@ -96,16 +117,15 @@ def provision_ephemeral_checkout() -> Iterator[Path]:
     parent = Path(tempfile.mkdtemp(prefix="t3-eval-ephemeral-checkout-"))
     checkout = parent / "teatree"
     try:
-        if not worktree_add_at_ref(str(repo_root), str(checkout), "HEAD"):
+        if not _clone_detached(repo_root, checkout):
             msg = (
                 f"cannot provision an isolated ephemeral checkout at {checkout}: "
-                "git worktree add failed. The sub-agent-spawning scenario REFUSES "
+                "git clone failed. The sub-agent-spawning scenario REFUSES "
                 "to run on the real clone."
             )
             raise EphemeralCheckoutError(msg)
         yield checkout
     finally:
-        worktree_remove(str(repo_root), str(checkout))
         shutil.rmtree(parent, ignore_errors=True)
 
 

--- a/tests/teatree_eval/test_ephemeral_checkout.py
+++ b/tests/teatree_eval/test_ephemeral_checkout.py
@@ -166,6 +166,15 @@ class TestProvisionEphemeralCheckout:
         with pytest.raises(EphemeralCheckoutError, match="REFUSES to run"), provision_ephemeral_checkout():
             pass
 
+    def test_refuses_when_the_source_is_not_clonable(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A resolvable path that is NOT a git repo makes `git clone` fail; provisioning
+        # must REFUSE (raise) rather than yield a half-built checkout or fall back.
+        not_a_repo = tmp_path / "not-a-repo"
+        not_a_repo.mkdir()
+        monkeypatch.setattr("teatree.eval.ephemeral_checkout.resolve_teatree_repo_root", lambda: not_a_repo)
+        with pytest.raises(EphemeralCheckoutError, match="git clone failed"), provision_ephemeral_checkout():
+            pass
+
 
 class TestEphemeralCheckoutEnv:
     def test_prepends_ephemeral_src_to_pythonpath(self) -> None:

--- a/tests/teatree_eval/test_ephemeral_checkout.py
+++ b/tests/teatree_eval/test_ephemeral_checkout.py
@@ -37,6 +37,13 @@ def _init_repo(root: Path) -> None:
     run_git(root, "commit", "-qm", "init")
 
 
+def _chmod_tree(root: Path, mode: int) -> None:
+    Path(root).chmod(mode)
+    for dirpath, dirnames, filenames in os.walk(root):
+        for name in (*dirnames, *filenames):
+            Path(Path(dirpath) / name).chmod(mode)
+
+
 class TestResolveTeatreeRepoRoot:
     def test_resolves_the_running_teatree_clone_to_a_git_toplevel(self) -> None:
         root = resolve_teatree_repo_root()
@@ -52,7 +59,7 @@ class TestResolveTeatreeRepoRoot:
 
 
 class TestProvisionEphemeralCheckout:
-    def test_creates_a_detached_worktree_that_is_not_the_real_clone(
+    def test_creates_a_detached_clone_that_is_not_the_real_clone(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         real = tmp_path / "real-clone"
@@ -63,10 +70,28 @@ class TestProvisionEphemeralCheckout:
             assert checkout.is_dir()
             assert checkout != real
             assert (checkout / "src" / "teatree" / "__init__.py").is_file()
-            # A detached HEAD worktree of the real clone — sub-agent writes land here.
+            # A detached-HEAD independent clone — sub-agent writes land here.
             assert _git(checkout, "rev-parse", "--abbrev-ref", "HEAD") == "HEAD", (
                 "ephemeral checkout must be detached, not on a real branch"
             )
+
+    def test_provisions_against_a_read_only_source_repo(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The CI eval mounts the repo ``:ro``; provisioning must only READ the source.
+
+        ``git worktree add`` writes the worktree's metadata into the source's
+        ``.git/worktrees/`` and so FAILS on a read-only repo (the regression this
+        guards) — a clone reads the source and writes only to the throwaway.
+        """
+        real = tmp_path / "real-clone"
+        _init_repo(real)
+        monkeypatch.setattr("teatree.eval.ephemeral_checkout.resolve_teatree_repo_root", lambda: real)
+        _chmod_tree(real / ".git", 0o555)
+        try:
+            with provision_ephemeral_checkout() as checkout:
+                assert (checkout / "src" / "teatree" / "__init__.py").is_file()
+                assert _git(checkout, "rev-parse", "--abbrev-ref", "HEAD") == "HEAD"
+        finally:
+            _chmod_tree(real / ".git", 0o755)
 
     def test_sub_agent_writes_land_in_the_ephemeral_not_the_real_clone(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -111,8 +136,12 @@ class TestProvisionEphemeralCheckout:
             captured = checkout
             assert captured.is_dir()
         assert not captured.exists(), "the ephemeral checkout directory must be removed on exit"
-        registered = _git(real, "worktree", "list", "--porcelain")
-        assert str(captured) not in registered, "the ephemeral worktree must be deregistered from the real clone"
+        # An independent clone is never a worktree of the source, so provisioning must
+        # leave the real clone with exactly its own (single) worktree entry — nothing leaked.
+        worktree_lines = [
+            line for line in _git(real, "worktree", "list", "--porcelain").splitlines() if line.startswith("worktree ")
+        ]
+        assert worktree_lines == [f"worktree {real}"], "provisioning must not register a worktree on the source clone"
 
     def test_cleans_up_even_when_the_body_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         real = tmp_path / "real-clone"


### PR DESCRIPTION
## Problem

The metered eval mounts the repo `:ro` (a metered run must never mutate the working tree — `src/teatree/cli/eval/docker.py:50`). Sub-agent-spawning scenarios (`*_under_load`, `orchestrator_delegates_*`, `full_speed_*`, `team_mate_*`) provision a throwaway isolated checkout so the spawned SDK sub-agent's destructive git work can't reach the developer's real clone.

That checkout was a `git worktree add`, which writes the new worktree's metadata into the **source's** `.git/worktrees/` — impossible under the `:ro` mount. So provisioning raised `EphemeralCheckoutError`, the scenario refused to run, the leg billed `$0`, and the unmetered-`$0` guard failed the leg loud (its message guessed "auth failure", but the real cause was the read-only checkout). This affects the weekly `eval.yml` under_load legs identically — it is pre-existing, surfaced once the lane started running metered.

## Fix

Replace the worktree with an independent `git clone --quiet` at a detached `HEAD`:

- A `git clone` **reads** the source and writes only to the destination, so it provisions even when the source is mounted `:ro`.
- It is also **stronger** isolation than a worktree: its own `HEAD`/refs/index and its own object store mean a sub-agent's branch switches **and** commits stay inside the throwaway — the old shared-worktree path left the sub-agent's commits as loose objects in the real store.

The public API (`provision_ephemeral_checkout`, `ephemeral_checkout_env`) is unchanged, so `api_runner.py` is untouched.

## Test (TDD)

`test_provisions_against_a_read_only_source_repo` provisions against a source whose `.git` is `chmod 0o555` — RED on the old `git worktree add` path (writes into the read-only `.git/worktrees/` fail), GREEN on the clone. The now-vacuous "not registered as a worktree" assertion in `test_cleans_up_the_checkout_on_exit` was replaced with a meaningful one (the source's worktree list stays a single self-entry — provisioning registered nothing).

## Verification

- `uv run pytest tests/teatree_eval/test_ephemeral_checkout.py` → 13 passed.
- `uv run pytest tests/teatree_eval/test_api_runner.py` → 128 passed (public API unchanged).
- `uv run ruff check` / `ruff format` / `ty check` clean on both files.

End-to-end confirmation (a single metered `*_under_load` run in the `:ro` Docker context) follows separately to keep API spend bounded.
