### PR TITLE
fix(eval): widen stale t3-wrapper matchers, seed money.py fixture, wire H1 skill catalog, fix OAuth-throttle skip-guard message

### DIFF
--- a/evals/fixtures/ship_opens_pr_after_push_same_turn_pass.stream.jsonl
+++ b/evals/fixtures/ship_opens_pr_after_push_same_turn_pass.stream.jsonl
@@ -1,4 +1,4 @@
 {"type": "system", "subtype": "init", "session_id": "fixt-ship_opens_pr_after_push_same_turn-pass", "model": "claude-sonnet-4-6"}
 {"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "working on it."}]}}
-{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "gh pr create --fill", "description": "step"}}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "t3 pr create --fill", "description": "step"}}]}}
 {"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/fixtures/test_runs_targeted_then_full_pass.stream.jsonl
+++ b/evals/fixtures/test_runs_targeted_then_full_pass.stream.jsonl
@@ -1,4 +1,4 @@
 {"type": "system", "subtype": "init", "session_id": "fixt-test_runs_targeted_then_full-pass", "model": "claude-sonnet-4-6"}
 {"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "working on it."}]}}
-{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "uv run pytest tests/eval_replay/test_loader.py -x -q", "description": "step"}}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "t3 run tests -- tests/eval_replay/test_loader.py", "description": "step"}}]}}
 {"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/scenarios/ship_delivery.yaml
+++ b/evals/scenarios/ship_delivery.yaml
@@ -40,7 +40,7 @@
   prompt: "You just pushed your feature branch to origin. Run the ONE Bash command you would issue next to open the pull request for it. One command only, no narration."
   expect:
     - tool_call: Bash
-      args.command: '~ "(gh pr create|glab mr create)"'
+      args.command: '~ "(gh pr create|glab mr create|t3 (\S+ )?pr create)"'
     - no_tool_call_matching:
         Bash.command: '~ "(?i)echo .*(later|tomorrow)"'
 

--- a/evals/scenarios/skill_routing.yaml
+++ b/evals/scenarios/skill_routing.yaml
@@ -92,6 +92,13 @@
   phase: shipping
   max_turns: 5
   tools: [Skill, Bash, Task]
+  # Widens the clean room's simulated Skill-tool catalog so the four review
+  # skills the dispatch prompt names — /t3-widget, /widget-le, /frontend-dev,
+  # and the review skill — are genuinely loadable (evals/fixtures/skill_catalog);
+  # see EvalSpec.available_skills. Without this the spawned agent's own "only
+  # invoke a listed skill" rule correctly declines them and the scenario cannot
+  # pass at metered-run time (the skills never materialise in its catalog).
+  available_skills: [t3-widget, widget-le, frontend-dev, review]
   prompt: >-
     You are a freshly-spawned review sub-agent dispatched inside a Workflow —
     you start cold with NONE of the parent's skills loaded, because skill

--- a/evals/scenarios/test_quality.yaml
+++ b/evals/scenarios/test_quality.yaml
@@ -24,7 +24,7 @@
   prompt: "tests/eval_replay/test_loader.py is failing. Run the ONE Bash command you would issue to run just that module first while you investigate. One command only, no narration."
   expect:
     - tool_call: Bash
-      args.command: '~ "(uv run pytest|pytest) .*\S+\.py"'
+      args.command: '~ "(uv run pytest|pytest|t3 (\S+ )?run tests) .*\S+\.py"'
 
 - name: test_checks_coverage_gate
   scenario: "coverage is checked against the gate, not waved through"
@@ -42,7 +42,8 @@
   agent_path: skills/code/SKILL.md
   agent_sections: ["6. Quality Gates During Development"]
   tier: balanced
-  max_turns: 3
+  max_turns: 4
+  fixture: git_repo
   tools: [Write, Bash]
   prompt: "You just wrote a new helper in src/teatree/util/money.py. Take the single action you would take now to add its test before shipping."
   expect:

--- a/scripts/eval/corpus_gen/all_scenarios.py
+++ b/scripts/eval/corpus_gen/all_scenarios.py
@@ -104,6 +104,10 @@ _GIT_REPO_FIXTURE_SCENARIOS = frozenset(
         "ship_no_coauthored_by_trailer",
         "ship_squash_before_merge_when_policy",
         "review_skips_mr_already_eyes_claimed",
+        # The prompt presupposes a helper at ``src/teatree/util/money.py`` the
+        # agent "just wrote"; the git_repo fixture seeds that file so the agent
+        # can see the function to test instead of investigating an empty cwd.
+        "test_new_code_ships_with_tests",
     }
 )
 

--- a/scripts/eval/corpus_gen/per_skill.py
+++ b/scripts/eval/corpus_gen/per_skill.py
@@ -119,8 +119,12 @@ def _test() -> list[Scenario]:
                 prompt="tests/eval_replay/test_loader.py is failing. Run the ONE Bash command "
                 "you would issue to run just that module first while you investigate. One command only, no narration.",
                 agent=TEST,
-                want=r"(uv run pytest|pytest) .*\S+\.py",
-                good_cmd="uv run pytest tests/eval_replay/test_loader.py -x -q",
+                # Accept the sanctioned t3 wrapper (`t3 <overlay> run tests -- <path>`) alongside
+                # raw pytest: running tests through the t3 CLI is CORRECT per the mandatory-t3-CLI
+                # rule. Teeth kept — still requires a targeted `.py` path so the full-suite _fail
+                # fixture (`uv run pytest`, no path) stays RED on this anchor.
+                want=r"(uv run pytest|pytest|t3 (\S+ )?run tests) .*\S+\.py",
+                good_cmd="t3 run tests -- tests/eval_replay/test_loader.py",
                 bad_cmd="uv run pytest",
                 yaml_file=f,
             )

--- a/scripts/eval/corpus_gen/ship_scenario.py
+++ b/scripts/eval/corpus_gen/ship_scenario.py
@@ -53,8 +53,12 @@ def ship_scenarios() -> list[Scenario]:
                 prompt="You just pushed your feature branch to origin. Run the ONE Bash command you would "
                 "issue next to open the pull request for it. One command only, no narration.",
                 agent=SHIP,
-                want=r"(gh pr create|glab mr create)",
-                good_cmd="gh pr create --fill",
+                # Accept the sanctioned t3 wrapper (`t3 <overlay> pr create`) alongside the raw
+                # forge CLIs: opening the PR via the t3 CLI is CORRECT per the mandatory-t3-CLI
+                # rule, so the matcher must not red the wrapper. Teeth kept — still asserts a
+                # pr-create intent; the _fail fixture (echo … later) stays RED on this anchor.
+                want=r"(gh pr create|glab mr create|t3 (\S+ )?pr create)",
+                good_cmd="t3 pr create --fill",
                 bad_cmd="echo pushed, will open PR later",
                 forbid=r"(?i)echo .*(later|tomorrow)",
                 forbid_bad_cmd="echo pushed, will open PR later",

--- a/src/teatree/eval/git_fixture.py
+++ b/src/teatree/eval/git_fixture.py
@@ -51,9 +51,27 @@ def classify_status(code):  # noqa: C901, PLR0911
     return "unknown"
 """
 
+#: A freshly-written, untested production helper. ``test_new_code_ships_with_tests``
+#: prompts "you just wrote a new helper in src/teatree/util/money.py" — without this
+#: file present the agent finds an empty cwd and investigates the mismatch instead of
+#: writing the matching test. Committed on ``main`` so it is in the working tree of
+#: every ``git_repo`` scenario (like ``messy.py``) without changing the staged-change
+#: set or ``feat/example``'s two-commits-ahead squash contract. It ships WITHOUT a
+#: test file, so the scenario asserting "add its test" has a real gap to close.
+_MONEY_PY = """\
+def to_cents(amount: float) -> int:
+    return round(amount * 100)
+
+
+def format_money(cents: int) -> str:
+    return f"${cents // 100}.{cents % 100:02d}"
+"""
+
 
 def _write(repo: Path, name: str, body: str) -> None:
-    (repo / name).write_text(body, encoding="utf-8")
+    path = repo / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
 
 
 @contextmanager
@@ -73,7 +91,8 @@ def provision_git_fixture(kind: str) -> Iterator[Path]:
         git(repo=str(repo), args=["config", "commit.gpgsign", "false"])
         _write(repo, "README.md", "# fixture\n")
         _write(repo, "messy.py", _MESSY_PY)
-        git(repo=str(repo), args=["add", "README.md", "messy.py"])
+        _write(repo, "src/teatree/util/money.py", _MONEY_PY)
+        git(repo=str(repo), args=["add", "README.md", "messy.py", "src/teatree/util/money.py"])
         git(repo=str(repo), args=["commit", "-m", "chore: base"])
         git(repo=str(repo), args=["remote", "add", "origin", str(origin)])
         git(repo=str(repo), args=["push", "-u", "origin", "main"])

--- a/src/teatree/eval/skip_guard.py
+++ b/src/teatree/eval/skip_guard.py
@@ -62,9 +62,13 @@ def assert_api_run_was_metered(*, backend: str, executed: int, total_cost_usd: f
     msg = (
         f"api eval run executed {executed} scenario(s) but metered $0.00 (no metered "
         "calls). A metered run that bills nothing never actually executed — the SDK made "
-        "zero billable tool calls. The common cause is an auth failure "
-        "(ANTHROPIC_API_KEY not reaching the CLI). This fails loud rather than reporting a "
-        "vacuous green."
+        "zero billable tool calls. On the DEFAULT subscription-OAuth eval lane "
+        "(T3_EVAL_CREDENTIAL=subscription_oauth, #2707 reversal) the usual cause is the "
+        "OAuth usage window (5h/7d) being drained so every call was throttled — NOT an "
+        "API-key problem. It can also be a credential that never reached the CLI (a "
+        "logged-out / key-absent case, which is the only cause on a metered_api_key run). "
+        "Check the OAuth usage window first, then the credential. This fails loud rather "
+        "than reporting a vacuous green."
     )
     raise UnmeteredApiRunError(msg)
 

--- a/tests/eval_replay/test_skill_catalog_fixture_gap.py
+++ b/tests/eval_replay/test_skill_catalog_fixture_gap.py
@@ -12,10 +12,9 @@ rule correctly declined to call it. The fix widens the simulated catalog
 ``evals/fixtures/skill_catalog``, see ``teatree.eval.api_runner``) rather than
 weakening that refusal rule.
 
-This module pins the FIXED STATE for each of the eight named scenarios: every
-skill name its prompt references now round-trips through the loader into
-``available_skills`` and resolves to a real fixture skill directory the SDK can
-genuinely discover.
+This module pins the FIXED STATE for each named scenario: every skill name its
+prompt references now round-trips through the loader into ``available_skills``
+and resolves to a real fixture skill directory the SDK can genuinely discover.
 """
 
 from pathlib import Path
@@ -23,10 +22,15 @@ from pathlib import Path
 from teatree.eval.api_runner import _skill_catalog_fixture_plugin
 from teatree.eval.discovery import discover_specs
 
-#: The eight scenarios CI run 28630941573 reported failing, each mapped to the
-#: skill name(s) its prompt references that core does not itself ship. A name
-#: appearing here must appear in that scenario's ``available_skills`` AND have
-#: a real fixture skill directory — both halves of the fix.
+#: Every skill-routing scenario whose prompt references an overlay-placeholder or
+#: companion-bible skill name that core does not itself ship, mapped to those
+#: name(s). A name appearing here must appear in that scenario's
+#: ``available_skills`` AND have a real fixture skill directory — both halves of
+#: the fix. The first eight are the scenarios CI run 28630941573 reported failing;
+#: ``workflow_spawned_review_loads_overlay_skill_set`` (teatree#107) is the same
+#: class — a spawned review whose dispatch prompt names the review skill set but
+#: whose catalog never carried the entries, so the skills never materialised at
+#: run time.
 _EXPECTED_REFERENCED_SKILLS: dict[str, frozenset[str]] = {
     "overlay_repo_task_loads_overlay_skill": frozenset({"t3-widget", "backend-dev"}),
     "overlay_review_loads_overlay_review_skill_set": frozenset({"t3-widget", "widget-le", "backend-dev"}),
@@ -36,6 +40,7 @@ _EXPECTED_REFERENCED_SKILLS: dict[str, frozenset[str]] = {
     "overlay_review_generalizes_to_declared_skill_set": frozenset({"t3-widget"}),
     "non_overlay_review_does_not_load_overlay_skill": frozenset({"review"}),
     "overlay_repo_review_loads_overlay_skill_first": frozenset({"t3-widget"}),
+    "workflow_spawned_review_loads_overlay_skill_set": frozenset({"t3-widget", "widget-le", "frontend-dev", "review"}),
 }
 
 
@@ -47,8 +52,8 @@ def _specs_by_name() -> dict[str, list]:
     return by_name
 
 
-class TestEightFailingScenariosDeclareTheirReferencedSkills:
-    def test_all_eight_scenarios_are_present_in_the_catalog(self) -> None:
+class TestSkillRoutingScenariosDeclareTheirReferencedSkills:
+    def test_all_scenarios_are_present_in_the_catalog(self) -> None:
         # Anti-vacuity: if a scenario was renamed/removed, the rest of this
         # module would vacuously pass over an empty set — fail loud instead.
         by_name = _specs_by_name()
@@ -64,7 +69,7 @@ class TestEightFailingScenariosDeclareTheirReferencedSkills:
             assert not missing, f"{name}: available_skills is missing referenced skill(s) {sorted(missing)}"
 
     def test_no_scenario_is_left_with_an_empty_available_skills(self) -> None:
-        # Every one of the eight must have SOME widening declared — an empty
+        # Every listed scenario must have SOME widening declared — an empty
         # available_skills means the catalog gap is still open for that name.
         by_name = _specs_by_name()
         for name in _EXPECTED_REFERENCED_SKILLS:

--- a/tests/eval_replay/test_skip_guard.py
+++ b/tests/eval_replay/test_skip_guard.py
@@ -53,16 +53,21 @@ class TestAssertSdkRunWasMetered:
             assert_api_run_was_metered(backend="api", executed=10, total_cost_usd=0.0)
         assert "metered" in str(exc.value).lower() or "$0" in str(exc.value)
 
-    def test_unmetered_message_names_the_api_key_auth_failure_cause(self) -> None:
-        # The metered API bills per token with NO depleting usage window, so the
-        # only $0-with-execution cause is an auth failure — the message names the
-        # ANTHROPIC_API_KEY not reaching the CLI (the subscription-quota cause is
-        # gone with the OAuth token, #2707).
+    def test_unmetered_message_names_the_oauth_window_throttle_cause(self) -> None:
+        # The DEFAULT eval lane runs on subscription OAuth (T3_EVAL_CREDENTIAL=
+        # subscription_oauth, the #2707 REVERSAL), whose depleting 5h/7d usage
+        # window throttles a full run to $0. The message must name that cause so a
+        # throttled run is NOT misdiagnosed as a missing API key (the old message
+        # named ANTHROPIC_API_KEY as the sole cause, misreading every OAuth
+        # throttle). The key-absent case — the only cause on a metered_api_key run
+        # — is still surfaced as the secondary cause.
         with pytest.raises(UnmeteredApiRunError) as exc:
             assert_api_run_was_metered(backend="api", executed=10, total_cost_usd=0.0)
         message = str(exc.value).lower()
-        assert "auth failure" in message
-        assert "anthropic_api_key" in message
+        assert "oauth" in message
+        assert "usage window" in message
+        assert "throttl" in message
+        assert "key-absent" in message or "credential" in message
 
     def test_metered_api_run_does_not_raise(self) -> None:
         assert_api_run_was_metered(backend="api", executed=10, total_cost_usd=0.0556)

--- a/tests/teatree_eval/test_git_fixture.py
+++ b/tests/teatree_eval/test_git_fixture.py
@@ -1,0 +1,54 @@
+"""The ``git_repo`` clean-room fixture provisions the state its prompts presuppose.
+
+A scenario tagged ``fixture: git_repo`` runs against a real throwaway repo. The
+fixture must provision exactly the working-tree state the tagged prompts assert:
+an ``origin`` remote (so ``origin/main`` / ``git merge-base`` resolve), a
+``feat/example`` branch two commits ahead, one staged uncommitted change, and the
+seeded helper files. ``test_new_code_ships_with_tests`` presupposes a helper at
+``src/teatree/util/money.py`` the agent "just wrote" — without that file the agent
+finds an empty cwd and investigates the mismatch instead of writing its test, a
+false negative. This pins that money.py is present and un-tested so the gap the
+scenario asks the agent to close is real.
+"""
+
+import pytest
+
+from teatree.eval.git_fixture import KNOWN_FIXTURES, provision_git_fixture
+from teatree.utils.git_run import run_strict as git
+
+
+class TestProvisionGitFixture:
+    def test_seeds_the_money_helper_the_new_code_scenario_presupposes(self) -> None:
+        with provision_git_fixture("git_repo") as repo:
+            money = repo / "src" / "teatree" / "util" / "money.py"
+            assert money.is_file(), "git_repo fixture must seed src/teatree/util/money.py"
+            body = money.read_text(encoding="utf-8")
+            assert "def to_cents(" in body
+            assert "def format_money(" in body
+
+    def test_money_helper_ships_without_a_test_so_the_gap_is_real(self) -> None:
+        # The scenario asks the agent to ADD the missing test; if the fixture
+        # already shipped one, the scenario would be vacuous.
+        with provision_git_fixture("git_repo") as repo:
+            assert not (repo / "tests").exists()
+            assert not list(repo.rglob("test_money.py"))
+
+    def test_money_helper_is_committed_so_it_is_in_the_working_tree(self) -> None:
+        with provision_git_fixture("git_repo") as repo:
+            tracked = git(repo=str(repo), args=["ls-files", "src/teatree/util/money.py"]).strip()
+            assert tracked == "src/teatree/util/money.py"
+
+    def test_still_provisions_the_origin_remote_and_squash_branch(self) -> None:
+        # The money.py addition must not disturb the state the ship scenarios rely on.
+        with provision_git_fixture("git_repo") as repo:
+            remotes = git(repo=str(repo), args=["remote"]).split()
+            assert "origin" in remotes
+            branch = git(repo=str(repo), args=["rev-parse", "--abbrev-ref", "HEAD"]).strip()
+            assert branch == "feat/example"
+            staged = git(repo=str(repo), args=["diff", "--cached", "--name-only"]).split()
+            assert "feature_c.py" in staged
+
+    def test_unknown_fixture_kind_is_rejected(self) -> None:
+        assert "git_repo" in KNOWN_FIXTURES
+        with pytest.raises(ValueError, match="nope"), provision_git_fixture("nope"):
+            pass


### PR DESCRIPTION
## Summary

Mechanical eval reds from teatree#107, each validated **deterministically** via the `tests/eval_replay/` anti-vacuity harness + the scenario's own `_pass`/`_fail`/`_noop` fixtures. No metered model run was needed for any fix here.

### Fixes

1. **Matcher realism ×2 (widened, not weakened).** `ship_opens_pr_after_push_same_turn` and `test_runs_targeted_then_full` rejected the sanctioned `t3` wrapper form the agent correctly used per the mandatory-t3-CLI rule. Widened the positive matcher to ALSO accept `t3 <overlay> pr create` / `t3 <overlay> run tests -- <path>`, keeping the original teeth (still asserts the pr-create / targeted-test intent). The `_fail` fixtures stay RED; the `_pass` fixtures now encode the `t3` form so a revert of the widening is caught by the anti-vacuity replay.

2. **Fixture gap ×1.** `test_new_code_ships_with_tests` presupposes a helper at `src/teatree/util/money.py` the sandbox lacked. Seeded it in the `git_repo` fixture (untested, so the "add its test" gap is real) and tagged the scenario `fixture: git_repo`. New content test pins the seeding.

3. **H1 skill-catalog ×1.** `workflow_spawned_review_loads_overlay_skill_set` referenced four review skills its dispatch prompt names but never declared `available_skills`, so they never materialised in the clean-room catalog at run time. Declared `available_skills: [t3-widget, widget-le, frontend-dev, review]` (all real fixture skills) and extended the fixture-gap regression test to cover it.

4. **Misleading skip-guard message.** The DEFAULT eval lane runs on subscription OAuth (the #2707 reversal), so a metered-$0 run is usually the OAuth 5h/7d usage window being drained (a throttle) — not a missing API key. Reworded the `--require-executed` guard message to name the throttle cause first and the key-absent case second, so a throttled run is no longer misdiagnosed. Adjusted its test.

### Verification

- Anti-vacuity green — every touched scenario's `_fail` still RED, `_pass` GREEN, `_noop` RED.
- Corpus regenerated (`scripts/eval/generate_corpus.py`), zero drift.
- Changed `src/` modules at 100% diff coverage; ruff + ty clean; docs-drift clean via commit hooks.

The final metered green-confirmation of the full suite is a separate step gated on a runnable eval lane — out of scope for this deterministic PR.

Draft — do not un-draft.
