### PR TITLE
fix(provision): co-locate an added repo with existing worktrees

### DIFF
--- a/src/teatree/core/runners/provision.py
+++ b/src/teatree/core/runners/provision.py
@@ -26,10 +26,17 @@ class WorktreeProvisioner(RunnerBase):
 
     #33: a ticket whose repos live on DIFFERENT branches maps each repo to its
     own branch in ``ticket.extra['branches']`` (repo → branch); a repo absent
-    from the map falls back to ``extra['branch']``. The ticket DIR is always
-    ``extra['branch']`` regardless, so every repo provisions as a SIBLING in
-    one dir even when the repos are on split per-repo branches — this is what
-    lets an e2e / workspace-ticket stack compose split branches together.
+    from the map falls back to ``extra['branch']``. Every repo provisions as a
+    SIBLING in one dir even when the repos are on split per-repo branches — this
+    is what lets an e2e / workspace-ticket stack compose split branches together.
+
+    The ticket dir is normally ``<workspace>/<extra['branch']>``, but when the
+    ticket ALREADY has materialised worktrees (a repo added to an in-flight
+    ticket via ``workspace ticket --repos``) the dir is taken from the existing
+    worktrees' shared parent so the added repo co-locates as a sibling — see
+    ``_existing_ticket_dir``. This keeps an added FE next to the backend even
+    when ``extra['branch']`` has drifted from the original dir name (the
+    ``auto:<branch>`` ticket case).
     """
 
     def __init__(self, ticket: Ticket) -> None:
@@ -53,7 +60,14 @@ class WorktreeProvisioner(RunnerBase):
         branches = dict(extra.get("branches") or {})
 
         workspace = _workspace_dir()
-        ticket_dir = workspace / branch
+        # A repo ADDED to a ticket that already has materialised worktrees must
+        # co-locate as a SIBLING of the existing ones — derive the ticket dir
+        # from an existing worktree's parent, not blindly from ``branch``. The
+        # ``auto:<branch>`` case is where this matters: the first worktree lives
+        # in ``<workspace>/<actual-branch>`` while ``extra['branch']`` may have
+        # been (re)set to a pk-default like ``<pk>-ticket`` by a later scope(),
+        # so ``workspace / branch`` would split the second repo into a new dir.
+        ticket_dir = self._existing_ticket_dir(ticket) or (workspace / branch)
         ticket_dir.mkdir(parents=True, exist_ok=True)
 
         provisioned: dict[str, str] = dict(extra.get("provision") or {})
@@ -96,6 +110,26 @@ class WorktreeProvisioner(RunnerBase):
         if failed:
             return RunnerResult(ok=False, detail=f"failed to create worktrees for: {', '.join(failed)}")
         return RunnerResult(ok=True, detail=f"provisioned {len(provisioned)} worktree(s)")
+
+    @staticmethod
+    def _existing_ticket_dir(ticket: Ticket) -> Path | None:
+        """The shared parent dir of this ticket's already-materialised worktrees.
+
+        Returns the common parent of every existing ``Worktree`` whose
+        ``worktree_path`` is on disk, so a repo added later co-locates as a
+        sibling there rather than in a fresh ``<workspace>/<branch>`` dir. A
+        repo worktree lives at ``<ticket_dir>/<repo-basename>``, so its parent
+        IS the ticket dir. Returns ``None`` when the ticket has no materialised
+        worktree yet (first provision) or when the existing ones disagree on a
+        parent (a pre-existing split we don't paper over), leaving the caller's
+        ``workspace / branch`` default in force.
+        """
+        parents = {
+            Path(path).parent
+            for wt in Worktree.objects.filter(ticket=ticket)
+            if (path := (wt.extra or {}).get("worktree_path")) and Path(path).is_dir()
+        }
+        return parents.pop() if len(parents) == 1 else None
 
     @staticmethod
     def _create(workspace: Path, repo_name: str, ticket_dir: Path, branch: str) -> tuple[str, Path] | None:

--- a/tests/teatree_core/test_runners_provision.py
+++ b/tests/teatree_core/test_runners_provision.py
@@ -360,6 +360,105 @@ class TestWorktreeProvisionerPerRepoBranches(TestCase):
             assert wt.branch == "77-feature"
 
 
+class TestWorktreeProvisionerCoLocatesAddedRepo(TestCase):
+    """A repo ADDED to an in-flight ticket co-locates with the existing worktrees.
+
+    ``workspace ticket --repos`` over a ticket that already has materialised
+    worktrees merges the new repo into ``ticket.repos`` for the next provision.
+    The added repo must land as a SIBLING of the existing worktrees, even when
+    ``extra['branch']`` has drifted from the original ticket-dir name — the
+    ``auto:<branch>`` ticket case, where a later ``scope()`` reset
+    ``extra['branch']`` to a ``<pk>-ticket`` pk-default. The dir is taken from
+    the existing worktrees' shared parent, not blindly from ``extra['branch']``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _tmp_workspace(self, tmp_path: Path) -> None:
+        self.workspace = tmp_path / "workspace"
+        self.workspace.mkdir()
+
+    def _patch_workspace_dir(self) -> Any:
+        return patch("teatree.core.runners.provision._workspace_dir", return_value=self.workspace)
+
+    def _make_clone(self, repo: str) -> None:
+        repo_dir = self.workspace / repo
+        repo_dir.mkdir()
+        (repo_dir / ".git").mkdir()
+
+    def _run_capturing_dests(self, ticket: Ticket) -> tuple[Any, list[str]]:
+        created_paths: list[str] = []
+
+        def fake_worktree_add(repo: str, path: str, branch: str, *, create_branch: bool = True) -> bool:
+            del repo, branch, create_branch
+            Path(path).mkdir(parents=True, exist_ok=True)
+            created_paths.append(path)
+            return True
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            self._patch_workspace_dir(),
+            patch("teatree.core.runners.provision.git.worktree_add", side_effect=fake_worktree_add),
+            patch("teatree.core.runners.provision.git.pull_ff_only", return_value=True),
+        ):
+            result = WorktreeProvisioner(ticket).run()
+        return result, created_paths
+
+    def test_added_repo_co_locates_with_existing_worktree_despite_drifted_branch(self) -> None:
+        # The exact #8648 footgun: the backend worktree lives in the
+        # original branch-named dir, but a later scope() drifted
+        # ``extra['branch']`` to a pk-default. Adding the FE must NOT split
+        # it into ``<workspace>/<pk>-ticket/``.
+        self._make_clone("backend-repo")
+        self._make_clone("frontend-repo")
+        original_dir = self.workspace / "8648-store-signed-docs"
+        backend_wt = original_dir / "backend-repo"
+        backend_wt.mkdir(parents=True)
+
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="auto:8648-store-signed-docs",
+            repos=["backend-repo", "frontend-repo"],
+            extra={"branch": "23-ticket", "description": "x"},  # drifted pk-default
+        )
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="backend-repo",
+            branch="8648-store-signed-docs",
+            extra={"worktree_path": str(backend_wt)},
+        )
+
+        result, created_paths = self._run_capturing_dests(ticket)
+
+        assert result.ok is True, result.detail
+        # The FE co-located as a SIBLING of the existing backend worktree …
+        expected_fe = original_dir / "frontend-repo"
+        assert str(expected_fe) in created_paths
+        # … and was NOT split into the drifted pk-default dir.
+        split_fe = self.workspace / "23-ticket" / "frontend-repo"
+        assert str(split_fe) not in created_paths
+        assert not (self.workspace / "23-ticket").exists()
+
+        fe_wt = Worktree.objects.get(ticket=ticket, repo_path="frontend-repo")
+        assert (fe_wt.extra or {}).get("worktree_path") == str(expected_fe)
+
+    def test_first_provision_with_no_existing_worktree_uses_branch_dir(self) -> None:
+        # No materialised worktree yet → the normal ``workspace / branch``
+        # path is unchanged (the helper returns None, default in force).
+        self._make_clone("repo-a")
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://example.com/issues/900",
+            repos=["repo-a"],
+            extra={"branch": "900-feature", "description": "x"},
+        )
+
+        result, created_paths = self._run_capturing_dests(ticket)
+
+        assert result.ok is True, result.detail
+        assert str(self.workspace / "900-feature" / "repo-a") in created_paths
+
+
 class TestWorktreeProvisionerStampsScopedIdentity(TestCase):
     """#762 source-fix: public souliane/* worktrees get a local noreply identity.
 


### PR DESCRIPTION
## What

`workspace ticket --repos` placed a repo added to an in-flight ticket in `<workspace>/<extra['branch']>` instead of co-locating it with the ticket's already-materialised worktrees. For an `auto:<branch>` ticket whose `extra['branch']` had drifted to a `<pk>-ticket` pk-default, the added repo split into a separate dir rather than landing as a sibling of the existing backend worktree.

## Why

The provision runner derived the ticket dir from `extra['branch']` even when the ticket already had materialised worktrees with a known shared parent. The fix derives the ticket dir from the existing worktrees' shared parent when present (new `_existing_ticket_dir` helper in `src/teatree/core/runners/provision.py`), falling back to `workspace / branch` for the first provision.

## Tests

TDD-verified RED -> GREEN. The regression test reproduces the drifted-branch split (failed before, passes after) and asserts the unchanged first-provision path. 19 tests in `tests/teatree_core/test_runners_provision.py`, ruff + ty clean.

## Open questions & assumptions

- none

docs: n/a — internal provision-runner bug fix, no user-visible command/flag/contract change
