### PR TITLE
fix(update): bootstrap Django before the stale-clone notice so `t3 update` never crashes on a stale repo

### DIFF
--- a/src/teatree/cli/update.py
+++ b/src/teatree/cli/update.py
@@ -54,6 +54,7 @@ codes").  Precedent: ``cli/setup/clone.py`` ``validate_repo`` → ``raise typer.
 """
 
 import enum
+import logging
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
@@ -62,7 +63,10 @@ import typer
 
 from teatree.self_update import ReinstallResult, SubprocessRunner, ensure_self_db_migrated, reinstall_running_editable
 from teatree.utils.dep_drift import editable_source_path, find_missing_dependencies
+from teatree.utils.django_bootstrap import ensure_django
 from teatree.utils.run import CompletedProcess, run_allowed_to_fail
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "ReinstallResult",
@@ -506,25 +510,44 @@ def _notify_if_stale(result: RepoUpdate, *, repo: Path) -> None:
     scroll away; this records a durable, idempotent ``BotPing`` notice naming the
     repo path + manual remediation so a stale editable clone is never invisible.
     The safe update never auto-stashes/auto-checkouts to recover — the user does.
+
+    ``t3 update`` is a top-level typer command that never bootstraps Django, yet
+    the notice writes its ``BotPing`` through :mod:`teatree.core.notify` — whose
+    module-scope :mod:`teatree.core.models` import needs a configured Django
+    (#2844 hoisted it to satisfy the intra-core deferred-import ratchet). So
+    :func:`ensure_django` runs first, before the notify import touches the ORM.
+    The whole block is FAIL-SAFE: the durable audit row is best-effort (the loud
+    terminal warning already printed), so a bootstrap/notify failure degrades to
+    a plain warning — ``t3 update`` must never crash just because it could not
+    record the stale-clone notice (mirrors :func:`notify_stale_clone_skip`'s own
+    "never raises" contract, which the import-time failure here sits outside of).
     """
     if not result.stale_kind:
         return
-    from teatree.core.stale_clone_notice import (  # noqa: PLC0415
-        StaleCloneReason,
-        StaleCloneSkip,
-        notify_stale_clone_skip,
-    )
-
-    notify_stale_clone_skip(
-        StaleCloneSkip(
-            label=result.name,
-            repo_path=str(repo),
-            reason=StaleCloneReason(result.stale_kind),
-            head_sha=result.old_sha or _short_sha(repo),
-            default_branch=_default_branch(repo) or "",
-            detail=result.reason,
+    try:
+        ensure_django()
+        from teatree.core.stale_clone_notice import (  # noqa: PLC0415
+            StaleCloneReason,
+            StaleCloneSkip,
+            notify_stale_clone_skip,
         )
-    )
+
+        notify_stale_clone_skip(
+            StaleCloneSkip(
+                label=result.name,
+                repo_path=str(repo),
+                reason=StaleCloneReason(result.stale_kind),
+                head_sha=result.old_sha or _short_sha(repo),
+                default_branch=_default_branch(repo) or "",
+                detail=result.reason,
+            )
+        )
+    except Exception:
+        logger.exception("Could not record the durable stale-clone notice for %s (%s)", result.name, repo)
+        typer.echo(
+            f"WARN  Could not record the durable stale-clone notice for {result.name} ({repo}); "
+            "resolve the stale clone, then re-run `t3 update`."
+        )
 
 
 def _run_update() -> None:

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -9,7 +9,9 @@ host machine and are out of scope for the git-sync behaviour under test.
 The stubs are recording callables, not ``Mock()`` assertions on call_args.
 """
 
+import os
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -1081,6 +1083,90 @@ class TestStaleCloneNotice:
             update_mod._run_update()
 
         spy.assert_not_called()
+
+
+# Regression for #2844: the stale-clone notice writes a ``BotPing`` through
+# ``teatree.core.notify``, whose module-scope ``teatree.core.models`` import
+# needs a configured Django. ``t3 update`` is a top-level typer command that
+# never bootstraps Django, so the notify import raised ``ImproperlyConfigured``
+# at IMPORT time — before ``notify_stale_clone_skip``'s own try/except could
+# catch it — aborting the whole run whenever any tracked repo was stale.
+_STALE_NOTICE_SUBPROCESS = """
+import sys
+from pathlib import Path
+
+from django.conf import settings
+
+# Mirror the real `t3 update` process: Django is NOT bootstrapped here.
+assert not settings.configured, "precondition: Django must be unconfigured"
+
+from teatree.cli.update import RepoUpdate, UpdateStatus, _notify_if_stale
+
+result = RepoUpdate(
+    "clone", UpdateStatus.SKIPPED, old_sha="abc1234", reason="tracked dirty", stale_kind="dirty"
+)
+_notify_if_stale(result, repo=Path(sys.argv[1]))
+
+# The fix bootstraps Django before touching the ORM-backed notify path.
+assert settings.configured, "ensure_django() must run before the notify import"
+print("STALE-NOTICE-OK")
+"""
+
+
+class TestStaleNoticeNeverCrashesUpdate:
+    """``_notify_if_stale`` must survive a process where Django was never set up (#2844)."""
+
+    def test_stale_notice_does_not_crash_unconfigured_django_process(self, tmp_path: Path) -> None:
+        """Faithful reproduction: run the stale path in a fresh, Django-unconfigured process.
+
+        In-process, pytest has already configured Django, so the crash can only
+        be reproduced in a subprocess that mirrors the real ``t3 update`` runtime
+        (no ``django.setup()``). RED before the fix: the subprocess dies with
+        ``ImproperlyConfigured`` (non-zero exit). GREEN after: it bootstraps
+        Django and exits 0.
+        """
+        repo = tmp_path / "stale-clone"  # an existing dir → `_default_branch` degrades to None, not a crash
+        repo.mkdir()
+        env = {k: v for k, v in os.environ.items() if k != "DJANGO_SETTINGS_MODULE"}
+        env["XDG_DATA_HOME"] = str(tmp_path / "xdg")  # isolate the self-DB from the real one
+
+        proc = subprocess.run(
+            [sys.executable, "-c", _STALE_NOTICE_SUBPROCESS, str(repo)],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert proc.returncode == 0, f"`t3 update` stale path crashed:\n{proc.stderr}"
+        assert "STALE-NOTICE-OK" in proc.stdout
+        assert "ImproperlyConfigured" not in proc.stderr
+
+    def test_notify_failure_degrades_to_a_warning_never_propagates(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A failing notify path must degrade to a plain warning, not abort the update.
+
+        RED before the fix: ``notify_stale_clone_skip`` raising propagates out of
+        ``_notify_if_stale`` (no surrounding try/except). GREEN after: it is
+        caught and surfaced as a ``WARN`` line naming the stale repo path.
+        """
+        from unittest.mock import patch  # noqa: PLC0415
+
+        result = update_mod.RepoUpdate(
+            "clone", update_mod.UpdateStatus.SKIPPED, old_sha="abc1234", reason="tracked dirty", stale_kind="dirty"
+        )
+
+        with patch(
+            "teatree.core.stale_clone_notice.notify_stale_clone_skip",
+            side_effect=RuntimeError("notify backend down"),
+        ):
+            update_mod._notify_if_stale(result, repo=tmp_path)  # must NOT raise
+
+        out = capsys.readouterr().out
+        assert "WARN" in out
+        assert str(tmp_path) in out
+        assert "re-run `t3 update`" in out
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`t3 update` crashes with `django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured` whenever **any** tracked repo is stale (e.g. it has uncommitted tracked changes, so the fast-forward pull is refused).

### Root cause — a regression from #2844

`t3 update` is a top-level Typer command that never bootstraps Django (no `ensure_django()` / `django.setup()` in its flow). When a repo is stale, `_run_update()` calls `_notify_if_stale(...)`, which records a durable `BotPing` notice through `teatree.core.notify`.

`teatree.core.stale_clone_notice` has a **module-scope** `from teatree.core.notify import ...` (hoisted to module scope in #2844 to satisfy the intra-core deferred-import ratchet). Importing `teatree.core.notify` eagerly imports `teatree.core.models`, which touches Django settings at class-definition time. Because Django was never bootstrapped in the `t3 update` process, the import raises `ImproperlyConfigured`.

Crucially the failure happens at **import** (the `from teatree.core.stale_clone_notice import ...` line inside `_notify_if_stale`), which is **before** `notify_stale_clone_skip`'s own `try/except` (at call time) can catch it — so the whole `t3 update` run aborts.

## Fix (localized to `cli/update.py`)

`_notify_if_stale` now:

1. Calls `ensure_django()` (the canonical `teatree.utils.django_bootstrap` seam used by `cost`/`admin`/`ci`/`loop_claude_spec`) **before** the notify import, so the in-process notify path has a configured Django.
2. Wraps the whole stale-notice block in a **fail-safe** `try/except`: if `ensure_django()` or the notify path raises for any reason, it logs and degrades to a plain `typer.echo(...)` warning naming the stale repo path + remediation. `t3 update` must never crash just because it could not record the best-effort durable notice — the loud terminal warning from `update_repo` / `_check_clean` has already printed.

This honours `stale_clone_notice`'s own stated *"never raises — surfacing a stale clone must not break the update flow it rides on"* contract; the previous code violated it only because the failure was at import, outside the existing `try/except`.

The core module's module-scope `from teatree.core.notify import ...` is intentionally **left in place** — moving it back to function scope would re-break the intra-core deferred-import ratchet (frozen ceiling 183). The fix belongs in `cli/update.py`.

## Architecture pre-check

- **BLUEPRINT alignment.** No contract change. `t3 update` stays a top-level Typer group that raises `typer.Exit`; the only new behaviour is that the ORM-touching notice now bootstraps Django through the single sanctioned `ensure_django` seam, exactly like the other top-level ORM-touching commands.
- **The `cli -> utils` edge.** The added `from teatree.utils.django_bootstrap import ensure_django` is a legal `cli -> utils` import (already present in many commands); `tach check` passes. It is **not** an intra-core deferred import, so the ratchet ceiling stays **183**.
- **Resilience invariant — fail-safe degradation.** The durable `BotPing` is best-effort; a bootstrap/notify failure degrades to a warning and never aborts the update. The blind `except` logs via `logger.exception` (consistent with `notify_stale_clone_skip`) so failures stay debuggable.
- **Test surface.** Two regression tests in `tests/test_cli_update.py`, both observed RED before the fix:
  - a subprocess test that faithfully reproduces the real `t3 update` runtime (no `django.setup()`) and asserts the stale path no longer crashes and that Django gets bootstrapped (RED: `ImproperlyConfigured`, non-zero exit);
  - an in-process test that forces the notify path to raise and asserts `_notify_if_stale` degrades to a `WARN` line instead of propagating (covers the fail-safe branch in-process for the coverage gate).

## Verification

- `tests/test_cli_update.py` — all pass (incl. the 2 new tests); both new tests confirmed RED on the pre-fix code.
- `tests/quality/test_intra_core_deferred_import_ratchet.py` — passes, ceiling stays 183.
- `uv run tach check` — all modules validated.
- `uv run ruff check` + `ruff format --check` — clean.
