### PR TITLE
fix(loop): remove stale tick-meta guard that stalled loop after claim (#2714)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -1167,18 +1167,17 @@ def _claim_loop_ownership(session_id: str) -> None:
 
 
 def handle_enforce_loop_on_prompt(data: dict) -> None:
-    """On first prompt, the loop OWNER registers one native Claude ``/loop`` per enabled DB Loop (#2650).
+    """On first prompt, the loop OWNER registers one ``/loop`` per enabled DB Loop (#2650).
 
-    The single fat-tick cron is GONE: the live set of native Claude ``/loop``s
-    MIRRORS the set of ENABLED ``Loop`` rows — one ``/loop`` per enabled row
-    (per-loop, not per-group), each on that loop's own cadence. Only the
-    loop-owner session (``_loop_auto_load_active`` + ``_claim_loop_ownership``)
-    registers; a non-owner registers nothing. The per-loop directive building
-    lives in the bare sibling :mod:`loop_registrations` (hooks/CLAUDE.md keeps NEW
-    logic out of this shrink-only router); this stays a thin owner-gated
-    delegator. Crash-proof / fail-open: zero enabled loops (or an unavailable
-    seam) emits nothing and writes no pending marker, so the PreToolUse nudge
-    never fires when there is nothing to register.
+    One ``/loop`` per ENABLED ``Loop`` row, each on its own cadence.  Only the
+    owner session (``_loop_auto_load_active`` + ``_claim_loop_ownership``) registers.
+    Directive building lives in the bare sibling :mod:`loop_registrations`.
+    Fail-open: zero enabled loops emits nothing, so the PreToolUse nudge never
+    fires when there is nothing to register.
+
+    ``_session_has_loop`` is the sole registration gate.  A fresh
+    ``tick-meta.json`` from a prior session (e.g. after release + claim) must
+    NOT suppress registration — that was the #2714 stall bug.
     """
     session_id = data.get("session_id", "")
     if not session_id:
@@ -1191,8 +1190,6 @@ def handle_enforce_loop_on_prompt(data: dict) -> None:
     pending = _state_file(session_id, "loop-pending")
     if _session_has_loop(session_id):
         pending.unlink(missing_ok=True)
-        return
-    if not _tick_meta_stale():
         return
     if emit_loop_registrations(sys.stdout):
         pending.write_text("1", encoding="utf-8")

--- a/tests/test_loop_registrations_hook.py
+++ b/tests/test_loop_registrations_hook.py
@@ -115,6 +115,37 @@ class TestOwnerSessionEmitsPerLoop:
         router.handle_enforce_loop_on_prompt({"session_id": owner_session})
         assert capsys.readouterr().out == ""
 
+    def test_owner_emits_when_tick_meta_fresh_but_session_has_no_cron(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Regression for #2714: release+claim must re-register even when tick-meta is fresh.
+
+        tick-meta.json can be fresh because the previous owner session was ticking
+        normally before ``t3 loop release``.  A new session that claims ownership
+        afterwards has no registered cron yet — _tick_meta_stale() returning False
+        must NOT prevent registration.  Only _session_has_loop() is the correct gate.
+        """
+        state = tmp_path / "state"
+        state.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(router, "STATE_DIR", state)
+        monkeypatch.setenv("T3_LOOP_REGISTRY_DIR", str(tmp_path / "data"))
+        monkeypatch.setenv("T3_LOOPS_AUTO_LOAD", "1")
+        session_id = "new-owner-after-claim"
+        (state / f"{session_id}.teatree-active").touch()
+        # tick-meta is FRESH — previous owner was ticking before release.
+        monkeypatch.setattr(router, "_tick_meta_stale", lambda: False)
+        # This new session has no registered cron yet.
+        monkeypatch.setattr(router, "_session_has_loop", lambda sid: False)
+        monkeypatch.setattr(loop_registrations, "_enabled_loop_specs", _two_specs)
+
+        router.handle_enforce_loop_on_prompt({"session_id": session_id})
+
+        out = capsys.readouterr().out
+        assert out != "", "must emit registration even when tick-meta is fresh after claim"
+        directive = json.loads(out.splitlines()[0])
+        loops = directive["hookSpecificOutput"]["loops"]
+        assert len(loops) == 2
+
     def test_non_owner_session_emits_nothing(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
## Root cause

`handle_enforce_loop_on_prompt` (called on every `UserPromptSubmit`) had
two serial guards before calling `emit_loop_registrations`:

1. `_session_has_loop(session_id)` — returns `True` if THIS session already
   has a registered cron (correct gate).
2. `_tick_meta_stale()` — returns `True` if `tick-meta.json` is older than
   `2 × cadence` (wrong gate for a newly-claimed session).

The stall scenario:

1. Session A owns the loop; ticks fire; `tick-meta.json` is fresh.
2. User runs `t3 loop release` — DB owner cleared.
3. User runs `t3 loop claim` — DB `LoopLease` updated with session B.
4. Session B's first `UserPromptSubmit`:
   - `_session_has_loop(B)` = `False` (no crons file yet)
   - `_tick_meta_stale()` = `False` (meta is fresh from A) **→ early return**
   - No `CronCreate` emitted → loop stalls, `t3 loop list` shows `STALLED`.

## Fix

Remove the two-line `_tick_meta_stale()` guard entirely.
`_session_has_loop(session_id)` is the correct and sufficient gate: it checks
whether *this specific session* has a registered cron.  A fresh `tick-meta.json`
from a dead session is irrelevant to whether the new owner must register.

## Why DB-native, no watchdog

The fix relies solely on:
- DB `LoopLease` row (DB-native) — determines which session should own
- `_session_has_loop()` state file — determines if this session already registered

No OS daemon, no watchdog process.  The macOS LaunchAgent watchdog is being
removed separately (PR #2713); this fix makes the existing `UserPromptSubmit`
hook correctly detect "I own the loop but have no crons" on every prompt,
not only when tick-meta is stale.

## Architectural note

`CronCreate` is session-scoped (Claude Code harness) — it dies with the session.
"No watchdog" is the correct design, but something session-bound must still fire
the `CronCreate`.  The fix makes the existing `UserPromptSubmit` hook serve that
role reliably: every prompt on a session that owns the loop but has no registered
cron now emits the registration, regardless of tick-meta age.

## Test

Regression test `test_owner_emits_when_tick_meta_fresh_but_session_has_no_cron`
in `tests/test_loop_registrations_hook.py` was observed RED on the buggy code
(the exact stall scenario: `_tick_meta_stale()=False`, `_session_has_loop()=False`)
and GREEN after the fix.

Closes #2714