### PR TITLE
fix(hooks): catch ValueError in managed-repo base loop (main-clone guard fail-open)

### DIFF
--- a/hooks/scripts/managed_repo.py
+++ b/hooks/scripts/managed_repo.py
@@ -211,7 +211,13 @@ def repo_root_is_teatree_managed(repo_root: str) -> bool:
     except (OSError, RuntimeError):
         return False
     for base in paths:
-        with contextlib.suppress(OSError, RuntimeError):
+        # ``Path.relative_to`` raises ``ValueError`` (NOT OSError/RuntimeError)
+        # when ``root_resolved`` is not under ``base`` — the normal "this repo is
+        # not under that managed base" case when several overlays register bases.
+        # It must be suppressed so a non-matching base is skipped and the next
+        # base is tried, instead of crashing the whole managed-repo classifier
+        # (which fails the caller open, silently disabling the main-clone guard).
+        with contextlib.suppress(OSError, RuntimeError, ValueError):
             root_resolved.relative_to(base)
             return True
     try:

--- a/tests/teatree_hooks/test_managed_repo_relative_to.py
+++ b/tests/teatree_hooks/test_managed_repo_relative_to.py
@@ -1,0 +1,68 @@
+"""``repo_root_is_teatree_managed`` skips a non-subpath base instead of crashing.
+
+Regression for the ``Path.relative_to`` ``ValueError`` bug: the loop that tests
+each managed overlay base suppressed only ``OSError`` / ``RuntimeError``, but
+``relative_to`` raises ``ValueError`` when the repo is NOT under a base — the
+normal case as soon as more than one overlay registers a base (a teatree clone
+plus a second overlay's ``path``). When a non-matching base was iterated
+FIRST, the unsuppressed ``ValueError`` crashed the classifier; the crash bubbled
+out of ``handle_block_main_clone_mutation`` and the router caught it and failed
+the main-clone guard OPEN — silently disabling it on every teatree-clone git /
+edit call.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from hooks.scripts import managed_repo
+
+
+class TestRepoRootIsTeatreeManagedNonSubpathBase:
+    """The managed-base loop must survive a base the repo is not under."""
+
+    def test_non_subpath_base_first_finds_later_match_without_crashing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-subpath base iterated first is skipped; a later matching base wins.
+
+        Pre-fix this raised ``ValueError`` on the first ``relative_to`` and never
+        reached the matching base — the exact two-overlay crash.
+        """
+        non_subpath_base = tmp_path / "other-overlay"
+        managed_base = tmp_path / "teatree"
+        repo_root = managed_base / "repo"
+        repo_root.mkdir(parents=True)
+        non_subpath_base.mkdir()
+
+        # Ordering is the whole point: the base the repo is NOT under comes first.
+        monkeypatch.setattr(
+            managed_repo,
+            "overlay_managed_repo_signals",
+            lambda: (["souliane/teatree"], [non_subpath_base.resolve(), managed_base.resolve()]),
+        )
+
+        assert managed_repo.repo_root_is_teatree_managed(str(repo_root)) is True
+
+    def test_no_matching_base_returns_false_without_crashing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A repo under NONE of the bases falls through to False, never raises.
+
+        Every base raises ``ValueError`` for this repo; the loop must exhaust
+        cleanly (fail OPEN → unmanaged → ``False``) rather than crash.
+        """
+        base_one = tmp_path / "overlay-a"
+        base_two = tmp_path / "overlay-b"
+        unmanaged_repo = tmp_path / "elsewhere" / "repo"
+        base_one.mkdir()
+        base_two.mkdir()
+        unmanaged_repo.mkdir(parents=True)
+
+        monkeypatch.setattr(
+            managed_repo,
+            "overlay_managed_repo_signals",
+            lambda: (["souliane/teatree"], [base_one.resolve(), base_two.resolve()]),
+        )
+
+        assert managed_repo.repo_root_is_teatree_managed(str(unmanaged_repo)) is False


### PR DESCRIPTION
## What

`repo_root_is_teatree_managed` (`hooks/scripts/managed_repo.py`) iterates each
registered overlay's managed base and calls `root_resolved.relative_to(base)`.
`Path.relative_to` raises **`ValueError`** (not `OSError`/`RuntimeError`) when the
repo is not under a base, but the loop suppressed only `OSError`/`RuntimeError`.
As soon as more than one overlay registers a base (a teatree clone plus a second
overlay `path`), a non-matching base iterated first raised an unsuppressed
`ValueError` that crashed the classifier.

## Impact

The crash bubbled out of `handle_block_main_clone_mutation`; the router caught it
per-handler and failed the main-clone guard **OPEN** — silently disabling
main-clone-mutation protection on every teatree-clone git / edit call.

## Fix

Add `ValueError` to the `contextlib.suppress(...)` so a non-matching base is
skipped and the next base is tried. Fail-before / pass-after regression test
(`tests/teatree_hooks/test_managed_repo_relative_to.py`) covers a non-subpath
base iterated first (finds the later match) and a repo under no base (returns
`False`, never raises).

## Also investigated — no code change warranted

Traced the repeated-denial circuit breaker (`hooks/scripts/deny_circuit_breaker.py`)
for a reported "legitimate commands get permanently denied" symptom:

- State lives at `<state_dir>/<session_id>.deny-streak` (JSON `{fp, count}`),
  keyed on the harness `session_id` plus a volatility-normalised fingerprint of
  the deny reason — not on the command or any parent session id.
- The reset is **not** broken: verified empirically that an intervening allowed
  PreToolUse call deletes the streak file and the next deny restarts at count=1.
- For a safety gate (banned-terms), the breaker at threshold only appends an
  escalation to an *already-denied* reason — it never flips an allowed command
  into a deny, so it cannot permanently hard-deny legitimate commands.

That path is correct; no breaker/reset change is included here.
