### PR TITLE
feat(mcp): widen read tools + command_search + migrate read-skills (#108)

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -60,7 +60,7 @@ cli/         # Typer CLI — bootstrap commands (no Django needed); cohesive gro
 core/        # Django app — models, FSM, managers, sync, runners, management commands; backend_protocols hub at root + packages models/ gates/ merge/ runners/ selectors/ views/ modelkit/ and the clustered leaf packages cleanup/ worktree/ provision/ factory/ intake/ review/ evidence/
 agents/      # Headless executor (in-process claude-agent-sdk)
 loop/        # /loop topology — tick, scanners, dispatch, statusline
-mcp/         # Read-only structured-search MCP server (serializers + search + FastMCP wiring); `t3 mcp serve`
+mcp/         # Read-only structured-search MCP server (serializers + search + command_catalogue + FastMCP wiring); `t3 mcp serve`. Tools: command_search (CLI discoverability) + ticket_get/ticket_list/ticket_search/worktree_status/pr_for_ticket/task_list/loop_stats/incoming_event_recent/config_setting_get/gate_status/factory_signals(+factory_score dark)
 backends/    # Pluggable external service integrations; per-forge subpackages github/ gitlab/ slack/ (+ flat notion, sentry, figma)
 config/      # Settings load + overlay discovery
 utils/       # Pure utilities (git, git_remote remote-URL parsing [#2404], ports, db, secrets, compose contract, ...)

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -41,7 +41,7 @@ For short prompts, pass `--reason "<text>"` directly. For multiline prompts, wri
 
 **Phase transitions:** `scoping → coding`, `coding → testing`, `testing → reviewing`, `reviewing → shipping`.
 
-**Gotcha:** the `<TICKET_PK>` argument takes the teatree **ticket PK** (visible as `ticket_id` in `t3 <overlay> tasks list`), NOT the external issue number — they differ. Confirm via the CLI output, not by guessing.
+**Gotcha:** the `<TICKET_PK>` argument takes the teatree **ticket PK** (visible as `ticket_id` in the `mcp__teatree__task_list` MCP tool, or `t3 <overlay> tasks list`), NOT the external issue number — they differ. Confirm via the returned `ticket_id`, not by guessing.
 
 ### 3. Emit Structured Result
 

--- a/skills/todos/SKILL.md
+++ b/skills/todos/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 Two words, two stores. They are routinely conflated; keep them strictly apart in every identifier, docstring, log line, config key, and prose surface:
 
 - **TODO** = the **harness** ("Claude") task list — the `TaskCreate` / `TaskList` / `TaskUpdate` tools (formerly `TodoWrite`). Live, in-memory, harness-owned. Never persisted by teatree.
-- **task** = a teatree **`Task` DB row** — a claimable lifecycle work unit with a phase, lease, and ticket (`t3 <overlay> tasks list`). DB-backed, teatree-owned.
+- **task** = a teatree **`Task` DB row** — a claimable lifecycle work unit with a phase, lease, and ticket (read via the `mcp__teatree__task_list` MCP tool, or the `t3 <overlay> tasks list` CLI). DB-backed, teatree-owned.
 
 There is **no such thing** as a "teatree todo". A loop unit, setting, or signal that acts on `Task` rows is named `task_*` / `task.*`, never `todo_*` / `todo.*` — e.g. the `task_sweep` scanner (`TaskSweepScanner`, settings `task_sweep_*`, signals `task.completion_detected` / `task.orphaned`, handler `task_completion`) reconciles teatree `Task` rows, **not** the harness TODO list. Cross-ref: `BLUEPRINT.md` § "Loop scanners" (`TaskSweepScanner` row).
 
@@ -25,7 +25,7 @@ A SHORT, read-only view of everything on the current harness session's plate. `/
 There are **two distinct stores**, and they are built two different ways — never conflate them:
 
 - **harness TODO** — the agent harness's own working list (the `TaskCreate` / `TaskUpdate` items, formerly `TodoWrite`). This is the agent's **live, in-memory** session list. Build it **dynamically from the `TaskList` harness tool** — see below.
-- **teatree task** — a row in teatree's DB-backed `Task` model: a claimable lifecycle work unit with a phase, lease, and ticket. Read it with the `t3 <overlay> tasks list` CLI.
+- **teatree task** — a row in teatree's DB-backed `Task` model: a claimable lifecycle work unit with a phase, lease, and ticket. Read it with the `mcp__teatree__task_list` MCP tool (structured JSON — no text parsing), or the `t3 <overlay> tasks list` CLI.
 
 There is no such thing as a "teatree todo" — use **teatree task** for the DB model and **harness TODO** for the harness list.
 
@@ -89,20 +89,20 @@ It is a read-only emitter — it makes no reconciliation writes (it never create
 
 ## The teatree-tasks half (a separate, DB-backed concern)
 
-The teatree `Task` rows (the loop's claimable lifecycle work units) are a **separate** store — DB-backed, not your harness list — read with the CLI:
+The teatree `Task` rows (the loop's claimable lifecycle work units) are a **separate** store — DB-backed, not your harness list. Prefer the `mcp__teatree__task_list` MCP tool for the overlay-wide queue — it returns structured JSON (filter by `status` / `phase` / `ticket` / `overlay`); read its fields directly, no CLI text parsing (`mcp__teatree__loop_stats` gives the per-status counts). Fall back to the CLI when the MCP server isn't connected:
 
 ```bash
-t3 <overlay> tasks list                      # the teatree-tasks queue across every ticket
-t3 <overlay> tasks list --session            # teatree tasks scoped to THIS harness session
+t3 <overlay> tasks list                      # CLI fallback: the teatree-tasks queue across every ticket (MCP: mcp__teatree__task_list)
+t3 <overlay> tasks list --session            # CLI-only: teatree tasks scoped to THIS harness session
 ```
 
-`--session` scopes **only the teatree `Task` rows** to the current harness session (resolved via `current_session_id()` — `CLAUDE_SESSION_ID`, the loop-session override, then the loop registry). It renders a single `teatree tasks` section — it does **not** print a harness-TODO section, because the CLI cannot read your live harness list. Add `--status` / `--execution-target` to filter the teatree-tasks view.
+`--session` scopes **only the teatree `Task` rows** to the current harness session (resolved via `current_session_id()` — `CLAUDE_SESSION_ID`, the loop-session override, then the loop registry) and is CLI-only — the MCP tool serves the overlay-wide queue, not the per-harness-session view. It renders a single `teatree tasks` section — it does **not** print a harness-TODO section, because the CLI cannot read your live harness list. Add `--status` / `--execution-target` to filter the teatree-tasks view.
 
 When the user asks "show my task list", render both halves: the live harness TODOs (from `TaskList`) under a `harness TODOs` heading, then the teatree tasks (from `t3 ... tasks list --session`) under a `teatree tasks` heading.
 
 ## Resolving a single `TODO-<n>` id (not the same as listing)
 
-Looking up *what one task id is* is a different operation from listing the live list. A bare numeric id or a `TODO-<n>` id is a **harness task id**, not a forge issue — resolve it against the harness task store (`~/.claude/tasks/<session-id>/*.json`, override the root with `CLAUDE_TASKS_DIR`) or via `t3 <overlay> tasks list`, never by querying the issue tracker (`gh issue view <n>` / `glab issue view <n>`). That store is **not** `~/.claude/todos.json` (no such file exists). For the *live current list*, still use `TaskList` — the store read is only for resolving an individual id reference.
+Looking up *what one task id is* is a different operation from listing the live list. A bare numeric id or a `TODO-<n>` id is a **harness task id**, not a forge issue — resolve it against the harness task store (`~/.claude/tasks/<session-id>/*.json`, override the root with `CLAUDE_TASKS_DIR`) or via the `mcp__teatree__task_list` MCP tool (or the `t3 <overlay> tasks list` CLI), never by querying the issue tracker (`gh issue view <n>` / `glab issue view <n>`). That store is **not** `~/.claude/todos.json` (no such file exists). For the *live current list*, still use `TaskList` — the store read is only for resolving an individual id reference.
 
 ## Output contract
 

--- a/src/teatree/cli/__init__.py
+++ b/src/teatree/cli/__init__.py
@@ -61,6 +61,7 @@ from teatree.cli.assess import assess_app
 from teatree.cli.banned_terms import banned_terms_app
 from teatree.cli.ci import ci_app
 from teatree.cli.codex import codex_app
+from teatree.cli.command_tree import command_catalogue
 from teatree.cli.config import config_app
 from teatree.cli.directive import directive_app
 from teatree.cli.doctor import DoctorService, IntrospectionHelpers, doctor_app
@@ -87,6 +88,7 @@ from teatree.cli.teams import teams_app
 from teatree.cli.tools import tool_app
 from teatree.cli.update import update_app
 from teatree.cli.worker import worker_app
+from teatree.mcp.command_catalogue import CommandRecord, register_command_catalogue_provider
 
 logger = logging.getLogger(__name__)
 
@@ -237,7 +239,11 @@ def register_overlay_commands(allowlist: set[str] | None = None) -> None:
     active = discover_active_overlay()
     installed = discover_overlays()
 
-    registered: set[str] = set()
+    # Idempotent across calls: an overlay group already on ``app`` (from an
+    # earlier call — the reference builder, the #550 registry, and the
+    # command-catalogue provider each register the ``teatree`` overlay lazily)
+    # must not be re-added, or Typer would carry a duplicate group.
+    registered: set[str] = {info.name for info in app.registered_groups if info.name}
     for entry in _collapse_to_canonical(installed):
         if allowlist is not None and entry.name not in allowlist:
             continue
@@ -271,7 +277,21 @@ def _build_skill_command_registry() -> tuple[set[str], set[str]]:
     return command_paths(app), command_groups(app)
 
 
+def _build_command_catalogue() -> list[CommandRecord]:
+    """The live command catalogue for the MCP ``command_search`` tool.
+
+    Registers the ``teatree`` overlay's command group (so ``t3 teatree …`` leaves
+    are discoverable), then projects the assembled root app to one record per
+    leaf. Inverted for the same reason as the #550 registry — ``teatree.mcp``
+    (integration) cannot import ``teatree.cli`` (interface), so the parent injects
+    this builder via ``register_command_catalogue_provider``.
+    """
+    register_overlay_commands(allowlist={"t3-teatree"})
+    return command_catalogue(app)
+
+
 register_command_registry_provider(_build_skill_command_registry)
+register_command_catalogue_provider(_build_command_catalogue)
 
 
 # ── Entry point ──────────────────────────────────────────────────────

--- a/src/teatree/cli/command_tree.py
+++ b/src/teatree/cli/command_tree.py
@@ -28,6 +28,7 @@ import typer.rich_utils
 from typer.main import get_command
 
 from teatree.cli.overlay import OVERLAY_PROXY_COMMANDS
+from teatree.mcp.command_catalogue import CommandRecord
 
 # The render must be byte-identical regardless of the environment it runs in
 # (#2599): a fixed console width so the rich help boxes wrap identically on a
@@ -230,6 +231,56 @@ def command_paths(app: typer.Typer, *, base_name: str = "t3") -> set[str]:
 
     _collect(get_command(app), [base_name], parent_ctx=None)
     return paths
+
+
+def _emits_json(cmd: click.Command) -> bool:
+    """Whether *cmd* exposes a machine-readable ``--json`` / ``--format`` output.
+
+    Both output shapes in the tree signal parseable output: a boolean ``--json``
+    flag and a ``--format`` selector (text|json). The catalogue carries the flag
+    so ``command_search`` can tell an agent a command it can parse from one it
+    must scrape.
+    """
+    for param in getattr(cmd, "params", []):
+        opts = [*getattr(param, "opts", []), *getattr(param, "secondary_opts", [])]
+        if "--json" in opts or "--format" in opts:
+            return True
+    return False
+
+
+def command_catalogue(app: typer.Typer, *, base_name: str = "t3") -> list[CommandRecord]:
+    """Every LEAF command in *app* as a ``CommandRecord`` for ``command_search``.
+
+    Walks the tree exactly like :func:`command_paths` — resolving overlay proxies
+    to their real click leaf so the summary and ``--json`` detection see the true
+    command — but emits one record per leaf (not groups), carrying the full
+    ``path``, its short help ``summary``, and whether it ``emits_json``. This is
+    the CLI-side of the inverted ``command_search`` dependency: ``teatree.cli``
+    builds it from its own assembled app and registers it into the mcp seam.
+    """
+    records: list[CommandRecord] = []
+
+    def _collect(cmd: click.Command, parts: list[str], parent_ctx: click.Context | None) -> None:
+        real = _resolve_proxy_leaf(cmd)
+        if real is not None:
+            cmd = real
+        ctx = click.Context(cmd, info_name=parts[-1], parent=parent_ctx)
+        if isinstance(cmd, click.Group):
+            for sub_name in cmd.list_commands(ctx):
+                sub_cmd = cmd.get_command(ctx, sub_name)
+                if sub_cmd is not None:
+                    _collect(sub_cmd, [*parts, sub_name], parent_ctx=ctx)
+            return
+        records.append(
+            CommandRecord(
+                path=" ".join(parts),
+                summary=cmd.get_short_help_str(limit=200),
+                emits_json=_emits_json(cmd),
+            ),
+        )
+
+    _collect(get_command(app), [base_name], parent_ctx=None)
+    return records
 
 
 def command_groups(app: typer.Typer, *, base_name: str = "t3") -> set[str]:

--- a/src/teatree/mcp/__init__.py
+++ b/src/teatree/mcp/__init__.py
@@ -7,9 +7,30 @@ shelling out to ``t3 ... list`` and parsing text. Wired into the CLI as
 
 - :mod:`teatree.mcp.serializers` — pure model -> JSON-dict projections
 - :mod:`teatree.mcp.search` — sync ORM queries reusing the model managers
+- :mod:`teatree.mcp.command_catalogue` — the `command_search` catalogue seam
+  (CLI-provided, for discovering which `t3` command to run)
 - :mod:`teatree.mcp.server` — FastMCP wiring (``build_server``)
+
+``build_server`` is exported LAZILY (PEP 562 ``__getattr__``): importing the
+``teatree.mcp`` package — which ``teatree.cli`` does at import time to reach the
+``command_catalogue`` registration seam — must NOT eagerly pull ``server`` →
+``search`` → the Django ORM before ``django.setup()`` has run. The lazy export
+keeps ``from teatree.mcp import build_server`` working while deferring the
+ORM-touching import to the ``t3 mcp serve`` path (which bootstraps Django first).
 """
 
-from teatree.mcp.server import build_server
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from teatree.mcp.server import build_server
 
 __all__ = ["build_server"]
+
+
+def __getattr__(name: str) -> object:
+    if name == "build_server":
+        from teatree.mcp.server import build_server  # noqa: PLC0415 — deferred so the package import stays ORM-free
+
+        return build_server
+    msg = f"module {__name__!r} has no attribute {name!r}"
+    raise AttributeError(msg)

--- a/src/teatree/mcp/command_catalogue.py
+++ b/src/teatree/mcp/command_catalogue.py
@@ -1,0 +1,105 @@
+"""Command-catalogue seam for the `command_search` discoverability tool.
+
+`command_search` answers "which `t3` command do I run for X" — the recurring gap
+where an agent guesses a subcommand that does not exist. Its data is the live
+Typer command tree, which only :mod:`teatree.cli` can introspect. ``teatree.cli``
+sits ABOVE ``teatree.mcp`` in the layer graph, so — exactly like the #550
+skill-command-validity lane — the dependency is INVERTED: ``teatree.cli``
+registers a provider at import time via
+:func:`register_command_catalogue_provider`, and this low module (which the mcp
+query layer can import) holds only the registration seam plus the pure ranking.
+
+The default provider raises loud, so a caller that never registered one fails
+with a clear message rather than silently searching an empty catalogue.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+# The leaf-name segment is weighted above the rest of the path, which is
+# weighted above the help summary, so `worktree provision` ranks the leaf whose
+# name IS those tokens ahead of one that merely mentions them in prose.
+_LEAF_WEIGHT = 3
+_PATH_WEIGHT = 2
+_SUMMARY_WEIGHT = 1
+
+
+@dataclass(frozen=True)
+class CommandRecord:
+    """One `t3` leaf command projected for discoverability search.
+
+    ``path`` is the full invocation (``t3 <overlay> worktree provision``),
+    ``summary`` its one-line help, and ``emits_json`` whether it exposes a
+    ``--json`` / ``--format`` machine-readable output the agent can parse.
+    """
+
+    path: str
+    summary: str
+    emits_json: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"path": self.path, "summary": self.summary, "emits_json": self.emits_json}
+
+
+CatalogueProvider = Callable[[], list[CommandRecord]]
+
+
+def _unregistered_provider() -> list[CommandRecord]:
+    msg = (
+        "command-catalogue provider not registered — teatree.cli must call "
+        "register_command_catalogue_provider() at import time"
+    )
+    raise RuntimeError(msg)
+
+
+_provider: CatalogueProvider = _unregistered_provider
+
+
+def register_command_catalogue_provider(provider: CatalogueProvider) -> None:
+    """Inject the catalogue builder (called by ``teatree.cli`` at import time)."""
+    global _provider  # noqa: PLW0603 — the single registration seam for the inverted dependency
+    _provider = provider
+
+
+def build_command_catalogue() -> list[CommandRecord]:
+    """The live command catalogue via the registered provider."""
+    return _provider()
+
+
+def _score(record: CommandRecord, tokens: list[str]) -> int:
+    """Relevance of *record* to the query *tokens* (0 = no match).
+
+    A token counts once per surface it hits: the leaf name (last path segment),
+    the whole path, and the summary — highest-weighted surface first.
+    """
+    leaf = record.path.rsplit(" ", 1)[-1].lower()
+    path = record.path.lower()
+    summary = record.summary.lower()
+    total = 0
+    for token in tokens:
+        if token in leaf:
+            total += _LEAF_WEIGHT
+        if token in path:
+            total += _PATH_WEIGHT
+        if token in summary:
+            total += _SUMMARY_WEIGHT
+    return total
+
+
+def search_commands(query: str, *, catalogue: list[CommandRecord], limit: int) -> list[dict[str, Any]]:
+    """Rank *catalogue* by relevance to *query*; return the best *limit* matches.
+
+    Pure and CLI-free — the caller passes the catalogue (the registered provider
+    supplies the live one). A blank query matches nothing. Ties break on the
+    command path so the ordering is deterministic.
+    """
+    tokens = query.lower().split()
+    if not tokens:
+        return []
+    scored = [(record, _score(record, tokens)) for record in catalogue]
+    matches = sorted(
+        ((record, score) for record, score in scored if score > 0),
+        key=lambda pair: (-pair[1], pair[0].path),
+    )
+    return [record.to_dict() for record, _ in matches[:limit]]

--- a/src/teatree/mcp/search.py
+++ b/src/teatree/mcp/search.py
@@ -19,20 +19,43 @@ from typing import Any
 
 from django.db.models import Count, Q
 
-from teatree.config import get_effective_settings
+from teatree.config import COLD_HOOK_SETTINGS, OVERLAY_OVERRIDABLE_SETTINGS, cold_reader, get_effective_settings
+from teatree.config.registries import REGISTRY_SETTINGS
 from teatree.core.factory.factory_score import score as factory_score_compute
 from teatree.core.factory.factory_signals import DEFAULT_WINDOW_DAYS, compute_factory_signals
-from teatree.core.models import IncomingEvent, PullRequest, ReplyDispatch, Task, Ticket, Worktree
+from teatree.core.modelkit.phases import phase_spellings
+from teatree.core.models import ConfigSetting, IncomingEvent, PullRequest, ReplyDispatch, Task, Ticket, Worktree
+from teatree.mcp import command_catalogue
 from teatree.mcp.serializers import (
     serialize_incoming_event,
     serialize_pull_request,
+    serialize_task,
     serialize_ticket,
+    serialize_ticket_detail,
     serialize_worktree,
 )
 
 _DEFAULT_TICKET_LIMIT = 50
 _DEFAULT_EVENT_LIMIT = 20
+_DEFAULT_TASK_LIMIT = 50
+_DEFAULT_COMMAND_LIMIT = 20
 _MAX_LIMIT = 200
+
+# The review/merge-governing settings agents most need to read before deciding
+# whether a merge is theirs to make — the review gate proper plus the review-phase
+# evidence gates. All are ``UserSettings`` bool fields resolved via the effective
+# settings, so a per-overlay override is reflected.
+_REVIEW_GATE_KEYS = (
+    "require_human_approval_to_merge",
+    "require_reviewed_state_for_review_request",
+    "require_review_context",
+    "require_anti_vacuity_attestation",
+    "require_merge_evidence",
+    "e2e_mandatory_gate_enabled",
+)
+# The raw/out-of-band merge gate is a cold-hook key (no ``UserSettings`` field),
+# resolved from the canonical config DB with its registered fail-open default.
+_RAW_MERGE_GATE_KEY = "out_of_band_merge_gate_enabled"
 
 
 def _capped(limit: int, default: int) -> int:
@@ -77,6 +100,39 @@ def ticket_search(  # noqa: PLR0913 — search entry-point; each kwarg is a docu
         )
     rows = queryset.order_by("-pk")[: _capped(limit, _DEFAULT_TICKET_LIMIT)]
     return [serialize_ticket(ticket) for ticket in rows]
+
+
+def ticket_list(
+    *,
+    overlay: str | None = None,
+    state: str | None = None,
+    in_flight: bool = False,
+    limit: int = _DEFAULT_TICKET_LIMIT,
+) -> list[dict[str, Any]]:
+    """The MCP mirror of ``t3 <overlay> ticket list`` — enumerate tickets by state.
+
+    The list counterpart to the free-text ``ticket_search``: filter by lifecycle
+    ``state`` (the stage an agent means by "phase"), scope to an ``overlay``, and
+    set ``in_flight=True`` for the not-yet-delivered/ignored set. Delegates to
+    ``ticket_search`` (kind / role / free-text refinements live there). For one
+    ticket's full detail (including its visited-phase ledger) use ``ticket_get``.
+    """
+    return ticket_search(overlay=overlay, state=state, in_flight=in_flight, limit=limit)
+
+
+def ticket_get(*, ticket: str) -> dict[str, Any]:
+    """One ticket's full detail, resolved by pk, issue number, URL, or repo key.
+
+    Resolves through ``TicketManager.resolve`` and returns the base ticket fields
+    plus ``visited_phases`` (the union of lifecycle phases recorded across the
+    ticket's sessions). An unresolvable reference returns an empty dict rather
+    than raising, so the long-running server never crashes on a bad argument.
+    """
+    try:
+        resolved = Ticket.objects.resolve(ticket)
+    except Ticket.DoesNotExist:
+        return {}
+    return serialize_ticket_detail(resolved)
 
 
 def worktree_status(
@@ -200,3 +256,125 @@ def incoming_event_recent(
         queryset = queryset.filter(source=source)
     rows = queryset.order_by("-received_at", "-pk")[: _capped(limit, _DEFAULT_EVENT_LIMIT)]
     return [serialize_incoming_event(event) for event in rows]
+
+
+def task_list(
+    *,
+    overlay: str | None = None,
+    status: str | None = None,
+    phase: str | None = None,
+    ticket: str | None = None,
+    limit: int = _DEFAULT_TASK_LIMIT,
+) -> list[dict[str, Any]]:
+    """The autonomous loop's task queue, newest first — the MCP mirror of ``tasks list``.
+
+    ``status`` filters to one ``Task.Status`` (pending / claimed / completed /
+    failed). ``phase`` matches any accepted spelling of a phase (short verb or
+    gerund, via ``phase_spellings``). ``overlay`` scopes through
+    ``TaskManager.for_overlay`` (spanning the ticket and session relations,
+    legacy empty-overlay rows included). ``ticket`` narrows to one ticket
+    (resolved through ``TicketManager.resolve``); an unresolvable reference
+    returns an empty list rather than raising.
+    """
+    queryset = Task.objects.for_overlay(overlay)
+    if ticket:
+        try:
+            resolved = Ticket.objects.resolve(ticket)
+        except Ticket.DoesNotExist:
+            return []
+        queryset = queryset.filter(ticket=resolved)
+    if status:
+        queryset = queryset.filter(status=status)
+    if phase:
+        queryset = queryset.filter(phase__in=phase_spellings(phase))
+    rows = queryset.select_related("ticket").order_by("-pk")[: _capped(limit, _DEFAULT_TASK_LIMIT)]
+    return [serialize_task(task) for task in rows]
+
+
+def _scope_label(scope: str) -> str:
+    """``global`` for the empty scope, else ``overlay:<name>`` — mirrors the CLI label."""
+    return "global" if not scope else f"overlay:{scope}"
+
+
+def _jsonable(value: object) -> object:
+    """Coerce a resolved config value to a JSON-safe primitive for the boundary.
+
+    A ``ConfigSetting`` row is already JSON; a ``UserSettings`` fallback may be a
+    ``StrEnum``, ``Path`` or other rich type, so anything not a plain primitive
+    is stringified so the read-only tool never fails to serialize.
+    """
+    if value is None or isinstance(value, bool | int | float | str):
+        return value
+    if isinstance(value, list | tuple):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    return str(value)
+
+
+def config_setting_get(*, key: str, overlay: str | None = None) -> dict[str, Any]:
+    """The effective value of a config setting and where it resolves from.
+
+    The read side of the DB override store, mirroring ``t3 <overlay>
+    config_setting get``: a ``ConfigSetting`` row in the requested scope is
+    reported as ``source == "db"``; otherwise the value falls through to the
+    file/env layer (``source == "file/env"``). ``overlay`` reads that overlay's
+    scope. A key in neither the overridable nor the registry partition is
+    reported ``known == False`` (value ``None``) rather than raising — the read
+    surface stays crash-proof on a typo.
+    """
+    scope = overlay or ""
+    label = _scope_label(scope)
+    if key not in OVERLAY_OVERRIDABLE_SETTINGS and key not in REGISTRY_SETTINGS:
+        return {"key": key, "known": False, "value": None, "source": None, "scope": label, "overlay": scope}
+    stored = ConfigSetting.objects.get_effective(key, scope=scope)
+    if stored is not None:
+        return {"key": key, "known": True, "value": _jsonable(stored), "source": "db", "scope": label, "overlay": scope}
+    fallback = getattr(get_effective_settings(overlay or None), key, None)
+    return {
+        "key": key,
+        "known": True,
+        "value": _jsonable(fallback),
+        "source": "file/env",
+        "scope": label,
+        "overlay": scope,
+    }
+
+
+def gate_status(*, overlay: str | None = None) -> dict[str, Any]:
+    """The review-gate and raw-merge gate state — the merge-governing gates at a glance.
+
+    ``review_gate`` reports whether a human must approve a merge
+    (``require_human_approval_to_merge``) plus the review-phase evidence gates,
+    all resolved through the effective settings so a per-``overlay`` override is
+    reflected. ``raw_merge_gate`` reports whether raw ``gh``/``glab`` merges are
+    blocked (``out_of_band_merge_gate_enabled``), resolved from the canonical
+    config DB with its registered fail-open default. Read-only: flip a gate with
+    ``t3 <overlay> config_setting set`` / ``t3 <overlay> gate``.
+    """
+    settings = get_effective_settings(overlay or None)
+    review_gate = {key: bool(getattr(settings, key)) for key in _REVIEW_GATE_KEYS}
+    raw_merge_gate = {
+        _RAW_MERGE_GATE_KEY: cold_reader.bool_setting(
+            _RAW_MERGE_GATE_KEY,
+            default=bool(COLD_HOOK_SETTINGS[_RAW_MERGE_GATE_KEY].default),
+        ),
+    }
+    return {"overlay": overlay or "", "review_gate": review_gate, "raw_merge_gate": raw_merge_gate}
+
+
+def command_search(*, query: str, limit: int = _DEFAULT_COMMAND_LIMIT) -> list[dict[str, Any]]:
+    """The `t3` leaf commands matching *query* — the CLI-discoverability read.
+
+    Answers "which `t3` command do I run for X" so an agent stops guessing
+    subcommands that do not exist. Each match carries the full invocation
+    ``path``, its one-line help ``summary``, and ``emits_json`` (whether it
+    exposes a ``--json`` / ``--format`` output the agent can parse). Sourced from
+    the live Typer command tree via the registered catalogue provider, best match
+    first.
+    """
+    return command_catalogue.search_commands(
+        query,
+        catalogue=command_catalogue.build_command_catalogue(),
+        limit=_capped(limit, _DEFAULT_COMMAND_LIMIT),
+    )

--- a/src/teatree/mcp/serializers.py
+++ b/src/teatree/mcp/serializers.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from teatree.core.models.incoming_event import IncomingEvent
     from teatree.core.models.pull_request import PullRequest
+    from teatree.core.models.task import Task
     from teatree.core.models.ticket import Ticket
     from teatree.core.models.worktree import Worktree
 
@@ -43,6 +44,40 @@ def serialize_ticket(ticket: "Ticket") -> dict[str, Any]:
         "short_description": ticket.short_description,
         "is_terminal": ticket.is_terminal,
         "remote_missing": ticket.remote_missing,
+    }
+
+
+def serialize_ticket_detail(ticket: "Ticket") -> dict[str, Any]:
+    """The single-ticket projection: the base fields plus the visited-phase ledger.
+
+    A list read serializes many rows and stays on :func:`serialize_ticket` (no
+    per-row session query); the ``ticket_get`` single read affords the one extra
+    query for ``visited_phases`` — the union of phases recorded across every
+    session, the lifecycle-progress answer a client inspecting one ticket wants.
+    """
+    visited_phases, _ = ticket.aggregate_phase_records()
+    return {**serialize_ticket(ticket), "visited_phases": visited_phases}
+
+
+def serialize_task(task: "Task") -> dict[str, Any]:
+    """Project a :class:`Task` onto its structured-search shape.
+
+    ``ticket_number``, ``overlay`` and ``subject`` read through the related
+    ticket — callers select_related ``ticket`` so this adds no per-row query.
+    ``subject`` is the human-readable one-line description the statusline shows.
+    """
+    return {
+        "id": task.pk,
+        "ticket_id": task.ticket_id,  # ty: ignore[unresolved-attribute]
+        "ticket_number": task.ticket.ticket_number,
+        "overlay": task.ticket.overlay,
+        "phase": task.phase,
+        "status": task.status,
+        "execution_target": task.execution_target,
+        "subject": task.display_subject(),
+        "claimed_by": task.claimed_by,
+        "created_at": _iso(task.created_at),
+        "claimed_at": _iso(task.claimed_at),
     }
 
 

--- a/src/teatree/mcp/server.py
+++ b/src/teatree/mcp/server.py
@@ -23,11 +23,35 @@ from teatree.mcp import search
 _READ_ONLY = ToolAnnotations(readOnlyHint=True)
 
 _INSTRUCTIONS = (
-    "Read-only structured search over teatree's internal model — tickets, "
-    "worktrees, pull requests, the autonomous loop's task queue, inbound "
-    "platform events, and derived-on-read factory quality/velocity signals. "
-    "Prefer these tools over shelling out to `t3 ... list` and parsing text. "
-    "All tools are read-only; mutations go through the `t3` CLI."
+    "Read-only structured search over teatree's internal model. Prefer these "
+    "tools over shelling out to `t3 ... list` and parsing text. All tools are "
+    "read-only; mutations go through the `t3` CLI.\n"
+    "\n"
+    "Tools:\n"
+    "- command_search(query): which `t3` CLI leaf command to run for a task — "
+    "path, help summary, and whether it emits --json. Use this FIRST when unsure "
+    "which command exists.\n"
+    "- ticket_get(ticket): one ticket's full detail (by pk / issue number / URL) "
+    "incl. its visited-phase ledger.\n"
+    "- ticket_list(overlay, state, kind, role, in_flight): enumerate tickets by "
+    "lifecycle state — the mirror of `t3 <overlay> ticket list`.\n"
+    "- ticket_search(text, overlay, state, kind, role, in_flight): free-text "
+    "ticket search across url / description / context.\n"
+    "- worktree_status(ticket, overlay, active_only): a ticket's or an overlay's "
+    "worktrees with FSM state, branch, db, staleness.\n"
+    "- pr_for_ticket(ticket): the pull requests recorded for a ticket.\n"
+    "- task_list(overlay, status, phase, ticket): the autonomous loop's task "
+    "queue — the mirror of `t3 <overlay> tasks list`.\n"
+    "- loop_stats(overlay): task-status counts plus the dead-letter total.\n"
+    "- incoming_event_recent(source, unprocessed_only): recent inbound platform "
+    "events.\n"
+    "- config_setting_get(key, overlay): a config setting's effective value, its "
+    "source (db vs file/env), and scope.\n"
+    "- gate_status(overlay): the review-gate and raw-merge gate state.\n"
+    "- factory_signals(overlay, window_days): the five factory quality/velocity "
+    "signals with fail-loud statuses and the verdict.\n"
+    "- factory_score(overlay, window_days): the recipe-weighted factory score "
+    "(registered only when factory_score_enabled is on)."
 )
 
 
@@ -57,6 +81,38 @@ async def _ticket_search(  # noqa: PLR0913 — MCP tool surface; each kwarg is a
         in_flight=in_flight,
         limit=limit,
     )
+
+
+async def _ticket_list(
+    *,
+    overlay: str | None = None,
+    state: str | None = None,
+    in_flight: bool = False,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """List tickets by lifecycle state — the mirror of ``t3 <overlay> ticket list``.
+
+    Filter by ``state`` (the stage agents call the "phase"), scope to an
+    ``overlay``, or set ``in_flight=true`` for the not-yet-delivered set. For
+    free-text / kind / role search use ``ticket_search``; for one ticket's full
+    detail use ``ticket_get``.
+    """
+    return await sync_to_async(search.ticket_list, thread_sensitive=True)(
+        overlay=overlay,
+        state=state,
+        in_flight=in_flight,
+        limit=limit,
+    )
+
+
+async def _ticket_get(ticket: str) -> dict[str, Any]:
+    """One ticket's full detail by pk, issue number, URL, or repo key.
+
+    Returns the base ticket fields plus ``visited_phases`` (the union of
+    lifecycle phases recorded across the ticket's sessions). An empty object
+    means the reference did not resolve.
+    """
+    return await sync_to_async(search.ticket_get, thread_sensitive=True)(ticket=ticket)
 
 
 async def _worktree_status(
@@ -144,6 +200,62 @@ async def _incoming_event_recent(
     )
 
 
+async def _task_list(
+    *,
+    overlay: str | None = None,
+    status: str | None = None,
+    phase: str | None = None,
+    ticket: str | None = None,
+    limit: int = 50,
+) -> list[dict[str, Any]]:
+    """The autonomous loop's task queue — the mirror of ``t3 <overlay> tasks list``.
+
+    ``status`` filters to one status (pending / claimed / completed / failed).
+    ``phase`` matches any spelling of a phase (short verb or gerund). ``ticket``
+    narrows to one ticket (pk / issue number / URL). ``overlay`` scopes the
+    queue. Returns each task's phase, status, target, subject, and claim, newest
+    first.
+    """
+    return await sync_to_async(search.task_list, thread_sensitive=True)(
+        overlay=overlay,
+        status=status,
+        phase=phase,
+        ticket=ticket,
+        limit=limit,
+    )
+
+
+async def _config_setting_get(key: str, *, overlay: str | None = None) -> dict[str, Any]:
+    """A config setting's effective value, its source (db vs file/env), and scope.
+
+    ``key`` is the setting name (e.g. ``mode``, ``require_human_approval_to_merge``).
+    ``overlay`` reads that overlay's scope; omitted reads the global scope. An
+    unknown key is reported ``known=false`` rather than raising.
+    """
+    return await sync_to_async(search.config_setting_get, thread_sensitive=True)(key=key, overlay=overlay)
+
+
+async def _gate_status(*, overlay: str | None = None) -> dict[str, Any]:
+    """The review-gate and raw-merge gate state — the merge-governing gates at a glance.
+
+    ``review_gate`` reports whether a human must approve a merge and the
+    review-phase evidence gates; ``raw_merge_gate`` reports whether raw
+    ``gh``/``glab`` merges are blocked. Scope to an overlay with ``overlay``.
+    """
+    return await sync_to_async(search.gate_status, thread_sensitive=True)(overlay=overlay)
+
+
+async def _command_search(query: str, *, limit: int = 20) -> list[dict[str, Any]]:
+    """Which `t3` CLI leaf command to run for a task — the discoverability read.
+
+    Given a natural-language ``query`` returns the matching `t3` leaf commands,
+    each with the full ``path``, a one-line ``summary``, and ``emits_json``
+    (whether it exposes a ``--json`` / ``--format`` output to parse). Use this
+    when unsure which command exists instead of guessing a subcommand.
+    """
+    return await sync_to_async(search.command_search, thread_sensitive=True)(query=query, limit=limit)
+
+
 def build_server() -> FastMCP:
     """Assemble a fresh stdio MCP server with the read-only search tools registered.
 
@@ -152,10 +264,16 @@ def build_server() -> FastMCP:
     configured (the ``t3 mcp serve`` entry point calls ``ensure_django`` first).
     """
     server: FastMCP = FastMCP("teatree", instructions=_INSTRUCTIONS)
+    server.add_tool(_command_search, name="command_search", annotations=_READ_ONLY)
     server.add_tool(_ticket_search, name="ticket_search", annotations=_READ_ONLY)
+    server.add_tool(_ticket_list, name="ticket_list", annotations=_READ_ONLY)
+    server.add_tool(_ticket_get, name="ticket_get", annotations=_READ_ONLY)
     server.add_tool(_worktree_status, name="worktree_status", annotations=_READ_ONLY)
     server.add_tool(_pr_for_ticket, name="pr_for_ticket", annotations=_READ_ONLY)
+    server.add_tool(_task_list, name="task_list", annotations=_READ_ONLY)
     server.add_tool(_loop_stats, name="loop_stats", annotations=_READ_ONLY)
+    server.add_tool(_config_setting_get, name="config_setting_get", annotations=_READ_ONLY)
+    server.add_tool(_gate_status, name="gate_status", annotations=_READ_ONLY)
     server.add_tool(_factory_signals, name="factory_signals", annotations=_READ_ONLY)
     server.add_tool(_incoming_event_recent, name="incoming_event_recent", annotations=_READ_ONLY)
     # T4-PR-2 — the recipe-weighted score is a DARK feature-flagged surface: it is

--- a/tests/teatree_cli/test_cli_mcp.py
+++ b/tests/teatree_cli/test_cli_mcp.py
@@ -200,10 +200,16 @@ class TestServeSubprocessSmoke:
         tool_names, payload = asyncio.run(_round_trip(env))
 
         assert tool_names == {
+            "command_search",
             "ticket_search",
+            "ticket_list",
+            "ticket_get",
             "worktree_status",
             "pr_for_ticket",
+            "task_list",
             "loop_stats",
+            "config_setting_get",
+            "gate_status",
             "factory_signals",
             "incoming_event_recent",
         }

--- a/tests/teatree_mcp/test_command_catalogue.py
+++ b/tests/teatree_mcp/test_command_catalogue.py
@@ -1,0 +1,86 @@
+"""Tests for the `command_search` discoverability tool and its catalogue seam.
+
+The pure ranking (`search_commands`) is exercised against an explicit catalogue
+so it needs no CLI. The provider-inversion round-trip is exercised on the seam's
+own register/build pair. The real end-to-end path is exercised by importing
+`teatree.cli` (which registers the live catalogue provider at import time) and
+searching the actual `t3` command tree through `search.command_search`.
+"""
+
+import pytest
+from django.test import TestCase
+
+import teatree.cli  # noqa: F401 — import registers the live command-catalogue provider
+from teatree.mcp import command_catalogue, search
+from teatree.mcp.command_catalogue import CommandRecord, search_commands
+
+
+def _fixture_catalogue() -> list[CommandRecord]:
+    return [
+        CommandRecord(
+            path="t3 teatree worktree provision",
+            summary="Provision a worktree's DB and env.",
+            emits_json=False,
+        ),
+        CommandRecord(path="t3 cost", summary="Show the session cost report.", emits_json=True),
+        CommandRecord(path="t3 loop tick", summary="Run one autonomous loop tick.", emits_json=False),
+    ]
+
+
+class TestSearchCommands:
+    def test_matches_on_path_tokens(self) -> None:
+        rows = search_commands("worktree provision", catalogue=_fixture_catalogue(), limit=10)
+
+        assert rows[0]["path"] == "t3 teatree worktree provision"
+
+    def test_matches_on_summary_words(self) -> None:
+        rows = search_commands("session cost", catalogue=_fixture_catalogue(), limit=10)
+
+        assert any(row["path"] == "t3 cost" for row in rows)
+
+    def test_carries_the_emits_json_flag(self) -> None:
+        rows = search_commands("cost", catalogue=_fixture_catalogue(), limit=10)
+
+        assert rows[0]["emits_json"] is True
+
+    def test_blank_query_returns_nothing(self) -> None:
+        assert search_commands("   ", catalogue=_fixture_catalogue(), limit=10) == []
+
+    def test_no_match_returns_empty(self) -> None:
+        assert search_commands("zzznotacommand", catalogue=_fixture_catalogue(), limit=10) == []
+
+    def test_limit_caps_the_result_count(self) -> None:
+        catalogue = [CommandRecord(path=f"t3 group{n} run", summary="run a thing", emits_json=False) for n in range(10)]
+
+        rows = search_commands("run", catalogue=catalogue, limit=3)
+
+        assert len(rows) == 3
+
+
+class TestProviderInversion:
+    def test_default_provider_fails_loud(self) -> None:
+        with pytest.raises(RuntimeError, match="not registered"):
+            command_catalogue._unregistered_provider()
+
+    def test_register_and_build_round_trip(self) -> None:
+        records = [CommandRecord(path="t3 x", summary="y", emits_json=False)]
+        original = command_catalogue._provider
+        command_catalogue.register_command_catalogue_provider(lambda: records)
+        try:
+            assert command_catalogue.build_command_catalogue() == records
+        finally:
+            command_catalogue.register_command_catalogue_provider(original)
+
+
+class TestRealCliProvider(TestCase):
+    def test_a_known_leaf_resolves_through_command_search(self) -> None:
+        rows = search.command_search(query="mcp serve", limit=50)
+
+        assert any(row["path"] == "t3 mcp serve" for row in rows)
+
+    def test_a_json_emitting_command_is_flagged(self) -> None:
+        rows = search.command_search(query="cost", limit=50)
+
+        cost = next((row for row in rows if row["path"] == "t3 cost"), None)
+        assert cost is not None
+        assert cost["emits_json"] is True

--- a/tests/teatree_mcp/test_search.py
+++ b/tests/teatree_mcp/test_search.py
@@ -5,9 +5,12 @@ result of the query function — the manager reuse (overlay scoping, in-flight,
 resolve) is exercised end to end against the test DB, not mocked.
 """
 
+from pathlib import Path
+
+from django.core.management import call_command
 from django.test import TestCase
 
-from teatree.core.models import IncomingEvent, PullRequest, Task, Ticket
+from teatree.core.models import ConfigSetting, IncomingEvent, PullRequest, Task, Ticket
 from teatree.mcp import search
 from tests.factories import (
     IncomingEventFactory,
@@ -204,6 +207,179 @@ class TestFactoryScore(TestCase):
 
     def test_window_days_flows_through(self) -> None:
         assert search.factory_score(window_days=14)["window_days"] == 14
+
+
+class TestConfigSettingGet(TestCase):
+    def test_db_override_reports_db_source(self) -> None:
+        ConfigSetting.objects.set_value("factory_score_enabled", value=True)
+
+        row = search.config_setting_get(key="factory_score_enabled")
+
+        assert row["known"] is True
+        assert row["value"] is True
+        assert row["source"] == "db"
+        assert row["scope"] == "global"
+
+    def test_absent_row_falls_through_to_file_env(self) -> None:
+        row = search.config_setting_get(key="factory_score_enabled")
+
+        assert row["known"] is True
+        assert row["source"] == "file/env"
+        assert isinstance(row["value"], bool)
+
+    def test_overlay_scope_row_reports_overlay_scope(self) -> None:
+        ConfigSetting.objects.set_value("factory_score_enabled", value=True, scope="t3-teatree")
+
+        row = search.config_setting_get(key="factory_score_enabled", overlay="t3-teatree")
+
+        assert row["source"] == "db"
+        assert row["scope"] == "overlay:t3-teatree"
+        assert row["overlay"] == "t3-teatree"
+
+    def test_unknown_key_is_flagged_not_raised(self) -> None:
+        row = search.config_setting_get(key="not_a_real_setting")
+
+        assert row["known"] is False
+        assert row["value"] is None
+
+    def test_path_valued_setting_is_coerced_to_a_string(self) -> None:
+        # A Path fallback (workspace_dir) is not JSON-serializable — it must be
+        # stringified so the read-only tool never fails at the JSON boundary.
+        row = search.config_setting_get(key="workspace_dir")
+
+        assert isinstance(row["value"], str)
+
+    def test_list_valued_setting_round_trips_as_a_list(self) -> None:
+        row = search.config_setting_get(key="excluded_skills")
+
+        assert isinstance(row["value"], list)
+
+
+class TestJsonable:
+    def test_primitives_and_none_pass_through(self) -> None:
+        assert search._jsonable(None) is None
+        assert search._jsonable(value=True) is True
+        assert search._jsonable(3) == 3
+        assert search._jsonable("x") == "x"
+
+    def test_nested_containers_are_coerced_recursively(self) -> None:
+        coerced = search._jsonable({"p": Path("/tmp/x"), "nums": [1, 2]})
+
+        assert coerced == {"p": "/tmp/x", "nums": [1, 2]}
+
+    def test_a_non_json_scalar_is_stringified(self) -> None:
+        assert search._jsonable(object()).startswith("<object object")
+
+
+class TestTicketGet(TestCase):
+    def test_resolves_by_pk_and_returns_detail(self) -> None:
+        ticket = TicketFactory(issue_url="https://x/issues/500", short_description="detail me")
+
+        row = search.ticket_get(ticket=str(ticket.pk))
+
+        assert row["id"] == ticket.pk
+        assert row["short_description"] == "detail me"
+        assert row["visited_phases"] == []
+
+    def test_resolves_by_bare_issue_number(self) -> None:
+        ticket = TicketFactory(issue_url="https://github.com/souliane/teatree/issues/501")
+
+        row = search.ticket_get(ticket="501")
+
+        assert row["id"] == ticket.pk
+
+    def test_surfaces_visited_phases_from_the_session_ledger(self) -> None:
+        ticket = TicketFactory(issue_url="https://x/issues/502")
+        SessionFactory(ticket=ticket, visited_phases=["scoping", "planning"])
+
+        row = search.ticket_get(ticket=str(ticket.pk))
+
+        assert row["visited_phases"] == ["scoping", "planning"]
+
+    def test_unknown_ticket_returns_empty_dict(self) -> None:
+        assert search.ticket_get(ticket="999999") == {}
+
+
+class TestTicketList(TestCase):
+    def test_filters_by_state(self) -> None:
+        coded = TicketFactory(state=Ticket.State.CODED, issue_url="https://x/issues/510")
+        TicketFactory(state=Ticket.State.MERGED, issue_url="https://x/issues/511")
+
+        rows = search.ticket_list(state=Ticket.State.CODED)
+
+        assert [row["id"] for row in rows] == [coded.pk]
+
+    def test_in_flight_excludes_delivered(self) -> None:
+        live = TicketFactory(state=Ticket.State.STARTED, issue_url="https://x/issues/512")
+        TicketFactory(state=Ticket.State.DELIVERED, issue_url="https://x/issues/513")
+
+        ids = {row["id"] for row in search.ticket_list(in_flight=True)}
+
+        assert ids == {live.pk}
+
+    def test_overlay_scopes_the_list(self) -> None:
+        mine = TicketFactory(overlay="t3-teatree", issue_url="https://x/issues/514")
+        TicketFactory(overlay="other-overlay", issue_url="https://x/issues/515")
+
+        ids = {row["id"] for row in search.ticket_list(overlay="t3-teatree")}
+
+        assert mine.pk in ids
+
+
+class TestTaskList(TestCase):
+    def test_filters_by_status(self) -> None:
+        pending = TaskFactory(status=Task.Status.PENDING)
+        TaskFactory(status=Task.Status.COMPLETED)
+
+        rows = search.task_list(status=Task.Status.PENDING)
+
+        assert [row["id"] for row in rows] == [pending.pk]
+        assert rows[0]["status"] == Task.Status.PENDING
+
+    def test_phase_filter_accepts_any_spelling(self) -> None:
+        review = TaskFactory(phase="review")
+        TaskFactory(phase="coding")
+
+        ids = {row["id"] for row in search.task_list(phase="reviewing")}
+
+        assert ids == {review.pk}
+
+    def test_scopes_to_a_ticket_reference(self) -> None:
+        ticket = TicketFactory(issue_url="https://x/issues/520")
+        mine = TaskFactory(ticket=ticket)
+        TaskFactory()  # a task on a different ticket
+
+        rows = search.task_list(ticket=str(ticket.pk))
+
+        assert [row["id"] for row in rows] == [mine.pk]
+
+    def test_serializes_ticket_number_and_subject(self) -> None:
+        ticket = TicketFactory(issue_url="https://x/issues/521", short_description="do the thing")
+        TaskFactory(ticket=ticket, phase="coding")
+
+        row = search.task_list(ticket=str(ticket.pk))[0]
+
+        assert row["ticket_number"] == ticket.ticket_number
+        assert row["phase"] == "coding"
+        assert row["subject"]
+
+    def test_unknown_ticket_returns_empty(self) -> None:
+        assert search.task_list(ticket="999999") == []
+
+
+class TestGateStatus(TestCase):
+    def test_reports_review_and_raw_merge_gate_shape(self) -> None:
+        report = search.gate_status()
+
+        assert isinstance(report["review_gate"]["require_human_approval_to_merge"], bool)
+        assert isinstance(report["raw_merge_gate"]["out_of_band_merge_gate_enabled"], bool)
+
+    def test_review_gate_reflects_a_config_override(self) -> None:
+        call_command("config_setting", "set", "require_human_approval_to_merge", "false")
+
+        report = search.gate_status()
+
+        assert report["review_gate"]["require_human_approval_to_merge"] is False
 
 
 class TestIncomingEventRecent(TestCase):

--- a/tests/teatree_mcp/test_server.py
+++ b/tests/teatree_mcp/test_server.py
@@ -21,11 +21,17 @@ from tests.factories import TaskFactory, TicketFactory
 
 _EXPECTED_TOOLS = {
     "ticket_search",
+    "ticket_get",
+    "ticket_list",
     "worktree_status",
     "pr_for_ticket",
     "loop_stats",
+    "task_list",
     "factory_signals",
     "incoming_event_recent",
+    "config_setting_get",
+    "gate_status",
+    "command_search",
 }
 
 
@@ -89,6 +95,58 @@ class TestCallToolThroughServer(TestCase):
         result = async_to_sync(server.call_tool)("worktree_status", {"ticket": "999999"})
 
         assert _payloads(result) == []
+
+    def test_ticket_list_returns_real_rows(self) -> None:
+        ticket = TicketFactory(overlay="t3-teatree", state="coded", issue_url="https://x/issues/700")
+        server = build_server()
+
+        result = async_to_sync(server.call_tool)("ticket_list", {"state": "coded"})
+
+        assert ticket.pk in {payload["id"] for payload in _payloads(result)}
+
+    def test_ticket_get_returns_a_single_detail_object(self) -> None:
+        ticket = TicketFactory(issue_url="https://x/issues/701")
+        server = build_server()
+
+        result = async_to_sync(server.call_tool)("ticket_get", {"ticket": str(ticket.pk)})
+
+        payload = _payloads(result)[0]
+        assert payload["id"] == ticket.pk
+        assert "visited_phases" in payload
+
+    def test_config_setting_get_reports_the_source(self) -> None:
+        server = build_server()
+
+        result = async_to_sync(server.call_tool)("config_setting_get", {"key": "factory_score_enabled"})
+
+        payload = _payloads(result)[0]
+        assert payload["source"] in {"db", "file/env"}
+
+    def test_task_list_returns_real_rows(self) -> None:
+        task = TaskFactory(status=Task.Status.PENDING)
+        server = build_server()
+
+        result = async_to_sync(server.call_tool)("task_list", {"status": "pending"})
+
+        assert task.pk in {payload["id"] for payload in _payloads(result)}
+
+    def test_gate_status_reports_the_review_gate(self) -> None:
+        server = build_server()
+
+        result = async_to_sync(server.call_tool)("gate_status", {})
+
+        report = _payloads(result)[0]
+        assert "require_human_approval_to_merge" in report["review_gate"]
+        assert "out_of_band_merge_gate_enabled" in report["raw_merge_gate"]
+
+    def test_command_search_finds_a_real_command(self) -> None:
+        import teatree.cli  # noqa: F401, PLC0415 — registers the live command-catalogue provider
+
+        server = build_server()
+
+        result = async_to_sync(server.call_tool)("command_search", {"query": "mcp serve"})
+
+        assert any(payload["path"] == "t3 mcp serve" for payload in _payloads(result))
 
 
 class TestFactoryScoreFlagGating(TestCase):


### PR DESCRIPTION
Six MCP read tools: command_search (CLI discovery), ticket_get, ticket_list, task_list, config_setting_get, gate_status; read-skills migrated off list-parse; server-instructions updated. 88 tests; grep-gate clean.