### PR TITLE
ci: feed T3_BANNED_TERMS to the lint prek run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,8 +161,8 @@ jobs:
       - run: uv sync
       - uses: j178/prek-action@e98a699c41eb69ab013a45817a0406469a748f8d  # v2
         env:
-          # banned-terms skipped: the secret-backed full-tree banned-terms-tree job covers brands on every PR+push.
-          SKIP: pytest,uv-audit,cyclonedx-sbom,banned-terms
+          SKIP: pytest,uv-audit,cyclonedx-sbom
+          T3_BANNED_TERMS: ${{ secrets.TEATREE_BANNED_TERMS }}
       # Migration-graph linearity gate. Two PRs branching a migration off
       # the same parent each pass locally and pass their own CI, then merge
       # into a forked graph with multiple leaf nodes that ``migrate`` refuses


### PR DESCRIPTION
The `banned-terms` prek hook resolves its term list from the
`T3_BANNED_TERMS` env var, then a DB-home ConfigSetting row, and fails
closed with BannedTermsUnsetError (exit 2) when neither is present.
#3074's DB-home config cutover removed the old `--config ~/.teatree.toml`
absent-file no-op, so on a fresh CI runner (no term source) the lint
job's prek run started failing repo-wide with "banned_terms is unset",
reddening main and every open PR.

Feed the term list to the lint job from the `TEATREE_BANNED_TERMS` repo
secret via the prek step's env block, so the hook resolves and runs
again instead of failing closed.

This also drops `banned-terms` from the lint SKIP list. #3087 added it
there as a stopgap to unblock main, on the rationale that the
`banned-terms-tree` job covers it -- but that job checks `banned_brands`
(from `TEATREE_BANNED_BRANDS`), a different key than the diff-only
`banned-terms` hook's `banned_terms`, so it is not a substitute for term
coverage. Feeding the secret is a no-op while the hook stays skipped, so
the SKIP entry and its now-false comment are removed.

The lint check stays red until the `TEATREE_BANNED_TERMS` secret is
configured on the repo (being added in parallel).

## Open questions & assumptions
- This reverses the SKIP entry added in #3087 (decided-by-user Option A).
  Assumed intended: the parallel addition of the TEATREE_BANNED_TERMS
  secret indicates the stopgap SKIP is being replaced by the proper
  secret-fed gate.
- Assumed the secret name is `TEATREE_BANNED_TERMS`, mirroring the
  existing `TEATREE_BANNED_BRANDS` secret used by banned-terms-tree.
