### PR TITLE
test(reliability): drive schema_guard tests off a private SQLite alias (#2915)

### DIFF
--- a/tests/teatree_core/conftest.py
+++ b/tests/teatree_core/conftest.py
@@ -1,10 +1,17 @@
 """Shared fixtures for teatree.core test modules."""
 
-from collections.abc import Iterator
+import uuid
+from collections.abc import Callable, Iterator
+from contextlib import ExitStack
+from dataclasses import dataclass
+from pathlib import Path
 from typing import cast
 from unittest.mock import patch
 
 import pytest
+from django.core.management import call_command
+from django.db import connections
+from django.test import override_settings
 
 from teatree.core.models import Worktree
 from teatree.core.models.review_verdict import ReviewVerdict
@@ -120,3 +127,104 @@ def mock_command_overlay() -> Iterator[None]:
         return_value={"test": CommandOverlay()},
     ):
         yield
+
+
+class _RouteAllToAlias:
+    """Force every unscoped ORM query onto ``alias`` for one migrate call (#2915).
+
+    Several ``core`` migrations (e.g. ``0001_initial``'s loop/prompt seed,
+    ``0016_loop_colleague_facing``'s backfill) run a ``RunPython`` that reads
+    historical models via ``apps.get_model(...).objects`` with no
+    ``.using(...)`` — Django resolves that to ``DEFAULT_DB_ALIAS`` regardless
+    of which connection the surrounding ``migrate --database`` targets.
+    Installing this as the sole ``DATABASE_ROUTERS`` entry for the migrate
+    call reroutes those unscoped reads/writes onto the private alias instead
+    of leaking onto the shared ``default`` connection.
+    """
+
+    def __init__(self, alias: str) -> None:
+        self.alias = alias
+
+    def db_for_read(self, model: type, **hints: object) -> str:
+        return self.alias
+
+    def db_for_write(self, model: type, **hints: object) -> str:
+        return self.alias
+
+
+@dataclass(frozen=True)
+class SchemaGuardAlias:
+    """Factory for private, file-backed SQLite connections used by schema_guard tests (#2915)."""
+
+    register_current: Callable[[], str]
+    make_stale: Callable[[], str]
+
+
+@pytest.fixture
+def _unblocked_db(django_db_blocker: pytest.FixtureRequest) -> Iterator[None]:
+    """Lift pytest-django's DB-access guard for a test that never touches ``default``."""
+    with django_db_blocker.unblock():
+        yield
+
+
+@pytest.fixture
+def schema_guard_alias(tmp_path: Path, _unblocked_db: None) -> Iterator[SchemaGuardAlias]:
+    """Private, throwaway SQLite connections for schema_guard tests (#2915).
+
+    Every alias this factory creates is registered against its own file under
+    ``tmp_path`` and torn down automatically — a crashed reverse-migrate/
+    restore cycle can corrupt only that one throwaway file, never the shared,
+    xdist-worker-lifetime-reused ``default`` test database every other test in
+    the worker relies on.
+
+    The ``_RouteAllToAlias`` router is installed for the alias's whole
+    remaining lifetime, not just this factory's own migrate calls: the
+    schema-guard functions under test (``migrate_self_db``,
+    ``require_current_schema``) run their own ``migrate --database=<alias>``
+    internally, and without the router active for *those* calls too, their
+    RunPython seed/backfill operations resolve back onto the shared
+    ``default`` connection they were built to avoid.
+    """
+    stack = ExitStack()
+    created: list[str] = []
+
+    def _register_current() -> str:
+        """Register + migrate-to-HEAD a private, file-backed SQLite connection.
+
+        Runs a real ``migrate`` (not a hand-rolled table) so the full app
+        graph is current — the schema-guard functions under test read the
+        migration ledger via Django's own ``MigrationExecutor``, which needs
+        every app's history.
+        """
+        alias = f"sg_{uuid.uuid4().hex}"
+        db_file = tmp_path / f"{alias}.sqlite3"
+        connections.databases[alias] = {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": str(db_file),
+            "OPTIONS": {},
+            "ATOMIC_REQUESTS": False,
+            "AUTOCOMMIT": True,
+            "CONN_MAX_AGE": 0,
+            "CONN_HEALTH_CHECKS": False,
+            "TIME_ZONE": None,
+            "TEST": {},
+        }
+        stack.enter_context(override_settings(DATABASE_ROUTERS=[_RouteAllToAlias(alias)]))
+        call_command("migrate", "--no-input", database=alias, verbosity=0)
+        created.append(alias)
+        return alias
+
+    def _make_stale() -> str:
+        """A private alias migrated to HEAD, then reverse-migrated ``core`` to ``zero``."""
+        alias = _register_current()
+        call_command("migrate", "core", "zero", "--no-input", database=alias, verbosity=0)
+        return alias
+
+    with stack:
+        yield SchemaGuardAlias(register_current=_register_current, make_stale=_make_stale)
+
+    for alias in created:
+        for conn in connections.all():
+            if conn.alias == alias:
+                conn.close()
+        connections.databases.pop(alias, None)

--- a/tests/teatree_core/test_schema_guard.py
+++ b/tests/teatree_core/test_schema_guard.py
@@ -16,6 +16,19 @@ before proceeding. A migrate that itself fails still fails LOUD with the
 actionable remediation. These tests pin the self-heal behaviour and the
 read-only doctor surfacing (the doctor reports the gap, it does not
 heal).
+
+Tests that exercise a function accepting an explicit ``alias`` argument
+(``pending_migrations``, ``migrate_self_db``, ``require_current_schema``,
+``doctor_check_self_db_migrations``) drive their stale/restore cycle
+against a **private, file-backed SQLite connection** — never the shared,
+xdist-worker-lifetime-reused ``default`` test database (#2915). The
+handful of tests that exercise a sanctioned command (`ticket clear`,
+`ticket merge`, `review record`) or the `t3 doctor check` aggregator
+cannot move: those entry points hard-code ``DEFAULT_DB_ALIAS`` with no
+alias parameter, so genuinely testing their self-heal behaviour requires
+``default`` itself to be behind. Those stay on ``default``, scoped as
+tightly as possible (see :class:`BehindSelfDbReportingTest` and
+:class:`BehindSelfDbSelfHealsTest`).
 """
 
 import io
@@ -38,26 +51,23 @@ from teatree.core.gates.schema_guard import (
     require_current_schema,
 )
 from teatree.core.models import MergeClear
+from tests.teatree_core.conftest import SchemaGuardAlias
 
 # ``0001_initial`` (post the #2652 squash) creates the ``teatree_merge_clear``
-# table; later migrations extend the graph. A real backward ``migrate`` can only
-# reach the pre-initial state (``zero``) since the squash.
+# table; later migrations extend the graph. Migrating all the way back to
+# ``zero`` reverses the whole chain regardless of how many migrations exist.
 _CORE_MIGRATIONS_DIR = Path(__file__).resolve().parents[2] / "src" / "teatree" / "core" / "migrations"
 
 
 def _unmigrate_core_to_zero() -> None:
     """Drive the self-DB genuinely behind via a real backward `migrate` (#2006).
 
-    The squashed graph has a single ``0001_initial``, so the only "behind"
-    state a real ``migrate`` can produce is the pre-initial one: migrating
-    ``core`` back to ``zero`` really drops every core table and clears the
-    ``django_migrations`` ledger — the way the editable install *advances
-    past* an unapplied migration. A forward heal re-applies ``0001_initial``
-    cleanly (re-creating the schema and re-running its seed) — exactly the
-    state a keystone merge of a migration-adding PR leaves behind. (The cheap
-    delete-one-table reproduction below fakes only the symptom and a real
-    ``migrate`` cannot heal it, so it is reserved for the read-only/doctor
-    surfaces that never migrate.)
+    Migrating ``core`` back to ``zero`` reverses the whole chain: it drops
+    every core table and clears the ``django_migrations`` ledger — the way
+    the editable install *advances past* an unapplied migration. A forward
+    heal re-applies the whole graph cleanly (re-creating the schema and
+    re-running its seed/backfill data migrations) — exactly the state a
+    keystone merge of a migration-adding PR leaves behind.
     """
     call_command("migrate", "core", "zero", "--no-input", verbosity=0)
 
@@ -67,7 +77,7 @@ def _migrate_core_forward() -> None:
 
 
 def _unapply_initial_migration() -> None:
-    """Reproduce the #869 self-DB symptom against the core graph.
+    """Reproduce the #869 self-DB symptom against the core graph, minimally.
 
     Drop the ``teatree_merge_clear`` table and un-record EVERY ``core`` migration
     from the ledger so the table is absent *and* the ``django_migrations`` ledger
@@ -76,10 +86,11 @@ def _unapply_initial_migration() -> None:
     would not surface a pending migration once a later leaf (``0002…``) is still
     recorded applied: ``migration_plan`` to that recorded leaf is empty. Clearing
     the whole core ledger makes the plan report the unapplied chain (``0001_initial``
-    first). The other core tables are left in place: this is the cheap symptom for
-    the read-only / doctor surfaces that never call ``migrate`` (a real ``migrate``
-    cannot heal a half-dropped schema — :class:`BehindSelfDbSelfHealsTest` covers
-    the real backward-migrate heal).
+    first). The other core tables are left in place: this is the narrowest
+    mutation of the shared ``default`` connection that still reproduces the
+    symptom (#2915) — the one remaining test here (`doctor_check()`, the `t3
+    doctor check` aggregator) hard-codes ``DEFAULT_DB_ALIAS`` with no alias
+    parameter, so it cannot move to a private connection like its siblings did.
     """
     with connection.schema_editor() as editor:
         editor.delete_model(MergeClear)
@@ -124,34 +135,80 @@ class PendingMigrationsTest(TransactionTestCase):
         require_current_schema()  # must not raise
 
 
-class BehindSelfDbReportingTest(TransactionTestCase):
-    """The cheap symptom reproduction: `MergeClear` table + ledger row absent.
+class TestSchemaGuardOnPrivateAlias:
+    """Read-only / self-heal surfaces exercised against a private alias (#2915).
 
-    This drops one table and un-records ``0001_initial`` to make the gap
-    visible to the read-only surfaces (the raw-ORM anchor, the doctor checks)
-    that never call `migrate` — so they need only the symptom, not a state a
-    real `migrate` can heal. The self-heal behaviour is covered by
-    :class:`BehindSelfDbSelfHealsTest` with a real backward migration.
+    Every function under test here (``pending_migrations``, ``require_current_
+    schema``, ``doctor_check_self_db_migrations``) accepts an explicit
+    ``alias`` argument, so each test drives its own throwaway, file-backed
+    SQLite connection (via the shared ``schema_guard_alias`` fixture)
+    reverse-migrated to ``zero`` — never the shared ``default`` connection
+    every other test in the xdist worker reuses. A crashed reverse-migrate/
+    restore cycle here can corrupt only the one file the fixture created,
+    which it tears down itself.
+    """
+
+    def test_raw_orm_call_would_fail_with_operationalerror(self, schema_guard_alias: SchemaGuardAlias) -> None:
+        alias = schema_guard_alias.make_stale()
+        # Anchor: before any heal the ORM raises the raw, opaque error this
+        # whole module exists to replace.
+        with pytest.raises(OperationalError, match="no such table"):
+            MergeClear.objects.using(alias).count()
+
+    def test_doctor_surface_fails_and_names_pending_migrations(self, schema_guard_alias: SchemaGuardAlias) -> None:
+        alias = schema_guard_alias.make_stale()
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            result = doctor_check_self_db_migrations(alias)
+        assert result is False
+        out = buffer.getvalue()
+        assert "unapplied migration" in out
+        assert "0001_initial" in out
+
+    def test_migrate_failure_fails_loud_with_remediation(self, schema_guard_alias: SchemaGuardAlias) -> None:
+        alias = schema_guard_alias.make_stale()
+        # When the heal itself fails, the gate must fail LOUD with the
+        # actionable remediation — never silently swallow a half-migrated DB.
+        with (
+            patch(
+                "teatree.core.gates.schema_guard.migrate_self_db",
+                side_effect=SelfDbMigrationError("migrate exploded mid-apply"),
+            ),
+            pytest.raises(SelfDbMigrationError) as exc,
+        ):
+            require_current_schema(alias)
+        message = str(exc.value)
+        assert "unapplied migration" in message
+        assert "t3 teatree db migrate" in message
+        assert "migrate exploded mid-apply" in message
+
+    def test_require_current_schema_auto_applies_then_proceeds(self, schema_guard_alias: SchemaGuardAlias) -> None:
+        alias = schema_guard_alias.make_stale()
+        assert pending_migrations(alias), "guard precondition: the self-DB must be behind for this test"
+        with pytest.raises(OperationalError, match="no such table"):
+            MergeClear.objects.using(alias).count()  # behind: the table genuinely does not exist
+
+        require_current_schema(alias)  # heals in place — must not raise
+
+        assert pending_migrations(alias) == [], "the pending migrations should have been applied"
+        assert MergeClear.objects.using(alias).count() == 0  # healed: the table is now usable
+
+
+class BehindSelfDbReportingTest(TransactionTestCase):
+    """The one surface that cannot move off ``default`` (#2915).
+
+    ``t3 doctor check`` (the aggregator, not the schema-guard-specific
+    ``doctor_check_self_db_migrations`` it wraps) has no ``alias`` parameter —
+    it always inspects ``DEFAULT_DB_ALIAS`` — so genuinely exercising it needs
+    ``default`` itself to be behind. The mutation is the narrowest available
+    (one table dropped, one app's ledger rows cleared, see
+    ``_unapply_initial_migration``) rather than a full reverse-migrate, to
+    keep the shared connection's exposure as small as possible.
     """
 
     def setUp(self) -> None:
         _unapply_initial_migration()
         self.addCleanup(_reapply_initial_migration)
-
-    def test_raw_orm_call_would_fail_with_operationalerror(self) -> None:
-        # Anchor: before any heal the ORM raises the raw, opaque error this
-        # whole module exists to replace.
-        with pytest.raises(OperationalError, match="no such table"):
-            MergeClear.objects.count()
-
-    def test_doctor_surface_fails_and_names_pending_migrations(self) -> None:
-        buffer = io.StringIO()
-        with redirect_stdout(buffer):
-            result = doctor_check_self_db_migrations()
-        assert result is False
-        out = buffer.getvalue()
-        assert "unapplied migration" in out
-        assert "0001_initial" in out
 
     def test_doctor_check_command_aggregates_pending_migrations(self) -> None:
         # The `t3 doctor check` aggregation wires the schema-guard surface
@@ -162,47 +219,22 @@ class BehindSelfDbReportingTest(TransactionTestCase):
         assert ok is False
         assert "unapplied migration" in buffer.getvalue()
 
-    def test_migrate_failure_fails_loud_with_remediation(self) -> None:
-        # When the heal itself fails, the gate must fail LOUD with the
-        # actionable remediation — never silently swallow a half-migrated DB.
-        with (
-            patch(
-                "teatree.core.gates.schema_guard.migrate_self_db",
-                side_effect=SelfDbMigrationError("migrate exploded mid-apply"),
-            ),
-            pytest.raises(SelfDbMigrationError) as exc,
-        ):
-            require_current_schema()
-        message = str(exc.value)
-        assert "unapplied migration" in message
-        assert "t3 teatree db migrate" in message
-        assert "migrate exploded mid-apply" in message
-
 
 class BehindSelfDbSelfHealsTest(TransactionTestCase):
-    """A keystone merge advanced the install over a migration; the gate self-heals (#2006).
+    """The sanctioned commands that cannot move off ``default`` (#2915).
 
-    `setUp` drives the self-DB genuinely behind with a real backward
-    `migrate core zero` (every core table dropped, ledger cleared),
-    reproducing the state the live editable install lands in after a keystone
-    merge of a migration-adding PR (the only "behind" state the squashed
-    single-`0001_initial` graph admits). The sanctioned operations must now
-    apply the pending self-DB migrations in place and proceed, instead of
-    crashing every tick with `no such table` until a manual
-    `t3 teatree db migrate`.
+    ``ticket clear``, ``ticket merge`` and ``review record`` call
+    ``require_current_schema()`` with no ``alias`` argument — they always
+    self-heal ``DEFAULT_DB_ALIAS``. Testing their self-heal integration for
+    real (a keystone merge advanced the install over a migration, #2006)
+    needs ``default`` itself genuinely behind, via a real backward `migrate
+    core zero` (every core table dropped, ledger cleared) — the state a real
+    ``migrate`` can heal, unlike the cheap symptom reproduction above.
     """
 
     def setUp(self) -> None:
         _unmigrate_core_to_zero()
         self.addCleanup(_migrate_core_forward)
-
-    def test_require_current_schema_auto_applies_then_proceeds(self) -> None:
-        assert pending_migrations(), "guard precondition: the self-DB must be behind for this test"
-        with pytest.raises(OperationalError, match="no such table"):
-            MergeClear.objects.count()  # behind: the table genuinely does not exist
-        require_current_schema()  # heals in place — must not raise
-        assert pending_migrations() == [], "the pending migrations should have been applied"
-        assert MergeClear.objects.count() == 0  # healed: the table is now usable
 
     def test_ticket_clear_command_proceeds_past_schema_gate(self) -> None:
         result = cast(

--- a/tests/teatree_core/test_schema_guard_migrate.py
+++ b/tests/teatree_core/test_schema_guard_migrate.py
@@ -11,81 +11,72 @@ process, against the exact connection** ``pending_migrations()`` reads — so
 non-destructive (rows survive), idempotent (a no-op on a current DB), and
 fail-closed (a real migrate error raises).
 
-Since the #2652 squash ``core`` is a single ``0001_initial``, so the only
-genuinely-stale state a real reverse migrate can reach is the pre-initial one
-(``zero``), from which ``migrate_self_db`` re-applies the initial and seeds.
+A real reverse migrate can leave ``core`` behind at any point in its
+migration graph; the tests below exercise the pre-initial state (``zero``),
+the state a keystone merge of a migration-adding PR leaves the runtime
+self-DB in, from which ``migrate_self_db`` re-applies the whole graph.
+
+Every test below drives its stale/restore cycle against a **private,
+file-backed SQLite connection** registered per test — never the shared,
+xdist-worker-lifetime-reused ``default`` test database (#2915). Reverse-
+migrating ``core`` to ``zero`` against ``default`` risked leaving every other
+test in the same worker permanently stale if a cleanup was ever interrupted
+(a ``pytest-timeout`` firing mid-restore, an OOM-kill); a private alias
+confines that risk to the one throwaway file this test itself creates and
+tears down.
 """
 
 from unittest.mock import patch
 
 import pytest
-from django.core.management import call_command
 from django.db import OperationalError
-from django.test import TransactionTestCase
 
 from teatree.core.gates.schema_guard import SelfDbMigrationError, migrate_self_db, pending_migrations
+from teatree.core.models import Ticket
+from tests.teatree_core.conftest import SchemaGuardAlias
 
 
-class MigrateSelfDbInProcessTest(TransactionTestCase):
-    """``migrate_self_db`` converges the live test connection.
+class TestMigrateSelfDbInProcess:
+    """``migrate_self_db`` converges the connection named by its ``alias`` arg.
 
-    It targets the same connection ``pending_migrations()`` inspects, so the
-    migrate-then-recheck round-trip is guaranteed to converge on one DB.
+    Each test registers its own private, file-backed SQLite alias (via the
+    shared ``schema_guard_alias`` fixture) — never the shared ``default``
+    connection every other test in the xdist worker reuses — so a crashed
+    reverse-migrate/restore cycle cannot corrupt unrelated tests (#2915).
     """
 
-    def _make_stale(self) -> list[str]:
-        """Reverse the live DB to ``zero`` so it is genuinely behind.
+    def test_stale_db_is_brought_current(self, schema_guard_alias: SchemaGuardAlias) -> None:
+        alias = schema_guard_alias.make_stale()
+        assert pending_migrations(alias) != [], "precondition: DB must be stale"
 
-        The squashed graph's only reverse target is ``zero``: un-applying
-        ``0001_initial`` really drops the core tables (schema genuinely
-        behind), the exact stale-runtime-DB state ``schema_guard`` guards
-        against. ``migrate_self_db`` then re-applies the initial forward.
-        """
-        call_command("migrate", "core", "zero", "--no-input", verbosity=0)
-        return pending_migrations()
+        applied = migrate_self_db(alias)
 
-    def _restore_head(self) -> None:
-        call_command("migrate", "core", "--no-input", verbosity=0)
-
-    def test_stale_db_is_brought_current(self) -> None:
-        self.addCleanup(self._restore_head)
-        self._make_stale()
-        assert pending_migrations() != [], "precondition: DB must be stale"
-
-        applied = migrate_self_db()
-
-        assert pending_migrations() == [], "migrate_self_db must converge the live connection"
+        assert pending_migrations(alias) == [], "migrate_self_db must converge the aliased connection"
         assert applied, "must report the migration labels it applied"
         assert any("0001_initial" in label for label in applied)
 
-    def test_idempotent_noop_on_current_db(self) -> None:
-        # A current DB yields nothing pending; migrate returns an empty list
-        # and does not error.
-        assert pending_migrations() == []
-        assert migrate_self_db() == []
-        assert pending_migrations() == []
+    def test_idempotent_noop_on_current_db(self, schema_guard_alias: SchemaGuardAlias) -> None:
+        alias = schema_guard_alias.register_current()
+        # A current DB yields nothing pending; migrate returns an empty
+        # list and does not error.
+        assert pending_migrations(alias) == []
+        assert migrate_self_db(alias) == []
+        assert pending_migrations(alias) == []
 
-    def test_migrate_is_non_destructive_to_existing_rows(self) -> None:
-        # ``migrate_self_db`` runs a forward ``migrate`` that never drops live
-        # rows. On the squashed single-migration graph the only reverse target
-        # is ``zero`` (which recreates the schema from scratch), so the
-        # non-destructive guarantee is pinned on the always-available
-        # invocation: a no-op migrate against a current DB leaves existing rows
-        # exactly as they were.
-        from teatree.core.models import Ticket  # noqa: PLC0415
+    def test_migrate_is_non_destructive_to_existing_rows(self, schema_guard_alias: SchemaGuardAlias) -> None:
+        alias = schema_guard_alias.register_current()
+        ticket = Ticket.objects.using(alias).create(overlay="t3-teatree", issue_url="https://example.com/issues/126")
 
-        ticket = Ticket.objects.create(overlay="t3-teatree", issue_url="https://example.com/issues/126")
-
-        assert migrate_self_db() == [], "current DB: migrate is a no-op"
+        assert migrate_self_db(alias) == [], "current DB: migrate is a no-op"
 
         ticket.refresh_from_db()
         assert ticket.issue_url == "https://example.com/issues/126", "non-destructive: existing rows survive"
 
-    def test_fails_closed_when_migrate_errors(self) -> None:
+    def test_fails_closed_when_migrate_errors(self, schema_guard_alias: SchemaGuardAlias) -> None:
         # A genuine migrate failure must raise SelfDbMigrationError, never be
         # swallowed — the consumer relies on a non-zero outcome to fail closed.
-        self.addCleanup(self._restore_head)
-        self._make_stale()  # ensure pending != [] so call_command is reached
+        alias = schema_guard_alias.make_stale()
+        assert pending_migrations(alias) != [], "precondition: ensure call_command is reached"
         with (
             patch(
                 "teatree.core.gates.schema_guard.call_command",
@@ -93,5 +84,5 @@ class MigrateSelfDbInProcessTest(TransactionTestCase):
             ),
             pytest.raises(SelfDbMigrationError) as exc,
         ):
-            migrate_self_db()
+            migrate_self_db(alias)
         assert "disk I/O error" in str(exc.value)


### PR DESCRIPTION
Closes #2915.

The schema_guard read-only/self-heal surfaces (`pending_migrations`,
`migrate_self_db`, `require_current_schema`, `doctor_check_self_db_migrations`)
all accept an explicit alias argument, so their stale/restore cycle no
longer needs to reverse-migrate the shared, `--reuse-db`-persisted default
test database. Each test now drives a throwaway, file-backed SQLite
connection via a shared `schema_guard_alias` fixture instead, so a crashed
cleanup can corrupt only that one file, never every other test in the
xdist worker.

The handful of tests that exercise a sanctioned command (`ticket clear`/
`merge`, `review record`) or the `t3 doctor check` aggregator hard-code
the default DB alias with no alias parameter, so they stay on `default`,
scoped to the narrowest possible mutation.

Consolidates the duplicated alias-registration helpers from both test
files into `tests/teatree_core/conftest.py`, and keeps the
`DATABASE_ROUTERS` override active for the alias's whole test lifetime,
not just the initial build — `migrate_self_db`'s own internal migrate
call needs the same routing the fixture's setup uses, or its `RunPython`
seed data silently leaks onto the shared default connection.

## Architecture pre-check — #2915

### 1. BLUEPRINT § alignment
No dedicated BLUEPRINT section covers test-infrastructure isolation; this
is a test-reliability fix confined to `tests/teatree_core/`, not a
runtime behavior or contract change.

### 2. FSM phase boundaries
n/a — no `Ticket.State`/`Worktree.State` transition touched.

### 3. Extension-point contracts
n/a — no `OverlayBase`/scanner/hook/Protocol surface touched. The
production functions under test (`pending_migrations`, `migrate_self_db`,
`require_current_schema`, `doctor_check_self_db_migrations`) already
accepted an `alias` argument before this change; only their test callers
changed.

### 4. Component boundaries
Test-only change: `tests/teatree_core/conftest.py` (shared fixture),
`tests/teatree_core/test_schema_guard.py`, `tests/teatree_core/
test_schema_guard_migrate.py`.

### 5. Dependency direction
No new cross-module `src/` import. `uv run tach check` passes (verified
pre-commit hook run, see below).

### 6. Test surface
This PR *is* the test surface — no production code changed. Each
schema_guard test now asserts against a private, file-backed SQLite
alias instead of the shared `default` connection; behavior asserted is
unchanged, only DB isolation.

### 7. Resilience invariants
n/a — no external write (Slack/PR/DB-outside-request-cycle/fs) introduced.
The private alias itself IS the resilience improvement: a crashed
reverse-migrate/restore cycle can now corrupt only a throwaway
`tmp_path` file, never the shared, worker-lifetime-reused `default` test
database.

### 8. Identity and key normalization
n/a — no dual bare/qualified identity form introduced.

### 9. Behavior preservation / capability deletion
Every test case from the pre-change file is preserved 1:1 (verified by
diffing test method names before/after — none removed, none renamed to
change behavior). The only case that stays on the shared `default`
connection is the handful whose target function hard-codes
`DEFAULT_DB_ALIAS` with no `alias` parameter (`t3 doctor check`, `ticket
clear`/`merge`, `review record`) — scoped to the narrowest mutation
already used pre-change (`_unapply_initial_migration`/
`_unmigrate_core_to_zero`), not widened.

## Test plan

- `uv run pytest tests/teatree_core/test_schema_guard.py
  tests/teatree_core/test_schema_guard_migrate.py -q --reuse-db` — 18
  passed locally (verified twice: once under heavy concurrent local load
  with `--timeout=300` to isolate load-induced flakiness from logic
  correctness, once under normal load with the standard 60s timeout —
  35s total).
- Full pre-commit hook suite (ruff, ruff format, tach, ty-check,
  import-linter, module-health, BLUEPRINT sync, etc.) — all passed on
  commit.
- CI `test (3.13)` lane (full suite + 93% coverage floor) — pending, see
  PR checks.

## Open questions & assumptions

- **Full-graph migrate replay is inherently CPU-heavy on this large
  migration history** (status: assumed). Building a private alias to
  HEAD, then reverse-to-`zero`, then forward-to-HEAD again costs roughly
  the same as the pre-change reverse/restore against `default` — this PR
  does not add extra replay passes, it only changes which connection
  absorbs the cost. Under heavy *local* concurrent load (unrelated
  processes) this can legitimately exceed the 60s per-test
  `pytest-timeout`, exactly the class of flakiness #2915 describes, but
  it is environmental, not a logic defect (confirmed: same tests pass in
  35s total under normal load). CI runs on an isolated, uncontended
  runner, so this should not be an issue there; flagging in case CI
  proves otherwise.
- **DRY consolidation of the alias-registration helpers into
  `conftest.py`** (status: decided-by-agent, not requested by the
  issue). The issue only asked for the private-alias approach; I found
  the helper trio (`_RouteAllToAlias`, `_register_current_alias`,
  `_make_stale_alias`, `_teardown_alias`) 100% duplicated across both
  touched test files and consolidated them into the shared
  `schema_guard_alias` pytest fixture, since I was already touching both
  files. This also fixed a real bug in the salvaged draft: the
  `DATABASE_ROUTERS` override was previously scoped only to the
  *initial* forward-migrate, so `migrate_self_db`'s own internal
  forward-migrate call (the function under test) silently leaked
  `RunPython` seed writes onto the shared `default` connection,
  defeating the isolation the fix exists to provide. Caught by running
  the tests before committing (2 of 18 failed with a `NOT NULL`
  constraint error on `default` until fixed).
- **A prior, stalled attempt at this exact ticket already existed** in a
  worktree on this branch (status: decided-by-agent). I salvaged and
  built on that work rather than starting fresh, per the dispatch
  instructions to check for prior progress first.
