### PR TITLE
fix(worktree): pk-key compose_project + fail-loud guard (WT-PR-D follow-up to #2774)

### DIFF
--- a/src/teatree/core/migrations/0010_worktree_compose_project.py
+++ b/src/teatree/core/migrations/0010_worktree_compose_project.py
@@ -1,0 +1,47 @@
+import re
+
+from django.db import migrations, models
+
+
+def _ticket_number(issue_url: str, pk: int) -> str:
+    match = re.search(r"(\d+)$", issue_url or "")
+    if match and match.group(1) != "0":
+        return match.group(1)
+    return str(pk)
+
+
+def backfill_compose_project(apps, schema_editor):
+    """Freeze each existing worktree's compose project at its RUNNING stack name.
+
+    Before this field, ``compose_project`` was derived live as
+    ``<repo_path>-wt<ticket_number>`` — the name every already-running docker
+    stack carries. Storing it verbatim means the pk-scheme cutover applies only
+    to NEW worktrees: an existing stack is never renamed and so never orphaned
+    (the live-stack-compat concern #2774 deferred). An explicit value is left
+    untouched.
+    """
+    worktree_model = apps.get_model("core", "Worktree")
+    for wt in worktree_model.objects.filter(compose_project="").select_related("ticket").iterator():
+        ticket = wt.ticket
+        number = _ticket_number(ticket.issue_url, ticket.pk)
+        wt.compose_project = f"{wt.repo_path}-wt{number}"
+        wt.save(update_fields=["compose_project"])
+
+
+def noop_reverse(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0009_seed_loop_descriptions"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="worktree",
+            name="compose_project",
+            field=models.CharField(blank=True, default="", max_length=255),
+        ),
+        migrations.RunPython(backfill_compose_project, noop_reverse),
+    ]

--- a/src/teatree/core/migrations/max_migration.txt
+++ b/src/teatree/core/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0009_seed_loop_descriptions
+0010_worktree_compose_project

--- a/src/teatree/core/models/worktree.py
+++ b/src/teatree/core/models/worktree.py
@@ -19,6 +19,16 @@ class WorktreeDbNameConflictError(RuntimeError):
     """
 
 
+class WorktreeComposeProjectConflictError(RuntimeError):
+    """Raised when another live worktree of a different ticket owns a computed compose project.
+
+    ``compose_project`` is frozen on the immutable, unique Ticket pk so a
+    collision cannot arise through the normal flow; this guards a hand-built,
+    legacy, or backfilled row from bringing a docker stack up under a name
+    another live worktree already runs (a clobber at ``docker compose up``).
+    """
+
+
 class Worktree(models.Model):
     class State(models.TextChoices):
         CREATED = "created", "Created"
@@ -36,6 +46,11 @@ class Worktree(models.Model):
     branch = models.CharField(max_length=255)
     state = FSMField(max_length=32, choices=State.choices, default=State.CREATED)
     db_name = models.CharField(max_length=255, blank=True)
+    # Frozen docker-compose project name (``<repo_path>-wt<ticket.pk>``). Set once
+    # at provision time and never rewritten — renaming it would orphan a running
+    # stack's containers. Empty before provisioning; resolved (stored-or-derived)
+    # through ``worktree_env.compose_project``.
+    compose_project = models.CharField(max_length=255, blank=True, default="")
     extra = models.JSONField(default=dict, blank=True)
     # #2190 Activity-recency signal for the idle-stack reaper. Stamped on
     # ``start_services``/``verify``/``db_refresh`` (the operator-driven
@@ -105,6 +120,12 @@ class Worktree(models.Model):
         name — the body stays free of the worktree-tasks up-edge (#2385).
         """
         self.db_name = self._build_db_name()
+        # STICKY (unlike db_name, which is recomputed every provision): set the
+        # compose project once and keep it for the worktree's life. An orphaned
+        # db is reaped scheme-agnostically, but renaming a compose project would
+        # orphan a RUNNING stack's containers — so a worktree keeps the name its
+        # stack was first brought up under.
+        self.compose_project = self.compose_project or self._build_compose_project()
 
     @transition(field=state, source=[State.PROVISIONED, State.SERVICES_UP, State.READY], target=State.SERVICES_UP)
     def start_services(self, *, services: list[str] | None = None) -> None:
@@ -237,6 +258,40 @@ class Worktree(models.Model):
                 f"(#{conflict.pk}); refusing db_import for worktree #{self.pk} to avoid clobber."
             )
             raise WorktreeDbNameConflictError(msg)
+
+    def _build_compose_project(self) -> str:
+        ticket = cast("Ticket", self.ticket)
+        # Keyed on the immutable, unique Ticket pk (not the derived, non-unique
+        # ``ticket_number``): two tickets sharing a trailing issue number must
+        # never collide on one docker stack. Per-repo (NOT ticket-scoped) — each
+        # repo runs its own compose project, unlike the ticket-shared db_name.
+        return f"{self.repo_path}-wt{ticket.pk}"
+
+    def assert_compose_project_unclaimed(self) -> None:
+        """Fail loud if another LIVE worktree of a DIFFERENT ticket owns ``compose_project``.
+
+        Defense-in-depth guard ``worktree start`` calls before ``docker compose up``:
+        ``compose_project`` is ticket-pk-keyed so a collision cannot arise through
+        the normal flow, but a hand-built, legacy, or backfilled row could still
+        bring a stack up under a name another live worktree already runs — clobbering
+        it. CREATED rows own no stack yet and are excluded.
+        """
+        if not self.compose_project:
+            return
+        ticket_pk = self.ticket_id  # ty: ignore[unresolved-attribute]  # Django FK accessor
+        conflict = (
+            Worktree.objects.exclude(pk=self.pk)
+            .exclude(ticket_id=ticket_pk)
+            .exclude(state=Worktree.State.CREATED)
+            .filter(compose_project=self.compose_project)
+            .first()
+        )
+        if conflict is not None:
+            msg = (
+                f"compose project {self.compose_project!r} is owned by another live worktree "
+                f"(#{conflict.pk}); refusing docker compose up for worktree #{self.pk} to avoid clobber."
+            )
+            raise WorktreeComposeProjectConflictError(msg)
 
     def get_extra(self) -> WorktreeExtra:
         return validated_worktree_extra(self.extra)

--- a/src/teatree/core/runners/worktree_start.py
+++ b/src/teatree/core/runners/worktree_start.py
@@ -75,6 +75,10 @@ class WorktreeStartRunner(RunnerBase):
     def run(self) -> RunnerResult:
         worktree = self.worktree
         overlay = self.overlay
+        # Fail loud BEFORE any docker call: if another live, foreign-ticket worktree
+        # already owns this compose project, the `down` below would tear down ITS
+        # running stack — never clobber a foreign stack (#2774 follow-up).
+        worktree.assert_compose_project_unclaimed()
         project = compose_project(worktree)
 
         docker_compose_down(project, timeout=self.timeouts.get(DOCKER_COMPOSE_DOWN))

--- a/src/teatree/core/worktree_env.py
+++ b/src/teatree/core/worktree_env.py
@@ -57,13 +57,24 @@ class EnvCacheSpec:
 def compose_project(worktree: Worktree) -> str:
     """Return the docker-compose project name for *worktree*.
 
-    The single source of truth for the ``<repo_path>-wt<ticket_number>``
-    qualified key. Every consumer (the env cache, the stack gate, the
-    reconciler, the start/cleanup runners, the CLI) resolves through here
-    so the naming scheme can never drift across call sites.
+    Single source of truth for the project key — every consumer (the env cache,
+    the stack gate, the reconciler, the start/cleanup runners, the CLI) resolves
+    through here so the naming scheme can never drift across call sites.
+
+    For a provisioned worktree the name is FROZEN on the immutable, unique
+    ``Ticket.pk`` (``<repo_path>-wt<ticket.pk>``) and stored on
+    ``Worktree.compose_project``, so two tickets sharing a trailing issue number
+    never collide on one docker stack (the deferred half of #2774). The stored
+    value is returned verbatim so a running stack's name never changes under it
+    (a rename orphans its containers). Falls back to a live
+    ``<repo_path>-wt<ticket.pk>`` derivation for a ticketless probe or an
+    unprovisioned row that has no stored name yet.
     """
-    ticket = worktree.ticket
-    return f"{worktree.repo_path}-wt{ticket.ticket_number}" if ticket else worktree.repo_path
+    stored = getattr(worktree, "compose_project", "")
+    if stored:
+        return stored
+    ticket = getattr(worktree, "ticket", None)
+    return f"{worktree.repo_path}-wt{ticket.pk}" if ticket else worktree.repo_path
 
 
 def _docker_host_address() -> str:

--- a/tests/teatree_core/cleanup/test_cleanup_worktree.py
+++ b/tests/teatree_core/cleanup/test_cleanup_worktree.py
@@ -124,7 +124,7 @@ class TestCleanupWorktree(TestCase):
         wt = self._make_worktree(wt_path="/tmp/wt/org/repo")
         with patch("teatree.core.runners.worktree_start.docker_compose_down") as mock_down:
             cleanup_worktree(wt)
-        # The compose project name follows `{repo_path}-wt{ticket_number}`.
+        # The compose project name follows `{repo_path}-wt{ticket.pk}`.
         ((project,), _kwargs) = mock_down.call_args
         assert project.startswith("org/repo-wt")
 

--- a/tests/teatree_core/management_commands/test_e2e.py
+++ b/tests/teatree_core/management_commands/test_e2e.py
@@ -650,7 +650,7 @@ class TestE2eExternal(TestCase):
                 result = cast("str", call_command("e2e", "external", target="local"))
             assert "passed" in result
             env = mock_run.call_args[1]["env"]
-            assert env["COMPOSE_PROJECT_NAME"] == f"backend-wt{ticket.ticket_number}"
+            assert env["COMPOSE_PROJECT_NAME"] == f"backend-wt{ticket.pk}"
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -757,7 +757,7 @@ class TestE2eExternal(TestCase):
             assert env["BASE_URL"] == "http://localhost:62674"
             # COMPOSE_PROJECT_NAME points at the backend worktree's project,
             # not the e2e cache worktree's.
-            assert env["COMPOSE_PROJECT_NAME"] == f"backend-repo-wt{backend_ticket.ticket_number}"
+            assert env["COMPOSE_PROJECT_NAME"] == f"backend-repo-wt{backend_ticket.pk}"
             # Defect 2: the env-cache that feeds get_e2e_env_extras must be
             # the linked backend worktree's, so overlay-derived extras (e.g.
             # CUSTOMER=<variant>) reach the spec.
@@ -824,7 +824,7 @@ class TestE2eExternal(TestCase):
             assert "passed" in result
             env = mock_run.call_args[1]["env"]
             assert env["BASE_URL"] == "http://localhost:4202"
-            assert env["COMPOSE_PROJECT_NAME"] == f"backend-repo-wt{backend_ticket.ticket_number}"
+            assert env["COMPOSE_PROJECT_NAME"] == f"backend-repo-wt{backend_ticket.pk}"
             assert env["CUSTOMER"] == "acme"
 
     @_patch_overlays(FULL_OVERLAY)

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -3079,6 +3079,7 @@ def _make_squash_merged_worktree(tmp: Path, *, overlay: str = "test", ticket_num
         repo_path="backend",
         branch="feature",
         db_name=f"wt_test_{ticket_number}",
+        compose_project=f"backend-wt{ticket_number}",
         state=Worktree.State.PROVISIONED,
         extra={"clone_path": str(work), "worktree_path": str(wt_path)},
     )

--- a/tests/teatree_core/models/test_worktree.py
+++ b/tests/teatree_core/models/test_worktree.py
@@ -6,6 +6,7 @@ import pytest
 from django.test import TestCase
 
 from teatree.core.models import Ticket, Worktree
+from teatree.core.worktree_env import compose_project
 
 
 class TestWorktreeTransitionSignals(TestCase):
@@ -258,3 +259,131 @@ class TestAssertDbNameUnclaimed(TestCase):
         )
 
         wt_b.assert_db_name_unclaimed()  # CREATED row owns no DB → no conflict
+
+
+class TestWorktreeComposeProjectIsIdentityScoped(TestCase):
+    """The docker compose project keys on the unique Ticket pk (#2774 follow-up).
+
+    ``ticket_number`` is a DERIVED, non-unique key, so two tickets on different
+    repos/forges can share one and collide on a single docker stack
+    (``COMPOSE_PROJECT_NAME``). Keying the project name on the immutable Ticket
+    pk — frozen on the row at provision time so a running stack is never renamed
+    out from under its containers — makes a cross-ticket clobber impossible. A
+    ticket's sibling repos each get their OWN stack (distinct ``repo_path``),
+    unlike the ticket-shared db_name.
+    """
+
+    def test_compose_project_keyed_on_ticket_pk_not_ticket_number(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://a.example.com/x/issues/5")
+        worktree = Worktree.objects.create(ticket=ticket, repo_path="backend", branch="5-x")
+        worktree.provision()
+        worktree.save()
+
+        assert worktree.compose_project == f"backend-wt{ticket.pk}"
+        assert worktree.compose_project != "backend-wt5"
+
+    def test_two_tickets_sharing_trailing_number_get_distinct_compose_projects(self) -> None:
+        ticket_a = Ticket.objects.create(issue_url="https://a.example.com/x/issues/5")
+        ticket_b = Ticket.objects.create(issue_url="https://b.example.com/y/issues/5")
+        wt_a = Worktree.objects.create(ticket=ticket_a, repo_path="backend", branch="5-a")
+        wt_b = Worktree.objects.create(ticket=ticket_b, repo_path="backend", branch="5-b")
+        wt_a.provision()
+        wt_a.save()
+        wt_b.provision()
+        wt_b.save()
+
+        assert compose_project(wt_a) != compose_project(wt_b)
+
+    def test_sibling_repos_of_one_ticket_get_distinct_compose_projects(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://a.example.com/x/issues/5")
+        backend = Worktree.objects.create(ticket=ticket, repo_path="backend", branch="5-x")
+        frontend = Worktree.objects.create(ticket=ticket, repo_path="frontend", branch="5-x")
+        backend.provision()
+        backend.save()
+        frontend.provision()
+        frontend.save()
+
+        assert backend.compose_project != frontend.compose_project
+
+    def test_provision_does_not_rename_an_already_stored_project(self) -> None:
+        # Sticky: a worktree whose compose project was set under a previous scheme
+        # (e.g. backfilled to its running stack's name) keeps that name across
+        # re-provision — renaming it would orphan its live containers.
+        ticket = Ticket.objects.create(issue_url="https://a.example.com/x/issues/5")
+        worktree = Worktree.objects.create(
+            ticket=ticket, repo_path="backend", branch="5-x", compose_project="backend-wt5"
+        )
+        worktree.provision()
+        worktree.save()
+
+        assert worktree.compose_project == "backend-wt5"
+
+
+class TestAssertComposeProjectUnclaimed(TestCase):
+    """``worktree start`` must refuse a compose project a foreign live worktree owns."""
+
+    def test_raises_when_another_live_different_ticket_owns_compose_project(self) -> None:
+        from teatree.core.models.worktree import WorktreeComposeProjectConflictError  # noqa: PLC0415
+
+        ticket_a = Ticket.objects.create(issue_url="https://a.example.com/x/issues/1")
+        ticket_b = Ticket.objects.create(issue_url="https://b.example.com/y/issues/2")
+        Worktree.objects.create(
+            ticket=ticket_a,
+            repo_path="backend",
+            branch="1-x",
+            compose_project="backend-wt-shared",
+            state=Worktree.State.SERVICES_UP,
+        )
+        wt_b = Worktree.objects.create(
+            ticket=ticket_b,
+            repo_path="backend",
+            branch="2-x",
+            compose_project="backend-wt-shared",
+            state=Worktree.State.PROVISIONED,
+        )
+
+        with pytest.raises(WorktreeComposeProjectConflictError):
+            wt_b.assert_compose_project_unclaimed()
+
+    def test_noop_when_compose_project_is_unique(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://a.example.com/x/issues/1")
+        worktree = Worktree.objects.create(
+            ticket=ticket,
+            repo_path="backend",
+            branch="1-x",
+            compose_project="backend-wt-unique",
+            state=Worktree.State.PROVISIONED,
+        )
+
+        worktree.assert_compose_project_unclaimed()  # no raise
+
+    def test_noop_when_compose_project_unset(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://a.example.com/x/issues/1")
+        worktree = Worktree.objects.create(
+            ticket=ticket,
+            repo_path="backend",
+            branch="1-x",
+            state=Worktree.State.CREATED,
+        )
+
+        worktree.assert_compose_project_unclaimed()  # empty project → nothing to claim
+
+    def test_ignores_created_state_row_that_owns_no_stack_yet(self) -> None:
+        ticket_a = Ticket.objects.create(issue_url="https://a.example.com/x/issues/1")
+        ticket_b = Ticket.objects.create(issue_url="https://b.example.com/y/issues/2")
+        Worktree.objects.create(
+            ticket=ticket_a,
+            repo_path="backend",
+            branch="1-x",
+            compose_project="backend-wt-shared",
+            state=Worktree.State.CREATED,
+        )
+        wt_b = Worktree.objects.create(
+            ticket=ticket_b,
+            repo_path="backend",
+            branch="2-x",
+            compose_project="backend-wt-shared",
+            state=Worktree.State.PROVISIONED,
+        )
+
+        wt_b.assert_compose_project_unclaimed()  # CREATED row owns no stack → no conflict

--- a/tests/teatree_core/test_compose_project_dry.py
+++ b/tests/teatree_core/test_compose_project_dry.py
@@ -1,6 +1,6 @@
 """Every compose-project name derives through one helper (Follow-ups from #1998).
 
-The docker-compose project name ``<repo_path>-wt<ticket_number>`` was
+The docker-compose project name ``<repo_path>-wt<ticket.pk>`` was
 re-derived inline in several core modules (the stack gate, the env cache,
 the reconciler) instead of resolving through the single
 ``compose_project`` helper. A duplicated derivation drifts silently — a
@@ -47,7 +47,7 @@ def _make_worktree(*, ticket_number: str, repo_path: str = "backend") -> Worktre
 class TestComposeProjectSingleSource(TestCase):
     def test_helper_qualifies_repo_and_ticket(self) -> None:
         wt = _make_worktree(ticket_number="9001", repo_path="frontend")
-        assert compose_project(wt) == "frontend-wt9001"
+        assert compose_project(wt) == f"frontend-wt{wt.ticket.pk}"
 
     def test_helper_falls_back_to_repo_path_without_ticket(self) -> None:
         wt = _TicketlessWorktree(repo_path="backend")

--- a/tests/teatree_core/test_e2e_frontend_discovery.py
+++ b/tests/teatree_core/test_e2e_frontend_discovery.py
@@ -20,14 +20,14 @@ class TicketFrontendProjectsTests(TestCase):
         # compose project, never the sibling app worktree hosting the frontend.
         projects = _ticket_frontend_projects(self.test_repo_wt)
 
-        assert projects[0] == "e2e-tests-wt147"
-        assert "webapp-wt147" in projects
+        assert projects[0] == f"e2e-tests-wt{self.ticket.pk}"
+        assert f"webapp-wt{self.ticket.pk}" in projects
 
     def test_resolved_worktree_is_probed_first(self) -> None:
         projects = _ticket_frontend_projects(self.app_repo_wt)
 
-        assert projects[0] == "webapp-wt147"
-        assert "e2e-tests-wt147" in projects
+        assert projects[0] == f"webapp-wt{self.ticket.pk}"
+        assert f"e2e-tests-wt{self.ticket.pk}" in projects
 
     def test_no_duplicate_projects(self) -> None:
         projects = _ticket_frontend_projects(self.test_repo_wt)
@@ -65,7 +65,7 @@ class TicketFrontendProjectsTests(TestCase):
 
         assert compose_project(backend_wt) in projects
         # The resolved-worktree ticket's siblings are bypassed when a link is given.
-        assert "webapp-wt147" not in projects
+        assert f"webapp-wt{self.ticket.pk}" not in projects
 
 
 class ResolveLinkedWorktreeTests(TestCase):

--- a/tests/teatree_core/test_migration_backfill_compose_project.py
+++ b/tests/teatree_core/test_migration_backfill_compose_project.py
@@ -1,0 +1,48 @@
+"""Regression test for ``core.0010_worktree_compose_project``.
+
+A worktree provisioned before ``compose_project`` was stored has a blank
+project; deriving it live under the new pk scheme would rename the running
+docker stack out from under its containers (the #2774-deferred orphan risk).
+The migration freezes each existing worktree's project at the name its stack
+already runs under (``<repo_path>-wt<ticket_number>``), so the cutover never
+orphans a live stack. New worktrees adopt the pk scheme at provision time.
+"""
+
+import importlib
+
+from django.apps import apps
+from django.db import connection
+from django.test import TestCase
+
+from teatree.core.models import Ticket, Worktree
+
+_migration = importlib.import_module("teatree.core.migrations.0010_worktree_compose_project")
+
+
+class BackfillComposeProjectTest(TestCase):
+    def test_blank_project_backfilled_to_running_ticket_number_scheme(self) -> None:
+        ticket = Ticket.objects.create(overlay="acme", issue_url="https://example.com/issues/42")
+        wt = Worktree.objects.create(ticket=ticket, repo_path="backend", branch="42-x")
+
+        _migration.backfill_compose_project(apps, connection.schema_editor())
+
+        wt.refresh_from_db()
+        assert wt.compose_project == "backend-wt42"
+
+    def test_does_not_overwrite_an_explicit_project(self) -> None:
+        ticket = Ticket.objects.create(overlay="acme", issue_url="https://example.com/issues/42")
+        wt = Worktree.objects.create(ticket=ticket, repo_path="backend", branch="42-x", compose_project="custom-name")
+
+        _migration.backfill_compose_project(apps, connection.schema_editor())
+
+        wt.refresh_from_db()
+        assert wt.compose_project == "custom-name"
+
+    def test_no_trailing_number_falls_back_to_pk(self) -> None:
+        ticket = Ticket.objects.create(overlay="acme", issue_url="dogfood-smoke://acme")
+        wt = Worktree.objects.create(ticket=ticket, repo_path="backend", branch="x")
+
+        _migration.backfill_compose_project(apps, connection.schema_editor())
+
+        wt.refresh_from_db()
+        assert wt.compose_project == f"backend-wt{ticket.pk}"

--- a/tests/test_contrib_overlay.py
+++ b/tests/test_contrib_overlay.py
@@ -438,19 +438,21 @@ class TestReapWorktreeExternalResources(TestCase):
         return Worktree.objects.create(ticket=ticket, overlay="t3-teatree", repo_path="teatree", branch="1523-x")
 
     def test_reaps_the_worktree_compose_project(self) -> None:
+        from teatree.core.worktree_env import compose_project  # noqa: PLC0415
         from teatree.docker.reap import ReapResult  # noqa: PLC0415
 
         worktree = self._worktree()
+        project = compose_project(worktree)
         with patch.object(
             overlay_mod,
             "reap_compose_project",
-            return_value=ReapResult(project="teatree-wt1523", containers_removed=2, images_removed=1),
+            return_value=ReapResult(project=project, containers_removed=2, images_removed=1),
         ) as mock_reap:
             outcomes = TeatreeOverlay().reap_worktree_external_resources(worktree)
 
-        mock_reap.assert_called_once_with("teatree-wt1523")
+        mock_reap.assert_called_once_with(project)
         assert len(outcomes) == 1
-        assert "teatree-wt1523" in outcomes[0]
+        assert project in outcomes[0]
 
     def test_returns_empty_when_nothing_to_reap(self) -> None:
         from teatree.docker.reap import ReapResult  # noqa: PLC0415

--- a/tests/test_max_concurrent_local_stacks.py
+++ b/tests/test_max_concurrent_local_stacks.py
@@ -26,6 +26,7 @@ from teatree.config import get_effective_settings, load_config
 from teatree.core.gates import local_stack_gate as gate_mod
 from teatree.core.gates.local_stack_gate import LocalStackLimitExceededError, check_local_stack_limit
 from teatree.core.models import ConfigSetting, Ticket, Worktree
+from teatree.core.worktree_env import compose_project
 
 
 @pytest.fixture(autouse=True)
@@ -446,8 +447,10 @@ class TestLocalStackGateDockerReconciliation(TestCase):
             state=Worktree.State.PROVISIONED,
         )
 
+        phantom_project = compose_project(phantom)
+
         def counts(project: str) -> int:
-            return 0 if "wt7040" in project else 1
+            return 0 if project == phantom_project else 1
 
         with (
             patch.object(gate_mod, "_running_container_count", side_effect=counts),


### PR DESCRIPTION
## Summary

[#2774](https://github.com/souliane/teatree/pull/2774) canonicalized worktree/ticket identity onto the immutable `Ticket.pk` for `db_name` + `pass_key` and made collisions fail loud, but **explicitly deferred `compose_project`** (its own arch pre-check #8 says so). `compose_project` in `worktree_env.py` was still derived from the mutable, non-unique `ticket_number` (trailing issue digits) — so two tickets sharing a trailing issue number on different repos/forges resolved to one `COMPOSE_PROJECT_NAME` and could silently share/clobber a single docker stack.

This finishes WT-PR-D for the docker stack, mirroring #2774's exact pattern.

### Changes
- `compose_project` is keyed on `Ticket.pk` (`<repo_path>-wt<ticket.pk>`), **stored** on a new `Worktree.compose_project` field and set **sticky** at provision time (set once, never rewritten).
- `assert_compose_project_unclaimed()` fail-loud guard (analogous to `assert_db_name_unclaimed`), called by the start runner **before** the compose down/up step so a collision never tears down a foreign stack.
- Migration `0010` adds the field and **backfills every existing row to its current running stack name** (`<repo_path>-wt<ticket_number>`) — a non-orphaning cutover.
- Every stale `<repo_path>-wt<ticket_number>` reference (helper + test docstrings) and all `COMPOSE_PROJECT_NAME` assertions updated to the pk scheme.

## Architecture pre-check — WT-PR-D follow-up (#2774)

### 1. BLUEPRINT § alignment
§4 Domain Models (Worktree identity + FSM) and §6 Overlay System — the same sections #2774 cited. This hardens existing identity resolution; no contradiction and no new section. No BLUEPRINT change, **coherent with #2774**, which likewise kept this implementation-level identity hardening (db_name/pass_key pk-keying) out of BLUEPRINT.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition is added or moved. `compose_project` is set in the existing `Worktree.provision()` pure-transition body (right beside `db_name = self._build_db_name()`). The guard is invoked by the start RUNNER before the compose-up step, not inside a transition body.

### 3. Extension-point contracts
No `OverlayBase` hook signature changes. The only overlay consumer — `t3-teatree`'s `reap_worktree_external_resources` -> `reap_compose_project(compose_project(worktree))` — routes through the unchanged `compose_project` helper, so it adopts the new (stored) value automatically with no overlay code change. No registered overlay implements a compose-project hook.

### 4. Component boundaries
- `core/models/worktree.py` — fat-model identity: the `compose_project` field, `_build_compose_project`, `assert_compose_project_unclaimed`, `WorktreeComposeProjectConflictError` (invariant on the model that owns the data).
- `core/worktree_env.py` — the single-source-of-truth resolver (`compose_project`), now stored-or-derived.
- `core/runners/worktree_start.py` — coordination only: the guard call at the destructive write.
- `core/migrations/0010_worktree_compose_project.py` — AddField + backfill.

### 5. Dependency direction
No new imports anywhere. The model inlines the pk derivation (no `models -> worktree_env` edge); the helper reads the stored field via `getattr`. `uv run tach check` -> `All modules validated`. The intra-`teatree.core` deferred-import ratchet is **untouched at 183** (the migration uses `apps.get_model` + stdlib `re` only, no function-scoped `teatree.core` import).

### 6. Test surface
- `models/test_worktree.py::TestWorktreeComposeProjectIsIdentityScoped` — pk-keying; two-tickets-same-trailing-number get distinct projects (the bug, RED before); sibling repos get distinct projects; provision does not rename an already-stored project (stickiness/compat).
- `models/test_worktree.py::TestAssertComposeProjectUnclaimed` — raises on a foreign-ticket collision; no-op when unique; no-op when the field is unset; ignores CREATED rows.
- `test_migration_backfill_compose_project.py` — blank row backfilled to the running `ticket_number` name; explicit value untouched; no-trailing-number falls back to pk.
- `test_compose_project_dry.py` — the single-source-of-truth helper test, updated to the pk scheme.

### 7. Resilience invariants
The external write guarded here is the compose-up step (and the `down --remove-orphans` that precedes it). The guard is **fail-LOUD before the write**, never fail-open. **Idempotency**: provision is sticky (re-firing never rewrites the name), backfill only fills empty rows, and teardown leaves `compose_project` intact so the teardown worker tears down the correct stack. No new sub-agent / transport / heartbeat surface is introduced.

### 8. Identity and key normalization
The canonical, fully-qualified key for a worktree's docker stack is the **immutable, unique `Ticket.pk`** (per-repo: `<repo_path>-wt<ticket.pk>`), NOT the derived, non-unique `ticket_number`. One resolver (`compose_project`) normalizes every consumer UP to the stored canonical value at every boundary (env cache, stack gate, reconciler, start/cleanup runners, e2e discovery, CLI). No qualifier-stripping / `split`-to-match. This removes the **last** derived-non-unique resource key #2774 left on `ticket_number`.

### 9. Behavior preservation / capability deletion — live-stack compatibility
This is the concern that made #2774 defer the change. **`db_name` is read from a stored field, so it stays frozen until re-provision; `compose_project` was derived LIVE on every helper call — so flipping the scheme in place would instantly rename every already-running worktree's docker project and orphan its containers/volumes.**

Disposition (chose option (b): new key for newly-provisioned worktrees, guard catches collisions — the non-breaking coherent path):
- **Give `compose_project` the same frozen property** by storing it on the row and setting it **sticky** at provision time. A worktree keeps the exact name its stack was first brought up under, for life.
- **Migration `0010` backfills every existing row** to `<repo_path>-wt<ticket_number>` — the name its running stack already carries. So the pk scheme applies **only to newly-provisioned worktrees**; **no running stack is renamed or orphaned**.
- **The guard** catches the only residual risk (a NEW pk-scheme worktree whose `<repo>-wt<pk>` coincides with a backfilled `<repo>-wt<ticket_number>`): it fails loud at the compose-up step so the operator resolves it, rather than clobbering.
- **`teardown()` deliberately does NOT blank `compose_project`** (unlike `db_name`/`extra`) so the teardown worker resolves the correct stack name and never leaks the old containers.
- No privacy/security matcher is narrowed; no must-block test was inverted to must-not-block.

## Open questions & assumptions
- **Decided (option b over a):** a clean non-orphaning cutover IS possible via the stored-field + backfill, so option (a) (a migration that tears down / re-labels live stacks) is unnecessary and would be destructive to running stacks. No STOP / owner-decision needed.
- **Assumed (sticky, unlike db_name's recompute):** `compose_project` is set only when empty, a deliberate divergence from `db_name`'s unconditional recompute — renaming a compose project orphans a live stack, so it must never change once a stack exists. Documented inline.
- **Assumed (per-repo, not ticket-scoped):** each sibling repo gets its own stack (`backend-wt<pk>` vs `frontend-wt<pk>`), unlike the ticket-shared `db_name`. Matches the existing one-compose-project-per-repo behavior.

## Test evidence (RED-before / GREEN-after)
RED on `origin/main` (pre-fix), confirming the bug is genuine and the tests are anti-vacuous:
- `test_two_tickets_sharing_trailing_number_get_distinct_compose_projects` -> `AssertionError: assert 'backend-wt5' != 'backend-wt5'` (both tickets collide today).
- guard / identity / migration tests -> `AttributeError` / `TypeError` / `ImportError` (field, method, exception, migration absent).
- Guard anti-vacuity additionally proven by neutering the guard body -> `Failed: DID NOT RAISE`.

GREEN after the change. Gates: `uv run ruff check` + `ruff format --check` clean; `uv run tach check` passes; the deferred-import ratchet (183) passes unchanged; the compose-project + worktree-identity suites and the full sweep of compose-project consumers pass; `manage.py makemigrations --check` -> `No changes detected`.

Do NOT merge — opened for review per the task brief.
