### PR TITLE
fix(merge): canonicalize ticket-clear verdict slug to gate parity (#2829)

### DIFF
--- a/src/teatree/core/management/commands/ticket.py
+++ b/src/teatree/core/management/commands/ticket.py
@@ -23,7 +23,7 @@ from teatree.core.management.commands._plan_gate_commands import (
 from teatree.core.management.commands._rubric_commands import RubricCommands
 from teatree.core.management.commands._ticket_show import TicketShowCommands
 from teatree.core.management.commands._transition_refusals import review_context_refusal
-from teatree.core.merge import MergePreconditionError, merge_ticket_pr
+from teatree.core.merge import MergePreconditionError, merge_ticket_pr, resolve_pr_repo_slug
 from teatree.core.models import ClearIssuanceError, ClearRequest, MergeClear, ReviewVerdict, Ticket
 from teatree.core.models.errors import InvalidTransitionError
 from teatree.core.models.external_delivery import refresh_external_delivery_if_active
@@ -569,9 +569,13 @@ class Command(RubricCommands, TicketShowCommands, TyperCommand):
         # (issuance refused any non-green verdict). Record the durable read-side
         # sibling so a later `review status` lookup can answer "safe to approve
         # at the current head?" without re-deriving the cold review.
+        #
+        # Key the verdict under the SAME owner/repo the merge gate resolves, not
+        # the raw workstream `clear.slug`: a bare slug would record where the gate
+        # never queries. An already-qualified slug resolves to itself.
         verdict = ReviewVerdict.record(
             pr_id=clear.pr_id,
-            slug=clear.slug,
+            slug=resolve_pr_repo_slug(clear),
             reviewed_sha=clear.reviewed_sha,
             verdict=ReviewVerdict.Verdict.MERGE_SAFE,
             reviewer_identity=clear.reviewer_identity,

--- a/tests/teatree_core/test_clear_issuance_and_human_substrate.py
+++ b/tests/teatree_core/test_clear_issuance_and_human_substrate.py
@@ -34,8 +34,9 @@ import pytest
 from django.core.management import call_command
 from django.test import TestCase
 
-from teatree.core.merge import MergePreconditionError, assert_merge_preconditions, merge_ticket_pr
-from teatree.core.models import ConfigSetting, MergeAudit, MergeClear, Ticket
+from teatree.core.merge import MergePreconditionError, assert_merge_preconditions, merge_ticket_pr, resolve_pr_repo_slug
+from teatree.core.merge.authorization import assert_review_verdict_gate
+from teatree.core.models import ConfigSetting, MergeAudit, MergeClear, ReviewVerdict, Ticket
 from tests.teatree_core.conftest import seed_merge_safe_verdict
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
@@ -1169,3 +1170,71 @@ class TestRequireHumanApprovalFalseStandingGrantNonSubstrate(TestCase):
             pytest.raises(MergePreconditionError, match="head moved"),
         ):
             _assert_preconditions(clear, human_authorized="owner:adrien")
+
+
+class TestClearCanonicalizesVerdictSlug(TestCase):
+    """A bare/workstream CLEAR slug records the by-product verdict where the #2829 gate looks it up."""
+
+    def test_bare_slug_clear_records_verdict_under_resolved_owner_repo(self) -> None:
+        """`ticket clear` with a bare repo slug keys its verdict under ``resolve_pr_repo_slug``.
+
+        Pre-fix the verdict was recorded under the raw ``clear.slug`` ("teatree"),
+        but ``assert_review_verdict_gate`` looks it up under
+        ``resolve_pr_repo_slug(clear)`` ("souliane/teatree") — so a bare slug was
+        silently unmergeable ("no recorded merge_safe ReviewVerdict at the live
+        head") even though the independent cold review WAS recorded.
+        """
+        ticket = Ticket.objects.create(
+            overlay="t3-teatree",
+            state=Ticket.State.IN_REVIEW,
+            issue_url="https://github.com/souliane/teatree/issues/859",
+        )
+        result = cast(
+            "dict[str, object]",
+            call_command(
+                "ticket",
+                "clear",
+                "859",
+                "teatree",
+                reviewed_sha=_SHA,
+                reviewer_identity="cold-reviewer",
+                gh_verify_result="green",
+                blast_class="docs",
+                ticket_id=int(ticket.pk),
+            ),
+        )
+        assert result["issued"]
+        clear = MergeClear.objects.get(pk=result["clear_id"])
+        assert clear.slug == "teatree"
+
+        resolved = resolve_pr_repo_slug(clear)
+        assert resolved == "souliane/teatree"
+
+        verdict = ReviewVerdict.objects.get(pk=result["recorded_verdict_id"])
+        assert verdict.slug == resolved
+
+        assert_review_verdict_gate(slug=resolved, pr_id=clear.pr_id, head_sha=clear.reviewed_sha)
+
+    def test_qualified_slug_clear_records_verdict_unchanged(self) -> None:
+        """An already-qualified ``owner/repo`` clear keys the verdict identically — no behaviour change."""
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
+        result = cast(
+            "dict[str, object]",
+            call_command(
+                "ticket",
+                "clear",
+                "860",
+                "souliane/teatree",
+                reviewed_sha=_SHA,
+                reviewer_identity="cold-reviewer",
+                gh_verify_result="green",
+                blast_class="docs",
+                ticket_id=int(ticket.pk),
+            ),
+        )
+        assert result["issued"]
+        clear = MergeClear.objects.get(pk=result["clear_id"])
+        verdict = ReviewVerdict.objects.get(pk=result["recorded_verdict_id"])
+        assert verdict.slug == "souliane/teatree"
+        assert resolve_pr_repo_slug(clear) == "souliane/teatree"
+        assert_review_verdict_gate(slug=verdict.slug, pr_id=clear.pr_id, head_sha=clear.reviewed_sha)


### PR DESCRIPTION
A bare/workstream repo slug passed to `t3 teatree ticket clear` was silently unmergeable: the by-product `ReviewVerdict` was recorded under the raw `clear.slug`, but the #2829 merge gate (`assert_review_verdict_gate`) looks the verdict up under `resolve_pr_repo_slug(clear)` (owner/repo). So a bare slug ("teatree" vs "souliane/teatree") recorded the verdict where the gate never queries, and the keystone merge refused with "no recorded merge_safe ReviewVerdict at the live head" even though the independent review WAS recorded.

Fix: record the verdict under the same resolver the gate uses. An already-qualified `owner/repo` slug resolves to itself, so a normal qualified clear/merge is byte-identical. Every reader of the verdict (the #2829 gate, the solo-sweep predicate, `review status`) already keys under `owner/repo`, so record-time and read-time slugs are now consistent.

Tactical single-call-site fix (architecture pre-check skipped per `t3:architecture-design`).

Test: regression drives the real `ticket clear` with a bare slug and asserts the recorded verdict slug == `resolve_pr_repo_slug(clear)` and that the #2829 gate passes at the reviewed head. Observed RED on the pre-fix record site, GREEN after. Ran the ticket-clear + merge + verdict modules (194 passed) and ruff on changed files.