### PR TITLE
refactor(hooks): extract SubagentStop no-commit gate from hook_router (#35, #2384)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -72,6 +72,7 @@ from question_gates import read_transcript_entries as _read_transcript_entries
 from quote_verdict import QuoteVerdict
 from quote_verdict import resolve_high_verdict as _resolve_quote_verdict
 from state_files import append_line, read_lines
+from subagent_no_commit import handle_subagent_stop_no_commit
 from subagent_skill_gate import is_file_safe, unreferenced_demand_reason
 from teatree_settings import autoload_enabled as _autoload_enabled
 from teatree_settings import teatree_bool_setting as _teatree_bool_setting
@@ -7976,98 +7977,6 @@ def handle_clear_classifier_deny_marker(data: dict) -> None:
 
 
 # ── Router ──────────────────────────────────────────────────────────
-
-# ── SubagentStop: record a sub-agent that terminated without committing ──
-#
-# Issue #1205: an ``isolation: worktree`` sub-agent that only edits files and
-# never commits loses ALL its work when the worktree is auto-cleaned on
-# teardown, yet the orchestrator believes work landed — a phantom-completion
-# source (3x recurrence). This SubagentStop handler runs once per sub-agent
-# termination and, when the sub-agent's worktree shows a WORK branch with ZERO
-# commits ahead of its base, records a ``terminated_without_commit`` signal so
-# the orchestrator can SEE the empty termination instead of assuming success.
-#
-# It is a DETECTION/surfacing hook, not a deny — SubagentStop cannot
-# un-terminate the agent. The signal is recorded through the SAME durable seam
-# the dispatched-sub-agent roster uses: a per-session ``<session>.no-commit``
-# state file (mirrors ``<session>.agents``), which the PreCompact recovery
-# snapshot already reads back and renders so it survives compaction. A
-# structured stderr line (this module's logging channel) carries the same fact
-# for the live transcript.
-#
-# Crash-proof and conservative (the #810 Stop-hook contract): a detached/
-# read-only review worktree (detached HEAD or a base branch) and a sub-agent
-# that DID commit are NOT flagged, and ANY inability to introspect git fails
-# OPEN (never flag) — a detection bug must never manufacture a false alarm.
-#
-# Limitation: the SubagentStop payload's ``cwd`` is the only reliable handle on
-# the sub-agent's worktree (the harness does not carry a dedicated worktree-path
-# field, and ``transcript_path`` points at the parent session — see the #115
-# note above). For a worktree-isolated sub-agent the harness ``cwd`` IS the
-# worktree, so it is the right signal; when ``cwd`` is absent the handler is a
-# clean no-op rather than guessing.
-
-
-def _record_no_commit_signal(session_id: str, finding: object) -> None:
-    r"""Persist + log one ``terminated_without_commit`` signal.
-
-    Durable channel: append a deduped ``<branch>\t<worktree>`` line to the
-    per-session ``<session>.no-commit`` state file (same shape/seam as the
-    ``<session>.agents`` roster, which the PreCompact snapshot reads back).
-    Live channel: a structured stderr line. Best-effort — a record failure
-    must never propagate out of the Stop hook.
-    """
-    branch = getattr(finding, "branch", "") or "(unknown)"
-    worktree = getattr(finding, "worktree", "") or "(unknown)"
-    print(  # noqa: T201 — hook stderr is the module's logging channel
-        f"[hook_router] terminated_without_commit — sub-agent left work branch "
-        f"{branch!r} at {worktree!r} with 0 commits; work would be lost on worktree teardown.",
-        file=sys.stderr,
-    )
-    if not session_id:
-        return
-    with contextlib.suppress(OSError):
-        _ensure_state_dir()
-        no_commit_file = _state_file(session_id, "no-commit")
-        line = f"{branch}\t{worktree}"
-        if line not in _read_lines(no_commit_file):
-            _append_line(no_commit_file, line)
-
-
-def handle_subagent_stop_no_commit(data: dict) -> None:
-    """SubagentStop: record a work-branch worktree that produced 0 commits (#1205).
-
-    Resolves the sub-agent's worktree from the harness ``cwd``, runs the
-    conservative :func:`teatree.hooks.no_commit_detector.detect`, and records a
-    ``terminated_without_commit`` signal only on the confirmed-flag verdict, so the
-    orchestrator SEES the empty termination instead of assuming work landed. It is
-    a pure DETECTION/surfacing hook — there is no recovery snapshot (the #1770
-    capture mechanism was removed): unproven sub-agent work is surfaced for
-    salvage, never auto-captured. No-op for a read-only/detached worktree, a
-    committed branch, an undeterminable git state, or a missing ``cwd``.
-
-    Crash-proof (#810 Stop contract): a broad boundary guard contains any
-    unexpected error (an unimportable ``teatree``, git introspection failure)
-    to a single stderr line — the sub-agent terminates normally and the
-    detection is simply skipped (fail open).
-    """
-    try:
-        worktree = data.get("cwd", "")
-        if not worktree:
-            return
-        src_dir = Path(__file__).resolve().parents[2] / "src"
-        if str(src_dir) not in sys.path:
-            sys.path.insert(0, str(src_dir))
-        from teatree.hooks import no_commit_detector  # noqa: PLC0415
-
-        finding = no_commit_detector.detect(worktree)
-        if finding.is_flagged:
-            _record_no_commit_signal(data.get("session_id", ""), finding)
-    except Exception as exc:  # noqa: BLE001 — SubagentStop hook must be crash-proof
-        print(  # noqa: T201 — hook stderr is the module's logging channel
-            f"[hook_router] no-commit detection skipped (unexpected error: {exc})",
-            file=sys.stderr,
-        )
 
 
 _HANDLERS: dict[str, list] = {

--- a/hooks/scripts/subagent_no_commit.py
+++ b/hooks/scripts/subagent_no_commit.py
@@ -1,0 +1,103 @@
+"""SubagentStop: record a sub-agent that terminated without committing (#1205).
+
+An ``isolation: worktree`` sub-agent that only edits files and never commits
+loses ALL its work when the worktree is auto-cleaned on teardown, yet the
+orchestrator believes work landed — a phantom-completion source (3x recurrence).
+This SubagentStop handler runs once per sub-agent termination and, when the
+sub-agent's worktree (the harness ``cwd``) shows a WORK branch with ZERO commits
+ahead of its base, records a ``terminated_without_commit`` signal so the
+orchestrator can SEE the empty termination instead of assuming success.
+
+It is a DETECTION/surfacing hook, not a deny — SubagentStop cannot un-terminate
+the agent. The signal is recorded through the SAME durable seam the
+dispatched-sub-agent roster uses: a per-session ``<session>.no-commit`` state
+file (mirrors ``<session>.agents``), which the PreCompact recovery snapshot
+already reads back and renders so it survives compaction. A structured stderr
+line (this module's logging channel) carries the same fact for the live
+transcript.
+
+Crash-proof and conservative (the #810 Stop-hook contract): a detached/read-only
+review worktree (detached HEAD or a base branch) and a sub-agent that DID commit
+are NOT flagged, and ANY inability to introspect git fails OPEN (never flag) — a
+detection bug must never manufacture a false alarm. The decision logic lives in
+the pure ``teatree.hooks.no_commit_detector`` leaf, imported function-scoped
+after the ``src/`` bootstrap; this module is the thin worktree-resolving +
+signal-recording wrapper. A ``hooks/scripts`` sibling may back-import the router
+spine (``_ensure_state_dir`` / ``_state_file``) lazily — the import-direction
+fitness test governs only the ``src/teatree/hooks`` leaves.
+"""
+
+import contextlib
+import sys
+from pathlib import Path
+
+from state_files import append_line, read_lines
+
+# Alias the bare and ``hooks.scripts.`` identities so the handler the router
+# registers and a test patching a helper here operate on ONE module object.
+sys.modules.setdefault("subagent_no_commit", sys.modules[__name__])
+sys.modules.setdefault("hooks.scripts.subagent_no_commit", sys.modules[__name__])
+
+
+def _record_no_commit_signal(session_id: str, finding: object) -> None:
+    r"""Persist + log one ``terminated_without_commit`` signal.
+
+    Durable channel: append a deduped ``<branch>\t<worktree>`` line to the
+    per-session ``<session>.no-commit`` state file (same shape/seam as the
+    ``<session>.agents`` roster, which the PreCompact snapshot reads back).
+    Live channel: a structured stderr line. Best-effort — a record failure
+    must never propagate out of the Stop hook.
+    """
+    from hook_router import _ensure_state_dir, _state_file  # noqa: PLC0415, PLC2701
+
+    branch = getattr(finding, "branch", "") or "(unknown)"
+    worktree = getattr(finding, "worktree", "") or "(unknown)"
+    print(  # noqa: T201 — hook stderr is the module's logging channel
+        f"[hook_router] terminated_without_commit — sub-agent left work branch "
+        f"{branch!r} at {worktree!r} with 0 commits; work would be lost on worktree teardown.",
+        file=sys.stderr,
+    )
+    if not session_id:
+        return
+    with contextlib.suppress(OSError):
+        _ensure_state_dir()
+        no_commit_file = _state_file(session_id, "no-commit")
+        line = f"{branch}\t{worktree}"
+        if line not in read_lines(no_commit_file):
+            append_line(no_commit_file, line)
+
+
+def handle_subagent_stop_no_commit(data: dict) -> None:
+    """SubagentStop: record a work-branch worktree that produced 0 commits (#1205).
+
+    Resolves the sub-agent's worktree from the harness ``cwd``, runs the
+    conservative :func:`teatree.hooks.no_commit_detector.detect`, and records a
+    ``terminated_without_commit`` signal only on the confirmed-flag verdict, so the
+    orchestrator SEES the empty termination instead of assuming work landed. It is
+    a pure DETECTION/surfacing hook — there is no recovery snapshot (the #1770
+    capture mechanism was removed): unproven sub-agent work is surfaced for
+    salvage, never auto-captured. No-op for a read-only/detached worktree, a
+    committed branch, an undeterminable git state, or a missing ``cwd``.
+
+    Crash-proof (#810 Stop contract): a broad boundary guard contains any
+    unexpected error (an unimportable ``teatree``, git introspection failure)
+    to a single stderr line — the sub-agent terminates normally and the
+    detection is simply skipped (fail open).
+    """
+    try:
+        worktree = data.get("cwd", "")
+        if not worktree:
+            return
+        src_dir = Path(__file__).resolve().parents[2] / "src"
+        if str(src_dir) not in sys.path:
+            sys.path.insert(0, str(src_dir))
+        from teatree.hooks import no_commit_detector  # noqa: PLC0415
+
+        finding = no_commit_detector.detect(worktree)
+        if finding.is_flagged:
+            _record_no_commit_signal(data.get("session_id", ""), finding)
+    except Exception as exc:  # noqa: BLE001 — SubagentStop hook must be crash-proof
+        print(  # noqa: T201 — hook stderr is the module's logging channel
+            f"[hook_router] no-commit detection skipped (unexpected error: {exc})",
+            file=sys.stderr,
+        )

--- a/tests/teatree_hooks/test_hook_scripts_py_version_compat.py
+++ b/tests/teatree_hooks/test_hook_scripts_py_version_compat.py
@@ -201,3 +201,13 @@ class TestInterpreterPinIsLoadBearing:
         assert result.returncode == 0, (
             f"availability_away_probe should import under {sys.executable}: {result.stderr.strip()}"
         )
+
+    def test_subagent_no_commit_sibling_cold_imports(self) -> None:
+        # The extracted SubagentStop no-commit sibling (#2384 Wave-2 PR1) must
+        # cold-import under a bare interpreter — its module-top state_files import
+        # and dual-identity alias resolve with hooks/scripts on sys.path and no
+        # Django, the way the live SubagentStop hook subprocess loads it.
+        result = _import_under(sys.executable, "subagent_no_commit")
+        assert result.returncode == 0, (
+            f"subagent_no_commit should cold-import under {sys.executable}: {result.stderr.strip()}"
+        )

--- a/tests/test_subagent_stop_no_commit_hook.py
+++ b/tests/test_subagent_stop_no_commit_hook.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import pytest
 
 import hooks.scripts.hook_router as router
+from hooks.scripts import subagent_no_commit
 from hooks.scripts.hook_router import _T3_TEMP_PREFIX, handle_pre_compact, handle_subagent_stop_no_commit
 
 _GIT_ENV = {
@@ -161,7 +162,7 @@ class TestFailsOpen:
         def _boom(*_args: object) -> None:
             raise RuntimeError
 
-        monkeypatch.setattr(router, "_record_no_commit_signal", _boom)
+        monkeypatch.setattr(subagent_no_commit, "_record_no_commit_signal", _boom)
         # The handler must swallow the error from the recording path.
         handle_subagent_stop_no_commit({"session_id": "sess-f", "cwd": str(clone)})
 


### PR DESCRIPTION
Wave-2 PR1 of the `hook_router` split (#2384).

Pure behavior-preserving move of `_record_no_commit_signal` +
`handle_subagent_stop_no_commit` out of the `hooks/scripts/hook_router.py`
god-module into a new flat sibling `hooks/scripts/subagent_no_commit.py`,
re-exported into the router's top import block so the
`_HANDLERS["SubagentStop"]` dispatch entry and all existing tests are
unchanged.

Module-health: `hook_router.py` shrinks (code-LOC 5814 -> 5761, public fns
55 -> 54); the new sibling is 86 code-LOC / 1 public fn. Both caps pass. The
intra-core deferred-import ratchet is unchanged (this move is outside
`src/teatree/core`).

Refs #2384.

## Architecture pre-check — #35 / #2384

### 1. BLUEPRINT § alignment
`hooks/CLAUDE.md` "One router, many events": a handler lives in a bare sibling
module imported into the router's `_HANDLERS` chain; the god-module is
shrink-only. This PR moves an EXISTING handler out along that same seam — no
behavior change, so no BLUEPRINT prose change.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition touched.

### 3. Extension-point contracts
The SubagentStop event consumer is unchanged: `_HANDLERS["SubagentStop"] =
[handle_subagent_stop_no_commit]` still references the same function object,
now re-exported from the sibling. No hook / overlay / Protocol surface changed.

### 4. Component boundaries (sibling vs leaf)
`hooks/scripts/subagent_no_commit.py` is a flat hook-script SIBLING (on
`sys.path` via the router's parent-dir insert), not a `src/teatree/hooks/*`
leaf. It carries the worktree-resolving + signal-recording wrapper only. The
pure decision logic stays in the existing `teatree.hooks.no_commit_detector`
leaf, imported function-scoped after the `src/` bootstrap — unchanged.

### 5. Dependency direction (sibling back-imports the spine lazily — allowed)
Module-top imports are stdlib + the already-extracted `state_files` sibling
only (no Django / no `teatree.core` — cold-import discipline). The spine
helpers `_ensure_state_dir` / `_state_file` are back-imported from `hook_router`
LAZILY inside the handler body. The back-edge is allowed: the import-direction
fitness test (`tests/teatree_quality/test_hooks_import_direction.py`) governs
only `src/teatree/hooks/*` leaves, never `hooks/scripts/` siblings — it stays
green. `tach check` is n/a (`hook_router` lives outside `src/`, the tach tree).

### 6. Test surface
- `tests/test_subagent_stop_no_commit_hook.py` — behavior unchanged; the only
  edit is the single mechanical repoint of the `_record_no_commit_signal`
  monkeypatch target to the new module (the dual-identity alias keeps it one
  module object). The crash-containment test exercises that patch, so the
  repoint is load-bearing.
- `tests/teatree_hooks/test_hook_scripts_py_version_compat.py` — adds a cold
  import smoke assertion that `subagent_no_commit` imports under a bare
  interpreter (its module-top `state_files` import + dual-identity alias, no
  Django).

### 7. Resilience invariants
n/a — no new external write. The moved code's existing best-effort recording
(dedup on `<session>.no-commit`, crash-proof fail-open) is preserved.

### 8. Identity and key normalization
n/a — no identity/key handling introduced or changed.

### 9. Behavior preservation / capability deletion
Pure move — nothing removed. Enumerated:
- Same handler (`handle_subagent_stop_no_commit`), same `_record_no_commit_signal`
  helper, byte-identical bodies. Only token change: `_read_lines` / `_append_line`
  -> the canonical `read_lines` / `append_line` from the `state_files` sibling
  they already aliased (same function objects).
- Same dispatch entry `_HANDLERS["SubagentStop"]`.
- Same deny/None contract: SubagentStop is detection-only — the handler returns
  `None`, records a signal only on the confirmed-flag verdict, and fails open on
  any error.
- Existing test corpus green UNCHANGED (35 passed across the four-test
  verification run); intra-core deferred-import ratchet UNCHANGED at 182.
- No privacy / leak / security matcher narrowed; no must-block test inverted.
