### PR TITLE
refactor(utils): remove dead recovery-bundle code; guard against git-work-to-file serialization

### DIFF
--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -437,11 +437,13 @@ def _guard_or_warn_dirty_worktree(worktree: Worktree, wt_path: str, *, keep_if_d
 
     A worktree with uncommitted changes may be a live one an agent is mid-task in.
     The unattended ``clean-all`` path passes ``keep_if_dirty=True`` so such a
-    worktree is never bundle-and-reaped on a merged signal: this raises
-    ``RuntimeError`` before any destructive step, which the reaper routes to a
-    KEEP-with-warning. ``force=True`` (explicit abandon) overrides the guard. The
-    automated FSM teardown of a genuinely-MERGED ticket leaves ``keep_if_dirty``
-    off and keeps the documented warn-then-reap-with-recovery-bundle behaviour.
+    worktree is never reaped on a merged signal: this raises ``RuntimeError``
+    before any destructive step, which the reaper routes to a KEEP-with-warning.
+    ``force=True`` (explicit abandon) overrides the guard. The automated FSM
+    teardown of a genuinely-MERGED ticket leaves ``keep_if_dirty`` off and
+    warn-then-reaps — there is no recovery bundle or snapshot and nothing is ever
+    serialized to a file; the work was already preserved on the remote by the
+    merge.
     """
     if not (Path(wt_path).is_dir() and git.status_porcelain(wt_path)):
         return

--- a/src/teatree/utils/git.py
+++ b/src/teatree/utils/git.py
@@ -44,8 +44,6 @@ from teatree.utils.git_run import check, git_env_without_overrides, run, run_str
 from teatree.utils.git_status import full_worktree_diff, status_porcelain, status_porcelain_strict
 from teatree.utils.git_sync import fetch, merge_abort, merge_no_edit, pull_ff_only, push, rebase
 from teatree.utils.git_worktree import (
-    bundle_create,
-    bundle_create_at_sha,
     commits_absent_from_all_remotes,
     locked_worktree_paths,
     recovered_head_sha_after_ref_gone,
@@ -61,8 +59,6 @@ __all__ = [
     "branch_delete",
     "branch_diff",
     "branch_merged",
-    "bundle_create",
-    "bundle_create_at_sha",
     "check",
     "commit",
     "commit_messages",

--- a/src/teatree/utils/git_worktree.py
+++ b/src/teatree/utils/git_worktree.py
@@ -1,8 +1,8 @@
 """Worktree management and the teardown data-loss guards.
 
-The worktree partition of :mod:`teatree.utils.git`. Holds worktree add/remove,
-the #706 "absent from all remotes" guard, and the bundle-recovery primitive,
-all via the :mod:`teatree.utils.git_run` runners.
+The worktree partition of :mod:`teatree.utils.git`. Holds worktree add/remove
+and the #706 "absent from all remotes" guard, all via the
+:mod:`teatree.utils.git_run` runners.
 """
 
 from pathlib import Path
@@ -142,38 +142,3 @@ def worktree_add(repo: str, path: str, branch: str, *, create_branch: bool = Tru
     except CommandFailedError:
         return False
     return True
-
-
-def bundle_create(repo: str, bundle_path: str, branch: str) -> None:
-    """Write a self-contained ``git bundle`` of ``branch`` to ``bundle_path``.
-
-    A bundle carries every commit reachable from the branch tip and is
-    restorable with ``git clone <bundle>`` / ``git fetch <bundle>`` — preferred
-    over relocating a worktree directory, which leaves git's worktree admin
-    pointing at a stale path. Raises ``CommandFailedError`` on failure (the
-    caller must not believe a recovery artifact exists when it does not).
-    """
-    run_strict(repo=repo, args=["bundle", "create", bundle_path, branch])
-
-
-def bundle_create_at_sha(repo: str, bundle_path: str, sha: str, recovery_branch: str) -> None:
-    """Bundle a bare ``sha`` anchored under ``refs/heads/<recovery_branch>``.
-
-    Used to capture a dangling-HEAD worktree (forge post-merge ref deletion):
-    ``git rev-parse HEAD`` exits 128 there, so :func:`bundle_create` of the
-    literal ``HEAD`` cannot run — but the surviving tip SHA recovered from the
-    per-worktree reflog still resolves as a commit. ``git bundle`` refuses a
-    bare commit ("Refusing to create empty bundle") and ``git clone`` only
-    checks out branch refs, so this anchors the recovered tip under a transient
-    ``refs/heads/<recovery_branch>`` ref, bundles THAT (clone-restorable to a
-    branch the caller can ``git apply`` its working-tree diff onto), then
-    deletes the temp ref. Raises ``CommandFailedError`` on a failed bundle (the
-    temp ref is still cleaned up first) so the caller never believes a recovery
-    artifact exists when it does not.
-    """
-    recovery_ref = f"refs/heads/{recovery_branch}"
-    run_strict(repo=repo, args=["update-ref", recovery_ref, sha])
-    try:
-        run_strict(repo=repo, args=["bundle", "create", bundle_path, recovery_ref])
-    finally:
-        check(repo=repo, args=["update-ref", "-d", recovery_ref])

--- a/tests/quality/test_no_git_work_to_file_serialization.py
+++ b/tests/quality/test_no_git_work_to_file_serialization.py
@@ -1,0 +1,103 @@
+"""Fitness function: no module serializes git work to a patch/bundle file.
+
+Backing up a git worktree or branch to a ``.patch`` / ``.bundle`` file (via
+``git bundle`` or ``git format-patch``) is a banned anti-pattern in teatree. The
+hand-off and the recovery snapshot are MARKDOWN-only — the durable-state text the
+PreCompact hook writes (``teatree.core.handover``); unsynced or dirty worktrees
+are KEPT by the #706 data-loss guard, never reaped onto a file; and salvage
+captures unique content to a PR (push -> open PR -> verify -> delete the source),
+never to a file. The dead ``bundle_create`` / ``bundle_create_at_sha`` leftovers
+of the removed #1770 recovery-snapshot mechanism were excised; this gate keeps
+that whole class from creeping back into the cleanup / recovery / hand-off /
+git-utils surface.
+
+The matcher is anti-vacuous (proven by the golden corpus below): it FLAGS a
+re-added ``git bundle`` / ``git format-patch`` call or a ``.bundle`` / ``.patch``
+file write, and does NOT flag the markdown snapshot, the salvage-to-PR path, a
+``git diff`` captured into a variable, or the bare word "snapshot" in prose.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The cleanup / recovery / hand-off / git-utils modules that must never serialize
+# git work to a file. The ``cleanup_*.py`` family is globbed so a new sibling is
+# covered automatically.
+_SCANNED_MODULES: tuple[Path, ...] = (
+    _REPO_ROOT / "src" / "teatree" / "core" / "cleanup.py",
+    _REPO_ROOT / "src" / "teatree" / "core" / "handover.py",
+    _REPO_ROOT / "src" / "teatree" / "core" / "worktree_done.py",
+    _REPO_ROOT / "src" / "teatree" / "utils" / "git_worktree.py",
+    _REPO_ROOT / "src" / "teatree" / "utils" / "git.py",
+    _REPO_ROOT / "hooks" / "scripts" / "hook_router.py",
+    *sorted((_REPO_ROOT / "src" / "teatree" / "core").glob("cleanup_*.py")),
+)
+
+# Each pattern matches a git-work-to-file SERIALIZATION call, not the benign word
+# "snapshot" (the markdown hand-off) or "diff" (a ``git diff`` read into memory).
+_SERIALIZATION_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # `git bundle ...` as a shell-string command.
+    re.compile(r"\bgit\s+bundle\b"),
+    # `bundle create` as adjacent tokens in a command string.
+    re.compile(r"\bbundle\s+create\b"),
+    # the args-list form `["bundle", "create", ...]` (how ``bundle_create`` was written).
+    re.compile(r"""['"]bundle['"]\s*,\s*['"]create['"]"""),
+    # `git format-patch` / `format_patch`.
+    re.compile(r"format[-_]patch"),
+    # writing a branch/worktree to a ``.bundle`` / ``.patch`` / ``.diff`` file.
+    re.compile(r"""\.(?:bundle|patch|diff)['"]"""),
+)
+
+
+def _find_serialization(source: str) -> list[str]:
+    """Return every git-work-to-file serialization snippet found in *source*."""
+    return [m.group(0) for pattern in _SERIALIZATION_PATTERNS for m in pattern.finditer(source)]
+
+
+@pytest.mark.parametrize("module", _SCANNED_MODULES, ids=lambda p: str(p.relative_to(_REPO_ROOT)))
+def test_module_does_not_serialize_git_work_to_file(module: Path) -> None:
+    """No scanned module contains a git-work-to-file serialization call."""
+    assert module.is_file(), f"scanned module is missing (renamed?): {module.relative_to(_REPO_ROOT)}"
+    hits = _find_serialization(module.read_text(encoding="utf-8"))
+    assert not hits, (
+        f"{module.relative_to(_REPO_ROOT)} serializes git work to a file ({hits!r}); "
+        "backing a branch/worktree up to a patch/bundle file is banned — "
+        "the hand-off/snapshot is markdown-only and salvage captures to a PR."
+    )
+
+
+# --- anti-vacuity corpus: prove the matcher is neither vacuous nor over-blocking ---
+
+_MUST_FLAG: tuple[tuple[str, str], ...] = (
+    ("bundle_create args-list", 'run_strict(repo=repo, args=["bundle", "create", bundle_path, branch])'),
+    ("git bundle shell command", 'subprocess.run(["git", "bundle", "create", path, branch])'),
+    ("format-patch", 'run(["git", "format-patch", "origin/main..HEAD", "-o", out_dir])'),
+    ("format_patch underscore", 'cmd = "git format_patch HEAD~3"'),
+    (".bundle file write", 'bundle_path = wt_dir / f"{branch}.bundle"'),
+    (".patch file write", 'patch_file = Path(out) / "work.patch"'),
+)
+
+_MUST_NOT_FLAG: tuple[tuple[str, str], ...] = (
+    ("markdown snapshot path", 'snapshot = _state_dir() / f"{prefix}{session_id}-precompact.md"'),
+    ("snapshot read", 'text = snapshot.read_text(encoding="utf-8").strip()'),
+    ("salvage branch ref", 'git.check(repo=repo, args=["branch", "-f", branch, request.source_ref])'),
+    ("salvage to PR", "pr_url = hooks.open_pr(repo, branch, request.target)"),
+    ("snapshot in prose", "# there is no recovery bundle or snapshot; nothing is serialized to a file"),
+    ("git diff into memory", 'diff = git.run(repo=repo, args=["diff", f"{target}...{source_ref}"])'),
+)
+
+
+@pytest.mark.parametrize(("label", "snippet"), _MUST_FLAG, ids=[c[0] for c in _MUST_FLAG])
+def test_matcher_flags_serialization(label: str, snippet: str) -> None:
+    """The matcher catches a re-added bundle / format-patch / patch-file call."""
+    assert _find_serialization(snippet), f"matcher missed a serialization call: {label}"
+
+
+@pytest.mark.parametrize(("label", "snippet"), _MUST_NOT_FLAG, ids=[c[0] for c in _MUST_NOT_FLAG])
+def test_matcher_ignores_legitimate_paths(label: str, snippet: str) -> None:
+    """The matcher does not flag the markdown snapshot, salvage-to-PR, or git-diff reads."""
+    assert not _find_serialization(snippet), f"matcher false-positived on a legitimate path: {label}"


### PR DESCRIPTION
## What

Excise the dead "serialize git work to a file" helpers and add a guard so the pattern cannot come back.

`bundle_create` and `bundle_create_at_sha` in `src/teatree/utils/git_worktree.py` were dead leftovers of the removed #1770 recovery-snapshot mechanism. They had no caller anywhere — only the two definitions, the `git.py` facade import + `__all__` re-export, and one docstring cross-reference. The hand-off/snapshot is markdown-only; backing a worktree/branch up to a patch/bundle file is an anti-pattern we do not want.

## Changes

- Delete `bundle_create` / `bundle_create_at_sha` from `git_worktree.py` (the surrounding runners stay — they are still used by the teardown guards).
- Drop both from the `git.py` imports and `__all__`.
- Reword the now-false `cleanup.py` prose in `_guard_or_warn_dirty_worktree` that described a "recovery bundle": there is no recovery bundle or snapshot anywhere; the FSM-teardown path warn-then-reaps (no bundle), unsynced/dirty worktrees are KEPT by the #706 guard, and nothing is ever serialized to a file. No behavior change — prose only.
- Add `tests/quality/test_no_git_work_to_file_serialization.py`: a fitness function that scans the cleanup / recovery / hand-off / git-utils modules and fails on any git-work-to-file serialization call (`git bundle`, `format-patch`, `.bundle`/`.patch` file writes). An anti-vacuity corpus proves the matcher flags a re-added call and does not false-positive on the markdown snapshot or the salvage-to-PR path.

## Verification

- `git grep bundle_create` → no matches.
- `ruff check`, `prek run --files` (banned-terms, ty-check, docs-in-sync) → clean.
- Guard test + git-utils + cleanup tests → pass; matcher proven red on a re-added `bundle_create`, green now.
- `makemigrations --check --dry-run` → No changes detected.
