### PR TITLE
test(self-catch): registry-parity residue lanes — signal-kind↔route, gate-registry↔call-site, UserSettings↔reader, roster meta-ratchet (SELFCATCH-4, re-scoped)

### DIFF
--- a/tests/conformance/test_gate_registry_walk.py
+++ b/tests/conformance/test_gate_registry_walk.py
@@ -1,0 +1,150 @@
+"""Gate/resolver registry ↔ call-site bidirectional walk — the registered-but-uncalled lane (SELFCATCH-4).
+
+``teatree.core.model_registries`` inverts an intra-``core`` up-edge: a gate module
+registers its callable via ``register_gate("<name>", fn)`` at app-ready time, and
+:class:`teatree.core.models.ticket.Ticket` fetches it at call time via
+``get_gate("<name>")``. The name is the seam — and a bare string on both sides, so
+the two can drift silently: a registered gate that no FSM transition calls is dead
+authority, and a ``get_gate("typo")`` call site for a name nothing registered
+raises only when that transition executes (a runtime ``KeyError``, not a CI
+failure). ``test_model_registries.py`` guards the round-trip mechanics and
+hand-enumerates six known gates; this lane makes the parity TOTAL and
+introspective — an AST walk of ``src/teatree`` in both directions, so a NEW
+registered gate with no call site (or a NEW call site for an unregistered name)
+fails the PR that introduces it.
+
+Also covers the resolver registry (``register_resolver`` ↔ ``get_resolver``), the
+sibling seam sharing the same drift shape.
+"""
+
+import ast
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+
+from teatree.core.model_registries import populate_model_registries
+from teatree.core.modelkit import gate_registry
+
+_SRC_DIR = Path(__file__).resolve().parents[2] / "src" / "teatree"
+
+# The register/get callable pairs the walk covers, keyed by the runtime resolver
+# used for the liveness cross-check. A NEW registry seam of this shape enrolls
+# here (and, via the roster meta-ratchet, must); the pair is walked both ways.
+_REGISTRY_PAIRS: tuple[tuple[str, str, str], ...] = (
+    ("register_gate", "get_gate", "gate"),
+    ("register_resolver", "get_resolver", "resolver"),
+)
+
+
+def _first_string_arg(call: ast.Call) -> str | None:
+    """The first positional argument of *call* when it is a string literal, else ``None``.
+
+    A non-literal first argument (``get_gate(gate)`` where ``gate`` is a variable)
+    is a dynamic target the static walk cannot resolve — skipped, not a phantom.
+    """
+    if call.args and isinstance(call.args[0], ast.Constant) and isinstance(call.args[0].value, str):
+        return call.args[0].value
+    return None
+
+
+def _literal_call_names(func_name: str) -> set[str]:
+    """Every string-literal first arg passed to a call of ``func_name`` under ``src/teatree``.
+
+    Introspection over the source tree: ``register_gate("x", fn)`` and
+    ``get_gate("x")`` both surface here so neither side of the seam can be
+    hand-listed out of sync with the code.
+    """
+    names: set[str] = set()
+    for path in _SRC_DIR.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            called = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if called != func_name:
+                continue
+            literal = _first_string_arg(node)
+            if literal is not None:
+                names.add(literal)
+    return names
+
+
+def _assert_covers(*, producers: Iterable[str], consumers: Iterable[str], label: str) -> None:
+    uncovered = sorted(set(producers) - set(consumers))
+    assert not uncovered, f"{label}: {uncovered}"
+
+
+class TestGateRegistryBidirectionalWalk:
+    """Every registered gate/resolver has a call site, and every call site is registered."""
+
+    @pytest.mark.parametrize(("register_fn", "get_fn", "kind"), _REGISTRY_PAIRS)
+    def test_every_registration_has_a_call_site(self, register_fn: str, get_fn: str, kind: str) -> None:
+        _assert_covers(
+            producers=_literal_call_names(register_fn),
+            consumers=_literal_call_names(get_fn),
+            label=f"registered {kind}(s) with no {get_fn}(...) call site (dead {kind})",
+        )
+
+    @pytest.mark.parametrize(("register_fn", "get_fn", "kind"), _REGISTRY_PAIRS)
+    def test_every_call_site_references_a_registration(self, register_fn: str, get_fn: str, kind: str) -> None:
+        _assert_covers(
+            producers=_literal_call_names(get_fn),
+            consumers=_literal_call_names(register_fn),
+            label=f"{get_fn}(...) call site(s) for a {kind} nothing {register_fn}s (runtime KeyError waiting to fire)",
+        )
+
+    def test_every_registered_gate_resolves_at_runtime(self) -> None:
+        # Ties the static walk to runtime reality: each statically-registered gate
+        # name must resolve through the LIVE registry after population — an
+        # ``@transition`` calling ``get_gate("x")`` would otherwise KeyError.
+        populate_model_registries()
+        for name in _literal_call_names("register_gate"):
+            assert gate_registry.get_gate(name) is not None, f"registered gate {name!r} does not resolve at runtime"
+
+    def test_every_registered_resolver_resolves_at_runtime(self) -> None:
+        populate_model_registries()
+        for name in _literal_call_names("register_resolver"):
+            assert gate_registry.get_resolver(name) is not None, f"registered resolver {name!r} does not resolve"
+
+
+class TestGateRegistryWalkCardinalityFloors:
+    """Anti-vacuity — a broken AST walk that finds nothing must not pass green."""
+
+    def test_gate_floor(self) -> None:
+        registered = _literal_call_names("register_gate")
+        called = _literal_call_names("get_gate")
+        assert len(registered) >= 8, sorted(registered)
+        assert len(called) >= 8, sorted(called)
+
+    def test_resolver_floor(self) -> None:
+        assert len(_literal_call_names("register_resolver")) >= 2
+        assert len(_literal_call_names("get_resolver")) >= 2
+
+
+class TestGateRegistryWalkFiresRed:
+    """Anti-vacuity — the walk must actually name a registered-uncalled gate and a called-unregistered name."""
+
+    def test_a_registered_gate_with_no_call_site_is_named(self) -> None:
+        with pytest.raises(AssertionError, match="synthetic_registered_only"):
+            _assert_covers(
+                producers={"plan_artifact", "synthetic_registered_only"},
+                consumers={"plan_artifact"},
+                label="registered gate(s) with no call site",
+            )
+
+    def test_a_call_site_for_an_unregistered_gate_is_named(self) -> None:
+        with pytest.raises(AssertionError, match="synthetic_called_only"):
+            _assert_covers(
+                producers={"plan_artifact", "synthetic_called_only"},
+                consumers={"plan_artifact"},
+                label="get_gate(...) call site(s) for an unregistered gate",
+            )
+
+    def test_a_dynamic_call_target_is_not_a_phantom(self) -> None:
+        # ``get_gate(gate)`` with a variable arg must NOT be mistaken for a literal
+        # call site — the reverse walk would false-positive on it otherwise.
+        dynamic = ast.parse("get_gate(gate)").body[0].value
+        assert isinstance(dynamic, ast.Call)
+        assert _first_string_arg(dynamic) is None

--- a/tests/conformance/test_gate_registry_walk.py
+++ b/tests/conformance/test_gate_registry_walk.py
@@ -81,6 +81,13 @@ class TestGateRegistryBidirectionalWalk:
 
     @pytest.mark.parametrize(("register_fn", "get_fn", "kind"), _REGISTRY_PAIRS)
     def test_every_registration_has_a_call_site(self, register_fn: str, get_fn: str, kind: str) -> None:
+        # Known low-risk false-positive: a gate invoked ONLY via the dynamic
+        # ``get_gate(gate)`` loop (a variable arg the static walk cannot resolve)
+        # would show here as "registered, no literal call site". It is loud (a RED
+        # naming the gate, not a silent pass) and today never triggers — the one
+        # dynamically-dispatched gate (``plan_currency``) also has a direct literal
+        # ``get_gate("plan_currency")`` call. A future dynamic-only gate resolves it
+        # by adding one literal call site or an explicit allowlist.
         _assert_covers(
             producers=_literal_call_names(register_fn),
             consumers=_literal_call_names(get_fn),
@@ -119,6 +126,10 @@ class TestGateRegistryWalkCardinalityFloors:
         assert len(called) >= 8, sorted(called)
 
     def test_resolver_floor(self) -> None:
+        # Pinned at the exact current count: there are exactly 2 registered resolvers
+        # (``infer_overlay_for_url`` + ``resolve_overlay_name``), so ``>= 2`` is a
+        # proof the walk found the resolver seam AND a regression tripwire if one is
+        # dropped. Raise the floor when a 3rd resolver lands.
         assert len(_literal_call_names("register_resolver")) >= 2
         assert len(_literal_call_names("get_resolver")) >= 2
 

--- a/tests/conformance/test_registry_parity_roster.py
+++ b/tests/conformance/test_registry_parity_roster.py
@@ -1,0 +1,138 @@
+"""Roster-completeness meta-ratchet — the parity corpus guards ITSELF (SELFCATCH-4).
+
+Every lane in the registry-parity corpus governs one producer/consumer registry
+pair. The residual gap the per-lane cardinality floors leave: a NEW paired
+registry can be added with no parity lane at all — the corpus does not know it is
+missing coverage. This meta-lane closes it, the same "phantom roster asserted
+EMPTY" trick ``test_gate_liveness_corpus`` uses on gates.
+
+It introspects the routing/dispatch/phase modules for every registry-shaped
+module constant (``*_BY_KIND`` / ``*_BY_PHASE`` / ``*_ZONES`` / ``*_HANDLERS`` /
+``*_TARGET_PHASES``) and asserts each is enrolled in ``PARITY_LANE_ROSTER`` — a
+declared map from the registry to the test module whose parity lane covers it. A
+registry with no roster entry (and not in the ``NOT_A_PARITY_PAIR`` allowlist of
+single-sided config) fails: a producer/consumer pair added without a parity lane
+cannot ship green. Reverse: every roster entry names a live registry AND a test
+module that references it, so a phantom/renamed roster row fails too.
+"""
+
+import ast
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The modules carrying the producer/consumer registries the parity corpus governs.
+_SCOPED_MODULES: tuple[str, ...] = (
+    "src/teatree/loop/dispatch_tables.py",
+    "src/teatree/core/modelkit/phases.py",
+    "src/teatree/core/modelkit/phase_tools.py",
+    "src/teatree/loop/persistence.py",
+)
+
+# A module-level constant whose NAME matches this shape is a paired routing/phase
+# registry — the corpus's unit of coverage.
+_REGISTRY_NAME_SHAPE = re.compile(r".*(_BY_KIND|_BY_PHASE|_ZONES|_HANDLERS|_TARGET_PHASES)$")
+
+# Every registry-shaped constant -> the test module whose parity lane covers it.
+# A NEW registry of this shape must enrol here (or in NOT_A_PARITY_PAIR); the
+# per-lane floors cannot catch an entirely unenrolled pair, this ratchet does.
+PARITY_LANE_ROSTER: dict[str, str] = {
+    # signal-kind ↔ dispatch/statusline route totality — this PR's LANE 1.
+    "AGENT_BY_KIND": "tests/conformance/test_signal_route_totality.py",
+    "MECHANICAL_BY_KIND": "tests/conformance/test_signal_route_totality.py",
+    "STATUSLINE_ZONE_BY_KIND": "tests/conformance/test_signal_route_totality.py",
+    # zone-executor + phase-totality parity — the DIS-A framework.
+    "AGENT_ZONES": "tests/conformance/test_registry_parity.py",
+    "PERSISTED_AT_SOURCE_ZONES": "tests/conformance/test_registry_parity.py",
+    "SUBAGENT_BY_PHASE": "tests/conformance/test_registry_parity.py",
+    "_TOOLS_BY_PHASE": "tests/conformance/test_registry_parity.py",
+    "_ZONE_HANDLERS": "tests/conformance/test_registry_parity.py",
+    "_HANDLER_TARGET_PHASES": "tests/conformance/test_registry_parity.py",
+    # fan-out panel parity (keys ⊆ SUBAGENT_BY_PHASE) — the #2229 conformance lane.
+    "FANOUT_BY_PHASE": "tests/teatree_core/test_phase_agent_conformance.py",
+}
+
+# Registry-shaped constants that are NOT producer/consumer PAIRS — single-sided
+# routing config or diagnostic sets that carry no partner registry to drift
+# against, so a parity lane would have nothing to compare. Named + reviewable.
+NOT_A_PARITY_PAIR: frozenset[str] = frozenset()
+
+
+def _registry_constants(module_rel: str) -> set[str]:
+    """Every module-level constant in *module_rel* whose name matches the registry shape."""
+    tree = ast.parse((_REPO_ROOT / module_rel).read_text(encoding="utf-8"), filename=module_rel)
+    names: set[str] = set()
+    for node in tree.body:
+        targets: list[str] = []
+        if isinstance(node, ast.Assign):
+            targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            targets = [node.target.id]
+        names.update(name for name in targets if _REGISTRY_NAME_SHAPE.match(name))
+    return names
+
+
+def discovered_registries() -> set[str]:
+    """Every registry-shaped constant across the scoped modules — introspection, not a hand-list."""
+    registries: set[str] = set()
+    for module_rel in _SCOPED_MODULES:
+        registries |= _registry_constants(module_rel)
+    return registries
+
+
+class TestParityRosterIsComplete:
+    """Every discovered registry is enrolled in a parity lane — no silent-coverage gap."""
+
+    def test_every_registry_shaped_constant_is_enrolled(self) -> None:
+        unenrolled = sorted(
+            name for name in discovered_registries() if name not in PARITY_LANE_ROSTER and name not in NOT_A_PARITY_PAIR
+        )
+        assert not unenrolled, (
+            "registry-shaped constant(s) with no parity lane — a producer/consumer pair added without "
+            "coverage. Add a parity lane and enrol it in PARITY_LANE_ROSTER, or (single-sided config) "
+            "NOT_A_PARITY_PAIR: " + str(unenrolled)
+        )
+
+    def test_no_roster_entry_is_a_phantom_registry(self) -> None:
+        # Reverse: a roster row must name a constant that still exists somewhere in
+        # the scoped modules OR the phases module (FANOUT_BY_PHASE lives there).
+        known = discovered_registries() | _registry_constants("src/teatree/core/modelkit/phases.py")
+        phantom = sorted(name for name in PARITY_LANE_ROSTER if name not in known)
+        assert not phantom, f"PARITY_LANE_ROSTER entries naming no live registry (renamed/removed): {phantom}"
+
+    def test_every_roster_lane_file_exists_and_references_its_registry(self) -> None:
+        # A roster entry whose covering test file is gone, or no longer mentions the
+        # registry, is a stale claim of coverage.
+        for registry, test_rel in PARITY_LANE_ROSTER.items():
+            path = _REPO_ROOT / test_rel
+            assert path.is_file(), f"{registry}: covering lane file {test_rel} is missing"
+            assert registry in path.read_text(encoding="utf-8"), (
+                f"{registry}: covering lane {test_rel} does not reference it (renamed/uncovered)"
+            )
+
+
+class TestParityRosterCardinalityFloors:
+    """Anti-vacuity — a broken discovery that finds nothing must not pass green."""
+
+    def test_discovery_and_roster_floors(self) -> None:
+        assert len(discovered_registries()) >= 9, sorted(discovered_registries())
+        assert len(PARITY_LANE_ROSTER) >= 10, sorted(PARITY_LANE_ROSTER)
+
+
+class TestParityRosterFiresRed:
+    """Anti-vacuity — the ratchet must actually catch an unenrolled paired registry."""
+
+    def test_a_synthetic_unenrolled_registry_is_reported(self) -> None:
+        # A registry-shaped constant absent from both the roster and the allowlist is
+        # exactly the uncovered-pair class the ratchet exists to catch.
+        synthetic = "SYNTHETIC_ROUTE_BY_KIND"
+        assert _REGISTRY_NAME_SHAPE.match(synthetic)
+        assert synthetic not in PARITY_LANE_ROSTER
+        assert synthetic not in NOT_A_PARITY_PAIR
+
+    def test_the_shape_matcher_is_selective(self) -> None:
+        # The heuristic must not sweep in unrelated constants (a false ratchet trip).
+        assert not _REGISTRY_NAME_SHAPE.match("SELF_UPDATE_CI_SKIP_REASONS")
+        assert not _REGISTRY_NAME_SHAPE.match("DUAL_DISPATCH")
+        assert _REGISTRY_NAME_SHAPE.match("AGENT_BY_KIND")

--- a/tests/conformance/test_registry_parity_roster.py
+++ b/tests/conformance/test_registry_parity_roster.py
@@ -6,14 +6,17 @@ registry can be added with no parity lane at all — the corpus does not know it
 missing coverage. This meta-lane closes it, the same "phantom roster asserted
 EMPTY" trick ``test_gate_liveness_corpus`` uses on gates.
 
-It introspects the routing/dispatch/phase modules for every registry-shaped
+The scan is TREE-WIDE, not a hardcoded module list: a hardcoded list is exactly
+what rots (an early version scanned four modules and already missed
+``dispatch.py``'s ``_CONDITIONAL_HANDLERS``, a real ``*_HANDLERS`` dispatch
+registry). It introspects EVERY module under ``src/teatree`` for a registry-shaped
 module constant (``*_BY_KIND`` / ``*_BY_PHASE`` / ``*_ZONES`` / ``*_HANDLERS`` /
 ``*_TARGET_PHASES``) and asserts each is enrolled in ``PARITY_LANE_ROSTER`` — a
 declared map from the registry to the test module whose parity lane covers it. A
 registry with no roster entry (and not in the ``NOT_A_PARITY_PAIR`` allowlist of
-single-sided config) fails: a producer/consumer pair added without a parity lane
-cannot ship green. Reverse: every roster entry names a live registry AND a test
-module that references it, so a phantom/renamed roster row fails too.
+single-sided config) fails: a producer/consumer pair added anywhere without a
+parity lane cannot ship green. A self-completeness assertion pins that the scan
+stays tree-wide, so the scope itself cannot silently re-narrow.
 """
 
 import ast
@@ -21,14 +24,8 @@ import re
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
-
-# The modules carrying the producer/consumer registries the parity corpus governs.
-_SCOPED_MODULES: tuple[str, ...] = (
-    "src/teatree/loop/dispatch_tables.py",
-    "src/teatree/core/modelkit/phases.py",
-    "src/teatree/core/modelkit/phase_tools.py",
-    "src/teatree/loop/persistence.py",
-)
+#: The WHOLE package — the scan root is the package, never a hardcoded subset.
+_SCAN_ROOT = _REPO_ROOT / "src" / "teatree"
 
 # A module-level constant whose NAME matches this shape is a paired routing/phase
 # registry — the corpus's unit of coverage.
@@ -38,10 +35,12 @@ _REGISTRY_NAME_SHAPE = re.compile(r".*(_BY_KIND|_BY_PHASE|_ZONES|_HANDLERS|_TARG
 # A NEW registry of this shape must enrol here (or in NOT_A_PARITY_PAIR); the
 # per-lane floors cannot catch an entirely unenrolled pair, this ratchet does.
 PARITY_LANE_ROSTER: dict[str, str] = {
-    # signal-kind ↔ dispatch/statusline route totality — this PR's LANE 1.
+    # signal-kind ↔ dispatch/statusline route totality — this PR's LANE 1. It also
+    # consumes `_CONDITIONAL_HANDLERS` into its explicitly-routed union.
     "AGENT_BY_KIND": "tests/conformance/test_signal_route_totality.py",
     "MECHANICAL_BY_KIND": "tests/conformance/test_signal_route_totality.py",
     "STATUSLINE_ZONE_BY_KIND": "tests/conformance/test_signal_route_totality.py",
+    "_CONDITIONAL_HANDLERS": "tests/conformance/test_signal_route_totality.py",
     # zone-executor + phase-totality parity — the DIS-A framework.
     "AGENT_ZONES": "tests/conformance/test_registry_parity.py",
     "PERSISTED_AT_SOURCE_ZONES": "tests/conformance/test_registry_parity.py",
@@ -58,10 +57,16 @@ PARITY_LANE_ROSTER: dict[str, str] = {
 # against, so a parity lane would have nothing to compare. Named + reviewable.
 NOT_A_PARITY_PAIR: frozenset[str] = frozenset()
 
+# The scan must span at least this many distinct subpackages — a self-completeness
+# floor so a re-narrowed walk (back to one module/dir) is caught, not the drift
+# the tree-wide scan exists to prevent.
+_MIN_SUBPACKAGES = 2
+# Registries known to live in DISTINCT subpackages — a re-narrowed scan drops one.
+_CROSS_SUBPACKAGE_ANCHORS: frozenset[str] = frozenset({"AGENT_BY_KIND", "SUBAGENT_BY_PHASE", "_CONDITIONAL_HANDLERS"})
 
-def _registry_constants(module_rel: str) -> set[str]:
-    """Every module-level constant in *module_rel* whose name matches the registry shape."""
-    tree = ast.parse((_REPO_ROOT / module_rel).read_text(encoding="utf-8"), filename=module_rel)
+
+def _registry_constants(tree: ast.Module) -> set[str]:
+    """Every module-level constant in *tree* whose name matches the registry shape."""
     names: set[str] = set()
     for node in tree.body:
         targets: list[str] = []
@@ -73,12 +78,20 @@ def _registry_constants(module_rel: str) -> set[str]:
     return names
 
 
+def _discovered_by_module() -> dict[str, set[str]]:
+    """Registry-shaped constants keyed by their module path (relative to ``src``)."""
+    by_module: dict[str, set[str]] = {}
+    for path in _SCAN_ROOT.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        found = _registry_constants(tree)
+        if found:
+            by_module[path.relative_to(_SCAN_ROOT).as_posix()] = found
+    return by_module
+
+
 def discovered_registries() -> set[str]:
-    """Every registry-shaped constant across the scoped modules — introspection, not a hand-list."""
-    registries: set[str] = set()
-    for module_rel in _SCOPED_MODULES:
-        registries |= _registry_constants(module_rel)
-    return registries
+    """Every registry-shaped constant across the WHOLE package — introspection, not a hand-list."""
+    return {name for names in _discovered_by_module().values() for name in names}
 
 
 class TestParityRosterIsComplete:
@@ -95,10 +108,8 @@ class TestParityRosterIsComplete:
         )
 
     def test_no_roster_entry_is_a_phantom_registry(self) -> None:
-        # Reverse: a roster row must name a constant that still exists somewhere in
-        # the scoped modules OR the phases module (FANOUT_BY_PHASE lives there).
-        known = discovered_registries() | _registry_constants("src/teatree/core/modelkit/phases.py")
-        phantom = sorted(name for name in PARITY_LANE_ROSTER if name not in known)
+        # Reverse: a roster row must name a constant that still exists in the tree.
+        phantom = sorted(name for name in PARITY_LANE_ROSTER if name not in discovered_registries())
         assert not phantom, f"PARITY_LANE_ROSTER entries naming no live registry (renamed/removed): {phantom}"
 
     def test_every_roster_lane_file_exists_and_references_its_registry(self) -> None:
@@ -112,12 +123,37 @@ class TestParityRosterIsComplete:
             )
 
 
+class TestParityRosterScanIsTreeWide:
+    """Self-completeness — the scan cannot silently re-narrow to a hardcoded subset."""
+
+    def test_scan_root_is_the_whole_package(self) -> None:
+        assert _SCAN_ROOT.name == "teatree"
+        assert (_SCAN_ROOT / "__init__.py").is_file()
+
+    def test_scan_spans_multiple_subpackages(self) -> None:
+        # A walk narrowed back to one module/dir drops registries from other
+        # subpackages; the anchors span core/ and loop/, so all must be discovered.
+        discovered = discovered_registries()
+        missing_anchors = sorted(_CROSS_SUBPACKAGE_ANCHORS - discovered)
+        assert not missing_anchors, (
+            f"tree-wide scan missed cross-subpackage anchor(s) — scope narrowed?: {missing_anchors}"
+        )
+        subpackages = {module.split("/", 1)[0] for module in _discovered_by_module()}
+        assert len(subpackages) >= _MIN_SUBPACKAGES, f"scan reached only {subpackages} — not tree-wide"
+
+    def test_previously_unscanned_conditional_handlers_is_now_covered(self) -> None:
+        # The exact regression a hardcoded 4-module scope missed: dispatch.py's
+        # `_CONDITIONAL_HANDLERS` is discovered AND enrolled.
+        assert "_CONDITIONAL_HANDLERS" in discovered_registries()
+        assert "_CONDITIONAL_HANDLERS" in PARITY_LANE_ROSTER
+
+
 class TestParityRosterCardinalityFloors:
     """Anti-vacuity — a broken discovery that finds nothing must not pass green."""
 
     def test_discovery_and_roster_floors(self) -> None:
-        assert len(discovered_registries()) >= 9, sorted(discovered_registries())
-        assert len(PARITY_LANE_ROSTER) >= 10, sorted(PARITY_LANE_ROSTER)
+        assert len(discovered_registries()) >= 10, sorted(discovered_registries())
+        assert len(PARITY_LANE_ROSTER) >= 11, sorted(PARITY_LANE_ROSTER)
 
 
 class TestParityRosterFiresRed:
@@ -136,3 +172,4 @@ class TestParityRosterFiresRed:
         assert not _REGISTRY_NAME_SHAPE.match("SELF_UPDATE_CI_SKIP_REASONS")
         assert not _REGISTRY_NAME_SHAPE.match("DUAL_DISPATCH")
         assert _REGISTRY_NAME_SHAPE.match("AGENT_BY_KIND")
+        assert _REGISTRY_NAME_SHAPE.match("_CONDITIONAL_HANDLERS")

--- a/tests/conformance/test_signal_route_totality.py
+++ b/tests/conformance/test_signal_route_totality.py
@@ -165,6 +165,28 @@ def _produced(kind: str, literals: set[str], prefixes: set[str]) -> bool:
     return kind in literals or any(kind.startswith(prefix) for prefix in prefixes)
 
 
+def unrouted_kinds(literals: set[str]) -> list[str]:
+    """Emitted literal kinds with no explicit route/drop/allowlist — the forward predicate.
+
+    Shared by the real assertion and the anti-vacuity self-test so the gate is
+    proven to fire by running the SAME predicate over an injected emitted-set.
+    """
+    return sorted(
+        kind
+        for kind in literals
+        if kind not in _EXPLICITLY_ROUTED_KINDS and not _prefix_dropped(kind) and kind not in INTENTIONAL_FALLBACK_KINDS
+    )
+
+
+def dead_routes(literals: set[str], prefixes: set[str]) -> list[str]:
+    """Dispatch-route keys no scanner produces and not pre-provisioned — the reverse predicate."""
+    return sorted(
+        kind
+        for kind in _DISPATCH_ROUTE_KEYS
+        if not _produced(kind, literals, prefixes) and kind not in ROUTES_WITHOUT_STATIC_PRODUCER
+    )
+
+
 class TestEveryEmittedKindHasAnExplicitRoute:
     """Forward — a scanner-emitted kind is never a silent in_flight fallback.
 
@@ -175,13 +197,7 @@ class TestEveryEmittedKindHasAnExplicitRoute:
 
     def test_no_emitted_kind_falls_through_to_the_generic_fallback(self) -> None:
         literals, _ = emitted_signal_kinds()
-        uncovered = sorted(
-            kind
-            for kind in literals
-            if kind not in _EXPLICITLY_ROUTED_KINDS
-            and not _prefix_dropped(kind)
-            and kind not in INTENTIONAL_FALLBACK_KINDS
-        )
+        uncovered = unrouted_kinds(literals)
         assert not uncovered, (
             "scanner-emitted signal kind(s) with no explicit dispatch/statusline route — "
             "each falls through to the generic ('statusline', 'in_flight') fallback (a silent drop). "
@@ -216,11 +232,7 @@ class TestEveryDispatchRouteHasAProducer:
 
     def test_no_dispatch_route_key_is_a_dead_route(self) -> None:
         literals, prefixes = emitted_signal_kinds()
-        dead = sorted(
-            kind
-            for kind in _DISPATCH_ROUTE_KEYS
-            if not _produced(kind, literals, prefixes) and kind not in ROUTES_WITHOUT_STATIC_PRODUCER
-        )
+        dead = dead_routes(literals, prefixes)
         assert not dead, (
             "dispatch-route key(s) with no scanner producing the kind (dead route) — "
             "wire a producer or add to ROUTES_WITHOUT_STATIC_PRODUCER on purpose: " + str(dead)
@@ -250,19 +262,19 @@ class TestSignalRouteTotalityFiresRed:
     """Anti-vacuity — the lane must actually catch a new-kind silent drop and a dead route."""
 
     def test_a_synthetic_unrouted_kind_is_reported(self) -> None:
-        # A synthetic kind that no table routes, no prefix drops, and no allowlist
-        # names is exactly the silent-drop class — the forward predicate flags it.
+        # Run the REAL forward predicate over an injected emitted-set: a synthetic
+        # kind that no table routes, no prefix drops, and no allowlist names is
+        # named, a genuinely-routed kind is not — the silent-drop class fires.
         synthetic = "synthetic_scanner.brandnew_unrouted_kind"
-        assert synthetic not in _EXPLICITLY_ROUTED_KINDS
-        assert not _prefix_dropped(synthetic)
-        assert synthetic not in INTENTIONAL_FALLBACK_KINDS
+        result = unrouted_kinds({synthetic, "reviewer_pr.new_sha"})
+        assert result == [synthetic], result
 
     def test_a_synthetic_dead_route_is_reported(self) -> None:
-        # A route key produced by no scanner and not pre-provisioned is a dead route.
-        literals, prefixes = emitted_signal_kinds()
-        synthetic = "synthetic_route.no_producer"
-        assert not _produced(synthetic, literals, prefixes)
-        assert synthetic not in ROUTES_WITHOUT_STATIC_PRODUCER
+        # Run the REAL reverse predicate over an empty emitted-set: every dispatch
+        # route key except the pre-provisioned allowlist is then unproduced (dead).
+        dead = dead_routes(set(), set())
+        assert set(_DISPATCH_ROUTE_KEYS) - set(ROUTES_WITHOUT_STATIC_PRODUCER) == set(dead)
+        assert dead, "reverse predicate must name dead routes when nothing is produced"
 
     def test_a_resolved_family_prefix_covers_its_dynamic_kinds(self) -> None:
         # The reverse walk must not false-positive on dynamically-built kinds: the

--- a/tests/conformance/test_signal_route_totality.py
+++ b/tests/conformance/test_signal_route_totality.py
@@ -1,0 +1,272 @@
+"""Signal-KIND ↔ dispatch/statusline route totality — the kind-level anti-drift lane (SELFCATCH-4).
+
+``test_registry_parity.py`` LANE 1 governs the *zone* level (``AGENT_ZONES`` ↔
+``_ZONE_HANDLERS``): a dispatch zone with no persistence executor. This lane
+governs the *kind* level, the distinct gap that leaves: a scanner emitting a NEW
+``ScanSignal.kind`` with no ``AGENT_BY_KIND`` / ``MECHANICAL_BY_KIND`` /
+``STATUSLINE_ZONE_BY_KIND`` / drop entry is not caught by the zone lane — it
+falls through :func:`teatree.loop.dispatch._dispatch_one` to the generic
+``("statusline", "in_flight")`` fallback, a silent statusline drop into the wrong
+zone.
+
+Both directions, introspective (won't drift). Forward (kind → route): every
+scanner-emitted kind is EXPLICITLY routed (a route/conditional/special-case),
+explicitly dropped (a drop-kind / drop-prefix), or named in the
+``INTENTIONAL_FALLBACK_KINDS`` allowlist (deliberate in_flight rendering). A NEW
+kind that is none of these fails loud. Reverse (route → kind): every
+``AGENT_BY_KIND`` / ``MECHANICAL_BY_KIND`` dispatch-route key is a kind some
+scanner actually emits (as a literal, a resolved module constant, or an f-string
+family), or is named in ``ROUTES_WITHOUT_STATIC_PRODUCER`` — a dispatch route for
+a kind nothing produces is dead surface.
+"""
+
+import ast
+from pathlib import Path
+
+from teatree.loop.dispatch import _CONDITIONAL_HANDLERS
+from teatree.loop.dispatch_tables import (
+    AGENT_BY_KIND,
+    MECHANICAL_BY_KIND,
+    STATUSLINE_DROP_KINDS,
+    STATUSLINE_DROP_PREFIXES,
+    STATUSLINE_ZONE_BY_KIND,
+)
+
+_LOOP_DIR = Path(__file__).resolve().parents[2] / "src" / "teatree" / "loop"
+
+# Kinds that DELIBERATELY render through the generic ``("statusline", "in_flight")``
+# fallback in ``_dispatch_one`` — low-priority bookkeeping / status observations
+# that need no dedicated route. Named + reviewable (the SIG-4 allowlist idiom): a
+# NEW emitted kind is NOT on this list, so it fails the forward walk until a
+# conscious route-or-fallback decision is made.
+INTENTIONAL_FALLBACK_KINDS: frozenset[str] = frozenset(
+    {
+        "deferred_question.mirrored",
+        "eval_local.queued",
+        "incoming_event.dead_letter",
+        "notify.redelivered",
+        "pr.approved",
+        "team_pane.reaped",
+        "waiting.digest",
+    }
+)
+
+# Dispatch-route keys with no statically discoverable producer in ``src/teatree/loop``.
+# ``skill_drift_detected`` (#1295 cap H) routes the ac-reviewing-codebase auto-fix
+# sweep's per-finding signal to ``t3:coder``; the emitting sweep is documented on
+# ``AssessFinding`` but is not wired as a static ``ScanSignal`` in this tree, so the
+# route is pre-provisioned for it. Named so a reviewer sees the pre-provisioned
+# route; a NEW unproduced route is NOT on this list and fails the reverse walk.
+ROUTES_WITHOUT_STATIC_PRODUCER: frozenset[str] = frozenset({"skill_drift_detected"})
+
+
+def _kind_argument(call: ast.Call) -> ast.expr | None:
+    """The ``kind`` argument of a ``ScanSignal(...)`` call — ``kind=`` kwarg or first positional."""
+    for keyword in call.keywords:
+        if keyword.arg == "kind":
+            return keyword.value
+    return call.args[0] if call.args else None
+
+
+def _string_assignments(tree: ast.Module) -> dict[str, list[ast.expr]]:
+    """Every ``NAME = <expr>`` binding in the module (module- and function-level).
+
+    Resolves an indirect ``kind`` argument that is a ``Name`` — a module constant
+    (``CLOSE_CANDIDATE_KIND``) or a local ``kind = f"self_update.{...}"`` — back to
+    its value expression(s), so a dynamically-built kind is not invisible.
+    """
+    bindings: dict[str, list[ast.expr]] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    bindings.setdefault(target.id, []).append(node.value)
+    return bindings
+
+
+def _resolve_kind(expr: ast.expr, bindings: dict[str, list[ast.expr]]) -> tuple[set[str], set[str]]:
+    """Resolve a kind-argument expression to (literal kinds, family prefixes).
+
+    ``Constant`` -> a literal kind. ``JoinedStr`` (f-string) -> its leading literal
+    prefix (``f"pr_sweep.{x}"`` -> ``"pr_sweep."``). ``IfExp`` -> both branches.
+    ``Name`` -> its binding(s). ``Attribute`` (``signal.kind`` re-emission) is a
+    pass-through and contributes nothing.
+    """
+    literals: set[str] = set()
+    prefixes: set[str] = set()
+    if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
+        literals.add(expr.value)
+    elif isinstance(expr, ast.JoinedStr):
+        head = expr.values[0] if expr.values else None
+        if isinstance(head, ast.Constant) and isinstance(head.value, str):
+            prefixes.add(head.value)
+    elif isinstance(expr, ast.IfExp):
+        for branch in (expr.body, expr.orelse):
+            branch_literals, branch_prefixes = _resolve_kind(branch, bindings)
+            literals |= branch_literals
+            prefixes |= branch_prefixes
+    elif isinstance(expr, ast.Name):
+        for value in bindings.get(expr.id, ()):
+            value_literals, value_prefixes = _resolve_kind(value, bindings)
+            literals |= value_literals
+            prefixes |= value_prefixes
+    return literals, prefixes
+
+
+def emitted_signal_kinds() -> tuple[set[str], set[str]]:
+    """Every ``ScanSignal`` kind produced under ``src/teatree/loop`` — (literals, prefixes).
+
+    Introspection, not a hand-list: a new scanner emitting a new kind is discovered
+    the moment it lands, so the totality assertion cannot silently lag it.
+    """
+    literals: set[str] = set()
+    prefixes: set[str] = set()
+    for path in _LOOP_DIR.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        bindings = _string_assignments(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if name != "ScanSignal":
+                continue
+            argument = _kind_argument(node)
+            if argument is None:
+                continue
+            call_literals, call_prefixes = _resolve_kind(argument, bindings)
+            literals |= call_literals
+            prefixes |= call_prefixes
+    return literals, prefixes
+
+
+#: Every kind the dispatcher routes or drops EXPLICITLY (never via the in_flight
+#: fallback): the three routing tables, the drop-kinds, the payload-conditional
+#: handlers, and the one payload-branch special case in ``_dispatch_one``.
+_EXPLICITLY_ROUTED_KINDS: frozenset[str] = frozenset(
+    set(AGENT_BY_KIND)
+    | set(MECHANICAL_BY_KIND)
+    | set(STATUSLINE_ZONE_BY_KIND)
+    | set(STATUSLINE_DROP_KINDS)
+    | set(_CONDITIONAL_HANDLERS)
+    | {"ticket.disposition_candidate"}
+)
+
+#: The two generic DISPATCH route tables (agent + mechanical), whose keys must each
+#: name a kind a scanner actually produces — the reverse (dead-route) direction.
+_DISPATCH_ROUTE_KEYS: frozenset[str] = frozenset(set(AGENT_BY_KIND) | set(MECHANICAL_BY_KIND))
+
+
+def _prefix_dropped(kind: str) -> bool:
+    return any(kind.startswith(prefix) for prefix in STATUSLINE_DROP_PREFIXES)
+
+
+def _produced(kind: str, literals: set[str], prefixes: set[str]) -> bool:
+    return kind in literals or any(kind.startswith(prefix) for prefix in prefixes)
+
+
+class TestEveryEmittedKindHasAnExplicitRoute:
+    """Forward — a scanner-emitted kind is never a silent in_flight fallback.
+
+    Every literal ``ScanSignal.kind`` must be explicitly routed, explicitly
+    dropped, or an allowlisted deliberate fallback. A new emitted kind that
+    resolves to the generic fallback fails here instead of shipping.
+    """
+
+    def test_no_emitted_kind_falls_through_to_the_generic_fallback(self) -> None:
+        literals, _ = emitted_signal_kinds()
+        uncovered = sorted(
+            kind
+            for kind in literals
+            if kind not in _EXPLICITLY_ROUTED_KINDS
+            and not _prefix_dropped(kind)
+            and kind not in INTENTIONAL_FALLBACK_KINDS
+        )
+        assert not uncovered, (
+            "scanner-emitted signal kind(s) with no explicit dispatch/statusline route — "
+            "each falls through to the generic ('statusline', 'in_flight') fallback (a silent drop). "
+            "Route them, drop them, or add to INTENTIONAL_FALLBACK_KINDS on purpose: " + str(uncovered)
+        )
+
+    def test_allowlisted_fallback_kinds_are_all_still_emitted(self) -> None:
+        # A stale allowlist entry (a kind that no scanner emits anymore) is dead
+        # surface — the allowlist must not outlive its kinds.
+        literals, _ = emitted_signal_kinds()
+        stale = sorted(INTENTIONAL_FALLBACK_KINDS - literals)
+        assert not stale, f"INTENTIONAL_FALLBACK_KINDS entries no scanner emits (dead allowlist): {stale}"
+
+    def test_no_allowlisted_fallback_kind_is_secretly_routed(self) -> None:
+        # An allowlist entry that IS explicitly routed / dropped is a contradiction:
+        # keep the allowlist minimal to the genuinely-fallback kinds.
+        contradictory = sorted(
+            kind for kind in INTENTIONAL_FALLBACK_KINDS if kind in _EXPLICITLY_ROUTED_KINDS or _prefix_dropped(kind)
+        )
+        assert not contradictory, (
+            f"INTENTIONAL_FALLBACK_KINDS entries that are actually routed/dropped: {contradictory}"
+        )
+
+
+class TestEveryDispatchRouteHasAProducer:
+    """Reverse — a dispatch route for a kind nothing emits is dead surface.
+
+    Every ``AGENT_BY_KIND`` / ``MECHANICAL_BY_KIND`` key must name a kind a scanner
+    produces (literal, resolved constant, or f-string family), or be an
+    allowlisted pre-provisioned route.
+    """
+
+    def test_no_dispatch_route_key_is_a_dead_route(self) -> None:
+        literals, prefixes = emitted_signal_kinds()
+        dead = sorted(
+            kind
+            for kind in _DISPATCH_ROUTE_KEYS
+            if not _produced(kind, literals, prefixes) and kind not in ROUTES_WITHOUT_STATIC_PRODUCER
+        )
+        assert not dead, (
+            "dispatch-route key(s) with no scanner producing the kind (dead route) — "
+            "wire a producer or add to ROUTES_WITHOUT_STATIC_PRODUCER on purpose: " + str(dead)
+        )
+
+    def test_pre_provisioned_routes_are_registered_routes(self) -> None:
+        # A ROUTES_WITHOUT_STATIC_PRODUCER entry must still BE a live dispatch route;
+        # otherwise the allowlist points at nothing.
+        orphan = sorted(ROUTES_WITHOUT_STATIC_PRODUCER - _DISPATCH_ROUTE_KEYS)
+        assert not orphan, f"ROUTES_WITHOUT_STATIC_PRODUCER entries that are not dispatch routes: {orphan}"
+
+
+class TestSignalRouteTotalityCardinalityFloors:
+    """Anti-vacuity — a broken enumerator that discovers nothing must not pass green."""
+
+    def test_emitted_kind_floor(self) -> None:
+        literals, prefixes = emitted_signal_kinds()
+        assert len(literals) >= 50, sorted(literals)
+        assert len(prefixes) >= 3, sorted(prefixes)
+
+    def test_route_table_floor(self) -> None:
+        assert len(_EXPLICITLY_ROUTED_KINDS) >= 30, sorted(_EXPLICITLY_ROUTED_KINDS)
+        assert len(_DISPATCH_ROUTE_KEYS) >= 10, sorted(_DISPATCH_ROUTE_KEYS)
+
+
+class TestSignalRouteTotalityFiresRed:
+    """Anti-vacuity — the lane must actually catch a new-kind silent drop and a dead route."""
+
+    def test_a_synthetic_unrouted_kind_is_reported(self) -> None:
+        # A synthetic kind that no table routes, no prefix drops, and no allowlist
+        # names is exactly the silent-drop class — the forward predicate flags it.
+        synthetic = "synthetic_scanner.brandnew_unrouted_kind"
+        assert synthetic not in _EXPLICITLY_ROUTED_KINDS
+        assert not _prefix_dropped(synthetic)
+        assert synthetic not in INTENTIONAL_FALLBACK_KINDS
+
+    def test_a_synthetic_dead_route_is_reported(self) -> None:
+        # A route key produced by no scanner and not pre-provisioned is a dead route.
+        literals, prefixes = emitted_signal_kinds()
+        synthetic = "synthetic_route.no_producer"
+        assert not _produced(synthetic, literals, prefixes)
+        assert synthetic not in ROUTES_WITHOUT_STATIC_PRODUCER
+
+    def test_a_resolved_family_prefix_covers_its_dynamic_kinds(self) -> None:
+        # The reverse walk must not false-positive on dynamically-built kinds: the
+        # ``pr_sweep.`` f-string family means ``pr_sweep.flag_no_review`` is produced.
+        literals, prefixes = emitted_signal_kinds()
+        assert _produced("pr_sweep.flag_no_review", literals, prefixes)
+        assert _produced("issue_disposition.close_candidate", literals, prefixes)

--- a/tests/conformance/test_user_settings_readers.py
+++ b/tests/conformance/test_user_settings_readers.py
@@ -1,4 +1,4 @@
-"""UserSettings field ↔ ≥1 reader — the dead-config totality lane (SELFCATCH-4).
+"""UserSettings field ↔ ≥1 real reader — the dead-config totality lane (SELFCATCH-4).
 
 ``test_removed_dead_settings.py`` guards exactly two historically-removed fields
 (``branch_prefix``, ``ask_before_post_on_behalf``, #2731) and ``test_feature_flags``
@@ -6,19 +6,26 @@ governs only flag lifecycle. Neither is total: a NEW ``UserSettings`` field that
 nothing reads — the dead-toggle class — ships green, an operator-facing knob that
 silently does nothing.
 
-This lane makes the guard total by introspection. Every :class:`UserSettings`
-field must be READ by at least one consumer: a ``.<field>`` attribute access or an
-exact ``"<field>"`` string constant somewhere under ``src/teatree`` /
-``hooks/*.py`` (AST — so a docstring merely *mentioning* the name, being a longer
-string, never counts as a read), or the field name on a non-comment line of a
-``hooks/*.sh`` script (the pre-Django cold-read seam). A field read by none of
-these is dead config and fails, unless it is named in ``FIELDS_WITHOUT_SRC_READER``
-— the reviewable allowlist of fields consumed by agent-prose / documentation
-rather than ``src`` code.
+This lane makes the guard total by introspection — but a reader must be a REAL
+settings read, not a coincidental token match. A bare ``django.utils.timezone``
+attribute (receiver is a module, not a settings object) and a keyword string
+``"privacy"`` in an unrelated intent catalog would each falsely "read" a field
+that the codebase itself documents as reader-less, hollowing the lane out. So a
+read is one of: a ``.<field>`` access whose RECEIVER resolves to a settings object
+(``get_effective_settings()`` / ``load_config().user`` / a var bound to those / a
+high-confidence ``settings``/``cfg``/``config`` receiver), a ``getattr(settings,
+"<field>")`` / cold-reader key read, a ``<NAME>_KEY = "<field>"`` config-key
+constant, a field-name string literal inside a settings-RESOLUTION module (where
+such a string IS a config key — ``getattr(settings, key)`` over a dict/tuple of
+key names), or the field on a non-comment line of a ``hooks/*.sh`` cold-read
+script. A field read by none is dead config, unless named in
+``FIELDS_WITHOUT_SRC_READER`` — the reviewable allowlist of fields consumed by
+agent-prose / documentation rather than ``src`` code, or documented reader-less.
 """
 
 import ast
 import dataclasses
+from collections.abc import Callable
 from pathlib import Path
 
 from teatree.config import UserSettings
@@ -28,19 +35,66 @@ _SETTINGS_DEF = (_REPO_ROOT / "src" / "teatree" / "config" / "settings.py").reso
 _PY_ROOTS = (_REPO_ROOT / "src" / "teatree", _REPO_ROOT / "hooks")
 _SH_ROOT = _REPO_ROOT / "hooks"
 
+#: Functions returning a ``UserSettings`` — a call to one is a settings object.
+_SETTINGS_ACCESSORS = frozenset({"get_effective_settings"})
+#: Functions returning a ``TeaTreeConfig`` — its ``.user`` is a ``UserSettings``.
+_CONFIG_ACCESSORS = frozenset({"load_config"})
+#: High-confidence bare receiver names that hold a ``UserSettings`` object. A
+#: lower-confidence receiver (``s``, ``user``) is only trusted when var-tracking
+#: bound it to an accessor in the same file — never blanket-listed.
+_SETTINGS_RECEIVERS = frozenset({"settings", "settings_", "cfg", "config", "user_settings", "effective_settings"})
+#: Calls whose string-literal argument is a settings/config read KEY.
+_READ_HELPERS = frozenset(
+    {
+        "getattr",
+        "bool_setting",
+        "int_setting",
+        "str_setting",
+        "value_setting",
+        "read_setting",
+        "_cold_db_bool",
+        "_cold_db_int",
+        "_cold_db_raw",
+        "_cold_db_str",
+    }
+)
+#: A module referencing any of these RESOLVES settings by key, so a field-name
+#: string literal in it IS a config key (``getattr(settings, key)`` over a
+#: dict/tuple of key names). An unrelated module (an intent catalog) has none, so
+#: a keyword string that merely collides with a field name never counts there.
+_RESOLUTION_MARKERS = frozenset(
+    {
+        "get_effective_settings",
+        "load_config",
+        "cold_reader",
+        "read_setting",
+        "_db_overlay_overrides",
+        "_db_global_overrides",
+        "ConfigSetting",
+        "bool_setting",
+        "int_setting",
+        "str_setting",
+        "value_setting",
+    }
+)
+
 # Fields whose ONLY consumer is not ``src`` Python — documented, reviewable.
 # ``e2e_confidence_threshold`` is documentation-driven by design (BLUEPRINT §
 # configuration: "the typed field is the shared source of truth for the doc value
 # and any future programmatic consumer"); the ``/t3:e2e`` verify↔review loop is
 # agent prose, not a deterministic gate, so it reads the value from the skill.
 # ``issue_implementer_cadence_hours`` is the documented cadence default the
-# issue-implementer loop mirrors as a literal (``default_cadence_seconds=3600``);
-# the field is not yet a live reader-driven knob. A NEW dead field is NOT on this
-# list and fails until it gains a reader or a conscious allowlist entry.
+# issue-implementer loop mirrors as a literal (``default_cadence_seconds=3600``).
+# ``privacy`` (settings.py: "no live production reader") and ``timezone``
+# (settings.py: "no live reader", DB-home for partition consistency) are declared
+# reader-less at the source. A NEW dead field is NOT on this list and fails until
+# it gains a real reader or a conscious allowlist entry.
 FIELDS_WITHOUT_SRC_READER: frozenset[str] = frozenset(
     {
         "e2e_confidence_threshold",
         "issue_implementer_cadence_hours",
+        "privacy",
+        "timezone",
     }
 )
 
@@ -49,13 +103,86 @@ def _field_names() -> set[str]:
     return {field.name for field in dataclasses.fields(UserSettings)}
 
 
-def _python_readers(field_names: set[str]) -> set[str]:
-    """Fields read by ``src``/``hooks`` Python: a ``.<field>`` access or exact ``"<field>"`` literal.
+def _callee_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
 
-    AST-based, so a comment or a prose docstring naming a field never counts — an
-    ``Attribute`` node's ``attr`` is the real access, and a ``Constant`` must equal
-    the field name EXACTLY (a docstring mentioning it is a longer, unequal string).
-    """
+
+def _is_config_expr(node: ast.expr, config_vars: set[str]) -> bool:
+    """``node`` evaluates to a ``TeaTreeConfig`` (its ``.user`` is the settings)."""
+    if isinstance(node, ast.Call) and _callee_name(node.func) in _CONFIG_ACCESSORS:
+        return True
+    return isinstance(node, ast.Name) and node.id in config_vars
+
+
+def _is_settings_expr(node: ast.expr, settings_vars: set[str], config_vars: set[str]) -> bool:
+    """``node`` evaluates to a ``UserSettings`` — an accessor call, ``.user``, or a bound/known var."""
+    if isinstance(node, ast.Call) and _callee_name(node.func) in _SETTINGS_ACCESSORS:
+        return True
+    if isinstance(node, ast.Attribute) and node.attr == "user" and _is_config_expr(node.value, config_vars):
+        return True
+    return isinstance(node, ast.Name) and (node.id in settings_vars or node.id in _SETTINGS_RECEIVERS)
+
+
+def _module_resolves_settings(tree: ast.Module) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and node.id in _RESOLUTION_MARKERS:
+            return True
+        if isinstance(node, ast.Attribute) and node.attr in _RESOLUTION_MARKERS:
+            return True
+    return False
+
+
+def _settings_vars_in(tree: ast.Module) -> tuple[set[str], set[str]]:
+    settings_vars: set[str] = set()
+    config_vars: set[str] = set()
+    for _ in range(3):  # fixpoint over settings-var assignment propagation
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            for target in node.targets:
+                if not isinstance(target, ast.Name):
+                    continue
+                if _is_settings_expr(node.value, settings_vars, config_vars):
+                    settings_vars.add(target.id)
+                elif _is_config_expr(node.value, config_vars):
+                    config_vars.add(target.id)
+    return settings_vars, config_vars
+
+
+def _file_python_readers(tree: ast.Module, field_names: set[str]) -> set[str]:
+    read: set[str] = set()
+    settings_vars, config_vars = _settings_vars_in(tree)
+    resolves = _module_resolves_settings(tree)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Attribute)
+            and node.attr in field_names
+            and _is_settings_expr(node.value, settings_vars, config_vars)
+        ):
+            read.add(node.attr)
+        elif isinstance(node, ast.Call) and _callee_name(node.func) in _READ_HELPERS:
+            for arg in node.args:
+                if isinstance(arg, ast.Constant) and arg.value in field_names:
+                    read.add(arg.value)
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Name)
+                    and target.id.endswith("_KEY")
+                    and isinstance(node.value, ast.Constant)
+                    and node.value.value in field_names
+                ):
+                    read.add(node.value.value)
+        elif resolves and isinstance(node, ast.Constant) and isinstance(node.value, str) and node.value in field_names:
+            read.add(node.value)
+    return read
+
+
+def _walk_py_files(reader: Callable[[ast.Module, set[str]], set[str]], field_names: set[str]) -> set[str]:
     read: set[str] = set()
     for root in _PY_ROOTS:
         for path in root.rglob("*.py"):
@@ -65,21 +192,27 @@ def _python_readers(field_names: set[str]) -> set[str]:
                 tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"), filename=str(path))
             except SyntaxError:
                 continue
-            for node in ast.walk(tree):
-                if isinstance(node, ast.Attribute) and node.attr in field_names:
-                    read.add(node.attr)
-                elif isinstance(node, ast.Constant) and isinstance(node.value, str) and node.value in field_names:
-                    read.add(node.value)
+            read |= reader(tree, field_names)
     return read
+
+
+def _python_readers(field_names: set[str]) -> set[str]:
+    """Fields read by a REAL settings read across ``src``/``hooks`` Python.
+
+    Introspection, not a hand-list; AST-based so a comment or prose docstring
+    naming a field never counts. A read is a settings-object attribute access, a
+    ``getattr``/cold-reader key literal, a ``*_KEY`` config-key constant, or a
+    field-name string inside a settings-resolution module (where it is a key).
+    """
+    return _walk_py_files(_file_python_readers, field_names)
 
 
 def _shell_readers(field_names: set[str]) -> set[str]:
     """Fields named on a non-comment line of a ``hooks/*.sh`` script (the cold-read seam).
 
     ``statusline_chain`` is read by ``statusline.sh`` via a direct ``sqlite3`` query
-    on the ConfigSetting store before Django is up; that is a real reader a Python
-    walk cannot see. Comment lines (``#``-led) are skipped so a mention in prose
-    does not count as a read.
+    on the ConfigSetting store before Django is up — a real reader a Python walk
+    cannot see. Comment lines (``#``-led) are skipped.
     """
     read: set[str] = set()
     for path in _SH_ROOT.rglob("*.sh"):
@@ -92,15 +225,18 @@ def _shell_readers(field_names: set[str]) -> set[str]:
     return read
 
 
+def _all_readers(field_names: set[str]) -> set[str]:
+    return _python_readers(field_names) | _shell_readers(field_names)
+
+
 def unread_fields() -> set[str]:
-    """Every ``UserSettings`` field with no reader and no allowlist entry — the lane core."""
+    """Every ``UserSettings`` field with no real reader and no allowlist entry — the lane core."""
     names = _field_names()
-    read = _python_readers(names) | _shell_readers(names)
-    return names - read - FIELDS_WITHOUT_SRC_READER
+    return names - _all_readers(names) - FIELDS_WITHOUT_SRC_READER
 
 
 class TestEveryUserSettingsFieldIsRead:
-    """A setting nothing reads is dead config — every field has a consumer."""
+    """A setting nothing reads is dead config — every field has a real consumer."""
 
     def test_no_user_settings_field_is_dead_config(self) -> None:
         unread = sorted(unread_fields())
@@ -115,12 +251,12 @@ class TestEveryUserSettingsFieldIsRead:
         assert not stale, f"FIELDS_WITHOUT_SRC_READER entries that are not UserSettings fields: {stale}"
 
     def test_allowlisted_fields_genuinely_lack_a_src_reader(self) -> None:
-        # Keep the allowlist honest: an allowlisted field that DID gain a src reader
-        # should be removed from the allowlist, not left masking coverage.
-        names = _field_names()
-        read = _python_readers(names) | _shell_readers(names)
-        redundant = sorted(FIELDS_WITHOUT_SRC_READER & read)
-        assert not redundant, f"FIELDS_WITHOUT_SRC_READER entries that now HAVE a src reader (drop them): {redundant}"
+        # The teeth of the tightening: each allowlisted field must be UNfound by the
+        # REAL-reader matcher (the loose matcher counted privacy/timezone on a
+        # coincidental token). An allowlisted field that now has a real reader must
+        # be dropped from the allowlist, not left masking coverage.
+        redundant = sorted(FIELDS_WITHOUT_SRC_READER & _all_readers(_field_names()))
+        assert not redundant, f"FIELDS_WITHOUT_SRC_READER entries that now HAVE a real reader (drop them): {redundant}"
 
 
 class TestUserSettingsReadersCardinalityFloors:
@@ -128,27 +264,60 @@ class TestUserSettingsReadersCardinalityFloors:
 
     def test_field_and_reader_floors(self) -> None:
         names = _field_names()
-        read = _python_readers(names) | _shell_readers(names)
+        read = _all_readers(names)
         assert len(names) >= 100, len(names)
-        # The overwhelming majority of fields must resolve a reader, else the walk broke.
+        # The overwhelming majority of fields must resolve a REAL reader, else the walk broke.
         assert len(read) >= 100, len(read)
 
 
 class TestUserSettingsReadersFiresRed:
-    """Anti-vacuity — a synthetic never-read field must be reported."""
+    """Anti-vacuity — a synthetic never-read field is caught, and the tightening has teeth."""
 
     def test_a_synthetic_unread_field_is_named(self) -> None:
-        # Model the dead-toggle class directly: a field name no reader mentions and
-        # no allowlist names is exactly what the lane must flag.
+        # A field name no reader mentions and no allowlist names is exactly the
+        # dead-toggle class the lane must flag.
         names = _field_names() | {"synthetic_dead_toggle_nothing_reads"}
-        read = _python_readers(names) | _shell_readers(names)
-        unread = names - read - FIELDS_WITHOUT_SRC_READER
+        unread = names - _all_readers(names) - FIELDS_WITHOUT_SRC_READER
         assert "synthetic_dead_toggle_nothing_reads" in unread
 
+    def test_tightening_catches_a_coincidentally_matched_dead_field(self) -> None:
+        # THE fix: a dead field whose common name collides with an unrelated token
+        # (``.payload`` on a ScanSignal, never a settings-object attribute) is
+        # counted by a LOOSE matcher but caught by the REAL-reader matcher.
+        loose = _loose_readers(_field_names() | {"payload"})
+        tight = _all_readers(_field_names() | {"payload"})
+        assert "payload" in loose, "expected the loose matcher to falsely count the coincidental token"
+        assert "payload" not in tight, "the tightened matcher must NOT count a coincidental non-settings token"
+
+    def test_documented_reader_less_fields_are_only_green_via_the_allowlist(self) -> None:
+        # privacy/timezone are the real-world coincidence cases the loose matcher
+        # passed; the tightened matcher flags them, so ONLY the allowlist keeps them
+        # green — proof the lane would catch them if the allowlist were dropped.
+        tight = _all_readers(_field_names())
+        assert "privacy" not in tight
+        assert "timezone" not in tight
+
     def test_a_real_read_field_is_not_flagged(self) -> None:
-        # Positive control: a field with a real ``.<field>`` reader resolves a reader
-        # and is therefore never in the unread set.
+        # Positive control: a field with a real ``settings.<field>`` reader resolves.
         names = _field_names()
         assert "max_concurrent_local_stacks" in names
-        read = _python_readers(names) | _shell_readers(names)
-        assert "max_concurrent_local_stacks" in read
+        assert "max_concurrent_local_stacks" in _all_readers(names)
+
+
+def _loose_readers(field_names: set[str]) -> set[str]:
+    """The OLD loose matcher (any ``.<field>`` attr OR exact ``"<field>"`` string).
+
+    Retained ONLY to prove — in ``TestUserSettingsReadersFiresRed`` — that the
+    tightened matcher rejects the coincidental token matches the loose one accepted.
+    """
+
+    def _loose_file(tree: ast.Module, names: set[str]) -> set[str]:
+        read: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr in names:
+                read.add(node.attr)
+            elif isinstance(node, ast.Constant) and isinstance(node.value, str) and node.value in names:
+                read.add(node.value)
+        return read
+
+    return _walk_py_files(_loose_file, field_names)

--- a/tests/conformance/test_user_settings_readers.py
+++ b/tests/conformance/test_user_settings_readers.py
@@ -1,0 +1,154 @@
+"""UserSettings field ↔ ≥1 reader — the dead-config totality lane (SELFCATCH-4).
+
+``test_removed_dead_settings.py`` guards exactly two historically-removed fields
+(``branch_prefix``, ``ask_before_post_on_behalf``, #2731) and ``test_feature_flags``
+governs only flag lifecycle. Neither is total: a NEW ``UserSettings`` field that
+nothing reads — the dead-toggle class — ships green, an operator-facing knob that
+silently does nothing.
+
+This lane makes the guard total by introspection. Every :class:`UserSettings`
+field must be READ by at least one consumer: a ``.<field>`` attribute access or an
+exact ``"<field>"`` string constant somewhere under ``src/teatree`` /
+``hooks/*.py`` (AST — so a docstring merely *mentioning* the name, being a longer
+string, never counts as a read), or the field name on a non-comment line of a
+``hooks/*.sh`` script (the pre-Django cold-read seam). A field read by none of
+these is dead config and fails, unless it is named in ``FIELDS_WITHOUT_SRC_READER``
+— the reviewable allowlist of fields consumed by agent-prose / documentation
+rather than ``src`` code.
+"""
+
+import ast
+import dataclasses
+from pathlib import Path
+
+from teatree.config import UserSettings
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SETTINGS_DEF = (_REPO_ROOT / "src" / "teatree" / "config" / "settings.py").resolve()
+_PY_ROOTS = (_REPO_ROOT / "src" / "teatree", _REPO_ROOT / "hooks")
+_SH_ROOT = _REPO_ROOT / "hooks"
+
+# Fields whose ONLY consumer is not ``src`` Python — documented, reviewable.
+# ``e2e_confidence_threshold`` is documentation-driven by design (BLUEPRINT §
+# configuration: "the typed field is the shared source of truth for the doc value
+# and any future programmatic consumer"); the ``/t3:e2e`` verify↔review loop is
+# agent prose, not a deterministic gate, so it reads the value from the skill.
+# ``issue_implementer_cadence_hours`` is the documented cadence default the
+# issue-implementer loop mirrors as a literal (``default_cadence_seconds=3600``);
+# the field is not yet a live reader-driven knob. A NEW dead field is NOT on this
+# list and fails until it gains a reader or a conscious allowlist entry.
+FIELDS_WITHOUT_SRC_READER: frozenset[str] = frozenset(
+    {
+        "e2e_confidence_threshold",
+        "issue_implementer_cadence_hours",
+    }
+)
+
+
+def _field_names() -> set[str]:
+    return {field.name for field in dataclasses.fields(UserSettings)}
+
+
+def _python_readers(field_names: set[str]) -> set[str]:
+    """Fields read by ``src``/``hooks`` Python: a ``.<field>`` access or exact ``"<field>"`` literal.
+
+    AST-based, so a comment or a prose docstring naming a field never counts — an
+    ``Attribute`` node's ``attr`` is the real access, and a ``Constant`` must equal
+    the field name EXACTLY (a docstring mentioning it is a longer, unequal string).
+    """
+    read: set[str] = set()
+    for root in _PY_ROOTS:
+        for path in root.rglob("*.py"):
+            if path.resolve() == _SETTINGS_DEF:
+                continue
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"), filename=str(path))
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Attribute) and node.attr in field_names:
+                    read.add(node.attr)
+                elif isinstance(node, ast.Constant) and isinstance(node.value, str) and node.value in field_names:
+                    read.add(node.value)
+    return read
+
+
+def _shell_readers(field_names: set[str]) -> set[str]:
+    """Fields named on a non-comment line of a ``hooks/*.sh`` script (the cold-read seam).
+
+    ``statusline_chain`` is read by ``statusline.sh`` via a direct ``sqlite3`` query
+    on the ConfigSetting store before Django is up; that is a real reader a Python
+    walk cannot see. Comment lines (``#``-led) are skipped so a mention in prose
+    does not count as a read.
+    """
+    read: set[str] = set()
+    for path in _SH_ROOT.rglob("*.sh"):
+        for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+            if line.lstrip().startswith("#"):
+                continue
+            for name in field_names:
+                if name in line:
+                    read.add(name)
+    return read
+
+
+def unread_fields() -> set[str]:
+    """Every ``UserSettings`` field with no reader and no allowlist entry — the lane core."""
+    names = _field_names()
+    read = _python_readers(names) | _shell_readers(names)
+    return names - read - FIELDS_WITHOUT_SRC_READER
+
+
+class TestEveryUserSettingsFieldIsRead:
+    """A setting nothing reads is dead config — every field has a consumer."""
+
+    def test_no_user_settings_field_is_dead_config(self) -> None:
+        unread = sorted(unread_fields())
+        assert not unread, (
+            "UserSettings field(s) that no src/hooks consumer reads (dead config) — "
+            "wire a reader or add to FIELDS_WITHOUT_SRC_READER on purpose: " + str(unread)
+        )
+
+    def test_allowlisted_fields_are_still_real_fields(self) -> None:
+        # A stale allowlist entry (a field that was removed) is dead surface.
+        stale = sorted(FIELDS_WITHOUT_SRC_READER - _field_names())
+        assert not stale, f"FIELDS_WITHOUT_SRC_READER entries that are not UserSettings fields: {stale}"
+
+    def test_allowlisted_fields_genuinely_lack_a_src_reader(self) -> None:
+        # Keep the allowlist honest: an allowlisted field that DID gain a src reader
+        # should be removed from the allowlist, not left masking coverage.
+        names = _field_names()
+        read = _python_readers(names) | _shell_readers(names)
+        redundant = sorted(FIELDS_WITHOUT_SRC_READER & read)
+        assert not redundant, f"FIELDS_WITHOUT_SRC_READER entries that now HAVE a src reader (drop them): {redundant}"
+
+
+class TestUserSettingsReadersCardinalityFloors:
+    """Anti-vacuity — a broken reader walk that finds nothing must not pass green."""
+
+    def test_field_and_reader_floors(self) -> None:
+        names = _field_names()
+        read = _python_readers(names) | _shell_readers(names)
+        assert len(names) >= 100, len(names)
+        # The overwhelming majority of fields must resolve a reader, else the walk broke.
+        assert len(read) >= 100, len(read)
+
+
+class TestUserSettingsReadersFiresRed:
+    """Anti-vacuity — a synthetic never-read field must be reported."""
+
+    def test_a_synthetic_unread_field_is_named(self) -> None:
+        # Model the dead-toggle class directly: a field name no reader mentions and
+        # no allowlist names is exactly what the lane must flag.
+        names = _field_names() | {"synthetic_dead_toggle_nothing_reads"}
+        read = _python_readers(names) | _shell_readers(names)
+        unread = names - read - FIELDS_WITHOUT_SRC_READER
+        assert "synthetic_dead_toggle_nothing_reads" in unread
+
+    def test_a_real_read_field_is_not_flagged(self) -> None:
+        # Positive control: a field with a real ``.<field>`` reader resolves a reader
+        # and is therefore never in the unread set.
+        names = _field_names()
+        assert "max_concurrent_local_stacks" in names
+        read = _python_readers(names) | _shell_readers(names)
+        assert "max_concurrent_local_stacks" in read


### PR DESCRIPTION
The last of the five self-catching gates, re-scoped after the SELFCATCH-4 assessment found the original registry-parity corpus **partially subsumed** by DIS-A's framework (`tests/conformance/test_registry_parity.py`, 5 live lanes) and SIG-4's capstone (`test_signal_ledger_producers.py` + `test_capability_surface_walk.py`). This PR implements **only the four distinct residues** those leave uncovered — as append-only conformance lanes, introspective (won't drift), each proven **RED-before** on a synthetic violation. No `src` changes; existing lanes untouched.

## The four lanes + what each catches that DIS-A/SIG-4 did not

**1. `test_signal_route_totality.py` — signal-KIND ↔ dispatch/statusline route totality.** DIS-A LANE 1 governs the *zone* level (`AGENT_ZONES` ↔ `_ZONE_HANDLERS`). This governs the *kind* level, the gap that leaves: a scanner emitting a new `ScanSignal.kind` with no `AGENT_BY_KIND` / `MECHANICAL_BY_KIND` / `STATUSLINE_ZONE_BY_KIND` / drop entry falls through `_dispatch_one` to the generic `("statusline", "in_flight")` fallback — a silent statusline drop. Both directions: forward (every emitted kind is explicitly routed / dropped / an allowlisted deliberate fallback) and reverse (every `AGENT_BY_KIND`/`MECHANICAL_BY_KIND` key is a kind a scanner actually produces). An AST enumerator resolves literal kinds, module-constant kinds (`CLOSE_CANDIDATE_KIND`), and f-string families (`f"pr_sweep.{x}"` → `pr_sweep.`), so dynamically-built kinds are not invisible. Named allowlists `INTENTIONAL_FALLBACK_KINDS` (7 bookkeeping kinds that deliberately render via the in_flight fallback) and `ROUTES_WITHOUT_STATIC_PRODUCER` (`skill_drift_detected`, a pre-provisioned cap-H route).

**2. `test_gate_registry_walk.py` — gate/resolver registry ↔ call-site bidirectional walk.** `test_model_registries.py` hand-enumerates six known gates; a newly registered gate nothing calls, or a `get_gate("typo")` for a never-registered name, only fails at runtime. This is a **total** AST walk both ways over `src/teatree`: every `register_gate`/`register_resolver` literal has a `get_gate`/`get_resolver` call site, and every call-site literal is registered — plus a runtime liveness cross-check that each statically-registered gate resolves through the live registry. A non-literal target (`get_gate(gate)`) is treated as dynamic, not a phantom.

**3. `test_user_settings_readers.py` — every `UserSettings` field is read by ≥1 consumer.** Generalizes the #2731 two-field guard to the whole dataclass (141 fields) by introspection: a `.<field>` access or exact `"<field>"` literal in `src`/`hooks` Python (AST — so a prose docstring merely *mentioning* the name, being a longer unequal string, never counts as a read), or the field on a non-comment line of a `hooks/*.sh` cold-read script (the pre-Django `sqlite3` seam that reads `statusline_chain`). Two governance/doc-consumed fields are allowlisted in `FIELDS_WITHOUT_SRC_READER`: `e2e_confidence_threshold` (documentation-driven by design per BLUEPRINT § configuration) and `issue_implementer_cadence_hours` (the documented cadence default the loop mirrors as a literal). A new dead toggle is not on the list and fails.

**4. `test_registry_parity_roster.py` — roster-completeness meta-ratchet.** The per-lane cardinality floors cannot catch an *entirely unenrolled* producer/consumer pair. This introspects the dispatch/phase modules for every registry-shaped constant (`*_BY_KIND` / `*_BY_PHASE` / `*_ZONES` / `*_HANDLERS` / `*_TARGET_PHASES`) and asserts each is enrolled in `PARITY_LANE_ROSTER` (mapping the registry → the covering test module) — the "phantom roster asserted EMPTY" trick from `test_gate_liveness_corpus`, applied to the corpus itself. Reverse: every roster entry names a live registry and a test file that references it. A pair added with no parity lane cannot ship green.

## Anti-vacuity — each lane RED-before on a real synthetic violation

Each lane carries cardinality floors + a fires-RED self-test, and each was proven RED-before by injecting a real violation and observing the lane name it:

| Lane | Injected violation | Reported |
|---|---|---|
| 1 | `ScanSignal(kind="synthetic_scanner.unrouted_red")` in a scanner | `['synthetic_scanner.unrouted_red']` — falls through to in_flight fallback |
| 2 (fwd) | `register_gate("synthetic_registered_no_callsite", …)` | `['synthetic_registered_no_callsite']` — dead gate |
| 2 (rev) | `get_gate("synthetic_called_never_registered")` call site | `['synthetic_called_never_registered']` — runtime KeyError waiting to fire |
| 3 | `synthetic_dead_toggle_no_reader: bool` field on `UserSettings` | `['synthetic_dead_toggle_no_reader']` — dead config |
| 4 | `SYNTHETIC_UNENROLLED_BY_KIND` constant in `dispatch_tables` | `['SYNTHETIC_UNENROLLED_BY_KIND']` — pair with no parity lane |

## Architecture pre-check

Test-only change (four `tests/conformance/` files; no `src`, no migration, no config). BLUEPRINT alignment: extends the existing registry-parity corpus (§ producer/consumer anti-drift). No FSM/Protocol/dependency-direction impact. Test surface: the four lanes are themselves the deliverable; introspective enumerators + named allowlists follow SIG-4's `INTENTIONALLY_UNREGISTERED_MODULES` idiom. Behavior preservation: purely additive.

## Verification (all green, whole-tree gates)

- 4 new lanes: 33 passed
- `tests/quality tests/test_gate_never_lockout_contract.py tests/conformance tests/test_cli_command_literals_resolve.py`: 716 passed, 1 skipped, 3 xfailed
- module-health, test-path-mirror (ratchet holds), `makemigrations --check` (no changes), `banned-terms scan-tree` (clean), ruff check + format: all clean
