### PR TITLE
feat(core): repo-namespaced key for the per-ticket context store (#2293)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -82,6 +82,8 @@ Five core lifecycle models in `teatree.core.models/`, all FSM-driven (`django-fs
 
 `Ticket` also carries a `Role` enum (`AUTHOR` / `REVIEWER`) orthogonal to its state. The reviewer role drives the §5.6 `reviewer_prs` scanner (`Ticket(role="reviewer", issue_url=<pr_url>)`) and short-circuits to `delivered` once the review work completes; the author role is the default lifecycle.
 
+**Repo-namespaced ticket key ([#2293](https://github.com/souliane/teatree/issues/2293)).** `Ticket.repo_namespaced_key` is a collision-free `<repo-slug>#<issue-number>` computed from `issue_url` on save (issue-only — GitLab issues and merge requests are separate numbering sequences in the same project, so a PR/MR URL never feeds this key), backed by a partial unique constraint mirroring `issue_url`'s. `TicketManager.resolve()` and `t3 <overlay> ticket context show|add|edit` (the durable per-ticket context store, [#627](https://github.com/souliane/teatree/issues/627)) accept it alongside pk / bare issue number / full issue URL, so `owner/repo#42` never risks landing on a different repo's issue #42.
+
 **State machines** (one row per `Ticket` is the unit of work):
 
 | Model | States |

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -7647,7 +7647,7 @@ Usage: t3 teatree ticket create-sub [OPTIONS]
 ```
 Usage: t3 teatree ticket context [OPTIONS] COMMAND [ARGS]...
 
- Durable per-ticket knowledge store (#627).
+ Durable per-ticket knowledge store (#627, repo-namespaced key #2293).
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
@@ -7666,8 +7666,12 @@ Usage: t3 teatree ticket context show [OPTIONS] TICKET_ID
 
  Print the ticket's durable context store.
 
+ ``ticket_id`` accepts the internal DB pk, the full issue URL, the
+ bare issue number, or the repo-namespaced key (``owner/repo#42``) —
+ the same identifier set as ``pr create`` (#694, #2293).
+
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
-│ *    ticket_id      INTEGER  [required]                                      │
+│ *    ticket_id      TEXT  [required]                                         │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
@@ -7683,10 +7687,11 @@ Usage: t3 teatree ticket context add [OPTIONS] TICKET_ID ENTRY
 
  Append-only: parallel sessions never overwrite each other (open
  question 2). A blank entry is refused with a nonzero exit.
+ ``ticket_id`` accepts the same identifier set as ``context show``.
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
-│ *    ticket_id      INTEGER  [required]                                      │
-│ *    entry          TEXT     [required]                                      │
+│ *    ticket_id      TEXT  [required]                                         │
+│ *    entry          TEXT  [required]                                         │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
@@ -7702,10 +7707,11 @@ Usage: t3 teatree ticket context edit [OPTIONS] TICKET_ID
 
  Unlike ``add``, ``edit`` is a full-field rewrite — for pruning stale
  entries or restructuring. An aborted edit (editor exits without
- saving) leaves the store untouched.
+ saving) leaves the store untouched. ``ticket_id`` accepts the same
+ identifier set as ``context show``.
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
-│ *    ticket_id      INTEGER  [required]                                      │
+│ *    ticket_id      TEXT  [required]                                         │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │

--- a/docs/generated/management-commands.json
+++ b/docs/generated/management-commands.json
@@ -765,6 +765,10 @@
       "name": "ticket",
       "subcommands": [
         {
+          "help": "Durable per-ticket knowledge store (#627, repo-namespaced key #2293)",
+          "name": "context"
+        },
+        {
           "help": "Show a ticket's state plus the per-phase ``attempt N/max`` budget (#2009)",
           "name": "show"
         },
@@ -775,10 +779,6 @@
         {
           "help": "Record a PlanArtifact and advance the ticket STARTED \u2192 PLANNED",
           "name": "plan"
-        },
-        {
-          "help": "Durable per-ticket knowledge store (#627)",
-          "name": "context"
         },
         {
           "help": "Issue a per-diff CLEAR \u2014 the orchestrator's only merge output (BLUEPRINT \u00a717.4.2)",

--- a/docs/generated/management-commands.md
+++ b/docs/generated/management-commands.md
@@ -402,10 +402,10 @@ The ``ticket rubric-set`` / ``rubric-grade`` commands, mounted via MRO inheritan
 
 | Subcommand | Description |
 | --- | --- |
+| `context` | Durable per-ticket knowledge store (#627, repo-namespaced key #2293) |
 | `show` | Show a ticket's state plus the per-phase ``attempt N/max`` budget (#2009) |
 | `transition` | Transition a ticket to a new state |
 | `plan` | Record a PlanArtifact and advance the ticket STARTED → PLANNED |
-| `context` | Durable per-ticket knowledge store (#627) |
 | `clear` | Issue a per-diff CLEAR — the orchestrator's only merge output (BLUEPRINT §17.4.2) |
 | `merge` | Execute the missing IN_REVIEW → MERGED keystone transition (BLUEPRINT §17.4) |
 | `comment` | Post a comment to an issue or work item by its URL |

--- a/src/teatree/core/admin.py
+++ b/src/teatree/core/admin.py
@@ -16,7 +16,8 @@ from teatree.core.models import (
 
 @admin.register(Ticket)
 class TicketAdmin(admin.ModelAdmin):
-    list_display = ("id", "state", "variant", "issue_url")
+    list_display = ("id", "state", "variant", "issue_url", "repo_namespaced_key")
+    search_fields = ("issue_url", "repo_namespaced_key")
 
 
 @admin.register(Worktree)

--- a/src/teatree/core/management/commands/_context_commands.py
+++ b/src/teatree/core/management/commands/_context_commands.py
@@ -1,0 +1,105 @@
+"""``ticket context show|add|edit`` — durable per-ticket knowledge store (#627, #2293).
+
+Split out of ``ticket.py`` as a :class:`ContextCommands` mixin (the same MRO
+split as ``RubricCommands`` / ``TicketShowCommands``) so the already-cap-bound
+command god-module does not grow.
+"""
+
+from typing import TypedDict
+
+import click
+from django_typer.management import TyperCommand, group
+
+from teatree.core.models import Ticket
+
+
+class ContextResult(TypedDict, total=False):
+    ticket_id: int
+    repo_namespaced_key: str
+    context: str
+
+
+class ContextCommands(TyperCommand):
+    """The ``ticket context`` command group, mounted via MRO inheritance.
+
+    Lives here as a mixin the ``ticket`` command inherits (the same split as
+    ``RubricCommands`` / ``TicketShowCommands``) so its LOC stays out of the
+    already-cap-bound ``ticket.py``. django-typer collects ``@command``/
+    ``@group`` methods from every ``TyperCommand`` base in the MRO, so the
+    CLI surface is unchanged.
+    """
+
+    def _resolve_ticket_ref(self, ticket_id: str) -> Ticket:
+        """Resolve *ticket_id* (pk / issue number / issue URL / repo-namespaced key) or abort.
+
+        The durable context store is looked up by the same identifier set as
+        ``pr create`` / ``lifecycle visit-phase`` (#694), including the
+        collision-free repo-namespaced key (#2293) — so
+        ``t3 <overlay> ticket context show owner/repo#42`` never risks
+        landing on the wrong repo's issue #42.
+        """
+        try:
+            return Ticket.objects.resolve(ticket_id)
+        except Ticket.DoesNotExist:
+            self.stderr.write(f"  Ticket {ticket_id!r} not found")
+            raise SystemExit(1) from None
+
+    @group(help="Durable per-ticket knowledge store (#627, repo-namespaced key #2293).")
+    def context(self) -> None:
+        """Group root — forces sub-commands to be addressed by name."""
+
+    @context.command(name="show")
+    def context_show(self, ticket_id: str) -> ContextResult:
+        """Print the ticket's durable context store.
+
+        ``ticket_id`` accepts the internal DB pk, the full issue URL, the
+        bare issue number, or the repo-namespaced key (``owner/repo#42``) —
+        the same identifier set as ``pr create`` (#694, #2293).
+        """
+        ticket = self._resolve_ticket_ref(ticket_id)
+        self.stdout.write(ticket.context or "(empty)")
+        return {
+            "ticket_id": int(ticket.pk),
+            "repo_namespaced_key": ticket.repo_namespaced_key,
+            "context": ticket.context,
+        }
+
+    @context.command(name="add")
+    def context_add(self, ticket_id: str, entry: str) -> ContextResult:
+        """Append a timestamped ``<key>: <value>`` line to the context store.
+
+        Append-only: parallel sessions never overwrite each other (open
+        question 2). A blank entry is refused with a nonzero exit.
+        ``ticket_id`` accepts the same identifier set as ``context show``.
+        """
+        ticket = self._resolve_ticket_ref(ticket_id)
+        try:
+            updated = ticket.append_context(entry)
+        except ValueError as exc:
+            self.stderr.write(f"  refused: {exc}")
+            raise SystemExit(1) from exc
+        self.stdout.write(f"  appended to ticket {ticket.pk} context")
+        return {"ticket_id": int(ticket.pk), "repo_namespaced_key": ticket.repo_namespaced_key, "context": updated}
+
+    @context.command(name="edit")
+    def context_edit(self, ticket_id: str) -> ContextResult:
+        """Open the full context store in ``$EDITOR`` and replace it.
+
+        Unlike ``add``, ``edit`` is a full-field rewrite — for pruning stale
+        entries or restructuring. An aborted edit (editor exits without
+        saving) leaves the store untouched. ``ticket_id`` accepts the same
+        identifier set as ``context show``.
+        """
+        ticket = self._resolve_ticket_ref(ticket_id)
+        edited = click.edit(ticket.context)
+        if edited is None:
+            self.stdout.write(f"  edit aborted — ticket {ticket.pk} context unchanged")
+            return {
+                "ticket_id": int(ticket.pk),
+                "repo_namespaced_key": ticket.repo_namespaced_key,
+                "context": ticket.context,
+            }
+        ticket.context = edited
+        ticket.save(update_fields=["context"])
+        self.stdout.write(f"  ticket {ticket.pk} context replaced")
+        return {"ticket_id": int(ticket.pk), "repo_namespaced_key": ticket.repo_namespaced_key, "context": edited}

--- a/src/teatree/core/management/commands/ticket.py
+++ b/src/teatree/core/management/commands/ticket.py
@@ -3,15 +3,15 @@
 import logging
 from typing import Annotated, TypedDict
 
-import click
 import typer
 from django.db import transaction
 from django_fsm import TransitionNotAllowed
-from django_typer.management import TyperCommand, command, group
+from django_typer.management import TyperCommand, command
 
 from teatree.core.gates.owned_repo_guard import MergeKeystoneResult, escalated_merge_result, merge_clear_refusal
 from teatree.core.gates.schema_guard import SelfDbMigrationError, require_current_schema
 from teatree.core.management.commands._clear_preflight import clear_preflight_refusal
+from teatree.core.management.commands._context_commands import ContextCommands
 from teatree.core.management.commands._plan_gate_commands import (
     PlanAdvanceError,
     PlanReconcileResult,
@@ -60,11 +60,6 @@ class ClearIssueResult(TypedDict, total=False):
     ticket_id: int
     recorded_verdict_id: int
     error: str
-
-
-class ContextResult(TypedDict, total=False):
-    ticket_id: int
-    context: str
 
 
 class DodOverrideResult(TypedDict, total=False):
@@ -117,7 +112,7 @@ _ALLOWED_TRANSITIONS = {
 }
 
 
-class Command(RubricCommands, TicketShowCommands, TyperCommand):
+class Command(RubricCommands, TicketShowCommands, ContextCommands, TyperCommand):
     @command()
     def transition(self, ticket_id: int, transition_name: str) -> dict[str, object]:
         """Transition a ticket to a new state.
@@ -415,51 +410,6 @@ class Command(RubricCommands, TicketShowCommands, TyperCommand):
         except Ticket.DoesNotExist:
             self.stderr.write(f"  Ticket {ticket_id} not found")
             raise SystemExit(1) from None
-
-    @group(help="Durable per-ticket knowledge store (#627).")
-    def context(self) -> None:
-        """Group root — forces sub-commands to be addressed by name."""
-
-    @context.command(name="show")
-    def context_show(self, ticket_id: int) -> ContextResult:
-        """Print the ticket's durable context store."""
-        ticket = self._resolve_ticket(ticket_id)
-        self.stdout.write(ticket.context or "(empty)")
-        return {"ticket_id": int(ticket.pk), "context": ticket.context}
-
-    @context.command(name="add")
-    def context_add(self, ticket_id: int, entry: str) -> ContextResult:
-        """Append a timestamped ``<key>: <value>`` line to the context store.
-
-        Append-only: parallel sessions never overwrite each other (open
-        question 2). A blank entry is refused with a nonzero exit.
-        """
-        ticket = self._resolve_ticket(ticket_id)
-        try:
-            updated = ticket.append_context(entry)
-        except ValueError as exc:
-            self.stderr.write(f"  refused: {exc}")
-            raise SystemExit(1) from exc
-        self.stdout.write(f"  appended to ticket {ticket.pk} context")
-        return {"ticket_id": int(ticket.pk), "context": updated}
-
-    @context.command(name="edit")
-    def context_edit(self, ticket_id: int) -> ContextResult:
-        """Open the full context store in ``$EDITOR`` and replace it.
-
-        Unlike ``add``, ``edit`` is a full-field rewrite — for pruning stale
-        entries or restructuring. An aborted edit (editor exits without
-        saving) leaves the store untouched.
-        """
-        ticket = self._resolve_ticket(ticket_id)
-        edited = click.edit(ticket.context)
-        if edited is None:
-            self.stdout.write(f"  edit aborted — ticket {ticket.pk} context unchanged")
-            return {"ticket_id": int(ticket.pk), "context": ticket.context}
-        ticket.context = edited
-        ticket.save(update_fields=["context"])
-        self.stdout.write(f"  ticket {ticket.pk} context replaced")
-        return {"ticket_id": int(ticket.pk), "context": edited}
 
     @command()
     # ast-grep-ignore: ac-django-no-complexity-suppressions

--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -58,13 +58,17 @@ class _OverlayFilterMixin:
 
 class TicketQuerySet(_OverlayFilterMixin, models.QuerySet):
     def resolve(self, ref: str) -> "Ticket":
-        """Resolve a ticket from a numeric pk, an issue number, or an issue URL.
+        """Resolve a ticket from a pk, an issue number, an issue URL, or a repo key.
 
         Accepts a numeric pk (``"314"`` — direct DB lookup), a full issue URL
         (``"https://github.com/owner/repo/issues/466"`` — exact match on
-        ``issue_url``), or a bare issue number when no pk exists (``"466"`` —
+        ``issue_url``), a bare issue number when no pk exists (``"466"`` —
         matches an ``issue_url`` ending in ``/466`` *or* one stored as the
-        bare string ``"466"``, #707). Shared by
+        bare string ``"466"``, #707), or the collision-free repo-namespaced
+        key (``"owner/repo#466"`` — exact match on ``repo_namespaced_key``,
+        #2293). The bare-number fallback stays ambiguous by construction (a
+        digit alone carries no repo information) — pass the repo-namespaced
+        key or the full URL when two repos share an issue number. Shared by
         ``pr create`` and ``lifecycle visit-phase`` so both accept the same
         identifier set (#694) — callers naturally pass the forge issue number
         and must not silently hit ``DoesNotExist``.
@@ -82,9 +86,12 @@ class TicketQuerySet(_OverlayFilterMixin, models.QuerySet):
                 if ticket is not None:
                     return ticket
                 raise
+        keyed = self.filter(repo_namespaced_key=ref).first()
+        if keyed is not None:
+            return keyed
         ticket = self.filter(issue_url=ref).first()
         if ticket is None:
-            msg = f"No ticket matching {ref!r} (looked up by pk and issue_url)"
+            msg = f"No ticket matching {ref!r} (looked up by pk, issue_url, and repo_namespaced_key)"
             raise ticket_model.DoesNotExist(msg)
         return ticket
 

--- a/src/teatree/core/migrations/0014_ticket_repo_namespaced_key.py
+++ b/src/teatree/core/migrations/0014_ticket_repo_namespaced_key.py
@@ -1,0 +1,70 @@
+import re
+from urllib.parse import urlparse
+
+from django.db import migrations, models
+
+# Frozen copy of `teatree.utils.url_slug`'s issue-only regexes (#2293): a
+# migration's data transform must stay historically accurate even if the
+# live parser's rules evolve later, so the pattern is duplicated here
+# rather than imported (mirrors `0005_backfill_task_subject._ticket_number`).
+_GITHUB_ISSUE_RE = re.compile(r"^/(?P<slug>[^/]+/[^/]+)/issues/(?P<number>\d+)/?$")
+_GITLAB_ISSUE_RE = re.compile(r"^/(?P<slug>.+?)/-/(?:issues|work_items)/(?P<number>\d+)/?$")
+
+
+def _repo_namespaced_key(issue_url: str) -> str:
+    path = urlparse(issue_url or "").path
+    gitlab = _GITLAB_ISSUE_RE.match(path)
+    if gitlab is not None:
+        return f"{gitlab['slug']}#{gitlab['number']}"
+    github = _GITHUB_ISSUE_RE.match(path)
+    if github is not None:
+        return f"{github['slug']}#{github['number']}"
+    return ""
+
+
+def backfill_repo_namespaced_key(apps, schema_editor):
+    Ticket = apps.get_model("core", "Ticket")
+    # Seed with every already-set key (an explicit value, or a prior partial
+    # run of this backfill) so a freshly-computed key can never claim one
+    # that is already spoken for — this is idempotent and re-runnable.
+    seen: set[str] = set(Ticket.objects.exclude(repo_namespaced_key="").values_list("repo_namespaced_key", flat=True))
+    candidates = Ticket.objects.filter(repo_namespaced_key="").exclude(issue_url="")
+    for ticket in candidates.iterator():
+        key = _repo_namespaced_key(ticket.issue_url)
+        # No-op for a non-issue `issue_url` (blank key) and for a duplicate
+        # key a pre-existing data anomaly would otherwise produce (two rows
+        # whose `issue_url` differ byte-for-byte but parse to the same repo
+        # and issue number) — the unique constraint added below must never
+        # see an IntegrityError from this backfill.
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        ticket.repo_namespaced_key = key
+        ticket.save(update_fields=["repo_namespaced_key"])
+
+
+def noop_reverse(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0013_alter_pendingchatinjection_answer_kind"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="ticket",
+            name="repo_namespaced_key",
+            field=models.CharField(blank=True, db_index=True, default="", max_length=300),
+        ),
+        migrations.RunPython(backfill_repo_namespaced_key, noop_reverse),
+        migrations.AddConstraint(
+            model_name="ticket",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("repo_namespaced_key", ""), _negated=True),
+                fields=("repo_namespaced_key",),
+                name="unique_nonempty_repo_namespaced_key",
+            ),
+        ),
+    ]

--- a/src/teatree/core/migrations/max_migration.txt
+++ b/src/teatree/core/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0013_alter_pendingchatinjection_answer_kind
+0014_ticket_repo_namespaced_key

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -12,8 +12,9 @@ from teatree.core.managers import TicketManager
 from teatree.core.modelkit.gate_registry import get_gate, get_resolver
 from teatree.core.modelkit.review_state import ReviewState
 from teatree.core.models.errors import DirtyWorktreeError, InvalidTransitionError
-from teatree.core.models.ticket_worktree_checks import worktree_has_commits_ahead, worktree_tracked_dirty_path
+from teatree.core.models.ticket_worktree_checks import collect_dirty_worktree_paths, worktree_has_commits_ahead
 from teatree.core.models.types import validated_ticket_extra
+from teatree.utils.url_slug import repo_namespaced_key as compute_repo_namespaced_key
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +125,11 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
     # Set to True when the remote forge returns HTTP 404; the disposition scanner
     # then excludes this ticket from future fetches (#1875).
     remote_missing = models.BooleanField(default=False)
+    # Collision-free ``<repo-slug>#<issue-number>`` derived from `issue_url`
+    # (#2293): a bare numeric IID may collide across repos, this key never
+    # does. Blank when `issue_url` is a PR/MR reference, a bare number, or
+    # any other non-issue shape — see `repo_namespaced_key_from_path`.
+    repo_namespaced_key = models.CharField(max_length=300, blank=True, default="", db_index=True)
 
     objects = TicketManager()
 
@@ -135,6 +141,11 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
                 name="unique_nonempty_issue_url",
                 condition=~models.Q(issue_url=""),
             ),
+            models.UniqueConstraint(
+                fields=["repo_namespaced_key"],
+                name="unique_nonempty_repo_namespaced_key",
+                condition=~models.Q(repo_namespaced_key=""),
+            ),
         ]
 
     def __str__(self) -> str:
@@ -143,6 +154,8 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
     def save(self, *args: object, **kwargs: object) -> None:
         if not self.overlay and self.issue_url:
             self.overlay = self._infer_overlay()
+        if not self.repo_namespaced_key and self.issue_url:
+            self.repo_namespaced_key = compute_repo_namespaced_key(self.issue_url)
         super().save(*args, **kwargs)  # type: ignore[arg-type]
 
     def _infer_overlay(self) -> str:
@@ -823,42 +836,14 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         """Preflight gate (#884): refuse the transition if a worktree is tracked-dirty.
 
         Run at the top of the ``code``/``test``/``review``/``ship``
-        transition bodies, before any scheduling side effect. Owner-resolved
-        policy: a worktree with uncommitted *tracked* changes must not
-        advance the FSM — the agent has to commit or discard first. We do
-        NOT auto-stash: teatree worktrees share one ``.git`` so a stash is
-        repo-global and would clobber an unrelated branch's work (the
-        foreign-stash hazard, near-miss class #806).
-
-        Untracked-only files do not block (the #925 distinction, mirroring
-        ``cli.update._tracked_dirty_paths``): a fast-forward never conflicts
-        with untracked scratch, and the loop legitimately leaves scratch
-        files around. Only a tracked modification — work the agent forgot to
-        commit — is the refusal trigger.
-
-        On dirty: a loud :class:`DirtyWorktreeError` is raised naming the
-        dirty worktree. The transition does **not** advance — every
-        production caller wraps the transition body in an *outer*
-        ``transaction.atomic`` (the loop: ``Task.complete()`` →
-        ``_advance_ticket`` → ``_apply_phase_transition``; ship:
-        ``_ship_exec._do_ship_transition``), so the raise rolls that whole
-        atomic back and the ticket stays put. **The task is not
-        force-reopened here** — there is no cross-transaction durable write
-        that could survive the caller's rollback, so attempting one only
-        adds a false durability claim. Held-task recovery is the existing
-        **lease-reaper safety net**: the worker that called the transition
-        stops heartbeating after the exception, the task's lease expires,
-        and ``TaskManager.reclaim_orphaned_claims`` returns the CLAIMED task
-        to PENDING on the next loop tick so the agent re-runs it and
-        finishes the commit. Mirrors the existing loud-refusal convention
-        (``InvalidTransitionError`` in ``schedule_coding`` / the #694 gate).
+        transition bodies. Dirty-collection rule and the no-auto-stash/
+        lease-reaper rationale live on :func:`collect_dirty_worktree_paths`
+        (#1983 LOC-ratchet split). On dirty: a loud :class:`DirtyWorktreeError`
+        names the dirty worktree(s) and the transition does not advance —
+        every production caller wraps the transition body in an outer
+        ``transaction.atomic``, so the raise rolls that whole atomic back.
         """
-        worktree_model = apps.get_model("core", "Worktree")
-        dirty = [
-            path
-            for wt in worktree_model.objects.filter(ticket=self)
-            if (path := worktree_tracked_dirty_path(wt)) is not None
-        ]
+        dirty = collect_dirty_worktree_paths(self)
         if not dirty:
             return
         joined = ", ".join(dirty)

--- a/src/teatree/core/models/ticket_worktree_checks.py
+++ b/src/teatree/core/models/ticket_worktree_checks.py
@@ -8,10 +8,13 @@ stays under the module-health LOC cap.
 
 from typing import TYPE_CHECKING
 
+from django.apps import apps
+
 from teatree.utils import git
 from teatree.utils.run import CommandFailedError
 
 if TYPE_CHECKING:
+    from teatree.core.models.ticket import Ticket
     from teatree.core.models.worktree import Worktree
 
 
@@ -55,6 +58,29 @@ def worktree_tracked_dirty_path(worktree: "Worktree") -> str | None:
         return None
     tracked_dirty = any(line and not line.startswith("??") for line in porcelain.splitlines())
     return repo_path if tracked_dirty else None
+
+
+def collect_dirty_worktree_paths(ticket: "Ticket") -> list[str]:
+    """Return the on-disk paths of every ``ticket`` worktree with uncommitted tracked changes.
+
+    Backs ``Ticket._refuse_if_worktree_dirty`` (#884 preflight, moved out here
+    in the #1983 LOC-ratchet split): a worktree with uncommitted *tracked*
+    changes must not let its ticket's FSM advance — the agent has to commit
+    or discard first. We do NOT auto-stash: teatree worktrees share one
+    ``.git`` so a stash is repo-global and would clobber an unrelated
+    branch's work (the foreign-stash hazard, near-miss class #806).
+
+    Untracked-only files do not block (the #925 distinction): a
+    fast-forward never conflicts with untracked scratch, and the loop
+    legitimately leaves scratch files around — only a tracked modification
+    is the refusal trigger, via :func:`worktree_tracked_dirty_path`.
+    """
+    worktree_model = apps.get_model("core", "Worktree")
+    return [
+        path
+        for wt in worktree_model.objects.filter(ticket=ticket)
+        if (path := worktree_tracked_dirty_path(wt)) is not None
+    ]
 
 
 def _resolve_base_branch(repo_path: str) -> str:

--- a/src/teatree/utils/url_slug.py
+++ b/src/teatree/utils/url_slug.py
@@ -18,6 +18,13 @@ _GITLAB_RE = re.compile(r"^/(?P<slug>.+?)/-/(?:issues|work_items|merge_requests)
 _GITHUB_PR_RE = re.compile(r"^/(?P<slug>[^/]+/[^/]+)/(?:pull|pulls|merge_requests)/(?P<number>\d+)/?$")
 _GITLAB_MR_RE = re.compile(r"^/(?P<slug>.+?)/-/merge_requests/(?P<number>\d+)/?$")
 
+# Issue-only (never PR/MR): GitLab issues and merge requests are separate
+# numbering sequences within the same project, so a PR/MR path must never
+# feed the repo-namespaced key below — issue #5 and merge request !5 could
+# otherwise collide on the same key (#2293).
+_GITHUB_ISSUE_RE = re.compile(r"^/(?P<slug>[^/]+/[^/]+)/issues/(?P<number>\d+)/?$")
+_GITLAB_ISSUE_RE = re.compile(r"^/(?P<slug>.+?)/-/(?:issues|work_items)/(?P<number>\d+)/?$")
+
 
 def slug_from_issue_or_pr_url(url_path: str) -> str:
     """Return the repo slug for *url_path* (a ``urlparse(...).path``).
@@ -67,3 +74,33 @@ def pr_ref_from_url(url: str) -> PrRef | None:
         host_kind = "gitlab" if "gitlab" in host else "github"
         return PrRef(slug=github["slug"], number=int(github["number"]), host_kind=host_kind)
     return None
+
+
+def repo_namespaced_key_from_path(url_path: str) -> str:
+    """Return the collision-free ``<repo-slug>#<issue-number>`` key for *url_path*.
+
+    Recognises GitHub ``/<owner>/<repo>/issues/<n>`` and GitLab
+    ``/<path>/-/issues|work_items/<iid>`` — issue references only, never a
+    PR/MR path (see the note on :data:`_GITHUB_ISSUE_RE`). Returns ``""``
+    when *url_path* matches neither shape, so a bare-number or non-forge
+    ``issue_url`` (a reviewer-role ticket keyed by a PR/MR URL, a
+    ``dogfood-smoke://`` scheme, ...) is a deliberate no-op rather than a
+    guessed key (#2293).
+    """
+    gitlab = _GITLAB_ISSUE_RE.match(url_path)
+    if gitlab is not None:
+        return f"{gitlab['slug']}#{gitlab['number']}"
+    github = _GITHUB_ISSUE_RE.match(url_path)
+    if github is not None:
+        return f"{github['slug']}#{github['number']}"
+    return ""
+
+
+def repo_namespaced_key(url: str) -> str:
+    """Return :func:`repo_namespaced_key_from_path` for a full issue *url*.
+
+    The canonical, collision-free ticket-context cache key (#2293):
+    ``acme-eng/bugs#42`` and ``acme-product#42`` share a bare numeric IID
+    but never collide on this key, since the full repo path is part of it.
+    """
+    return repo_namespaced_key_from_path(urlparse(url).path)

--- a/tests/teatree_core/models/test_ticket_dirty_worktree_preflight.py
+++ b/tests/teatree_core/models/test_ticket_dirty_worktree_preflight.py
@@ -235,3 +235,42 @@ class TestWorktreeTrackedDirtyPathFailOpen(TestCase):
         err = CommandFailedError(["git", "status", "--porcelain"], 128, "", "not a git repository")
         with patch.object(checks_mod.git, "status_porcelain", side_effect=err):
             assert worktree_tracked_dirty_path(wt) is None
+
+
+class TestCollectDirtyWorktreePaths(TestCase):
+    """Direct coverage of the #1983 extraction backing ``_refuse_if_worktree_dirty``."""
+
+    @pytest.fixture(autouse=True)
+    def _inject_tmp_path(self, tmp_path: Path) -> None:
+        self._tmp_path = tmp_path
+
+    def test_returns_the_repo_path_for_a_tracked_dirty_worktree(self) -> None:
+        from teatree.core.models.ticket_worktree_checks import collect_dirty_worktree_paths  # noqa: PLC0415
+
+        ticket = Ticket.objects.create()
+        repo_dir = self._tmp_path / "repo"
+        _init_repo_with_branch(repo_dir, branch="feature", commits_ahead=1)
+        Worktree.objects.create(
+            ticket=ticket,
+            repo_path=str(repo_dir),
+            branch="feature",
+            extra={"worktree_path": str(repo_dir)},
+        )
+        (repo_dir / "f0.txt").write_text("uncommitted tracked change\n")
+
+        assert collect_dirty_worktree_paths(ticket) == [str(repo_dir)]
+
+    def test_returns_empty_for_a_clean_worktree(self) -> None:
+        from teatree.core.models.ticket_worktree_checks import collect_dirty_worktree_paths  # noqa: PLC0415
+
+        ticket = Ticket.objects.create()
+        repo_dir = self._tmp_path / "repo"
+        _init_repo_with_branch(repo_dir, branch="feature", commits_ahead=1)
+        Worktree.objects.create(
+            ticket=ticket,
+            repo_path=str(repo_dir),
+            branch="feature",
+            extra={"worktree_path": str(repo_dir)},
+        )
+
+        assert collect_dirty_worktree_paths(ticket) == []

--- a/tests/teatree_core/test_migration_backfill_repo_namespaced_key.py
+++ b/tests/teatree_core/test_migration_backfill_repo_namespaced_key.py
@@ -1,0 +1,80 @@
+"""Regression test for ``core.0014_ticket_repo_namespaced_key`` (#2293).
+
+A ``Ticket`` row created before ``repo_namespaced_key`` existed carries a
+blank key even though its ``issue_url`` is a parseable GitHub/GitLab issue
+URL. ``0014`` backfills the collision-free key for every existing row it
+can parse, and is a no-op for rows it cannot (PR/MR-shaped, bare-number,
+or non-forge ``issue_url``).
+"""
+
+import importlib
+
+from django.apps import apps
+from django.db import connection
+from django.test import TestCase
+
+from teatree.core.models import Ticket
+
+_migration = importlib.import_module("teatree.core.migrations.0014_ticket_repo_namespaced_key")
+
+
+class BackfillRepoNamespacedKeyTest(TestCase):
+    def test_backfills_key_from_a_parseable_issue_url(self) -> None:
+        ticket = Ticket.objects.create(overlay="acme", issue_url="https://github.com/acme-eng/widgets/issues/42")
+        Ticket.objects.filter(pk=ticket.pk).update(repo_namespaced_key="")
+
+        _migration.backfill_repo_namespaced_key(apps, connection.schema_editor())
+
+        ticket.refresh_from_db()
+        assert ticket.repo_namespaced_key == "acme-eng/widgets#42"
+
+    def test_noop_for_a_non_issue_shaped_url(self) -> None:
+        ticket = Ticket.objects.create(overlay="acme", issue_url="dogfood-smoke://acme")
+
+        _migration.backfill_repo_namespaced_key(apps, connection.schema_editor())
+
+        ticket.refresh_from_db()
+        assert ticket.repo_namespaced_key == ""
+
+    def test_noop_for_a_blank_issue_url(self) -> None:
+        ticket = Ticket.objects.create(overlay="acme")
+
+        _migration.backfill_repo_namespaced_key(apps, connection.schema_editor())
+
+        ticket.refresh_from_db()
+        assert ticket.repo_namespaced_key == ""
+
+    def test_does_not_overwrite_an_already_set_key(self) -> None:
+        ticket = Ticket.objects.create(overlay="acme", issue_url="https://github.com/acme-eng/widgets/issues/42")
+        assert ticket.repo_namespaced_key == "acme-eng/widgets#42"
+        Ticket.objects.filter(pk=ticket.pk).update(repo_namespaced_key="hand-set")
+
+        _migration.backfill_repo_namespaced_key(apps, connection.schema_editor())
+
+        ticket.refresh_from_db()
+        assert ticket.repo_namespaced_key == "hand-set"
+
+    def test_skips_a_would_be_duplicate_key_instead_of_raising(self) -> None:
+        """The #2293 no-clobber regression.
+
+        Two rows whose ``issue_url`` differ byte-for-byte but parse to the
+        same key must never raise IntegrityError from this backfill — the
+        second row is left blank.
+
+        Both tickets are created blank and their ``issue_url`` set via a raw
+        queryset ``update()`` — going through ``Ticket.objects.create(...)``
+        with the forge URL directly would trip ``save()``'s own key
+        computation and hit the real unique constraint before the migration
+        ever runs, which is not what this test is pinning.
+        """
+        first = Ticket.objects.create(overlay="acme")
+        second = Ticket.objects.create(overlay="acme")
+        Ticket.objects.filter(pk=first.pk).update(issue_url="https://github.com/acme-eng/widgets/issues/42")
+        Ticket.objects.filter(pk=second.pk).update(issue_url="https://github.com/acme-eng/widgets/issues/42/")
+
+        _migration.backfill_repo_namespaced_key(apps, connection.schema_editor())
+
+        first.refresh_from_db()
+        second.refresh_from_db()
+        assert first.repo_namespaced_key == "acme-eng/widgets#42"
+        assert second.repo_namespaced_key == ""

--- a/tests/teatree_core/test_ticket_context_command.py
+++ b/tests/teatree_core/test_ticket_context_command.py
@@ -7,7 +7,15 @@ import pytest
 from django.core.management import call_command
 from django.test import TestCase
 
+from teatree.core.management.commands._context_commands import ContextCommands, ContextResult
+from teatree.core.management.commands.ticket import Command
 from teatree.core.models import Ticket
+
+
+class TicketContextCommandWiringTest(TestCase):
+    def test_context_commands_mixin_is_wired_into_the_ticket_command(self) -> None:
+        """The #2293 MRO-split regression: a removed base silently drops the CLI group."""
+        assert ContextCommands in Command.__mro__
 
 
 class TicketContextShowTest(TestCase):
@@ -18,7 +26,7 @@ class TicketContextShowTest(TestCase):
             context="\n\n[2026-05-18 09:00] dev_lr_id = 5842",
         )
         result = cast(
-            "dict[str, object]",
+            "ContextResult",
             call_command("ticket", "context", "show", str(ticket.pk)),
         )
         assert result == {
@@ -38,7 +46,7 @@ class TicketContextShowTest(TestCase):
             context="notes",
         )
         result = cast(
-            "dict[str, object]",
+            "ContextResult",
             call_command("ticket", "context", "show", "https://github.com/acme-eng/widgets/issues/42"),
         )
         assert result == {
@@ -54,7 +62,7 @@ class TicketContextShowTest(TestCase):
             context="notes",
         )
         result = cast(
-            "dict[str, object]",
+            "ContextResult",
             call_command("ticket", "context", "show", "acme-eng/widgets#42"),
         )
         assert result["ticket_id"] == int(ticket.pk)
@@ -77,11 +85,11 @@ class TicketContextShowTest(TestCase):
         )
 
         bugs_result = cast(
-            "dict[str, object]",
+            "ContextResult",
             call_command("ticket", "context", "show", "acme-eng/bugs#2242"),
         )
         product_result = cast(
-            "dict[str, object]",
+            "ContextResult",
             call_command("ticket", "context", "show", "acme-product/repo#2242"),
         )
 
@@ -101,7 +109,7 @@ class TicketContextAddTest(TestCase):
     def test_add_appends_timestamped_block(self) -> None:
         ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/2")
         result = cast(
-            "dict[str, object]",
+            "ContextResult",
             call_command("ticket", "context", "add", str(ticket.pk), "dev_lr_id: 5842"),
         )
         ticket.refresh_from_db()
@@ -121,7 +129,7 @@ class TicketContextAddTest(TestCase):
     def test_add_resolves_by_repo_namespaced_key(self) -> None:
         ticket = Ticket.objects.create(overlay="test", issue_url="https://github.com/acme-eng/widgets/issues/42")
         result = cast(
-            "dict[str, object]",
+            "ContextResult",
             call_command("ticket", "context", "add", "acme-eng/widgets#42", "dev_lr_id: 5842"),
         )
         ticket.refresh_from_db()
@@ -138,7 +146,7 @@ class TicketContextEditTest(TestCase):
         )
         with patch("teatree.core.management.commands._context_commands.click.edit", return_value="new full body"):
             result = cast(
-                "dict[str, object]",
+                "ContextResult",
                 call_command("ticket", "context", "edit", str(ticket.pk)),
             )
         ticket.refresh_from_db()

--- a/tests/teatree_core/test_ticket_context_command.py
+++ b/tests/teatree_core/test_ticket_context_command.py
@@ -1,4 +1,4 @@
-"""`t3 ticket context show|add|edit` — durable per-ticket knowledge store CLI (#627)."""
+"""`t3 ticket context show|add|edit` — durable per-ticket knowledge store CLI (#627, #2293)."""
 
 from typing import cast
 from unittest.mock import patch
@@ -23,12 +23,78 @@ class TicketContextShowTest(TestCase):
         )
         assert result == {
             "ticket_id": int(ticket.pk),
+            "repo_namespaced_key": "",
             "context": "\n\n[2026-05-18 09:00] dev_lr_id = 5842",
         }
 
     def test_show_unknown_ticket_exits_nonzero(self) -> None:
         with pytest.raises(SystemExit):
             call_command("ticket", "context", "show", "999999")
+
+    def test_show_resolves_by_full_ticket_url(self) -> None:
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://github.com/acme-eng/widgets/issues/42",
+            context="notes",
+        )
+        result = cast(
+            "dict[str, object]",
+            call_command("ticket", "context", "show", "https://github.com/acme-eng/widgets/issues/42"),
+        )
+        assert result == {
+            "ticket_id": int(ticket.pk),
+            "repo_namespaced_key": "acme-eng/widgets#42",
+            "context": "notes",
+        }
+
+    def test_show_resolves_by_repo_namespaced_key(self) -> None:
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://github.com/acme-eng/widgets/issues/42",
+            context="notes",
+        )
+        result = cast(
+            "dict[str, object]",
+            call_command("ticket", "context", "show", "acme-eng/widgets#42"),
+        )
+        assert result["ticket_id"] == int(ticket.pk)
+
+    def test_show_never_confuses_two_repos_sharing_an_issue_number(self) -> None:
+        """The #2293 regression.
+
+        Two repos with the same bare IID must resolve to their own
+        ticket's context, never the sibling's.
+        """
+        bugs = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://github.com/acme-eng/bugs/issues/2242",
+            context="bugs-repo notes",
+        )
+        product = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://github.com/acme-product/repo/issues/2242",
+            context="product-repo notes",
+        )
+
+        bugs_result = cast(
+            "dict[str, object]",
+            call_command("ticket", "context", "show", "acme-eng/bugs#2242"),
+        )
+        product_result = cast(
+            "dict[str, object]",
+            call_command("ticket", "context", "show", "acme-product/repo#2242"),
+        )
+
+        assert bugs_result == {
+            "ticket_id": int(bugs.pk),
+            "repo_namespaced_key": "acme-eng/bugs#2242",
+            "context": "bugs-repo notes",
+        }
+        assert product_result == {
+            "ticket_id": int(product.pk),
+            "repo_namespaced_key": "acme-product/repo#2242",
+            "context": "product-repo notes",
+        }
 
 
 class TicketContextAddTest(TestCase):
@@ -52,6 +118,16 @@ class TicketContextAddTest(TestCase):
         with pytest.raises(SystemExit):
             call_command("ticket", "context", "add", str(ticket.pk), "   ")
 
+    def test_add_resolves_by_repo_namespaced_key(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://github.com/acme-eng/widgets/issues/42")
+        result = cast(
+            "dict[str, object]",
+            call_command("ticket", "context", "add", "acme-eng/widgets#42", "dev_lr_id: 5842"),
+        )
+        ticket.refresh_from_db()
+        assert "dev_lr_id: 5842" in ticket.context
+        assert result["ticket_id"] == int(ticket.pk)
+
 
 class TicketContextEditTest(TestCase):
     def test_edit_replaces_full_field_via_editor(self) -> None:
@@ -60,7 +136,7 @@ class TicketContextEditTest(TestCase):
             issue_url="https://example.com/issues/4",
             context="old",
         )
-        with patch("teatree.core.management.commands.ticket.click.edit", return_value="new full body"):
+        with patch("teatree.core.management.commands._context_commands.click.edit", return_value="new full body"):
             result = cast(
                 "dict[str, object]",
                 call_command("ticket", "context", "edit", str(ticket.pk)),
@@ -75,7 +151,7 @@ class TicketContextEditTest(TestCase):
             issue_url="https://example.com/issues/5",
             context="keep me",
         )
-        with patch("teatree.core.management.commands.ticket.click.edit", return_value=None):
+        with patch("teatree.core.management.commands._context_commands.click.edit", return_value=None):
             call_command("ticket", "context", "edit", str(ticket.pk))
         ticket.refresh_from_db()
         assert ticket.context == "keep me"

--- a/tests/teatree_core/test_ticket_repo_namespaced_key.py
+++ b/tests/teatree_core/test_ticket_repo_namespaced_key.py
@@ -1,0 +1,74 @@
+"""``Ticket.repo_namespaced_key`` — computed on save, collision-free (#2293).
+
+The ``context`` CLI resolves tickets through this field (see
+``tests/teatree_core/test_ticket_context_command.py`` and
+``tests/teatree_core/test_ticket_resolve.py`` for the resolution-layer
+coverage); this file pins the model-level computation on ``save()``.
+"""
+
+import pytest
+from django.db import IntegrityError, transaction
+from django.test import TestCase
+
+from teatree.core.models import Ticket
+
+
+class TestTicketRepoNamespacedKeyOnSave(TestCase):
+    def test_computed_from_a_github_issue_url(self) -> None:
+        ticket = Ticket.objects.create(overlay="acme", issue_url="https://github.com/acme-eng/widgets/issues/42")
+        assert ticket.repo_namespaced_key == "acme-eng/widgets#42"
+
+    def test_computed_from_a_gitlab_issue_url(self) -> None:
+        ticket = Ticket.objects.create(overlay="acme", issue_url="https://gitlab.com/group/sub/project/-/issues/7")
+        assert ticket.repo_namespaced_key == "group/sub/project#7"
+
+    def test_blank_for_a_pr_shaped_issue_url(self) -> None:
+        """A reviewer-role ticket keyed by a PR/MR URL gets no repo key (#2293).
+
+        GitLab issues and merge requests are separate numbering sequences —
+        deriving the same key shape from both would risk a collision, so
+        this is a deliberate no-op, not an oversight.
+        """
+        ticket = Ticket.objects.create(
+            overlay="acme",
+            role=Ticket.Role.REVIEWER,
+            issue_url="https://gitlab.com/group/project/-/merge_requests/7",
+        )
+        assert ticket.repo_namespaced_key == ""
+
+    def test_blank_for_a_non_forge_issue_url(self) -> None:
+        ticket = Ticket.objects.create(overlay="acme", issue_url="https://example.com/issues/1")
+        assert ticket.repo_namespaced_key == ""
+
+    def test_blank_for_a_bare_number_issue_url(self) -> None:
+        ticket = Ticket.objects.create(overlay="acme", issue_url="694")
+        assert ticket.repo_namespaced_key == ""
+
+    def test_blank_when_issue_url_is_blank(self) -> None:
+        ticket = Ticket.objects.create(overlay="acme")
+        assert ticket.repo_namespaced_key == ""
+
+    def test_does_not_recompute_an_already_set_key(self) -> None:
+        ticket = Ticket.objects.create(
+            overlay="acme",
+            issue_url="https://github.com/acme-eng/widgets/issues/42",
+            repo_namespaced_key="manually-set",
+        )
+        ticket.save()
+        assert ticket.repo_namespaced_key == "manually-set"
+
+    def test_two_repos_sharing_an_issue_number_get_distinct_keys(self) -> None:
+        first = Ticket.objects.create(overlay="acme", issue_url="https://github.com/acme-eng/bugs/issues/2242")
+        second = Ticket.objects.create(overlay="acme", issue_url="https://github.com/acme-product/repo/issues/2242")
+        assert first.repo_namespaced_key != second.repo_namespaced_key
+
+
+class TestTicketRepoNamespacedKeyUniqueConstraint(TestCase):
+    def test_duplicate_key_is_rejected_at_the_db_level(self) -> None:
+        Ticket.objects.create(overlay="acme", issue_url="https://github.com/acme-eng/widgets/issues/42")
+        with pytest.raises(IntegrityError), transaction.atomic():
+            Ticket.objects.create(overlay="acme", repo_namespaced_key="acme-eng/widgets#42")
+
+    def test_two_blank_keys_do_not_collide(self) -> None:
+        Ticket.objects.create(overlay="acme", issue_url="")
+        Ticket.objects.create(overlay="acme", issue_url="")

--- a/tests/teatree_core/test_ticket_resolve.py
+++ b/tests/teatree_core/test_ticket_resolve.py
@@ -58,3 +58,25 @@ class TestTicketResolve(TestCase):
     def test_raises_does_not_exist_for_unknown_number(self) -> None:
         with pytest.raises(Ticket.DoesNotExist):
             Ticket.objects.resolve("87654")
+
+    def test_resolves_by_repo_namespaced_key(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://github.com/acme-eng/bugs/issues/2242")
+        resolved = Ticket.objects.resolve("acme-eng/bugs#2242")
+        assert resolved.pk == ticket.pk
+
+    def test_repo_namespaced_key_never_collides_across_repos(self) -> None:
+        """The #2293 regression.
+
+        A bare-number lookup is ambiguous; the repo-namespaced key is
+        not — passing the full repo path resolves the exact ticket even
+        when another repo shares the issue number.
+        """
+        bugs = Ticket.objects.create(overlay="test", issue_url="https://github.com/acme-eng/bugs/issues/2242")
+        Ticket.objects.create(overlay="test", issue_url="https://github.com/acme-product/repo/issues/2242")
+
+        assert Ticket.objects.resolve("acme-eng/bugs#2242").pk == bugs.pk
+        assert Ticket.objects.resolve("acme-product/repo#2242").pk != bugs.pk
+
+    def test_raises_does_not_exist_for_unknown_repo_namespaced_key(self) -> None:
+        with pytest.raises(Ticket.DoesNotExist):
+            Ticket.objects.resolve("acme-eng/bugs#99999")

--- a/tests/teatree_utils/test_url_slug_repo_namespaced_key.py
+++ b/tests/teatree_utils/test_url_slug_repo_namespaced_key.py
@@ -1,0 +1,51 @@
+"""``repo_namespaced_key`` — collision-free ``<repo-slug>#<issue-number>`` (#2293).
+
+A bare numeric issue IID collides across repos (``acme-eng/bugs#42`` vs
+``acme-product#42``); the repo-namespaced key never does, since the full
+repo path is part of it. Issue-only by design — a GitLab MR/issue in the
+same project uses a separate numbering sequence, so a PR/MR path must
+never feed this key (see the module docstring on the issue-only regexes).
+"""
+
+import pytest
+
+from teatree.utils.url_slug import repo_namespaced_key
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://github.com/acme-eng/widgets/issues/42", "acme-eng/widgets#42"),
+        ("https://github.com/acme-eng/widgets/issues/42/", "acme-eng/widgets#42"),
+        ("https://gitlab.com/group/sub/project/-/issues/7", "group/sub/project#7"),
+        ("https://gitlab.example.com/team/api/-/work_items/9", "team/api#9"),
+    ],
+)
+def test_parses_known_issue_urls(url: str, expected: str) -> None:
+    assert repo_namespaced_key(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # PR/MR paths never feed the key — a GitLab MR and an issue in the
+        # same project share no numbering sequence, so treating them the
+        # same way risks a genuine collision.
+        "https://github.com/acme-eng/widgets/pull/42",
+        "https://gitlab.com/group/project/-/merge_requests/42",
+        "https://example.com/issues/1",
+        "not-a-url",
+        "694",
+        "",
+    ],
+)
+def test_returns_empty_for_non_issue_or_unrecognised_urls(url: str) -> None:
+    assert repo_namespaced_key(url) == ""
+
+
+def test_different_repos_sharing_an_issue_number_never_collide() -> None:
+    first = repo_namespaced_key("https://github.com/acme-eng/bugs/issues/2242")
+    second = repo_namespaced_key("https://github.com/acme-product/repo/issues/2242")
+    assert first != second
+    assert first == "acme-eng/bugs#2242"
+    assert second == "acme-product/repo#2242"

--- a/tests/teatree_utils/test_url_slug_repo_namespaced_key.py
+++ b/tests/teatree_utils/test_url_slug_repo_namespaced_key.py
@@ -9,7 +9,7 @@ never feed this key (see the module docstring on the issue-only regexes).
 
 import pytest
 
-from teatree.utils.url_slug import repo_namespaced_key
+from teatree.utils.url_slug import repo_namespaced_key, repo_namespaced_key_from_path
 
 
 @pytest.mark.parametrize(
@@ -49,3 +49,12 @@ def test_different_repos_sharing_an_issue_number_never_collide() -> None:
     assert first != second
     assert first == "acme-eng/bugs#2242"
     assert second == "acme-product/repo#2242"
+
+
+def test_from_path_parses_a_bare_url_path() -> None:
+    """``repo_namespaced_key`` is a thin ``urlparse().path`` wrapper around this."""
+    assert repo_namespaced_key_from_path("/acme-eng/widgets/issues/42") == "acme-eng/widgets#42"
+
+
+def test_from_path_returns_empty_for_a_pr_shaped_path() -> None:
+    assert repo_namespaced_key_from_path("/acme-eng/widgets/pull/42") == ""


### PR DESCRIPTION
## What

Adds a collision-free `<repo-slug>#<issue-number>` key to `Ticket`, computed from `issue_url` on save, so `t3 <overlay> ticket context show|add|edit` (the durable per-ticket context store from #627) can be addressed by repo-namespaced ref instead of only pk / bare issue number / full issue URL.

## Why

Scoped per the maintainer's narrowing comment on #2293: a delta on the already-shipped per-ticket context store, not a green-field cache. A bare issue number is ambiguous across repos sharing the same numbering; the repo-namespaced key resolves the exact ticket even when two repos share an issue number.

## Changes

- `teatree.utils.url_slug`: new `repo_namespaced_key()` / `repo_namespaced_key_from_path()`, issue-only regexes (GitHub + GitLab). Deliberately issue-only: GitLab issues and merge requests are separate numbering sequences in the same project, so a PR/MR path must never feed this key or issue #5 and merge request !5 could collide.
- `Ticket.repo_namespaced_key`: new indexed field, backfilled by migration 0014 (idempotent, never overwrites an already-set key, skips a would-be duplicate rather than raising), partial unique constraint mirroring the existing `issue_url` one.
- `TicketQuerySet.resolve()`: new lookup branch between the bare-digit and issue_url fallbacks.
- `ticket context show|add|edit`: accept the repo-namespaced key as an identifier; `context show` also returns it in the result dict. Extracted to a new `_context_commands.ContextCommands` mixin (same MRO-mixin split as the existing `RubricCommands` / `TicketShowCommands`) so the already-cap-bound `ticket.py` command module does not grow past its module-health LOC ratchet.
- `Ticket._refuse_if_worktree_dirty`'s dirty-worktree collection logic moved to `ticket_worktree_checks.collect_dirty_worktree_paths` for the same reason, on the model side (#1983 precedent).
- `BLUEPRINT.md` § 4 Domain Models: documents the new field + resolution surface.

## Open questions & assumptions

- assumed: issue-only scoping (no PR/MR key) is correct per the GitLab issue/MR numbering-collision analysis above — not spelled out explicitly in the issue thread, but follows directly from it.
- assumed: migration numbered 0014, directly after #1941's `0013_alter_pendingchatinjection_answer_kind` (confirmed against `origin/main` at push time, no renumbering needed).
- decided-by-maintainer: scope narrowed to the repo-namespaced-key delta only, per the GitHub issue comment — not the original green-field "tool-owned cache" framing in the ticket title.

docs: BLUEPRINT.md § 4 updated (see Changes above).

Closes #2293
