### PR TITLE
fix(merge): recognize GitHub's 404 'Not Found' as no branch protection, not a query failure

### DIFF
--- a/src/teatree/backends/forge_merge_rpc.py
+++ b/src/teatree/backends/forge_merge_rpc.py
@@ -160,7 +160,9 @@ class GhMergeRpc:
         rc, out, err = self._run(["api", f"repos/{slug}/branches/{base}/protection/required_status_checks"])
         if rc != 0:
             body = f"{out}\n{err}".lower()
-            if "branch not protected" in body or "required status checks not enabled" in body:
+            # `base` was already confirmed a real branch above, so a 404 here
+            # can only mean "no protection configured" — never "no such branch".
+            if "branch not protected" in body or "required status checks not enabled" in body or "not found" in body:
                 return []
             return [ROLLUP_QUERY_FAILED]
         try:

--- a/tests/teatree_core/merge/test_ci_rollup.py
+++ b/tests/teatree_core/merge/test_ci_rollup.py
@@ -469,6 +469,18 @@ class TestRequiredStatusCheckContextsTransport:
         result = self._contexts(_contexts_runner(protection=(1, "", "Required status checks not enabled")))
         assert result == []
 
+    def test_generic_404_not_found_is_empty_no_gate(self) -> None:
+        # A repo with no branch-protection rule configured at all returns
+        # GitHub's generic 404 body — not the "Branch not protected" /
+        # "Required status checks not enabled" phrasing (souliane/teatree#2900).
+        body = (
+            '{"message":"Not Found","documentation_url":'
+            '"https://docs.github.com/rest/branches/branch-protection'
+            '#get-status-checks-protection","status":"404"}'
+        )
+        result = self._contexts(_contexts_runner(protection=(1, "", body)))
+        assert result == []
+
     def test_generic_protection_error_fails_closed(self) -> None:
         result = self._contexts(_contexts_runner(protection=(1, "", "HTTP 403: Forbidden")))
         assert rollup_query_failed(result)


### PR DESCRIPTION
fix(merge): recognize GitHub's 404 'Not Found' as no branch protection, not a query failure

fetch_required_status_check_contexts only recognized the "Branch not
protected" and "Required status checks not enabled" 404 phrasings for
a repo with no branch-protection rule configured. GitHub's actual 404
body for that state is the generic {"message":"Not Found",...} — which
fell through to the fail-closed sentinel, making the required-checks
set look indeterminate and blocking merge on an otherwise fully green
PR.

Recognize the generic "not found" phrase too. The base branch is
already validated as real one call earlier, so a 404 on its protection
endpoint can only mean "no protection configured."

Fixes souliane/teatree#2900

## What

## Why