### PR TITLE
fix(gate): handle_enforce_structured_question no longer over-fires on attended turns

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -5789,20 +5789,20 @@ def handle_enforce_structured_question(data: dict) -> bool | None:
     ``_is_classifier_relax_explanation`` and let it through, avoiding the
     infinite block → explain → block loop.
 
-    Context-aware: this gate exists because an inline question is invisible in
-    an autonomous/loop run (it reads as a log line, so the decision is lost). In
-    an attended interactive session a human IS reading the prose, so the gate is
-    pointless nagging. It therefore only enforces on a loop-driven turn —
-    ``_session_drives_loop`` is the same signal the loop-registration gate uses
-    (this session owns the tick, OR there is no live owner). When a *different*
-    live session owns the loop, this is the attended session and the gate is
-    skipped. DEGRADATION CONTRACT — FAIL SAFE: an unknown/unreadable ownership
-    signal yields a driver verdict (see ``_session_drives_loop``), so the gate
-    keeps firing.
+    Context-aware: an inline question is invisible in an autonomous/loop run (it
+    reads as a log line, so the decision is lost), but in an attended session a
+    human IS reading the prose, so the gate is pointless nagging. Two attended
+    signals skip it (mirroring ``handle_mirror_question_to_slack``): a LIVE USER
+    TURN — the user typed a prompt seconds ago in THIS session
+    (``_is_live_user_turn``), responding in real time, even when this session is
+    the SessionStart-designated tick-owner (``_session_drives_loop`` true); and a
+    NON-OWNER turn — a *different* live session owns the loop. It thus enforces
+    only on a genuine autonomous turn: a driver verdict AND no live user turn.
+    FAIL SAFE: unknown ownership or an ``_is_live_user_turn`` error keep it firing.
     """
     if data.get("stop_hook_active"):
         return None
-    if not _session_drives_loop(data.get("session_id", "")):
+    if _is_live_user_turn(data) or not _session_drives_loop(data.get("session_id", "")):
         return None
     turn = _last_assistant_turn(data.get("transcript_path", ""))
     if turn is None:

--- a/tests/test_structured_question_hook.py
+++ b/tests/test_structured_question_hook.py
@@ -520,6 +520,73 @@ class TestGateIsLoopDrivenContextAware:
         assert result is not True
 
 
+class TestGateSkipsLiveUserTurn:
+    """A live user turn skips the gate even when this session owns the loop (#807).
+
+    The over-fire: this session is the SessionStart-designated tick-owner
+    (``_session_drives_loop`` true), but a human is actively responding in real
+    time (``_is_live_user_turn`` true). Forcing an ``AskUserQuestion`` menu into
+    that free-form discussion is exactly the pointless nagging the gate must
+    avoid. The anti-vacuous pair pins both dimensions: live turn ⇒ skip, and the
+    SAME owning session with no live turn ⇒ the gate still fires (the live-turn
+    escape is not an over-exemption that neuters the autonomous-loop job).
+    """
+
+    @staticmethod
+    def _owner_record(session_id: str, pid: int) -> dict[str, dict]:
+        return {
+            router._OWNER_LOOP: {
+                "session_id": session_id,
+                "agent_id": "a",
+                "pid": pid,
+                "heartbeat_ts": 0,
+            }
+        }
+
+    @pytest.fixture(autouse=True)
+    def _registry_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        reg = tmp_path / "data"
+        reg.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("T3_LOOP_REGISTRY_DIR", str(reg))
+
+    def _inline_question_transcript(self, tmp_path: Path) -> Path:
+        return _write_transcript(
+            tmp_path,
+            [_user("let us discuss the design"), _assistant("Done. Should I push the branch now?")],
+        )
+
+    def test_must_not_fire_on_live_user_turn_even_when_owner(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Over-fire reproduction: this session OWNS the tick (drives_loop true),
+        # but a human typed a prompt seconds ago in it (live user turn). The
+        # human is reading the prose, so the gate MUST NOT force a tool call.
+        router._write_loop_registry(self._owner_record("owner-live", os.getpid()))
+        monkeypatch.setattr(router, "_is_live_user_turn", lambda _data: True)
+        transcript = self._inline_question_transcript(tmp_path)
+
+        result = handle_enforce_structured_question({"transcript_path": str(transcript), "session_id": "owner-live"})
+
+        assert _decision(capsys) == {}
+        assert result is not True
+
+    def test_must_fire_on_autonomous_owner_turn_when_not_live(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Anti-over-exemption: the SAME owning session with NO live user turn is
+        # a genuinely autonomous loop run, where the inline question is invisible
+        # — the gate MUST still fire. This goes GREEN only because the skip is
+        # gated on the live-turn signal, not an unconditional owner exemption.
+        router._write_loop_registry(self._owner_record("owner-auto", os.getpid()))
+        monkeypatch.setattr(router, "_is_live_user_turn", lambda _data: False)
+        transcript = self._inline_question_transcript(tmp_path)
+
+        result = handle_enforce_structured_question({"transcript_path": str(transcript), "session_id": "owner-auto"})
+
+        assert _decision(capsys).get("decision") == "block"
+        assert result is True
+
+
 class TestSequencingOfferDoesNotFire:
     """Anti-vacuous pair: the rhetorical sequencing offer passes; a real offer fires."""
 


### PR DESCRIPTION
## What

The #807 inline-question Stop gate (`handle_enforce_structured_question`) keyed its enforce/skip decision solely on `_session_drives_loop`. That predicate is `True` for the SessionStart-designated tick-owner session, so the gate fired on attended, interactive design turns in the owner session — forcing `AskUserQuestion` menus into free-form discussions that the present human kept rejecting in order to talk freely.

## Why it over-fired

`_session_drives_loop` returns `True` when this session owns the tick-owner record or when there is no live owner. It does not account for a human actively responding in real time. A banner-designated tick-owner that a human is interactively driving is attended — not an autonomous loop run — but the old condition treated it as loop-driven and gated it.

## Fix

Skip the gate on a live user turn (`_is_live_user_turn`) — the same attended signal the sibling `handle_mirror_question_to_slack` already uses (`if _is_live_user_turn(data) or not _session_drives_loop(...)`). A live user turn means the user typed a prompt seconds ago in this session, i.e. a human is responding in real time, even when this session is the banner-designated tick-owner.

The gate's real job is preserved: a genuinely autonomous loop run has no live user turn (`_is_live_user_turn` fails safe to `False` on any error / no fresh prompt), so it still fires on the invisible-question case it exists for. The away-mode `DeferredQuestion` path is a separate PreToolUse handler and is untouched.

## Tests

New `TestGateSkipsLiveUserTurn` (anti-vacuous pair):

- `test_must_not_fire_on_live_user_turn_even_when_owner` — owning session (`_session_drives_loop` true) + live user turn => no block. Verified RED on revert (fires `block` on the old condition).
- `test_must_fire_on_autonomous_owner_turn_when_not_live` — the SAME owning session with no live user turn => still blocks, so the live-turn escape is not an over-exemption.

The existing `TestGateIsLoopDrivenContextAware` must-fire / must-not-fire cases remain green. Module-health LOC ratchet kept net-zero (docstring condensed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
