### PR TITLE
fix(hooks): stop pre-publish gates over-blocking forge body content (#1415)

### DIFF
--- a/hooks/scripts/direct_command_guard.py
+++ b/hooks/scripts/direct_command_guard.py
@@ -37,6 +37,7 @@ never Django / ``teatree.core``.
 
 import re
 import sys
+from pathlib import PurePosixPath
 
 # Alias the bare and ``hooks.scripts.`` identities so the handler the router
 # re-exports and a test patching a helper here operate on ONE module object.
@@ -216,6 +217,65 @@ def _has_shell_chain(command: str) -> bool:
     return bool(_SHELL_CHAIN_RE.search(command))
 
 
+# Leaders whose heredoc body is post/commit DATA (a PR/issue/MR body or a commit
+# message), never executed — so a blocked-tool phrase inside such a heredoc is
+# documentation, not an invocation, and must not trip the denylist. A heredoc fed
+# to an INTERPRETER (``bash <<EOF docker compose up EOF``) is NOT in this set, so
+# its body stays scanned and a real bypass piped to a shell still blocks.
+_FORGE_HEREDOC_LEADERS: frozenset[str] = frozenset({"gh", "glab", "git"})
+
+# A heredoc: ``<<['"]?DELIM['"]?`` on a command line, then a body up to a line
+# that is just DELIM. ``body`` is the content between the intro line and the
+# closing delimiter.
+_HEREDOC_BODY_RE = re.compile(
+    r"<<-?\s*['\"]?(?P<delim>\w+)['\"]?[^\n]*\n(?P<body>.*?)\n[ \t]*(?P=delim)\b",
+    re.DOTALL,
+)
+
+# Command separators that end one command and begin the next.
+_CMD_SEP_SPLIT_RE = re.compile(r"\|\||&&|[;|&\n]")
+
+
+def _heredoc_owner_leader(prefix: str) -> str:
+    """Return the executable leading the command that introduces a heredoc.
+
+    ``prefix`` is the command text up to the ``<<`` operator; a heredoc attaches
+    to the command on its line, so the owner is the first non-env-assignment
+    token of the last command segment in ``prefix`` (after the final
+    ``;``/``|``/``&&``/``||``/newline). The basename is returned so a path-form
+    leader (``/usr/bin/gh``) matches a bare ``gh``.
+    """
+    last_segment = _CMD_SEP_SPLIT_RE.split(prefix)[-1]
+    for token in last_segment.split():
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", token):
+            continue
+        return PurePosixPath(token).name
+    return ""
+
+
+def _strip_forge_heredoc_bodies(command: str) -> str:
+    """Blank heredoc bodies fed to a ``gh``/``glab``/``git`` command.
+
+    A heredoc feeding a forge/git posting command (``gh pr create --body-file -
+    <<EOF … EOF``, ``git commit -F - <<EOF … EOF``) is the PR/issue/MR body or
+    commit message — pure DATA the command never executes. A blocked-tool phrase
+    inside it (``docker compose up`` documented in a PR body) is text, not an
+    invocation, so it must not trip the denylist. Only forge/git-owned heredocs
+    are blanked: a heredoc fed to an interpreter (``bash <<EOF docker compose up
+    EOF``) keeps its body scanned, so a real bypass piped to a shell still blocks.
+    """
+
+    def blank(match: "re.Match[str]") -> str:
+        if _heredoc_owner_leader(command[: match.start()]) not in _FORGE_HEREDOC_LEADERS:
+            return match.group(0)
+        body_start = match.start("body") - match.start()
+        body_end = match.end("body") - match.start()
+        whole = match.group(0)
+        return whole[:body_start] + " " + whole[body_end:]
+
+    return _HEREDOC_BODY_RE.sub(blank, command)
+
+
 def deny_match(command: str) -> str | None:
     """Return a deny reason for *command*, or None if it should pass through."""
     # Checked FIRST — even before t3/read-only bypass — because agents must
@@ -229,17 +289,23 @@ def deny_match(command: str) -> str | None:
     # must inspect the full command rather than short-circuiting on the prefix.
     if not _has_shell_chain(command) and (_T3_CMD_PREFIX_RE.match(stripped) or _READONLY_CMD_PREFIX_RE.match(stripped)):
         return None
-    # Scan VALUE/CONFIG patterns against the raw command so that quoting the
-    # value (e.g. ``git -c "core.hooksPath=/dev/null"``) cannot evade the gate.
+    # A heredoc feeding a gh/glab/git posting command is the PR/commit BODY —
+    # pure data. Blank those bodies before the denylist scans so a blocked-tool
+    # phrase documented in a body (``docker compose up`` in a PR description) is
+    # not read as an invocation; a heredoc fed to an interpreter keeps its body.
+    scan_command = _strip_forge_heredoc_bodies(command)
+    # Scan VALUE/CONFIG patterns against the (body-stripped) raw command so that
+    # quoting the value (e.g. ``git -c "core.hooksPath=/dev/null"``) cannot evade
+    # the gate — a real bypass is never inside a forge heredoc body.
     for pattern, reason in _RAW_SCAN_BLOCKED:
-        if pattern.search(command):
+        if pattern.search(scan_command):
             return reason + " If `t3` fails, fix the CLI — do not work around it."
     # Scan TOOL-INVOCATION patterns against a quote-stripped copy so that a
     # blocked tool name that appears only inside a quoted commit message or grep
     # argument (e.g. ``git commit -m 'fix: handle pip install edge case'``) does
     # not false-block the command.  Real blocked invocations are unquoted and
     # still match the stripped target.
-    quote_stripped = _QUOTED_LITERAL_RE.sub(" ", command)
+    quote_stripped = _QUOTED_LITERAL_RE.sub(" ", scan_command)
     for pattern, reason in _QUOTE_STRIPPED_BLOCKED:
         if pattern.search(quote_stripped):
             return reason + " If `t3` fails, fix the CLI — do not work around it."

--- a/src/teatree/hooks/_body_file_resolution.py
+++ b/src/teatree/hooks/_body_file_resolution.py
@@ -279,12 +279,18 @@ def unredirected_heredoc_bodies(command: str) -> list[str]:
     ]
 
 
-# Stdin spellings of git's commit-message file flag: ``git commit -F -`` (and
-# the long ``--file -`` / ``--file=-`` forms). ``-`` means "read the commit
-# message from STDIN", so the body lives in whatever feeds the command's stdin
-# (an in-command heredoc or a piped ``printf``/``echo`` writer), NOT in a file
-# named ``-`` on disk.
+# Stdin spellings of a body-file flag: ``git commit -F -`` and the gh/glab
+# ``--body-file -`` / ``-F -`` / ``--file -`` forms (plus the ``--file=-``
+# equals spelling). ``-`` means "read the body/message from STDIN", so the body
+# lives in whatever feeds the command's stdin (an in-command heredoc or a piped
+# ``printf``/``echo`` writer), NOT in a file named ``-`` on disk.
 STDIN_DASH: Final[str] = "-"
+
+# Leaders whose ``-F -`` / ``--file -`` / ``--body-file -`` reads its
+# body/message from stdin rather than a file named ``-``: git's commit-message
+# flag and gh/glab's body-file short/long forms. The stdin body is resolved from
+# the in-command heredoc / piped writer instead of fail-closing on ``-`` (#1415).
+_STDIN_BODY_LEADERS: Final[frozenset[str]] = frozenset({"git", "gh", "glab"})
 
 
 def _segments_with_leading_separator(tokens: list[Token]) -> list[tuple[str | None, list[str]]]:
@@ -312,41 +318,56 @@ def _segments_with_leading_separator(tokens: list[Token]) -> list[tuple[str | No
     return out
 
 
-def _segment_reads_commit_message_from_stdin(words: list[str]) -> bool:
-    """Return True iff ``words`` is a ``git ... commit`` reading its message from stdin.
+def _reads_dash_stdin(words: list[str], flags: frozenset[str]) -> bool:
+    """Return True iff a body-file ``flag`` in ``words`` points at stdin (``-``).
 
-    The message comes from stdin when the commit carries ``-F -`` (or the long
-    ``--file -`` / ``--file=-`` form). A bare ``git commit`` opens an editor, and
-    ``-F <file>`` / ``-m`` read elsewhere, so neither pairs with a pipe.
+    Covers the space-separated (``--body-file -``), equals (``--file=-``), and
+    git-glued short (``-F-``) spellings.
     """
-    if not words or PurePosixPath(words[0]).name != "git" or "commit" not in words:
-        return False
     for i, word in enumerate(words):
-        if word in {"-F", "--file"} and i + 1 < len(words) and words[i + 1] == STDIN_DASH:
+        if word in flags and i + 1 < len(words) and words[i + 1] == STDIN_DASH:
             return True
-        if word == "--file=-":
+        if any(word == f"{flag}=-" for flag in flags):
             return True
         if attached_value(word, "-F") == STDIN_DASH:
             return True
     return False
 
 
-def piped_stdin_writer_body(tokens: list[Token]) -> str | None:
-    """Return the body a ``printf``/``echo`` writer pipes into a ``git commit -F -``.
+def _segment_reads_body_from_stdin(words: list[str]) -> bool:
+    """Return True iff a git-commit / gh / glab segment reads its body from stdin.
 
-    For ``printf '%s' 'msg' | git commit -F -`` the writer's operands ARE the
-    commit message fed to git's stdin — at PreToolUse scan time that is the only
-    place the message lives (the commit has not run). Returns the joined operands
-    of a ``printf``/``echo`` segment sitting immediately upstream (via a ``|``
-    pipe) of a ``git commit`` reading its message from stdin, else ``None``. The
-    operands are joined verbatim and scanned as a conservative SUPERSET (a banned
-    term / user quote in the real body is a substring of the join), never
-    re-executed.
+    git's commit message comes from stdin on ``-F -`` / ``--file -`` /
+    ``--file=-``; a gh/glab post body on ``--body-file -`` / ``-F -`` / ``--file
+    -``. A bare ``git commit`` opens an editor and ``-F <file>`` / ``-m`` read
+    elsewhere, so neither pairs with a pipe.
+    """
+    if not words:
+        return False
+    leader = PurePosixPath(words[0]).name
+    if leader == "git":
+        return "commit" in words and _reads_dash_stdin(words, frozenset({"-F", "--file"}))
+    if leader in {"gh", "glab"}:
+        return _reads_dash_stdin(words, frozenset({"-F", "--file", "--body-file"}))
+    return False
+
+
+def piped_stdin_writer_body(tokens: list[Token]) -> str | None:
+    """Return the body a ``printf``/``echo`` writer pipes into a stdin body reader.
+
+    For ``printf '%s' 'msg' | git commit -F -`` (or ``… | gh pr create
+    --body-file -``) the writer's operands ARE the body fed to the reader's stdin
+    — at PreToolUse scan time that is the only place the body lives (the command
+    has not run). Returns the joined operands of a ``printf``/``echo`` segment
+    sitting immediately upstream (via a ``|`` pipe) of a git-commit / gh / glab
+    segment reading its body from stdin, else ``None``. The operands are joined
+    verbatim and scanned as a conservative SUPERSET (a banned term / user quote
+    in the real body is a substring of the join), never re-executed.
     """
     segments = _segments_with_leading_separator(tokens)
     for idx in range(1, len(segments)):
         separator, words = segments[idx]
-        if separator != "|" or not _segment_reads_commit_message_from_stdin(words):
+        if separator != "|" or not _segment_reads_body_from_stdin(words):
             continue
         _, prev_words = segments[idx - 1]
         if prev_words and PurePosixPath(prev_words[0]).name in _REDIRECT_WRITER_COMMANDS:
@@ -514,36 +535,36 @@ def walk_body_file_flags(words: list[str], payloads: list[str], *, leader: str, 
         i += 1
 
 
-def _append_git_stdin_commit_body(payloads: list[str], ctx: BodyFileContext) -> None:
-    """Resolve the message a ``git commit -F -`` reads from STDIN (#1415).
+def _append_stdin_body(payloads: list[str], ctx: BodyFileContext, *, fail_closed: bool) -> None:
+    """Resolve a ``… -F -`` / ``--body-file -`` body read from STDIN (#1415).
 
-    ``-F -`` is not a file named ``-`` — git reads the commit message from
-    stdin, so the body lives in whatever feeds the command's stdin at scan
-    time:
+    ``-`` is not a file named ``-`` — the body/message comes from stdin, so it
+    lives in whatever feeds the command's stdin at scan time:
 
-    - a piped ``printf``/``echo`` writer (``printf 'msg' | git commit -F -``) →
-        its operands are appended (``ctx.stdin_piped_body``) and SCANNED, so a
-        real banned term / user quote in the body still blocks;
-    - a heredoc (``git commit -F - <<EOF … EOF``) → the body is already appended
-        globally by :func:`_command_parser.extract_bash_payload`
+    - a piped ``printf``/``echo`` writer (``printf 'msg' | gh pr create
+        --body-file -``) → its operands are appended (``ctx.stdin_piped_body``)
+        and SCANNED, so a real banned term / user quote in the body still blocks;
+    - a heredoc (``gh pr create --body-file - <<EOF … EOF``) → the body is already
+        appended globally by :func:`_command_parser.extract_bash_payload`
         (``ctx.has_unredirected_heredoc``), so this contributes nothing (no
-        double-count) and emits NO sentinel;
-    - genuinely-opaque stdin (``cat file | git commit -F -``, an interactive
-        editor) → the message is unreadable at scan time. It is a LOCAL commit
-        (no leak until push, and the pre-push gate re-scans commit messages), so
-        the generic fail-closed sentinel is emitted: the destination-aware
-        gates DOWNGRADE it to a warning for a local commit rather than
-        hard-blocking, while a chained PUBLIC post still defeats that downgrade.
+        double-count) and emits NO sentinel — the heredoc content is scanned;
+    - genuinely-opaque stdin (``cat file | gh pr create --body-file -``, an
+        interactive editor) → the body is unreadable at scan time, so the generic
+        fail-closed sentinel is emitted when ``fail_closed``. A PUBLIC gh/glab
+        post the gate cannot read hard-blocks; a LOCAL git commit's sentinel is
+        later DOWNGRADED to a warning by the destination-aware carve-out (the
+        pre-push gate re-scans commit messages). ``fail_closed`` False appends
+        nothing (the quote scanner's drafted-but-absent posture).
 
-    Resolving the readable stdin sources is the #1415 fix: a clean ``git commit
-    -F -`` heredoc/piped message is no longer hard-blocked merely for being
-    unreadable as a file named ``-``.
+    Extending this from ``git commit -F -`` to gh/glab ``--body-file -`` is the
+    #1415 fix: a clean heredoc/piped gh/glab body is no longer hard-blocked as an
+    unreadable file named ``-`` (previously only git resolved its stdin body).
     """
     if ctx.stdin_piped_body is not None:
         payloads.append(ctx.stdin_piped_body)
     elif ctx.has_unredirected_heredoc:
         return
-    else:
+    elif fail_closed:
         payloads.append(FAIL_CLOSED_SENTINEL)
 
 
@@ -552,10 +573,12 @@ def _append_file_payload(
 ) -> None:
     """Append the body referenced by a ``-F``/``--file``/``--body-file`` path.
 
-    A ``git commit -F -`` (``leader == "git"`` and ``path == "-"``) reads its
-    message from STDIN, not a file named ``-``; it is resolved by
-    :func:`_append_git_stdin_commit_body` (the in-command heredoc / piped writer,
-    else a downgrade-eligible fail-closed sentinel for the LOCAL commit).
+    A stdin body reference (``path == "-"`` on a git-commit / gh / glab leader —
+    ``git commit -F -``, ``gh pr create --body-file -``) reads its body/message
+    from STDIN, not a file named ``-``; it is resolved by
+    :func:`_append_stdin_body` (the in-command heredoc / piped writer, else a
+    fail-closed sentinel — always for git's LOCAL commit, else per the
+    destination-aware ``fail_closed`` policy for a gh/glab post).
 
     For a real path the resolution order is: the on-disk file (as-is, then
     relative to ``ctx.base`` -- the commit's repo dir), then an in-command body
@@ -581,8 +604,10 @@ def _append_file_payload(
     scanner keeps a drafted-but-absent ``gh``/``glab`` body file as
     "needs-inline", not a fail-closed HIGH (#126).
     """
-    if leader == "git" and path == STDIN_DASH:
-        _append_git_stdin_commit_body(payloads, ctx)
+    if path == STDIN_DASH and leader in _STDIN_BODY_LEADERS:
+        # git's commit-message stdin ALWAYS fails closed on opaque input (#1207);
+        # gh/glab's body-file stdin follows the destination-aware fail_closed policy.
+        _append_stdin_body(payloads, ctx, fail_closed=leader == "git" or fail_closed)
         return
     content = read_file_arg(path, ctx.base)
     if content is None:

--- a/tests/teatree_hooks/test_banned_terms_scanner.py
+++ b/tests/teatree_hooks/test_banned_terms_scanner.py
@@ -2518,6 +2518,94 @@ class TestGitCommitStdinBodyResolution:
         assert capsys.readouterr().out == ""
 
 
+class TestGhGlabStdinBodyResolution:
+    """``gh``/``glab --body-file -`` stdin heredoc / piped bodies are RESOLVED and scanned (#1415).
+
+    The over-block this fixes: a ``gh pr create --body-file - <<EOF … EOF`` (or
+    ``glab mr note … --body-file -``) whose body is fed on stdin hard-blocked with
+    the "body file is missing or unresolvable" message — the ``-`` was read as an
+    unreadable file named ``-`` and the fail-closed sentinel preempted the scan,
+    even though the heredoc/piped body is fully present at scan time. Only ``git
+    commit -F -`` resolved its stdin body; gh/glab did not. The fix resolves the
+    in-command stdin body so a CLEAN post PASSES and a REAL banned term in that
+    same readable body BLOCKS with the banned-term reason (not the unresolvable
+    one) — the resolution ADDS coverage, never weakens it. A genuinely-OPAQUE
+    stdin (``cat file | gh pr create --body-file -``) is a PUBLIC post the gate
+    cannot read, so it stays hard-blocked (unlike a LOCAL git commit, which
+    downgrades).
+    """
+
+    def _deny(self, command: str, cwd: Path, capsys: pytest.CaptureFixture[str]) -> str | None:
+        event = {"tool_name": "Bash", "tool_input": {"command": command}, "cwd": str(cwd)}
+        blocked = handle_banned_terms_pretool(event)
+        out = capsys.readouterr().out
+        return json.loads(out)["permissionDecisionReason"] if blocked else None
+
+    def test_gh_heredoc_stdin_clean_body_passes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # USED-TO-FALSE-BLOCK ("body file is missing or unresolvable"), now PASSES:
+        # the heredoc body IS present at scan time and scans clean.
+        repo = _public_repo(tmp_path)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+        cmd = "gh pr create --title t --body-file - <<'EOF'\nclean pr body about shipping\nEOF"
+        assert self._deny(cmd, repo, capsys) is None
+
+    def test_gh_heredoc_stdin_banned_term_blocks_as_banned_not_unresolvable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # ANTI-VACUITY: a REAL banned term in the SAME readable heredoc body blocks
+        # with the BANNED-TERM reason. Before the fix it blocked with the WRONG
+        # "could not be read" reason (the sentinel preempted the scan) — asserting
+        # the reason distinguishes the added coverage from the old fail-closed.
+        repo = _public_repo(tmp_path)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+        cmd = "gh pr create --title t --body-file - <<'EOF'\nrolling out acmecorp integration\nEOF"
+        reason = self._deny(cmd, repo, capsys)
+        assert reason is not None
+        assert "banned term 'acmecorp'" in reason
+        assert "could not be read" not in reason
+
+    def test_glab_note_heredoc_stdin_clean_body_passes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo = _public_repo(tmp_path)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+        cmd = "glab mr note 1 --body-file - <<'EOF'\nclean review note here\nEOF"
+        assert self._deny(cmd, repo, capsys) is None
+
+    def test_piped_printf_gh_clean_body_passes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        repo = _public_repo(tmp_path)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+        cmd = "printf '%s' 'a perfectly clean pr body' | gh pr create --title t --body-file -"
+        assert self._deny(cmd, repo, capsys) is None
+
+    def test_piped_printf_gh_banned_term_still_blocks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # ANTI-VACUITY: the piped writer's body is scanned, so a banned term blocks.
+        repo = _public_repo(tmp_path)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+        cmd = "printf '%s' 'ship acmecorp today' | gh pr create --title t --body-file -"
+        reason = self._deny(cmd, repo, capsys)
+        assert reason is not None
+        assert "banned term 'acmecorp'" in reason
+
+    def test_opaque_stdin_gh_post_stays_hard_blocked(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # A genuinely-opaque stdin (no heredoc, no printf/echo writer) feeding a
+        # PUBLIC gh post is unreadable at scan time — it stays hard-blocked (a
+        # public post never downgrades the way a local commit does).
+        repo = _public_repo(tmp_path)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+        reason = self._deny("cat body.txt | gh pr create --title t --body-file -", repo, capsys)
+        assert reason is not None
+        assert "could not be read" in reason
+
+
 class TestAbsoluteBodyFileResolvesRegardlessOfCwd:
     """An absolute ``--body-file`` written by a prior step is read at scan time (#2369 case 1).
 

--- a/tests/test_bash_command_blocker.py
+++ b/tests/test_bash_command_blocker.py
@@ -147,6 +147,73 @@ class TestAllowsLegitimateCommands:
         assert capsys.readouterr().out.strip() == ""
 
 
+class TestForgeHeredocBodyIsNotAnInvocation:
+    """A blocked-tool phrase inside a gh/glab/git heredoc BODY is documentation, not a command.
+
+    A ``gh pr create --body-file - <<EOF … EOF`` / ``git commit -F - <<EOF … EOF``
+    heredoc is the PR/commit BODY — pure data the command never executes. Before
+    the fix the denylist scanned the whole command string, so a PR description
+    documenting ``docker compose up`` (or ``manage.py runserver``, etc.) was
+    hard-blocked as if it were the invocation. The fix blanks a forge/git-owned
+    heredoc body before the scan while keeping an INTERPRETER heredoc (``bash
+    <<EOF docker compose up EOF``) fully scanned — so a real bypass piped to a
+    shell still blocks.
+    """
+
+    _DOCKER = "docker compose up"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            f"gh pr create --title t --body-file - <<'EOF'\nWe fix the {_DOCKER} false-positive.\nEOF",
+            "git commit -F - <<'EOF'\ndocs: note that manage.py runserver is banned\nEOF",
+            "glab mr note 1 --body-file - <<'EOF'\nwe ran createdb by hand once\nEOF",
+            f"cd /repo && gh pr create --title t --body-file - <<'EOF'\n{_DOCKER} in the body\nEOF",
+            f'gh pr create --title t --body "{_DOCKER} inline quoted body"',
+        ],
+    )
+    def test_forge_body_phrase_passes(self, capsys: pytest.CaptureFixture[str], command: str) -> None:
+        result = handle_block_direct_commands(_bash_event(command))
+        assert result is not True
+        assert capsys.readouterr().out.strip() == ""
+
+    @pytest.mark.parametrize(
+        ("command", "expected_fragment"),
+        [
+            (f"{_DOCKER} -d", "worktree start"),
+            (f"cd /app && {_DOCKER}", "worktree start"),
+            (f"bash <<'EOF'\n{_DOCKER}\nEOF", "worktree start"),
+            (f"sh <<'EOF'\n{_DOCKER}\nEOF", "worktree start"),
+            (f"{_DOCKER} <<'EOF'\nx\nEOF", "worktree start"),
+            (f"gh pr create --title t --body-file - <<'EOF'\ndoc\nEOF\n{_DOCKER}", "worktree start"),
+        ],
+    )
+    def test_real_invocation_still_blocks(
+        self, capsys: pytest.CaptureFixture[str], command: str, expected_fragment: str
+    ) -> None:
+        # TEETH: the fix must not weaken the block on an ACTUAL invocation — a real
+        # ``docker compose up``, a heredoc fed to an interpreter, and a real
+        # invocation chained AFTER a forge heredoc all still deny.
+        result = handle_block_direct_commands(_bash_event(command))
+        assert result is True
+        deny = _parse_deny(capsys)
+        assert deny is not None
+        assert expected_fragment in deny["permissionDecisionReason"]
+
+    def test_real_bypass_on_the_command_line_with_a_forge_heredoc_still_blocks(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Blanking the heredoc BODY must not hide a real bypass sitting on the
+        # command LINE beside it: a hook-silencer (F3) that also feeds a heredoc
+        # body still blocks because the bypass is outside the blanked span.
+        command = "git -c core.hooksPath=/dev/null commit -F - <<'EOF'\njust a commit body\nEOF"
+        result = handle_block_direct_commands(_bash_event(command))
+        assert result is True
+        deny = _parse_deny(capsys)
+        assert deny is not None
+        assert "bypasses git hooks" in deny["permissionDecisionReason"]
+
+
 class TestHandlerChainStopsAfterDeny:
     """The router stops running handlers after the first deny."""
 


### PR DESCRIPTION
## What

Two PreToolUse gate false-positives that fire when opening PRs whose body/commit
message is fed via a heredoc or stdin, or documents an infra command.

**FP-1 — banned-terms gate (`teatree.hooks._body_file_resolution`).** A gh/glab
`--body-file -` post that reads its body from a heredoc (`gh pr create
--body-file - <<EOF … EOF`) or a piped writer was hard-blocked as an unreadable
file named `-` ("body file is missing or unresolvable at scan time") — even
though the body is fully present at scan time. Only `git commit -F -` resolved
its stdin body. Now the stdin-dash resolution is generalized to gh/glab: a clean
body passes, and a real banned term in that same readable body BLOCKS with the
banned-term reason (added coverage, never weakened). A genuinely-opaque stdin
(`cat file | gh … --body-file -`) still hard-blocks for a public post; git's
local commit still downgrades to a warn via the destination-aware carve-out.

**FP-2 — block-direct-commands gate (`hooks/scripts/direct_command_guard.py`).**
A blocked-tool phrase inside a gh/glab/git heredoc BODY (a PR/commit body
documenting `docker compose up`) was matched as if it were the invocation.
Forge/git-owned heredoc bodies are now blanked before the denylist scans. A
heredoc fed to an INTERPRETER (`bash <<EOF … EOF`) keeps its body scanned, so a
real bypass piped to a shell still blocks; a real invocation on the command line
or chained after a forge heredoc still blocks.

Why: opening this very PR is the repro — a PR/commit body legitimately naming
`docker compose up`, or fed on stdin/heredoc, must reach the forge without the
safe path being hard-blocked. The net effect on the banned-terms gate is that it
scans MORE (heredoc/piped gh-glab bodies are now scanned), never less.

## Architecture pre-check — pre-publish gate FPs (#1415)

**1. BLUEPRINT § alignment.** Hook-layer PreToolUse gates (BLUEPRINT § "hooks — one
router, many events"; `hooks/CLAUDE.md` block-direct-commands + banned-terms
carve-out bullets). No new gate, no new event — two existing gates fixed in place.

**2. FSM phase boundaries.** n/a — no `Ticket`/`Worktree` state transition.

**3. Extension-point contracts.** No `OverlayBase` / scanner-registration / Protocol
change. `direct_command_guard` keeps its router re-export contract
(`handle_block_direct_commands`, `deny_match`→`_deny_match`, `BLOCKED_COMMANDS`);
`_body_file_resolution` keeps its `_command_parser` call contract
(`piped_stdin_writer_body`, `walk_body_file_flags`). The renamed private helpers
(`_append_git_stdin_commit_body`→`_append_stdin_body`,
`_segment_reads_commit_message_from_stdin`→`_segment_reads_body_from_stdin`) are
module-private, no external consumers (grepped).

**4. Component boundaries.** FP-2 stays in the stdlib-only cold-import-safe sibling
`hooks/scripts/direct_command_guard.py`; FP-1 stays in the pure
`teatree.hooks._body_file_resolution` leaf. No straddle.

**5. Dependency direction.** No new cross-module import (FP-1 adds only stdlib
`frozenset` usage; FP-2 adds stdlib `pathlib.PurePosixPath`). `uv run tach check`
→ "All modules validated!".

**6. Test surface.** FP-1: `tests/teatree_hooks/test_banned_terms_scanner.py::
TestGhGlabStdinBodyResolution` (6 tests). FP-2: `tests/test_bash_command_blocker.py::
TestForgeHeredocBodyIsNotAnInvocation` (12 tests). Each new behavior asserts the
end-to-end gate decision + deny reason (banned-term vs unresolvable; worktree-start
vs pass).

**7. Resilience invariants.** No external write. Both gates keep failing CLOSED on a
genuinely-unresolvable body (opaque stdin to a public post; a real bypass on the
command line); the change only stops fail-closing on a body that IS readable.

**8. Identity/key normalization.** Leader detection canonicalizes UP to the
executable basename (`PurePosixPath(token).name`) so `/usr/bin/gh` matches `gh`
— no qualifier-stripping-to-match.

**9. Behavior preservation / capability deletion.** No must-block behavior removed;
FP-1 ADDS coverage (heredoc/piped gh-glab bodies now scanned). Every must-block
case has a regression test (below). No must-block test inverted to must-not-block.
No privacy/security matcher narrowed — the banned-terms scan now runs on strictly
more content.

## Must-block behaviors preserved (regression tests)

- banned term in a readable `--body-file`/`-F`/heredoc/piped body → BLOCK
  (`test_gh_heredoc_stdin_banned_term_blocks_as_banned_not_unresolvable`,
  `test_piped_printf_gh_banned_term_still_blocks`, existing git-stdin tests)
- opaque stdin to a public gh/glab post → BLOCK
  (`test_opaque_stdin_gh_post_stays_hard_blocked`)
- actual `docker compose up`, `cd /app && docker compose up`, interpreter
  heredocs (`bash`/`sh <<EOF … EOF`), docker-with-own-heredoc, real invocation
  chained AFTER a forge heredoc → BLOCK (`test_real_invocation_still_blocks`)
- F3 hook-silencer on the command line beside a forge heredoc → BLOCK
  (`test_real_bypass_on_the_command_line_with_a_forge_heredoc_still_blocks`)
- inline quoted `--body "docker compose up"` still passes (unchanged) — guard case

## RED-before proof

Reverting only the FP-1 src (`_body_file_resolution.py`) makes 5/6
`TestGhGlabStdinBodyResolution` fail (clean bodies blocked as "could not be read";
banned bodies blocked with the wrong "unresolvable" reason). Reverting only the
FP-2 src (`direct_command_guard.py`) makes 4/12
`TestForgeHeredocBodyIsNotAnInvocation` fail (forge heredoc bodies blocked as
invocations). The remaining cases are must-not-regress guards (green both ways).

## Gates

`uv run ruff check` + `ruff format --check` clean; `uv run tach check` ✅;
`check_module_health.py` exit 0 (no hook_router.py change — its shrink-only cap is
untouched); 903 passing across the banned-terms / quote-scanner / direct-command /
lockout / AI-signature / never-lockout suites, plus the 18 new tests.
