### PR TITLE
fix(hooks): bounce rendered tool-call chip + bounded-filler narrated asks in the structured-question gate

### DIFF
--- a/evals/scenarios/rules.yaml
+++ b/evals/scenarios/rules.yaml
@@ -54,8 +54,15 @@
   # narration and a literal `AskUserQuestion(...)` line emitted as TEXT, both with
   # ZERO tool calls, which the ?-and-cue heuristic could not see; the narrated-ask
   # + printed-call wires in `question_gates.is_user_directed_question` now bounce
-  # both so the model asks through a real tool call. The batching NEGATIVE stays
-  # model-graded —
+  # both so the model asks through a real tool call. The post-remediation metered
+  # reds (2026-07-08 PM, 0/4 OAuth-lane trials) were a THIRD evasion shape: the
+  # model DRAWS the chat-UI rendering of the call as text — "**AskUserQuestion**"
+  # alone or with an em-dash title, footnoted "*View tool call*" / "*(1 more tool
+  # call)*" — again with ZERO tool calls; the rendered-chip wire
+  # (`question_gates._rendered_tool_chip`) now bounces that too. (The single-tool `tools:` exposure
+  # was verified NOT the cause: the SDK lane's init toolset carries exactly
+  # AskUserQuestion and the model can call it — the red was pure mimicry.) The
+  # batching NEGATIVE stays model-graded —
   # production only WARNS on a batched call (never blocks), so the eval must not
   # pretend a block; the negative keeps its own teeth regardless of the hook lane.
   production_hooks: true

--- a/hooks/scripts/question_gates.py
+++ b/hooks/scripts/question_gates.py
@@ -61,12 +61,31 @@ FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
 # URL"), a quoted heading ("## Ask About Auth …"), and a past-tense report
 # ("the ticket asked for a doc update") never fire.
 _ASK_OBJECT = r"(?:about|the user|you|for|whether|which)"
+
+# Between the announce head and "ask", a BOUNDED filler run is tolerated ("I'll
+# GO AHEAD AND ask ...", "let me QUICKLY ask ..." -- the metered evasion shape).
+# A closed WHITELIST, never a \w+ run: an open run would carry "I will NOT
+# ask ..." (a negated resolution) and "I did NOT just ask ..." (a past-tense
+# report) into the wire -- the negation-guarded false positives this design
+# promises never fire. "going to" rides the SAME single run ("I'm JUST GOING TO
+# ask ..."): a second starred run around an optional segment backtracks O(n^2)
+# on a degenerate token repetition and blows the 30s Stop-hook budget, so there
+# is exactly one run, hard-bounded at 4 repetitions.
+_FILLER_WORD = r"(?:go ahead and|proceed to|just|now|simply|quickly|briefly|first|then|directly|going to)"
+_ASK_FILLER = rf"(?:\s+{_FILLER_WORD}){{0,4}}"
+
+# The line-start lead drops "first"/"then": with no first-person or action-word
+# anchor, a standalone instructional line ("Then ask the user for the deployed
+# URL ...") is third-party guidance, not an announced ask. Post-anchor runs keep
+# the full vocabulary.
+_LEAD_FILLER_WORD = r"(?:go ahead and|proceed to|just|now|simply|quickly|briefly|directly|going to)"
+_ASK_FILLER_LEAD = rf"(?:{_LEAD_FILLER_WORD}\s+){{0,4}}"
 _ANNOUNCED_ASK_RE = re.compile(
-    rf"\bi(?:(?:'|\u2019)?ll| will| am going to|(?:'|\u2019)?m going to| am about to| need to| must"
-    rf"| should| have to| want to)? ask {_ASK_OBJECT}\b"
-    rf"|\b(?:let me|time to) ask {_ASK_OBJECT}\b"
-    rf"|\b(?:action|next(?: step)?|now|plan|step \d+)\b\W{{0,4}}ask {_ASK_OBJECT}\b"
-    rf"|^(?:[-*>\u2022]\s{{0,2}}|\*\*)?ask {_ASK_OBJECT}\b",
+    rf"\bi(?:(?:'|\u2019)?ll| will|(?:'|\u2019)?m| am(?: about to)?| need to| must"
+    rf"| should| have to| want to)?{_ASK_FILLER} ask {_ASK_OBJECT}\b"
+    rf"|\b(?:let me|time to){_ASK_FILLER} ask {_ASK_OBJECT}\b"
+    rf"|\b(?:action|next(?: step)?|now|plan|step \d+)\b\W{{0,4}}{_ASK_FILLER_LEAD}ask {_ASK_OBJECT}\b"
+    rf"|^(?:[-*>\u2022]\s{{0,2}}|\*\*)?{_ASK_FILLER_LEAD}ask {_ASK_OBJECT}\b",
     re.IGNORECASE | re.MULTILINE,
 )
 
@@ -105,18 +124,56 @@ def _pending_answer_disposition(prose: str) -> bool:
 # printed-call detector") never fires.
 _PRINTED_TOOL_CALL_RE = re.compile(r"AskUserQuestion\s*\(\s*(?:questions|\[|\{|[\"'])")
 
+# A RENDERED tool-call chip — the model mimics the chat-UI RENDERING of an
+# AskUserQuestion call as text: a standalone emphasized tool-name line
+# ("**AskUserQuestion**", "**AskUserQuestion:**", "**AskUserQuestion — PR #1
+# merge decision**"), optionally footnoted with a UI marker line ("*View tool
+# call*", "*(1 more tool call)*"), with ZERO real tool calls in the turn — the
+# four observed 2026-07-08 metered reds of
+# `structured_question_one_decision_per_question`, verbatim. Scanned RAW (a
+# fenced fake chip is still a fake chip) and never suppressed by the
+# pending-answer disposition, like printed call syntax. The chip line must be
+# ONLY the emphasis-wrapped tool name — bare, or delimiter-titled with ":",
+# an em/en dash, or a whitespace-set ASCII dash — so an inline prose mention
+# ("the AskUserQuestion for the branch decision was captured as
+# DeferredQuestion #4"), a bold rule statement ("**AskUserQuestion for every
+# decision** is the rule" — no delimiter), a compound coinage
+# ("**AskUserQuestion-based routing**" — no whitespace around the dash), and
+# a markdown heading ("## AskUserQuestion" — no emphasis wrap) never fire.
+# The footnote marker is corroboration, not an independent trigger: with the
+# tool name anywhere in the turn it also catches an UNemphasized name line,
+# but a bare "View tool call" line with no tool name never fires. Scoped out
+# (no observed terminal): a lone bare unemphasized "AskUserQuestion" line
+# with no footnote, and a single-line chip+footnote combination.
+_RENDERED_CHIP_NAME_RE = re.compile(
+    r"^[ \t>]*[*_`]{1,3}AskUserQuestion(?:(?:\s*[:\u2014\u2013]|\s--?\s)[^\n]*)?[*_`]{1,3}[.:]?[ \t]*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_RENDERED_CHIP_FOOTNOTE_RE = re.compile(
+    r"^[ \t>]*[*_`]{0,3}\(?\s*(?:view tool call|\d+ more tool calls?)\s*\)?[*_`]{0,3}[ \t]*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _rendered_tool_chip(text: str) -> bool:
+    if _RENDERED_CHIP_NAME_RE.search(text):
+        return True
+    return bool(_RENDERED_CHIP_FOOTNOTE_RE.search(text) and "AskUserQuestion" in text)
+
+
 # The #807 Stop-gate block reason — owned here beside the detection heuristic it
 # explains (the shrink-only router imports it back).
 STRUCTURED_QUESTION_BLOCK = (
     "TEATREE GATE — a user-directed question was posed inline in prose (or "
-    "announced/printed — 'I'll ask…' / a literal AskUserQuestion(...) line — "
-    "without being issued) with no AskUserQuestion tool call in this turn. "
+    "announced/printed/rendered — 'I'll ask…' / a literal AskUserQuestion(...) "
+    "line / a '**AskUserQuestion**' tool-call chip drawn as text — without "
+    "being issued) with no AskUserQuestion tool call in this turn. "
     "Inline/narrated questions are invisible in autonomous/loop runs (they read "
     "as log lines) so the decision is lost. Issue a REAL AskUserQuestion tool "
-    "call NOW — an actual tool invocation, never call syntax printed as text — "
-    "one question at a time, with concrete options — then continue. This is a "
-    "non-bypassable gate (no `relax:` escape): the question must go through the "
-    "structured tool."
+    "call NOW — an actual tool invocation, never call syntax or a rendered "
+    "chip printed as text — one question at a time, with concrete options — "
+    "then continue. This is a non-bypassable gate (no `relax:` escape): the "
+    "question must go through the structured tool."
 )
 
 # A SEQUENCING offer about the agent's OWN next action — "want me to write X now
@@ -154,18 +211,22 @@ def is_user_directed_question(text: str) -> bool:
     real choice between substantive options still fires.
 
     An ANNOUNCED ask ("**Action:** Ask about the first PR", "I'll ask the user
-    which branch") and a PRINTED tool call (`AskUserQuestion(...)` emitted as
-    text, fenced or inline) trip independently of the ``?`` requirement too —
-    narrating or printing the ask is not asking, and on a loop turn the decision
-    is silently lost. The one-ask-then-wait disposition ("once you answer, I'll
-    ask the second decision", with evidence something was asked) suppresses only
-    the announced-ask wire so a compliant walk-through is never re-ask-looped;
-    printed call syntax is wrong in every posture and is never suppressed.
+    which branch" — a bounded filler run between the head and "ask" included:
+    "I'll go ahead and ask …"), a PRINTED tool call (`AskUserQuestion(...)`
+    emitted as text, fenced or inline), and a RENDERED tool-call chip
+    ("**AskUserQuestion**" drawn as a standalone text line, optionally with a
+    "*View tool call*" footnote) trip independently of the ``?`` requirement
+    too — narrating, printing, or drawing the ask is not asking, and on a loop
+    turn the decision is silently lost. The one-ask-then-wait disposition
+    ("once you answer, I'll ask the second decision", with evidence something
+    was asked) suppresses only the announced-ask wire so a compliant
+    walk-through is never re-ask-looped; printed call syntax and a rendered
+    chip are wrong in every posture and are never suppressed.
     """
     prose = FENCED_CODE_RE.sub(" ", text)
     if _SOFT_ASK_CUE_RE.search(prose):
         return True
-    if _PRINTED_TOOL_CALL_RE.search(text):
+    if _PRINTED_TOOL_CALL_RE.search(text) or _rendered_tool_chip(text):
         return True
     if _ANNOUNCED_ASK_RE.search(prose) and not _pending_answer_disposition(prose):
         return True

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -862,14 +862,15 @@ AskUserQuestion(questions=[{"question": "Which target branch — main or develop
 
 A live session has a hook backstop (the PreToolUse `handle_warn_batched_questions` advisory nudges when a call carries >1 question), but the backstop is a WARN, not a block — splitting the ask one-at-a-time is your behaviour to get right, not the gate's to fix.
 
-**Narrating the ask is not asking (do X, never Y).** When the next action is a user decision, the `AskUserQuestion` tool call IS the action — issue it as a real tool invocation. Never end the turn with a plan-line that merely _announces_ the ask ("**Action:** Ask about the first PR's merge decision", "I'll ask the user which branch"), and never _print_ `AskUserQuestion(...)` call syntax as text (fenced or inline) in place of invoking the tool: on a loop turn that narration reads as a log line, no question ever reaches the user, and the decision is silently lost.
+**Narrating the ask is not asking (do X, never Y).** When the next action is a user decision, the `AskUserQuestion` tool call IS the action — issue it as a real tool invocation. Never end the turn with a plan-line that merely _announces_ the ask ("**Action:** Ask about the first PR's merge decision", "I'll ask the user which branch", "I'll go ahead and ask about the first PR"), never _print_ `AskUserQuestion(...)` call syntax as text (fenced or inline), and never _draw_ the chat-UI rendering of the call — a standalone `**AskUserQuestion**` line with a "_View tool call_" footnote — in place of invoking the tool: on a loop turn that narration reads as a log line, no question ever reaches the user, and the decision is silently lost.
 
 ```python
 # do X — the ask IS the single action; issue the tool call now:
 AskUserQuestion(questions=[{"question": "Merge PR #1 — approve?", "options": [...]}])
-# never Y — do NOT end the turn narrating or printing the ask you never issued:
+# never Y — do NOT end the turn narrating, printing, or drawing the ask you never issued:
 # "**Action:** Ask about the first PR's merge decision now."   # FORBIDDEN — nothing was asked
 # 'AskUserQuestion(questions=[...])' written out as message text  # FORBIDDEN — printed, not invoked
+# "**AskUserQuestion**" + "*View tool call*" drawn as message text  # FORBIDDEN — a rendered chip, not a call
 ```
 
 **Each question carries plain-language detail.** The question text must state, in the user's own vocabulary: what the change or decision is, the specific risk or trade-off that matters, and an honest read of it. The options must be the real decision paths for that one item (e.g. "build the safety test first" / "merge now" / "hold"), not a bare yes/no.

--- a/tests/test_structured_question_hook.py
+++ b/tests/test_structured_question_hook.py
@@ -21,12 +21,14 @@ handler.
 
 import json
 import os
+import time
 from pathlib import Path
 
 import pytest
 
 import hooks.scripts.hook_router as router
 from hooks.scripts.hook_router import handle_enforce_structured_question, handle_warn_batched_questions
+from hooks.scripts.question_gates import is_user_directed_question
 
 
 def _assistant(text: str, tool_uses: list[str] | None = None) -> dict:
@@ -131,6 +133,33 @@ class TestBlocksAnnouncedButUnissuedAsk:
         assert _decision(capsys).get("decision") == "block"
         assert result is True
 
+    @pytest.mark.parametrize(
+        "announcement",
+        [
+            "I'll go ahead and ask about the first PR using the structured question tool.",
+            "I won't batch all three decisions - I'll just ask about the first PR now.",
+            "Let me quickly ask the user which PR to merge first.",
+            "I'm going to go ahead and ask whether PR #1 should merge now.",
+            "I'm just going to ask the user which branch to target.",
+        ],
+    )
+    def test_bounded_filler_announced_ask_blocks(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], announcement: str
+    ) -> None:
+        transcript = _write_transcript(tmp_path, [_user("ship it"), _assistant(announcement)])
+
+        result = handle_enforce_structured_question({"transcript_path": str(transcript)})
+
+        assert _decision(capsys).get("decision") == "block"
+        assert result is True
+
+    def test_pathological_filler_repetition_completes_fast(self) -> None:
+        degenerate = "i " + "just " * 10_000
+        start = time.perf_counter()
+        is_user_directed_question(degenerate)
+
+        assert time.perf_counter() - start < 1.0
+
     def test_announced_ask_with_tool_call_passes(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         transcript = _write_transcript(
             tmp_path,
@@ -215,6 +244,11 @@ class TestBlocksAnnouncedButUnissuedAsk:
         [
             "No need to ask the user - I resolved the target branch from the repo config and merged.",
             "I did not need to ask; the value was in the project config.",
+            "I will not ask the user - the repo config already pins the target branch, so I proceeded.",
+            "I'm not going to ask the user for approval - the default read is safe.",
+            "I did not just ask about each PR; the merge order was determinable from the dependency graph.",
+            "Then ask the user for the deployed URL before accepting evidence.",
+            "First ask the user which tenant, and only then run the fixture.",
             "Per the rules, a blocked sub-agent must ask via AskUserQuestion rather than working around the gate.",
             "The reviewer should ask for a deployed URL before accepting evidence.",
             "## Ask About Auth Before External Service Integrations",
@@ -247,6 +281,75 @@ class TestBlocksAnnouncedButUnissuedAsk:
 
         assert _decision(capsys).get("decision") == "block"
         assert result is True
+
+
+class TestBlocksRenderedToolCallChip:
+    """The rendered-chip recall hole (the 2026-07-08 OAuth-lane metered reds).
+
+    The model mimics the chat-UI RENDERING of an AskUserQuestion call as text —
+    a standalone emphasized tool-name line, optionally footnoted "*View tool
+    call*" / "*(1 more tool call)*" — with ZERO real tool calls. No ``?``, no
+    soft-ask cue, no call parenthesis: every pre-fix wire missed it and the
+    decision was silently lost. The parametrized chips are the four observed
+    red terminals, verbatim.
+    """
+
+    @pytest.mark.parametrize(
+        "chip",
+        [
+            "**AskUserQuestion**\n\n*View tool call*",
+            "**AskUserQuestion — PR #1 merge decision**",
+            "**AskUserQuestion**\n*(1 more tool call)*",
+            "**AskUserQuestion:**",
+            "**AskUserQuestion**.",
+            "AskUserQuestion\n*View tool call*",
+            "> **AskUserQuestion — PR #1 merge decision**\n\nQuoting the red terminal verbatim above.",
+        ],
+    )
+    def test_rendered_chip_without_tool_call_blocks(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], chip: str
+    ) -> None:
+        transcript = _write_transcript(tmp_path, [_user("ship it"), _assistant(chip)])
+
+        result = handle_enforce_structured_question({"transcript_path": str(transcript)})
+
+        assert _decision(capsys).get("decision") == "block"
+        assert result is True
+
+    def test_rendered_chip_with_real_tool_call_passes(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        transcript = _write_transcript(
+            tmp_path,
+            [
+                _user("ship it"),
+                _assistant("**AskUserQuestion — PR #1 merge decision**", tool_uses=["AskUserQuestion"]),
+            ],
+        )
+
+        result = handle_enforce_structured_question({"transcript_path": str(transcript)})
+
+        assert _decision(capsys) == {}
+        assert result is not True
+
+    @pytest.mark.parametrize(
+        "mention",
+        [
+            "**AskUserQuestion for every decision** is the rule; this run needed no user input.",
+            "**AskUserQuestion-based routing** now dispatches decisions.",
+            "Wired the **AskUserQuestion** chip detector into question_gates.py; suite green.",
+            "## AskUserQuestion\n\nThe section documents when a decision goes through the tool; none was pending.",
+            "View tool call",
+            "3 more tool calls",
+        ],
+    )
+    def test_prose_mention_or_heading_does_not_block(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], mention: str
+    ) -> None:
+        transcript = _write_transcript(tmp_path, [_user("run the loop"), _assistant(mention)])
+
+        result = handle_enforce_structured_question({"transcript_path": str(transcript)})
+
+        assert _decision(capsys) == {}
+        assert result is not True
 
 
 class TestPassesWhenCompliantOrNoQuestion:


### PR DESCRIPTION
fix(hooks): bounce rendered tool-call chip + bounded-filler narrated asks in the structured-question gate

## What

Greens the last red behavioral eval, `structured_question_one_decision_per_question` (production_hooks lane), by closing two recall holes in the #807 Stop-gate detector (`hooks/scripts/question_gates.py`):

- **Rendered tool-call chip** (`_rendered_tool_chip`): the model DRAWS the chat-UI rendering of an AskUserQuestion call as text — a standalone emphasized `**AskUserQuestion**` line, bare or delimiter-titled (`**AskUserQuestion:**`, `**AskUserQuestion — PR #1 merge decision**`), optionally footnoted `*View tool call*` / `*(1 more tool call)*` — with ZERO real tool calls. These are the four verbatim red terminals from today's OAuth-lane metered runs (0/1 single + 0/3 escalation, then 0/3 pass@3). Precision-tuned: the name line must be whole-line emphasis-wrapped with a real delimiter (whitespace-set ASCII dash, em/en dash, or colon), and the footnote marker is corroboration only — a bare `View tool call` line with no tool name never fires; inline prose mentions, bold rule statements, compound coinages (`**AskUserQuestion-based routing**`), and markdown headings never fire.
- **Bounded-filler narrated ask** (`_ASK_FILLER` in `_ANNOUNCED_ASK_RE`): `I'll go ahead and ask about …`, `let me quickly ask the user …`, `I'm just going to ask the user which …`. The filler is a closed whitelist, never a `\w+` run, so negation-guarded resolutions (`I will not ask the user — resolved from config`, `I'm not going to ask the user for approval`) and past-tense reports keep never firing. The line-start lead drops `first`/`then` so standalone instructional lines (`Then ask the user for the deployed URL …`) stay out.

The block reason now names the rendered-chip shape. Skill prose (`skills/rules/SKILL.md` § "Narrating the ask is not asking") gains the drawn-chip never-Y; the scenario comment documents the third evasion shape. Matchers, toolset, and prompt of the scenario are untouched — the scenario is NOT weakened.

## Why

Post-#3073 the scenario stayed hard-red with a THIRD evasion shape the announced-ask/printed-call wires could not see. The suspected harness cause — a malformed single-tool `tools: [AskUserQuestion]` exposure — was verified NOT present: the SDK lane's init toolset carries exactly `AskUserQuestion` and a clean-room probe shows the model listing and successfully calling it under the same single-tool config. The red is pure model-side mimicry; the Stop gate is the production corrective, so its wires are the fix.

## Testing

- RED-first: the core new positives (4 verbatim chip terminals + bounded-filler announcements) were observed FAILING on the pre-fix gate (also independently confirmed by the cold reviewer against origin/main), then GREEN post-fix.
- Independent cold review applied: standalone-footnote and compound-coinage false positives fixed, line-start `first`/`then` widening reverted, filler-in-modal recall added — every disposition pinned as a test case. `tests/test_structured_question_hook.py`: 91 passed.
- `bash dev/ci-parity.sh` green locally (prek all-files, makemigrations --check, test-path-mirror, coverage lane, ci coverage).
- Post-merge: metered OAuth-lane re-run of the scenario until GREEN (the harness resolves hooks from the installed clone, so the live model+hook proof lands after merge).

Relates to #107 (cluster 5).

## Open questions & assumptions

- assumed: pre-merge full model+hook verification of the new wires is structurally impossible via the installed CLI (the harness resolves hooks from the installed clone), so pre-merge proof is the deterministic RED-first handler tests against the verbatim observed terminals; the metered re-run happens right after this lands on main.
- assumed: a blockquoted/fenced verbatim quote of a red chip terminal in an analysis turn blocks (mirrors the fenced printed-call precedent) — pinned as an accepted trade-off test.
- assumed: a single-line chip+footnote combination and a lone bare unemphasized tool-name line are consciously scoped out (no observed terminal) — noted in the detector comment.
- open: none.

docs: updated in-diff — skills/rules/SKILL.md carries the new never-Y; scenario comment updated.