### PR TITLE
fix(security): out-of-band merge gate must classify the merge target, not the cwd

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -6838,29 +6838,28 @@ def _invokes_raw_merge_subcommand(command: str) -> bool:
 
 
 def handle_block_out_of_band_merge(data: dict) -> bool:
-    """Block a raw merge command or REST-API merge write on a managed repo.
+    """Block a raw/REST-API/graphql merge form aimed at a teatree-managed repo.
 
-    Covers two bypass vectors. The literal subcommand form (``gh pr merge`` /
-    ``glab mr merge``) is matched action-aware by
-    :func:`_invokes_raw_merge_subcommand` — only an actual invocation, not a
-    heredoc/echo/comment that documents the phrase (#2387). The REST-API form
-    (``gh api .../pulls/<n>/merge -X PUT``, ``glab api
-    .../merge_requests/<n>/merge --method POST``) is matched by
-    :func:`_is_raw_merge_api_write` (last ``-X``/``--method`` wins; default POST
-    with a body flag, else GET). A GET to the merge endpoint reads merge status
-    and is NOT denied.
+    Three bypass vectors. The literal subcommand (``gh pr merge`` / ``glab mr
+    merge``) is matched action-aware by :func:`_invokes_raw_merge_subcommand`
+    (a real invocation, not a heredoc/echo/comment — #2387). The REST-API form
+    (``gh api .../pulls/<n>/merge -X PUT``) is matched by
+    :func:`_is_raw_merge_api_write` (a GET read is NOT denied). A graphql
+    ``mergePullRequest`` mutation has an opaque node-id target that cannot resolve
+    to a slug and is never used by the keystone, so it is blocked (fail-closed).
 
-    Classification keys on the merge TARGET (parsed from the command), not the
-    cwd: a managed-repo target is BLOCKED regardless of cwd, closing the bypass
-    where the same merge ran from an unmanaged cwd. When no target parses, the
-    cwd-keyed check (#126) is the fail-safe fallback — allow only on a
-    confidently-unmanaged cwd; a managed or unresolvable cwd stays BLOCKED.
+    Otherwise classification keys on the merge TARGET (parsed from the command),
+    not the cwd: a managed-repo target is BLOCKED regardless of cwd. When no
+    target parses, the cwd-keyed check (#126) is the fail-safe fallback — allow
+    only on a confidently-unmanaged cwd; a managed/unresolvable cwd stays BLOCKED.
     """
     if data.get("tool_name") != "Bash":
         return False
     command = data.get("tool_input", {}).get("command", "")
     if not command:
         return False
+    if _GLAB_GH_API_RE.search(command) and re.search(r"mergePullRequest\s*\(", command):
+        return emit_pretooluse_deny(_OUT_OF_BAND_MERGE_REASON)
     if not _invokes_raw_merge_subcommand(command) and not _is_raw_merge_api_write(command):
         return False
     if not merge_target_is_managed(command, _overlay_managed_repo_signals()[0]):

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -6705,6 +6705,9 @@ _OUT_OF_BAND_MERGE_RE = re.compile(r"\b(?:gh\s+pr\s+merge|glab\s+mr\s+merge)\b")
 # Matches both GitHub (``repos/OWNER/REPO/pulls/<n>/merge``) and
 # GitLab (``projects/<id>/merge_requests/<n>/merge``) URL shapes.
 _MERGE_ENDPOINT_RE = re.compile(r"(?:merge_requests|pulls)/\d+/merge\b")
+# GitHub GraphQL merge-effecting mutations (all merge the PR / a branch out of band):
+# mergePullRequest, enablePullRequestAutoMerge (native-rules merge), mergeBranch.
+_GRAPHQL_MERGE_MUTATION_RE = re.compile(r"(?:mergePullRequest|enablePullRequestAutoMerge|mergeBranch)\s*\(")
 _OUT_OF_BAND_MERGE_REASON = (
     "BLOCKED: raw `gh pr merge` / `glab mr merge` on a teatree-managed repo — "
     "an out-of-band merge bypasses the FSM coherence mechanism (ledger update, "
@@ -6844,21 +6847,23 @@ def handle_block_out_of_band_merge(data: dict) -> bool:
     merge``) is matched action-aware by :func:`_invokes_raw_merge_subcommand`
     (a real invocation, not a heredoc/echo/comment — #2387). The REST-API form
     (``gh api .../pulls/<n>/merge -X PUT``) is matched by
-    :func:`_is_raw_merge_api_write` (a GET read is NOT denied). A graphql
-    ``mergePullRequest`` mutation has an opaque node-id target that cannot resolve
-    to a slug and is never used by the keystone, so it is blocked (fail-closed).
+    :func:`_is_raw_merge_api_write` (a GET read is NOT denied). A graphql merge
+    mutation (mergePullRequest / enablePullRequestAutoMerge / mergeBranch) has an
+    unresolvable node-id target, so it is blocked (fail-closed).
 
     Otherwise classification keys on the merge TARGET (parsed from the command),
-    not the cwd: a managed-repo target is BLOCKED regardless of cwd. When no
-    target parses, the cwd-keyed check (#126) is the fail-safe fallback — allow
-    only on a confidently-unmanaged cwd; a managed/unresolvable cwd stays BLOCKED.
+    not the cwd — a managed-repo target is BLOCKED regardless of cwd; when none
+    parses, the cwd-keyed fallback (#126) allows only a confidently-unmanaged cwd.
     """
     if data.get("tool_name") != "Bash":
         return False
     command = data.get("tool_input", {}).get("command", "")
     if not command:
         return False
-    if _GLAB_GH_API_RE.search(command) and re.search(r"mergePullRequest\s*\(", command):
+    # Matches the mutation name in argv only: a query loaded from a file or stdin
+    # (`gh api graphql -F query=@file` / `--input`) moves the text out of argv and
+    # is NOT inspected — an accepted residual, not a silent miss.
+    if _GLAB_GH_API_RE.search(command) and _GRAPHQL_MERGE_MUTATION_RE.search(command):
         return emit_pretooluse_deny(_OUT_OF_BAND_MERGE_REASON)
     if not _invokes_raw_merge_subcommand(command) and not _is_raw_merge_api_write(command):
         return False

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -55,7 +55,7 @@ from django_bootstrap import bootstrap_teatree_django
 from loop_registrations import emit_loop_registrations, is_bare_loop_tick_prompt, loop_name_from_prompt
 from loop_state_self_pump_gate import db_loop_state_suppresses_self_pump
 from memory_recall import handle_recall_cold_memory
-from mr_cli_fields import extract_cli_mr_fields, extract_mr_target_repo
+from mr_cli_fields import extract_cli_mr_fields, extract_mr_target_repo, merge_target_is_managed
 from no_self_reviewer_assign import handle_block_self_reviewer_assign
 from orchestration_boundary_signals import PYTEST_VERB_FINDER as _PYTEST_VERB_FINDER
 from orchestration_boundary_signals import PYTEST_VERB_RE as _PYTEST_VERB_RE
@@ -6850,9 +6850,11 @@ def handle_block_out_of_band_merge(data: dict) -> bool:
     with a body flag, else GET). A GET to the merge endpoint reads merge status
     and is NOT denied.
 
-    Carve-out for the permanent-lockout case (#126): a merge is allowed only
-    when the cwd repo is confidently NOT teatree-managed. Managed repos and
-    any case the gate cannot classify stay BLOCKED — fail-safe on uncertainty.
+    Classification keys on the merge TARGET (parsed from the command), not the
+    cwd: a managed-repo target is BLOCKED regardless of cwd, closing the bypass
+    where the same merge ran from an unmanaged cwd. When no target parses, the
+    cwd-keyed check (#126) is the fail-safe fallback — allow only on a
+    confidently-unmanaged cwd; a managed or unresolvable cwd stays BLOCKED.
     """
     if data.get("tool_name") != "Bash":
         return False
@@ -6861,12 +6863,10 @@ def handle_block_out_of_band_merge(data: dict) -> bool:
         return False
     if not _invokes_raw_merge_subcommand(command) and not _is_raw_merge_api_write(command):
         return False
-    cwd = _resolve_cwd_repo(data)
-    if cwd is None:
-        return emit_pretooluse_deny(_OUT_OF_BAND_MERGE_REASON)
-    managed = _cwd_is_teatree_managed(cwd)
-    if managed is False:
-        return False
+    if not merge_target_is_managed(command, _overlay_managed_repo_signals()[0]):
+        cwd = _resolve_cwd_repo(data)
+        if cwd is not None and _cwd_is_teatree_managed(cwd) is False:
+            return False
     return emit_pretooluse_deny(_OUT_OF_BAND_MERGE_REASON)
 
 

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -6806,9 +6806,12 @@ def _cwd_is_teatree_managed(cwd: Path) -> bool | None:
     """
     slugs, paths = _overlay_managed_repo_signals()
     for base in paths:
+        # is_relative_to, not relative_to: a non-subpath returns False instead
+        # of raising ValueError, which the suppress() below does NOT catch — an
+        # uncaught crash here makes the crash-proof dispatcher fail OPEN.
         with contextlib.suppress(OSError, RuntimeError):
-            cwd.resolve().relative_to(base)
-            return True
+            if cwd.resolve().is_relative_to(base):
+                return True
     try:
         with _teatree_src_on_path():
             from teatree.hooks import publish_surface  # noqa: PLC0415

--- a/hooks/scripts/mr_cli_fields.py
+++ b/hooks/scripts/mr_cli_fields.py
@@ -224,3 +224,22 @@ def extract_mr_target_repo(command: str) -> str | None:
         return gh_api_match.group("slug")
 
     return None
+
+
+def merge_target_is_managed(command: str, managed_slugs: list[str]) -> bool:
+    """Whether the command's MR-TARGET slug names a teatree-managed repo.
+
+    Classifies the merge TARGET (parsed by :func:`extract_mr_target_repo`),
+    NOT the agent's cwd, so a raw merge form aimed at a managed repo is caught
+    regardless of where it runs. Returns ``True`` only when a target slug
+    parses AND contains one of the ``managed_slugs`` signal substrings (the
+    same offline set the cwd-keyed check uses). A non-parseable target — a
+    numeric GitLab project id, or a bare ``gh pr merge <n>`` with no
+    ``--repo`` — returns ``False`` so the caller falls back to its cwd-keyed
+    classification (the established fail-safe).
+    """
+    target = extract_mr_target_repo(command)
+    if target is None:
+        return False
+    target_lower = target.strip().lower()
+    return bool(target_lower) and any(entry in target_lower for entry in managed_slugs)

--- a/hooks/scripts/mr_cli_fields.py
+++ b/hooks/scripts/mr_cli_fields.py
@@ -196,6 +196,14 @@ _GLAB_API_PROJECT_RE = re.compile(r"\bprojects/(?P<ns>[^/\s'\"]+)/merge_requests
 # ``gh api repos/<owner>/<repo>/pulls…`` — the slug is the two path segments
 # after ``repos/``.
 _GH_API_REPO_RE = re.compile(r"\brepos/(?P<slug>[^/\s'\"]+/[^/\s'\"]+)/pulls")
+# A GitHub PR WEB URL operand to ``gh pr merge`` —
+# ``https://<host>/<owner>/<repo>/pull/<n>`` yields ``owner/repo``.
+_GH_WEB_PR_URL_RE = re.compile(r"https?://[^/\s]+/(?P<slug>[^/\s]+/[^/\s]+)/pull/\d+")
+# A GitLab MR WEB URL operand to ``glab mr merge`` —
+# ``https://<host>/<namespace…>/-/merge_requests/<n>`` yields the namespace.
+# The namespace may span subgroups (multiple path segments) up to the ``/-/``
+# separator, so it is captured non-greedily and URL-decoded like the api form.
+_GL_WEB_MR_URL_RE = re.compile(r"https?://[^/\s]+/(?P<ns>[^\s]+?)/-/merge_requests/\d+")
 
 
 def extract_mr_target_repo(command: str) -> str | None:
@@ -206,7 +214,10 @@ def extract_mr_target_repo(command: str) -> str | None:
     ``-R``/``--repo`` flag on ``glab mr`` gives the slug directly; the
     ``glab api .../projects/<ns>/merge_requests…`` namespace is URL-decoded
     (``acme-group%2Fwidget`` → ``acme-group/widget``); a ``gh api
-    repos/<owner>/<repo>/pulls…`` path yields the two segments after ``repos/``.
+    repos/<owner>/<repo>/pulls…`` path yields the two segments after ``repos/``;
+    and a forge WEB URL operand to ``gh pr merge`` / ``glab mr merge``
+    (``…/<owner>/<repo>/pull/<n>`` or ``…/<namespace>/-/merge_requests/<n>``)
+    yields the owner/repo or namespace.
 
     ``None`` when no target is parseable — the validator then keeps its
     cwd-keyed resolution (the established never-lockout fallback).
@@ -222,6 +233,14 @@ def extract_mr_target_repo(command: str) -> str | None:
     gh_api_match = _GH_API_REPO_RE.search(command)
     if gh_api_match:
         return gh_api_match.group("slug")
+
+    gh_web_match = _GH_WEB_PR_URL_RE.search(command)
+    if gh_web_match:
+        return gh_web_match.group("slug")
+
+    gl_web_match = _GL_WEB_MR_URL_RE.search(command)
+    if gl_web_match:
+        return unquote(gl_web_match.group("ns"))
 
     return None
 

--- a/hooks/scripts/mr_cli_fields.py
+++ b/hooks/scripts/mr_cli_fields.py
@@ -197,13 +197,14 @@ _GLAB_API_PROJECT_RE = re.compile(r"\bprojects/(?P<ns>[^/\s'\"]+)/merge_requests
 # after ``repos/``.
 _GH_API_REPO_RE = re.compile(r"\brepos/(?P<slug>[^/\s'\"]+/[^/\s'\"]+)/pulls")
 # A GitHub PR WEB URL operand to ``gh pr merge`` —
-# ``https://<host>/<owner>/<repo>/pull/<n>`` yields ``owner/repo``.
-_GH_WEB_PR_URL_RE = re.compile(r"https?://[^/\s]+/(?P<slug>[^/\s]+/[^/\s]+)/pull/\d+")
+# ``https://<host>/<owner>/<repo>/pull/<n>`` yields ``owner/repo``. The ``/pull/``
+# path segment matches case-insensitively; the captured slug stays case-preserved.
+_GH_WEB_PR_URL_RE = re.compile(r"https?://[^/\s]+/(?P<slug>[^/\s]+/[^/\s]+)/pull/\d+", re.IGNORECASE)
 # A GitLab MR WEB URL operand to ``glab mr merge`` —
 # ``https://<host>/<namespace…>/-/merge_requests/<n>`` yields the namespace.
 # The namespace may span subgroups (multiple path segments) up to the ``/-/``
 # separator, so it is captured non-greedily and URL-decoded like the api form.
-_GL_WEB_MR_URL_RE = re.compile(r"https?://[^/\s]+/(?P<ns>[^\s]+?)/-/merge_requests/\d+")
+_GL_WEB_MR_URL_RE = re.compile(r"https?://[^/\s]+/(?P<ns>[^\s]+?)/-/merge_requests/\d+", re.IGNORECASE)
 
 
 def extract_mr_target_repo(command: str) -> str | None:

--- a/tests/test_hook_router_out_of_band_merge.py
+++ b/tests/test_hook_router_out_of_band_merge.py
@@ -273,6 +273,16 @@ class TestClassifiesMergeTargetNotCwd:
             # GitLab REST POST to the managed overlay repo's merge endpoint
             # (url-encoded namespace decodes to example-org/private-repo).
             "glab api projects/example-org%2Fprivate-repo/merge_requests/9/merge --method POST",
+            # Forge WEB-URL operand to ``gh pr merge`` — no --repo/api path, so the
+            # slug must be parsed from the URL itself (GitHub /pull/<n>).
+            "gh pr merge https://github.com/souliane/teatree/pull/123 --squash",
+            # Forge WEB-URL operand to ``glab mr merge`` — GitLab /-/merge_requests/<n>
+            # against the managed overlay namespace.
+            "glab mr merge https://gitlab.com/example-org/private-repo/-/merge_requests/9",
+            # GraphQL mergePullRequest mutation — target is an opaque node id the
+            # slug parser cannot resolve, and the keystone never merges via raw
+            # graphql, so this signature is blocked unconditionally (fail-closed).
+            "gh api graphql -f query='mutation{mergePullRequest(input:{pullRequestId:\"PR_x\"}){clientMutationId}}'",
         ],
     )
     def test_managed_target_blocked_from_unmanaged_cwd(
@@ -300,4 +310,14 @@ class TestClassifiesMergeTargetNotCwd:
         repo = _repo_with_remote(tmp_path / "wt", "git@github.com:example-org/public-repo.git")
         command = "gh pr merge 3 --repo example-org/public-repo --squash"
         assert router.handle_block_out_of_band_merge(_merge_event(command, repo)) is False
+        assert capsys.readouterr().out.strip() == ""
+
+    def test_bare_number_from_unmanaged_cwd_still_allowed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # ``gh pr merge <n>`` with no --repo targets the cwd repo; from an
+        # unmanaged cwd it must still ALLOW — the URL/graphql branches must not
+        # fail-close the legitimate no-target case (#126 lockout guard).
+        repo = _repo_with_remote(tmp_path / "wt", "git@github.com:example-org/public-repo.git")
+        assert router.handle_block_out_of_band_merge(_merge_event("gh pr merge 5", repo)) is False
         assert capsys.readouterr().out.strip() == ""

--- a/tests/test_hook_router_out_of_band_merge.py
+++ b/tests/test_hook_router_out_of_band_merge.py
@@ -240,3 +240,64 @@ class TestAllowsApiMergeEndpointReadsAndUnrelated:
         repo = _repo_with_remote(tmp_path / "wt", "git@github.com:souliane/teatree.git")
         assert router.handle_block_out_of_band_merge(_merge_event("gh pr merge 12", repo)) is True
         assert _parse_deny(capsys) is not None
+
+
+# ── Merge-TARGET classification — the cwd-only bypass (security) ──────────────
+#
+# The gate must classify the merge TARGET repo (extracted from the command),
+# not the agent's cwd. Keying solely on the cwd meant a raw REST merge form —
+# ``gh api --method PUT repos/souliane/teatree/pulls/N/merge`` or ``gh pr merge
+# N --repo souliane/teatree`` — issued from ANY resolvable-but-UNMANAGED git
+# cwd resolved cwd->unmanaged->ALLOW and merged a MANAGED repo's PR, bypassing
+# the keystone MergeClear ceremony (reviewer!=loop, SHA-bind, live-CI recheck).
+# Pre-fix, every command below returned False (allowed) from the unmanaged cwd.
+
+
+class TestClassifiesMergeTargetNotCwd:
+    """A managed-repo TARGET is blocked even from a resolvable, unmanaged cwd."""
+
+    @pytest.fixture(autouse=True)
+    def _home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_home(tmp_path / "home", _MANAGED_CONFIG, monkeypatch)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # GitHub REST PUT to teatree-core's merge endpoint (the cited bypass).
+            "gh api --method PUT repos/souliane/teatree/pulls/123/merge",
+            "gh api -X PUT repos/souliane/teatree/pulls/123/merge",
+            # ``gh pr merge`` naming the managed target via ``--repo``.
+            "gh pr merge 123 --repo souliane/teatree --squash",
+            # An overlay-claimed managed repo named via ``--repo``.
+            "gh pr merge 7 --repo example-org/private-repo",
+            # GitLab REST POST to the managed overlay repo's merge endpoint
+            # (url-encoded namespace decodes to example-org/private-repo).
+            "glab api projects/example-org%2Fprivate-repo/merge_requests/9/merge --method POST",
+        ],
+    )
+    def test_managed_target_blocked_from_unmanaged_cwd(
+        self, command: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # cwd is a resolvable, confidently-UNMANAGED repo — the bypass surface.
+        repo = _repo_with_remote(tmp_path / "wt", "git@github.com:example-org/public-repo.git")
+        assert router.handle_block_out_of_band_merge(_merge_event(command, repo)) is True
+        deny = _parse_deny(capsys)
+        assert deny is not None
+        assert "ticket merge" in deny["permissionDecisionReason"]
+
+    def test_sanctioned_keystone_still_passes(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        # The keystone transition is not a raw gh/glab merge form, so the gate
+        # never fires — even from inside the managed teatree-core checkout.
+        repo = _repo_with_remote(tmp_path / "wt", "git@github.com:souliane/teatree.git")
+        assert router.handle_block_out_of_band_merge(_merge_event("t3 t3-teatree ticket merge 42", repo)) is False
+        assert capsys.readouterr().out.strip() == ""
+
+    def test_unmanaged_target_from_unmanaged_cwd_still_allowed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # A genuinely-unmanaged target named via ``--repo`` from an unmanaged
+        # cwd is still ALLOWED — the fix only blocks managed targets.
+        repo = _repo_with_remote(tmp_path / "wt", "git@github.com:example-org/public-repo.git")
+        command = "gh pr merge 3 --repo example-org/public-repo --squash"
+        assert router.handle_block_out_of_band_merge(_merge_event(command, repo)) is False
+        assert capsys.readouterr().out.strip() == ""

--- a/tests/test_hook_router_out_of_band_merge.py
+++ b/tests/test_hook_router_out_of_band_merge.py
@@ -328,3 +328,52 @@ class TestClassifiesMergeTargetNotCwd:
         repo = _repo_with_remote(tmp_path / "wt", "git@github.com:example-org/public-repo.git")
         assert router.handle_block_out_of_band_merge(_merge_event("gh pr merge 5", repo)) is False
         assert capsys.readouterr().out.strip() == ""
+
+
+# ── cwd classifier must not crash-fail-open with an overlay path configured ───
+#
+# `_cwd_is_teatree_managed` iterated each overlay `path` base with
+# `cwd.resolve().relative_to(base)` under `suppress(OSError, RuntimeError)`.
+# `Path.relative_to` raises `ValueError` for a non-subpath — NOT one of the
+# suppressed types — so with ≥1 overlay path configured (the real config sets
+# one) and a cwd NOT under it, the handler raised before the slug-based managed
+# check ran. The crash-proof dispatcher catches the exception and fails OPEN,
+# so a bare `gh pr merge <n>` / `glab mr merge !<n>` from a managed-by-slug
+# checkout outside the overlay path bypassed the keystone. The fix swaps
+# `relative_to` for the non-raising `is_relative_to`.
+
+
+def _overlay_path_config(overlay_root: Path) -> str:
+    return f'[overlays.example]\nworkspace_repos = ["example-org/private-repo"]\npath = "{overlay_root}"\n'
+
+
+class TestCwdClassifyDoesNotCrashWithOverlayPath:
+    """A configured overlay `path` must not crash the cwd-keyed classifier."""
+
+    @pytest.fixture(autouse=True)
+    def _home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        overlay_root = tmp_path / "overlay-root"
+        overlay_root.mkdir()
+        _patch_home(tmp_path / "home", _overlay_path_config(overlay_root), monkeypatch)
+
+    @pytest.mark.parametrize("command", ["gh pr merge 5", "glab mr merge !9"])
+    def test_bare_merge_from_managed_slug_cwd_outside_overlay_path_blocks(
+        self, command: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # cwd is teatree-core (managed BY SLUG) but sits OUTSIDE the overlay
+        # path, so the path loop must fall through to the slug check, not crash.
+        repo = _repo_with_remote(tmp_path / "wt", "git@github.com:souliane/teatree.git")
+        assert router.handle_block_out_of_band_merge(_merge_event(command, repo)) is True
+        deny = _parse_deny(capsys)
+        assert deny is not None
+        assert "ticket merge" in deny["permissionDecisionReason"]
+
+    @pytest.mark.parametrize("command", ["gh pr merge 5", "glab mr merge !9"])
+    def test_bare_merge_from_unmanaged_cwd_outside_overlay_path_allows(
+        self, command: str, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Same overlay-path config, but an unmanaged-slug cwd outside the path:
+        # the classifier must ALLOW (the fix classifies, it does not over-block).
+        repo = _repo_with_remote(tmp_path / "wt", "git@github.com:example-org/public-repo.git")
+        assert router.handle_block_out_of_band_merge(_merge_event(command, repo)) is False
+        assert capsys.readouterr().out.strip() == ""

--- a/tests/test_hook_router_out_of_band_merge.py
+++ b/tests/test_hook_router_out_of_band_merge.py
@@ -283,6 +283,13 @@ class TestClassifiesMergeTargetNotCwd:
             # slug parser cannot resolve, and the keystone never merges via raw
             # graphql, so this signature is blocked unconditionally (fail-closed).
             "gh api graphql -f query='mutation{mergePullRequest(input:{pullRequestId:\"PR_x\"}){clientMutationId}}'",
+            # GraphQL enablePullRequestAutoMerge — merges on GitHub's native rules,
+            # same merge effect as mergePullRequest under a different name.
+            "gh api graphql -f query='mutation{enablePullRequestAutoMerge(input:{pullRequestId:\"X\"})}'",
+            # GraphQL mergeBranch — merges head ref into base ref out-of-band.
+            'gh api graphql -f query=\'mutation{mergeBranch(input:{base:"a",head:"b"})}\'',
+            # Uppercase URL path segment must still match (case-insensitive /PULL/).
+            "gh pr merge https://github.com/souliane/teatree/PULL/9 --squash",
         ],
     )
     def test_managed_target_blocked_from_unmanaged_cwd(


### PR DESCRIPTION
## The bypass

`handle_block_out_of_band_merge` (the out-of-band merge gate, `hooks/scripts/hook_router.py`) detected a raw REST/CLI merge form but decided block/allow **solely from the CWD repo's** managed-state (`_cwd_is_teatree_managed`). It never looked at the merge **target**.

So a raw merge aimed at a teatree-managed repo — for example:

- `gh api --method PUT repos/souliane/teatree/pulls/N/merge`
- `gh pr merge N --repo souliane/teatree`
- `glab api projects/<managed-ns>/merge_requests/N/merge --method POST`

issued from **any resolvable-but-unmanaged git cwd** resolved cwd→unmanaged→ALLOW and merged a managed repo's PR, skipping the keystone MergeClear ceremony (reviewer-identity check, commit-SHA binding, live-CI re-check in `src/teatree/core/merge/execution.py`) entirely.

## The fix

Classify the merge **target** first, reusing the existing target-axis parser `mr_cli_fields.extract_mr_target_repo` (built for the analogous [#1703](https://github.com/souliane/teatree/issues/1703) fix) — no parsing duplicated. A new pure predicate `mr_cli_fields.merge_target_is_managed(command, managed_slugs)` matches the parsed target slug against the **same offline managed-repo signal set** the cwd check already uses (`_overlay_managed_repo_signals`).

The gate now **BLOCKS whenever the target is managed, regardless of cwd**. The cwd-keyed check ([#126](https://github.com/souliane/teatree/issues/126)) stays the fail-safe fallback **only when no target parses** (numeric GitLab project id, bare `gh pr merge <n>` with no `--repo`) — allowing the merge solely on a confidently-unmanaged cwd; a managed or unresolvable cwd stays BLOCKED.

This is purely additive — it inserts a managed-target block ahead of the **unchanged** cwd fallback logic. Reads of the merge endpoint (`-X GET`) and genuinely-unmanaged targets still pass, and the sanctioned `t3 <overlay> ticket merge` keystone (not a raw `gh`/`glab` merge form) is never matched by the gate.

## The pinning test

`tests/test_hook_router_out_of_band_merge.py::TestClassifiesMergeTargetNotCwd` — five managed-target merge forms issued from a resolvable, **unmanaged** cwd are now BLOCKED. All five returned **ALLOW (the bypass) on `origin/main`** (verified RED pre-fix); they go GREEN with the fix. Two control cases confirm no over-block: the keystone path and a genuinely-unmanaged `--repo` target both still pass.

## Architecture pre-check

1. **BLUEPRINT § alignment** — §17.1 invariant 8 / §17.4 (orchestrator-decides / loop-executes; out-of-band merges must route through the keystone). No BLUEPRINT change: this closes a hole in an existing invariant's enforcement.
2. **FSM phase boundaries** — n/a (no `Ticket.State`/`Worktree.State` transition).
3. **Extension-point contracts** — none changed; the gate stays one `PreToolUse` handler. No overlay/scanner/Protocol surface touched.
4. **Component boundaries** — pure target-classification predicate added to the existing `hooks/scripts/mr_cli_fields.py` sibling (target-repo parsing already lives there); the router only gains the call. `hook_router.py` nets the same code-LOC (docstring trim + body collapse offset the addition) so the shrink-only god-module ratchet stays green.
5. **Dependency direction** — no new cross-module import; the router already imports from `mr_cli_fields`.
6. **Test surface** — `TestClassifiesMergeTargetNotCwd` (above); anti-vacuous (RED on `origin/main`, GREEN with fix).
7. **Resilience invariants** — fail-closed posture preserved: an unparseable target falls back to the cwd check, which itself blocks on a managed/uncertain cwd. No new external write.
8. **Identity / key normalization** — the target slug is the canonical `owner/repo` key from `extract_mr_target_repo`; matched against the same managed-signal substrings as the cwd path (one signal source).
9. **Behavior preservation** — no behavior removed. The change only *adds* a block condition (managed target); every prior allow/deny path is retained, confirmed by the pre-existing test classes all passing unchanged.
