### PR TITLE
fix(loop): complete dispatch-zone executor contract — revive dark agent zones + persist-time marker claims + registry-parity conformance (#1)

### DIFF
--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -223,6 +223,7 @@ graph TD
     teatree.loop.statusline --> teatree.loop.statusline_loops
     teatree.loop.statusline --> teatree.loop.statusline_render
     teatree.loop.review_request_tracker --> teatree.core.models
+    teatree.loop.dispatch_tables --> teatree.core.modelkit
     teatree.loop.pr_ticket_index --> teatree.loop.dispatch_tables
     teatree.loop.review_claim_signals --> teatree.types
     teatree.loop.review_claim_signals --> teatree.core.models
@@ -346,7 +347,6 @@ graph TD
     teatree.loop.statusline_palette
     teatree.loop.loop_cadences
     teatree.loop.url_specificity
-    teatree.loop.dispatch_tables
     teatree.slack_mrkdwn
     teatree.memory_audit
 ```

--- a/src/teatree/core/modelkit/phases.py
+++ b/src/teatree/core/modelkit/phases.py
@@ -95,6 +95,19 @@ SUBAGENT_BY_PHASE: dict[tuple[str, str], str] = {
     # transition, so not in ``_PHASE_ALIASES``/``CANONICAL_PHASES``. Registered
     # here so it is dispatchable and carries the find-then-verify fan-out below.
     ("author", "bughunt"): "t3:bughunter",
+    # Red-MR auto-fix (#1295 cap D): the loop persistence handler for a failing
+    # ``my_pr.failed`` PR creates an author ``debugging`` task the /loop slot
+    # dispatches to the ``debugger`` sub-agent. ``debug`` is the AGENT_BY_KIND
+    # dispatch *zone*; ``debugging`` is the phase this row runs under.
+    ("author", "debugging"): "t3:debugger",
+    # Codex auto-review (#1254): the codex_review.dispatch persistence handler
+    # creates a reviewer task whose PHASE encodes the review variant, so the
+    # /loop slot resolves the matching ``/codex:*`` slash-command agent directly
+    # (no per-task variant override needed). These are slash-command agents, not
+    # ``agents/*.md`` sub-agents — the conformance guard exempts the ``codex:``
+    # namespace from the ``t3:``-agent-file checks.
+    ("reviewer", "codex_reviewing"): "codex:review",
+    ("reviewer", "codex_adversarial_reviewing"): "codex:adversarial-review",
 }
 
 #: The chaining orchestrator must never be the target of an author phase

--- a/src/teatree/core/models/types.py
+++ b/src/teatree/core/models/types.py
@@ -142,6 +142,26 @@ class TicketExtra(TypedDict, total=False):
     # (pops) its entry, so the map never accumulates stale threads. See
     # ``teatree.agents.pydantic_ai_resume``.
     pydantic_ai_threads: dict[str, list[object]]
+    # #1 dispatch-zone executor contract: metadata the revived correction-zone
+    # persistence handlers stamp so the dispatched agent has its context.
+    # Codex auto-review: the resolved ``/codex:*`` variant on a reviewer ticket.
+    codex_variant: str
+    # RED CARD corrective action: the ``RedCardSignal`` row + surfaces so the
+    # agent can file the enforcement issue and record it via ``link_issue``.
+    red_card_signal_id: int
+    red_card_signal_kind: str
+    red_card_signal_text: str
+    red_card_offending_text: str
+    # Failed-E2E fix: the spec + test title the fix targets.
+    e2e_spec: str
+    e2e_test_title: str
+    # Skill-drift fix: the drifted repo/file + the finding fingerprint.
+    drift_repo: str
+    drift_file: str
+    drift_fingerprint: str
+    # Answerer: the inbound event id + the question detail.
+    answer_event_id: int
+    answer_detail: str
 
 
 class ReviewSkillRun(TypedDict, total=False):

--- a/src/teatree/loop/dispatch.py
+++ b/src/teatree/loop/dispatch.py
@@ -20,12 +20,7 @@ the per-tick ``dispatch`` loop that swallows per-signal errors.
 import logging
 from typing import TYPE_CHECKING
 
-from teatree.loop.dispatch_gates import (
-    claim_red_mr_fix,
-    dispatch_incoming_task,
-    dispatch_slack_message,
-    gate_review_intent,
-)
+from teatree.loop.dispatch_gates import dispatch_incoming_task, dispatch_slack_message, gate_review_intent
 from teatree.loop.dispatch_reducer import (
     codex_review_dispatch,
     dispatch_assigned_issue,
@@ -102,13 +97,14 @@ def _dispatch_one(signal: ScanSignal) -> list[DispatchAction]:
     agent = AGENT_BY_KIND.get(signal.kind)
     if agent is not None:
         actions: list[DispatchAction] = []
-        # #1295 cap D: gate the agent action on the RedMrFixAttempt
-        # idempotency ledger so the same failing head_sha never
-        # re-dispatches. The statusline mirror still fires below.
-        if signal.kind != "my_pr.failed" or claim_red_mr_fix(signal):
-            actions.append(
-                DispatchAction(kind="agent", zone=agent, detail=signal.summary, payload=signal.payload),
-            )
+        # The agent action is emitted unconditionally; the RedMrFixAttempt
+        # idempotency claim for ``my_pr.failed`` (#1295 cap D) now lives at
+        # PERSIST time (``persistence._handle_debug``, #1 blocker), so a dropped
+        # persist rolls the claim back and the next tick retries — the claim can
+        # no longer be burned before the Task is created.
+        actions.append(
+            DispatchAction(kind="agent", zone=agent, detail=signal.summary, payload=signal.payload),
+        )
         if signal.kind in DUAL_DISPATCH:
             actions.append(
                 DispatchAction(

--- a/src/teatree/loop/dispatch_gates.py
+++ b/src/teatree/loop/dispatch_gates.py
@@ -161,21 +161,26 @@ def review_request_dispatch(signal: ScanSignal, pr_url: str) -> list[DispatchAct
     ]
 
 
-def claim_red_mr_fix(signal: ScanSignal) -> bool:
-    """Idempotency gate for capability D's ``my_pr.failed`` dispatch.
+def claim_red_mr_fix(payload: ActionPayload) -> bool:
+    """Idempotency claim for capability D's ``my_pr.failed`` fix dispatch.
 
-    Returns True when the ``(pr_url, head_sha)`` pair was not seen on a
-    previous tick — the caller proceeds to dispatch the agent. Returns
-    False when the same failing SHA already has a recorded attempt —
-    the statusline mirror still emits so the user sees the red MR but
-    the agent does not re-run. Best-effort: any DB issue defaults to
-    True so the fix-attempt path is not silently dropped on a missing
-    migration; the statusline always fires.
+    Called at PERSIST time (``persistence._handle_debug``, #1 blocker fix), not
+    at dispatch time: the claim rides the same ``transaction.atomic`` block that
+    creates the debugging Task, so a dropped/failed persist rolls the claim back
+    and the next tick retries — the marker can no longer be burned before the
+    action lands.
+
+    Returns True when the ``(pr_url, head_sha)`` pair was not seen on a previous
+    tick — the caller proceeds to create the Task. Returns False when the same
+    failing SHA already has a recorded attempt — the statusline mirror still
+    emitted at dispatch so the user sees the red MR, but no new Task is created.
+    Best-effort: any DB issue defaults to True so the fix path is not silently
+    dropped on a missing migration.
     """
     from django.db import DatabaseError  # noqa: PLC0415
 
-    pr_url = str(signal.payload.get("pr_url") or signal.payload.get("url") or "")
-    head_sha = str(signal.payload.get("head_sha", ""))
+    pr_url = str(payload.get("pr_url") or payload.get("url") or "")
+    head_sha = str(payload.get("head_sha", ""))
     if not pr_url or not head_sha:
         return True
     try:
@@ -184,8 +189,8 @@ def claim_red_mr_fix(signal: ScanSignal) -> bool:
         row = RedMrFixAttempt.claim(
             pr_url=pr_url,
             head_sha=head_sha,
-            overlay=str(signal.payload.get("overlay", "")),
-            worktree_hint=str(signal.payload.get("worktree_hint", "")),
+            overlay=str(payload.get("overlay", "")),
+            worktree_hint=str(payload.get("worktree_hint", "")),
         )
     except DatabaseError:
         return True

--- a/src/teatree/loop/dispatch_tables.py
+++ b/src/teatree/loop/dispatch_tables.py
@@ -9,6 +9,8 @@ signal kind routes to; the dispatcher is the *order* the maps are consulted.
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+from teatree.core.modelkit.phases import SUBAGENT_BY_PHASE
+
 ActionKind = Literal["statusline", "agent", "webhook", "mechanical"]
 type ActionPayload = dict[str, Any]
 
@@ -245,3 +247,38 @@ MECHANICAL_BY_KIND: dict[str, tuple[ActionKind, str]] = {
     # ticket-critical-path provision.
     "snapshot_warmer.refresh_needed": ("mechanical", "refresh_snapshot"),
 }
+
+
+def _mechanical_agent_zones() -> frozenset[str]:
+    """The agent zones the mechanical table routes to (e.g. ``t3:e2e``, ``t3:coder``).
+
+    A handful of ``MECHANICAL_BY_KIND`` rows are ``("agent", <zone>)`` — a
+    scanner that mechanically classifies work but hands the *fix* to a phase
+    agent (failed-E2E → ``t3:e2e``, skill-drift → ``t3:coder``). They are agent
+    producers exactly like ``AGENT_BY_KIND``, so :data:`AGENT_ZONES` folds them
+    in structurally rather than re-listing the zones.
+    """
+    return frozenset(zone for kind, zone in MECHANICAL_BY_KIND.values() if kind == "agent")
+
+
+#: Every agent-dispatch *zone* a ``dispatch_*`` path can emit, derived
+#: structurally from its three producers so a new producer widens this set
+#: automatically: the ``AGENT_BY_KIND`` routes, the ``("agent", zone)`` rows of
+#: ``MECHANICAL_BY_KIND``, and every ``SUBAGENT_BY_PHASE`` value (the per-phase
+#: ``pending_task``/answering/codex targets). This is the PRODUCER side of the
+#: persistence executor contract: ``tests/conformance/test_registry_parity.py``
+#: asserts every zone here is either a ``persistence._ZONE_HANDLERS`` consumer or
+#: a ``PERSISTED_AT_SOURCE_ZONES`` no-op, so a new producer with no consumer
+#: fails CI instead of silently dropping the dispatch.
+AGENT_ZONES: frozenset[str] = (
+    frozenset(AGENT_BY_KIND.values()) | _mechanical_agent_zones() | frozenset(SUBAGENT_BY_PHASE.values())
+)
+
+#: Zones that are persisted *by construction* — the ``pending_task`` re-emission
+#: of rows that already exist as ``Task``s. ``dispatch_pending_task`` resolves a
+#: pending row's ``(role, phase)`` to its agent via ``SUBAGENT_BY_PHASE``, so
+#: every such value is a re-emission whose Task is already in the DB. Persisting
+#: it again is a deliberate no-op (keyed off the carried ``task_id``), never a
+#: silent fallthrough — the parity test proves ``AGENT_ZONES`` is exactly the
+#: union of the handler consumers and this set.
+PERSISTED_AT_SOURCE_ZONES: frozenset[str] = frozenset(SUBAGENT_BY_PHASE.values())

--- a/src/teatree/loop/persistence.py
+++ b/src/teatree/loop/persistence.py
@@ -14,32 +14,77 @@ because we look up the existing Ticket+Task before creating new rows.
 """
 
 import logging
+from typing import TYPE_CHECKING
+
+from django.db import transaction
 
 from teatree.core.models import Task, Ticket
 from teatree.loop.dispatch import DispatchAction
+from teatree.loop.dispatch_gates import claim_red_mr_fix
+from teatree.loop.dispatch_tables import PERSISTED_AT_SOURCE_ZONES
+
+if TYPE_CHECKING:
+    from teatree.core.models.types import TicketExtra
 
 logger = logging.getLogger(__name__)
 
 
-def persist_agent_actions(actions: list[DispatchAction]) -> list[Task]:
+def persist_agent_actions(
+    actions: list[DispatchAction],
+    *,
+    errors: dict[str, str] | None = None,
+) -> list[Task]:
     """Translate ``kind="agent"`` actions into DB rows; return the newly created Tasks.
 
-    Each action is dispatched by ``zone`` to a per-zone handler. Unknown
-    zones are logged and skipped — the caller (tick) treats this as
-    advisory, not fatal.
+    The DB is the dispatch queue: every agent zone a ``dispatch_*`` path emits
+    is a COMPLETE executor contract here — routed by ``zone`` to a per-zone
+    handler (``_ZONE_HANDLERS``) that creates the ``Ticket`` + initial ``Task``
+    the ``/loop`` slot then dispatches. A ``pending_task`` re-emission (carrying
+    the existing row's ``task_id``) is persisted-by-construction, so it is a
+    deliberate no-op.
+
+    Fail-loud (#1 blocker): an agent zone with no handler that is NOT a
+    persisted-at-source zone is a *dropped dispatch* — it records
+    ``errors["persist:<zone>"]`` (rendered in ``action_needed``) instead of a
+    silent ``logger.debug``, so a new producer with no consumer is visible.
+    ``errors`` is the ``TickReport.errors`` sink threaded from
+    ``tick_recovery._persist_agent_dispatches``.
     """
     created: list[Task] = []
     for action in actions:
         if action.kind != "agent":
             continue
-        handler = _ZONE_HANDLERS.get(action.zone)
-        if handler is None:
-            logger.debug("No persistence handler for agent zone %r", action.zone)
-            continue
-        task = handler(action)
+        task = _persist_one(action, errors)
         if task is not None:
             created.append(task)
     return created
+
+
+def _persist_one(action: DispatchAction, errors: dict[str, str] | None) -> Task | None:
+    # A ``pending_task`` re-emission carries the existing row's ``task_id``: the
+    # Task is already in the DB (persisted at source), so persisting is a
+    # deliberate no-op. Checked before the handler lookup because a persisted
+    # zone (e.g. ``t3:coder``) overlaps a handler zone (skill-drift → t3:coder):
+    # only the NEW-work action (no ``task_id``) must reach the handler.
+    if "task_id" in action.payload:
+        return None
+    handler = _ZONE_HANDLERS.get(action.zone)
+    if handler is None:
+        if action.zone not in PERSISTED_AT_SOURCE_ZONES:
+            _record_persist_error(errors, action.zone, f"unhandled agent dispatch zone {action.zone!r}")
+            logger.error("No persistence handler for agent zone %r (detail=%r)", action.zone, action.detail)
+        return None
+    try:
+        return handler(action)
+    except Exception as exc:
+        logger.exception("Persistence handler for zone %r failed", action.zone)
+        _record_persist_error(errors, action.zone, f"{type(exc).__name__}: {exc}")
+        return None
+
+
+def _record_persist_error(errors: dict[str, str] | None, zone: str, detail: str) -> None:
+    if errors is not None:
+        errors[f"persist:{zone}"] = detail
 
 
 def _owning_overlay(url: str, scan_tag: str) -> str:
@@ -210,10 +255,300 @@ def _has_open_task(ticket: Ticket, *, phase: str) -> bool:
     return Task.objects.pending_in_phase(phase).filter(ticket=ticket).exists()
 
 
+def _get_or_create_ticket(
+    url: str,
+    *,
+    role: str,
+    overlay: str,
+    extra: "TicketExtra | None" = None,
+) -> tuple[Ticket, bool]:
+    """``get_or_create`` a ticket keyed on ``url`` + reconcile its overlay.
+
+    The shared ticket-row primitive for the correction-zone handlers below
+    (debug / codex / red-card / e2e / skill-drift / answerer). ``overlay`` is the
+    already-resolved owning overlay (a real forge URL resolves via
+    :func:`_owning_overlay`; a synthetic ``<scheme>://…`` key uses the scan tag).
+    ``_reconcile_existing_overlay`` re-infers a pre-existing row from its
+    ``issue_url`` and never blanks a set value (#743), so a synthetic key whose
+    inference is empty is left untouched.
+    """
+    ticket, created = Ticket.objects.get_or_create(
+        issue_url=url,
+        defaults={"overlay": overlay, "role": role, "extra": extra or {}},
+    )
+    _reconcile_existing_overlay(ticket, created=created)
+    return ticket, created
+
+
+def _create_phase_task(ticket: Ticket, *, phase: str, agent_id: str, reason: str) -> Task:
+    """Create a fresh ``Session`` + initial ``Task`` for ``(ticket.role, phase)``.
+
+    Mirrors ``ticket.schedule_coding`` / ``schedule_external_review`` for the
+    phases those methods do not cover (``debugging``/``e2e``/``answering``/
+    ``codex_reviewing``). ``Task.save`` routes a loop-dispatched ``(role, phase)``
+    to INTERACTIVE under the default ``agent_runtime`` (the /loop slot is its
+    dispatcher), so no explicit ``execution_target`` is set here.
+    """
+    from teatree.core.models.session import Session  # noqa: PLC0415 — lazy: avoids the models import cycle
+
+    session = Session.objects.create(ticket=ticket, agent_id=agent_id)
+    return Task.objects.create(ticket=ticket, session=session, phase=phase, execution_reason=reason)
+
+
+def _handle_orchestrator_zone(action: DispatchAction) -> Task | None:
+    """Route the shared ``t3:orchestrator`` zone by payload shape.
+
+    Two distinct signals dispatch to this one zone: the auto-start kickoff
+    (``assigned_issue.ready`` / ``issue_implementer.claimed``, carrying
+    ``auto_start``) and the RED CARD corrective signal (carrying ``row_id`` with
+    NO ``auto_start``). The RED CARD path was silently dropped inside
+    ``_handle_orchestrator`` (its ``auto_start is not True`` guard, #1 blocker),
+    so it gets its OWN handler here rather than sharing the auto-start body.
+    """
+    payload = action.payload
+    if payload.get("row_id") and payload.get("auto_start") is not True:
+        return _handle_red_card(action)
+    return _handle_orchestrator(action)
+
+
+def _handle_red_card(action: DispatchAction) -> Task | None:
+    """RED CARD signal → author ticket + corrective ``coding`` task (#1130).
+
+    Stamps the ``RedCardSignal`` row id into ``ticket.extra`` so the corrective
+    agent can identify the upstream teatree gap, file the enforcement issue, and
+    record it back via ``RedCardSignal.link_issue``. Keyed on a synthetic
+    ``redcard://signal/<row_id>`` url so re-observing the same signal is
+    idempotent (one corrective ticket per red card).
+    """
+    payload = action.payload
+    row_id = payload.get("row_id")
+    if not row_id:
+        logger.debug("Skipping red_card action with no row_id: %r", action.detail)
+        return None
+    ticket, _created = _get_or_create_ticket(
+        f"redcard://signal/{row_id}",
+        role=Ticket.Role.AUTHOR,
+        overlay=str(payload.get("overlay") or ""),
+        extra={
+            "red_card_signal_id": row_id,
+            "red_card_signal_kind": str(payload.get("signal_kind") or ""),
+            "red_card_signal_text": str(payload.get("signal_text") or ""),
+            "red_card_offending_text": str(payload.get("offending_message_text") or ""),
+        },
+    )
+    if ticket.role != Ticket.Role.AUTHOR or _has_open_task(ticket, phase="coding"):
+        return None
+    return _create_phase_task(
+        ticket,
+        phase="coding",
+        agent_id="red-card",
+        reason=(
+            "Auto-scheduled RED CARD corrective action — identify the upstream teatree gap, "
+            "file the enforcement issue, and record it via RedCardSignal.link_issue"
+        ),
+    )
+
+
+def _handle_debug(action: DispatchAction) -> Task | None:
+    """Failing own PR (``my_pr.failed``) → author ticket + ``debugging`` task (#1295 cap D).
+
+    The ``RedMrFixAttempt`` idempotency claim (``claim_red_mr_fix``) rides the
+    SAME atomic block that creates the Task, so a dropped/failed persist rolls
+    the claim back and the next tick retries — the marker can no longer be burned
+    before the fix ran (#1 blocker). A role conflict returns before the claim, so
+    it is never touched. SIG-2 hardens WHAT is claimed (real sha / sentinel).
+    """
+    payload = action.payload
+    pr_url = str(payload.get("pr_url") or payload.get("url") or "")
+    if not pr_url:
+        logger.debug("Skipping t3:debug action with no pr_url: %r", action.detail)
+        return None
+    with transaction.atomic():
+        ticket, _created = _get_or_create_ticket(
+            pr_url,
+            role=Ticket.Role.AUTHOR,
+            overlay=_owning_overlay(pr_url, str(payload.get("overlay") or "")),
+        )
+        if ticket.role != Ticket.Role.AUTHOR or _has_open_task(ticket, phase="debugging"):
+            return None
+        if not claim_red_mr_fix(payload):
+            return None
+        return _create_phase_task(
+            ticket,
+            phase="debugging",
+            agent_id="debug",
+            reason=f"Auto-scheduled red-MR fix — debug {pr_url}",
+        )
+
+
+def _handle_codex_review(action: DispatchAction) -> Task | None:
+    """Codex auto-review dispatch → reviewer ticket + variant-encoded task (#1254).
+
+    The ``CodexReviewMarker`` claim rides the SAME atomic block that creates the
+    Task (#1 blocker): the scanner now emits unconditionally, so persistence owns
+    the per-SHA idempotency and a dropped persist rolls the marker back. The
+    review VARIANT is the dispatch zone (``codex:review`` /
+    ``codex:adversarial-review``); the Task's PHASE encodes it so the /loop slot
+    resolves the matching ``/codex:*`` slash-command agent directly.
+    """
+    from teatree.core.models.codex_review_marker import CodexReviewMarker  # noqa: PLC0415 — lazy: codex path only
+
+    payload = action.payload
+    pr_url = str(payload.get("pr_url") or payload.get("url") or "")
+    slug = str(payload.get("slug") or "")
+    pr_id = payload.get("pr_id")
+    head_sha = str(payload.get("head_sha") or "")
+    if not pr_url or not slug or not isinstance(pr_id, int) or not head_sha:
+        logger.debug("Skipping codex-review action with incomplete payload: %r", action.detail)
+        return None
+    variant = action.zone
+    phase = "codex_adversarial_reviewing" if variant == "codex:adversarial-review" else "codex_reviewing"
+    with transaction.atomic():
+        ticket, _created = _get_or_create_ticket(
+            pr_url,
+            role=Ticket.Role.REVIEWER,
+            overlay=_owning_overlay(pr_url, str(payload.get("overlay") or "")),
+            extra={"reviewed_sha": head_sha, "codex_variant": variant},
+        )
+        if ticket.role != Ticket.Role.REVIEWER or _has_open_task(ticket, phase=phase):
+            return None
+        marker = CodexReviewMarker.claim(
+            slug=slug,
+            pr_id=pr_id,
+            head_sha=head_sha,
+            overlay=str(payload.get("overlay") or ""),
+            variant=variant,
+        )
+        if marker is None:
+            return None
+        return _create_phase_task(
+            ticket,
+            phase=phase,
+            agent_id="codex-review",
+            reason=f"Auto-scheduled codex review ({variant}) — {pr_url}",
+        )
+
+
+def _handle_e2e_fix(action: DispatchAction) -> Task | None:
+    """Failed-E2E post (``e2e.failure_detected``) → author ticket + ``e2e`` task (#1295 cap E).
+
+    Emission is deduped by the scanner's own ``ScannedFailedE2E`` ledger, so this
+    handler carries no marker of its own. Keyed on a synthetic
+    ``e2e-failure://<overlay>/<spec>`` url; the open-``e2e``-task check prevents a
+    duplicate fix while one is in flight.
+    """
+    payload = action.payload
+    spec = str(payload.get("spec") or "")
+    if not spec:
+        logger.debug("Skipping e2e-fix action with no spec: %r", action.detail)
+        return None
+    overlay = str(payload.get("skill_overlay") or payload.get("overlay") or "")
+    ticket, _created = _get_or_create_ticket(
+        f"e2e-failure://{overlay}/{spec}",
+        role=Ticket.Role.AUTHOR,
+        overlay=overlay,
+        extra={"e2e_spec": spec, "e2e_test_title": str(payload.get("test_title") or "")},
+    )
+    if ticket.role != Ticket.Role.AUTHOR or _has_open_task(ticket, phase="e2e"):
+        return None
+    return _create_phase_task(
+        ticket,
+        phase="e2e",
+        agent_id="e2e-fix",
+        reason=f"Auto-scheduled E2E fix — {spec}",
+    )
+
+
+def _handle_skill_drift(action: DispatchAction) -> Task | None:
+    """Skill-drift finding (``skill_drift_detected``) → author ticket + ``coding`` task (#1295 cap H).
+
+    Emission is deduped by the scanner's own ``AssessFinding`` ledger. Keyed on a
+    synthetic ``skill-drift://<repo>/<file>`` url so one drift finding maps to one
+    corrective coding ticket.
+    """
+    payload = action.payload
+    repo = str(payload.get("repo") or "")
+    file_path = str(payload.get("file_path") or payload.get("path") or "")
+    if not repo or not file_path:
+        logger.debug("Skipping skill-drift action with incomplete payload: %r", action.detail)
+        return None
+    ticket, _created = _get_or_create_ticket(
+        f"skill-drift://{repo}/{file_path}",
+        role=Ticket.Role.AUTHOR,
+        overlay=str(payload.get("overlay") or ""),
+        extra={
+            "drift_repo": repo,
+            "drift_file": file_path,
+            "drift_fingerprint": str(payload.get("finding_fingerprint") or ""),
+        },
+    )
+    if ticket.role != Ticket.Role.AUTHOR or _has_open_task(ticket, phase="coding"):
+        return None
+    return _create_phase_task(
+        ticket,
+        phase="coding",
+        agent_id="skill-drift",
+        reason=f"Auto-scheduled skill-drift fix — {file_path}",
+    )
+
+
+def _handle_answerer(action: DispatchAction) -> Task | None:
+    """Inbound question (``incoming_event.task_needed`` answering) → author ticket + ``answering`` task (#670).
+
+    Keyed on a synthetic ``answer://event/<event_id>`` url (the inbound event has
+    no forge URL) so re-observing the same event is idempotent.
+    """
+    payload = action.payload
+    event_id = payload.get("event_id")
+    if not event_id:
+        logger.debug("Skipping answerer action with no event_id: %r", action.detail)
+        return None
+    ticket, _created = _get_or_create_ticket(
+        f"answer://event/{event_id}",
+        role=Ticket.Role.AUTHOR,
+        overlay=str(payload.get("overlay") or ""),
+        extra={"answer_event_id": event_id, "answer_detail": str(payload.get("detail") or "")},
+    )
+    if ticket.role != Ticket.Role.AUTHOR or _has_open_task(ticket, phase="answering"):
+        return None
+    return _create_phase_task(
+        ticket,
+        phase="answering",
+        agent_id="answerer",
+        reason="Auto-scheduled answer — respond to the inbound question",
+    )
+
+
+#: The COMPLETE executor contract: every non-``pending_task`` agent zone a
+#: ``dispatch_*`` path emits maps to a handler that creates its Ticket + Task.
+#: ``tests/conformance/test_registry_parity.py`` asserts
+#: ``AGENT_ZONES == set(_ZONE_HANDLERS) | PERSISTED_AT_SOURCE_ZONES`` so a new
+#: producer with no consumer fails CI instead of silently dropping the dispatch.
 _ZONE_HANDLERS = {
     "t3:reviewer": _handle_reviewer,
-    "t3:orchestrator": _handle_orchestrator,
+    "t3:orchestrator": _handle_orchestrator_zone,
+    "t3:debug": _handle_debug,
+    "t3:e2e": _handle_e2e_fix,
+    "t3:coder": _handle_skill_drift,
+    "t3:answerer": _handle_answerer,
+    "codex:review": _handle_codex_review,
+    "codex:adversarial-review": _handle_codex_review,
 }
+
+#: The ``(role, phase)`` pairs the handlers above write rows on — asserted a
+#: subset of ``SUBAGENT_BY_PHASE`` by the parity test so every persisted row has
+#: a claimer that can dispatch it (a row no phase agent can pick up fails CI).
+_HANDLER_TARGET_PHASES: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("reviewer", "reviewing"),  # _handle_reviewer
+        ("author", "coding"),  # _handle_orchestrator / _handle_red_card / _handle_skill_drift
+        ("author", "debugging"),  # _handle_debug
+        ("author", "e2e"),  # _handle_e2e_fix
+        ("author", "answering"),  # _handle_answerer
+        ("reviewer", "codex_reviewing"),  # _handle_codex_review (standard)
+        ("reviewer", "codex_adversarial_reviewing"),  # _handle_codex_review (adversarial)
+    },
+)
 
 
 __all__ = ["persist_agent_actions"]

--- a/src/teatree/loop/scanners/codex_review.py
+++ b/src/teatree/loop/scanners/codex_review.py
@@ -10,21 +10,25 @@ Decision per open self-authored PR:
 
 1. ``draft: true`` → skip (the user is still iterating; auto-review
     would be noise)
-2. ``CodexReviewMarker.claim(slug, pr_id, head_sha)`` returns ``None``
-    (already dispatched on a previous tick for the same head SHA) → skip
-3. Otherwise → emit one ``codex_review.dispatch`` ``ScanSignal`` carrying
+2. Otherwise → emit one ``codex_review.dispatch`` ``ScanSignal`` carrying
     the dispatch variant (``codex:review`` by default, ``codex:adversarial-review``
     when the diff touches a high-stakes path) so the dispatcher can route
     it to the codex review agent.
 
+The scanner emits UNCONDITIONALLY per non-draft PR every tick — the
+per-SHA idempotency is enforced downstream at PERSIST time, where
+``persistence._handle_codex_review`` claims the ``CodexReviewMarker`` in the
+same transaction that creates the reviewer Task (#1 blocker fix). Before this
+move the scanner burned the marker on every tick even though persistence then
+dropped the dispatch, so the codex review never actually ran yet could not be
+retried. Keying the marker on ``head_sha`` still makes a force-push re-fire the
+review automatically.
+
 The CLI surface mirrors the agent zone naming: ``t3 codex review <pr_url>``
 spawns the same agent the scanner emits a signal for, so manual fire-and-
-forget invocation is available alongside the loop-driven auto-dispatch.
-
-Why a per-SHA marker rather than a PR-level marker: a force-push must
-re-fire the codex review (the diff changed). Keying on head_sha makes
-the re-fire automatic; a PR-level marker would silently skip the second
-review on a meaningful re-push.
+forget invocation is available alongside the loop-driven auto-dispatch. That
+manual path keeps claiming the marker itself (a human-triggered one-shot, not a
+loop persistence flow).
 """
 
 import json
@@ -35,7 +39,6 @@ from dataclasses import dataclass
 from typing import Protocol, TypedDict, cast, runtime_checkable
 
 from teatree.core.author_trust import classify_author
-from teatree.core.models.codex_review_marker import CodexReviewMarker
 from teatree.loop.scanners.base import ScannerError, ScanSignal, classify_gh_stderr
 from teatree.utils.run import run_allowed_to_fail
 
@@ -156,15 +159,12 @@ class CodexReviewScanner:
         if pr.is_draft:
             return None
         variant = _classify_variant(pr.changed_files, slug=pr.slug, author=pr.author)
-        marker = CodexReviewMarker.claim(
-            slug=pr.slug,
-            pr_id=pr.number,
-            head_sha=pr.head_sha,
-            overlay=self.overlay,
-            variant=variant,
-        )
-        if marker is None:
-            return None
+        # The scanner emits UNCONDITIONALLY per open non-draft PR (#1 blocker):
+        # the ``CodexReviewMarker`` idempotency claim moved to persist time
+        # (``persistence._handle_codex_review``) so it rides the same transaction
+        # that creates the reviewer Task — a dropped/failed persist rolls the
+        # marker back and re-fires next tick, instead of the scanner burning the
+        # marker before the review ever executed.
         return ScanSignal(
             kind="codex_review.dispatch",
             summary=f"codex review {pr.slug}#{pr.number} @ {pr.head_sha[:8]} ({variant})",

--- a/src/teatree/loop/tick_recovery.py
+++ b/src/teatree/loop/tick_recovery.py
@@ -47,7 +47,10 @@ def _persist_agent_dispatches(report: "TickReport") -> None:
     from teatree.loop.persistence import persist_agent_actions  # noqa: PLC0415
 
     try:
-        persist_agent_actions(report.actions)
+        # Thread the report's error sink so a dropped/failed per-zone persist
+        # records ``errors["persist:<zone>"]`` (rendered in action_needed) rather
+        # than a silent ``logger.debug`` — the #1 blocker fail-loud contract.
+        persist_agent_actions(report.actions, errors=report.errors)
     except Exception as exc:
         logger.exception("Persisting agent dispatches failed")
         report.errors["dispatch_persist"] = f"{type(exc).__name__}: {exc}"

--- a/tach.toml
+++ b/tach.toml
@@ -503,7 +503,12 @@ depends_on = ["teatree.core.models"]
 [[modules]]
 path = "teatree.loop.dispatch_tables"
 layer = "domain"
-depends_on = []
+depends_on = [
+  # AGENT_ZONES (the producer SSOT the persistence executor contract is proven
+  # against) folds in SUBAGENT_BY_PHASE.values() — a forward same-layer edge the
+  # sibling dispatch_reducer/dispatch_gates already declare.
+  "teatree.core.modelkit"
+]
 
 [[modules]]
 path = "teatree.loop.pr_ticket_index"

--- a/tests/conformance/test_registry_parity.py
+++ b/tests/conformance/test_registry_parity.py
@@ -1,0 +1,115 @@
+"""Producer/consumer registry-parity conformance — the anti-drift framework (#1).
+
+The dominant integration-failure family in the autonomy layer is *paired-registry
+drift*: one side of a producer→consumer seam gains a member while the other does
+not, so work is produced that nothing consumes (or vice versa) and the dispatch
+is silently dropped. The #1 blocker was exactly this — ``dispatch_*`` produced
+~6 agent zones (codex review, red-card, red-MR fix, e2e-fix, answerer,
+skill-drift) that ``persistence._ZONE_HANDLERS`` had no consumer for, so they
+were dropped AND their idempotency markers were burned first.
+
+This module is the reusable structural fix. ``assert_registry_covers`` enumerates
+one side of a seam and asserts coverage on the other; each seam is its OWN test
+function so later fix-PRs (DIS-B/D/E, SIG-4, MW-A/B) add lanes append-only —
+a new registry pair is a new ``TestXParity`` class + a call to the shared helper,
+never a rewrite. Every lane carries an anti-vacuity floor so emptying an
+enumeration cannot turn a lane vacuous-green.
+"""
+
+from collections.abc import Iterable
+
+import pytest
+
+from teatree.core.modelkit.phases import SUBAGENT_BY_PHASE
+from teatree.loop.dispatch_tables import AGENT_ZONES, PERSISTED_AT_SOURCE_ZONES
+from teatree.loop.persistence import _HANDLER_TARGET_PHASES, _ZONE_HANDLERS
+
+
+def assert_registry_covers(
+    *,
+    producers: Iterable[object],
+    consumers: Iterable[object],
+    label: str,
+    allowlist: Iterable[object] = (),
+) -> None:
+    """Assert every *producer* has a *consumer* (or is explicitly allowlisted).
+
+    The single reusable primitive every parity lane below calls. An allowlisted
+    producer is a deliberate no-consumer case (documented at the call site); an
+    un-allowlisted uncovered producer is registry drift and fails loud.
+    """
+    uncovered = set(producers) - set(consumers) - set(allowlist)
+    assert not uncovered, f"{label}: producer(s) with no consumer (registry drift): {sorted(map(str, uncovered))}"
+
+
+class TestDispatchZoneExecutorParity:
+    """LANE 1 — every ``dispatch_*`` agent zone has a persistence executor.
+
+    ``AGENT_ZONES`` (the producer SSOT) must be exactly the union of the
+    ``_ZONE_HANDLERS`` consumers and the ``PERSISTED_AT_SOURCE_ZONES`` no-ops.
+    A new dispatch producer with no persistence consumer fails here — the #1
+    blocker's silent-drop can no longer ship green.
+    """
+
+    def test_every_agent_zone_is_handled_or_persisted_at_source(self) -> None:
+        assert_registry_covers(
+            producers=AGENT_ZONES,
+            consumers=set(_ZONE_HANDLERS) | set(PERSISTED_AT_SOURCE_ZONES),
+            label="AGENT_ZONES -> persistence executor contract",
+        )
+
+    def test_no_handler_or_persisted_zone_is_an_orphan(self) -> None:
+        # The reverse direction: a handler (or persisted-at-source zone) that no
+        # ``dispatch_*`` path can actually produce is dead consumer surface.
+        orphans = (set(_ZONE_HANDLERS) | set(PERSISTED_AT_SOURCE_ZONES)) - set(AGENT_ZONES)
+        assert not orphans, f"consumer zones with no producer: {sorted(orphans)}"
+
+    def test_handler_target_phases_are_dispatchable(self) -> None:
+        # Every (role, phase) a handler writes MUST be a SUBAGENT_BY_PHASE key,
+        # else the persisted row is one no claimer can pick up.
+        orphan = _HANDLER_TARGET_PHASES - set(SUBAGENT_BY_PHASE)
+        assert not orphan, f"handler target (role, phase) with no dispatchable agent: {sorted(orphan)}"
+
+    def test_persisted_at_source_zones_are_the_subagent_values(self) -> None:
+        # The pending_task re-emission set IS the SUBAGENT_BY_PHASE value set —
+        # the two must not drift.
+        assert set(PERSISTED_AT_SOURCE_ZONES) == set(SUBAGENT_BY_PHASE.values())
+
+    def test_cardinality_floors_anti_vacuity(self) -> None:
+        # A refactor that empties an enumeration must not make the lanes above
+        # vacuously green. These floors are safely below the real cardinalities.
+        assert len(AGENT_ZONES) >= 10, AGENT_ZONES
+        assert len(_ZONE_HANDLERS) >= 6, _ZONE_HANDLERS
+        assert len(PERSISTED_AT_SOURCE_ZONES) >= 10, PERSISTED_AT_SOURCE_ZONES
+        assert len(_HANDLER_TARGET_PHASES) >= 6, _HANDLER_TARGET_PHASES
+
+    def test_revived_dark_zones_are_now_handled(self) -> None:
+        # The #1 blocker's specific dark zones: each must now be a real handler
+        # consumer (not merely persisted-at-source), because each is produced by
+        # a NON-pending-task path (AGENT_BY_KIND / MECHANICAL / conditional).
+        for zone in ("t3:debug", "t3:e2e", "t3:coder", "t3:answerer", "codex:review", "codex:adversarial-review"):
+            assert zone in _ZONE_HANDLERS, f"dark zone {zone!r} still has no persistence handler"
+
+
+class TestRegistryParityFrameworkFiresRed:
+    """Anti-vacuity: prove ``assert_registry_covers`` actually catches drift.
+
+    A conformance gate that can never fail is worthless. A synthetic producer
+    with no consumer must raise; an allowlisted one must pass.
+    """
+
+    def test_uncovered_producer_raises(self) -> None:
+        with pytest.raises(AssertionError):
+            assert_registry_covers(
+                producers={"t3:reviewer", "t3:SYNTHETIC-UNCONSUMED"},
+                consumers={"t3:reviewer"},
+                label="self-test",
+            )
+
+    def test_allowlisted_producer_passes(self) -> None:
+        assert_registry_covers(
+            producers={"t3:reviewer", "t3:DELIBERATE-NO-CONSUMER"},
+            consumers={"t3:reviewer"},
+            label="self-test",
+            allowlist={"t3:DELIBERATE-NO-CONSUMER"},
+        )

--- a/tests/teatree_core/test_phase_agent_conformance.py
+++ b/tests/teatree_core/test_phase_agent_conformance.py
@@ -54,6 +54,19 @@ def _agent_name(subagent: str) -> str:
     return subagent.removeprefix("t3:")
 
 
+#: Slash-command agents are resolved by the ``t3 codex`` CLI / ``/codex:*``
+#: slash command, NOT the Agent tool against ``agents/<name>.md``. They are a
+#: distinct spawn mechanism, so they are exempt from the ``t3:``-namespace and
+#: agents-file checks below — but they stay in this KNOWN allowlist so an
+#: arbitrary non-``t3:`` value still fails loud (the checks are not weakened for
+#: any other namespace).
+_SLASH_COMMAND_AGENTS: frozenset[str] = frozenset({"codex:review", "codex:adversarial-review"})
+
+
+def _is_slash_command_agent(subagent: str) -> bool:
+    return subagent in _SLASH_COMMAND_AGENTS
+
+
 class TestSubagentForPhaseConformance(TestCase):
     """The canonical ``subagent_for_phase`` map — the single source of truth."""
 
@@ -175,7 +188,7 @@ class TestEverySubagentResolvesToAnAgentDefinition(TestCase):
         missing = {
             (role, phase): subagent
             for (role, phase), subagent in SUBAGENT_BY_PHASE.items()
-            if not (AGENTS_DIR / f"{_agent_name(subagent)}.md").is_file()
+            if not _is_slash_command_agent(subagent) and not (AGENTS_DIR / f"{_agent_name(subagent)}.md").is_file()
         }
         assert missing == {}, (
             f"phases mapped to a sub-agent with no agents/<name>.md definition: {missing}. "
@@ -186,12 +199,16 @@ class TestEverySubagentResolvesToAnAgentDefinition(TestCase):
         offenders = {
             (role, phase): subagent
             for (role, phase), subagent in SUBAGENT_BY_PHASE.items()
-            if not subagent.startswith("t3:")
+            if not subagent.startswith("t3:") and not _is_slash_command_agent(subagent)
         }
-        assert offenders == {}, f"sub-agent values must be namespaced 't3:<name>': {offenders}"
+        assert offenders == {}, (
+            f"sub-agent values must be namespaced 't3:<name>' (or a known slash-command agent): {offenders}"
+        )
 
     def test_agent_definition_name_matches_its_filename(self) -> None:
         for (role, phase), subagent in SUBAGENT_BY_PHASE.items():
+            if _is_slash_command_agent(subagent):
+                continue  # resolved via the codex CLI / slash command, not agents/<name>.md
             name = _agent_name(subagent)
             agent_file = AGENTS_DIR / f"{name}.md"
             text = agent_file.read_text(encoding="utf-8")
@@ -199,6 +216,15 @@ class TestEverySubagentResolvesToAnAgentDefinition(TestCase):
                 f"{agent_file} frontmatter 'name:' must equal {name!r} so the Agent tool "
                 f"resolves {subagent!r} dispatched for ({role}, {phase})"
             )
+
+    def test_codex_review_phases_resolve_to_slash_command_agents(self) -> None:
+        # The #1 blocker revived codex auto-review by encoding the variant in the
+        # PHASE so the /loop slot resolves the matching /codex:* agent directly.
+        assert subagent_for_phase(Ticket.Role.REVIEWER, "codex_reviewing") == "codex:review"
+        assert subagent_for_phase(Ticket.Role.REVIEWER, "codex_adversarial_reviewing") == "codex:adversarial-review"
+
+    def test_debugging_phase_resolves_to_debugger_agent(self) -> None:
+        assert subagent_for_phase(Ticket.Role.AUTHOR, "debugging") == "t3:debugger"
 
 
 class TestFanoutRegistryConformance(TestCase):

--- a/tests/teatree_loop/phases/test_act.py
+++ b/tests/teatree_loop/phases/test_act.py
@@ -35,7 +35,7 @@ def test_act_phase_runs_mechanical_handler_and_captures_its_error(monkeypatch: p
 
 
 def test_act_phase_captures_persist_failure_instead_of_raising(monkeypatch: pytest.MonkeyPatch) -> None:
-    def boom(_actions: object) -> None:
+    def boom(_actions: object, *, errors: object = None) -> None:
         msg = "persistence down"
         raise RuntimeError(msg)
 

--- a/tests/teatree_loop/test_codex_review_scanner.py
+++ b/tests/teatree_loop/test_codex_review_scanner.py
@@ -4,10 +4,14 @@ The scanner is the structural fix for the "user has to remember to run
 ``/codex:review`` after every push" failure mode encoded in the
 ``feedback_fleet_of_agents_with_codex_doublecheck`` binding. It runs
 every tick, walks the configured repo list, and emits one
-``codex_review.dispatch`` signal per open self-authored PR whose head SHA
-the scanner hasn't seen before — keyed on ``(slug, pr_id, head_sha)``
-via :class:`CodexReviewMarker`. Re-ticking on the same SHA is a no-op;
-a force-push (new SHA) re-fires.
+``codex_review.dispatch`` signal per open non-draft self-authored PR.
+
+The per-SHA idempotency (keyed on ``(slug, pr_id, head_sha)`` via
+:class:`CodexReviewMarker`) moved DOWNSTREAM to persist time (#1 blocker):
+``persistence._handle_codex_review`` claims the marker in the same transaction
+that creates the reviewer Task, so the scanner emits UNCONDITIONALLY and a
+dropped persist rolls the marker back for retry. A force-push (new SHA) still
+re-fires because the marker key includes ``head_sha``.
 
 The scanner is the loop-level enforcement of the fleet-of-agents rule:
 the user never has to ask "have you run codex on this?" again.
@@ -105,18 +109,24 @@ class TestDispatchOnNewSha:
         assert payload["pr_url"] == f"https://github.com/{SLUG}/pull/1254"
         assert payload["overlay"] == "teatree"
 
-    def test_marker_row_persisted_after_dispatch(self) -> None:
-        """After dispatch, a :class:`CodexReviewMarker` row makes re-ticks a no-op."""
+    def test_scanner_does_not_claim_marker_at_scan_time(self) -> None:
+        """The per-SHA marker moved to PERSIST time — the scanner emits, no marker (#1)."""
         api = FakeCodexPrApi(prs_by_slug={SLUG: [_pr()]})
         scanner = _scanner(api=api)
 
-        scanner.scan()
+        signals = scanner.scan()
 
-        marker = CodexReviewMarker.objects.get(slug=SLUG, pr_id=1254, head_sha=HEAD)
-        assert marker.overlay == "teatree"
+        assert [s.kind for s in signals] == ["codex_review.dispatch"]
+        assert not CodexReviewMarker.objects.filter(slug=SLUG, pr_id=1254, head_sha=HEAD).exists()
 
-    def test_second_tick_on_same_head_does_not_redispatch(self) -> None:
-        """The hard requirement: re-ticking on the same SHA is silent."""
+    def test_second_tick_on_same_head_re_emits_dedup_is_persist_time(self) -> None:
+        """The scanner emits UNCONDITIONALLY every tick; dedup is now at persist time (#1).
+
+        Before the #1 blocker fix the scanner burned the marker on the first tick
+        and went silent thereafter — even though persistence then dropped the
+        dispatch, so the review never ran. Now the scanner re-emits and
+        ``persistence._handle_codex_review`` owns the per-SHA idempotency.
+        """
         api = FakeCodexPrApi(prs_by_slug={SLUG: [_pr()]})
         scanner = _scanner(api=api)
 
@@ -124,7 +134,7 @@ class TestDispatchOnNewSha:
         second = scanner.scan()
 
         assert [s.kind for s in first] == ["codex_review.dispatch"]
-        assert second == []
+        assert [s.kind for s in second] == ["codex_review.dispatch"]
 
     def test_new_head_sha_after_force_push_redispatches(self) -> None:
         """A new head SHA on the same PR (force-push) fires a fresh dispatch."""

--- a/tests/teatree_loop/test_dispatch.py
+++ b/tests/teatree_loop/test_dispatch.py
@@ -65,8 +65,15 @@ class MyPrFailedDispatchTests(TestCase):
         assert ("agent", "t3:debug") in kinds_zones
         assert ("statusline", "action_needed") in kinds_zones
 
-    def test_my_pr_failed_idempotent_on_same_head_sha(self) -> None:
-        """Re-dispatching on the same ``(pr_url, head_sha)`` yields no second agent action (#1295 cap D)."""
+    def test_dispatch_always_emits_agent_action_dedup_is_persist_time(self) -> None:
+        """Dispatch emits the ``t3:debug`` agent action on EVERY tick (#1 blocker).
+
+        The RedMrFixAttempt idempotency claim moved from dispatch time to PERSIST
+        time (``persistence._handle_debug``), so a dropped/failed persist can no
+        longer burn the marker before the fix runs. Dispatch is therefore
+        unconditional; the per-SHA dedup is proven at persist time in
+        ``tests/teatree_loop/test_persistence_zone_handlers.py``.
+        """
         signal = ScanSignal(
             kind="my_pr.failed",
             summary="PR #1 failed",
@@ -74,12 +81,9 @@ class MyPrFailedDispatchTests(TestCase):
         )
         first = dispatch([signal])
         second = dispatch([signal])
-        first_agents = [a for a in first if a.kind == "agent"]
-        second_agents = [a for a in second if a.kind == "agent"]
-        assert len(first_agents) == 1
-        assert second_agents == []
-        # Statusline mirror still fires on every tick — user sees the
-        # red PR even though the agent does not re-run.
+        assert [a for a in first if a.kind == "agent"]
+        assert [a for a in second if a.kind == "agent"]
+        # Statusline mirror still fires on every tick — user always sees the red PR.
         assert any(a.kind == "statusline" for a in second)
 
 

--- a/tests/teatree_loop/test_persistence_zone_handlers.py
+++ b/tests/teatree_loop/test_persistence_zone_handlers.py
@@ -1,0 +1,319 @@
+"""Wire-level persistence for the revived agent-dispatch zones (#1 blocker).
+
+Each revived zone is exercised through the REAL ``dispatch() -> persist_agent_actions()``
+round trip with a production-shaped ``ScanSignal`` — the previously-dropped zones
+(codex review, red-card, red-MR fix, e2e-fix, answerer, skill-drift) must now
+produce a ``Ticket`` + ``Task`` on the registered ``(role, phase)``, be
+idempotent, and — for the marker-bearing zones — claim their idempotency marker
+at PERSIST time so a dropped/failed persist rolls the marker back for retry.
+
+Anti-vacuity: on the pre-fix code every zone below except ``t3:reviewer`` /
+``t3:orchestrator`` was dropped by ``_ZONE_HANDLERS`` (``logger.debug`` + skip),
+so ``persist_agent_actions`` returned ``[]`` and created no rows — every
+``created`` / ``Task.objects.filter(...)`` assertion here was RED before the fix.
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from teatree.core.models import Task, Ticket
+from teatree.core.models.codex_review_marker import CodexReviewMarker
+from teatree.core.models.red_mr_fix_attempt import RedMrFixAttempt
+from teatree.loop.dispatch import DispatchAction, dispatch
+from teatree.loop.persistence import persist_agent_actions
+from teatree.loop.scanners.base import ScanSignal
+
+
+def _agent_actions(signal: ScanSignal) -> list[DispatchAction]:
+    """Dispatch a signal and return only its ``kind="agent"`` actions."""
+    return [a for a in dispatch([signal]) if a.kind == "agent"]
+
+
+class TestDebugZoneRevived(TestCase):
+    """``my_pr.failed`` → author ``debugging`` task + persist-time RedMrFixAttempt."""
+
+    def _signal(self, *, pr_url: str = "https://example.com/o/r/pull/5", head_sha: str = "sha-red-1") -> ScanSignal:
+        return ScanSignal(
+            kind="my_pr.failed",
+            summary=f"PR failed: {pr_url}",
+            payload={"pr_url": pr_url, "head_sha": head_sha, "overlay": "acme"},
+        )
+
+    def test_creates_author_debugging_task(self) -> None:
+        created = persist_agent_actions(_agent_actions(self._signal()))
+        assert len(created) == 1
+        task = created[0]
+        assert task.phase == "debugging"
+        assert task.ticket.role == Ticket.Role.AUTHOR
+        assert task.execution_target == Task.ExecutionTarget.INTERACTIVE
+
+    def test_claims_red_mr_fix_marker_at_persist_time(self) -> None:
+        persist_agent_actions(_agent_actions(self._signal(pr_url="https://x/pr/9", head_sha="sha-9")))
+        assert RedMrFixAttempt.objects.filter(pr_url="https://x/pr/9", head_sha="sha-9").count() == 1
+
+    def test_idempotent_across_ticks_same_sha(self) -> None:
+        actions = _agent_actions(self._signal(pr_url="https://x/pr/10", head_sha="sha-10"))
+        first = persist_agent_actions(actions)
+        second = persist_agent_actions(_agent_actions(self._signal(pr_url="https://x/pr/10", head_sha="sha-10")))
+        assert len(first) == 1
+        assert second == []
+        assert Task.objects.filter(ticket__issue_url="https://x/pr/10", phase="debugging").count() == 1
+        assert RedMrFixAttempt.objects.filter(pr_url="https://x/pr/10").count() == 1
+
+    def test_role_conflict_does_not_burn_marker(self) -> None:
+        # An existing REVIEWER ticket for the same url makes the handler drop
+        # (role conflict) BEFORE the claim — the marker is never touched, so the
+        # next tick retries once the conflict clears.
+        Ticket.objects.create(issue_url="https://x/pr/11", overlay="acme", role=Ticket.Role.REVIEWER)
+        created = persist_agent_actions(_agent_actions(self._signal(pr_url="https://x/pr/11", head_sha="sha-11")))
+        assert created == []
+        assert not RedMrFixAttempt.objects.filter(pr_url="https://x/pr/11").exists()
+
+    def test_task_creation_failure_rolls_back_marker(self) -> None:
+        # Force the Task write to fail AFTER the marker claim: the shared atomic
+        # block must roll the RedMrFixAttempt row back so the dropped action does
+        # not burn its idempotency marker (#1 blocker — markers survive for retry).
+        with patch("teatree.loop.persistence._create_phase_task", side_effect=RuntimeError("boom")):
+            errors: dict[str, str] = {}
+            created = persist_agent_actions(
+                _agent_actions(self._signal(pr_url="https://x/pr/12", head_sha="sha-12")),
+                errors=errors,
+            )
+        assert created == []
+        assert not RedMrFixAttempt.objects.filter(pr_url="https://x/pr/12").exists()
+        assert "persist:t3:debug" in errors
+
+
+class TestCodexReviewZoneRevived(TestCase):
+    """``codex_review.dispatch`` → reviewer variant task + persist-time CodexReviewMarker."""
+
+    def _signal(
+        self,
+        *,
+        pr_url: str = "https://github.com/o/r/pull/7",
+        pr_id: int = 7,
+        head_sha: str = "codexsha1",
+        variant: str = "codex:review",
+    ) -> ScanSignal:
+        return ScanSignal(
+            kind="codex_review.dispatch",
+            summary=f"codex review {pr_url}",
+            payload={
+                "slug": "o/r",
+                "pr_id": pr_id,
+                "head_sha": head_sha,
+                "pr_url": pr_url,
+                "variant": variant,
+                "overlay": "acme",
+                "title": "PR 7",
+            },
+        )
+
+    def test_standard_variant_creates_codex_reviewing_task(self) -> None:
+        created = persist_agent_actions(_agent_actions(self._signal()))
+        assert len(created) == 1
+        task = created[0]
+        assert task.phase == "codex_reviewing"
+        assert task.ticket.role == Ticket.Role.REVIEWER
+        assert task.ticket.extra["codex_variant"] == "codex:review"
+
+    def test_adversarial_variant_creates_adversarial_phase(self) -> None:
+        created = persist_agent_actions(
+            _agent_actions(
+                self._signal(pr_url="https://github.com/o/r/pull/8", pr_id=8, variant="codex:adversarial-review")
+            ),
+        )
+        assert len(created) == 1
+        assert created[0].phase == "codex_adversarial_reviewing"
+
+    def test_claims_codex_marker_at_persist_time(self) -> None:
+        persist_agent_actions(_agent_actions(self._signal(pr_id=100, head_sha="csha-100")))
+        assert CodexReviewMarker.objects.filter(slug="o/r", pr_id=100, head_sha="csha-100").count() == 1
+
+    def test_idempotent_after_marker_claim_across_completed_task(self) -> None:
+        # Prove the PERSIST-time marker (not just the open-task check) dedups: even
+        # after the first review task completes, the same SHA does not re-dispatch.
+        first = persist_agent_actions(_agent_actions(self._signal(pr_id=101, head_sha="csha-101")))
+        assert len(first) == 1
+        first[0].complete()
+        second = persist_agent_actions(_agent_actions(self._signal(pr_id=101, head_sha="csha-101")))
+        assert second == []
+        assert (
+            Task.objects.filter(ticket__issue_url="https://github.com/o/r/pull/7", phase="codex_reviewing").count() == 1
+        )
+
+    def test_role_conflict_does_not_burn_marker(self) -> None:
+        Ticket.objects.create(issue_url="https://github.com/o/r/pull/13", overlay="acme", role=Ticket.Role.AUTHOR)
+        created = persist_agent_actions(
+            _agent_actions(self._signal(pr_url="https://github.com/o/r/pull/13", pr_id=13, head_sha="csha-13")),
+        )
+        assert created == []
+        assert not CodexReviewMarker.objects.filter(slug="o/r", pr_id=13).exists()
+
+    def test_task_creation_failure_rolls_back_marker(self) -> None:
+        with patch("teatree.loop.persistence._create_phase_task", side_effect=RuntimeError("boom")):
+            errors: dict[str, str] = {}
+            created = persist_agent_actions(
+                _agent_actions(self._signal(pr_url="https://github.com/o/r/pull/14", pr_id=14, head_sha="csha-14")),
+                errors=errors,
+            )
+        assert created == []
+        assert not CodexReviewMarker.objects.filter(slug="o/r", pr_id=14).exists()
+        assert "persist:codex:review" in errors
+
+
+class TestRedCardZoneRevived(TestCase):
+    """``red_card.signal`` → author corrective ``coding`` task, row_id stamped."""
+
+    def _signal(self, *, row_id: int = 42) -> ScanSignal:
+        return ScanSignal(
+            kind="red_card.signal",
+            summary="RED CARD (red_circle) from U1",
+            payload={
+                "row_id": row_id,
+                "signal_kind": "red_circle",
+                "user_id": "U1",
+                "signal_text": ":red_circle:",
+                "offending_message_text": "the offending message",
+                "overlay": "acme",
+            },
+        )
+
+    def test_creates_corrective_task_and_stamps_row_id(self) -> None:
+        # On the pre-fix code red_card fell into _handle_orchestrator, whose
+        # ``auto_start is not True`` guard returned None — nothing was created (RED).
+        created = persist_agent_actions(_agent_actions(self._signal(row_id=42)))
+        assert len(created) == 1
+        task = created[0]
+        assert task.phase == "coding"
+        assert task.ticket.role == Ticket.Role.AUTHOR
+        assert task.ticket.extra["red_card_signal_id"] == 42
+        assert task.ticket.issue_url == "redcard://signal/42"
+
+    def test_idempotent_across_ticks(self) -> None:
+        first = persist_agent_actions(_agent_actions(self._signal(row_id=43)))
+        second = persist_agent_actions(_agent_actions(self._signal(row_id=43)))
+        assert len(first) == 1
+        assert second == []
+
+
+class TestE2eFixZoneRevived(TestCase):
+    def _signal(self, *, spec: str = "e2e/specs/login.spec.ts") -> ScanSignal:
+        return ScanSignal(
+            kind="e2e.failure_detected",
+            summary=f"Failed E2E: {spec}",
+            payload={"spec": spec, "test_title": "login flow", "skill_overlay": "acme", "ts": "1.2"},
+        )
+
+    def test_creates_author_e2e_task(self) -> None:
+        created = persist_agent_actions(_agent_actions(self._signal()))
+        assert len(created) == 1
+        assert created[0].phase == "e2e"
+        assert created[0].ticket.role == Ticket.Role.AUTHOR
+
+    def test_idempotent_across_ticks(self) -> None:
+        persist_agent_actions(_agent_actions(self._signal(spec="e2e/specs/a.spec.ts")))
+        second = persist_agent_actions(_agent_actions(self._signal(spec="e2e/specs/a.spec.ts")))
+        assert second == []
+
+
+class TestSkillDriftZoneRevived(TestCase):
+    def _signal(self, *, repo: str = "/repos/skills", file_path: str = "code/SKILL.md") -> ScanSignal:
+        return ScanSignal(
+            kind="skill_drift_detected",
+            summary=f"drift {file_path}",
+            payload={"repo": repo, "file_path": file_path, "finding_fingerprint": "fp1", "overlay": "acme"},
+        )
+
+    def test_creates_author_coding_task(self) -> None:
+        created = persist_agent_actions(_agent_actions(self._signal()))
+        assert len(created) == 1
+        assert created[0].phase == "coding"
+        assert created[0].ticket.role == Ticket.Role.AUTHOR
+
+
+class TestAnswererZoneRevived(TestCase):
+    def _signal(self, *, event_id: int = 55) -> ScanSignal:
+        return ScanSignal(
+            kind="incoming_event.task_needed",
+            summary="task request (answering): what is X?",
+            payload={"event_id": event_id, "phase": "answering", "detail": "what is X?", "target_ref": ""},
+        )
+
+    def test_creates_author_answering_task(self) -> None:
+        created = persist_agent_actions(_agent_actions(self._signal()))
+        assert len(created) == 1
+        assert created[0].phase == "answering"
+        assert created[0].ticket.role == Ticket.Role.AUTHOR
+
+
+class TestFailLoudOnUnhandledZone(TestCase):
+    def test_unhandled_zone_records_persist_error(self) -> None:
+        # An agent zone that is neither handled nor persisted-at-source is a
+        # DROPPED dispatch — it must surface in errors (action_needed), not a
+        # silent logger.debug (#1 blocker fail-loud contract).
+        action = DispatchAction(kind="agent", zone="t3:never-registered", detail="?", payload={"url": "x"})
+        errors: dict[str, str] = {}
+        created = persist_agent_actions([action], errors=errors)
+        assert created == []
+        assert errors["persist:t3:never-registered"]
+
+    def test_handled_zone_records_no_error(self) -> None:
+        # Anti-vacuity: a genuinely-handled zone must NOT record a spurious error.
+        signal = ScanSignal(kind="my_pr.failed", summary="x", payload={"pr_url": "https://x/pr/1", "head_sha": "s1"})
+        errors: dict[str, str] = {}
+        persist_agent_actions(_agent_actions(signal), errors=errors)
+        assert errors == {}
+
+    def test_pending_task_reemission_is_a_silent_no_op(self) -> None:
+        # A pending_task re-emission (carrying task_id) of a persisted-at-source
+        # zone is a deliberate no-op — no row, no error.
+        action = DispatchAction(
+            kind="agent", zone="t3:coder", detail="pending", payload={"task_id": 99, "phase": "coding"}
+        )
+        errors: dict[str, str] = {}
+        created = persist_agent_actions([action], errors=errors)
+        assert created == []
+        assert errors == {}
+
+
+class TestFullDispatchPersistWire(TestCase):
+    def test_every_revived_zone_yields_exactly_one_task(self) -> None:
+        """One end-to-end sweep: each revived zone's signal yields exactly one Task."""
+        signals = [
+            ScanSignal(
+                kind="my_pr.failed", summary="x", payload={"pr_url": "https://w/pr/1", "head_sha": "w1", "overlay": "o"}
+            ),
+            ScanSignal(
+                kind="codex_review.dispatch",
+                summary="x",
+                payload={
+                    "slug": "o/r",
+                    "pr_id": 200,
+                    "head_sha": "w2",
+                    "pr_url": "https://w/pr/2",
+                    "variant": "codex:review",
+                    "overlay": "o",
+                },
+            ),
+            ScanSignal(
+                kind="red_card.signal",
+                summary="x",
+                payload={"row_id": 300, "signal_kind": "red_circle", "overlay": "o"},
+            ),
+            ScanSignal(
+                kind="e2e.failure_detected", summary="x", payload={"spec": "e2e/z.spec.ts", "skill_overlay": "o"}
+            ),
+            ScanSignal(
+                kind="skill_drift_detected", summary="x", payload={"repo": "/r", "file_path": "f.md", "overlay": "o"}
+            ),
+            ScanSignal(
+                kind="incoming_event.task_needed",
+                summary="x",
+                payload={"event_id": 400, "phase": "answering", "detail": "q"},
+            ),
+        ]
+        actions = [a for s in signals for a in dispatch([s]) if a.kind == "agent"]
+        created = persist_agent_actions(actions)
+        assert len(created) == len(signals), f"expected one task per revived zone, got {[t.phase for t in created]}"

--- a/tests/teatree_loop/test_tick.py
+++ b/tests/teatree_loop/test_tick.py
@@ -924,7 +924,7 @@ def test_tick_captures_persist_agent_dispatches_exception(
 ) -> None:
     """If ``persist_agent_actions`` raises, the tick records it instead of crashing."""
 
-    def boom(_actions: object) -> None:
+    def boom(_actions: object, *, errors: object = None) -> None:
         msg = "persistence down"
         raise RuntimeError(msg)
 


### PR DESCRIPTION
## Root cause (#1 blocker)

`kind="agent"` dispatch actions for every zone **outside** `t3:reviewer` / `t3:orchestrator` were silently dropped by `persistence._ZONE_HANDLERS` (`logger.debug` + skip), and their idempotency markers were claimed **upstream** (in the scanner / dispatcher) **before** the drop. Net effect: codex reviews, red-card follow-up, red-MR fix, e2e-fix, answerer and skill-drift **never executed** AND could **never be retried** — the marker was already burned even though the action produced no Ticket/Task.

## The fix

- **Persistence is now the COMPLETE executor contract.** New per-zone handlers translate each remaining agent zone into `Ticket`+`Task` rows on the `(role, phase)` pairs registered in `SUBAGENT_BY_PHASE`:
  - `_handle_debug` — `my_pr.failed` → author `debugging` task
  - `_handle_codex_review` — reviewer task whose **phase encodes the `/codex:*` variant** (`codex_reviewing` / `codex_adversarial_reviewing`)
  - `_handle_e2e_fix`, `_handle_skill_drift`, `_handle_answerer`
  - `_handle_red_card` — its **OWN** handler (not `_handle_orchestrator`, whose `auto_start` guard dropped it); stamps the `RedCardSignal` row id into `ticket.extra` for `link_issue`
- **Marker claims move to PERSIST time.** `CodexReviewMarker.claim` leaves the scanner (it now emits unconditionally per head SHA) and `claim_red_mr_fix` leaves `dispatch._dispatch_one`. Both ride the **same `transaction.atomic`** that creates the Task, so a dropped/failed persist **rolls the marker back** and the next tick retries. `claim_red_mr_fix` stays in `dispatch_gates` (SIG-2 hardens *what* it claims — sha/payload); DIS-A moves only the call site.
- **Fail-loud.** `persist_agent_actions` gains a `report.errors` sink (threaded via `tick_recovery`); an agent zone with no handler that is **not** persisted-at-source records `errors["persist:<zone>"]` (rendered in `action_needed`) instead of a silent `logger.debug`.
- **Lands classifier-free** (no `Kind.FIX` stamping — that's SIG-3). The correction-zone handlers are structured so SIG-3 can wire `classify_ticket_kind` in as a one-liner.

## Registry-parity conformance framework (the durable deliverable)

`tests/conformance/test_registry_parity.py` is the reusable producer/consumer anti-drift framework — the fix for the dominant ~8-bug "registry drift" family. It asserts:

- `AGENT_ZONES == set(_ZONE_HANDLERS) | PERSISTED_AT_SOURCE_ZONES` — a new dispatch **producer** with no persistence **consumer** fails CI.
- every `(role, phase)` a handler writes is a `SUBAGENT_BY_PHASE` key — a persisted row no claimer can dispatch fails CI.
- cardinality floors (anti-vacuity) so emptying an enumeration cannot turn a lane vacuous-green.

`assert_registry_covers(...)` is the shared primitive; each seam is its **own** test function, designed **append-only** so DIS-B/D/E, SIG-4 and MW-A/B add lanes as additive test functions (trivial rebases by construction).

## Anti-vacuity proof

- **Parity lane goes RED** when a handler is removed (verified: removing `t3:debug` → `registry drift: ['t3:debug']`).
- **Wire tests** prove a previously-dropped zone now produces its `Ticket`+`Task` rows AND that a dropped/failed action does **NOT** burn its marker (marker survives for retry). Both the marker-rollback lanes were verified RED on the pre-fix shape (neutered atomic → marker survives → assertion fails), GREEN after.
- Never-lockout preserved: persist errors are advisory (they never abort the tick); the top-level `tick_recovery` catch still records `dispatch_persist`.

## Zones revived

codex review (`codex:review` / `codex:adversarial-review`), red-card corrective (`red_card.signal`), red-MR fix (`t3:debug`), e2e-fix (`t3:e2e`), skill-drift (`t3:coder`), answerer (`t3:answerer`). New `SUBAGENT_BY_PHASE` entries: `(author, debugging)→t3:debugger`, `(reviewer, codex_reviewing)→codex:review`, `(reviewer, codex_adversarial_reviewing)→codex:adversarial-review` (codex slash-command agents are exempted from the `t3:`-agent-file conformance checks via a known allowlist).

## Second-wave watch

These ~6 agent paths execute for the FIRST time on the next post-merge tick and meet real payload shapes first time — schedule ONE supervised dogfood tick before re-enabling full autonomy. Persist-time claims dedupe and DIS-D's budget will cap in-flight, but a standing backlog of red PRs / unclaimed markers can dispatch in a burst. The codex variant now dispatches correctly (phase-encoded), and red-MR fix becomes once-per-SHA.

## Architecture pre-check — #1 (DIS-A)

1. **BLUEPRINT §**: §5.2 / §17.8 (per-phase loop dispatch; the orchestrator dispatches, phase agents execute). No contradiction — extends the executor contract.
2. **FSM phase boundaries**: no `Ticket.State` transition changed. New reactive phases (`debugging`, `codex_reviewing`, `codex_adversarial_reviewing`) are orthogonal (like `answering`/`bughunt`) — not FSM phases, no `_PHASE_ALIASES` entry.
3. **Extension-point contracts**: `SUBAGENT_BY_PHASE` widened; the phase-agent conformance test updated to recognise codex slash-command agents (allowlisted, not weakened for `t3:`).
4. **Component boundaries**: handlers stay in `teatree.loop.persistence`; producer SSOT (`AGENT_ZONES`) in `dispatch_tables`; conformance in `tests/conformance`.
5. **Dependency direction**: one new forward same-layer edge `dispatch_tables → core.modelkit` (declared in `tach.toml`; `uv run tach check` green). The sibling `dispatch_reducer`/`dispatch_gates` already declare it.
6. **Test surface**: `tests/conformance/test_registry_parity.py` (parity) + `tests/teatree_loop/test_persistence_zone_handlers.py` (per-zone wire round-trip, marker rollback, fail-loud).
7. **Resilience invariants**: idempotency (persist-time marker + open-task check), fail-loud (`report.errors`), rollback (atomic), retry-safe (marker survives a drop).
8. **Identity/key normalization**: `_has_open_task` matches via `phase_spellings` (canonical up); synthetic ticket keys (`redcard://`, `e2e-failure://`, `skill-drift://`, `answer://event/`) are stable per-signal.
9. **Behaviour preservation**: the codex conformance narrowing is an **additive allowlist** (`codex:review`/`codex:adversarial-review`) for a distinct spawn mechanism, not a weakening of the `t3:`-agent checks; no must-block test inverted. The `my_pr.failed` dispatch-time dedup was **moved** (not removed) to persist-time — its test was updated to assert the new architecture.

Closes #1
