### PR TITLE
fix(banned-terms): stop false-positive on overlay-name reference (#2597)

### DIFF
--- a/hooks/scripts/banned_terms_deny.py
+++ b/hooks/scripts/banned_terms_deny.py
@@ -13,7 +13,13 @@ known-private target, where the repo's own domain words are expected. (2)
 own org/repo slug, landing in that private repo; a work-item URL naming the repo
 is not a leak. (3) ``own_repo_url_carve_out`` — a structured ``gh``/``glab`` post
 to a PUBLIC surface whose term appears ONLY inside a URL of one of the overlay's
-own configured repos; the address of the repo is not a leak.
+own configured repos; the address of the repo is not a leak. (4)
+``own_dest_slug_carve_out.term_is_destination_own_slug`` (#2597) — a structured
+post whose tripped term IS the OWN repo slug of every publish destination (the
+overlay's private tracker, named after the overlay); the repo's own name on its
+own surface is not a leak. Unlike (1)-(3) this keys off the resolved destination
+slug, not ``private_repos``, so it needs no config; a public destination whose
+slug omits the term still hard-blocks.
 
 Anything not downgraded hard-blocks, after emitting the #1657 unknown-visibility
 NOTE when the target's visibility could not be resolved in-hook.
@@ -26,7 +32,12 @@ from pathlib import Path
 def emit_banned_term_deny(tool_name: str, command: str, payload: str, term: str, cwd_repo: Path | None) -> bool:
     from hook_router import emit_pretooluse_deny  # noqa: PLC0415
 
-    from teatree.hooks import banned_terms_scanner, own_repo_url_carve_out, publish_surface  # noqa: PLC0415
+    from teatree.hooks import (  # noqa: PLC0415
+        banned_terms_scanner,
+        own_dest_slug_carve_out,
+        own_repo_url_carve_out,
+        publish_surface,
+    )
 
     if publish_surface.carve_out_applies(tool_name, command, payload, cwd_repo):
         sys.stderr.write(
@@ -48,6 +59,13 @@ def emit_banned_term_deny(tool_name: str, command: str, payload: str, term: str,
         sys.stderr.write(
             f"WARNING: banned-terms gate (#1415) — term '{term}' appears only inside a URL of "
             "the overlay's own configured repo; downgraded to warn. The address of the repo is not a leak.\n"
+        )
+        return False
+    if tool_name == "Bash" and own_dest_slug_carve_out.term_is_destination_own_slug(command, term, cwd_repo):
+        sys.stderr.write(
+            f"WARNING: banned-terms gate (#1415/#2597) — term '{term}' is the OWN repo slug of this "
+            "post's private destination; downgraded to warn. The tracker named after the overlay is "
+            "not a leak on its own surface; a public destination whose slug omits the term still blocks.\n"
         )
         return False
     unknown_slug = publish_surface.visibility_unknown_for_block(command, cwd_repo)

--- a/src/teatree/hooks/own_dest_slug_carve_out.py
+++ b/src/teatree/hooks/own_dest_slug_carve_out.py
@@ -1,0 +1,94 @@
+r"""Own-destination-slug carve-out for the banned-terms posting gate (#2597).
+
+Sibling of the own-repo-URL carve-out (:mod:`own_repo_url_carve_out`) and the
+own-slug commit downgrade (``_commit_carve_out.own_slug_term_downgrades``). It
+closes the #2597 false positive: a status comment that mentions the overlay
+name, posted to the overlay's OWN private tracker whose repo slug literally
+carries that name. On a private tracker the overlay name is the repo's own
+identity, not a foreign leak -- yet the banned-terms posting gate fired on it,
+forcing the ``ALLOW_BANNED_TERM=1`` escape on every internal status post.
+
+The carve-out is DERIVED, never hardcoded, and -- unlike the ``private_repos``
+carve-outs -- needs NO config: it keys off the RESOLVED DESTINATION SLUG. A
+post whose own destination repo path carries the tripped term proves itself the
+overlay's own repo; a repo whose forge path already carries the (private)
+overlay name has by construction already published that name in its slug, so a
+comment to it is not a NEW leak the gate could prevent. It is the posting-path
+sibling of ``_commit_carve_out.own_slug_term_downgrades`` (#1951), which keys
+off ``private_repos`` for the commit surface.
+
+The matching reuses the whole-token matcher (:mod:`teatree.hooks.term_match`)
+and the per-segment destination resolution / fail-closed segment predicates of
+:mod:`teatree.hooks.publish_destination`, so the destination resolution stays in
+one place across the destination skip and this downgrade. The predicate is
+fail-safe-to-block: it downgrades ONLY when EVERY top-level segment is a
+structured post whose resolved destination slug carries the term (or a provably
+inert nav segment), with no substitution / transport / raw-REST segment -- so a
+chained or substituted post to a public repo whose slug omits the term defeats
+the downgrade and that public surface stays hard-blocked.
+"""
+
+from pathlib import Path
+
+from teatree.hooks._gh_glab_hiding import command_segments
+from teatree.hooks._publish_detection import segment_is_api_read, segment_is_api_write
+from teatree.hooks.publish_destination import (
+    _destination_from_words,
+    _segment_carries_substitution_or_transport,
+    _segment_is_skip_inert,
+)
+from teatree.hooks.term_match import _contains_run, tokens
+
+
+def _term_is_slug_token_run(term: str, slug: str) -> bool:
+    """Return True iff ``term``'s tokens form a contiguous run within ``slug``'s tokens.
+
+    The org-prefix token ``democorp`` of ``democorp-eng/tracker`` matches, a
+    substring ``demo`` of ``democorp`` does not (whole-token), and a SUPERSET
+    ``democorp-services`` is a longer run than the slug carries and so is NOT
+    contained. An empty term tokenizes to nothing and never matches
+    (``_contains_run`` rejects an empty needle).
+    """
+    return _contains_run(tokens(slug), tokens(term))
+
+
+def term_is_destination_own_slug(command: str, term: str, cwd: Path | None) -> bool:
+    """Return True iff ``term`` is the OWN repo-slug of EVERY publish destination of ``command``.
+
+    The #2597 false positive: a status comment mentioning the overlay name,
+    posted to the overlay's OWN private tracker whose repo slug literally carries
+    that name. The name is the destination repo's own identity on its own
+    surface, not a foreign leak -- so the banned-term match downgrades to a warn.
+    A public destination whose slug does NOT carry the term (the canonical public
+    ``souliane/teatree``) is not matched, so that surface stays hard-blocked
+    (#2597 acceptance criterion 2).
+
+    Fires ONLY when EVERY top-level segment is either a structured
+    ``gh``/``glab``/``t3 review`` post whose resolved destination slug carries
+    ``term`` as a token-run, or a provably-inert nav/local segment -- with at
+    least one publish segment and no substitution/transport/raw-REST segment.
+    A chained post to a PUBLIC repo whose slug does NOT carry the term therefore
+    defeats the downgrade, and a raw ``api`` WRITE (which can carry its body to
+    any endpoint) is never eligible. Mirrors
+    :func:`publish_destination.gate_skips_destination`'s all-segments
+    fail-closed posture.
+    """
+    segments = command_segments(command)
+    if not segments:
+        return False
+    saw_publish = False
+    for words in segments:
+        if _segment_carries_substitution_or_transport(words):
+            return False
+        if segment_is_api_write(words):
+            return False
+        if segment_is_api_read(words):
+            continue
+        dest = _destination_from_words(words, cwd)
+        if dest is not None:
+            if not _term_is_slug_token_run(term, dest.slug):
+                return False
+            saw_publish = True
+        elif not _segment_is_skip_inert(words):
+            return False
+    return saw_publish

--- a/tests/teatree_hooks/test_own_dest_slug_carve_out.py
+++ b/tests/teatree_hooks/test_own_dest_slug_carve_out.py
@@ -1,0 +1,98 @@
+"""Tests for the own-destination-slug carve-out (`teatree.hooks.own_dest_slug_carve_out`).
+
+``term_is_destination_own_slug`` downgrades a banned-term match when the post's
+OWN destination repo slug IS the tripped term — the #2597 false positive where a
+status comment mentioning the overlay name, posted to the overlay's own private
+tracker (named after the overlay), was hard-blocked. The carve-out keys off the
+RESOLVED DESTINATION SLUG (config-free), so a tracker named after the overlay
+downgrades while a post to a public repo whose slug does NOT carry the term
+(``souliane/teatree``) still blocks (the #2597 acceptance criteria).
+
+Synthetic overlay name ``democorp`` only — no real overlay/customer name.
+"""
+
+from teatree.hooks.own_dest_slug_carve_out import term_is_destination_own_slug
+
+
+class TestTermIsDestinationOwnSlug:
+    def test_comment_to_private_tracker_named_after_overlay_downgrades(self) -> None:
+        cmd = 'gh issue comment 5 -R democorp-eng/tracker --body "status: democorp rollout on track"'
+        assert term_is_destination_own_slug(cmd, "democorp", None) is True
+
+    def test_same_term_to_public_teatree_still_blocks(self) -> None:
+        # Acceptance criterion 2: the public teatree slug does NOT carry the
+        # overlay term, so the same comment to a public destination still blocks.
+        cmd = 'gh issue create -R souliane/teatree --title x --body "democorp leak"'
+        assert term_is_destination_own_slug(cmd, "democorp", None) is False
+
+    def test_org_prefix_token_of_multi_token_slug_matches(self) -> None:
+        # The overlay name is the ORG-PREFIX token of the tracker's own path.
+        cmd = 'glab mr note 7 -R democorp-engineering/internal-tracker --message "democorp status"'
+        assert term_is_destination_own_slug(cmd, "democorp", None) is True
+
+    def test_url_positional_destination_resolves_and_downgrades(self) -> None:
+        cmd = 'gh issue comment https://github.com/democorp-eng/tracker/issues/5 --body "democorp note"'
+        assert term_is_destination_own_slug(cmd, "democorp", None) is True
+
+    def test_t3_review_post_to_own_named_project_downgrades(self) -> None:
+        cmd = 't3 review post-comment democorp-eng/tracker 5 --body "democorp status"'
+        assert term_is_destination_own_slug(cmd, "democorp", None) is True
+
+    def test_chained_public_post_defeats_downgrade(self) -> None:
+        # A private post named after the overlay chained to a PUBLIC post whose
+        # slug does NOT carry the term must NOT downgrade — the public surface
+        # stays blocked.
+        cmd = (
+            'gh issue comment 5 -R democorp-eng/tracker --body "democorp" '
+            '&& gh pr create -R souliane/teatree --body "democorp"'
+        )
+        assert term_is_destination_own_slug(cmd, "democorp", None) is False
+
+    def test_substitution_construct_defeats_downgrade(self) -> None:
+        cmd = 'glab mr note 7 -R democorp-eng/tracker --message "$(gh pr create -R souliane/teatree --body democorp)"'
+        assert term_is_destination_own_slug(cmd, "democorp", None) is False
+
+    def test_raw_api_write_is_not_eligible(self) -> None:
+        # A raw ``gh``/``glab api`` WRITE can carry its body to any endpoint, so
+        # it is never downgraded by the structured-destination slug carve-out.
+        cmd = "gh api --method POST repos/democorp-eng/tracker/issues/5/comments -f body=democorp"
+        assert term_is_destination_own_slug(cmd, "democorp", None) is False
+
+    def test_foreign_term_not_in_slug_does_not_downgrade(self) -> None:
+        # A genuine foreign customer term that is NOT the destination's own slug
+        # stays blocked even on a post to the private-named tracker.
+        cmd = 'gh issue comment 5 -R democorp-eng/tracker --body "othercorp secret"'
+        assert term_is_destination_own_slug(cmd, "othercorp", None) is False
+
+    def test_superset_term_longer_than_slug_run_does_not_downgrade(self) -> None:
+        # A SUPERSET term (a longer token-run than the slug's own) is not
+        # contained in the slug and stays blocked.
+        cmd = 'gh issue comment 5 -R democorp/tracker --body "democorp-services secret"'
+        assert term_is_destination_own_slug(cmd, "democorp-services", None) is False
+
+    def test_git_commit_is_not_eligible(self) -> None:
+        # The commit path keeps its own landing-repo carve-out; this destination
+        # carve-out is for structured posts only.
+        assert term_is_destination_own_slug('git commit -m "democorp"', "democorp", None) is False
+
+    def test_no_publish_segment_does_not_downgrade(self) -> None:
+        assert term_is_destination_own_slug("echo democorp", "democorp", None) is False
+
+    def test_empty_command_does_not_downgrade(self) -> None:
+        assert term_is_destination_own_slug("", "democorp", None) is False
+
+    def test_chained_read_only_api_stays_eligible(self) -> None:
+        # A read-only ``gh api`` GET posts no body, so it does not defeat the
+        # downgrade when the actual post targets the own-named private tracker.
+        cmd = (
+            "gh api repos/democorp-eng/tracker/issues "
+            '&& gh issue comment 5 -R democorp-eng/tracker --body "democorp status"'
+        )
+        assert term_is_destination_own_slug(cmd, "democorp", None) is True
+
+    def test_unrecognised_leader_chain_defeats_downgrade(self) -> None:
+        # An unrecognised executable can shell out to a hidden public post with
+        # no forge token in its argv, so it is never provably inert and defeats
+        # the downgrade (fail-closed, mirroring the destination skip).
+        cmd = 'gh issue comment 5 -R democorp-eng/tracker --body "democorp" && make release'
+        assert term_is_destination_own_slug(cmd, "democorp", None) is False


### PR DESCRIPTION
Refs #2597.

## Problem

The banned-terms posting gate is meant to protect PUBLIC artifacts, but it also
fired when posting a comment to the overlay's OWN private tracker — the private
repo whose own slug and URLs intrinsically carry the overlay name. On a private
tracker the overlay name is the repo's own identity, not a leak, so this was a
false positive that forced the `ALLOW_BANNED_TERM=1` escape on every internal
status post.

## Fix

Add a destination-slug carve-out to the banned-term deny chain: when a
structured `gh`/`glab`/`t3 review` post's **resolved destination slug IS the
tripped term** (a whole-token run of the repo's own path), downgrade the match
to a warn. It keys off the resolved destination slug rather than the
`private_repos` allowlist, so it needs **no config** — a tracker whose path
carries the overlay name proves itself the overlay's own repo. It is the
posting-path sibling of the existing commit-path own-slug downgrade.

The carve-out lives in a new leaf module `own_dest_slug_carve_out.py` (sibling
of `own_repo_url_carve_out.py`), which keeps `publish_destination.py` under its
module-health LOC cap.

### Fail-closed posture preserved

It fires only when EVERY top-level segment is a structured post whose resolved
destination slug carries the term (or a provably inert nav segment), with no
substitution / transport / raw-REST segment. So:

- A chained or substituted post to a public repo whose slug omits the term
  defeats the downgrade.
- A raw `api` WRITE (can target any endpoint) is never eligible.
- A `git commit` is not eligible (the commit path keeps its own carve-out).

### Acceptance criteria

- A comment containing the overlay name posted to the overlay's **private**
  tracker (whose slug carries that name) is **not** blocked — no escape needed.
- The same comment to a **public** destination (a public teatree issue/PR whose
  slug does not carry the term) **is still blocked**.

Both are pinned by `tests/teatree_hooks/test_own_dest_slug_carve_out.py`
(15 cases, 100% coverage of the new module). The tests use **synthetic terms
only** (a placeholder overlay name, the genuinely-public `souliane/teatree`) —
no real overlay/customer name appears anywhere in the diff.

## Architecture pre-check — #2597

### 1. BLUEPRINT § alignment
Privacy/leak-prevention gate surface (the public-vs-private "Visibility" repo
axis). A hook-layer carve-out composing with the existing destination-aware
publish gate; no BLUEPRINT section contradicted. The deny-chain ordering doc is
updated in `banned_terms_deny.py`.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition.

### 3. Extension-point contracts
None changed. No `OverlayBase` / scanner / hook-Protocol surface touched. The
banned-term deny chain gains one carve-out step; no overlay consumes it.

### 4. Component boundaries
New leaf `src/teatree/hooks/own_dest_slug_carve_out.py` (a banned-terms
carve-out, sibling of `own_repo_url_carve_out`) + one call site in
`hooks/scripts/banned_terms_deny.py` (the deny chain). Splitting into a new leaf
keeps `publish_destination.py` under the 500-LOC module-health cap.

### 5. Dependency direction
The new leaf imports `publish_destination`, `_gh_glab_hiding`,
`_publish_detection`, `term_match` (all `teatree.hooks` leaves);
`banned_terms_deny` (a router-side script) imports the new leaf. No back-edge
(the leaf never imports `hook_router` — the import-direction fitness test stays
green). `uv run tach check`: ✅ all modules validated.

### 6. Test surface
`tests/teatree_hooks/test_own_dest_slug_carve_out.py` — 15 cases: the FP
downgrade, criterion-2 public-still-blocks, the fail-closed defeats (chained
public, substitution, raw-api-write, unrecognised leader), and the whole-token
edge cases (org-prefix token, superset term, foreign term). 100% coverage of the
new module. RED was observed before the module existed.

### 7. Resilience invariants
Pure read-only detection predicate — no external write, so verify-by-re-read /
fallback-transport / heartbeat / sub-agent-return do not apply. Idempotent (pure
function). A detection failure leaves the destination scanned/blocked
(fail-closed) — it never weakens the gate.

### 8. Identity and key normalization
The destination slug is the canonical key. The term↔slug match canonicalizes
through the shared whole-token matcher (`tokens` / `_contains_run`) — no
strip/split-to-make-a-comparison-succeed. Bare and host-qualified slugs both
tokenize correctly, and a substring/superset never matches (whole-token only).

### 9. Behavior preservation / capability deletion
Purely additive — adds one carve-out step to the deny chain; narrows nothing. No
existing matcher weakened, no must-block test inverted. It widens the allow set
only for the narrow case the issue authorizes (a post whose destination slug IS
the term), bounded so public-surface coverage is unchanged: criterion-2 proves a
public destination whose slug omits the term still hard-blocks.
