### PR TITLE
fix(signals): populate the RedMrFixAttempt ledger — my_prs emits head_sha + claim fails loud not open (#7)

### DIFF
--- a/src/teatree/loop/dispatch_gates.py
+++ b/src/teatree/loop/dispatch_gates.py
@@ -8,16 +8,27 @@ test can pin or stub the seam without touching the routing tables, and so the
 dispatcher module stays focused on the consult order.
 """
 
+import logging
+
 from teatree.config import get_effective_settings
 from teatree.core.modelkit.phases import normalize_phase
 from teatree.loop.dispatch_reducer import slack_pr_url, task_pr_url
 from teatree.loop.dispatch_tables import STATUSLINE_ZONE_BY_KIND, ActionPayload, DispatchAction
 from teatree.loop.review_claim_signals import review_loop_enabled
 from teatree.loop.scanners.base import ScanSignal
+from teatree.loop.scanners.pr_payload import head_sha as _extract_head_sha
+
+logger = logging.getLogger(__name__)
 
 #: The display marker an untyped/empty spawn degrades to in :func:`spawn_display_name`.
 #: A real phase agent is always ``t3:<type>``, so this never names a live phase agent.
 GENERAL_PURPOSE_SUBAGENT = "general-purpose"
+
+#: Head-SHA placeholder for a red PR whose real sha the scanner never carried.
+#: The claim is keyed on ``(pr_url, sentinel)`` so at most ONE fix dispatches for
+#: that PR until a real sha appears — replacing the old blank-sha fail-OPEN
+#: (``return True`` forever) that let the same red PR re-dispatch every tick (#7).
+_BLANK_SHA_SENTINEL = "sha-unavailable"
 
 
 def spawn_display_name(subagent: str, task_id: int) -> str:
@@ -174,24 +185,43 @@ def claim_red_mr_fix(payload: ActionPayload) -> bool:
     tick — the caller proceeds to create the Task. Returns False when the same
     failing SHA already has a recorded attempt — the statusline mirror still
     emitted at dispatch so the user sees the red MR, but no new Task is created.
-    Best-effort: any DB issue defaults to True so the fix path is not silently
-    dropped on a missing migration.
+
+    SIG-2 (#7) hardens WHAT is claimed: the real head sha is recovered from
+    ``payload['raw']`` via the shared dual-forge helper when the top-level
+    ``head_sha`` is blank; a still-blank sha claims the :data:`_BLANK_SHA_SENTINEL`
+    keyed on ``pr_url`` (at most one dispatch per PR) and logs the instrumentation
+    gap — replacing the old fail-OPEN that re-dispatched forever. A ``DatabaseError``
+    still fails open (a missing migration must not silently drop the fix path) but
+    now logs at WARNING with the ``pr_url`` so the fail-open is visible and bounded.
     """
     from django.db import DatabaseError  # noqa: PLC0415
 
     pr_url = str(payload.get("pr_url") or payload.get("url") or "")
-    head_sha = str(payload.get("head_sha", ""))
-    if not pr_url or not head_sha:
+    if not pr_url:
         return True
+    sha = str(payload.get("head_sha") or "") or _sha_from_raw(payload)
+    if not sha:
+        logger.warning(
+            "claim_red_mr_fix: no head sha for red PR %s — claiming sentinel (one dispatch, gap surfaced)",
+            pr_url,
+        )
+        sha = _BLANK_SHA_SENTINEL
     try:
         from teatree.core.models import RedMrFixAttempt  # noqa: PLC0415
 
         row = RedMrFixAttempt.claim(
             pr_url=pr_url,
-            head_sha=head_sha,
+            head_sha=sha,
             overlay=str(payload.get("overlay", "")),
             worktree_hint=str(payload.get("worktree_hint", "")),
         )
     except DatabaseError:
+        logger.warning("claim_red_mr_fix: DB error claiming %s — failing open (bounded)", pr_url)
         return True
     return row is not None
+
+
+def _sha_from_raw(payload: ActionPayload) -> str:
+    """Recover the head sha from the raw forge PR dict on the payload, or ``""``."""
+    raw = payload.get("raw")
+    return _extract_head_sha(raw) if isinstance(raw, dict) else ""

--- a/src/teatree/loop/scanners/my_prs.py
+++ b/src/teatree/loop/scanners/my_prs.py
@@ -5,6 +5,7 @@ from typing import cast
 
 from teatree.core.backend_protocols import CodeHostBackend
 from teatree.loop.scanners.base import ScanSignal, SignalPayload
+from teatree.loop.scanners.pr_payload import head_sha
 from teatree.loop.url_specificity import best_url_match_specificity
 from teatree.types import RawAPIDict
 
@@ -133,6 +134,10 @@ class MyPrsScanner:
                 "title": title,
                 "iid": iid,
                 "status": status,
+                # Carried on EVERY signal so ``my_pr.failed`` reaches
+                # ``claim_red_mr_fix`` with a real head sha — the RedMrFixAttempt
+                # ledger stayed empty (#7) while this was omitted.
+                "head_sha": head_sha(pr),
                 "raw": pr,
             }
             if _needs_attention(status):

--- a/src/teatree/loop/scanners/pr_payload.py
+++ b/src/teatree/loop/scanners/pr_payload.py
@@ -1,0 +1,36 @@
+"""Shared dual-forge PR payload extractors (#7 / SIG-2).
+
+One canonical head-SHA reader for both forge shapes, imported by every scanner
+that emits a PR signal — ``reviewer_prs`` (its review-cache keys) and ``my_prs``
+(the ``my_pr.failed`` payload that feeds the ``RedMrFixAttempt`` ledger). A
+single symbol at every extraction site kills the sibling-reimplementation drift
+the audit flagged: a scanner that re-derives the head SHA locally would diverge
+on the next forge-shape change, and the divergence would be silent.
+"""
+
+from typing import cast
+
+from teatree.types import RawAPIDict
+
+
+def head_sha(pr: RawAPIDict) -> str:
+    """The PR's head commit SHA across forge shapes, or ``""`` when absent.
+
+    GitLab MR list endpoints expose a top-level ``sha``; GitHub PRs nest it
+    under ``head.sha``; GitLab MR detail endpoints carry it under
+    ``diff_refs.head_sha``.
+    """
+    sha = pr.get("sha")
+    if isinstance(sha, str):
+        return sha
+    head = pr.get("head")
+    if isinstance(head, dict):
+        nested = cast("RawAPIDict", head).get("sha")
+        if isinstance(nested, str):
+            return nested
+    diff_refs = pr.get("diff_refs")
+    if isinstance(diff_refs, dict):
+        nested = cast("RawAPIDict", diff_refs).get("head_sha")
+        if isinstance(nested, str):
+            return nested
+    return ""

--- a/src/teatree/loop/scanners/reviewer_prs.py
+++ b/src/teatree/loop/scanners/reviewer_prs.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, cast
 from teatree.core.backend_protocols import CodeHostBackend, PrOpenState, ReviewState
 from teatree.core.review_candidate import should_review_candidate_reasons
 from teatree.loop.scanners.base import ScanSignal
+from teatree.loop.scanners.pr_payload import head_sha
 from teatree.loop.url_specificity import best_url_match_specificity
 from teatree.types import RawAPIDict
 
@@ -131,25 +132,6 @@ def _read_cache() -> dict[str, CacheEntry]:
             state=state if isinstance(state, str) else "",
         )
     return result
-
-
-def _head_sha(pr: RawAPIDict) -> str:
-    sha = pr.get("sha")
-    if isinstance(sha, str):
-        return sha
-    head = pr.get("head")
-    if isinstance(head, dict):
-        head_dict = cast("RawAPIDict", head)
-        head_sha = head_dict.get("sha")
-        if isinstance(head_sha, str):
-            return head_sha
-    diff_refs = pr.get("diff_refs")
-    if isinstance(diff_refs, dict):
-        diff_dict = cast("RawAPIDict", diff_refs)
-        head_sha = diff_dict.get("head_sha")
-        if isinstance(head_sha, str):
-            return head_sha
-    return ""
 
 
 def _pr_url(pr: RawAPIDict) -> str:
@@ -404,7 +386,7 @@ class ReviewerPrsScanner:
         primary_reviewer: str,
     ) -> list[ScanSignal]:
         """Emit the review signals (new_sha / unreviewed / approval_dismissed) for one PR."""
-        head = _head_sha(pr)
+        head = head_sha(pr)
         previous = cache.get(url, CacheEntry())
         if previous.sha and previous.sha != head:
             if ticket_model is not None:

--- a/tests/teatree_loop/scanners/test_pr_payload.py
+++ b/tests/teatree_loop/scanners/test_pr_payload.py
@@ -1,0 +1,29 @@
+"""Unit tests for the shared dual-forge PR payload extractors (#7 / SIG-2)."""
+
+from teatree.loop.scanners.pr_payload import head_sha
+
+
+class TestHeadSha:
+    def test_gitlab_top_level_sha(self) -> None:
+        # GitLab MR list endpoints expose the head commit as top-level ``sha``.
+        assert head_sha({"sha": "abc123"}) == "abc123"
+
+    def test_github_nested_head_sha(self) -> None:
+        # GitHub PRs nest the head commit under ``head.sha``.
+        assert head_sha({"head": {"sha": "deadbeef"}}) == "deadbeef"
+
+    def test_gitlab_diff_refs_fallback(self) -> None:
+        # GitLab MR detail endpoints carry it under ``diff_refs.head_sha``.
+        assert head_sha({"diff_refs": {"head_sha": "feedface"}}) == "feedface"
+
+    def test_top_level_sha_wins_over_nested(self) -> None:
+        assert head_sha({"sha": "top", "head": {"sha": "nested"}}) == "top"
+
+    def test_missing_everywhere_is_blank(self) -> None:
+        assert head_sha({}) == ""
+
+    def test_wrong_types_are_blank(self) -> None:
+        assert head_sha({"sha": 123}) == ""
+        assert head_sha({"head": {"sha": 99}}) == ""
+        assert head_sha({"diff_refs": {"head_sha": True}}) == ""
+        assert head_sha({"head": "not-a-dict"}) == ""

--- a/tests/teatree_loop/test_scanners.py
+++ b/tests/teatree_loop/test_scanners.py
@@ -13,6 +13,7 @@ from teatree.core.models import Ticket
 from teatree.loop.scanners.assigned_issues import AssignedIssuesScanner
 from teatree.loop.scanners.my_prs import MyPrsScanner
 from teatree.loop.scanners.notion_view import NotionViewScanner
+from teatree.loop.scanners.pr_payload import head_sha
 from teatree.loop.scanners.reviewer_prs import CacheEntry, ReviewerPrsScanner, _persist_entry
 from teatree.loop.scanners.reviewer_prs import mark_reviewed as _mark_reviewed_helper
 from teatree.loop.scanners.slack_mentions import SlackMentionsScanner
@@ -302,12 +303,10 @@ class TestReviewerPrsScanner(TestCase):
         assert signals[0].payload["head_sha"] == "feedface"
 
     def test_head_sha_returns_empty_when_no_field_present(self) -> None:
-        from teatree.loop.scanners.reviewer_prs import _head_sha  # noqa: PLC0415
-
-        assert _head_sha({}) == ""
-        assert _head_sha({"sha": 123}) == ""
-        assert _head_sha({"head": {"sha": 99}}) == ""
-        assert _head_sha({"diff_refs": {"head_sha": True}}) == ""
+        assert head_sha({}) == ""
+        assert head_sha({"sha": 123}) == ""
+        assert head_sha({"head": {"sha": 99}}) == ""
+        assert head_sha({"diff_refs": {"head_sha": True}}) == ""
 
     def test_dismissed_after_approval_emits_approval_dismissed_signal(self) -> None:
         url = "https://gitlab/x/-/merge_requests/9"

--- a/tests/teatree_loop/test_sig2_red_mr_ledger.py
+++ b/tests/teatree_loop/test_sig2_red_mr_ledger.py
@@ -1,0 +1,250 @@
+"""SIG-2 (#7): the RedMrFixAttempt ledger is actually populated end-to-end.
+
+The bug: ``MyPrsScanner`` omitted ``head_sha`` from the ``my_pr.failed``
+payload, so ``claim_red_mr_fix`` always saw a blank sha and fail-OPENed
+(``return True`` forever) — the ledger was never written, the same red SHA
+re-dispatched every tick, and S1 stayed permanently ``instrumentation_gap``.
+
+These tests pin the fix at four levels the audit prescribed:
+(a) wire-level scan->dispatch round-trip yields exactly one row / one action;
+(b) forge-shape parity — GitLab top-level ``sha`` and GitHub ``head.sha``;
+(c) blank-sha sentinel — one dispatch, gap surfaced (not silent, not open);
+(d) live-writer feeding S1 — a scanned+claimed red PR counts NOT first-try-green.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from django.db import DatabaseError
+from django.test import TestCase
+from django.utils import timezone
+
+from teatree.core.factory_signals import SignalStatus, first_try_green_rate
+from teatree.core.models import RedMrFixAttempt
+from teatree.loop.dispatch import _dispatch_one
+from teatree.loop.dispatch_gates import claim_red_mr_fix
+from teatree.loop.scanners import my_prs as my_prs_mod
+from teatree.loop.scanners import pr_payload
+from teatree.loop.scanners import reviewer_prs as reviewer_prs_mod
+from teatree.loop.scanners.my_prs import MyPrsScanner
+from tests.factories import MergeAuditFactory, MergeClearFactory
+from tests.teatree_loop.test_scanners import FakeCodeHost
+
+
+def _gitlab_failed_pr(*, iid: int = 7, sha: str = "abc123", url: str = "") -> dict[str, object]:
+    return {
+        "iid": iid,
+        "title": "Fix thing",
+        "web_url": url or f"https://gitlab.com/souliane/teatree/-/merge_requests/{iid}",
+        "sha": sha,
+        "head_pipeline": {"status": "failed"},
+    }
+
+
+def _github_failed_pr(*, number: int = 9, sha: str = "deadbeef", url: str = "") -> dict[str, object]:
+    return {
+        "number": number,
+        "title": "Fix thing",
+        "html_url": url or f"https://github.com/souliane/teatree/pull/{number}",
+        "head": {"sha": sha},
+        "status_check_rollup": {"state": "failure"},
+    }
+
+
+class TestHeadShaSsot:
+    """One helper, two importers — the sibling-reimplementation family killer."""
+
+    def test_my_prs_and_reviewer_prs_reference_the_same_symbol(self) -> None:
+        assert my_prs_mod.head_sha is pr_payload.head_sha
+        assert reviewer_prs_mod.head_sha is pr_payload.head_sha
+
+
+class TestMyPrsEmitsHeadSha:
+    """Every emitted ``my_pr.*`` signal carries the head sha via the shared helper."""
+
+    def test_failed_signal_carries_head_sha_gitlab_shape(self) -> None:
+        host = FakeCodeHost(user="alice", my_prs=[_gitlab_failed_pr(sha="abc123")])
+        signals = MyPrsScanner(host=host).scan()
+        assert [s.kind for s in signals] == ["my_pr.failed"]
+        assert signals[0].payload["head_sha"] == "abc123"
+
+    def test_failed_signal_carries_head_sha_github_shape(self) -> None:
+        # Forge-shape parity: GitHub nests the sha under ``head.sha``.
+        host = FakeCodeHost(user="alice", my_prs=[_github_failed_pr(sha="deadbeef")])
+        signals = MyPrsScanner(host=host).scan()
+        assert [s.kind for s in signals] == ["my_pr.failed"]
+        assert signals[0].payload["head_sha"] == "deadbeef"
+
+    def test_open_signal_also_carries_head_sha(self) -> None:
+        host = FakeCodeHost(
+            user="alice",
+            my_prs=[
+                {
+                    "iid": 3,
+                    "title": "Clean PR",
+                    "web_url": "https://gitlab.com/souliane/teatree/-/merge_requests/3",
+                    "sha": "cafef00d",
+                    "head_pipeline": {"status": "success"},
+                }
+            ],
+        )
+        signals = MyPrsScanner(host=host).scan()
+        assert [s.kind for s in signals] == ["my_pr.open"]
+        assert signals[0].payload["head_sha"] == "cafef00d"
+
+    def test_draft_notes_signal_also_carries_head_sha(self) -> None:
+        host = FakeCodeHost(
+            user="alice",
+            my_prs=[
+                {
+                    "iid": 4,
+                    "title": "Notes PR",
+                    "web_url": "https://gitlab.com/souliane/teatree/-/merge_requests/4",
+                    "sha": "b0bab0ba",
+                    "head_pipeline": {"status": "running"},
+                    "user_notes_count": 2,
+                }
+            ],
+        )
+        signals = MyPrsScanner(host=host).scan()
+        assert [s.kind for s in signals] == ["my_pr.draft_notes"]
+        assert signals[0].payload["head_sha"] == "b0bab0ba"
+
+    def test_missing_sha_emits_blank_head_sha_not_absent_key(self) -> None:
+        host = FakeCodeHost(
+            user="alice",
+            my_prs=[
+                {
+                    "iid": 5,
+                    "title": "No sha PR",
+                    "web_url": "https://gitlab.com/souliane/teatree/-/merge_requests/5",
+                    "head_pipeline": {"status": "failed"},
+                }
+            ],
+        )
+        signals = MyPrsScanner(host=host).scan()
+        assert signals[0].payload["head_sha"] == ""
+
+
+class TestClaimRedMrFixWireRoundTrip(TestCase):
+    """(a) The same failing PR through scan->dispatch->claim TWICE => one row, one action."""
+
+    def _agent_action_payload(self, pr: dict[str, object]) -> dict[str, object]:
+        host = FakeCodeHost(user="alice", my_prs=[pr])
+        signals = MyPrsScanner(host=host).scan()
+        actions = _dispatch_one(signals[0])
+        agent = [a for a in actions if a.kind == "agent"]
+        assert len(agent) == 1, actions
+        assert agent[0].zone == "t3:debug"
+        return agent[0].payload
+
+    def test_two_ticks_same_red_sha_yield_one_claim_and_one_row(self) -> None:
+        payload = self._agent_action_payload(_gitlab_failed_pr(sha="abc123"))
+        first = claim_red_mr_fix(payload)
+        second = claim_red_mr_fix(payload)
+        assert first is True
+        assert second is False
+        assert RedMrFixAttempt.objects.count() == 1
+        row = RedMrFixAttempt.objects.get()
+        assert row.head_sha == "abc123"
+
+    def test_new_sha_after_first_dispatch_claims_again(self) -> None:
+        first = claim_red_mr_fix(self._agent_action_payload(_gitlab_failed_pr(iid=7, sha="aaa")))
+        moved = claim_red_mr_fix(self._agent_action_payload(_gitlab_failed_pr(iid=7, sha="bbb")))
+        assert first is True
+        assert moved is True
+        assert RedMrFixAttempt.objects.count() == 2
+
+
+class TestClaimRedMrFixHardening(TestCase):
+    """(c) blank-sha sentinel + raw fallback + DB fail-open-with-warning."""
+
+    URL = "https://github.com/souliane/teatree/pull/12"
+
+    def test_extracts_sha_from_raw_when_head_sha_blank(self) -> None:
+        # A payload with no top-level head_sha but a ``raw`` dict carrying it
+        # (GitHub shape) still claims a real sha via the shared helper.
+        payload = {"url": self.URL, "raw": {"head": {"sha": "fromraw"}}}
+        assert claim_red_mr_fix(payload) is True
+        assert RedMrFixAttempt.objects.get().head_sha == "fromraw"
+
+    def test_blank_sha_sentinel_dispatches_exactly_once(self) -> None:
+        # No sha anywhere: the old code fail-OPENed (True forever, zero rows).
+        # Now: one sentinel claim keyed on pr_url, then no further dispatch.
+        payload = {"url": self.URL}
+        first = claim_red_mr_fix(payload)
+        second = claim_red_mr_fix(payload)
+        assert first is True
+        assert second is False
+        assert RedMrFixAttempt.objects.filter(pr_url=self.URL).count() == 1
+
+    def test_blank_sha_surfaces_the_gap_not_silent(self) -> None:
+        with self.assertLogs("teatree.loop.dispatch_gates", level="WARNING") as logs:
+            claim_red_mr_fix({"url": self.URL})
+        assert any(self.URL in message for message in logs.output)
+
+    def test_database_error_fails_open_and_warns(self) -> None:
+        payload = {"url": self.URL, "head_sha": "abc123"}
+        with (
+            patch.object(RedMrFixAttempt, "claim", side_effect=DatabaseError("boom")),
+            self.assertLogs("teatree.loop.dispatch_gates", level="WARNING") as logs,
+        ):
+            result = claim_red_mr_fix(payload)
+        assert result is True
+        assert any(self.URL in message for message in logs.output)
+
+    def test_no_pr_url_returns_true_without_a_row(self) -> None:
+        assert claim_red_mr_fix({"head_sha": "abc123"}) is True
+        assert RedMrFixAttempt.objects.count() == 0
+
+
+class TestS1LiveWriterEndToEnd(TestCase):
+    """(d) A scanned + claimed red PR feeds S1: counted NOT first-try-green, status OK.
+
+    RED before the fix: my_prs emitted no head_sha, so ``claim_red_mr_fix`` wrote
+    ZERO RedMrFixAttempt rows -> every merge read first-try-green with a silent
+    recorder -> S1 ``instrumentation_gap``. GREEN after: the live claim writes the
+    row, the red PR is excluded from first-try-green, and S1 reports a real rate.
+    """
+
+    SLUG = "souliane/teatree"
+
+    def _seed_merges(self, now: datetime, pr_ids: range) -> None:
+        for pr_id in pr_ids:
+            merged_at = now - timedelta(days=5)
+            clear = MergeClearFactory(
+                pr_id=pr_id,
+                slug=self.SLUG,
+                issued_at=merged_at - timedelta(hours=1),
+                consumed_at=merged_at,
+            )
+            MergeAuditFactory(clear=clear, merged_at=merged_at)
+
+    def test_scanned_red_pr_counts_not_first_try_green(self) -> None:
+        now = timezone.now()
+        self._seed_merges(now, range(901, 906))  # 5 merges -> denom == 5
+
+        # Live producer: scan the red PR, dispatch, claim — writes the ledger row.
+        host = FakeCodeHost(
+            user="alice",
+            my_prs=[_github_failed_pr(number=901, sha="cafe1234", url=f"https://github.com/{self.SLUG}/pull/901")],
+        )
+        signals = MyPrsScanner(host=host).scan()
+        agent = [a for a in _dispatch_one(signals[0]) if a.kind == "agent"]
+        assert claim_red_mr_fix(agent[0].payload) is True
+
+        reading = first_try_green_rate(now=now)
+        assert reading.status == SignalStatus.OK
+        assert reading.status != SignalStatus.INSTRUMENTATION_GAP
+        assert reading.sample_size == 5
+        assert reading.value == pytest.approx(0.8)
+
+    def test_dead_recorder_stays_instrumentation_gap_control(self) -> None:
+        # Control twin: no red rows at all (a genuinely silent recorder) still
+        # trips instrumentation_gap — proving the live-writer test above is not
+        # vacuously OK for some unrelated reason.
+        now = timezone.now()
+        self._seed_merges(now, range(901, 906))
+        reading = first_try_green_rate(now=now)
+        assert reading.status == SignalStatus.INSTRUMENTATION_GAP


### PR DESCRIPTION
## What / why (#7)

The `RedMrFixAttempt` ledger was **never populated**. `MyPrsScanner` omitted `head_sha` from the `my_pr.failed` payload, so `claim_red_mr_fix` always saw a blank sha and **fail-OPENed** (`return True` forever). Three consequences, all live:

- the same red head **re-dispatched every tick** — unlimited red-MR fix dispatch;
- the ledger stayed empty, so S1 `first_try_green` was permanently `INSTRUMENTATION_GAP`;
- the idempotency the ledger exists to provide never engaged.

## The fix

**Shared dual-forge helper (SSOT).** `src/teatree/loop/scanners/pr_payload.py` holds the one `head_sha` reader (GitLab top-level `sha` / GitHub `head.sha` / GitLab `diff_refs.head_sha`). `reviewer_prs` imports it (no behaviour change); `my_prs` adds `head_sha` to `base_payload` so **every** emitted signal (`failed`/`draft_notes`/`open`) carries it. One symbol, two importers — this kills the sibling-reimplementation drift the audit flagged.

**Fail-loud claim.** `claim_red_mr_fix` now:

- recovers the sha from `payload['raw']` via the shared helper when the top-level `head_sha` is blank;
- on a **still-blank** sha, claims a **sentinel keyed on `pr_url`** (at most ONE dispatch per PR until a real sha appears) and **logs the instrumentation gap** — replacing the blank-sha fail-OPEN;
- on `DatabaseError`, still fails open (a missing migration must not silently drop the fix path) but now **logs at WARNING with the `pr_url`** — visible and bounded.

## Anti-vacuity (each observed RED on pre-fix code)

- **(a) wire round-trip** — the same failing PR dict through `MyPrsScanner` → dispatch → claim **twice** yields exactly **one** agent action and exactly **one** `RedMrFixAttempt` row (RED before: unlimited / zero rows).
- **(b) forge-shape parity** — production GitLab (top-level `sha`) and GitHub (`head.sha`) both populate `head_sha` via the shared helper.
- **(c) blank-sha sentinel** — no sha anywhere → exactly one dispatch (not unlimited), gap surfaced in the log (asserted, not silent).
- **(d) live-writer feeding S1** — scan-dispatch a red PR, claim it, then compute S1 over 5 merges → the PR counts **NOT** first-try-green and status is **OK**, not `INSTRUMENTATION_GAP`.

## File-disjoint scope

Owns `my_prs.py`, `reviewer_prs.py`, `pr_payload.py` (new), and `dispatch_gates.py` (`claim_red_mr_fix` hardening only). Does not touch `persistence.py`/`execution.py`/`ticket.py`/`factory_signal_queries.py`. The claim hardening targets `claim_red_mr_fix` at its persist-time location (after DIS-A). No `SIGNAL_LEDGER_PRODUCERS` lane exists yet in the registry-parity framework, so the RedMrFixAttempt producer entry is left for SIG-4's capstone.

Closes #7
