### PR TITLE
fix(loop): refresh statusline on loop-owner take-over to clear stale hijack anchor

### DIFF
--- a/src/teatree/core/management/commands/loop_owner.py
+++ b/src/teatree/core/management/commands/loop_owner.py
@@ -27,10 +27,31 @@ import typer
 from django_typer.management import TyperCommand, command
 
 
+def _refresh_loop_owner_statusline() -> None:
+    """Re-render the statusline after a global ``loop-owner`` ownership change.
+
+    The foreign-hijack RED anchor reads the DB ``loop-owner`` lease, but the
+    rendered zones file is rewritten only on a tick or an explicit re-render —
+    so a ``claim``/``take-over`` that transfers the lease to THIS session left
+    the stale pre-claim RED line (written by this session's own earlier foreign
+    render) alive in the file, split-brained against the live per-session badge
+    ``statusline.sh`` reads from the loop registry. Recomputing the anchor here
+    against the just-written owner (now this session) clears it in the same
+    command. Reuses the #2625 self-heal render seam. Fails open: a render error
+    must never fail the claim it follows.
+    """
+    try:
+        from teatree.loop.phases.render import rerender_statusline  # noqa: PLC0415
+
+        rerender_statusline()
+    except Exception:  # noqa: BLE001
+        return
+
+
 def _claim(slot: str, *, take_over: bool, json_output: bool, stdout_write) -> None:  # noqa: ANN001
     import os  # noqa: PLC0415
 
-    from teatree.core.loop_lease_manager import is_per_loop_owner_slot  # noqa: PLC0415
+    from teatree.core.loop_lease_manager import GLOBAL_OWNER_SLOT, is_per_loop_owner_slot  # noqa: PLC0415
     from teatree.core.models import LoopLease  # noqa: PLC0415
     from teatree.loop.session_identity import current_session_id, current_session_pid  # noqa: PLC0415
 
@@ -61,6 +82,10 @@ def _claim(slot: str, *, take_over: bool, json_output: bool, stdout_write) -> No
     won, owner = LoopLease.objects.claim_ownership(
         slot, session_id=session_id, take_over=take_over, owner_pid=owner_pid
     )
+    if won and slot == GLOBAL_OWNER_SLOT:
+        # The lease now names THIS session — clear any stale foreign-hijack
+        # anchor the rendered statusline still carries from before the claim.
+        _refresh_loop_owner_statusline()
     if json_output:
         stdout_write(json.dumps({"ok": won, "slot": slot, "owner_session": owner}, indent=2))
     elif won:

--- a/tests/teatree_loop/test_loop_owner_statusline_refresh.py
+++ b/tests/teatree_loop/test_loop_owner_statusline_refresh.py
@@ -1,0 +1,98 @@
+"""``t3 loop claim --take-over`` refreshes the foreign-hijack statusline anchor.
+
+The split-brain bug: the per-session loop-owner badge (``statusline.sh``) reads
+the LIVE ``loop-registry.json``, while the foreign-hijack RED anchor
+(:func:`teatree.loop.phases.render._populate_loop_owner_anchor`) reads the DB
+``loop-owner`` lease and is only ever re-rendered on a tick or an explicit
+re-render. A take-over mutates the DB lease but, pre-fix, never re-rendered the
+zones file — so after ``t3 loop claim --slot loop-owner --take-over`` the stale
+pre-take-over RED line (correctly written while the OLD session owned the lease)
+persisted alongside the now-live current-session badge:
+
+    loop-owner: <new>·pid<pid> · loop-owner=session <old> (NOT this session)
+
+The fix re-renders the statusline from inside the claim command on a won global
+``loop-owner`` claim, recomputing the anchor against the just-written owner
+(which is THIS session), so the stale RED clears in the same command that
+transferred ownership.
+"""
+
+import io
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from teatree.core.models import LoopLease
+from teatree.loop.phases.render import rerender_statusline
+from teatree.loop.statusline import default_path
+
+_RED_MARKER = "(NOT this session)"
+_OLD_SESSION = "0cd47d1adeadbeef"
+_NEW_SESSION = "647346c8cafebabe"
+
+
+def _isolated_env(td: str) -> dict[str, str]:
+    """Statusline file + loop registry under a temp dir, color stripped.
+
+    ``default_path()`` and the loop-registry both resolve under
+    ``XDG_DATA_HOME``; isolating it keeps the rendered file and the session-id
+    fallback off the dev box's real ``~/.local/share/teatree``. ``NO_COLOR``
+    strips ANSI so the RED-line assertion matches on plain text.
+    """
+    return {
+        "XDG_DATA_HOME": str(Path(td) / "data"),
+        "T3_LOOP_REGISTRY_DIR": str(Path(td) / "reg"),
+        "NO_COLOR": "1",
+    }
+
+
+def _clear_session_env() -> None:
+    for key in ("CLAUDE_SESSION_ID", "T3_LOOP_SESSION_ID", "T3_LOOP_SESSION_PID"):
+        os.environ.pop(key, None)
+
+
+class TestTakeOverRefreshesStatusline(TestCase):
+    def test_take_over_clears_stale_foreign_hijack_anchor(self) -> None:
+        with tempfile.TemporaryDirectory() as td, mock.patch.dict(os.environ, _isolated_env(td)):
+            _clear_session_env()
+
+            # 1. The OLD session holds a live ``loop-owner`` lease.
+            LoopLease.objects.claim_ownership("loop-owner", session_id=_OLD_SESSION, owner_pid=os.getpid())
+
+            # 2. The NEW session renders the statusline while the OLD session
+            #    still owns it → the foreign-hijack RED line is written.
+            os.environ["CLAUDE_SESSION_ID"] = _NEW_SESSION
+            rerender_statusline()
+            pre = default_path().read_text(encoding="utf-8")
+            assert _RED_MARKER in pre  # anti-vacuity: the RED line really is present pre-take-over
+            assert _OLD_SESSION[:8] in pre
+
+            # 3. The NEW session takes the loop over via the user hand-off command.
+            call_command(
+                "loop_owner", "claim", take_over=True, slot="loop-owner", json_output=True, stdout=io.StringIO()
+            )
+            assert LoopLease.objects.get(name="loop-owner").session_id == _NEW_SESSION
+
+            # 4. The rendered statusline no longer carries the stale foreign-hijack
+            #    line (RED pre-fix — take-over never re-rendered; GREEN post-fix).
+            post = default_path().read_text(encoding="utf-8")
+            assert _RED_MARKER not in post, f"stale foreign-hijack anchor survived take-over: {post!r}"
+            assert _OLD_SESSION[:8] not in post
+
+    def test_genuine_foreign_owner_still_renders_red(self) -> None:
+        # A genuinely foreign live owner must still surface the RED anchor — the
+        # fix clears a STALE anchor, it must not suppress real hijack detection.
+        with tempfile.TemporaryDirectory() as td, mock.patch.dict(os.environ, _isolated_env(td)):
+            _clear_session_env()
+            LoopLease.objects.claim_ownership("loop-owner", session_id=_OLD_SESSION, owner_pid=os.getpid())
+            os.environ["CLAUDE_SESSION_ID"] = _NEW_SESSION
+
+            rerender_statusline()
+
+            rendered = default_path().read_text(encoding="utf-8")
+            assert _RED_MARKER in rendered
+            assert f"loop-owner=session {_OLD_SESSION[:8]} {_RED_MARKER}" in rendered


### PR DESCRIPTION
## Summary

After a loop-owner take-over (`t3 loop claim --slot loop-owner --take-over`), the rendered statusline showed the loop owner twice with conflicting values — the live per-session badge naming the new owner, and a stale RED foreign-hijack anchor still naming the OLD owner and spuriously firing `(NOT this session)`.

## Root cause

Two reads of "who owns the loop" diverge after a take-over:

- The per-session badge in `hooks/scripts/statusline.sh` reads the **live** `loop-registry.json` `t3-loop-tick-owner` record on every render.
- The foreign-hijack RED anchor (`teatree.loop.phases.render._populate_loop_owner_anchor` → `loop_owner_anchor`) reads the **DB** `loop-owner` `LoopLease` row, but the rendered zones file (`default_path()`, the file `statusline.sh` `cat`s) is rewritten only on a loop tick or an explicit `rerender_statusline()`.

`t3 loop claim --take-over` updates the DB lease to the current session (so `t3 loop list` correctly shows the new owner) but never re-rendered the zones file. The RED line surviving in the file was the one correctly written by **this** session's earlier foreign render (when the OLD session still held the lease) — it persisted stale after ownership transferred. `loop_owner_anchor` prints `status.owner_session[:8]`, so the anchor named the old owner. Confirmed by the regression test, which reproduced the exact reported line `loop-owner=session 0cd47d1a (NOT this session)` after take-over.

This is candidate root cause #1 (the statusline reflects an older owner read than the take-over wrote) — specifically a missing re-render, not a stale `current_session_id()` and not a divergent owner key (`claim`/`take-over`/`loop list`/the anchor all key the single DB `loop-owner` row).

## Fix

Re-render the statusline from inside the claim command on a won global `loop-owner` claim (`_refresh_loop_owner_statusline` in `loop_owner.py`), recomputing the anchor against the just-written owner — which is THIS session, so the stale RED clears in the same command that transferred ownership. The write and the comparison use the same `current_session_id()` value within the one subprocess, so the cleared state is guaranteed consistent. Reuses the #2625 self-heal render seam and fails open so a render error never fails the claim.

## Tests

`tests/teatree_loop/test_loop_owner_statusline_refresh.py`:
- `test_take_over_clears_stale_foreign_hijack_anchor` — RED before / GREEN after; asserts the RED line is present pre-take-over (anti-vacuity) and absent post-take-over.
- `test_genuine_foreign_owner_still_renders_red` — a genuinely foreign live owner still surfaces the RED anchor (detection not suppressed).

## Architecture pre-check

- **One source of truth for the anchor.** `claim`/`take-over`, `t3 loop list` (`teatree.loops.live.build_report`), and the anchor (`ownership_status`) all read/write the single DB `loop-owner` `LoopLease` row — no divergent owner store was introduced. The badge intentionally reads the registry (per-session, no Django bootstrap in the shell hook); the fix makes the DB-derived anchor reflect the change promptly rather than collapsing the two stores.
- **Reuses the existing render seam.** No new rendering path — calls the established `rerender_statusline()` (#2625), the sanctioned self-heal seam, rather than hand-rolling a write.
- **Module boundaries.** `teatree.core.management` already declares `teatree.loop` in its tach `depends_on`; the deferred import keeps the dependency direction legal (tach green).
- **Fail-open preserved.** The render is wrapped so a render error never fails the ownership claim, matching the module's existing fail-open idiom for the loop-owner anchor.
- **Scoped to the bug class.** Gated on `won and slot == GLOBAL_OWNER_SLOT`, so per-loop (`loop:<name>`) claims and SKIPs are untouched; only a successful global-owner transfer triggers the refresh.

## Gates

`ruff check` ✓ · `ruff format --check` ✓ · `ty check` ✓ · `tach check` ✓ · `makemigrations --check --dry-run` (No changes detected) ✓ · 164 related tests + 2 new tests green.
