### PR TITLE
fix(hooks): resolve publish destination for t3 review posts and api/vN endpoints

### DIFF
--- a/src/teatree/hooks/publish_destination.py
+++ b/src/teatree/hooks/publish_destination.py
@@ -44,7 +44,7 @@ carve-out and the destination skip.
 import os
 import re
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Final
 
 from teatree.hooks._command_parser import first_segment_words
@@ -107,6 +107,16 @@ _GH_API_REPOS_RE: Final[re.Pattern[str]] = re.compile(r"^/?repos/([^/]+/[^/]+)")
 # single URL-encoded path segment (``ns%2Frepo`` or ``ns%2Fsub%2Frepo``).
 # ``%2F`` decodes back to ``/`` so the slug matches the allowlist shape.
 _GLAB_API_PROJECTS_RE: Final[re.Pattern[str]] = re.compile(r"^/?projects/([^/?]+)")
+
+# A leading ``https?://<host>/`` and an ``api/vN/`` REST-version segment that a
+# full-URL or version-prefixed endpoint carries before the ``repos/`` /
+# ``projects/`` path the slug patterns above match. ``glab``/``gh api`` accept
+# the endpoint as a bare relative path (``projects/...``), a version-prefixed
+# path (``api/v4/projects/...``), or a full URL
+# (``https://gitlab.com/api/v4/projects/...``); stripping this optional prefix
+# normalises all three to the bare relative form. Both groups are optional, so a
+# bare ``[/]repos/...`` / ``[/]projects/...`` endpoint is returned unchanged.
+_API_ENDPOINT_PREFIX_RE: Final[re.Pattern[str]] = re.compile(r"^(?:https?://[^/]+/)?(?:/?api/v\d+/)?")
 
 # The ``owner/repo`` of a forge URL positional, before the resource segment
 # (GitLab ``/-/`` infix and nested group paths handled; ``.git`` suffix stripped).
@@ -216,11 +226,24 @@ def _api_url_arg(words: list[str]) -> str | None:
     return None
 
 
+def _normalize_api_endpoint(url: str) -> str:
+    """Strip a leading ``https?://<host>/`` and ``api/vN/`` prefix from an endpoint.
+
+    The ``repos/...`` / ``projects/...`` slug patterns match a RELATIVE endpoint,
+    but ``gh``/``glab api`` also accept a version-prefixed (``api/v4/projects/...``)
+    or full-URL (``https://gitlab.com/api/v4/projects/...``) endpoint. Removing the
+    optional host + ``api/vN/`` prefix collapses all three forms to the bare
+    relative path the patterns expect; a bare endpoint is returned unchanged.
+    """
+    return _API_ENDPOINT_PREFIX_RE.sub("", url, count=1)
+
+
 def _destination_from_api(words: list[str], tool: str) -> Destination | None:
     """Resolve the destination of a ``gh api`` / ``glab api`` raw REST call."""
     url = _api_url_arg(words)
     if url is None:
         return None
+    url = _normalize_api_endpoint(url)
     forge = _forge_for_tool(tool)
     if tool == "gh":
         match = _GH_API_REPOS_RE.match(url)
@@ -274,6 +297,52 @@ def _flagless_destination(words: list[str], tool: str, cwd: Path | None) -> Dest
     return None
 
 
+# ``t3 [overlay] review post-comment`` / ``... post-draft-note`` -- the
+# GitLab-only review-post verbs. The FIRST positional after the verb is the
+# project slug (confirmed at ``cli/review/commands.py`` ``post_comment`` /
+# ``post_draft_note``: ``repo`` is the leading ``typer.Argument``).
+_T3_REVIEW_POST_VERBS: Final[frozenset[str]] = frozenset({"post-comment", "post-draft-note"})
+
+
+def _first_positional(words: list[str]) -> str | None:
+    """Return the first token in ``words`` that is not a flag, or ``None``.
+
+    A flag is any token starting with ``-`` (``--body-file``, ``--live``, ``-m``).
+    Taking the first NON-FLAG token rather than strictly the first one tolerates
+    an interleaved leading flag (``--live <repo>``) before the repo positional.
+    """
+    for word in words:
+        if word.startswith("-"):
+            continue
+        return word
+    return None
+
+
+def _destination_from_t3_review(words: list[str]) -> Destination | None:
+    """Resolve the destination of a ``t3 [overlay] review post-comment/post-draft-note``.
+
+    ``t3 review`` posts a GitLab MR comment / draft note on the user's behalf; its
+    destination is the project-slug positional. The resolver never extracted it
+    (``_destination_from_words`` only knew ``gh``/``glab``), so a ``t3``-led
+    segment resolved to no destination -- and ``t3`` is not a recognised inert
+    leader -- so a post to an allowlisted-private repo fell through to the
+    fail-closed leak scan and over-fired.
+
+    The leader is canonicalised up to the ``t3`` basename so a path-form leader
+    (``./t3``, ``/usr/local/bin/t3``) is recognised the same as a bare ``t3``, and
+    the arbitrary overlay token between ``t3`` and ``review`` is tolerated --
+    mirroring :func:`_command_parser._segment_is_t3_publish`. The forge is pinned
+    to ``gitlab`` because ``t3 review`` is GitLab-only.
+    """
+    if PurePosixPath(words[0]).name != "t3":
+        return None
+    for i in range(1, len(words) - 1):
+        if words[i] == "review" and words[i + 1] in _T3_REVIEW_POST_VERBS:
+            slug = _first_positional(words[i + 2 :])
+            return Destination(slug=slug, via="t3", forge="gitlab") if slug else None
+    return None
+
+
 def _destination_from_words(words: list[str], cwd: Path | None) -> Destination | None:
     """Resolve the publish destination of one command segment's word list.
 
@@ -282,7 +351,12 @@ def _destination_from_words(words: list[str], cwd: Path | None) -> Destination |
     PER top-level segment (the ALL-SEGMENTS invariant) rather than only from
     the first segment.
     """
-    if not words or words[0] not in {"gh", "glab"}:
+    if not words:
+        return None
+    t3_dest = _destination_from_t3_review(words)
+    if t3_dest is not None:
+        return t3_dest
+    if words[0] not in {"gh", "glab"}:
         return None
     explicit = _extract_repo_flag(words)
     if explicit:
@@ -297,9 +371,15 @@ def resolve_publish_destination(command: str, cwd: Path | None = None) -> Destin
 
     - ``glab ... -R <ns>/<repo>`` / ``gh ... -R <owner>/<repo>`` -- the
         explicit ``--repo``/``-R`` flag (LAST-WINS, mirroring gh/glab).
-    - ``gh api repos/<owner>/<repo>/...`` -- the ``repos/`` path segment.
-    - ``glab api projects/<url-encoded ns%2Frepo>/...`` -- the ``projects/``
-        path segment, ``%2F``-decoded.
+    - ``gh api [https://<host>/][api/vN/]repos/<owner>/<repo>/...`` -- the
+        ``repos/`` path segment, after stripping an optional full-URL host and
+        ``api/vN/`` REST-version prefix.
+    - ``glab api [https://<host>/][api/vN/]projects/<url-encoded ns%2Frepo>/...``
+        -- the ``projects/`` path segment, ``%2F``-decoded, after the same
+        host + ``api/vN/`` prefix strip.
+    - ``t3 [overlay] review post-comment``/``post-draft-note <ns>/<repo> ...``
+        -- the project-slug positional (forge pinned to gitlab; ``t3 review`` is
+        GitLab-only).
     - ``gh``/``glab`` ``pr``/``issue``/``mr`` ``create``/``comment``/``note``
         with no ``--repo`` flag -- the CURRENT repo, via the git remote of
         ``cwd``.

--- a/tests/teatree_hooks/test_publish_destination.py
+++ b/tests/teatree_hooks/test_publish_destination.py
@@ -517,3 +517,175 @@ class TestForgeAwareVisibility:
 
         cmd = "gh pr create -R souliane/teatree --title x --body y"
         assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False
+
+
+class TestT3ReviewDestination:
+    """Fix A: ``t3 [overlay] review post-comment/post-draft-note`` resolves to its repo slug.
+
+    The destination resolver early-returned ``None`` for any non-``gh``/``glab``
+    leader, so a ``t3 review post-comment <repo> ...`` segment resolved to no
+    destination -- and ``t3`` is not a recognised inert leader either, so the
+    whole command fell through to the fail-closed scan. A post to an
+    allowlisted-private repo via ``t3 review`` therefore over-fired the
+    banned-terms gate. The resolver now extracts the repo positional (the first
+    non-flag token after the verb) and classifies it against the internal
+    allowlist; ``t3 review`` is GitLab-only, so the forge is pinned to gitlab.
+    """
+
+    def test_resolve_post_comment_records_slug_via_and_forge(self) -> None:
+        dest = publish_destination.resolve_publish_destination(
+            "t3 review post-comment internalcorp/svc 6378 --body-file /x --live"
+        )
+        assert dest is not None
+        assert dest.slug == "internalcorp/svc"
+        assert dest.via == "t3"
+        assert dest.forge == "gitlab"
+
+    def test_resolve_post_draft_note_records_slug(self) -> None:
+        dest = publish_destination.resolve_publish_destination(
+            "t3 review post-draft-note internalcorp/svc 6378 --body-file /x"
+        )
+        assert dest is not None
+        assert dest.slug == "internalcorp/svc"
+        assert dest.via == "t3"
+        assert dest.forge == "gitlab"
+
+    def test_resolve_tolerates_interleaved_leading_flag_before_repo(self) -> None:
+        # The repo is the first NON-FLAG positional after the verb, so a leading
+        # boolean flag interleaved before it does not derail resolution.
+        dest = publish_destination.resolve_publish_destination(
+            "t3 review post-comment --live internalcorp/svc 6378 --body-file /x"
+        )
+        assert dest is not None
+        assert dest.slug == "internalcorp/svc"
+
+    def test_non_review_t3_verb_is_none(self) -> None:
+        # A ``t3`` sub-command that is not a review post verb resolves to no
+        # destination via this path (the resolver only knows the review posts).
+        assert publish_destination.resolve_publish_destination("t3 review list internalcorp/svc") is None
+
+    def test_internal_post_comment_is_skipped(self, tmp_path: Path) -> None:
+        cfg = _config(tmp_path, ["internalcorp"])
+        assert (
+            publish_destination.gate_skips_destination(
+                "t3 review post-comment internalcorp/svc 6378 --body-file /x --live", None, config_path=cfg
+            )
+            is True
+        )
+
+    def test_internal_post_draft_note_is_skipped(self, tmp_path: Path) -> None:
+        cfg = _config(tmp_path, ["internalcorp"])
+        assert (
+            publish_destination.gate_skips_destination(
+                "t3 review post-draft-note internalcorp/svc 6378 --body-file /x", None, config_path=cfg
+            )
+            is True
+        )
+
+    def test_overlay_token_between_t3_and_review_is_tolerated(self, tmp_path: Path) -> None:
+        # The arbitrary overlay token between ``t3`` and ``review`` must not
+        # break detection (e.g. ``t3 acme-internal review post-comment ...``).
+        cfg = _config(tmp_path, ["internalcorp"])
+        assert (
+            publish_destination.gate_skips_destination(
+                "t3 acme-internal review post-comment internalcorp/svc 6378 --body-file /x --live",
+                None,
+                config_path=cfg,
+            )
+            is True
+        )
+
+    def test_path_form_t3_leader_is_canonicalised(self, tmp_path: Path) -> None:
+        # A path-form leader (``./t3``) canonicalises to the ``t3`` basename, the
+        # same as ``_segment_is_t3_publish`` does.
+        cfg = _config(tmp_path, ["internalcorp"])
+        assert (
+            publish_destination.gate_skips_destination(
+                "./t3 review post-comment internalcorp/svc 6378 --body-file /x --live", None, config_path=cfg
+            )
+            is True
+        )
+
+    def test_chained_cd_then_post_comment_is_skipped(self, tmp_path: Path) -> None:
+        # A leading ``cd <wt>`` is a recognised inert leader, and the trailing
+        # ``t3 review post-comment`` segment resolves to a provably-internal repo.
+        cfg = _config(tmp_path, ["internalcorp"])
+        cmd = "cd /wt && t3 review post-comment internalcorp/svc 6378 --body-file /x --live"
+        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is True
+
+    def test_public_repo_post_still_scans(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # MUST-FIRE: a ``t3 review`` post to a NON-allowlisted repo the probe
+        # cannot prove private stays PUBLIC and is scanned -- recognising the
+        # destination must not relax the public-surface default.
+        cfg = _config(tmp_path, ["internalcorp"])
+        monkeypatch.setattr(publish_destination, "slug_is_private", lambda slug: False)
+        cmd = "t3 review post-comment public-org/app 6378 --body-file /x --live"
+        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False
+
+
+class TestApiEndpointNormalization:
+    """Fix B: ``api/vN/`` and full-URL ``gh``/``glab api`` endpoints resolve to a slug.
+
+    ``_destination_from_api`` matched only a RELATIVE ``repos/...`` /
+    ``projects/...`` path, so an ``api/v4/projects/<ns>%2F<repo>/...`` endpoint
+    or a full ``https://gitlab.com/api/v4/projects/...`` URL yielded ``None`` and
+    the gate over-blocked an internal-MR update. The endpoint is now normalised
+    (a leading ``https?://<host>/`` and an ``api/vN/`` segment stripped) before
+    the existing relative patterns -- purely additive, a public endpoint still
+    resolves public and still scans.
+    """
+
+    def test_resolve_versioned_projects_path(self) -> None:
+        dest = publish_destination.resolve_publish_destination(
+            "glab api --method POST api/v4/projects/internalcorp%2Fsvc/merge_requests/6378/notes -f body=x"
+        )
+        assert dest is not None
+        assert dest.slug == "internalcorp/svc"
+        assert dest.via == "api"
+
+    def test_resolve_full_url_projects_path(self) -> None:
+        dest = publish_destination.resolve_publish_destination(
+            "glab api --method POST "
+            "https://gitlab.com/api/v4/projects/internalcorp%2Fsvc/merge_requests/6378/notes -f body=x"
+        )
+        assert dest is not None
+        assert dest.slug == "internalcorp/svc"
+        assert dest.via == "api"
+
+    def test_resolve_gh_full_url_repos_path(self) -> None:
+        # The same normalisation strips the GitHub API host so a full-URL ``gh
+        # api`` endpoint resolves its ``repos/owner/repo`` slug too.
+        dest = publish_destination.resolve_publish_destination(
+            "gh api --method POST https://api.github.com/repos/internalcorp/svc/issues -f body=x"
+        )
+        assert dest is not None
+        assert dest.slug == "internalcorp/svc"
+        assert dest.via == "api"
+
+    def test_internal_versioned_write_is_skipped(self, tmp_path: Path) -> None:
+        cfg = _config(tmp_path, ["internalcorp"])
+        cmd = "glab api --method POST api/v4/projects/internalcorp%2Fsvc/merge_requests/6378/notes -f body=x"
+        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is True
+
+    def test_internal_full_url_write_is_skipped(self, tmp_path: Path) -> None:
+        cfg = _config(tmp_path, ["internalcorp"])
+        cmd = (
+            "glab api --method POST "
+            "https://gitlab.com/api/v4/projects/internalcorp%2Fsvc/merge_requests/6378/notes -f body=x"
+        )
+        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is True
+
+    def test_public_versioned_write_still_scans(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        cfg = _config(tmp_path, ["internalcorp"])
+        monkeypatch.setattr(publish_destination, "slug_is_private", lambda slug: False)
+        cmd = "glab api --method POST api/v4/projects/public-org%2Fapp/merge_requests/6378/notes -f body=x"
+        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False
+
+    def test_public_full_url_write_still_scans(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        cfg = _config(tmp_path, ["internalcorp"])
+        monkeypatch.setattr(publish_destination, "slug_is_private", lambda slug: False)
+        cmd = (
+            "glab api --method POST "
+            "https://gitlab.com/api/v4/projects/public-org%2Fapp/merge_requests/6378/notes -f body=x"
+        )
+        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False


### PR DESCRIPTION
## Summary

The destination-aware gate skip (`teatree.hooks.publish_destination`) scans only PUBLIC publish targets. It resolves the target repo/namespace from the command, classifies it fail-closed, and skips the leak scan only for a provably-internal target. Two command shapes resolved to **no destination**, so the banned-terms / bare-reference gates treated them as PUBLIC (the conservative default) and **over-blocked** posts to allowlisted-private repos.

This fixes both, with red→green tests, keeping the conservative default intact.

### Defect A — `t3 review` posting verbs were never resolved

`src/teatree/hooks/publish_destination.py:300` — `_destination_from_words` early-returned `None` unless `words[0]` was `gh`/`glab`, so a `t3 [overlay] review post-comment <repo> ...` (or `post-draft-note`) segment resolved to no destination. `t3` is also not in `_SKIP_INERT_LEADERS`, so the whole command was scanned as public.

Fix: a new `_destination_from_t3_review(words)` helper, called before the gh/glab branch. It mirrors `_command_parser._segment_is_t3_publish` (canonicalises a path-form `t3` leader to its basename, tolerates the arbitrary overlay token between `t3` and `review`) and returns the **first non-flag positional** after the verb as the slug — `Destination(slug=<repo>, via="t3", forge="gitlab")` (forge pinned: `t3 review` is GitLab-only). Taking the first non-flag token (not strictly verb+1) tolerates an interleaved leading flag. Repo-arg location confirmed at `src/teatree/cli/review/commands.py:184-187` (`repo` is the leading `typer.Argument`).

### Defect B — `api/vN/` and full-URL `api` endpoints yielded None

`src/teatree/hooks/publish_destination.py` — `_destination_from_api` matched only a **relative** path (`^/?repos/...`, `^/?projects/...`). Endpoints like `api/v4/projects/<ns>%2F<repo>/...` and `https://gitlab.com/api/v4/projects/<ns>%2F<repo>/...` resolved to `None` → blocked.

Fix: a new `_normalize_api_endpoint` strips an optional leading `https?://<host>/` and an optional `api/vN/` segment **before** the existing relative patterns. Purely additive — a bare relative endpoint is unchanged, and a public endpoint still resolves public and still scans.

Both fixes preserve the fail-closed posture: a non-allowlisted repo still classifies public and still scans, so no leak surface opens.

## Tests

Added to `tests/teatree_hooks/test_publish_destination.py` (synthetic namespaces only — `internalcorp`/`acme-internal` internal, `public-org` public):

- `TestT3ReviewDestination` — resolve `slug`/`via`/`forge`; overlay-token variant; path-form leader; chained `cd … && t3 review …`; interleaved leading flag; `post-draft-note`; internal-skips; **public still scans**.
- `TestApiEndpointNormalization` — resolve versioned + full-URL `projects/` paths (and a GitHub full-URL `repos/` path); internal-skips; **public still scans**.

All 13 positive tests were observed RED on the unmodified resolver, GREEN after. Full file: 84 passed. Wider `tests/teatree_hooks/`: 1573 passed. Lint, format, and `ty` clean.

## Architecture pre-check

1. **BLUEPRINT § alignment** — touches the publish-surface gate (`teatree.hooks.publish_destination`), the destination-aware skip for the #1415 / #1530 leak gates. No BLUEPRINT contradiction; behaviour stays fail-closed.
2. **FSM phase boundaries** — n/a, no `Ticket`/`Worktree` state transition.
3. **Extension-point contracts** — no `OverlayBase`/scanner/hook/Protocol surface changed; consumers (`gate_skips_destination`) unchanged.
4. **Component boundaries** — `src/teatree/hooks/` (Claude Code gate helpers), the correct home.
5. **Dependency direction** — no new cross-module import (reuses existing `re`/`PurePosixPath` + in-module helpers).
6. **Test surface** — each behaviour pinned by a named test asserting the resolved `Destination` or the `gate_skips_destination` verdict; positives observed red-before-green.
7. **Resilience invariants** — read-only command parsing; no external write introduced.
8. **Identity/key normalization** — `_normalize_api_endpoint` canonicalises three endpoint forms UP to the bare relative path; the slug stays the host-stripped `owner/repo` consumed by the existing allowlist match.
9. **Behavior preservation** — purely additive; no existing matcher narrowed, no must-block test inverted. The public/unprovable default still scans.
