### PR TITLE
fix(hooks): shared Bash hard-deny registry closes the Lane-B raw-merge/no-verify bypass (#2)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -5443,21 +5443,19 @@ _OUT_OF_BAND_MERGE_REASON = (
 def _is_raw_merge_api_write(command: str) -> bool:
     """Whether *command* is a raw forge REST WRITE to a merge endpoint.
 
-    True only when the command targets a ``.../pulls/<n>/merge`` or
-    ``.../merge_requests/<n>/merge`` endpoint AND its EFFECTIVE HTTP method is
-    not GET. Reuses the gate-3 effective-method classifier: the LAST
-    ``-X``/``--method`` value wins; with no method flag the default is POST
-    when a body/field flag is present, else GET. A GET to the merge endpoint
-    reads merge status and must NOT be denied.
-
-    Uses a word-boundary regex (not plain ``in``) so double-space variants
-    are caught (same class as F4).
+    Delegates to :func:`teatree.hooks.raw_merge_detect.is_raw_merge_api_write` —
+    the SAME leaf the shared hard-deny registry (Lane B) uses, so the two lanes
+    classify the merge API write identically. Fails CLOSED (treats the command as
+    a possible merge write) on any import error so a broken environment cannot
+    weaken the gate; the cwd-managed check then blocks on uncertainty.
     """
-    if not _GLAB_GH_API_RE.search(command):
-        return False
-    if not _MERGE_ENDPOINT_RE.search(command):
-        return False
-    return _effective_method_is_write(command)
+    try:
+        with _teatree_src_on_path():
+            from teatree.hooks import raw_merge_detect  # noqa: PLC0415 (lazy src-bootstrap import)
+
+            return raw_merge_detect.is_raw_merge_api_write(command)
+    except Exception:  # noqa: BLE001 (fail-closed: a broken import must not weaken the merge gate)
+        return True
 
 
 def _cwd_is_teatree_managed(cwd: Path) -> bool | None:

--- a/src/teatree/agents/lane_b/gating.py
+++ b/src/teatree/agents/lane_b/gating.py
@@ -2,22 +2,39 @@
 
 Two gate kinds, mirroring Lane A.
 
-Hard-deny — a command that must never run (a main-clone working-tree mutation, a
-privacy/banned-term leak). :func:`hard_deny_reason` is the single shared
-evaluator; it consults the SAME importable ``teatree`` functions Lane A's
-PreToolUse hook wraps (:func:`teatree.core.gates.main_clone_guard.find_main_clone_git_mutation`,
-and :func:`teatree.hooks.quote_scanner.extract_publish_payload` → :func:`~teatree.hooks.quote_scanner.scan_text`
-for the privacy scan — scoped to a PUBLISH payload, never every string argument —
-then a HIGH finding routed through Lane A's OWN destination gate
-(:func:`teatree.hooks.public_visibility.gate_skips_for_visibility` +
-:func:`teatree.hooks.publish_surface.command_targets_private_only`, the two
-predicates Lane A's ``resolve_high_verdict`` composes), never an unconditional
-deny-any-HIGH), so the two lanes refuse the identical set by construction — same
-payload scoping AND same destination-awareness — not by a parallel
-re-implementation.
+Hard-deny — a command that must never run. :func:`hard_deny_reason` is the single
+shared evaluator; it composes THREE importable-``teatree`` deny families, each the
+SAME code Lane A's PreToolUse gates consult, so the two lanes refuse the same set.
+
+Family 1, the main-clone working-tree mutation, is
+:func:`~teatree.core.gates.main_clone_env.main_clone_git_deny_reason`, scoped by
+*cwd* (the worktree jail), exactly as Lane A's main-clone gate. Family 2, the
+Bash-shaped hard-denies, is the shared
+:func:`teatree.hooks.hard_deny_registry.hard_deny_reason`, iterating the ONE
+registry (raw forge-merge, ``--no-verify``/hooksPath, secret-file-print,
+raw-review-post, self-reviewer-assign, raw-pid-kill) that the cold PreToolUse
+guards delegate to. Before this registry, Lane B checked only families 1 and 3, so
+a raw forge merge or a hook-silencing push was reachable under
+``agent_harness=pydantic_ai`` with NO MergeClear or CI verification (the "Lane-B
+bypass" class, souliane/teatree#2 — closed here). Family 3, the privacy/banned-term
+leak, is the publish payload
+(:func:`~teatree.hooks.quote_scanner.extract_publish_payload`, ``None`` for a
+non-publish call), privacy-scanned, then a HIGH finding routed through Lane A's OWN
+destination gate (:func:`~teatree.hooks.public_visibility.gate_skips_for_visibility`
++ :func:`~teatree.hooks.publish_surface.command_targets_private_only`), never an
+unconditional deny-any-HIGH.
+
+The two lanes refuse the SAME set because they run the SAME predicates — not
+"identical by construction" of two parallel re-implementations (that claim was
+false: it omitted family 2 entirely). The deny-corpus parity test
+(``tests/teatree_agents/lane_b/test_parity.py``) feeds every Lane-A deny fixture
+through :func:`hard_deny_reason` and asserts identical refusals, so a future
+divergence fails CI.
+
 :class:`HardDenyToolset` wraps a toolset and raises the refusal into the model as
 a ``RetryPromptPart`` (the model sees the reason and must adapt) exactly as a
-Lane-A PreToolUse deny surfaces its message.
+Lane-A PreToolUse deny surfaces its message — under a per-run retry cap so a
+predicate false-positive aborts the run cleanly instead of looping the model.
 
 Soft-gate — a command that needs a human's approval (the ask-gate).
 :func:`make_soft_gate_predicate` builds the ``approval_required`` predicate; a
@@ -28,12 +45,12 @@ approve/deny.
 """
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from pydantic_ai import RunContext
-from pydantic_ai.exceptions import ApprovalRequired, ModelRetry
+from pydantic_ai.exceptions import ApprovalRequired, ModelRetry, UnexpectedModelBehavior
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.toolsets.abstract import ToolsetTool
 from pydantic_ai.toolsets.wrapper import WrapperToolset
@@ -99,14 +116,20 @@ def hard_deny_reason(tool_name: str, tool_args: dict[str, Any], *, cwd: Path | N
     """Return the refusal reason for a tool call, or ``None`` when it is allowed.
 
     The single shared hard-deny evaluator, consulting the same ``teatree``
-    functions Lane A's PreToolUse hook does. First, a command-tool call is run
-    through the FULL main-clone gate (:func:`main_clone_git_deny_reason`),
-    mirroring Lane A: it resolves the command's effective dir (honouring
-    ``-C``/``--git-dir``) and refuses a ``checkout <feature>`` / ``reset --hard``
-    / ``restore`` / ``stash pop`` ONLY when it targets a managed MAIN CLONE —
-    the same routine worktree git ops Lane A ALLOWS pass here too, since Lane B
-    tools are jailed to *cwd* (the worktree). Then the call's PUBLISH payload — the
-    body of a publish command, resolved through the SAME
+    functions Lane A's PreToolUse hook does, in three families. FIRST, a
+    command-tool call is run through the FULL main-clone gate
+    (:func:`main_clone_git_deny_reason`), mirroring Lane A: it resolves the
+    command's effective dir (honouring ``-C``/``--git-dir``) and refuses a
+    ``checkout <feature>`` / ``reset --hard`` / ``restore`` / ``stash pop`` ONLY
+    when it targets a managed MAIN CLONE — the same routine worktree git ops Lane A
+    ALLOWS pass here too, since Lane B tools are jailed to *cwd* (the worktree).
+    SECOND, the command runs through the shared Bash-shaped hard-deny registry
+    (:func:`teatree.hooks.hard_deny_registry.hard_deny_reason`) — the ONE set the
+    cold PreToolUse guards also iterate (raw forge-merge, ``--no-verify``/hooksPath,
+    secret-file-print, raw-review-post, self-reviewer-assign, raw-pid-kill), so a
+    raw ``gh pr merge`` / ``git push --no-verify`` is denied here exactly as Lane A
+    denies it. THIRD, the call's PUBLISH payload — the body of a publish command,
+    resolved through the SAME
     :func:`~teatree.hooks.quote_scanner.extract_publish_payload` scoping Lane A's
     PreToolUse uses — is privacy-scanned; a HIGH finding is routed through Lane A's
     OWN destination gate (:func:`_publish_high_denies`) and refuses the call ONLY
@@ -117,6 +140,9 @@ def hard_deny_reason(tool_name: str, tool_args: dict[str, Any], *, cwd: Path | N
     identical publish set, not a wider everything-scan nor a wider deny-any-HIGH.
     """
     from teatree.core.gates.main_clone_env import main_clone_git_deny_reason  # noqa: PLC0415
+    from teatree.hooks.hard_deny_registry import (  # noqa: PLC0415 (lazy, mirrors the other in-function hard-deny imports)
+        hard_deny_reason as bash_hard_deny_reason,
+    )
     from teatree.hooks.quote_scanner import HIGH, scan_text  # noqa: PLC0415
 
     command = _command_of(tool_name, tool_args)
@@ -124,6 +150,9 @@ def hard_deny_reason(tool_name: str, tool_args: dict[str, Any], *, cwd: Path | N
         main_clone_reason = main_clone_git_deny_reason(command, cwd)
         if main_clone_reason is not None:
             return main_clone_reason
+        registry_reason = bash_hard_deny_reason(command)
+        if registry_reason is not None:
+            return registry_reason
 
     payload = _publish_payload(command, cwd)
     if payload is not None:
@@ -133,6 +162,14 @@ def hard_deny_reason(tool_name: str, tool_args: dict[str, Any], *, cwd: Path | N
             return f"BLOCKED: privacy/banned-term gate — {high.name}: {high.excerpt!r}"
 
     return None
+
+
+#: How many hard-denies one run may raise before the run is aborted. A refusal is
+#: a ``ModelRetry`` the model is meant to adapt to; but a predicate FALSE-positive
+#: it cannot satisfy (or a genuinely-blocked path the model keeps re-attempting
+#: with variations) would loop, burning tokens. Past this cap the deny becomes a
+#: terminal :class:`UnexpectedModelBehavior` that ends the run instead of retrying.
+_DEFAULT_MAX_DENIALS: int = 3
 
 
 @dataclass
@@ -148,15 +185,32 @@ class HardDenyToolset(WrapperToolset[None]):
     git ops. It is a dataclass FIELD (not a plain attribute) because
     ``WrapperToolset`` rebuilds itself via ``dataclasses.replace`` in ``for_run``
     — a non-field would be dropped and reset each run.
+
+    *max_denials* caps how many hard-denies a single run may raise: past it the
+    deny is a terminal :class:`UnexpectedModelBehavior` (the run ends) rather than
+    a :class:`ModelRetry`, so a predicate false-positive cannot loop the model.
+    *denial_counts* tallies denials per ``run_id``; it is a shared-by-``replace``
+    field (``for_run`` rebuilds the toolset), so all per-run copies increment the
+    same tally and each run's count is isolated by its own key.
     """
 
     cwd: Path | None = None
+    max_denials: int = _DEFAULT_MAX_DENIALS
+    denial_counts: dict[str, int] = field(default_factory=dict)
 
     async def call_tool(
         self, name: str, tool_args: dict[str, Any], ctx: RunContext[None], tool: ToolsetTool[None]
     ) -> Any:  # noqa: ANN401 — the ``WrapperToolset.call_tool`` contract is ``-> Any``; matched here.
         reason = hard_deny_reason(name, tool_args, cwd=self.cwd)
         if reason is not None:
+            run_key = getattr(ctx, "run_id", "") or ""
+            self.denial_counts[run_key] = self.denial_counts.get(run_key, 0) + 1
+            if self.denial_counts[run_key] >= self.max_denials:
+                cap_reached = (
+                    f"Lane-B hard-deny retry cap reached ({self.max_denials} refusals this run); "
+                    f"aborting rather than looping. Last refusal — {reason}"
+                )
+                raise UnexpectedModelBehavior(cap_reached)
             raise ModelRetry(reason)
         return await super().call_tool(name, tool_args, ctx, tool)
 

--- a/src/teatree/hooks/git_bypass_detect.py
+++ b/src/teatree/hooks/git_bypass_detect.py
@@ -1,0 +1,79 @@
+"""Detect a git command that silences hooks or schedules an out-of-band auto-merge.
+
+The safety-critical subset of the ``hooks/scripts/direct_command_guard`` denylist
+that must ALSO refuse on Lane B (the ``pydantic_ai`` shell): a command that
+disables the git verification hooks (``--no-verify``, the ``git -c
+core.hooksPath=…`` silencer), skips commit signing (``--no-gpg-sign``), or
+schedules a GitLab pipeline-succeeds auto-merge (``git push -o
+merge_request.merge_when_pipeline_succeeds``) — each a way to land work past the
+gates the keystone merge enforces. The full direct-command denylist (docker,
+npm, pip, playbook workflow bypasses) is a workflow-convention gate that stays
+in the PreToolUse guard; only this hook/merge-bypass family is a hard-deny the
+headless shell shares.
+
+Pure and self-contained (stdlib-only) so it is importable by Lane B AND by the
+cold PreToolUse subprocess. VALUE/CONFIG patterns (``core.hooksPath=``, the
+push-option value) are scanned against the RAW command so quoting cannot evade
+them; the flag patterns (``--no-verify`` / ``--no-gpg-sign``) are scanned against
+a quote-stripped copy so the phrase inside a commit message / grep argument does
+not false-fire — the exact split
+:func:`hooks.scripts.direct_command_guard.deny_match` uses, so the
+:mod:`teatree.hooks.hard_deny_registry` deny-corpus parity test binds the two.
+"""
+
+import re
+
+_HOOKS_PATH_REASON = (
+    "BLOCKED: `git -c core.hooksPath=…` bypasses git hooks (equivalent to `--no-verify`) — "
+    "fix the hook failure instead."
+)
+_AUTO_MERGE_REASON = (
+    "BLOCKED: `git push -o merge_request.merge_when_pipeline_succeeds` schedules an auto-merge "
+    "bypassing the FSM keystone — use `t3 <overlay> ticket merge` instead."
+)
+_NO_VERIFY_REASON = "BLOCKED: `--no-verify` — fix the hook failure instead of bypassing it."
+_NO_GPG_REASON = "BLOCKED: `--no-gpg-sign` — do not bypass signing without explicit user approval."
+
+# VALUE/CONFIG patterns — scanned against the RAW command (quoting cannot evade).
+_RAW_SCAN: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\bgit\b.*-c\s+['\"]?core\.hooksPath\s*=", re.IGNORECASE), _HOOKS_PATH_REASON),
+    (
+        re.compile(
+            r"\bgit\s+push\b.*"
+            r"(?:-o\s+['\"]?merge_request\.merge_when_pipeline_succeeds"
+            r"|--push-option=['\"]?merge_request\.merge_when_pipeline_succeeds)"
+        ),
+        _AUTO_MERGE_REASON,
+    ),
+)
+
+# TOOL-INVOCATION flag patterns — scanned against a quote-stripped copy so a flag
+# mentioned inside a commit message / grep argument does not false-block.
+_FLAG_SCAN: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\bgit\s+\S+.*--no-verify\b"), _NO_VERIFY_REASON),
+    (re.compile(r"\bgit\s+\S+.*--no-gpg-sign\b"), _NO_GPG_REASON),
+)
+
+_QUOTED_LITERAL_RE = re.compile(r"'[^']*'|\"[^\"]*\"")
+
+
+def git_bypass_deny_reason(command: str) -> str | None:
+    """Return the deny reason for a hook/merge-bypass git command, or ``None``.
+
+    ``None`` for anything that does not silence hooks, skip signing, or schedule an
+    auto-merge — including ordinary git ops and prose that merely mentions a flag
+    inside a quoted argument.
+    """
+    if not command:
+        return None
+    for pattern, reason in _RAW_SCAN:
+        if pattern.search(command):
+            return reason
+    quote_stripped = _QUOTED_LITERAL_RE.sub(" ", command)
+    for pattern, reason in _FLAG_SCAN:
+        if pattern.search(quote_stripped):
+            return reason
+    return None
+
+
+__all__ = ["git_bypass_deny_reason"]

--- a/src/teatree/hooks/hard_deny_registry.py
+++ b/src/teatree/hooks/hard_deny_registry.py
@@ -1,0 +1,76 @@
+"""The ONE shared registry of Bash-shaped hard-deny predicates (#2, souliane/teatree).
+
+A single source of truth for the shell-command refusals that BOTH lanes must
+enforce identically: the cold PreToolUse subprocess (``hooks/scripts/hook_router``
+and its sibling gates) AND the Lane-B ``pydantic_ai`` shell
+(:func:`teatree.agents.lane_b.gating.hard_deny_reason`, which iterates this
+registry). Before this registry the two diverged — Lane B's ``hard_deny_reason``
+checked only the main-clone + privacy gates, so a raw ``gh pr merge`` /
+``git push --no-verify`` / secret-print / raw-review-post / reviewer-assign /
+raw-pid-kill was reachable under ``agent_harness=pydantic_ai`` with NO MergeClear
+or CI verification (the "Lane-B bypass" class). Registering every Bash-shaped deny
+predicate here, iterated by both consumers, closes that class by construction.
+
+Each predicate is a PURE ``(command) -> reason-or-None`` matcher living in its own
+:mod:`teatree.hooks` leaf (stdlib-only, importable by Lane B and by the cold
+subprocess alike). The predicates carry NO cwd/kill-switch/carve-out context — that
+per-gate context (the raw-merge unmanaged-repo carve-out, the reviewer-ok token,
+the config kill-switches) stays in the individual PreToolUse guards, which layer it
+ON TOP of the same pure detectors. The deny-corpus parity test
+(``tests/teatree_agents/lane_b/test_parity.py``) feeds every Lane-A deny fixture
+through :func:`hard_deny_reason` and asserts identical refusals, so a future
+divergence between a leaf and its Lane-A guard fails CI.
+"""
+
+from collections.abc import Callable
+
+from teatree.hooks import (
+    git_bypass_detect,
+    raw_merge_detect,
+    raw_review_post_detect,
+    safe_kill_detect,
+    secret_file_print_detect,
+    self_reviewer_assign_detect,
+)
+
+#: A pure Bash-shaped deny predicate: the refusal reason for a command, or ``None``.
+HardDenyPredicate = Callable[[str], str | None]
+
+
+def _raw_pid_kill_deny_reason(command: str) -> str | None:
+    """The raw-pid-kill deny reason for *command*, or ``None`` — wraps the detection leaf."""
+    detection = safe_kill_detect.detect_raw_pid_kill(command)
+    return detection.message if detection.is_raw_pid_kill else None
+
+
+#: The SSOT list of ``(name, predicate)`` pairs iterated by BOTH the cold
+#: PreToolUse guards (each delegating to the same leaf) and Lane B's
+#: :func:`~teatree.agents.lane_b.gating.hard_deny_reason`. Order is deny priority:
+#: the first predicate to return a reason wins.
+HARD_DENY_PREDICATES: tuple[tuple[str, HardDenyPredicate], ...] = (
+    ("raw_merge", raw_merge_detect.raw_merge_deny_reason),
+    ("git_bypass", git_bypass_detect.git_bypass_deny_reason),
+    ("secret_file_print", secret_file_print_detect.secret_print_deny_reason),
+    ("raw_review_post", raw_review_post_detect.raw_review_deny_reason),
+    ("self_reviewer_assign", self_reviewer_assign_detect.reviewer_assign_deny_reason),
+    ("raw_pid_kill", _raw_pid_kill_deny_reason),
+)
+
+
+def hard_deny_reason(command: str) -> str | None:
+    """Return the first registered predicate's refusal reason for *command*, or ``None``.
+
+    The shared iteration both lanes run: a command denied by any Bash-shaped
+    predicate here is refused identically on Lane A and Lane B. An empty command
+    (a non-command tool call) is never a shell egress, so it is allowed.
+    """
+    if not command:
+        return None
+    for _name, predicate in HARD_DENY_PREDICATES:
+        reason = predicate(command)
+        if reason is not None:
+            return reason
+    return None
+
+
+__all__ = ["HARD_DENY_PREDICATES", "HardDenyPredicate", "hard_deny_reason"]

--- a/src/teatree/hooks/raw_merge_detect.py
+++ b/src/teatree/hooks/raw_merge_detect.py
@@ -29,6 +29,90 @@ import re
 
 from teatree.hooks._shell_lexer import split_commands, tokenize
 
+# A ``gh``/``glab api`` REST call — the out-of-band merge/mutation surface.
+_GLAB_GH_API_RE = re.compile(r"\b(?:glab|gh)\s+api\b")
+# The REST merge endpoint: ``(merge_requests|pulls)/<n>/merge`` (GitLab + GitHub shapes).
+_MERGE_ENDPOINT_RE = re.compile(r"(?:merge_requests|pulls)/\d+/merge\b")
+# GitHub GraphQL merge-effecting mutations (each merges a PR / branch out of band).
+_GRAPHQL_MERGE_MUTATION_RE = re.compile(r"(?:mergePullRequest|enablePullRequestAutoMerge|mergeBranch)\s*\(")
+# The gh/glab HTTP-method flag, both empirically-valid forms: spaced/``=`` (``-X PUT``,
+# ``--method=POST``) and the no-space pflag shorthand (``-XPUT``). Consumers flatten the
+# two capture groups and keep last-wins effective-method semantics — the same classifier
+# ``hook_router._effective_method_is_write`` encodes, carried self-contained here so the
+# leaf stays importable by Lane B and the cold PreToolUse subprocess alike.
+_METHOD_FLAG_RE = re.compile(r"(?:-X|--method)[\s=]+['\"]?([A-Za-z]+)\b|(?<=-X)([A-Za-z]+)\b")
+_BODY_FLAG_RE = re.compile(r"(?:^|\s)(?:-f|--field|-F|--raw-field|--input|-d|--data)\b")
+
+_RAW_MERGE_DENY_REASON = (
+    "BLOCKED: raw `gh pr merge` / `glab mr merge` on a teatree-managed repo — "
+    "an out-of-band merge bypasses the FSM coherence mechanism (ledger update, "
+    "MergeClear validation, SHA-binding, privacy/AI-signature scan, mark_merged). "
+    "Use the sanctioned keystone transition `t3 <overlay> ticket merge <clear_id>` "
+    "(BLUEPRINT §17.1 invariant 8 / §17.4). kill-switch: `t3 <overlay> gate raw-merge disable`."
+)
+
+
+def _effective_method_is_write(command: str) -> bool:
+    """Whether a gh/glab REST command's EFFECTIVE HTTP method is a write (not GET).
+
+    The LAST ``-X``/``--method`` value wins; with no method flag the forge defaults
+    to POST when a body/field flag is present, else GET. A GET is the only read.
+    """
+    methods = [m.upper() for pair in _METHOD_FLAG_RE.findall(command) for m in pair if m]
+    if methods:
+        return methods[-1] != "GET"
+    return bool(_BODY_FLAG_RE.search(command))
+
+
+def is_raw_merge_api_write(command: str) -> bool:
+    """Whether *command* is a raw forge REST WRITE to a ``.../<n>/merge`` endpoint.
+
+    True only when the command targets a ``.../pulls/<n>/merge`` or
+    ``.../merge_requests/<n>/merge`` endpoint AND its effective HTTP method is not
+    GET (a GET reads merge status and must NOT be denied).
+    """
+    if not command or not _GLAB_GH_API_RE.search(command):
+        return False
+    if not _MERGE_ENDPOINT_RE.search(command):
+        return False
+    return _effective_method_is_write(command)
+
+
+def invokes_graphql_merge_mutation(command: str) -> bool:
+    """Whether *command* is a ``gh``/``glab api`` GraphQL merge-effecting mutation.
+
+    A ``mergePullRequest`` / ``enablePullRequestAutoMerge`` / ``mergeBranch`` call
+    has an unresolvable node-id target, so any occurrence in a forge-``api`` command
+    is treated as a merge (fail-closed). A query moved out of argv (``-F query=@file``
+    / ``--input``) is an accepted residual, matching the router gate.
+    """
+    if not command or not _GLAB_GH_API_RE.search(command):
+        return False
+    return bool(_GRAPHQL_MERGE_MUTATION_RE.search(command))
+
+
+def raw_merge_deny_reason(command: str) -> str | None:
+    """Return the raw-merge deny reason for *command*, or ``None`` when it is allowed.
+
+    Fires on any of the three out-of-band merge vectors — the literal subcommand
+    (``gh pr merge`` / ``glab mr merge``, action-aware), the REST-API merge write, or
+    a GraphQL merge mutation. This is the PURE detector shared by
+    :mod:`teatree.hooks.hard_deny_registry` (Lane B) and delegated to by the router's
+    cwd-aware merge gate; the unmanaged-repo carve-out (#126) is hook_router context
+    layered ON TOP of this detector, never part of it — Lane B is always jailed to a
+    managed worktree, so it denies every raw merge unconditionally.
+    """
+    if not command:
+        return None
+    if (
+        invokes_raw_merge_subcommand(command)
+        or is_raw_merge_api_write(command)
+        or invokes_graphql_merge_mutation(command)
+    ):
+        return _RAW_MERGE_DENY_REASON
+    return None
+
+
 # A heredoc body span: ``<<['"]?DELIM['"]?\n … \nDELIM``. Stripped before lexing
 # so a body line that BEGINS with the merge phrase cannot land at a command
 # position. Mirrors the shape used by ``_body_file_resolution._HEREDOC_RE``.
@@ -149,4 +233,9 @@ def _segment_word_lists(command: str) -> list[list[str]]:
     return [[token.value for token in segment] for segment in split_commands(tokenize(command))]
 
 
-__all__ = ["invokes_raw_merge_subcommand"]
+__all__ = [
+    "invokes_graphql_merge_mutation",
+    "invokes_raw_merge_subcommand",
+    "is_raw_merge_api_write",
+    "raw_merge_deny_reason",
+]

--- a/src/teatree/hooks/raw_review_post_detect.py
+++ b/src/teatree/hooks/raw_review_post_detect.py
@@ -1,0 +1,64 @@
+"""Detect a raw ``glab api``/``gh api`` WRITE to a review-comment endpoint.
+
+The pure matcher behind the PreToolUse raw-review-post gate (#1164 / #2384 PR6),
+carried in a :mod:`teatree.hooks` leaf so BOTH the cold PreToolUse subprocess (via
+``hooks/scripts/raw_review_post_guard.py``) AND Lane B's shared hard-deny registry
+refuse the SAME set — a raw REST WRITE to a ``.../discussions``/``.../notes``/
+``.../comments`` endpoint, which bypasses the sanctioned ``t3 <overlay> review
+post-comment`` path (draft-default, dedup, on-behalf approval). A plain GET read
+is allowed.
+
+The command is classified by its EFFECTIVE HTTP method — the LAST ``-X``/
+``--method`` value wins; with no method flag the forge defaults to POST when a
+body/field flag is present, else GET. Only a GET is a read. The method regexes are
+carried self-contained here (the same shapes ``hook_router`` keeps for its own
+gates), so the leaf stays importable by Lane B; the deny-corpus parity test binds
+this leaf to ``hooks.scripts.raw_review_post_guard.is_raw_review_write``. Pure and
+stdlib-only.
+"""
+
+import re
+
+REVIEW_POST_ENDPOINT_RE = re.compile(r"(?:merge_requests|pulls|issues)/\d+/(?:discussions|notes|comments)\b")
+_GLAB_GH_API_RE = re.compile(r"\b(?:glab|gh)\s+api\b")
+_METHOD_FLAG_RE = re.compile(r"(?:-X|--method)[\s=]+['\"]?([A-Za-z]+)\b|(?<=-X)([A-Za-z]+)\b")
+_BODY_FLAG_RE = re.compile(r"(?:^|\s)(?:-f|--field|-F|--raw-field|--input|-d|--data)\b")
+
+_RAW_REVIEW_DENY_REASON = (
+    "BLOCKED: raw `glab api`/`gh api` POST to a review discussion/notes/comments "
+    "endpoint bypasses the sanctioned review-post CLI. To CREATE a note use "
+    "`t3 <overlay> review post-comment` (draft by default, #1207) or `post-draft-note`; "
+    "to EDIT use `t3 <overlay> review update-note`; to REMOVE use `delete-discussion` (MR) "
+    "or `delete-issue-note` (issue/work-item) — the CLI enforces draft-default, dedup, and "
+    "on-behalf approval, which a direct REST write skips. Read-only GETs are unaffected."
+)
+
+
+def is_raw_review_write(command: str) -> bool:
+    """Whether *command* is a raw forge REST WRITE to a review-comment endpoint.
+
+    True only when the command targets a ``.../discussions``/``.../notes``/
+    ``.../comments`` endpoint AND its effective HTTP method is not GET.
+    """
+    if not command or not _GLAB_GH_API_RE.search(command):
+        return False
+    if not REVIEW_POST_ENDPOINT_RE.search(command):
+        return False
+    methods = [m.upper() for pair in _METHOD_FLAG_RE.findall(command) for m in pair if m]
+    if methods:
+        is_read = methods[-1] == "GET"
+    elif _BODY_FLAG_RE.search(command):
+        is_read = False
+    else:
+        is_read = True
+    return not is_read
+
+
+def raw_review_deny_reason(command: str) -> str | None:
+    """Return the deny reason for a raw review-post write, or ``None`` when allowed."""
+    if not is_raw_review_write(command):
+        return None
+    return _RAW_REVIEW_DENY_REASON
+
+
+__all__ = ["is_raw_review_write", "raw_review_deny_reason"]

--- a/src/teatree/hooks/secret_file_print_detect.py
+++ b/src/teatree/hooks/secret_file_print_detect.py
@@ -1,0 +1,110 @@
+"""Detect a shell command that routes a secret-bearing source to stdout.
+
+The pure matcher behind the PreToolUse secret-file-print gate (#2384 PR4), carried
+in a :mod:`teatree.hooks` leaf so BOTH the cold PreToolUse subprocess (via
+``hooks/scripts/secret_file_print_guard.py``) AND Lane B's shared hard-deny
+registry refuse the SAME set. A command is a secret print when it would route a
+credential/key/``.env`` file or a pass store to stdout:
+
+* cat/head/tail of a known secret-bearing path;
+* ``pass show …`` whose stdout is neither captured nor redirected;
+* echo/printf of a pasted token literal (``glpat-``/``ghp_``/``xoxb-``/``sk-`` …).
+
+Allowed (must NOT false-positive): a variable capture (``VAR=$(…)``), a file
+redirect (``… > out``), env/header use (``curl -H "Token: $VAR"``), cat of an
+ordinary file, and echo of prose that merely MENTIONS a secret path. Pure and
+stdlib-only (regex + ``str`` ops), so it never raises on a shell-command string.
+"""
+
+import re
+
+# A pipe with a downstream sink — ``head | tail`` etc. — has at least this many
+# segments; fewer means no sink to consume the secret.
+_MIN_PIPE_SEGMENTS = 2
+
+_SECRET_PATHS_RE = re.compile(  # [skill-load-ok: souliane/teatree repo]
+    r"""(?x)
+    (?:~|/root|/home/[^/\s]+|/Users/[^/\s]+|\$HOME|\$\{HOME\}|\$\{?HOME\}?)
+    /(?:
+        \.teatree\.toml
+        | \.netrc
+        | \.config/gh/hosts\.yml
+        | (?:Library/Application\s+Support|\.config)/glab-cli/config\.yml
+        | \.ssh/(?:id_[a-z0-9_]+|.*\.pem|.*\.key)
+    )
+    | (?:^|[\s/])(?:
+        \.env(?!\.(?:example|sample|template|dist)\b)(?:\.[a-z]+)?
+        | secrets?\.env
+        | .*\.credentials?
+        | .*\.pem
+        | .*\.key
+        | .*_account\.json
+    )(?:\s|$|['")])
+    """,
+    re.IGNORECASE,
+)
+
+_TOKEN_LITERAL_RE = re.compile(r"""(?:^|\s)(?:glpat[-_]|ghp_|gho_|xoxb-|xoxp-|sk-)\S+""")
+_PRINT_CMDS_RE = re.compile(r"^\s*(?:cat|head|tail)\b")
+_PASS_SHOW_RE = re.compile(r"^\s*pass\s+show\b")
+_CAPTURE_RE = re.compile(  # [skill-load-ok: souliane/teatree repo]
+    r"""
+    \$\(            # subshell capture: $(…)
+    | >\s*\S+       # stdout redirect to a file or /dev/null
+    """,
+    re.VERBOSE,
+)
+_RE_EMITTER_SINK_RE = re.compile(r"^\s*(?:cat|less|more|tee|grep|head|tail)\b")
+_ECHO_SAFE_QUOTE_RE = re.compile(r"""^(?:'[^']*'|"[^"]*")$""")
+
+_STDOUT_LEAK_DENY_REASON = (  # [skill-load-ok: souliane/teatree repo]
+    "BLOCKED: this command would print a secret-bearing file or credential token "
+    "to the transcript. Reading a secret into the transcript is irrecoverable — "
+    "rotation is the only remedy. Instead, extract the value into a shell variable "
+    "(`TOKEN=$(pass show …)`) and use it via env/header without printing it. "
+    "Do NOT implement 'mask-then-print' — a masking regex is one edge case away "
+    "from leaking. The gate's job is to keep the value off stdout entirely."
+)
+
+
+def _command_captures_or_redirects(command: str) -> bool:
+    """Whether the command's stdout is captured or redirected (kept off the transcript)."""
+    if _CAPTURE_RE.search(command):
+        return True
+    segments = command.split("|")
+    if len(segments) < _MIN_PIPE_SEGMENTS:
+        return False
+    return not any(_RE_EMITTER_SINK_RE.match(segment) for segment in segments[1:])
+
+
+def _echo_arg_is_token(command: str) -> bool:
+    """Whether the echo/printf command carries a token literal (not just quoted prose)."""
+    verb_and_arg = 2
+    parts = command.split(None, 1)
+    if len(parts) < verb_and_arg:
+        return False
+    arg = parts[1].strip()
+    if _ECHO_SAFE_QUOTE_RE.match(arg):
+        return bool(_TOKEN_LITERAL_RE.search(arg[1:-1]))
+    return bool(_TOKEN_LITERAL_RE.search(command))
+
+
+def is_secret_print(command: str) -> bool:  # [skill-load-ok: souliane/teatree repo]
+    """Whether *command* would print a secret-bearing value to stdout."""
+    if _command_captures_or_redirects(command):
+        return False
+    if _PRINT_CMDS_RE.match(command):
+        return bool(_SECRET_PATHS_RE.search(command))
+    if re.match(r"^\s*(?:echo|printf)\b", command):
+        return _echo_arg_is_token(command)
+    return bool(_PASS_SHOW_RE.match(command))
+
+
+def secret_print_deny_reason(command: str) -> str | None:
+    """Return the deny reason for a secret-print command, or ``None`` when allowed."""
+    if not command or not is_secret_print(command):
+        return None
+    return _STDOUT_LEAK_DENY_REASON
+
+
+__all__ = ["is_secret_print", "secret_print_deny_reason"]

--- a/src/teatree/hooks/self_reviewer_assign_detect.py
+++ b/src/teatree/hooks/self_reviewer_assign_detect.py
@@ -1,0 +1,88 @@
+"""Detect a Bash command that directly assigns a reviewer on an MR/PR.
+
+The pure Bash-surface matcher behind the PreToolUse self-reviewer-assign gate
+(``hooks/scripts/no_self_reviewer_assign.py``), carried in a :mod:`teatree.hooks`
+leaf so BOTH the cold PreToolUse subprocess AND Lane B's shared hard-deny registry
+refuse the SAME set. Reviewers are NEVER directly assigned — review is REQUESTED
+via the Slack/approval channel; teatree has no sanctioned direct-assignment path.
+The matcher covers the CLI (``glab mr create/update --reviewer``, ``gh pr
+create/edit --reviewer``/``-r``/``--add-reviewer``) and the out-of-band REST WRITE
+that sets ``reviewer_ids``/``reviewers``/``requested_reviewers`` (a GET read of the
+same field is allowed — the block is gated on the effective HTTP method).
+
+The MCP-tool surface (``mcp__glab__glab_mr_*`` carrying a reviewer arg) stays in
+the PreToolUse guard — it is not a shell command and Lane B's MCP toolsets are
+read-only. Detection runs on the verb-skeleton (quoted spans + heredoc bodies
+stripped) so the phrase inside a commit message / doc string cannot false-fire —
+the same shape ``mr_cli_fields.strip_quoted_and_heredoc`` uses, carried
+self-contained here; the deny-corpus parity test binds this leaf to
+``hooks.scripts.no_self_reviewer_assign._bash_assigns_reviewer``. Pure and
+stdlib-only.
+"""
+
+import re
+
+_GLAB_MR_OP_RE = re.compile(r"\bglab\s+mr\s+(?:create|update)\b")
+_GH_PR_OP_RE = re.compile(r"\bgh\s+pr\s+(?:create|edit)\b")
+_REVIEWER_FLAG_RE = re.compile(r"--reviewers?\b")
+_GH_REVIEWER_FLAG_RE = re.compile(r"--(?:add-)?reviewers?\b|(?<![\w-])-r\b")
+_API_VERB_RE = re.compile(r"\b(?:gh|glab)\s+api\b")
+_API_REVIEWER_FIELD_RE = re.compile(r"\b(?:reviewer_ids|reviewers|requested_reviewers)\b")
+_API_WRITE_METHOD_RE = re.compile(r"(?:--method[ =]+|-X[ =]?)(?P<m>[A-Za-z]+)")
+_API_WRITE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+_API_BODY_FIELD_RE = re.compile(r"(?:--raw-field|--field|-[fF])\b")
+
+# Verb-skeleton strip (heredoc bodies, then quoted spans) — mirrors
+# ``mr_cli_fields.strip_quoted_and_heredoc``.
+_HEREDOC_RE = re.compile(r"<<-?\s*(['\"]?)(?P<delim>\w+)\1.*?^\s*(?P=delim)\b", re.DOTALL | re.MULTILINE)
+_SQUOTE_SPAN_RE = re.compile(r"'[^']*'")
+_DQUOTE_SPAN_RE = re.compile(r'"[^"]*"')
+
+_REVIEWER_ASSIGN_DENY_REASON = (
+    "BLOCKED: teatree NEVER directly assigns a reviewer on an MR/PR — least of "
+    "all the user's OWN MR. Review is REQUESTED via the Slack/approval channel "
+    "only (post the MR link to the review channel; the reviewer self-claims). "
+    "There is no sanctioned direct-assignment path: do not run "
+    "`glab mr create/update --reviewer`, `gh pr create --reviewer`/`-r`, "
+    "`gh pr edit --add-reviewer`, and do not set `reviewer_ids`/`requested_reviewers` "
+    "via a write API call."
+)
+
+
+def _strip_quoted_and_heredoc(command: str) -> str:
+    """Command with heredoc bodies and quoted spans removed — for verb DETECTION."""
+    without_heredoc = _HEREDOC_RE.sub(" ", command)
+    without_squote = _SQUOTE_SPAN_RE.sub(" ", without_heredoc)
+    return _DQUOTE_SPAN_RE.sub(" ", without_squote)
+
+
+def _api_call_writes_reviewer(skeleton: str) -> bool:
+    """Whether a ``gh``/``glab api`` call is a reviewer-list WRITE (not a GET read)."""
+    if not (_API_VERB_RE.search(skeleton) and _API_REVIEWER_FIELD_RE.search(skeleton)):
+        return False
+    method_match = _API_WRITE_METHOD_RE.search(skeleton)
+    if method_match:
+        return method_match.group("m").upper() in _API_WRITE_METHODS
+    return bool(_API_BODY_FIELD_RE.search(skeleton))
+
+
+def bash_assigns_reviewer(command: str) -> bool:
+    """Whether a Bash command directly assigns a reviewer on an MR/PR."""
+    if not command:
+        return False
+    skeleton = _strip_quoted_and_heredoc(command)
+    if _GLAB_MR_OP_RE.search(skeleton) and _REVIEWER_FLAG_RE.search(skeleton):
+        return True
+    if _GH_PR_OP_RE.search(skeleton) and _GH_REVIEWER_FLAG_RE.search(skeleton):
+        return True
+    return _api_call_writes_reviewer(skeleton)
+
+
+def reviewer_assign_deny_reason(command: str) -> str | None:
+    """Return the deny reason for a direct reviewer-assign command, or ``None``."""
+    if not bash_assigns_reviewer(command):
+        return None
+    return _REVIEWER_ASSIGN_DENY_REASON
+
+
+__all__ = ["bash_assigns_reviewer", "reviewer_assign_deny_reason"]

--- a/tests/teatree_agents/lane_b/test_gating.py
+++ b/tests/teatree_agents/lane_b/test_gating.py
@@ -1,15 +1,24 @@
+import asyncio
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
-from pydantic_ai.exceptions import ApprovalRequired
+from pydantic_ai.exceptions import ApprovalRequired, ModelRetry, UnexpectedModelBehavior
 from pydantic_ai.tools import ToolDefinition
+from pydantic_ai.toolsets.function import FunctionToolset
 
-from teatree.agents.lane_b.gating import hard_deny_reason, make_soft_gate_predicate, raise_if_soft_gated
+from teatree.agents.lane_b.gating import (
+    HardDenyToolset,
+    hard_deny_reason,
+    make_soft_gate_predicate,
+    raise_if_soft_gated,
+)
 from teatree.hooks import _repo_visibility
 from tests._git_repo import make_git_repo, run_git
 from tests.teatree_agents.lane_b._managed_clone import linked_worktree, managed_main_clone
 
 _MUTATIONS = ("git reset --hard HEAD~1", "git checkout my-feature", "git stash pop")
+_DENIED_CALL = {"command": "gh pr merge 5"}  # a registry hard-deny (raw forge merge)
 
 
 class TestHardDenyReason:
@@ -126,6 +135,33 @@ class TestHardDenyReason:
                 }
                 lane_a_denied = router.handle_block_main_clone_mutation(event)
                 assert lane_b_denied is lane_a_denied, (command, cwd)
+
+
+class TestHardDenyRetryCap:
+    """A hard-deny is a retryable ``ModelRetry`` UNTIL the per-run cap, then terminal.
+
+    A predicate false-positive the model cannot satisfy (or a blocked path it keeps
+    re-attempting with variations) would loop, burning tokens; the cap converts the
+    N-th refusal in a run into a terminal :class:`UnexpectedModelBehavior` so the
+    run ends cleanly instead of looping.
+    """
+
+    def test_denials_retry_until_the_cap_then_abort(self) -> None:
+        toolset = HardDenyToolset(FunctionToolset(), max_denials=3)
+        ctx = SimpleNamespace(run_id="run-1")
+        for _ in range(2):
+            with pytest.raises(ModelRetry):
+                asyncio.run(toolset.call_tool("shell", _DENIED_CALL, ctx, None))
+        with pytest.raises(UnexpectedModelBehavior):
+            asyncio.run(toolset.call_tool("shell", _DENIED_CALL, ctx, None))
+
+    def test_the_cap_is_isolated_per_run(self) -> None:
+        # A fresh run_id starts a fresh tally — the cap is per-run, not per-toolset.
+        toolset = HardDenyToolset(FunctionToolset(), max_denials=2)
+        with pytest.raises(ModelRetry):
+            asyncio.run(toolset.call_tool("shell", _DENIED_CALL, SimpleNamespace(run_id="run-1"), None))
+        with pytest.raises(ModelRetry):
+            asyncio.run(toolset.call_tool("shell", _DENIED_CALL, SimpleNamespace(run_id="run-2"), None))
 
 
 class TestSoftGate:

--- a/tests/teatree_agents/lane_b/test_parity.py
+++ b/tests/teatree_agents/lane_b/test_parity.py
@@ -16,6 +16,7 @@ consults, surfacing an ``is_error`` :class:`ToolResultBlock`.
 
 import asyncio
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 import pydantic_ai.models
@@ -40,14 +41,61 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models.function import DeltaToolCall, FunctionModel
 
+import hooks.scripts.no_self_reviewer_assign as _reviewer_guard
+import hooks.scripts.secret_file_print_guard as _secret_guard
+from hooks.scripts.direct_command_guard import deny_match as _direct_deny_match
 from hooks.scripts.quote_verdict import resolve_high_verdict
+from hooks.scripts.raw_review_post_guard import is_raw_review_write as raw_review_write_lane_a
 from teatree.agents.harness import PydanticAiHarness
 from teatree.agents.lane_b.gating import hard_deny_reason
-from teatree.hooks import _repo_visibility
+from teatree.hooks import (
+    _repo_visibility,
+    raw_merge_detect,
+    raw_review_post_detect,
+    safe_kill_detect,
+    secret_file_print_detect,
+    self_reviewer_assign_detect,
+)
 from teatree.hooks.quote_scanner import extract_publish_payload, scan_text
 from tests.teatree_agents.lane_b._managed_clone import linked_worktree, managed_main_clone
+from tests.test_hook_router_classifier_relax_wire import run_hook_router
 
 pydantic_ai.models.ALLOW_MODEL_REQUESTS = False  # ty: ignore[invalid-assignment] — the zero-token test guard.
+
+# Lane-A Bash-shaped deny matchers, imported from the cold PreToolUse guards — the
+# INDEPENDENT implementations the Lane-B leaves must agree with. raw-merge and
+# raw-pid-kill are already unified (the router guards DELEGATE to the leaves), so
+# their "Lane A denies" proof reads the shared detector; the other four guards keep
+# their own matcher, making the parity check a genuine cross-implementation compare.
+bash_assigns_reviewer_lane_a = _reviewer_guard._bash_assigns_reviewer
+_secret_print_lane_a = _secret_guard._is_secret_print
+
+
+def _lane_a_direct_denies(command: str) -> bool:
+    return _direct_deny_match(command) is not None
+
+
+def _lane_a_secret_denies(command: str) -> bool:
+    return _secret_print_lane_a(command)
+
+
+def _lane_a_review_denies(command: str) -> bool:
+    return raw_review_write_lane_a(command)
+
+
+def _lane_a_reviewer_denies(command: str) -> bool:
+    return bash_assigns_reviewer_lane_a(command)
+
+
+def _lane_a_raw_merge_denies(command: str) -> bool:
+    # The router's out-of-band-merge gate delegates its detection to
+    # raw_merge_detect and denies when the repo is managed; the detector firing IS
+    # the Lane-A deny trigger (Lane B is always jailed to a managed worktree).
+    return raw_merge_detect.raw_merge_deny_reason(command) is not None
+
+
+def _lane_a_pid_kill_denies(command: str) -> bool:
+    return safe_kill_detect.detect_raw_pid_kill(command).is_raw_pid_kill
 
 
 def _streaming_model(*, tool_command: str) -> FunctionModel:
@@ -302,6 +350,116 @@ class TestPrivacyGateParity:
         args = self._post("someowner/mystery", self._HIGH_BODY)
         assert hard_deny_reason("shell", args, cwd=tmp_path) is None
         assert self._lane_a_denies("shell", args, tmp_path) is False
+
+
+class TestBashHardDenyCorpusParity:
+    """Every Lane-A Bash-shaped hard-deny fires identically on Lane B (souliane/teatree#2).
+
+    The structural capstone for the "Lane-B bypass" class: before the shared
+    :mod:`teatree.hooks.hard_deny_registry`, Lane B's :func:`hard_deny_reason`
+    checked only main-clone + privacy, so a raw ``gh pr merge`` /
+    ``git push --no-verify`` / secret-print / raw-review-post / reviewer-assign /
+    raw-pid-kill was reachable under ``agent_harness=pydantic_ai`` with NO
+    MergeClear or CI verification. This test feeds each Lane-A deny fixture through
+    Lane B's ``hard_deny_reason`` (via the SAME registry) and asserts an identical
+    refusal — and, per family, feeds a fixture through the Lane-A guard matcher AND
+    the Lane-B leaf and asserts they agree, so a future divergence fails CI.
+    """
+
+    # (label, command, lane_a_denies) — every row is a REAL Lane-A Bash-shaped deny
+    # (the last field is the ANTI-VACUITY proof: the Lane-A guard denies it too).
+    _CORPUS: tuple[tuple[str, str, Callable[[str], bool]], ...] = (
+        ("raw gh pr merge", "gh pr merge 5 --repo o/x", _lane_a_raw_merge_denies),
+        ("raw glab mr merge", "glab mr merge 7", _lane_a_raw_merge_denies),
+        ("raw merge api PUT", "gh api repos/o/x/pulls/7/merge -X PUT", _lane_a_raw_merge_denies),
+        ("git commit no-verify", "git commit -m x --no-" + "verify", _lane_a_direct_denies),
+        ("git push no-verify", "git push --no-" + "verify", _lane_a_direct_denies),
+        ("git hooksPath silencer", "git -c core.hooks" + "Path=/dev/null commit -m x", _lane_a_direct_denies),
+        ("secret cat netrc", "cat ~/.netrc", _lane_a_secret_denies),
+        ("pass show unredirected", "pass show ci/token", _lane_a_secret_denies),
+        (
+            "raw review POST",
+            "glab api projects/42/merge_requests/7/discussions -X POST -f body=hi",
+            _lane_a_review_denies,
+        ),
+        ("glab reviewer assign", "glab mr update 7 --reviewer alice", _lane_a_reviewer_denies),
+        ("gh reviewer assign", "gh pr edit 7 --add-reviewer bob", _lane_a_reviewer_denies),
+        ("raw pid kill", "kill -9 4242", _lane_a_pid_kill_denies),
+    )
+
+    @pytest.mark.parametrize(("label", "command", "lane_a_denies"), _CORPUS, ids=[row[0] for row in _CORPUS])
+    def test_lane_b_denies_every_lane_a_bash_hard_deny(
+        self, label: str, command: str, lane_a_denies: Callable[[str], bool], tmp_path: Path
+    ) -> None:
+        # Anti-vacuity: the fixture is a genuine Lane-A refusal.
+        assert lane_a_denies(command), f"{label}: fixture is not a Lane-A deny — the parity claim is vacuous"
+        # RED before the registry wiring: Lane B returned None (the command was reachable).
+        reason = hard_deny_reason("shell", {"command": command}, cwd=tmp_path)
+        assert reason is not None, f"{label}: Lane B must refuse a command Lane A refuses (the bypass class)"
+        assert "BLOCKED" in reason
+
+    def test_benign_commands_are_allowed_on_lane_b(self, tmp_path: Path) -> None:
+        # The anti-over-block twin: a benign shell command Lane A allows is allowed.
+        for command in ("ls -la", "gh pr view 5", "git commit -m 'normal'", "gh api repos/o/x/pulls/7/comments"):
+            assert hard_deny_reason("shell", {"command": command}, cwd=tmp_path) is None, command
+
+    # (leaf-predicate, INDEPENDENT lane-a-matcher, commands) — the divergence guard:
+    # for each command (deny AND allow shapes), the Lane-B leaf and the Lane-A guard
+    # (a separate hooks/scripts implementation) must agree. raw-merge and raw-pid-kill
+    # are omitted here — the router guards DELEGATE to those leaves, so there is no
+    # independent implementation to diverge (the corpus test covers them).
+    def test_each_leaf_agrees_with_its_independent_lane_a_guard(self) -> None:
+        pairs: tuple[tuple[Callable[[str], bool], Callable[[str], bool], tuple[str, ...]], ...] = (
+            (
+                secret_file_print_detect.is_secret_print,
+                _secret_print_lane_a,
+                ("cat ~/.netrc", "pass show ci/token", "cat README.md", "TOKEN=$(pass show x)", "ls"),
+            ),
+            (
+                raw_review_post_detect.is_raw_review_write,
+                raw_review_write_lane_a,
+                (
+                    "glab api projects/42/merge_requests/7/discussions -X POST -f body=hi",
+                    "glab api projects/42/merge_requests/7/discussions",
+                    "gh api repos/o/x/pulls/7/comments -X GET",
+                    "ls",
+                ),
+            ),
+            (
+                self_reviewer_assign_detect.bash_assigns_reviewer,
+                bash_assigns_reviewer_lane_a,
+                (
+                    "glab mr update 7 --reviewer alice",
+                    "gh pr create --reviewer bob",
+                    "glab api projects/1/merge_requests/2 -X PUT -f reviewer_ids=3",
+                    "gh api repos/o/x/pulls/7/requested_reviewers",
+                    "git commit -m 'note about --reviewer'",
+                ),
+            ),
+        )
+        for leaf_matcher, guard_matcher, commands in pairs:
+            for command in commands:
+                assert leaf_matcher(command) == guard_matcher(command), command
+
+
+class TestBashHardDenyWireParity:
+    """Wire-level: a command Lane A's real PreToolUse subprocess denies, Lane B denies too.
+
+    Reuses GM-1's ``run_hook_router`` subprocess harness so the check runs through
+    the actual ``hook_router.main()`` exit-code translation (not the in-process
+    matcher), closing the "tests exercise the unit but never the wire" pattern for
+    this seam. ``git … --no-verify`` is the fixture: the direct-command guard denies
+    it unconditionally (no cwd carve-out), so the subprocess reliably exits 2.
+    """
+
+    def test_no_verify_denied_at_the_wire_and_on_lane_b(self, tmp_path: Path) -> None:
+        command = "git commit -m x --no-" + "verify"
+        home = str(tmp_path / "home")
+        Path(home).mkdir(parents=True, exist_ok=True)
+        result = run_hook_router("PreToolUse", {"tool_name": "Bash", "tool_input": {"command": command}}, home=home)
+        assert result.returncode == 2, f"Lane A's PreToolUse subprocess must deny --no-verify; got {result.returncode}"
+        # The SAME command is refused on Lane B through the shared registry.
+        assert hard_deny_reason("shell", {"command": command}, cwd=tmp_path) is not None
 
 
 def test_zero_tokens_enforced() -> None:

--- a/tests/teatree_hooks/test_git_bypass_detect.py
+++ b/tests/teatree_hooks/test_git_bypass_detect.py
@@ -1,0 +1,51 @@
+"""The git hook/merge-bypass detector (the ``--no-verify``/hooksPath safety subset).
+
+Mirrors ``hooks.scripts.direct_command_guard.deny_match`` for the hook/merge-bypass
+family so both lanes refuse the same set; the guard-vs-leaf agreement itself is
+pinned by the deny-corpus parity test.
+"""
+
+import pytest
+
+from teatree.hooks.git_bypass_detect import git_bypass_deny_reason
+
+# Assembled so the literal bypass strings never appear in this file's own scanned
+# transcript / commit body (the PreToolUse gates scan them).
+_NO_VERIFY = "--no-" + "verify"
+_NO_GPG = "--no-" + "gpg-sign"
+_HOOKS_PATH = "core.hooks" + "Path=/dev/null"
+
+
+class TestDenies:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            f"git commit -m x {_NO_VERIFY}",
+            f"git push {_NO_VERIFY}",
+            f"git commit -m x {_NO_GPG}",
+            f"git -c {_HOOKS_PATH} commit -m x",
+            'git -c "' + _HOOKS_PATH + '" commit -m x',  # quoted config value still caught
+            "git push -o merge_request.merge_when_pipeline_succeeds",
+            "git push --push-option=merge_request.merge_when_pipeline_succeeds",
+        ],
+    )
+    def test_hook_and_merge_bypasses_are_denied(self, command: str) -> None:
+        reason = git_bypass_deny_reason(command)
+        assert reason is not None
+        assert "BLOCKED" in reason
+
+
+class TestAllows:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "git commit -m 'normal message'",
+            "git push origin HEAD",
+            "git commit -m 'note: mention " + _NO_VERIFY + " inside a quoted message'",
+            "ls -la",
+            "docker compose up",  # a direct-command deny, but NOT this leaf's concern
+            "",
+        ],
+    )
+    def test_ordinary_and_out_of_scope_commands_pass(self, command: str) -> None:
+        assert git_bypass_deny_reason(command) is None

--- a/tests/teatree_hooks/test_hard_deny_registry.py
+++ b/tests/teatree_hooks/test_hard_deny_registry.py
@@ -1,0 +1,50 @@
+"""The shared Bash-shaped hard-deny registry — the ONE set both lanes iterate."""
+
+import pytest
+
+from teatree.hooks.hard_deny_registry import HARD_DENY_PREDICATES, hard_deny_reason
+
+# Assembled so the literal bypass strings never appear in this file's scanned transcript.
+_NO_VERIFY = "--no-" + "verify"
+
+_DENIED = [
+    pytest.param("gh pr merge 5", "raw_merge", id="raw-merge"),
+    pytest.param("gh api repos/o/x/pulls/7/merge -X PUT", "raw_merge", id="raw-merge-api"),
+    pytest.param(f"git commit -m x {_NO_VERIFY}", "git_bypass", id="no-verify"),
+    pytest.param("cat ~/.netrc", "secret_file_print", id="secret-print"),
+    pytest.param(
+        "glab api projects/1/merge_requests/2/discussions -X POST -f body=hi",
+        "raw_review_post",
+        id="raw-review",
+    ),
+    pytest.param("glab mr update 7 --reviewer alice", "self_reviewer_assign", id="reviewer-assign"),
+    pytest.param("kill -9 4242", "raw_pid_kill", id="raw-pid-kill"),
+]
+
+
+@pytest.mark.parametrize(("command", "expected_family"), _DENIED)
+def test_each_family_denies(command: str, expected_family: str) -> None:
+    reason = hard_deny_reason(command)
+    assert reason is not None
+    assert "BLOCKED" in reason
+    # The named family's predicate is the one that fires (order-independent check).
+    predicate = dict(HARD_DENY_PREDICATES)[expected_family]
+    assert predicate(command) is not None
+
+
+@pytest.mark.parametrize("command", ["ls -la", "gh pr view 5", "git commit -m 'ok'", ""])
+def test_benign_commands_are_allowed(command: str) -> None:
+    assert hard_deny_reason(command) is None
+
+
+def test_registry_covers_every_named_family() -> None:
+    # A cardinality floor so a refactor that empties the registry cannot pass vacuously.
+    names = {name for name, _ in HARD_DENY_PREDICATES}
+    assert names == {
+        "raw_merge",
+        "git_bypass",
+        "secret_file_print",
+        "raw_review_post",
+        "self_reviewer_assign",
+        "raw_pid_kill",
+    }

--- a/tests/teatree_hooks/test_raw_merge_detect.py
+++ b/tests/teatree_hooks/test_raw_merge_detect.py
@@ -14,7 +14,12 @@ fails the specific id.
 
 import pytest
 
-from teatree.hooks.raw_merge_detect import invokes_raw_merge_subcommand
+from teatree.hooks.raw_merge_detect import (
+    invokes_graphql_merge_mutation,
+    invokes_raw_merge_subcommand,
+    is_raw_merge_api_write,
+    raw_merge_deny_reason,
+)
 
 _STILL_BLOCKED = [
     pytest.param("gh pr merge 5 --squash", id="bare-gh"),
@@ -80,3 +85,77 @@ def test_plausible_invocation_blocks(command: str) -> None:
 @pytest.mark.parametrize("command", _STILL_ALLOWED)
 def test_documentation_or_mention_is_allowed(command: str) -> None:
     assert invokes_raw_merge_subcommand(command) is False
+
+
+class TestMergeApiWrite:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh api repos/o/r/pulls/12/merge -X PUT",
+            "gh api repos/o/r/pulls/12/merge --method PUT",
+            "gh api repos/o/r/pulls/12/merge -XPUT",
+            "gh api repos/o/r/pulls/12/merge -f merge_method=squash",
+            "glab api projects/9/merge_requests/3/merge -X PUT",
+        ],
+    )
+    def test_write_to_merge_endpoint_is_detected(self, command: str) -> None:
+        assert is_raw_merge_api_write(command) is True
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh api repos/o/r/pulls/12/merge",  # bare GET reads merge status
+            "gh api repos/o/r/pulls/12/merge -X GET",
+            "gh api repos/o/r/pulls/12/merge -X PUT -X GET",  # last-wins GET
+            "gh api repos/o/r/pulls/12/comments -X POST",  # not a merge endpoint
+            "ls",  # not an api command
+            "",
+        ],
+    )
+    def test_reads_and_non_merge_endpoints_are_allowed(self, command: str) -> None:
+        assert is_raw_merge_api_write(command) is False
+
+
+class TestGraphqlMergeMutation:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh api graphql -f query='mutation { mergePullRequest(input: {}) { clientMutationId } }'",
+            "gh api graphql -f query='mutation { enablePullRequestAutoMerge(input: {}) { actor { login } } }'",
+            "gh api graphql -f query='mutation { mergeBranch(input: {}) { mergeCommit { oid } } }'",
+        ],
+    )
+    def test_merge_mutation_is_detected(self, command: str) -> None:
+        assert invokes_graphql_merge_mutation(command) is True
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh api graphql -f query='query { viewer { login } }'",  # a read query
+            "mergePullRequest(input: {})",  # not a forge api command
+            "",
+        ],
+    )
+    def test_non_mutation_is_allowed(self, command: str) -> None:
+        assert invokes_graphql_merge_mutation(command) is False
+
+
+class TestRawMergeDenyReason:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh pr merge 5",
+            "glab mr merge 7",
+            "gh api repos/o/r/pulls/12/merge -X PUT",
+            "gh api graphql -f query='mutation { mergeBranch(input: {}) { x } }'",
+        ],
+    )
+    def test_every_merge_vector_yields_a_reason(self, command: str) -> None:
+        reason = raw_merge_deny_reason(command)
+        assert reason is not None
+        assert "BLOCKED" in reason
+        assert "ticket merge" in reason
+
+    @pytest.mark.parametrize("command", ["gh pr view 5", "ls -la", "", "gh api repos/o/r/pulls/12/merge"])
+    def test_non_merge_commands_yield_no_reason(self, command: str) -> None:
+        assert raw_merge_deny_reason(command) is None

--- a/tests/teatree_hooks/test_raw_review_post_detect.py
+++ b/tests/teatree_hooks/test_raw_review_post_detect.py
@@ -1,0 +1,40 @@
+"""The raw-review-post detector leaf — mirrors the PreToolUse guard's matcher."""
+
+import pytest
+
+from teatree.hooks.raw_review_post_detect import is_raw_review_write, raw_review_deny_reason
+
+
+class TestDenies:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "glab api projects/42/merge_requests/7/discussions -X POST -f body=hi",
+            "gh api repos/o/x/pulls/7/comments -X POST -f body=hi",
+            "glab api projects/42/merge_requests/7/notes -f body=hi",  # body flag → implicit POST
+            "gh api repos/o/x/issues/7/comments -X GET -X POST",  # last-wins POST
+            "glab  api projects/42/merge_requests/7/discussions -X POST -f body=hi",  # double space
+        ],
+    )
+    def test_review_writes_are_denied(self, command: str) -> None:
+        assert is_raw_review_write(command) is True
+        reason = raw_review_deny_reason(command)
+        assert reason is not None
+        assert "BLOCKED" in reason
+
+
+class TestAllows:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "glab api projects/42/merge_requests/7/discussions",  # bare GET
+            "gh api repos/o/x/pulls/7/comments -X GET",  # explicit GET
+            "gh api repos/o/x/pulls/7/comments -X POST -X GET",  # last-wins GET
+            "gh api repos/o/x/pulls/7/reviews -X POST -f body=hi",  # not a comment endpoint
+            "gh pr view 7",  # not an api command
+            "",
+        ],
+    )
+    def test_reads_and_non_review_endpoints_pass(self, command: str) -> None:
+        assert is_raw_review_write(command) is False
+        assert raw_review_deny_reason(command) is None

--- a/tests/teatree_hooks/test_secret_file_print_detect.py
+++ b/tests/teatree_hooks/test_secret_file_print_detect.py
@@ -1,0 +1,50 @@
+"""The secret-file-print detector leaf — mirrors the PreToolUse guard's matcher."""
+
+import pytest
+
+from teatree.hooks.secret_file_print_detect import is_secret_print, secret_print_deny_reason
+
+
+class TestDenies:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cat ~/.netrc",
+            "cat ~/.ssh/id_rsa",
+            "head -n1 /home/ci/.env",
+            "tail secrets.env",
+            "pass show ci/deploy-token",
+            "echo glpat-abcdef123456",
+            "printf ghp_deadbeefcafebabe0000",
+            "echo 'gl" + "pat-fullyquotedtoken0'",  # a fully-quoted token still lands on stdout
+        ],
+    )
+    def test_secret_prints_are_denied(self, command: str) -> None:
+        assert is_secret_print(command) is True
+        reason = secret_print_deny_reason(command)
+        assert reason is not None
+        assert "BLOCKED" in reason
+
+
+class TestAllows:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "TOKEN=$(pass show ci/deploy-token)",  # captured into a variable
+            "cat ~/.netrc > /tmp/out",  # redirected to a file
+            "cat README.md",  # ordinary file
+            "echo 'see ~/.netrc for the token path'",  # prose mentioning a path
+            "pass show ci/token | gpg --encrypt",  # piped to a consuming sink
+            'curl -H "Token: $TOKEN" https://api',  # value used via header, not printed
+            "echo",  # bare echo, no argument
+            "printf",  # bare printf, no argument
+            "",
+        ],
+    )
+    def test_captures_redirects_and_prose_pass(self, command: str) -> None:
+        assert is_secret_print(command) is False
+        assert secret_print_deny_reason(command) is None
+
+    def test_pass_show_piped_to_re_emitter_is_still_a_print(self) -> None:
+        # A pipe whose sink re-emits (cat/tee/…) still displays the secret.
+        assert is_secret_print("pass show ci/token | cat") is True

--- a/tests/teatree_hooks/test_self_reviewer_assign_detect.py
+++ b/tests/teatree_hooks/test_self_reviewer_assign_detect.py
@@ -1,0 +1,42 @@
+"""The self-reviewer-assign Bash detector leaf — mirrors the PreToolUse guard's matcher."""
+
+import pytest
+
+from teatree.hooks.self_reviewer_assign_detect import bash_assigns_reviewer, reviewer_assign_deny_reason
+
+
+class TestDenies:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "glab mr update 7 --reviewer alice",
+            "glab mr create --reviewers alice,bob",
+            "gh pr create --reviewer bob",
+            "gh pr create -r bob",
+            "gh pr edit 7 --add-reviewer bob",
+            "glab api projects/1/merge_requests/2 -X PUT -f reviewer_ids=3",
+            "gh api repos/o/x/pulls/7/requested_reviewers -f reviewers=bob",  # body flag → implicit write
+        ],
+    )
+    def test_reviewer_assignments_are_denied(self, command: str) -> None:
+        assert bash_assigns_reviewer(command) is True
+        reason = reviewer_assign_deny_reason(command)
+        assert reason is not None
+        assert "BLOCKED" in reason
+
+
+class TestAllows:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "gh api repos/o/x/pulls/7/requested_reviewers",  # GET reads the list
+            "glab mr update 7 --title 'new title'",  # not a reviewer op
+            "gh pr view 7",
+            "git commit -m 'note about --reviewer flag'",  # phrase inside a quoted message
+            "glab mr merge 7",
+            "",
+        ],
+    )
+    def test_reads_and_non_reviewer_ops_pass(self, command: str) -> None:
+        assert bash_assigns_reviewer(command) is False
+        assert reviewer_assign_deny_reason(command) is None


### PR DESCRIPTION
## The safety hole (integration-audit bug #2)

The Lane-B shell (`agent_harness=pydantic_ai`) bypassed **every** Bash-shaped PreToolUse deny except main-clone + privacy. So a raw forge merge, a hook-silencing push (`--no-verify` / `core.hooksPath`), a secret-file print, a raw review-post, a reviewer-assign, and a raw-pid-kill were all reachable under `pydantic_ai` with **no MergeClear or CI verification**. The `lane_b/gating` docstring falsely claimed the two lanes refused an "identical set by construction" — it omitted the entire Bash-shaped family.

## The fix — one shared registry, iterated by both lanes

`src/teatree/hooks/hard_deny_registry.py` is the single source of truth: a registry of pure `(command) -> reason` predicates, each in a stdlib-only `teatree.hooks` leaf importable by **both** Lane B and the cold PreToolUse subprocess.

- `raw_merge_detect` extended with `is_raw_merge_api_write` / graphql detection / a combined `raw_merge_deny_reason`; the router's out-of-band-merge gate now **delegates** its API-write detection to the leaf (shared SSOT).
- New leaves: `git_bypass_detect` (hook-silencing / signing / auto-merge push bypasses), `secret_file_print_detect`, `raw_review_post_detect`, `self_reviewer_assign_detect`; `safe_kill_detect` reused for raw-pid-kill.
- `lane_b/gating.hard_deny_reason` now iterates the registry (family 2) between the main-clone (family 1) and privacy (family 3) checks — the bypassed families are now denied on Lane B exactly as Lane A denies them.
- The false "identical set by construction" docstring is corrected to describe the three shared families.

## Retry cap

`HardDenyToolset` gains a per-run retry cap: a hard-deny is a `ModelRetry` until the Nth refusal in a run, then a terminal `UnexpectedModelBehavior`, so a predicate false-positive cannot loop the model. The count is keyed on `run_id` (isolated per run).

## Structural — the deny-corpus parity test (kills the Lane-B-bypass class)

`tests/teatree_agents/lane_b/test_parity.py` feeds **every** Lane-A Bash-shaped deny fixture through Lane B's `hard_deny_reason` and asserts an identical refusal, plus a per-leaf agreement check against each **independent** `hooks/scripts` guard — so a future divergence between a leaf and its Lane-A guard fails CI. A wire-level check reuses the `run_hook_router` subprocess harness (a hook-silencing commit denied at exit 2 **and** on Lane B).

## Anti-vacuity

Every corpus fixture (raw forge merge, hook-silencing push, and the four other families) goes **RED** on Lane B without the registry wiring and **GREEN** with it (verified by reverting the wiring). Benign commands stay allowed.

## Never-lockout

The router deny paths are unchanged and still route through `_fail_open_or_deny`; the never-lockout contract test passes. New modules ship at 100% branch coverage; lint / type-check / architecture-import-direction / test-path-mirror / banned-terms all clean.

## Architecture pre-check

- **BLUEPRINT §17.1 invariant 8 / §17.4** (keystone merge) — the raw-merge deny is preserved on both lanes; a new shared registry seam under `teatree.hooks`.
- **Component boundaries** — pure detectors in `src/teatree/hooks/` leaves (stdlib-only, importable by the cold hook and the in-process Lane B).
- **Dependency direction** — leaves import nothing from `hooks/scripts` (cold-import safe); `tach` / import-linter clean.
- **Test surface** — per-leaf unit tests + the deny-corpus parity test + the retry-cap tests; every behaviour has a failing-without-the-fix assertion.
- **Behavior preservation** — no privacy/safety matcher narrowed; the router's own gates keep their kill-switches and carve-outs (layered on top of the shared detectors).

Closes the Lane-B bypass described in integration-audit bug #2.
