### PR TITLE
fix(config): fail loud when a DB registry row silently overrides the TOML (#128)

### DIFF
--- a/docs/generated/management-commands.json
+++ b/docs/generated/management-commands.json
@@ -61,6 +61,10 @@
           "name": "export"
         },
         {
+          "help": "Surgically set ONE field of ONE overlay in the DB-home ``overlays`` registry",
+          "name": "set-overlay"
+        },
+        {
           "help": "List every DB config override row, naming each row's scope (read-only)",
           "name": "list"
         },

--- a/docs/generated/management-commands.md
+++ b/docs/generated/management-commands.md
@@ -32,6 +32,7 @@ Edit the source command, not this file.
 | `flags` | The read-only dead-toggle audit report over the ``FEATURE_FLAGS`` registry |
 | `get` | Print the resolved value for *key* and name its source (DB vs file/env) |
 | `export` | Dump the ``ConfigSetting`` store to TOML — the inverse of ``import`` |
+| `set-overlay` | Surgically set ONE field of ONE overlay in the DB-home ``overlays`` registry |
 | `list` | List every DB config override row, naming each row's scope (read-only) |
 | `import` | Seed the DB store from the operational toml keys (one-time migration) |
 

--- a/src/teatree/config/loader.py
+++ b/src/teatree/config/loader.py
@@ -26,7 +26,7 @@ import os
 import tomllib
 from contextlib import suppress
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import teatree.config as _facade
 from teatree.config.settings import E2ERepo, TeaTreeConfig, UserSettings
@@ -302,6 +302,81 @@ def _warn_db_home_keys_in_toml(raw: dict, path: Path) -> None:
 # table is the migration fallback.
 
 
+def _registry_conflicts(toml_table: dict[str, Any], db_registry: dict[str, Any], key: str) -> list[str]:
+    """The ``[<key>.<entry>] <field>`` leaves where the TOML value is silently ignored.
+
+    ``_inject_db_registries`` REPLACES ``raw[key]`` wholesale with the DB registry row,
+    so any TOML entry/field that DIFFERS from — or is ABSENT in — that row is silently
+    dropped on read (the file value never reaches a reader). This enumerates each such
+    leaf so the operator sees exactly which edit had no effect. A whole TOML entry the
+    DB row does not define reports as ``[<key>.<entry>]`` (the entry is dropped); a field
+    present in the TOML entry but absent from the DB entry, or set to a DIFFERENT value,
+    reports as ``[<key>.<entry>] <field>`` (the reported ``path`` case).
+
+    A TOML entry/field that AGREES with the DB row is silent — it resolves to the same
+    effective value, so warning about it would be the noise this stays clear of.
+    """
+    conflicts: list[str] = []
+    for entry_name, toml_entry in toml_table.items():
+        if not isinstance(toml_entry, dict):
+            continue
+        db_entry = db_registry.get(entry_name)
+        if not isinstance(db_entry, dict):
+            conflicts.append(f"[{key}.{entry_name}]")
+            continue
+        conflicts.extend(
+            f"[{key}.{entry_name}] {field}"
+            for field, toml_val in toml_entry.items()
+            if field not in db_entry or db_entry[field] != toml_val
+        )
+    return conflicts
+
+
+def _warn_registry_conflicts_in_toml(raw: dict, path: Path) -> None:
+    """Emit ONE aggregated WARN when a TOML registry value is silently ignored (#1775).
+
+    The ``overlays`` / ``e2e_repos`` registries are DB-home: ``_inject_db_registries``
+    REPLACES the whole TOML ``[overlays]`` / ``[e2e_repos]`` table with its
+    ``ConfigSetting`` row when one exists, so editing an overlay ``path`` in the file
+    has NO effect — and, unlike a DB-home ``UserSettings`` key
+    (:func:`_warn_db_home_keys_in_toml`), it produced ZERO signal, silently returning
+    the stale DB value (souliane/teatree#128). This is the registry twin of that
+    warning: on a genuine divergence between the file table and the authoritative DB
+    row it names each silently-ignored leaf and the surgical reconcile command, so a
+    stale overlay path can never be returned without surfacing it.
+
+    Must run BEFORE :func:`_inject_db_registries` (while ``raw[key]`` still holds the
+    TOML table); the DB row is read independently via the Django-free ``cold_reader``
+    (the same store the injection reads), so a not-yet-migrated install with no DB row
+    is silent — the file table is then the authoritative fallback, not a conflict.
+    """
+    from teatree.config import cold_reader  # noqa: PLC0415 — Django-free DB read on the pre-Django discovery path
+    from teatree.config.registries import REGISTRY_KEYS  # noqa: PLC0415 — deferred to avoid the config import cycle
+
+    offenders: list[str] = []
+    for key in REGISTRY_KEYS:
+        toml_table = raw.get(key)
+        if not isinstance(toml_table, dict) or not toml_table:
+            continue
+        db_registry = cold_reader.read_setting(key)
+        if not isinstance(db_registry, dict):
+            continue  # no DB row → the TOML table IS the authoritative fallback, no conflict
+        offenders.extend(_registry_conflicts(toml_table, cast("dict[str, Any]", db_registry), key))
+
+    if offenders:
+        _logger.warning(
+            "Registry values in %s are DB-home (#1775) and IGNORED on read — the "
+            "ConfigSetting `overlays`/`e2e_repos` row replaces the whole file table, so these "
+            "edits have NO effect: %s. The DB row is authoritative; reconcile a single field "
+            "surgically (no clobber) with "
+            "`t3 <overlay> config_setting set-overlay <name> <field> '<json-value>'` "
+            "(e.g. point an overlay at its canonical clone path), or re-seed every registry "
+            "field from this file with `t3 <overlay> config_setting import`.",
+            path,
+            ", ".join(offenders),
+        )
+
+
 def _inject_db_registries(raw: dict) -> None:
     """Override ``raw['overlays']`` / ``raw['e2e_repos']`` with their DB rows when present.
 
@@ -336,6 +411,10 @@ def load_config(path: Path | None = None) -> TeaTreeConfig:
         _warn_db_home_keys_in_toml(raw, path)
         _warn_retired_keys_in_toml(raw, path)
         _warn_migrated_keys_in_toml(raw, path)
+        # BEFORE the injection below overwrites the TOML registry tables — while
+        # ``raw['overlays']`` / ``raw['e2e_repos']`` still hold the FILE values — so a
+        # divergence with the authoritative DB row is surfaced, never silently dropped.
+        _warn_registry_conflicts_in_toml(raw, path)
     _inject_db_registries(raw)
     return TeaTreeConfig(user=UserSettings(), raw=raw)
 

--- a/src/teatree/core/management/commands/config_setting.py
+++ b/src/teatree/core/management/commands/config_setting.py
@@ -25,7 +25,7 @@ Non-zero exits use ``raise SystemExit(N)`` — this runs under Django's
 
 import json
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
 from django_typer.management import TyperCommand, command
@@ -107,6 +107,45 @@ class Command(TyperCommand):
         # Verify-by-re-read: report the stored value the resolver will now see.
         stored = ConfigSetting.objects.get_effective(key, scope=overlay)
         self.stdout.write(f"  set {key} = {stored!r}  [{_scope_label(overlay)}]{_flag_suffix(key)}")
+
+    @command(name="set-overlay")
+    def set_overlay(
+        self,
+        name: Annotated[str, typer.Argument(help="Overlay name whose registry definition to update, e.g. my-overlay.")],
+        key: Annotated[str, typer.Argument(help="Definition field to set, e.g. path or class.")],
+        value: Annotated[str, typer.Argument(help="JSON value, e.g. '\"~/workspace/canonical\"'.")],
+    ) -> None:
+        """Surgically set ONE field of ONE overlay in the DB-home ``overlays`` registry.
+
+        A read-modify-write on the single JSON ``overlays`` ``ConfigSetting`` row (always
+        the GLOBAL scope — the one ``loader._inject_db_registries`` reads): it updates
+        ``overlays[<name>][<key>]`` and leaves every OTHER overlay and every OTHER field
+        of ``<name>`` untouched. This is the NO-CLOBBER way to fix a stale overlay clone
+        ``path`` — never hand-write the whole registry dict with ``set overlays '<json>'``.
+        The DB registry row is authoritative over the ``[overlays.<name>]`` TOML table
+        (#1775), so this is the sanctioned way to change a value that editing the file can
+        no longer affect (souliane/teatree#128). ``value`` is parsed as JSON, so a path is
+        a QUOTED string, e.g. ``'"~/workspace/canonical"'``.
+        """
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError as exc:
+            self.stderr.write(f"  invalid JSON value for overlays.{name}.{key}: {exc}")
+            raise SystemExit(2) from exc
+        current = ConfigSetting.objects.get_effective("overlays")
+        registry: dict[str, Any] = dict(current) if isinstance(current, dict) else {}
+        entry = registry.get(name)
+        updated_entry: dict[str, Any] = dict(entry) if isinstance(entry, dict) else {}
+        updated_entry[key] = parsed
+        registry[name] = updated_entry
+        # Validate through the SAME registry parser the resolver applies on read (mirrors
+        # ``set`` above), so a malformed registry dict can never be stored.
+        canonical = REGISTRY_SETTINGS["overlays"](registry)
+        ConfigSetting.objects.set_value("overlays", canonical)
+        # Verify-by-re-read: report the value the resolver will now see for this leaf.
+        stored = ConfigSetting.objects.get_effective("overlays")
+        effective = stored[name][key] if isinstance(stored, dict) and isinstance(stored.get(name), dict) else parsed
+        self.stdout.write(f"  set overlays.{name}.{key} = {effective!r}  [{_scope_label('')}]")
 
     @command()
     def clear(

--- a/tests/config/test_registries_db.py
+++ b/tests/config/test_registries_db.py
@@ -118,3 +118,86 @@ def test_load_config_no_toml_no_db_is_empty(tmp_path: Path, monkeypatch: pytest.
 
     assert "overlays" not in config.raw
     assert "e2e_repos" not in config.raw
+
+
+def _load_and_collect_ignored(config_path: Path, caplog: pytest.LogCaptureFixture) -> tuple[object, list[str]]:
+    """Run ``load_config`` and return the config plus every 'ignored on read' WARN line."""
+    with caplog.at_level("WARNING", logger="teatree.config"):
+        config = load_config(config_path)
+    warnings = [r.getMessage() for r in caplog.records if "ignored on read" in r.getMessage().lower()]
+    return config, warnings
+
+
+def test_toml_overlay_path_conflicting_with_db_registry_warns_loud(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # souliane/teatree#128 (the reported bug, anti-vacuous repro): the DB-home
+    # ``overlays`` registry row silently REPLACES the whole ``[overlays]`` TOML table, so
+    # a ``path`` edit in the file has NO effect. Before the fix this returned the stale DB
+    # path with ZERO signal — the exact silent-stale-return that blocked provisioning.
+    # After the fix the divergence is surfaced LOUD, naming the ignored field and the
+    # surgical reconcile command; the DB stays authoritative but is never returned silently.
+    config_path = tmp_path / ".teatree.toml"
+    _write_toml(config_path, '[overlays.myoverlay]\npath = "~/workspace/canonical"\n')
+    db = tmp_path / "db.sqlite3"
+    _seed_registry_db(db, overlays={"myoverlay": {"path": "~/workspace/stale-worktree"}})
+    monkeypatch.setenv("T3_CONFIG_DB", str(db))
+
+    config, warnings = _load_and_collect_ignored(config_path, caplog)
+
+    # The DB row is still authoritative — but no longer SILENTLY: the divergence is loud.
+    assert config.raw["overlays"]["myoverlay"]["path"] == "~/workspace/stale-worktree"
+    assert len(warnings) == 1
+    assert "myoverlay" in warnings[0]
+    assert "path" in warnings[0]
+    assert "config_setting set-overlay" in warnings[0]
+
+
+def test_toml_overlay_agreeing_with_db_registry_is_silent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # No divergence: the file value equals the effective DB value, so it resolves to the
+    # same thing — warning would be pure noise. Stays silent.
+    config_path = tmp_path / ".teatree.toml"
+    _write_toml(config_path, '[overlays.myoverlay]\npath = "~/workspace/same"\n')
+    db = tmp_path / "db.sqlite3"
+    _seed_registry_db(db, overlays={"myoverlay": {"path": "~/workspace/same"}})
+    monkeypatch.setenv("T3_CONFIG_DB", str(db))
+
+    _config, warnings = _load_and_collect_ignored(config_path, caplog)
+
+    assert warnings == []
+
+
+def test_toml_overlay_without_db_registry_row_is_silent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # The pre-migration fallback: with NO DB registry row the TOML table IS the
+    # authoritative source (``_inject_db_registries`` leaves it in place), so there is no
+    # conflict and nothing to warn about.
+    config_path = tmp_path / ".teatree.toml"
+    _write_toml(config_path, '[overlays.myoverlay]\npath = "~/workspace/from-file"\n')
+    monkeypatch.setenv("T3_CONFIG_DB", str(tmp_path / "absent.sqlite3"))
+
+    config, warnings = _load_and_collect_ignored(config_path, caplog)
+
+    assert config.raw["overlays"]["myoverlay"]["path"] == "~/workspace/from-file"
+    assert warnings == []
+
+
+def test_toml_overlay_entry_absent_from_db_registry_warns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # A whole ``[overlays.<name>]`` table the DB row does not define is dropped on read
+    # (the DB row replaces the file table wholesale) — surfaced so a would-be-registered
+    # overlay is never silently invisible.
+    config_path = tmp_path / ".teatree.toml"
+    _write_toml(config_path, '[overlays.only-in-file]\npath = "~/p"\n')
+    db = tmp_path / "db.sqlite3"
+    _seed_registry_db(db, overlays={"other": {"path": "~/other"}})
+    monkeypatch.setenv("T3_CONFIG_DB", str(db))
+
+    _config, warnings = _load_and_collect_ignored(config_path, caplog)
+
+    assert len(warnings) == 1
+    assert "only-in-file" in warnings[0]

--- a/tests/teatree_core/management/test_config_setting_command.py
+++ b/tests/teatree_core/management/test_config_setting_command.py
@@ -140,6 +140,55 @@ class TestConfigSettingSet(TestCase):
         assert get_effective_settings().mode is Mode.AUTO
 
 
+class TestConfigSettingSetOverlay(TestCase):
+    """``set-overlay`` — surgical no-clobber update of one overlay's registry field (#128).
+
+    The sanctioned way to fix a stale overlay clone ``path`` in the DB-home ``overlays``
+    registry without hand-rewriting (clobbering) the whole JSON dict: a read-modify-write
+    that touches exactly ``overlays[<name>][<field>]``.
+    """
+
+    def test_set_overlay_path_updates_only_that_field(self) -> None:
+        # The reported bug's remedy (souliane/teatree#128): repoint one overlay's path
+        # and leave every sibling field AND every other overlay untouched.
+        ConfigSetting.objects.set_value(
+            "overlays",
+            {
+                "my-overlay": {"path": "~/workspace/stale-worktree", "workspace_repos": ["a/b"]},
+                "other": {"path": "~/other"},
+            },
+        )
+        call_command("config_setting", "set-overlay", "my-overlay", "path", '"~/workspace/canonical"')
+        registry = ConfigSetting.objects.get_effective("overlays")
+        assert registry["my-overlay"]["path"] == "~/workspace/canonical"
+        # No clobber: the same overlay's other fields and every other overlay survive.
+        assert registry["my-overlay"]["workspace_repos"] == ["a/b"]
+        assert registry["other"] == {"path": "~/other"}
+
+    def test_set_overlay_creates_registry_row_when_absent(self) -> None:
+        assert ConfigSetting.objects.filter(key="overlays").exists() is False
+        call_command("config_setting", "set-overlay", "newov", "path", '"~/p"')
+        assert ConfigSetting.objects.get_effective("overlays") == {"newov": {"path": "~/p"}}
+
+    def test_set_overlay_adds_field_to_existing_overlay(self) -> None:
+        ConfigSetting.objects.set_value("overlays", {"ov": {"path": "~/p"}})
+        call_command("config_setting", "set-overlay", "ov", "class", '"pkg.settings"')
+        assert ConfigSetting.objects.get_effective("overlays")["ov"] == {"path": "~/p", "class": "pkg.settings"}
+
+    def test_set_overlay_rejects_invalid_json_and_leaves_store_untouched(self) -> None:
+        ConfigSetting.objects.set_value("overlays", {"ov": {"path": "~/p"}})
+        with pytest.raises(SystemExit):
+            call_command("config_setting", "set-overlay", "ov", "path", "not-json", stderr=StringIO())
+        assert ConfigSetting.objects.get_effective("overlays") == {"ov": {"path": "~/p"}}
+
+    def test_set_overlay_reports_the_new_value(self) -> None:
+        out = StringIO()
+        call_command("config_setting", "set-overlay", "ov", "path", '"~/canonical"', stdout=out)
+        rendered = out.getvalue()
+        assert "overlays.ov.path" in rendered
+        assert "~/canonical" in rendered
+
+
 class TestConfigSettingClear(TestCase):
     def test_clear_removes_row(self) -> None:
         ConfigSetting.objects.set_value("issue_implementer_enabled", value=True)


### PR DESCRIPTION
## Summary

Fixes #128. Editing `[overlays.<name>].path` in `~/.teatree.toml` had **no effect** and returned a **stale** overlay clone path with **zero signal**, which is the real root of the reported provisioning block (a stale worktree path pinned in the DB → `t3 <overlay>` crashes at overlay import).

### Root cause

The `overlays` / `e2e_repos` config tables are **DB-home** (#1775 eliminate-`~/.teatree.toml`). `teatree.config.loader._inject_db_registries` reads the `overlays` `ConfigSetting` row and **replaces the whole `[overlays]` TOML table** with it:

```python
for key in REGISTRY_KEYS:
    stored = cold_reader.read_setting(key)
    if isinstance(stored, dict):
        raw[key] = stored   # ← DB row wins, TOML edit silently dropped
```

So a `path` edit in the file never reaches `discovery.discover_overlays` (which reads `raw["overlays"][name]["path"]`). Unlike a DB-home `UserSettings` key — which gets `_warn_db_home_keys_in_toml` on a conflict — the **registry** override was **completely silent**: the stale DB `path` was returned with no warning.

### Fix

The DB stays authoritative (consistent with the #1775 partition), but the override is no longer silent, and there is now a **surgical, no-clobber** way to reconcile it:

- `load_config` emits **one aggregated WARN** (`_warn_registry_conflicts_in_toml`) naming each TOML registry leaf that diverges from the authoritative DB row, plus the exact reconcile command. An agreeing value, or a not-yet-migrated install with no DB row, stays silent (no noise).
- New `t3 <overlay> config_setting set-overlay <name> <field> <value>` — a read-modify-write on **one** field of **one** overlay in the `overlays` registry row, leaving every other overlay and every sibling field untouched (never hand-rewrite the whole dict).

### Tests (anti-vacuous, RED-before / GREEN-after)

- `tests/config/test_registries_db.py` — the reported bug's repro: TOML says A, DB says B → `load_config` no longer returns B **silently** (loud WARN naming the leaf + reconcile command). Observed RED without the fix (`assert 0 == 1`, no warning), GREEN with it. Plus silent-on-agreement and silent-without-a-DB-row guards.
- `tests/teatree_core/management/test_config_setting_command.py` — `set-overlay` updates one field surgically, preserves siblings/other overlays, creates the row when absent, rejects invalid JSON.

### Gates

Full config/overlay/migration suites green; ruff, ty, tach, module-health, `makemigrations --check`, test-path-mirror all clean.
