### PR TITLE
fix(core): defer send_proxy ORM-model imports to repair the t3 CLI bootstrap (P0)

### DIFF
--- a/src/teatree/core/send_proxy.py
+++ b/src/teatree/core/send_proxy.py
@@ -26,9 +26,14 @@ carrying the delegation provenance (#119 reads it). The proxy is **fail-open in
 audit-write failure degrades to "allow, unredacted, unaudited" and is logged, so
 the proxy can sit on the hot outbound path without ever breaking a send.
 
-Home is :mod:`teatree.core`: it imports config, the ``SendAudit`` model, the
-overlay loader (for the allowlist + redact terms), and the shared
-:mod:`teatree.hooks.term_match` matcher — no edge into ``teatree.backends``.
+Home is :mod:`teatree.core`: it imports config, the overlay loader (for the
+allowlist + redact terms), and the shared :mod:`teatree.hooks.term_match`
+matcher — no edge into ``teatree.backends``. The ``SendAudit`` / ``Provenance``
+model imports are DEFERRED into the functions that use them: this module sits on
+the CLI bootstrap path (``teatree.cli.review.service`` imports it at module
+scope, reached from ``teatree.cli`` before ``django.setup()``), so a top-level
+``teatree.core.models.*`` import would drag the whole model registry in
+pre-app-registry and raise ``ImproperlyConfigured``.
 """
 
 import logging
@@ -37,16 +42,20 @@ import re
 from dataclasses import dataclass, field
 from enum import StrEnum
 from fnmatch import fnmatch
+from typing import TYPE_CHECKING
 
 from django.db import DatabaseError, transaction
 
 from teatree.config import get_effective_settings
 from teatree.config.enums import SendProxyMode
-from teatree.core.models.provenance import Provenance
-from teatree.core.models.send_audit import SendAudit
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.session_identity import current_session_id
 from teatree.utils import secrets
+
+if TYPE_CHECKING:
+    # Annotation-only: keeps ``_audit_verdict``'s return type resolvable to the
+    # ORM model without a runtime import on the pre-app-registry bootstrap path.
+    from teatree.core.models.send_audit import SendAudit
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +97,19 @@ class SendChannel(StrEnum):
     OTHER = "other"
 
 
+def _default_provenance() -> str:
+    """The default ``SendRequest.provenance`` — ``Provenance.OWNER`` (the operator's own send).
+
+    A ``default_factory`` (not a class-body constant) so the ``Provenance``
+    import stays deferred: the enum lives in the ``teatree.core.models`` package,
+    whose ``__init__`` eagerly loads the ORM model registry, and evaluating it at
+    class-definition time would break the pre-app-registry CLI bootstrap path.
+    """
+    from teatree.core.models.provenance import Provenance  # noqa: PLC0415 — deferred: ORM model pkg, pre-app-registry
+
+    return Provenance.OWNER.value
+
+
 @dataclass(frozen=True, slots=True)
 class SendRequest:
     """One outbound artifact presented to the proxy for policy + audit.
@@ -107,7 +129,7 @@ class SendRequest:
     target: str = ""
     overlay: str = ""
     authorized_by: str = ""
-    provenance: str = Provenance.OWNER.value
+    provenance: str = field(default_factory=_default_provenance)
     is_self_dm: bool = False
 
 
@@ -281,6 +303,8 @@ def _record_audit(request: SendRequest, verdict: SendVerdict) -> None:
     ``max_length``, and a Postgres backend would otherwise raise on an overlong
     destination/target) so a pathological ref can never break the audit write.
     """
+    from teatree.core.models.send_audit import SendAudit  # noqa: PLC0415 — deferred: ORM model, pre-app-registry
+
     overlay = request.overlay or os.environ.get("T3_OVERLAY_NAME", "") or ""
     try:
         with transaction.atomic():
@@ -307,6 +331,8 @@ def _record_audit(request: SendRequest, verdict: SendVerdict) -> None:
 
 def _audit_verdict(verdict: SendVerdict) -> "SendAudit.Verdict":
     """Map a :class:`SendVerdict` onto the audit's tri-state verdict enum."""
+    from teatree.core.models.send_audit import SendAudit  # noqa: PLC0415 — deferred: ORM model, pre-app-registry
+
     if verdict.allowlist_ok:
         return SendAudit.Verdict.ALLOWED
     if verdict.mode is SendProxyMode.ENFORCE:

--- a/tests/quality/deferred_import_pegs.toml
+++ b/tests/quality/deferred_import_pegs.toml
@@ -10,6 +10,7 @@
 [intra_core]
 "src/teatree/core/_checking_gather.py" = 5
 "src/teatree/core/apps.py" = 2
+"src/teatree/core/backend_factory.py" = 3
 "src/teatree/core/checking.py" = 2
 "src/teatree/core/cleanup/cleanup.py" = 1
 "src/teatree/core/cost.py" = 1
@@ -76,6 +77,7 @@
 "src/teatree/core/reply_transport.py" = 1
 "src/teatree/core/safe_kill.py" = 1
 "src/teatree/core/intake/scope_cache.py" = 1
+"src/teatree/core/send_proxy.py" = 3
 "src/teatree/core/signals.py" = 6
 "src/teatree/core/speak.py" = 2
 "src/teatree/core/provision/step_runner.py" = 4

--- a/tests/teatree_cli/test_review_django_bootstrap.py
+++ b/tests/teatree_cli/test_review_django_bootstrap.py
@@ -26,8 +26,17 @@ INSTALLED_APPS, but settings are not configured``. The bug was originally
 masked by typer's rich-traceback handler exiting 0 — see souliane/teatree#932
 for the management-command equivalent.
 
-These tests pin both invariants via subprocesses (a clean child interpreter
-state) so future code additions cannot silently re-break either one.
+The same failure class re-surfaced from a different chokepoint: #117's
+:mod:`teatree.core.send_proxy` is imported at module scope by
+:mod:`teatree.cli.review.service`, which ``teatree.cli.__init__`` imports
+eagerly — so a top-level ``teatree.core.models.*`` import in ``send_proxy``
+drags the whole ORM model registry in pre-app-registry and breaks a bare
+``import teatree.cli`` / ``t3 --help``. ``TestCliImportSafePreBootstrap`` and
+``TestSendProxyIsImportSafePreBootstrap`` pin that ``send_proxy`` stays
+import-safe (its model imports deferred into the functions that use them).
+
+These tests pin every invariant via subprocesses (a clean child interpreter
+state) so future code additions cannot silently re-break any one.
 """
 
 import os
@@ -64,6 +73,71 @@ class TestOnBehalfGateRecordedIsImportSafePreBootstrap:
             "    'on_behalf_gate_recorded must not eagerly import the ORM models — '\n"
             "    'the import must be lazy inside require_on_behalf_approval so the '\n"
             "    'CLI can be loaded before django.setup() (souliane/teatree#1003)'\n"
+            ")\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=_clean_env(),
+        )
+        assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+
+
+class TestCliImportSafePreBootstrap:
+    """A bare ``import teatree.cli`` must not require Django to be configured.
+
+    ``teatree.cli.__init__`` eagerly imports :mod:`teatree.cli.review`, whose
+    :mod:`teatree.cli.review.service` imports :mod:`teatree.core.send_proxy` at
+    module scope. If ``send_proxy`` imports ``teatree.core.models.*`` at the top
+    level, that pulls in the whole ORM model registry before ``django.setup()``
+    and every ``t3`` invocation (including ``t3 --help``) crashes with
+    ``ImproperlyConfigured`` at bootstrap. This drives the raw import in a clean
+    child interpreter, the way the ``t3`` console script reaches it.
+    """
+
+    def test_import_teatree_cli_does_not_raise_improperly_configured(self) -> None:
+        probe = "import teatree.cli  # noqa: F401\nprint('cli-import-ok')\n"
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=_clean_env(),
+        )
+        assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        assert "ImproperlyConfigured" not in result.stderr
+        assert "cli-import-ok" in result.stdout
+
+
+class TestSendProxyIsImportSafePreBootstrap:
+    """:mod:`teatree.core.send_proxy` is on the CLI bootstrap path — keep it ORM-free at import.
+
+    ``send_proxy`` uses the ``SendAudit`` and ``Provenance`` models, but only
+    inside the functions that touch them (the audit writer / the ``SendRequest``
+    provenance default-factory). A child interpreter imports the module with
+    ``DJANGO_SETTINGS_MODULE`` unset and asserts the ``teatree.core.models``
+    package — whose ``__init__`` eager-loads every ORM model and is what raises
+    ``ImproperlyConfigured`` pre-app-registry — was never pulled into
+    ``sys.modules`` as an import side effect.
+    """
+
+    def test_module_import_does_not_eager_load_orm_models(self) -> None:
+        probe = (
+            "import sys\n"
+            "import teatree.core.send_proxy  # noqa: F401\n"
+            "leaked = [m for m in (\n"
+            "    'teatree.core.models',\n"
+            "    'teatree.core.models.send_audit',\n"
+            "    'teatree.core.models.provenance',\n"
+            "    'teatree.core.models.anthropic_active_pick',\n"
+            ") if m in sys.modules]\n"
+            "assert not leaked, (\n"
+            "    'send_proxy must not eagerly import teatree.core.models.* — the '\n"
+            "    'SendAudit / Provenance imports must be deferred into the functions '\n"
+            "    'that use them so the CLI bootstrap path stays Django-free '\n"
+            "    f'(souliane/teatree#117); leaked: {leaked}'\n"
             ")\n"
         )
         result = subprocess.run(


### PR DESCRIPTION
send_proxy imported Provenance and SendAudit at module scope on the CLI bootstrap path, so every t3 command raised ImproperlyConfigured. Deferred both into their functions, pegged the deferred-import ledger (send_proxy=3, backend_factory=3), added RED-first CLI-import regression tests. t3 --help verified clean; 41 tests pass.