### PR TITLE
fix(dispatch): _TOOLS_BY_PHASE totality bughunt + typed envelope channels + PHASE_REQUIRED_EVIDENCE for shell-denied phases + agents.md↔SSOT parity (#9,#10)

### DIFF
--- a/agents/answerer.md
+++ b/agents/answerer.md
@@ -6,7 +6,6 @@ description: >
   routed to the answering phase.
 tools:
   - Read
-  - Bash
   - Grep
   - Glob
 skills:
@@ -18,11 +17,13 @@ skills:
 
 # Answerer Agent
 
-You are a TeaTree answerer agent. Read the thread context, draft a
-reply in the user's voice, DM the user for approval, and post on the
-user's behalf only after explicit confirmation (unless the active
-overlay has opted into direct posting).
+You are a TeaTree answerer agent. Read the thread context and draft a
+reply in the user's voice. You run shell-denied, so you do not post
+yourself: RETURN the draft in the result envelope's `answer` field
+(`{text, thread_ref}`). The loop routes it through the approval path
+(a `DeferredQuestion` correlated to this task) and posts on the user's
+behalf only after explicit confirmation.
 
-Follow the loaded skills for the draft/approve/post workflow, the
-publishing and on-behalf-posting rules, platform API recipes, and
-cross-cutting rules.
+Follow the loaded skills for the draft/approve workflow, the publishing
+and on-behalf-posting rules, platform API recipes, and cross-cutting
+rules.

--- a/agents/scanning-news.md
+++ b/agents/scanning-news.md
@@ -6,7 +6,6 @@ description: >
   Spawned by the loop for the daily scanning-news cadence.
 tools:
   - Read
-  - Bash
   - Grep
   - Glob
   - WebFetch
@@ -20,9 +19,13 @@ skills:
 # Scanning-News Agent
 
 You are a TeaTree scanning-news agent. Verify each newsletter's edition
-date, fetch promising articles, record each concrete t3-improvement
-candidate behind the ask-gate (never auto-file an issue), dedupe by
-source URL, and post a terse Slack DM summary.
+date, fetch promising articles, and identify each concrete t3-improvement
+candidate. You run shell-denied, so you do not file issues or post
+yourself: RETURN every candidate in the result envelope's
+`article_suggestions` field (each `{title, url, rationale}`). The loop
+persists each as a `PENDING` `PendingArticleSuggestion` behind the
+ask-gate (idempotent by source URL) and surfaces the batch — nothing is
+filed until the user approves.
 
 Follow the loaded skills for the scanning workflow, the publishing and
 ask-gate rules, platform API recipes, and cross-cutting rules.

--- a/src/teatree/agents/attempt_recorder.py
+++ b/src/teatree/agents/attempt_recorder.py
@@ -21,10 +21,19 @@ from typing import TYPE_CHECKING, cast
 from django.utils import timezone
 
 from teatree.agents.outage_classifier import outage_signature
-from teatree.agents.result_schema import RESULT_JSON_SCHEMA, AgentResultBlob, ReviewVerdictEnvelope, check_evidence
+from teatree.agents.result_schema import (
+    RESULT_JSON_SCHEMA,
+    AgentResultBlob,
+    AnswerEnvelope,
+    ArticleSuggestion,
+    ReviewVerdictEnvelope,
+    check_evidence,
+)
 from teatree.core.modelkit.phases import normalize_phase
 from teatree.core.models import (
+    DeferredQuestion,
     Finding,
+    PendingArticleSuggestion,
     ReviewLoop,
     ReviewLoopRound,
     ReviewVerdict,
@@ -136,6 +145,8 @@ def record_result_envelope(
         return _record_failure(task, error=verdict_error)
 
     _maybe_record_plan_artifact(task, result, phase=phase)
+    _maybe_record_article_suggestions(task, result, phase=phase)
+    _maybe_record_answer_draft(task, result, phase=phase)
 
     attempt = TaskAttempt.objects.create(
         task=task,
@@ -290,6 +301,72 @@ def _maybe_record_plan_artifact(task: Task, result: AgentResultBlob, *, phase: s
         recorded_by=recorded_by,
         base_sha=base_sha if isinstance(base_sha, str) else "",
         adequacy=adequacy if isinstance(adequacy, dict) else None,
+    )
+
+
+#: Shell-denied reactive phases whose headless agent hands its work back through
+#: a typed envelope channel (#9): the agent cannot run the ``t3`` CLI, so the
+#: recorder is the server-side half that persists the returned structure. The
+#: ``PHASE_REQUIRED_EVIDENCE`` gate has already refused a summary-only run before
+#: these fire, so the channel field is present and non-empty here.
+_SCANNING_NEWS_PHASE = "scanning_news"
+_ANSWERING_PHASE = "answering"
+
+
+def _maybe_record_article_suggestions(task: Task, result: AgentResultBlob, *, phase: str) -> None:
+    """Persist a scanning_news agent's returned ``article_suggestions`` (corr-11, #9).
+
+    One ``PENDING`` :class:`PendingArticleSuggestion` per candidate, idempotent by
+    source URL (a re-scan never duplicates) and behind the same ask-gate the
+    scanner used to enqueue directly — the shell-denied agent hands the batch
+    back, the server persists it. A non-scanning_news phase or a result with no
+    ``article_suggestions`` list is a no-op.
+    """
+    if normalize_phase(phase or task.phase) != _SCANNING_NEWS_PHASE:
+        return
+    suggestions = result.get("article_suggestions")
+    if not isinstance(suggestions, list):
+        return
+    overlay = task.ticket.overlay
+    for raw_item in suggestions:
+        if not isinstance(raw_item, dict):
+            continue
+        item = cast("ArticleSuggestion", raw_item)
+        url = str(item.get("url") or "").strip()
+        if not url:
+            continue
+        PendingArticleSuggestion.record_candidate(
+            url=url,
+            title=str(item.get("title") or ""),
+            summary=str(item.get("rationale") or ""),
+            overlay=overlay,
+        )
+
+
+def _maybe_record_answer_draft(task: Task, result: AgentResultBlob, *, phase: str) -> None:
+    """Route an answering agent's returned ``answer`` draft to the approval path (corr-11, #9).
+
+    The shell-denied answerer cannot post on the user's behalf, so it hands the
+    draft back: this records a :class:`DeferredQuestion` (correlated to the task
+    via ``parked_task``) asking the user to approve the reply — the orchestrator
+    posts on confirmation. A non-answering phase or a result with no ``answer``
+    text is a no-op.
+    """
+    if normalize_phase(phase or task.phase) != _ANSWERING_PHASE:
+        return
+    raw_answer = result.get("answer")
+    if not isinstance(raw_answer, dict):
+        return
+    answer = cast("AnswerEnvelope", raw_answer)
+    text = str(answer.get("text") or "").strip()
+    if not text:
+        return
+    thread_ref = str(answer.get("thread_ref") or "").strip()
+    where = f" (thread {thread_ref})" if thread_ref else ""
+    DeferredQuestion.record(
+        question=f"Approve this drafted reply{where}?\n\n{text}",
+        session_id=task.claimed_by_session or "",
+        parked_task=task,
     )
 
 

--- a/src/teatree/agents/attempt_recorder.py
+++ b/src/teatree/agents/attempt_recorder.py
@@ -27,7 +27,9 @@ from teatree.agents.result_schema import (
     AnswerEnvelope,
     ArticleSuggestion,
     ReviewVerdictEnvelope,
+    answer_text,
     check_evidence,
+    suggestion_url,
 )
 from teatree.core.modelkit.phases import normalize_phase
 from teatree.core.models import (
@@ -329,12 +331,10 @@ def _maybe_record_article_suggestions(task: Task, result: AgentResultBlob, *, ph
         return
     overlay = task.ticket.overlay
     for raw_item in suggestions:
-        if not isinstance(raw_item, dict):
-            continue
-        item = cast("ArticleSuggestion", raw_item)
-        url = str(item.get("url") or "").strip()
+        url = suggestion_url(raw_item)
         if not url:
             continue
+        item = cast("ArticleSuggestion", raw_item)
         PendingArticleSuggestion.record_candidate(
             url=url,
             title=str(item.get("title") or ""),
@@ -355,12 +355,10 @@ def _maybe_record_answer_draft(task: Task, result: AgentResultBlob, *, phase: st
     if normalize_phase(phase or task.phase) != _ANSWERING_PHASE:
         return
     raw_answer = result.get("answer")
-    if not isinstance(raw_answer, dict):
-        return
-    answer = cast("AnswerEnvelope", raw_answer)
-    text = str(answer.get("text") or "").strip()
+    text = answer_text(raw_answer)
     if not text:
         return
+    answer = cast("AnswerEnvelope", raw_answer)
     thread_ref = str(answer.get("thread_ref") or "").strip()
     where = f" (thread {thread_ref})" if thread_ref else ""
     DeferredQuestion.record(

--- a/src/teatree/agents/result_schema.py
+++ b/src/teatree/agents/result_schema.py
@@ -39,6 +39,35 @@ class ReviewFinding(TypedDict, total=False):
     line: int
 
 
+class ArticleSuggestion(TypedDict, total=False):
+    """One news-scan candidate a shell-denied scanning_news agent hands back (#9).
+
+    The headless scanning_news phase cannot run the ``t3`` CLI to enqueue
+    candidates, so it RETURNS these instead: the recorder creates one
+    :class:`~teatree.core.models.pending_article_suggestion.PendingArticleSuggestion`
+    per candidate behind the ask-gate (idempotent by ``url``). ``rationale`` is
+    the one-line why-this-matters that becomes the row's summary.
+    """
+
+    title: str
+    url: str
+    rationale: str
+
+
+class AnswerEnvelope(TypedDict, total=False):
+    """A shell-denied answering agent's drafted reply, handed back for approval (#9).
+
+    The headless answering phase cannot post on the user's behalf, so it
+    RETURNS the draft: the recorder routes ``text`` through the
+    :class:`~teatree.core.models.deferred_question.DeferredQuestion` approval
+    path (correlated to the task), and the orchestrator posts on confirmation.
+    ``thread_ref`` is the inbound thread the reply targets.
+    """
+
+    text: str
+    thread_ref: str
+
+
 class ReviewVerdictEnvelope(TypedDict, total=False):
     """A reviewing-phase agent's typed verdict, recorded server-side (corr-11).
 
@@ -74,6 +103,8 @@ class AgentResult(TypedDict, total=False):
     tests_failed: int
     decisions: list[str]
     review_verdict: ReviewVerdictEnvelope
+    article_suggestions: list[ArticleSuggestion]
+    answer: AnswerEnvelope
     needs_user_input: bool
     user_input_reason: str
     next_steps: list[str]
@@ -142,6 +173,28 @@ RESULT_JSON_SCHEMA: dict[str, object] = {
             },
             "required": ["verdict"],
         },
+        "article_suggestions": {
+            "type": "array",
+            "description": "Candidate news articles a shell-denied scanning_news agent hands back for queuing.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string"},
+                    "url": {"type": "string"},
+                    "rationale": {"type": "string"},
+                },
+                "required": ["url"],
+            },
+        },
+        "answer": {
+            "type": "object",
+            "description": "A shell-denied answering agent's drafted reply, handed back for approval-gated posting.",
+            "properties": {
+                "text": {"type": "string"},
+                "thread_ref": {"type": "string"},
+            },
+            "required": ["text"],
+        },
         "needs_user_input": {"type": "boolean"},
         "user_input_reason": {"type": "string"},
         "next_steps": {
@@ -175,6 +228,11 @@ RESULT_JSON_SCHEMA: dict[str, object] = {
 #:   headless reviewer denied the shell proves the review happened by the
 #:   verdict it hands back, not only by a decision list.
 #: - ``shipping``: at least one command executed (``git push``, ``gh pr``...).
+#: - ``scanning_news``: at least one ``article_suggestion`` returned — the
+#:   shell-denied scanner hands its candidates back through the envelope, so a
+#:   summary-only run is a silently-dropped scan (#9), refused here.
+#: - ``answering``: an ``answer`` draft returned — same shell-denied hand-back;
+#:   a summary-only run dropped the drafted reply.
 #:
 #: Phases not in this map (``scoping``, ``retro``) carry no evidence
 #: requirement — they are intentionally lightweight.
@@ -184,6 +242,8 @@ PHASE_REQUIRED_EVIDENCE: dict[str, tuple[str, ...]] = {
     "testing": ("tests_run", "tests_passed"),
     "reviewing": ("decisions", "review_verdict"),
     "shipping": ("commands_executed",),
+    "scanning_news": ("article_suggestions",),
+    "answering": ("answer",),
 }
 
 

--- a/src/teatree/agents/result_schema.py
+++ b/src/teatree/agents/result_schema.py
@@ -13,7 +13,8 @@ shape this prevents: a one-line summary advancing the FSM with no underlying
 proof.
 """
 
-from typing import TypedDict
+from collections.abc import Callable
+from typing import TypedDict, cast
 
 from teatree.core.modelkit.phases import normalize_phase
 
@@ -255,13 +256,54 @@ def required_evidence_for_phase(phase: str) -> tuple[str, ...]:
 type AgentResultBlob = dict[str, object]
 
 
+def suggestion_url(item: object) -> str:
+    """The persistable source URL of one article suggestion, or ``""`` if absent.
+
+    The single URL extractor BOTH the evidence gate and ``record_result_envelope``
+    call, so "the gate passed" and "the recorder wrote a row" cannot disagree on
+    what counts as a real candidate — the #9 gate/recorder-drift hardening.
+    """
+    if not isinstance(item, dict):
+        return ""
+    return str(cast("ArticleSuggestion", item).get("url") or "").strip()
+
+
+def answer_text(answer: object) -> str:
+    """The persistable reply text of an answer envelope, or ``""`` if absent."""
+    if not isinstance(answer, dict):
+        return ""
+    return str(cast("AnswerEnvelope", answer).get("text") or "").strip()
+
+
+#: Channels whose "evidence present" test is stricter than coarse truthiness:
+#: the field must carry what the recorder actually PERSISTS (a url-bearing
+#: suggestion, a text-bearing answer). Without this a schema-violating-but-
+#: nonempty hand-back (``[{"title": "x"}]`` / ``{"thread_ref": "x"}``) the
+#: recorder drops entirely would pass the gate and COMPLETE the task over zero
+#: persisted work — the exact silent-drop class #9 closes.
+_FIELD_PERSISTS: dict[str, Callable[[object], bool]] = {
+    "article_suggestions": lambda v: isinstance(v, list) and any(suggestion_url(item) for item in v),
+    "answer": lambda v: bool(answer_text(v)),
+}
+
+
+def _field_carries_evidence(result: AgentResultBlob, field: str) -> bool:
+    predicate = _FIELD_PERSISTS.get(field)
+    if predicate is not None:
+        return predicate(result.get(field))
+    return bool(result.get(field))
+
+
 def check_evidence(result: AgentResultBlob, phase: str) -> str:
     """Return an error message if *result* lacks required evidence, else ``""``.
 
     A field is "present" iff the result has the key AND its value is
-    truthy (non-zero int, non-empty list/dict/string). Supplying ANY of the
-    acceptable fields for ``phase`` satisfies the check — the requirement
-    is "one of these, non-empty", not "all of these".
+    truthy (non-zero int, non-empty list/dict/string) — except the envelope
+    channels in ``_FIELD_PERSISTS``, which require the value to carry what the
+    recorder actually PERSISTS (a url-bearing suggestion / a text-bearing
+    answer), so the gate can never pass an envelope the recorder would drop.
+    Supplying ANY of the acceptable fields for ``phase`` satisfies the check —
+    the requirement is "one of these, with real content", not "all of these".
 
     Sub-agent contracts that opt out of normal completion (``needs_user_input``
     handoffs) bypass the check: the agent is *not* claiming the phase is
@@ -272,7 +314,7 @@ def check_evidence(result: AgentResultBlob, phase: str) -> str:
     accepted = required_evidence_for_phase(phase)
     if not accepted:
         return ""
-    if any(result.get(field) for field in accepted):
+    if any(_field_carries_evidence(result, field) for field in accepted):
         return ""
     joined = " | ".join(accepted)
     return (

--- a/src/teatree/core/modelkit/phase_tools.py
+++ b/src/teatree/core/modelkit/phase_tools.py
@@ -44,21 +44,31 @@ _WRITE: Final[frozenset[str]] = frozenset({"write_file", "edit_file"})
 _FULL: Final[frozenset[str]] = ALL_TOOLS
 
 #: Canonical phase -> the exact set of capability tool names it may call.
-#: A read-only phase (reviewing, e2e_reviewing, requesting_review, scanning_news)
-#: has NO write/edit/shell — the cold-review least-privilege PR-11 enforces on
-#: Lane A. A write phase (coding, testing, e2e) gets the full set. An unknown
-#: phase falls back to read-only (:func:`tools_for_phase`) — deny-by-default, so
-#: a new phase never silently inherits shell/write until it is added here.
+#: A read-only phase (reviewing, e2e_reviewing, requesting_review, scanning_news,
+#: answering, codex_reviewing) has NO write/edit/shell — the cold-review
+#: least-privilege PR-11 enforces on Lane A. A write phase (coding, testing, e2e,
+#: debugging) gets the full set. ``bughunt`` executes to reproduce a candidate
+#: but never writes (shell + dispatch, no write/edit). An unknown phase falls
+#: back to read-only (:func:`tools_for_phase`) — deny-by-default, so a new phase
+#: never silently inherits shell/write until it is added here. TOTALITY: every
+#: dispatchable ``SUBAGENT_BY_PHASE`` phase MUST have an explicit entry here (the
+#: ``test_registry_parity`` totality lane), so the read-only fallback is
+#: defense-in-depth for a genuinely unregistered phase, never the silent
+#: resolution for a dispatchable one (#10).
 _TOOLS_BY_PHASE: Final[dict[str, frozenset[str]]] = {
     "planning": _READ_ONLY | _WEB | {"dispatch_subtask"},
     "scoping": _READ_ONLY | _WEB,
     "coding": _FULL,
     "testing": _FULL,
     "e2e": _FULL,
+    "debugging": _FULL,
     "reviewing": _READ_ONLY | _WEB,
     "e2e_reviewing": _READ_ONLY | _WEB,
+    "codex_reviewing": _READ_ONLY | _WEB,
+    "codex_adversarial_reviewing": _READ_ONLY | _WEB,
     "requesting_review": _READ_ONLY,
     "scanning_news": _READ_ONLY | _WEB,
+    "bughunt": _READ_ONLY | {"shell", "dispatch_subtask"},
     "shipping": _READ_ONLY | {"shell", "record_attempt"},
     "answering": _READ_ONLY | _WEB,
     "retro": _READ_ONLY | _WRITE,

--- a/tests/conformance/test_registry_parity.py
+++ b/tests/conformance/test_registry_parity.py
@@ -18,14 +18,17 @@ enumeration cannot turn a lane vacuous-green.
 
 import inspect
 from collections.abc import Iterable
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from django.db.models import Q
 
+from teatree.agents.sdk_tool_map import CAPABILITY_TO_SDK_TOOLS
 from teatree.core.management.commands import loop_dispatch
 from teatree.core.managers import TaskQuerySet
-from teatree.core.modelkit.phases import SUBAGENT_BY_PHASE
+from teatree.core.modelkit.phase_tools import _TOOLS_BY_PHASE, tools_for_phase
+from teatree.core.modelkit.phases import SUBAGENT_BY_PHASE, normalize_phase
 from teatree.core.models import Task
 from teatree.loop.dispatch_tables import AGENT_ZONES, PERSISTED_AT_SOURCE_ZONES
 from teatree.loop.job_identity import PER_OVERLAY_DOMAINS
@@ -226,3 +229,115 @@ class TestRegistryParityFrameworkFiresRed:
             label="self-test",
             allowlist={"t3:DELIBERATE-NO-CONSUMER"},
         )
+
+
+class TestPhaseToolsTotalityParity:
+    """LANE 4 — every dispatchable phase has an EXPLICIT least-privilege entry (#10).
+
+    ``bughunt`` (and, after DIS-A, ``debugging`` / ``codex_reviewing`` /
+    ``codex_adversarial_reviewing``) were dispatchable through
+    ``SUBAGENT_BY_PHASE`` yet absent from ``_TOOLS_BY_PHASE``, so
+    ``tools_for_phase`` silently resolved them to the read-only fallback — a
+    bughunter whose brief tells it to reproduce findings could not run the
+    shell. Every ``SUBAGENT_BY_PHASE`` phase must carry an explicit
+    ``_TOOLS_BY_PHASE`` key; the read-only fallback stays as defense-in-depth
+    for a genuinely unregistered phase, never as the silent resolution for a
+    dispatchable one — the #10 recurrence dies in CI.
+    """
+
+    @staticmethod
+    def _dispatchable_phases() -> set[str]:
+        return {normalize_phase(phase) for _role, phase in SUBAGENT_BY_PHASE}
+
+    def test_every_dispatchable_phase_has_an_explicit_tool_entry(self) -> None:
+        assert_registry_covers(
+            producers=self._dispatchable_phases(),
+            consumers=set(_TOOLS_BY_PHASE),
+            label="SUBAGENT_BY_PHASE phase -> explicit _TOOLS_BY_PHASE entry",
+        )
+
+    def test_bughunt_can_reproduce_findings_but_not_write(self) -> None:
+        tools = tools_for_phase("bughunt")
+        assert {"shell", "dispatch_subtask", "read_file"} <= tools
+        assert "write_file" not in tools
+        assert "edit_file" not in tools
+
+    def test_cardinality_floor_anti_vacuity(self) -> None:
+        assert len(self._dispatchable_phases()) >= 12, self._dispatchable_phases()
+        assert len(_TOOLS_BY_PHASE) >= 12, set(_TOOLS_BY_PHASE)
+
+
+#: teatree capability name <- each ``claude_sdk`` built-in tool an agent md may list.
+_SDK_TOOL_TO_CAPABILITY: dict[str, str] = {
+    sdk_name: capability for capability, sdk_names in CAPABILITY_TO_SDK_TOOLS.items() for sdk_name in sdk_names
+}
+_AGENTS_DIR = Path(__file__).resolve().parents[2] / "agents"
+#: The shell-denied reactive phases whose headless agents hand work back through
+#: the result envelope (DIS-B, #9). Their briefs must not promise the shell the
+#: lane strips, or the article-ideas / approved-reply silent-drop class returns.
+_ENVELOPE_SHELL_DENIED_PHASES = ("scanning_news", "answering")
+
+
+def _agent_allowlist_tools(agent_file_stem: str) -> frozenset[str] | None:
+    """Teatree capabilities an ``agents/<stem>.md`` ``tools:`` allowlist grants.
+
+    ``None`` for a brief using the ``disallowedTools:`` denylist convention (a
+    different mechanism) or missing frontmatter — this lane checks only positive
+    allowlist briefs, where a listed tool is a direct promise of that capability.
+    """
+    path = _AGENTS_DIR / f"{agent_file_stem}.md"
+    if not path.is_file():
+        return None
+    in_tools = False
+    listed: list[str] = []
+    for number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = raw.strip()
+        if number > 1 and stripped == "---":
+            break
+        if not raw.startswith((" ", "\t")) and ":" in stripped:
+            in_tools = stripped.split(":", 1)[0].strip() == "tools"
+            continue
+        if in_tools and stripped.startswith("- "):
+            listed.append(stripped.removeprefix("- ").strip())
+    if not listed:
+        return None
+    return frozenset(_SDK_TOOL_TO_CAPABILITY[name] for name in listed if name in _SDK_TOOL_TO_CAPABILITY)
+
+
+def _agent_for_phase(target_phase: str) -> str:
+    for (_role, phase), agent in SUBAGENT_BY_PHASE.items():
+        if phase == target_phase:
+            return agent
+    return ""
+
+
+class TestAgentMdPhaseToolParity:
+    """LANE 5 — a headless brief never promises a tool its phase denies (#9).
+
+    ``scanning-news.md`` / ``answerer.md`` listed ``Bash`` while their
+    ``phase_tools`` entry is shell-denied, so the lane stripped the shell the
+    brief promised and a run that tried to use it dropped its work. These
+    reactive phases now hand results back through the typed envelope channel
+    BECAUSE they cannot shell out; their ``tools:`` allowlist must match the
+    SSOT (no shell), or the silent-drop class returns. Scoped to the two
+    envelope-channel phases DIS-B owns — the planner/shipper allowlist briefs
+    carry separate pre-existing divergences outside this PR's file ownership.
+    """
+
+    @pytest.mark.parametrize("phase", _ENVELOPE_SHELL_DENIED_PHASES)
+    def test_agent_tools_are_a_subset_of_the_phase_allowance(self, phase: str) -> None:
+        agent = _agent_for_phase(phase)
+        assert agent, f"no dispatched agent for phase {phase!r}"
+        declared = _agent_allowlist_tools(agent.removeprefix("t3:"))
+        assert declared is not None, f"{agent} has no tools: allowlist to check"
+        allowed = tools_for_phase(phase)
+        assert declared <= allowed, f"{agent} promises {sorted(declared - allowed)} denied by phase {phase!r}"
+        assert "shell" not in declared, f"{agent} declares the shell but phase {phase!r} is shell-denied"
+
+    def test_both_reactive_agents_are_actually_checked(self) -> None:
+        checked = [
+            _agent_allowlist_tools(_agent_for_phase(phase).removeprefix("t3:"))
+            for phase in _ENVELOPE_SHELL_DENIED_PHASES
+        ]
+        assert all(tools is not None for tools in checked), checked
+        assert len(checked) >= 2

--- a/tests/teatree_agents/test_attempt_recorder.py
+++ b/tests/teatree_agents/test_attempt_recorder.py
@@ -149,6 +149,15 @@ class TestScanningNewsEnvelopeChannel(TestCase):
         assert task.status == Task.Status.FAILED
         assert PendingArticleSuggestion.objects.count() == 0
 
+    def test_url_less_suggestions_fail_the_task_persisting_nothing(self) -> None:
+        # The gate must refuse a nonempty-but-url-less hand-back the recorder
+        # would drop entirely — not complete the task over zero persisted rows.
+        task = self._claimed()
+        record_result_envelope(task, {"summary": "found 1", "article_suggestions": [{"title": "no url"}]})
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+        assert PendingArticleSuggestion.objects.count() == 0
+
 
 class TestAnsweringEnvelopeChannel(TestCase):
     """A shell-denied answering agent hands its draft back for approval-gated posting (#9)."""
@@ -177,6 +186,15 @@ class TestAnsweringEnvelopeChannel(TestCase):
     def test_summary_only_answering_is_refused(self) -> None:
         task = self._claimed()
         record_result_envelope(task, {"summary": "drafted but not returned"})
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+        assert DeferredQuestion.objects.count() == 0
+
+    def test_text_less_answer_fails_the_task_persisting_nothing(self) -> None:
+        # A draft with only a thread_ref persists no DeferredQuestion, so the gate
+        # must refuse it rather than complete over a dropped reply.
+        task = self._claimed()
+        record_result_envelope(task, {"summary": "drafted", "answer": {"thread_ref": "C1/1.0"}})
         task.refresh_from_db()
         assert task.status == Task.Status.FAILED
         assert DeferredQuestion.objects.count() == 0

--- a/tests/teatree_agents/test_attempt_recorder.py
+++ b/tests/teatree_agents/test_attempt_recorder.py
@@ -1,5 +1,7 @@
 """Shared result-envelope recorder used by both dispatch backends."""
 
+from unittest.mock import patch
+
 import pytest
 from django.test import TestCase
 
@@ -10,7 +12,8 @@ from teatree.agents.attempt_recorder import (
     record_result_envelope,
     validate_result_keys,
 )
-from teatree.core.models import Session, Task, TaskAttempt, Ticket
+from teatree.core.models import DeferredQuestion, PendingArticleSuggestion, Session, Task, TaskAttempt, Ticket
+from teatree.verification.url_check import UrlCheckResult, UrlCheckStatus
 
 
 class TestParseResultEnvelope(TestCase):
@@ -105,3 +108,75 @@ class TestRecordResultEnvelope(TestCase):
         record_result_envelope(task, {"summary": "x", "bogus": True})
         task.refresh_from_db()
         assert task.status == Task.Status.FAILED
+
+
+class TestScanningNewsEnvelopeChannel(TestCase):
+    """A shell-denied scanning_news agent hands candidates back through the envelope (#9)."""
+
+    def _claimed(self) -> Task:
+        ticket = Ticket.objects.create(role=Ticket.Role.AUTHOR, state=Ticket.State.STARTED, overlay="acme")
+        session = Session.objects.create(ticket=ticket, agent_id="scanning_news")
+        task = Task.objects.create(ticket=ticket, session=session, phase="scanning_news")
+        task.claim(claimed_by="loop-slot")
+        return task
+
+    @patch("teatree.core.models.pending_article_suggestion.check_url")
+    def test_article_suggestions_round_trip_to_pending_rows(self, check_url: object) -> None:
+        check_url.return_value = UrlCheckResult(url="", status=UrlCheckStatus.OK, http_status=200)
+        task = self._claimed()
+        record_result_envelope(
+            task,
+            {
+                "summary": "2 candidates",
+                "article_suggestions": [
+                    {"title": "A", "url": "https://ex.com/a", "rationale": "why a"},
+                    {"title": "B", "url": "https://ex.com/b", "rationale": "why b"},
+                ],
+            },
+        )
+        task.refresh_from_db()
+        assert task.status == Task.Status.COMPLETED
+        rows = PendingArticleSuggestion.objects.all()
+        assert rows.count() == 2
+        assert set(rows.values_list("url", flat=True)) == {"https://ex.com/a", "https://ex.com/b"}
+        assert {row.overlay for row in rows} == {"acme"}
+        assert {row.status for row in rows} == {PendingArticleSuggestion.Status.PENDING}
+
+    def test_summary_only_scanning_news_is_refused(self) -> None:
+        task = self._claimed()
+        record_result_envelope(task, {"summary": "nothing found today"})
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+        assert PendingArticleSuggestion.objects.count() == 0
+
+
+class TestAnsweringEnvelopeChannel(TestCase):
+    """A shell-denied answering agent hands its draft back for approval-gated posting (#9)."""
+
+    def _claimed(self) -> Task:
+        ticket = Ticket.objects.create(role=Ticket.Role.AUTHOR, state=Ticket.State.STARTED, overlay="acme")
+        session = Session.objects.create(ticket=ticket, agent_id="answering")
+        task = Task.objects.create(ticket=ticket, session=session, phase="answering")
+        task.claim(claimed_by="loop-slot")
+        return task
+
+    def test_answer_draft_routes_to_a_deferred_question(self) -> None:
+        task = self._claimed()
+        record_result_envelope(
+            task,
+            {"summary": "drafted", "answer": {"text": "Here is the reply.", "thread_ref": "C123/168.9"}},
+        )
+        task.refresh_from_db()
+        assert task.status == Task.Status.COMPLETED
+        question = DeferredQuestion.objects.get()
+        assert question.parked_task_id == task.pk
+        assert "Here is the reply." in question.question
+        assert "C123/168.9" in question.question
+        assert question.is_pending
+
+    def test_summary_only_answering_is_refused(self) -> None:
+        task = self._claimed()
+        record_result_envelope(task, {"summary": "drafted but not returned"})
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+        assert DeferredQuestion.objects.count() == 0

--- a/tests/teatree_agents/test_result_schema.py
+++ b/tests/teatree_agents/test_result_schema.py
@@ -48,3 +48,18 @@ class TestShellDeniedPhaseEvidenceGate:
         # no content is still a dropped scan, refused.
         assert check_evidence({"article_suggestions": []}, "scanning_news")
         assert check_evidence({"answer": {}}, "answering")
+
+    def test_url_less_article_suggestions_do_not_satisfy_the_gate(self) -> None:
+        # Nonempty-but-malformed: the recorder skips every url-less item, so this
+        # would persist ZERO rows. The gate predicate matches what persists — at
+        # least one url-bearing item — so a run that would drop everything is
+        # refused, not greened.
+        assert check_evidence({"article_suggestions": [{"title": "x"}]}, "scanning_news")
+        mixed = check_evidence({"article_suggestions": [{"title": "x"}, {"url": "https://e/a"}]}, "scanning_news")
+        assert mixed == ""
+
+    def test_text_less_answer_does_not_satisfy_the_gate(self) -> None:
+        # A draft with a thread_ref but no text persists no DeferredQuestion, so
+        # the gate refuses it rather than completing over a dropped reply.
+        assert check_evidence({"answer": {"thread_ref": "x"}}, "answering")
+        assert check_evidence({"answer": {"thread_ref": "x", "text": "hi"}}, "answering") == ""

--- a/tests/teatree_agents/test_result_schema.py
+++ b/tests/teatree_agents/test_result_schema.py
@@ -1,0 +1,50 @@
+"""Typed envelope channels + the phase-evidence gate for shell-denied phases (#9).
+
+A headless scanning_news / answering agent is denied the shell, so it cannot run
+the ``t3`` CLI to persist its work. The typed ``article_suggestions`` / ``answer``
+channels let it hand the work back through the result envelope, and
+``PHASE_REQUIRED_EVIDENCE`` refuses a summary-only run that silently dropped it.
+"""
+
+from typing import Any, cast
+
+from teatree.agents.result_schema import RESULT_JSON_SCHEMA, check_evidence, required_evidence_for_phase
+
+_PROPERTIES = cast("dict[str, Any]", RESULT_JSON_SCHEMA["properties"])
+
+
+class TestEnvelopeChannelSchema:
+    def test_article_suggestions_and_answer_are_schema_keys(self) -> None:
+        assert "article_suggestions" in _PROPERTIES
+        assert "answer" in _PROPERTIES
+
+    def test_article_suggestion_items_carry_the_typed_shape(self) -> None:
+        item = _PROPERTIES["article_suggestions"]["items"]
+        assert set(item["properties"]) == {"title", "url", "rationale"}
+        assert item["required"] == ["url"]
+
+    def test_answer_carries_the_typed_shape(self) -> None:
+        answer = _PROPERTIES["answer"]
+        assert set(answer["properties"]) == {"text", "thread_ref"}
+        assert answer["required"] == ["text"]
+
+
+class TestShellDeniedPhaseEvidenceGate:
+    def test_reactive_phases_require_their_envelope_channel(self) -> None:
+        assert required_evidence_for_phase("scanning_news") == ("article_suggestions",)
+        assert required_evidence_for_phase("answering") == ("answer",)
+
+    def test_scanning_news_summary_only_is_missing_evidence(self) -> None:
+        assert check_evidence({"summary": "nothing"}, "scanning_news")
+        satisfied = check_evidence({"summary": "x", "article_suggestions": [{"url": "https://e/a"}]}, "scanning_news")
+        assert satisfied == ""
+
+    def test_answering_summary_only_is_missing_evidence(self) -> None:
+        assert check_evidence({"summary": "drafted"}, "answering")
+        assert check_evidence({"summary": "x", "answer": {"text": "hi"}}, "answering") == ""
+
+    def test_empty_channel_does_not_satisfy_the_gate(self) -> None:
+        # An empty list / empty draft is falsy — a run that returned the key but
+        # no content is still a dropped scan, refused.
+        assert check_evidence({"article_suggestions": []}, "scanning_news")
+        assert check_evidence({"answer": {}}, "answering")

--- a/tests/teatree_core/modelkit/test_phase_tools.py
+++ b/tests/teatree_core/modelkit/test_phase_tools.py
@@ -32,3 +32,25 @@ class TestToolsForPhase:
 
     def test_review_phase_disallows_write_tools(self) -> None:
         assert {"write_file", "edit_file", "shell"} <= disallowed_tools_for_phase("reviewing")
+
+
+class TestDispatchablePhaseTotality:
+    """Every DIS-A/DIS-B dispatchable phase resolves an explicit, correct tool set."""
+
+    def test_bughunt_executes_but_never_writes(self) -> None:
+        bughunt = tools_for_phase("bughunt")
+        assert {"shell", "dispatch_subtask", "read_file", "search_files"} <= bughunt
+        assert "write_file" not in bughunt
+        assert "edit_file" not in bughunt
+
+    def test_debugging_gets_the_full_write_set(self) -> None:
+        debugging = tools_for_phase("debugging")
+        assert {"shell", "write_file", "edit_file", "read_file"} <= debugging
+
+    def test_codex_review_phases_are_read_only_no_write_no_shell(self) -> None:
+        for phase in ("codex_reviewing", "codex_adversarial_reviewing"):
+            tools = tools_for_phase(phase)
+            assert "read_file" in tools, phase
+            assert "write_file" not in tools, phase
+            assert "edit_file" not in tools, phase
+            assert "shell" not in tools, phase


### PR DESCRIPTION
DIS-B (campaign slot 12) — closes integration-audit bugs #9 and #10. Sole owner of `phase_tools.py`. Branches off `origin/main` (after DIS-A + MW-A merged).

## `_TOOLS_BY_PHASE` totality bughunt (#10)

`bughunt` was dispatchable through `SUBAGENT_BY_PHASE` yet absent from the `_TOOLS_BY_PHASE` least-privilege table, so `tools_for_phase` silently resolved it to the read-only fallback — a bughunter whose brief tells it to reproduce a candidate could not run the shell. DIS-A's new `debugging` / `codex_reviewing` / `codex_adversarial_reviewing` phases had the same gap. Added explicit entries for all four:

- `bughunt` = read + `shell` + `dispatch_subtask`, no write/edit (execute to reproduce, never mutate).
- `debugging` = full (the debugger edits code and runs tests).
- `codex_reviewing` / `codex_adversarial_reviewing` = read-only review.

A new conformance totality lane asserts every dispatchable `SUBAGENT_BY_PHASE` phase carries an **explicit** `_TOOLS_BY_PHASE` entry, so the read-only fallback stays defense-in-depth for a genuinely unregistered phase and is never the silent resolution for a dispatchable one — the #10 recurrence dies in CI.

## Typed `article_suggestions` / `answer` envelope channels + `PHASE_REQUIRED_EVIDENCE` for shell-denied phases (#9)

Headless `scanning_news` / `answering` are shell-denied, so they cannot run the `t3` CLI to persist their work and were COMPLETING summary-only with the article ideas / drafted replies silently dropped. Propagated the corr-11 hand-back pattern:

- Typed `article_suggestions` (`{title, url, rationale}`) and `answer` (`{text, thread_ref}`) fields on `AgentResult` / `RESULT_JSON_SCHEMA`.
- `record_result_envelope` records them server-side: one `PENDING` `PendingArticleSuggestion` per candidate (idempotent by source URL, behind the ask-gate); the `answer` draft routed to a `DeferredQuestion` approval correlated to the task via `parked_task`.
- `scanning_news -> article_suggestions` and `answering -> answer` in `PHASE_REQUIRED_EVIDENCE`, so a summary-only run is **refused** at recording rather than completing with the work discarded — the same fail-loud mechanism that guards coding/reviewing.

## `agents/*.md` to phase_tools SSOT parity

`scanning-news.md` and `answerer.md` declared `Bash` while their phase is shell-denied — briefs promising a tool the lane strips. Dropped `Bash`, aligned the prose to the envelope hand-back (the agents now RETURN their work instead of posting), and added a parity lane asserting these two envelope-channel agents' `tools:` allowlists never exceed the phase_tools allowance. Scoped to the two phases this PR owns; the planner/shipper allowlist briefs carry separate pre-existing divergences outside this PR's file ownership.

## Anti-vacuity (RED-before, observed)

- **Totality lane** — RED on the four missing phases before the `_TOOLS_BY_PHASE` fix.
- **Envelope channels** — 11 tests RED against the pre-fix source (schema rejects the new keys -> task FAILED; summary-only runs COMPLETED because the evidence gate wasn't enforced), GREEN after.
- **agents.md to SSOT parity** — RED with `t3:scanning-news` / `t3:answerer` promising `shell`, GREEN after dropping `Bash`.

## Verification

Targeted + `tests/quality` + never-lockout + `tests/conformance` + `tests/test_cli_command_literals_resolve.py` + full `tests/teatree_agents` green; `ty check`, `ruff`, module-health, `test-path-mirror` (ledger exact), `makemigrations --check` (no changes), and banned-terms scan-tree all clean.

Closes #9
Closes #10
