### PR TITLE
fix(hooks): sanctioned ALLOW exits 0 with allow-envelope + consent survives denied attempts + JSON-key blanket-rule fix (#3,#4)

### DIFF
--- a/hooks/scripts/classifier_relax_gate.py
+++ b/hooks/scripts/classifier_relax_gate.py
@@ -54,6 +54,7 @@ import re
 import sys
 from pathlib import Path
 
+from pretooluse_verdict import Verdict, emit_pretooluse_allow
 from question_gates import read_transcript_entries as _read_transcript_entries
 
 # Alias the bare and ``hooks.scripts.`` identities so the handler the router
@@ -141,15 +142,57 @@ def _user_entry_affirms_relax(entry: dict) -> bool:
     return bool(_CLASSIFIER_RELAX_AFFIRMATIVE.search(" ".join(texts).strip()))
 
 
+def _denied_settings_write_ids(entries: list, start: int) -> set[str]:
+    """Return the ``tool_use_id``s of settings writes DENIED since ``start``.
+
+    A settings.json write that this gate denies leaves an ``is_error`` tool_result
+    in the transcript; that attempt never landed. Its id is collected here so the
+    consume-once scan does NOT treat it as spending the consent — the approval
+    survives a denied attempt (a false-block, or any deny) so a corrected retry is
+    still allowed (#3/#4). Fail-safe: an unparsable block is skipped.
+    """
+    from hook_router import _entry_content  # noqa: PLC0415, PLC2701 — cold-hook lazy back-import
+
+    denied: set[str] = set()
+    for k in range(start, len(entries)):
+        for block in _entry_content(entries[k]):
+            if not isinstance(block, dict) or block.get("type") != "tool_result" or not block.get("is_error"):
+                continue
+            tool_use_id = block.get("tool_use_id")
+            if isinstance(tool_use_id, str):
+                denied.add(tool_use_id)
+    return denied
+
+
+def _consent_unconsumed(entries: list, start: int) -> bool:
+    """True when no LANDED settings write has spent the consent since ``start``.
+
+    A settings write whose ``tool_use_id`` carries an is_error tool_result was
+    denied — it did not land, so it does not consume the consent (the approval
+    survives a denied attempt, #3/#4). Any other settings write since the approval
+    is a completed write that spends it (a replay of consumed consent).
+    """
+    from hook_router import _entry_content  # noqa: PLC0415, PLC2701 — cold-hook lazy back-import
+
+    denied_ids = _denied_settings_write_ids(entries, start)
+    for k in range(start, len(entries)):
+        for block in _entry_content(entries[k]):
+            if isinstance(block, dict) and _block_is_settings_write(block) and block.get("id") not in denied_ids:
+                return False
+    return True
+
+
 def _has_sanctioned_relax_approval(transcript_path: str) -> bool:
     """Return True only for an unconsumed, most-recent Step-3 relax approval.
 
     Walk the transcript from the END to the most-recent assistant
     ``AskUserQuestion`` offering the verbatim relax option; require the first
     subsequent user turn to affirmatively select it; then consume-once — a
-    settings.json write already performed since that approval spends the consent
-    (return False, the pending write would be a replay). Fail-safe to "no allow"
-    on any missing/unmatched condition.
+    settings.json write that ACTUALLY LANDED since that approval spends the consent
+    (return False, the pending write would be a replay). A write that was DENIED
+    (its ``tool_use_id`` carries an ``is_error`` tool_result) did not land, so it
+    does NOT consume the consent — the approval survives a denied attempt. Fail-safe
+    to "no allow" on any missing/unmatched condition.
     """
     from hook_router import _entry_content, _entry_role  # noqa: PLC0415, PLC2701 — cold-hook lazy back-imports
 
@@ -172,10 +215,7 @@ def _has_sanctioned_relax_approval(transcript_path: str) -> bool:
             break
         if approval_user_idx is None:
             return False
-        for k in range(approval_user_idx + 1, len(entries)):
-            if any(isinstance(block, dict) and _block_is_settings_write(block) for block in _entry_content(entries[k])):
-                return False
-        return True
+        return _consent_unconsumed(entries, approval_user_idx + 1)
     return False
 
 
@@ -232,10 +272,23 @@ def _validate_full_content(content: str) -> str | None:
 
 
 def _new_string_adds_blanket_rule(new_string: str) -> str | None:
-    """Return an error if an Edit ``new_string`` adds a blanket-wildcard rule."""
-    for token in re.findall(r'"([^"]*)"', new_string):
-        if _is_blanket_rule(token):
-            return f"blanket-wildcard rule `{token}` — use the smallest rule that covers the use case"
+    """Return an error if an Edit ``new_string`` adds a blanket-wildcard rule.
+
+    Only quoted tokens that are allow-list *entries* are candidate rules. A quoted
+    token followed by a colon is a JSON KEY (``"allow":``, ``"permissions":``), not a
+    permission rule, so it is skipped — otherwise the key ``allow`` matches the
+    bare-tool blanket-rule shape and a legitimate Edit adding a scoped rule under an
+    allow list is false-blocked (#4). Quotes are paired with ``finditer`` on the full
+    ``"[^"]*"`` literal (a lookahead-``findall`` re-anchors on a key's closing quote
+    and mis-pairs the rest, letting a real bare-tool entry slip past). This
+    raw-fragment scan is only the FALLBACK; ``validate_relax_write`` prefers the
+    parsed applied-content check, which validates real list entries and never keys.
+    """
+    for match in re.finditer(r'"([^"]*)"', new_string):
+        if new_string[match.end() :].lstrip().startswith(":"):
+            continue  # a JSON key, not a rule entry
+        if _is_blanket_rule(match.group(1)):
+            return f"blanket-wildcard rule `{match.group(1)}` — use the smallest rule that covers the use case"
     return None
 
 
@@ -262,35 +315,38 @@ def _applied_edit_content(tool_input: dict) -> str | None:
 def validate_relax_write(tool_name: str | None, tool_input: dict) -> str | None:
     """Return an error string if the relax settings write is malformed, else ``None`` (#857).
 
-    A ``Write`` validates its full ``content``; an ``Edit`` validates its
-    ``new_string`` fragment for a blanket-wildcard rule and — when the current
-    file is readable and the ``old_string`` matches — the applied result as full
-    JSON. The user has approved THAT a write occurs; this check enforces the
-    sanctioned SHAPE of the payload so a corrupting or over-broad write is
-    refused pre-persist.
+    A ``Write`` validates its full ``content``. An ``Edit`` prefers the parsed
+    applied-content check when the current file is readable and the ``old_string``
+    matches — ``_validate_full_content`` parses the resulting JSON and validates the
+    real allow-list *entries* (never keys), so a legitimate rule added under an
+    ``"allow":`` key is not false-blocked (#4). Only when the applied result is
+    unresolvable (file unreadable / ``old_string`` absent) does it fall back to the
+    raw ``new_string`` fragment scan, whose regex also excludes JSON keys. The user
+    has approved THAT a write occurs; this check enforces the sanctioned SHAPE so a
+    corrupting or over-broad write is refused pre-persist.
     """
     if tool_name == "Write":
         return _validate_full_content(str(tool_input.get("content", "")))
-    fragment_error = _new_string_adds_blanket_rule(str(tool_input.get("new_string", "")))
-    if fragment_error is not None:
-        return fragment_error
     applied = _applied_edit_content(tool_input)
     if applied is not None:
         return _validate_full_content(applied)
-    return None
+    return _new_string_adds_blanket_rule(str(tool_input.get("new_string", "")))
 
 
-def handle_allow_classifier_relax_settings_write(data: dict) -> bool | None:
+def handle_allow_classifier_relax_settings_write(data: dict) -> bool | Verdict | None:
     """Allow Edit/Write to ~/.claude/settings.json after sanctioned Step-3 approval.
 
-    Emits ``{"permissionDecision": "allow"}`` and returns ``True`` when the tool
-    is ``Edit``/``Write``, the target resolves to ``~/.claude/settings.json``, the
-    transcript carries an unconsumed Step-3 relax approval, AND the payload passes
-    content-schema validation (#857). A payload that fails validation with a
-    recorded approval is REFUSED (the user approved that a write occurs, not a
-    malformed one). Any other condition returns ``None`` — later handlers stay in
-    play. Registered FIRST in the PreToolUse chain so it fires before the
-    settings-write deny.
+    Emits the nested ``hookSpecificOutput`` allow envelope and returns the distinct
+    :data:`Verdict.ALLOW` sentinel — which ``main()`` translates to exit 0 (the
+    harness only honours a PreToolUse allow at exit 0 with the nested shape) — when
+    the tool is ``Edit``/``Write``, the target resolves to ``~/.claude/settings.json``,
+    the transcript carries an unconsumed Step-3 relax approval, AND the payload passes
+    content-schema validation (#857). Returning ``True`` here instead (the pre-#3 bug)
+    made ``main()`` exit 2, so the human approval acted as a BLOCK and burned the
+    one-shot consent. A payload that fails validation with a recorded approval is
+    REFUSED (the user approved that a write occurs, not a malformed one). Any other
+    condition returns ``None`` — later handlers stay in play. Registered FIRST in the
+    PreToolUse chain so it fires before the settings-write deny.
     """
     if data.get("tool_name") not in {"Edit", "Write"}:
         return None
@@ -310,5 +366,4 @@ def handle_allow_classifier_relax_settings_write(data: dict) -> bool | None:
             f"{schema_error}. Only a smallest-scope string rule may be appended to permissions.allow / "
             "autoMode.allow; no blanket wildcard, and the result must stay valid JSON.",
         )
-    json.dump({"permissionDecision": "allow"}, sys.stdout)
-    return True
+    return emit_pretooluse_allow()

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -6747,26 +6747,32 @@ def main() -> None:
         # fail-open is incomplete can neither (a) surface its crash as a deny
         # that hard-blocks the tool, nor (b) disable every downstream gate. The
         # diagnostic goes to stderr (never stdout) so it cannot be read as a
-        # deny payload. Only an explicit ``True`` return is a deny — it stops the
-        # chain to avoid writing multiple JSON objects to stdout (invalid JSON).
+        # deny payload. A truthy return is a DECISION that stops the chain (to
+        # avoid writing multiple JSON objects to stdout): ``True`` is a deny
+        # (exit 2), the ``Verdict.ALLOW`` sentinel is an explicit allow (exit 0,
+        # #3). ``None`` / ``False`` are "no decision" — the chain continues.
         try:
             verdict = handler(data)
         except Exception:  # noqa: BLE001 — crash-proof router: a broken gate fails open, never denies.
             traceback.print_exc(file=sys.stderr)
             continue
-        if verdict is True:
-            deny_emitted = True
+        if verdict:
+            deny_emitted = verdict is True
             break
 
     # A PreToolUse call that ran the whole chain without a deny is genuine
     # progress: reset the deny-streak so only CONSECUTIVE identical denials
-    # accumulate in the circuit breaker.
+    # accumulate in the circuit breaker. A ``Verdict.ALLOW`` decision leaves
+    # ``deny_emitted`` False, so a sanctioned allow resets the streak too.
     if args.event == "PreToolUse" and not deny_emitted:
         _reset_deny_streak(data.get("session_id", ""))
 
     # Exit-code contract is per-event. PreToolUse / TaskCreated denies are only
     # honoured at exit code 2 (#1447) and their reason rides ``hookSpecificOutput``
     # / ``continue:false`` on stdout, which the harness reads even at exit 2.
+    # A ``Verdict.ALLOW`` decision must NOT exit 2: the harness honours a PreToolUse
+    # allow only at exit 0 with the nested envelope, so ``deny_emitted`` gates the
+    # exit-2 branch and an allow falls through to the exit-0 default (#3).
     # Stop / SubagentStop and the other top-level-``decision`` events INVERT this:
     # exit 2 is a blocking error that makes the harness discard the stdout JSON
     # and read stderr instead — so a Stop block must exit 0 to let its

--- a/hooks/scripts/pretooluse_verdict.py
+++ b/hooks/scripts/pretooluse_verdict.py
@@ -1,0 +1,66 @@
+"""PreToolUse ALLOW verdict primitive (#3 — a sanctioned allow must exit 0).
+
+The DENY counterpart (``emit_pretooluse_deny`` + ``_write_pretooluse_deny``)
+stays in ``hook_router`` where the never-lockout contract's call-graph analysis
+can see it. The ALLOW verdict is its own leaf here so the ``classifier_relax_gate``
+cold hook can emit a sanctioned allow without importing the router: it writes the
+nested ``hookSpecificOutput`` allow envelope Claude Code actually reads and
+returns the distinct :data:`Verdict.ALLOW` sentinel, which ``main()`` breaks the
+handler chain on and translates to exit 0 — never the deny exit 2.
+
+Before #3 the sanctioned allow emitted a bare legacy ``{"permissionDecision":
+"allow"}`` and returned ``True``; ``main()`` treats a ``True`` return as a deny
+and translates it to ``sys.exit(2)``, so a human's one-shot classifier-relax
+approval acted as a BLOCK (and the blocked attempt in the transcript then burned
+the consume-once consent). The distinct sentinel is what lets ``main()`` tell an
+allow (exit 0) from a deny (exit 2).
+
+Cold-import safe: stdlib only, so a bare ``python3`` PreToolUse subprocess can
+import it with no ``teatree`` on the path.
+"""
+
+import enum
+import json
+import sys
+
+# Alias the bare and ``hooks.scripts.`` identities so a bare ``from
+# pretooluse_verdict import Verdict`` (the cold hook) and a ``hooks.scripts``
+# test import resolve to ONE module object — one ``Verdict`` enum class, so
+# ``verdict is Verdict.ALLOW`` identity holds across both import paths.
+sys.modules.setdefault("pretooluse_verdict", sys.modules[__name__])
+sys.modules.setdefault("hooks.scripts.pretooluse_verdict", sys.modules[__name__])
+
+
+class Verdict(enum.Enum):
+    """A PreToolUse handler decision ``main()`` maps to a process exit code.
+
+    Handlers return ``bool | Verdict | None``: ``True`` denies (chain breaks,
+    exit 2), ``None`` / ``False`` make no decision (the chain continues to the
+    next handler), and ``ALLOW`` is an explicit allow — it breaks the chain with
+    its envelope already on stdout but exits 0, never the deny exit 2 (#3).
+    """
+
+    ALLOW = "allow"
+
+
+def emit_pretooluse_allow() -> Verdict:
+    """Write the nested ``hookSpecificOutput`` allow envelope; return ``Verdict.ALLOW``.
+
+    The allow counterpart of ``emit_pretooluse_deny``. Claude Code honours a
+    PreToolUse allow only when ``permissionDecision`` rides inside
+    ``hookSpecificOutput`` — a bare legacy ``{"permissionDecision": "allow"}`` is
+    ignored. The legacy flat keys ride alongside for in-process test consumers,
+    mirroring ``_write_pretooluse_deny``.
+    """
+    payload = {
+        # Legacy flat shape — kept for in-process consumers (existing handler
+        # tests). Harmless to the harness because it ignores unknown top-level keys.
+        "permissionDecision": "allow",
+        # Modern shape — the one the harness actually reads.
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+        },
+    }
+    json.dump(payload, sys.stdout)
+    return Verdict.ALLOW

--- a/tests/test_classifier_relax_pretooluse_hook.py
+++ b/tests/test_classifier_relax_pretooluse_hook.py
@@ -60,8 +60,9 @@ from pathlib import Path
 import pytest
 
 import hooks.scripts.hook_router as router
-from hooks.scripts.classifier_relax_gate import _is_blanket_rule, validate_relax_write
+from hooks.scripts.classifier_relax_gate import _is_blanket_rule, _new_string_adds_blanket_rule, validate_relax_write
 from hooks.scripts.hook_router import handle_allow_classifier_relax_settings_write
+from hooks.scripts.pretooluse_verdict import Verdict
 
 # ── Transcript helpers (mirrors test_structured_question_hook.py) ─────
 
@@ -112,6 +113,20 @@ def _decision(capsys: pytest.CaptureFixture[str]) -> dict:
     return json.loads(out) if out else {}
 
 
+def _assert_sanctioned_allow(decision: dict, result: object) -> None:
+    """Assert the emitted decision + return value are the #3 nested-allow verdict.
+
+    The handler must return the distinct ``Verdict.ALLOW`` sentinel (so ``main()``
+    exits 0, not the deny exit 2) and emit the nested ``hookSpecificOutput`` allow
+    envelope the harness reads. The legacy flat ``permissionDecision`` key rides
+    alongside for back-compat.
+    """
+    assert result is Verdict.ALLOW, f"a sanctioned allow must return Verdict.ALLOW, got {result!r}"
+    assert decision["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+    assert decision["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert decision["permissionDecision"] == "allow"
+
+
 # ── Test data helpers ─────────────────────────────────────────────────
 
 
@@ -150,8 +165,7 @@ class TestClassifierRelaxAllow:
             }
         )
 
-        assert _decision(capsys) == {"permissionDecision": "allow"}
-        assert result is True
+        _assert_sanctioned_allow(_decision(capsys), result)
 
     def test_allow_write_settings_json_after_affirmative(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -170,8 +184,7 @@ class TestClassifierRelaxAllow:
             }
         )
 
-        assert _decision(capsys) == {"permissionDecision": "allow"}
-        assert result is True
+        _assert_sanctioned_allow(_decision(capsys), result)
 
     def test_allow_with_tilde_path(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """The tilde form ~/.claude/settings.json is normalised before comparison."""
@@ -185,8 +198,7 @@ class TestClassifierRelaxAllow:
             }
         )
 
-        assert _decision(capsys) == {"permissionDecision": "allow"}
-        assert result is True
+        _assert_sanctioned_allow(_decision(capsys), result)
 
     def test_allow_when_user_says_allow_it(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """User response "Allow it" (substring of the full option) is treated as affirmative."""
@@ -200,8 +212,7 @@ class TestClassifierRelaxAllow:
             }
         )
 
-        assert _decision(capsys) == {"permissionDecision": "allow"}
-        assert result is True
+        _assert_sanctioned_allow(_decision(capsys), result)
 
     def test_allow_when_user_says_yes(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """User response "yes" is treated as affirmative."""
@@ -215,8 +226,7 @@ class TestClassifierRelaxAllow:
             }
         )
 
-        assert _decision(capsys) == {"permissionDecision": "allow"}
-        assert result is True
+        _assert_sanctioned_allow(_decision(capsys), result)
 
     def test_allow_when_user_says_relax_classifier(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """User response "relax classifier" (the protocol shorthand) is affirmative.
@@ -235,8 +245,7 @@ class TestClassifierRelaxAllow:
             }
         )
 
-        assert _decision(capsys) == {"permissionDecision": "allow"}
-        assert result is True
+        _assert_sanctioned_allow(_decision(capsys), result)
 
 
 # ── Tests for wrong tool / wrong path ────────────────────────────────
@@ -645,8 +654,7 @@ class TestClassifierRelaxConsumeOnce:
             }
         )
 
-        assert _decision(capsys) == {"permissionDecision": "allow"}
-        assert result is True
+        _assert_sanctioned_allow(_decision(capsys), result)
 
 
 # ── Affirmative-pattern precision (review Findings 3/4) ────────────────
@@ -670,8 +678,7 @@ class TestClassifierRelaxAffirmativePrecision:
             }
         )
 
-        assert _decision(capsys) == {"permissionDecision": "allow"}
-        assert result is True
+        _assert_sanctioned_allow(_decision(capsys), result)
 
     def test_please_relax_the_check_is_not_affirmative(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -740,8 +747,7 @@ class TestClassifierRelaxHelperDefensiveBranches:
             }
         )
 
-        assert _decision(capsys) == {"permissionDecision": "allow"}
-        assert result is True
+        _assert_sanctioned_allow(_decision(capsys), result)
 
     def test_block_is_settings_write_false_for_non_edit_tool(self) -> None:
         block = {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}}
@@ -849,8 +855,7 @@ class TestClassifierRelaxHelperDefensiveBranches:
             }
         )
 
-        assert _decision(capsys) == {"permissionDecision": "allow"}
-        assert result is True
+        _assert_sanctioned_allow(_decision(capsys), result)
 
 
 # ── #857: content-schema validation of the relax write payload ─────────
@@ -969,3 +974,149 @@ class TestRelaxWriteSchemaDeniesHandler:
         )
         assert result is True
         assert _decision(capsys) != {"permissionDecision": "allow"}
+
+
+# ── #4: JSON-key fragments must not be read as blanket rules ───────────
+
+
+class TestNewStringBlanketRuleExcludesJsonKeys:
+    """`_new_string_adds_blanket_rule` must skip JSON KEYS, not treat them as rules.
+
+    CORR-10 widened `_is_blanket_rule` to all bare words, so the fragment scan read
+    the JSON key `allow` / `permissions` as a whole-tool blanket grant and
+    false-blocked a legitimate Edit that adds a scoped rule under an allow list —
+    burning the consume-once approval (#4). A quoted token followed by a colon is a
+    key and is excluded; a real list ENTRY (bare tool) is still refused.
+    """
+
+    def test_scoped_rule_under_allow_key_is_not_blanket(self) -> None:
+        # The exact audit case: '"allow": [\n "Bash(uv run pytest:*)",' → None.
+        assert _new_string_adds_blanket_rule('"allow": [\n    "Bash(uv run pytest:*)",') is None
+
+    def test_permissions_and_allow_keys_alone_are_not_blanket(self) -> None:
+        assert _new_string_adds_blanket_rule('"permissions": {\n    "allow": [') is None
+
+    def test_key_with_space_before_colon_is_still_a_key(self) -> None:
+        assert _new_string_adds_blanket_rule('"allow" : [\n    "Bash(gh pr view *)",') is None
+
+    def test_bare_tool_list_entry_after_keys_still_refused(self) -> None:
+        # The multi-key case a lookahead-findall mis-pairs and lets slip: a bare
+        # `"Bash",` ENTRY sitting after `"permissions":`/`"allow":` keys must refuse.
+        reason = _new_string_adds_blanket_rule('"permissions": {\n    "allow": [\n        "Bash",')
+        assert reason is not None
+        assert "blanket-wildcard" in reason
+        assert "`Bash`" in reason
+
+    def test_bare_tool_list_entry_alone_still_refused(self) -> None:
+        reason = _new_string_adds_blanket_rule('    "Bash",')
+        assert reason is not None
+        assert "blanket-wildcard" in reason
+
+    def test_validate_relax_write_edit_json_key_fragment_passes(self) -> None:
+        # Through the public validator, fragment fallback (empty old_string → the
+        # applied-content path is skipped): the JSON key must not false-block.
+        assert validate_relax_write("Edit", {"new_string": '"allow": [\n    "Bash(uv run pytest:*)",'}) is None
+
+
+# ── #3/#4: consent survives a DENIED attempt (not burned by a false-block) ──
+
+
+def _settings_write_tool_with_id(tool_use_id: str, name: str = "Edit") -> dict:
+    """An Edit/Write tool_use targeting settings.json, carrying a tool_use ``id``."""
+    return {
+        "type": "tool_use",
+        "id": tool_use_id,
+        "name": name,
+        "input": {"file_path": str(Path("~/.claude/settings.json").expanduser())},
+    }
+
+
+def _tool_result(tool_use_id: str, *, is_error: bool) -> dict:
+    """A user-turn tool_result block referencing ``tool_use_id`` (denied when is_error)."""
+    return {
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": tool_use_id, "is_error": is_error, "content": "x"}],
+        },
+    }
+
+
+class TestConsentSurvivesDeniedAttempt:
+    """A settings write that was DENIED did not land, so it must not spend the consent.
+
+    Before the fix a false-block denied the write, but the denied attempt's tool_use
+    still sat in the transcript and the consume-once scan read it as a completed
+    write — refusing the corrected retry as a replay (consent burned). The fix keys
+    consumption on whether the write LANDED: a write whose ``tool_use_id`` carries an
+    ``is_error`` tool_result did not land, so the approval survives for the retry.
+    """
+
+    def test_denied_attempt_does_not_consume_consent(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        transcript = _write_transcript(
+            tmp_path,
+            [
+                _user("file the issue"),
+                _assistant(
+                    "Choose:",
+                    tool_uses=[
+                        _ask_question_tool(["Allow it (relax classifier)", "Keep the denial (do it differently)"])
+                    ],
+                ),
+                _user("Allow it (relax classifier)"),
+                # A first attempt that the gate DENIED (its tool_result is is_error):
+                {
+                    "type": "assistant",
+                    "message": {"role": "assistant", "content": [_settings_write_tool_with_id("toolu_denied")]},
+                },
+                _tool_result("toolu_denied", is_error=True),
+            ],
+        )
+
+        result = handle_allow_classifier_relax_settings_write(
+            {
+                "tool_name": "Edit",
+                "tool_input": {"file_path": _settings_json_path()},
+                "transcript_path": str(transcript),
+            }
+        )
+
+        _assert_sanctioned_allow(_decision(capsys), result)
+
+    def test_landed_write_still_consumes_consent(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """Anti-vacuity twin: a write that LANDED (success tool_result) still consumes it.
+
+        Without this, the denied-attempt carve-out could vacuously allow every replay.
+        A settings write whose tool_result is NOT an error did land — the retry is a
+        replay of consumed consent and must be refused.
+        """
+        transcript = _write_transcript(
+            tmp_path,
+            [
+                _user("file the issue"),
+                _assistant(
+                    "Choose:",
+                    tool_uses=[
+                        _ask_question_tool(["Allow it (relax classifier)", "Keep the denial (do it differently)"])
+                    ],
+                ),
+                _user("Allow it (relax classifier)"),
+                {
+                    "type": "assistant",
+                    "message": {"role": "assistant", "content": [_settings_write_tool_with_id("toolu_ok")]},
+                },
+                _tool_result("toolu_ok", is_error=False),
+            ],
+        )
+
+        result = handle_allow_classifier_relax_settings_write(
+            {
+                "tool_name": "Edit",
+                "tool_input": {"file_path": _settings_json_path()},
+                "transcript_path": str(transcript),
+            }
+        )
+
+        assert _decision(capsys) == {}
+        assert result is not True
+        assert result is not Verdict.ALLOW

--- a/tests/test_gate_liveness_corpus.py
+++ b/tests/test_gate_liveness_corpus.py
@@ -45,6 +45,7 @@ from typing import Final
 import pytest
 
 import hooks.scripts.hook_router as router
+from hooks.scripts.pretooluse_verdict import Verdict
 from teatree.core.overlay import OverlayBase, OverlayConfig
 from teatree.hooks import _repo_visibility
 
@@ -93,7 +94,7 @@ class GateRow:
     """One deny/enforcement gate. Adding a gate is exactly one of these rows."""
 
     gate_id: str
-    handler: Callable[[dict], bool | None]
+    handler: Callable[[dict], bool | Verdict | None]
     event: str
     matched: str
     deny_input: PayloadBuilder
@@ -162,7 +163,7 @@ def _gate_is_reachable(row: GateRow) -> bool:
 # ── deny detection ───────────────────────────────────────────────────────
 
 
-def _denied(handler: Callable[[dict], bool | None], event_input: dict) -> bool:
+def _denied(handler: Callable[[dict], bool | Verdict | None], event_input: dict) -> bool:
     """Run *handler*; True iff it denied (returned ``True``).
 
     Every deny gate in scope signals a deny via a ``True`` return — the
@@ -1129,7 +1130,7 @@ def test_phantom_roster_is_explicit_and_loud() -> None:
     )
 
 
-_NON_DENY_PRETOOLUSE_HANDLERS: Final[frozenset[Callable[[dict], bool | None]]] = frozenset(
+_NON_DENY_PRETOOLUSE_HANDLERS: Final[frozenset[Callable[[dict], bool | Verdict | None]]] = frozenset(
     {
         # Emits ``permissionDecision=allow`` (or ``None``) — it unblocks the
         # settings.json write, it never denies content.
@@ -1171,7 +1172,7 @@ def test_every_pretooluse_deny_handler_has_a_registry_row() -> None:
     Exempting a genuinely-non-deny handler requires a deliberate, reviewable
     addition to the allow-list, not a silent omission.
     """
-    registry: list[Callable[[dict], bool | None]] = router._HANDLERS["PreToolUse"]
+    registry: list[Callable[[dict], bool | Verdict | None]] = router._HANDLERS["PreToolUse"]
     allowlisted = _NON_DENY_PRETOOLUSE_HANDLERS - set(registry)
     assert not allowlisted, (
         "Non-deny allow-list names handlers absent from the live PreToolUse "

--- a/tests/test_hook_router_classifier_relax_wire.py
+++ b/tests/test_hook_router_classifier_relax_wire.py
@@ -1,0 +1,201 @@
+"""Subprocess wire-test harness for the classifier-relax PreToolUse verdict (#3, #4).
+
+The existing classifier-relax tests call ``handle_allow_classifier_relax_settings_write``
+in-process and read the stdout payload. They NEVER exercise ``main()``'s exit-code
+translation — which is exactly why #3 shipped: the sanctioned allow emitted a bare
+legacy ``{"permissionDecision": "allow"}`` and returned ``True``, and ``main()``
+translated that ``True`` into ``sys.exit(2)`` (a BLOCK). The human approval acted as a
+block and the blocked attempt burned the one-shot consent — invisible to an in-process
+test that only reads the emitted JSON.
+
+This harness runs ``hook_router.py --event PreToolUse`` as a real subprocess so the
+process exit code propagates through ``sys.exit``, and asserts BOTH the exit code and
+the emitted envelope shape. It is the wire-level anti-vacuity proof for #3/#4 and the
+reusable harness GM-2 extends for the Lane-B hard-deny parity.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+HOOK_ROUTER = Path(__file__).resolve().parent.parent / "hooks" / "scripts" / "hook_router.py"
+
+
+def run_hook_router(event: str, payload: dict, *, home: str) -> subprocess.CompletedProcess[str]:
+    """Run ``hook_router.py --event <event>`` as a subprocess with a controlled HOME.
+
+    ``home`` isolates ``~/.claude/settings.json`` (the classifier-relax target) and
+    ``~/.teatree.toml`` (the fail-open kill-switch read) from the developer's real
+    config, so the deny/allow assertions depend only on the payload + transcript.
+    ``Path.home()`` honours ``HOME`` on POSIX.
+    """
+    env = {**os.environ, "HOME": home, "USERPROFILE": home}
+    return subprocess.run(
+        [sys.executable, str(HOOK_ROUTER), "--event", event],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=15,
+        env=env,
+    )
+
+
+# ── Transcript builders (mirror test_classifier_relax_pretooluse_hook.py) ──
+
+
+def _assistant(text: str, tool_uses: list[dict] | None = None) -> dict:
+    content: list[dict] = []
+    if text:
+        content.append({"type": "text", "text": text})
+    content.extend({"type": "tool_use", "name": tu["name"], "input": tu.get("input", {})} for tu in tool_uses or [])
+    return {"type": "assistant", "message": {"role": "assistant", "content": content}}
+
+
+def _user(text: str = "go") -> dict:
+    return {"type": "user", "message": {"role": "user", "content": [{"type": "text", "text": text}]}}
+
+
+def _ask_relax_question() -> dict:
+    return {
+        "name": "AskUserQuestion",
+        "input": {
+            "questions": [
+                {"question": "?", "options": ["Allow it (relax classifier)", "Keep the denial (do it differently)"]}
+            ]
+        },
+    }
+
+
+@contextmanager
+def _sanctioned_home() -> Iterator[tuple[str, str, str]]:
+    """Yield ``(home, settings_path, transcript_path)`` with a Step-3 approval on record.
+
+    The transcript carries the sanctioned classifier-relax AskUserQuestion + an
+    affirmative user turn and NO settings.json write since, so the allow gate's
+    consume-once consent is live.
+    """
+    with tempfile.TemporaryDirectory() as home:
+        settings = str(Path(home) / ".claude" / "settings.json")
+        transcript = Path(home) / "transcript.jsonl"
+        entries = [
+            _user("file the issue"),
+            _assistant("The command was denied. Choose:", tool_uses=[_ask_relax_question()]),
+            _user("Allow it (relax classifier)"),
+        ]
+        transcript.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+        yield home, settings, str(transcript)
+
+
+class TestSanctionedAllowExitsZeroWithNestedEnvelope:
+    """#3: a sanctioned classifier-relax allow must exit 0 with the nested allow shape.
+
+    RED before the fix: the handler emitted flat ``{"permissionDecision": "allow"}``
+    and returned ``True``, so ``main()`` exited 2 (a BLOCK) and there was no
+    ``hookSpecificOutput`` envelope for the harness to read.
+    """
+
+    def test_valid_write_allow_exits_0_and_nested_envelope(self) -> None:
+        with _sanctioned_home() as (home, settings, transcript):
+            payload = {
+                "tool_name": "Write",
+                "tool_input": {
+                    "file_path": settings,
+                    "content": '{"permissions": {"allow": ["Bash(gh issue create *)"]}}',
+                },
+                "transcript_path": transcript,
+            }
+            result = run_hook_router("PreToolUse", payload, home=home)
+
+        assert result.returncode == 0, (
+            f"a sanctioned allow must exit 0, not the deny exit 2 (#3); got {result.returncode}; "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        out = json.loads(result.stdout)
+        nested = out.get("hookSpecificOutput")
+        assert nested is not None, "the allow must carry the nested hookSpecificOutput envelope the harness reads"
+        assert nested.get("hookEventName") == "PreToolUse"
+        assert nested.get("permissionDecision") == "allow"
+
+
+class TestSanctionedDenyExitsTwo:
+    """A schema-invalid write WITH the approval must still deny — and deny exits 2."""
+
+    def test_malformed_write_denied_exits_2(self) -> None:
+        with _sanctioned_home() as (home, settings, transcript):
+            payload = {
+                "tool_name": "Write",
+                "tool_input": {"file_path": settings, "content": "{ broken json"},
+                "transcript_path": transcript,
+            }
+            result = run_hook_router("PreToolUse", payload, home=home)
+
+        assert result.returncode == 2, (
+            f"a malformed sanctioned write must deny (exit 2); got {result.returncode}; stdout={result.stdout!r}"
+        )
+        out = json.loads(result.stdout)
+        assert out["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+class TestJsonKeyEditIsNotFalseBlocked:
+    """#4: an Edit whose new_string carries JSON KEYS (``"allow":``) must NOT be blocked.
+
+    RED before the fix: ``_new_string_adds_blanket_rule`` extracted every quoted token,
+    so the JSON key ``allow`` matched the bare-tool blanket-rule pattern and the write
+    was DENIED (exit 2) — burning the consume-once approval on a false-block.
+    """
+
+    def test_edit_adding_scoped_rule_under_allow_key_exits_0(self) -> None:
+        with _sanctioned_home() as (home, settings, transcript):
+            # No settings.json seeded → the applied-content path is unreadable, so the
+            # raw-fragment fallback runs. Its regex must exclude the ``"allow":`` key.
+            payload = {
+                "tool_name": "Edit",
+                "tool_input": {
+                    "file_path": settings,
+                    "old_string": "",
+                    "new_string": '  "permissions": {\n    "allow": [\n      "Bash(uv run pytest:*)",',
+                },
+                "transcript_path": transcript,
+            }
+            result = run_hook_router("PreToolUse", payload, home=home)
+
+        assert result.returncode == 0, (
+            f'an Edit adding a scoped rule under the "allow": key must not be blocked (#4); '
+            f"got {result.returncode}; stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        out = json.loads(result.stdout)
+        assert out["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+
+class TestBareToolListEntryStillRefused:
+    """#4 not-weakened: a bare-tool list entry (``"Bash",``) after a key is STILL refused.
+
+    The regex fix excludes JSON keys, but a whole-tool blanket grant that IS a list
+    entry (followed by ``,``/``]``, not ``:``) must keep failing — the smallest-rule
+    protocol is not relaxed.
+    """
+
+    def test_edit_adding_bare_bash_rule_denied_exits_2(self) -> None:
+        with _sanctioned_home() as (home, settings, transcript):
+            payload = {
+                "tool_name": "Edit",
+                "tool_input": {
+                    "file_path": settings,
+                    "old_string": "",
+                    "new_string": '  "permissions": {\n    "allow": [\n      "Bash",',
+                },
+                "transcript_path": transcript,
+            }
+            result = run_hook_router("PreToolUse", payload, home=home)
+
+        assert result.returncode == 2, (
+            f"a bare-tool blanket rule must still be refused; got {result.returncode}; stdout={result.stdout!r}"
+        )
+        out = json.loads(result.stdout)
+        assert out["hookSpecificOutput"]["permissionDecision"] == "deny"


### PR DESCRIPTION
## The safety bug (a human approval acted as a BLOCK and burned consent)

The sanctioned classifier-relax `~/.claude/settings.json` allow — the last step of the Classifier Denial Protocol, where the user explicitly approves relaxing a permission — was unusable and consent-destroying:

- **#3 (safety):** the allow emitted a bare legacy `{"permissionDecision": "allow"}` and returned `True`. `main()` treats a `True` handler return as a **deny** and translates it to `sys.exit(2)`. So the sanctioned ALLOW was translated to a BLOCK — the human approval never let the write through — and because the blocked attempt still sits in the transcript, the consume-once scan read it as a completed write and refused the retry as a replay. Human approvals were both non-functional and one-shot-consent-destroying.
- **#4:** `_is_blanket_rule` was widened to flag all bare words, so the Edit `new_string` fragment scan read the JSON **keys** `"allow"`/`"permissions"` as whole-tool blanket grants and false-blocked a legitimate scoped-rule Edit — again burning the consume-once approval.

## The fix

- New `hooks/scripts/pretooluse_verdict.py`: a distinct `Verdict.ALLOW` sentinel + `emit_pretooluse_allow()` that writes the nested `hookSpecificOutput` allow envelope Claude Code actually reads. The deny writer stays in `hook_router` so the never-lockout contract's call-graph analysis still sees it.
- `main()` breaks the handler chain on any truthy decision but `sys.exit(2)` **only** on a deny (`verdict is True`); the `Verdict.ALLOW` sentinel falls through to exit 0. Net-zero LOC in the shrink-only `hook_router`.
- `_new_string_adds_blanket_rule` excludes JSON-key positions (a quoted token followed by a colon), pairing quotes with `finditer` so a bare-tool list **entry** after keys is still refused (a lookahead-`findall` mis-pairs on multi-key fragments and would let a real bare-tool entry slip). `validate_relax_write` now prefers the parsed applied-content check (`_validate_allow_lists` over real allow-list entries, never keys) as authoritative when the file is readable.
- **Consent survives a denied attempt:** a settings write whose `tool_use_id` carries an `is_error` tool_result did not land, so it no longer consumes the one-shot consent — a false-block (or any deny) leaves the approval alive for a corrected retry.

## Subprocess wire-test harness (exit-code translation) — the anti-vacuity proof

The existing classifier-relax tests call the handler in-process and read the emitted JSON; they **never** exercise `main()`'s exit-code translation — which is exactly why #3 shipped green. `tests/test_hook_router_classifier_relax_wire.py` runs `hook_router.main()` via a real argv/subprocess and asserts the **exit code + envelope shape**.

**Observed RED before the fix:**

- sanctioned allow → exit **2** (the block), no `hookSpecificOutput` envelope;
- a JSON-key Edit (`"allow": [ … ]`) → **denied** with `blanket-wildcard rule ``permissions```.

**GREEN after:** sanctioned allow → exit 0 + nested allow shape; the JSON-key Edit → exit 0; a bare-tool `"Bash",` list entry after keys → still exit 2 (deny). The consent-survives and JSON-key regressions were each verified RED-before-GREEN in `tests/test_classifier_relax_pretooluse_hook.py`.

The subprocess harness (`run_hook_router`) is written as a reusable helper the next gate-merge PR extends for its Lane-B hard-deny parity.

## Verification

- `dev/ci-parity.sh`: coverage **95.23%** (≥93% floor). The only failures in the full run were `pytest-timeout` / subprocess-spawn timeouts on tree-wide scanners under concurrent machine load (a second `ci-parity` was running in another worktree) — each passes in isolation and Tach reports them unaffected by this change.
- `tests/quality` + `tests/test_gate_never_lockout_contract.py`: green (the deny single-funnel + never-lockout routing is preserved).
- `banned-terms scan-tree`: clean.

The `#3`/`#4` identifiers are integration-audit bug numbers (audit-doc IDs), not GitHub issue numbers, so no close-keyword is used.
