### PR TITLE
fix(tooling): idempotent ruff, index-read catalog gate, single FSM renderer, hermetic dispatch env

### DIFF
--- a/scripts/hooks/check_antipattern_catalog_sync.py
+++ b/scripts/hooks/check_antipattern_catalog_sync.py
@@ -1,27 +1,56 @@
 """Pre-commit hook: fail when antipatterns.yaml drifts from its generated doc.
 
-Mirrors ``check_blueprint_sync.py`` in spirit: the generated
+Mirrors ``check_cli_reference_sync.py``: the generated
 ``docs/generated/antipattern-catalog.md`` MUST stay in lockstep with its YAML
-source. The hook re-renders the doc in-memory and fails if the committed file
-differs — the fix is to run ``generate_antipattern_catalog.py`` and stage the
-result.
+source. The hook re-renders the doc in-memory and compares against BOTH inputs
+as they sit in the git INDEX — the bytes that will be committed — not the
+working tree. Reading the index is what makes the gate un-maskable: staging a
+``antipatterns.yaml`` edit while leaving the regenerated doc unstaged (or an
+out-of-band working-tree regeneration) cannot repair the file out from under
+the gate and hide a stale committed catalog. The fix on a failure is to run
+``generate_antipattern_catalog.py`` and stage the result.
 
 See: souliane/teatree#166
 """
 
+import subprocess
 import sys
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-_DOC = _REPO_ROOT / "docs" / "generated" / "antipattern-catalog.md"
+_YAML_REL = "src/teatree/quality/antipatterns.yaml"
+_DOC_REL = "docs/generated/antipattern-catalog.md"
 
 
-def main() -> int:
-    sys.path.insert(0, str(_REPO_ROOT / "scripts" / "hooks"))
+def _committed(repo_root: Path, rel: str) -> str | None:
+    """The ``rel`` file as staged in the git index, or ``None`` outside a tracked tree.
+
+    ``git show :<path>`` reads the index entry — the bytes git will record — so a
+    working-tree edit that was not staged leaves the drifted committed bytes here
+    for the gate to catch. ``None`` (no git repo, untracked path) lets the caller
+    fall back to the working tree, e.g. a throwaway test tree.
+    """
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "show", f":{rel}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout if result.returncode == 0 else None
+
+
+def check(repo_root: Path) -> int:
     from generate_antipattern_catalog import build_markdown
 
-    expected = build_markdown()
-    actual = _DOC.read_text(encoding="utf-8") if _DOC.is_file() else ""
+    committed_yaml = _committed(repo_root, _YAML_REL)
+    expected = build_markdown(committed_yaml) if committed_yaml is not None else build_markdown()
+
+    committed_doc = _committed(repo_root, _DOC_REL)
+    if committed_doc is not None:
+        actual = committed_doc
+    else:
+        doc_path = repo_root / _DOC_REL
+        actual = doc_path.read_text(encoding="utf-8") if doc_path.is_file() else ""
 
     if expected == actual:
         return 0
@@ -30,6 +59,11 @@ def main() -> int:
     print("Regenerate and stage it:")
     print("  uv run python scripts/hooks/generate_antipattern_catalog.py")
     return 1
+
+
+def main() -> int:
+    sys.path.insert(0, str(_REPO_ROOT / "scripts" / "hooks"))
+    return check(_REPO_ROOT)
 
 
 if __name__ == "__main__":

--- a/scripts/hooks/generate_antipattern_catalog.py
+++ b/scripts/hooks/generate_antipattern_catalog.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
 
-from teatree.quality.catalog import AntiPatternEntry, load_catalog
+from teatree.quality.catalog import AntiPatternEntry, load_catalog, load_catalog_text
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _DEFAULT_OUTPUT = _REPO_ROOT / "docs" / "generated" / "antipattern-catalog.md"
@@ -52,8 +52,8 @@ def _render_entry(e: AntiPatternEntry) -> list[str]:
     return lines
 
 
-def build_markdown() -> str:
-    entries = load_catalog()
+def build_markdown(catalog_text: str | None = None) -> str:
+    entries = load_catalog_text(catalog_text) if catalog_text is not None else load_catalog()
     greppable = sum(1 for e in entries if e.detection == "greppable")
     judgement = len(entries) - greppable
 

--- a/scripts/lib/url_title_fetcher.py
+++ b/scripts/lib/url_title_fetcher.py
@@ -1,1 +1,11 @@
-../../src/teatree/url_title_fetcher.py
+"""Re-export of :mod:`teatree.url_title_fetcher` for the ``lib.*`` hook import path.
+
+The implementation is canonical in ``src/teatree/url_title_fetcher.py``. This is
+a real module (never a symlink): a symlink puts one physical file under both the
+``scripts/**`` and ``src/**`` ruff per-file-ignore scopes, which breaks
+``ruff check --fix`` idempotency on a pristine checkout.
+"""
+
+from teatree.url_title_fetcher import enrich_prompt, fetch_titles
+
+__all__ = ["enrich_prompt", "fetch_titles"]

--- a/src/teatree/agents/headless.py
+++ b/src/teatree/agents/headless.py
@@ -17,7 +17,6 @@ process registry, no platform autostart.
 import asyncio
 import json
 import logging
-import os
 import shutil
 import time
 from dataclasses import dataclass
@@ -52,6 +51,7 @@ from teatree.llm.anthropic_limits import LimitMatch, classify_limit, classify_ra
 from teatree.llm.credentials import CredentialError
 from teatree.skill_support.loading import SkillLoadingPolicy
 from teatree.types import SkillMetadata
+from teatree.utils.git_run import git_env_hermetic, git_env_without_overrides
 
 if TYPE_CHECKING:
     from pydantic_ai.messages import ModelMessage
@@ -251,7 +251,8 @@ def run_headless(
     options = _build_options(task, system_context, phase=phase, skills=skills, env=child_env)
 
     try:
-        outcome = asyncio.run(_drive_with_heartbeat(task, prompt, options, harness))
+        with git_env_hermetic():
+            outcome = asyncio.run(_drive_with_heartbeat(task, prompt, options, harness))
     except CredentialError as exc:
         # A non-ClaudeSdkHarness resolves its own credential lazily inside
         # ``harness.open`` — this is the same "fail loud, record it" contract
@@ -394,9 +395,13 @@ def _provider_child_env(provider: AgentHarnessProvider | None, *, scope: str = "
             f"valid values: {', '.join(sorted(p.value for p in valid))}"
         )
         raise CredentialError(msg)
+    # Pin the credential onto a GIT_*-stripped base so ``options.env`` cannot
+    # re-introduce an outer git hook's GIT_DIR/GIT_INDEX_FILE (the SDK merges
+    # ``options.env`` over the inherited env, so a GIT_* here would reach the child).
+    base = git_env_without_overrides()
     if provider is AgentHarnessProvider.API_KEY:
-        return resolve_api_key_credential(scope=scope).child_env(os.environ)
-    return resolve_subscription_credential(scope=scope).child_env(os.environ)
+        return resolve_api_key_credential(scope=scope).child_env(base)
+    return resolve_subscription_credential(scope=scope).child_env(base)
 
 
 # souliane/teatree#657: the Layer-2 lane (subscription vs metered) each

--- a/src/teatree/core/management/commands/worktree.py
+++ b/src/teatree/core/management/commands/worktree.py
@@ -16,6 +16,7 @@ import typer
 from django.db import transaction
 from django_typer.management import TyperCommand, command
 
+from teatree.core.diagrams import render_fsm_mermaid
 from teatree.core.gates.local_stack_gate import acquire_or_enqueue
 from teatree.core.machine_output import emit
 from teatree.core.management.commands._workspace_docker import reap_stale_local_stacks
@@ -530,30 +531,13 @@ class Command(TyperCommand):
 
             return build_ticket_lifecycle_mermaid(ticket)
 
-        model_map: dict[str, type] = {"worktree": Worktree, "ticket": Ticket}
+        model_map = {"worktree": Worktree, "ticket": Ticket}
         if model == "task":
             return _task_diagram()
         if model not in model_map:
             self.stderr.write(f"Unknown model: {model}. Choose from: worktree, ticket, task")
             raise SystemExit(1)
-        return _fsm_diagram(model_map[model])
-
-
-def _fsm_diagram(model: type) -> str:
-    """Generate a Mermaid state diagram from django-fsm transitions."""
-    field = model._meta.get_field("state")  # type: ignore[attr-defined]  # noqa: SLF001
-    default = field.default
-    lines = ["stateDiagram-v2", f"    [*] --> {default}"]
-
-    for t in field.get_all_transitions(model):
-        source = t.source
-        target = t.target
-        if source == "*":
-            for choice_val, _label in field.choices:
-                lines.append(f"    {choice_val} --> {target}: {t.name}()")
-        else:
-            lines.append(f"    {source} --> {target}: {t.name}()")
-    return "\n".join(lines)
+        return render_fsm_mermaid(model_map[model])
 
 
 def _task_diagram() -> str:

--- a/src/teatree/quality/catalog.py
+++ b/src/teatree/quality/catalog.py
@@ -64,7 +64,16 @@ class AntiPatternEntry:
 
 def load_catalog(path: Path | None = None) -> tuple[AntiPatternEntry, ...]:
     source = path or catalog_path()
-    text = source.read_text(encoding="utf-8")
+    return load_catalog_text(source.read_text(encoding="utf-8"))
+
+
+def load_catalog_text(text: str) -> tuple[AntiPatternEntry, ...]:
+    """Parse catalog YAML from an in-memory string.
+
+    The path-free entry point lets a drift gate render the catalog from the
+    YAML as it sits in the git index (``git show :<path>``) rather than the
+    working tree, so an unstaged edit cannot mask committed drift.
+    """
     try:
         loaded = yaml.safe_load(text)
     except yaml.YAMLError as exc:

--- a/src/teatree/utils/git.py
+++ b/src/teatree/utils/git.py
@@ -40,7 +40,7 @@ from teatree.utils.git_commit import (
     unsynced_commits,
 )
 from teatree.utils.git_remote_ops import config_value, remote_slug, remote_url
-from teatree.utils.git_run import check, git_env_without_overrides, run, run_strict
+from teatree.utils.git_run import check, git_env_hermetic, git_env_without_overrides, run, run_strict
 from teatree.utils.git_status import full_worktree_diff, status_porcelain, status_porcelain_strict
 from teatree.utils.git_sync import fetch, merge_abort, merge_no_edit, pull_ff_only, push, rebase
 from teatree.utils.git_worktree import (
@@ -69,6 +69,7 @@ __all__ = [
     "fetch",
     "first_commit_message",
     "full_worktree_diff",
+    "git_env_hermetic",
     "git_env_without_overrides",
     "head_sha",
     "last_commit_message",

--- a/src/teatree/utils/git_run.py
+++ b/src/teatree/utils/git_run.py
@@ -8,7 +8,9 @@ runners from here, so the runners live in exactly one place and a test that
 patches the subprocess boundary (``teatree.utils.run``) intercepts all of them.
 """
 
+import contextlib
 import os
+from collections.abc import Iterator
 
 from teatree.utils.run import run_allowed_to_fail, run_checked
 
@@ -38,3 +40,26 @@ def git_env_without_overrides() -> dict[str, str]:
     context must run with this env so it stays hermetic.
     """
     return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
+@contextlib.contextmanager
+def git_env_hermetic() -> Iterator[None]:
+    """Strip every ``GIT_*`` override from ``os.environ`` for the duration, restoring after.
+
+    The mutating sibling of :func:`git_env_without_overrides`, for a caller that
+    cannot pass an explicit ``env=`` — a child spawned by a library that merges
+    ``os.environ`` under the caller's overrides (e.g. the claude-agent-sdk
+    transport builds ``{**os.environ, ..., **options.env}``, a merge that cannot
+    DELETE a key the overrides omit). A dispatch fired from inside a git hook
+    inherits ``GIT_DIR``/``GIT_INDEX_FILE``/``GIT_WORK_TREE``; removing them from
+    ``os.environ`` for the spawn window is the only point such a child inherits a
+    hermetic environment. They are restored on exit so the rest of the process is
+    unaffected.
+    """
+    stripped = {k: v for k, v in os.environ.items() if k.startswith("GIT_")}
+    for key in stripped:
+        del os.environ[key]
+    try:
+        yield
+    finally:
+        os.environ.update(stripped)

--- a/tests/quality/test_url_title_fetcher_reexport.py
+++ b/tests/quality/test_url_title_fetcher_reexport.py
@@ -1,0 +1,43 @@
+"""``scripts/lib/url_title_fetcher.py`` is a real re-export module, not a symlink.
+
+A symlink there pointed one physical file (``src/teatree/url_title_fetcher.py``)
+into the ``scripts/`` tree, so ruff walked the SAME inode twice — once under the
+``scripts/**`` per-file-ignore scope and once under the ``src/**`` scope. Two
+scopes disagreeing on which rules apply is what broke ``ruff check --fix``
+idempotency on a pristine checkout. A real re-export module is a distinct
+physical file, scanned under exactly one scope.
+"""
+
+import importlib
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SHIM = _REPO_ROOT / "scripts" / "lib" / "url_title_fetcher.py"
+
+
+def test_shim_is_a_real_file_not_a_symlink() -> None:
+    assert _SHIM.is_file()
+    assert not _SHIM.is_symlink(), (
+        "scripts/lib/url_title_fetcher.py must be a real re-export module, not a symlink into "
+        "src/ — a symlinked inode is scanned by ruff under two per-file-ignore scopes and breaks "
+        "`ruff check --fix` idempotency."
+    )
+
+
+def test_shim_reexports_the_public_api() -> None:
+    shim = importlib.import_module("lib.url_title_fetcher")
+    canonical = importlib.import_module("teatree.url_title_fetcher")
+    assert shim.enrich_prompt is canonical.enrich_prompt
+    assert shim.fetch_titles is canonical.fetch_titles
+
+
+def test_ruff_walks_no_inode_under_two_scopes() -> None:
+    """No two ruff-visible files under ``scripts/`` and ``src/`` share an inode.
+
+    The concrete failure this pins: ``ruff check --show-files`` listed the one
+    ``url_title_fetcher`` inode under both paths. A shim re-export severs that.
+    """
+    scripts_files = {p.resolve() for p in (_REPO_ROOT / "scripts").rglob("*.py")}
+    src_files = {p.resolve() for p in (_REPO_ROOT / "src").rglob("*.py")}
+    shared = scripts_files & src_files
+    assert not shared, f"same physical file reachable under both scripts/ and src/: {sorted(shared)}"

--- a/tests/teatree_agents/test_headless_git_env_scrub.py
+++ b/tests/teatree_agents/test_headless_git_env_scrub.py
@@ -1,0 +1,70 @@
+"""A dispatched agent inherits a hermetic environment — no ``GIT_*`` overrides.
+
+When a headless dispatch fires from inside a git hook (pre-commit/pre-push), the
+process env carries ``GIT_DIR``/``GIT_INDEX_FILE``/``GIT_WORK_TREE``. The
+claude-agent-sdk transport spawns its child with ``{**os.environ, ...,
+**options.env}`` — a dict merge that cannot DELETE a key ``options.env`` omits —
+so those overrides would reach the agent and hijack its ``git`` calls onto the
+outer repo. The dispatch seam strips them from ``os.environ`` for the spawn
+window (so the SDK-inherited base is clean) and builds any credential-pinned
+``options.env`` off the stripped base too.
+"""
+
+import os
+from unittest.mock import patch
+
+from django.test import TestCase
+
+import teatree.agents.harness as harness_mod
+import teatree.agents.headless as headless_mod
+from teatree.agents.headless import _provider_child_env, run_headless
+from teatree.config import AgentHarnessProvider
+from teatree.core.models import Session, Task, Ticket
+from tests.teatree_agents._sdk_fake import FakeHarnessSession, success_stream
+
+
+class TestGitEnvStrippedAtDispatch(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.ticket = Ticket.objects.create()
+
+    def test_child_inherits_no_git_overrides_and_they_are_restored(self) -> None:
+        captured: dict[str, set[str]] = {}
+
+        def _make_client(*, options: object = None, **_: object) -> FakeHarnessSession:
+            # os.environ here is the transport's inherited_env base for the child.
+            captured["env"] = {k for k in os.environ if k.startswith("GIT_")}
+            opt_env = getattr(options, "env", None) or {}
+            captured["options_env"] = {k for k in opt_env if k.startswith("GIT_")}
+            return FakeHarnessSession(
+                success_stream({"summary": "ok", "files_modified": [{"path": "src/x.py", "action": "modified"}]})
+            )
+
+        snapshot = headless_mod.TaskUsage(turns=0, cost_usd=0.0)
+        with (
+            patch.dict(os.environ, {"GIT_DIR": "/outer/.git", "GIT_INDEX_FILE": "/outer/.git/index"}, clear=False),
+            patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude"),
+            patch.object(harness_mod, "ClaudeSDKClient", _make_client),
+            patch.object(headless_mod.TaskUsage, "for_task", classmethod(lambda cls, task: snapshot)),
+        ):
+            session = Session.objects.create(ticket=self.ticket, agent_id="a1")
+            task = Task.objects.create(ticket=self.ticket, session=session)
+            run_headless(task, phase="coding", overlay_skill_metadata={})
+
+            assert captured["env"] == set(), f"child inherits GIT_* from os.environ: {captured['env']}"
+            assert captured["options_env"] == set()
+            # Restored for the rest of the (possibly hook) process once dispatch ends.
+            assert os.environ["GIT_DIR"] == "/outer/.git"
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.COMPLETED
+
+
+class TestCredentialChildEnvStripsGitOverrides(TestCase):
+    def test_api_key_child_env_carries_the_token_but_no_git_overrides(self) -> None:
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "key-y", "GIT_DIR": "/outer/.git"}, clear=False):
+            env = _provider_child_env(AgentHarnessProvider.API_KEY)
+
+        assert env is not None
+        assert env["ANTHROPIC_API_KEY"] == "key-y"
+        assert not any(k.startswith("GIT_") for k in env), "credential child env must not carry GIT_* overrides"

--- a/tests/teatree_core/management_commands/test_diagram_canonical_renderer.py
+++ b/tests/teatree_core/management_commands/test_diagram_canonical_renderer.py
@@ -1,0 +1,39 @@
+"""``worktree diagram`` renders through the one canonical FSM renderer.
+
+There were two FSM-diagram renderers: the canonical
+``teatree.core.diagrams.render_fsm_mermaid`` (drift-gated, byte-stable, reused by
+the generate/check hooks) and a private ``_fsm_diagram`` copy inside the
+``worktree`` command. Two renderers drift; the command must call the canonical
+one so its output can never diverge from the committed diagrams.
+"""
+
+from typing import cast
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from teatree.core.diagrams import render_fsm_mermaid
+from teatree.core.management.commands import worktree as worktree_cmd
+from teatree.core.models import Ticket, Worktree
+from tests.teatree_core.management_commands.test_lifecycle import FULL_OVERLAY, SETTINGS, _patch_overlays
+
+
+class TestDiagramCanonicalRenderer(TestCase):
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_worktree_output_equals_render_fsm_mermaid(self) -> None:
+        result = cast("str", call_command("worktree", "diagram"))
+        assert result == render_fsm_mermaid(Worktree)
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_ticket_output_equals_render_fsm_mermaid(self) -> None:
+        result = cast("str", call_command("worktree", "diagram", model="ticket"))
+        assert result == render_fsm_mermaid(Ticket)
+
+    def test_no_local_fsm_diagram_renderer_remains(self) -> None:
+        assert not hasattr(worktree_cmd, "_fsm_diagram"), (
+            "the private _fsm_diagram copy must be deleted — the diagram command uses the "
+            "canonical teatree.core.diagrams.render_fsm_mermaid so there is exactly one renderer."
+        )

--- a/tests/teatree_core/management_commands/test_lifecycle.py
+++ b/tests/teatree_core/management_commands/test_lifecycle.py
@@ -1090,7 +1090,7 @@ class TestLifecycleDiagram(TestCase):
 
         assert "stateDiagram-v2" in result
         assert "[*] --> created" in result
-        assert "provision()" in result
+        assert "created --> provisioned : provision" in result
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
@@ -1099,7 +1099,7 @@ class TestLifecycleDiagram(TestCase):
 
         assert "stateDiagram-v2" in result
         assert "[*] --> not_started" in result
-        assert "scope()" in result
+        assert "not_started --> scoped : scope" in result
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)

--- a/tests/teatree_hooks/test_antipattern_catalog_sync_reads_index.py
+++ b/tests/teatree_hooks/test_antipattern_catalog_sync_reads_index.py
@@ -1,0 +1,100 @@
+"""The antipattern-catalog sync gate reads the git INDEX, not the working tree.
+
+souliane/teatree#166 hardening: a working-tree read let a staged ``antipatterns.yaml``
+edit pair with an unstaged (regenerated) doc — the working tree looked in sync
+while the index carried a stale committed doc, so the drift shipped. Reading both
+the YAML input and the doc from the index (``git show :<path>``) closes the
+generate-before-check / stage-one-not-the-other vacuousness class.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+
+from tests._git_repo import make_git_repo, run_git
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_YAML_REL = "src/teatree/quality/antipatterns.yaml"
+_DOC_REL = "docs/generated/antipattern-catalog.md"
+
+
+def _sync_hook():
+    sys.path.insert(0, str(_REPO_ROOT / "scripts" / "hooks"))
+    return importlib.import_module("check_antipattern_catalog_sync")
+
+
+def _real_yaml() -> str:
+    return (_REPO_ROOT / _YAML_REL).read_text(encoding="utf-8")
+
+
+def _real_doc() -> str:
+    return (_REPO_ROOT / _DOC_REL).read_text(encoding="utf-8")
+
+
+def _seed_in_sync(tmp_path: Path) -> Path:
+    """A committed repo whose YAML and doc are the real, in-sync pair."""
+    repo = make_git_repo(tmp_path / "repo")
+    (repo / _YAML_REL).parent.mkdir(parents=True, exist_ok=True)
+    (repo / _DOC_REL).parent.mkdir(parents=True, exist_ok=True)
+    (repo / _YAML_REL).write_text(_real_yaml(), encoding="utf-8")
+    (repo / _DOC_REL).write_text(_real_doc(), encoding="utf-8")
+    run_git(repo, "add", ".")
+    run_git(repo, "commit", "-qm", "seed in-sync catalog")
+    return repo
+
+
+def test_passes_on_the_real_in_sync_tree() -> None:
+    assert _sync_hook().check(_REPO_ROOT) == 0
+
+
+def test_red_when_staged_yaml_pairs_with_unstaged_doc_regeneration(tmp_path: Path) -> None:
+    """Stage a YAML edit; regenerate the doc in the working tree but do NOT stage it.
+
+    Index: new YAML + old doc (the drift that would be committed). Working tree:
+    new YAML + new doc (looks in sync). Only an index read catches this.
+    """
+    hook = _sync_hook()
+    build_markdown = importlib.import_module("generate_antipattern_catalog").build_markdown
+    repo = _seed_in_sync(tmp_path)
+
+    # Add a valid new entry to the YAML, stage it (index gets the new YAML).
+    new_entry = (
+        "\n- id: pr24-index-read-probe\n"
+        "  name: PR24 index-read probe\n"
+        "  severity: low\n"
+        "  detection: judgement\n"
+        "  anti_pattern: A probe entry that only exists in the staged YAML.\n"
+        "  preferred_pattern: Read the index so this new entry forces a doc regen.\n"
+        "  consumers: [architecture-design]\n"
+        "  refs: [pr24]\n"
+    )
+    new_yaml = _real_yaml() + new_entry
+    (repo / _YAML_REL).write_text(new_yaml, encoding="utf-8")
+    run_git(repo, "add", _YAML_REL)
+
+    # Regenerate the doc into the WORKING TREE only (never staged) — the exact
+    # move that masks drift under a working-tree read.
+    regenerated_doc = build_markdown(new_yaml)
+    (repo / _DOC_REL).write_text(regenerated_doc, encoding="utf-8")
+
+    # A working-tree read would pass vacuously (working tree is internally in sync)...
+    assert build_markdown(new_yaml) == (repo / _DOC_REL).read_text(encoding="utf-8")
+    # ...but the index read must catch the stale committed doc.
+    assert hook.check(repo) == 1
+
+
+def test_red_when_committed_doc_is_stale_after_worktree_repair(tmp_path: Path) -> None:
+    """Commit a stale doc, then repair the working tree — the index read still fires."""
+    hook = _sync_hook()
+    repo = make_git_repo(tmp_path / "repo")
+    (repo / _YAML_REL).parent.mkdir(parents=True, exist_ok=True)
+    (repo / _DOC_REL).parent.mkdir(parents=True, exist_ok=True)
+    (repo / _YAML_REL).write_text(_real_yaml(), encoding="utf-8")
+    stale = _real_doc() + "\nstale drift line the generator never produces\n"
+    (repo / _DOC_REL).write_text(stale, encoding="utf-8")
+    run_git(repo, "add", ".")
+    run_git(repo, "commit", "-qm", "seed stale committed doc")
+
+    # Repair only the working-tree doc (write, do not stage): index keeps the stale bytes.
+    (repo / _DOC_REL).write_text(_real_doc(), encoding="utf-8")
+    assert hook.check(repo) == 1


### PR DESCRIPTION
PR-24 tooling-reliability fixes — four independent root-cause fixes, each with a RED-first regression test observed to fail on pre-fix code.

## Delivered

### 1. `scripts/lib/url_title_fetcher.py`: real re-export module, not a symlink
The symlink pointed one physical file into the `scripts/` tree, so ruff walked the same inode under both the `scripts/**` and `src/**` per-file-ignore scopes — the cause of `ruff check --fix` non-idempotency on a pristine checkout. It is now a real module re-exporting `enrich_prompt`/`fetch_titles` from the canonical `teatree.url_title_fetcher`.
**Acceptance:** `ruff check --show-files` no longer lists the same inode twice; the shim is a real file re-exporting the public API. Pinned by `tests/quality/test_url_title_fetcher_reexport.py`.

### 2. Antipattern-catalog sync gate reads the git index
`check_antipattern_catalog_sync.py` now renders `expected` from the **index** copy of `antipatterns.yaml` and compares against the **index** copy of the generated doc (`git show :<path>`), never the working tree. A staged YAML edit paired with an unstaged (regenerated) doc can no longer mask committed drift. `build_markdown()` gained a catalog-text parameter; `catalog.py` gained `load_catalog_text()` for the path-free render.
**Acceptance:** the gate goes red on a staged-YAML / unstaged-doc mismatch (working tree internally in sync, index drifted). Pinned by `tests/teatree_hooks/test_antipattern_catalog_sync_reads_index.py`.

### 3. Exactly one FSM renderer
The private `_fsm_diagram` copy in `worktree.py` is deleted; `worktree diagram` renders through the canonical `teatree.core.diagrams.render_fsm_mermaid` (drift-gated, byte-stable, reused by the generate/check hooks), so the CLI output can never diverge from the committed diagrams.
**Acceptance:** `worktree diagram` output equals `render_fsm_mermaid(model)`; no `_fsm_diagram` remains. Pinned by `tests/teatree_core/management_commands/test_diagram_canonical_renderer.py`.

### 4. Hermetic sub-agent dispatch environment
The claude-agent-sdk transport spawns its child with `{**os.environ, ..., **options.env}` — a dict merge that cannot delete a `GIT_*` key `options.env` omits — so a dispatch fired from inside a git hook would leak `GIT_DIR`/`GIT_INDEX_FILE`/`GIT_WORK_TREE` into the agent and hijack its `git` calls onto the outer repo. The dispatch seam now strips `GIT_*` from `os.environ` for the spawn window (`git_env_hermetic()`, restored after) and pins any credential env off a `git_env_without_overrides()` base.
**Acceptance:** a dispatched agent's inherited environment carries no `GIT_*` variables and they are restored after; the credential child env keeps its token but no `GIT_*`. Pinned by `tests/teatree_agents/test_headless_git_env_scrub.py`.

## Not delivered in this PR — availability.py mutation-baseline paydown (unnumbered)

The scope's fifth item (drive `src/teatree/core/availability.py`'s mutation baseline 124 → 0) requires an empirical mutmut measure-and-verify loop. `t3 mutation run` scoped to that module returns 334/334 mutants **inconclusive (segfault)** on this host — the documented macOS fork-segfault artifact already recorded in `pyproject.toml` (`[tool.teatree.mutation]`), which points at the Linux CI `mutation-full` job as the source of truth. Setting the baseline to 0 without a verified measurement would be the disarm those same comments explicitly forbid, so it is intentionally left for a Linux measurement rather than shipped unverified. The baseline is untouched.

## Verification
- `bash dev/test-cov.sh`: 95.20% coverage (93% floor), 23543 passed. The sole failure is a `test_jscpd_duplication.py` pytest-timeout (>60s) — a whole-tree scan that runs ~116s on this host under `-n auto --cov`; it passes in isolation and as a pre-commit hook, and `jscpd` reports 0 clones in this diff.
- `tests/quality` + `test_gate_never_lockout_contract.py`: green (same jscpd wall-clock artifact only).
- ruff, ty, tach, module-health, and the catalog/FSM sync gates: green.

Closes #2735
Closes #2831
Closes #2832
Closes #1911
