### PR TITLE
fix(worktree): canonicalize ticket/worktree identity, fail loud on collision

### DIFF
--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -561,10 +561,12 @@ def _remove_overlay_pass_entry(overlay: "OverlayBase | None", worktree: Worktree
     if ticket is None:
         return
     try:
-        remove_postgres_pass_entry(ticket.ticket_number)
+        # Keyed on the ticket pk (the canonical, unique key), matching
+        # ``Worktree.pass_key`` the env render wrote into the cache.
+        remove_postgres_pass_entry(ticket.pk)
     except Exception as exc:
         logger.exception("pass-entry removal failed for %s", worktree.repo_path)
-        step_errors.append(f"pass-entry removal failed for {ticket.ticket_number}: {exc}")
+        step_errors.append(f"pass-entry removal failed for ticket #{ticket.pk}: {exc}")
 
 
 def cleanup_worktree(

--- a/src/teatree/core/management/commands/env.py
+++ b/src/teatree/core/management/commands/env.py
@@ -183,14 +183,15 @@ class Command(TyperCommand):
         ticket = worktree.ticket
         if ticket is None:
             return _MigrationOutcome(ok=False, message="no ticket attached — cannot derive pass key")
-        ticket_number = ticket.ticket_number
 
         if not literal:
             write_env_cache(worktree)
             return _MigrationOutcome(ok=True, message="already migrated (no literal in cache)")
 
         try:
-            pass_key = ensure_postgres_pass_entry(ticket_number, literal)
+            # Keyed on the ticket pk (the canonical, unique key), matching
+            # ``Worktree.pass_key`` the env render writes into the cache.
+            pass_key = ensure_postgres_pass_entry(ticket.pk, literal)
         except PostgresPasswordUnavailableError as exc:
             return _MigrationOutcome(ok=False, message=str(exc))
 

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -32,7 +32,7 @@ from teatree.core.overlay_loader import get_overlay
 from teatree.core.public_identity import StampResult, is_public_github_remote, set_local_noreply_identity
 from teatree.core.readiness import run_and_report_probes
 from teatree.core.reconcile import reconcile_all, reconcile_ticket
-from teatree.core.resolve import WorktreeNotFoundError, _get_user_cwd, resolve_worktree
+from teatree.core.resolve import WorktreeNotFoundError, _get_user_cwd, resolve_worktree, workspace_owner_ticket
 from teatree.core.runners import (
     WorktreeProvisioner,
     WorktreeProvisionRunner,
@@ -82,28 +82,20 @@ def _resolve_workspace_ticket(path: str) -> Ticket:
     worktree in a ticket, so they should be runnable both from inside a
     worktree subdir and from the ticket workspace root that holds those
     subdirs. First try the normal worktree resolution; if that fails
-    because we're at the workspace root, match child worktree dirs back
-    to their ticket.
+    because we're at the workspace root, attribute the workspace dir to its
+    owning ticket through the single fail-loud resolver
+    (:func:`workspace_owner_ticket`) — the same symlink-tolerant, multi-owner
+    policy the auto-register chain uses, never a second hand-rolled check.
     """
     try:
         anchor = resolve_worktree(path)
         return Ticket.objects.get(pk=anchor.ticket.pk)
     except WorktreeNotFoundError:
         base = Path(path).resolve() if path else Path(_get_user_cwd()).resolve()
-        ticket_pks: set[int] = set()
-        for wt in Worktree.objects.exclude(extra__worktree_path__isnull=True):
-            wt_path = (wt.extra or {}).get("worktree_path", "")
-            if wt_path and Path(wt_path).resolve().parent == base:
-                ticket_pks.add(wt.ticket_id)
-        if len(ticket_pks) == 1:
-            return Ticket.objects.get(pk=ticket_pks.pop())
-        if len(ticket_pks) > 1:
-            msg = (
-                f"{base} holds worktrees from multiple tickets ({sorted(ticket_pks)}).\n"
-                "Run the command from a specific worktree subdir."
-            )
-            raise WorktreeNotFoundError(msg) from None
-        raise
+        owner = workspace_owner_ticket(base)
+        if owner is None:
+            raise
+        return Ticket.objects.get(pk=owner.pk)
 
 
 def _report_worktree_probes(

--- a/src/teatree/core/models/worktree.py
+++ b/src/teatree/core/models/worktree.py
@@ -8,10 +8,20 @@ from teatree.config import load_config as _load_config
 from teatree.core.managers import WorktreeManager
 from teatree.core.models.ticket import Ticket
 from teatree.core.models.types import WorktreeExtra, validated_worktree_extra
+from teatree.utils.postgres_secret import postgres_pass_key
 
 
 def _workspace_dir() -> Path:
     return _load_config().user.workspace_dir
+
+
+class WorktreeDbNameConflictError(RuntimeError):
+    """Raised when another live worktree of a different ticket owns a computed db_name.
+
+    ``db_name`` is keyed on the immutable, unique Ticket pk so a collision
+    cannot arise through the normal flow; this guards a hand-built or legacy
+    row from clobbering another ticket's database before ``db_import``.
+    """
 
 
 class Worktree(models.Model):
@@ -72,6 +82,17 @@ class Worktree(models.Model):
         """True if this row claims a worktree path that no longer exists on disk."""
         path = self.worktree_path
         return bool(path) and not Path(path).exists()
+
+    @property
+    def pass_key(self) -> str:
+        """Canonical, collision-free ``pass`` key for this worktree's postgres password.
+
+        Keyed on the immutable, unique Ticket pk (NOT the derived, non-unique
+        ``ticket_number``), so two tickets sharing a trailing issue number never
+        share one secret entry. Ticket-scoped — the same canonical key the
+        db_name uses — so a ticket's sibling repos share one database password.
+        """
+        return postgres_pass_key(self.ticket_id)  # ty: ignore[unresolved-attribute]  # Django FK accessor
 
     @transition(field=state, source=[State.CREATED, State.PROVISIONED], target=State.PROVISIONED)
     def provision(self) -> None:
@@ -190,7 +211,37 @@ class Worktree(models.Model):
     def _build_db_name(self) -> str:
         ticket = cast("Ticket", self.ticket)
         variant_suffix = f"_{ticket.variant}" if ticket.variant else ""
-        return f"wt_{ticket.ticket_number}{variant_suffix}"
+        # Keyed on the immutable, unique Ticket pk (not the derived, non-unique
+        # ``ticket_number``): two tickets sharing a trailing issue number must
+        # never resolve to one database. Ticket-scoped (not worktree-scoped) so a
+        # ticket's sibling repos share one database, as the per-ticket env cache
+        # requires.
+        return f"wt_{ticket.pk}{variant_suffix}"
+
+    def assert_db_name_unclaimed(self) -> None:
+        """Fail loud if another LIVE worktree of a DIFFERENT ticket owns ``db_name``.
+
+        Defense-in-depth guard the provision runner calls before ``db_import``:
+        ``db_name`` is ticket-pk-keyed so a collision cannot arise through the
+        normal flow, but a hand-built or legacy row could still clobber another
+        ticket's database. CREATED rows own no database yet and are excluded.
+        """
+        if not self.db_name:
+            return
+        ticket_pk = self.ticket_id  # ty: ignore[unresolved-attribute]  # Django FK accessor
+        conflict = (
+            Worktree.objects.exclude(pk=self.pk)
+            .exclude(ticket_id=ticket_pk)
+            .exclude(state=Worktree.State.CREATED)
+            .filter(db_name=self.db_name)
+            .first()
+        )
+        if conflict is not None:
+            msg = (
+                f"db_name {self.db_name!r} is owned by another live worktree "
+                f"(#{conflict.pk}); refusing db_import for worktree #{self.pk} to avoid clobber."
+            )
+            raise WorktreeDbNameConflictError(msg)
 
     def get_extra(self) -> WorktreeExtra:
         return validated_worktree_extra(self.extra)

--- a/src/teatree/core/reconcile.py
+++ b/src/teatree/core/reconcile.py
@@ -5,11 +5,12 @@ Postgres DBs, docker containers, env cache files — and returns
 a ``Drift`` bundle enumerating what's out of sync.
 
 Drift objects are typed (per-finding dataclass) so callers can inspect and
-act without string-parsing a log.  ``t3 teatree workspace doctor`` is the primary
-consumer; ``worktree start`` calls ``reconcile_ticket`` before provisioning
-and refuses when drift is present.
+act without string-parsing a log.  ``t3 teatree workspace doctor`` is the
+primary consumer; ``recover`` surfaces the drifted ticket pks via
+``reconcile_all``.
 """
 
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -233,14 +234,17 @@ def _collect_stale_worktree_dirs(drift: Drift, worktrees: list[Worktree], ticket
         for wt in worktrees
         if (wt.extra or {}).get("worktree_path")
     }
+    # Anchor the ticket-number match on path segments so ``/9`` no longer
+    # matches ``/90``: the number must be a whole segment, bounded by ``/`` or
+    # ``-`` (or the string ends), never a substring of a longer number.
+    ticket_anchor = re.compile(rf"(?:^|[/-]){re.escape(ticket.ticket_number)}(?:[-/]|$)")
     for wt in worktrees:
         repo_main = resolve_clone_path(workspace, wt) or workspace / wt.repo_path
         for path_str in _find_worktree_paths_on_disk(repo_main):
             resolved = Path(path_str).resolve().as_posix()
             if resolved == str(repo_main.resolve()):
                 continue
-            matches_ticket = f"/{ticket.ticket_number}" in path_str or f"-{ticket.ticket_number}-" in path_str
-            if matches_ticket and resolved not in seen_paths:
+            if ticket_anchor.search(path_str) and resolved not in seen_paths:
                 drift.stale_worktree_dirs.append(StaleWorktreeDir(path=Path(path_str)))
 
 

--- a/src/teatree/core/resolve.py
+++ b/src/teatree/core/resolve.py
@@ -16,7 +16,10 @@ import os
 import re
 from pathlib import Path
 
+from django.core.exceptions import ImproperlyConfigured
+
 from teatree.core.models import Ticket, Worktree
+from teatree.core.overlay_loader import get_all_overlays, get_overlay_for_repo
 from teatree.core.worktree_env import CACHE_FILENAME
 from teatree.utils import git
 
@@ -29,6 +32,35 @@ _LEADING_TICKET_NUMBER = re.compile(r"^(?:[^/]*/)?(\d+)(?:-|$)")
 
 class WorktreeNotFoundError(RuntimeError):
     """Raised when no worktree can be resolved from the current context."""
+
+
+class TicketIdentityCollisionError(RuntimeError):
+    """Raised when a derived ``ticket_number`` resolves to more than one ticket.
+
+    ``ticket_number`` is a DERIVED, non-unique key (trailing digits of
+    ``issue_url``, else the pk), so two tickets on different repos/forges can
+    share one. Returning an arbitrary ``.first()`` silently cross-attaches a
+    worktree to the wrong ticket; failing loud surfaces the ambiguity instead.
+    """
+
+
+class WorktreePathConflictError(RuntimeError):
+    """Raised when refreshing a row would steal a ``worktree_path`` another row owns.
+
+    Repointing row A onto a path row B already records would leave two rows
+    claiming one directory — every downstream consumer (run, provision,
+    teardown) would then disagree about which ticket owns it. Fail loud rather
+    than silently repoint.
+    """
+
+
+class WorkspaceOwnerCollisionError(RuntimeError):
+    """Raised when one workspace dir is owned by worktrees of more than one ticket.
+
+    The one-ticket-per-workspace-dir invariant is violated. Picking an
+    arbitrary owner mis-attributes a sibling worktree; failing loud tells the
+    operator to run the command from a specific worktree subdir.
+    """
 
 
 def _get_user_cwd() -> str:
@@ -128,48 +160,90 @@ def _ticket_number_from_branch(branch: str) -> str | None:
     return match.group(1) if match else None
 
 
-def _ticket_by_number(number: str) -> Ticket | None:
+def _ticket_by_number(number: str, *, overlay: str | None = None) -> Ticket | None:
     """Return the non-synthetic ticket whose ``ticket_number`` is *number*.
 
-    ``ticket_number`` is a derived property (trailing digits of ``issue_url``,
-    else the pk), so the match is done in Python over real tickets — synthetic
+    ``ticket_number`` is a DERIVED, non-unique key (trailing digits of
+    ``issue_url``, else the pk), so two tickets on different repos/forges can
+    share one. The match is done in Python over real tickets — synthetic
     ``auto:`` rows are excluded so a hint never resolves back to a placeholder.
+
+    When *overlay* is known (inferred from the resolving repo's remote) the
+    candidates are narrowed to that overlay first, so a same-number ticket in a
+    different overlay never competes. More than one surviving candidate raises
+    :class:`TicketIdentityCollisionError` (fail loud) rather than returning an
+    arbitrary ``.first()`` that would cross-attach the worktree to the wrong
+    ticket.
     """
-    for ticket in Ticket.objects.exclude(issue_url="").exclude(issue_url__startswith="auto:"):
-        if ticket.ticket_number == number:
-            return ticket
-    return None
+    matches = [
+        ticket
+        for ticket in Ticket.objects.exclude(issue_url="").exclude(issue_url__startswith="auto:")
+        if ticket.ticket_number == number
+    ]
+    if overlay:
+        scoped = [ticket for ticket in matches if ticket.overlay == overlay]
+        if scoped:
+            matches = scoped
+    if len(matches) > 1:
+        msg = (
+            f"ticket_number {number!r} resolves to {len(matches)} tickets "
+            f"(pks {sorted(ticket.pk for ticket in matches)}); refusing to attach a "
+            "worktree to an arbitrary one. Pass --ticket to disambiguate."
+        )
+        raise TicketIdentityCollisionError(msg)
+    return matches[0] if matches else None
 
 
-def _ticket_owning_branch(branch: str) -> Ticket | None:
+def _ticket_owning_branch(branch: str, *, overlay: str | None = None) -> Ticket | None:
     """Return the ticket whose ``ticket_number`` the branch encodes, or None.
 
     A manually-added worktree (``git worktree add`` without ``workspace
     ticket``) has no Worktree row yet, but its branch already names the
     ticket. Matching on that number attaches the worktree to the correct
-    ticket instead of the most-recent workspace sibling.
+    ticket instead of the most-recent workspace sibling. *overlay* scopes the
+    number lookup (see :func:`_ticket_by_number`).
     """
     number = _ticket_number_from_branch(branch)
     if number is None:
         return None
-    return _ticket_by_number(number)
+    return _ticket_by_number(number, overlay=overlay)
+
+
+def _overlay_name_for_cwd(cwd_path: Path) -> str | None:
+    """Best-effort overlay name owning the repo at *cwd_path* (or ``None``).
+
+    Scopes ``_ticket_by_number`` so a same-number ticket in another overlay
+    never collides. Resolution is via the repo's ``origin`` remote
+    (:func:`get_overlay_for_repo`); a repo with no recognised remote yields
+    ``None`` and the number match stays global (still fail-loud on >1).
+    """
+    try:
+        overlay = get_overlay_for_repo(str(cwd_path))
+    except ImproperlyConfigured:
+        return None
+    if overlay is None:
+        return None
+    for name, candidate in get_all_overlays().items():
+        if candidate is overlay:
+            return name
+    return None
 
 
 def _auto_register_from_git(cwd: str, ticket_hint: Ticket | None = None) -> Worktree | None:
     """Detect a git worktree from the filesystem and auto-register it in the DB.
 
-    Reuses an existing Worktree row keyed by branch + repo before falling
-    through to creating a new ``auto:<branch>`` ticket. This prevents duplicate
-    ticket rows when a real-ticket worktree exists but its
-    ``extra["worktree_path"]`` is missing or stale (which would make
-    ``match_worktree_by_path`` miss it).
-
     Ticket attribution for a manually-added worktree resolves in order:
     an explicit *ticket_hint* (the ``--ticket`` flag), the branch-encoded
-    ticket number (``_ticket_owning_branch``), the workspace-dir owner
-    (``_workspace_owner_ticket``), then a fresh ``auto:<branch>`` ticket. The
-    hint and branch number win first so a manual worktree never cross-attaches
-    to an unrelated sibling under the same workspace dir.
+    ticket number (``_ticket_owning_branch``, overlay-scoped), then the
+    workspace-dir owner (``_workspace_owner_ticket``). The attribution chain
+    runs FIRST so a real signal always wins over a foreign row that merely
+    shares this branch + repo basename — the cross-attach that bound a worktree
+    to a merged ticket.
+
+    Only when the chain yields nothing does the legacy branch+repo reuse fire,
+    as a LAST resort before forking a fresh ``auto:<branch>`` ticket — it
+    rescues a moved or stale-``worktree_path`` worktree of a non-numbered branch
+    without forking a duplicate, and can no longer out-vote real attribution.
     """
     cwd_path = Path(cwd).resolve()
     git_file = cwd_path / ".git"
@@ -181,21 +255,30 @@ def _auto_register_from_git(cwd: str, ticket_hint: Ticket | None = None) -> Work
         return None
 
     repo_name = cwd_path.name
+    overlay_name = _overlay_name_for_cwd(cwd_path)
+    ticket = ticket_hint or _ticket_owning_branch(branch, overlay=overlay_name) or _workspace_owner_ticket(cwd_path)
+    if ticket is not None:
+        return _get_or_refresh_worktree(ticket, repo_name, branch, cwd_path)
+
     existing = Worktree.objects.filter(branch=branch, repo_path=repo_name).first()
     if existing is not None:
         _refresh_reused_row(existing, branch, cwd_path)
         return existing
 
-    ticket = (
-        ticket_hint
-        or _ticket_owning_branch(branch)
-        or _workspace_owner_ticket(cwd_path)
-        or Ticket.objects.get_or_create(
-            issue_url=f"auto:{branch}",
-            defaults={"variant": "", "repos": [repo_name]},
-        )[0]
-    )
-    wt, wt_created = Worktree.objects.get_or_create(
+    ticket = Ticket.objects.get_or_create(
+        issue_url=f"auto:{branch}",
+        defaults={"variant": "", "repos": [repo_name]},
+    )[0]
+    return _get_or_refresh_worktree(ticket, repo_name, branch, cwd_path)
+
+
+def _get_or_refresh_worktree(ticket: Ticket, repo_name: str, branch: str, cwd_path: Path) -> Worktree:
+    """Reuse *ticket*'s row for *repo_name* (mirror ``provision.py``) or create it.
+
+    The reuse is scoped to the RESOLVED ticket, so a foreign ticket's row that
+    happens to share this branch + repo basename is never stolen.
+    """
+    wt, created = Worktree.objects.get_or_create(
         ticket=ticket,
         repo_path=repo_name,
         defaults={
@@ -204,7 +287,7 @@ def _auto_register_from_git(cwd: str, ticket_hint: Ticket | None = None) -> Work
             "extra": {"worktree_path": str(cwd_path)},
         },
     )
-    if not wt_created:
+    if not created:
         _refresh_reused_row(wt, branch, cwd_path)
     return wt
 
@@ -212,54 +295,99 @@ def _auto_register_from_git(cwd: str, ticket_hint: Ticket | None = None) -> Work
 def _refresh_reused_row(worktree: Worktree, branch: str, cwd_path: Path) -> None:
     """Re-point a reused row at the git worktree actually being resolved.
 
-    Both reuse arms above hand back an existing row whose recorded
-    ``branch``/``extra.worktree_path`` may describe a PREVIOUS worktree of
-    the same ticket+repo (the dir was re-created elsewhere, or the work
-    moved to a new branch). ``get_or_create`` ignores its ``defaults`` on
-    reuse, so without this refresh every downstream consumer (run
-    commands, provision steps) keeps acting on the stale path — e.g. a
-    frontend build silently lands in a different ticket's worktree
-    directory while the user is sitting in the current one.
+    A reused row's recorded ``branch``/``extra.worktree_path`` may describe a
+    PREVIOUS worktree of the same ticket+repo (the dir was re-created
+    elsewhere, or the work moved to a new branch). ``get_or_create`` ignores
+    its ``defaults`` on reuse, so without this refresh every downstream
+    consumer (run commands, provision steps) keeps acting on the stale path.
+
+    Refuses to repoint onto a ``worktree_path`` another row already owns: two
+    rows claiming one directory is the collision this fix forecloses, so it
+    raises :class:`WorktreePathConflictError` rather than silently steal.
     """
     update_fields: list[str] = []
     if worktree.branch != branch:
         worktree.branch = branch
         update_fields.append("branch")
     extra = worktree.extra or {}
-    if extra.get("worktree_path") != str(cwd_path):
-        extra["worktree_path"] = str(cwd_path)
+    new_path = str(cwd_path)
+    if extra.get("worktree_path") != new_path:
+        _assert_path_unclaimed(worktree, new_path)
+        extra["worktree_path"] = new_path
         worktree.extra = extra
         update_fields.append("extra")
     if update_fields:
         worktree.save(update_fields=update_fields)
 
 
-def _workspace_owner_ticket(cwd_path: Path) -> Ticket | None:
-    """Return the ticket that already owns *cwd_path*'s workspace dir, if any.
+def _assert_path_unclaimed(worktree: Worktree, new_path: str) -> None:
+    """Raise if a row other than *worktree* already records *new_path*."""
+    conflict = (
+        Worktree.objects.exclude(pk=worktree.pk).filter(extra__worktree_path__in=_candidate_paths(new_path)).first()
+    )
+    if conflict is not None:
+        msg = (
+            f"Refusing to repoint worktree #{worktree.pk} onto {new_path}: "
+            f"worktree #{conflict.pk} (ticket {conflict.ticket_id}) already owns it. "
+            "Two rows must never claim one directory."
+        )
+        raise WorktreePathConflictError(msg)
+
+
+def tickets_owning_workspace_dir(workspace_dir: Path) -> list[Ticket]:
+    """Return the distinct tickets whose worktrees live directly under *workspace_dir*.
 
     A per-ticket workspace dir holds one repo worktree per affected repo
-    (e.g. ``<workspace>/<ticket>/<repoA>``, ``…/<repoB>``). When a sibling
-    worktree under the same parent directory is already registered, its
-    ticket owns the workspace — a different branch/repo resolved from the
-    same workspace must attach to that ticket rather than fork a fresh
-    ``auto:<branch>`` ticket (#641).
+    (``<workspace>/<ticket>/<repoA>``, ``…/<repoB>``). A worktree belongs to
+    *workspace_dir* when its stored ``worktree_path``'s parent matches it.
 
     Stored ``worktree_path`` values are written unresolved (provision uses
-    ``config.workspace_dir()`` verbatim) while ``cwd_path`` here is
-    ``.resolve()``-d, so a symlinked workspace root (macOS ``/tmp`` →
-    ``/private/tmp``) would otherwise miss. Comparison goes through
-    ``_candidate_paths`` — the same symlink-variant set
-    ``match_worktree_by_path`` uses. Relies on the one-ticket-per-
-    workspace-dir invariant; if violated the first match wins.
+    ``config.workspace_dir()`` verbatim) while callers pass a ``.resolve()``-d
+    dir, so comparison goes through ``_candidate_paths`` — the same
+    symlink-variant set ``match_worktree_by_path`` uses (macOS ``/tmp`` →
+    ``/private/tmp``). This is the single source of truth for workspace-dir →
+    ticket attribution, routed through by both the auto-register attribution
+    chain and the ``workspace`` command resolver.
     """
-    workspace_candidates = set(_candidate_paths(str(cwd_path.parent)))
+    workspace_candidates = set(_candidate_paths(str(workspace_dir)))
+    owners: dict[int, Ticket] = {}
     for wt in Worktree.objects.exclude(extra__worktree_path__isnull=True).order_by("pk"):
         recorded = (wt.extra or {}).get("worktree_path", "")
         if not recorded:
             continue
         if set(_candidate_paths(str(Path(recorded).parent))) & workspace_candidates:
-            return wt.ticket
-    return None
+            owners.setdefault(wt.ticket_id, wt.ticket)
+    return list(owners.values())
+
+
+def workspace_owner_ticket(workspace_dir: Path) -> Ticket | None:
+    """Return the single ticket owning *workspace_dir*, or ``None``; fail loud on >1.
+
+    The one-ticket-per-workspace-dir invariant: at most one ticket's worktrees
+    share a workspace dir (#641). More than one owner means the invariant is
+    violated; raising :class:`WorkspaceOwnerCollisionError` is the single
+    fail-loud policy both ``_auto_register_from_git`` and the ``workspace``
+    command resolver share — never an arbitrary pick.
+    """
+    owners = tickets_owning_workspace_dir(workspace_dir)
+    if len(owners) > 1:
+        msg = (
+            f"{workspace_dir} holds worktrees from {len(owners)} tickets "
+            f"(pks {sorted(ticket.pk for ticket in owners)}). Run the command "
+            "from a specific worktree subdir."
+        )
+        raise WorkspaceOwnerCollisionError(msg)
+    return owners[0] if owners else None
+
+
+def _workspace_owner_ticket(cwd_path: Path) -> Ticket | None:
+    """Return the ticket that owns *cwd_path*'s workspace dir, if any.
+
+    Thin wrapper resolving the workspace dir (the parent that holds the repo
+    subdirs) and delegating to :func:`workspace_owner_ticket` so the
+    attribution chain shares the one fail-loud multi-owner policy (#641).
+    """
+    return workspace_owner_ticket(cwd_path.parent)
 
 
 def _is_main_clone(path: str) -> bool:

--- a/src/teatree/core/runners/worktree_provision.py
+++ b/src/teatree/core/runners/worktree_provision.py
@@ -146,6 +146,10 @@ class WorktreeProvisionRunner(RunnerBase):
         worktree = self.worktree
         overlay = self.overlay
 
+        # Fail loud before importing into a db_name another ticket's live
+        # worktree already owns — never clobber a foreign database (#WT-PR-D).
+        worktree.assert_db_name_unclaimed()
+
         if worktree.db_name:
             user, host, env = worktree_pg_connection(worktree, overlay=overlay)
             try:

--- a/src/teatree/core/worktree_env.py
+++ b/src/teatree/core/worktree_env.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, cast
 from teatree.core.models import Ticket, Worktree, WorktreeEnvOverride
 from teatree.core.models.types import WorktreeExtra, validated_worktree_extra
 from teatree.core.overlay_loader import get_overlay_for_worktree
-from teatree.utils.postgres_secret import PASS_KEY_ENV, postgres_pass_key
+from teatree.utils.postgres_secret import PASS_KEY_ENV
 
 if TYPE_CHECKING:
     from teatree.core.overlay import OverlayBase
@@ -89,7 +89,7 @@ def _core_env_pairs(worktree: Worktree) -> list[tuple[str, str]]:
         ("TICKET_URL", ticket.issue_url),
         ("WT_DB_NAME", worktree.db_name),
         ("COMPOSE_PROJECT_NAME", compose_project(worktree)),
-        (PASS_KEY_ENV, postgres_pass_key(ticket.ticket_number)),
+        (PASS_KEY_ENV, worktree.pass_key),
     ]
 
 

--- a/src/teatree/utils/db.py
+++ b/src/teatree/utils/db.py
@@ -21,11 +21,6 @@ def pg_user() -> str:
     return os.environ.get("POSTGRES_USER", "postgres")
 
 
-def worktree_db_name(ticket_number: str, variant: str) -> str:
-    suffix = f"_{variant}" if variant else ""
-    return f"wt_{ticket_number}{suffix}"
-
-
 _TRUNCATION_PATTERNS = ("could not read", "unexpected EOF", "invalid page", "WARNING:  errors ignored")
 
 

--- a/tests/teatree_core/cleanup/test_cleanup_worktree.py
+++ b/tests/teatree_core/cleanup/test_cleanup_worktree.py
@@ -250,10 +250,10 @@ class TestCleanupWorktree(TestCase):
         mock_overlay.return_value.config.teardown_removes_pass_entries = True
 
         wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
-        ticket_number = wt.ticket.ticket_number
         with patch("teatree.core.cleanup.remove_postgres_pass_entry") as mock_remove:
             cleanup_worktree(wt)
-        mock_remove.assert_called_once_with(ticket_number)
+        # Pass key is ticket-pk-scoped (canonical, unique), not ticket_number.
+        mock_remove.assert_called_once_with(wt.ticket_id)
 
     @_patch_overlay
     @_patch_git
@@ -823,7 +823,7 @@ class TestCleanupWorktreeLoudTeardown(TestCase):
 
         wt = self._make_worktree(db_name="wt_99")
         wt_id = wt.pk
-        ticket_number = wt.ticket.ticket_number
+        ticket_id = wt.ticket_id
 
         with (
             patch(
@@ -838,8 +838,9 @@ class TestCleanupWorktreeLoudTeardown(TestCase):
         assert result.clean is False
         assert any("wt_99" in e for e in result.errors)
         assert any("connection refused" in e for e in result.errors)
-        # Other resources STILL reaped despite the DB-drop failure
-        mock_remove.assert_called_once_with(ticket_number)
+        # Other resources STILL reaped despite the DB-drop failure.
+        # Pass key is ticket-pk-scoped (canonical, unique), not ticket_number.
+        mock_remove.assert_called_once_with(ticket_id)
         mock_git.worktree_remove.assert_called_once()
         assert not Worktree.objects.filter(pk=wt_id).exists()
 

--- a/tests/teatree_core/management_commands/test_lifecycle.py
+++ b/tests/teatree_core/management_commands/test_lifecycle.py
@@ -161,12 +161,13 @@ class TestLifecycleSetup(TestCase):
                 )
 
             worktree = Worktree.objects.get(pk=worktree_id)
-            assert worktree.db_name == "wt_91_acmebank"
+            # db_name keys on the unique Ticket pk, not the derived ticket_number.
+            assert worktree.db_name == f"wt_{worktree.ticket_id}_acmebank"
 
             cache_file = tmp_path / ".t3-cache" / ".t3-env.cache"
             cache_body = cache_file.read_text(encoding="utf-8")
             assert "WT_VARIANT=acmebank" in cache_body
-            assert "WT_DB_NAME=wt_91_acmebank" in cache_body
+            assert f"WT_DB_NAME=wt_{worktree.ticket_id}_acmebank" in cache_body
 
     @_patch_overlays(FAILING_IMPORT_OVERLAY)
     @override_settings(**SETTINGS)
@@ -918,8 +919,8 @@ class TestLifecycleClean(TestCase):
 
             dropdb_cmds = [c for c in commands_run if "dropdb" in c]
             assert len(dropdb_cmds) == 1
-            # provision() generates db_name as wt_{ticket_number}
-            assert f"wt_{ticket.ticket_number}" in " ".join(dropdb_cmds[0])
+            # provision() generates db_name as wt_{ticket.pk}
+            assert f"wt_{wt.ticket_id}" in " ".join(dropdb_cmds[0])
 
 
 class TestLifecycleStatus(TestCase):
@@ -959,7 +960,8 @@ class TestLifecycleDiagnose(TestCase):
 
             assert result["worktree_dir"] is True
             assert result["env_cache"] is True
-            assert result["db_name"] == "wt_120"
+            # provision() recomputes db_name from the unique Ticket pk.
+            assert result["db_name"] == f"wt_{wt.ticket_id}"
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)

--- a/tests/teatree_core/models/test_worktree.py
+++ b/tests/teatree_core/models/test_worktree.py
@@ -58,7 +58,7 @@ class TestWorktreeTransitionSignals(TestCase):
         worktree.save()
         worktree.refresh_from_db()
         pre_blank_db = worktree.db_name
-        assert pre_blank_db == "wt_79_acme"
+        assert pre_blank_db == f"wt_{worktree.ticket_id}_acme"
         worktree.extra = {"worktree_path": "/tmp/wt-79", "services": ["backend"]}
         worktree.save()
 
@@ -96,7 +96,7 @@ class TestWorktree(TestCase):
         worktree.refresh_from_db()
 
         assert worktree.state == Worktree.State.READY
-        assert worktree.db_name == "wt_42_acme"
+        assert worktree.db_name == f"wt_{worktree.ticket_id}_acme"
         assert worktree.extra["services"] == ["backend", "frontend"]
         assert worktree.extra["urls"] == {
             "backend": "http://localhost:8001",
@@ -150,3 +150,111 @@ class TestWorktree(TestCase):
 
         with pytest.raises(TransitionNotAllowed):
             worktree.verify()
+
+
+class TestWorktreeDbNameAndPassKeyAreIdentityScoped(TestCase):
+    """db_name and the postgres pass key key on the unique Ticket pk (#WT-PR-D finding 10).
+
+    ``ticket_number`` is a DERIVED, non-unique key (trailing issue digits), so
+    two tickets on different repos/forges can share one. Keying the database
+    name and the secret entry on the immutable Ticket pk instead makes a
+    cross-ticket clobber structurally impossible — and stays ticket-scoped (not
+    worktree-scoped) so a ticket's sibling repos share one database.
+    """
+
+    def test_db_name_keyed_on_ticket_pk_not_ticket_number(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://a.example.com/x/issues/5", variant="acme")
+        worktree = Worktree.objects.create(ticket=ticket, repo_path="backend", branch="5-x")
+        worktree.provision()
+        worktree.save()
+
+        assert worktree.db_name == f"wt_{ticket.pk}_acme"
+        assert "wt_5_acme" not in worktree.db_name
+
+    def test_sibling_repos_of_one_ticket_share_db_name(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://a.example.com/x/issues/5", variant="acme")
+        backend = Worktree.objects.create(ticket=ticket, repo_path="backend", branch="5-x")
+        frontend = Worktree.objects.create(ticket=ticket, repo_path="frontend", branch="5-x")
+        backend.provision()
+        backend.save()
+        frontend.provision()
+        frontend.save()
+
+        assert backend.db_name == frontend.db_name
+
+    def test_two_tickets_sharing_trailing_number_get_distinct_db_names(self) -> None:
+        ticket_a = Ticket.objects.create(issue_url="https://a.example.com/x/issues/5")
+        ticket_b = Ticket.objects.create(issue_url="https://b.example.com/y/issues/5")
+        wt_a = Worktree.objects.create(ticket=ticket_a, repo_path="backend", branch="5-a")
+        wt_b = Worktree.objects.create(ticket=ticket_b, repo_path="backend", branch="5-b")
+        wt_a.provision()
+        wt_a.save()
+        wt_b.provision()
+        wt_b.save()
+
+        assert wt_a.db_name != wt_b.db_name
+
+    def test_pass_key_keyed_on_ticket_pk(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://a.example.com/x/issues/5")
+        worktree = Worktree.objects.create(ticket=ticket, repo_path="backend", branch="5-x")
+
+        assert worktree.pass_key == f"teatree/wt/{ticket.pk}/postgres"
+
+
+class TestAssertDbNameUnclaimed(TestCase):
+    """``db_import`` must refuse a db_name another live, foreign-ticket worktree owns."""
+
+    def test_raises_when_another_live_different_ticket_owns_db_name(self) -> None:
+        from teatree.core.models.worktree import WorktreeDbNameConflictError  # noqa: PLC0415
+
+        ticket_a = Ticket.objects.create(issue_url="https://a.example.com/x/issues/1")
+        ticket_b = Ticket.objects.create(issue_url="https://b.example.com/y/issues/2")
+        Worktree.objects.create(
+            ticket=ticket_a,
+            repo_path="backend",
+            branch="1-x",
+            db_name="wt_shared",
+            state=Worktree.State.PROVISIONED,
+        )
+        wt_b = Worktree.objects.create(
+            ticket=ticket_b,
+            repo_path="backend",
+            branch="2-x",
+            db_name="wt_shared",
+            state=Worktree.State.PROVISIONED,
+        )
+
+        with pytest.raises(WorktreeDbNameConflictError):
+            wt_b.assert_db_name_unclaimed()
+
+    def test_noop_when_db_name_is_unique(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://a.example.com/x/issues/1")
+        worktree = Worktree.objects.create(
+            ticket=ticket,
+            repo_path="backend",
+            branch="1-x",
+            db_name="wt_unique",
+            state=Worktree.State.PROVISIONED,
+        )
+
+        worktree.assert_db_name_unclaimed()  # no raise
+
+    def test_ignores_created_state_row_that_owns_no_db_yet(self) -> None:
+        ticket_a = Ticket.objects.create(issue_url="https://a.example.com/x/issues/1")
+        ticket_b = Ticket.objects.create(issue_url="https://b.example.com/y/issues/2")
+        Worktree.objects.create(
+            ticket=ticket_a,
+            repo_path="backend",
+            branch="1-x",
+            db_name="wt_shared",
+            state=Worktree.State.CREATED,
+        )
+        wt_b = Worktree.objects.create(
+            ticket=ticket_b,
+            repo_path="backend",
+            branch="2-x",
+            db_name="wt_shared",
+            state=Worktree.State.PROVISIONED,
+        )
+
+        wt_b.assert_db_name_unclaimed()  # CREATED row owns no DB → no conflict

--- a/tests/teatree_core/test_env_command.py
+++ b/tests/teatree_core/test_env_command.py
@@ -221,10 +221,11 @@ class TestEnvMigrateSecrets(TestCase):
             ):
                 call_command("env", "migrate-secrets", "--path", str(wt_path))
 
-            assert stored == {"teatree/wt/42/postgres": "top-secret"}
+            # Pass key is ticket-pk-scoped (canonical, unique), not ticket_number.
+            assert stored == {f"teatree/wt/{wt.ticket_id}/postgres": "top-secret"}
             new_body = cache_file.read_text(encoding="utf-8")
             assert "POSTGRES_PASSWORD=top-secret" not in new_body
-            assert "POSTGRES_PASSWORD_PASS_KEY=teatree/wt/42/postgres" in new_body
+            assert f"POSTGRES_PASSWORD_PASS_KEY=teatree/wt/{wt.ticket_id}/postgres" in new_body
 
     def test_reports_already_migrated_when_no_literal_present(self) -> None:
         from tempfile import TemporaryDirectory  # noqa: PLC0415

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -863,7 +863,7 @@ class TestUpdateTicketVariant(TestCase):
             overlay="test",
             repo_path="backend",
             branch="feature",
-            db_name=f"wt_{ticket.ticket_number}_old",
+            db_name=f"wt_{ticket.pk}_old",
         )
 
         _update_ticket_variant(ticket, "new")
@@ -871,7 +871,7 @@ class TestUpdateTicketVariant(TestCase):
         ticket.refresh_from_db()
         wt.refresh_from_db()
         assert ticket.variant == "new"
-        assert wt.db_name == f"wt_{ticket.ticket_number}_new"
+        assert wt.db_name == f"wt_{ticket.pk}_new"
 
     def test_skips_save_when_db_name_unchanged(self) -> None:
         from teatree.core.management.commands.worktree import _update_ticket_variant  # noqa: PLC0415
@@ -886,7 +886,7 @@ class TestUpdateTicketVariant(TestCase):
             overlay="test",
             repo_path="backend",
             branch="feature",
-            db_name=f"wt_{ticket.ticket_number}",
+            db_name=f"wt_{ticket.pk}",
         )
         original_db_name = wt.db_name
 
@@ -895,7 +895,7 @@ class TestUpdateTicketVariant(TestCase):
 
         wt.refresh_from_db()
         assert wt.db_name != original_db_name
-        assert wt.db_name == f"wt_{ticket.ticket_number}_acme"
+        assert wt.db_name == f"wt_{ticket.pk}_acme"
 
 
 class TestFollowupCommands(TestCase):

--- a/tests/teatree_core/test_reconcile.py
+++ b/tests/teatree_core/test_reconcile.py
@@ -17,6 +17,7 @@ from teatree.core.reconcile import (
     MissingEnvCache,
     MissingWorktreeDir,
     UnresolvableOverlay,
+    _collect_stale_worktree_dirs,
     reconcile_all,
     reconcile_ticket,
 )
@@ -261,3 +262,46 @@ class TestReconcileUnresolvableOverlay(TestCase):
         assert ghost_ticket.pk in drifts
         assert ok_ticket.pk in drifts
         assert len(drifts[ok_ticket.pk].missing_worktree_dirs) == 1
+
+
+class TestStaleWorktreeDirAttributionIsSegmentAnchored(TestCase):
+    """Stale-dir attribution anchors the ticket-number on path segments (#WT-PR-D finding 17).
+
+    ``/9`` must not match ``/90``: the pre-fix raw substring (``f"/{n}" in path``)
+    mis-attributed an unrelated ticket-90 dir to ticket 9.
+    """
+
+    def _ticket9_with_wt(self) -> tuple[Ticket, Worktree]:
+        ticket = Ticket.objects.create(issue_url="https://github.com/org/repo/issues/9")
+        wt = Worktree.objects.create(
+            ticket=ticket,
+            repo_path="repo",
+            branch="9-fix",
+            extra={"worktree_path": "/ws/9-fix/repo"},
+        )
+        return ticket, wt
+
+    def test_ticket90_dir_not_attributed_to_ticket9(self) -> None:
+        ticket, wt = self._ticket9_with_wt()
+        drift = Drift(ticket_pk=ticket.pk)
+        foreign = "/ws/90-other/repo"  # belongs to ticket 90, not 9
+        with (
+            patch("teatree.core.reconcile._find_worktree_paths_on_disk", return_value={foreign}),
+            patch("teatree.core.reconcile.resolve_clone_path", return_value=Path("/ws/repo")),
+        ):
+            _collect_stale_worktree_dirs(drift, [wt], ticket, Path("/ws"))
+
+        assert drift.stale_worktree_dirs == []
+
+    def test_genuine_ticket9_dir_is_attributed(self) -> None:
+        ticket, wt = self._ticket9_with_wt()
+        drift = Drift(ticket_pk=ticket.pk)
+        genuine = "/ws/9-elsewhere/repo"  # a stale dir genuinely for ticket 9
+        with (
+            patch("teatree.core.reconcile._find_worktree_paths_on_disk", return_value={genuine}),
+            patch("teatree.core.reconcile.resolve_clone_path", return_value=Path("/ws/repo")),
+        ):
+            _collect_stale_worktree_dirs(drift, [wt], ticket, Path("/ws"))
+
+        assert len(drift.stale_worktree_dirs) == 1
+        assert str(drift.stale_worktree_dirs[0].path) == genuine

--- a/tests/teatree_core/test_resolve.py
+++ b/tests/teatree_core/test_resolve.py
@@ -9,17 +9,24 @@ from django.test import TestCase
 from teatree.core import resolve as resolve_module
 from teatree.core.models import Ticket, Worktree
 from teatree.core.resolve import (
+    TicketIdentityCollisionError,
+    WorkspaceOwnerCollisionError,
     WorktreeNotFoundError,
+    WorktreePathConflictError,
     _auto_register_from_git,
     _find_env_cache,
     _parse_env_file,
+    _refresh_reused_row,
+    _ticket_by_number,
     _ticket_number_from_branch,
     _ticket_owning_branch,
     _warn_cwd_mismatch,
     _workspace_owner_ticket,
     match_worktree_by_path,
     resolve_worktree,
+    tickets_owning_workspace_dir,
 )
+from tests._git_repo import make_git_repo, run_git
 
 
 class TestParseEnvFile:
@@ -788,27 +795,21 @@ class TestResolveWorktreeTicketHint(TestCase):
         assert result.ticket_id == real_ticket.pk
 
 
-class TestWorkspaceOwnerTicketIsDeterministic(TestCase):
+class TestWorkspaceOwnerFailsLoudOnCollision(TestCase):
+    """Multi-owner workspace dir fails loud, never picks an arbitrary ticket (#WT-PR-D finding 11)."""
+
     @pytest.fixture(autouse=True)
     def _inject_fixtures(self, tmp_path: Path) -> None:
         self._tmp_path = tmp_path
 
-    def test_lowest_pk_wins_when_multiple_siblings_share_workspace(self) -> None:
-        """Resolution stays deterministic if the invariant is violated.
-
-        The one-ticket-per-workspace invariant being violated, the
-        lowest-``pk`` worktree's ticket wins. Without ``.order_by("pk")``
-        the "first match wins" comment is a lie — the unordered queryset's
-        iteration order is backend-dependent.
-        """
+    def _seed_two_owners(self) -> tuple[Ticket, Ticket]:
         repo_a = self._tmp_path / "repo-a"
         repo_b = self._tmp_path / "repo-b"
         repo_a.mkdir()
         repo_b.mkdir()
-
         first_ticket = Ticket.objects.create(issue_url="https://gitlab.com/org/repo/-/issues/1")
         second_ticket = Ticket.objects.create(issue_url="https://gitlab.com/org/repo/-/issues/2")
-        first_wt = Worktree.objects.create(
+        Worktree.objects.create(
             ticket=first_ticket,
             repo_path="repo-a",
             branch="ac/first",
@@ -820,14 +821,120 @@ class TestWorkspaceOwnerTicketIsDeterministic(TestCase):
             branch="ac/second",
             extra={"worktree_path": str(repo_b)},
         )
+        return first_ticket, second_ticket
 
-        # Resolving a third sibling under the same workspace dir: cwd's
-        # parent is tmp_path, matching both stored worktree_path parents.
+    def test_workspace_owner_ticket_raises_on_multiple_owners(self) -> None:
+        """A workspace dir holding two tickets' worktrees raises, not an arbitrary pick.
+
+        The pre-fix code returned the lowest-pk owner silently; that
+        arbitrary selection is exactly what mis-attributes a sibling worktree.
+        """
+        self._seed_two_owners()
+
+        with pytest.raises(WorkspaceOwnerCollisionError):
+            _workspace_owner_ticket((self._tmp_path / "repo-c").resolve())
+
+    def test_tickets_owning_workspace_dir_lists_all_owners(self) -> None:
+        first_ticket, second_ticket = self._seed_two_owners()
+
+        owners = tickets_owning_workspace_dir(self._tmp_path.resolve())
+
+        assert {t.pk for t in owners} == {first_ticket.pk, second_ticket.pk}
+
+    def test_single_owner_resolves_without_raising(self) -> None:
+        repo_a = self._tmp_path / "repo-a"
+        repo_a.mkdir()
+        ticket = Ticket.objects.create(issue_url="https://gitlab.com/org/repo/-/issues/1")
+        Worktree.objects.create(
+            ticket=ticket,
+            repo_path="repo-a",
+            branch="ac/first",
+            extra={"worktree_path": str(repo_a)},
+        )
+
         owner = _workspace_owner_ticket((self._tmp_path / "repo-c").resolve())
 
         assert owner is not None
-        assert owner.pk == first_ticket.pk
-        assert owner.pk == first_wt.ticket.pk
+        assert owner.pk == ticket.pk
+
+
+class TestTicketByNumberFailsLoudOnCollision(TestCase):
+    """A non-unique ``ticket_number`` fails loud, never resolves an arbitrary ticket (#WT-PR-D finding 9)."""
+
+    def test_raises_when_two_tickets_share_number(self) -> None:
+        Ticket.objects.create(issue_url="https://a.example.com/x/issues/5")
+        Ticket.objects.create(issue_url="https://b.example.com/y/issues/5")
+
+        with pytest.raises(TicketIdentityCollisionError):
+            _ticket_by_number("5")
+
+    def test_returns_single_match(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://a.example.com/x/issues/5")
+
+        assert _ticket_by_number("5") == ticket
+
+    def test_returns_none_when_no_match(self) -> None:
+        Ticket.objects.create(issue_url="https://a.example.com/x/issues/42")
+
+        assert _ticket_by_number("5") is None
+
+    def test_overlay_scope_disambiguates_cross_overlay_collision(self) -> None:
+        Ticket.objects.create(issue_url="https://a.example.com/x/issues/5", overlay="ov-a")
+        ticket_b = Ticket.objects.create(issue_url="https://b.example.com/y/issues/5", overlay="ov-b")
+
+        assert _ticket_by_number("5", overlay="ov-b") == ticket_b
+
+    def test_branch_lookup_raises_on_collision(self) -> None:
+        Ticket.objects.create(issue_url="https://a.example.com/x/issues/5")
+        Ticket.objects.create(issue_url="https://b.example.com/y/issues/5")
+
+        with pytest.raises(TicketIdentityCollisionError):
+            _ticket_owning_branch("5-fix-the-thing")
+
+
+class TestRefreshReusedRowRefusesPathSteal(TestCase):
+    """A reused row must never be repointed onto a path another row owns (#WT-PR-D finding 8)."""
+
+    @pytest.fixture(autouse=True)
+    def _inject_fixtures(self, tmp_path: Path) -> None:
+        self._tmp_path = tmp_path
+
+    def test_raises_when_target_path_owned_by_another_row(self) -> None:
+        owned_path = str(self._tmp_path / "shared-dir")
+        ticket_a = Ticket.objects.create(issue_url="https://a.example.com/x/issues/1")
+        ticket_b = Ticket.objects.create(issue_url="https://b.example.com/y/issues/2")
+        Worktree.objects.create(
+            ticket=ticket_a,
+            repo_path="repo",
+            branch="1-x",
+            extra={"worktree_path": owned_path},
+        )
+        row_b = Worktree.objects.create(
+            ticket=ticket_b,
+            repo_path="repo",
+            branch="2-x",
+            extra={"worktree_path": str(self._tmp_path / "b-dir")},
+        )
+
+        with pytest.raises(WorktreePathConflictError):
+            _refresh_reused_row(row_b, "2-x", Path(owned_path))
+
+    def test_refreshes_freely_when_target_path_unowned(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://a.example.com/x/issues/1")
+        row = Worktree.objects.create(
+            ticket=ticket,
+            repo_path="repo",
+            branch="1-old",
+            extra={"worktree_path": str(self._tmp_path / "old-dir"), "keep": "me"},
+        )
+        new_dir = self._tmp_path / "new-dir"
+
+        _refresh_reused_row(row, "1-new", new_dir)
+
+        row.refresh_from_db()
+        assert row.branch == "1-new"
+        assert row.extra["worktree_path"] == str(new_dir)
+        assert row.extra["keep"] == "me"
 
 
 class TestResolveModuleDocstringMatchesCopyShape:
@@ -875,3 +982,70 @@ class TestResolveModuleDocstringMatchesCopyShape:
             f"'symlink'; since #1316 the in-worktree env cache is a "
             f"regular file copy. Offending block:\n{block}"
         )
+
+
+class TestProvisionResolveAttributionRoundTrip(TestCase):
+    """Real git worktrees under a symlinked workspace root resolve to the right ticket.
+
+    The headline integration net for the cross-attach bug class (#WT-PR-D): a
+    REAL ``git worktree add`` under a workspace root reached via a symlink
+    (mimicking macOS ``/tmp`` → ``/private/tmp``) must attribute to the ticket
+    its branch encodes — never to a FOREIGN merged ticket whose lingering row
+    merely shares the branch + repo basename. A second sibling worktree under
+    the same ticket dir must attach to that same ticket through the symlink,
+    not fork a fresh ``auto:<branch>`` ticket.
+
+    RED before the fix: the auto-register reuse arm ran BEFORE attribution, so
+    both worktrees bound to the foreign merged ticket #999.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _inject_fixtures(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        self._monkeypatch = monkeypatch
+        self._tmp_path = tmp_path
+
+    def test_real_worktrees_attribute_to_provisioned_ticket_not_foreign_merged(self) -> None:
+        real_root = self._tmp_path / "real"
+        real_root.mkdir()
+        repo_a_clone = make_git_repo(real_root / "repo-a")
+        repo_b_clone = make_git_repo(real_root / "repo-b")
+
+        # Workspace root reached through a symlink (macOS /tmp → /private/tmp).
+        link_root = self._tmp_path / "wslink"
+        link_root.symlink_to(real_root)
+
+        provisioned = Ticket.objects.create(issue_url="https://github.com/org/repo/issues/123")
+        foreign_merged = Ticket.objects.create(issue_url="https://github.com/org/repo/issues/999")
+        # The lingering merged-ticket row that shares the branch + repo basename
+        # — the cross-attach source. Its stored path is unrelated/stale.
+        foreign_row = Worktree.objects.create(
+            ticket=foreign_merged,
+            repo_path="repo-a",
+            branch="123-feature",
+            extra={"worktree_path": "/stale/merged/repo-a"},
+        )
+
+        ticket_dir = link_root / "123-feature"
+        ticket_dir.mkdir()
+        run_git(repo_a_clone, "worktree", "add", "-b", "123-feature", str(ticket_dir / "repo-a"))
+        run_git(repo_b_clone, "worktree", "add", "-b", "feat/sibling", str(ticket_dir / "repo-b"))
+
+        resolved_cwd_a = str((ticket_dir / "repo-a").resolve())
+        self._monkeypatch.setenv("T3_ORIG_CWD", resolved_cwd_a)
+        wt_a = resolve_worktree()
+
+        # Branch-encoded number 123 wins over the foreign #999 row.
+        assert wt_a.ticket_id == provisioned.pk
+        # The foreign merged row is never stolen / repointed.
+        foreign_row.refresh_from_db()
+        assert foreign_row.extra["worktree_path"] == "/stale/merged/repo-a"
+
+        resolved_cwd_b = str((ticket_dir / "repo-b").resolve())
+        self._monkeypatch.setenv("T3_ORIG_CWD", resolved_cwd_b)
+        wt_b = resolve_worktree()
+
+        # The non-numbered sibling attaches to the SAME ticket via the
+        # symlink-tolerant workspace-owner resolver, not a fresh auto: ticket.
+        assert wt_b.ticket_id == provisioned.pk
+        assert wt_b.repo_path == "repo-b"
+        assert not Ticket.objects.filter(issue_url="auto:feat/sibling").exists()

--- a/tests/teatree_core/test_workflows.py
+++ b/tests/teatree_core/test_workflows.py
@@ -213,7 +213,8 @@ class TestLifecycleProvision(TestCase):
         wt_frontend.refresh_from_db()
         assert wt_backend.state == Worktree.State.PROVISIONED
         assert wt_frontend.state == Worktree.State.PROVISIONED
-        assert wt_backend.db_name == "wt_42_testclient"
+        # db_name is keyed on the unique Ticket pk, not the derived ticket_number.
+        assert wt_backend.db_name == f"wt_{wt_backend.ticket_id}_testclient"
         assert wt_backend.extra.get("provisioned_by_overlay") is True
         assert wt_frontend.extra.get("provisioned_by_overlay") is True
 
@@ -221,7 +222,7 @@ class TestLifecycleProvision(TestCase):
         assert envfile.is_file(), "env cache should be generated during setup"
         env_content = envfile.read_text()
         assert "WT_VARIANT=testclient" in env_content
-        assert "WT_DB_NAME=wt_42_testclient" in env_content
+        assert f"WT_DB_NAME=wt_{wt_backend.ticket_id}_testclient" in env_content
         assert "DJANGO_SETTINGS_MODULE=" in env_content
         # Per-repo copies are regular files, not symlinks (#1313) — a
         # host-absolute symlink would dangle inside a bind-mounted container.
@@ -326,8 +327,10 @@ class TestLifecycleProvision(TestCase):
         wt1.refresh_from_db()
         wt2.refresh_from_db()
 
-        assert wt1.db_name == "wt_100_alpha"
-        assert wt2.db_name == "wt_200_beta"
+        # db_name keys on the unique Ticket pk, not the derived ticket_number.
+        assert wt1.db_name == f"wt_{wt1.ticket_id}_alpha"
+        assert wt2.db_name == f"wt_{wt2.ticket_id}_beta"
+        assert wt1.db_name != wt2.db_name
 
     @override_settings(**WORKFLOW_SETTINGS)
     def test_password_reset_runs_automatically(self) -> None:
@@ -668,7 +671,7 @@ class TestRunBackend(TestCase):
 
         backend_wt.refresh_from_db()
         assert backend_wt.state == Worktree.State.PROVISIONED
-        assert backend_wt.db_name == "wt_999_testclient"
+        assert backend_wt.db_name == f"wt_{backend_wt.ticket_id}_testclient"
 
         # --- Step 3: run backend (docker compose) ---
         mock_config = MagicMock()

--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -136,7 +136,6 @@ def test_db_helpers_cover_env_exists_and_psql_fallback(monkeypatch: pytest.Monke
     assert db.pg_env().get("PGPASSWORD") is None
     assert db.pg_host() == "db.internal"
     assert db.pg_user() == "worker"
-    assert db.worktree_db_name("42", "") == "wt_42"
     db.db_restore("wt_42", "/tmp/dump.sql")
     assert db.db_exists("wt_42") is True
     assert commands[3][0] == "psql"


### PR DESCRIPTION
## What

Root-cause the worktree/ticket IDENTITY-COLLISION bug class. `ticket_number` is a DERIVED, non-unique key (trailing digits of `issue_url`, else `str(pk)`); five seams trusted it as unique. Each now resolves through a canonical, unique identity and fails loud on collision instead of an arbitrary `.first()`. The cross-attach that mis-bound a worktree to a merged ticket is one of these five seams.

| # | Seam | File | Fix |
|---|------|------|-----|
| 1 | `_ticket_by_number` resolved an arbitrary cross-repo ticket | `core/resolve.py` | overlay-scope the lookup; raise `TicketIdentityCollisionError` on >1 match |
| 2 | auto-register reuse arm bound a foreign ticket by `(branch, basename)` before honoring attribution | `core/resolve.py` | run the attribution chain FIRST; reuse arm is a last resort; `_refresh_reused_row` refuses to steal a path another row owns (`WorktreePathConflictError`) |
| 3 | `db_name` + postgres `pass` key keyed on non-unique `ticket_number` | `core/models/worktree.py`, `worktree_env.py`, `env.py`, `cleanup.py` | key on the immutable, unique **Ticket pk** (ticket-scoped so sibling repos still share one DB); `db_import` asserts no other live worktree of a different ticket owns the computed `db_name` |
| 4 | two divergent workspace-dir→ticket resolvers | `core/resolve.py`, `core/management/commands/workspace.py` | one `tickets_owning_workspace_dir` / `workspace_owner_ticket` resolver (symlink-tolerant `_candidate_paths`), routed through by both call sites; deletes the duplicate hand-iteration |
| 5 | reconcile attributed stale dirs by unanchored substring (`/9` ⊂ `/90`) | `core/reconcile.py` | anchor the match on path segments `(^|[/-])<n>(-|/|$)`; drops the false `worktree start` reconcile docstring clause |

## Why

The cutover left `ticket_number` as a derived non-unique key trusted as unique across five seams: two tickets sharing a trailing issue number (different repos/forges) could cross-attach a worktree, share one database, or share one secret. The fix canonicalizes every reference up to a unique identity (Ticket pk for the database resource; overlay-scoped + fail-loud for attribution) and refuses ambiguity rather than silently picking one.

## Architecture pre-check — WT-PR-D (identity canonicalization)

### 1. BLUEPRINT § alignment
§4 Domain Models (Ticket/Worktree identity + FSM) and §6 Overlay System (overlay-scoped attribution). No contradiction with the cited sections; no new BLUEPRINT section needed — this hardens existing identity resolution.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition is added or moved. `_build_db_name` is still computed in the existing `Worktree.provision()` pure-transition body (db_name set there, side-effects after commit). `assert_db_name_unclaimed` is a guard called by the provision RUNNER before `db_import`, not in a transition body.

### 3. Extension-point contracts
No `OverlayBase` hook signature changes. `_overlay_name_for_cwd` consumes the existing `get_overlay_for_repo` / `get_workspace_repos` contract read-only. The `pass`-key change is internal to core; no overlay implements `postgres_pass_key`.

### 4. Component boundaries
- `core/resolve.py` — resolution/attribution (new exceptions + `tickets_owning_workspace_dir`/`workspace_owner_ticket` resolver).
- `core/models/worktree.py` — fat-model identity: `pass_key` property, pk-keyed `_build_db_name`, `assert_db_name_unclaimed` (invariant on the model that owns the data).
- `core/reconcile.py` — drift detection (segment-anchored match).
- `core/management/commands/workspace.py` — command coordination only (routes through the resolver).
- `worktree_env.py` / `env.py` / `cleanup.py` — consume `Worktree.pass_key` / ticket pk.

### 5. Dependency direction
`resolve.py` adds `from teatree.core.overlay_loader import ...` and `from django.core.exceptions import ImproperlyConfigured` — same `teatree.core` group, already a transitive edge (resolve → worktree_env → overlay_loader). `models/worktree.py` adds `from teatree.utils.postgres_secret import postgres_pass_key` — `core.models` → `utils`, an edge `ticket.py` already uses. `uv run tach check` → ✅ All modules validated. No backwards edge.

### 6. Test surface
- Headline integration (`tests/teatree_core/test_resolve.py::TestProvisionResolveAttributionRoundTrip`): REAL `git worktree add` under a SYMLINKED workspace root; resolve attributes to the provisioned ticket, NOT a foreign merged ticket; a second sibling repo attaches to the same ticket through the symlink. RED with reuse-arm-first.
- Fail-loud units: `_ticket_by_number` collision raise; `workspace_owner_ticket`/`tickets_owning_workspace_dir` multi-owner raise; `_refresh_reused_row` path-steal raise; `assert_db_name_unclaimed` raise; reconcile `/9` vs `/90`.
- Each observed RED before its fix (revert-the-logic verification) and GREEN after.

### 7. Resilience invariants
External writes (db_import, the pass store) are guarded fail-LOUD, not fail-open: `db_import` asserts the db_name is unclaimed before writing; the reuse refresh refuses to steal a path; collisions raise rather than silently proceed. Idempotency preserved: re-resolving the same worktree is a no-op (get_or_create + refresh-only-on-change). No new sub-agent / transport surface.

### 8. Identity and key normalization
The canonical, fully-qualified key for a worktree's database resources is the **immutable Ticket pk** (ticket-scoped: a ticket's sibling repos share one DB, as the per-ticket env cache requires) — NOT the derived, non-unique `ticket_number`. `_build_db_name` and `Worktree.pass_key` both key on `ticket.pk`; the three pass-key call sites (`worktree_env`, `env`, `cleanup`) route through `Worktree.pass_key` / the ticket pk. Attribution keys (`_ticket_by_number`) are normalized UP by overlay scope and fail loud on residual ambiguity rather than stripping qualifiers to force a match. Every derived-non-unique use of `ticket_number` for resource naming/attribution is removed or replaced with the unique key; the one remaining `ticket_number` use in reconcile is a path-segment-anchored match (display/attribution, fail-safe), not a resource key. `compose_project` (`<repo>-wt<ticket_number>`) is intentionally left unchanged — it is the cited reference and is out of WT-PR-D scope; db_name now uses a strictly-more-unique key (pk) and the `assert_db_name_unclaimed` guard catches any residual collision.

### 9. Behavior preservation / capability deletion
Behaviors the old code handled, and their disposition:
- **Reuse a real-ticket row when `worktree_path` is stale/missing** — PRESERVED. For a numbered branch, branch-number attribution finds the ticket; for a non-numbered branch with no attribution signal, the legacy `(branch, repo)` reuse still fires as a LAST resort (moved after the attribution chain). All existing `TestAutoRegisterReusesExistingWorktree` tests still pass.
- **Foreign-row steal by `(branch, basename)` before honoring `--ticket`/branch-number** — INTENTIONALLY DROPPED (this is the cross-attach bug). Justified: attribution now wins first; `_refresh_reused_row` raises rather than repoint onto another row's path.
- **`_workspace_owner_ticket` lowest-pk-wins on multi-owner** — CHANGED to fail-loud (raise). The old `TestWorkspaceOwnerTicketIsDeterministic` test (which asserted lowest-pk wins) is replaced with the multi-owner-raises test per the fail-loud policy. No privacy/leak/security matcher is narrowed; no must-block test was inverted to must-not-block.
- **`workspace.py` duplicate multi-ticket hand-iteration** — DELETED intentionally and routed through the shared `workspace_owner_ticket` resolver (the planned `_workspace_owner_ticket` hardening; no third check added).
- **`db_name` = `wt_<ticket_number>_<variant>`** — CHANGED to `wt_<ticket.pk>_<variant>` (sibling repos still share it). Existing db_name assertions updated to the pk form; the multi-repo shared-DB invariant is preserved (new test `test_sibling_repos_of_one_ticket_share_db_name`).
- **`pass` key = `teatree/wt/<ticket_number>/postgres`** — CHANGED to `teatree/wt/<ticket.pk>/postgres`. `postgres_pass_key` itself is unchanged (still stringifies its id arg); only the argument is the unique key.

## Open questions & assumptions
- **Assumed (ticket-pk over worktree-pk for db_name/pass key):** the audit suggested "Worktree pk", but the per-ticket env cache is shared across a ticket's sibling repos, so a worktree-pk key would give siblings inconsistent db_names. Keyed on the **Ticket pk** instead — strictly unique across tickets AND shared across a ticket's repos. Stated in the model docstrings.
- **Decided (compose_project left unchanged):** WT-PR-D scope is db_name + pass key; `compose_project` is the cited "good" reference and is out of scope.
- **Open (DB/pass-key migration):** existing worktrees provisioned under the old `wt_<ticket_number>` scheme will compute a new pk-based `db_name`/`pass_key` on re-provision; the old DB/pass entry orphans (reaped by `clean-all` / `drop_orphan_databases`, which are scheme-agnostic). Acceptable for an experimental tool; no data migration shipped.
