### PR TITLE
docs(rules): ship related work as one PR — splitting requires explicit approval

### DIFF
--- a/skills/contribute/SKILL.md
+++ b/skills/contribute/SKILL.md
@@ -56,7 +56,7 @@ Show the commit log to the user.
 
 ### 1a. Bundle Sibling Retro Branches (Default)
 
-When multiple local branches hold unpushed retro commits from the **same session** or same logical topic, **bundle them into a single PR by default** — do not open one PR per branch. Each PR costs a review cycle; the user's explicit policy is to minimise the number of PRs when commits belong together.
+When multiple local branches hold unpushed retro commits from the **same session** or same logical topic, **bundle them into a single PR by default** — do not open one PR per branch. Each PR costs a review cycle; the user's explicit policy is to minimise the number of PRs when commits belong together. This is the retro-commit instance of the general [`../rules/SKILL.md`](../rules/SKILL.md) § "Fewest PRs for Related Work" rule — related work ships as one PR, and splitting needs explicit user approval.
 
 **Detect siblings:**
 

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -700,6 +700,18 @@ When a PR targets a non-default branch, that is intentional — it means the PR 
 
 Destroying PR dependency chains wastes hours of carefully organized work.
 
+## Fewest PRs for Related Work — Splitting Requires Approval (Non-Negotiable)
+
+Ship a piece of **related** work as **one** PR. Do not preemptively carve a single coherent change into a chain of stacked or follow-up PRs. The user's standing policy: teatree ships related work in **as few PRs as possible**, and **splitting related work across multiple PRs needs the user's explicit, up-front approval**. Without that approval, the default is one PR.
+
+- The small-focused-PR habit is a human code-**review** convenience; it does not transfer to agent-driven, self-verified work. When the user is not reviewing PRs, splitting buys nothing and costs more — every extra PR multiplies CI runs, base-branch drift, stacked-rebase overhead, BLUEPRINT churn, and partial-merge states, and each seam is a fresh place for error.
+- "Related" is a judgment call: commits that serve **one goal** (one feature, one refactor, one migration — even across several files or several days) belong together. A migration that touches N fields is one PR, not N PRs.
+- Genuinely **unrelated** work still gets its own PR — this rule minimises PRs _within_ a coherent change, it does not bundle disjoint concerns.
+- When you believe a split is genuinely warranted (e.g. an enormous diff, or a risky change that benefits from landing a safe prerequisite first), **ask the user first** and proceed only on an explicit yes. If you proceed without asking, ship it as one PR.
+- Per-commit granularity inside one PR is encouraged — meaningful, self-contained commits on a single branch give you reviewable history without paying the multi-PR cost.
+
+This generalises the `/t3:contribute` "bundle into a single PR by default" rule from retro commits to **all** related work, and gates the stacking option in `/t3:ship` § "One Open PR Per Ticket" behind explicit approval.
+
 ## Always Create Tasks
 
 On **every prompt**, use `TaskCreate` to create tasks before doing any work — even for a single task. Mark each task `in_progress` when starting, `completed` when done. Never skip this. Visible task tracking prevents forgotten steps and shows the user your progress.

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -437,10 +437,13 @@ Before opening a new MR/PR, check whether a sibling PR for the **same ticket** i
 gh pr list --repo <repo> --search "<ticket-ref> is:open" --json number,headRefName,baseRefName
 ```
 
+**First question is whether a second PR should exist at all.** Per [`../rules/SKILL.md`](../rules/SKILL.md) § "Fewest PRs for Related Work", related work ships as **one** PR — if the new commits serve the same goal as the sibling, add them to the sibling's branch (bundle), do not open a second PR. Splitting one coherent change into multiple/stacked PRs needs the user's explicit, up-front approval.
+
 If a sibling is open, **do not open a second PR targeting the default branch** — the two branches will diverge on the same files and the second one will need a painful 3-way merge. Pick one:
 
-1. **Wait for the sibling to merge**, then rebase the new work on the updated default branch and open the PR.
-2. **Stack on the sibling's branch** — set the new PR's base to the sibling's source branch (`gh pr create --base <sibling-branch>`). Update the base to the default branch after the sibling merges, so the stacked PR stays minimal.
+1. **Bundle into the sibling (default)** — add the commits to the sibling's branch (per `## Bundle Into an Existing Open PR` below). One coherent change, one PR.
+2. **Wait for the sibling to merge**, then rebase the new work on the updated default branch and open the PR — only when the new work is genuinely a *separate* concern.
+3. **Stack on the sibling's branch** — `gh pr create --base <sibling-branch>`. This splits related work across PRs, so use it **only with the user's explicit approval** (or when the two are genuinely disjoint concerns that merely share a base); update the base to the default branch after the sibling merges.
 
 **Never open two PRs on the same ticket targeting the default branch in parallel.** The only exception is when the two PRs touch genuinely disjoint files (different repos, different modules with no shared imports, no overlapping generated docs) — and even then, the second PR's description must name the sibling PR it races with.
 


### PR DESCRIPTION
## Why

Codifies the user's standing directive: **teatree ships related work in as few PRs as possible, and splitting a coherent change across multiple/stacked PRs requires explicit, up-front approval.** Nothing in the skills told the agent to split into stacked PRs — it was an imported human-review habit. The `/t3:contribute` skill already encoded the opposite ("bundle into a single PR by default") but scoped only to retro commits; this generalises it to all related work and makes it canonical.

## Changes

- **`skills/rules/SKILL.md`** — new always-loaded section "Fewest PRs for Related Work — Splitting Requires Approval". Related work (one feature / refactor / migration, even across many files or days) = one PR. Splitting needs explicit approval. Explains why the small-PR habit doesn't transfer to agent-driven self-verified work (CI multiplication, base-branch drift, rebase overhead, partial-merge states). Per-commit granularity inside one PR stays encouraged.
- **`skills/ship/SKILL.md`** — "One Open PR Per Ticket" reframed: bundling into the sibling is the default; the stack-on-sibling option is gated behind explicit approval.
- **`skills/contribute/SKILL.md`** — retro-commit bundling note now points at the general rule.

## Verification

Full prek gate suite green, including the #140 "imperative rules need companion code" hook (the rule is judgment-based methodology phrased as a `## Header` + prose, the sanctioned non-code home).
