### PR TITLE
fix(ci): give jscpd + whole-tree scan tests headroom over their pytest-timeout (unblocks pushes under load)

### DIFF
--- a/tests/quality/test_git_fixture_default_branch.py
+++ b/tests/quality/test_git_fixture_default_branch.py
@@ -279,6 +279,9 @@ def scan_tree(root: Path) -> list[GitInitFinding]:
     return findings
 
 
+# Whole-tree AST scan of every tests/**/*.py — headroom over the 60s default
+# pytest-timeout so it never trips under concurrent-coder load in the push hook.
+@pytest.mark.timeout(300)
 class TestLiveTree:
     def test_no_real_git_fixture_assumes_the_default_branch(self) -> None:
         findings = scan_tree(_TESTS_ROOT)

--- a/tests/quality/test_jscpd_duplication.py
+++ b/tests/quality/test_jscpd_duplication.py
@@ -60,6 +60,10 @@ def _expected_clone_capable_files(min_lines: int) -> set[Path]:
     return {p.resolve() for p in _SRC.rglob("*.py") if "migrations" not in p.parts and _line_count(p) >= min_lines}
 
 
+# Whole-tree jscpd scan is ~60s standalone and stretches further under
+# concurrent-coder load; the 60s default pytest-timeout deterministically
+# tripped and blocked every push through the ci-critical-parity hook.
+@pytest.mark.timeout(300)
 @pytest.mark.integration
 @pytest.mark.skipif(shutil.which("npx") is None, reason="npx (node) not on PATH")
 class TestScanCoverage:

--- a/tests/quality/test_no_test_writes_under_src.py
+++ b/tests/quality/test_no_test_writes_under_src.py
@@ -15,6 +15,8 @@ correctly ignored.
 import ast
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _TESTS_ROOT = _REPO_ROOT / "tests"
 
@@ -84,6 +86,9 @@ def writes_into_live_src(source: str) -> list[str]:
     return offenders
 
 
+# Whole-tree AST scan of every tests/**/*.py — headroom over the 60s default
+# pytest-timeout so it never trips under concurrent-coder load in the push hook.
+@pytest.mark.timeout(300)
 class TestNoTestWritesUnderSrc:
     def test_no_test_module_writes_into_the_live_src_tree(self) -> None:
         offenders: dict[str, list[str]] = {}

--- a/tests/teatree_cli/test_cli_reference_drift_gate.py
+++ b/tests/teatree_cli/test_cli_reference_drift_gate.py
@@ -14,9 +14,15 @@ import sys
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
 import yaml
 
 from tests._git_repo import make_git_repo, run_git
+
+# Each subprocess-spawning class below runs the cli-reference generator/sync
+# checker, a full Django bootstrap that stretches past the 60s default
+# pytest-timeout under concurrent-coder load; give them headroom.
+_SCAN_TIMEOUT = pytest.mark.timeout(300)
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _GENERATOR = _REPO_ROOT / "scripts" / "hooks" / "generate_cli_reference.py"
@@ -46,6 +52,7 @@ def _run(script: Path, *args: str, env_overrides: dict[str, str] | None = None) 
     )
 
 
+@_SCAN_TIMEOUT
 class TestGeneratorNoStageOptOut:
     """With CLI_REFERENCE_NO_STAGE set, the generator writes but never git-adds."""
 
@@ -57,6 +64,7 @@ class TestGeneratorNoStageOptOut:
         assert out.read_text(encoding="utf-8") == committed
 
 
+@_SCAN_TIMEOUT
 class TestDocsDriftGateCatchesStaleReference:
     """End-to-end: the working-tree-vs-index diff catches a stale committed doc.
 
@@ -105,6 +113,7 @@ class TestDocsDriftGateCatchesStaleReference:
         assert self._diff_is_clean(repo), "an in-sync committed reference must pass the gate"
 
 
+@_SCAN_TIMEOUT
 class TestSyncCheckerFiresOnDrift:
     """The loud sync checker detects a stale committed reference."""
 
@@ -127,6 +136,7 @@ class TestSyncCheckerFiresOnDrift:
         assert result.returncode == 1, f"checker must go red on stale doc:\n{result.stdout}"
 
 
+@_SCAN_TIMEOUT
 class TestSyncCheckerUnmaskableByGenerator:
     """The sync checker catches a stale COMMITTED doc even after the generator runs.
 


### PR DESCRIPTION
The ci-critical-parity push hook's jscpd whole-tree scan (~63s) exceeded its 60s pytest-timeout, blocking pushes under concurrent-coder load. Bumps the scan-test timeouts to 300s. Infra-only.