### PR TITLE
fix(cli): apply overlay-shipped migrations in db migrate (#3077)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -6961,10 +6961,13 @@ Usage: t3 teatree db migrate [OPTIONS]
  converges on one DB.
 
  Unlike ``resetdb`` this drops nothing — live ticket/session/lease
- rows survive. Unlike the old ``uv --directory <clone>`` wrapper it
- cannot target a different (auto-isolated) DB than the runtime
- resolves. Dispatched via teatree-core (``python -m teatree``) so it
- reaches the runtime self-DB regardless of which overlay invokes it.
+ rows survive. It applies every pending migration in ``INSTALLED_APPS``,
+ so it brings BOTH the teatree-core apps AND the active overlay's own
+ Django app current in one pass. When the overlay ships its own settings
+ module the ``t3`` bridge runs this in the overlay ``manage.py`` context
+ (where the overlay app is in ``INSTALLED_APPS``); an overlay on the base
+ ``teatree.settings`` reaches it via ``python -m teatree``. Either way it
+ targets the same canonical control DB the merge gate reads.
 
  Fail-closed: a real migrate failure exits non-zero with the captured
  error, never leaving a half-migrated DB look like a success.

--- a/src/teatree/cli/django_groups.py
+++ b/src/teatree/cli/django_groups.py
@@ -22,20 +22,57 @@ class DjangoGroup:
     ``core_subcommands`` is the *per-subcommand* variant for a mixed group:
     most subcommands route through the overlay ``manage.py`` (they drive the
     overlay's own behaviour) but a named few must run in the teatree-core
-    runtime. ``db`` is the canonical case — ``refresh``/``restore-ci`` need
-    the overlay's ``db_import`` strategy, but ``migrate`` must migrate the
-    teatree-core control DB the merge gate reads, in the runtime process
-    (#126).
+    runtime. ``db approve`` is the canonical case — it records a ``DbApproval``
+    row in the teatree-core control DB the gate reads, so it must run in the
+    runtime process (``python -m teatree``) rather than route through an overlay
+    ``manage.py`` whose self-DB lacks the row (#953/#126).
+
+    ``overlay_settings_subcommands`` is the third variant: subcommands that must
+    run in the active overlay's **own** Django settings context when it ships
+    one, so an overlay-shipped Django app (and its migrations) is in
+    ``INSTALLED_APPS``. ``db migrate`` is the case — it must apply BOTH the
+    teatree-core migrations AND the overlay app's migrations against the same
+    canonical control DB. The core ``teatree.settings`` cannot see the overlay
+    app: its entry-point app discovery imports the overlay class at
+    settings-bootstrap time, which raises before the app registry is ready (or
+    on a missing overlay dependency), so the overlay app is dropped and its
+    migrations are structurally invisible on the ``python -m teatree`` path. The
+    overlay's own settings module lists the app explicitly and resolves the same
+    canonical DB, so :meth:`OverlayAppBuilder._bridge_subcommand` routes migrate
+    through the overlay ``manage.py`` when the overlay ships its own settings
+    module, and keeps the in-process core path when it runs on the base
+    ``teatree.settings`` (nothing extra to load) or ships no project dir.
     """
 
     help_text: str
     subcommands: list[tuple[str, str]]
     core_dispatch: bool = False
     core_subcommands: frozenset[str] = frozenset()
+    overlay_settings_subcommands: frozenset[str] = frozenset()
 
     def dispatches_to_core(self, sub_name: str) -> bool:
         """True iff *sub_name* must dispatch via teatree-core, not overlay manage.py."""
         return self.core_dispatch or sub_name in self.core_subcommands
+
+    def needs_overlay_settings(self, sub_name: str) -> bool:
+        """True iff *sub_name* must run in the overlay's own settings context when it ships one."""
+        return sub_name in self.overlay_settings_subcommands
+
+    def resolve_core_dispatch(self, sub_name: str, *, ships_own_overlay_settings: bool) -> bool:
+        """Whether *sub_name* dispatches via teatree-core, given this overlay's settings.
+
+        Core-dispatched when the group/subcommand is marked core-only, OR when it
+        is an overlay-settings subcommand (``db migrate``) but the overlay does
+        NOT ship its own settings module — the overlay ``manage.py`` context
+        would add nothing (its ``INSTALLED_APPS`` are the core ones), so the
+        in-process core path is kept (#126, no ``uv --directory`` hop). An
+        overlay-settings subcommand on an overlay that DOES ship its own settings
+        module routes to the overlay ``manage.py``, where the overlay app (and
+        its migrations) is in ``INSTALLED_APPS``.
+        """
+        if self.dispatches_to_core(sub_name):
+            return True
+        return self.needs_overlay_settings(sub_name) and not ships_own_overlay_settings
 
 
 DJANGO_GROUPS: dict[str, DjangoGroup] = {
@@ -122,14 +159,19 @@ DJANGO_GROUPS: dict[str, DjangoGroup] = {
             ("query", "Run a read-only SQL query against the control DB; emit rows as JSON."),
             ("shell", "Drop into a Django shell against the resolved (gate) control DB."),
         ],
-        # `migrate` migrates the teatree-core control DB the merge gate reads,
-        # so it must run in the runtime process (#126). `approve` records a
-        # DbApproval row in that same teatree-core control DB (the gate reads it
-        # at consume time), so it must also run in the runtime process rather
-        # than route through an overlay manage.py whose self-DB lacks the row.
-        # Their siblings (refresh/restore-ci/reset-passwords) keep routing
-        # through the overlay manage.py for the overlay's db_import strategy.
-        core_subcommands=frozenset({"migrate", "approve"}),
+        # `approve` records a DbApproval row in the teatree-core control DB the
+        # gate reads at consume time, so it must run in the runtime process
+        # (`python -m teatree`) rather than route through an overlay manage.py
+        # whose self-DB lacks the row (#953/#126). `migrate` must apply BOTH the
+        # core migrations AND the overlay app's migrations against that same
+        # canonical DB — the core settings cannot see an overlay-shipped app
+        # (its bootstrap-time app discovery fails), so migrate runs in the
+        # overlay's own settings context when the overlay ships one, and stays
+        # on the core path otherwise. Their siblings (refresh/restore-ci/
+        # reset-passwords) always route through the overlay manage.py for the
+        # overlay's db_import strategy.
+        core_subcommands=frozenset({"approve"}),
+        overlay_settings_subcommands=frozenset({"migrate"}),
     ),
     "pr": DjangoGroup(
         "Pull request helpers.",

--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -286,6 +286,11 @@ class OverlayAppBuilder:
         register_wip_commands(self.overlay_app)
         register_autonomy_commands(self.overlay_app)
 
+        # An overlay ships its own Django app in its own settings module's
+        # INSTALLED_APPS; the base ``teatree.settings`` (or the empty default)
+        # means there is nothing extra to load, so overlay-settings subcommands
+        # (``db migrate``) stay on the in-process core path there (#126).
+        ships_own_overlay_settings = bool(self.settings_module) and self.settings_module != "teatree.settings"
         for group_name, dj_group in DJANGO_GROUPS.items():
             group = typer.Typer(no_args_is_help=True, help=dj_group.help_text)
             for sub_name, sub_help in dj_group.subcommands:
@@ -294,7 +299,9 @@ class OverlayAppBuilder:
                     group_name,
                     sub_name,
                     sub_help,
-                    core_dispatch=dj_group.dispatches_to_core(sub_name),
+                    core_dispatch=dj_group.resolve_core_dispatch(
+                        sub_name, ships_own_overlay_settings=ships_own_overlay_settings
+                    ),
                 )
             self.overlay_app.add_typer(group, name=group_name)
 
@@ -491,7 +498,8 @@ class OverlayAppBuilder:
         :func:`managepy_core` (teatree-native ``python -m teatree``) instead
         of :func:`managepy` — required for groups whose commands live in
         teatree core only and would crash if routed through an overlay's
-        own ``manage.py`` (#1312, #1318).
+        own ``manage.py`` (#1312, #1318). The per-subcommand ``db migrate``
+        overlay-settings routing is resolved by :meth:`_dispatches_to_core`.
         """
         project_path = self.project_path
         overlay_name = self.overlay_name

--- a/src/teatree/core/management/commands/db.py
+++ b/src/teatree/core/management/commands/db.py
@@ -120,10 +120,13 @@ class Command(TyperCommand):
         converges on one DB.
 
         Unlike ``resetdb`` this drops nothing — live ticket/session/lease
-        rows survive. Unlike the old ``uv --directory <clone>`` wrapper it
-        cannot target a different (auto-isolated) DB than the runtime
-        resolves. Dispatched via teatree-core (``python -m teatree``) so it
-        reaches the runtime self-DB regardless of which overlay invokes it.
+        rows survive. It applies every pending migration in ``INSTALLED_APPS``,
+        so it brings BOTH the teatree-core apps AND the active overlay's own
+        Django app current in one pass. When the overlay ships its own settings
+        module the ``t3`` bridge runs this in the overlay ``manage.py`` context
+        (where the overlay app is in ``INSTALLED_APPS``); an overlay on the base
+        ``teatree.settings`` reaches it via ``python -m teatree``. Either way it
+        targets the same canonical control DB the merge gate reads.
 
         Fail-closed: a real migrate failure exits non-zero with the captured
         error, never leaving a half-migrated DB look like a success.

--- a/tests/teatree_core/test_overlay_core_dispatch.py
+++ b/tests/teatree_core/test_overlay_core_dispatch.py
@@ -221,36 +221,77 @@ class TestLifecycleGroupCoreDispatch:
         assert "visit-phase" in cmd
 
 
-class TestDbMigrateCoreDispatch:
-    """``db migrate`` routes through ``python -m teatree`` (core); siblings do not.
+class TestDbMigrateDispatch:
+    """``db migrate`` runs where the active overlay's Django app is installed.
 
-    ``db migrate`` migrates the teatree-core control DB the merge gate reads,
-    so it must run in the runtime process (``python -m teatree``). The sibling
-    ``db`` subcommands (``refresh``/``restore-ci``/``reset-passwords``) drive
-    the overlay's own ``db_import`` strategy and must keep routing through the
-    overlay's ``manage.py``. So ``db`` is a *per-subcommand* core-dispatch
-    group, not a wholesale one (#126).
+    ``db migrate`` must apply BOTH the teatree-core migrations AND the active
+    overlay's own app migrations against the same gate-resolved control DB.
+    An overlay that ships its own Django app lists it in that overlay's own
+    settings module (``INSTALLED_APPS``); the teatree-core settings cannot see
+    it, because ``teatree.settings._discover_overlay_apps`` imports the overlay
+    class at settings-bootstrap time and that import raises before the app
+    registry is ready (or on a missing overlay dependency), so the overlay app
+    is silently dropped and its migrations are structurally invisible on the
+    ``python -m teatree`` path.
+
+    So when the overlay ships its own settings module, ``db migrate`` routes
+    through the overlay's ``manage.py`` (its settings list the overlay app
+    explicitly and resolve the same canonical control DB). When the overlay
+    runs on the base ``teatree.settings`` (or ships no project dir), there is
+    nothing extra to load, so it stays on the in-process core path (#126). The
+    sibling ``db`` subcommands (``refresh``/``restore-ci``/``reset-passwords``)
+    always route through the overlay ``manage.py`` for the ``db_import``
+    strategy; ``db approve`` always core-dispatches (it records a ``DbApproval``
+    in the core control DB and needs no overlay app).
     """
 
-    def test_db_migrate_is_marked_core_dispatch_per_subcommand(self) -> None:
+    def test_db_migrate_marked_overlay_settings_not_core(self) -> None:
         entry = DJANGO_GROUPS["db"]
-        assert "migrate" in getattr(entry, "core_subcommands", frozenset()), (
-            f"db.migrate must opt into per-subcommand core dispatch (#126), got {entry!r}"
+        assert "migrate" in getattr(entry, "overlay_settings_subcommands", frozenset()), (
+            f"db.migrate must opt into overlay-settings dispatch so an overlay-shipped app "
+            f"migration is applied, got {entry!r}"
         )
+        # migrate must NOT be core-only — that path omits the overlay app.
+        assert "migrate" not in getattr(entry, "core_subcommands", frozenset())
         # The group itself must NOT be wholesale core_dispatch — refresh et al.
         # still need the overlay manage.py.
         assert getattr(entry, "core_dispatch", False) is False
 
-    def test_db_migrate_uses_core_dispatch(self, overlay_clone_path: Path) -> None:
+    def test_db_migrate_routes_to_overlay_settings_when_overlay_ships_own(self, overlay_clone_path: Path) -> None:
+        # An overlay with its own settings module (its INSTALLED_APPS list the
+        # overlay app) must run migrate through the overlay manage.py, so the
+        # overlay-shipped migration is applied. On the pre-fix core path this
+        # ran ``python -m teatree`` against teatree.settings, where the overlay
+        # app is structurally invisible and its migration silently skipped.
         runner = CliRunner()
-        app = _build_overlay_app(overlay_clone_path)
+        app = OverlayAppBuilder("acme", overlay_clone_path, settings_module="acme.settings").build()
         with patch("teatree.cli.overlay.run_streamed") as run_streamed:
             result = runner.invoke(app, ["db", "migrate"])
         assert result.exit_code == 0, result.output
         cmd = run_streamed.call_args.args[0]
-        assert "-m" in cmd, f"db migrate must dispatch via python -m teatree, got {cmd!r}"
-        assert "teatree" in cmd, f"db migrate must dispatch via python -m teatree, got {cmd!r}"
-        assert "manage.py" not in " ".join(cmd), f"db migrate must NOT route through manage.py, got {cmd!r}"
+        assert "manage.py" in " ".join(cmd), (
+            f"db migrate must route through the overlay manage.py when the overlay ships its "
+            f"own settings module, so the overlay app's migration is applied, got {cmd!r}"
+        )
+        assert "db" in cmd
+        assert "migrate" in cmd
+
+    def test_db_migrate_stays_core_on_base_teatree_settings(self, overlay_clone_path: Path) -> None:
+        # An overlay on the base teatree.settings gains nothing from the overlay
+        # manage.py context (its INSTALLED_APPS are the core ones), so migrate
+        # keeps the in-process core path (#126) — no regression to a
+        # ``uv --directory`` subprocess.
+        runner = CliRunner()
+        app = OverlayAppBuilder("acme", overlay_clone_path, settings_module="teatree.settings").build()
+        with patch("teatree.cli.overlay.run_streamed") as run_streamed:
+            result = runner.invoke(app, ["db", "migrate"])
+        assert result.exit_code == 0, result.output
+        cmd = run_streamed.call_args.args[0]
+        assert "-m" in cmd, f"db migrate on base settings must dispatch via python -m teatree, got {cmd!r}"
+        assert "teatree" in cmd, f"db migrate on base settings must dispatch via python -m teatree, got {cmd!r}"
+        assert "manage.py" not in " ".join(cmd), (
+            f"db migrate on base teatree.settings must NOT route through manage.py, got {cmd!r}"
+        )
         assert "db" in cmd
         assert "migrate" in cmd
 


### PR DESCRIPTION
fix(cli): apply overlay-shipped migrations in db migrate (#3077)

## What / Why

t3 <overlay> db migrate dispatched the db group migrate subcommand teatree-core-only (python -m teatree against teatree.settings). The core settings build INSTALLED_APPS via _discover_overlay_apps(), which imports the overlay class at settings-bootstrap time; that import raises before the app registry is ready (or on a missing overlay dependency), so the overlay Django app is dropped and its migrations are structurally invisible. The command reported the schema as already current and never applied an overlay-shipped migration.

This routes the migrate subcommand through the active overlay own Django settings context (its manage.py, whose INSTALLED_APPS list the overlay app explicitly) when the overlay ships its own settings module, so migrate applies BOTH the core migrations AND the overlay app migrations against the same canonical control DB. Overlays on the base teatree.settings and core-only installs keep the in-process python -m teatree path (no uv --directory hop). db approve stays core-only.

## How

- django_groups.py: new overlay_settings_subcommands per-subcommand marker plus needs_overlay_settings() and resolve_core_dispatch(); the db group moves migrate out of core_subcommands into overlay_settings_subcommands (approve stays core).
- overlay.py: build() computes ships_own_overlay_settings once and resolves per-subcommand routing via DjangoGroup.resolve_core_dispatch -- an overlay-settings subcommand goes to the overlay manage.py only when the overlay ships its own settings module, else the core path.
- db.py: migrate command docstring updated (applies every pending migration in INSTALLED_APPS, both core and overlay).

## Tests

TestDbMigrateDispatch (observed RED before the fix): an overlay with its own settings module routes db migrate through the overlay manage.py (where the overlay app is in INSTALLED_APPS); an overlay on base teatree.settings keeps the core python -m teatree path; db approve stays core. The complementary migrate_self_db applies-pending-migrations half is covered by test_schema_guard_migrate. Verified end-to-end on an isolated temp DB: migrate applied a pending overlay-app migration.

docs: generated CLI reference regenerated for the migrate docstring change.

## Open questions and assumptions

- assumed: an overlay own settings module (settings_module != teatree.settings) is the reliable signal it ships a Django app to load; overlays on the base settings gain nothing from the overlay manage.py context.
- decided: db approve stays core-dispatched; only migrate moved to overlay-settings dispatch.

Fixes #3077