### PR TITLE
fix(gate): completion-claim recognizes merge-SHA evidence (#2665)

### DIFF
--- a/src/teatree/hooks/completion_claim_scanner.py
+++ b/src/teatree/hooks/completion_claim_scanner.py
@@ -90,7 +90,10 @@ _DELIVERABLE_LINE_RE: Final[re.Pattern[str]] = re.compile(
 # STRONGEST possible proof a deliverable landed — you only obtain a merge SHA
 # AFTER the merge lands. Each hex SHA is anchored to a merge cue (merge commit /
 # merged as / origin-HEAD / fast-forwarded), never matched bare, so a SHA quoted
-# on an unmerged feature branch is not mistaken for on-target evidence.
+# on an unmerged feature branch is not mistaken for on-target evidence. The
+# MERGED-state leg binds the PR/MR id adjacently to "merged" (only a small copula
+# between), so forward-looking "PR #41 will be merged once CI passes" is not read as
+# a landed state.
 _ON_TARGET_EVIDENCE_RE: Final[re.Pattern[str]] = re.compile(
     r"\bmerged (?:to|into|onto) (?:the )?(?:merge )?target\b|"
     r"\bmerged to (?:main|master|develop|the default branch)\b|"
@@ -102,7 +105,7 @@ _ON_TARGET_EVIDENCE_RE: Final[re.Pattern[str]] = re.compile(
     r"\bevidence (?:posted|on target)\b|"
     r"\bmerge(?:d)? commit\s+[0-9a-f]{7,40}\b|"
     r"\b(?:squash[- ]?)?merged as\s+[0-9a-f]{7,40}\b|"
-    r"\b(?:pr|mr|pull request|merge request)\b[^.\n]*\bmerged\b|"
+    r"\b(?:pr|mr|pull request|merge request)\s*[#!]?\d+\b\s*(?:(?:is|was|has been|now)\s+|[:=]\s*)?merged\b|"
     r"\borigin/[\w./-]+\s+HEAD\s*(?:is|=|now|at)\s*[0-9a-f]{7,40}\b|"
     r"\bfast[- ]forwarded(?:\s+to)?\s+[0-9a-f]{7,40}\b",
     re.IGNORECASE,

--- a/src/teatree/hooks/completion_claim_scanner.py
+++ b/src/teatree/hooks/completion_claim_scanner.py
@@ -83,6 +83,14 @@ _DELIVERABLE_LINE_RE: Final[re.Pattern[str]] = re.compile(
 
 # On-target evidence anchors: proof a deliverable landed on the actual merge
 # target. "an MR exists" is explicitly NOT evidence and must NOT match here.
+#
+# The machine-grade alternations (merge-commit SHA / MERGED state / origin-HEAD /
+# fast-forward) recognise the merged-to-target vocabulary a real ship report uses
+# (#2665 over-fire): a merge-commit SHA reachable from origin/main is the
+# STRONGEST possible proof a deliverable landed — you only obtain a merge SHA
+# AFTER the merge lands. Each hex SHA is anchored to a merge cue (merge commit /
+# merged as / origin-HEAD / fast-forwarded), never matched bare, so a SHA quoted
+# on an unmerged feature branch is not mistaken for on-target evidence.
 _ON_TARGET_EVIDENCE_RE: Final[re.Pattern[str]] = re.compile(
     r"\bmerged (?:to|into|onto) (?:the )?(?:merge )?target\b|"
     r"\bmerged to (?:main|master|develop|the default branch)\b|"
@@ -91,7 +99,12 @@ _ON_TARGET_EVIDENCE_RE: Final[re.Pattern[str]] = re.compile(
     r"\bverified on (?:the |its )?(?:correct |config |configuration |intended |right )*surface\b|"
     r"\bpassing e2e\b|\be2e (?:passes|passing|green)\b|"
     r"\bverified on (?:the )?deployed\b|"
-    r"\bevidence (?:posted|on target)\b",
+    r"\bevidence (?:posted|on target)\b|"
+    r"\bmerge(?:d)? commit\s+[0-9a-f]{7,40}\b|"
+    r"\b(?:squash[- ]?)?merged as\s+[0-9a-f]{7,40}\b|"
+    r"\b(?:pr|mr|pull request|merge request)\b[^.\n]*\bmerged\b|"
+    r"\borigin/[\w./-]+\s+HEAD\s*(?:is|=|now|at)\s*[0-9a-f]{7,40}\b|"
+    r"\bfast[- ]forwarded(?:\s+to)?\s+[0-9a-f]{7,40}\b",
     re.IGNORECASE,
 )
 

--- a/tests/teatree_hooks/test_completion_claim_scanner.py
+++ b/tests/teatree_hooks/test_completion_claim_scanner.py
@@ -18,6 +18,8 @@ the real ``hook_router`` Stop handler exercised through a real transcript JSONL
 written under ``tmp_path`` (only stdin/stdout cross the boundary).
 """
 
+import pytest
+
 from teatree.hooks import completion_claim_scanner as scanner
 
 # A complete, on-target deliverable->evidence map for a multi-deliverable ticket:
@@ -291,6 +293,79 @@ class TestMergeShaEvidenceClears:
         assert verdict is not None
         assert verdict.deliverable_count == 2
         assert any("on-target evidence" in reason for reason in verdict.missing)
+
+
+# The reviewer's forward-looking slip-through (#2842 must not re-open): a premature
+# multi-deliverable false-"done" whose every row is FORWARD-LOOKING ("will be merged
+# once CI passes") with NOTHING actually merged. The loose MERGED-state alternation
+# `(?:pr|mr|...)[^.\n]*merged` let the wide id-to-"merged" gap swallow "will be", so
+# the row read as a landed state and the gate cleared. With the id bound adjacently
+# to "merged" (only a small copula allowed between), no row carries on-target
+# evidence, so this premature claim MUST block.
+_FORWARD_LOOKING_SLIP_THROUGH = (
+    "I read the authoritative spec and enumerated every deliverable.\n"
+    "Everything is done and ready to merge.\n"
+    "- US-03: PR #41 will be merged once CI passes.\n"
+    "- US-05: PR #42 will be merged once CI passes.\n"
+    "The crucial deliverable US-03 is verified on its correct surface.\n"
+)
+
+# A genuine MERGED-state map whose ONLY on-target evidence is the bare MERGED token
+# (no merge-commit SHA, no origin/HEAD, no fast-forward) — proves the tightening
+# preserved genuine present-state recognition and did not over-tighten the leg away.
+_BARE_MERGED_STATE_MAP = (
+    "I read the authoritative spec and its comments and enumerated every deliverable.\n"
+    "Both deliverables are merged and live — done.\n"
+    "- US-03 EURIBOR endpoint: PR #42 merged.\n"
+    "- US-05 product-items endpoint: MR !41 is merged.\n"
+    "The crucial deliverable (US-03) is verified on its correct surface.\n"
+)
+
+
+def _two_row_claim(row_a: str, row_b: str) -> str:
+    # Spec-read and crucial-surface legs are pre-satisfied so the ONLY open leg is the
+    # on-target evidence of the two enumerated rows — isolating the MERGED-state regex.
+    return (
+        "I read the authoritative spec and enumerated every deliverable.\n"
+        "Everything is done and ready to merge.\n"
+        f"- US-03: {row_a}\n"
+        f"- US-05: {row_b}\n"
+        "The crucial deliverable US-03 is verified on its correct surface.\n"
+    )
+
+
+class TestForwardLookingMergedDoesNotSlipThrough:
+    """Anti-vacuous pair: the forward-looking slip-through fires; a genuine bare MERGED-state map still clears."""
+
+    def test_forward_looking_slip_through_fires(self) -> None:
+        # The reviewer's exact input: every row "will be merged once CI passes" with
+        # nothing landed. Reverting the alternation to the loose `[^.\n]*merged` makes
+        # this return None — the RED-on-revert anchor for the tightening.
+        verdict = scanner.find_completion_block(_FORWARD_LOOKING_SLIP_THROUGH)
+        assert verdict is not None
+        assert verdict.deliverable_count == 2
+        assert any("on-target evidence" in reason for reason in verdict.missing)
+
+    @pytest.mark.parametrize(
+        "phrase",
+        [
+            "will be merged once CI passes",
+            "is about to be merged",
+            "gets merged on green",
+            "remains to be merged",
+        ],
+    )
+    def test_forward_looking_variants_fire(self, phrase: str) -> None:
+        verdict = scanner.find_completion_block(_two_row_claim(f"PR #41 {phrase}.", f"PR #42 {phrase}."))
+        assert verdict is not None
+        assert verdict.deliverable_count == 2
+        assert any("on-target evidence" in reason for reason in verdict.missing)
+
+    def test_genuine_bare_merged_state_still_clears(self) -> None:
+        # Preservation: a real "PR #42 merged" / "MR !41 is merged" row (the bare
+        # MERGED state, no SHA) is still recognised as on-target, so a complete map
+        # built only on MERGED-state evidence does NOT fire. Guards over-tightening.
+        assert scanner.find_completion_block(_BARE_MERGED_STATE_MAP) is None
 
 
 class TestFormatBlockMessage:

--- a/tests/teatree_hooks/test_completion_claim_scanner.py
+++ b/tests/teatree_hooks/test_completion_claim_scanner.py
@@ -237,6 +237,62 @@ class TestMultiDeliverableFalseDoneWithoutDeliveryVocabStillFires:
         assert verdict.missing
 
 
+# The #2665 over-fire: a real ship report binds each deliverable to a 40-hex merge
+# commit SHA + a MERGED PR/MR state + origin/main HEAD + fast-forward — the
+# STRONGEST proof it landed on the merge target. The on-target recognizer enumerated
+# only English "landed on target" phrases, so every machine-grade row fell into
+# lines_without_evidence and the gate over-fired "N of N deliverables lack on-target
+# evidence". (Enumerated as list lines, not a `| … |` table — a pure markdown table
+# returns None for a different reason: its rows do not match _DELIVERABLE_LINE_RE.)
+# The spec-read and crucial-surface legs are confirmed too, so the ONLY leg the
+# recognizer extension clears is on-target — making this the RED-on-revert anchor.
+_MERGE_SHA_EVIDENCE_MAP = (
+    "I read the authoritative spec and its comments and enumerated every deliverable.\n"
+    "Both deliverables are merged and live on main — done.\n"
+    "- US-03 EURIBOR endpoint: MR !41 MERGED, merge commit "
+    "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0, origin/main HEAD = "
+    "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0, fast-forwarded.\n"
+    "- US-05 product-items endpoint: MR !42 MERGED, merge commit "
+    "0f1e2d3c4b5a69788796a5b4c3d2e1f0a9b8c7d6, origin/main HEAD = "
+    "0f1e2d3c4b5a69788796a5b4c3d2e1f0a9b8c7d6, fast-forwarded.\n"
+    "The crucial deliverable (US-03) is verified on its correct surface.\n"
+    "Both US-03 and US-05 are fixed and live on main.\n"
+)
+
+# The sibling over-exemption guard (#2842 must not re-open): a multi-deliverable
+# "done" whose ONLY evidence is "an MR/PR exists" — a PR url/number with NO merge
+# commit SHA and NO MERGED state. The spec-read and crucial-surface legs are
+# confirmed, so the on-target leg is the only thing that can keep it firing — and it
+# MUST, because neither row carries a merge SHA or a MERGED token.
+_MR_EXISTS_ONLY_FALSE_DONE = (
+    "I read the authoritative spec and its comments.\n"
+    "Both deliverables are done and ready to merge.\n"
+    "- US-03 EURIBOR endpoint: MR !41 opened, ready for review.\n"
+    "- US-05 product-items endpoint: PR #42 created, branch pushed.\n"
+    "The crucial deliverable (US-03) is verified on its correct surface.\n"
+)
+
+
+class TestMergeShaEvidenceClears:
+    """Anti-vacuous pair: the merge-SHA over-fire clears; the MR-exists-only claim fires."""
+
+    def test_merge_sha_evidence_map_does_not_fire(self) -> None:
+        # The over-fire: each row bound to a merge commit SHA + MERGED + origin/main
+        # HEAD + fast-forward is a COMPLETE on-target map. Reverting the recognizer
+        # alternations makes this fire — the RED-on-revert anchor.
+        assert scanner.find_completion_block(_MERGE_SHA_EVIDENCE_MAP) is None
+
+    def test_mr_exists_only_false_done_still_fires(self) -> None:
+        # The #2842 sibling over-exemption must NOT re-open: "MR opened" / "PR created"
+        # with no merge SHA and no MERGED state is not on-target evidence, so the
+        # multi-deliverable claim STILL blocks. Stays GREEN when the recognizer is
+        # reverted — proving the positive test isolates the recognizer, not the legs.
+        verdict = scanner.find_completion_block(_MR_EXISTS_ONLY_FALSE_DONE)
+        assert verdict is not None
+        assert verdict.deliverable_count == 2
+        assert any("on-target evidence" in reason for reason in verdict.missing)
+
+
 class TestFormatBlockMessage:
     def test_message_names_the_incomplete_legs(self) -> None:
         verdict = scanner.find_completion_block(_STRANDED_CLAIM)


### PR DESCRIPTION
## The over-fire (#2665)

The completion-claim gate's on-target-evidence recognizer (`_ON_TARGET_EVIDENCE_RE`) enumerated only English "landed on target" phrases — `merged to main/target`, `verified on … surface`, `passing e2e`. A real ship report binds each deliverable to a **merge-commit SHA + a `MERGED` PR/MR state + `origin/main HEAD = <sha>` + fast-forward** — the STRONGEST possible proof a deliverable landed (you only obtain a merge SHA after the merge lands). The recognizer could not see any of that, so every machine-grade row fell into `lines_without_evidence` and the gate over-fired `N of N deliverables lack on-target evidence` on a complete, genuinely-merged map.

## The fix (narrow)

Extend `_ON_TARGET_EVIDENCE_RE` with merge-commit-SHA / `merged as <sha>` / MERGED-state / origin-HEAD / fast-forwarded alternations. Each hex SHA is **anchored to a merge cue** (merge commit / merged as / origin-HEAD / fast-forwarded), never matched bare, so a SHA quoted on an unmerged feature branch is not mistaken for on-target evidence.

## Not re-opening #2842

Only the narrow on-target recognizer is touched. `_ARTIFACT_EXISTS_RE` is left as-is, so a multi-deliverable "done" whose ONLY evidence is "an MR/PR exists" (a PR url/number, no merge SHA, no `MERGED`) STILL blocks — the sibling over-exemption from #2842 stays closed.

## Tests (anti-vacuous)

- Positive: a 2-deliverable map, each row bound to a merge commit SHA + `MERGED` + `origin/main HEAD`, with spec-read and crucial-surface legs confirmed — no longer fires. Reverting only the recognizer alternations turns this RED.
- Over-exemption guard: a multi-deliverable "done" whose only evidence is "MR opened" / "PR created" STILL fires; stays GREEN when the recognizer is reverted.
- All existing scanner + Stop-hook tests stay green, including the #2842 over-exemption regression tests.

Tactical recognizer extension (single regex constant) — the nine-check architecture pre-check is not applicable.
