### PR TITLE
fix(hooks): exempt merge commits from the BLUEPRINT-sync check

### DIFF
--- a/scripts/hooks/check_blueprint_sync.py
+++ b/scripts/hooks/check_blueprint_sync.py
@@ -18,6 +18,11 @@ stage or by ``prek run --all-files``) is never mistaken for the commit message â
 that coupling was the bug behind task #35, where a ``fix(db)`` commit was gated
 because the first line of a staged source file was read as the "commit type".
 
+A commit mid-``git merge`` is exempt regardless of message or staged files
+(mirroring ``check_module_health.py``'s own merge exemption): its staged tree
+carries every upstream commit's changes in one shot, so it would otherwise
+false-block on virtually any non-BLUEPRINT upstream source commit.
+
 See: souliane/teatree#8
 """
 
@@ -45,6 +50,25 @@ def _staged_files() -> list[str]:
         check=False,
     )
     return result.stdout.strip().splitlines()
+
+
+def _is_merge_commit() -> bool:
+    """True mid-``git merge`` (``MERGE_HEAD`` exists), mirroring ``check_module_health.py``.
+
+    A merge commit's staged tree carries every upstream commit's changes at
+    once, including a ``src/`` change from a commit that never touched
+    BLUEPRINT.md on its own â€” a routine ``git merge origin/main`` would
+    otherwise false-block on virtually any non-BLUEPRINT upstream source
+    commit, since the commit-type exemption can't apply (a merge's default
+    message matches no ``fix:``/``refactor:``/etc. prefix).
+    """
+    result = subprocess.run(
+        ["git", "rev-parse", "-q", "--verify", "MERGE_HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
 
 
 def _is_blueprint(path: str) -> bool:
@@ -107,6 +131,9 @@ def _commit_message() -> str:
 
 
 def main() -> int:
+    if _is_merge_commit():
+        return 0
+
     msg = _commit_message()
 
     # Skip for commit types that don't need blueprint changes.

--- a/tests/test_check_blueprint_sync_hook.py
+++ b/tests/test_check_blueprint_sync_hook.py
@@ -16,11 +16,20 @@ argument that is a ``src/`` path was mis-read as the commit message, so the
 gated.
 """
 
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 
 from scripts.hooks import check_blueprint_sync as hook
+
+
+@dataclass
+class _RunOptions:
+    """``TestMain._run``'s optional invocation flags."""
+
+    argv_is_src: bool = False
+    is_merge_commit: bool = False
 
 
 class TestIsBlueprint:
@@ -130,18 +139,20 @@ class TestMain:
         *,
         message: str,
         staged: list[str],
-        argv_is_src: bool = False,
+        options: _RunOptions | None = None,
     ) -> int:
+        options = options or _RunOptions()
         msg_file = tmp_path / "COMMIT_EDITMSG"
         msg_file.write_text(message + "\n", encoding="utf-8")
         # Git's canonical commit-msg path always carries the real message.
         monkeypatch.setattr(hook, "_git_commit_editmsg_path", lambda: str(msg_file))
-        if argv_is_src:
+        if options.argv_is_src:
             # Simulate the buggy invocation: a staged src path as argv[1].
             monkeypatch.setattr(hook.sys, "argv", ["check_blueprint_sync.py", "src/teatree/x.py"])
         else:
             monkeypatch.setattr(hook.sys, "argv", ["check_blueprint_sync.py", str(msg_file)])
         monkeypatch.setattr(hook, "_staged_files", lambda: staged)
+        monkeypatch.setattr(hook, "_is_merge_commit", lambda: options.is_merge_commit)
         return hook.main()
 
     def test_src_without_blueprint_fails(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -214,7 +225,7 @@ class TestMain:
             tmp_path,
             message="fix(db): reconcile renumbered migration records",
             staged=["src/teatree/db.py"],
-            argv_is_src=True,
+            options=_RunOptions(argv_is_src=True),
         )
         assert rc == 0
 
@@ -229,6 +240,38 @@ class TestMain:
             tmp_path,
             message="feat(db): a new capability",
             staged=["src/teatree/db.py"],
-            argv_is_src=True,
+            options=_RunOptions(argv_is_src=True),
+        )
+        assert rc == 1
+
+    def test_merge_commit_is_exempt_even_with_src_and_no_blueprint(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # A merge commit's default message ("Merge branch 'origin/main' into
+        # <branch>") matches no exempt prefix, and its staged tree carries
+        # every upstream commit's src/ changes without necessarily carrying a
+        # matching BLUEPRINT update in the SAME commit — merging any non-
+        # BLUEPRINT upstream source commit would otherwise always false-block.
+        rc = self._run(
+            monkeypatch,
+            tmp_path,
+            message="Merge branch 'origin/main' into some-branch",
+            staged=["src/teatree/config_agent.py"],
+            options=_RunOptions(is_merge_commit=True),
+        )
+        assert rc == 0
+
+    def test_non_merge_commit_with_unexempt_message_still_gated(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # The merge exemption must not over-correct: an ordinary (non-merge)
+        # commit with a message that happens to start with "Merge" is still
+        # gated when it isn't actually mid-merge.
+        rc = self._run(
+            monkeypatch,
+            tmp_path,
+            message="Merge in the new config helper",
+            staged=["src/teatree/config_agent.py"],
+            options=_RunOptions(is_merge_commit=False),
         )
         assert rc == 1


### PR DESCRIPTION
## Summary

Discovered while shipping an unrelated ticket: check_blueprint_sync.py had no merge-commit exemption, unlike check_module_health.py's existing _is_merge_commit() guard.

A merge commit's staged tree carries every upstream commit's changes at once, so `git merge origin/main` on any branch false-blocks at the commit-msg hook whenever main has advanced by a source commit that didn't itself touch BLUEPRINT.md (its default "Merge branch ..." message matches no fix:/refactor:/etc. exempt prefix) -- the common case on an active branch.

This also produces a misleading "produced conflicts" ship-gate error: _attempt_merge() (branch_currency.py) treats any nonzero `git merge --no-edit` exit as CONFLICTED, including a textually-clean merge whose implicit commit was rejected by this hook -- surfacing "(unknown -- see git status)" since there are no actual unmerged paths. Exempting merge commits here removes the root cause; the misclassification in _attempt_merge is a separate, lower-severity concern left for later.

- Add _is_merge_commit(), mirroring check_module_health.py's helper (checks for MERGE_HEAD).
- Exempt merge commits at the top of main().

## Architecture pre-check

Tactical fix (a hook script gains a merge-commit exemption already established as a pattern elsewhere in the same hooks directory) -- no FSM/extension-point/dependency-direction impact.

## Test plan

- [x] New RED tests confirmed failing on pre-fix code (AttributeError: no attribute '_is_merge_commit')
- [x] uv run pytest tests/test_check_blueprint_sync_hook.py -- 32 passed
- [x] uv run ruff check / uv run ruff format --check -- clean
- [x] uv run tach check -- clean
