### PR TITLE
refactor(loop): drop always-true hasattr guards on overlay token getters

### DIFF
--- a/src/teatree/loop/scanner_factories.py
+++ b/src/teatree/loop/scanner_factories.py
@@ -253,8 +253,8 @@ def _slack_broadcasts_scanner_for(backend: OverlayBackends) -> SlackBroadcastsSc
     channel_ids = [cid for _name, cid in channels_pairs if cid]
     if not channel_ids:
         return None
-    glab_token = overlay.config.get_gitlab_token() if hasattr(overlay.config, "get_gitlab_token") else ""
-    github_token = overlay.config.get_github_token() if hasattr(overlay.config, "get_github_token") else ""
+    glab_token = overlay.config.get_gitlab_token()
+    github_token = overlay.config.get_github_token()
     current_gitlab_username = _own_author_identity(backend)
     return SlackBroadcastsScanner(
         backend=backend.messaging,
@@ -287,7 +287,7 @@ def _pr_sweep_scanner_for(backend: OverlayBackends, *, slack_user_id: str) -> Pr
     repos = tuple(overlay.metadata.get_followup_repos())
     if not repos:
         return None
-    github_token = overlay.config.get_github_token() if hasattr(overlay.config, "get_github_token") else ""
+    github_token = overlay.config.get_github_token()
     notifier: SlackMergeNotifier | NullMergeNotifier
     if backend.messaging is not None and slack_user_id:
         notifier = SlackMergeNotifier(backend=backend.messaging, user_id=slack_user_id)
@@ -380,7 +380,7 @@ def _codex_review_scanner_for(backend: OverlayBackends) -> CodexReviewScanner | 
     settings = _effective_settings_for_overlay(backend.name)
     if settings.mode != Mode.AUTO or settings.require_human_approval_to_merge:
         return None
-    github_token = overlay.config.get_github_token() if hasattr(overlay.config, "get_github_token") else ""
+    github_token = overlay.config.get_github_token()
     return CodexReviewScanner(
         repos=repos,
         api=GhCodexPrApi(token=github_token),

--- a/tests/teatree_core/test_overlay.py
+++ b/tests/teatree_core/test_overlay.py
@@ -232,6 +232,13 @@ class TestOverlayConfig(TestCase):
         assert config.custom_setting == "value"
         assert not hasattr(config, "class")  # reserved, skipped
 
+    def test_default_token_getters_always_defined(self) -> None:
+        # scanner_factories calls these getters unguarded (no hasattr fallback),
+        # so a default OverlayConfig MUST expose both returning a string.
+        config = OverlayConfig()
+        assert config.get_gitlab_token() == ""
+        assert config.get_github_token() == ""
+
     def test_toml_pass_key_registers_secret_reader(self) -> None:
         mock_config = MagicMock()
         mock_config.raw = {


### PR DESCRIPTION
## What

Removes 4 always-true `hasattr(overlay.config, "get_gitlab_token")` /
`hasattr(overlay.config, "get_github_token")` guards in
`src/teatree/loop/scanner_factories.py` (broadcast, PR-sweep, and
codex-review scanner factories) and calls the getters directly.

## Why redundant

- `OverlayConfig` defines `get_gitlab_token` and `get_github_token`
  unconditionally (`src/teatree/core/overlay.py`).
- `OverlayBase.config` is typed and defaulted to an `OverlayConfig`
  instance; the only registered overlay (`TeatreeOverlay`) instantiates a
  plain `OverlayConfig`. There are no `OverlayConfig` subclasses.
- The `_register_secret` `setattr` path only adds instance-level getter
  overrides — it never removes the base methods.

So `hasattr` was always true and the `else ""` fallback was dead code.

## Test

Adds `test_default_token_getters_always_defined` pinning that a default
`OverlayConfig` always exposes both getters (returning `""`), so the now
unguarded call sites stay safe against a future removal of the base
methods.

Behavior is identical. Affected scanner-factory + overlay tests pass;
the full `tests/teatree_loop/` module is green (2098 passed). ruff + ty
clean.

## Architecture pre-check

Tactical fix (dead-branch removal, no contract/FSM/Protocol change) —
skips the nine-check architecture gate per `t3:architecture-design`.
