### PR TITLE
fix(ticket): CLI-expose ignore/unignore; validate --adopt targets

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -6057,6 +6057,8 @@ Usage: t3 teatree workspace ticket [OPTIONS] ISSUE_URL
 │ --adopt-branch        TEXT  Adopt this EXISTING branch (implies --adopt).    │
 │                             Omit to auto-detect from the current git         │
 │                             worktree.                                        │
+│ --adopt-closed              Override the --adopt guard that refuses a        │
+│                             CLOSED/nonexistent target issue/PR URL.          │
 │ --kind                TEXT  Classify: 'fix' or 'feature' (blank infers from  │
 │                             the title, #17).                                 │
 │ --help                      Show this message and exit.                      │

--- a/src/teatree/core/management/commands/_transition_names.py
+++ b/src/teatree/core/management/commands/_transition_names.py
@@ -27,4 +27,11 @@ ALLOWED_TRANSITIONS = {
     # stranded at ``in_review`` after a failed ship can be reconciled
     # without a code-level workaround.
     "reconcile_reviewed",
+    # Abandon/neutralize a mis-adopted or stray ticket: ``ignore`` drives the
+    # reversible terminal IGNORED state (its body only stamps ``ignored_from``;
+    # it enqueues no teardown/ship task and posts nothing to the forge), and
+    # ``unignore`` restores the pre-abandon state. Both are FSM-model methods
+    # the CLI merely refused to dispatch.
+    "ignore",
+    "unignore",
 }

--- a/src/teatree/core/management/commands/_workspace_ticket_intake.py
+++ b/src/teatree/core/management/commands/_workspace_ticket_intake.py
@@ -149,9 +149,10 @@ def adopt_target_refusal(overlay: "OverlayBase", issue_url: str, *, allow_closed
     ``--adopt-closed`` override (``allow_closed``) is the explicit escape.
 
     Fail-open on the ambiguous cases — a URL no code host can resolve (an
-    unknown tracker) or a transient forge error is NOT proof of a bad target,
-    so it proceeds. The refusal fires only on a POSITIVE closed / not-found
-    signal from a resolvable host.
+    unknown tracker), a transient forge error, or an error dict from a host that
+    could not parse the URL as an issue (a GitHub ``/pull/<n>`` URL) is NOT proof
+    of a bad target, so it proceeds. The refusal fires only on a POSITIVE signal:
+    a genuine 404 (``IssueNotFoundError``) or a resolvable-but-CLOSED target.
     """
     host = get_code_host_for_url(overlay, issue_url)
     if host is None:
@@ -164,7 +165,12 @@ def adopt_target_refusal(overlay: "OverlayBase", issue_url: str, *, allow_closed
         logger.warning("adopt-target validation could not resolve %s: %s", issue_url, exc)
         return None
     if not isinstance(data, dict) or data.get("error"):
-        return f"  Refused: --adopt target {issue_url} does not resolve to a real issue/PR. Check the URL."
+        # An error dict means the host could not PARSE/resolve the URL as an issue
+        # (e.g. a GitHub /pull/<n> URL, which the issue-only ref parser rejects) —
+        # ambiguity, not a positive bad signal. Fail open like the transient case;
+        # only a genuine 404 (IssueNotFoundError, above) or a resolvable-closed
+        # target refuses.
+        return None
     if overlay.is_issue_done(data) and not allow_closed:
         return (
             f"  Refused: --adopt target {issue_url} is CLOSED. Adopting a closed issue/PR is the "

--- a/src/teatree/core/management/commands/_workspace_ticket_intake.py
+++ b/src/teatree/core/management/commands/_workspace_ticket_intake.py
@@ -7,27 +7,40 @@ double-dispatch guard that runs inside that transaction so a refusal rolls the
 freshly-created ticket back and leaves no DB trace.
 """
 
+import json
+import logging
 import re
 from collections.abc import Callable
+from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
+import httpx
 from django.db import transaction
 
+from teatree.backends.errors import IssueNotFoundError
+from teatree.backends.loader import get_code_host_for_url
 from teatree.core.dev_repo import parse_repo_branch_map, resolve_repo_names
 from teatree.core.management.commands import _workspace_helpers as _wh
 from teatree.core.models import Ticket
 from teatree.core.models.external_delivery import mark_external_delivery
+from teatree.core.models.project_learning import ProjectLearning
+from teatree.core.models.ticket_display import format_intake_summary
 from teatree.core.resolve import _get_user_cwd
+from teatree.core.runners import WorktreeProvisioner
 from teatree.core.ticket_kind_classification import classify_ticket_kind, parse_kind
 from teatree.core.worktree_collision import find_foreign_issue_worktrees
 from teatree.core.worktree_paths import ticket_dir_for
 from teatree.utils import git
+from teatree.utils.run import CommandFailedError, TimeoutExpired
+from teatree.utils.url_slug import project_slug_from_ref
 
 if TYPE_CHECKING:
     from teatree.core.models.types import TicketExtra
     from teatree.core.overlay import OverlayBase
+
+logger = logging.getLogger(__name__)
 
 
 class ForeignIssueWorktreeRefusedError(Exception):
@@ -108,6 +121,56 @@ def resolve_adopt_context(*, adopt: bool, adopt_branch: str) -> AdoptContext | N
     branch = adopt_branch or git.current_branch(repo=worktree_path)
     repo = git.remote_slug(repo=worktree_path) or Path(worktree_path).name
     return AdoptContext(branch=branch, worktree_path=worktree_path, repo=repo)
+
+
+def adopt_preflight_refusal(
+    overlay: "OverlayBase", issue_url: str, adopt_ctx: AdoptContext | None, *, allow_closed: bool
+) -> str | None:
+    """The full ``--adopt`` precondition check: refusal message, or ``None`` to proceed.
+
+    Not adopting (``adopt_ctx is None``) is always fine. Otherwise the branch
+    must be checked out (a detached HEAD has nothing to register), and the
+    target issue/PR must not be CLOSED or nonexistent (:func:`adopt_target_refusal`).
+    """
+    if adopt_ctx is None:
+        return None
+    if not adopt_ctx.branch or adopt_ctx.branch == git.DETACHED_HEAD:
+        return "  Refused: --adopt needs a checked-out branch (HEAD is detached); pass --adopt-branch <branch>."
+    return adopt_target_refusal(overlay, issue_url, allow_closed=allow_closed)
+
+
+def adopt_target_refusal(overlay: "OverlayBase", issue_url: str, *, allow_closed: bool) -> str | None:
+    """Refusal message when ``--adopt``'s target issue/PR is CLOSED or nonexistent, else ``None``.
+
+    Anti-recurrence guard: ``--adopt`` binds a Ticket to whatever ``issue_url``
+    the operator typed, and the recorded failure was adopting a stray number
+    that resolved to a CLOSED, unrelated PR. We resolve the URL's live state
+    through the per-URL code host and refuse a closed or not-found target; the
+    ``--adopt-closed`` override (``allow_closed``) is the explicit escape.
+
+    Fail-open on the ambiguous cases — a URL no code host can resolve (an
+    unknown tracker) or a transient forge error is NOT proof of a bad target,
+    so it proceeds. The refusal fires only on a POSITIVE closed / not-found
+    signal from a resolvable host.
+    """
+    host = get_code_host_for_url(overlay, issue_url)
+    if host is None:
+        return None
+    try:
+        data = host.get_issue(issue_url)
+    except IssueNotFoundError:
+        return f"  Refused: --adopt target {issue_url} does not exist (HTTP 404). Check the issue/PR URL."
+    except (httpx.HTTPError, CommandFailedError, TimeoutExpired, json.JSONDecodeError, OSError) as exc:
+        logger.warning("adopt-target validation could not resolve %s: %s", issue_url, exc)
+        return None
+    if not isinstance(data, dict) or data.get("error"):
+        return f"  Refused: --adopt target {issue_url} does not resolve to a real issue/PR. Check the URL."
+    if overlay.is_issue_done(data) and not allow_closed:
+        return (
+            f"  Refused: --adopt target {issue_url} is CLOSED. Adopting a closed issue/PR is the "
+            "recorded mis-adoption failure; pass --adopt-closed to override if this is intentional."
+        )
+    return None
 
 
 def build_intake(overlay: "OverlayBase", raw: RawTicketInputs) -> TicketIntake:
@@ -289,3 +352,53 @@ def _refuse_on_foreign_issue_worktree(
         "someone may already be working it. Re-run with --take-over to proceed."
     )
     raise ForeignIssueWorktreeRefusedError
+
+
+def _project_learnings_for_ticket(ticket: Ticket) -> str:
+    """Durable per-repo learnings (#2892) for *ticket*'s repo, or "" when none recorded."""
+    slug = project_slug_from_ref(ticket.issue_url)
+    return ProjectLearning.objects.content_for_slug(slug) if slug else ""
+
+
+def finalize_ticket_provision(
+    write_out: Callable[[str], None],
+    write_err: Callable[[str], None],
+    ticket: Ticket,
+    adopt_ctx: AdoptContext | None,
+    workspace_root: Path,
+) -> int:
+    """Provision the ticket's worktrees, discard an unattested failure, print the summary.
+
+    The second half of ``workspace ticket``, split from the command module to
+    keep it under the per-module LOC cap. Returns the ticket pk on success (or a
+    soft-failure warning), or 0 when an unrecoverable provision aborted and the
+    unattested ticket was discarded.
+    """
+    branch = cast("TicketExtra", ticket.extra)["branch"]
+    # In adopt mode the checkout lives where the operator ran the command, not
+    # under the worktree root — surface that path in the summary.
+    ticket_dir = Path(adopt_ctx.worktree_path).parent if adopt_ctx else ticket_dir_for(workspace_root, branch)
+
+    # Run the provisioner synchronously so the CLI gives immediate feedback; the
+    # worker that ``start()`` enqueued is idempotent and no-ops when it finds the
+    # worktrees already in place. Single source of truth: the runner.
+    result = WorktreeProvisioner(ticket).run()
+    if not result.ok and not ticket.worktrees.exists():  # ty: ignore[unresolved-attribute]
+        write_err(f"  Provisioning failed: {result.detail}")
+        # #748: only discard the ticket if it carries NO phase attestation.
+        # ``get_or_create`` may have resolved an existing loop/coordinator-built
+        # ticket whose sessions hold genuinely-completed-work phase records;
+        # ``Session.ticket`` is ``on_delete=CASCADE``, so ``ticket.delete()``
+        # here would cascade-reap that attestation. A failed provision must never
+        # destroy attested work — leave the ticket + sessions intact.
+        visited, _ = ticket.aggregate_phase_records()
+        if not visited:
+            ticket.delete()
+            with suppress(OSError):
+                ticket_dir.rmdir()
+        return 0
+    if not result.ok:
+        write_err(f"  WARNING: {result.detail}")
+    learnings = _project_learnings_for_ticket(ticket)
+    write_out(format_intake_summary(ticket, str(ticket_dir), branch, project_learnings=learnings))
+    return int(ticket.pk)

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -1,9 +1,8 @@
 """Workspace management: create ticket worktrees, finalize, clean stale branches."""
 
 import os
-from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, cast
+from typing import Annotated
 
 import typer
 from django.db import transaction
@@ -29,32 +28,21 @@ from teatree.core.management.commands._workspace_ticket_intake import (
     ForeignIssueWorktreeRefusedError,
     InvalidTicketKindError,
     RawTicketInputs,
+    adopt_preflight_refusal,
     build_intake,
     build_ticket,
+    finalize_ticket_provision,
     resolve_adopt_context,
 )
 from teatree.core.models import Ticket, Worktree
-from teatree.core.models.project_learning import ProjectLearning
-from teatree.core.models.ticket_display import format_intake_summary
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.public_identity import StampResult, is_public_github_remote, set_local_noreply_identity
 from teatree.core.reconcile import reconcile_all, reconcile_ticket
 from teatree.core.resolve import WorktreeNotFoundError, _get_user_cwd, resolve_worktree, workspace_owner_ticket
-from teatree.core.runners import WorktreeProvisioner, WorktreeStartRunner, WorktreeTeardownRunner
+from teatree.core.runners import WorktreeStartRunner, WorktreeTeardownRunner
 from teatree.core.worktree_done import reap_done_worktrees
-from teatree.core.worktree_paths import ticket_dir_for
 from teatree.docker.reclaim import reclaim_disk
 from teatree.utils import git
-from teatree.utils.url_slug import project_slug_from_ref
-
-if TYPE_CHECKING:
-    from teatree.core.models.types import TicketExtra
-
-
-def _project_learnings_for_ticket(ticket: Ticket) -> str:
-    """Durable per-repo learnings (#2892) for *ticket*'s repo, or "" when none recorded."""
-    slug = project_slug_from_ref(ticket.issue_url)
-    return ProjectLearning.objects.content_for_slug(slug) if slug else ""
 
 
 def _worktree_root() -> Path:
@@ -128,6 +116,13 @@ class Command(TyperCommand):
                 help="Adopt this EXISTING branch (implies --adopt). Omit to auto-detect from the current git worktree.",
             ),
         ] = "",
+        adopt_closed: Annotated[
+            bool,
+            typer.Option(
+                "--adopt-closed",
+                help="Override the --adopt guard that refuses a CLOSED/nonexistent target issue/PR URL.",
+            ),
+        ] = False,
         kind: Annotated[
             str, typer.Option("--kind", help="Classify: 'fix' or 'feature' (blank infers from the title, #17).")
         ] = "",
@@ -157,10 +152,9 @@ class Command(TyperCommand):
         # default ``get_overlay()`` env-var path still wins when set.
         overlay = get_overlay(_wh.resolve_overlay_name_for_url(issue_url))
         adopt_ctx = resolve_adopt_context(adopt=adopt, adopt_branch=adopt_branch)
-        if adopt_ctx is not None and (not adopt_ctx.branch or adopt_ctx.branch == git.DETACHED_HEAD):
-            self.stderr.write(
-                "  Refused: --adopt needs a checked-out branch (HEAD is detached); pass --adopt-branch <branch>."
-            )
+        adopt_refusal = adopt_preflight_refusal(overlay, issue_url, adopt_ctx, allow_closed=adopt_closed)
+        if adopt_refusal is not None:
+            self.stderr.write(adopt_refusal)
             return 0
         raw = RawTicketInputs(issue_url, repos, variant, description, take_over, adopt=adopt_ctx, kind=kind)
         try:
@@ -172,42 +166,13 @@ class Command(TyperCommand):
         except ForeignIssueWorktreeRefusedError:
             return 0
 
-        branch = cast("TicketExtra", ticket.extra)["branch"]
-        # In adopt mode the checkout lives where the operator ran the command, not
-        # under the worktree root — surface that path in the summary.
-        ticket_dir = Path(adopt_ctx.worktree_path).parent if adopt_ctx else ticket_dir_for(_worktree_root(), branch)
-
-        # Run the provisioner synchronously so the CLI gives immediate feedback;
-        # the worker that ``start()`` enqueued is idempotent and no-ops when it
-        # finds the worktrees already in place. Single source of truth: the runner.
-        result = WorktreeProvisioner(ticket).run()
-        if not result.ok and not ticket.worktrees.exists():  # ty: ignore[unresolved-attribute]
-            self.stderr.write(f"  Provisioning failed: {result.detail}")
-            # #748: only discard the ticket if it carries NO phase
-            # attestation. ``get_or_create`` may have resolved an
-            # existing loop/coordinator-built ticket whose sessions hold
-            # genuinely-completed-work phase records; ``Session.ticket``
-            # is ``on_delete=CASCADE``, so ``ticket.delete()`` here would
-            # cascade-reap that attestation (the observed session-reaper).
-            # A failed provision must never destroy attested work — leave
-            # the ticket + sessions intact and just report the failure.
-            visited, _ = ticket.aggregate_phase_records()
-            if not visited:
-                ticket.delete()
-                with suppress(OSError):
-                    ticket_dir.rmdir()
-            return 0
-        if not result.ok:
-            self.stderr.write(f"  WARNING: {result.detail}")
-        self.stdout.write(
-            format_intake_summary(
-                ticket,
-                str(ticket_dir),
-                branch,
-                project_learnings=_project_learnings_for_ticket(ticket),
-            )
+        return finalize_ticket_provision(
+            self.stdout.write,
+            self.stderr.write,
+            ticket,
+            adopt_ctx,
+            _worktree_root(),
         )
-        return int(ticket.pk)
 
     @command()
     def provision(

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import cast
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from django.core.management import call_command
 from django.test import TestCase, override_settings
@@ -25,6 +26,7 @@ import teatree.core.management.commands._workspace_cleanup as ws_cleanup_mod
 import teatree.core.management.commands._workspace_docker as ws_docker_mod
 import teatree.core.management.commands._workspace_salvage as ws_salvage_mod
 import teatree.core.management.commands._workspace_stash as ws_stash_mod
+import teatree.core.management.commands._workspace_ticket_intake as workspace_intake_mod
 import teatree.core.management.commands.workspace as workspace_mod
 import teatree.core.overlay_loader as overlay_loader_mod
 import teatree.core.runners.provision as provision_mod
@@ -33,6 +35,7 @@ import teatree.utils.db as db_mod
 import teatree.utils.git as git_mod
 import teatree.utils.git_commit as git_commit_mod
 import teatree.utils.run as utils_run_mod
+from teatree.backends.errors import IssueNotFoundError
 from teatree.config import load_config
 from teatree.core.cleanup_liveness import LivenessVerdict
 from teatree.core.gates.provision_admission_gate import ProvisionAdmissionVerdict
@@ -359,6 +362,135 @@ class TestWorkspaceTicketAdopt(TestCase):
         assert rc == 0
         assert not Ticket.objects.filter(issue_url="https://example.com/issues/2275").exists()
 
+    def _patch_issue_host(self, host: MagicMock) -> None:
+        self.enterContext(
+            patch.object(workspace_intake_mod, "get_code_host_for_url", return_value=host),
+        )
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_adopt_refuses_closed_target(self) -> None:
+        worktree = self._clone_and_worktree("feature-x")
+        self._enter_adopt_patches(worktree)
+        host = MagicMock()
+        host.get_issue.return_value = {"state": "closed", "title": "An unrelated closed PR"}
+        self._patch_issue_host(host)
+
+        rc = call_command("workspace", "ticket", "https://github.com/souliane/teatree/issues/89", adopt=True)
+
+        assert rc == 0
+        assert not Ticket.objects.filter(issue_url="https://github.com/souliane/teatree/issues/89").exists()
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_adopt_refuses_nonexistent_target(self) -> None:
+        worktree = self._clone_and_worktree("feature-x")
+        self._enter_adopt_patches(worktree)
+        url = "https://github.com/souliane/teatree/issues/999999"
+        host = MagicMock()
+        host.get_issue.side_effect = IssueNotFoundError(url)
+        self._patch_issue_host(host)
+
+        rc = call_command("workspace", "ticket", url, adopt=True)
+
+        assert rc == 0
+        assert not Ticket.objects.filter(issue_url=url).exists()
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_adopt_closed_override_proceeds(self) -> None:
+        worktree = self._clone_and_worktree("feature-x")
+        self._enter_adopt_patches(worktree)
+        host = MagicMock()
+        host.get_issue.return_value = {"state": "closed", "title": "Closed but intentionally adopted"}
+        self._patch_issue_host(host)
+
+        ticket_id = cast(
+            "int",
+            call_command(
+                "workspace",
+                "ticket",
+                "https://github.com/souliane/teatree/issues/89",
+                adopt=True,
+                adopt_closed=True,
+            ),
+        )
+
+        ticket = Ticket.objects.get(pk=ticket_id)
+        assert ticket.extra["branch"] == "feature-x"
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_adopt_refuses_error_dict_target(self) -> None:
+        worktree = self._clone_and_worktree("feature-x")
+        self._enter_adopt_patches(worktree)
+        url = "https://github.com/souliane/teatree/pull/89"
+        host = MagicMock()
+        host.get_issue.return_value = {"error": f"Not a GitHub issue URL: {url}"}
+        self._patch_issue_host(host)
+
+        rc = call_command("workspace", "ticket", url, adopt=True)
+
+        assert rc == 0
+        assert not Ticket.objects.filter(issue_url=url).exists()
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_adopt_proceeds_on_transient_forge_error(self) -> None:
+        worktree = self._clone_and_worktree("feature-x")
+        self._enter_adopt_patches(worktree)
+        url = "https://github.com/souliane/teatree/issues/7"
+        host = MagicMock()
+        host.get_issue.side_effect = httpx.ConnectError("forge unreachable")
+        self._patch_issue_host(host)
+
+        ticket_id = cast("int", call_command("workspace", "ticket", url, adopt=True))
+
+        ticket = Ticket.objects.get(pk=ticket_id)
+        assert ticket.extra["branch"] == "feature-x"
+
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_adopt_open_target_succeeds(self) -> None:
+        worktree = self._clone_and_worktree("feature-x")
+        self._enter_adopt_patches(worktree)
+        host = MagicMock()
+        host.get_issue.return_value = {"state": "open", "title": "A genuine open issue"}
+        self._patch_issue_host(host)
+
+        ticket_id = cast(
+            "int",
+            call_command("workspace", "ticket", "https://github.com/souliane/teatree/issues/42", adopt=True),
+        )
+
+        ticket = Ticket.objects.get(pk=ticket_id)
+        assert ticket.extra["branch"] == "feature-x"
+        assert ticket.repos == ["myrepo"]
+
+
+class TestFinalizeTicketProvision(TestCase):
+    """#748: a failed provision never discards a ticket that carries phase attestation."""
+
+    @pytest.fixture(autouse=True)
+    def _tmp(self, tmp_path: Path) -> None:
+        self.workspace = tmp_path
+
+    def test_failed_provision_keeps_attested_ticket(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", extra={"branch": "748-keep"})
+        provisioner = MagicMock()
+        provisioner.run.return_value = RunnerResult(ok=False, detail="boom")
+        errs: list[str] = []
+        with (
+            patch.object(workspace_intake_mod, "WorktreeProvisioner", return_value=provisioner),
+            patch.object(Ticket, "aggregate_phase_records", return_value=(["coding"], {})),
+        ):
+            rc = workspace_intake_mod.finalize_ticket_provision(
+                lambda _s: None, errs.append, ticket, None, self.workspace
+            )
+        assert rc == 0
+        assert Ticket.objects.filter(pk=ticket.pk).exists()
+        assert any("Provisioning failed" in line for line in errs)
+
 
 class TestWorkspaceTicket(TestCase):
     def setUp(self) -> None:
@@ -408,7 +540,7 @@ class TestWorkspaceTicket(TestCase):
             (workspace / "42-someone-else-already-here").mkdir()
             with (
                 patch.object(workspace_mod, "_worktree_root", return_value=workspace),
-                patch.object(workspace_mod, "WorktreeProvisioner") as provisioner,
+                patch.object(workspace_intake_mod, "WorktreeProvisioner") as provisioner,
             ):
                 provisioner.return_value.run.return_value = RunnerResult(ok=True, detail="ok")
                 rc = call_command("workspace", "ticket", "https://example.com/issues/42", take_over=True)
@@ -424,7 +556,7 @@ class TestWorkspaceTicket(TestCase):
             workspace = Path(tmp)
             with (
                 patch.object(workspace_mod, "_worktree_root", return_value=workspace),
-                patch.object(workspace_mod, "WorktreeProvisioner") as provisioner,
+                patch.object(workspace_intake_mod, "WorktreeProvisioner") as provisioner,
             ):
                 provisioner.return_value.run.return_value = RunnerResult(ok=True, detail="ok")
                 first = call_command("workspace", "ticket", "https://example.com/issues/42")
@@ -1446,7 +1578,7 @@ class TestWorkspaceMultiOverlayResolution(TestCase):
         with (
             patch.dict(os.environ, env_without_overlay, clear=True),
             patch.object(overlay_loader_mod, "_discover_overlays", new=_fake_discover),
-            patch.object(workspace_mod, "WorktreeProvisioner", return_value=provisioner),
+            patch.object(workspace_intake_mod, "WorktreeProvisioner", return_value=provisioner),
         ):
             ticket_id = cast("int", call_command("workspace", "ticket", url, repos="backend"))
 

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -421,7 +421,10 @@ class TestWorkspaceTicketAdopt(TestCase):
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_adopt_refuses_error_dict_target(self) -> None:
+    def test_adopt_proceeds_on_unparsable_pull_url(self) -> None:
+        # A GitHub /pull/<n> URL is unparsable by get_issue's issue-only ref
+        # parser, so a resolvable host returns {"error": ...} — ambiguity, not a
+        # positive bad signal. A valid OPEN PR adopted via /pull/<n> must PROCEED.
         worktree = self._clone_and_worktree("feature-x")
         self._enter_adopt_patches(worktree)
         url = "https://github.com/souliane/teatree/pull/89"
@@ -429,10 +432,10 @@ class TestWorkspaceTicketAdopt(TestCase):
         host.get_issue.return_value = {"error": f"Not a GitHub issue URL: {url}"}
         self._patch_issue_host(host)
 
-        rc = call_command("workspace", "ticket", url, adopt=True)
+        ticket_id = cast("int", call_command("workspace", "ticket", url, adopt=True))
 
-        assert rc == 0
-        assert not Ticket.objects.filter(issue_url=url).exists()
+        ticket = Ticket.objects.get(pk=ticket_id)
+        assert ticket.extra["branch"] == "feature-x"
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)

--- a/tests/teatree_core/test_loop_built_ticket_session.py
+++ b/tests/teatree_core/test_loop_built_ticket_session.py
@@ -47,7 +47,7 @@ class TestProvisionRollbackPreservesAttestationSessions(TestCase):
         # the SAME ticket via get_or_create, then provisioning fails with
         # no worktrees → the rollback path (`ticket.delete()`) fires.
         with patch(
-            "teatree.core.management.commands.workspace.WorktreeProvisioner",
+            "teatree.core.management.commands._workspace_ticket_intake.WorktreeProvisioner",
         ) as prov:
             prov.return_value.run.return_value = type("R", (), {"ok": False, "detail": "provision boom"})()
             call_command("workspace", "ticket", "https://example.com/issues/748")

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -17,9 +17,11 @@ import teatree.core.management.commands.worktree as worktree_cmd
 import teatree.core.overlay_loader as overlay_loader_mod
 import teatree.core.runners.worktree_provision as worktree_provision_mod
 import teatree.utils.run as utils_run_mod
+from teatree.core.management.commands._transition_names import ALLOWED_TRANSITIONS
 from teatree.core.models import ConfigSetting, Session, Task, TaskAttempt, Ticket, Worktree
 from teatree.core.models.ticket_external_review import schedule_external_review
 from teatree.core.overlay import DbImportStrategy, OverlayBase, ProvisionStep, RunCommands
+from teatree.core.signals import _TICKET_TRANSITION_TASKS
 from tests._ansi import strip_ansi as _strip_ansi
 from tests.teatree_agents._sdk_fake import fake_sdk, success_stream
 
@@ -916,6 +918,42 @@ class TestTicketCommand(TestCase):
         assert reason in str(result["error"])
         ticket.refresh_from_db()
         assert ticket.state == Ticket.State.REVIEWED
+
+    def test_ignore_and_unignore_are_cli_allowed_and_enqueue_no_task(self) -> None:
+        """#2275 cleanup: abandon (ignore) is CLI-reachable and never drives teardown/ship/post.
+
+        The two names must be in the CLI allow-list, and neither may map to a
+        ``_TICKET_TRANSITION_TASKS`` executor — that mapping is what enqueues
+        ``execute_teardown`` / ``execute_ship`` (the only transition side effects
+        that post to the forge). Their absence is the structural proof that
+        abandoning a mis-adopted ticket is non-posting.
+        """
+        assert {"ignore", "unignore"} <= ALLOWED_TRANSITIONS
+        assert "ignore" not in _TICKET_TRANSITION_TASKS
+        assert "unignore" not in _TICKET_TRANSITION_TASKS
+
+    def test_transition_ignore_reaches_ignored_state(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.STARTED)
+        result = cast(
+            "dict[str, object]",
+            call_command("ticket", "transition", ticket.pk, "ignore"),
+        )
+        assert result["state"] == Ticket.State.IGNORED
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.IGNORED
+        assert ticket.extra["ignored_from"] == Ticket.State.STARTED
+
+    def test_transition_unignore_restores_prior_state(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.STARTED)
+        call_command("ticket", "transition", ticket.pk, "ignore")
+        result = cast(
+            "dict[str, object]",
+            call_command("ticket", "transition", ticket.pk, "unignore"),
+        )
+        assert result["state"] == Ticket.State.STARTED
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.STARTED
+        assert "ignored_from" not in (ticket.extra or {})
 
     def test_transition_mark_review_no_action_delivers_reviewer_ticket(self) -> None:
         """#1077: the no-action disposition is reachable via the CLI transition."""


### PR DESCRIPTION
## What

Two related CLI gaps around abandoning and adopting tickets.

**1. Expose the FSM `ignore`/`unignore` transitions in the CLI.**
The `Ticket` FSM already has `ignore` → `IGNORED` (a terminal state, reversible
via `unignore`), but neither name was in the CLI transition allow-list, so
`t3 teatree ticket transition <id> ignore` returned `{'error': 'Unknown
transition: ignore'}`. This left no sanctioned way to abandon/neutralize a
stray or mis-created ticket from the CLI. Both names are now allowed.

`ignore` is genuinely terminal and non-posting: its transition body only stamps
`extra["ignored_from"]`, it is absent from `_TICKET_TRANSITION_TASKS` (so it
enqueues no teardown/ship worker), and it posts nothing to the forge — its only
external effect is a gated Slack reaction on the review message (skipped without
a recorded on-behalf approval). `unignore` restores the pre-abandon state.

**2. Validate `workspace ticket <url> --adopt`.**
`--adopt` bound a `Ticket` to whatever issue URL was typed without checking it.
Adopting a stray number that resolved to a CLOSED, unrelated PR was the recorded
mis-adoption. The command now resolves the target's live state through the
per-URL code host and refuses a CLOSED or nonexistent issue/PR before creating
any row; the new `--adopt-closed` flag is the explicit override. It fails open
on the ambiguous cases (no code host resolves the URL, or a transient forge
error) so the guard fires only on a positive closed/not-found signal — existing
adoption against trackers with no configured backend is preserved.

The `workspace ticket` command was at the per-module LOC cap, so adding the flag
required a split: the adopt preconditions and the provision/summary tail move
into the intake module (its named purpose), leaving the command a thin
orchestrator.

## Testing

TDD, red-before/green-after for both fixes:

- `ignore`/`unignore` are CLI-allowed and enqueue no transition task;
  `transition <id> ignore` drives `STARTED → IGNORED` (stamping `ignored_from`),
  and `unignore` restores `STARTED`.
- adopting a CLOSED target is refused; a nonexistent (404 / error-dict) target
  is refused; `--adopt-closed` overrides; an OPEN target succeeds; a transient
  forge error fails open and proceeds.
- 100% coverage on the changed intake module; full local gate (`prek`, `ruff`,
  `tach`, `ty`, module-health, patch-target resolver) green.

## Architecture pre-check

**1. BLUEPRINT § alignment** — §4 (Ticket FSM) and §17.1 invariant 8 (FSM
transitions via `t3` CLI): fix 1 makes the CLI mirror the FSM-table surface for
an existing transition. No BLUEPRINT change — no new model, command, or config.

**2. FSM phase boundaries** — `ignore` is the existing `<any-live-state> →
IGNORED` transition (unchanged); `unignore` restores `ignored_from`. No new
transition is introduced; only the CLI allow-list gains the two names.

**3. Extension-point contracts** — consumes the existing
`CodeHostBackend.get_issue` + `OverlayBase.is_issue_done` contracts for the
adopt validation; no contract changed.

**4. Component boundaries** — CLI refusal/orchestration stays in the command
module; state resolution and the extracted provision tail live in the intake
concern module. No straddle.

**5. Dependency direction** — new imports are `teatree.core.management.commands`
→ `teatree.backends` / `teatree.core.*` / `teatree.utils`, all already-declared
edges. `tach check` green.

**6. Test surface** — each behaviour has a named test asserting the CLI result
state / the refusal / the survival of an attested ticket.

**7. Resilience invariants** — the adopt guard fails open on transient forge
errors (never blocks on an unverifiable signal) and is idempotent (a read-only
check before row creation).

**8. Identity/key normalization** — n/a.

**9. Behavior preservation** — the provision/summary tail and the detached-HEAD
refusal are moved verbatim (behaviour-preserving extraction), covered by the
existing and one added test; no matcher narrowed, no must-block test inverted.


## Cold-review follow-up

**MED (fixed).** The `--adopt` target guard's error-dict branch fail-CLOSED on an
unparsable URL: a GitHub `/pull/<n>` URL is rejected by `get_issue`'s issue-only
ref parser (`{"error": "Not a GitHub issue URL"}`), so a valid OPEN PR adopted
via `/pull/<n>` was wrongly refused (and `--adopt-closed` couldn't rescue it). An
error dict from a resolvable host is ambiguity, not a positive bad signal, so it
now fails OPEN — consistent with the transient-error and no-host cases. The
positive signals still refuse: a genuine 404 (`IssueNotFoundError`) and a
resolvable-but-CLOSED target (still overridable via `--adopt-closed`). Pinned by
`test_adopt_proceeds_on_unparsable_pull_url` (regression cure),
`test_adopt_refuses_nonexistent_target` (404), and `test_adopt_refuses_closed_target`.

**LOW (left as-is, non-blocking).** `unignore` restores the prior state by setting
`self.state` directly rather than via an FSM `@transition`, so it does not fire
the `post_transition` signal and writes no `TicketTransition` audit row (whereas
`ignore` does). The abandon/restore round-trip is still correct and reversible;
the missing audit row is a minor observability gap, not a correctness issue.
