### PR TITLE
chore(deploy): one-click Hetzner headless deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# The deploy image bakes only the toolchain + entrypoint — the teatree source
+# is cloned onto a volume at runtime, never baked. Keep the build context
+# (the repo root) small and free of secrets.
+
+.git
+**/.venv
+**/node_modules
+**/__pycache__
+**/*.pyc
+.claude/worktrees
+.mypy_cache
+.ruff_cache
+.pytest_cache
+htmlcov
+build
+dist
+artifacts
+
+# The box-side secrets file (tokens) must never enter the build context.
+deploy/teatree.env

--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -1,0 +1,80 @@
+# One-click teatree headless deploy to an existing Hetzner box.
+# Manual trigger only. No box-identifying info lives here — the server name, SSH
+# user/port, host key, and IP all come from secrets, and the resolved IP is
+# masked out of the logs. Uses no third-party actions (nothing to SHA-pin); the
+# hcloud CLI is installed from a checksum-pinned release.
+name: Deploy teatree to Hetzner
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Install hcloud CLI (checksum-pinned)
+        env:
+          HCLOUD_VERSION: v1.66.0
+          HCLOUD_SHA256: 8b1a8598858232c491f58cbf65ce1bd0ec6f725114bb62ec967a20ab03e29a86
+        run: |
+          curl -fsSL -o hcloud.tar.gz \
+            "https://github.com/hetznercloud/cli/releases/download/${HCLOUD_VERSION}/hcloud-linux-amd64.tar.gz"
+          echo "${HCLOUD_SHA256}  hcloud.tar.gz" | sha256sum -c -
+          tar -xzf hcloud.tar.gz hcloud
+          sudo install -m 0755 hcloud /usr/local/bin/hcloud
+          rm -f hcloud.tar.gz hcloud
+
+      - name: Resolve box IP (masked)
+        env:
+          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+          HETZNER_SERVER_NAME: ${{ secrets.HETZNER_SERVER_NAME }}
+        run: |
+          IP="$(hcloud server ip "$HETZNER_SERVER_NAME")"
+          echo "::add-mask::$IP"
+          echo "SERVER_IP=$IP" >> "$GITHUB_ENV"
+
+      - name: Configure SSH
+        env:
+          HETZNER_SSH_KEY: ${{ secrets.HETZNER_SSH_KEY }}
+          HETZNER_SSH_KNOWN_HOSTS: ${{ secrets.HETZNER_SSH_KNOWN_HOSTS }}
+        run: |
+          mkdir -p "$HOME/.ssh"
+          umask 077
+          printf '%s\n' "$HETZNER_SSH_KEY" > "$HOME/.ssh/id_deploy"
+          chmod 600 "$HOME/.ssh/id_deploy"
+          printf '%s\n' "$HETZNER_SSH_KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
+          chmod 600 "$HOME/.ssh/known_hosts"
+
+      - name: Write box secrets file and deploy
+        env:
+          SSH_USER: ${{ secrets.HETZNER_SSH_USER }}
+          SSH_PORT: ${{ secrets.HETZNER_SSH_PORT }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          TEATREE_GH_TOKEN: ${{ secrets.TEATREE_GH_TOKEN }}
+          T3_ADMIN_USER: ${{ secrets.T3_ADMIN_USER }}
+          T3_ADMIN_PASSWORD: ${{ secrets.T3_ADMIN_PASSWORD }}
+          GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
+          GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
+        run: |
+          SSH="ssh -p ${SSH_PORT} -i ${HOME}/.ssh/id_deploy -o UserKnownHostsFile=${HOME}/.ssh/known_hosts -o StrictHostKeyChecking=yes -o ConnectTimeout=20"
+          TARGET="${SSH_USER}@${SERVER_IP}"
+
+          # 1. Ensure the build-context checkout exists on the box.
+          $SSH "$TARGET" 'set -e; REMOTE_DIR="$HOME/teatree-deploy"; if [ ! -d "$REMOTE_DIR/.git" ]; then git clone https://github.com/souliane/teatree.git "$REMOTE_DIR"; fi; mkdir -p "$REMOTE_DIR/deploy"'
+
+          # 2. Write the secrets file (piped over stdin — never on argv or in logs; mode 600).
+          {
+            printf 'CLAUDE_CODE_OAUTH_TOKEN=%s\n' "$CLAUDE_CODE_OAUTH_TOKEN"
+            printf 'TEATREE_GH_TOKEN=%s\n' "$TEATREE_GH_TOKEN"
+            printf 'T3_ADMIN_USER=%s\n' "$T3_ADMIN_USER"
+            printf 'T3_ADMIN_PASSWORD=%s\n' "$T3_ADMIN_PASSWORD"
+            printf 'GIT_AUTHOR_NAME=%s\n' "$GIT_AUTHOR_NAME"
+            printf 'GIT_AUTHOR_EMAIL=%s\n' "$GIT_AUTHOR_EMAIL"
+          } | $SSH "$TARGET" 'umask 077; cat > "$HOME/teatree-deploy/deploy/teatree.env"'
+
+          # 3. Converge the stack (deploy.sh reads no secrets — compose's env_file does).
+          $SSH "$TARGET" 'cd "$HOME/teatree-deploy" && bash deploy/deploy.sh'

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,10 @@ e2e/.videos/
 # lives in the PR body, not a tracked file — see skills/architecture-design).
 ARCHITECTURE.md
 
+# Box-side secrets file for the Hetzner headless deploy (tokens/admin creds).
+# Written on the box by the deploy workflow; must never be committed.
+deploy/teatree.env
+
 # Captured eval transcripts (`t3 eval capture-subagent`, the `transcript`
 # backend's input) are written as a plain `<scenario>.jsonl` to the cwd / the
 # `--transcript-dir` (default the repo root). A REAL captured transcript holds

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,62 @@
+# teatree headless deployment image — one image, three roles (init/worker/admin)
+# selected by $TEATREE_ROLE. Extends the dev/Dockerfile.test toolchain and adds
+# gh. The teatree source is NOT baked: it is cloned onto a volume at runtime and
+# installed editable by the init role, so the image is just the toolchain.
+FROM ubuntu:24.04
+
+# Toolchain layer — ca-certificates, curl, git, jq, sqlite3, direnv, node 24, the
+# claude CLI (as in dev/Dockerfile.test) plus gh. No pass/gpg (auth is token-only).
+RUN apt-get update -qq && \
+    apt-get install -y -qq --no-install-recommends \
+        ca-certificates curl direnv git jq sqlite3 && \
+    curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
+    apt-get install -y -qq --no-install-recommends nodejs && \
+    install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update -qq && \
+    apt-get install -y -qq --no-install-recommends gh && \
+    npm install -g @anthropic-ai/claude-code && \
+    npm cache clean --force && \
+    rm -rf /var/lib/apt/lists/*
+
+# Non-root runtime user.
+RUN useradd -m -d /home/teatree -s /bin/bash teatree
+
+# Pre-create the volume mount points owned by teatree so a fresh named volume
+# inherits teatree ownership (Docker seeds an empty volume from the image dir).
+# /opt/teatree/uv carries the runtime-installed teatree python + venv + shims so
+# all three services see the same t3.
+RUN mkdir -p \
+        /home/teatree/teatree \
+        /home/teatree/.local/share/teatree \
+        /home/teatree/.local/share/teatree-worktrees \
+        /home/teatree/workspace/t3-workspaces \
+        /opt/teatree/uv && \
+    chown -R teatree:teatree /home/teatree /opt/teatree
+
+COPY --chmod=0755 deploy/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+USER teatree
+WORKDIR /home/teatree
+
+# uv (the only baked python toolchain) — the teatree editable install and its
+# managed Python land on the shared /opt/teatree/uv volume at runtime.
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# No XDG_DATA_HOME: with HOME=/home/teatree the default already resolves DATA_DIR
+# to ~/.local/share/teatree (the canonical DB on the teatree_data volume). Setting
+# it explicitly to that same canonical value would make paths.py refuse every
+# loop-provisioned worktree (CanonicalDBFromWorktreeError) and defeat the
+# teatree_worktrees auto-isolation volume.
+ENV PATH="/opt/teatree/uv/bin:/home/teatree/.local/bin:${PATH}" \
+    UV_TOOL_DIR=/opt/teatree/uv/tools \
+    UV_TOOL_BIN_DIR=/opt/teatree/uv/bin \
+    UV_PYTHON_INSTALL_DIR=/opt/teatree/uv/python \
+    TEATREE_CLONE_DIR=/home/teatree/teatree \
+    TEATREE_REPO_URL=https://github.com/souliane/teatree.git
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,141 @@
+# teatree headless deployment (Hetzner)
+
+Run teatree headless on a single existing Hetzner ARM64 box (CAX21, 8 GB), driven
+by one manual GitHub Action. teatree runs the autonomous loop (`t3 worker`,
+`agent_runtime=headless`), self-updates via its own loop, autostarts on reboot,
+and serves the Django admin on the box loopback for SSH-tunnel access.
+
+This is **teatree-only** — no customer or product overlays. The only registered
+overlay is the built-in `t3-teatree`.
+
+## How the one-click deploy works
+
+`Actions → Deploy teatree to Hetzner → Run workflow` (`.github/workflows/deploy-hetzner.yml`):
+
+1. Installs a checksum-pinned `hcloud` CLI and resolves the box IP from the server
+   name (the IP is masked out of the logs immediately).
+2. Writes the SSH key + known_hosts from secrets, connects with strict host-key
+   checking.
+3. Writes the box secrets file `deploy/teatree.env` over SSH (piped over stdin,
+   mode 600 — never on a command line or in logs).
+4. Runs `deploy/deploy.sh` on the box, which brings the checkout current and runs
+   `docker compose up -d --build`.
+
+The stack is three services from one image (`deploy/Dockerfile`), selected by
+`TEATREE_ROLE`:
+
+| Service | Role | Restart | Notes |
+| --- | --- | --- | --- |
+| `teatree-init` | one-shot prep | `no` | clone + editable install + `t3 setup` + DB config; exits 0 |
+| `teatree-worker` | `t3 worker` | `unless-stopped` | the loop cadence owner; `DEBUG` off |
+| `teatree-admin` | `t3 admin` | `unless-stopped` | Django admin on `127.0.0.1:8000`; `DEBUG` on (admin only) |
+
+`worker` and `admin` wait for `init` to complete, so the editable install on the
+shared clone happens exactly once. All three share named volumes, so the admin and
+the worker read the **same** `db.sqlite3` (WAL — safe concurrent reads):
+
+| Volume | Mount | Holds |
+| --- | --- | --- |
+| `teatree_src` | `/home/teatree/teatree` | the teatree clone (source) |
+| `teatree_data` | `/home/teatree/.local/share/teatree` | the canonical DB (`db.sqlite3`) |
+| `teatree_worktrees` | `/home/teatree/.local/share/teatree-worktrees` | per-worktree isolated DBs |
+| `teatree_workspaces` | `/home/teatree/workspace/t3-workspaces` | ticket worktrees |
+| `teatree_uv` | `/opt/teatree/uv` | the runtime teatree Python + venv + `t3` shims |
+
+Re-running the workflow is **idempotent** — it converges the same stack.
+
+## One-time bootstrap (on the box)
+
+Do this once as an admin on the box.
+
+1. **Create a dedicated deploy user in the docker group** and install its SSH
+   public key:
+
+   ```bash
+   sudo adduser --disabled-password --gecos "" teatree
+   sudo usermod -aG docker teatree
+   sudo -u teatree mkdir -p /home/teatree/.ssh
+   # add the deploy PUBLIC key to authorized_keys (paste the .pub contents):
+   sudo -u teatree tee -a /home/teatree/.ssh/authorized_keys < deploy-key.pub
+   sudo -u teatree chmod 700 /home/teatree/.ssh
+   sudo -u teatree chmod 600 /home/teatree/.ssh/authorized_keys
+   ```
+
+2. **Install Docker Engine + the compose plugin** and enable it on boot:
+
+   ```bash
+   curl -fsSL https://get.docker.com | sudo sh
+   sudo systemctl enable --now docker
+   ```
+
+   (`deploy.sh` also runs `systemctl enable --now docker` if it isn't active; give
+   the deploy user passwordless sudo for that one command if you want the workflow
+   to self-heal it, otherwise this bootstrap step covers it.)
+
+3. **Clone the build context** for the deploy user (the workflow also clones it if
+   absent):
+
+   ```bash
+   sudo -u teatree git clone https://github.com/souliane/teatree.git /home/teatree/teatree-deploy
+   ```
+
+   The deploy always builds the checkout's current branch (default `main`).
+
+### GitHub repository secrets to set
+
+| Secret | Purpose |
+| --- | --- |
+| `HCLOUD_TOKEN` | Hetzner Cloud API token (read-only is enough) to resolve the box IP |
+| `HETZNER_SERVER_NAME` | the Cloud server name to resolve |
+| `HETZNER_SSH_USER` | the deploy user (e.g. `teatree`) |
+| `HETZNER_SSH_PORT` | the SSH port |
+| `HETZNER_SSH_KEY` | the deploy **private** SSH key |
+| `HETZNER_SSH_KNOWN_HOSTS` | the box's host key line(s) for strict checking |
+| `CLAUDE_CODE_OAUTH_TOKEN` | Claude Code OAuth token — the headless auth |
+| `TEATREE_GH_TOKEN` | GitHub token for the loop (clone/read/PRs) |
+| `T3_ADMIN_USER` | Django admin superuser name |
+| `T3_ADMIN_PASSWORD` | Django admin superuser password |
+| `GIT_AUTHOR_NAME` | git identity for the loop's commits |
+| `GIT_AUTHOR_EMAIL` | git identity email (use a GitHub noreply for public repos) |
+
+The `known_hosts` line comes from `ssh-keyscan -p <port> <box-host>` (run once,
+verify the fingerprint out of band).
+
+## Access & networking
+
+- **Admin (Django):** the admin binds to the box loopback only. Reach it through an
+  SSH tunnel — no port is exposed publicly:
+
+  ```bash
+  ssh -L 8000:localhost:8000 -p <ssh-port> <ssh-user>@<box-host>
+  # then open http://localhost:8000/admin
+  ```
+
+  There is **no admin login prompt**: while DEBUG is on (the admin service), the
+  auto-login middleware authenticates the first superuser on every `/admin/`
+  request, so the **SSH tunnel to the loopback — not an admin password — is the
+  security boundary**. `T3_ADMIN_USER` / `T3_ADMIN_PASSWORD` still seed that
+  superuser row deterministically (they only matter as a password in a DEBUG-off
+  context).
+
+- **No Tailscale.** SSH is the only inbound port. This works with a corporate VPN
+  up — the tunnel rides your normal SSH access.
+- **Loop notifications / questions** go out over Slack (Socket Mode, outbound only)
+  — no inbound webhook, nothing extra to expose.
+- **Autostart on reboot:** the compose `restart: unless-stopped` policy plus Docker
+  enabled on boot bring the worker and admin back after a reboot.
+- **Updates:** teatree self-updates in-loop via `t3 update` (deferred reinstall on
+  the editable clone). There is **no** second workflow and no quiescence probe — a
+  re-run of the deploy workflow is only needed for infra/compose/image changes.
+
+## Caveats
+
+- **Headless orchestration is still maturing** — expect to babysit early runs via
+  the admin and Slack.
+- **The admin is a Django dev server** behind a loopback + SSH tunnel. Never expose
+  it publicly; `DEBUG` is on for the admin service only (the worker runs with
+  `DEBUG` off to avoid `connection.queries` growth in a long-running process).
+- **The OAuth token shares your weekly Claude quota and does not auto-refresh** —
+  rotate `CLAUDE_CODE_OAUTH_TOKEN` manually and re-run the workflow when it expires.
+- **teatree-only:** this deployment never clones or references any customer or
+  product overlay — only the built-in `t3-teatree`.

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Converge the teatree headless stack on the box. Idempotent: re-running brings
+# the checkout current, rebuilds the image, and re-applies the compose stack.
+# Run as the deploy user (in the docker group) from the repo checkout.
+# Reads NO secrets — compose's env_file (deploy/teatree.env) supplies them.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
+ENV_FILE="$SCRIPT_DIR/teatree.env"
+
+# Docker installed + enabled on boot (so the stack autostarts after a reboot,
+# alongside the compose restart policies). is-active needs no root, so the
+# common case (docker already running) never invokes sudo.
+if ! command -v docker >/dev/null 2>&1; then
+    echo "deploy: docker is not installed — see deploy/README.md bootstrap." >&2
+    exit 1
+fi
+if ! systemctl is-active --quiet docker; then
+    sudo systemctl enable --now docker
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+    echo "deploy: missing $ENV_FILE (the deploy workflow writes it before this runs)." >&2
+    exit 1
+fi
+
+# Bring the build context current (fast-forward only — never clobber local work).
+git -C "$REPO_ROOT" fetch --prune origin
+git -C "$REPO_ROOT" pull --ff-only
+
+docker compose -f "$COMPOSE_FILE" up -d --build
+
+# Wait for the admin dev server on the box loopback (init clone + install can
+# take a few minutes on first run).
+echo "deploy: waiting for the admin service on 127.0.0.1:8000 ..."
+for _ in $(seq 1 60); do
+    if curl -fsS -o /dev/null "http://127.0.0.1:8000/admin/login/"; then
+        echo "deploy: admin is up; stack converged."
+        exit 0
+    fi
+    sleep 10
+done
+
+echo "deploy: admin did not become ready in time — recent logs:" >&2
+docker compose -f "$COMPOSE_FILE" ps >&2 || true
+docker compose -f "$COMPOSE_FILE" logs --tail 50 teatree-init teatree-admin >&2 || true
+exit 1

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,69 @@
+# teatree headless deployment — one image, three services (init/worker/admin)
+# sharing named volumes so init installs teatree once and worker/admin run it.
+#
+# The box-side secrets file `teatree.env` (next to this file, gitignored, written
+# by the deploy workflow) supplies every credential. Non-secret runtime config
+# (clone/repo paths, uv dirs) is baked into the image.
+name: teatree
+
+x-teatree-common: &teatree-common
+  image: teatree-headless:latest
+  build:
+    context: ..
+    dockerfile: deploy/Dockerfile
+  env_file:
+    - teatree.env
+  # All services mount all volumes so admin and worker share ONE db.sqlite3
+  # (WAL — safe concurrent reads) and one editable install.
+  volumes:
+    - teatree_src:/home/teatree/teatree
+    - teatree_data:/home/teatree/.local/share/teatree
+    - teatree_worktrees:/home/teatree/.local/share/teatree-worktrees
+    - teatree_workspaces:/home/teatree/workspace/t3-workspaces
+    - teatree_uv:/opt/teatree/uv
+  init: true
+
+services:
+  # One-shot prep. worker/admin wait for this to exit 0, so the editable install
+  # on the shared clone never races.
+  teatree-init:
+    <<: *teatree-common
+    environment:
+      TEATREE_ROLE: init
+    restart: "no"
+
+  # The loop cadence owner. DEBUG off — a long-running DEBUG Django process grows
+  # connection.queries unboundedly.
+  teatree-worker:
+    <<: *teatree-common
+    environment:
+      TEATREE_ROLE: worker
+      T3_DEBUG: "0"
+    depends_on:
+      teatree-init:
+        condition: service_completed_successfully
+    restart: unless-stopped
+    mem_limit: 5g
+    cpus: "3.0"
+
+  # Django admin dev server, published on the BOX loopback only (reach it via an
+  # SSH tunnel). DEBUG on (default) — required to mount /admin/.
+  teatree-admin:
+    <<: *teatree-common
+    environment:
+      TEATREE_ROLE: admin
+    depends_on:
+      teatree-init:
+        condition: service_completed_successfully
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8000:8000"
+    mem_limit: 512m
+    cpus: "0.5"
+
+volumes:
+  teatree_src:
+  teatree_data:
+  teatree_worktrees:
+  teatree_workspaces:
+  teatree_uv:

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# teatree headless deployment entrypoint. One image, three roles selected by
+# $TEATREE_ROLE:
+#   init   — one-shot prep (clone + editable install + t3 setup + DB config),
+#            exits 0. worker/admin depend on its successful completion, so the
+#            editable-install-on-the-shared-clone happens exactly once.
+#   worker — runs `t3 worker` (the loop cadence owner), DEBUG off.
+#   admin  — runs `t3 admin` (Django admin dev server) on the box loopback.
+set -euo pipefail
+
+ROLE="${TEATREE_ROLE:?TEATREE_ROLE must be one of: init, worker, admin}"
+CLONE_DIR="${TEATREE_CLONE_DIR:-/home/teatree/teatree}"
+REPO_URL="${TEATREE_REPO_URL:-https://github.com/souliane/teatree.git}"
+
+# The loop and gh use GH_TOKEN from the ambient env for GitHub access, so the
+# token never appears in a clone URL, argv, or logs.
+if [ -n "${TEATREE_GH_TOKEN:-}" ]; then
+    export GH_TOKEN="$TEATREE_GH_TOKEN"
+fi
+
+# Global git identity fallback — commits and the runtime loop need one.
+git config --global user.name "${GIT_AUTHOR_NAME:-teatree}"
+git config --global user.email "${GIT_AUTHOR_EMAIL:-teatree@localhost}"
+git config --global init.defaultBranch main
+git config --global --add safe.directory "$CLONE_DIR"
+
+ensure_clone() {
+    if [ -e "$CLONE_DIR/.git" ]; then
+        return 0
+    fi
+    if [ -n "${GH_TOKEN:-}" ]; then
+        gh auth setup-git
+    fi
+    git clone "$REPO_URL" "$CLONE_DIR"
+}
+
+case "$ROLE" in
+init)
+    ensure_clone
+    uv python install 3.13
+    uv tool install --editable "$CLONE_DIR" --reinstall --python 3.13
+    t3 setup
+    t3 teatree db migrate
+    # Values are JSON: enum strings are quoted, booleans and ints are bare.
+    t3 teatree config_setting set agent_harness '"claude_sdk"'
+    t3 teatree config_setting set agent_runtime '"headless"'
+    t3 teatree config_setting set loop_runner_enabled true
+    t3 teatree config_setting set provision_max_concurrency 1
+    t3 teatree config_setting set provision_ram_ceiling_percent 75
+    t3 teatree config_setting set max_concurrent_local_stacks 1
+    echo "teatree-init: complete"
+    ;;
+worker)
+    exec t3 worker
+    ;;
+admin)
+    exec t3 admin --host 0.0.0.0 --port 8000 --no-browser
+    ;;
+*)
+    echo "entrypoint: unknown TEATREE_ROLE '$ROLE' (expected init|worker|admin)" >&2
+    exit 64
+    ;;
+esac

--- a/src/teatree/settings.py
+++ b/src/teatree/settings.py
@@ -4,7 +4,10 @@ Used when teatree is the Django project (the standard case).
 Auto-discovers overlay Django apps via entry points and adds them to INSTALLED_APPS.
 """
 
+import os
+
 from teatree.config import default_logging
+from teatree.config.setting_parsers import _parse_env_bool_default_on
 from teatree.paths import CANONICAL_DB, DATA_DIR, DATA_DIR_AUTO_ISOLATED, seed_isolated_db
 from teatree.timeouts import CORE_DEFAULTS
 
@@ -36,7 +39,21 @@ def _discover_overlay_apps() -> list[str]:
 
 
 SECRET_KEY = "teatree-dev-insecure"  # noqa: S105 — local-dev CLI, never deployed
-DEBUG = True
+
+
+def _debug_enabled() -> bool:
+    """Whether ``DEBUG`` is on — env-gated so it can differ per service.
+
+    Default on preserves local-dev behaviour (the admin needs DEBUG to mount
+    ``/admin/`` and auto-login the superuser). A long-running Django process
+    with DEBUG on grows ``connection.queries`` unboundedly, so the headless
+    worker sets ``T3_DEBUG=0`` to run with DEBUG off while the admin service
+    leaves it on.
+    """
+    return _parse_env_bool_default_on(os.environ.get("T3_DEBUG", ""))
+
+
+DEBUG = _debug_enabled()
 ALLOWED_HOSTS = ["localhost", "127.0.0.1", "[::1]"]
 INTERNAL_IPS = ["127.0.0.1"]
 

--- a/tests/quality/test_repo_root_minimal.py
+++ b/tests/quality/test_repo_root_minimal.py
@@ -42,6 +42,7 @@ ALLOWED_ROOT = frozenset(
         "mkdocs.yml",
         ".pre-commit-config.yaml",
         ".gitignore",
+        ".dockerignore",  # headless-deploy build-context ignore (deploy/README.md is the SOT)
         ".gitlab-ci.yml",
         "requirements.audit.ignore",  # per-CVE pip-audit allowlist (CI security gate)
         ".github",
@@ -67,6 +68,7 @@ ALLOWED_ROOT = frozenset(
         "docs",
         "scripts",
         "dev",
+        "deploy",  # headless-deploy tooling (deploy/README.md is the SOT)
         "dist",
     }
 )

--- a/tests/test_dev_settings.py
+++ b/tests/test_dev_settings.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 
 from django.test import override_settings
 
+from teatree.settings import _debug_enabled
+
 
 def test_settings_importable():
     """Importing the module should execute it without errors."""
@@ -55,6 +57,24 @@ def test_discover_overlay_apps_skips_entry_points_without_django_app():
         result = mod._discover_overlay_apps()
 
     assert result == []
+
+
+def test_debug_defaults_on_and_env_disables_it(monkeypatch):
+    """DEBUG is on by default (admin needs it) but T3_DEBUG=0 turns it off (worker)."""
+    monkeypatch.delenv("T3_DEBUG", raising=False)
+    assert _debug_enabled() is True
+
+    monkeypatch.setenv("T3_DEBUG", "0")
+    assert _debug_enabled() is False
+    monkeypatch.setenv("T3_DEBUG", "false")
+    assert _debug_enabled() is False
+    monkeypatch.setenv("T3_DEBUG", "off")
+    assert _debug_enabled() is False
+
+    monkeypatch.setenv("T3_DEBUG", "1")
+    assert _debug_enabled() is True
+    monkeypatch.setenv("T3_DEBUG", "")
+    assert _debug_enabled() is True
 
 
 def test_urls_module_loads_with_admin_disabled():


### PR DESCRIPTION
Add a manual GitHub Action (workflow_dispatch) that converges teatree headless on an existing Hetzner ARM64 box: three compose services from one toolchain image (init/worker/admin) sharing named volumes, so init installs teatree editable once and worker/admin run it. The worker owns the loop cadence (t3 worker, agent_runtime=headless); the admin serves Django's /admin/ on the box loopback for SSH-tunnel access. Autostart on reboot via the compose restart policy; self-update via the loop's own t3 update (no second workflow). teatree-only.

Gate DEBUG on an env var (T3_DEBUG, default on) so the admin service can mount /admin/ while the long-running worker runs DEBUG off: a DEBUG-on Django process grows connection.queries unboundedly.

No box-identifying info is committed: server name, SSH user/port, host key, and the resolved IP all come from secrets, and the IP is masked out of the workflow logs. The box secrets file is written over SSH and never committed.