### PR TITLE
fix(tests): use generic fixture handles in author-trust tests

### DIFF
--- a/tests/teatree_core/test_author_trust.py
+++ b/tests/teatree_core/test_author_trust.py
@@ -25,7 +25,7 @@ _PUBLIC = "souliane/teatree"
 
 def _seed_known() -> None:
     TrustedIdentity.objects.get_or_create(platform="github", handle="souliane")
-    TrustedIdentity.objects.get_or_create(platform="github", handle="adrien-oper")
+    TrustedIdentity.objects.get_or_create(platform="github", handle="trusted-bot")
     TrustedIdentity.objects.get_or_create(platform="gitlab", handle="adrien.cossa")
 
 
@@ -46,7 +46,7 @@ class TestTrustedIdentityManager(TestCase):
             ("souliane", ""),
             ("Souliane", ""),
             ("SOULIANE", "github"),
-            ("adrien-oper", "github"),
+            ("trusted-bot", "github"),
             ("adrien.cossa", "gitlab"),
             ("adrien.cossa", ""),
             ("adrien.cossa", "github"),  # platform-tolerant: handle trusted on any forge
@@ -60,7 +60,7 @@ class TestTrustedIdentityManager(TestCase):
                 assert TrustedIdentity.objects.is_trusted(handle) is False
 
     def test_trusted_handles_union_lowercased(self) -> None:
-        assert TrustedIdentity.objects.trusted_handles() == {"souliane", "adrien-oper", "adrien.cossa"}
+        assert TrustedIdentity.objects.trusted_handles() == {"souliane", "trusted-bot", "adrien.cossa"}
 
 
 class TestClassifyAuthorPublicRepo(TestCase):
@@ -70,7 +70,7 @@ class TestClassifyAuthorPublicRepo(TestCase):
     def test_seeded_identities_trusted(self) -> None:
         cases = (
             (_PUBLIC, "souliane", "github"),
-            (_PUBLIC, "adrien-oper", "github"),
+            (_PUBLIC, "trusted-bot", "github"),
             ("adrien.cossa/proj", "adrien.cossa", "gitlab"),
         )
         for slug, author, host_kind in cases:

--- a/tests/teatree_core/test_merge_execution_author_gate.py
+++ b/tests/teatree_core/test_merge_execution_author_gate.py
@@ -36,7 +36,7 @@ _MOCK_OVERLAY = {"t3-teatree": CommandOverlay()}
 
 def _seed_known() -> None:
     TrustedIdentity.objects.get_or_create(platform="github", handle="souliane")
-    TrustedIdentity.objects.get_or_create(platform="github", handle="adrien-oper")
+    TrustedIdentity.objects.get_or_create(platform="github", handle="trusted-bot")
     TrustedIdentity.objects.get_or_create(platform="gitlab", handle="adrien.cossa")
 
 
@@ -108,7 +108,7 @@ class TestPublicRepoMustAllow(TestCase):
 
     def test_second_github_login_merges(self) -> None:
         ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
-        stub = _GhStub(author="adrien-oper")
+        stub = _GhStub(author="trusted-bot")
         _run(_clear(ticket), stub, internal=False)
         ticket.refresh_from_db()
         assert ticket.state == Ticket.State.MERGED


### PR DESCRIPTION
The author-trust test fixtures seeded an overlay-specific fixture handle. This change replaces it with a generic placeholder handle (`trusted-bot`) so the BLUEPRINT §1 generic-core gate — which runs on a main push and is skipped on PR CI — passes.

Test behavior is unchanged: the same trusted/untrusted decision matrix is asserted, now with the generic fixture handle. Scope is the two author-trust test fixture files only — no production or gate logic is touched.