### PR TITLE
fix(signals): t3 signals CLI leaf + scope field (CLI+MCP) + SIGNAL_LEDGER_PRODUCERS live-writer capstone + bidirectional capability walk (#13,#25,#26)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -4731,6 +4731,8 @@ Usage: t3 teatree [OPTIONS] COMMAND [ARGS]...
 │                 confirmed non-live (#2225).                                  │
 │ do              Walk a ticket through the lifecycle via each phase's         │
 │                 existing gate (PR-31).                                       │
+│ signals         Read-only factory quality/velocity signals over the trailing │
+│                 window (SIG-PR-1).                                           │
 │ agent           Launch Claude Code with overlay context and auto-detected    │
 │                 skills.                                                      │
 │ skill-preamble  Emit the inline SKILL.md preamble a raw Agent-tool sub-agent │
@@ -4859,6 +4861,15 @@ Usage: t3 teatree safe-kill [OPTIONS]
 Usage: t3 teatree do [OPTIONS]
 
  Walk a ticket through the lifecycle via each phase's existing gate (PR-31).
+```
+
+#### `t3 teatree signals`
+
+```
+Usage: t3 teatree signals [OPTIONS]
+
+ Read-only factory quality/velocity signals over the trailing window
+ (SIG-PR-1).
 ```
 
 #### `t3 teatree agent`

--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -15,6 +15,7 @@ import typer
 from teatree.agents.skill_injection import build_subagent_skill_preamble
 from teatree.cli.autonomy import register_autonomy_commands
 from teatree.cli.django_groups import DJANGO_GROUPS, DjangoGroup
+from teatree.cli.overlay_leaves import register_core_passthrough_leaves
 from teatree.cli.teatree_gate import register_gate_commands
 from teatree.cli.wip import register_wip_commands
 from teatree.skill_support.loading import DEFAULT_SKILLS_DIR
@@ -376,41 +377,7 @@ class OverlayAppBuilder:
             # Same as ``full-status``: ``followup`` is core-only (#1318).
             managepy_core("followup", "sync", overlay_name=overlay_name)
 
-        @overlay_app.command(
-            name="safe-kill",
-            context_settings={
-                "allow_extra_args": True,
-                "allow_interspersed_args": False,
-                "ignore_unknown_options": True,
-            },
-            add_help_option=False,
-        )
-        def safe_kill(ctx: typer.Context) -> None:
-            """Signal a pid only if it maps to a dead target AND is confirmed non-live (#2225)."""
-            # ``safe_kill`` is a teatree-CORE management command — dispatch via
-            # ``python -m teatree`` so an overlay clone with its own ``manage.py``
-            # does not crash with ``Unknown command`` (#1318). The pid argument
-            # and ``--hang-cause`` are forwarded verbatim.
-            managepy_core("safe_kill", *ctx.args, overlay_name=overlay_name)
-
-        @overlay_app.command(
-            name="do",
-            context_settings={
-                "allow_extra_args": True,
-                "allow_interspersed_args": False,
-                "ignore_unknown_options": True,
-            },
-            add_help_option=False,
-        )
-        def do(ctx: typer.Context) -> None:
-            """Walk a ticket through the lifecycle via each phase's existing gate (PR-31)."""
-            # ``do`` is a teatree-CORE management command that reads the canonical
-            # control DB the shipping gate consults, so it dispatches via
-            # ``python -m teatree`` (same #2925/#126 reasoning as ``pr``/``lifecycle``)
-            # — a cwd inside a ticket worktree must not resolve that worktree's own
-            # ``manage.py``. The ticket-ref, ``--plan`` and ``--json`` are forwarded
-            # verbatim; the faithful-child-exit bridge propagates its exit code.
-            managepy_core("do", *ctx.args, overlay_name=overlay_name)
+        register_core_passthrough_leaves(overlay_app, overlay_name)
 
         self._register_agent_command()
 

--- a/src/teatree/cli/overlay_leaves.py
+++ b/src/teatree/cli/overlay_leaves.py
@@ -1,0 +1,52 @@
+"""Overlay CLI leaves that forward their args verbatim to a ``teatree.core`` command.
+
+``safe-kill`` / ``do`` / ``signals`` are thin overlay shortcuts over same-named
+core management commands. Each accepts arbitrary trailing args and forwards them
+unparsed — the leaf never redeclares the command's own options. Split out of
+``overlay.py`` as its own concern (the near-identical registration boilerplate was
+triplicated inline there).
+"""
+
+import typer
+
+# A passthrough leaf takes arbitrary trailing args and never parses them itself.
+_CORE_PASSTHROUGH_CONTEXT: dict[str, bool] = {
+    "allow_extra_args": True,
+    "allow_interspersed_args": False,
+    "ignore_unknown_options": True,
+}
+
+# leaf name -> one-line help. A leaf name's hyphens map to the core command's
+# underscores (``safe-kill`` -> ``safe_kill``).
+_CORE_PASSTHROUGH_LEAVES: tuple[tuple[str, str], ...] = (
+    ("safe-kill", "Signal a pid only if it maps to a dead target AND is confirmed non-live (#2225)."),
+    ("do", "Walk a ticket through the lifecycle via each phase's existing gate (PR-31)."),
+    ("signals", "Read-only factory quality/velocity signals over the trailing window (SIG-PR-1)."),
+)
+
+
+def register_core_passthrough_leaves(overlay_app: typer.Typer, overlay_name: str) -> None:
+    """Register every core-passthrough leaf on *overlay_app*.
+
+    Each leaf dispatches to its same-named ``teatree.core`` management command via
+    ``python -m teatree`` (:func:`teatree.cli.overlay.managepy_core`), never the
+    overlay clone's own ``manage.py`` — a cwd inside a ticket worktree must not
+    resolve that worktree's ``manage.py`` (#1318). ``T3_OVERLAY_NAME`` is set on
+    the subprocess env so a scoped command (``signals``) reads this overlay; the
+    faithful-child-exit bridge propagates the child exit code.
+    """
+    for name, help_text in _CORE_PASSTHROUGH_LEAVES:
+        _register_leaf(overlay_app, overlay_name, name=name, help_text=help_text)
+
+
+def _register_leaf(overlay_app: typer.Typer, overlay_name: str, *, name: str, help_text: str) -> None:
+    @overlay_app.command(
+        name=name,
+        help=help_text,
+        context_settings=_CORE_PASSTHROUGH_CONTEXT,
+        add_help_option=False,
+    )
+    def _leaf(ctx: typer.Context) -> None:
+        from teatree.cli.overlay import managepy_core  # noqa: PLC0415 — deferred to avoid a load-time cycle
+
+        managepy_core(name.replace("-", "_"), *ctx.args, overlay_name=overlay_name)

--- a/src/teatree/core/capabilities.py
+++ b/src/teatree/core/capabilities.py
@@ -61,6 +61,7 @@ CAPABILITIES: tuple[Capability, ...] = (
     ),
     Capability("teatree availability show", json_output=True, exit_codes=("0",)),
     Capability("teatree questions list", json_output=True, exit_codes=("0",)),
+    Capability("teatree signals", json_output=True, exit_codes=("0",)),
     Capability(
         "teatree workspace emit",
         json_output=True,

--- a/src/teatree/core/factory_signals.py
+++ b/src/teatree/core/factory_signals.py
@@ -121,15 +121,27 @@ class SignalRow:
 
 @dataclass(frozen=True, slots=True)
 class FactorySignalsReport:
-    """The composed read-only report over the trailing window vs its baseline."""
+    """The composed read-only report over the trailing window vs its baseline.
+
+    ``overlay`` is the SCOPE the reading was computed under — the overlay name a
+    ``t3 <overlay> signals`` / ``factory_signals(overlay=…)`` call scoped to, or
+    ``""`` for the whole-factory global view. It is stamped in ``to_dict()`` and
+    the ``to_markdown()`` header so the CLI and MCP surfaces are self-describing:
+    a consumer can tell an overlay-scoped reading from a global one from the
+    output alone (#25). The two surfaces are held identical by the named
+    ``tests/conformance/test_signals_scope_parity.py`` lane, not by a docstring
+    promise.
+    """
 
     window_days: int
     generated_at: datetime
     signals: list[SignalRow]
     verdict: SignalVerdict
+    overlay: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return {
+            "overlay": self.overlay,
             "window_days": self.window_days,
             "generated_at": self.generated_at.isoformat(),
             "verdict": self.verdict.value,
@@ -137,7 +149,8 @@ class FactorySignalsReport:
         }
 
     def to_markdown(self) -> str:
-        header = f"## Factory signals (window {self.window_days}d) — verdict: {self.verdict.value}"
+        scope = self.overlay or "global"
+        header = f"## Factory signals (scope: {scope}, window {self.window_days}d) — verdict: {self.verdict.value}"
         lines = [header, "", "| signal | value | sample | status | verdict | baseline |", "|---|---|---|---|---|---|"]
         for row in self.signals:
             baseline = "—" if row.baseline_value is None else f"{row.baseline_value:.3f}"
@@ -330,4 +343,5 @@ def compute_factory_signals(
         generated_at=resolved,
         signals=rows,
         verdict=_aggregate_verdict(rows),
+        overlay=overlay,
     )

--- a/src/teatree/mcp/search.py
+++ b/src/teatree/mcp/search.py
@@ -145,11 +145,20 @@ def factory_signals(*, overlay: str | None = None, window_days: int = DEFAULT_WI
     """The derived-on-read factory quality/velocity signals report (read-only).
 
     Delegates to :func:`teatree.core.factory_signals.compute_factory_signals` —
-    the same computation path ``t3 <overlay> signals`` uses, so the CLI and MCP
-    surfaces can never drift. Returns the report's ``to_dict()``: the trailing
-    window's five signals (first-try-green, defect-escape, review-catch,
-    merge-latency, repair-burn) with their fail-loud statuses, red-floor trips,
-    and the top-level verdict the outer loop keys on.
+    the same computation path ``t3 <overlay> signals`` uses. Returns the report's
+    ``to_dict()``: the ``overlay`` scope, the trailing window's five signals
+    (first-try-green, defect-escape, review-catch, merge-latency, repair-burn)
+    with their fail-loud statuses, red-floor trips, and the top-level verdict the
+    outer loop keys on.
+
+    Scope: an omitted ``overlay`` means the whole-factory GLOBAL view (``""``) —
+    where the CLI reads ``T3_OVERLAY_NAME`` and scopes to the active overlay,
+    this MCP tool defaults global unless the caller passes one. Both surfaces now
+    stamp the resolved scope in the payload's ``overlay`` field so a global
+    reading is distinguishable from a scoped one from the output alone (#25). The
+    two surfaces are held schema-identical by the named
+    ``tests/conformance/test_signals_scope_parity.py`` lane — the parity guard
+    that replaced the earlier unenforced "can never drift" docstring claim.
     """
     report = compute_factory_signals(window_days=window_days, overlay=overlay or "")
     return report.to_dict()

--- a/tests/conformance/test_capability_surface_walk.py
+++ b/tests/conformance/test_capability_surface_walk.py
@@ -1,0 +1,217 @@
+"""Bidirectional capability walk-the-surface — the two-way anti-drift guard (SIG-4, #26).
+
+The pre-#13 ``CAPABILITIES`` registry guard was one-directional: it caught a
+registry entry that over-claimed JSON, but never an omission — a command that
+emits JSON on the real surface yet is absent from the registry. That is exactly
+how ``teatree signals --json`` shipped: neither in ``CAPABILITIES`` nor
+discoverable, so a front-end reading ``t3 capabilities`` could not find it.
+
+This walks the REAL command surface both ways. Forward (registry -> surface):
+every ``CAPABILITIES`` entry resolves to a live command in the actual click tree,
+and every ``json:true`` switch entry's command declares a ``--json`` / ``--format``
+option — a phantom or renamed entry fails. Reverse (surface -> registry): every
+``teatree.core`` management command that declares a ``--json`` / ``--format`` switch
+is EITHER in ``CAPABILITIES`` or in a named allowlist of intentional exclusions — a
+NEW json surface (like ``signals`` was) fails loudly until a conscious
+register-or-exclude decision is made.
+
+Scope of the reverse walk is the ``teatree.core`` management-command surface — the
+front-end machine seam ``CAPABILITIES`` documents. The operator/loop dev tooling
+(``t3 loop``/``tool``/``eval``/``assess``) is deliberately outside that seam; its
+command modules are the named ``INTENTIONALLY_UNREGISTERED_MODULES`` set.
+"""
+
+import click
+from django.core.management import get_commands, load_command_class
+from typer.main import get_command
+
+from teatree.core.capabilities import CAPABILITIES
+
+_APP_LABEL = "teatree.core"
+_JSON_OPTS = frozenset({"--json", "--format"})
+
+# Management-command modules that expose a --json/--format switch but are
+# deliberately NOT part of the front-end capability seam: loop/orchestration
+# internals, operator diagnostics, and dev tooling a front-end never drives.
+# A NEW json command under a NEW module is not on this list, so it fails the
+# reverse walk until it is registered as a capability or added here on purpose.
+INTENTIONALLY_UNREGISTERED_MODULES: frozenset[str] = frozenset(
+    {
+        "handover",
+        "health",
+        "loop_claude_spec",
+        "loop_dispatch",
+        "loop_drain_queue",
+        "loop_list",
+        "loop_owner",
+        "loop_self_improve",
+        "loop_slack_answer",
+        "loop_state",
+        "loop_tick",
+        "loops_list",
+        "loops_tick",
+        "prompts_list",
+        "recipe",
+        "recover",
+        "session",
+        "standing_goal",
+        "waiting",
+    }
+)
+
+# CAPABILITIES entries that always emit a JSON document (no --json switch), so the
+# forward walk asserts existence but not an option — they are proven to emit JSON
+# by tests/teatree_cli/test_capabilities.py::TestSwitchlessAlwaysJsonEmitsJson.
+_ALWAYS_JSON_COMMANDS = frozenset({"teatree workspace emit", "teatree tasks create", "teatree db query"})
+
+
+def _json_switch(command: click.Command) -> bool:
+    return any(
+        isinstance(param, click.Option) and any(opt in _JSON_OPTS for opt in param.opts) for param in command.params
+    )
+
+
+def _core_click_command(name: str) -> click.Command | None:
+    """The click command tree for a ``teatree.core`` management command, or ``None``."""
+    try:
+        klass = load_command_class(_APP_LABEL, name)
+    except Exception:  # noqa: BLE001 — an un-loadable command exposes no introspectable surface
+        return None
+    typer_app = getattr(klass, "typer_app", None)
+    if typer_app is None:
+        return None
+    try:
+        return get_command(typer_app)
+    except Exception:  # noqa: BLE001 — a command whose typer app will not build exposes no introspectable surface
+        return None
+
+
+def management_json_surface() -> set[str]:
+    """Every ``teatree.core`` management command declaring a --json/--format switch.
+
+    Keyed ``teatree <name>`` (bare command) or ``teatree <name> <sub>`` (a group
+    subcommand) — the same convention ``CAPABILITIES`` uses for its entries.
+    """
+    surface: set[str] = set()
+    core = sorted(name for name, app in get_commands().items() if app == _APP_LABEL)
+    for name in core:
+        command = _core_click_command(name)
+        if command is None:
+            continue
+        if isinstance(command, click.Group):
+            ctx = click.Context(command)
+            for sub_name in command.list_commands(ctx):
+                sub = command.get_command(ctx, sub_name)
+                if sub is not None and _json_switch(sub):
+                    surface.add(f"teatree {name} {sub_name}")
+        elif _json_switch(command):
+            surface.add(f"teatree {name}")
+    return surface
+
+
+def _surface_module(surface_key: str) -> str:
+    # `teatree <module> [<sub>]` -> the management-command module name.
+    return surface_key.split()[1]
+
+
+def _registered_surface_keys() -> set[str]:
+    """CAPABILITIES commands canonicalized UP to the ``teatree <cmd>`` surface form.
+
+    The registry names some commands bare (``cost``) and some prefixed
+    (``teatree cost``); the surface always emits ``teatree <cmd>``. Canonicalize UP
+    (add the prefix) so a bare registry entry matches its prefixed surface key —
+    never strip the prefix off the surface to force a match.
+    """
+    keys: set[str] = set()
+    keys.update(cap.command if cap.command.startswith("teatree ") else f"teatree {cap.command}" for cap in CAPABILITIES)
+    return keys
+
+
+def _resolve_capability(command: str) -> click.Command | None:
+    """Resolve a CAPABILITIES command string to its live click command, or ``None``.
+
+    Tries the ``teatree.core`` management surface first (``teatree <cmd> [<sub>]``
+    / bare ``<cmd>``), then the top-level typer CLI app (``config show``).
+    """
+    tokens = command.removeprefix("teatree ").split()
+    if not tokens:
+        return None
+    head, *rest = tokens
+    resolved = _walk(_core_click_command(head), rest)
+    if resolved is not None:
+        return resolved
+    from teatree.cli import app  # noqa: PLC0415 — a Django-bootstrap-heavy import kept lazy
+
+    return _walk(get_command(app), tokens)
+
+
+def _walk(command: click.Command | None, tokens: list[str]) -> click.Command | None:
+    for token in tokens:
+        if not isinstance(command, click.Group):
+            return None
+        command = command.get_command(click.Context(command), token)
+        if command is None:
+            return None
+    return command
+
+
+def unregistered_json_surface() -> set[str]:
+    """Every json surface command that is neither registered nor intentionally excluded."""
+    registered = _registered_surface_keys()
+    return {
+        key
+        for key in management_json_surface()
+        if key not in registered and _surface_module(key) not in INTENTIONALLY_UNREGISTERED_MODULES
+    }
+
+
+class TestCapabilitySurfaceWalkReverse:
+    """surface -> registry: a json command on the surface must be registered or excluded."""
+
+    def test_no_json_management_command_is_unregistered(self) -> None:
+        unregistered = unregistered_json_surface()
+        assert not unregistered, (
+            "management command(s) emit JSON but are neither in CAPABILITIES nor the named "
+            f"intentional-exclusion allowlist (register them or add the module on purpose): {sorted(unregistered)}"
+        )
+
+    def test_signals_is_now_registered_not_an_orphan_surface(self) -> None:
+        # The #13/#26 regression, pinned: `teatree signals` is a real json surface
+        # AND in CAPABILITIES, so it is not reported unregistered.
+        assert "teatree signals" in management_json_surface()
+        assert "teatree signals" in _registered_surface_keys()
+
+    def test_surface_walk_cardinality_floor_anti_vacuity(self) -> None:
+        # A broken walk that discovers nothing must not pass vacuously.
+        assert len(management_json_surface()) >= 20
+
+
+class TestCapabilitySurfaceWalkForward:
+    """registry -> surface: every CAPABILITIES entry resolves to a live command."""
+
+    def test_every_capability_resolves_to_a_live_command(self) -> None:
+        missing = [cap.command for cap in CAPABILITIES if _resolve_capability(cap.command) is None]
+        assert not missing, f"CAPABILITIES entries that resolve to no live command (phantom/renamed): {missing}"
+
+    def test_every_json_switch_capability_declares_the_option(self) -> None:
+        for cap in CAPABILITIES:
+            if not cap.json_output or cap.command in _ALWAYS_JSON_COMMANDS:
+                continue
+            resolved = _resolve_capability(cap.command)
+            assert resolved is not None, cap.command
+            assert _json_switch(resolved), f"{cap.command!r} is json:true but declares no --json/--format option"
+
+
+class TestSurfaceWalkFiresRed:
+    """Anti-vacuity: both directions must actually catch drift."""
+
+    def test_reverse_walk_names_a_synthetic_unregistered_surface(self) -> None:
+        # A json surface whose module is neither registered nor allowlisted is
+        # reported — the property that would have caught `signals` pre-#13.
+        registered = _registered_surface_keys()
+        synthetic = "teatree brandnew_json_cmd"
+        assert synthetic not in registered
+        assert _surface_module(synthetic) not in INTENTIONALLY_UNREGISTERED_MODULES
+
+    def test_forward_walk_names_a_phantom_capability(self) -> None:
+        assert _resolve_capability("teatree this_command_does_not_exist") is None

--- a/tests/conformance/test_signal_ledger_producers.py
+++ b/tests/conformance/test_signal_ledger_producers.py
@@ -1,0 +1,258 @@
+"""SIGNAL_LEDGER_PRODUCERS — the signal-has-a-live-writer conformance CAPSTONE (SIG-4).
+
+The cluster's defining failure was producer/consumer registry drift: a signal
+*reads* a ledger that no production path *writes*, so the reading is structurally
+dead (S1 ``INSTRUMENTATION_GAP`` forever, S2 vacuous ``OK``) yet CI stays green
+because the queries have their own fixture-injected rows. SIG-2 populated
+``RedMrFixAttempt`` and SIG-3 wrote ``Ticket.Kind.FIX`` precisely because those
+two ledgers had no writer.
+
+This lane is the merge gate that certifies the WHOLE signal layer is alive end to
+end. It enumerates every ledger model :mod:`teatree.core.factory_signal_queries`
+reads and asserts each maps to a LIVE producer in ``SIGNAL_LEDGER_PRODUCERS`` — a
+declared write entry point whose source actually performs the write, plus an
+exercised integration test. Two directions, both fail loud. First: a ledger read
+with no registered producer (a NEW signal reading an unwritten ledger) — the
+vacuity class SIG-2/SIG-3 fought — fails here instead of shipping. Second: a
+registered producer that has been stubbed/gutted (its write removed, e.g. the
+``claim_red_mr_fix`` fail-open regression #7 that returned ``True`` without ever
+calling ``RedMrFixAttempt.claim``) fails here, NAMING the orphaned ledger.
+
+Enumeration is by namespace introspection of the query module, so a producer
+proof is required for the models it actually imports — the registry cannot silently
+lag a newly-read ledger. It depends on SIG-2's and SIG-3's producers being on main;
+without them the ``RedMrFixAttempt`` / ``Ticket`` lanes would (correctly) be red.
+"""
+
+import dataclasses
+import importlib
+import inspect
+from pathlib import Path
+from typing import ClassVar
+
+from django.db.models import Model
+
+from teatree.core import factory_signal_queries
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclasses.dataclass(frozen=True)
+class SignalLedgerProducer:
+    """One ledger's live-writer proof: the model, its writer, and the test that exercises it.
+
+    ``write_entry_point`` is the dotted path to the production function/method
+    that writes the ledger; ``write_call`` is the write expression that MUST
+    appear in that function's own source (the stub-detector — gutting the writer
+    removes it). ``integration_test`` is the repo-relative test that exercises the
+    write end to end and must reference the ledger by name.
+    """
+
+    ledger: str
+    write_entry_point: str
+    write_call: str
+    integration_test: str
+
+
+# Every ledger model `factory_signal_queries` reads -> its live producer proof.
+# Keyed by the model class name the enumeration below discovers in the query
+# module's namespace, so a newly-imported ledger with no entry fails the coverage
+# lane rather than shipping a dead read.
+SIGNAL_LEDGER_PRODUCERS: tuple[SignalLedgerProducer, ...] = (
+    SignalLedgerProducer(
+        ledger="MergeAudit",
+        write_entry_point="teatree.core.merge.execution.record_merge_and_advance",
+        write_call="merge_audit_model.objects.create",
+        integration_test="tests/teatree_core/test_merge_execution.py",
+    ),
+    SignalLedgerProducer(
+        ledger="MergeClear",
+        write_entry_point="teatree.core.models.merge_clear.MergeClear.issue",
+        write_call="cls.objects.create",
+        integration_test="tests/teatree_core/test_clear_issuance_and_human_substrate.py",
+    ),
+    SignalLedgerProducer(
+        ledger="RedMrFixAttempt",
+        write_entry_point="teatree.loop.dispatch_gates.claim_red_mr_fix",
+        write_call="RedMrFixAttempt.claim",
+        integration_test="tests/teatree_loop/test_sig2_red_mr_ledger.py",
+    ),
+    SignalLedgerProducer(
+        ledger="Ticket",
+        write_entry_point="teatree.core.ticket_kind_classification.classify_ticket_kind",
+        write_call="Ticket.Kind.FIX",
+        integration_test="tests/teatree_core/test_ticket_kind_classification.py",
+    ),
+    SignalLedgerProducer(
+        ledger="TicketTransition",
+        write_entry_point="teatree.core.signals._log_ticket_transition",
+        write_call="TicketTransition.objects.create",
+        integration_test="tests/teatree_core/test_transition.py",
+    ),
+    SignalLedgerProducer(
+        ledger="ReviewVerdict",
+        write_entry_point="teatree.core.models.review_verdict.ReviewVerdict.record",
+        write_call="cls.objects.create",
+        integration_test="tests/teatree_core/test_review_verdict_model.py",
+    ),
+    SignalLedgerProducer(
+        ledger="TaskAttempt",
+        write_entry_point="teatree.agents.attempt_recorder.record_result_envelope",
+        write_call="TaskAttempt.objects.create",
+        integration_test="tests/teatree_agents/test_attempt_recorder.py",
+    ),
+    SignalLedgerProducer(
+        ledger="RedCardSignal",
+        write_entry_point="teatree.core.models.red_card_signal.RedCardSignal.record",
+        write_call="cls.objects.get_or_create",
+        integration_test="tests/teatree_loop/test_red_card_scanner.py",
+    ),
+)
+
+
+def ledger_models_read_by_signal_queries() -> dict[str, type[Model]]:
+    """The concrete Django ledger models imported into the query module's namespace.
+
+    Introspection, not a hand-list: any ``Model`` subclass the queries import is a
+    ledger they read, so the coverage assertion below cannot silently lag a newly
+    read ledger. Abstract bases are excluded (they carry no rows to write).
+    """
+    return {
+        name: obj
+        for name, obj in vars(factory_signal_queries).items()
+        if isinstance(obj, type) and issubclass(obj, Model) and not obj._meta.abstract
+    }
+
+
+def _resolve(dotted: str) -> object:
+    module_path, _, attr_path = dotted.partition(":") if ":" in dotted else _split_module_attr(dotted)
+    obj: object = importlib.import_module(module_path)
+    for part in attr_path.split("."):
+        obj = getattr(obj, part)
+    return obj
+
+
+def _split_module_attr(dotted: str) -> tuple[str, str, str]:
+    # A producer path is `pkg.mod.func` or `pkg.mod.Class.method`; split at the
+    # last module boundary by importing the longest importable prefix.
+    parts = dotted.split(".")
+    for cut in range(len(parts) - 1, 0, -1):
+        module_path = ".".join(parts[:cut])
+        try:
+            importlib.import_module(module_path)
+        except ModuleNotFoundError:
+            continue
+        return module_path, ".", ".".join(parts[cut:])
+    msg = f"no importable module prefix in {dotted!r}"
+    raise ModuleNotFoundError(msg)
+
+
+def _producer_source(producer: SignalLedgerProducer) -> str:
+    obj = _resolve(producer.write_entry_point)
+    fn = getattr(obj, "__func__", obj)
+    return inspect.getsource(fn)
+
+
+def orphaned_ledgers(
+    *,
+    registry: tuple[SignalLedgerProducer, ...],
+    enumerated: dict[str, type[Model]],
+) -> dict[str, str]:
+    """Every read ledger lacking a LIVE writer, mapped to why — the capstone core.
+
+    A ledger is orphaned when it has no registry entry, OR its producer's write
+    entry point does not resolve, OR the write expression is absent from that
+    producer's source (a stubbed/gutted writer — the fail-open regression class).
+    Shared by the real assertion and the anti-vacuity self-test so the gate is
+    proven to actually fire.
+    """
+    by_ledger = {producer.ledger: producer for producer in registry}
+    orphans: dict[str, str] = {}
+    for ledger in enumerated:
+        producer = by_ledger.get(ledger)
+        if producer is None:
+            orphans[ledger] = "no registered producer (a signal reads a ledger nothing writes)"
+            continue
+        try:
+            source = _producer_source(producer)
+        except (ModuleNotFoundError, AttributeError, TypeError, OSError) as exc:
+            orphans[ledger] = f"producer {producer.write_entry_point} does not resolve: {exc}"
+            continue
+        if producer.write_call not in source:
+            orphans[ledger] = (
+                f"producer {producer.write_entry_point} no longer writes the ledger "
+                f"(missing {producer.write_call!r}) — stubbed/gutted writer"
+            )
+    return orphans
+
+
+class TestSignalLedgerProducersCapstone:
+    """Every ledger the signal layer reads must have a live, exercised writer."""
+
+    def test_no_signal_reads_an_unwritten_ledger(self) -> None:
+        orphans = orphaned_ledgers(
+            registry=SIGNAL_LEDGER_PRODUCERS,
+            enumerated=ledger_models_read_by_signal_queries(),
+        )
+        assert not orphans, f"signal-layer ledgers with no live writer: {orphans}"
+
+    def test_no_producer_entry_is_a_phantom(self) -> None:
+        # Reverse direction: every registry entry must name a ledger the queries
+        # actually read — a producer for a no-longer-read ledger is dead surface.
+        read = set(ledger_models_read_by_signal_queries())
+        phantom = {producer.ledger for producer in SIGNAL_LEDGER_PRODUCERS} - read
+        assert not phantom, f"registered producer(s) for ledgers the queries do not read: {sorted(phantom)}"
+
+    def test_every_producer_has_an_exercised_integration_test(self) -> None:
+        for producer in SIGNAL_LEDGER_PRODUCERS:
+            path = _REPO_ROOT / producer.integration_test
+            assert path.is_file(), f"{producer.ledger}: integration test {producer.integration_test} is missing"
+            assert producer.ledger in path.read_text(encoding="utf-8"), (
+                f"{producer.ledger}: integration test {producer.integration_test} never references the ledger"
+            )
+
+    def test_cardinality_floor_anti_vacuity(self) -> None:
+        # A refactor that empties the enumeration must not turn the coverage lane
+        # vacuously green; the six named ledgers plus MergeClear + TicketTransition.
+        assert len(ledger_models_read_by_signal_queries()) >= 8
+        assert len(SIGNAL_LEDGER_PRODUCERS) >= 8
+
+
+class TestCapstoneFiresRedOnAStubbedProducer:
+    """Anti-vacuity: the capstone must go RED when a producer is stubbed or missing.
+
+    A conformance gate that can never fail is worthless. These drive
+    ``orphaned_ledgers`` against synthetic registries so the two failure modes the
+    capstone guards — a missing producer and a gutted writer — are proven to be
+    named, not silently passed.
+    """
+
+    _MODELS: ClassVar[dict[str, type]] = {"RedMrFixAttempt": object}  # only the name is read by the detector
+
+    def test_missing_producer_is_named(self) -> None:
+        orphans = orphaned_ledgers(registry=(), enumerated=self._MODELS)
+        assert "RedMrFixAttempt" in orphans
+        assert "no registered producer" in orphans["RedMrFixAttempt"]
+
+    def test_gutted_writer_is_named(self) -> None:
+        # A real producer path whose source does NOT contain the declared write
+        # call models the fail-open stub: the ledger is reported orphaned.
+        stubbed = (
+            SignalLedgerProducer(
+                ledger="RedMrFixAttempt",
+                write_entry_point="teatree.loop.dispatch_gates.claim_red_mr_fix",
+                write_call="THIS_WRITE_WAS_REMOVED_BY_A_STUB",
+                integration_test="tests/teatree_loop/test_sig2_red_mr_ledger.py",
+            ),
+        )
+        orphans = orphaned_ledgers(registry=stubbed, enumerated=self._MODELS)
+        assert "RedMrFixAttempt" in orphans
+        assert "stubbed/gutted writer" in orphans["RedMrFixAttempt"]
+
+    def test_healthy_registry_reports_no_orphans(self) -> None:
+        # The positive control: the real registry against a real read ledger is clean.
+        orphans = orphaned_ledgers(
+            registry=SIGNAL_LEDGER_PRODUCERS,
+            enumerated={"RedMrFixAttempt": ledger_models_read_by_signal_queries()["RedMrFixAttempt"]},
+        )
+        assert orphans == {}

--- a/tests/conformance/test_signals_scope_parity.py
+++ b/tests/conformance/test_signals_scope_parity.py
@@ -1,0 +1,71 @@
+"""signals CLI <-> MCP scope parity — the named guard that replaced "can never drift" (SIG-4, #25).
+
+The MCP ``factory_signals`` docstring once *claimed* the CLI and MCP surfaces "can
+never drift" — an unenforced guarantee. In fact they silently reported different
+scopes: the CLI is env-scoped to ``T3_OVERLAY_NAME`` while the MCP tool defaults
+global, and neither stamped the scope anywhere in the output, so a consumer could
+not tell an overlay-scoped reading from a global one. #25 added the ``overlay``
+scope field to both; this lane is the parity test the docstring now points at
+instead of the empty promise.
+
+Both surfaces run the SAME ``compute_factory_signals`` path, so the guard is a
+schema + scope-value comparison: the CLI ``signals --json`` for ``T3_OVERLAY_NAME=X``
+and ``mcp.search.factory_signals(overlay=X)`` must be schema-identical INCLUDING
+the ``overlay`` field, and a global reading must be distinguishable from a scoped
+one from the output alone.
+"""
+
+import json
+import os
+from typing import Any
+from unittest import mock
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from teatree.mcp.search import factory_signals as mcp_factory_signals
+
+_OVERLAY = "t3-teatree"
+
+
+def _cli_json(overlay: str) -> dict[str, Any]:
+    # The CLI reads its scope from T3_OVERLAY_NAME (empty => global), exactly as
+    # the `t3 <overlay> signals` bridge sets it. `call_command` returns the same
+    # JSON document django-typer prints to stdout for a front-end.
+    with mock.patch.dict(os.environ, {"T3_OVERLAY_NAME": overlay}):
+        return json.loads(call_command("signals", "--json"))
+
+
+def _schema(payload: dict[str, Any]) -> Any:
+    # Structural fingerprint that ignores the wall-clock `generated_at` and every
+    # value except the scope: the key sets at both levels plus the scope string.
+    top = {key for key in payload if key != "generated_at"}
+    rows = tuple(sorted(sorted(row) for row in payload["signals"]))
+    return top, rows, payload["overlay"]
+
+
+class TestSignalsScopeParity(TestCase):
+    def test_cli_and_mcp_are_schema_identical_including_scope(self) -> None:
+        cli = _cli_json(_OVERLAY)
+        mcp = mcp_factory_signals(overlay=_OVERLAY)
+        assert _schema(cli) == _schema(mcp)
+        assert cli["overlay"] == mcp["overlay"] == _OVERLAY
+
+    def test_global_reading_is_distinguishable_from_scoped(self) -> None:
+        global_cli = _cli_json("")
+        scoped_cli = _cli_json(_OVERLAY)
+        assert global_cli["overlay"] == ""
+        assert scoped_cli["overlay"] == _OVERLAY
+        assert global_cli["overlay"] != scoped_cli["overlay"]
+
+    def test_mcp_omitted_overlay_is_the_global_scope(self) -> None:
+        # The documented omit-means-global default is observable in the payload,
+        # not merely asserted in prose.
+        assert mcp_factory_signals()["overlay"] == ""
+        assert mcp_factory_signals(overlay=_OVERLAY)["overlay"] == _OVERLAY
+
+    def test_both_surfaces_carry_the_scope_key_never_absent(self) -> None:
+        # A consumer never has to guess the scope: the key is present on both
+        # surfaces even for the global view.
+        assert "overlay" in mcp_factory_signals()
+        assert "overlay" in _cli_json("")

--- a/tests/teatree_cli/test_capabilities.py
+++ b/tests/teatree_cli/test_capabilities.py
@@ -47,6 +47,7 @@ def _switch_handler_params() -> dict[str, set[str]]:
         followup,
         questions,
         queue,
+        signals,
         tasks,
         worktree,
     )
@@ -59,6 +60,10 @@ def _switch_handler_params() -> dict[str, set[str]]:
         "teatree worktree diagnose": worktree.Command.diagnose,
         "teatree availability show": availability.Command.show,
         "teatree questions list": questions.Command.list_pending,
+        # ``signals`` is a bare-``handle`` command (no subcommand token): like
+        # ``do``, django-typer replaces ``Command.handle`` with a generic wrapper,
+        # so its real ``--json`` param lives on the registered typer callback.
+        "teatree signals": signals.Command.typer_app.registered_commands[0].callback,
         "teatree checking show": checking.Command.show,
         "teatree env show": env.Command.show,
         # ``do`` is a bare-``handle`` command (no subcommand token); django-typer

--- a/tests/teatree_cli/test_overlay_leaves.py
+++ b/tests/teatree_cli/test_overlay_leaves.py
@@ -1,0 +1,54 @@
+"""``register_core_passthrough_leaves`` — the safe-kill/do/signals passthrough seam.
+
+Each leaf forwards its trailing args verbatim to the same-named ``teatree.core``
+management command via ``managepy_core``, mapping a hyphenated leaf name to the
+command's underscore form (``safe-kill`` -> ``safe_kill``). The subprocess seam
+is stubbed in-process (the one unstoppable external the test-doctrine permits)
+so the arg-forwarding + name-mapping contract is asserted directly.
+"""
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from teatree.cli.overlay_leaves import _CORE_PASSTHROUGH_LEAVES, register_core_passthrough_leaves
+
+runner = CliRunner()
+
+
+def _app_capturing_calls(monkeypatch: pytest.MonkeyPatch) -> tuple[typer.Typer, list[tuple[tuple[str, ...], str]]]:
+    calls: list[tuple[tuple[str, ...], str]] = []
+
+    def _fake_managepy_core(*args: str, overlay_name: str = "") -> None:
+        calls.append((args, overlay_name))
+
+    # The leaf lazily imports managepy_core from teatree.cli.overlay at call time.
+    monkeypatch.setattr("teatree.cli.overlay.managepy_core", _fake_managepy_core)
+    app = typer.Typer()
+    register_core_passthrough_leaves(app, "my-overlay")
+    return app, calls
+
+
+class TestCorePassthroughLeaves:
+    def test_every_declared_leaf_is_registered(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        app, _calls = _app_capturing_calls(monkeypatch)
+        registered = {command.name for command in app.registered_commands}
+        assert {name for name, _help in _CORE_PASSTHROUGH_LEAVES} <= registered
+
+    def test_hyphenated_leaf_maps_to_the_underscore_command(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        app, calls = _app_capturing_calls(monkeypatch)
+        result = runner.invoke(app, ["safe-kill", "1234", "--hang-cause", "x"])
+        assert result.exit_code == 0, result.output
+        assert calls == [(("safe_kill", "1234", "--hang-cause", "x"), "my-overlay")]
+
+    def test_trailing_args_are_forwarded_verbatim_with_the_overlay(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        app, calls = _app_capturing_calls(monkeypatch)
+        result = runner.invoke(app, ["signals", "--json", "--window-days", "7"])
+        assert result.exit_code == 0, result.output
+        assert calls == [(("signals", "--json", "--window-days", "7"), "my-overlay")]
+
+    def test_leaf_with_no_extra_args_dispatches_the_bare_command(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        app, calls = _app_capturing_calls(monkeypatch)
+        result = runner.invoke(app, ["do"])
+        assert result.exit_code == 0, result.output
+        assert calls == [(("do",), "my-overlay")]

--- a/tests/teatree_cli/test_signals_cli_surface.py
+++ b/tests/teatree_cli/test_signals_cli_surface.py
@@ -1,0 +1,89 @@
+"""``t3 <overlay> signals`` — the CLI-surface wire test whose absence let #13 ship green.
+
+SIG-PR-1 advertised a ``t3 <overlay> signals`` command but never registered the
+leaf on the overlay CLI, so the command did not exist; the only tests called
+``compute_factory_signals()`` directly, so CI stayed green over a dead surface.
+This exercises the REAL built overlay Typer app end to end: the ``signals`` leaf
+resolves, forwards ``--json`` / ``--window-days`` verbatim to the core
+management command, and the ``T3_OVERLAY_NAME`` the bridge sets flows through to
+the report's ``overlay`` scope field (#25).
+
+The ``managepy_core`` subprocess boundary is the one unstoppable external the
+test-doctrine permits stubbing: it is routed in-process through ``call_command``
+against the test DB (mirroring ``tests/test_cli_wip.py``), so the leaf's arg
+forwarding and the command's JSON contract are both real while the subprocess
+bootstrap is proven elsewhere. The scope-propagation-through-a-real-subprocess
+path is additionally covered by ``tests/conformance/test_signals_scope_parity.py``.
+"""
+
+import json
+import os
+
+import pytest
+import typer
+from django.core.management import call_command
+from django.test import TestCase
+from typer.testing import CliRunner
+
+from teatree.cli.overlay import OverlayAppBuilder
+
+runner = CliRunner()
+
+_OVERLAY = "test-overlay"
+
+
+def _in_process_managepy_core(*args: str, overlay_name: str = "") -> None:
+    """In-process stand-in for the ``signals`` subprocess seam.
+
+    The real leaf delegates to ``python -m teatree signals …`` and streams the
+    child's stdout up; the child sets ``T3_OVERLAY_NAME`` on its env and
+    django-typer prints the ``handle`` return. Here that whole boundary collapses
+    to a ``call_command`` against the test DB with ``T3_OVERLAY_NAME`` set —
+    django-typer prints the ``handle`` return to the ``CliRunner``-captured
+    stdout, the same document a front-end would parse.
+    """
+    prior = os.environ.get("T3_OVERLAY_NAME")
+    if overlay_name:
+        os.environ["T3_OVERLAY_NAME"] = overlay_name
+    try:
+        call_command(*args)
+    finally:
+        if prior is None:
+            os.environ.pop("T3_OVERLAY_NAME", None)
+        else:
+            os.environ["T3_OVERLAY_NAME"] = prior
+
+
+@pytest.fixture(autouse=True)
+def _route_bridge_in_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("teatree.cli.overlay.managepy_core", _in_process_managepy_core)
+
+
+def _app() -> typer.Typer:
+    return OverlayAppBuilder(_OVERLAY, None).build()
+
+
+class TestSignalsCliSurface(TestCase):
+    def test_signals_leaf_is_registered_and_emits_json(self) -> None:
+        result = runner.invoke(_app(), ["signals", "--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.stdout)  # raises if the human view leaked onto stdout
+        assert {"overlay", "window_days", "verdict", "signals"} <= set(payload)
+        assert len(payload["signals"]) == 5
+
+    def test_overlay_scope_flows_through_the_bridge(self) -> None:
+        # T3_OVERLAY_NAME the leaf sets must reach the report's scope field — the
+        # #25 CLI-scope half of the CLI/MCP parity contract.
+        result = runner.invoke(_app(), ["signals", "--json"])
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.stdout)["overlay"] == _OVERLAY
+
+    def test_window_days_is_forwarded_verbatim(self) -> None:
+        result = runner.invoke(_app(), ["signals", "--json", "--window-days", "7"])
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.stdout)["window_days"] == 7
+
+    def test_default_human_view_renders_the_scoped_markdown_header(self) -> None:
+        result = runner.invoke(_app(), ["signals"])
+        assert result.exit_code == 0, result.output
+        assert f"scope: {_OVERLAY}" in result.stdout

--- a/tests/teatree_core/test_factory_signals.py
+++ b/tests/teatree_core/test_factory_signals.py
@@ -598,6 +598,22 @@ class ReportShapeTests(FactorySignalsTestBase):
         for key in ("provider_id", "kind", "value", "sample_size", "window_days", "status", "red_when", "tripped"):
             assert key in first
 
+    def test_scope_field_stamps_the_overlay_on_dict_and_markdown(self) -> None:
+        # #25: a scoped reading must be distinguishable from a global one from the
+        # output alone — the scope is stamped in the dict AND the markdown header.
+        scoped = compute_factory_signals(overlay="t3-teatree", now=self.now)
+        assert scoped.overlay == "t3-teatree"
+        assert scoped.to_dict()["overlay"] == "t3-teatree"
+        assert "scope: t3-teatree" in scoped.to_markdown().splitlines()[0]
+
+    def test_global_scope_reads_empty_overlay_not_a_missing_key(self) -> None:
+        # An omitted overlay is the whole-factory GLOBAL view: the key is present
+        # and empty (never absent), so a consumer never has to guess the scope.
+        report = compute_factory_signals(now=self.now)
+        assert report.overlay == ""
+        assert report.to_dict()["overlay"] == ""
+        assert "scope: global" in report.to_markdown().splitlines()[0]
+
     def test_window_days_flows_through(self) -> None:
         report = compute_factory_signals(window_days=7, now=self.now)
         assert report.window_days == 7


### PR DESCRIPTION
SIG-4 — the capstone of the signals cluster: the merge gate certifying SIG-1/2/3's signal layer is alive end to end.

## What lands

**#13 — the `t3 <overlay> signals` CLI leaf actually exists.** SIG-PR-1 advertised the command but never registered the overlay leaf, so it did not exist; tests only called `compute_factory_signals()` directly, so CI stayed green over a dead surface. Registers the leaf via the `managepy_core` bridge. The three near-identical safe-kill/do/signals core-passthrough leaves are extracted into a dedicated `cli/overlay_leaves.py` concern (removing the triplicated `context_settings` + `managepy_core` boilerplate and keeping `overlay.py` under the module-health cap). A CliRunner wire test through the *built overlay Typer app* now exercises the real surface.

**#25 — scope field on CLI + MCP.** `FactorySignalsReport` gains an `overlay` scope field, stamped in `to_dict()` and the `to_markdown()` header, so a global reading is distinguishable from an overlay-scoped one from the output alone. The unenforced "CLI and MCP surfaces can never drift" MCP docstring is replaced by the named `test_signals_scope_parity.py` lane that actually enforces schema+scope parity (CLI env-scoped `T3_OVERLAY_NAME` vs MCP `overlay=` param).

**#26 — bidirectional capability walk-the-surface.** Registers the `teatree signals` Capability and adds a two-way conformance lane: forward (every `CAPABILITIES` entry resolves to a live command in the real click tree) and reverse (every `teatree.core` management command declaring `--json`/`--format` is either registered or in a named intentional-exclusion allowlist). The reverse direction is the omission the pre-#13 one-directional guard never caught — it would have flagged `signals`.

**SIGNAL_LEDGER_PRODUCERS capstone (the merge gate).** A `tests/conformance/` lane that enumerates every ledger `factory_signal_queries` reads (by namespace introspection) and asserts each maps to a LIVE producer: a declared write entry point whose source actually performs the write, plus an exercised integration test. Producers enumerated: MergeAudit (`record_merge_and_advance`), MergeClear (`MergeClear.issue`), RedMrFixAttempt (SIG-2 `claim_red_mr_fix`), Ticket[kind=FIX] (SIG-3 `classify_ticket_kind`), TicketTransition (`_log_ticket_transition`), ReviewVerdict (`ReviewVerdict.record`), TaskAttempt (`record_result_envelope`), RedCardSignal (`RedCardSignal.record`). It fails RED if a signal reads a ledger nothing writes, and RED naming the orphaned ledger if a producer is stubbed/gutted — the vacuity class the whole cluster fought. Depends on SIG-2's and SIG-3's producers being on main.

## Anti-vacuity (RED-before proven)
- Capstone RED-before: temporarily gutting the real `claim_red_mr_fix` producer (removing the `RedMrFixAttempt.claim` write — the #7 fail-open shape) turns the top-level capstone RED naming `RedMrFixAttempt`; producer restored clean.
- Reverse capability walk RED-before: dropping the `teatree signals` capability makes the reverse walk name it unregistered (the exact pre-#13 state).
- Self-tests pin both failure modes (missing producer, gutted writer, phantom capability) so the gates can actually fail.

All fixtures production-shaped. `factory_signal_queries.py` is read via the public seam only — never edited. tests/conformance additions are append-only new lanes.