### PR TITLE
fix(merge): scope §17.4.3 step-3 to branch-protection required checks

### DIFF
--- a/src/teatree/backends/forge_merge_rpc.py
+++ b/src/teatree/backends/forge_merge_rpc.py
@@ -121,6 +121,51 @@ class GhMergeRpc:
             return [ROLLUP_QUERY_FAILED]
         return [entry for entry in rollup if isinstance(entry, dict)]
 
+    def fetch_required_status_check_contexts(self, *, slug: str, pr_id: int) -> list[RawAPIDict]:
+        """Branch-protection required-status-check contexts for the PR's base branch.
+
+        The AUTHORITATIVE required set for §17.4.3 step 3: only a context the
+        repo's branch protection lists as a required status check may block the
+        merge. A check NOT in this set (``eval``, advisory lanes, …) never blocks
+        regardless of its conclusion.
+
+        Returns ``[ROLLUP_QUERY_FAILED]`` (fail CLOSED) when the base branch or
+        the ``branches/<base>/protection/required_status_checks`` endpoint cannot
+        be read — an indeterminate required set must refuse the merge, never fall
+        open. Returns ``[]`` when the base branch genuinely has no required-status-
+        check protection (the determinate "no required gate" 404 the forge raises
+        with a ``Branch not protected`` / ``Required status checks not enabled``
+        body — no gate → green). Otherwise one ``{"context": <name>}`` entry per
+        required context, the UNION of the legacy ``contexts`` array and the newer
+        ``checks[].context`` array (GitHub returns both; either may carry a name).
+        """
+        rc, out, _ = self._run(
+            ["pr", "view", str(pr_id), "--repo", slug, "--json", "baseRefName", "--jq", ".baseRefName"],
+        )
+        base = out.strip()
+        if rc != 0 or not base:
+            return [ROLLUP_QUERY_FAILED]
+        rc, out, err = self._run(["api", f"repos/{slug}/branches/{base}/protection/required_status_checks"])
+        if rc != 0:
+            body = f"{out}\n{err}".lower()
+            if "branch not protected" in body or "required status checks not enabled" in body:
+                return []
+            return [ROLLUP_QUERY_FAILED]
+        try:
+            data = json.loads(out) if out.strip() else {}
+        except json.JSONDecodeError:
+            return [ROLLUP_QUERY_FAILED]
+        if not isinstance(data, dict):
+            return [ROLLUP_QUERY_FAILED]
+        contexts: set[str] = set()
+        for ctx in data.get("contexts") or []:
+            if isinstance(ctx, str) and ctx:
+                contexts.add(ctx)
+        for check in data.get("checks") or []:
+            if isinstance(check, dict) and isinstance(check.get("context"), str) and check["context"]:
+                contexts.add(check["context"])
+        return [{"context": ctx} for ctx in sorted(contexts)]
+
     def fetch_pr_changed_paths(self, *, slug: str, pr_id: int) -> list[str]:
         rc, out, _ = self._run(
             ["pr", "view", str(pr_id), "--repo", slug, "--json", "files", "--jq", ".files[].path"],
@@ -201,6 +246,19 @@ class GlabMergeRpc:
         if not isinstance(pipelines, list):
             return [ROLLUP_QUERY_FAILED]
         return [entry for entry in pipelines if isinstance(entry, dict)]
+
+    @staticmethod
+    def fetch_required_status_check_contexts(*, slug: str, pr_id: int) -> list[RawAPIDict]:
+        """GitLab has no branch-protection-required-status-checks gate on this path.
+
+        The GitLab §17.4.3 verdict is the head pipeline's overall status (see
+        :func:`core.merge.ci_rollup._classify_gitlab_pipeline`), which already
+        aggregates the required jobs server-side. Core never calls this on the
+        GitLab path; the method exists only to satisfy the ``CodeHostBackend``
+        Protocol surface. Returns ``[]`` (no separate required-context gate).
+        """
+        del slug, pr_id
+        return []
 
     def fetch_pr_changed_paths(self, *, slug: str, pr_id: int) -> list[str]:
         rc, out, _ = self._run(["api", f"projects/{glab_project_path(slug)}/merge_requests/{pr_id}/diffs"])

--- a/src/teatree/backends/github/client.py
+++ b/src/teatree/backends/github/client.py
@@ -463,6 +463,9 @@ class GitHubCodeHost:  # noqa: PLR0904 — method count reflects the CodeHostBac
     def fetch_required_checks_rollup(self, *, slug: str, pr_id: int) -> list[RawAPIDict]:
         return self._merge_rpc().fetch_required_checks_rollup(slug=slug, pr_id=pr_id)
 
+    def fetch_required_status_check_contexts(self, *, slug: str, pr_id: int) -> list[RawAPIDict]:
+        return self._merge_rpc().fetch_required_status_check_contexts(slug=slug, pr_id=pr_id)
+
     def fetch_pr_changed_paths(self, *, slug: str, pr_id: int) -> list[str]:
         return self._merge_rpc().fetch_pr_changed_paths(slug=slug, pr_id=pr_id)
 

--- a/src/teatree/backends/gitlab/client.py
+++ b/src/teatree/backends/gitlab/client.py
@@ -568,6 +568,9 @@ class GitLabCodeHost:  # noqa: PLR0904 — method count reflects the CodeHostBac
     def fetch_required_checks_rollup(self, *, slug: str, pr_id: int) -> list[RawAPIDict]:
         return self._merge_rpc().fetch_required_checks_rollup(slug=slug, pr_id=pr_id)
 
+    def fetch_required_status_check_contexts(self, *, slug: str, pr_id: int) -> list[RawAPIDict]:
+        return self._merge_rpc().fetch_required_status_check_contexts(slug=slug, pr_id=pr_id)
+
     def fetch_pr_changed_paths(self, *, slug: str, pr_id: int) -> list[str]:
         return self._merge_rpc().fetch_pr_changed_paths(slug=slug, pr_id=pr_id)
 

--- a/src/teatree/core/backend_protocols.py
+++ b/src/teatree/core/backend_protocols.py
@@ -112,6 +112,13 @@ ROLLUP_QUERY_FAILED: "RawAPIDict" = {_ROLLUP_QUERY_FAILED_KEY: True}
 query itself failed (non-zero rc / malformed / non-list payload), distinct from
 an empty list (no required checks → green). Core's classifier treats the sentinel
 as ``failed`` so a transport failure is never mistaken for "no checks to satisfy".
+
+``fetch_required_status_check_contexts`` reuses the same sentinel for the
+branch-protection lookup: ``[ROLLUP_QUERY_FAILED]`` when the required-status-check
+contexts could not be read (the base branch or the protection endpoint errored —
+fail CLOSED so an indeterminate required set never falls open), distinct from an
+empty list (the base branch has no required-status-check protection → no gate →
+green).
 """
 
 
@@ -289,6 +296,13 @@ class CodeHostBackend(Protocol):
     def fetch_pr_is_draft(self, *, slug: str, pr_id: int) -> bool: ...  # pragma: no branch
 
     def fetch_required_checks_rollup(self, *, slug: str, pr_id: int) -> list[RawAPIDict]: ...  # pragma: no branch
+
+    def fetch_required_status_check_contexts(  # pragma: no branch
+        self,
+        *,
+        slug: str,
+        pr_id: int,
+    ) -> list[RawAPIDict]: ...
 
     def fetch_pr_changed_paths(self, *, slug: str, pr_id: int) -> list[str]: ...  # pragma: no branch
 

--- a/src/teatree/core/merge/ci_rollup.py
+++ b/src/teatree/core/merge/ci_rollup.py
@@ -200,42 +200,120 @@ def _rollup_verdict(statuses: list[str]) -> str:
     return "green"
 
 
+def _check_name(entry: object) -> str:
+    """The NAME used to match a rollup entry against a required-status-check context.
+
+    A CheckRun carries ``name``; a legacy StatusContext carries ``context``. The
+    branch-protection required contexts are keyed by this name.
+    """
+    if not isinstance(entry, dict):
+        return ""
+    typed = cast("_RollupEntry", entry)
+    return str(typed.get("name") or typed.get("context") or "")
+
+
+def _required_contexts_verdict(deduped: "list[RawAPIDict]", required_names: set[str]) -> str:
+    """Verdict over ONLY the branch-protection-required contexts (§17.4.3 step 3).
+
+    The authoritative required set is *required_names* (the repo's branch-
+    protection ``required_status_checks`` contexts). Each required context must
+    have a reporting check that is green; a required context that is failing →
+    ``failed``, one still pending OR with no reporting check at all (missing) →
+    ``pending`` (both refuse the merge, fail closed). A check whose name is NOT
+    in *required_names* (``eval``, advisory lanes) is ignored entirely — it can
+    never block the merge regardless of its conclusion. When several rollup
+    entries share a required name the WORST verdict wins.
+    """
+    verdicts_by_name: dict[str, list[str]] = {}
+    for check in deduped:
+        name = _check_name(check)
+        if name not in required_names:
+            continue
+        if verdict := _classify_check(check):
+            verdicts_by_name.setdefault(name, []).append(verdict)
+    # A required context with no reporting check at all is "pending" (missing → refuse).
+    per_context = [_rollup_verdict(verdicts_by_name.get(name) or ["pending"]) for name in required_names]
+    return _rollup_verdict(per_context)
+
+
 def fetch_required_checks_status(slug: str, pr_id: int, *, host_kind: str = "github") -> str:
     """Live required-checks verdict for the PR/MR head — §17.4.3 step 3.
 
-    Evaluated against the forge's live rollup at merge time (the authoritative
+    Evaluated against the forge's live state at merge time (the authoritative
     set), NOT the ``gh_verify_result`` snapshot saved on the CLEAR. Returns
-    ``"green"`` only when every reported check concluded successfully;
-    ``"pending"`` while any is still running; otherwise the failing state.
+    ``"green"`` only when every branch-protection-REQUIRED context concluded
+    successfully; ``"pending"`` while a required context is still running or has
+    not reported; otherwise ``"failed"``.
 
     The backend returns the RAW rollup (GitHub ``statusCheckRollup`` entries,
     GitLab pipeline entries); core does the verdict classification here so the
-    §17.4.3 ``green``/``pending``/``failed`` semantics stay in one place. A
-    backend query failure surfaces as the :data:`ROLLUP_QUERY_FAILED` sentinel
-    → ``failed``; an empty rollup means no required checks → ``green``. GitLab
-    needs the head SHA to pick the right (non-merge-train) pipeline, fetched via
-    :func:`fetch_live_head_sha`.
+    §17.4.3 ``green``/``pending``/``failed`` semantics stay in one place. A rollup
+    query failure surfaces as the :data:`ROLLUP_QUERY_FAILED` sentinel → ``failed``.
 
-    The GitHub rollup is first deduped to the newest check-run per
-    ``(typename, name)`` so a stale/cancelled FAILURE superseded by a newer
-    SUCCESS for the same name does not false-block the merge — parity with the
-    forge's own branch protection, which keys newest-per-context.
+    **GitHub — the required set is branch protection, not the whole rollup.** The
+    ``statusCheckRollup`` reports EVERY check on the head commit, required or not
+    (``eval``, advisory lanes, …). The authoritative required set is the repo's
+    branch-protection ``required_status_checks`` contexts, fetched via
+    :meth:`fetch_required_status_check_contexts`. Only a check whose name is in
+    that set can block the merge; a non-required check NEVER blocks regardless of
+    its conclusion (failed/pending/skipped). If the required set cannot be fetched
+    the merge fails CLOSED (``failed``) — an indeterminate required set never
+    falls open. An empty required set (the base branch has no required-status-
+    check protection) means no gate → ``green``. The rollup is first deduped to
+    the newest check-run per ``(typename, name)`` so a stale/cancelled FAILURE
+    superseded by a newer SUCCESS for the same name does not false-block — parity
+    with the forge's own branch protection, which keys newest-per-context.
+
+    **GitLab** gates on the head pipeline's overall status (which aggregates the
+    required jobs server-side); it needs the head SHA to pick the right
+    (non-merge-train) pipeline, fetched via :func:`fetch_live_head_sha`.
     """
     backend = _code_host_for(host_kind)
     rollup = backend.fetch_required_checks_rollup(slug=slug, pr_id=pr_id)
     if rollup_query_failed(rollup):
         return "failed"
     if host_kind == "gitlab":
-        if not rollup:
-            return "green"
-        head_sha = backend.fetch_live_head_sha(slug=slug, pr_id=pr_id)
-        head = _select_gitlab_head_pipeline(list(rollup), head_sha, slug=slug, pr_id=pr_id)
-        if head is None:
-            return "failed"
-        return _classify_gitlab_pipeline(str(head.get("status") or ""))
-    deduped = _dedupe_newest_per_name(rollup)
-    statuses = [verdict for check in deduped if (verdict := _classify_check(check))]
-    return _rollup_verdict(statuses) if statuses else "green"
+        return _gitlab_pipeline_verdict(backend, rollup, slug=slug, pr_id=pr_id)
+    return _github_required_checks_verdict(backend, rollup, slug=slug, pr_id=pr_id)
+
+
+def _gitlab_pipeline_verdict(
+    backend: "CodeHostBackend",
+    rollup: "list[RawAPIDict]",
+    *,
+    slug: str,
+    pr_id: int,
+) -> str:
+    """GitLab §17.4.3 verdict: the head pipeline's overall status (aggregates required jobs)."""
+    if not rollup:
+        return "green"
+    head_sha = backend.fetch_live_head_sha(slug=slug, pr_id=pr_id)
+    head = _select_gitlab_head_pipeline(list(rollup), head_sha, slug=slug, pr_id=pr_id)
+    if head is None:
+        return "failed"
+    return _classify_gitlab_pipeline(str(head.get("status") or ""))
+
+
+def _github_required_checks_verdict(
+    backend: "CodeHostBackend",
+    rollup: "list[RawAPIDict]",
+    *,
+    slug: str,
+    pr_id: int,
+) -> str:
+    """GitHub §17.4.3 verdict: scope the rollup to the branch-protection required contexts.
+
+    Fail CLOSED when the required set is indeterminate; ``green`` when no
+    required-status-check gate is configured; otherwise the verdict over only
+    the required contexts (a non-required check never blocks).
+    """
+    required = backend.fetch_required_status_check_contexts(slug=slug, pr_id=pr_id)
+    if rollup_query_failed(required):
+        return "failed"  # fail CLOSED — the branch-protection required set is indeterminate
+    required_names = {str(entry["context"]) for entry in required if isinstance(entry, dict) and entry.get("context")}
+    if not required_names:
+        return "green"  # no required-status-check gate configured → nothing to satisfy
+    return _required_contexts_verdict(_dedupe_newest_per_name(rollup), required_names)
 
 
 _GITLAB_PIPELINE_GREEN_STATUSES = frozenset({"success", "manual", "skipped"})

--- a/tests/teatree_backends/test_code_host_protocol_coverage.py
+++ b/tests/teatree_backends/test_code_host_protocol_coverage.py
@@ -34,6 +34,10 @@ _MERGE_RPC_SIGNATURES: dict[str, list[tuple[str, inspect._ParameterKind]]] = {
         ("slug", inspect.Parameter.KEYWORD_ONLY),
         ("pr_id", inspect.Parameter.KEYWORD_ONLY),
     ],
+    "fetch_required_status_check_contexts": [
+        ("slug", inspect.Parameter.KEYWORD_ONLY),
+        ("pr_id", inspect.Parameter.KEYWORD_ONLY),
+    ],
     "fetch_pr_changed_paths": [
         ("slug", inspect.Parameter.KEYWORD_ONLY),
         ("pr_id", inspect.Parameter.KEYWORD_ONLY),

--- a/tests/teatree_backends/test_protocols.py
+++ b/tests/teatree_backends/test_protocols.py
@@ -178,6 +178,10 @@ class _FakeCodeHost:
         _ = (slug, pr_id)
         return []
 
+    def fetch_required_status_check_contexts(self, *, slug: str, pr_id: int) -> list[dict[str, object]]:
+        _ = (slug, pr_id)
+        return []
+
     def fetch_pr_changed_paths(self, *, slug: str, pr_id: int) -> list[str]:
         _ = (slug, pr_id)
         return []

--- a/tests/teatree_core/merge/test_ci_rollup.py
+++ b/tests/teatree_core/merge/test_ci_rollup.py
@@ -1,41 +1,87 @@
 """GitHub required-checks rollup classification (BLUEPRINT §17.4.3 step 3).
 
 ``fetch_required_checks_status`` re-verifies the live required-checks at merge
-time. GitHub branch protection keys the *newest* check-run per context name, so
-a cancelled/stale run that left a spurious FAILURE check-run on the same head
-commit must NOT block a merge that a newer SUCCESS for the same name supersedes.
+time. The authoritative required set is the repo's branch-protection
+``required_status_checks`` contexts — NOT the whole ``statusCheckRollup`` (which
+reports every check on the head, required or not). A check NOT in the required
+set (``eval``, advisory lanes) never blocks the merge regardless of its
+conclusion; a branch-protection-required check that is failing/pending/missing
+still refuses (fail closed). GitHub branch protection keys the *newest* check-run
+per context name, so a cancelled/stale FAILURE superseded by a newer SUCCESS for
+the same name must NOT block.
 
-These tests pin that dedupe-newest-per-name semantics: the verdict is computed
-over the newest check-run per identity, matching ``mergeStateStatus=CLEAN`` the
-forge itself computes. Only the unstoppable external — the ``gh`` subprocess —
-is stubbed; the classification under test is real.
+``TestRequiredContextsGate`` pins the required-set filtering (incl. the three
+anti-vacuous merge-allow/refuse cases and the fail-closed branch-protection
+lookup); ``TestDedupeNewestPerName`` pins the newest-per-name dedupe over a set
+where every rolled-up name is required. Only the unstoppable external — the
+``gh`` subprocess — is stubbed; the classification under test is real.
 """
 
 import json
 from collections.abc import Callable
 from unittest.mock import patch
 
+from teatree.backends.forge_merge_rpc import GhMergeRpc
+from teatree.core.backend_protocols import rollup_query_failed
 from teatree.core.merge import fetch_required_checks_status
-from teatree.core.merge.ci_rollup import _dedupe_newest_per_name
+from teatree.core.merge.ci_rollup import _check_name, _dedupe_newest_per_name, _required_contexts_verdict
 
 _SLUG = "souliane/teatree"
 _PR_ID = 2580
 
 
-def _gh_stub(rollup: list[dict[str, object]]) -> Callable[[list[str]], tuple[int, str, str]]:
-    """A ``gh`` runner that returns *rollup* for the statusCheckRollup query."""
+def _rollup_names(rollup: list[dict[str, object]]) -> list[str]:
+    """The distinct check names in *rollup* (CheckRun ``name`` / StatusContext ``context``)."""
+    names: list[str] = []
+    for entry in rollup:
+        if isinstance(entry, dict):
+            name = str(entry.get("name") or entry.get("context") or "")
+            if name and name not in names:
+                names.append(name)
+    return names
+
+
+def _gh_stub(
+    rollup: list[dict[str, object]],
+    *,
+    required: list[str] | None = None,
+    protection_rc: int = 0,
+    protection_body: str | None = None,
+) -> Callable[[list[str]], tuple[int, str, str]]:
+    """A ``gh`` runner answering the statusCheckRollup AND branch-protection queries.
+
+    *required* is the branch-protection ``required_status_checks`` context set the
+    repo reports. When ``None`` it defaults to every name present in *rollup* — so
+    the dedupe tests, which treat all checks as required, keep their semantics.
+    *protection_rc* / *protection_body* simulate a failed (or "no protection")
+    branch-protection fetch — the fail-closed / no-gate paths.
+    """
+    contexts = _rollup_names(rollup) if required is None else required
 
     def run(argv: list[str]) -> tuple[int, str, str]:
         joined = " ".join(argv)
         if "statusCheckRollup" in joined:
             return (0, json.dumps(rollup), "")
+        if "baseRefName" in joined:
+            return (0, "main", "")
+        if "required_status_checks" in joined:
+            if protection_rc != 0:
+                return (protection_rc, "", protection_body or "api error")
+            return (0, json.dumps({"contexts": contexts}), "")
         return (0, "", "")
 
     return run
 
 
-def _verdict(rollup: list[dict[str, object]]) -> str:
-    with patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_gh_stub(rollup)):
+def _verdict(
+    rollup: list[dict[str, object]],
+    *,
+    required: list[str] | None = None,
+    protection_rc: int = 0,
+    protection_body: str | None = None,
+) -> str:
+    stub = _gh_stub(rollup, required=required, protection_rc=protection_rc, protection_body=protection_body)
+    with patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=stub):
         return fetch_required_checks_status(_SLUG, _PR_ID, host_kind="github")
 
 
@@ -64,6 +110,93 @@ def _status_context(name: str, *, state: str, created_at: str) -> dict[str, obje
         "state": state,
         "createdAt": created_at,
     }
+
+
+_T0 = "2026-06-19T10:00:00Z"
+_T1 = "2026-06-19T10:05:00Z"
+
+# The real souliane/teatree branch-protection required_status_checks contexts.
+_REQUIRED = ["lint", "test (3.13)", "docs-drift", "uv-audit", "sbom", "blueprint-cross-pr"]
+
+
+def _green(name: str) -> dict[str, object]:
+    return _check_run(name, conclusion="SUCCESS", started_at=_T0, completed_at=_T1)
+
+
+def _failed(name: str) -> dict[str, object]:
+    return _check_run(name, conclusion="FAILURE", started_at=_T0, completed_at=_T1)
+
+
+def _all_required_green() -> list[dict[str, object]]:
+    return [_green(name) for name in _REQUIRED]
+
+
+class TestRequiredContextsGate:
+    """The branch-protection required-set filter — §17.4.3 step 3 (the #2769/#2770 bug).
+
+    The keystone wrongly refused to merge PRs whose only non-success check was
+    ``eval`` (a metered behavioral lane that is NOT a branch-protection-required
+    context) — it treated EVERY rolled-up check as required. The fix scopes the
+    verdict to the repo's branch-protection ``required_status_checks`` contexts.
+    """
+
+    def test_all_required_green_plus_non_required_failed_is_green(self) -> None:
+        # Anti-vacuous #1 (RED on the pre-fix code): every branch-protection-
+        # required context is SUCCESS; the ONLY failing check is ``eval`` — a
+        # non-required metered lane. The merge must be ALLOWED (green). On the
+        # buggy code the failed ``eval`` made the whole rollup "failed".
+        rollup = [*_all_required_green(), _failed("eval")]
+        assert _verdict(rollup, required=_REQUIRED) == "green"
+
+    def test_non_required_pending_or_skipped_never_blocks(self) -> None:
+        # A non-required check that is pending or skipped is equally irrelevant —
+        # only the required set decides the verdict.
+        rollup = [
+            *_all_required_green(),
+            _check_run("eval", status="IN_PROGRESS", conclusion="", started_at=_T0, completed_at=""),
+            _check_run("advisory-lane", conclusion="SKIPPED", started_at=_T0, completed_at=_T1),
+        ]
+        assert _verdict(rollup, required=_REQUIRED) == "green"
+
+    def test_required_check_failed_is_refused(self) -> None:
+        # Anti-vacuous #2 (RED if the fix over-relaxes): a branch-protection-
+        # REQUIRED context (``test (3.13)``) is FAILURE — the merge must be
+        # REFUSED even though every non-required check is green.
+        rollup = [_green(n) for n in _REQUIRED if n != "test (3.13)"]
+        rollup += [_failed("test (3.13)"), _green("eval")]
+        assert _verdict(rollup, required=_REQUIRED) == "failed"
+
+    def test_required_check_pending_is_refused(self) -> None:
+        # Anti-vacuous #3a: a required context still running → pending → refused.
+        rollup = [_green(n) for n in _REQUIRED if n != "sbom"]
+        rollup += [_check_run("sbom", status="IN_PROGRESS", conclusion="", started_at=_T0, completed_at="")]
+        assert _verdict(rollup, required=_REQUIRED) == "pending"
+
+    def test_required_check_missing_from_rollup_is_refused(self) -> None:
+        # Anti-vacuous #3b: a required context with NO reporting check at all
+        # (never started / not yet reported) → pending → refused. The rollup is
+        # all-green but is missing the required ``blueprint-cross-pr`` context.
+        rollup = [_green(n) for n in _REQUIRED if n != "blueprint-cross-pr"]
+        assert _verdict(rollup, required=_REQUIRED) == "pending"
+
+    def test_no_required_gate_configured_is_green(self) -> None:
+        # The base branch has no required-status-check protection (empty contexts):
+        # there is no gate to satisfy, so a failing non-required check cannot block.
+        rollup = [_failed("eval"), _green("lint")]
+        assert _verdict(rollup, required=[]) == "green"
+
+    def test_branch_protection_fetch_failure_fails_closed(self) -> None:
+        # Fail CLOSED: when the branch-protection required_status_checks endpoint
+        # cannot be read (403 no-admin, 5xx, network), the required set is
+        # indeterminate and the merge is REFUSED — never falls open to green.
+        rollup = _all_required_green()
+        assert _verdict(rollup, protection_rc=1, protection_body="HTTP 403: Forbidden") == "failed"
+
+    def test_branch_not_protected_404_is_no_gate_green(self) -> None:
+        # A determinate "Branch not protected" 404 is NOT a fetch failure — it
+        # means no required-status-check gate exists, so the merge is allowed.
+        rollup = [_failed("eval")]
+        assert _verdict(rollup, protection_rc=1, protection_body="HTTP 404: Branch not protected") == "green"
 
 
 class TestDedupeNewestPerName:
@@ -256,3 +389,99 @@ class TestDedupeHelperEdgeCases:
         assert nameless in deduped
         assert keyed in deduped
         assert len(deduped) == 2
+
+
+class TestRequiredContextsVerdictHelper:
+    """Defensive branches of ``_required_contexts_verdict`` / ``_check_name``."""
+
+    def test_non_dict_entry_is_ignored(self) -> None:
+        # A non-dict deduped entry has no name → not in the required set → ignored.
+        assert _check_name("not-a-dict") == ""
+        assert _required_contexts_verdict(["not-a-dict", _green("lint")], {"lint"}) == "green"
+
+    def test_worst_verdict_wins_among_entries_sharing_a_required_name(self) -> None:
+        # A CheckRun "x" (SUCCESS) and a StatusContext "x" (FAILURE) are distinct
+        # identities that both survive dedupe; the required context "x" takes the
+        # WORST verdict (failed), never the lenient one.
+        entries = [_green("x"), _status_context("x", state="FAILURE", created_at=_T0)]
+        assert _required_contexts_verdict(entries, {"x"}) == "failed"
+
+
+def _contexts_runner(
+    *,
+    base: str = "main",
+    base_rc: int = 0,
+    protection: tuple[int, str, str],
+) -> Callable[[list[str]], tuple[int, str, str]]:
+    """A ``gh`` runner scripting the base-branch then branch-protection calls."""
+
+    def run(argv: list[str]) -> tuple[int, str, str]:
+        joined = " ".join(argv)
+        if "baseRefName" in joined:
+            return (base_rc, base, "")
+        if "required_status_checks" in joined:
+            return protection
+        return (0, "", "")
+
+    return run
+
+
+class TestRequiredStatusCheckContextsTransport:
+    """``GhMergeRpc.fetch_required_status_check_contexts`` — the branch-protection lookup.
+
+    Fail CLOSED (``ROLLUP_QUERY_FAILED`` sentinel) whenever the required set is
+    indeterminate; an empty list ONLY for a determinate "no required gate".
+    """
+
+    def _contexts(self, runner: Callable[[list[str]], tuple[int, str, str]]) -> list[dict[str, object]]:
+        return GhMergeRpc(runner).fetch_required_status_check_contexts(slug=_SLUG, pr_id=_PR_ID)
+
+    def test_union_of_contexts_and_checks_arrays(self) -> None:
+        body = json.dumps({"contexts": ["lint", "sbom"], "checks": [{"context": "sbom"}, {"context": "uv-audit"}]})
+        result = self._contexts(_contexts_runner(protection=(0, body, "")))
+        assert sorted(str(entry["context"]) for entry in result) == ["lint", "sbom", "uv-audit"]
+
+    def test_malformed_context_and_check_entries_are_skipped(self) -> None:
+        # Non-str contexts and non-dict / context-less / empty-context checks are
+        # defensively ignored; only well-formed required context names survive.
+        body = json.dumps(
+            {
+                "contexts": ["lint", 123, ""],
+                "checks": [{"context": "sbom"}, {"context": ""}, {"no_context": 1}, "not-a-dict"],
+            },
+        )
+        result = self._contexts(_contexts_runner(protection=(0, body, "")))
+        assert sorted(str(entry["context"]) for entry in result) == ["lint", "sbom"]
+
+    def test_empty_base_branch_fails_closed(self) -> None:
+        result = self._contexts(_contexts_runner(base="", protection=(0, "{}", "")))
+        assert rollup_query_failed(result)
+
+    def test_base_branch_query_error_fails_closed(self) -> None:
+        result = self._contexts(_contexts_runner(base="", base_rc=1, protection=(0, "{}", "")))
+        assert rollup_query_failed(result)
+
+    def test_branch_not_protected_404_is_empty_no_gate(self) -> None:
+        result = self._contexts(_contexts_runner(protection=(1, "", "HTTP 404: Branch not protected")))
+        assert result == []
+
+    def test_required_status_checks_not_enabled_404_is_empty_no_gate(self) -> None:
+        result = self._contexts(_contexts_runner(protection=(1, "", "Required status checks not enabled")))
+        assert result == []
+
+    def test_generic_protection_error_fails_closed(self) -> None:
+        result = self._contexts(_contexts_runner(protection=(1, "", "HTTP 403: Forbidden")))
+        assert rollup_query_failed(result)
+
+    def test_malformed_protection_json_fails_closed(self) -> None:
+        result = self._contexts(_contexts_runner(protection=(0, "{not json", "")))
+        assert rollup_query_failed(result)
+
+    def test_non_dict_protection_payload_fails_closed(self) -> None:
+        result = self._contexts(_contexts_runner(protection=(0, "[1, 2, 3]", "")))
+        assert rollup_query_failed(result)
+
+    def test_empty_protection_body_is_empty_required_set(self) -> None:
+        # rc==0 with an empty body → no required-status-check rule → no gate.
+        result = self._contexts(_contexts_runner(protection=(0, "", "")))
+        assert result == []

--- a/tests/teatree_core/test_clear_issuance_and_human_substrate.py
+++ b/tests/teatree_core/test_clear_issuance_and_human_substrate.py
@@ -98,6 +98,9 @@ def _gh_stub(argv: list[str]) -> tuple[int, str, str]:
         return (0, "false", "")
     if "statusCheckRollup" in joined:
         return (0, _GREEN, "")
+    if "baseRefName" in joined or "required_status_checks" in joined:
+        # Base branch "main"; empty required-context gate → live rollup verdict stands.
+        return (0, "main" if "baseRefName" in joined else '{"contexts": []}', "")
     if "pulls" in joined and "merge" in joined:
         return (0, '{"sha": "landed00deadbeef"}', "")
     return (0, "", "")

--- a/tests/teatree_core/test_is_non_reviewer_role.py
+++ b/tests/teatree_core/test_is_non_reviewer_role.py
@@ -32,6 +32,9 @@ def _gh_stub(argv: list[str]) -> tuple[int, str, str]:
         return (0, "false", "")
     if "statusCheckRollup" in joined:
         return (0, _GREEN, "")
+    if "baseRefName" in joined or "required_status_checks" in joined:
+        # Base branch "main"; empty required-context gate → live rollup verdict stands.
+        return (0, "main" if "baseRefName" in joined else '{"contexts": []}', "")
     if "pulls" in joined and "merge" in joined:
         return (0, '{"sha": "landed00deadbeef"}', "")
     return (0, "", "")

--- a/tests/teatree_core/test_lifecycle_reviewer_attestation.py
+++ b/tests/teatree_core/test_lifecycle_reviewer_attestation.py
@@ -93,6 +93,9 @@ class TestTicketMergeKeystoneCli(TestCase):
             return (0, "false", "")
         if "statusCheckRollup" in joined:
             return (0, '[{"status": "COMPLETED", "conclusion": "SUCCESS"}]', "")
+        if "baseRefName" in joined or "required_status_checks" in joined:
+            # Base branch "main"; empty required-context gate → live rollup verdict stands.
+            return (0, "main" if "baseRefName" in joined else '{"contexts": []}', "")
         if "pulls" in joined and "merge" in joined:
             return (0, '{"sha": "landed00"}', "")
         return (0, "", "")

--- a/tests/teatree_core/test_merge_candidate_working_repos.py
+++ b/tests/teatree_core/test_merge_candidate_working_repos.py
@@ -109,6 +109,23 @@ def _working_repo_clear() -> MergeClear:
     )
 
 
+def _read_probe(joined: str, *, head: str) -> tuple[int, str, str] | None:
+    """The §17.4.3 read-only probes (head / draft / checks / branch-protection).
+
+    The branch-protection required-context set is empty (no gate) so a green
+    rollup stays green; returns ``None`` when *joined* is none of the probes.
+    """
+    if "headRefOid" in joined:
+        return (0, head, "")
+    if "isDraft" in joined:
+        return (0, "false", "")
+    if "statusCheckRollup" in joined:
+        return (0, _GREEN, "")
+    if "baseRefName" in joined or "required_status_checks" in joined:
+        return (0, "main" if "baseRefName" in joined else '{"contexts": []}', "")
+    return None
+
+
 def _gh_keyed_by_repo(calls: list[list[str]], right_repo: str):
     """``gh`` stub keyed by ``--repo`` — only *right_repo*'s PR head matches."""
 
@@ -117,12 +134,8 @@ def _gh_keyed_by_repo(calls: list[list[str]], right_repo: str):
         joined = " ".join(argv)
         repo = argv[argv.index("--repo") + 1] if "--repo" in argv else ""
         head = _RIGHT_SHA if repo == right_repo else _WRONG_SHA
-        if "headRefOid" in joined:
-            return (0, head, "")
-        if "isDraft" in joined:
-            return (0, "false", "")
-        if "statusCheckRollup" in joined:
-            return (0, _GREEN, "")
+        if (probe := _read_probe(joined, head=head)) is not None:
+            return probe
         if "state,mergeCommit" in joined:
             return (0, '{"state": "OPEN", "mergeCommit": null}', "")
         if "pulls" in joined and "merge" in joined:

--- a/tests/teatree_core/test_merge_clear_verdict_must_be_merge_safe.py
+++ b/tests/teatree_core/test_merge_clear_verdict_must_be_merge_safe.py
@@ -46,6 +46,9 @@ def _gh_stub_live_green(argv: list[str]) -> tuple[int, str, str]:
         return (0, "false", "")
     if "statusCheckRollup" in joined:
         return (0, _GREEN, "")
+    if "baseRefName" in joined or "required_status_checks" in joined:
+        # Base branch "main"; an empty required-context gate → the live rollup verdict stands.
+        return (0, "main" if "baseRefName" in joined else '{"contexts": []}', "")
     if "pulls" in joined and "merge" in joined:
         return (0, '{"sha": "landed00deadbeef"}', "")
     return (0, "", "")

--- a/tests/teatree_core/test_merge_execution.py
+++ b/tests/teatree_core/test_merge_execution.py
@@ -55,6 +55,18 @@ _MOVED = "b" * 40
 _GREEN = '[{"status": "COMPLETED", "conclusion": "SUCCESS"}]'
 
 
+def _branch_protection_probe(joined: str, *, required: list[str]) -> tuple[int, str, str] | None:
+    """Answer the §17.4.3 base-branch + branch-protection required-context probes.
+
+    Returns ``None`` when *joined* is neither probe so the caller falls through.
+    """
+    if "baseRefName" in joined:
+        return (0, "main", "")
+    if "required_status_checks" in joined:
+        return (0, json.dumps({"contexts": required}), "")
+    return None
+
+
 def _clear(ticket: Ticket, **overrides: object) -> MergeClear:
     defaults: dict[str, object] = {
         "ticket": ticket,
@@ -70,18 +82,36 @@ def _clear(ticket: Ticket, **overrides: object) -> MergeClear:
 
 
 class _GhStub:
-    """Records argv and returns scripted ``gh`` responses keyed by subcommand."""
+    """Records argv and returns scripted ``gh`` responses keyed by subcommand.
 
-    def __init__(self, *, head: str = _SHA, draft: str = "false", checks: str = _GREEN, merge_rc: int = 0) -> None:
+    ``required`` is the branch-protection ``required_status_checks`` context set
+    the repo reports (§17.4.3 step 3). It defaults to ``[]`` (no required-context
+    gate), so a default green ``checks`` rollup yields a green verdict and the
+    merge proceeds — the required-set filtering itself is pinned in
+    ``test_ci_rollup.py``.
+    """
+
+    def __init__(
+        self,
+        *,
+        head: str = _SHA,
+        draft: str = "false",
+        checks: str = _GREEN,
+        merge_rc: int = 0,
+        required: list[str] | None = None,
+    ) -> None:
         self.head = head
         self.draft = draft
         self.checks = checks
         self.merge_rc = merge_rc
+        self.required = required or []
         self.calls: list[list[str]] = []
 
     def __call__(self, argv: list[str]) -> tuple[int, str, str]:
         self.calls.append(argv)
         joined = " ".join(argv)
+        if (meta := _branch_protection_probe(joined, required=self.required)) is not None:
+            return meta
         if "headRefOid" in joined:
             return (0, self.head, "")
         if "isDraft" in joined:
@@ -89,9 +119,8 @@ class _GhStub:
         if "statusCheckRollup" in joined:
             return (0, self.checks, "")
         if "pulls" in joined and "merge" in joined:
-            if self.merge_rc != 0:
-                return (1, "", "Head branch was modified. Review and try the merge again. (409)")
-            return (0, '{"sha": "merged0deadbeef"}', "")
+            moved = "Head branch was modified. Review and try the merge again. (409)"
+            return (1, "", moved) if self.merge_rc != 0 else (0, '{"sha": "merged0deadbeef"}', "")
         return (0, "", "")
 
 
@@ -213,12 +242,13 @@ class TestMergeKeystonePreconditions(TestCase):
         with pytest.raises(MergePreconditionError, match="draft"):
             _run(clear, _GhStub(draft="true"))
 
-    def test_non_green_checks_refused(self) -> None:
+    def test_non_green_required_check_refused(self) -> None:
+        # A branch-protection-REQUIRED context that concluded FAILURE refuses the merge.
         ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
         clear = _clear(ticket)
-        failing = '[{"status": "COMPLETED", "conclusion": "FAILURE"}]'
+        failing = '[{"name": "lint", "status": "COMPLETED", "conclusion": "FAILURE"}]'
         with pytest.raises(MergePreconditionError, match="not green"):
-            _run(clear, _GhStub(checks=failing))
+            _run(clear, _GhStub(checks=failing, required=["lint"]))
 
     def test_consumed_clear_not_actionable(self) -> None:
         ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
@@ -281,12 +311,8 @@ class TestMergeExecutionEdgeCases(TestCase):
 
         def _merge_500(argv: list[str]) -> tuple[int, str, str]:
             joined = " ".join(argv)
-            if "headRefOid" in joined:
-                return (0, _SHA, "")
-            if "isDraft" in joined:
-                return (0, "false", "")
-            if "statusCheckRollup" in joined:
-                return (0, _GREEN, "")
+            if (probe := _green_probe_response(joined)) is not None:
+                return probe
             if "pulls" in joined and "merge" in joined:
                 return (1, "", "500 Internal Server Error")
             return (0, "", "")
@@ -309,19 +335,20 @@ class TestMergeExecutionEdgeCases(TestCase):
         with pytest.raises(MergePreconditionError, match="not green"):
             _run(clear, _GhStub(checks='{"a": 1}'))
 
-    def test_pending_check_is_not_green(self) -> None:
+    def test_pending_required_check_is_not_green(self) -> None:
+        # A branch-protection-REQUIRED context still running refuses the merge.
         ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
         clear = _clear(ticket)
-        pending = '[{"status": "IN_PROGRESS"}]'
+        pending = '[{"name": "lint", "status": "IN_PROGRESS"}]'
         with pytest.raises(MergePreconditionError, match="not green"):
-            _run(clear, _GhStub(checks=pending))
+            _run(clear, _GhStub(checks=pending, required=["lint"]))
 
     def test_legacy_status_context_pending_state_is_not_green(self) -> None:
         ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
         clear = _clear(ticket)
-        legacy_pending = '[{"state": "PENDING"}]'
+        legacy_pending = '[{"context": "legacy-ci", "state": "PENDING"}]'
         with pytest.raises(MergePreconditionError, match="not green"):
-            _run(clear, _GhStub(checks=legacy_pending))
+            _run(clear, _GhStub(checks=legacy_pending, required=["legacy-ci"]))
 
     def test_non_dict_rollup_entry_is_ignored(self) -> None:
         ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
@@ -462,12 +489,8 @@ class TestMergeExecutionEdgeCases(TestCase):
 
         def _bad_merge_json(argv: list[str]) -> tuple[int, str, str]:
             joined = " ".join(argv)
-            if "headRefOid" in joined:
-                return (0, _SHA, "")
-            if "isDraft" in joined:
-                return (0, "false", "")
-            if "statusCheckRollup" in joined:
-                return (0, _GREEN, "")
+            if (probe := _green_probe_response(joined)) is not None:
+                return probe
             if "pulls" in joined and "merge" in joined:
                 return (0, "not-json-at-all", "")
             return (0, "", "")
@@ -530,13 +553,10 @@ class _LostPostHookGhStub:
     def __call__(self, argv: list[str]) -> tuple[int, str, str]:
         self.calls.append(argv)
         joined = " ".join(argv)
-        if "headRefOid" in joined:
-            # GitHub keeps reporting the squashed tip as headRefOid.
-            return (0, self.reviewed_sha, "")
-        if "isDraft" in joined:
-            return (0, "false", "")
-        if "statusCheckRollup" in joined:
-            return (0, _GREEN, "")
+        # GitHub keeps reporting the squashed tip as headRefOid; the branch-
+        # protection probes answer empty (no required-context gate → green).
+        if (probe := _green_probe_response(joined, head=self.reviewed_sha)) is not None:
+            return probe
         if "state,mergeCommit" in joined:
             return (0, self._merge_state_payload(), "")
         if "pulls" in joined and "merge" in joined:
@@ -633,12 +653,8 @@ class TestLostPostHookRecoverable(TestCase):
 
         def _merged_no_commit(argv: list[str]) -> tuple[int, str, str]:
             joined = " ".join(argv)
-            if "headRefOid" in joined:
-                return (0, _SHA, "")
-            if "isDraft" in joined:
-                return (0, "false", "")
-            if "statusCheckRollup" in joined:
-                return (0, _GREEN, "")
+            if (probe := _green_probe_response(joined)) is not None:
+                return probe
             if "state,mergeCommit" in joined:
                 return (0, '{"state": "MERGED", "mergeCommit": null}', "")
             return (0, "", "")
@@ -907,11 +923,13 @@ class TestIsTransientMergeResponse(TestCase):
 
 
 def _green_probe_response(joined: str, *, head: str = _SHA) -> tuple[int, str, str] | None:
-    """The constant §17.4.3 GET-probe responses (head / draft / checks all healthy).
+    """The constant §17.4.3 GET-probe responses (head / draft / checks / branch-protection).
 
-    Returns ``None`` when *joined* is not one of the three read-only probes, so
-    a stub can fall through to its own merge / merge-state branches without
-    repeating these three identical conditionals.
+    Returns ``None`` when *joined* is not one of the read-only probes, so a stub
+    can fall through to its own merge / merge-state branches without repeating
+    these identical conditionals. The branch-protection ``required_status_checks``
+    set is reported EMPTY (no required-context gate) so a green rollup stays green
+    — the required-set filtering itself is pinned in ``test_ci_rollup.py``.
     """
     if "headRefOid" in joined:
         return (0, head, "")
@@ -919,7 +937,7 @@ def _green_probe_response(joined: str, *, head: str = _SHA) -> tuple[int, str, s
         return (0, "false", "")
     if "statusCheckRollup" in joined:
         return (0, _GREEN, "")
-    return None
+    return _branch_protection_probe(joined, required=[])
 
 
 class _TransientThenSuccessGhStub:
@@ -1017,12 +1035,8 @@ class TestTransientMergeRetry(TestCase):
 
         def _policy_refusal(argv: list[str]) -> tuple[int, str, str]:
             joined = " ".join(argv)
-            if "headRefOid" in joined:
-                return (0, _SHA, "")
-            if "isDraft" in joined:
-                return (0, "false", "")
-            if "statusCheckRollup" in joined:
-                return (0, _GREEN, "")
+            if (probe := _green_probe_response(joined)) is not None:
+                return probe
             if "pulls" in joined and "merge" in joined:
                 attempts["merge"] += 1
                 return (1, "", "Pull Request is not mergeable (405)")
@@ -1048,12 +1062,8 @@ class TestTransientMergeRetry(TestCase):
 
         def _head_moved(argv: list[str]) -> tuple[int, str, str]:
             joined = " ".join(argv)
-            if "headRefOid" in joined:
-                return (0, _SHA, "")
-            if "isDraft" in joined:
-                return (0, "false", "")
-            if "statusCheckRollup" in joined:
-                return (0, _GREEN, "")
+            if (probe := _green_probe_response(joined)) is not None:
+                return probe
             if "pulls" in joined and "merge" in joined:
                 attempts["merge"] += 1
                 return (1, "", "Head branch was modified. Review and try the merge again. (409)")

--- a/tests/teatree_core/test_merge_execution_cross_repo.py
+++ b/tests/teatree_core/test_merge_execution_cross_repo.py
@@ -39,6 +39,25 @@ _CLONE_ORIGIN = "souliane/teatree"
 _OVERLAY_REPO = "downstream-org/downstream-overlay"
 
 
+def _cross_repo_probe(joined: str, *, head: str) -> tuple[int, str, str] | None:
+    """The §17.4.3 read-only probes (head / draft / checks / branch-protection).
+
+    The branch-protection required-context set is reported EMPTY (no gate) so a
+    green rollup stays green; returns ``None`` when *joined* is none of them.
+    """
+    if "headRefOid" in joined:
+        return (0, head, "")
+    if "isDraft" in joined:
+        return (0, "false", "")
+    if "statusCheckRollup" in joined:
+        return (0, _GREEN, "")
+    if "baseRefName" in joined:
+        return (0, "main", "")
+    if "required_status_checks" in joined:
+        return (0, '{"contexts": []}', "")
+    return None
+
+
 def _cross_repo_clear() -> MergeClear:
     """A CLEAR shaped like CLEAR 22 from the #1335 incident.
 
@@ -71,12 +90,8 @@ def _gh_keyed_by_repo(calls: list[list[str]], right_repo: str = _OVERLAY_REPO):
         joined = " ".join(argv)
         repo = argv[argv.index("--repo") + 1] if "--repo" in argv else ""
         head = _RIGHT_SHA if repo == right_repo else _WRONG_SHA
-        if "headRefOid" in joined:
-            return (0, head, "")
-        if "isDraft" in joined:
-            return (0, "false", "")
-        if "statusCheckRollup" in joined:
-            return (0, _GREEN, "")
+        if (probe := _cross_repo_probe(joined, head=head)) is not None:
+            return probe
         if "state,mergeCommit" in joined:
             return (0, '{"state": "OPEN", "mergeCommit": null}', "")
         if "pulls" in joined and "merge" in joined:
@@ -222,14 +237,11 @@ class TestCrossRepoCandidateProbe(TestCase):
             calls.append(argv)
             joined = " ".join(argv)
             repo = argv[argv.index("--repo") + 1] if "--repo" in argv else ""
-            if "headRefOid" in joined:
-                # The clone-origin repo has NO PR #159 -> empty head; only the
-                # overlay repo owns the reviewed PR at _RIGHT_SHA.
-                return (0, _RIGHT_SHA if repo == _OVERLAY_REPO else "", "")
-            if "isDraft" in joined:
-                return (0, "false", "")
-            if "statusCheckRollup" in joined:
-                return (0, _GREEN, "")
+            # The clone-origin repo has NO PR #159 -> empty head; only the
+            # overlay repo owns the reviewed PR at _RIGHT_SHA.
+            head = _RIGHT_SHA if repo == _OVERLAY_REPO else ""
+            if (probe := _cross_repo_probe(joined, head=head)) is not None:
+                return probe
             if "state,mergeCommit" in joined:
                 return (0, '{"state": "OPEN", "mergeCommit": null}', "")
             if "pulls" in joined and "merge" in joined:

--- a/tests/teatree_core/test_merge_execution_gitlab.py
+++ b/tests/teatree_core/test_merge_execution_gitlab.py
@@ -244,6 +244,14 @@ class TestFetchRequiredChecksGitLab(TestCase):
         with patch("teatree.backends.forge_merge_rpc.glab_runner", return_value=_boom):
             assert fetch_required_checks_status(_GITLAB_SLUG, _PR_IID, host_kind="gitlab") == "failed"
 
+    def test_required_status_check_contexts_is_empty_no_separate_gate(self) -> None:
+        # GitLab gates on the pipeline-status verdict, not branch-protection
+        # required-status-check contexts — the host method returns [] (no gate).
+        from teatree.backends.gitlab import GitLabCodeHost  # noqa: PLC0415
+
+        host = GitLabCodeHost(token="x", base_url="https://gitlab.com/api/v4")
+        assert host.fetch_required_status_check_contexts(slug=_GITLAB_SLUG, pr_id=_PR_IID) == []
+
     def test_selects_head_sha_pipeline_ignoring_canceled_merge_train(self) -> None:
         # The pipelines endpoint interleaves a canceled merge-train pipeline
         # ahead of the real head-branch pipeline; selecting pipelines[0] would

--- a/tests/teatree_core/test_merge_head_guard.py
+++ b/tests/teatree_core/test_merge_head_guard.py
@@ -91,14 +91,24 @@ def _clear(ticket: Ticket) -> MergeClear:
     )
 
 
-def _gh_ok(argv: list[str]) -> tuple[int, str, str]:
-    joined = " ".join(argv)
+def _read_probe(joined: str) -> tuple[int, str, str] | None:
+    """The §17.4.3 read-only probes (head / draft / checks / branch-protection)."""
     if "headRefOid" in joined:
         return (0, _SHA, "")
     if "isDraft" in joined:
         return (0, "false", "")
     if "statusCheckRollup" in joined:
         return (0, _GREEN, "")
+    if "baseRefName" in joined or "required_status_checks" in joined:
+        # Base branch "main"; empty required-context gate → live rollup verdict stands.
+        return (0, "main" if "baseRefName" in joined else '{"contexts": []}', "")
+    return None
+
+
+def _gh_ok(argv: list[str]) -> tuple[int, str, str]:
+    joined = " ".join(argv)
+    if (probe := _read_probe(joined)) is not None:
+        return probe
     if "state,mergeCommit" in joined:
         return (0, '{"state": "OPEN", "mergeCommit": null}', "")
     if "pulls" in joined and "merge" in joined:

--- a/tests/teatree_core/test_merge_repo_resolution.py
+++ b/tests/teatree_core/test_merge_repo_resolution.py
@@ -100,6 +100,8 @@ class TestMergeUsesResolvedRepo(TestCase):
                 return (0, "false", "")
             if "statusCheckRollup" in joined:
                 return (0, _GREEN, "")
+            if "baseRefName" in joined or "required_status_checks" in joined:
+                return (0, "main" if "baseRefName" in joined else '{"contexts": []}', "")
             if "pulls" in joined and "merge" in joined:
                 return (0, '{"sha": "merged0deadbeef"}', "")
             return (0, "", "")
@@ -198,6 +200,8 @@ class TestOverlayRepoDiffersFromCloneOrigin(TestCase):
                 return (0, "false", "")
             if "statusCheckRollup" in joined:
                 return (0, _GREEN, "")
+            if "baseRefName" in joined or "required_status_checks" in joined:
+                return (0, "main" if "baseRefName" in joined else '{"contexts": []}', "")
             if "pulls" in joined and "merge" in joined:
                 return (0, '{"sha": "merged0deadbeef"}', "")
             return (0, "", "")


### PR DESCRIPTION
Problem: the §17.4 keystone re-checks CI at merge time (fetch_required_checks_status, §17.4.3 step 3). On GitHub it classified every check in the statusCheckRollup and refused the merge if any was non-success — even checks NOT in the protected branch required_status_checks set (e.g. a metered behavioral lane that fails in PR CI on a known env issue). Sibling PRs merged only because that lane was skipped; a non-success non-required check wrongly tripped the step-3 refusal that named the rolled-up status as not green.

Root cause: fetch_required_checks_status (GitHub path, src/teatree/core/merge/ci_rollup.py) treated the whole rollup as the required set — no filtering against the branch-protection required_status_checks contexts.

Fix: scope the GitHub verdict to the authoritative required set — the branch-protection required_status_checks contexts, fetched via the forge API (new CodeHostBackend.fetch_required_status_check_contexts). A check NOT in the required set never blocks regardless of conclusion (failed/pending/skipped). A required check that is failed/pending/missing still refuses. If the required set cannot be fetched the merge refuses, never falling open. GitLab is unchanged (it gates on the head pipeline overall status).

Anti-vacuous tests (tests/teatree_core/merge/test_ci_rollup.py::TestRequiredContextsGate): (1) all required-contexts green + a non-required check FAILED -> merge ALLOWED (red on the old code); (2) a required check FAILED -> REFUSED (red if the fix over-relaxes); (3) a required check PENDING/missing -> REFUSED; plus a branch-protection fetch failure -> REFUSED.