### PR TITLE
fix(review): approve never forces a public APPROVE note (#2716)

### DIFF
--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -559,7 +559,13 @@ t3 review approve <REPO> <MR_IID>      # approve
 t3 review unapprove <REPO> <MR_IID>    # revoke your approval
 ```
 
-**Review-first precondition (enforced, not advisory).** `approve` refuses unless a review note/discussion authored by *your* identity already exists on that MR. This encodes the approve-on-review doctrine in the tool itself: you cannot record an approval without having left a reviewing footprint first. If it refuses, post your review (`t3 review post-comment` — default draft, #1207) and then approve. `unapprove` has no precondition — revoking is the safe direction and is always reachable.
+**Review-first precondition (enforced, not advisory) — never forces a public note (#2716).** `approve` refuses unless the approver has left a *reviewing footprint*, encoding the approve-on-review doctrine in the tool: you cannot record an approval without having reviewed first. The doctrine is an anti-rubber-stamp guarantee, **not** a public comment — so a content-free "APPROVE" prose note is never posted to satisfy it. Any of three footprints clears the gate, none of which is a colleague-visible auto-comment:
+
+- a **published note/discussion** authored by your identity (a genuine inline finding — still fine, never auto-posted just to clear this gate);
+- a **draft note** authored by your identity (a colleague-invisible review — no public comment);
+- the **recorded internal verdict** — an `OnBehalfApproval` for `(<repo>!<mr>, "approve")`, the human-recorded, maker≠checker attribution the on-behalf approve path already requires. On the on-behalf path the `approve-on-behalf` row *is* the footprint, so approving records the verdict + the GitLab `approved_by` (and the ✅ reaction) with **zero** MR notes/discussions posted.
+
+If it refuses, leave a genuine review (a real finding via `t3 review post-comment` — default draft, #1207 — or record the internal verdict), then approve. `unapprove` has no precondition — revoking is the safe direction and is always reachable.
 
 **On-behalf gate.** An approval is an outward, state-changing post under your identity, so `approve`/`unapprove` also respect the `on_behalf_post_mode` pre-gate (souliane/teatree#960). Under an autonomous overlay (`autonomy = "full"` / `"notify"`, which collapse the mode to `"immediate"`) the approval proceeds unattended — that is the "Colleague-MR Autonomy" behavior above, no further step. Under `"babysit"` (mode stays `"ask"` / `"draft_or_ask"`) the command refuses unattended with an actionable message — record an `OnBehalfApproval` via `t3 review approve-on-behalf <target> approve --approver <user-id>` and re-run, or raise the tier with `t3 <overlay> autonomy set full` / `t3 <overlay> autonomy set notify` (preferred — one knob) for the overlay.
 

--- a/src/teatree/cli/review/approval.py
+++ b/src/teatree/cli/review/approval.py
@@ -16,17 +16,41 @@ if TYPE_CHECKING:
 
 
 def identity_has_reviewed(api: "GitLabAPI", encoded_repo: str, mr: int) -> tuple[bool, str]:
-    """Whether the approving identity already authored a note on this MR.
+    """Whether the approving identity left a reviewing footprint on this MR.
 
-    Encodes the review-before-approve doctrine: an approval may only be
-    recorded once the same identity has left a reviewing footprint
-    (any note in any discussion thread). Returns ``(reviewed, error)``;
-    ``error`` is non-empty only when the identity itself cannot be
-    resolved (a hard precondition failure, not "no review yet").
+    Encodes the review-before-approve doctrine — an approval may only be
+    recorded once the same identity has reviewed — WITHOUT forcing a
+    content-free public "APPROVE" prose note (souliane/teatree#2716). The
+    doctrine's purpose is an anti-rubber-stamp guarantee, not a public
+    comment, so any of three footprints satisfies it, none of which is a
+    colleague-visible auto-comment:
+
+    * a published note authored by the approver (a genuine inline finding
+        — still fine, never auto-posted just to clear this gate);
+    * a **draft** note authored by the approver (a colleague-invisible
+        review left as a draft — no public comment);
+    * the recorded internal verdict — an :class:`OnBehalfApproval` for
+        ``(<repo>!<mr>, "approve")``, the human-recorded, maker!=checker
+        attribution the on-behalf approve path already requires.
+
+    Returns ``(reviewed, error)``; ``error`` is non-empty only when the
+    identity itself cannot be resolved (a hard precondition failure, not
+    "no review yet").
     """
     username = api.current_username()
     if not username:
         return False, "Could not resolve the approving GitLab identity (check token / `glab auth status`)."
+    if _identity_authored_published_note(api, encoded_repo, mr, username):
+        return True, ""
+    if _identity_authored_draft_note(api, encoded_repo, mr, username):
+        return True, ""
+    if _internal_approve_verdict_recorded(encoded_repo, mr):
+        return True, ""
+    return False, ""
+
+
+def _identity_authored_published_note(api: "GitLabAPI", encoded_repo: str, mr: int, username: str) -> bool:
+    """True iff *username* authored any published note in any discussion thread."""
     discussions = api.get_json_paginated(f"projects/{encoded_repo}/merge_requests/{mr}/discussions?per_page=100")
     for discussion in discussions:
         if not isinstance(discussion, dict):
@@ -35,12 +59,44 @@ def identity_has_reviewed(api: "GitLabAPI", encoded_repo: str, mr: int) -> tuple
         if not isinstance(notes, list):
             continue
         for note in notes:
-            if not isinstance(note, dict):
-                continue
-            author = cast("RawAPIDict", note).get("author")
-            if isinstance(author, dict) and cast("RawAPIDict", author).get("username") == username:
-                return True, ""
-    return False, ""
+            if _note_authored_by(note, username):
+                return True
+    return False
+
+
+def _identity_authored_draft_note(api: "GitLabAPI", encoded_repo: str, mr: int, username: str) -> bool:
+    """True iff *username* authored a colleague-invisible draft note on this MR.
+
+    A draft is a genuine review that has not been published — it satisfies
+    the review-before-approve doctrine without any public comment.
+    """
+    drafts = api.get_json(f"projects/{encoded_repo}/merge_requests/{mr}/draft_notes")
+    if not isinstance(drafts, list):
+        return False
+    return any(_note_authored_by(draft, username) for draft in drafts)
+
+
+def _internal_approve_verdict_recorded(encoded_repo: str, mr: int) -> bool:
+    """True iff a human-recorded internal approve verdict exists for this MR.
+
+    The recorded :class:`OnBehalfApproval` for ``(<repo>!<mr>, "approve")``
+    is the internal attribution the on-behalf approve path requires — a
+    durable, maker!=checker record that a human reviewed and authorised the
+    approval. Its presence is a reviewing footprint that needs no public
+    note. Read lazily so the CLI imports before ``django.setup()``.
+    """
+    from teatree.core.models.on_behalf_approval import OnBehalfApproval  # noqa: PLC0415
+
+    repo = encoded_repo.replace("%2F", "/")
+    return OnBehalfApproval.has_unconsumed(f"{repo}!{mr}", "approve")
+
+
+def _note_authored_by(note: object, username: str) -> bool:
+    """True iff *note* is a dict whose ``author.username`` equals *username*."""
+    if not isinstance(note, dict):
+        return False
+    author = cast("RawAPIDict", note).get("author")
+    return isinstance(author, dict) and cast("RawAPIDict", author).get("username") == username
 
 
 def identity_in_approved_by(api: "GitLabAPI", encoded_repo: str, mr: int) -> bool:

--- a/tests/teatree_cli/test_review_approval.py
+++ b/tests/teatree_cli/test_review_approval.py
@@ -3,14 +3,24 @@
 The functions are exercised end-to-end in ``test_review_approve_gate.py``
 and ``test_review_approve_already_approved.py``, but the branches around
 malformed payloads and the username-resolution failure mode are easier
-to pin directly. Pure stub against the ``GitLabAPI.current_username`` /
-``get_json`` shape — no Django, no network, no migrations.
+to pin directly. Stub against the ``GitLabAPI.current_username`` /
+``get_json`` / ``get_json_paginated`` shape — no network, no migrations.
+
+Since #2716 the "no published note" path also consults the recorded
+internal verdict (:class:`OnBehalfApproval`), so this module carries the
+``django_db`` mark; the note-found tests short-circuit before the DB read
+and never write a row.
 """
 
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 from teatree.cli.review.approval import identity_has_reviewed, identity_in_approved_by
+
+# ast-grep-ignore: ac-django-no-pytest-django-db
+pytestmark = pytest.mark.django_db
 
 
 def _api(*, username: str = "souliane", discussions: Any = None) -> MagicMock:

--- a/tests/teatree_cli/test_review_approval_pagination.py
+++ b/tests/teatree_cli/test_review_approval_pagination.py
@@ -19,7 +19,14 @@ reviewer approve.
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from teatree.cli.review.approval import identity_has_reviewed
+
+# The reviewer-absent path consults the recorded internal verdict
+# (:class:`OnBehalfApproval`) since #2716, so it touches the DB.
+# ast-grep-ignore: ac-django-no-pytest-django-db
+pytestmark = pytest.mark.django_db
 
 
 def _api_with_paginated(*, username: str, page1: list, page2: list) -> MagicMock:

--- a/tests/teatree_cli/test_review_approve_no_public_note.py
+++ b/tests/teatree_cli/test_review_approve_no_public_note.py
@@ -1,0 +1,168 @@
+"""Approving never forces a public prose APPROVE note (souliane/teatree#2716).
+
+The recurring user complaint: ``t3 review approve`` refused unless a note
+authored by the approver's identity already existed on the MR (the
+review-before-approve doctrine, ``identity_has_reviewed``). To satisfy it
+the agent had to post a content-free "APPROVE" prose comment from the
+approver's identity first — the useless approval-summary comment the user
+repeatedly deletes (concrete instance: a now-deleted note on a real MR).
+
+The corrected contract: an *internal* reviewing footprint satisfies the
+precondition so no public comment is ever forced. The two internal
+footprints, neither of which is a colleague-visible post:
+
+* a **draft note** authored by the approver (colleague-invisible review);
+* the recorded :class:`OnBehalfApproval` for ``(<repo>!<mr>, "approve")`` —
+    the human-recorded, maker!=checker internal verdict/attribution that the
+    on-behalf approve path already requires.
+
+Approval then records the GitLab ``approved_by`` (verify-after-post) and
+the internal audit, and posts ZERO notes/discussions. The maker!=checker
+and on-behalf gates are untouched — only the *public prose note* is gone.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from teatree.cli.review import ReviewService
+from teatree.core.models import ConfigSetting, OnBehalfApproval
+
+# ast-grep-ignore: ac-django-no-pytest-django-db
+pytestmark = pytest.mark.django_db
+
+
+class _SilentApproveStubAPI:
+    """``GitLabAPI`` stand-in with NO published note authored by the approver.
+
+    ``discussions`` and ``draft_notes`` come back empty — there is no public
+    prose footprint at all. The only attribution is the recorded
+    :class:`OnBehalfApproval`. Records every call so the test can assert
+    nothing was posted to the MR.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, Any]] = []
+
+    def current_username(self) -> str:
+        self.calls.append(("current_username", "", None))
+        return "souliane"
+
+    def get_json(self, endpoint: str) -> object:
+        self.calls.append(("get_json", endpoint, None))
+        if endpoint.endswith("/approvals"):
+            return {"approved_by": [{"user": {"username": "souliane"}}]}
+        if endpoint.endswith("/draft_notes"):
+            return []
+        return []
+
+    def get_json_paginated(self, endpoint: str) -> list:
+        self.calls.append(("get_json_paginated", endpoint, None))
+        # No published discussion notes by anyone — no public footprint.
+        return []
+
+    def post_json(self, endpoint: str, payload: object) -> object:
+        # A posting attempt is a contract violation under this test.
+        self.calls.append(("post_json", endpoint, payload))
+        return {"id": 1}
+
+    def post_status(self, endpoint: str) -> int:
+        self.calls.append(("post_status", endpoint, None))
+        return 200
+
+
+def _immediate_gate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Lift the on-behalf gate (mode=immediate) to isolate the review-first precondition."""
+    cfg = tmp_path / ".teatree.toml"
+    cfg.write_text("[teatree]\n", encoding="utf-8")
+    monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)
+    ConfigSetting.objects.set_value("on_behalf_post_mode", "immediate")
+
+
+def _service_with_stub() -> tuple[ReviewService, _SilentApproveStubAPI]:
+    service = ReviewService(token="t")
+    stub = _SilentApproveStubAPI()
+    service._get_api = lambda: stub  # type: ignore[method-assign]
+    return service, stub
+
+
+def _posted_to_mr(stub: _SilentApproveStubAPI) -> list[tuple[str, str, Any]]:
+    """Every call that would create a public MR note or discussion."""
+    return [
+        c
+        for c in stub.calls
+        if c[0] == "post_json" and ("/notes" in c[1] or "/discussions" in c[1] or "/draft_notes" in c[1])
+    ]
+
+
+class TestApproveOnBehalfNeedsNoPublicNote:
+    @pytest.fixture(autouse=True)
+    def _ctx(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self.tmp_path = tmp_path
+        self.monkeypatch = monkeypatch
+
+    def test_recorded_approval_satisfies_precondition_with_no_public_note(self) -> None:
+        """On-behalf approve succeeds via the internal verdict, posting ZERO notes."""
+        _immediate_gate(self.tmp_path, self.monkeypatch)
+        # The internal verdict/attribution record — human-recorded, maker!=checker.
+        OnBehalfApproval.record(target="org/repo!7", action="approve", approver_id="souliane")
+        service, stub = _service_with_stub()
+
+        msg, code = service.approve("org/repo", 7)
+
+        assert code == 0, msg
+        assert "OK approved" in msg
+        # The GitLab approval landed...
+        assert any(c[0] == "post_status" and c[1].endswith("/approve") for c in stub.calls)
+        # ...and NOT ONE note/discussion/draft was posted to the MR.
+        assert _posted_to_mr(stub) == []
+
+    def test_no_footprint_and_no_recorded_approval_still_refuses(self) -> None:
+        """Without ANY footprint (no note, no draft, no recorded approval) approve refuses.
+
+        Maker!=checker / anti-rubber-stamp is preserved: with neither a
+        reviewing footprint nor the internal verdict record, approve must
+        still refuse — and still post nothing.
+        """
+        _immediate_gate(self.tmp_path, self.monkeypatch)
+        service, stub = _service_with_stub()
+
+        msg, code = service.approve("org/repo", 7)
+
+        assert code == 1
+        assert "review before approve" in msg
+        assert not any(c[0] == "post_status" for c in stub.calls)
+        assert _posted_to_mr(stub) == []
+
+
+class _DraftReviewStubAPI(_SilentApproveStubAPI):
+    """Like the silent stub, but the approver left a DRAFT note (no public note)."""
+
+    def get_json(self, endpoint: str) -> object:
+        self.calls.append(("get_json", endpoint, None))
+        if endpoint.endswith("/approvals"):
+            return {"approved_by": [{"user": {"username": "souliane"}}]}
+        if endpoint.endswith("/draft_notes"):
+            return [{"author": {"username": "souliane"}, "note": "LGTM modulo the edge case"}]
+        return []
+
+
+class TestApproveAcceptsDraftFootprint:
+    @pytest.fixture(autouse=True)
+    def _ctx(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self.tmp_path = tmp_path
+        self.monkeypatch = monkeypatch
+
+    def test_draft_note_footprint_satisfies_precondition(self) -> None:
+        """A colleague-invisible draft review satisfies the precondition — no public note forced."""
+        _immediate_gate(self.tmp_path, self.monkeypatch)
+        service = ReviewService(token="t")
+        stub = _DraftReviewStubAPI()
+        service._get_api = lambda: stub  # type: ignore[method-assign]
+
+        msg, code = service.approve("org/repo", 7)
+
+        assert code == 0, msg
+        assert "OK approved" in msg
+        assert _posted_to_mr(stub) == []


### PR DESCRIPTION
## What

`t3 review approve` (and the approve-on-behalf path) no longer forces a content-free public "APPROVE" prose note on the MR. Approving now records the internal verdict + the GitLab `approved_by` (and the Slack ✅ reaction) with **zero** MR notes/discussions posted.

## Why (root cause)

The `approve` command itself never posted a note. The forcing function was the **review-before-approve precondition** `identity_has_reviewed` (`src/teatree/cli/review/approval.py`): it refused to approve unless a *published* note authored by the approver's GitLab identity already existed on the MR. To satisfy it, the agent had to post a content-free "APPROVE" comment from the approver's identity first — the useless approval-summary note the user repeatedly deletes (e.g. a now-deleted note on a real MR).

The doctrine's actual purpose is an **anti-rubber-stamp guarantee**, not a public comment. A posted prose note is the wrong proxy for "the approver reviewed".

## The fix

`identity_has_reviewed` now accepts any of three reviewing footprints, **none of which is a colleague-visible auto-comment**:

- a **published note** authored by the approver (a genuine inline finding — still fine, never auto-posted just to clear the gate);
- a **draft note** authored by the approver (a colleague-invisible review left as a draft — no public comment);
- the **recorded internal verdict** — an `OnBehalfApproval` for `(<repo>!<mr>, "approve")`, the human-recorded, maker≠checker attribution the on-behalf approve path already requires.

On the on-behalf path the `approve-on-behalf` row *is* the footprint, so approving records the verdict and the GitLab approval with no public comment.

## Invariants preserved (not weakened)

- **maker≠checker** — `OnBehalfApproval.record` still refuses a maker/coding-agent/loop approver id; an agent can never self-authorize.
- **anti-rubber-stamp** — with neither a footprint nor the internal verdict record, `approve` still refuses (and still posts nothing). Pinned by `test_no_footprint_and_no_recorded_approval_still_refuses`.
- **on-behalf gate** — untouched; `approve`/`unapprove` still route through the `on_behalf_post_mode` pre-gate.
- **audit trail** — the GitLab `approved_by` (verify-after-post) + the `OnBehalfApproval`/`OnBehalfAudit` rows + the outbound-claim `record_note_claim` all still record who/what/when.

## Tests (TDD, anti-vacuity proven)

New `tests/teatree_cli/test_review_approve_no_public_note.py`:

- recorded `OnBehalfApproval` satisfies the precondition with a stub MR carrying **no** published note, and asserts **zero** `post_json` to any `/notes`, `/discussions`, or `/draft_notes` endpoint;
- a draft-note footprint satisfies the precondition with no public note;
- no footprint + no recorded approval still refuses (and posts nothing).

Anti-vacuity: with the fix reverted, the two new-contract tests go RED; the preserved-invariant test stays green. `approval.py` is at 100% branch coverage.

The two pure-unit modules that exercise the no-published-note path (`test_review_approval.py`, `test_review_approval_pagination.py`) gained the `django_db` mark because `identity_has_reviewed` now consults the DB on that path (note-found tests short-circuit before the DB read).

## Architecture pre-check

- **BLUEPRINT §** — `/t3:rules` § "Ask Before Posting on the User's Behalf" / review skill § "Review-first precondition". No BLUEPRINT invariant changed.
- **FSM** — n/a (no state transition).
- **Extension points** — n/a.
- **Component boundaries** — change stays in `teatree.cli.review.approval`; new lazy import of `teatree.core.models.on_behalf_approval` (CLI→core, allowed by tach; `tach check` green).
- **Test surface** — see Tests above.
- **Resilience** — the precondition fails **closed** (no footprint → refuse, the conservative direction), so a DB-unavailable read can never grant an approval.
- **Behavior preservation** — purely additive on the footprint set; no existing must-block path inverted (the no-footprint refusal is preserved and pinned by a test).