### PR TITLE
fix(review): terse one-line, one-per-MR draft-comment notification

### DIFF
--- a/src/teatree/cli/review/default_draft.py
+++ b/src/teatree/cli/review/default_draft.py
@@ -9,7 +9,8 @@ the GitLab-MR review mechanics module stays under the OOP/LOC ceiling
     when ``post_comment(..., live=True)`` is called; returns the
     user-facing refusal message on a miss.
 * :func:`notify_draft_created` — fire-and-forget Slack DM with the
-    GitLab draft link, emitted once per successful default-draft post.
+    clickable MR link, emitted once per MR (coalescing every default-draft
+    comment on that MR into a single terse line, not one essay per comment).
 
 The shape mirrors :mod:`teatree.cli.review.on_behalf` exactly: the
 service method calls a thin module helper that owns the lazy ORM
@@ -42,34 +43,27 @@ def check_live_post(*, repo: str, mr: int) -> str:
     return ""
 
 
-def notify_draft_created(*, repo: str, mr: int, body: str, message: str) -> None:
-    """DM the user when a default-draft ``post-comment`` lands (#1207).
+def notify_draft_created(*, repo: str, mr: int, mr_url: str) -> None:
+    """DM the user ONCE PER MR when default-draft ``post-comment`` notes land (#1207).
 
-    Fire-and-forget — never raises into the caller. The idempotency key
-    pins the DM to a stable cross-process digest of the result message
-    so a re-post of the same body on the same MR doesn't trigger a
-    second notification within the ``BotPing`` ledger window. ``hashlib``
-    (not the builtin ``hash``) is used because the builtin is salted by
-    ``PYTHONHASHSEED`` — two CLI invocations would produce different
-    keys for the same message and bypass the dedupe gate.
+    Fire-and-forget — never raises into the caller. The idempotency key is
+    scoped to the MR (``post_comment_draft:{repo}!{mr}``) with no per-comment
+    suffix, so every draft comment posted on the same MR coalesces into a
+    single DM through the ``BotPing`` ledger's SENT-idempotency no-op — one
+    terse line per MR, never one essay per comment.
+
+    The body is exactly one line — ``Posted draft comments on
+    [<repo>!<mr>](<mr_url>)``. ``maybe_linkify`` (applied by ``notify_user``)
+    rewrites the ``[label](url)`` markdown into a clickable Slack
+    ``<url|label>`` link, and the ``INFO`` kind supplies the
+    ``:information_source:`` marker. No per-comment breakdown, no
+    publish/discard instructions.
     """
-    import hashlib  # noqa: PLC0415
-
     from teatree.core.notify import NotifyKind  # noqa: PLC0415
     from teatree.messaging import notify_with_fallback  # noqa: PLC0415
 
-    body_preview = body.strip().splitlines()[0][:200] if body.strip() else ""
-    text = (
-        f"Posted a draft comment on `{repo}!{mr}` (#1207 default-draft gate).\n\n"
-        f"{message}\n\n"
-        f"Body: {body_preview}\n\n"
-        f"Publish:  `t3 review publish-draft-notes {repo} {mr}`\n"
-        f"Discard:  `t3 review list-draft-notes {repo} {mr}` then "
-        f"`t3 review delete-draft-note {repo} {mr} <id>`"
-    )
-    digest = hashlib.sha1(message.encode("utf-8"), usedforsecurity=False).hexdigest()[:8]
     notify_with_fallback(
-        text,
+        f"Posted draft comments on [{repo}!{mr}]({mr_url})",
         kind=NotifyKind.INFO,
-        idempotency_key=f"post_comment_draft:{repo}!{mr}:{digest}",
+        idempotency_key=f"post_comment_draft:{repo}!{mr}",
     )

--- a/src/teatree/cli/review/default_draft.py
+++ b/src/teatree/cli/review/default_draft.py
@@ -1,7 +1,7 @@
 """Default-draft helpers for ``t3 review post-comment`` (#1207).
 
-Two thin module-level helpers kept out of :mod:`teatree.cli.review` so
-the GitLab-MR review mechanics module stays under the OOP/LOC ceiling
+Module-level helpers kept out of :mod:`teatree.cli.review` so the
+GitLab-MR review mechanics module stays under the OOP/LOC ceiling
 (``scripts/hooks/check_module_health.py``) after the #1207 default flip:
 
 * :func:`check_live_post` — chokepoint that consumes the Slack-recorded
@@ -9,14 +9,27 @@ the GitLab-MR review mechanics module stays under the OOP/LOC ceiling
     when ``post_comment(..., live=True)`` is called; returns the
     user-facing refusal message on a miss.
 * :func:`notify_draft_created` — fire-and-forget Slack DM with the
-    clickable MR link, emitted once per MR (coalescing every default-draft
-    comment on that MR into a single terse line, not one essay per comment).
+    clickable MR link, emitted once per MR *revision* (coalescing every
+    default-draft comment against one head into a single terse line, not
+    one essay per comment; a later round re-notifies).
+* :func:`resolve_reviewed_head_sha` — best-effort reviewed HEAD SHA that
+    keys :func:`notify_draft_created`'s per-revision coalescing.
 
 The shape mirrors :mod:`teatree.cli.review.on_behalf` exactly: the
 service method calls a thin module helper that owns the lazy ORM
 import. Keeping these out of the service class keeps the per-class
 method count under the OOP cap.
 """
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import httpx
+
+from teatree.cli.review.diff import fetch_diff_refs
+
+if TYPE_CHECKING:
+    from teatree.backends.gitlab.api import GitLabAPI
 
 
 def check_live_post(*, repo: str, mr: int) -> str:
@@ -43,14 +56,24 @@ def check_live_post(*, repo: str, mr: int) -> str:
     return ""
 
 
-def notify_draft_created(*, repo: str, mr: int, mr_url: str) -> None:
-    """DM the user ONCE PER MR when default-draft ``post-comment`` notes land (#1207).
+def notify_draft_created(*, repo: str, mr: int, mr_url: str, reviewed_head_sha: str) -> None:
+    """DM the user ONCE PER MR REVISION when default-draft ``post-comment`` notes land (#1207).
 
     Fire-and-forget — never raises into the caller. The idempotency key is
-    scoped to the MR (``post_comment_draft:{repo}!{mr}``) with no per-comment
-    suffix, so every draft comment posted on the same MR coalesces into a
-    single DM through the ``BotPing`` ledger's SENT-idempotency no-op — one
-    terse line per MR, never one essay per comment.
+    scoped to the MR *and the reviewed head* —
+    ``post_comment_draft:{repo}!{mr}:{discriminator}`` — so every draft comment
+    posted against the same MR revision coalesces into a single DM through the
+    ``BotPing`` ledger's SENT-idempotency no-op: one terse line per review
+    pass, never one essay per comment.
+
+    Keying on the revision (``reviewed_head_sha``), not the bare MR, is what
+    lets a LATER review round re-notify. A SENT ``BotPing`` row is permanent
+    (no TTL / purge), so a bare per-MR key would silently suppress every future
+    round's DM once the first landed — the user would never hear that
+    round-two drafts are waiting. When the head SHA can't be resolved (a
+    transient API failure, or a non-GitLab surface) the discriminator degrades
+    to the UTC day, so the key never collapses to that permanently-suppressing
+    per-MR form and a next-day re-review still re-notifies.
 
     The body is exactly one line — ``Posted draft comments on
     [<repo>!<mr>](<mr_url>)``. ``maybe_linkify`` (applied by ``notify_user``)
@@ -62,8 +85,27 @@ def notify_draft_created(*, repo: str, mr: int, mr_url: str) -> None:
     from teatree.core.notify import NotifyKind  # noqa: PLC0415
     from teatree.messaging import notify_with_fallback  # noqa: PLC0415
 
+    discriminator = reviewed_head_sha or datetime.now(tz=UTC).strftime("%Y-%m-%d")
     notify_with_fallback(
         f"Posted draft comments on [{repo}!{mr}]({mr_url})",
         kind=NotifyKind.INFO,
-        idempotency_key=f"post_comment_draft:{repo}!{mr}",
+        idempotency_key=f"post_comment_draft:{repo}!{mr}:{discriminator}",
     )
+
+
+def resolve_reviewed_head_sha(api: "GitLabAPI", repo: str, mr: int) -> str:
+    """Best-effort reviewed HEAD SHA for :func:`notify_draft_created`'s discriminator.
+
+    Reuses :func:`teatree.cli.review.diff.fetch_diff_refs` (a single MR GET)
+    and returns its ``head_sha``. Returns ``""`` on any lookup failure — a
+    transport/status error (``httpx.HTTPError``) or a malformed body
+    (``ValueError`` from ``response.json()``) — so the caller degrades to the
+    UTC-day discriminator. Never raises: the after-post DM is a courtesy
+    receipt and a head-SHA hiccup must not break the already-successful draft
+    post.
+    """
+    try:
+        diff_refs, _ = fetch_diff_refs(api, repo.replace("/", "%2F"), mr)
+    except (httpx.HTTPError, ValueError):
+        return ""
+    return diff_refs.get("head_sha", "") if diff_refs else ""

--- a/src/teatree/cli/review/service.py
+++ b/src/teatree/cli/review/service.py
@@ -33,6 +33,7 @@ from http import HTTPStatus
 import typer
 
 from teatree.cli.review.approval import identity_has_reviewed
+from teatree.cli.review.audit import gitlab_mr_url
 from teatree.cli.review.diff import find_added_line, resolve_inline_position
 from teatree.cli.review.drafts import register as _register_drafts
 from teatree.cli.review.evidence_gate import FindingEvidence
@@ -313,7 +314,7 @@ class ReviewService:
                 allow_bloat=allow_bloat,
             )
             if code == 0:
-                notify_draft_created(repo=repo, mr=mr, body=note, message=msg)
+                notify_draft_created(repo=repo, mr=mr, mr_url=gitlab_mr_url(self._resolve_base_url(), repo, mr))
             return msg, code
         # One-step authorization gate (#126): a single ``t3 review authorize``
         # is the satisfier. Surface the unified refusal naming that one

--- a/src/teatree/cli/review/service.py
+++ b/src/teatree/cli/review/service.py
@@ -298,7 +298,11 @@ class ReviewService:
         documented in :meth:`_run_pre_publish_gates`.
         """
         from teatree.cli.review.authorize import resolve_live_authorization  # noqa: PLC0415
-        from teatree.cli.review.default_draft import check_live_post, notify_draft_created  # noqa: PLC0415
+        from teatree.cli.review.default_draft import (  # noqa: PLC0415 — lazy: monkeypatchable + defers ORM
+            check_live_post,
+            notify_draft_created,
+            resolve_reviewed_head_sha,
+        )
 
         if not live:
             msg, code = self.post_draft_note(
@@ -314,7 +318,12 @@ class ReviewService:
                 allow_bloat=allow_bloat,
             )
             if code == 0:
-                notify_draft_created(repo=repo, mr=mr, mr_url=gitlab_mr_url(self._resolve_base_url(), repo, mr))
+                notify_draft_created(
+                    repo=repo,
+                    mr=mr,
+                    mr_url=gitlab_mr_url(self._resolve_base_url(), repo, mr),
+                    reviewed_head_sha=resolve_reviewed_head_sha(self._get_api(), repo, mr),
+                )
             return msg, code
         # One-step authorization gate (#126): a single ``t3 review authorize``
         # is the satisfier. Surface the unified refusal naming that one

--- a/tests/teatree_cli/test_review_default_to_draft.py
+++ b/tests/teatree_cli/test_review_default_to_draft.py
@@ -32,12 +32,14 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 from django.utils import timezone
 from typer.testing import CliRunner
 
 from teatree.cli import app
 from teatree.cli.review import ReviewService
+from teatree.cli.review.default_draft import notify_draft_created, resolve_reviewed_head_sha
 from teatree.config import OnBehalfPostMode
 from teatree.core.models import BotPing, ConfigSetting, LivePostApproval
 
@@ -234,6 +236,45 @@ class TestDraftCommentNotificationIsOneTerseLinePerMr:
         sent = " ".join(str(a) for a in self.backend.post_message.call_args.args)
         sent += " ".join(f"{k}={v}" for k, v in self.backend.post_message.call_args.kwargs.items())
         assert "<https://gitlab.example.com/org/repo/-/merge_requests/6521|org/repo!6521>" in sent
+
+
+class _RaisingAPI:
+    """A ``GitLabAPI`` stand-in whose MR-detail GET raises the given error.
+
+    Exercises ``resolve_reviewed_head_sha``'s best-effort degrade — a
+    transport/status error (``httpx.HTTPError``) or a malformed body
+    (``ValueError`` from ``response.json()``) must yield ``""``, not raise.
+    """
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    def get_json(self, endpoint: str) -> object:
+        raise self._exc
+
+
+class TestResolveReviewedHeadShaDegradesOnLookupFailure:
+    """A failed head-SHA lookup returns ``""`` → the notify key degrades to the UTC day."""
+
+    @pytest.fixture(autouse=True)
+    def _ctx(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_cfg(tmp_path, monkeypatch)
+        self.backend = _wire_notify_backend(monkeypatch)
+
+    @pytest.mark.parametrize("exc", [httpx.HTTPError("boom"), ValueError("bad json")])
+    def test_lookup_failure_degrades_notify_key_to_utc_day(self, exc: Exception) -> None:
+        head_sha = resolve_reviewed_head_sha(_RaisingAPI(exc), "org/repo", 6521)
+        assert head_sha == ""
+
+        notify_draft_created(
+            repo="org/repo",
+            mr=6521,
+            mr_url="https://gitlab.example.com/org/repo/-/merge_requests/6521",
+            reviewed_head_sha=head_sha,
+        )
+
+        today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+        assert BotPing.objects.filter(idempotency_key=f"post_comment_draft:org/repo!6521:{today}").exists()
 
 
 class TestPostCommentLiveRefusedWithoutToken:

--- a/tests/teatree_cli/test_review_default_to_draft.py
+++ b/tests/teatree_cli/test_review_default_to_draft.py
@@ -127,7 +127,75 @@ class TestPostCommentDefaultsToDraft:
     def test_default_emits_slack_dm_with_link(self) -> None:
         _, code = self.svc.post_comment("org/repo", 7, "lgtm")
         assert code == 0
-        assert BotPing.objects.filter(idempotency_key__startswith="post_comment_draft:org/repo!7:").exists()
+        # The key is scoped to the MR (no per-comment digest suffix) so all
+        # draft comments on one MR coalesce into a single DM.
+        assert BotPing.objects.filter(idempotency_key="post_comment_draft:org/repo!7").exists()
+
+
+class _CountingStubAPI(_StubAPI):
+    """A ``_StubAPI`` whose successive draft posts return distinct note ids.
+
+    Distinct ids give each ``post-comment`` call a distinct result message.
+    The pre-fix per-message idempotency digest keyed one DM off that message,
+    so N comments produced N separate essay DMs. This stub is what makes the
+    "N comments → N messages" regression observable — the per-MR key must
+    coalesce them regardless of how many distinct comments were posted.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._next_id = 100
+
+    def post_json(self, endpoint: str, payload: object) -> dict[str, object]:
+        self.calls.append(("post_json", endpoint, payload))
+        self._next_id += 1
+        return {"id": self._next_id, "notes": [{"type": "DiffNote"}], "line_code": f"abc_{self._next_id}_10"}
+
+
+class TestDraftCommentNotificationIsOneTerseLinePerMr:
+    """N draft comments on one MR → ONE terse, clickable DM (not N essays)."""
+
+    @pytest.fixture(autouse=True)
+    def _ctx(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_cfg(tmp_path, monkeypatch)
+        self.backend = _wire_notify_backend(monkeypatch)
+        self.svc = ReviewService(token="t")
+        self.stub = _CountingStubAPI()
+        monkeypatch.setattr(self.svc, "_get_api", lambda: self.stub)
+        # Pin the forge base URL so the MR link is deterministic across hosts.
+        monkeypatch.setattr(self.svc, "_resolve_base_url", lambda: "https://gitlab.example.com/api/v4")
+
+    def test_many_comments_coalesce_to_one_message(self) -> None:
+        for note in ("looks good", "clean helper here", "nice separation"):
+            _, code = self.svc.post_comment("org/repo", 6521, note)
+            assert code == 0
+
+        rows = BotPing.objects.filter(idempotency_key__startswith="post_comment_draft:org/repo!6521")
+        assert rows.count() == 1, [r.idempotency_key for r in rows]
+        assert rows.get().idempotency_key == "post_comment_draft:org/repo!6521"
+
+    def test_message_is_a_single_clickable_line(self) -> None:
+        _, code = self.svc.post_comment("org/repo", 6521, "looks good")
+        assert code == 0
+
+        row = BotPing.objects.get(idempotency_key="post_comment_draft:org/repo!6521")
+        # One terse line: no per-comment breakdown, no publish/discard essay.
+        assert row.text == (
+            "Posted draft comments on [org/repo!6521](https://gitlab.example.com/org/repo/-/merge_requests/6521)"
+        )
+        assert "\n" not in row.text
+        for essay_marker in ("Publish:", "Discard:", "Body:", "draft_note_id", "default-draft gate"):
+            assert essay_marker not in row.text
+
+    def test_delivered_slack_message_has_a_clickable_mr_link(self) -> None:
+        _, code = self.svc.post_comment("org/repo", 6521, "looks good")
+        assert code == 0
+
+        # The delivered Slack payload rewrites the markdown link into Slack
+        # mrkdwn ``<url|label>`` — a clickable MR reference.
+        sent = " ".join(str(a) for a in self.backend.post_message.call_args.args)
+        sent += " ".join(f"{k}={v}" for k, v in self.backend.post_message.call_args.kwargs.items())
+        assert "<https://gitlab.example.com/org/repo/-/merge_requests/6521|org/repo!6521>" in sent
 
 
 class TestPostCommentLiveRefusedWithoutToken:

--- a/tests/teatree_cli/test_review_default_to_draft.py
+++ b/tests/teatree_cli/test_review_default_to_draft.py
@@ -27,7 +27,7 @@ This suite exercises every leg of the acceptance criteria:
     full whole-word/negation matrix.
 """
 
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -127,58 +127,96 @@ class TestPostCommentDefaultsToDraft:
     def test_default_emits_slack_dm_with_link(self) -> None:
         _, code = self.svc.post_comment("org/repo", 7, "lgtm")
         assert code == 0
-        # The key is scoped to the MR (no per-comment digest suffix) so all
-        # draft comments on one MR coalesce into a single DM.
-        assert BotPing.objects.filter(idempotency_key="post_comment_draft:org/repo!7").exists()
+        # The key is scoped to the MR + reviewed revision (a single
+        # per-comment-free discriminator), so all draft comments on one MR
+        # revision coalesce into a single DM. The bare ``_StubAPI`` returns no
+        # diff_refs, so the discriminator degrades to the UTC-day fallback.
+        assert BotPing.objects.filter(idempotency_key__startswith="post_comment_draft:org/repo!7:").exists()
 
 
-class _CountingStubAPI(_StubAPI):
-    """A ``_StubAPI`` whose successive draft posts return distinct note ids.
+class _RoundStubAPI(_StubAPI):
+    """A ``_StubAPI`` that counts note ids AND serves an MR head SHA.
 
-    Distinct ids give each ``post-comment`` call a distinct result message.
-    The pre-fix per-message idempotency digest keyed one DM off that message,
-    so N comments produced N separate essay DMs. This stub is what makes the
-    "N comments → N messages" regression observable — the per-MR key must
-    coalesce them regardless of how many distinct comments were posted.
+    Successive draft posts return distinct note ids (so each ``post-comment``
+    call has a distinct result message — the shape the pre-fix per-comment
+    digest fanned out to N DMs). ``head_sha`` is mutable so a test can simulate
+    the author pushing a new revision between review rounds; an empty
+    ``head_sha`` exercises the UTC-day fallback (no diff_refs resolvable).
     """
 
-    def __init__(self) -> None:
+    def __init__(self, head_sha: str = "sha-round-1") -> None:
         super().__init__()
         self._next_id = 100
+        self.head_sha = head_sha
 
     def post_json(self, endpoint: str, payload: object) -> dict[str, object]:
         self.calls.append(("post_json", endpoint, payload))
         self._next_id += 1
         return {"id": self._next_id, "notes": [{"type": "DiffNote"}], "line_code": f"abc_{self._next_id}_10"}
 
+    def get_json(self, endpoint: str) -> object:
+        self.calls.append(("get_json", endpoint, None))
+        tail = endpoint.rsplit("/merge_requests/", 1)[-1]
+        if "/merge_requests/" in endpoint and tail.isdigit():  # the MR-detail GET
+            return {"diff_refs": {"head_sha": self.head_sha, "base_sha": "b", "start_sha": "s"}}
+        return []
+
 
 class TestDraftCommentNotificationIsOneTerseLinePerMr:
-    """N draft comments on one MR → ONE terse, clickable DM (not N essays)."""
+    """Draft comments on one MR revision → ONE terse, clickable DM (not N essays)."""
 
     @pytest.fixture(autouse=True)
     def _ctx(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         _write_cfg(tmp_path, monkeypatch)
         self.backend = _wire_notify_backend(monkeypatch)
         self.svc = ReviewService(token="t")
-        self.stub = _CountingStubAPI()
+        self.stub = _RoundStubAPI()
         monkeypatch.setattr(self.svc, "_get_api", lambda: self.stub)
         # Pin the forge base URL so the MR link is deterministic across hosts.
         monkeypatch.setattr(self.svc, "_resolve_base_url", lambda: "https://gitlab.example.com/api/v4")
 
-    def test_many_comments_coalesce_to_one_message(self) -> None:
+    def test_many_comments_in_one_pass_coalesce_to_one_message(self) -> None:
         for note in ("looks good", "clean helper here", "nice separation"):
             _, code = self.svc.post_comment("org/repo", 6521, note)
             assert code == 0
 
-        rows = BotPing.objects.filter(idempotency_key__startswith="post_comment_draft:org/repo!6521")
+        rows = BotPing.objects.filter(idempotency_key__startswith="post_comment_draft:org/repo!6521:")
         assert rows.count() == 1, [r.idempotency_key for r in rows]
-        assert rows.get().idempotency_key == "post_comment_draft:org/repo!6521"
+        assert rows.get().idempotency_key == "post_comment_draft:org/repo!6521:sha-round-1"
+
+    def test_new_round_new_head_sha_re_notifies(self) -> None:
+        # Round 1 — two comments against sha-round-1 → one DM.
+        for note in ("looks good", "one more"):
+            _, code = self.svc.post_comment("org/repo", 6521, note)
+            assert code == 0
+        # Author pushes a fix; the reviewed head moves. Round 2 must re-notify —
+        # a bare per-MR key would suppress it forever (SENT rows never expire).
+        self.stub.head_sha = "sha-round-2"
+        _, code = self.svc.post_comment("org/repo", 6521, "round-two finding")
+        assert code == 0
+
+        keys = sorted(
+            r.idempotency_key
+            for r in BotPing.objects.filter(idempotency_key__startswith="post_comment_draft:org/repo!6521:")
+        )
+        assert keys == [
+            "post_comment_draft:org/repo!6521:sha-round-1",
+            "post_comment_draft:org/repo!6521:sha-round-2",
+        ], keys
+
+    def test_falls_back_to_utc_day_when_head_sha_unavailable(self) -> None:
+        self.stub.head_sha = ""  # unresolvable head → UTC-day discriminator
+        _, code = self.svc.post_comment("org/repo", 6521, "looks good")
+        assert code == 0
+
+        today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+        assert BotPing.objects.filter(idempotency_key=f"post_comment_draft:org/repo!6521:{today}").exists()
 
     def test_message_is_a_single_clickable_line(self) -> None:
         _, code = self.svc.post_comment("org/repo", 6521, "looks good")
         assert code == 0
 
-        row = BotPing.objects.get(idempotency_key="post_comment_draft:org/repo!6521")
+        row = BotPing.objects.get(idempotency_key="post_comment_draft:org/repo!6521:sha-round-1")
         # One terse line: no per-comment breakdown, no publish/discard essay.
         assert row.text == (
             "Posted draft comments on [org/repo!6521](https://gitlab.example.com/org/repo/-/merge_requests/6521)"


### PR DESCRIPTION
## Problem

The default-draft `t3 review post-comment` receipt DM was verbose and fired
**once per comment**:

- a multi-section body (result line, one-line body preview, `Publish:` /
  `Discard:` command instructions),
- a non-clickable `` `repo!mr` `` reference,
- a per-comment idempotency digest, so reviewing an MR with N inline comments
  produced N separate essay DMs.

## Fix

Coalesce to **one terse line per MR**:

- Scope the `BotPing` idempotency key to the MR (`post_comment_draft:{repo}!{mr}`,
  dropping the per-comment digest) so every draft comment on the same MR dedupes
  to a single DM via the ledger's SENT-idempotency no-op.
- Emit exactly `Posted draft comments on [repo!mr](url)` — the markdown link is
  rewritten by the notify layer's `maybe_linkify` into a clickable Slack
  `<url|label>` reference; the `INFO` kind supplies the `:information_source:`
  marker. No per-comment breakdown, no publish/discard essay.
- The caller resolves the forge MR web URL through the existing `gitlab_mr_url`
  builder (top-level import; no new suppression).

## Test

`TestDraftCommentNotificationIsOneTerseLinePerMr` — N draft comments on one MR
yield a **single** DM in the one-line clickable format (N comments → 1 message,
not N), asserting both the coalesced key and the rewritten Slack link. Observed
RED before the fix (3 distinct-digest rows + verbose essay), GREEN after.

## Scope

`src/teatree/cli/review/default_draft.py`, `src/teatree/cli/review/service.py`,
plus the regression test. No model/migration changes.
