### PR TITLE
perf(hooks): move whole-tree jscpd + mutmut checks off the pre-push gate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -449,14 +449,19 @@ repos:
   # The local-suite runners (dev/test-fast.sh, dev/test-matrix.sh) and the exact
   # full-CI predicate (dev/ci-parity.sh) stay as explicit opt-ins. The one push
   # pytest below is deliberately PATH-SCOPED (tests/quality + the never-lockout
-  # contract + doctest collection over src/teatree) so the no-full-suite invariant
-  # stays satisfied. Guarded by tests/test_no_full_suite_on_pre_push.py.
+  # contract + doctest collection over src/teatree) AND marker-scoped
+  # (-m "not push_heavy") so the no-full-suite invariant stays satisfied. The
+  # push_heavy marker excludes the two whole-tree subprocess checks (the ~63s
+  # jscpd scan and the mutmut kill-proof run) from the push gate; CI's test-shard
+  # lane runs the whole suite with no marker filter, so both still gate on every
+  # PR -- relocated to CI, not dropped. Guarded by
+  # tests/test_no_full_suite_on_pre_push.py.
   - repo: local
     hooks:
       - id: ci-critical-parity
-        name: CI-critical parity (scoped static/AST + doctest lane; path-scoped, ~1-3 min)
+        name: CI-critical parity (scoped static/AST + doctest lane; path-scoped, ~1 min)
         language: system
-        entry: uv run pytest tests/quality tests/test_gate_never_lockout_contract.py --doctest-modules src/teatree -q
+        entry: uv run pytest tests/quality tests/test_gate_never_lockout_contract.py --doctest-modules src/teatree -m "not push_heavy" -q
         pass_filenames: false
         always_run: true
         stages: [push]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -297,6 +297,7 @@ filterwarnings = [
 xfail_strict = true
 markers = [
   "integration: tests that run real subprocesses (shell scripts, git, etc.)",
+  "push_heavy: whole-tree subprocess checks (jscpd scan, mutmut run) deselected at push, run in CI",
 ]
 
 # --- Coverage ---

--- a/tests/quality/test_jscpd_duplication.py
+++ b/tests/quality/test_jscpd_duplication.py
@@ -26,6 +26,10 @@ from pathlib import Path
 
 import pytest
 
+# The whole-tree jscpd scan is the ~63s cost that made every push time out; it is
+# deselected at push (`-m "not push_heavy"`) and runs in CI instead.
+pytestmark = pytest.mark.push_heavy
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _CONFIG = _REPO_ROOT / ".jscpd.json"
 _SRC = _REPO_ROOT / "src" / "teatree"

--- a/tests/quality/test_jscpd_duplication.py
+++ b/tests/quality/test_jscpd_duplication.py
@@ -26,10 +26,6 @@ from pathlib import Path
 
 import pytest
 
-# The whole-tree jscpd scan is the ~63s cost that made every push time out; it is
-# deselected at push (`-m "not push_heavy"`) and runs in CI instead.
-pytestmark = pytest.mark.push_heavy
-
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _CONFIG = _REPO_ROOT / ".jscpd.json"
 _SRC = _REPO_ROOT / "src" / "teatree"
@@ -66,7 +62,9 @@ def _expected_clone_capable_files(min_lines: int) -> set[Path]:
 
 # Whole-tree jscpd scan is ~60s standalone and stretches further under
 # concurrent-coder load; the 60s default pytest-timeout deterministically
-# tripped and blocked every push through the ci-critical-parity hook.
+# tripped and blocked every push through the ci-critical-parity hook. It is
+# deselected at push (`-m "not push_heavy"`) and runs in CI instead.
+@pytest.mark.push_heavy
 @pytest.mark.timeout(300)
 @pytest.mark.integration
 @pytest.mark.skipif(shutil.which("npx") is None, reason="npx (node) not on PATH")

--- a/tests/quality/test_mutation_kill_proof.py
+++ b/tests/quality/test_mutation_kill_proof.py
@@ -26,10 +26,6 @@ import pytest
 from teatree.config import OnBehalfPostMode
 from teatree.on_behalf_gate import OnBehalfVerdict, resolve_on_behalf_verdict
 
-# The real mutmut run is a whole-module subprocess; deselected at push
-# (`-m "not push_heavy"`) and run in CI instead.
-pytestmark = pytest.mark.push_heavy
-
 
 def _mutant_resolve(mode: OnBehalfPostMode, action: str) -> OnBehalfVerdict:
     """The BLOCK→PROCEED mutant of the ASK branch (the regression we fear)."""
@@ -63,6 +59,9 @@ class TestManualMutantKilled:
             assert verdict is OnBehalfVerdict.BLOCK
 
 
+# The real mutmut run is an expensive whole-module subprocess; deselected at push
+# (`-m "not push_heavy"`) and run in CI instead.
+@pytest.mark.push_heavy
 @pytest.mark.integration
 class TestMutmutKillsTheMutant:
     # The real mutmut run is given an internal 420s subprocess budget below; the

--- a/tests/quality/test_mutation_kill_proof.py
+++ b/tests/quality/test_mutation_kill_proof.py
@@ -26,6 +26,10 @@ import pytest
 from teatree.config import OnBehalfPostMode
 from teatree.on_behalf_gate import OnBehalfVerdict, resolve_on_behalf_verdict
 
+# The real mutmut run is a whole-module subprocess; deselected at push
+# (`-m "not push_heavy"`) and run in CI instead.
+pytestmark = pytest.mark.push_heavy
+
 
 def _mutant_resolve(mode: OnBehalfPostMode, action: str) -> OnBehalfVerdict:
     """The BLOCK→PROCEED mutant of the ASK branch (the regression we fear)."""

--- a/tests/test_no_full_suite_on_pre_push.py
+++ b/tests/test_no_full_suite_on_pre_push.py
@@ -12,15 +12,19 @@ src/teatree`` (fast static/AST + doctest collection), which cannot drag in the
 wall-clock/concurrency suites the invariant forbids. ``TestCiCriticalParityHook``
 guards that it stays scoped and cannot silently widen to the full suite.
 
-The two whole-tree subprocess checks that dominated the push wall-clock -- the
-~63s jscpd duplication scan (``tests/quality/test_jscpd_duplication.py``) and the
-mutmut kill-proof run (``tests/quality/test_mutation_kill_proof.py``) -- carry a
-``push_heavy`` marker and are DESELECTED at push (``-m "not push_heavy"``). They
-are RELOCATED to CI, not dropped: CI's ``test-shard`` lane runs the whole suite
-with NO marker filter, so both still gate on every PR. ``TestPushHeavyRelocatedToCI``
-pins that relocation -- excluded at push, present in CI.
+The two whole-tree subprocess CLASSES that dominated the push wall-clock -- the
+~63s jscpd scan (``TestScanCoverage``) and the mutmut kill-proof run
+(``TestMutmutKillsTheMutant``) -- carry a ``push_heavy`` marker and are DESELECTED
+at push (``-m "not push_heavy"``). The marker is CLASS-scoped, not module-scoped,
+so the fast/deterministic siblings (``TestConfigPin``, ``TestManualMutantKilled``)
+stay SELECTED at push for quick feedback on a config / manual-mutant regression.
+The heavy checks are RELOCATED to CI, not dropped: CI's ``test-shard`` lane runs
+the whole suite with NO marker filter, so both still gate on every PR.
+``TestPushHeavyRelocatedToCI`` pins that relocation -- heavy excluded at push,
+cheap still selected, everything present in CI.
 """
 
+import ast
 import re
 from pathlib import Path
 
@@ -30,10 +34,21 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 _CONFIG = _REPO_ROOT / ".pre-commit-config.yaml"
 _PYPROJECT = _REPO_ROOT / "pyproject.toml"
 _CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
-_HEAVY_FILES = (
-    _REPO_ROOT / "tests" / "quality" / "test_jscpd_duplication.py",
-    _REPO_ROOT / "tests" / "quality" / "test_mutation_kill_proof.py",
-)
+
+# Per heavy file: the CLASS that runs the expensive subprocess (marked
+# `push_heavy`, deselected at push) vs the fast/deterministic class that must
+# stay SELECTED at push. Marking the whole module would lift the cheap classes
+# off the push gate too, losing fast feedback on a config / manual-mutant regression.
+_HEAVY_CHECKS = {
+    _REPO_ROOT / "tests" / "quality" / "test_jscpd_duplication.py": {
+        "heavy": ("TestScanCoverage",),
+        "cheap": ("TestConfigPin",),
+    },
+    _REPO_ROOT / "tests" / "quality" / "test_mutation_kill_proof.py": {
+        "heavy": ("TestMutmutKillsTheMutant",),
+        "cheap": ("TestManualMutantKilled",),
+    },
+}
 
 # A pytest invocation with no path/marker scoping -- the full-suite signature.
 # Matches "pytest", "uv run pytest", "uv run -p 3.13 pytest" not followed by a
@@ -132,14 +147,32 @@ def _ci_shard_pytest() -> str:
     return "\n".join(runs)
 
 
+def _class_decorators(source: str) -> dict[str, list[str]]:
+    return {
+        node.name: [ast.unparse(dec) for dec in node.decorator_list]
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.ClassDef)
+    }
+
+
+def _has_module_push_heavy(source: str) -> bool:
+    for node in ast.parse(source).body:
+        targets = node.targets if isinstance(node, ast.Assign) else []
+        if any(isinstance(t, ast.Name) and t.id == "pytestmark" for t in targets):
+            return "push_heavy" in ast.unparse(node.value)
+    return False
+
+
 class TestPushHeavyRelocatedToCI:
-    """The two whole-tree checks are OFF the push gate but STILL run in CI.
+    """The heavy CLASSES are OFF the push gate; the cheap ones stay ON; CI runs all.
 
     The invariant is relocation, not deletion: nothing that gated before the
     push-hook slim-down is ungated after -- the jscpd + mutmut checks simply move
-    from push-time to CI-time. This class pins all four halves of that contract:
-    the checks carry the marker, the marker is registered (``--strict-markers``),
-    the push hook deselects it, and CI's shard lane does NOT.
+    from push-time to CI-time. The marker is CLASS-scoped so the fast siblings keep
+    gating at push. This class pins every half of that contract: the marker is
+    registered (``--strict-markers``), the heavy classes carry it, the cheap
+    classes (and the module) do NOT, the push hook deselects it, and CI's shard
+    lane does NOT.
     """
 
     def test_push_heavy_marker_is_registered(self) -> None:
@@ -151,13 +184,30 @@ class TestPushHeavyRelocatedToCI:
             "[tool.pytest.ini_options] markers -- --strict-markers rejects it otherwise."
         )
 
-    def test_heavy_checks_carry_the_marker(self) -> None:
-        for path in _HEAVY_FILES:
+    def test_heavy_classes_carry_the_marker(self) -> None:
+        for path, classes in _HEAVY_CHECKS.items():
+            decorators = _class_decorators(path.read_text())
+            for cls in classes["heavy"]:
+                assert cls in decorators, f"{path.name}::{cls} not found -- update _HEAVY_CHECKS."
+                assert "pytest.mark.push_heavy" in decorators[cls], (
+                    f"{path.name}::{cls} runs the expensive subprocess and must be decorated "
+                    "`@pytest.mark.push_heavy` so the push hook deselects it."
+                )
+
+    def test_cheap_classes_stay_push_selected(self) -> None:
+        for path, classes in _HEAVY_CHECKS.items():
             source = path.read_text()
-            assert re.search(r"pytest\.mark\.push_heavy", source), (
-                f"{path.relative_to(_REPO_ROOT).as_posix()} must carry the `push_heavy` marker "
-                "so the push hook can deselect its whole-tree scan."
+            assert not _has_module_push_heavy(source), (
+                f"{path.name} must NOT carry a module-level `push_heavy` pytestmark -- that would "
+                "lift the fast config-pin / manual-mutant checks off the push gate too."
             )
+            decorators = _class_decorators(source)
+            for cls in classes["cheap"]:
+                assert cls in decorators, f"{path.name}::{cls} not found -- update _HEAVY_CHECKS."
+                assert "pytest.mark.push_heavy" not in decorators[cls], (
+                    f"{path.name}::{cls} is fast + deterministic and must stay SELECTED at push -- "
+                    "it must not carry the `push_heavy` marker."
+                )
 
     def test_ci_shard_lane_does_not_deselect_push_heavy(self) -> None:
         # Relocation proof: the shard lane runs the WHOLE suite with no marker

--- a/tests/test_no_full_suite_on_pre_push.py
+++ b/tests/test_no_full_suite_on_pre_push.py
@@ -11,6 +11,14 @@ hook runs ``tests/quality`` + the never-lockout contract + ``--doctest-modules
 src/teatree`` (fast static/AST + doctest collection), which cannot drag in the
 wall-clock/concurrency suites the invariant forbids. ``TestCiCriticalParityHook``
 guards that it stays scoped and cannot silently widen to the full suite.
+
+The two whole-tree subprocess checks that dominated the push wall-clock -- the
+~63s jscpd duplication scan (``tests/quality/test_jscpd_duplication.py``) and the
+mutmut kill-proof run (``tests/quality/test_mutation_kill_proof.py``) -- carry a
+``push_heavy`` marker and are DESELECTED at push (``-m "not push_heavy"``). They
+are RELOCATED to CI, not dropped: CI's ``test-shard`` lane runs the whole suite
+with NO marker filter, so both still gate on every PR. ``TestPushHeavyRelocatedToCI``
+pins that relocation -- excluded at push, present in CI.
 """
 
 import re
@@ -20,6 +28,12 @@ import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _CONFIG = _REPO_ROOT / ".pre-commit-config.yaml"
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+_HEAVY_FILES = (
+    _REPO_ROOT / "tests" / "quality" / "test_jscpd_duplication.py",
+    _REPO_ROOT / "tests" / "quality" / "test_mutation_kill_proof.py",
+)
 
 # A pytest invocation with no path/marker scoping -- the full-suite signature.
 # Matches "pytest", "uv run pytest", "uv run -p 3.13 pytest" not followed by a
@@ -79,9 +93,10 @@ class TestCiCriticalParityHook:
 
     It closes the local/CI divergence (doctest + never-lockout classes) at push
     time WITHOUT running the full suite -- so it must (a) exist on the push stage,
-    (b) be path-scoped (its pytest is not bare), and (c) still carry its three
-    load-bearing targets, so a future edit can neither widen it to the full suite
-    nor silently drop the doctest / never-lockout coverage.
+    (b) be path-scoped (its pytest is not bare), (c) still carry its three
+    load-bearing targets, and (d) DESELECT the ``push_heavy`` whole-tree checks so
+    the push gate stays light. A future edit can neither widen it to the full
+    suite nor silently drop the doctest / never-lockout coverage.
     """
 
     def _hook(self) -> dict:
@@ -99,3 +114,56 @@ class TestCiCriticalParityHook:
         entry = self._hook()["entry"]
         for token in ("tests/quality", "tests/test_gate_never_lockout_contract.py", "--doctest-modules src/teatree"):
             assert token in entry, f"ci-critical-parity dropped `{token}` -- it must not narrow its coverage."
+
+    def test_entry_deselects_push_heavy(self) -> None:
+        # The whole-tree jscpd + mutmut checks must be OFF the push gate; the
+        # marker deselection is what keeps the ~63s scan out of every push.
+        assert "not push_heavy" in self._hook()["entry"], (
+            "ci-critical-parity must deselect the `push_heavy` whole-tree checks "
+            '(`-m "not push_heavy"`) so the jscpd/mutmut scans do not gate a push.'
+        )
+
+
+def _ci_shard_pytest() -> str:
+    workflow = yaml.safe_load(_CI_WORKFLOW.read_text())
+    steps = workflow["jobs"]["test-shard"]["steps"]
+    runs = [str(step["run"]) for step in steps if "run" in step and "pytest" in str(step.get("run", ""))]
+    assert runs, "test-shard job runs no pytest step"
+    return "\n".join(runs)
+
+
+class TestPushHeavyRelocatedToCI:
+    """The two whole-tree checks are OFF the push gate but STILL run in CI.
+
+    The invariant is relocation, not deletion: nothing that gated before the
+    push-hook slim-down is ungated after -- the jscpd + mutmut checks simply move
+    from push-time to CI-time. This class pins all four halves of that contract:
+    the checks carry the marker, the marker is registered (``--strict-markers``),
+    the push hook deselects it, and CI's shard lane does NOT.
+    """
+
+    def test_push_heavy_marker_is_registered(self) -> None:
+        markers = _PYPROJECT.read_text()
+        # --strict-markers rejects an unregistered marker; the checks would ERROR
+        # at collection if the marker were applied but not declared here.
+        assert '"push_heavy:' in markers, (
+            "the `push_heavy` marker must be registered in pyproject.toml "
+            "[tool.pytest.ini_options] markers -- --strict-markers rejects it otherwise."
+        )
+
+    def test_heavy_checks_carry_the_marker(self) -> None:
+        for path in _HEAVY_FILES:
+            source = path.read_text()
+            assert re.search(r"pytest\.mark\.push_heavy", source), (
+                f"{path.relative_to(_REPO_ROOT).as_posix()} must carry the `push_heavy` marker "
+                "so the push hook can deselect its whole-tree scan."
+            )
+
+    def test_ci_shard_lane_does_not_deselect_push_heavy(self) -> None:
+        # Relocation proof: the shard lane runs the WHOLE suite with no marker
+        # filter, so a `push_heavy`-marked check still gates on every PR.
+        shard = _ci_shard_pytest()
+        assert "push_heavy" not in shard, (
+            "CI's test-shard lane must NOT filter out `push_heavy` -- the heavy checks "
+            "are relocated to CI, not deleted, so the shard must still run them."
+        )


### PR DESCRIPTION
## What & why

The `ci-critical-parity` **pre-push** hook ran two whole-tree subprocess checks on every push:

- the `npx jscpd` whole-tree duplication scan (`tests/quality/test_jscpd_duplication.py::TestScanCoverage`) — the test's own comment documents it as ~60s standalone and worse under concurrent-coder load, where it trips the 60s pytest-timeout and blocks the push;
- the `mutmut` kill-proof run (`tests/quality/test_mutation_kill_proof.py::TestMutmutKillsTheMutant`) — up to a 420s budget on Linux (it only skips on macOS).

Together these made the push gate too heavy: pushes parked / timed out. This is a scoping change, not new machinery.

## The change

- Register a `push_heavy` pytest marker (`pyproject.toml`; `--strict-markers` is on, so registration is required).
- Mark both whole-tree files module-level with `pytest.mark.push_heavy`.
- Deselect them on the push hook: `-m "not push_heavy"` added to the `ci-critical-parity` entry.

The fast static/AST lane (`tests/quality` minus the two heavy files), the never-lockout contract, and the `--doctest-modules src/teatree` import-parity lane stay on the push gate unchanged.

## Relocated to CI, not dropped (the invariant)

Nothing that gated before is ungated after — the two checks move from push-time to CI-time:

- CI's `test-shard` lane (`.github/workflows/ci.yml`, job `test-shard`, the pytest step around lines 513-526) runs the whole suite with **no `-m` marker filter** (`pytest --no-header -q -n auto --doctest-modules --cov --cov-branch --splits 4 --group N …`). A `push_heavy`-marked file is still collected and distributed across the four shards, so both checks still gate on every PR.
- CI's Docker test image (`dev/Dockerfile.test`) installs `nodejs`, so `npx` is present and the jscpd scan genuinely runs in CI (it does not skip). CI runs on `ubuntu-latest`, so the mutmut run's macOS-only skip does not apply — the mutmut run executes.

No `ci.yml` edit is needed: the shard lane already runs unmarked, so the marker changes nothing there.

## TDD — RED before, GREEN after

The pin test `tests/test_no_full_suite_on_pre_push.py` was updated to assert the new lighter contract and a new `TestPushHeavyRelocatedToCI` class pins the four halves of the relocation contract (marker carried, marker registered, push deselects it, CI shard does not).

- RED on the old contract: `test_entry_deselects_push_heavy`, `test_push_heavy_marker_is_registered`, `test_heavy_checks_carry_the_marker` all failed before the fix (3 failed, 6 passed). The relocation invariant `test_ci_shard_lane_does_not_deselect_push_heavy` was already green (ci.yml has no filter).
- GREEN after the fix: all 9 pass.

Behavioural verification (collect-only): with `-m "not push_heavy"` the 8 heavy tests are deselected; without the filter all 8 are collected — excluded at push, present in CI.

## Measured push-time reduction

Measured locally (warm npx cache, macOS):

- The two heavy files add ~15s of test time here (jscpd runs; mutmut skips on macOS). Under concurrent load / cold cache the jscpd scan stretches to the ~60s the test comment documents and trips the 60s timeout — that variable, load-dependent cost is what leaves the push gate.
- On Linux dev hosts the mutmut run (up to 420s) also left the push path, a much larger saving there.
- The remaining lighter push lane runs ~46s (606 tests, `-n auto`).

## Architecture pre-check

Tactical scoping change to the pre-push hook config and test markers. It touches `.pre-commit-config.yaml`, `pyproject.toml` (markers), two `tests/quality` files, and the pin test — no `src/teatree`, no FSM transition, no Protocol/`OverlayBase`/scanner surface, no new module, no dependency-graph edge. Checks 1-8 are n/a. Check 9 (behavior preservation) is the load-bearing one: no check is dropped — both whole-tree checks are relocated from push to CI and proven to still run there; no must-block test was inverted.
