### PR TITLE
refactor(self-mod): transition-keyed critic rubric seam + shared no_collateral_regression extraction (north-star PR-1 foundation)

### DIFF
--- a/src/teatree/core/critic_rubric.py
+++ b/src/teatree/core/critic_rubric.py
@@ -50,6 +50,13 @@ if TYPE_CHECKING:
 
 CriticPredicate = Callable[["Ticket"], "str | None"]
 
+# The FSM transition an item is judged at. The seeded rubric all lands here (the
+# critic gate runs at ``mark_delivered``); the north-star arc adds ``plan``/``merge``
+# items on the SAME registry, selected by transition — keeping the models
+# (CriticDispatch/CriticVerdict/CriticFinding), which are already transition-keyed,
+# and the rubric in step.
+DEFAULT_TRANSITION = "mark_delivered"
+
 
 class RubricKind(StrEnum):
     DETERMINISTIC = "deterministic"
@@ -93,6 +100,7 @@ class CriticRubricItem:
     origin: str
     predicate_path: str = ""
     blocking: bool = False
+    transition: str = DEFAULT_TRANSITION
 
     def resolve(self) -> CriticPredicate:
         return _resolve_predicate(self.predicate_path)
@@ -211,18 +219,20 @@ CRITIC_RUBRIC: tuple[CriticRubricItem, ...] = (
 )
 
 
-def rubric_items() -> tuple[CriticRubricItem, ...]:
-    """The active critic rubric, in seeded order."""
-    return CRITIC_RUBRIC
+def rubric_items(transition: str = DEFAULT_TRANSITION) -> tuple[CriticRubricItem, ...]:
+    """The active critic rubric for *transition*, in seeded order."""
+    return tuple(item for item in CRITIC_RUBRIC if item.transition == transition)
 
 
-def deterministic_items() -> tuple[CriticRubricItem, ...]:
-    return tuple(item for item in CRITIC_RUBRIC if item.kind is RubricKind.DETERMINISTIC)
+def deterministic_items(transition: str = DEFAULT_TRANSITION) -> tuple[CriticRubricItem, ...]:
+    return tuple(
+        item for item in CRITIC_RUBRIC if item.transition == transition and item.kind is RubricKind.DETERMINISTIC
+    )
 
 
-def llm_items() -> tuple[CriticRubricItem, ...]:
-    return tuple(item for item in CRITIC_RUBRIC if item.kind is RubricKind.LLM)
+def llm_items(transition: str = DEFAULT_TRANSITION) -> tuple[CriticRubricItem, ...]:
+    return tuple(item for item in CRITIC_RUBRIC if item.transition == transition and item.kind is RubricKind.LLM)
 
 
-def item_for(slug: str) -> "CriticRubricItem | None":
-    return next((item for item in CRITIC_RUBRIC if item.slug == slug), None)
+def item_for(slug: str, transition: str = DEFAULT_TRANSITION) -> "CriticRubricItem | None":
+    return next((item for item in CRITIC_RUBRIC if item.slug == slug and item.transition == transition), None)

--- a/src/teatree/core/gates/critic_gate.py
+++ b/src/teatree/core/gates/critic_gate.py
@@ -75,7 +75,7 @@ def delivered_head_sha(ticket: "Ticket") -> str:
 
 def _deterministic_specs(ticket: "Ticket", head_sha: str) -> list[CriticFindingSpec]:
     specs: list[CriticFindingSpec] = []
-    for item in deterministic_items():
+    for item in deterministic_items(_TRANSITION):
         try:
             detail = item.evaluate(ticket)
         except Exception as exc:  # noqa: BLE001 — an inconclusive predicate is a finding, not a crash of the gate.
@@ -114,7 +114,7 @@ def _llm_specs(ticket: "Ticket", head_sha: str) -> list[CriticFindingSpec]:
         return []
     specs: list[CriticFindingSpec] = []
     for failed in verdict.failed_items():
-        item = item_for(failed.slug)
+        item = item_for(failed.slug, _TRANSITION)
         if item is None:
             continue  # a verdict slug outside the rubric is ignored, never recorded as a phantom finding
         status = (
@@ -167,14 +167,14 @@ def build_critic_contract(ticket: "Ticket", head_sha: str) -> str:
     self-declared claim. The contract instructs the critic to RETURN a
     ``critic_verdict`` envelope (corr-11) — it has no shell to record it itself.
     """
-    questions = "\n".join(f"  - {item.slug}: {item.adversarial_question}" for item in llm_items())
+    questions = "\n".join(f"  - {item.slug}: {item.adversarial_question}" for item in llm_items(_TRANSITION))
     plan = latest_plan_artifact(ticket)
     plan_text = (plan.plan_text if plan else "").strip() or "<no plan recorded>"
     manifest = AttachmentManifest.latest_for(ticket)
     entries = manifest.entries if manifest else []
     inputs = [str(e.get("source_url") or "").strip() for e in entries if isinstance(e, dict)]
     inputs_block = "\n".join(f"  - {url}" for url in inputs if url) or "  - <none recorded>"
-    item_slugs = ", ".join(item.slug for item in llm_items())
+    item_slugs = ", ".join(item.slug for item in llm_items(_TRANSITION))
     return (
         f"You are the autonomous user-proxy CRITIC judging the DELIVERY of ticket {ticket.pk}. Read the "
         f"delivered artifacts — the merged PR diff at head {head_sha[:8] or '<unknown>'}, the plan below, and the "
@@ -238,7 +238,7 @@ def record_returned_critic_verdict(task: object, result: dict) -> str:
 
 def blocking_specs(specs: list[CriticFindingSpec]) -> list[CriticFindingSpec]:
     """The subset of *specs* whose rubric item BLOCKS under enforcement (the deterministic teeth)."""
-    return [spec for spec in specs if (item := item_for(spec.rubric_item)) is not None and item.blocking]
+    return [spec for spec in specs if (item := item_for(spec.rubric_item, _TRANSITION)) is not None and item.blocking]
 
 
 def check_critic(ticket: "Ticket") -> None:

--- a/src/teatree/loops/outer_loop/decide.py
+++ b/src/teatree/loops/outer_loop/decide.py
@@ -12,8 +12,7 @@ import dataclasses
 
 from teatree.core.factory_score import FactoryScore, ScoredSignal
 from teatree.core.factory_signals import SignalVerdict
-
-_WORSE_VERDICTS = frozenset({SignalVerdict.REGRESSING.value, SignalVerdict.RED.value})
+from teatree.loops.shared.regression import no_collateral_regression
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -63,25 +62,8 @@ def decide_keep(
             ),
         )
 
-    regressed = _collateral_regression(baseline_by_id, post_by_id, target_provider_id=target_provider_id)
+    regressed = no_collateral_regression(baseline, post, exclude_provider_id=target_provider_id)
     if regressed:
         return Decision(keep=False, reason=f"non-target signal {regressed!r} regressed vs baseline — revert")
 
     return Decision(keep=True, reason=f"target {target_provider_id!r} improved {improvement:.3f}, no regression")
-
-
-def _collateral_regression(
-    baseline_by_id: dict[str, ScoredSignal],
-    post_by_id: dict[str, ScoredSignal],
-    *,
-    target_provider_id: str,
-) -> str:
-    """The id of the first non-target signal that turned worse vs baseline, or ``""``."""
-    for provider_id, after in post_by_id.items():
-        if provider_id == target_provider_id:
-            continue
-        before = baseline_by_id.get(provider_id)
-        was_worse = before is not None and before.verdict in _WORSE_VERDICTS
-        if after.verdict in _WORSE_VERDICTS and not was_worse:
-            return provider_id
-    return ""

--- a/src/teatree/loops/shared/__init__.py
+++ b/src/teatree/loops/shared/__init__.py
@@ -1,0 +1,6 @@
+"""Pure rules shared across loops — extracted so one implementation serves many.
+
+The first tenant is :func:`~teatree.loops.shared.regression.no_collateral_regression`,
+extracted from the outer loop's ``decide.py`` so the outer loop AND the future
+directive loop's VERIFYING step read the SAME anti-Goodhart fold, never two copies.
+"""

--- a/src/teatree/loops/shared/regression.py
+++ b/src/teatree/loops/shared/regression.py
@@ -1,0 +1,42 @@
+"""The shared anti-Goodhart collateral-regression fold.
+
+Extracted from :mod:`teatree.loops.outer_loop.decide` so BOTH the outer loop's
+keep-only-if-better rule AND the directive loop's VERIFYING step read ONE
+implementation of the same question: did any factory signal turn RED/REGRESSING vs
+the admission baseline? A pure fold over two
+:class:`~teatree.core.factory_score.FactoryScore` snapshots — no DB, table-tested.
+"""
+
+from teatree.core.factory_score import FactoryScore, ScoredSignal
+from teatree.core.factory_signals import SignalVerdict
+
+_WORSE_VERDICTS = frozenset({SignalVerdict.REGRESSING.value, SignalVerdict.RED.value})
+
+
+def _by_id(score: FactoryScore) -> dict[str, ScoredSignal]:
+    return {sig.provider_id: sig for sig in score.signals}
+
+
+def no_collateral_regression(
+    baseline: FactoryScore,
+    post: FactoryScore,
+    *,
+    exclude_provider_id: str = "",
+) -> str | None:
+    """The id of the first signal that turned worse vs *baseline*, or ``None`` when clean.
+
+    A signal already RED/REGRESSING in the baseline that STAYS worse is not a NEW
+    collateral regression — only a signal that crossed into a worse verdict counts.
+    ``exclude_provider_id`` skips the outer loop's target signal (whose own
+    improvement is judged separately); the directive loop omits it, so every signal
+    is treated as collateral.
+    """
+    baseline_by_id = _by_id(baseline)
+    for provider_id, after in _by_id(post).items():
+        if provider_id == exclude_provider_id:
+            continue
+        before = baseline_by_id.get(provider_id)
+        was_worse = before is not None and before.verdict in _WORSE_VERDICTS
+        if after.verdict in _WORSE_VERDICTS and not was_worse:
+            return provider_id
+    return None

--- a/tests/teatree_core/gates/test_critic_gate.py
+++ b/tests/teatree_core/gates/test_critic_gate.py
@@ -22,7 +22,9 @@ from django.test import TestCase
 
 from teatree.agents.attempt_recorder import record_result_envelope
 from teatree.config import UserSettings
+from teatree.core import critic_rubric
 from teatree.core import tasks as core_tasks
+from teatree.core.critic_rubric import CRITIC_RUBRIC, CriticRubricItem, RubricKind
 from teatree.core.gates import critic_gate
 from teatree.core.gates.critic_gate import (
     check_critic,
@@ -369,6 +371,33 @@ class TestProductionRecordingPath(TestCase):
             record_result_envelope(task, _critic_envelope())
         assert not CriticVerdict.objects.filter(ticket=ticket).exists()
         assert not CriticFinding.objects.filter(ticket=ticket, rubric_item="coherence").exists()
+
+
+class TestTransitionScoping(TestCase):
+    """check_critic evaluates only the mark_delivered rubric subset (PR-1 transition seam).
+
+    A deterministic item keyed to another transition, injected into the registry, must NOT
+    be run by the mark_delivered gate — otherwise a plan/merge critic's items would fire at
+    the wrong FSM point. Anti-vacuity: the same ticket makes the mark_delivered items fire,
+    so the exclusion is a real filter, not an empty pass.
+    """
+
+    def test_run_critic_ignores_a_foreign_transition_item(self) -> None:
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.RETROSPECTED)
+        foreign = CriticRubricItem(
+            slug="plan_transition_probe",
+            adversarial_question="a plan-transition item must not run at mark_delivered",
+            kind=RubricKind.DETERMINISTIC,
+            origin="north-star plan critic",
+            predicate_path="teatree.core.critic_rubric.spec_not_plan",
+            blocking=True,
+            transition="plan",
+        )
+        with patch.object(critic_rubric, "CRITIC_RUBRIC", (*CRITIC_RUBRIC, foreign)):
+            specs = run_critic(ticket)
+        flagged = {spec.rubric_item for spec in specs}
+        assert "plan_transition_probe" not in flagged
+        assert "spec_not_plan" in flagged  # the mark_delivered items DID run — not a blanket-empty pass
 
 
 class TestRegistration(TestCase):

--- a/tests/teatree_core/test_critic_rubric.py
+++ b/tests/teatree_core/test_critic_rubric.py
@@ -16,12 +16,14 @@ from django.test import TestCase
 from teatree.core import critic_rubric
 from teatree.core.critic_rubric import (
     CRITIC_RUBRIC,
+    CriticRubricItem,
     CriticRubricResolutionError,
     RubricKind,
     _resolve_predicate,
     completeness,
     deterministic_items,
     done_not_done,
+    item_for,
     llm_items,
     rubric_items,
     spec_not_plan,
@@ -165,3 +167,46 @@ class TestModuleExportsEveryDeterministicPredicate(TestCase):
 
     def test_rubric_items_returns_the_full_registry(self) -> None:
         assert rubric_items() == CRITIC_RUBRIC
+
+
+class TestTransitionSelection:
+    """Accessors return only the items keyed to the requested transition (the PR-1 seam)."""
+
+    _PLAN_ITEM = CriticRubricItem(
+        slug="plan_only_probe",
+        adversarial_question="a plan-transition item that must not leak into mark_delivered",
+        kind=RubricKind.DETERMINISTIC,
+        origin="north-star plan critic",
+        predicate_path="teatree.core.critic_rubric.spec_not_plan",
+        blocking=True,
+        transition="plan",
+    )
+
+    def _mixed_rubric(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(critic_rubric, "CRITIC_RUBRIC", (*CRITIC_RUBRIC, self._PLAN_ITEM))
+
+    def test_seeded_items_default_to_mark_delivered(self) -> None:
+        assert all(item.transition == "mark_delivered" for item in CRITIC_RUBRIC)
+
+    def test_deterministic_items_excludes_a_foreign_transition(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._mixed_rubric(monkeypatch)
+        slugs = {item.slug for item in deterministic_items("mark_delivered")}
+        assert slugs == {"spec_not_plan", "done_not_done", "completeness"}
+        assert "plan_only_probe" not in slugs
+
+    def test_deterministic_items_selects_the_requested_transition(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._mixed_rubric(monkeypatch)
+        assert [item.slug for item in deterministic_items("plan")] == ["plan_only_probe"]
+
+    def test_llm_and_rubric_items_are_transition_scoped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._mixed_rubric(monkeypatch)
+        assert len(llm_items("mark_delivered")) == 5
+        assert llm_items("plan") == ()
+        assert len(rubric_items("mark_delivered")) == 8
+        assert [item.slug for item in rubric_items("plan")] == ["plan_only_probe"]
+
+    def test_item_for_is_scoped_to_its_transition(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._mixed_rubric(monkeypatch)
+        assert item_for("plan_only_probe", "plan") is self._PLAN_ITEM
+        assert item_for("plan_only_probe", "mark_delivered") is None
+        assert item_for("spec_not_plan", "mark_delivered") is not None

--- a/tests/teatree_loops/shared/test_regression.py
+++ b/tests/teatree_loops/shared/test_regression.py
@@ -1,0 +1,71 @@
+"""The shared anti-Goodhart collateral-regression fold (north-star PR-1 extraction).
+
+Pure table tests over constructed :class:`FactoryScore` snapshots (no DB): a signal
+newly RED/REGRESSING vs the admission baseline is the finding; a signal already worse
+in the baseline that stays worse is not a NEW regression; ``exclude_provider_id`` skips
+the outer loop's own target signal. This is the ONE implementation both the outer
+loop's ``decide_keep`` and the future directive loop's VERIFYING step read.
+"""
+
+from teatree.core.factory_score import FactoryScore, ScoredSignal
+from teatree.loops.shared.regression import no_collateral_regression
+
+
+def _sig(provider_id: str, *, normalized: float | None = 0.7, verdict: str = "ok") -> ScoredSignal:
+    return ScoredSignal(
+        provider_id=provider_id,
+        status="ok" if normalized is not None else "instrumentation_gap",
+        value=normalized,
+        normalized=normalized,
+        weight=0.2,
+        covered=normalized is not None,
+        red=verdict == "red",
+        verdict=verdict,
+    )
+
+
+def _score(signals: list[ScoredSignal]) -> FactoryScore:
+    return FactoryScore(
+        aggregate=0.7,
+        verdict="ok",
+        coverage=1.0,
+        coverage_floor=0.6,
+        recipe_sha="sha",
+        recipe_approved=True,
+        window_days=7,
+        signals=signals,
+    )
+
+
+class TestNoCollateralRegression:
+    def test_no_signal_turned_worse_is_none(self) -> None:
+        baseline = _score([_sig("review_catch"), _sig("first_try_green")])
+        post = _score([_sig("review_catch"), _sig("first_try_green")])
+        assert no_collateral_regression(baseline, post) is None
+
+    def test_a_signal_newly_red_is_the_finding(self) -> None:
+        baseline = _score([_sig("review_catch"), _sig("first_try_green")])
+        post = _score([_sig("review_catch"), _sig("first_try_green", verdict="red")])
+        assert no_collateral_regression(baseline, post) == "first_try_green"
+
+    def test_a_signal_newly_regressing_is_the_finding(self) -> None:
+        baseline = _score([_sig("merge_latency")])
+        post = _score([_sig("merge_latency", verdict="regressing")])
+        assert no_collateral_regression(baseline, post) == "merge_latency"
+
+    def test_a_preexisting_regression_that_stays_is_not_new(self) -> None:
+        baseline = _score([_sig("merge_latency", verdict="regressing")])
+        post = _score([_sig("merge_latency", verdict="regressing")])
+        assert no_collateral_regression(baseline, post) is None
+
+    def test_exclude_provider_id_skips_the_target_signal(self) -> None:
+        # The excluded target may itself be RED (its improvement is judged elsewhere) —
+        # excluding it is what keeps the outer loop's decide_keep behaviour intact.
+        baseline = _score([_sig("review_catch")])
+        post = _score([_sig("review_catch", verdict="red")])
+        assert no_collateral_regression(baseline, post, exclude_provider_id="review_catch") is None
+
+    def test_without_exclude_the_same_signal_is_the_finding(self) -> None:
+        baseline = _score([_sig("review_catch")])
+        post = _score([_sig("review_catch", verdict="red")])
+        assert no_collateral_regression(baseline, post) == "review_catch"


### PR DESCRIPTION
## North-star PR-1 — the enabling refactor

Foundation for the directive-driven self-modification arc: the later PRs need
(a) critic rubric items selectable **by transition** so `plan` and `merge`
critics can attach to the SAME rubric registry, and (b) ONE shared
`no_collateral_regression` that both the outer loop and the future directive
loop's VERIFYING step read. This PR delivers only those two seams — no new
loop, no new rubric items, no new merge authority. Pure enabling refactor,
zero behaviour change.

### Seam 1 — transition-keyed critic rubric
`CriticRubricItem` gains a `transition` field (default `"mark_delivered"`), and
`rubric_items` / `deterministic_items` / `llm_items` / `item_for` take a
transition argument selecting only that transition's subset. `check_critic`
passes its own `"mark_delivered"`, so the `mark_delivered` gate evaluates only
the `mark_delivered` items. The critic models (`CriticDispatch` /
`CriticVerdict` / `CriticFinding`) are already transition-keyed — this brings
the **rubric** side into step without adding any rubric items.

### Seam 2 — shared `no_collateral_regression` extraction
The anti-Goodhart collateral-regression fold moves out of
`loops/outer_loop/decide.py` into a new pure module
`teatree.loops.shared.regression`, so one implementation serves both the outer
loop's keep-only-if-better rule and the future directive loop's VERIFYING step.
`decide_keep` now delegates to
`no_collateral_regression(baseline, post, exclude_provider_id=...)`; the
optional keyword-only exclude preserves the outer loop's exact target-exclusion
behaviour, while the bare 2-arg call shape (which the directive loop uses)
checks every signal.

### Behaviour-preservation proof
- The existing outer-loop `test_measure_decision.py` decide table tests stay
  green **untouched** — the extraction is behaviour-identical (`""` -> `None`
  for the no-regression case is falsy at the `if regressed:` call site either
  way).
- All 8 seeded rubric items default to `mark_delivered`, so every existing
  critic-gate and rubric conformance test stays green with zero edits.

### Anti-vacuity (tests that MATTER, RED-before)
- New `TestTransitionScoping` on the gate + `TestTransitionSelection` on the
  accessors prove `check_critic` (and the accessors) exclude a
  foreign-transition item while STILL running the `mark_delivered` items. Proven
  RED-before: stripping only the transition filter (keeping the field) turns the
  gate test and 4 accessor tests RED — the filter is load-bearing, not the
  field's mere presence.
- The extracted `no_collateral_regression` carries its own table tests at its
  new home (newly RED/REGRESSING vs baseline, pre-existing-worse-not-new,
  exclude-vs-no-exclude) AND is exercised by the unchanged-green outer-loop
  decide path.

### BLUEPRINT
No BLUEPRINT change — behaviour-preserving refactor. The `transition` field
defaults to `mark_delivered`, so the documented critic-gate behaviour
(`check_critic` walking the seeded rubric) is unchanged. The
`Check BLUEPRINT.md updated` gate passes.

## Architecture pre-check — north-star PR-1

**1. BLUEPRINT alignment** — § "Critic gate (SELFCATCH-5)". The claim: the
critic rubric becomes transition-selectable while its documented
`mark_delivered` behaviour is preserved exactly. No contradiction, so no
BLUEPRINT edit.

**2. FSM phase boundaries** — n/a. No `Ticket.State` / `Worktree.State`
transition added or moved. `transition` here is a rubric-item key
(`"mark_delivered"`), not a new FSM edge.

**3. Extension-point contracts** — the critic rubric accessors
(`deterministic_items` / `llm_items` / `item_for` / `rubric_items`) gained an
optional transition argument. Sole consumer is `core/gates/critic_gate.py`,
updated in the same change to pass `_TRANSITION`. No overlay/scanner/hook reads
the rubric.

**4. Component boundaries** — the shared fold lands in a new
`src/teatree/loops/shared/` package (pure loop-level rules), not in `core/`
(it is loop policy over factory-score snapshots, not a model/manager). The
rubric field stays in `core/critic_rubric.py`.

**5. Dependency direction** — `loops.shared.regression` imports only
`core.factory_score` + `core.factory_signals` (loops -> core, downward);
`loops.outer_loop.decide` imports `loops.shared.regression` (sibling within
loops). `tach` + `import-linter` pass — no backwards edge.

**6. Test surface** — `tests/teatree_loops/shared/test_regression.py`
(extracted fold), `TestTransitionSelection` in `test_critic_rubric.py`
(accessor filtering), `TestTransitionScoping` in `test_critic_gate.py`
(`run_critic` transition scoping). Each asserts a behaviour that regresses if
the seam is removed (proven RED-before for the transition filter).

**7. Resilience invariants** — n/a. No external write, no DB row outside the
request cycle, no fs write. Both changes are pure in-process refactors.

**8. Identity/key normalization** — the transition key is a plain string
(`"mark_delivered"`), one canonical form used at every accessor boundary; no
bare-vs-qualified split, no strip/split-to-match.

**9. Behaviour preservation / capability deletion** — this replaces
`_collateral_regression` (returned `""`) with `no_collateral_regression`
(returns `None`); the only reachable call site treats both as falsy, so no case
is dropped. The rubric change is purely additive (a defaulted field). No
must-block test inverted; no privacy/security matcher narrowed.

Implements the first of the north-star directive-driven self-modification PR
breakdown; the design doc is the authoritative spec.
