### PR TITLE
fix(hooks): add verify-cron instruction to SessionStart bulk registration nudge

### DIFF
--- a/hooks/scripts/loop_registrations.py
+++ b/hooks/scripts/loop_registrations.py
@@ -26,6 +26,11 @@ yields ZERO specs, so the handler stays silent — never an exception into the 3
 so the three infra loops still register even when the DB is unreachable (only the
 DB-loop directives fall away). With no enabled DB loops AND no reactive slots
 resolvable, nothing is emitted.
+
+**Verify-by-reread (#1192).** This is the primary, higher-traffic live loop
+registration path (every SessionStart with enabled loops), so it carries the
+same ``t3 loop verify-cron`` confirm-step nudge as the manual ``/t3:loops``
+skill workflow — see :mod:`teatree.core.verify_by_reread`.
 """
 
 import json
@@ -123,6 +128,17 @@ def _write_prose(loops: list[dict], stream: _Writable) -> None:
         stream.write(
             f'  - {entry["slot_id"]}: CronCreate(cron="{entry["cron"]}", prompt="{entry["prompt"]}", recurring=true)\n'
         )
+    stream.write(
+        "Verify-by-reread (#1192): each CronCreate's own success is not proof the registration is visible. "
+        "After calling CronCreate for every loop above, call CronList once, save its JSON output, then run "
+        "`t3 loop verify-cron <name> --cron-list-json <path>` for each loop below (or pipe: `... | t3 loop "
+        "verify-cron <name> --cron-list-json -`). Exits 0 and prints `confirmed: ...` when a loop's "
+        "registration is present in the snapshot; exits non-zero with a reason when it is not — retry that "
+        "loop's CronCreate in that case:\n"
+    )
+    for entry in loops:
+        name = loop_name_from_prompt(entry["prompt"]) or entry["slot_id"]
+        stream.write(f"  - {name}: t3 loop verify-cron {name} --cron-list-json <path>\n")
 
 
 def _write_reactive_prose(directives: list[str], stream: _Writable) -> None:

--- a/tests/test_loop_registrations_hook.py
+++ b/tests/test_loop_registrations_hook.py
@@ -57,6 +57,13 @@ class TestEmitLoopRegistrations:
         # not read the structured directive still registers all of them.
         assert "t3-loop-inbox" in text
         assert "t3-loop-ship" in text
+        # Verify-by-reread (#1192): the bulk SessionStart nudge must instruct the
+        # same confirm step the manual /t3:loops skill path already has, per
+        # loop name (not slot_id) — the CLI's positional arg is the DB Loop name.
+        assert "verify-cron" in text
+        assert "CronList" in text
+        assert "t3 loop verify-cron inbox --cron-list-json" in text
+        assert "t3 loop verify-cron ship --cron-list-json" in text
 
     def test_no_db_loops_still_auto_registers_the_three_reactive_slots(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # No enabled DB loop, but the three always-on reactive slots have no DB


### PR DESCRIPTION
## What / Why

A cold review of #2905 (verify-by-reread contract for post-write side effects, #1192) found a gap: `hooks/scripts/loop_registrations.py`'s SessionStart bulk `CronCreate` nudge — the primary, higher-traffic live loop registration path — was not updated to instruct `t3 loop verify-cron`. Only the manual single-loop `/t3:loops` skill workflow got the instruction, so the resilience invariant #2905 introduced was unexercised on the path that matters most (every session start with enabled loops).

This adds the equivalent verify-by-reread nudge to the bulk path, reusing the existing `loop_name_from_prompt` helper (already in the same module, already tested) to derive each loop's DB name from its registered prompt — no new imports, no duplicated prefix-stripping logic.

## Architecture pre-check

- **BLUEPRINT § alignment:** #1192 resilience invariants (verify-by-reread). Tactical consistency fix on an already-shipped contract — no new BLUEPRINT section needed.
- **FSM phase boundaries:** n/a — no `Ticket.State`/`Worktree.State` transition involved.
- **Extension-point contracts:** n/a — no `OverlayBase`/scanner/hook Protocol change.
- **Component boundaries:** stays in `hooks/scripts/loop_registrations.py` (hook prose emission), matching the existing module.
- **Dependency direction:** no new imports; reuses the module's own `loop_name_from_prompt`.
- **Test surface:** extended `tests/test_loop_registrations_hook.py::TestEmitLoopRegistrations::test_emits_one_register_cron_entry_per_enabled_loop` to assert the verify-cron nudge text and per-loop `t3 loop verify-cron <name> --cron-list-json` lines are present.
- **Resilience invariants:** this change itself only adds prose guidance — no new external write introduced.
- **Identity/key normalization:** derives the DB Loop name from the prompt via the existing single-source-of-truth `loop_name_from_prompt`, not by re-deriving/stripping the slot_id prefix.
- **Behavior preservation:** purely additive — no existing behavior removed.

## Test plan

- `uv run pytest tests/test_loop_registrations_hook.py tests/test_teatree_opt_in.py tests/teatree_loop/test_loop_cadences.py -q --no-migrations --reuse-db` — 107 passed.
- Full pre-commit/prek suite green on commit; pre-push privacy/leak/near-zero-comments gates green on push.

## Open questions & assumptions

- assumed: the bulk nudge should list one `t3 loop verify-cron <name>` line per registered loop (mirroring the per-loop `CronCreate` list above it), rather than a single generic instruction, since the manual skill's `X` placeholder implies a per-loop invocation.
- none further.
