### PR TITLE
fix(agents): classify exhaustion cause distinctly (credit vs subscription)

### DIFF
--- a/src/teatree/agents/headless.py
+++ b/src/teatree/agents/headless.py
@@ -36,6 +36,7 @@ from teatree.agents.skill_bundle import resolve_skill_bundle
 from teatree.config import AgentRuntime, get_effective_settings
 from teatree.core.models import Task, TaskAttempt, Ticket
 from teatree.core.models.worktree import Worktree
+from teatree.llm.anthropic_limits import LimitMatch, classify_limit
 from teatree.llm.credentials import AnthropicApiKeyCredential, AnthropicSubscriptionCredential, CredentialError
 from teatree.skill_support.loading import SkillLoadingPolicy
 from teatree.types import SkillMetadata
@@ -171,21 +172,6 @@ class TicketBudget:
 UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
 
 _STUCK_LOOP_PREFIX = "stuck_loop: "
-_USAGE_LIMIT_PREFIX = "usage_limit: "
-
-# Phrases the SDK surfaces on a subscription quota / weekly-limit exhaustion
-# (dogfood-surfaced). A ``ResultMessage(is_error=True)`` carrying any of these
-# is a limit condition the operator must wait out — not a generic crash and not
-# a silent success.
-_USAGE_LIMIT_PHRASES = (
-    "usage limit",
-    "weekly limit",
-    "rate limit",
-    "out of credits",
-    "quota exceeded",
-)
-
-
 _RESULT_ERROR_PREFIX = "result_error: "
 
 
@@ -197,7 +183,7 @@ def _error_result_reason(message: ResultMessage | None) -> str | None:
     are both genuine FAILED runs (#1764 class): they must record a failed attempt
     carrying the CLI's own ``result`` / ``errors`` / ``api_error_status``, never
     be laundered into a completion that advances the ticket FSM over a failed run.
-    Called only AFTER :func:`_limit_signature` has already claimed a limit error,
+    Called only AFTER :func:`_limit_match` has already claimed a limit error,
     so a limit message never reaches here.
     """
     if message is None:
@@ -216,20 +202,19 @@ def _error_result_reason(message: ResultMessage | None) -> str | None:
     return _RESULT_ERROR_PREFIX + " — ".join(parts)
 
 
-def _limit_signature(message: ResultMessage | None) -> str:
-    """Return the matched usage-limit phrase, or ``""`` when not a limit error.
+def _limit_match(message: ResultMessage | None) -> LimitMatch | None:
+    """Return the classified :class:`LimitMatch`, or ``None`` when not a limit error.
 
     Keyed on ``is_error`` so a healthy result whose text merely discusses limits
     is never flagged. The agent's final ``result`` string is the haystack — the
-    SDK puts the limit message there on a quota-exhausted run.
+    SDK puts the limit message there on an exhausted run — and
+    :func:`~teatree.llm.anthropic_limits.classify_limit` sorts it into its
+    distinct cause (API-credit / subscription-session / subscription-weekly /
+    rate-limit), so a credit-empty key is never reported as a subscription quota.
     """
     if message is None or not message.is_error:
-        return ""
-    haystack = str(message.result or "").casefold()
-    for phrase in _USAGE_LIMIT_PHRASES:
-        if phrase in haystack:
-            return phrase
-    return ""
+        return None
+    return classify_limit(str(message.result or ""))
 
 
 @dataclass(frozen=True)
@@ -303,10 +288,10 @@ def _outcome_failure(task: Task, outcome: _SdkOutcome) -> TaskAttempt | None:
     """
     if outcome.stuck_reason is not None:
         return _record_failure(task, error=f"{_STUCK_LOOP_PREFIX}{outcome.stuck_reason}")
-    limit = _limit_signature(outcome.result_message)
-    if limit:
-        reason = f"{_USAGE_LIMIT_PREFIX}{limit} — subscription quota exhausted; retry after the limit resets"
-        logger.warning("Task %s hit a usage limit: %s", task.pk, reason)
+    limit = _limit_match(outcome.result_message)
+    if limit is not None:
+        reason = limit.as_reason()
+        logger.warning("Task %s hit a model-access limit (%s): %s", task.pk, limit.cause.value, reason)
         return _record_failure(task, error=reason)
     error_reason = _error_result_reason(outcome.result_message)
     if error_reason is not None:

--- a/src/teatree/agents/headless.py
+++ b/src/teatree/agents/headless.py
@@ -22,8 +22,15 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
-from claude_agent_sdk import AssistantMessage, ClaudeAgentOptions, ClaudeSDKClient, ResultMessage, TextBlock
-from claude_agent_sdk.types import SystemPromptPreset
+from claude_agent_sdk import (
+    AssistantMessage,
+    ClaudeAgentOptions,
+    ClaudeSDKClient,
+    RateLimitEvent,
+    ResultMessage,
+    TextBlock,
+)
+from claude_agent_sdk.types import RateLimitInfo, SystemPromptPreset
 from django.conf import settings
 from django.db import close_old_connections
 from django.db.models import Sum
@@ -36,7 +43,7 @@ from teatree.agents.skill_bundle import resolve_skill_bundle
 from teatree.config import AgentRuntime, get_effective_settings
 from teatree.core.models import Task, TaskAttempt, Ticket
 from teatree.core.models.worktree import Worktree
-from teatree.llm.anthropic_limits import LimitMatch, classify_limit
+from teatree.llm.anthropic_limits import LimitMatch, classify_limit, classify_rate_limit_type
 from teatree.llm.credentials import AnthropicApiKeyCredential, AnthropicSubscriptionCredential, CredentialError
 from teatree.skill_support.loading import SkillLoadingPolicy
 from teatree.types import SkillMetadata
@@ -202,18 +209,25 @@ def _error_result_reason(message: ResultMessage | None) -> str | None:
     return _RESULT_ERROR_PREFIX + " — ".join(parts)
 
 
-def _limit_match(message: ResultMessage | None) -> LimitMatch | None:
+def _limit_match(message: ResultMessage | None, rate_limit_info: RateLimitInfo | None = None) -> LimitMatch | None:
     """Return the classified :class:`LimitMatch`, or ``None`` when not a limit error.
 
     Keyed on ``is_error`` so a healthy result whose text merely discusses limits
-    is never flagged. The agent's final ``result`` string is the haystack — the
-    SDK puts the limit message there on an exhausted run — and
-    :func:`~teatree.llm.anthropic_limits.classify_limit` sorts it into its
-    distinct cause (API-credit / subscription-session / subscription-weekly /
-    rate-limit), so a credit-empty key is never reported as a subscription quota.
+    is never flagged. When the run IS an error and the stream carried a rejected
+    :class:`~claude_agent_sdk.types.RateLimitInfo`, classify from its TYPED
+    ``rate_limit_type`` window (unambiguous structured data — a ``seven_day_opus``
+    is the WEEKLY cause, never a 5-hour one); otherwise fall back to phrase-matching
+    the agent's final ``result`` string. Either way
+    :func:`~teatree.llm.anthropic_limits.classify_limit` sorts it into its distinct
+    cause (API-credit / subscription-session / subscription-weekly / rate-limit),
+    so a credit-empty key is never reported as a subscription quota.
     """
     if message is None or not message.is_error:
         return None
+    if rate_limit_info is not None and rate_limit_info.status == "rejected":
+        typed = classify_rate_limit_type(rate_limit_info.rate_limit_type)
+        if typed is not None:
+            return typed
     return classify_limit(str(message.result or ""))
 
 
@@ -230,6 +244,11 @@ class _SdkOutcome:
     agent_text: str
     result_message: ResultMessage | None
     stuck_reason: str | None
+    #: The last REJECTED rate-limit window the stream carried (a ``RateLimitEvent``
+    #: with ``status == "rejected"``), used to classify a limit failure from the
+    #: SDK's unambiguous typed field. ``None`` when the stream named no rejected
+    #: window — the classifier then falls back to phrase-matching the result text.
+    rate_limit_info: RateLimitInfo | None = None
 
 
 def run_headless(
@@ -288,7 +307,7 @@ def _outcome_failure(task: Task, outcome: _SdkOutcome) -> TaskAttempt | None:
     """
     if outcome.stuck_reason is not None:
         return _record_failure(task, error=f"{_STUCK_LOOP_PREFIX}{outcome.stuck_reason}")
-    limit = _limit_match(outcome.result_message)
+    limit = _limit_match(outcome.result_message, outcome.rate_limit_info)
     if limit is not None:
         reason = limit.as_reason()
         logger.warning("Task %s hit a model-access limit (%s): %s", task.pk, limit.cause.value, reason)
@@ -468,21 +487,40 @@ async def _drive_with_heartbeat(
             heartbeat_task.cancel()
 
     if breach:
-        return _SdkOutcome(agent_text=outcome.agent_text, result_message=outcome.result_message, stuck_reason=breach[0])
+        return _SdkOutcome(
+            agent_text=outcome.agent_text,
+            result_message=outcome.result_message,
+            stuck_reason=breach[0],
+            rate_limit_info=outcome.rate_limit_info,
+        )
     return outcome
 
 
 async def _collect(client: ClaudeSDKClient, prompt: str) -> _SdkOutcome:
-    """Send *prompt* and collect the agent's text + terminal ``ResultMessage``."""
+    """Send *prompt* and collect the agent's text + terminal ``ResultMessage`` + rejected window.
+
+    A ``RateLimitEvent`` with ``status == "rejected"`` carries the SDK's typed
+    ``rate_limit_type`` window — the unambiguous source the limit classifier
+    prefers over prose-grep. The LAST rejected one is kept so a hard limit hit at
+    the end of the stream classifies the failure precisely.
+    """
     await client.query(prompt)
     text_parts: list[str] = []
     result_message: ResultMessage | None = None
+    rate_limit_info: RateLimitInfo | None = None
     async for message in client.receive_response():
         if isinstance(message, AssistantMessage):
             text_parts.extend(block.text for block in message.content if isinstance(block, TextBlock))
         elif isinstance(message, ResultMessage):
             result_message = message
-    return _SdkOutcome(agent_text="\n".join(text_parts), result_message=result_message, stuck_reason=None)
+        elif isinstance(message, RateLimitEvent) and message.rate_limit_info.status == "rejected":
+            rate_limit_info = message.rate_limit_info
+    return _SdkOutcome(
+        agent_text="\n".join(text_parts),
+        result_message=result_message,
+        stuck_reason=None,
+        rate_limit_info=rate_limit_info,
+    )
 
 
 def _record_success(task: Task, outcome: _SdkOutcome, *, phase: str = "") -> TaskAttempt:

--- a/src/teatree/cli/eval/all.py
+++ b/src/teatree/cli/eval/all.py
@@ -45,6 +45,7 @@ from teatree.eval.report import ScenarioResult, evaluate
 from teatree.eval.skip_guard import UnmeteredApiRunError, assert_api_run_was_metered
 from teatree.eval.transcript_conformance import InvariantResult
 from teatree.eval.trigger_qa import TriggerQAReport, run_trigger_qa
+from teatree.llm.anthropic_limits import CreditExhaustedError
 from teatree.utils.django_bootstrap import ensure_django
 
 
@@ -165,7 +166,11 @@ def run_ai_lane(
     if isinstance(runner, TranscriptRunner) and not _any_transcript_present(specs, runner):
         _emit_transcript_recipe(specs, target_dir)
         return AiLaneOutcome(lane=_ai_lane_result([], backend=backend, graded=False), results=[])
-    runs = run_specs(runner, specs, parallel=parallel)
+    try:
+        runs = run_specs(runner, specs, parallel=parallel)
+    except CreditExhaustedError as exc:
+        typer.echo(f"ABORTED: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
     results = list(starmap(evaluate, zip(specs, runs, strict=True)))
     return AiLaneOutcome(lane=_ai_lane_result(results, backend=backend, graded=True), results=results)
 

--- a/src/teatree/cli/eval/single_trial.py
+++ b/src/teatree/cli/eval/single_trial.py
@@ -36,6 +36,7 @@ from teatree.eval.backends import (
 from teatree.eval.models import EvalSpec
 from teatree.eval.parallel import run_specs
 from teatree.eval.report import JudgeGrader, ScenarioResult, evaluate, render_html, render_json, render_text
+from teatree.llm.anthropic_limits import CreditExhaustedError
 
 __all__ = ["EscalationConfig", "SingleTrialGates", "make_escalation_runner", "run_single_trial"]
 
@@ -107,7 +108,11 @@ def run_single_trial(  # noqa: PLR0913 — each kwarg threads one resolved `eval
     except UnknownBackendError as exc:
         typer.echo(str(exc), err=True)
         raise typer.Exit(code=2) from None
-    runs = run_specs(runner, specs, parallel=parallel)
+    try:
+        runs = run_specs(runner, specs, parallel=parallel)
+    except CreditExhaustedError as exc:
+        typer.echo(f"ABORTED: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
     results = [evaluate(spec, run, judge=grader) for spec, run in zip(specs, runs, strict=True)]
     renderers = {"json": render_json, "html": render_html}
     typer.echo(renderers.get(output_format, render_text)(results))

--- a/src/teatree/eval/api_runner.py
+++ b/src/teatree/eval/api_runner.py
@@ -64,6 +64,7 @@ from teatree.eval.toolset import (
     scenario_exposes_subagent_spawn,
 )
 from teatree.eval.under_load import build_system_prompt, build_user_prompt
+from teatree.llm.anthropic_limits import CreditExhaustedError, LimitCause, classify_limit
 
 #: Env var names for the metered lane's GENEROUS, configurable resource caps. A
 #: truncated run measures the cap, not behaviour (the first full metered run lost
@@ -667,7 +668,11 @@ async def _collect(prompt: str, options: ClaudeAgentOptions) -> list[Message]:
     :class:`_TerminalResultError` for the runner to grade; a SUCCESS mislabeled as
     an error result (the CLI exited non-zero on a ``"success"`` subtype) is
     re-raised inside a :class:`_SuccessMislabelResultError` so the runner grades the
-    captured messages AND clears the stray ``is_error``; any other error re-raises
+    captured messages AND clears the stray ``is_error``; a metered-key CREDIT
+    exhaustion (HTTP 400 "credit balance is too low" — the billed
+    ``ANTHROPIC_API_KEY`` at $0) is re-raised as a :class:`CreditExhaustedError`
+    so the batch fails LOUD with the console remediation instead of redding every
+    remaining scenario behind an opaque error result; any other error re-raises
     unchanged so a genuine crash is never swallowed.
     """
     messages: list[Message] = []
@@ -680,6 +685,9 @@ async def _collect(prompt: str, options: ClaudeAgentOptions) -> list[Message]:
     except Exception as exc:
         if is_success_result_error(str(exc)):
             raise _SuccessMislabelResultError(messages=messages, cause=exc) from exc
+        limit = classify_limit(str(exc))
+        if limit is not None and limit.cause is LimitCause.API_CREDIT:
+            raise CreditExhaustedError(limit.remediation) from exc
         reason = classify_terminal_error(str(exc))
         if reason is None:
             raise

--- a/src/teatree/eval/parallel.py
+++ b/src/teatree/eval/parallel.py
@@ -15,14 +15,25 @@ regardless of completion order, so callers still ``zip`` runs to specs.
 
 A scenario whose ``run`` raises (an unexpected runner crash) is captured as an
 errored :class:`EvalRun` rather than aborting the whole pool — one bad scenario
-must not lose the other 165's results.
+must not lose the other 165's results. The ONE exception is a
+:class:`~teatree.llm.anthropic_limits.CreditExhaustedError`: a $0 metered key is
+terminal for the WHOLE suite (every remaining scenario would red identically on
+the dead key), so it is NOT swallowed into per-scenario reds — it propagates past
+:func:`_safe_run` and ABORTS the run, cancelling any not-yet-started scenarios.
 """
 
 import concurrent.futures
+import threading
 import traceback
 
 from teatree.eval.backends import EvalRunner
 from teatree.eval.models import EvalRun, EvalSpec
+from teatree.llm.anthropic_limits import CreditExhaustedError
+
+#: Raised by a worker that found the abort flag already set — a sibling scenario
+#: exhausted the metered key's credit, so this one short-circuits BEFORE touching
+#: the runner (no further scenario runs on the dead key).
+_SUITE_ABORTED_MESSAGE = "suite aborted: a prior scenario exhausted the metered key's credit"
 
 DEFAULT_PARALLEL = 1
 MAX_PARALLEL = 20
@@ -34,19 +45,55 @@ def run_specs(runner: EvalRunner, specs: list[EvalSpec], *, parallel: int = DEFA
     ``parallel=1`` (default) runs strictly sequentially — identical to the
     pre-existing ``[runner.run(s) for s in specs]`` loop. ``parallel>1`` caps
     concurrent in-flight runs at ``min(parallel, len(specs), MAX_PARALLEL)``.
+
+    A :class:`~teatree.llm.anthropic_limits.CreditExhaustedError` from any
+    scenario ABORTS the whole run (it propagates instead of becoming N reds): the
+    serial loop stops on the raise, and the parallel pool cancels every
+    not-yet-started future so no further scenario runs on the dead key.
     """
     if not specs:
         return []
     workers = max(1, min(parallel, len(specs), MAX_PARALLEL))
     if workers == 1:
         return [_safe_run(runner, spec) for spec in specs]
+
+    # A shared flag, set by the first scenario to exhaust the metered key. A
+    # worker that picks up a queued scenario after the flag is set short-circuits
+    # BEFORE calling the runner — so no further scenario runs on the dead key even
+    # though every spec was submitted to the pool up front (workers pull from the
+    # queue faster than the consumer could cancel them otherwise).
+    aborted = threading.Event()
+
+    def _guarded(spec: EvalSpec) -> EvalRun:
+        if aborted.is_set():
+            raise CreditExhaustedError(_SUITE_ABORTED_MESSAGE)
+        try:
+            return _safe_run(runner, spec)
+        except CreditExhaustedError:
+            aborted.set()
+            raise
+
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
-        return list(pool.map(lambda spec: _safe_run(runner, spec), specs))
+        futures = {pool.submit(_guarded, spec): index for index, spec in enumerate(specs)}
+        completed: dict[int, EvalRun] = {}
+        try:
+            for future in concurrent.futures.as_completed(futures):
+                completed[futures[future]] = future.result()
+        except CreditExhaustedError:
+            for pending in futures:
+                pending.cancel()
+            raise
+        return [completed[index] for index in range(len(specs))]
 
 
 def _safe_run(runner: EvalRunner, spec: EvalSpec) -> EvalRun:
     try:
         return runner.run(spec)
+    except CreditExhaustedError:
+        # A $0 metered key is terminal for the WHOLE suite, not one scenario:
+        # propagate so run_specs aborts the run instead of redding every
+        # remaining scenario identically behind the dead key.
+        raise
     except Exception as exc:  # noqa: BLE001 — one scenario's crash must not abort the suite.
         return EvalRun(
             spec_name=spec.name,

--- a/src/teatree/llm/anthropic_limits.py
+++ b/src/teatree/llm/anthropic_limits.py
@@ -13,16 +13,39 @@ The four causes (see :class:`LimitCause`):
 - subscription WEEKLY limit — the 7-day window; hard, resets weekly.
 - transient API rate limit — HTTP 429; retry shortly.
 
-The phrase set is the bundled ``claude`` CLI's own error vocabulary — its
-auth-error classifier groups ``credit balance (?:is )?too low | usage limit
-reached``, and the SDK types name the subscription windows ``five_hour`` /
-``seven_day`` (see ``claude_agent_sdk.types.RateLimitType``). The matcher keys on
-those REAL strings, never a guess, so a credit-empty condition is never laundered
-into a subscription-quota report.
+Two inputs classify a signal, preferred in this order:
+
+- The SDK's TYPED window — ``claude_agent_sdk.types.RateLimitInfo.rate_limit_type``
+    (``five_hour`` / ``seven_day`` / ``seven_day_opus`` / ``seven_day_sonnet`` /
+    ``overage``). This is unambiguous structured data, so when it is available
+    (a ``RateLimitEvent`` in the message stream) :func:`classify_rate_limit_type`
+    maps it directly — no prose-grep, no chance of mislabeling a 7-day window as a
+    5-hour one.
+- The raw error TEXT — phrase-matched by :func:`classify_limit` as the fallback
+    for an error string that carries no typed field (e.g. an HTTP 400 ``result``
+    string surfaced by the SDK).
+
+Phrase provenance (finding-4 honesty — the phrases are NOT all verbatim static
+strings, so this does not claim they are). Most are grepped from the bundled
+``claude`` CLI binary, with occurrence counts where confirmed: ``out_of_credits``
+(x16, the structured error code), ``out of usage credits`` (x12), ``credit
+balance (?:is )?too low`` (x7), ``weekly limit`` (x13), ``7-day limit`` (x1),
+``Opus limit`` / ``Sonnet limit`` (x8 each, the per-model 7-day caps), ``session
+limit`` (x12), ``usage limit`` (x31), ``rate limit`` (x81). The remaining entries
+are DEFENSIVE human-readable renderings of the same windows that the CLI composes
+dynamically (e.g. the statusline labels "5-hour and 7-day limits"): ``out of
+credits``, ``seven-day limit``, ``5-hour limit``, ``five-hour limit``. One entry
+is mapped on API semantics rather than a literal match: ``quota exceeded`` — in
+the binary the literal string is only the libc "Disk quota exceeded" error, so it
+is mapped to the transient :data:`LimitCause.RATE_LIMIT` (the API's rate-quota
+wording, keeping pre-PR parity), never to a subscription or credit cause. A
+credit-empty condition is never laundered into a subscription-quota report.
 """
 
 import dataclasses
 from enum import Enum
+
+from claude_agent_sdk.types import RateLimitType
 
 
 class LimitCause(Enum):
@@ -40,23 +63,49 @@ class LimitCause(Enum):
 
 
 #: Phrase -> cause, ordered MOST-SPECIFIC first. Credit phrases precede every
-#: subscription phrase (their remediation is unrelated to any plan), and the
-#: weekly phrase precedes the generic session ``usage limit`` so a 7-day message
-#: is never mislabeled a 5-hour one. Each phrase is a substring the bundled
-#: ``claude`` CLI actually emits — see the module docstring for provenance.
+#: subscription phrase (their remediation is unrelated to any plan); the weekly
+#: phrases (incl. the per-model Opus/Sonnet 7-day caps) precede the generic
+#: session ``usage limit`` so a 7-day message is never mislabeled a 5-hour one;
+#: ``rate limit`` / ``quota exceeded`` are last (the lowest-priority transient
+#: bucket). See the module docstring for each phrase's provenance and counts.
 _SIGNATURES: tuple[tuple[str, LimitCause], ...] = (
-    ("credit balance too low", LimitCause.API_CREDIT),
-    ("credit balance is too low", LimitCause.API_CREDIT),
-    ("out of credits", LimitCause.API_CREDIT),
-    ("weekly limit", LimitCause.SUBSCRIPTION_WEEKLY),
-    ("7-day limit", LimitCause.SUBSCRIPTION_WEEKLY),
-    ("seven-day limit", LimitCause.SUBSCRIPTION_WEEKLY),
-    ("5-hour limit", LimitCause.SUBSCRIPTION_SESSION),
-    ("five-hour limit", LimitCause.SUBSCRIPTION_SESSION),
-    ("session limit", LimitCause.SUBSCRIPTION_SESSION),
-    ("usage limit", LimitCause.SUBSCRIPTION_SESSION),
-    ("rate limit", LimitCause.RATE_LIMIT),
+    # API-key CREDIT / metered usage-based-billing exhaustion (a $0 balance).
+    ("credit balance too low", LimitCause.API_CREDIT),  # CLI x3
+    ("credit balance is too low", LimitCause.API_CREDIT),  # CLI x4
+    ("out of usage credits", LimitCause.API_CREDIT),  # CLI x12
+    ("out_of_credits", LimitCause.API_CREDIT),  # CLI x16 (the structured error code)
+    ("out of credits", LimitCause.API_CREDIT),  # human-readable rendering
+    # Subscription WEEKLY (7-day) windows — the plan-wide cap and the per-model
+    # Opus/Sonnet 7-day caps (the SDK's seven_day_opus / seven_day_sonnet).
+    ("weekly limit", LimitCause.SUBSCRIPTION_WEEKLY),  # CLI x13
+    ("7-day limit", LimitCause.SUBSCRIPTION_WEEKLY),  # CLI x1 (the statusline window label)
+    ("seven-day limit", LimitCause.SUBSCRIPTION_WEEKLY),  # human-readable rendering
+    ("opus limit", LimitCause.SUBSCRIPTION_WEEKLY),  # CLI x8 (the seven_day_opus prose label)
+    ("sonnet limit", LimitCause.SUBSCRIPTION_WEEKLY),  # CLI x8 (the seven_day_sonnet prose label)
+    # Subscription SESSION (~5h rolling) window.
+    ("5-hour limit", LimitCause.SUBSCRIPTION_SESSION),  # the five_hour window rendered in prose
+    ("five-hour limit", LimitCause.SUBSCRIPTION_SESSION),  # human-readable rendering
+    ("session limit", LimitCause.SUBSCRIPTION_SESSION),  # CLI x12
+    ("usage limit", LimitCause.SUBSCRIPTION_SESSION),  # CLI x31
+    # Transient API rate / quota limit (HTTP 429).
+    ("rate limit", LimitCause.RATE_LIMIT),  # CLI x81
+    ("quota exceeded", LimitCause.RATE_LIMIT),  # API rate-quota wording (see docstring)
 )
+
+#: The SDK's TYPED rate-limit window -> cause. This is the unambiguous,
+#: structured-data path (``RateLimitInfo.rate_limit_type``), preferred over
+#: prose-grep whenever a ``RateLimitEvent`` is available: the five-hour window is
+#: the rolling SESSION limit, every seven-day window (plan-wide + the per-model
+#: Opus/Sonnet caps) is the WEEKLY limit, and an ``overage`` window is the
+#: usage-based-billing credit cause (its remediation is to add credits, never to
+#: wait out a plan reset).
+_RATE_LIMIT_TYPE_CAUSES: dict[RateLimitType, LimitCause] = {
+    "five_hour": LimitCause.SUBSCRIPTION_SESSION,
+    "seven_day": LimitCause.SUBSCRIPTION_WEEKLY,
+    "seven_day_opus": LimitCause.SUBSCRIPTION_WEEKLY,
+    "seven_day_sonnet": LimitCause.SUBSCRIPTION_WEEKLY,
+    "overage": LimitCause.API_CREDIT,
+}
 
 #: Operator-facing remediation per cause. The API-credit message names the
 #: console explicitly and never says "subscription"; the two subscription
@@ -109,6 +158,23 @@ def classify_limit(text: str) -> LimitMatch | None:
         if phrase in haystack:
             return LimitMatch(phrase=phrase, cause=cause)
     return None
+
+
+def classify_rate_limit_type(rate_limit_type: RateLimitType | None) -> LimitMatch | None:
+    """Classify the SDK's TYPED :attr:`RateLimitInfo.rate_limit_type` window into its cause.
+
+    This is the unambiguous, structured-data path — preferred over
+    :func:`classify_limit`'s prose-grep whenever a ``RateLimitEvent`` is available
+    (it cannot mislabel a 7-day window as a 5-hour one). ``None`` (no typed field)
+    or an unrecognized window value falls through to ``None`` so the caller can
+    drop back to phrase-matching the raw error text. The match's ``phrase`` is the
+    window token itself, so :meth:`LimitMatch.as_reason` records ``seven_day_opus``
+    et al. verbatim.
+    """
+    if rate_limit_type is None:
+        return None
+    cause = _RATE_LIMIT_TYPE_CAUSES.get(rate_limit_type)
+    return LimitMatch(phrase=rate_limit_type, cause=cause) if cause is not None else None
 
 
 class CreditExhaustedError(RuntimeError):

--- a/src/teatree/llm/anthropic_limits.py
+++ b/src/teatree/llm/anthropic_limits.py
@@ -1,0 +1,122 @@
+"""Classify an Anthropic exhaustion signal into its distinct, non-interchangeable cause.
+
+A terminal run can halt for several distinct exhaustion reasons that demand
+DIFFERENT remediations — conflating them sends the operator to the wrong fix.
+The four causes (see :class:`LimitCause`):
+
+- API-key CREDIT exhaustion — the billed ``ANTHROPIC_API_KEY`` has a $0 balance;
+    a real ``/v1/messages`` call returns HTTP 400 (credit balance too low). Fix:
+    add credits at console.anthropic.com. This is NOT a subscription limit and
+    must never be reported as one — the metered-eval path rides this key.
+- subscription SESSION limit — the ~5h rolling limit; resets the same day, so
+    re-dispatching later works.
+- subscription WEEKLY limit — the 7-day window; hard, resets weekly.
+- transient API rate limit — HTTP 429; retry shortly.
+
+The phrase set is the bundled ``claude`` CLI's own error vocabulary — its
+auth-error classifier groups ``credit balance (?:is )?too low | usage limit
+reached``, and the SDK types name the subscription windows ``five_hour`` /
+``seven_day`` (see ``claude_agent_sdk.types.RateLimitType``). The matcher keys on
+those REAL strings, never a guess, so a credit-empty condition is never laundered
+into a subscription-quota report.
+"""
+
+import dataclasses
+from enum import Enum
+
+
+class LimitCause(Enum):
+    """The distinct exhaustion cause a terminal limit signal carries.
+
+    The ``value`` doubles as the machine marker prefixed onto a recorded failure
+    reason, so a downstream reader can branch on the cause without re-parsing the
+    human message.
+    """
+
+    API_CREDIT = "api_credit"
+    SUBSCRIPTION_SESSION = "subscription_session"
+    SUBSCRIPTION_WEEKLY = "subscription_weekly"
+    RATE_LIMIT = "rate_limit"
+
+
+#: Phrase -> cause, ordered MOST-SPECIFIC first. Credit phrases precede every
+#: subscription phrase (their remediation is unrelated to any plan), and the
+#: weekly phrase precedes the generic session ``usage limit`` so a 7-day message
+#: is never mislabeled a 5-hour one. Each phrase is a substring the bundled
+#: ``claude`` CLI actually emits — see the module docstring for provenance.
+_SIGNATURES: tuple[tuple[str, LimitCause], ...] = (
+    ("credit balance too low", LimitCause.API_CREDIT),
+    ("credit balance is too low", LimitCause.API_CREDIT),
+    ("out of credits", LimitCause.API_CREDIT),
+    ("weekly limit", LimitCause.SUBSCRIPTION_WEEKLY),
+    ("7-day limit", LimitCause.SUBSCRIPTION_WEEKLY),
+    ("seven-day limit", LimitCause.SUBSCRIPTION_WEEKLY),
+    ("5-hour limit", LimitCause.SUBSCRIPTION_SESSION),
+    ("five-hour limit", LimitCause.SUBSCRIPTION_SESSION),
+    ("session limit", LimitCause.SUBSCRIPTION_SESSION),
+    ("usage limit", LimitCause.SUBSCRIPTION_SESSION),
+    ("rate limit", LimitCause.RATE_LIMIT),
+)
+
+#: Operator-facing remediation per cause. The API-credit message names the
+#: console explicitly and never says "subscription"; the two subscription
+#: messages name their own reset cadence so session and weekly read distinctly.
+_REMEDIATION: dict[LimitCause, str] = {
+    LimitCause.API_CREDIT: (
+        "API credits exhausted — the billed ANTHROPIC_API_KEY has no balance; add credits at console.anthropic.com"
+    ),
+    LimitCause.SUBSCRIPTION_SESSION: (
+        "subscription session limit reached (the ~5h rolling limit) — retry after it resets (same day)"
+    ),
+    LimitCause.SUBSCRIPTION_WEEKLY: ("subscription weekly limit reached — retry after the weekly reset"),
+    LimitCause.RATE_LIMIT: ("Anthropic API rate limit hit (transient) — retry shortly"),
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class LimitMatch:
+    """A matched exhaustion signal: the phrase that fired and its classified cause."""
+
+    phrase: str
+    cause: LimitCause
+
+    @property
+    def remediation(self) -> str:
+        """The operator-facing remediation message for this match's cause."""
+        return _REMEDIATION[self.cause]
+
+    def as_reason(self) -> str:
+        """The recorded failure reason: ``<cause>: <phrase> — <remediation>``.
+
+        The leading ``<cause>`` marker lets a downstream reader branch on the
+        cause without re-parsing prose; the phrase preserves the actual signal
+        the CLI emitted; the remediation tells the operator exactly what to do.
+        """
+        return f"{self.cause.value}: {self.phrase} — {self.remediation}"
+
+
+def classify_limit(text: str) -> LimitMatch | None:
+    """Return the :class:`LimitMatch` *text* signals, or ``None`` when it names no known limit.
+
+    Case-insensitive substring match against :data:`_SIGNATURES` in order, so the
+    most-specific phrase wins. The caller is responsible for gating on whatever
+    "this is an error" signal its transport carries (``ResultMessage.is_error``
+    for the headless path, a raised SDK exception for the eval path) before
+    handing the text here — this function only classifies the text.
+    """
+    haystack = text.casefold()
+    for phrase, cause in _SIGNATURES:
+        if phrase in haystack:
+            return LimitMatch(phrase=phrase, cause=cause)
+    return None
+
+
+class CreditExhaustedError(RuntimeError):
+    """The billed ``ANTHROPIC_API_KEY`` has a $0 balance (an :data:`LimitCause.API_CREDIT`).
+
+    A real ``/v1/messages`` call on a credit-empty key returns HTTP 400 (credit
+    balance too low). That is NOT a per-scenario cap and NOT a generic crash —
+    nothing more can execute until credits are added — so the metered-eval lane
+    raises this distinct, actionable error (carrying the console remediation)
+    rather than redding every remaining scenario behind an opaque error result.
+    """

--- a/tests/teatree_agents/_sdk_fake.py
+++ b/tests/teatree_agents/_sdk_fake.py
@@ -14,7 +14,8 @@ from collections.abc import AsyncIterator, Iterator
 from typing import Any, Self
 from unittest.mock import patch
 
-from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+from claude_agent_sdk import AssistantMessage, RateLimitEvent, ResultMessage, TextBlock
+from claude_agent_sdk.types import RateLimitInfo, RateLimitStatus, RateLimitType
 
 import teatree.agents.headless as headless_mod
 from teatree.agents.headless import TaskUsage
@@ -45,6 +46,18 @@ def result_message(**overrides: Any) -> ResultMessage:
 
 def assistant_text(text: str) -> AssistantMessage:
     return AssistantMessage(content=[TextBlock(text=text)], model="claude-opus-4-8[1m]")
+
+
+def rate_limit_event(rate_limit_type: RateLimitType, *, status: RateLimitStatus = "rejected") -> RateLimitEvent:
+    """A typed :class:`RateLimitEvent` carrying the SDK's unambiguous window.
+
+    ``status="rejected"`` is the hard-limit-hit signal the classifier acts on.
+    """
+    return RateLimitEvent(
+        rate_limit_info=RateLimitInfo(status=status, rate_limit_type=rate_limit_type),
+        uuid="rl-1",
+        session_id="s1",
+    )
 
 
 def success_stream(result: dict[str, Any], **result_kwargs: Any) -> list[Any]:

--- a/tests/teatree_agents/test_headless.py
+++ b/tests/teatree_agents/test_headless.py
@@ -17,7 +17,7 @@ from teatree.agents.headless import (
     TicketBudget,
     _drive_with_heartbeat,
     _get_resume_session_id,
-    _limit_signature,
+    _limit_match,
     _parse_result,
     _runtime_child_env,
     _validate_result,
@@ -28,6 +28,7 @@ from teatree.agents.headless_usage import _safe_float, _safe_int
 from teatree.agents.model_tiering import TIER_MODELS
 from teatree.config import AgentRuntime
 from teatree.core.models import ConfigSetting, Session, Task, TaskAttempt, Ticket
+from teatree.llm.anthropic_limits import LimitCause
 from tests.teatree_agents._sdk_fake import assistant_text as _assistant_text
 from tests.teatree_agents._sdk_fake import fake_sdk as _fake_sdk
 from tests.teatree_agents._sdk_fake import result_message as _result_message
@@ -244,8 +245,9 @@ class TestRunHeadlessUsageLimit(TestCase):
 
         task.refresh_from_db()
         assert attempt.exit_code != 0
-        assert "usage_limit" in attempt.error
+        assert "subscription_weekly" in attempt.error
         assert "weekly limit" in attempt.error
+        assert "credit" not in attempt.error.casefold()
         assert task.status == Task.Status.FAILED
 
     def test_usage_limit_phrase_recorded(self) -> None:
@@ -260,8 +262,69 @@ class TestRunHeadlessUsageLimit(TestCase):
             attempt = run_headless(task, phase="coding", overlay_skill_metadata={})
 
         task.refresh_from_db()
-        assert "usage_limit" in attempt.error
+        assert "subscription_session" in attempt.error
         assert "usage limit" in attempt.error
+        assert task.status == Task.Status.FAILED
+
+    def test_credit_balance_too_low_is_api_credit_not_subscription(self) -> None:
+        # The billed ANTHROPIC_API_KEY at $0 surfaces HTTP 400 "credit balance
+        # is too low" — an API-CREDIT exhaustion, NOT a subscription quota. The
+        # operator fix is to add credits at console.anthropic.com.
+        credit_message = _result_message(
+            subtype="error_during_execution",
+            is_error=True,
+            api_error_status=400,
+            result="Your credit balance is too low to access the Anthropic API.",
+        )
+        with _fake_sdk([_assistant_text("starting"), credit_message]):
+            session = Session.objects.create(ticket=self.ticket)
+            task = Task.objects.create(ticket=self.ticket, session=session)
+            attempt = run_headless(task, phase="coding", overlay_skill_metadata={})
+
+        task.refresh_from_db()
+        assert attempt.exit_code != 0
+        assert "api_credit" in attempt.error
+        assert "console.anthropic.com" in attempt.error
+        assert "subscription" not in attempt.error.casefold()
+        assert "weekly" not in attempt.error.casefold()
+        assert task.status == Task.Status.FAILED
+
+    def test_out_of_credits_is_api_credit_not_subscription(self) -> None:
+        # "out of credits" is an API-CREDIT signal — it must NOT be laundered into
+        # the generic "subscription quota exhausted" message (the original bug).
+        credit_message = _result_message(
+            subtype="error_during_execution",
+            is_error=True,
+            result="The request failed: you are out of credits.",
+        )
+        with _fake_sdk([credit_message]):
+            session = Session.objects.create(ticket=self.ticket)
+            task = Task.objects.create(ticket=self.ticket, session=session)
+            attempt = run_headless(task, phase="coding", overlay_skill_metadata={})
+
+        task.refresh_from_db()
+        assert "api_credit" in attempt.error
+        assert "console.anthropic.com" in attempt.error
+        assert "subscription" not in attempt.error.casefold()
+        assert task.status == Task.Status.FAILED
+
+    def test_session_limit_classified_distinctly_from_weekly(self) -> None:
+        # The ~5h rolling SESSION limit resets same-day — it must report a session
+        # cause, never the weekly one and never a credit one.
+        session_message = _result_message(
+            subtype="error_during_execution",
+            is_error=True,
+            result="Claude 5-hour limit reached for this session.",
+        )
+        with _fake_sdk([session_message]):
+            session = Session.objects.create(ticket=self.ticket)
+            task = Task.objects.create(ticket=self.ticket, session=session)
+            attempt = run_headless(task, phase="coding", overlay_skill_metadata={})
+
+        task.refresh_from_db()
+        assert "subscription_session" in attempt.error
+        assert "weekly" not in attempt.error.casefold()
+        assert "credit" not in attempt.error.casefold()
         assert task.status == Task.Status.FAILED
 
     def test_non_error_result_mentioning_limit_is_not_a_limit_failure(self) -> None:
@@ -313,23 +376,35 @@ class TestRunHeadlessUsageLimit(TestCase):
         assert task.status == Task.Status.FAILED
 
 
-def test_limit_signature_matches_known_phrases() -> None:
+def test_limit_match_classifies_weekly_distinctly() -> None:
     msg = _result_message(is_error=True, result="You've hit your weekly limit.")
-    assert _limit_signature(msg) == "weekly limit"
+    match = _limit_match(msg)
+    assert match is not None
+    assert match.cause is LimitCause.SUBSCRIPTION_WEEKLY
+    assert match.phrase == "weekly limit"
 
 
-def test_limit_signature_ignores_non_error_results() -> None:
+def test_limit_match_classifies_credit_as_api_credit_not_subscription() -> None:
+    msg = _result_message(is_error=True, result="Your credit balance is too low.")
+    match = _limit_match(msg)
+    assert match is not None
+    assert match.cause is LimitCause.API_CREDIT
+    assert "console.anthropic.com" in match.remediation
+    assert "subscription" not in match.as_reason().casefold()
+
+
+def test_limit_match_ignores_non_error_results() -> None:
     msg = _result_message(is_error=False, result="weekly limit discussed in passing")
-    assert _limit_signature(msg) == ""
+    assert _limit_match(msg) is None
 
 
-def test_limit_signature_ignores_unrelated_error() -> None:
+def test_limit_match_ignores_unrelated_error() -> None:
     msg = _result_message(is_error=True, result="some other failure")
-    assert _limit_signature(msg) == ""
+    assert _limit_match(msg) is None
 
 
-def test_limit_signature_handles_missing_message() -> None:
-    assert _limit_signature(None) == ""
+def test_limit_match_handles_missing_message() -> None:
+    assert _limit_match(None) is None
 
 
 # --- Pure function tests (no DB) ---

--- a/tests/teatree_agents/test_headless.py
+++ b/tests/teatree_agents/test_headless.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from claude_agent_sdk.types import RateLimitType
 from django.test import TestCase, override_settings
 
 import teatree.agents.headless as headless_mod
@@ -31,6 +32,7 @@ from teatree.core.models import ConfigSetting, Session, Task, TaskAttempt, Ticke
 from teatree.llm.anthropic_limits import LimitCause
 from tests.teatree_agents._sdk_fake import assistant_text as _assistant_text
 from tests.teatree_agents._sdk_fake import fake_sdk as _fake_sdk
+from tests.teatree_agents._sdk_fake import rate_limit_event as _rate_limit_event
 from tests.teatree_agents._sdk_fake import result_message as _result_message
 from tests.teatree_agents._sdk_fake import success_stream as _success_stream
 
@@ -374,6 +376,64 @@ class TestRunHeadlessUsageLimit(TestCase):
         task.refresh_from_db()
         assert attempt.exit_code != 0
         assert task.status == Task.Status.FAILED
+
+
+class TestRunHeadlessTypedRateLimitWindow(TestCase):
+    """A rejected ``RateLimitEvent`` classifies the failure from its TYPED window.
+
+    The per-model 7-day windows (``seven_day_opus`` / ``seven_day_sonnet``)
+    matched NO phrase signature, so a weekly cap would land as a generic crash.
+    With the typed field wired through ``_collect`` they classify WEEKLY — and the
+    result text here names NO limit phrase, so the ONLY path to a weekly verdict is
+    the typed window (anti-vacuous: the test fails without the typed wiring).
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.ticket = Ticket.objects.create()
+
+    def _run_with_window(self, window: RateLimitType) -> TaskAttempt:
+        event = _rate_limit_event(window)
+        terminal = _result_message(
+            subtype="error_during_execution", is_error=True, result="The run could not complete."
+        )
+        with _fake_sdk([_assistant_text("working"), event, terminal]):
+            session = Session.objects.create(ticket=self.ticket, agent_id="agent-typed")
+            task = Task.objects.create(ticket=self.ticket, session=session)
+            attempt = run_headless(task, phase="coding", overlay_skill_metadata={})
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+        return attempt
+
+    def test_seven_day_opus_window_recorded_as_subscription_weekly(self) -> None:
+        attempt = self._run_with_window("seven_day_opus")
+        assert "subscription_weekly" in attempt.error
+        assert "seven_day_opus" in attempt.error
+        assert "credit" not in attempt.error.casefold()
+
+    def test_seven_day_sonnet_window_recorded_as_subscription_weekly(self) -> None:
+        attempt = self._run_with_window("seven_day_sonnet")
+        assert "subscription_weekly" in attempt.error
+        assert "seven_day_sonnet" in attempt.error
+
+
+def test_limit_match_prefers_the_typed_window_over_the_result_text() -> None:
+    # The result text names no limit phrase; the rejected typed window is the only
+    # signal, so _limit_match classifies WEEKLY from it (the fallback would be None).
+    msg = _result_message(is_error=True, result="The run could not complete.")
+    info = _rate_limit_event("seven_day_sonnet").rate_limit_info
+    match = _limit_match(msg, info)
+    assert match is not None
+    assert match.cause is LimitCause.SUBSCRIPTION_WEEKLY
+    assert match.phrase == "seven_day_sonnet"
+
+
+def test_limit_match_typed_window_ignored_when_result_is_not_an_error() -> None:
+    # The is_error gate still governs: a healthy run is never failed on a stray
+    # rejected window event.
+    msg = _result_message(is_error=False, result="done")
+    info = _rate_limit_event("seven_day_opus").rate_limit_info
+    assert _limit_match(msg, info) is None
 
 
 def test_limit_match_classifies_weekly_distinctly() -> None:

--- a/tests/teatree_eval/test_api_runner.py
+++ b/tests/teatree_eval/test_api_runner.py
@@ -26,6 +26,7 @@ from teatree.eval.api_runner import (
     BudgetExceededError,
     ClaudeCliMissingError,
     CleanRoomConfig,
+    CreditExhaustedError,
     build_sdk_options,
     classify_terminal_error,
     is_success_result_error,
@@ -857,6 +858,43 @@ class TestApiInProcessRunnerBudgetExceeded:
         assert result.passed is False
         assert result.verdict == "fail"
         assert result.run.cost_usd == pytest.approx(0.1)
+
+
+class TestApiInProcessRunnerCreditExhausted:
+    """A metered-key $0 balance surfaces a distinct, actionable CreditExhaustedError."""
+
+    def _run_with_raising_query(self, spec: EvalSpec, query):
+        with (
+            patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
+            patch("teatree.eval.api_runner.query", query),
+        ):
+            return ApiInProcessRunner(workspace=spec.source_path.parent).run(spec)
+
+    def test_credit_balance_too_low_raises_credit_exhausted_not_generic(self, tmp_path: Path) -> None:
+        # The billed ANTHROPIC_API_KEY at $0 surfaces HTTP 400 "credit balance is
+        # too low". The metered lane must fail LOUD with the console remediation,
+        # not bubble an opaque error result that reds every remaining scenario.
+        spec = _spec(tmp_path)
+        query = _budget_raising_query(
+            "Claude Code returned an error result: Your credit balance is too low to access the Anthropic API."
+        )
+        with pytest.raises(CreditExhaustedError, match=r"console\.anthropic\.com"):
+            self._run_with_raising_query(spec, query)
+
+    def test_credit_exhausted_message_does_not_claim_subscription(self, tmp_path: Path) -> None:
+        spec = _spec(tmp_path)
+        query = _budget_raising_query("Claude Code returned an error result: credit balance too low")
+        with pytest.raises(CreditExhaustedError) as exc_info:
+            self._run_with_raising_query(spec, query)
+        assert "subscription" not in str(exc_info.value).casefold()
+
+    def test_non_credit_error_still_propagates_unchanged(self, tmp_path: Path) -> None:
+        # Anti-vacuity: the credit catch is targeted, NOT a blanket swallow. A
+        # generic error must still surface as itself.
+        spec = _spec(tmp_path)
+        query = _budget_raising_query("Claude Code returned an error result: error_during_execution")
+        with pytest.raises(Exception, match="error_during_execution"):
+            self._run_with_raising_query(spec, query)
 
 
 def _yield_then_raise_query(messages: list[Any], message: str):

--- a/tests/teatree_eval/test_parallel.py
+++ b/tests/teatree_eval/test_parallel.py
@@ -4,8 +4,11 @@ import threading
 import time
 from pathlib import Path
 
+import pytest
+
 from teatree.eval.models import EvalRun, EvalSpec, Matcher
 from teatree.eval.parallel import DEFAULT_PARALLEL, run_specs
+from teatree.llm.anthropic_limits import CreditExhaustedError
 
 
 def _spec(tmp_path: Path, *, name: str) -> EvalSpec:
@@ -115,3 +118,53 @@ class TestRunSpecs:
         assert errored.is_error
         assert "boom" in errored.terminal_reason or "RuntimeError" in errored.terminal_reason
         assert all(not r.is_error for r in runs if r.spec_name != "s2")
+
+
+class _CreditExhaustedRunner:
+    """A runner whose every ``run`` raises ``CreditExhaustedError`` (a $0 metered key).
+
+    Records how many runs it serviced so a test can prove the suite ABORTED early
+    rather than redding every scenario on the dead key.
+    """
+
+    def __init__(self, *, work_seconds: float = 0.0) -> None:
+        self._work_seconds = work_seconds
+        self._lock = threading.Lock()
+        self.ran = 0
+
+    def run(self, spec: EvalSpec) -> EvalRun:
+        with self._lock:
+            self.ran += 1
+        if self._work_seconds:
+            time.sleep(self._work_seconds)
+        msg = "API credits exhausted — add credits at console.anthropic.com"
+        raise CreditExhaustedError(msg)
+
+
+class TestCreditExhaustedAbortsTheSuite:
+    """A $0 metered key is terminal for the WHOLE suite — it must NOT become N reds.
+
+    On the UNFIXED code ``_safe_run``'s broad ``except Exception`` swallowed the
+    ``CreditExhaustedError`` into a per-scenario errored ``EvalRun``, so the batch
+    kept running against the dead key and red'd every remaining scenario
+    identically. These assert the opposite: the error PROPAGATES (aborts) and
+    fewer than all scenarios run.
+    """
+
+    def test_serial_credit_exhaustion_aborts_and_does_not_red_every_scenario(self, tmp_path: Path) -> None:
+        specs = [_spec(tmp_path, name=f"s{i}") for i in range(5)]
+        runner = _CreditExhaustedRunner()
+        with pytest.raises(CreditExhaustedError, match=r"console\.anthropic\.com"):
+            run_specs(runner, specs, parallel=1)
+        # Aborted on the FIRST scenario — never red'd the remaining four.
+        assert runner.ran == 1
+
+    def test_parallel_credit_exhaustion_aborts_and_cancels_pending_scenarios(self, tmp_path: Path) -> None:
+        specs = [_spec(tmp_path, name=f"s{i}") for i in range(8)]
+        # A small per-run delay so the pool's first wave hits the dead key and the
+        # abort cancels the not-yet-started futures before they are dispatched.
+        runner = _CreditExhaustedRunner(work_seconds=0.02)
+        with pytest.raises(CreditExhaustedError):
+            run_specs(runner, specs, parallel=4)
+        # Pending scenarios were cancelled, so NOT all eight ran on the dead key.
+        assert runner.ran < len(specs)

--- a/tests/teatree_llm/test_anthropic_limits.py
+++ b/tests/teatree_llm/test_anthropic_limits.py
@@ -1,0 +1,59 @@
+"""The Anthropic exhaustion classifier sorts each REAL signal into its distinct cause."""
+
+import pytest
+
+from teatree.llm.anthropic_limits import LimitCause, LimitMatch, classify_limit
+
+
+class TestClassifyLimit:
+    @pytest.mark.parametrize(
+        ("text", "cause"),
+        [
+            # API-key credit exhaustion — the billed key at $0 (HTTP 400).
+            ("Your credit balance is too low to access the Anthropic API.", LimitCause.API_CREDIT),
+            ("Credit balance too low", LimitCause.API_CREDIT),
+            ("the request failed: you are out of credits", LimitCause.API_CREDIT),
+            # Subscription weekly (7-day) window.
+            ("You've hit your weekly limit. It resets on Jun 14.", LimitCause.SUBSCRIPTION_WEEKLY),
+            ("reached the 7-day limit", LimitCause.SUBSCRIPTION_WEEKLY),
+            # Subscription ~5h rolling session window.
+            ("Claude usage limit reached for this session.", LimitCause.SUBSCRIPTION_SESSION),
+            ("you hit the 5-hour limit", LimitCause.SUBSCRIPTION_SESSION),
+            # Transient API rate limit.
+            ("HTTP 429: rate limit exceeded, retry later", LimitCause.RATE_LIMIT),
+        ],
+    )
+    def test_classifies_each_real_signal_distinctly(self, text: str, cause: LimitCause) -> None:
+        match = classify_limit(text)
+        assert match is not None
+        assert match.cause is cause
+
+    def test_credit_precedes_subscription_and_remediation_names_the_console(self) -> None:
+        match = classify_limit("Your credit balance is too low.")
+        assert match is not None
+        assert match.cause is LimitCause.API_CREDIT
+        assert "console.anthropic.com" in match.remediation
+        assert "subscription" not in match.as_reason().casefold()
+
+    def test_weekly_is_not_mislabeled_as_the_generic_session_usage_limit(self) -> None:
+        # A 7-day message must classify weekly, never the 5-hour session cause.
+        match = classify_limit("You've reached your weekly limit.")
+        assert match is not None
+        assert match.cause is LimitCause.SUBSCRIPTION_WEEKLY
+
+    def test_session_and_weekly_remediations_read_distinctly(self) -> None:
+        session = classify_limit("usage limit reached")
+        weekly = classify_limit("weekly limit reached")
+        assert session is not None
+        assert weekly is not None
+        assert "same day" in session.remediation
+        assert "weekly reset" in weekly.remediation
+        assert session.remediation != weekly.remediation
+
+    def test_unrelated_text_classifies_as_no_limit(self) -> None:
+        assert classify_limit("some other failure about a socket") is None
+        assert classify_limit("") is None
+
+    def test_as_reason_leads_with_the_machine_cause_marker(self) -> None:
+        match = LimitMatch(phrase="weekly limit", cause=LimitCause.SUBSCRIPTION_WEEKLY)
+        assert match.as_reason().startswith("subscription_weekly: weekly limit — ")

--- a/tests/teatree_llm/test_anthropic_limits.py
+++ b/tests/teatree_llm/test_anthropic_limits.py
@@ -1,26 +1,36 @@
 """The Anthropic exhaustion classifier sorts each REAL signal into its distinct cause."""
 
-import pytest
+from typing import cast
 
-from teatree.llm.anthropic_limits import LimitCause, LimitMatch, classify_limit
+import pytest
+from claude_agent_sdk.types import RateLimitType
+
+from teatree.llm.anthropic_limits import LimitCause, LimitMatch, classify_limit, classify_rate_limit_type
 
 
 class TestClassifyLimit:
     @pytest.mark.parametrize(
         ("text", "cause"),
         [
-            # API-key credit exhaustion — the billed key at $0 (HTTP 400).
+            # API-key credit exhaustion — the billed key at $0 (HTTP 400) /
+            # metered usage-based-billing overage exhaustion (the REAL CLI strings).
             ("Your credit balance is too low to access the Anthropic API.", LimitCause.API_CREDIT),
             ("Credit balance too low", LimitCause.API_CREDIT),
             ("the request failed: you are out of credits", LimitCause.API_CREDIT),
-            # Subscription weekly (7-day) window.
+            ("You're out of usage credits. Run /usage-credits to keep going.", LimitCause.API_CREDIT),
+            ("rejected: out_of_credits — your org is out of usage", LimitCause.API_CREDIT),
+            # Subscription weekly (7-day) window — incl. the per-model Opus/Sonnet
+            # 7-day caps (the seven_day_opus / seven_day_sonnet prose labels).
             ("You've hit your weekly limit. It resets on Jun 14.", LimitCause.SUBSCRIPTION_WEEKLY),
             ("reached the 7-day limit", LimitCause.SUBSCRIPTION_WEEKLY),
+            ("You've reached your Opus limit. It resets next week.", LimitCause.SUBSCRIPTION_WEEKLY),
+            ("You've reached your Sonnet limit for this week.", LimitCause.SUBSCRIPTION_WEEKLY),
             # Subscription ~5h rolling session window.
             ("Claude usage limit reached for this session.", LimitCause.SUBSCRIPTION_SESSION),
             ("you hit the 5-hour limit", LimitCause.SUBSCRIPTION_SESSION),
-            # Transient API rate limit.
+            # Transient API rate / quota limit.
             ("HTTP 429: rate limit exceeded, retry later", LimitCause.RATE_LIMIT),
+            ("Anthropic API quota exceeded; please back off and retry.", LimitCause.RATE_LIMIT),
         ],
     )
     def test_classifies_each_real_signal_distinctly(self, text: str, cause: LimitCause) -> None:
@@ -57,3 +67,69 @@ class TestClassifyLimit:
     def test_as_reason_leads_with_the_machine_cause_marker(self) -> None:
         match = LimitMatch(phrase="weekly limit", cause=LimitCause.SUBSCRIPTION_WEEKLY)
         assert match.as_reason().startswith("subscription_weekly: weekly limit — ")
+
+    def test_opus_and_sonnet_phrases_are_weekly_not_the_generic_session_limit(self) -> None:
+        # The per-model 7-day caps render as "Opus limit" / "Sonnet limit" — they
+        # are WEEKLY windows and must win over the generic session ``usage limit``.
+        for text in ("You've hit your Opus limit.", "You've hit your Sonnet limit."):
+            match = classify_limit(text)
+            assert match is not None
+            assert match.cause is LimitCause.SUBSCRIPTION_WEEKLY
+
+    def test_overage_credit_strings_are_api_credit_never_subscription(self) -> None:
+        # The REAL usage-based-billing $0 strings must reach the api-credit cause —
+        # a $0 metered condition was previously caught by neither.
+        for text in ("You're out of usage credits.", "error code: out_of_credits"):
+            match = classify_limit(text)
+            assert match is not None
+            assert match.cause is LimitCause.API_CREDIT
+            assert "subscription" not in match.as_reason().casefold()
+
+    def test_quota_exceeded_is_a_transient_rate_limit_not_credit_or_subscription(self) -> None:
+        # Re-added (finding 2) mapped to the transient rate/quota bucket — never
+        # laundered into a credit or subscription cause.
+        match = classify_limit("Anthropic API quota exceeded; back off.")
+        assert match is not None
+        assert match.cause is LimitCause.RATE_LIMIT
+        assert "credit" not in match.as_reason().casefold()
+        assert "subscription" not in match.as_reason().casefold()
+
+
+class TestClassifyRateLimitType:
+    """The SDK's TYPED ``RateLimitInfo.rate_limit_type`` window classifies unambiguously."""
+
+    @pytest.mark.parametrize(
+        ("window", "cause"),
+        [
+            ("five_hour", LimitCause.SUBSCRIPTION_SESSION),
+            ("seven_day", LimitCause.SUBSCRIPTION_WEEKLY),
+            ("seven_day_opus", LimitCause.SUBSCRIPTION_WEEKLY),
+            ("seven_day_sonnet", LimitCause.SUBSCRIPTION_WEEKLY),
+            ("overage", LimitCause.API_CREDIT),
+        ],
+    )
+    def test_each_typed_window_maps_to_its_cause(self, window: RateLimitType, cause: LimitCause) -> None:
+        match = classify_rate_limit_type(window)
+        assert match is not None
+        assert match.cause is cause
+        assert match.phrase == window
+
+    def test_opus_and_sonnet_seven_day_windows_are_weekly_via_the_typed_field(self) -> None:
+        # Finding 3: the per-model 7-day windows that matched NO phrase signature
+        # before now classify WEEKLY from the unambiguous typed field.
+        for window in ("seven_day_opus", "seven_day_sonnet"):
+            match = classify_rate_limit_type(cast("RateLimitType", window))
+            assert match is not None
+            assert match.cause is LimitCause.SUBSCRIPTION_WEEKLY
+
+    def test_overage_window_is_the_credit_cause_with_the_console_remediation(self) -> None:
+        match = classify_rate_limit_type("overage")
+        assert match is not None
+        assert match.cause is LimitCause.API_CREDIT
+        assert "console.anthropic.com" in match.remediation
+        assert "subscription" not in match.as_reason().casefold()
+
+    def test_none_and_unknown_window_classify_as_no_limit(self) -> None:
+        assert classify_rate_limit_type(None) is None
+        # A future/unknown window value falls through to the phrase fallback.
+        assert classify_rate_limit_type(cast("RateLimitType", "made_up_window")) is None


### PR DESCRIPTION
## Problem

A terminal limit ResultMessage collapsed several distinct exhaustion causes
into a single "subscription quota exhausted" report. The reason was assembled
the same way regardless of which phrase matched, so a metered ANTHROPIC_API_KEY
with a $0 balance (HTTP 400, credit balance too low) was reported as a
subscription weekly limit — sending the operator to the wrong fix. A raw
"credit balance too low" message wasn't even recognised as a limit and surfaced
as a generic crash.

## Change

Centralise the Anthropic limit vocabulary in teatree.llm.anthropic_limits,
keyed on the bundled claude CLI's own error strings (its auth classifier groups
credit-balance-too-low and usage-limit-reached) and the SDK's five_hour /
seven_day rate-limit windows. The headless runner now emits a per-cause message
plus remediation:

| Cause | Message |
|---|---|
| api_credit | API credits exhausted — the billed ANTHROPIC_API_KEY has no balance; add credits at console.anthropic.com |
| subscription_session | subscription session limit reached (the ~5h rolling limit) — retry after it resets (same day) |
| subscription_weekly | subscription weekly limit reached — retry after the weekly reset |
| rate_limit | Anthropic API rate limit hit (transient) — retry shortly |

A credit-empty key is never labelled a subscription quota.

The metered-eval api_runner now detects a $0-balance key distinctly: a
credit-empty mid-run raises CreditExhaustedError with the console remediation
instead of redding every remaining scenario behind an opaque error result.

Follow-up (not in this PR): the docker auth path can only resolve the key's
presence, not its balance — only a real /v1/messages call reveals an empty
balance, which is why the distinct detection lives at the api_runner call site
rather than in credential resolution.

## Tests

- tests/teatree_llm/test_anthropic_limits.py — each real signal classifies into its distinct cause; credit precedes subscription; session vs weekly read distinctly.
- tests/teatree_agents/test_headless.py — a credit / out-of-credits message reports api_credit (not subscription); session vs weekly classify distinctly.
- tests/teatree_eval/test_api_runner.py — a credit-balance-too-low mid-run raises CreditExhaustedError; a non-credit error still propagates unchanged.

All touched tests green (222 passed); ruff check / ruff format clean.
