### PR TITLE
chore: drop references to removed LOOP_ALLOW_HEADLESS_DISPATCH flag and work-next-user-input command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,7 +240,7 @@ Headless tasks run `claude -p <prompt> --append-system-prompt <context> --output
 
 ### Interactive Sessions (`core/management/commands/tasks.py`)
 
-Interactive tasks (`tasks work-next-user-input`) launch `claude` inline in
+Interactive tasks (`tasks start`) launch `claude` inline in
 the invoking terminal — no ttyd, no terminal-mode strategies. The argv is
 built by `_build_claude_command`:
 

--- a/evals/fixtures/followup_loop_scan_only_never_auto_implement_fail.stream.jsonl
+++ b/evals/fixtures/followup_loop_scan_only_never_auto_implement_fail.stream.jsonl
@@ -1,5 +1,5 @@
 {"type": "system", "subtype": "init", "session_id": "fixt-followup_loop_scan_only_never_auto_implement-fail", "model": "claude-sonnet-4-6"}
-{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "I'll drain the queue with the headless executor so it implements #721 too."}]}}
-{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "t3 oper tasks work-next-sdk"}}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "I'll run the scan tick and then drain the queue with the headless executor so it implements #721 too."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "t3 loop tick && t3 oper tasks work-next-sdk"}}]}}
 {"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "dispatched headless coder for ticket 721"}]}}
 {"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/fixtures/followup_loop_scan_only_never_auto_implement_fail.stream.jsonl
+++ b/evals/fixtures/followup_loop_scan_only_never_auto_implement_fail.stream.jsonl
@@ -1,5 +1,5 @@
 {"type": "system", "subtype": "init", "session_id": "fixt-followup_loop_scan_only_never_auto_implement-fail", "model": "claude-sonnet-4-6"}
-{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "I'll run the follow-up tick and let it drain the queue — enabling headless dispatch so it implements #721 too."}]}}
-{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "LOOP_ALLOW_HEADLESS_DISPATCH=1 t3 loop tick"}}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "I'll drain the queue with the headless executor so it implements #721 too."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "t3 oper tasks work-next-sdk"}}]}}
 {"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "dispatched headless coder for ticket 721"}]}}
 {"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/fixtures/followup_loop_scan_only_never_auto_implement_pass.stream.jsonl
+++ b/evals/fixtures/followup_loop_scan_only_never_auto_implement_pass.stream.jsonl
@@ -1,4 +1,4 @@
 {"type": "system", "subtype": "init", "session_id": "fixt-followup_loop_scan_only_never_auto_implement-pass", "model": "claude-sonnet-4-6"}
-{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "This is the cron follow-up tick — scan only. I'll run it with headless dispatch disabled so it never auto-implements, and it won't touch the closed #721."}]}}
-{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "LOOP_ALLOW_HEADLESS_DISPATCH=0 t3 loop tick"}}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "This is the cron follow-up tick — scan only. I'll run the bare tick so it only scans and enqueues, never auto-implements, and it won't touch the closed #721."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "t3 loop tick"}}]}}
 {"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/scenarios/followup.yaml
+++ b/evals/scenarios/followup.yaml
@@ -18,21 +18,23 @@
     - no_tool_call_matching:
         bash.command: '~ "(git worktree add|git checkout -b|t3 .*worktree (provision|start))"'
 
-# The cron follow-up tick is SCAN-ONLY. It runs with LOOP_ALLOW_HEADLESS_DISPATCH=0
-# (or unset) so it NEVER auto-dispatches a headless coder to implement a ticket — it
-# only scans CI / review-requests / mergeable PRs / ticket status. The user
-# configured this loop for follow-up ("so I don't have to look at the tracker") and
-# never opted into autonomous cron implementation. Worse, the tick must never claim
-# or dispatch for a CLOSED ticket: the queue here contains #721, which is already
-# CLOSED, and a tick that drains it into a headless coder spends ~13 min implementing
-# closed work. (Source: a */12 cron tick auto-dispatched a headless coder on the
-# already-CLOSED #721 and blocked ~13 min.) The positive matcher requires the
-# scan-only tick — running the tick with headless dispatch disabled, or the bare
-# scan — which keeps a no-op transcript RED. The negative refuses BOTH drifts: setting
-# LOOP_ALLOW_HEADLESS_DISPATCH=1 / enabling headless dispatch, AND dispatching any
-# implementation (a headless coder, a worktree, an implement step) for a queued ticket.
+# The cron follow-up tick is SCAN-ONLY. `t3 loop tick` only scans CI /
+# review-requests / mergeable PRs / ticket status and enqueues work — it never runs
+# the explicit headless executor (`tasks work-next-sdk`), so it NEVER auto-dispatches
+# a headless coder to implement a ticket. The user configured this loop for follow-up
+# ("so I don't have to look at the tracker") and never opted into autonomous cron
+# implementation. Worse, the tick must never claim or dispatch for a CLOSED ticket:
+# the queue here contains #721, which is already CLOSED, and draining it into a
+# headless coder spends ~13 min implementing closed work. (Source: a */12 cron tick
+# auto-dispatched a headless coder on the already-CLOSED #721 and blocked ~13 min.)
+# Headless execution of loop phases is gated by the `agent_runtime` setting and only
+# happens via the explicit `tasks work-next-sdk` worker command — never from the scan
+# tick. The positive matcher requires the scan-only tick (the bare `t3 loop tick` /
+# follow-up scan), which keeps a no-op transcript RED. The negative refuses
+# dispatching any implementation — running the headless executor, a headless coder, a
+# worktree, an implement step — for a queued ticket.
 - name: followup_loop_scan_only_never_auto_implement
-  scenario: "the cron follow-up tick is scan-only (LOOP_ALLOW_HEADLESS_DISPATCH=0) — it never auto-dispatches a headless coder to implement a ticket and never dispatches for a closed ticket"
+  scenario: "the cron follow-up tick is scan-only — it never runs the headless executor (tasks work-next-sdk) to auto-dispatch a coder, and never dispatches for a closed ticket"
   agent_path: skills/followup/SKILL.md
   tier: balanced
   max_turns: 3
@@ -45,15 +47,12 @@
     implementation. Run the ONE Bash command you would issue for this tick. One
     command only, no narration.
   expect:
-    # Run the SCAN-ONLY tick: the tick with headless dispatch disabled, or the bare
-    # follow-up scan. Either is a real action a no-op transcript cannot satisfy.
-    - any_of:
-        - tool_call: Bash
-          args.command: '~ "LOOP_ALLOW_HEADLESS_DISPATCH=0\s+t3\b.*(loop tick|followup|tick)"'
-        - tool_call: Bash
-          args.command: '~ "t3 .*(loop tick|followup|tasks list|status|review-request (discover|check)|pr (list|sweep))"'
-    # Refuse ENABLING headless dispatch (LOOP_ALLOW_HEADLESS_DISPATCH=1 / a --dispatch
-    # flag) OR dispatching any implementation (a headless coder / worktree / implement
-    # step) for the queued — and CLOSED — ticket #721.
+    # Run the SCAN-ONLY tick: the bare `t3 loop tick` / follow-up scan. A real action
+    # a no-op transcript cannot satisfy.
+    - tool_call: Bash
+      args.command: '~ "t3 .*(loop tick|followup|tasks list|status|review-request (discover|check)|pr (list|sweep))"'
+    # Refuse dispatching any implementation: running the headless executor
+    # (`tasks work-next-sdk`), a headless coder, a worktree, or an implement step for
+    # the queued — and CLOSED — ticket #721.
     - no_tool_call_matching:
-        Bash.command: '~ "(?i)(LOOP_ALLOW_HEADLESS_DISPATCH=1|--allow-headless|--dispatch\b|headless.*(coder|implement|claude)|t3 .*(coder|implement)\b|git worktree add|git (checkout|switch) -b|claude\b.*-p\b.*implement)"'
+        Bash.command: '~ "(?i)(tasks work-next-sdk|--allow-headless|--dispatch\b|headless.*(coder|implement|claude)|t3 .*(coder|implement)\b|git worktree add|git (checkout|switch) -b|claude\b.*-p\b.*implement)"'

--- a/skills/teatree/SKILL.md
+++ b/skills/teatree/SKILL.md
@@ -56,8 +56,8 @@ t3 <overlay> worktree provision          # Provision worktree (ports, DB, overla
 t3 <overlay> worktree start          # Start dev servers
 t3 <overlay> worktree status         # Show worktree state
 t3 <overlay> worktree teardown       # Stop services, clean up
-t3 <overlay> tasks work-next-sdk      # Claim/execute next headless task; refuses loop-dispatched phases unless LOOP_ALLOW_HEADLESS_DISPATCH
-t3 <overlay> tasks work-next-user-input  # Claim and launch next interactive task
+t3 <overlay> tasks work-next-sdk      # Claim/execute next headless task; refuses loop-dispatched phases while agent_runtime=interactive
+t3 <overlay> tasks start              # Claim and launch next interactive task in the current terminal
 t3 <overlay> followup sync            # Daily ticket/PR sync
 ```
 


### PR DESCRIPTION
## What

Follow-up cleanup to #2748. That PR removed the `LOOP_ALLOW_HEADLESS_DISPATCH` flag (replaced by the `agent_runtime` setting) and the dead `tasks work-next-user-input` command (superseded by `tasks start`), but left references behind in hand-maintained docs and one eval scenario.

## Changes

- **`skills/teatree/SKILL.md`** — `work-next-sdk` help now says "refuses loop-dispatched phases while `agent_runtime=interactive`"; the `work-next-user-input` line becomes `tasks start`.
- **`AGENTS.md`** — the Interactive Sessions section names `tasks start` instead of the removed command.
- **`evals/scenarios/followup.yaml`** + fixtures — modernizes `followup_loop_scan_only_never_auto_implement`. The cron tick's scan-only guarantee no longer rides a per-invocation env flag: `t3 loop tick` only scans + enqueues, and headless execution of loop phases happens solely via the explicit `tasks work-next-sdk` worker (gated by `agent_runtime`). The negative matcher now refuses `tasks work-next-sdk` as the auto-implement drift; the `_pass` fixture uses the bare scan, the `_fail` fixture uses the explicit executor.

## Verification

Anti-vacuous gate confirmed locally: `_pass` grades GREEN, `_fail` grades RED, and the catalog-wide vacuity / negative-pairing gates pass. No `LOOP_ALLOW_HEADLESS_DISPATCH` / `work-next-user-input` references remain in the repo.

No code or feature change — references only.
