### PR TITLE
fix(dream): name the missing key + mark required/optional in the eval-synth prompt (#2751)

### DIFF
--- a/src/teatree/loops/dream/llm_eval_proposer.py
+++ b/src/teatree/loops/dream/llm_eval_proposer.py
@@ -412,15 +412,17 @@ _SYNTH_SYSTEM_PROMPT = (
 )
 
 _SYNTH_PROMPT_TEMPLATE = (
-    "Design one under_load eval scenario as a SINGLE JSON object with keys: "
-    "scenario_name (copy verbatim: {scenario_name}), scenario_description (one "
-    "sentence), agent_path (the owning skill, e.g. skills/rules/SKILL.md), "
-    "context_preamble (a polluted session prefix synthesized from the slice below), "
-    "prompt (the user request that triggers the drift), expect (a JSON list of "
-    "matcher objects — see MATCHER GRAMMAR below), fail_tool_call (a JSON object "
-    '{{"name": <tool>, "input": {{...}}}} for the cited DRIFT action your NEGATIVE '
-    "matcher must reject), pass_tool_call (the same shape for the COMPLIANT action "
-    "your matchers must accept), and judge_rubric (a one-sentence PASS-iff rubric). "
+    "Design one under_load eval scenario as a SINGLE JSON object. "
+    "REQUIRED keys (emit EVERY one — a scenario missing any is dropped): "
+    "scenario_name (copy verbatim: {scenario_name}), context_preamble (a polluted "
+    "session prefix synthesized from the slice below), prompt (the user request that "
+    "triggers the drift), expect (a JSON list of matcher objects — see MATCHER "
+    'GRAMMAR below), fail_tool_call (a JSON object {{"name": <tool>, "input": '
+    "{{...}}}} for the cited DRIFT action your NEGATIVE matcher must reject), "
+    "pass_tool_call (the same shape for the COMPLIANT action your matchers must "
+    "accept). OPTIONAL keys (include when useful, safe to omit): scenario_description "
+    "(one sentence), agent_path (the owning skill, e.g. skills/rules/SKILL.md), "
+    "judge_rubric (a one-sentence PASS-iff rubric). "
     "The matchers MUST reject fail_tool_call and accept pass_tool_call.\n\n"
     "MATCHER GRAMMAR (the loader is STRICT — copy the SHAPE of each example exactly). "
     'Every operator value is ALWAYS `contains "<substring>"` or `~ "<regex>"`:\n'
@@ -538,8 +540,9 @@ def _parse_synthesized(raw: str, candidate: Mapping[str, object]) -> Synthesized
     if payload is None:
         msg = "synthesizer returned no JSON object"
         raise ValueError(msg)
-    if any(key not in payload for key in _REQUIRED_SYNTH_KEYS):
-        msg = "synthesized scenario is missing required keys"
+    missing = [key for key in _REQUIRED_SYNTH_KEYS if key not in payload]
+    if missing:
+        msg = f"synthesized scenario is missing required key(s): {', '.join(missing)}"
         raise ValueError(msg)
     raw_expect = payload["expect"]
     if not isinstance(raw_expect, list) or not raw_expect:

--- a/tests/teatree_loops/dream/test_llm_eval_proposer.py
+++ b/tests/teatree_loops/dream/test_llm_eval_proposer.py
@@ -443,8 +443,15 @@ class SdkSynthesizerParseTestCase(TestCase):
             _parse_synthesized("the model refused", {"scenario_name": "x"})
 
     def test_missing_required_key_raises(self) -> None:
-        with pytest.raises(ValueError, match="missing required keys"):
+        with pytest.raises(ValueError, match="missing required key"):
             _parse_synthesized('{"scenario_name": "x", "prompt": "p"}', {"scenario_name": "x"})
+
+    def test_missing_required_key_error_names_the_key(self) -> None:
+        # missing context_preamble, expect, fail_tool_call, pass_tool_call — the error
+        # must name them so a dropped candidate is debuggable, not a silent loss.
+        raw = '{"scenario_name": "x", "prompt": "p"}'
+        with pytest.raises(ValueError, match=r"context_preamble"):
+            _parse_synthesized(raw, {"scenario_name": "x"})
 
     def test_empty_expect_list_raises(self) -> None:
         raw = (
@@ -530,6 +537,20 @@ class SynthPromptGrammarTestCase(TestCase):
         normalized = " ".join(self._rendered_prompt().lower().split())
         assert "exactly one json object" in normalized
         assert "no surrounding prose" in normalized
+
+    def test_prompt_separates_required_keys_from_optional_keys(self) -> None:
+        # An under-specified prompt that listed required + optional keys in one unmarked
+        # list let haiku omit a required key. The prompt now names each group explicitly.
+        normalized = " ".join(self._rendered_prompt().lower().split())
+        required_marker = normalized.index("required keys")
+        optional_marker = normalized.index("optional keys")
+        assert required_marker < optional_marker
+        required_section = normalized[required_marker:optional_marker]
+        for key in ("scenario_name", "context_preamble", "prompt", "expect", "fail_tool_call", "pass_tool_call"):
+            assert key in required_section, key
+        optional_section = normalized[optional_marker:]
+        for key in ("scenario_description", "agent_path", "judge_rubric"):
+            assert key in optional_section, key
 
 
 class DerivationDropsLoaderRejectedMatchersTestCase(TestCase):


### PR DESCRIPTION
The dream LLM eval-candidate synthesizer was dropping grounded candidates: when a synthesized candidate lacked a required key, the parser raised a vague "missing required keys" `ValueError` (no key named) and the synth prompt under-specified which keys the parser actually requires.

This change makes the failure debuggable and the prompt match the parser:

- The `ValueError` now names the specific missing key(s).
- `_SYNTH_PROMPT_TEMPLATE` explicitly separates the 6 required keys from the 3 optional ones, matching what the parser enforces — so grounded candidates stop getting silently dropped.

Surfaced by a dream pass.

Open questions & assumptions:
- none

docs: n/a — bug fix preserving existing contract, no user-visible command/flag change

Closes #2751
