### PR TITLE
fix(eval): grade negative+contains matchers (was NotImplementedError)

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -1252,8 +1252,9 @@ Supported matcher operators:
   positive matcher that pairs with a `no_tool_call_matching` line to
   prevent the scenario from being satisfied vacuously by a no-op
   transcript.
-- `no_tool_call_matching: { <tool>.<arg>: ~ "<regex>" }` — no matching
-  tool call may exist. A negative matcher MUST be paired with a positive
+- `no_tool_call_matching: { <tool>.<arg>: ~ "<regex>" }` (regex) or
+  `no_tool_call_matching: { <tool>.<arg>: contains "<substring>" }` (substring) —
+  no matching tool call may exist. A negative matcher MUST be paired with a positive
   anchor (a `tool_call` / `any_of` / `final_state` matcher) in the same
   `expect` list — a negative-only scenario is satisfied by a no-op agent and
   guards nothing. `tests/eval_replay/test_scenarios_anti_vacuous.py`

--- a/src/teatree/eval/matchers.py
+++ b/src/teatree/eval/matchers.py
@@ -74,6 +74,19 @@ def assert_tool_call_matching(run: EvalRun, tool_name: str, arg_path: str, regex
     raise AssertionError(msg)
 
 
+def assert_no_tool_call_contains(run: EvalRun, tool_name: str, arg_path: str, substring: str) -> None:
+    for call in run.tool_calls:
+        if canonicalize_tool(call.name) != tool_name:
+            continue
+        value = _as_text(_get_arg(call, arg_path))
+        if value is not None and substring in value:
+            msg = (
+                f"Did not expect any {tool_name} tool call with {arg_path} containing {substring!r}, "
+                f"but found:\n  - {call.name}({call.input!r})\nAll captured tool calls:\n{_format_calls(run)}"
+            )
+            raise AssertionError(msg)
+
+
 def assert_no_tool_call_matching(run: EvalRun, tool_name: str, arg_path: str, regex: str) -> None:
     pattern = re.compile(regex)
     for call in run.tool_calls:

--- a/src/teatree/eval/report.py
+++ b/src/teatree/eval/report.py
@@ -10,6 +10,7 @@ from teatree.eval.discovery import find_spec
 from teatree.eval.matchers import (
     assert_final_state_contains,
     assert_final_state_matching,
+    assert_no_tool_call_contains,
     assert_no_tool_call_matching,
     assert_tool_call_contains,
     assert_tool_call_matching,
@@ -127,6 +128,9 @@ def _dispatch(matcher: ExpectItem, run: EvalRun) -> None:
         return
     if matcher.kind == "negative" and matcher.operator == "~":
         assert_no_tool_call_matching(run, tool, matcher.arg_path, matcher.value)
+        return
+    if matcher.kind == "negative" and matcher.operator == "contains":
+        assert_no_tool_call_contains(run, tool, matcher.arg_path, matcher.value)
         return
     msg = f"unsupported matcher operator: kind={matcher.kind!r}, operator={matcher.operator!r}"
     raise NotImplementedError(msg)

--- a/tests/eval_replay/test_loader.py
+++ b/tests/eval_replay/test_loader.py
@@ -3,7 +3,8 @@ from pathlib import Path
 import pytest
 
 from teatree.eval.loader import EvalSpecError, load_eval_yaml
-from teatree.eval.models import DEFAULT_MAX_TURNS, AnyOf, FinalStateMatcher
+from teatree.eval.models import DEFAULT_MAX_TURNS, AnyOf, EvalRun, EvalToolCall, FinalStateMatcher
+from teatree.eval.report import evaluate
 
 _MINIMAL = (
     "- name: example\n"
@@ -19,6 +20,18 @@ def _write(tmp_path: Path, body: str) -> Path:
     target = tmp_path / "spec.yaml"
     target.write_text(body, encoding="utf-8")
     return target
+
+
+def _run(*calls: EvalToolCall) -> EvalRun:
+    return EvalRun(
+        spec_name="neg_contains",
+        tool_calls=calls,
+        text_blocks=(),
+        terminal_reason="success",
+        is_error=False,
+        raw_stdout="",
+        raw_stderr="",
+    )
 
 
 class TestLoadEvalYaml:
@@ -280,6 +293,38 @@ class TestLoadEvalYaml:
         assert matcher.arg_path == "command"
         assert matcher.operator == "~"
         assert matcher.value == "rm -rf"
+
+    def test_negative_contains_yaml_round_trips_through_grader(self, tmp_path: Path) -> None:
+        # Regression seam (loader -> dispatch): the loader accepts `contains` for a
+        # `no_tool_call_matching` line, producing Matcher(kind="negative",
+        # operator="contains"); the grader's _dispatch had no branch for that combo
+        # and fell through to NotImplementedError, crashing the dream `--full` eval
+        # derivation. The matcher-level and dispatch-level halves are covered
+        # separately; this exercises a LOADER-produced matcher (not a hand-built
+        # one) through report.evaluate in a single load -> grade round-trip.
+        body = (
+            "- name: neg_contains\n"
+            "  scenario: forbid a drift substring\n"
+            "  prompt: do the thing\n"
+            "  expect:\n"
+            "    - no_tool_call_matching:\n"
+            '        bash.command: contains "--no-verify"\n'
+        )
+        spec = load_eval_yaml(_write(tmp_path, body))[0]
+        matcher = spec.matchers[0]
+        assert matcher.kind == "negative"
+        assert matcher.operator == "contains"
+        assert matcher.tool == "bash"
+        assert matcher.arg_path == "command"
+        assert matcher.value == "--no-verify"
+
+        # FAIL when a matching tool call CONTAINS the forbidden substring...
+        present = _run(EvalToolCall(name="Bash", input={"command": "git commit --no-verify -m x"}, turn=1))
+        assert evaluate(spec, present).passed is False
+
+        # ...PASS when it is absent. The present/absent pair proves teeth.
+        absent = _run(EvalToolCall(name="Bash", input={"command": "git commit -m x"}, turn=1))
+        assert evaluate(spec, absent).passed is True
 
     def test_rejects_empty_expect(self, tmp_path: Path) -> None:
         body = "- name: bad\n  scenario: bad\n  prompt: do the thing\n  expect: []\n"

--- a/tests/eval_replay/test_matchers.py
+++ b/tests/eval_replay/test_matchers.py
@@ -3,6 +3,7 @@ import pytest
 from teatree.eval.matchers import (
     assert_final_state_contains,
     assert_final_state_matching,
+    assert_no_tool_call_contains,
     assert_no_tool_call_matching,
     assert_tool_call_contains,
     assert_tool_call_matching,
@@ -123,6 +124,35 @@ class TestAssertNoToolCallMatching:
         with pytest.raises(AssertionError) as exc_info:
             assert_no_tool_call_matching(run, "Bash", "command", r"Edit.*README\.md")
         assert "Edit" in str(exc_info.value)
+
+
+class TestAssertNoToolCallContains:
+    """The substring sibling of ``assert_no_tool_call_matching`` (regex).
+
+    Also the logical negation of ``assert_tool_call_contains``: PASS when NO
+    matching call has its arg value containing the substring; raise when at least
+    one does.
+    """
+
+    def test_passes_when_substring_absent(self) -> None:
+        run = _run([EvalToolCall(name="Bash", input={"command": "git commit -m fix"}, turn=1)])
+        assert_no_tool_call_contains(run, "Bash", "command", "--no-verify")
+
+    def test_passes_when_only_other_tool_contains_substring(self) -> None:
+        run = _run([EvalToolCall(name="Read", input={"command": "git commit --no-verify"}, turn=1)])
+        assert_no_tool_call_contains(run, "Bash", "command", "--no-verify")
+
+    def test_passes_when_matching_tool_has_a_different_arg_value(self) -> None:
+        # Bash IS called, but its command does not contain the forbidden substring.
+        run = _run([EvalToolCall(name="Bash", input={"command": "git commit -m fix"}, turn=1)])
+        assert_no_tool_call_contains(run, "Bash", "command", "--no-verify")
+
+    def test_raises_when_substring_present(self) -> None:
+        run = _run([EvalToolCall(name="Bash", input={"command": "git commit --no-verify -m fix"}, turn=1)])
+        with pytest.raises(AssertionError) as exc_info:
+            assert_no_tool_call_contains(run, "Bash", "command", "--no-verify")
+        assert "--no-verify" in str(exc_info.value)
+        assert "git commit --no-verify -m fix" in str(exc_info.value)
 
 
 class TestAssertFinalStateMatching:

--- a/tests/eval_replay/test_report.py
+++ b/tests/eval_replay/test_report.py
@@ -20,6 +20,7 @@ from teatree.eval.report import (
 _TASK_BRANCH = Matcher(kind="positive", tool="Task", arg_path="prompt", operator="~", value="pytest")
 _BG_BASH_BRANCH = Matcher(kind="positive", tool="Bash", arg_path="run_in_background", operator="~", value="(?i)true")
 _ANY_OF = AnyOf(alternatives=(_TASK_BRANCH, _BG_BASH_BRANCH))
+_NEG_CONTAINS = Matcher(kind="negative", tool="Bash", arg_path="command", operator="contains", value="--no-verify")
 
 
 def _spec(
@@ -214,6 +215,47 @@ class TestVerdict:
         run = _run(
             tool_calls=(EvalToolCall(name="Bash", input={"command": "x"}, turn=1),),
         )
+        with pytest.raises(NotImplementedError):
+            evaluate(spec, run)
+
+
+class TestNegativeContainsMatcherDispatch:
+    """A negative+contains matcher grades through ``_dispatch`` (was NotImplementedError).
+
+    The loader accepts ``contains`` for a ``no_tool_call_matching`` line, so a
+    negative+contains matcher is loadable; but ``_dispatch`` had no branch for it
+    and fell through to ``NotImplementedError``, crashing the grader (and the
+    ``llm_eval_proposer`` teeth_check on any synthesized spec using one). The pair
+    below proves teeth: FAIL when the forbidden drift is present, PASS when absent.
+    """
+
+    def test_fails_when_forbidden_substring_present(self) -> None:
+        spec = _spec(matchers=(_NEG_CONTAINS,))
+        run = _run(tool_calls=(EvalToolCall(name="Bash", input={"command": "git commit --no-verify -m x"}, turn=1),))
+        result = evaluate(spec, run)
+        assert result.passed is False
+        assert "--no-verify" in result.matcher_results[0].message
+
+    def test_passes_when_forbidden_substring_absent(self) -> None:
+        spec = _spec(matchers=(_NEG_CONTAINS,))
+        run = _run(tool_calls=(EvalToolCall(name="Bash", input={"command": "git commit -m x"}, turn=1),))
+        result = evaluate(spec, run)
+        assert result.passed is True
+
+    def test_does_not_raise_not_implemented_error(self) -> None:
+        # The regression: negative+contains used to fall through to
+        # NotImplementedError. ``evaluate`` only catches ``AssertionError``, so an
+        # ungraded combo would propagate here rather than grade.
+        spec = _spec(matchers=(_NEG_CONTAINS,))
+        run = _run(tool_calls=(EvalToolCall(name="Bash", input={"command": "ls"}, turn=1),))
+        assert evaluate(spec, run).passed is True
+
+    def test_unsupported_negative_operator_still_raises_not_implemented(self) -> None:
+        # The fallback for a genuinely-unsupported combo is intact (not removed).
+        spec = _spec(
+            matchers=(Matcher(kind="negative", tool="Bash", arg_path="command", operator="??", value="x"),),
+        )
+        run = _run(tool_calls=(EvalToolCall(name="Bash", input={"command": "x"}, turn=1),))
         with pytest.raises(NotImplementedError):
             evaluate(spec, run)
 


### PR DESCRIPTION
## What

The eval grader could not grade a `negative + contains` matcher. The loader's `_parse_negative` / `_parse_op_expr` accept `contains` for a `no_tool_call_matching` line, producing `Matcher(kind="negative", operator="contains", ...)`, but `report._dispatch` had no branch for that combination and fell through to `NotImplementedError`. Since `evaluate` only catches `AssertionError`, the error propagated out of the grader rather than producing a verdict.

This showed up during the dream `--full` eval-derivation step as the "eval derivation raised" WARN: a synthesized spec using the negative-contains form crashed grading instead of grading cleanly.

## Fix

- Added `assert_no_tool_call_contains` in `src/teatree/eval/matchers.py` — the negative sibling of `assert_tool_call_contains`.
- Added the `negative + contains` branch to `report._dispatch`, so the matcher grades through that assertion instead of raising.
- The genuinely-unsupported fallback (`NotImplementedError` for an unknown kind/operator combo) stays in place.

## Tests

- `tests/eval_replay/test_matchers.py` covers the matcher-level half.
- `tests/eval_replay/test_report.py` covers the dispatch-level half with a hand-built matcher, plus a "does not raise NotImplementedError" regression and the intact unsupported-operator fallback.
- `tests/eval_replay/test_loader.py` adds the loader to grade seam test: it loads the YAML negative-contains form (`no_tool_call_matching: { bash.command: contains "..." }`), asserts it parses to `Matcher(kind="negative", operator="contains", ...)`, then runs the loader-produced matcher (not a hand-built one) through `report.evaluate` over a real `EvalRun` — FAIL when a tool call contains the forbidden substring, PASS when absent. The present/absent pair is anti-vacuous (pre-fix, the uncaught `NotImplementedError` makes it red).

Evidence:

```
uv run ruff check src/teatree/eval/ tests/eval_replay/  ->  All checks passed!
uv run pytest tests/eval_replay tests/teatree_eval -q   ->  2429 passed, 28 skipped in 27.58s
```

## Scope

Not substrate: the only doc touched is `evals/README.md` (the eval schema reference). `BLUEPRINT.md` is unchanged.
