### PR TITLE
feat(backends): add Figma backend — direct REST API for large files

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -61,7 +61,7 @@ core/        # Django app — models, FSM, managers, sync, runners, management c
 agents/      # Headless executor (in-process claude-agent-sdk)
 loop/        # /loop topology — tick, scanners, dispatch, statusline
 mcp/         # Read-only structured-search MCP server (serializers + search + FastMCP wiring); `t3 mcp serve`
-backends/    # Pluggable external service integrations; per-forge subpackages github/ gitlab/ slack/ (+ flat notion, sentry)
+backends/    # Pluggable external service integrations; per-forge subpackages github/ gitlab/ slack/ (+ flat notion, sentry, figma)
 config/      # Settings load + overlay discovery
 utils/       # Pure utilities (git, git_remote remote-URL parsing [#2404], ports, db, secrets, compose contract, ...)
 skill_support/  # Skill metadata, loading policy, deps resolution, schema/ref validation

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -2485,6 +2485,15 @@ Usage: t3 tool [OPTIONS] COMMAND [ARGS]...
 │                      AI-signature trailer.                                   │
 │ diff-coverage        Per-diff coverage + mutation/revert gate (BLUEPRINT     │
 │                      §17.6 gate 12, #836).                                   │
+│ figma-screenshot     Fetch a Figma node/frame as a PNG — bypasses the MCP    │
+│                      integration's size limits.                              │
+│ figma-frames         List a node's child frames (name + ID) for navigation.  │
+│ figma-comments       Fetch Figma comments (designer annotations, review      │
+│                      feedback) for a file or node.                           │
+│ figma-components     Fetch component descriptions, variant properties, and   │
+│                      styles (design tokens).                                 │
+│ figma-compare        Combine a Figma mockup and a Playwright screenshot side │
+│                      by side for MR evidence.                                │
 │ validate-skill-refs  Assert every skill reference resolves to a real skill   │
 │                      in the canonical set.                                   │
 │ test-path-mirror     Forward-guard: test files mirror their                  │
@@ -2786,6 +2795,97 @@ Usage: t3 tool diff-coverage [OPTIONS]
 │                              [default: .coverage]                            │
 │ --json                       Emit machine-readable JSON.                     │
 │ --help                       Show this message and exit.                     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 tool figma-screenshot`
+
+```
+Usage: t3 tool figma-screenshot [OPTIONS] FILE_KEY NODE_ID
+
+ Fetch a Figma node/frame as a PNG — bypasses the MCP integration's size
+ limits.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    file_key      TEXT  Figma file key (from the file URL). [required]      │
+│ *    node_id       TEXT  Node/frame ID to render (e.g. `12:34`). [required]  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --dest   -d      PATH                        Output PNG path.                │
+│                                              [default: figma-screenshot.png] │
+│ --scale          FLOAT RANGE [0.01<=x<=4.0]  Render scale. [default: 2.0]    │
+│ --help                                       Show this message and exit.     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 tool figma-frames`
+
+```
+Usage: t3 tool figma-frames [OPTIONS] FILE_KEY NODE_ID
+
+ List a node's child frames (name + ID) for navigation.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    file_key      TEXT  Figma file key. [required]                          │
+│ *    node_id       TEXT  Parent node ID to list children of. [required]      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 tool figma-comments`
+
+```
+Usage: t3 tool figma-comments [OPTIONS] FILE_KEY
+
+ Fetch Figma comments (designer annotations, review feedback) for a file or
+ node.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    file_key      TEXT  Figma file key. [required]                          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --node-id        TEXT  Restrict to comments anchored on this node.           │
+│ --help                 Show this message and exit.                           │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 tool figma-components`
+
+```
+Usage: t3 tool figma-components [OPTIONS] FILE_KEY
+
+ Fetch component descriptions, variant properties, and styles (design tokens).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    file_key      TEXT  Figma file key. [required]                          │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 tool figma-compare`
+
+```
+Usage: t3 tool figma-compare [OPTIONS] DESIGN_IMAGE ACTUAL_SCREENSHOT
+
+ Combine a Figma mockup and a Playwright screenshot side by side for MR
+ evidence.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    design_image           PATH  Figma mockup PNG (e.g. from                │
+│                                   `figma-screenshot`).                       │
+│                                   [required]                                 │
+│ *    actual_screenshot      PATH  Playwright screenshot PNG to compare       │
+│                                   against.                                   │
+│                                   [required]                                 │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --dest  -d      PATH  Output side-by-side PNG path.                          │
+│                       [default: figma-comparison.png]                        │
+│ --help                Show this message and exit.                            │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/backends/figma.py
+++ b/src/teatree/backends/figma.py
@@ -16,6 +16,14 @@ import httpx
 from PIL import Image
 
 
+class FigmaComponentPropertyDefinition(TypedDict, total=False):
+    """A single variant property definition on a Figma ``COMPONENT_SET`` node."""
+
+    type: str
+    defaultValue: object
+    variantOptions: list[str]
+
+
 class FigmaNode(TypedDict, total=False):
     """Subset of a Figma document node that teatree reads."""
 
@@ -23,6 +31,7 @@ class FigmaNode(TypedDict, total=False):
     name: str
     type: str
     children: list["FigmaNode"]
+    componentPropertyDefinitions: dict[str, FigmaComponentPropertyDefinition]
 
 
 class FigmaComponentEntry(TypedDict, total=False):
@@ -103,11 +112,16 @@ class FigmaComponentMetadata:
 
     ``styles`` covers Figma's color/text/effect/grid styles, the closest REST-level
     equivalent to design tokens (the ``variables`` API is Enterprise-only).
+    ``variant_properties`` maps each ``COMPONENT_SET`` node id to its
+    ``componentPropertyDefinitions`` — the root ``componentSets`` map carries only
+    key/name/description, so the variant properties themselves are read from the
+    document tree, keyed by node id.
     """
 
     components: dict[str, FigmaComponentEntry]
     component_sets: dict[str, FigmaComponentEntry]
     styles: dict[str, FigmaStyleEntry]
+    variant_properties: dict[str, dict[str, FigmaComponentPropertyDefinition]]
 
 
 class FigmaClient:
@@ -182,10 +196,12 @@ class FigmaClient:
 
     def get_component_metadata(self, file_key: str) -> FigmaComponentMetadata:
         file_data = self.get_file(file_key)
+        document = file_data.get("document")
         return FigmaComponentMetadata(
             components=file_data.get("components") or {},
             component_sets=file_data.get("componentSets") or {},
             styles=file_data.get("styles") or {},
+            variant_properties=_collect_variant_properties(document) if document else {},
         )
 
     def _client(self) -> httpx.Client:
@@ -194,6 +210,18 @@ class FigmaClient:
             headers={"X-Figma-Token": self.token},
             timeout=30.0,
         )
+
+
+def _collect_variant_properties(node: FigmaNode) -> dict[str, dict[str, FigmaComponentPropertyDefinition]]:
+    """Recursively collect ``componentPropertyDefinitions`` from every ``COMPONENT_SET`` node."""
+    found: dict[str, dict[str, FigmaComponentPropertyDefinition]] = {}
+    if node.get("type") == "COMPONENT_SET":
+        definitions = node.get("componentPropertyDefinitions")
+        if definitions:
+            found[node["id"]] = definitions
+    for child in node.get("children", []):
+        found.update(_collect_variant_properties(child))
+    return found
 
 
 def download_image(url: str, dest: Path) -> Path:

--- a/src/teatree/backends/figma.py
+++ b/src/teatree/backends/figma.py
@@ -1,0 +1,220 @@
+"""Figma backend — direct REST API client for large files.
+
+The claude.ai Figma MCP integration times out or truncates data on large
+files. This wraps the Figma REST API directly (``X-Figma-Token`` personal
+access token auth) as a lightweight, reliable alternative for design-to-code
+workflows: mockup screenshots, frame navigation, review comments, and
+component/style ("design token") metadata. Callers resolve the token via
+``teatree.utils.secrets.read_pass("figma/pat")``.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypedDict, cast
+
+import httpx
+from PIL import Image
+
+
+class FigmaNode(TypedDict, total=False):
+    """Subset of a Figma document node that teatree reads."""
+
+    id: str
+    name: str
+    type: str
+    children: list["FigmaNode"]
+
+
+class FigmaComponentEntry(TypedDict, total=False):
+    """Subset of a Figma component/component-set entry that teatree reads."""
+
+    key: str
+    name: str
+    description: str
+
+
+class FigmaStyleEntry(TypedDict, total=False):
+    """Subset of a Figma style ("design token") entry that teatree reads."""
+
+    key: str
+    name: str
+    description: str
+    styleType: str
+
+
+class FigmaCommentClientMeta(TypedDict, total=False):
+    """The anchor of a Figma comment — a node ID when pinned to a layer."""
+
+    node_id: str
+
+
+class FigmaComment(TypedDict, total=False):
+    """Subset of a Figma comment (designer annotation / review feedback) that teatree reads."""
+
+    id: str
+    message: str
+    client_meta: FigmaCommentClientMeta
+
+
+class _FigmaFileResponse(TypedDict, total=False):
+    """Subset of the ``GET /v1/files/:key`` response that teatree reads."""
+
+    document: FigmaNode
+    components: dict[str, FigmaComponentEntry]
+    componentSets: dict[str, FigmaComponentEntry]
+    styles: dict[str, FigmaStyleEntry]
+
+
+class _FigmaNodeEntry(TypedDict, total=False):
+    document: FigmaNode
+
+
+class _FigmaNodesResponse(TypedDict, total=False):
+    """Subset of the ``GET /v1/files/:key/nodes`` response that teatree reads."""
+
+    nodes: dict[str, _FigmaNodeEntry]
+
+
+class _FigmaImagesResponse(TypedDict, total=False):
+    """Subset of the ``GET /v1/images/:key`` response that teatree reads."""
+
+    err: str | None
+    images: dict[str, str]
+
+
+class _FigmaCommentsResponse(TypedDict, total=False):
+    """Subset of the ``GET /v1/files/:key/comments`` response that teatree reads."""
+
+    comments: list[FigmaComment]
+
+
+@dataclass(frozen=True)
+class FigmaFrameRef:
+    """A child node of a listed frame — enough to navigate or re-fetch it."""
+
+    node_id: str
+    name: str
+    node_type: str
+
+
+@dataclass(frozen=True)
+class FigmaComponentMetadata:
+    """Component/style metadata embedded in a file's ``GET /v1/files/:key`` response.
+
+    ``styles`` covers Figma's color/text/effect/grid styles, the closest REST-level
+    equivalent to design tokens (the ``variables`` API is Enterprise-only).
+    """
+
+    components: dict[str, FigmaComponentEntry]
+    component_sets: dict[str, FigmaComponentEntry]
+    styles: dict[str, FigmaStyleEntry]
+
+
+class FigmaClient:
+    """Figma REST API client — one HTTP call per method, no local state."""
+
+    def __init__(self, *, token: str, base_url: str = "https://api.figma.com") -> None:
+        self.token = token
+        self.base_url = base_url.rstrip("/")
+
+    def get_file(self, file_key: str) -> _FigmaFileResponse:
+        with self._client() as client:
+            response = client.get(f"/v1/files/{file_key}")
+            response.raise_for_status()
+            return cast("_FigmaFileResponse", response.json())
+
+    def get_node(self, file_key: str, node_id: str) -> FigmaNode:
+        with self._client() as client:
+            response = client.get(f"/v1/files/{file_key}/nodes", params={"ids": node_id})
+            response.raise_for_status()
+            body = cast("_FigmaNodesResponse", response.json())
+        entry = body.get("nodes", {}).get(node_id)
+        if not entry:
+            msg = f"Figma node {node_id} not found in file {file_key}"
+            raise ValueError(msg)
+        return entry["document"]
+
+    def list_frame_children(self, file_key: str, node_id: str) -> list[FigmaFrameRef]:
+        document = self.get_node(file_key, node_id)
+        return [
+            FigmaFrameRef(node_id=child["id"], name=child["name"], node_type=child["type"])
+            for child in document.get("children", [])
+        ]
+
+    def get_image_urls(
+        self, file_key: str, node_ids: list[str], *, scale: float = 1.0, image_format: str = "png"
+    ) -> dict[str, str]:
+        with self._client() as client:
+            response = client.get(
+                f"/v1/images/{file_key}",
+                params={"ids": ",".join(node_ids), "scale": scale, "format": image_format},
+            )
+            response.raise_for_status()
+            body = cast("_FigmaImagesResponse", response.json())
+        if body.get("err"):
+            msg = f"Figma image render failed: {body['err']}"
+            raise RuntimeError(msg)
+        return body.get("images") or {}
+
+    def get_screenshot(
+        self, file_key: str, node_id: str, dest: Path, *, scale: float = 2.0, image_format: str = "png"
+    ) -> Path:
+        urls = self.get_image_urls(file_key, [node_id], scale=scale, image_format=image_format)
+        url = urls.get(node_id)
+        if not url:
+            msg = f"Figma returned no rendered image URL for node {node_id}"
+            raise RuntimeError(msg)
+        return download_image(url, dest)
+
+    def get_comments(self, file_key: str) -> list[FigmaComment]:
+        with self._client() as client:
+            response = client.get(f"/v1/files/{file_key}/comments")
+            response.raise_for_status()
+            body = cast("_FigmaCommentsResponse", response.json())
+        return body.get("comments") or []
+
+    def get_node_comments(self, file_key: str, node_id: str) -> list[FigmaComment]:
+        return [
+            comment
+            for comment in self.get_comments(file_key)
+            if comment.get("client_meta", {}).get("node_id") == node_id
+        ]
+
+    def get_component_metadata(self, file_key: str) -> FigmaComponentMetadata:
+        file_data = self.get_file(file_key)
+        return FigmaComponentMetadata(
+            components=file_data.get("components") or {},
+            component_sets=file_data.get("componentSets") or {},
+            styles=file_data.get("styles") or {},
+        )
+
+    def _client(self) -> httpx.Client:
+        return httpx.Client(
+            base_url=self.base_url,
+            headers={"X-Figma-Token": self.token},
+            timeout=30.0,
+        )
+
+
+def download_image(url: str, dest: Path) -> Path:
+    """Download a rendered image URL (from :meth:`FigmaClient.get_image_urls`) to *dest*."""
+    with httpx.Client(timeout=30.0, follow_redirects=True) as client:
+        response = client.get(url)
+        response.raise_for_status()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(response.content)
+    return dest
+
+
+def build_side_by_side_comparison(design_image: Path, actual_screenshot: Path, dest: Path) -> Path:
+    """Combine a Figma mockup and a Playwright screenshot side by side for MR evidence."""
+    with Image.open(design_image) as design, Image.open(actual_screenshot) as actual:
+        design_rgb = design.convert("RGB")
+        actual_rgb = actual.convert("RGB")
+        height = max(design_rgb.height, actual_rgb.height)
+        combined = Image.new("RGB", (design_rgb.width + actual_rgb.width, height), color="white")
+        combined.paste(design_rgb, (0, 0))
+        combined.paste(actual_rgb, (design_rgb.width, 0))
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    combined.save(dest)
+    return dest

--- a/src/teatree/cli/__init__.py
+++ b/src/teatree/cli/__init__.py
@@ -34,6 +34,9 @@ from teatree.cli import (
     enforcement_tools as _enforcement_tools,  # noqa: F401  (side-effect: registers §17.6 gate commands onto tool_app)
 )
 from teatree.cli import (
+    figma_tools as _figma_tools,  # noqa: F401  (side-effect: registers figma-* commands onto tool_app)
+)
+from teatree.cli import (
     skill_ref_tools as _skill_ref_tools,  # noqa: F401  (side-effect: registers validate-skill-refs onto tool_app)
 )
 from teatree.cli import (

--- a/src/teatree/cli/figma_tools.py
+++ b/src/teatree/cli/figma_tools.py
@@ -1,0 +1,91 @@
+"""Figma tool commands — direct REST API wrapper for large Figma files.
+
+Split out of ``cli/tools.py`` per the module-health function cap (see
+``triage_tools.py``): every command here is a thin front-end over
+``teatree.backends.figma.FigmaClient``. Commands register onto the shared
+``tool_app`` so ``t3 tool figma-*`` is a single coherent namespace.
+
+Importing this module has the side effect of registering the commands;
+``cli/__init__`` imports it after ``tool_app`` is constructed.
+"""
+
+import dataclasses
+import json
+from pathlib import Path
+
+import typer
+
+from teatree.backends.figma import FigmaClient, build_side_by_side_comparison
+from teatree.cli.tools import tool_app
+from teatree.utils.secrets import read_pass
+
+_TOKEN_PASS_KEY = "figma/pat"  # noqa: S105 — pass key name, not a secret
+
+
+def _client() -> FigmaClient:
+    token = read_pass(_TOKEN_PASS_KEY)
+    if not token:
+        typer.echo(
+            f"No Figma personal access token at `pass show {_TOKEN_PASS_KEY}`. "
+            f"Store one with `pass insert {_TOKEN_PASS_KEY}`.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    return FigmaClient(token=token)
+
+
+@tool_app.command("figma-screenshot")
+def figma_screenshot(
+    file_key: str = typer.Argument(..., help="Figma file key (from the file URL)."),
+    node_id: str = typer.Argument(..., help="Node/frame ID to render (e.g. `12:34`)."),
+    dest: Path = typer.Option(Path("figma-screenshot.png"), "--dest", "-d", help="Output PNG path."),
+    scale: float = typer.Option(2.0, "--scale", min=0.01, max=4.0, help="Render scale."),
+) -> None:
+    """Fetch a Figma node/frame as a PNG — bypasses the MCP integration's size limits."""
+    result = _client().get_screenshot(file_key, node_id, dest, scale=scale)
+    typer.echo(f"Saved: {result} ({result.stat().st_size:,} bytes)")
+
+
+@tool_app.command("figma-frames")
+def figma_frames(
+    file_key: str = typer.Argument(..., help="Figma file key."),
+    node_id: str = typer.Argument(..., help="Parent node ID to list children of."),
+) -> None:
+    """List a node's child frames (name + ID) for navigation."""
+    frames = _client().list_frame_children(file_key, node_id)
+    if not frames:
+        typer.echo("No child frames found.")
+        return
+    for frame in frames:
+        typer.echo(f"{frame.node_id}  {frame.node_type:<12}  {frame.name}")
+
+
+@tool_app.command("figma-comments")
+def figma_comments(
+    file_key: str = typer.Argument(..., help="Figma file key."),
+    node_id: str = typer.Option("", "--node-id", help="Restrict to comments anchored on this node."),
+) -> None:
+    """Fetch Figma comments (designer annotations, review feedback) for a file or node."""
+    client = _client()
+    comments = client.get_node_comments(file_key, node_id) if node_id else client.get_comments(file_key)
+    typer.echo(json.dumps(comments, indent=2))
+
+
+@tool_app.command("figma-components")
+def figma_components(
+    file_key: str = typer.Argument(..., help="Figma file key."),
+) -> None:
+    """Fetch component descriptions, variant properties, and styles (design tokens)."""
+    metadata = _client().get_component_metadata(file_key)
+    typer.echo(json.dumps(dataclasses.asdict(metadata), indent=2))
+
+
+@tool_app.command("figma-compare")
+def figma_compare(
+    design_image: Path = typer.Argument(..., help="Figma mockup PNG (e.g. from `figma-screenshot`)."),
+    actual_screenshot: Path = typer.Argument(..., help="Playwright screenshot PNG to compare against."),
+    dest: Path = typer.Option(Path("figma-comparison.png"), "--dest", "-d", help="Output side-by-side PNG path."),
+) -> None:
+    """Combine a Figma mockup and a Playwright screenshot side by side for MR evidence."""
+    result = build_side_by_side_comparison(design_image, actual_screenshot, dest)
+    typer.echo(f"Saved: {result} ({result.stat().st_size:,} bytes)")

--- a/src/teatree/cli/figma_tools.py
+++ b/src/teatree/cli/figma_tools.py
@@ -3,7 +3,8 @@
 Split out of ``cli/tools.py`` per the module-health function cap (see
 ``triage_tools.py``): every command here is a thin front-end over
 ``teatree.backends.figma.FigmaClient``. Commands register onto the shared
-``tool_app`` so ``t3 tool figma-*`` is a single coherent namespace.
+``tool_app`` so ``t3 tool figma-screenshot`` and its siblings form a single
+coherent namespace.
 
 Importing this module has the side effect of registering the commands;
 ``cli/__init__`` imports it after ``tool_app`` is constructed.

--- a/tests/teatree_backends/test_figma.py
+++ b/tests/teatree_backends/test_figma.py
@@ -8,8 +8,13 @@ from PIL import Image
 
 from teatree.backends.figma import (
     FigmaClient,
+    FigmaComment,
+    FigmaCommentClientMeta,
+    FigmaComponentEntry,
     FigmaComponentMetadata,
     FigmaFrameRef,
+    FigmaNode,
+    FigmaStyleEntry,
     build_side_by_side_comparison,
     download_image,
 )
@@ -67,7 +72,7 @@ class TestGetNode:
 class TestListFrameChildren:
     def test_returns_frame_refs_for_children(self) -> None:
         client = FigmaClient(token="fake")
-        document = {
+        document: FigmaNode = {
             "id": "1:1",
             "children": [
                 {"id": "1:2", "name": "Header", "type": "FRAME"},
@@ -155,9 +160,11 @@ class TestGetComments:
 class TestGetNodeComments:
     def test_filters_by_client_meta_node_id(self) -> None:
         client = FigmaClient(token="fake")
-        comments = [
-            {"id": "c1", "client_meta": {"node_id": "1:2"}, "message": "on frame"},
-            {"id": "c2", "client_meta": {"node_id": "1:3"}, "message": "elsewhere"},
+        on_frame: FigmaCommentClientMeta = {"node_id": "1:2"}
+        elsewhere: FigmaCommentClientMeta = {"node_id": "1:3"}
+        comments: list[FigmaComment] = [
+            {"id": "c1", "client_meta": on_frame, "message": "on frame"},
+            {"id": "c2", "client_meta": elsewhere, "message": "elsewhere"},
             {"id": "c3", "message": "no client_meta at all"},
         ]
 
@@ -170,19 +177,22 @@ class TestGetNodeComments:
 class TestGetComponentMetadata:
     def test_extracts_components_sets_and_styles(self) -> None:
         client = FigmaClient(token="fake")
+        button: FigmaComponentEntry = {"name": "Button"}
+        button_variants: FigmaComponentEntry = {"name": "Button variants"}
+        primary_blue: FigmaStyleEntry = {"name": "Primary/Blue"}
         file_data = {
-            "components": {"1:2": {"name": "Button"}},
-            "componentSets": {"1:1": {"name": "Button variants"}},
-            "styles": {"S:1": {"name": "Primary/Blue"}},
+            "components": {"1:2": button},
+            "componentSets": {"1:1": button_variants},
+            "styles": {"S:1": primary_blue},
         }
 
         with patch.object(client, "get_file", return_value=file_data):
             metadata = client.get_component_metadata("abc123")
 
         assert metadata == FigmaComponentMetadata(
-            components={"1:2": {"name": "Button"}},
-            component_sets={"1:1": {"name": "Button variants"}},
-            styles={"S:1": {"name": "Primary/Blue"}},
+            components={"1:2": button},
+            component_sets={"1:1": button_variants},
+            styles={"S:1": primary_blue},
         )
 
     def test_defaults_to_empty_when_keys_missing(self) -> None:

--- a/tests/teatree_backends/test_figma.py
+++ b/tests/teatree_backends/test_figma.py
@@ -12,6 +12,7 @@ from teatree.backends.figma import (
     FigmaCommentClientMeta,
     FigmaComponentEntry,
     FigmaComponentMetadata,
+    FigmaComponentPropertyDefinition,
     FigmaFrameRef,
     FigmaNode,
     FigmaStyleEntry,
@@ -193,14 +194,51 @@ class TestGetComponentMetadata:
             components={"1:2": button},
             component_sets={"1:1": button_variants},
             styles={"S:1": primary_blue},
+            variant_properties={},
         )
+
+    def test_extracts_variant_properties_from_nested_component_set_nodes(self) -> None:
+        client = FigmaClient(token="fake")
+        size_prop: FigmaComponentPropertyDefinition = {"type": "VARIANT", "variantOptions": ["Small", "Large"]}
+        document: FigmaNode = {
+            "id": "0:0",
+            "type": "DOCUMENT",
+            "children": [
+                {
+                    "id": "0:1",
+                    "type": "CANVAS",
+                    "children": [
+                        {
+                            "id": "1:1",
+                            "name": "Button",
+                            "type": "COMPONENT_SET",
+                            "componentPropertyDefinitions": {"Size": size_prop},
+                        },
+                        {"id": "1:2", "name": "Empty", "type": "COMPONENT_SET"},
+                    ],
+                },
+            ],
+        }
+        file_data = {"document": document, "components": {}, "componentSets": {}, "styles": {}}
+
+        with patch.object(client, "get_file", return_value=file_data):
+            metadata = client.get_component_metadata("abc123")
+
+        assert metadata.variant_properties == {"1:1": {"Size": size_prop}}
+
+    def test_variant_properties_empty_when_document_absent(self) -> None:
+        client = FigmaClient(token="fake")
+        with patch.object(client, "get_file", return_value={"name": "My File"}):
+            metadata = client.get_component_metadata("abc123")
+
+        assert metadata.variant_properties == {}
 
     def test_defaults_to_empty_when_keys_missing(self) -> None:
         client = FigmaClient(token="fake")
         with patch.object(client, "get_file", return_value={"name": "My File"}):
             metadata = client.get_component_metadata("abc123")
 
-        assert metadata == FigmaComponentMetadata(components={}, component_sets={}, styles={})
+        assert metadata == FigmaComponentMetadata(components={}, component_sets={}, styles={}, variant_properties={})
 
 
 class TestClientFactory:

--- a/tests/teatree_backends/test_figma.py
+++ b/tests/teatree_backends/test_figma.py
@@ -1,0 +1,246 @@
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from PIL import Image
+
+from teatree.backends.figma import (
+    FigmaClient,
+    FigmaComponentMetadata,
+    FigmaFrameRef,
+    build_side_by_side_comparison,
+    download_image,
+)
+
+
+def _mock_response(json_data: object, status_code: int = 200) -> httpx.Response:
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.json.return_value = json_data
+    response.raise_for_status = MagicMock()
+    return response
+
+
+def _mock_http(get_return: httpx.Response) -> MagicMock:
+    mock_http = MagicMock()
+    mock_http.__enter__ = MagicMock(return_value=mock_http)
+    mock_http.__exit__ = MagicMock(return_value=False)
+    mock_http.get.return_value = get_return
+    return mock_http
+
+
+class TestGetFile:
+    def test_returns_file_json(self) -> None:
+        client = FigmaClient(token="fake")
+        mock_http = _mock_http(_mock_response({"name": "My File", "document": {}}))
+
+        with patch.object(client, "_client", return_value=mock_http):
+            body = client.get_file("abc123")
+
+        assert body == {"name": "My File", "document": {}}
+        mock_http.get.assert_called_once_with("/v1/files/abc123")
+
+
+class TestGetNode:
+    def test_returns_document_subtree(self) -> None:
+        client = FigmaClient(token="fake")
+        mock_http = _mock_http(
+            _mock_response({"nodes": {"1:2": {"document": {"id": "1:2", "name": "Frame", "type": "FRAME"}}}})
+        )
+
+        with patch.object(client, "_client", return_value=mock_http):
+            document = client.get_node("abc123", "1:2")
+
+        assert document == {"id": "1:2", "name": "Frame", "type": "FRAME"}
+        mock_http.get.assert_called_once_with("/v1/files/abc123/nodes", params={"ids": "1:2"})
+
+    def test_raises_when_node_absent(self) -> None:
+        client = FigmaClient(token="fake")
+        mock_http = _mock_http(_mock_response({"nodes": {}}))
+
+        with patch.object(client, "_client", return_value=mock_http), pytest.raises(ValueError, match="not found"):
+            client.get_node("abc123", "9:9")
+
+
+class TestListFrameChildren:
+    def test_returns_frame_refs_for_children(self) -> None:
+        client = FigmaClient(token="fake")
+        document = {
+            "id": "1:1",
+            "children": [
+                {"id": "1:2", "name": "Header", "type": "FRAME"},
+                {"id": "1:3", "name": "Body", "type": "GROUP"},
+            ],
+        }
+        with patch.object(client, "get_node", return_value=document):
+            frames = client.list_frame_children("abc123", "1:1")
+
+        assert frames == [
+            FigmaFrameRef(node_id="1:2", name="Header", node_type="FRAME"),
+            FigmaFrameRef(node_id="1:3", name="Body", node_type="GROUP"),
+        ]
+
+    def test_returns_empty_list_when_no_children(self) -> None:
+        client = FigmaClient(token="fake")
+        with patch.object(client, "get_node", return_value={"id": "1:1"}):
+            assert client.list_frame_children("abc123", "1:1") == []
+
+
+class TestGetImageUrls:
+    def test_returns_image_url_map(self) -> None:
+        client = FigmaClient(token="fake")
+        mock_http = _mock_http(_mock_response({"images": {"1:2": "https://cdn.figma.com/x.png"}, "err": None}))
+
+        with patch.object(client, "_client", return_value=mock_http):
+            urls = client.get_image_urls("abc123", ["1:2"], scale=2.0, image_format="png")
+
+        assert urls == {"1:2": "https://cdn.figma.com/x.png"}
+        mock_http.get.assert_called_once_with("/v1/images/abc123", params={"ids": "1:2", "scale": 2.0, "format": "png"})
+
+    def test_raises_on_render_error(self) -> None:
+        client = FigmaClient(token="fake")
+        mock_http = _mock_http(_mock_response({"err": "boom", "images": None}))
+
+        with (
+            patch.object(client, "_client", return_value=mock_http),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            client.get_image_urls("abc123", ["1:2"])
+
+
+class TestGetScreenshot:
+    def test_downloads_rendered_image(self, tmp_path: Path) -> None:
+        client = FigmaClient(token="fake")
+        dest = tmp_path / "out.png"
+        captured: dict[str, Any] = {}
+
+        def fake_download(url: str, dest_path: Path) -> Path:
+            captured["url"] = url
+            captured["dest"] = dest_path
+            return dest_path
+
+        with (
+            patch.object(client, "get_image_urls", return_value={"1:2": "https://cdn.figma.com/x.png"}),
+            patch("teatree.backends.figma.download_image", side_effect=fake_download),
+        ):
+            result = client.get_screenshot("abc123", "1:2", dest, scale=3.0)
+
+        assert result == dest
+        assert captured["url"] == "https://cdn.figma.com/x.png"
+        assert captured["dest"] == dest
+
+    def test_raises_when_node_has_no_rendered_url(self, tmp_path: Path) -> None:
+        client = FigmaClient(token="fake")
+        with (
+            patch.object(client, "get_image_urls", return_value={}),
+            pytest.raises(RuntimeError, match="no rendered image URL"),
+        ):
+            client.get_screenshot("abc123", "1:2", tmp_path / "out.png")
+
+
+class TestGetComments:
+    def test_returns_comment_list(self) -> None:
+        client = FigmaClient(token="fake")
+        mock_http = _mock_http(_mock_response({"comments": [{"id": "c1", "message": "hi"}]}))
+
+        with patch.object(client, "_client", return_value=mock_http):
+            comments = client.get_comments("abc123")
+
+        assert comments == [{"id": "c1", "message": "hi"}]
+        mock_http.get.assert_called_once_with("/v1/files/abc123/comments")
+
+
+class TestGetNodeComments:
+    def test_filters_by_client_meta_node_id(self) -> None:
+        client = FigmaClient(token="fake")
+        comments = [
+            {"id": "c1", "client_meta": {"node_id": "1:2"}, "message": "on frame"},
+            {"id": "c2", "client_meta": {"node_id": "1:3"}, "message": "elsewhere"},
+            {"id": "c3", "message": "no client_meta at all"},
+        ]
+
+        with patch.object(client, "get_comments", return_value=comments):
+            filtered = client.get_node_comments("abc123", "1:2")
+
+        assert filtered == [comments[0]]
+
+
+class TestGetComponentMetadata:
+    def test_extracts_components_sets_and_styles(self) -> None:
+        client = FigmaClient(token="fake")
+        file_data = {
+            "components": {"1:2": {"name": "Button"}},
+            "componentSets": {"1:1": {"name": "Button variants"}},
+            "styles": {"S:1": {"name": "Primary/Blue"}},
+        }
+
+        with patch.object(client, "get_file", return_value=file_data):
+            metadata = client.get_component_metadata("abc123")
+
+        assert metadata == FigmaComponentMetadata(
+            components={"1:2": {"name": "Button"}},
+            component_sets={"1:1": {"name": "Button variants"}},
+            styles={"S:1": {"name": "Primary/Blue"}},
+        )
+
+    def test_defaults_to_empty_when_keys_missing(self) -> None:
+        client = FigmaClient(token="fake")
+        with patch.object(client, "get_file", return_value={"name": "My File"}):
+            metadata = client.get_component_metadata("abc123")
+
+        assert metadata == FigmaComponentMetadata(components={}, component_sets={}, styles={})
+
+
+class TestClientFactory:
+    def test_client_method_creates_httpx_client_with_token_header(self) -> None:
+        client = FigmaClient(token="my-token", base_url="https://api.figma.example.com/")
+
+        with client._client() as http_client:
+            assert isinstance(http_client, httpx.Client)
+            assert http_client.headers["x-figma-token"] == "my-token"
+        assert client.base_url == "https://api.figma.example.com"
+
+
+class TestDownloadImage:
+    def _patch_transport(self, monkeypatch: pytest.MonkeyPatch, handler: Any) -> None:
+        original_init = httpx.Client.__init__
+
+        def patched_init(self: httpx.Client, **kwargs: Any) -> None:
+            kwargs["transport"] = httpx.MockTransport(handler)
+            original_init(self, **kwargs)
+
+        monkeypatch.setattr(httpx.Client, "__init__", patched_init)
+
+    def test_writes_response_bytes_to_dest(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch_transport(monkeypatch, lambda _request: httpx.Response(200, content=b"PNG-BYTES"))
+
+        dest = tmp_path / "sub" / "shot.png"
+        result = download_image("https://cdn.figma.com/x.png", dest)
+
+        assert result == dest
+        assert dest.read_bytes() == b"PNG-BYTES"
+
+    def test_raises_on_http_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch_transport(monkeypatch, lambda _request: httpx.Response(404, content=b"not found"))
+
+        with pytest.raises(httpx.HTTPStatusError):
+            download_image("https://cdn.figma.com/missing.png", tmp_path / "x.png")
+
+
+class TestBuildSideBySideComparison:
+    def test_combines_two_images_horizontally(self, tmp_path: Path) -> None:
+        design = tmp_path / "design.png"
+        actual = tmp_path / "actual.png"
+        Image.new("RGB", (100, 50), color="red").save(design)
+        Image.new("RGB", (60, 80), color="blue").save(actual)
+
+        dest = tmp_path / "out" / "comparison.png"
+        result = build_side_by_side_comparison(design, actual, dest)
+
+        assert result == dest
+        with Image.open(dest) as combined:
+            assert combined.size == (160, 80)
+            assert combined.getpixel((10, 10)) == (255, 0, 0)
+            assert combined.getpixel((110, 10)) == (0, 0, 255)

--- a/tests/teatree_cli/test_cli_figma_tools.py
+++ b/tests/teatree_cli/test_cli_figma_tools.py
@@ -1,0 +1,136 @@
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from teatree.backends.figma import FigmaComponentMetadata, FigmaFrameRef
+from teatree.cli import app
+
+runner = CliRunner()
+
+
+class TestFigmaClientFactory:
+    def test_exits_with_hint_when_no_token_stored(self) -> None:
+        with patch("teatree.cli.figma_tools.read_pass", return_value=""):
+            result = runner.invoke(app, ["tool", "figma-frames", "abc123", "1:1"])
+
+        assert result.exit_code == 1
+        assert "pass show figma/pat" in result.output
+        assert "pass insert figma/pat" in result.output
+
+
+class TestFigmaScreenshotCLI:
+    def test_saves_screenshot_and_reports_size(self, tmp_path: Path) -> None:
+        dest = tmp_path / "shot.png"
+        dest.write_bytes(b"PNG-BYTES")
+
+        with (
+            patch("teatree.cli.figma_tools.read_pass", return_value="tok"),
+            patch("teatree.cli.figma_tools.FigmaClient") as client_cls,
+        ):
+            client_cls.return_value.get_screenshot.return_value = dest
+            result = runner.invoke(
+                app, ["tool", "figma-screenshot", "abc123", "1:2", "--dest", str(dest), "--scale", "3.0"]
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "Saved:" in result.output
+        client_cls.return_value.get_screenshot.assert_called_once_with("abc123", "1:2", dest, scale=3.0)
+
+
+class TestFigmaFramesCLI:
+    def test_lists_child_frames(self) -> None:
+        frames = [
+            FigmaFrameRef(node_id="1:2", name="Header", node_type="FRAME"),
+            FigmaFrameRef(node_id="1:3", name="Body", node_type="GROUP"),
+        ]
+        with (
+            patch("teatree.cli.figma_tools.read_pass", return_value="tok"),
+            patch("teatree.cli.figma_tools.FigmaClient") as client_cls,
+        ):
+            client_cls.return_value.list_frame_children.return_value = frames
+            result = runner.invoke(app, ["tool", "figma-frames", "abc123", "1:1"])
+
+        assert result.exit_code == 0, result.output
+        assert "1:2" in result.output
+        assert "Header" in result.output
+        assert "1:3" in result.output
+        assert "Body" in result.output
+
+    def test_reports_when_no_children(self) -> None:
+        with (
+            patch("teatree.cli.figma_tools.read_pass", return_value="tok"),
+            patch("teatree.cli.figma_tools.FigmaClient") as client_cls,
+        ):
+            client_cls.return_value.list_frame_children.return_value = []
+            result = runner.invoke(app, ["tool", "figma-frames", "abc123", "1:1"])
+
+        assert result.exit_code == 0, result.output
+        assert "No child frames found." in result.output
+
+
+class TestFigmaCommentsCLI:
+    def test_fetches_all_comments_by_default(self) -> None:
+        with (
+            patch("teatree.cli.figma_tools.read_pass", return_value="tok"),
+            patch("teatree.cli.figma_tools.FigmaClient") as client_cls,
+        ):
+            client_cls.return_value.get_comments.return_value = [{"id": "c1", "message": "hi"}]
+            result = runner.invoke(app, ["tool", "figma-comments", "abc123"])
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == [{"id": "c1", "message": "hi"}]
+        client_cls.return_value.get_comments.assert_called_once_with("abc123")
+        client_cls.return_value.get_node_comments.assert_not_called()
+
+    def test_filters_by_node_id_when_given(self) -> None:
+        with (
+            patch("teatree.cli.figma_tools.read_pass", return_value="tok"),
+            patch("teatree.cli.figma_tools.FigmaClient") as client_cls,
+        ):
+            client_cls.return_value.get_node_comments.return_value = [{"id": "c1"}]
+            result = runner.invoke(app, ["tool", "figma-comments", "abc123", "--node-id", "1:2"])
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == [{"id": "c1"}]
+        client_cls.return_value.get_node_comments.assert_called_once_with("abc123", "1:2")
+        client_cls.return_value.get_comments.assert_not_called()
+
+
+class TestFigmaComponentsCLI:
+    def test_prints_component_metadata_as_json(self) -> None:
+        metadata = FigmaComponentMetadata(
+            components={"1:2": {"name": "Button"}}, component_sets={}, styles={"S:1": {"name": "Primary"}}
+        )
+        with (
+            patch("teatree.cli.figma_tools.read_pass", return_value="tok"),
+            patch("teatree.cli.figma_tools.FigmaClient") as client_cls,
+        ):
+            client_cls.return_value.get_component_metadata.return_value = metadata
+            result = runner.invoke(app, ["tool", "figma-components", "abc123"])
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == {
+            "components": {"1:2": {"name": "Button"}},
+            "component_sets": {},
+            "styles": {"S:1": {"name": "Primary"}},
+        }
+
+
+class TestFigmaCompareCLI:
+    def test_builds_side_by_side_comparison(self, tmp_path: Path) -> None:
+        design = tmp_path / "design.png"
+        actual = tmp_path / "actual.png"
+        dest = tmp_path / "out.png"
+        design.write_bytes(b"design")
+        actual.write_bytes(b"actual")
+
+        fake_compare = MagicMock(return_value=dest)
+        dest.write_bytes(b"combined")
+        with patch("teatree.cli.figma_tools.build_side_by_side_comparison", fake_compare):
+            result = runner.invoke(app, ["tool", "figma-compare", str(design), str(actual), "--dest", str(dest)])
+
+        assert result.exit_code == 0, result.output
+        assert "Saved:" in result.output
+        fake_compare.assert_called_once_with(design, actual, dest)

--- a/tests/teatree_cli/test_cli_figma_tools.py
+++ b/tests/teatree_cli/test_cli_figma_tools.py
@@ -101,7 +101,10 @@ class TestFigmaCommentsCLI:
 class TestFigmaComponentsCLI:
     def test_prints_component_metadata_as_json(self) -> None:
         metadata = FigmaComponentMetadata(
-            components={"1:2": {"name": "Button"}}, component_sets={}, styles={"S:1": {"name": "Primary"}}
+            components={"1:2": {"name": "Button"}},
+            component_sets={},
+            styles={"S:1": {"name": "Primary"}},
+            variant_properties={"1:1": {"Size": {"type": "VARIANT", "variantOptions": ["Small", "Large"]}}},
         )
         with (
             patch("teatree.cli.figma_tools.read_pass", return_value="tok"),
@@ -115,6 +118,7 @@ class TestFigmaComponentsCLI:
             "components": {"1:2": {"name": "Button"}},
             "component_sets": {},
             "styles": {"S:1": {"name": "Primary"}},
+            "variant_properties": {"1:1": {"Size": {"type": "VARIANT", "variantOptions": ["Small", "Large"]}}},
         }
 
 


### PR DESCRIPTION
feat(backends): add Figma backend — direct REST API for large files

Wraps the Figma REST API directly (X-Figma-Token PAT auth, read from
`pass show figma/pat`) as a lightweight alternative to the Figma MCP
integration, which times out / truncates data on large files.

FigmaClient covers the scope from souliane/teatree#72 (folded into
#2556, re-homed standalone as #2893): mockup screenshots at a
configurable scale, frame/child-node listing for navigation, file/node
comments (designer annotations, review feedback), and component +
style ("design token") metadata. A module-level helper combines a
Figma mockup and a Playwright screenshot side by side for MR evidence.

Exposed via t3 tool figma-screenshot / figma-frames / figma-comments /
figma-components / figma-compare, following the existing notion-download
CLI-tool convention.

Open questions & assumptions:
- assumed: 'design tokens' maps to Figma's file-embedded styles object
  (color/text/effect/grid styles) since the dedicated variables API is
  Enterprise-only and REST-inaccessible for most accounts.
- assumed: component/style metadata is read from the file-embedded
  components/componentSets/styles maps (GET /v1/files/:key), not the
  separate published-library endpoints, so it works on any file
  regardless of whether it is published as a library.
- decided-by-user: no migration expected for this ticket (per the
  dispatch scope pointer) — confirmed, no model/schema changes needed.

Closes #2893