### PR TITLE
fix(hooks): resolve cwd git remote offline so a flagless glab mr create to a private repo is not over-blocked

### DIFF
--- a/src/teatree/hooks/_repo_visibility.py
+++ b/src/teatree/hooks/_repo_visibility.py
@@ -22,7 +22,7 @@ import time
 from pathlib import Path
 from typing import Final, TypedDict
 
-from teatree.utils import git
+from teatree.hooks import git_config_offline
 from teatree.utils.run import CommandFailedError, run_allowed_to_fail
 
 
@@ -125,16 +125,13 @@ def slug_for_cwd(cwd: Path) -> str:
         tripped the substring matcher and falsely downgraded a PUBLIC repo
         (#1953).
 
-    ``FileNotFoundError`` (the ``git`` binary unresolved on the restricted hook
-    PATH) and ``OSError`` are caught alongside ``CommandFailedError`` so a
-    degraded subprocess fails SAFE to an empty slug -- an uncaught error would
-    propagate out of the carve-out and crash the whole gate, denying the offline
-    allowlist any chance to downgrade.
+    The ``origin`` URL is resolved OFFLINE-FIRST (:func:`_origin_remote_url`):
+    parsing ``.git/config`` directly needs no ``git`` binary, so the slug
+    resolves inside the restricted PreToolUse hook subprocess where a bare
+    ``git`` is unresolvable. An empty slug fails SAFE -- the destination then
+    resolves PUBLIC and the gate stays hard-blocking.
     """
-    try:
-        url = git.remote_url(repo=str(cwd))
-    except (CommandFailedError, OSError):
-        return ""
+    url = _origin_remote_url(cwd)
     if not url:
         return ""
     cleaned = url.strip().rstrip("/").removesuffix(".git")
@@ -152,6 +149,47 @@ def slug_for_cwd(cwd: Path) -> str:
             return f"{real_host}/{path}"
         return path
     return cleaned
+
+
+def _origin_remote_url(cwd: Path) -> str:
+    """Resolve ``cwd``'s ``origin`` URL, OFFLINE-FIRST.
+
+    The offline ``.git/config`` parse (:func:`git_config_offline.origin_url`)
+    spawns no process, so it resolves the remote inside the restricted
+    PreToolUse hook subprocess where a bare ``git`` is unresolvable -- the bug
+    that left a flagless ``glab mr create`` / ``gh pr create`` to the user's
+    OWN private repo with no slug to match the offline ``private_repos``
+    allowlist, over-blocking it. The PATH-augmented subprocess is the fallback
+    for the rare configs an offline parse cannot read (e.g. an
+    ``[include]``-redirected url).
+    """
+    offline = git_config_offline.origin_url(cwd)
+    if offline:
+        return offline
+    return _origin_url_via_git(cwd)
+
+
+def _origin_url_via_git(cwd: Path) -> str:
+    """Resolve ``origin`` via ``git remote get-url`` against the augmented PATH.
+
+    The PreToolUse hook subprocess inherits a restricted PATH where a bare
+    ``git`` may not resolve; resolving the binary against the augmented probe
+    PATH (the same one the visibility probe uses) keeps this fallback working
+    in-hook. Any failure (binary absent, not a repo) fails SAFE to ``""``.
+    """
+    binary = shutil.which("git", path=_probe_search_path())
+    if binary is None:
+        return ""
+    try:
+        result = run_allowed_to_fail(
+            [binary, "-C", str(cwd), "remote", "get-url", "origin"],
+            expected_codes=(0,),
+            env=_probe_env(),
+            timeout=_PROBE_TIMEOUT_S,
+        )
+    except (CommandFailedError, OSError):
+        return ""
+    return result.stdout.strip()
 
 
 def _is_canonical_host(host: str) -> bool:

--- a/src/teatree/hooks/git_config_offline.py
+++ b/src/teatree/hooks/git_config_offline.py
@@ -1,0 +1,139 @@
+"""Offline, worktree-aware ``origin`` remote-URL resolution from ``.git/config``.
+
+The cwd-remote half of the publish-surface destination resolution
+(:func:`teatree.hooks._repo_visibility.slug_for_cwd`) must work inside the
+restricted PreToolUse hook subprocess, whose inherited PATH frequently does NOT
+resolve a bare ``git`` -- the same restriction the live-visibility probe
+augments PATH around (:data:`_repo_visibility._PROBE_PATH_EXTRA`). Shelling out
+to ``git remote get-url`` there raises ``FileNotFoundError`` and yields an empty
+slug, so a flagless ``glab mr create`` / ``gh pr create`` resolves to NO
+destination and the banned-terms gate (#1415) over-blocks a post to the user's
+OWN private repo -- the offline ``[teatree] private_repos`` allowlist never got
+a slug to match against.
+
+This module reads the ``origin`` URL by PARSING ``.git/config`` directly -- no
+subprocess, so it is immune to the restricted hook PATH. It resolves the config
+the way git itself does for a linked worktree: a worktree's ``.git`` is a FILE
+``gitdir: <path>`` pointing at the per-worktree admin dir under the main repo's
+``.git/worktrees/<name>``; that dir's ``commondir`` names the shared common dir
+holding the single ``config`` (remotes are shared across every worktree of a
+repo). A main checkout's ``.git`` is a directory that IS its own common dir.
+
+Detection is fail-safe: an unresolvable repo, config, or remote yields ``""``,
+which keeps the destination ``None`` and the gate hard-blocking. The minimal
+git-config reader covers the ordinary ``[remote "origin"] url = ...`` form; the
+PATH-augmented ``git`` subprocess fallback in :mod:`_repo_visibility` handles
+the rare configs an offline parse cannot read (e.g. an ``[include]``-redirected
+url).
+"""
+
+import re
+from pathlib import Path
+from typing import Final
+
+# A linked worktree's ``.git`` FILE points at its admin dir via this prefix.
+_GITDIR_PREFIX: Final[str] = "gitdir:"
+
+# ``[remote "<name>"]`` section header. Section names are case-insensitive in
+# git config; the quoted subsection (the remote name) is case-sensitive, so it
+# is captured and compared exactly rather than under the IGNORECASE flag.
+_REMOTE_HEADER_RE: Final[re.Pattern[str]] = re.compile(r'^\[\s*remote\s+"([^"]*)"\s*\]', re.IGNORECASE)
+
+
+def origin_url(cwd: Path, remote: str = "origin") -> str:
+    """Return ``cwd``'s ``remote`` URL parsed offline from ``.git/config``.
+
+    Never spawns a process, so it resolves the remote inside the restricted
+    PreToolUse hook subprocess where a bare ``git`` is unresolvable. Returns
+    ``""`` when the repo, its config, or the remote cannot be resolved.
+    """
+    config = _git_config_path(cwd)
+    if config is None:
+        return ""
+    try:
+        text = config.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    return _remote_url_from_config(text, remote)
+
+
+def _git_config_path(cwd: Path) -> Path | None:
+    """Resolve the shared ``config`` file governing ``cwd``'s repo, or ``None``."""
+    git_dir = _git_dir(cwd)
+    if git_dir is None:
+        return None
+    config = _common_dir(git_dir) / "config"
+    return config if config.is_file() else None
+
+
+def _git_dir(cwd: Path) -> Path | None:
+    """Resolve ``cwd``'s ``.git`` admin dir, walking up parents like git does."""
+    for directory in (cwd, *cwd.parents):
+        dot_git = directory / ".git"
+        if dot_git.is_dir():
+            return dot_git
+        if dot_git.is_file():
+            return _gitdir_from_file(dot_git)
+    return None
+
+
+def _gitdir_from_file(dot_git: Path) -> Path | None:
+    """Resolve the admin dir a linked worktree's ``.git`` FILE points at."""
+    try:
+        content = dot_git.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not content.startswith(_GITDIR_PREFIX):
+        return None
+    target = content[len(_GITDIR_PREFIX) :].strip()
+    if not target:
+        return None
+    git_dir = Path(target)
+    if not git_dir.is_absolute():
+        git_dir = (dot_git.parent / git_dir).resolve()
+    return git_dir if git_dir.is_dir() else None
+
+
+def _common_dir(git_dir: Path) -> Path:
+    """Return the shared common dir holding ``config`` for ``git_dir``.
+
+    A linked worktree's admin dir carries a ``commondir`` file naming the
+    repo's shared common dir (where the single ``config`` and its remotes
+    live); a main checkout's ``.git`` directory IS its own common dir.
+    """
+    commondir = git_dir / "commondir"
+    if not commondir.is_file():
+        return git_dir
+    try:
+        target = commondir.read_text(encoding="utf-8").strip()
+    except OSError:
+        return git_dir
+    if not target:
+        return git_dir
+    common = Path(target)
+    if not common.is_absolute():
+        common = (git_dir / common).resolve()
+    return common
+
+
+def _remote_url_from_config(text: str, remote: str) -> str:
+    """Return the ``url`` of section ``[remote "<remote>"]``, or ``""``.
+
+    A minimal git-config reader for the ``url`` key only: section names are
+    case-insensitive, the quoted remote name is case-sensitive, and the key
+    name is case-insensitive. Lines beginning with ``#`` / ``;`` are comments.
+    """
+    in_remote = False
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line[0] in "#;":
+            continue
+        if line.startswith("["):
+            match = _REMOTE_HEADER_RE.match(line)
+            in_remote = match is not None and match.group(1) == remote
+            continue
+        if in_remote:
+            key, sep, value = line.partition("=")
+            if sep and key.strip().lower() == "url":
+                return value.strip()
+    return ""

--- a/tests/teatree_hooks/test_banned_terms_scanner.py
+++ b/tests/teatree_hooks/test_banned_terms_scanner.py
@@ -2061,21 +2061,27 @@ class TestPrivateRepoCarveOut:
         assert blocked is False
         assert capsys.readouterr().out == ""
 
-    def test_slug_for_cwd_fails_safe_when_git_binary_is_absent(
+    def test_slug_for_cwd_resolves_offline_when_git_binary_is_absent(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # The cold hook subprocess can inherit a restricted PATH where ``git``
-        # does not resolve, so ``git remote get-url`` raises FileNotFoundError.
-        # An uncaught error would propagate out of the carve-out and crash the
-        # whole gate; the slug resolver must fail SAFE to an empty slug exactly
-        # as it already does for a CommandFailedError.
+        # does not resolve. The slug must STILL resolve -- parsed OFFLINE from
+        # ``.git/config`` -- so the offline ``private_repos`` allowlist gets a
+        # slug to match and the user's OWN private post is not over-blocked.
+        # Before the fix the bare ``git remote get-url`` raised
+        # FileNotFoundError and the slug was empty, which over-blocked it.
         repo = _private_repo(tmp_path)
-        monkeypatch.setattr(
-            _repo_visibility.git,
-            "remote_url",
-            lambda repo=".", remote="origin": (_ for _ in ()).throw(FileNotFoundError("git")),
-        )
-        assert _repo_visibility.slug_for_cwd(repo) == ""
+        monkeypatch.setenv("PATH", "")  # mimic the restricted hook subprocess: no git
+        assert _repo_visibility.slug_for_cwd(repo) == "gitlab.com/acmecorp-engineering/product"
+
+    def test_slug_for_cwd_fails_safe_for_non_repo_cwd_without_git(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A genuinely non-repo cwd has no ``.git/config`` to parse and ``git``
+        # is absent, so the slug fails SAFE to an empty string -- a detection
+        # failure never weakens the gate.
+        monkeypatch.setenv("PATH", "")
+        assert _repo_visibility.slug_for_cwd(tmp_path) == ""
 
     def test_private_repo_commit_downgrades_when_probe_binary_is_absent(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/teatree_hooks/test_git_config_offline.py
+++ b/tests/teatree_hooks/test_git_config_offline.py
@@ -21,7 +21,19 @@ def _git(cwd: Path, *args: str) -> None:
         cwd=cwd,
         check=True,
         capture_output=True,
-        env={**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"},
+        env={
+            **os.environ,
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            # Deterministic identity so ``git commit`` / ``git worktree add``
+            # succeed under an identity-less git: the CI container has no global
+            # user.name/email and auto-detection is disabled, so no inherited
+            # identity can be assumed.
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        },
     )
 
 

--- a/tests/teatree_hooks/test_git_config_offline.py
+++ b/tests/teatree_hooks/test_git_config_offline.py
@@ -1,0 +1,98 @@
+"""Tests for offline ``origin`` remote-URL resolution (`teatree.hooks.git_config_offline`).
+
+The cwd-remote resolution must work inside the restricted PreToolUse hook
+subprocess where a bare ``git`` is unresolvable, so the URL is read by PARSING
+``.git/config`` directly -- no subprocess. These tests exercise a real ``git``
+checkout under ``tmp_path`` (a main repo AND a linked worktree whose ``.git`` is
+a FILE pointing at the shared common-dir config), plus the minimal config
+reader on raw config text.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+from teatree.hooks import git_config_offline
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],  # noqa: S607
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        env={**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"},
+    )
+
+
+def _repo_with_remote(path: Path, remote_url: str) -> Path:
+    path.mkdir(parents=True)
+    _git(path, "init", "-b", "main")
+    _git(path, "remote", "add", "origin", remote_url)
+    return path
+
+
+class TestOriginUrlFromCheckout:
+    """``origin_url`` resolves the remote from a real ``.git/config`` offline."""
+
+    def test_main_checkout_dir_git(self, tmp_path: Path) -> None:
+        # A main checkout's ``.git`` is a directory that is its own common dir.
+        repo = _repo_with_remote(tmp_path / "r", "git@gitlab.com:internalcorp/svc.git")
+        assert git_config_offline.origin_url(repo) == "git@gitlab.com:internalcorp/svc.git"
+
+    def test_subdirectory_walks_up_to_repo_root(self, tmp_path: Path) -> None:
+        repo = _repo_with_remote(tmp_path / "r", "https://github.com/acme-internal/app.git")
+        sub = repo / "deep" / "nested"
+        sub.mkdir(parents=True)
+        assert git_config_offline.origin_url(sub) == "https://github.com/acme-internal/app.git"
+
+    def test_linked_worktree_git_file_reads_shared_config(self, tmp_path: Path) -> None:
+        # The real-world hook case: the agent's cwd is a LINKED worktree whose
+        # ``.git`` is a FILE ``gitdir: ...``; the origin lives in the shared
+        # common-dir config and must resolve without a ``git`` subprocess.
+        repo = _repo_with_remote(tmp_path / "r", "git@gitlab.com:internalcorp/svc.git")
+        _git(repo, "commit", "--allow-empty", "-m", "init")
+        linked = tmp_path / "linked"
+        _git(repo, "worktree", "add", str(linked), "-b", "feat/x")
+        assert (linked / ".git").is_file()
+        assert git_config_offline.origin_url(linked) == "git@gitlab.com:internalcorp/svc.git"
+
+    def test_non_repo_dir_returns_empty(self, tmp_path: Path) -> None:
+        assert git_config_offline.origin_url(tmp_path) == ""
+
+    def test_missing_origin_remote_returns_empty(self, tmp_path: Path) -> None:
+        repo = tmp_path / "r"
+        repo.mkdir()
+        _git(repo, "init", "-b", "main")  # no origin added
+        assert git_config_offline.origin_url(repo) == ""
+
+
+class TestRemoteUrlFromConfig:
+    """The minimal git-config reader picks the right ``url`` for ``[remote "..."]``."""
+
+    def test_picks_origin_url_among_sections(self) -> None:
+        text = (
+            "[core]\n\trepositoryformatversion = 0\n"
+            '[remote "upstream"]\n\turl = https://example.com/up/stream.git\n'
+            '[remote "origin"]\n\turl = git@gitlab.com:internalcorp/svc.git\n'
+            "\tfetch = +refs/heads/*:refs/remotes/origin/*\n"
+        )
+        assert git_config_offline._remote_url_from_config(text, "origin") == "git@gitlab.com:internalcorp/svc.git"
+
+    def test_section_name_is_case_insensitive(self) -> None:
+        text = '[REMOTE "origin"]\n\tURL = git@gitlab.com:ns/repo.git\n'
+        assert git_config_offline._remote_url_from_config(text, "origin") == "git@gitlab.com:ns/repo.git"
+
+    def test_subsection_remote_name_is_case_sensitive(self) -> None:
+        # The quoted remote name is case-sensitive in git, so ``Origin`` is a
+        # different remote than ``origin`` and must NOT match.
+        text = '[remote "Origin"]\n\turl = git@gitlab.com:ns/repo.git\n'
+        assert git_config_offline._remote_url_from_config(text, "origin") == ""
+
+    def test_comment_lines_ignored(self) -> None:
+        text = '# a comment\n; another\n[remote "origin"]\n\turl = https://github.com/o/r.git\n'
+        assert git_config_offline._remote_url_from_config(text, "origin") == "https://github.com/o/r.git"
+
+    def test_absent_remote_returns_empty(self) -> None:
+        text = "[core]\n\tbare = false\n"
+        assert git_config_offline._remote_url_from_config(text, "origin") == ""

--- a/tests/teatree_hooks/test_publish_destination.py
+++ b/tests/teatree_hooks/test_publish_destination.py
@@ -689,3 +689,66 @@ class TestApiEndpointNormalization:
             "https://gitlab.com/api/v4/projects/public-org%2Fapp/merge_requests/6378/notes -f body=x"
         )
         assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False
+
+
+def _private_repos_config(tmp_path: Path, namespaces: list[str]) -> Path:
+    cfg = tmp_path / ".teatree.toml"
+    entries = ", ".join(f'"{n}"' for n in namespaces)
+    cfg.write_text(f"[teatree]\nprivate_repos = [{entries}]\n", encoding="utf-8")
+    return cfg
+
+
+class TestRestrictedPathCwdResolution:
+    """The cwd-remote slug must resolve OFFLINE inside the restricted hook PATH.
+
+    The PreToolUse hook subprocess inherits a PATH that frequently does not
+    resolve a bare ``git``. Resolving the flagless-create destination by
+    shelling out to ``git remote get-url`` failed there, so the destination
+    resolved to ``None`` and the banned-terms gate OVER-BLOCKED a flagless
+    ``glab mr create`` to the user's OWN private repo (the offline
+    ``private_repos`` allowlist never got a slug to match). The slug is now
+    parsed from ``.git/config`` directly, so it resolves with no ``git`` on
+    PATH -- while a genuinely-PUBLIC cwd still scans (no over-relaxation).
+    """
+
+    def test_flagless_create_to_private_cwd_skips_without_git_on_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # MUST-NOT-FIRE (red on revert): a flagless ``glab mr create`` whose cwd
+        # is an allowlisted-private checkout SKIPS the leak scan even when ``git``
+        # is unresolvable on PATH -- the offline ``.git/config`` parse supplies
+        # the slug the allowlist matches. Before the fix the slug was empty, the
+        # destination None, and the gate over-blocked.
+        repo = _repo_with_remote(tmp_path / "wt", "git@gitlab.com:internalcorp/svc.git")
+        cfg = _private_repos_config(tmp_path, ["internalcorp"])
+        monkeypatch.setenv("PATH", "")  # mimic the restricted hook subprocess: no git
+        cmd = "glab mr create --source-branch x --target-branch master --fill"
+        assert publish_destination.gate_skips_destination(cmd, repo, config_path=cfg) is True
+
+    def test_flagless_create_from_linked_worktree_skips_without_git_on_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The real-world shape: the agent's cwd is a LINKED worktree whose
+        # ``.git`` is a FILE pointing at the shared common-dir config. The slug
+        # must still resolve offline so the private post is not over-blocked.
+        repo = _repo_with_remote(tmp_path / "main", "git@gitlab.com:internalcorp/svc.git")
+        _git(repo, "commit", "--allow-empty", "-m", "init")
+        linked = tmp_path / "linked"
+        _git(repo, "worktree", "add", str(linked), "-b", "feat/x")
+        cfg = _private_repos_config(tmp_path, ["internalcorp"])
+        monkeypatch.setenv("PATH", "")
+        cmd = "glab mr create --source-branch x --target-branch master --fill"
+        assert publish_destination.gate_skips_destination(cmd, linked, config_path=cfg) is True
+
+    def test_flagless_create_to_public_cwd_still_scans_without_git_on_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # MUST-FIRE (no over-relaxation): the offline slug resolution must NOT
+        # relax a genuinely-PUBLIC cwd. With the repo not in the allowlist and
+        # the probe confirming PUBLIC, the flagless create still scans.
+        repo = _repo_with_remote(tmp_path / "wt", "git@github.com:souliane/teatree.git")
+        cfg = _private_repos_config(tmp_path, ["internalcorp"])
+        monkeypatch.setattr(publish_destination, "slug_is_private", lambda slug: False)
+        monkeypatch.setenv("PATH", "")
+        cmd = "gh pr create --title x --body y"
+        assert publish_destination.gate_skips_destination(cmd, repo, config_path=cfg) is False

--- a/tests/teatree_hooks/test_publish_destination.py
+++ b/tests/teatree_hooks/test_publish_destination.py
@@ -28,7 +28,19 @@ def _git(cwd: Path, *args: str) -> None:
         cwd=cwd,
         check=True,
         capture_output=True,
-        env={**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"},
+        env={
+            **os.environ,
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            # Deterministic identity so ``git commit`` / ``git worktree add``
+            # succeed under an identity-less git: the CI container has no global
+            # user.name/email and auto-detection is disabled, so no inherited
+            # identity can be assumed.
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        },
     )
 
 


### PR DESCRIPTION
## What

The banned-terms PreToolUse gate (#1415) over-blocked a **flagless** `glab mr create` / `gh pr create` whose cwd is the user own **private** repo (a namespace declared in `[teatree] private_repos`). The gate is supposed to SKIP the public-leak scan for a post to a provably-internal destination, but the destination resolved to `None`, so it treated the post as PUBLIC and scanned/blocked it.

## Root cause

`publish_destination` resolves a flagless create command target from the cwd git remote via `slug_for_cwd` → `git.remote_url` → a bare `["git", -C, repo, "remote", "get-url", "origin"]` subprocess. The PreToolUse hook subprocess inherits a **restricted PATH** where a bare `git` is frequently unresolvable (the same restriction the live-visibility probe already augments PATH around). The subprocess raised `FileNotFoundError`, `slug_for_cwd` caught it and returned an **empty slug**, the destination resolved to `None`, and the offline `private_repos` allowlist never got a slug to match — so the gate fell through to the fail-closed PUBLIC scan and over-blocked.

Confirmed empirically: under a restricted/empty PATH, `gate_skips_destination(flagless_cmd, <oper-engineering checkout>)` returned `False` (over-block); under full PATH it returned `True`.

## Fix

Resolve the origin URL **offline-first** by parsing `.git/config` directly (new `teatree.hooks.git_config_offline`), so the slug resolves with no `git` on PATH:

- **Worktree-aware**: a linked worktree `.git` is a FILE `gitdir: ...` whose `commondir` names the shared common dir that holds the single `config` (the real-world shape — the agent cwd is a worktree).
- The **PATH-augmented `git` subprocess** (the same augmented PATH the visibility probe uses) stays as a fallback for the rare configs an offline parse cannot read.

The public-surface default is unchanged and fail-closed: a genuinely-public cwd still resolves its slug, stays PUBLIC, and scans; an unresolvable cwd still fails closed.

## Tests

- `tests/teatree_hooks/test_git_config_offline.py` — the offline parser (main checkout, linked-worktree `.git`-file via shared common dir, subdir walk-up, missing-remote/non-repo fail-safe, config-text edge cases).
- `tests/teatree_hooks/test_publish_destination.py::TestRestrictedPathCwdResolution` — a flagless create from a private cwd (dir and linked-worktree) SKIPS under an empty PATH (**red on revert**: `assert False is True` on the buggy resolver), and a public cwd still SCANS (no over-relaxation).
- Updated the stale `test_banned_terms_scanner.py` case that asserted the empty-slug over-block was "fail safe" — it now asserts offline resolution under a restricted PATH, with a separate non-repo fail-safe case.

Full surface green (772 passed for the publish/banned-terms suites), `ruff check`/`format`, `ty`, module-health, and chokepoints all pass.
