### PR TITLE
docs(config): confirm check_updates stays TOML-home after #1775; document the carve-out (config-unify PR5)

### DIFF
--- a/src/teatree/config/homes.py
+++ b/src/teatree/config/homes.py
@@ -14,18 +14,25 @@ config_setting import``.
 ``ConfigSetting`` row for a TOML-home key is ignored on read; ``config_setting
 set`` refuses to write one.
 
-The TOML-home set is the irreducible carve-out: settings a NON-DJANGO or
-PRE-DJANGO reader needs (so the DB is unreachable — ``orchestrator_bash_gate_enabled``,
-``speak``, ``handover_mirror_path``, ``check_updates``, ``autoload`` (the cold
-SessionStart / UserPromptSubmit hooks read it pre-Django to decide engagement),
-and ``statusline_chain``, which the bash statusline hook reads straight from
-``~/.teatree.toml`` and can never reach the DB), path/infra bootstrap that the settings module itself needs
-(``workspace_dir``, ``worktrees_dir``, ``timezone``,
-``privacy``), and nested structured tables that have no flat scalar shape for a
-``ConfigSetting`` row (``mr_reminder``). Every other field is DB-home — it resolves
-from the ``ConfigSetting`` store + env, never from a ``[teatree]`` /
-``[overlays.<name>]`` TOML value (which is ignored on read and the resolver warns
-on).
+The TOML-home set is the irreducible carve-out — a field stays here ONLY when a
+NON-DJANGO / PRE-DJANGO reader needs it (the DB is then unreachable), it bootstraps
+path/infra the settings module itself needs, or it is a nested table with no flat
+``ConfigSetting`` shape. The pre-Django readers: ``orchestrator_bash_gate_enabled``
+(the GATE_KEY bash self-rescue), ``speak`` (the Stop hook re-reads ``[teatree.speak]``
+with tomllib), ``handover_mirror_path`` (the SessionStart bootstrap path read when the
+DB is unreachable), ``autoload`` (the cold SessionStart / UserPromptSubmit hooks read
+``[teatree] autoload`` pre-Django to decide engagement, #256), ``statusline_chain`` (the
+bash statusline hook reads it straight from ``~/.teatree.toml`` and can never reach the
+DB), and ``check_updates`` (its sole reader ``check_for_updates`` runs only on pre-Django
+CLI paths — the root callback in the parent ``t3`` process on every invocation, and the
+plain-Typer ``t3 config check-update`` — so a DB-home value would fail safe to the default
+there and a stored ``check_updates=false`` would be silently ignored; config-unify PR5
+audit). The path/infra bootstrap the settings module needs to even open the DB:
+``worktrees_dir``, ``timezone``, ``privacy``. The nested structured table with no flat
+scalar shape: ``mr_reminder``. Every other field is DB-home — it resolves from the
+``ConfigSetting`` store + env, never from a ``[teatree]`` / ``[overlays.<name>]`` TOML
+value (which is ignored on read and the resolver warns on). ``workspace_dir`` is DB-home
+(per-overlay overridable), NOT in this carve-out.
 
 :data:`DERIVED_FIELDS` is the one value the resolver COMPUTES rather than
 reads (``notify_on_behalf`` derived by the autonomy collapse); it has
@@ -52,15 +59,20 @@ DERIVED_FIELDS: frozenset[str] = frozenset({"notify_on_behalf"})
 
 # The irreducible TOML-home carve-out (exactly these ten):
 # - non-Django / pre-Django readers (read via tomllib or a bash grep, no DB):
-#   ``orchestrator_bash_gate_enabled``, ``speak`` (the Stop hook re-reads the
-#   ``[teatree.speak]`` sub-table with tomllib — it cannot reach the Django DB),
-#   ``handover_mirror_path`` (the SessionStart bootstrap path read precisely when
-#   the DB is unreachable), ``check_updates``, ``autoload`` (the cold SessionStart
-#   / UserPromptSubmit hooks read ``[teatree] autoload`` with tomllib to decide
-#   default-off engagement, before any Django bootstrap — #256), and
+#   ``orchestrator_bash_gate_enabled`` (the GATE_KEY bash self-rescue), ``speak``
+#   (the Stop hook re-reads the ``[teatree.speak]`` sub-table with tomllib — it
+#   cannot reach the Django DB), ``handover_mirror_path`` (the SessionStart
+#   bootstrap path read precisely when the DB is unreachable), ``autoload`` (the
+#   cold SessionStart / UserPromptSubmit hooks read ``[teatree] autoload`` with
+#   tomllib to decide default-off engagement, before any Django bootstrap — #256),
 #   ``statusline_chain`` (the bash statusline hook reads ``[teatree]
 #   statusline_chain`` straight from ``~/.teatree.toml`` — it has no path to the
-#   Django DB, so a DB row for it would be silently unread)
+#   Django DB, so a DB row for it would be silently unread), and ``check_updates``
+#   (its sole reader ``check_for_updates`` runs only on pre-Django CLI paths — the
+#   root callback in the parent ``t3`` process on every invocation, and the
+#   plain-Typer ``t3 config check-update``; neither bootstraps Django, so a
+#   DB-home value would fail safe to the default and a stored ``check_updates=false``
+#   would be silently ignored — config-unify PR5 audit confirmed the move is unsafe)
 # - path / infra bootstrap the settings module needs to even open the DB:
 #   ``worktrees_dir``, ``timezone``, ``privacy``
 # - nested structured table with no flat ConfigSetting shape: ``mr_reminder``

--- a/tests/config/test_check_for_updates.py
+++ b/tests/config/test_check_for_updates.py
@@ -36,6 +36,22 @@ class TestCheckForUpdates:
 
         assert check_for_updates(force=False) is None
 
+    def test_disabled_check_honoured_pre_django_without_network(self, config_file: Path) -> None:
+        """A TOML ``check_updates=false`` is honoured with no Django/DB and no network.
+
+        config-unify PR5 audit: ``check_for_updates`` resolves ``check_updates``
+        from ``load_config().user`` (the TOML file tier), so the opt-out holds on
+        the pre-Django CLI paths that are its only readers. This guard is
+        anti-vacuous against a DB-home move of ``check_updates``: dropping the
+        loader field-build would resolve ``check_updates`` to its ``True`` default
+        here, skip the early return, and reach the network call — turning this red.
+        """
+        _write_check_updates_toml(config_file, enabled=False)
+
+        with patch("teatree.update_check.run_allowed_to_fail") as network:
+            assert check_for_updates(force=False) is None
+        network.assert_not_called()
+
     def test_cached_result_returned_when_fresh(
         self,
         tmp_path: Path,

--- a/tests/config/test_settings_home_partition.py
+++ b/tests/config/test_settings_home_partition.py
@@ -77,6 +77,18 @@ def test_autoload_is_toml_home_not_db() -> None:
     assert SETTING_HOMES["autoload"] is SettingHome.TOML
 
 
+def test_check_updates_is_toml_home_not_db() -> None:
+    # config-unify PR5 audit: ``check_updates``'s sole reader ``check_for_updates``
+    # runs only on PRE-DJANGO paths — the CLI root callback (parent ``t3`` process,
+    # every invocation; Django subcommands subprocess to manage.py) and the
+    # plain-Typer ``t3 config check-update``, neither of which bootstraps Django. A
+    # DB-home read there fails safe to the default, so a stored ``check_updates=false``
+    # would be silently ignored and the banner would reappear. It must stay TOML-home.
+    # The behavioural guard is ``test_check_for_updates`` §
+    # ``test_disabled_check_honoured_pre_django_without_network``.
+    assert SETTING_HOMES["check_updates"] is SettingHome.TOML
+
+
 def test_derived_fields_are_exactly_the_one_computed_value() -> None:
     assert frozenset({"notify_on_behalf"}) == DERIVED_FIELDS
 


### PR DESCRIPTION
Verification PR for config-unify PR5.

PR5 asked whether `check_updates` — the one warm-looking residual `_TOML_HOME` field after the #1775 partition — could move to DB-home, shrinking the carve-out to nine. The ground-truth audit of its read sites found the move unsafe, so this PR confirms and documents the carve-out instead of moving the field. No behaviour change.

**Why the move is unsafe.** `check_updates`'s sole reader, `config.check_for_updates`, runs only on pre-Django CLI paths: the root callback in the parent `t3` process (every invocation — Django subcommands subprocess to manage.py) and the plain-Typer `t3 config check-update`. Neither bootstraps Django, so the DB-home resolver fails safe to the dataclass default there; a stored `check_updates=false` would be silently ignored and the update banner would reappear on every command. The carve-out stays the irreducible ten.

**Changes.**
- `homes.py`: tighten the `_TOML_HOME` docstring with a per-field reason for each carve-out field — `check_updates` gets its own reason instead of the ambiguous grouping next to `autoload`, and a stale `workspace_dir` reference is dropped (it is DB-home).
- Two anti-vacuous guards pinning the conclusion: the partition keeps `check_updates` TOML-home, and `check_for_updates` honours a TOML `check_updates=false` with no Django/DB read and no network call. Both go red under a simulated DB-home move.
