### PR TITLE
fix(orphan-guard): fail loud on git failure instead of misclassifying ahead branches as synced

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -6459,6 +6459,10 @@ Usage: t3 teatree pr ensure-pr [OPTIONS]
  git pre-push hook for a *first* push, the branch is not yet on the
  remote — creating the PR is deferred so the push proceeds.
 
+ ``--repo`` must be a filesystem path to a git checkout, never a forge
+ slug (``owner/repo``) — validated up front so that mistake surfaces
+ as a clear error instead of a silently misclassified branch (#2937).
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --branch        TEXT                                                         │
 │ --repo          TEXT                                                         │

--- a/src/teatree/core/branch_classification.py
+++ b/src/teatree/core/branch_classification.py
@@ -128,9 +128,14 @@ def classify_branch_commits(repo: str, branch: str, target: str = "origin/main")
 
     Runs two git log invocations: one to list branch commits not on any remote
     (same as :func:`git.unsynced_commits`), one to fetch subjects on ``target``
-    for subject matching.
+    for subject matching. Both use :func:`git.run_strict` — a real git failure
+    (e.g. ``repo`` is not a filesystem path to a checkout, such as a forge
+    slug like ``owner/repo`` passed where a path is expected) raises
+    :class:`CommandFailedError` instead of returning empty output, which used
+    to be indistinguishable from "branch has no unsynced commits" and
+    misclassified a genuinely-ahead branch as synced (#2937).
     """
-    raw = git.run(
+    raw = git.run_strict(
         repo=repo,
         args=["log", branch, "--not", target, "--format=%H%x00%P%x00%s"],
     )
@@ -138,7 +143,7 @@ def classify_branch_commits(repo: str, branch: str, target: str = "origin/main")
     if not raw.strip():
         return classification
 
-    target_raw = git.run(repo=repo, args=["log", target, "--format=%s", "-n", "500"])
+    target_raw = git.run_strict(repo=repo, args=["log", target, "--format=%s", "-n", "500"])
     target_subjects = {_canonicalize_subject(line) for line in target_raw.splitlines() if line.strip()}
     target_subjects.discard("")
 

--- a/src/teatree/core/gates/orphan_guard.py
+++ b/src/teatree/core/gates/orphan_guard.py
@@ -17,6 +17,7 @@ points that keep the no-orphan invariant:
     workspace already contains orphans.
 """
 
+import logging
 from dataclasses import dataclass
 from enum import StrEnum
 
@@ -26,6 +27,8 @@ from teatree.core.clone_paths import resolve_clone_path
 from teatree.core.models import Worktree
 from teatree.utils import git
 from teatree.utils.run import CommandFailedError
+
+logger = logging.getLogger(__name__)
 
 
 class BranchStatus(StrEnum):
@@ -121,7 +124,11 @@ def find_orphans_in_workspace() -> list[BranchReport]:
     """Return orphan branches across all tracked worktrees in the workspace.
 
     Deduplicates by ``(repo, branch)`` — multiple Worktree rows sharing a
-    branch produce a single report.
+    branch produce a single report. A single worktree whose classification
+    fails (a real git error — corrupt checkout, unresolvable target ref) is
+    logged and skipped rather than aborting the whole scan (#2937): this
+    sweep spans every tracked worktree in the workspace, and one bad row
+    must not hide every other worktree's orphan status.
     """
     workspace = clone_root()
     reports: list[BranchReport] = []
@@ -134,7 +141,16 @@ def find_orphans_in_workspace() -> list[BranchReport]:
         if key in seen:
             continue
         seen.add(key)
-        report = classify_branch(str(repo_main), wt.branch)
+        try:
+            report = classify_branch(str(repo_main), wt.branch)
+        except CommandFailedError:
+            logger.warning(
+                "orphan scan: could not classify %s@%s (git command failed) — skipping",
+                repo_main,
+                wt.branch,
+                exc_info=True,
+            )
+            continue
         if report.is_orphan:
             reports.append(report)
     return reports

--- a/src/teatree/core/management/commands/pr.py
+++ b/src/teatree/core/management/commands/pr.py
@@ -60,6 +60,7 @@ from teatree.core.public_identity import MergeResult
 from teatree.core.runners.ship import resolve_and_reconcile_branch, resolve_ship_worktree
 from teatree.types import RawAPIDict
 from teatree.utils import git
+from teatree.utils.run import CommandFailedError
 
 if TYPE_CHECKING:
     from teatree.core.models.types import TicketExtra
@@ -175,6 +176,30 @@ def _dispatch_ship(
     if sync:
         return _ship_sync(ticket, title)
     return _enqueue_ship(ticket, title)
+
+
+def _validate_repo_and_resolve_branch(repo: str, repo_path: str, branch: str) -> tuple[str, EnsurePrResult | None]:
+    """Validate ``--repo`` is a real git checkout and resolve the branch to classify.
+
+    ``--repo`` must be a filesystem path, never a forge slug (``owner/repo``) —
+    ``git -C <slug>`` fails, and that failure used to be swallowed into a
+    false SYNCED classification (#2937). Returns ``(branch_name, None)`` on
+    success, or ``("", <result>)`` — the early :class:`EnsurePrResult` the
+    caller returns as-is — when validation stops the command before
+    classification.
+    """
+    if repo and not git.check(repo=repo_path, args=["rev-parse", "--is-inside-work-tree"]):
+        return "", EnsurePrResult(
+            error=(
+                f"--repo {repo!r} is not a git checkout on this filesystem. Pass a "
+                "path to a local clone or worktree (e.g. '.' or '/path/to/repo'), "
+                "not a forge slug like 'owner/repo'."
+            ),
+        )
+    branch_name = branch or git.current_branch(repo=repo_path)
+    if not branch_name or branch_name in {"HEAD", "main", "master"}:
+        return "", EnsurePrResult(skipped="not on a feature branch", branch=branch_name)
+    return branch_name, None
 
 
 class Command(TyperCommand):
@@ -316,13 +341,23 @@ class Command(TyperCommand):
         match + tree-equality checks and no open PR. When this runs inside a
         git pre-push hook for a *first* push, the branch is not yet on the
         remote — creating the PR is deferred so the push proceeds.
+
+        ``--repo`` must be a filesystem path to a git checkout, never a forge
+        slug (``owner/repo``) — validated up front so that mistake surfaces
+        as a clear error instead of a silently misclassified branch (#2937).
         """
         repo_path = repo or "."
-        branch_name = branch or git.current_branch(repo=repo_path)
-        if not branch_name or branch_name in {"HEAD", "main", "master"}:
-            return EnsurePrResult(skipped="not on a feature branch", branch=branch_name)
+        branch_name, early_result = _validate_repo_and_resolve_branch(repo, repo_path, branch)
+        if early_result is not None:
+            return early_result
 
-        report = classify_branch(repo_path, branch_name)
+        try:
+            report = classify_branch(repo_path, branch_name)
+        except CommandFailedError as exc:
+            return EnsurePrResult(
+                branch=branch_name,
+                error=f"could not determine sync status of {branch_name!r} in {repo_path!r}: {exc}",
+            )
 
         if report.status is BranchStatus.SYNCED:
             return EnsurePrResult(skipped="branch synced to default branch", branch=branch_name)

--- a/tests/teatree_core/cleanup/test_classify_branch_commits.py
+++ b/tests/teatree_core/cleanup/test_classify_branch_commits.py
@@ -2,11 +2,15 @@
 
 Split verbatim from the former monolithic ``tests/teatree_core/test_cleanup.py``
 (souliane/teatree#443). These pure-logic cases drive the classifier directly
-with a mocked ``teatree.core.cleanup.git.run``; no behavior change.
+with a mocked ``teatree.core.cleanup.git.run_strict`` (#2937: the classifier's
+git calls fail loud on a real git error, so the happy-path mock target moved
+from the lenient ``git.run`` to the strict runner); no bucketing behavior
+change.
 """
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from django.test import TestCase
 
 from teatree.core.cleanup import BranchClassification, BranchCommit, classify_branch_commits
@@ -20,13 +24,13 @@ class TestClassifyBranchCommits(TestCase):
     SHA, via squash-merge) from work that still needs pushing.
     """
 
-    @patch("teatree.core.cleanup.git.run")
+    @patch("teatree.core.cleanup.git.run_strict")
     def test_empty_when_no_unsynced_commits(self, mock_run: MagicMock) -> None:
         mock_run.side_effect = ["", ""]  # unsynced log empty, target log empty
         result = classify_branch_commits("/repo", "feature")
         assert result == BranchClassification(squash_merged=[], merge_commits=[], genuinely_ahead=[])
 
-    @patch("teatree.core.cleanup.git.run")
+    @patch("teatree.core.cleanup.git.run_strict")
     def test_subject_match_with_pr_suffix_marks_squash_merged(self, mock_run: MagicMock) -> None:
         branch_log = "abc123\x00parent1\x00fix(ui): button alignment"
         target_log = "fix(ui): button alignment (#42)\nfeat(core): unrelated"
@@ -37,7 +41,7 @@ class TestClassifyBranchCommits(TestCase):
         assert result.squash_merged == [BranchCommit(sha="abc123", subject="fix(ui): button alignment", is_merge=False)]
         assert result.genuinely_ahead == []
 
-    @patch("teatree.core.cleanup.git.run")
+    @patch("teatree.core.cleanup.git.run_strict")
     def test_strips_type_prefix_for_relax_to_feat_rewrite(self, mock_run: MagicMock) -> None:
         """Branch has ``relax: X (#140)``; main has ``feat(fsm): X (#140) (#368)`` — same content, different prefix."""
         branch_log = "def456\x00parent1\x00relax: transition-driven workflow (#140)"
@@ -50,7 +54,7 @@ class TestClassifyBranchCommits(TestCase):
         assert result.squash_merged[0].sha == "def456"
         assert result.genuinely_ahead == []
 
-    @patch("teatree.core.cleanup.git.run")
+    @patch("teatree.core.cleanup.git.run_strict")
     def test_merge_commit_detected_via_multiple_parents(self, mock_run: MagicMock) -> None:
         branch_log = "mrg001\x00parent1 parent2\x00Merge branch 'main' into feature"
         target_log = ""
@@ -63,7 +67,7 @@ class TestClassifyBranchCommits(TestCase):
         assert result.genuinely_ahead == []
         assert result.squash_merged == []
 
-    @patch("teatree.core.cleanup.git.run")
+    @patch("teatree.core.cleanup.git.run_strict")
     def test_genuinely_ahead_when_no_subject_match(self, mock_run: MagicMock) -> None:
         branch_log = "new001\x00parent1\x00fix(hooks): strip trailing whitespace"
         target_log = "chore(deps): bump pytest\nfeat(config): add t3.mode"
@@ -75,7 +79,7 @@ class TestClassifyBranchCommits(TestCase):
         assert len(result.genuinely_ahead) == 1
         assert result.genuinely_ahead[0].sha == "new001"
 
-    @patch("teatree.core.cleanup.git.run")
+    @patch("teatree.core.cleanup.git.run_strict")
     def test_mixed_buckets(self, mock_run: MagicMock) -> None:
         branch_log = (
             "sha1\x00p1\x00feat(config): add setting\n"
@@ -91,7 +95,7 @@ class TestClassifyBranchCommits(TestCase):
         assert [c.sha for c in result.merge_commits] == ["sha2"]
         assert [c.sha for c in result.genuinely_ahead] == ["sha3"]
 
-    @patch("teatree.core.cleanup.git.run")
+    @patch("teatree.core.cleanup.git.run_strict")
     def test_unsynced_fully_merged_via_squash_returns_empty_genuinely_ahead(self, mock_run: MagicMock) -> None:
         """Every unsynced commit has a subject match on target → branch is safe to clean."""
         branch_log = "sha1\x00p1\x00feat(config): generic per-overlay override\nsha2\x00p1\x00fix: trailing whitespace"
@@ -103,7 +107,7 @@ class TestClassifyBranchCommits(TestCase):
         assert result.genuinely_ahead == []
         assert len(result.squash_merged) == 2
 
-    @patch("teatree.core.cleanup.git.run")
+    @patch("teatree.core.cleanup.git.run_strict")
     def test_release_note_suffix_on_target_matches_plain_local_subject(self, mock_run: MagicMock) -> None:
         """Regression for #387 — target carries ``[flag] (url) (#NNN)``, local has only the plain subject."""
         branch_log = "sha1\x00p1\x00fix(ship,workspace): pre-push main merge + t3 pr create over raw gh/glab"
@@ -118,7 +122,7 @@ class TestClassifyBranchCommits(TestCase):
         assert [c.sha for c in result.squash_merged] == ["sha1"]
         assert result.genuinely_ahead == []
 
-    @patch("teatree.core.cleanup.git.run")
+    @patch("teatree.core.cleanup.git.run_strict")
     def test_release_note_suffix_on_both_sides_matches(self, mock_run: MagicMock) -> None:
         """Both local and target carry the release-note suffix — canonicalization must strip from both."""
         branch_log = (
@@ -136,7 +140,7 @@ class TestClassifyBranchCommits(TestCase):
         assert [c.sha for c in result.squash_merged] == ["sha1"]
         assert result.genuinely_ahead == []
 
-    @patch("teatree.core.cleanup.git.run")
+    @patch("teatree.core.cleanup.git.run_strict")
     def test_plain_subjects_without_release_note_suffix_still_match(self, mock_run: MagicMock) -> None:
         """Fallback case — neither title has a release-note suffix (e.g. ``chore:`` without ticket)."""
         branch_log = "sha1\x00p1\x00chore(prek): move pip-audit to manual stage"
@@ -147,3 +151,21 @@ class TestClassifyBranchCommits(TestCase):
 
         assert [c.sha for c in result.squash_merged] == ["sha1"]
         assert result.genuinely_ahead == []
+
+    @patch("teatree.core.cleanup.git.run_strict")
+    def test_git_failure_on_unsynced_log_propagates_instead_of_empty_classification(
+        self,
+        mock_run: MagicMock,
+    ) -> None:
+        """#2937: a git failure must raise, never silently look like "no unsynced commits"."""
+        from teatree.utils.run import CommandFailedError  # noqa: PLC0415
+
+        mock_run.side_effect = CommandFailedError(
+            cmd=["git", "-C", "owner/repo", "log", "feature", "--not", "origin/main"],
+            returncode=128,
+            stdout="",
+            stderr="fatal: cannot change to 'owner/repo': No such file or directory",
+        )
+
+        with pytest.raises(CommandFailedError):
+            classify_branch_commits("owner/repo", "feature")

--- a/tests/teatree_core/pr_command/test_ensure_pr.py
+++ b/tests/teatree_core/pr_command/test_ensure_pr.py
@@ -173,6 +173,54 @@ class TestEnsurePr(TestCase):
         assert "feat-q" in str(result["hint"])
         host.create_pr.assert_called_once()
 
+    def test_repo_flag_with_forge_slug_rejected_before_touching_classification(self) -> None:
+        """#2937.
+
+        ``--repo owner/repo`` (a forge slug, not a filesystem path) must fail
+        loud with a clear, actionable error — and never reach branch classification,
+        the path that used to silently misreport the branch as SYNCED.
+        """
+        with patch.object(pr_command, "classify_branch") as mock_classify:
+            result = cast(
+                "dict[str, object]",
+                call_command("pr", "ensure-pr", repo="owner/repo", branch="feature"),
+            )
+
+        assert "error" in result
+        assert "owner/repo" in str(result["error"])
+        mock_classify.assert_not_called()
+
+    def test_classify_branch_git_failure_surfaces_as_structured_error(self) -> None:
+        """#2937.
+
+        A real git failure during classification must surface as a
+        structured error, never an unhandled exception or a silent SYNCED skip.
+        """
+        host = MagicMock()
+        self._monkeypatch.setattr(pr_command, "code_host_from_overlay", lambda: host)
+
+        from teatree.utils.run import CommandFailedError  # noqa: PLC0415
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(pr_command.git, "current_branch", return_value="feat-r"),
+            patch.object(
+                pr_command,
+                "classify_branch",
+                side_effect=CommandFailedError(
+                    cmd=["git", "-C", ".", "log", "feat-r", "--not", "origin/main"],
+                    returncode=128,
+                    stdout="",
+                    stderr="fatal: ambiguous argument 'origin/main': unknown revision",
+                ),
+            ),
+        ):
+            result = cast("dict[str, object]", call_command("pr", "ensure-pr"))
+
+        assert "error" in result
+        assert "feat-r" in str(result["error"])
+        host.create_pr.assert_not_called()
+
     def test_other_create_pr_failure_still_raises(self) -> None:
         """A non-race create_pr failure must still surface (no silent swallow)."""
         from teatree.utils.run import CommandFailedError  # noqa: PLC0415

--- a/tests/teatree_core/test_orphan_guard.py
+++ b/tests/teatree_core/test_orphan_guard.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from teatree.core.cleanup import BranchClassification, BranchCommit
 from teatree.core.gates.orphan_guard import BranchReport, BranchStatus, classify_branch, find_orphans_in_workspace
 from teatree.core.models import Ticket, Worktree
+from teatree.utils.run import CommandFailedError
 from tests.teatree_core.cleanup._shared import _run_git
 
 _patch_classify = patch("teatree.core.gates.orphan_guard.classify_branch_commits")
@@ -191,6 +192,44 @@ class TestFindOrphansInWorkspace(TestCase):
         assert len(orphans) == 1
         assert mock_classify.call_count == 1
 
+    @patch("teatree.core.gates.orphan_guard.clone_root")
+    @patch("teatree.core.gates.orphan_guard.classify_branch")
+    def test_skips_worktree_whose_classification_fails_but_reports_the_rest(
+        self,
+        mock_classify: MagicMock,
+        mock_clone_root: MagicMock,
+    ) -> None:
+        """#2937: one worktree's git failure must not crash the whole scan."""
+        fake_workspace = MagicMock()
+
+        def _fake_div(_self: object, x: str) -> MagicMock:
+            return MagicMock(spec=Path, is_dir=lambda: True, __str__=lambda _s: f"/ws/{x}")
+
+        fake_workspace.__truediv__ = _fake_div
+        mock_clone_root.return_value = fake_workspace
+
+        self._make_worktree("org/alpha", "feat-1")
+        self._make_worktree("org/beta", "feat-2")
+
+        def classify(repo: str, branch: str) -> BranchReport:
+            if branch == "feat-1":
+                raise CommandFailedError(
+                    cmd=["git", "-C", repo, "log", branch, "--not", "origin/main"],
+                    returncode=128,
+                    stdout="",
+                    stderr="fatal: cannot change to '/ws/org/alpha': No such file or directory",
+                )
+            return BranchReport(repo=repo, branch=branch, status=BranchStatus.PUSHED_ORPHAN, ahead_count=1)
+
+        mock_classify.side_effect = classify
+
+        orphans = find_orphans_in_workspace()
+
+        branches = [o.branch for o in orphans]
+        assert "feat-1" not in branches
+        assert "feat-2" in branches
+        assert len(orphans) == 1
+
 
 class TestClassifyBranchRespectsRepoDefaultBranch:
     """Real-git integration: ``classify_branch`` must use the repo's actual default branch.
@@ -228,11 +267,15 @@ class TestClassifyBranchRespectsRepoDefaultBranch:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Fallback path — ``git.default_branch`` raises, classifier still returns a report.
+        """Fallback path — ``git.default_branch`` raises, classifier falls back to ``origin/main``.
 
         When the repo has no ``origin/HEAD`` and no known fallback name on the
-        remote, ``classify_branch`` must still return a valid report rather
-        than crashing — falls back to ``origin/main``.
+        remote, ``classify_branch`` still attempts ``origin/main``. On this
+        fixture that ref genuinely does not exist either (the remote's only
+        branch is ``master``), so the underlying ``git log ... --not
+        origin/main`` fails for real — and per #2937 that failure must
+        propagate (fail loud), never silently degrade to a possibly-wrong
+        report.
         """
         from teatree.core.gates import orphan_guard as og  # noqa: PLC0415
 
@@ -242,5 +285,25 @@ class TestClassifyBranchRespectsRepoDefaultBranch:
             raise RuntimeError(msg)
 
         monkeypatch.setattr(og.git, "default_branch", _raise)
-        report = classify_branch(str(self.clone), "feature-branch")
-        assert isinstance(report, BranchReport)
+        with pytest.raises(CommandFailedError, match="origin/main"):
+            classify_branch(str(self.clone), "feature-branch")
+
+
+class TestClassifyBranchFailsLoudOnGitFailure:
+    """#2937.
+
+    An invalid ``repo`` filesystem path must fail loud, never silently
+    misclassify a genuinely-ahead branch as SYNCED.
+
+    ``t3 <overlay> pr ensure-pr --repo <owner/repo-slug>`` passes a forge
+    slug (``owner/repo``) where a filesystem path is expected. ``git -C
+    <bad-path> log ...`` then fails, and the classifier used to swallow that
+    failure as an empty (legitimately-synced-looking) result.
+    """
+
+    def test_nonexistent_repo_path_raises_instead_of_reporting_synced(self, tmp_path: Path) -> None:
+        # Never created — mimics passing a forge slug like "owner/repo"
+        # instead of a real checkout path.
+        bad_repo = str(tmp_path / "owner" / "repo")
+        with pytest.raises(CommandFailedError):
+            classify_branch(bad_repo, "feature-branch")


### PR DESCRIPTION
fix(orphan-guard): fail loud on git failure instead of misclassifying ahead branches as synced

## What

`classify_branch_commits` used the lenient `git.run` primitive for the two
git log calls that determine a branch's "ahead" count. A real git failure
(e.g. `t3 <overlay> pr ensure-pr --repo` given a forge slug like `owner/repo`
instead of a filesystem path) was swallowed into empty output, which is
indistinguishable from "no unsynced commits" — so a genuinely-ahead branch
was reported SYNCED instead of erroring.

- `classify_branch_commits` now uses `git.run_strict` for both determining
  git log calls, so a real git failure raises `CommandFailedError` instead
  of masking as SYNCED.
- `find_orphans_in_workspace` (the broad multi-worktree sweep used by the
  session-end hook and `workspace ticket`) catches that failure per-worktree
  and skips with a logged warning, so one bad worktree never aborts the
  whole scan across every tracked ticket.
- `ensure-pr` validates `--repo` up front (`git rev-parse
  --is-inside-work-tree`) and rejects a non-checkout value with a clear
  error naming the forge-slug mistake, and converts a deeper
  `CommandFailedError` from classification into a structured
  `EnsurePrResult` error instead of an unhandled exception.

## Why

Root cause: `git_run.run()` (the lenient primitive) never raises on a
non-zero exit — by design, for callers that treat "nothing" as a legitimate
empty result. `classify_branch_commits` used it for a call where failure and
legitimate emptiness must be distinguishable; using the strict primitive
fixes that at the source, so any invalid `repo` path (not just a forge slug)
now fails loud instead of silently reporting SYNCED.

## Architecture pre-check

Tactical/logic-class bug fix (no BLUEPRINT.md / CLAUDE.md / AGENTS.md /
`src/teatree/core/merge/` touched) — scoped to the classify path + the one
CLI command it's reported against, so the full nine-check gate is not
required. Summary of the load-bearing checks that do apply:

- **Dependency direction**: no new cross-module imports beyond
  `teatree.utils.run.CommandFailedError` (already used throughout
  `management/commands/`). `uv run tach check` passes.
- **Test surface**: RED→GREEN TDD throughout — a real-git integration test
  reproduces the bug (`classify_branch` on a nonexistent repo path silently
  returned SYNCED pre-fix, now raises `CommandFailedError`), plus targeted
  tests for the `find_orphans_in_workspace` per-worktree resilience and the
  `ensure-pr` CLI's `--repo` validation / structured-error conversion.
- **Behavior preservation**: one pre-existing test
  (`test_falls_back_to_origin_main_when_default_branch_undetectable`)
  asserted `classify_branch` never crashes even when the target ref is
  fully unresolvable. That assumption was an accidental side effect of the
  swallow-all-failures primitive this PR removes — the whole point of the
  fix is that "could not determine sync status" must fail loud rather than
  guess. The resilience requirement is preserved at the correct layer
  instead: `find_orphans_in_workspace` (the broad multi-worktree sweep,
  `classify_branch`'s only other caller) now catches and skips per-worktree,
  so the "never crash the whole scan" invariant holds where it matters. The
  test was updated to assert the new fail-loud contract, with this
  justification.

## Open questions & assumptions

- Assumed (not asked): `find_orphans_in_workspace`'s per-worktree resilience
  belongs at that layer, not inside `classify_branch` itself — since
  `classify_branch`'s only two callers are this broad sweep and the single,
  explicit `ensure-pr` CLI command, and the CLI call site should fail loud
  on its own explicit request rather than silently degrade.
- Assumed (not asked): only the two git calls that determine ahead/synced
  status in `classify_branch_commits` needed to move to the strict
  primitive; the many other `git.run` call sites across the codebase are
  out of scope — they don't feed a genuinely-empty-vs-failed ambiguity into
  a data-loss-relevant classification decision the way this one did.

Closes #2937
