### PR TITLE
fix(merge): resolve ticket-clear verdict slug before issuing — no orphaned CLEAR (#2860)

### DIFF
--- a/src/teatree/core/management/commands/ticket.py
+++ b/src/teatree/core/management/commands/ticket.py
@@ -546,36 +546,38 @@ class Command(RubricCommands, TicketShowCommands, TyperCommand):
             self.stdout.write(f"  CLEAR refused: {preflight_refusal}")
             return {"issued": False, "error": preflight_refusal}
 
+        request = ClearRequest(
+            pr_id=pr_id,
+            slug=slug,
+            reviewed_sha=reviewed_sha,
+            reviewer_identity=reviewer_identity,
+            gh_verify_result=gh_verify_result,
+            blast_class=blast_class,
+            ticket=resolved_ticket,
+            human_authorizer=human_authorize,
+            executing_loop_identity=executing_loop_identity,
+        )
+
+        # Resolve the verdict's owner/repo BEFORE issuing: resolve_pr_repo_slug
+        # fails closed in a degenerate environment (workstream slug, no ticket
+        # issue_url, no clone origin), and resolving it after MergeClear.issue()
+        # persisted the row would orphan an already-issued CLEAR behind a traceback.
+        # Issue runs only when resolution succeeds, so neither failure persists a row.
         try:
-            clear = MergeClear.issue(
-                ClearRequest(
-                    pr_id=pr_id,
-                    slug=slug,
-                    reviewed_sha=reviewed_sha,
-                    reviewer_identity=reviewer_identity,
-                    gh_verify_result=gh_verify_result,
-                    blast_class=blast_class,
-                    ticket=resolved_ticket,
-                    human_authorizer=human_authorize,
-                    executing_loop_identity=executing_loop_identity,
-                )
-            )
-        except ClearIssuanceError as exc:
+            verdict_slug = resolve_pr_repo_slug(request)
+            clear = MergeClear.issue(request)
+        except (MergePreconditionError, ClearIssuanceError) as exc:
             self.stdout.write(f"  CLEAR refused: {exc}")
             return {"issued": False, "error": str(exc)}
 
         self.stdout.write(f"  issued CLEAR {clear.pk} for {clear.slug}#{clear.pr_id}@{clear.reviewed_sha[:8]}")
-        # A CLEAR is a merge-safe judgment at the reviewed tree by construction
-        # (issuance refused any non-green verdict). Record the durable read-side
-        # sibling so a later `review status` lookup can answer "safe to approve
-        # at the current head?" without re-deriving the cold review.
-        #
-        # Key the verdict under the SAME owner/repo the merge gate resolves, not
-        # the raw workstream `clear.slug`: a bare slug would record where the gate
-        # never queries. An already-qualified slug resolves to itself.
+        # Record the durable read-side sibling (a merge-safe judgment by
+        # construction — issuance refused any non-green verdict) so a later
+        # `review status` answers "safe to approve at the current head?". Key it
+        # under verdict_slug — where the merge gate queries — not the workstream slug.
         verdict = ReviewVerdict.record(
             pr_id=clear.pr_id,
-            slug=resolve_pr_repo_slug(clear),
+            slug=verdict_slug,
             reviewed_sha=clear.reviewed_sha,
             verdict=ReviewVerdict.Verdict.MERGE_SAFE,
             reviewer_identity=clear.reviewer_identity,

--- a/src/teatree/core/management/commands/ticket.py
+++ b/src/teatree/core/management/commands/ticket.py
@@ -548,7 +548,9 @@ class Command(RubricCommands, TicketShowCommands, TyperCommand):
 
         request = ClearRequest(
             pr_id=pr_id,
-            slug=slug,
+            # Strip so the by-product verdict keys off the same normalized slug the
+            # merge gate resolves — whitespace can otherwise flip _looks_like_owner_repo.
+            slug=slug.strip(),
             reviewed_sha=reviewed_sha,
             reviewer_identity=reviewer_identity,
             gh_verify_result=gh_verify_result,

--- a/tests/teatree_core/test_clear_issuance_and_human_substrate.py
+++ b/tests/teatree_core/test_clear_issuance_and_human_substrate.py
@@ -1238,3 +1238,62 @@ class TestClearCanonicalizesVerdictSlug(TestCase):
         assert verdict.slug == "souliane/teatree"
         assert resolve_pr_repo_slug(clear) == "souliane/teatree"
         assert_review_verdict_gate(slug=verdict.slug, pr_id=clear.pr_id, head_sha=clear.reviewed_sha)
+
+
+class TestClearResolvesVerdictSlugBeforeIssuing(TestCase):
+    """The verdict owner/repo is resolved BEFORE issuing — a resolution failure never orphans a CLEAR.
+
+    ``resolve_pr_repo_slug`` raises ``MergePreconditionError`` in a degenerate
+    environment (a workstream slug + no ticket ``issue_url`` + no resolvable clone
+    ``origin``). Resolving it AFTER ``MergeClear.issue()`` persisted the row left an
+    already-issued CLEAR orphaned behind a traceback; resolving up-front fails
+    cleanly with nothing persisted, while the happy path is byte-identical.
+    """
+
+    def test_unresolvable_slug_refuses_before_issuing_and_persists_nothing(self) -> None:
+        """No owner/repo resolvable → clean refusal, NO orphaned CLEAR, NO verdict row."""
+        with patch("teatree.core.merge.pr_slug_resolution._project_repo_slug", return_value=""):
+            result = cast(
+                "dict[str, object]",
+                call_command(
+                    "ticket",
+                    "clear",
+                    "159",
+                    "merge-candidate-working-repos",
+                    reviewed_sha=_SHA,
+                    reviewer_identity="cold-reviewer",
+                    gh_verify_result="green",
+                    blast_class="logic",
+                ),
+            )
+        assert not result["issued"]
+        error = cast("str", result["error"])
+        assert "could not resolve" in error.lower()
+        assert MergeClear.objects.count() == 0
+        assert ReviewVerdict.objects.count() == 0
+
+    def test_clone_origin_fallback_still_issues_and_records_verdict(self) -> None:
+        """The happy twin: a resolvable clone origin issues the CLEAR and records the verdict under it."""
+        with patch(
+            "teatree.core.merge.pr_slug_resolution._project_repo_slug",
+            return_value="souliane/teatree",
+        ):
+            result = cast(
+                "dict[str, object]",
+                call_command(
+                    "ticket",
+                    "clear",
+                    "160",
+                    "merge-candidate-working-repos",
+                    reviewed_sha=_SHA,
+                    reviewer_identity="cold-reviewer",
+                    gh_verify_result="green",
+                    blast_class="logic",
+                ),
+            )
+        assert result["issued"]
+        clear = MergeClear.objects.get(pk=result["clear_id"])
+        verdict = ReviewVerdict.objects.get(pk=result["recorded_verdict_id"])
+        assert verdict.slug == "souliane/teatree"
+        assert resolve_pr_repo_slug(clear) == "souliane/teatree"
+        assert_review_verdict_gate(slug=verdict.slug, pr_id=clear.pr_id, head_sha=clear.reviewed_sha)

--- a/tests/teatree_core/test_clear_issuance_and_human_substrate.py
+++ b/tests/teatree_core/test_clear_issuance_and_human_substrate.py
@@ -1239,6 +1239,72 @@ class TestClearCanonicalizesVerdictSlug(TestCase):
         assert resolve_pr_repo_slug(clear) == "souliane/teatree"
         assert_review_verdict_gate(slug=verdict.slug, pr_id=clear.pr_id, head_sha=clear.reviewed_sha)
 
+    def test_whitespace_padded_slug_keys_verdict_where_merge_gate_resolves(self) -> None:
+        """Whitespace must not flip ``_looks_like_owner_repo`` and split the verdict key.
+
+        Record-time resolution keys off the request slug; the merge gate keys off
+        the persisted ``clear.slug`` (which ``issue()`` stores stripped). A padded
+        branch-name slug (``  fix/clear-slug  ``) momentarily passes the
+        ``owner/repo`` structural check while padded, so record-time would key the
+        verdict under the raw branch name — where the gate, resolving the stripped
+        slug to the ticket's repo, never queries. Stripping at request construction
+        keeps both sides on the identical normalized ``souliane/teatree``.
+        """
+        ticket = Ticket.objects.create(
+            overlay="t3-teatree",
+            state=Ticket.State.IN_REVIEW,
+            issue_url="https://github.com/souliane/teatree/issues/859",
+        )
+        result = cast(
+            "dict[str, object]",
+            call_command(
+                "ticket",
+                "clear",
+                "859",
+                "  fix/clear-slug  ",
+                reviewed_sha=_SHA,
+                reviewer_identity="cold-reviewer",
+                gh_verify_result="green",
+                blast_class="docs",
+                ticket_id=int(ticket.pk),
+            ),
+        )
+        assert result["issued"]
+        clear = MergeClear.objects.get(pk=result["clear_id"])
+        assert clear.slug == "fix/clear-slug"
+
+        resolved = resolve_pr_repo_slug(clear)
+        assert resolved == "souliane/teatree"
+
+        verdict = ReviewVerdict.objects.get(pk=result["recorded_verdict_id"])
+        assert verdict.slug == resolved
+        assert_review_verdict_gate(slug=resolved, pr_id=clear.pr_id, head_sha=clear.reviewed_sha)
+
+    def test_whitespace_padded_qualified_slug_records_verdict_unchanged(self) -> None:
+        """An already-qualified slug with surrounding whitespace records identically — no behaviour change."""
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
+        result = cast(
+            "dict[str, object]",
+            call_command(
+                "ticket",
+                "clear",
+                "860",
+                "  souliane/teatree  ",
+                reviewed_sha=_SHA,
+                reviewer_identity="cold-reviewer",
+                gh_verify_result="green",
+                blast_class="docs",
+                ticket_id=int(ticket.pk),
+            ),
+        )
+        assert result["issued"]
+        clear = MergeClear.objects.get(pk=result["clear_id"])
+        assert clear.slug == "souliane/teatree"
+        verdict = ReviewVerdict.objects.get(pk=result["recorded_verdict_id"])
+        assert verdict.slug == "souliane/teatree"
+        assert resolve_pr_repo_slug(clear) == "souliane/teatree"
+        assert_review_verdict_gate(slug=verdict.slug, pr_id=clear.pr_id, head_sha=clear.reviewed_sha)
+
 
 class TestClearResolvesVerdictSlugBeforeIssuing(TestCase):
     """The verdict owner/repo is resolved BEFORE issuing — a resolution failure never orphans a CLEAR.

--- a/tests/teatree_core/test_merge_execution_cross_repo.py
+++ b/tests/teatree_core/test_merge_execution_cross_repo.py
@@ -19,14 +19,18 @@ candidate it considered.
 """
 
 from pathlib import Path
+from typing import cast
 from unittest.mock import patch
 
 import pytest
+from django.core.management import call_command
 from django.test import TestCase
 
 from teatree.config import OverlayEntry
-from teatree.core.merge import MergePreconditionError, merge_ticket_pr
-from teatree.core.models import MergeClear
+from teatree.core.merge import MergePreconditionError, merge_ticket_pr, resolve_pr_repo_slug
+from teatree.core.merge.authorization import assert_review_verdict_gate
+from teatree.core.merge.pr_slug_resolution import _reconcile_slug_against_reviewed_sha
+from teatree.core.models import MergeAudit, MergeClear, ReviewVerdict, Ticket
 from tests.teatree_core.conftest import seed_merge_safe_verdict
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
@@ -349,3 +353,121 @@ class TestCrossRepoCandidateProbe(TestCase):
         # No overlay-repo probe call was made.
         overlay_calls = [argv for argv in calls if _OVERLAY_REPO in " ".join(argv)]
         assert not overlay_calls, f"probe must not run when resolved repo's PR head matches: {overlay_calls}"
+
+
+class TestUrlFormCrossRepoClearVerdictStaysConsistent(TestCase):
+    """A url-form CLEAR keeps clear-time record and merge-time lookup consistent across repos (#2860).
+
+    When the CLEAR's ticket ``issue_url`` names the real downstream repo (Y),
+    ``resolve_pr_repo_slug`` returns Y at BOTH clear time (where the by-product
+    verdict is recorded) and merge time (where the gate's reconcile starts), and
+    ``_reconcile_slug_against_reviewed_sha`` is a no-op because Y's PR head already
+    equals ``reviewed_sha``. So the recorded slug and the looked-up slug match even
+    though Y differs from the running clone's ``origin`` — the contained boundary
+    the #2860 verdict-slug canonicalisation covers, exercised end to end here.
+    """
+
+    def test_recorded_verdict_slug_equals_merge_time_reconciled_lookup_slug(self) -> None:
+        ticket = Ticket.objects.create(
+            overlay="t3-teatree",
+            state=Ticket.State.IN_REVIEW,
+            issue_url=f"https://github.com/{_OVERLAY_REPO}/issues/159",
+        )
+        # The CLEAR slug is a bare workstream name; the real repo (Y) is resolved
+        # from the ticket issue_url, NOT the running clone's origin (X).
+        with patch("teatree.core.merge.pr_slug_resolution._project_repo_slug", return_value=_CLONE_ORIGIN):
+            issued = cast(
+                "dict[str, object]",
+                call_command(
+                    "ticket",
+                    "clear",
+                    "159",
+                    "downstream-overlay",
+                    reviewed_sha=_RIGHT_SHA,
+                    reviewer_identity="cold-reviewer",
+                    gh_verify_result="green",
+                    blast_class="logic",
+                    ticket_id=int(ticket.pk),
+                ),
+            )
+        assert issued["issued"]
+        clear = MergeClear.objects.get(pk=issued["clear_id"])
+        verdict = ReviewVerdict.objects.get(pk=issued["recorded_verdict_id"])
+        assert verdict.slug == _OVERLAY_REPO
+
+        initial = resolve_pr_repo_slug(clear)
+        assert initial == _OVERLAY_REPO
+        calls: list[list[str]] = []
+        with patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_gh_keyed_by_repo(calls)):
+            reconciled = _reconcile_slug_against_reviewed_sha(
+                initial_slug=initial,
+                pr_id=clear.pr_id,
+                reviewed_sha=clear.reviewed_sha,
+                host_kind="github",
+            )
+        # The merge-time lookup slug equals the clear-time record slug.
+        assert reconciled == verdict.slug
+        assert_review_verdict_gate(slug=reconciled, pr_id=clear.pr_id, head_sha=clear.reviewed_sha)
+
+
+class TestTicketlessWorkstreamCrossRepoClearFailsClosed(TestCase):
+    """The residual cross-repo desync (the #2860 boundary) fails CLOSED — never a silent mismerge.
+
+    A TICKETLESS CLEAR with a workstream slug for a PR that lives in a downstream
+    overlay repo resolves (``resolve_pr_repo_slug``) only to the running clone's
+    ``origin`` (X) — the real repo (Y) is discoverable solely by the forge-probing
+    ``_reconcile_slug_against_reviewed_sha`` at merge time. So the by-product
+    verdict is recorded under X while the #2829 gate looks it up under the
+    reconciled Y — a miss. Closing this consistently would need the forge probe to
+    run at CLEAR-issue time (coupling issuance to forge connectivity and breaking
+    the forge-free clear contract), so it is out of the tactical scope. It fails
+    CLOSED (a refusal, never a silent mismerge), which this pins.
+    """
+
+    def test_cross_repo_merge_refuses_when_verdict_is_under_clone_origin(self) -> None:
+        with patch("teatree.core.merge.pr_slug_resolution._project_repo_slug", return_value=_CLONE_ORIGIN):
+            issued = cast(
+                "dict[str, object]",
+                call_command(
+                    "ticket",
+                    "clear",
+                    "159",
+                    "fix-ensure-pr-default-branch-153",
+                    reviewed_sha=_RIGHT_SHA,
+                    reviewer_identity="cold-reviewer",
+                    gh_verify_result="green",
+                    blast_class="logic",
+                ),
+            )
+        assert issued["issued"]
+        verdict = ReviewVerdict.objects.get(pk=issued["recorded_verdict_id"])
+        # The verdict landed under the clone origin (X), not the real repo (Y).
+        assert verdict.slug == _CLONE_ORIGIN
+
+        candidate_entries = [
+            OverlayEntry(name="downstream", overlay_class="", project_path=Path("/clones/downstream-overlay")),
+        ]
+
+        def _remote_slug_for_path(repo: str = ".", remote: str = "origin") -> str:
+            del remote
+            return _OVERLAY_REPO if repo == "/clones/downstream-overlay" else ""
+
+        calls: list[list[str]] = []
+        with (
+            patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=_gh_keyed_by_repo(calls)),
+            patch("teatree.core.merge.pr_slug_resolution._project_repo_slug", return_value=_CLONE_ORIGIN),
+            patch("teatree.core.merge.pr_slug_resolution.discover_overlays", return_value=candidate_entries),
+            patch("teatree.core.merge.pr_slug_resolution.git.remote_slug", side_effect=_remote_slug_for_path),
+        ):
+            merged = cast(
+                "dict[str, object]",
+                call_command("ticket", "merge", str(issued["clear_id"]), loop_identity="merge-loop"),
+            )
+
+        # The merge reconciled to the real repo (Y) and the #2829 gate found no
+        # verdict there (it is under X) — it FAILS CLOSED, never a silent mismerge.
+        assert not merged["merged"]
+        assert merged["escalated"]
+        clear = MergeClear.objects.get(pk=issued["clear_id"])
+        assert clear.consumed_at is None
+        assert not MergeAudit.objects.filter(clear=clear).exists()


### PR DESCRIPTION
## Summary

Hardens the keystone slug clear path (`t3 <overlay> ticket clear`) with the two items a prior cold review flagged on #2860.

### (B) Resolve the verdict slug BEFORE issuing — no orphaned CLEAR

After #2860, `ticket clear` records the by-product `ReviewVerdict` under `resolve_pr_repo_slug(clear)` **after** `MergeClear.issue()` has already persisted the CLEAR row. In a degenerate environment (a workstream slug + no ticket `issue_url` + no resolvable clone `origin`) the resolver raises `MergePreconditionError`, which orphaned an already-issued CLEAR behind a traceback (only `ClearIssuanceError` was caught).

Fix: build the `ClearRequest`, resolve the owner/repo up-front from it (the resolver reads only `slug`/`pr_id`/`ticket`, all carried by the request), and issue + record only when resolution succeeds. Resolve and issue share one refusal block — `MergeClear.issue()` runs only if `resolve_pr_repo_slug` did not raise, so **neither** failure can persist a partial row. The happy path is byte-identical (same resolved slug, same row).

### (C) Cross-repo reconcile consistency — investigated; contained-fix boundary stated (NOT a risky partial fix)

The canonical verdict key is the **real `owner/repo`**: the solo sweep reads `has_independent_cold_review(slug=pr.slug)` (the live forge slug), the #2829 keystone gate reads the **reconciled** slug, and the cross-repo merge tests seed under the real repo.

- For every CLEAR whose real repo is **locally derivable** — an `owner/repo`-shaped slug **or** a ticket `issue_url` — the merge-time `_reconcile_slug_against_reviewed_sha` is a **no-op**, so the clear-time record slug equals the merge-time lookup slug. The number / url / id forms are consistent; a new end-to-end test pins the url form across a clone-origin-differs repo (recorded slug == reconciled lookup slug).
- The **only** residual desync is the #1335 **ticketless + non-`owner/repo`-slug** cross-repo recovery case: `resolve_pr_repo_slug` falls back to the running clone's `origin` (X) while the merge-time forge probe recovers the real repo (Y), so the gate looks the verdict up under Y → miss.

**Why this is a larger redesign, not contained:** the real repo Y is discoverable **only** by the forge-probing reconcile (there is no local-only mapping from a workstream slug + PR number to the downstream repo). Recording under Y at clear time therefore requires running `_reconcile_slug_against_reviewed_sha` (live PR-head probes) inside `ticket clear`, which (a) couples CLEAR issuance to forge connectivity, (b) adds new clear-time failure modes (head-moved / ambiguity / no-candidate), and (c) breaks the forge-free clear contract that a dozen existing `ticket clear` tests rely on. The alternative — keying the merge gate off the un-reconciled X — inverts the canonical key the solo sweep reader and the existing cross-repo tests depend on. Either is out of scope for this tactical hardening.

The residual case **fails CLOSED** (a refusal, never a silent mismerge), recoverable by re-issuing the CLEAR with an explicit `owner/repo` slug. A new regression test drives the real `clear → merge` cross-repo path and pins that fail-closed behaviour (it goes RED — a silent mismerge — if the #2829 gate is bypassed).

## Architecture pre-check — #2860 follow-up

Tactical fix (single-call-site reordering in the `ticket clear` command + tests; no new module, no Protocol/FSM change, no substrate-path edit).

1. **BLUEPRINT § alignment** — §17.4.2 (the CLEAR issuance seam) / §17.8 clause 3 (independent cold review). No spec change.
2. **FSM phase boundaries** — n/a (no `Ticket.State` transition touched).
3. **Extension-point contracts** — none touched. Verdict readers (`assert_review_verdict_gate`, `has_independent_cold_review`, `review status`) all key under the real `owner/repo` and are unchanged.
4. **Component boundaries** — change is in `src/teatree/core/management/commands/ticket.py` (CLI command), not the substrate `src/teatree/core/merge/` module.
5. **Dependency direction** — no new import (`MergePreconditionError`/`resolve_pr_repo_slug` already imported); `tach` clean.
6. **Test surface** — `tests/teatree_core/test_clear_issuance_and_human_substrate.py::TestClearResolvesVerdictSlugBeforeIssuing`; `tests/teatree_core/test_merge_execution_cross_repo.py::{TestUrlFormCrossRepoClearVerdictStaysConsistent, TestTicketlessWorkstreamCrossRepoClearFailsClosed}`.
7. **Resilience invariants** — no new external write; the change removes a partial-write (orphaned CLEAR) failure mode.
8. **Identity/key normalization** — the verdict is keyed UP to the fully-qualified `owner/repo` via `resolve_pr_repo_slug` (no qualifier stripping).
9. **Behavior preservation** — happy path byte-identical; only the degenerate resolution-failure path changes (clean refusal instead of orphan + traceback).

## Tests

- `module-health` cap honoured: `ticket.py` shrinks (the combined refusal block + tightened comments offset the added code).
- Anti-vacuity verified for each new test (revert the corresponding production change → RED; restore → GREEN).
- Ran the ticket + merge + verdict + cross-repo + pr-sweep test modules (all green) and ruff/format/ty on changed files.
