### PR TITLE
refactor(eval): qualify clean-room skill-filter keys to the plugin-scoped canonical form

### DIFF
--- a/src/teatree/eval/api_runner.py
+++ b/src/teatree/eval/api_runner.py
@@ -217,6 +217,20 @@ EMPTY_SETTINGS = '{"hooks":{}}'
 #: hook these scenarios' prompts say "did not fire" to force a genuine self-load.
 _SKILL_CATALOG_FIXTURE_RELATIVE_PATH = ("evals", "fixtures", "skill_catalog")
 
+#: The fixture plugin's registered name — MUST equal the ``name`` in
+#: ``evals/fixtures/skill_catalog/.claude-plugin/plugin.json``
+#: (pinned by ``test_plugin_name_constant_matches_the_fixture_plugin_json``).
+#: The bundled ``claude`` CLI lists a plugin's skills under the plugin-qualified
+#: ``<plugin>:<skill>`` key (verified against the binary: the ``system/init``
+#: event exposes ``eval-skill-catalog:t3-widget``). The SDK ``skills`` filter
+#: accepts either that qualified key OR the bare SKILL.md ``name`` (types.py:
+#: "Names match the SKILL.md name / directory name, or plugin:skill"), so the
+#: qualified form is the unambiguous canonical key (§8 identity-normalization) —
+#: it matches the CLI's own listing exactly and stays correct if a future CLI
+#: build ever tightens the filter to the qualified form only.
+#: :func:`_qualify_catalog_skill` canonicalizes each declared name UP to it.
+_SKILL_CATALOG_PLUGIN_NAME = "eval-skill-catalog"
+
 #: Typed alias callers may ``raise``/``except`` against. The SDK raises a bare
 #: ``Exception`` for the budget breaker, so the runner ALSO matches the message
 #: substring — this alias only types the direct-raise path, never narrows it.
@@ -311,6 +325,19 @@ class CleanRoomConfig:
     skills: tuple[str, ...] = ()
 
 
+def _qualify_catalog_skill(name: str) -> str:
+    """Canonicalize a fixture-catalog skill name UP to the CLI's ``<plugin>:<skill>`` key.
+
+    The plugin-qualified form is the unambiguous canonical key the CLI lists a
+    plugin's skills under (see :data:`_SKILL_CATALOG_PLUGIN_NAME`). An
+    already-qualified name (any name containing ``":"``) is returned unchanged,
+    so the transform is idempotent.
+    """
+    if ":" in name:
+        return name
+    return f"{_SKILL_CATALOG_PLUGIN_NAME}:{name}"
+
+
 def _skill_catalog_fixture_plugin() -> SdkPluginConfig:
     """The local-plugin config for the eval-only skill-catalog fixture.
 
@@ -355,9 +382,12 @@ def build_sdk_options(config: CleanRoomConfig) -> ClaudeAgentOptions:
     ``skills``/``plugins`` widen the simulated Skill-tool catalog for a scenario
     that declares ``config.skills`` (threaded from ``EvalSpec.available_skills``):
     the eval-only fixture plugin is registered and the listing filtered to
-    exactly the declared names. Empty ``config.skills`` (the default) renders
-    ``skills=None`` and ``plugins=[]`` — the SDK's own untouched defaults, so a
-    scenario declaring none is byte-identical to before this lever existed.
+    exactly the declared names, each canonicalized UP to the plugin-qualified
+    ``<plugin>:<skill>`` key the CLI actually lists them under
+    (:func:`_qualify_catalog_skill` — a bare-name filter matches nothing). Empty
+    ``config.skills`` (the default) renders ``skills=None`` and ``plugins=[]`` —
+    the SDK's own untouched defaults, so a scenario declaring none is
+    byte-identical to before this lever existed.
     """
     available = list(config.available_tools) if config.available_tools else None
     return ClaudeAgentOptions(
@@ -378,7 +408,7 @@ def build_sdk_options(config: CleanRoomConfig) -> ClaudeAgentOptions:
         model=config.model,
         fallback_model=FALLBACK_MODEL,
         effort=config.effort,
-        skills=list(config.skills) if config.skills else None,
+        skills=[_qualify_catalog_skill(name) for name in config.skills] if config.skills else None,
         plugins=[_skill_catalog_fixture_plugin()] if config.skills else [],
     )
 

--- a/tests/eval_replay/test_skill_catalog_fixture_gap.py
+++ b/tests/eval_replay/test_skill_catalog_fixture_gap.py
@@ -20,7 +20,12 @@ genuinely discover.
 
 from pathlib import Path
 
-from teatree.eval.api_runner import _skill_catalog_fixture_plugin
+from teatree.eval.api_runner import (
+    CleanRoomConfig,
+    _qualify_catalog_skill,
+    _skill_catalog_fixture_plugin,
+    build_sdk_options,
+)
 from teatree.eval.discovery import discover_specs
 
 #: The eight scenarios CI run 28630941573 reported failing, each mapped to the
@@ -109,8 +114,10 @@ class TestClaudeAgentOptionsCarryTheWidenedCatalog:
     """End-to-end: the loaded spec's available_skills reaches the SDK options."""
 
     def test_build_sdk_options_lists_exactly_the_declared_names(self, tmp_path: Path) -> None:
-        from teatree.eval.api_runner import CleanRoomConfig, build_sdk_options  # noqa: PLC0415
-
+        # The CLI lists a plugin's skills under the plugin-qualified
+        # `<plugin>:<skill>` key, so the options filter carries the qualified
+        # form of each declared name (see `_qualify_catalog_skill`) — the
+        # unambiguous canonical key that matches the CLI's own listing.
         by_name = _specs_by_name()
         (spec,) = by_name["overlay_django_coding_loads_companion_bible"]
         config = CleanRoomConfig(
@@ -124,5 +131,5 @@ class TestClaudeAgentOptionsCarryTheWidenedCatalog:
             skills=spec.available_skills,
         )
         options = build_sdk_options(config)
-        assert set(options.skills or []) == set(spec.available_skills)
+        assert set(options.skills or []) == {_qualify_catalog_skill(name) for name in spec.available_skills}
         assert len(options.plugins) == 1

--- a/tests/teatree_eval/test_api_runner.py
+++ b/tests/teatree_eval/test_api_runner.py
@@ -8,7 +8,9 @@ the swap is invisible to the grader. The SDK is mocked here — no metered calls
 
 import asyncio
 import dataclasses
+import json
 import os
+import re
 from collections.abc import AsyncIterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -19,6 +21,7 @@ import pytest
 from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUseBlock
 
 from teatree.eval.api_runner import (
+    _SKILL_CATALOG_PLUGIN_NAME,
     CLAUDE_RESOLVE_MAX_ATTEMPTS,
     DEFAULT_WATCHDOG_SECONDS,
     MAX_BUDGET_USD,
@@ -28,11 +31,14 @@ from teatree.eval.api_runner import (
     ClaudeCliMissingError,
     CleanRoomConfig,
     CreditExhaustedError,
+    _qualify_catalog_skill,
+    _skill_catalog_fixture_plugin,
     build_sdk_options,
     classify_terminal_error,
     is_success_result_error,
     resolve_claude_path,
 )
+from teatree.eval.discovery import discover_specs
 from teatree.eval.models import (
     DEFAULT_MAX_TURNS,
     AnyOf,
@@ -691,9 +697,19 @@ class TestBuildSdkOptionsSkillCatalog:
         assert options.plugins == []
 
     def test_declared_skills_populate_the_skills_filter(self, tmp_path: Path) -> None:
+        # The filter carries the plugin-qualified `<plugin>:<skill>` key the CLI
+        # lists a plugin's skills under (verified: the init event exposes
+        # `eval-skill-catalog:t3-widget`) — the unambiguous canonical form.
         config = _skills_config(tmp_path, skills=("t3-widget", "ac-django"))
         options = build_sdk_options(config)
-        assert options.skills == ["t3-widget", "ac-django"]
+        assert options.skills == ["eval-skill-catalog:t3-widget", "eval-skill-catalog:ac-django"]
+
+    def test_already_qualified_declared_skill_is_not_double_qualified(self, tmp_path: Path) -> None:
+        # Qualification is idempotent: a name that already carries the plugin
+        # prefix is passed through untouched, never `eval-skill-catalog:eval-skill-catalog:…`.
+        config = _skills_config(tmp_path, skills=("eval-skill-catalog:t3-widget",))
+        options = build_sdk_options(config)
+        assert options.skills == ["eval-skill-catalog:t3-widget"]
 
     def test_declared_skills_register_the_fixture_plugin(self, tmp_path: Path) -> None:
         config = _skills_config(tmp_path, skills=("t3-widget",))
@@ -711,6 +727,38 @@ class TestBuildSdkOptionsSkillCatalog:
         plugin_dir = Path(_skill_catalog_fixture_plugin()["path"])
         assert (plugin_dir / ".claude-plugin" / "plugin.json").is_file()
         assert list(plugin_dir.glob("skills/*/SKILL.md")), "fixture plugin ships no skills"
+
+    def test_plugin_name_constant_matches_the_fixture_plugin_json(self) -> None:
+        # The qualified skill key `<plugin>:<skill>` is built from this constant;
+        # if the fixture's plugin.json `name` ever drifts from it, the CLI would
+        # list the skills under a DIFFERENT prefix and the filter would silently
+        # resolve empty again. Pin the two together at their single seam.
+        plugin_json = Path(_skill_catalog_fixture_plugin()["path"]) / ".claude-plugin" / "plugin.json"
+        assert json.loads(plugin_json.read_text(encoding="utf-8"))["name"] == _SKILL_CATALOG_PLUGIN_NAME
+
+    def test_qualification_preserves_every_shipped_positive_skill_anchor(self) -> None:
+        # The fix qualifies each declared skill name UP to `<plugin>:<skill>`.
+        # Prove that qualification does not desynchronise the filter from the
+        # matchers: for every shipped scenario declaring available_skills, each
+        # positive `Skill` matcher's `args.skill` regex must still be satisfied
+        # by at least one QUALIFIED available-skill name — else the model would
+        # load a skill whose recorded tool-call value no longer matches the
+        # positive anchor (a silent re-red in the other direction).
+        for spec in discover_specs():
+            if not spec.available_skills:
+                continue
+            qualified = [_qualify_catalog_skill(name) for name in spec.available_skills]
+            for item in spec.matchers:
+                positives = item.alternatives if isinstance(item, AnyOf) else [item]
+                for matcher in positives:
+                    if not isinstance(matcher, Matcher) or matcher.kind != "positive":
+                        continue
+                    if canonicalize_tool(matcher.tool) != "Skill" or matcher.operator != "~":
+                        continue
+                    assert any(re.search(matcher.value, name) for name in qualified), (
+                        f"{spec.name}: positive Skill anchor /{matcher.value}/ matches no "
+                        f"qualified available_skill in {qualified}"
+                    )
 
     def test_every_scenario_declared_skill_has_a_fixture_entry(self) -> None:
         # Anti-drift: every skill name any shipped scenario declares via
@@ -738,7 +786,7 @@ class TestBuildSdkOptionsSkillCatalog:
             patch("teatree.eval.api_runner.query", query),
         ):
             ApiInProcessRunner(workspace=tmp_path).run(spec)
-        assert captured["options"].skills == ["t3-widget", "widget-le"]
+        assert captured["options"].skills == ["eval-skill-catalog:t3-widget", "eval-skill-catalog:widget-le"]
         assert len(captured["options"].plugins) == 1
 
     def test_runner_without_available_skills_matches_prior_behaviour(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Headline finding — the 8 skill-routing "reds" do NOT reproduce on current main

The stale dashboard (run 28630941573, sha `12264ae0`, 2026-07-03 00:46) reported 8 skill-routing scenarios red 0/2. That baseline **predates the fixture-plugin wiring** (`c94729c8`, 2026-07-03 09:22 — ~8.5h later) that made the fixture skills discoverable, so it measured the scenarios *before the plugin catalog existed*.

On current main the plugin loads and the scenarios pass. Verified green live this session:

- **Host api lane (5/8):** `overlay_repo_task_loads_overlay_skill`, `overlay_review_loads_overlay_review_skill_set`, `non_overlay_task_does_not_require_overlay_skill`, `overlay_django_coding_loads_companion_bible`, `overlay_repo_review_loads_overlay_skill_first`.
- **Docker CI lane** (`:ro` mount at `/app`, `HOME=/tmp` — the exact CI env): `overlay_repo_task_loads_overlay_skill` PASS.

There is **no bare-vs-qualified name-mismatch bug** (the triage's prime suspect): a probe showed the model calling `Skill(eval-skill-catalog:t3-widget)` and the skill *loading* even under the bare filter, and the plugin skills load from a read-only plugin dir too. The SDK documents the bare SKILL.md name as a valid filter form.

## What this change does

`build_sdk_options` threaded a scenario's `available_skills` into `ClaudeAgentOptions.skills` as **bare** SKILL.md names (`t3-widget`). The bundled `claude` CLI lists the fixture plugin's skills under the **plugin-qualified** key (`eval-skill-catalog:t3-widget`). Both forms are accepted by the SDK filter (`types.py`: "the SKILL.md name / directory name, or plugin:skill"), so this is a **canonical-key alignment** (architecture-design section 8, identity-normalization) — the filter now matches the CLI's own listing exactly and stays correct if a future CLI build ever tightens the filter to the qualified form only.

`_qualify_catalog_skill` canonicalizes each declared name UP at the single seam (idempotent). Adds a plugin-name **drift pin** (constant == fixture `plugin.json` name) and a **matchability guard** (every shipped positive `Skill` anchor still matches a qualified name). Matchers are untouched — regex substring, so `eval-skill-catalog:t3-widget` still matches `~ "t3-widget"`.

**This is a robustness alignment, not the fix for the (already-resolved) reds.**

## Verification

- `TestBuildSdkOptionsSkillCatalog` (17) + `test_skill_catalog_fixture_gap.py` — green, incl. new drift/matchability pins.
- `tests/teatree_eval` (450) + `tests/quality` (606) — green.
- Deterministic replay lane green except 2 pre-existing `test_regression_corpus.py` failures that fail identically on clean `origin/main` (a local-env migration/git artifact, unrelated to this change).
- Re-baseline `workflow_dispatch`: run 28791929503 (kicked on current main; CI-wide confirmation).

## Architecture pre-check

Narrow change to one existing function in `src/teatree/eval/api_runner.py`; no new module, no Protocol/FSM/OverlayBase surface.

- **Section 4 Component boundaries:** stays in the eval harness (`src/teatree/eval/`).
- **Section 5 Dependency direction:** no new src imports; `tach` unaffected.
- **Section 6 Test surface:** qualified-form assertion, idempotence, plugin-name drift, positive-anchor matchability.
- **Section 8 Identity/key normalization:** the core — the plugin-qualified `<plugin>:<skill>` is the canonical key; one function normalizes UP at the single seam.
- **Section 9 Behavior preservation:** purely additive; no matcher/negative weakened; no must-block test inverted.
- **Section 10 Removability:** self-contained; reverting restores the bare-name filter (a documented-valid equivalent).

Draft — not merging; for cold review.
