### PR TITLE
fix(lane-b): compaction preserves tool-call/return pairing + privacy-scan parity with Lane A

### DIFF
--- a/src/teatree/agents/lane_b/compaction.py
+++ b/src/teatree/agents/lane_b/compaction.py
@@ -7,9 +7,18 @@ compaction the provider-agnostic way: :func:`compact_history` runs over the
 bounded on an unattended, many-turn dispatch. It preserves the FIRST message (the
 task framing) and the most-recent ``keep_recent`` messages, dropping the stale
 middle — the cheap, deterministic trim; a summarizing variant is a follow-up.
+
+The cut never orphans a tool result: an OpenAI-compatible provider rejects a
+``ModelRequest`` carrying a ``ToolReturnPart`` (or a tool-linked
+``RetryPromptPart``) whose paired ``ToolCallPart`` was dropped with the trimmed
+middle ("tool message without preceding tool_calls"). :func:`compact_history`
+drops the orphaned leading tool-result messages so the kept window always opens
+on a valid call→return pairing.
 """
 
 from typing import TYPE_CHECKING
+
+from pydantic_ai.messages import ModelRequest, ModelResponse, RetryPromptPart, ToolCallPart, ToolReturnPart
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -30,9 +39,60 @@ def compact_history(
     unchanged, so a normal conversation is byte-identical. Over it, the first
     message (task framing, the system context the model needs to stay on task) is
     preserved and the stale middle dropped, leaving the head plus the freshest
-    *keep_recent* turns. Deterministic and zero-token — no model call.
+    *keep_recent* turns. Any orphaned tool-result messages at the head of the kept
+    window — a ``ToolReturnPart`` whose ``ToolCallPart`` fell in the dropped middle
+    — are trimmed too, so the window opens on a valid call→return pairing an
+    OpenAI-compatible provider accepts. Deterministic and zero-token — no model call.
     """
     history = list(messages)
     if keep_recent < 1 or len(history) <= keep_recent + 1:
         return history
-    return [history[0], *history[-keep_recent:]]
+    tail = history[len(history) - keep_recent :]
+    return [history[0], *tail[_leading_orphan_count(tail) :]]
+
+
+def _leading_orphan_count(window: "list[ModelMessage]") -> int:
+    """Count leading messages whose tool-results have no matching call kept in *window*.
+
+    A cut can land so the first kept message is a ``ModelRequest`` carrying tool
+    results whose paired ``ToolCallPart`` was in a dropped ``ModelResponse``. Those
+    orphaned leading messages are dropped; scanning stops at the first message that
+    is not an orphaned tool-result request, so a valid call→return pairing later in
+    the window is never disturbed.
+    """
+    kept_call_ids = _tool_call_ids(window)
+    dropped = 0
+    for message in window:
+        return_ids = _tool_result_ids(message)
+        if not return_ids or return_ids <= kept_call_ids:
+            break
+        dropped += 1
+    return dropped
+
+
+def _tool_call_ids(window: "list[ModelMessage]") -> set[str]:
+    """Every ``ToolCallPart.tool_call_id`` emitted by a ``ModelResponse`` in *window*."""
+    return {
+        part.tool_call_id
+        for message in window
+        if isinstance(message, ModelResponse)
+        for part in message.parts
+        if isinstance(part, ToolCallPart)
+    }
+
+
+def _tool_result_ids(message: "ModelMessage") -> set[str]:
+    """The ``tool_call_id``s a ``ModelRequest`` returns, else the empty set.
+
+    A ``ToolReturnPart`` and a tool-linked ``RetryPromptPart`` (``tool_name`` set —
+    a gate/validation refusal of a specific call) both serialize as a tool message
+    that needs a preceding ``tool_calls``; a plain ``RetryPromptPart`` (no
+    ``tool_name``) is an output retry, not tool-linked, so it is excluded.
+    """
+    if not isinstance(message, ModelRequest):
+        return set()
+    ids: set[str] = set()
+    for part in message.parts:
+        if isinstance(part, ToolReturnPart) or (isinstance(part, RetryPromptPart) and part.tool_name is not None):
+            ids.add(part.tool_call_id)
+    return ids

--- a/src/teatree/agents/lane_b/gating.py
+++ b/src/teatree/agents/lane_b/gating.py
@@ -6,8 +6,10 @@ Hard-deny — a command that must never run (a main-clone working-tree mutation,
 privacy/banned-term leak). :func:`hard_deny_reason` is the single shared
 evaluator; it consults the SAME importable ``teatree`` functions Lane A's
 PreToolUse hook wraps (:func:`teatree.core.gates.main_clone_guard.find_main_clone_git_mutation`,
-:func:`teatree.hooks.quote_scanner.scan_text`), so the two lanes refuse the
-identical set by construction, not by a parallel re-implementation.
+and :func:`teatree.hooks.quote_scanner.extract_publish_payload` → :func:`~teatree.hooks.quote_scanner.scan_text`
+for the privacy scan — scoped to a PUBLISH payload, never every string argument),
+so the two lanes refuse the identical set by construction, not by a parallel
+re-implementation.
 :class:`HardDenyToolset` wraps a toolset and raises the refusal into the model as
 a ``RetryPromptPart`` (the model sees the reason and must adapt) exactly as a
 Lane-A PreToolUse deny surfaces its message.
@@ -48,9 +50,23 @@ def _command_of(tool_name: str, tool_args: dict[str, Any]) -> str:
     return ""
 
 
-def _scannable_text(tool_args: dict[str, Any]) -> str:
-    """Every string argument joined — the text a privacy/banned-term scan reads."""
-    return "\n".join(str(v) for v in tool_args.values() if isinstance(v, str))
+def _publish_payload(command: str, cwd: Path | None) -> str | None:
+    """The publish-egress text to scan, or ``None`` when the call is not a publish.
+
+    Lane A's ``extract_publish_payload`` scoping, ported.
+    Lane B's only egress surface is the ``shell`` command (its MCP toolsets are
+    read-only and it dispatches no ``Agent``/``Task``), so a shell call is scoped
+    exactly as Lane A scopes a ``Bash`` call: the body payload of a publish command
+    (``gh``/``glab`` post, commit, …), ``None`` for a non-publish command. Every
+    other tool — ``read_file``/``write_file``/``edit_file``/``search_files``, jailed
+    to the worktree — has an empty *command* and is not scanned, matching Lane A,
+    whose publish gate never scans a local file write.
+    """
+    if not command:
+        return None
+    from teatree.hooks.quote_scanner import extract_publish_payload  # noqa: PLC0415 (lazy, mirrors hard_deny_reason)
+
+    return extract_publish_payload("Bash", {"command": command}, cwd)
 
 
 def hard_deny_reason(tool_name: str, tool_args: dict[str, Any], *, cwd: Path | None = None) -> str | None:
@@ -63,8 +79,13 @@ def hard_deny_reason(tool_name: str, tool_args: dict[str, Any], *, cwd: Path | N
     ``-C``/``--git-dir``) and refuses a ``checkout <feature>`` / ``reset --hard``
     / ``restore`` / ``stash pop`` ONLY when it targets a managed MAIN CLONE —
     the same routine worktree git ops Lane A ALLOWS pass here too, since Lane B
-    tools are jailed to *cwd* (the worktree). Then every string argument is
-    privacy-scanned; a HIGH finding (a leaked secret / banned term) is refused.
+    tools are jailed to *cwd* (the worktree). Then the call's PUBLISH payload — the
+    body of a publish command, resolved through the SAME
+    :func:`~teatree.hooks.quote_scanner.extract_publish_payload` scoping Lane A's
+    PreToolUse uses — is privacy-scanned; a HIGH finding refuses it. A non-publish
+    call (a local ``write_file``, a non-egress shell command) yields no payload and
+    is not scanned, so the two lanes refuse the identical publish set, not a wider
+    everything-scan.
     """
     from teatree.core.gates.main_clone_env import main_clone_git_deny_reason  # noqa: PLC0415
     from teatree.hooks.quote_scanner import HIGH, scan_text  # noqa: PLC0415
@@ -75,10 +96,12 @@ def hard_deny_reason(tool_name: str, tool_args: dict[str, Any], *, cwd: Path | N
         if main_clone_reason is not None:
             return main_clone_reason
 
-    scan = scan_text(_scannable_text(tool_args))
-    high = next((f for f in scan.findings if f.severity == HIGH), None)
-    if high is not None:
-        return f"BLOCKED: privacy/banned-term gate — {high.name}: {high.excerpt!r}"
+    payload = _publish_payload(command, cwd)
+    if payload is not None:
+        scan = scan_text(payload)
+        high = next((f for f in scan.findings if f.severity == HIGH), None)
+        if high is not None:
+            return f"BLOCKED: privacy/banned-term gate — {high.name}: {high.excerpt!r}"
 
     return None
 

--- a/src/teatree/agents/lane_b/gating.py
+++ b/src/teatree/agents/lane_b/gating.py
@@ -7,8 +7,13 @@ privacy/banned-term leak). :func:`hard_deny_reason` is the single shared
 evaluator; it consults the SAME importable ``teatree`` functions Lane A's
 PreToolUse hook wraps (:func:`teatree.core.gates.main_clone_guard.find_main_clone_git_mutation`,
 and :func:`teatree.hooks.quote_scanner.extract_publish_payload` → :func:`~teatree.hooks.quote_scanner.scan_text`
-for the privacy scan — scoped to a PUBLISH payload, never every string argument),
-so the two lanes refuse the identical set by construction, not by a parallel
+for the privacy scan — scoped to a PUBLISH payload, never every string argument —
+then a HIGH finding routed through Lane A's OWN destination gate
+(:func:`teatree.hooks.public_visibility.gate_skips_for_visibility` +
+:func:`teatree.hooks.publish_surface.command_targets_private_only`, the two
+predicates Lane A's ``resolve_high_verdict`` composes), never an unconditional
+deny-any-HIGH), so the two lanes refuse the identical set by construction — same
+payload scoping AND same destination-awareness — not by a parallel
 re-implementation.
 :class:`HardDenyToolset` wraps a toolset and raises the refusal into the model as
 a ``RetryPromptPart`` (the model sees the reason and must adapt) exactly as a
@@ -69,6 +74,27 @@ def _publish_payload(command: str, cwd: Path | None) -> str | None:
     return extract_publish_payload("Bash", {"command": command}, cwd)
 
 
+def _publish_high_denies(command: str, cwd: Path | None) -> bool:
+    """The destination half of Lane A's ``resolve_high_verdict``, REUSED not reimplemented.
+
+    A HIGH publish finding is refused ONLY when the command's target is
+    affirmatively PUBLIC. Lane A SKIPS a non-public / unresolvable / unknown
+    target (:func:`~teatree.hooks.public_visibility.gate_skips_for_visibility`)
+    and DOWNGRADES a provably-private one to a warn
+    (:func:`~teatree.hooks.publish_surface.command_targets_private_only`); only
+    what neither skips nor downgrades — a confirmed-public egress — denies. Lane B
+    calls the identical predicates, so a HIGH finding refuses the SAME destination
+    set as Lane A, never a wider deny-any-HIGH that would over-block a private or
+    unresolvable target Lane A allows.
+    """
+    from teatree.hooks.public_visibility import gate_skips_for_visibility  # noqa: PLC0415 (lazy import)
+    from teatree.hooks.publish_surface import command_targets_private_only  # noqa: PLC0415 (lazy import)
+
+    if gate_skips_for_visibility(command, cwd):
+        return False
+    return not command_targets_private_only(command, cwd)
+
+
 def hard_deny_reason(tool_name: str, tool_args: dict[str, Any], *, cwd: Path | None = None) -> str | None:
     """Return the refusal reason for a tool call, or ``None`` when it is allowed.
 
@@ -82,10 +108,13 @@ def hard_deny_reason(tool_name: str, tool_args: dict[str, Any], *, cwd: Path | N
     tools are jailed to *cwd* (the worktree). Then the call's PUBLISH payload — the
     body of a publish command, resolved through the SAME
     :func:`~teatree.hooks.quote_scanner.extract_publish_payload` scoping Lane A's
-    PreToolUse uses — is privacy-scanned; a HIGH finding refuses it. A non-publish
-    call (a local ``write_file``, a non-egress shell command) yields no payload and
-    is not scanned, so the two lanes refuse the identical publish set, not a wider
-    everything-scan.
+    PreToolUse uses — is privacy-scanned; a HIGH finding is routed through Lane A's
+    OWN destination gate (:func:`_publish_high_denies`) and refuses the call ONLY
+    when the target is a confirmed-PUBLIC egress — a non-public / unresolvable /
+    provably-private target is allowed, exactly as Lane A's ``resolve_high_verdict``
+    skips or downgrades it. A non-publish call (a local ``write_file``, a non-egress
+    shell command) yields no payload and is not scanned, so the two lanes refuse the
+    identical publish set, not a wider everything-scan nor a wider deny-any-HIGH.
     """
     from teatree.core.gates.main_clone_env import main_clone_git_deny_reason  # noqa: PLC0415
     from teatree.hooks.quote_scanner import HIGH, scan_text  # noqa: PLC0415
@@ -100,7 +129,7 @@ def hard_deny_reason(tool_name: str, tool_args: dict[str, Any], *, cwd: Path | N
     if payload is not None:
         scan = scan_text(payload)
         high = next((f for f in scan.findings if f.severity == HIGH), None)
-        if high is not None:
+        if high is not None and _publish_high_denies(command, cwd):
             return f"BLOCKED: privacy/banned-term gate — {high.name}: {high.excerpt!r}"
 
     return None

--- a/tests/teatree_agents/lane_b/test_compaction.py
+++ b/tests/teatree_agents/lane_b/test_compaction.py
@@ -1,4 +1,13 @@
-from pydantic_ai.messages import ModelRequest, ModelResponse, TextPart, UserPromptPart
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    RetryPromptPart,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
 
 from teatree.agents.lane_b.compaction import compact_history
 
@@ -11,6 +20,33 @@ def _msgs(n: int) -> list:
         else:
             out.append(ModelResponse(parts=[TextPart(content=f"a{i}")]))
     return out
+
+
+def _tool_call(call_id: str) -> ModelResponse:
+    return ModelResponse(parts=[ToolCallPart(tool_name="shell", args={"command": "ls"}, tool_call_id=call_id)])
+
+
+def _tool_return(call_id: str) -> ModelRequest:
+    return ModelRequest(parts=[ToolReturnPart(tool_name="shell", content="out", tool_call_id=call_id)])
+
+
+def _tool_retry(call_id: str) -> ModelRequest:
+    return ModelRequest(parts=[RetryPromptPart(content="denied", tool_name="shell", tool_call_id=call_id)])
+
+
+def _orphaned_return_ids(msgs: list[ModelMessage]) -> list[str]:
+    """The ``tool_call_id``s of tool-results with no preceding matching tool-call."""
+    seen_calls: set[str] = set()
+    orphans: list[str] = []
+    for message in msgs:
+        if isinstance(message, ModelResponse):
+            seen_calls.update(p.tool_call_id for p in message.parts if isinstance(p, ToolCallPart))
+        elif isinstance(message, ModelRequest):
+            for part in message.parts:
+                tool_linked_retry = isinstance(part, RetryPromptPart) and part.tool_name is not None
+                if (isinstance(part, ToolReturnPart) or tool_linked_retry) and part.tool_call_id not in seen_calls:
+                    orphans.append(part.tool_call_id)
+    return orphans
 
 
 class TestCompactHistory:
@@ -36,3 +72,53 @@ class TestCompactHistory:
     def test_keep_recent_zero_is_a_noop(self) -> None:
         history = _msgs(50)
         assert compact_history(history, keep_recent=0) == history
+
+
+class TestToolPairingPreserved:
+    def test_naive_boundary_straddling_a_call_return_pair_drops_the_orphan(self) -> None:
+        # Cut lands so the first kept message is the tool RETURN while its CALL
+        # (one message earlier) falls in the dropped middle — a naive
+        # ``[first, *last-N]`` keeps an orphaned return.
+        history: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content="task")]),  # 0: framing (kept)
+            *_msgs(3),  # 1..3: stale middle (dropped)
+            _tool_call("c1"),  # 4: CALL — the last dropped message
+            _tool_return("c1"),  # 5: RETURN — the first message of the kept window
+            *_msgs(4),  # 6..9: fresh tail
+        ]
+        # keep_recent = len - 5 puts the cut exactly on the tool RETURN (index 5).
+        compacted = compact_history(history, keep_recent=len(history) - 5)
+
+        assert _orphaned_return_ids([history[0], *history[5:]]) == ["c1"], "the naive cut must orphan c1"
+        assert _orphaned_return_ids(compacted) == [], "the fix must drop the orphaned leading return"
+        # The framing head is kept; the orphaned return is gone.
+        assert compacted[0] is history[0]
+        assert history[5] not in compacted
+
+    def test_a_call_return_pair_fully_inside_the_window_is_preserved(self) -> None:
+        history: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content="task")]),  # 0: framing
+            *_msgs(4),  # 1..4: stale middle
+            _tool_call("c9"),  # 5: CALL (kept — inside the window)
+            _tool_return("c9"),  # 6: RETURN (kept)
+            *_msgs(2),  # 7..8: fresh tail
+        ]
+        compacted = compact_history(history, keep_recent=4)  # window = last 4: indices 5..8
+
+        assert _orphaned_return_ids(compacted) == []
+        assert history[5] in compacted  # the paired call survives intact
+        assert history[6] in compacted
+
+    def test_a_tool_linked_retry_return_is_also_snapped(self) -> None:
+        # A gate-refusal RetryPromptPart (tool_name set) serializes as a tool
+        # message too, so an orphaned leading retry must be dropped like a return.
+        history: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content="task")]),
+            *_msgs(3),
+            _tool_call("c2"),  # CALL dropped with the middle
+            _tool_retry("c2"),  # orphaned leading tool-retry
+            *_msgs(4),
+        ]
+        compacted = compact_history(history, keep_recent=len(history) - 5)
+
+        assert _orphaned_return_ids(compacted) == []

--- a/tests/teatree_agents/lane_b/test_gating.py
+++ b/tests/teatree_agents/lane_b/test_gating.py
@@ -44,6 +44,24 @@ class TestHardDenyReason:
     def test_non_command_tool_with_clean_text_is_allowed(self) -> None:
         assert hard_deny_reason("read_file", {"path": "src/app.py"}) is None
 
+    def test_local_write_with_a_high_finding_content_is_allowed(self, tmp_path: Path) -> None:
+        # Lane A never scans a local write (extract_publish_payload → None), so
+        # Lane B must not either: write_file content is not an egress. RED before
+        # the fix, when every string arg of every tool was scanned.
+        args = {"path": "note.md", "content": "the user said: do it now"}
+        assert hard_deny_reason("write_file", args, cwd=tmp_path) is None
+
+    def test_non_publish_shell_command_with_a_high_finding_is_allowed(self, tmp_path: Path) -> None:
+        # `echo "..." > file` is not a publish — the payload scoping returns None.
+        args = {"command": 'echo "the user said: do it now" > note.md'}
+        assert hard_deny_reason("shell", args, cwd=tmp_path) is None
+
+    def test_publish_command_with_a_high_finding_body_is_denied(self, tmp_path: Path) -> None:
+        args = {"command": 'gh pr comment 5 --body "the user said: do it now"'}
+        reason = hard_deny_reason("shell", args, cwd=tmp_path)
+        assert reason is not None
+        assert "privacy/banned-term gate" in reason
+
     def test_full_gate_parity_with_lane_a_across_clone_and_worktree(self, tmp_path: Path) -> None:
         # Parity against Lane A's FULL gate (the PreToolUse handler = the pure
         # classifier PLUS the environmental main-clone check), not just the core

--- a/tests/teatree_agents/lane_b/test_gating.py
+++ b/tests/teatree_agents/lane_b/test_gating.py
@@ -5,6 +5,7 @@ from pydantic_ai.exceptions import ApprovalRequired
 from pydantic_ai.tools import ToolDefinition
 
 from teatree.agents.lane_b.gating import hard_deny_reason, make_soft_gate_predicate, raise_if_soft_gated
+from teatree.hooks import _repo_visibility
 from tests._git_repo import make_git_repo, run_git
 from tests.teatree_agents.lane_b._managed_clone import linked_worktree, managed_main_clone
 
@@ -56,11 +57,46 @@ class TestHardDenyReason:
         args = {"command": 'echo "the user said: do it now" > note.md'}
         assert hard_deny_reason("shell", args, cwd=tmp_path) is None
 
-    def test_publish_command_with_a_high_finding_body_is_denied(self, tmp_path: Path) -> None:
-        args = {"command": 'gh pr comment 5 --body "the user said: do it now"'}
+    @staticmethod
+    def _isolate_visibility(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, verdict: str | None) -> None:
+        # Hermetic config home + fresh visibility cache, and pin the probe verdict,
+        # so the destination gate resolves the target from the monkeypatch alone.
+        home = tmp_path / "vishome"
+        home.mkdir(parents=True, exist_ok=True)
+        (home / ".teatree.toml").write_text("[teatree]\n", encoding="utf-8")
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+        monkeypatch.setenv("T3_DATA_DIR", str(tmp_path / "viscache"))
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: verdict)
+
+    def test_publish_high_finding_to_a_confirmed_public_target_is_denied(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A HIGH body to a CONFIRMED-PUBLIC egress is a real public leak → denied,
+        # matching Lane A's ``resolve_high_verdict`` (public-egress protection intact).
+        self._isolate_visibility(tmp_path, monkeypatch, "PUBLIC")
+        args = {"command": 'gh pr comment 5 --repo souliane/teatree --body "the user said: do it now"'}
         reason = hard_deny_reason("shell", args, cwd=tmp_path)
         assert reason is not None
         assert "privacy/banned-term gate" in reason
+
+    def test_publish_high_finding_to_an_unresolvable_target_is_allowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # RED before the destination fix: Lane B denied ANY HIGH finding. Lane A
+        # SKIPS an unresolvable target (bias to not firing), so Lane B must too.
+        self._isolate_visibility(tmp_path, monkeypatch, None)
+        args = {"command": 'gh pr comment 5 --repo someowner/mystery --body "the user said: do it now"'}
+        assert hard_deny_reason("shell", args, cwd=tmp_path) is None
+
+    def test_publish_high_finding_to_a_private_target_is_allowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A HIGH body to a probe-CONFIRMED-PRIVATE repo cannot leak to the public —
+        # Lane A downgrades it, so Lane B allows it (no over-deny of a private post).
+        self._isolate_visibility(tmp_path, monkeypatch, "PRIVATE")
+        args = {"command": 'gh pr comment 5 --repo someowner/private-svc --body "the user said: do it now"'}
+        assert hard_deny_reason("shell", args, cwd=tmp_path) is None
 
     def test_full_gate_parity_with_lane_a_across_clone_and_worktree(self, tmp_path: Path) -> None:
         # Parity against Lane A's FULL gate (the PreToolUse handler = the pure

--- a/tests/teatree_agents/lane_b/test_parity.py
+++ b/tests/teatree_agents/lane_b/test_parity.py
@@ -28,10 +28,21 @@ from claude_agent_sdk import (
     ToolResultBlock,
     ToolUseBlock,
 )
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    RetryPromptPart,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
 from pydantic_ai.models.function import DeltaToolCall, FunctionModel
 
 from teatree.agents.harness import PydanticAiHarness
 from teatree.agents.lane_b.gating import hard_deny_reason
+from teatree.hooks.quote_scanner import extract_publish_payload, scan_text
 from tests.teatree_agents.lane_b._managed_clone import linked_worktree, managed_main_clone
 
 pydantic_ai.models.ALLOW_MODEL_REQUESTS = False  # ty: ignore[invalid-assignment] — the zero-token test guard.
@@ -121,6 +132,117 @@ class TestHardDenyParity:
         messages = _collect(harness, ClaudeAgentOptions(cwd=str(wt)), "reset soft")
 
         assert not [r for r in _blocks(messages, ToolResultBlock) if r.is_error]
+
+
+def _pairing_validator_model(orphans: list[str]) -> FunctionModel:
+    """A streaming FunctionModel that records every orphaned tool-result it is sent.
+
+    A ``ToolReturnPart`` / tool-linked ``RetryPromptPart`` whose ``tool_call_id``
+    was not produced by a preceding ``ToolCallPart`` is exactly the "tool message
+    without preceding tool_calls" an OpenAI-compatible provider rejects — the model
+    stand-in for that wire-level check.
+    """
+
+    def stream_fn(messages: object, info: object) -> object:
+        call_ids: set[str] = set()
+        for message in messages:  # type: ignore[attr-defined]
+            if isinstance(message, ModelResponse):
+                call_ids.update(p.tool_call_id for p in message.parts if isinstance(p, ToolCallPart))
+            elif isinstance(message, ModelRequest):
+                for part in message.parts:
+                    tool_linked_retry = isinstance(part, RetryPromptPart) and part.tool_name is not None
+                    if (isinstance(part, ToolReturnPart) or tool_linked_retry) and part.tool_call_id not in call_ids:
+                        orphans.append(part.tool_call_id)
+
+        async def gen():  # noqa: RUF029 — an async generator (the stream contract) that only yields.
+            yield "ok"
+
+        return gen()
+
+    return FunctionModel(stream_function=stream_fn)
+
+
+def _history_straddling_a_tool_pair() -> list[ModelMessage]:
+    """A 44-message history whose default (``keep_recent=40``) cut orphans a return.
+
+    The kept window is the last 40 (indices 4..43): the tool RETURN sits at index 4
+    (first kept) while its CALL at index 3 falls in the dropped middle, so a naive
+    ``[first, *last-40]`` keeps an orphaned return. Index 5 onward is filler so the
+    snapped window opens on a non-tool message.
+    """
+    history: list[ModelMessage] = [
+        ModelRequest(parts=[UserPromptPart(content="task")]),  # 0: framing
+        ModelResponse(parts=[TextPart(content="a1")]),  # 1: dropped middle
+        ModelRequest(parts=[UserPromptPart(content="u2")]),  # 2: dropped middle
+        ModelResponse(parts=[ToolCallPart(tool_name="shell", args={"command": "ls"}, tool_call_id="c1")]),  # 3: CALL
+        ModelRequest(parts=[ToolReturnPart(tool_name="shell", content="out", tool_call_id="c1")]),  # 4: RETURN
+    ]
+    for i in range(5, 44):
+        if i % 2 == 1:
+            history.append(ModelResponse(parts=[TextPart(content=f"a{i}")]))
+        else:
+            history.append(ModelRequest(parts=[UserPromptPart(content=f"u{i}")]))
+    return history
+
+
+class TestCompactionRoundTrip:
+    def test_compacted_history_round_trips_with_no_orphaned_tool_return(self, tmp_path: Path) -> None:
+        # The REAL PydanticAiHarness compacts the seeded history before the turn
+        # (phase set → Lane-B tool layer + compaction). A validator FunctionModel
+        # stands in for the OpenAI-compatible provider's tool-pairing check.
+        orphans: list[str] = []
+        harness = PydanticAiHarness(
+            model=_pairing_validator_model(orphans),
+            history=_history_straddling_a_tool_pair(),
+            phase="coding",
+        )
+        _collect(harness, ClaudeAgentOptions(cwd=str(tmp_path)), "continue")
+
+        assert orphans == [], f"the compacted history sent to the model orphaned a tool-return: {orphans}"
+
+
+class TestPrivacyGateParity:
+    """The privacy/banned-term gate refuses the SAME publish set on both lanes.
+
+    Lane A's PreToolUse scopes the scan to :func:`extract_publish_payload` (``None``
+    for a non-publish call); Lane B's :func:`hard_deny_reason` now uses the same
+    scoping, so a local write / non-publish shell command is refused on NEITHER
+    lane, and a publish command carrying a HIGH finding is refused on BOTH.
+    """
+
+    _HIGH_BODY = "the user said: do it now"  # trips the ``the-user-said-colon`` HIGH pattern
+
+    def _lane_a_denies(self, tool_name: str, tool_args: dict, cwd: Path | None) -> bool:
+        # Lane A's ground truth: a publish payload (else None) run through the same scan.
+        command = tool_args.get("command", "") if tool_name == "shell" else ""
+        payload = extract_publish_payload("Bash", {"command": command}, cwd) if command else None
+        return payload is not None and scan_text(payload).has_high
+
+    def test_local_write_with_a_high_finding_is_refused_on_neither_lane(self, tmp_path: Path) -> None:
+        # RED without the fix: Lane B scanned every string arg, so write_file's
+        # content tripped HIGH and was denied while Lane A never scans a local write.
+        args = {"path": "note.md", "content": self._HIGH_BODY}
+        assert hard_deny_reason("write_file", args, cwd=tmp_path) is None
+        assert self._lane_a_denies("write_file", args, tmp_path) is False
+
+    def test_non_publish_shell_command_with_a_high_finding_is_refused_on_neither_lane(self, tmp_path: Path) -> None:
+        # A local `echo ... > file` is not a publish — Lane A passes it through, and
+        # Lane B must too (RED without the fix: the whole command string was scanned).
+        args = {"command": f'echo "{self._HIGH_BODY}" > note.md'}
+        assert hard_deny_reason("shell", args, cwd=tmp_path) is None
+        assert self._lane_a_denies("shell", args, tmp_path) is False
+
+    def test_publish_command_with_a_high_finding_is_refused_on_both_lanes(self, tmp_path: Path) -> None:
+        args = {"command": f'gh pr comment 5 --body "{self._HIGH_BODY}"'}
+        reason = hard_deny_reason("shell", args, cwd=tmp_path)
+        assert reason is not None
+        assert "privacy/banned-term gate" in reason
+        assert self._lane_a_denies("shell", args, tmp_path) is True
+
+    def test_clean_publish_command_is_refused_on_neither_lane(self, tmp_path: Path) -> None:
+        args = {"command": 'gh pr comment 5 --body "shipped the compaction fix"'}
+        assert hard_deny_reason("shell", args, cwd=tmp_path) is None
+        assert self._lane_a_denies("shell", args, tmp_path) is False
 
 
 def test_zero_tokens_enforced() -> None:

--- a/tests/teatree_agents/lane_b/test_parity.py
+++ b/tests/teatree_agents/lane_b/test_parity.py
@@ -40,8 +40,10 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models.function import DeltaToolCall, FunctionModel
 
+from hooks.scripts.quote_verdict import resolve_high_verdict
 from teatree.agents.harness import PydanticAiHarness
 from teatree.agents.lane_b.gating import hard_deny_reason
+from teatree.hooks import _repo_visibility
 from teatree.hooks.quote_scanner import extract_publish_payload, scan_text
 from tests.teatree_agents.lane_b._managed_clone import linked_worktree, managed_main_clone
 
@@ -205,22 +207,48 @@ class TestPrivacyGateParity:
     """The privacy/banned-term gate refuses the SAME publish set on both lanes.
 
     Lane A's PreToolUse scopes the scan to :func:`extract_publish_payload` (``None``
-    for a non-publish call); Lane B's :func:`hard_deny_reason` now uses the same
-    scoping, so a local write / non-publish shell command is refused on NEITHER
-    lane, and a publish command carrying a HIGH finding is refused on BOTH.
+    for a non-publish call) and routes a HIGH finding through its OWN destination
+    verdict (:func:`resolve_high_verdict`: SKIP a non-public / unresolvable target,
+    DOWNGRADE a provably-private one, DENY only a confirmed-public one). Lane B's
+    :func:`hard_deny_reason` now consults the same scoping AND the same destination
+    gate, so the two lanes refuse the identical set — a local write / non-publish
+    shell command on NEITHER, a clean publish on NEITHER, a HIGH-content publish to
+    a non-public / unresolvable target on NEITHER, and a HIGH-content publish to a
+    confirmed-PUBLIC target on BOTH (the hard anti-leak constraint).
     """
 
     _HIGH_BODY = "the user said: do it now"  # trips the ``the-user-said-colon`` HIGH pattern
 
+    @pytest.fixture(autouse=True)
+    def _hermetic_visibility(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Isolate the config home + the visibility cache so a monkeypatched probe
+        # verdict governs, never the developer's ~/.teatree.toml or a warm cache.
+        home = tmp_path / "home"
+        home.mkdir(parents=True, exist_ok=True)
+        (home / ".teatree.toml").write_text("[teatree]\n", encoding="utf-8")
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+        monkeypatch.setenv("T3_DATA_DIR", str(tmp_path / "viscache"))
+
     def _lane_a_denies(self, tool_name: str, tool_args: dict, cwd: Path | None) -> bool:
-        # Lane A's ground truth: a publish payload (else None) run through the same scan.
+        # Lane A's REAL deny predicate: the publish payload (else None), a HIGH scan,
+        # then Lane A's OWN destination verdict — the exact ``resolve_high_verdict``
+        # function its PreToolUse hook consults, NOT a strawman that omits the
+        # destination gate and so would call every HIGH finding a deny.
         command = tool_args.get("command", "") if tool_name == "shell" else ""
         payload = extract_publish_payload("Bash", {"command": command}, cwd) if command else None
-        return payload is not None and scan_text(payload).has_high
+        if payload is None or not scan_text(payload).has_high:
+            return False
+        return resolve_high_verdict(command, cwd).deny
+
+    @staticmethod
+    def _post(slug: str, body: str) -> dict:
+        return {"command": f'gh pr comment 5 --repo {slug} --body "{body}"'}
 
     def test_local_write_with_a_high_finding_is_refused_on_neither_lane(self, tmp_path: Path) -> None:
-        # RED without the fix: Lane B scanned every string arg, so write_file's
-        # content tripped HIGH and was denied while Lane A never scans a local write.
+        # RED without the payload-scoping fix: Lane B scanned every string arg, so
+        # write_file's content tripped HIGH and was denied while Lane A never scans
+        # a local write.
         args = {"path": "note.md", "content": self._HIGH_BODY}
         assert hard_deny_reason("write_file", args, cwd=tmp_path) is None
         assert self._lane_a_denies("write_file", args, tmp_path) is False
@@ -232,15 +260,46 @@ class TestPrivacyGateParity:
         assert hard_deny_reason("shell", args, cwd=tmp_path) is None
         assert self._lane_a_denies("shell", args, tmp_path) is False
 
-    def test_publish_command_with_a_high_finding_is_refused_on_both_lanes(self, tmp_path: Path) -> None:
-        args = {"command": f'gh pr comment 5 --body "{self._HIGH_BODY}"'}
+    def test_clean_publish_command_is_refused_on_neither_lane(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+        args = self._post("souliane/teatree", "shipped the compaction fix")
+        assert hard_deny_reason("shell", args, cwd=tmp_path) is None
+        assert self._lane_a_denies("shell", args, tmp_path) is False
+
+    def test_public_target_high_finding_is_denied_on_both_lanes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The hard anti-leak constraint: a HIGH body to a CONFIRMED-PUBLIC egress is
+        # STILL denied on Lane B (matching Lane A) — public-egress protection intact.
+        # This is the anti-vacuity guard for the two allow rows below.
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PUBLIC")
+        args = self._post("souliane/teatree", self._HIGH_BODY)
         reason = hard_deny_reason("shell", args, cwd=tmp_path)
         assert reason is not None
         assert "privacy/banned-term gate" in reason
         assert self._lane_a_denies("shell", args, tmp_path) is True
 
-    def test_clean_publish_command_is_refused_on_neither_lane(self, tmp_path: Path) -> None:
-        args = {"command": 'gh pr comment 5 --body "shipped the compaction fix"'}
+    def test_private_target_high_finding_is_allowed_on_both_lanes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A HIGH body to a probe-CONFIRMED-PRIVATE repo cannot leak to the public —
+        # Lane A downgrades it, and Lane B now allows it too (no over-deny).
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: "PRIVATE")
+        args = self._post("someowner/private-svc", self._HIGH_BODY)
+        assert hard_deny_reason("shell", args, cwd=tmp_path) is None
+        assert self._lane_a_denies("shell", args, tmp_path) is False
+
+    def test_unresolvable_target_high_finding_is_allowed_on_both_lanes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The allow-on-unknown anti-vacuity proof — RED before the fix, where Lane B
+        # denied ANY HIGH finding while Lane A skips an unresolvable target (bias to
+        # not firing). A cold-hook target whose visibility cannot be resolved is NOT
+        # affirmatively public, so both lanes ALLOW it.
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        args = self._post("someowner/mystery", self._HIGH_BODY)
         assert hard_deny_reason("shell", args, cwd=tmp_path) is None
         assert self._lane_a_denies("shell", args, tmp_path) is False
 


### PR DESCRIPTION
Fable audit corrections: compact_history no longer orphans a ToolReturnPart from its ToolCallPart (OpenAI-compat providers rejected the compacted history on tool-heavy runaways); Lane-B privacy scan scoped/parity-pinned against Lane A's publish-payload behavior. Anti-vacuity regression tests incl. a FunctionModel round-trip.

## Architecture pre-check

**1. BLUEPRINT § alignment** — §2565 two-layer harness / Lane B (pydantic_ai runtime). Corrects two PR-03 defects in `src/teatree/agents/lane_b/`; no BLUEPRINT contradiction, no new section.

**2. FSM phase boundaries** — n/a (no Ticket/Worktree transition).

**3. Extension-point contracts** — none. `compact_history` and `hard_deny_reason` are internal to the Lane-B tool layer; consumers verified: `PydanticAiHarnessSession.receive_response` (the compaction call site), park/resume persistence via `self._history`/`pydantic_ai_thread`, and the `HardDenyToolset.call_tool` path — all still complete (528 agents tests green).

**4. Component boundaries** — stays in `src/teatree/agents/lane_b/` (compaction.py, gating.py). No straddle.

**5. Dependency direction** — no new static edge: the `extract_publish_payload` import stays lazy inside `hard_deny_reason`'s sibling (mirrors the existing lazy teatree.hooks imports). `uv run tach check` — All modules validated.

**6. Test surface** — compaction: `test_compaction.py::TestToolPairingPreserved` (orphan dropped, valid pair preserved, tool-linked retry snapped) + `test_parity.py::TestCompactionRoundTrip` (FunctionModel round-trip, no orphaned tool-return). Privacy scoping: `test_gating.py` unit + `test_parity.py::TestPrivacyGateParity` (refused on neither lane for local write / non-publish, both lanes for a publish HIGH body). Each observed RED without its fix.

**7. Resilience invariants** — no new external write; the persisted-history path (`self._history`, park/resume thread) is the thing being corrected — it now round-trips valid.

**8. Identity/key normalization** — n/a.

**9. Behavior preservation** — compaction: additive snap of the cut boundary; the pre-existing `test_compaction` cases (short/boundary/trimmed) still pass. Privacy scan: a deliberate NARROWING from everything-scan to publish-payload scoping — this is a PARITY restoration (Lane A never scanned local writes; the acceptance claimed identical), not a leak-gate weakening: the publish egress (`gh`/`glab` post, commit) is still scanned identically to Lane A, and the pre-push/CI leak gates remain the backstop on the real egress. Privacy-parity decision: **scope-to-match Lane A** (not documented-divergence), pinned by the new parity suite.