### PR TITLE
feat(docs): generate the PullRequest and Ticket FSM diagrams from the models (issue #12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,9 +339,9 @@ jobs:
       - run: uv run python scripts/hooks/generate_antipattern_catalog.py
         env:
           ANTIPATTERN_CATALOG_NO_STAGE: "1"
-      # Check the worktree-lifecycle FSM diagram is in sync with the model
-      # BEFORE regenerating it. The sync check reads the COMMITTED consumers, so
-      # it catches drift in README + SKILL.md (which the docs/generated diff
+      # Check every FSM lifecycle diagram is in sync with its model BEFORE
+      # regenerating it. The sync check reads the COMMITTED consumers, so it
+      # catches drift in README + SKILL.md (which the docs/generated diff
       # below does NOT cover). It must run first: the generator REWRITES those
       # files on disk (FSM_DIAGRAMS_NO_STAGE only skips git-add), so a check run
       # after the generator would see freshly-repaired files and pass vacuously.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -261,13 +261,13 @@ repos:
         always_run: true
         stages: [commit-msg]
       - id: generate-fsm-diagrams
-        name: Generate the worktree-lifecycle FSM diagram from the model
+        name: Generate the FSM lifecycle diagrams from the models
         language: system
         entry: uv run python scripts/hooks/generate_fsm_diagrams.py
         pass_filenames: false
-        files: ^src/teatree/core/(models/worktree\.py|diagrams\.py)$
+        files: ^src/teatree/core/(models/(worktree|pull_request|ticket)\.py|diagrams\.py)$
       - id: fsm-diagrams-sync
-        name: Worktree FSM diagram in sync with the Worktree model
+        name: FSM lifecycle diagrams in sync with their models
         language: system
         entry: uv run python scripts/hooks/check_fsm_diagrams_sync.py
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -179,7 +179,83 @@ in `src/teatree/core/models/` (`ticket.py`, `worktree.py`, `task.py`,
 (ticket → code → test → review → ship) drive corresponding ticket states. The
 full `Ticket.State` set is `not_started → scoped → started → planned → coded → tested →
 reviewed → shipped → in_review → merged → retrospected → delivered`, plus
-`ignored` for work that is consciously skipped.
+`ignored` for work that is consciously skipped. This diagram is generated from
+the `Ticket` model's `@transition` decorators; edit the model, not the diagram
+(`scripts/hooks/generate_fsm_diagrams.py`).
+
+<!-- BEGIN GENERATED: ticket-fsm -->
+```mermaid
+stateDiagram-v2
+    [*] --> not_started
+    not_started --> scoped : scope
+    not_started --> reviewed : reconcile_reviewed
+    not_started --> merged : reconcile_merged
+    not_started --> delivered : mark_review_no_action
+    not_started --> delivered : mark_reviewed_externally
+    not_started --> ignored : ignore
+    scoped --> started : start
+    scoped --> reviewed : reconcile_reviewed
+    scoped --> merged : reconcile_merged
+    scoped --> delivered : mark_review_no_action
+    scoped --> delivered : mark_reviewed_externally
+    scoped --> ignored : ignore
+    started --> started : start
+    started --> planned : plan
+    started --> reviewed : reconcile_reviewed
+    started --> merged : reconcile_merged
+    started --> delivered : mark_review_no_action
+    started --> delivered : mark_reviewed_externally
+    started --> ignored : ignore
+    planned --> coded : code
+    planned --> reviewed : reconcile_reviewed
+    planned --> merged : reconcile_merged
+    planned --> delivered : mark_review_no_action
+    planned --> delivered : mark_reviewed_externally
+    planned --> ignored : ignore
+    coded --> started : rework
+    coded --> tested : test
+    coded --> reviewed : reconcile_reviewed
+    coded --> merged : reconcile_merged
+    coded --> delivered : mark_review_no_action
+    coded --> delivered : mark_reviewed_externally
+    coded --> ignored : ignore
+    tested --> started : rework
+    tested --> reviewed : reconcile_reviewed
+    tested --> reviewed : review
+    tested --> merged : reconcile_merged
+    tested --> delivered : mark_review_no_action
+    tested --> delivered : mark_reviewed_externally
+    tested --> ignored : ignore
+    reviewed --> started : rework
+    reviewed --> reviewed : reconcile_reviewed
+    reviewed --> shipped : ship
+    reviewed --> merged : reconcile_merged
+    reviewed --> delivered : mark_review_no_action
+    reviewed --> delivered : mark_reviewed_externally
+    reviewed --> ignored : ignore
+    shipped --> started : reopen
+    shipped --> shipped : ship
+    shipped --> in_review : request_review
+    shipped --> merged : reconcile_merged
+    shipped --> ignored : ignore
+    in_review --> started : reopen
+    in_review --> reviewed : reconcile_reviewed
+    in_review --> merged : mark_merged
+    in_review --> merged : reconcile_merged
+    in_review --> ignored : ignore
+    merged --> started : reopen
+    merged --> merged : mark_merged
+    merged --> merged : reconcile_merged
+    merged --> retrospected : retrospect
+    merged --> ignored : ignore
+    retrospected --> started : reopen
+    retrospected --> reviewed : reconcile_reviewed
+    retrospected --> retrospected : retrospect
+    retrospected --> delivered : mark_delivered
+    retrospected --> ignored : ignore
+    delivered --> delivered : mark_review_no_action
+```
+<!-- END GENERATED: ticket-fsm -->
 
 **Worktree** — one repo checkout inside a ticket's workspace. This diagram is
 generated from the `Worktree` model's `@transition` decorators; edit the model,
@@ -208,7 +284,10 @@ stateDiagram-v2
 ```
 <!-- END GENERATED: worktree-fsm -->
 
-**Task** — claimable work unit with lease and heartbeat.
+**Task** — claimable work unit with lease and heartbeat. Unlike the others,
+`Task` advances through guarded methods (`claim`, `complete`, `fail`, `reopen`)
+that take a row lock and a lease rather than `@transition` decorators, so this
+diagram is illustrative and maintained by hand, not generated.
 
 ```mermaid
 stateDiagram-v2
@@ -219,15 +298,21 @@ stateDiagram-v2
   claimed --> pending: lease_expired
 ```
 
-**PullRequest** — tracks delivery state on the code host.
+**PullRequest** — tracks delivery state on the code host. This diagram is
+generated from the `PullRequest` model's `@transition` decorators; edit the
+model, not the diagram (`scripts/hooks/generate_fsm_diagrams.py`).
 
+<!-- BEGIN GENERATED: pull-request-fsm -->
 ```mermaid
 stateDiagram-v2
-  [*] --> open
-  open --> review_requested: request_review
-  review_requested --> approved: approve
-  approved --> merged: merge
+    [*] --> open
+    open --> review_requested : request_review
+    open --> merged : mark_merged
+    review_requested --> approved : approve
+    review_requested --> merged : mark_merged
+    approved --> merged : mark_merged
 ```
+<!-- END GENERATED: pull-request-fsm -->
 
 Every state change goes through a method with code behind it. `Ticket`,
 `Worktree`, and `PullRequest` use `django-fsm`-style `@transition` decorators

--- a/docs/generated/diagrams/pull-request-lifecycle.md
+++ b/docs/generated/diagrams/pull-request-lifecycle.md
@@ -1,0 +1,13 @@
+# PullRequest lifecycle
+
+<!-- BEGIN GENERATED: pull-request-fsm -->
+```mermaid
+stateDiagram-v2
+    [*] --> open
+    open --> review_requested : request_review
+    open --> merged : mark_merged
+    review_requested --> approved : approve
+    review_requested --> merged : mark_merged
+    approved --> merged : mark_merged
+```
+<!-- END GENERATED: pull-request-fsm -->

--- a/docs/generated/diagrams/ticket-lifecycle.md
+++ b/docs/generated/diagrams/ticket-lifecycle.md
@@ -1,0 +1,75 @@
+# Ticket lifecycle
+
+<!-- BEGIN GENERATED: ticket-fsm -->
+```mermaid
+stateDiagram-v2
+    [*] --> not_started
+    not_started --> scoped : scope
+    not_started --> reviewed : reconcile_reviewed
+    not_started --> merged : reconcile_merged
+    not_started --> delivered : mark_review_no_action
+    not_started --> delivered : mark_reviewed_externally
+    not_started --> ignored : ignore
+    scoped --> started : start
+    scoped --> reviewed : reconcile_reviewed
+    scoped --> merged : reconcile_merged
+    scoped --> delivered : mark_review_no_action
+    scoped --> delivered : mark_reviewed_externally
+    scoped --> ignored : ignore
+    started --> started : start
+    started --> planned : plan
+    started --> reviewed : reconcile_reviewed
+    started --> merged : reconcile_merged
+    started --> delivered : mark_review_no_action
+    started --> delivered : mark_reviewed_externally
+    started --> ignored : ignore
+    planned --> coded : code
+    planned --> reviewed : reconcile_reviewed
+    planned --> merged : reconcile_merged
+    planned --> delivered : mark_review_no_action
+    planned --> delivered : mark_reviewed_externally
+    planned --> ignored : ignore
+    coded --> started : rework
+    coded --> tested : test
+    coded --> reviewed : reconcile_reviewed
+    coded --> merged : reconcile_merged
+    coded --> delivered : mark_review_no_action
+    coded --> delivered : mark_reviewed_externally
+    coded --> ignored : ignore
+    tested --> started : rework
+    tested --> reviewed : reconcile_reviewed
+    tested --> reviewed : review
+    tested --> merged : reconcile_merged
+    tested --> delivered : mark_review_no_action
+    tested --> delivered : mark_reviewed_externally
+    tested --> ignored : ignore
+    reviewed --> started : rework
+    reviewed --> reviewed : reconcile_reviewed
+    reviewed --> shipped : ship
+    reviewed --> merged : reconcile_merged
+    reviewed --> delivered : mark_review_no_action
+    reviewed --> delivered : mark_reviewed_externally
+    reviewed --> ignored : ignore
+    shipped --> started : reopen
+    shipped --> shipped : ship
+    shipped --> in_review : request_review
+    shipped --> merged : reconcile_merged
+    shipped --> ignored : ignore
+    in_review --> started : reopen
+    in_review --> reviewed : reconcile_reviewed
+    in_review --> merged : mark_merged
+    in_review --> merged : reconcile_merged
+    in_review --> ignored : ignore
+    merged --> started : reopen
+    merged --> merged : mark_merged
+    merged --> merged : reconcile_merged
+    merged --> retrospected : retrospect
+    merged --> ignored : ignore
+    retrospected --> started : reopen
+    retrospected --> reviewed : reconcile_reviewed
+    retrospected --> retrospected : retrospect
+    retrospected --> delivered : mark_delivered
+    retrospected --> ignored : ignore
+    delivered --> delivered : mark_review_no_action
+```
+<!-- END GENERATED: ticket-fsm -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,4 +78,6 @@ nav:
       - Skills Catalogue: generated/skills-catalogue.md
       - Anti-Pattern Catalog: generated/antipattern-catalog.md
       - Worktree Lifecycle: generated/diagrams/worktree-lifecycle.md
+      - PullRequest Lifecycle: generated/diagrams/pull-request-lifecycle.md
+      - Ticket Lifecycle: generated/diagrams/ticket-lifecycle.md
   - Contributing: contributing.md

--- a/scripts/hooks/check_fsm_diagrams_sync.py
+++ b/scripts/hooks/check_fsm_diagrams_sync.py
@@ -1,39 +1,17 @@
-"""Pre-commit hook: fail when the worktree-lifecycle FSM diagram drifts.
+"""Pre-commit hook: fail when any FSM lifecycle diagram drifts from its model.
 
-Re-renders the ``Worktree`` FSM block in memory (deterministically) and fails if
-any consumer's marked block differs from it — the fix is to run
-``generate_fsm_diagrams.py`` and stage the result. The loud local gate; CI
-un-masks the same drift via the ``docs-drift`` ``git diff`` step. Mirrors
-``check_cli_reference_sync.py``.
+Re-renders each :class:`~scripts.hooks.fsm_diagram_specs.DiagramSpec`'s block in
+memory (deterministically) and fails if any consumer's marked block differs from
+it — the fix is to run ``generate_fsm_diagrams.py`` and stage the result. The
+loud local gate; CI un-masks the same drift via the ``docs-drift`` ``git diff``
+step. Mirrors ``check_cli_reference_sync.py``.
 
 See: souliane/teatree#12
 """
 
-import os
 import sys
-from pathlib import Path
 
-BEGIN = "<!-- BEGIN GENERATED: worktree-fsm -->"
-END = "<!-- END GENERATED: worktree-fsm -->"
-_CONSUMERS = (
-    Path("docs/generated/diagrams/worktree-lifecycle.md"),
-    Path("README.md"),
-    Path("skills/workspace/SKILL.md"),
-)
-
-
-def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[2]
-
-
-def _django_setup() -> None:
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "teatree.settings")
-    src = _repo_root() / "src"
-    if src.is_dir():
-        sys.path.insert(0, str(src))
-    import django
-
-    django.setup()
+import fsm_diagram_specs
 
 
 def find_drift(expected_block: str, consumers: dict[str, str], *, begin: str, end: str) -> list[str]:
@@ -47,18 +25,19 @@ def find_drift(expected_block: str, consumers: dict[str, str], *, begin: str, en
 
 
 def main() -> int:
-    _django_setup()
-    from teatree.core.diagrams import fenced_mermaid, render_fsm_mermaid
-    from teatree.core.models import Worktree
+    fsm_diagram_specs.django_setup()
+    root = fsm_diagram_specs.repo_root()
 
-    root = _repo_root()
-    expected = fenced_mermaid(render_fsm_mermaid(Worktree))
-    consumers = {str(rel): (root / rel).read_text(encoding="utf-8") for rel in _CONSUMERS}
-    drifted = find_drift(expected, consumers, begin=BEGIN, end=END)
+    drifted: list[str] = []
+    for spec in fsm_diagram_specs.specs():
+        consumers = {str(spec.canonical): (root / spec.canonical).read_text(encoding="utf-8")}
+        consumers.update({str(rel): (root / rel).read_text(encoding="utf-8") for rel in spec.consumers})
+        drifted.extend(find_drift(spec.block(), consumers, begin=spec.begin, end=spec.end))
+
     if not drifted:
         return 0
 
-    print("Worktree FSM diagram is out of sync with the Worktree model.")
+    print("An FSM lifecycle diagram is out of sync with its model.")
     print("Regenerate and stage it:")
     print("  uv run python scripts/hooks/generate_fsm_diagrams.py")
     for name in drifted:

--- a/scripts/hooks/fsm_diagram_specs.py
+++ b/scripts/hooks/fsm_diagram_specs.py
@@ -1,0 +1,78 @@
+"""Single source of which FSM models become generated Mermaid diagrams.
+
+The generator (``generate_fsm_diagrams.py``) and the drift gate
+(``check_fsm_diagrams_sync.py``) both loop over :func:`specs`, so a new model's
+lifecycle diagram is wired by adding one :class:`DiagramSpec` here — markers,
+canonical page path, and title all derive from its ``slug``.
+
+Only models whose FSM is declared with django-fsm ``@transition`` decorators
+belong here: ``render_fsm_mermaid`` introspects ``get_all_transitions``, so a
+model that mutates its ``FSMField`` imperatively (e.g. ``Task``, whose
+``claim``/``complete``/``fail``/``reopen`` take a row lock rather than a
+``@transition``) would render an edge-less graph and is intentionally absent.
+
+See: souliane/teatree#12
+"""
+
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from django.db.models import Model
+
+_DIAGRAMS_DIR = Path("docs/generated/diagrams")
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def django_setup() -> None:
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "teatree.settings")
+    src = repo_root() / "src"
+    if src.is_dir():
+        sys.path.insert(0, str(src))
+    import django
+
+    django.setup()
+
+
+@dataclass(frozen=True)
+class DiagramSpec:
+    slug: str
+    model: type[Model]
+    title: str
+    consumers: tuple[Path, ...]
+    field: str = "state"
+
+    @property
+    def begin(self) -> str:
+        return f"<!-- BEGIN GENERATED: {self.slug}-fsm -->"
+
+    @property
+    def end(self) -> str:
+        return f"<!-- END GENERATED: {self.slug}-fsm -->"
+
+    @property
+    def canonical(self) -> Path:
+        return _DIAGRAMS_DIR / f"{self.slug}-lifecycle.md"
+
+    def block(self) -> str:
+        from teatree.core.diagrams import fenced_mermaid, render_fsm_mermaid
+
+        return fenced_mermaid(render_fsm_mermaid(self.model, field=self.field))
+
+    def canonical_document(self, block: str) -> str:
+        return f"# {self.title}\n\n{self.begin}\n{block}\n{self.end}\n"
+
+
+def specs() -> list[DiagramSpec]:
+    from teatree.core.models import PullRequest, Ticket, Worktree
+
+    readme = Path("README.md")
+    return [
+        DiagramSpec("worktree", Worktree, "Worktree lifecycle", (readme, Path("skills/workspace/SKILL.md"))),
+        DiagramSpec("pull-request", PullRequest, "PullRequest lifecycle", (readme,)),
+        DiagramSpec("ticket", Ticket, "Ticket lifecycle", (readme,)),
+    ]

--- a/scripts/hooks/generate_fsm_diagrams.py
+++ b/scripts/hooks/generate_fsm_diagrams.py
@@ -1,12 +1,13 @@
-"""Pre-commit hook: generate the worktree-lifecycle FSM diagram from the model.
+"""Pre-commit hook: generate every FSM lifecycle diagram from its model.
 
-Renders the ``Worktree`` django-fsm graph (``teatree.core.diagrams``) and writes
-the canonical ``docs/generated/diagrams/worktree-lifecycle.md`` plus the
-identical fenced block spliced between the worktree-fsm markers in every
-consumer (``README.md``, ``skills/workspace/SKILL.md``). Auto-stages changed
-files unless ``FSM_DIAGRAMS_NO_STAGE`` is set — CI sets it for the docs-drift
-step so ``git diff`` catches a stale committed diagram. Modelled byte-for-byte
-on ``generate_cli_reference.py``.
+For each :class:`~scripts.hooks.fsm_diagram_specs.DiagramSpec`, renders the
+model's django-fsm graph (``teatree.core.diagrams``) and writes the canonical
+``docs/generated/diagrams/<slug>-lifecycle.md`` plus the identical fenced block
+spliced between that spec's markers in every consumer (``README.md``,
+``skills/workspace/SKILL.md``). Auto-stages changed files unless
+``FSM_DIAGRAMS_NO_STAGE`` is set — CI sets it for the docs-drift step so
+``git diff`` catches a stale committed diagram. Modelled byte-for-byte on
+``generate_cli_reference.py``.
 
 See: souliane/teatree#12
 """
@@ -16,32 +17,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-BEGIN = "<!-- BEGIN GENERATED: worktree-fsm -->"
-END = "<!-- END GENERATED: worktree-fsm -->"
-_CANONICAL = Path("docs/generated/diagrams/worktree-lifecycle.md")
-_CANONICAL_TITLE = "Worktree lifecycle"
-_CONSUMERS = (Path("README.md"), Path("skills/workspace/SKILL.md"))
-
-
-def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[2]
-
-
-def _django_setup() -> None:
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "teatree.settings")
-    src = _repo_root() / "src"
-    if src.is_dir():
-        sys.path.insert(0, str(src))
-    import django
-
-    django.setup()
-
-
-def _worktree_fsm_block() -> str:
-    from teatree.core.diagrams import fenced_mermaid, render_fsm_mermaid
-    from teatree.core.models import Worktree
-
-    return fenced_mermaid(render_fsm_mermaid(Worktree))
+import fsm_diagram_specs
 
 
 def _write_if_changed(path: Path, content: str, *, stage: bool) -> None:
@@ -55,23 +31,25 @@ def _write_if_changed(path: Path, content: str, *, stage: bool) -> None:
 
 
 def main() -> int:
-    _django_setup()
+    fsm_diagram_specs.django_setup()
     from teatree.core.diagrams import MarkerNotFoundError, inject_between_markers
 
-    root = _repo_root()
-    block = _worktree_fsm_block()
+    root = fsm_diagram_specs.repo_root()
     stage = not os.environ.get("FSM_DIAGRAMS_NO_STAGE")
 
-    _write_if_changed(root / _CANONICAL, f"# {_CANONICAL_TITLE}\n\n{BEGIN}\n{block}\n{END}\n", stage=stage)
-
-    for rel in _CONSUMERS:
-        path = root / rel
-        try:
-            new_text = inject_between_markers(path.read_text(encoding="utf-8"), begin=BEGIN, end=END, block=block)
-        except MarkerNotFoundError as exc:
-            print(f"ERROR: {rel} {exc}", file=sys.stderr)
-            return 1
-        _write_if_changed(path, new_text, stage=stage)
+    for spec in fsm_diagram_specs.specs():
+        block = spec.block()
+        _write_if_changed(root / spec.canonical, spec.canonical_document(block), stage=stage)
+        for rel in spec.consumers:
+            path = root / rel
+            try:
+                new_text = inject_between_markers(
+                    path.read_text(encoding="utf-8"), begin=spec.begin, end=spec.end, block=block
+                )
+            except MarkerNotFoundError as exc:
+                print(f"ERROR: {rel} {exc}", file=sys.stderr)
+                return 1
+            _write_if_changed(path, new_text, stage=stage)
 
     return 0
 

--- a/tests/test_generate_fsm_diagrams.py
+++ b/tests/test_generate_fsm_diagrams.py
@@ -1,15 +1,22 @@
 # test-path: cross-cutting
-"""Worktree-FSM diagram generation: pure renderer + generate/check hooks.
+"""FSM-diagram generation: pure renderer + the spec-driven generate/check hooks.
 
-Spans ``teatree.core.diagrams`` (the pure Mermaid renderer + marker splice) and
-the two ``scripts/hooks`` drift-pipeline scripts, mirroring the
-generate-cli-reference / cli-reference-sync pair.
+Spans ``teatree.core.diagrams`` (the pure Mermaid renderer + marker splice), the
+``scripts/hooks/fsm_diagram_specs`` registry (which models become diagrams), and
+the two drift-pipeline scripts, mirroring the generate-cli-reference /
+cli-reference-sync pair. A new model is wired by one ``DiagramSpec``; these tests
+assert the loop covers Worktree, PullRequest, and Ticket, and that Task — which
+mutates its ``FSMField`` imperatively rather than via ``@transition`` — is
+deliberately excluded.
 """
 
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
+import fsm_diagram_specs as fsm
 import pytest
+from django.db.models import Model
 from django.db.models.fields import NOT_PROVIDED
 
 from scripts.hooks import check_fsm_diagrams_sync as chk
@@ -21,18 +28,39 @@ from teatree.core.diagrams import (
     inject_between_markers,
     render_fsm_mermaid,
 )
-from teatree.core.models import Worktree
+from teatree.core.models import PullRequest, Task, Ticket, Worktree
 
-BEGIN = "<!-- BEGIN GENERATED: worktree-fsm -->"
-END = "<!-- END GENERATED: worktree-fsm -->"
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from django_fsm import FSMField
+
+WORKTREE_BEGIN = "<!-- BEGIN GENERATED: worktree-fsm -->"
+WORKTREE_END = "<!-- END GENERATED: worktree-fsm -->"
+PR_BEGIN = "<!-- BEGIN GENERATED: pull-request-fsm -->"
+PR_END = "<!-- END GENERATED: pull-request-fsm -->"
+TICKET_BEGIN = "<!-- BEGIN GENERATED: ticket-fsm -->"
+TICKET_END = "<!-- END GENERATED: ticket-fsm -->"
+
+# The marker-splice tests are model-agnostic; reuse the worktree pair as the generic one.
+BEGIN = WORKTREE_BEGIN
+END = WORKTREE_END
+
+# (model, field, default-state) for every model whose FSM IS generated.
+GENERATED_MODELS = [
+    (Worktree, "state", "created"),
+    (PullRequest, "state", "open"),
+    (Ticket, "state", "not_started"),
+]
 
 
-def _model_edges(model: type, field: str = "state") -> set[tuple[str, str, str]]:
+def _model_edges(model: type[Model], field: str = "state") -> set[tuple[str, str, str]]:
     """The (source, target, name) edge set straight from the FSM field's registry."""
-    fsm = model._meta.get_field(field)
-    states = [str(value) for value, _label in fsm.choices]
+    fsm_field = cast("FSMField", model._meta.get_field(field))
+    choices = cast("Iterable[tuple[object, object]]", fsm_field.choices)
+    states = [str(value) for value, _label in choices]
     edges: set[tuple[str, str, str]] = set()
-    for transition in fsm.get_all_transitions(model):
+    for transition in fsm_field.get_all_transitions(model):
         target = str(getattr(transition.target, "value", transition.target))
         sources = states if transition.source == "*" else [str(getattr(transition.source, "value", transition.source))]
         edges.update((source, target, transition.name) for source in sources)
@@ -51,44 +79,76 @@ def _diagram_edges(diagram: str) -> set[tuple[str, str, str]]:
 
 
 class TestRenderFsmMermaid:
-    def test_render_is_deterministic(self) -> None:
-        assert render_fsm_mermaid(Worktree) == render_fsm_mermaid(Worktree)
+    @pytest.mark.parametrize(("model", "field", "_default"), GENERATED_MODELS)
+    def test_render_is_deterministic(self, model: type[Model], field: str, _default: str) -> None:
+        assert render_fsm_mermaid(model, field=field) == render_fsm_mermaid(model, field=field)
 
-    def test_first_line_is_state_diagram_header(self) -> None:
-        assert render_fsm_mermaid(Worktree).splitlines()[0] == "stateDiagram-v2"
+    @pytest.mark.parametrize(("model", "field", "_default"), GENERATED_MODELS)
+    def test_first_line_is_state_diagram_header(self, model: type[Model], field: str, _default: str) -> None:
+        assert render_fsm_mermaid(model, field=field).splitlines()[0] == "stateDiagram-v2"
 
-    def test_contains_exactly_the_model_transitions_no_phantom_edges(self) -> None:
-        assert _diagram_edges(render_fsm_mermaid(Worktree)) == _model_edges(Worktree)
+    @pytest.mark.parametrize(("model", "field", "_default"), GENERATED_MODELS)
+    def test_contains_exactly_the_model_transitions_no_phantom_edges(
+        self, model: type[Model], field: str, _default: str
+    ) -> None:
+        assert _diagram_edges(render_fsm_mermaid(model, field=field)) == _model_edges(model, field)
 
-    def test_includes_previously_omitted_stop_services_edges(self) -> None:
-        """The drift proof: both hand-drawn consumers omitted these SERVICES_UP/READY -> PROVISIONED edges."""
-        rendered = render_fsm_mermaid(Worktree)
-        assert "services_up --> provisioned : stop_services" in rendered
-        assert "ready --> provisioned : stop_services" in rendered
+    @pytest.mark.parametrize(("model", "field", "default"), GENERATED_MODELS)
+    def test_emits_initial_state_edge_from_the_field_default(
+        self, model: type[Model], field: str, default: str
+    ) -> None:
+        assert render_fsm_mermaid(model, field=field).splitlines()[1] == f"    [*] --> {default}"
 
-    def test_includes_wildcard_expanded_teardown_edges(self) -> None:
-        rendered = render_fsm_mermaid(Worktree)
-        for source in ("created", "provisioned", "services_up", "ready"):
-            assert f"{source} --> created : teardown" in rendered
+    def test_pull_request_generated_block_removes_handdrawn_merge_drift(self) -> None:
+        """Drift proof: the hand-drawn block named the merge edge ``merge`` and dropped two ``mark_merged`` sources."""
+        rendered = render_fsm_mermaid(PullRequest)
+        assert "approved --> merged : mark_merged" in rendered
+        assert "open --> merged : mark_merged" in rendered
+        assert "review_requested --> merged : mark_merged" in rendered
+        assert ": merge\n" not in rendered + "\n"
 
-    def test_emits_initial_state_edge_from_the_field_default(self) -> None:
-        lines = render_fsm_mermaid(Worktree).splitlines()
-        assert lines[1] == "    [*] --> created"
+    def test_ticket_wildcard_ignore_edge_expands_to_every_state(self) -> None:
+        rendered = render_fsm_mermaid(Ticket)
+        for source in ("not_started", "scoped", "started", "planned", "coded", "tested", "reviewed"):
+            assert f"{source} --> ignored : ignore" in rendered
+
+    def test_task_fsm_has_no_transitions_so_is_not_single_sourceable(self) -> None:
+        """Task mutates ``status`` imperatively (no ``@transition``), so the renderer finds no edges."""
+        assert _model_edges(Task, "status") == set()
+        rendered = render_fsm_mermaid(Task, field="status")
+        assert _diagram_edges(rendered) == set()
+        assert rendered.splitlines() == ["stateDiagram-v2", "    [*] --> pending"]
 
     def test_omits_initial_state_edge_when_field_has_no_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(Worktree._meta.get_field("state"), "default", NOT_PROVIDED)
-        rendered = render_fsm_mermaid(Worktree)
+        monkeypatch.setattr(PullRequest._meta.get_field("state"), "default", NOT_PROVIDED)
+        rendered = render_fsm_mermaid(PullRequest)
         assert "[*]" not in rendered
         assert rendered.splitlines()[0] == "stateDiagram-v2"
 
     def test_title_emits_mermaid_frontmatter(self) -> None:
-        rendered = render_fsm_mermaid(Worktree, title="Worktree lifecycle")
-        assert rendered.startswith("---\ntitle: Worktree lifecycle\n---\nstateDiagram-v2")
+        rendered = render_fsm_mermaid(PullRequest, title="PullRequest lifecycle")
+        assert rendered.startswith("---\ntitle: PullRequest lifecycle\n---\nstateDiagram-v2")
 
-    def test_no_title_emits_no_frontmatter(self) -> None:
-        rendered = render_fsm_mermaid(Worktree)
-        assert rendered.startswith("stateDiagram-v2")
-        assert "---" not in rendered
+
+class TestDiagramSpecRegistry:
+    def test_specs_cover_worktree_pull_request_and_ticket(self) -> None:
+        by_slug = {spec.slug: spec for spec in fsm.specs()}
+        assert by_slug["worktree"].model is Worktree
+        assert by_slug["pull-request"].model is PullRequest
+        assert by_slug["ticket"].model is Ticket
+
+    def test_task_is_not_a_generated_spec(self) -> None:
+        assert Task not in {spec.model for spec in fsm.specs()}
+
+    def test_markers_and_canonical_derive_from_slug(self) -> None:
+        spec = next(s for s in fsm.specs() if s.slug == "pull-request")
+        assert spec.begin == PR_BEGIN
+        assert spec.end == PR_END
+        assert spec.canonical == Path("docs/generated/diagrams/pull-request-lifecycle.md")
+
+    def test_block_renders_the_models_fsm(self) -> None:
+        spec = next(s for s in fsm.specs() if s.slug == "ticket")
+        assert spec.block() == fenced_mermaid(render_fsm_mermaid(Ticket))
 
 
 class TestMarkerSplice:
@@ -116,7 +176,7 @@ class TestMarkerSplice:
             inject_between_markers(f"{BEGIN}\nbody\n", begin=BEGIN, end=END, block="X")
 
     def test_extract_returns_the_injected_block(self) -> None:
-        block = fenced_mermaid(render_fsm_mermaid(Worktree))
+        block = fenced_mermaid(render_fsm_mermaid(PullRequest))
         doc = inject_between_markers(self._doc("OLD"), begin=BEGIN, end=END, block=block)
         assert extract_between_markers(doc, begin=BEGIN, end=END) == block
 
@@ -132,38 +192,51 @@ class TestFenced:
 
 class TestSyncGateLogic:
     def test_find_drift_empty_when_every_consumer_matches(self) -> None:
-        block = fenced_mermaid(render_fsm_mermaid(Worktree))
-        doc = f"x\n{BEGIN}\n{block}\n{END}\ny\n"
-        assert chk.find_drift(block, {"README.md": doc, "SKILL.md": doc}, begin=BEGIN, end=END) == []
+        block = fenced_mermaid(render_fsm_mermaid(PullRequest))
+        doc = f"x\n{PR_BEGIN}\n{block}\n{PR_END}\ny\n"
+        assert chk.find_drift(block, {"README.md": doc, "canon.md": doc}, begin=PR_BEGIN, end=PR_END) == []
 
     def test_find_drift_reports_the_mutated_consumer(self) -> None:
-        block = fenced_mermaid(render_fsm_mermaid(Worktree))
-        good = f"x\n{BEGIN}\n{block}\n{END}\ny\n"
-        stale = f"x\n{BEGIN}\n```mermaid\nstateDiagram-v2\n    stale\n```\n{END}\ny\n"
-        assert chk.find_drift(block, {"README.md": good, "SKILL.md": stale}, begin=BEGIN, end=END) == ["SKILL.md"]
+        block = fenced_mermaid(render_fsm_mermaid(PullRequest))
+        good = f"x\n{PR_BEGIN}\n{block}\n{PR_END}\ny\n"
+        stale = f"x\n{PR_BEGIN}\n```mermaid\nstateDiagram-v2\n    stale\n```\n{PR_END}\ny\n"
+        assert chk.find_drift(block, {"README.md": good, "canon.md": stale}, begin=PR_BEGIN, end=PR_END) == ["canon.md"]
+
+
+def _empty_markers(*pairs: tuple[str, str]) -> str:
+    body = "\n\n".join(f"{begin}\n{end}" for begin, end in pairs)
+    return f"intro\n\n{body}\n\noutro\n"
 
 
 @pytest.fixture
 def fake_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     (tmp_path / "docs" / "generated" / "diagrams").mkdir(parents=True)
     (tmp_path / "skills" / "workspace").mkdir(parents=True)
-    empty = f"intro\n\n{BEGIN}\n{END}\n\noutro\n"
-    (tmp_path / "README.md").write_text(empty, encoding="utf-8")
-    (tmp_path / "skills" / "workspace" / "SKILL.md").write_text(empty, encoding="utf-8")
-    monkeypatch.setattr(gen, "_repo_root", lambda: tmp_path)
-    monkeypatch.setattr(chk, "_repo_root", lambda: tmp_path)
+    (tmp_path / "README.md").write_text(
+        _empty_markers((WORKTREE_BEGIN, WORKTREE_END), (PR_BEGIN, PR_END), (TICKET_BEGIN, TICKET_END)),
+        encoding="utf-8",
+    )
+    (tmp_path / "skills" / "workspace" / "SKILL.md").write_text(
+        _empty_markers((WORKTREE_BEGIN, WORKTREE_END)), encoding="utf-8"
+    )
+    monkeypatch.setattr(fsm, "repo_root", lambda: tmp_path)
     monkeypatch.setenv("FSM_DIAGRAMS_NO_STAGE", "1")
     return tmp_path
 
 
 class TestGeneratorAndCheckAgainstFakeRepo:
-    def test_generator_populates_all_consumers_in_sync(self, fake_repo: Path) -> None:
+    def test_generator_populates_every_consumer_in_sync(self, fake_repo: Path) -> None:
         assert gen.main() == 0
-        canonical = (fake_repo / "docs" / "generated" / "diagrams" / "worktree-lifecycle.md").read_text("utf-8")
         readme = (fake_repo / "README.md").read_text("utf-8")
         skill = (fake_repo / "skills" / "workspace" / "SKILL.md").read_text("utf-8")
-        for text in (canonical, readme, skill):
-            assert "services_up --> provisioned : stop_services" in text
+        # Worktree's drift proof from PR-a, plus each new model's signature edge.
+        assert "services_up --> provisioned : stop_services" in readme
+        assert "services_up --> provisioned : stop_services" in skill
+        assert "open --> merged : mark_merged" in readme
+        assert "not_started --> scoped : scope" in readme
+        for slug in ("worktree", "pull-request", "ticket"):
+            canon = (fake_repo / "docs" / "generated" / "diagrams" / f"{slug}-lifecycle.md").read_text("utf-8")
+            assert "stateDiagram-v2" in canon
         assert chk.main() == 0
 
     def test_generator_run_twice_is_a_noop(self, fake_repo: Path) -> None:
@@ -172,14 +245,20 @@ class TestGeneratorAndCheckAgainstFakeRepo:
         gen.main()
         assert {p: p.read_text("utf-8") for p in fake_repo.rglob("*.md")} == snapshot
 
-    def test_check_detects_a_mutated_consumer(self, fake_repo: Path) -> None:
+    @pytest.mark.parametrize("needle", ["stop_services", "mark_merged", "not_started --> scoped"])
+    def test_check_detects_a_mutated_consumer(self, fake_repo: Path, needle: str) -> None:
         gen.main()
         readme = fake_repo / "README.md"
-        readme.write_text(readme.read_text("utf-8").replace("stop_services", "TAMPERED"), encoding="utf-8")
+        readme.write_text(readme.read_text("utf-8").replace(needle, "TAMPERED"), encoding="utf-8")
         assert chk.main() == 1
 
     def test_generator_fails_loud_on_a_consumer_missing_markers(self, fake_repo: Path) -> None:
         (fake_repo / "README.md").write_text("no markers at all\n", encoding="utf-8")
+        assert gen.main() == 1
+
+    def test_generator_fails_loud_when_a_new_diagrams_markers_are_absent(self, fake_repo: Path) -> None:
+        readme = fake_repo / "README.md"
+        readme.write_text(_empty_markers((WORKTREE_BEGIN, WORKTREE_END)), encoding="utf-8")  # PR + ticket markers gone
         assert gen.main() == 1
 
     def test_generator_stages_changed_files_when_not_suppressed(
@@ -193,7 +272,7 @@ class TestGeneratorAndCheckAgainstFakeRepo:
 
 
 class TestRealRepoConsumersInSync:
-    """The committed consumers must already carry the generated block (guards the wired gate)."""
+    """The committed consumers must already carry the generated blocks (guards the wired gate)."""
 
     def test_real_repo_passes_the_sync_gate(self) -> None:
         previous = os.environ.pop("FSM_DIAGRAMS_NO_STAGE", None)
@@ -202,3 +281,20 @@ class TestRealRepoConsumersInSync:
         finally:
             if previous is not None:
                 os.environ["FSM_DIAGRAMS_NO_STAGE"] = previous
+
+    def test_real_readme_pull_request_block_is_generated_not_handdrawn(self) -> None:
+        readme = (fsm.repo_root() / "README.md").read_text("utf-8")
+        block = extract_between_markers(readme, begin=PR_BEGIN, end=PR_END)
+        assert block == fenced_mermaid(render_fsm_mermaid(PullRequest))
+        assert _diagram_edges(block) == _model_edges(PullRequest)
+        assert "mark_merged" in block  # the model's real transition name, not the hand-drawn ``merge``
+
+    def test_real_readme_ticket_block_matches_the_model(self) -> None:
+        readme = (fsm.repo_root() / "README.md").read_text("utf-8")
+        block = extract_between_markers(readme, begin=TICKET_BEGIN, end=TICKET_END)
+        assert _diagram_edges(block) == _model_edges(Ticket)
+
+    def test_real_repo_task_diagram_is_still_hand_drawn(self) -> None:
+        readme = (fsm.repo_root() / "README.md").read_text("utf-8")
+        assert "BEGIN GENERATED: task-fsm" not in readme
+        assert "claimed --> completed: success" in readme  # the hand-drawn block survives untouched


### PR DESCRIPTION
Follows PR-a (#2815). Extends the FSM-diagram generation pipeline to the remaining models with a real django-fsm `@transition` graph — **PullRequest** and **Ticket** — single-sourcing them like PR-a did for Worktree, drift-gated by the same `generate_fsm_diagrams.py` / `check_fsm_diagrams_sync.py` pair.

## What changed
- `scripts/hooks/fsm_diagram_specs.py` (new) — a `DiagramSpec` registry; the generator and checker loop over it, so a new model is one spec (markers, canonical page, title all derive from the slug).
- `scripts/hooks/generate_fsm_diagrams.py` / `check_fsm_diagrams_sync.py` — refactored to the loop.
- README: the hand-drawn **PullRequest** block is replaced with a generated marker pair; a new generated **Ticket** block is added.
- `docs/generated/diagrams/{pull-request,ticket}-lifecycle.md` (new) canonical pages + mkdocs nav.
- `.pre-commit-config.yaml` `files:` trigger extended to `pull_request.py` / `ticket.py`.

## Drift the generation revealed
The hand-drawn README PullRequest block carried real drift vs the model:

| Hand-drawn edge | Generated from the model |
|---|---|
| `open --> review_requested: request_review` | `open --> review_requested : request_review` (kept) |
| `review_requested --> approved: approve` | `review_requested --> approved : approve` (kept) |
| `approved --> merged: merge` | `approved --> merged : mark_merged` (real transition name) |
| (absent) | `open --> merged : mark_merged` (added) |
| (absent) | `review_requested --> merged : mark_merged` (added) |

`mark_merged` has `source=[OPEN, REVIEW_REQUESTED, APPROVED]`; the hand-drawn block named it `merge` and showed only one of its three source edges.

## Task is intentionally NOT generated
`Task.status` is an `FSMField` with **zero `@transition` decorators** — status moves through guarded imperative methods (`claim`/`complete`/`fail`/`reopen`; the #786 conditional-UPDATE claim path). `render_fsm_mermaid(Task, field="status")` therefore yields an edge-less graph (`[*] --> pending` only). Generating it would destroy the hand-drawn diagram's content; converting Task to django-fsm would change error-type semantics on the concurrency-critical claim path — a behaviour change out of scope for a docs PR. Task stays hand-drawn (README note added); a test pins the exclusion.

## Architecture pre-check — issue #12

### 1. BLUEPRINT section alignment
Section 4 Domain Models (FSM lifecycle) docs surface. No model/FSM behaviour change — docs-generation tooling only.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition added or moved. The diagrams render the existing FSMs.

### 3. Extension-point contracts
n/a — no `OverlayBase` / scanner / hook / Protocol surface touched. `render_fsm_mermaid` is unchanged.

### 4. Component boundaries
`scripts/hooks/` (docs-generation tooling), not `src/teatree/`. The new `fsm_diagram_specs.py` is the single source of which models become diagrams; both scripts import it as a sibling (the repo's bare-import convention, matching `check_antipattern_catalog_sync.py`).

### 5. Dependency direction
`scripts/hooks/*` -> `teatree.core.diagrams` + `teatree.core.models` (the existing direction; scripts are top-level tooling). No new `src/teatree` cross-module import. `uv run tach check` -> All modules validated.

### 6. Test surface
`tests/test_generate_fsm_diagrams.py` (extended, 42 tests): per-model (Worktree/PullRequest/Ticket) determinism, exact edge-set equality `_diagram_edges(render) == _model_edges(model)` (no phantom edges), and the `[*] --> <default>` initial edge; the PullRequest drift proof (the `mark_merged` edges + the absent `: merge`); the Task exclusion (`_model_edges(Task, "status") == set()`, `Task not in specs()`); generator idempotence, marker-guard (missing markers -> exit 1), sync-gate red on a mutated PR/Ticket block; real-repo README PR block == model render and README Task block still hand-drawn.

### 7. Resilience invariants
n/a — no external write. Pure string transforms + local file writes (idempotent write-if-changed) inherited from the PR-a pipeline.

### 8. Identity and key normalization
n/a — slugs are the canonical key for markers/paths/titles (one derivation, no stripping to force a match).

### 9. Behavior preservation / capability deletion
- **PullRequest**: every hand-drawn edge is preserved or corrected (table above). No edge dropped; the `merge` -> `mark_merged` rename + two added edges bring the diagram into faithful agreement with the model.
- **Task**: hand-drawn diagram preserved (not replaced).
- No must-block test inverted. The ci.yml check-BEFORE-generate ordering (#2599 anti-vacuity) is preserved.

## Verify
- `uv run pytest tests/test_generate_fsm_diagrams.py` -> 42 passed.
- generator -> `check_fsm_diagrams_sync.py` exit 0; mutate a new block -> exit 1 -> restore -> exit 0.
- `uv run mkdocs build --strict` -> exit 0 (both new nav pages resolve).
- `tach check` / `ty check` / `ruff check` / `ruff format --check` -> clean.
- `check_no_overlay_leak.py --require-terms` -> exit 0.
- Broad slice `tests/teatree_core/` -> 5678 passed; the 33 `--no-migrations`-induced schema/migration failures pass 24/24 when re-run with migrations.

## Follow-up (not bundled)
A second, duplicate FSM renderer lives in `src/teatree/core/management/commands/worktree.py` (`_fsm_diagram` + hand-drawn `_task_diagram`) for a CLI lifecycle-diagram command. Collapsing it onto `render_fsm_mermaid` would change that command's output format (`claim()` -> `claim`) and touch a different module + test — left as a focused follow-up rather than scope creep here.

Refs #12.
