### PR TITLE
fix(worktree): self-heal unmigrated self-DB before provision (#2919)

### DIFF
--- a/src/teatree/core/runners/worktree_provision.py
+++ b/src/teatree/core/runners/worktree_provision.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 
 from teatree.core import prek_hook
+from teatree.core.gates.schema_guard import SelfDbMigrationError, require_current_schema
 from teatree.core.models import Worktree
 from teatree.core.overlay import OverlayBase
 from teatree.core.overlay_loader import get_overlay_for_worktree
@@ -113,6 +114,17 @@ class WorktreeProvisionRunner(RunnerBase):
     def run(self) -> RunnerResult:
         worktree = self.worktree
         overlay = self.overlay
+
+        # #2919: an auto-isolated per-worktree self-DB (teatree.paths) is seeded
+        # once from a canonical snapshot and never re-migrated on its own — a
+        # provision step below reads settings (e.g. provision_timebox's
+        # get_effective_settings()), and a stored ConfigSetting row that predates
+        # a since-added migration crashes that read with a raw ValueError. Self-heal
+        # the self-DB schema first, exactly like the sanctioned merge path (#2006).
+        try:
+            require_current_schema()
+        except SelfDbMigrationError as exc:
+            return RunnerResult(ok=False, detail=str(exc))
 
         spec = write_env_cache(worktree, overlay=overlay)
         if spec:

--- a/tests/teatree_core/test_worktree_provision_schema_guard.py
+++ b/tests/teatree_core/test_worktree_provision_schema_guard.py
@@ -1,0 +1,141 @@
+"""Regression test for #2919.
+
+``worktree provision`` crashed on an unmigrated auto-isolated per-worktree
+self-DB: the DB is seeded once from a canonical snapshot
+(``teatree.paths._seed_isolated_db``) and never re-migrated on its own. A
+provisioning step reads ``get_effective_settings()`` (e.g.
+``provision_timebox.resolve_step_timeout_seconds``), and a stored
+``ConfigSetting`` row that predates a since-added migration crashes that read
+with a raw ``ValueError`` instead of provisioning. Migration
+``0015_agent_harness_two_layer_config`` is the concrete reproduction: a
+pre-#2887 ``agent_runtime`` row (``sdk_oauth`` / ``sdk_apikey`` / ``api``) is
+unparsable by the current :class:`~teatree.config.enums.AgentRuntime` enum
+until that migration's ``RunPython`` rewrites it.
+
+``WorktreeProvisionRunner.run()`` now self-heals the self-DB schema first
+(mirroring the sanctioned merge path's ``require_current_schema``, #2006),
+so an unmigrated self-DB provisions cleanly instead of crashing.
+"""
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+from django.test import TestCase, TransactionTestCase
+
+from teatree.config import get_effective_settings
+from teatree.core.gates.schema_guard import SelfDbMigrationError, pending_migrations
+from teatree.core.models import ConfigSetting, Ticket, Worktree
+from teatree.core.overlay import DbImportStrategy, OverlayBase, ProvisionStep
+from teatree.core.runners import WorktreeProvisionRunner
+
+
+def _migrate_core_to(target: str) -> None:
+    call_command("migrate", "core", target, "--no-input", verbosity=0)
+
+
+def _migrate_core_forward() -> None:
+    call_command("migrate", "core", "--no-input", verbosity=0)
+
+
+class _DbImportOverlay(OverlayBase):
+    """Overlay whose DB-import strategy routes through ``run_timeboxed_db_import``."""
+
+    def get_repos(self) -> list[str]:
+        return ["backend"]
+
+    def get_provision_steps(self, worktree: Worktree) -> list[ProvisionStep]:
+        return []
+
+    def get_db_import_strategy(self, worktree: Worktree) -> DbImportStrategy | None:
+        return {
+            "kind": "fallback-chain",
+            "source_database": "dev",
+            "shared_postgres": True,
+            "snapshot_tool": "dslr",
+            "restore_order": [],
+            "notes": [],
+            "worktree_repo_path": worktree.repo_path,
+        }
+
+    def db_import(self, worktree: Worktree, **kwargs: Any) -> bool:
+        return True
+
+
+class WorktreeProvisionSelfHealsStaleAgentRuntimeTest(TransactionTestCase):
+    """Self-DB left one migration behind, carrying a pre-#2887 ``agent_runtime`` row."""
+
+    @pytest.fixture(autouse=True)
+    def _tmp_workspace(self, tmp_path: Path) -> None:
+        self.wt_path = tmp_path / "worktree"
+        self.wt_path.mkdir()
+
+    def setUp(self) -> None:
+        _migrate_core_to("0014_ticket_repo_namespaced_key")
+        ConfigSetting.objects.create(scope="", key="agent_runtime", value="sdk_oauth")
+        self.addCleanup(_migrate_core_forward)
+
+    def _make_worktree(self) -> Worktree:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/i/2919")
+        return Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="backend",
+            branch="feature",
+            db_name="wt_2919",
+            extra={"worktree_path": str(self.wt_path)},
+        )
+
+    def test_stale_row_crashes_settings_resolution_while_unmigrated(self) -> None:
+        assert pending_migrations(), "guard precondition: migration 0015 must still be pending"
+        with pytest.raises(ValueError, match="agent_runtime"):
+            get_effective_settings()
+
+    def test_provision_runner_self_heals_before_reading_settings(self) -> None:
+        worktree = self._make_worktree()
+        overlay = _DbImportOverlay()
+
+        with (
+            patch(
+                "teatree.core.runners.worktree_provision._setup_worktree_dir",
+                return_value=None,
+            ),
+            patch("teatree.utils.db.db_exists", return_value=False),
+        ):
+            result = WorktreeProvisionRunner(worktree, overlay=overlay).run()
+
+        assert result.ok is True, result.detail
+        assert pending_migrations() == []
+        # 0015's RunPython collapsed the stale value in place.
+        assert get_effective_settings().agent_runtime.value == "headless"
+
+
+class WorktreeProvisionFailsLoudOnSelfHealFailureTest(TestCase):
+    """A self-heal migrate failure must fail loud, never crash with a raw traceback."""
+
+    @pytest.fixture(autouse=True)
+    def _tmp_workspace(self, tmp_path: Path) -> None:
+        self.wt_path = tmp_path / "worktree"
+        self.wt_path.mkdir()
+
+    def test_reports_the_migrate_failure_instead_of_raising(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/i/2919b")
+        worktree = Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="backend",
+            branch="feature",
+            db_name="wt_2919b",
+            extra={"worktree_path": str(self.wt_path)},
+        )
+
+        with patch(
+            "teatree.core.runners.worktree_provision.require_current_schema",
+            side_effect=SelfDbMigrationError("migrate exploded mid-apply"),
+        ):
+            result = WorktreeProvisionRunner(worktree, overlay=_DbImportOverlay()).run()
+
+        assert result.ok is False
+        assert "migrate exploded mid-apply" in result.detail


### PR DESCRIPTION
Closes #2919

## What

`WorktreeProvisionRunner.run()` reads settings via `get_effective_settings()`
(`provision_timebox.resolve_step_timeout_seconds`, called ahead of the
DB-import time-box) before doing any provisioning work. An auto-isolated
per-worktree self-DB (`teatree.paths`) is seeded once from a canonical
snapshot and never re-migrated on its own, so a stored `ConfigSetting` row
that predates a since-added migration crashes that settings read with a raw
`ValueError` instead of provisioning.

Migration `0015_agent_harness_two_layer_config`'s pre-#2887 `agent_runtime`
values (`sdk_oauth` / `sdk_apikey` / `api`) are the concrete reproduction: an
isolated self-DB seeded before that migration landed still carries one of
those values, which the current `AgentRuntime` enum can no longer parse.

`WorktreeProvisionRunner.run()` now calls `require_current_schema()` first
-- the same self-heal the sanctioned merge path already uses (#2006) --
so the self-DB schema is always current before any provisioning step reads
settings. A genuine migrate failure still returns `RunnerResult(ok=False, ...)`
instead of a raw traceback. This is the single choke point both `t3 <overlay>
worktree provision` and `t3 <overlay> workspace provision` (plus the
start-time `heal_missing_provisioned_db` path) funnel through, so all three
self-heal from one change.

## Testing

New regression test `tests/teatree_core/test_worktree_provision_schema_guard.py`:
migrates the self-DB to just before 0015, inserts a stale `agent_runtime`
row, and proves (a) `get_effective_settings()` crashes on the unmigrated
schema (RED, confirmed against the pre-fix code -- reverting the fix
reproduces the reported crash verbatim), (b) `WorktreeProvisionRunner.run()`
now self-heals and completes provisioning, and (c) a genuine self-heal
failure still returns `ok=False` with the failure detail rather than
raising.

`t3 tool verify-gates` (commit + push stage) is green. Full local suite run
clean in an isolated clone; the handful of failures seen under heavy
parallel load in this worktree (git origin resolution, timezone-dependent
schedule test, macOS `say` binary, loop cross-plane race) reproduce
identically on the pre-change base commit in the same isolated clone, so
they are pre-existing local-environment flakiness, not a regression from
this change.

Open questions & assumptions:
- assumed: the fix belongs on `WorktreeProvisionRunner.run()` (the single
  choke point both `t3 <overlay> worktree provision` and `t3 <overlay>
  workspace provision` funnel through), rather than duplicated in each CLI
  command.
- assumed: the issue's "worktree provision" title covers this whole choke
  point, since `workspace provision` and the start-time DB heal share the
  exact same crash via the exact same runner.

docs: n/a -- bug fix extending an existing self-heal pattern (#2006) to a new choke point, no new command/setting/FSM state
