### PR TITLE
feat(cli): t3 checking show --notify — tabular recap DM via Block Kit table (#2966)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -7721,6 +7721,8 @@ Usage: t3 teatree checking show [OPTIONS]
 │                             last-checked marker.                             │
 │ --this-overlay              Scope to the current overlay only (default:      │
 │                             aggregate all configured overlays).              │
+│ --notify                    Also DM the recap to you as a Slack table        │
+│                             (native Block Kit + monospace fence fallback).   │
 │ --help                      Show this message and exit.                      │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```

--- a/src/teatree/core/management/commands/checking.py
+++ b/src/teatree/core/management/commands/checking.py
@@ -18,9 +18,11 @@ output channel (``django-typer`` serialises it) — JSON when ``--json``, else
 the terse human view.
 """
 
+import hashlib
 import io
 import json
 import os
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Annotated
 
@@ -28,10 +30,23 @@ import typer
 from django.utils import timezone
 from django_typer.management import TyperCommand, command, initialize
 
+from teatree.backends.slack.table_format import render_table_message
 from teatree.core.checking import DEFAULT_CAP, CheckGroup, gather_all_overlays_report, gather_checking_report
 from teatree.core.checkpoint import advance_checkpoint_monotonic, checkpoint_path, resolve_window_start
+from teatree.core.notify import NotifyKind, notify_user
 from teatree.core.ref_render import render_ref
 from teatree.core.table_output import print_table
+from teatree.types import RawAPIDict
+
+
+@dataclass(frozen=True, slots=True)
+class _ShowFlags:
+    """The ``checking show`` window/output/side-effect flags, bundled to keep the dispatch narrow."""
+
+    since: str
+    json_output: bool
+    no_advance: bool
+    notify: bool
 
 
 def _stamp(when: datetime) -> str:
@@ -63,6 +78,45 @@ def _render_groups_tables(groups: list[CheckGroup], *, header: str, stamp: str, 
     return buffer.getvalue()
 
 
+def _recap_table_dm(groups: list[CheckGroup], *, header: str, cap: int = DEFAULT_CAP) -> tuple[list[RawAPIDict], str]:
+    """Render the non-empty recap groups as native ``table`` blocks + a fence.
+
+    Each group becomes a titled :func:`render_table_message` — the native
+    Block Kit ``table`` block for a rich rendering plus the monospace fence for
+    the ``text`` degradation path. Returns ``([], "")`` when every group is
+    empty so the caller skips the DM (an empty recap never pings).
+    """
+    blocks: list[RawAPIDict] = []
+    fences: list[str] = []
+    for group in groups:
+        if group.total == 0:
+            continue
+        rows = [[item.label, item.title, item.detail] for item in group.items[:cap]]
+        message = render_table_message(["Ref", "Title", "Detail"], rows, title=f"{group.title} ({group.total})")
+        blocks.extend(message.blocks)
+        fences.append(message.fence)
+    if not blocks:
+        return [], ""
+    return blocks, f"{header}\n" + "\n".join(fences)
+
+
+def _recap_key(groups: list[CheckGroup], *, scope: str) -> str:
+    """Content-hashed idempotency key so an unchanged recap never re-DMs."""
+    payload = "\n".join(f"{group.title}|{item.label}|{item.detail}" for group in groups for item in group.items)
+    digest = hashlib.sha256(payload.encode()).hexdigest()[:16]
+    return f"checking_recap:{scope}:{digest}"
+
+
+def _maybe_notify_recap(groups: list[CheckGroup], *, header: str, scope: str, notify: bool) -> None:
+    """DM the recap through the real bot→user egress when ``--notify`` is set (#2966)."""
+    if not notify:
+        return
+    blocks, fence = _recap_table_dm(groups, header=header)
+    if not blocks:
+        return
+    notify_user(fence, kind=NotifyKind.INFO, idempotency_key=_recap_key(groups, scope=scope), blocks=blocks)
+
+
 class Command(TyperCommand):
     @initialize()
     def init(self) -> None:
@@ -91,6 +145,13 @@ class Command(TyperCommand):
                 help="Scope to the current overlay only (default: aggregate all configured overlays).",
             ),
         ] = False,
+        notify: Annotated[
+            bool,
+            typer.Option(
+                "--notify",
+                help="Also DM the recap to you as a Slack table (native Block Kit + monospace fence fallback).",
+            ),
+        ] = False,
     ) -> str:
         """Print a terse, grouped, clickable report of changes since the last check."""
         overlay_name = os.environ.get("T3_OVERLAY_NAME", "")
@@ -98,32 +159,14 @@ class Command(TyperCommand):
 
         _validate_since(since)
 
+        flags = _ShowFlags(since=since, json_output=json_output, no_advance=no_advance, notify=notify)
         if this_overlay:
-            return self._show_single_overlay(
-                overlay_name=overlay_name,
-                now=now,
-                since=since,
-                json_output=json_output,
-                no_advance=no_advance,
-            )
-        return self._show_all_overlays(
-            now=now,
-            since=since,
-            json_output=json_output,
-            no_advance=no_advance,
-        )
+            return self._show_single_overlay(overlay_name=overlay_name, now=now, flags=flags)
+        return self._show_all_overlays(now=now, flags=flags)
 
-    def _show_single_overlay(
-        self,
-        *,
-        overlay_name: str,
-        now: datetime,
-        since: str,
-        json_output: bool,
-        no_advance: bool,
-    ) -> str:
+    def _show_single_overlay(self, *, overlay_name: str, now: datetime, flags: _ShowFlags) -> str:
         """Single-overlay path (``--this-overlay`` or backward-compat)."""
-        window_start = resolve_window_start(since=since, now=now)
+        window_start = resolve_window_start(since=flags.since, now=now)
         report = gather_checking_report(
             since=window_start,
             now=now,
@@ -131,26 +174,17 @@ class Command(TyperCommand):
             code_host=self._resolve_code_host(),
             overlay_repos=self._resolve_overlay_repos(),
         )
-        if not since and not no_advance:
+        if not flags.since and not flags.no_advance:
             advance_checkpoint_monotonic(now)
-        if json_output:
-            return json.dumps(report.to_dict())
         stamp = _stamp(report.since)
         header = f"Since {stamp} · {overlay_name}" if overlay_name else f"Since {stamp}"
-        return _render_groups_tables(
-            [report.merged, report.in_flight, report.needs_you],
-            header=header,
-            stamp=stamp,
-        )
+        groups = [report.merged, report.in_flight, report.needs_you]
+        _maybe_notify_recap(groups, header=header, scope=overlay_name or "global", notify=flags.notify)
+        if flags.json_output:
+            return json.dumps(report.to_dict())
+        return _render_groups_tables(groups, header=header, stamp=stamp)
 
-    def _show_all_overlays(
-        self,
-        *,
-        now: datetime,
-        since: str,
-        json_output: bool,
-        no_advance: bool,
-    ) -> str:
+    def _show_all_overlays(self, *, now: datetime, flags: _ShowFlags) -> str:
         """All-overlays path (default): aggregate every configured overlay."""
         from teatree.core.overlay_loader import get_all_overlays  # noqa: PLC0415
 
@@ -161,7 +195,7 @@ class Command(TyperCommand):
 
         for name, overlay in overlays.items():
             path = checkpoint_path(overlay=name)
-            window_start = resolve_window_start(since=since, now=now, path=path)
+            window_start = resolve_window_start(since=flags.since, now=now, path=path)
             overlay_windows[name] = (window_start, now)
             code_host = _overlay_code_host(overlay)
             repos = _overlay_repos(overlay)
@@ -172,19 +206,18 @@ class Command(TyperCommand):
             overlay_configs=overlay_configs,
         )
 
-        if not since and not no_advance:
+        if not flags.since and not flags.no_advance:
             for name in overlays:
                 path = checkpoint_path(overlay=name)
                 advance_checkpoint_monotonic(now, path)
 
-        if json_output:
-            return json.dumps(report.to_dict())
         stamp = _stamp(report.earliest_since)
-        return _render_groups_tables(
-            [report.merged, report.in_flight, report.needs_you],
-            header=f"Since {stamp} · all overlays",
-            stamp=stamp,
-        )
+        header = f"Since {stamp} · all overlays"
+        groups = [report.merged, report.in_flight, report.needs_you]
+        _maybe_notify_recap(groups, header=header, scope="all", notify=flags.notify)
+        if flags.json_output:
+            return json.dumps(report.to_dict())
+        return _render_groups_tables(groups, header=header, stamp=stamp)
 
     @staticmethod
     def _resolve_code_host() -> str:

--- a/tests/teatree_core/management_commands/test_checking.py
+++ b/tests/teatree_core/management_commands/test_checking.py
@@ -14,7 +14,7 @@ from datetime import timedelta
 from io import StringIO
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.core.management import call_command
@@ -246,6 +246,55 @@ class TestCheckingShow:
         assert "Merged" in out  # the recent merge is NOT skipped
         # The marker is not rewound to ``now`` (which would lose the bound).
         assert load_checkpoint(checkpoint_file) == future_marker
+
+
+def _notify_backend() -> MagicMock:
+    b = MagicMock()
+    b.open_dm.return_value = "D-USER"
+    b.post_message.return_value = {"ok": True, "ts": "1700000000.000000"}
+    b.get_permalink.return_value = "https://acme.slack.com/archives/D-USER/p1700000000000000"
+    return b
+
+
+class TestCheckingNotify:
+    """``--notify`` DMs the recap as a native Block Kit table + fence fallback (#2966)."""
+
+    def test_notify_emits_table_block_through_the_real_notify_path(self, checkpoint_file: Path) -> None:
+        # Anti-vacuity: the DM must be produced by the real ``notify_user`` egress
+        # (mocked Slack backend), not a direct formatter call — the ``table`` block
+        # and the monospace fence must both reach ``post_message``.
+        _merged_ticket()
+        backend = _notify_backend()
+        with (
+            patch("teatree.core.notify.messaging_from_overlay", return_value=backend),
+            patch("teatree.core.notify.resolve_user_id", return_value="U_ME"),
+        ):
+            _call("checking", "show", "--this-overlay", "--notify")
+        backend.post_message.assert_called_once()
+        call_kwargs = backend.post_message.call_args.kwargs
+        assert "table" in [block["type"] for block in call_kwargs["blocks"]]
+        assert "```" in call_kwargs["text"]
+        assert "acme/widgets#7" in call_kwargs["text"]
+
+    def test_notify_skipped_when_nothing_to_report(self, checkpoint_file: Path) -> None:
+        backend = _notify_backend()
+        with (
+            patch("teatree.core.notify.messaging_from_overlay", return_value=backend),
+            patch("teatree.core.notify.resolve_user_id", return_value="U_ME"),
+        ):
+            _call("checking", "show", "--this-overlay", "--notify")
+        backend.post_message.assert_not_called()
+
+    def test_unchanged_recap_deduped_to_one_dm(self, checkpoint_file: Path) -> None:
+        _merged_ticket()
+        backend = _notify_backend()
+        with (
+            patch("teatree.core.notify.messaging_from_overlay", return_value=backend),
+            patch("teatree.core.notify.resolve_user_id", return_value="U_ME"),
+        ):
+            _call("checking", "show", "--this-overlay", "--no-advance", "--notify")
+            _call("checking", "show", "--this-overlay", "--no-advance", "--notify")
+        backend.post_message.assert_called_once()
 
 
 class TestCheckingShowAllOverlays:


### PR DESCRIPTION
The waiting-digest already emits table blocks (#2990); the checking recap was CLI-only. Adds opt-in 't3 checking show --notify' DMing the Merged/In-flight/Needs-you recap as native Block Kit table blocks + monospace fence fallback through the real notify_user egress; content-hashed idempotency. 17 tests green, anti-vacuity verified.