### PR TITLE
fix(dream): tiered hot/cold memory index keeps MEMORY.md under the loadable budget (#2723)

### DIFF
--- a/src/teatree/loops/dream/cross_link.py
+++ b/src/teatree/loops/dream/cross_link.py
@@ -79,7 +79,7 @@ def _existing_links(text: str) -> frozenset[str]:
 def _load_memories(memory_dir: Path) -> list[_Memory]:
     memories: list[_Memory] = []
     for md in sorted(memory_dir.glob("*.md")):
-        if md.name == "MEMORY.md":
+        if md.name in {"MEMORY.md", "MEMORY_ARCHIVE.md"}:  # never cross-link an index (#2723)
             continue
         try:
             text = md.read_text(encoding="utf-8")

--- a/src/teatree/loops/dream/decay.py
+++ b/src/teatree/loops/dream/decay.py
@@ -32,6 +32,20 @@ mechanics stay pure and DB-free under test; the production default is
 ledger row by path membership in ``source_files`` OR by its name appearing in a
 ``durable_destination``.
 
+The SECOND tier — the BUDGET tier (#2723) — exists because the curated corpus has
+~294 must-preserve (user / BINDING) entries, MORE than the ~150-line hot-index load
+budget, and the ledger home-rail is structurally empty for hand-authored memories (it
+can never archive them). When the hot ``MEMORY.md`` is over budget the budget tier
+scores every file by :func:`_signal_score` (user / BINDING / inbound links / recency /
+type) and archives the LOWEST-signal first — only as many as it takes to bring the
+projected hot index back under budget — so the top ~150 by signal stay HOT and the rest
+move to a COLD tier: ``archive/`` holds the full restorable body and the cold
+``MEMORY_ARCHIVE.md`` index holds one signature line per archived entry. The cold index
+lives in the main memory dir (so the gate snapshot still finds the signature — retention
+stays green) but is NEVER re-indexed into the hot ``MEMORY.md``. A referenced file is
+never budget-archived; the universal "signature preserved in the cold index" rail
+replaces the old duplicate-only safety rail.
+
 PURE w.r.t. the real ``~/.claude``: the caller passes an explicit ``memory_dir``
 and a ``now``/``retention`` policy; tests pass a tmp fixture and a fixed clock.
 Fault-isolated: the command runs it in a try/except so a phase-6 failure never
@@ -49,33 +63,54 @@ from typing import cast
 #: regardless of references (a fresh lesson is never stale). Generous on purpose.
 DEFAULT_RETENTION_DAYS = 30
 
-#: Hard age ceiling for the BUDGET decay tier (#2723, Decision-2). When the index
-#: exceeds the load budget, a file older than this AND unreferenced AND whose
-#: lesson is captured by a near-duplicate survivor is archivable — INDEPENDENT of
-#: the (structurally-empty for the curated corpus) ledger home-rail.
-BUDGET_AGE_CEILING_DAYS = 90
-
 _ARCHIVE_DIRNAME = "archive"
 _INDEX_NAME = "MEMORY.md"
+#: The COLD archive index (#2723), written by this phase in the MAIN memory dir so the
+#: gate snapshot globs it as a memory body (an archived entry's signature stays findable
+#: there, keeping retention green) while it is NEVER re-indexed, cross-linked, or
+#: itself archived/merged — excluded alongside ``MEMORY.md`` in every loader.
+_ARCHIVE_INDEX_NAME = "MEMORY_ARCHIVE.md"
 _WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
 _FRONTMATTER_NAME_RE = re.compile(r"^name:\s*(\S+)\s*$", re.MULTILINE)
 #: A logical "lesson last-touched" frontmatter date — the age clock the budget tier
 #: reads so a cross-link / re-index rewrite (which bumps ``st_mtime``) does NOT reset
 #: the decay clock. Absent the field, the budget tier falls back to ``st_mtime``.
 _LESSON_UPDATED_RE = re.compile(r"^lesson_updated:\s*(\S+)\s*$", re.MULTILINE)
+#: Frontmatter ``type:`` (top-level or nested under ``metadata:``) — the memory's
+#: declared kind, used for the type-weight signal. ``node_type:`` never matches.
+_TYPE_LINE_RE = re.compile(r"^\s*type:\s*(\S+)\s*$", re.MULTILINE)
+
+#: The recognised memory types (filename prefix or frontmatter ``metadata.type``).
+_KNOWN_TYPES = frozenset({"user", "feedback", "retro", "reference", "project"})
+
+#: Additive signal weights for :func:`_signal_score` — higher means keep HOT. ``user``
+#: and BINDING dominate so they are archived only if the budget forces it; inbound
+#: ``[[name]]`` wikilinks and recency add the rest; a per-type floor breaks ties.
+_SIGNAL_USER = 1000
+_SIGNAL_BINDING = 500
+_SIGNAL_PER_INBOUND_LINK = 40
+_SIGNAL_RECENT = 200
+_TYPE_WEIGHTS = {"feedback": 90, "retro": 70, "reference": 30, "project": 20, "user": 10, "other": 10}
+
+#: Preamble of the cold ``MEMORY_ARCHIVE.md`` — kept machine-readable (one
+#: ``- <name>.md — <original signature>`` line per entry) for a future recall pass.
+_COLD_HEADER = (
+    "# Auto Memory — Cold Archive Index\n\n"
+    "> Low-signal memories archived out of the hot MEMORY.md to keep it under the "
+    "session-load budget. NOT loaded at session start; searchable here, full bodies "
+    "in archive/ (restorable). One line per entry: `- <name>.md — <original signature>`.\n\n"
+)
 
 
 @dataclass(frozen=True, slots=True)
 class BudgetTier:
-    """The on-disk RETIRE tier config (#2723) — opt in via :class:`DecayPolicy`.
+    """The on-disk RETIRE tier marker (#2723) — opt in via :class:`DecayPolicy`.
 
-    Bundles the budget tier's knobs. When supplied AND the index is over the load
-    budget, decay archives files older than ``age_ceiling_days`` (by the logical
-    lesson clock) that are unreferenced and whose lesson a near-duplicate survivor
-    captures.
+    When supplied AND the hot ``MEMORY.md`` is over the load budget, decay archives the
+    LOWEST-:func:`_signal_score` files first — just enough to bring the projected hot
+    index back under budget. The tier needs no knobs of its own: the freshness window
+    is :attr:`DecayPolicy.retention_days` and the budget is the gate-(d) constants.
     """
-
-    age_ceiling_days: int = BUDGET_AGE_CEILING_DAYS
 
 
 @dataclass(frozen=True, slots=True)
@@ -210,7 +245,7 @@ def _memory_name(path: Path, text: str) -> str:
 def _load_memory_files(memory_dir: Path) -> list[_MemoryFile]:
     files: list[_MemoryFile] = []
     for md in sorted(memory_dir.glob("*.md")):
-        if md.name == _INDEX_NAME:
+        if md.name in {_INDEX_NAME, _ARCHIVE_INDEX_NAME}:  # never load an index as a memory (#2723)
             continue
         try:
             text = md.read_text(encoding="utf-8")
@@ -271,63 +306,190 @@ def _stale_candidates(
         yield memory
 
 
-def _index_over_budget(index_text: str) -> bool:
-    """Whether the rendered ``MEMORY.md`` exceeds the gate-(d) session-load budget.
+def _over_budget(line_count: int, byte_size: int) -> bool:
+    """Whether an index of *line_count* non-blank lines / *byte_size* bytes is over budget.
 
-    Reuses the §4 budget constants so the decay-pressure trigger and the gate that
-    grades the result agree on what "over budget" means (#2723).
+    The one place the §4 gate-(d) budget constants are compared, so the decay-pressure
+    trigger and the gate that grades the result agree on "over budget" (#2723).
     """
     from teatree.loops.dream.gates import INDEX_BYTE_BUDGET, INDEX_LINE_BUDGET  # noqa: PLC0415
 
+    return byte_size > INDEX_BYTE_BUDGET or line_count > INDEX_LINE_BUDGET
+
+
+def _index_over_budget(index_text: str) -> bool:
+    """Whether the rendered ``MEMORY.md`` exceeds the gate-(d) session-load budget."""
     line_count = sum(1 for line in index_text.splitlines() if line.strip())
-    return len(index_text.encode("utf-8")) > INDEX_BYTE_BUDGET or line_count > INDEX_LINE_BUDGET
+    return _over_budget(line_count, len(index_text.encode("utf-8")))
 
 
-def _captured_elsewhere(memory: _MemoryFile, others: Sequence[_MemoryFile]) -> bool:
-    """Whether *memory*'s lesson is captured by a near-duplicate SURVIVOR.
+def _resolved_type(memory: _MemoryFile) -> str:
+    """The memory's type for the type-weight signal.
 
-    The budget tier's safety rail: a file is only archivable when another file
-    (which is NOT itself being archived this pass) records the same lesson — a
-    body-token near-duplicate above the merge floor. A genuinely UNIQUE lesson with
-    no twin is retained, even over budget. This is the content/duplication check the
-    plan mandates in place of the structurally-empty ``prunable()`` ledger join.
+    Frontmatter ``metadata.type`` when present and recognised, else the filename prefix
+    (``feedback_x`` -> ``feedback``), else ``other``. The ~96 older files with no
+    parseable ``metadata.type`` fall back to the prefix; deterministic and DB-free.
     """
-    from teatree.loops.dream.cross_link import _jaccard  # noqa: PLC0415
-    from teatree.loops.dream.merge import _NEAR_DUPLICATE_FLOOR, _body_tokens  # noqa: PLC0415
+    match = _TYPE_LINE_RE.search(memory.text)
+    if match:
+        candidate = match.group(1).strip().lower()
+        if candidate in _KNOWN_TYPES:
+            return candidate
+    prefix = memory.path.stem.split("_", 1)[0].lower()
+    return prefix if prefix in _KNOWN_TYPES else "other"
 
-    mine = _body_tokens(memory)
-    if not mine:
-        return False
-    return any(
-        other.path != memory.path and _jaccard(mine, _body_tokens(other)) >= _NEAR_DUPLICATE_FLOOR for other in others
-    )
+
+def _is_user_memory(memory: _MemoryFile) -> bool:
+    """True for a user-authored memory — frontmatter ``metadata.type: user`` OR a ``user_*`` filename."""
+    return _resolved_type(memory) == "user" or memory.path.name.lower().startswith("user_")
+
+
+def _is_binding_text(text: str) -> bool:
+    """True when the memory carries BINDING / Non-Negotiable doctrine (mirrors the engine weight)."""
+    lowered = text.lower()
+    return "binding" in lowered or "non-negotiable" in lowered
+
+
+def _inbound_link_counts(files: Sequence[_MemoryFile], index_text: str) -> dict[str, int]:
+    """Map each memory NAME to the number of distinct documents that ``[[name]]``-link it.
+
+    Counted in ONE pass (the index counts as one source, each other memory as one) so
+    the per-file inbound-wikilink signal is O(N), not an O(N²) rescan per memory.
+    """
+    counts: dict[str, int] = {}
+    for name in set(_WIKILINK_RE.findall(index_text)):
+        counts[name] = counts.get(name, 0) + 1
+    for source in files:
+        for name in set(_WIKILINK_RE.findall(source.text)):
+            if name == source.name:
+                continue  # a memory linking itself is not an inbound reference
+            counts[name] = counts.get(name, 0) + 1
+    return counts
+
+
+def _recency_score(memory: _MemoryFile, now: datetime, retention: timedelta) -> int:
+    """Recency signal — +200 within the retention window, decaying linearly past it.
+
+    Floored at 0. Reads the logical ``lesson_touched`` clock so a cross-link / re-index
+    rewrite (which bumps ``st_mtime``) does not reset recency.
+    """
+    age = now - memory.lesson_touched
+    if age <= retention:
+        return _SIGNAL_RECENT
+    return max(0, _SIGNAL_RECENT - (age - retention).days)
+
+
+def _signal_score(memory: _MemoryFile, *, inbound_links: int, now: datetime, retention: timedelta) -> int:
+    """The keep-HOT signal of a memory — higher means more worth keeping in ``MEMORY.md``.
+
+    Composed ADDITIVELY (never short-circuits) from the signals that mark a lesson
+    load-bearing: a user-authored memory (+1000), BINDING / Non-Negotiable doctrine
+    (+500), each inbound ``[[name]]`` wikilink (+40, *inbound_links* precomputed by the
+    caller via :func:`_inbound_link_counts` so scoring the whole set stays O(N)), recency
+    by the logical ``lesson_touched`` clock (+200 within *retention*, decaying linearly
+    with age beyond it), and a per-type floor (feedback 90 / retro 70 / reference 30 /
+    project 20 / other 10). The budget tier archives LOWEST score first, so the
+    highest-signal memories stay hot and user / BINDING entries are archived only if the
+    budget forces it. DB-free and deterministic — usable under ``SimpleTestCase``.
+    """
+    score = _SIGNAL_USER if _is_user_memory(memory) else 0
+    if _is_binding_text(memory.text):
+        score += _SIGNAL_BINDING
+    score += _SIGNAL_PER_INBOUND_LINK * inbound_links
+    score += _recency_score(memory, now, retention)
+    score += _TYPE_WEIGHTS.get(_resolved_type(memory), _TYPE_WEIGHTS["other"])
+    return score
 
 
 def _budget_tier_candidates(
-    files: Sequence[_MemoryFile], index_text: str, now: datetime, ceiling: timedelta
+    files: Sequence[_MemoryFile], index_text: str, now: datetime, retention: timedelta
 ) -> Iterable[_MemoryFile]:
-    """Yield budget-tier archival candidates: old AND unreferenced AND captured elsewhere.
+    """Yield budget-tier archival candidates lowest-signal first, just enough to fit budget.
 
-    Fires ONLY when the index is over budget. A candidate's lesson age reads the
-    logical ``lesson_touched`` clock (not ``st_mtime``), it must be unreferenced, and
-    its lesson must be captured by a near-duplicate survivor — never a unique lesson.
-    Candidates are removed from the survivor pool greedily so two twins do not both
-    archive each other away (one always survives).
+    Fires only when the live ``MEMORY.md`` is over budget. Each file is scored by
+    :func:`_signal_score` and the lowest-signal files are archived first; a referenced
+    file (a live consumer still ``[[link]]``s it) is never archived. After each removal
+    the survivor set's PROJECTED index — rendered exactly as the re-index will render it —
+    is re-measured, and the walk STOPS as soon as it is under both the line and byte
+    budgets, so the MINIMUM number of (lowest-signal) files is archived and as much
+    high-signal memory as fits stays hot. user / BINDING entries score highest and are
+    archived only if the budget forces it — their full body is archived (restorable) and
+    their signature is preserved in the cold ``MEMORY_ARCHIVE.md``.
     """
     if not _index_over_budget(index_text):
         return
-    cutoff = now - ceiling
-    survivors = list(files)
-    for memory in sorted(files, key=lambda m: m.lesson_touched):
-        if memory.lesson_touched >= cutoff:
-            continue  # lesson recently touched — retained
+    from teatree.loops.dream import reindex  # noqa: PLC0415
+
+    inbound = _inbound_link_counts(files, index_text)
+    ordered = sorted(
+        files, key=lambda m: _signal_score(m, inbound_links=inbound.get(m.name, 0), now=now, retention=retention)
+    )
+    line_bytes = {m.path: len(reindex.index_line_for(m.path.name, m.text).encode("utf-8")) for m in files}
+    header = reindex.render_index_lines([])
+    header_bytes = len(header.encode("utf-8"))
+    header_lines = sum(1 for line in header.splitlines() if line.strip())
+    survivor_count = len(files)
+    survivor_bytes = sum(line_bytes.values())
+    for memory in ordered:
+        # projected_bytes == len(render_index_lines(survivor lines).encode()) — exact for any
+        # count (the per-line "\n" join + trailing newline total ``survivor_count`` bytes).
+        projected_bytes = header_bytes + survivor_bytes + survivor_count
+        if not _over_budget(header_lines + survivor_count, projected_bytes):
+            break  # projected survivor index is back under budget — archive no more
         if _is_referenced(memory, files, index_text):
-            continue  # referenced — retained
-        remaining = [m for m in survivors if m.path != memory.path]
-        if not _captured_elsewhere(memory, remaining):
-            continue  # unique lesson with no twin — retained (captured-elsewhere rail)
-        survivors = remaining
+            continue  # referenced — retained (a live consumer still links it)
+        survivor_count -= 1
+        survivor_bytes -= line_bytes[memory.path]
         yield memory
+
+
+def _strip_provenance(text: str) -> str:
+    """Drop the leading ``<!-- archived by dream decay ... -->`` provenance line.
+
+    So the cold-index signature is computed from the ORIGINAL body (matching the
+    retention probe, which lifts its signature from the pre-archival text).
+    """
+    if text.startswith("<!--"):
+        _comment, marker, rest = text.partition("-->\n")
+        if marker:
+            return rest
+    return text
+
+
+def _cold_index_line(archived_md: Path) -> str:
+    """One ``- <name>.md — <original signature>`` cold-index line for an archived file.
+
+    The signature is computed from the original body (provenance header stripped) with
+    the SAME helper the retention gate uses, so ``snapshot.contains(signature)`` is True
+    for the archived entry — its lesson stays answerable from the cold index. Uncapped:
+    the verbatim signature is what retention needs.
+    """
+    from teatree.loops.dream.gates import _signature_line  # noqa: PLC0415
+
+    try:
+        text = archived_md.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    signature = _signature_line(_strip_provenance(text))
+    return f"- {archived_md.name} — {signature}" if signature else f"- {archived_md.name}"
+
+
+def _rebuild_cold_index(memory_dir: Path, archive_dir: Path) -> None:
+    """Rebuild the cold ``MEMORY_ARCHIVE.md`` from EVERY file under ``archive/``.
+
+    One line per archived entry, carrying its full unclipped original signature. Rebuilt
+    wholesale each pass (idempotent) so the cold tier accumulates across passes and a
+    second pass rewrites it byte-identically. Written in the MAIN memory dir so the gate
+    snapshot globs it as a memory body, keeping the retention / interference gates green
+    for archived entries; it is excluded from every re-index / cross-link / decay loader,
+    so it never re-bloats the hot index. A no-op when nothing has been archived.
+    """
+    if not archive_dir.is_dir():
+        return
+    lines = [line for md in sorted(archive_dir.glob("*.md")) if (line := _cold_index_line(md))]
+    if not lines:
+        return
+    (memory_dir / _ARCHIVE_INDEX_NAME).write_text(_COLD_HEADER + "\n".join(lines) + "\n", encoding="utf-8")
 
 
 def decay_memories(
@@ -355,11 +517,14 @@ def decay_memories(
     *policy* bundles the freshness window and the optional budget tier. A
     :class:`DecayPolicy` with a :class:`BudgetTier` opts into a SECOND,
     ledger-INDEPENDENT decay tier (#2723) for the hand-authored corpus the empty
-    ``prunable()`` join can never reach: when the index is over the load budget,
-    decay ALSO archives files older than the tier's ``age_ceiling_days`` (by the
-    logical ``lesson_touched`` clock) that are unreferenced AND whose lesson a
-    near-duplicate survivor captures. The default policy (no budget tier) leaves the
-    ledger-home tier alone — byte-identical to before.
+    ``prunable()`` join can never reach: when the hot ``MEMORY.md`` is over the load
+    budget, decay ALSO archives the LOWEST-:func:`_signal_score` files first — just
+    enough to bring the projected hot index back under budget. The default policy (no
+    budget tier) leaves the ledger-home tier alone — byte-identical to before.
+
+    Whichever tier fires, the cold ``MEMORY_ARCHIVE.md`` is rebuilt from ``archive/`` so
+    every archived entry's signature stays findable (retention-safe) while its full body
+    remains in ``archive/`` (restorable).
     """
     settings = policy or DecayPolicy()
     moment = now or datetime.now(tz=UTC)
@@ -380,17 +545,12 @@ def decay_memories(
     if settings.budget_tier is not None:
         homed_paths = {m.path for m in home_tier}
         remaining = [m for m in files if m.path not in homed_paths]
-        ceiling = timedelta(days=settings.budget_tier.age_ceiling_days)
         archived.extend(
-            _archive_one(
-                memory,
-                archive_dir,
-                moment,
-                reason="over-budget, stale, unreferenced, captured elsewhere",
-                dry_run=dry_run,
-            )
-            for memory in _budget_tier_candidates(remaining, index_text, moment, ceiling)
+            _archive_one(memory, archive_dir, moment, reason="over-budget, lowest-signal", dry_run=dry_run)
+            for memory in _budget_tier_candidates(remaining, index_text, moment, retention)
         )
+    if not dry_run:
+        _rebuild_cold_index(memory_dir, archive_dir)
     return DecayResult(
         seen=len(files),
         archived=tuple(archived),
@@ -400,7 +560,6 @@ def decay_memories(
 
 
 __all__ = [
-    "BUDGET_AGE_CEILING_DAYS",
     "DEFAULT_RETENTION_DAYS",
     "ArchivedMemory",
     "BudgetTier",

--- a/src/teatree/loops/dream/gates.py
+++ b/src/teatree/loops/dream/gates.py
@@ -47,7 +47,7 @@ the run attempted-not-succeeded (staleness keeps firing).
 
 import hashlib
 import re
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Container, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -187,15 +187,16 @@ def _normalize(text: str) -> str:
     return " ".join(text.split()).lower()
 
 
-def _line_targets_live_memory(line: str, snapshot: MemorySnapshot) -> bool:
-    """Whether a pruned index *line* still points at a memory file present after the pass.
+def _line_targets(line: str, names: Container[str]) -> bool:
+    """Whether a pruned index *line*'s leading ``.md`` pointer is one of *names*.
 
-    The re-index phase rewrites an index line whenever a curated summary is
-    clipped/reworded — the line TEXT changes but the pointer (and its memory
-    file) survives. Such a line is NOT a lost lesson, so it must count as homed;
-    only a pointer to a memory that actually vanished stays unhomed.
+    The shared homing test — a pruned line is NOT a lost lesson when its pointer targets a
+    memory still present after the pass (re-index merely reworded the summary) OR a file
+    archived this pass (a restorable durable home in ``archive/`` + the cold
+    ``MEMORY_ARCHIVE.md``, #2723, resolving the #2546 transfer-before-prune tension). Keys
+    on the line-leading pointer only, never a ``.md`` token in the free-text summary.
     """
-    return any(ref in snapshot.memories for ref in _MEMORY_REF_RE.findall(line))
+    return any(ref in names for ref in _MEMORY_REF_RE.findall(line))
 
 
 def snapshot_memory_dir(memory_dir: Path) -> MemorySnapshot:
@@ -341,7 +342,7 @@ class Gate:
         unhomed = sorted(
             line
             for line in pruned_lines
-            if line not in homed_index_lines and not _line_targets_live_memory(line, snapshot_after)
+            if line not in homed_index_lines and not _line_targets(line, snapshot_after.memories)
         )
         consolidated = size_reduced or schema_grew or distilled or maintenance_performed
         passed = consolidated and not unhomed
@@ -524,7 +525,8 @@ def run_acceptance_pass(  # noqa: PLR0913 — kwargs-only §4 pass inputs; the c
     BEFORE snapshot, reads the recorded prior-session pass-rate as the monotonicity
     / interference baseline, computes the durable-home set for the consolidation
     gate as the pruned index lines whose lesson is still findable in the AFTER
-    snapshot (transfer-before-prune), threads the caller's *maintenance_performed*
+    snapshot (transfer-before-prune) OR whose pointer targets a file archived this
+    pass (a restorable durable home, #2723), threads the caller's *maintenance_performed*
     signal (file-side phases did real cross-link / re-index / decay work) into the
     consolidation gate so a quiet 0-cluster maintenance pass still counts as
     consolidation, runs all seven gates, and — unless *persist* is
@@ -539,7 +541,8 @@ def run_acceptance_pass(  # noqa: PLR0913 — kwargs-only §4 pass inputs; the c
     prior_rate, had_prior = _prior_pass_rate(overlay)
     now_rate = _pass_rate(probes, snapshot_after, None)
     pruned_lines = snapshot_before.index_lines - snapshot_after.index_lines
-    homed_index_lines = {line for line in pruned_lines if snapshot_after.contains(line)}
+    archived_names = {a.source.name for a in archived}
+    homed_index_lines = {ln for ln in pruned_lines if snapshot_after.contains(ln) or _line_targets(ln, archived_names)}
     remediations = compliance_remediations if compliance_remediations is not None else _compliance_remediations(overlay)
     report = evaluate_gates(
         snapshot_before=snapshot_before,

--- a/src/teatree/loops/dream/phase_runner.py
+++ b/src/teatree/loops/dream/phase_runner.py
@@ -153,8 +153,9 @@ class MemoryPhaseRunner:
         """Run phase-6 decay per dir under fault isolation, returning its summary + archives.
 
         The budget tier is enabled (#2723): when ``MEMORY.md`` is over the load budget,
-        decay ALSO archives old, unreferenced, duplicated files the (empty) ledger
-        home-rail can never reach — the reachable on-disk RETIRE for the curated corpus.
+        decay ALSO archives the LOWEST-signal files the (empty) ledger home-rail can never
+        reach — the reachable on-disk RETIRE for the curated corpus, just enough to bring
+        the hot index back under budget while their signatures persist in MEMORY_ARCHIVE.md.
         """
         from teatree.loops.dream import decay  # noqa: PLC0415
         from teatree.loops.dream.loop import decay_enabled  # noqa: PLC0415

--- a/src/teatree/loops/dream/reindex.py
+++ b/src/teatree/loops/dream/reindex.py
@@ -23,16 +23,23 @@ pins. It NEVER touches the real ``~/.claude``: the caller passes an explicit
 """
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 
 _INDEX_NAME = "MEMORY.md"
 
+#: The COLD archive index (#2723), written by the decay phase in the MAIN memory dir.
+#: It is NEVER re-indexed into the hot ``MEMORY.md`` — excluded here exactly like the
+#: hot index — so its one-line-per-archived-entry signatures do not re-bloat the index.
+_ARCHIVE_INDEX_NAME = "MEMORY_ARCHIVE.md"
+
 #: Per-summary clip and per-line cap (#2723). The summary is clipped first; the
-#: whole line is then capped so a long filename plus a long summary can never
-#: blow the per-line budget. Sized so ~150 lines fit the ~24 KB index budget.
-_SUMMARY_MAX_CHARS = 120
-_LINE_MAX_CHARS = 160
+#: whole line is then capped so a long filename plus a long summary can never blow
+#: the per-line budget. Sized so even a long-filename line fits 140 chars and ~150
+#: such lines stay under the ~24 KB session-load budget gate (d) enforces.
+_SUMMARY_MAX_CHARS = 110
+_LINE_MAX_CHARS = 140
 
 _HEADER = (
     "# Auto Memory — Index\n\n"
@@ -95,26 +102,46 @@ def _index_line(md: Path, summary: str) -> str:
     return f"- {md.name} — {summary[:keep].rstrip()}…"
 
 
+def index_line_for(name: str, text: str) -> str:
+    """The single ``MEMORY.md`` index line for one memory — the pure per-file renderer.
+
+    Exposed so the decay phase can PROJECT the post-archival index byte-for-byte the
+    way the re-index will render it (#2723), keeping the budget-tier stop condition
+    exact w.r.t. the gate-(d) line / byte budget.
+    """
+    return _index_line(Path(name), _summary_for(text))
+
+
+def render_index_lines(lines: Iterable[str]) -> str:
+    """Wrap already-rendered per-memory index *lines* with the standard preamble.
+
+    The pure tail of :func:`render_index`, exposed so the decay phase can render the
+    projected (post-archival) index exactly as it will be written.
+    """
+    body = "\n".join(lines)
+    return f"{_HEADER}{body}\n" if body else _HEADER
+
+
 def render_index(memory_dir: Path) -> str:
     """Render the full ``MEMORY.md`` text for the current memory set (deterministic).
 
     Lines are deduped by filename and stably ordered (filename sort), so the
     output is a pure function of the memory set's content — a re-run with no
-    changes renders the identical string.
+    changes renders the identical string. Both the hot ``MEMORY.md`` and the cold
+    ``MEMORY_ARCHIVE.md`` are excluded so neither index re-bloats the hot index.
     """
     seen: set[str] = set()
     lines: list[str] = []
     for md in sorted(memory_dir.glob("*.md")):
-        if md.name == _INDEX_NAME or md.name in seen:
+        if md.name in {_INDEX_NAME, _ARCHIVE_INDEX_NAME} or md.name in seen:
             continue
         seen.add(md.name)
         try:
             text = md.read_text(encoding="utf-8")
         except OSError:
             continue
-        lines.append(_index_line(md, _summary_for(text)))
-    body = "\n".join(lines)
-    return f"{_HEADER}{body}\n" if body else _HEADER
+        lines.append(index_line_for(md.name, text))
+    return render_index_lines(lines)
 
 
 def reindex_memory(memory_dir: Path, *, dry_run: bool = False) -> ReindexResult:
@@ -140,4 +167,4 @@ def _count_lines(rendered: str) -> int:
     return sum(1 for line in rendered.splitlines() if line.startswith("- "))
 
 
-__all__ = ["ReindexResult", "reindex_memory", "render_index"]
+__all__ = ["ReindexResult", "index_line_for", "reindex_memory", "render_index", "render_index_lines"]

--- a/tests/teatree_loops/dream/test_decay.py
+++ b/tests/teatree_loops/dream/test_decay.py
@@ -25,7 +25,7 @@ transfer-before-prune rail (the DB-backed default resolver) has its own
 import hashlib
 import os
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
@@ -33,7 +33,7 @@ from unittest.mock import patch
 from django.test import SimpleTestCase, TestCase
 
 from teatree.core.models import ConsolidatedMemory
-from teatree.loops.dream import decay
+from teatree.loops.dream import decay, gates, reindex
 from teatree.loops.dream.decay import BudgetTier, DecayPolicy, _MemoryFile, decay_memories, ledger_durable_home_resolver
 
 _NOW = datetime(2026, 6, 16, 12, tzinfo=UTC)
@@ -273,152 +273,370 @@ class TransferBeforePruneRailTestCase(TestCase):
         assert ledger_durable_home_resolver()(probe) is True
 
 
-_BIG_TOPIC = (
-    "the worktree provision lease pid-anchored claim guard rejects an empty owner "
-    "liveness probe session heartbeat expiry compare-and-swap concurrent acquire "
-    "release reaper stale lease ttl budget seconds owner token isolation deadlock"
-)
-
-
 class BudgetDecayTierTestCase(SimpleTestCase):
-    """The age+budget decay tier, INDEPENDENT of the empty ledger home-rail (#2723).
+    """The SCORED budget-tier RETIRE, INDEPENDENT of the empty ledger home-rail (#2723).
 
     The ledger home-rail (``prunable()``) is structurally empty for the hand-authored
     corpus (0 rows reference on-disk memories), so it can never archive the bloating
-    files. This tier fires only when ``MEMORY.md`` exceeds the load budget and
-    archives the oldest files that are (a) older than a hard ceiling (90d), (b)
-    unreferenced, and (c) whose lesson is CAPTURED ELSEWHERE (a near-duplicate
-    survivor exists) — a content/duplication check, NOT the empty ledger join. The
-    age clock reads a logical ``lesson_updated`` frontmatter timestamp so cross-link /
-    re-index rewrites do not reset it.
+    files. This tier fires only when ``MEMORY.md`` is over the session-load budget and
+    then archives the LOWEST-:func:`~decay._signal_score` files first — just enough to
+    bring the projected hot index back under budget. A user / BINDING entry scores
+    highest and is archived only if the budget forces it; a referenced file is never
+    archived; every archived entry keeps its full signature in the cold
+    ``MEMORY_ARCHIVE.md`` (restorable). Exercised DB-free with a no-ledger-home resolver.
     """
 
     def setUp(self) -> None:
         self.dir = Path(self.enterContext(tempfile.TemporaryDirectory()))
 
-    def _decay(self, *, budget_tier: bool = False) -> decay.DecayResult:
+    def _decay(self, *, budget_tier: bool = True, retention_days: int = 30) -> decay.DecayResult:
         # Inject a no-ledger-home resolver so the budget tier is exercised in
         # isolation from the (DB-backed) ledger home-rail — this stays DB-free.
         return decay_memories(
             self.dir,
             now=_NOW,
             has_durable_home=lambda _m: False,
-            policy=_policy(budget_tier=budget_tier),
+            policy=_policy(retention_days=retention_days, budget_tier=budget_tier),
         )
 
-    def _write(self, name: str, body: str, *, age_days: int, lesson_updated: str | None = None) -> Path:
+    def _write(
+        self, name: str, body: str, *, age_days: int = 120, mtype: str = "feedback", lesson_updated: str | None = None
+    ) -> Path:
+        # A BINDING fixture just prepends "BINDING " to *body* (no separate kwarg).
         path = self.dir / f"{name}.md"
-        front = f"---\nname: {name}\ntype: feedback\n"
+        front = f"---\nname: {name}\n"
         if lesson_updated is not None:
             front += f"lesson_updated: {lesson_updated}\n"
-        front += "---\n"
-        path.write_text(f"{front}{body}\n", encoding="utf-8")
+        front += f"metadata:\n  type: {mtype}\n---\n"
+        path.write_text(f"{front}\n{body}\n", encoding="utf-8")
         ts = (_NOW - timedelta(days=age_days)).timestamp()
         os.utime(path, (ts, ts))
         return path
 
-    def _write_over_budget_index(self, count: int) -> None:
-        lines = "".join(
-            f"- mem_{i:04d}.md — a summary that fills the index past the load budget {i}\n" for i in range(count)
-        )
-        (self.dir / "MEMORY.md").write_text(f"# index\n{lines}", encoding="utf-8")
+    def _seed_low_signal(self, count: int, *, age_days: int = 120) -> None:
+        """Seed *count* genuinely-UNIQUE, unreferenced, stale, low-signal feedback files.
 
-    def test_over_budget_archives_old_unreferenced_duplicated_files(self) -> None:
-        # MEMORY.md is over budget AND two >90d unreferenced near-duplicates exist:
-        # the budget tier archives the duplicate (its lesson is captured by the twin).
-        self._write("feedback_dup_keep", _BIG_TOPIC + " KEEP", age_days=120)
-        archived_target = self._write("feedback_dup_drop", _BIG_TOPIC + " DROP", age_days=120)
-        self._write_over_budget_index(2000)
+        The bodies carry per-file keyword tokens so no two are near-duplicates — the
+        OLD captured-elsewhere rail would retain every one (RED), the NEW signal-scored
+        tier archives the lowest until under budget (GREEN).
+        """
+        for i in range(count):
+            self._write(
+                f"feedback_filler_{i:04d}",
+                f"lesson keyword{i:04d}alpha keyword{i:04d}beta about a niche low-signal note",
+                age_days=age_days,
+            )
+
+    def _seed_index(self) -> None:
+        """Write MEMORY.md as the real rendered index of the current files (over budget when many)."""
+        (self.dir / "MEMORY.md").write_text(reindex.render_index(self.dir), encoding="utf-8")
+
+    def _rendered_line_count(self) -> int:
+        return sum(1 for line in reindex.render_index(self.dir).splitlines() if line.strip())
+
+    @staticmethod
+    def _archived_sources(result: decay.DecayResult) -> set[str]:
+        return {a.source.name for a in result.archived}
+
+    def test_over_budget_archives_lowest_signal_unique_entries_until_under_budget(self) -> None:
+        # M unique low-signal feedback files older than the retention window + an
+        # over-budget MEMORY.md: the budget tier archives the lowest-signal ones until
+        # the projected survivor index is back under budget. (RED before the fix —
+        # captured-elsewhere retained every unique file.)
+        self._seed_low_signal(160)
+        self._seed_index()  # 162-line index -> over the 150-line budget
         result = self._decay(budget_tier=True)
-        assert result.archived_count >= 1
-        # The duplicated file is archived (moved, never deleted), its twin survives.
-        assert any(a.name == "feedback_dup_drop" for a in result.archived)
-        assert not archived_target.exists()
-        assert (self.dir / "archive" / "feedback_dup_drop.md").is_file()
-        assert (self.dir / "feedback_dup_keep.md").exists()
+        assert result.archived_count > 0
+        assert self._rendered_line_count() <= gates.INDEX_LINE_BUDGET
+        for archived in result.archived:
+            assert (self.dir / "archive" / archived.source.name).is_file()  # moved, not deleted
+            assert not (self.dir / archived.source.name).exists()
+
+    def test_binding_and_user_entries_are_archived_last(self) -> None:
+        # A mix of BINDING / user with low-signal stale, over budget: only the
+        # low-signal filler is archived; the BINDING + user entries survive.
+        self._seed_low_signal(160)
+        keep_binding = self._write("feedback_binding_doctrine", "BINDING the load-bearing doctrine")
+        keep_user = self._write("user_editor_preference", "the user's own editor preference", mtype="user")
+        self._seed_index()
+        result = self._decay(budget_tier=True)
+        archived = self._archived_sources(result)
+        assert keep_binding.name not in archived
+        assert keep_user.name not in archived
+        assert keep_binding.exists()
+        assert keep_user.exists()
+        assert any(name.startswith("feedback_filler") for name in archived)
+
+    def test_archived_entry_is_restorable_with_provenance(self) -> None:
+        self._seed_low_signal(160)
+        self._seed_index()
+        result = self._decay(budget_tier=True)
+        assert result.archived
+        for archived in result.archived:
+            assert archived.destination.is_file()
+            text = archived.destination.read_text(encoding="utf-8")
+            assert "archived by dream decay" in text  # provenance header
+            assert not archived.source.exists()  # original gone (moved, not copied)
+
+    def test_unique_lowest_signal_lesson_is_archived_when_over_budget_with_signature_preserved(self) -> None:
+        # The OLD captured-elsewhere rail RETAINED a unique lesson with no twin; the NEW
+        # universal rail ARCHIVES it (over budget, lowest signal) because its full
+        # signature survives in the cold MEMORY_ARCHIVE.md — a stronger durable home.
+        self._seed_low_signal(159)
+        unique = self._write(
+            "feedback_unique_lowsig", "a genuinely unique low-signal lesson with no twin anywhere", age_days=200
+        )
+        self._seed_index()
+        result = self._decay(budget_tier=True)
+        assert unique.name in self._archived_sources(result)
+        assert not unique.exists()
+        cold = (self.dir / "MEMORY_ARCHIVE.md").read_text(encoding="utf-8")
+        assert "feedback_unique_lowsig.md" in cold
+        assert "a genuinely unique low-signal lesson with no twin anywhere" in cold
+
+    def test_cold_index_signature_is_uncapped(self) -> None:
+        # The cold MEMORY_ARCHIVE.md keeps the FULL signature (uncapped) — retention
+        # needs the verbatim line — even though the hot index clips lines to 140.
+        long_sig = "a long unique low-signal lesson that exceeds the hot per-line cap " + "x" * 200
+        self._seed_low_signal(159)
+        long_file = self._write("feedback_long_signature", long_sig, age_days=300)
+        self._seed_index()
+        result = self._decay(budget_tier=True)
+        assert long_file.name in self._archived_sources(result)
+        cold = (self.dir / "MEMORY_ARCHIVE.md").read_text(encoding="utf-8")
+        cold_line = next(line for line in cold.splitlines() if line.startswith("- feedback_long_signature.md"))
+        assert len(cold_line) > reindex._LINE_MAX_CHARS  # uncapped, unlike the hot index
+        assert long_sig in cold_line
 
     def test_nothing_archived_while_under_budget(self) -> None:
-        # The SAME old, unreferenced, duplicated files — but the index is small, so
-        # the budget tier does NOT fire (no pressure, nothing archived).
-        self._write("feedback_dup_keep", _BIG_TOPIC + " KEEP", age_days=120)
-        self._write("feedback_dup_drop", _BIG_TOPIC + " DROP", age_days=120)
-        (self.dir / "MEMORY.md").write_text(
-            "# index\n- feedback_dup_keep.md — a\n- feedback_dup_drop.md — b\n", encoding="utf-8"
-        )
+        # A handful of files + a small index: the tier does not fire (no pressure).
+        self._seed_low_signal(3)
+        self._seed_index()
         result = self._decay(budget_tier=True)
         assert result.archived_count == 0
 
     def test_budget_tier_off_by_default_archives_nothing(self) -> None:
-        # Without budget_tier=True the new tier never fires (no behaviour change to
-        # the existing ledger-home decay path).
-        self._write("feedback_dup_keep", _BIG_TOPIC + " KEEP", age_days=120)
-        self._write("feedback_dup_drop", _BIG_TOPIC + " DROP", age_days=120)
-        self._write_over_budget_index(2000)
-        result = self._decay()
+        # Without budget_tier the new tier never fires (no behaviour change to the
+        # existing ledger-home decay path).
+        self._seed_low_signal(160)
+        self._seed_index()
+        result = self._decay(budget_tier=False)
         assert result.archived_count == 0
 
     def test_recently_touched_lesson_is_retained_even_over_budget(self) -> None:
-        # The age clock reads the logical lesson_updated frontmatter, not st_mtime:
-        # a file whose st_mtime is old (a cross-link rewrite bumped it long ago) but
-        # whose lesson_updated is recent is RETAINED — the lesson is fresh.
-        self._write("feedback_dup_keep", _BIG_TOPIC + " KEEP", age_days=120)
+        # The recency signal reads the logical lesson_updated clock, not st_mtime: an
+        # old-mtime file whose lesson was just updated scores high -> archived last.
+        self._seed_low_signal(160)
         recent = (_NOW - timedelta(days=5)).date().isoformat()
-        self._write("feedback_dup_fresh", _BIG_TOPIC + " FRESH", age_days=120, lesson_updated=recent)
-        self._write_over_budget_index(2000)
+        fresh = self._write("feedback_fresh_lesson", "a freshly updated lesson", age_days=300, lesson_updated=recent)
+        self._seed_index()
         result = self._decay(budget_tier=True)
-        # The fresh-lesson file is never archived despite being over budget + old mtime.
-        assert "feedback_dup_fresh" not in {a.name for a in result.archived}
-        assert (self.dir / "feedback_dup_fresh.md").exists()
+        assert fresh.name not in self._archived_sources(result)
+        assert fresh.exists()
 
     def test_referenced_file_is_retained_even_over_budget(self) -> None:
-        # A file the index/another memory [[link]]s is retained even over budget.
-        self._write("feedback_dup_keep", _BIG_TOPIC + " KEEP", age_days=120)
-        self._write("feedback_dup_drop", _BIG_TOPIC + " DROP", age_days=120)
-        # mem_other links feedback_dup_drop -> referenced -> retained.
-        self._write("feedback_other", f"see [[feedback_dup_drop]] for detail {_BIG_TOPIC}", age_days=1)
-        self._write_over_budget_index(2000)
+        # A file another memory [[link]]s is never archived even when low-signal + over budget.
+        self._seed_low_signal(160)
+        target = self._write("feedback_referenced", "an old but referenced lesson", age_days=400)
+        self._write("feedback_linker", "see [[feedback_referenced]] for the detail", age_days=1)
+        self._seed_index()
         result = self._decay(budget_tier=True)
-        assert "feedback_dup_drop" not in {a.name for a in result.archived}
-
-    def test_unique_lesson_not_captured_elsewhere_is_retained(self) -> None:
-        # An old, unreferenced file over budget whose lesson is UNIQUE (no
-        # near-duplicate survivor) is RETAINED — captured-elsewhere is the safety rail.
-        self._write("feedback_unique", _BIG_TOPIC + " a genuinely unique lesson", age_days=120)
-        self._write(
-            "feedback_other_topic",
-            "slack notify thread timestamp channel speak tts message digest receipt reaction emoji broadcast outcome",
-            age_days=120,
-        )
-        self._write_over_budget_index(2000)
-        result = self._decay(budget_tier=True)
-        assert result.archived_count == 0  # no near-duplicate survivor -> nothing safe to archive
+        assert target.name not in self._archived_sources(result)
+        assert target.exists()
 
     def test_malformed_lesson_updated_falls_back_to_mtime(self) -> None:
-        # A garbage lesson_updated value falls back to the old st_mtime, so the
-        # file is still treated as old and archivable.
-        self._write("feedback_dup_keep", _BIG_TOPIC + " KEEP", age_days=120)
-        self._write("feedback_dup_drop", _BIG_TOPIC + " DROP", age_days=120, lesson_updated="not-a-date")
-        self._write_over_budget_index(2000)
+        # A garbage lesson_updated value falls back to st_mtime -> low recency -> archivable.
+        self._seed_low_signal(160)
+        bad = self._write(
+            "feedback_bad_date", "a lesson with a garbage clock", age_days=300, lesson_updated="not-a-date"
+        )
+        self._seed_index()
         result = self._decay(budget_tier=True)
-        assert result.archived_count >= 1
-
-    def test_token_less_lesson_is_never_captured_elsewhere(self) -> None:
-        # A file whose body is all stopwords has an empty token set -> it can never
-        # be "captured elsewhere", so it is retained (never archived) over budget.
-        self._write("feedback_empty", "a an the to of in on at is it by", age_days=120)
-        self._write("feedback_other", _BIG_TOPIC + " a lesson", age_days=120)
-        self._write_over_budget_index(2000)
-        result = self._decay(budget_tier=True)
-        assert "feedback_empty" not in {a.name for a in result.archived}
+        assert bad.name in self._archived_sources(result)
 
     def test_budget_tier_has_teeth(self) -> None:
-        # Teeth: the SAME over-budget + old + duplicated file IS retained when the
-        # tier is off, and archived when on — a vacuous tier would behave identically.
-        self._write("feedback_dup_keep", _BIG_TOPIC + " KEEP", age_days=120)
-        self._write("feedback_dup_drop", _BIG_TOPIC + " DROP", age_days=120)
-        self._write_over_budget_index(2000)
+        # Teeth: the SAME over-budget corpus archives nothing with the tier off and
+        # something with it on — a vacuous tier would behave identically.
+        self._seed_low_signal(160)
+        self._seed_index()
         off = self._decay(budget_tier=False)
         assert off.archived_count == 0, "tier off must archive nothing"
-        # Re-write the files (the off run did not move them) for the on run.
         on = self._decay(budget_tier=True)
-        assert on.archived_count >= 1, "tier on must archive the duplicated file"
+        assert on.archived_count > 0, "tier on must archive the lowest-signal files"
+
+    def test_referenced_files_are_never_archived_even_when_budget_cannot_be_met(self) -> None:
+        # A hub links every filler, so the filler are all referenced (inviolable). Even
+        # over budget the tier archives ONLY the unreferenced hub and exhausts its walk
+        # without touching a referenced file — references win over the budget.
+        self._seed_low_signal(160)
+        links = " ".join(f"[[feedback_filler_{i:04d}]]" for i in range(160))
+        self._write("feedback_hub", f"a hub that links everything {links}", age_days=400)
+        self._seed_index()
+        result = self._decay(budget_tier=True)
+        archived = self._archived_sources(result)
+        assert "feedback_hub.md" in archived  # the unreferenced hub is archivable
+        assert not any(name.startswith("feedback_filler") for name in archived)  # every referenced file survives
+
+
+class SignalScoreTestCase(SimpleTestCase):
+    """Unit coverage of the pure signal-score / cold-index helpers (#2723) — DB-free."""
+
+    @staticmethod
+    def _mem(name: str, text: str, *, age_days: int = 0) -> _MemoryFile:
+        return _MemoryFile(path=Path(f"{name}.md"), name=name, text=text, mtime=_NOW - timedelta(days=age_days))
+
+    def test_user_memory_by_filename_and_by_frontmatter_type(self) -> None:
+        assert decay._is_user_memory(self._mem("user_pref", "a pref"))  # filename prefix
+        assert decay._is_user_memory(self._mem("misc_note", "---\nmetadata:\n  type: user\n---\nx"))  # frontmatter
+        assert not decay._is_user_memory(self._mem("feedback_x", "---\nmetadata:\n  type: feedback\n---\nx"))
+
+    def test_resolved_type_frontmatter_then_prefix_then_other(self) -> None:
+        assert decay._resolved_type(self._mem("anything", "---\nmetadata:\n  type: reference\n---\nx")) == "reference"
+        # an unrecognised frontmatter type falls back to the filename prefix
+        assert decay._resolved_type(self._mem("project_x", "---\nmetadata:\n  type: bogus\n---\nx")) == "project"
+        # no recognised type, unknown prefix -> other
+        assert decay._resolved_type(self._mem("random_note", "a body")) == "other"
+        # node_type is never read as type
+        assert decay._resolved_type(self._mem("misc", "metadata:\n  node_type: memory\n")) == "other"
+
+    def test_binding_detection_matches_binding_and_non_negotiable(self) -> None:
+        assert decay._is_binding_text("this is a BINDING rule")
+        assert decay._is_binding_text("a Non-Negotiable directive")
+        assert not decay._is_binding_text("an ordinary lesson")
+
+    def test_recency_within_window_is_max_then_decays_to_floor(self) -> None:
+        retention = timedelta(days=30)
+        assert decay._recency_score(self._mem("m", "x", age_days=5), _NOW, retention) == decay._SIGNAL_RECENT
+        assert decay._recency_score(self._mem("m", "x", age_days=60), _NOW, retention) == decay._SIGNAL_RECENT - 30
+        assert decay._recency_score(self._mem("m", "x", age_days=900), _NOW, retention) == 0  # floored
+
+    def test_signal_score_composes_additively(self) -> None:
+        user_binding = self._mem("user_rule", "BINDING the rule", age_days=1)
+        score = decay._signal_score(user_binding, inbound_links=2, now=_NOW, retention=timedelta(days=30))
+        assert score == 1000 + 500 + (2 * 40) + 200 + 10  # user + binding + inbound + recency + user type weight
+
+    def test_inbound_link_counts_index_self_skip_and_cross_link(self) -> None:
+        a = self._mem("mem_a", "see [[mem_b]] and [[mem_a]] (a self link is ignored)")
+        b = self._mem("mem_b", "no links here")
+        counts = decay._inbound_link_counts([a, b], "- index line [[mem_b]]")
+        assert counts["mem_b"] == 2  # the index + mem_a
+        assert counts.get("mem_a", 0) == 0  # self-link does not count as inbound
+
+    def test_over_budget_by_bytes_or_lines(self) -> None:
+        assert decay._over_budget(0, gates.INDEX_BYTE_BUDGET + 1)  # over by bytes
+        assert decay._over_budget(gates.INDEX_LINE_BUDGET + 1, 0)  # over by lines
+        assert not decay._over_budget(1, 1)  # under both
+
+    def test_strip_provenance_with_without_and_malformed(self) -> None:
+        prov = "<!-- archived by dream decay 2026-06-16: x; original mtime 2026-01-01 -->\nthe body\n"
+        assert decay._strip_provenance(prov) == "the body\n"
+        assert decay._strip_provenance("no provenance here\n") == "no provenance here\n"
+        assert decay._strip_provenance("<!-- unterminated") == "<!-- unterminated"  # no closing marker -> left intact
+
+    def test_cold_index_line_handles_unreadable_and_signatureless(self) -> None:
+        d = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        broken = d / "broken.md"
+        broken.mkdir()
+        assert decay._cold_index_line(broken) == ""  # unreadable -> empty
+        headings_only = d / "feedback_headings.md"
+        headings_only.write_text(
+            "<!-- archived by dream decay 2026-06-16: x; original mtime 2026-01-01 -->\n# Only A Heading\n",
+            encoding="utf-8",
+        )
+        assert decay._cold_index_line(headings_only) == "- feedback_headings.md"  # no prose -> pointer only
+
+    def test_rebuild_cold_index_noop_when_archive_absent_or_yields_no_lines(self) -> None:
+        d = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        decay._rebuild_cold_index(d, d / "archive")  # absent
+        assert not (d / "MEMORY_ARCHIVE.md").exists()
+        archive = d / "archive"
+        archive.mkdir()
+        (archive / "broken.md").mkdir()  # unreadable -> no usable line
+        decay._rebuild_cold_index(d, archive)
+        assert not (d / "MEMORY_ARCHIVE.md").exists()
+
+
+class OverBudgetDecayEndToEndTestCase(TestCase):
+    """#2723 end-to-end: an over-budget hot index FAILS gate (d), then ONE pass fixes it.
+
+    The budget-tier decay + re-index brings the index under budget while retention /
+    no-loss / consolidation stay GREEN, and a second pass over the now-stable corpus
+    archives nothing (monotonic).
+    """
+
+    def setUp(self) -> None:
+        self.dir = Path(self.enterContext(tempfile.TemporaryDirectory()))
+
+    def _write(self, name: str, body: str, *, age_days: int, mtype: str = "feedback", binding: bool = False) -> Path:
+        path = self.dir / f"{name}.md"
+        marker = "BINDING " if binding else ""
+        path.write_text(f"---\nname: {name}\nmetadata:\n  type: {mtype}\n---\n\n{marker}{body}\n", encoding="utf-8")
+        ts = (_NOW - timedelta(days=age_days)).timestamp()
+        os.utime(path, (ts, ts))
+        return path
+
+    def _decay(self) -> decay.DecayResult:
+        return decay_memories(
+            self.dir, now=_NOW, has_durable_home=lambda _m: False, policy=DecayPolicy(budget_tier=BudgetTier())
+        )
+
+    def _run_gates(
+        self,
+        before: gates.MemorySnapshot,
+        after: gates.MemorySnapshot,
+        archived: Sequence[decay.ArchivedMemory],
+    ) -> gates.DreamQaReport:
+        return gates.run_acceptance_pass(
+            before,
+            after,
+            overlay="acme",
+            archived=archived,
+            schema_before=0,
+            schema_after=0,
+            maintenance_performed=True,
+            persist=False,
+        )
+
+    def test_over_budget_index_fails_gate_then_decays_under_budget_next_pass(self) -> None:
+        for i in range(170):
+            self._write(
+                f"feedback_low_{i:04d}",
+                f"lesson keyword{i:04d}gamma keyword{i:04d}delta a niche low-signal note",
+                age_days=120 + (i % 90),
+            )
+        self._write("feedback_binding_rule", "the load-bearing binding doctrine", age_days=80, binding=True)
+        self._write(
+            "reference_stale_note", "an old reference note nobody links to anymore", age_days=500, mtype="reference"
+        )
+        (self.dir / "MEMORY.md").write_text(reindex.render_index(self.dir), encoding="utf-8")
+
+        before = gates.snapshot_memory_dir(self.dir)
+        assert not gates.Gate.index_budget(before).passed  # over budget -> gate (d) FAILS
+
+        result = self._decay()
+        assert result.archived_count > 0
+        reindex.reindex_memory(self.dir)  # final re-index drops the archived pointers
+
+        after = gates.snapshot_memory_dir(self.dir)
+        assert gates.Gate.index_budget(after).passed  # now under budget
+        assert after.index_line_count <= gates.INDEX_LINE_BUDGET
+
+        report = self._run_gates(before, after, result.archived)
+        failed = {g.name for g in report.gate_results if not g.passed}
+        assert report.passed, [g.detail for g in report.gate_results if not g.passed]
+        assert {"retention", "no_loss_audit", "consolidation"}.isdisjoint(failed)
+
+        # The BINDING entry survives (highest signal) OR its signature is in the cold index.
+        cold_path = self.dir / "MEMORY_ARCHIVE.md"
+        cold = cold_path.read_text(encoding="utf-8") if cold_path.exists() else ""
+        assert (self.dir / "feedback_binding_rule.md").exists() or "feedback_binding_rule.md" in cold
+
+        # Pass 2: the corpus is now under budget -> nothing archived (monotonic).
+        before2 = gates.snapshot_memory_dir(self.dir)
+        result2 = self._decay()
+        assert result2.archived_count == 0
+        reindex.reindex_memory(self.dir)
+        after2 = gates.snapshot_memory_dir(self.dir)
+        report2 = self._run_gates(before2, after2, result2.archived)
+        mono = next(g for g in report2.gate_results if g.name == "monotonicity")
+        assert mono.passed

--- a/tests/teatree_loops/dream/test_gates.py
+++ b/tests/teatree_loops/dream/test_gates.py
@@ -243,6 +243,15 @@ class TestGateC(SimpleTestCase):
         )
         assert not result.passed  # maintenance happened but a pruned line is orphaned
 
+    def test_archived_entry_pruned_line_is_homed_via_archived_names(self) -> None:
+        # #2723: an archived entry's pruned hot line points at a .md that LEFT `memories`
+        # for the cold archive/ — a RESTORABLE durable home. The shared _line_targets homes
+        # it when the line's pointer is in the archived set; an empty set leaves it unhomed
+        # (teeth — the homing is real, not always-true).
+        line = "- feedback_low_signal.md — a stale low-signal lesson"
+        assert gates._line_targets(line, {"feedback_low_signal.md"})
+        assert not gates._line_targets(line, set())
+
     def test_summary_name_dropping_a_live_memory_does_not_home_a_gone_target(self) -> None:
         # The pruned line's link TARGET (gone_x.md) vanished, but its free-text summary
         # mentions a DIFFERENT, surviving memory's filename. Homing keys on the link

--- a/tests/teatree_loops/dream/test_reindex.py
+++ b/tests/teatree_loops/dream/test_reindex.py
@@ -53,6 +53,28 @@ class ReindexTestCase(SimpleTestCase):
         assert reindex._SUMMARY_MAX_CHARS <= 120
         assert summary.endswith("…")
 
+    def test_line_max_chars_pinned_to_140_and_hot_lines_capped(self) -> None:
+        # #2723: the hot per-line cap is 140 (was 160) so `- <name>.md — <summary>` fits
+        # even with a long filename. The cold MEMORY_ARCHIVE.md is uncapped — that is
+        # decay's concern, pinned in test_decay.py::...::test_cold_index_signature_is_uncapped.
+        assert reindex._LINE_MAX_CHARS == 140
+        self._write("mem_long", f"---\nname: mem_long\nsummary: {'z' * 400}\n---\nbody")
+        index = render_index(self.dir)
+        hot_lines = [line for line in index.splitlines() if line.startswith("- ")]
+        assert hot_lines
+        for line in hot_lines:
+            assert len(line) <= 140
+
+    def test_archive_index_is_not_re_indexed_into_the_hot_index(self) -> None:
+        # #2723: MEMORY_ARCHIVE.md lives in the memory dir but must never appear as a
+        # hot index line (it is the cold index, excluded exactly like MEMORY.md).
+        self._write("mem_a", "---\nname: mem_a\nsummary: a\n---\nbody")
+        (self.dir / "MEMORY_ARCHIVE.md").write_text("# cold\n- archived_x.md — a signature\n", encoding="utf-8")
+        index = render_index(self.dir)
+        assert "MEMORY_ARCHIVE.md" not in index
+        assert "archived_x.md" not in index
+        assert "mem_a.md" in index
+
     def test_whole_line_is_capped(self) -> None:
         # #2723: the WHOLE line (filename + summary) is capped, so a long filename
         # plus a long summary can never blow the per-line byte budget. The pointer


### PR DESCRIPTION
fix(dream): tiered hot/cold memory index keeps MEMORY.md under the loadable budget (#2723)

## Root cause

The dream re-index decay's budget tier only archived near-duplicate entries. With a corpus of ~693 mostly-unique memories (~294 of them BINDING), near-duplicate collapse alone could never bring the session-loaded `MEMORY.md` down to the 150-line / 24KB load budget — so the `index_budget` §4 acceptance gate could not converge.

## Fix

Decay now scores every entry by signal and archives the lowest-signal entries until the hot `MEMORY.md` is within budget (≤150 lines / ≤24KB):

- Archived lines move to a restorable `archive/` so nothing is lost and any entry can be brought back.
- A not-loaded, searchable `MEMORY_ARCHIVE.md` cold index keeps archived content discoverable without inflating the session-loaded hot file.

## §4 gates stay green (all 7)

- **consolidation** homes archived lines via the archived-names path.
- **no_loss_audit** verifies every archived line has a restorable destination.
- **retention** and **interference** find archived signatures in the cold index.
- The remaining gates continue to pass on the trimmed hot file.

## Review

Independently, adversarially reviewed — PASS, no blockers. The 127 real pre-existing archive files were verified to strip provenance headers correctly, and both regression tests were proven RED-before / GREEN-after.

## Follow-up

A follow-up PR adds recall over the cold tier.

## Open questions & assumptions

- none

Closes #2723
