### PR TITLE
fix(tests): make the linear-migrations test xdist-safe (#2689)

### DIFF
--- a/tests/teatree_core/test_linear_migrations.py
+++ b/tests/teatree_core/test_linear_migrations.py
@@ -3,45 +3,32 @@
 ``django_linear_migrations`` registers ``check_max_migration_files`` as a
 Django system check (tagged ``Tags.models``).  It fires whenever Django runs
 its check framework (``python manage.py check``, or any management command
-that runs checks).  This suite exercises the check directly against the live
-``teatree.core`` migrations directory so that the tests are anti-vacuous:
-they fail if ``django_linear_migrations`` is absent from ``INSTALLED_APPS``
-or if ``max_migration.txt`` is missing.
+that runs checks).
+
+Each error condition (dlm.E001/E002/E004/E005) is provoked against a throwaway
+migrations app built under the test's ``tmp_path`` and installed for the
+duration of the check — the live ``teatree.core`` migrations directory is never
+mutated.  That isolation is what makes the suite xdist-safe: the live
+``max_migration.txt`` is shared mutable state that the system check run by other
+suites (e.g. ``call_command`` in ``test_env_command``) reads concurrently, so a
+test that overwrote it could race a parallel worker into a spurious dlm.E002.
+A separate read-only test asserts the live graph is itself dlm-clean, preserving
+the anti-vacuity the per-condition sandbox tests cannot.
 """
 
+import sys
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 import django.conf
+from django.conf import settings
 from django.core.checks import run_checks
-from django.db.migrations.loader import MigrationLoader
-from django.test import SimpleTestCase
+from django.test import override_settings
 
 _CORE_MIGRATIONS_DIR = Path(__file__).resolve().parents[2] / "src" / "teatree" / "core" / "migrations"
-_MAX_MIGRATION_TXT = _CORE_MIGRATIONS_DIR / "max_migration.txt"
-_SIBLING_LEAF = _CORE_MIGRATIONS_DIR / "0001_sibling_leaf_fork.py"
-# A transient linear child of the real leaf — used to manufacture an
-# existing-but-stale ``max_migration.txt`` (dlm.E004): it depends on the real
-# leaf so the chain stays linear (one leaf), making any earlier name a stale
-# entry rather than a fork.
-_LINEAR_CHILD = _CORE_MIGRATIONS_DIR / "9999_linear_child.py"
-
-
-def _real_latest_migration() -> str:
-    names = sorted(p.stem for p in _CORE_MIGRATIONS_DIR.glob("[0-9]*.py"))
-    return names[-1]
-
-
-def _core_leaf_dependencies() -> list[tuple[str, str]]:
-    """The ``(app, name)`` dependencies of the live ``core`` leaf migration.
-
-    A sibling sharing these dependencies forks the graph (two leaves off the
-    same parent). For the squashed single-``0001_initial`` graph the leaf is a
-    *root* with no parent, so this returns ``[]`` and the sibling is a second
-    root — still two leaf nodes, which is exactly the dlm.E005 fork condition.
-    """
-    loader = MigrationLoader(None, ignore_no_migrations=True)
-    leaf = max(node for node in loader.graph.leaf_nodes() if node[0] == "core")
-    return [parent.key for parent in loader.graph.node_map[leaf].parents]
+_CORE_MAX_MIGRATION_TXT = _CORE_MIGRATIONS_DIR / "max_migration.txt"
 
 
 def _migration_source(dependencies: list[tuple[str, str]]) -> str:
@@ -53,63 +40,116 @@ def _migration_source(dependencies: list[tuple[str, str]]) -> str:
     )
 
 
-class LinearMigrationsCheckTest(SimpleTestCase):
-    """check_max_migration_files catches fork signals and passes clean graphs."""
+def _dlm_error_ids() -> list[str]:
+    return [e.id for e in run_checks(tags=["models"]) if e.id and e.id.startswith("dlm.")]
 
-    def setUp(self) -> None:
-        self._original_content: str | None = None
-        if _MAX_MIGRATION_TXT.exists():
-            self._original_content = _MAX_MIGRATION_TXT.read_text()
 
-    def tearDown(self) -> None:
-        _SIBLING_LEAF.unlink(missing_ok=True)
-        _LINEAR_CHILD.unlink(missing_ok=True)
-        if self._original_content is None:
-            _MAX_MIGRATION_TXT.unlink(missing_ok=True)
-        else:
-            _MAX_MIGRATION_TXT.write_text(self._original_content)
+@contextmanager
+def _sandbox_migrations_app(
+    tmp_path: Path,
+    *,
+    migrations: dict[str, list[str]],
+    max_migration: str | None,
+) -> Iterator[None]:
+    """Install a throwaway migrations app under ``tmp_path`` for the block.
 
-    def _dlm_errors(self) -> list[str]:
-        errors = run_checks(tags=["models"])
-        return [e.id for e in errors if e.id and e.id.startswith("dlm.")]
+    ``migrations`` maps a migration name to the names of its same-app
+    dependencies, so the caller shapes the graph (a linear chain, or two roots
+    for a fork) without knowing the app's generated label.  The app is added to
+    ``INSTALLED_APPS`` so the real ``check_max_migration_files`` runs against it,
+    then fully unwound — including the ``sys.path`` entry and any imported
+    submodules — so nothing leaks into a sibling test.  A per-call unique label
+    means even a crashed unwind cannot collide a later test on a stale
+    ``sys.modules`` entry.
+    """
+    label = f"dlm_sandbox_{uuid.uuid4().hex}"
+    migrations_dir = tmp_path / label / "migrations"
+    migrations_dir.mkdir(parents=True)
+    (tmp_path / label / "__init__.py").write_text("")
+    (migrations_dir / "__init__.py").write_text("")
+    for name, sibling_deps in migrations.items():
+        (migrations_dir / f"{name}.py").write_text(_migration_source([(label, dep) for dep in sibling_deps]))
+    if max_migration is not None:
+        (migrations_dir / "max_migration.txt").write_text(max_migration)
 
-    def test_linear_graph_passes(self) -> None:
-        _MAX_MIGRATION_TXT.write_text(_real_latest_migration() + "\n")
-        assert self._dlm_errors() == [], "clean max_migration.txt must produce no dlm.* errors"
+    sys.path.insert(0, str(tmp_path))
+    try:
+        with override_settings(INSTALLED_APPS=[*settings.INSTALLED_APPS, label]):
+            yield
+    finally:
+        if str(tmp_path) in sys.path:
+            sys.path.remove(str(tmp_path))
+        for module_name in [m for m in sys.modules if m == label or m.startswith(f"{label}.")]:
+            del sys.modules[module_name]
 
-    def test_missing_max_migration_txt_raises_e001(self) -> None:
-        _MAX_MIGRATION_TXT.unlink(missing_ok=True)
-        errors = self._dlm_errors()
-        assert "dlm.E001" in errors, f"missing max_migration.txt must yield dlm.E001; got {errors}"
 
-    def test_forked_max_migration_txt_detected(self) -> None:
-        latest = _real_latest_migration()
-        _MAX_MIGRATION_TXT.write_text(f"{latest}\n0002_other_leaf\n")
-        errors = self._dlm_errors()
-        assert "dlm.E002" in errors, (
-            f"two-line max_migration.txt (merge-conflict residue) must yield dlm.E002; got {errors}"
-        )
+def test_clean_linear_graph_produces_no_dlm_errors(tmp_path: Path) -> None:
+    with _sandbox_migrations_app(
+        tmp_path,
+        migrations={"0001_initial": [], "0002_child": ["0001_initial"]},
+        max_migration="0002_child\n",
+    ):
+        assert _dlm_error_ids() == [], "a clean linear graph must produce no dlm.* errors"
 
-    def test_stale_max_migration_txt_raises_e004(self) -> None:
-        # Add a transient linear child of the REAL leaf so the chain stays
-        # linear (one leaf, ``9999_linear_child``); naming the prior real leaf
-        # in ``max_migration.txt`` is then an existing — but stale — entry
-        # (dlm.E004, not E003), without forking the graph (which would be E005).
-        latest = _real_latest_migration()
-        _LINEAR_CHILD.write_text(_migration_source([("core", latest)]))
-        _MAX_MIGRATION_TXT.write_text(f"{latest}\n")
-        errors = self._dlm_errors()
-        assert "dlm.E004" in errors, f"stale max_migration.txt must yield dlm.E004; got {errors}"
 
-    def test_multiple_leaf_nodes_raises_e005(self) -> None:
-        deps = _core_leaf_dependencies()
-        _SIBLING_LEAF.write_text(_migration_source(deps))
-        errors = self._dlm_errors()
-        assert "dlm.E005" in errors, (
-            f"a forked migration graph (a sibling leaf off deps {deps!r}) must yield dlm.E005; got {errors}"
-        )
+def test_missing_max_migration_txt_raises_e001(tmp_path: Path) -> None:
+    with _sandbox_migrations_app(
+        tmp_path,
+        migrations={"0001_initial": []},
+        max_migration=None,
+    ):
+        errors = _dlm_error_ids()
+    assert "dlm.E001" in errors, f"missing max_migration.txt must yield dlm.E001; got {errors}"
 
-    def test_dlm_installed_in_apps(self) -> None:
-        assert "django_linear_migrations" in django.conf.settings.INSTALLED_APPS, (
-            "django_linear_migrations must be in INSTALLED_APPS for the check to fire"
-        )
+
+def test_forked_max_migration_txt_raises_e002(tmp_path: Path) -> None:
+    with _sandbox_migrations_app(
+        tmp_path,
+        migrations={"0001_initial": []},
+        max_migration="0001_initial\n0002_other_leaf\n",
+    ):
+        errors = _dlm_error_ids()
+    assert "dlm.E002" in errors, (
+        f"a two-line max_migration.txt (merge-conflict residue) must yield dlm.E002; got {errors}"
+    )
+
+
+def test_stale_max_migration_txt_raises_e004(tmp_path: Path) -> None:
+    # A linear chain 0001 -> 0002 with max_migration.txt naming the earlier
+    # 0001 — an existing but stale entry (dlm.E004), not a non-existent one
+    # (E003) and not a fork (E005).
+    with _sandbox_migrations_app(
+        tmp_path,
+        migrations={"0001_initial": [], "0002_child": ["0001_initial"]},
+        max_migration="0001_initial\n",
+    ):
+        errors = _dlm_error_ids()
+    assert "dlm.E004" in errors, f"stale max_migration.txt must yield dlm.E004; got {errors}"
+
+
+def test_multiple_leaf_nodes_raises_e005(tmp_path: Path) -> None:
+    with _sandbox_migrations_app(
+        tmp_path,
+        migrations={"0001_root_a": [], "0001_root_b": []},
+        max_migration="0001_root_a\n",
+    ):
+        errors = _dlm_error_ids()
+    assert "dlm.E005" in errors, f"a forked migration graph (two leaf nodes) must yield dlm.E005; got {errors}"
+
+
+def test_dlm_installed_and_live_core_graph_is_clean() -> None:
+    """Read-only anti-vacuity against the real graph.
+
+    Proves ``django_linear_migrations`` is wired (so the per-condition sandbox
+    checks actually fire) and the live ``teatree.core`` max_migration.txt is
+    present, single-line, and current.  Reads the live file but never writes it,
+    so it stays xdist-safe alongside the system check other suites trigger.
+    """
+    assert "django_linear_migrations" in django.conf.settings.INSTALLED_APPS, (
+        "django_linear_migrations must be in INSTALLED_APPS for the check to fire"
+    )
+    assert _CORE_MAX_MIGRATION_TXT.exists(), "live core max_migration.txt must exist"
+    assert len(_CORE_MAX_MIGRATION_TXT.read_text().strip().splitlines()) == 1, (
+        "live core max_migration.txt must be a single line"
+    )
+    assert _dlm_error_ids() == [], "the live migration graph must be dlm-clean"


### PR DESCRIPTION
## Summary

`tests/teatree_core/test_linear_migrations.py` overwrote the live,
version-controlled `src/teatree/core/migrations/max_migration.txt` in
`setUp`/test/`tearDown`. Under the repo's default parallel distribution
(`-n auto`) that file is process-shared mutable state: `test_env_command`'s
`call_command` invocations run Django's system checks — including
`django_linear_migrations`' `check_max_migration_files` — against the same
live file. A concurrent xdist worker (or a crashed teardown) could observe the
mid-mutation two-line file and report a spurious `dlm.E002` on a PR that never
touched migrations; a crashed teardown also left the working tree dirty.

Refs [#2689](https://github.com/souliane/teatree/issues/2689).

## Root cause

Shared mutable state on a real on-disk file. The fix the issue flags as the
more robust one is to stop mutating the live file rather than only serialize
access to it.

## Fix

Each `dlm` error condition (E001/E002/E004/E005) and the clean-graph case is
now provoked against a throwaway migrations app built under the test's
`tmp_path` and installed into `INSTALLED_APPS` only for the duration of the
real `check_max_migration_files` run, then fully unwound (`sys.path` +
`sys.modules`). The live `teatree.core` migrations directory is never written,
so there is no shared state for a parallel worker to race on. A per-call unique
app label means even a crashed unwind cannot collide a sibling test on a stale
`sys.modules` entry.

Anti-vacuity is preserved:

- the per-condition assertions still fire — verified RED when the provoked
  condition is removed (a single-line `max_migration.txt` makes the E002
  assertion fail);
- a new read-only test asserts the live core graph is itself `dlm`-clean and
  single-line — the property the sandbox tests cannot cover — without writing
  the file, so it stays xdist-safe alongside the system check other suites
  trigger.

## Verification

- Serial: `pytest test_linear_migrations.py -n0` → 6 passed.
- Parallel (specific test): `pytest test_linear_migrations.py -n auto` → 6 passed.
- Parallel (the exact race pair): `pytest test_linear_migrations.py test_env_command.py -n auto` → 22 passed.
- The live `max_migration.txt` / `migrations/` dir is untouched after a run
  (`git status` clean outside the test file).
- `ruff check` / `ruff format --check` / `ty check` clean on the file.

## Architecture pre-check — #2689

### 1. BLUEPRINT § alignment
n/a — tactical test-reliability change. No `src/` behaviour changes; the
production `check_max_migration_files` it exercises is unchanged.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transitions.

### 3. Extension-point contracts
n/a — no `OverlayBase` / scanner / hook / Protocol surface touched.

### 4. Component boundaries
Change is confined to `tests/teatree_core/test_linear_migrations.py`. The
sandbox-app helper lives with the test that uses it (no new module).

### 5. Dependency direction
No new cross-module `src/` imports — test-only. Uses stdlib (`sys`, `uuid`,
`contextlib`, `pathlib`) and Django test utilities already in scope.

### 6. Test surface
The behaviour under test is unchanged (the dlm.E001/E002/E004/E005 + clean
cases). Isolation strategy moved from live-file mutation to a `tmp_path`
sandbox app; each assertion was confirmed RED when its provoked condition is
removed.

### 7. Resilience invariants
The only writes are to `tmp_path` (auto-cleaned) and the scoped
`override_settings` + `sys.path`/`sys.modules` mutations, all unwound in a
`finally`. Idempotent: a unique per-call app label means repeated/overlapping
runs never collide; a crashed unwind cannot strand a sibling test.

### 8. Identity and key normalization
n/a — no qualified/bare identity handling.

### 9. Behavior preservation / capability deletion
Removed the live-file mutation path and the now-unused `MigrationLoader`-based
helpers (`_real_latest_migration`, `_core_leaf_dependencies`). Every dlm case
the old code asserted is preserved; the live-graph anti-vacuity the old design
got from mutating the real file is replaced by an explicit read-only assertion
that the live core graph is dlm-clean. No privacy/security matcher narrowed; no
must-block test inverted.