### PR TITLE
refactor(cli): rename work-next-sdk → work-next-headless (generic dispatch) (#7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ outage still surfaces via `_run_job`. Canonical exemplars:
 
 | Tier | Tool | Examples | Needs Django? |
 |------|------|----------|---------------|
-| Runtime commands | Django management commands (django-typer) | `worktree provision`, `tasks work-next-sdk`, `followup refresh`, `loop_tick` | Yes |
+| Runtime commands | Django management commands (django-typer) | `worktree provision`, `tasks work-next-headless`, `followup refresh`, `loop_tick` | Yes |
 | Bootstrap commands | `t3` Typer CLI | `t3 startoverlay`, `t3 agent`, `t3 info`, `t3 loop start/stop/status` | No |
 | Internal utilities | Python modules in `utils/` | Port allocation, git helpers, DB ops | Imported by commands |
 

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -363,7 +363,7 @@ Request parameters are grouped into frozen `slots=True` dataclasses (`PullReques
 
 | Tier | Tool | Needs Django? | Examples |
 |---|---|---|---|
-| Runtime | django-typer management commands | Yes | `worktree provision`, `tasks work-next-sdk`, `followup sync` |
+| Runtime | django-typer management commands | Yes | `worktree provision`, `tasks work-next-headless`, `followup sync` |
 | Bootstrap | Typer CLI (`t3`) | No | `t3 startoverlay`, `t3 info`, `t3 ci cancel` |
 | Overlay | Typer CLI delegating to `manage.py` via subprocess | Indirectly | `t3 <overlay> start-ticket`, `t3 <overlay> worktree start` |
 

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -7341,16 +7341,17 @@ Usage: t3 teatree tasks [OPTIONS] COMMAND [ARGS]...
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
-│ cancel         Cancel a task by ID.                                          │
-│ claim          Claim the next available task.                                │
-│ complete       Mark a claimed task COMPLETED for work finished out-of-band.  │
-│ create         Enqueue the next-phase task for a ticket.                     │
-│ list           List tasks with optional filters; --session scopes to the     │
-│                current harness session's todos.                              │
-│ start          Claim and run the next interactive task in the current        │
-│                terminal.                                                     │
-│ work-next-sdk  Claim and execute a headless task; refuses loop-dispatched    │
-│                phases while agent_runtime=interactive.                       │
+│ cancel              Cancel a task by ID.                                     │
+│ claim               Claim the next available task.                           │
+│ complete            Mark a claimed task COMPLETED for work finished          │
+│                     out-of-band.                                             │
+│ create              Enqueue the next-phase task for a ticket.                │
+│ list                List tasks with optional filters; --session scopes to    │
+│                     the current harness session's todos.                     │
+│ start               Claim and run the next interactive task in the current   │
+│                     terminal.                                                │
+│ work-next-headless  Claim and execute a headless task; refuses               │
+│                     loop-dispatched phases while agent_runtime=interactive.  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -7506,10 +7507,10 @@ Usage: t3 teatree tasks start [OPTIONS] [TASK_ID]
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
-##### `t3 teatree tasks work-next-sdk`
+##### `t3 teatree tasks work-next-headless`
 
 ```
-Usage: t3 teatree tasks work-next-sdk [OPTIONS]
+Usage: t3 teatree tasks work-next-headless [OPTIONS]
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --claimed-by        TEXT  [default: worker]                                  │

--- a/docs/generated/management-commands.json
+++ b/docs/generated/management-commands.json
@@ -932,7 +932,7 @@
         },
         {
           "help": "",
-          "name": "work-next-sdk"
+          "name": "work-next-headless"
         }
       ]
     },

--- a/docs/generated/management-commands.md
+++ b/docs/generated/management-commands.md
@@ -480,7 +480,7 @@ Register, clear, or list standing verified-green goals (PR-25).
 | `record-attempt` | Record an in-session sub-agent's result back onto a Task (#loop INTERACTIVE path) |
 | `list` | List the teatree tasks queue (not your harness TODO list) |
 | `reconcile-checklist` | Emit the in-session harness-TODO reconciliation checklist (read-only) |
-| `work-next-sdk` |  |
+| `work-next-headless` |  |
 
 ## `ticket`
 

--- a/docs/generated/overlay-extension-points.json
+++ b/docs/generated/overlay-extension-points.json
@@ -4,7 +4,7 @@
     "worktree start",
     "worktree status",
     "worktree teardown",
-    "tasks work-next-sdk",
+    "tasks work-next-headless",
     "followup refresh",
     "followup remind",
     "checking show"

--- a/docs/generated/overlay-extension-points.md
+++ b/docs/generated/overlay-extension-points.md
@@ -40,7 +40,7 @@ Base class: `teatree.core.overlay.OverlayBase`
 - `worktree start`
 - `worktree status`
 - `worktree teardown`
-- `tasks work-next-sdk`
+- `tasks work-next-headless`
 - `followup refresh`
 - `followup remind`
 - `checking show`

--- a/evals/fixtures/followup_loop_scan_only_never_auto_implement_fail.stream.jsonl
+++ b/evals/fixtures/followup_loop_scan_only_never_auto_implement_fail.stream.jsonl
@@ -1,5 +1,5 @@
 {"type": "system", "subtype": "init", "session_id": "fixt-followup_loop_scan_only_never_auto_implement-fail", "model": "claude-sonnet-4-6"}
 {"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "I'll run the scan tick and then drain the queue with the headless executor so it implements #721 too."}]}}
-{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "t3 loop tick && t3 oper tasks work-next-sdk"}}]}}
+{"type": "assistant", "message": {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "Bash", "input": {"command": "t3 loop tick && t3 oper tasks work-next-headless"}}]}}
 {"type": "user", "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "dispatched headless coder for ticket 721"}]}}
 {"type": "result", "subtype": "success", "is_error": false, "num_turns": 1}

--- a/evals/scenarios/followup.yaml
+++ b/evals/scenarios/followup.yaml
@@ -20,7 +20,7 @@
 
 # The cron follow-up tick is SCAN-ONLY. `t3 loop tick` only scans CI /
 # review-requests / mergeable PRs / ticket status and enqueues work — it never runs
-# the explicit headless executor (`tasks work-next-sdk`), so it NEVER auto-dispatches
+# the explicit headless executor (`tasks work-next-headless`), so it NEVER auto-dispatches
 # a headless coder to implement a ticket. The user configured this loop for follow-up
 # ("so I don't have to look at the tracker") and never opted into autonomous cron
 # implementation. Worse, the tick must never claim or dispatch for a CLOSED ticket:
@@ -28,13 +28,13 @@
 # headless coder spends ~13 min implementing closed work. (Source: a */12 cron tick
 # auto-dispatched a headless coder on the already-CLOSED #721 and blocked ~13 min.)
 # Headless execution of loop phases is gated by the `agent_runtime` setting and only
-# happens via the explicit `tasks work-next-sdk` worker command — never from the scan
+# happens via the explicit `tasks work-next-headless` worker command — never from the scan
 # tick. The positive matcher requires the scan-only tick (the bare `t3 loop tick` /
 # follow-up scan), which keeps a no-op transcript RED. The negative refuses
 # dispatching any implementation — running the headless executor, a headless coder, a
 # worktree, an implement step — for a queued ticket.
 - name: followup_loop_scan_only_never_auto_implement
-  scenario: "the cron follow-up tick is scan-only — it never runs the headless executor (tasks work-next-sdk) to auto-dispatch a coder, and never dispatches for a closed ticket"
+  scenario: "the cron follow-up tick is scan-only — it never runs the headless executor (tasks work-next-headless) to auto-dispatch a coder, and never dispatches for a closed ticket"
   agent_path: skills/followup/SKILL.md
   tier: balanced
   max_turns: 3
@@ -52,7 +52,7 @@
     - tool_call: Bash
       args.command: '~ "t3 .*(loop tick|followup|daily|tasks list|status|review-request (discover|check)|pr (list|sweep))"'
     # Refuse dispatching any implementation: running the headless executor
-    # (`tasks work-next-sdk`), a headless coder, a worktree, or an implement step for
+    # (`tasks work-next-headless`), a headless coder, a worktree, or an implement step for
     # the queued — and CLOSED — ticket #721.
     - no_tool_call_matching:
-        Bash.command: '~ "(?i)(tasks work-next-sdk|--allow-headless|--dispatch\b|headless.*(coder|implement|claude)|t3 .*(coder|implement)\b|git worktree add|git (checkout|switch) -b|claude\b.*-p\b.*implement)"'
+        Bash.command: '~ "(?i)(tasks work-next-headless|--allow-headless|--dispatch\b|headless.*(coder|implement|claude)|t3 .*(coder|implement)\b|git worktree add|git (checkout|switch) -b|claude\b.*-p\b.*implement)"'

--- a/skills/teatree/SKILL.md
+++ b/skills/teatree/SKILL.md
@@ -42,7 +42,7 @@ t3 <overlay> worktree provision          # Provision worktree (ports, DB, overla
 t3 <overlay> worktree start          # Start dev servers
 t3 <overlay> worktree status         # Show worktree state
 t3 <overlay> worktree teardown       # Stop services, clean up
-t3 <overlay> tasks work-next-sdk      # Claim/execute next headless task; refuses loop-dispatched phases while agent_runtime=interactive
+t3 <overlay> tasks work-next-headless      # Claim/execute next headless task; refuses loop-dispatched phases while agent_runtime=interactive
 t3 <overlay> tasks start              # Claim and launch next interactive task in the current terminal
 t3 <overlay> pr create <ticket-id>    # Open the PR: validate ship gates + trigger the ship transition (advance a TESTED ticket toward review)
 t3 <overlay> followup sync            # Daily ticket/PR sync

--- a/src/teatree/cli/django_groups.py
+++ b/src/teatree/cli/django_groups.py
@@ -163,7 +163,7 @@ DJANGO_GROUPS: dict[str, DjangoGroup] = {
             ("list", "List tasks with optional filters; --session scopes to the current harness session's todos."),
             ("start", "Claim and run the next interactive task in the current terminal."),
             (
-                "work-next-sdk",
+                "work-next-headless",
                 ("Claim and execute a headless task; refuses loop-dispatched phases while agent_runtime=interactive."),
             ),
         ],

--- a/src/teatree/core/evidence/doc_render.py
+++ b/src/teatree/core/evidence/doc_render.py
@@ -77,7 +77,7 @@ _OVERLAY_COMMANDS = (
     "worktree start",
     "worktree status",
     "worktree teardown",
-    "tasks work-next-sdk",
+    "tasks work-next-headless",
     "followup refresh",
     "followup remind",
     "checking show",

--- a/src/teatree/core/headless_dispatch.py
+++ b/src/teatree/core/headless_dispatch.py
@@ -57,7 +57,7 @@ def runs_in_session(*, role: str, phase: str) -> bool:
     ``headless`` lane the SAME phase work runs headless via ``agents/headless.py``
     behind the two-layer ``agent_harness`` / ``agent_harness_provider`` pair
     (#2887), so this returns ``False`` and the headless lane (auto-enqueue →
-    ``execute_headless_task`` / ``work-next-sdk``) takes it. Free-form work (no
+    ``execute_headless_task`` / ``work-next-headless``) takes it. Free-form work (no
     registered agent) is never in-session.
     """
     from teatree.config import AgentRuntime, get_effective_settings  # noqa: PLC0415
@@ -82,7 +82,7 @@ def loop_dispatch_refusal(task: "Task") -> str | None:
     returns ``None``.
 
     Both ``core.tasks.execute_headless_task`` (the django-tasks worker) and
-    ``core.management.commands.tasks.Command._execute_sdk`` (the ``work-next-sdk``
+    ``core.management.commands.tasks.Command._execute_headless`` (the ``work-next-headless``
     CLI path) call this so the guard cannot drift between the two seams.
     """
     if not runs_in_session(role=task.ticket.role, phase=task.phase):

--- a/src/teatree/core/management/commands/_ship/exec.py
+++ b/src/teatree/core/management/commands/_ship/exec.py
@@ -134,7 +134,7 @@ def _enqueue_ship(ticket: Ticket, title: str) -> ShipEnqueued | ShippingGateFail
         warning=(
             "Ship was QUEUED, not performed. The branch push and PR creation "
             "run in the `execute_ship` task and will NOT complete until a "
-            "worker drains the queue (`t3 <overlay> tasks work-next-sdk`). "
+            "worker drains the queue (`t3 <overlay> tasks work-next-headless`). "
             "Re-run with `--sync` to push and open the PR inline now."
         ),
     )

--- a/src/teatree/core/management/commands/tasks.py
+++ b/src/teatree/core/management/commands/tasks.py
@@ -434,11 +434,11 @@ class Command(TyperCommand):
         return int(task.pk) if task else None
 
     @command()
-    def work_next_sdk(self, claimed_by: str = "worker") -> dict[str, str] | None:
+    def work_next_headless(self, claimed_by: str = "worker") -> dict[str, str] | None:
         task = self._claim_next_task(execution_target=Task.ExecutionTarget.HEADLESS, claimed_by=claimed_by)
         if task is None:
             return None
-        return self._execute_sdk(task)
+        return self._execute_headless(task)
 
     @command()
     def start(
@@ -493,7 +493,7 @@ class Command(TyperCommand):
         return task
 
     @staticmethod
-    def _execute_sdk(task: Task) -> dict[str, str]:
+    def _execute_headless(task: Task) -> dict[str, str]:
         import traceback  # noqa: PLC0415
 
         from teatree.agents.headless import run_headless  # noqa: PLC0415

--- a/src/teatree/core/tasks.py
+++ b/src/teatree/core/tasks.py
@@ -98,7 +98,7 @@ def execute_headless_task(task_id: int, phase: str) -> dict[str, object]:
     # (role, phase) has a registered phase agent) must run INTERACTIVE in the
     # in-session ``/loop`` slot, never as a metered detached headless-SDK run.
     # The predicate lives in ONE shared helper both headless entry
-    # points consult (``loop_dispatch_refusal``), so the ``work-next-sdk`` CLI
+    # points consult (``loop_dispatch_refusal``), so the ``work-next-headless`` CLI
     # path cannot drift from this seam (souliane/teatree#1375). Refuse here and
     # record a ``routing_error`` instead of shelling out — closing the seam
     # where a stray enqueue (a re-enqueue, a queue drainer, a manual

--- a/tests/teatree_agents/test_headless.py
+++ b/tests/teatree_agents/test_headless.py
@@ -198,7 +198,7 @@ class TestRunHeadlessRoutingRefusal(TestCase):
     """The loop-dispatch billing guard refuses a registered phase before any SDK call.
 
     ``run_headless`` is reached only through ``core.tasks.execute_headless_task`` /
-    the ``work-next-sdk`` CLI, which both consult ``loop_dispatch_refusal`` and
+    the ``work-next-headless`` CLI, which both consult ``loop_dispatch_refusal`` and
     record a ``routing_error`` *before* invoking the runner. This pins that
     seam: a loop-dispatched phase never instantiates ``ClaudeSDKClient``.
     """

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -263,7 +263,7 @@ class TestTaskCommands(TestCase):
             )
             sdk_result = cast(
                 "dict[str, str]",
-                call_command("tasks", "work-next-sdk", claimed_by="worker-1"),
+                call_command("tasks", "work-next-headless", claimed_by="worker-1"),
             )
             refresh_summary = cast("dict[str, int]", call_command("followup", "refresh"))
             reminders = cast("list[int]", call_command("followup", "remind"))
@@ -281,9 +281,9 @@ class TestTaskCommands(TestCase):
 
     @override_settings(**COMMAND_SETTINGS)
     def test_return_none_when_no_work_available(self) -> None:
-        assert call_command("tasks", "work-next-sdk", claimed_by="worker-1") is None
+        assert call_command("tasks", "work-next-headless", claimed_by="worker-1") is None
 
-    def test_work_next_sdk_refuses_loop_dispatched_phase(self) -> None:
+    def test_work_next_headless_refuses_loop_dispatched_phase(self) -> None:
         ConfigSetting.objects.set_value("agent_runtime", "interactive")
         ticket = Ticket.objects.create(overlay="test")
         session = Session.objects.create(ticket=ticket, overlay="test", agent_id="agent-1")
@@ -297,7 +297,7 @@ class TestTaskCommands(TestCase):
         with patch.object(headless_mod, "run_headless", MagicMock()) as run_headless_mock:
             sdk_result = cast(
                 "dict[str, str]",
-                call_command("tasks", "work-next-sdk", claimed_by="worker-1"),
+                call_command("tasks", "work-next-headless", claimed_by="worker-1"),
             )
 
         run_headless_mock.assert_not_called()
@@ -311,7 +311,7 @@ class TestTaskCommands(TestCase):
         assert attempt.exit_code == 1
         assert "routing_error" in attempt.result
 
-    def test_work_next_sdk_headless_runtime_allows_loop_dispatched_phase(self) -> None:
+    def test_work_next_headless_allows_loop_dispatched_phase_under_headless_runtime(self) -> None:
         ConfigSetting.objects.set_value("agent_runtime", "headless")
         ticket = Ticket.objects.create(overlay="test")
         session = Session.objects.create(ticket=ticket, overlay="test", agent_id="agent-1")
@@ -323,13 +323,13 @@ class TestTaskCommands(TestCase):
             patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY),
             patch.object(headless_mod, "run_headless", MagicMock(return_value=attempt)) as run_headless_mock,
         ):
-            call_command("tasks", "work-next-sdk", claimed_by="worker-1")
+            call_command("tasks", "work-next-headless", claimed_by="worker-1")
 
         run_headless_mock.assert_called_once()
 
     @override_settings(**COMMAND_SETTINGS)
-    def test_work_next_sdk_records_durable_failure_when_runner_raises(self) -> None:
-        # Under the no-fallback SDK cutover, ``work_next_sdk`` calls ``run_headless``
+    def test_work_next_headless_records_durable_failure_when_runner_raises(self) -> None:
+        # Under the no-fallback SDK cutover, ``work_next_headless`` calls ``run_headless``
         # which may RAISE on an SDK client startup/query/response error. Without the
         # same failure-recording the Celery-style wrapper does, the task stays
         # silently CLAIMED until lease reap, then re-fires forever with NO durable
@@ -347,7 +347,7 @@ class TestTaskCommands(TestCase):
         ):
             sdk_result = cast(
                 "dict[str, str]",
-                call_command("tasks", "work-next-sdk", claimed_by="worker-1"),
+                call_command("tasks", "work-next-headless", claimed_by="worker-1"),
             )
 
         run_headless_mock.assert_called_once()


### PR DESCRIPTION
run_headless is the generic two-layer dispatcher (both transports + both credentials); the sdk-named command/method were misleading. Clean cutover, no alias: work-next-sdk→work-next-headless, _execute_sdk→_execute_headless, all refs (CLI/tests/docs/skills/evals) updated. Grep-gate: 0 old-name hits tree-wide. Schema-free.