### PR TITLE
fix(merge): conflict-only oracle uses git merge-tree conflicted-path set + wire verify_sha_bound

### DIFF
--- a/src/teatree/core/merge/conflict_only.py
+++ b/src/teatree/core/merge/conflict_only.py
@@ -12,13 +12,15 @@ keeps refusing it and a fresh review is forced.
 
 The oracle is ``git merge-tree --write-tree`` — git's own machine auto-merge of
 the two parents. The merge commit is conflict-only iff every path where the
-committed merge tree deviates from that auto-merge tree was a CONFLICTED path in
-the auto-merge (its auto-merged blob carries git conflict markers). Any deviation
-on a cleanly-merged path is a substantive change.
+committed merge tree deviates from that auto-merge tree is in git's OWN
+authoritative conflicted-path set for that auto-merge. Any deviation on a
+cleanly-merged path is a substantive change — even when that file's content
+legitimately contains literal conflict-marker strings (a doc/fixture), which a
+marker-grep would misread as "was conflicted" and fail OPEN.
 
-Every uncertainty fails SAFE — a non-two-parent commit, a git error, or an
-unreadable blob returns ``False`` (force re-review), never a false "conflict-only"
-that would skip an independent review.
+Every uncertainty fails SAFE — a non-two-parent commit or any git error returns
+``False`` (force re-review), never a false "conflict-only" that would skip an
+independent review.
 """
 
 import logging
@@ -36,8 +38,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_CONFLICT_START = "<<<<<<<"
-_CONFLICT_END = ">>>>>>>"
 _OID_ALPHABET = frozenset("0123456789abcdef")
 _MIN_OID_LEN = 40
 _MERGE_PARENT_COUNT = 2
@@ -61,35 +61,44 @@ def merge_commit_parents(repo_root: str, merge_sha: str) -> tuple[str, ...]:
     return tuple(result.stdout.strip().split()[1:])
 
 
-def _path_was_conflicted(repo_root: str, tree: str, path: str) -> bool:
-    """True iff the auto-merge blob at ``path`` in ``tree`` carries conflict markers.
+def _auto_merge(repo_root: str, p1: str, p2: str) -> "tuple[str, frozenset[str]] | None":
+    """Git's machine auto-merge of two parents: (merged tree OID, conflicted-path set).
 
-    Fails safe: an unreadable path (add/add or delete conflicts leave no single
-    blob) returns ``False`` so it counts as a substantive deviation, never a
-    silently-allowed one.
+    ``git merge-tree --write-tree --name-only -z`` emits the merged tree OID
+    followed by git's OWN authoritative list of the paths it could not cleanly
+    auto-merge — NUL-separated, terminated by an empty record before the
+    informational-message section. A path is conflicted iff git reports it here,
+    never inferred from marker strings a cleanly-merged blob may legitimately
+    carry. Returns ``None`` on any git error / unparsable OID (fails safe).
     """
-    result = _git(repo_root, ["cat-file", "-p", f"{tree}:{path}"])
-    if result.returncode != 0:
-        return False
-    return _CONFLICT_START in result.stdout and _CONFLICT_END in result.stdout
+    result = _git(repo_root, ["merge-tree", "--write-tree", "--name-only", "-z", p1, p2])
+    records = result.stdout.split("\x00")
+    if not _looks_like_oid(records[0]):
+        return None
+    conflicted: set[str] = set()
+    for record in records[1:]:
+        if not record:
+            break
+        conflicted.add(record)
+    return records[0].strip(), frozenset(conflicted)
 
 
 def is_conflict_only_merge_commit(repo_root: str, merge_sha: str) -> bool:
     """True iff ``merge_sha`` is a two-parent merge that only resolves conflicts.
 
     Compares the committed merge tree against ``git merge-tree --write-tree`` of
-    its two parents: conflict-only iff every deviating path was conflicted in the
-    machine auto-merge. An empty deviation set (the commit is exactly the machine
-    merge) is trivially conflict-only.
+    its two parents: conflict-only iff every deviating path is in git's
+    authoritative conflicted-path set for that auto-merge. An empty deviation set
+    (the commit is exactly the machine merge) is trivially conflict-only.
     """
     parents = merge_commit_parents(repo_root, merge_sha)
     if len(parents) != _MERGE_PARENT_COUNT:
         return False
     p1, p2 = parents
-    auto = _git(repo_root, ["merge-tree", "--write-tree", p1, p2])
-    auto_tree = auto.stdout.splitlines()[0].strip() if auto.stdout.strip() else ""
-    if not _looks_like_oid(auto_tree):
+    auto = _auto_merge(repo_root, p1, p2)
+    if auto is None:
         return False
+    auto_tree, conflicted_paths = auto
     merge_tree = _git(repo_root, ["rev-parse", f"{merge_sha}^{{tree}}"]).stdout.strip()
     if not _looks_like_oid(merge_tree):
         return False
@@ -97,7 +106,7 @@ def is_conflict_only_merge_commit(repo_root: str, merge_sha: str) -> bool:
     if diff.returncode != 0:
         return False
     deviations = [line for line in diff.stdout.splitlines() if line.strip()]
-    return all(_path_was_conflicted(repo_root, auto_tree, path) for path in deviations)
+    return all(path in conflicted_paths for path in deviations)
 
 
 def rebind_clearance_after_conflict_only_merge(

--- a/src/teatree/core/merge/execution.py
+++ b/src/teatree/core/merge/execution.py
@@ -49,6 +49,7 @@ from teatree.core.merge.pr_slug_resolution import (
     _resolve_host_kind,
     resolve_pr_repo_slug,
 )
+from teatree.core.merge.sha_bind import verify_sha_bound
 from teatree.project import find_project_root
 
 if TYPE_CHECKING:
@@ -213,18 +214,15 @@ def assert_merge_preconditions(  # noqa: PLR0913 — §17.4.3 gate entry-point; 
     if not live_sha:
         msg = f"could not resolve the live head SHA for {slug}#{pr_id} (§17.4.3 step 2)"
         raise MergePreconditionError(msg)
-    if live_sha != authorized_clear.reviewed_sha:
+    if not verify_sha_bound(cleared_sha=authorized_clear.reviewed_sha, live_sha=live_sha):
         # Show full SHAs (not [:8] prefixes) so a length-mismatch or any other
-        # silent difference is obvious in the diagnostic (#1162). The registry's
-        # ``sha_bind`` gate (``merge.sha_bind.verify_sha_bound``) is the same
-        # equality; both compare the full lowercased SHA.
-        reviewed_sha = authorized_clear.reviewed_sha
+        # silent difference is obvious in the diagnostic (#1162).
+        reviewed = authorized_clear.reviewed_sha
         msg = (
             f"PR head moved: live={live_sha} (length={len(live_sha)}) != "
-            f"reviewed={reviewed_sha} (length={len(reviewed_sha)}) — "
-            f"the CLEAR is stale (force-push / new commits) or was issued with a "
-            f"truncated SHA. Re-escalate; the loop never self-issues a replacement "
-            f"(§17.4.3 step 2)"
+            f"reviewed={reviewed} (length={len(reviewed)}) — the CLEAR is stale "
+            f"(force-push / new commits) or was issued with a truncated SHA. "
+            f"Re-escalate; the loop never self-issues a replacement (§17.4.3 step 2)"
         )
         raise MergePreconditionError(msg)
 

--- a/tests/teatree_core/merge/test_conflict_only.py
+++ b/tests/teatree_core/merge/test_conflict_only.py
@@ -13,7 +13,6 @@ from django.test import TestCase
 from teatree.core.management.commands import review as review_cmd
 from teatree.core.merge import conflict_only as co
 from teatree.core.merge.conflict_only import (
-    _path_was_conflicted,
     is_conflict_only_merge_commit,
     merge_commit_parents,
     rebind_clearance_after_conflict_only_merge,
@@ -146,10 +145,55 @@ class TestConflictOnlyFailsSafe:
         ):
             assert is_conflict_only_merge_commit("/repo", self._MERGE) is False
 
-    def test_path_was_conflicted_is_false_on_unreadable_blob(self, tmp_path: Path) -> None:
+
+def _init_repo_marker_file(repo: Path) -> None:
+    """Like ``_init_repo`` but ``other.txt`` legitimately CONTAINS conflict markers.
+
+    A doc/fixture whose content includes literal ``<<<<<<<`` / ``>>>>>>>`` lines.
+    ``other.txt`` is cleanly merged (untouched on both sides), so its marker
+    content flows verbatim into git's auto-merge tree — the exact shape a
+    marker-grep oracle misreads as "was conflicted".
+    """
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "Tester")
+    _git(repo, "config", "commit.gpgsign", "false")
+    (repo / "conflict.txt").write_text("line1\nline2\nline3\n")
+    (repo / "other.txt").write_text("<<<<<<< example\nsome doc text\n>>>>>>> example\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "base")
+
+
+class TestEvilMergeOnMarkerContainingFile:
+    """PR-07 fail-open: an evil merge editing a cleanly-merged marker-containing file.
+
+    ``other.txt`` merges cleanly yet its content carries literal conflict markers.
+    The evil merge resolves ``conflict.txt`` AND edits ``other.txt``. A marker-grep
+    oracle sees markers in the auto-merge blob of ``other.txt`` and misclassifies
+    the substantive deviation as conflict-only — re-binding clearance and SKIPPING
+    re-review. git's authoritative conflicted-path set contains only ``conflict.txt``,
+    so the deviation on ``other.txt`` correctly forces a fresh review.
+    """
+
+    def test_evil_edit_on_marker_file_is_not_conflict_only(self, tmp_path: Path) -> None:
         repo = tmp_path / "repo"
-        _init_repo(repo)
-        assert _path_was_conflicted(str(repo), "0" * 40, "nope.txt") is False
+        _init_repo_marker_file(repo)
+        _diverge(repo, "feature")
+        merge_sha = _merge_main_resolving(repo, extra_edit=True)
+        # RED without the fix: the marker-grep oracle returns True (misclassified
+        # conflict-only) and this assertion fails; git's conflicted-path set returns
+        # False (re-review forced).
+        assert is_conflict_only_merge_commit(str(repo), merge_sha) is False
+
+    def test_marker_file_untouched_conflict_only_still_detected(self, tmp_path: Path) -> None:
+        # Control: with NO evil edit, the only deviation IS the genuinely-conflicted
+        # file, so the merge stays conflict-only even though other.txt carries markers.
+        repo = tmp_path / "repo"
+        _init_repo_marker_file(repo)
+        _diverge(repo, "feature")
+        merge_sha = _merge_main_resolving(repo, extra_edit=False)
+        assert is_conflict_only_merge_commit(str(repo), merge_sha) is True
 
 
 def _clear_with_verdict(repo: Path, feature_tip: str) -> MergeClear:

--- a/tests/teatree_core/test_merge_execution.py
+++ b/tests/teatree_core/test_merge_execution.py
@@ -294,6 +294,23 @@ class TestMergeKeystonePreconditions(TestCase):
         ticket.refresh_from_db()
         assert ticket.state == Ticket.State.IN_REVIEW
 
+    def test_sha_bind_precondition_runs_the_named_registry_gate(self) -> None:
+        # The named ``sha_bind`` gate (``merge.sha_bind.verify_sha_bound``) IS the
+        # enforcing code in the precondition path — not a dead registry entry beside
+        # an inline ``!=`` twin. Force the gate to report "not bound" while the live
+        # head equals the reviewed SHA: the merge is refused, so the gate's verdict —
+        # not a parallel copy — drives the SHA-bind check.
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.IN_REVIEW)
+        clear = _clear(ticket)
+        with (
+            patch("teatree.core.merge.execution.verify_sha_bound", return_value=False) as gate,
+            pytest.raises(MergePreconditionError, match="head moved"),
+        ):
+            _run(clear, _GhStub())  # head == reviewed_sha — the inline twin would PASS
+        gate.assert_called_once_with(cleared_sha=_SHA, live_sha=_SHA)
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.IN_REVIEW
+
     def test_expedite_flag_does_not_bypass_sha_bind(self) -> None:
         # PR-07: the expedite/release-blocker flag relaxes only the pre-CI push
         # posture — it grants NO merge bypass. An expedited ticket whose head


### PR DESCRIPTION
Keystone fail-open fix (Fable audit): replace conflict-marker string-grep with git's authoritative conflicted-path set so an evil merge on a marker-containing file can't skip re-review; wire verify_sha_bound into assert_merge_preconditions so the named SHA-bind gate is the enforcing code. Regression test on the evil-merge case.