### PR TITLE
feat(doctor): Slack Socket-Mode token/scope auto-management (#106)

### DIFF
--- a/src/teatree/backends/slack/socket_mode.py
+++ b/src/teatree/backends/slack/socket_mode.py
@@ -1,0 +1,123 @@
+"""Socket Mode readiness — the app-level token probe + manifest gap analysis.
+
+Socket Mode is teatree's primary inbound transport (BLUEPRINT § B5): the worker
+holds one WebSocket per overlay, opened with an app-level ``xapp-`` token
+carrying ``connections:write``. Three things must hold for events to arrive: the
+app-level token is valid, the manifest has Socket Mode enabled with the inbound
+events subscribed, and the bot carries the scopes those events require.
+
+Slack exposes NO API to mint an app-level token — it is generated once in the
+app's Basic Information page — so that single step is the only part of Socket
+Mode setup ``t3`` cannot self-provision. Everything else (the socket-mode flag,
+event subscriptions, and bot scopes) is auto-fixable through
+``apps.manifest.update``. This module is the mockable boundary the doctor check
+drives: :func:`manifest_socket_gaps` is pure, and :func:`probe_app_connections`
+isolates the one live Slack call so tests never touch the network.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from teatree.types import RawAPIDict
+
+type SlackManifest = dict[str, Any]
+type ConnectionOpener = Callable[[str], RawAPIDict]
+
+SOCKET_MODE_APP_SCOPE = "connections:write"
+
+# The inbound events teatree's Socket Mode receiver consumes: DM messages
+# (message.im), @-mentions (app_mention), and emoji reactions (reaction_added).
+REQUIRED_SOCKET_EVENTS: frozenset[str] = frozenset({"app_mention", "message.im", "reaction_added"})
+
+# The bot scopes those events require to be delivered / readable.
+REQUIRED_SOCKET_BOT_SCOPES: frozenset[str] = frozenset({"app_mentions:read", "im:history", "reactions:read"})
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestSocketGaps:
+    """What a manifest lacks for Socket Mode — empty on all counts means ready."""
+
+    socket_mode_disabled: bool
+    missing_events: frozenset[str]
+    missing_bot_scopes: frozenset[str]
+
+    @property
+    def ok(self) -> bool:
+        return not (self.socket_mode_disabled or self.missing_events or self.missing_bot_scopes)
+
+
+def manifest_socket_gaps(manifest: SlackManifest) -> ManifestSocketGaps:
+    """Compare *manifest* against the Socket Mode requirements (pure)."""
+    settings = manifest.get("settings", {})
+    events = set(settings.get("event_subscriptions", {}).get("bot_events", []))
+    bot_scopes = set(manifest.get("oauth_config", {}).get("scopes", {}).get("bot", []))
+    return ManifestSocketGaps(
+        socket_mode_disabled=not bool(settings.get("socket_mode_enabled")),
+        missing_events=frozenset(REQUIRED_SOCKET_EVENTS - events),
+        missing_bot_scopes=frozenset(REQUIRED_SOCKET_BOT_SCOPES - bot_scopes),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class AppTokenProbe:
+    """The classified result of an ``apps.connections.open`` probe."""
+
+    ok: bool
+    missing_scope: bool
+    error: str
+
+    @classmethod
+    def valid(cls) -> "AppTokenProbe":
+        return cls(ok=True, missing_scope=False, error="")
+
+
+def open_app_connection(app_token: str) -> RawAPIDict:
+    """POST ``apps.connections.open`` with *app_token*; return the raw JSON body.
+
+    The single live Slack call in the Socket Mode readiness path.
+    ``apps.connections.open`` succeeds only for an app-level (``xapp-``) token
+    carrying ``connections:write`` — so its result is a direct proof of that
+    scope. Tests inject a stub via the ``opener`` parameter of
+    :func:`probe_app_connections`.
+    """
+    response = httpx.post(
+        "https://slack.com/api/apps.connections.open",
+        headers={"Authorization": f"Bearer {app_token}"},
+        timeout=30,
+    )
+    response.raise_for_status()
+    return dict(response.json())
+
+
+def probe_app_connections(app_token: str, *, opener: ConnectionOpener = open_app_connection) -> AppTokenProbe:
+    """Classify whether *app_token* is a working ``connections:write`` app token.
+
+    ``apps.connections.open`` returns ``ok=True`` only for a valid app-level
+    token carrying ``connections:write`` — the exact capability Socket Mode
+    needs. A ``missing_scope`` (needing ``connections:write``) is flagged
+    separately so the doctor can name the precise gap; any other error surfaces
+    verbatim.
+    """
+    body = opener(app_token)
+    if body.get("ok"):
+        return AppTokenProbe.valid()
+    error = str(body.get("error", "unknown error"))
+    missing_scope = error == "missing_scope" or body.get("needed") == SOCKET_MODE_APP_SCOPE
+    return AppTokenProbe(ok=False, missing_scope=missing_scope, error=error)
+
+
+__all__ = [
+    "REQUIRED_SOCKET_BOT_SCOPES",
+    "REQUIRED_SOCKET_EVENTS",
+    "SOCKET_MODE_APP_SCOPE",
+    "AppTokenProbe",
+    "ConnectionOpener",
+    "ManifestSocketGaps",
+    "SlackManifest",
+    "manifest_socket_gaps",
+    "open_app_connection",
+    "probe_app_connections",
+]

--- a/src/teatree/cli/_doctor_checks.py
+++ b/src/teatree/cli/_doctor_checks.py
@@ -555,6 +555,32 @@ def _check_statusline(settings_path: Path | None = None) -> bool:
     return True
 
 
+def _check_slack_socket_mode() -> bool:
+    """Report + auto-fix Slack Socket Mode readiness per overlay (#106 / BLUEPRINT § B5).
+
+    Extends the existing Slack scope auto-management to Socket Mode: for every
+    Slack-backed overlay it validates the app-level ``xapp-`` token (present,
+    prefixed, carrying ``connections:write``) and auto-fixes the manifest's
+    socket-mode flag / events / bot scopes via ``apps.manifest.update`` where the
+    app-config token allows. Slack has no API to mint an app-level token, so an
+    absent one is surfaced as a single ACTION with its exact URL + ``pass`` slot.
+
+    Surfacing-only: always returns ``True`` so it never gates the overall doctor
+    exit code (Slack is optional — it must never become mandatory). Crash-proof:
+    any error degrades to a WARN so a doctor run never aborts on this check.
+    """
+    try:
+        from teatree.cli.slack_socket_doctor import check_slack_socket_mode  # noqa: PLC0415
+
+        outcome = check_slack_socket_mode()
+    except Exception as exc:  # noqa: BLE001 — doctor check must never crash the run
+        typer.echo(f"WARN  Slack Socket Mode check crashed: {exc.__class__.__name__}: {exc}")
+        return True
+    for finding in outcome.findings:
+        typer.echo(f"{finding.level.value:<5} [{finding.overlay}] {finding.message}")
+    return True
+
+
 def _check_dream_staleness() -> bool:
     """Warn when the idle-time dream consolidation cron is stale (#1933).
 

--- a/src/teatree/cli/doctor.py
+++ b/src/teatree/cli/doctor.py
@@ -33,6 +33,7 @@ from teatree.cli._doctor_checks import (
     _check_single_db,
     _check_singletons,
     _check_skills,
+    _check_slack_socket_mode,
     _check_stale_path_t3,
     _check_stale_uv_venv,
     _check_statusline,
@@ -82,6 +83,7 @@ __all__ = (
     "_check_single_db",
     "_check_singletons",
     "_check_skills",
+    "_check_slack_socket_mode",
     "_check_stale_path_t3",
     "_check_stale_uv_venv",
     "_check_statusline",
@@ -593,6 +595,14 @@ def check() -> bool:
     # (not a hard FAIL): a stale dream cron means memories pile up unpromoted,
     # which the operator should fix, but it must not red the whole doctor run.
     _check_dream_staleness()
+
+    # Slack Socket Mode readiness (#106 / BLUEPRINT § B5). Extends the Slack scope
+    # auto-management to the app-level (xapp-) token + socket-mode manifest: it
+    # reports and auto-fixes (via apps.manifest.update) where the Slack API allows,
+    # and surfaces a single actionable message for the one thing Slack cannot
+    # self-provision — minting the app-level token. Surfacing-only (never gates the
+    # exit code): Slack is optional and must never become mandatory.
+    _check_slack_socket_mode()
 
     # In-session `/login` account-switch recovery (#1916). Runs after
     # ``ensure_django`` because it builds messaging backends via the overlay

--- a/src/teatree/cli/slack_manifest.py
+++ b/src/teatree/cli/slack_manifest.py
@@ -83,7 +83,7 @@ _USER_SCOPES = [
     "users:read",
     "users:read.email",
 ]
-_BOT_EVENTS = ["app_mention", "message.im"]
+_BOT_EVENTS = ["app_mention", "message.im", "reaction_added"]
 
 
 def _user_scopes_carry_no_bot_only_scope() -> None:
@@ -151,6 +151,16 @@ def app_manifest_editor_url(app_id: str) -> str:
 def app_install_url(app_id: str) -> str:
     """Deep link to the app's install page (the one manual OAuth-consent step)."""
     return f"https://api.slack.com/apps/{app_id}/install-on-team"
+
+
+def app_level_token_url(app_id: str) -> str:
+    """Deep link to Basic Information, where App-Level (``xapp-``) Tokens are minted.
+
+    Slack has no API to create an app-level token; it is generated once in this
+    UI under "App-Level Tokens". This is the single Socket Mode step ``t3``
+    cannot automate.
+    """
+    return f"https://api.slack.com/apps/{app_id}"
 
 
 def _slack_app_api(method: str, payload: dict[str, Any], *, token: str) -> dict[str, Any]:
@@ -226,6 +236,7 @@ __all__ = [
     "_slack_app_api",
     "_user_scopes_carry_no_bot_only_scope",
     "app_install_url",
+    "app_level_token_url",
     "app_manifest_editor_url",
     "build_manifest",
     "export_manifest",

--- a/src/teatree/cli/slack_socket_doctor.py
+++ b/src/teatree/cli/slack_socket_doctor.py
@@ -1,0 +1,211 @@
+"""``t3 doctor`` Socket Mode readiness — validate + auto-fix per Slack overlay.
+
+Extends teatree's existing Slack auto-management (``t3 setup slack-provision``
+already pushes bot/user scopes via the app-config token) to cover Socket Mode
+(BLUEPRINT § B5 / issue #106). For every Slack-backed overlay in the config this:
+
+1. Validates the app-level ``xapp-`` token in the ``<token_ref>-app`` slot —
+   present, correctly prefixed, and carrying ``connections:write`` (probed via
+   ``apps.connections.open``). Slack has no API to mint an app-level token, so an
+   absent one is the single actionable human step, surfaced with its exact
+   Basic-Information URL and ``pass`` slot.
+2. Auto-fixes the manifest where the Slack API allows — enables Socket Mode and
+   adds the inbound events / bot scopes via ``apps.manifest.update`` using the
+   app-config token. With no app-config token it degrades to an actionable
+   message naming the manifest editor and the precise gaps.
+
+The doctor renderer (``_doctor_checks._check_slack_socket_mode``) consumes the
+structured :class:`SocketModeOutcome` this returns. Every live Slack call is
+funnelled through a patchable module-level name so tests never touch the network.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+import httpx
+
+from teatree.backends.slack.socket_mode import (
+    SOCKET_MODE_APP_SCOPE,
+    AppTokenProbe,
+    ManifestSocketGaps,
+    manifest_socket_gaps,
+    probe_app_connections,
+)
+from teatree.backends.slack.token_validation import APP_TOKEN_RE
+from teatree.cli.slack_app_resolve import read_overlay_field, resolve_overlay_app_id
+from teatree.cli.slack_manifest import (
+    _CONFIG_TOKEN_REF,
+    SlackManifestError,
+    app_install_url,
+    app_level_token_url,
+    app_manifest_editor_url,
+    build_manifest,
+    update_manifest,
+)
+from teatree.cli.slack_provision import _export_with_rotation, _slack_overlays
+from teatree.cli.slack_token_store import app_token_slot
+from teatree.utils.secrets import read_pass
+
+
+class Level(Enum):
+    """Severity of a Socket Mode finding, mapped to the doctor's line prefixes."""
+
+    OK = "OK"
+    ACTION = "ACTION"
+    WARN = "WARN"
+    FAIL = "FAIL"
+
+
+@dataclass(frozen=True, slots=True)
+class SocketModeFinding:
+    """One overlay-scoped Socket Mode observation the doctor renders on its own line."""
+
+    overlay: str
+    level: Level
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class SocketModeOutcome:
+    """The full set of Socket Mode findings across every Slack overlay."""
+
+    findings: tuple[SocketModeFinding, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not any(finding.level is Level.FAIL for finding in self.findings)
+
+
+def _mint_app_token_message(app_id: str, pass_key: str) -> str:
+    return (
+        f"no app-level (xapp-) token for Socket Mode. Slack cannot mint one via API — "
+        f"create it once at {app_level_token_url(app_id)} (App-Level Tokens → Generate, "
+        f"scope {SOCKET_MODE_APP_SCOPE}, name 'teatree'), then store it: `pass insert {pass_key}`."
+    )
+
+
+def _check_app_token(config_path: Path, overlay: str) -> list[SocketModeFinding]:
+    token_ref = read_overlay_field(config_path, overlay, "slack_token_ref")
+    app_id = resolve_overlay_app_id(config_path, overlay)
+    if not token_ref:
+        return [SocketModeFinding(overlay, Level.WARN, "no slack_token_ref configured — run `t3 setup slack-bot`.")]
+    slot = app_token_slot(token_ref)
+    app_token = read_pass(slot.pass_key)
+    if not app_token:
+        return [SocketModeFinding(overlay, Level.ACTION, _mint_app_token_message(app_id, slot.pass_key))]
+    if not APP_TOKEN_RE.match(app_token):
+        return [
+            SocketModeFinding(
+                overlay,
+                Level.FAIL,
+                f"app-level token in `pass {slot.pass_key}` is not an `xapp-` token — mint one at "
+                f"{app_level_token_url(app_id)} (scope {SOCKET_MODE_APP_SCOPE}) and re-store it.",
+            )
+        ]
+    try:
+        probe = probe_app_connections(app_token)
+    except httpx.HTTPError as exc:
+        return [SocketModeFinding(overlay, Level.WARN, f"could not reach Slack to verify the app-level token: {exc}.")]
+    return [_probe_finding(overlay, probe, app_id=app_id, pass_key=slot.pass_key)]
+
+
+def _probe_finding(overlay: str, probe: AppTokenProbe, *, app_id: str, pass_key: str) -> SocketModeFinding:
+    if probe.ok:
+        return SocketModeFinding(
+            overlay, Level.OK, f"app-level token valid — Socket Mode ready ({SOCKET_MODE_APP_SCOPE} granted)."
+        )
+    if probe.missing_scope:
+        return SocketModeFinding(
+            overlay,
+            Level.FAIL,
+            f"app-level token lacks {SOCKET_MODE_APP_SCOPE} — mint a new one at "
+            f"{app_level_token_url(app_id)} and store it: `pass insert {pass_key}`.",
+        )
+    return SocketModeFinding(
+        overlay, Level.WARN, f"could not verify the app-level token via apps.connections.open: {probe.error}."
+    )
+
+
+def _fixed_message(gaps: ManifestSocketGaps, app_id: str) -> str:
+    parts: list[str] = []
+    if gaps.socket_mode_disabled:
+        parts.append("enabled Socket Mode")
+    if gaps.missing_events:
+        parts.append(f"added events {', '.join(sorted(gaps.missing_events))}")
+    if gaps.missing_bot_scopes:
+        parts.append(f"added bot scopes {', '.join(sorted(gaps.missing_bot_scopes))}")
+    return f"Fixed manifest — {'; '.join(parts)}. Reinstall to consent: {app_install_url(app_id)}."
+
+
+def _no_config_token_message(app_id: str, gaps: ManifestSocketGaps) -> str:
+    missing: list[str] = []
+    if gaps.socket_mode_disabled:
+        missing.append("Socket Mode disabled")
+    if gaps.missing_events:
+        missing.append(f"events {', '.join(sorted(gaps.missing_events))}")
+    if gaps.missing_bot_scopes:
+        missing.append(f"bot scopes {', '.join(sorted(gaps.missing_bot_scopes))}")
+    docs_url = "https://api.slack.com/reference/manifests#config_tokens"
+    return (
+        f"manifest Socket Mode gaps ({'; '.join(missing)}) but no app-config token in "
+        f"`pass {_CONFIG_TOKEN_REF}` to auto-fix. Add one (create at {docs_url}): "
+        f"`pass insert {_CONFIG_TOKEN_REF}`, or edit the manifest manually at {app_manifest_editor_url(app_id)}."
+    )
+
+
+def _check_manifest(config_path: Path, overlay: str) -> list[SocketModeFinding]:
+    app_id = resolve_overlay_app_id(config_path, overlay)
+    if not app_id:
+        message = "no slack_app_id — cannot inspect the manifest; run `t3 setup slack-bot`."
+        return [SocketModeFinding(overlay, Level.WARN, message)]
+    try:
+        current = _export_with_rotation(app_id=app_id)
+    except SlackManifestError as exc:
+        return [SocketModeFinding(overlay, Level.WARN, f"could not export the manifest: {exc}.")]
+    gaps = manifest_socket_gaps(current)
+    if gaps.ok:
+        message = "manifest Socket Mode config current (socket mode on, events + scopes present)."
+        return [SocketModeFinding(overlay, Level.OK, message)]
+    if not read_pass(_CONFIG_TOKEN_REF):
+        return [SocketModeFinding(overlay, Level.ACTION, _no_config_token_message(app_id, gaps))]
+    desired = build_manifest(overlay_name=overlay)
+    try:
+        update_manifest(app_id=app_id, manifest=desired, config_token=read_pass(_CONFIG_TOKEN_REF))
+    except SlackManifestError as exc:
+        return [SocketModeFinding(overlay, Level.WARN, f"manifest update failed: {exc}.")]
+    return [SocketModeFinding(overlay, Level.OK, _fixed_message(gaps, app_id))]
+
+
+def check_slack_socket_mode(config_path: Path | None = None) -> SocketModeOutcome:
+    """Validate + auto-fix Socket Mode readiness for every Slack overlay.
+
+    ``config_path`` defaults to the canonical ``CONFIG_PATH`` resolved at call
+    time (not an import-frozen constant), so a staged ``$HOME`` in tests reads
+    the sandboxed config — no Slack overlays there means no findings and no
+    live calls.
+    """
+    if config_path is not None:
+        resolved = config_path
+    else:
+        from teatree.config import CONFIG_PATH  # noqa: PLC0415 — cold import, matches sibling doctor checks
+
+        resolved = CONFIG_PATH
+    findings: list[SocketModeFinding] = []
+    for overlay in _slack_overlays(resolved):
+        try:
+            findings.extend(_check_app_token(resolved, overlay))
+            findings.extend(_check_manifest(resolved, overlay))
+        except Exception as exc:  # noqa: BLE001 — one overlay's failure must not abort the rest
+            findings.append(
+                SocketModeFinding(overlay, Level.WARN, f"Socket Mode check crashed: {exc.__class__.__name__}: {exc}")
+            )
+    return SocketModeOutcome(findings=tuple(findings))
+
+
+__all__ = [
+    "Level",
+    "SocketModeFinding",
+    "SocketModeOutcome",
+    "check_slack_socket_mode",
+]

--- a/src/teatree/core/send_proxy.py
+++ b/src/teatree/core/send_proxy.py
@@ -37,16 +37,18 @@ import re
 from dataclasses import dataclass, field
 from enum import StrEnum
 from fnmatch import fnmatch
+from typing import TYPE_CHECKING
 
 from django.db import DatabaseError, transaction
 
 from teatree.config import get_effective_settings
 from teatree.config.enums import SendProxyMode
-from teatree.core.models.provenance import Provenance
-from teatree.core.models.send_audit import SendAudit
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.session_identity import current_session_id
 from teatree.utils import secrets
+
+if TYPE_CHECKING:
+    from teatree.core.models.send_audit import SendAudit
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +57,15 @@ REDACTION_PLACEHOLDER = "[redacted]"
 
 #: How much of the payload is kept in the audit row's non-sensitive preview.
 _PAYLOAD_SUMMARY_CHARS = 200
+
+
+def _default_owner_provenance() -> str:
+    # Deferred so importing send_proxy never triggers teatree.core.models at load —
+    # a module-top core.models import here breaks the `t3` CLI bootstrap
+    # (cli/__init__ imports send_proxy consumers before django.setup()).
+    from teatree.core.models.provenance import Provenance  # noqa: PLC0415
+
+    return Provenance.OWNER.value
 
 
 def read_posting_credential(ref: str) -> str:
@@ -107,7 +118,7 @@ class SendRequest:
     target: str = ""
     overlay: str = ""
     authorized_by: str = ""
-    provenance: str = Provenance.OWNER.value
+    provenance: str = field(default_factory=_default_owner_provenance)
     is_self_dm: bool = False
 
 
@@ -281,6 +292,8 @@ def _record_audit(request: SendRequest, verdict: SendVerdict) -> None:
     ``max_length``, and a Postgres backend would otherwise raise on an overlong
     destination/target) so a pathological ref can never break the audit write.
     """
+    from teatree.core.models.send_audit import SendAudit  # noqa: PLC0415
+
     overlay = request.overlay or os.environ.get("T3_OVERLAY_NAME", "") or ""
     try:
         with transaction.atomic():
@@ -307,6 +320,8 @@ def _record_audit(request: SendRequest, verdict: SendVerdict) -> None:
 
 def _audit_verdict(verdict: SendVerdict) -> "SendAudit.Verdict":
     """Map a :class:`SendVerdict` onto the audit's tri-state verdict enum."""
+    from teatree.core.models.send_audit import SendAudit  # noqa: PLC0415
+
     if verdict.allowlist_ok:
         return SendAudit.Verdict.ALLOWED
     if verdict.mode is SendProxyMode.ENFORCE:

--- a/tests/teatree_backends/slack/test_socket_mode.py
+++ b/tests/teatree_backends/slack/test_socket_mode.py
@@ -1,0 +1,93 @@
+"""Socket Mode readiness boundary — manifest gap analysis + app-token probe (#106/B5)."""
+
+from unittest.mock import MagicMock, patch
+
+from teatree.backends.slack.socket_mode import (
+    REQUIRED_SOCKET_BOT_SCOPES,
+    REQUIRED_SOCKET_EVENTS,
+    SOCKET_MODE_APP_SCOPE,
+    AppTokenProbe,
+    manifest_socket_gaps,
+    open_app_connection,
+    probe_app_connections,
+)
+from teatree.cli.slack_manifest import build_manifest
+
+
+class TestManifestSocketGaps:
+    def test_built_manifest_satisfies_socket_mode(self) -> None:
+        gaps = manifest_socket_gaps(build_manifest(overlay_name="acme"))
+        assert gaps.ok
+        assert gaps.socket_mode_disabled is False
+        assert gaps.missing_events == frozenset()
+        assert gaps.missing_bot_scopes == frozenset()
+
+    def test_reports_missing_reaction_added_event(self) -> None:
+        manifest = {
+            "settings": {
+                "socket_mode_enabled": True,
+                "event_subscriptions": {"bot_events": ["app_mention", "message.im"]},
+            },
+            "oauth_config": {"scopes": {"bot": sorted(REQUIRED_SOCKET_BOT_SCOPES)}},
+        }
+        gaps = manifest_socket_gaps(manifest)
+        assert gaps.missing_events == frozenset({"reaction_added"})
+        assert not gaps.ok
+
+    def test_reports_socket_mode_disabled(self) -> None:
+        manifest = {
+            "settings": {
+                "socket_mode_enabled": False,
+                "event_subscriptions": {"bot_events": sorted(REQUIRED_SOCKET_EVENTS)},
+            },
+            "oauth_config": {"scopes": {"bot": sorted(REQUIRED_SOCKET_BOT_SCOPES)}},
+        }
+        assert manifest_socket_gaps(manifest).socket_mode_disabled is True
+
+    def test_reports_missing_bot_scopes(self) -> None:
+        manifest = {
+            "settings": {
+                "socket_mode_enabled": True,
+                "event_subscriptions": {"bot_events": sorted(REQUIRED_SOCKET_EVENTS)},
+            },
+            "oauth_config": {"scopes": {"bot": ["chat:write"]}},
+        }
+        assert manifest_socket_gaps(manifest).missing_bot_scopes == REQUIRED_SOCKET_BOT_SCOPES
+
+    def test_empty_manifest_reports_everything_missing(self) -> None:
+        gaps = manifest_socket_gaps({})
+        assert gaps.socket_mode_disabled is True
+        assert gaps.missing_events == REQUIRED_SOCKET_EVENTS
+        assert gaps.missing_bot_scopes == REQUIRED_SOCKET_BOT_SCOPES
+
+
+class TestProbeAppConnections:
+    def test_ok_when_connection_opens(self) -> None:
+        probe = probe_app_connections("xapp-1", opener=lambda _t: {"ok": True, "url": "wss://x"})
+        assert probe == AppTokenProbe.valid()
+
+    def test_missing_scope_flagged(self) -> None:
+        probe = probe_app_connections(
+            "xapp-1",
+            opener=lambda _t: {"ok": False, "error": "missing_scope", "needed": SOCKET_MODE_APP_SCOPE},
+        )
+        assert probe.ok is False
+        assert probe.missing_scope is True
+
+    def test_other_error_surfaced_verbatim(self) -> None:
+        probe = probe_app_connections("xapp-1", opener=lambda _t: {"ok": False, "error": "invalid_auth"})
+        assert probe.ok is False
+        assert probe.missing_scope is False
+        assert probe.error == "invalid_auth"
+
+
+class TestOpenAppConnection:
+    def test_posts_to_apps_connections_open_and_returns_body(self) -> None:
+        response = MagicMock()
+        response.json.return_value = {"ok": True, "url": "wss://x"}
+        with patch("teatree.backends.slack.socket_mode.httpx.post", return_value=response) as post:
+            body = open_app_connection("xapp-1")
+        assert body == {"ok": True, "url": "wss://x"}
+        response.raise_for_status.assert_called_once()
+        assert post.call_args.args[0] == "https://slack.com/api/apps.connections.open"
+        assert post.call_args.kwargs["headers"]["Authorization"] == "Bearer xapp-1"

--- a/tests/teatree_cli/test_slack_socket_doctor.py
+++ b/tests/teatree_cli/test_slack_socket_doctor.py
@@ -1,0 +1,260 @@
+"""``t3 doctor`` Socket Mode readiness — validate + auto-fix per Slack overlay (#106)."""
+
+from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+
+from teatree.backends.slack.socket_mode import AppTokenProbe, ManifestSocketGaps
+from teatree.cli.slack_manifest import _CONFIG_TOKEN_REF, SlackManifestError, build_manifest
+from teatree.cli.slack_socket_doctor import Level, _fixed_message, _no_config_token_message, check_slack_socket_mode
+
+_APP_SLOT = "teatree/t3/slack-app"
+_BOT_SLOT = "teatree/t3/slack-bot"
+_CURRENT_MANIFEST = build_manifest(overlay_name="t3")
+
+
+def _config(tmp_path: Path) -> Path:
+    config = tmp_path / "teatree.toml"
+    config.write_text(
+        "[overlays.t3]\n"
+        'messaging_backend = "slack"\n'
+        'slack_token_ref = "teatree/t3/slack"\n'
+        'slack_app_id = "A_T3"\n'
+        'slack_user_id = "U1"\n',
+        encoding="utf-8",
+    )
+    return config
+
+
+def _pass(mapping: dict[str, str]) -> Callable[[str], str]:
+    return lambda key: mapping.get(key, "")
+
+
+class TestAppTokenValidation:
+    def test_missing_app_token_is_actionable(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        mapping = {_CONFIG_TOKEN_REF: "cfg", _BOT_SLOT: "xoxb-b"}
+        with (
+            patch("teatree.cli.slack_socket_doctor.read_pass", side_effect=_pass(mapping)),
+            patch("teatree.cli.slack_socket_doctor._export_with_rotation", return_value=_CURRENT_MANIFEST),
+        ):
+            outcome = check_slack_socket_mode(config)
+        actions = [f for f in outcome.findings if f.level is Level.ACTION]
+        assert any("app-level" in f.message and "connections:write" in f.message for f in actions)
+        assert any("pass insert" in f.message and _APP_SLOT in f.message for f in actions)
+        # An absent xapp token is a human step, not a broken config: no hard FAIL.
+        assert outcome.ok
+
+    def test_malformed_app_token_is_fail(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        mapping = {_CONFIG_TOKEN_REF: "cfg", _APP_SLOT: "xoxb-wrong-slot"}
+        with (
+            patch("teatree.cli.slack_socket_doctor.read_pass", side_effect=_pass(mapping)),
+            patch("teatree.cli.slack_socket_doctor._export_with_rotation", return_value=_CURRENT_MANIFEST),
+        ):
+            outcome = check_slack_socket_mode(config)
+        assert any(f.level is Level.FAIL and "xapp-" in f.message for f in outcome.findings)
+        assert outcome.ok is False
+
+    def test_app_token_missing_scope_is_reported(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        mapping = {_CONFIG_TOKEN_REF: "cfg", _APP_SLOT: "xapp-a"}
+        with (
+            patch("teatree.cli.slack_socket_doctor.read_pass", side_effect=_pass(mapping)),
+            patch(
+                "teatree.cli.slack_socket_doctor.probe_app_connections",
+                return_value=AppTokenProbe(ok=False, missing_scope=True, error="missing_scope"),
+            ),
+            patch("teatree.cli.slack_socket_doctor._export_with_rotation", return_value=_CURRENT_MANIFEST),
+        ):
+            outcome = check_slack_socket_mode(config)
+        assert any(f.level is Level.FAIL and "connections:write" in f.message for f in outcome.findings)
+
+    def test_valid_app_token_reports_ok(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        mapping = {_CONFIG_TOKEN_REF: "cfg", _APP_SLOT: "xapp-a"}
+        with (
+            patch("teatree.cli.slack_socket_doctor.read_pass", side_effect=_pass(mapping)),
+            patch("teatree.cli.slack_socket_doctor.probe_app_connections", return_value=AppTokenProbe.valid()),
+            patch("teatree.cli.slack_socket_doctor._export_with_rotation", return_value=_CURRENT_MANIFEST),
+        ):
+            outcome = check_slack_socket_mode(config)
+        assert outcome.ok
+        assert any(f.level is Level.OK and "Socket Mode ready" in f.message for f in outcome.findings)
+
+
+class TestManifestAutoFix:
+    def test_manifest_gap_is_autofixed_via_update(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        stale = build_manifest(overlay_name="t3")
+        # Drop reaction_added — the exact gap the auto-fix must close.
+        stale["settings"]["event_subscriptions"]["bot_events"] = ["app_mention", "message.im"]
+        mapping = {_CONFIG_TOKEN_REF: "cfg", _APP_SLOT: "xapp-a", _BOT_SLOT: "xoxb-b"}
+        with (
+            patch("teatree.cli.slack_socket_doctor.read_pass", side_effect=_pass(mapping)),
+            patch("teatree.cli.slack_socket_doctor.probe_app_connections", return_value=AppTokenProbe.valid()),
+            patch("teatree.cli.slack_socket_doctor._export_with_rotation", return_value=stale),
+            patch("teatree.cli.slack_socket_doctor.update_manifest", return_value={"permissions_updated": True}) as upd,
+        ):
+            outcome = check_slack_socket_mode(config)
+        upd.assert_called_once()
+        assert any(f.level is Level.OK and "reaction_added" in f.message for f in outcome.findings)
+        assert outcome.ok
+
+    def test_no_config_token_degrades_manifest_to_action(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        stale = build_manifest(overlay_name="t3")
+        stale["settings"]["socket_mode_enabled"] = False
+        mapping = {_APP_SLOT: "xapp-a"}  # no app-config token
+        with (
+            patch("teatree.cli.slack_socket_doctor.read_pass", side_effect=_pass(mapping)),
+            patch("teatree.cli.slack_socket_doctor.probe_app_connections", return_value=AppTokenProbe.valid()),
+            patch("teatree.cli.slack_socket_doctor._export_with_rotation", return_value=stale),
+            patch("teatree.cli.slack_socket_doctor.update_manifest") as upd,
+        ):
+            outcome = check_slack_socket_mode(config)
+        upd.assert_not_called()
+        assert any(f.level is Level.ACTION and _CONFIG_TOKEN_REF in f.message for f in outcome.findings)
+
+    def test_current_manifest_reports_ok(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        mapping = {_CONFIG_TOKEN_REF: "cfg", _APP_SLOT: "xapp-a"}
+        with (
+            patch("teatree.cli.slack_socket_doctor.read_pass", side_effect=_pass(mapping)),
+            patch("teatree.cli.slack_socket_doctor.probe_app_connections", return_value=AppTokenProbe.valid()),
+            patch("teatree.cli.slack_socket_doctor._export_with_rotation", return_value=_CURRENT_MANIFEST),
+            patch("teatree.cli.slack_socket_doctor.update_manifest") as upd,
+        ):
+            outcome = check_slack_socket_mode(config)
+        upd.assert_not_called()
+        assert any(f.level is Level.OK and "current" in f.message for f in outcome.findings)
+
+
+class TestOverlaySelection:
+    def test_no_slack_overlays_yields_no_findings(self, tmp_path: Path) -> None:
+        config = tmp_path / "teatree.toml"
+        config.write_text('[overlays.t3]\npath = "/repo"\n', encoding="utf-8")
+        assert check_slack_socket_mode(config).findings == ()
+
+    def test_one_overlay_failure_does_not_abort_others(self, tmp_path: Path) -> None:
+        config = tmp_path / "teatree.toml"
+        config.write_text(
+            "[overlays.t3]\n"
+            'messaging_backend = "slack"\n'
+            'slack_token_ref = "teatree/t3/slack"\n'
+            'slack_app_id = "A_T3"\n'
+            "[overlays.two]\n"
+            'messaging_backend = "slack"\n'
+            'slack_token_ref = "teatree/two/slack"\n'
+            'slack_app_id = "A_TWO"\n',
+            encoding="utf-8",
+        )
+        mapping = {_CONFIG_TOKEN_REF: "cfg", _APP_SLOT: "xapp-a", "teatree/two/slack-app": "xapp-b"}
+        with (
+            patch("teatree.cli.slack_socket_doctor.read_pass", side_effect=_pass(mapping)),
+            patch("teatree.cli.slack_socket_doctor.probe_app_connections", return_value=AppTokenProbe.valid()),
+            patch(
+                "teatree.cli.slack_socket_doctor._export_with_rotation",
+                side_effect=[RuntimeError("boom"), build_manifest(overlay_name="two")],
+            ),
+        ):
+            outcome = check_slack_socket_mode(config)
+        overlays_seen = {f.overlay for f in outcome.findings}
+        assert overlays_seen == {"t3", "two"}
+        assert any(f.overlay == "t3" and f.level is Level.WARN and "crashed" in f.message for f in outcome.findings)
+
+
+class TestDegradedPaths:
+    def _slack_config_missing_fields(self, tmp_path: Path) -> Path:
+        config = tmp_path / "teatree.toml"
+        config.write_text('[overlays.t3]\nmessaging_backend = "slack"\n', encoding="utf-8")
+        return config
+
+    def test_no_token_ref_and_no_app_id_warn(self, tmp_path: Path) -> None:
+        config = self._slack_config_missing_fields(tmp_path)
+        with patch("teatree.cli.slack_socket_doctor.read_pass", side_effect=_pass({})):
+            outcome = check_slack_socket_mode(config)
+        assert any(f.level is Level.WARN and "slack_token_ref" in f.message for f in outcome.findings)
+        assert any(f.level is Level.WARN and "slack_app_id" in f.message for f in outcome.findings)
+        assert outcome.ok
+
+    def test_probe_network_error_warns(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        mapping = {_CONFIG_TOKEN_REF: "cfg", _APP_SLOT: "xapp-a"}
+        with (
+            patch("teatree.cli.slack_socket_doctor.read_pass", side_effect=_pass(mapping)),
+            patch("teatree.cli.slack_socket_doctor.probe_app_connections", side_effect=httpx.ConnectError("down")),
+            patch("teatree.cli.slack_socket_doctor._export_with_rotation", return_value=_CURRENT_MANIFEST),
+        ):
+            outcome = check_slack_socket_mode(config)
+        assert any(f.level is Level.WARN and "could not reach Slack" in f.message for f in outcome.findings)
+
+    def test_probe_other_error_warns(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        mapping = {_CONFIG_TOKEN_REF: "cfg", _APP_SLOT: "xapp-a"}
+        with (
+            patch("teatree.cli.slack_socket_doctor.read_pass", side_effect=_pass(mapping)),
+            patch(
+                "teatree.cli.slack_socket_doctor.probe_app_connections",
+                return_value=AppTokenProbe(ok=False, missing_scope=False, error="invalid_auth"),
+            ),
+            patch("teatree.cli.slack_socket_doctor._export_with_rotation", return_value=_CURRENT_MANIFEST),
+        ):
+            outcome = check_slack_socket_mode(config)
+        assert any(f.level is Level.WARN and "invalid_auth" in f.message for f in outcome.findings)
+
+    def test_manifest_export_error_warns(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        mapping = {_CONFIG_TOKEN_REF: "cfg", _APP_SLOT: "xapp-a"}
+        with (
+            patch("teatree.cli.slack_socket_doctor.read_pass", side_effect=_pass(mapping)),
+            patch("teatree.cli.slack_socket_doctor.probe_app_connections", return_value=AppTokenProbe.valid()),
+            patch(
+                "teatree.cli.slack_socket_doctor._export_with_rotation",
+                side_effect=SlackManifestError("invalid_auth"),
+            ),
+        ):
+            outcome = check_slack_socket_mode(config)
+        assert any(f.level is Level.WARN and "could not export the manifest" in f.message for f in outcome.findings)
+
+    def test_manifest_update_error_warns(self, tmp_path: Path) -> None:
+        config = _config(tmp_path)
+        stale = build_manifest(overlay_name="t3")
+        stale["settings"]["event_subscriptions"]["bot_events"] = ["app_mention", "message.im"]
+        mapping = {_CONFIG_TOKEN_REF: "cfg", _APP_SLOT: "xapp-a"}
+        with (
+            patch("teatree.cli.slack_socket_doctor.read_pass", side_effect=_pass(mapping)),
+            patch("teatree.cli.slack_socket_doctor.probe_app_connections", return_value=AppTokenProbe.valid()),
+            patch("teatree.cli.slack_socket_doctor._export_with_rotation", return_value=stale),
+            patch("teatree.cli.slack_socket_doctor.update_manifest", side_effect=SlackManifestError("boom")),
+        ):
+            outcome = check_slack_socket_mode(config)
+        assert any(f.level is Level.WARN and "manifest update failed" in f.message for f in outcome.findings)
+
+
+class TestFindingMessages:
+    def test_fixed_message_lists_every_gap_kind(self) -> None:
+        gaps = ManifestSocketGaps(
+            socket_mode_disabled=True,
+            missing_events=frozenset({"reaction_added"}),
+            missing_bot_scopes=frozenset({"im:history"}),
+        )
+        message = _fixed_message(gaps, "A1")
+        assert "enabled Socket Mode" in message
+        assert "reaction_added" in message
+        assert "im:history" in message
+        assert "install-on-team" in message
+
+    def test_no_config_token_message_lists_every_gap_kind(self) -> None:
+        gaps = ManifestSocketGaps(
+            socket_mode_disabled=True,
+            missing_events=frozenset({"app_mention"}),
+            missing_bot_scopes=frozenset({"reactions:read"}),
+        )
+        message = _no_config_token_message("A1", gaps)
+        assert "Socket Mode disabled" in message
+        assert "app_mention" in message
+        assert "reactions:read" in message
+        assert _CONFIG_TOKEN_REF in message

--- a/tests/teatree_cli/test_slack_socket_mode_check.py
+++ b/tests/teatree_cli/test_slack_socket_mode_check.py
@@ -1,0 +1,35 @@
+"""``_check_slack_socket_mode`` doctor renderer — surfacing-only, crash-proof (#106)."""
+
+from unittest.mock import patch
+
+import pytest
+
+from teatree.cli._doctor_checks import _check_slack_socket_mode
+from teatree.cli.slack_socket_doctor import Level, SocketModeFinding, SocketModeOutcome
+
+
+class TestRenderer:
+    def test_prints_each_finding_with_level_and_overlay(self, capsys: pytest.CaptureFixture[str]) -> None:
+        outcome = SocketModeOutcome(
+            findings=(
+                SocketModeFinding("t3", Level.ACTION, "mint an app-level token"),
+                SocketModeFinding("t3", Level.OK, "manifest current"),
+            )
+        )
+        with patch("teatree.cli.slack_socket_doctor.check_slack_socket_mode", return_value=outcome):
+            assert _check_slack_socket_mode() is True
+        out = capsys.readouterr().out
+        assert "ACTION" in out
+        assert "mint an app-level token" in out
+        assert "[t3]" in out
+
+    def test_never_gates_exit_code_even_on_fail_findings(self, capsys: pytest.CaptureFixture[str]) -> None:
+        outcome = SocketModeOutcome(findings=(SocketModeFinding("t3", Level.FAIL, "token lacks connections:write"),))
+        with patch("teatree.cli.slack_socket_doctor.check_slack_socket_mode", return_value=outcome):
+            assert _check_slack_socket_mode() is True
+        assert "FAIL" in capsys.readouterr().out
+
+    def test_crash_degrades_to_warn(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("teatree.cli.slack_socket_doctor.check_slack_socket_mode", side_effect=RuntimeError("boom")):
+            assert _check_slack_socket_mode() is True
+        assert "WARN" in capsys.readouterr().out


### PR DESCRIPTION
t3 doctor validates/auto-fixes the Socket-Mode manifest (socket flag, events message.im/app_mention/reaction_added, bot scopes) via apps.manifest.update; surfaces the one-time xapp- app-level token mint as an ACTION (Slack has no API for it). Slack stays optional (never gates exit). 28 tests green.