### PR TITLE
fix(eval): blank efforts is single-tier, not a 3x-cost fan

### DIFF
--- a/.github/workflows/eval-weekly-reusable.yml
+++ b/.github/workflows/eval-weekly-reusable.yml
@@ -51,9 +51,9 @@ on:
         default: ""
         type: string
       efforts:
-        description: "Comma-separated reasoning-effort tiers to fan the matrix across (e.g. 'low,medium,high'); empty = no effort axis (single tier at the lane default)."
+        description: "Comma-separated reasoning-effort tiers to fan the matrix across (e.g. 'low,medium,high'); empty = no effort axis (single tier at the lane default). The scheduled weekly run still fans all three."
         required: false
-        default: "low,medium,high"
+        default: ""
         type: string
       lookback-days:
         description: "No-PR-merged guard lookback window in days."
@@ -151,18 +151,21 @@ jobs:
           fi
       # Compute the {lane, shard[, effort]} matrix the eval job fans out over.
       # Empty `lane` = every permitted lane, sharded into budget-safe legs on the
-      # lane-aware ceiling. `efforts` (default 'low,medium,high') adds the model-
-      # tier axis: each {lane, shard} leg runs once per reasoning-effort tier, so
-      # the weekly run measures pass-rate vs effort across the whole suite; an
-      # empty `efforts` keeps the single-tier {lane, shard} matrix. An unknown lane
-      # or effort fails loud here rather than producing an empty/invalid matrix.
-      # Both inputs are routed through `env:` vars (never inlined into the script).
+      # lane-aware ceiling. `efforts` adds the model-tier axis: each {lane, shard}
+      # leg runs once per reasoning-effort tier. The SCHEDULED cron run defaults to
+      # all three (low,medium,high), so the weekly run measures pass-rate vs effort
+      # across the whole suite; a manual run with an empty `efforts` keeps the
+      # single-tier {lane, shard} matrix (lane default). The 3-tier default is keyed
+      # on the schedule EVENT (not a blanket `|| 'low,medium,high'`, which would fan
+      # a blank field 3x and triple the metered spend). An unknown lane or effort
+      # fails loud here rather than producing an empty/invalid matrix. Both inputs
+      # are routed through `env:` vars (never inlined into the script).
       - name: Compute the lane+shard+effort matrix
         id: matrix
         if: steps.gate.outputs.run_eval == 'true'
         env:
           EVAL_LANE: ${{ inputs.lane }}
-          EVAL_EFFORTS: ${{ inputs.efforts }}
+          EVAL_EFFORTS: ${{ inputs.efforts || (github.event_name == 'schedule' && 'low,medium,high' || '') }}
         run: |
           MATRIX="$(uv run python scripts/eval/lane_matrix.py --lane "$EVAL_LANE" --efforts "$EVAL_EFFORTS")"
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -109,9 +109,9 @@ on:
         default: ""
         type: string
       efforts:
-        description: "Comma-separated reasoning-effort tiers to fan the matrix across (e.g. 'low,medium,high'); empty = no effort axis (single tier at the lane default)."
+        description: "Comma-separated reasoning-effort tiers to fan the matrix across (e.g. 'low,medium,high'); empty = no effort axis (single tier at the lane default). The weekly cron still fans all three."
         required: false
-        default: "low,medium,high"
+        default: ""
         type: string
 
 jobs:
@@ -172,18 +172,21 @@ jobs:
       # Empty `lane` input (scheduled runs and the default manual run) = every
       # permitted lane, sharded into budget-safe legs on the lane-aware ceiling
       # (clean_room ~182 → ~13 shards of ≤14, under_load 14 → 4 shards of ≤4 —
-      # #2683). The `efforts` axis (default 'low,medium,high', also for the
-      # scheduled cron run) fans each {lane, shard} leg across the three reasoning-
-      # effort tiers, so the weekly run measures pass-rate vs effort across the
-      # whole suite; an empty `efforts` keeps the single-tier matrix. An unknown
-      # lane or effort fails loud here rather than producing an empty/invalid
-      # matrix. Both inputs are routed through `env:` vars (never inlined) and
-      # validated by lane_matrix.py.
+      # #2683). The `efforts` axis fans each {lane, shard} leg across the reasoning-
+      # effort tiers it lists. The SCHEDULED cron run defaults to all three
+      # (low,medium,high), so the weekly run measures pass-rate vs effort across the
+      # whole suite; a MANUAL run with an empty `efforts` field keeps the single-tier
+      # matrix (lane default) — the documented "empty = single tier". The 3-tier
+      # default is keyed on the schedule EVENT (not a blanket `|| 'low,medium,high'`,
+      # which would fan a blank manual field 3x and triple the metered spend), so a
+      # blank workflow_dispatch field is a single-tier run. An unknown lane or effort
+      # fails loud here rather than producing an empty/invalid matrix. Both inputs are
+      # routed through `env:` vars (never inlined) and validated by lane_matrix.py.
       - name: Compute the lane+shard+effort matrix
         id: matrix
         env:
           EVAL_LANE: ${{ inputs.lane || '' }}
-          EVAL_EFFORTS: ${{ inputs.efforts || 'low,medium,high' }}
+          EVAL_EFFORTS: ${{ inputs.efforts || (github.event_name == 'schedule' && 'low,medium,high' || '') }}
         run: |
           MATRIX="$(uv run python scripts/eval/lane_matrix.py --lane "$EVAL_LANE" --efforts "$EVAL_EFFORTS")"
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"

--- a/tests/test_eval_ci_require_executed_gate.py
+++ b/tests/test_eval_ci_require_executed_gate.py
@@ -23,11 +23,13 @@ regresses to the subscription OAuth token.
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
 import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _GH_CI = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
 _GH_EVAL = _REPO_ROOT / ".github" / "workflows" / "eval.yml"
+_GH_EVAL_WEEKLY_REUSABLE = _REPO_ROOT / ".github" / "workflows" / "eval-weekly-reusable.yml"
 _GITLAB_CI = _REPO_ROOT / ".gitlab-ci.yml"
 
 _FLAG = "--require-executed"
@@ -290,4 +292,74 @@ class TestGitLabRequireExecutedUnconditional:
         manual_rules = cast("list[dict[str, Any]]", config["eval-manual"]["rules"])
         assert not any("RUN_EVAL" in rule.get("if", "") for rule in manual_rules), (
             "eval-manual must be unguarded (the manual run always runs, no-PR guard bypassed)."
+        )
+
+
+def _workflow_triggers(config: dict[str, Any]) -> dict[str, Any]:
+    # PyYAML parses the unquoted `on:` workflow key as the boolean True (YAML 1.1).
+    return cast("dict[str, Any]", config.get("on", config.get(True)))
+
+
+def _efforts_input_default(path: Path) -> str | None:
+    config = cast("dict[str, Any]", yaml.safe_load(path.read_text(encoding="utf-8")))
+    triggers = _workflow_triggers(config)
+    for trigger in ("workflow_dispatch", "workflow_call"):
+        inputs = cast("dict[str, Any]", triggers.get(trigger, {})).get("inputs", {})
+        if "efforts" in inputs:
+            return cast("str | None", inputs["efforts"].get("default"))
+    msg = f"{path.name} declares no efforts input."
+    raise AssertionError(msg)
+
+
+def _matrix_step_efforts_env(path: Path) -> str:
+    jobs = cast("dict[str, Any]", yaml.safe_load(path.read_text(encoding="utf-8"))["jobs"])
+    for step in cast("list[dict[str, Any]]", jobs["prepare"]["steps"]):
+        if step.get("id") == "matrix":
+            return cast("str", step["env"]["EVAL_EFFORTS"])
+    msg = f"{path.name} prepare job has no matrix step wiring EVAL_EFFORTS."
+    raise AssertionError(msg)
+
+
+_EFFORTS_WORKFLOWS = [_GH_EVAL, _GH_EVAL_WEEKLY_REUSABLE]
+
+
+class TestEffortsAxisEmptyIsSingleTier:
+    """A blank efforts field is single-tier; only the scheduled cron fans all three.
+
+    A blank `efforts` field must produce a SINGLE-tier matrix (no effort axis, lane
+    default) — the documented "empty = single tier" behaviour. The old
+    `default: "low,medium,high"` plus the blanket `inputs.efforts || 'low,medium,high'`
+    coercion silently fanned every blank run across all three tiers, tripling the
+    metered API spend. The 3-tier default is now keyed on the schedule EVENT, so the
+    weekly cron still fans low,medium,high while a blank manual run stays single-tier.
+    """
+
+    @pytest.mark.parametrize("path", _EFFORTS_WORKFLOWS, ids=lambda p: p.name)
+    def test_efforts_input_default_is_empty(self, path: Path) -> None:
+        assert _efforts_input_default(path) == "", (
+            f"{path.name}: the efforts input default must be empty, so a blank manual "
+            "dispatch field is a single-tier run — not a 3x-cost fan across every tier."
+        )
+
+    @pytest.mark.parametrize("path", _EFFORTS_WORKFLOWS, ids=lambda p: p.name)
+    def test_three_tier_default_is_keyed_on_the_schedule_event(self, path: Path) -> None:
+        expr = _matrix_step_efforts_env(path)
+        assert "inputs.efforts" in expr, f"{path.name}: an explicit efforts input must still win."
+        assert "github.event_name == 'schedule'" in expr, (
+            f"{path.name}: the 3-tier efforts default must be keyed on the schedule event, so "
+            "ONLY the weekly cron fans low,medium,high — a blank manual run stays single-tier."
+        )
+        assert "low,medium,high" in expr, f"{path.name}: the scheduled run must still fan the three tiers."
+
+    @pytest.mark.parametrize("path", _EFFORTS_WORKFLOWS, ids=lambda p: p.name)
+    def test_blank_efforts_is_not_blanket_coerced_to_all_tiers(self, path: Path) -> None:
+        # The bug: `inputs.efforts || 'low,medium,high'` coerced EVERY blank efforts —
+        # manual OR scheduled — to all three tiers, so the "empty = single tier" path
+        # was unreachable from the manual UI. The 3-tier fallback must be gated on the
+        # event, never an unconditional `|| 'low,medium,high'`.
+        expr = "".join(_matrix_step_efforts_env(path).split())
+        assert "inputs.efforts||'low,medium,high'" not in expr, (
+            f"{path.name}: efforts must not be blanket-coerced to all three tiers — a blank "
+            "manual field would then fan 3x (the money-burning bug). Gate the 3-tier fallback "
+            "on github.event_name == 'schedule'."
         )


### PR DESCRIPTION
## The bug

The metered-eval `workflow_dispatch` `efforts` input is documented as: comma-separated reasoning-effort tiers to fan the matrix across (e.g. `low,medium,high`); empty = no effort axis (single tier at the lane default).

But leaving the field **blank** in the GitHub Actions UI did **not** produce a single tier — it fanned the matrix across `low,medium,high`, tripling the metered API spend on every manual run. The documented "empty = single tier" path was unreachable from a manual dispatch, via two coercions of blank into all three tiers:

1. the input `default: "low,medium,high"` — a blank `workflow_dispatch` field falls back to the input default, so blank became `low,medium,high`;
2. `EVAL_EFFORTS: ${{ inputs.efforts || 'low,medium,high' }}` — a second, blanket coercion of empty into all three tiers.

## The fix

- Set the `efforts` input `default` to `""`.
- Key the 3-tier fallback on the schedule **event** instead of the blanket `|| 'low,medium,high'`:

  ```yaml
  EVAL_EFFORTS: ${{ inputs.efforts || (github.event_name == 'schedule' && 'low,medium,high' || '') }}
  ```

Resulting behaviour:

| Trigger | `efforts` | Matrix |
|---|---|---|
| Manual dispatch, field left blank | empty | **single tier** (no effort axis, lane default) — the promised behaviour |
| Manual dispatch, field set (e.g. `medium` or `low,medium,high`) | explicit | fans exactly those tiers |
| Scheduled weekly cron | empty (`inputs.*` is empty on a `schedule` event) | **still fans `low,medium,high`** |

The scheduled weekly run measures pass-rate vs effort across all three tiers, so it must keep fanning `low,medium,high`. Because `inputs.*` is empty on a `schedule` event, the 3-tier default is keyed on `github.event_name == 'schedule'` rather than on the input value — the cron behaviour is preserved.

The same `default: "low,medium,high"` and misleading description existed in `eval-weekly-reusable.yml`; it gets the same fix. Inside a reusable (`workflow_call`) workflow `github.event_name` is inherited from the caller's triggering event, so a scheduled caller stays at 3 tiers while a manual caller passing a blank `efforts` gets single-tier.

## Not the bug

`scripts/eval/lane_matrix.py` already mapped an empty `--efforts` to a single-tier matrix (`_efforts_for("")` returns `[None]`, no `effort` key per leg). The defect was purely the workflow's coercion of blank into all three tiers before the value ever reached the script. No change to `lane_matrix.py` was needed.

## Tests

`tests/test_eval_ci_require_executed_gate.py` gains `TestEffortsAxisEmptyIsSingleTier`, which parses both workflows and pins:

- the `efforts` input default is empty (not a tier list);
- the `EVAL_EFFORTS` expression keys the 3-tier default on `github.event_name == 'schedule'` and still lists `low,medium,high`;
- the expression is not a blanket `inputs.efforts || 'low,medium,high'` coercion.

The class was observed RED against the pre-fix YAML (5 of 6 parametrized cases failed) and is GREEN after the fix. The existing `tests/eval_replay/test_lane_matrix.py` (empty `--efforts` → single-tier, non-empty → N tiers) still passes.

## Architecture pre-check

Tactical fix — a narrow change to two workflow YAML expressions plus a regression test. It touches no `src/teatree/`, no FSM transition, no Protocol/overlay contract, so the nine-check architecture gate does not apply.
