### PR TITLE
fix(gate): completion-claim disqualifies merged-qualifier synonyms + punctuation gap (#2665)

### DIFF
--- a/src/teatree/hooks/completion_claim_scanner.py
+++ b/src/teatree/hooks/completion_claim_scanner.py
@@ -95,15 +95,20 @@ _DELIVERABLE_LINE_RE: Final[re.Pattern[str]] = re.compile(
 # between), so forward-looking "PR #41 will be merged once CI passes" is not read as
 # a landed state. A trailing future/conditional qualifier ("merged once CI passes",
 # "merged on green/ci/pipeline", "merged pending/awaiting approval", "merged subject
-# to/following/contingent on approval", "merged provided/assuming CI passes")
-# likewise leans not-yet-landed, so a negative lookahead after the bare-MERGED
-# "merged" token disqualifies it — applied ONLY to this leg, never to the
-# merged-to-target / on-main / merge-commit-SHA / origin-HEAD / fast-forward legs,
-# which are past-tense. The separator before the qualifier is the punctuation-
-# tolerant class [\s,:(\-]+, so a comma/paren/colon/dash between "merged" and the
-# qualifier ("merged, pending", "merged (pending …)", "merged: once …") cannot
-# defeat it. "after" and "to" are deliberately NOT qualifiers — "merged after the
-# refactor landed" / "merged to main" are landed, not conditional.
+# to/following approval", "merged contingent/dependent/conditional on-or-upon
+# approval", "merged provided/assuming CI passes", "merged barring objections",
+# "merged save for the changelog") likewise leans not-yet-landed, so a negative lookahead after the
+# bare-MERGED "merged" token disqualifies it — applied ONLY to this leg, never to
+# the merged-to-target / on-main / merge-commit-SHA / origin-HEAD / fast-forward
+# legs, which are past-tense. The separator before the qualifier is the
+# punctuation-tolerant class — ASCII space/comma/colon/open-paren/hyphen plus the
+# whole adjacent Unicode dash family as a RANGE, not an enumeration: the contiguous
+# U+2010-U+2015 (HYPHEN through HORIZONTAL BAR) and the non-contiguous outliers U+2212
+# (MINUS SIGN), U+2E3A/U+2E3B (TWO/THREE-EM DASH), and U+FE58/U+FE63/U+FF0D (the small
+# and fullwidth forms). So any Unicode dash an agent types between "merged" and the
+# qualifier ("merged, pending", "merged — pending", "merged: once …") cannot defeat it.
+# "after" and "to" are deliberately NOT qualifiers — "merged after the refactor
+# landed" / "merged to main" are landed, not conditional.
 _ON_TARGET_EVIDENCE_RE: Final[re.Pattern[str]] = re.compile(
     r"\bmerged (?:to|into|onto) (?:the )?(?:merge )?target\b|"
     r"\bmerged to (?:main|master|develop|the default branch)\b|"
@@ -116,8 +121,11 @@ _ON_TARGET_EVIDENCE_RE: Final[re.Pattern[str]] = re.compile(
     r"\bmerge(?:d)? commit\s+[0-9a-f]{7,40}\b|"
     r"\b(?:squash[- ]?)?merged as\s+[0-9a-f]{7,40}\b|"
     r"\b(?:pr|mr|pull request|merge request)\s*[#!]?\d+\b\s*(?:(?:is|was|has been|now)\s+|[:=]\s*)?merged\b"
-    r"(?![\s,:(\-]+(?:once|on\s+green|on\s+ci|on\s+(?:the\s+)?pipeline|pending|when|upon|"
-    r"as\s+soon\s+as|if|unless|awaiting|subject\s+to|following|provided|assuming|contingent\s+on)\b)|"
+    r"(?![\s,:(\-\u2010-\u2015\u2212\u2e3a\u2e3b\ufe58\ufe63\uff0d]+"
+    r"(?:once|on\s+green|on\s+ci|on\s+(?:the\s+)?pipeline|pending|when|upon|"
+    r"as\s+soon\s+as|if|unless|awaiting|subject\s+to|following|provided|assuming|"
+    r"contingent\s+(?:on|upon)|depend(?:ing|ent)\s+(?:on|upon)|conditional\s+(?:on|upon)|"
+    r"barring|save\s+for)\b)|"
     r"\borigin/[\w./-]+\s+HEAD\s*(?:is|=|now|at)\s*[0-9a-f]{7,40}\b|"
     r"\bfast[- ]forwarded(?:\s+to)?\s+[0-9a-f]{7,40}\b",
     re.IGNORECASE,

--- a/src/teatree/hooks/completion_claim_scanner.py
+++ b/src/teatree/hooks/completion_claim_scanner.py
@@ -94,10 +94,16 @@ _DELIVERABLE_LINE_RE: Final[re.Pattern[str]] = re.compile(
 # MERGED-state leg binds the PR/MR id adjacently to "merged" (only a small copula
 # between), so forward-looking "PR #41 will be merged once CI passes" is not read as
 # a landed state. A trailing future/conditional qualifier ("merged once CI passes",
-# "merged on green", "merged pending approval", "merged when CI passes") likewise
-# leans not-yet-landed, so a negative lookahead after the bare-MERGED "merged" token
-# disqualifies it — applied ONLY to this leg, never to the merged-to-target /
-# on-main / merge-commit-SHA / origin-HEAD / fast-forward legs, which are past-tense.
+# "merged on green/ci/pipeline", "merged pending/awaiting approval", "merged subject
+# to/following/contingent on approval", "merged provided/assuming CI passes")
+# likewise leans not-yet-landed, so a negative lookahead after the bare-MERGED
+# "merged" token disqualifies it — applied ONLY to this leg, never to the
+# merged-to-target / on-main / merge-commit-SHA / origin-HEAD / fast-forward legs,
+# which are past-tense. The separator before the qualifier is the punctuation-
+# tolerant class [\s,:(\-]+, so a comma/paren/colon/dash between "merged" and the
+# qualifier ("merged, pending", "merged (pending …)", "merged: once …") cannot
+# defeat it. "after" and "to" are deliberately NOT qualifiers — "merged after the
+# refactor landed" / "merged to main" are landed, not conditional.
 _ON_TARGET_EVIDENCE_RE: Final[re.Pattern[str]] = re.compile(
     r"\bmerged (?:to|into|onto) (?:the )?(?:merge )?target\b|"
     r"\bmerged to (?:main|master|develop|the default branch)\b|"
@@ -110,7 +116,8 @@ _ON_TARGET_EVIDENCE_RE: Final[re.Pattern[str]] = re.compile(
     r"\bmerge(?:d)? commit\s+[0-9a-f]{7,40}\b|"
     r"\b(?:squash[- ]?)?merged as\s+[0-9a-f]{7,40}\b|"
     r"\b(?:pr|mr|pull request|merge request)\s*[#!]?\d+\b\s*(?:(?:is|was|has been|now)\s+|[:=]\s*)?merged\b"
-    r"(?!\s+(?:once|on\s+green|on\s+ci|on\s+the\s+pipeline|pending|when|upon|as\s+soon\s+as|if|unless)\b)|"
+    r"(?![\s,:(\-]+(?:once|on\s+green|on\s+ci|on\s+(?:the\s+)?pipeline|pending|when|upon|"
+    r"as\s+soon\s+as|if|unless|awaiting|subject\s+to|following|provided|assuming|contingent\s+on)\b)|"
     r"\borigin/[\w./-]+\s+HEAD\s*(?:is|=|now|at)\s*[0-9a-f]{7,40}\b|"
     r"\bfast[- ]forwarded(?:\s+to)?\s+[0-9a-f]{7,40}\b",
     re.IGNORECASE,

--- a/tests/teatree_hooks/test_completion_claim_scanner.py
+++ b/tests/teatree_hooks/test_completion_claim_scanner.py
@@ -502,6 +502,110 @@ class TestMergedQualifierSynonymsAndPunctuationDoNotCount:
         assert scanner.find_completion_block(_MERGED_QUALIFIER_PRESERVATION_MAP) is None
 
 
+# The HOLD on #2864 (reviewer-verified): the punctuation-tolerant separator class
+# covered ASCII space/comma/colon/open-paren/hyphen but NOT the Unicode em-dash
+# (U+2014) or en-dash (U+2013) — the dash agents most often type — so "PR #41
+# merged — pending approval" (em-dash) CLEARED even though the comma form of the
+# identical claim correctly BLOCKED and "pending" is already a covered qualifier.
+# And four future/conditional SYNONYMS stayed uncovered ("merged depending on /
+# conditional on approval", "merged barring objections", "merged save for the
+# changelog"), each reading as landed evidence. Every one is a premature
+# not-yet-landed row that MUST disqualify the bare-MERGED leg so the claim blocks.
+_EM_DASH = "\u2014"
+_EN_DASH = "\u2013"
+_DASH_AND_SYNONYM_LEAK_PHRASES = [
+    f"merged {_EM_DASH} pending approval",
+    f"merged {_EN_DASH} pending approval",
+    "merged depending on approval",
+    "merged conditional on approval",
+    "merged barring objections",
+    "merged save for the changelog",
+]
+
+
+class TestUnicodeDashSeparatorAndSynonymQualifiersDoNotCount:
+    """Anti-vacuous pair: Unicode-dash + synonym 'merged' qualifiers fire; a dash + NON-qualifier still clears."""
+
+    @pytest.mark.parametrize("phrase", _DASH_AND_SYNONYM_LEAK_PHRASES)
+    def test_unicode_dash_and_synonym_qualifier_leak_fires(self, phrase: str) -> None:
+        # Each phrase is a covered qualifier reached past an em/en-dash, or an
+        # uncovered synonym (depending on / conditional on / barring / save for) — all
+        # lean not-yet-landed, so no row carries on-target evidence and the premature
+        # multi-deliverable claim MUST block. Reverting the dash chars from the
+        # separator class or the four synonyms from the alternation makes these
+        # return None — the RED-on-revert anchor for the leak fix.
+        verdict = scanner.find_completion_block(_two_row_claim(f"PR #41 {phrase}.", f"PR #42 {phrase}."))
+        assert verdict is not None
+        assert verdict.deliverable_count == 2
+        assert any("on-target evidence" in reason for reason in verdict.missing)
+
+    def test_dash_followed_by_non_qualifier_still_clears(self) -> None:
+        # Preservation: "PR #42 merged — see the changelog #123" — an em-dash followed
+        # by a NON-qualifier ("see") — is landed evidence, so the complete map clears.
+        # Only a dash followed by a COVERED qualifier disqualifies the leg. Stays GREEN
+        # when the dash chars are reverted, isolating the leak fix.
+        row = f"PR #42 merged {_EM_DASH} see the changelog #123"
+        assert scanner.find_completion_block(_two_row_claim(f"{row}.", f"{row}.")) is None
+
+
+# The second HOLD on #2864 (reviewer-verified): the prior fix ENUMERATED only
+# en-dash (U+2013) and em-dash (U+2014), so the rest of the adjacent Unicode dash
+# family still slipped. The reviewer's named failing input -- PR #41 merged <U+2015>
+# pending approval (HORIZONTAL BAR) -- cleared, as did U+2010 HYPHEN, U+2012 FIGURE
+# DASH, U+2212 MINUS SIGN, U+2E3A TWO-EM DASH, and U+FF0D FULLWIDTH HYPHEN-MINUS,
+# each reaching the COVERED 'pending' qualifier yet read as landed. The on/upon
+# conditional synonyms ('contingent upon', 'dependent on', 'depending upon',
+# 'conditional upon') stayed uncovered too. The dash ENUMERATION is replaced with a
+# RANGE and the synonyms generalized, so each is a premature not-yet-landed row that
+# MUST disqualify the bare-MERGED leg so the claim blocks.
+_HORIZONTAL_BAR = "\u2015"
+_HYPHEN = "\u2010"
+_FIGURE_DASH = "\u2012"
+_MINUS_SIGN = "\u2212"
+_TWO_EM_DASH = "\u2e3a"
+_FULLWIDTH_HYPHEN_MINUS = "\uff0d"
+
+
+_DASH_FAMILY_LEAK_PHRASES = [
+    f"merged {_HORIZONTAL_BAR} pending approval",
+    f"merged {_HYPHEN} pending approval",
+    f"merged {_FIGURE_DASH} pending approval",
+    f"merged {_MINUS_SIGN} pending approval",
+    f"merged {_TWO_EM_DASH} pending approval",
+    f"merged {_FULLWIDTH_HYPHEN_MINUS} pending approval",
+]
+_CONDITIONAL_SYNONYM_LEAK_PHRASES = [
+    "merged contingent upon approval",
+    "merged dependent on approval",
+    "merged depending upon approval",
+    "merged conditional upon approval",
+]
+
+
+class TestUnicodeDashFamilyAndConditionalSynonymsDoNotCount:
+    """Anti-vacuous pair: the full Unicode dash family + on/upon synonyms fire; a dash + NON-qualifier clears."""
+
+    @pytest.mark.parametrize("phrase", _DASH_FAMILY_LEAK_PHRASES + _CONDITIONAL_SYNONYM_LEAK_PHRASES)
+    def test_dash_family_and_conditional_synonym_leak_fires(self, phrase: str) -> None:
+        # Each phrase reaches the covered "pending" qualifier past a Unicode-dash-family
+        # separator (incl. the named U+2015 HORIZONTAL BAR), or is an on/upon conditional
+        # synonym. All lean not-yet-landed, so no row carries on-target evidence and the
+        # premature multi-deliverable claim MUST block. Reverting the dash RANGE or the
+        # widened synonyms makes these return None, the RED-on-revert anchor.
+        verdict = scanner.find_completion_block(_two_row_claim(f"PR #41 {phrase}.", f"PR #42 {phrase}."))
+        assert verdict is not None
+        assert verdict.deliverable_count == 2
+        assert any("on-target evidence" in reason for reason in verdict.missing)
+
+    def test_horizontal_bar_followed_by_non_qualifier_still_clears(self) -> None:
+        # Preservation: a HORIZONTAL BAR (U+2015) followed by a NON-qualifier ("see") is
+        # landed evidence, so the complete map clears. Only a dash followed by a COVERED
+        # qualifier disqualifies the leg, so the widened range must not over-block. Stays
+        # GREEN when the range is reverted, isolating the leak fix.
+        row = f"PR #42 merged {_HORIZONTAL_BAR} see the changelog #123"
+        assert scanner.find_completion_block(_two_row_claim(f"{row}.", f"{row}.")) is None
+
+
 class TestFormatBlockMessage:
     def test_message_names_the_incomplete_legs(self) -> None:
         verdict = scanner.find_completion_block(_STRANDED_CLAIM)

--- a/tests/teatree_hooks/test_completion_claim_scanner.py
+++ b/tests/teatree_hooks/test_completion_claim_scanner.py
@@ -427,6 +427,81 @@ class TestTrailingConditionalMergedDoesNotCount:
         assert scanner.find_completion_block(_BARE_AND_MERGED_TO_MAIN_MAP) is None
 
 
+# The residual leaks the prior fix left open (#2665): the bare-MERGED leg's
+# trailing lookahead only knew a handful of qualifiers and was anchored with a
+# bare ``\s+`` right after "merged", so (1) future/conditional SYNONYMS it did not
+# enumerate ("merged awaiting approval", "merged subject to approval", "merged
+# following approval", "merged provided/assuming CI passes", "merged contingent on
+# approval", the bare "merged on pipeline") read as landed evidence, and (2) any
+# punctuation between "merged" and an otherwise-covered qualifier ("merged,
+# pending", "merged (pending …)", "merged: once …") defeated the lookahead. Each is
+# a premature not-yet-landed row that MUST disqualify the leg so the claim blocks.
+_MERGED_QUALIFIER_LEAK_PHRASES = [
+    "merged awaiting approval",
+    "merged subject to approval",
+    "merged following approval",
+    "merged provided CI passes",
+    "merged assuming CI passes",
+    "merged contingent on approval",
+    "merged on pipeline",
+    "merged, pending approval",
+    "merged (pending approval)",
+    "merged: once CI passes",
+]
+
+# Preservation: a complete map whose rows are genuine landed evidence with the
+# DELIBERATE non-conditional qualifiers "after" and "to" ("merged after the
+# refactor landed", "merged to main") must STILL clear — neither is conditional, so
+# the widened lookahead must leave them on-target.
+_MERGED_QUALIFIER_PRESERVATION_MAP = (
+    "I read the authoritative spec and its comments and enumerated every deliverable.\n"
+    "Both deliverables are merged and live — done.\n"
+    "- US-03 EURIBOR endpoint: PR #42 merged after the refactor landed.\n"
+    "- US-05 product-items endpoint: merged to main.\n"
+    "The crucial deliverable (US-03) is verified on its correct surface.\n"
+)
+
+
+class TestMergedQualifierSynonymsAndPunctuationDoNotCount:
+    """Anti-vacuous pair: synonym/punctuation 'merged' qualifiers fire; genuine landed rows still clear."""
+
+    @pytest.mark.parametrize("phrase", _MERGED_QUALIFIER_LEAK_PHRASES)
+    def test_future_conditional_qualifier_leak_fires(self, phrase: str) -> None:
+        # The residual leaks: each future/conditional qualifier — whether an
+        # uncaught synonym, the bare "on pipeline", or one reached past a comma /
+        # open-paren / colon — leans not-yet-landed, so no row carries on-target
+        # evidence and the premature multi-deliverable claim MUST block. Reverting
+        # the widened alternations + generalized separator makes these return None.
+        verdict = scanner.find_completion_block(_two_row_claim(f"PR #41 {phrase}.", f"PR #42 {phrase}."))
+        assert verdict is not None
+        assert verdict.deliverable_count == 2
+        assert any("on-target evidence" in reason for reason in verdict.missing)
+
+    @pytest.mark.parametrize(
+        "row",
+        [
+            "PR #42 merged",
+            "MR !41 MERGED",
+            "PR #42 is merged",
+            "PR #42: merged",
+            "merged to main",
+            "on main",
+            "PR #42 merged after the refactor landed",
+        ],
+    )
+    def test_genuine_landed_rows_still_clear(self, row: str) -> None:
+        # Preservation guardrails: each genuine landed-state row is past-tense
+        # on-target evidence, so a complete map built only on it does NOT fire. The
+        # deliberate non-conditional qualifiers "after"/"to" stay on-target. These
+        # stay GREEN when the change is reverted, isolating the leak fix.
+        assert scanner.find_completion_block(_two_row_claim(f"{row}.", f"{row}.")) is None
+
+    def test_after_and_to_qualifiers_preservation_map_clears(self) -> None:
+        # The full preservation map: "merged after the refactor landed" and "merged
+        # to main" are landed evidence, so the complete on-target map clears.
+        assert scanner.find_completion_block(_MERGED_QUALIFIER_PRESERVATION_MAP) is None
+
+
 class TestFormatBlockMessage:
     def test_message_names_the_incomplete_legs(self) -> None:
         verdict = scanner.find_completion_block(_STRANDED_CLAIM)


### PR DESCRIPTION
Extends the completion-claim Stop gate (#2665) bare-MERGED on-target leg to close the two residual leaks a cold review flagged, so a premature multi-deliverable false-done can no longer clear the on-target leg via an unrecognized merged-qualifier or a punctuation gap.

1. Uncaught future/conditional synonyms now disqualify. These previously read as landed evidence and now fire the gate: awaiting, subject to, following, provided, assuming, contingent on. Also added the bare on-pipeline (no the), alongside the existing on-the-pipeline. Now-firing rows: PR #42 merged awaiting approval; PR #42 merged subject to approval; PR #42 merged following approval; PR #42 merged provided CI passes; PR #42 merged assuming CI passes; PR #42 merged contingent on approval; PR #42 merged on pipeline.

2. Punctuation gap closed. The lookahead was anchored with a bare whitespace token right after merged, so a comma/open-paren/colon/dash between merged and an otherwise-covered qualifier defeated it. The separator is now a punctuation-tolerant character class. Now-firing rows: PR #41 merged, pending approval; PR #41 merged (pending approval); PR #41 merged: once CI passes.

Deliberate non-change: after and to are NOT conditional. merged after the refactor landed and merged to main stay on-target (landed, not conditional); they are not added to the disqualify set.

Precision guardrails preserved, all still clear: PR #42 merged; MR !41 MERGED; PR #42 is merged; PR #42: merged; merged to main; on main; merge commit 40hex; origin/main HEAD = 40hex; fast-forwarded to 40hex.

Tests: tests/teatree_hooks/test_completion_claim_scanner.py adds TestMergedQualifierSynonymsAndPunctuationDoNotCount, a parametrized must-fire test over all 10 new inputs (6 synonyms + on-pipeline + 3 punctuation forms) asserting BLOCK, plus preservation positives that genuine landed rows still clear. Anti-vacuity proven: reverting ONLY the widened alternations + generalized separator turns the 10 new must-fire tests RED while the 8 preservation positives stay GREEN. Every existing test (trailing-conditional, #2849 forward-looking, merge-SHA no-fire, #2842 regressions, design-table suppression, mr-exists-only) stays GREEN. Verified: scanner module 54 passed + Stop-hook integration 11 passed + ruff check/format clean on changed files.

Architecture pre-check (#2665):
1. BLUEPRINT alignment: the rules Verification-Before-Completion section maps to the hard-blocking handle_completion_claim_gate Stop gate (#2665). No section change; this tightens an existing detector regex.
2. FSM phase boundaries: n/a (no Ticket.State / Worktree.State transition).
3. Extension-point contracts: n/a (pure detector find_completion_block; the Stop handler consumes it unchanged).
4. Component boundaries: src/teatree/hooks/completion_claim_scanner.py (pure detector). Correct module; no straddle.
5. Dependency direction: no new imports; tach/import-linter passed in pre-commit.
6. Test surface: the new test class (must-fire parametrize + preservation). Each leak phrase yields a non-None verdict with an on-target-evidence missing leg.
7. Resilience invariants: n/a (no external write; fail-safe-to-silent on odd input unchanged).
8. Identity/key normalization: n/a.
9. Behavior preservation / capability deletion: purely additive to the disqualify set + separator widening; no must-block test inverted; after/to and all past-tense landed legs explicitly preserved.