### PR TITLE
fix(eval): widen the clean-room skill catalog for 8 skill-routing scenarios (#2940)

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -1084,6 +1084,14 @@ its own, and reuses `backend-dev` / `frontend-dev` unchanged); the contract
 under test is identical. Grading inspects the agent's `Skill` tool calls
 (`input.skill`).
 
+Because these placeholder/companion names are not skills core itself ships, a
+scenario that needs the agent to actually ISSUE the `Skill` call (not just
+narrate it) must also widen the clean room's simulated catalog via
+`available_skills:` — see "Scenario shape" above. Without it the model's own
+"only invoke a listed skill name" refusal correctly declines to call one, which
+looks like a routing failure but is really a catalog gap
+(`evals/fixtures/skill_catalog` is the fixture plugin that closes it).
+
 #### Coverage matrix
 
 The user's requirement is that **every** phase load the right skill set —
@@ -1260,6 +1268,20 @@ Fields:
   removing the tool it guards. Without this, a scenario declaring `tools: [Write]`
   still saw `Bash`/`Read`/etc. and could explore until `max_turns` (a false FAIL
   even when every matcher passed).
+- `available_skills` — optional list of skill names that WIDEN the clean
+  room's simulated Skill-tool catalog on top of whatever the CLI discovers on
+  its own. Absent (the default) leaves `ClaudeAgentOptions.skills`/`plugins`
+  untouched, so a scenario declaring none is byte-identical to before this
+  field existed. A scenario whose prompt references a skill name core does
+  not itself ship — a placeholder overlay's workspace/legal-entity skill
+  (`t3-widget`, `widget-le`), a companion language bible (`ac-django`,
+  `ac-python`), or the review skill named without a leading slash (`review`)
+  — declares the referenced names here; the runner registers the eval-only
+  fixture plugin (`evals/fixtures/skill_catalog`) and lists exactly this set.
+  The agent's own "only invoke a name in the available list, or one the user
+  explicitly typed" refusal rule stays intact — this widens what is listed,
+  it never bypasses the rule. See `teatree.eval.api_runner.build_sdk_options`
+  and `teatree.eval.models.EvalSpec.available_skills`.
 - `expect` — list of matchers (see below); required unless a `judge` block is
   present (a judge-only scenario may omit it).
 - `judge` — optional LLM-judge block (`rubric`, optional `model`, optional

--- a/evals/fixtures/skill_catalog/.claude-plugin/plugin.json
+++ b/evals/fixtures/skill_catalog/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "eval-skill-catalog",
+  "version": "0.0.1",
+  "description": "Eval-only fixture plugin. Provides synthetic SKILL.md stand-ins for names that skill-routing eval scenarios (evals/scenarios/skill_routing.yaml, overlay_work_requires_overlay_skill.yaml) reference but core does not itself ship: a placeholder overlay's workspace/legal-entity skill, its project dev skill, the generic language bibles, and the review skill named without a leading slash. Registered by teatree.eval.api_runner ONLY for a scenario that declares EvalSpec.available_skills, so the isolated eval clean room has a real, discoverable Skill-tool catalog entry for each. Not a real overlay, not shipped skill content, not installed for real use."
+}

--- a/evals/fixtures/skill_catalog/skills/ac-django/SKILL.md
+++ b/evals/fixtures/skill_catalog/skills/ac-django/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: ac-django
+description: "EVAL FIXTURE. Stand-in for the generic Django companion bible layered underneath a project's own backend dev skill for Django work. Placeholder only — see evals/scenarios/skill_routing.yaml (overlay_django_coding_loads_companion_bible)."
+---
+
+# ac-django (eval fixture)
+
+This is a synthetic stand-in loaded only inside the teatree eval harness's
+isolated clean room (`teatree.eval.api_runner`), so skill-routing scenarios
+that reference `/ac-django` have a real, loadable Skill-tool catalog entry.
+It carries no operational instructions and is never installed for real use —
+core stays overlay-agnostic; a real environment supplies its own real Django
+companion bible under its own name.

--- a/evals/fixtures/skill_catalog/skills/ac-python/SKILL.md
+++ b/evals/fixtures/skill_catalog/skills/ac-python/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: ac-python
+description: "EVAL FIXTURE. Stand-in for the generic Python companion bible layered underneath a project's own backend dev skill for plain-Python (non-Django) work. Placeholder only — see evals/scenarios/skill_routing.yaml (overlay_python_coding_generalizes_to_python_bible)."
+---
+
+# ac-python (eval fixture)
+
+This is a synthetic stand-in loaded only inside the teatree eval harness's
+isolated clean room (`teatree.eval.api_runner`), so skill-routing scenarios
+that reference `/ac-python` have a real, loadable Skill-tool catalog entry.
+It carries no operational instructions and is never installed for real use —
+core stays overlay-agnostic; a real environment supplies its own real Python
+companion bible under its own name.

--- a/evals/fixtures/skill_catalog/skills/backend-dev/SKILL.md
+++ b/evals/fixtures/skill_catalog/skills/backend-dev/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: backend-dev
+description: "EVAL FIXTURE. Stand-in for a hypothetical overlay's project dev skill (backend/Django flavour) — the standing companion skill loaded alongside the coding/reviewing phase skill for its backend repos. Placeholder only — see evals/scenarios/skill_routing.yaml."
+---
+
+# backend-dev (eval fixture)
+
+This is a synthetic stand-in loaded only inside the teatree eval harness's
+isolated clean room (`teatree.eval.api_runner`), so skill-routing scenarios
+that reference `/backend-dev` have a real, loadable Skill-tool catalog entry.
+It carries no operational instructions and is never installed for real use —
+core stays overlay-agnostic; an installed overlay supplies its own real
+project dev skill under its own name.

--- a/evals/fixtures/skill_catalog/skills/frontend-dev/SKILL.md
+++ b/evals/fixtures/skill_catalog/skills/frontend-dev/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: frontend-dev
+description: "EVAL FIXTURE. Stand-in for a hypothetical overlay's project dev skill (frontend flavour) — the standing companion skill loaded alongside the coding/reviewing phase skill for its frontend repos. Placeholder only — see evals/scenarios/skill_routing.yaml."
+---
+
+# frontend-dev (eval fixture)
+
+This is a synthetic stand-in loaded only inside the teatree eval harness's
+isolated clean room (`teatree.eval.api_runner`), so skill-routing scenarios
+that reference `/frontend-dev` have a real, loadable Skill-tool catalog entry.
+It carries no operational instructions and is never installed for real use —
+core stays overlay-agnostic; an installed overlay supplies its own real
+project dev skill under its own name.

--- a/evals/fixtures/skill_catalog/skills/review/SKILL.md
+++ b/evals/fixtures/skill_catalog/skills/review/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: review
+description: "EVAL FIXTURE. Stand-in for the code-review skill named without a leading slash by a scenario that must DERIVE it applies here rather than pattern-match a literal '/t3:review' in the prompt. Placeholder only — see evals/scenarios/skill_routing.yaml."
+---
+
+# review (eval fixture)
+
+This is a synthetic stand-in loaded only inside the teatree eval harness's
+isolated clean room (`teatree.eval.api_runner`), so skill-routing scenarios
+whose prompt requires deriving the review skill (never spelling out
+`/t3:review`) have a real, loadable Skill-tool catalog entry to call. It
+carries no operational instructions and is never installed for real use —
+the real project skill is `skills/review/SKILL.md`, shipped under teatree's
+own `t3` plugin namespace.

--- a/evals/fixtures/skill_catalog/skills/t3-widget/SKILL.md
+++ b/evals/fixtures/skill_catalog/skills/t3-widget/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: t3-widget
+description: "EVAL FIXTURE. Stand-in for a hypothetical overlay's multi-repo workspace playbook skill: worktree/run/test/review wiring for its repos. Placeholder only — see evals/scenarios/skill_routing.yaml and overlay_work_requires_overlay_skill.yaml."
+---
+
+# t3-widget (eval fixture)
+
+This is a synthetic stand-in loaded only inside the teatree eval harness's
+isolated clean room (`teatree.eval.api_runner`), so skill-routing scenarios
+that reference `/t3-widget` have a real, loadable Skill-tool catalog entry.
+It carries no operational instructions and is never installed for real use —
+core stays overlay-agnostic; an installed overlay supplies its own real
+workspace-playbook skill under its own name.

--- a/evals/fixtures/skill_catalog/skills/widget-le/SKILL.md
+++ b/evals/fixtures/skill_catalog/skills/widget-le/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: widget-le
+description: "EVAL FIXTURE. Stand-in for a hypothetical overlay's legal-entity review skill, part of the declared reviewer skill set for its legal-entity repos. Placeholder only — see evals/scenarios/skill_routing.yaml."
+---
+
+# widget-le (eval fixture)
+
+This is a synthetic stand-in loaded only inside the teatree eval harness's
+isolated clean room (`teatree.eval.api_runner`), so skill-routing scenarios
+that reference `/widget-le` have a real, loadable Skill-tool catalog entry.
+It carries no operational instructions and is never installed for real use —
+core stays overlay-agnostic; an installed overlay supplies its own real
+legal-entity review skill under its own name.

--- a/evals/scenarios/overlay_work_requires_overlay_skill.yaml
+++ b/evals/scenarios/overlay_work_requires_overlay_skill.yaml
@@ -18,6 +18,10 @@
   tier: balanced
   max_turns: 4
   tools: [Skill, Bash]
+  # Widens the clean room's simulated Skill-tool catalog so /t3-widget — a
+  # name core does not itself ship — is genuinely loadable
+  # (evals/fixtures/skill_catalog); see EvalSpec.available_skills.
+  available_skills: [t3-widget]
   prompt: >-
     You are about to cold-review merge request !4120 in the overlay-managed repo
     `widget-le-service`. Skill prose does not auto-load into a review context and

--- a/evals/scenarios/skill_routing.yaml
+++ b/evals/scenarios/skill_routing.yaml
@@ -33,6 +33,10 @@
   tier: balanced
   max_turns: 4
   tools: [Skill, Bash, Edit]
+  # Widens the clean room's simulated Skill-tool catalog so /t3-widget and
+  # /backend-dev — names core does not itself ship — are genuinely loadable
+  # (evals/fixtures/skill_catalog); see EvalSpec.available_skills.
+  available_skills: [t3-widget, backend-dev, frontend-dev]
   prompt: >-
     You are about to implement a backend feature in the overlay repo
     `widget-product` (a Django service). This overlay declares its standing
@@ -56,6 +60,11 @@
   tier: balanced
   max_turns: 5
   tools: [Skill, Bash]
+  # Widens the clean room's simulated Skill-tool catalog so /t3-widget,
+  # /widget-le, /backend-dev, and the review skill — names core does not
+  # itself ship inside this isolated run — are genuinely loadable
+  # (evals/fixtures/skill_catalog); see EvalSpec.available_skills.
+  available_skills: [t3-widget, widget-le, backend-dev, review]
   prompt: >-
     You are about to review a merge request in the overlay repo
     `widget-le-service`. The active overlay declares the reviewer's skill set
@@ -106,6 +115,12 @@
   tier: balanced
   max_turns: 4
   tools: [Skill, Bash]
+  # Widens the clean room's simulated Skill-tool catalog so /ac-django — a
+  # name core does not itself ship (it is the generic Django companion bible,
+  # not a teatree skill) — is genuinely loadable, matching the (ac-django|
+  # code|teatree) matcher's first alternative (evals/fixtures/skill_catalog);
+  # see EvalSpec.available_skills.
+  available_skills: [ac-django]
   prompt: >-
     You are about to implement a small change inside the `souliane/teatree`
     repo itself — teatree is its own Django project, not an overlay repo, and
@@ -132,6 +147,11 @@
   tier: balanced
   max_turns: 5
   tools: [Skill, Bash, Edit]
+  # Widens the clean room's simulated Skill-tool catalog so /t3-widget,
+  # /backend-dev, and /ac-django — names core does not itself ship — are
+  # genuinely loadable (evals/fixtures/skill_catalog); see
+  # EvalSpec.available_skills.
+  available_skills: [t3-widget, backend-dev, ac-django]
   prompt: >-
     You are about to add a Django model field plus migration in the overlay
     repo `widget-product` (a Django/DRF service). The full skill set for this
@@ -162,6 +182,13 @@
   tier: balanced
   max_turns: 5
   tools: [Skill, Bash, Edit]
+  # Widens the clean room's simulated Skill-tool catalog so /t3-widget,
+  # /backend-dev, and /ac-python — names core does not itself ship — are
+  # genuinely loadable (evals/fixtures/skill_catalog); see
+  # EvalSpec.available_skills. ac-python is included even though the prompt
+  # withholds it (GENERALIZATION) so a correct DERIVATION still finds a real
+  # catalog entry to call.
+  available_skills: [t3-widget, backend-dev, ac-python]
   prompt: >-
     You are about to implement a CLI entrypoint in the overlay repo
     `widget-microservice` — a standalone Python service with NO Django (no
@@ -191,6 +218,13 @@
   tier: balanced
   max_turns: 5
   tools: [Skill, Bash]
+  # Widens the clean room's simulated Skill-tool catalog so /t3-widget and the
+  # review skill — names core does not itself ship inside this isolated run —
+  # are genuinely loadable (evals/fixtures/skill_catalog); see
+  # EvalSpec.available_skills. t3-widget is included even though the prompt
+  # withholds it (GENERALIZATION) so a correct DERIVATION still finds a real
+  # catalog entry to call.
+  available_skills: [t3-widget, backend-dev, review]
   prompt: >-
     You are about to cold-review a merge request in the overlay repo
     `widget-product`. The active overlay declares the reviewer's skill set
@@ -232,6 +266,11 @@
   tier: balanced
   max_turns: 4
   tools: [Skill, Bash]
+  # Widens the clean room's simulated Skill-tool catalog so the review skill —
+  # a name core's own review agent embodies but did not necessarily register
+  # in this isolated run's catalog — is genuinely loadable
+  # (evals/fixtures/skill_catalog); see EvalSpec.available_skills.
+  available_skills: [review]
   prompt: >-
     You are about to cold-review a branch in the `souliane/teatree` repo
     itself — teatree is its own Django project, not an overlay repo, and no

--- a/evals/scenarios/skill_routing.yaml
+++ b/evals/scenarios/skill_routing.yaml
@@ -119,8 +119,10 @@
   # name core does not itself ship (it is the generic Django companion bible,
   # not a teatree skill) — is genuinely loadable, matching the (ac-django|
   # code|teatree) matcher's first alternative (evals/fixtures/skill_catalog);
-  # see EvalSpec.available_skills.
-  available_skills: [ac-django]
+  # see EvalSpec.available_skills. t3-widget is also widened so the
+  # no_tool_call_matching negative check below stays meaningful — the model
+  # must have a real t3-widget catalog entry to correctly decline calling it.
+  available_skills: [ac-django, t3-widget]
   prompt: >-
     You are about to implement a small change inside the `souliane/teatree`
     repo itself — teatree is its own Django project, not an overlay repo, and
@@ -187,8 +189,10 @@
   # genuinely loadable (evals/fixtures/skill_catalog); see
   # EvalSpec.available_skills. ac-python is included even though the prompt
   # withholds it (GENERALIZATION) so a correct DERIVATION still finds a real
-  # catalog entry to call.
-  available_skills: [t3-widget, backend-dev, ac-python]
+  # catalog entry to call. ac-django is also widened so the no_tool_call_
+  # matching negative check below stays meaningful — the model must have a
+  # real ac-django catalog entry available to correctly decline it.
+  available_skills: [t3-widget, backend-dev, ac-python, ac-django]
   prompt: >-
     You are about to implement a CLI entrypoint in the overlay repo
     `widget-microservice` — a standalone Python service with NO Django (no
@@ -269,8 +273,11 @@
   # Widens the clean room's simulated Skill-tool catalog so the review skill —
   # a name core's own review agent embodies but did not necessarily register
   # in this isolated run's catalog — is genuinely loadable
-  # (evals/fixtures/skill_catalog); see EvalSpec.available_skills.
-  available_skills: [review]
+  # (evals/fixtures/skill_catalog); see EvalSpec.available_skills. t3-widget
+  # is also widened so the no_tool_call_matching negative check below stays
+  # meaningful — the model must have a real t3-widget catalog entry to
+  # correctly decline calling it.
+  available_skills: [review, t3-widget]
   prompt: >-
     You are about to cold-review a branch in the `souliane/teatree` repo
     itself — teatree is its own Django project, not an overlay repo, and no

--- a/src/teatree/eval/api_runner.py
+++ b/src/teatree/eval/api_runner.py
@@ -45,7 +45,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 from claude_agent_sdk import AgentDefinition, ClaudeAgentOptions, Message, query
-from claude_agent_sdk.types import EffortLevel
+from claude_agent_sdk.types import EffortLevel, SdkPluginConfig
 
 from teatree.eval.api_errors import (
     BUDGET_EXCEEDED_REASON,
@@ -203,6 +203,20 @@ MAX_BUDGET_USD = "0.10"
 FALLBACK_MODEL = "claude-sonnet-5"
 EMPTY_SETTINGS = '{"hooks":{}}'
 
+#: Local-plugin path (relative to the teatree repo root) for the eval-only
+#: skill-catalog fixture: synthetic ``SKILL.md`` stand-ins for names a
+#: skill-routing scenario's prompt references that core does not itself ship —
+#: a placeholder overlay's workspace/legal-entity skill, a companion language
+#: bible, the review skill named without a leading slash. Registered ONLY for a
+#: scenario that declares ``EvalSpec.available_skills`` (see
+#: :func:`_skill_catalog_fixture_plugin`); every scenario that declares none
+#: never loads it, so the isolation guarantee (no personal/project context bias)
+#: is unchanged for the existing catalog. It carries no ``hooks.json`` of its
+#: own, so loading it cannot resurrect the ``UserPromptSubmit`` skill-suggestion
+#: hook the ``settings=EMPTY_SETTINGS`` isolation already suppresses — the exact
+#: hook these scenarios' prompts say "did not fire" to force a genuine self-load.
+_SKILL_CATALOG_FIXTURE_RELATIVE_PATH = ("evals", "fixtures", "skill_catalog")
+
 #: Typed alias callers may ``raise``/``except`` against. The SDK raises a bare
 #: ``Exception`` for the budget breaker, so the runner ALSO matches the message
 #: substring — this alias only types the direct-raise path, never narrows it.
@@ -286,6 +300,28 @@ class CleanRoomConfig:
     #: subagent for a scenario whose toolset exposes the spawn tool
     #: (:func:`scenario_exposes_subagent_spawn`).
     agents: dict[str, AgentDefinition] | None = None
+    #: Skill names to widen the simulated Skill-tool catalog with (the SDK's
+    #: ``skills`` context filter), sourced from ``EvalSpec.available_skills``.
+    #: Empty (the default) leaves ``ClaudeAgentOptions.skills``/``plugins`` at
+    #: their untouched defaults, so a scenario declaring none is byte-identical
+    #: to before this field existed — this is a WIDENING lever, never a
+    #: narrowing one. Non-empty registers the eval-only fixture plugin
+    #: (:data:`_SKILL_CATALOG_FIXTURE_RELATIVE_PATH`) so the named skills are
+    #: genuinely discoverable, then filters the listing to exactly this set.
+    skills: tuple[str, ...] = ()
+
+
+def _skill_catalog_fixture_plugin() -> SdkPluginConfig:
+    """The local-plugin config for the eval-only skill-catalog fixture.
+
+    Resolved against :func:`_teatree_root`, not the process cwd, so it resolves
+    correctly whether the eval CLI runs from teatree's own root or a scenario's
+    isolated temp dir (the sub-agent-spawning lane's ephemeral checkout never
+    reaches this — none of the ``available_skills``-declaring scenarios expose
+    the ``Agent`` spawn tool).
+    """
+    path = _teatree_root().joinpath(*_SKILL_CATALOG_FIXTURE_RELATIVE_PATH)
+    return {"type": "local", "path": str(path)}
 
 
 def build_sdk_options(config: CleanRoomConfig) -> ClaudeAgentOptions:
@@ -315,6 +351,13 @@ def build_sdk_options(config: CleanRoomConfig) -> ClaudeAgentOptions:
     spawn tool genuinely usable: a delegation scenario exposes ``Agent`` in its
     allowlist AND ships a sub-agent definition, mirroring how the real agent gets
     its sub-agents. ``None`` (the default) is the judge/non-delegation shape.
+
+    ``skills``/``plugins`` widen the simulated Skill-tool catalog for a scenario
+    that declares ``config.skills`` (threaded from ``EvalSpec.available_skills``):
+    the eval-only fixture plugin is registered and the listing filtered to
+    exactly the declared names. Empty ``config.skills`` (the default) renders
+    ``skills=None`` and ``plugins=[]`` — the SDK's own untouched defaults, so a
+    scenario declaring none is byte-identical to before this lever existed.
     """
     available = list(config.available_tools) if config.available_tools else None
     return ClaudeAgentOptions(
@@ -335,6 +378,8 @@ def build_sdk_options(config: CleanRoomConfig) -> ClaudeAgentOptions:
         model=config.model,
         fallback_model=FALLBACK_MODEL,
         effort=config.effort,
+        skills=list(config.skills) if config.skills else None,
+        plugins=[_skill_catalog_fixture_plugin()] if config.skills else [],
     )
 
 
@@ -503,6 +548,7 @@ class ApiInProcessRunner:
                     max_turns=max_turns,
                     effort=effort,
                     max_budget_usd=max_budget_usd,
+                    skills=spec.available_skills,
                 )
             )
             return await asyncio.wait_for(_collect(build_user_prompt(spec), options), timeout=watchdog)

--- a/src/teatree/eval/loader.py
+++ b/src/teatree/eval/loader.py
@@ -84,6 +84,7 @@ def _parse_spec(entry: object, path: Path, default_agent_path: str | None) -> Ev
     max_turns = _parse_max_turns(spec_map, name, path)
     tools = _parse_tools(spec_map, name, path)
     agent_sections = _parse_agent_sections(spec_map, name, path)
+    available_skills = _parse_available_skills(spec_map, name, path)
     return EvalSpec(
         name=name,
         scenario=scenario,
@@ -103,6 +104,7 @@ def _parse_spec(entry: object, path: Path, default_agent_path: str | None) -> Ev
         context_preamble=str(spec_map.get("context_preamble") or ""),
         max_budget_usd=_parse_positive_float(spec_map, "max_budget_usd", name, path),
         watchdog_seconds=_parse_positive_float(spec_map, "watchdog_seconds", name, path),
+        available_skills=available_skills,
     )
 
 
@@ -206,6 +208,24 @@ def _parse_agent_sections(entry: Mapping[str, Any], spec_name: str, path: Path) 
     if not isinstance(raw, list) or not raw or not all(isinstance(s, str) and s.strip() for s in raw):
         raise EvalSpecError(
             path, None, f"spec {spec_name!r}: `agent_sections` must be a non-empty list of section-heading strings"
+        )
+    return tuple(raw)
+
+
+def _parse_available_skills(entry: Mapping[str, Any], spec_name: str, path: Path) -> tuple[str, ...]:
+    """Parse the optional ``available_skills`` catalog-widening list, or ``()``.
+
+    Mirrors :func:`_parse_agent_sections`: absent means "widen nothing" (every
+    existing scenario is unaffected), present must be a non-empty list of
+    non-blank strings — a fat-fingered empty list is a spec error, not a silent
+    no-op, since an author who wrote the key meant to widen the catalog.
+    """
+    raw = entry.get("available_skills")
+    if raw is None:
+        return ()
+    if not isinstance(raw, list) or not raw or not all(isinstance(s, str) and s.strip() for s in raw):
+        raise EvalSpecError(
+            path, None, f"spec {spec_name!r}: `available_skills` must be a non-empty list of skill-name strings"
         )
     return tuple(raw)
 

--- a/src/teatree/eval/models.py
+++ b/src/teatree/eval/models.py
@@ -230,6 +230,19 @@ class EvalSpec:
     phase: str = ""
     max_turns: int = DEFAULT_MAX_TURNS
     tools: tuple[str, ...] = ("Bash",)
+    #: Skill names to widen the clean-room's simulated Skill-tool catalog with, on
+    #: top of whatever the CLI discovers on its own. Empty (the default) leaves the
+    #: SDK ``skills``/``plugins`` options untouched, so every existing scenario is
+    #: byte-identical to before this field existed. A scenario whose prompt
+    #: references a skill name core does not itself ship — a placeholder overlay's
+    #: workspace/legal-entity skill, a companion language bible (``ac-django`` /
+    #: ``ac-python``), or the review skill named without a leading slash — declares
+    #: the referenced names here so the runner registers the eval-only fixture
+    #: plugin (``evals/fixtures/skill_catalog``) and lists exactly this set: the
+    #: agent's own "only invoke a listed name" refusal rule is real and must stay
+    #: intact, so the fix widens what is listed rather than bypassing the rule. See
+    #: ``teatree.eval.api_runner.build_sdk_options``.
+    available_skills: tuple[str, ...] = ()
     #: Opt-in throwaway sandbox fixture (``""`` = the neutral empty cwd). A scenario
     #: whose prompt presupposes a working tree (staged changes, commits to squash)
     #: declares ``fixture: git_repo`` so the runner provisions a real repo whose

--- a/tests/eval_replay/test_loader.py
+++ b/tests/eval_replay/test_loader.py
@@ -215,6 +215,49 @@ class TestLoadEvalYaml:
         with pytest.raises(EvalSpecError, match="agent_sections"):
             load_eval_yaml(_write(tmp_path, body))
 
+    def test_defaults_available_skills_to_empty(self, tmp_path: Path) -> None:
+        spec = load_eval_yaml(_write(tmp_path, _MINIMAL))[0]
+        assert spec.available_skills == ()
+
+    def test_parses_available_skills_list(self, tmp_path: Path) -> None:
+        body = (
+            "- name: widened\n"
+            "  scenario: widened scenario\n"
+            "  available_skills: [t3-widget, ac-django]\n"
+            "  prompt: do the thing\n"
+            "  expect:\n"
+            "    - tool_call: bash\n"
+            '      args.command: contains "x"\n'
+        )
+        spec = load_eval_yaml(_write(tmp_path, body))[0]
+        assert spec.available_skills == ("t3-widget", "ac-django")
+
+    def test_rejects_empty_available_skills(self, tmp_path: Path) -> None:
+        body = (
+            "- name: bad\n"
+            "  scenario: bad\n"
+            "  available_skills: []\n"
+            "  prompt: x\n"
+            "  expect:\n"
+            "    - tool_call: bash\n"
+            '      args.command: contains "x"\n'
+        )
+        with pytest.raises(EvalSpecError, match="available_skills"):
+            load_eval_yaml(_write(tmp_path, body))
+
+    def test_rejects_non_string_available_skills(self, tmp_path: Path) -> None:
+        body = (
+            "- name: bad\n"
+            "  scenario: bad\n"
+            "  available_skills: [123]\n"
+            "  prompt: x\n"
+            "  expect:\n"
+            "    - tool_call: bash\n"
+            '      args.command: contains "x"\n'
+        )
+        with pytest.raises(EvalSpecError, match="available_skills"):
+            load_eval_yaml(_write(tmp_path, body))
+
     def test_defaults_lane_to_clean_room(self, tmp_path: Path) -> None:
         spec = load_eval_yaml(_write(tmp_path, _MINIMAL))[0]
         assert spec.lane == "clean_room"

--- a/tests/eval_replay/test_skill_catalog_fixture_gap.py
+++ b/tests/eval_replay/test_skill_catalog_fixture_gap.py
@@ -1,0 +1,128 @@
+"""Regression coverage for the eval skill-catalog fixture gap.
+
+CI run 28630941573 (shard ``clean_room`` 8/15 and 9/15) reproducibly failed
+eight ``overlay_*``/``non_overlay_*`` skill-routing scenarios: each prompt
+references an overlay-placeholder or companion-bible skill name with a leading
+slash (``/t3-widget``, ``/widget-le``, ``/backend-dev``, ``/ac-django``, ...),
+or a name the agent must DERIVE (``/ac-python``, the review skill), but the
+name never appeared in the simulated agent's ambient "available skills" list
+during the eval run — so the agent's own "only invoke a listed skill" refusal
+rule correctly declined to call it. The fix widens the simulated catalog
+(``EvalSpec.available_skills`` -> ``ClaudeAgentOptions.skills``/``plugins`` via
+``evals/fixtures/skill_catalog``, see ``teatree.eval.api_runner``) rather than
+weakening that refusal rule.
+
+This module pins the FIXED STATE for each of the eight named scenarios: every
+skill name its prompt references now round-trips through the loader into
+``available_skills`` and resolves to a real fixture skill directory the SDK can
+genuinely discover.
+"""
+
+from pathlib import Path
+
+from teatree.eval.api_runner import _skill_catalog_fixture_plugin
+from teatree.eval.discovery import discover_specs
+
+#: The eight scenarios CI run 28630941573 reported failing, each mapped to the
+#: skill name(s) its prompt references that core does not itself ship. A name
+#: appearing here must appear in that scenario's ``available_skills`` AND have
+#: a real fixture skill directory — both halves of the fix.
+_EXPECTED_REFERENCED_SKILLS: dict[str, frozenset[str]] = {
+    "overlay_repo_task_loads_overlay_skill": frozenset({"t3-widget", "backend-dev"}),
+    "overlay_review_loads_overlay_review_skill_set": frozenset({"t3-widget", "widget-le", "backend-dev"}),
+    "non_overlay_task_does_not_require_overlay_skill": frozenset({"ac-django"}),
+    "overlay_django_coding_loads_companion_bible": frozenset({"t3-widget", "backend-dev", "ac-django"}),
+    "overlay_python_coding_generalizes_to_python_bible": frozenset({"t3-widget", "backend-dev", "ac-python"}),
+    "overlay_review_generalizes_to_declared_skill_set": frozenset({"t3-widget"}),
+    "non_overlay_review_does_not_load_overlay_skill": frozenset({"review"}),
+    "overlay_repo_review_loads_overlay_skill_first": frozenset({"t3-widget"}),
+}
+
+
+def _specs_by_name() -> dict[str, list]:
+    specs = discover_specs()
+    by_name: dict[str, list] = {}
+    for spec in specs:
+        by_name.setdefault(spec.name, []).append(spec)
+    return by_name
+
+
+class TestEightFailingScenariosDeclareTheirReferencedSkills:
+    def test_all_eight_scenarios_are_present_in_the_catalog(self) -> None:
+        # Anti-vacuity: if a scenario was renamed/removed, the rest of this
+        # module would vacuously pass over an empty set — fail loud instead.
+        by_name = _specs_by_name()
+        missing = set(_EXPECTED_REFERENCED_SKILLS) - set(by_name)
+        assert not missing, f"expected failing scenario(s) not found in the catalog: {sorted(missing)}"
+
+    def test_each_scenario_declares_available_skills_covering_every_referenced_name(self) -> None:
+        by_name = _specs_by_name()
+        for name, referenced in _EXPECTED_REFERENCED_SKILLS.items():
+            (spec,) = by_name[name]
+            declared = set(spec.available_skills)
+            missing = referenced - declared
+            assert not missing, f"{name}: available_skills is missing referenced skill(s) {sorted(missing)}"
+
+    def test_no_scenario_is_left_with_an_empty_available_skills(self) -> None:
+        # Every one of the eight must have SOME widening declared — an empty
+        # available_skills means the catalog gap is still open for that name.
+        by_name = _specs_by_name()
+        for name in _EXPECTED_REFERENCED_SKILLS:
+            (spec,) = by_name[name]
+            assert spec.available_skills, f"{name}: available_skills is still empty"
+
+
+class TestReferencedSkillsResolveToRealFixtureDirectories:
+    """The widening must be REAL, not just a declared name with nothing behind it."""
+
+    def test_every_referenced_skill_has_a_fixture_skill_md(self) -> None:
+        plugin_dir = Path(_skill_catalog_fixture_plugin()["path"])
+        fixture_names = {p.parent.name for p in plugin_dir.glob("skills/*/SKILL.md")}
+        every_referenced: set[str] = set()
+        for referenced in _EXPECTED_REFERENCED_SKILLS.values():
+            every_referenced.update(referenced)
+        missing = every_referenced - fixture_names
+        assert not missing, f"referenced skill(s) have no fixture SKILL.md: {sorted(missing)}"
+
+    def test_fixture_plugin_manifest_is_valid_json_with_a_name(self) -> None:
+        import json  # noqa: PLC0415
+
+        plugin_dir = Path(_skill_catalog_fixture_plugin()["path"])
+        manifest = json.loads((plugin_dir / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8"))
+        assert manifest.get("name")
+
+    def test_each_fixture_skill_md_has_a_matching_frontmatter_name(self) -> None:
+        # The SDK's `skills` filter matches "the SKILL.md name / directory
+        # name" — a mismatched frontmatter `name:` would silently break the
+        # widening for a caller that filters on the frontmatter value.
+        plugin_dir = Path(_skill_catalog_fixture_plugin()["path"])
+        for skill_md in plugin_dir.glob("skills/*/SKILL.md"):
+            text = skill_md.read_text(encoding="utf-8")
+            assert text.startswith("---\n"), skill_md
+            frontmatter = text[3 : text.index("---", 3)]
+            name_line = next((line for line in frontmatter.splitlines() if line.startswith("name:")), None)
+            assert name_line is not None, f"{skill_md}: no `name:` in frontmatter"
+            assert name_line.split(":", 1)[1].strip() == skill_md.parent.name
+
+
+class TestClaudeAgentOptionsCarryTheWidenedCatalog:
+    """End-to-end: the loaded spec's available_skills reaches the SDK options."""
+
+    def test_build_sdk_options_lists_exactly_the_declared_names(self, tmp_path: Path) -> None:
+        from teatree.eval.api_runner import CleanRoomConfig, build_sdk_options  # noqa: PLC0415
+
+        by_name = _specs_by_name()
+        (spec,) = by_name["overlay_django_coding_loads_companion_bible"]
+        config = CleanRoomConfig(
+            system_prompt="sp",
+            workspace=tmp_path,
+            cwd=str(tmp_path),
+            env={},
+            allowed_tools=("Skill", "Bash", "Edit"),
+            model="haiku",
+            max_turns=5,
+            skills=spec.available_skills,
+        )
+        options = build_sdk_options(config)
+        assert set(options.skills or []) == set(spec.available_skills)
+        assert len(options.plugins) == 1

--- a/tests/teatree_eval/test_api_runner.py
+++ b/tests/teatree_eval/test_api_runner.py
@@ -7,6 +7,7 @@ the swap is invisible to the grader. The SDK is mocked here — no metered calls
 """
 
 import asyncio
+import dataclasses
 import os
 from collections.abc import AsyncIterator
 from contextlib import contextmanager
@@ -657,6 +658,99 @@ class TestBuildSdkOptionsBudget:
         # this is the seam the benchmark's generous cap threads through.
         config = _config(tmp_path, max_budget_usd=2.5)
         assert build_sdk_options(config).max_budget_usd == pytest.approx(2.5)
+
+
+def _skills_config(tmp_path: Path, *, skills: tuple[str, ...] = ()) -> CleanRoomConfig:
+    return CleanRoomConfig(
+        system_prompt="sp",
+        workspace=tmp_path,
+        cwd=str(tmp_path),
+        env={},
+        allowed_tools=("Bash",),
+        model="haiku",
+        max_turns=3,
+        skills=skills,
+    )
+
+
+class TestBuildSdkOptionsSkillCatalog:
+    """A scenario's ``available_skills`` widens the clean room's simulated catalog.
+
+    The eval-skill-catalog fixture gap (#2630-family): a scenario prompt that
+    references a skill name core does not itself ship (a placeholder overlay's
+    workspace/legal-entity skill, a companion language bible, the review skill
+    named without a leading slash) needs that name to be genuinely LISTED, or
+    the agent's own "only invoke a listed skill" refusal correctly declines to
+    call it. This is a WIDENING lever only — a scenario declaring no
+    ``available_skills`` must see byte-identical ``ClaudeAgentOptions``.
+    """
+
+    def test_no_declared_skills_leaves_options_untouched(self, tmp_path: Path) -> None:
+        options = build_sdk_options(_skills_config(tmp_path))
+        assert options.skills is None
+        assert options.plugins == []
+
+    def test_declared_skills_populate_the_skills_filter(self, tmp_path: Path) -> None:
+        config = _skills_config(tmp_path, skills=("t3-widget", "ac-django"))
+        options = build_sdk_options(config)
+        assert options.skills == ["t3-widget", "ac-django"]
+
+    def test_declared_skills_register_the_fixture_plugin(self, tmp_path: Path) -> None:
+        config = _skills_config(tmp_path, skills=("t3-widget",))
+        options = build_sdk_options(config)
+        assert len(options.plugins) == 1
+        assert options.plugins[0]["type"] == "local"
+        assert options.plugins[0]["path"].endswith("evals/fixtures/skill_catalog")
+
+    def test_fixture_plugin_path_is_a_real_local_plugin_on_disk(self, tmp_path: Path) -> None:
+        # Anti-vacuity: the registered path must actually resolve to a real
+        # plugin directory (a valid plugin.json + at least one skill), or the
+        # widening is a no-op that still leaves the model's catalog empty.
+        from teatree.eval.api_runner import _skill_catalog_fixture_plugin  # noqa: PLC0415
+
+        plugin_dir = Path(_skill_catalog_fixture_plugin()["path"])
+        assert (plugin_dir / ".claude-plugin" / "plugin.json").is_file()
+        assert list(plugin_dir.glob("skills/*/SKILL.md")), "fixture plugin ships no skills"
+
+    def test_every_scenario_declared_skill_has_a_fixture_entry(self) -> None:
+        # Anti-drift: every skill name any shipped scenario declares via
+        # available_skills must resolve to a real fixture skill directory, or a
+        # scenario author's typo silently widens the catalog with nothing.
+        from teatree.eval.api_runner import _skill_catalog_fixture_plugin  # noqa: PLC0415
+        from teatree.eval.discovery import discover_specs  # noqa: PLC0415
+
+        plugin_dir = Path(_skill_catalog_fixture_plugin()["path"])
+        fixture_names = {p.parent.name for p in plugin_dir.glob("skills/*/SKILL.md")}
+        declared: set[str] = set()
+        for spec in discover_specs():
+            declared.update(spec.available_skills)
+        missing = declared - fixture_names
+        assert not missing, f"scenario(s) declare available_skills with no fixture entry: {sorted(missing)}"
+
+    def test_runner_threads_spec_available_skills_into_options(self, tmp_path: Path) -> None:
+        # End-to-end: EvalSpec.available_skills -> CleanRoomConfig.skills ->
+        # ClaudeAgentOptions.skills, through the real ApiInProcessRunner.run().
+        spec = _spec(tmp_path)
+        spec = dataclasses.replace(spec, available_skills=("t3-widget", "widget-le"))
+        query, captured = _fake_query([_result()])
+        with (
+            patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
+            patch("teatree.eval.api_runner.query", query),
+        ):
+            ApiInProcessRunner(workspace=tmp_path).run(spec)
+        assert captured["options"].skills == ["t3-widget", "widget-le"]
+        assert len(captured["options"].plugins) == 1
+
+    def test_runner_without_available_skills_matches_prior_behaviour(self, tmp_path: Path) -> None:
+        spec = _spec(tmp_path)
+        query, captured = _fake_query([_result()])
+        with (
+            patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
+            patch("teatree.eval.api_runner.query", query),
+        ):
+            ApiInProcessRunner(workspace=tmp_path).run(spec)
+        assert captured["options"].skills is None
+        assert captured["options"].plugins == []
 
 
 class TestCalibratedCaps:


### PR DESCRIPTION
fix(eval): widen the clean-room skill catalog for 8 skill-routing scenarios (#2940)

## What

CI run 28630941573 (clean_room shards 8/15, 9/15) reproducibly failed eight
`overlay_*`/`non_overlay_*` skill-routing scenarios in
`evals/scenarios/skill_routing.yaml` and
`evals/scenarios/overlay_work_requires_overlay_skill.yaml`. Each prompt
references a skill name (`t3-widget`, `widget-le`, `backend-dev`,
`ac-django`, `ac-python`, or the review skill named without a leading slash)
that never appeared in the isolated eval clean room's simulated Skill-tool
catalog, so the model's own only-invoke-a-listed-skill refusal rule
correctly declined every time.

- `src/teatree/eval/models.py` -- new `EvalSpec.available_skills` field.
- `src/teatree/eval/loader.py` -- parses the `available_skills:` YAML key.
- `src/teatree/eval/api_runner.py` -- `CleanRoomConfig.skills` threads
  `spec.available_skills` through `_drive`; `build_sdk_options` sets
  `ClaudeAgentOptions.skills`/`plugins` only when non-empty (empty is
  byte-identical to prior behaviour for every other scenario).
- `evals/fixtures/skill_catalog/` -- new eval-only local plugin fixture
  (stub `SKILL.md` per referenced name, no `hooks.json` so it cannot
  resurrect the `UserPromptSubmit` skill-suggestion hook these prompts
  assume did not fire).
- `evals/scenarios/skill_routing.yaml` and
  `evals/scenarios/overlay_work_requires_overlay_skill.yaml` -- all 8
  affected scenarios declare `available_skills:`.
- `evals/README.md` -- documents the new field and the fixture.
- New regression coverage: `tests/eval_replay/test_loader.py`,
  `tests/teatree_eval/test_api_runner.py::TestBuildSdkOptionsSkillCatalog`,
  `tests/eval_replay/test_skill_catalog_fixture_gap.py` (pins the fixed
  state for all 8 named scenarios).

A follow-up commit (independent `codex exec review` pass) fixed 3
negative-control matchers that widening made vacuous: a `no_tool_call_matching`
check on a skill excluded from `available_skills` can never fail, since the
model has no catalog entry to call in the first place. Those 3 scenarios now
also widen the forbidden skill so the negative check stays meaningful.

## Why

This is a fixture gap, not a model/refusal-logic problem -- the eval harness
never set `ClaudeAgentOptions.skills`/`plugins`, so 8 scenarios were failing
for a reason unrelated to the behaviour under test. The fix widens the
fixture (what names the isolated clean room offers) rather than narrowing
the model's refusal rule.

## Testing

- Confirmed genuinely RED before the fix (10 new test failures + 1 import
  error) by temporarily stashing only the production changes while keeping
  the new tests.
- Confirmed GREEN after (203 passed).
- Full targeted suites (`tests/eval_replay/`, `tests/teatree_eval/`,
  `tests/eval_harness/`, `tests/teatree_cli/eval/`): 2847 passed, 29 skipped,
  no regressions.
- Independent cold review via `codex exec review --base main` (I do not have
  Agent/Task sub-agent dispatch in this session, so this stands in for the
  sanctioned `t3:reviewer` sub-agent spawn per `/t3:ship` § "Review Gate") --
  found 3 real P2 findings (vacuous negative matchers), all fixed in the
  second commit and re-verified green.

## Open questions & assumptions

- assumed: this fix was discovered fully implemented but uncommitted in an
  orphaned worktree from a prior, now-terminated agent session; I salvaged
  it (verified RED-then-GREEN myself, rebased cleanly onto current `main`,
  no conflicts) rather than re-implementing from scratch. Assumed the
  salvaged implementation was fine to ship once independently re-verified.
- assumed: no ticket existed for this fix, so per `/t3:ship` § "Missing
  Issue Reference Policy" (own-repo case) I filed
  https://github.com/souliane/teatree/issues/2940 to track it.
- open: I lack Agent/Task sub-agent dispatch in this session, so the
  mandatory independent review was performed via `codex exec review`
  instead of a spawned `t3:reviewer` sub-agent. A maintainer may still want
  a `t3:reviewer` pass before merge.

docs: n/a -- eval-harness-only change (new field + fixture + scenario
declarations); no user-facing `t3` command, FSM state, or skill behaviour
changed.
