### PR TITLE
ci: run the overlay-leak and banned-terms tree gates on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,9 @@
 #                              test-path-mirror (ratchet gate)
 #   5. Test suite            — test, test-shim
 #   6. Architecture / quality fitness gates — mutation-diff, mutation-full,
-#                              banned-terms-tree
+#                              banned-terms-tree, overlay-leak-tree
+#                              (the two tree gates run on push, schedule AND PR
+#                              so a leak is caught before merge — #44)
 #   7. Security & supply chain — uv-audit, sbom, uv-audit-advisory
 #
 # THE METERED AI EVAL DOES NOT RUN HERE
@@ -657,21 +659,26 @@ jobs:
         if: steps.gate.outputs.run_mutation == 'true'
         run: uv run t3 mutation run --all
 
-  # GATE (push + schedule only): full-tree scan for committed customer brand names;
-  # runs daily and on push-to-main; skipped on PRs (diff-only gate handles PRs).
+  # GATE (push + schedule + PR): full-tree scan for committed customer brand
+  # names. Runs daily, on push-to-main, AND on every PR so a brand committed by
+  # a PR is caught BEFORE merge instead of turning main RED on landing (#44).
   banned-terms-tree:
-    # Full-tree banned-brand backstop (souliane/teatree#1570). The
+    # Full-tree banned-brand backstop (souliane/teatree#1570, #44). The
     # diff/payload banned-terms gate only ever sees a *change*; a brand
     # name ALREADY committed never appears in a post-landing diff. This
     # job scans every git-tracked file's content for the high-confidence
-    # brand list on push-to-main and on a daily schedule, failing CI if a
-    # brand is present. The public repo ships with no brands; the list is
-    # supplied from the TEATREE_BANNED_BRANDS secret so no tenant name is
-    # ever committed. ``--require-brands`` makes a MISSING secret a LOUD
-    # failure (exit 2 = misconfigured) instead of a silent clean no-op — the
-    # job stays RED until the secret is wired (intended). Local dev omits the
-    # flag and stays green.
-    if: github.event_name == 'push' || github.event_name == 'schedule'
+    # brand list on push-to-main, on a daily schedule, and on PRs, failing
+    # CI if a brand is present. The public repo ships with no brands; the
+    # list is supplied from the TEATREE_BANNED_BRANDS secret so no tenant
+    # name is ever committed.
+    #
+    # push/schedule keep ``--require-brands`` so a MISSING secret stays a LOUD
+    # exit-2 failure on main. The PR step drops it and adds a fork-safe
+    # explicit-empty fallback: a same-repo PR reads the secret (full brand +
+    # terminology coverage), while a fork PR — which cannot read secrets —
+    # still runs the always-on terminology pass instead of false-redding on
+    # the unset-list refusal.
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -682,23 +689,35 @@ jobs:
         with:
           python-version: "3.13"
       - run: uv sync
-      - name: Full-tree banned-brand scan
+      - name: Full-tree banned-brand scan (push/schedule — require brands)
+        if: github.event_name != 'pull_request'
         env:
           TEATREE_BANNED_BRANDS: ${{ secrets.TEATREE_BANNED_BRANDS }}
         run: uv run t3 banned-terms scan-tree --repo-root . --require-brands
+      - name: Full-tree banned-brand + terminology scan (PR — brands optional)
+        if: github.event_name == 'pull_request'
+        env:
+          TEATREE_BANNED_BRANDS: ${{ secrets.TEATREE_BANNED_BRANDS }}
+          T3_BANNED_TERMS_CONFIG: dev/ci/pr-empty-brands.toml
+        run: uv run t3 banned-terms scan-tree --repo-root .
 
-  # GATE (push + schedule only): full-tree overlay-leak scan. The pre-commit
+  # GATE (push + schedule + PR): full-tree overlay-leak scan. The pre-commit
   # `no-overlay-leak` hook only sees STAGED files; an overlay-scoped name or a
   # real-shaped Slack/forge opaque id ALREADY committed never appears in a
   # staged diff. This job walks every scanned root (src/teatree, docs, skills,
   # agents, tests, scripts + top-level README/BLUEPRINT/AGENTS) for the
-  # configured term list AND the always-on opaque-ID pass. `--require-terms`
-  # makes a MISSING TEATREE_OVERLAY_LEAK_TERMS secret a LOUD failure (exit 2 =
-  # misconfigured) instead of a silent inert no-op — the job stays RED until the
-  # secret is wired (intended); the opaque-ID pass runs regardless. Local dev
+  # configured term list AND the always-on opaque-ID pass. It runs on every PR
+  # too (#44) so a leak introduced by a PR is caught BEFORE merge instead of
+  # turning main RED on landing.
+  #
+  # push/schedule keep ``--require-terms`` so a MISSING
+  # TEATREE_OVERLAY_LEAK_TERMS secret stays a LOUD exit-2 failure on main. The
+  # PR step drops it: a same-repo PR reads the secret (full term + opaque-ID
+  # coverage), while a fork PR — which cannot read secrets — still runs the
+  # always-on opaque-ID pass (term pass inert, never a false exit-2). Local dev
   # omits the flag and stays green.
   overlay-leak-tree:
-    if: github.event_name == 'push' || github.event_name == 'schedule'
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -709,10 +728,16 @@ jobs:
         with:
           python-version: "3.13"
       - run: uv sync
-      - name: Full-tree overlay-leak scan
+      - name: Full-tree overlay-leak scan (push/schedule — require terms)
+        if: github.event_name != 'pull_request'
         env:
           TEATREE_OVERLAY_LEAK_TERMS: ${{ secrets.TEATREE_OVERLAY_LEAK_TERMS }}
         run: uv run python scripts/hooks/check_no_overlay_leak.py --require-terms
+      - name: Full-tree overlay-leak scan (PR — terms optional)
+        if: github.event_name == 'pull_request'
+        env:
+          TEATREE_OVERLAY_LEAK_TERMS: ${{ secrets.TEATREE_OVERLAY_LEAK_TERMS }}
+        run: uv run python scripts/hooks/check_no_overlay_leak.py
 
   # ── 7. Security & supply chain ─────────────────────────────────────────────
 

--- a/dev/ci/pr-empty-brands.toml
+++ b/dev/ci/pr-empty-brands.toml
@@ -1,0 +1,11 @@
+# Fork-PR fallback for the banned-terms full-tree gate (#44).
+#
+# A fork PR cannot read repository secrets, so $TEATREE_BANNED_BRANDS is empty
+# and the loader would refuse a genuinely-unset brand list (exit 2). Pointing
+# T3_BANNED_TERMS_CONFIG at this explicit-empty list lets the always-on
+# terminology pass run pre-merge without that refusal. Same-repo PRs read the
+# secret (which takes precedence) and the full brand backstop runs on
+# push/schedule.
+
+[teatree]
+banned_brands = []

--- a/tests/test_ci_diff_scoped_lanes.py
+++ b/tests/test_ci_diff_scoped_lanes.py
@@ -120,7 +120,10 @@ class TestAlwaysRunLanesNotGated:
 
 
 class TestExistingTriggersPreserved:
-    def test_banned_terms_tree_stays_push_or_schedule(self) -> None:
+    def test_banned_terms_tree_keeps_push_and_schedule_backstop(self) -> None:
+        # The gate also runs on PRs now (#44, pinned in
+        # test_ci_tree_gates_run_on_prs); the push/schedule backstop must not
+        # be dropped by a diff-scoping edit.
         condition = str(_load_jobs()["banned-terms-tree"].get("if", ""))
         assert "push" in condition
         assert "schedule" in condition

--- a/tests/test_ci_tree_gates_run_on_prs.py
+++ b/tests/test_ci_tree_gates_run_on_prs.py
@@ -1,0 +1,83 @@
+"""The full-tree leak gates run on pull_request, not only push/schedule (#44).
+
+``overlay-leak-tree`` and ``banned-terms-tree`` scan the whole committed tree
+for overlay-scoped names, opaque Slack/forge IDs, and brand terms. They used
+to run only on push-to-main and on the daily schedule, so a leak introduced by
+a PR passed every PR check and turned main RED on merge (the #2801
+hardcoded-handle incident, hotfixed by #2804). These tests pin that the gates
+ALSO run on pull_request — catching the leak pre-merge — while keeping the
+push/schedule backstop and never false-redding a fork PR that cannot read the
+term/brand secret.
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+_TREE_GATES = ("overlay-leak-tree", "banned-terms-tree")
+
+
+def _jobs() -> dict[str, Any]:
+    return cast("dict[str, Any]", yaml.safe_load(_CI_WORKFLOW.read_text(encoding="utf-8"))["jobs"])
+
+
+def _steps(job_name: str) -> list[dict[str, Any]]:
+    return [s for s in _jobs()[job_name]["steps"] if isinstance(s, dict)]
+
+
+def _run_where(job_name: str, keep: Callable[[str], bool]) -> str:
+    return " ".join(str(s.get("run", "")) for s in _steps(job_name) if keep(str(s.get("if", ""))))
+
+
+def _pr_step_env(job_name: str) -> dict[str, Any]:
+    env: dict[str, Any] = {}
+    for step in _steps(job_name):
+        if "== 'pull_request'" in str(step.get("if", "")):
+            env.update(cast("dict[str, Any]", step.get("env", {})))
+    return env
+
+
+class TestTreeGatesTriggerOnPullRequest:
+    def test_both_tree_gates_run_on_push_schedule_and_pr(self) -> None:
+        jobs = _jobs()
+        for lane in _TREE_GATES:
+            condition = str(jobs[lane].get("if", ""))
+            assert "push" in condition, f"{lane} must keep its push trigger"
+            assert "schedule" in condition, f"{lane} must keep its schedule trigger"
+            assert "pull_request" in condition, f"{lane} must ALSO run on pull_request (#44)"
+
+
+class TestPrSideRunIsSecretOptional:
+    def test_overlay_leak_pr_step_drops_require_terms_main_keeps_it(self) -> None:
+        pr = _run_where("overlay-leak-tree", lambda c: "== 'pull_request'" in c)
+        non_pr = _run_where("overlay-leak-tree", lambda c: "!= 'pull_request'" in c)
+        assert "check_no_overlay_leak.py" in pr, "the PR step must run the full-tree overlay-leak scan"
+        assert "--require-terms" not in pr, "the PR step must NOT require terms (a fork PR has no secret)"
+        assert "--require-terms" in non_pr, "the push/schedule step keeps --require-terms (loud-on-misconfig)"
+        assert "TEATREE_OVERLAY_LEAK_TERMS" in _pr_step_env("overlay-leak-tree"), (
+            "the PR step threads the term secret so same-repo PRs get full term coverage"
+        )
+
+    def test_banned_terms_pr_step_drops_require_brands_main_keeps_it(self) -> None:
+        pr = _run_where("banned-terms-tree", lambda c: "== 'pull_request'" in c)
+        non_pr = _run_where("banned-terms-tree", lambda c: "!= 'pull_request'" in c)
+        assert "scan-tree" in pr, "the PR step must run the full-tree banned-terms scan"
+        assert "--require-brands" not in pr, "the PR step must NOT require brands (a fork PR has no secret)"
+        assert "--require-brands" in non_pr, "the push/schedule step keeps --require-brands (loud-on-misconfig)"
+        assert "TEATREE_BANNED_BRANDS" in _pr_step_env("banned-terms-tree"), (
+            "the PR step threads the brand secret so same-repo PRs get full brand coverage"
+        )
+
+    def test_banned_terms_pr_step_has_fork_safe_brand_fallback(self) -> None:
+        # A fork PR cannot read $TEATREE_BANNED_BRANDS; without a fallback the
+        # loader refuses a genuinely-unset list (exit 2). The PR step points the
+        # brand list at an explicit-empty config so the always-on terminology
+        # pass still runs pre-merge.
+        env = _pr_step_env("banned-terms-tree")
+        assert "T3_BANNED_TERMS_CONFIG" in env, (
+            "the banned-terms PR step needs an explicit-empty brand fallback for fork PRs"
+        )


### PR DESCRIPTION
The full-tree gates `overlay-leak-tree` and `banned-terms-tree` ran only on push-to-main and the daily schedule, so a generic-core violation passed PR CI and only turned main RED on merge (the #2801 hardcoded-handle incident, hotfixed by #2804). This runs them on the pull_request event too so the gate catches it pre-merge.

**Detection unchanged** — only *when* the gates run changes. Both job `if:` conditions add an `|| github.event_name == pull_request` clause; the existing push/schedule scan is unchanged.

**Design: full tree scan on PRs** (not diff-scoped). The gates are static greps over the tree (`check_no_overlay_leak.py` / `banned-terms scan-tree`) — fast enough to run whole-tree on every PR, and a full scan catches a pre-existing leak a diff-scoped run would miss.

**Secret-gated brand/term pass on PRs.** Each job splits the scan into two mutually-exclusive steps:

- **push/schedule** keep `--require-terms` / `--require-brands` so a missing secret stays a loud exit-2 on main (unchanged).
- **pull_request** drops the require flag. A same-repo PR reads the secret (`TEATREE_OVERLAY_LEAK_TERMS` / `TEATREE_BANNED_BRANDS`) for full term/brand coverage. A fork PR cannot read secrets; `overlay-leak` still runs its always-on opaque-ID pass (term pass inert, no false exit-2), and `banned-terms` points at an explicit-empty brand config (`dev/ci/pr-empty-brands.toml`) so the always-on terminology pass runs instead of the unset-list refusal.

**Gap documented:** on a fork PR (no secret access) the configured term/brand list is inert — only the always-on opaque-ID + terminology passes run. The full term/brand backstop still runs on push/schedule. Same-repo PRs (the normal workflow for this repo) get full coverage.

## Architecture pre-check — #44

**1. BLUEPRINT alignment** — CI gate wiring; no BLUEPRINT contract touched.
**4. Component boundaries** — change confined to `.github/workflows/ci.yml` plus a CI fixture; no `src/` change.
**6. Test surface** — `tests/test_ci_tree_gates_run_on_prs.py` pins: both gates trigger on push+schedule+pull_request; the PR step drops the require flag while push/schedule keep it; the PR step threads the secret and has the fork-safe fallback. Observed red before the workflow change, green after.
**9. Behavior preservation** — push/schedule strict behavior is preserved (its step keeps `--require-terms`/`--require-brands`); the existing require-flag assertions and `test_banned_terms_tree_keeps_push_and_schedule_backstop` stay green. No detection narrowed; no must-block test inverted.

Verified locally: `check_no_overlay_leak.py --require-terms` exit 0; fork-PR `banned-terms` fallback exit 0 (terminology pass runs); same-repo PR exit 0; main `--require-brands` misconfig exit 2.