### PR TITLE
fix(backends): let get_code_host_for_repo fall back to gh's ambient auth

### DIFF
--- a/src/teatree/backends/github/api.py
+++ b/src/teatree/backends/github/api.py
@@ -13,7 +13,7 @@ from typing import cast
 from urllib.parse import urlparse
 
 from teatree.types import RawAPIDict
-from teatree.utils.run import CompletedProcess, run_checked
+from teatree.utils.run import CompletedProcess, run_allowed_to_fail, run_checked
 
 _ISSUE_URL_RE = re.compile(r"^/(?P<owner>[^/]+)/(?P<repo>[^/]+)/issues/(?P<number>\d+)/?$")
 
@@ -27,6 +27,21 @@ def _run_gh(*args: str, token: str = "") -> CompletedProcess[str]:
     """
     env = {**os.environ, "GH_TOKEN": token} if token else None
     return run_checked(list(args), env=env)
+
+
+def gh_ambient_auth_available() -> bool:
+    """Whether ``gh``'s own logged-in account (no explicit token) is usable.
+
+    ``gh auth status`` exits 0 when the CLI has a valid active account.
+    :func:`teatree.backends.loader.get_code_host_for_repo` uses this to fail
+    fast with a clear message instead of letting a raw ``gh`` auth error
+    surface deep inside a PR-creation call.
+    """
+    try:
+        result = run_allowed_to_fail(["gh", "auth", "status"], expected_codes=None)
+    except FileNotFoundError:
+        return False
+    return result.returncode == 0
 
 
 def _gh_api_get(endpoint: str, *, token: str = "") -> object:

--- a/src/teatree/backends/loader.py
+++ b/src/teatree/backends/loader.py
@@ -11,6 +11,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, Literal
 
 from teatree.backends.github import GitHubCodeHost
+from teatree.backends.github.api import gh_ambient_auth_available
 from teatree.backends.gitlab import GitLabCodeHost
 from teatree.backends.gitlab.api import GitLabAPI
 from teatree.backends.gitlab.ci import GitLabCIService
@@ -157,25 +158,37 @@ def get_code_host_for_repo(overlay: "OverlayBase", repo_path: str) -> CodeHostBa
     GitLab-hosted repo and ran ``gh`` against a GitLab remote (#2025).
 
     Raises :class:`BackendResolutionError` when the origin host is a
-    recognised forge but the overlay has no credentials for it — surfacing
-    the mismatch BEFORE the PR-creation attempt instead of letting a raw
-    ``gh``/``glab`` GraphQL error be the first signal. Falls back to
+    recognised forge but the overlay has no working credentials for it —
+    surfacing the mismatch BEFORE the PR-creation attempt instead of letting
+    a raw ``gh``/``glab`` GraphQL error be the first signal. Falls back to
     :func:`get_code_host` (the overlay default) only when the repo has no
     origin remote / an unrecognised host.
+
+    GitHub carve-out: an overlay with no explicitly-configured GitHub token
+    is not necessarily unauthenticated — ``_run_gh`` already inherits the
+    ambient environment (and thus ``gh``'s own logged-in account) whenever
+    no token is passed. So when the forge is GitHub and no token is
+    configured, this checks :func:`gh_ambient_auth_available` and, if it
+    passes, builds a ``GitHubCodeHost(token="")`` that relies on that
+    fallback rather than raising. GitLab has no equivalent: its REST
+    transport (``GitLabHTTPClient``) returns early on an empty token with
+    no ``glab`` call at all, so it keeps raising here.
     """
     remote = git.remote_url(repo=repo_path)
     forge = forge_from_remote(remote) if remote else ""
     if not forge:
         return get_code_host(overlay)
     backend = _host_backend(overlay, forge)
-    if backend is None:
-        msg = (
-            f"repo origin resolves to the {forge} forge ({remote!r}) but the active "
-            f"overlay has no {forge} credentials configured — cannot open a PR. "
-            f"Configure a {forge} token for this overlay."
-        )
-        raise BackendResolutionError(msg)
-    return backend
+    if backend is not None:
+        return backend
+    if forge == "github" and gh_ambient_auth_available():
+        return GitHubCodeHost(token="")
+    msg = (
+        f"repo origin resolves to the {forge} forge ({remote!r}) but the active "
+        f"overlay has no {forge} credentials configured — cannot open a PR. "
+        f"Configure a {forge} token for this overlay."
+    )
+    raise BackendResolutionError(msg)
 
 
 def get_messaging(overlay: "OverlayBase") -> MessagingBackend:

--- a/tests/teatree_backends/test_loader.py
+++ b/tests/teatree_backends/test_loader.py
@@ -325,3 +325,52 @@ class TestGetCodeHostForRepo:
         path.mkdir()
         subprocess.run([_GIT, "-C", str(path), "init", "-q", "-b", "main"], check=True, capture_output=True)
         assert isinstance(get_code_host_for_repo(overlay, str(path)), GitLabCodeHost)
+
+
+class TestGetCodeHostForRepoGithubAmbientAuth:
+    """A tokenless overlay falls back to ``gh``'s own ambient auth (#2946).
+
+    ``_run_gh`` already inherits the parent environment (and thus ``gh``'s
+    logged-in account) when no explicit token is passed — ``_host_backend``
+    used to short-circuit to ``None`` before that fallback ever got a
+    chance to run. GitLab's REST transport has no equivalent ambient-auth
+    path (see ``GitLabHTTPClient.get_json``/``post_json``), so it keeps
+    raising on an empty token.
+    """
+
+    def test_falls_back_to_ambient_auth_when_no_token_configured(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        overlay = _build_overlay()
+        _stub_token(overlay)  # no GitHub, no GitLab token configured
+        monkeypatch.setattr("teatree.backends.loader.gh_ambient_auth_available", lambda: True)
+        repo = _git_repo_with_origin(tmp_path / "gh-ambient", "git@github.com:souliane/teatree.git")
+
+        result = get_code_host_for_repo(overlay, repo)
+
+        assert isinstance(result, GitHubCodeHost)
+
+    def test_configured_token_path_is_unchanged(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        overlay = _build_overlay()
+        _stub_token(overlay, github="gh-tok")
+        # Ambient-auth check must never even run when a token is configured.
+        monkeypatch.setattr(
+            "teatree.backends.loader.gh_ambient_auth_available",
+            lambda: (_ for _ in ()).throw(AssertionError("should not probe ambient auth when a token is set")),
+        )
+        repo = _git_repo_with_origin(tmp_path / "gh-tok", "git@github.com:souliane/teatree.git")
+
+        result = get_code_host_for_repo(overlay, repo)
+
+        assert isinstance(result, GitHubCodeHost)
+
+    def test_raises_when_no_token_and_ambient_auth_unavailable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        overlay = _build_overlay()
+        _stub_token(overlay)
+        monkeypatch.setattr("teatree.backends.loader.gh_ambient_auth_available", lambda: False)
+        repo = _git_repo_with_origin(tmp_path / "gh-noauth", "git@github.com:souliane/teatree.git")
+
+        with pytest.raises(BackendResolutionError, match="github"):
+            get_code_host_for_repo(overlay, repo)

--- a/tests/test_github_backend.py
+++ b/tests/test_github_backend.py
@@ -11,7 +11,14 @@ import teatree.backends.github.client as github_mod
 import teatree.backends.github.projects as github_projects_mod
 import teatree.utils.run as utils_run_mod
 from teatree.backends.github import GitHubCodeHost, ProjectItem, fetch_project_items, issue_repo_short
-from teatree.backends.github.api import _gh_api_get, _gh_api_get_paginated, _gh_api_patch, _gh_api_post, _run_gh
+from teatree.backends.github.api import (
+    _gh_api_get,
+    _gh_api_get_paginated,
+    _gh_api_patch,
+    _gh_api_post,
+    _run_gh,
+    gh_ambient_auth_available,
+)
 from teatree.backends.github.projects import _gh_graphql
 from teatree.core.backend_protocols import PullRequestSpec
 
@@ -57,6 +64,23 @@ class TestRunGh:
             _run_gh("gh", "version")
         env = mock_run.call_args.kwargs.get("env")
         assert env is None or "GH_TOKEN" not in env
+
+
+class TestGhAmbientAuthAvailable:
+    def test_true_when_gh_auth_status_succeeds(self) -> None:
+        with patch.object(utils_run_mod.subprocess, "run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(["gh", "auth", "status"], 0, "", "")
+            assert gh_ambient_auth_available() is True
+        assert mock_run.call_args.args[0] == ["gh", "auth", "status"]
+
+    def test_false_when_gh_auth_status_fails(self) -> None:
+        with patch.object(utils_run_mod.subprocess, "run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(["gh", "auth", "status"], 1, "", "not logged in")
+            assert gh_ambient_auth_available() is False
+
+    def test_false_when_gh_not_installed(self) -> None:
+        with patch.object(utils_run_mod.subprocess, "run", side_effect=FileNotFoundError):
+            assert gh_ambient_auth_available() is False
 
 
 class TestGhApiGet:


### PR DESCRIPTION
## Summary

`get_code_host_for_repo` (`src/teatree/backends/loader.py`) raised `BackendResolutionError` whenever an overlay had no explicitly-configured GitHub token, even when `gh`'s own ambient authentication (its active logged-in account) was perfectly usable.

**Root cause.** `_host_backend()` did `return GitHubCodeHost(token=token) if token else None` — an empty token short-circuited to `None` before a host was ever constructed. The transport layer already handled this correctly: `_run_gh` does `env = {**os.environ, "GH_TOKEN": token} if token else None` — an empty token means `env=None`, so the subprocess inherits the parent environment and `gh`'s own ambient auth applies. `_host_backend` never let that fallback run.

## What changed

- Added `gh_ambient_auth_available()` in `backends/github/api.py` — a cheap `gh auth status` probe.
- `get_code_host_for_repo` now: if the forge is GitHub and no token is configured, checks `gh_ambient_auth_available()`; if it's usable, builds `GitHubCodeHost(token="")` (relying on the existing `_run_gh` fallback) instead of raising. Still raises `BackendResolutionError` when ambient auth is also unavailable, so the fail-fast UX is preserved for the genuinely-broken-auth case.
- `_host_backend` itself, `get_code_host`, and `get_code_hosts` (the multi-host auto-mode resolvers) are **untouched** — their does-a-token-exist semantics are correct there (deciding which hosts to include when auto-detecting across both forges).

## GitHub vs GitLab — why GitLab is unchanged

I checked GitLab's transport before extending the same fallback there, and it doesn't have an equivalent:

- GitLab's REST client (`GitLabHTTPClient` in `backends/gitlab/api.py`) requires a `PRIVATE-TOKEN` header. `get_json`/`post_json`/etc. all start with `if not self.token: return None` — with no token, they never even shell out to `glab`. Building a tokenless `GitLabCodeHost` here would make PR creation (`create_pr` → `post_json(...) or {}`) silently return `{}` (no error field) instead of failing loudly.
- GitLab's separate merge-RPC surface (`glab_runner()` in `backends/forge_merge_rpc.py`, used for the 5 keystone-merge methods) *does* already rely purely on ambient `glab` auth with no token plumbed at all — but that's a different code path from PR creation, and it was already ambient-auth-only before this change.

So GitLab's `get_code_host_for_repo` behavior (raise on no token) stays exactly as it was — extending the same "construct anyway" shortcut there would trade a clear error for a silent no-op.

## The still-broken-auth case

When the forge is GitHub, no token is configured, *and* `gh auth status` also fails, `get_code_host_for_repo` still raises `BackendResolutionError` with the same message as before. I considered letting a raw `gh` error surface instead (the "fix the CLI, don't work around it" argument — `gh`'s own auth error is a fine signal), but kept the cheap preflight check since it costs one subprocess call and preserves the original intent of this function: fail *before* attempting the PR creation with a clear message, not deep inside a `gh` invocation.

## Testing

- `tests/test_github_backend.py::TestGhAmbientAuthAvailable` — `gh auth status` success/failure/gh-not-installed.
- `tests/teatree_backends/test_loader.py::TestGetCodeHostForRepoGithubAmbientAuth`:
  - tokenless overlay + ambient auth valid → builds a working `GitHubCodeHost`, no raise.
  - configured-token path is unchanged (asserts the ambient-auth probe never even runs when a token is set).
  - tokenless overlay + ambient auth unavailable → still raises `BackendResolutionError`.
- Full regression suite: `uv run pytest --no-cov -q` → 22573 passed, 44 skipped, 5 xfailed (1 unrelated pre-existing flaky failure in `test_schema_guard_migrate.py` — an execnet/xdist teardown warning under parallel load, confirmed to pass in isolation and unrelated to this diff).

## Architecture pre-check

Tactical bug fix — narrow, single-function change to an existing resolution helper behind the unchanged `CodeHostBackend` Protocol. No FSM/extension-point/dependency-direction changes; `uv run tach check` passes clean.
