### PR TITLE
fix(eval): short-circuit in-container credential routing; PR-gate the dashboard push

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -430,16 +430,19 @@ jobs:
           if-no-files-found: warn
 
   # PUBLISH: merge every shard's sanitized summary into ONE public dashboard and
-  # commit it to main. `needs: [prepare, eval]` + `if: always() && run_eval == 'true'`
-  # so it still runs when a shard went red (a red dashboard is worth publishing) but is
-  # SKIPPED when prepare gated the eval out — otherwise it would download zero summaries
-  # and commit a zero-row dashboard over the real one. It downloads only
-  # the `eval-summary-*` artifacts (NEVER the private transcripts), merges them via
-  # scripts/eval/merge_summaries.py into docs/evals/index.md, writes the same
-  # content to $GITHUB_STEP_SUMMARY, and — when the file changed — commits + pushes
-  # to main as github-actions[bot]. The push triggers docs.yml, which builds the
-  # site and serves the dashboard on GitHub Pages. The unchanged-file guard makes a
-  # no-diff run a clean no-op (no empty commit).
+  # open a PR carrying it against main. `needs: [prepare, eval]` + `if: always() &&
+  # run_eval == 'true'` so it still runs when a shard went red (a red dashboard is
+  # worth publishing) but is SKIPPED when prepare gated the eval out — otherwise it
+  # would download zero summaries and commit a zero-row dashboard over the real one.
+  # It downloads only the `eval-summary-*` artifacts (NEVER the private transcripts),
+  # merges them via scripts/eval/merge_summaries.py into docs/evals/index.md, writes
+  # the same content to $GITHUB_STEP_SUMMARY, and — when the file changed — commits
+  # it on a dedicated branch and opens (or updates) a PR against main, mirroring the
+  # `uv-lock-upgrade.yml` weekly-refresh precedent: main's branch protection requires
+  # PRs + required status checks, so a direct `git push origin main` is rejected
+  # (GH013). The unchanged-file guard makes a no-diff run a clean no-op (no empty
+  # commit, no PR). Merging the PR triggers docs.yml, which builds the site and
+  # serves the dashboard on GitHub Pages.
   #
   # FAILURE NOTIFICATION: a red weekly run is surfaced by GitHub's NATIVE failed-run
   # email to the maintainer (no extra secret, no bot) — see the top-of-file note.
@@ -449,10 +452,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: main
+          # Full history so the PR branch can be force-pushed cleanly on reruns
+          # (mirrors uv-lock-upgrade.yml).
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           enable-cache: true
@@ -481,17 +488,36 @@ jobs:
             --run-url "$RUN_URL" --sha "$SHA" --generated-at "$GENERATED_AT" \
             --out docs/evals/index.md
           cat docs/evals/index.md >> "$GITHUB_STEP_SUMMARY"
-      # Commit + push the dashboard ONLY when it changed (an unchanged file is a
-      # clean no-op — no empty commit). The push to main triggers docs.yml, which
-      # serves the dashboard on Pages.
-      - name: Commit and push the dashboard when it changed
+      # Commit the dashboard ONLY when it changed (an unchanged file is a clean
+      # no-op — no empty commit, no PR) and open (or update) a PR against main —
+      # main's branch protection requires PRs + required status checks, so a direct
+      # `git push origin main` is rejected (GH013). Mirrors the `uv-lock-upgrade.yml`
+      # weekly-refresh precedent: a week-dated branch is force-pushed on reruns so
+      # repeated runs within the same week update ONE PR instead of piling up
+      # duplicates, and `gh pr view` before `gh pr create` keeps re-runs idempotent.
+      # This commit carries no judgment content (a mechanical merge of sanitized
+      # summaries), so it is left for the standing PR-sweep loop (or a human) to
+      # merge once CI is green — merging triggers docs.yml, which serves the
+      # dashboard on Pages.
+      - name: Commit the dashboard refresh and open (or update) a PR
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           if git diff --quiet -- docs/evals/index.md; then
             echo "Dashboard unchanged — nothing to commit."
-          else
-            git add docs/evals/index.md
-            git commit -m "docs(evals): refresh weekly behavioral-eval dashboard"
-            git push origin main
+            exit 0
+          fi
+          BRANCH="docs/eval-dashboard-refresh-$(date -u +%Y-%W)"
+          git checkout -B "$BRANCH"
+          git add docs/evals/index.md
+          git commit -m "docs(evals): refresh weekly behavioral-eval dashboard"
+          git push --force-with-lease origin "$BRANCH"
+          # Open a PR if one does not already exist for this branch.
+          if ! gh pr view "$BRANCH" --json number -q .number 2>/dev/null; then
+            gh pr create \
+              --title "docs(evals): refresh weekly behavioral-eval dashboard" \
+              --body "Automated dashboard refresh merging every shard's sanitized eval summary. No judgment content — merge when green." \
+              --base main
           fi

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -7,6 +7,7 @@ graph TD
     teatree.credential_config --> teatree.config
     teatree.credential_config --> teatree.core.models
     teatree.credential_config --> teatree.llm
+    teatree.credential_config --> teatree.utils
     teatree.token_report --> teatree.core.models
     teatree.token_report --> teatree.credential_config
     teatree.token_report --> teatree.llm

--- a/src/teatree/cli/eval/docker.py
+++ b/src/teatree/cli/eval/docker.py
@@ -35,13 +35,11 @@ from pathlib import Path
 
 from teatree.eval.backends import API_BACKEND
 from teatree.utils.django_bootstrap import ensure_django
+from teatree.utils.eval_container import IN_CONTAINER_ENV_VAR
 from teatree.utils.run import run_allowed_to_fail, run_streamed
 
 DOCKER_IMAGE = "teatree-test"
 _DOCKERFILE = "dev/Dockerfile.test"
-#: Env marker set on the container so the in-container ``t3 eval`` re-invocation
-#: runs the metered/benchmark command in-process instead of re-routing to docker.
-IN_CONTAINER_ENV_VAR = "T3_EVAL_IN_CONTAINER"
 #: The ``eval_credential`` knob env override. Forwarded into the container (when set
 #: on the host) so the in-container ``make_runner`` re-invocation resolves the SAME
 #: credential KIND — CI wires it so the choice is deterministic without depending on

--- a/src/teatree/cli/eval/metered_routing.py
+++ b/src/teatree/cli/eval/metered_routing.py
@@ -7,8 +7,9 @@ lanes spawn no agent and stay host-default.
 
 Two predicates break the re-route loop and gate the host escape:
 
-*   :func:`in_container` — the docker runner set ``T3_EVAL_IN_CONTAINER=1`` on the
-    container, so the in-container re-invocation runs the command in-process.
+*   :func:`~teatree.utils.eval_container.in_container` (re-exported here) — the
+    docker runner set ``T3_EVAL_IN_CONTAINER=1`` on the container, so the
+    in-container re-invocation runs the command in-process.
 *   :func:`should_route_to_docker` — a metered command runs in-process ONLY when
     it is already in the container OR ``--local`` was passed; otherwise it routes
     back through :func:`~teatree.cli.eval.docker.run_eval_in_docker`.
@@ -17,15 +18,11 @@ Two predicates break the re-route loop and gate the host escape:
 escape.
 """
 
-import os
 import sys
 
-from teatree.cli.eval.docker import IN_CONTAINER_ENV_VAR
+from teatree.utils.eval_container import IN_CONTAINER_ENV_VAR, in_container
 
-
-def in_container() -> bool:
-    """``True`` when the docker runner's ``T3_EVAL_IN_CONTAINER=1`` marker is set."""
-    return bool(os.environ.get(IN_CONTAINER_ENV_VAR))
+__all__ = ["IN_CONTAINER_ENV_VAR", "in_container", "should_route_to_docker", "warn_local_metered"]
 
 
 def should_route_to_docker(*, metered: bool, local: bool) -> bool:

--- a/src/teatree/credential_config.py
+++ b/src/teatree/credential_config.py
@@ -54,6 +54,7 @@ from teatree.llm.rate_limits import (
     read_api_key_status,
     read_rate_limits,
 )
+from teatree.utils.eval_container import in_container
 
 if TYPE_CHECKING:
     from teatree.config.enums import EvalCredential
@@ -251,12 +252,30 @@ _SELECTOR = PassPathSelector()
 
 
 def resolve_subscription_credential(*, scope: str = GLOBAL_SCOPE) -> AnthropicSubscriptionCredential:
-    """The subscription OAuth credential, routed to its selected account's ``pass`` entry."""
+    """The subscription OAuth credential, routed to its selected account's ``pass`` entry.
+
+    Inside the ephemeral eval container (:func:`~teatree.utils.eval_container.in_container`),
+    the per-account DB routing is short-circuited: the HOST already selected an
+    account and forwarded its resolved ``CLAUDE_CODE_OAUTH_TOKEN`` via ``docker
+    run -e`` (see ``teatree.cli.eval.docker``), so the credential's own
+    env-then-``pass`` resolution picks that up with no DB read — the container's
+    SQLite has zero tables (never migrated), so a DB query there is a guaranteed
+    ``OperationalError``, not a degraded-but-safe read.
+    """
+    if in_container():
+        return AnthropicSubscriptionCredential()
     return AnthropicSubscriptionCredential(pass_path_override=_SELECTOR.select(TokenKind.OAUTH, scope))
 
 
 def resolve_api_key_credential(*, scope: str = GLOBAL_SCOPE) -> AnthropicApiKeyCredential:
-    """The metered API-key credential, routed to its selected account's ``pass`` entry."""
+    """The metered API-key credential, routed to its selected account's ``pass`` entry.
+
+    Inside the ephemeral eval container, the per-account DB routing is
+    short-circuited the same way as :func:`resolve_subscription_credential` —
+    the HOST-forwarded ``ANTHROPIC_API_KEY`` env var is reused instead.
+    """
+    if in_container():
+        return AnthropicApiKeyCredential()
     return AnthropicApiKeyCredential(pass_path_override=_SELECTOR.select(TokenKind.API_KEY, scope))
 
 

--- a/src/teatree/utils/eval_container.py
+++ b/src/teatree/utils/eval_container.py
@@ -1,0 +1,21 @@
+"""Whether this process runs inside the ephemeral eval Docker container.
+
+Foundation-layer home for the ``T3_EVAL_IN_CONTAINER`` marker. Both the
+interface-layer ``teatree.cli.eval`` package (which SETS the marker) and the
+domain-layer ``teatree.credential_config`` (which READS it to short-circuit
+its DB-backed per-account routing — the container's SQLite is never migrated,
+so a live query there is a guaranteed crash) need this predicate. Tach's
+layered DAG forbids the domain layer importing the interface layer, so the
+marker lives here, below both.
+"""
+
+import os
+
+#: Set by ``teatree.cli.eval.docker`` on the container's env so the in-container
+#: ``t3 eval`` re-invocation runs in-process instead of re-routing to docker.
+IN_CONTAINER_ENV_VAR = "T3_EVAL_IN_CONTAINER"
+
+
+def in_container() -> bool:
+    """``True`` when the docker runner's ``T3_EVAL_IN_CONTAINER=1`` marker is set."""
+    return bool(os.environ.get(IN_CONTAINER_ENV_VAR))

--- a/tach.toml
+++ b/tach.toml
@@ -66,7 +66,7 @@ depends_on = ["teatree.utils"]
 [[modules]]
 path = "teatree.credential_config"
 layer = "domain"
-depends_on = ["teatree.config", "teatree.core.models", "teatree.llm"]
+depends_on = ["teatree.config", "teatree.core.models", "teatree.llm", "teatree.utils"]
 
 [[modules]]
 path = "teatree.token_report"

--- a/tests/teatree_cli/eval/test_metered_routing.py
+++ b/tests/teatree_cli/eval/test_metered_routing.py
@@ -5,6 +5,12 @@ container — the reproducible gate must never accidentally bill the host. The
 ``T3_EVAL_IN_CONTAINER=1`` marker (set by the docker runner) and the explicit
 ``--local`` escape are the two ways the command runs DIRECTLY in-process; any
 other case routes back through docker.
+
+``in_container`` is re-exported from the foundation-layer
+``teatree.utils.eval_container`` (both the interface-layer eval CLI and the
+domain-layer credential factory read the same marker; tach's layered DAG
+forbids domain -> interface, so the predicate lives below both) — its
+``os.environ`` is patched at that origin module, not here.
 """
 
 from unittest.mock import patch
@@ -13,40 +19,40 @@ import pytest
 
 from teatree.cli.eval.metered_routing import in_container, should_route_to_docker, warn_local_metered
 
-_MODULE = "teatree.cli.eval.metered_routing"
+_ENV_MODULE = "teatree.utils.eval_container"
 
 
 class TestInContainer:
     def test_true_when_marker_set(self) -> None:
-        with patch(f"{_MODULE}.os.environ", {"T3_EVAL_IN_CONTAINER": "1"}):
+        with patch(f"{_ENV_MODULE}.os.environ", {"T3_EVAL_IN_CONTAINER": "1"}):
             assert in_container() is True
 
     def test_false_when_marker_absent(self) -> None:
-        with patch(f"{_MODULE}.os.environ", {}):
+        with patch(f"{_ENV_MODULE}.os.environ", {}):
             assert in_container() is False
 
     def test_false_when_marker_empty(self) -> None:
-        with patch(f"{_MODULE}.os.environ", {"T3_EVAL_IN_CONTAINER": ""}):
+        with patch(f"{_ENV_MODULE}.os.environ", {"T3_EVAL_IN_CONTAINER": ""}):
             assert in_container() is False
 
 
 class TestShouldRouteToDocker:
     def test_metered_routes_to_docker_by_default(self) -> None:
-        with patch(f"{_MODULE}.os.environ", {}):
+        with patch(f"{_ENV_MODULE}.os.environ", {}):
             assert should_route_to_docker(metered=True, local=False) is True
 
     def test_local_escape_runs_in_process(self) -> None:
-        with patch(f"{_MODULE}.os.environ", {}):
+        with patch(f"{_ENV_MODULE}.os.environ", {}):
             assert should_route_to_docker(metered=True, local=True) is False
 
     def test_in_container_runs_in_process(self) -> None:
-        with patch(f"{_MODULE}.os.environ", {"T3_EVAL_IN_CONTAINER": "1"}):
+        with patch(f"{_ENV_MODULE}.os.environ", {"T3_EVAL_IN_CONTAINER": "1"}):
             assert should_route_to_docker(metered=True, local=False) is False
 
     def test_non_metered_lane_stays_host_default(self) -> None:
         # Free / deterministic / subscription lanes never spawn an agent, so they
         # are not subject to docker-by-default.
-        with patch(f"{_MODULE}.os.environ", {}):
+        with patch(f"{_ENV_MODULE}.os.environ", {}):
             assert should_route_to_docker(metered=False, local=False) is False
 
 

--- a/tests/teatree_utils/test_eval_container.py
+++ b/tests/teatree_utils/test_eval_container.py
@@ -1,0 +1,26 @@
+"""The ``T3_EVAL_IN_CONTAINER`` marker (``teatree.utils.eval_container``).
+
+The foundation-layer home both the interface-layer eval CLI (which SETS the
+marker) and the domain-layer credential factory (which READS it) depend on —
+see ``teatree.cli.eval.metered_routing`` and ``teatree.credential_config``.
+"""
+
+from unittest.mock import patch
+
+from teatree.utils.eval_container import IN_CONTAINER_ENV_VAR, in_container
+
+_MODULE = "teatree.utils.eval_container"
+
+
+class TestInContainer:
+    def test_true_when_marker_set(self) -> None:
+        with patch(f"{_MODULE}.os.environ", {IN_CONTAINER_ENV_VAR: "1"}):
+            assert in_container() is True
+
+    def test_false_when_marker_absent(self) -> None:
+        with patch(f"{_MODULE}.os.environ", {}):
+            assert in_container() is False
+
+    def test_false_when_marker_empty(self) -> None:
+        with patch(f"{_MODULE}.os.environ", {IN_CONTAINER_ENV_VAR: ""}):
+            assert in_container() is False

--- a/tests/test_credential_config.py
+++ b/tests/test_credential_config.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from django.db.utils import OperationalError
 from django.test import TestCase
 from django.utils import timezone
 
@@ -34,6 +35,7 @@ from teatree.credential_config import (
 )
 from teatree.llm.credentials import AnthropicApiKeyCredential, AnthropicSubscriptionCredential
 from teatree.llm.rate_limits import MeteredKeySnapshot, RateLimitProbeError, RateLimitSnapshot
+from teatree.utils.eval_container import IN_CONTAINER_ENV_VAR
 
 _OAUTH_BUILTIN = "anthropic/oauth-token"
 _API_KEY_BUILTIN = "anthropic/api-key"
@@ -332,6 +334,56 @@ class TestFactoryWiring(TestCase):
     def test_resolvers_return_the_expected_credential_classes(self) -> None:
         assert isinstance(resolve_api_key_credential(), AnthropicApiKeyCredential)
         assert isinstance(resolve_subscription_credential(), AnthropicSubscriptionCredential)
+
+
+class TestInContainerNeverTouchesConfigSetting(TestCase):
+    """Per-account routing must never touch ``ConfigSetting`` in-container.
+
+    Inside the ephemeral eval Docker container the SQLite DB has zero tables
+    (never migrated) — a live ``ConfigSetting`` read there is a guaranteed
+    crash, not a degraded path. ``docker.py`` already forwards the HOST's
+    selected credential env var into the container (its own docstring states
+    the intent), so the factory must reuse that env-var passthrough instead of
+    re-running the per-account routing selector against a DB that structurally
+    cannot exist in-container.
+    """
+
+    @contextmanager
+    def _in_container(self, **extra_env: str) -> Iterator[None]:
+        # A DB read that would raise exactly CI's crash ("no such table:
+        # teatree_config_setting") proves the short-circuit never reaches it —
+        # a raise here means the fix regressed, not that the DB was "empty".
+        db_has_no_tables = OperationalError("no such table: teatree_config_setting")
+        with (
+            patch.dict(os.environ, {IN_CONTAINER_ENV_VAR: "1", **extra_env}),
+            patch("teatree.credential_config.ConfigSetting.objects.get_effective", side_effect=db_has_no_tables),
+        ):
+            yield
+
+    def test_subscription_resolver_never_touches_configsetting_in_container(self) -> None:
+        with self._in_container(CLAUDE_CODE_OAUTH_TOKEN="host-forwarded-oauth-token"):
+            credential = resolve_subscription_credential()
+            assert isinstance(credential, AnthropicSubscriptionCredential)
+            assert credential.resolve() == "host-forwarded-oauth-token", "the host-forwarded env var must win"
+
+    def test_api_key_resolver_never_touches_configsetting_in_container(self) -> None:
+        with self._in_container(ANTHROPIC_API_KEY="host-forwarded-api-key"):
+            credential = resolve_api_key_credential()
+            assert isinstance(credential, AnthropicApiKeyCredential)
+            assert credential.resolve() == "host-forwarded-api-key"
+
+    def test_outside_the_container_the_selector_still_runs_and_would_crash(self) -> None:
+        # Control: WITHOUT the in-container marker, the same "no such table" DB
+        # failure surfaces — proving the short-circuit above is container-gated,
+        # not an accidental universal bypass of the selector.
+        db_has_no_tables = OperationalError("no such table: teatree_config_setting")
+        ConfigSetting.objects.set_value(_OAUTH_SETTING, ["anthropic/a/oauth"])
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch("teatree.credential_config.ConfigSetting.objects.get_effective", side_effect=db_has_no_tables),
+            pytest.raises(OperationalError),
+        ):
+            resolve_subscription_credential()
 
 
 class TestResolveEvalCredential(TestCase):


### PR DESCRIPTION
Closes #2920

Two independent bugs both blocked the metered `eval.yml` workflow from going green (validated after #2913's concurrency fix).

## What

**Bug 1 (critical path — blocked every eval scenario from ever running).** Every metered/subscription `eval` job crashed 19/19 immediately after the Docker image built, before any Claude API/OAuth call, with `OperationalError: no such table: teatree_config_setting`. The #2877 per-account credential routing selector (`PassPathSelector.select`, reached via `resolve_subscription_credential`/`resolve_api_key_credential`) queried `ConfigSetting` unconditionally, even inside the ephemeral eval Docker container — whose SQLite DB is never migrated (the repo mount is `:ro` and the image runs no `migrate` step).

The host already resolves the selected credential and forwards it into the container via `docker run -e` (see `teatree/cli/eval/docker.py`'s own docstring, which already stated this intent). `resolve_subscription_credential`/`resolve_api_key_credential` now short-circuit the DB-backed selector when running in-container and let the credential's normal env-then-`pass` resolution pick up the forwarded env var instead — zero DB reads in-container.

The `in_container()` marker (previously interface-layer `teatree.cli.eval.metered_routing`) moved to a new foundation-layer module, `teatree.utils.eval_container`, so the domain-layer `teatree.credential_config` can read it without crossing tach's layered DAG (domain must not import interface). `metered_routing.py` and `docker.py` now both source the marker from there; `metered_routing.in_container` stays a valid public re-export so no other caller changes.

**Bug 2 (unrelated — blocked the `publish` job).** The dashboard-auto-commit step pushed directly to `main` with `git push origin main`, now rejected by branch protection's required PRs + 6 required status checks (GH013). It now commits the refresh onto a dedicated, week-dated branch and opens (or updates) a PR, mirroring the existing `uv-lock-upgrade.yml` weekly-refresh precedent for the identical constraint (force-pushed on reruns within the same week, `gh pr view` before `gh pr create` for idempotence). The commit carries no judgment content (a mechanical merge of sanitized eval summaries), so it's left for the standing PR-sweep loop (or a human) to merge once CI is green, rather than wiring a bespoke auto-merge ceremony for a one-off case — the smaller diff against the precedented pattern already in this repo.

## Why

Both bugs independently block `eval.yml` from ever reporting green, so bundling them in one PR avoids a second review round-trip for the same standing goal ("make the metered evals genuinely green").

## Verification

- Reproduced bug 1 for real: a direct `docker run` against the actual `teatree-test` CI image (mounting the pre-fix worktree, `HOME=/tmp` so the container's DB is genuinely unmigrated, matching CI's mount/env-var flags exactly) hit the exact reported traceback (`OperationalError: no such table: teatree_config_setting` at `credential_config.py`'s `resolve_subscription_credential` → `PassPathSelector.select` → `ConfigSetting.objects.get_effective`). After the fix, the identical invocation resolves the credential from the host-forwarded env var with zero DB reads.
- New regression tests in `tests/test_credential_config.py` simulate `in_container()=True` with a mocked `ConfigSetting.objects.get_effective` that raises the exact CI `OperationalError`, and assert `resolve_subscription_credential`/`resolve_api_key_credential` never touch it in that mode (plus a control test proving the DB read still fires when the container marker is absent).
- `uv run ruff check` / `ruff format --check` / `ty check` / `tach check` all pass on the touched files.
- Targeted regression: 284 tests across `test_credential_config.py`, `test_metered_routing.py`, `test_eval_container.py` (new), `test_eval_docker.py`, `test_eval_docker_django_bootstrap.py`, `test_run_docker.py`, `test_eval_credential_config.py`, and `test_eval.py` pass.
- Full local `uv run pytest --no-cov -x -q` regression suite: 16452 passed (3 unrelated pytest-timeout flakes on completely different files under heavy local machine load — `test_cli_reference_determinism.py`, `test_initial_migration_seed.py`, `test_jscpd_duplication.py` — none touch the changed code paths).
- `actionlint .github/workflows/eval.yml`: zero findings.

## Architecture pre-check

Skipped per `/t3:code`'s tactical-fix carve-out — this is a narrow bug fix at a specific, already-identified code path (no new FSM transition, no new Protocol/extension-point surface, no BLUEPRINT change). The one structural decision (moving the `in_container()` marker to a new foundation-layer module to satisfy tach's layered DAG) is explained inline above and pinned by the updated `tach.toml` entry + `docs/dependency-graph.md` (auto-regenerated by the pre-commit hook).

## Open questions & assumptions

- **assumed:** no existing GitHub issue tracked this before this session — filed #2920 to give the ticket-required overlay a tracked reference, since `souliane/teatree` requires a ticket for every worktree/PR.
- **decided:** for bug 2, mirrored the existing `uv-lock-upgrade.yml` open-PR pattern (force-pushed week-dated branch, left open for the PR-sweep loop) rather than wiring a bespoke auto-merge ceremony, per the task's own preference for "whichever is the smaller diff against how other CI-originated auto-commits in this repo already handle the same branch-protection constraint."
- **assumed:** `eval-weekly-reusable.yml` (a separate `workflow_call`-only workflow invoked by *other* repos, not `souliane/teatree` itself) has a similar direct-push pattern but is out of scope here — it's a different workflow serving different, unknown external callers, and the task scoped bug 2 to `eval.yml`'s own `publish` job specifically.
- **not yet verified:** a full live `t3 eval run --docker` invocation against a real scenario through the globally-installed `t3` CLI, end-to-end including a real Claude API call — the auto-mode classifier blocks pointing the shared global `t3` install at an uncommitted worktree (`uv run t3 ...`), and reinstalling the shared tool mid-session risks disrupting other concurrently-running agents on this machine. Verified instead via a direct, faithful `docker run` reproduction that exercises the exact same container-side code path with the exact same mount/env-var flags `run_eval_in_docker`/`_run_in_image` construct (see Verification above) — this proves the crash and the fix, but doesn't exercise the host-side image-build-and-launch wrapper itself (which this PR does not modify). CI's `eval` job will exercise that host-side path for real.
