### PR TITLE
fix(cli): route pr and lifecycle groups through core dispatch (#2925)

### DIFF
--- a/src/teatree/cli/django_groups.py
+++ b/src/teatree/cli/django_groups.py
@@ -142,6 +142,15 @@ DJANGO_GROUPS: dict[str, DjangoGroup] = {
             ("post-evidence", "[Deprecated] Alias for post-test-plan (renamed; kept one release for back-compat)."),
             ("sweep", "List your open PRs across the forge for the /t3:sweeping-prs skill."),
         ],
+        # `create` gate-validates against the teatree-core control DB the
+        # shipping gate reads (`assert_lifecycle_db_is_canonical`), and every
+        # sibling lives in the same core-only `pr.py` module. Without
+        # `core_dispatch`, the overlay project-path resolver prefers any
+        # `manage.py` discovered from the invoking cwd — which, from inside a
+        # ticket worktree, is that worktree's OWN `manage.py`, running against
+        # its per-worktree auto-isolated DB the gate never consults (#2925,
+        # the same #126 class `db migrate`/`db approve` were fixed under).
+        core_dispatch=True,
     ),
     "tasks": DjangoGroup(
         "Async task queue.",
@@ -208,6 +217,13 @@ DJANGO_GROUPS: dict[str, DjangoGroup] = {
             ("record-review-context", "Record referenced-context retrieval before reviewing (deep-retrieval gate)."),
             ("record-anti-vacuity", "Record the SHA-bound anti-vacuity attestation before review-request/merge."),
         ],
+        # Every subcommand records phase attestations against the
+        # teatree-core control DB the shipping gate reads
+        # (`assert_lifecycle_db_is_canonical`) — same #2925/#126 reasoning as
+        # the `pr` group above: without `core_dispatch`, a cwd inside a ticket
+        # worktree resolves that worktree's own `manage.py` and its
+        # per-worktree auto-isolated DB instead.
+        core_dispatch=True,
     ),
     "env": DjangoGroup(
         "Inspect and mutate the worktree env cache.",

--- a/tests/teatree_core/test_overlay_core_dispatch.py
+++ b/tests/teatree_core/test_overlay_core_dispatch.py
@@ -150,6 +150,77 @@ class TestTicketGroupCoreDispatch:
         assert "merge" in cmd
 
 
+class TestPrGroupCoreDispatch:
+    """``pr create`` routes through ``python -m teatree`` (core), not the overlay manage.py.
+
+    ``pr`` subcommands live in ``teatree.core.management.commands.pr`` —
+    teatree CORE — and ``create`` gate-validates against the teatree-core
+    control DB the shipping gate reads
+    (``teatree.core.db_anchor.assert_lifecycle_db_is_canonical``). Without the
+    ``core_dispatch`` marker, the overlay project-path resolver prefers any
+    ``manage.py`` discovered from the invoking cwd — from inside a ticket
+    worktree that is the worktree's OWN ``manage.py``, running against its
+    per-worktree auto-isolated DB the gate never consults
+    (souliane/teatree#2925, the same #126 class as ``db migrate``/``db approve``).
+    """
+
+    def test_pr_group_is_marked_core_dispatch(self) -> None:
+        """``DJANGO_GROUPS['pr']`` carries the ``core_dispatch`` marker."""
+        entry = DJANGO_GROUPS["pr"]
+        assert getattr(entry, "core_dispatch", False) is True, (
+            f"pr group must opt into core dispatch (#2925) — its create command reads/writes "
+            f"the teatree-core control DB, not an overlay manage.py, got {entry!r}"
+        )
+
+    def test_pr_create_uses_core_dispatch(self, overlay_clone_path: Path) -> None:
+        """``t3 <overlay> pr create`` must dispatch to core, never the overlay manage.py."""
+        runner = CliRunner()
+        app = _build_overlay_app(overlay_clone_path)
+        with patch("teatree.cli.overlay.run_streamed") as run_streamed:
+            result = runner.invoke(app, ["pr", "create", "15"])
+        assert result.exit_code == 0, result.output
+        assert run_streamed.called
+        cmd = run_streamed.call_args.args[0]
+        assert "-m" in cmd, f"pr create must dispatch via python -m teatree, got {cmd!r}"
+        assert "teatree" in cmd, f"pr create must dispatch via python -m teatree, got {cmd!r}"
+        assert "manage.py" not in " ".join(cmd), f"pr create must NOT route through manage.py, got {cmd!r}"
+        assert "pr" in cmd
+        assert "create" in cmd
+
+
+class TestLifecycleGroupCoreDispatch:
+    """``lifecycle visit-phase`` routes through ``python -m teatree`` (core), not the overlay manage.py.
+
+    ``lifecycle`` subcommands live in ``teatree.core.management.commands.lifecycle``
+    — teatree CORE — and every one of them records a phase attestation against
+    the teatree-core control DB the shipping gate reads via
+    ``assert_lifecycle_db_is_canonical``. Same #2925 reasoning as ``pr`` above.
+    """
+
+    def test_lifecycle_group_is_marked_core_dispatch(self) -> None:
+        """``DJANGO_GROUPS['lifecycle']`` carries the ``core_dispatch`` marker."""
+        entry = DJANGO_GROUPS["lifecycle"]
+        assert getattr(entry, "core_dispatch", False) is True, (
+            f"lifecycle group must opt into core dispatch (#2925) — its subcommands record "
+            f"phase attestations against the teatree-core control DB, got {entry!r}"
+        )
+
+    def test_lifecycle_visit_phase_uses_core_dispatch(self, overlay_clone_path: Path) -> None:
+        """``t3 <overlay> lifecycle visit-phase`` must dispatch to core, never the overlay manage.py."""
+        runner = CliRunner()
+        app = _build_overlay_app(overlay_clone_path)
+        with patch("teatree.cli.overlay.run_streamed") as run_streamed:
+            result = runner.invoke(app, ["lifecycle", "visit-phase", "15", "testing"])
+        assert result.exit_code == 0, result.output
+        assert run_streamed.called
+        cmd = run_streamed.call_args.args[0]
+        assert "-m" in cmd, f"lifecycle visit-phase must dispatch via python -m teatree, got {cmd!r}"
+        assert "teatree" in cmd, f"lifecycle visit-phase must dispatch via python -m teatree, got {cmd!r}"
+        assert "manage.py" not in " ".join(cmd), f"lifecycle visit-phase must NOT route through manage.py, got {cmd!r}"
+        assert "lifecycle" in cmd
+        assert "visit-phase" in cmd
+
+
 class TestDbMigrateCoreDispatch:
     """``db migrate`` routes through ``python -m teatree`` (core); siblings do not.
 


### PR DESCRIPTION
fix(cli): route pr and lifecycle groups through core dispatch (#2925)

## What

`t3 <overlay> pr create` and `t3 <overlay> lifecycle <sub>` now dispatch
via `python -m teatree` (teatree-core) unconditionally, instead of
preferring whatever `manage.py` the overlay project-path resolver finds
from the invoking cwd.

## Why

Both `DJANGO_GROUPS["pr"]` and `DJANGO_GROUPS["lifecycle"]` defaulted to
`core_dispatch=False`. From inside a ticket worktree, the resolver finds
that worktree's OWN `manage.py`, which runs against its per-worktree
auto-isolated DB — not the canonical control DB the shipping gate reads
(`assert_lifecycle_db_is_canonical`). The result was `WrongWorktreeDBError`
on the last step of the standard `cd <worktree>` → ship workflow.

Both groups' subcommands live entirely in `teatree.core.management.commands`
(`pr.py`, `lifecycle.py`) — same as `db migrate`/`db approve` (#126) and
`ticket clear`/`merge` (already `core_dispatch=True`) — so they get the
same marker to force `python -m teatree` regardless of cwd.

## Architecture pre-check

1. **BLUEPRINT § alignment** — §6 Overlay System. The `core_dispatch`
   dispatch mechanism isn't itself documented in BLUEPRINT prose (the prior
   #1312/#1318/#126 `core_dispatch` fixes also landed without a BLUEPRINT
   edit — it's an implementation-level routing detail). No BLUEPRINT change.
2. **FSM phase boundaries** — n/a, no `Ticket.State`/`Worktree.State`
   transition touched.
3. **Extension-point contracts** — `DjangoGroup.core_dispatch`, one
   consumer (`OverlayAppBuilder._bridge_subcommand`). No Protocol changed;
   two static data rows flip an existing boolean field.
4. **Component boundaries** — `src/teatree/cli/django_groups.py`, the
   static command-group catalogue; exactly where the analogous #126/#1318
   markers already live for `db`/`ticket`/`review`/`followup`.
5. **Dependency direction** — no new imports.
6. **Test surface** — `tests/teatree_core/test_overlay_core_dispatch.py::
   TestPrGroupCoreDispatch` / `::TestLifecycleGroupCoreDispatch`. Confirmed
   RED without the fix (4 failing assertions), GREEN with it.
7. **Resilience invariants** — no new external write; routes an *existing*
   write to the correct DB instead of an isolated one.
8. **Identity and key normalization** — n/a.
9. **Behavior preservation / capability deletion** — purely additive; no
   test inverted, no matcher narrowed.

## Open questions & assumptions

- **Assumed:** the issue's named scope (`pr create`, `ticket clear`,
  `ticket merge`, `lifecycle visit-phase`) is the full fix surface for this
  ticket. `ticket clear`/`merge` were already `core_dispatch=True` on
  `main` before this change (a prior, separate fix). Status: assumed.
- **Open (out of scope, flagged for a follow-up):** other non-provisioning
  groups (`tasks`, `standup`, `availability`) also read/write ticket/session
  bookkeeping state and may have the same latent cwd-dependent DB
  resolution gap. Not verified or fixed here — the issue names a narrower,
  explicit scope and this PR stays within it. Status: open.
