### PR TITLE
fix: stabilise the url_title_fetcher deferred import vs ruff autofix

### DIFF
--- a/src/teatree/url_title_fetcher.py
+++ b/src/teatree/url_title_fetcher.py
@@ -18,6 +18,7 @@ import shutil
 from collections.abc import Callable
 from pathlib import Path
 
+from teatree.config import get_effective_settings
 from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to_fail
 
 CACHE_FILE = Path.home() / ".cache" / "teatree" / "url-titles.json"
@@ -108,8 +109,6 @@ def fetch_titles(prompt: str) -> list[str]:
     pre-Django, so there the DB tier is skipped (fail-safe) and env + the
     dataclass default govern — identical to the legacy behaviour.
     """
-    from teatree.config import get_effective_settings  # noqa: PLC0415
-
     if not get_effective_settings().hook_fetch_titles:
         return []
     jobs = _extract_jobs(prompt)

--- a/tests/test_url_title_fetcher.py
+++ b/tests/test_url_title_fetcher.py
@@ -9,6 +9,7 @@ import pytest
 from django.test import TestCase
 
 from teatree import url_title_fetcher as utf
+from teatree.config import get_effective_settings
 from teatree.core.models import ConfigSetting
 
 
@@ -128,6 +129,13 @@ class TestFetchTitlesDbHome(TestCase):
     def test_enabled_by_default_with_no_db_row(self) -> None:
         self.cache_path.write_text(json.dumps({"gitlab:g/r:merge_requests:1": "Cached title"}))
         assert utf.fetch_titles("https://gitlab.com/g/r/-/merge_requests/1") == ["Cached title"]
+
+
+class TestModuleScopeConfigImport:
+    def test_get_effective_settings_imported_at_module_scope(self):
+        # The deferred function-scoped form required a PLC0415 suppression that ruff
+        # autofix could strip then re-flag; importing at module scope removes that.
+        assert utf.get_effective_settings is get_effective_settings
 
 
 class TestEnrichPrompt:


### PR DESCRIPTION
## What

`fetch_titles` imported `get_effective_settings` from `teatree.config` at
function scope, which required a `PLC0415` (import-outside-top-level)
suppression. Under ruff autofix that valid suppression could be stripped and
`PLC0415` then re-flagged, confusing agents and risking a pre-commit that
removes the suppression then fails.

This hoists the import to module top-level, removing `PLC0415` and the
suppression entirely. Behavior is unchanged.

## Why hoisting is safe

- **No circular import** — `teatree.config` does not import `url_title_fetcher`
  (verified: importing `teatree.config` loads zero `url_title` modules).
- **No Django trigger** — importing `teatree.config` leaves Django unconfigured;
  `get_effective_settings` is fail-safe when Django is not configured.
- **Pre-Django hook path preserved** — the `UserPromptSubmit` hook imports this
  module (as `lib.url_title_fetcher`, a symlink) before Django is set up; the
  module still imports and `enrich_prompt` still runs with Django unconfigured.
- Matches the majority convention in the codebase, where `get_effective_settings`
  is imported at module top-level.

A regression test pins the module-scope import so the fragile deferred form
cannot return.

## Architecture pre-check

Tactical fix — a single-call-site import relocation in one leaf module; the
nine-check gate does not apply.

- **Component boundaries / dependency direction** — `teatree.config` is lower
  level than `teatree.url_title_fetcher`; `uv run tach check` confirms no
  backwards edge.
- **Test surface** — `tests/test_url_title_fetcher.py::TestModuleScopeConfigImport`
  asserts `get_effective_settings` is bound at module scope (RED on the deferred
  form, GREEN after the hoist).
- **Behavior preservation** — no behavior removed; the existing
  env-var / DB-row driven `hook_fetch_titles` tests pass unchanged.

## Verification

- `uv run ruff check src/teatree/url_title_fetcher.py tests/test_url_title_fetcher.py` — clean; autofix makes no further edits (no suppression stripped).
- `uv run ty check` — clean.
- `uv run tach check` — no backwards edge.
- `uv run pytest -q -k url_title` — 17 passed.
- Importing the module with Django unconfigured succeeds and leaves Django unconfigured.
