### PR TITLE
refactor(config): remove two provably-dead settings (#2731)

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,7 +562,6 @@ live in `UserSettings` in `src/teatree/config.py`.
 ```toml
 [teatree]
 workspace_dir = "~/workspace"            # where ticket workspaces are created
-branch_prefix = "dev"                     # prefix for worktree branches
 mode = "interactive"                      # "interactive" (default) | "auto"
 privacy = ""                              # privacy-scan profile name
 contribute = false                        # enable skill self-improvement
@@ -582,7 +581,6 @@ path = "~/workspace/my-overlay"
 | Key | Default | Effect |
 |-----|---------|--------|
 | `workspace_dir` | `~/workspace` | Root for per-ticket workspace directories |
-| `branch_prefix` | `""` | Prefix prepended to worktree branch names |
 | `mode` | `interactive` | `interactive` confirms before publishing; `auto` is end-to-end |
 | `privacy` | `""` | Named privacy-scan profile applied before pushes |
 | `contribute` | `false` | Allow `t3:retro` to write fixes into core skills |
@@ -622,7 +620,7 @@ to a less-safe mode.
 A subset of `[teatree]` keys can be **overridden per-overlay** in
 `[overlays.<name>]`. The overridable set lives in
 `OVERLAY_OVERRIDABLE_SETTINGS` in `src/teatree/config.py`: `mode`,
-`branch_prefix`, `privacy`, `contribute`, `excluded_skills`,
+`privacy`, `contribute`, `excluded_skills`,
 `loop_cadence_seconds`, `require_human_approval_to_merge`, and
 `require_human_approval_to_answer`. For example, run `auto` mode on a personal
 dogfooding overlay while keeping `interactive` on a client project:

--- a/docs/blueprint/configuration.md
+++ b/docs/blueprint/configuration.md
@@ -130,9 +130,8 @@ the DB is unreachable — `check_updates`, and `statusline_chain` — read
 straight from `~/.teatree.toml` by the **bash** statusline hook, which has no path
 to the DB), path/infra bootstrap (`workspace_dir`, `worktrees_dir`,
 `timezone`, `privacy`), and the nested structured `mr_reminder`
-table. The two DERIVED fields (`notify_on_behalf`, `ask_before_post_on_behalf`) are
-computed by the resolver and have no home. The resolution-tier wiring below details
-each home's chain.
+table. The one DERIVED field (`notify_on_behalf`) is computed by the resolver and
+has no home. The resolution-tier wiring below details each home's chain.
 
 The resolution chain is **per home** (first match wins) — each field reads from
 exactly the tiers its home allows:
@@ -253,14 +252,12 @@ below mirrors it; consult the dataclass for type signatures and defaults.
 | `mode` | `auto` for a personal dogfooding overlay, `interactive` for a client overlay |
 | `autonomy` | Single trust switch, tiers `full > notify > babysit` (default `babysit`). Both autonomous tiers collapse the three approval gates (colleague auto-approve via `on_behalf_post_mode`, auto-merge, auto-answer) and pin `mode = auto`; `full` enables the single-author `solo_overlay` merge bypass, `notify` derives `notify_on_behalf = true` and keeps the colleague-approval CLEAR merge path. An explicit per-gate value wins, and a global `mode` does not defeat the `mode = auto` pin (a per-overlay one does). Set without hand-editing TOML via `t3 <overlay> autonomy set <tier>` (`--overlay <name>` / `--global`); `t3 <overlay> autonomy show` reports the effective tier. Safety floor untouched |
 | `speed` | Throughput dial `slow < medium < full < boost` (default `medium`): how many threads run at once, orthogonal to `mode`/`autonomy`. `t3 <overlay> speed set`; `T3_SPEED` env. |
-| `branch_prefix` | Different prefix conventions per project |
 | `privacy` | Stricter for client code, looser for personal |
 | `contribute` | Contribute to one overlay's skills but not another |
 | `excluded_skills` | Project-specific skill exclusions |
 | `loop_cadence_seconds` | Per-overlay tick cadence (e.g. tighter on a hot overlay, looser on a maintenance one) |
 | `require_human_approval_to_merge` | Training-wheel: auto-mode overlay can publish autonomously, merge stays gated |
 | `require_human_approval_to_answer` | Training-wheel for `t3:answerer`: drafts + DMs, posts only on confirm |
-| `ask_before_post_on_behalf` | Legacy boolean pre-gate over on-behalf posts (kept for back-compat — prefer `on_behalf_post_mode`) |
 | `on_behalf_post_mode` | Tri-state pre-gate (#960) over colleague-VISIBLE posts: `draft_or_ask` / `ask` / `immediate`, scoped per overlay so a client overlay can stay `ask` while a personal one runs `immediate`. Drafts (`post-draft-note`) are colleague-invisible and exempt under every mode — they never need approval |
 | `missing_issue_ref_policy` | What to do when a commit/MR needs an issue ref and none is in hand: `find_existing_then_ask` (default) / `create` / `dummy`. Scoped per overlay so a colleague-facing client overlay stays on the never-create default while a personal one can opt into `create`. The default always recovers the original existing issue first, then ASKs on a colleague-facing repo and CREATEs on the user's own repo — never a dummy. `create` / `dummy` are opt-in and authorise auto-create / a placeholder ref on colleague repos too. Resolved by `teatree.missing_issue_policy.resolve_missing_issue_verdict`; `T3_MISSING_ISSUE_POLICY` env wins; agent prose in `skills/ship/SKILL.md` § 0a |
 | `on_behalf_auto_actions` | Allowlist of on-behalf actions that PROCEED even under `ask`/`draft_or_ask` (default `["post_e2e_evidence"]`): the user's own-ticket self-documentation, not a colleague-facing voice, so they never need per-post approval. Clear to `[]` to re-gate test plan; env `T3_ON_BEHALF_AUTO_ACTIONS` (comma-separated) wins |
@@ -370,14 +367,13 @@ is a one-line registry change picked up via `dataclasses.replace`; `speak` is
 the one non-generic override (its overlay sub-table merges onto the base
 rather than flat-replacing).
 
-`mode`, `branch_prefix`, and `autonomy` are DB-home (#1775) — they live in the
+`mode` and `autonomy` are DB-home (#1775) — they live in the
 `ConfigSetting` store, NOT in `~/.teatree.toml`. A value for one of them left in
 `[teatree]` / `[overlays.<name>]` is IGNORED on read (the resolver warns and drops
 it). Set them in the store, globally or scoped to one overlay with `--overlay`:
 
 ```bash
 t3 <overlay> config_setting set mode interactive                      # global default
-t3 <overlay> config_setting set branch_prefix ac
 t3 <overlay> config_setting set autonomy full --overlay t3-teatree    # single-author dogfooding: one switch collapses the gates + pins mode = auto
 t3 <overlay> config_setting set autonomy notify --overlay t3-client   # collaborative: autonomous + DM per on-behalf action, keeps CLEAR merge gate
 t3 <overlay> config_setting set mode interactive --overlay client-project   # stay gated on client code (autonomy defaults to babysit)

--- a/docs/blueprint/loop-topology.md
+++ b/docs/blueprint/loop-topology.md
@@ -155,7 +155,7 @@ approval:
 - `ask` — every colleague-VISIBLE action requires an explicit recorded approval before publishing; a draft is exempt and auto-publishes (+ DMs the user) without approval.
 - `draft_or_ask` (the new default) — identical to `ask`: `t3 review post-draft-note` publishes autonomously (drafts are colleague-invisible and revocable, and the agent DMs the user with the publish/delete commands); every colleague-visible action BLOCKs until the user records an approval.
 
-The legacy boolean `ask_before_post_on_behalf = true/false` keeps working through one deprecation release (true → `ask`, false → `immediate`). The setting is resolved through the env (`T3_ON_BEHALF_POST_MODE`) → active-overlay → global → default chain (`teatree.on_behalf_gate.resolve_on_behalf_verdict`); it is the *pre*-gate companion to the notify-*after* path (#949). Both ship on; the user flips this one off per-overlay first.
+The legacy boolean `ask_before_post_on_behalf` is retired (souliane/teatree#2731): its `UserSettings` field is gone and a leftover `[teatree]` / `[overlays.<name>]` key is ignored on read (`load_config` warns). Set the successor `on_behalf_post_mode` (DB-home) instead. The setting is resolved through the env (`T3_ON_BEHALF_POST_MODE`) → active-overlay → global → default chain (`teatree.on_behalf_gate.resolve_on_behalf_verdict`); it is the *pre*-gate companion to the notify-*after* path (#949). Both ship on; the user flips this one off per-overlay first.
 
 The gate is **enforced uniformly** at the chokepoints that cover every on-behalf publish path:
 

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1015,7 +1015,7 @@ Usage: t3 review delete-discussion [OPTIONS] REPO MR NOTE_ID
  Use to clean up a published general comment that should have
  been inline, or any other published note that needs removal.
  Distinct from `delete-draft-note`, which removes a user's own
- pre-publication draft. Respects the `ask_before_post_on_behalf`
+ pre-publication draft. Respects the `on_behalf_post_mode`
  pre-gate (souliane/teatree#960).
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮

--- a/src/teatree/cli/review/drafts.py
+++ b/src/teatree/cli/review/drafts.py
@@ -94,7 +94,7 @@ def _delete_discussion(
     Use to clean up a published general comment that should have
     been inline, or any other published note that needs removal.
     Distinct from `delete-draft-note`, which removes a user's own
-    pre-publication draft. Respects the `ask_before_post_on_behalf`
+    pre-publication draft. Respects the `on_behalf_post_mode`
     pre-gate (souliane/teatree#960).
     """
     from teatree.cli.review.commands import _require_token  # noqa: PLC0415

--- a/src/teatree/cli/review/service.py
+++ b/src/teatree/cli/review/service.py
@@ -453,7 +453,7 @@ class ReviewService:
         own unpublished draft — that is not a colleague-visible mutation
         and stays ungated; this one is.
 
-        Gated by ``ask_before_post_on_behalf`` (#960): the call is refused
+        Gated by ``on_behalf_post_mode`` (#960): the call is refused
         without any GitLab side effect when the gate is on and no recorded
         :class:`OnBehalfApproval` matches ``(<repo>!<mr>, "delete_discussion")``.
         """
@@ -525,7 +525,7 @@ class ReviewService:
         the approve-on-review doctrine: an approval cannot be recorded
         without a prior reviewing footprint from the same identity.
 
-        Gated by ``ask_before_post_on_behalf`` (#960/#1013): an approval is
+        Gated by ``on_behalf_post_mode`` (#960/#1013): an approval is
         an outward post on the user's identity, so it routes through the
         same recorded-approval gate every other on-behalf method uses. Gate
         ON + no recorded :class:`OnBehalfApproval` matching
@@ -556,7 +556,7 @@ class ReviewService:
         No review-first precondition — removing an approval is the safe
         direction and must always be reachable.
 
-        Gated by ``ask_before_post_on_behalf`` (#960/#1013): an unapproval
+        Gated by ``on_behalf_post_mode`` (#960/#1013): an unapproval
         is still a colleague-visible post on the user's identity, so it
         routes through the same recorded-approval gate as ``approve`` (and
         every other on-behalf method). The recorded row scopes to

--- a/src/teatree/config/homes.py
+++ b/src/teatree/config/homes.py
@@ -26,10 +26,9 @@ from the ``ConfigSetting`` store + env, never from a ``[teatree]`` /
 ``[overlays.<name>]`` TOML value (which is ignored on read and the resolver warns
 on).
 
-:data:`DERIVED_FIELDS` are the two values the resolver COMPUTES rather than
-reads (``notify_on_behalf`` derived by the autonomy collapse,
-``ask_before_post_on_behalf`` derived from ``on_behalf_post_mode``); they have
-no home and are excluded from the partition.
+:data:`DERIVED_FIELDS` is the one value the resolver COMPUTES rather than
+reads (``notify_on_behalf`` derived by the autonomy collapse); it has
+no home and is excluded from the partition.
 
 The fitness functions in ``tests/config/test_settings_home_partition.py`` keep
 this exhaustive and disjoint: every ``UserSettings`` field is in exactly one of
@@ -46,10 +45,9 @@ class SettingHome(StrEnum):
     TOML = "toml"
 
 
-# The two values the resolver computes rather than reads — no home, excluded
-# from the partition. ``notify_on_behalf`` is ORed in by the autonomy collapse;
-# ``ask_before_post_on_behalf`` is derived from the resolved ``on_behalf_post_mode``.
-DERIVED_FIELDS: frozenset[str] = frozenset({"notify_on_behalf", "ask_before_post_on_behalf"})
+# The one value the resolver computes rather than reads — no home, excluded
+# from the partition. ``notify_on_behalf`` is ORed in by the autonomy collapse.
+DERIVED_FIELDS: frozenset[str] = frozenset({"notify_on_behalf"})
 
 # The irreducible TOML-home carve-out (exactly these ten):
 # - non-Django / pre-Django readers (read via tomllib or a bash grep, no DB):

--- a/src/teatree/config/loader.py
+++ b/src/teatree/config/loader.py
@@ -130,6 +130,40 @@ def _db_home_keys_in(toml_table: dict[str, Any]) -> list[str]:
     return [key for key in toml_table if SETTING_HOMES.get(key) is SettingHome.DB]
 
 
+# Settings whose ``UserSettings`` field was removed (souliane/teatree#2731). A
+# stored ``[teatree]`` / ``[overlays.<name>]`` value for one of these resolves to
+# nothing — the key no longer maps to any field — so a leftover entry is warned
+# about (never silently no-opped) so the operator knows it has no effect.
+_RETIRED_SETTING_KEYS: frozenset[str] = frozenset({"branch_prefix", "ask_before_post_on_behalf"})
+
+
+def _warn_retired_keys_in_toml(raw: dict, path: Path) -> None:
+    """Emit ONE aggregated WARN for retired setting keys still present in TOML.
+
+    A retired key (its ``UserSettings`` field is gone, souliane/teatree#2731) maps
+    to no field, so a stored value resolves to nothing. Unlike a migrated DB-home
+    key — which the operator moves into the ``ConfigSetting`` store — a retired key
+    has no successor and should simply be deleted from the file.
+    """
+    offenders: list[str] = []
+    teatree = raw.get("teatree")
+    if isinstance(teatree, dict):
+        offenders.extend(f"[teatree] {key}" for key in _RETIRED_SETTING_KEYS if key in teatree)
+    overlays = raw.get("overlays")
+    if isinstance(overlays, dict):
+        for overlay_name, overlay_cfg in overlays.items():
+            if not isinstance(overlay_cfg, dict):
+                continue
+            offenders.extend(f"[overlays.{overlay_name}] {key}" for key in _RETIRED_SETTING_KEYS if key in overlay_cfg)
+    if offenders:
+        _logger.warning(
+            "Retired setting keys in %s have no effect (souliane/teatree#2731 removed the field) "
+            "and are IGNORED on read: %s. Delete them from the file.",
+            path,
+            ", ".join(offenders),
+        )
+
+
 def _conflicting_db_home_keys(
     toml_table: dict[str, Any], db_home_keys: list[str], db_overrides: dict[str, Any]
 ) -> list[str]:
@@ -219,6 +253,7 @@ def load_config(path: Path | None = None) -> TeaTreeConfig:
 
     raw = _load_toml(path)
     _warn_db_home_keys_in_toml(raw, path)
+    _warn_retired_keys_in_toml(raw, path)
 
     teatree = raw.get("teatree", {})
     workspace_dir = Path(teatree.get("workspace_dir", "~/workspace")).expanduser()
@@ -229,11 +264,9 @@ def load_config(path: Path | None = None) -> TeaTreeConfig:
     # nested structured tables). Every DB-home field keeps its dataclass default
     # at the file tier; its value comes from the ``ConfigSetting`` store via
     # ``get_effective_settings``. ``on_behalf_post_mode`` is DB-home (so it keeps
-    # its default here), and ``ask_before_post_on_behalf`` is DERIVED from the
-    # mode — derived from the file-tier default mode here, re-derived from the
-    # resolved DB-home mode by ``get_effective_settings``. A DB-home key left in
-    # ``[teatree]`` / ``[overlays.<name>]`` is ignored on read (its home is the
-    # DB); migrate it into the store with ``t3 <overlay> config_setting import``.
+    # its default here). A DB-home key left in ``[teatree]`` / ``[overlays.<name>]``
+    # is ignored on read (its home is the DB); migrate it into the store with
+    # ``t3 <overlay> config_setting import``.
     user = UserSettings(
         workspace_dir=workspace_dir,
         worktrees_dir=worktrees_dir,

--- a/src/teatree/config/resolution.py
+++ b/src/teatree/config/resolution.py
@@ -18,7 +18,7 @@ field to its dataclass default.
 
 import logging
 import os
-from dataclasses import is_dataclass, replace
+from dataclasses import replace
 from typing import Any
 
 import teatree.config as _facade
@@ -125,23 +125,10 @@ def get_effective_settings(overlay_name: str | None = None) -> UserSettings:
     speak_override = _overlay_speak_override(config, overlay_name, base.speak)
     if speak_override is not None:
         settings = replace(settings, speak=speak_override)
-    settings = _apply_autonomy(
+    return _apply_autonomy(
         settings,
         hard_pinned=hard_pinned,
         global_pinned=_global_pinned_fields(config),
-    )
-    # ``ask_before_post_on_behalf`` is DERIVED (#1775) from the resolved DB-home
-    # ``on_behalf_post_mode``: True unless the mode is IMMEDIATE. Re-derived here
-    # so the deprecated legacy field stays consistent with the effective mode.
-    # Guarded on a real dataclass so a test that patches ``load_config`` to return
-    # a bare mock (``config.user`` is not a ``UserSettings``) gets the same
-    # untouched passthrough it got before the partition — the derivation is only
-    # meaningful on a real settings dataclass anyway.
-    if not is_dataclass(settings):
-        return settings
-    return replace(
-        settings,
-        ask_before_post_on_behalf=settings.on_behalf_post_mode is not OnBehalfPostMode.IMMEDIATE,
     )
 
 

--- a/src/teatree/config/settings.py
+++ b/src/teatree/config/settings.py
@@ -293,7 +293,6 @@ OVERLAY_OVERRIDABLE_SETTINGS: dict[str, Callable[[Any], Any]] = {
     "mode": Mode.parse,
     "autonomy": Autonomy.parse,
     "speed": Speed.parse,
-    "branch_prefix": _parse_strict_str,
     "contribute": _parse_strict_bool,
     "excluded_skills": _parse_str_list,
     "loop_cadence_seconds": _parse_strict_int,
@@ -493,7 +492,6 @@ def _default_handover_mirror_path() -> Path:
 class UserSettings:
     workspace_dir: Path = field(default_factory=lambda: Path.home() / "workspace")
     worktrees_dir: Path = field(default_factory=lambda: DATA_DIR / "worktrees")
-    branch_prefix: str = ""
     privacy: str = ""
     check_updates: bool = True
     timezone: str = ""
@@ -569,19 +567,6 @@ class UserSettings:
     # direct posting without flipping the global). Default on, mirroring
     # `require_human_approval_to_merge`.
     require_human_approval_to_answer: bool = True
-    # Pre-gate for posts the agent makes under the user's identity to a
-    # colleague/customer surface (PR/MR comment, issue comment, Slack
-    # channel/thread post, Notion post, PR/MR approve, reaction on
-    # someone else's message).
-    #
-    # **Deprecated** in favour of the tri-state ``on_behalf_post_mode``
-    # below, and now a DERIVED value (#1775): the resolver computes it
-    # (``True`` when the resolved mode is ``ASK`` or ``DRAFT_OR_ASK``,
-    # ``False`` when ``IMMEDIATE``) rather than reading it. Under the hard
-    # partition a legacy ``[teatree] ask_before_post_on_behalf`` TOML key is
-    # ignored on read; set the successor ``on_behalf_post_mode`` (DB-home)
-    # via ``config_setting set`` / migrate it with ``config_setting import``.
-    ask_before_post_on_behalf: bool = True
     # Tri-state pre-gate over on-behalf colleague/customer posts (#960):
     #
     # * ``DRAFT_OR_ASK`` (default) — colleague-invisible, revocable draft

--- a/src/teatree/on_behalf_gate.py
+++ b/src/teatree/on_behalf_gate.py
@@ -58,14 +58,8 @@ The resolver returns one of three :class:`OnBehalfVerdict` values:
     :attr:`~teatree.config.OnBehalfPostMode.ASK` and
     :attr:`~teatree.config.OnBehalfPostMode.DRAFT_OR_ASK` (drafts are
     exempt under every blocking mode, not just the default).
-
-The legacy boolean helper :func:`ask_before_post_on_behalf_enabled` is
-kept as a deprecated shim returning ``True`` for ASK/DRAFT_OR_ASK and
-``False`` for IMMEDIATE — it emits a :class:`DeprecationWarning` on
-first call. Use :func:`resolve_on_behalf_verdict` instead.
 """
 
-import warnings
 from enum import StrEnum
 
 from teatree.config import OnBehalfPostMode, get_effective_settings
@@ -163,30 +157,3 @@ def resolve_on_behalf_verdict(action: str) -> OnBehalfVerdict:
     if action in _DRAFT_FORM_ACTIONS:
         return OnBehalfVerdict.AUTO_DRAFT
     return OnBehalfVerdict.BLOCK
-
-
-_DEPRECATION_EMITTED = False
-
-
-def ask_before_post_on_behalf_enabled() -> bool:
-    """Deprecated boolean shim — prefer :func:`resolve_on_behalf_verdict`.
-
-    Returns ``True`` when the resolved mode is ASK or DRAFT_OR_ASK (both
-    of which BLOCK colleague-visible posts), ``False`` when IMMEDIATE.
-    Note this boolean is per-mode, not per-action: it cannot express that
-    a draft-form action is exempt and auto-drafts under ASK/DRAFT_OR_ASK.
-    Emits a :class:`DeprecationWarning` on first call — new code should
-    call :func:`resolve_on_behalf_verdict` directly so the per-action
-    distinction (BLOCK for visible posts vs AUTO_DRAFT for drafts under
-    both blocking modes) isn't lost.
-    """
-    global _DEPRECATION_EMITTED  # noqa: PLW0603 — module-level first-call flag
-    if not _DEPRECATION_EMITTED:
-        warnings.warn(
-            "ask_before_post_on_behalf_enabled() is deprecated; "
-            "use teatree.on_behalf_gate.resolve_on_behalf_verdict(action) instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        _DEPRECATION_EMITTED = True
-    return get_effective_settings().on_behalf_post_mode is not OnBehalfPostMode.IMMEDIATE

--- a/tests/config/test_dirs_and_helpers.py
+++ b/tests/config/test_dirs_and_helpers.py
@@ -120,7 +120,7 @@ e2e_dir = "e2e"
 
 def test_load_e2e_repos_missing_section(tmp_path: Path) -> None:
     config_path = tmp_path / ".teatree.toml"
-    _write_toml(config_path, '[teatree]\nbranch_prefix = "ac-"\n')
+    _write_toml(config_path, '[teatree]\nprivacy = "strict"\n')
     assert load_e2e_repos(config_path) == []
 
 

--- a/tests/config/test_load_config.py
+++ b/tests/config/test_load_config.py
@@ -24,7 +24,7 @@ from ._shared import _write_toml
 
 
 def test_load_config_reads_toml_home_fields(tmp_path: Path) -> None:
-    # workspace_dir + privacy are TOML-home; branch_prefix is DB-home and keeps
+    # workspace_dir + privacy are TOML-home; review_skill is DB-home and keeps
     # its dataclass default at the file tier (resolved from the DB store).
     config_path = tmp_path / ".teatree.toml"
     _write_toml(
@@ -38,14 +38,14 @@ privacy = "strict"
     config = load_config(config_path)
     assert config.user.workspace_dir == Path("/custom/workspace")
     assert config.user.privacy == "strict"
-    assert config.user.branch_prefix == ""
+    assert config.user.review_skill == ""
     assert "teatree" in config.raw
 
 
 def test_load_config_missing_file(tmp_path: Path) -> None:
     config = load_config(tmp_path / "nonexistent.toml")
     assert config.user.workspace_dir == Path.home() / "workspace"
-    assert config.user.branch_prefix == ""
+    assert config.user.review_skill == ""
     assert config.user.privacy == ""
 
 
@@ -53,7 +53,7 @@ def test_load_config_defaults_when_teatree_section_empty(tmp_path: Path) -> None
     config_path = tmp_path / ".teatree.toml"
     _write_toml(config_path, "[other]\nfoo = 1\n")
     config = load_config(config_path)
-    assert config.user.branch_prefix == ""
+    assert config.user.review_skill == ""
 
 
 def test_handover_mirror_path_defaults_under_xdg_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -212,16 +212,11 @@ class TestDbHomeGlobalResolution(TestCase):
 
     def test_on_behalf_post_mode_db_immediate(self) -> None:
         ConfigSetting.objects.set_value("on_behalf_post_mode", "immediate")
-        settings = get_effective_settings()
-        assert settings.on_behalf_post_mode is OnBehalfPostMode.IMMEDIATE
-        # ask_before_post_on_behalf is DERIVED from the resolved mode.
-        assert settings.ask_before_post_on_behalf is False
+        assert get_effective_settings().on_behalf_post_mode is OnBehalfPostMode.IMMEDIATE
 
-    def test_on_behalf_post_mode_db_ask_derives_true(self) -> None:
+    def test_on_behalf_post_mode_db_ask(self) -> None:
         ConfigSetting.objects.set_value("on_behalf_post_mode", "ask")
-        settings = get_effective_settings()
-        assert settings.on_behalf_post_mode is OnBehalfPostMode.ASK
-        assert settings.ask_before_post_on_behalf is True
+        assert get_effective_settings().on_behalf_post_mode is OnBehalfPostMode.ASK
 
     def test_user_identity_aliases_db(self) -> None:
         ConfigSetting.objects.set_value("user_identity_aliases", ["adrien.work", "souliane", "adrien.cossa"])

--- a/tests/config/test_overlay_overrides.py
+++ b/tests/config/test_overlay_overrides.py
@@ -115,11 +115,11 @@ class TestOverlayDbHomeOverrides(TestCase):
         self._activate()
         assert get_effective_settings().mode is Mode.AUTO
 
-    def test_overlay_scoped_branch_prefix_wins_over_global(self) -> None:
-        ConfigSetting.objects.set_value("branch_prefix", "ac")
-        ConfigSetting.objects.set_value("branch_prefix", "xp", scope="my-overlay")
+    def test_overlay_scoped_str_setting_wins_over_global(self) -> None:
+        ConfigSetting.objects.set_value("review_skill", "ac")
+        ConfigSetting.objects.set_value("review_skill", "xp", scope="my-overlay")
         self._activate()
-        assert get_effective_settings().branch_prefix == "xp"
+        assert get_effective_settings().review_skill == "xp"
 
     def test_env_var_beats_overlay_scoped_db_row(self) -> None:
         ConfigSetting.objects.set_value("mode", "auto", scope="my-overlay")

--- a/tests/config/test_removed_dead_settings.py
+++ b/tests/config/test_removed_dead_settings.py
@@ -1,0 +1,144 @@
+# test-path: cross-cutting
+"""Guard the removal of two provably-dead settings (souliane/teatree#2731).
+
+Both ``branch_prefix`` and ``ask_before_post_on_behalf`` were dead surface on
+``UserSettings`` — the former a DB-home field nothing read, the latter a derived
+value nothing read and a deprecated shim only tests referenced. This guard turns
+their removal into a mechanical floor: the field is gone from the dataclass and
+the parser registry, a stored row / TOML key resolves to nothing, and nothing in
+``src/`` reads the retired derived field. On-behalf gating is unaffected — it
+resolves through ``resolve_on_behalf_verdict`` / ``on_behalf_post_mode``.
+
+Integration-first per the Test-Writing Doctrine: real ``ConfigSetting`` rows and
+real TOML under ``tmp_path`` asserted through ``get_effective_settings``.
+"""
+
+import dataclasses
+import logging
+from pathlib import Path
+
+import pytest
+from django.test import TestCase
+
+import teatree.config as config_facade
+from teatree.config import (
+    OVERLAY_OVERRIDABLE_SETTINGS,
+    OnBehalfPostMode,
+    UserSettings,
+    get_effective_settings,
+    load_config,
+)
+from teatree.core.models import ConfigSetting
+from teatree.on_behalf_gate import OnBehalfVerdict, resolve_on_behalf_verdict
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SRC = _REPO_ROOT / "src"
+
+
+def _field_names() -> set[str]:
+    return {f.name for f in dataclasses.fields(UserSettings)}
+
+
+class TestBranchPrefixRemoved:
+    """``branch_prefix`` is no longer a ``UserSettings`` field or a parser entry.
+
+    The env-driven ``_branch_prefix()`` workspace helper (reads ``T3_BRANCH_PREFIX``
+    / ``git config user.name``) is unrelated and stays — it never read this field.
+    """
+
+    def test_branch_prefix_is_not_a_user_settings_field(self) -> None:
+        assert "branch_prefix" not in _field_names()
+
+    def test_branch_prefix_not_in_overlay_overridable_registry(self) -> None:
+        assert "branch_prefix" not in OVERLAY_OVERRIDABLE_SETTINGS
+
+
+class TestStoredBranchPrefixResolvesToNothing(TestCase):
+    """A stored ``branch_prefix`` row / ``[teatree]`` TOML key resolves to nothing.
+
+    The key is absent from the DB-home parser registry, so a stored row supplies
+    no value and the setting does not reappear on the resolved dataclass.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self.config_path = tmp_path / ".teatree.toml"
+        monkeypatch.setattr(config_facade, "CONFIG_PATH", self.config_path)
+        for env in ("T3_OVERLAY_NAME", "T3_BRANCH_PREFIX"):
+            monkeypatch.delenv(env, raising=False)
+        self.monkeypatch = monkeypatch
+
+    def test_stored_row_is_ignored_no_attribute_reappears(self) -> None:
+        ConfigSetting.objects.set_value("branch_prefix", "ac")
+        settings = get_effective_settings()
+        assert not hasattr(settings, "branch_prefix")
+
+    def test_toml_key_is_ignored_on_read(self) -> None:
+        self.config_path.write_text('[teatree]\nbranch_prefix = "ac"\n', encoding="utf-8")
+        settings = get_effective_settings()
+        assert not hasattr(settings, "branch_prefix")
+
+
+class TestAskBeforePostOnBehalfRemoved:
+    """The derived ``ask_before_post_on_behalf`` field and its shim are retired."""
+
+    def test_ask_before_post_on_behalf_is_not_a_user_settings_field(self) -> None:
+        assert "ask_before_post_on_behalf" not in _field_names()
+
+    def test_resolved_settings_carry_no_ask_before_post_on_behalf(self) -> None:
+        assert not hasattr(get_effective_settings(), "ask_before_post_on_behalf")
+
+    def test_deprecated_shim_is_gone(self) -> None:
+        import teatree.on_behalf_gate as gate_mod  # noqa: PLC0415
+
+        assert not hasattr(gate_mod, "ask_before_post_on_behalf_enabled")
+
+    def test_no_src_module_reads_the_retired_field(self) -> None:
+        offenders: list[str] = []
+        for path in _SRC.rglob("*.py"):
+            text = path.read_text(encoding="utf-8", errors="ignore")
+            for lineno, line in enumerate(text.splitlines(), start=1):
+                if ".ask_before_post_on_behalf" in line:
+                    offenders.append(f"{path.relative_to(_REPO_ROOT).as_posix()}:{lineno}: {line.strip()}")
+        assert offenders == [], (
+            "Retired derived field `.ask_before_post_on_behalf` is still read in src/ — "
+            "use resolve_on_behalf_verdict / on_behalf_post_mode instead:\n" + "\n".join(offenders)
+        )
+
+
+class TestOnBehalfGatingStillResolves(TestCase):
+    """Removing the dead field/shim leaves on-behalf gating fully intact."""
+
+    @pytest.fixture(autouse=True)
+    def _config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self.config_path = tmp_path / ".teatree.toml"
+        monkeypatch.setattr(config_facade, "CONFIG_PATH", self.config_path)
+        for env in ("T3_OVERLAY_NAME", "T3_ON_BEHALF_POST_MODE", "T3_ON_BEHALF_AUTO_ACTIONS"):
+            monkeypatch.delenv(env, raising=False)
+
+    def test_default_mode_blocks_visible_posts_and_drafts_auto(self) -> None:
+        assert resolve_on_behalf_verdict("post_comment") is OnBehalfVerdict.BLOCK
+        assert resolve_on_behalf_verdict("post_draft_note") is OnBehalfVerdict.AUTO_DRAFT
+
+    def test_immediate_mode_resolves_to_proceed(self) -> None:
+        ConfigSetting.objects.set_value("on_behalf_post_mode", "immediate")
+        assert resolve_on_behalf_verdict("post_comment") is OnBehalfVerdict.PROCEED
+        assert get_effective_settings().on_behalf_post_mode is OnBehalfPostMode.IMMEDIATE
+
+
+class TestRetiredKeyWarnList:
+    """A leftover retired key in TOML warns rather than silently no-opping."""
+
+    def test_branch_prefix_in_toml_warns(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        config_path = tmp_path / ".teatree.toml"
+        config_path.write_text('[teatree]\nbranch_prefix = "ac"\n', encoding="utf-8")
+        with caplog.at_level(logging.WARNING, logger="teatree.config.loader"):
+            load_config(config_path)
+        assert any("branch_prefix" in rec.message and "Retired" in rec.message for rec in caplog.records)
+
+    def test_clean_toml_does_not_warn(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        config_path = tmp_path / ".teatree.toml"
+        config_path.write_text('[teatree]\nprivacy = "strict"\n', encoding="utf-8")
+        with caplog.at_level(logging.WARNING, logger="teatree.config.loader"):
+            load_config(config_path)
+        assert not any("Retired setting keys" in rec.message for rec in caplog.records)

--- a/tests/config/test_settings_home_partition.py
+++ b/tests/config/test_settings_home_partition.py
@@ -3,8 +3,8 @@
 
 The hard partition: a setting that CAN live in the DB MUST be DB-home; only the
 irreducible carve-out (pre-Django readers, path/infra bootstrap, nested
-structured tables, dead fields) stays TOML-home. Two fields are DERIVED — the
-resolver computes them, so they have no home and are excluded from the partition.
+structured tables, dead fields) stays TOML-home. One field is DERIVED — the
+resolver computes it, so it has no home and is excluded from the partition.
 
 The fitness functions below make the partition machine-checked: they go RED the
 moment a new ``UserSettings`` field is added without classifying it, or a field
@@ -66,8 +66,8 @@ def test_toml_carve_out_is_exactly_the_ten_fields() -> None:
     assert toml_home == _TOML_CARVE_OUT
 
 
-def test_derived_fields_are_exactly_the_two_computed_values() -> None:
-    assert frozenset({"notify_on_behalf", "ask_before_post_on_behalf"}) == DERIVED_FIELDS
+def test_derived_fields_are_exactly_the_one_computed_value() -> None:
+    assert frozenset({"notify_on_behalf"}) == DERIVED_FIELDS
 
 
 def test_db_home_covers_every_non_carve_out_non_derived_field() -> None:

--- a/tests/integration/slack_bridge_e2e/conftest.py
+++ b/tests/integration/slack_bridge_e2e/conftest.py
@@ -193,13 +193,11 @@ class _FakeUserSettings:
     # subset of the real ``UserSettings``.
     slack_voice_classifier_mode: _VoiceClassifierMode = _VoiceClassifierMode.WARN
     # #1775 ``_resolved_identities()`` now routes through
-    # ``get_effective_settings()``, whose autonomy collapse + derived
-    # ``ask_before_post_on_behalf`` + per-overlay speak merge read these
-    # fields. Mirror them with the real ``UserSettings`` defaults so the
-    # fixture stays a structural subset.
+    # ``get_effective_settings()``, whose autonomy collapse + per-overlay
+    # speak merge read these fields. Mirror them with the real
+    # ``UserSettings`` defaults so the fixture stays a structural subset.
     autonomy: _Autonomy = _Autonomy.BABYSIT
     on_behalf_post_mode: _OnBehalfPostMode = _OnBehalfPostMode.DRAFT_OR_ASK
-    ask_before_post_on_behalf: bool = True
     speak: _SpeakConfig = field(default_factory=_SpeakConfig)
 
 

--- a/tests/teatree_cli/test_review_approve_already_approved.py
+++ b/tests/teatree_cli/test_review_approve_already_approved.py
@@ -28,9 +28,8 @@ pytestmark = pytest.mark.django_db
 
 
 def _gate_off(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # ``on_behalf_post_mode`` is DB-home (#1775): IMMEDIATE turns the gate off
-    # (the derived ``ask_before_post_on_behalf`` follows). A TOML key would be
-    # ignored on read.
+    # ``on_behalf_post_mode`` is DB-home (#1775): IMMEDIATE turns the gate off.
+    # A TOML key would be ignored on read.
     cfg = tmp_path / ".teatree.toml"
     cfg.write_text("[teatree]\n", encoding="utf-8")
     monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)

--- a/tests/teatree_cli/test_review_approve_gate.py
+++ b/tests/teatree_cli/test_review_approve_gate.py
@@ -27,9 +27,9 @@ pytestmark = pytest.mark.django_db
 
 
 def _gate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, *, on: bool) -> None:
-    # ``on_behalf_post_mode`` is DB-home (#1775) and drives the gate; the derived
-    # ``ask_before_post_on_behalf`` follows it. Gate OFF = ``immediate`` (the
-    # store row), gate ON = ``draft_or_ask`` (the dataclass default — clear any row).
+    # ``on_behalf_post_mode`` is DB-home (#1775) and drives the gate. Gate OFF =
+    # ``immediate`` (the store row), gate ON = ``draft_or_ask`` (the dataclass
+    # default — clear any row).
     cfg = tmp_path / ".teatree.toml"
     cfg.write_text("[teatree]\n", encoding="utf-8")
     monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)

--- a/tests/teatree_cli/test_review_outbound_claim.py
+++ b/tests/teatree_cli/test_review_outbound_claim.py
@@ -19,9 +19,8 @@ pytestmark = pytest.mark.django_db
 
 
 def _gate_off(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # ``on_behalf_post_mode`` is DB-home (#1775): IMMEDIATE turns the gate off
-    # (the derived ``ask_before_post_on_behalf`` follows). A TOML key would be
-    # ignored on read.
+    # ``on_behalf_post_mode`` is DB-home (#1775): IMMEDIATE turns the gate off.
+    # A TOML key would be ignored on read.
     cfg = tmp_path / ".teatree.toml"
     cfg.write_text("[teatree]\n", encoding="utf-8")
     monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)

--- a/tests/teatree_cli/test_review_verify_after_post.py
+++ b/tests/teatree_cli/test_review_verify_after_post.py
@@ -31,9 +31,9 @@ pytestmark = pytest.mark.django_db
 
 
 def _gate_off(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # The on-behalf gate is OFF when ``ask_before_post_on_behalf`` is False —
-    # derived (#1775) from the DB-home ``on_behalf_post_mode`` being IMMEDIATE.
-    # Staging it via TOML is a no-op on read, so the mode is set in the DB store.
+    # The on-behalf gate is OFF when the DB-home ``on_behalf_post_mode`` is
+    # IMMEDIATE (#1775). Staging it via TOML is a no-op on read, so the mode is
+    # set in the DB store.
     cfg = tmp_path / ".teatree.toml"
     cfg.write_text("[teatree]\n", encoding="utf-8")
     monkeypatch.setattr("teatree.config.CONFIG_PATH", cfg)

--- a/tests/test_cli_review.py
+++ b/tests/test_cli_review.py
@@ -912,9 +912,7 @@ class TestApprove:
         # The autouse ``_no_on_behalf_gate`` fixture sets the gate to immediate
         # via ``T3_ON_BEHALF_POST_MODE`` (``on_behalf_post_mode`` is DB-home,
         # #1775). This test needs the gate ON, so undo that override and let the
-        # mode resolve to its blocking ``DRAFT_OR_ASK`` default. (The old
-        # ``ask_before_post_on_behalf`` TOML staging is inert — that field is
-        # derived from ``on_behalf_post_mode`` and ignored on read.)
+        # mode resolve to its blocking ``DRAFT_OR_ASK`` default.
         monkeypatch.delenv("T3_ON_BEHALF_POST_MODE", raising=False)
         mock_api = MagicMock()
         mock_api.current_username.return_value = "reviewer-bot"

--- a/tests/test_on_behalf_gate.py
+++ b/tests/test_on_behalf_gate.py
@@ -8,11 +8,10 @@ is exercised end-to-end with no mocks. ``CONFIG_PATH`` is monkeypatched to an
 isolated (unwritten) file so the real ``~/.teatree.toml`` never leaks in.
 
 The fine-grained (mode, action) → verdict matrix lives in
-``tests/test_on_behalf_post_mode.py``; this file focuses on the deprecation
-shim and the retirement of the legacy ``ask_before_post_on_behalf`` TOML alias.
+``tests/test_on_behalf_post_mode.py``; this file focuses on the retirement of
+the legacy ``ask_before_post_on_behalf`` TOML alias.
 """
 
-import warnings
 from pathlib import Path
 
 import pytest
@@ -20,7 +19,7 @@ from django.test import TestCase
 
 from teatree.config import OnBehalfPostMode
 from teatree.core.models import ConfigSetting
-from teatree.on_behalf_gate import OnBehalfVerdict, ask_before_post_on_behalf_enabled, resolve_on_behalf_verdict
+from teatree.on_behalf_gate import OnBehalfVerdict, resolve_on_behalf_verdict
 
 
 class _OnBehalfDbBase(TestCase):
@@ -67,40 +66,6 @@ class TestPerOverlayOverride(_OnBehalfDbBase):
         ConfigSetting.objects.set_value("on_behalf_post_mode", "immediate", scope="trusted")
         self.monkeypatch.setenv("T3_OVERLAY_NAME", "trusted")
         assert resolve_on_behalf_verdict("post_comment") is OnBehalfVerdict.PROCEED
-
-
-class TestDeprecatedShim(_OnBehalfDbBase):
-    """``ask_before_post_on_behalf_enabled()`` is kept for one release."""
-
-    def test_returns_true_under_ask(self) -> None:
-        ConfigSetting.objects.set_value("on_behalf_post_mode", "ask")
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            assert ask_before_post_on_behalf_enabled() is True
-
-    def test_returns_true_under_draft_or_ask(self) -> None:
-        ConfigSetting.objects.set_value("on_behalf_post_mode", "draft_or_ask")
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            assert ask_before_post_on_behalf_enabled() is True
-
-    def test_returns_false_under_immediate(self) -> None:
-        ConfigSetting.objects.set_value("on_behalf_post_mode", "immediate")
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            assert ask_before_post_on_behalf_enabled() is False
-
-    def test_emits_deprecation_warning(self) -> None:
-        # Reset the module-level once-flag so this test sees the warning.
-        import teatree.on_behalf_gate as gate_mod  # noqa: PLC0415
-
-        gate_mod._DEPRECATION_EMITTED = False
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always", DeprecationWarning)
-            ask_before_post_on_behalf_enabled()
-        assert any(
-            issubclass(w.category, DeprecationWarning) and "resolve_on_behalf_verdict" in str(w.message) for w in caught
-        )
 
 
 class TestRetiredLegacyTomlAlias(_OnBehalfDbBase):


### PR DESCRIPTION
## Summary

Removes two provably-dead settings from `UserSettings` — both were surface that nothing read.

Closes #2731

### Unit 1 — `branch_prefix` (dead DB-home field)

`UserSettings.branch_prefix` was a DB-home field that no reader consulted. The env-driven `_branch_prefix()` workspace helper (`src/teatree/core/management/commands/workspace.py`) reads `T3_BRANCH_PREFIX` / `git config user.name` and never touched this field — it is unrelated and stays, along with its tests and the git-branch-name heuristic tests in `test_merge_repo_resolution.py`.

- Drop the field (`settings.py`) and its `OVERLAY_OVERRIDABLE_SETTINGS` parser entry. `homes.py` auto-derives the home registry from the dataclass fields, so the partition stays in sync with no manual edit.
- Add `branch_prefix` (and `ask_before_post_on_behalf`) to a retired-key warn-list in `loader.py` (`_warn_retired_keys_in_toml`), so a leftover stored/TOML key WARNs rather than silently no-opping.
- Docs: removed the `branch_prefix` rows from `docs/blueprint/configuration.md` and `README.md`. The unrelated `T3_BRANCH_PREFIX` env var stays documented.

### Unit 2 — `ask_before_post_on_behalf` (derived-but-unread field + deprecated shim)

The boolean was a derived value the resolver computed but nothing read, and its deprecated shim `ask_before_post_on_behalf_enabled()` was referenced only by tests. Both retired now (the shim was "kept for one release").

- Drop the field (`settings.py`), the `replace(... ask_before_post_on_behalf=...)` derivation (`resolution.py`, plus the now-unused `is_dataclass` import), and the `DERIVED_FIELDS` entry (now just `notify_on_behalf`) in `homes.py`.
- Remove the shim `ask_before_post_on_behalf_enabled()` and its `warnings` import in `on_behalf_gate.py`; grep-confirmed no non-test caller.
- Scrub stale docstrings to reference `on_behalf_post_mode`: `cli/review/drafts.py`, `cli/review/service.py`, `docs/blueprint/loop-topology.md`, and several test comments.

On-behalf gating is unchanged — it resolves through `resolve_on_behalf_verdict` / `on_behalf_post_mode`, which the new guard test pins (BLOCK for visible posts, AUTO_DRAFT for drafts, PROCEED under IMMEDIATE).

### Not in scope

No renames, no merges, no model/migration change (`ConfigSetting` stores rows, not columns — `makemigrations --check --dry-run` reports no changes). The `*_disabled`/`*_enabled` scanner family, `contribute`/`contribute_plugin_dir`, the `notify_*` trio, the `*_repo_url_pattern` pair, and the `idle_stack_reaper_*` infix are all behavior-bearing and untouched.

## Tests (TDD, anti-vacuity proven)

New guard suite `tests/config/test_removed_dead_settings.py` — observed RED before removal (7 failing), GREEN after. It asserts: the field is gone from the dataclass and the parser registry; a stored row / TOML key resolves to nothing; nothing in `src/` reads `.ask_before_post_on_behalf`; the shim is gone; on-behalf gating still resolves; and the retired-key warn-list bites.

Plumbing tests that used `branch_prefix` as generic filler are re-pointed onto other DB-home keys (`review_skill`) / TOML-home keys (`privacy`); the partition fitness test's `DERIVED_FIELDS` assertion is updated to the single value.

## Verification

- `makemigrations --check --dry-run` → No changes detected
- Full suite → 20500 passed (2 unrelated load-flakes — `test_speak_serial_lock` and `test_jscpd_duplication` — both green in isolation)
- `tests/quality/` → 558 passed, 1 skipped
- `tests/config/test_settings_home_partition.py` → green
- `ruff check` (changed files) + `ruff format --check` → clean
- `tach check` → validated
- `generate_all_docs` + `generate_cli_reference.py` → `docs/generated` drift clean

## Architecture pre-check — #2731

**1. BLUEPRINT § alignment** — config partition (#1775, `docs/blueprint/configuration.md`). Removing two fields from the partition; the home registry auto-derives from the dataclass so the partition stays exhaustive/disjoint.

**2. FSM phase boundaries** — n/a (no `Ticket.State` / `Worktree.State` transition).

**3. Extension-point contracts** — n/a (no `OverlayBase` / scanner / hook / Protocol surface touched).

**4. Component boundaries** — all edits in `src/teatree/config/` (settings, resolution, homes, loader), `src/teatree/on_behalf_gate.py`, and `cli/review/` docstrings. No straddle.

**5. Dependency direction** — no new imports added; one removed (`is_dataclass`). `tach check` validated.

**6. Test surface** — `tests/config/test_removed_dead_settings.py` (field-gone, registry-gone, resolves-to-nothing, shim-gone, gating-intact, warn-list); partition fitness updated.

**7. Resilience invariants** — n/a (no new external write; removal only).

**8. Identity and key normalization** — n/a.

**9. Behavior preservation / capability deletion** — both removals enumerated as dead surface (no reader; shim only test-referenced). On-behalf gating behavior is preserved and pinned by the guard test. No privacy/security matcher narrowed. No must-block test inverted.
