### PR TITLE
refactor(dream): split gates.py by concern to restore module-health headroom

### DIFF
--- a/src/teatree/loops/dream/acceptance.py
+++ b/src/teatree/loops/dream/acceptance.py
@@ -1,0 +1,178 @@
+"""§4 acceptance-pass orchestration + persistence around the dream consolidation gates.
+
+The pure gate predicates and their domain types live in :mod:`gates` (snapshot in,
+verdict out, no DB). This module is the impure WIRING around them: it derives the
+probe corpus, reads the recorded prior-session baseline, computes the durable-home
+set from what decay archived, runs the seven gates via :func:`gates.evaluate_gates`,
+and persists each probe's replay outcome to :class:`teatree.core.models.DreamQaProbe`.
+
+Dependency direction is one-way — ``acceptance`` imports ``gates`` and ``decay``;
+neither imports it back (``decay`` still reaches a couple of gate helpers
+function-scoped, unchanged), so the split adds no import cycle.
+"""
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from teatree.loops.dream import decay
+from teatree.loops.dream.gates import (
+    ComplianceRemediationView,
+    DreamQaReport,
+    MemorySnapshot,
+    ProbeAnswerer,
+    QaProbe,
+    _line_targets,
+    _pass_rate,
+    derive_probes,
+    evaluate_gates,
+    probe_answerable,
+)
+
+if TYPE_CHECKING:
+    from teatree.loops.dream.decay import ArchivedMemory
+
+
+# ast-grep-ignore: ac-django-no-complexity-suppressions
+def run_acceptance_pass(  # noqa: PLR0913 — kwargs-only §4 pass inputs; the command's per-dir gate entry point.
+    snapshot_before: MemorySnapshot,
+    snapshot_after: MemorySnapshot,
+    *,
+    overlay: str,
+    archived: "Sequence[ArchivedMemory]",
+    schema_before: int,
+    schema_after: int,
+    clusters_recorded: int = 0,
+    maintenance_performed: bool = False,
+    persist: bool = True,
+    archive_dir: Path | None = None,
+    compliance_remediations: Sequence[ComplianceRemediationView] | None = None,
+) -> DreamQaReport:
+    """Run the §4 acceptance gates for one memory dir and persist the probe corpus.
+
+    Wiring entry point for the dream command (#2545): derives probes from the
+    BEFORE snapshot, reads the recorded prior-session pass-rate as the monotonicity
+    / interference baseline, computes the durable-home set for the consolidation
+    gate as the pruned index lines whose lesson is still findable in the AFTER
+    snapshot (transfer-before-prune) OR whose pointer targets a file in the durable
+    ``archive/`` cold store (*archive_dir*, this/prior pass, #2723), threads the caller's *maintenance_performed*
+    signal (file-side phases did real cross-link / re-index / decay work) into the
+    consolidation gate so a quiet 0-cluster maintenance pass still counts as
+    consolidation, runs all seven gates, and — unless *persist* is
+    off (dry-run) — records each probe's outcome to :class:`DreamQaProbe` (so the
+    formerly-dead model is populated and the next pass has a prior baseline).
+
+    *compliance_remediations* feeds gate (g); when not supplied it is read from the
+    persisted instruction-compliance records for *overlay* (#2663) so a recurrence
+    remediated with a memory FAILS the pass.
+    """
+    probes = derive_probes(snapshot_before)
+    prior_rate, had_prior = _prior_pass_rate(overlay)
+    now_rate = _pass_rate(probes, snapshot_after, None)
+    pruned_lines = snapshot_before.index_lines - snapshot_after.index_lines
+    homed_names = {a.source.name for a in archived} | decay.cold_archive_names(archive_dir)
+    homed_index_lines = {ln for ln in pruned_lines if snapshot_after.contains(ln) or _line_targets(ln, homed_names)}
+    remediations = compliance_remediations if compliance_remediations is not None else _compliance_remediations(overlay)
+    report = evaluate_gates(
+        snapshot_before=snapshot_before,
+        snapshot_after=snapshot_after,
+        schema_before=schema_before,
+        schema_after=schema_after,
+        homed_index_lines=homed_index_lines,
+        prior_pass_rate=prior_rate if had_prior else now_rate,
+        pass_rate_first=prior_rate if had_prior else now_rate,
+        pass_rate_second=now_rate,
+        archived=archived,
+        clusters_recorded=clusters_recorded,
+        maintenance_performed=maintenance_performed,
+        probes=probes,
+        compliance_remediations=remediations,
+    )
+    if persist:
+        persist_probe_results(probes, snapshot_after, overlay=overlay)
+    return report
+
+
+def persist_probe_results(
+    probes: Sequence[QaProbe],
+    snapshot: MemorySnapshot,
+    *,
+    overlay: str,
+    answerer: ProbeAnswerer | None = None,
+) -> int:
+    """Record each probe's replay outcome to the ``DreamQaProbe`` corpus, idempotently.
+
+    Idempotent on ``probe_key`` (sha256 of the question): a probe re-recorded on a
+    later run finds its existing row and ACCUMULATES pass/run counts via
+    :meth:`DreamQaProbe.record_result`, and is marked ``is_prior_session`` from the
+    second recording on (it now carries over from an earlier run). Returns the
+    number of probes that PASSED this replay.
+    """
+    from teatree.core.models import DreamQaProbe  # noqa: PLC0415
+
+    passed = 0
+    for probe in probes:
+        answerable = probe_answerable(probe, snapshot, answerer)
+        passed += int(answerable)
+        row, created = DreamQaProbe.objects.get_or_create(
+            probe_key=probe.probe_key,
+            defaults={
+                "question": probe.question,
+                "expected_answer": probe.expected_answer,
+                "source_memory_path": probe.source_name,
+                "overlay": overlay,
+            },
+        )
+        if not created and not row.is_prior_session:
+            row.is_prior_session = True
+            row.save(update_fields=["is_prior_session"])
+        row.record_result(passed=answerable)
+    return passed
+
+
+def _prior_pass_rate(overlay: str) -> tuple[float, bool]:
+    """Recorded prior-session pass-rate for *overlay* and whether a prior run exists.
+
+    Averages ``last_pass_rate`` over the persisted prior-session probes. A fresh
+    overlay (no prior probes) returns ``(1.0, False)`` — gate (b)/(e) cannot
+    regress against a non-existent baseline, so the first run is never failed by
+    interference/monotonicity.
+    """
+    from teatree.core.models import DreamQaProbe  # noqa: PLC0415
+
+    prior = list(DreamQaProbe.objects.prior_session_probes(overlay))
+    if not prior:
+        return 1.0, False
+    return sum(p.last_pass_rate for p in prior) / len(prior), True
+
+
+def _compliance_remediations(overlay: str) -> list[ComplianceRemediationView]:
+    """Build gate-(g) views from the latest persisted instruction-compliance records.
+
+    Reads the most recent :class:`InstructionComplianceSnapshot` for *overlay* and
+    maps each of its records to a :class:`ComplianceRemediationView`. A pass with no
+    snapshot yet returns no views — gate (g) then cleanly passes (nothing observed).
+    """
+    from teatree.core.models import (  # noqa: PLC0415
+        InstructionComplianceRecord,
+        InstructionComplianceSnapshot,
+        RemediationKind,
+    )
+
+    snapshot = InstructionComplianceSnapshot.objects.latest_for(overlay)
+    if snapshot is None:
+        return []
+    return [
+        ComplianceRemediationView(
+            rule_identity=record.rule_identity,
+            is_recurrence=record.is_recurrence,
+            remediated_with_memory=record.remediation == RemediationKind.MEMORY,
+        )
+        for record in InstructionComplianceRecord.objects.filter(snapshot=snapshot)
+    ]
+
+
+__all__ = [
+    "persist_probe_results",
+    "run_acceptance_pass",
+]

--- a/src/teatree/loops/dream/gates.py
+++ b/src/teatree/loops/dream/gates.py
@@ -34,15 +34,11 @@ still counts). This is the deterministic, LLM-free replay the gates run on; the
 answerer is injectable so a richer (LLM) answerer can replace it later without
 touching the gates.
 
-:func:`persist_probe_results` writes the corpus to the migrated-but-formerly-dead
-:class:`teatree.core.models.DreamQaProbe` (idempotent on ``probe_key``,
-accumulating pass/run counts and marking a re-recorded probe ``is_prior_session``)
-so the model is now live.
-
-PURE w.r.t. the real ``~/.claude``: every gate takes explicit snapshots; tests
-pass in-memory snapshots and a tmp archive dir. The command computes the
-before/after snapshots around the pass and surfaces a failing report by marking
-the run attempted-not-succeeded (staleness keeps firing).
+The impure WIRING around these gates — deriving the probe corpus, reading the
+prior-session baseline, running the pass, and persisting each probe's replay to
+:class:`teatree.core.models.DreamQaProbe` — lives in the sibling :mod:`acceptance`
+module. This module stays PURE w.r.t. the real ``~/.claude``: every gate takes
+explicit snapshots; tests pass in-memory snapshots and a tmp archive dir.
 """
 
 import hashlib
@@ -52,7 +48,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from teatree.loops.dream import decay, reindex
+from teatree.loops.dream import reindex
 
 if TYPE_CHECKING:
     from teatree.loops.dream.decay import ArchivedMemory
@@ -458,145 +454,6 @@ def evaluate_gates(  # noqa: PLR0913 — each kwarg is one documented §4 gate i
     )
 
 
-def persist_probe_results(
-    probes: Sequence[QaProbe],
-    snapshot: MemorySnapshot,
-    *,
-    overlay: str,
-    answerer: ProbeAnswerer | None = None,
-) -> int:
-    """Record each probe's replay outcome to the ``DreamQaProbe`` corpus, idempotently.
-
-    Idempotent on ``probe_key`` (sha256 of the question): a probe re-recorded on a
-    later run finds its existing row and ACCUMULATES pass/run counts via
-    :meth:`DreamQaProbe.record_result`, and is marked ``is_prior_session`` from the
-    second recording on (it now carries over from an earlier run). Returns the
-    number of probes that PASSED this replay.
-    """
-    from teatree.core.models import DreamQaProbe  # noqa: PLC0415
-
-    passed = 0
-    for probe in probes:
-        answerable = probe_answerable(probe, snapshot, answerer)
-        passed += int(answerable)
-        row, created = DreamQaProbe.objects.get_or_create(
-            probe_key=probe.probe_key,
-            defaults={
-                "question": probe.question,
-                "expected_answer": probe.expected_answer,
-                "source_memory_path": probe.source_name,
-                "overlay": overlay,
-            },
-        )
-        if not created and not row.is_prior_session:
-            row.is_prior_session = True
-            row.save(update_fields=["is_prior_session"])
-        row.record_result(passed=answerable)
-    return passed
-
-
-def _prior_pass_rate(overlay: str) -> tuple[float, bool]:
-    """Recorded prior-session pass-rate for *overlay* and whether a prior run exists.
-
-    Averages ``last_pass_rate`` over the persisted prior-session probes. A fresh
-    overlay (no prior probes) returns ``(1.0, False)`` — gate (b)/(e) cannot
-    regress against a non-existent baseline, so the first run is never failed by
-    interference/monotonicity.
-    """
-    from teatree.core.models import DreamQaProbe  # noqa: PLC0415
-
-    prior = list(DreamQaProbe.objects.prior_session_probes(overlay))
-    if not prior:
-        return 1.0, False
-    return sum(p.last_pass_rate for p in prior) / len(prior), True
-
-
-# ast-grep-ignore: ac-django-no-complexity-suppressions
-def run_acceptance_pass(  # noqa: PLR0913 — kwargs-only §4 pass inputs; the command's per-dir gate entry point.
-    snapshot_before: MemorySnapshot,
-    snapshot_after: MemorySnapshot,
-    *,
-    overlay: str,
-    archived: "Sequence[ArchivedMemory]",
-    schema_before: int,
-    schema_after: int,
-    clusters_recorded: int = 0,
-    maintenance_performed: bool = False,
-    persist: bool = True,
-    archive_dir: Path | None = None,
-    compliance_remediations: Sequence[ComplianceRemediationView] | None = None,
-) -> DreamQaReport:
-    """Run the §4 acceptance gates for one memory dir and persist the probe corpus.
-
-    Wiring entry point for the dream command (#2545): derives probes from the
-    BEFORE snapshot, reads the recorded prior-session pass-rate as the monotonicity
-    / interference baseline, computes the durable-home set for the consolidation
-    gate as the pruned index lines whose lesson is still findable in the AFTER
-    snapshot (transfer-before-prune) OR whose pointer targets a file in the durable
-    ``archive/`` cold store (*archive_dir*, this/prior pass, #2723), threads the caller's *maintenance_performed*
-    signal (file-side phases did real cross-link / re-index / decay work) into the
-    consolidation gate so a quiet 0-cluster maintenance pass still counts as
-    consolidation, runs all seven gates, and — unless *persist* is
-    off (dry-run) — records each probe's outcome to :class:`DreamQaProbe` (so the
-    formerly-dead model is populated and the next pass has a prior baseline).
-
-    *compliance_remediations* feeds gate (g); when not supplied it is read from the
-    persisted instruction-compliance records for *overlay* (#2663) so a recurrence
-    remediated with a memory FAILS the pass.
-    """
-    probes = derive_probes(snapshot_before)
-    prior_rate, had_prior = _prior_pass_rate(overlay)
-    now_rate = _pass_rate(probes, snapshot_after, None)
-    pruned_lines = snapshot_before.index_lines - snapshot_after.index_lines
-    homed_names = {a.source.name for a in archived} | decay.cold_archive_names(archive_dir)
-    homed_index_lines = {ln for ln in pruned_lines if snapshot_after.contains(ln) or _line_targets(ln, homed_names)}
-    remediations = compliance_remediations if compliance_remediations is not None else _compliance_remediations(overlay)
-    report = evaluate_gates(
-        snapshot_before=snapshot_before,
-        snapshot_after=snapshot_after,
-        schema_before=schema_before,
-        schema_after=schema_after,
-        homed_index_lines=homed_index_lines,
-        prior_pass_rate=prior_rate if had_prior else now_rate,
-        pass_rate_first=prior_rate if had_prior else now_rate,
-        pass_rate_second=now_rate,
-        archived=archived,
-        clusters_recorded=clusters_recorded,
-        maintenance_performed=maintenance_performed,
-        probes=probes,
-        compliance_remediations=remediations,
-    )
-    if persist:
-        persist_probe_results(probes, snapshot_after, overlay=overlay)
-    return report
-
-
-def _compliance_remediations(overlay: str) -> list[ComplianceRemediationView]:
-    """Build gate-(g) views from the latest persisted instruction-compliance records.
-
-    Reads the most recent :class:`InstructionComplianceSnapshot` for *overlay* and
-    maps each of its records to a :class:`ComplianceRemediationView`. A pass with no
-    snapshot yet returns no views — gate (g) then cleanly passes (nothing observed).
-    """
-    from teatree.core.models import (  # noqa: PLC0415
-        InstructionComplianceRecord,
-        InstructionComplianceSnapshot,
-        RemediationKind,
-    )
-
-    snapshot = InstructionComplianceSnapshot.objects.latest_for(overlay)
-    if snapshot is None:
-        return []
-    return [
-        ComplianceRemediationView(
-            rule_identity=record.rule_identity,
-            is_recurrence=record.is_recurrence,
-            remediated_with_memory=record.remediation == RemediationKind.MEMORY,
-        )
-        for record in InstructionComplianceRecord.objects.filter(snapshot=snapshot)
-    ]
-
-
 __all__ = [
     "INDEX_BYTE_BUDGET",
     "ComplianceRemediationView",
@@ -608,8 +465,6 @@ __all__ = [
     "QaProbe",
     "derive_probes",
     "evaluate_gates",
-    "persist_probe_results",
     "probe_answerable",
-    "run_acceptance_pass",
     "snapshot_memory_dir",
 ]

--- a/src/teatree/loops/dream/phase_runner.py
+++ b/src/teatree/loops/dream/phase_runner.py
@@ -72,7 +72,7 @@ class MemoryPhaseRunner:
         a lossy consolidation into a success. A gate-evaluation failure for one dir is
         reported in the summary, defaults that dir's verdict to PASS, and never crashes.
         """
-        from teatree.loops.dream import gates  # noqa: PLC0415
+        from teatree.loops.dream import acceptance, gates  # noqa: PLC0415
         from teatree.loops.dream.decay import ARCHIVE_DIRNAME  # noqa: PLC0415
         from teatree.memory_audit import discover_memory_dirs  # noqa: PLC0415
 
@@ -89,7 +89,7 @@ class MemoryPhaseRunner:
         clauses: list[str] = []
         for d in memory_dirs:
             try:
-                report = gates.run_acceptance_pass(
+                report = acceptance.run_acceptance_pass(
                     before[d],
                     gates.snapshot_memory_dir(d),
                     overlay="",

--- a/tests/teatree_core/management_commands/test_dream.py
+++ b/tests/teatree_core/management_commands/test_dream.py
@@ -672,7 +672,7 @@ class DreamAcceptanceGateWiringTestCase(TestCase):
             patch("teatree.loops.dream.engine.run_consolidation", return_value=_ok_result()),
             patch("teatree.loops.dream.promote.promote_proposals_file", return_value=[]),
             patch("teatree.memory_audit.discover_memory_dirs", return_value=[self.memdir]),
-            patch("teatree.loops.dream.gates.run_acceptance_pass", return_value=report),
+            patch("teatree.loops.dream.acceptance.run_acceptance_pass", return_value=report),
             patch.dict(
                 "os.environ",
                 {

--- a/tests/teatree_loops/dream/test_decay.py
+++ b/tests/teatree_loops/dream/test_decay.py
@@ -33,7 +33,7 @@ from unittest.mock import patch
 from django.test import SimpleTestCase, TestCase
 
 from teatree.core.models import ConsolidatedMemory
-from teatree.loops.dream import decay, gates, reindex
+from teatree.loops.dream import acceptance, decay, gates, reindex
 from teatree.loops.dream.decay import BudgetTier, DecayPolicy, _MemoryFile, decay_memories, ledger_durable_home_resolver
 
 _NOW = datetime(2026, 6, 16, 12, tzinfo=UTC)
@@ -719,7 +719,7 @@ class OverBudgetDecayEndToEndTestCase(TestCase):
         after: gates.MemorySnapshot,
         archived: Sequence[decay.ArchivedMemory],
     ) -> gates.DreamQaReport:
-        return gates.run_acceptance_pass(
+        return acceptance.run_acceptance_pass(
             before,
             after,
             overlay="acme",

--- a/tests/teatree_loops/dream/test_gates.py
+++ b/tests/teatree_loops/dream/test_gates.py
@@ -22,6 +22,7 @@ from django.test import SimpleTestCase, TestCase
 
 from teatree.core.models import DreamQaProbe
 from teatree.loops.dream import gates, reindex
+from teatree.loops.dream.acceptance import persist_probe_results, run_acceptance_pass
 from teatree.loops.dream.decay import ArchivedMemory
 from teatree.loops.dream.gates import (
     ComplianceRemediationView,
@@ -31,9 +32,7 @@ from teatree.loops.dream.gates import (
     QaProbe,
     derive_probes,
     evaluate_gates,
-    persist_probe_results,
     probe_answerable,
-    run_acceptance_pass,
     snapshot_memory_dir,
 )
 

--- a/tests/teatree_loops/dream/test_phase_runner.py
+++ b/tests/teatree_loops/dream/test_phase_runner.py
@@ -60,7 +60,7 @@ class MemoryPhaseRunnerTestCase(TestCase):
         with (
             self._patch_dirs(),
             patch(
-                "teatree.loops.dream.gates.run_acceptance_pass",
+                "teatree.loops.dream.acceptance.run_acceptance_pass",
                 side_effect=RuntimeError("gate boom"),
             ),
         ):


### PR DESCRIPTION
## What

`src/teatree/loops/dream/gates.py` sat at **exactly 500 non-comment LOC** — the hard
module-health cap. The gate blocks on `> 500`, so it passed with **zero headroom**: the
next non-comment line would trip *"500 LOC (max 500). Split by concern."*

This is a **pure refactor, no behavior change**. It splits the module by concern:

- **`gates.py`** keeps the *pure* gate computation — domain types (`MemorySnapshot`,
  `QaProbe`, `GateResult`, `ComplianceRemediationView`, `DreamQaReport`, `ProbeAnswerer`),
  the constants, the probe helpers, the `Gate` predicate class, and `evaluate_gates`
  (snapshot in → verdict out, no DB).
- **`acceptance.py`** (new sibling) takes the *impure* acceptance-pass orchestration +
  persistence: `run_acceptance_pass`, `persist_probe_results`, `_prior_pass_rate`,
  `_compliance_remediations`. This is the wiring that reads/writes `DreamQaProbe` and the
  instruction-compliance records, computes the durable-home set from what `decay`
  archived, and runs the seven gates.

### Resulting LOC / function counts

| File | LOC (before → after) | public module fns |
|------|----------------------|-------------------|
| `gates.py` | 500 → **373** | 4 (`snapshot_memory_dir`, `derive_probes`, `probe_answerable`, `evaluate_gates`) |
| `acceptance.py` (new) | — → **154** | 2 (`run_acceptance_pass`, `persist_probe_results`) |

Both are comfortably under the 500-LOC cap and well under the 10-public-function limit.

### Public-API / consumer approach

Re-exporting the two moved orchestration functions from `gates` would create a
`gates ↔ acceptance` **import cycle** (`acceptance` imports `gates` for the domain types),
which `tach` rejects. So the pure-gate symbols stay importable from `gates` unchanged, and
the two moved functions are imported from `acceptance` by their consumers instead:

- `src/teatree/loops/dream/phase_runner.py` — now `acceptance.run_acceptance_pass(...)`
- `tests/teatree_loops/dream/test_gates.py` — imports the two movers from `acceptance`
- `tests/teatree_loops/dream/test_decay.py` — `acceptance.run_acceptance_pass(...)`
- `tests/teatree_loops/dream/test_phase_runner.py` — patch target `...acceptance.run_acceptance_pass`
- `tests/teatree_core/management_commands/test_dream.py` — patch target `...acceptance.run_acceptance_pass`

`gates` no longer imports `decay` at runtime (its only `decay` use — `cold_archive_names` —
moved with `run_acceptance_pass`). `decay`'s function-scoped imports of the gate helpers
(`INDEX_BYTE_BUDGET`, `_signature_line`) are untouched, so that arrangement is preserved
and no cycle is added.

## Verification

- `uv run ruff check` + `uv run ruff format --check` — clean
- `uv run tach check` — all modules validated (no new cross-node edge, no cycle)
- `uv run pytest tests/teatree_loops/dream tests/teatree_core/management_commands/test_dream.py`
  — **570 nodes, identical set before/after** (collected node IDs diff-clean vs `origin/main`), all pass
- Module-health gate: both files under 500 with headroom; the pre-commit "Enforce module
  health" hook passed
- Ratchets green: intra-core deferred imports (183) and intra-loop deferred imports (28)
  unchanged; test-path-mirror ratchet unaffected

## Architecture pre-check — refactor(dream): split gates.py

### 1. BLUEPRINT § alignment
Structural split of an existing module in the dream consolidation loop (the §4 acceptance
gates, #2545 / #1933 §4 / #2663). No architectural contract changes; no BLUEPRINT section
is contradicted, so no BLUEPRINT edit is required.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition is touched.

### 3. Extension-point contracts
n/a — no `OverlayBase` hook, scanner registration, hook-router surface, or `*Backend`
Protocol is touched. The change is internal to `teatree.loops.dream`.

### 4. Component boundaries
New `acceptance.py` lives in `teatree.loops` (orchestration layer), the impure wiring that
depends on the pure `gates` computation and on `decay`. The two concerns were previously
co-located in one file straddling *pure verdict computation* and *DB persistence /
orchestration*; the split puts each on its own side of that seam.

### 5. Dependency direction
Imports added: `acceptance → gates` (domain types + `evaluate_gates` + `derive_probes` /
`probe_answerable` / `_pass_rate` / `_line_targets`), `acceptance → decay`
(`cold_archive_names`); consumers import `acceptance`. Removed the now-unused eager
`gates → decay` import. One-way graph — `gates` never imports `acceptance` — so no cycle.
`uv run tach check` → *All modules validated!* (`teatree.loops` is one tach node; the split
adds no cross-node edge.)

### 6. Test surface
The existing dream suite is the safety net — same 570-node set passes before and after (the
collected node IDs diff clean against `origin/main`). No test was added: the split exposes
no new observable seam, and the module-health / tach / ratchet gates already pin the
structural invariants. The acceptance-pass test classes stay in `test_gates.py` (which
already imports across `gates` / `decay` / `reindex`); its directory
`tests/teatree_loops/dream/` mirrors both `gates` and the new `acceptance`, so the
test-path-mirror ratchet is unaffected. No assertion weakened, xfailed, or skipped.

### 7. Resilience invariants
n/a — pure refactor. The one external-write path (`persist_probe_results` writing
`DreamQaProbe`) moved **verbatim**; its idempotency-on-`probe_key` and accumulate-counts
behavior is unchanged.

### 8. Identity and key normalization
n/a — no identity/key handling is introduced or changed.

### 9. Behavior preservation / capability deletion
This is a high-move refactor, so every moved unit is accounted for: the four functions
(`run_acceptance_pass`, `persist_probe_results`, `_prior_pass_rate`,
`_compliance_remediations`) moved with **byte-identical bodies** (including their existing
`# noqa: PLR0913` / `# ast-grep-ignore` markers — no new suppression added). No behavior
dropped, no branch removed, no must-block test inverted to must-not-block. No
privacy / leak / security matcher is touched. Public API: the pure-gate symbols remain
importable from `gates`; the two moved orchestration functions are relocated to
`acceptance` with all consumers updated in the same change.

## Open questions & assumptions
- Assumed the cleanest concern boundary is *pure gate computation* (`gates`) vs *impure
  acceptance-pass orchestration + persistence* (`acceptance`). The alternative (extracting
  the `Gate` predicate class) would still leave `evaluate_gates` → `Gate` →
  `run_acceptance_pass` as one linear chain, so the same cut point is required to avoid a
  cycle; this boundary also aligns with the module's own "PURE w.r.t. the real `~/.claude`"
  invariant.
- Kept the two moved functions' inline `# noqa` / `# ast-grep-ignore` markers verbatim
  rather than re-justifying them — this is a move, not a rewrite.

Do NOT merge — opened for review per the task.
