### PR TITLE
fix(worktree): guard reapers with shared liveness predicate (no reaping live work)

### DIFF
--- a/src/teatree/backends/github/sync.py
+++ b/src/teatree/backends/github/sync.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, cast, override
 
 from django.core.cache import cache
 
-from teatree.core.cleanup import cleanup_worktree
+from teatree.core.cleanup import WorktreeBusyError, cleanup_worktree
 from teatree.types import PENDING_REVIEWS_CACHE_KEY, RawAPIDict, SyncBackend, SyncResult
 from teatree.utils.run import run_allowed_to_fail
 
@@ -150,6 +150,8 @@ class GitHubSyncBackend(SyncBackend):
                 cleanup_result = cleanup_worktree(worktree)
                 result.worktrees_cleaned += 1
                 result.errors.extend(cleanup_result.errors)
+            except WorktreeBusyError as exc:
+                logger.info("Keeping worktree %s (live work): %s", worktree.repo_path, exc)
             except RuntimeError as exc:
                 logger.info("Keeping worktree %s (unpushed work): %s", worktree.repo_path, exc)
             except Exception as exc:

--- a/src/teatree/backends/gitlab/sync_terminal.py
+++ b/src/teatree/backends/gitlab/sync_terminal.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, cast
 
 import httpx
 
-from teatree.core.cleanup import cleanup_worktree
+from teatree.core.cleanup import WorktreeBusyError, cleanup_worktree
 from teatree.core.gates.dod_gate import record_terminal_dod_violation
 from teatree.core.models import Ticket, Worktree
 from teatree.types import PREntryDict, RawAPIDict, SyncResult
@@ -143,6 +143,8 @@ def _cleanup_merged_worktrees(ticket: Ticket, result: SyncResult) -> None:
             cleanup_result = cleanup_worktree(worktree)
             result.worktrees_cleaned += 1
             result.errors.extend(cleanup_result.errors)
+        except WorktreeBusyError as exc:
+            logger.info("Keeping worktree %s (live work): %s", worktree.repo_path, exc)
         except Exception as exc:
             logger.exception("Failed to clean worktree %s", worktree.repo_path)
             result.errors.append(f"Worktree cleanup failed for {worktree.repo_path} ({worktree.branch}): {exc}")

--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -31,6 +31,7 @@ from teatree.core.branch_classification import (
     content_equivalence_blockers,
     probe_host_cli,
 )
+from teatree.core.cleanup_busy_guards import WorktreeBusyError, guard_live_worktree
 from teatree.core.cleanup_orphan_ref import raise_or_reap_orphan_ref
 from teatree.core.clone_paths import resolve_clone_path
 from teatree.core.models import Worktree
@@ -46,6 +47,7 @@ __all__ = [
     "BranchClassification",
     "BranchCommit",
     "CleanupResult",
+    "WorktreeBusyError",
     "_branch_pr_is_merged",
     "_branch_tree_matches_squash",
     "_pr_merge_commit_sha",
@@ -568,20 +570,23 @@ def _remove_overlay_pass_entry(overlay: "OverlayBase | None", worktree: Worktree
 
 
 def cleanup_worktree(
-    worktree: Worktree, *, force: bool = False, strict_hygiene: bool = True, keep_if_dirty: bool = False
+    worktree: Worktree,
+    *,
+    force: bool = False,
+    strict_hygiene: bool = True,
+    keep_if_dirty: bool = False,
+    respect_liveness: bool = True,
 ) -> CleanupResult:
     """Remove a single worktree: git worktree, branch, DB, overlay cleanup.
 
     Deletes the Worktree record from the database and returns a
-    :class:`CleanupResult`. Individual teardown-step failures (overlay
-    hook, git worktree/branch removal, DB drop, pass-entry removal,
-    recovery capture) are captured into ``result.errors`` and the
-    remaining steps still run — collect-and-surface, never crash
-    mid-teardown leaving other resources orphaned (#877). The caller is
-    responsible for routing ``result.errors`` to its visible channel
-    (``SyncResult.errors`` for sync backends, runner detail for runners).
+    :class:`CleanupResult`. Individual teardown-step failures are captured into
+    ``result.errors`` and the remaining steps still run — collect-and-surface,
+    never crash mid-teardown leaving other resources orphaned (#877). The caller
+    routes ``result.errors`` to its visible channel (``SyncResult.errors`` for
+    sync backends, runner detail for runners).
 
-    Two guards protect against losing work, both bypassed only by an explicit
+    Several guards protect against losing work; all are bypassed by an explicit
     ``force=True``.
 
     Data-loss guard (#706, always on): raises ``RuntimeError`` when the branch
@@ -589,32 +594,32 @@ def cleanup_worktree(
     irrecoverably.
 
     Hygiene gate (``strict_hygiene``, default on): additionally raises when the
-    branch is genuinely ahead of ``origin/main`` and not squash-merged. Sync
-    backends and interactive ``clean-all`` keep this on; the automated FSM
-    teardown path passes ``strict_hygiene=False`` (the ticket is MERGED and the
-    branch is already on its remote).
+    branch is genuinely ahead of ``origin/main`` and not squash-merged — see
+    :func:`_raise_if_genuinely_ahead`. Sync backends and interactive
+    ``clean-all`` keep it on; the FSM teardown path passes ``strict_hygiene=False``.
 
     Dirty-worktree guard (``keep_if_dirty``, default off): when set, a worktree
-    with uncommitted changes is KEPT — ``RuntimeError`` is raised before any
-    destructive step rather than bundle-and-reaping it. ``clean-all`` passes
-    this so a live worktree an agent is mid-task in is never deleted on a merged
-    signal (#2243); the automated FSM teardown of a genuinely-MERGED ticket
-    leaves it off (the recovery-bundle reap of a dirty merged worktree is
-    intentional there). ``force=True`` overrides it — the explicit-abandon path
-    still bundles and reaps.
+    with uncommitted changes is KEPT before any destructive step — see
+    :func:`_guard_or_warn_dirty_worktree`. ``force=True`` overrides it.
 
-    Recovery-capture backstop (#1506, ``force=True`` only): when the #706/#835
-    guards are bypassed by force, the recovery capture is the only protection.
-    If that capture *fails* and the worktree still has work to lose (dirty or
-    unpushed, determined fail-closed), this raises ``RuntimeError`` too — before
-    the destructive remove and the DB-row delete — so the worktree is left
-    intact and tracked rather than silently destroyed. A proven clean+pushed
-    worktree whose (no-op) capture failed is still reaped, with the failure in
-    ``result.errors``.
+    Recovery-capture backstop (#1506, ``force=True`` only): when force bypasses
+    the #706/#835 guards and the recovery capture itself *fails* while the
+    worktree still has work to lose, teardown is refused before the destructive
+    remove — see :func:`_remove_git_worktree`.
+
+    Liveness guard (``respect_liveness``, default on, #291/#2243): OPPORTUNISTIC
+    reapers KEEP a worktree under live work (raising :class:`WorktreeBusyError`),
+    so the irreversible teardown never protects LESS than the reversible
+    idle-stack reaper — see :func:`guard_live_worktree`. FSM teardown passes
+    ``respect_liveness=False``; ``force=True`` bypasses it.
 
     Pass ``force=True`` only from trusted callers (explicit operator override,
     tests, programmatic API).
     """
+    # Liveness FIRST: a busy worktree short-circuits before resolving paths,
+    # overlay, or touching docker — the cheapest possible KEEP for live work.
+    guard_live_worktree(worktree, respect_liveness=respect_liveness, force=force)
+
     workspace = load_config().user.workspace_dir
     wt_path = _resolve_worktree_path(workspace, worktree)
     overlay = _resolve_overlay_or_none(worktree)

--- a/src/teatree/core/cleanup_busy_guards.py
+++ b/src/teatree/core/cleanup_busy_guards.py
@@ -1,0 +1,53 @@
+"""The worktree-liveness KEEP guard, split out of :mod:`teatree.core.cleanup`.
+
+Lives in its own module so the teardown orchestrator stays under the
+module-health LOC cap (mirrors ``cleanup_orphan_ref``). :func:`guard_live_worktree`
+is the LIVENESS funnel every OPPORTUNISTIC reaper routes through: it
+short-circuits :func:`teatree.core.cleanup.cleanup_worktree` with
+:class:`WorktreeBusyError` BEFORE any destructive step when the ticket has a live
+session, an active/claimed task, an external-delivery lease, a recent E2E run, or
+an explicit ``reaper_pinned`` pin.
+
+The dirty-worktree guard and the committed-but-unpushed DATA-LOSS guards are a
+different concern — they gate the git-removal step on on-disk / remote *git*
+state — and stay in :mod:`teatree.core.cleanup` next to the removal they protect.
+"""
+
+from teatree.core.gates.idle_stack import worktree_protects_against_reap
+from teatree.core.models import Worktree
+
+
+class WorktreeBusyError(RuntimeError):
+    """Raised by :func:`cleanup_worktree` when an OPPORTUNISTIC reap hits live work.
+
+    A subclass of ``RuntimeError`` so existing ``except RuntimeError`` teardown
+    handlers still catch it, while callers that want a distinct
+    keep-with-warning (vs. the unsynced-work push/abandon path) can catch it
+    specifically. Carries the human-readable keep reason from
+    :func:`teatree.core.gates.idle_stack.worktree_protects_against_reap`.
+    """
+
+
+def guard_live_worktree(worktree: Worktree, *, respect_liveness: bool, force: bool) -> None:
+    """KEEP a worktree whose ticket has live work, before any destructive step (#291/#2243).
+
+    The funnel liveness guard every teardown caller routes through. An
+    OPPORTUNISTIC reaper (clean-all, clean-merged, merge-sync cleanup,
+    orphan-isolated-root) leaves ``respect_liveness`` on, so a worktree under
+    live work — a live session, an active/claimed task, an external-delivery
+    lease, a recent E2E run, or an explicit ``reaper_pinned`` — raises
+    :class:`WorktreeBusyError` before docker-down / git-removal / DB-drop, and
+    the caller keeps it with a warning. The IRREVERSIBLE teardown therefore never
+    protects LESS than the REVERSIBLE idle-stack reaper.
+
+    Explicit/FSM-driven teardown (``respect_liveness=False`` — the FSM has
+    decided to tear this worktree down) and explicit abandon (``force=True``)
+    bypass the guard. The data-loss guards (#706 unpushed, dirty-worktree) are
+    orthogonal and still apply on those paths.
+    """
+    if force or not respect_liveness:
+        return
+    reason = worktree_protects_against_reap(worktree)
+    if reason is not None:
+        msg = f"{worktree.repo_path} ({worktree.branch}): kept — {reason} (live work)"
+        raise WorktreeBusyError(msg)

--- a/src/teatree/core/gates/idle_stack.py
+++ b/src/teatree/core/gates/idle_stack.py
@@ -103,12 +103,10 @@ def _is_currently_active(worktree: Worktree, active_path: Path | None) -> bool:
 def ticket_is_busy(ticket: Ticket) -> bool:
     """True iff *ticket* has a live session or an active/claimed task.
 
-    The shared liveness predicate every destructive reaper/teardown path
-    consults before deleting filesystem or DB state: a busy ticket's worktree is
-    live work and must be KEPT, never reaped (#291/#2243 data-loss discipline).
-    The idle-stack reaper, the clean-all worktree reaper
-    (:func:`teatree.core.management.commands._workspace_reap.reap_one_worktree`),
-    and the orphan-isolated-root reaper all route through it.
+    The ticket-level half of the liveness signal. Reapers do not call this
+    directly — they call :func:`worktree_protects_against_reap`, which combines
+    it with the worktree-level active-delivery guards so an irreversible reaper
+    never protects LESS than the reversible idle-stack reaper.
     """
     if Session.objects.filter(ticket=ticket, ended_at__isnull=True).exists():
         return True
@@ -150,6 +148,29 @@ def _active_delivery_keep_reason(worktree: Worktree, *, e2e_cutoff: datetime) ->
     if _is_reaper_pinned(worktree):
         return "explicitly pinned (extra['reaper_pinned'])"
     return None
+
+
+def worktree_protects_against_reap(worktree: Worktree, *, now: datetime | None = None) -> str | None:
+    """The reason a destructive reaper must KEEP *worktree*, or ``None`` when it may reap.
+
+    The shared liveness predicate every OPPORTUNISTIC destructive reaper/teardown
+    path consults before deleting filesystem or DB state — the clean-all worktree
+    reaper (:func:`...._workspace_reap.reap_one_worktree`), the clean-merged sweep,
+    the merge-sync cleanup, and the orphan-isolated-root reaper all route through
+    it (via :func:`teatree.core.cleanup.cleanup_worktree`). It combines the
+    ticket-level :func:`ticket_is_busy` (live session / active-or-claimed task)
+    with the worktree-level #2227 active-delivery guards
+    (:func:`_active_delivery_keep_reason` — external-delivery lease, recent E2E,
+    ``reaper_pinned``) so the IRREVERSIBLE teardown reapers never protect LESS
+    than the REVERSIBLE idle-stack reaper. Explicit/FSM-driven teardown bypasses
+    this (it has decided to tear the worktree down); opportunistic reaps respect
+    it (#291/#2243 data-loss discipline).
+    """
+    if ticket_is_busy(worktree.ticket):
+        return "ticket has a live session or active/claimed task"
+    e2e_minutes = get_effective_settings().idle_stack_e2e_recent_minutes
+    e2e_cutoff = (now or timezone.now()) - timedelta(minutes=e2e_minutes)
+    return _active_delivery_keep_reason(worktree, e2e_cutoff=e2e_cutoff)
 
 
 def preserve_reason(
@@ -223,4 +244,10 @@ def reapable_worktrees(
             yield worktree
 
 
-__all__ = ["classify_running_worktrees", "preserve_reason", "reapable_worktrees", "ticket_is_busy"]
+__all__ = [
+    "classify_running_worktrees",
+    "preserve_reason",
+    "reapable_worktrees",
+    "ticket_is_busy",
+    "worktree_protects_against_reap",
+]

--- a/src/teatree/core/gates/idle_stack.py
+++ b/src/teatree/core/gates/idle_stack.py
@@ -44,7 +44,7 @@ from django.utils import timezone
 from django_fsm import can_proceed
 
 from teatree.config import get_effective_settings
-from teatree.core.models import Session, Task, Worktree
+from teatree.core.models import Session, Task, Ticket, Worktree
 from teatree.core.models.external_delivery import under_external_delivery
 from teatree.core.models.types import validated_worktree_extra
 from teatree.core.worktree_env import compose_project
@@ -100,9 +100,16 @@ def _is_currently_active(worktree: Worktree, active_path: Path | None) -> bool:
     return active_path == resolved or resolved in active_path.parents
 
 
-def _ticket_is_busy(worktree: Worktree) -> bool:
-    """True iff the worktree's ticket has a live session or an active/claimed task."""
-    ticket = worktree.ticket
+def ticket_is_busy(ticket: Ticket) -> bool:
+    """True iff *ticket* has a live session or an active/claimed task.
+
+    The shared liveness predicate every destructive reaper/teardown path
+    consults before deleting filesystem or DB state: a busy ticket's worktree is
+    live work and must be KEPT, never reaped (#291/#2243 data-loss discipline).
+    The idle-stack reaper, the clean-all worktree reaper
+    (:func:`teatree.core.management.commands._workspace_reap.reap_one_worktree`),
+    and the orphan-isolated-root reaper all route through it.
+    """
     if Session.objects.filter(ticket=ticket, ended_at__isnull=True).exists():
         return True
     return Task.objects.filter(ticket=ticket, status__in=_ACTIVE_TASK_STATES).exists()
@@ -127,7 +134,7 @@ def _structural_keep_reason(worktree: Worktree, *, cutoff: datetime, active_path
         return "never started (last_used_at is null) — cannot confirm idle"
     if worktree.last_used_at > cutoff:
         return "recently used (within the idle window)"
-    if _ticket_is_busy(worktree):
+    if ticket_is_busy(worktree.ticket):
         return "ticket has a live session or active/claimed task"
     if _is_currently_active(worktree, active_path):
         return "the currently-active worktree (CWD)"
@@ -216,4 +223,4 @@ def reapable_worktrees(
             yield worktree
 
 
-__all__ = ["classify_running_worktrees", "preserve_reason", "reapable_worktrees"]
+__all__ = ["classify_running_worktrees", "preserve_reason", "reapable_worktrees", "ticket_is_busy"]

--- a/src/teatree/core/management/commands/_workspace_cleanup.py
+++ b/src/teatree/core/management/commands/_workspace_cleanup.py
@@ -14,6 +14,7 @@ from django.core.exceptions import ImproperlyConfigured
 
 from teatree.config import get_effective_settings
 from teatree.core.cleanup import (
+    WorktreeBusyError,
     _branch_tree_matches_squash,
     _ref_captured_by_merge,
     _remote_tracking_ref_exists,
@@ -570,10 +571,17 @@ def _fix_drift(drift: "Drift") -> list[str]:
 def clean_merged_worktrees() -> list[str]:
     """Tear down every worktree whose ticket is already MERGED.
 
+    An OPPORTUNISTIC sweep (the daily followup sync runs it), so it routes through
+    :func:`cleanup_worktree`'s liveness guard: a merged ticket whose worktree has
+    live work — a live session, an active/claimed task, an external-delivery
+    lease, a recent E2E run, or an explicit pin — is KEPT, never torn down
+    mid-task (#291/#2243). A targeted FSM teardown of a freshly-merged ticket is a
+    separate path that bypasses liveness.
+
     Fails open per row: a worktree whose overlay is not installed in this
     environment is SKIPPED (recorded) rather than aborting the whole sweep
-    (#2472); a teardown ``RuntimeError`` is reported as FAILED. Errors are
-    surfaced inline — no suppression.
+    (#2472); live work is SKIPPED (kept); any other teardown ``RuntimeError`` is
+    reported as FAILED. Errors are surfaced inline — no suppression.
     """
     cleaned: list[str] = []
     for ticket in Ticket.objects.filter(state=Ticket.State.MERGED):
@@ -582,6 +590,8 @@ def clean_merged_worktrees() -> list[str]:
                 cleaned.append(str(cleanup_worktree(wt, strict_hygiene=False)))
             except ImproperlyConfigured as exc:
                 cleaned.append(f"SKIPPED {wt.repo_path} ({wt.branch}): overlay not installed here — {exc}")
+            except WorktreeBusyError as exc:
+                cleaned.append(f"SKIPPED {wt.repo_path} ({wt.branch}): {exc}")
             except RuntimeError as exc:
                 cleaned.append(f"FAILED {wt.repo_path} ({wt.branch}): {exc}")
     if not cleaned:

--- a/src/teatree/core/management/commands/_workspace_isolated_roots.py
+++ b/src/teatree/core/management/commands/_workspace_isolated_roots.py
@@ -13,8 +13,27 @@ import shutil
 from pathlib import Path
 
 from teatree import paths
+from teatree.core.gates.idle_stack import ticket_is_busy
 from teatree.core.management.commands._workspace_cleanup import is_clean_ignored
 from teatree.core.models import Worktree
+
+
+def _has_unmappable_live_worktree() -> bool:
+    """True iff a busy worktree row lacks a recorded checkout path (#291 data-loss).
+
+    A busy worktree WITH a checkout path already contributes its slug to the
+    keep-set (:func:`_referenced_isolated_slugs`), so its env dir is kept. But a
+    busy worktree whose canonical row LOST its ``worktree_path`` (the stale-row
+    class the resolver tolerates) cannot be hashed to a slug, so its in-use
+    isolated DB looks like an orphan. When any such row exists, no unreferenced
+    dir can be proven dead — fail safe and keep them all rather than reap a live
+    isolated DB out from under a mid-task agent.
+    """
+    for worktree in Worktree.objects.select_related("ticket"):
+        extra = worktree.extra if isinstance(worktree.extra, dict) else {}
+        if not str(extra.get("worktree_path", "")) and ticket_is_busy(worktree.ticket):
+            return True
+    return False
 
 
 def _referenced_isolated_slugs() -> set[str]:
@@ -64,11 +83,18 @@ def reap_orphan_isolated_worktree_roots() -> list[str]:
     a live row's slug, a ``clean_ignore`` glob, or any git work is skipped with
     a one-line outcome. Only immediate child *directories* of the root are
     considered; loose files (seed locks) are ignored.
+
+    Liveness guard (#291/#2243): when a BUSY worktree row has no recorded
+    checkout path (:func:`_has_unmappable_live_worktree`), its in-use isolated DB
+    cannot be mapped to a slug, so no unreferenced dir can be proven dead. Every
+    such dir is then KEPT — fail safe rather than reap a live isolated DB out
+    from under a mid-task agent.
     """
     root = paths.auto_isolated_worktrees_dir()
     if not root.is_dir():
         return []
     referenced = _referenced_isolated_slugs()
+    keep_unmappable_live = _has_unmappable_live_worktree()
     outcomes: list[str] = []
     for env_dir in sorted(p for p in root.iterdir() if p.is_dir()):
         slug = env_dir.name
@@ -79,6 +105,12 @@ def reap_orphan_isolated_worktree_roots() -> list[str]:
             continue
         if _holds_git_checkout(env_dir):
             outcomes.append(f"SKIPPED '{slug}': holds a git checkout (uncommitted/unpushed work) — keeping")
+            continue
+        if keep_unmappable_live:
+            outcomes.append(
+                f"SKIPPED '{slug}': a live worktree has no recorded checkout path "
+                "— cannot prove this env dir is orphan, keeping (live work)"
+            )
             continue
         shutil.rmtree(env_dir)
         outcomes.append(f"Removed orphan isolated worktree root: {slug}")

--- a/src/teatree/core/management/commands/_workspace_isolated_roots.py
+++ b/src/teatree/core/management/commands/_workspace_isolated_roots.py
@@ -13,25 +13,30 @@ import shutil
 from pathlib import Path
 
 from teatree import paths
-from teatree.core.gates.idle_stack import ticket_is_busy
+from teatree.core.gates.idle_stack import worktree_protects_against_reap
 from teatree.core.management.commands._workspace_cleanup import is_clean_ignored
 from teatree.core.models import Worktree
 
 
 def _has_unmappable_live_worktree() -> bool:
-    """True iff a busy worktree row lacks a recorded checkout path (#291 data-loss).
+    """True iff a live worktree row lacks a recorded checkout path (#291 data-loss).
 
-    A busy worktree WITH a checkout path already contributes its slug to the
+    A live worktree WITH a checkout path already contributes its slug to the
     keep-set (:func:`_referenced_isolated_slugs`), so its env dir is kept. But a
-    busy worktree whose canonical row LOST its ``worktree_path`` (the stale-row
+    live worktree whose canonical row LOST its ``worktree_path`` (the stale-row
     class the resolver tolerates) cannot be hashed to a slug, so its in-use
     isolated DB looks like an orphan. When any such row exists, no unreferenced
     dir can be proven dead — fail safe and keep them all rather than reap a live
     isolated DB out from under a mid-task agent.
+
+    "Live" is the shared :func:`worktree_protects_against_reap` predicate — a live
+    session, an active/claimed task, an external-delivery lease, a recent E2E run,
+    or an explicit pin — so this reaper never protects LESS than the reversible
+    idle-stack reaper.
     """
     for worktree in Worktree.objects.select_related("ticket"):
         extra = worktree.extra if isinstance(worktree.extra, dict) else {}
-        if not str(extra.get("worktree_path", "")) and ticket_is_busy(worktree.ticket):
+        if not str(extra.get("worktree_path", "")) and worktree_protects_against_reap(worktree) is not None:
             return True
     return False
 

--- a/src/teatree/core/management/commands/_workspace_reap.py
+++ b/src/teatree/core/management/commands/_workspace_reap.py
@@ -11,6 +11,7 @@ import sys
 from pathlib import Path
 
 from teatree.core.cleanup import cleanup_worktree
+from teatree.core.gates.idle_stack import ticket_is_busy
 from teatree.core.models import Worktree
 from teatree.utils.run import run_allowed_to_fail
 
@@ -70,7 +71,17 @@ def reap_one_worktree(worktree: Worktree, *, interactive: bool, strict_hygiene: 
     their docker/DB behind). :func:`cleanup_worktree` resolves the overlay
     tolerantly and runs the overlay-agnostic teardown so the row is actually
     reaped, with the same data-loss guards in force.
+
+    Liveness guard (#291/#2243): the shared ``ticket_is_busy`` predicate is
+    consulted FIRST — a worktree whose ticket has a live session or an
+    active/claimed task is live work and is KEPT before any destructive step,
+    never handed to :func:`cleanup_worktree`. This covers both clean-all worktree
+    loops (the CREATED-state loop and the squash-merged reaper) since both funnel
+    through here, so a squash-merged follow-up worktree an agent is mid-task in is
+    never torn down out from under it.
     """
+    if ticket_is_busy(worktree.ticket):
+        return f"SKIPPED '{worktree.branch}': ticket has a live session or active/claimed task — keeping (live work)"
     try:
         return str(cleanup_worktree(worktree, strict_hygiene=strict_hygiene, keep_if_dirty=True))
     except RuntimeError as exc:

--- a/src/teatree/core/management/commands/_workspace_reap.py
+++ b/src/teatree/core/management/commands/_workspace_reap.py
@@ -10,8 +10,7 @@ import logging
 import sys
 from pathlib import Path
 
-from teatree.core.cleanup import cleanup_worktree
-from teatree.core.gates.idle_stack import ticket_is_busy
+from teatree.core.cleanup import WorktreeBusyError, cleanup_worktree
 from teatree.core.models import Worktree
 from teatree.utils.run import run_allowed_to_fail
 
@@ -72,18 +71,20 @@ def reap_one_worktree(worktree: Worktree, *, interactive: bool, strict_hygiene: 
     tolerantly and runs the overlay-agnostic teardown so the row is actually
     reaped, with the same data-loss guards in force.
 
-    Liveness guard (#291/#2243): the shared ``ticket_is_busy`` predicate is
-    consulted FIRST — a worktree whose ticket has a live session or an
-    active/claimed task is live work and is KEPT before any destructive step,
-    never handed to :func:`cleanup_worktree`. This covers both clean-all worktree
-    loops (the CREATED-state loop and the squash-merged reaper) since both funnel
-    through here, so a squash-merged follow-up worktree an agent is mid-task in is
-    never torn down out from under it.
+    Liveness guard (#291/#2243): :func:`cleanup_worktree` is the funnel that
+    consults the shared liveness predicate (live session / active-or-claimed task
+    / external-delivery lease / recent E2E / ``reaper_pinned``) before any
+    destructive step and raises :class:`WorktreeBusyError` for live work. Both
+    clean-all worktree loops (the CREATED-state loop and the squash-merged
+    reaper) funnel through here, so a follow-up worktree an agent is mid-task in
+    is KEPT with a warning, never torn down — distinct from the unsynced-work
+    ``RuntimeError`` path (which offers push/abandon), since live work is not
+    unpushed work.
     """
-    if ticket_is_busy(worktree.ticket):
-        return f"SKIPPED '{worktree.branch}': ticket has a live session or active/claimed task — keeping (live work)"
     try:
         return str(cleanup_worktree(worktree, strict_hygiene=strict_hygiene, keep_if_dirty=True))
+    except WorktreeBusyError as exc:
+        return f"SKIPPED '{worktree.branch}': {exc}"
     except RuntimeError as exc:
         return resolve_unsynced_worktree(worktree, exc, interactive=interactive)
 

--- a/src/teatree/core/runners/teardown.py
+++ b/src/teatree/core/runners/teardown.py
@@ -52,7 +52,14 @@ class WorktreeTeardown(RunnerBase):
         step_errors: list[str] = []
         for worktree in worktrees:
             try:
-                cleanup_result = cleanup_worktree(worktree, force=self.force, strict_hygiene=False)
+                # FSM-driven teardown of a MERGED ticket: the FSM decided to tear
+                # this worktree down, so it bypasses the opportunistic liveness
+                # guard (respect_liveness=False) — a still-open session row on a
+                # merged ticket must not block teardown. The #706 unpushed-commit
+                # guard (force defaults False here) still protects real work.
+                cleanup_result = cleanup_worktree(
+                    worktree, force=self.force, strict_hygiene=False, respect_liveness=False
+                )
             except RuntimeError as exc:
                 logger.exception("teardown refused for %s", worktree.repo_path)
                 refusals.append(f"{worktree.repo_path} ({worktree.branch}): {exc}")

--- a/src/teatree/core/runners/worktree_teardown.py
+++ b/src/teatree/core/runners/worktree_teardown.py
@@ -51,7 +51,11 @@ class WorktreeTeardownRunner(RunnerBase):
         # (runner, sync backend, clean-all, clean-merged) tears down docker
         # the same way (#1306).
         try:
-            cleanup_result = cleanup_worktree(worktree, force=self.force, strict_hygiene=False)
+            # FSM/operator-driven teardown of this specific worktree bypasses the
+            # opportunistic liveness guard (respect_liveness=False): the caller has
+            # decided to tear it down. The #706 unpushed-commit guard (force
+            # defaults False) still fires to protect real work.
+            cleanup_result = cleanup_worktree(worktree, force=self.force, strict_hygiene=False, respect_liveness=False)
         except RuntimeError as exc:
             logger.warning("teardown refused for %s: %s", worktree.repo_path, exc)
             return RunnerResult(ok=False, detail=str(exc))

--- a/tests/teatree_core/cleanup/test_cleanup_worktree.py
+++ b/tests/teatree_core/cleanup/test_cleanup_worktree.py
@@ -12,9 +12,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from django.test import TestCase
+from django.utils import timezone
 
-from teatree.core.cleanup import cleanup_worktree
-from teatree.core.models import Ticket, Worktree
+from teatree.core.cleanup import WorktreeBusyError, cleanup_worktree
+from teatree.core.models import Session, Task, Ticket, Worktree
+from teatree.core.models.external_delivery import mark_external_delivery
 from teatree.core.overlay import OverlayBase, ProvisionStep, RunCommands
 from teatree.utils.run import CommandFailedError
 from tests.teatree_core._provision_timebox_stub import provision_timebox_unimportable
@@ -1057,3 +1059,109 @@ class TestCleanupWorktreeMultiOverlay(TestCase):
 
         assert b_called, "overlay-B's cleanup steps were not invoked"
         assert not a_called, "overlay-A's cleanup steps were invoked but should not have been"
+
+
+class TestCleanupWorktreeLivenessGuard(TestCase):
+    """The funnel liveness guard: an opportunistic teardown never reaps live work.
+
+    ``cleanup_worktree`` is the single seam every teardown caller routes through.
+    With ``respect_liveness`` (default on), a worktree under live work — a live
+    session, an active/claimed task, an external-delivery lease, a recent E2E
+    run, or an explicit pin — raises :class:`WorktreeBusyError` before any
+    destructive step. ``force=True`` (abandon) and ``respect_liveness=False``
+    (FSM-driven teardown) bypass it. The IRREVERSIBLE teardown therefore never
+    protects LESS than the REVERSIBLE idle-stack reaper (#291/#2243).
+    """
+
+    def _make_worktree(self) -> Worktree:
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://gitlab.com/org/repo/-/issues/2243",
+            state=Ticket.State.MERGED,
+        )
+        return Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="org/repo",
+            branch="fix-2243",
+            extra={"worktree_path": "/tmp/wt/org/repo"},
+        )
+
+    def _tear_down(self, wt: Worktree, **kwargs: object) -> None:
+        """Run cleanup_worktree with the git layer mocked so a non-busy teardown completes."""
+        with _patch_config as mock_config, _patch_git as mock_git, _patch_overlay as mock_overlay:
+            _mock_workspace(mock_config)
+            _no_unpushed(mock_git)
+            mock_git.status_porcelain.return_value = ""
+            mock_overlay.return_value.get_cleanup_steps.return_value = []
+            mock_overlay.return_value.reap_worktree_external_resources.return_value = []
+            cleanup_worktree(wt, **kwargs)
+
+    def test_live_session_keeps_worktree_by_default(self) -> None:
+        wt = self._make_worktree()
+        Session.objects.create(ticket=wt.ticket, overlay="test")  # live: ended_at is null
+
+        with pytest.raises(WorktreeBusyError, match="live work"):
+            cleanup_worktree(wt)
+
+        assert Worktree.objects.filter(pk=wt.pk).exists(), "DATA LOSS: busy worktree reaped"
+
+    def test_claimed_task_keeps_worktree_by_default(self) -> None:
+        wt = self._make_worktree()
+        session = Session.objects.create(ticket=wt.ticket, overlay="test")
+        session.ended_at = timezone.now()
+        session.save(update_fields=["ended_at"])
+        Task.objects.create(ticket=wt.ticket, session=session, status=Task.Status.CLAIMED)
+
+        with pytest.raises(WorktreeBusyError, match="live work"):
+            cleanup_worktree(wt)
+
+    def test_external_delivery_lease_keeps_worktree(self) -> None:
+        """A worktree under a live external-delivery lease is KEPT — the wider predicate (#2227)."""
+        wt = self._make_worktree()
+        mark_external_delivery(wt.ticket)
+
+        with pytest.raises(WorktreeBusyError, match="live work"):
+            cleanup_worktree(wt)
+
+    def test_recent_e2e_run_keeps_worktree(self) -> None:
+        wt = self._make_worktree()
+        wt.last_e2e_run = timezone.now()
+        wt.save(update_fields=["last_e2e_run"])
+
+        with pytest.raises(WorktreeBusyError, match="live work"):
+            cleanup_worktree(wt)
+
+    def test_reaper_pinned_keeps_worktree(self) -> None:
+        wt = self._make_worktree()
+        wt.extra = {**wt.extra, "reaper_pinned": True}
+        wt.save(update_fields=["extra"])
+
+        with pytest.raises(WorktreeBusyError, match="live work"):
+            cleanup_worktree(wt)
+
+    def test_force_tears_down_busy_worktree(self) -> None:
+        """Explicit abandon (force=True) overrides the liveness guard."""
+        wt = self._make_worktree()
+        Session.objects.create(ticket=wt.ticket, overlay="test")
+
+        self._tear_down(wt, force=True)
+
+        assert not Worktree.objects.filter(pk=wt.pk).exists(), "force=True must still tear down"
+
+    def test_respect_liveness_false_tears_down_busy_worktree(self) -> None:
+        """FSM-driven teardown (respect_liveness=False) bypasses the guard — no leak regression."""
+        wt = self._make_worktree()
+        Session.objects.create(ticket=wt.ticket, overlay="test")
+
+        self._tear_down(wt, respect_liveness=False)
+
+        assert not Worktree.objects.filter(pk=wt.pk).exists(), "FSM teardown of a merged ticket must proceed"
+
+    def test_idle_worktree_is_torn_down(self) -> None:
+        """Safe-reap preserved: a worktree with no live work tears down as before."""
+        wt = self._make_worktree()
+
+        self._tear_down(wt)
+
+        assert not Worktree.objects.filter(pk=wt.pk).exists(), "idle worktree should still reap"

--- a/tests/teatree_core/management/commands/test__workspace_isolated_roots.py
+++ b/tests/teatree_core/management/commands/test__workspace_isolated_roots.py
@@ -18,6 +18,7 @@ from django.utils import timezone
 from teatree import paths
 from teatree.core.management.commands import _workspace_isolated_roots as reaper
 from teatree.core.models import Session, Task, Ticket, Worktree
+from teatree.core.models.external_delivery import mark_external_delivery
 from tests._git_repo import make_git_repo
 
 _REAP = "teatree.core.management.commands._workspace_isolated_roots"
@@ -148,6 +149,54 @@ class TestReapOrphanIsolatedWorktreeRoots(TestCase):
         result = reaper.reap_orphan_isolated_worktree_roots()
 
         assert orphan.exists(), "DATA LOSS: a worktree with an active task lost its env dir"
+        assert any("SKIPPED" in line and "live work" in line for line in result)
+
+    def test_external_delivery_pathless_row_keeps_orphan_dirs(self) -> None:
+        """A pathless row under a live external-delivery lease protects env dirs (#2227).
+
+        The widened predicate: the destructive isolated-root reaper must not
+        protect LESS than the reversible idle-stack reaper, which honors the
+        external-delivery lease.
+        """
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/291e")
+        Worktree.objects.create(ticket=ticket, overlay="test", repo_path="org/repo", branch="lease-no-path", extra={})
+        mark_external_delivery(ticket)
+        orphan = _make_env_dir(self.root, paths.isolated_slug(Path("/gone/elsewhere")))
+
+        result = reaper.reap_orphan_isolated_worktree_roots()
+
+        assert orphan.exists(), "DATA LOSS: a worktree under external delivery lost its env dir"
+        assert any("SKIPPED" in line and "live work" in line for line in result)
+
+    def test_recent_e2e_pathless_row_keeps_orphan_dirs(self) -> None:
+        """A pathless row with a recent E2E run protects env dirs (widened predicate, #2227)."""
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/291f")
+        Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="org/repo",
+            branch="e2e-no-path",
+            extra={},
+            last_e2e_run=timezone.now(),
+        )
+        orphan = _make_env_dir(self.root, paths.isolated_slug(Path("/gone/elsewhere")))
+
+        result = reaper.reap_orphan_isolated_worktree_roots()
+
+        assert orphan.exists(), "DATA LOSS: a worktree with a recent E2E run lost its env dir"
+        assert any("SKIPPED" in line and "live work" in line for line in result)
+
+    def test_reaper_pinned_pathless_row_keeps_orphan_dirs(self) -> None:
+        """A pathless row explicitly pinned protects env dirs (widened predicate, #2227)."""
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/291g")
+        Worktree.objects.create(
+            ticket=ticket, overlay="test", repo_path="org/repo", branch="pinned-no-path", extra={"reaper_pinned": True}
+        )
+        orphan = _make_env_dir(self.root, paths.isolated_slug(Path("/gone/elsewhere")))
+
+        result = reaper.reap_orphan_isolated_worktree_roots()
+
+        assert orphan.exists(), "DATA LOSS: an explicitly-pinned worktree lost its env dir"
         assert any("SKIPPED" in line and "live work" in line for line in result)
 
     def test_missing_root_returns_empty(self) -> None:

--- a/tests/teatree_core/management/commands/test__workspace_isolated_roots.py
+++ b/tests/teatree_core/management/commands/test__workspace_isolated_roots.py
@@ -13,10 +13,11 @@ from pathlib import Path
 from unittest.mock import patch
 
 from django.test import TestCase
+from django.utils import timezone
 
 from teatree import paths
 from teatree.core.management.commands import _workspace_isolated_roots as reaper
-from teatree.core.models import Ticket, Worktree
+from teatree.core.models import Session, Task, Ticket, Worktree
 from tests._git_repo import make_git_repo
 
 _REAP = "teatree.core.management.commands._workspace_isolated_roots"
@@ -95,15 +96,59 @@ class TestReapOrphanIsolatedWorktreeRoots(TestCase):
         assert env_dir.exists()
         assert any("SKIPPED" in line and slug in line for line in result)
 
-    def test_row_without_checkout_path_does_not_protect_a_dir(self) -> None:
+    def test_busy_pathless_row_keeps_orphan_dirs(self) -> None:
+        """A BUSY worktree whose row lost its checkout path protects every env dir (#291 data-loss).
+
+        The data-loss bug this pins: a live worktree whose canonical row is
+        missing ``worktree_path`` (the stale-row class the resolver tolerates)
+        cannot be hashed to a slug, so its in-use isolated DB looks like an
+        orphan and was reaped out from under the mid-task agent. With a live
+        :class:`Session` on its ticket, no unreferenced dir can be proven dead,
+        so the reaper must KEEP them all.
+
+        This is the documented red-first inversion: the prior test asserted the
+        pathless row's would-be dir is reaped — the wrong, data-losing behavior.
+        """
         ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/291b")
-        Worktree.objects.create(ticket=ticket, overlay="test", repo_path="org/repo", branch="no-path", extra={})
+        Worktree.objects.create(ticket=ticket, overlay="test", repo_path="org/repo", branch="busy-no-path", extra={})
+        Session.objects.create(ticket=ticket, overlay="test")  # live: ended_at is null
+        orphan = _make_env_dir(self.root, paths.isolated_slug(Path("/gone/elsewhere")))
+
+        result = reaper.reap_orphan_isolated_worktree_roots()
+
+        assert orphan.exists(), "DATA LOSS: a busy pathless worktree's env dir was reaped"
+        assert any("SKIPPED" in line and "live work" in line for line in result)
+
+    def test_dead_pathless_row_still_reaps_orphan_dirs(self) -> None:
+        """A pathless row whose ticket has NO live work does not protect an orphan dir.
+
+        Preserves the safe-reap path: only LIVE work blocks reaping. A genuinely
+        idle pathless row (no live session, no active/claimed task) cannot be
+        mapped to a dir, so the unmatchable orphan is reaped as before.
+        """
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/291c")
+        Worktree.objects.create(ticket=ticket, overlay="test", repo_path="org/repo", branch="idle-no-path", extra={})
         orphan = _make_env_dir(self.root, paths.isolated_slug(Path("/gone/elsewhere")))
 
         result = reaper.reap_orphan_isolated_worktree_roots()
 
         assert not orphan.exists()
         assert any("Removed orphan isolated worktree root" in line for line in result)
+
+    def test_busy_via_claimed_task_pathless_row_keeps_orphan_dirs(self) -> None:
+        """A claimed-Task (no live session) on a pathless row also protects env dirs."""
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/291d")
+        Worktree.objects.create(ticket=ticket, overlay="test", repo_path="org/repo", branch="task-no-path", extra={})
+        session = Session.objects.create(ticket=ticket, overlay="test")
+        session.ended_at = timezone.now()
+        session.save(update_fields=["ended_at"])
+        Task.objects.create(ticket=ticket, session=session, status=Task.Status.CLAIMED)
+        orphan = _make_env_dir(self.root, paths.isolated_slug(Path("/gone/elsewhere")))
+
+        result = reaper.reap_orphan_isolated_worktree_roots()
+
+        assert orphan.exists(), "DATA LOSS: a worktree with an active task lost its env dir"
+        assert any("SKIPPED" in line and "live work" in line for line in result)
 
     def test_missing_root_returns_empty(self) -> None:
         shutil.rmtree(self.root)

--- a/tests/teatree_core/management/commands/test__workspace_reap.py
+++ b/tests/teatree_core/management/commands/test__workspace_reap.py
@@ -1,19 +1,20 @@
-"""``reap_one_worktree`` — the funnel guard that never reaps live work.
+"""``reap_one_worktree`` — translates the funnel liveness keep into a clean line.
 
-Both clean-all worktree loops (the CREATED-state loop and the squash-merged
-reaper) funnel through :func:`reap_one_worktree`. It consults the shared
-liveness predicate (``idle_stack.ticket_is_busy``) FIRST: a worktree whose
-ticket has a live :class:`Session` or an active/claimed :class:`Task` is live
-work and is KEPT, never handed to the destructive teardown (#291/#2243).
+The liveness guard lives in :func:`teatree.core.cleanup.cleanup_worktree` (the
+single seam every teardown caller routes through). ``reap_one_worktree`` — the
+funnel both clean-all worktree loops use (the CREATED-state loop and the
+squash-merged reaper) — catches :class:`WorktreeBusyError` and reports a clean
+KEEP line, distinct from the unsynced-work ``RuntimeError`` path that offers
+push/abandon (live work is not unpushed work).
 """
 
 from unittest.mock import patch
 
 from django.test import TestCase
-from django.utils import timezone
 
+from teatree.core.cleanup import CleanupResult, WorktreeBusyError
 from teatree.core.management.commands import _workspace_reap as reap
-from teatree.core.models import Session, Task, Ticket, Worktree
+from teatree.core.models import Session, Ticket, Worktree
 
 _REAP = "teatree.core.management.commands._workspace_reap"
 
@@ -30,39 +31,57 @@ class TestReapOneWorktreeLivenessGuard(TestCase):
             extra={"worktree_path": "/tmp/does-not-matter"},
         )
 
-    def test_live_session_keeps_worktree_without_teardown(self) -> None:
-        """A live session short-circuits before the destructive teardown is reached."""
+    def test_live_work_keeps_worktree(self) -> None:
+        """A live worktree raises WorktreeBusyError in the funnel; the row is KEPT.
+
+        Uses the real ``cleanup_worktree`` whose liveness guard fires FIRST (before
+        any path/overlay/git resolution), so a live session short-circuits without
+        touching the worktree.
+        """
         worktree = self._make_worktree()
         Session.objects.create(ticket=worktree.ticket, overlay="test")  # live: ended_at is null
 
-        with patch(f"{_REAP}.cleanup_worktree") as cleanup:
-            line = reap.reap_one_worktree(worktree, interactive=False)
+        line = reap.reap_one_worktree(worktree, interactive=False)
 
-        cleanup.assert_not_called()
         assert Worktree.objects.filter(pk=worktree.pk).exists(), "DATA LOSS: live worktree reaped mid-task"
         assert "SKIPPED" in line
         assert "live work" in line
 
-    def test_claimed_task_keeps_worktree_without_teardown(self) -> None:
-        """An active task on an ended session still marks the worktree live."""
-        worktree = self._make_worktree(branch="task-feature")
-        session = Session.objects.create(ticket=worktree.ticket, overlay="test")
-        session.ended_at = timezone.now()
-        session.save(update_fields=["ended_at"])
-        Task.objects.create(ticket=worktree.ticket, session=session, status=Task.Status.CLAIMED)
+    def test_busy_error_reports_keep_not_push_abandon(self) -> None:
+        """A WorktreeBusyError is translated to a clean SKIPPED line, never the resolve path."""
+        worktree = self._make_worktree(branch="busy")
+        busy = WorktreeBusyError("org/repo (busy): kept — ticket has a live session or active/claimed task (live work)")
 
-        with patch(f"{_REAP}.cleanup_worktree") as cleanup:
-            line = reap.reap_one_worktree(worktree, interactive=False)
+        with (
+            patch(f"{_REAP}.cleanup_worktree", side_effect=busy),
+            patch(f"{_REAP}.resolve_unsynced_worktree") as resolve,
+        ):
+            line = reap.reap_one_worktree(worktree, interactive=True)
 
-        cleanup.assert_not_called()
+        resolve.assert_not_called()
         assert "SKIPPED" in line
         assert "live work" in line
+
+    def test_unsynced_runtimeerror_routes_to_resolve(self) -> None:
+        """A non-liveness RuntimeError still routes to the unsynced push/abandon resolver."""
+        worktree = self._make_worktree(branch="unsynced")
+        exc = RuntimeError("2 commit(s) on NO remote")
+
+        with (
+            patch(f"{_REAP}.cleanup_worktree", side_effect=exc),
+            patch(f"{_REAP}.resolve_unsynced_worktree", return_value="Skipped: unsynced") as resolve,
+        ):
+            line = reap.reap_one_worktree(worktree, interactive=False)
+
+        resolve.assert_called_once()
+        assert line == "Skipped: unsynced"
 
     def test_idle_ticket_is_reaped(self) -> None:
         """A worktree with no live work is handed to teardown as before (safe-reap preserved)."""
         worktree = self._make_worktree(branch="idle-feature")
+        result = CleanupResult(label="Cleaned: org/repo (idle-feature)")
 
-        with patch(f"{_REAP}.cleanup_worktree", return_value="Cleaned: org/repo (idle-feature)") as cleanup:
+        with patch(f"{_REAP}.cleanup_worktree", return_value=result) as cleanup:
             line = reap.reap_one_worktree(worktree, interactive=False)
 
         cleanup.assert_called_once()

--- a/tests/teatree_core/management/commands/test__workspace_reap.py
+++ b/tests/teatree_core/management/commands/test__workspace_reap.py
@@ -1,0 +1,69 @@
+"""``reap_one_worktree`` — the funnel guard that never reaps live work.
+
+Both clean-all worktree loops (the CREATED-state loop and the squash-merged
+reaper) funnel through :func:`reap_one_worktree`. It consults the shared
+liveness predicate (``idle_stack.ticket_is_busy``) FIRST: a worktree whose
+ticket has a live :class:`Session` or an active/claimed :class:`Task` is live
+work and is KEPT, never handed to the destructive teardown (#291/#2243).
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from teatree.core.management.commands import _workspace_reap as reap
+from teatree.core.models import Session, Task, Ticket, Worktree
+
+_REAP = "teatree.core.management.commands._workspace_reap"
+
+
+class TestReapOneWorktreeLivenessGuard(TestCase):
+    def _make_worktree(self, *, branch: str = "feature") -> Worktree:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/2243")
+        return Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="org/repo",
+            branch=branch,
+            state=Worktree.State.PROVISIONED,
+            extra={"worktree_path": "/tmp/does-not-matter"},
+        )
+
+    def test_live_session_keeps_worktree_without_teardown(self) -> None:
+        """A live session short-circuits before the destructive teardown is reached."""
+        worktree = self._make_worktree()
+        Session.objects.create(ticket=worktree.ticket, overlay="test")  # live: ended_at is null
+
+        with patch(f"{_REAP}.cleanup_worktree") as cleanup:
+            line = reap.reap_one_worktree(worktree, interactive=False)
+
+        cleanup.assert_not_called()
+        assert Worktree.objects.filter(pk=worktree.pk).exists(), "DATA LOSS: live worktree reaped mid-task"
+        assert "SKIPPED" in line
+        assert "live work" in line
+
+    def test_claimed_task_keeps_worktree_without_teardown(self) -> None:
+        """An active task on an ended session still marks the worktree live."""
+        worktree = self._make_worktree(branch="task-feature")
+        session = Session.objects.create(ticket=worktree.ticket, overlay="test")
+        session.ended_at = timezone.now()
+        session.save(update_fields=["ended_at"])
+        Task.objects.create(ticket=worktree.ticket, session=session, status=Task.Status.CLAIMED)
+
+        with patch(f"{_REAP}.cleanup_worktree") as cleanup:
+            line = reap.reap_one_worktree(worktree, interactive=False)
+
+        cleanup.assert_not_called()
+        assert "SKIPPED" in line
+        assert "live work" in line
+
+    def test_idle_ticket_is_reaped(self) -> None:
+        """A worktree with no live work is handed to teardown as before (safe-reap preserved)."""
+        worktree = self._make_worktree(branch="idle-feature")
+
+        with patch(f"{_REAP}.cleanup_worktree", return_value="Cleaned: org/repo (idle-feature)") as cleanup:
+            line = reap.reap_one_worktree(worktree, interactive=False)
+
+        cleanup.assert_called_once()
+        assert "Cleaned" in line

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -2038,6 +2038,31 @@ class TestWorkspaceCleanMerged(TestCase):
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
+    def test_keeps_busy_merged_worktree(self) -> None:
+        """A MERGED ticket whose worktree has live work is KEPT, not torn down (#2243).
+
+        ``clean-merged`` is the daily opportunistic sweep — it must not reap a
+        merged-but-still-worked-in worktree out from under a mid-task agent. The
+        funnel liveness guard in ``cleanup_worktree`` fires first, so the sweep
+        records a SKIPPED-kept line and the row survives, distinct from the FAILED
+        line a genuine teardown error produces.
+        """
+        merged = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://example.com/issues/2243m",
+            state=Ticket.State.MERGED,
+        )
+        wt = Worktree.objects.create(overlay="test", ticket=merged, repo_path="repo", branch="ac-repo-2243m")
+        Session.objects.create(ticket=merged, overlay="test")  # live: ended_at is null
+
+        cleaned = cast("list[str]", call_command("workspace", "clean-merged"))
+
+        assert Worktree.objects.filter(pk=wt.pk).exists(), f"DATA LOSS: busy merged worktree reaped; got: {cleaned!r}"
+        assert any("SKIPPED" in c and "live work" in c for c in cleaned), f"expected a live-work skip, got: {cleaned!r}"
+        assert not any("FAILED" in c for c in cleaned), f"a kept-live worktree must not be a FAILURE; got: {cleaned!r}"
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
     def test_surfaces_cleanup_failures(self) -> None:
         merged = Ticket.objects.create(
             overlay="test",
@@ -3777,8 +3802,15 @@ class TestCleanAllReapsAndSurvivesForeignOverlay(TestCase):
             assert wt_path.is_dir(), "DATA LOSS: busy worktree dir removed"
             assert any("live work" in c for c in cleaned), f"expected a live-work skip line, got: {cleaned!r}"
 
-    def test_keeps_busy_created_worktree_reaps_idle(self) -> None:
-        """The CREATED-state loop keeps a busy worktree while still reaping an idle one."""
+    def test_keeps_busy_created_worktree(self) -> None:
+        """The CREATED-state loop keeps a worktree whose ticket has live work (#2243).
+
+        The funnel liveness guard in ``cleanup_worktree`` fires first (before any
+        path/git resolution), so a busy CREATED row survives clean-all with a KEEP
+        line — never handed to teardown. The safe-reap of an IDLE worktree is
+        covered by ``test_reaps_merged_worktree_fully`` and the cleanup-level
+        ``TestCleanupWorktreeLivenessGuard.test_idle_worktree_is_torn_down``.
+        """
         with tempfile.TemporaryDirectory() as tmp_s:
             tmp = Path(tmp_s)
             workspace = tmp / "workspace"
@@ -3796,32 +3828,13 @@ class TestCleanAllReapsAndSurvivesForeignOverlay(TestCase):
             session = Session.objects.create(ticket=busy_ticket, overlay="test")
             session.ended_at = timezone.now()
             session.save(update_fields=["ended_at"])
-            Task.objects.create(ticket=busy_ticket, session=session, status=Task.Status.PENDING)
+            Task.objects.create(ticket=busy_ticket, session=session, status=Task.Status.CLAIMED)
 
-            idle_ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/2243b")
-            idle = Worktree.objects.create(
-                overlay="test",
-                ticket=idle_ticket,
-                repo_path="backend",
-                branch="idle",
-                state=Worktree.State.CREATED,
-                extra={"worktree_path": str(workspace / "idle" / "backend")},
-            )
+            with patch.object(workspace_mod, "_workspace_dir", return_value=workspace):
+                cleaned = cast("list[str]", call_command("workspace", "clean-all"))
 
-            reaped_pks: list[int] = []
-
-            def _record(worktree: Worktree, **_kw: object) -> str:
-                reaped_pks.append(worktree.pk)
-                return f"Cleaned: {worktree.repo_path} ({worktree.branch})"
-
-            with (
-                patch.object(workspace_mod, "_workspace_dir", return_value=workspace),
-                patch.object(ws_reap_mod, "cleanup_worktree", side_effect=_record),
-            ):
-                call_command("workspace", "clean-all")
-
-            assert busy.pk not in reaped_pks, "DATA LOSS: busy CREATED worktree handed to teardown"
-            assert idle.pk in reaped_pks, "idle CREATED worktree should still be reaped (safe-reap preserved)"
+            assert Worktree.objects.filter(pk=busy.pk).exists(), "DATA LOSS: busy CREATED worktree reaped"
+            assert any("live work" in c for c in cleaned), f"expected a live-work skip line, got: {cleaned!r}"
 
     def test_foreign_overlay_merged_row_is_reaped_overlay_free_not_skipped(self) -> None:
         """A merged row whose overlay is unregistered is REAPED overlay-free, not skipped.

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.core.management import call_command
 from django.test import TestCase, override_settings
+from django.utils import timezone
 from django.utils.module_loading import import_string
 
 import teatree.core.branch_classification as bc_mod
@@ -32,7 +33,7 @@ import teatree.utils.run as utils_run_mod
 from teatree.config import load_config
 from teatree.core.management.commands._workspace_ticket_intake import build_branch_name
 from teatree.core.management.commands.workspace import _branch_prefix, _workspace_dir
-from teatree.core.models import Ticket, Worktree
+from teatree.core.models import Session, Task, Ticket, Worktree
 from teatree.core.overlay import OverlayBase, ProvisionStep
 from teatree.core.runners import RunnerResult
 from tests.teatree_core.management_commands._overlays import (
@@ -3755,6 +3756,72 @@ class TestCleanAllReapsAndSurvivesForeignOverlay(TestCase):
             assert wt_path.is_dir(), "DATA LOSS: worktree dir was removed"
             assert "feature" in _git(work, "branch", "--format=%(refname:short)").split()
             assert any("feature" in c and "Skipped" in c for c in cleaned), f"expected a skip line, got: {cleaned!r}"
+
+    def test_keeps_busy_squash_merged_worktree(self) -> None:
+        """A squash-merged worktree whose ticket has live work is KEPT, not reaped (#2243).
+
+        ``test_reaps_merged_worktree_fully`` proves the same row IS reaped when
+        idle, so a live :class:`Session` flipping it to KEEP is a non-vacuous
+        red-first guard: clean-all must never tear down a squash-merged
+        follow-up worktree an agent is mid-task in.
+        """
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            wt = _make_squash_merged_worktree(tmp)
+            wt_path = Path(wt.extra["worktree_path"])
+            Session.objects.create(ticket=wt.ticket, overlay="test")  # live: ended_at is null
+
+            cleaned, _docker, _dropped = self._run_clean_all(tmp)
+
+            assert Worktree.objects.filter(pk=wt.pk).exists(), f"DATA LOSS: busy merged row reaped; got: {cleaned!r}"
+            assert wt_path.is_dir(), "DATA LOSS: busy worktree dir removed"
+            assert any("live work" in c for c in cleaned), f"expected a live-work skip line, got: {cleaned!r}"
+
+    def test_keeps_busy_created_worktree_reaps_idle(self) -> None:
+        """The CREATED-state loop keeps a busy worktree while still reaping an idle one."""
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            workspace = tmp / "workspace"
+            workspace.mkdir()
+
+            busy_ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/2243a")
+            busy = Worktree.objects.create(
+                overlay="test",
+                ticket=busy_ticket,
+                repo_path="backend",
+                branch="busy",
+                state=Worktree.State.CREATED,
+                extra={"worktree_path": str(workspace / "busy" / "backend")},
+            )
+            session = Session.objects.create(ticket=busy_ticket, overlay="test")
+            session.ended_at = timezone.now()
+            session.save(update_fields=["ended_at"])
+            Task.objects.create(ticket=busy_ticket, session=session, status=Task.Status.PENDING)
+
+            idle_ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/2243b")
+            idle = Worktree.objects.create(
+                overlay="test",
+                ticket=idle_ticket,
+                repo_path="backend",
+                branch="idle",
+                state=Worktree.State.CREATED,
+                extra={"worktree_path": str(workspace / "idle" / "backend")},
+            )
+
+            reaped_pks: list[int] = []
+
+            def _record(worktree: Worktree, **_kw: object) -> str:
+                reaped_pks.append(worktree.pk)
+                return f"Cleaned: {worktree.repo_path} ({worktree.branch})"
+
+            with (
+                patch.object(workspace_mod, "_workspace_dir", return_value=workspace),
+                patch.object(ws_reap_mod, "cleanup_worktree", side_effect=_record),
+            ):
+                call_command("workspace", "clean-all")
+
+            assert busy.pk not in reaped_pks, "DATA LOSS: busy CREATED worktree handed to teardown"
+            assert idle.pk in reaped_pks, "idle CREATED worktree should still be reaped (safe-reap preserved)"
 
     def test_foreign_overlay_merged_row_is_reaped_overlay_free_not_skipped(self) -> None:
         """A merged row whose overlay is unregistered is REAPED overlay-free, not skipped.

--- a/tests/teatree_core/test_runners_teardown.py
+++ b/tests/teatree_core/test_runners_teardown.py
@@ -52,8 +52,12 @@ class TestWorktreeTeardown(TestCase):
 
         cleaned: list[str] = []
 
-        def fake_cleanup(worktree: Worktree, *, force: bool = False, strict_hygiene: bool = True) -> CleanupResult:
-            del force, strict_hygiene
+        def fake_cleanup(
+            worktree: Worktree, *, force: bool = False, strict_hygiene: bool = True, respect_liveness: bool = True
+        ) -> CleanupResult:
+            # FSM teardown bypasses the opportunistic liveness guard (#2243).
+            assert respect_liveness is False, "FSM teardown must opt out of the liveness guard"
+            del force, strict_hygiene, respect_liveness
             label = f"Cleaned: {worktree.repo_path}"
             cleaned.append(worktree.repo_path)
             worktree.delete()
@@ -72,8 +76,12 @@ class TestWorktreeTeardown(TestCase):
     def test_continues_on_individual_failure_and_reports_errors(self) -> None:
         ticket = self._ticket_with_worktrees(count=2)
 
-        def fake_cleanup(worktree: Worktree, *, force: bool = False, strict_hygiene: bool = True) -> CleanupResult:
-            del force, strict_hygiene
+        def fake_cleanup(
+            worktree: Worktree, *, force: bool = False, strict_hygiene: bool = True, respect_liveness: bool = True
+        ) -> CleanupResult:
+            # FSM teardown bypasses the opportunistic liveness guard (#2243).
+            assert respect_liveness is False, "FSM teardown must opt out of the liveness guard"
+            del force, strict_hygiene, respect_liveness
             if worktree.repo_path == "repo-0":
                 msg = "branch ahead of main"
                 raise RuntimeError(msg)


### PR DESCRIPTION
fix(worktree): guard reapers with shared liveness predicate (no reaping live work)

The clean-all, clean-merged, orphan-isolated-root, and merge-sync reapers
consulted no Session/Task liveness: a squash-merged or CREATED worktree whose
ticket has a live session or active/claimed task was torn down mid-task, a live
worktree whose canonical row lost its worktree_path had its in-use isolated DB
reaped, and `clean_merged_worktrees` called `cleanup_worktree` with no liveness
guard at all.

## Final design

1. **Widened liveness predicate.** `idle_stack.worktree_protects_against_reap(worktree)`
   returns a human-readable keep-reason when EITHER `ticket_is_busy` (a live
   Session OR an active/CLAIMED Task) OR an active delivery exists
   (external-delivery lease / recent E2E run / `extra['reaper_pinned']`, reusing
   the existing `_active_delivery_keep_reason` rather than duplicating it). The
   IRREVERSIBLE reapers therefore never protect LESS than the REVERSIBLE
   idle-stack reaper. `ticket_is_busy(ticket)` is also exposed (extracted from
   the former `_ticket_is_busy`).

2. **Funnel the guard into the single teardown seam.** `cleanup_worktree` gains
   `respect_liveness` (default True, fail-safe) and calls `guard_live_worktree`
   FIRST — a worktree under live work raises `WorktreeBusyError` before
   docker-down / git-removal / DB-drop. OPPORTUNISTIC reapers (clean-all,
   clean-merged, merge-sync cleanup, orphan-isolated-root) keep `respect_liveness`
   on and translate `WorktreeBusyError` into a KEEP-with-warning.
   FSM-driven teardown passes `respect_liveness=False` (the FSM decided to tear
   this worktree down) and explicit abandon passes `force=True`, so a
   genuinely-completed ticket still tears down.

3. **orphan-isolated-root** keeps every unmappable env dir when a protected
   worktree row has no recorded checkout path (fail-safe data-loss guard, now
   keyed on the widened `worktree_protects_against_reap`).

4. **Module health.** Adding the guard pushed `cleanup.py` over the 500-LOC cap.
   The pure-liveness concern (`WorktreeBusyError` + `guard_live_worktree`) is
   split into `cleanup_busy_guards.py`; the dirty-worktree and committed-unpushed
   data-loss guards stay in `cleanup.py` next to the git-removal they gate.
   `WorktreeBusyError` is re-exported from `teatree.core.cleanup` so the
   catch-what-cleanup_worktree-raises import surface stays stable.

## Architecture pre-check — auto:wt-reaper-liveness-guard (WT-PR-F)

## 1. BLUEPRINT § alignment
Workspace lifecycle / worktree teardown. Extends the §"Cleanup Patterns"
"uncertain -> keep with a warning, never delete" doctrine (#291/#706/#835/#2243)
to Session/Task liveness AND active-delivery, applied at the single
`cleanup_worktree` seam. No new section needed; the BLUEPRINT-source pre-commit
gate passed (no doc drift).

## 2. FSM phase boundaries
n/a. No Ticket.State / Worktree.State transition is added or moved. The guard
only reads liveness/delivery; it transitions nothing. FSM-driven teardown opts
out via `respect_liveness=False` so a MERGED ticket still tears down.

## 3. Extension-point contracts
n/a for overlay hooks / scanners / backends. `cleanup_worktree` (the shared
teardown seam) gains one keyword-only `respect_liveness: bool = True`; the
default is the fail-safe, so all existing callers keep current behaviour unless
they explicitly opt out. FSM teardown runners pass `respect_liveness=False`
(verified: `runners/teardown.py`, `runners/worktree_teardown.py`).

## 4. Component boundaries
The predicate stays in core (`teatree.core.gates.idle_stack` — the canonical
liveness home). The liveness guard + `WorktreeBusyError` live in
`teatree.core.cleanup_busy_guards` (sibling of the existing `cleanup_orphan_ref`,
split out purely for module-health); the dirty/data-loss guards stay in
`teatree.core.cleanup`. Reapers stay in `teatree.core.management.commands`; sync
backends in `teatree.backends.*`. No straddle.

## 5. Dependency direction
New edges: `teatree.core.cleanup` -> `teatree.core.cleanup_busy_guards` ->
`teatree.core.gates.idle_stack` (all intra-core, downward); reapers and sync
backends -> `teatree.core.cleanup` (interface/backend -> domain, legal).
`uv run tach check` -> "All modules validated!". No backwards edge (idle_stack
does not import cleanup, so the guard's idle_stack import is a clean module-level
import — no cycle).

## 6. Test surface (anti-vacuity verified)
- `cleanup_worktree` funnel: live session / claimed task / external-delivery /
  recent E2E / reaper_pinned -> KEEP (WorktreeBusyError) by default; `force=True`
  and `respect_liveness=False` tear down; idle tears down.
  tests/teatree_core/cleanup/test_cleanup_worktree.py::TestCleanupWorktreeLivenessGuard.
- reap_one_worktree: busy -> SKIPPED KEEP (not the push/abandon path); unsynced
  RuntimeError still routes to resolve; idle -> reap.
  tests/teatree_core/management/commands/test__workspace_reap.py.
- clean_merged_worktrees: busy merged worktree -> SKIPPED KEEP.
  tests/teatree_core/management_commands/test_workspace.py::TestWorkspaceCleanMerged.
- run_clean_all: busy squash-merged + busy CREATED -> KEEP; idle CREATED -> reap.
- reap_orphan_isolated_worktree_roots: busy/protected pathless row (session,
  claimed task, external-delivery, recent E2E, reaper_pinned) -> KEEP every dir;
  dead pathless row -> reap.
  tests/teatree_core/management/commands/test__workspace_isolated_roots.py.
- FSM teardown runners assert `respect_liveness is False`.
  tests/teatree_core/test_runners_teardown.py.
Each new guard was observed RED with the guard neutered (9 funnel/predicate-off
scenarios) and the widened predicate narrowed back to Session+Task (3 delivery
scenarios RED) before the fix; GREEN after.

## 7. Resilience invariants
No external write is added, so the relevant invariants are fail-safe +
idempotency. The guard fails toward KEEP at the single seam: `respect_liveness`
defaults True, `worktree_protects_against_reap` returns a keep-reason on EITHER
busy OR active-delivery (never protecting less than the reversible reaper), and
an unmappable busy row keeps ALL orphan dirs. Reaping stays idempotent (a kept
worktree reaps on a later clean-all/clean-merged once its ticket is idle and the
delivery lease lapses). verify-by-re-read / fallback-transport / heartbeat /
sub-agent-return: n/a (no external write, no long-running work, no sub-agent).

## 8. Identity and key normalization
n/a. No new identity key; the predicate keys on the Ticket FK already present on
Session/Task and on the Worktree row for the delivery checks. The env-dir slug
mapping (sha256 of worktree_path) is unchanged; the guard only covers the case
where that mapping is impossible (no worktree_path).

## 9. Behavior preservation / capability deletion
The only removed behaviour is the data-loss bug. Two deliberate must-keep ->
must-keep-more changes, neither weakening a safety gate:
- The prior isolated-root test test_row_without_checkout_path_does_not_protect_a_dir
  asserted a pathless row's would-be env dir is REAPED — that pinned the bug. It
  is inverted to assert KEEP because the old behaviour IS the data-loss bug; a
  NEW test_dead_pathless_row_still_reaps_orphan_dirs preserves the safe half.
- `ticket_is_busy`'s reachability narrowed (reapers no longer call it directly —
  they call the strictly-wider `worktree_protects_against_reap`), so the
  irreversible path can only KEEP more than before, never less.
No privacy/leak/security matcher is narrowed; no must-block test inverted to
must-not-block in any gate. Every existing safe-reap path (idle squash-merged /
CREATED / pathless rows, merged-and-idle clean-merged, FSM teardown of a MERGED
ticket) is preserved and still green.
