### PR TITLE
fix(merge-auth): revive M7 PrApprovalScanner + get_mr_approvals + sync_forge_approvals + repo-scoped ticket-less _has_covering_clear via superseded-aware helper (#8,#21)

### DIFF
--- a/src/teatree/backends/github/client.py
+++ b/src/teatree/backends/github/client.py
@@ -1,5 +1,6 @@
 """GitHub backend — code host via the ``gh`` CLI."""
 
+import json
 import re
 from typing import cast
 from urllib.parse import quote_plus, urlparse
@@ -359,17 +360,29 @@ class GitHubCodeHost:  # noqa: PLR0904 — method count reflects the CodeHostBac
         )
         return {}
 
-    @staticmethod
-    def get_mr_approvals(*, repo: str, pr_iid: int) -> ApprovalState:
-        """Out of scope for #936 — GitLab-only approval polling for now.
+    def get_mr_approvals(self, *, repo: str, pr_iid: int) -> ApprovalState:
+        """Return GitHub's aggregate review decision as an approval snapshot (#8).
 
-        Raising rather than returning a vacuous zero state forces the caller
-        (``GitLabApprovalsScanner``) to skip GitHub PRs silently rather than
-        silently treating them as "approved with zero approvals_left".
+        GitHub exposes no numeric "approvals remaining" counter; its aggregate
+        ``reviewDecision`` (``gh pr view --json reviewDecision``) is the
+        merge-authorising signal — ``APPROVED`` means every required review is
+        satisfied. Maps to ``approvals_left=0`` on ``APPROVED`` and ``1``
+        otherwise, so a not-yet-approved (or a payload with no decision) is
+        never mis-read as merge-authorised. ``unresolved_resolvable`` is ``0``:
+        GitHub has no resolvable-thread merge block like GitLab's "must resolve"
+        policy, so nothing there gates the M7 waiting lane.
         """
-        _ = (repo, pr_iid)
-        msg = "GitHub approval state is not yet wired up (#936 is GitLab-scoped)"
-        raise NotImplementedError(msg)
+        result = _run_gh("gh", "pr", "view", str(pr_iid), "--repo", repo, "--json", "reviewDecision", token=self._token)
+        try:
+            data = json.loads(result.stdout or "{}")
+        except json.JSONDecodeError:
+            data = {}
+        decision = str(data.get("reviewDecision") or "").upper() if isinstance(data, dict) else ""
+        return ApprovalState(
+            approvals_left=0 if decision == "APPROVED" else 1,
+            approved_by=[],
+            unresolved_resolvable=0,
+        )
 
     def get_review_state(self, *, pr_url: str, reviewer: str) -> ReviewState:
         """Return *reviewer*'s current review state on the PR at *pr_url*.

--- a/src/teatree/core/_checking_gather.py
+++ b/src/teatree/core/_checking_gather.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from teatree.core.models.deferred_question import DeferredQuestion
-from teatree.core.models.merge_clear import MergeAudit, MergeClear
+from teatree.core.models.merge_clear import MergeAudit
 from teatree.core.models.task_attempt import TaskAttempt
 from teatree.core.models.ticket import Ticket
 from teatree.core.models.transition import TicketTransition
@@ -50,16 +50,6 @@ def pr_url_for(ticket: Ticket | None, *, repo_slug: str, pr_id: int, code_host: 
     if built:
         return built
     return ticket.issue_url if ticket is not None else ""
-
-
-def resolved_repo_slug(clear: MergeClear) -> str:
-    """The real ``owner/repo`` for *clear*'s PR, or ``""`` when unresolvable."""
-    from teatree.core.merge import MergePreconditionError, resolve_pr_repo_slug  # noqa: PLC0415
-
-    try:
-        return resolve_pr_repo_slug(clear)
-    except MergePreconditionError:
-        return ""
 
 
 def repo_entry_matches(declared: str, resolved_slug: str, *, overlay_owner: str | None) -> bool:
@@ -139,6 +129,7 @@ def merged_group_from_qs(
 ) -> tuple[list, int]:
     """Query and scope the merged audits; return (items, total)."""
     from teatree.core.checking import CheckItem  # noqa: PLC0415
+    from teatree.core.merge import resolved_repo_slug  # noqa: PLC0415 — deferred merge edge
 
     qs = (
         MergeAudit.objects.filter(merged_at__gte=since, merged_at__lt=now)

--- a/src/teatree/core/factory_signal_queries.py
+++ b/src/teatree/core/factory_signal_queries.py
@@ -302,7 +302,7 @@ def compute_s3(window: Window, overlay: str, now: datetime) -> Computation:  # n
     return Computation(SignalReading(caught / denom, denom, window.days, SignalStatus.OK), evidence)
 
 
-def _superseding_context(overlay: str) -> tuple[dict[tuple[str, int], datetime], set[tuple[str, int]]]:
+def superseding_context(overlay: str) -> tuple[dict[tuple[str, int], datetime], set[tuple[str, int]]]:
     """The two supersede signals S4's staleness trip consults, each one grouped read (#15).
 
     ``(latest_issued, merged_keys)`` keyed on the raw ``MergeClear.slug`` (a
@@ -311,6 +311,13 @@ def _superseding_context(overlay: str) -> tuple[dict[tuple[str, int], datetime],
     ``(slug, pr_id)`` that already has a ``MergeAudit`` (the PR merged). Together
     they identify an unconsumed CLEAR the merge loop has moved past — a
     strictly-newer sibling re-reviewed it forward, or a merge already covers it.
+
+    Public because the waiting-lane covering-CLEAR match (:func:`~teatree.core.waiting._has_covering_clear`,
+    #21) reads the SAME context and applies the SAME :func:`clear_is_superseded`
+    predicate — a superseded orphan must not authorise a merge there while S4
+    excludes it here, or the two lanes diverge on the SIG-1 supersede semantics.
+    An empty ``overlay`` scopes globally, which is what the per-PR waiting match
+    wants so a ticket-less CLEAR's siblings are seen regardless of overlay.
     """
     clears = MergeClear.objects.all()
     audits = MergeAudit.objects.all()
@@ -324,6 +331,26 @@ def _superseding_context(overlay: str) -> tuple[dict[tuple[str, int], datetime],
             latest_issued[key] = issued_at
     merged_keys = {(slug, pr_id) for slug, pr_id in audits.values_list("clear__slug", "clear__pr_id")}
     return latest_issued, merged_keys
+
+
+def clear_is_superseded(
+    clear: MergeClear,
+    latest_issued: dict[tuple[str, int], datetime],
+    merged_keys: set[tuple[str, int]],
+) -> bool:
+    """True iff *clear* has been moved past — the shared SIG-1 supersede predicate (#15/#21).
+
+    A CLEAR is superseded when a ``MergeAudit`` already covers its ``(slug,
+    pr_id)`` (the PR merged) or a strictly-newer sibling CLEAR exists for the
+    same key (a head-move re-review issued forward). The single predicate S4's
+    staleness trip and the waiting-lane covering match both apply against a
+    :func:`superseding_context`, so an orphaned old CLEAR is treated identically
+    on both lanes instead of one counting it live and the other excluding it.
+    """
+    key = (clear.slug, clear.pr_id)
+    if key in merged_keys:
+        return True
+    return latest_issued.get(key, clear.issued_at) > clear.issued_at
 
 
 def _max_actionable_clear_age_hours(overlay: str, now: datetime) -> float | None:
@@ -344,12 +371,11 @@ def _max_actionable_clear_age_hours(overlay: str, now: datetime) -> float | None
     actionable = [clear for clear in qs if clear.is_actionable()]
     if not actionable:
         return None
-    latest_issued, merged_keys = _superseding_context(overlay)
+    latest_issued, merged_keys = superseding_context(overlay)
     ages = [
         (now - clear.issued_at).total_seconds() / 3600.0
         for clear in actionable
-        if (clear.slug, clear.pr_id) not in merged_keys
-        and latest_issued.get((clear.slug, clear.pr_id), clear.issued_at) <= clear.issued_at
+        if not clear_is_superseded(clear, latest_issued, merged_keys)
     ]
     return max(ages) if ages else None
 

--- a/src/teatree/core/merge/__init__.py
+++ b/src/teatree/core/merge/__init__.py
@@ -26,7 +26,13 @@ from teatree.core.merge.execution import (
     record_merge_and_advance,
 )
 from teatree.core.merge.head_guard import restore_caller_branch
-from teatree.core.merge.pr_slug_resolution import _GIT_BRANCH_PREFIXES, _looks_like_owner_repo, resolve_pr_repo_slug
+from teatree.core.merge.pr_slug_resolution import (
+    _GIT_BRANCH_PREFIXES,
+    _looks_like_owner_repo,
+    normalize_repo_slug,
+    resolve_pr_repo_slug,
+    resolved_repo_slug,
+)
 
 __all__ = [
     "_GIT_BRANCH_PREFIXES",
@@ -49,7 +55,9 @@ __all__ = [
     "fetch_required_checks_status",
     "fetch_required_context_names",
     "merge_ticket_pr",
+    "normalize_repo_slug",
     "record_merge_and_advance",
     "resolve_pr_repo_slug",
+    "resolved_repo_slug",
     "restore_caller_branch",
 ]

--- a/src/teatree/core/merge/pr_slug_resolution.py
+++ b/src/teatree/core/merge/pr_slug_resolution.py
@@ -181,6 +181,22 @@ def resolve_pr_repo_slug(clear: object) -> str:
     raise MergePreconditionError(msg)
 
 
+def resolved_repo_slug(clear: object) -> str:
+    """The real ``owner/repo`` for *clear*'s PR, or ``""`` when unresolvable.
+
+    The non-raising sibling of :func:`resolve_pr_repo_slug`, promoted here as the
+    single canonical helper every repo-scoping join site reads (the merged-audit
+    checking gather and the waiting-lane covering-CLEAR match). A CLEAR whose repo
+    cannot be resolved (a workstream slug with no ticket ``issue_url`` and no
+    clone origin) yields ``""`` so a repo-scoping caller drops it, instead of
+    surfacing the fail-closed :class:`MergePreconditionError`.
+    """
+    try:
+        return resolve_pr_repo_slug(clear)
+    except MergePreconditionError:
+        return ""
+
+
 def normalize_repo_slug(value: str) -> str:
     """Canonicalize *value* UP to a GitHub ``owner/repo`` slug, or ``""``.
 

--- a/src/teatree/core/waiting.py
+++ b/src/teatree/core/waiting.py
@@ -26,6 +26,7 @@ import enum
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 
+from django.db.models import Q
 from django.utils import timezone
 
 from teatree.core.models.deferred_question import DeferredQuestion
@@ -104,12 +105,19 @@ def _question_entries(now: datetime) -> list[WaitingEntry]:
 
 
 def _merge_authorization_entries(now: datetime, overlay: str) -> list[WaitingEntry]:
-    prs = PullRequest.objects.filter(state=PullRequest.State.APPROVED).select_related("ticket")
+    prs = list(PullRequest.objects.filter(state=PullRequest.State.APPROVED).select_related("ticket"))
     if overlay:
-        prs = prs.filter(overlay__in=[overlay, ""])
+        prs = [pr for pr in prs if pr.overlay in {overlay, ""}]
+    if not prs:
+        return []
+    # One grouped supersede read for the whole set — global scope so a
+    # ticket-less CLEAR's siblings are seen regardless of overlay (#21).
+    from teatree.core.factory_signal_queries import superseding_context  # noqa: PLC0415 — deferred intra-core edge
+
+    latest_issued, merged_keys = superseding_context("")
     entries: list[WaitingEntry] = []
     for pr in prs:
-        if _has_covering_clear(pr):
+        if _has_covering_clear(pr, latest_issued, merged_keys):
             continue
         waited_from = pr.review_requested_at or pr.create_verified_at or now
         entries.append(
@@ -123,14 +131,41 @@ def _merge_authorization_entries(now: datetime, overlay: str) -> list[WaitingEnt
     return entries
 
 
-def _has_covering_clear(pr: PullRequest) -> bool:
-    """True iff an unconsumed, actionable CLEAR already authorises *pr*'s merge."""
+def _has_covering_clear(
+    pr: PullRequest,
+    latest_issued: dict[tuple[str, int], datetime],
+    merged_keys: set[tuple[str, int]],
+) -> bool:
+    """True iff an unconsumed, actionable, non-superseded, repo-matching CLEAR authorises *pr*.
+
+    Matches coverage the way the merge gate does (#21): a ticket-less
+    ``t3 <overlay> ticket clear`` CLEAR (``ticket IS NULL``) covers alongside a
+    ticket-linked one, and each candidate must resolve to *pr*'s own repo —
+    ``pr_id`` alone collides across repos. A CLEAR the merge loop has moved
+    past (a strictly-newer sibling, or a covering merge) is excluded via the
+    SAME :func:`~teatree.core.factory_signal_queries.clear_is_superseded`
+    predicate S4 applies, so the waiting lane and the staleness trip never
+    diverge on the SIG-1 supersede semantics.
+    """
     try:
         pr_id = int(pr.iid)
     except (TypeError, ValueError):
         return False
-    clears = MergeClear.objects.filter(ticket=pr.ticket, pr_id=pr_id, consumed_at__isnull=True)
-    return any(clear.is_actionable() for clear in clears)
+    from teatree.core.factory_signal_queries import clear_is_superseded  # noqa: PLC0415 — deferred intra-core edge
+    from teatree.core.merge import normalize_repo_slug, resolved_repo_slug  # noqa: PLC0415 — deferred merge edge
+
+    pr_repo = normalize_repo_slug(pr.repo)
+    clears = (
+        MergeClear.objects.filter(pr_id=pr_id, consumed_at__isnull=True)
+        .filter(Q(ticket=pr.ticket) | Q(ticket__isnull=True))
+        .select_related("ticket")
+    )
+    for clear in clears:
+        if not clear.is_actionable() or clear_is_superseded(clear, latest_issued, merged_keys):
+            continue
+        if pr_repo and normalize_repo_slug(resolved_repo_slug(clear)) == pr_repo:
+            return True
+    return False
 
 
 def _review_request_entries(now: datetime, overlay: str) -> list[WaitingEntry]:

--- a/src/teatree/loop/domain_jobs.py
+++ b/src/teatree/loop/domain_jobs.py
@@ -39,6 +39,7 @@ from teatree.loop.scanners import (
     MyPrsScanner,
     OutboundAuditScanner,
     PendingTasksScanner,
+    PrApprovalScanner,
     RedCardScanner,
     ReviewerPrsScanner,
     ReviewNagScanner,
@@ -505,6 +506,11 @@ def _inbound_messaging_jobs(messaging: MessagingBackend, tag: str) -> list[_Scan
         # drain reactions; this one only cares about ``:red_circle:`` /
         # ``:no_entry_sign:`` plus the literal phrase in DMs.
         _ScannerJob(scanner=RedCardScanner(backend=messaging, overlay=tag), overlay=tag),
+        # #8: forge-approval poll that revives the M7 merge_authorization
+        # waiting lane — drives REVIEW_REQUESTED PRs to APPROVED so the
+        # waiting-digest DM + the (on-behalf-gated) #961 approval reaction fire.
+        # Resolves its own code host from the overlay; no messaging dependency.
+        _ScannerJob(scanner=PrApprovalScanner(overlay=tag), overlay=tag),
     ]
 
 

--- a/src/teatree/loop/scanners/__init__.py
+++ b/src/teatree/loop/scanners/__init__.py
@@ -29,6 +29,7 @@ from teatree.loop.scanners.notion_view import NotionViewScanner
 from teatree.loop.scanners.outbound_audit import OutboundAuditScanner
 from teatree.loop.scanners.pane_reaper import PaneReaperScanner
 from teatree.loop.scanners.pending_tasks import PendingTasksScanner
+from teatree.loop.scanners.pr_approvals import PrApprovalScanner
 from teatree.loop.scanners.pr_sweep import PrSweepScanner
 from teatree.loop.scanners.pr_sweep_adapters import (
     AutoReviewTaskDispatcher,
@@ -90,6 +91,7 @@ __all__ = [
     "OutboundAuditScanner",
     "PaneReaperScanner",
     "PendingTasksScanner",
+    "PrApprovalScanner",
     "PrSweepScanner",
     "ProvisionSmokeScanner",
     "PullMainCloneScanner",

--- a/src/teatree/loop/scanners/gitlab_approvals.py
+++ b/src/teatree/loop/scanners/gitlab_approvals.py
@@ -21,9 +21,9 @@ Design notes
     ``Ticket.extra['last_approval_sha']``; a second tick whose payload
     carries the same head SHA is a no-op. A new push (different head SHA)
     resets the window — approval must be re-acquired on the new commit.
-* GitHub silently skipped. ``CodeHostBackend.get_mr_approvals`` raises
-    ``NotImplementedError`` on the GitHub backend; the scanner catches and
-    skips so a mixed-host overlay does not surface an error per tick.
+* GitHub silently skipped. The URL filter (:func:`is_gitlab_mr_url`) drops a
+    GitHub PR before any approval call, so a mixed-host overlay never pays the
+    round-trip — the merge signal this scanner drives is GitLab-only.
 """
 
 import logging
@@ -104,10 +104,9 @@ class GitLabApprovalsScanner:
     def _scan_one(self, pr: RawAPIDict) -> ScanSignal | None:
         # GitLab MRs carry a numeric ``iid`` and a ``project`` reference;
         # GitHub PRs carry a ``number`` and an ``html_url`` shape. The
-        # scanner only meaningfully runs against GitLab — GitHub backends
-        # raise NotImplementedError on ``get_mr_approvals`` and we skip
-        # silently. Differentiating on the URL host avoids paying the
-        # round-trip to discover that.
+        # scanner only drives the GitLab auto-merge signal, so a GitHub PR is
+        # dropped here by the URL host filter — never reaching the approval
+        # call, which is why differentiating on the URL avoids the round-trip.
         url = _str_field(pr, "web_url", "html_url")
         ref = pr_ref(url) if url else None
         repo_slug = ref.slug if ref is not None and ref.host_kind == "gitlab" else ""
@@ -118,9 +117,9 @@ class GitLabApprovalsScanner:
 
         approvals = self._fetch_approvals(repo_slug, iid)
         if approvals is None or approvals["approvals_left"] > 0:
-            # ``None`` → backend skipped (NotImplementedError or transient
-            # error). ``approvals_left > 0`` → not approved yet; the
-            # not-yet-approved case is steady state, not "blocked".
+            # ``None`` → a transient error swallowed per-MR. ``approvals_left
+            # > 0`` → not approved yet; the not-yet-approved case is steady
+            # state, not "blocked".
             return None
 
         # Approved. Idempotency gate: same head SHA as the last emission?
@@ -145,22 +144,19 @@ class GitLabApprovalsScanner:
         return signal
 
     def _fetch_approvals(self, repo_slug: str, iid: int) -> ApprovalState | None:
-        """Fetch approvals; return ``None`` on backend skip, raise on auth failure.
+        """Fetch approvals; return ``None`` on a transient defect, raise on auth failure.
 
-        Three outcomes. ``NotImplementedError`` becomes ``None`` (GitHub
-        stubs ``get_mr_approvals``; the URL filter usually drops these
-        before the call, this is the belt-and-braces case). An
-        ``httpx.HTTPStatusError`` or any other ``httpx.HTTPError`` is
-        translated into ``ScannerError`` so the dispatcher records the
-        error and DMs the user (#1287) — the previous ``return None``
-        silently converted a 401 into "not approved yet". Anything else
-        is logged and returned as ``None`` so a transient defect on one
-        MR does not break the scan for the others.
+        Only reached for a GitLab MR URL (the ``_scan_one`` host filter drops a
+        GitHub PR first), so ``get_mr_approvals`` is always the live GitLab
+        implementation here. An ``httpx.HTTPStatusError`` or any other
+        ``httpx.HTTPError`` is translated into ``ScannerError`` so the dispatcher
+        records the error and DMs the user (#1287) — the previous ``return None``
+        silently converted a 401 into "not approved yet". Anything else is
+        logged and returned as ``None`` so a transient defect on one MR does not
+        break the scan for the others.
         """
         try:
             return self.host.get_mr_approvals(repo=repo_slug, pr_iid=iid)
-        except NotImplementedError:
-            return None
         except ScannerError:
             raise
         except httpx.HTTPStatusError as exc:

--- a/src/teatree/loop/scanners/pr_approvals.py
+++ b/src/teatree/loop/scanners/pr_approvals.py
@@ -1,0 +1,121 @@
+"""Poll ``REVIEW_REQUESTED`` PRs for forge approval — revives the M7 lane (#8).
+
+No production path ever transitioned a :class:`~teatree.core.models.pull_request.PullRequest`
+to ``APPROVED``, so the whole merge_authorization waiting lane — the waiting-digest
+DM, the statusline count, and the #961 approval check-mark reaction — was
+structurally cold. This scanner is that missing producer: every tick it reads each
+``REVIEW_REQUESTED``, unmerged PR row's live forge approval (GitHub
+``reviewDecision`` / GitLab approvals endpoint) via :func:`sync_forge_approvals`
+(co-located below) and drives an approved one to ``APPROVED``.
+
+Outbound-gating floor: the ``approve`` transition fires the #961 approval
+check-mark reaction, a colleague-visible Slack post routed through the on-behalf
+gate. At default settings (``on_behalf_post_mode = draft_or_ask``) the reaction is
+SKIPPED, so this revived lane sends nothing unsanctioned — only the FSM state
+change and the best-effort bot→user waiting-digest self-DM (posted by the global
+``WaitingDigestScanner``) happen at default. The forge approval read is a plain
+GET, never a write.
+
+The scanner resolves its code host from its overlay (:func:`code_host_from_overlay`)
+so it can be registered through the shared single-overlay messaging builder
+(:func:`~teatree.loop.domain_jobs._inbound_messaging_jobs`) without a per-host
+fan-out; an explicit ``host`` may be injected for tests.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from teatree.loop.scanners.base import ScanSignal
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from teatree.core.backend_protocols import CodeHostBackend
+    from teatree.core.models import PullRequest
+
+logger = logging.getLogger(__name__)
+
+
+def sync_forge_approvals(host: "CodeHostBackend", prs: "Iterable[PullRequest]") -> "list[PullRequest]":
+    """Drive each forge-approved ``REVIEW_REQUESTED`` PR to ``APPROVED`` (#8).
+
+    The first production path that ever transitions a
+    :class:`~teatree.core.models.pull_request.PullRequest` to ``APPROVED`` —
+    reviving the M7 merge_authorization waiting lane that was cold because
+    nothing wrote that state. For each unmerged ``REVIEW_REQUESTED`` row it
+    reads the live forge approval (``host.get_mr_approvals``: GitHub
+    ``reviewDecision`` / GitLab approvals endpoint) and calls ``row.approve()``
+    when the forge threshold is satisfied.
+
+    The ``approve`` transition fires the #961 approval check-mark reaction, a
+    colleague-visible Slack post routed through the on-behalf gate — at default
+    settings it is SKIPPED, so this revival sends nothing unsanctioned. Per-row
+    isolation: an auth failure, a deleted PR, or a refused transition is logged
+    and skipped so one bad row never aborts the others. Returns the rows newly
+    transitioned to ``APPROVED``.
+    """
+    from teatree.core.models import PullRequest  # noqa: PLC0415 — deferred: Django-backed read
+
+    approved: list[PullRequest] = []
+    for row in prs:
+        if row.state != PullRequest.State.REVIEW_REQUESTED:
+            continue
+        try:
+            pr_iid = int(row.iid)
+        except (TypeError, ValueError):
+            continue
+        try:
+            state = host.get_mr_approvals(repo=row.repo, pr_iid=pr_iid)
+            if state["approvals_left"] > 0:
+                continue
+            row.approve()
+            row.save()
+        except Exception:
+            logger.exception("forge-approval sync failed for %s — skipping", row.url)
+            continue
+        approved.append(row)
+    return approved
+
+
+@dataclass(slots=True)
+class PrApprovalScanner:
+    """Emit ``pr.approved`` and drive forge-approved review-requested PRs to ``APPROVED``.
+
+    ``overlay`` scopes which PR rows are polled (an empty overlay is the
+    single-overlay default); ``host`` is resolved from the overlay at scan time
+    unless injected.
+    """
+
+    overlay: str = ""
+    host: "CodeHostBackend | None" = field(default=None)
+    name: str = "pr_approvals"
+
+    def scan(self) -> list[ScanSignal]:
+        from teatree.core.models import PullRequest  # noqa: PLC0415 — deferred: Django-backed read
+
+        host = self.host or self._resolve_host()
+        if host is None:
+            return []
+        rows = list(PullRequest.objects.filter(state=PullRequest.State.REVIEW_REQUESTED).select_related("ticket"))
+        if self.overlay:
+            rows = [row for row in rows if row.overlay in {self.overlay, ""}]
+        if not rows:
+            return []
+        return [
+            ScanSignal(
+                kind="pr.approved",
+                summary=f"forge-approved: {row.repo}#{row.iid}",
+                payload={"url": row.url, "repo": row.repo, "iid": row.iid, "overlay": row.overlay},
+            )
+            for row in sync_forge_approvals(host, rows)
+        ]
+
+    def _resolve_host(self) -> "CodeHostBackend | None":
+        from teatree.core.backend_factory import code_host_from_overlay  # noqa: PLC0415 — needs django.setup()
+
+        try:
+            return code_host_from_overlay(self.overlay or None)
+        except Exception:
+            logger.exception("PrApprovalScanner: could not resolve a code host for overlay %r", self.overlay)
+            return None

--- a/tests/quality/deferred_import_pegs.toml
+++ b/tests/quality/deferred_import_pegs.toml
@@ -84,7 +84,8 @@
 "src/teatree/core/views/_rate_limit.py" = 1
 # #8 M7 revival: the waiting-lane covering-CLEAR match reads the shared SIG-1
 # supersede helper (superseding_context / clear_is_superseded) and the promoted
-# repo resolver — deferred to keep waiting.py light and free of an intra-core cycle.
+# repo resolver — deferred for import-weight (merge/__init__ pulls the whole merge
+# subtree, factory_signal_queries the signal stack) to keep waiting.py light.
 "src/teatree/core/waiting.py" = 3
 "src/teatree/core/worktree_tasks.py" = 1
 

--- a/tests/quality/deferred_import_pegs.toml
+++ b/tests/quality/deferred_import_pegs.toml
@@ -82,6 +82,10 @@
 "src/teatree/core/sync.py" = 3
 "src/teatree/core/tasks.py" = 5
 "src/teatree/core/views/_rate_limit.py" = 1
+# #8 M7 revival: the waiting-lane covering-CLEAR match reads the shared SIG-1
+# supersede helper (superseding_context / clear_is_superseded) and the promoted
+# repo resolver — deferred to keep waiting.py light and free of an intra-core cycle.
+"src/teatree/core/waiting.py" = 3
 "src/teatree/core/worktree_tasks.py" = 1
 
 [intra_loop]

--- a/tests/teatree_core/test_waiting.py
+++ b/tests/teatree_core/test_waiting.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 import pytest
 
 from teatree.core.models.deferred_question import DeferredQuestion
-from teatree.core.models.merge_clear import ClearRequest, MergeClear
+from teatree.core.models.merge_clear import ClearRequest, MergeAudit, MergeClear
 from teatree.core.models.pull_request import PullRequest
 from teatree.core.models.review_assignment import ReviewAssignment, ReviewIntent
 from teatree.core.models.ticket import Ticket
@@ -123,6 +123,69 @@ class TestOverlayScoping:
         pr.approve()
         pr.save()
         assert _kinds("") == [WaitingKind.MERGE_AUTHORIZATION]
+
+
+# ast-grep-ignore: ac-django-no-pytest-django-db
+@pytest.mark.django_db
+class TestCoveringClearHonorsTicketlessRepoScopedAndSupersede:
+    """#21: the covering-CLEAR match honours ticket-less CLEARs, repo scoping, and supersede."""
+
+    def _approved_pr(self, *, repo: str = "o/r", iid: str = "5") -> tuple[Ticket, PullRequest]:
+        ticket = Ticket.objects.create(overlay="teatree", issue_url="https://x/50")
+        pr = PullRequest.objects.create(
+            ticket=ticket,
+            overlay="teatree",
+            url=f"https://github.com/{repo}/pull/{iid}",
+            repo=repo,
+            iid=iid,
+        )
+        pr.request_review()
+        pr.approve()
+        pr.save()
+        return ticket, pr
+
+    def test_ticketless_repo_matching_clear_covers(self) -> None:
+        """A ticket-less ``t3 ticket clear`` for the PR's repo suppresses the nag (RED pre-fix)."""
+        _ticket, _pr = self._approved_pr()
+        MergeClear.issue(
+            ClearRequest(pr_id=5, slug="o/r", reviewed_sha="a" * 40, reviewer_identity="cold-reviewer", ticket=None)
+        )
+        assert WaitingKind.MERGE_AUTHORIZATION not in _kinds("teatree")
+
+    def test_clear_for_a_different_repo_does_not_cover(self) -> None:
+        """A ticket-linked CLEAR with the same pr_id but a FOREIGN repo must NOT cover (RED pre-fix)."""
+        ticket, _pr = self._approved_pr()
+        MergeClear.issue(
+            ClearRequest(
+                pr_id=5, slug="other/repo", reviewed_sha="a" * 40, reviewer_identity="cold-reviewer", ticket=ticket
+            )
+        )
+        assert WaitingKind.MERGE_AUTHORIZATION in _kinds("teatree")
+
+    def test_superseded_by_merge_clear_does_not_cover(self) -> None:
+        """An orphaned CLEAR whose (slug, pr_id) already merged is superseded — surfaced, not covered (RED pre-fix)."""
+        ticket, _pr = self._approved_pr()
+        # The live-but-orphaned CLEAR: ticket-linked, repo-matching, actionable —
+        # it clears every pre-supersede check, so ONLY the shared supersede
+        # predicate keeps it from falsely covering the PR.
+        MergeClear.issue(
+            ClearRequest(pr_id=5, slug="o/r", reviewed_sha="a" * 40, reviewer_identity="cold-reviewer", ticket=ticket)
+        )
+        merged = MergeClear.issue(
+            ClearRequest(pr_id=5, slug="o/r", reviewed_sha="b" * 40, reviewer_identity="cold-reviewer", ticket=ticket)
+        )
+        merged.consumed_at = merged.issued_at
+        merged.save(update_fields=["consumed_at"])
+        MergeAudit.objects.create(clear=merged, merged_sha="b" * 40, required_checks_status="green")
+        assert WaitingKind.MERGE_AUTHORIZATION in _kinds("teatree")
+
+    def test_non_superseded_ticket_linked_clear_still_covers(self) -> None:
+        """Positive control: a live ticket-linked repo-matching CLEAR still suppresses the nag."""
+        ticket, _pr = self._approved_pr()
+        MergeClear.issue(
+            ClearRequest(pr_id=5, slug="o/r", reviewed_sha="a" * 40, reviewer_identity="cold-reviewer", ticket=ticket)
+        )
+        assert WaitingKind.MERGE_AUTHORIZATION not in _kinds("teatree")
 
 
 class TestFormatAge:

--- a/tests/teatree_loop/scanners/test_pr_approvals.py
+++ b/tests/teatree_loop/scanners/test_pr_approvals.py
@@ -1,0 +1,153 @@
+"""Tests for ``PrApprovalScanner`` — revives the M7 merge_authorization lane (#8).
+
+Anti-vacuity: the scanner emits an approval signal on a real forge-approval
+payload (RED if the lane stays cold), and the twin — a not-yet-approved PR —
+emits nothing. Outbound-gating floor: the revived ``approve`` transition's #961
+Slack reaction does NOT fire at default settings (the on-behalf gate is ON) and
+DOES fire when the gate is lifted.
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+import teatree.core.signals as signals_mod
+from teatree.core.backend_protocols import ApprovalState
+from teatree.core.models.pull_request import PullRequest
+from teatree.core.models.ticket import Ticket
+from teatree.loop.scanners.pr_approvals import PrApprovalScanner, sync_forge_approvals
+from tests.teatree_core._on_behalf_gate_helpers import mode_immediate_cm
+
+
+class _ApprovedHost:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int]] = []
+
+    def get_mr_approvals(self, *, repo: str, pr_iid: int) -> ApprovalState:
+        self.calls.append((repo, pr_iid))
+        return ApprovalState(approvals_left=0, approved_by=[], unresolved_resolvable=0)
+
+
+class _UnapprovedHost:
+    def get_mr_approvals(self, *, repo: str, pr_iid: int) -> ApprovalState:
+        return ApprovalState(approvals_left=1, approved_by=[], unresolved_resolvable=0)
+
+
+class _RaisingHost:
+    def get_mr_approvals(self, *, repo: str, pr_iid: int) -> ApprovalState:
+        msg = "forge is down"
+        raise RuntimeError(msg)
+
+
+class _FakeReactionPublisher:
+    def __init__(self) -> None:
+        self.approval_calls: list[object] = []
+
+    def add_reactions_for_transition(self, ticket: object, transition_name: str) -> int:
+        return 0
+
+    def add_approval_reaction(self, pull_request: object) -> int:
+        self.approval_calls.append(pull_request)
+        return 1
+
+
+class _PrApprovalScannerTestBase(TestCase):
+    def _review_requested_pr(self, *, repo: str = "o/r", iid: str = "7") -> PullRequest:
+        ticket = Ticket.objects.create(overlay="teatree", issue_url="https://x/70")
+        pr = PullRequest.objects.create(
+            ticket=ticket, overlay="teatree", url=f"https://github.com/{repo}/pull/{iid}", repo=repo, iid=iid
+        )
+        pr.request_review()
+        pr.save()
+        return pr
+
+
+class TestPrApprovalScannerEmitsSignal(_PrApprovalScannerTestBase):
+    def test_forge_approved_pr_emits_pr_approved_signal(self) -> None:
+        pr = self._review_requested_pr()
+
+        with mode_immediate_cm():
+            signals = PrApprovalScanner(overlay="teatree", host=_ApprovedHost()).scan()
+
+        assert [s.kind for s in signals] == ["pr.approved"]
+        assert signals[0].payload["url"] == pr.url
+        pr.refresh_from_db()
+        assert pr.state == PullRequest.State.APPROVED
+
+    def test_unapproved_pr_emits_nothing(self) -> None:
+        pr = self._review_requested_pr()
+
+        signals = PrApprovalScanner(overlay="teatree", host=_UnapprovedHost()).scan()
+
+        assert signals == []
+        pr.refresh_from_db()
+        assert pr.state == PullRequest.State.REVIEW_REQUESTED
+
+    def test_no_review_requested_rows_is_a_noop(self) -> None:
+        assert PrApprovalScanner(overlay="teatree", host=_ApprovedHost()).scan() == []
+
+
+class TestPrApprovalScannerOutboundGating(_PrApprovalScannerTestBase):
+    """The revived lane must not fire the #961 approval reaction at default settings."""
+
+    def test_no_reaction_when_gate_on_default(self) -> None:
+        pr = self._review_requested_pr()
+        publisher = _FakeReactionPublisher()
+
+        # Gate ON (default draft_or_ask) — no recorded approval → the reaction
+        # is skipped even though the PR does transition to APPROVED.
+        with patch.object(signals_mod, "get_reaction_publisher", lambda: publisher):
+            PrApprovalScanner(overlay="teatree", host=_ApprovedHost()).scan()
+
+        pr.refresh_from_db()
+        assert pr.state == PullRequest.State.APPROVED
+        assert publisher.approval_calls == []
+
+    def test_reaction_fires_when_gate_lifted(self) -> None:
+        pr = self._review_requested_pr()
+        publisher = _FakeReactionPublisher()
+
+        with mode_immediate_cm(), patch.object(signals_mod, "get_reaction_publisher", lambda: publisher):
+            PrApprovalScanner(overlay="teatree", host=_ApprovedHost()).scan()
+
+        assert publisher.approval_calls == [pr]
+
+
+class TestSyncForgeApprovals(_PrApprovalScannerTestBase):
+    """#8: the pure per-row sync helper — the first production writer of APPROVED."""
+
+    def test_forge_approved_pr_transitions_to_approved(self) -> None:
+        pr = self._review_requested_pr()
+        host = _ApprovedHost()
+
+        with mode_immediate_cm():
+            approved = sync_forge_approvals(host, [pr])
+
+        assert [row.pk for row in approved] == [pr.pk]
+        pr.refresh_from_db()
+        assert pr.state == PullRequest.State.APPROVED
+        assert host.calls == [("o/r", 7)]
+
+    def test_unapproved_pr_stays_review_requested(self) -> None:
+        pr = self._review_requested_pr()
+
+        assert sync_forge_approvals(_UnapprovedHost(), [pr]) == []
+        pr.refresh_from_db()
+        assert pr.state == PullRequest.State.REVIEW_REQUESTED
+
+    def test_non_review_requested_rows_are_skipped(self) -> None:
+        ticket = Ticket.objects.create(overlay="teatree", issue_url="https://x/71")
+        open_pr = PullRequest.objects.create(
+            ticket=ticket, overlay="teatree", url="https://github.com/o/r/pull/12", repo="o/r", iid="12"
+        )
+        host = _ApprovedHost()
+
+        assert sync_forge_approvals(host, [open_pr]) == []
+        assert host.calls == []  # never polled — not in REVIEW_REQUESTED
+
+    def test_forge_error_isolated_per_row(self) -> None:
+        pr = self._review_requested_pr()
+
+        assert sync_forge_approvals(_RaisingHost(), [pr]) == []
+        pr.refresh_from_db()
+        assert pr.state == PullRequest.State.REVIEW_REQUESTED

--- a/tests/teatree_loop/test_gitlab_approvals_scanner.py
+++ b/tests/teatree_loop/test_gitlab_approvals_scanner.py
@@ -37,7 +37,6 @@ class FakeCodeHost:
     my_prs: list[RawAPIDict] = field(default_factory=list)
     approvals: dict[tuple[str, int], ApprovalState] = field(default_factory=dict)
     approval_calls: list[tuple[str, int]] = field(default_factory=list)
-    raise_not_implemented: bool = False
 
     def current_user(self) -> str:
         return self.user
@@ -88,9 +87,6 @@ class FakeCodeHost:
 
     def get_mr_approvals(self, *, repo: str, pr_iid: int) -> ApprovalState:
         self.approval_calls.append((repo, pr_iid))
-        if self.raise_not_implemented:
-            msg = "GitHub stub"
-            raise NotImplementedError(msg)
         return self.approvals.get(
             (repo, pr_iid),
             ApprovalState(approvals_left=1, approved_by=[], unresolved_resolvable=0),
@@ -279,27 +275,11 @@ class TestGitLabApprovalsScanner(TestCase):
         ticket = Ticket.objects.get(issue_url=url)
         assert ticket.extra["last_approval_sha"] == "sha-2"
 
-    def test_github_backend_silently_skipped(self) -> None:
-        """``get_mr_approvals`` raising NotImplementedError → scanner skips the PR."""
-        host = FakeCodeHost(
-            raise_not_implemented=True,
-            my_prs=[_gitlab_mr(iid=48, sha="ddd444")],
-        )
-        scanner = GitLabApprovalsScanner(host=host)
-
-        signals = scanner.scan()
-
-        assert signals == []
-        # The scanner must still have CALLED the backend — silent skip, not
-        # short-circuit. This catches a regression where a future "only call
-        # GitLab backends" filter forgets to call the unknown ones at all.
-        assert host.approval_calls == [("acme/backend", 48)]
-
     def test_github_url_pattern_skipped_without_backend_call(self) -> None:
         """GitHub PR URLs (``/pull/`` shape) are filtered out before the backend call.
 
         This keeps a mixed-host overlay from paying a backend round-trip per
-        tick to discover that the GitHub backend raises NotImplementedError.
+        tick — the GitLab auto-merge signal this scanner drives is GitLab-only.
         """
         host = FakeCodeHost(
             my_prs=[

--- a/tests/teatree_loops/test_mini_loop_jobs.py
+++ b/tests/teatree_loops/test_mini_loop_jobs.py
@@ -163,12 +163,13 @@ class TestInboxLoopBuildJobs:
 
     def test_single_overlay_messaging_path(self, stub_messaging: Any) -> None:
         jobs = INBOX_LOOP.build_jobs(messaging=stub_messaging)
-        # mentions, dms, ask-reply, review_intent, red_card — the shared #23 SSOT
-        assert len(jobs) == 5
+        # mentions, dms, ask-reply, review_intent, red_card, pr_approvals — the shared #23 SSOT
+        assert len(jobs) == 6
         names = {j.scanner.name for j in jobs}
         assert "slack_mentions" in names
         assert "askuserquestion_reply" in names
         assert "red_card" in names
+        assert "pr_approvals" in names
 
     def test_with_notion_client_only(self) -> None:
         notion = MagicMock()

--- a/tests/test_github_backend.py
+++ b/tests/test_github_backend.py
@@ -2,6 +2,7 @@
 
 import json
 import subprocess
+from contextlib import AbstractContextManager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -21,6 +22,39 @@ from teatree.backends.github.api import (
 )
 from teatree.backends.github.projects import _gh_graphql
 from teatree.core.backend_protocols import PullRequestSpec
+
+
+class TestGetMrApprovals:
+    """GitHub aggregate ``reviewDecision`` mapped to an ``ApprovalState`` (#8)."""
+
+    def _run_gh_returning(self, stdout: str) -> AbstractContextManager[MagicMock]:
+        return patch.object(github_mod, "_run_gh", return_value=subprocess.CompletedProcess([], 0, stdout, ""))
+
+    def test_approved_decision_is_zero_approvals_left(self) -> None:
+        with self._run_gh_returning(json.dumps({"reviewDecision": "APPROVED"})) as mock_run:
+            state = GitHubCodeHost(token="tok").get_mr_approvals(repo="o/r", pr_iid=9)
+        assert state["approvals_left"] == 0
+        args = mock_run.call_args.args
+        assert args[:4] == ("gh", "pr", "view", "9")
+        assert "reviewDecision" in args
+
+    def test_non_approved_decision_is_positive_approvals_left(self) -> None:
+        with self._run_gh_returning(json.dumps({"reviewDecision": "REVIEW_REQUIRED"})):
+            state = GitHubCodeHost().get_mr_approvals(repo="o/r", pr_iid=9)
+        assert state["approvals_left"] == 1
+
+    def test_null_decision_is_not_approved(self) -> None:
+        # A PR requiring no review returns ``reviewDecision: null`` — never
+        # mis-read as merge-authorised.
+        with self._run_gh_returning(json.dumps({"reviewDecision": None})):
+            state = GitHubCodeHost().get_mr_approvals(repo="o/r", pr_iid=9)
+        assert state["approvals_left"] == 1
+
+    def test_unparsable_stdout_is_not_approved(self) -> None:
+        with self._run_gh_returning("not json"):
+            state = GitHubCodeHost().get_mr_approvals(repo="o/r", pr_iid=9)
+        assert state["approvals_left"] == 1
+        assert state["unresolved_resolvable"] == 0
 
 
 class TestIssueRepoShort:


### PR DESCRIPTION
Revives the cold M7 `merge_authorization` lane and fixes the waiting-lane covering-CLEAR match (integration-fix campaign slot 15, bugs #8 + #21).

## #8 — revive the M7 lane (no writer of `PullRequest.APPROVED`)

No production path ever transitioned a `PullRequest` to `APPROVED`, so the entire merge_authorization lane — the waiting-digest DM, the statusline count, and the #961 approval reaction — was structurally dead.

- **`GitHubCodeHost.get_mr_approvals`** — implemented via the aggregate `reviewDecision` (was `NotImplementedError`). `APPROVED` → `approvals_left=0`; anything else (incl. `null` / unparsable) → `1`, so a non-approved PR is never mis-read as merge-authorised.
- **`sync_forge_approvals`** — the first production writer of `APPROVED`: polls each `REVIEW_REQUESTED`, unmerged PR's live forge approval and calls `row.approve()`, per-row isolated. Lives in the scanner domain module so it stays below the orchestration layer the tach DAG enforces.
- **`PrApprovalScanner`** (new) — the tick producer wrapping `sync_forge_approvals`, emits `pr.approved`. Registered **through DIS-E's shared `_inbound_messaging_jobs` builder** (no re-fork), resolving its own code host from the overlay.

## Outbound Slack writes GATED — no unsanctioned sends at default

This lane lights up first-ever outbound writes from this path. Both are best-effort and behind the existing gate:

- The `approve` transition fires the #961 approval check-mark reaction, already routed through the on-behalf gate (`require_on_behalf_approval`). At default settings (`on_behalf_post_mode = draft_or_ask`) the reaction is **SKIPPED**; it fires only when the gate is lifted or an approval is recorded — proven by `TestPrApprovalScannerOutboundGating` (off → no publisher call; on → publisher called).
- The waiting-digest is a best-effort bot→user self-DM (`WaitingDigestScanner`), not colleague-visible. The forge approval read is a plain GET, never a write.

## #21 — repo-scoped, ticket-less, supersede-aware covering-CLEAR

`_has_covering_clear` now:
- honors ticket-less `t3 <overlay> ticket clear` CLEARs (`Q(ticket=pr.ticket) | Q(ticket__isnull=True)`),
- requires a per-CLEAR repo match via the promoted `resolved_repo_slug` (`pr_id` alone collides across repos),
- excludes a superseded CLEAR (a strictly-newer sibling, or a covering merge) via the **same `clear_is_superseded` predicate S4 applies** — SIG-1's `superseding_context` was promoted public + a shared predicate extracted, and S4 refactored to reuse it, so the waiting lane and the staleness trip can never diverge on the SIG-1 supersede semantics.

`resolved_repo_slug` promoted from `_checking_gather` to `pr_slug_resolution` (both call sites reuse it); `normalize_repo_slug` re-exported from `teatree.core.merge`. **No migration** (uses the existing PR FSM states).

## Architecture pre-check

1. **BLUEPRINT §** — §17.4 (merge keystone / CLEAR semantics), §5.6 (loop topology / scanners).
2. **FSM** — reuses the existing `PullRequest` FSM (`REVIEW_REQUESTED → approve → APPROVED`); no new state.
3. **Extension points** — extends the shared `_inbound_messaging_jobs` builder (both single-overlay and per-overlay fan-outs pick it up; parity pinned by `TestSingleOverlayMessagingParity`).
4. **Component boundaries** — scanner + its per-row sync helper live in the domain layer; the resolver/predicate reuse core-layer helpers.
5. **Dependency direction** — `tach check` green; the initial scanner→orchestration edge was removed by co-locating `sync_forge_approvals` in the scanner module.
6. **Test surface** — scanner emit / no-emit, sync-per-row, get_mr_approvals mapping, covering-CLEAR ticket-less/repo/supersede (RED-verified pre-fix), outbound gate off/on.
7. **Resilience** — per-row isolation + best-effort; outbound gated + idempotent (FSM one-way transition).
8. **Identity/keys** — one canonical `resolved_repo_slug`; supersede keyed on the shared `(slug, pr_id)`.
9. **Behavior preservation** — additive; no gate narrowed, no must-block test inverted.

## Verification

- Anti-vacuity: the three `_has_covering_clear` cases fail RED on pre-fix `waiting.py`, green after; `PrApprovalScanner` emits on a real forge-approval payload; outbound-gate off/on both proven.
- Green: `tests/quality`, `tests/conformance`, never-lockout contract, CLI-literals, module-health, `test-path-mirror`, `makemigrations --check` (no changes), all changed-file targeted suites, `tach check`, `ruff`, `ty`, banned-terms clean.
