### PR TITLE
refactor(hooks): extract the banned-terms publish gate from hook_router (#35, #2384)

### DIFF
--- a/hooks/scripts/banned_terms_gate.py
+++ b/hooks/scripts/banned_terms_gate.py
@@ -1,0 +1,161 @@
+"""PreToolUse: refuse a non-commit publish whose body carries a banned term (#1415).
+
+The commit-only ``check-banned-terms.sh`` pre-commit hook misses ``gh
+issue/pr create|edit|comment``, ``glab mr|issue note|create`` and the ``gh
+api`` / ``glab api`` REST posting paths — exactly where overlay/customer terms
+have leaked on this PUBLIC repo. This gate (sibling of the #1213 quote-scanner
+gate) reuses the #1213 publish-surface detection + body extraction, then
+delegates the matching to the SAME ``check-banned-terms.sh`` term list, denying
+via ``permissionDecision: deny`` when a banned term reaches a public surface.
+
+Extracted whole from ``hook_router`` (the #2384 Wave-2 router split, PR2) so the
+8800-LOC dispatcher shrinks; the router re-exports
+:func:`handle_banned_terms_pretool` into its ``_HANDLERS`` chain unchanged.
+
+Cold-import safe: the live PreToolUse hook is a bare ``python3`` subprocess with
+no guarantee ``teatree`` is importable, so the module top imports only stdlib and
+already-extracted ``hooks/scripts`` siblings (``teatree_settings`` /
+``banned_terms_deny`` / ``banned_terms_marker``) — never Django / ``teatree.core``.
+The pure ``teatree.hooks`` leaves (``banned_terms_scanner`` /
+``publish_destination`` / ``publish_surface``) stay function-scoped, imported only
+after the handler bootstraps ``sys.path``. The shared spine helpers
+``emit_pretooluse_deny`` and ``_resolve_cwd_repo`` stay in the router and are
+back-imported lazily inside the handler bodies — the ``hooks/scripts`` sibling
+back-import the import-direction fitness test permits (it governs only the
+``src/teatree/hooks`` leaves).
+"""
+
+import contextlib
+import sys
+from pathlib import Path
+
+from banned_terms_deny import emit_banned_term_deny
+from banned_terms_marker import resolve_marker as _resolve_banned_terms_marker
+from teatree_settings import teatree_bool_setting as _teatree_bool_setting
+
+# Alias the bare and ``hooks.scripts.`` identities so the handler the router
+# registers and a test patching a helper here operate on ONE module object.
+sys.modules.setdefault("banned_terms_gate", sys.modules[__name__])
+sys.modules.setdefault("hooks.scripts.banned_terms_gate", sys.modules[__name__])
+
+
+def _banned_terms_gate_enabled() -> bool:
+    """Whether the #1415 banned-terms publish gate is enabled (default True).
+
+    Fails OPEN to enabled on a missing/broken config so the gate keeps its
+    protective default; an explicit ``[teatree] banned_terms_gate_enabled =
+    false`` is the one-line kill-switch (NEVER-LOCKOUT) the user flips to
+    disable the gate while its body-resolution over-block (an allowlisted
+    private-repo commit hard-blocked because the body could not be read) is
+    fixed properly. See :func:`_teatree_bool_setting` for the shared semantics.
+    """
+    return _teatree_bool_setting("banned_terms_gate_enabled", default=True)
+
+
+def handle_banned_terms_pretool(data: dict) -> bool:
+    """Refuse a non-commit publish whose body carries a banned term.
+
+    Sibling of the #1213 quote-scanner gate. The commit-only
+    ``check-banned-terms.sh`` pre-commit hook misses ``gh issue/pr
+    create|edit|comment``, ``glab mr|issue note|create`` and the
+    ``gh api`` / ``glab api`` REST posting paths — exactly where
+    overlay/customer terms have leaked on this PUBLIC repo. This gate
+    reuses the #1213 ``_command_parser`` publish-surface detection + body
+    extraction, then delegates the matching to the SAME
+    ``check-banned-terms.sh`` against the ``~/.teatree.toml`` term list
+    (no new term config, no reimplemented matching).
+
+    A banned-term match ⇒ refuse via ``permissionDecision: deny`` + a
+    reason naming the matched term and pointing at the
+    ``--allow-banned-term`` / ``ALLOW_BANNED_TERM=1`` override.
+
+    Fail-open on any internal error: a crashing hook is worse than no
+    scan. The handler bootstraps ``sys.path`` to import ``teatree`` from
+    the sibling ``src/`` directory (the hook script runs in the user's
+    session shell with no guarantee that ``teatree`` is already
+    importable, #1314) and swallows any exception, returning ``False``.
+    """
+    if not _banned_terms_gate_enabled():
+        return False
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    added = False
+    try:
+        if str(src_dir) not in sys.path:
+            sys.path.insert(0, str(src_dir))
+            added = True
+        return _run_banned_terms_pretool(data)
+    except Exception:  # noqa: BLE001
+        return False
+    finally:
+        if added:
+            with contextlib.suppress(ValueError):
+                sys.path.remove(str(src_dir))
+
+
+_BANNED_TERMS_CREDENTIAL_DENY = (
+    "BLOCKED: a high-confidence secret (token / key / private-key block) was detected in the "
+    "publish payload. Secrets are blocked on every surface, including a private repo — remove "
+    "the credential before posting."
+)
+
+
+def _banned_term_marker_blocks(term: str, command: str, cwd_repo: "Path | None") -> bool | None:
+    """Decide a fail-closed MARKER term, or ``None`` when ``term`` is a real banned term.
+
+    Thin router wrapper over ``banned_terms_marker.resolve_marker`` (which owns the
+    destination-aware logic + rationale). For a real configured term it returns
+    ``None`` so the caller takes its own destination-aware banned-term path. For a
+    fail-closed marker the verdict is either a downgrade-to-warn (write the stderr
+    line, return ``False``) or a hard-block (``emit_pretooluse_deny``).
+    """
+    from hook_router import emit_pretooluse_deny  # noqa: PLC0415
+
+    verdict = _resolve_banned_terms_marker(term, command, cwd_repo)
+    if not verdict.is_marker:
+        return None
+    if verdict.warning is not None:
+        sys.stderr.write(verdict.warning)
+        return False
+    return emit_pretooluse_deny(verdict.deny_message or "")
+
+
+def _run_banned_terms_pretool(data: dict) -> bool:
+    """Banned-terms inner body — assumes ``teatree`` is already importable."""
+    from typing import cast  # noqa: PLC0415
+
+    from hook_router import _resolve_cwd_repo, emit_pretooluse_deny  # noqa: PLC0415, PLC2701
+
+    from teatree.hooks import banned_terms_scanner, publish_destination, publish_surface  # noqa: PLC0415
+
+    tool_name = data.get("tool_name", "")
+    raw_input = data.get("tool_input", {}) or {}
+    if not isinstance(raw_input, dict):
+        return False
+    tool_input = cast("banned_terms_scanner.ToolInput", raw_input)
+
+    command = tool_input.get("command", "")
+    cwd_repo = _resolve_cwd_repo(data)
+
+    # A high-confidence secret leaks on EVERY surface -- a title, a short ``-t``
+    # flag, a ``gh api -f title=`` field, a ``git -C ... commit`` subject -- not
+    # only the description body, and on an internal post the destination gate
+    # would SKIP or a command carrying the --allow-banned-term override. Scan the
+    # WIDE surface set and block before the payload-None early-return and any skip
+    # / override short-circuit (#1672 secrets-always-blocked invariant).
+    if publish_surface.contains_secret(banned_terms_scanner.secret_scan_text(tool_name, tool_input)):
+        return emit_pretooluse_deny(_BANNED_TERMS_CREDENTIAL_DENY)
+
+    payload = banned_terms_scanner.extract_publish_payload(tool_name, tool_input, cwd_repo)
+    if payload is None:
+        return False
+
+    skipped = banned_terms_scanner.has_override(tool_name, tool_input) or (
+        tool_name == "Bash" and publish_destination.gate_skips_destination(command, cwd_repo)
+    )
+    term = None if skipped else banned_terms_scanner.scan_text(payload)
+    if term is None:
+        return False
+    marker_decision = _banned_term_marker_blocks(term, command, cwd_repo)
+    if marker_decision is not None:
+        return marker_decision
+    return emit_banned_term_deny(tool_name, command, payload, term, cwd_repo)

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -47,8 +47,7 @@ if "hook_router" not in sys.modules:
     sys.modules["hook_router"] = sys.modules[__name__]
 
 from availability_away_probe import resolved_away_mode as resolved_away_mode_stdlib
-from banned_terms_deny import emit_banned_term_deny
-from banned_terms_marker import resolve_marker as _resolve_banned_terms_marker
+from banned_terms_gate import handle_banned_terms_pretool
 from completion_claim_gate import handle_completion_claim_gate
 from config_overwrite_guard import handle_block_config_overwrite
 from django_bootstrap import bootstrap_teatree_django
@@ -3064,127 +3063,6 @@ def _run_dispatch_quote_scanner_on_task_create(data: dict) -> bool:
         override=False,
     )
     return False
-
-
-# ── PreToolUse: banned-terms posting gate (#1415) ───────────────────
-
-
-def _banned_terms_gate_enabled() -> bool:
-    """Whether the #1415 banned-terms publish gate is enabled (default True).
-
-    Fails OPEN to enabled on a missing/broken config so the gate keeps its
-    protective default; an explicit ``[teatree] banned_terms_gate_enabled =
-    false`` is the one-line kill-switch (NEVER-LOCKOUT) the user flips to
-    disable the gate while its body-resolution over-block (an allowlisted
-    private-repo commit hard-blocked because the body could not be read) is
-    fixed properly. See :func:`_teatree_bool_setting` for the shared semantics.
-    """
-    return _teatree_bool_setting("banned_terms_gate_enabled", default=True)
-
-
-def handle_banned_terms_pretool(data: dict) -> bool:
-    """Refuse a non-commit publish whose body carries a banned term.
-
-    Sibling of the #1213 quote-scanner gate. The commit-only
-    ``check-banned-terms.sh`` pre-commit hook misses ``gh issue/pr
-    create|edit|comment``, ``glab mr|issue note|create`` and the
-    ``gh api`` / ``glab api`` REST posting paths — exactly where
-    overlay/customer terms have leaked on this PUBLIC repo. This gate
-    reuses the #1213 ``_command_parser`` publish-surface detection + body
-    extraction, then delegates the matching to the SAME
-    ``check-banned-terms.sh`` against the ``~/.teatree.toml`` term list
-    (no new term config, no reimplemented matching).
-
-    A banned-term match ⇒ refuse via ``permissionDecision: deny`` + a
-    reason naming the matched term and pointing at the
-    ``--allow-banned-term`` / ``ALLOW_BANNED_TERM=1`` override.
-
-    Fail-open on any internal error: a crashing hook is worse than no
-    scan. The handler bootstraps ``sys.path`` to import ``teatree`` from
-    the sibling ``src/`` directory (the hook script runs in the user's
-    session shell with no guarantee that ``teatree`` is already
-    importable, #1314) and swallows any exception, returning ``False``.
-    """
-    if not _banned_terms_gate_enabled():
-        return False
-    src_dir = Path(__file__).resolve().parents[2] / "src"
-    added = False
-    try:
-        if str(src_dir) not in sys.path:
-            sys.path.insert(0, str(src_dir))
-            added = True
-        return _run_banned_terms_pretool(data)
-    except Exception:  # noqa: BLE001
-        return False
-    finally:
-        if added:
-            with contextlib.suppress(ValueError):
-                sys.path.remove(str(src_dir))
-
-
-_BANNED_TERMS_CREDENTIAL_DENY = (
-    "BLOCKED: a high-confidence secret (token / key / private-key block) was detected in the "
-    "publish payload. Secrets are blocked on every surface, including a private repo — remove "
-    "the credential before posting."
-)
-
-
-def _banned_term_marker_blocks(term: str, command: str, cwd_repo: "Path | None") -> bool | None:
-    """Decide a fail-closed MARKER term, or ``None`` when ``term`` is a real banned term.
-
-    Thin router wrapper over ``banned_terms_marker.resolve_marker`` (which owns the
-    destination-aware logic + rationale). For a real configured term it returns
-    ``None`` so the caller takes its own destination-aware banned-term path. For a
-    fail-closed marker the verdict is either a downgrade-to-warn (write the stderr
-    line, return ``False``) or a hard-block (``emit_pretooluse_deny``).
-    """
-    verdict = _resolve_banned_terms_marker(term, command, cwd_repo)
-    if not verdict.is_marker:
-        return None
-    if verdict.warning is not None:
-        sys.stderr.write(verdict.warning)
-        return False
-    return emit_pretooluse_deny(verdict.deny_message or "")
-
-
-def _run_banned_terms_pretool(data: dict) -> bool:
-    """Banned-terms inner body — assumes ``teatree`` is already importable."""
-    from typing import cast  # noqa: PLC0415
-
-    from teatree.hooks import banned_terms_scanner, publish_destination, publish_surface  # noqa: PLC0415
-
-    tool_name = data.get("tool_name", "")
-    raw_input = data.get("tool_input", {}) or {}
-    if not isinstance(raw_input, dict):
-        return False
-    tool_input = cast("banned_terms_scanner.ToolInput", raw_input)
-
-    command = tool_input.get("command", "")
-    cwd_repo = _resolve_cwd_repo(data)
-
-    # A high-confidence secret leaks on EVERY surface -- a title, a short ``-t``
-    # flag, a ``gh api -f title=`` field, a ``git -C ... commit`` subject -- not
-    # only the description body, and on an internal post the destination gate
-    # would SKIP or a command carrying the --allow-banned-term override. Scan the
-    # WIDE surface set and block before the payload-None early-return and any skip
-    # / override short-circuit (#1672 secrets-always-blocked invariant).
-    if publish_surface.contains_secret(banned_terms_scanner.secret_scan_text(tool_name, tool_input)):
-        return emit_pretooluse_deny(_BANNED_TERMS_CREDENTIAL_DENY)
-
-    payload = banned_terms_scanner.extract_publish_payload(tool_name, tool_input, cwd_repo)
-    if payload is None:
-        return False
-
-    skipped = banned_terms_scanner.has_override(tool_name, tool_input) or (
-        tool_name == "Bash" and publish_destination.gate_skips_destination(command, cwd_repo)
-    )
-    term = None if skipped else banned_terms_scanner.scan_text(payload)
-    if term is None:
-        return False
-    marker_decision = _banned_term_marker_blocks(term, command, cwd_repo)
-    if marker_decision is not None:
-        return marker_decision
-    return emit_banned_term_deny(tool_name, command, payload, term, cwd_repo)
 
 
 # ── PreToolUse: block-uncovered-diff (#937 §17.6 gate 12) ───────────

--- a/tests/teatree_hooks/test_hook_scripts_py_version_compat.py
+++ b/tests/teatree_hooks/test_hook_scripts_py_version_compat.py
@@ -211,3 +211,14 @@ class TestInterpreterPinIsLoadBearing:
         assert result.returncode == 0, (
             f"subagent_no_commit should cold-import under {sys.executable}: {result.stderr.strip()}"
         )
+
+    def test_banned_terms_gate_sibling_cold_imports(self) -> None:
+        # The extracted PreToolUse banned-terms publish gate (#2384 Wave-2 PR2)
+        # must cold-import under a bare interpreter — its module-top
+        # teatree_settings / banned_terms_deny / banned_terms_marker sibling
+        # imports and dual-identity alias resolve with hooks/scripts on sys.path
+        # and no Django, the way the live PreToolUse hook subprocess loads it.
+        result = _import_under(sys.executable, "banned_terms_gate")
+        assert result.returncode == 0, (
+            f"banned_terms_gate should cold-import under {sys.executable}: {result.stderr.strip()}"
+        )

--- a/tests/test_gate_never_lockout_contract.py
+++ b/tests/test_gate_never_lockout_contract.py
@@ -160,6 +160,47 @@ def _module_functions(tree: ast.Module) -> dict[str, ast.FunctionDef]:
     return {n.name: n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)}
 
 
+def _reexport_sibling_sources(tree: ast.Module, handler_names: set[str]) -> list[ast.Module]:
+    """Parsed ASTs of the ``hooks/scripts`` siblings a re-exported handler is defined in.
+
+    A PreToolUse handler extracted into a sibling (the #2384 router split) is
+    registered in ``_HANDLERS`` under its re-exported name but DEFINED in the
+    sibling, reached via a top-level ``from <sibling> import <handler>`` at the
+    router head. To trace such a handler's deny path the call graph must include the
+    sibling's functions — the sibling reaches the deny writer through a lazy
+    ``from hook_router import emit_pretooluse_deny`` back-import.
+    """
+    scripts_dir = _HOOK_ROUTER_SRC.parent
+    sources: list[ast.Module] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom) or node.level or node.module is None:
+            continue
+        if not any(alias.name in handler_names for alias in node.names):
+            continue
+        sibling = scripts_dir / f"{node.module}.py"
+        if sibling.is_file():
+            sources.append(ast.parse(sibling.read_text(encoding="utf-8")))
+    return sources
+
+
+def _call_graph_functions(tree: ast.Module) -> dict[str, ast.FunctionDef]:
+    """Every function in the router's PreToolUse call graph, including re-exported siblings.
+
+    The router's own functions PLUS the functions of each ``hooks/scripts`` sibling
+    it re-exports a PreToolUse handler from. The graph is name-based and module-flat
+    (``_callee_names`` keys on the call name regardless of import origin), so a
+    handler defined in a sibling and the sibling's lazy ``from hook_router import
+    emit_pretooluse_deny`` back-import resolve transitively once both modules' defs
+    share one dict. Router defs win on a name collision.
+    """
+    handler_names = set(_pretooluse_handler_names(tree))
+    funcs: dict[str, ast.FunctionDef] = {}
+    for sibling_tree in _reexport_sibling_sources(tree, handler_names):
+        funcs.update(_module_functions(sibling_tree))
+    funcs.update(_module_functions(tree))
+    return funcs
+
+
 def _callers_of(name: str, funcs: dict[str, ast.FunctionDef]) -> set[str]:
     """The names of module functions that call ``name`` directly."""
     return {fname for fname, func in funcs.items() if name in _callee_names(func)}
@@ -175,7 +216,7 @@ def _never_lockout_offenders(tree: ast.Module) -> list[str]:
     is caught, not evaded. Shared by the real-source check and the synthetic-source
     proof so both exercise the identical classifier.
     """
-    funcs = _module_functions(tree)
+    funcs = _call_graph_functions(tree)
     handlers = _pretooluse_handler_names(tree)
     offenders: list[str] = []
     for handler in handlers:
@@ -212,7 +253,7 @@ def test_every_pretooluse_deny_handler_is_never_lockout() -> None:
 def test_loop_registration_gate_routes_through_fail_open() -> None:
     """The incident gate itself must now fail-open-route (regression pin)."""
     tree = _module_tree()
-    funcs = _module_functions(tree)
+    funcs = _call_graph_functions(tree)
     reachable = _reachable_callees("handle_enforce_loop_registration", funcs)
     assert _DENY_WRITER in reachable, "loop-registration gate must still be able to deny"
     assert _FAIL_OPEN_ROUTER in reachable, (
@@ -232,7 +273,7 @@ def test_exemption_allowlist_has_no_stale_entries() -> None:
     fail-open-routing) must be pruned, not left as a silent broadening.
     """
     tree = _module_tree()
-    funcs = _module_functions(tree)
+    funcs = _call_graph_functions(tree)
     handlers = set(_pretooluse_handler_names(tree))
 
     stale: list[str] = []
@@ -261,7 +302,7 @@ def test_write_pretooluse_deny_has_single_funnel() -> None:
     fail-open / circuit-breaker routing un-sidesteppable.
     """
     tree = _module_tree()
-    funcs = _module_functions(tree)
+    funcs = _call_graph_functions(tree)
     assert _DENY_WRITER in funcs, f"{_DENY_WRITER} not found in hook_router — writer rename regression"
 
     callers = _callers_of(_DENY_WRITER, funcs)


### PR DESCRIPTION
Wave-2 PR2 of the hook_router split. Pure behavior-preserving move of the PreToolUse banned-terms publish gate into `hooks/scripts/banned_terms_gate.py`, re-exported so the `_HANDLERS` dispatch table and all existing banned-terms tests are unchanged.

The five H-cluster symbols move verbatim: `_banned_terms_gate_enabled`, `handle_banned_terms_pretool`, `_BANNED_TERMS_CREDENTIAL_DENY`, `_banned_term_marker_blocks`, `_run_banned_terms_pretool`. Module-top imports are stdlib plus already-extracted `hooks/scripts` siblings only (`teatree_settings`, `banned_terms_deny`, `banned_terms_marker`) — cold-import safe for the bare `python3` hook subprocess. The shared spine helpers `emit_pretooluse_deny` and `_resolve_cwd_repo` stay in the router and are back-imported lazily inside the handler bodies. The router re-exports the handler via `from banned_terms_gate import handle_banned_terms_pretool` into the top import block; the `_HANDLERS` PreToolUse entry is unchanged.

Module-health: `hook_router` shrinks 8119 → 7997 LOC; the new sibling is 161 LOC / 1 public function — both under the 500 LOC / 10-function caps. A cold-import smoke assertion for the sibling is added to `test_hook_scripts_py_version_compat.py`, mirroring PR1.

Refs #2384.

## Architecture pre-check — #2384 (Wave-2 PR2)

## 1. BLUEPRINT § alignment
No BLUEPRINT change. This is a mechanical god-module shrink per `hooks/CLAUDE.md` ("hook_router.py is a shrink-only god-module: put a NEW handler in a bare sibling module and import it into the router's `_HANDLERS` chain") — the same pattern PR1 (#2814) applied to the SubagentStop no-commit gate.

## 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition is touched. This is a PreToolUse hook handler, not an FSM transition.

## 3. Extension-point contracts
The router's `_HANDLERS` PreToolUse chain is the only consumer; it references the re-exported `handle_banned_terms_pretool` by the same name, unchanged. No `OverlayBase`, scanner, or `*Backend` Protocol surface changes.

## 4. Component boundaries
`hooks/scripts/` — Claude Code PreToolUse hook handler. The whole banned-terms publish-gate concern moves into one cohesive sibling, exactly the `django_bootstrap` / `subagent_no_commit` shape. Nothing straddles two categories.

## 5. Dependency direction
The new sibling back-imports the spine lazily (`from hook_router import emit_pretooluse_deny, _resolve_cwd_repo` inside the handler bodies). This is the allowed `hooks/scripts` → router back-import: the import-direction fitness test (`tests/teatree_quality/test_hooks_import_direction.py`) governs only `src/teatree/hooks/*.py` leaves, not `hooks/scripts` siblings — green. Module-top imports add no backwards edge (stdlib + already-extracted siblings). The intra-core deferred-import ratchet is unchanged (the move is outside `src/teatree/core`).

## 6. Test surface
The existing banned-terms corpus is the behavior contract and stays green unchanged: `tests/teatree_hooks/test_banned_terms_hook.py`, `tests/test_banned_terms_shell_fallback.py`, `tests/test_banned_terms_tree_scan.py` (all import `handle_banned_terms_pretool` via the re-export). A new cold-import smoke assertion `test_banned_terms_gate_sibling_cold_imports` mirrors PR1's.

## 7. Resilience invariants
n/a — no new external write. The handler's existing fail-open contract (swallow any exception → return `False`) and the `emit_pretooluse_deny` circuit-breaker chokepoint are preserved verbatim.

## 8. Identity and key normalization
n/a — no identity/key normalization is introduced or changed.

## 9. Behavior preservation / capability deletion
Pure move, no behavior removed. Same gate decision, same deny payload (`_BANNED_TERMS_CREDENTIAL_DENY`, `emit_banned_term_deny`), same secrets-always-blocked / marker / carve-out paths. The five symbols are copied verbatim (no logic edit); no must-block regression test was inverted or weakened. The existing test corpus passing unchanged is the preservation evidence.
