### PR TITLE
feat(deploy): disable fleet-scoped loops on the headless box

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -44,6 +44,32 @@ the worker read the **same** `db.sqlite3` (WAL — safe concurrent reads):
 
 Re-running the workflow is **idempotent** — it converges the same stack.
 
+## Fleet role split — which loops run where
+
+teatree runs as a small fleet: the operator's laptop plus this headless box.
+Some autonomous loops are **fleet-scoped** — they must run on exactly **one**
+instance or they double-act. The box provisions **no Slack credential** (see
+[Access & networking](#access--networking)), so the Slack-facing loops would be
+both broken here and duplicates of the laptop's. The split:
+
+| Instance | Runs | Does not run |
+| --- | --- | --- |
+| **Laptop** | `inbox` (Slack drain), `review` (colleague PR review → Slack), `directive_loop` (asks the human via Slack) | `tickets` — the operator disables it by hand |
+| **Box** (this deploy) | `tickets` (issue scanning/dispatch) + all machine-local loops | `inbox`, `review`, `directive_loop` |
+
+The box enforces its side in `deploy/entrypoint.sh` (init role): after seeding
+config it calls `t3 loop disable <name>` — the single DB-backed per-loop control
+plane (`Loop.enabled` AND `LoopsConfig.is_enabled`) — for each fleet-scoped loop.
+The disable is idempotent, so re-running the deploy converges.
+
+`TEATREE_DISABLED_LOOPS` (comma-separated) overrides the set the box disables. It
+defaults to `inbox,review,directive_loop` when unset, so a fresh deploy is safe
+with no configuration; an **empty** value disables nothing (every loop runs
+here). Set it in the box env file (`teatree.env`) to change the set. Because the
+deploy workflow rewrites `teatree.env` from repository secrets on every run, a
+persistent override belongs in that workflow's env-file writer (add a
+`TEATREE_DISABLED_LOOPS` line beside the others), not a hand-edit on the box.
+
 ## One-time bootstrap (on the box)
 
 Do this once as an admin on the box.

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -59,13 +59,35 @@ seed_setting() {
 # one DB-backed per-loop control plane. `t3 loop disable` is idempotent, so a
 # re-deploy converges. TEATREE_DISABLED_LOOPS (comma-separated, from teatree.env)
 # overrides the default; an empty value runs every loop here.
+#
+# `t3 loop disable` exits 0 even on an unregistered name (it only flips a real
+# Loop row), so a typo would silently disable nothing and leave the real loop
+# running — a double-run against the laptop. Validate the WHOLE list against the
+# registered mini-loops first, so a bad value fails before anything is disabled.
 disable_fleet_scoped_loops() {
     local raw="${TEATREE_DISABLED_LOOPS-inbox,review,directive_loop}"
-    local loops loop
-    IFS=',' read -ra loops <<<"$raw"
-    for loop in ${loops[@]+"${loops[@]}"}; do
-        loop="${loop//[[:space:]]/}"
-        [ -n "$loop" ] || continue
+    local field loop registered
+    local fields=() requested=()
+    IFS=',' read -ra fields <<<"$raw"
+    for field in ${fields[@]+"${fields[@]}"}; do
+        field="${field//[[:space:]]/}"
+        [ -n "$field" ] && requested+=("$field")
+    done
+    [ ${#requested[@]} -gt 0 ] || return 0
+
+    if ! registered="$(t3 loop list --json | jq -r '.mini_loops[].name')" || [ -z "$registered" ]; then
+        echo "entrypoint: could not read the registered loops ('t3 loop list --json' failed or was empty) - confirm 't3 teatree db migrate' seeded the loops above and re-run Deploy" >&2
+        exit 1
+    fi
+
+    for loop in "${requested[@]}"; do
+        if ! grep -qxF "$loop" <<<"$registered"; then
+            echo "entrypoint: TEATREE_DISABLED_LOOPS names an unknown loop '${loop}' - valid loops are: $(tr '\n' ' ' <<<"$registered")- fix the value in teatree.env and re-run Deploy" >&2
+            exit 1
+        fi
+    done
+
+    for loop in "${requested[@]}"; do
         if ! t3 loop disable "$loop"; then
             echo "entrypoint: 't3 loop disable ${loop}' FAILED - the DB-backed loop control plane is unreachable; confirm 't3 teatree db migrate' succeeded above and re-run Deploy" >&2
             exit 1

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -53,6 +53,26 @@ seed_setting() {
     fi
 }
 
+# Fleet role split: this instance must not run the loops another fleet member
+# owns. The box provisions no Slack credential (see README), so the Slack-facing
+# loops — broken here AND duplicates of the laptop's — are disabled through the
+# one DB-backed per-loop control plane. `t3 loop disable` is idempotent, so a
+# re-deploy converges. TEATREE_DISABLED_LOOPS (comma-separated, from teatree.env)
+# overrides the default; an empty value runs every loop here.
+disable_fleet_scoped_loops() {
+    local raw="${TEATREE_DISABLED_LOOPS-inbox,review,directive_loop}"
+    local loops loop
+    IFS=',' read -ra loops <<<"$raw"
+    for loop in ${loops[@]+"${loops[@]}"}; do
+        loop="${loop//[[:space:]]/}"
+        [ -n "$loop" ] || continue
+        if ! t3 loop disable "$loop"; then
+            echo "entrypoint: 't3 loop disable ${loop}' FAILED - the DB-backed loop control plane is unreachable; confirm 't3 teatree db migrate' succeeded above and re-run Deploy" >&2
+            exit 1
+        fi
+    done
+}
+
 ensure_clone() {
     if [ -e "$CLONE_DIR/.git" ]; then
         return 0
@@ -75,6 +95,7 @@ init)
     seed_setting provision_max_concurrency 1
     seed_setting provision_ram_ceiling_percent 75
     seed_setting max_concurrent_local_stacks 1
+    disable_fleet_scoped_loops
     echo "teatree-init: complete"
     ;;
 worker)

--- a/tests/test_deploy_entrypoint_disable_loops.py
+++ b/tests/test_deploy_entrypoint_disable_loops.py
@@ -1,0 +1,188 @@
+"""Integration tests for the deploy entrypoint's fleet-loop disable step.
+
+`deploy/entrypoint.sh` (init role) disables the loops the headless box must
+not run — the Slack-facing `inbox` / `review` / `directive_loop` — through
+`t3 loop disable`, driven by `TEATREE_DISABLED_LOOPS`. Because `t3 loop
+disable` exits 0 even on an unregistered name (it only flips a real `Loop`
+row), a typo in `TEATREE_DISABLED_LOOPS` would silently disable nothing and
+leave the real loop running — a double-run against the operator's laptop. The
+step therefore validates the whole requested list against the registered
+mini-loops (`t3 loop list --json`) and fails loudly, before disabling
+anything, on an unknown name.
+
+In the spirit of the Test-Writing Doctrine these run the REAL shell function
+(extracted verbatim from `deploy/entrypoint.sh`) in a bash subprocess with a
+stub `t3` on PATH and real `jq` — nothing about the shell logic is
+reimplemented. This mirrors the standalone-shell-script tests
+(`tests/test_refuse_public_push_with_leak.py`).
+"""
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("jq") is None or shutil.which("bash") is None,
+    reason="needs bash + jq (both present in the deploy image and CI)",
+)
+
+ENTRYPOINT = Path(__file__).resolve().parents[1] / "deploy" / "entrypoint.sh"
+_BASH = shutil.which("bash") or "bash"  # absolute path (the skipif guarantees it resolves)
+
+# The registered mini-loops the stub `t3 loop list --json` reports. `loop-tick`
+# sits under infra_slots to prove the validator keys on mini-loops only (it is
+# NOT a valid disable target).
+_STUB_LOOP_STATUS = {
+    "mini_loops": [
+        {"name": "inbox"},
+        {"name": "review"},
+        {"name": "directive_loop"},
+        {"name": "tickets"},
+        {"name": "ship"},
+    ],
+    "infra_slots": [{"name": "loop-tick"}],
+}
+
+
+def _extract_shell_function(name: str) -> str:
+    """Return the verbatim source of shell function *name* from the entrypoint.
+
+    Slices from the ``name() {`` opener to its column-0 ``}`` terminator — the
+    formatting the shellcheck-clean script guarantees.
+    """
+    body: list[str] = []
+    capturing = False
+    for line in ENTRYPOINT.read_text(encoding="utf-8").splitlines():
+        if line.startswith(f"{name}() {{"):
+            capturing = True
+        if capturing:
+            body.append(line)
+            if line == "}":
+                return "\n".join(body)
+    not_found = f"function {name!r} not found in {ENTRYPOINT}"
+    raise AssertionError(not_found)
+
+
+def _write_t3_stub(bin_dir: Path) -> None:
+    """A `t3` shim: reports the loop list from a file, records disable calls.
+
+    Behaviour is env-driven so one shim covers every case:
+    ``T3_LIST_JSON`` (file to emit for ``loop list``), ``T3_DISABLE_LOG``
+    (append each disabled name), ``T3_LIST_FAIL`` (make ``loop list`` exit
+    non-zero), ``T3_FAIL_LOOP`` (make ``loop disable`` fail for that name).
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    shim = bin_dir / "t3"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "${1:-}" = "loop" ] && [ "${2:-}" = "list" ]; then\n'
+        '  [ -n "${T3_LIST_FAIL:-}" ] && exit 3\n'
+        '  cat "$T3_LIST_JSON"\n'
+        "  exit 0\n"
+        "fi\n"
+        'if [ "${1:-}" = "loop" ] && [ "${2:-}" = "disable" ]; then\n'
+        '  echo "$3" >> "$T3_DISABLE_LOG"\n'
+        '  if [ "$3" = "${T3_FAIL_LOOP:-}" ]; then echo "boom" >&2; exit 1; fi\n'
+        "  echo \"OK    loop '$3' is now disabled.\"\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _run(tmp_path: Path, disabled: str | None, **stub_env: str) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    """Run the extracted function once; return (result, list of disabled names)."""
+    bin_dir = tmp_path / "bin"
+    _write_t3_stub(bin_dir)
+    list_json = tmp_path / "loops.json"
+    list_json.write_text(json.dumps(_STUB_LOOP_STATUS), encoding="utf-8")
+    disable_log = tmp_path / "disabled.log"
+    disable_log.write_text("", encoding="utf-8")
+
+    func = _extract_shell_function("disable_fleet_scoped_loops")
+    harness = tmp_path / "harness.sh"
+    harness.write_text(f"set -euo pipefail\n{func}\ndisable_fleet_scoped_loops\n", encoding="utf-8")
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["T3_LIST_JSON"] = str(list_json)
+    env["T3_DISABLE_LOG"] = str(disable_log)
+    env.update(stub_env)
+    if disabled is None:
+        env.pop("TEATREE_DISABLED_LOOPS", None)
+    else:
+        env["TEATREE_DISABLED_LOOPS"] = disabled
+
+    result = subprocess.run(
+        [_BASH, str(harness)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    disabled_names = [line for line in disable_log.read_text(encoding="utf-8").splitlines() if line]
+    return result, disabled_names
+
+
+class TestDisableFleetScopedLoops:
+    def test_unset_disables_the_default_fleet_loops(self, tmp_path: Path) -> None:
+        result, disabled = _run(tmp_path, None)
+        assert result.returncode == 0, result.stderr
+        assert disabled == ["inbox", "review", "directive_loop"]
+
+    def test_explicit_subset_disables_only_those(self, tmp_path: Path) -> None:
+        result, disabled = _run(tmp_path, "inbox,review")
+        assert result.returncode == 0, result.stderr
+        assert disabled == ["inbox", "review"]
+
+    def test_whitespace_and_trailing_comma_tolerated(self, tmp_path: Path) -> None:
+        result, disabled = _run(tmp_path, "inbox, review, ,")
+        assert result.returncode == 0, result.stderr
+        assert disabled == ["inbox", "review"]
+
+    def test_empty_value_disables_nothing_and_succeeds(self, tmp_path: Path) -> None:
+        result, disabled = _run(tmp_path, "")
+        assert result.returncode == 0, result.stderr
+        assert disabled == []
+
+    def test_unknown_loop_fails_before_disabling_anything(self, tmp_path: Path) -> None:
+        """A typo must fail loudly AND disable nothing — the whole point of the gate.
+
+        `revieww` is unregistered; `inbox` precedes it in the list. Validation
+        happens up front, so NOTHING is disabled even though a valid name came
+        first — the box is never left half-configured.
+        """
+        result, disabled = _run(tmp_path, "inbox,revieww")
+        assert result.returncode != 0
+        assert disabled == [], "a bad list must not disable any loop"
+        assert "unknown loop 'revieww'" in result.stderr
+        assert "valid loops are:" in result.stderr
+
+    def test_infra_slot_name_is_not_a_valid_target(self, tmp_path: Path) -> None:
+        """`loop-tick` is an infra slot, not a disable-able mini-loop → rejected."""
+        result, disabled = _run(tmp_path, "loop-tick")
+        assert result.returncode != 0
+        assert disabled == []
+        assert "unknown loop 'loop-tick'" in result.stderr
+
+    def test_disable_failure_is_loud(self, tmp_path: Path) -> None:
+        result, _ = _run(tmp_path, "inbox,review", T3_FAIL_LOOP="review")
+        assert result.returncode != 0
+        assert "'t3 loop disable review' FAILED" in result.stderr
+
+    def test_unreadable_loop_list_fails_loud(self, tmp_path: Path) -> None:
+        result, disabled = _run(tmp_path, "inbox", T3_LIST_FAIL="1")
+        assert result.returncode != 0
+        assert disabled == []
+        assert "could not read the registered loops" in result.stderr
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Why

teatree now runs as a fleet: the operator's laptop plus the headless box stood
up by `deploy/docker-compose.yml` + `deploy/entrypoint.sh`. Some autonomous
loops are **fleet-scoped** — they must run on exactly one instance or they
double-act:

- **Laptop** keeps `inbox` (Slack drain), `review` (colleague PR review → Slack)
  and `directive_loop` (asks the human via Slack); the operator disables
  `tickets` there by hand.
- **Box** runs `tickets` (issue scanning/dispatch) plus all machine-local loops.
  The box provisions **no Slack credential**, so `inbox`, `review` and
  `directive_loop` would be both broken and duplicates of the laptop's.

Today the box's fresh DB seeds every loop enabled, so a deploy would double-run
those three.

## What changed

In `deploy/entrypoint.sh` (init role only), after the existing idempotent config
seeding, disable each fleet-scoped loop through the existing unified DB-backed
per-loop control plane — `t3 loop disable <name>` (admission is
`Loop.enabled AND LoopsConfig.is_enabled`). No new toggle, no per-scanner flag.

- Driven by `TEATREE_DISABLED_LOOPS` (comma-separated, read from the box env
  file). Defaults to `inbox,review,directive_loop` when unset, so a fresh deploy
  is safe with no configuration; an empty value disables nothing.
- **Validates each requested name against the registered mini-loops
  (`t3 loop list --json` → `.mini_loops[].name`) BEFORE disabling anything, and
  fails loudly on an unknown name.** `t3 loop disable` exits `0` even on a
  mistyped/unregistered name (it only flips a real `Loop` row), so without this
  check a typo like `revieww` would silently disable nothing and leave the real
  loop running — the exact double-run this PR exists to prevent. The whole list
  is validated up front, so a bad value never leaves the box half-configured.
- Idempotent — `t3 loop disable` on an already-disabled loop is a no-op success,
  so re-running the init service converges.
- Fails loudly and actionably (matching the file's `... - do X` preflight style)
  if a named disable errors or the loop list can't be read; never hard-fails on
  an empty/unset list.
- `deploy/README.md` documents the env var, the fleet role split, the WHY (the
  box has no Slack credential) and the laptop `tickets` note.

## Verified against the real CLI

- **Exists:** `t3 loop disable <name>` and `t3 loop list --json` are top-level
  verbs (`src/teatree/cli/loop_state.py` → the `loop_state` management command;
  `t3 loop list --json` emits `mini_loops[]` / `infra_slots[]`).
- **Idempotent:** `LoopState` upsert via `update_or_create` + `Loop.enabled`
  `.update()`; ran it twice on a throwaway name — same result, exit 0 both times.
- **Exit code on an unknown name:** `0` — the finding that motivated the
  validation above.
- **Seeding order:** `Loop` rows are seeded by both `t3 setup` and
  `t3 teatree db migrate` (migration `0001_initial._seed_default_loops`), both of
  which run before this step, so `t3 loop list --json` returns the full mini-loop
  set at init time.
- Confirmed `inbox`, `review`, `directive_loop`, `tickets` are real registered
  mini-loops. The throwaway probe row was deleted afterward; no real loop state
  was touched.

`shellcheck` clean on the modified script; `docker compose config` still parses.

## Test

`tests/test_deploy_entrypoint_disable_loops.py` drives the **real** shell
function (extracted verbatim from `deploy/entrypoint.sh`) in a bash subprocess
with a stub `t3` and real `jq` — the repo's established shell-script test pattern
(`tests/test_refuse_public_push_with_leak.py`). It covers the default set, the
explicit-subset / whitespace / empty cases, the disable-failure and
unreadable-list paths, and — the key regression — that a mistyped name fails
loudly AND disables nothing. That regression was confirmed RED against the
pre-validation function (which exits 0 and disables the valid prefix).

## Architecture pre-check

Not applicable — this is a deploy shell script + README + a shell-script test.
It touches no `src/teatree/` module, Protocol, scanner, `OverlayBase`, FSM
transition, or BLUEPRINT section, so the ten-check architecture gate does not
fire (tactical non-`src` change).
