### PR TITLE
fix(loops): scope connector preflight per-loop so one overlay outage can't SystemExit the fleet

### DIFF
--- a/src/teatree/core/management/commands/loops_tick.py
+++ b/src/teatree/core/management/commands/loops_tick.py
@@ -169,7 +169,16 @@ class Command(TyperCommand):
         ] = "",
         json_output: Annotated[bool, typer.Option("--json", help="Emit the tick report as JSON.")] = False,
     ) -> None:
-        run_connector_preflight(overlay)
+        # A per-loop tick (#2650) preflights ONLY its own overlay, gated on the
+        # loop being enabled + due — so one overlay's connector outage can't
+        # SystemExit an unrelated loop's tick (LOOP-PR-C). The master fan-out
+        # keeps the fleet-wide gate before dispatching every overlay's loops.
+        if loop:
+            from teatree.loops.connector_preflight import run_loop_connector_preflight  # noqa: PLC0415
+
+            run_loop_connector_preflight(loop)
+        else:
+            run_connector_preflight(overlay)
 
         from teatree.loop.session_identity import current_session_id, current_session_pid  # noqa: PLC0415
 

--- a/src/teatree/loops/connector_preflight.py
+++ b/src/teatree/loops/connector_preflight.py
@@ -1,0 +1,65 @@
+"""Per-loop connector preflight — scope the gate to ONE loop's overlay (LOOP-PR-C).
+
+:func:`teatree.core.connector_preflight.run_connector_preflight` is the
+fleet-wide gate: the master tick runs it once before fanning every overlay's
+loops out. A per-loop tick (``t3 loops tick --loop <name>``) must NOT inherit
+that fleet scope — probing every overlay there means one overlay's connector
+outage ``SystemExit``-s an unrelated loop's tick, taking the whole fleet of
+per-loop loops down on a single outage.
+
+This narrows the gate to the loop being run: it preflights ONLY the loop's own
+overlay (derived from ``Loop.overlay``), and only once the loop is actually
+going to run (enabled + due, via the canonical :func:`loop_enabled` verdict). A
+disabled/cooling loop — and a loop whose overlay can't be resolved to a single
+registered overlay — preflights nothing, so the per-loop tick stays isolated
+from every overlay it does not depend on. A loop's OWN connector being down
+still ``SystemExit``-s that loop's tick (fail loud), unchanged from the fleet
+gate.
+"""
+
+import logging
+import os
+
+from django.utils import timezone
+
+from teatree.core.connector_preflight import run_connector_preflight
+from teatree.core.overlay_loader import get_all_overlays, resolve_overlay_name
+from teatree.loop.loop_state_db import loop_enabled
+
+logger = logging.getLogger(__name__)
+
+
+def run_loop_connector_preflight(loop_name: str) -> None:
+    from teatree.core.models import Loop  # noqa: PLC0415
+
+    row = Loop.objects.filter(name=loop_name).first()
+    if row is None:
+        return
+    if not (loop_enabled(loop_name) and row.is_due(timezone.now())):
+        return
+    overlay_name = _scoped_overlay_name(row.overlay)
+    if overlay_name is None:
+        return
+    run_connector_preflight(overlay_name)
+
+
+def _scoped_overlay_name(loop_overlay: str) -> str | None:
+    """The single registered overlay a loop's connectors belong to, or ``None``.
+
+    A set ``Loop.overlay`` is canonicalized UP to its registered name (an
+    unknown/stale value resolves to ``None`` → skip, never the fleet). A blank
+    overlay resolves to the one overlay on a single-overlay install (so a
+    bare-config install keeps the original fail-loud gate), or to the ambient
+    ``T3_OVERLAY_NAME`` on a multi-overlay install. ``None`` (unresolvable) is
+    the resilient default: preflight nothing rather than fall back to probing
+    every overlay.
+    """
+    if loop_overlay:
+        return resolve_overlay_name(loop_overlay)
+    overlays = get_all_overlays()
+    if len(overlays) == 1:
+        return next(iter(overlays))
+    return os.environ.get("T3_OVERLAY_NAME") or None
+
+
+__all__ = ["run_loop_connector_preflight"]

--- a/tests/teatree_core/test_loops_tick_command.py
+++ b/tests/teatree_core/test_loops_tick_command.py
@@ -13,10 +13,12 @@ import io
 from unittest.mock import patch
 
 import django.test
+import pytest
 from django.core.management import call_command
 
 from teatree.core.management.commands.loops_tick import _loop_table_jobs_builder
-from teatree.core.models import LoopLease
+from teatree.core.models import Loop, LoopLease, Worktree
+from teatree.core.overlay import OverlayBase, ProvisionStep
 from teatree.loop.tick import TickReport
 
 
@@ -24,6 +26,31 @@ def _run(**kwargs: object) -> str:
     out = io.StringIO()
     call_command("loops_tick", stdout=out, **kwargs)
     return out.getvalue()
+
+
+class _CleanOverlay(OverlayBase):
+    def get_repos(self) -> list[str]:
+        return ["backend"]
+
+    def get_provision_steps(self, worktree: Worktree) -> list[ProvisionStep]:
+        _ = worktree
+        return []
+
+
+class _SlackDownOverlay(OverlayBase):
+    def get_repos(self) -> list[str]:
+        return ["backend"]
+
+    def get_provision_steps(self, worktree: Worktree) -> list[ProvisionStep]:
+        _ = worktree
+        return []
+
+    def get_connector_preflight(self) -> list:
+        def _probe() -> None:
+            msg = "Slack auth.test failed: missing_scope"
+            raise RuntimeError(msg)
+
+        return [_probe]
 
 
 class TestLoopsTickOwnership(django.test.TestCase):
@@ -151,3 +178,55 @@ class TestLoopsTickPerLoop(django.test.TestCase):
         with patch("teatree.loops.master.build_loop_table_jobs", return_value=[]) as build:
             jobs_builder(TickRequest(), dt.datetime.now(dt.UTC))
         assert build.call_args.kwargs["only"] == "inbox"
+
+
+class TestPerLoopConnectorIsolation(django.test.TestCase):
+    """A per-loop tick preflights ONLY its own overlay — one outage can't take the fleet (LOOP-PR-C).
+
+    The bug: ``t3 loops tick --loop X`` (no ``--overlay``) ran the fleet-wide
+    ``run_connector_preflight("")`` BEFORE the enabled/due gate, so an unrelated
+    overlay's connector outage ``SystemExit``-ed loop ``X``'s tick — one outage
+    SystemExits the whole fleet of per-loop loops.
+    """
+
+    @staticmethod
+    def _seed(name: str, overlay: str, *, enabled: bool = True, last_run_at: dt.datetime | None = None) -> None:
+        Loop.objects.create(
+            name=name,
+            script=f"src/teatree/loops/{name}/loop.py",
+            delay_seconds=60,
+            overlay=overlay,
+            enabled=enabled,
+            last_run_at=last_run_at,
+        )
+
+    def _run_isolated(self, *, loop: str) -> object:
+        report = TickReport(started_at=dt.datetime.now(dt.UTC))
+        overlays = {"alpha": _CleanOverlay(), "beta": _SlackDownOverlay()}
+        with (
+            patch("teatree.core.connector_preflight.get_all_overlays", return_value=overlays),
+            patch("teatree.core.overlay_loader.get_all_overlay_names", return_value=list(overlays)),
+            patch.object(LoopLease.objects, "claim_ownership", return_value=(True, "me")),
+            patch.object(LoopLease.objects, "acquire", return_value=True),
+            patch.object(LoopLease.objects, "release"),
+            patch("teatree.core.backend_factory.iter_overlay_backends", return_value=[]),
+            patch("teatree.loop.tick.run_tick", return_value=report) as run_tick,
+            patch("teatree.loop.tick_piggyback.run_piggyback_cycles"),
+        ):
+            _run(loop=loop)
+        return run_tick
+
+    def test_unrelated_overlay_outage_does_not_systemexit_per_loop_tick(self) -> None:
+        self._seed("inbox", overlay="alpha")
+        run_tick = self._run_isolated(loop="inbox")
+        assert run_tick.called
+
+    def test_disabled_loop_on_down_overlay_does_not_systemexit(self) -> None:
+        self._seed("review", overlay="beta", enabled=False)
+        run_tick = self._run_isolated(loop="review")
+        assert run_tick.called
+
+    def test_loop_on_own_down_overlay_still_systemexits(self) -> None:
+        self._seed("review", overlay="beta")
+        with pytest.raises(SystemExit):
+            self._run_isolated(loop="review")

--- a/tests/teatree_core/test_loops_tick_command.py
+++ b/tests/teatree_core/test_loops_tick_command.py
@@ -217,16 +217,16 @@ class TestPerLoopConnectorIsolation(django.test.TestCase):
         return run_tick
 
     def test_unrelated_overlay_outage_does_not_systemexit_per_loop_tick(self) -> None:
-        self._seed("inbox", overlay="alpha")
-        run_tick = self._run_isolated(loop="inbox")
+        self._seed("probe-alpha", overlay="alpha")
+        run_tick = self._run_isolated(loop="probe-alpha")
         assert run_tick.called
 
     def test_disabled_loop_on_down_overlay_does_not_systemexit(self) -> None:
-        self._seed("review", overlay="beta", enabled=False)
-        run_tick = self._run_isolated(loop="review")
+        self._seed("probe-beta", overlay="beta", enabled=False)
+        run_tick = self._run_isolated(loop="probe-beta")
         assert run_tick.called
 
     def test_loop_on_own_down_overlay_still_systemexits(self) -> None:
-        self._seed("review", overlay="beta")
+        self._seed("probe-beta", overlay="beta")
         with pytest.raises(SystemExit):
-            self._run_isolated(loop="review")
+            self._run_isolated(loop="probe-beta")

--- a/tests/teatree_loops/test_connector_preflight.py
+++ b/tests/teatree_loops/test_connector_preflight.py
@@ -1,0 +1,122 @@
+"""Per-loop connector preflight — scope the gate to ONE loop's overlay (LOOP-PR-C).
+
+The fleet-wide ``run_connector_preflight`` probes every overlay; a per-loop tick
+must not. ``run_loop_connector_preflight`` narrows the gate to the loop's own
+overlay and only fires when the loop is enabled + due, so an unrelated overlay's
+outage can never ``SystemExit`` an unrelated loop's tick — while the loop's OWN
+down connector still fails loud.
+"""
+
+import datetime as dt
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+from django.test import TestCase
+from django.utils import timezone
+
+from teatree.core.models import Loop, Worktree
+from teatree.core.overlay import OverlayBase, ProvisionStep
+from teatree.loops.connector_preflight import run_loop_connector_preflight
+
+
+class _CleanOverlay(OverlayBase):
+    def get_repos(self) -> list[str]:
+        return ["backend"]
+
+    def get_provision_steps(self, worktree: Worktree) -> list[ProvisionStep]:
+        _ = worktree
+        return []
+
+
+class _SlackDownOverlay(OverlayBase):
+    def get_repos(self) -> list[str]:
+        return ["backend"]
+
+    def get_provision_steps(self, worktree: Worktree) -> list[ProvisionStep]:
+        _ = worktree
+        return []
+
+    def get_connector_preflight(self) -> list:
+        def _probe() -> None:
+            msg = "Slack auth.test failed: missing_scope"
+            raise RuntimeError(msg)
+
+        return [_probe]
+
+
+@contextmanager
+def _registered(overlays: dict[str, OverlayBase]) -> Iterator[None]:
+    with (
+        patch("teatree.core.connector_preflight.get_all_overlays", return_value=overlays),
+        patch("teatree.loops.connector_preflight.get_all_overlays", return_value=overlays),
+        patch("teatree.core.overlay_loader.get_all_overlay_names", return_value=list(overlays)),
+    ):
+        yield
+
+
+def _seed(
+    name: str, overlay: str, *, enabled: bool = True, delay_seconds: int = 60, last_run_at: dt.datetime | None = None
+) -> None:
+    Loop.objects.create(
+        name=name,
+        script=f"src/teatree/loops/{name}/loop.py",
+        delay_seconds=delay_seconds,
+        overlay=overlay,
+        enabled=enabled,
+        last_run_at=last_run_at,
+    )
+
+
+class TestRunLoopConnectorPreflight(TestCase):
+    def test_clean_own_overlay_returns_none(self) -> None:
+        _seed("inbox", overlay="alpha")
+        with _registered({"alpha": _CleanOverlay(), "beta": _SlackDownOverlay()}):
+            assert run_loop_connector_preflight("inbox") is None
+
+    def test_unrelated_down_overlay_does_not_systemexit(self) -> None:
+        _seed("inbox", overlay="alpha")
+        with _registered({"alpha": _CleanOverlay(), "beta": _SlackDownOverlay()}):
+            assert run_loop_connector_preflight("inbox") is None
+
+    def test_own_down_overlay_systemexits(self) -> None:
+        _seed("review", overlay="beta")
+        with _registered({"alpha": _CleanOverlay(), "beta": _SlackDownOverlay()}), pytest.raises(SystemExit) as excinfo:
+            run_loop_connector_preflight("review")
+        assert excinfo.value.code != 0
+        assert "beta" in str(excinfo.value)
+
+    def test_disabled_loop_skips_its_own_down_overlay(self) -> None:
+        _seed("review", overlay="beta", enabled=False)
+        with _registered({"beta": _SlackDownOverlay()}):
+            assert run_loop_connector_preflight("review") is None
+
+    def test_cooling_loop_not_due_skips_its_own_down_overlay(self) -> None:
+        _seed("review", overlay="beta", delay_seconds=3600, last_run_at=timezone.now())
+        with _registered({"beta": _SlackDownOverlay()}):
+            assert run_loop_connector_preflight("review") is None
+
+    def test_missing_loop_row_is_a_noop(self) -> None:
+        with _registered({"beta": _SlackDownOverlay()}):
+            assert run_loop_connector_preflight("does-not-exist") is None
+
+    def test_blank_overlay_single_install_preflights_the_one_overlay(self) -> None:
+        _seed("review", overlay="")
+        with _registered({"beta": _SlackDownOverlay()}), pytest.raises(SystemExit):
+            run_loop_connector_preflight("review")
+
+    def test_blank_overlay_multi_install_skips_when_ambient_unset(self) -> None:
+        _seed("review", overlay="")
+        with (
+            _registered({"alpha": _CleanOverlay(), "beta": _SlackDownOverlay()}),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            os.environ.pop("T3_OVERLAY_NAME", None)
+            assert run_loop_connector_preflight("review") is None
+
+    def test_unknown_overlay_name_skips_rather_than_probing_the_fleet(self) -> None:
+        _seed("review", overlay="ghost")
+        with _registered({"alpha": _CleanOverlay(), "beta": _SlackDownOverlay()}):
+            assert run_loop_connector_preflight("review") is None

--- a/tests/teatree_loops/test_connector_preflight.py
+++ b/tests/teatree_loops/test_connector_preflight.py
@@ -72,51 +72,51 @@ def _seed(
 
 class TestRunLoopConnectorPreflight(TestCase):
     def test_clean_own_overlay_returns_none(self) -> None:
-        _seed("inbox", overlay="alpha")
+        _seed("probe-alpha", overlay="alpha")
         with _registered({"alpha": _CleanOverlay(), "beta": _SlackDownOverlay()}):
-            assert run_loop_connector_preflight("inbox") is None
+            assert run_loop_connector_preflight("probe-alpha") is None
 
     def test_unrelated_down_overlay_does_not_systemexit(self) -> None:
-        _seed("inbox", overlay="alpha")
+        _seed("probe-alpha", overlay="alpha")
         with _registered({"alpha": _CleanOverlay(), "beta": _SlackDownOverlay()}):
-            assert run_loop_connector_preflight("inbox") is None
+            assert run_loop_connector_preflight("probe-alpha") is None
 
     def test_own_down_overlay_systemexits(self) -> None:
-        _seed("review", overlay="beta")
+        _seed("probe-beta", overlay="beta")
         with _registered({"alpha": _CleanOverlay(), "beta": _SlackDownOverlay()}), pytest.raises(SystemExit) as excinfo:
-            run_loop_connector_preflight("review")
+            run_loop_connector_preflight("probe-beta")
         assert excinfo.value.code != 0
         assert "beta" in str(excinfo.value)
 
     def test_disabled_loop_skips_its_own_down_overlay(self) -> None:
-        _seed("review", overlay="beta", enabled=False)
+        _seed("probe-beta", overlay="beta", enabled=False)
         with _registered({"beta": _SlackDownOverlay()}):
-            assert run_loop_connector_preflight("review") is None
+            assert run_loop_connector_preflight("probe-beta") is None
 
     def test_cooling_loop_not_due_skips_its_own_down_overlay(self) -> None:
-        _seed("review", overlay="beta", delay_seconds=3600, last_run_at=timezone.now())
+        _seed("probe-beta", overlay="beta", delay_seconds=3600, last_run_at=timezone.now())
         with _registered({"beta": _SlackDownOverlay()}):
-            assert run_loop_connector_preflight("review") is None
+            assert run_loop_connector_preflight("probe-beta") is None
 
     def test_missing_loop_row_is_a_noop(self) -> None:
         with _registered({"beta": _SlackDownOverlay()}):
             assert run_loop_connector_preflight("does-not-exist") is None
 
     def test_blank_overlay_single_install_preflights_the_one_overlay(self) -> None:
-        _seed("review", overlay="")
+        _seed("probe-beta", overlay="")
         with _registered({"beta": _SlackDownOverlay()}), pytest.raises(SystemExit):
-            run_loop_connector_preflight("review")
+            run_loop_connector_preflight("probe-beta")
 
     def test_blank_overlay_multi_install_skips_when_ambient_unset(self) -> None:
-        _seed("review", overlay="")
+        _seed("probe-beta", overlay="")
         with (
             _registered({"alpha": _CleanOverlay(), "beta": _SlackDownOverlay()}),
             patch.dict(os.environ, {}, clear=False),
         ):
             os.environ.pop("T3_OVERLAY_NAME", None)
-            assert run_loop_connector_preflight("review") is None
+            assert run_loop_connector_preflight("probe-beta") is None
 
     def test_unknown_overlay_name_skips_rather_than_probing_the_fleet(self) -> None:
-        _seed("review", overlay="ghost")
+        _seed("probe-beta", overlay="ghost")
         with _registered({"alpha": _CleanOverlay(), "beta": _SlackDownOverlay()}):
-            assert run_loop_connector_preflight("review") is None
+            assert run_loop_connector_preflight("probe-beta") is None


### PR DESCRIPTION
## Summary

A per-loop tick fires `t3 loops tick --loop <name>` with **no** `--overlay`, so `loops_tick` ran the fleet-wide `run_connector_preflight("")` — probing **every** registered overlay — at the very top of `handle`, before the enabled/due gate. A single overlay's connector outage (Slack `missing_scope`, Notion unreachable) raised `RuntimeError` then `SystemExit`, killing an **unrelated** loop's tick. One outage took the whole fleet of per-loop loops down, violating per-loop isolation (#1192).

The fix narrows the per-loop path to the loop's own overlay and gates it on the loop actually running. The master/full-fleet path is unchanged.

- New `teatree.loops.connector_preflight.run_loop_connector_preflight(name)` preflights **only** the loop's overlay (derived from `Loop.overlay`, canonicalized up via `resolve_overlay_name`), and self-gates on the canonical `loop_enabled` verdict + `is_due` so a disabled/cooling loop preflights nothing.
- A blank `Loop.overlay` resolves to the single overlay on a single-overlay install (preserving the original fail-loud gate) or to the ambient `T3_OVERLAY_NAME`; anything unresolvable preflights nothing rather than falling back to the fleet.
- `loops_tick` routes the per-loop path to it; the master path keeps `run_connector_preflight(overlay)` unchanged, still gating every overlay before fan-out.
- A loop's **own** connector being down still fails loud (`SystemExit`) for that loop.

## RED-before / GREEN-after

The behavioral tests in `tests/teatree_core/test_loops_tick_command.py::TestPerLoopConnectorIsolation` go through the real `call_command("loops_tick", loop=...)` entrypoint and were observed RED on the unmodified code:

```
FAILED ...TestPerLoopConnectorIsolation::test_disabled_loop_on_down_overlay_does_not_systemexit - SystemExit
FAILED ...TestPerLoopConnectorIsolation::test_unrelated_overlay_outage_does_not_systemexit_per_loop_tick - SystemExit
2 failed, 1 passed
```

The 1 passing pre-fix is `test_loop_on_own_down_overlay_still_systemexits` (the over-correction guard — own outage must still fail loud, both before and after). After the fix all three are GREEN, plus the function-level suite `tests/teatree_loops/test_connector_preflight.py` (9 cases). Full affected-area regression: **751 passed**.

## Gates

- `uv run ruff check` + `ruff format --check`: clean.
- `uv run tach check`: `All modules validated!` (no new backwards edge — the wrapper is in the orchestration `teatree.loops` layer, calling down into core; core stays a pure leaf).
- `tests/quality/test_intra_core_deferred_import_ratchet.py`: passes — ratchet unchanged at 183 (the new module is in `teatree.loops`, and the loops_tick deferred import targets `teatree.loops`, not `teatree.core`).
- New + existing connector-preflight / loops-tick tests: green.

## Architecture pre-check — LOOP-PR-C

### 1. BLUEPRINT § alignment
§5.6 Loop Topology / the #2650 per-loop tick primitive + the §17.1 resilience invariant (per-loop isolation, #1192). This restores the existing topology's isolation guarantee; no new section. The BLUEPRINT-sync gate confirmed no doc drift.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition. The `Loop.last_run_at` cadence-anchor CAS is untouched (the preflight runs before it).

### 3. Extension-point contracts
Consumes the existing `OverlayBase.get_connector_preflight()` hook only (read through the unchanged `run_connector_preflight`). The ABC contract is unchanged, so no registered overlay needs updating.

### 4. Component boundaries
The loop-scoped wrapper lives in `teatree.loops` (orchestration — owns the DB-`Loop` fan-out concerns); it calls down into `teatree.core.connector_preflight` (the per-overlay engine, unchanged). `loops_tick` (command layer) routes per-loop vs master. No straddle.

### 5. Dependency direction
`teatree.loops` → `teatree.core.connector_preflight` / `teatree.core.overlay_loader` / `teatree.core.models` (down) + `teatree.loop.loop_state_db` (a declared dep). No backwards edge; core gains no edge into loops. `uv run tach check` = `All modules validated!`. Intra-core deferred-import ratchet unchanged (183).

### 6. Test surface
- `tests/teatree_loops/test_connector_preflight.py` — `run_loop_connector_preflight`: clean/unrelated overlay no `SystemExit`; own down overlay `SystemExit` naming it; disabled + not-due skip; missing row no-op; blank-overlay single-vs-multi resolution; unknown overlay skips (no fleet fallback).
- `tests/teatree_core/test_loops_tick_command.py::TestPerLoopConnectorIsolation` — behavioral, via `call_command`: unrelated outage no `SystemExit` (RED-before), disabled loop on down overlay no `SystemExit` (RED-before), own down overlay still `SystemExit`s (guard).

### 7. Resilience invariants (#1192)
This is a resilience fix; the gate's probe is a read-only connector check (no external write).
- verify-by-re-read / heartbeat / sub-agent return contract: n/a (no write, no long-running work, no sub-agent).
- fallback-transport: the resilient default — an unresolvable overlay preflights nothing and the loop proceeds, rather than taking the fleet down.
- idempotency: the preflight is a pure probe — a no-op on success, deterministic `SystemExit` on a real outage; re-running is identical.
- Invariant restored: one overlay's outage no longer `SystemExit`s an unrelated per-loop tick.

### 8. Identity and key normalization
`Loop.overlay` is the under-qualified form; it is canonicalized **up** to its registered overlay name via the single source-of-truth `resolve_overlay_name` — no `split`/`strip`/`removeprefix` to force a match. A blank overlay is special-cased explicitly (single-install one overlay, or ambient `T3_OVERLAY_NAME`), never silently folded into "all overlays".

### 9. Behavior preservation / capability deletion
`run_connector_preflight` is **untouched**, so every fleet behavior is preserved: blank name → all overlays; named → that one; unknown name → no-op; `SystemExit` naming the connector on the first `RuntimeError`; clean run → `None`. `loops_tick`'s master path still calls it before fan-out (the fleet preflight is **not** dropped). The only changed surface is the per-loop path, previously `run_connector_preflight("")` (all overlays, before the enabled/due gate); now `run_loop_connector_preflight(loop)` — scoped + gated. Justified changes: (a) an unrelated overlay outage no longer kills the loop (the bug); (b) a disabled/cooling loop no longer preflights (requirement); (c) a loop's own outage still `SystemExit`s (preserved, guarded by `test_loop_on_own_down_overlay_still_systemexits`). No must-block test inverted to must-not-block; no privacy/security matcher narrowed.
