### PR TITLE
fix(fleet-safety): read-back fails open on an unparsable issue URL

### DIFF
--- a/src/teatree/instance_id.py
+++ b/src/teatree/instance_id.py
@@ -8,7 +8,7 @@ instances and the same work gets double-claimed.
 
 This module gives the installation a stable identity: a UUID persisted once in
 the machine data dir, read identically by the main clone and every worktree
-checkout on the machine (:func:`teatree.paths.machine_data_dir` deliberately
+checkout on the machine (:func:`teatree.instance_id.machine_data_dir` deliberately
 resolves to the non-isolated dir). The id is stamped into claim/lease metadata
 so a claim can name its owner, and it is the identity Stage 2's GitHub claim
 refs will fence on. It is not a network identity — a persisted UUID4 is
@@ -81,7 +81,7 @@ def read_or_create_instance_id(data_dir: Path) -> str:
 def instance_id() -> str:
     """The stable id for this teatree installation.
 
-    Resolves the machine data dir at call time (:func:`teatree.paths.machine_data_dir`),
+    Resolves the machine data dir at call time (:func:`teatree.instance_id.machine_data_dir`),
     so every process on the machine — main clone or worktree — reads the same
     persisted file. The read is a few bytes; correctness (respecting the live
     ``HOME``/``XDG_DATA_HOME``) beats caching a frozen path.

--- a/src/teatree/loop/scanners/forge_readback.py
+++ b/src/teatree/loop/scanners/forge_readback.py
@@ -109,14 +109,23 @@ def existing_work_for_issue(
     branch equal to ``<ticket_number>`` or prefixed ``<ticket_number>-`` (the
     deterministic worktree branch), the issue URL cited in the PR body, or a
     ``Closes #<ticket_number>`` keyword in the body. ``None`` means clean.
+
+    Fails OPEN when the issue's own repo slug is unparsable (a synthetic or
+    non-standard issue URL): without a slug to scope by, a ``<ticket_number>-*``
+    branch or a ``Closes #<ticket_number>`` in a FOREIGN repo would match and
+    strand the issue on a spurious skip. Consistent with the module's fail-open
+    design (a forge error also degrades to "claim anyway"), the read-back yields
+    no match and the caller claims.
     """
     if not ticket_number:
         return None
     issue_slug = slug_from_issue_or_pr_url(urlparse(issue_url).path)
+    if not issue_slug:
+        return None
     branch_prefix = f"{ticket_number}-"
     for raw in open_prs:
         pr_url = _pr_url(raw)
-        if issue_slug and not _same_repo(pr_url, issue_slug):
+        if not _same_repo(pr_url, issue_slug):
             continue
         head = _pr_head_branch(raw)
         if head == ticket_number or head.startswith(branch_prefix):

--- a/tests/teatree_loop/scanners/test_forge_readback.py
+++ b/tests/teatree_loop/scanners/test_forge_readback.py
@@ -70,6 +70,14 @@ class TestExistingWorkForIssue:
     def test_no_ticket_number_returns_none(self) -> None:
         assert existing_work_for_issue(issue_url=ISSUE, ticket_number="", open_prs=[]) is None
 
+    def test_unparseable_issue_url_fails_open_not_closed(self) -> None:
+        # An issue URL with no parseable repo slug cannot be scoped to a repo, so a
+        # foreign-repo PR whose branch matches the ticket number must NOT skip the
+        # issue (that would strand it). Fail open — the caller claims.
+        unparsable = "https://internal.example/tracker/42"
+        prs = [_github_pr(url="https://github.com/souliane/other/pull/9", head="42-feature")]
+        assert existing_work_for_issue(issue_url=unparsable, ticket_number="42", open_prs=prs) is None
+
     def test_matches_gitlab_source_branch(self) -> None:
         prs = [_gitlab_mr(url="https://gitlab.com/acme/app/-/merge_requests/9", source_branch="42-feature")]
         hit = existing_work_for_issue(issue_url=GITLAB_ISSUE, ticket_number="42", open_prs=prs)


### PR DESCRIPTION
Follow-up to #3103, which squash-merged before this review fix could push.

## The bug
`existing_work_for_issue` guarded repo scoping with `if issue_slug and not _same_repo(...)`. When the issue URL yields no repo slug (unparsable or synthetic), that guard short-circuits OFF, so a `<num>-*` branch or a `Closes #<num>` reference in ANY repo can match. Result: a cross-repo false SKIP. The issue is never claimed, and the skip is only logger.info, so the lost work is invisible.

That contradicts the module design: a forge error correctly degrades to claim-anyway (fail open); an unparsable URL failed closed.

## The fix
Early-return None when the issue URL yields no repo slug, so the read-back fails open consistently. Guarded by a test that is RED against the pre-fix code and green after. Also repoints two stale docstring refs from `teatree.paths.machine_data_dir` (no such symbol) to `teatree.instance_id.machine_data_dir`.

## Impact
Latent on main today (issue_implementer is default-off), but live the moment a fleet instance runs the tickets loop -- which is what the headless deployment does.