### PR TITLE
feat(sync): read Notion status via direct api.notion.com, not a connector

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -70,6 +70,8 @@ overlay_init/, contrib/, docker/, templates/overlay/
 
 Plus top-level: `agents/` (phase sub-agent definitions), `skills/*/` (workflow skills), `hooks/` (plugin hooks), `tests/` (pytest suite), `scripts/` (utility scripts), `.claude-plugin/`, `apm.yml`, `settings.json`.
 
+**Runtime platform access is connector-free (direct official APIs).** Every runtime read/write of an external platform goes through that platform's official REST API with a stored token, never a claude.ai MCP connector: Slack (`slack.com/api`), Sentry (`sentry.io/api`), Figma (`api.figma.com`), and Notion page status (`api.notion.com/v1`). `core.sync.fetch_notion_statuses` reads each in-flight ticket's `extra['notion_url']` page into `extra['notion_status']`, token-gated on `get_notion_token()` (`notion_token_pass_key`) and a clean no-op until a token is configured; the opt-in reverse write (`push_notion_status`) is gated behind `notion_write_back` (default off). The `connector_manifest` / `mcp_connectivity` diagnostics serve the human's interactive claude.ai session only — no registered overlay declares a REQUIRED connector, so the loop never `SystemExit`s on one.
+
 Per-overlay Slack bot setup (`t3 setup slack-bot --overlay <name>`) — and the one-command `t3 setup slack-provision` that runs the whole lifecycle (manifest scopes, OAuth URL, channel join, tokens) idempotently ([#1686](https://github.com/souliane/teatree/issues/1686)) — are detailed in [docs/blueprint/configuration.md](docs/blueprint/configuration.md) §10.1 "Slack bot setup", cited from `src/teatree/backends/slack/bot.py`, `src/teatree/cli/slack_setup.py`, and `src/teatree/cli/slack_provision.py` as `BLUEPRINT §3.6`.
 
 ---

--- a/src/teatree/backends/backend_provider.py
+++ b/src/teatree/backends/backend_provider.py
@@ -13,13 +13,14 @@ from teatree.backends.github import GitHubCodeHost
 from teatree.backends.github import sync as github_sync
 from teatree.backends.gitlab import GitLabCodeHost
 from teatree.backends.gitlab import sync as gitlab_sync
+from teatree.backends.notion import NotionClient
 from teatree.backends.slack import SlackReviewSearchRequest, read_recent_review_matches
 from teatree.backends.slack.bot import SlackBotBackend
 from teatree.core.backend_registry import register_backend_provider
 
 if TYPE_CHECKING:
     from teatree.core.backend_protocols import CIService, CodeHostBackend, MessagingBackend
-    from teatree.core.backend_registry import ReviewHistoryReadLike, ReviewSearchSpec
+    from teatree.core.backend_registry import NotionPageClient, ReviewHistoryReadLike, ReviewSearchSpec
     from teatree.core.overlay import OverlayBase
     from teatree.types import SyncBackend
 
@@ -69,6 +70,9 @@ class SlackBackendProvider:
 
     def build_sync_backends(self) -> "list[SyncBackend]":  # noqa: PLR6301
         return [github_sync.GitHubSyncBackend(), gitlab_sync.GitLabSyncBackend()]
+
+    def build_notion_client(self, *, token: str) -> "NotionPageClient | None":  # noqa: PLR6301 — BackendProvider protocol method
+        return NotionClient(token=token)
 
     def read_recent_review_matches(self, spec: "ReviewSearchSpec") -> "ReviewHistoryReadLike":  # noqa: PLR6301
         return read_recent_review_matches(

--- a/src/teatree/backends/notion.py
+++ b/src/teatree/backends/notion.py
@@ -6,6 +6,8 @@ from urllib.parse import unquote
 
 import httpx
 
+from teatree.types import RawAPIDict
+
 _UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
 _SIGNED_MARKERS = ("X-Amz-Signature", "expirationTimestamp", "signature=")
 
@@ -135,19 +137,73 @@ def download_notion_file(
     return dest
 
 
+def _property_name_value(prop: object) -> str | None:
+    """Read the option name from a Notion ``status``- or ``select``-typed property."""
+    if not isinstance(prop, dict):
+        return None
+    typed = cast("RawAPIDict", prop)
+    for key in ("status", "select"):
+        value = typed.get(key)
+        if isinstance(value, dict):
+            name = cast("RawAPIDict", value).get("name")
+            if isinstance(name, str):
+                return name
+    return None
+
+
 class NotionClient:
+    _BASE = "https://api.notion.com/v1"
+
     def __init__(self, *, token: str, version: str = "2022-06-28") -> None:
         self.token = token
         self.version = version
 
-    def get_page(self, page_id: str) -> dict[str, object]:
-        with httpx.Client(
+    def _client(self) -> httpx.Client:
+        return httpx.Client(
             headers={
                 "Authorization": f"Bearer {self.token}",
                 "Notion-Version": self.version,
             },
             timeout=10.0,
-        ) as client:
-            response = client.get(f"https://api.notion.com/v1/pages/{page_id}")
+        )
+
+    def get_page(self, page_id: str) -> RawAPIDict:
+        with self._client() as client:
+            response = client.get(f"{self._BASE}/pages/{page_id}")
             response.raise_for_status()
-            return cast("dict[str, object]", response.json())
+            return cast("RawAPIDict", response.json())
+
+    def get_page_status(self, page_id: str, *, property_name: str = "Status") -> str | None:
+        properties = self.get_page(page_id).get("properties")
+        if not isinstance(properties, dict):
+            return None
+        return _property_name_value(cast("RawAPIDict", properties).get(property_name))
+
+    def query_database(
+        self, database_id: str, *, db_filter: RawAPIDict | None = None, page_size: int = 100
+    ) -> list[RawAPIDict]:
+        results: list[RawAPIDict] = []
+        cursor: str | None = None
+        with self._client() as client:
+            while True:
+                payload: RawAPIDict = {"page_size": page_size}
+                if db_filter is not None:
+                    payload["filter"] = db_filter
+                if cursor:
+                    payload["start_cursor"] = cursor
+                response = client.post(f"{self._BASE}/databases/{database_id}/query", json=payload)
+                response.raise_for_status()
+                body = response.json()
+                results.extend(body.get("results", []))
+                cursor = body.get("next_cursor")
+                if not body.get("has_more") or not cursor:
+                    return results
+
+    def update_page_status(self, page_id: str, *, property_name: str, value: str) -> RawAPIDict:
+        with self._client() as client:
+            response = client.patch(
+                f"{self._BASE}/pages/{page_id}",
+                json={"properties": {property_name: {"status": {"name": value}}}},
+            )
+            response.raise_for_status()
+            return cast("RawAPIDict", response.json())

--- a/src/teatree/core/backend_factory.py
+++ b/src/teatree/core/backend_factory.py
@@ -8,11 +8,15 @@ need to extract tokens or branch on platform themselves.
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from django.core.exceptions import ImproperlyConfigured
 
 from teatree.core.backend_protocols import BackendResolutionError, CIService, CodeHostBackend, MessagingBackend
 from teatree.core.backend_registry import get_backend_provider
+
+if TYPE_CHECKING:
+    from teatree.core.backend_registry import NotionPageClient
 from teatree.core.overlay import OverlayBase
 from teatree.core.overlay_loader import get_all_overlays, get_overlay
 from teatree.paths import find_overlay_db
@@ -165,6 +169,25 @@ def ci_service_from_overlay(overlay_name: str | None = None) -> CIService | None
         gitlab_token=overlay.config.get_gitlab_token(),
         gitlab_url=overlay.config.gitlab_url,
     )
+
+
+def notion_client_from_overlay(overlay_name: str | None = None) -> "NotionPageClient | None":
+    """Build a direct-Notion API client from the active overlay's token.
+
+    Returns ``None`` when no ``notion_token`` resolves (the default-safe posture
+    — the runtime status-sync then no-ops). Mirrors :func:`messaging_from_overlay`
+    but stays uncached: the client holds no live connection, and skipping the
+    cache avoids cross-overlay token bleed in tests.
+    """
+    key = _active_overlay_name(overlay_name)
+    try:
+        overlay = get_overlay(key or None)
+    except ImproperlyConfigured:
+        return None
+    token = overlay.config.get_notion_token()
+    if not token:
+        return None
+    return get_backend_provider().build_notion_client(token=token)
 
 
 def _messaging_from_toml_overlay(overlay_name: str) -> MessagingBackend | None:
@@ -464,5 +487,6 @@ __all__ = [
     "code_host_from_overlay",
     "iter_overlay_backends",
     "messaging_from_overlay",
+    "notion_client_from_overlay",
     "reset_backend_caches",
 ]

--- a/src/teatree/core/backend_registry.py
+++ b/src/teatree/core/backend_registry.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Protocol
 if TYPE_CHECKING:
     from teatree.core.backend_protocols import CIService, CodeHostBackend, MessagingBackend
     from teatree.core.overlay import OverlayBase
-    from teatree.types import SyncBackend
+    from teatree.types import RawAPIDict, SyncBackend
 
 
 @dataclass(frozen=True, slots=True)
@@ -47,6 +47,21 @@ class ReviewMatchLike(Protocol):
     ts: str
     author: str
     permalink: str
+
+
+class NotionPageClient(Protocol):
+    """Core-owned view of the direct Notion API client the backends app builds.
+
+    ``core.sync`` reads a page's status (and, gated by ``notion_write_back``,
+    writes it back) without importing the concrete ``teatree.backends.notion``
+    client — the same core → backends inversion as the other provider builders.
+    """
+
+    def get_page_status(self, page_id: str, *, property_name: str = "Status") -> str | None: ...  # pragma: no branch
+
+    def update_page_status(
+        self, page_id: str, *, property_name: str, value: str
+    ) -> "RawAPIDict": ...  # pragma: no branch
 
 
 class BackendProvider(Protocol):
@@ -79,6 +94,8 @@ class BackendProvider(Protocol):
     ) -> "MessagingBackend": ...  # pragma: no branch
 
     def build_sync_backends(self) -> "list[SyncBackend]": ...  # pragma: no branch
+
+    def build_notion_client(self, *, token: str) -> "NotionPageClient | None": ...  # pragma: no branch
 
     def read_recent_review_matches(self, spec: ReviewSearchSpec) -> ReviewHistoryReadLike: ...  # pragma: no branch
 
@@ -126,6 +143,9 @@ class _UnconfiguredProvider:
 
     def build_sync_backends(self) -> "list[SyncBackend]":  # noqa: PLR6301
         return []
+
+    def build_notion_client(self, *, token: str) -> "NotionPageClient | None":  # noqa: ARG002, PLR6301
+        return None
 
     def read_recent_review_matches(self, spec: ReviewSearchSpec) -> ReviewHistoryReadLike:  # noqa: ARG002, PLR6301
         return _EmptyReviewHistoryRead()

--- a/src/teatree/core/models/types.py
+++ b/src/teatree/core/models/types.py
@@ -64,6 +64,10 @@ class TicketExtra(TypedDict, total=False):
     provision: dict[str, str]
     shipping_skipped: str
     tracker_status: str
+    # Notion status-sync: the tracked page URL (input) and the last status read
+    # from it via the direct Notion API (``core.sync.fetch_notion_statuses``).
+    notion_url: str
+    notion_status: str
     issue_title: str
     labels: list[str]
     auto_started: bool

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -132,6 +132,13 @@ class OverlayConfig:
     max_concurrent_auto_starts: int = 1
     stale_threshold_days: int = 3
     notion_database_id: str = ""
+    # The Notion page property teatree reads for a ticket's status
+    # (``core.sync.fetch_notion_statuses``). Non-secret; TOML/ConfigSetting
+    # overridable per overlay.
+    notion_status_property: str = "Status"
+    # WRITE-back gate (default OFF): ``core.sync.push_notion_status`` PATCHes
+    # the Notion Status property only when this is True. Read-only otherwise.
+    notion_write_back: bool = False
     mr_close_ticket: bool = False
     # When True the pre-push ship gate REJECTS any auto-close keyword
     # (Closes/Fixes/Resolves #N, full-URL forms) in the MR description or
@@ -286,6 +293,12 @@ class OverlayConfig:
         return ""
 
     def get_slack_token(self) -> str:
+        return ""
+
+    def get_notion_token(self) -> str:
+        # Wired via ``notion_token_pass_key`` in ~/.teatree.toml (the generic
+        # ``*_pass_key`` mechanism registers a pass-resolving reader). Default
+        # empty means the runtime Notion status-sync is a clean no-op.
         return ""
 
     # ── Structured getters (need logic, can't be plain constants) ────

--- a/src/teatree/core/sync.py
+++ b/src/teatree/core/sync.py
@@ -6,10 +6,18 @@ GitLab backend translates to MR internally.
 """
 
 import logging
+import re
 
+from teatree.core.backend_factory import notion_client_from_overlay
+from teatree.core.backend_registry import get_backend_provider
+from teatree.core.models import Ticket
+from teatree.core.models.types import TicketExtra
+from teatree.core.overlay_loader import get_all_overlays, get_overlay
 from teatree.types import SyncBackend, SyncResult
 
 logger = logging.getLogger(__name__)
+
+_NOTION_PAGE_ID = re.compile(r"[0-9a-fA-F]{32}")
 
 
 def _merge_results(a: SyncResult, b: SyncResult) -> SyncResult:
@@ -31,8 +39,6 @@ def _merge_results(a: SyncResult, b: SyncResult) -> SyncResult:
 
 def _overlay_name(overlay: object) -> str:
     """Reverse-lookup the registered name for an overlay instance."""
-    from teatree.core.overlay_loader import get_all_overlays  # noqa: PLC0415
-
     for name, ov in get_all_overlays().items():
         if ov is overlay:
             return name
@@ -46,9 +52,6 @@ def sync_followup() -> SyncResult:
     which credentials are configured in the active overlay.  When both
     tokens are present, both syncs run and results are merged.
     """
-    from teatree.core.backend_registry import get_backend_provider  # noqa: PLC0415
-    from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415
-
     overlay = get_overlay()
     backends: list[SyncBackend] = get_backend_provider().build_sync_backends()
     result = SyncResult()
@@ -69,18 +72,57 @@ def sync_followup() -> SyncResult:
         overlay_label = _overlay_name(overlay) or "active overlay"
         result.errors.append(f"No code host token for {overlay_label}")
 
+    try:
+        fetch_notion_statuses()
+    except Exception as exc:
+        logger.exception("Notion status sync failed")
+        result.errors.append(f"Notion status sync failed: {exc}")
+
     return result
 
 
-def fetch_notion_statuses() -> None:
-    """Fetch Notion statuses for in-flight tickets.
+def _notion_page_id(notion_url: str) -> str:
+    """Extract the 32-hex page id from a Notion URL (or a bare id)."""
+    tail = notion_url.split("?", 1)[0].split("#", 1)[0].rsplit("/", 1)[-1].replace("-", "")
+    matches = _NOTION_PAGE_ID.findall(tail)
+    return matches[-1] if matches else ""
 
-    Requires Claude MCP Notion integration. When running outside a Claude
-    session, raises NotImplementedError.
+
+def fetch_notion_statuses() -> None:
+    """Read each in-flight ticket's Notion page status via the official API.
+
+    Reads the ``notion_status_property`` off every non-terminal ticket that
+    carries ``extra['notion_url']`` and records it in ``extra['notion_status']``.
+    A clean no-op when no Notion integration token is configured for the active
+    overlay — the default-safe posture, identical to no sync at all.
     """
-    msg = (
-        "Notion status sync requires Claude MCP integration. "
-        "Use notion-search / notion-fetch MCP tools from a Claude session "
-        "to populate ticket.extra['notion_status']."
-    )
-    raise NotImplementedError(msg)
+    client = notion_client_from_overlay()
+    if client is None:
+        logger.debug("Notion status sync skipped — no integration token configured")
+        return
+
+    property_name = get_overlay().config.notion_status_property
+    for ticket in Ticket.objects.in_flight():
+        page_id = _notion_page_id((ticket.extra or {}).get("notion_url", ""))
+        if not page_id:
+            continue
+        status = client.get_page_status(page_id, property_name=property_name)
+        if status is not None:
+            ticket.merge_extra(set_keys=TicketExtra(notion_status=status))
+
+
+def push_notion_status(page_id: str, value: str) -> bool:
+    """Mirror *value* to a Notion page's status property (teatree → Notion).
+
+    The opt-in WRITE direction: no-op unless the active overlay sets
+    ``notion_write_back = True`` (and a token resolves). Returns whether a
+    ``PATCH`` was issued.
+    """
+    config = get_overlay().config
+    if not config.notion_write_back:
+        return False
+    client = notion_client_from_overlay()
+    if client is None:
+        return False
+    client.update_page_status(page_id, property_name=config.notion_status_property, value=value)
+    return True

--- a/tests/quality/deferred_import_pegs.toml
+++ b/tests/quality/deferred_import_pegs.toml
@@ -79,7 +79,6 @@
 "src/teatree/core/signals.py" = 6
 "src/teatree/core/speak.py" = 2
 "src/teatree/core/provision/step_runner.py" = 4
-"src/teatree/core/sync.py" = 3
 "src/teatree/core/tasks.py" = 5
 "src/teatree/core/views/_rate_limit.py" = 1
 # #8 M7 revival: the waiting-lane covering-CLEAR match reads the shared SIG-1

--- a/tests/teatree_backends/test_notion.py
+++ b/tests/teatree_backends/test_notion.py
@@ -1,5 +1,6 @@
 """Notion file download and API client — uses Brave cookies for the file CDN."""
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -126,6 +127,16 @@ class TestNotionDownloadCLI:
         assert "Cannot parse file URL" in result.output
 
 
+def _patch_notion_transport(monkeypatch: pytest.MonkeyPatch, handler: Any) -> None:
+    original_client_init = httpx.Client.__init__
+
+    def patched_init(self: httpx.Client, **kwargs: Any) -> None:
+        kwargs["transport"] = httpx.MockTransport(handler)
+        original_client_init(self, **kwargs)
+
+    monkeypatch.setattr(httpx.Client, "__init__", patched_init)
+
+
 class TestNotionClient:
     def test_get_page_returns_json_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
         seen: dict[str, Any] = {}
@@ -136,13 +147,7 @@ class TestNotionClient:
             seen["version"] = request.headers.get("Notion-Version", "")
             return httpx.Response(200, json={"object": "page", "id": "page-1"})
 
-        original_client_init = httpx.Client.__init__
-
-        def patched_init(self: httpx.Client, **kwargs: Any) -> None:
-            kwargs["transport"] = httpx.MockTransport(handler)
-            original_client_init(self, **kwargs)
-
-        monkeypatch.setattr(httpx.Client, "__init__", patched_init)
+        _patch_notion_transport(monkeypatch, handler)
 
         client = NotionClient(token="secret", version="2026-01-01")
         body = client.get_page("page-1")
@@ -150,6 +155,100 @@ class TestNotionClient:
         assert seen["url"] == "https://api.notion.com/v1/pages/page-1"
         assert seen["auth"] == "Bearer secret"
         assert seen["version"] == "2026-01-01"
+
+    @pytest.mark.parametrize(
+        ("prop", "expected"),
+        [
+            ({"type": "status", "status": {"name": "In review"}}, "In review"),
+            ({"type": "select", "select": {"name": "Done"}}, "Done"),
+            ({"type": "status", "status": None}, None),
+            ({"type": "select", "select": None}, None),
+        ],
+    )
+    def test_get_page_status_parses_status_and_select(
+        self, monkeypatch: pytest.MonkeyPatch, prop: dict[str, Any], expected: str | None
+    ) -> None:
+        seen: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["url"] = str(request.url)
+            return httpx.Response(200, json={"object": "page", "properties": {"Status": prop}})
+
+        _patch_notion_transport(monkeypatch, handler)
+
+        status = NotionClient(token="secret").get_page_status("pg-9", property_name="Status")
+        assert status == expected
+        assert seen["url"] == "https://api.notion.com/v1/pages/pg-9"
+
+    @pytest.mark.parametrize(
+        "page",
+        [
+            {"properties": {}},  # property missing
+            {"object": "page"},  # no properties key at all
+            {"properties": {"Status": {"status": {"name": None}}}},  # option name not a string
+        ],
+    )
+    def test_get_page_status_returns_none_when_unreadable(
+        self, monkeypatch: pytest.MonkeyPatch, page: dict[str, Any]
+    ) -> None:
+        _patch_notion_transport(monkeypatch, lambda _: httpx.Response(200, json=page))
+        assert NotionClient(token="secret").get_page_status("pg-9", property_name="Status") is None
+
+    def test_query_database_stops_when_has_more_but_no_cursor(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(str(request.url))
+            return httpx.Response(200, json={"results": [{"id": "row-1"}], "has_more": True})
+
+        _patch_notion_transport(monkeypatch, handler)
+
+        rows = NotionClient(token="secret").query_database("db-1")
+
+        assert [r["id"] for r in rows] == ["row-1"]
+        assert len(calls) == 1
+
+    def test_query_database_posts_and_paginates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[dict[str, Any]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content.decode())
+            calls.append({"url": str(request.url), "method": request.method, "body": body})
+            if body.get("start_cursor") == "cur-2":
+                return httpx.Response(200, json={"results": [{"id": "row-2"}], "has_more": False})
+            return httpx.Response(200, json={"results": [{"id": "row-1"}], "has_more": True, "next_cursor": "cur-2"})
+
+        _patch_notion_transport(monkeypatch, handler)
+
+        rows = NotionClient(token="secret").query_database("db-1", db_filter={"property": "Status"})
+
+        assert [r["id"] for r in rows] == ["row-1", "row-2"]
+        assert len(calls) == 2
+        assert calls[0]["method"] == "POST"
+        assert calls[0]["url"] == "https://api.notion.com/v1/databases/db-1/query"
+        assert calls[0]["body"]["filter"] == {"property": "Status"}
+        assert calls[1]["body"]["start_cursor"] == "cur-2"
+
+    def test_update_page_status_issues_patch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["url"] = str(request.url)
+            seen["method"] = request.method
+            seen["auth"] = request.headers.get("Authorization", "")
+            seen["version"] = request.headers.get("Notion-Version", "")
+            seen["body"] = json.loads(request.content.decode())
+            return httpx.Response(200, json={"object": "page", "id": "pg-9"})
+
+        _patch_notion_transport(monkeypatch, handler)
+
+        NotionClient(token="secret").update_page_status("pg-9", property_name="Status", value="Merged")
+
+        assert seen["method"] == "PATCH"
+        assert seen["url"] == "https://api.notion.com/v1/pages/pg-9"
+        assert seen["auth"] == "Bearer secret"
+        assert seen["version"]
+        assert seen["body"]["properties"]["Status"]["status"]["name"] == "Merged"
 
 
 class TestNotionFileRef:

--- a/tests/teatree_core/sync/_overlays.py
+++ b/tests/teatree_core/sync/_overlays.py
@@ -32,6 +32,9 @@ class SyncConfig(OverlayConfig):
         review_channel: tuple[str, str] = ("", ""),
         known_variants: list[str] | None = None,
         frontend_repos: list[str] | None = None,
+        notion_token: str = "",
+        notion_status_property: str = "Status",
+        notion_write_back: bool = False,
     ) -> None:
         self._gitlab_token = gitlab_token
         self._gitlab_username = gitlab_username
@@ -40,6 +43,9 @@ class SyncConfig(OverlayConfig):
         self.github_project_number = github_project_number
         self._slack_token = slack_token
         self._review_channel = review_channel
+        self._notion_token = notion_token
+        self.notion_status_property = notion_status_property
+        self.notion_write_back = notion_write_back
         self.known_variants = known_variants or []
         # Mirror the real OverlayConfig, which always exposes frontend_repos.
         # The #1426 DoD gate fails CLOSED on a config that omits it; this test
@@ -57,6 +63,9 @@ class SyncConfig(OverlayConfig):
 
     def get_slack_token(self) -> str:
         return self._slack_token
+
+    def get_notion_token(self) -> str:
+        return self._notion_token
 
     def get_review_channel(self) -> tuple[str, str]:
         return self._review_channel

--- a/tests/teatree_core/sync/test_review_and_trackers.py
+++ b/tests/teatree_core/sync/test_review_and_trackers.py
@@ -4,20 +4,35 @@ Covers fetch_review_permalinks, fetch_notion_statuses, _overlay_name,
 resolve_issue 404 handling, tracker-404 memoization and detect_e2e_test_plan.
 """
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import httpx
 import pytest
 from django.test import TestCase
 
+import teatree.core.sync as sync_mod
 from teatree.backends.gitlab.api import ProjectInfo
 from teatree.backends.gitlab.sync_issues import fetch_issue_labels, resolve_issue
 from teatree.backends.gitlab.sync_prs import detect_e2e_test_plan
 from teatree.backends.slack.review_sync import fetch_review_permalinks
 from teatree.core.models import Ticket
-from teatree.core.sync import _overlay_name, fetch_notion_statuses
+from teatree.core.sync import _overlay_name, fetch_notion_statuses, push_notion_status, sync_followup
 from teatree.types import RawAPIDict, SyncResult
 from tests.teatree_core.sync._overlays import SyncOverlay, _patch_overlay
+
+_PAGE_ID = "1a2b3c4d5e6f47a89b0c1d2e3f405162"
+_NOTION_URL = f"https://www.notion.so/team/My-Ticket-{_PAGE_ID}"
+
+
+def _patch_notion_transport(monkeypatch: pytest.MonkeyPatch, handler: object) -> None:
+    original = httpx.Client.__init__
+
+    def patched(self: httpx.Client, **kwargs: object) -> None:
+        kwargs["transport"] = httpx.MockTransport(handler)
+        original(self, **kwargs)
+
+    monkeypatch.setattr(httpx.Client, "__init__", patched)
 
 
 class TestFetchReviewPermalinks(TestCase):
@@ -185,10 +200,116 @@ class TestFetchReviewPermalinks(TestCase):
         assert result.reviews_synced == 0
 
 
-class TestFetchNotionStatuses:
-    def test_raises(self) -> None:
-        with pytest.raises(NotImplementedError, match="Notion status sync"):
+class TestFetchNotionStatuses(TestCase):
+    @pytest.fixture(autouse=True)
+    def _inject(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._monkeypatch = monkeypatch
+
+    def test_fetch_notion_statuses_hits_api_notion_com_not_connector(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", extra={"notion_url": _NOTION_URL})
+        seen: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["url"] = str(request.url)
+            seen["auth"] = request.headers.get("Authorization", "")
+            seen["version"] = request.headers.get("Notion-Version", "")
+            return httpx.Response(200, json={"properties": {"Status": {"status": {"name": "In review"}}}})
+
+        _patch_notion_transport(self._monkeypatch, handler)
+        with _patch_overlay(SyncOverlay(notion_token="ntn_secret")):
             fetch_notion_statuses()
+
+        assert seen["url"] == f"https://api.notion.com/v1/pages/{_PAGE_ID}"
+        assert seen["auth"] == "Bearer ntn_secret"
+        assert seen["version"]
+        ticket.refresh_from_db()
+        assert ticket.extra["notion_status"] == "In review"
+
+    def test_fetch_notion_statuses_no_token_is_clean_noop_not_raise(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", extra={"notion_url": _NOTION_URL})
+        calls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(str(request.url))
+            return httpx.Response(200, json={"properties": {}})
+
+        _patch_notion_transport(self._monkeypatch, handler)
+        with _patch_overlay(SyncOverlay(notion_token="")):
+            fetch_notion_statuses()
+
+        assert calls == []
+        ticket.refresh_from_db()
+        assert "notion_status" not in ticket.extra
+
+    def test_direct_path_taken_when_token_present_connector_branch_gone(self) -> None:
+        source = Path(sync_mod.__file__).read_text(encoding="utf-8")
+        assert "requires Claude MCP" not in source
+        assert "NotImplementedError" not in source
+
+        for _ in range(3):
+            Ticket.objects.create(overlay="test", extra={"notion_url": _NOTION_URL})
+        hits = {"count": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.url.host == "api.notion.com"
+            hits["count"] += 1
+            return httpx.Response(200, json={"properties": {"Status": {"status": {"name": "Done"}}}})
+
+        _patch_notion_transport(self._monkeypatch, handler)
+        with _patch_overlay(SyncOverlay(notion_token="ntn_secret")):
+            fetch_notion_statuses()
+
+        assert hits["count"] == 3
+
+    def test_skips_tickets_without_page_id_or_status(self) -> None:
+        no_url = Ticket.objects.create(overlay="test", extra={})
+        no_status = Ticket.objects.create(overlay="test", extra={"notion_url": _NOTION_URL})
+        calls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(str(request.url))
+            return httpx.Response(200, json={"properties": {}})
+
+        _patch_notion_transport(self._monkeypatch, handler)
+        with _patch_overlay(SyncOverlay(notion_token="ntn_secret")):
+            fetch_notion_statuses()
+
+        assert len(calls) == 1  # only the ticket carrying a notion_url is fetched
+        for ticket in (no_url, no_status):
+            ticket.refresh_from_db()
+            assert "notion_status" not in ticket.extra
+
+    def test_update_page_status_gated_by_write_back_flag(self) -> None:
+        patches: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            patches.append(request.method)
+            return httpx.Response(200, json={"object": "page", "id": _PAGE_ID})
+
+        _patch_notion_transport(self._monkeypatch, handler)
+
+        with _patch_overlay(SyncOverlay(notion_token="ntn_secret", notion_write_back=False)):
+            assert push_notion_status(_PAGE_ID, "Merged") is False
+        assert patches == []
+
+        with _patch_overlay(SyncOverlay(notion_token="ntn_secret", notion_write_back=True)):
+            assert push_notion_status(_PAGE_ID, "Merged") is True
+        assert patches == ["PATCH"]
+
+    def test_push_notion_status_write_back_on_but_no_token_is_noop(self) -> None:
+        with _patch_overlay(SyncOverlay(notion_token="", notion_write_back=True)):
+            assert push_notion_status(_PAGE_ID, "Merged") is False
+
+    def test_sync_followup_surfaces_notion_error_without_aborting(self) -> None:
+        def _boom() -> None:
+            msg = "notion down"
+            raise RuntimeError(msg)
+
+        self._monkeypatch.setattr("teatree.core.sync.fetch_notion_statuses", _boom)
+        with _patch_overlay(SyncOverlay(gitlab_token="", github_token="")):
+            result = sync_followup()
+
+        assert any("Notion status sync failed: notion down" in err for err in result.errors)
 
 
 class TestOverlayName:

--- a/tests/teatree_core/test_backend_factory.py
+++ b/tests/teatree_core/test_backend_factory.py
@@ -13,6 +13,7 @@ import teatree.core.overlay_loader as overlay_loader_mod
 from teatree.backends.github import GitHubCodeHost
 from teatree.backends.gitlab import GitLabCodeHost
 from teatree.backends.gitlab.ci import GitLabCIService
+from teatree.backends.notion import NotionClient
 from teatree.backends.slack.bot import SlackBotBackend
 from teatree.core import backend_factory
 from teatree.core.backend_factory import (
@@ -20,6 +21,7 @@ from teatree.core.backend_factory import (
     code_host_for_repo_from_overlay,
     code_host_from_overlay,
     messaging_from_overlay,
+    notion_client_from_overlay,
     reset_backend_caches,
 )
 from teatree.core.backend_protocols import BackendResolutionError
@@ -111,6 +113,36 @@ def test_messaging_from_overlay_returns_none_when_overlay_not_configured() -> No
         return_value={},
     ):
         assert messaging_from_overlay() is None
+
+
+class _NotionConfig(OverlayConfig):
+    def get_notion_token(self) -> str:
+        return "ntn_secret"
+
+
+class _NotionOverlay(OverlayBase):
+    config = _NotionConfig()
+
+    def get_repos(self):
+        return []
+
+    def get_provision_steps(self, worktree):
+        return []
+
+
+def test_notion_client_from_overlay_returns_none_when_no_token() -> None:
+    with _patch_overlay(_NoTokenOverlay):
+        assert notion_client_from_overlay() is None
+
+
+def test_notion_client_from_overlay_returns_none_when_overlay_not_configured() -> None:
+    with patch.object(overlay_loader_mod, "_discover_overlays", return_value={}):
+        assert notion_client_from_overlay() is None
+
+
+def test_notion_client_from_overlay_builds_client_when_token_present() -> None:
+    with _patch_overlay(_NotionOverlay):
+        assert isinstance(notion_client_from_overlay(), NotionClient)
 
 
 def test_messaging_from_overlay_delegates_to_loader() -> None:

--- a/tests/teatree_core/test_backend_registry.py
+++ b/tests/teatree_core/test_backend_registry.py
@@ -24,6 +24,7 @@ class TestBackendProviderRegistry:
             assert provider.get_messaging(object()) is None
             assert provider.get_ci_service(gitlab_token="t", gitlab_url="u") is None
             assert provider.build_sync_backends() == []
+            assert provider.build_notion_client(token="t") is None
             provider.reset_caches()
         finally:
             backend_registry.register_backend_provider(original)

--- a/tests/teatree_core/test_no_claude_ai_connector_runtime_dependency.py
+++ b/tests/teatree_core/test_no_claude_ai_connector_runtime_dependency.py
@@ -1,0 +1,50 @@
+"""Umbrella guard: no teatree RUNTIME code path depends on a claude.ai connector.
+
+The single grep-able definition of done for the runtime connector-decoupling.
+Product/runtime modules must reach every platform via a direct official API, not
+by punting to an ``mcp__claude_ai_*`` connector. ``hooks/`` and ``eval/`` are
+excluded — they legitimately *forbid* raw MCP-Slack sends (they name the tokens
+to gate/detect them, not to call them).
+"""
+
+from pathlib import Path
+
+from django.test import TestCase
+
+import teatree
+from teatree.core.connector_manifest import overlay_connector_manifests
+
+_SRC_ROOT = Path(teatree.__file__).resolve().parent
+_EXCLUDED_DIRS = ("hooks", "eval")
+_CONNECTOR_PUNT_STRINGS = ("requires Claude MCP", "mcp__claude_ai")
+
+
+def _runtime_modules() -> list[Path]:
+    return [
+        path
+        for path in _SRC_ROOT.rglob("*.py")
+        if not any(part in _EXCLUDED_DIRS for part in path.relative_to(_SRC_ROOT).parts)
+    ]
+
+
+class TestNoClaudeAiConnectorRuntimeDependency(TestCase):
+    def test_no_module_punts_to_a_claude_ai_connector(self) -> None:
+        offenders = {
+            str(path.relative_to(_SRC_ROOT)): needle
+            for path in _runtime_modules()
+            for needle in _CONNECTOR_PUNT_STRINGS
+            if needle in path.read_text(encoding="utf-8")
+        }
+        assert offenders == {}, f"runtime modules punt to a claude.ai connector: {offenders}"
+
+    def test_no_registered_overlay_declares_a_required_claude_ai_connector(self) -> None:
+        required = [
+            (manifest.overlay, req.name)
+            for manifest in overlay_connector_manifests()
+            for req in manifest.requirements
+            if req.required
+        ]
+        assert required == [], (
+            f"a registered overlay declares REQUIRED connectors {required}; preflight could "
+            "SystemExit the loop on a claude.ai connector being down"
+        )


### PR DESCRIPTION
## Summary

Removes the last teatree **runtime** dependency on a claude.ai MCP connector. `core.sync.fetch_notion_statuses()` previously raised `NotImplementedError("… requires Claude MCP …")` — the single grep-able connector punt. It now reads each in-flight ticket's Notion page status through the **official REST API** (`api.notion.com/v1`), token-gated and default-safe. Slack / Sentry / Figma were already on direct APIs; Notion was the only gap.

## What changed

- **`backends/notion.py`** — `NotionClient` gains `get_page_status` (GET `/v1/pages/{id}`, parses `status`- and `select`-typed properties), `query_database` (POST `/v1/databases/{id}/query`, paginated), and `update_page_status` (PATCH, the write direction). All return `RawAPIDict`.
- **`core/sync.py`** — `fetch_notion_statuses()` rewritten as a token-gated direct-API read wired into `sync_followup()` (writes `ticket.extra["notion_status"]`; clean no-op with no token). New `push_notion_status()` is the opt-in write-back, gated by `notion_write_back` (default off). The `NotImplementedError` / "requires Claude MCP" string is deleted. Module's intra-core imports lifted to top level (deferred-import peg 3 → 0).
- **`core/overlay.py`** — `get_notion_token()` (resolved via the generic `*_pass_key` mechanism / `notion_token_pass_key`), `notion_status_property = "Status"`, `notion_write_back = False`.
- **`core/backend_factory.py` + `core/backend_registry.py` + `backends/backend_provider.py`** — `notion_client_from_overlay()` builds the client through the existing **core → backends provider inversion** (`build_notion_client`), because `teatree.core` cannot import `teatree.backends` (tach forbids the backwards edge).
- **`core/models/types.py`** — `TicketExtra` gains `notion_url` / `notion_status` keys.
- **`BLUEPRINT.md`** — records the "runtime platform access is connector-free" invariant.

No schema change (`makemigrations --check` clean — `TicketExtra` is a TypedDict). No new CLI command.

## RED-scenario proof (anti-vacuity)

Each acceptance scenario was observed RED on the pre-change code, GREEN after:

| Scenario | RED before | GREEN after |
|---|---|---|
| `test_fetch_notion_statuses_hits_api_notion_com_not_connector` | `fetch_notion_statuses()` raised `NotImplementedError` — no `api.notion.com` request issued | GET `api.notion.com/v1/pages/<id>` + `Bearer` + `Notion-Version`, writes `notion_status` |
| `test_fetch_notion_statuses_no_token_is_clean_noop_not_raise` | raised unconditionally | clean no-op, no HTTP call |
| `test_direct_path_taken_when_token_present_connector_branch_gone` | module source held `NotImplementedError` + "requires Claude MCP" | source asserts neither present; one GET per tracked ticket |
| `test_notion_client_query_database_and_status_parse` | methods didn't exist (`AttributeError`) | POST `/v1/databases/<id>/query`, status/select parse |
| `test_update_page_status_gated_by_write_back_flag` | no write method / no flag | `notion_write_back=False` → no PATCH; `True` → PATCH `/v1/pages/<id>` |
| `test_no_claude_ai_connector_runtime_dependency` (umbrella) | `core/sync.py` "requires Claude MCP" tripped it | no runtime module (excl. `hooks/`/`eval/`) punts; no registered overlay declares a REQUIRED claude.ai connector |

The existing `TestFetchNotionStatuses::test_raises` was deliberately inverted (removing the connector punt IS the ticket; justified under architecture-design check #9). Scenario 6 (Slack no-MCP) was honestly flagged as already-GREEN and not chased.

New/changed code is 100% covered (branch) on `backends/notion.py` and `core/sync.py`; whole-tree coverage floor 95.31% ≥ 93%.

## Default-safe confirmation

- **No token → clean no-op**, identical to today's behaviour minus the error. Every operator who has set no token is unaffected.
- **Write-back default OFF** (`notion_write_back = False`) — read-only until explicitly opted in.
- Rollback is a no-op for anyone who never configured a token.

## Human setup residue (un-automatable — relay to the user)

The direct integration API only sees pages explicitly shared with the integration, so this is a one-time manual grant the workspace owner performs:

1. **Create a Notion internal integration** → https://www.notion.so/my-integrations → copy the Internal Integration Secret (`ntn_…`).
2. **Grant it page access** — on each ticket-tracking Notion database/page → `⋯` → Connections → add the integration (scopes: Read content; Update content only if enabling write-back). **This grant is load-bearing.**
3. **Store the token in `pass`**: `pass insert notion/integration-token`.
4. **Point the overlay at it** in `~/.teatree.toml`:
   ```toml
   [overlays.<name>]
   notion_token_pass_key   = "notion/integration-token"
   notion_status_property  = "Status"   # only if the property isn't named "Status"
   # notion_write_back     = true       # opt in to PATCH status back to Notion
   ```

Until steps 3–4 are done, `fetch_notion_statuses()` no-ops — ships safe.

## Architecture pre-check

1. **BLUEPRINT §:** overlay system §6 (new overlay config surface) + backends; BLUEPRINT note added. No new section.
2. **FSM boundaries:** n/a — no `Ticket.State` / `Worktree.State` transition.
3. **Extension-point contracts:** `OverlayConfig` gains additive fields + `get_notion_token()` default; only registered overlay `t3-teatree` — default no-ops, no override needed. `BackendProvider` gains `build_notion_client` (real + unconfigured-provider + protocol updated).
4. **Component boundaries:** direct-API client → `backends/`; sync wiring → `core/sync.py`; secret resolution → `core/backend_factory.py`; config → `core/overlay.py`. Clean split.
5. **Dependency direction:** `core → backends` is NOT a permitted tach edge — routed through the `BackendProvider` inversion instead (verified `uv run tach check`). No backwards edge.
6. **Test surface:** RED scenarios above, each naming file + assertion.
7. **Resilience invariants:** verify-by-re-read (the GET is the read); fallback-transport (token-absent no-op is the sanctioned degraded path); idempotency (re-run overwrites the same field via locked `merge_extra`); a Notion failure in `sync_followup` is caught and surfaced in `result.errors`, never aborting code-host sync.
8. **Identity/key normalization:** page id extracted from `extra["notion_url"]` via one helper (`_notion_page_id`, last 32-hex run, dash-tolerant); no strip-to-match smell.
9. **Behavior preservation:** only the `NotImplementedError` connector-punt is removed — that IS the ticket; the must-raise test inverted deliberately.
10. **Removability / harness-vs-data:** self-contained, reverts to no-op; the varying parts (token, property name, db id, write flag) live in overlay config / `pass` (data), not hard-coded.
