### PR TITLE
fix(e2e): suppress empty Dev|Local table for imageless test-plan workflows + retract-evidence CLI reachability [#8521]

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -6424,16 +6424,17 @@ Usage: t3 teatree e2e [OPTIONS] COMMAND [ARGS]...
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ run             Run E2E tests — dispatches to project or external runner     │
-│                 based on overlay config.                                     │
-│ trigger-ci      Trigger E2E tests on a remote CI pipeline.                   │
-│ external        Run Playwright tests from the external test repo             │
-│                 (T3_PRIVATE_TESTS).                                          │
-│ project         Run E2E tests from the project's own test directory.         │
-│ post-test-plan  Post/update the ticket's single test-plan note (side-by-side │
-│                 Dev|Local test plan) from a manifest.                        │
-│ post-evidence   [Deprecated] Alias for post-test-plan (renamed; kept one     │
-│                 release for back-compat).                                    │
+│ run               Run E2E tests — dispatches to project or external runner   │
+│                   based on overlay config.                                   │
+│ trigger-ci        Trigger E2E tests on a remote CI pipeline.                 │
+│ external          Run Playwright tests from the external test repo           │
+│                   (T3_PRIVATE_TESTS).                                        │
+│ project           Run E2E tests from the project's own test directory.       │
+│ post-test-plan    Post/update the ticket's single test-plan note             │
+│                   (side-by-side Dev|Local test plan) from a manifest.        │
+│ retract-evidence  Withdraw the ticket's single test-plan note.               │
+│ post-evidence     [Deprecated] Alias for post-test-plan (renamed; kept one   │
+│                   release for back-compat).                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -6653,6 +6654,19 @@ Usage: t3 teatree e2e post-test-plan [OPTIONS]
 │                                                    no-allow-no-video]        │
 │ --help                                             Show this message and     │
 │                                                    exit.                     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree e2e retract-evidence`
+
+```
+Usage: t3 teatree e2e retract-evidence [OPTIONS]
+
+ Withdraw the ticket's single test-plan note.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --ticket        TEXT                                                         │
+│ --help                Show this message and exit.                            │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/skills/e2e/SKILL.md
+++ b/skills/e2e/SKILL.md
@@ -232,6 +232,8 @@ t3 <overlay> e2e post-test-plan --manifest artifacts/<TICKET>/manifest.json
 
 Do step 1 — never push a UI-visible ticket with no recorded E2E artifact. Then do step 3 — a deployed-env (`dev`) E2E run plus a posted test plan is what closes the loop on a UI-visible ticket; merging without it leaves "done" half-proven.
 
+The posted test plan the gate expects is the **comprehensive ticket test plan**, not just proof a green local run happened: one workflow per affected UI surface with a red-boxed screenshot, plus an explicit `Actual: ✅ <result>` for every backend/API claim (a backend-only workflow renders as its steps + `Actual` line, not an empty Dev|Local table). A green local E2E artifact satisfies the ship gate; the comprehensive plan is what makes the posted evidence trustworthy.
+
 `Ticket.ship()` refuses to ship a **UI-visible** ticket — one whose scope includes a repo in the active overlay's `frontend_repos` — until a **green local-stack E2E artifact** exists. The durable `Ticket.extra['e2e_recipe'].last_run` must be `result == "green"` AND `env == "local"`; a `dev` run records provenance but does NOT satisfy the gate. A dev-after-merge run is deliberately not enough — the whole point is to catch missing scope *before* the merge, not after. A green local run is recorded automatically by `t3 <overlay> e2e run <work-item>` (which resolves an on-disk workspace, so `env` defaults to `local`).
 
 The gate raises `DodLocalE2EError` (a transition refusal, like the dirty-worktree preflight) and the FSM stays put. Escape hatch for a genuinely non-UI or exempt ticket the heuristic mis-flags:

--- a/src/teatree/cli/django_groups.py
+++ b/src/teatree/cli/django_groups.py
@@ -104,6 +104,7 @@ DJANGO_GROUPS: dict[str, DjangoGroup] = {
                 "post-test-plan",
                 "Post/update the ticket's single test-plan note (side-by-side Dev|Local test plan) from a manifest.",
             ),
+            ("retract-evidence", "Withdraw the ticket's single test-plan note."),
             (
                 "post-evidence",
                 "[Deprecated] Alias for post-test-plan (renamed; kept one release for back-compat).",

--- a/src/teatree/core/management/commands/_test_plan_render.py
+++ b/src/teatree/core/management/commands/_test_plan_render.py
@@ -501,14 +501,27 @@ def _test_plan_block(state: TestPlanState, workflow: str) -> list[str]:
 
 
 def _workflow_table(state: TestPlanState, workflow: str) -> list[str]:
-    """Heading + optional steps + ``| Dev | Local |`` table for one workflow."""
+    """Heading + optional steps + ``| Dev | Local |`` table for one workflow.
+
+    A backend-only workflow carries neither video nor screenshots on either
+    side; emitting the table header alone renders an empty ``| Dev | Local |``
+    grid that reads as missing evidence. Such a workflow renders as its heading
+    + steps only (the steps carry the ``Actual: ✅`` claim), no empty table.
+    """
     dev_video, dev_images = _cells(state["dev"], workflow)
     local_video, local_images = _cells(state["local"], workflow)
 
     lines = [f"### {workflow}", ""]
     lines.extend(_test_plan_block(state, workflow))
+
+    has_video = dev_video != _EMPTY_CELL or local_video != _EMPTY_CELL
+    has_images = bool(dev_images or local_images)
+    if not has_video and not has_images:
+        lines.append("")
+        return lines
+
     lines.extend(["| Dev | Local |", "|---|---|"])
-    if dev_video != _EMPTY_CELL or local_video != _EMPTY_CELL:
+    if has_video:
         lines.append(f"| {dev_video} | {local_video} |")
     for i in range(max(len(dev_images), len(local_images))):
         left = dev_images[i] if i < len(dev_images) else _EMPTY_CELL

--- a/tests/teatree_core/e2e_command/test_post_test_plan.py
+++ b/tests/teatree_core/e2e_command/test_post_test_plan.py
@@ -240,6 +240,48 @@ class TestRenderBody:
         body = _test_plan.render_body(state)
         assert "**How to test:**" not in body
 
+    def test_backend_only_workflow_suppresses_the_empty_dev_local_table(self) -> None:
+        # A backend/API workflow carries neither video nor screenshots on either
+        # side — only its steps, which include the `Actual: ✅` claim. Emitting
+        # the `| Dev | Local |` header alone renders an empty grid that reads as
+        # missing evidence; the workflow renders as heading + steps only.
+        state = self._state(
+            local={"commits": {}, "workflows": {}},
+            steps={"Backend fee removal": ["Load the offer serializer", "Actual: ✅ fee line absent from payload"]},
+        )
+        body = _test_plan.render_body(state)
+        assert "### Backend fee removal" in body
+        assert "1. Load the offer serializer" in body
+        assert "2. Actual: ✅ fee line absent from payload" in body
+        assert "| Dev | Local |" not in body
+        assert "|---|---|" not in body
+
+    def test_empty_embed_workflow_suppresses_the_empty_dev_local_table(self) -> None:
+        # A workflow present in a side's map but carrying an empty embed (no
+        # video, no screenshots) is the same imageless case — suppress its table.
+        state = self._state(
+            local={"commits": {}, "workflows": {"Backend claim": self._embedded()}},
+        )
+        body = _test_plan.render_body(state)
+        assert "### Backend claim" in body
+        assert "| Dev | Local |" not in body
+
+    def test_media_bearing_workflow_still_renders_the_table_alongside_a_backend_one(self) -> None:
+        # A backend-only workflow suppresses its table; a media-bearing sibling
+        # in the same plan still renders its Dev | Local comparison table.
+        state = self._state(
+            local={
+                "commits": {},
+                "workflows": {"UI login": self._embedded(images=("![i](/uploads/s/l1.png)",))},
+            },
+            steps={"Backend fee removal": ["Load the serializer", "Actual: ✅ absent"]},
+        )
+        body = _test_plan.render_body(state)
+        assert "### UI login" in body
+        assert "| Dev | Local |" in body  # the media-bearing workflow keeps its table
+        assert "| — | ![i](/uploads/s/l1.png) |" in body
+        assert "### Backend fee removal" in body
+
     def test_commit_shas_render_as_clickable_links_derived_from_mrs(self) -> None:
         # The repo short-name (client) matches the MR URL .../org/client/...,
         # so its SHA links to that project's commit page.

--- a/tests/test_cli_overlay_groups.py
+++ b/tests/test_cli_overlay_groups.py
@@ -7,6 +7,7 @@ that table is unreachable via the overlay CLI even though the core
 """
 
 from teatree.cli.overlay import DJANGO_GROUPS
+from teatree.core.management.commands.e2e import Command as E2eCommand
 from teatree.core.management.commands.honesty import Command as HonestyCommand
 from teatree.core.management.commands.learnings import Command as LearningsCommand
 from teatree.core.management.commands.lifecycle import Command as LifecycleCommand
@@ -66,6 +67,19 @@ def test_e2e_group_exposes_deprecated_post_evidence_alias() -> None:
     # ``post-evidence``; without a bridge entry in DJANGO_GROUPS the alias
     # is unreachable via ``t3 <overlay> e2e post-evidence``.
     assert "post-evidence" in _e2e_subcommands()
+
+
+def test_e2e_group_exposes_retract_evidence() -> None:
+    # ``retract-evidence`` is defined on the e2e management command but was
+    # absent from DJANGO_GROUPS, so ``t3 <overlay> e2e retract-evidence`` was
+    # unreachable from the installed CLI even though the command exists — the
+    # class of regression this table guards.
+    assert "retract-evidence" in _e2e_subcommands()
+
+
+def test_e2e_subcommands_map_to_real_command_methods() -> None:
+    for name in _e2e_subcommands():
+        assert hasattr(E2eCommand, name.replace("-", "_")), name
 
 
 def test_pr_group_exposes_deprecated_post_evidence_alias() -> None:


### PR DESCRIPTION
Two teatree e2e-DoD gaps surfaced by the [#8521](https://gitlab.com/) e2e work, plus one skill sentence.

## 1. Empty `| Dev | Local |` table for imageless workflows (reads as missing)
The capture-matrix renderer (`_test_plan_render._workflow_table`) emitted a bare `| Dev | Local |` header for a backend-only workflow — no video, no screenshots on either side — rendering an empty grid that reads as missing evidence. Such a workflow now renders as its heading + steps only (the steps carry the `Actual: ✅` claim); media-bearing workflows keep their comparison table unchanged. RED-before test added, plus a companion asserting a media-bearing sibling in the same plan still renders its table.

## 2. `e2e retract-evidence` unreachable from the installed CLI — DIAGNOSIS: registration gap (fixed)
`retract-evidence` is defined on the e2e management command (`e2e.py`) but was **absent from the `DJANGO_GROUPS` overlay catalogue** (`cli/django_groups.py`), so `t3 <overlay> e2e retract-evidence` was unreachable even though the command exists. This was reproduced against the current tree (`t3 teatree e2e --help` omitted it, and the deterministic `cli-reference.md` did not list it) — a code registration gap, **not** install staleness. Fix: added the bridge entry; regenerated `docs/generated/cli-reference.md`. CLI-reference test pins `retract-evidence` into the catalogue and maps every e2e subcommand to a real command method.

## 3. e2e skill DoD sentence
Made the comprehensive ticket test plan (red-boxed screenshot per UI surface + `Actual` per backend claim) an explicit part of the e2e skill's "DoD Local-E2E Gate" — not just "a green local E2E artifact exists".

## Architecture pre-check
1. BLUEPRINT § alignment: § 6 Overlay System (`DJANGO_GROUPS` is the overlay CLI proxy catalogue) + the test-plan renderer. No BLUEPRINT contradiction.
2. FSM phase boundaries: n/a — no state transitions.
3. Extension-point contracts: additive `DJANGO_GROUPS["e2e"]` entry, consumed by `OverlayAppBuilder._bridge_subcommand`; no contract shape change.
4. Component boundaries: renderer helper stays in `core/management/commands/_test_plan_render.py`; catalogue entry in `cli/django_groups.py`.
5. Dependency direction: no new src imports; test imports the e2e `Command` for the method-mapping assertion. `tach` green.
6. Test surface: `tests/teatree_core/e2e_command/test_post_test_plan.py` (renderer) + `tests/test_cli_overlay_groups.py` (CLI reachability).
7. Resilience invariants: n/a — no external writes changed.
8. Identity/key normalization: n/a.
9. Behavior preservation: the empty-table suppression removes an information-free grid only; media-bearing workflows unchanged (existing `test_empty_video_row_is_omitted` + new companion guard). No capability removed.
