### PR TITLE
docs(platforms): fix gitlab.md Post Note recipe that trips its own new gate rule

### DIFF
--- a/skills/platforms/references/gitlab.md
+++ b/skills/platforms/references/gitlab.md
@@ -300,12 +300,14 @@ curl -s -X POST "https://gitlab.com/api/v4/projects/<PROJECT_ID>/merge_requests/
 
 ### Post Note
 
+Pass the body as a **literal** `-m` value in its own, single Bash call — never via `$(cat <path>)` or a heredoc. `glab mr note` has no `-F`/`--body-file` flag (`glab mr note --help` lists only `-m`/`--message`), so there is no substitution-free way to source the body from a file. Per `t3:rules` § "Never Pipe, Redirect, or Chain a gh/glab Publish Command", any `$(...)` construct — a plain `$(cat <path>)` just as much as a heredoc — carries a substitution marker that the leak gate's segment-walk treats as unresolvable, forcing a conservative scan even on a genuinely private repo. Verified directly against `teatree.hooks.public_visibility.gate_skips_for_visibility` with the destination mocked non-public: both `-m "$(cat <<'EOF' ... EOF)"` and a plain `-m "$(cat <path>)"` return `skip=False`; only a fully literal `-m` value returns `skip=True`. A single-quoted literal spans multiple lines fine on its own:
+
 ```bash
-glab mr note <MR_NUMBER> -R <REPO_PATH> -m "$(cat <<'EOF'
-Comment body here.
-EOF
-)"
+glab mr note <MR_NUMBER> -R <REPO_PATH> -m 'Comment body here.
+A second line works directly inside the quotes.'
 ```
+
+For a body too complex to embed safely as a literal argument (single quotes/backticks, markdown images), use the Python + REST API recipe below instead of `glab mr note` — it never invokes `gh`/`glab` at all, so this concern doesn't apply to it. Note it also means the banned-terms/quote-scanner gates don't scan it (they only recognise `gh`/`glab`/`git`/`curl`-led segments as a publish) — compose that body carefully.
 
 ### Post or Update Note with Images — Always Use Python
 


### PR DESCRIPTION
docs(platforms): fix gitlab.md Post Note recipe that trips its own new gate rule

Closes #2941

The gitlab.md Post Note recipe still combined a heredoc with command
substitution in the -m value -- exactly the pattern the sibling 'Never
Pipe, Redirect, or Chain a gh/glab Publish Command' rule (landed in
#2939, the same PR whose cold review flagged this contradiction)
warns against.

Verified empirically against
teatree.hooks.public_visibility.gate_skips_for_visibility with the
destination mocked non-public: a plain command-substitution read of a
file trips the same false scan as the heredoc form (skip=False on
both); only a fully literal -m value returns skip=True. glab mr note
has no -F/--body-file flag (confirmed via --help), so the fix embeds
the body literally instead of sourcing it via substitution, and
points complex bodies at the existing Python + REST API recipe below
it.

Open questions & assumptions:
- assumed: a single-quoted -m value spanning multiple lines is an
  acceptable replacement for the old multi-line mechanism -- verified
  it parses and is skip-eligible via the same probe.
- open: the Python + REST API recipe (unchanged) bypasses the
  banned-terms/quote-scanner gates entirely because a python3-led
  segment is never classified as a publish command -- flagged as a
  known limitation in the new prose, not fixed here (out of scope for
  a doc-only contradiction fix).

docs: n/a -- this commit IS the doc fix

## What

Rewrites the "Post Note" recipe in `skills/platforms/references/gitlab.md`
to pass the comment body as a literal `-m` argument instead of a
heredoc-wrapped command substitution, matching the "Never Pipe, Redirect,
or Chain a gh/glab Publish Command" rule added in #2939.

## Why

An independent cold-review pass on #2939 found the new rule and the
existing "Post Note" recipe directly contradicted each other. Both
sides were re-checked empirically against
`teatree.hooks.public_visibility.gate_skips_for_visibility` (destination
mocked non-public) before writing the fix: a plain `$(cat <path>)`
substitution trips the same false-scan as a heredoc, so the literal-`-m`
form is the only pattern verified to be skip-eligible.

## Architecture pre-check

Tactical, doc-only fix (a one-section prose rewrite in a `references/*.md`
file, no code/behavior change) -- the nine-check architecture-design gate
does not apply per its own scoping ("tactical fixes ... skip the gate").

## Independent review

An independent cold review was run via `codex exec review --base origin/main`
(a different model/tool than the implementing agent) against this diff.
Verdict: "The diff only updates documentation for GitLab MR note posting.
I did not find a discrete introduced bug that would break existing
behavior or tests." It re-derived the same `gate_skips_for_visibility`
probe results independently.
