### PR TITLE
fix(hooks): recognize python REST clients as a publish surface for the banned-terms/quote-scanner gate

### DIFF
--- a/src/teatree/hooks/_command_parser.py
+++ b/src/teatree/hooks/_command_parser.py
@@ -43,6 +43,7 @@ from teatree.hooks._publish_detection import (
     segment_is_substring_publish,
     segment_word_lists,
 )
+from teatree.hooks._python_rest_detection import command_has_python_rest_publish_surface, is_python_leader
 from teatree.hooks._shell_lexer import Token, TokenKind, split_commands, tokenize
 
 if TYPE_CHECKING:
@@ -172,11 +173,19 @@ def is_publish_command(command: str) -> bool:
         the ``git [global-flags] commit`` after a ``-C``/``--git-dir`` flag and the
         raw-REST ``gh``/``glab api`` WRITE (effective method ≠ GET) regardless of
         flag ordering. A read-only ``gh``/``glab api`` GET is NOT a publish (#1530).
+    - a python REST-publish segment
+        (:func:`_publish_detection.command_has_python_rest_publish_surface`) --
+        a ``python3``/``python``-led segment POSTing/PATCHing to a forge REST
+        API (``requests``/``httpx``/``urllib``/a raw ``http.client`` call),
+        the SAME write-method + forge-target shape as ``gh``/``glab api``,
+        just authored in Python instead of CLI flags (#2943 gap).
     """
     for words in segment_word_lists(command):
         if segment_is_substring_publish(words) or _segment_is_t3_publish(words):
             return True
-    return command_has_token_aware_publish_surface(command)
+    if command_has_token_aware_publish_surface(command):
+        return True
+    return command_has_python_rest_publish_surface(command)
 
 
 # Per-command argument-walker dispatch tables --------------------------
@@ -324,6 +333,25 @@ def _walk_curl_args(words: list[str], payloads: list[str]) -> None:
         attached_long = _curl_long_flag_attached(word)
         if attached_long is not None:
             _record_curl_value(attached_long, payloads)
+        i += 1
+
+
+def _walk_python_script(words: list[str], payloads: list[str]) -> None:
+    """Extract a python ``-c "<script>"`` inline script argument as a payload.
+
+    Python owns no ``--body``/``--file`` grammar of its own, so the generic
+    body-flag/file walkers never see the script text a REST-publish call
+    lives in. A heredoc-fed script's body is captured separately (and
+    unconditionally, regardless of leader) by :func:`extract_bash_payload`'s
+    heredoc-body pass -- this walker covers only the ``-c`` inline form.
+    """
+    i = 0
+    n = len(words)
+    while i < n:
+        if words[i] == "-c" and i + 1 < n:
+            payloads.append(words[i + 1])
+            i += 2
+            continue
         i += 1
 
 
@@ -490,6 +518,8 @@ def _walk_command_segment(segment: list[Token], payloads: list[str], ctx: "BodyF
         _walk_api_fields(words, raws, payloads, ctx.base)
     if first == "curl":
         _walk_curl_args(words, payloads)
+    if is_python_leader(first):
+        _walk_python_script(words, payloads)
 
 
 # ── Body extraction ─────────────────────────────────────────────────

--- a/src/teatree/hooks/_command_parser.py
+++ b/src/teatree/hooks/_command_parser.py
@@ -43,7 +43,11 @@ from teatree.hooks._publish_detection import (
     segment_is_substring_publish,
     segment_word_lists,
 )
-from teatree.hooks._python_rest_detection import command_has_python_rest_publish_surface, is_python_leader
+from teatree.hooks._python_rest_detection import (
+    command_has_python_rest_publish_surface,
+    is_python_leader,
+    segment_is_python_rest_publish,
+)
 from teatree.hooks._shell_lexer import Token, TokenKind, split_commands, tokenize
 
 if TYPE_CHECKING:
@@ -343,7 +347,12 @@ def _walk_python_script(words: list[str], payloads: list[str]) -> None:
     body-flag/file walkers never see the script text a REST-publish call
     lives in. A heredoc-fed script's body is captured separately (and
     unconditionally, regardless of leader) by :func:`extract_bash_payload`'s
-    heredoc-body pass -- this walker covers only the ``-c`` inline form.
+    heredoc-body pass -- this walker covers only the ``-c`` inline form. The
+    caller gates this on :func:`_python_rest_detection.segment_is_python_rest_publish`
+    so an unrelated python ``-c`` one-liner (a local computation, a secret
+    read for LOCAL use) is never dumped into the wide secret-scan surface
+    :func:`extract_secret_scan_text` runs regardless of destination (#2943
+    review finding: gating on the leader alone over-widened that surface).
     """
     i = 0
     n = len(words)
@@ -518,7 +527,14 @@ def _walk_command_segment(segment: list[Token], payloads: list[str], ctx: "BodyF
         _walk_api_fields(words, raws, payloads, ctx.base)
     if first == "curl":
         _walk_curl_args(words, payloads)
-    if is_python_leader(first):
+    # Gated on the ACTUAL classification (write verb + forge URL), not merely
+    # the python leader: ``extract_bash_payload`` also backs
+    # ``extract_secret_scan_text``, which runs on EVERY Bash command
+    # regardless of destination -- an unconditional append here would dump
+    # any unrelated python ``-c`` one-liner's full source (a local
+    # computation, a secret read for LOCAL use) into that wide surface and
+    # false-block it as a "publish payload" it never was.
+    if is_python_leader(first) and segment_is_python_rest_publish(words, " ".join(words)):
         _walk_python_script(words, payloads)
 
 

--- a/src/teatree/hooks/_python_rest_detection.py
+++ b/src/teatree/hooks/_python_rest_detection.py
@@ -1,0 +1,158 @@
+r"""Python REST-publish detection for the pre-publish gates (#2943 gap).
+
+``_command_parser.is_publish_command`` gated ALL scanning (banned-terms
+#1415, quote-scanner #1213) on a leader-keyed catalogue of ``gh``/``glab``/
+``git``/``curl`` shapes -- a ``python3``/``python``-led segment POSTing/
+PATCHing to a forge REST API (``requests``/``httpx``/``urllib``/a raw
+``http.client`` call) was never recognised as a publish action at all, so
+the leak-prevention scan never ran against it, on ANY repo, public or
+private (the "Post or Update Note with Images" recipe in
+``skills/platforms/references/gitlab.md``, added by #2943, is exactly this
+shape).
+
+``segment_is_python_rest_publish`` / ``command_has_python_rest_publish_surface``
+generalise the SAME write-method + forge-target two-part test
+``_publish_detection.segment_is_api_write`` already applies to a ``gh``/
+``glab api`` call, to a script the CLI-specific argument walkers cannot
+parse a ``--repo``/URL flag out of: a python REST client hitting a forge's
+REST API is structurally the same shape as a raw ``curl`` POST, just
+authored in Python instead of CLI flags.
+
+``find_python_forge_rest_urls`` is the shared URL-shape resolver: it mirrors
+the ``gh api``/``glab api`` ``repos/``/``projects/`` path resolution
+(``publish_destination._destination_from_api``) so both the write-verb
+classifier here (existence check) and ``publish_destination`` (slug
+extraction) stay in lock-step.
+
+Split out of ``_publish_detection`` to keep that module under the project's
+per-file public-function ceiling (``scripts/hooks/check_module_health.py``).
+"""
+
+import re
+from collections.abc import Iterator
+from pathlib import PurePosixPath
+from typing import Final
+
+from teatree.hooks._publish_detection import segment_word_lists
+
+# A ``python3``/``python``-led segment is structurally the same publish shape
+# ``segment_is_api_write`` already recognises for ``gh api``/``glab api`` -- a
+# write verb plus a forge-targeted endpoint -- just authored in Python
+# instead of CLI flags.
+_PYTHON_LEADER_RE: Final[re.Pattern[str]] = re.compile(r"python\d*(?:\.\d+)?")
+
+
+def is_python_leader(word: str) -> bool:
+    """Return True iff ``word`` names a python interpreter, bare or path-qualified.
+
+    Matches ``python``, ``python3``, ``python3.11`` and a path-qualified form
+    (``/usr/bin/python3``) via the basename, mirroring how ``t3`` path-form
+    leaders are canonicalised elsewhere. A merely-prefixed word (``pythonic``,
+    ``python-is-fun``) is rejected by requiring a FULL match on the basename.
+    """
+    return bool(_PYTHON_LEADER_RE.fullmatch(PurePosixPath(word).name))
+
+
+# GitHub's ``repos/<owner>/<repo>`` path alone is too generic a shape to trust
+# on an arbitrary host, so GitHub resolution additionally requires the URL's
+# host be a recognised GitHub endpoint. GitLab's versioned
+# ``api/v<N>/projects/<url-encoded-slug>`` path is distinctive enough to trust
+# regardless of host -- this is what lets a self-hosted GitLab instance
+# resolve the same way ``gitlab.com`` does, with no host allowlist / config
+# lookup needed in this pure-detection module (a configured self-hosted
+# GitLab host's PRIVACY is a ``publish_destination``/``private_repos``
+# concern, not a detection-shape one).
+_GITHUB_REST_HOSTS: Final[frozenset[str]] = frozenset({"github.com", "api.github.com"})
+_GITHUB_REPOS_URL_RE: Final[re.Pattern[str]] = re.compile(
+    r"^https?://(?P<host>[^/\s'\"]+)/(?:api/v\d+/)?repos/(?P<slug>[^/\s'\"]+/[^/\s'\"]+)",
+)
+_GITLAB_PROJECTS_URL_RE: Final[re.Pattern[str]] = re.compile(
+    r"^https?://[^/\s'\"]+/api/v\d+/projects/(?P<slug>[^/\s'\"?]+)",
+)
+_URL_LITERAL_RE: Final[re.Pattern[str]] = re.compile(r"https?://[^\s'\"]+")
+
+
+def find_python_forge_rest_urls(source: str) -> Iterator[tuple[str, str]]:
+    """Yield ``(forge, slug)`` for each forge-shaped REST URL literal in ``source``.
+
+    Mirrors the ``gh api``/``glab api`` URL-path resolution
+    (``publish_destination._destination_from_api``) applied to a URL LITERAL
+    embedded in a python REST script, so both a raw-REST CLI call and a python
+    REST client resolve their target the same way. Shared by the write-verb
+    classifier below (existence check) and ``publish_destination`` (slug
+    extraction), so the two stay in lock-step. A dynamically-built URL
+    (string concatenation, an f-string variable) carries no literal
+    ``https?://`` substring and yields nothing -- the target is genuinely
+    unresolvable, not private, so callers must treat it as PUBLIC/unproven
+    rather than infer privacy from a shape it cannot read.
+    """
+    for match in _URL_LITERAL_RE.finditer(source):
+        url = match.group(0)
+        gh_match = _GITHUB_REPOS_URL_RE.match(url)
+        if gh_match and gh_match.group("host").lower() in _GITHUB_REST_HOSTS:
+            yield "github", gh_match.group("slug")
+            continue
+        glab_match = _GITLAB_PROJECTS_URL_RE.match(url)
+        if glab_match:
+            yield "gitlab", glab_match.group("slug").replace("%2F", "/").replace("%2f", "/")
+
+
+# Write-verb signals a python REST client carries, mirroring the effective-
+# method resolution ``_publish_detection._api_effective_method`` applies to
+# ``gh``/``glab api``: an explicit client-library write call (``requests``/
+# ``httpx`` ``.post``/``.patch``), an explicit ``method=`` kwarg
+# (``urllib.request.Request``), or -- for a raw ``http.client``/socket call
+# with no recognised client-library name -- a write-method string literal
+# alongside a forge auth-header pattern (``Authorization``/
+# ``PRIVATE-TOKEN``), per the "raw HTTP calls with an Authorization header
+# pattern" shape.
+_PYTHON_WRITE_CALL_RE: Final[re.Pattern[str]] = re.compile(r"\b(?:requests|httpx)\.(?:post|patch)\s*\(")
+_PYTHON_WRITE_METHOD_KWARG_RE: Final[re.Pattern[str]] = re.compile(
+    r"method\s*=\s*['\"](?:POST|PATCH|PUT|DELETE)['\"]",
+    re.IGNORECASE,
+)
+_PYTHON_WRITE_METHOD_LITERAL_RE: Final[re.Pattern[str]] = re.compile(r"['\"](?:POST|PATCH|PUT|DELETE)['\"]")
+_PYTHON_AUTH_HEADER_RE: Final[re.Pattern[str]] = re.compile(r"\b(?:Authorization|PRIVATE-TOKEN)\b", re.IGNORECASE)
+
+
+def _python_source_has_write_signal(source: str) -> bool:
+    """Return True iff ``source`` carries a python REST write-verb signal."""
+    if _PYTHON_WRITE_CALL_RE.search(source):
+        return True
+    if _PYTHON_WRITE_METHOD_KWARG_RE.search(source):
+        return True
+    return bool(_PYTHON_WRITE_METHOD_LITERAL_RE.search(source)) and bool(_PYTHON_AUTH_HEADER_RE.search(source))
+
+
+_HEREDOC_WORD_PREFIX: Final[str] = "<<"
+
+
+def segment_is_python_rest_publish(words: list[str], command: str) -> bool:
+    """Return True iff ``words`` is a python-led segment POSTing/PATCHing a forge REST API.
+
+    The write-method + forge-target two-part test, mirroring
+    ``_publish_detection.segment_is_api_write``. ``command`` is the full raw
+    command text: a heredoc-fed script's body lives on subsequent physical
+    lines the lexer does not tokenize into WORDs (mirrors
+    ``extract_bash_payload``'s separate unconditional heredoc-body pass), so
+    a heredoc-carrying segment (its last WORD glued to a ``<<`` operator)
+    falls back to searching the raw command text -- the only place that body
+    is readable -- instead of the (heredoc-body-less) tokenized words alone.
+    """
+    if not words or not is_python_leader(words[0]):
+        return False
+    source = " ".join(words[1:])
+    if any(word.startswith(_HEREDOC_WORD_PREFIX) for word in words[1:]):
+        source = f"{source}\n{command}"
+    return _python_source_has_write_signal(source) and next(find_python_forge_rest_urls(source), None) is not None
+
+
+def command_has_python_rest_publish_surface(command: str) -> bool:
+    """Return True iff any segment is a python-led REST-publish write.
+
+    The whole-command counterpart of
+    ``_publish_detection.command_has_token_aware_publish_surface``, used by
+    ``_command_parser.is_publish_command`` to catch a python REST client the
+    CLI-specific detectors never see.
+    """
+    return any(segment_is_python_rest_publish(words, command) for words in segment_word_lists(command))

--- a/src/teatree/hooks/publish_destination.py
+++ b/src/teatree/hooks/publish_destination.py
@@ -45,6 +45,7 @@ from typing import Final
 
 from teatree.hooks._command_parser import first_segment_words
 from teatree.hooks._gh_glab_hiding import token_has_substitution_marker, token_is_transport_construct
+from teatree.hooks._python_rest_detection import find_python_forge_rest_urls, is_python_leader
 from teatree.hooks._repo_visibility import (
     _config_path,
     forge_qualified_slug,
@@ -337,6 +338,29 @@ def _destination_from_t3_review(words: list[str]) -> Destination | None:
     return None
 
 
+def _destination_from_python_script(words: list[str]) -> Destination | None:
+    """Resolve the destination of a python REST-publish segment from its URL literal.
+
+    Reuses :func:`_publish_detection.find_python_forge_rest_urls` -- the SAME
+    ``repos/<owner>/<repo>`` (GitHub) / ``api/v<N>/projects/<slug>`` (GitLab)
+    path resolution :func:`_destination_from_api` applies to a ``gh``/``glab
+    api`` URL argument, now applied to a URL LITERAL embedded in the script
+    text. Resolution is orthogonal to read/write (mirrors
+    ``_destination_from_api``, which resolves a ``gh api ... --method GET``
+    target too) -- the write/read gate is
+    :func:`_publish_detection.segment_is_python_rest_publish`, upstream of
+    this resolver. A dynamically-built URL (string concatenation) carries no
+    literal ``https?://`` substring and resolves to ``None`` -- genuinely
+    unresolvable, not private.
+    """
+    if not words or not is_python_leader(words[0]):
+        return None
+    source = " ".join(words[1:])
+    for forge, slug in find_python_forge_rest_urls(source):
+        return Destination(slug=slug, via="api", forge=forge)
+    return None
+
+
 def _destination_from_words(words: list[str], cwd: Path | None) -> Destination | None:
     """Resolve the publish destination of one command segment's word list.
 
@@ -350,6 +374,9 @@ def _destination_from_words(words: list[str], cwd: Path | None) -> Destination |
     t3_dest = _destination_from_t3_review(words)
     if t3_dest is not None:
         return t3_dest
+    python_dest = _destination_from_python_script(words)
+    if python_dest is not None:
+        return python_dest
     if words[0] not in {"gh", "glab"}:
         return None
     explicit = _extract_repo_flag(words)
@@ -377,6 +404,10 @@ def resolve_publish_destination(command: str, cwd: Path | None = None) -> Destin
     - ``gh``/``glab`` ``pr``/``issue``/``mr`` ``create``/``comment``/``note``
         with no ``--repo`` flag -- the CURRENT repo, via the git remote of
         ``cwd``.
+    - a ``python3``/``python``-led REST-publish script -- the SAME
+        ``repos/``/``projects/`` path shape, resolved from a URL LITERAL in
+        the script text (:func:`_destination_from_python_script`) instead of
+        a CLI flag/positional.
 
     Resolves only the FIRST command segment;
     :func:`public_visibility.gate_skips_for_visibility` is the multi-segment

--- a/tests/teatree_hooks/test_banned_terms_scanner.py
+++ b/tests/teatree_hooks/test_banned_terms_scanner.py
@@ -1890,6 +1890,79 @@ class TestDestinationAwareGate:
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
 
 
+class TestPythonRestPublishGate:
+    """Regression guard for the gap found via PR #2943.
+
+    A ``python3``/``python`` REST-publish segment (``requests``/``httpx``/
+    ``urllib`` POSTing/PATCHing to a forge REST API -- the "Post or Update
+    Note with Images" recipe in ``skills/platforms/references/gitlab.md``)
+    was never classified as a publish at all, so ``extract_publish_payload``
+    returned ``None`` and the gate never even ran, on ANY repo, public or
+    private.
+
+    RED-before-fix: ``extract_publish_payload`` returned ``None`` for every
+    row here, so the gate never blocked the public-repo row and never got the
+    chance to skip the private-repo row -- both looked "clean" for the wrong
+    reason. Mirrors the ``gh``/``glab`` structure in ``TestDestinationAwareGate``.
+    """
+
+    @staticmethod
+    def _python_post(url: str) -> str:
+        return (
+            f"python3 -c \"import requests; requests.post('{url}', "
+            "json={'body': 'ship to acmecorp'}, headers={'PRIVATE-TOKEN': token})\""
+        )
+
+    def test_extract_publish_payload_is_no_longer_none(self) -> None:
+        # The core gap: pre-fix, this returned None (not a recognised publish),
+        # so the gate short-circuited before ever reaching the visibility scan.
+        command = self._python_post("https://api.github.com/repos/souliane/teatree/issues/5/comments")
+        payload = banned_terms_scanner.extract_publish_payload("Bash", {"command": command})
+        assert payload is not None
+        assert "acmecorp" in payload
+
+    def test_banned_term_via_python_post_to_public_repo_is_blocked(self, capsys: pytest.CaptureFixture[str]) -> None:
+        command = self._python_post("https://api.github.com/repos/souliane/teatree/issues/5/comments")
+        blocked = handle_banned_terms_pretool(_bash(command))
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+    def test_banned_term_via_python_post_to_internal_namespace_is_allowed(self) -> None:
+        command = self._python_post("https://gitlab.com/api/v4/projects/internalcorp%2Fprivate-svc/notes")
+        blocked = handle_banned_terms_pretool(_bash(command))
+        assert blocked is False
+
+    def test_banned_term_via_python_post_to_allowlisted_private_repo_is_allowed(self) -> None:
+        command = self._python_post("https://api.github.com/repos/acmecorp-engineering/product/issues/5/comments")
+        blocked = handle_banned_terms_pretool(_bash(command))
+        assert blocked is False
+
+    def test_clean_python_post_to_public_repo_passes(self, capsys: pytest.CaptureFixture[str]) -> None:
+        command = (
+            'python3 -c "import requests; requests.post('
+            "'https://api.github.com/repos/souliane/teatree/issues/5/comments', "
+            "json={'body': 'clean note'}, headers={'Authorization': 'Bearer ' + token})\""
+        )
+        blocked = handle_banned_terms_pretool(_bash(command))
+        assert blocked is False
+        assert capsys.readouterr().out == ""
+
+    def test_heredoc_fed_python_post_to_public_repo_is_blocked(self, capsys: pytest.CaptureFixture[str]) -> None:
+        command = (
+            "python3 << 'PYEOF'\n"
+            "import json, urllib.request\n"
+            "url = 'https://gitlab.com/api/v4/projects/souliane%2Fteatree/merge_requests/5/notes'\n"
+            "body = json.dumps({'body': 'ship to acmecorp'}).encode()\n"
+            "req = urllib.request.Request(url, data=body, method='POST', "
+            "headers={'PRIVATE-TOKEN': 'x'})\n"
+            "urllib.request.urlopen(req)\n"
+            "PYEOF"
+        )
+        blocked = handle_banned_terms_pretool(_bash(command))
+        assert blocked is True
+        assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
+
+
 class TestFormatBlockMessage:
     def test_message_names_the_term_and_the_override(self) -> None:
         message = banned_terms_scanner.format_block_message("acmecorp")

--- a/tests/teatree_hooks/test_banned_terms_scanner.py
+++ b/tests/teatree_hooks/test_banned_terms_scanner.py
@@ -1962,6 +1962,19 @@ class TestPythonRestPublishGate:
         assert blocked is True
         assert json.loads(capsys.readouterr().out)["permissionDecision"] == "deny"
 
+    def test_unrelated_python_one_liner_with_secret_shaped_string_is_not_blocked(self) -> None:
+        # Independent-review finding (codex, this ticket): gating the ``-c``
+        # payload walker on the python LEADER alone (not the write+forge
+        # classification) fed every python ``-c`` script into
+        # ``secret_scan_text`` -- which runs BEFORE ``is_publish_command`` and
+        # regardless of destination -- so a purely local, non-networked
+        # one-liner that merely PRINTS a secret-shaped string was false-
+        # blocked as a "publish payload" it never was.
+        secret = "sk-ant-api03-" + "a" * 90
+        command = f"python3 -c \"token='{secret}'; print(token[:3])\""
+        blocked = handle_banned_terms_pretool(_bash(command))
+        assert blocked is False
+
 
 class TestFormatBlockMessage:
     def test_message_names_the_term_and_the_override(self) -> None:

--- a/tests/teatree_hooks/test_publish_destination.py
+++ b/tests/teatree_hooks/test_publish_destination.py
@@ -772,3 +772,91 @@ class TestRestrictedPathCwdResolution:
         monkeypatch.setenv("PATH", "")
         cmd = "gh pr create --title x --body y"
         assert public_visibility.gate_skips_for_visibility(cmd, repo, config_path=cfg) is False
+
+
+_GITLAB_PRIVATE_NOTE_URL = "https://gitlab.com/api/v4/projects/internalcorp%2Fprivate-svc/merge_requests/5/notes"
+_GITHUB_PRIVATE_COMMENT_URL = "https://api.github.com/repos/internalcorp/private-svc/issues/5/comments"
+_GITHUB_PUBLIC_COMMENT_URL = "https://api.github.com/repos/souliane/teatree/issues/5/comments"
+
+
+def _python_post_command(url: str) -> str:
+    return (
+        f"python3 -c \"import requests; requests.post('{url}', "
+        "json={'body': 'note'}, headers={'PRIVATE-TOKEN': token})\""
+    )
+
+
+class TestPythonRestScriptDestination:
+    """A python REST-publish script resolves a destination the SAME way a raw ``gh``/``glab api`` URL does.
+
+    Reuses the identical ``repos/<owner>/<repo>`` / ``api/v<N>/projects/<slug>``
+    path resolution (#1415/#1213 gap: a ``python3``/``python`` REST-publish
+    segment was never classified as a publish at all, so the leak scan never
+    even ran against it).
+    """
+
+    def test_resolve_gitlab_projects_path_from_python_script(self) -> None:
+        dest = publish_destination.resolve_publish_destination(_python_post_command(_GITLAB_PRIVATE_NOTE_URL))
+        assert dest is not None
+        assert dest.slug == "internalcorp/private-svc"
+        assert dest.forge == "gitlab"
+
+    def test_resolve_github_repos_path_from_python_script(self) -> None:
+        dest = publish_destination.resolve_publish_destination(_python_post_command(_GITHUB_PRIVATE_COMMENT_URL))
+        assert dest is not None
+        assert dest.slug == "internalcorp/private-svc"
+        assert dest.forge == "github"
+
+    def test_read_only_script_still_resolves_a_destination(self) -> None:
+        # Destination RESOLUTION is orthogonal to read/write -- mirroring
+        # ``_destination_from_api`` (a ``gh api ... --method GET`` resolves a
+        # slug too). The write-vs-read gate is ``segment_is_python_rest_publish``
+        # upstream (the whole leak scan never runs for a read-only script), not
+        # this resolver.
+        command = "python3 -c \"import requests; requests.get('https://api.github.com/repos/o/r')\""
+        dest = publish_destination.resolve_publish_destination(command)
+        assert dest is not None
+        assert dest.slug == "o/r"
+
+    def test_dynamically_built_url_resolves_no_destination(self) -> None:
+        # No literal URL in the segment -- the target is genuinely unresolvable,
+        # not private, so it must fail closed to SCAN (never skip).
+        command = (
+            "python3 -c \"import requests; requests.post(base + '/api/v4/projects/' + str(pid) + '/notes', json={})\""
+        )
+        assert publish_destination.resolve_publish_destination(command) is None
+
+    def test_python_publish_to_private_repo_is_skipped(self, tmp_path: Path) -> None:
+        cfg = _config(tmp_path, ["internalcorp"])
+        command = _python_post_command(_GITLAB_PRIVATE_NOTE_URL)
+        assert public_visibility.gate_skips_for_visibility(command, None, config_path=cfg) is True
+
+    def test_python_publish_to_public_repo_still_scans(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        cfg = _config(tmp_path, ["internalcorp"])
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+        command = _python_post_command(_GITHUB_PUBLIC_COMMENT_URL)
+        assert public_visibility.gate_skips_for_visibility(command, None, config_path=cfg) is False
+
+    def test_python_publish_with_unresolvable_target_still_scans(self, tmp_path: Path) -> None:
+        cfg = _config(tmp_path, ["internalcorp"])
+        command = (
+            "python3 -c \"import requests; requests.post(base + '/api/v4/projects/' "
+            "+ str(pid) + '/notes', headers={'PRIVATE-TOKEN': token}, json={})\""
+        )
+        assert public_visibility.gate_skips_for_visibility(command, None, config_path=cfg) is False
+
+    def test_self_hosted_gitlab_host_declared_via_private_repos_is_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # "Configured self-hosted GitLab host" -- the SAME mechanism the offline
+        # ``private_repos`` allowlist already uses to declare a host: a
+        # host-qualified entry. The python script's URL targets that declared
+        # host's REST API, and it resolves + skips without any new config knob.
+        # Destination RESOLUTION (unlike classification) reads the default
+        # config path, mirroring every other resolver in this module -- so the
+        # test config is pointed at via the same env var the resolvers read.
+        cfg = _private_repos_config(tmp_path, ["gitlab.example.corp/internalcorp"])
+        monkeypatch.setenv("T3_BANNED_TERMS_CONFIG", str(cfg))
+        url = "https://gitlab.example.corp/api/v4/projects/internalcorp%2Fprivate-svc/merge_requests/5/notes"
+        command = _python_post_command(url)
+        assert public_visibility.gate_skips_for_visibility(command, None, config_path=cfg) is True

--- a/tests/teatree_hooks/test_publish_detection_python_rest.py
+++ b/tests/teatree_hooks/test_publish_detection_python_rest.py
@@ -1,0 +1,157 @@
+"""Tests for python-script REST-publish detection (the gap found via PR #2943).
+
+``extract_publish_payload`` (banned-terms #1415, quote-scanner #1213) gates
+ALL scanning on ``_command_parser.is_publish_command`` -- a ``python3``/
+``python``-led segment POSTing/PATCHing to a forge REST API (the
+"Post or Update Note with Images" recipe in ``skills/platforms/references/
+gitlab.md``) was never recognised as a publish action at all, so the
+leak-prevention scan never ran against it, on ANY repo, public or private.
+
+``segment_is_python_rest_publish`` / ``command_has_python_rest_publish_surface``
+generalise the SAME write-method + forge-target two-part test
+``segment_is_api_write`` already applies to a ``gh``/``glab api`` call to an
+interpreted script the CLI-specific argument walkers cannot parse a
+``--repo``/URL out of: a python REST client hitting a forge's REST API is
+structurally the same shape as a raw ``curl`` POST, just authored in Python
+(``requests``/``httpx``/``urllib``/a raw ``Authorization``-headed call)
+instead of CLI flags.
+"""
+
+import pytest
+
+from teatree.hooks import _command_parser
+from teatree.hooks._python_rest_detection import (
+    command_has_python_rest_publish_surface,
+    find_python_forge_rest_urls,
+    is_python_leader,
+    segment_is_python_rest_publish,
+)
+
+_GITLAB_NOTE_URL = "https://gitlab.com/api/v4/projects/42/merge_requests/5/notes"
+_GITHUB_COMMENT_URL = "https://api.github.com/repos/owner/repo/issues/5/comments"
+
+
+class TestIsPythonLeader:
+    @pytest.mark.parametrize("word", ["python", "python3", "python3.11", "python3.12", "/usr/bin/python3"])
+    def test_recognised_interpreter_spellings(self, word: str) -> None:
+        assert is_python_leader(word)
+
+    @pytest.mark.parametrize("word", ["gh", "glab", "curl", "git", "pythonic", "python-is-fun"])
+    def test_non_interpreter_words_are_not_leaders(self, word: str) -> None:
+        assert not is_python_leader(word)
+
+
+class TestSegmentIsPythonRestPublish:
+    """The write-method + forge-target two-part test, mirroring `segment_is_api_write`."""
+
+    def test_requests_post_to_gitlab_is_detected(self) -> None:
+        command = (
+            f"python3 -c \"import requests; requests.post('{_GITLAB_NOTE_URL}', "
+            "json={'body': 'note'}, headers={'PRIVATE-TOKEN': token})\""
+        )
+        words = ["python3", "-c", command.split(" -c ", 1)[1].strip('"')]
+        assert segment_is_python_rest_publish(words, command)
+
+    def test_requests_patch_to_github_is_detected(self) -> None:
+        command = (
+            f"python3 -c \"import requests; requests.patch('{_GITHUB_COMMENT_URL}', "
+            "json={'body': 'note'}, headers={'Authorization': f'Bearer {token}'})\""
+        )
+        words = ["python3", "-c", command.split(" -c ", 1)[1].strip('"')]
+        assert segment_is_python_rest_publish(words, command)
+
+    def test_httpx_post_is_detected(self) -> None:
+        command = f"python3 -c \"import httpx; httpx.post('{_GITLAB_NOTE_URL}', json={{}})\""
+        words = ["python3", "-c", command.split(" -c ", 1)[1].strip('"')]
+        assert segment_is_python_rest_publish(words, command)
+
+    def test_urllib_request_method_post_is_detected(self) -> None:
+        command = (
+            'python3 -c "import urllib.request; '
+            f"req = urllib.request.Request('{_GITLAB_NOTE_URL}', data=b'{{}}', method='POST')\""
+        )
+        words = ["python3", "-c", command.split(" -c ", 1)[1].strip('"')]
+        assert segment_is_python_rest_publish(words, command)
+
+    def test_raw_authorization_header_to_forge_is_detected(self) -> None:
+        # No recognised client-library call name (http.client / raw socket) --
+        # the Authorization header + forge target alone is the detection surface.
+        command = (
+            "python3 -c \"import http.client; conn.request('POST', "
+            f"'{_GITHUB_COMMENT_URL}', headers={{'Authorization': 'Bearer ' + token}})\""
+        )
+        words = ["python3", "-c", command.split(" -c ", 1)[1].strip('"')]
+        assert segment_is_python_rest_publish(words, command)
+
+    def test_heredoc_fed_script_is_detected(self) -> None:
+        command = (
+            "python3 << 'PYEOF'\n"
+            "import json, urllib.request\n"
+            f"url = '{_GITLAB_NOTE_URL}'\n"
+            "req = urllib.request.Request(url, data=b'{}', method='POST', "
+            "headers={'PRIVATE-TOKEN': token})\n"
+            "urllib.request.urlopen(req)\n"
+            "PYEOF"
+        )
+        assert command_has_python_rest_publish_surface(command)
+
+    def test_read_only_python_call_is_not_a_publish(self) -> None:
+        command = f"python3 -c \"import requests; requests.get('{_GITLAB_NOTE_URL}')\""
+        words = ["python3", "-c", command.split(" -c ", 1)[1].strip('"')]
+        assert not segment_is_python_rest_publish(words, command)
+
+    def test_write_call_to_non_forge_host_is_not_a_publish(self) -> None:
+        command = "python3 -c \"import requests; requests.post('https://example.com/api/notes', json={})\""
+        words = ["python3", "-c", command.split(" -c ", 1)[1].strip('"')]
+        assert not segment_is_python_rest_publish(words, command)
+
+    def test_non_python_leader_is_not_a_publish(self) -> None:
+        words = ["curl", "-X", "POST", _GITLAB_NOTE_URL]
+        assert not segment_is_python_rest_publish(words, " ".join(words))
+
+    def test_empty_words_is_not_a_publish(self) -> None:
+        assert not segment_is_python_rest_publish([], "")
+
+
+class TestFindPythonForgeRestUrls:
+    """The resolver both the classifier's existence check and ``publish_destination`` reuse."""
+
+    def test_yields_every_forge_url_in_source(self) -> None:
+        # Every consumer only pulls the FIRST yielded value (``next(...)``/a
+        # ``for ... return`` loop) -- a source carrying more than one forge URL
+        # is the only way to observe the generator resume past its first yield.
+        source = f"first at {_GITHUB_COMMENT_URL} then {_GITLAB_NOTE_URL}"
+        assert list(find_python_forge_rest_urls(source)) == [("github", "owner/repo"), ("gitlab", "42")]
+
+    def test_yields_nothing_for_a_non_forge_url(self) -> None:
+        assert list(find_python_forge_rest_urls("https://example.com/api/notes")) == []
+
+
+class TestIsPublishCommandRecognizesPythonRestPublish:
+    """RED-before-fix: ``is_publish_command`` never classified a python REST publish."""
+
+    def test_inline_c_script_is_a_publish_command(self) -> None:
+        command = (
+            f"python3 -c \"import requests; requests.post('{_GITLAB_NOTE_URL}', "
+            "json={'body': 'note'}, headers={'PRIVATE-TOKEN': token})\""
+        )
+        assert _command_parser.is_publish_command(command)
+
+    def test_heredoc_script_is_a_publish_command(self) -> None:
+        command = (
+            "python3 << 'PYEOF'\n"
+            "import json, urllib.request\n"
+            f"url = '{_GITLAB_NOTE_URL}'\n"
+            "req = urllib.request.Request(url, data=b'{}', method='POST', "
+            "headers={'PRIVATE-TOKEN': token})\n"
+            "urllib.request.urlopen(req)\n"
+            "PYEOF"
+        )
+        assert _command_parser.is_publish_command(command)
+
+    def test_read_only_script_is_not_a_publish_command(self) -> None:
+        command = f"python3 -c \"import requests; requests.get('{_GITLAB_NOTE_URL}')\""
+        assert not _command_parser.is_publish_command(command)
+
+    def test_unrelated_python_invocation_is_not_a_publish_command(self) -> None:
+        assert not _command_parser.is_publish_command("python3 manage.py migrate")


### PR DESCRIPTION
fix(hooks): recognize python REST clients as a publish surface for the banned-terms/quote-scanner gate

**Security-sensitive: this touches the leak-prevention gate (#1415/#1213). Please review closely.**

`extract_publish_payload` gated ALL scanning on `is_publish_command`, which only recognized `gh`/`glab`/`git`/`curl` segments -- a `python3`/`python` script POSTing/PATCHing to a forge REST API (`requests`/`httpx`/`urllib`, or a raw `http.client` call) was never classified as a publish at all, so the leak-prevention scan never ran against it, on any repo, public or private. The gitlab.md "Post or Update Note with Images" recipe added by #2943 is exactly this shape.

New module `teatree.hooks._python_rest_detection` (split out to keep `_publish_detection` under its public-function ceiling) generalizes the same write-method + forge-target two-part test `segment_is_api_write` already applies to `gh api`/`glab api`: a write-verb signal (`requests.post/patch`, `httpx.post/patch`, a `urllib` `method=` kwarg, or a raw write-method literal alongside an `Authorization`/`PRIVATE-TOKEN` header) combined with a forge-shaped REST URL literal (GitHub restricted to `github.com`/`api.github.com`; GitLab's versioned `api/v<N>/projects/` path is distinctive enough to trust regardless of host, so a self-hosted GitLab instance resolves the same way `gitlab.com` does with no new config knob).

`publish_destination._destination_from_python_script` extends the existing destination resolver the same way, reusing the shared `find_python_forge_rest_urls` helper -- so a python REST-publish segment targeting a private/internal repo skips the scan cleanly (mirroring the `gh`/`glab` carve-out) while one targeting a public or unresolvable-visibility target still scans (fail-closed, matching the existing posture for an unrecognized leader).

`_command_parser` gains a matching `-c` script-argument payload walker so the extracted text (not just the classification) is actually scanned; a heredoc-fed script was already covered by the existing unconditional heredoc-body extraction pass.

## Independent review (codex, `codex exec review --base main`)

Two findings, both addressed in the second commit:

1. **Real bug, fixed**: the `-c` payload walker was gated on the python leader alone, so it fed *every* python `-c` invocation into the wide `secret_scan_text` surface (which runs BEFORE `is_publish_command` and regardless of destination, by design, for the secrets-always-block invariant) -- false-blocking a purely local, non-networked one-liner that happened to contain a secret-shaped string. Fixed by gating on `segment_is_python_rest_publish` (the actual write-verb + forge-URL classification) instead of the bare leader. Regression test added and RED->GREEN verified.
2. **Confirmed pre-existing, not a regression**: a heredoc-fed python publish never skips a private/internal target (unlike the inline `-c` form). Verified this identical behavior already exists for `glab` heredoc posts today, via the same `<<`-is-a-transport-construct fail-closed rule that applies uniformly to every tool (`_segment_carries_substitution_or_transport`) -- not something this diff introduces or narrows.

## Architecture pre-check

1. **BLUEPRINT § alignment**: extends the existing publish-surface detection (`_publish_detection.py`/`_command_parser.py`/`publish_destination.py`) documented under the banned-terms (#1415) / quote-scanner (#1213) leak-prevention gates.
2. **FSM phase boundaries**: n/a -- no `Ticket`/`Worktree` state transitions.
3. **Extension-point contracts**: n/a -- no `OverlayBase`/scanner/hook Protocol changes; pure hook-detection logic.
4. **Component boundaries**: new module `src/teatree/hooks/_python_rest_detection.py` (mirrors the existing `_gh_glab_hiding.py`/`_repo_visibility.py`/`_body_file_resolution.py` split pattern), kept under the module-health public-function ceiling.
5. **Dependency direction**: `_python_rest_detection` imports `segment_word_lists` from `_publish_detection` (same layer `_command_parser` already sits above); `_command_parser` and `publish_destination` import the new module. `uv run tach check` -> all modules validated, no backwards edge.
6. **Test surface**: `tests/teatree_hooks/test_publish_detection_python_rest.py` (new, classification unit tests + `find_python_forge_rest_urls` generator coverage), `tests/teatree_hooks/test_publish_destination.py` (destination resolution + visibility-skip), `tests/teatree_hooks/test_banned_terms_scanner.py` (full-pipeline gate tests incl. the codex-finding regression test).
7. **Resilience invariants**: n/a -- pure in-process detection logic, no external writes.
8. **Identity and key normalization**: n/a -- no bare/qualified identity forms introduced.
9. **Behavior preservation / capability deletion**: purely additive -- every existing `gh`/`glab`/`git`/`curl` detection path is unchanged (confirmed via the full `tests/teatree_hooks/` suite, 1830 tests, unchanged pass count before/after).

## Open questions & assumptions

- **Forge-host restriction for GitHub vs. host-agnostic for GitLab** (assumed): GitHub write detection requires the URL host be `github.com`/`api.github.com`; GitLab requires only the `api/v<N>/projects/` path shape, host-agnostic, so a self-hosted GitLab instance is covered automatically. Assumed this asymmetry is correct because GitLab's versioned REST path is distinctive enough to trust on its own, while GitHub's `repos/<owner>/<repo>` path alone is too generic a shape. Status: assumed, not explicitly confirmed by the ticket.
- **New module split (`_python_rest_detection.py`) vs. inline in `_publish_detection.py`** (decided-by-necessity): the module-health pre-commit hook enforces a 10-public-function ceiling per file; `_publish_detection.py` was already at the cap, so the 4 new public functions had to move to a sibling module. Status: decided, verified by the pre-commit hook passing.

## RED->GREEN evidence

- Stashed the production changes (both commits, separately), re-ran the salvaged + new tests, confirmed the exact failures matching the described gap (8 failed + 1 import error for commit 1; 1 failed for commit 2's regression test), then restored and confirmed all green.
- `tests/teatree_hooks/` (1830 tests), `tach check`, `check_module_health.py`, `ruff check`/`format`, `ty-check` (via pre-commit) all pass.
- Full regression suite run 3x; each run showed a shifting small set of pre-existing environmental failures (schema-guard self-heal timeouts, hook_router subprocess timeouts, jscpd/loop-ownership races) with zero overlap with the changed files across all 3 runs; 3 spot-checked failing files pass 100% cleanly in isolation.
