### PR TITLE
fix(dream): generate the eval-synth prompt grammar from the loader single source (#2646)

### DIFF
--- a/src/teatree/eval/loader.py
+++ b/src/teatree/eval/loader.py
@@ -19,6 +19,8 @@ from teatree.agents.model_tiering import TIER_MODELS
 from teatree.eval.models import (
     CLEAN_ROOM_LANE,
     DEFAULT_MAX_TURNS,
+    MATCHER_KINDS,
+    MATCHER_OPERATORS,
     PERMITTED_LANES,
     AnyOf,
     EvalSpec,
@@ -39,7 +41,10 @@ DEFAULT_TOOLS: tuple[str, ...] = ("Bash",)
 DEFAULT_JUDGE_MODEL = "claude-sonnet-4-6"
 DEFAULT_JUDGE_MAX_OUTPUT_TOKENS = 512
 
-_OP_PATTERN = re.compile(r'^(contains|~)\s+"(.*)"$')
+# Compiled FROM the single-source-of-truth operator set (teatree.eval.models) so the
+# loader, the grader, and the dream synthesizer prompt cannot drift apart on which
+# operators an `op "value"` expression may use.
+_OP_PATTERN = re.compile(rf'^({"|".join(re.escape(op) for op in MATCHER_OPERATORS)})\s+"(.*)"$')
 
 
 class EvalSpecError(ValueError):
@@ -224,11 +229,8 @@ def _parse_matcher(item: object, spec_name: str, path: Path) -> ExpectItem:
         return _parse_negative(item_map, spec_name, path)
     if "final_state" in item_map:
         return _parse_final_state(item_map, spec_name, path)
-    raise EvalSpecError(
-        path,
-        None,
-        f"spec {spec_name!r}: expect entry must have `tool_call`, `no_tool_call_matching`, `any_of`, or `final_state`",
-    )
+    kinds = ", ".join(f"`{kind}`" for kind in MATCHER_KINDS)
+    raise EvalSpecError(path, None, f"spec {spec_name!r}: expect entry must have one of {kinds}")
 
 
 def _parse_final_state(item: Mapping[str, Any], spec_name: str, path: Path) -> FinalStateMatcher:

--- a/src/teatree/eval/models.py
+++ b/src/teatree/eval/models.py
@@ -113,6 +113,22 @@ class FinalStateMatcher:
 # assertion about the run's final assistant message (the end state).
 ExpectItem = Matcher | AnyOf | FinalStateMatcher
 
+#: The SINGLE SOURCE OF TRUTH for the matcher grammar, read by every place that has
+#: to agree on it: the loader compiles ``_OP_PATTERN`` from ``MATCHER_OPERATORS`` and
+#: keys its ``expect``-entry dispatch on ``MATCHER_KINDS``; the grader
+#: (``report._dispatch``) branches on the same operators; and the dream eval
+#: synthesizer prompt (``llm_eval_proposer``) enumerates BOTH so it can never tell
+#: the model to emit a shape the loader rejects. Hand-duplicating the grammar into
+#: the prompt is exactly what dropped every derived candidate in #2646 — these
+#: constants make a future operator/kind change touch one place and fan out, instead
+#: of silently re-opening the drift.
+#:
+#: ``MATCHER_OPERATORS`` are the operator tokens an ``op "value"`` expression may use
+#: (``contains`` substring / ``~`` regex). ``MATCHER_KINDS`` are the four
+#: ``expect``-entry kinds, ordered as the synthesizer prompt teaches them.
+MATCHER_OPERATORS: tuple[str, ...] = ("contains", "~")
+MATCHER_KINDS: tuple[str, ...] = ("tool_call", "no_tool_call_matching", "any_of", "final_state")
+
 #: Case aliases mapping a tool name's lowercase form to its canonical name. The
 #: single source of truth so the grader (``report._canonicalize_tool``) and the
 #: metered runner's toolset restriction (``api_runner.compute_disallowed_tools``)

--- a/src/teatree/loops/dream/llm_eval_proposer.py
+++ b/src/teatree/loops/dream/llm_eval_proposer.py
@@ -323,11 +323,15 @@ def stage_proposals_file(
         name = str(row.get("scenario_name") or "")
         if name:
             slices[name] = str(row.get("seed_citation") or "")
+    if synthesizer is None:
+        from teatree.loops.dream.sdk_eval_synthesizer import sdk_spec_synthesizer  # noqa: PLC0415
+
+        synthesizer = sdk_spec_synthesizer
     return stage_derived_evals(
         candidates,
         transcript_slices=slices,
         staging_dir=staging_dir or default_staging_dir(),
-        synthesizer=synthesizer or sdk_spec_synthesizer,
+        synthesizer=synthesizer,
         dry_run=dry_run,
     )
 
@@ -401,196 +405,12 @@ def _op(matcher: Matcher) -> str:
     return f'{matcher.operator} "{matcher.value}"'
 
 
-_SYNTH_SYSTEM_PROMPT = (
-    "You design ONE under_load behavioural eval that pins a drift rule. From the "
-    "drift rule, the cited real mistake, and a session slice, emit discriminating "
-    "matchers: a POSITIVE for the corrected behaviour and a NEGATIVE for the drift. "
-    "Use ONLY the existing matcher shapes; never invent a rule the slice cannot "
-    "ground. Also emit the cited drift's ACTUAL tool-call shape and the compliant "
-    "tool-call shape so the gate can prove your matchers reject the cited drift. "
-    "Reply with EXACTLY ONE JSON object and NO surrounding prose."
-)
-
-_SYNTH_PROMPT_TEMPLATE = (
-    "Design one under_load eval scenario as a SINGLE JSON object. "
-    "REQUIRED keys (emit EVERY one — a scenario missing any is dropped): "
-    "scenario_name (copy verbatim: {scenario_name}), context_preamble (a polluted "
-    "session prefix synthesized from the slice below), prompt (the user request that "
-    "triggers the drift), expect (a JSON list of matcher objects — see MATCHER "
-    'GRAMMAR below), fail_tool_call (a JSON object {{"name": <tool>, "input": '
-    "{{...}}}} for the cited DRIFT action your NEGATIVE matcher must reject), "
-    "pass_tool_call (the same shape for the COMPLIANT action your matchers must "
-    "accept). OPTIONAL keys (include when useful, safe to omit): scenario_description "
-    "(one sentence), agent_path (the owning skill, e.g. skills/rules/SKILL.md), "
-    "judge_rubric (a one-sentence PASS-iff rubric). "
-    "The matchers MUST reject fail_tool_call and accept pass_tool_call.\n\n"
-    "MATCHER GRAMMAR (the loader is STRICT — copy the SHAPE of each example exactly). "
-    'Every operator value is ALWAYS `contains "<substring>"` or `~ "<regex>"`:\n'
-    "  - positive tool_call — a `tool_call` key plus EXACTLY ONE `args.<path>` key "
-    "(no more, no fewer):\n"
-    '      {{"tool_call": "Bash", "args.command": "contains \\"git worktree add\\""}}\n'
-    "  - no_tool_call_matching — a single inner mapping holding EXACTLY ONE "
-    "`<tool>.<arg>` key (the key MUST contain a dot):\n"
-    '      {{"no_tool_call_matching": {{"Bash.command": "~ \\"rm -rf\\""}}}}\n'
-    "  - any_of — a NON-EMPTY list of positive `tool_call` entries ONLY (each itself "
-    "a single-`args.<path>` object):\n"
-    '      {{"any_of": [{{"tool_call": "Task", "args.prompt": "~ \\"fix\\""}}, '
-    '{{"tool_call": "Agent", "args.prompt": "~ \\"fix\\""}}]}}\n'
-    "  - final_state — one operator expression over the agent's FINAL message:\n"
-    '      {{"final_state": "~ \\"opened PR\\""}}\n'
-    "An expect entry that is none of these four kinds, a positive `tool_call` with "
-    "zero or several `args.<path>` keys, or a `no_tool_call_matching` with zero or "
-    "several inner entries is REJECTED and the whole scenario is dropped.\n\n"
-    "Reply with EXACTLY ONE JSON object and NO surrounding prose, markdown fences, "
-    "or trailing objects.\n\n"
-    "Drift rule: {drift_rule}\n"
-    "Cited real mistake: {seed_citation}\n\n"
-    "Session slice:\n{slice}"
-)
-
-_SYNTH_WATCHDOG_SECONDS = 5 * 60
-_SYNTH_MODEL = "claude-haiku-4-5"
-_REQUIRED_SYNTH_KEYS = ("scenario_name", "context_preamble", "prompt", "expect", "fail_tool_call", "pass_tool_call")
-
-
-def sdk_spec_synthesizer(candidate: Mapping[str, object], transcript_slice: str) -> SynthesizedSpec:
-    """The real synthesizer: one bounded headless SDK turn → a scenario, parsed defensively.
-
-    Mirrors :func:`teatree.loops.dream.sdk_distiller.sdk_distiller`'s invocation shape (the
-    ``claude_code`` preset, ``bypassPermissions``, a wall-clock watchdog) for a single
-    no-tool turn that transforms the candidate + slice into one scenario JSON object.
-    Raises on an unavailable ``claude`` or a malformed reply, so the caller DROPS the
-    candidate (never a staged unproven spec) rather than reporting a fake success.
-    """
-    import asyncio  # noqa: PLC0415
-    import shutil  # noqa: PLC0415
-
-    if shutil.which("claude") is None:
-        msg = "claude is not installed — the dream eval synthesizer cannot run"
-        raise RuntimeError(msg)
-    prompt = _SYNTH_PROMPT_TEMPLATE.format(
-        scenario_name=str(candidate.get("scenario_name") or ""),
-        drift_rule=str(candidate.get("drift_rule") or ""),
-        seed_citation=str(candidate.get("seed_citation") or ""),
-        slice=transcript_slice,
-    )
-    raw = asyncio.run(_collect_synth_turn(prompt))
-    return _parse_synthesized(raw, candidate)
-
-
-async def _collect_synth_turn(prompt: str) -> str:
-    import asyncio  # noqa: PLC0415
-
-    from claude_agent_sdk import AssistantMessage, ClaudeAgentOptions, ClaudeSDKClient, TextBlock  # noqa: PLC0415
-    from claude_agent_sdk.types import SystemPromptPreset  # noqa: PLC0415
-
-    options = ClaudeAgentOptions(
-        system_prompt=SystemPromptPreset(type="preset", preset="claude_code", append=_SYNTH_SYSTEM_PROMPT),
-        model=_SYNTH_MODEL,
-        permission_mode="bypassPermissions",
-        max_turns=1,
-        allowed_tools=[],
-    )
-    parts: list[str] = []
-    async with ClaudeSDKClient(options=options) as client:
-        await client.query(prompt)
-
-        async def _drain() -> list[object]:
-            return [message async for message in client.receive_response()]
-
-        for message in await asyncio.wait_for(_drain(), timeout=_SYNTH_WATCHDOG_SECONDS):
-            if isinstance(message, AssistantMessage):
-                parts.extend(block.text for block in message.content if isinstance(block, TextBlock))
-    return "\n".join(parts)
-
-
-def _extract_json_object(raw: str) -> Mapping[str, object] | None:
-    """The FIRST balanced JSON object in *raw*, tolerating prose and trailing objects.
-
-    The object analogue of :func:`teatree.loops.dream.sdk_distiller._extract_json_array`:
-    rather than spanning the first ``{`` to the last ``}`` (which captures multiple
-    objects or a trailing fragment and makes ``json.loads`` raise ``Extra data``), it
-    scans each ``{`` with :meth:`json.JSONDecoder.raw_decode` and returns the first
-    that decodes to a mapping — so a reply carrying prose plus more than one object
-    yields its first object instead of crashing the whole derivation phase.
-    """
-    import json  # noqa: PLC0415
-
-    decoder = json.JSONDecoder()
-    index = raw.find("{")
-    while index != -1:
-        try:
-            parsed, _ = decoder.raw_decode(raw, index)
-        except json.JSONDecodeError:
-            index = raw.find("{", index + 1)
-        else:
-            return parsed
-    return None
-
-
-def _parse_synthesized(raw: str, candidate: Mapping[str, object]) -> SynthesizedSpec:
-    """Parse the synthesizer's JSON object into a :class:`SynthesizedSpec`.
-
-    Extracts the first balanced JSON object (via :func:`_extract_json_object`), so
-    surrounding prose or a trailing second object no longer raises ``Extra data``. A
-    missing required key or a non-list ``expect`` raises, so a malformed reply DROPS
-    the candidate rather than staging a partial scenario.
-    """
-    payload = _extract_json_object(raw)
-    if payload is None:
-        msg = "synthesizer returned no JSON object"
-        raise ValueError(msg)
-    missing = [key for key in _REQUIRED_SYNTH_KEYS if key not in payload]
-    if missing:
-        msg = f"synthesized scenario is missing required key(s): {', '.join(missing)}"
-        raise ValueError(msg)
-    raw_expect = payload["expect"]
-    if not isinstance(raw_expect, list) or not raw_expect:
-        msg = "synthesized scenario has no matchers"
-        raise ValueError(msg)
-    matchers: list[Mapping[str, object]] = [
-        {str(key): value for key, value in entry.items()} for entry in raw_expect if isinstance(entry, Mapping)
-    ]
-    fail_tool_call = _require_tool_call(payload["fail_tool_call"], "fail_tool_call")
-    pass_tool_call = _require_tool_call(payload["pass_tool_call"], "pass_tool_call")
-    return SynthesizedSpec(
-        scenario_name=str(payload["scenario_name"] or candidate.get("scenario_name") or ""),
-        scenario_description=str(payload.get("scenario_description") or ""),
-        agent_path=str(payload.get("agent_path") or "skills/rules/SKILL.md"),
-        context_preamble=str(payload["context_preamble"]),
-        prompt=str(payload["prompt"]),
-        expect=matchers,
-        fail_tool_call=fail_tool_call,
-        pass_tool_call=pass_tool_call,
-        judge_rubric=str(payload.get("judge_rubric") or ""),
-    )
-
-
-def _require_tool_call(value: object, key: str) -> ToolCallShape:
-    """Validate a synthesized tool-call shape (``{"name": <tool>, "input": {...}}``).
-
-    The teeth check seeds its candidate-derived ``_fail`` / ``_pass`` transcripts
-    from these, so a malformed shape (no ``name``) is fatal — the candidate DROPS
-    rather than teeth-checking against an empty transcript that fails nothing.
-    """
-    if not isinstance(value, Mapping):
-        value = {}
-    fields = {str(field_key): field_value for field_key, field_value in value.items()}
-    name = str(fields.get("name") or "")
-    if not name:
-        msg = f"synthesized scenario has a malformed {key} (need a tool-call with a name)"
-        raise ValueError(msg)
-    tool_input = fields.get("input")
-    return ToolCallShape(name=name, input=dict(tool_input) if isinstance(tool_input, Mapping) else {})
-
-
 __all__ = [
     "DerivationOutcome",
     "SpecSynthesizer",
     "SynthesizedSpec",
     "default_staging_dir",
     "derive_eval_from_candidate",
-    "sdk_spec_synthesizer",
     "stage_derived_evals",
     "stage_proposals_file",
 ]

--- a/src/teatree/loops/dream/sdk_eval_synthesizer.py
+++ b/src/teatree/loops/dream/sdk_eval_synthesizer.py
@@ -1,0 +1,221 @@
+"""The real LLM-backed eval synthesizer: prompt + one bounded SDK turn + reply parse.
+
+The injected :data:`~teatree.loops.dream.llm_eval_proposer.SpecSynthesizer`
+implementation that :mod:`teatree.loops.dream.llm_eval_proposer` calls by default —
+split out so the derivation/staging orchestration and the concrete LLM seam stay one
+concern each.
+
+The prompt enumerates the loader's matcher grammar from its SINGLE SOURCE OF TRUTH
+(:data:`teatree.eval.models.MATCHER_OPERATORS` / :data:`~teatree.eval.models.MATCHER_KINDS`),
+so the synthesizer can never be told to emit a shape the loader rejects — the
+hand-duplicated grammar that dropped every derived candidate in #2646. Tests inject a
+fake synthesizer, so the only live-LLM path here is exercised by the defensive
+reply-parsing tests, never a metered call.
+"""
+
+from collections.abc import Mapping
+
+from teatree.eval.models import MATCHER_KINDS, MATCHER_OPERATORS
+from teatree.loops.dream._teeth_check import ToolCallShape
+from teatree.loops.dream.llm_eval_proposer import SynthesizedSpec
+
+_SYNTH_SYSTEM_PROMPT = (
+    "You design ONE under_load behavioural eval that pins a drift rule. From the "
+    "drift rule, the cited real mistake, and a session slice, emit discriminating "
+    "matchers: a POSITIVE for the corrected behaviour and a NEGATIVE for the drift. "
+    "Use ONLY the existing matcher shapes; never invent a rule the slice cannot "
+    "ground. Also emit the cited drift's ACTUAL tool-call shape and the compliant "
+    "tool-call shape so the gate can prove your matchers reject the cited drift. "
+    "Reply with EXACTLY ONE JSON object and NO surrounding prose."
+)
+
+# The operator + matcher-kind enumerations the prompt teaches are GENERATED from the
+# loader's single source of truth (``teatree.eval.models``), so the synthesizer can
+# never be told to emit a shape the loader rejects — the hand-duplicated grammar that
+# dropped every derived candidate in #2646. A per-operator value hint keeps the
+# substring-vs-regex nuance; an operator with no hint still surfaces with a generic
+# placeholder, so a future loader operator can never silently vanish from the prompt.
+_OPERATOR_VALUE_HINTS = {"contains": "<substring>", "~": "<regex>"}
+_OPERATOR_CLAUSE = " or ".join(
+    f'`{operator} "{_OPERATOR_VALUE_HINTS.get(operator, "<value>")}"`' for operator in MATCHER_OPERATORS
+)
+_MATCHER_KINDS_CLAUSE = ", ".join(f"`{kind}`" for kind in MATCHER_KINDS)
+
+_SYNTH_PROMPT_TEMPLATE = (
+    "Design one under_load eval scenario as a SINGLE JSON object. "
+    "REQUIRED keys (emit EVERY one — a scenario missing any is dropped): "
+    "scenario_name (copy verbatim: {scenario_name}), context_preamble (a polluted "
+    "session prefix synthesized from the slice below), prompt (the user request that "
+    "triggers the drift), expect (a JSON list of matcher objects — see MATCHER "
+    'GRAMMAR below), fail_tool_call (a JSON object {{"name": <tool>, "input": '
+    "{{...}}}} for the cited DRIFT action your NEGATIVE matcher must reject), "
+    "pass_tool_call (the same shape for the COMPLIANT action your matchers must "
+    "accept). OPTIONAL keys (include when useful, safe to omit): scenario_description "
+    "(one sentence), agent_path (the owning skill, e.g. skills/rules/SKILL.md), "
+    "judge_rubric (a one-sentence PASS-iff rubric). "
+    "The matchers MUST reject fail_tool_call and accept pass_tool_call.\n\n"
+    "MATCHER GRAMMAR (the loader is STRICT — copy the SHAPE of each example exactly). "
+    "The matcher kinds are "
+    + _MATCHER_KINDS_CLAUSE
+    + "; every operator value is ALWAYS one of "
+    + _OPERATOR_CLAUSE
+    + ":\n"
+    "  - positive tool_call — a `tool_call` key plus EXACTLY ONE `args.<path>` key "
+    "(no more, no fewer):\n"
+    '      {{"tool_call": "Bash", "args.command": "contains \\"git worktree add\\""}}\n'
+    "  - no_tool_call_matching — a single inner mapping holding EXACTLY ONE "
+    "`<tool>.<arg>` key (the key MUST contain a dot):\n"
+    '      {{"no_tool_call_matching": {{"Bash.command": "~ \\"rm -rf\\""}}}}\n'
+    "  - any_of — a NON-EMPTY list of positive `tool_call` entries ONLY (each itself "
+    "a single-`args.<path>` object):\n"
+    '      {{"any_of": [{{"tool_call": "Task", "args.prompt": "~ \\"fix\\""}}, '
+    '{{"tool_call": "Agent", "args.prompt": "~ \\"fix\\""}}]}}\n'
+    "  - final_state — one operator expression over the agent's FINAL message:\n"
+    '      {{"final_state": "~ \\"opened PR\\""}}\n'
+    "An expect entry whose top-level key is none of " + _MATCHER_KINDS_CLAUSE + ", a positive "
+    "`tool_call` with zero or several `args.<path>` keys, or a `no_tool_call_matching` with "
+    "zero or several inner entries is REJECTED and the whole scenario is dropped.\n\n"
+    "Reply with EXACTLY ONE JSON object and NO surrounding prose, markdown fences, "
+    "or trailing objects.\n\n"
+    "Drift rule: {drift_rule}\n"
+    "Cited real mistake: {seed_citation}\n\n"
+    "Session slice:\n{slice}"
+)
+
+_SYNTH_WATCHDOG_SECONDS = 5 * 60
+_SYNTH_MODEL = "claude-haiku-4-5"
+_REQUIRED_SYNTH_KEYS = ("scenario_name", "context_preamble", "prompt", "expect", "fail_tool_call", "pass_tool_call")
+
+
+def sdk_spec_synthesizer(candidate: Mapping[str, object], transcript_slice: str) -> SynthesizedSpec:
+    """The real synthesizer: one bounded headless SDK turn → a scenario, parsed defensively.
+
+    Mirrors :func:`teatree.loops.dream.sdk_distiller.sdk_distiller`'s invocation shape (the
+    ``claude_code`` preset, ``bypassPermissions``, a wall-clock watchdog) for a single
+    no-tool turn that transforms the candidate + slice into one scenario JSON object.
+    Raises on an unavailable ``claude`` or a malformed reply, so the caller DROPS the
+    candidate (never a staged unproven spec) rather than reporting a fake success.
+    """
+    import asyncio  # noqa: PLC0415
+    import shutil  # noqa: PLC0415
+
+    if shutil.which("claude") is None:
+        msg = "claude is not installed — the dream eval synthesizer cannot run"
+        raise RuntimeError(msg)
+    prompt = _SYNTH_PROMPT_TEMPLATE.format(
+        scenario_name=str(candidate.get("scenario_name") or ""),
+        drift_rule=str(candidate.get("drift_rule") or ""),
+        seed_citation=str(candidate.get("seed_citation") or ""),
+        slice=transcript_slice,
+    )
+    raw = asyncio.run(_collect_synth_turn(prompt))
+    return _parse_synthesized(raw, candidate)
+
+
+async def _collect_synth_turn(prompt: str) -> str:
+    import asyncio  # noqa: PLC0415
+
+    from claude_agent_sdk import AssistantMessage, ClaudeAgentOptions, ClaudeSDKClient, TextBlock  # noqa: PLC0415
+    from claude_agent_sdk.types import SystemPromptPreset  # noqa: PLC0415
+
+    options = ClaudeAgentOptions(
+        system_prompt=SystemPromptPreset(type="preset", preset="claude_code", append=_SYNTH_SYSTEM_PROMPT),
+        model=_SYNTH_MODEL,
+        permission_mode="bypassPermissions",
+        max_turns=1,
+        allowed_tools=[],
+    )
+    parts: list[str] = []
+    async with ClaudeSDKClient(options=options) as client:
+        await client.query(prompt)
+
+        async def _drain() -> list[object]:
+            return [message async for message in client.receive_response()]
+
+        for message in await asyncio.wait_for(_drain(), timeout=_SYNTH_WATCHDOG_SECONDS):
+            if isinstance(message, AssistantMessage):
+                parts.extend(block.text for block in message.content if isinstance(block, TextBlock))
+    return "\n".join(parts)
+
+
+def _extract_json_object(raw: str) -> Mapping[str, object] | None:
+    """The FIRST balanced JSON object in *raw*, tolerating prose and trailing objects.
+
+    The object analogue of :func:`teatree.loops.dream.sdk_distiller._extract_json_array`:
+    rather than spanning the first ``{`` to the last ``}`` (which captures multiple
+    objects or a trailing fragment and makes ``json.loads`` raise ``Extra data``), it
+    scans each ``{`` with :meth:`json.JSONDecoder.raw_decode` and returns the first
+    that decodes to a mapping — so a reply carrying prose plus more than one object
+    yields its first object instead of crashing the whole derivation phase.
+    """
+    import json  # noqa: PLC0415
+
+    decoder = json.JSONDecoder()
+    index = raw.find("{")
+    while index != -1:
+        try:
+            parsed, _ = decoder.raw_decode(raw, index)
+        except json.JSONDecodeError:
+            index = raw.find("{", index + 1)
+        else:
+            return parsed
+    return None
+
+
+def _parse_synthesized(raw: str, candidate: Mapping[str, object]) -> SynthesizedSpec:
+    """Parse the synthesizer's JSON object into a :class:`SynthesizedSpec`.
+
+    Extracts the first balanced JSON object (via :func:`_extract_json_object`), so
+    surrounding prose or a trailing second object no longer raises ``Extra data``. A
+    missing required key or a non-list ``expect`` raises, so a malformed reply DROPS
+    the candidate rather than staging a partial scenario.
+    """
+    payload = _extract_json_object(raw)
+    if payload is None:
+        msg = "synthesizer returned no JSON object"
+        raise ValueError(msg)
+    missing = [key for key in _REQUIRED_SYNTH_KEYS if key not in payload]
+    if missing:
+        msg = f"synthesized scenario is missing required key(s): {', '.join(missing)}"
+        raise ValueError(msg)
+    raw_expect = payload["expect"]
+    if not isinstance(raw_expect, list) or not raw_expect:
+        msg = "synthesized scenario has no matchers"
+        raise ValueError(msg)
+    matchers: list[Mapping[str, object]] = [
+        {str(key): value for key, value in entry.items()} for entry in raw_expect if isinstance(entry, Mapping)
+    ]
+    fail_tool_call = _require_tool_call(payload["fail_tool_call"], "fail_tool_call")
+    pass_tool_call = _require_tool_call(payload["pass_tool_call"], "pass_tool_call")
+    return SynthesizedSpec(
+        scenario_name=str(payload["scenario_name"] or candidate.get("scenario_name") or ""),
+        scenario_description=str(payload.get("scenario_description") or ""),
+        agent_path=str(payload.get("agent_path") or "skills/rules/SKILL.md"),
+        context_preamble=str(payload["context_preamble"]),
+        prompt=str(payload["prompt"]),
+        expect=matchers,
+        fail_tool_call=fail_tool_call,
+        pass_tool_call=pass_tool_call,
+        judge_rubric=str(payload.get("judge_rubric") or ""),
+    )
+
+
+def _require_tool_call(value: object, key: str) -> ToolCallShape:
+    """Validate a synthesized tool-call shape (``{"name": <tool>, "input": {...}}``).
+
+    The teeth check seeds its candidate-derived ``_fail`` / ``_pass`` transcripts
+    from these, so a malformed shape (no ``name``) is fatal — the candidate DROPS
+    rather than teeth-checking against an empty transcript that fails nothing.
+    """
+    if not isinstance(value, Mapping):
+        value = {}
+    fields = {str(field_key): field_value for field_key, field_value in value.items()}
+    name = str(fields.get("name") or "")
+    if not name:
+        msg = f"synthesized scenario has a malformed {key} (need a tool-call with a name)"
+        raise ValueError(msg)
+    tool_input = fields.get("input")
+    return ToolCallShape(name=name, input=dict(tool_input) if isinstance(tool_input, Mapping) else {})
+
+
+__all__ = ["sdk_spec_synthesizer"]

--- a/tests/teatree_loops/dream/test_llm_eval_proposer.py
+++ b/tests/teatree_loops/dream/test_llm_eval_proposer.py
@@ -27,19 +27,17 @@ import pytest
 from django.test import TestCase
 
 from teatree.eval.discovery import SCENARIOS_DIR
-from teatree.eval.loader import _parse_matcher, load_eval_yaml
-from teatree.eval.models import UNDER_LOAD_LANE
+from teatree.eval.loader import _OP_PATTERN, _parse_matcher, load_eval_yaml
+from teatree.eval.models import MATCHER_KINDS, MATCHER_OPERATORS, UNDER_LOAD_LANE
 from teatree.loops.dream.llm_eval_proposer import (
-    _SYNTH_PROMPT_TEMPLATE,
     SpecSynthesizer,
     SynthesizedSpec,
-    _parse_synthesized,
     default_staging_dir,
     derive_eval_from_candidate,
-    sdk_spec_synthesizer,
     stage_derived_evals,
     stage_proposals_file,
 )
+from teatree.loops.dream.sdk_eval_synthesizer import _SYNTH_PROMPT_TEMPLATE, _parse_synthesized, sdk_spec_synthesizer
 
 _CANDIDATE: dict[str, object] = {
     "scenario_name": "derived_delegate_under_load",
@@ -251,9 +249,6 @@ def _json_objects_in(text: str) -> list[Mapping[str, object]]:
             objects.append(parsed)
         index = text.find("{", index + 1)
     return objects
-
-
-_MATCHER_KINDS = ("tool_call", "no_tool_call_matching", "any_of", "final_state")
 
 
 class DeriveEvalFromCandidateTestCase(TestCase):
@@ -527,9 +522,9 @@ class SynthPromptGrammarTestCase(TestCase):
         return _SYNTH_PROMPT_TEMPLATE.format(scenario_name="x_under_load", drift_rule="d", seed_citation="c", slice="s")
 
     def test_prompt_carries_a_loader_parseable_example_of_every_matcher_kind(self) -> None:
-        examples = [obj for obj in _json_objects_in(self._rendered_prompt()) if any(k in obj for k in _MATCHER_KINDS)]
-        kinds = {kind for obj in examples for kind in _MATCHER_KINDS if kind in obj}
-        assert kinds == set(_MATCHER_KINDS)
+        examples = [obj for obj in _json_objects_in(self._rendered_prompt()) if any(k in obj for k in MATCHER_KINDS)]
+        kinds = {kind for obj in examples for kind in MATCHER_KINDS if kind in obj}
+        assert kinds == set(MATCHER_KINDS)
         for example in examples:
             _parse_matcher(example, "prompt_example", Path("synthesizer-prompt"))
 
@@ -642,3 +637,45 @@ class ParseSynthesizedExtractsOneObjectTestCase(TestCase):
     def test_only_a_non_json_brace_raises_no_object(self) -> None:
         with pytest.raises(ValueError, match="no JSON object"):
             _parse_synthesized("the model mused {about it but emitted no object", {"scenario_name": "x"})
+
+
+class PromptGrammarTracksTheLoaderSingleSourceTestCase(TestCase):
+    """The synth prompt is GENERATED from the loader's grammar single source (#2646).
+
+    The drop-every-candidate bug was a synthesizer prompt that diverged from the
+    loader's strict grammar. The first fix hand-wrote the grammar into the prompt —
+    correct, but a SECOND copy that can silently drift the next time the loader's
+    operator/kind set changes. ``MATCHER_OPERATORS`` / ``MATCHER_KINDS`` are now the
+    one source both sides read: the loader's ``_OP_PATTERN`` is compiled from the
+    operator constant, and the prompt enumerates both constants. These lock the
+    coupling, so a future operator/kind added to the loader but missing from the
+    prompt fails here instead of re-opening the drift.
+    """
+
+    def _rendered_prompt(self) -> str:
+        return _SYNTH_PROMPT_TEMPLATE.format(scenario_name="x_under_load", drift_rule="d", seed_citation="c", slice="s")
+
+    def test_prompt_offers_every_loader_supported_operator(self) -> None:
+        rendered = self._rendered_prompt()
+        for operator in MATCHER_OPERATORS:
+            assert operator in rendered, f"prompt omits supported operator {operator!r}"
+
+    def test_prompt_names_every_loader_matcher_kind(self) -> None:
+        rendered = self._rendered_prompt()
+        for kind in MATCHER_KINDS:
+            assert kind in rendered, f"prompt omits matcher kind {kind!r}"
+
+    def test_loader_op_pattern_accepts_exactly_the_operator_constant(self) -> None:
+        # The pattern is compiled FROM MATCHER_OPERATORS — every declared operator
+        # parses and an undeclared one does not, so the regex and the constant (and
+        # therefore the prompt) cannot drift apart.
+        for operator in MATCHER_OPERATORS:
+            assert _OP_PATTERN.match(f'{operator} "x"') is not None, operator
+        assert _OP_PATTERN.match('startswith "x"') is None
+
+    def test_each_synthesized_matcher_kind_round_trips_through_the_loader(self) -> None:
+        # Belt-and-braces over the existing example-parity test: the kinds the prompt
+        # advertises are exactly the kinds the loader dispatches, with no orphan on
+        # either side.
+        kinds_in_prompt = {kind for kind in MATCHER_KINDS if kind in self._rendered_prompt()}
+        assert kinds_in_prompt == set(MATCHER_KINDS)


### PR DESCRIPTION
## What

The dream LLM eval-synthesizer prompt hand-duplicated the loader's strict matcher grammar. The earlier enrichment (the rich `MATCHER GRAMMAR` block + the `_extract_json_object` hardening) already closed the original *drop-every-candidate* behaviour and is green on `main` — but it left the prompt and the loader as **two independent copies** of the operator set and the matcher kinds. That second copy silently drifts the next time the loader's grammar changes, re-opening the 100% candidate-drop the issue describes.

This PR closes that remaining drift hazard by giving both sides one source.

## Change

- **Single source of truth** in `teatree.eval.models`: `MATCHER_OPERATORS` (`contains` / `~`) and `MATCHER_KINDS` (the four `expect`-entry kinds).
- The loader compiles `_OP_PATTERN` **from** `MATCHER_OPERATORS` and keys its `expect`-entry rejection message on `MATCHER_KINDS` (no behaviour change — the compiled pattern is equivalent).
- The synthesizer prompt **enumerates both constants** instead of restating them, so it can never instruct the model to emit a shape the loader rejects.
- A parity test locks the coupling: a future operator/kind added to the loader but missing from the prompt fails the test instead of dropping candidates.
- Split the SDK-backed synthesizer (prompt + headless turn + reply parse) out of `llm_eval_proposer` into `sdk_eval_synthesizer` so each module stays one concern and under the module-health LOC cap.

## Tests (RED → GREEN)

New `PromptGrammarTracksTheLoaderSingleSourceTestCase` was **RED** before the fix (`ImportError: cannot import name 'MATCHER_KINDS'` — the single source did not exist) and is **GREEN** after. Full module: 36 passed (was 32) plus the dream-command suite green.

Gates: `ruff check` / `ruff format --check` / `ty check` / `tach check` / module-health / overlay-leak `--require-terms` all clean.

Closes #2646