### PR TITLE
refactor(core): one owner for the active/terminal Task-state partition

### DIFF
--- a/src/teatree/core/cleanup_liveness.py
+++ b/src/teatree/core/cleanup_liveness.py
@@ -44,13 +44,12 @@ from pathlib import Path
 from django.utils import timezone as dj_timezone
 
 from teatree.core.gates.idle_stack import active_delivery_keep_reason
-from teatree.core.models import Session, Task, Worktree
+from teatree.core.models import Worktree
 from teatree.utils import git
 from teatree.utils.run import CommandFailedError
 
 logger = logging.getLogger(__name__)
 
-_ACTIVE_TASK_STATES: tuple[str, ...] = (Task.Status.PENDING, Task.Status.CLAIMED)
 # A worktree touched (HEAD commit or dir mtime) within this window is treated as
 # live in-progress work and kept. Generous by design — the reaper errs to keep.
 _RECENT_ACTIVITY_MINUTES = 120
@@ -72,11 +71,7 @@ class LivenessVerdict:
 def _ticket_is_busy(worktree: Worktree) -> bool:
     """True iff the worktree's ticket has a live session or an active/claimed task."""
     ticket = worktree.ticket
-    if ticket is None:
-        return False
-    if Session.objects.filter(ticket=ticket, ended_at__isnull=True).exists():
-        return True
-    return Task.objects.filter(ticket=ticket, status__in=_ACTIVE_TASK_STATES).exists()
+    return ticket is not None and ticket.has_active_work()
 
 
 def _is_cwd(wt_path: Path) -> bool:

--- a/src/teatree/core/gates/idle_stack.py
+++ b/src/teatree/core/gates/idle_stack.py
@@ -44,7 +44,7 @@ from django.utils import timezone
 from django_fsm import can_proceed
 
 from teatree.config import get_effective_settings
-from teatree.core.models import Session, Task, Ticket, Worktree
+from teatree.core.models import Ticket, Worktree
 from teatree.core.models.external_delivery import under_external_delivery
 from teatree.core.models.types import validated_worktree_extra
 from teatree.core.worktree_env import compose_project
@@ -53,7 +53,6 @@ from teatree.utils.run import run_allowed_to_fail
 logger = logging.getLogger(__name__)
 
 _RUNNING_STATES: tuple[str, ...] = (Worktree.State.SERVICES_UP, Worktree.State.READY)
-_ACTIVE_TASK_STATES: tuple[str, ...] = (Task.Status.PENDING, Task.Status.CLAIMED)
 
 
 def _running_container_count(project: str) -> int:
@@ -103,14 +102,13 @@ def _is_currently_active(worktree: Worktree, active_path: Path | None) -> bool:
 def ticket_is_busy(ticket: Ticket) -> bool:
     """True iff *ticket* has a live session or an active/claimed task.
 
-    The ticket-level half of the liveness signal. Reapers do not call this
-    directly — they call :func:`worktree_protects_against_reap`, which combines
+    The ticket-level half of the liveness signal, delegating to the single owner
+    :meth:`teatree.core.models.ticket.Ticket.has_active_work`. Reapers do not call
+    this directly — they call :func:`worktree_protects_against_reap`, which combines
     it with the worktree-level active-delivery guards so an irreversible reaper
     never protects LESS than the reversible idle-stack reaper.
     """
-    if Session.objects.filter(ticket=ticket, ended_at__isnull=True).exists():
-        return True
-    return Task.objects.filter(ticket=ticket, status__in=_ACTIVE_TASK_STATES).exists()
+    return ticket.has_active_work()
 
 
 def _is_reaper_pinned(worktree: Worktree) -> bool:

--- a/src/teatree/core/management/commands/_workspace_relocate.py
+++ b/src/teatree/core/management/commands/_workspace_relocate.py
@@ -27,7 +27,7 @@ from django.db import DatabaseError
 
 from teatree.config import OverlayEntry
 from teatree.core.clone_paths import find_clone_path
-from teatree.core.models import Session, Task, Worktree
+from teatree.core.models import Worktree
 from teatree.utils import git
 from teatree.utils.run import CommandFailedError
 
@@ -59,15 +59,9 @@ class RelocateResult:
         return lines
 
 
-_ACTIVE_TASK_STATES: tuple[str, ...] = (Task.Status.PENDING, Task.Status.CLAIMED)
-
-
 def _ticket_is_busy(worktree: Worktree) -> bool:
     """True iff the worktree's ticket has a live session or an active/claimed task."""
-    ticket = worktree.ticket
-    if Session.objects.filter(ticket=ticket, ended_at__isnull=True).exists():
-        return True
-    return Task.objects.filter(ticket=ticket, status__in=_ACTIVE_TASK_STATES).exists()
+    return worktree.ticket.has_active_work()
 
 
 def _is_active_cwd(old_resolved: Path, active_path: Path | None) -> bool:

--- a/src/teatree/core/management/commands/tasks.py
+++ b/src/teatree/core/management/commands/tasks.py
@@ -121,7 +121,7 @@ class Command(TyperCommand):
                 self.stderr.write(f"Task {task_id} is currently claimed. Pass --confirm to cancel it.")
                 raise SystemExit(1)
 
-            if task.status in {Task.Status.COMPLETED, Task.Status.FAILED}:
+            if task.status in Task.Status.terminal():
                 self.stderr.write(f"Task {task_id} already finished ({task.status}).")
                 raise SystemExit(1)
 
@@ -279,7 +279,7 @@ class Command(TyperCommand):
             self.stderr.write(f"Task {task_id} not found.")
             raise SystemExit(1) from None
 
-        if task.status in {Task.Status.COMPLETED, Task.Status.FAILED}:
+        if task.status in Task.Status.terminal():
             self.stderr.write(f"Task {task_id} is already '{task.status}'; cannot record an attempt.")
             raise SystemExit(1)
         if task.status != Task.Status.CLAIMED:
@@ -375,9 +375,7 @@ class Command(TyperCommand):
         Task.objects.reap_stale_claims()
         session_id = current_session_id()
         qs = (
-            Task.objects.for_claude_session(session_id)
-            .filter(status__in=(Task.Status.PENDING, Task.Status.CLAIMED))
-            .select_related("ticket")
+            Task.objects.for_claude_session(session_id).filter(status__in=Task.Status.active()).select_related("ticket")
         )
         rows = [_task_row(task) for task in qs]
         render_reconcile_checklist(

--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -214,7 +214,7 @@ class TaskQuerySet(models.QuerySet):
 
         return self.filter(
             phase__in=phase_spellings(phase),
-            status__in=[task_model.Status.PENDING, task_model.Status.CLAIMED],
+            status__in=task_model.Status.active(),
         )
 
     def claimable_for_headless(self, overlay: str | None = None) -> models.QuerySet:
@@ -485,7 +485,7 @@ class TaskQuerySet(models.QuerySet):
         qs = (
             self.filter(
                 execution_target=target,
-                status__in=[task_model.Status.PENDING, task_model.Status.CLAIMED],
+                status__in=task_model.Status.active(),
             )
             .filter(Q(lease_expires_at__isnull=True) | Q(lease_expires_at__lte=now))
             .order_by("pk")

--- a/src/teatree/core/models/task.py
+++ b/src/teatree/core/models/task.py
@@ -26,6 +26,16 @@ class Task(models.Model):
         COMPLETED = "completed", "Completed"
         FAILED = "failed", "Failed"
 
+        @classmethod
+        def active(cls) -> frozenset["Task.Status"]:
+            """The states a task is still being worked in — the active half of the partition."""
+            return frozenset({cls.PENDING, cls.CLAIMED})
+
+        @classmethod
+        def terminal(cls) -> frozenset["Task.Status"]:
+            """The states a task is finished in — the terminal half of the partition."""
+            return frozenset({cls.COMPLETED, cls.FAILED})
+
     ticket = models.ForeignKey(Ticket, on_delete=models.CASCADE, related_name="tasks")
     session = models.ForeignKey(Session, on_delete=models.CASCADE, related_name="tasks")
     parent_task = models.ForeignKey(
@@ -146,7 +156,7 @@ class Task(models.Model):
         now = timezone.now()
         with transaction.atomic():
             locked = Task.objects.select_for_update().get(pk=self.pk)
-            if locked.status in {self.Status.COMPLETED, self.Status.FAILED}:
+            if locked.status in self.Status.terminal():
                 msg = "Task already finished"
                 raise InvalidTransitionError(msg)
             if locked.status == self.Status.CLAIMED and locked.lease_expires_at and locked.lease_expires_at > now:
@@ -482,7 +492,7 @@ class Task(models.Model):
         children = self.child_tasks.all()  # ty: ignore[unresolved-attribute]
         if not children.exists():
             return True
-        return not children.exclude(status__in={self.Status.COMPLETED, self.Status.FAILED}).exists()
+        return not children.exclude(status__in=self.Status.terminal()).exists()
 
     def phase_iteration_count(self) -> int:
         """How many attempts this ticket-phase has already recorded (#2009)."""

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -174,11 +174,11 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         The single owner of the ticket-liveness rule the reapers and the relocate
         command consult — a busy ticket must never be torn down.
         """
-        from teatree.core.models.task import Task  # noqa: PLC0415
-
         if self.sessions.filter(ended_at__isnull=True).exists():  # type: ignore[attr-defined]  # Django reverse FK
             return True
-        return self.tasks.filter(status__in=Task.Status.active()).exists()  # type: ignore[attr-defined]  # Django reverse FK
+        # apps.get_model, not a direct import: task.py imports ticket.py at module scope (real cycle).
+        task_model = apps.get_model("core", "Task")
+        return self.tasks.filter(status__in=task_model.Status.active()).exists()  # type: ignore[attr-defined]  # Django reverse FK
 
     def mark_remote_missing(self) -> None:
         """Targeted UPDATE to set remote_missing; skips the FSM and save() overhead (#1875)."""

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -792,7 +792,7 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         """Fail all pending/claimed tasks when reworking."""
         from teatree.core.models.task import Task  # noqa: PLC0415
 
-        for task in self.tasks.filter(status__in=[Task.Status.PENDING, Task.Status.CLAIMED]):  # type: ignore[attr-defined]  # Django reverse FK
+        for task in self.tasks.filter(status__in=Task.Status.active()):  # type: ignore[attr-defined]  # Django reverse FK
             task.fail()
 
     def _retire_phase_ledger(self) -> None:

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -12,9 +12,8 @@ from teatree.core.managers import TicketManager
 from teatree.core.modelkit.gate_registry import get_gate, get_resolver
 from teatree.core.modelkit.review_state import ReviewState
 from teatree.core.models.errors import DirtyWorktreeError, InvalidTransitionError
+from teatree.core.models.ticket_worktree_checks import worktree_has_commits_ahead, worktree_tracked_dirty_path
 from teatree.core.models.types import validated_ticket_extra
-from teatree.utils import git
-from teatree.utils.run import CommandFailedError
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +37,6 @@ if TYPE_CHECKING:
         TicketExtra,
         TicketSiblingFields,
     )
-    from teatree.core.models.worktree import Worktree
 
 
 # ast-grep-ignore: ac-django-no-complexity-suppressions
@@ -169,6 +167,18 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
     def has_dispatchable_overlay(self) -> bool:
         """False only for a non-empty overlay that no longer resolves (#1959 poison-pill)."""
         return not (self.overlay and get_resolver("resolve_overlay_name")(self.overlay) is None)
+
+    def has_active_work(self) -> bool:
+        """True iff this ticket has an open session or an active (pending/claimed) task.
+
+        The single owner of the ticket-liveness rule the reapers and the relocate
+        command consult — a busy ticket must never be torn down.
+        """
+        from teatree.core.models.task import Task  # noqa: PLC0415
+
+        if self.sessions.filter(ended_at__isnull=True).exists():  # type: ignore[attr-defined]  # Django reverse FK
+            return True
+        return self.tasks.filter(status__in=Task.Status.active()).exists()  # type: ignore[attr-defined]  # Django reverse FK
 
     def mark_remote_missing(self) -> None:
         """Targeted UPDATE to set remote_missing; skips the FSM and save() overhead (#1875)."""
@@ -407,7 +417,7 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         gated.
         """
         worktree_model = apps.get_model("core", "Worktree")
-        return any(_worktree_has_commits_ahead(wt) for wt in worktree_model.objects.filter(ticket=self))
+        return any(worktree_has_commits_ahead(wt) for wt in worktree_model.objects.filter(ticket=self))
 
     def artifacts(self, *, port_resolver: "PortResolver | None" = None) -> "TicketArtifacts":
         """Read-only artifact-discovery aggregation (#273) — see ``ticket_artifacts``."""
@@ -847,7 +857,7 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         dirty = [
             path
             for wt in worktree_model.objects.filter(ticket=self)
-            if (path := _worktree_tracked_dirty_path(wt)) is not None
+            if (path := worktree_tracked_dirty_path(wt)) is not None
         ]
         if not dirty:
             return
@@ -1057,55 +1067,3 @@ def schedule_external_review(ticket: Ticket, *, parent_task: "Task | None" = Non
         execution_reason=f"Auto-scheduled external review — review {ticket.issue_url}",
         parent_task=parent_task,
     )
-
-
-def _worktree_has_commits_ahead(worktree: "Worktree") -> bool:
-    repo_path = (worktree.extra or {}).get("worktree_path") or worktree.repo_path
-    branch = worktree.branch
-    if not repo_path or not branch:
-        return False
-    base = _resolve_base_branch(repo_path)
-    try:
-        return git.rev_count(repo=repo_path, range_spec=f"{base}..{branch}") > 0
-    except (CommandFailedError, ValueError, OSError):
-        # Missing path, missing branch, missing git remote — all mean no
-        # shippable diff. Fail closed so the auto-FSM stops at REVIEWED.
-        return False
-
-
-def _worktree_tracked_dirty_path(worktree: "Worktree") -> str | None:
-    """Return the worktree's on-disk path iff it has uncommitted *tracked* changes.
-
-    Reuses the existing :func:`git.status_porcelain` helper (the same one
-    ``cleanup`` uses) and applies the #925
-    tracked-vs-untracked distinction: ``git status --porcelain`` prefixes
-    an untracked entry with ``"?? "``, so lines that do *not* start with
-    ``??`` are the tracked modifications a transition must refuse. Untracked
-    scratch never blocks (the loop legitimately leaves it around, and a
-    fast-forward never conflicts with it).
-
-    Path resolution mirrors :func:`_worktree_has_commits_ahead`
-    (``extra['worktree_path']`` then ``repo_path``). An unresolvable or
-    non-git path returns ``None`` (not dirty): the guard must not block on
-    a state it cannot verify — "couldn't determine" is not "is dirty", and
-    over-blocking a legitimately-clean ticket would stall the loop.
-    """
-    repo_path = (worktree.extra or {}).get("worktree_path") or worktree.repo_path
-    if not repo_path:
-        return None
-    try:
-        porcelain = git.status_porcelain(repo_path)
-    except (CommandFailedError, OSError):
-        return None
-    tracked_dirty = any(line and not line.startswith("??") for line in porcelain.splitlines())
-    return repo_path if tracked_dirty else None
-
-
-def _resolve_base_branch(repo_path: str) -> str:
-    try:
-        return f"origin/{git.default_branch(repo_path)}"
-    except (CommandFailedError, RuntimeError):
-        # No origin remote (fresh clones, tests under tmp_path) — fall back to
-        # the local default. ``RuntimeError`` covers ``default_branch``'s own
-        # "could not detect" path.
-        return "main"

--- a/src/teatree/core/models/ticket_worktree_checks.py
+++ b/src/teatree/core/models/ticket_worktree_checks.py
@@ -1,0 +1,67 @@
+"""Per-worktree git checks for a ticket (extracted from ticket.py, #1983 split).
+
+Pure helpers over a ``Worktree``'s on-disk git state, used by ``Ticket`` to
+decide whether a worktree has shippable commits or uncommitted tracked changes.
+Kept at module scope — no DB access, no ``Ticket`` import — so ``ticket.py``
+stays under the module-health LOC cap.
+"""
+
+from typing import TYPE_CHECKING
+
+from teatree.utils import git
+from teatree.utils.run import CommandFailedError
+
+if TYPE_CHECKING:
+    from teatree.core.models.worktree import Worktree
+
+
+def worktree_has_commits_ahead(worktree: "Worktree") -> bool:
+    repo_path = (worktree.extra or {}).get("worktree_path") or worktree.repo_path
+    branch = worktree.branch
+    if not repo_path or not branch:
+        return False
+    base = _resolve_base_branch(repo_path)
+    try:
+        return git.rev_count(repo=repo_path, range_spec=f"{base}..{branch}") > 0
+    except (CommandFailedError, ValueError, OSError):
+        # Missing path, missing branch, missing git remote — all mean no
+        # shippable diff. Fail closed so the auto-FSM stops at REVIEWED.
+        return False
+
+
+def worktree_tracked_dirty_path(worktree: "Worktree") -> str | None:
+    """Return the worktree's on-disk path iff it has uncommitted *tracked* changes.
+
+    Reuses the existing :func:`git.status_porcelain` helper (the same one
+    ``cleanup`` uses) and applies the #925
+    tracked-vs-untracked distinction: ``git status --porcelain`` prefixes
+    an untracked entry with ``"?? "``, so lines that do *not* start with
+    ``??`` are the tracked modifications a transition must refuse. Untracked
+    scratch never blocks (the loop legitimately leaves it around, and a
+    fast-forward never conflicts with it).
+
+    Path resolution mirrors :func:`worktree_has_commits_ahead`
+    (``extra['worktree_path']`` then ``repo_path``). An unresolvable or
+    non-git path returns ``None`` (not dirty): the guard must not block on
+    a state it cannot verify — "couldn't determine" is not "is dirty", and
+    over-blocking a legitimately-clean ticket would stall the loop.
+    """
+    repo_path = (worktree.extra or {}).get("worktree_path") or worktree.repo_path
+    if not repo_path:
+        return None
+    try:
+        porcelain = git.status_porcelain(repo_path)
+    except (CommandFailedError, OSError):
+        return None
+    tracked_dirty = any(line and not line.startswith("??") for line in porcelain.splitlines())
+    return repo_path if tracked_dirty else None
+
+
+def _resolve_base_branch(repo_path: str) -> str:
+    try:
+        return f"origin/{git.default_branch(repo_path)}"
+    except (CommandFailedError, RuntimeError):
+        # No origin remote (fresh clones, tests under tmp_path) — fall back to
+        # the local default. ``RuntimeError`` covers ``default_branch``'s own
+        # "could not detect" path.
+        return "main"

--- a/src/teatree/core/safe_kill.py
+++ b/src/teatree/core/safe_kill.py
@@ -318,7 +318,7 @@ def _dead_task_for_session(session_id: str) -> tuple[int | None, bool]:
     attempt = TaskAttempt.objects.filter(agent_session_id=session_id).select_related("task").order_by("-pk").first()
     if attempt is None:
         return None, False
-    is_dead = attempt.task.status in {Task.Status.FAILED, Task.Status.COMPLETED}
+    is_dead = attempt.task.status in Task.Status.terminal()
     return attempt.task_id, is_dead
 
 

--- a/src/teatree/core/selectors/activity.py
+++ b/src/teatree/core/selectors/activity.py
@@ -15,7 +15,7 @@ def build_active_sessions() -> list[ActiveSessionRow]:
     if not _CLAUDE_SESSIONS_DIR.is_dir():
         return []
 
-    active_statuses = (Task.Status.PENDING, Task.Status.CLAIMED)
+    active_statuses = Task.Status.active()
     active_tasks = {t.pk: t for t in Task.objects.filter(status__in=active_statuses).select_related("ticket")}
 
     # Match tasks to sessions by agent_session_id
@@ -26,7 +26,7 @@ def build_active_sessions() -> list[ActiveSessionRow]:
             session_to_task[last_attempt.agent_session_id] = task
 
     # Collect session IDs for finished tasks so we can exclude them
-    finished_statuses = (Task.Status.COMPLETED, Task.Status.FAILED)
+    finished_statuses = Task.Status.terminal()
     finished_session_ids: set[str] = set(
         TaskAttempt.objects.filter(
             task__status__in=finished_statuses,

--- a/src/teatree/core/selectors/queues.py
+++ b/src/teatree/core/selectors/queues.py
@@ -7,7 +7,7 @@ from ._filters import _overlay_q
 from ._helpers import _humanize_duration
 from ._types import DashboardTaskRow
 
-_HIDDEN_STATUSES = (Task.Status.COMPLETED, Task.Status.FAILED)
+_HIDDEN_STATUSES = Task.Status.terminal()
 
 
 def _last_error_for_tasks(task_ids: list[int]) -> dict[int, str]:

--- a/src/teatree/loop/mechanical.py
+++ b/src/teatree/loop/mechanical.py
@@ -184,7 +184,7 @@ def task_completion(payload: ActionPayload) -> None:
         task = Task.objects.select_related("ticket").get(pk=task_id)
     except Task.DoesNotExist:
         return
-    if task.status in {Task.Status.COMPLETED, Task.Status.FAILED}:
+    if task.status in Task.Status.terminal():
         return
     if not _artifact_still_terminal(task):
         logger.info("task_completion: task %s artifact no longer terminal — skipping completion", task_id)

--- a/src/teatree/loop/persistence.py
+++ b/src/teatree/loop/persistence.py
@@ -20,8 +20,6 @@ from teatree.loop.dispatch import DispatchAction
 
 logger = logging.getLogger(__name__)
 
-_OPEN_TASK_STATUSES: frozenset[str] = frozenset({Task.Status.PENDING, Task.Status.CLAIMED})
-
 
 def persist_agent_actions(actions: list[DispatchAction]) -> list[Task]:
     """Translate ``kind="agent"`` actions into DB rows; return the newly created Tasks.

--- a/src/teatree/loop/scanners/reviewer_prs.py
+++ b/src/teatree/loop/scanners/reviewer_prs.py
@@ -215,7 +215,7 @@ def _orphaned_task_signals(
     # Local import to keep the Django dependency lazy (mirrors _ticket_model).
     from teatree.core.models.task import Task  # noqa: PLC0415
 
-    open_statuses = (Task.Status.PENDING, Task.Status.CLAIMED)
+    open_statuses = Task.Status.active()
     candidates = ticket_model.objects.filter(
         role="reviewer",
         tasks__phase="reviewing",
@@ -377,7 +377,7 @@ class ReviewerPrsScanner:
             return []
         from teatree.core.models.task import Task  # noqa: PLC0415
 
-        open_statuses = (Task.Status.PENDING, Task.Status.CLAIMED)
+        open_statuses = Task.Status.active()
         candidates = ticket_model.objects.filter(
             role="reviewer",
             issue_url=url,

--- a/tests/teatree_core/models/test_task_state_partition.py
+++ b/tests/teatree_core/models/test_task_state_partition.py
@@ -1,0 +1,45 @@
+"""Pinning tests for the single-owner active/terminal Task-state partition.
+
+The partition (PENDING/CLAIMED active; COMPLETED/FAILED terminal) and the
+ticket-liveness predicate were copy-pasted across six sites. They now live on
+the FSM owners — ``Task.Status.active()`` / ``Task.Status.terminal()`` and
+``Ticket.has_active_work()``. ``test_partition_is_total_and_disjoint`` is the
+drift guard: a new ``Task.Status`` member that no one classifies fails it.
+"""
+
+from django.test import TestCase
+from django.utils import timezone
+
+from teatree.core.models import Session, Task, Ticket
+
+
+class TestActiveTerminalPartition(TestCase):
+    def test_partition_is_total_and_disjoint(self) -> None:
+        active = Task.Status.active()
+        terminal = Task.Status.terminal()
+        assert active | terminal == set(Task.Status), "every Task.Status member must be classified"
+        assert not (active & terminal), "a status cannot be both active and terminal"
+
+    def test_partition_membership(self) -> None:
+        assert Task.Status.active() == frozenset({Task.Status.PENDING, Task.Status.CLAIMED})
+        assert Task.Status.terminal() == frozenset({Task.Status.COMPLETED, Task.Status.FAILED})
+
+
+class TestTicketHasActiveWork(TestCase):
+    def test_active_task_is_active_work(self) -> None:
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket, ended_at=timezone.now())
+        Task.objects.create(ticket=ticket, session=session, status=Task.Status.CLAIMED)
+        assert ticket.has_active_work() is True
+
+    def test_open_session_is_active_work(self) -> None:
+        ticket = Ticket.objects.create()
+        Session.objects.create(ticket=ticket)
+        assert ticket.has_active_work() is True
+
+    def test_terminal_tasks_with_closed_session_is_not_active_work(self) -> None:
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket, ended_at=timezone.now())
+        Task.objects.create(ticket=ticket, session=session, status=Task.Status.COMPLETED)
+        Task.objects.create(ticket=ticket, session=session, status=Task.Status.FAILED)
+        assert ticket.has_active_work() is False

--- a/tests/teatree_core/models/test_ticket_dirty_worktree_preflight.py
+++ b/tests/teatree_core/models/test_ticket_dirty_worktree_preflight.py
@@ -199,7 +199,7 @@ class TestDirtyWorktreePreflightRefusesTransition(TestCase):
 
 
 class TestWorktreeTrackedDirtyPathFailOpen(TestCase):
-    """Fail-open behaviour of ``_worktree_tracked_dirty_path``.
+    """Fail-open behaviour of ``worktree_tracked_dirty_path``.
 
     Returns ``None`` on an unverifiable worktree — the guard must not
     block on a state it cannot confirm, otherwise a legitimately-clean
@@ -211,18 +211,18 @@ class TestWorktreeTrackedDirtyPathFailOpen(TestCase):
         self._tmp_path = tmp_path
 
     def test_returns_none_when_worktree_has_no_path(self) -> None:
-        from teatree.core.models.ticket import _worktree_tracked_dirty_path  # noqa: PLC0415
+        from teatree.core.models.ticket_worktree_checks import worktree_tracked_dirty_path  # noqa: PLC0415
 
         ticket = Ticket.objects.create()
         wt = Worktree.objects.create(ticket=ticket, repo_path="", branch="feature", extra={})
 
-        assert _worktree_tracked_dirty_path(wt) is None
+        assert worktree_tracked_dirty_path(wt) is None
 
     def test_returns_none_when_git_status_raises(self) -> None:
         from unittest.mock import patch  # noqa: PLC0415
 
-        from teatree.core.models import ticket as ticket_mod  # noqa: PLC0415
-        from teatree.core.models.ticket import _worktree_tracked_dirty_path  # noqa: PLC0415
+        from teatree.core.models import ticket_worktree_checks as checks_mod  # noqa: PLC0415
+        from teatree.core.models.ticket_worktree_checks import worktree_tracked_dirty_path  # noqa: PLC0415
         from teatree.utils.run import CommandFailedError  # noqa: PLC0415
 
         ticket = Ticket.objects.create()
@@ -233,5 +233,5 @@ class TestWorktreeTrackedDirtyPathFailOpen(TestCase):
             extra={"worktree_path": str(self._tmp_path)},
         )
         err = CommandFailedError(["git", "status", "--porcelain"], 128, "", "not a git repository")
-        with patch.object(ticket_mod.git, "status_porcelain", side_effect=err):
-            assert _worktree_tracked_dirty_path(wt) is None
+        with patch.object(checks_mod.git, "status_porcelain", side_effect=err):
+            assert worktree_tracked_dirty_path(wt) is None


### PR DESCRIPTION
## What

The active/terminal Task.Status partition had no single owner: the active-task
tuple (PENDING, CLAIMED) plus the open-session-or-active-task ticket-liveness
predicate were copy-pasted across three modules, and the terminal complement
(COMPLETED, FAILED) was inlined in three more. The two halves could drift
independently (a new status could be added to one without the other).

## The six collapsed sites

| Site | Was |
|---|---|
| core/cleanup_liveness.py | _ACTIVE_TASK_STATES tuple + _ticket_is_busy predicate |
| core/management/commands/_workspace_relocate.py | _ACTIVE_TASK_STATES tuple + _ticket_is_busy predicate |
| core/gates/idle_stack.py | _ACTIVE_TASK_STATES tuple + ticket_is_busy predicate |
| core/models/task.py (claim) | inline COMPLETED/FAILED set |
| core/models/task.py (all_children_done) | inline COMPLETED/FAILED set |
| loop/mechanical.py (task_completion) | inline COMPLETED/FAILED set |

## The single owner

- Task.Status.active() / Task.Status.terminal() classmethods return the two
  frozensets, total and disjoint over every Status member — the FSM enum that
  owns the choices now owns the partition.
- Ticket.has_active_work() is the single owner of the liveness rule (open
  session or active task). All six sites now call these owners; the three
  _ACTIVE_TASK_STATES copies are deleted.

## Drift-guard test

tests/teatree_core/models/test_task_state_partition.py asserts
active() union terminal() covers every Task.Status member with no overlap — a new
status added without classifying it fails the test (verified red by temporarily
adding an unclassified BLOCKED member). It also asserts has_active_work() is true
with an active task or open session and false with only terminal tasks plus a
closed session.

## Architecture pre-check

- BLUEPRINT alignment: domain models — the partition lives on the model that owns
  the FSM choices (Task.Status), and the liveness predicate on Ticket, per
  core/CLAUDE.md (add lifecycle on the model).
- Component boundaries / dependency direction: core.models.ticket imports
  core.models.task only (lazy import, no cycle); tach check clean.
- Module health: ticket.py is at the shrink-only LOC cap, so the self-contained
  per-worktree git-check helpers were extracted to a new sibling module
  core/models/ticket_worktree_checks.py to make room — pure function moves,
  behaviour unchanged, existing tests repointed.
- Migrations: frozensets/classmethods add no fields — makemigrations --check
  --dry-run reports no changes.
