### PR TITLE
fix(test): refresh example values in core identity and recall tests (tree gates green)

### DIFF
--- a/evals/fixtures/comm_slack_permalink_not_bare_ts_fail.stream.jsonl
+++ b/evals/fixtures/comm_slack_permalink_not_bare_ts_fail.stream.jsonl
@@ -1,3 +1,3 @@
 {"type": "system", "subtype": "init", "session_id": "fixt-slack-permalink-fail-01", "model": "claude-sonnet-4-6"}
-{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Posted in #the-review-crew at ts=1716234567.123456."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Posted in #the-review-team at ts=1716234567.123456."}]}}
 {"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/fixtures/comm_slack_permalink_not_bare_ts_pass.stream.jsonl
+++ b/evals/fixtures/comm_slack_permalink_not_bare_ts_pass.stream.jsonl
@@ -1,3 +1,3 @@
 {"type": "system", "subtype": "init", "session_id": "fixt-slack-permalink-pass-01", "model": "claude-sonnet-4-6"}
-{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Posted in [#the-review-crew](https://acme.slack.com/archives/C123ABC/p1716234567123456)."}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "Posted in [#the-review-team](https://acme.slack.com/archives/C123ABC/p1716234567123456)."}]}}
 {"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/tests/teatree_core/test_public_identity.py
+++ b/tests/teatree_core/test_public_identity.py
@@ -118,7 +118,7 @@ class TestIsGithubHost:
             "ssh://git@github.com/souliane/teatree.git",
             "https://user@github.com:443/souliane/teatree.git",
             "git@github.com-work:souliane/teatree.git",  # ssh-alias host
-            "git@github.com-adrien-oper:souliane/teatree.git",
+            "git@github.com-work-2:souliane/teatree.git",  # ssh-alias host (2nd alias)
         ],
     )
     def test_github_hosts(self, remote: str) -> None:

--- a/tests/teatree_loops/dream/test_recall.py
+++ b/tests/teatree_loops/dream/test_recall.py
@@ -173,7 +173,7 @@ class TestRelevanceFloor(RecallTestCase):
         # scorer double-counted that one name token (entry-overlap PLUS name-overlap)
         # to fake-clear the floor of 2 and surface the rule. The floor must count
         # DISTINCT tokens, so a single name token is below it and the entry is dropped.
-        self._cold("- feedback_review_crew.md — slack reaction rendering colors note")
+        self._cold("- feedback_review_team.md — slack reaction rendering colors note")
         hits = recall_cold_memory(self.dir, "review the kubernetes deployment manifest")
         assert hits == []
 


### PR DESCRIPTION
Two core tests carried example values that the tree terminology CI gates flag on `main`. This replaces them with generic placeholders that keep each test asserting the same behaviour, turning both tree gates green.

## Changes

- **`tests/teatree_core/test_public_identity.py`** — the `test_github_hosts` parametrize list had a second ssh-alias-host example; it now uses the generic alias `github.com-work-2`, matching the existing generic `github.com-work` example on the line above. The test verifies ssh-alias-host parsing (`is_github_host(...) is True`); the alias name is incidental.
- **`tests/teatree_loops/dream/test_recall.py`** — the relevance-floor fixture filename stem is now `feedback_review_team.md`. The test asserts that a single overlapping `review` filename word stays below the relevance floor (`hits == []`); the rest of the stem is incidental.
- **`evals/fixtures/comm_slack_permalink_not_bare_ts_{fail,pass}.stream.jsonl`** — the simulated Slack channel name is now `#the-review-team`. The scenario grades permalink-vs-bare-ts rendering; the channel name is incidental.

## Verification

- `scripts/hooks/check_no_overlay_leak.py --require-terms` -> exit 0, no findings
- `banned-terms scan-tree` terminology pass -> clean (0 findings); the flagged literal no longer appears in any tracked file
- `pytest tests/teatree_core/test_public_identity.py tests/teatree_loops/dream/test_recall.py` -> 60 passed
- `ruff check` clean; `makemigrations --check --dry-run` -> No changes
