### PR TITLE
feat(config): flip the three integer budgets to DB-first (config-unify PR4)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -75,6 +75,7 @@ from state_files import append_line, read_lines
 from subagent_skill_gate import is_file_safe, unreferenced_demand_reason
 from teatree_settings import autoload_enabled as _autoload_enabled
 from teatree_settings import teatree_bool_setting as _teatree_bool_setting
+from teatree_settings import teatree_int_setting as _teatree_int_setting
 from turn_inspect import current_turn_tool_commands
 from unknown_repo_push_gate import handle_block_unknown_repo_push
 
@@ -472,28 +473,15 @@ def _deny_circuit_breaker_enabled() -> bool:
 def _deny_circuit_breaker_threshold() -> int:
     """Consecutive-denial count K at which the breaker trips (default 3).
 
-    Best-effort read of ``[teatree] deny_circuit_breaker_threshold`` from
-    ``~/.teatree.toml``. Fails to the default on a missing/broken config or a
-    non-positive / non-int value so a malformed config can never disable the
-    breaker by setting an impossible threshold.
+    DB-first read of ``[teatree] deny_circuit_breaker_threshold`` via the shared
+    :func:`_teatree_int_setting` adapter (config-unify PR4), TOML as never-lockout
+    fallback. ``minimum=1`` keeps a non-positive / non-int value falling to the
+    default so a malformed config can never disable the breaker by setting an
+    impossible threshold.
     """
-    import tomllib  # noqa: PLC0415
-
-    config_path = Path.home() / ".teatree.toml"
-    if not config_path.is_file():
-        return _DENY_CIRCUIT_BREAKER_DEFAULT_THRESHOLD
-    try:
-        with config_path.open("rb") as f:
-            config = tomllib.load(f)
-    except Exception:  # noqa: BLE001
-        return _DENY_CIRCUIT_BREAKER_DEFAULT_THRESHOLD
-    teatree = config.get("teatree") if isinstance(config, dict) else None
-    if not isinstance(teatree, dict):
-        return _DENY_CIRCUIT_BREAKER_DEFAULT_THRESHOLD
-    value = teatree.get("deny_circuit_breaker_threshold")
-    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
-        return _DENY_CIRCUIT_BREAKER_DEFAULT_THRESHOLD
-    return value
+    return _teatree_int_setting(
+        "deny_circuit_breaker_threshold", default=_DENY_CIRCUIT_BREAKER_DEFAULT_THRESHOLD, minimum=1
+    )
 
 
 def _deny_gate_id(reason: str) -> str:
@@ -3745,57 +3733,27 @@ _DEFAULT_ORCHESTRATOR_WALL_CLOCK_SECONDS = 180
 def _orchestrator_turn_budget() -> int:
     """Soft per-turn tool-call budget for the main agent (default 25; 0 ⇒ off).
 
-    Best-effort read of ``[teatree] orchestrator_turn_budget`` from
-    ``~/.teatree.toml``, mirroring :func:`_orchestrator_bash_gate_enabled`'s
-    toml-read shape. A missing/broken config keeps the protective default; an
-    explicit ``0`` (or any non-positive value) disables the nudge with one
-    config line — never a code edit. A non-int value falls back to the default.
+    DB-first read of ``[teatree] orchestrator_turn_budget`` via the shared
+    :func:`_teatree_int_setting` adapter (config-unify PR4), TOML as never-lockout
+    fallback. ``minimum=0`` keeps an explicit ``0`` valid — it disables the nudge
+    with one config line, never a code edit — while a below-zero or non-int value
+    falls back to the default.
     """
-    import tomllib  # noqa: PLC0415
-
-    config_path = Path.home() / ".teatree.toml"
-    if not config_path.is_file():
-        return _DEFAULT_ORCHESTRATOR_TURN_BUDGET
-    try:
-        with config_path.open("rb") as f:
-            config = tomllib.load(f)
-    except Exception:  # noqa: BLE001
-        return _DEFAULT_ORCHESTRATOR_TURN_BUDGET
-    teatree = config.get("teatree") if isinstance(config, dict) else None
-    if not isinstance(teatree, dict):
-        return _DEFAULT_ORCHESTRATOR_TURN_BUDGET
-    raw = teatree.get("orchestrator_turn_budget", _DEFAULT_ORCHESTRATOR_TURN_BUDGET)
-    if not isinstance(raw, int) or isinstance(raw, bool):
-        return _DEFAULT_ORCHESTRATOR_TURN_BUDGET
-    return raw
+    return _teatree_int_setting("orchestrator_turn_budget", default=_DEFAULT_ORCHESTRATOR_TURN_BUDGET, minimum=0)
 
 
 def _orchestrator_turn_wall_clock_threshold() -> int:
     """Wall-clock responsiveness threshold for the main agent (default 180s; 0 ⇒ off).
 
-    Best-effort read of ``[teatree] orchestrator_turn_wall_clock_seconds`` from
-    ``~/.teatree.toml``, mirroring :func:`_orchestrator_turn_budget`'s toml-read
-    shape. A missing/broken config keeps the protective default; an explicit
-    ``0`` (or any non-positive value) disables the wall-clock dimension with one
-    config line. A non-int (or bool) value falls back to the default.
+    DB-first read of ``[teatree] orchestrator_turn_wall_clock_seconds`` via the
+    shared :func:`_teatree_int_setting` adapter (config-unify PR4), TOML as
+    never-lockout fallback. ``minimum=0`` keeps an explicit ``0`` valid — it
+    disables the wall-clock dimension with one config line — while a below-zero or
+    non-int value falls back to the default.
     """
-    import tomllib  # noqa: PLC0415
-
-    config_path = Path.home() / ".teatree.toml"
-    if not config_path.is_file():
-        return _DEFAULT_ORCHESTRATOR_WALL_CLOCK_SECONDS
-    try:
-        with config_path.open("rb") as f:
-            config = tomllib.load(f)
-    except Exception:  # noqa: BLE001
-        return _DEFAULT_ORCHESTRATOR_WALL_CLOCK_SECONDS
-    teatree = config.get("teatree") if isinstance(config, dict) else None
-    if not isinstance(teatree, dict):
-        return _DEFAULT_ORCHESTRATOR_WALL_CLOCK_SECONDS
-    raw = teatree.get("orchestrator_turn_wall_clock_seconds", _DEFAULT_ORCHESTRATOR_WALL_CLOCK_SECONDS)
-    if not isinstance(raw, int) or isinstance(raw, bool):
-        return _DEFAULT_ORCHESTRATOR_WALL_CLOCK_SECONDS
-    return raw
+    return _teatree_int_setting(
+        "orchestrator_turn_wall_clock_seconds", default=_DEFAULT_ORCHESTRATOR_WALL_CLOCK_SECONDS, minimum=0
+    )
 
 
 def handle_reset_turn_tool_budget(data: dict) -> None:

--- a/hooks/scripts/teatree_settings.py
+++ b/hooks/scripts/teatree_settings.py
@@ -1,4 +1,4 @@
-"""Shared ``[teatree] <flag>`` boolean-setting reader for the hook leaves (#2746).
+"""Shared ``[teatree] <flag>`` boolean + integer setting readers for the hook leaves (#2746).
 
 Extracted from ``hook_router`` so a leaf gate (e.g. ``memory_recall``) can read its
 own kill-switch WITHOUT importing ``hook_router`` — which would create a
@@ -93,6 +93,56 @@ def section_bool_setting(section: str, name: str, *, default: bool) -> bool:
 def teatree_bool_setting(name: str, *, default: bool = True) -> bool:
     """Best-effort read of a ``[teatree] <name>`` boolean flag (see :func:`section_bool_setting`)."""
     return section_bool_setting("teatree", name, default=default)
+
+
+def _cold_db_int(name: str) -> int | None:
+    """The stored GLOBAL-scope DB int for ``[teatree] <name>``; ``None`` on absence/failure.
+
+    The integer sibling of :func:`_cold_db_bool` (config-unify PR4). Lazily delegates
+    to the Django-free ``teatree.config.cold_reader`` and fails open to ``None`` on
+    ANY error. REJECTS a ``bool``: a ``bool`` subclasses ``int``, but a stored boolean
+    must never be read as a budget, so it returns ``None`` and the caller's TOML
+    fallback / default fires instead (never-lockout).
+    """
+    try:
+        from teatree.config.cold_reader import read_setting  # noqa: PLC0415
+
+        value = read_setting(name, scope=_GLOBAL_SCOPE)
+    except Exception:  # noqa: BLE001
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value
+
+
+def section_int_setting(section: str, name: str, *, default: int, minimum: int | None = None) -> int:
+    """DB-first, TOML-fallback read of a ``[section] <name>`` integer budget (config-unify PR4).
+
+    The integer sibling of :func:`section_bool_setting`. Resolves from the DB
+    ``ConfigSetting`` store FIRST — ``section`` ``teatree`` maps to the GLOBAL scope,
+    the only section the cold budgets use — falling back to the ``[section] <name>``
+    TOML value, then *default*. Only a real int (never a bool) is honoured at either
+    tier. A value below *minimum* is malformed and degrades to *default* so the bound
+    it encodes can't be mistyped away (a ``deny_circuit_breaker_threshold`` of ``0``
+    never disables the breaker); ``minimum=0`` keeps ``0`` valid so an explicit "off"
+    budget survives. A missing/unreadable DB row falls through to the SAME
+    TOML-or-default verdict the inline ``tomllib`` reader produced before the flip.
+    """
+    if section == "teatree":
+        db_value = _cold_db_int(name)
+        if db_value is not None:
+            return db_value if minimum is None or db_value >= minimum else default
+    table = _load_home_toml().get(section)
+    if isinstance(table, dict):
+        value = table.get(name)
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value if minimum is None or value >= minimum else default
+    return default
+
+
+def teatree_int_setting(name: str, *, default: int, minimum: int | None = None) -> int:
+    """Best-effort read of a ``[teatree] <name>`` integer budget (see :func:`section_int_setting`)."""
+    return section_int_setting("teatree", name, default=default, minimum=minimum)
 
 
 _AUTOLOAD_TRUTHY: frozenset[str] = frozenset({"1", "true", "yes", "on"})

--- a/tests/config/test_cold_hook_settings.py
+++ b/tests/config/test_cold_hook_settings.py
@@ -2,19 +2,19 @@
 """``COLD_HOOK_SETTINGS`` registers every pre-Django cold-hook setting (config-unify PR2).
 
 The no-silent-drop fitness guard. The cold hook layer reads a set of global
-``[teatree]`` keys straight from ``~/.teatree.toml`` before any Django bootstrap —
-gate kill-switches via ``teatree_settings.teatree_bool_setting`` and a few bespoke
-``tomllib`` integer budgets in ``hook_router``. The TOML->DB import used to walk
-only ``OVERLAY_OVERRIDABLE_SETTINGS``, so these keys were dropped on import and
-would reset to their in-code defaults the moment the cold reader is flipped onto
-the DB store. These tests MECHANICALLY enumerate the live cold-read sites and
-assert each key has a registered home, so a new hook gate flag added without a
+``[teatree]`` keys before any Django bootstrap — gate kill-switches via
+``teatree_settings.teatree_bool_setting`` and the integer budgets in ``hook_router``
+via ``teatree_settings.teatree_int_setting`` (config-unify PR3/PR4 flipped both onto
+the DB store, TOML-fallback). The TOML->DB import used to walk only
+``OVERLAY_OVERRIDABLE_SETTINGS``, so these keys were dropped on import and would
+reset to their in-code defaults the moment the cold reader is flipped onto the DB
+store. These tests MECHANICALLY enumerate the live cold-read sites and assert each
+key has a registered home, so a new hook gate flag or budget added without a
 ``COLD_HOOK_SETTINGS`` entry turns the suite red — the guard against the lossy
 cutover recurring.
 """
 
 import dataclasses
-import itertools
 import re
 from pathlib import Path
 
@@ -33,7 +33,6 @@ from teatree.config.settings import _parse_strict_bool, _parse_strict_int
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _HOOK_SCRIPTS = _REPO_ROOT / "hooks" / "scripts"
-_HOOK_ROUTER = _HOOK_SCRIPTS / "hook_router.py"
 
 # ``teatree_bool_setting("x")`` / ``_teatree_bool_setting("x")`` — the shared cold
 # ``[teatree] <flag>`` boolean adapter. A call captures the flag's exact key.
@@ -45,45 +44,37 @@ _BOOL_FLAG_DEFAULT = re.compile(
     r"(?:_)?teatree_bool_setting\(\s*[\"']([a-z0-9_]+)[\"']\s*,\s*default=(True|False)\s*\)",
 )
 
-# The bespoke ``[teatree] <key>`` integer budgets ``hook_router`` reads directly
-# with ``tomllib`` (not through the bool adapter), via ``teatree.get("<key>")`` where
-# ``teatree`` is the parsed ``[teatree]`` table. Restricted to reads inside a ``->
-# int`` reader so a sibling str/table read (``slack_user_id``, ``speak``) is never
-# mistaken for a budget. Each match captures the budget key + its reader function.
-_TEATREE_INT_READ = re.compile(r"""teatree\.get\(\s*["']([a-z0-9_]+)["']""")
-_INT_READER_SIG = re.compile(r"^def \w+\([^\n]*\)\s*->\s*int:\s*$")
-# The first ``return _UPPER_CONST`` in a reader names its in-code default constant.
-_RETURN_DEFAULT_CONST = re.compile(r"^\s*return\s+(_[A-Z][A-Z0-9_]*)\s*$", re.MULTILINE)
+# The ``[teatree] <key>`` integer budgets ``hook_router`` reads cold through the
+# shared ``teatree_int_setting`` / ``section_int_setting`` adapter (config-unify PR4,
+# replacing the old inline ``teatree.get(...)`` ``tomllib`` reads). ``_KEY`` regexes
+# capture the budget key from either call shape; ``_DEFAULT`` regexes also capture the
+# ``default=`` constant so the registered default can be pinned to the hook's own
+# ``_DEFAULT_*`` fallback (a drift would seed the wrong DB default).
+_INT_BUDGET_KEY = re.compile(r"(?:_)?teatree_int_setting\(\s*[\"']([a-z0-9_]+)[\"']")
+_SECTION_INT_BUDGET_KEY = re.compile(r"(?:_)?section_int_setting\(\s*[\"']teatree[\"']\s*,\s*[\"']([a-z0-9_]+)[\"']")
+_INT_BUDGET_DEFAULT = re.compile(
+    r"(?:_)?teatree_int_setting\(\s*[\"']([a-z0-9_]+)[\"']\s*,\s*default=(_[A-Z][A-Z0-9_]*)",
+)
+_SECTION_INT_BUDGET_DEFAULT = re.compile(
+    r"(?:_)?section_int_setting\(\s*[\"']teatree[\"']\s*,\s*[\"']([a-z0-9_]+)[\"']\s*,\s*default=(_[A-Z][A-Z0-9_]*)",
+)
 # Module-level ``_UPPER_CONST = <int>`` assignments (the default constants).
 _MODULE_INT_CONST = re.compile(r"^(_[A-Z][A-Z0-9_]*)\s*=\s*(-?\d+)\b", re.MULTILINE)
 
 
-def _top_level_def_bodies(src: str) -> dict[str, str]:
-    """Map each top-level ``def <name>`` to its source body (its def line up to the next)."""
-    boundaries = [m.start() for m in re.finditer(r"^(?:def |class )", src, re.MULTILINE)]
-    boundaries.append(len(src))
-    bodies: dict[str, str] = {}
-    for start, end in itertools.pairwise(boundaries):
-        chunk = src[start:end]
-        match = re.match(r"def (\w+)\(", chunk)
-        if match:
-            bodies[match.group(1)] = chunk
-    return bodies
+def _enumerate_cold_int_budgets() -> set[str]:
+    """Every ``[teatree]`` integer budget read cold via the int adapter, across the hook leaves."""
+    keys: set[str] = set()
+    for script in _HOOK_SCRIPTS.glob("*.py"):
+        text = script.read_text(encoding="utf-8")
+        keys.update(_INT_BUDGET_KEY.findall(text))
+        keys.update(_SECTION_INT_BUDGET_KEY.findall(text))
+    return keys
 
 
-def _enumerate_cold_int_reads(src: str) -> dict[str, str]:
-    """Every ``[teatree]`` budget read via ``teatree.get(...)`` inside a ``-> int`` reader.
-
-    Returns ``{key: reader_function_name}`` so the default-drift check below can
-    locate each budget's own reader and its returned default constant.
-    """
-    reads: dict[str, str] = {}
-    for name, body in _top_level_def_bodies(src).items():
-        if not _INT_READER_SIG.match(body.splitlines()[0]):
-            continue
-        for key in _TEATREE_INT_READ.findall(body):
-            reads[key] = name
-    return reads
+def _registered_int_keys() -> set[str]:
+    """The COLD_HOOK_SETTINGS keys whose default is an int (the budgets, not the bool gates)."""
+    return {k for k, s in COLD_HOOK_SETTINGS.items() if isinstance(s.default, int) and not isinstance(s.default, bool)}
 
 
 def _toml_home_user_settings_fields() -> set[str]:
@@ -143,23 +134,13 @@ def test_cold_bool_flag_defaults_match_the_hook_default() -> None:
     assert len(registered) >= 10
 
 
-def test_bespoke_int_budgets_are_registered_with_a_matching_default() -> None:
-    # The mechanized int-side no-silent-drop guard (#2794 review MED). Every
-    # ``[teatree]`` integer budget hook_router reads cold (via ``teatree.get(...)``
-    # in a ``-> int`` reader), once the bool-adapter keys and recognised non-cold
-    # homes are subtracted, MUST be registered in COLD_HOOK_SETTINGS AND carry the
-    # SAME default the hook's own ``_DEFAULT_*`` constant uses — so a future budget
-    # added without a registration, or a drifted default, turns this red rather than
-    # silently resetting on the reader flip. No hand-frozen allowlist.
-    router_src = _HOOK_ROUTER.read_text(encoding="utf-8")
-    int_reads = _enumerate_cold_int_reads(router_src)
-    const_values = {name: int(value) for name, value in _MODULE_INT_CONST.findall(router_src)}
-    bodies = _top_level_def_bodies(router_src)
-
-    recognised_non_cold = (
-        set(OVERLAY_OVERRIDABLE_SETTINGS) | set(TOML_OVERLAY_OVERRIDABLE_SETTINGS) | _toml_home_user_settings_fields()
-    )
-    bespoke_int_budgets = set(int_reads) - _enumerate_cold_bool_flags() - recognised_non_cold
+def test_int_budget_cold_reads_equal_the_registered_int_keys() -> None:
+    # The mechanized int-side no-silent-drop guard (teatree task #25, #2794 review
+    # MED). The live ``teatree_int_setting`` / ``section_int_setting`` cold-read sites
+    # must EXACTLY equal the int keys registered in COLD_HOOK_SETTINGS: a new budget
+    # read added without a registration (the import would drop it) OR a registered int
+    # key with no live reader turns this red. No hand-frozen allowlist.
+    budgets = _enumerate_cold_int_budgets()
 
     # Anti-vacuity: the three known budgets must surface, so a broken regex / moved
     # reader cannot make the guard pass against an empty enumeration.
@@ -167,13 +148,25 @@ def test_bespoke_int_budgets_are_registered_with_a_matching_default() -> None:
         "deny_circuit_breaker_threshold",
         "orchestrator_turn_budget",
         "orchestrator_turn_wall_clock_seconds",
-    } <= bespoke_int_budgets
+    } <= budgets
 
-    for key in bespoke_int_budgets:
-        assert key in COLD_HOOK_SETTINGS, f"bespoke cold-hook int {key!r} unregistered — the import would drop it"
-        default_const = _RETURN_DEFAULT_CONST.search(bodies[int_reads[key]])
-        assert default_const is not None, f"no ``_DEFAULT_*`` return found in the reader for {key!r}"
-        hook_default = const_values[default_const.group(1)]
+    assert budgets == _registered_int_keys()
+
+
+def test_int_budget_defaults_match_the_registered_default() -> None:
+    # Pin each budget's ``default=`` constant to the registered COLD_HOOK_SETTINGS
+    # default so the DB-seeded default can never drift from the hook's own fallback.
+    const_values: dict[str, int] = {}
+    declared: dict[str, str] = {}
+    for script in _HOOK_SCRIPTS.glob("*.py"):
+        text = script.read_text(encoding="utf-8")
+        const_values.update({name: int(value) for name, value in _MODULE_INT_CONST.findall(text)})
+        declared.update(_INT_BUDGET_DEFAULT.findall(text))
+        declared.update(_SECTION_INT_BUDGET_DEFAULT.findall(text))
+
+    assert set(declared) == _registered_int_keys(), "every registered int budget must expose a resolvable default="
+    for key, const in declared.items():
+        hook_default = const_values[const]
         registered = COLD_HOOK_SETTINGS[key].default
         assert registered == hook_default, (
             f"registered default for {key!r} ({registered}) drifted from the hook default {hook_default}"

--- a/tests/config/test_teatree_settings_int_flip.py
+++ b/tests/config/test_teatree_settings_int_flip.py
@@ -1,0 +1,227 @@
+# test-path: cross-cutting
+"""The cold-hook integer budgets resolve from the DB store, TOML-fallback (config-unify PR4).
+
+The integer sibling of ``test_teatree_settings_db_flip``. PR4 flips the three
+``hook_router`` budgets — the deny-circuit-breaker threshold and the orchestrator
+turn / wall-clock budgets — off their inline ``tomllib`` reads and onto the new
+``teatree_settings.teatree_int_setting`` adapter, which resolves from the canonical
+``ConfigSetting`` store FIRST (seeded by ``t3 setup``), falls back to the
+``[teatree]`` TOML value, then the per-budget default.
+
+These integration tests build a REAL ``teatree_config_setting`` sqlite file (the
+exact Django-migration shape, JSON-encoded values) and read it back through the
+LIVE ``hook_router`` reader functions — the actual repointed consumers — so the
+DB-precedence, never-lockout TOML fallback, bool-rejection, and minimum/zero
+semantics are exercised end to end against real sqlite and a real ``~/.teatree.toml``.
+"""
+
+import json
+import sqlite3
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+
+import hooks.scripts.hook_router as router
+from teatree.config import cold_reader
+
+Row = tuple[str, str, object]
+
+
+class Budget(NamedTuple):
+    key: str
+    reader_attr: str
+    default: int
+    minimum: int
+
+    @property
+    def reader(self) -> Callable[[], int]:
+        return getattr(router, self.reader_attr)
+
+
+_BUDGETS: list[Budget] = [
+    Budget("deny_circuit_breaker_threshold", "_deny_circuit_breaker_threshold", 3, 1),
+    Budget("orchestrator_turn_budget", "_orchestrator_turn_budget", 25, 0),
+    Budget("orchestrator_turn_wall_clock_seconds", "_orchestrator_turn_wall_clock_threshold", 180, 0),
+]
+
+
+def _make_config_db(path: Path, rows: Iterable[Row]) -> None:
+    """Build a real ``teatree_config_setting`` DB matching the Django migration."""
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            "CREATE TABLE teatree_config_setting ("
+            "id INTEGER PRIMARY KEY, scope TEXT NOT NULL DEFAULT '', "
+            "key TEXT NOT NULL, value TEXT NOT NULL)"
+        )
+        conn.executemany(
+            "INSERT INTO teatree_config_setting (scope, key, value) VALUES (?, ?, ?)",
+            [(scope, key, json.dumps(value)) for scope, key, value in rows],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """A clean ``$HOME`` so a TOML fallback only fires when the test plants the file.
+
+    Clearing ``T3_CONFIG_DB`` / ``XDG_DATA_HOME`` means the cold reader resolves
+    under the isolated ``$HOME`` and never reads a host DB, so DB-precedence
+    assertions are not masked by stray host config.
+    """
+    home_dir = tmp_path / "home"
+    home_dir.mkdir(exist_ok=True)
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.delenv("T3_CONFIG_DB", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    return home_dir
+
+
+def _seed_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, rows: Iterable[Row]) -> None:
+    db = tmp_path / "db.sqlite3"
+    _make_config_db(db, rows)
+    monkeypatch.setenv("T3_CONFIG_DB", str(db))
+
+
+def _write_teatree_toml(home: Path, body: str) -> None:
+    (home / ".teatree.toml").write_text(f"[teatree]\n{body}", encoding="utf-8")
+
+
+class TestBudgetReadersResolveDbFirst:
+    """Each repointed ``hook_router`` budget reader is DB-first, TOML-fallback, default."""
+
+    @pytest.mark.parametrize("budget", _BUDGETS, ids=lambda b: b.key)
+    def test_seeded_db_row_is_honoured(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, budget: Budget
+    ) -> None:
+        # (a) a seeded DB row wins over the in-code default.
+        _seed_db(monkeypatch, tmp_path, [("", budget.key, 7)])
+        assert budget.reader() == 7
+
+    @pytest.mark.parametrize("budget", _BUDGETS, ids=lambda b: b.key)
+    def test_toml_value_honoured_when_db_absent(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, budget: Budget
+    ) -> None:
+        # (b) never-lockout: a present DB with no row for the budget falls back to
+        # the ``[teatree]`` TOML value — the fail-open path that keeps a configured
+        # budget working without a seeded row.
+        _seed_db(monkeypatch, tmp_path, [("", "some_other_key", 1)])
+        _write_teatree_toml(home, f"{budget.key} = 9\n")
+        assert budget.reader() == 9
+
+    @pytest.mark.parametrize("budget", _BUDGETS, ids=lambda b: b.key)
+    def test_neither_db_nor_toml_returns_default(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, budget: Budget
+    ) -> None:
+        # (c) no DB file and no TOML → the in-code default.
+        assert budget.reader() == budget.default
+
+    @pytest.mark.parametrize("budget", _BUDGETS, ids=lambda b: b.key)
+    def test_bool_db_value_is_rejected_and_falls_back(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, budget: Budget
+    ) -> None:
+        # (d) a stored bool is NOT a budget — a bool subclasses int but must never be
+        # read as one, so it falls through to the TOML value (here, present).
+        _seed_db(monkeypatch, tmp_path, [("", budget.key, True)])
+        _write_teatree_toml(home, f"{budget.key} = 11\n")
+        assert budget.reader() == 11
+
+    @pytest.mark.parametrize("budget", _BUDGETS, ids=lambda b: b.key)
+    def test_non_int_db_value_is_rejected_and_falls_back_to_default(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, budget: Budget
+    ) -> None:
+        # (d) a JSON string in the DB is not an int → rejected → default (no TOML).
+        _seed_db(monkeypatch, tmp_path, [("", budget.key, "13")])
+        assert budget.reader() == budget.default
+
+    @pytest.mark.parametrize("budget", _BUDGETS, ids=lambda b: b.key)
+    def test_zero_survives_only_when_minimum_is_zero(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, budget: Budget
+    ) -> None:
+        # (e) ``0`` is an explicit "off" for the orchestrator budgets (minimum=0) and
+        # MUST survive; for the deny-circuit-breaker threshold (minimum=1) a value
+        # ``< 1`` is malformed and falls back to the default.
+        _seed_db(monkeypatch, tmp_path, [("", budget.key, 0)])
+        expected = 0 if budget.minimum == 0 else budget.default
+        assert budget.reader() == expected
+
+    @pytest.mark.parametrize("budget", _BUDGETS, ids=lambda b: b.key)
+    def test_below_minimum_value_falls_back_to_default(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, budget: Budget
+    ) -> None:
+        # (e) a value strictly below the minimum is always rejected to the default —
+        # a negative budget can never be mistyped into disabling the guard.
+        _seed_db(monkeypatch, tmp_path, [("", budget.key, budget.minimum - 1)])
+        assert budget.reader() == budget.default
+
+
+class TestIntHelperSemantics:
+    """Helper-level behaviour the per-reader parametrization does not cover."""
+
+    def test_db_value_wins_over_a_conflicting_toml_value(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from hooks.scripts import teatree_settings  # noqa: PLC0415
+
+        _seed_db(monkeypatch, tmp_path, [("", "orchestrator_turn_budget", 40)])
+        _write_teatree_toml(home, "orchestrator_turn_budget = 5\n")
+        assert teatree_settings.teatree_int_setting("orchestrator_turn_budget", default=25, minimum=0) == 40
+
+    def test_quoted_numeric_string_in_toml_is_rejected(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from hooks.scripts import teatree_settings  # noqa: PLC0415
+
+        _write_teatree_toml(home, 'orchestrator_turn_budget = "5"\n')
+        assert teatree_settings.teatree_int_setting("orchestrator_turn_budget", default=25, minimum=0) == 25
+
+    def test_non_teatree_section_reads_its_toml_value_not_the_global_db_row(
+        self, home: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from hooks.scripts import teatree_settings  # noqa: PLC0415
+
+        _seed_db(monkeypatch, tmp_path, [("", "budget", 99)])  # a GLOBAL row that must NOT leak in
+        (home / ".teatree.toml").write_text("[mysection]\nbudget = 7\n", encoding="utf-8")
+        assert teatree_settings.section_int_setting("mysection", "budget", default=3, minimum=0) == 7
+
+    def test_non_teatree_section_missing_returns_default(self, home: Path) -> None:
+        from hooks.scripts import teatree_settings  # noqa: PLC0415
+
+        assert teatree_settings.section_int_setting("mysection", "budget", default=3) == 3
+
+    def test_no_minimum_allows_any_int(self, home: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        from hooks.scripts import teatree_settings  # noqa: PLC0415
+
+        _seed_db(monkeypatch, tmp_path, [("", "budget", -42)])
+        assert teatree_settings.teatree_int_setting("budget", default=3) == -42
+
+
+class TestDelegatesToColdReader:
+    """Anti-vacuous: patching ``cold_reader.read_setting`` flips the int reader output."""
+
+    def test_reader_routes_through_cold_reader(self, home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from hooks.scripts import teatree_settings  # noqa: PLC0415
+
+        seen: list[tuple[str, str]] = []
+
+        def _fake(name: str, *, scope: str = "", **_: object) -> object:
+            seen.append((name, scope))
+            return 17
+
+        monkeypatch.setattr(cold_reader, "read_setting", _fake)
+        assert teatree_settings.teatree_int_setting("orchestrator_turn_budget", default=25, minimum=0) == 17
+        assert ("orchestrator_turn_budget", "") in seen
+
+    def test_reader_fails_open_when_the_db_layer_raises(self, home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from hooks.scripts import teatree_settings  # noqa: PLC0415
+
+        def _boom(*_args: object, **_kwargs: object) -> object:
+            msg = "db layer exploded"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(cold_reader, "read_setting", _boom)
+        assert teatree_settings.teatree_int_setting("orchestrator_turn_budget", default=25, minimum=0) == 25


### PR DESCRIPTION
The deny-circuit-breaker threshold + orchestrator turn-budget + wall-clock budget now read the canonical `ConfigSetting` DB first via a new `teatree_int_setting` helper that mirrors the PR3 bool path (`_cold_db_int` / `section_int_setting` / `teatree_int_setting`), with TOML kept as the never-lockout fallback. The three `hook_router` readers are repointed onto the helper and their inline `tomllib` imports are dropped.

Each budget's semantics are preserved via the `minimum` bound: the deny threshold falls back to its default below `1`, while the orchestrator budgets keep `0` valid as an explicit off.

The per-overlay identity/safety/discovery reads (self-DM destinations, protected branches, mcp managed signals) stay TOML by design and are untouched.

Extends the no-silent-drop fitness test so the live `teatree_int_setting` / `section_int_setting` cold-read sites equal the registered integer keys in `COLD_HOOK_SETTINGS`, folding in the int-side fitness guard.

## Architecture pre-check
Tactical reader-repoint within `hooks/scripts/` (no `src/teatree/{cli,core,agents}`, no FSM boundary, no Protocol or entry-point change), mirroring the merged PR3 bool path — the nine-check gate does not fire. Behaviour-preserving: the readers keep their defaults/min semantics; only the resolution tier (DB-first, TOML-fallback) changes. Test surface: `tests/config/test_teatree_settings_int_flip.py` (integration, real sqlite + real TOML) plus the extended `tests/config/test_cold_hook_settings.py` fitness guard.
