### PR TITLE
docs(skills): two agent-facing gotchas from a live MR review pass

### DIFF
--- a/skills/platforms/references/gitlab.md
+++ b/skills/platforms/references/gitlab.md
@@ -179,6 +179,13 @@ glab api "projects/<PROJECT_ID>/merge_requests/<IID>/notes?per_page=100"
 glab ci status --branch <source_branch> -R <repo>
 ```
 
+**One SHA can have MULTIPLE pipelines with DIFFERENT job sets — check all of them before declaring an MR green.** `glab ci status --branch` (and a first glance at `glab mr view`) surfaces only the LATEST pipeline for that branch. A `push` pipeline and a separate `merge_request_event` pipeline can both exist for the exact same head SHA, and the `merge_request_event` one often carries jobs the push pipeline doesn't run at all (e.g. an MR title/description format validator). A push pipeline showing all-green does NOT mean the MR is mergeable if a later `merge_request_event` pipeline for the same SHA failed. Before asserting "CI green" on any MR, list every pipeline for the head SHA and check every job in each:
+
+```bash
+glab api "projects/<URL-ENCODED-PROJECT>/pipelines?sha=<head_sha>&per_page=10"   # lists ALL pipelines for that SHA
+glab api "projects/<URL-ENCODED-PROJECT>/pipelines/<pipeline_id>/jobs?per_page=100"  # every job's real status, not just the ones glab prints first
+```
+
 ### Watch a Manually-Triggered Job by ID
 
 `glab ci status --branch` only finds the latest pipeline; it misses manually-triggered stage jobs and old pipelines. When you already have a job URL (e.g., from `glab mr view`'s `head_pipeline.jobs[]`), hit the REST API directly:

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -388,6 +388,12 @@ Some issue tracker CLIs cannot serialize nested JSON. **Always use `curl`** with
 
 For note bodies containing markdown images (`![alt](url)`), shell variable interpolation and `jq --arg` both escape `!` to `\!`. **Always use Python** (`urllib.request` or `requests`) to serialize the JSON payload.
 
+## Never Pipe, Redirect, or Chain a gh/glab Publish Command
+
+The banned-terms (#1415) and quote-scanner (#1213) gates classify a command's visibility by walking EVERY top-level `&&`/`;`/`|`/newline segment — a segment carrying any redirection, heredoc, or substitution construct (`>`, `<<`, `2>&1`, `$(...)`) forces a conservative SCAN of the whole command, even when the actual `gh`/`glab` post targets a known-private repo that would otherwise skip. This is by design (an unrecognised construct could hide a second, unverifiable command), but it means a habitual `... 2>&1 | python3 -c "..."` tacked onto a `gh pr create`/`glab api` call — or writing a body file via heredoc in the SAME Bash call as the post — reliably trips the gate on a repo that is genuinely private.
+
+**Issue the publish command ALONE, in its own Bash call, with no trailing `2>&1`, no pipe, no heredoc.** Write any body file in a separate, prior Bash call; inspect the JSON response (if needed) in a separate, later call. Splitting the call costs nothing and avoids a false block that has nothing to do with the destination's actual visibility.
+
 ## Preserve Existing UX Patterns
 
 When fixing a broken UX mechanism (web terminal, browser launch, notification method), fix it **in-kind** — do not replace it with a different mechanism without asking. If proposing a different approach, ask the user first: "Currently this uses X. Want to keep that or switch to Y?"


### PR DESCRIPTION
Doc-only retro finding from a live MR review session: (1) GitLab MRs can carry multiple pipelines per head SHA with different job sets, so checking only the first one printed by glab understates real CI state; (2) a gh/glab publish command chained with a pipe/redirect/2>&1 in the same Bash call forces the banned-terms/quote-scanner gate's conservative scan even against a genuinely private repo. Both documented with concrete recipes/guidance.