### PR TITLE
fix(url-slug): fragment-aware repo_namespaced_key so umbrella tickets don't collide

### DIFF
--- a/src/teatree/utils/url_slug.py
+++ b/src/teatree/utils/url_slug.py
@@ -97,13 +97,28 @@ def repo_namespaced_key_from_path(url_path: str) -> str:
 
 
 def repo_namespaced_key(url: str) -> str:
-    """Return :func:`repo_namespaced_key_from_path` for a full issue *url*.
+    """Return the collision-free ticket-context cache key for a full issue *url*.
 
     The canonical, collision-free ticket-context cache key (#2293):
     ``acme-eng/bugs#42`` and ``acme-product#42`` share a bare numeric IID
     but never collide on this key, since the full repo path is part of it.
+
+    A URL **fragment** is appended when present, so the key stays as unique
+    as the ``issue_url`` it is derived from (#102). Synthetic loop tickets
+    (the directive interpret + implement tickets, the outer-loop experiment
+    tickets) all anchor on ONE umbrella issue and disambiguate solely via a
+    fragment — ``.../issues/3009#directive=5`` vs ``#directive-impl=5`` vs
+    ``#outer-loop-experiment=7``. Without the fragment they would all collapse
+    to ``souliane/teatree#3009`` and collide on the ``Ticket`` unique
+    constraint; the fragment restores the "distinct ``issue_url`` ⇒ distinct
+    key" invariant the constraint depends on. A real ``.../issues/42`` (no
+    fragment) is unchanged.
     """
-    return repo_namespaced_key_from_path(urlparse(url).path)
+    parsed = urlparse(url)
+    base = repo_namespaced_key_from_path(parsed.path)
+    if base and parsed.fragment:
+        return f"{base}#{parsed.fragment}"
+    return base
 
 
 def project_slug_from_ref(ref: str) -> str:

--- a/tests/teatree_loops/directive_loop/test_tick.py
+++ b/tests/teatree_loops/directive_loop/test_tick.py
@@ -236,6 +236,47 @@ class TestFullHappyPathAndKeepRule(TestCase):
         assert second.reason == "awaiting_human_revert"
 
 
+class TestDirectiveSpawnedTicketsDoNotCollide(TestCase):
+    """The full real tick's two spawned tickets keep distinct namespaced keys (#102).
+
+    The FULL real tick spawns an interpret ticket AND an impl ticket under one
+    umbrella (#3009). Both anchor on the same umbrella URL with only a URL fragment
+    to disambiguate (``#directive=<pk>`` vs ``#directive-impl=<pk>``), so their
+    ``repo_namespaced_key`` must stay distinct — the whole full-tick path throws an
+    IntegrityError on the ``unique_nonempty_repo_namespaced_key`` constraint otherwise
+    (the PR-8 dogfood collision that blocks enabling ``directive_loop_enabled``).
+    """
+
+    def _drive_captured_to_implementing(self) -> Directive:
+        directive = Directive.objects.capture("max 1 MR", source=Directive.Source.CLI, scope_overlay=_SCOPE)
+        # CAPTURED → interpret_dispatched: creates the synthetic interpret ticket under #3009.
+        assert _tick().action == "interpret_dispatched"
+        # The recorder binds the sketch (INTERPRETED).
+        directive.refresh_from_db()
+        directive.record_interpretation(sketch_from_envelope(valid_envelope()), constraint_statement="c")
+        # INTERPRETED → ratify_asked: records the human-approval question.
+        assert _tick().action == "ratify_asked"
+        directive.refresh_from_db()
+        DeferredQuestion.consume(directive.ratify_question_id, answer="approve")
+        # RATIFY_PENDING → admitted.
+        assert _tick().action == "admitted"
+        # ADMITTED → implementing: creates the impl ticket under the SAME #3009 umbrella.
+        assert _tick().action == "implementing"
+        directive.refresh_from_db()
+        return directive
+
+    def test_full_tick_spawns_both_tickets_without_key_collision(self) -> None:
+        directive = self._drive_captured_to_implementing()
+        interpret_url = f"https://github.com/souliane/teatree/issues/3009#directive={directive.pk}"
+        impl_url = f"https://github.com/souliane/teatree/issues/3009#directive-impl={directive.pk}"
+        interpret_ticket = Ticket.objects.get(issue_url=interpret_url)
+        impl_ticket = Ticket.objects.get(issue_url=impl_url)
+        # Both spawned tickets exist and carry DISTINCT, non-empty namespaced keys.
+        assert interpret_ticket.repo_namespaced_key
+        assert impl_ticket.repo_namespaced_key
+        assert interpret_ticket.repo_namespaced_key != impl_ticket.repo_namespaced_key
+
+
 class TestIdle(TestCase):
     def test_no_active_directive_is_idle(self) -> None:
         result = run_tick(settings=_open_settings(), seams=_seams())

--- a/tests/teatree_utils/test_url_slug_repo_namespaced_key.py
+++ b/tests/teatree_utils/test_url_slug_repo_namespaced_key.py
@@ -51,6 +51,33 @@ def test_different_repos_sharing_an_issue_number_never_collide() -> None:
     assert second == "acme-product/repo#2242"
 
 
+def test_a_url_fragment_disambiguates_synthetic_umbrella_tickets() -> None:
+    """A URL fragment keeps synthetic umbrella tickets from colliding (#102).
+
+    Synthetic loop tickets anchor on ONE umbrella issue and disambiguate solely
+    via a fragment (``#directive=`` vs ``#directive-impl=`` vs
+    ``#outer-loop-experiment=``). The key must honour it, or they collapse to the
+    umbrella key and collide on the ``Ticket`` unique constraint (#102).
+    """
+    umbrella = "https://github.com/souliane/teatree/issues/3009"
+    interpret = repo_namespaced_key(f"{umbrella}#directive=5")
+    implement = repo_namespaced_key(f"{umbrella}#directive-impl=5")
+    experiment = repo_namespaced_key(f"{umbrella}#outer-loop-experiment=7")
+    assert interpret == "souliane/teatree#3009#directive=5"
+    assert implement == "souliane/teatree#3009#directive-impl=5"
+    assert experiment == "souliane/teatree#3009#outer-loop-experiment=7"
+    assert len({interpret, implement, experiment}) == 3
+
+
+def test_a_bare_issue_url_without_a_fragment_is_unchanged() -> None:
+    """A real issue with no fragment is untouched by the fragment-awareness (#102).
+
+    The common case — a real issue with no fragment — is untouched by the
+    fragment-awareness added for the umbrella-ticket collision (#102).
+    """
+    assert repo_namespaced_key("https://github.com/acme-eng/widgets/issues/42") == "acme-eng/widgets#42"
+
+
 def test_from_path_parses_a_bare_url_path() -> None:
     """``repo_namespaced_key`` is a thin ``urlparse().path`` wrapper around this."""
     assert repo_namespaced_key_from_path("/acme-eng/widgets/issues/42") == "acme-eng/widgets#42"


### PR DESCRIPTION
## Problem

Driving a `setting_policy_gate` directive through the FULL real directive tick spawns TWO tickets under one umbrella issue (`https://github.com/souliane/teatree/issues/3009`):

- the synthetic **interpret** ticket at `CAPTURED` → `issue_url = .../issues/3009#directive=<pk>`
- the synthetic **implement** ticket at `ADMITTED` → `issue_url = .../issues/3009#directive-impl=<pk>`

`Ticket.save()` derives `repo_namespaced_key` via `repo_namespaced_key(issue_url)` = `repo_namespaced_key_from_path(urlparse(url).path)`. `urlparse` puts the `#...` in `.fragment`, not `.path`, so BOTH tickets' paths collapse to `/souliane/teatree/issues/3009` → the same key `souliane/teatree#3009`. The second `Ticket` insert then throws `IntegrityError: UNIQUE constraint failed: teatree_ticket.repo_namespaced_key`, so the full directive tick throws and `directive_loop_enabled` can never be turned on. PR-8's Test C had to work around this by constructing the admitted directive directly instead of driving the full tick.

## Root cause

The URL fragment is the *only* discriminator that makes the two synthetic `issue_url`s unique, but `repo_namespaced_key` derivation dropped it — breaking the invariant "distinct `issue_url` ⇒ distinct (or empty) `repo_namespaced_key`" that the unique constraint depends on.

## Fix

`teatree.utils.url_slug.repo_namespaced_key` now appends the URL fragment to the key when present, so the key stays as unique as the `issue_url` it derives from. A real issue URL (no fragment) is unchanged. This is a single-seam fix that also removes the same latent collision for the outer loop's per-experiment synthetic tickets under the same umbrella. No model change, so no migration.

## Tests (RED-before / GREEN-after)

- `tests/teatree_loops/directive_loop/test_tick.py::TestDirectiveSpawnedTicketsDoNotCollide` — drives the real full tick (`CAPTURED → interpret_dispatched → INTERPRETED → ratify_asked → admitted → implementing`) and asserts both spawned tickets get distinct non-empty keys. RED on main with the exact `IntegrityError` on `repo_namespaced_key`; GREEN with the fix.
- `tests/teatree_utils/test_url_slug_repo_namespaced_key.py` — fragment discriminates the three synthetic umbrella tickets; a fragment-less real issue URL is unchanged.

The directive_loop quadruple-OFF safety is untouched — this is a keying fix only, no flag flipped.

Draft — do not merge; the maintainer owns the keystone after cold review.

