### PR TITLE
fix(dream): bound the whole distiller SDK turn so a stalled connect can't hang the pass

### DIFF
--- a/src/teatree/loops/dream/sdk_distiller.py
+++ b/src/teatree/loops/dream/sdk_distiller.py
@@ -9,6 +9,10 @@ of :mod:`teatree.loops.dream.engine` (#2723) is the LLM call + defensive JSON pa
 headless-runner invocation shape: ``claude_code`` preset, ``bypassPermissions``, a
 wall-clock watchdog) and raises when ``claude`` is unavailable or the turn fails, so a
 failure propagates and the pass is marked attempted-not-succeeded — never a fake success.
+The watchdog (:func:`asyncio.timeout`) bounds the WHOLE turn — the ``claude`` connect, the
+query, AND the response drain — so a stuck subprocess connect can never hang the dream pass
+forever (the prior watchdog wrapped only the response drain, leaving connect/query
+unbounded: a stalled ``claude`` spawn hung the pass with no rows, no marker, no output).
 
 :func:`_parse_clusters` tolerates surrounding prose and drops malformed entries so one bad
 element never discards a valid batch.
@@ -95,10 +99,11 @@ def _run_distiller_turn(extract: ConsolidationExtract) -> str:
     """Run one bounded headless ``claude-agent-sdk`` turn, returning its text.
 
     Reuses the headless-runner invocation shape (the ``claude_code`` preset,
-    ``bypassPermissions``, a wall-clock watchdog via :func:`asyncio.wait_for`)
+    ``bypassPermissions``, a wall-clock watchdog via :func:`asyncio.timeout`)
     for a single no-tool turn — the extract is already bounded, so the model
     only transforms text to JSON. Raises when ``claude`` is unavailable or the
-    turn fails, so the caller never reports a fake success.
+    turn fails (including :class:`TimeoutError` when the turn exceeds the
+    watchdog), so the caller never reports a fake success and never hangs.
     """
     import asyncio  # noqa: PLC0415
     import shutil  # noqa: PLC0415
@@ -124,13 +129,15 @@ async def _collect_turn(prompt: str) -> str:
         allowed_tools=[],
     )
     parts: list[str] = []
-    async with ClaudeSDKClient(options=options) as client:
+    # Bound the ENTIRE turn — connect (``__aenter__`` spawns the ``claude``
+    # subprocess), query, AND the response drain — under one watchdog. Wrapping
+    # only the drain (the prior shape) left connect/query unbounded, so a stalled
+    # ``claude`` connect hung the dream pass forever (no rows, no marker, no
+    # output) instead of failing loud; ``asyncio.timeout`` raises ``TimeoutError``
+    # on expiry and the ``async with`` tears the subprocess down on unwind.
+    async with asyncio.timeout(_DISTILL_WATCHDOG_SECONDS), ClaudeSDKClient(options=options) as client:
         await client.query(prompt)
-
-        async def _drain() -> list[object]:
-            return [message async for message in client.receive_response()]
-
-        for message in await asyncio.wait_for(_drain(), timeout=_DISTILL_WATCHDOG_SECONDS):
+        async for message in client.receive_response():
             if isinstance(message, AssistantMessage):
                 parts.extend(block.text for block in message.content if isinstance(block, TextBlock))
     return "\n".join(parts)

--- a/tests/teatree_loops/dream/test_sdk_distiller.py
+++ b/tests/teatree_loops/dream/test_sdk_distiller.py
@@ -1,7 +1,9 @@
 """Tests for the real LLM distiller seam — extract → clusters, no live LLM (#2723)."""
 
 import json
+import threading
 from pathlib import Path
+from typing import Self
 from unittest.mock import patch
 
 import claude_agent_sdk
@@ -164,3 +166,65 @@ class SdkDistillerParseTestCase(SimpleTestCase):
             clusters = sdk_distiller.sdk_distiller(empty)
         turn.assert_not_called()
         assert clusters == []
+
+
+class _HangOnConnectClient:
+    """A ``ClaudeSDKClient`` stand-in whose connect (``__aenter__``) never returns.
+
+    Models a ``claude`` subprocess that stalls during spawn/handshake — the region
+    the prior watchdog (which wrapped only the response drain) did NOT cover, so a
+    real stall there hung the dream pass forever.
+    """
+
+    def __init__(self, *, options: object = None, **_: object) -> None:
+        self._options = options
+
+    async def __aenter__(self) -> Self:
+        import asyncio  # noqa: PLC0415
+
+        await asyncio.sleep(30)  # connect stalls; only the turn watchdog can bound it
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        return None
+
+    async def query(self, prompt: str) -> None:  # pragma: no cover - connect hangs first
+        return None
+
+    async def receive_response(self) -> object:  # pragma: no cover - connect hangs first
+        return
+        yield  # unreachable
+
+
+class SdkDistillerWatchdogTestCase(SimpleTestCase):
+    def test_turn_is_time_bounded_when_sdk_connect_hangs(self) -> None:
+        # Anti-vacuous regression pin for the silent-hang bug: a stalled ``claude``
+        # CONNECT must raise TimeoutError within the watchdog, never hang the dream
+        # pass forever. RED on the pre-fix code whose watchdog wrapped only the
+        # response drain (leaving connect/query unbounded); GREEN once the watchdog
+        # bounds the WHOLE turn. Run on a thread so a regression hangs the THREAD,
+        # not the suite, and is observed as a still-alive thread.
+        captured: dict[str, BaseException | None] = {}
+
+        def _run() -> None:
+            try:
+                sdk_distiller._run_distiller_turn(_extract_with_one_snippet())
+                captured["exc"] = None
+            except BaseException as exc:  # noqa: BLE001 - record whatever the turn raised
+                captured["exc"] = exc
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch.object(sdk_distiller, "_DISTILL_WATCHDOG_SECONDS", 0.5),
+            patch.object(claude_agent_sdk, "ClaudeSDKClient", _HangOnConnectClient),
+        ):
+            thread = threading.Thread(target=_run, daemon=True)
+            thread.start()
+            thread.join(timeout=8)
+
+        assert not thread.is_alive(), (
+            "distiller SDK turn was NOT time-bounded: a stalled claude connect hangs the dream pass forever"
+        )
+        assert isinstance(captured.get("exc"), TimeoutError), (
+            f"expected the watchdog to raise TimeoutError on a stalled turn, got {captured.get('exc')!r}"
+        )


### PR DESCRIPTION
## Problem

`t3 dream run` (a real consolidation pass) could die silently — no `ConsolidatedMemory` rows, no marker, no output, terminated mid-run — so the pipeline never completed a real pass and memories piled up unpromoted (the standing "dream stale — no successful pass" warning).

## Root cause

The dream distiller makes one headless `claude-agent-sdk` turn in `_collect_turn` (`src/teatree/loops/dream/sdk_distiller.py`). The wall-clock watchdog wrapped **only the response drain** — `ClaudeSDKClient.__aenter__` (which spawns the subprocess) and `client.query()` were left unbounded. A stalled `claude` connect or query therefore had no timeout, so the whole pass hung indefinitely and was terminated before writing anything. A `faulthandler` dump caught the hang exactly at `asyncio.run(_collect_turn(...))`, with a worker thread blocked in `_do_waitpid` on the `claude` subprocess.

The distiller runs in **both** `--dry-run` and a real pass, so this is independent of dry-run vs real — a dry-run that happened to connect fast looked fine while a real pass that stalled looked dead.

## Fix

Wrap the **entire** turn — connect + query + drain — in one `asyncio.timeout`, so any stall raises `TimeoutError` within the watchdog and the pass is marked attempted-not-succeeded loudly instead of hanging. The `async with` tears the subprocess down on unwind.

## Test

Anti-vacuous pin: a stalled connect must raise `TimeoutError` within the watchdog (run on a thread so a regression hangs the thread, not the suite). RED on the pre-fix drain-only watchdog, GREEN after. Full `tests/teatree_loops/dream/` suite passes (476).
