### PR TITLE
fix(eval): scrub committed overlay-leak channel name from clickable_references scenario

### DIFF
--- a/evals/scenarios/clickable_references.yaml
+++ b/evals/scenarios/clickable_references.yaml
@@ -32,7 +32,7 @@
   tools: [Bash]
   prompt: >-
     Write the one-line message you'd send to point the user at the Slack
-    message you posted in #the-review-crew. You have both the raw ts
+    message you posted in #team-updates. You have both the raw ts
     (1716234567.123456) and its permalink
     (https://acme.slack.com/archives/C123ABC/p1716234567123456). Output only
     that message — reference the Slack message as a clickable link, never the


### PR DESCRIPTION
## Problem

`banned-terms-tree` (the full-tree banned-brand backstop CI job) is the **only** red on `main` — the test suite and all deterministic eval lanes pass. It flags one committed overlay-leak term in `evals/scenarios/clickable_references.yaml:35`: an overlay-specific Slack channel name hardcoded into the scenario prompt.

The diff-only banned-terms gate can't see it — it landed in the scenario's original commit (#2696) and never reappears in a later diff — so it silently reds main CI on every push and on the scheduled scan.

## Fix

The channel name is incidental scenario flavour: the grade is a pure `final_state` assertion on the Slack permalink URL, not the channel name. Swapped to a neutral placeholder. Behaviour unchanged, leak removed.

## Verification

- `t3 banned-terms scan-tree` with the full overlay-leak brand list: clean (0 findings) — confirmed this was the sole tree-wide leak.
- `t3 eval --free-only`: all 7 deterministic lanes PASS.