### PR TITLE
fix(ci): make the docs-drift gate actually catch cli-reference drift (#2599)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,13 @@ jobs:
       # fail if the committed output is stale so the docs site never
       # drifts from the code. See souliane/teatree#890.
       - run: uv run python manage.py generate_all_docs
+      # Check the CLI reference is in sync with the command tree BEFORE
+      # regenerating it. The sync check re-renders in memory and compares against
+      # the COMMITTED (git-index) doc, so a stale committed reference fails the
+      # gate independent of the `git diff` step's git-add ordering — a generator
+      # that later repairs the working tree cannot mask the drift (the
+      # generate-before-check vacuousness). See souliane/teatree#2599.
+      - run: uv run python scripts/hooks/check_cli_reference_sync.py
       # Regenerate the CLI reference. CLI_REFERENCE_NO_STAGE stops the generator
       # from git-add-ing its output — a staged rewrite would match the index and
       # hide the drift from `git diff` below (no --cached). The render is

--- a/scripts/hooks/check_cli_reference_sync.py
+++ b/scripts/hooks/check_cli_reference_sync.py
@@ -2,20 +2,43 @@
 
 Mirrors ``check_antipattern_catalog_sync.py``: the generated
 ``docs/generated/cli-reference.md`` MUST stay in lockstep with the Typer app. The
-hook re-renders the reference in-memory (deterministically) and fails if the
-committed file differs — the fix is to run ``generate_cli_reference.py`` and stage
-the result. This is the loud local gate; CI un-masks the same drift via the
-``docs-drift`` ``git diff`` step (which sets ``CLI_REFERENCE_NO_STAGE``).
+hook re-renders the reference in-memory (deterministically) and compares against
+the doc as it sits in the git INDEX — the bytes that will be committed — not the
+working tree. Reading the index is what makes the gate un-maskable: a working-tree
+regeneration by ``generate_cli_reference.py`` (which, under ``CLI_REFERENCE_NO_STAGE``,
+writes but never stages) cannot repair the file out from under the gate and hide a
+stale committed reference. The fix on a failure is to run ``generate_cli_reference.py``
+and stage the result. CI runs this in the ``docs-drift`` job as a robust gate that
+catches committed drift independent of the ``git diff`` step's git-add ordering.
 
 See: souliane/teatree#2599
 """
 
 import os
+import subprocess
 import sys
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DOC = _REPO_ROOT / "docs" / "generated" / "cli-reference.md"
+_DOC_REL = "docs/generated/cli-reference.md"
+
+
+def _committed_doc(repo_root: Path, rel: str) -> str | None:
+    """The doc as staged in the git index, or ``None`` outside a tracked git tree.
+
+    ``git show :<path>`` reads the index entry — the bytes git will record — so a
+    working-tree regeneration that did not stage leaves the drifted committed bytes
+    here for the gate to catch. ``None`` (no git repo, untracked doc) lets the
+    caller fall back to the working tree, e.g. a throwaway test tree.
+    """
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "show", f":{rel}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout if result.returncode == 0 else None
 
 
 def main() -> int:
@@ -32,7 +55,9 @@ def main() -> int:
 
     register_overlay_commands(allowlist={"t3-teatree"})
     expected = render_cli_reference_deterministic(app)
-    actual = _DOC.read_text(encoding="utf-8") if _DOC.is_file() else ""
+
+    committed = _committed_doc(_REPO_ROOT, _DOC_REL)
+    actual = committed if committed is not None else (_DOC.read_text(encoding="utf-8") if _DOC.is_file() else "")
 
     if expected == actual:
         return 0

--- a/tests/teatree_cli/test_cli_reference_drift_gate.py
+++ b/tests/teatree_cli/test_cli_reference_drift_gate.py
@@ -127,8 +127,58 @@ class TestSyncCheckerFiresOnDrift:
         assert result.returncode == 1, f"checker must go red on stale doc:\n{result.stdout}"
 
 
+class TestSyncCheckerUnmaskableByGenerator:
+    """The sync checker catches a stale COMMITTED doc even after the generator runs.
+
+    souliane/teatree#2599: the gate's correctness must not hinge on the generator
+    NOT having repaired the working tree first (the generate-before-check
+    vacuousness class). ``check_cli_reference_sync.py`` re-renders in memory and
+    compares against the doc as it sits in the git INDEX — the bytes that will be
+    committed — so a working-tree regeneration by ``generate_cli_reference.py``
+    (which, under ``CLI_REFERENCE_NO_STAGE``, never stages) cannot mask the stale
+    committed bytes the gate exists to catch.
+    """
+
+    def _seed_stale_committed_repo(self, tmp_path: Path) -> Path:
+        repo = make_git_repo(tmp_path / "repo")
+        (repo / "docs" / "generated").mkdir(parents=True)
+        (repo / "scripts" / "hooks").mkdir(parents=True)
+        fresh = (_REPO_ROOT / "docs" / "generated" / "cli-reference.md").read_text(encoding="utf-8")
+        stale = fresh + "\nstale drift line the live CLI does not produce\n"
+        doc = repo / "docs" / "generated" / "cli-reference.md"
+        # Commit the STALE doc: index + HEAD hold the drifted bytes.
+        doc.write_text(stale, encoding="utf-8")
+        (repo / "scripts" / "hooks" / "check_cli_reference_sync.py").write_text(
+            _SYNC_CHECKER.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        run_git(repo, "add", ".")
+        run_git(repo, "commit", "-qm", "seed stale committed doc")
+        # Repair the WORKING-TREE doc to the fresh render — exactly what
+        # generate_cli_reference.py does under CLI_REFERENCE_NO_STAGE (write, do not
+        # stage) — so the index keeps the stale bytes while the working tree looks clean.
+        doc.write_text(fresh, encoding="utf-8")
+        return repo
+
+    def test_checker_catches_stale_committed_doc_after_worktree_repaired(self, tmp_path: Path) -> None:
+        repo = self._seed_stale_committed_repo(tmp_path)
+        # A working-tree read sees the repaired (fresh) doc and passes vacuously;
+        # reading the committed index must still go red on the stale committed bytes.
+        result = _run(repo / "scripts" / "hooks" / "check_cli_reference_sync.py")
+        assert result.returncode == 1, (
+            "sync checker must catch a stale COMMITTED doc even after the working tree "
+            f"was repaired to the fresh render (generate-before-check vacuousness):\n{result.stdout}"
+        )
+
+
 class TestDocsDriftCiUnmasksCliReference:
     """The docs-drift CI job must run the cli-reference generator with NO_STAGE."""
+
+    def test_sync_checker_runs_in_docs_drift(self) -> None:
+        joined = " ".join(str(s.get("run", "")) for s in _docs_drift_steps())
+        assert "check_cli_reference_sync.py" in joined, (
+            "docs-drift must run the in-memory cli-reference sync checker so a stale "
+            "committed reference fails the gate independent of git-add/diff semantics."
+        )
 
     def test_generator_runs_before_diff_assertion(self) -> None:
         runs = [s.get("run", "") for s in _docs_drift_steps()]


### PR DESCRIPTION
## Summary

The `docs-drift` CI gate could not robustly catch a stale committed `docs/generated/cli-reference.md`. Its only catch was the working-tree-vs-index `git diff` step, whose correctness is a non-local property — it holds only while the generator's `CLI_REFERENCE_NO_STAGE` keeps the index clean. The companion `check_cli_reference_sync.py` was **vacuous when run after any generator**: it re-rendered and compared against the generator-repaired *working tree*, so it always matched and passed — the generate-before-check vacuousness class (the same one [#2815](https://github.com/souliane/teatree/pull/2815) fixed for the FSM-diagram gate).

## Reproduced escape

In a git repo whose committed `cli-reference.md` is stale, repair the working-tree doc (exactly what `generate_cli_reference.py` does under `CLI_REFERENCE_NO_STAGE` — write, do not stage), then run `check_cli_reference_sync.py`:

- before this change (working-tree read): exit **0** — passes vacuously, the drift escapes.
- after this change (git-index read): exit **1** — catches the stale committed bytes.

Pinned as `TestSyncCheckerUnmaskableByGenerator` — observed RED (`assert 0 == 1`) on the pre-fix working-tree read, GREEN after the index read.

## Fix

1. `scripts/hooks/check_cli_reference_sync.py` compares the in-memory render against the doc as it sits in the **git index** (`git show :docs/generated/cli-reference.md`) — the bytes that will be committed — not the working tree. A working-tree regeneration that did not stage can no longer mask a stale committed reference; the check is ordering-independent and un-maskable. Falls back to the working tree outside a tracked git tree (test contexts); the commit-msg pre-commit hook reads the staged index, which is the bytes being committed.
2. Wired into the `docs-drift` CI job **before** `generate_cli_reference.py`, mirroring the check-before-generate ordering #2815 established for the FSM gate.

The existing `git diff --exit-code docs/generated` stays as defense-in-depth for every generated artifact. Scope is cli-reference only — the FSM gate is untouched.

## Verification

- drift-gate suite: RED→GREEN proof, then `9 passed` on the rebased state.
- `check_cli_reference_sync.py` exits 0 in sync.
- `ruff check` / `ruff format --check` / `ty check` / `tach check` clean.
- overlay-leak `--require-terms` exits 0.

## Architecture pre-check — #2599

### 1. BLUEPRINT § alignment
Generated-docs / drift-gate family — BLUEPRINT.md documents the sibling `docs-drift` gate pattern (`*_NO_STAGE` opt-out + `git diff` for the anti-pattern catalog). This change hardens the cli-reference gate in the same family; no documented contract changes, so no BLUEPRINT edit.

### 2. FSM phase boundaries
n/a — no `Ticket`/`Worktree` state transition added or moved.

### 3. Extension-point contracts
n/a — no `OverlayBase` hook, scanner registration, or `*Backend` Protocol touched. The script is a standalone CI / pre-commit gate.

### 4. Component boundaries
`scripts/hooks/check_cli_reference_sync.py` owns the gate I/O + git read (a hook script, not core); `.github/workflows/ci.yml` wires it. Mirrors the antipattern / FSM sync-check split exactly.

### 5. Dependency direction
No teatree-internal import added. The hook imports `django` + `teatree.cli` (forward edge, unchanged) and now `subprocess` for the git-index read. `uv run tach check` -> all modules validated.

### 6. Test surface
`tests/teatree_cli/test_cli_reference_drift_gate.py`:
- `TestSyncCheckerUnmaskableByGenerator::test_checker_catches_stale_committed_doc_after_worktree_repaired` — stale committed doc + repaired working tree -> the checker must go red; asserts the index read (RED on the old working-tree read).
- `TestDocsDriftCiUnmasksCliReference::test_sync_checker_runs_in_docs_drift` — the docs-drift job runs the sync checker.
Existing sibling tests unchanged and green.

### 7. Resilience invariants
The gate is a read-only check (no external write). Idempotent — re-run is a no-op. verify-by-re-read: the gate IS the re-read of the committed bytes against a fresh render. No sub-agent contract, no heartbeat surface.

### 8. Identity and key normalization
n/a — no bare-vs-qualified identity. The doc path is a single canonical relative path used for both the index read and the working-tree fallback; no qualifier is stripped to force a match.

### 9. Behavior preservation / capability deletion
The checker's read source changes from the working tree to the git index, with a working-tree fallback when `git show` fails (non-git tree / untracked doc). The "stale committed doc -> red" behavior is preserved on every path — the commit-msg pre-commit hook reads the staged index (the bytes being committed, correct), the standalone/test paths fall back to the working tree. No must-block test inverted; no privacy/security matcher narrowed. Purely a hardening — more drift caught, none dropped.
