### PR TITLE
fix(merge): substrate pings the owner and holds under autonomy=full

### DIFF
--- a/src/teatree/backends/forge_merge_rpc.py
+++ b/src/teatree/backends/forge_merge_rpc.py
@@ -121,6 +121,14 @@ class GhMergeRpc:
             return [ROLLUP_QUERY_FAILED]
         return [entry for entry in rollup if isinstance(entry, dict)]
 
+    def fetch_pr_changed_paths(self, *, slug: str, pr_id: int) -> list[str]:
+        rc, out, _ = self._run(
+            ["pr", "view", str(pr_id), "--repo", slug, "--json", "files", "--jq", ".files[].path"],
+        )
+        if rc != 0:
+            return []
+        return [line.strip() for line in out.splitlines() if line.strip()]
+
     def merge_pr_squash_bound(self, *, slug: str, pr_id: int, expected_head_oid: str) -> ForgeMergeResult:
         endpoint = f"repos/{slug}/pulls/{pr_id}/merge"
         rc, out, err = self._run(
@@ -193,6 +201,25 @@ class GlabMergeRpc:
         if not isinstance(pipelines, list):
             return [ROLLUP_QUERY_FAILED]
         return [entry for entry in pipelines if isinstance(entry, dict)]
+
+    def fetch_pr_changed_paths(self, *, slug: str, pr_id: int) -> list[str]:
+        rc, out, _ = self._run(["api", f"projects/{glab_project_path(slug)}/merge_requests/{pr_id}/diffs"])
+        if rc != 0 or not out.strip():
+            return []
+        try:
+            diffs = json.loads(out)
+        except json.JSONDecodeError:
+            return []
+        if not isinstance(diffs, list):
+            return []
+        paths: list[str] = []
+        for entry in diffs:
+            if not isinstance(entry, dict):
+                continue
+            new_path = str(entry.get("new_path") or entry.get("old_path") or "").strip()
+            if new_path:
+                paths.append(new_path)
+        return paths
 
     def merge_pr_squash_bound(self, *, slug: str, pr_id: int, expected_head_oid: str) -> ForgeMergeResult:
         endpoint = f"projects/{glab_project_path(slug)}/merge_requests/{pr_id}/merge"

--- a/src/teatree/backends/github/client.py
+++ b/src/teatree/backends/github/client.py
@@ -581,5 +581,8 @@ class GitHubCodeHost:  # noqa: PLR0904 — method count reflects the CodeHostBac
     def fetch_required_checks_rollup(self, *, slug: str, pr_id: int) -> list[RawAPIDict]:
         return self._merge_rpc().fetch_required_checks_rollup(slug=slug, pr_id=pr_id)
 
+    def fetch_pr_changed_paths(self, *, slug: str, pr_id: int) -> list[str]:
+        return self._merge_rpc().fetch_pr_changed_paths(slug=slug, pr_id=pr_id)
+
     def merge_pr_squash_bound(self, *, slug: str, pr_id: int, expected_head_oid: str) -> ForgeMergeResult:
         return self._merge_rpc().merge_pr_squash_bound(slug=slug, pr_id=pr_id, expected_head_oid=expected_head_oid)

--- a/src/teatree/backends/gitlab/client.py
+++ b/src/teatree/backends/gitlab/client.py
@@ -542,5 +542,8 @@ class GitLabCodeHost:  # noqa: PLR0904 — method count reflects the CodeHostBac
     def fetch_required_checks_rollup(self, *, slug: str, pr_id: int) -> list[RawAPIDict]:
         return self._merge_rpc().fetch_required_checks_rollup(slug=slug, pr_id=pr_id)
 
+    def fetch_pr_changed_paths(self, *, slug: str, pr_id: int) -> list[str]:
+        return self._merge_rpc().fetch_pr_changed_paths(slug=slug, pr_id=pr_id)
+
     def merge_pr_squash_bound(self, *, slug: str, pr_id: int, expected_head_oid: str) -> ForgeMergeResult:
         return self._merge_rpc().merge_pr_squash_bound(slug=slug, pr_id=pr_id, expected_head_oid=expected_head_oid)

--- a/src/teatree/core/backend_protocols.py
+++ b/src/teatree/core/backend_protocols.py
@@ -288,6 +288,8 @@ class CodeHostBackend(Protocol):
 
     def fetch_required_checks_rollup(self, *, slug: str, pr_id: int) -> list[RawAPIDict]: ...  # pragma: no branch
 
+    def fetch_pr_changed_paths(self, *, slug: str, pr_id: int) -> list[str]: ...  # pragma: no branch
+
     def merge_pr_squash_bound(
         self,
         *,

--- a/src/teatree/core/gates/owned_repo_guard.py
+++ b/src/teatree/core/gates/owned_repo_guard.py
@@ -48,12 +48,18 @@ class MergeKeystoneResult(TypedDict, total=False):
     ticket_state: str
     error: str
     escalated: bool
+    # ``"substrate"`` when a substrate-class refusal was escalated (the loop edge
+    # pings the owner once and holds — ping-and-hold). Empty / absent for any
+    # other refusal so the loop pings ONLY on substrate, not every held merge.
+    escalation_kind: str
 
 
 class _MergeClearLike(Protocol):
     slug: str
     pr_id: int | str
     ticket: object
+
+    def is_substrate(self) -> bool: ...  # pragma: no branch
 
 
 class PushScopeVerdict(StrEnum):
@@ -213,9 +219,19 @@ def escalated_merge_result(clear: "_MergeClearLike", error: str) -> MergeKeyston
     """The canonical "merge held, re-escalate" result for a CLEAR.
 
     Shared by every keystone-merge refusal (scope-gate AND merge-precondition)
-    so the held-merge result shape stays defined in exactly one place.
+    so the held-merge result shape stays defined in exactly one place. Carries
+    ``escalation_kind = "substrate"`` when the held CLEAR is substrate, so the
+    loop edge pings the owner ONCE and holds (ping-and-hold) — and only on
+    substrate, never on every held merge.
     """
-    return {"merged": False, "escalated": True, "pr_id": int(clear.pr_id), "slug": clear.slug, "error": error}
+    return {
+        "merged": False,
+        "escalated": True,
+        "pr_id": int(clear.pr_id),
+        "slug": clear.slug,
+        "error": error,
+        "escalation_kind": "substrate" if clear.is_substrate() else "",
+    }
 
 
 def merge_clear_refusal(clear: "_MergeClearLike", *, approved: bool) -> MergeKeystoneResult | None:

--- a/src/teatree/core/merge/authorization.py
+++ b/src/teatree/core/merge/authorization.py
@@ -123,45 +123,41 @@ def _assert_clear_authorized(
         )
         raise MergePreconditionError(msg)
 
-    # 5. blast_class respected — substrate-class PRs are draft-locked and
-    #    require a recorded human sign-off (invariant 4 / §17.4.3 step 5). Two
-    #    things satisfy the per-PR sign-off, in this order:
-    #      a. a per-CLEAR ``human_authorizer`` matching the value re-presented
-    #         at merge time (the owner approved this exact diff), OR
-    #      b. the overlay's STANDING merge-approval grant — the owner recorded
-    #         once, in config, that this overlay merges end-to-end without a
-    #         per-PR sign-off (invariant 4 carve-out). EITHER equivalent owner
-    #         statement counts (#2666): ``autonomy = full``, OR an explicit
-    #         ``require_human_approval_to_merge = false`` on a non-collaborative
-    #         tier — see ``_overlay_grants_standing_substrate_signoff``.
-    #    Either way the AGENT executes through this same SHA-bound, audited
-    #    transition (invariant 8) — never raw ``gh``, never a human-performed
-    #    merge. The quality/safety floor (independent cold-review, reviewed-SHA
-    #    bind, CI-green, not-draft, never-lockout, privacy scan) is untouched by
-    #    the carve-out; the standing grant removes ONLY the per-PR human sign-off.
+    # 5. blast_class respected — substrate-class PRs are draft-locked and require
+    #    a recorded PER-PR human sign-off (invariant 4 / §17.4.3 step 5). Substrate
+    #    is NEVER covered by the overlay's standing grant — not even at
+    #    ``autonomy = full``: the owner's directive is that substrate (merge
+    #    keystone, architecture spec, governance doc) PINGS-and-HOLDS so they
+    #    authorize every such merge. ``_overlay_grants_standing_substrate_signoff``
+    #    therefore returns ``False`` for any substrate clear (the explicit gate
+    #    that the standing grant excludes substrate), so the ONLY thing that unlocks
+    #    a substrate merge here is a per-CLEAR ``human_authorizer`` matching the
+    #    value re-presented at merge time. When unsatisfied the held clear raises
+    #    below, which the loop edge routes to the substrate-hold Slack ping. The
+    #    AGENT still executes the authorized merge through this same SHA-bound,
+    #    audited transition (invariant 8). The quality/safety floor (independent
+    #    cold-review, reviewed-SHA bind, CI-green, not-draft, never-lockout, privacy
+    #    scan) is untouched. NON-substrate changes self-merge unchanged.
     if (
         clear.is_substrate()
         and not clear.human_merge_authorized_by(presented)
         and not _overlay_grants_standing_substrate_signoff(clear, resolved_slug=slug)
     ):
         detail = (
-            "no human authoriser recorded on the CLEAR and the overlay carries no standing "
-            "merge-approval grant (autonomy is not full and require_human_approval_to_merge is not false)"
+            "no human authoriser recorded on the CLEAR — substrate is held for the owner, never auto-merged"
             if not clear.human_authorizer
             else f"presented authoriser != recorded ({clear.human_authorizer!r})"
             if presented
-            else "no --human-authorized presented at merge time and the overlay carries no standing "
-            "merge-approval grant (autonomy is not full and require_human_approval_to_merge is not false)"
+            else "no --human-authorized presented at merge time"
         )
         msg = (
             f"MergeClear for {slug}#{pr_id} is blast_class=substrate — substrate "
-            f"changes require a recorded human approval and are draft-locked "
-            f"(invariant 4); the loop never auto-merges them (§17.4.3 step 5). "
-            f"{detail.capitalize()}. The sanctioned paths: `t3 <overlay> autonomy "
-            f"set full` (the standing owner grant), or issue `t3 <overlay> ticket "
+            f"changes are held for the owner and are draft-locked (invariant 4); the "
+            f"loop never auto-merges them, not even at autonomy=full (§17.4.3 step 5). "
+            f"{detail.capitalize()}. The sanctioned path: issue `t3 <overlay> ticket "
             f"clear … --blast-class substrate --human-authorize <id>` (a per-PR "
             f"recorded approval), then the agent executes `t3 <overlay> ticket "
-            f"merge <clear_id> [--human-authorized <id>]`"
+            f"merge <clear_id> --human-authorized <id>`"
         )
         raise MergePreconditionError(msg)
 
@@ -217,41 +213,33 @@ def _resolve_clear_overlay_name(clear: "MergeClear", *, resolved_slug: str = "")
 
 
 def _overlay_grants_standing_substrate_signoff(clear: "MergeClear", *, resolved_slug: str = "") -> bool:
-    """Whether the CLEAR's overlay carries a standing substrate sign-off grant (invariant 4 carve-out).
+    """Whether the overlay's standing grant covers this per-PR sign-off (invariant 4 carve-out).
 
-    Resolves the effective settings for the CLEAR's overlay
-    (:func:`_resolve_clear_overlay_name`) via :func:`get_effective_settings` and
-    treats the substrate per-PR human sign-off as satisfied when the owner has
-    recorded EITHER equivalent standing grant (#2666):
+    A SUBSTRATE clear is NEVER covered — it returns ``False`` immediately. The
+    owner's directive is that substrate must PING-and-HOLD, never auto-merge: a
+    substrate change (merge keystone, architecture spec, governance doc) is the
+    one class the owner sees and authorizes every time, so even at
+    ``autonomy = full`` the standing grant does not remove its per-PR human
+    sign-off. The held substrate CLEAR raises the same MergePreconditionError,
+    which the loop edge routes to the substrate-hold Slack ping.
 
-    1.  ``autonomy = full`` — the single switch that collapses every approval
-        gate, OR
-    2.  an explicit ``require_human_approval_to_merge = false`` on a
-        NON-collaborative tier — the canonical documented auto-merge knob
-        (``mode = auto`` + ``require_human_approval_to_merge = false``). This IS
-        the owner's standing "no per-PR human merge approval needed" statement,
-        the same one ``autonomy = full`` makes, so an owner who set it but left
-        ``autonomy`` at the default ``babysit`` must not have their OWN green,
-        cold-reviewed substrate CLEAR refused.
-
-    The ``notify`` collaborative tier is EXCLUDED: it also collapses
-    ``require_human_approval_to_merge`` to ``false``, but a notify-tier MR merges
-    only after a colleague approval, so its ``false`` is a tier side effect, not
-    a self-owned standing grant — its substrate CLEAR keeps the per-PR human
-    authoriser mandatory. Any other below-full tier with the merge-approval gate
-    ON, or an unresolvable overlay, is fail-closed: the per-CLEAR human authoriser
-    stays mandatory. The carve-out touches ONLY the per-PR sign-off — every other
-    substrate-merge floor guard (independent cold-review, reviewed-SHA bind,
-    CI-green, not-draft, never-lockout, privacy scan) runs unchanged.
+    The remaining resolution (the standing grant for a NON-substrate clear —
+    ``autonomy = full`` OR an explicit ``require_human_approval_to_merge = false``
+    on a non-collaborative tier, the ``notify`` tier excluded, #2666) is retained
+    so the gate stays a single named contract; non-substrate clears do not reach
+    this function from the substrate-only call site, so for them it is moot.
 
     *resolved_slug* is the real ``owner/repo`` the merge keystone recovered for
     this CLEAR (threaded from :func:`assert_merge_preconditions`'s ``slug``
-    kwarg). It is the recovery source for a ticket-less CLEAR whose stored
-    ``slug`` is a branch name rather than ``owner/repo`` — see
-    :func:`_resolve_clear_overlay_name`.
+    kwarg) — see :func:`_resolve_clear_overlay_name`.
     """
     from teatree.config import Autonomy, get_effective_settings  # noqa: PLC0415
 
+    # Substrate is excluded from the standing grant entirely (the §3.2 gate):
+    # substrate PINGS-and-HOLDS for the owner, so the standing grant never removes
+    # its per-PR human sign-off, not even at ``autonomy = full``.
+    if clear.is_substrate():
+        return False
     overlay_name = _resolve_clear_overlay_name(clear, resolved_slug=resolved_slug)
     if not overlay_name:
         return False

--- a/src/teatree/core/merge/ci_rollup.py
+++ b/src/teatree/core/merge/ci_rollup.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, TypedDict, cast
 
 from teatree.core.backend_protocols import PrMergeState, rollup_query_failed
 from teatree.core.backend_registry import get_backend_provider
+from teatree.core.models import MergeClear
 
 if TYPE_CHECKING:
     from teatree.core.backend_protocols import CodeHostBackend
@@ -96,8 +97,6 @@ def attach_touched_paths(clear: object, *, slug: str, pr_id: int, host_kind: str
     only WIDEN substrate over the recorded ``blast_class``, never narrow it, so a
     missing diff never weakens the existing label-based substrate gate.
     """
-    from teatree.core.models import MergeClear  # noqa: PLC0415
-
     if not isinstance(clear, MergeClear):
         return
     try:

--- a/src/teatree/core/merge/ci_rollup.py
+++ b/src/teatree/core/merge/ci_rollup.py
@@ -76,6 +76,38 @@ def fetch_pr_is_draft(slug: str, pr_id: int, *, host_kind: str = "github") -> bo
     return _code_host_for(host_kind).fetch_pr_is_draft(slug=slug, pr_id=pr_id)
 
 
+def fetch_pr_changed_paths(slug: str, pr_id: int, *, host_kind: str = "github") -> list[str]:
+    """The PR/MR's changed file paths — feeds the path-based substrate detector.
+
+    Delegates to the registry-resolved :class:`CodeHostBackend` (GitHub reads
+    ``gh pr view --json files``; GitLab the MR ``diffs`` API). A forge error
+    degrades to an empty list — the path detector is an ADD-ON to the recorded
+    ``blast_class`` label (it can only widen substrate, never narrow it), so a
+    missing diff never weakens the existing label-based gate.
+    """
+    return _code_host_for(host_kind).fetch_pr_changed_paths(slug=slug, pr_id=pr_id)
+
+
+def attach_touched_paths(clear: object, *, slug: str, pr_id: int, host_kind: str) -> None:
+    """Populate ``clear.touched_paths`` from the forge's live changed-file list.
+
+    Best-effort: a non-``MergeClear`` *clear* (the gate handles that refusal) or a
+    forge error degrades to leaving ``touched_paths`` empty. The path detector can
+    only WIDEN substrate over the recorded ``blast_class``, never narrow it, so a
+    missing diff never weakens the existing label-based substrate gate.
+    """
+    from teatree.core.models import MergeClear  # noqa: PLC0415
+
+    if not isinstance(clear, MergeClear):
+        return
+    try:
+        paths = fetch_pr_changed_paths(slug, pr_id, host_kind=host_kind)
+    except Exception:  # noqa: BLE001 — a diff-fetch failure must never wedge the merge gate.
+        logger.debug("ci_rollup: changed-paths fetch failed for %s#%s — substrate label stands", slug, pr_id)
+        return
+    clear.touched_paths = tuple(paths)
+
+
 class _RollupEntry(TypedDict, total=False):
     """One ``gh ... statusCheckRollup`` entry — CheckRun or StatusContext."""
 

--- a/src/teatree/core/merge/execution.py
+++ b/src/teatree/core/merge/execution.py
@@ -33,6 +33,7 @@ from teatree.core.merge.authorization import (
 )
 from teatree.core.merge.ci_rollup import (
     _code_host_for,
+    attach_touched_paths,
     fetch_live_head_sha,
     fetch_pr_is_draft,
     fetch_pr_merge_state,
@@ -180,21 +181,25 @@ def assert_merge_preconditions(  # noqa: PLR0913 — §17.4.3 gate entry-point; 
     runs the post hook idempotently instead of re-issuing the merge — a
     lost post-hook becomes recoverable rather than a permanent brick.
 
-    The substrate sign-off (step 5) is satisfied by EITHER a matching per-CLEAR
-    ``human_authorized`` OR the CLEAR's overlay carrying a STANDING merge-approval
-    grant. ``human_authorized`` unlocks the merge **only** when the CLEAR is
-    substrate-class AND its recorded ``human_authorizer`` matches; it can never
-    unlock a non-substrate CLEAR. The standing grant is EITHER equivalent owner
-    statement (#2666): ``autonomy = full``, OR an explicit
-    ``require_human_approval_to_merge = false`` on a non-collaborative tier (the
-    collaborative ``notify`` tier is excluded — it merges only after a colleague
-    approval; below-full tiers with the gate ON keep the per-CLEAR authoriser
-    mandatory). Either path runs the identical sanctioned ``t3`` transition
-    (invariant 8: even an owner-approved merge goes through it, never raw ``gh``).
-    The carve-out removes ONLY the per-PR sign-off — the quality/safety floor
-    (independent cold-review, reviewed-SHA bind, CI-green, not-draft,
-    never-lockout, privacy scan) is untouched.
+    Substrate (step 5) is HELD for the owner — never covered by the standing
+    grant, not even at ``autonomy = full``: it pings-and-holds (the loop edge
+    DMs the owner). The ONLY thing that unlocks a substrate merge is a matching
+    per-CLEAR ``human_authorized`` re-presented at merge time; the AGENT then
+    executes through this same sanctioned transition (invariant 8). A substrate
+    diff is detected by EITHER the ``blast_class`` label OR the live diff paths
+    (:func:`attach_touched_paths`), so a mislabeled substrate change is still
+    held. Non-substrate self-merges through the standing grant unchanged. The
+    quality/safety floor (independent cold-review, reviewed-SHA bind, CI-green,
+    not-draft, never-lockout, privacy scan) is untouched.
     """
+    # Attach the live diff paths so the substrate authorization guard can detect
+    # a mislabeled substrate diff (path-based classifier — invariant 4). A forge
+    # error degrades to no paths: the path detector only WIDENS substrate over the
+    # recorded ``blast_class``, never narrows it, so a missing diff never weakens
+    # the label-based gate. Set BEFORE the authorize call so the substrate branch
+    # reads it.
+    attach_touched_paths(clear, slug=slug, pr_id=pr_id, host_kind=host_kind)
+
     authorized_clear = _assert_clear_authorized(
         clear=clear,
         executing_loop_identity=executing_loop_identity,

--- a/src/teatree/core/models/merge_clear.py
+++ b/src/teatree/core/models/merge_clear.py
@@ -18,13 +18,16 @@ Both rows are written through the same ``transaction.atomic()`` path that gets
 
 import re
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 from django.db import models, transaction
 from django.utils import timezone
 
 from teatree.core.modelkit.db_retry import retry_on_locked
 from teatree.core.models.ticket import Ticket
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 # §17.8 clause 3 / §17.6 candidate 13: an independent cold-review attestation
 # cannot be recorded by the maker/coding-agent/loop side — the author would be
@@ -50,6 +53,36 @@ SHA_FULL_LEN = 40
 
 
 _COMPONENT_ROLE_WORDS = frozenset({"maker", "coding", "loop"})
+
+# A diff is substrate — independent of the reviewer's ``blast_class`` label —
+# when it touches the merge keystone, the architecture spec, or a governance
+# doc. The label defaults to ``logic`` (the orchestrator's judgment), so a
+# substrate change a human forgot to mark would otherwise auto-merge silently
+# under ``autonomy = full``. This path detector makes the substrate guarantee
+# label-independent (invariant 4): the change is substrate if its diff is.
+_SUBSTRATE_PATH_PREFIXES = ("src/teatree/core/merge/", "docs/blueprint/")
+_SUBSTRATE_FILE_NAMES = frozenset({"BLUEPRINT.md", "CLAUDE.md", "AGENTS.md"})
+
+
+def diff_paths_are_substrate(paths: "Iterable[str]") -> bool:
+    """True iff any of *paths* is a substrate path (merge keystone / spec / governance).
+
+    Substrate paths are: anything under ``src/teatree/core/merge/`` (the merge
+    keystone), the architecture spec (``BLUEPRINT.md`` and ``docs/blueprint/``),
+    and the governance docs (``CLAUDE.md`` / ``AGENTS.md`` at any depth). Matching
+    is on whole path components after stripping a leading ``./`` or ``/`` so a
+    look-alike sibling (``BLUEPRINT.md.bak``, ``src/teatree/core/merger/``) is not
+    misclassified.
+    """
+    for raw in paths:
+        normalized = raw.strip().lstrip("/").removeprefix("./")
+        if not normalized:
+            continue
+        if any(normalized.startswith(prefix) for prefix in _SUBSTRATE_PATH_PREFIXES):
+            return True
+        if normalized.rsplit("/", 1)[-1] in _SUBSTRATE_FILE_NAMES:
+            return True
+    return False
 
 
 def is_non_reviewer_role(identity: str) -> bool:
@@ -151,6 +184,13 @@ class MergeClear(models.Model):
     human_authorizer = models.CharField(max_length=255, blank=True, default="")
     issued_at = models.DateTimeField(default=timezone.now)
     consumed_at = models.DateTimeField(null=True, blank=True)
+
+    # Non-persisted: the diff paths the merge gate fetched live for this CLEAR.
+    # Populated at merge time (``_assert_clear_authorized``) from the forge's
+    # changed-file list so ``is_substrate()`` can detect a mislabeled substrate
+    # diff. Not a DB column — no migration, no compaction-survival concern (it is
+    # re-derived from the live PR each merge attempt).
+    touched_paths: "tuple[str, ...]" = ()
 
     class Meta:
         db_table = "teatree_merge_clear"
@@ -284,8 +324,15 @@ class MergeClear(models.Model):
         return all(bool(value) for value in required)
 
     def is_substrate(self) -> bool:
-        """True iff this CLEAR is for a substrate-class change (invariant 4)."""
-        return self.blast_class == self.BlastClass.SUBSTRATE
+        """True iff this CLEAR is for a substrate-class change (invariant 4).
+
+        Substrate by EITHER the recorded ``blast_class`` label OR the live diff
+        touching a substrate path (:func:`diff_paths_are_substrate` over
+        :attr:`touched_paths`). The path detector makes the guarantee reliable —
+        a substrate diff a human left at the default ``logic`` label is still
+        held, never auto-merged.
+        """
+        return self.blast_class == self.BlastClass.SUBSTRATE or diff_paths_are_substrate(self.touched_paths)
 
     def human_merge_authorized_by(self, presented_authorizer: str) -> bool:
         """True iff a substrate CLEAR's recorded authoriser matches what the merge call presents.

--- a/src/teatree/eval/regression_corpus.py
+++ b/src/teatree/eval/regression_corpus.py
@@ -40,7 +40,7 @@ from teatree.eval.regression_corpus_predicates import (
     _check_forge_resolves_by_host_not_token,
     _check_loop_owner_lease_pid_anchored,
     _check_merge_precondition_maker_is_not_checker,
-    _check_merge_precondition_substrate_full_autonomy,
+    _check_merge_precondition_substrate_full_autonomy_holds,
     _check_merge_precondition_substrate_human_authorize,
     _check_mr_description_first_line_validated,
     _check_private_repo_allowlist_path_segment_match,
@@ -99,10 +99,10 @@ _CHECKS: tuple[RegressionCheck, ...] = (
         needs_db=True,
     ),
     RegressionCheck(
-        failure_class="substrate-merge full-autonomy carve-out",
+        failure_class="substrate-merge full-autonomy ping-and-hold",
         origin="https://github.com/souliane/teatree/issues/1748",
-        invariant="an autonomy=full overlay clears a ticket-less substrate CLEAR without a per-PR human sign-off",
-        predicate=_check_merge_precondition_substrate_full_autonomy,
+        invariant="an autonomy=full overlay HOLDS a substrate CLEAR with no per-PR human authorizer (ping-and-hold)",
+        predicate=_check_merge_precondition_substrate_full_autonomy_holds,
         needs_db=True,
     ),
     RegressionCheck(

--- a/src/teatree/eval/regression_corpus_predicates.py
+++ b/src/teatree/eval/regression_corpus_predicates.py
@@ -98,25 +98,27 @@ def _check_merge_precondition_substrate_human_authorize() -> bool:
 
     The CLEAR's overlay (resolved from its ``slug``) is pinned to ``babysit``
     via the DB-home autonomy seam (#1775) so the check is deterministic
-    regardless of the developer's live config. The ``autonomy = full`` carve-out is a
-    distinct must-allow path verified by
-    :func:`_check_merge_precondition_substrate_full_autonomy`; this check is the
-    must-block direction for a below-full overlay.
+    regardless of the developer's live config. Substrate is held under EVERY tier
+    (including ``full`` — verified by
+    :func:`_check_merge_precondition_substrate_full_autonomy_holds`); this check is
+    the must-block direction for a below-full overlay.
     """
     return _exercise_substrate_authorize(autonomy="babysit", expect_cleared_without_human=False)
 
 
-def _check_merge_precondition_substrate_full_autonomy() -> bool:
-    """Carve-out: a substrate CLEAR under an ``autonomy = full`` overlay clears without a per-PR sign-off.
+def _check_merge_precondition_substrate_full_autonomy_holds() -> bool:
+    """Ping-and-hold: a substrate CLEAR under an ``autonomy = full`` overlay is HELD, never auto-merged.
 
-    The mirror of :func:`_check_merge_precondition_substrate_human_authorize`:
-    with the CLEAR's overlay pinned to ``full``, the standing grant satisfies
-    the substrate sign-off, so presenting no ``--human-authorized`` must NOT
-    raise. This is the must-allow direction the ticket-less / aliased
-    overlay-resolution fix restores; without it, a full-autonomy substrate
-    merge is wrongly blocked (the rest of the floor is unaffected).
+    The owner's directive — substrate (merge keystone, architecture spec,
+    governance doc) PINGS-and-HOLDS so they authorize every such merge. With the
+    CLEAR's overlay pinned to ``full`` and NO ``--human-authorized`` presented, the
+    standing grant does NOT cover substrate, so ``_assert_clear_authorized`` MUST
+    raise (the loop edge then pings the owner). This is the inverse of the prior
+    carve-out: substrate is excluded from the standing grant entirely, so a
+    mislabeled or genuine substrate change can never auto-merge silently under
+    full autonomy. The only path that clears it is a per-PR human authorizer.
     """
-    return _exercise_substrate_authorize(autonomy="full", expect_cleared_without_human=True)
+    return _exercise_substrate_authorize(autonomy="full", expect_cleared_without_human=False)
 
 
 def _exercise_substrate_authorize(*, autonomy: str, expect_cleared_without_human: bool) -> bool:
@@ -411,7 +413,7 @@ __all__ = [
     "_check_forge_resolves_by_host_not_token",
     "_check_loop_owner_lease_pid_anchored",
     "_check_merge_precondition_maker_is_not_checker",
-    "_check_merge_precondition_substrate_full_autonomy",
+    "_check_merge_precondition_substrate_full_autonomy_holds",
     "_check_merge_precondition_substrate_human_authorize",
     "_check_mr_description_first_line_validated",
     "_check_private_repo_allowlist_path_segment_match",

--- a/src/teatree/loop/scanner_factories.py
+++ b/src/teatree/loop/scanner_factories.py
@@ -40,6 +40,7 @@ from teatree.loop.scanners import (
     TicketCompletionScanner,
     TicketDispositionScanner,
 )
+from teatree.loop.substrate_pinger import NotifyWithFallbackSubstratePinger
 from teatree.loop.tick_resolvers import (
     _allowed_url_prefixes_for_host,
     _identity_alias_groups_for_overlay,
@@ -312,6 +313,9 @@ def _pr_sweep_scanner_for(backend: OverlayBackends, *, slack_user_id: str) -> Pr
         # #2210: scope the review-arm to the operator's own PRs — a colleague's
         # open PR in a watched repo must never be auto-scheduled for review.
         self_identities=backend.identities,
+        # Ping-and-hold: a held SUBSTRATE merge DMs the owner once (deduped per
+        # diff via the BotPing ledger) so substrate is never auto-merged silently.
+        substrate_pinger=NotifyWithFallbackSubstratePinger(),
     )
 
 

--- a/src/teatree/loop/scanners/pr_sweep.py
+++ b/src/teatree/loop/scanners/pr_sweep.py
@@ -49,6 +49,7 @@ from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
 from teatree.core.models.merge_clear import MergeClear
+from teatree.loop.scanners import pr_sweep_substrate as substrate
 from teatree.loop.scanners.base import ScannerError, ScanSignal
 from teatree.loop.scanners.pr_sweep_decision import (
     classify_checks,
@@ -59,7 +60,6 @@ from teatree.loop.scanners.pr_sweep_decision import (
     record_mergeable_notified,
     red_checks_are_all_repo_state,
 )
-from teatree.loop.scanners.pr_sweep_substrate import SubstratePinger, ping_substrate_hold
 from teatree.loop.scanners.pr_sweep_types import (
     GH_CONFLICT_MERGE_STATE,
     GH_CONFLICT_MERGEABLE,
@@ -232,7 +232,7 @@ class PrSweepScanner:
     #: the legacy log-only behaviour; ``scanner_factories`` wires the production
     #: ``notify_with_fallback`` adapter so the owner is pinged ONCE per held
     #: substrate diff (deduped via the BotPing ledger on the per-diff key).
-    substrate_pinger: "SubstratePinger | None" = None
+    substrate_pinger: "substrate.SubstratePinger | None" = None
     name: str = "pr_sweep"
 
     def scan(self) -> list[ScanSignal]:
@@ -386,6 +386,8 @@ class PrSweepScanner:
             return self._ci_block(pr, reason=ci_skip)
         if not has_independent_cold_review(slug=pr.slug, pr_id=pr.number, head_sha=pr.head_sha):
             return self._flag_no_review(pr)
+        if substrate.pr_diff_is_substrate(pr):
+            return substrate.hold_solo_overlay_substrate(self.substrate_pinger, pr=pr)
         ok, merged_sha = self.api.merge_pr_squash_bound(
             slug=pr.slug,
             pr_id=pr.number,
@@ -527,7 +529,13 @@ class PrSweepScanner:
                 merged_sha=merged_sha,
                 reason="fallback_uv_audit" if fallback else "all_green",
             )
-        if fallback:
+        # Finding 1 (fail-open): the uv-audit-fallback raw-merge must NOT fire for a
+        # substrate CLEAR. A substrate change that lands on the fallback path (the
+        # only red check is uv-audit, red on main too) would otherwise raw-merge
+        # here BEFORE the substrate-ping check below, silently bypassing the keystone
+        # hold. Gate the escalation on the CLEAR not being substrate; a substrate
+        # CLEAR falls through to ping-and-hold instead.
+        if fallback and not clear.is_substrate():
             ok, fallback_sha = self.api.merge_pr_squash_bound(
                 slug=pr.slug,
                 pr_id=pr.number,
@@ -543,8 +551,8 @@ class PrSweepScanner:
                     merged_sha=fallback_sha,
                     reason="fallback_uv_audit_gh",
                 )
-        if escalation_kind == "substrate":
-            ping_substrate_hold(self.substrate_pinger, pr=pr, reviewed_sha=clear.reviewed_sha, error=error)
+        if escalation_kind == "substrate" or clear.is_substrate():
+            substrate.ping_substrate_hold(self.substrate_pinger, pr=pr, reviewed_sha=clear.reviewed_sha, error=error)
         return MergeAttempt(
             slug=pr.slug,
             pr_id=pr.number,

--- a/src/teatree/loop/scanners/pr_sweep.py
+++ b/src/teatree/loop/scanners/pr_sweep.py
@@ -59,6 +59,7 @@ from teatree.loop.scanners.pr_sweep_decision import (
     record_mergeable_notified,
     red_checks_are_all_repo_state,
 )
+from teatree.loop.scanners.pr_sweep_substrate import SubstratePinger, ping_substrate_hold
 from teatree.loop.scanners.pr_sweep_types import (
     GH_CONFLICT_MERGE_STATE,
     GH_CONFLICT_MERGEABLE,
@@ -116,8 +117,13 @@ class PrApiClient(Protocol):
 class MergeKeystone(Protocol):
     """Adapter over ``call_command('ticket', 'merge', ...)`` — mockable."""
 
-    def merge_clear(self, *, clear_id: int) -> tuple[bool, str, str]:
-        """Return ``(merged, merged_sha, error)`` — ``error`` is the rejection reason."""
+    def merge_clear(self, *, clear_id: int) -> tuple[bool, str, str, str]:
+        """Return ``(merged, merged_sha, error, escalation_kind)``.
+
+        ``error`` is the rejection reason; ``escalation_kind`` is ``"substrate"``
+        when the refusal is a substrate sign-off hold (else empty) so the loop
+        pings the owner ONLY on substrate.
+        """
         ...  # pragma: no branch
 
 
@@ -222,6 +228,11 @@ class PrSweepScanner:
     #: too, and a colleague's PR must never be auto-scheduled for review. Empty
     #: means no PR is confirmable as ours, so nothing is armed (fail closed).
     self_identities: tuple[str, ...] = ()
+    #: Bot→user DM seam for a HELD substrate merge (ping-and-hold). ``None`` keeps
+    #: the legacy log-only behaviour; ``scanner_factories`` wires the production
+    #: ``notify_with_fallback`` adapter so the owner is pinged ONCE per held
+    #: substrate diff (deduped via the BotPing ledger on the per-diff key).
+    substrate_pinger: "SubstratePinger | None" = None
     name: str = "pr_sweep"
 
     def scan(self) -> list[ScanSignal]:
@@ -505,7 +516,7 @@ class PrSweepScanner:
             return False
 
     def _merge(self, *, pr: PrSummary, clear: MergeClear, fallback: bool) -> MergeAttempt:
-        merged, merged_sha, error = self.keystone.merge_clear(clear_id=int(clear.pk))
+        merged, merged_sha, error, escalation_kind = self.keystone.merge_clear(clear_id=int(clear.pk))
         if merged:
             self._announce_merge(slug=pr.slug, pr_id=pr.number, merged_sha=merged_sha, fallback=fallback)
             return MergeAttempt(
@@ -532,6 +543,8 @@ class PrSweepScanner:
                     merged_sha=fallback_sha,
                     reason="fallback_uv_audit_gh",
                 )
+        if escalation_kind == "substrate":
+            ping_substrate_hold(self.substrate_pinger, pr=pr, reviewed_sha=clear.reviewed_sha, error=error)
         return MergeAttempt(
             slug=pr.slug,
             pr_id=pr.number,

--- a/src/teatree/loop/scanners/pr_sweep_adapters.py
+++ b/src/teatree/loop/scanners/pr_sweep_adapters.py
@@ -250,16 +250,17 @@ class CallCommandMergeKeystone:
 
     loop_identity: str = "merge-loop"
 
-    def merge_clear(self, *, clear_id: int) -> tuple[bool, str, str]:
+    def merge_clear(self, *, clear_id: int) -> tuple[bool, str, str, str]:
         from django.core.management import call_command  # noqa: PLC0415
 
         result = call_command("ticket", "merge", str(clear_id), loop_identity=self.loop_identity)
         if not isinstance(result, dict):
-            return False, "", "ticket merge returned non-dict"
+            return False, "", "ticket merge returned non-dict", ""
         merged = bool(result.get("merged"))
         merged_sha = str(result.get("merged_sha") or "")
         error = str(result.get("error") or "")
-        return merged, merged_sha, error
+        escalation_kind = str(result.get("escalation_kind") or "")
+        return merged, merged_sha, error, escalation_kind
 
 
 @dataclass(slots=True)

--- a/src/teatree/loop/scanners/pr_sweep_substrate.py
+++ b/src/teatree/loop/scanners/pr_sweep_substrate.py
@@ -1,0 +1,58 @@
+"""Substrate-hold ping seam for the PR sweep (ping-and-hold, #3.1).
+
+A held SUBSTRATE merge DMs the owner once via the injected
+:class:`SubstratePinger` (the concrete ``notify_with_fallback`` egress is wired
+at the loop edge — this domain module stays import-clean of messaging/notify).
+The per-diff idempotency key keeps it to one ping per held diff and re-fires
+only on a new reviewed SHA.
+"""
+
+import logging
+from typing import Protocol, runtime_checkable
+
+from teatree.loop.scanners.pr_sweep_types import PrSummary
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class SubstratePinger(Protocol):
+    """Deliver a bot→user DM when a substrate merge is held (ping-and-hold) — mockable.
+
+    The production adapter wraps :func:`teatree.messaging.notify_with_fallback`,
+    so the per-diff ``idempotency_key`` dedupes across re-ticks via the
+    :class:`teatree.core.models.BotPing` ledger — exactly one ping per held
+    substrate diff, re-firing only on a new reviewed SHA.
+    """
+
+    def ping(self, *, text: str, idempotency_key: str) -> None: ...  # pragma: no branch
+
+
+def substrate_hold_text(pr: PrSummary, *, reviewed_sha: str, error: str) -> str:
+    """The owner-facing DM body for a held substrate merge."""
+    return (
+        f"substrate merge held for your sign-off: [{pr.slug}#{pr.number}]({pr.url}) "
+        f"@ {reviewed_sha[:8]} — {error or 'substrate change, held for the owner'}"
+    )
+
+
+def substrate_hold_key(pr: PrSummary, *, reviewed_sha: str) -> str:
+    """The per-diff idempotency key so the BotPing ledger dedupes re-ticks."""
+    return f"substrate-hold:{pr.slug}#{pr.number}:{reviewed_sha}"
+
+
+def ping_substrate_hold(pinger: "SubstratePinger | None", *, pr: PrSummary, reviewed_sha: str, error: str) -> None:
+    """DM the owner ONCE that a substrate merge is held (ping-and-hold).
+
+    No-op when no pinger is wired. Best-effort: a pinger error never aborts the
+    sweep — the substrate clear is still held; only the DM is missed.
+    """
+    if pinger is None:
+        return
+    try:
+        pinger.ping(
+            text=substrate_hold_text(pr, reviewed_sha=reviewed_sha, error=error),
+            idempotency_key=substrate_hold_key(pr, reviewed_sha=reviewed_sha),
+        )
+    except Exception:
+        logger.exception("pr_sweep failed to ping substrate-hold for %s#%d", pr.slug, pr.number)

--- a/src/teatree/loop/scanners/pr_sweep_substrate.py
+++ b/src/teatree/loop/scanners/pr_sweep_substrate.py
@@ -10,9 +10,33 @@ only on a new reviewed SHA.
 import logging
 from typing import Protocol, runtime_checkable
 
-from teatree.loop.scanners.pr_sweep_types import PrSummary
+from teatree.core.merge.ci_rollup import fetch_pr_changed_paths
+from teatree.core.models.merge_clear import diff_paths_are_substrate
+from teatree.loop.scanners.pr_sweep_types import MergeAttempt, PrSummary
 
 logger = logging.getLogger(__name__)
+
+
+def pr_diff_is_substrate(pr: PrSummary) -> bool:
+    """True iff *pr*'s changed paths make it a substrate change — FAIL-SAFE (Finding 2).
+
+    The solo-overlay no-CLEAR bypass has no CLEAR row to read ``is_substrate`` from,
+    so the diff is classified live via :func:`fetch_pr_changed_paths` +
+    :func:`diff_paths_are_substrate`. The fetch is FAIL-SAFE: an exception OR an
+    empty list (a real open PR always changes >=1 file, so an empty list signals the
+    forge fetch failed) is treated conservatively as substrate so the can't-tell case
+    HOLDS rather than widening to a silent merge. Only a non-empty, confirmed-non-
+    substrate diff lets the merge proceed.
+    """
+    try:
+        paths = fetch_pr_changed_paths(pr.slug, pr.number)
+    except Exception:
+        logger.exception("pr_sweep changed-paths fetch failed for %s#%d — holding", pr.slug, pr.number)
+        return True
+    if not paths:
+        logger.warning("pr_sweep empty changed-paths for %s#%d — holding conservatively", pr.slug, pr.number)
+        return True
+    return diff_paths_are_substrate(paths)
 
 
 @runtime_checkable
@@ -56,3 +80,25 @@ def ping_substrate_hold(pinger: "SubstratePinger | None", *, pr: PrSummary, revi
         )
     except Exception:
         logger.exception("pr_sweep failed to ping substrate-hold for %s#%d", pr.slug, pr.number)
+
+
+def hold_solo_overlay_substrate(pinger: "SubstratePinger | None", *, pr: PrSummary) -> MergeAttempt:
+    """Ping-and-hold a substrate PR on the solo-overlay no-CLEAR bypass (Finding 2).
+
+    Reuses the existing substrate pinger + per-diff idempotency key (keyed on the
+    live head SHA, since there is no CLEAR ``reviewed_sha`` here) so a re-tick dedupes
+    through the BotPing ledger. The PR is held, never raw-merged.
+    """
+    ping_substrate_hold(
+        pinger,
+        pr=pr,
+        reviewed_sha=pr.head_sha,
+        error="substrate change on solo overlay, held for the owner",
+    )
+    return MergeAttempt(
+        slug=pr.slug,
+        pr_id=pr.number,
+        decision="blocked",
+        reason="solo_overlay_substrate_hold",
+        url=pr.url,
+    )

--- a/src/teatree/loop/substrate_pinger.py
+++ b/src/teatree/loop/substrate_pinger.py
@@ -1,0 +1,23 @@
+"""Loop-edge substrate-hold pinger (orchestration layer).
+
+A held SUBSTRATE merge DMs the owner once (ping-and-hold) via the existing
+``notify_with_fallback`` egress. Lives at the ``teatree.loop`` orchestration
+layer — NOT in ``teatree.loop.scanners`` (domain), where the tach boundary
+forbids importing ``teatree.messaging`` / ``teatree.notify`` (integration). The
+scanner depends only on the ``SubstratePinger`` Protocol; this concrete notify
+egress is injected at the loop edge, mirroring ``domain_jobs``'s use.
+"""
+
+from teatree.messaging import notify_with_fallback
+from teatree.notify import NotifyKind
+
+
+class NotifyWithFallbackSubstratePinger:
+    """Production :class:`~teatree.loop.scanners.pr_sweep.SubstratePinger` (ping-and-hold).
+
+    The per-diff idempotency key dedupes across re-ticks through the BotPing
+    ledger, so the owner is pinged exactly once per held substrate diff.
+    """
+
+    def ping(self, *, text: str, idempotency_key: str) -> None:  # noqa: PLR6301 — instance method satisfies the injected SubstratePinger Protocol.
+        notify_with_fallback(text=text, kind=NotifyKind.INFO, idempotency_key=idempotency_key)

--- a/tests/teatree_backends/test_code_host_protocol_coverage.py
+++ b/tests/teatree_backends/test_code_host_protocol_coverage.py
@@ -1,4 +1,4 @@
-"""Protocol-coverage fitness for the 5 merge-RPC methods (PR 4 / #1985).
+"""Protocol-coverage fitness for the merge-RPC methods (PR 4 / #1985).
 
 ``runtime_checkable`` only checks method NAMES; these tests additionally pin the
 exact keyword-only signature so a drifted parameter (or a removed method on one
@@ -31,6 +31,10 @@ _MERGE_RPC_SIGNATURES: dict[str, list[tuple[str, inspect._ParameterKind]]] = {
         ("pr_id", inspect.Parameter.KEYWORD_ONLY),
     ],
     "fetch_required_checks_rollup": [
+        ("slug", inspect.Parameter.KEYWORD_ONLY),
+        ("pr_id", inspect.Parameter.KEYWORD_ONLY),
+    ],
+    "fetch_pr_changed_paths": [
         ("slug", inspect.Parameter.KEYWORD_ONLY),
         ("pr_id", inspect.Parameter.KEYWORD_ONLY),
     ],

--- a/tests/teatree_backends/test_protocols.py
+++ b/tests/teatree_backends/test_protocols.py
@@ -174,6 +174,10 @@ class _FakeCodeHost:
         _ = (slug, pr_id)
         return []
 
+    def fetch_pr_changed_paths(self, *, slug: str, pr_id: int) -> list[str]:
+        _ = (slug, pr_id)
+        return []
+
     def merge_pr_squash_bound(self, *, slug: str, pr_id: int, expected_head_oid: str) -> ForgeMergeResult:
         _ = (slug, pr_id, expected_head_oid)
         return ForgeMergeResult(returncode=0, stdout="", stderr="", merged_sha="")

--- a/tests/teatree_core/models/test_merge_clear_substrate_paths.py
+++ b/tests/teatree_core/models/test_merge_clear_substrate_paths.py
@@ -1,0 +1,112 @@
+"""Path-based substrate classifier — label-independent substrate detection.
+
+``blast_class`` is the orchestrator's (or a human's) judgment and defaults to
+``logic``. Under ``autonomy = full`` a substrate diff mislabeled ``logic`` would
+otherwise auto-merge silently. The path classifier makes the substrate guarantee
+reliable: a diff touching a substrate path (``BLUEPRINT.md``, governance docs,
+anything under ``src/teatree/core/merge/``) is substrate regardless of the label.
+
+Pure-logic unit tests for :func:`diff_paths_are_substrate`; the model-method
+integration (``is_substrate()`` consulting ``touched_paths``) is a thin DB test.
+"""
+
+import pytest
+from django.test import TestCase
+
+from teatree.core.models import MergeClear
+from teatree.core.models.merge_clear import diff_paths_are_substrate
+
+# ast-grep-ignore: ac-django-no-pytest-django-db
+pytestmark = pytest.mark.django_db
+
+
+class TestDiffPathsAreSubstrate:
+    """The pure path classifier — no DB, no model instance."""
+
+    def test_blueprint_root_is_substrate(self) -> None:
+        assert diff_paths_are_substrate(["BLUEPRINT.md"]) is True
+
+    def test_blueprint_appendix_is_substrate(self) -> None:
+        assert diff_paths_are_substrate(["docs/blueprint/17-merge.md"]) is True
+
+    def test_core_merge_dir_is_substrate(self) -> None:
+        assert diff_paths_are_substrate(["src/teatree/core/merge/authorization.py"]) is True
+
+    def test_nested_under_core_merge_is_substrate(self) -> None:
+        assert diff_paths_are_substrate(["src/teatree/core/merge/sub/deep.py"]) is True
+
+    def test_governance_claude_md_is_substrate(self) -> None:
+        assert diff_paths_are_substrate(["CLAUDE.md"]) is True
+
+    def test_governance_agents_md_is_substrate(self) -> None:
+        assert diff_paths_are_substrate(["AGENTS.md"]) is True
+
+    def test_nested_governance_doc_is_substrate(self) -> None:
+        assert diff_paths_are_substrate(["src/teatree/core/CLAUDE.md"]) is True
+
+    def test_ordinary_logic_path_is_not_substrate(self) -> None:
+        assert diff_paths_are_substrate(["src/teatree/loop/scanners/pr_sweep.py"]) is False
+
+    def test_ordinary_doc_path_is_not_substrate(self) -> None:
+        assert diff_paths_are_substrate(["README.md", "docs/usage.md"]) is False
+
+    def test_empty_paths_is_not_substrate(self) -> None:
+        assert diff_paths_are_substrate([]) is False
+
+    def test_mixed_diff_with_one_substrate_path_is_substrate(self) -> None:
+        # A single substrate path in an otherwise-logic diff still classifies
+        # the whole change as substrate — the guarantee is "touches substrate".
+        assert diff_paths_are_substrate(["src/teatree/cli/x.py", "src/teatree/core/merge/x.py"]) is True
+
+    def test_leading_slash_and_dotslash_are_normalized(self) -> None:
+        assert diff_paths_are_substrate(["./src/teatree/core/merge/x.py"]) is True
+        assert diff_paths_are_substrate(["/BLUEPRINT.md"]) is True
+
+    def test_substring_lookalike_is_not_substrate(self) -> None:
+        # ``BLUEPRINT.md.bak`` and a sibling dir that merely starts with the
+        # same prefix must not be misclassified — match on path components.
+        assert diff_paths_are_substrate(["docs/BLUEPRINT.md.bak"]) is False
+        assert diff_paths_are_substrate(["src/teatree/core/merger/x.py"]) is False
+
+
+class TestIsSubstrateConsultsTouchedPaths(TestCase):
+    """``MergeClear.is_substrate()`` returns true on a substrate diff regardless of the label."""
+
+    def _logic_clear(self) -> MergeClear:
+        return MergeClear.objects.create(
+            pr_id=4242,
+            slug="souliane/teatree",
+            reviewed_sha="a" * 40,
+            reviewer_identity="cold-reviewer",
+            gh_verify_result=MergeClear.VerifyResult.GREEN,
+            blast_class=MergeClear.BlastClass.LOGIC,
+        )
+
+    def test_logic_clear_with_substrate_path_is_substrate(self) -> None:
+        # The anti-vacuity test (c): blast_class left at the 'logic' default,
+        # but the diff touches src/teatree/core/merge/ -> is_substrate() True.
+        clear = self._logic_clear()
+        assert clear.is_substrate() is False  # no paths attached yet
+        clear.touched_paths = ("src/teatree/core/merge/authorization.py",)
+        assert clear.is_substrate() is True
+
+    def test_logic_clear_with_only_logic_paths_is_not_substrate(self) -> None:
+        clear = self._logic_clear()
+        clear.touched_paths = ("src/teatree/loop/scanners/pr_sweep.py",)
+        assert clear.is_substrate() is False
+
+    def test_substrate_label_is_substrate_even_with_logic_paths(self) -> None:
+        clear = MergeClear.objects.create(
+            pr_id=4243,
+            slug="souliane/teatree",
+            reviewed_sha="a" * 40,
+            reviewer_identity="cold-reviewer",
+            gh_verify_result=MergeClear.VerifyResult.GREEN,
+            blast_class=MergeClear.BlastClass.SUBSTRATE,
+        )
+        clear.touched_paths = ("src/teatree/loop/scanners/pr_sweep.py",)
+        assert clear.is_substrate() is True
+
+    def test_touched_paths_defaults_empty(self) -> None:
+        clear = self._logic_clear()
+        assert clear.touched_paths == ()

--- a/tests/teatree_core/test_clear_issuance_and_human_substrate.py
+++ b/tests/teatree_core/test_clear_issuance_and_human_substrate.py
@@ -671,26 +671,35 @@ def _assert_preconditions(clear: MergeClear, *, human_authorized: str = "", slug
         )
 
 
-class TestFullAutonomyStandingGrantSatisfiesSubstrateSignoff(TestCase):
-    """Invariant 4 carve-out: an overlay at ``autonomy = full`` is the standing human approval.
+class TestFullAutonomySubstrateIsHeldAndPingedNotAutoMerged(TestCase):
+    """Under ``autonomy = full`` a SUBSTRATE clear is HELD for the owner, never auto-merged.
 
-    The substrate per-PR sign-off is satisfied by EITHER a per-CLEAR
-    ``human_authorizer`` OR the CLEAR's overlay standing at ``autonomy = full``.
-    The quality/safety floor (independent cold-review, reviewed-SHA bind,
-    CI-green, not-draft, maker≠checker) is never relaxed by this knob — only
-    the per-PR human sign-off is what ``full`` removes.
+    The owner's directive: substrate (merge keystone, architecture spec,
+    governance doc) must PING-and-HOLD so the owner sees and authorizes every
+    such merge — even at ``autonomy = full``. The standing grant removes the
+    per-PR human sign-off only for NON-substrate changes; a substrate clear under
+    ``full`` raises the same ``MergePreconditionError`` (routed at the loop edge to
+    the substrate-hold Slack ping). The only path that merges a substrate clear is
+    a per-CLEAR ``human_authorizer`` re-presented at merge time. The quality/safety
+    floor (independent cold-review, reviewed-SHA bind, CI-green, not-draft,
+    maker≠checker) is untouched.
     """
 
-    def test_full_autonomy_substrate_passes_without_human_authorizer(self) -> None:
-        """MUST-ALLOW: full + substrate + reviewer!=maker + green + not-draft + no authorizer."""
+    def test_full_autonomy_substrate_is_held_without_human_authorizer(self) -> None:
+        """MUST-DENY: full + substrate + no authorizer is HELD (the standing grant excludes substrate)."""
         ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
         clear = _substrate_clear(ticket)
-        with _overlay_autonomy("t3-teatree", "full"):
-            precheck = _assert_preconditions(clear)
-        assert precheck is not None
+        with _overlay_autonomy("t3-teatree", "full"), pytest.raises(MergePreconditionError, match="substrate"):
+            _assert_preconditions(clear)
 
-    def test_full_autonomy_substrate_merges_end_to_end_without_human_authorizer(self) -> None:
-        """MUST-ALLOW end-to-end: the keystone merge advances the FSM with no per-PR sign-off."""
+    def test_full_autonomy_substrate_is_held_end_to_end_no_auto_merge(self) -> None:
+        """MUST-DENY end-to-end: the keystone merge HOLDS the substrate clear and leaves the FSM untouched.
+
+        Pins the regression the fix closes: before the fix, ``autonomy = full``
+        auto-merged this substrate clear SILENTLY (``merged`` True, FSM advanced,
+        no ping). Now it is held (``merged`` False, escalated) so the loop edge can
+        ping the owner.
+        """
         ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
         clear = _substrate_clear(ticket, pr_id=1731)
         with (
@@ -703,9 +712,19 @@ class TestFullAutonomyStandingGrantSatisfiesSubstrateSignoff(TestCase):
             )
         ticket.refresh_from_db()
         clear.refresh_from_db()
-        assert result["merged"]
-        assert ticket.state == Ticket.State.MERGED
-        assert clear.consumed_at is not None
+        assert result["merged"] is False
+        assert result["escalated"] is True
+        assert result["escalation_kind"] == "substrate"
+        assert ticket.state == Ticket.State.IN_REVIEW
+        assert clear.consumed_at is None
+
+    def test_full_autonomy_substrate_with_human_authorizer_still_merges(self) -> None:
+        """MUST-ALLOW: a per-CLEAR ``human_authorizer`` re-presented at merge is the unchanged substrate path."""
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
+        clear = _substrate_clear(ticket, pr_id=1730, human_authorizer="owner:adrien")
+        with _overlay_autonomy("t3-teatree", "full"):
+            precheck = _assert_preconditions(clear, human_authorized="owner:adrien")
+        assert precheck is not None
 
     def test_notify_autonomy_substrate_without_authorizer_still_refused(self) -> None:
         """MUST-DENY: notify (not full) keeps the per-PR human authorizer mandatory."""
@@ -735,12 +754,17 @@ class TestFullAutonomyStandingGrantSatisfiesSubstrateSignoff(TestCase):
         ):
             _assert_preconditions(clear)
 
-    def test_full_autonomy_does_not_relax_sha_bind_floor(self) -> None:
-        """MUST-DENY: full + head moved off reviewed_sha still refuses — the SHA bind is intact."""
+    def test_human_authorized_substrate_does_not_relax_sha_bind_floor(self) -> None:
+        """MUST-DENY: a human-authorized substrate clear with head moved off reviewed_sha still refuses.
+
+        The SHA-bind floor runs AFTER the substrate sign-off, so it is exercised
+        with the per-CLEAR human authoriser present (the only substrate-merge
+        path); the bind still fails closed on a moved head.
+        """
         ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
-        clear = _substrate_clear(ticket, pr_id=1735, reviewed_sha="d" * 40)
+        clear = _substrate_clear(ticket, pr_id=1735, reviewed_sha="d" * 40, human_authorizer="owner:adrien")
         with _overlay_autonomy("t3-teatree", "full"), pytest.raises(MergePreconditionError, match="head moved"):
-            _assert_preconditions(clear)
+            _assert_preconditions(clear, human_authorized="owner:adrien")
 
     def test_full_autonomy_does_not_relax_ci_green_floor(self) -> None:
         """MUST-DENY: full + non-green recorded verdict still refuses — the CI floor is intact."""
@@ -795,20 +819,18 @@ class TestFullAutonomyStandingGrantSatisfiesSubstrateSignoff(TestCase):
             precheck = _assert_preconditions(clear, human_authorized="owner:adrien")
         assert precheck is not None
 
-    def test_full_autonomy_substrate_passes_for_ticketless_clear_via_slug(self) -> None:
-        """MUST-ALLOW: a ticket-less CLEAR resolves its overlay from ``slug`` (the loop's common case)."""
+    def test_full_autonomy_substrate_is_held_for_ticketless_clear_via_slug(self) -> None:
+        """MUST-DENY: a ticket-less CLEAR whose slug resolves to the full overlay is STILL held (substrate)."""
         clear = _substrate_clear(None, pr_id=1740, slug="souliane/teatree")
-        with _overlay_autonomy("t3-teatree", "full"):
-            precheck = _assert_preconditions(clear)
-        assert precheck is not None
+        with _overlay_autonomy("t3-teatree", "full"), pytest.raises(MergePreconditionError, match="substrate"):
+            _assert_preconditions(clear)
 
-    def test_full_autonomy_substrate_passes_when_ticket_overlay_is_canonical_alias(self) -> None:
-        """MUST-ALLOW: ``ticket.overlay`` short alias resolves the entry-point-keyed override."""
+    def test_full_autonomy_substrate_is_held_when_ticket_overlay_is_canonical_alias(self) -> None:
+        """MUST-DENY: a ``ticket.overlay`` alias resolving to the full overlay is STILL held (substrate)."""
         ticket = Ticket.objects.create(overlay="teatree", state=Ticket.State.IN_REVIEW)
         clear = _substrate_clear(ticket, pr_id=1741)
-        with _overlay_autonomy("t3-teatree", "full"):
-            precheck = _assert_preconditions(clear)
-        assert precheck is not None
+        with _overlay_autonomy("t3-teatree", "full"), pytest.raises(MergePreconditionError, match="substrate"):
+            _assert_preconditions(clear)
 
     def test_babysit_autonomy_ticketless_clear_still_refused(self) -> None:
         """MUST-DENY: a ticket-less CLEAR under a below-full overlay keeps the per-PR sign-off."""
@@ -824,32 +846,23 @@ class TestFullAutonomyStandingGrantSatisfiesSubstrateSignoff(TestCase):
 
 
 class TestBranchSlugClearResolvesOverlayFromRecoveredRepo(TestCase):
-    """A branch-name-slug CLEAR resolves its overlay from the merge's recovered repo.
+    """A branch-name-slug substrate CLEAR is held under ``full`` regardless of recovered repo.
 
     The loop issues ticket-less substrate CLEARs whose stored ``slug`` is a
     *branch name* (``merge-candidate-working-repos``), not ``owner/repo``. The
-    merge keystone recovers the real ``owner/repo`` via
-    ``resolve_pr_repo_slug`` → ``_reconcile_slug_against_reviewed_sha`` and
-    threads it into ``assert_merge_preconditions`` as the ``slug`` kwarg. The
-    autonomy carve-out must resolve its overlay from that recovered slug — not
-    the raw branch-name slug, which maps to no overlay (the global babysit
-    default) and wrongly refuses a merge the overlay genuinely stands ``full``
-    for. Fail-closed is preserved: a branch-slug CLEAR whose recovered repo is
-    NOT full (or unresolvable) still requires the per-PR human authoriser.
+    merge keystone recovers the real ``owner/repo`` and threads it into
+    ``assert_merge_preconditions`` as the ``slug`` kwarg. Substrate is HELD for the
+    owner regardless of how the overlay resolves: even when the recovered repo's
+    overlay stands at ``full``, a substrate CLEAR is held (ping-and-hold), never
+    auto-merged. The recovered-repo overlay resolution still governs the NON-
+    substrate standing grant (exercised elsewhere); for substrate it is moot.
     """
 
-    def test_full_autonomy_branch_slug_passes_via_recovered_repo(self) -> None:
-        """MUST-ALLOW: branch-name slug + recovered owner/repo at full satisfies the sign-off.
-
-        RED before the fix: the carve-out resolved the overlay from the raw
-        branch-name ``slug`` (→ no overlay → babysit) and refused with
-        "the overlay autonomy is not full" despite the recovered repo's overlay
-        standing at full.
-        """
+    def test_full_autonomy_branch_slug_substrate_held_via_recovered_repo(self) -> None:
+        """MUST-DENY: a branch-name slug recovered to a full overlay's repo is STILL held (substrate)."""
         clear = _substrate_clear(None, pr_id=1750, slug="merge-candidate-working-repos")
-        with _overlay_autonomy("t3-teatree", "full"):
-            precheck = _assert_preconditions(clear, slug="souliane/teatree")
-        assert precheck is not None
+        with _overlay_autonomy("t3-teatree", "full"), pytest.raises(MergePreconditionError, match="substrate"):
+            _assert_preconditions(clear, slug="souliane/teatree")
 
     def test_full_autonomy_branch_slug_without_recovered_repo_still_refused(self) -> None:
         """MUST-DENY: a branch-name slug with no recovered owner/repo fails closed.
@@ -941,12 +954,13 @@ class TestMergeGateResolvesOverlayByRepoIdentity(TestCase):
             resolved = _resolve_clear_overlay_name(clear, resolved_slug=_OWNED_TOOLING_REPO)
         assert resolved == "t3-teatree"
 
-    def test_owned_repo_pr_is_not_human_approval_gated(self) -> None:
-        """A PR on a repo the full overlay owns is NOT human-approval-gated.
+    def test_owned_repo_substrate_pr_is_still_held(self) -> None:
+        """A SUBSTRATE PR on a repo the full overlay owns is STILL held (ping-and-hold).
 
-        The full end-to-end gate: a substrate CLEAR whose ticket carries a
-        foreign overlay token still PASSES the substrate sign-off, because the
-        repo's owning overlay stands at ``autonomy = full``.
+        Repo identity resolves to the ``full`` overlay, but substrate is held for
+        the owner regardless — the standing grant excludes substrate. (The
+        repo-identity standing grant still governs NON-substrate changes, pinned by
+        ``test_owned_repo_logic_clear_is_covered_by_standing_grant``.)
         """
         ticket = Ticket.objects.create(
             overlay="some-other-overlay",
@@ -954,66 +968,97 @@ class TestMergeGateResolvesOverlayByRepoIdentity(TestCase):
             state=Ticket.State.IN_REVIEW,
         )
         clear = _substrate_clear(ticket, pr_id=6, slug=_OWNED_TOOLING_REPO)
-        with _teatree_owns("souliane/teatree", _OWNED_TOOLING_REPO), _overlay_autonomy("t3-teatree", "full"):
-            precheck = _assert_preconditions(clear, slug=_OWNED_TOOLING_REPO)
-        assert precheck is not None
-
-    def test_foreign_repo_pr_is_human_approval_gated(self) -> None:
-        """A PR on a repo NO full overlay owns IS human-approval-gated — no over-relax.
-
-        The foreign repo is owned by no registered (full) overlay in this test
-        environment, so repo identity resolves to no full overlay and the
-        substrate sign-off stays mandatory. The anti-vacuity twin: the fix must
-        keep a foreign repo's PR gated even when a ``full`` overlay exists.
-        """
-        ticket = Ticket.objects.create(
-            overlay="some-other-overlay",
-            issue_url=f"https://gitlab.com/{_FOREIGN_REPO}/-/merge_requests/7",
-            state=Ticket.State.IN_REVIEW,
-        )
-        clear = _substrate_clear(ticket, pr_id=7, slug=_FOREIGN_REPO)
         with (
             _teatree_owns("souliane/teatree", _OWNED_TOOLING_REPO),
             _overlay_autonomy("t3-teatree", "full"),
             pytest.raises(MergePreconditionError, match="substrate"),
         ):
-            _assert_preconditions(clear, slug=_FOREIGN_REPO)
+            _assert_preconditions(clear, slug=_OWNED_TOOLING_REPO)
+
+    def test_owned_repo_logic_clear_is_covered_by_standing_grant(self) -> None:
+        """The NON-substrate standing grant resolves by repo identity (``full`` overlay owns the repo).
+
+        Tests ``_overlay_grants_standing_substrate_signoff`` directly for a LOGIC
+        clear: the repo's owning overlay (resolved from its slug) standing at
+        ``full`` covers the per-PR sign-off. (End-to-end, a logic clear never reaches
+        the substrate branch — this pins the resolution + standing-grant logic.)
+        """
+        from teatree.core.merge.authorization import _overlay_grants_standing_substrate_signoff  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(
+            overlay="some-other-overlay",
+            issue_url=f"https://github.com/{_OWNED_TOOLING_REPO}/pull/6",
+            state=Ticket.State.IN_REVIEW,
+        )
+        clear = _substrate_clear(ticket, pr_id=6, slug=_OWNED_TOOLING_REPO, blast_class=MergeClear.BlastClass.LOGIC)
+        with _teatree_owns("souliane/teatree", _OWNED_TOOLING_REPO), _overlay_autonomy("t3-teatree", "full"):
+            granted = _overlay_grants_standing_substrate_signoff(clear, resolved_slug=_OWNED_TOOLING_REPO)
+        assert granted is True
+
+    def test_foreign_repo_logic_clear_is_not_covered_by_standing_grant(self) -> None:
+        """The NON-substrate standing grant does NOT cover a repo no full overlay owns.
+
+        The anti-vacuity twin: a LOGIC clear on a foreign repo resolves to no full
+        overlay, so ``_overlay_grants_standing_substrate_signoff`` returns False.
+        """
+        from teatree.core.merge.authorization import _overlay_grants_standing_substrate_signoff  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(
+            overlay="some-other-overlay",
+            issue_url=f"https://gitlab.com/{_FOREIGN_REPO}/-/merge_requests/7",
+            state=Ticket.State.IN_REVIEW,
+        )
+        clear = _substrate_clear(ticket, pr_id=7, slug=_FOREIGN_REPO, blast_class=MergeClear.BlastClass.LOGIC)
+        with _teatree_owns("souliane/teatree", _OWNED_TOOLING_REPO), _overlay_autonomy("t3-teatree", "full"):
+            granted = _overlay_grants_standing_substrate_signoff(clear, resolved_slug=_FOREIGN_REPO)
+        assert granted is False
+
+    def test_substrate_clear_is_excluded_from_standing_grant(self) -> None:
+        """A SUBSTRATE clear is never covered by the standing grant, even on a full-owned repo (§3.2)."""
+        from teatree.core.merge.authorization import _overlay_grants_standing_substrate_signoff  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(
+            overlay="some-other-overlay",
+            issue_url=f"https://github.com/{_OWNED_TOOLING_REPO}/pull/8",
+            state=Ticket.State.IN_REVIEW,
+        )
+        clear = _substrate_clear(ticket, pr_id=8, slug=_OWNED_TOOLING_REPO)
+        with _teatree_owns("souliane/teatree", _OWNED_TOOLING_REPO), _overlay_autonomy("t3-teatree", "full"):
+            granted = _overlay_grants_standing_substrate_signoff(clear, resolved_slug=_OWNED_TOOLING_REPO)
+        assert granted is False
 
 
-class TestRequireHumanApprovalFalseStandingGrantSatisfiesSubstrateSignoff(TestCase):
+class TestRequireHumanApprovalFalseStandingGrantNonSubstrate(TestCase):
     """#2666: ``require_human_approval_to_merge = false`` is the SAME standing grant as ``autonomy = full``.
 
-    An owner who turned auto-merge ON via the canonical documented knobs —
-    ``mode = auto`` + ``require_human_approval_to_merge = false`` — but left
-    ``autonomy`` at the default ``babysit`` (never flipping the newer single
-    switch) had their OWN green, cold-reviewed substrate CLEAR refused with "the
-    overlay autonomy is not full". ``require_human_approval_to_merge = false`` IS
-    the owner's standing "no per-PR human merge approval needed" statement — the
-    same one ``autonomy = full`` makes — so the substrate sign-off must honor it.
+    The standing grant (``autonomy = full`` OR ``require_human_approval_to_merge =
+    false`` on a non-collaborative tier) removes the per-PR human sign-off for
+    NON-substrate changes — proven here with a ``logic`` CLEAR. SUBSTRATE is
+    excluded from the standing grant entirely (held for the owner, ping-and-hold),
+    pinned by ``test_require_false_substrate_is_still_held`` below.
 
     The quality/safety floor (independent cold-review, reviewed-SHA bind,
     CI-green, not-draft, maker≠checker) is never relaxed by this — only the
     per-PR human sign-off is what the standing grant removes.
     """
 
-    def test_explicit_require_false_at_babysit_satisfies_substrate_signoff(self) -> None:
-        """MUST-ALLOW: babysit + require_human_approval_to_merge=false signs off the substrate CLEAR.
+    def test_explicit_require_false_at_babysit_signs_off_non_substrate(self) -> None:
+        """MUST-ALLOW: babysit + require_human_approval_to_merge=false signs off a NON-substrate CLEAR.
 
-        RED before the fix: the standing-grant check keyed solely on
+        RED before the #2666 fix: the standing-grant check keyed solely on
         ``autonomy = full``, so an explicit ``require_human_approval_to_merge =
-        false`` at the default ``babysit`` tier was ignored and the merge was
-        refused with "the overlay autonomy is not full".
+        false`` at the default ``babysit`` tier was ignored.
         """
         ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
-        clear = _substrate_clear(ticket, pr_id=2660)
+        clear = _substrate_clear(ticket, pr_id=2660, blast_class=MergeClear.BlastClass.LOGIC)
         with _overlay_standing_signoff("t3-teatree", autonomy="babysit", require_human_approval_to_merge=False):
             precheck = _assert_preconditions(clear)
         assert precheck is not None
 
-    def test_explicit_require_false_at_babysit_merges_end_to_end(self) -> None:
-        """MUST-ALLOW end-to-end: the keystone merge advances the FSM with no per-PR sign-off."""
+    def test_explicit_require_false_at_babysit_merges_non_substrate_end_to_end(self) -> None:
+        """MUST-ALLOW end-to-end: the keystone merge advances the FSM for a NON-substrate CLEAR."""
         ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
-        clear = _substrate_clear(ticket, pr_id=2661)
+        clear = _substrate_clear(ticket, pr_id=2661, blast_class=MergeClear.BlastClass.LOGIC)
         with (
             _overlay_standing_signoff("t3-teatree", autonomy="babysit", require_human_approval_to_merge=False),
             patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_gh_stub),
@@ -1027,6 +1072,23 @@ class TestRequireHumanApprovalFalseStandingGrantSatisfiesSubstrateSignoff(TestCa
         assert result["merged"]
         assert ticket.state == Ticket.State.MERGED
         assert clear.consumed_at is not None
+
+    def test_require_false_substrate_is_still_held(self) -> None:
+        """MUST-DENY: require_human_approval_to_merge=false does NOT sign off a SUBSTRATE CLEAR.
+
+        Substrate is excluded from the standing grant entirely — even with the
+        owner's explicit ``require_human_approval_to_merge = false`` it is held for
+        the owner (ping-and-hold).
+        """
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
+        clear = _substrate_clear(ticket, pr_id=2666)
+        with (
+            _overlay_standing_signoff("t3-teatree", autonomy="babysit", require_human_approval_to_merge=False),
+            pytest.raises(MergePreconditionError, match="substrate"),
+        ):
+            _assert_preconditions(clear)
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.IN_REVIEW
 
     def test_default_require_true_at_babysit_still_refused(self) -> None:
         """MUST-DENY: babysit + require_human_approval_to_merge=true keeps the per-PR sign-off.
@@ -1076,11 +1138,16 @@ class TestRequireHumanApprovalFalseStandingGrantSatisfiesSubstrateSignoff(TestCa
             _assert_preconditions(clear)
 
     def test_require_false_does_not_relax_sha_bind_floor(self) -> None:
-        """MUST-DENY: require=false + head moved off reviewed_sha still refuses — SHA bind holds."""
+        """MUST-DENY: a human-authorized substrate clear with head moved still refuses — SHA bind holds.
+
+        The SHA-bind floor runs after the substrate sign-off, so it is exercised
+        with the per-CLEAR human authoriser present (substrate holds first
+        otherwise); the bind still fails closed on a moved head.
+        """
         ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
-        clear = _substrate_clear(ticket, pr_id=2665, reviewed_sha="d" * 40)
+        clear = _substrate_clear(ticket, pr_id=2665, reviewed_sha="d" * 40, human_authorizer="owner:adrien")
         with (
             _overlay_standing_signoff("t3-teatree", autonomy="babysit", require_human_approval_to_merge=False),
             pytest.raises(MergePreconditionError, match="head moved"),
         ):
-            _assert_preconditions(clear)
+            _assert_preconditions(clear, human_authorized="owner:adrien")

--- a/tests/teatree_eval/test_regression_corpus_predicates.py
+++ b/tests/teatree_eval/test_regression_corpus_predicates.py
@@ -48,8 +48,8 @@ class TestDbBackedPredicatesHoldOnRealCode(TestCase):
     def test_substrate_human_authorize_floor(self) -> None:
         assert predicates._check_merge_precondition_substrate_human_authorize() is True
 
-    def test_substrate_full_autonomy_carveout(self) -> None:
-        assert predicates._check_merge_precondition_substrate_full_autonomy() is True
+    def test_substrate_full_autonomy_holds(self) -> None:
+        assert predicates._check_merge_precondition_substrate_full_autonomy_holds() is True
 
     def test_maker_is_not_checker(self) -> None:
         assert predicates._check_merge_precondition_maker_is_not_checker() is True

--- a/tests/teatree_loop/test_pr_sweep_scanner.py
+++ b/tests/teatree_loop/test_pr_sweep_scanner.py
@@ -20,10 +20,11 @@ pre-conditions. These tests pin every branch of the decision ladder:
 """
 
 from dataclasses import dataclass, field, replace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from teatree.core.models import AutoReviewDispatch, MergeableNotified, Task
+from teatree.core.models import AutoReviewDispatch, BotPing, MergeableNotified, Task
 from teatree.core.models.merge_clear import ClearRequest, MergeClear
 from teatree.core.models.review_verdict import ReviewVerdict
 from teatree.loop.scanners.base import ScannerError, ScannerErrorClass
@@ -34,6 +35,7 @@ from teatree.loop.scanners.pr_sweep_adapters import (
     SlackMergeNotifier,
     _decode_pr,
 )
+from teatree.loop.substrate_pinger import NotifyWithFallbackSubstratePinger
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
@@ -145,11 +147,22 @@ class FakeKeystone:
     merged: bool = True
     merged_sha: str = MAIN_SHA
     error: str = ""
+    escalation_kind: str = ""
     calls: list[int] = field(default_factory=list)
 
-    def merge_clear(self, *, clear_id: int) -> tuple[bool, str, str]:
+    def merge_clear(self, *, clear_id: int) -> tuple[bool, str, str, str]:
         self.calls.append(clear_id)
-        return self.merged, self.merged_sha, self.error
+        return self.merged, self.merged_sha, self.error, self.escalation_kind
+
+
+@dataclass(slots=True)
+class FakeSubstratePinger:
+    """Mock ``SubstratePinger`` — records every (text, idempotency_key) ping."""
+
+    calls: list[tuple[str, str]] = field(default_factory=list)
+
+    def ping(self, *, text: str, idempotency_key: str) -> None:
+        self.calls.append((text, idempotency_key))
 
 
 @dataclass(slots=True)
@@ -175,6 +188,7 @@ def _scanner(  # noqa: PLR0913 — test helper: each kwarg maps 1:1 to a PrSweep
     auto_review_dispatch: bool = False,
     dispatcher: FakeReviewDispatcher | None = None,
     self_identities: tuple[str, ...] = (SELF_LOGIN,),
+    substrate_pinger: FakeSubstratePinger | None = None,
 ) -> tuple[PrSweepScanner, NullMergeNotifier]:
     notifier = notifier or NullMergeNotifier()
     return (
@@ -188,6 +202,7 @@ def _scanner(  # noqa: PLR0913 — test helper: each kwarg maps 1:1 to a PrSweep
             auto_review_dispatch=auto_review_dispatch,
             review_dispatcher=dispatcher,
             self_identities=self_identities,
+            substrate_pinger=substrate_pinger,
         ),
         notifier,
     )
@@ -1288,13 +1303,13 @@ class TestErrorIsolation:
         class _BoomFirstKeystone:
             calls: list[int] = field(default_factory=list)
 
-            def merge_clear(self, *, clear_id: int) -> tuple[bool, str, str]:
+            def merge_clear(self, *, clear_id: int) -> tuple[bool, str, str, str]:
                 self.calls.append(clear_id)
                 if not self.calls or (self.calls == [clear_id] and len(self.calls) == 1):
                     # First call: inject a fault to simulate a merge conflict / DB error
                     msg = "simulated keystone failure"
                     raise RuntimeError(msg)
-                return True, MAIN_SHA, ""  # pragma: no cover
+                return True, MAIN_SHA, "", ""  # pragma: no cover
 
         # Issue a CLEAR for both PRs so _evaluate reaches _merge for each.
         _issue_clear(pr_id=6230)
@@ -1315,7 +1330,7 @@ class TestErrorIsolation:
 
         @dataclass(slots=True)
         class _AuthErrorKeystone:
-            def merge_clear(self, *, clear_id: int) -> tuple[bool, str, str]:
+            def merge_clear(self, *, clear_id: int) -> tuple[bool, str, str, str]:
                 raise ScannerError(
                     scanner="pr_sweep",
                     error_class=ScannerErrorClass.AUTH,
@@ -1411,3 +1426,76 @@ class TestEvaluateOne:
         assert attempt.merged is False
         assert attempt.decision == "flag_no_review"
         assert api.merge_pr_calls == []
+
+
+class TestSubstrateHoldPing:
+    """A HELD substrate merge pings the owner ONCE per diff (ping-and-hold, #3.1)."""
+
+    def test_substrate_hold_pings_once_with_per_diff_key(self) -> None:
+        # The anti-vacuity test (a): a substrate refusal from the keystone fires
+        # exactly one notify ping with the per-diff idempotency key. Before the
+        # fix the held substrate clear was swallowed silently with no ping.
+        clear = _issue_clear()
+        api = FakePrApiClient(prs_by_slug={SLUG: [_open_pr()]})
+        keystone = FakeKeystone(merged=False, error="held: substrate change", escalation_kind="substrate")
+        pinger = FakeSubstratePinger()
+        scanner, _ = _scanner(api=api, keystone=keystone, substrate_pinger=pinger)
+
+        signals = scanner.scan()
+
+        assert signals[0].payload["decision"] == "blocked"
+        assert len(pinger.calls) == 1
+        text, key = pinger.calls[0]
+        assert key == f"substrate-hold:{SLUG}#6230:{clear.reviewed_sha}"
+        assert f"{SLUG}#6230" in text
+
+    def test_non_substrate_block_does_not_ping(self) -> None:
+        # The anti-vacuity twin (b-adjacent): a NON-substrate keystone refusal
+        # never pings — the loop pings ONLY on substrate.
+        _issue_clear()
+        api = FakePrApiClient(prs_by_slug={SLUG: [_open_pr()]})
+        keystone = FakeKeystone(merged=False, error="some other refusal", escalation_kind="")
+        pinger = FakeSubstratePinger()
+        scanner, _ = _scanner(api=api, keystone=keystone, substrate_pinger=pinger)
+
+        scanner.scan()
+
+        assert pinger.calls == []
+
+    def test_substrate_hold_without_pinger_does_not_crash(self) -> None:
+        _issue_clear()
+        api = FakePrApiClient(prs_by_slug={SLUG: [_open_pr()]})
+        keystone = FakeKeystone(merged=False, error="held", escalation_kind="substrate")
+        scanner, _ = _scanner(api=api, keystone=keystone, substrate_pinger=None)
+
+        signals = scanner.scan()
+
+        assert signals[0].payload["decision"] == "blocked"
+
+    def test_re_tick_does_not_double_ping_real_notify_dedupe(self) -> None:
+        # The anti-vacuity test (d): re-running the sweep on the SAME held head
+        # does not double-ping. Uses the REAL NotifyWithFallbackSubstratePinger so
+        # the BotPing idempotency ledger genuinely dedupes across two ticks; only
+        # the unstoppable Slack HTTP boundary is faked.
+        clear = _issue_clear()
+        api = FakePrApiClient(prs_by_slug={SLUG: [_open_pr()]})
+        keystone = FakeKeystone(merged=False, error="held: substrate", escalation_kind="substrate")
+        scanner, _ = _scanner(api=api, keystone=keystone, substrate_pinger=NotifyWithFallbackSubstratePinger())
+
+        backend = MagicMock()
+        backend.open_dm.return_value = "D-USER"
+        backend.post_message.return_value = {"ok": True, "ts": "1700000000.000100"}
+        backend.get_permalink.return_value = "https://x.slack.com/p1"
+        backend.fetch_message.return_value = {"ts": "1700000000.000100", "text": "held"}
+
+        with (
+            patch("teatree.core.notify.messaging_from_overlay", return_value=backend),
+            patch("teatree.core.notify.resolve_user_id", return_value="U_ME"),
+        ):
+            scanner.scan()
+            scanner.scan()
+
+        key = f"substrate-hold:{SLUG}#6230:{clear.reviewed_sha}"
+        assert BotPing.objects.filter(idempotency_key=key, status=BotPing.Status.SENT).count() == 1
+        # Exactly one Slack post landed despite two ticks — the ledger deduped.
+        assert backend.post_message.call_count == 1

--- a/tests/teatree_loop/test_pr_sweep_scanner.py
+++ b/tests/teatree_loop/test_pr_sweep_scanner.py
@@ -41,6 +41,24 @@ from teatree.loop.substrate_pinger import NotifyWithFallbackSubstratePinger
 pytestmark = pytest.mark.django_db
 
 
+@pytest.fixture(autouse=True)
+def _non_substrate_changed_paths():
+    """Default the solo-overlay substrate gate to a non-substrate diff.
+
+    The solo-overlay no-CLEAR bypass classifies the PR's changed paths live
+    (Finding 2). With no real PR behind the fake ``gh``, an unmocked fetch
+    returns ``[]`` and the FAIL-SAFE gate holds — so every existing
+    merge-path test would now hold. Default the fetch to a known
+    non-substrate path; the substrate / fail-safe cases override it with
+    their own ``with patch(...)``.
+    """
+    with patch(
+        "teatree.loop.scanners.pr_sweep_substrate.fetch_pr_changed_paths",
+        return_value=["src/teatree/loop/scanners/pr_sweep.py"],
+    ):
+        yield
+
+
 SLUG = "souliane/teatree"
 HEAD = "feedfacecafebabe1234567890abcdef12345678"
 STALE = "deadbeef00000000000000000000000000000000"
@@ -74,6 +92,19 @@ def _issue_clear(*, pr_id: int = 6230, sha: str = HEAD) -> MergeClear:
             reviewer_identity="cold-reviewer",
             gh_verify_result="green",
             blast_class="logic",
+        )
+    )
+
+
+def _issue_substrate_clear(*, pr_id: int = 6230, sha: str = HEAD) -> MergeClear:
+    return MergeClear.issue(
+        ClearRequest(
+            pr_id=pr_id,
+            slug=SLUG,
+            reviewed_sha=sha,
+            reviewer_identity="cold-reviewer",
+            gh_verify_result="green",
+            blast_class="substrate",
         )
     )
 
@@ -1472,6 +1503,53 @@ class TestSubstrateHoldPing:
 
         assert signals[0].payload["decision"] == "blocked"
 
+    def test_substrate_clear_in_uv_audit_fallback_holds_and_pings_no_raw_merge(self) -> None:
+        # Finding 1 (fail-open): a SUBSTRATE CLEAR whose only red check is uv-audit
+        # (and main is also uv-audit-red) lands on the keystone fallback path. When
+        # the keystone refuses (substrate hold), the legacy code raw-merged via
+        # ``merge_pr_squash_bound`` BEFORE the substrate-ping check — silently
+        # bypassing the hold. The fix gates the raw-merge on the CLEAR not being
+        # substrate, so a substrate PR HOLDS + pings instead.
+        clear = _issue_substrate_clear()
+        api = FakePrApiClient(
+            prs_by_slug={SLUG: [_open_pr(checks=(_green_required(), _red_uv_audit()))]},
+            main_uv_audit_red=True,
+            fallback_succeeds=True,
+        )
+        keystone = FakeKeystone(merged=False, error="held: substrate change", escalation_kind="substrate")
+        pinger = FakeSubstratePinger()
+        scanner, notifier = _scanner(api=api, keystone=keystone, substrate_pinger=pinger)
+
+        signals = scanner.scan()
+
+        assert api.merge_pr_calls == []  # the raw gh fallback was NOT fired for substrate
+        assert notifier.calls == []  # no merge announcement
+        assert signals[0].payload["decision"] == "blocked"
+        assert len(pinger.calls) == 1
+        _, key = pinger.calls[0]
+        assert key == f"substrate-hold:{SLUG}#6230:{clear.reviewed_sha}"
+
+    def test_non_substrate_uv_audit_fallback_still_raw_merges_on_keystone_refusal(self) -> None:
+        # Anti-vacuity twin: the NON-substrate uv-audit fallback escalation is
+        # unchanged — a logic-class CLEAR whose keystone refuses still raw-merges
+        # via gh and never pings. Guards against over-gating Finding 1.
+        _issue_clear()
+        api = FakePrApiClient(
+            prs_by_slug={SLUG: [_open_pr(checks=(_green_required(), _red_uv_audit()))]},
+            main_uv_audit_red=True,
+            fallback_succeeds=True,
+        )
+        keystone = FakeKeystone(merged=False, error="uv-audit failing", escalation_kind="")
+        pinger = FakeSubstratePinger()
+        scanner, notifier = _scanner(api=api, keystone=keystone, substrate_pinger=pinger)
+
+        signals = scanner.scan()
+
+        assert api.merge_pr_calls == [(SLUG, 6230, HEAD)]  # non-substrate still escalates
+        assert notifier.calls == [(SLUG, 6230, MAIN_SHA, True)]
+        assert signals[0].payload["reason"] == "fallback_uv_audit_gh"
+        assert pinger.calls == []
+
     def test_re_tick_does_not_double_ping_real_notify_dedupe(self) -> None:
         # The anti-vacuity test (d): re-running the sweep on the SAME held head
         # does not double-ping. Uses the REAL NotifyWithFallbackSubstratePinger so
@@ -1499,3 +1577,96 @@ class TestSubstrateHoldPing:
         assert BotPing.objects.filter(idempotency_key=key, status=BotPing.Status.SENT).count() == 1
         # Exactly one Slack post landed despite two ticks — the ledger deduped.
         assert backend.post_message.call_count == 1
+
+
+class TestSoloOverlaySubstrateHold:
+    """Finding 2 (fail-open): the solo-overlay no-CLEAR bypass must hold substrate.
+
+    The bypass raw-merges a green+clean+cold-reviewed own PR via
+    ``merge_pr_squash_bound`` when no CLEAR exists — with ZERO substrate gating.
+    A substrate PR on a solo overlay (cold-review, no CLEAR) would therefore
+    auto-merge with no hold and no ping, bypassing the keystone substrate
+    guarantee. The fix classifies the PR's changed paths before the direct
+    merge; a substrate diff (or an unfetchable one — fail-safe) HOLDS + pings
+    instead of merging.
+    """
+
+    def test_solo_overlay_substrate_pr_holds_and_pings_no_raw_merge(self) -> None:
+        # Cold-review recorded, no CLEAR, CI green — the bypass would merge — but
+        # the diff touches a substrate path, so it HOLDS + pings instead.
+        _record_cold_review()
+        api = FakePrApiClient(prs_by_slug={SLUG: [_open_pr()]})
+        keystone = FakeKeystone()
+        pinger = FakeSubstratePinger()
+        scanner, notifier = _scanner(api=api, keystone=keystone, solo_overlay=True, substrate_pinger=pinger)
+
+        with patch(
+            "teatree.loop.scanners.pr_sweep_substrate.fetch_pr_changed_paths",
+            return_value=["src/teatree/core/merge/authorization.py"],
+        ):
+            signals = scanner.scan()
+
+        assert api.merge_pr_calls == []  # the raw gh merge was NOT fired for substrate
+        assert notifier.calls == []  # no merge announcement
+        assert signals[0].payload["decision"] == "blocked"
+        assert len(pinger.calls) == 1
+        _, key = pinger.calls[0]
+        assert key == f"substrate-hold:{SLUG}#6230:{HEAD}"
+
+    def test_solo_overlay_non_substrate_pr_still_merges_via_gh_fallback(self) -> None:
+        # Anti-vacuity twin: a NON-substrate diff on the solo overlay still merges
+        # via the direct gh fallback. Guards against over-gating Finding 2.
+        _record_cold_review()
+        api = FakePrApiClient(prs_by_slug={SLUG: [_open_pr()]})
+        keystone = FakeKeystone()
+        pinger = FakeSubstratePinger()
+        scanner, notifier = _scanner(api=api, keystone=keystone, solo_overlay=True, substrate_pinger=pinger)
+
+        with patch(
+            "teatree.loop.scanners.pr_sweep_substrate.fetch_pr_changed_paths",
+            return_value=["src/teatree/loop/scanners/pr_sweep.py"],
+        ):
+            signals = scanner.scan()
+
+        assert api.merge_pr_calls == [(SLUG, 6230, HEAD)]  # non-substrate still merges
+        assert notifier.calls == [(SLUG, 6230, MAIN_SHA, False)]
+        assert pinger.calls == []
+        assert signals[0].payload["reason"] == "solo_overlay_no_clear"
+
+    def test_solo_overlay_unfetchable_paths_fail_safe_holds(self) -> None:
+        # FAIL-SAFE: a real PR always changes >=1 file, so an empty changed-paths
+        # list signals the forge fetch failed. The bypass must treat the can't-tell
+        # case conservatively — HOLD + ping, never widen to a silent merge.
+        _record_cold_review()
+        api = FakePrApiClient(prs_by_slug={SLUG: [_open_pr()]})
+        keystone = FakeKeystone()
+        pinger = FakeSubstratePinger()
+        scanner, notifier = _scanner(api=api, keystone=keystone, solo_overlay=True, substrate_pinger=pinger)
+
+        with patch("teatree.loop.scanners.pr_sweep_substrate.fetch_pr_changed_paths", return_value=[]):
+            signals = scanner.scan()
+
+        assert api.merge_pr_calls == []  # the can't-tell case held, did not merge
+        assert notifier.calls == []
+        assert signals[0].payload["decision"] == "blocked"
+        assert len(pinger.calls) == 1
+
+    def test_solo_overlay_paths_fetch_raises_fail_safe_holds(self) -> None:
+        # FAIL-SAFE: a forge exception during the changed-paths fetch must also hold,
+        # never crash the sweep into the silent-merge branch.
+        _record_cold_review()
+        api = FakePrApiClient(prs_by_slug={SLUG: [_open_pr()]})
+        keystone = FakeKeystone()
+        pinger = FakeSubstratePinger()
+        scanner, notifier = _scanner(api=api, keystone=keystone, solo_overlay=True, substrate_pinger=pinger)
+
+        with patch(
+            "teatree.loop.scanners.pr_sweep_substrate.fetch_pr_changed_paths",
+            side_effect=RuntimeError("forge down"),
+        ):
+            signals = scanner.scan()
+
+        assert api.merge_pr_calls == []
+        assert notifier.calls == []
+        assert signals[0].payload["decision"] == "blocked"
+        assert len(pinger.calls) == 1

--- a/tests/teatree_loop/test_scanner_error_signals.py
+++ b/tests/teatree_loop/test_scanner_error_signals.py
@@ -138,9 +138,9 @@ class TestPrSweepScannerPropagatesError:
                 return False, ""
 
         class _NullKeystone:
-            def merge_clear(self, *, clear_id: int) -> tuple[bool, str, str]:
+            def merge_clear(self, *, clear_id: int) -> tuple[bool, str, str, str]:
                 _ = clear_id
-                return False, "", ""
+                return False, "", "", ""
 
         scanner = PrSweepScanner(
             repos=("owner/repo",),


### PR DESCRIPTION
## Substrate pings the owner and holds under autonomy=full

Under maximal merge-autonomy (`autonomy = full`), non-substrate PRs continue to
auto-merge, but a **substrate** PR (the merge keystone, an architecture spec, a
governance doc) must **ping the owner and hold** for their per-PR sign-off
instead of self-merging silently. Reuses the existing notifier — no new model,
notifier, or autonomy tier. Closes [souliane/teatree#1748](https://github.com/souliane/teatree/issues/1748).

### What changes

**1 — Substrate hold pings the owner (loop edge).** The `pr_sweep` substrate
path wires the held substrate clear to the existing `notify_with_fallback` at the
loop edge, pinging the owner **once per held diff** with the per-diff idempotency
key `substrate-hold:slug#pr:sha` (the `BotPing` ledger dedupes a re-tick). An
`escalation_kind` field is threaded through the keystone result
(`MergeKeystoneResult` / `escalated_merge_result`, populated from
`clear.is_substrate()`) so the loop pings **only** on substrate.
`merge/authorization.py` stays import-clean of notify/messaging.

**2 — Substrate excluded from the standing sign-off grant.**
`_overlay_grants_standing_substrate_signoff` returns `False` for any substrate
clear, so a substrate clear under `autonomy = full` raises the same
`MergePreconditionError` (routed to the ping above) instead of auto-merging.
Non-substrate self-merge is unchanged.

**3 — Path-based substrate classifier.** `diff_paths_are_substrate`:
`is_substrate()` returns true regardless of the reviewer's blast-class label when
the changed paths touch `BLUEPRINT.md`, governance docs, or
`src/teatree/core/merge/`. The merge gate attaches the live PR diff paths (new
`fetch_pr_changed_paths` on both forge backends) to a non-persisted
`touched_paths` attribute — no migration. This makes the guarantee reliable
rather than dependent on a human passing `--blast-class substrate`.

The cold-review floor and every existing merge gate (reviewer != maker, SHA-bind,
CI-green, not-draft, never-lockout, privacy scan) are untouched.

### Regression eval (anti-vacuous)

The regression corpus predicate that asserted the **old** carve-out (a substrate
clear auto-clears without a per-PR human sign-off under `autonomy = full`) is
inverted to pin the **new** contract: under `autonomy = full` a substrate clear
is **held**. Renamed `_check_merge_precondition_substrate_full_autonomy` →
`_check_merge_precondition_substrate_full_autonomy_holds` across the corpus
registration, the predicate impl + `__all__`, and the predicate test, flipping
`expect_cleared_without_human` to `False`. The predicate drives the real
`_assert_clear_authorized` guard; neutralizing the substrate exclusion turns it
red (verified locally), so it guards the fix rather than passing vacuously.

### Verification (locally observed)

- `uv run pytest tests/teatree_core tests/teatree_loop tests/teatree_backends tests/teatree_eval -q` — **8535 passed, 13 skipped, 57 subtests passed**
- `uv run ruff check` on the changed files — all checks passed
- `uv run ty check` on the changed src modules — all checks passed
- `uv run python manage.py makemigrations --check --dry-run` — no changes detected (migration-free)

## Architecture pre-check — substrate ping-and-hold

### 1. BLUEPRINT § alignment
§17.4 Orchestrator-decides / loop-executes merge keystone — the substrate hold is
a merge-precondition decision surfaced to the loop edge as a ping, keeping the
keystone the single merge-authorization contract.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition is added or moved. The
change is entirely within the merge-authorization precondition and the loop's
`pr_sweep` scanner edge.

### 3. Extension-point contracts
Adds `fetch_pr_changed_paths` to the `CodeHostBackend` Protocol
(`core/backend_protocols.py`) and implements it on both forge hosts
(`backends/github/client.py`, `backends/gitlab/client.py`) plus the shared
`forge_merge_rpc.py`. Protocol-coverage fixtures
(`tests/teatree_backends/test_code_host_protocol_coverage.py`,
`test_protocols.py`) are updated so the `runtime_checkable` membership +
signature fitness tests pin the new method on both forges.

### 4. Component boundaries
- merge-authorization policy → `core/merge/authorization.py` (substrate exclusion)
- substrate classification → `core/models/merge_clear.py` (`is_substrate` /
  `diff_paths_are_substrate`, non-persisted `touched_paths`)
- loop-edge ping → `loop/scanners/pr_sweep_substrate.py` + `loop/substrate_pinger.py`
- forge diff-path fetch → `backends/` (Protocol implementations only)

`authorization.py` stays import-clean of notify/messaging — the ping lives at the
loop edge, not in the precondition gate.

### 5. Dependency direction
No backwards edge. The notify wiring lives in `loop/` (higher level), which is
allowed to import `core/`; `core/merge/` does not import `loop/` or messaging.
The forge `fetch_pr_changed_paths` additions are within `backends/`.

### 6. Test surface
- substrate held under full autonomy → `_check_merge_precondition_substrate_full_autonomy_holds` predicate + `test_substrate_full_autonomy_holds` (red when the exclusion is neutralized)
- path-based classification →
  `tests/teatree_core/models/test_merge_clear_substrate_paths.py`
- human-authorize floor + full-autonomy hold →
  `tests/teatree_core/test_clear_issuance_and_human_substrate.py`
- loop-edge ping (once per diff, idempotency key) →
  `tests/teatree_loop/test_pr_sweep_scanner.py`,
  `tests/teatree_loop/test_scanner_error_signals.py`
- Protocol coverage for `fetch_pr_changed_paths` →
  `tests/teatree_backends/test_code_host_protocol_coverage.py`,
  `test_protocols.py`

### 7. Resilience invariants
The single external write is the owner ping. It is **idempotent** (per-diff
idempotency key `substrate-hold:slug#pr:sha`, deduped by the `BotPing` ledger on
re-tick) and uses the existing `notify_with_fallback` **fallback transport**. The
hold is the conservative branch: when the substrate signal is present the clear
is held and pinged, never auto-merged — the merge never silently proceeds.

### 8. Identity and key normalization
The idempotency key is the fully-qualified `slug#pr:sha` triple (owner/repo plus
PR id plus reviewed sha), not a bare PR number, so two diffs on the same PR at
different shas ping distinctly and a re-tick at the same sha dedupes.

### 9. Behavior preservation / capability deletion
The prior `autonomy = full` carve-out (substrate auto-merges) is intentionally
**removed** — that is the whole point of the ping-and-hold directive. Substrate is
now excluded from the standing grant entirely, so a mislabeled or genuine
substrate change can never auto-merge silently under full autonomy. Non-substrate
self-merge behavior is preserved unchanged. The must-block human-authorize floor
for a below-full overlay is preserved. The regression eval that pinned the old
carve-out is inverted (not deleted) to pin the new contract.
