### PR TITLE
fix(config): alias retired `speed` ConfigSetting key to `wip` + retired-key guard

### DIFF
--- a/src/teatree/config/resolution.py
+++ b/src/teatree/config/resolution.py
@@ -270,11 +270,31 @@ def _db_overlay_overrides(overlay_name: str = "") -> dict[str, Any]:
 # resolves to the renamed field. The canonical key always wins when both rows
 # exist (the alias only fills a gap). ``todo_sweep_*`` → ``task_sweep_*`` (#129):
 # the loop unit reconciles teatree Task rows, not the harness TODO list, so the
-# settings follow the scanner's name.
+# settings follow the scanner's name. ``speed`` → ``wip`` (#2951/#3109): the old
+# ``Speed`` enum's value set was identical to ``Wip`` (slow/medium/full/boost,
+# aliases low/normal/high), so a plain key alias restores the stored value with
+# no remapping.
 _LEGACY_SETTING_ALIASES: dict[str, str] = {
     "todo_sweep_disabled": "task_sweep_disabled",
     "todo_sweep_recheck_interval_hours": "task_sweep_recheck_interval_hours",
+    "speed": "wip",
 }
+
+
+# Every key that has ever been a DB-home settings field name and was RENAMED (not
+# removed-dead — a removed field intentionally resolves to nothing and is pinned by
+# ``tests/config/test_removed_dead_settings.py``). This is the explicitly-maintained
+# history the guard in ``tests/config/test_legacy_setting_aliases.py`` reads: because
+# no record of the dataclass's past field names exists in code, retiring a key must
+# be a deliberate edit here, and the guard then forces its ``_LEGACY_SETTING_ALIASES``
+# entry so a stored row under the old key can never be silently dropped.
+_RETIRED_SETTING_KEYS: frozenset[str] = frozenset(
+    {
+        "todo_sweep_disabled",
+        "todo_sweep_recheck_interval_hours",
+        "speed",
+    }
+)
 
 
 def _coerce_db_rows(rows: dict[str, Any]) -> dict[str, Any]:

--- a/tests/config/test_legacy_setting_aliases.py
+++ b/tests/config/test_legacy_setting_aliases.py
@@ -1,0 +1,102 @@
+# test-path: cross-cutting
+"""The retired-key alias contract for DB-home settings (souliane/teatree#3109).
+
+A DB-home ``UserSettings`` field renamed without an alias (or a data migration)
+silently discards any ``ConfigSetting`` row stored under the old key: the row
+falls through ``_coerce_db_rows`` and the field takes its dataclass default. The
+``speed`` -> ``wip`` rename (#2951) was exactly that — an install that set
+``speed = full`` silently ran at ``Wip.MEDIUM``.
+
+Two guards live here:
+
+*   the instance guard — a stored ``speed`` row resolves to ``Wip.FULL`` through
+    the ``speed -> wip`` alias;
+*   the class-of-bug guard — every key that has ever been a DB-home settings
+    field name (the explicitly-maintained ``_RETIRED_SETTING_KEYS`` registry) is
+    still reachable: a current ``UserSettings`` field or a ``_LEGACY_SETTING_ALIASES``
+    entry, so the next rename cannot silently drop an operator's setting.
+
+Integration-first per the Test-Writing Doctrine: real ``ConfigSetting`` rows
+resolved through ``get_effective_settings``.
+"""
+
+import dataclasses
+
+import pytest
+from django.test import TestCase
+
+from teatree.config import OVERLAY_OVERRIDABLE_SETTINGS, UserSettings, Wip, get_effective_settings
+from teatree.config.resolution import _LEGACY_SETTING_ALIASES, _RETIRED_SETTING_KEYS
+from teatree.core.models import ConfigSetting
+
+
+class RetiredSpeedRowResolvesToWip(TestCase):
+    """A ``ConfigSetting`` row under the retired ``speed`` key still takes effect."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+        monkeypatch.delenv("T3_WIP", raising=False)
+
+    def test_stored_speed_full_resolves_to_wip_full(self) -> None:
+        # The bug: on main this resolves Wip.MEDIUM because `speed` has no alias.
+        ConfigSetting.objects.set_value("speed", "full")
+        assert get_effective_settings().wip is Wip.FULL
+
+    def test_stored_speed_slow_resolves_to_wip_slow(self) -> None:
+        ConfigSetting.objects.set_value("speed", "slow")
+        assert get_effective_settings().wip is Wip.SLOW
+
+    def test_canonical_wip_row_wins_over_retired_speed_row(self) -> None:
+        # The alias only fills a gap: a current `wip` row always beats a `speed` row.
+        ConfigSetting.objects.set_value("speed", "boost")
+        ConfigSetting.objects.set_value("wip", "slow")
+        assert get_effective_settings().wip is Wip.SLOW
+
+
+class RetiredSettingKeysStayReachable(TestCase):
+    """The class-of-bug guard: a renamed DB-home key must never silently drop rows.
+
+    ``_RETIRED_SETTING_KEYS`` is the explicitly-maintained record of every key that
+    has ever been a DB-home settings field name. Retiring a key is a deliberate
+    two-part edit (record it here, wire its alias), and this guard fails loudly if
+    the alias half is missing.
+    """
+
+    @staticmethod
+    def _current_fields() -> set[str]:
+        return {field.name for field in dataclasses.fields(UserSettings)}
+
+    def test_every_retired_key_is_a_current_field_or_aliased(self) -> None:
+        current = self._current_fields()
+        unresolved = sorted(
+            key for key in _RETIRED_SETTING_KEYS if key not in current and key not in _LEGACY_SETTING_ALIASES
+        )
+        assert not unresolved, (
+            f"Retired DB-home settings key(s) {unresolved} are neither a current UserSettings "
+            f"field nor in _LEGACY_SETTING_ALIASES, so a ConfigSetting row stored under the old "
+            f"key is silently ignored. For each key, either add "
+            f"'<old_key>': '<current_field>' to _LEGACY_SETTING_ALIASES in "
+            f"src/teatree/config/resolution.py, or ship a data migration that renames the "
+            f"stored rows and drop the key from _RETIRED_SETTING_KEYS."
+        )
+
+    def test_every_alias_key_is_recorded_as_retired(self) -> None:
+        # The registry is the canonical record of renames: an alias without a
+        # retired-key entry means the guard above cannot see it.
+        unrecorded = sorted(set(_LEGACY_SETTING_ALIASES) - set(_RETIRED_SETTING_KEYS))
+        assert not unrecorded, (
+            f"_LEGACY_SETTING_ALIASES key(s) {unrecorded} are missing from _RETIRED_SETTING_KEYS. "
+            f"Add each retired key to _RETIRED_SETTING_KEYS so the reachability guard covers it."
+        )
+
+    def test_every_alias_target_actually_resolves(self) -> None:
+        # A dangling alias (target absent from the DB-home parser registry) would
+        # silently drop the row exactly like a missing alias.
+        dangling = sorted(
+            f"{old} -> {new}" for old, new in _LEGACY_SETTING_ALIASES.items() if new not in OVERLAY_OVERRIDABLE_SETTINGS
+        )
+        assert not dangling, (
+            f"_LEGACY_SETTING_ALIASES target(s) {dangling} are not in OVERLAY_OVERRIDABLE_SETTINGS, "
+            f"so a row under the old key resolves to nothing. Point the alias at a DB-home field."
+        )


### PR DESCRIPTION
## What & why

The `speed` → `wip` rename ([#2951](https://github.com/souliane/teatree/issues/2951)) was a clean cutover with **no legacy alias and no data migration**. A `ConfigSetting` row written under the retired `speed` key on an install that pre-dates the rename is silently ignored: it falls through `_coerce_db_rows` and `wip` takes its dataclass default (`Wip.MEDIUM`). An install that set `speed = full` has been running at `MEDIUM` ever since.

An alias mechanism already existed — `_LEGACY_SETTING_ALIASES` folds a `todo_sweep_* → task_sweep_*` row onto its current field — but `speed` was never added.

## Fix (the instance)

Add `"speed": "wip"` to `_LEGACY_SETTING_ALIASES`. The old `Speed` enum's value set was **identical** to `Wip` (`slow`/`medium`/`full`/`boost`, aliases `low`/`normal`/`high` — verified against the #2951 diff), so a plain key alias restores the stored value with no remapping. `wip` governs only how many workers run concurrently and never relaxes a safety gate, so honoring the stored `full` restores intent, it does not loosen safety.

## Fix (the class of bug)

Add the explicitly-maintained `_RETIRED_SETTING_KEYS` registry and a guard test (`tests/config/test_legacy_setting_aliases.py`) that fails when any key which has ever been a DB-home settings field name is neither a current `UserSettings` field nor present in `_LEGACY_SETTING_ALIASES`. The failure message names the remedy (add an alias, or ship a data migration and drop the key). Because no record of the dataclass's past field names exists in code, retiring a key is now a deliberate edit to the registry, and the guard mechanically forces the alias so the next rename cannot silently drop an operator's setting. Removed-dead settings (`branch_prefix`, `ask_before_post_on_behalf`) intentionally resolve to nothing and stay out of the registry — they keep their own guard in `test_removed_dead_settings.py`.

## Verification

- RED first: the instance test resolved `Wip.MEDIUM` on `main` for a `speed='full'` row; green after the alias.
- Guard non-vacuity: removing the `speed` alias while it stays in `_RETIRED_SETTING_KEYS` turns the guard RED with the actionable message; restored → green.
- Touched tests green (6/6); `pytest tests/ -k "config or resolution or settings"` green (1617 passed; two unrelated `test_eval_docker_django_bootstrap` cases timed out under parallel load and pass in isolation).

## Architecture pre-check — #3109

1. **BLUEPRINT § alignment** — §11.1 config resolution / #1775 DB partition. The retired-key alias is an existing mechanism; no BLUEPRINT change (implementation detail).
2. **FSM phase boundaries** — n/a (no `Ticket`/`Worktree` state change).
3. **Extension-point contracts** — n/a (no `OverlayBase`/scanner/hook/Protocol change).
4. **Component boundaries** — `src/teatree/config/resolution.py`, which already owns `_LEGACY_SETTING_ALIASES` and `_coerce_db_rows`. The registry sits next to the alias table it constrains.
5. **Dependency direction** — no new imports; `tach` and `import-linter` pass in pre-commit.
6. **Test surface** — instance behaviour (`speed` row → `Wip.FULL` via `get_effective_settings`) and the class-of-bug contract (retired key reachable), both in `tests/config/test_legacy_setting_aliases.py`.
7. **Resilience invariants** — n/a (pure read-side resolution; no external write). The alias is idempotent and the canonical key wins when both rows exist.
8. **Identity / key normalization** — the canonical key is `wip`; the retired `speed` key is folded UP to it at the one boundary (`_coerce_db_rows`), never the reverse.
9. **Behavior preservation / capability deletion** — additive; nothing removed. No matcher/guard narrowed.
10. **Removability / harness-vs-data** — the varying part (which keys were retired) is data (`_RETIRED_SETTING_KEYS` / `_LEGACY_SETTING_ALIASES`); the guard is the generic harness reading it. Deleting the two entries reverts cleanly with no call-site cascade.

## Open questions & assumptions

- Assumes the `speed` retirement is a pure rename (value semantics preserved), confirmed by the #2951 diff showing an identical `Speed`/`Wip` value set — so a key alias, not a value mapping, is correct.
- `_RETIRED_SETTING_KEYS` is scoped to genuine renames (`speed`, `todo_sweep_*`); intentionally-removed dead settings are excluded by design and covered by their own guard.

Closes #3109
