### PR TITLE
fix(hooks): scope pre-publish leak gates to affirmatively-public targets (#1415, #1213)

### DIFF
--- a/hooks/scripts/banned_terms_deny.py
+++ b/hooks/scripts/banned_terms_deny.py
@@ -19,17 +19,18 @@ Every carve-out above conditions its downgrade on a PROVABLY-internal landing
 repo or a PROVABLY-own configured URL — never on the destination SLUG TEXT
 alone. A slug-text downgrade (a term that merely matches the resolved
 destination's own repo slug) would fail OPEN: this deny path is reached ONLY
-after ``publish_destination.gate_skips_destination`` already returned False, so
-the destination is NOT provably-internal (it is PUBLIC or unknown-visibility) —
-exactly the surface the fail-closed design protects. An org/repo slug is
-attacker-controllable (``<term>-eng/tracker``), so downgrading on slug text
-would let a genuinely-public repo named after the term silence the leak block.
-The #2597 false positive (a status comment to the overlay's OWN private tracker)
-is therefore resolved the SOUND way instead: declaring that tracker in
-``[teatree] private_repos`` / ``internal_publish_namespaces`` makes
-``gate_skips_destination`` skip the WHOLE gate for it (the overlay name on a
-provably-private surface is not a leak), and the #1657 NOTE below points the
-operator at that config when an in-hook probe cannot prove visibility.
+after ``public_visibility.gate_skips_for_visibility`` already returned False, so
+the destination is affirmatively PUBLIC (an unknown/private target skips the
+gate before reaching here) — exactly the surface the leak block protects. An
+org/repo slug is attacker-controllable (``<term>-eng/tracker``), so downgrading
+on slug text would let a genuinely-public repo named after the term silence the
+leak block. The #2597 false positive (a status comment to the overlay's OWN
+private tracker) is resolved the SOUND way instead: a private/unknown tracker is
+NOT affirmatively public, so ``gate_skips_for_visibility`` skips the WHOLE gate
+for it; declaring it in ``[teatree] private_repos`` /
+``internal_publish_namespaces`` makes the skip reliable offline, and the #1657
+NOTE below points the operator at that config when an in-hook probe cannot
+prove visibility.
 
 Anything not downgraded hard-blocks, after emitting the #1657 unknown-visibility
 NOTE when the target's visibility could not be resolved in-hook.

--- a/hooks/scripts/banned_terms_gate.py
+++ b/hooks/scripts/banned_terms_gate.py
@@ -125,7 +125,7 @@ def _run_banned_terms_pretool(data: dict) -> bool:
 
     from hook_router import _resolve_cwd_repo, emit_pretooluse_deny  # noqa: PLC0415, PLC2701
 
-    from teatree.hooks import banned_terms_scanner, publish_destination, publish_surface  # noqa: PLC0415
+    from teatree.hooks import banned_terms_scanner, public_visibility, publish_surface  # noqa: PLC0415
 
     tool_name = data.get("tool_name", "")
     raw_input = data.get("tool_input", {}) or {}
@@ -150,7 +150,7 @@ def _run_banned_terms_pretool(data: dict) -> bool:
         return False
 
     skipped = banned_terms_scanner.has_override(tool_name, tool_input) or (
-        tool_name == "Bash" and publish_destination.gate_skips_destination(command, cwd_repo)
+        tool_name == "Bash" and public_visibility.gate_skips_for_visibility(command, cwd_repo)
     )
     term = None if skipped else banned_terms_scanner.scan_text(payload)
     if term is None:

--- a/hooks/scripts/quote_verdict.py
+++ b/hooks/scripts/quote_verdict.py
@@ -35,6 +35,13 @@ _PRIVATE_REPO_WARNING = (
     "private-repo commit; downgraded to warn (#126). Verify the content is paraphrased.\n"
 )
 
+# The non-public-destination SKIP reuses the ``warning`` channel with an EMPTY
+# string so the router's ``_quote_scanner_high_io`` prints nothing (a no-op
+# ``stderr.write("")``) yet takes the allow (non-deny) branch — the leak gate
+# enforces ONLY on an affirmatively-public target (#1415/#1213), so a HIGH match
+# whose repo target is not affirmatively public is silently allowed.
+_NON_PUBLIC_SKIP = ""
+
 
 @dataclass(frozen=True)
 class QuoteVerdict:
@@ -51,7 +58,16 @@ class QuoteVerdict:
 
 
 def resolve_high_verdict(command: str, cwd: Path | None) -> QuoteVerdict:
-    """Resolve a HIGH quote-scanner result to a deny / downgrade verdict.
+    """Resolve a HIGH quote-scanner result to a deny / skip / downgrade verdict.
+
+    A HIGH match whose repo target is NOT affirmatively PUBLIC is SKIPPED
+    entirely (#1415/#1213 -- the leak gate enforces ONLY on an affirmatively-
+    public target). ``gate_skips_for_visibility`` resolves the command's own
+    target (the ``--repo``/``-R`` flag, the ``gh``/``glab api`` URL path, or the
+    cwd remote) and skips a private/internal/unknown/unresolvable one; the skip
+    verdict is silent (empty ``warning``, ``allow-nonpublic-destination`` ledger
+    label). This is checked BEFORE the private-commit downgrade so a private
+    post never reaches the ``command_targets_private_only`` warn.
 
     A HIGH match whose destination is provably PRIVATE downgrades to a warn (#126
     -- a private repo cannot leak to the public). The check is body-INDEPENDENT
@@ -70,8 +86,10 @@ def resolve_high_verdict(command: str, cwd: Path | None) -> QuoteVerdict:
     default env/home one (the live gate passes no explicit config; tests pin it
     via ``T3_BANNED_TERMS_CONFIG``).
     """
-    from teatree.hooks import publish_surface  # noqa: PLC0415
+    from teatree.hooks import public_visibility, publish_surface  # noqa: PLC0415
 
+    if public_visibility.gate_skips_for_visibility(command, cwd):
+        return QuoteVerdict(deny=False, warning=_NON_PUBLIC_SKIP, decision="allow-nonpublic-destination")
     if publish_surface.command_targets_private_only(command, cwd):
         return QuoteVerdict(deny=False, warning=_PRIVATE_REPO_WARNING, decision="warn-private-repo")
     return QuoteVerdict(deny=True, warning=None, decision="deny")

--- a/src/teatree/hooks/_repo_visibility.py
+++ b/src/teatree/hooks/_repo_visibility.py
@@ -386,16 +386,27 @@ def forge_qualified_slug(slug: str, forge: str) -> str:
     return f"{canonical_host}/{slug}"
 
 
-def slug_is_private(slug: str) -> bool:
-    """Resolve whether ``slug`` is a private repo (cache -> probe -> cache write)."""
+def slug_visibility(slug: str) -> str | None:
+    """Resolve ``slug``'s visibility verdict (upper-cased), or ``None`` (cache -> probe -> cache).
+
+    ``None`` is the fail-safe unknown -- an absent probe tool, an unrecognised
+    slug, or a probe error. Callers read a ``"PRIVATE"`` verdict (the carve-out)
+    or a ``"PUBLIC"`` one (the affirmative-public leak-gate scope in
+    :mod:`teatree.hooks.public_visibility`); every other verdict, and ``None``,
+    is neither.
+    """
     cached = _read_visibility_cache(slug)
     if cached is not None:
-        return cached == "PRIVATE"
+        return cached
     verdict = probe_visibility(slug)
-    if verdict is None:
-        return False
-    _write_visibility_cache(slug, verdict)
-    return verdict == "PRIVATE"
+    if verdict is not None:
+        _write_visibility_cache(slug, verdict)
+    return verdict
+
+
+def slug_is_private(slug: str) -> bool:
+    """Return True iff ``slug``'s visibility verdict is ``"PRIVATE"``."""
+    return slug_visibility(slug) == "PRIVATE"
 
 
 def _strip_host_prefix(slug: str) -> str:

--- a/src/teatree/hooks/public_visibility.py
+++ b/src/teatree/hooks/public_visibility.py
@@ -1,0 +1,170 @@
+"""Affirmative-public visibility scope for the pre-publish leak gates (#1415/#1213).
+
+The banned-terms (#1415) and quote-scanner (#1213) gates protect against
+leaking internal vocabulary / user quotes onto PUBLIC surfaces. They therefore
+enforce ONLY when the target repository is affirmatively known ``public``. For
+every OTHER case -- a ``private`` or ``internal`` repo, an unknown/unresolvable
+target, or an in-hook visibility lookup error -- the gate is SKIPPED (bias hard
+toward not firing): a non-public repo must never be falsely blocked.
+
+The visibility verdict is resolved from the command's OWN target (the
+``--repo``/``-R`` flag, the ``gh``/``glab api`` URL path, or the cwd git remote
+-- reusing ``publish_destination``'s resolver), then classified: an
+allowlisted-private slug, an internal-namespace slug, a ``private``/``internal``
+probe verdict, and an unknown verdict all resolve NON-public; only a ``public``
+probe verdict on a non-allowlisted slug is public. The verdict is day-cached
+per-repo by :func:`_repo_visibility.slug_visibility`, so repeated gate
+evaluations never re-probe.
+
+:func:`gate_skips_for_visibility` is the composed predicate the gates call. It
+keeps the ALL-SEGMENTS anti-leak posture of the destination classifier it
+replaced -- a ``$(...)``/transport construct, an unrecognised chained executable
+(``sh -c``/``make``/``./x.sh``), or a raw ``api`` WRITE whose URL does not
+resolve are all NON-skippable, so an obscured PUBLIC post can never hide behind
+a leading non-public segment -- but with the destination polarity FLIPPED: a
+segment is skip-eligible when its target is NOT affirmatively public (rather
+than only when provably-internal), so an unknown/unresolvable target now SKIPS
+instead of failing closed. A ``git commit`` segment defers to the landing-repo
+carve-out and the #703 pre-push backstop and is never skipped here.
+
+This lives in its own module because :mod:`teatree.hooks.publish_destination`
+and :mod:`teatree.hooks._repo_visibility` are both at the per-file LOC cap.
+"""
+
+from pathlib import Path
+
+from teatree.hooks import _commit_carve_out, _repo_visibility
+from teatree.hooks._gh_glab_hiding import command_segments
+from teatree.hooks._publish_detection import segment_is_api_read, segment_is_api_write
+from teatree.hooks.publish_destination import (
+    Destination,
+    _destination_from_api,
+    _destination_from_words,
+    _internal_publish_namespaces,
+    _segment_carries_substitution_or_transport,
+    _segment_is_skip_inert,
+)
+from teatree.hooks.publish_surface import strip_cd_prefix
+
+_PUBLIC = "PUBLIC"
+
+# Per-segment visibility verdicts feeding :func:`gate_skips_for_visibility`.
+_SCAN = "scan"  # forces the whole command to scan (never skip) -- anti-leak
+_SKIP_PUBLISH = "skip-publish"  # skip-eligible AND counts as a repo-targeted publish
+_SKIP_INERT = "skip-inert"  # skip-eligible, not a publish (nav/local/api-read)
+
+
+def is_affirmatively_public(dest: Destination | None, *, config_path: Path | None = None) -> bool:
+    """Return True iff ``dest`` resolves to an affirmatively-PUBLIC repo.
+
+    NON-public (False) when the slug is empty / carries an unexpanded ``$``,
+    matches an ``internal_publish_namespaces`` entry, matches a ``private_repos``
+    allowlist entry, or its ``gh``/``glab`` visibility verdict is anything other
+    than ``"PUBLIC"`` (``private``/``internal``/unknown). ``dest.forge`` qualifies
+    a bare ``owner/repo`` slug up to its canonical host so the host-keyed probe
+    routes to the right tool.
+    """
+    if dest is None:
+        return False
+    slug = dest.slug.strip().lower()
+    if not slug or "$" in slug:
+        return False
+    if any(_repo_visibility.slug_namespace_matches(entry, slug) for entry in _internal_publish_namespaces(config_path)):
+        return False
+    if _repo_visibility.slug_is_allowlisted_private(slug, config_path):
+        return False
+    probe_slug = _repo_visibility.forge_qualified_slug(slug, dest.forge)
+    return _repo_visibility.slug_visibility(probe_slug) == _PUBLIC
+
+
+def _api_write_targets_non_public(words: list[str], *, config_path: Path | None = None) -> bool:
+    """Return True iff a raw ``api`` WRITE segment targets a NON-public repo.
+
+    A ``gh``/``glab api`` write carries its body only to the endpoint its URL
+    path names. When that path resolves to a repo slug that is NOT affirmatively
+    public (private/internal/unknown), the write cannot leak to a public surface
+    -- e.g. a private customer MR-description PUT -- so it is skip-eligible. The
+    slug must come from the URL path itself (``via="api"``): an ``-R`` flag does
+    not constrain a raw endpoint. An unresolvable path (a shell variable, a
+    flagless call, an ambiguous unknown flag, a non-repo endpoint) resolves to no
+    ``api`` destination and is treated NON-public -> skip-eligible (bias to not
+    firing). A path that resolves to an affirmatively-public repo is NOT
+    skip-eligible.
+    """
+    if not words or words[0] not in {"gh", "glab"}:
+        return False
+    dest = _destination_from_api(words, words[0])
+    if dest is None or dest.via != "api":
+        return True
+    return not is_affirmatively_public(dest, config_path=config_path)
+
+
+def _segment_visibility_verdict(words: list[str], cwd: Path | None, *, config_path: Path | None) -> str:
+    """Classify one top-level segment as :data:`_SCAN` / :data:`_SKIP_PUBLISH` / :data:`_SKIP_INERT`.
+
+    A ``$(...)``/transport construct or an unrecognised chained executable forces
+    :data:`_SCAN` (the ALL-SEGMENTS anti-leak posture); a repo-targeted publish
+    to an affirmatively-PUBLIC target forces :data:`_SCAN`; a repo-targeted
+    publish (structured or ``api`` WRITE) to a NON-public or UNRESOLVABLE target
+    is :data:`_SKIP_PUBLISH` (an unknown target skips, per #1415); an ``api``
+    read or an inert nav/local segment is :data:`_SKIP_INERT`.
+    """
+    if _segment_carries_substitution_or_transport(words):
+        return _SCAN
+    if segment_is_api_write(words):
+        return _SKIP_PUBLISH if _api_write_targets_non_public(words, config_path=config_path) else _SCAN
+    if segment_is_api_read(words):
+        return _SKIP_INERT
+    rest = strip_cd_prefix(words)
+    dest = _destination_from_words(rest, cwd)
+    if dest is not None:
+        return _SCAN if is_affirmatively_public(dest, config_path=config_path) else _SKIP_PUBLISH
+    if rest and rest[0] in {"gh", "glab"}:
+        return _SKIP_PUBLISH
+    return _SKIP_INERT if _segment_is_skip_inert(words) else _SCAN
+
+
+def gate_skips_for_visibility(command: str, cwd: Path | None, *, config_path: Path | None = None) -> bool:
+    """Return True iff a pre-publish leak gate should SKIP ``command`` on visibility.
+
+    SKIP (True) only when EVERY top-level segment is provably safe on visibility
+    grounds and at least one is a repo-targeted publish: the leak gate enforces
+    ONLY on an affirmatively-public target (#1415/#1213). A segment is safe when
+    it is one of:
+
+    - a ``gh``/``glab``/``t3 review`` publish whose destination is NOT
+        affirmatively public (private/internal/unknown/unresolvable) and carries
+        no substitution/transport construct;
+    - a raw ``gh``/``glab api`` WRITE whose URL path resolves to a NON-public
+        repo (:func:`_api_write_targets_non_public`);
+    - a read-only ``api`` GET (posts no body); or
+    - a provably-inert navigation / local-only / git-transport segment
+        (:func:`publish_destination._segment_is_skip_inert`).
+
+    Do NOT skip (False) when:
+
+    - any repo-targeted publish resolves to an affirmatively-PUBLIC repo (the
+        gate must fire to catch a real public leak);
+    - a segment carries a ``$(...)``/transport construct, is an unrecognised
+        chained executable (``sh -c``/``make``/``./x.sh`` -- can shell out to a
+        hidden public post), or is a raw ``api`` WRITE to an affirmatively-public
+        URL -- these keep the ALL-SEGMENTS anti-leak posture so an obscured public
+        post cannot hide behind a leading non-public segment;
+    - the command carries a ``git commit`` segment (the landing-repo carve-out
+        and the #703 pre-push backstop own that surface, unchanged); or
+    - the command has no repo-targeted publish segment at all (a Slack/curl post
+        is not repo-scoped, so this scope leaves it to the gate's default).
+    """
+    if _commit_carve_out.command_has_git_commit_segment(command):
+        return False
+    segments = command_segments(command)
+    if not segments:
+        return False
+    saw_repo_publish = False
+    for words in segments:
+        verdict = _segment_visibility_verdict(words, cwd, config_path=config_path)
+        if verdict == _SCAN:
+            return False
+        if verdict == _SKIP_PUBLISH:
+            saw_repo_publish = True
+    return saw_repo_publish

--- a/src/teatree/hooks/publish_destination.py
+++ b/src/teatree/hooks/publish_destination.py
@@ -1,44 +1,40 @@
-"""Destination-aware gate skip for the pre-publish gates (publish-surface purpose).
+"""Publish-destination resolution + classification for the pre-publish gates.
 
-The banned-terms (#1415) and bare-reference (#1530) gates exist to stop
-leaks on PUBLIC surfaces. Firing on EVERY publish command -- including
-writes to an INTERNAL/PRIVATE repo or namespace -- over-blocks: a private
-repo's own customer/domain terms and bare cross-references are exactly
-what its issues/PRs are supposed to carry.
+The banned-terms (#1415), quote-scanner (#1213) and bare-reference (#1530)
+gates exist to stop leaks on PUBLIC surfaces. This module RESOLVES a publish
+command's target repo/namespace and CLASSIFIES it; the visibility-scoped SKIP
+decision the leak gates call lives in :mod:`teatree.hooks.public_visibility`.
 
-:func:`resolve_publish_destination` extracts the target repo/namespace
-from the COMMAND ITSELF (the ``--repo``/``-R`` flag, the ``api`` URL path,
-or the cwd git remote) and :func:`is_public_destination` classifies THAT
-resolved target FAIL-CLOSED against an INTERNAL DENYLIST: a destination is
-PUBLIC (gate scans/blocks) UNLESS it is PROVABLY internal -- its namespace
-matches the config-driven ``[teatree] internal_publish_namespaces`` allowlist
-(or the ``T3_INTERNAL_PUBLISH_NAMESPACES`` env var), the
-``[teatree] private_repos`` allowlist, or the day-cached ``gh``/``glab``
-live-visibility probe returns a CONFIRMED-PRIVATE verdict. Every OTHER target
--- a genuinely-public non-teatree repo (a user's other public repos), a
-third-party repo, an UNKNOWN-visibility target, or an UNRESOLVABLE target --
-stays PUBLIC and is SCANNED. This is the only safe default: an allowlist of
-"surfaces to scan" would fail OPEN on a public repo nobody remembered to list,
-leaking an internal term unscanned onto a public surface. Resolving the target
-from the command rather than the harness cwd is what lets a post FROM a public
-clone TO a provably-private repo skip the public-leak scan instead of
-over-blocking. With nothing configured and no probe-resolvable private verdict,
-every destination stays PUBLIC, so behaviour is conservative for unconfigured
-users. :func:`gate_skips_destination` is the composed predicate the gates call.
+:func:`resolve_publish_destination` / :func:`_destination_from_words` extract
+the target repo/namespace from the COMMAND ITSELF (the ``--repo``/``-R`` flag,
+the ``gh``/``glab api`` URL path, a forge URL positional, ``GH_REPO``, the
+``t3 review`` project positional, or the cwd git remote).
+
+Two classifiers over that target, with OPPOSITE fail directions for two
+consumers:
+
+- :func:`is_public_destination` -- FAIL-CLOSED. A destination is PUBLIC (the
+    caller scans) UNLESS it is PROVABLY internal (an ``internal_publish_namespaces``
+    / ``private_repos`` allowlist match, or a CONFIRMED-PRIVATE probe verdict).
+    An unknown/unresolvable target stays PUBLIC. This conservative classifier is
+    consumed by the FSM-level :mod:`teatree.core.gates.privacy_gate`.
+- :func:`public_visibility.is_affirmatively_public` -- FAIL-OPEN. A destination
+    is public ONLY on a CONFIRMED-PUBLIC probe verdict for a non-allowlisted
+    slug; a private/internal/unknown/unresolvable target is NON-public. The
+    PreToolUse leak gates (#1415/#1213) use this so they enforce ONLY on an
+    affirmatively-public repo and never false-block a non-public one.
 
 The hook process is overlay-agnostic and cannot import ``OverlayConfig``; it
 reads the internal denylist from ``~/.teatree.toml`` DIRECTLY (the
 ``internal_publish_namespaces`` / ``private_repos`` readers in
-:mod:`teatree.hooks._repo_visibility` and this module). The canonical public
-teatree repo needs no entry -- it is public, so the fail-closed default already
-scans it.
+:mod:`teatree.hooks._repo_visibility` and this module).
 
 The shared command-parsing helpers (``_extract_repo_flag``, the
 eligible-verb sets) live in :mod:`teatree.hooks.publish_surface` and the
 repo-target resolution (``slug_for_cwd``, ``_config_path``) in
 :mod:`teatree.hooks._repo_visibility`; this module reuses them so the
-repo-target resolution stays in one place across both the private-repo
-carve-out and the destination skip.
+repo-target resolution stays in one place across the private-repo carve-out,
+the FSM privacy gate, and the affirmative-public leak-gate scope.
 """
 
 import os
@@ -48,9 +44,7 @@ from pathlib import Path, PurePosixPath
 from typing import Final
 
 from teatree.hooks._command_parser import first_segment_words
-from teatree.hooks._gh_glab_hiding import command_segments, token_has_substitution_marker, token_is_transport_construct
-from teatree.hooks._publish_detection import segment_is_api_read as _segment_is_api_read
-from teatree.hooks._publish_detection import segment_is_api_write as _segment_is_api_write
+from teatree.hooks._gh_glab_hiding import token_has_substitution_marker, token_is_transport_construct
 from teatree.hooks._repo_visibility import (
     _config_path,
     forge_qualified_slug,
@@ -347,9 +341,9 @@ def _destination_from_words(words: list[str], cwd: Path | None) -> Destination |
     """Resolve the publish destination of one command segment's word list.
 
     The visibility-independent half of :func:`resolve_publish_destination`,
-    factored out so :func:`gate_skips_destination` can resolve a destination
-    PER top-level segment (the ALL-SEGMENTS invariant) rather than only from
-    the first segment.
+    factored out so :func:`public_visibility.gate_skips_for_visibility` can
+    resolve a destination PER top-level segment (the ALL-SEGMENTS invariant)
+    rather than only from the first segment.
     """
     if not words:
         return None
@@ -384,12 +378,13 @@ def resolve_publish_destination(command: str, cwd: Path | None = None) -> Destin
         with no ``--repo`` flag -- the CURRENT repo, via the git remote of
         ``cwd``.
 
-    Resolves only the FIRST command segment; :func:`gate_skips_destination`
-    is the multi-segment predicate. Returns ``None`` when the target cannot
-    be determined (a non-publish command, a ``curl``/Slack surface, a
-    flagless API call, or a flagless create with no resolvable git remote).
-    ``None`` is the caller's signal to treat the destination as PUBLIC and
-    scan (fail-closed).
+    Resolves only the FIRST command segment;
+    :func:`public_visibility.gate_skips_for_visibility` is the multi-segment
+    predicate. Returns ``None`` when the target cannot be determined (a
+    non-publish command, a ``curl``/Slack surface, a flagless API call, or a
+    flagless create with no resolvable git remote). ``None`` is the fail-closed
+    signal for :func:`is_public_destination` (treat as PUBLIC) and the
+    fail-open signal for the affirmative-public scope (treat as NON-public).
     """
     return _destination_from_words(first_segment_words(command), cwd)
 
@@ -528,94 +523,3 @@ def is_public_destination(dest: Destination | None, *, config_path: Path | None 
     # the GitHub default. A host-qualified slug is unchanged.
     probe_slug = forge_qualified_slug(slug, dest.forge)
     return not slug_is_private(probe_slug)
-
-
-def _api_write_targets_internal_repo(words: list[str], *, config_path: Path | None = None) -> bool:
-    """Return True iff a raw ``api`` WRITE segment provably targets an internal repo.
-
-    A ``gh api`` / ``glab api`` write carries its body only to the endpoint its
-    URL path names. When that path resolves to a repo slug
-    (``repos/<owner>/<repo>`` / ``projects/<ns>%2F<repo>``) that is provably
-    internal, the write cannot leak to a public surface -- updating an MR
-    description on a private customer project is the canonical case. The slug
-    must come from the URL path itself (``via="api"``): an ``-R`` flag does not
-    constrain a raw endpoint. An unresolvable path (a shell variable, a
-    flagless call, an ambiguous unknown flag, a non-repo endpoint) or a
-    public/unknown-visibility slug stays fail-closed.
-    """
-    if not words or words[0] not in {"gh", "glab"}:
-        return False
-    dest = _destination_from_api(words, words[0])
-    if dest is None or dest.via != "api":
-        return False
-    return not is_public_destination(dest, config_path=config_path)
-
-
-def gate_skips_destination(command: str, cwd: Path | None, *, config_path: Path | None = None) -> bool:
-    """Return True iff a publish-surface gate should SKIP scanning ``command``.
-
-    The banned-terms / bare-reference gates scan only PUBLIC targets. The
-    skip is the ALL-SEGMENTS inversion that mirrors
-    :func:`publish_surface.command_is_pure_private_gh_glab_post`: skip ONLY
-    when EVERY top-level segment is provably safe to skip and there is at
-    least one publish segment. A single public, unresolvable, ``api`` WRITE, or
-    substitution/transport-carrying segment makes the WHOLE command scan
-    (fail-closed). Otherwise a chained or substituted public post hides
-    behind a leading internal segment and is never scanned.
-
-    A segment is skip-safe when it is one of:
-
-    - a publish segment whose destination resolves to a provably-INTERNAL
-        repo/namespace, which carries no substitution/transport construct;
-    - a raw ``gh``/``glab api`` WRITE whose URL path itself resolves to a
-        provably-INTERNAL repo (:func:`_api_write_targets_internal_repo`) --
-        the body lands only on that private project's surface, so updating
-        e.g. a private customer MR description is not a public leak. An api
-        WRITE with an unresolvable path (shell variable, non-repo endpoint)
-        or a public/unknown target still fails closed;
-    - a read-only ``gh``/``glab api`` GET (:func:`_segment_is_api_read`) --
-        a read posts NO body, so it can never leak content regardless of the
-        repo its URL names, and is skip-safe without resolving a destination; or
-    - a segment that is PROVABLY a recognised navigation / local-only /
-        git-transport command (:func:`_segment_is_skip_inert` -- its leading
-        executable is in the closed ``_SKIP_INERT_LEADERS`` allowlist, e.g.
-        ``cd``/``echo``/``git push``, with no forge token or
-        substitution/transport construct).
-
-    Every OTHER segment is NOT skip-safe and makes the whole command scan
-    (fail-closed): a raw ``gh api`` / ``glab api`` WRITE whose URL does not
-    prove an internal repo target (it carries a body to an arbitrary
-    endpoint), a
-    ``$(...)`` / process-substitution / redirection construct, a PUBLIC or
-    unresolvable publish destination, and -- the closed inversion -- ANY
-    segment whose leading word is an UNRECOGNISED executable (an interpreter
-    ``sh``/``bash``/``eval``, an ``ssh``/``xargs`` wrapper, a build/script
-    runner ``make``/``npm``/``python``/``./release.sh``, ...). Such a segment
-    resolves to no destination and is not a recognised inert leader, so it
-    could shell out to a hidden public post with no forge token in its own
-    argv; skipping on the strength of a sibling internal segment is exactly the
-    leak this guards. This mirrors the commit chain's prove-pure-or-fail-closed
-    inversion rather than enumerating transports.
-    """
-    segments = command_segments(command)
-    if not segments:
-        return False
-    saw_internal_publish = False
-    for words in segments:
-        if _segment_carries_substitution_or_transport(words):
-            return False
-        if _segment_is_api_write(words):
-            if not _api_write_targets_internal_repo(words, config_path=config_path):
-                return False
-            saw_internal_publish = True
-            continue
-        if _segment_is_api_read(words):
-            continue
-        dest = _destination_from_words(words, cwd)
-        if dest is not None:
-            if is_public_destination(dest, config_path=config_path):
-                return False
-            saw_internal_publish = True
-        elif not _segment_is_skip_inert(words):
-            return False
-    return saw_internal_publish

--- a/tests/teatree_hooks/test_banned_terms_env_override_eval.py
+++ b/tests/teatree_hooks/test_banned_terms_env_override_eval.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import pytest
 
 from hooks.scripts.hook_router import handle_banned_terms_pretool
+from teatree.hooks import _repo_visibility
 from teatree.hooks.banned_terms_scanner import has_override, scan_text
 
 
@@ -91,10 +92,15 @@ class TestBannedTermGenuineGuardIntact:
 
     @pytest.mark.usefixtures("_term_config")
     def test_banned_term_in_post_without_override_is_blocked(
-        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
         monkeypatch.delenv("ALLOW_BANNED_TERM", raising=False)
-        data = _bash('gh issue create --title t --body "acmecorp ships next week"')
+        # The leak gate enforces ONLY on an affirmatively-public target (#1415), so
+        # the genuine-violation guard posts to the public teatree repo with the
+        # probe confirming it public.
+        monkeypatch.setenv("T3_DATA_DIR", str(tmp_path / "viscache"))
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+        data = _bash('gh issue create -R souliane/teatree --title t --body "acmecorp ships next week"')
         blocked = handle_banned_terms_pretool(data)
         assert blocked is True
         out = json.loads(capsys.readouterr().out)
@@ -110,12 +116,18 @@ class TestBannedTermGenuineGuardIntact:
 
     @pytest.mark.usefixtures("_term_config")
     def test_override_on_decoy_segment_does_not_bypass_chained_publish(
-        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
         # The override leads a harmless echo; bash scopes it to that command, so
-        # it must NOT vouch for the banned-term publish chained after it.
+        # it must NOT vouch for the banned-term publish chained after it. The
+        # publish targets the affirmatively-public teatree repo so the leak gate
+        # fires (#1415) and the missing override on that segment blocks.
         monkeypatch.delenv("ALLOW_BANNED_TERM", raising=False)
-        data = _bash('ALLOW_BANNED_TERM=1 echo hi && gh issue create --title t --body "acmecorp ships"')
+        monkeypatch.setenv("T3_DATA_DIR", str(tmp_path / "viscache"))
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+        data = _bash(
+            'ALLOW_BANNED_TERM=1 echo hi && gh issue create -R souliane/teatree --title t --body "acmecorp ships"'
+        )
         blocked = handle_banned_terms_pretool(data)
         assert blocked is True
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"

--- a/tests/teatree_hooks/test_banned_terms_hook.py
+++ b/tests/teatree_hooks/test_banned_terms_hook.py
@@ -12,6 +12,22 @@ from teatree.hooks import _repo_visibility, banned_terms_scanner
 from teatree.hooks._command_parser import is_fail_closed_sentinel
 
 
+@pytest.fixture(autouse=True)
+def _public_teatree_probe(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The leak gate enforces ONLY on an affirmatively-PUBLIC target (#1415), so a
+    # must-BLOCK row toward the genuinely-public ``souliane/teatree`` needs the
+    # probe to CONFIRM it public. Delegate every other slug to the real probe so a
+    # per-test ``_resolve_probe_tool``/``probe_visibility`` shim still governs it
+    # (an unknown/unresolvable target then SKIPS). Isolate the visibility cache.
+    monkeypatch.setenv("T3_DATA_DIR", str(tmp_path / "viscache"))
+    real_probe = _repo_visibility.probe_visibility
+    monkeypatch.setattr(
+        _repo_visibility,
+        "probe_visibility",
+        lambda slug: "PUBLIC" if "souliane/teatree" in slug else real_probe(slug),
+    )
+
+
 @pytest.mark.integration
 def test_banned_terms_hook_expands_tilde_config_path(tmp_path: Path) -> None:
     home = tmp_path / "home"
@@ -80,12 +96,13 @@ def _git(cwd: Path, *args: str) -> None:
 
 
 @pytest.mark.integration
-def test_banned_terms_block_emits_visibility_unknown_note_and_still_denies(
+def test_banned_terms_skips_customer_term_to_unknown_visibility_target(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # A private-LOOKING target whose visibility is UNKNOWN in-hook (no probe
-    # tool resolvable, not in the allowlist) must STILL hard-block, and emit a
-    # diagnostic stderr NOTE pointing the operator at [teatree] private_repos.
+    # A target whose visibility is UNKNOWN in-hook (no probe tool resolvable, not
+    # in the allowlist) is NOT affirmatively public, so the leak gate SKIPS it
+    # entirely (#1415): the post is allowed with no deny. Bias hard toward not
+    # firing -- an unresolvable target is never treated as public.
     home = Path(os.environ["HOME"])  # the conftest-isolated HOME
     (home / ".teatree.toml").write_text('[teatree]\nbanned_terms = ["acmewidget"]\n', encoding="utf-8")
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
@@ -96,9 +113,9 @@ def test_banned_terms_block_emits_visibility_unknown_note_and_still_denies(
     _git(repo, "init", "-b", "main")
     _git(repo, "remote", "add", "origin", "git@github.com:acme/secret-product.git")
 
-    # The probe tool is unreachable in-hook -> visibility "unknown" -> the
-    # block stands. Patching the resolver (not PATH) keeps the shell scanner's
-    # ``bash``/``grep`` reachable so the banned-term match still fires.
+    # The probe tool is unreachable in-hook -> visibility "unknown" -> the gate
+    # skips. Patching the resolver (not PATH) keeps the shell scanner's
+    # ``bash``/``grep`` reachable so a fire, if it happened, would find the term.
     monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
     monkeypatch.delenv("GH_REPO", raising=False)
 
@@ -110,12 +127,8 @@ def test_banned_terms_block_emits_visibility_unknown_note_and_still_denies(
     blocked = handle_banned_terms_pretool(data)
     captured = capsys.readouterr()
 
-    assert blocked is True
-    decision = json.loads(captured.out)
-    assert decision["permissionDecision"] == "deny"
-    assert "banned-terms" in decision["permissionDecisionReason"]
-    assert "acme/secret-product" in captured.err
-    assert "private_repos" in captured.err
+    assert blocked is False
+    assert captured.out == ""  # no deny JSON
 
 
 def test_banned_terms_allowed_when_target_resolvable_private(
@@ -923,14 +936,14 @@ def test_kill_switch_default_on_still_blocks_a_public_post(
     assert json.loads(captured.out)["permissionDecision"] == "deny"
 
 
-# ── #1415 internal-denylist scoping (fail-closed) ────────────────────────────
+# ── #1415 visibility scoping (affirmative-public) ────────────────────────────
 #
 # The reported over-block fired on a publish to a PRIVATE internal remote the
-# user had not declared. The fix is config-driven and FAIL-CLOSED: a target named
-# in ``internal_publish_namespaces`` (the denylist) SKIPS the scan, while EVERY
-# non-internal target -- the public teatree repo, a USER-OWNED non-teatree PUBLIC
-# repo, an unknown/unresolvable target -- still SCANS. An allowlist of "surfaces
-# to scan" would fail OPEN on a public repo nobody listed and leak unscanned.
+# user had not declared. The leak gate enforces ONLY on an affirmatively-PUBLIC
+# target: a target named in ``internal_publish_namespaces`` SKIPS, and so does an
+# unknown/unresolvable one (bias hard toward not firing). ONLY a target the probe
+# CONFIRMS public -- the public teatree repo, a USER-OWNED non-teatree PUBLIC repo
+# -- SCANS. A private/internal/unknown repo must never be falsely blocked.
 
 _DENYLIST_CONFIG = '[teatree]\nbanned_terms = ["customercorp"]\ninternal_publish_namespaces = ["internal-eng"]\n'
 
@@ -983,12 +996,12 @@ def test_live_hook_blocks_customer_term_to_user_owned_non_teatree_public_repo(
     assert decision["permissionDecision"] == "deny"
 
 
-def test_live_hook_blocks_customer_term_to_unknown_visibility_non_denylisted_repo(
+def test_live_hook_skips_customer_term_to_unknown_visibility_non_denylisted_repo(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # MUST-FIRE: a non-denylisted target whose visibility the in-hook probe cannot
-    # resolve (the common cold-hook state) stays PUBLIC and is scanned -- detection
-    # failure never opens the gate.
+    # MUST-SKIP: a non-denylisted target whose visibility the in-hook probe cannot
+    # resolve (the common cold-hook state) is NOT affirmatively public, so the leak
+    # gate SKIPS it (#1415) -- an unknown target is never treated as public.
     home = Path(os.environ["HOME"])
     _write_home_config(home, _DENYLIST_CONFIG, monkeypatch, tmp_path)
     monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
@@ -1002,17 +1015,17 @@ def test_live_hook_blocks_customer_term_to_unknown_visibility_non_denylisted_rep
     blocked = handle_banned_terms_pretool(data)
     captured = capsys.readouterr()
 
-    assert blocked is True
-    decision = json.loads(captured.out)
-    assert decision["permissionDecision"] == "deny"
+    assert blocked is False
+    assert captured.out == ""  # no deny JSON
 
 
-def test_live_hook_scans_unresolvable_target_failsafe(
+def test_live_hook_skips_unresolvable_target(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # FAIL-SAFE: a publish whose target cannot be resolved from the command (a
-    # flagless create whose cwd has NO git remote -> destination None) keeps
-    # scanning and blocks the term. An unparsable target is never a silent bypass.
+    # MUST-SKIP: a publish whose target cannot be resolved from the command (a
+    # flagless create whose cwd has NO git remote -> destination None) is not
+    # affirmatively public, so the gate SKIPS it. Bias hard toward not firing:
+    # an unresolvable ``gh``/``glab`` publish is never treated as a public leak.
     home = Path(os.environ["HOME"])
     _write_home_config(home, _DENYLIST_CONFIG, monkeypatch, tmp_path)
     monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
@@ -1030,9 +1043,8 @@ def test_live_hook_scans_unresolvable_target_failsafe(
     blocked = handle_banned_terms_pretool(data)
     captured = capsys.readouterr()
 
-    assert blocked is True
-    decision = json.loads(captured.out)
-    assert decision["permissionDecision"] == "deny"
+    assert blocked is False
+    assert captured.out == ""  # no deny JSON
 
 
 def test_posting_body_file_resolves_against_cwd(tmp_path: Path) -> None:

--- a/tests/teatree_hooks/test_banned_terms_public_slug_with_term_blocks.py
+++ b/tests/teatree_hooks/test_banned_terms_public_slug_with_term_blocks.py
@@ -1,20 +1,18 @@
-"""A banned term on a slug-carries-term destination still BLOCKS unless private.
+"""A banned term on a slug-carries-term destination BLOCKS only when public.
 
 The #2597 carve-out downgraded a banned-term block to a warn whenever the
 resolved destination slug carried the term as a whole-token run -- with NO
-visibility check. Because the banned-terms deny path is only reached AFTER
-``gate_skips_destination`` has already returned False (the destination is NOT
-provably-internal -- it is PUBLIC or unknown-visibility), the slug-text
-downgrade fired precisely on the destinations the fail-closed design protects.
-An org/repo slug is attacker-controllable (``<term>-eng/tracker``), so a
-genuinely-public repo whose slug carries the term could silence the leak block.
+visibility check. An org/repo slug is attacker-controllable (``<term>-eng/tracker``),
+so a genuinely-public repo whose slug carries the term could silence the leak
+block.
 
-These tests pin the HARD invariant: a downgrade is permissible ONLY when the
-destination is PROVABLY internal. A PUBLIC destination, and an UNKNOWN-visibility
-destination (indeterminate probe -> fail closed), both BLOCK even when the slug
-carries the term. The companion ``TestProvablyPrivateDestinationStillAllowed``
-proves the #2597 false positive is still resolved the sound (config) way, so the
-fix did not simply block everything.
+These tests pin the HARD invariant on the PUBLIC surface the leak gate now
+scopes to: a CONFIRMED-PUBLIC destination BLOCKS even when the slug carries the
+term (the slug-text match must not vouch for a public leak). An
+UNKNOWN-visibility destination is NOT affirmatively public, so the gate SKIPS it
+entirely (#1415 -- bias hard toward not firing). The companion
+``TestProvablyPrivateDestinationStillAllowed`` proves a provably-private
+destination is likewise skipped via the config allowlist.
 
 Synthetic terms only (``apple`` / ``democorp`` / ``othercorp``) -- the
 overlay-leak-tree runs on PRs.
@@ -103,7 +101,7 @@ class TestPublicSlugCarryingTermStillBlocks:
         assert term in decision["permissionDecisionReason"]
 
     @pytest.mark.parametrize(("command", "term"), _SLUG_CARRIES_TERM_EXPLOITS)
-    def test_unknown_visibility_destination_blocks(
+    def test_unknown_visibility_destination_skips(
         self,
         command: str,
         term: str,
@@ -111,24 +109,22 @@ class TestPublicSlugCarryingTermStillBlocks:
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        # Indeterminate probe (tool absent in-hook). Fail CLOSED: an
-        # unknown-visibility destination is NOT provably-internal, so the
-        # slug-text match must never downgrade the block.
+        # Indeterminate probe (tool absent in-hook). An unknown-visibility
+        # destination is NOT affirmatively public, so the leak gate SKIPS it
+        # entirely (#1415) -- the post is allowed, bias hard toward not firing.
         _pin_probe(monkeypatch, None)
         blocked = handle_banned_terms_pretool(_bash(command))
-        assert blocked is True, "a banned term on an UNKNOWN-visibility slug-carries-term destination must BLOCK"
-        decision = json.loads(capsys.readouterr().out)
-        assert decision["permissionDecision"] == "deny"
-        assert term in decision["permissionDecisionReason"]
+        assert blocked is False, "a banned term on an UNKNOWN-visibility destination must SKIP"
+        assert capsys.readouterr().out == ""  # no deny JSON
 
 
 class TestProvablyPrivateDestinationStillAllowed:
     """The #2597 false positive is resolved the SOUND (config) way.
 
-    A provably-internal destination (declared in ``private_repos``) has the WHOLE
-    banned-terms gate skipped by ``gate_skips_destination`` -- the overlay name on
-    its own private surface is not a leak. This proves the fix did not block
-    everything; it blocks only on non-provably-internal destinations.
+    A provably-private destination (declared in ``private_repos``) has the WHOLE
+    banned-terms gate skipped by ``gate_skips_for_visibility`` -- the overlay name
+    on its own private surface is not a leak. This proves the gate blocks only on
+    an affirmatively-public destination.
     """
 
     def test_private_tracker_in_allowlist_is_allowed_offline(

--- a/tests/teatree_hooks/test_banned_terms_scanner.py
+++ b/tests/teatree_hooks/test_banned_terms_scanner.py
@@ -57,6 +57,19 @@ def _pin_config(config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("T3_BANNED_TERMS_CONFIG", str(config))
 
 
+@pytest.fixture(autouse=True)
+def _confirm_public_probe(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The leak gate enforces ONLY on an affirmatively-PUBLIC target (#1415), so the
+    # must-BLOCK rows post to a resolvable target the probe confirms public. The
+    # config-allowlisted (``private_repos``) and internal-namespace targets resolve
+    # NON-public BEFORE the probe, so their must-SKIP rows are unaffected by this
+    # pin. Isolate the visibility cache so a stale entry never masks the pin. A
+    # per-test ``probe_visibility`` setattr (the commit-path visibility rows)
+    # overrides this default.
+    monkeypatch.setenv("T3_DATA_DIR", str(tmp_path / "viscache"))
+    monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+
+
 def _bash(command: str) -> dict[str, object]:
     return {"tool_name": "Bash", "tool_input": {"command": command}}
 
@@ -1252,7 +1265,9 @@ class TestHookHandlerEndToEnd:
         assert capsys.readouterr().out == ""
 
     def test_banned_term_body_blocks(self, capsys: pytest.CaptureFixture[str]) -> None:
-        blocked = handle_banned_terms_pretool(_bash('gh issue create --title t --body "ship to acmecorp"'))
+        blocked = handle_banned_terms_pretool(
+            _bash('gh issue create -R souliane/teatree --title t --body "ship to acmecorp"')
+        )
         assert blocked is True
         decision = json.loads(capsys.readouterr().out)
         assert decision["permissionDecision"] == "deny"
@@ -1261,7 +1276,9 @@ class TestHookHandlerEndToEnd:
     def test_body_file_is_read_and_blocks(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         body_file = tmp_path / "issue_body.md"
         body_file.write_text("This affects acmecorp's deployment.\n", encoding="utf-8")
-        blocked = handle_banned_terms_pretool(_bash(f"gh pr create --title t --body-file {body_file}"))
+        blocked = handle_banned_terms_pretool(
+            _bash(f"gh pr create -R souliane/teatree --title t --body-file {body_file}")
+        )
         assert blocked is True
         decision = json.loads(capsys.readouterr().out)
         assert decision["permissionDecision"] == "deny"
@@ -1315,7 +1332,7 @@ class TestHookHandlerEndToEnd:
         # walker, the file went unread, and the term slipped through.)
         body_file = tmp_path / "issue_body.md"
         body_file.write_text("This affects acmecorp's deployment.\n", encoding="utf-8")
-        blocked = handle_banned_terms_pretool(_bash(f"gh pr create --title t -F {body_file}"))
+        blocked = handle_banned_terms_pretool(_bash(f"gh pr create -R souliane/teatree --title t -F {body_file}"))
         assert blocked is True
         decision = json.loads(capsys.readouterr().out)
         assert decision["permissionDecision"] == "deny"
@@ -1341,7 +1358,7 @@ class TestHookHandlerEndToEnd:
         # ``--body-file`` form: its file body is read and a banned term blocks.
         body_file = tmp_path / "issue_body.md"
         body_file.write_text("This affects acmecorp's deployment.\n", encoding="utf-8")
-        blocked = handle_banned_terms_pretool(_bash(f"gh pr create --title t -F{body_file}"))
+        blocked = handle_banned_terms_pretool(_bash(f"gh pr create -R souliane/teatree --title t -F{body_file}"))
         assert blocked is True
         decision = json.loads(capsys.readouterr().out)
         assert decision["permissionDecision"] == "deny"
@@ -1356,12 +1373,16 @@ class TestHookHandlerEndToEnd:
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
 
     def test_gh_pr_comment_with_banned_term_blocks(self, capsys: pytest.CaptureFixture[str]) -> None:
-        blocked = handle_banned_terms_pretool(_bash('gh pr comment 5 --body "acmecorp asked for this"'))
+        blocked = handle_banned_terms_pretool(
+            _bash('gh pr comment 5 -R souliane/teatree --body "acmecorp asked for this"')
+        )
         assert blocked is True
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
 
     def test_glab_mr_note_with_banned_term_blocks(self, capsys: pytest.CaptureFixture[str]) -> None:
-        blocked = handle_banned_terms_pretool(_bash('glab mr note 5 --message "acmecorp wants this"'))
+        blocked = handle_banned_terms_pretool(
+            _bash('glab mr note 5 -R souliane/teatree --message "acmecorp wants this"')
+        )
         assert blocked is True
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
 
@@ -1399,7 +1420,9 @@ class TestHookHandlerEndToEnd:
             raise banned_terms_scanner.CommandFailedError(["check"], 1, "", "ImportError")
 
         monkeypatch.setattr(banned_terms_scanner, "run_allowed_to_fail", _crash)
-        blocked = handle_banned_terms_pretool(_bash('gh issue create --title t --body "ship next week"'))
+        blocked = handle_banned_terms_pretool(
+            _bash('gh issue create -R souliane/teatree --title t --body "ship next week"')
+        )
         assert blocked is True
         decision = json.loads(capsys.readouterr().out)
         assert decision["permissionDecision"] == "deny"
@@ -1545,7 +1568,9 @@ class TestBannedTermPublishFormsMustBlock:
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
 
     def test_gh_pr_create_inline_body_banned_term_blocks(self, capsys: pytest.CaptureFixture[str]) -> None:
-        blocked = handle_banned_terms_pretool(_bash('gh pr create --title "feat" --body "Deploy to acmecorp cluster"'))
+        blocked = handle_banned_terms_pretool(
+            _bash('gh pr create -R souliane/teatree --title "feat" --body "Deploy to acmecorp cluster"')
+        )
         assert blocked is True
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
 
@@ -1554,13 +1579,15 @@ class TestBannedTermPublishFormsMustBlock:
     ) -> None:
         body_file = tmp_path / "pr_body.md"
         body_file.write_text("This PR fixes the acmecorp integration.\n", encoding="utf-8")
-        blocked = handle_banned_terms_pretool(_bash(f"gh pr create --title t --body-file {body_file}"))
+        blocked = handle_banned_terms_pretool(
+            _bash(f"gh pr create -R souliane/teatree --title t --body-file {body_file}")
+        )
         assert blocked is True
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
 
     def test_gh_issue_create_inline_body_banned_term_blocks(self, capsys: pytest.CaptureFixture[str]) -> None:
         blocked = handle_banned_terms_pretool(
-            _bash('gh issue create --title "Bug" --body "acmecorp reports this error"')
+            _bash('gh issue create -R souliane/teatree --title "Bug" --body "acmecorp reports this error"')
         )
         assert blocked is True
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
@@ -1570,13 +1597,15 @@ class TestBannedTermPublishFormsMustBlock:
     ) -> None:
         body_file = tmp_path / "issue_body.md"
         body_file.write_text("acmecorp's deployment is broken.\n", encoding="utf-8")
-        blocked = handle_banned_terms_pretool(_bash(f"gh issue create --title t --body-file {body_file}"))
+        blocked = handle_banned_terms_pretool(
+            _bash(f"gh issue create -R souliane/teatree --title t --body-file {body_file}")
+        )
         assert blocked is True
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
 
     def test_glab_mr_create_inline_description_banned_term_blocks(self, capsys: pytest.CaptureFixture[str]) -> None:
         blocked = handle_banned_terms_pretool(
-            _bash('glab mr create --title "feat" --description "Update acmecorp config"')
+            _bash('glab mr create -R souliane/teatree --title "feat" --description "Update acmecorp config"')
         )
         assert blocked is True
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
@@ -1586,7 +1615,9 @@ class TestBannedTermPublishFormsMustBlock:
     ) -> None:
         body_file = tmp_path / "mr_body.md"
         body_file.write_text("This MR updates the acmecorp adapter.\n", encoding="utf-8")
-        blocked = handle_banned_terms_pretool(_bash(f"glab mr create --title t --description-file {body_file}"))
+        blocked = handle_banned_terms_pretool(
+            _bash(f"glab mr create -R souliane/teatree --title t --description-file {body_file}")
+        )
         assert blocked is True
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
 
@@ -1751,12 +1782,13 @@ class TestLeadingEnvOverride:
 
 @pytest.mark.integration
 class TestDestinationAwareGate:
-    """The gate scans only PUBLIC targets (#1415 destination-awareness).
+    """The gate scans only affirmatively-PUBLIC targets (#1415 destination-awareness).
 
-    FAIL-CLOSED: a banned term posted to the genuinely-public
-    ``souliane/teatree`` is still blocked; the same term posted to a
-    configured internal namespace is allowed; an unresolvable destination
-    stays blocked.
+    A banned term posted to the probe-confirmed-public ``souliane/teatree`` is
+    blocked; the same term posted to a configured internal namespace is allowed.
+    A ``curl`` transport carrying no resolvable repo destination is NOT a
+    ``gh``/``glab`` publish the visibility scope covers, so it keeps scanning
+    (the ALL-SEGMENTS anti-leak posture) and stays blocked.
     """
 
     def test_banned_term_to_public_repo_is_blocked(self, capsys: pytest.CaptureFixture[str]) -> None:
@@ -1793,8 +1825,9 @@ class TestDestinationAwareGate:
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
 
     def test_banned_term_unparseable_destination_still_blocks(self, capsys: pytest.CaptureFixture[str]) -> None:
-        # A Slack-bound ``chat.postMessage`` curl has no resolvable repo
-        # destination → PUBLIC (fail-closed) → still blocked.
+        # A Slack-bound ``chat.postMessage`` curl is not a ``gh``/``glab`` publish
+        # the visibility scope covers; it forces a scan (ALL-SEGMENTS anti-leak) and
+        # the term is still blocked.
         cmd = "curl -d text=acmecorp https://slack.com/api/chat.postMessage"
         blocked = handle_banned_terms_pretool(_bash(cmd))
         assert blocked is True

--- a/tests/teatree_hooks/test_public_visibility.py
+++ b/tests/teatree_hooks/test_public_visibility.py
@@ -1,0 +1,154 @@
+"""The pre-publish leak gates enforce ONLY on affirmatively-public targets (#1415/#1213).
+
+The banned-terms (#1415) and quote-scanner (#1213) PUBLISH gates protect against
+leaking internal vocabulary / user quotes onto PUBLIC surfaces, so they enforce
+ONLY when the target repository is affirmatively ``public``. For EVERY other case
+-- a ``private``/``internal`` repo, or a target whose visibility cannot be
+resolved in-hook (the common cold-hook state) -- the gate is SKIPPED entirely
+(bias hard toward not firing: a non-public repo must never be falsely blocked).
+
+These tests drive BOTH live handlers across the three-visibility matrix with the
+forge visibility probe mocked (no ``gh``/``glab``, no network): a PUBLIC target
+carrying a leak FIRES, and both a PRIVATE and an UNRESOLVABLE target carrying the
+SAME leak SKIP. The public FIRE row is the anti-vacuity guard for the two SKIP
+rows -- it proves they are green because the target is non-public, not because
+the gate stopped detecting the leak. The unit block pins the polarity of the
+:func:`public_visibility.gate_skips_for_visibility` predicate the handlers call.
+"""
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from hooks.scripts.hook_router import handle_banned_terms_pretool, handle_quote_scanner_pretool
+from teatree.hooks import _repo_visibility, public_visibility
+from teatree.hooks.publish_destination import resolve_publish_destination
+
+_BANNED_TERM = "acmecorp"
+_BANNED_LEAK = f"rolling out {_BANNED_TERM} integration"
+_QUOTE_LEAK = "## User mandate\nplease ship now"
+
+# (handler, leak body, deny-reason token) for each leak gate under test.
+_GATES = [
+    pytest.param(handle_banned_terms_pretool, _BANNED_LEAK, "banned-terms", id="banned-terms-#1415"),
+    pytest.param(handle_quote_scanner_pretool, _QUOTE_LEAK, "quote-scanner", id="quote-scanner-#1213"),
+]
+
+Handler = Callable[[dict], bool | None]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Isolate the probe cache (T3_DATA_DIR) and the config home so the unit block
+    # (which does not request ``leak_home``) never reads the developer's real
+    # ``~/.teatree.toml`` or a warm visibility cache. ``leak_home`` re-points both.
+    home = tmp_path / "autohome"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".teatree.toml").write_text("[teatree]\n", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setenv("T3_DATA_DIR", str(tmp_path / "viscache"))
+
+
+@pytest.fixture
+def leak_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point ``~/.teatree.toml`` at a temp config with the banned term, isolate state.
+
+    Isolates the probe cache + quote ledger under ``tmp_path`` (``T3_DATA_DIR``)
+    so no test touches real state, and pins the banned-terms list for #1415.
+    """
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / ".teatree.toml").write_text(f'[teatree]\nbanned_terms = ["{_BANNED_TERM}"]\n', encoding="utf-8")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setenv("T3_DATA_DIR", str(tmp_path / "data"))
+    return home
+
+
+def _post(slug: str, body: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": f'gh issue create --repo {slug} --title t --body "{body}"'}}
+
+
+@pytest.mark.usefixtures("leak_home")
+@pytest.mark.parametrize(("handler", "leak_body", "reason_token"), _GATES)
+def test_public_target_with_leak_fires(
+    handler: Handler,
+    leak_body: str,
+    reason_token: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # A leak toward an affirmatively-PUBLIC target (probe confirms public) is a
+    # real public leak -> the gate DENIES. Anti-vacuity guard for the SKIP rows.
+    monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+    blocked = handler(_post("souliane/teatree", leak_body))
+    decision = json.loads(capsys.readouterr().out)
+    assert blocked is True
+    assert decision["permissionDecision"] == "deny"
+    assert reason_token in decision["permissionDecisionReason"]
+
+
+@pytest.mark.usefixtures("leak_home")
+@pytest.mark.parametrize(("handler", "leak_body", "reason_token"), _GATES)
+def test_private_target_with_leak_skips(
+    handler: Handler,
+    leak_body: str,
+    reason_token: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # The SAME leak toward a probe-CONFIRMED-PRIVATE target is not a public leak
+    # -> the gate SKIPS it entirely (no deny). A private repo is never blocked.
+    monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PRIVATE")
+    blocked = handler(_post("someowner/private-svc", leak_body))
+    assert blocked is False
+    assert capsys.readouterr().out == ""  # no deny JSON
+
+
+@pytest.mark.usefixtures("leak_home")
+@pytest.mark.parametrize(("handler", "leak_body", "reason_token"), _GATES)
+def test_unresolvable_target_with_leak_skips(
+    handler: Handler,
+    leak_body: str,
+    reason_token: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # The SAME leak toward a target whose visibility the in-hook probe cannot
+    # resolve (returns None -- the common cold-hook / lookup-failure state) is NOT
+    # affirmatively public, so the gate SKIPS it (bias hard toward not firing).
+    monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+    blocked = handler(_post("someowner/mystery", leak_body))
+    assert blocked is False
+    assert capsys.readouterr().out == ""  # no deny JSON
+
+
+class TestGateSkipsForVisibilityPolarity:
+    """The predicate both handlers call: SKIP unless the target is affirmatively public."""
+
+    @staticmethod
+    def _skips(command: str, monkeypatch: pytest.MonkeyPatch, verdict: str | None) -> bool:
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: verdict)
+        return public_visibility.gate_skips_for_visibility(command, cwd=None)
+
+    def test_confirmed_public_target_does_not_skip(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert self._skips("gh issue create --repo souliane/teatree --body x", monkeypatch, "PUBLIC") is False
+
+    def test_confirmed_private_target_skips(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert self._skips("gh issue create --repo owner/private-svc --body x", monkeypatch, "PRIVATE") is True
+
+    def test_unresolvable_target_skips(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert self._skips("gh issue create --repo owner/mystery --body x", monkeypatch, None) is True
+
+    def test_is_affirmatively_public_only_on_confirmed_public(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Distinct slugs so the per-slug day-cache does not carry the first
+        # verdict into the second assertion.
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+        public_dest = resolve_publish_destination("gh issue create --repo souliane/teatree --body x")
+        assert public_visibility.is_affirmatively_public(public_dest) is True
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        unknown_dest = resolve_publish_destination("gh issue create --repo owner/mystery --body x")
+        assert public_visibility.is_affirmatively_public(unknown_dest) is False

--- a/tests/teatree_hooks/test_publish_destination.py
+++ b/tests/teatree_hooks/test_publish_destination.py
@@ -1,12 +1,13 @@
-"""Tests for the destination-aware gate skip (`teatree.hooks.publish_destination`).
+"""Tests for publish-destination resolution + the affirmative-public gate skip.
 
 ``resolve_publish_destination`` extracts the target repo/namespace of a
 publish command; ``is_public_destination`` classifies it FAIL-CLOSED
-(PUBLIC unless its namespace provably matches the config-driven
-``[teatree] internal_publish_namespaces`` / ``T3_INTERNAL_PUBLISH_NAMESPACES``
-allowlist); ``gate_skips_destination`` is the composed predicate the
-banned-terms (#1415) and bare-reference (#1530) gates call to scan only
-PUBLIC targets.
+(PUBLIC unless provably internal -- consumed by the FSM privacy gate);
+``public_visibility.gate_skips_for_visibility`` is the composed predicate the
+banned-terms (#1415) / quote-scanner (#1213) gates call, which enforces ONLY on
+an affirmatively-PUBLIC target: a private/internal/unknown/unresolvable target
+SKIPS (bias hard toward not firing), while an affirmatively-public probe verdict
+scans.
 
 Synthetic namespaces only (``internalcorp``, ``acme-internal``, the
 genuinely-public ``souliane/teatree``); the allowlist lives in the user's
@@ -19,7 +20,19 @@ from pathlib import Path
 
 import pytest
 
-from teatree.hooks import _repo_visibility, publish_destination
+from teatree.hooks import _repo_visibility, public_visibility, publish_destination
+
+
+@pytest.fixture(autouse=True)
+def _isolate_visibility_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate the on-disk visibility cache so no test hits a real probe verdict.
+
+    Each test drives the probe verdict explicitly for any target that reaches
+    the live probe; an unmocked target resolves ``None`` (unknown, via the
+    unresolvable probe tool) rather than shelling out to a real ``gh``/``glab``.
+    """
+    monkeypatch.setenv("T3_DATA_DIR", str(tmp_path / "viscache"))
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
 
 
 def _git(cwd: Path, *args: str) -> None:
@@ -256,21 +269,22 @@ class TestIsPublicDestination:
 
 
 class TestGateSkipsDestination:
-    """The composed predicate the gates call: SKIP only a provably-internal target."""
+    """The composed predicate the gates call: SKIP unless the target is affirmatively PUBLIC."""
 
     def test_internal_flag_target_is_skipped(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path, ["internalcorp"])
         assert (
-            publish_destination.gate_skips_destination(
+            public_visibility.gate_skips_for_visibility(
                 "glab mr note 5 -R internalcorp/private-svc --message x", None, config_path=cfg
             )
             is True
         )
 
-    def test_public_flag_target_is_not_skipped(self, tmp_path: Path) -> None:
+    def test_public_flag_target_is_not_skipped(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         cfg = _config(tmp_path, ["internalcorp"])
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
         assert (
-            publish_destination.gate_skips_destination(
+            public_visibility.gate_skips_for_visibility(
                 "gh pr create -R souliane/teatree --title x", None, config_path=cfg
             )
             is False
@@ -279,7 +293,7 @@ class TestGateSkipsDestination:
     def test_unresolvable_destination_is_not_skipped(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path, ["internalcorp"])
         assert (
-            publish_destination.gate_skips_destination("curl -d x https://example.com", None, config_path=cfg) is False
+            public_visibility.gate_skips_for_visibility("curl -d x https://example.com", None, config_path=cfg) is False
         )
 
     @pytest.mark.parametrize(
@@ -300,7 +314,7 @@ class TestGateSkipsDestination:
         # NOT let it skip the whole command's leak scan (fail-closed).
         cfg = _config(tmp_path, ["internalcorp"])
         cmd = f"gh pr create -R internalcorp/private-svc --body hi && {wrapper}"
-        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is False
 
     @pytest.mark.parametrize(
         "tail",
@@ -314,7 +328,7 @@ class TestGateSkipsDestination:
         # local work chained off a legitimate internal publish.
         cfg = _config(tmp_path, ["internalcorp"])
         cmd = f'gh pr create -R internalcorp/private-svc --body "ok" && {tail}'
-        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is True
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is True
 
     @pytest.mark.parametrize(
         "read",
@@ -333,14 +347,16 @@ class TestGateSkipsDestination:
         # command on the bare ``api`` word (#1530 over-block).
         cfg = _config(tmp_path, ["internalcorp"])
         cmd = f'gh pr create -R internalcorp/private-svc --body "ok" && {read}'
-        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is True
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is True
 
-    def test_api_write_chain_still_fails_closed(self, tmp_path: Path) -> None:
-        # Leak guard: a chained ``api`` WRITE carries a body to an arbitrary
-        # endpoint, so a leading internal post must NOT let it skip the leak scan.
+    def test_api_write_chain_to_public_still_scans(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Leak guard: a chained ``api`` WRITE to an affirmatively-PUBLIC repo
+        # carries a body to a public surface, so a leading internal post must NOT
+        # let it skip the leak scan.
         cfg = _config(tmp_path, ["internalcorp"])
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
         cmd = "gh pr create -R internalcorp/private-svc --body ok && gh api repos/souliane/teatree/issues -f body=x"
-        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is False
 
     @pytest.mark.parametrize(
         "write",
@@ -367,50 +383,43 @@ class TestGateSkipsDestination:
         # surface (e.g. updating a customer MR description). It must skip the
         # public-leak scan instead of forcing the override escape hatch.
         cfg = _config(tmp_path, ["internalcorp"])
-        assert publish_destination.gate_skips_destination(write, None, config_path=cfg) is True
+        assert public_visibility.gate_skips_for_visibility(write, None, config_path=cfg) is True
 
     @pytest.mark.parametrize(
         "write",
         [
             'glab api --method PUT "projects/$opp/merge_requests/7562" --input /tmp/body.json',
             "gh api /user -f name=x",
-            "glab api projects/souliane%2Fteatree/issues -f title=x",
             "gh api --jq repos/internalcorp/private-svc user/keys -f key=x",
         ],
-        ids=["unexpanded-variable", "non-repo-endpoint", "public-repo", "unknown-flag-value-misparse"],
+        ids=["unexpanded-variable", "non-repo-endpoint", "unknown-flag-value-misparse"],
     )
-    def test_api_write_without_provable_internal_target_fails_closed(self, tmp_path: Path, write: str) -> None:
-        # The carve-out needs the slug from the URL path itself: a shell
-        # variable, a non-repo endpoint, or a public repo stays fail-closed.
-        # The ``--jq`` row pins the value-misparse hole: a known value-taking
-        # flag's VALUE that merely LOOKS like an internal repo path must not
-        # stand in for the real (public-surface) endpoint positional.
+    def test_api_write_to_unresolvable_target_skips(self, tmp_path: Path, write: str) -> None:
+        # An ``api`` WRITE whose URL path does not resolve to a repo -- a shell
+        # variable (``$opp``, unknowable runtime value), a non-repo endpoint
+        # (``/user``), or a value-misparse hole (``--jq``'s value LOOKS like an
+        # internal repo, real endpoint ``user/keys`` is non-repo) -- has an
+        # UNKNOWN target, so it SKIPS (bias hard toward not firing; #1415/#1213).
         cfg = _config(tmp_path, ["internalcorp"])
-        assert publish_destination.gate_skips_destination(write, None, config_path=cfg) is False
+        assert public_visibility.gate_skips_for_visibility(write, None, config_path=cfg) is True
 
-    def test_unexpanded_variable_slug_unprovable_even_when_probe_answers_private(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        # The visibility probe is a PROOF source, but an unexpanded ``$var``
-        # slug has an unknowable runtime value -- no probe answer about the
-        # literal ``$opp`` string can prove anything about the repo the
-        # expanded command will actually hit. Even a private-answering probe
-        # must leave it PUBLIC (fail-closed).
+    def test_api_write_to_public_repo_still_scans(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # An ``api`` WRITE whose URL path resolves to an affirmatively-PUBLIC
+        # repo must NOT skip -- the public-surface leak scan must fire.
         cfg = _config(tmp_path, ["internalcorp"])
-        monkeypatch.setattr(publish_destination, "slug_is_private", lambda slug: True)
-        cmd = 'glab api --method PUT "projects/$opp/merge_requests/7562" --input /tmp/body.json'
-        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+        cmd = "glab api projects/souliane%2Fteatree/issues -f title=x"
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is False
 
 
 class TestInternalDenylistScoping:
-    """#1415 fix: SCAN by default; SKIP only a PROVABLY-internal target (denylist).
+    """#1415/#1213 scope: enforce ONLY on an affirmatively-PUBLIC target.
 
-    The original over-block fired on a publish to a PRIVATE internal remote the
-    user had not declared. The fix is config-driven: with the user's internal
-    namespace in ``internal_publish_namespaces`` (the denylist), that internal
-    target SKIPS, while EVERY non-internal target -- a genuinely-public
-    non-teatree repo, an unknown target, an unresolvable target -- still SCANS.
-    The classifier stays FAIL-CLOSED so no public surface can leak unscanned.
+    A private internal namespace in ``internal_publish_namespaces`` (the
+    denylist) SKIPS; an affirmatively-PUBLIC probe verdict SCANS; and an
+    unknown/unresolvable target now SKIPS too (bias hard toward not firing so a
+    non-public repo is never falsely blocked). A non-repo surface (a Slack
+    ``curl``) is not repo-scoped, so this scope leaves it to the gate's default.
     """
 
     def test_denylisted_internal_target_skips(self, tmp_path: Path) -> None:
@@ -419,39 +428,38 @@ class TestInternalDenylistScoping:
         # provably internal, so the gate skips.
         cfg = _config(tmp_path, ["internal-eng"])
         cmd = 'glab mr note 5 -R internal-eng/internal-product --message "customercorp note"'
-        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is True
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is True
 
     def test_user_owned_non_teatree_public_repo_is_scanned(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # F3 (the leak path the review caught): a USER-OWNED non-teatree PUBLIC
-        # repo (e.g. a blog repo) is NOT in the denylist and the probe confirms it
-        # PUBLIC, so it must SCAN. A fail-open allowlist would have skipped it and
-        # leaked an internal term onto a public surface.
+        # A USER-OWNED non-teatree PUBLIC repo (e.g. a blog repo) is NOT in the
+        # denylist and the probe confirms it PUBLIC, so it must SCAN -- an
+        # affirmatively-public target is the only surface this gate fires on.
         cfg = _config(tmp_path, ["internal-eng"])
-        monkeypatch.setattr(publish_destination, "slug_is_private", lambda slug: False)
-        dest = publish_destination.Destination(slug="ourorg/other-public-repo", via="flag")
-        assert publish_destination.is_public_destination(dest, config_path=cfg) is True
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
         cmd = 'gh issue create -R ourorg/other-public-repo --body "customercorp leak"'
-        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is False
 
-    def test_unknown_visibility_non_denylisted_target_is_scanned(
+    def test_unknown_visibility_non_denylisted_target_skips(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # MUST-FIRE: a target not in the denylist whose visibility the in-hook
-        # probe cannot resolve (the common cold-hook state) stays PUBLIC and is
-        # scanned -- detection failure never opens the gate.
+        # POLICY FLIP (#1415/#1213): a target not in the denylist whose
+        # visibility the in-hook probe cannot resolve (the common cold-hook
+        # state) is NOT affirmatively public, so the gate SKIPS -- bias hard
+        # toward not firing, never false-block a repo of unknown visibility.
         cfg = _config(tmp_path, ["internal-eng"])
-        monkeypatch.setattr(publish_destination, "slug_is_private", lambda slug: False)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
         cmd = 'gh issue create -R someowner/mystery --body "customercorp note"'
-        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is True
 
-    def test_unresolvable_target_is_scanned_failsafe(self, tmp_path: Path) -> None:
-        # FAIL-SAFE: a publish whose target cannot be resolved from the command
-        # at all keeps scanning -- an unparsable target is never a silent bypass.
+    def test_non_repo_surface_is_not_scoped_out(self, tmp_path: Path) -> None:
+        # A publish with no repo-targeted segment (a Slack ``curl``) is not
+        # repo-scoped: this visibility scope does NOT skip it (returns False),
+        # leaving it to the gate's own default.
         cfg = _config(tmp_path, ["internal-eng"])
         cmd = "curl -d x https://example.com"
-        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is False
 
 
 class TestForgeAwareVisibility:
@@ -499,7 +507,7 @@ class TestForgeAwareVisibility:
         monkeypatch.setattr(_repo_visibility, "_write_visibility_cache", lambda *_a, **_k: None)
 
         cmd = "glab mr create -R internalcorp/private-svc --title x --description y"
-        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is True
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is True
         assert ("glab", "internalcorp/private-svc") in calls
         assert ("gh", "internalcorp/private-svc") not in calls
 
@@ -515,7 +523,7 @@ class TestForgeAwareVisibility:
         monkeypatch.setattr(_repo_visibility, "_write_visibility_cache", lambda *_a, **_k: None)
 
         cmd = "gh pr create -R someowner/private-repo --title x --body y"
-        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is True
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is True
 
     def test_public_github_target_still_scans(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         # MUST-FIRE: a genuinely-public GitHub repo (souliane/teatree itself) the
@@ -528,7 +536,7 @@ class TestForgeAwareVisibility:
         monkeypatch.setattr(_repo_visibility, "_write_visibility_cache", lambda *_a, **_k: None)
 
         cmd = "gh pr create -R souliane/teatree --title x --body y"
-        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is False
 
 
 class TestT3ReviewDestination:
@@ -579,7 +587,7 @@ class TestT3ReviewDestination:
     def test_internal_post_comment_is_skipped(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path, ["internalcorp"])
         assert (
-            publish_destination.gate_skips_destination(
+            public_visibility.gate_skips_for_visibility(
                 "t3 review post-comment internalcorp/svc 6378 --body-file /x --live", None, config_path=cfg
             )
             is True
@@ -588,7 +596,7 @@ class TestT3ReviewDestination:
     def test_internal_post_draft_note_is_skipped(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path, ["internalcorp"])
         assert (
-            publish_destination.gate_skips_destination(
+            public_visibility.gate_skips_for_visibility(
                 "t3 review post-draft-note internalcorp/svc 6378 --body-file /x", None, config_path=cfg
             )
             is True
@@ -599,7 +607,7 @@ class TestT3ReviewDestination:
         # break detection (e.g. ``t3 acme-internal review post-comment ...``).
         cfg = _config(tmp_path, ["internalcorp"])
         assert (
-            publish_destination.gate_skips_destination(
+            public_visibility.gate_skips_for_visibility(
                 "t3 acme-internal review post-comment internalcorp/svc 6378 --body-file /x --live",
                 None,
                 config_path=cfg,
@@ -612,7 +620,7 @@ class TestT3ReviewDestination:
         # same as ``_segment_is_t3_publish`` does.
         cfg = _config(tmp_path, ["internalcorp"])
         assert (
-            publish_destination.gate_skips_destination(
+            public_visibility.gate_skips_for_visibility(
                 "./t3 review post-comment internalcorp/svc 6378 --body-file /x --live", None, config_path=cfg
             )
             is True
@@ -623,16 +631,16 @@ class TestT3ReviewDestination:
         # ``t3 review post-comment`` segment resolves to a provably-internal repo.
         cfg = _config(tmp_path, ["internalcorp"])
         cmd = "cd /wt && t3 review post-comment internalcorp/svc 6378 --body-file /x --live"
-        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is True
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is True
 
     def test_public_repo_post_still_scans(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         # MUST-FIRE: a ``t3 review`` post to a NON-allowlisted repo the probe
         # cannot prove private stays PUBLIC and is scanned -- recognising the
         # destination must not relax the public-surface default.
         cfg = _config(tmp_path, ["internalcorp"])
-        monkeypatch.setattr(publish_destination, "slug_is_private", lambda slug: False)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
         cmd = "t3 review post-comment public-org/app 6378 --body-file /x --live"
-        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is False
 
 
 class TestApiEndpointNormalization:
@@ -677,7 +685,7 @@ class TestApiEndpointNormalization:
     def test_internal_versioned_write_is_skipped(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path, ["internalcorp"])
         cmd = "glab api --method POST api/v4/projects/internalcorp%2Fsvc/merge_requests/6378/notes -f body=x"
-        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is True
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is True
 
     def test_internal_full_url_write_is_skipped(self, tmp_path: Path) -> None:
         cfg = _config(tmp_path, ["internalcorp"])
@@ -685,22 +693,22 @@ class TestApiEndpointNormalization:
             "glab api --method POST "
             "https://gitlab.com/api/v4/projects/internalcorp%2Fsvc/merge_requests/6378/notes -f body=x"
         )
-        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is True
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is True
 
     def test_public_versioned_write_still_scans(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         cfg = _config(tmp_path, ["internalcorp"])
-        monkeypatch.setattr(publish_destination, "slug_is_private", lambda slug: False)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
         cmd = "glab api --method POST api/v4/projects/public-org%2Fapp/merge_requests/6378/notes -f body=x"
-        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is False
 
     def test_public_full_url_write_still_scans(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         cfg = _config(tmp_path, ["internalcorp"])
-        monkeypatch.setattr(publish_destination, "slug_is_private", lambda slug: False)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
         cmd = (
             "glab api --method POST "
             "https://gitlab.com/api/v4/projects/public-org%2Fapp/merge_requests/6378/notes -f body=x"
         )
-        assert publish_destination.gate_skips_destination(cmd, None, config_path=cfg) is False
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is False
 
 
 def _private_repos_config(tmp_path: Path, namespaces: list[str]) -> Path:
@@ -735,7 +743,7 @@ class TestRestrictedPathCwdResolution:
         cfg = _private_repos_config(tmp_path, ["internalcorp"])
         monkeypatch.setenv("PATH", "")  # mimic the restricted hook subprocess: no git
         cmd = "glab mr create --source-branch x --target-branch master --fill"
-        assert publish_destination.gate_skips_destination(cmd, repo, config_path=cfg) is True
+        assert public_visibility.gate_skips_for_visibility(cmd, repo, config_path=cfg) is True
 
     def test_flagless_create_from_linked_worktree_skips_without_git_on_path(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -750,7 +758,7 @@ class TestRestrictedPathCwdResolution:
         cfg = _private_repos_config(tmp_path, ["internalcorp"])
         monkeypatch.setenv("PATH", "")
         cmd = "glab mr create --source-branch x --target-branch master --fill"
-        assert publish_destination.gate_skips_destination(cmd, linked, config_path=cfg) is True
+        assert public_visibility.gate_skips_for_visibility(cmd, linked, config_path=cfg) is True
 
     def test_flagless_create_to_public_cwd_still_scans_without_git_on_path(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -760,7 +768,7 @@ class TestRestrictedPathCwdResolution:
         # the probe confirming PUBLIC, the flagless create still scans.
         repo = _repo_with_remote(tmp_path / "wt", "git@github.com:souliane/teatree.git")
         cfg = _private_repos_config(tmp_path, ["internalcorp"])
-        monkeypatch.setattr(publish_destination, "slug_is_private", lambda slug: False)
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
         monkeypatch.setenv("PATH", "")
         cmd = "gh pr create --title x --body y"
-        assert publish_destination.gate_skips_destination(cmd, repo, config_path=cfg) is False
+        assert public_visibility.gate_skips_for_visibility(cmd, repo, config_path=cfg) is False

--- a/tests/teatree_hooks/test_publish_gate_golden_corpus.py
+++ b/tests/teatree_hooks/test_publish_gate_golden_corpus.py
@@ -33,10 +33,29 @@ from pathlib import Path
 
 import pytest
 
-from teatree.hooks import _repo_visibility, banned_terms_scanner, publish_destination, publish_surface
+from teatree.hooks import _repo_visibility, banned_terms_scanner, public_visibility, publish_surface
 
 # A high-confidence fake secret (never a real credential): a GitHub PAT shape.
 _FAKE_SECRET = "ghp_" + "A" * 40
+
+
+@pytest.fixture(autouse=True)
+def _public_probe(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolve the genuinely-public ``souliane/teatree`` as PUBLIC; delegate the rest.
+
+    The leak gate enforces ONLY on an affirmatively-public target, so the
+    public rows need the probe to CONFIRM ``souliane/teatree`` public. Every
+    other slug delegates to the real probe so a per-test ``gh``/``glab`` shim (a
+    PRIVATE/PUBLIC verdict) or an explicit probe mock still governs its own
+    target. The cache dir is isolated so no real on-disk verdict leaks in.
+    """
+    monkeypatch.setenv("T3_DATA_DIR", str(tmp_path / "viscache"))
+    real_probe = _repo_visibility.probe_visibility
+    monkeypatch.setattr(
+        _repo_visibility,
+        "probe_visibility",
+        lambda slug: "PUBLIC" if "souliane/teatree" in slug else real_probe(slug),
+    )
 
 
 def _git(cwd: Path, *args: str) -> None:
@@ -135,11 +154,11 @@ def _verdict(command: str, cwd: Path | None, config_path: Path) -> str:
     Mirrors ``hook_router._run_banned_terms_pretool``: a secret on ANY surface
     (body, title, short ``-t`` flag, ``gh api`` field, ``git -C`` commit
     subject) always blocks, checked BEFORE the payload-None early-return; the
-    destination gate skips a PROVABLY-private target (offline allowlist or live
-    probe, resolved from the COMMAND target -- so the leak gate enforces on
-    PUBLIC targets only); otherwise the payload is scanned and a banned-term
-    match (or a fail-closed sentinel) blocks unless the private-repo commit
-    carve-out downgrades it.
+    visibility scope skips every target that is NOT affirmatively public
+    (private/internal/unknown/unresolvable, resolved from the COMMAND target --
+    so the leak gate enforces on affirmatively-PUBLIC targets only); otherwise
+    the payload is scanned and a banned-term match (or a fail-closed sentinel)
+    blocks unless the private-repo commit carve-out downgrades it.
     """
     tool_input = {"command": command}
     if publish_surface.contains_secret(banned_terms_scanner.secret_scan_text("Bash", tool_input)):
@@ -147,7 +166,7 @@ def _verdict(command: str, cwd: Path | None, config_path: Path) -> str:
     payload = banned_terms_scanner.extract_publish_payload("Bash", tool_input)
     if payload is None:
         return "allow"
-    skipped = banned_terms_scanner.has_override("Bash", tool_input) or publish_destination.gate_skips_destination(
+    skipped = banned_terms_scanner.has_override("Bash", tool_input) or public_visibility.gate_skips_for_visibility(
         command, cwd, config_path=config_path
     )
     if skipped or banned_terms_scanner.scan_text(payload, config_path=config_path) is None:
@@ -364,7 +383,7 @@ class TestMustDeny:
         # safety boundary the scanner-visible ``_verdict`` cannot reach (it never
         # sees the wrapper's opaque recipe), so the gate is asserted directly.
         cmd = f"glab mr create -R acme-internal/x --title ok && {wrapper}"
-        assert publish_destination.gate_skips_destination(cmd, None, config_path=config) is False
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=config) is False
 
     def test_raw_rest_with_interspersed_persistent_flag(self, config: Path) -> None:
         # Vector 2: an interspersed ``--hostname`` broke the contiguous ``gh api ``
@@ -581,20 +600,19 @@ class TestProbeResolvedTargetVisibility:
         cmd = 'gh issue comment 5 --repo someowner/open-svc --body "acmecorp domain note"'
         assert _verdict(cmd, cwd, empty_allowlist_config) == "block"
 
-    def test_unresolvable_target_fails_closed_blocks(
+    def test_unresolvable_target_skips(
         self, empty_allowlist_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # must-DENY (fail-closed): when the probe cannot prove the target private
-        # (probe returns the UNKNOWN ``None`` -- tool absent in-hook or auth
-        # differs) and the allowlist does not name it, the target is PUBLIC and
-        # the term blocks. Detection failure never opens. The probe is stubbed to
-        # the deterministic UNKNOWN verdict rather than relying on a flaky network
-        # call to a non-existent repo.
+        # must-ALLOW (#1415/#1213 policy): when the probe cannot prove the target
+        # PUBLIC (it returns the UNKNOWN ``None`` -- tool absent in-hook or auth
+        # differs) and the allowlist does not name it, the target is NOT
+        # affirmatively public, so the gate SKIPS -- bias hard toward not firing,
+        # never false-block a repo of unknown visibility.
         monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
         monkeypatch.delenv("GH_REPO", raising=False)
         cwd = self._public_cwd(tmp_path)
         cmd = 'gh issue comment 5 --repo unknown/mystery --body "acmecorp domain note"'
-        assert _verdict(cmd, cwd, empty_allowlist_config) == "block"
+        assert _verdict(cmd, cwd, empty_allowlist_config) == "allow"
 
     def test_clean_post_to_private_probe_target_never_blocks(
         self, empty_allowlist_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -624,12 +642,12 @@ class TestLeakGateEnforcesOnPublicTargetsOnly:
     """The leak gate enforces on PUBLIC targets ONLY (the user's explicit rule).
 
     A customer/banned term is blocked when -- and only when -- the COMMAND's
-    resolved target is PUBLIC (or its visibility cannot be determined, which
-    fails closed to strict). On ANY private target -- the user's OWN private
-    overlay repo AND a customer's own (colleague) private repo -- the gate does
-    NOT block: the destination skip resolves the real target from the command
-    and skips the scan. SYNTHETIC namespaces only; the private ones are proven
-    private via the allowlist and via the live ``gh`` probe shim.
+    resolved target is affirmatively PUBLIC. On ANY other target -- the user's
+    OWN private overlay repo, a customer's own (colleague) private repo, AND an
+    unknown/unresolvable target -- the gate does NOT block: it resolves the real
+    target from the command and skips the scan (bias hard toward not firing).
+    SYNTHETIC namespaces only; the private ones are proven private via the
+    allowlist and via the live ``gh`` probe shim.
     """
 
     @pytest.fixture
@@ -696,15 +714,16 @@ class TestLeakGateEnforcesOnPublicTargetsOnly:
         cmd = 'gh pr create --title "feat: x" --body "customercorp here"'
         assert _verdict(cmd, worktree, allowlist_config) == "allow"
 
-    def test_customer_term_to_unresolvable_target_fails_closed(
+    def test_customer_term_to_unresolvable_target_skips(
         self, allowlist_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # fail-closed: an undeclared target whose visibility cannot be determined
-        # (probe returns the UNKNOWN None) is treated as PUBLIC/strict and blocks.
+        # #1415/#1213 policy: an undeclared target whose visibility cannot be
+        # determined (probe returns the UNKNOWN None) is NOT affirmatively public,
+        # so the gate SKIPS -- bias hard toward not firing.
         monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
         cwd = self._public_cwd(tmp_path)
         cmd = 'gh issue comment 5 --repo unknown/mystery --body "customercorp note"'
-        assert _verdict(cmd, cwd, allowlist_config) == "block"
+        assert _verdict(cmd, cwd, allowlist_config) == "allow"
 
     def test_colleague_private_proven_only_by_probe_allows(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/teatree_hooks/test_quote_scanner.py
+++ b/tests/teatree_hooks/test_quote_scanner.py
@@ -390,8 +390,14 @@ class TestBypassClosures:
 
 
 class TestHookHandlerEndToEnd:
-    def test_high_match_emits_deny_and_breaks_chain(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-        data = _bash('gh pr create --title t --body "## User mandate\nplease ship now"')
+    def test_high_match_emits_deny_and_breaks_chain(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The leak gate scopes to an affirmatively-public target (#1213), so the
+        # deny row posts to the genuinely-public ``souliane/teatree`` with the probe
+        # confirming it public.
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+        data = _bash('gh pr create --repo souliane/teatree --title t --body "## User mandate\nplease ship now"')
         blocked = handle_quote_scanner_pretool(data)
         assert blocked is True
         decision = json.loads(capsys.readouterr().out)
@@ -889,9 +895,12 @@ class TestRound3BypassClosures:
         assert has_quote_ok_override("Bash", {"command": cmd}) is False
 
     def test_override_after_unspaced_semicolon_blocks_end_to_end(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        cmd = 'gh issue comment 1 --body "## User mandate\nbody";echo --quote-ok'
+        # Affirmatively-public target so the leak gate fires (#1213); the point is
+        # that the ``--quote-ok`` after the unspaced ``;`` does NOT bypass the deny.
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+        cmd = 'gh issue comment 1 --repo souliane/teatree --body "## User mandate\nbody";echo --quote-ok'
         blocked = handle_quote_scanner_pretool(_bash(cmd))
         assert blocked is True
         decision = json.loads(capsys.readouterr().out)
@@ -1224,24 +1233,27 @@ class TestPrivateRepoCarveOut:
         assert "WARNING" in captured.err
         assert _ledger_lines(tmp_path)[-1]["decision"] == "warn-private-repo"
 
-    def test_private_repo_posting_command_with_cwd_target_downgrades(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    def test_private_repo_posting_command_with_cwd_target_skips_silently(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
         repo = tmp_path / "repo"
         repo.mkdir()
         _git_init_remote(repo, "git@gitlab.com:acmecorp-engineering/product.git")
-        # gh issue create (no --repo) from a private CWD resolves the target
-        # from the CWD origin and applies the carve-out.
+        # gh issue create (no --repo) from a NON-public CWD resolves the target
+        # from the CWD origin; the leak gate scopes to affirmatively-public targets
+        # only (#1213), so a private-repo post is SKIPPED silently -- allowed with
+        # no deny and no warning (bias hard toward not firing).
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PRIVATE")
         data = {
             "tool_name": "Bash",
             "tool_input": {"command": 'gh issue create --title t --body "the user said: ship it now"'},
             "cwd": str(repo),
         }
         blocked = handle_quote_scanner_pretool(data)
-        assert blocked is False  # downgraded, not denied
+        assert blocked is False  # skipped, not denied
         captured = capsys.readouterr()
         assert captured.out == ""  # no deny JSON
-        assert "WARNING" in captured.err
+        assert "WARNING" not in captured.err  # silent skip, no downgrade warning
 
     def test_explicit_public_repo_still_denies(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/teatree_hooks/test_quote_scanner_env_override_eval.py
+++ b/tests/teatree_hooks/test_quote_scanner_env_override_eval.py
@@ -27,6 +27,7 @@ from pathlib import Path
 import pytest
 
 from hooks.scripts.hook_router import handle_quote_scanner_pretool
+from teatree.hooks import _repo_visibility
 from teatree.hooks.quote_scanner import extract_publish_payload, has_quote_ok_override, scan_text
 
 
@@ -77,8 +78,14 @@ class TestQuoteScannerGenuineGuardsIntact:
         assert handle_quote_scanner_pretool(data) is False
         assert capsys.readouterr().err == ""
 
-    def test_actual_user_quote_without_override_is_blocked(self, capsys: pytest.CaptureFixture[str]) -> None:
-        data = _bash('gh pr create --title t --body "## User mandate\nplease ship now"')
+    def test_actual_user_quote_without_override_is_blocked(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # The leak gate enforces ONLY on an affirmatively-public target (#1213), so
+        # the genuine-violation guard posts to the public teatree repo with the
+        # probe confirming it public.
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+        data = _bash('gh pr create -R souliane/teatree --title t --body "## User mandate\nplease ship now"')
         assert handle_quote_scanner_pretool(data) is True
         out = json.loads(capsys.readouterr().out)
         assert out["permissionDecision"] == "deny"

--- a/tests/test_gate_liveness_corpus.py
+++ b/tests/test_gate_liveness_corpus.py
@@ -46,6 +46,7 @@ import pytest
 
 import hooks.scripts.hook_router as router
 from teatree.core.overlay import OverlayBase, OverlayConfig
+from teatree.hooks import _repo_visibility
 
 # ── environment & invocation context ────────────────────────────────────
 
@@ -436,12 +437,20 @@ def _ai_sig_allow(ctx: GateContext) -> dict:
 # verbatim user quote denies; a clean body allows.
 
 
+# The leak gates (#1415/#1213) enforce ONLY on an affirmatively-PUBLIC target, so
+# the must-DENY rows post to the genuinely-public ``souliane/teatree`` with the
+# probe pinned public (and a cold visibility cache) for a deterministic fire.
+def _pin_public_probe(ctx: GateContext) -> None:
+    ctx.monkeypatch.setenv("T3_DATA_DIR", str(ctx.tmp_path / "viscache"))
+    ctx.monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+
+
 def _quote_bash_deny(ctx: GateContext) -> dict:
-    return _bash(f'gh issue create --title t --body "{_HIGH_QUOTE}"')
+    return _bash(f'gh issue create --repo souliane/teatree --title t --body "{_HIGH_QUOTE}"')
 
 
 def _quote_bash_allow(ctx: GateContext) -> dict:
-    return _bash('gh issue create --title t --body "Routine status update."')
+    return _bash('gh issue create --repo souliane/teatree --title t --body "Routine status update."')
 
 
 # quote-scanner Slack-MCP arm (mcp__*slack* send) — now reachable via the
@@ -540,14 +549,15 @@ def _arrange_banned_terms(ctx: GateContext) -> None:
     cfg.write_text(_BANNED_TERM_TOML, encoding="utf-8")
     ctx.monkeypatch.setenv("T3_BANNED_TERMS_CONFIG", str(cfg))
     ctx.monkeypatch.delenv("ALLOW_BANNED_TERM", raising=False)
+    _pin_public_probe(ctx)
 
 
 def _banned_bash_deny(ctx: GateContext) -> dict:
-    return _bash(f'gh issue create --title t --body "{_BANNED_BODY}"')
+    return _bash(f'gh issue create --repo souliane/teatree --title t --body "{_BANNED_BODY}"')
 
 
 def _banned_bash_allow(ctx: GateContext) -> dict:
-    return _bash('gh issue create --title t --body "Rolling out the integration."')
+    return _bash('gh issue create --repo souliane/teatree --title t --body "Rolling out the integration."')
 
 
 # block-uncovered-diff (PreToolUse Bash): a non-draft gh pr create whose diff
@@ -835,6 +845,7 @@ GATE_REGISTRY: Final[tuple[GateRow, ...]] = (
         matched="Bash",
         deny_input=_quote_bash_deny,
         allow_input=_quote_bash_allow,
+        arrange=_pin_public_probe,
     ),
     GateRow(
         gate_id="quote-scanner-slack-mcp",

--- a/tests/test_public_leak_gate_stays_fail_closed.py
+++ b/tests/test_public_leak_gate_stays_fail_closed.py
@@ -19,6 +19,7 @@ import pytest
 
 import hooks.scripts.hook_router as router
 from hooks.scripts.hook_router import handle_banned_terms_pretool, handle_quote_scanner_pretool
+from teatree.hooks import _repo_visibility
 
 
 @pytest.fixture
@@ -26,13 +27,16 @@ def fail_open_on(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Record ``danger_gate_fail_open = true`` in a temp ``~/.teatree.toml``.
 
     Also pins the quote-scanner ledger root under ``tmp_path`` so the gate
-    decision does not touch real state.
+    decision does not touch real state, and CONFIRMS the genuinely-public
+    ``souliane/teatree`` target public so the leak gate (which scopes to an
+    affirmatively-public destination, #1415/#1213) actually reaches its deny.
     """
     home = tmp_path / "home"
     home.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
     monkeypatch.setenv("T3_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
     (home / ".teatree.toml").write_text(
         '[teatree]\ndanger_gate_fail_open = true\nbanned_terms = ["acmecorp"]\n',
         encoding="utf-8",
@@ -51,7 +55,7 @@ class TestQuoteScannerLeakGateIgnoresFailOpen:
         # A PUBLIC posting surface (gh pr create) carrying a verbatim
         # user-quote pattern. Even with the master fail-open switch ON, the
         # leak gate must DENY.
-        data = _bash('gh pr create --title t --body "## User mandate\nplease ship now"')
+        data = _bash('gh pr create --repo souliane/teatree --title t --body "## User mandate\nplease ship now"')
         blocked = handle_quote_scanner_pretool(data)
         assert blocked is True, "PUBLIC quote leak must stay fail-closed even with danger_gate_fail_open=true"
         decision = json.loads(capsys.readouterr().out)
@@ -65,7 +69,7 @@ class TestBannedTermsLeakGateIgnoresFailOpen:
     ) -> None:
         # A PUBLIC posting surface (gh issue create) carrying a banned
         # overlay/customer term. The leak gate must DENY despite fail-open.
-        data = _bash('gh issue create --title t --body "rolling out acmecorp integration"')
+        data = _bash('gh issue create --repo souliane/teatree --title t --body "rolling out acmecorp integration"')
         blocked = handle_banned_terms_pretool(data)
         assert blocked is True, "PUBLIC banned-term leak must stay fail-closed even with danger_gate_fail_open=true"
         decision = json.loads(capsys.readouterr().out)
@@ -93,7 +97,9 @@ class TestLeakGateNeverReadsFailOpen:
             return real()
 
         monkeypatch.setattr(router, "_danger_gate_fail_open_enabled", _spy)
-        handle_quote_scanner_pretool(_bash('gh pr create --title t --body "## User mandate\nship"'))
+        handle_quote_scanner_pretool(
+            _bash('gh pr create --repo souliane/teatree --title t --body "## User mandate\nship"')
+        )
         capsys.readouterr()
         assert calls == [], "the PUBLIC leak gate must NEVER read danger_gate_fail_open"
 
@@ -108,6 +114,8 @@ class TestLeakGateNeverReadsFailOpen:
             return real()
 
         monkeypatch.setattr(router, "_danger_gate_fail_open_enabled", _spy)
-        handle_banned_terms_pretool(_bash('gh issue create --title t --body "ship acmecorp now"'))
+        handle_banned_terms_pretool(
+            _bash('gh issue create --repo souliane/teatree --title t --body "ship acmecorp now"')
+        )
         capsys.readouterr()
         assert calls == [], "the PUBLIC leak gate must NEVER read danger_gate_fail_open"


### PR DESCRIPTION
## What

Scope the pre-publish banned-terms (#1415) and quote-scanner (#1213) gates to public repositories only — skip private/internal targets by visibility.

## Why

Both gates fired on `gh`/`glab` publish and out-of-band API-write operations regardless of the target repository's visibility, blocking legitimate posts and edits to private and internal repositories. The gates exist to prevent leaks on PUBLIC surfaces, so they should enforce only when the target is affirmatively public.

## How

- New `teatree.hooks.public_visibility` module owns `gate_skips_for_visibility`, the composed predicate both gate choke points call.
- A target is gated only when the probe affirmatively confirms it public; a private, internal, or unresolvable/unknown target skips the gate entirely (bias toward not firing, so a non-public repo is never falsely blocked).
- Visibility is resolved from the command's own target — the `--repo`/`-R` flag, the `gh`/`glab api` URL path, or the cwd git remote — and probed with a per-repo day cache.
- The ALL-SEGMENTS anti-leak posture is preserved: a substitution/transport construct, an unrecognised chained executable, or a raw `api` write to a public URL still forces a scan, so an obscured public post cannot hide behind a leading non-public segment. A `git commit` still defers to the landing-repo carve-out and the pre-push backstop.

## Tests

- New `tests/teatree_hooks/test_public_visibility.py`: the three-visibility × two-gate matrix (public + leak → fire; private/unresolvable + leak → skip), with the forge probe mocked (no network). The public FIRE row anti-vacuity-guards the two SKIP rows.
- Migrated the banned-terms, quote-scanner, publish-destination, golden-corpus, gate-liveness, and public-leak-fail-closed suites to the affirmative-public policy. All affected suites are green.
