### PR TITLE
fix(loop): statusline re-render must not wipe the open-PRs cache

### DIFF
--- a/src/teatree/loop/phases/render.py
+++ b/src/teatree/loop/phases/render.py
@@ -238,10 +238,16 @@ def rerender_statusline(target: Path | None = None, *, colorize: bool | None = N
     invert the tach-enforced dependency DAG); the orchestration layer injects it
     as the action-ladder ``auto_fix_callable``, retiring the prior
     ``_default_rerender`` no-op.
+
+    A re-render runs NO scan, so it has no fresh ``my_pr.*`` signals — it must
+    leave the ``open-prs.json`` snapshot intact (the full-tick scan path owns
+    that cache). The open-PR anchor reads the existing snapshot via
+    :func:`_populate_open_prs_in_anchors`, so the genuinely-open PRs survive the
+    refresh. Writing an empty cache here (the prior behaviour) wiped every open
+    PR a real scan had recorded, blanking the anchor until the next full tick.
     """
     zones = StatuslineZones()
     _populate_live_loops_in_anchors(zones, colorize=colorize)
-    _write_open_prs_cache([], target=target)
     _populate_open_prs_in_anchors(zones, target=target, colorize=colorize)
     _populate_loop_owner_anchor(zones)
     return render(zones, target=target, colorize=colorize)

--- a/tests/teatree_loop/phases/test_render.py
+++ b/tests/teatree_loop/phases/test_render.py
@@ -101,6 +101,38 @@ def test_rerender_statusline_rewrites_a_stale_file(tmp_path: Path) -> None:
     assert "stale merged-PR" not in sl.read_text(encoding="utf-8")
 
 
+def test_rerender_statusline_preserves_the_open_prs_cache(tmp_path: Path) -> None:
+    """A re-render must NOT wipe the open-PRs snapshot a real scan recorded (M5).
+
+    ``rerender_statusline`` is a display refresh with no scan, so it carries no
+    fresh ``my_pr.*`` signals. The prior behaviour wrote an EMPTY cache, which
+    destroyed every open PR a previous full tick had snapshotted and blanked the
+    anchor until the next scan. The cache is owned by the scan path: the refresh
+    must leave it intact and re-render the preserved PRs from it.
+    """
+    from teatree.loop.open_prs import OpenPr, read_open_prs_cache, write_open_prs_cache  # noqa: PLC0415
+    from teatree.loop.phases.render import rerender_statusline  # noqa: PLC0415
+
+    sl = tmp_path / "statusline.txt"
+    pr = OpenPr(
+        iid=42,
+        title="ship the thing",
+        url="https://github.com/acme/repo/pull/42",
+        overlay="teatree",
+        draft=False,
+    )
+    write_open_prs_cache([pr], statusline_path=sl)
+
+    rerender_statusline(sl, colorize=False)
+
+    # The seeded snapshot survives the re-render (the bug wiped it to []).
+    assert read_open_prs_cache(statusline_path=sl) == [pr]
+    # And the preserved PR is actually rendered into the statusline anchor.
+    rendered = sl.read_text(encoding="utf-8")
+    assert "#42" in rendered
+    assert "ship the thing" in rendered
+
+
 def test_self_improve_rerender_adapter_invokes_the_render_seam(monkeypatch: pytest.MonkeyPatch) -> None:
     """The action-ladder ``auto_fix_callable`` adapter bridges to ``rerender_statusline``.
 


### PR DESCRIPTION
## The bug (data integrity — M5)

`rerender_statusline` in `src/teatree/loop/phases/render.py` is the #2625 self-heal seam: a pure statusline display refresh that runs **no scan**, so it carries no fresh `my_pr.*` signals. It called `_write_open_prs_cache([], ...)`, which persists an **empty** snapshot to the `open-prs.json` sidecar — destroying every open PR a previous full tick had recorded. The empty cache was then read back by `_populate_open_prs_in_anchors` in the same call, so the re-render rendered zero open PRs and blanked the open-PR anchor until the next full scan repopulated it.

A re-render is meant to redraw from existing state, not destroy it. The open-PRs cache is owned by the full-tick scan path (`render_phase`), which legitimately repopulates it from real scan signals; the re-render has no business writing it.

## The fix

Drop the destructive `_write_open_prs_cache([], ...)` call from `rerender_statusline`. The open-PR anchor (`_populate_open_prs_in_anchors`) reads the existing snapshot directly, so genuinely-open PRs survive the refresh. Full-scan behaviour (`render_phase`) is unchanged. The change stays entirely within the loop layer — no cross-layer leak.

## The pinning test

`test_rerender_statusline_preserves_the_open_prs_cache` seeds the cache with one open PR, runs the re-render, then asserts the snapshot **still** contains that PR and that it is rendered into the statusline anchor.

- **Pre-fix (RED):** the wipe leaves the cache empty — `assert [] == [OpenPr(iid=42, ...)]` fails. Verified by temporarily reintroducing the `_write_open_prs_cache([], ...)` line.
- **Post-fix (GREEN):** the cache and the rendered anchor both retain the PR.

## Verification

- `uv run ruff check` on changed files: clean
- `uv run pytest tests/teatree_loop/phases/test_render.py` and the open-PRs / self-improve / tick-piggyback suites: pass
- `uv run python manage.py makemigrations --check --dry-run`: No changes detected