### PR TITLE
fix(banned-terms): fail loud when the term/brand list is unset

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -400,11 +400,13 @@ Usage: t3 banned-terms scan-tree [OPTIONS]
 │                               current directory).                            │
 │ --config                PATH  Override the ~/.teatree.toml term-list config  │
 │                               (else resolved as the gate does).              │
-│ --require-brands              HARD-FAIL (exit 2) when no brands are          │
-│                               configured, instead of warning and exiting 0.  │
-│                               CI passes this so a missing                    │
-│                               TEATREE_BANNED_BRANDS secret reds the job      │
-│                               loudly; local dev omits it and stays green.    │
+│ --require-brands              HARD-FAIL (exit 2) on an explicit-empty brand  │
+│                               list (`banned_brands = []`), instead of        │
+│                               warning and exiting 0. A genuinely-unset list  │
+│                               always fails loud regardless of this flag;     │
+│                               --require-brands additionally rejects the      │
+│                               deliberate empty list. CI passes it; local dev │
+│                               omits it.                                      │
 │ --help                        Show this message and exit.                    │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```

--- a/src/teatree/cli/banned_terms.py
+++ b/src/teatree/cli/banned_terms.py
@@ -48,9 +48,10 @@ def scan_tree(
     require_brands: bool = typer.Option(
         False,
         "--require-brands",
-        help="HARD-FAIL (exit 2) when no brands are configured, instead of warning and "
-        "exiting 0. CI passes this so a missing TEATREE_BANNED_BRANDS secret reds the "
-        "job loudly; local dev omits it and stays green.",
+        help="HARD-FAIL (exit 2) on an explicit-empty brand list (`banned_brands = []`), "
+        "instead of warning and exiting 0. A genuinely-unset list always fails loud "
+        "regardless of this flag; --require-brands additionally rejects the deliberate "
+        "empty list. CI passes it; local dev omits it.",
     ),
 ) -> None:
     """Scan every git-tracked file for committed banned terms."""

--- a/src/teatree/cli/banned_terms.py
+++ b/src/teatree/cli/banned_terms.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import typer
 from rich.console import Console
 
-from teatree.core.banned_terms_tree import scan_committed_tree
+from teatree.core.banned_terms_tree import BannedTermsUnsetError, scan_committed_tree
 
 banned_terms_app = typer.Typer(no_args_is_help=True, help="Banned-terms backstop scans.")
 _console = Console()
@@ -55,7 +55,15 @@ def scan_tree(
 ) -> None:
     """Scan every git-tracked file for committed banned terms."""
     root = repo_root if repo_root is not None else Path.cwd()
-    result = scan_committed_tree(root, config_path=config)
+    try:
+        result = scan_committed_tree(root, config_path=config)
+    except BannedTermsUnsetError as exc:
+        # A genuinely-unset brand list (no config, no env, a missing key) is
+        # refused LOUD (exit 2) — never a silent inert scan that hides a load
+        # bug. An explicit empty list does not raise; it flows to the
+        # INERT warning below.
+        _console.print(f"[red]banned-terms scan-tree: MISCONFIGURED — {exc}[/]")
+        raise typer.Exit(_MISCONFIGURED_EXIT_CODE) from exc
 
     if not result.brands_configured:
         if require_brands:

--- a/src/teatree/core/banned_terms_tree.py
+++ b/src/teatree/core/banned_terms_tree.py
@@ -13,9 +13,9 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from teatree.hooks import banned_terms_scanner
-from teatree.hooks.banned_terms_tree_scan import TreeFinding, load_brand_terms, scan_tree
+from teatree.hooks.banned_terms_tree_scan import BannedTermsUnsetError, TreeFinding, load_brand_terms, scan_tree
 
-__all__ = ["TreeFinding", "TreeScanResult", "scan_committed_tree"]
+__all__ = ["BannedTermsUnsetError", "TreeFinding", "TreeScanResult", "scan_committed_tree"]
 
 
 @dataclass(frozen=True)
@@ -38,10 +38,13 @@ def scan_committed_tree(repo_root: Path, *, config_path: Path | None = None) -> 
     """Scan *repo_root*'s committed tree for high-confidence brand names.
 
     *config_path* overrides the resolved ``~/.teatree.toml``; when omitted
-    the gate's own resolution is used. A missing config is fine — the
-    ``$TEATREE_BANNED_BRANDS`` env var may still supply the brand list. With
-    no brands from either source the brand backstop is INERT
-    (``brands_configured=False``); the always-on terminology gate still runs.
+    the gate's own resolution is used. The ``$TEATREE_BANNED_BRANDS`` env var
+    may supply the brand list when no config exists. A genuinely-unset brand
+    list (no config, no env, a missing key) propagates
+    :class:`BannedTermsUnsetError` — the caller surfaces it LOUD rather
+    than scanning as empty. An explicit ``banned_brands = []`` is the
+    deliberate no-brands choice: the brand backstop is INERT
+    (``brands_configured=False``) and the always-on terminology gate still runs.
     """
     resolved = config_path if config_path is not None else banned_terms_scanner.resolve_config()
     terms = load_brand_terms(resolved or Path("/nonexistent/.teatree.toml"))

--- a/src/teatree/hooks/banned_terms_cli.py
+++ b/src/teatree/hooks/banned_terms_cli.py
@@ -41,6 +41,7 @@ import sys
 import tomllib
 from pathlib import Path
 
+from teatree.hooks.banned_terms_tree_scan import BannedTermsUnsetError
 from teatree.hooks.term_match import file_matches as _file_matches
 from teatree.hooks.term_match import line_matches, strip_emails
 from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to_fail
@@ -50,29 +51,49 @@ from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to
 # the commit, so the budget is deliberately tight.
 _GIT_DIFF_TIMEOUT_S = 10
 
+# The REQUIRED term-list key (an unset value fails loud) vs the OPTIONAL
+# allow-list key (an unset value defaults to empty). See ``_load_terms`` /
+# ``_load_allowlist`` for the split.
+_TERMS_KEY = "banned_terms"
+_ALLOWLIST_KEY = "banned_terms_allowlist"
 
-def _load_array(config: Path, key: str) -> tuple[str, ...]:
-    """Return the first ``key`` array found in any TOML section (or the root).
+
+def _load_array(config: Path, key: str) -> tuple[str, ...] | None:
+    """Return the first ``key`` array found in any TOML section, or ``None`` if unset.
 
     Mirrors the old shell extractor: scan every top-level section (and the
-    document root) for *key* and use the first one found. Backs both the
-    ``banned_terms`` list and the ``banned_terms_allowlist`` carve-out.
+    document root) for *key* and use the first list found. ``None`` is the
+    distinct "unset" signal — the key appears as a list in NO section, or the
+    config is unloadable — that the caller turns into a LOUD failure for the
+    REQUIRED ``banned_terms`` key while leaving the OPTIONAL allowlist at its
+    empty default. An explicit empty array returns ``()`` (set, but
+    deliberately empty), never ``None``.
     """
     try:
         data = tomllib.loads(config.read_text(encoding="utf-8"))
     except (OSError, tomllib.TOMLDecodeError):
-        return ()
+        return None
     for value in [*data.values(), data]:
         if isinstance(value, dict) and key in value:
             entries = value[key]
             if isinstance(entries, list):
                 return tuple(str(e).strip() for e in entries if str(e).strip())
-    return ()
+    return None
 
 
 def _load_terms(config: Path) -> tuple[str, ...]:
-    """Return the first ``banned_terms`` array found in the TOML config."""
-    return _load_array(config, "banned_terms")
+    """Return the ``banned_terms`` array; RAISE when it is genuinely unset.
+
+    An explicit ``banned_terms = []`` is the operator's deliberate no-terms
+    choice and returns ``()``. A genuinely-absent key (or an unloadable config)
+    raises :class:`BannedTermsUnsetError` — an unset list is too
+    dangerous to scan as empty because a load bug would look identical to a
+    deliberate empty list.
+    """
+    terms = _load_array(config, _TERMS_KEY)
+    if terms is None:
+        raise BannedTermsUnsetError.for_key(_TERMS_KEY)
+    return terms
 
 
 def _load_allowlist(config: Path) -> tuple[str, ...]:
@@ -83,9 +104,11 @@ def _load_allowlist(config: Path) -> tuple[str, ...]:
     NEVER a leak — they are the org's own org/repo names, not customer PII. Each
     entry's token-run is removed from a line before banned-term matching, so a
     shorter banned term (a bare org slug) can no longer surface inside a longer
-    company-owned identifier. Empty (default) preserves the prior behaviour.
+    company-owned identifier. Unlike ``banned_terms`` the allow-list is OPTIONAL:
+    an absent key defaults to empty (preserving the prior behaviour), never a
+    raise.
     """
-    return _load_array(config, "banned_terms_allowlist")
+    return _load_array(config, _ALLOWLIST_KEY) or ()
 
 
 def staged_added_lines(repo: Path, file: str) -> list[str] | None:
@@ -192,10 +215,18 @@ def main(argv: list[str]) -> int:  # pragma: no cover — CLI entry point (orche
 
     config = Path(args.config).expanduser()
     if not config.is_file():
-        return 0  # no config ⇒ no-op, matching the old shell behaviour
-    terms = _load_terms(config)
+        return 0  # no config file ⇒ no-op (a machine with no teatree config)
+    try:
+        terms = _load_terms(config)
+    except BannedTermsUnsetError as exc:
+        # The config EXISTS but omits banned_terms — fail LOUD (exit 2, the
+        # scanner's "could not run" code) rather than silently scan as empty:
+        # an unset list is indistinguishable from a load bug. An
+        # explicit ``banned_terms = []`` does not raise and is a clean no-op.
+        sys.stderr.write(f"{exc}\n")
+        return 2
     if not terms:
-        return 0  # no terms ⇒ no-op
+        return 0  # explicit empty list ⇒ deliberate no-op
     allowlist = _load_allowlist(config)
 
     if args.diff_only:

--- a/src/teatree/hooks/banned_terms_tree_scan.py
+++ b/src/teatree/hooks/banned_terms_tree_scan.py
@@ -106,10 +106,12 @@ class BannedTermsUnsetError(RuntimeError):
 
     @classmethod
     def for_key(cls, key: str, env_var: str | None = None) -> "BannedTermsUnsetError":
+        item_noun = key.rsplit("_", 1)[-1]
+        list_label = key.replace("_", "-")
         env_hint = f" (or supply the ${env_var} secret)" if env_var else ""
         return cls(
             f"{key} is unset — set it explicitly (use `{key} = []` if you intend "
-            f"no terms){env_hint}; refusing to run with an unloadable banned-terms list."
+            f"no {item_noun}){env_hint}; refusing to run with an unloadable {list_label} list."
         )
 
 

--- a/src/teatree/hooks/banned_terms_tree_scan.py
+++ b/src/teatree/hooks/banned_terms_tree_scan.py
@@ -51,6 +51,7 @@ from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to
 # gate so the public repo can enforce the backstop from a CI secret
 # without committing any brand name. Takes precedence over the config.
 _BRANDS_ENV = "TEATREE_BANNED_BRANDS"
+_BRANDS_KEY = "banned_brands"
 
 _GIT_LS_TIMEOUT_S = 30
 _GIT_SHOW_TIMEOUT_S = 30
@@ -91,6 +92,27 @@ _TEXT_SUFFIXES: frozenset[str] = frozenset(
 )
 
 
+class BannedTermsUnsetError(RuntimeError):
+    """The configured banned-terms/brands list is genuinely UNSET.
+
+    Separates a genuinely-absent list — a missing config, an unloadable
+    config, a missing key, or a wrong-typed value — from a DELIBERATE empty
+    list (``key = []``). An unset list is refused LOUD so a load bug that
+    silently returns nothing can never be mistaken for "the operator chose no
+    terms"; an explicit empty list is allowed and returns an empty tuple. The
+    message names the offending key and the deliberate-empty escape hatch so
+    the fix is actionable.
+    """
+
+    @classmethod
+    def for_key(cls, key: str, env_var: str | None = None) -> "BannedTermsUnsetError":
+        env_hint = f" (or supply the ${env_var} secret)" if env_var else ""
+        return cls(
+            f"{key} is unset — set it explicitly (use `{key} = []` if you intend "
+            f"no terms){env_hint}; refusing to run with an unloadable banned-terms list."
+        )
+
+
 @dataclass(frozen=True)
 class TreeFinding:
     """A single banned-brand hit in a committed file."""
@@ -105,28 +127,32 @@ class TreeFinding:
 
 
 def load_brand_terms(config_path: Path) -> tuple[str, ...]:
-    """Load the high-confidence brand list.
+    """Load the high-confidence brand list, FAILING LOUD when it is unset.
 
     ``$TEATREE_BANNED_BRANDS`` (comma-separated) takes precedence so CI —
-    where ``~/.teatree.toml`` does not exist — feeds the list from a
-    secret. Otherwise reads ``[teatree].banned_brands`` from *config_path*.
-    Returns an empty tuple when neither source declares any brand — the
-    scan is then a clean no-op, matching the public repo's tenant-agnostic
-    default.
+    where ``~/.teatree.toml`` does not exist — feeds the list from a secret;
+    a set env var short-circuits before any raise. Otherwise reads
+    ``[teatree].banned_brands`` from *config_path*. An explicit
+    ``banned_brands = []`` is the operator's deliberate no-brands choice and
+    returns an empty tuple. A genuinely-unset list — no config, an unloadable
+    config, a missing key, or a wrong-typed value — raises
+    :class:`BannedTermsUnsetError`: an unset list is too dangerous to
+    scan as empty because a load bug would look identical to a deliberate
+    no-brands choice.
     """
     env = os.environ.get(_BRANDS_ENV, "")
     if env.strip():
         return tuple(t.strip() for t in env.split(",") if t.strip())
     if not config_path.is_file():
-        return ()
+        raise BannedTermsUnsetError.for_key(_BRANDS_KEY, _BRANDS_ENV)
     try:
         data = tomllib.loads(config_path.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        return ()
-    section = data.get("teatree", {})
-    brands = section.get("banned_brands", []) if isinstance(section, dict) else []
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise BannedTermsUnsetError.for_key(_BRANDS_KEY, _BRANDS_ENV) from exc
+    section = data.get("teatree")
+    brands = section.get("banned_brands") if isinstance(section, dict) else None
     if not isinstance(brands, list):
-        return ()
+        raise BannedTermsUnsetError.for_key(_BRANDS_KEY, _BRANDS_ENV)
     return tuple(str(t).strip() for t in brands if isinstance(t, str) and t.strip())
 
 

--- a/tests/teatree_hooks/test_banned_terms_cli_diff_only.py
+++ b/tests/teatree_hooks/test_banned_terms_cli_diff_only.py
@@ -25,7 +25,15 @@ from pathlib import Path
 import pytest
 
 from teatree.hooks import banned_terms_cli
-from teatree.hooks.banned_terms_cli import _diff_only_report, _full_file_report, _load_terms, staged_added_lines
+from teatree.hooks.banned_terms_cli import (
+    _diff_only_report,
+    _full_file_report,
+    _load_allowlist,
+    _load_terms,
+    main,
+    staged_added_lines,
+)
+from teatree.hooks.banned_terms_tree_scan import BannedTermsUnsetError
 
 _TERMS = ("acme",)
 
@@ -379,13 +387,70 @@ def test_load_terms_reads_first_banned_terms_array(tmp_path: Path) -> None:
     assert _load_terms(config) == ("acme", "widget")
 
 
-def test_load_terms_empty_on_unreadable_or_termless_config(tmp_path: Path) -> None:
+def test_load_terms_raises_on_unset(tmp_path: Path) -> None:
+    # A missing config, a config that omits banned_terms, and a wrong-typed
+    # value are ALL "unset" — refused LOUD so a load bug never masquerades as a
+    # deliberate empty list.
     missing = tmp_path / "nope.toml"
-    assert _load_terms(missing) == ()
+    with pytest.raises(BannedTermsUnsetError):
+        _load_terms(missing)
 
     no_terms = tmp_path / "no_terms.toml"
     no_terms.write_text("[teatree]\nother = 1\n", encoding="utf-8")
-    assert _load_terms(no_terms) == ()
+    with pytest.raises(BannedTermsUnsetError):
+        _load_terms(no_terms)
+
+    non_list = tmp_path / "non_list.toml"
+    non_list.write_text('[teatree]\nbanned_terms = "not-a-list"\n', encoding="utf-8")
+    with pytest.raises(BannedTermsUnsetError):
+        _load_terms(non_list)
+
+
+def test_load_terms_explicit_empty_list_is_allowed(tmp_path: Path) -> None:
+    # The deliberate no-terms choice: an explicit empty array is NOT unset.
+    config = tmp_path / "empty.toml"
+    config.write_text("[teatree]\nbanned_terms = []\n", encoding="utf-8")
+    assert _load_terms(config) == ()
+
+
+def test_load_allowlist_stays_empty_when_unset(tmp_path: Path) -> None:
+    # The allowlist is OPTIONAL — an absent key defaults to empty, never raises.
+    config = tmp_path / "no_allow.toml"
+    config.write_text('[teatree]\nbanned_terms = ["acme"]\n', encoding="utf-8")
+    assert _load_allowlist(config) == ()
+
+
+class TestMainUnsetVsEmpty:
+    """``main`` fails LOUD on an unset banned_terms but is a no-op on empty.
+
+    The shell hook keeps "no config file ⇒ no-op" (the legitimate off-state for
+    a machine with no teatree config), but once a config FILE exists the
+    ``banned_terms`` key must be present — an absent key is refused (exit 2)
+    so a load bug never reads as a clean scan. An explicit empty list is the
+    deliberate no-op.
+    """
+
+    def test_no_config_file_is_a_noop(self, tmp_path: Path) -> None:
+        clean = tmp_path / "clean.md"
+        clean.write_text("nothing to see\n", encoding="utf-8")
+        assert main(["--config", str(tmp_path / "absent.toml"), str(clean)]) == 0
+
+    def test_config_without_banned_terms_exits_misconfigured(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        config = tmp_path / "no_terms.toml"
+        config.write_text("[teatree]\nother = 1\n", encoding="utf-8")
+        clean = tmp_path / "clean.md"
+        clean.write_text("nothing\n", encoding="utf-8")
+        assert main(["--config", str(config), str(clean)]) == 2
+        assert "banned_terms is unset" in capsys.readouterr().err
+
+    def test_explicit_empty_banned_terms_is_a_noop(self, tmp_path: Path) -> None:
+        config = tmp_path / "empty.toml"
+        config.write_text("[teatree]\nbanned_terms = []\n", encoding="utf-8")
+        flagged = tmp_path / "doc.md"
+        flagged.write_text("acme reference\n", encoding="utf-8")
+        assert main(["--config", str(config), str(flagged)]) == 0
 
 
 def test_full_file_report_flags_committed_line(tmp_path: Path) -> None:

--- a/tests/test_banned_terms_tree_scan.py
+++ b/tests/test_banned_terms_tree_scan.py
@@ -236,6 +236,16 @@ class TestScanTreeReadsCommittedBlob:
 
 
 class TestLoadBrandTerms:
+    """``load_brand_terms`` separates UNSET from explicit-empty.
+
+    A genuinely-absent brand list — no config, an unloadable config, a missing
+    ``banned_brands`` key, or a wrong-typed value — is refused LOUD with
+    ``BannedTermsUnsetError`` so a load bug can never masquerade as "the
+    operator chose no brands". An explicit ``banned_brands = []`` is the
+    deliberate no-brands choice and is allowed. ``$TEATREE_BANNED_BRANDS``
+    keeps precedence and short-circuits the raise.
+    """
+
     def test_reads_high_confidence_brands(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path, brands=[SYNTH_BRAND])
         assert banned_terms_tree_scan.load_brand_terms(cfg) == (SYNTH_BRAND,)
@@ -246,8 +256,26 @@ class TestLoadBrandTerms:
         cfg = _config(tmp_path, brands=[SYNTH_BRAND], banned_terms=["ship"])
         assert banned_terms_tree_scan.load_brand_terms(cfg) == (SYNTH_BRAND,)
 
-    def test_missing_config_is_empty(self, tmp_path: Path) -> None:
-        assert banned_terms_tree_scan.load_brand_terms(tmp_path / "absent.toml") == ()
+    def test_explicit_empty_brands_list_is_allowed(self, tmp_path: Path) -> None:
+        # The deliberate no-brands choice: an explicit empty list is NOT unset.
+        cfg = _config(tmp_path, brands=[])
+        assert banned_terms_tree_scan.load_brand_terms(cfg) == ()
+
+    def test_missing_config_with_no_env_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(banned_terms_tree_scan.BannedTermsUnsetError):
+            banned_terms_tree_scan.load_brand_terms(tmp_path / "absent.toml")
+
+    def test_missing_banned_brands_key_raises(self, tmp_path: Path) -> None:
+        cfg = tmp_path / ".teatree.toml"
+        cfg.write_text('[teatree]\nbanned_terms = ["ship"]\n', encoding="utf-8")
+        with pytest.raises(banned_terms_tree_scan.BannedTermsUnsetError):
+            banned_terms_tree_scan.load_brand_terms(cfg)
+
+    def test_no_teatree_section_raises(self, tmp_path: Path) -> None:
+        cfg = tmp_path / ".teatree.toml"
+        cfg.write_text("[other]\nx = 1\n", encoding="utf-8")
+        with pytest.raises(banned_terms_tree_scan.BannedTermsUnsetError):
+            banned_terms_tree_scan.load_brand_terms(cfg)
 
     def test_env_var_takes_precedence_over_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         cfg = _config(tmp_path, brands=["fromconfig"])
@@ -258,15 +286,17 @@ class TestLoadBrandTerms:
         monkeypatch.setenv("TEATREE_BANNED_BRANDS", SYNTH_BRAND)
         assert banned_terms_tree_scan.load_brand_terms(tmp_path / "absent.toml") == (SYNTH_BRAND,)
 
-    def test_malformed_toml_is_empty(self, tmp_path: Path) -> None:
+    def test_malformed_toml_raises(self, tmp_path: Path) -> None:
         cfg = tmp_path / ".teatree.toml"
         cfg.write_text("not = valid = toml", encoding="utf-8")
-        assert banned_terms_tree_scan.load_brand_terms(cfg) == ()
+        with pytest.raises(banned_terms_tree_scan.BannedTermsUnsetError):
+            banned_terms_tree_scan.load_brand_terms(cfg)
 
-    def test_non_list_brands_key_is_empty(self, tmp_path: Path) -> None:
+    def test_non_list_brands_key_raises(self, tmp_path: Path) -> None:
         cfg = tmp_path / ".teatree.toml"
         cfg.write_text('[teatree]\nbanned_brands = "not-a-list"\n', encoding="utf-8")
-        assert banned_terms_tree_scan.load_brand_terms(cfg) == ()
+        with pytest.raises(banned_terms_tree_scan.BannedTermsUnsetError):
+            banned_terms_tree_scan.load_brand_terms(cfg)
 
 
 class TestCommonWordIsNotSubstringMatched:
@@ -295,12 +325,20 @@ class TestScanCommittedTree:
         assert len(result.findings) == 1
         assert result.brands_configured is True
 
-    def test_no_brands_anywhere_reports_inert(self, tmp_path: Path) -> None:
-        # The brand backstop is INERT when no brands are configured: the
-        # result carries findings (terminology only) AND the loud inert flag,
-        # never a silent clean result that hides the unpopulated key.
+    def test_no_brands_anywhere_raises(self, tmp_path: Path) -> None:
+        # Genuinely unset (no config, no env) is refused LOUD by the loader and
+        # propagated by the coordinator, never a silent inert scan that hides a
+        # load bug.
         repo = _repo_with(tmp_path, "src/app.py", f"x = '{SYNTH_BRAND}'\n")
-        result = banned_terms_tree.scan_committed_tree(repo, config_path=tmp_path / "absent.toml")
+        with pytest.raises(banned_terms_tree.BannedTermsUnsetError):
+            banned_terms_tree.scan_committed_tree(repo, config_path=tmp_path / "absent.toml")
+
+    def test_explicit_empty_brands_is_inert_not_raise(self, tmp_path: Path) -> None:
+        # An explicit empty banned_brands is the deliberate no-brands choice:
+        # the scan is INERT (brands_configured False), never a raise.
+        cfg = _config(tmp_path, brands=[], banned_terms=["ship"])
+        repo = _repo_with(tmp_path, "src/app.py", "clean = True\n")
+        result = banned_terms_tree.scan_committed_tree(repo, config_path=cfg)
         assert result.findings == []
         assert result.brands_configured is False
 
@@ -337,45 +375,43 @@ class TestScanTreeCli:
         assert result.exit_code == 1
         assert "src/app.py" in result.stdout
 
-    def test_no_config_exits_zero(self, tmp_path: Path) -> None:
+    def test_no_config_with_no_env_exits_misconfigured(self, tmp_path: Path) -> None:
         repo = _repo_with(tmp_path, "src/app.py", f"x = '{SYNTH_BRAND}'\n")
         result = CliRunner().invoke(
             banned_terms_app,
             ["scan-tree", "--repo-root", str(repo), "--config", str(tmp_path / "absent.toml")],
         )
-        # An absent config file yields an empty brand list — a legitimate
-        # no-op for the public repo, but the inert state must be LOUD, never
-        # a silent clean green.
-        assert result.exit_code == 0
-        assert "INERT" in result.stdout
-        assert "banned_brands" in result.stdout
+        # Genuinely-unset brands (no config, no env) FAIL LOUD (exit 2): an
+        # unset list is too dangerous to scan as empty — a load bug would look
+        # identical to a deliberate no-brands choice.
+        assert result.exit_code == 2
+        assert "MISCONFIGURED" in result.stdout
+        assert "unset" in result.stdout.lower()
 
 
 class TestScanTreeCliInertSignal:
-    """The brand backstop announces when it is INERT (#1591).
+    """Unset brands FAIL LOUD; an explicit empty list stays INERT.
 
-    An unpopulated ``banned_brands`` key is the defect #1591 fixes: the
-    full-tree brand scan silently returned 0, hiding that the backstop did
-    nothing. The CLI must emit a LOUD inert warning instead of a silent
-    clean line, while still exiting 0 (the no-brands state is legitimate
-    for the public repo).
+    The #1591 design announced an INERT backstop but still exited 0 for BOTH
+    a genuinely-absent ``banned_brands`` and a deliberate empty list — the
+    exact conflation this rule forbids. Genuinely-unset now hard-fails (exit 2),
+    while an explicit ``banned_brands = []`` keeps the loud INERT warning at
+    exit 0 (the operator's deliberate no-brands choice).
     """
 
-    def test_no_brands_emits_loud_inert_warning(self, tmp_path: Path) -> None:
+    def test_unset_brands_exits_misconfigured(self, tmp_path: Path) -> None:
         repo = _repo_with(tmp_path, "src/app.py", "clean = True\n")
         result = CliRunner().invoke(
             banned_terms_app,
             ["scan-tree", "--repo-root", str(repo), "--config", str(tmp_path / "absent.toml")],
         )
-        assert result.exit_code == 0
-        assert "INERT" in result.stdout
-        assert "banned_brands" in result.stdout
-        # The silent-success phrasing must NOT be the whole story.
-        assert "clean (0 findings)" not in result.stdout
+        assert result.exit_code == 2
+        assert "MISCONFIGURED" in result.stdout
+        assert "unset" in result.stdout.lower()
 
     def test_empty_brands_list_in_config_is_inert(self, tmp_path: Path) -> None:
-        # A config that declares banned_terms but leaves banned_brands empty
-        # is exactly the #1591 scenario: the populated key is the wrong one.
+        # An explicit empty banned_brands is the deliberate no-brands choice:
+        # a loud INERT warning, exit 0 — NOT a hard fail and NOT a raise.
         cfg = _config(tmp_path, brands=[], banned_terms=["ship", "delivery"])
         repo = _repo_with(tmp_path, "src/app.py", "clean = True\n")
         result = CliRunner().invoke(
@@ -426,13 +462,16 @@ class TestScanTreeRequireBrandsHardFail:
         assert result.exit_code == 2
         assert "MISCONFIGURED" in result.stdout
 
-    def test_without_flag_no_brands_stays_green(self, tmp_path: Path) -> None:
-        # Anti-vacuity: the SAME no-brands repo that exits 2 under --require-brands
-        # must exit 0 without it, proving the hard-fail is the flag's doing.
+    def test_without_flag_explicit_empty_brands_stays_green(self, tmp_path: Path) -> None:
+        # Anti-vacuity for the flag: the SAME explicit-empty config that exits 2
+        # under --require-brands must exit 0 without it, proving the hard-fail is
+        # the flag's doing. (Genuinely-unset brands now fail LOUD regardless of
+        # the flag — see TestScanTreeCliInertSignal.)
+        cfg = _config(tmp_path, brands=[], banned_terms=["ship"])
         repo = _repo_with(tmp_path, "src/app.py", "clean = True\n")
         result = CliRunner().invoke(
             banned_terms_app,
-            ["scan-tree", "--repo-root", str(repo), "--config", str(tmp_path / "absent.toml")],
+            ["scan-tree", "--repo-root", str(repo), "--config", str(cfg)],
         )
         assert result.exit_code == 0
         assert "INERT" in result.stdout

--- a/tests/test_banned_terms_tree_scan.py
+++ b/tests/test_banned_terms_tree_scan.py
@@ -19,6 +19,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from typer.main import get_command
 from typer.testing import CliRunner
 
 from teatree.cli.banned_terms import banned_terms_app
@@ -299,6 +300,31 @@ class TestLoadBrandTerms:
             banned_terms_tree_scan.load_brand_terms(cfg)
 
 
+class TestBannedTermsUnsetErrorMessageIsKeyAware:
+    """``for_key`` phrases the message for the actual key it is raised for.
+
+    The same class serves both the ``banned_brands`` and ``banned_terms``
+    keys, so a brands failure must read in brand vocabulary ("no brands",
+    "banned-brands list") instead of the generic "terms" wording, while the
+    terms failure keeps its original phrasing.
+    """
+
+    def test_brands_key_reads_in_brand_vocabulary(self) -> None:
+        message = str(banned_terms_tree_scan.BannedTermsUnsetError.for_key("banned_brands", "TEATREE_BANNED_BRANDS"))
+        assert "banned_brands is unset" in message
+        assert "if you intend no brands" in message
+        assert "unloadable banned-brands list" in message
+        assert "$TEATREE_BANNED_BRANDS" in message
+        assert "no terms" not in message
+
+    def test_terms_key_keeps_term_vocabulary(self) -> None:
+        message = str(banned_terms_tree_scan.BannedTermsUnsetError.for_key("banned_terms"))
+        assert "banned_terms is unset" in message
+        assert "if you intend no terms" in message
+        assert "unloadable banned-terms list" in message
+        assert "secret" not in message
+
+
 class TestCommonWordIsNotSubstringMatched:
     def test_common_word_in_brand_scan_does_not_substring_match(self, tmp_path: Path) -> None:
         # If a common word like "ship" were ever fed to the brand scanner,
@@ -499,6 +525,17 @@ class TestScanTreeRequireBrandsHardFail:
         )
         assert result.exit_code == 1
         assert "src/app.py" in result.stdout
+
+    def test_help_text_describes_explicit_empty_governance_not_unset(self) -> None:
+        # The flag governs ONLY the explicit-empty list; a genuinely-unset list
+        # fails loud regardless. The help must reflect that — not the stale
+        # framing that tied the flag to a missing TEATREE_BANNED_BRANDS secret.
+        scan_tree = get_command(banned_terms_app).commands["scan-tree"]
+        option = next(p for p in scan_tree.params if "--require-brands" in p.opts)
+        help_text = option.help or ""
+        assert "banned_brands = []" in help_text
+        assert "regardless" in help_text
+        assert "missing TEATREE_BANNED_BRANDS secret reds" not in help_text
 
 
 class TestBannedTermsTreeCiPassesRequireBrands:


### PR DESCRIPTION
## Summary

An unset `banned_terms` / `banned_brands` list was silently read as an empty
list, so a load bug that returned nothing was indistinguishable from a
deliberate "no terms" choice. This splits UNSET from explicit-empty.

- **Unset** (missing config key, unloadable config, wrong-typed value) -> raise
  `BannedTermsUnsetError`. The shell-hook CLI (`main`, once a config file
  exists) and `t3 banned-terms scan-tree` surface it loudly (exit 2) instead of
  scanning as empty.
- **Explicit empty** (`banned_terms = []` / `banned_brands = []`) -> allowed,
  returns `()` and proceeds (INERT for the brand backstop).
- `$TEATREE_BANNED_BRANDS` precedence and the "no config file => no-op"
  off-state are preserved; the optional `banned_terms_allowlist` still defaults
  to empty.

## Behaviour matrix

| Source state | Before | After |
|---|---|---|
| key absent (no env) | silent empty / inert pass | raise -> exit 2 |
| unloadable / wrong-typed | silent empty | raise -> exit 2 |
| explicit `= []` | inert pass | inert pass (unchanged) |
| populated list | scans | scans (unchanged) |
| `$TEATREE_BANNED_BRANDS` set, toml absent | uses env | uses env (unchanged) |
| no config file at all (shell hook) | no-op | no-op (unchanged) |

## Architecture pre-check

**1. BLUEPRINT alignment** - BLUEPRINT section 1 "Core stays generic" (banned-terms / overlay-leak gates). Behaviour-only change to config loading; no new section.

**2. FSM phase boundaries** - n/a (no Ticket/Worktree state transition).

**3. Extension-point contracts** - n/a (no OverlayBase / scanner / hook-router surface change). `BannedTermsUnsetError` is re-exported from `teatree.core.banned_terms_tree` for the CLI consumer.

**4. Component boundaries** - `hooks/` (loaders + exception), `core/` (coordinator re-export), `cli/` (exit-2 surface). Each stays in its layer.

**5. Dependency direction** - new intra-`teatree.hooks` import (`banned_terms_cli` -> `banned_terms_tree_scan`, shared exception) + existing `cli -> core -> hooks` edge. `uv run tach check` passes (no backwards edge).

**6. Test surface** - `tests/test_banned_terms_tree_scan.py` (load_brand_terms unset/empty/env, scan_committed_tree propagation, scan-tree exit-2) and `tests/teatree_hooks/test_banned_terms_cli_diff_only.py` (`_load_terms` raise, `_load_allowlist` default, `main()` exit-2 vs no-op). Each unset case observed RED before the fix.

**7. Resilience invariants** - the gate fails CLOSED on an unloadable config (a gate that cannot load its config must FAIL, not skip-as-pass). No new external write.

**8. Identity / key normalization** - n/a.

**9. Behavior preservation** - the inert-warning path is preserved for the explicit-empty case; only the genuinely-unset branch is narrowed to fail-loud (the requested behaviour). No must-block test inverted.

## Verification

`uv run ruff check` + `uv run ruff format` clean; `uv run tach check` green; targeted suites green (482 + 87 tests); 100% coverage on the four changed modules.
