### PR TITLE
fix(signals): S1 first-try-green resolves workstream-slug CLEARs via issue_url (was INSUFFICIENT_DATA for self-merges)

### DIFF
--- a/src/teatree/core/factory_signal_queries.py
+++ b/src/teatree/core/factory_signal_queries.py
@@ -121,16 +121,25 @@ def _merge_audits_in(window: Window, overlay: str) -> list[MergeAudit]:
     return list(qs)
 
 
-def _clear_repo_key(clear: MergeClear) -> tuple[str, int] | None:
-    """``(owner/repo, pr_id)`` for a CLEAR, or ``None`` when its slug is a workstream.
+def _resolved_clear_key(clear: MergeClear) -> tuple[str, int] | None:
+    """``(owner/repo, pr_id)`` for a CLEAR, resolved to the real repo it targets.
 
-    The join key against ``RedMrFixAttempt.pr_url``: both sides canonicalise up
-    to ``owner/repo`` via :func:`normalize_repo_slug`. A workstream-slug CLEAR
-    (``normalize_repo_slug`` → ``""``) cannot be joined and is reported as
-    unmatched rather than silently counted as first-try-green.
+    ``MergeClear.slug`` is a *workstream* slug under teatree's dominant self-merge
+    convention, not ``owner/repo`` — so both S1 (join against ``RedMrFixAttempt``)
+    and S3 (join against ``ReviewVerdict``) resolve the CLEAR's real owner/repo via
+    :func:`resolve_pr_repo_slug` (the same key the merge gate stores the PR under)
+    before joining, offline (no network probe). Resolving-up beats stripping-down:
+    the workstream slug carries no repo, so ``normalize_repo_slug(clear.slug)``
+    would drop the dominant self-merge shape to ``""`` and collapse the sample. A
+    degenerate CLEAR that cannot be resolved (workstream slug, no ticket
+    ``issue_url``, no clone origin) is reported unmatched rather than joined on the
+    wrong slug.
     """
-    slug = normalize_repo_slug(clear.slug)
-    return (slug, clear.pr_id) if slug else None
+    try:
+        slug = resolve_pr_repo_slug(clear)
+    except MergePreconditionError:
+        return None
+    return (slug, clear.pr_id)
 
 
 def _red_pr_keys() -> tuple[set[tuple[str, int]], dict[tuple[str, int], set[str]]]:
@@ -158,12 +167,20 @@ def _red_pr_keys() -> tuple[set[tuple[str, int]], dict[tuple[str, int], set[str]
 
 
 def compute_s1(window: Window, overlay: str, now: datetime) -> Computation:  # noqa: ARG001 — uniform compute signature
-    """S1 first_try_green_rate: merged PRs with zero recorded CI-red fix attempts."""
+    """S1 first_try_green_rate: merged PRs with zero recorded CI-red fix attempts.
+
+    Each merge is joined to its CI-red record under the CLEAR's resolved owner/repo
+    slug (:func:`_resolved_clear_key`), so the workstream-slug CLEAR of the dominant
+    self-merge convention is resolved to its real repo and counts toward the
+    denominator instead of collapsing the whole sample to ``insufficient_data``. A
+    CLEAR whose owner/repo cannot be resolved is routed to ``unmatched_slug`` and
+    dropped from the denominator, the way S3 handles an unjoinable CLEAR.
+    """
     audits = _merge_audits_in(window, overlay)
     matchable: list[tuple[str, int]] = []
     unmatched = 0
     for audit in audits:
-        key = _clear_repo_key(audit.clear)
+        key = _resolved_clear_key(audit.clear)
         if key is None:
             unmatched += 1
         else:
@@ -235,23 +252,6 @@ def compute_s2(window: Window, overlay: str, now: datetime) -> Computation:  # n
     return Computation(SignalReading(numerator / denom, denom, window.days, SignalStatus.OK), evidence)
 
 
-def _verdict_repo_key(clear: MergeClear) -> tuple[str, int] | None:
-    """``(owner/repo, pr_id)`` for a CLEAR keyed the way its verdict is stored.
-
-    ``ReviewVerdict`` is keyed under :func:`resolve_pr_repo_slug` (the owner/repo
-    the merge gate targets), NOT the CLEAR's workstream slug — so S3 must resolve
-    the same owner/repo before ``for_pr``, mirroring how S1 canonicalises both
-    join sides. Offline (no network probe). A degenerate CLEAR that cannot be
-    resolved (workstream slug, no ticket ``issue_url``, no clone origin) is
-    reported unmatched rather than joined on the wrong (workstream) slug.
-    """
-    try:
-        slug = resolve_pr_repo_slug(clear)
-    except MergePreconditionError:
-        return None
-    return (slug, clear.pr_id)
-
-
 def _review_caught(slug: str, pr_id: int) -> bool:
     """True iff any recorded verdict for the PR held or surfaced a blocker/major."""
     for verdict in ReviewVerdict.objects.for_pr(slug, pr_id):
@@ -267,16 +267,17 @@ def compute_s3(window: Window, overlay: str, now: datetime) -> Computation:  # n
 
     The rubber-stamp detector: ≥MIN_SAMPLE merges with a catch rate of zero is a
     vacuous review lane, tripped RED by the red-floor of ``0.0``. Each merge is
-    joined to its verdict under the resolved owner/repo slug (:func:`_verdict_repo_key`,
-    the key ``ReviewVerdict`` is stored under); a CLEAR whose owner/repo cannot be
-    resolved is routed to ``unmatched_slug`` and dropped from the denominator, the
-    way S1 handles an unjoinable CLEAR — never mis-counted as a rubber-stamp.
+    joined to its verdict under the CLEAR's resolved owner/repo slug
+    (:func:`_resolved_clear_key`, the key ``ReviewVerdict`` is stored under); a CLEAR
+    whose owner/repo cannot be resolved is routed to ``unmatched_slug`` and dropped
+    from the denominator, the way S1 handles an unjoinable CLEAR — never mis-counted
+    as a rubber-stamp.
     """
     audits = _merge_audits_in(window, overlay)
     matchable: list[tuple[str, int]] = []
     unmatched = 0
     for audit in audits:
-        key = _verdict_repo_key(audit.clear)
+        key = _resolved_clear_key(audit.clear)
         if key is None:
             unmatched += 1
         else:

--- a/tests/teatree_core/test_factory_signals.py
+++ b/tests/teatree_core/test_factory_signals.py
@@ -10,6 +10,7 @@ or out of the trailing / baseline window.
 """
 
 from datetime import timedelta
+from unittest import mock
 
 import pytest
 from django.test import TestCase
@@ -27,6 +28,8 @@ from teatree.core.factory_signals import (
     repair_iteration_burn,
     review_catch_rate,
 )
+from teatree.core.merge.errors import MergePreconditionError
+from teatree.core.merge.pr_slug_resolution import resolve_pr_repo_slug
 from teatree.core.models.task_attempt import TaskAttempt
 from teatree.core.models.ticket import Ticket
 from teatree.core.models.transition import TicketTransition
@@ -152,6 +155,67 @@ class S1FirstTryGreenTests(FactorySignalsTestBase):
         assert row.reading.value == pytest.approx(0.2)
         assert row.tripped is True
         assert row.verdict == SignalVerdict.RED
+
+    def test_workstream_slug_clear_counts_toward_first_try_green(self) -> None:
+        # Dominant self-merge shape: each CLEAR carries a WORKSTREAM slug while its
+        # RedMrFixAttempt / MergeAudit rows are keyed under the resolved OWNER/REPO
+        # slug (the same `resolve_pr_repo_slug` the merge gate keys on). S1 must
+        # resolve that owner/repo before the join, mirroring S3 — so a real
+        # first_try_green_rate is computed instead of the whole sample collapsing
+        # to insufficient_data because every workstream-slug CLEAR was dropped.
+        for i in range(5):
+            pr_id = 971 + i
+            ticket = TicketFactory(issue_url=f"https://github.com/{self.SLUG}/issues/{pr_id}")
+            merged_at = self.now - timedelta(days=5)
+            clear = MergeClearFactory(
+                ticket=ticket,
+                pr_id=pr_id,
+                slug=f"{pr_id}-feat-x",
+                issued_at=merged_at - timedelta(hours=1),
+                consumed_at=merged_at,
+            )
+            MergeAuditFactory(clear=clear, merged_at=merged_at)
+        self._red(pr_id=971, days_ago=5)
+        self._red(pr_id=972, days_ago=5)
+        reading = first_try_green_rate(now=self.now)
+        assert reading.status == SignalStatus.OK
+        assert reading.status != SignalStatus.INSUFFICIENT_DATA
+        assert reading.value == pytest.approx(0.6)
+        assert reading.sample_size == 5
+
+    def test_unresolvable_clear_is_dropped_not_fabricated_green(self) -> None:
+        # A CLEAR whose owner/repo genuinely cannot be resolved is routed to
+        # unmatched_slug and dropped from the denominator — never fabricated as a
+        # first-try-green. The five resolvable merges (one CI-red) still yield a
+        # real 0.8; the unresolvable one moves the sample from 6 to 5, not into it.
+        for i in range(5):
+            self._merge(pr_id=981 + i, days_ago=5)
+        self._red(pr_id=981, days_ago=5)
+        orphan = MergeClearFactory(
+            pr_id=999,
+            slug="orphan-workstream",
+            issued_at=self.now - timedelta(days=5, hours=1),
+            consumed_at=self.now - timedelta(days=5),
+        )
+        MergeAuditFactory(clear=orphan, merged_at=self.now - timedelta(days=5))
+
+        def resolve_or_raise(clear: object) -> str:
+            if getattr(clear, "pr_id", None) == 999:
+                msg = "no resolvable repo"
+                raise MergePreconditionError(msg)
+            return resolve_pr_repo_slug(clear)
+
+        with mock.patch(
+            "teatree.core.factory_signal_queries.resolve_pr_repo_slug",
+            side_effect=resolve_or_raise,
+        ):
+            report = compute_factory_signals(now=self.now)
+        row = _row(report, "first_try_green")
+        assert row.evidence["unmatched_slug"] == 1
+        assert row.evidence["merges"] == 5
+        assert row.reading.sample_size == 5
+        assert row.reading.value == pytest.approx(0.8)
+        assert row.reading.status == SignalStatus.OK
 
 
 class S2DefectEscapeTests(FactorySignalsTestBase):


### PR DESCRIPTION
## Summary

S1 `first_try_green`'s per-CLEAR key helper (`_clear_repo_key`) keyed each merged CLEAR via `normalize_repo_slug(clear.slug)`. A **workstream slug** (`971-feat-x`) normalizes to `""`, so the CLEAR was routed to `unmatched_slug` and dropped. This is the SAFE direction (it never fabricates first-try-green), but under teatree's **dominant self-merge convention** — where CLEARs carry a workstream slug, not `owner/repo` — *every* merge is dropped, collapsing S1 to `INSUFFICIENT_DATA` and making the session's headline signal inert.

S3 already solved this same bug-class in [#2982](https://github.com/souliane/teatree/pull/2982) by resolving the CLEAR's real `owner/repo` via `resolve_pr_repo_slug(clear)` (offline) before its join. This applies the identical resolution to S1.

## Change

- The two per-CLEAR key helpers (`_clear_repo_key` for S1, `_verdict_repo_key` for S3) were identical modulo the resolution, so they collapse into **one** `_resolved_clear_key` shared by S1 and S3 — a single normalization boundary that resolves *up* to `owner/repo` (via `owner/repo` slug → `ticket.issue_url` → clone origin) rather than stripping *down* to `""`.
- A workstream-slug CLEAR now resolves to its owner/repo and counts toward the denominator, so the `MergeAudit`↔`RedMrFixAttempt` join runs on the real key.
- A genuinely-unresolvable CLEAR (`MergePreconditionError`) is still routed to `unmatched_slug` and dropped — never counted green.
- Fail-loud guards untouched: a dead `my_prs` recorder still yields `instrumentation_gap` (not a fabricated 100%); a low sample still yields `insufficient_data`.
- `resolve_pr_repo_slug` is offline for this read path (no network probe), matching S3's existing reliance on it.

## Anti-vacuity proof

`test_workstream_slug_clear_counts_toward_first_try_green` seeds a window of **five workstream-slug CLEARs** (each with a `ticket.issue_url` resolving to `owner/repo`) plus owner/repo-keyed `MergeAudit`/`RedMrFixAttempt` rows (two CI-red), and asserts a real `first_try_green_rate` of **0.6 at status `ok`, sample_size 5**.

- **RED against pre-fix `_clear_repo_key`** — observed: it drops every workstream-slug CLEAR, denom 0 < MIN_SAMPLE, status `insufficient_data`:

  ```
  AssertionError: assert <SignalStatus.insufficient_data> == <SignalStatus.OK: 'ok'>
  ```

- **GREEN after the fix.**

`test_unresolvable_clear_is_dropped_not_fabricated_green` pins the drop-not-fabricate guard (an unresolvable CLEAR moves the sample from 6 to 5, never into it).

## Verification

- `bash dev/ci-parity.sh`: 23777 passed, 0 failures, coverage 95.21% (floor 93%), all 5 blocking CI predicates green.
- `uv run pytest tests/quality -q`: 603 passed.
- `t3 banned-terms scan-tree`: clean (0 findings).

## Open questions & assumptions

- Assumes `resolve_pr_repo_slug` stays offline for S1's read path (no network), matching S3's existing reliance on it; it resolves via `owner/repo` slug, `ticket.issue_url`, then clone origin, raising only when none yields a repo.
