### PR TITLE
fix(dream): make the distiller's 0-cluster path diagnosable + harden JSON-array extraction (#2847)

### DIFF
--- a/src/teatree/loops/dream/distill.py
+++ b/src/teatree/loops/dream/distill.py
@@ -18,7 +18,7 @@ import logging
 import os
 from dataclasses import dataclass
 
-from teatree.loops.dream.engine import ConsolidationExtract, DistilledCluster, Distiller
+from teatree.loops.dream.engine import ConsolidationExtract, DistilledCluster, Distiller, DistillResult
 
 logger = logging.getLogger(__name__)
 
@@ -80,23 +80,34 @@ def distill_in_batches(extract: ConsolidationExtract, *, distiller: Distiller) -
     oversized call can never silently return nothing. Clusters are merged
     last-wins by ``cluster_key`` (the ledger's idempotency anchor), so a key
     surfaced in two batches collapses to one row instead of duplicating. A batch
-    that returns 0 clusters from a NON-empty member set is counted and logged —
-    the silent-empty case is surfaced, never swallowed.
+    that returns 0 clusters from a NON-empty member set is counted and logged with
+    the distiller's :class:`~teatree.loops.dream.engine.DistillEmptyReason` so the
+    operator can tell a healthy no-consolidation from a broken parse (#2847) — the
+    silent-empty case is surfaced with WHY, never swallowed.
     """
     merged: dict[str, DistilledCluster] = {}
     empty_batches = 0
     for batch in _batch_extracts(extract, _max_distill_members()):
-        clusters = distiller(batch)
-        if not clusters:
+        result = _as_result(distiller(batch))
+        if not result.clusters:
             empty_batches += 1
+            reason = f" — reason: {result.empty_reason.value}" if result.empty_reason else ""
             logger.warning(
-                "dream distiller returned 0 clusters from a non-empty batch of %d member(s)",
+                "dream distiller returned 0 clusters from a non-empty batch of %d member(s)%s",
                 len(batch.snippets),
+                reason,
             )
             continue
-        for cluster in clusters:
+        for cluster in result.clusters:
             merged[cluster.cluster_key] = cluster
     return BatchDistillOutcome(clusters=list(merged.values()), empty_batches=empty_batches)
+
+
+def _as_result(returned: list[DistilledCluster] | DistillResult) -> DistillResult:
+    """Normalize a distiller return: the real distiller carries a reason, a fake may not."""
+    if isinstance(returned, DistillResult):
+        return returned
+    return DistillResult(clusters=returned, empty_reason=None)
 
 
 __all__ = ["BatchDistillOutcome", "distill_in_batches"]

--- a/src/teatree/loops/dream/engine.py
+++ b/src/teatree/loops/dream/engine.py
@@ -75,6 +75,7 @@ import stat
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Protocol
 
@@ -142,10 +143,45 @@ class DistilledCluster:
     durable_destination: str
 
 
-class Distiller(Protocol):
-    """The injected LLM seam: extract → root-cause clusters."""
+class DistillEmptyReason(StrEnum):
+    """WHY a distiller produced 0 clusters — so a healthy-0 is told from a broken-0.
 
-    def __call__(self, extract: ConsolidationExtract) -> list[DistilledCluster]: ...
+    ``NOTHING_TO_CONSOLIDATE`` is the only HEALTHY value (the model returned a real
+    empty array — nothing met the consolidation bar). The other three are broken
+    output the operator must act on: ``EMPTY_RAW`` (the model returned empty /
+    whitespace), ``UNPARSABLE`` (no decodable JSON array in the reply), and
+    ``ALL_ENTRIES_DROPPED`` (an array decoded but every element was malformed).
+    """
+
+    NOTHING_TO_CONSOLIDATE = "nothing_to_consolidate"
+    EMPTY_RAW = "empty_raw"
+    UNPARSABLE = "unparsable"
+    ALL_ENTRIES_DROPPED = "all_entries_dropped"
+
+
+@dataclass(frozen=True, slots=True)
+class DistillResult:
+    """A distiller call's clusters plus, when empty, WHY (#2847).
+
+    ``empty_reason`` is set exactly when ``clusters`` is empty and ``None`` otherwise,
+    so :func:`distill_in_batches` can surface a broken parse distinctly from a genuine
+    no-consolidation in its 0-cluster WARNING.
+    """
+
+    clusters: list[DistilledCluster]
+    empty_reason: DistillEmptyReason | None
+
+
+class Distiller(Protocol):
+    """The injected LLM seam: extract → root-cause clusters.
+
+    The production distiller returns a :class:`DistillResult` carrying the clusters and,
+    when empty, the :class:`DistillEmptyReason` so the 0-cluster path is diagnosable. A
+    test fake may return a bare ``list[DistilledCluster]``; :func:`distill_in_batches`
+    normalizes both, so a minimal fake never constructs a diagnostic it has no basis for.
+    """
+
+    def __call__(self, extract: ConsolidationExtract) -> list[DistilledCluster] | DistillResult: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -431,11 +467,11 @@ def run_consolidation(
     descriptors, never a scenario file or fixture.
     """
     from teatree.loops.dream.distill import distill_in_batches  # noqa: PLC0415
-    from teatree.loops.dream.sdk_distiller import sdk_distiller  # noqa: PLC0415
+    from teatree.loops.dream.sdk_distiller import sdk_distill  # noqa: PLC0415
 
     members = enumerate_members(since=since)
     extract = build_extract(members)
-    distill = distiller or sdk_distiller
+    distill = distiller or sdk_distill
     outcome = distill_in_batches(extract, distiller=distill)
     clusters = outcome.clusters
     written = write_clusters(clusters, extract, dry_run=dry_run, overlay=overlay)
@@ -456,6 +492,8 @@ def run_consolidation(
 
 __all__ = [
     "ConsolidationExtract",
+    "DistillEmptyReason",
+    "DistillResult",
     "DistilledCluster",
     "Distiller",
     "DreamRunResult",

--- a/src/teatree/loops/dream/sdk_distiller.py
+++ b/src/teatree/loops/dream/sdk_distiller.py
@@ -1,9 +1,9 @@
 """The real LLM distiller: extract → root-cause clusters via one headless SDK call.
 
-This is the only place the dream pass touches an LLM. :func:`sdk_distiller` is the
-default :class:`~teatree.loops.dream.engine.Distiller` the engine injects; tests pass a
-fake so the engine — and every phase around it — runs with no LLM. The concern split out
-of :mod:`teatree.loops.dream.engine` (#2723) is the LLM call + defensive JSON parse.
+This is the only place the dream pass touches an LLM. :func:`sdk_distill` is the default
+:class:`~teatree.loops.dream.engine.Distiller` the engine injects; tests pass a fake so the
+engine — and every phase around it — runs with no LLM. The concern split out of
+:mod:`teatree.loops.dream.engine` (#2723) is the LLM call + defensive JSON parse.
 
 :func:`_run_distiller_turn` makes ONE bounded headless ``claude-agent-sdk`` turn (the
 headless-runner invocation shape: ``claude_code`` preset, ``bypassPermissions``, a
@@ -14,8 +14,12 @@ query, AND the response drain — so a stuck subprocess connect can never hang t
 forever (the prior watchdog wrapped only the response drain, leaving connect/query
 unbounded: a stalled ``claude`` spawn hung the pass with no rows, no marker, no output).
 
-:func:`_parse_clusters` tolerates surrounding prose and drops malformed entries so one bad
-element never discards a valid batch.
+:func:`_extract_json_array` finds the model's top-level JSON array tolerating bracket-heavy
+prose around it (a balanced-bracket scan, not the prior greedy first-``[`` … last-``]``
+span that swallowed prose brackets and silently yielded 0 — #2847). :func:`sdk_distill`
+classifies an empty return into a :class:`~teatree.loops.dream.engine.DistillEmptyReason`
+so a genuine no-consolidation is told from a broken parse; :func:`sdk_distiller` is the
+clusters-only convenience for callers that do not need that diagnostic.
 
 :func:`deterministic_cluster_key` is the idempotency anchor — sha256 over the normalized
 member set, NOT the LLM's prose slug (#2723), matching the ``ConsolidatedMemory`` docstring.
@@ -24,10 +28,11 @@ Two runs that group the same members under different wording upsert to one ledge
 
 import hashlib
 import json
+import re
 from collections.abc import Mapping, Sequence
 from typing import cast
 
-from teatree.loops.dream.engine import ConsolidationExtract, DistilledCluster
+from teatree.loops.dream.engine import ConsolidationExtract, DistilledCluster, DistillEmptyReason, DistillResult
 
 _DISTILL_SYSTEM_PROMPT = (
     "You consolidate an agent's recent feedback and lessons into durable rules. "
@@ -60,6 +65,15 @@ _DISTILL_MODEL = "claude-haiku-4-5"
 #: to fork a duplicate row; the deterministic key upserts instead.
 _REQUIRED_CLUSTER_KEYS = ("rule", "source_files", "is_binding", "verified_citation")
 
+#: A fenced ```json … ``` block the model may wrap its array in. Tried after a direct
+#: decode and before the balanced-bracket scan in :func:`_extract_json_array`.
+_JSON_FENCE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL)
+
+#: Anchored decoder for the balanced-bracket scan: ``raw_decode`` parses exactly one
+#: JSON value starting at a given ``[`` and returns where it ended, so a prose span
+#: that is not valid JSON raises and is skipped rather than swallowing the real array.
+_DECODER = json.JSONDecoder()
+
 
 def deterministic_cluster_key(source_files: Sequence[str]) -> str:
     """The idempotency anchor: sha256 over the normalized, sorted member identities.
@@ -74,19 +88,27 @@ def deterministic_cluster_key(source_files: Sequence[str]) -> str:
     return hashlib.sha256("\n".join(members).encode("utf-8")).hexdigest()
 
 
-def sdk_distiller(extract: ConsolidationExtract) -> list[DistilledCluster]:
-    """The real distiller: one bounded headless SDK call, parsed defensively.
+def sdk_distill(extract: ConsolidationExtract) -> DistillResult:
+    """The real distiller: one bounded headless SDK call, parsed defensively (#2847).
 
     An empty extract short-circuits without an LLM call. Otherwise one bounded
     turn through :func:`_run_distiller_turn` produces JSON, which is parsed into
     clusters; malformed or partial JSON yields no clusters rather than a crash.
+    When 0 clusters result, the :class:`~teatree.loops.dream.engine.DistillResult`
+    carries WHY (empty raw / unparsable / all-entries-dropped / genuine empty
+    array) so the operator can tell a healthy no-consolidation from a broken parse.
     An SDK failure propagates so the command marks the pass attempted-not-
     succeeded (staleness keeps firing) — never laundered into a fake success.
     """
     if not extract.snippets:
-        return []
+        return DistillResult(clusters=[], empty_reason=DistillEmptyReason.NOTHING_TO_CONSOLIDATE)
     raw = _run_distiller_turn(extract)
-    return _parse_clusters(raw)
+    return _parse_distill_result(raw)
+
+
+def sdk_distiller(extract: ConsolidationExtract) -> list[DistilledCluster]:
+    """Clusters-only distiller for callers that do not need the empty-reason diagnostic."""
+    return sdk_distill(extract).clusters
 
 
 def _render_snippets(extract: ConsolidationExtract) -> str:
@@ -143,34 +165,76 @@ async def _collect_turn(prompt: str) -> str:
     return "\n".join(parts)
 
 
-def _parse_clusters(raw: str) -> list[DistilledCluster]:
-    """Parse the distiller's JSON array into clusters, dropping malformed entries.
+def _parse_distill_result(raw: str) -> DistillResult:
+    """Parse the distiller's reply into clusters AND classify an empty result (#2847).
 
-    Tolerates surrounding prose by scanning for the first ``[`` … matching
-    ``]``. An entry missing a required key is skipped (not fatal), so one bad
-    element never discards a whole valid batch.
+    Drops malformed entries so one bad element never discards a valid batch. When the
+    result is empty the reason distinguishes a broken parse (empty/whitespace raw,
+    unparsable raw, or an array whose every entry was malformed) from a genuine empty
+    array (the model found nothing to consolidate — healthy).
     """
+    if not raw.strip():
+        return DistillResult(clusters=[], empty_reason=DistillEmptyReason.EMPTY_RAW)
     payload = _extract_json_array(raw)
     if payload is None:
-        return []
+        return DistillResult(clusters=[], empty_reason=DistillEmptyReason.UNPARSABLE)
     clusters: list[DistilledCluster] = []
     for entry in payload:
         cluster = _coerce_cluster(entry)
         if cluster is not None:
             clusters.append(cluster)
-    return clusters
+    if clusters:
+        return DistillResult(clusters=clusters, empty_reason=None)
+    reason = DistillEmptyReason.NOTHING_TO_CONSOLIDATE if not payload else DistillEmptyReason.ALL_ENTRIES_DROPPED
+    return DistillResult(clusters=[], empty_reason=reason)
 
 
 def _extract_json_array(raw: str) -> list[object] | None:
-    start = raw.find("[")
-    end = raw.rfind("]")
-    if start == -1 or end == -1 or end < start:
-        return None
+    """Find the model's top-level JSON array, tolerating bracketed prose around it.
+
+    Three tiers, first hit wins: (1) the stripped reply IS a JSON array; (2) a fenced
+    ```json code block holds one; (3) a balanced-bracket scan returns the FIRST ``[`` …
+    ``]`` span that decodes to a list. The scan — not the prior greedy first-``[`` …
+    last-``]`` span — is what makes bracket-heavy prose (markdown links, ``#N`` refs,
+    regex classes) around the array safe: a prose ``[…]`` that is not valid JSON is
+    skipped instead of swallowing the real array (#2847).
+    """
+    direct = _loads_array(raw.strip())
+    if direct is not None:
+        return direct
+    for match in _JSON_FENCE.finditer(raw):
+        fenced = _loads_array(match.group(1).strip())
+        if fenced is not None:
+            return fenced
+    return _first_balanced_array(raw)
+
+
+def _loads_array(text: str) -> list[object] | None:
     try:
-        parsed = json.loads(raw[start : end + 1])
+        parsed = json.loads(text)
     except json.JSONDecodeError:
         return None
     return parsed if isinstance(parsed, list) else None
+
+
+def _first_balanced_array(raw: str) -> list[object] | None:
+    """Return the first ``[``-anchored span that ``json`` decodes to a list.
+
+    Attempts a strict decode at each ``[`` (``raw_decode`` stops at the value's own
+    matching ``]`` and handles nested arrays and brackets-inside-strings natively), so
+    a bracketed prose span that is not valid JSON — a markdown ref, a regex class — is
+    skipped instead of being swallowed by the prior greedy first-``[`` … last-``]`` span.
+    A successful decode anchored at ``[`` is always a JSON array by grammar.
+    """
+    for i, ch in enumerate(raw):
+        if ch != "[":
+            continue
+        try:
+            parsed, _ = _DECODER.raw_decode(raw, i)
+        except json.JSONDecodeError:
+            continue
+        return cast("list[object]", parsed)
+    return None
 
 
 def _coerce_cluster(entry: object) -> DistilledCluster | None:
@@ -193,4 +257,4 @@ def _coerce_cluster(entry: object) -> DistilledCluster | None:
     )
 
 
-__all__ = ["deterministic_cluster_key", "sdk_distiller"]
+__all__ = ["deterministic_cluster_key", "sdk_distill", "sdk_distiller"]

--- a/tests/teatree_loops/dream/test_engine.py
+++ b/tests/teatree_loops/dream/test_engine.py
@@ -15,6 +15,8 @@ from teatree.loops.dream import distill, engine, sdk_distiller
 from teatree.loops.dream.engine import (
     ConsolidationExtract,
     DistilledCluster,
+    DistillEmptyReason,
+    DistillResult,
     DreamRunResult,
     TranscriptMember,
     WeightedSnippet,
@@ -764,6 +766,30 @@ class SilentEmptyBatchTestCase(TestCase):
         with patch.object(engine, "enumerate_members", return_value=[]):
             result = run_consolidation(overlay="", since=None, dry_run=True, distiller=_no_clusters)
         assert result.empty_batches == 0
+
+    def test_empty_batch_warning_surfaces_a_broken_reason(self) -> None:
+        # #2847: a distiller signalling an unparsable reply makes the 0-cluster WARNING
+        # name WHY, so an operator can tell a broken parse from a healthy no-consolidation.
+        members = _many_members(self.tmp, 2)
+        extract = build_extract(members)
+
+        def _broken(_batch: ConsolidationExtract) -> DistillResult:
+            return DistillResult(clusters=[], empty_reason=DistillEmptyReason.UNPARSABLE)
+
+        with self.assertLogs("teatree.loops.dream.distill", level="WARNING") as captured:
+            distill.distill_in_batches(extract, distiller=_broken)
+        assert any("unparsable" in line for line in captured.output)
+
+    def test_empty_batch_warning_surfaces_a_healthy_reason(self) -> None:
+        members = _many_members(self.tmp, 2)
+        extract = build_extract(members)
+
+        def _healthy(_batch: ConsolidationExtract) -> DistillResult:
+            return DistillResult(clusters=[], empty_reason=DistillEmptyReason.NOTHING_TO_CONSOLIDATE)
+
+        with self.assertLogs("teatree.loops.dream.distill", level="WARNING") as captured:
+            distill.distill_in_batches(extract, distiller=_healthy)
+        assert any("nothing_to_consolidate" in line for line in captured.output)
 
 
 class RunConsolidationEvalProposalTestCase(TestCase):

--- a/tests/teatree_loops/dream/test_sdk_distiller.py
+++ b/tests/teatree_loops/dream/test_sdk_distiller.py
@@ -11,7 +11,7 @@ import pytest
 from django.test import SimpleTestCase
 
 from teatree.loops.dream import sdk_distiller
-from teatree.loops.dream.engine import ConsolidationExtract, WeightedSnippet
+from teatree.loops.dream.engine import ConsolidationExtract, DistillEmptyReason, WeightedSnippet
 from teatree.loops.dream.sdk_distiller import deterministic_cluster_key
 from tests.teatree_agents._sdk_fake import FakeSdkClient, assistant_text
 
@@ -49,6 +49,68 @@ class SdkDistillerParseTestCase(SimpleTestCase):
         with patch.object(sdk_distiller, "_run_distiller_turn", return_value=payload):
             clusters = sdk_distiller.sdk_distiller(_extract_with_one_snippet())
         assert len(clusters) == 1
+
+    def test_parses_json_with_bracketed_prose_around_the_array(self) -> None:
+        # #2847 RED: the model wraps its array in bracket-heavy prose (a markdown-ish
+        # ref and a trailing marker). The greedy first-"[" .. last-"]" span captured the
+        # prose brackets, json.loads raised, and the batch silently yielded 0. The
+        # balanced-bracket scan must skip the prose "[...]" spans and return the real array.
+        payload = (
+            "Here are the clusters [per your guidance #2663]: "
+            '[{"cluster_key":"k1","rule":"do x","source_files":["/feedback_x.md"],'
+            '"is_binding":true,"verified_citation":"x","durable_destination":"d.md"}]'
+            " — done [end]"
+        )
+        with patch.object(sdk_distiller, "_run_distiller_turn", return_value=payload):
+            clusters = sdk_distiller.sdk_distiller(_extract_with_one_snippet())
+        assert len(clusters) == 1
+        assert clusters[0].source_files == ["/feedback_x.md"]
+
+    def test_parses_json_from_a_fenced_code_block(self) -> None:
+        # The model wraps its array in a ```json fence; the direct decode fails on the
+        # backticks, so the fenced-block tier must extract and decode the inner array.
+        payload = (
+            "```json\n"
+            '[{"cluster_key":"k1","rule":"do x","source_files":["/feedback_x.md"],'
+            '"is_binding":false,"verified_citation":"x","durable_destination":""}]\n'
+            "```"
+        )
+        with patch.object(sdk_distiller, "_run_distiller_turn", return_value=payload):
+            clusters = sdk_distiller.sdk_distiller(_extract_with_one_snippet())
+        assert len(clusters) == 1
+
+    def test_balanced_scan_skips_string_brackets_and_a_bad_prose_span(self) -> None:
+        # A leading prose "[noise]" span must be skipped, and a JSON string value carrying
+        # an escaped quote and bracket characters must NOT skew the bracket depth.
+        payload = (
+            "prose [noise] "
+            '[{"cluster_key":"k1","rule":"match \\"x\\" in [a-z]+",'
+            '"source_files":["/feedback_x.md"],"is_binding":false,'
+            '"verified_citation":"q","durable_destination":""}]'
+        )
+        with patch.object(sdk_distiller, "_run_distiller_turn", return_value=payload):
+            clusters = sdk_distiller.sdk_distiller(_extract_with_one_snippet())
+        assert len(clusters) == 1
+        assert clusters[0].source_files == ["/feedback_x.md"]
+
+    def test_fenced_non_array_falls_through_to_the_balanced_scan(self) -> None:
+        # A ```json fence wrapping a JSON object (not an array) is not the result; the
+        # scan must fall through to the real array that follows in prose.
+        payload = (
+            '```json\n{"not": "an array"}\n```\n'
+            '[{"rule":"r","source_files":["/feedback_x.md"],'
+            '"is_binding":false,"verified_citation":"m","durable_destination":""}]'
+        )
+        with patch.object(sdk_distiller, "_run_distiller_turn", return_value=payload):
+            clusters = sdk_distiller.sdk_distiller(_extract_with_one_snippet())
+        assert len(clusters) == 1
+        assert clusters[0].source_files == ["/feedback_x.md"]
+
+    def test_json_object_not_array_yields_no_clusters(self) -> None:
+        # A decodable JSON object (not a list) is not an array — it yields no clusters.
+        with patch.object(sdk_distiller, "_run_distiller_turn", return_value='{"not": "an array"}'):
+            clusters = sdk_distiller.sdk_distiller(_extract_with_one_snippet())
+        assert clusters == []
 
     def test_malformed_json_yields_no_clusters(self) -> None:
         with patch.object(sdk_distiller, "_run_distiller_turn", return_value="not json at all"):
@@ -166,6 +228,52 @@ class SdkDistillerParseTestCase(SimpleTestCase):
             clusters = sdk_distiller.sdk_distiller(empty)
         turn.assert_not_called()
         assert clusters == []
+
+
+class SdkDistillReasonTestCase(SimpleTestCase):
+    """The 0-cluster path is diagnosable: sdk_distill signals WHY it produced 0 (#2847)."""
+
+    def test_empty_raw_is_classified(self) -> None:
+        with patch.object(sdk_distiller, "_run_distiller_turn", return_value="   "):
+            result = sdk_distiller.sdk_distill(_extract_with_one_snippet())
+        assert result.clusters == []
+        assert result.empty_reason is DistillEmptyReason.EMPTY_RAW
+
+    def test_unparsable_raw_is_classified(self) -> None:
+        with patch.object(sdk_distiller, "_run_distiller_turn", return_value="not json at all"):
+            result = sdk_distiller.sdk_distill(_extract_with_one_snippet())
+        assert result.clusters == []
+        assert result.empty_reason is DistillEmptyReason.UNPARSABLE
+
+    def test_genuine_empty_array_is_healthy(self) -> None:
+        with patch.object(sdk_distiller, "_run_distiller_turn", return_value="[]"):
+            result = sdk_distiller.sdk_distill(_extract_with_one_snippet())
+        assert result.clusters == []
+        assert result.empty_reason is DistillEmptyReason.NOTHING_TO_CONSOLIDATE
+
+    def test_array_with_all_entries_dropped_is_classified(self) -> None:
+        with patch.object(sdk_distiller, "_run_distiller_turn", return_value='[{"is_binding":false}]'):
+            result = sdk_distiller.sdk_distill(_extract_with_one_snippet())
+        assert result.clusters == []
+        assert result.empty_reason is DistillEmptyReason.ALL_ENTRIES_DROPPED
+
+    def test_productive_result_carries_no_reason(self) -> None:
+        payload = (
+            '[{"rule":"r","source_files":["/feedback_x.md"],'
+            '"is_binding":false,"verified_citation":"m","durable_destination":""}]'
+        )
+        with patch.object(sdk_distiller, "_run_distiller_turn", return_value=payload):
+            result = sdk_distiller.sdk_distill(_extract_with_one_snippet())
+        assert len(result.clusters) == 1
+        assert result.empty_reason is None
+
+    def test_empty_extract_is_nothing_to_consolidate_without_sdk_call(self) -> None:
+        empty = ConsolidationExtract(snippets=(), truncated=False)
+        with patch.object(sdk_distiller, "_run_distiller_turn") as turn:
+            result = sdk_distiller.sdk_distill(empty)
+        turn.assert_not_called()
+        assert result.clusters == []
+        assert result.empty_reason is DistillEmptyReason.NOTHING_TO_CONSOLIDATE
 
 
 class _HangOnConnectClient:


### PR DESCRIPTION
## What

Two compounding output-side defects made the dream distiller silently return 0 clusters from a non-empty batch.

1. **Brittle JSON-array extraction.** `_extract_json_array` spanned the greedy first-`[` … last-`]` pair, so any bracketed prose the model emitted around its JSON array (markdown refs, regex classes, `#N` refs) made the span non-JSON, the decode raised, and the batch yielded a silent 0. It now tries three tiers, first hit wins: a direct decode of the stripped reply, a fenced ```json code block, then an anchored `json.JSONDecoder.raw_decode` scan that returns the first `[` span that decodes to a valid array — a prose `[…]` that is not valid JSON is skipped, not swallowed.
2. **Non-diagnosable 0-cluster WARNING.** `distill_in_batches` logged the same WARNING for every empty return. `sdk_distill` now returns a `DistillResult` carrying a `DistillEmptyReason` (`empty_raw` / `unparsable` / `all_entries_dropped` / `nothing_to_consolidate`), and `distill_in_batches` surfaces that reason in the WARNING — so an operator can tell a healthy no-consolidation from a broken parse.

`sdk_distiller` (clusters-only) is kept as a thin wrapper for callers that don't need the diagnostic; the existing parse tests stay green unchanged.

## RED-first

`tests/teatree_loops/dream/test_sdk_distiller.py::SdkDistillerParseTestCase::test_parses_json_with_bracketed_prose_around_the_array` reproduces the bug (a valid array wrapped in bracketed prose). Observed RED against the greedy pre-fix extractor (`assert 0 == 1`), GREEN after the hardening. The existing bracket-free prose test stays green.

## Architecture pre-check — #2847

### 1. BLUEPRINT alignment
Idle-time dream pass (engine, phase 2 cluster/distill). Output-side hardening of an existing seam; no BLUEPRINT contract change.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition.

### 3. Extension-point contracts
The `Distiller` Protocol return widens to `list[DistilledCluster] | DistillResult`. Sole production consumer is `distill_in_batches`, which normalizes both via `_as_result`; the production default `run_consolidation` injects (`sdk_distill`) returns the rich type. Test fakes returning a bare list keep working.

### 4. Component boundaries
`engine.py` owns the data contracts (`DistillEmptyReason`, `DistillResult` next to `DistilledCluster`/`Distiller`); `sdk_distiller.py` owns the LLM call + parse/classify; `distill.py` owns batching + the WARNING. No straddle.

### 5. Dependency direction
`sdk_distiller.py` and `distill.py` import the new types from `engine.py` (existing direction); no new cross-module edge. `uv run tach check` → all modules validated.

### 6. Test surface
- bracketed-prose extraction (RED→GREEN), fenced-block, fenced-non-array fallthrough, string-with-brackets, object-not-array.
- reason classification: `empty_raw` / `unparsable` / `nothing_to_consolidate` / `all_entries_dropped` / productive-has-no-reason / empty-extract-no-SDK-call.
- `distill.py` WARNING surfaces both a broken (`unparsable`) and a healthy (`nothing_to_consolidate`) reason.

### 7. Resilience invariants
No external write. An SDK failure still propagates (pass marked attempted-not-succeeded); idempotency of the ledger upsert is unchanged.

### 8. Identity and key normalization
n/a — no bare/qualified identity. `cluster_key` derivation is untouched.

### 9. Behavior preservation / capability deletion
Replaces the greedy extractor. Preserved: clean-array decode, bracket-free-prose decode, malformed-array yields empty, non-object/bad-`source_files` drop. The empty-raw guard and an `isinstance(parsed, list)` check after a `[`-anchored `raw_decode` were removed only because they were unreachable/always-true (no must-block test inverted). No privacy/security matcher touched.

Closes #2847
