### PR TITLE
fix(questions): resume parked headless task on CLI answer (#31)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -7890,7 +7890,8 @@ Usage: t3 teatree questions list [OPTIONS]
 ```
 Usage: t3 teatree questions answer [OPTIONS] QUESTION_ID TEXT
 
- Resolve a pending question with a user answer.
+ Resolve a pending question with a user answer (resumes a parked headless
+ task).
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    question_id      INTEGER  [required]                                    │

--- a/docs/generated/management-commands.json
+++ b/docs/generated/management-commands.json
@@ -561,7 +561,7 @@
           "name": "record"
         },
         {
-          "help": "Resolve a pending question with a user answer",
+          "help": "Resolve a pending question with a user answer (resumes a parked headless task)",
           "name": "answer"
         },
         {

--- a/docs/generated/management-commands.md
+++ b/docs/generated/management-commands.md
@@ -293,7 +293,7 @@ Render a reusable prompt by name with its declared params (read-only; #2513).
 | Subcommand | Description |
 | --- | --- |
 | `record` | Record a deferred question (called by the PreToolUse away-mode hook) |
-| `answer` | Resolve a pending question with a user answer |
+| `answer` | Resolve a pending question with a user answer (resumes a parked headless task) |
 | `dismiss` | Dismiss a pending question without answering it |
 | `resurface` | Re-post the pending backlog to the user's Slack DM (away→present drain) |
 | `list` | List pending deferred questions, oldest first |

--- a/src/teatree/core/management/commands/questions.py
+++ b/src/teatree/core/management/commands/questions.py
@@ -27,6 +27,7 @@ from django.db import transaction
 from django_typer.management import TyperCommand, command, initialize
 
 from teatree.core.models.deferred_question import DeferredQuestion, DeferredQuestionAudit, DeferredQuestionError
+from teatree.core.models.task_handoff import schedule_headless_resume
 from teatree.core.notify_question_drains import drain_deferred_questions
 
 
@@ -91,7 +92,7 @@ class Command(TyperCommand):
             typer.Option("--resolver", help="Identity of the resolver (audit trail)."),
         ] = "",
     ) -> str:
-        """Resolve a pending question with a user answer."""
+        """Resolve a pending question with a user answer (resumes a parked headless task)."""
         if not text.strip():
             self.stderr.write("answer text must not be empty")
             raise SystemExit(2)
@@ -109,6 +110,8 @@ class Command(TyperCommand):
                     answer_text=text,
                     resolver_id=resolver_id,
                 )
+                if row.parked_task is not None:
+                    schedule_headless_resume(row.parked_task, answer=text)
         except DeferredQuestionError as exc:
             self.stderr.write(str(exc))
             raise SystemExit(2) from exc

--- a/tests/teatree_core/management/test_questions_headless_resume.py
+++ b/tests/teatree_core/management/test_questions_headless_resume.py
@@ -1,0 +1,100 @@
+"""``t3 teatree questions answer`` resumes a parked headless task (#31).
+
+The CLI ``answer`` path is the chat-only operator's parallel of the Slack
+reply scanner (``askuserquestion_reply._apply_one``). The scanner re-queues a
+headless continuation when the resolved ``DeferredQuestion`` carries a
+``parked_task``; the CLI path historically resolved the answer + wrote the
+audit but never scheduled the resume, so a headless run parked via the
+away-mode hook stayed parked forever even though ``_resurface_text`` tells the
+user to answer through this very command.
+
+These tests pin parity with the scanner: a CLI-answered parked question
+re-queues exactly one HEADLESS followup chained on the captured session, a
+question with no ``parked_task`` queues none, and re-answering / a pre-existing
+resume child never double-queues.
+"""
+
+import pytest
+from django.core.management import call_command
+
+from teatree.agents.headless import _get_resume_session_id
+from teatree.core.models import ConfigSetting, Session, Task, TaskAttempt, Ticket
+from teatree.core.models.deferred_question import DeferredQuestion
+
+# ast-grep-ignore: ac-django-no-pytest-django-db
+pytestmark = pytest.mark.django_db
+
+_RESUME_UUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+
+def _parked_task() -> Task:
+    ConfigSetting.objects.set_value("agent_runtime", "sdk_oauth")
+    ticket = Ticket.objects.create()
+    session = Session.objects.create(ticket=ticket, agent_id=_RESUME_UUID)
+    parked = Task.objects.create(
+        ticket=ticket,
+        session=session,
+        phase="coding",
+        execution_target=Task.ExecutionTarget.HEADLESS,
+    )
+    TaskAttempt.objects.create(task=parked, agent_session_id=_RESUME_UUID)
+    return parked
+
+
+def _parked_question(parked: Task) -> DeferredQuestion:
+    return DeferredQuestion.record(
+        "Which DB host?",
+        session_id=str(parked.session_id),
+        parked_task=parked,
+    )
+
+
+class TestAnswerResumesParkedTask:
+    def test_answer_queues_headless_resume_with_answer_and_resume_session(self) -> None:
+        parked = _parked_task()
+        question = _parked_question(parked)
+
+        call_command("questions", "answer", question.pk, "use postgres-1")
+
+        question.refresh_from_db()
+        assert question.answer_text == "use postgres-1"
+        assert question.resolved_via == DeferredQuestion.ResolvedVia.LOCAL
+        resume = parked.child_tasks.get()
+        assert resume.execution_target == Task.ExecutionTarget.HEADLESS
+        assert resume.parent_task_id == parked.pk
+        assert "use postgres-1" in resume.execution_reason
+        assert _get_resume_session_id(resume) == _RESUME_UUID
+
+    def test_answer_without_parked_task_queues_no_resume(self) -> None:
+        question = DeferredQuestion.record("Chat-only question?")
+
+        call_command("questions", "answer", question.pk, "yes")
+
+        question.refresh_from_db()
+        assert question.answer_text == "yes"
+        assert not Task.objects.exists()
+
+    def test_re_answer_does_not_double_queue_resume(self) -> None:
+        parked = _parked_task()
+        question = _parked_question(parked)
+
+        call_command("questions", "answer", question.pk, "use postgres-1")
+        with pytest.raises(SystemExit):
+            call_command("questions", "answer", question.pk, "use postgres-2")
+
+        assert parked.child_tasks.count() == 1
+
+    def test_pre_existing_resume_child_is_not_double_queued(self) -> None:
+        parked = _parked_task()
+        question = _parked_question(parked)
+        existing = Task.objects.create(
+            ticket=parked.ticket,
+            session=parked.session,
+            phase=parked.phase,
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            parent_task=parked,
+        )
+
+        call_command("questions", "answer", question.pk, "use postgres-1")
+
+        assert list(parked.child_tasks.values_list("pk", flat=True)) == [existing.pk]


### PR DESCRIPTION
Makes the CLI answer channel (`t3 teatree questions answer <pk> <text>`) resume a parked headless task, reaching parity with the Slack reply channel. Previously the CLI path called `DeferredQuestion.consume()` + wrote an audit row but never called `schedule_headless_resume`, so a user who answered via the CLI (as `_resurface_text` instructs) stranded the headless run parked forever. Surfaced by the #2776 cold review.

## Architecture pre-check — #31

## 1. BLUEPRINT § alignment
§17.1 invariant 9 (away-mode question capture → durable DeferredQuestion) + the headless-resume seam. The fix makes the CLI answer channel reach parity with the Slack reply channel; no BLUEPRINT contradiction, no spec change.

## 2. FSM phase boundaries
n/a — no Ticket.State / Worktree.State transition. The resume Task is created by the existing schedule_headless_resume seam, not a new transition.

## 3. Extension-point contracts
n/a — no OverlayBase / scanner-registration / hook / *Backend Protocol change. Reuses the same seam (schedule_headless_resume) the askuserquestion_reply scanner already consumes; no new consumer introduced.

## 4. Component boundaries
src/teatree/core/management/commands/questions.py (interface layer, CLI command — coordination only). Business logic stays in the seam core/models/task_handoff.schedule_headless_resume. No straddle.

## 5. Dependency direction
Added import: teatree.core.management → teatree.core.models.task_handoff. tach.toml already declares teatree.core.management depends_on teatree.core, so no backwards edge. `uv run tach check` → "All modules validated".

## 6. Test surface
tests/teatree_core/management/test_questions_headless_resume.py via call_command:
- HAS parked_task → exactly one HEADLESS child chained on parent_task, answer in execution_reason, _get_resume_session_id == captured session.
- NO parked_task → no Task created.
- re-answer / pre-existing child → child count stays 1 (idempotent).
Anti-vacuity confirmed: the resume test REDs on pre-fix main (Task.DoesNotExist).

## 7. Resilience invariants
External write = local DB rows (resume Session + Task). idempotency: via schedule_headless_resume existing-child guard + consume single-use CAS. verify-by-re-read / fallback-transport / heartbeat / sub-agent-return-contract: n/a (single transactional CLI write, no external transport).

## 8. Identity and key normalization
n/a — no bare-vs-qualified identity; no split/strip/removeprefix introduced.

## 9. Behavior preservation / capability deletion
Purely additive. The existing answer behavior (consume + resolved_via=LOCAL + audit, all atomic) is unchanged; the resume scheduling is appended inside the same atomic block. No behavior removed, no test inverted, no matcher narrowed.
