### PR TITLE
fix(dream): distiller consolidates real learnings + passes acceptance + stamps cadence marker

### DIFF
--- a/src/teatree/loops/dream/transcript_extract.py
+++ b/src/teatree/loops/dream/transcript_extract.py
@@ -81,6 +81,52 @@ _ASK_CUES = (
     "rollback",
 )
 
+#: Declarative INSIGHT / root-cause / decision markers of a SUBSTANTIVE learning
+#: line — the keyword-blind (of :data:`TRANSCRIPT_SIGNALS`) keeper for the rich raw
+#: drift the literal-signal gate dropped. The correction/ask keepers cover the USER's
+#: own prose, but the day's richest drift is often a DECLARATIVE finding the agent
+#: recorded ("root caused the crash to a missing tenant filter", "turns out the
+#: migration never applied", "decided to split the resolver"). Without this keeper the
+#: keyword gate filtered that out before the distiller ever saw it, so a plain pass
+#: distilled 0 clusters from a corpus full of real learnings (#2986). Unlike the
+#: correction/ask keepers this is ROLE-AGNOSTIC — the literal-signal keeper already is,
+#: and a lesson is a lesson whether the user stated it or the agent found it. The cues
+#: stay tight to genuine finding/decision vocabulary, so mechanical status chatter
+#: ("computed result row 7") and cue-free filler carry none of it and stay dropped.
+_LEARNING_CUES = (
+    "root cause",
+    "root-cause",
+    "root caused",
+    "turns out",
+    "turned out",
+    "the bug was",
+    "the bug is",
+    "the issue was",
+    "the issue is",
+    "the problem was",
+    "the problem is",
+    "the fix was",
+    "the fix is",
+    "fixed by",
+    "caused by",
+    "discovered that",
+    "discovered the",
+    "realized",
+    "realised",
+    "learned that",
+    "the lesson",
+    "the mistake was",
+    "the mistake is",
+    "the reason was",
+    "the reason is",
+    "figured out",
+    "the culprit",
+    "boils down to",
+    "decided to",
+    "should have",
+    "the takeaway",
+)
+
 _USER_TURN_RE = re.compile(r'"(?:type|role)"\s*:\s*"user"')
 _WHY_QUESTION_RE = re.compile(r"\bwhy\b[^?]*\?")
 
@@ -130,6 +176,21 @@ def looks_like_user_ask(line: str) -> bool:
     return any(cue in lowered for cue in _ASK_CUES)
 
 
+def looks_like_learning(line: str) -> bool:
+    """True when *line* reads like a SUBSTANTIVE learning: a finding, or a decision.
+
+    Keyword-blind of :data:`TRANSCRIPT_SIGNALS` and, unlike the correction/ask
+    keepers, ROLE-AGNOSTIC: the declarative drift the literal-signal gate dropped is
+    frequently the agent's own recorded finding ("root caused the crash to a missing
+    tenant filter"), not only the user's prose — and a lesson is a lesson whichever
+    turn states it. Mechanical status chatter ("computed result row 7") and cue-free
+    filler carry none of :data:`_LEARNING_CUES`, so the widening keeps substance, not
+    volume. Necessary-not-sufficient alongside the other keepers (#2986).
+    """
+    lowered = line.lower()
+    return any(cue in lowered for cue in _LEARNING_CUES)
+
+
 def _repeated_user_turns(lines: Sequence[str]) -> set[str]:
     user_lines = [line for line in lines if _USER_TURN_HINT in line and _USER_TURN_RE.search(line)]
     counts = Counter(line.strip() for line in user_lines if line.strip())
@@ -137,12 +198,16 @@ def _repeated_user_turns(lines: Sequence[str]) -> set[str]:
 
 
 def high_signal_lines(raw: str) -> str:
-    """Keep the lines worth distilling: keyword signals, correction prose, or asks.
+    """Keep the lines worth distilling: keyword signals, corrections, asks, or learnings.
 
     The user-ask keeper rides here too (#2663) so a recurring manual directive
     reaches the distiller and clusters into an automatable-ask gap — otherwise the
     keyword gate would drop a directive that carries no correction cue and no signal
-    token before the engine ever saw it.
+    token before the engine ever saw it. The learning keeper rides here too (#2986):
+    a declarative finding/decision (from either role) carries no literal signal token
+    and neither a correction nor an ask cue, yet it is the day's richest drift — so the
+    keyword gate used to starve it out and a plain pass distilled 0 clusters from a
+    corpus full of real learnings.
     """
     lines = raw.splitlines()
     repeated = _repeated_user_turns(lines)
@@ -152,6 +217,7 @@ def high_signal_lines(raw: str) -> str:
         if any(signal in line for signal in TRANSCRIPT_SIGNALS)
         or looks_like_user_correction(line)
         or looks_like_user_ask(line)
+        or looks_like_learning(line)
         or line.strip() in repeated
     ]
     return "\n".join(kept)
@@ -171,6 +237,7 @@ def user_ask_lines(raw: str) -> str:
 __all__ = [
     "TRANSCRIPT_SIGNALS",
     "high_signal_lines",
+    "looks_like_learning",
     "looks_like_user_ask",
     "looks_like_user_correction",
     "user_ask_lines",

--- a/tests/teatree_core/management_commands/test_dream.py
+++ b/tests/teatree_core/management_commands/test_dream.py
@@ -8,7 +8,9 @@ engine is a typed seam.
 """
 
 import datetime as dt
+import tempfile
 from io import StringIO
+from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 from unittest.mock import patch
 
@@ -19,7 +21,7 @@ from django.test import TestCase
 from django.utils import timezone
 
 from teatree.core.models import ConsolidatedMemory, DreamRunMarker, Loop, LoopLease
-from teatree.loops.dream.engine import DreamRunResult
+from teatree.loops.dream.engine import ConsolidationExtract, DistilledCluster, DreamRunResult, TranscriptMember
 from teatree.loops.dream.loop import DREAM_LEASE_NAME, DREAM_LEASE_SECONDS, DREAM_LOOP_NAME
 
 
@@ -857,6 +859,82 @@ class DreamPriorArchivedPointerStampsSucceededTestCase(TestCase):
         out = stdout.getvalue()
         assert "re-indexed" in out  # real maintenance happened
         assert "acceptance gate(s) FAILED" not in out
+        marker = DreamRunMarker.objects.get(name=DreamRunMarker.NAME)
+        assert marker.last_succeeded_at is not None
+        assert DreamRunMarker.objects.is_stale(timezone.now()) is False
+
+
+class DreamConsolidatesRawTranscriptLearningTestCase(TestCase):
+    """A raw transcript learning reaches the distiller, grounds, passes the gates, and stamps (#2986).
+
+    The input-starvation regression, end-to-end through the command with the REAL
+    engine + REAL §4 gates + REAL marker (only the LLM distiller and the member
+    enumeration are faked). A realistic session transcript carries a substantive
+    finding that holds NONE of the literal signal tokens and neither a correction
+    nor an ask cue. Before the fix the keyword gate dropped it, the extract was
+    empty, the distiller was never called, 0 clusters were recorded, the §4
+    consolidation gate FAILED, and the DreamRunMarker was never stamped succeeded
+    (the >48h staleness alarm never cleared). The file-side phases are OFF so the
+    ONLY path to a passing consolidation gate is a genuinely-grounded cluster — the
+    gate stays anti-vacuous. The memory dir + transcript are TMP; ``~/.claude`` is
+    never touched.
+    """
+
+    def setUp(self) -> None:
+        self.memdir = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        topic = "the worktree provision lease pid claim guard owner liveness anchored"
+        (self.memdir / "mem_a.md").write_text(f"name: mem_a\n{topic}\n", encoding="utf-8")
+        session_dir = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.jsonl = session_dir / "session-xyz.jsonl"
+        chatter = "\n".join(f'{{"type":"assistant","text":"computed result row {i}"}}' for i in range(30))
+        self.finding = "root caused the empty owner crash to a missing tenant filter in resolve_owner"
+        self.jsonl.write_text(chatter + "\n" + f'{{"type":"assistant","text":"{self.finding}"}}', encoding="utf-8")
+
+    def _run(self, stdout: StringIO) -> None:
+        member = TranscriptMember(path=self.jsonl, kind="main")
+
+        def _distill(extract: ConsolidationExtract) -> list[DistilledCluster]:
+            snippet = next(s for s in extract.snippets if s.kind != "memory")
+            return [
+                DistilledCluster(
+                    cluster_key="raw-learning",
+                    rule="Guard resolve_owner against a missing tenant filter.",
+                    source_files=[str(snippet.path)],
+                    is_binding=False,
+                    verified_citation=self.finding,
+                    durable_destination="",
+                )
+            ]
+
+        with (
+            patch("teatree.loops.dream.engine.enumerate_members", return_value=[member]),
+            patch("teatree.loops.dream.sdk_distiller.sdk_distill", side_effect=_distill),
+            patch("teatree.memory_audit.discover_memory_dirs", return_value=[self.memdir]),
+            patch.dict(
+                "os.environ",
+                {
+                    "T3_DREAM_PROPOSE_EVALS": "0",
+                    "T3_DREAM_CROSS_LINK": "0",
+                    "T3_DREAM_MERGE": "0",
+                    "T3_DREAM_REINDEX": "0",
+                    "T3_DREAM_DECAY": "0",
+                },
+                clear=False,
+            ),
+        ):
+            call_command("dream", "run", stdout=stdout)
+
+    def test_raw_learning_grounds_a_cluster_passes_gates_and_stamps_marker(self) -> None:
+        stdout = StringIO()
+        self._run(stdout)
+        out = stdout.getvalue()
+        # (1) genuinely consolidated real learnings — one grounded cluster recorded.
+        assert ConsolidatedMemory.objects.filter(cluster_key="raw-learning").count() == 1
+        assert "1 cluster(s) recorded" in out
+        # (2) passed acceptance on real non-empty input (no gate laundering).
+        assert "all acceptance gates passed" in out
+        assert "acceptance gate(s) FAILED" not in out
+        # (3) advanced the cadence marker — the >48h staleness alarm cleared.
         marker = DreamRunMarker.objects.get(name=DreamRunMarker.NAME)
         assert marker.last_succeeded_at is not None
         assert DreamRunMarker.objects.is_stale(timezone.now()) is False

--- a/tests/teatree_loops/dream/test_engine.py
+++ b/tests/teatree_loops/dream/test_engine.py
@@ -416,6 +416,18 @@ class BuildExtractTestCase(TestCase):
         joined = "\n".join(s.text for s in extract.snippets)
         assert "computed result row" not in joined
 
+    def test_keeps_substantive_learning_prose_with_no_signal_keyword(self) -> None:
+        # #2986: the day's richest drift is a declarative finding carrying no literal
+        # signal token and no correction/ask cue. The keyword gate starved it before,
+        # so a plain pass distilled 0 clusters from a corpus full of real learnings.
+        chatter = "\n".join(f'{{"type":"assistant","text":"computed result row {i}"}}' for i in range(50))
+        learning = '{"type":"assistant","text":"root caused the empty owner crash to a missing tenant filter"}'
+        member = self._member("session.jsonl", chatter + "\n" + learning, kind="main")
+        extract = build_extract([member])
+        joined = "\n".join(s.text for s in extract.snippets)
+        assert "root caused the empty owner crash" in joined
+        assert "computed result row 25" not in joined
+
     def test_transcript_floor_survives_high_weight_memory_flood(self) -> None:
         flood = [self._member(f"feedback_{i}.md", "BINDING: " + ("x" * 50_000)) for i in range(20)]
         correction = '{"type":"user","text":"why did you do this again? do not, stop, I told you"}'
@@ -467,6 +479,34 @@ class CorrectionProseProducesGroundedClusterTestCase(TestCase):
             run_consolidation(overlay="", since=None, dry_run=False, distiller=_distill)
 
         assert ConsolidatedMemory.objects.filter(cluster_key="correction").count() == 1
+
+    def test_substantive_learning_only_transcript_yields_a_grounded_cluster(self) -> None:
+        # #2986: a transcript whose only substance is a declarative learning (no
+        # signal token, no correction/ask cue) must still reach the distiller and
+        # ground a cluster. RED before the fix: the keyword gate dropped the line, the
+        # extract was empty, the distiller was never called, 0 rows were written.
+        chatter = "\n".join(f'{{"type":"assistant","text":"computed result row {i}"}}' for i in range(30))
+        finding = '{"type":"assistant","text":"root caused the empty owner crash to a missing tenant filter"}'
+        member = TranscriptMember(path=self.tmp / "session.jsonl", kind="main")
+        member.path.write_text(chatter + "\n" + finding)
+
+        def _distill(extract: ConsolidationExtract) -> list[DistilledCluster]:
+            snippet = extract.snippets[0]
+            return [
+                DistilledCluster(
+                    cluster_key="learning",
+                    rule="Guard resolve_owner against a missing tenant filter.",
+                    source_files=[str(snippet.path)],
+                    is_binding=False,
+                    verified_citation="root caused the empty owner crash to a missing tenant filter",
+                    durable_destination="",
+                )
+            ]
+
+        with patch.object(engine, "enumerate_members", return_value=[member]):
+            run_consolidation(overlay="", since=None, dry_run=False, distiller=_distill)
+
+        assert ConsolidatedMemory.objects.filter(cluster_key="learning").count() == 1
 
 
 class WeightedSnippetTestCase(TestCase):

--- a/tests/teatree_loops/dream/test_transcript_extract.py
+++ b/tests/teatree_loops/dream/test_transcript_extract.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 
 from teatree.loops.dream.transcript_extract import (
     high_signal_lines,
+    looks_like_learning,
     looks_like_user_ask,
     looks_like_user_correction,
     user_ask_lines,
@@ -132,6 +133,42 @@ class LooksLikeUserAskTestCase(TestCase):
         assert not looks_like_user_ask('{"type":"user","text":"the pipeline looks wedged today"}')
 
 
+class LooksLikeLearningTestCase(TestCase):
+    """The role-agnostic keeper for a SUBSTANTIVE learning line (#2986).
+
+    The richest raw drift is often a declarative finding/decision carrying none of
+    :data:`TRANSCRIPT_SIGNALS` and neither a correction nor an ask cue — an
+    assistant "root caused X to Y", or a user stating a lesson. This keeper catches
+    it, keyword-blind of the literal-signal list and, unlike the correction/ask
+    keepers, from EITHER role.
+    """
+
+    def test_root_cause_finding_is_flagged(self) -> None:
+        assert looks_like_learning('{"type":"assistant","text":"root caused the crash to a missing tenant filter"}')
+
+    def test_turns_out_discovery_is_flagged(self) -> None:
+        assert looks_like_learning('{"type":"assistant","text":"turns out the migration was never applied"}')
+
+    def test_the_bug_was_is_flagged(self) -> None:
+        assert looks_like_learning('{"type":"assistant","text":"the bug was an off-by-one in the paginator"}')
+
+    def test_decision_is_flagged(self) -> None:
+        assert looks_like_learning('{"type":"assistant","text":"decided to split the resolver into two passes"}')
+
+    def test_user_stated_lesson_is_flagged(self) -> None:
+        # A lesson stated by the USER (not a correction, not an ask) is still drift.
+        assert looks_like_learning('{"type":"user","text":"the reason is the tenant scope is applied too late"}')
+
+    def test_should_have_regret_is_flagged(self) -> None:
+        assert looks_like_learning('{"type":"assistant","text":"I should have run the gate before pushing"}')
+
+    def test_neutral_status_chatter_is_not_flagged(self) -> None:
+        assert not looks_like_learning('{"type":"assistant","text":"computed result row 7"}')
+
+    def test_neutral_filler_prose_is_not_flagged(self) -> None:
+        assert not looks_like_learning('{"type":"user","text":"a neutral request with no cue at all here"}')
+
+
 class UserAskLinesTestCase(TestCase):
     """The sibling of :func:`high_signal_lines` that keeps only user-ask turns."""
 
@@ -180,3 +217,11 @@ class HighSignalLinesTestCase(TestCase):
         # automation half needs it clustered — high_signal_lines must keep it too.
         raw = '{"type":"assistant","text":"noise"}\n{"type":"user","text":"please set up the hotfix lane"}'
         assert "please set up the hotfix lane" in high_signal_lines(raw)
+
+    def test_keeps_substantive_learning_prose_with_no_signal_keyword(self) -> None:
+        # #2986: a declarative learning carries no literal signal token and neither a
+        # correction nor an ask cue, yet it is the day's richest drift — the input the
+        # keyword gate starved before. high_signal_lines must keep it (either role).
+        learning = '{"type":"assistant","text":"root caused the empty owner crash to a missing tenant filter"}'
+        raw = f'{{"type":"assistant","text":"row noise"}}\n{learning}'
+        assert "root caused the empty owner crash" in high_signal_lines(raw)


### PR DESCRIPTION
## Symptom

`t3 dream run` distilled **0 clusters from a corpus full of members** (`nothing_to_consolidate`), its §4 consolidation + acceptance gates FAILED, and the cadence marker (`last_succeeded_at`) never stamped — the >48h staleness alarm never cleared. The self-improvement/reflection loop was effectively blind to fresh session drift.

## Root cause — a single upstream defect (input starvation)

The three symptoms are one bug with two downstream consequences:

- **`high_signal_lines` (`transcript_extract.py`) starved the distiller.** It kept a transcript line only when it carried a **literal signal token** (`TRANSCRIPT_SIGNALS`: `TEATREE GATE` / `BLOCK` / `BINDING` / …) or matched the user-correction / user-ask keepers. The day's richest drift is often a **declarative finding/decision** — "root caused the crash to a missing tenant filter", "turns out the migration never applied", "decided to split the resolver" — which carries none of those. Those lines were filtered out before the distiller ever saw them, so the distiller was left with the already-consolidated memory files and correctly returned `nothing_to_consolidate`.
- **The §4 gate and the marker were working as designed.** With `clusters_recorded == 0` and a stable corpus (no size drop, no schema growth, no file-side maintenance), the consolidation gate (c) *legitimately* failed — that is the anti-vacuity guard doing its job. A failing gate keeps the marker `attempted`-not-`succeeded`, so the staleness alarm never cleared. Neither gate (c) nor the marker is buggy; both were starved of real input.

So the fix is upstream of the gate, not in it — the gate must keep failing on genuinely-empty input.

## The fix

Add `looks_like_learning`, a **role-agnostic** keeper for substantive finding/decision prose — keyword-blind of the literal-signal list, matching the existing `_CORRECTION_CUES` / `_ASK_CUES` keeper pattern — and wire it into `high_signal_lines`. Real transcript learnings now reach the distiller → ≥1 grounded cluster → `clusters_recorded > 0` → gate (c) passes → marker stamped.

The gate is **not** weakened: mechanical status chatter ("computed result row 7") and cue-free filler carry no learning cue and stay dropped, so a genuinely no-op / no-maintenance pass still fails the gate and still refuses to stamp. Existing "drops neutral chatter" tests stay green.

## Anti-vacuity proof (RED before, GREEN after)

With the keeper unwired (isolating exactly the defect), the behavioural tests fail with the reported symptom: `high_signal_lines` returns `''`, `build_extract` yields an empty extract, the distiller is never called, **0 clusters recorded, marker not stamped**. Wiring the keeper turns all of them green.

The full-chain command test `DreamConsolidatesRawTranscriptLearningTestCase` drives the **real** engine + **real** §4 gates + **real** marker over a realistic transcript whose only substance is a learning with no signal token and no correction/ask cue, and asserts:

1. ≥1 grounded cluster recorded (`ConsolidatedMemory` row exists);
2. all acceptance gates pass on real non-empty input (no gate laundering);
3. the cadence marker stamps `succeeded` and staleness clears.

The file-side phases are turned OFF in that test so the **only** path to a passing consolidation gate is a genuinely-grounded cluster — the gate stays anti-vacuous.

## Verification

- `bash dev/test-cov.sh`: **23718 passed**, 0 failures, coverage **95.21%** (≥93% floor).
- `uv run pytest tests/quality tests/test_gate_never_lockout_contract.py`: green.
- `banned-terms scan-tree`: clean (0 findings).
- Full dream scope (`tests/teatree_loops/dream/`, `test_dream.py`, CLI dream tests): 609+ passed.

Do not merge — cold review pending.
