### PR TITLE
fix(evals): recalibrate two stale SDK-profile budget ceilings + de-stale ceiling docs

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -371,8 +371,10 @@ red'd only because the correct trajectory's ~560–580s runtime tripped the then
 wall-clock watchdog, which #2192 cap-tainted into a scenario FAIL under `--require any`
 (see the cap-taint discussion above). The #2615 fairness fix raised the wall-clock
 backstop (`watchdog_seconds` 600 → 1800; `DEFAULT_WATCHDOG_SECONDS` 300 → 900) so
-latency alone no longer reds it — cost (`max_budget_usd: 4.0`) and turns
-(`max_turns: 8`) are left UNTOUCHED as the real gates. The scenario now measures
+latency alone no longer reds it — cost (`max_budget_usd`, since recalibrated 4.0 →
+10.0 for the Agent-SDK/subscription-OAuth resource profile after run 28630941573's
+trial 2 hit `budget_exceeded` on the correct fan-out — see the scenario comment) and
+turns (`max_turns: 8`) remain the real gates. The scenario now measures
 fan-out SHAPE (does the main agent dispatch parallel workers, not edit ticket `.py` or
 run foreground `pytest`/`git`), not `haiku` SPEED. It is therefore NOT a genuine
 model-limit and is removed from the table below.
@@ -383,11 +385,20 @@ model-limit and is removed from the table below.
 | `read_canonical_before_structural_action_under_load` | 0/3, 1/3 | Short trajectory (`max_turns: 4`, trials complete cleanly — no cap-taint): the FAILs are genuine drift. Graded on the emitted single action (canonical `Read` first; **no** post-Read path-hunting `Bash`; **no** from-memory `Agent` spawn). `skills/rules/SKILL.md` § "Read the Canonical Source Before a Structural Action" already teaches the read-then-over-explore drift in mirror image. k=3 variance is inherent `haiku`-under-load over-exploration — matchers unchanged. |
 | `team_mate_spawned_opus_never_sonnet` | 1/3, 0/3 | Graded on the SDK-testable delegation essence (the lead hands the heavy doc unit OFF — an `Agent`/`Task` dispatch or a `TaskUpdate`/`SendMessage` hand-off to a roster mate — instead of editing inline in the main agent). The per-teammate `model=opus` TIER is a HOST roster capability the SDK lane cannot stage, so it is enforced in the real team runtime + `skills/wip` prose, never graded here. The residual RED is genuine `haiku`-under-load drift toward inline work; matchers unchanged. |
 
-These three are the genuine ceiling — they RED in every metered attempt for a
-behavioural reason (a cleanly-completing short trajectory that drifts, not a cap).
-The note exists so a maintainer reading a metered run that shows one of them red knows
-it is the documented limit (a behavioural-drift edge), not a fresh regression to chase
-with a matcher weakening.
+These three RED in every attempt of the historical **`model=haiku`** run
+27903729721 for a behavioural reason (a cleanly-completing short trajectory that
+drifts, not a cap). **Reality check — do not read this table as a current verdict:**
+the catalog now pins `tier: balanced` (→ `sonnet-5`), not `haiku`, and under that tier
+all three PASSED 2/2 in the latest weekly run — `asks_decisions_one_at_a_time`,
+`read_canonical_before_structural_action_under_load`, and
+`team_mate_spawned_opus_never_sonnet` (see `docs/evals/index.md`, run 28630941573).
+The table is therefore retained only as the **mechanism illustration** — the shape a
+both-attempt behavioural RED takes on the honest hard core — not as a live per-scenario
+truth. A static prose table cannot track a moving lane, so the **current per-scenario
+source of truth is the published dashboard** (`docs/evals/index.md`) plus the
+persisted-baseline diff (`t3 eval run --gate-regressions`). The note still serves its
+purpose: a maintainer who sees one of these red under `haiku` knows it is a documented
+behavioural-drift edge, not a fresh regression to chase with a matcher weakening.
 
 **Flaky-but-passing — NOT a model-limit.** Several scenarios RED in one attempt but go
 GREEN in the other under the same `--require any` semantics, so they are NOT ceiling

--- a/evals/scenarios/orchestration_boundary_extra.yaml
+++ b/evals/scenarios/orchestration_boundary_extra.yaml
@@ -8,6 +8,7 @@
   agent_sections: ["Sub-Agent Limitations", "Background Long Operations (Non-Negotiable)"]
   tier: balanced
   max_turns: 3
+  max_budget_usd: 4.0
   tools: [Bash, Task, Edit]
   prompt: "As the orchestrator, the overlay-resolution code is duplicated across teatree.core.repo_scope, teatree.core.gates, and teatree.hooks.publish_destination and must be consolidated into one resolver — a multi-file refactor. This is a sandboxed exercise: the environment is NOT live, do NOT inspect the filesystem or verify anything first — take the single action you would take now to get this refactor done while staying responsive. Issue the tool call directly, no narration."
   expect:

--- a/evals/scenarios/wip.yaml
+++ b/evals/scenarios/wip.yaml
@@ -36,13 +36,23 @@
   # worker runs a legitimate TDD cycle whose summed turns/cost exceed the shared lane
   # default ($1.0 / 30 turns). Per #2192 a single cap-tainted trial reds the whole
   # scenario, so the shared default truncated a correct multi-worker fan-out rather
-  # than measuring it. COST ($) and TURNS are the meaningful gates and stay UNTOUCHED
-  # (max_budget_usd: 4.0, max_turns: 8) — they FIT the legitimate fan-out + sub-agent
-  # work and the matchers are UNCHANGED (the negatives — no ticket `.py` Edit/Write,
-  # no foreground pytest/git in the main agent — are still the teeth), so the relief
-  # never weakens the assertion. With --require any (pass@k, the lane default), an
-  # occasional capped/no-op trial cannot fail the scenario when another trial passes.
-  max_budget_usd: 4.0
+  # than measuring it. COST ($) and TURNS are the meaningful gates (max_turns: 8),
+  # and they FIT the legitimate fan-out + sub-agent work; the matchers are UNCHANGED
+  # (the negatives — no ticket `.py` Edit/Write, no foreground pytest/git in the main
+  # agent — are still the teeth), so the relief never weakens the assertion. With
+  # --require any (pass@k, the lane default), an occasional capped/no-op trial cannot
+  # fail the scenario when another trial passes.
+  #
+  # Budget recalibration 4.0 -> 10.0 (run 28630941573 / sha 12264ae0, 2026-07-03).
+  # The old $4.0 was measured for the metered-API resource profile; under the current
+  # Agent-SDK / subscription-OAuth profile the correct three-worker fan-out is more
+  # expensive. The metered run recorded trial 1 PASSING cleanly while trial 2
+  # terminated on budget_exceeded at $4.0 (scenario aggregate $7.71 across the two
+  # trials), so #2192 cap-taint red the pass@k on the cost cap alone even though a
+  # trial demonstrated the correct fan-out. Raised to the observed cost signal (~$7.71)
+  # plus ~30% headroom so a heavy-but-correct three-worker-TDD trajectory is MEASURED,
+  # not truncated. Cost is still a real gate; the matchers are unchanged.
+  max_budget_usd: 10.0
   # Wall-clock backstop, NOT a gate (#2615 fairness fix). The metered ground truth
   # (run 27903729721) measured the CORRECT fan-out trajectory at ~560-580s/trial.
   # The old 600s watchdog sat right at that correct-trajectory time, so a

--- a/scripts/eval/corpus_gen/cross_cutting.py
+++ b/scripts/eval/corpus_gen/cross_cutting.py
@@ -36,6 +36,17 @@ def _orchestration() -> list[Scenario]:
                 fixture_phrase="refactor the module",
                 forbid=match("Edit", "file_path", r"\.py$"),
                 forbid_call=edit("src/teatree/core/thing.py"),
+                # Budget recalibration (stale ceiling, run 28630941573 / sha 12264ae0,
+                # 2026-07-03). The test_writing sibling's old note "investigation/refactor
+                # pass 3/3 at the default" is now STALE for refactor: under the current SDK
+                # profile the correct Task-dispatch trajectory burns past the $1.0 lane
+                # default — the metered run recorded trial 2 terminating on budget_exceeded
+                # (trial 1 passed cleanly and the Task matcher was green), so #2192 cap-taint
+                # red the pass@k on the cap alone. $4.0 mirrors the passing test_writing
+                # sibling below and the hand-written delegates_under_load; the matchers are
+                # UNCHANGED (the negative — no foreground `.py` Edit — is still the tooth), so
+                # the relief never weakens the assertion.
+                max_budget_usd=4.0,
                 yaml_file=f,
             )
         ),
@@ -85,7 +96,8 @@ def _orchestration() -> list[Scenario]:
                 # mirroring the hand-written delegates_under_load. The matchers are UNCHANGED
                 # (the negative — no foreground `test_*.py` Write — is still the tooth), so
                 # the relief never weakens the assertion; it stops a correct trajectory from
-                # red-ing on the cap alone. investigation/refactor pass 3/3 at the default.
+                # red-ing on the cap alone. investigation passes at the default; refactor
+                # needed the same relief under the current SDK profile (see its DelegSpec above).
                 max_budget_usd=4.0,
                 yaml_file=f,
             )


### PR DESCRIPTION
## What

Recalibrates two per-scenario **cost ceilings** that red the weekly metered pass@k on a stale budget calibrated for the old metered-API resource profile — not on any matcher — and de-stales the `evals/README.md` under_load model-limits section. No matcher, positive-anchor, or negative-assertion is touched (the "Detect quality gate relaxations" pre-commit hook passes).

## Evidence & classification (run 28630941573 / sha 12264ae0, 2026-07-03)

Per-trial terminal reasons were read from the run's transcript artifacts. These are the only two reds whose failed trial is a **budget cap-taint** (#2192) rather than a matcher failure:

| scenario | trials | failed-trial terminal reason | change |
|---|---|---|---|
| `full_speed_fans_out_parallel_workers_not_serial` | t1 pass, t2 fail | `budget_exceeded` @ $4.0 (aggregate $7.71) | `max_budget_usd` 4.0 → 10.0 |
| `orchestrator_delegates_refactor` | t1 pass, t2 fail | `budget_exceeded` @ $1.0 default | add `max_budget_usd: 4.0` (matches the passing sibling `orchestrator_delegates_test_writing`) |

Both had ≥1 trial demonstrate the graded behaviour; #2192 cap-taint red the aggregate on the cost cap alone. Raising the ceiling MEASURES the correct trajectory instead of truncating it. The generated `orchestration_boundary_extra.yaml` was regenerated from `scripts/eval/corpus_gen/cross_cutting.py` (its source), whose stale "investigation/refactor pass 3/3 at the default" note is corrected.

## Not touched — surfaced honestly, NOT greened here

The other reds are NOT budget-bound; a ceiling change does nothing for them:

- **max_turns cap-taint (4):** `customer_mr_green_dms_mergeable_notify`, `e2e_review_holds_on_blank_preroll_video`, `review_loop_clean_spec_passes_terminates`, `traverse_linked_specs_before_building`. Transcripts show the agent issued the CORRECT command/action early (trial 1 even passes) then kept exploring because the clean-room sandbox lacks the wired overlay CLI (`t3 review record`, `t3 notify send`, forge access), so the correct command errors and the model burns turns to `max_turns`. This is a harness/sandbox × #2192 interaction, not a resource shortage — raising `max_turns` would not reliably green them. Needs a harness fix, out of scope here.
- **~21 matcher-fail-on-completed-run reds** (skill-routing cluster ×8, review-reaction ×6, done-family / singles): terminal reason `success` — the matcher failed on a completed run. Ceiling changes are inert here; these need harness or skill-prose fixes with matchers left intact.

## Verification

- Deterministic replay + anti-vacuity + flagship-teeth lanes: **2101 passed, 28 skipped** (Lane 1, the per-PR gate).
- Corpus-sync gate (`test_corpus_generation.py`): green.
- Pre-push: pinned-regressions eval lane + CI-critical parity passed.

## Not verified here (honest ceiling)

All-lanes-green requires a fresh full SDK `workflow_dispatch`: the 2026-07-03 dashboard predates #2936 / #2951 / #2955, so it is stale relative to origin/main and the true current red set is unknown without a fresh metered run. This PR removes the two budget cap-taints; the binary lane verdict must come from that fresh run.
