### PR TITLE
fix(worktree): teardown survives a vanished path during prek hook (#2692)

### DIFF
--- a/src/teatree/core/cleanup.py
+++ b/src/teatree/core/cleanup.py
@@ -428,7 +428,14 @@ def _remove_git_worktree(
     # detached HEAD has no branch to delete (``branch_to_delete is None``).
     if target.branch_to_delete is not None and not git.branch_delete(str(repo_main), target.branch_to_delete):
         errors.append(f"git branch -D failed for {target.branch_to_delete}")
-    prek_hook.remove_stale_hooks(str(repo_main), wt_path)
+    # Best-effort, per-step isolated: a benign hook-cleanup raise (e.g. a
+    # vanished path/CWD mid-teardown, #2692) is surfaced — never propagated past
+    # this step, which would skip the DB drop, ``Worktree`` row delete and reap
+    # ordered after it in ``cleanup_worktree``.
+    try:
+        prek_hook.remove_stale_hooks(str(repo_main), wt_path)
+    except OSError as exc:
+        errors.append(f"stale prek hook cleanup failed for {wt_path}: {exc}")
     return errors
 
 

--- a/src/teatree/core/prek_hook.py
+++ b/src/teatree/core/prek_hook.py
@@ -170,6 +170,13 @@ def remove_stale_hooks(wt_path: str, removed_dir: str) -> list[str]:
 
 
 def _is_within(candidate: Path, parent: Path) -> bool:
+    # A PATH-resolved hook bakes the relative ``PREK="prek"`` (#1462); that is a
+    # PATH lookup, never a filesystem path inside ``parent``, so it is never
+    # "within". Short-circuiting also avoids ``resolve()`` anchoring a relative
+    # path against ``os.getcwd()`` — which raises FileNotFoundError once the
+    # worktree the process sits in has vanished mid-teardown (#2692).
+    if not candidate.is_absolute():
+        return False
     try:
         candidate.resolve().relative_to(parent)
     except ValueError:

--- a/tests/teatree_core/cleanup/test_cleanup_worktree.py
+++ b/tests/teatree_core/cleanup/test_cleanup_worktree.py
@@ -776,6 +776,73 @@ class TestCleanupWorktreeSurvivesMissingProvisionTimebox(TestCase):
         assert result.clean is True
 
 
+class TestCleanupWorktreeSurvivesVanishedHookPath(TestCase):
+    """souliane/teatree#2692 — teardown completes ALL steps when hook-cleanup raises.
+
+    The benign prek hook-cleanup step (``_remove_git_worktree`` →
+    ``prek_hook.remove_stale_hooks``) resolves a PATH-hardened hook's relative
+    ``PREK="prek"`` value, which raises ``FileNotFoundError`` once the process
+    CWD has vanished mid-teardown (the worktree dir was removed earlier in the
+    same run). That throw aborted ``cleanup_worktree`` before the DB drop and
+    ``Worktree`` row delete — leaving an orphaned DB and DB row. Hook cleanup is
+    best-effort: its failure is surfaced, never propagated, so the later steps run.
+    """
+
+    def _make_worktree(self, *, db_name: str = "wt_2692") -> Worktree:
+        ticket = Ticket.objects.create(
+            issue_url="https://gitlab.com/org/repo/-/issues/2692",
+            state=Ticket.State.IN_REVIEW,
+        )
+        return Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="org/repo",
+            branch="fix-2692",
+            db_name=db_name,
+            extra={"worktree_path": "/tmp/wt/org/repo"},
+        )
+
+    @_patch_overlay
+    @_patch_config
+    def test_db_drop_and_row_delete_still_run_when_hook_cleanup_raises(
+        self,
+        mock_config: MagicMock,
+        mock_overlay: MagicMock,
+    ) -> None:
+        """A ``FileNotFoundError`` from hook cleanup is surfaced, not propagated.
+
+        Anti-vacuous: it pins that the DB-drop step IS invoked and the
+        ``Worktree`` row IS deleted (the two steps the abort skipped), and that
+        the hook-cleanup failure is recorded in ``errors`` rather than swallowed.
+        """
+        _mock_workspace(mock_config)
+        mock_overlay.return_value.get_cleanup_steps.return_value = []
+        mock_overlay.return_value.reap_worktree_external_resources.return_value = []
+
+        wt = self._make_worktree(db_name="wt_2692")
+        wt_id = wt.pk
+
+        with (
+            patch("teatree.core.cleanup.git") as mock_git,
+            patch("teatree.core.cleanup.drop_db") as mock_drop,
+            patch("teatree.core.runners.worktree_start.docker_compose_down"),
+            patch(
+                "teatree.core.cleanup.prek_hook.remove_stale_hooks",
+                side_effect=FileNotFoundError(2, "No such file or directory"),
+            ),
+        ):
+            _no_unpushed(mock_git)
+            mock_git.status_porcelain.return_value = ""
+            mock_git.unsynced_commits.return_value = []
+            result = cleanup_worktree(wt, strict_hygiene=False)
+
+        mock_drop.assert_called_once()
+        assert mock_drop.call_args.args == ("wt_2692",)
+        assert not Worktree.objects.filter(pk=wt_id).exists()
+        assert result.clean is False
+        assert any("hook" in e.lower() for e in result.errors)
+
+
 class TestCleanupWorktreeLoudTeardown(TestCase):
     """#877 — teardown failures surface in ``CleanupResult.errors``.
 

--- a/tests/teatree_core/test_prek_hook.py
+++ b/tests/teatree_core/test_prek_hook.py
@@ -18,6 +18,7 @@ with a path inside that worktree, so the OTHER worktrees' pushes keep running
 the hook to completion (the acceptance criterion).
 """
 
+import os
 import re
 import shutil
 import subprocess
@@ -26,6 +27,11 @@ from pathlib import Path
 import pytest
 
 from teatree.core import prek_hook
+
+
+def _vanished_cwd() -> str:
+    raise FileNotFoundError(2, "No such file or directory")
+
 
 _GIT_BIN = shutil.which("git") or "/usr/bin/git"
 
@@ -132,6 +138,32 @@ class TestRemoveStaleHooks:
 
         assert hook.exists(), "a PATH-resolved hook is never stale and must survive any teardown"
         assert cleaned == []
+
+
+class TestRemoveStaleHooksSurvivesVanishedAnchor:
+    """souliane/teatree#2692 — a PATH-resolved hook must not crash teardown on a vanished CWD.
+
+    Classifying a hook bakes its ``PREK=`` value through ``_is_within``. For a
+    PATH-hardened hook that value is the relative ``"prek"`` (#1462), so
+    ``Path("prek").resolve()`` resolves against ``os.getcwd()`` — which raises
+    ``FileNotFoundError`` once the worktree the process is sitting in has been
+    removed earlier in the same teardown. The throw aborted ``cleanup_worktree``
+    before the DB drop / row delete / reap steps ran.
+    """
+
+    def test_keeps_path_resolved_hook_when_cwd_is_gone(self, main_clone: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        hook = _write_stale_hook(main_clone, "pre-push", "prek")
+        monkeypatch.setattr(os, "getcwd", _vanished_cwd)
+
+        cleaned = prek_hook.remove_stale_hooks(str(main_clone), str(main_clone.parent / "torn-down-wt"))
+
+        assert hook.exists(), "PATH-resolved hook must survive teardown even with a vanished CWD"
+        assert cleaned == []
+
+    def test_is_within_relative_candidate_never_resolves(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(os, "getcwd", _vanished_cwd)
+
+        assert prek_hook._is_within(Path("prek"), Path("/removed/worktree")) is False
 
 
 @pytest.mark.skipif(shutil.which("prek") is None, reason="prek not on PATH")


### PR DESCRIPTION
## What

`t3 <overlay> worktree teardown` aborted with a `FileNotFoundError` raised inside `prek_hook._is_within` → `Path.resolve()` when the worktree directory had already been removed earlier in the same teardown. The throw propagated out of `_remove_git_worktree` and aborted `cleanup_worktree` before the DB drop, `Worktree` row delete and external-resource reap ran — leaving an orphaned DB and DB row (the same class as #2664).

## Root cause

A PATH-hardened prek hook bakes a **relative** `PREK="prek"` (#1462). During teardown, `_remove_git_worktree` → `prek_hook.remove_stale_hooks` classifies that value through `_is_within(Path("prek"), removed)`, and `Path("prek").resolve()` anchors the relative path against `os.getcwd()`. Once the worktree the process is sitting in has been removed earlier in the same run, `os.getcwd()` raises `FileNotFoundError`. (An absolute candidate's `resolve()` never needs `getcwd`, so the crash was specific to the relative PATH-resolved value.)

## Fix

- **Root cause** (`prek_hook._is_within`): a relative candidate is a PATH lookup, never a filesystem path inside the removed dir, so `_is_within` short-circuits to `False` for a non-absolute candidate instead of resolving it. This both fixes the classification correctness and removes the `getcwd`-dependent resolve.
- **Defense-in-depth** (`cleanup._remove_git_worktree`): the `remove_stale_hooks` call is now per-step isolated — an `OSError` is surfaced as a `CleanupResult.errors` entry (consistent with the existing #877 loud-teardown contract) rather than propagated past the steps ordered after it (DB drop, row delete, reap).

## Tests (RED → GREEN)

Observed failing on the pre-fix code (3 failed with the exact `FileNotFoundError`), passing after the fix:

- `test_prek_hook.py::TestRemoveStaleHooksSurvivesVanishedAnchor::test_keeps_path_resolved_hook_when_cwd_is_gone` — a PATH-resolved hook survives teardown when the process CWD has vanished.
- `test_prek_hook.py::…::test_is_within_relative_candidate_never_resolves` — `_is_within` never resolves a relative candidate.
- `test_cleanup_worktree.py::TestCleanupWorktreeSurvivesVanishedHookPath::test_db_drop_and_row_delete_still_run_when_hook_cleanup_raises` — `cleanup_worktree` still drops the DB and deletes the `Worktree` row when hook cleanup raises `FileNotFoundError` (anti-vacuous: it pins the two steps the abort skipped, and that the failure is surfaced in `errors`).

## Architecture pre-check — #2692

### 1. BLUEPRINT § alignment
Tactical resilience fix on the worktree teardown path (`cleanup_worktree` step runner); same class as the #877 loud-teardown contract and the #2664 sibling abort. No BLUEPRINT section change.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition added or moved.

### 3. Extension-point contracts
n/a — no `OverlayBase` / scanner / hook / `*Backend` Protocol surface touched.

### 4. Component boundaries
`src/teatree/core/`: `prek_hook.py` (path-classification helper) and `cleanup.py` (teardown step runner). Correct home for both.

### 5. Dependency direction
No new cross-module import. `uv run tach check` → all modules validated.

### 6. Test surface
`tests/teatree_core/test_prek_hook.py` (the `_is_within` / `remove_stale_hooks` contract) and `tests/teatree_core/cleanup/test_cleanup_worktree.py` (the per-step isolation in `_remove_git_worktree`). Each assertion is anti-vacuous and was observed RED before the fix.

### 7. Resilience invariants
This is a resilience fix: per-step isolation so a benign cleanup raise does not abort the steps ordered after it; idempotent; surfaced (never swallowed) into `CleanupResult.errors`. No new external write is introduced.

### 8. Identity and key normalization
n/a.

### 9. Behavior preservation / capability deletion
Purely additive — a non-absolute short-circuit guard plus a per-step `try/except` that surfaces. No behavior removed; happy-path hook classification is unchanged (existing `TestRemoveStaleHooks` tests stay green). No privacy/security matcher narrowed, no must-block test inverted.

Refs #2692
