### PR TITLE
fix(hooks): match forge-tool markers on word boundaries, not raw substring

### DIFF
--- a/src/teatree/hooks/_publish_detection.py
+++ b/src/teatree/hooks/_publish_detection.py
@@ -97,9 +97,30 @@ _LEADER_PUBLISH_SUBSTRINGS: Final[tuple[tuple[str, str], ...]] = (
     ("curl", "chat.postMessage"),
 )
 
-# Forge-tool markers detected as a SUBSTRING of any token, so a forge call
-# hidden inside a quoted interpreter argument is recognised as a transport.
+# Forge-tool markers detected as a WORD within any token, so a forge call
+# hidden inside a quoted interpreter argument (``sh -c "gh pr create ..."``,
+# one token after tokenization) is recognised as a transport.
 _FORGE_TOOL_MARKERS: Final[tuple[str, ...]] = ("gh", "glab", "curl")
+
+# Matches a marker only at a WORD boundary within the token, never inside a
+# longer run of word characters. A raw substring check (``marker in token``)
+# false-positived on ordinary English words carrying ``gh`` mid-word --
+# "though", "night", "light", "right", "weight", "eight" -- which a
+# ``t3 review post-comment`` NOTE (or any other publish body) legitimately
+# contains, wrongly classifying the whole segment as an opaque forge
+# transport and injecting the fail-closed sentinel into its own clean payload
+# (#1415). ``\b`` still matches a marker glued to punctuation/path separators
+# (`` "gh issue create ..." `` starts the token, ``/usr/bin/gh`` ends it), so
+# the opaque-wrapper detection (``sh -c "gh ..."``) is unaffected.
+_FORGE_TOOL_MARKER_RE: Final[re.Pattern[str]] = re.compile(
+    "|".join(rf"\b{re.escape(marker)}\b" for marker in _FORGE_TOOL_MARKERS)
+)
+
+
+def _token_carries_forge_marker(token: str) -> bool:
+    """Return True iff ``token`` contains a forge-tool marker as a whole word."""
+    return bool(_FORGE_TOOL_MARKER_RE.search(token))
+
 
 # Title / commit-subject flags (#1544). A title (``gh``/``glab`` ``--title``)
 # or git-commit subject is a forge surface distinct from the description body.
@@ -310,7 +331,7 @@ def segment_is_opaque_forge_transport(words: list[str]) -> bool:
     rest = _strip_cd_env_prefix(words)
     if not rest or rest[0] in _PARSEABLE_FORGE_LEADERS:
         return False
-    carries_forge = any(any(marker in token for marker in _FORGE_TOOL_MARKERS) for token in rest)
+    carries_forge = any(_token_carries_forge_marker(token) for token in rest)
     carries_substitution = any(token_has_substitution_marker(token) for token in rest)
     return carries_forge or carries_substitution
 
@@ -412,7 +433,7 @@ def _segment_is_opaque_forge_transport_raw(words: list[str], raws: list[str]) ->
         return False
     skipped = len(words) - len(rest_words)
     rest_raws = raws[skipped:]
-    carries_forge = any(any(marker in token for marker in _FORGE_TOOL_MARKERS) for token in rest_words)
+    carries_forge = any(_token_carries_forge_marker(token) for token in rest_words)
     carries_live_substitution = any(_raw_has_live_substitution(raw) for raw in rest_raws)
     return carries_forge or carries_live_substitution
 

--- a/tests/teatree_hooks/test_banned_terms_scanner.py
+++ b/tests/teatree_hooks/test_banned_terms_scanner.py
@@ -873,6 +873,62 @@ class TestMarkdownBacktickBodyResolves:
         assert FAIL_CLOSED_SENTINEL not in payload
 
 
+class TestOrdinaryWordsDoNotLookLikeOpaqueForgeTransport:
+    """An ordinary English word carrying ``gh``/``glab``/``curl`` mid-word is not a forge marker.
+
+    ``command_has_opaque_forge_transport`` flags a segment as an unscannable
+    interpreter wrapper (``sh -c "gh ..."``) when a forge-tool marker appears
+    in one of its tokens. The marker check used raw substring containment
+    (``marker in token``), which matched "gh" inside ordinary words like
+    "though", "night", "light", "right" -- so a clean ``t3 review
+    post-comment`` NOTE merely containing one of these words was misclassified
+    as hiding a forge call, and the gate appended the fail-closed sentinel to
+    its OWN clean payload (#1415). ``t3`` is not in ``_PARSEABLE_FORGE_LEADERS``
+    (it is not itself a forge tool), so every ``t3 review`` post reached this
+    check. The fix matches a marker only at a token WORD BOUNDARY.
+    """
+
+    def _payload(self, note: str) -> str | None:
+        command = f'''t3 review post-comment my-org/repo 7 --file x.py --line 1 -m "{note}"'''
+        return banned_terms_scanner.extract_publish_payload("Bash", {"command": command})
+
+    @pytest.mark.parametrize(
+        "word",
+        ["though", "night", "light", "right", "weight", "eight", "sigh", "high", "thought"],
+    )
+    def test_word_containing_gh_substring_does_not_fail_closed(self, word: str) -> None:
+        payload = self._payload(f"clean note, {word} still applies here")
+        assert payload is not None
+        assert FAIL_CLOSED_SENTINEL not in payload
+        assert word in payload
+
+    def test_word_containing_gh_substring_does_not_block_a_real_banned_term(self) -> None:
+        # The fix only stops the false-positive opaque-transport sentinel; a
+        # genuine banned term in the same note must still be scanned/matched.
+        payload = self._payload("though this mentions acmecorp directly")
+        assert payload is not None
+        assert "acmecorp" in payload
+        assert FAIL_CLOSED_SENTINEL not in payload
+
+    def test_opaque_wrapper_hiding_a_real_gh_token_still_fails_closed(self) -> None:
+        # Regression guard: the word-boundary fix must not weaken detection of
+        # an ACTUAL forge call hidden inside an opaque interpreter argument.
+        cmd = 'glab mr create -R acme-internal/x --title ok && sh -c "gh pr create -R o/public --body acmecorp"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert FAIL_CLOSED_SENTINEL in payload
+
+    def test_path_form_gh_marker_still_fails_closed(self) -> None:
+        # A path-qualified marker (``/usr/bin/gh``) is still bounded by ``/``
+        # on one side and end-of-token on the other, so it must still match.
+        # The leading ``glab mr create`` segment is what makes the whole
+        # command register as a publish in the first place.
+        cmd = 'glab mr create -R acme-internal/x --title ok && sh -c "/usr/bin/gh pr create --body acmecorp"'
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": cmd})
+        assert payload is not None
+        assert FAIL_CLOSED_SENTINEL in payload
+
+
 class TestMixedCommandSubstitutionBodyStillFailsClosed:
     """A body whose ``$(...)`` substitution content the gate cannot read fails closed.
 


### PR DESCRIPTION
## Summary

The #1415 banned-terms / #1213 quote-scanner opaque-forge-transport detector flagged a Bash segment as an unscannable interpreter wrapper whenever any token contained `gh`/`glab`/`curl` as a raw substring. Several ordinary English words contain `gh` mid-word, so a clean `t3 review post-comment` NOTE using one of them got misclassified as hiding a forge call, and the gate injected the fail-closed sentinel into its own clean payload. `t3` is not in `_PARSEABLE_FORGE_LEADERS` (it wraps gh/glab rather than being one), so every `t3 review` post reached this check.

Discovered while trying to post a routine review nit on a private GitLab repo's MR via `t3 review post-comment`: the note text contained one such word, which tripped this false positive and the gate blocked with "the body file is missing or unresolvable at scan time" -- a misleading message for what was actually an opaque-forge-transport false positive contaminating the payload.

## Fix

Match forge-tool markers on a word boundary instead of raw substring containment. Still catches the intended `sh -c "gh pr create ..."` / `/usr/bin/gh ...` opaque-wrapper shapes (the marker sits at a token boundary there -- start-of-token or after a `/`), but no longer trips on a marker buried inside an unrelated run of word characters.

## Test plan

- [x] New regression tests in `TestOrdinaryWordsDoNotLookLikeOpaqueForgeTransport` (`tests/teatree_hooks/test_banned_terms_scanner.py`) -- confirmed RED before the fix, GREEN after.
- [x] `uv run pytest tests/teatree_hooks/` -- 1775 passed.
- [x] `uv run pytest` (full suite) -- 12203 passed, 4 failed (all pre-existing environmental timeouts unrelated to this change: worktree provisioning, migration seed, CLI reference determinism -- none touch the publish-detection/hooks code path).
- [x] `ruff check` / `ruff format --check` -- clean.
