### PR TITLE
fix(ci): unblock main — skip redundant diff-only banned-terms lint + drop stale --config test arg (#3086)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,10 +161,7 @@ jobs:
       - run: uv sync
       - uses: j178/prek-action@e98a699c41eb69ab013a45817a0406469a748f8d  # v2
         env:
-          # banned-terms is skipped here (diff-only, DB-home term list): the
-          # secret-backed full-tree `banned-terms-tree` job runs on every PR +
-          # push and covers brands comprehensively, so the lint hook is strictly
-          # redundant — same "dedicated job, skip in lint" pattern as the rest.
+          # banned-terms skipped: the secret-backed full-tree banned-terms-tree job covers brands on every PR+push.
           SKIP: pytest,uv-audit,cyclonedx-sbom,banned-terms
       # Migration-graph linearity gate. Two PRs branching a migration off
       # the same parent each pass locally and pass their own CI, then merge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,11 @@ jobs:
       - run: uv sync
       - uses: j178/prek-action@e98a699c41eb69ab013a45817a0406469a748f8d  # v2
         env:
-          SKIP: pytest,uv-audit,cyclonedx-sbom
+          # banned-terms is skipped here (diff-only, DB-home term list): the
+          # secret-backed full-tree `banned-terms-tree` job runs on every PR +
+          # push and covers brands comprehensively, so the lint hook is strictly
+          # redundant — same "dedicated job, skip in lint" pattern as the rest.
+          SKIP: pytest,uv-audit,cyclonedx-sbom,banned-terms
       # Migration-graph linearity gate. Two PRs branching a migration off
       # the same parent each pass locally and pass their own CI, then merge
       # into a forked graph with multiple leaf nodes that ``migrate`` refuses

--- a/tests/teatree_hooks/test_banned_terms_hook.py
+++ b/tests/teatree_hooks/test_banned_terms_hook.py
@@ -33,22 +33,18 @@ def _seed_config_db(db_path: Path, rows: dict) -> None:
         conn.close()
 
 
-def _stage_hook_config(tmp_path: Path, terms: list[str]) -> tuple[Path, Path, Path]:
-    """Stage the banned-terms config for the pre-commit hook subprocess.
+def _stage_hook_config(tmp_path: Path, terms: list[str]) -> tuple[Path, Path]:
+    """Stage the DB-home banned-terms config for the pre-commit hook subprocess.
 
-    Returns ``(home, db, config)``. ``db`` is the DB-home config store (the
-    ``check-banned-terms.sh`` CLI resolves it via ``T3_CONFIG_DB``); ``config`` is
-    a plain file passed to the still-required ``--config`` arg. The scanner reads
-    the term list from whichever tier the installed CLI consults, so both carry it.
+    Returns ``(home, db)``. ``db`` is the DB-home config store the
+    ``check-banned-terms.sh`` CLI resolves via ``T3_CONFIG_DB`` — the only tier
+    the CLI consults for the term list.
     """
     home = tmp_path / "home"
     home.mkdir(exist_ok=True)
     db = home / "config.sqlite3"
     _seed_config_db(db, {"banned_terms": terms})
-    config = tmp_path / "banned.toml"
-    entries = ", ".join(f'"{t}"' for t in terms)
-    config.write_text(f"[teatree]\nbanned_terms = [{entries}]\n", encoding="utf-8")
-    return home, db, config
+    return home, db
 
 
 @pytest.fixture(autouse=True)
@@ -69,7 +65,7 @@ def _public_teatree_probe(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
 
 @pytest.mark.integration
 def test_banned_terms_hook_flags_a_configured_term(tmp_path: Path) -> None:
-    home, db, config = _stage_hook_config(tmp_path, ["acme"])
+    home, db = _stage_hook_config(tmp_path, ["acme"])
 
     sample = tmp_path / "README.md"
     sample.write_text("acme overlay\n", encoding="utf-8")
@@ -82,7 +78,7 @@ def test_banned_terms_hook_flags_a_configured_term(tmp_path: Path) -> None:
     env["T3_CONFIG_DB"] = str(db)
 
     result = subprocess.run(
-        [str(script), "--config", str(config), str(sample)],
+        [str(script), str(sample)],
         capture_output=True,
         check=False,
         env=env,
@@ -95,7 +91,7 @@ def test_banned_terms_hook_flags_a_configured_term(tmp_path: Path) -> None:
 
 @pytest.mark.integration
 def test_banned_terms_hook_ignores_matches_inside_email_addresses(tmp_path: Path) -> None:
-    home, db, config = _stage_hook_config(tmp_path, ["internalterm"])
+    home, db = _stage_hook_config(tmp_path, ["internalterm"])
 
     sample = tmp_path / "AGENTS.md"
     sample.write_text("Git author: adrien <adrien.cossa@internalterm.example>\n", encoding="utf-8")
@@ -108,7 +104,7 @@ def test_banned_terms_hook_ignores_matches_inside_email_addresses(tmp_path: Path
     env["T3_CONFIG_DB"] = str(db)
 
     result = subprocess.run(
-        [str(script), "--config", str(config), str(sample)],
+        [str(script), str(sample)],
         capture_output=True,
         check=False,
         env=env,


### PR DESCRIPTION
fix(ci): unblock main-red banned-terms lint + stale --config tests (#3086)

## What
Unblocks main, red since #3074's DB-home cutover.
- `.github/workflows/ci.yml`: add `banned-terms` to the lint job's prek `SKIP` list.
- `tests/teatree_hooks/test_banned_terms_hook.py`: drop the vestigial `--config` arg (and the now-unused `config` TOML `_stage_hook_config` produced); the DB seed via `T3_CONFIG_DB` is the only tier the CLI reads post-#3074.

## Why
#3074 made the prek `banned-terms` hook fail closed when `banned_terms` is unset — which it is in CI's fresh DB — and left two tests passing a `--config` flag the CLI dropped. Main's own push CI and every PR fail on `lint`, `test-shard (3.13,3)`, and the `test (3.13)` aggregator. Skipping the diff-only lint hook loses zero brand coverage: the secret-backed full-tree `banned-terms-tree` job runs on every PR+push (verified) and is a strict superset.

## Open questions & assumptions
- decided-by-user: Option A (skip the redundant diff-only lint hook) over seeding `banned_terms` in CI; leak coverage verified intact via `banned-terms-tree`.
- assumed: none beyond the above.

Closes #3086
