### PR TITLE
feat(gate): orchestrator-investigation-boundary WARN nudge (#1442)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -57,6 +57,10 @@ from loop_state_self_pump_gate import db_loop_state_suppresses_self_pump
 from memory_recall import handle_recall_cold_memory
 from mr_cli_fields import extract_cli_mr_fields, extract_mr_target_repo
 from no_self_reviewer_assign import handle_block_self_reviewer_assign
+from orchestration_boundary_signals import PYTEST_VERB_FINDER as _PYTEST_VERB_FINDER
+from orchestration_boundary_signals import PYTEST_VERB_RE as _PYTEST_VERB_RE
+from orchestration_boundary_signals import call_is_from_subagent as _call_is_from_subagent
+from orchestrator_investigation_gate import handle_enforce_orchestrator_investigation_boundary
 from question_gates import FENCED_CODE_RE, handle_warn_batched_questions, is_user_directed_question
 from state_files import append_line, read_lines
 from subagent_skill_gate import is_file_safe, unreferenced_demand_reason
@@ -3375,16 +3379,9 @@ def handle_block_uncovered_diff(data: dict) -> bool:
 # (#115): 4.x-class agents need to inspect freely, so the gate now flags
 # the narrow set of commands that actually hurt — never every Bash.
 #
-# Main-vs-sub-agent signal (#115 root cause). The PreToolUse payload's
-# ``transcript_path`` ALWAYS points at the PARENT session transcript,
-# even for a sub-agent's tool call (a sub-agent's own turns live in a
-# separate ``…/subagents/agent-<id>.jsonl`` the hook never receives), and
-# the parent transcript's tail entries carry ``isSidechain: false`` — so
-# the previous transcript-``isSidechain`` read MISDETECTED every genuine
-# sub-agent as the main agent and blocked it. The reliable signal is on
-# the payload itself: a sub-agent call carries a non-empty ``agent_id``
-# (and ``agent_type``); a main-agent call omits it. ``_call_is_from_subagent``
-# reads that field directly — no transcript needed.
+# The main-vs-sub-agent signal (#115 root cause: a sub-agent call carries a
+# non-empty ``agent_id``, a main-agent call omits it) is ``_call_is_from_subagent``,
+# imported aliased above from the shared ``orchestration_boundary_signals`` leaf.
 
 # Pure-orchestration tools — always allowed for the main agent.
 _ORCHESTRATION_TOOLS = {
@@ -3397,33 +3394,11 @@ _ORCHESTRATION_TOOLS = {
     "SendMessage",
     "AskUserQuestion",
 }
-# ``pytest`` must match only in a VERB POSITION — never inside a quoted
-# arg, a branch name, a ``-m``/``--title`` message, or a hyphenated
-# package name (``pytest-django``). A bare ``\bpytest\b`` mis-denied the
-# loop owner's ``git commit -m 'fix pytest fixture'`` / ``git branch
-# x-pytest`` / ``uv add pytest-django`` (#1178 cold-review false-deny).
-# So anchor it to a command head: start-of-string OR a shell separator
-# (``;`` ``&&`` ``||`` ``|`` newline ``(`` ``{``), then optional env-var
-# assignments, optional (possibly-stacked) command-wrapper prefixes
-# (``command``/``exec``/``time``/``nice``), and an optional Python runner
-# prefix — note ``uvx`` runs a tool DIRECTLY with no ``run`` (``uvx
-# pytest``), while ``uv``/``poetry``/``pdm``/``hatch`` DO need ``run``, and
-# ``python[3] -m`` — then ``pytest`` NOT followed by a word char or hyphen.
-# The separator branch keeps the shell-grammar bypass guard intact (``git
-# status && pytest`` still denies); the trailing ``(?![\w-])`` keeps the
-# match pinned to ``pytest`` so wrapper prefixes never widen to other tools
-# (``uvx ruff`` / ``command ls`` stay ALLOWED).
-_PYTEST_VERB_RE = (
-    r"(?:^|[;&|\n(){}])"
-    r"\s*"
-    r"(?:\w+=\S+\s+)*"
-    r"(?:(?:command|exec|time|nice)\s+)*"
-    r"(?:uvx\s+|(?:uv|poetry|pdm|hatch)\s+run\s+|python3?\s+-m\s+)?"
-    r"pytest(?![\w-])"
-)
-_PYTEST_VERB_FINDER = re.compile(_PYTEST_VERB_RE)
-
-# A TARGETED pytest run is cheap and must stay ALLOWED in the foreground
+# ``_PYTEST_VERB_RE`` / ``_PYTEST_VERB_FINDER`` (the VERB-position pytest matcher,
+# anchored to a command head so a ``git commit -m '…pytest…'`` mention is not a
+# false-deny — #1178) now live in the shared ``orchestration_boundary_signals``
+# leaf, imported aliased above so this gate and the investigation nudge read one
+# source. A TARGETED pytest run is cheap and must stay ALLOWED in the foreground
 # main agent (#1825): only the whole suite ties the session up. The verb
 # match above tells us a ``pytest`` invocation is present; this decides
 # whether the args make it a single/targeted run. Targeted iff the
@@ -3498,19 +3473,6 @@ _ORCHESTRATOR_HEAVY_BASH_RE = re.compile(
 # mirroring the ``[skip-skill-gate: <reason>]`` token. An empty reason does not
 # unblock.
 _FG_OK_RE = re.compile(r"\[fg-ok:\s*\S[^\]]*?\s*\]")
-
-
-def _call_is_from_subagent(data: dict) -> bool:
-    """True when the gated tool call originates from a sub-agent.
-
-    The PreToolUse payload carries a non-empty ``agent_id`` (and
-    ``agent_type``) for every sub-agent call and omits it for the main
-    agent — the only reliable main-vs-sub-agent signal, because the
-    payload's ``transcript_path`` always points at the PARENT session
-    transcript (see the #115 root-cause note above). Empty/absent
-    ``agent_id`` ⇒ main agent.
-    """
-    return bool(data.get("agent_id"))
 
 
 def _is_orchestration_action(data: dict) -> bool:
@@ -8292,6 +8254,7 @@ _HANDLERS: dict[str, list] = {
         handle_block_ai_signature,
         handle_block_uncovered_diff,
         handle_enforce_orchestrator_boundary,
+        handle_enforce_orchestrator_investigation_boundary,
         handle_warn_batched_questions,
         handle_mirror_question_to_slack,
         handle_orchestrator_turn_budget_nudge,

--- a/hooks/scripts/orchestration_boundary_signals.py
+++ b/hooks/scripts/orchestration_boundary_signals.py
@@ -1,0 +1,68 @@
+"""Shared leaf: orchestration-boundary command/origin signals (#115, #1442).
+
+Two primitives that the orchestrator-boundary gate family reads to decide
+whether a PreToolUse call should be governed:
+
+* :func:`call_is_from_subagent` — main-agent vs sub-agent origin.
+* :data:`PYTEST_VERB_RE` / :data:`PYTEST_VERB_FINDER` — a foreground
+    test-run command shape.
+
+They were inline in ``hook_router`` and are now extracted so BOTH the heavy-Bash
+deny gate (``handle_enforce_orchestrator_boundary``) and the broader
+orchestrator-investigation WARN nudge (``orchestrator_investigation_gate``) read
+them from one shared leaf — neither gate family imports a private off the other,
+and ``hook_router`` nets smaller. This is a dependency-free leaf: it imports
+nothing first-party, so ``hook_router`` and the gate leaves import IT without a
+cycle.
+"""
+
+import re
+import sys
+
+# Alias both identities so a bare ``from orchestration_boundary_signals import
+# ...`` (the live hook, whose dir is on sys.path) and the
+# ``hooks.scripts.orchestration_boundary_signals`` form (a subprocess/test
+# import) resolve the SAME module object.
+sys.modules.setdefault("orchestration_boundary_signals", sys.modules[__name__])
+sys.modules.setdefault("hooks.scripts.orchestration_boundary_signals", sys.modules[__name__])
+
+
+def call_is_from_subagent(data: dict) -> bool:
+    """True when the gated tool call originates from a sub-agent.
+
+    Main-vs-sub-agent signal (#115 root cause). The PreToolUse payload's
+    ``transcript_path`` ALWAYS points at the PARENT session transcript, even for
+    a sub-agent's tool call (a sub-agent's own turns live in a separate
+    ``…/subagents/agent-<id>.jsonl`` the hook never receives), and the parent
+    transcript's tail entries carry ``isSidechain: false`` — so a
+    transcript-``isSidechain`` read MISDETECTS every genuine sub-agent as the
+    main agent. The reliable signal is on the payload itself: a sub-agent call
+    carries a non-empty ``agent_id`` (and ``agent_type``); a main-agent call
+    omits it. Empty/absent ``agent_id`` ⇒ main agent.
+    """
+    return bool(data.get("agent_id"))
+
+
+# ``pytest`` must match only in a VERB POSITION — never inside a quoted arg, a
+# branch name, a ``-m``/``--title`` message, or a hyphenated package name
+# (``pytest-django``). A bare ``\bpytest\b`` mis-matched a ``git commit -m 'fix
+# pytest fixture'`` / ``git branch x-pytest`` / ``uv add pytest-django`` (#1178).
+# So anchor it to a command head: start-of-string OR a shell separator (``;``
+# ``&&`` ``||`` ``|`` newline ``(`` ``{``), then optional env-var assignments,
+# optional (possibly-stacked) command-wrapper prefixes
+# (``command``/``exec``/``time``/``nice``), and an optional Python runner prefix
+# — note ``uvx`` runs a tool DIRECTLY with no ``run`` (``uvx pytest``), while
+# ``uv``/``poetry``/``pdm``/``hatch`` DO need ``run``, and ``python[3] -m`` —
+# then ``pytest`` NOT followed by a word char or hyphen. The separator branch
+# keeps the shell-grammar bypass guard intact (``git status && pytest`` still
+# matches); the trailing ``(?![\w-])`` keeps the match pinned to ``pytest`` so
+# wrapper prefixes never widen to other tools (``uvx ruff`` stays unmatched).
+PYTEST_VERB_RE = (
+    r"(?:^|[;&|\n(){}])"
+    r"\s*"
+    r"(?:\w+=\S+\s+)*"
+    r"(?:(?:command|exec|time|nice)\s+)*"
+    r"(?:uvx\s+|(?:uv|poetry|pdm|hatch)\s+run\s+|python3?\s+-m\s+)?"
+    r"pytest(?![\w-])"
+)
+PYTEST_VERB_FINDER = re.compile(PYTEST_VERB_RE)

--- a/hooks/scripts/orchestrator_investigation_gate.py
+++ b/hooks/scripts/orchestrator_investigation_gate.py
@@ -1,0 +1,206 @@
+"""PreToolUse: orchestrator-investigation-boundary WARN nudge (#1442).
+
+The heavy-Bash gate (#115, ``handle_enforce_orchestrator_boundary``) enforces the
+LOAD-BEARING slice of the orchestrator-decides / loop-executes topology: it
+DENIES the main agent tying its session up on a long/heavy foreground command,
+and deliberately leaves Edit/Write and short Bash alone (4.x-class agents inspect
+freely). The user's standing directive is broader: the loop-owner orchestrator
+does ONLY orchestration (spawn / collect / route / decide / advance the FSM /
+communicate) and never, in the foreground, investigates, diagnoses, fixes, writes
+code, or does git/CI archaeology — all of that is delegated to a sub-agent in a
+worktree. That broader discipline was carried only by skill prose; this gate
+makes it a structural NUDGE.
+
+It is the broad WARN-only complement to the narrow Agent-dispatch DENY
+(``_deny_foreground_agent_dispatch``). Design constraints that make it a WARN,
+never a deny:
+
+* NEVER-LOCKOUT is a hard teatree invariant. A deny here would sit on the
+    orchestrator's own foreground Edit/Write/git hot path — the highest lockout
+    risk in the codebase. A warn cannot wedge the session, so it is the only
+    never-lockout-safe enforcement of a boundary this broad. (Pinned
+    structurally: the handler has NO deny path —
+    ``tests/test_orchestrator_investigation_boundary_hook.py`` asserts via AST
+    that it never reaches ``emit_pretooluse_deny`` / ``_fail_open_or_deny``.)
+* "Orchestration read" vs "investigation read" has no clean automatic split (a
+    single ``git show`` can be either routing or archaeology). A warn that fires
+    on the OBVIOUS investigation/fix signals — an Edit/Write, ``git
+    show``/``blame``/``bisect``, a ``git log`` pickaxe/patch/range, a deep ``git
+    diff``, ``gh``/``glab`` CI verbs, or a foreground test run — steers the
+    orchestrator without ever hard-blocking a borderline call.
+
+Scope: ONLY the live loop-owner session (the session holding the ``loop-owner``
+``LoopLease``); a non-owner interactive session and every sub-agent pass
+untouched. Off-ramps (any one suppresses the nudge): a per-call
+``[orchestration-ok: <reason>]`` token (mirroring ``[fg-ok:]`` /
+``[skip-skill-gate:]``) and the out-of-repo kill-switch ``[teatree]
+orchestrator_investigation_gate_enabled = false``.
+
+``call_is_from_subagent`` / ``PYTEST_VERB_FINDER`` come from the shared
+``orchestration_boundary_signals`` leaf, ``teatree_bool_setting`` from
+``teatree_settings``, and ``bootstrap_teatree_django`` from ``django_bootstrap``
+— all dependency-free leaves, so this module imports them at top level with no
+``hook_router`` cycle.
+"""
+
+import re
+import sys
+
+from django_bootstrap import bootstrap_teatree_django
+from orchestration_boundary_signals import PYTEST_VERB_FINDER, call_is_from_subagent
+from teatree_settings import teatree_bool_setting
+
+# Alias both identities so the handler the router registers and a test patching a
+# helper here operate on ONE module object.
+sys.modules.setdefault("orchestrator_investigation_gate", sys.modules[__name__])
+sys.modules.setdefault("hooks.scripts.orchestrator_investigation_gate", sys.modules[__name__])
+
+# Investigation/archaeology Bash shapes the loop-owner should DELEGATE, not run
+# inline. Read-only ORIENTATION that routes the next dispatch stays unflagged:
+# ``git status``, ``git diff --stat``/``--name-only``, ``gh pr view``/``pr
+# list``, ``glab mr view``/``mr list``, and ``git log --oneline -n`` are the grey
+# zone left to the orchestrator. The gated set is the DEEP-DIVE archaeology and
+# the CI-investigation verbs: ``git show``/``blame``/``bisect``, a ``git log``
+# with a pickaxe/patch/range/follow, a ``git diff`` against a ref/range, the
+# ``gh``/``glab`` ``run``/``api``/``ci``/``pipeline`` verbs, a watched ``gh pr
+# checks``, and a ``gh``/``glab`` ``diff``/``logs`` subcommand — how an agent
+# investigates a failure rather than routes work.
+_ORCHESTRATOR_INVESTIGATION_BASH_RE = re.compile(
+    r"(?:^|[;&|\n(){}])"
+    r"\s*"
+    r"(?:\w+=\S+\s+)*"
+    r"(?:(?:command|exec|time|nice)\s+)*"
+    r"(?:"
+    r"git\s+(?:show|blame|bisect)\b|"
+    r"git\s+log\b[^|&;]*?(?:-S|-G|-p\b|--patch|--follow)|"
+    r"git\s+diff\b[^|&;]*?(?:HEAD|origin/|\.\.)|"
+    r"(?:gh|glab)\s+(?:run|api|ci|pipeline)\b|"
+    r"gh\s+pr\s+checks\b[^|&;]*?--watch|"
+    r"(?:gh|glab)\s+\S+\s+(?:diff|logs?)\b"
+    r")"
+)
+
+# ``[orchestration-ok: <non-empty-reason>]`` anywhere in the command / edit
+# suppresses the nudge for the rare genuine orchestration read (e.g. a one-off
+# ``git show`` to route a dispatch). An empty reason does not suppress. Mirrors
+# the heavy-Bash gate's ``[fg-ok:]`` token.
+_ORCHESTRATION_OK_RE = re.compile(r"\[orchestration-ok:\s*\S[^\]]*?\s*\]")
+
+_INVESTIGATION_EDIT_TOOLS = frozenset({"Edit", "Write", "NotebookEdit"})
+
+
+def _orchestrator_investigation_gate_enabled() -> bool:
+    """Whether the loop-owner investigation NUDGE is enabled (default True).
+
+    Reads ``[teatree] orchestrator_investigation_gate_enabled`` from
+    ``~/.teatree.toml`` via the shared bare-boolean reader: fails OPEN to enabled
+    on a missing/broken config, and only a bare ``false`` is the one-line
+    out-of-repo kill-switch.
+    """
+    return teatree_bool_setting("orchestrator_investigation_gate_enabled", default=True)
+
+
+def _session_is_loop_owner(session_id: str) -> bool:
+    """True iff ``session_id`` holds the live ``loop-owner`` ``LoopLease``.
+
+    The nudge is scoped to the loop-owner session only — a non-owner interactive
+    session inspects freely. Reuses the canonical pid-anchored liveness predicate
+    (``LoopLeaseQuerySet.ownership_status``) so this never re-derives the
+    "live owner" rule. Fails OPEN to NOT-owner (returns False) on a missing
+    session id or any bootstrap/DB error, so a DB hiccup can never make the nudge
+    fire on a non-owner — the safe direction for a steering nudge is silence.
+    """
+    if not session_id or not bootstrap_teatree_django():
+        return False
+    try:
+        from teatree.core.models import LoopLease  # noqa: PLC0415 — Django model; importable only after django.setup().
+
+        status = LoopLease.objects.ownership_status("loop-owner")
+    except Exception:  # noqa: BLE001 — crash-proof: a broken resolver must never make the nudge fire on a non-owner.
+        return False
+    return status.is_live and status.owner_session == session_id
+
+
+def _investigation_signal(data: dict) -> str | None:
+    """A short human label of the investigation/fix shape in this call, or ``None``.
+
+    Names WHAT looks like investigation/diagnosis/fix work (an Edit/Write, a deep
+    ``git`` archaeology command, a ``gh``/``glab`` CI call, a foreground test run)
+    so the nudge can name it. Returns ``None`` for pure-orchestration calls
+    (Read/Grep, ``git status``, ``gh pr view``, the ``t3 …`` verbs) — those never
+    trip the nudge.
+    """
+    tool_name = data.get("tool_name", "")
+    if tool_name in _INVESTIGATION_EDIT_TOOLS:
+        return "an Edit/Write that mutates a file"
+    if tool_name != "Bash":
+        return None
+    command = data.get("tool_input", {}).get("command")
+    if not isinstance(command, str):
+        return None
+    if PYTEST_VERB_FINDER.search(command):
+        return "a foreground test run"
+    if _ORCHESTRATOR_INVESTIGATION_BASH_RE.search(command):
+        return "a deep git/CI investigation command"
+    return None
+
+
+def _orchestration_ok_haystack(data: dict) -> str:
+    """The text scanned for an ``[orchestration-ok: <reason>]`` opt-out token.
+
+    Bash reads ``command``; Edit/Write reads the file path and edited content
+    (first 512 chars each) so the orchestrator can mark a sanctioned inline edit.
+    Mirrors the skill-loading gate's per-call escape surface.
+    """
+    tool_input = data.get("tool_input", {})
+    if data.get("tool_name") == "Bash":
+        command = tool_input.get("command")
+        return command if isinstance(command, str) else ""
+    parts: list[str] = []
+    for key in ("file_path", "new_string", "content"):
+        value = tool_input.get(key)
+        if isinstance(value, str):
+            parts.append(value[:512])
+    return " ".join(parts)
+
+
+def handle_enforce_orchestrator_investigation_boundary(data: dict) -> bool:
+    """NUDGE the loop-owner away from foreground investigation/diagnosis/fix work.
+
+    Structural enforcement of the broader boundary the heavy-Bash gate (#115)
+    leaves to skill prose: the loop-owner orchestrator does ONLY orchestration and
+    delegates investigation / diagnosis / fixing / code-writing / git archaeology
+    / test runs to a sub-agent in a worktree.
+
+    This is a WARN, never a deny — it writes a one-line stderr nudge and ALWAYS
+    returns ``False`` (the call proceeds). A warn is the only never-lockout-safe
+    enforcement for a boundary this broad. Off-ramps that suppress the nudge: it
+    fires ONLY for the live loop-owner session (not sub-agents, not a non-owner
+    interactive session); a per-call ``[orchestration-ok: <reason>]`` token; and
+    the out-of-repo kill-switch ``[teatree]
+    orchestrator_investigation_gate_enabled = false``.
+    """
+    if not _orchestrator_investigation_gate_enabled():
+        return False
+    if call_is_from_subagent(data):
+        return False
+    signal = _investigation_signal(data)
+    if signal is None:
+        return False
+    if _ORCHESTRATION_OK_RE.search(_orchestration_ok_haystack(data)):
+        return False
+    if not _session_is_loop_owner(data.get("session_id", "")):
+        return False
+    sys.stderr.write(
+        "[orchestration-boundary] This looks like "
+        f"{signal} from the loop-owner orchestrator. The orchestrator does ONLY "
+        "orchestration (spawn / collect / route / decide / advance the FSM / "
+        "communicate); investigation, diagnosis, fixing, code edits, git/CI "
+        "archaeology, and test runs belong in a sub-agent in a worktree "
+        "(background if >~30s). Dispatch one (Task/Agent, run_in_background) "
+        "instead of doing the work inline. If this IS genuine orchestration, add "
+        "`[orchestration-ok: <reason>]` to suppress this nudge; to disable the "
+        "nudge entirely set `orchestrator_investigation_gate_enabled = false` "
+        "under `[teatree]` in ~/.teatree.toml.\n"
+    )
+    return False

--- a/tests/test_gate_liveness_corpus.py
+++ b/tests/test_gate_liveness_corpus.py
@@ -1080,6 +1080,10 @@ _NON_DENY_PRETOOLUSE_HANDLERS: Final[frozenset[Callable[[dict], bool | None]]] =
         # One-decision-per-call advisory — warn-only (stderr nudge on a batched
         # AskUserQuestion), returns ``None``, never denies.
         router.handle_warn_batched_questions,
+        # Orchestrator-investigation boundary (#1442) — a WARN-only nudge (stderr
+        # + always returns ``False``); it has no deny path, so no must-deny
+        # corpus payload.
+        router.handle_enforce_orchestrator_investigation_boundary,
     }
 )
 

--- a/tests/test_orchestrator_investigation_boundary_hook.py
+++ b/tests/test_orchestrator_investigation_boundary_hook.py
@@ -1,3 +1,4 @@
+# test-path: cross-cutting — drives the orchestrator-investigation PreToolUse gate in hooks/; no src/teatree/ mirror.
 """Tests for the orchestrator-investigation-boundary WARN nudge (#1442).
 
 The heavy-Bash gate (#115) DENIES only the load-bearing slice of the

--- a/tests/test_orchestrator_investigation_boundary_hook.py
+++ b/tests/test_orchestrator_investigation_boundary_hook.py
@@ -1,0 +1,368 @@
+"""Tests for the orchestrator-investigation-boundary WARN nudge (#1442).
+
+The heavy-Bash gate (#115) DENIES only the load-bearing slice of the
+orchestrator-decides / loop-executes topology (no long/heavy foreground Bash).
+This nudge enforces the BROADER boundary the heavy-Bash gate leaves to skill
+prose: the loop-owner orchestrator does ONLY orchestration and delegates
+investigation / diagnosis / fixing / code edits / git archaeology / test runs to
+a sub-agent in a worktree. It is the broad WARN-only complement to the narrow
+Agent-dispatch DENY.
+
+It is a WARN, never a deny — the only never-lockout-safe enforcement for a
+boundary this broad. It fires ONLY for the live loop-owner session (not
+sub-agents, not a non-owner interactive session), and is suppressed by a per-call
+``[orchestration-ok: <reason>]`` token or the out-of-repo kill-switch ``[teatree]
+orchestrator_investigation_gate_enabled = false``.
+"""
+
+import ast
+import contextlib
+import io
+import sys
+from collections.abc import Iterator
+from datetime import timedelta
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from django.test import TestCase
+from django.utils import timezone
+
+import hooks.scripts.hook_router as router
+import hooks.scripts.orchestrator_investigation_gate as gate
+from hooks.scripts.orchestrator_investigation_gate import (
+    _investigation_signal,
+    _orchestrator_investigation_gate_enabled,
+    _session_is_loop_owner,
+    handle_enforce_orchestrator_investigation_boundary,
+)
+from teatree.core.models import LoopLease
+
+_OWNER = "sess-owner"
+
+
+@contextlib.contextmanager
+def _capture_stderr() -> Iterator[io.StringIO]:
+    """Capture ``sys.stderr`` writes inside a Django ``TestCase`` (no ``capsys``)."""
+    buffer = io.StringIO()
+    original = sys.stderr
+    sys.stderr = buffer
+    try:
+        yield buffer
+    finally:
+        sys.stderr = original
+
+
+@pytest.fixture(autouse=True)
+def _gate_enabled_home(tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point ``Path.home`` at a clean tmp dir so the gate is ON by default."""
+    home = tmp_path_factory.mktemp("home")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+
+def _owner_call(tool_name: str, **tool_input: object) -> dict:
+    return {"session_id": _OWNER, "tool_name": tool_name, "tool_input": tool_input}
+
+
+def _owner_bash(command: str) -> dict:
+    return _owner_call("Bash", command=command)
+
+
+def _subagent_bash(command: str) -> dict:
+    return {
+        "session_id": _OWNER,
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "agent_id": "a4ad83956ff699aaa",
+        "agent_type": "general-purpose",
+    }
+
+
+class TestInvestigationSignalClassification:
+    """``_investigation_signal`` names the investigation/fix shape, or ``None``.
+
+    Pure-logic level (no DB / owner check) — the WHAT-looks-like-work classifier
+    the nudge sits on.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git show HEAD~3",
+            "git blame src/teatree/core/loop.py",
+            "git bisect start",
+            "git log -S needle -- src/",
+            "git log --patch src/teatree/core/loop.py",
+            "git log -G regex",
+            "git log --follow src/teatree/core/loop.py",
+            "git diff HEAD~1",
+            "git diff origin/main",
+            "git diff main..feature",
+            "gh run view 12345",
+            "gh run list --workflow ci",
+            "gh api repos/o/r/commits",
+            "glab ci view",
+            "glab pipeline list",
+            "gh pr checks 42 --watch",
+            "gh pr diff 42",
+            "glab mr diff 7",
+        ],
+    )
+    def test_investigation_bash_is_flagged(self, command: str) -> None:
+        assert _investigation_signal(_owner_bash(command)) == "a deep git/CI investigation command"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git status",
+            "git diff --stat",
+            "git diff --name-only",
+            "git log --oneline -5",
+            "gh pr view 42",
+            "gh pr view 42 --json state",
+            "gh pr list --author @me",
+            "glab mr view 7",
+            "glab mr list",
+            "cat src/teatree/core/loop.py",
+            "ls -la",
+            "grep -rn TODO src/",
+            "t3 loop status",
+            "t3 teatree checking show",
+            "t3 teatree ticket merge 7 --human-authorized owner",
+            "t3 teatree gate disable",
+            "t3 teatree gate fail-open enable",
+            "t3 teatree db migrate",
+        ],
+    )
+    def test_orientation_bash_is_not_flagged(self, command: str) -> None:
+        assert _investigation_signal(_owner_bash(command)) is None
+
+    def test_foreground_pytest_is_flagged(self) -> None:
+        assert _investigation_signal(_owner_bash("uv run pytest --no-cov -q")) == "a foreground test run"
+
+    @pytest.mark.parametrize("tool_name", ["Edit", "Write", "NotebookEdit"])
+    def test_edit_write_is_flagged(self, tool_name: str) -> None:
+        signal = _investigation_signal(_owner_call(tool_name, file_path="src/x.py", new_string="y"))
+        assert signal == "an Edit/Write that mutates a file"
+
+    @pytest.mark.parametrize("tool_name", ["Read", "Grep", "Glob"])
+    def test_read_only_tools_are_not_flagged(self, tool_name: str) -> None:
+        assert _investigation_signal(_owner_call(tool_name, file_path="src/x.py")) is None
+
+    @pytest.mark.parametrize("command", [None, 123, ["pytest"]])
+    def test_non_str_command_is_not_flagged(self, command: object) -> None:
+        assert _investigation_signal({"tool_name": "Bash", "tool_input": {"command": command}}) is None
+
+    def test_unknown_tool_is_not_flagged(self) -> None:
+        assert _investigation_signal({"tool_name": "WebFetch", "tool_input": {}}) is None
+
+
+class TestNudgeIsWarnOnlyNeverDenies:
+    """The handler NEVER returns ``True`` — it cannot lock out the orchestrator.
+
+    A loop-owner running investigation work gets a stderr nudge and the call
+    PROCEEDS (``False``). This is the strongest possible never-lockout guarantee:
+    the gate has no deny path at all.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _is_owner(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(gate, "_session_is_loop_owner", lambda _sid: True)
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            _owner_bash("git show HEAD"),
+            _owner_bash("git log -S secret"),
+            _owner_bash("gh run view 1"),
+            _owner_bash("uv run pytest"),
+            _owner_call("Edit", file_path="src/x.py", new_string="patch"),
+            _owner_call("Write", file_path="src/x.py", content="new file"),
+        ],
+    )
+    def test_investigation_never_denies(self, data: dict) -> None:
+        assert handle_enforce_orchestrator_investigation_boundary(data) is False
+
+    def test_investigation_emits_a_stderr_nudge(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_enforce_orchestrator_investigation_boundary(_owner_bash("git show HEAD")) is False
+        err = capsys.readouterr().err
+        assert "[orchestration-boundary]" in err
+        assert "sub-agent" in err
+        assert "[orchestration-ok:" in err
+
+    def test_orientation_call_emits_no_nudge(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_enforce_orchestrator_investigation_boundary(_owner_bash("git status")) is False
+        assert capsys.readouterr().err.strip() == ""
+
+
+class TestNudgeScopedToLoopOwnerOnly(TestCase):
+    """The nudge fires ONLY for the live loop-owner session.
+
+    A real ``LoopLease`` row drives ``_session_is_loop_owner`` (via the canonical
+    ``ownership_status`` predicate) — RED/GREEN proof that a non-owner interactive
+    session inspects freely while the owner is nudged.
+    """
+
+    @staticmethod
+    def _claim_owner(session_id: str, *, live: bool = True) -> None:
+        expires = timezone.now() + (timedelta(hours=1) if live else timedelta(seconds=-5))
+        LoopLease.objects.create(
+            name="loop-owner",
+            owner=session_id,
+            session_id=session_id,
+            owner_pid=None,
+            acquired_at=timezone.now(),
+            lease_expires_at=expires,
+        )
+
+    def test_owner_session_is_recognized(self) -> None:
+        self._claim_owner(_OWNER)
+        assert _session_is_loop_owner(_OWNER) is True
+
+    def test_non_owner_session_is_not_owner(self) -> None:
+        self._claim_owner(_OWNER)
+        assert _session_is_loop_owner("sess-other") is False
+
+    def test_expired_lease_is_not_owner(self) -> None:
+        self._claim_owner(_OWNER, live=False)
+        assert _session_is_loop_owner(_OWNER) is False
+
+    def test_no_lease_is_not_owner(self) -> None:
+        assert _session_is_loop_owner(_OWNER) is False
+
+    def test_empty_session_is_not_owner(self) -> None:
+        self._claim_owner("")
+        assert _session_is_loop_owner("") is False
+
+    def test_db_error_fails_open_to_not_owner(self) -> None:
+        # A DB hiccup must never make the nudge fire on a non-owner — fail OPEN
+        # to not-owner (silence is the safe direction for a steering nudge).
+        self._claim_owner(_OWNER)
+        with mock.patch.object(LoopLease.objects, "ownership_status", side_effect=RuntimeError("db down")):
+            assert _session_is_loop_owner(_OWNER) is False
+
+    def test_failed_bootstrap_is_not_owner(self) -> None:
+        self._claim_owner(_OWNER)
+        with mock.patch.object(gate, "bootstrap_teatree_django", return_value=False):
+            assert _session_is_loop_owner(_OWNER) is False
+
+    def test_owner_investigation_emits_nudge(self) -> None:
+        self._claim_owner(_OWNER)
+        with _capture_stderr() as err:
+            verdict = handle_enforce_orchestrator_investigation_boundary(_owner_bash("git show HEAD"))
+        assert verdict is False
+        assert "[orchestration-boundary]" in err.getvalue()
+
+    def test_non_owner_investigation_is_silent(self) -> None:
+        self._claim_owner(_OWNER)
+        with _capture_stderr() as err:
+            verdict = handle_enforce_orchestrator_investigation_boundary(
+                {"session_id": "sess-other", "tool_name": "Bash", "tool_input": {"command": "git show HEAD"}}
+            )
+        assert verdict is False
+        assert err.getvalue().strip() == ""
+
+
+class TestSubagentNeverNudged:
+    """A sub-agent (non-empty ``agent_id``) is the hands — never nudged.
+
+    Detection uses ``agent_id`` (the #115 signal), so a sub-agent investigating or
+    fixing in its own worktree is exempt even before the owner check runs (no DB
+    needed).
+    """
+
+    def test_subagent_investigation_is_silent(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert handle_enforce_orchestrator_investigation_boundary(_subagent_bash("git show HEAD")) is False
+        assert capsys.readouterr().err.strip() == ""
+
+
+class TestOrchestrationOkEscapeHatch:
+    """``[orchestration-ok: <reason>]`` suppresses the nudge for a genuine read."""
+
+    @pytest.fixture(autouse=True)
+    def _is_owner(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(gate, "_session_is_loop_owner", lambda _sid: True)
+
+    def test_token_in_bash_suppresses_nudge(self, capsys: pytest.CaptureFixture[str]) -> None:
+        data = _owner_bash("git show HEAD [orchestration-ok: routing the next dispatch]")
+        assert handle_enforce_orchestrator_investigation_boundary(data) is False
+        assert capsys.readouterr().err.strip() == ""
+
+    def test_token_in_edit_content_suppresses_nudge(self, capsys: pytest.CaptureFixture[str]) -> None:
+        data = _owner_call("Edit", file_path="src/x.py", new_string="x  [orchestration-ok: sanctioned memory write]")
+        assert handle_enforce_orchestrator_investigation_boundary(data) is False
+        assert capsys.readouterr().err.strip() == ""
+
+    def test_empty_reason_does_not_suppress(self, capsys: pytest.CaptureFixture[str]) -> None:
+        data = _owner_bash("git show HEAD [orchestration-ok: ]")
+        assert handle_enforce_orchestrator_investigation_boundary(data) is False
+        assert "[orchestration-boundary]" in capsys.readouterr().err
+
+
+class TestGateKillSwitch:
+    def test_disabled_via_toml_suppresses_nudge(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        (tmp_path / ".teatree.toml").write_text(
+            "[teatree]\norchestrator_investigation_gate_enabled = false\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        monkeypatch.setattr(gate, "_session_is_loop_owner", lambda _sid: True)
+        assert _orchestrator_investigation_gate_enabled() is False
+        assert handle_enforce_orchestrator_investigation_boundary(_owner_bash("git show HEAD")) is False
+        assert capsys.readouterr().err.strip() == ""
+
+    def test_enabled_by_default_when_key_absent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        (tmp_path / ".teatree.toml").write_text("[teatree]\n", encoding="utf-8")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        assert _orchestrator_investigation_gate_enabled() is True
+
+    def test_enabled_when_config_missing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        assert _orchestrator_investigation_gate_enabled() is True
+
+    def test_enabled_on_broken_toml(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        (tmp_path / ".teatree.toml").write_text("this is not = valid [[[", encoding="utf-8")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        assert _orchestrator_investigation_gate_enabled() is True
+
+
+class TestRegisteredAsWarnOnly:
+    def test_handler_is_in_pretooluse_chain(self) -> None:
+        assert handle_enforce_orchestrator_investigation_boundary in router._HANDLERS["PreToolUse"]
+
+    def test_handler_never_reaches_a_deny_emitter(self) -> None:
+        # Structural pin: the nudge must never call emit_pretooluse_deny nor
+        # _fail_open_or_deny, so it can never appear as a lockout-prone deny gate.
+        # We assert at BOTH scopes — the handler function AND the whole module —
+        # so no future helper in this module can introduce a deny path.
+        tree = ast.parse(Path(gate.__file__).read_text(encoding="utf-8"))
+        deny_emitters = {"emit_pretooluse_deny", "_fail_open_or_deny"}
+
+        module_calls = {
+            node.func.id for node in ast.walk(tree) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert deny_emitters.isdisjoint(module_calls)
+
+        handler = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef) and n.name == "handle_enforce_orchestrator_investigation_boundary"
+        )
+        handler_calls = {
+            node.func.id for node in ast.walk(handler) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert deny_emitters.isdisjoint(handler_calls)
+
+    def test_handler_returns_false_on_every_path(self) -> None:
+        # Every ``return`` in the handler is a bare ``return False`` — there is no
+        # truthy (deny) return anywhere, complementing the AST no-deny pin above.
+        tree = ast.parse(Path(gate.__file__).read_text(encoding="utf-8"))
+        handler = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef) and n.name == "handle_enforce_orchestrator_investigation_boundary"
+        )
+        returns = [n for n in ast.walk(handler) if isinstance(n, ast.Return)]
+        assert returns
+        assert all(isinstance(r.value, ast.Constant) and r.value.value is False for r in returns)


### PR DESCRIPTION
## What

A loop-owner-scoped, **WARN-only** PreToolUse hook (`handle_enforce_orchestrator_investigation_boundary`) that nudges the orchestrator away from doing investigation work in the foreground — git/CI archaeology, `Edit`/`Write`, and foreground test runs — and toward delegating it to a sub-agent in a worktree.

This is the broad WARN-only complement to the already-shipped **narrow Agent-dispatch DENY** (`_deny_foreground_agent_dispatch`). The heavy-Bash deny gate (#115) enforces only the load-bearing slice (no long/heavy foreground Bash); this nudge covers the broader boundary that was previously carried only by skill prose.

This is a clean re-implementation of recovered work, rebuilt against current `origin/main` (the reference patch was stale).

## Why warn-only (never a deny)

- **Never-lockout** is a hard teatree invariant. A deny on the orchestrator's own `Edit`/`Write`/git hot path would be the worst lockout risk in the codebase.
- "Orchestration read" vs "investigation read" has no clean automatic split — a `git show` can be routing *or* archaeology. A warn steers without ever hard-blocking a borderline call.
- The handler has **no deny path at all**: it writes one stderr line and always returns `False`. Pinned structurally by an AST test asserting it never reaches `emit_pretooluse_deny` / `_fail_open_or_deny`, plus an AST test that every `return` is `return False`, plus membership in the gate-liveness corpus non-deny allowlist.

## Scope + off-ramps

- Fires **only** for the live `loop-owner` `LoopLease` session — reusing the canonical pid-anchored `LoopLeaseQuerySet.ownership_status` predicate (no re-derivation). Sub-agents (non-empty `agent_id`) and non-owner interactive sessions pass untouched.
- Per-call `[orchestration-ok: <reason>]` token suppresses one call (empty reason does not).
- Out-of-repo kill-switch `[teatree] orchestrator_investigation_gate_enabled = false`. Defaults to enabled on a missing/broken config.
- Returns *not-owner* (silent) on a bootstrap/DB error — a hiccup can never make the nudge fire on a non-owner.

## Adaptations to current `main`

- The new handler lives in a **bare sibling module** (`hooks/scripts/orchestrator_investigation_gate.py`) because `hook_router.py` is a shrink-only god-module. The two shared orchestration-boundary primitives (`call_is_from_subagent`, the pytest-verb matcher) are relocated out of `hook_router` into a new dependency-free leaf `hooks/scripts/orchestration_boundary_signals.py`, so both the heavy-Bash gate and this nudge read one source and the router nets **-14 LOC** (ratchet satisfied).
- Uses the current `bootstrap_teatree_django` (was `_bootstrap_teatree_django` in the stale reference).
- No `src/teatree` change — reuses the existing `LoopLease` manager predicate.

## Architecture pre-check

- **BLUEPRINT** orchestrator-decides / loop-executes topology (heavy-Bash gate sibling); a structural nudge, not an FSM transition.
- **Extension point** PreToolUse `_HANDLERS` chain, registered after the heavy-Bash deny gate.
- **Component boundaries** hook handler + signal leaf in `hooks/scripts/`; no business logic added to `src/`.
- **Dependency direction** gate leaves import the signal leaf + `teatree_settings` + `django_bootstrap` (all dependency-free leaves); `tach` clean.
- **Test surface** 75 tests in `tests/test_orchestrator_investigation_boundary_hook.py`.
- **Resilience** idempotent (pure read + stderr); returns not-owner on bootstrap/DB error.

## Tests

- `tests/test_orchestrator_investigation_boundary_hook.py`: **75 passed** — signal classification (flagged vs orientation), warn-only/never-deny (AST + returns-False AST), loop-owner scoping with real `LoopLease` rows (RED/GREEN verified), sub-agent exemption, `[orchestration-ok:]` escape, kill-switch, fail-open branches.
- Affected hook suites together (investigation_boundary_hook, orchestrator_boundary_hook, gate_liveness_corpus, lockout_regression_corpus, gate_never_lockout_contract, orchestrator_responsiveness_corpus): **564 passed**.
- `ruff check` / `ruff format` / `ty-check` / `tach check` clean; module-health ratchet satisfied (`hook_router.py` nets smaller).
