### PR TITLE
fix(deps): bump Django to 6.0.7 to clear three OSV advisories (uv-audit)

### DIFF
--- a/dist/sbom.json
+++ b/dist/sbom.json
@@ -227,7 +227,7 @@
     },
     {
       "bom-ref": "requirements-L52",
-      "description": "requirements line 52: django==6.0.6",
+      "description": "requirements line 52: django==6.0.7",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -236,9 +236,9 @@
         }
       ],
       "name": "django",
-      "purl": "pkg:pypi/django@6.0.6",
+      "purl": "pkg:pypi/django@6.0.7",
       "type": "library",
-      "version": "6.0.6"
+      "version": "6.0.7"
     },
     {
       "bom-ref": "requirements-L62",

--- a/uv.lock
+++ b/uv.lock
@@ -509,16 +509,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "6.0.6"
+version = "6.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/29/ac41e16097af67066d97a7d5775c5d8e7efc5d0284f6b0a159e07b9adb92/django-6.0.6.tar.gz", hash = "sha256:ad03916ba59523d781ae5c3f631960c23d69a9d9c43cecda52fc23b47e953713", size = 10905525, upload-time = "2026-06-03T13:02:46.503Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/55/664f24ff81c9ea19cb7dfc851afeae1f3c2390c7aee01d4ded68b5c1580d/django-6.0.7.tar.gz", hash = "sha256:2998503fc083124fb58037084bfa00de323c7c743f05f1b4284e77bff0ab8890", size = 10921299, upload-time = "2026-07-07T13:51:26.485Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/50/23f9dc45483419a3cc2085b498b25adfbf10642b2941c73e6d2dfaffc9ab/django-6.0.6-py3-none-any.whl", hash = "sha256:25148b1194c47c2e685e5f5e9c5d59c78b075dfd282cb9618861ba6c1708f4d2", size = 8373354, upload-time = "2026-06-03T13:02:41.72Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ec/1ce5334b6a2c52ce619c23a0be8d366a57a0e080ebb2d88266e5c849157c/django-6.0.7-py3-none-any.whl", hash = "sha256:a037427c2288443a8c02a1b02295a31c239663aa682bc50b1976afb7cf6a769e", size = 8373344, upload-time = "2026-07-07T13:51:20.007Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Bump `django` `6.0.6 → 6.0.7` in `uv.lock` to clear three OSV advisories flagged by the blocking `uv-audit` gate. Lockfile-only — `pyproject.toml` already declares `"django>=5.2,<6.1"`, which 6.0.7 satisfies, so no range edit.

Closes #3110.

## Why

`main`'s `uv-audit` green check is stale: the advisories below were published after its last run, so `main` is currently flagged and the red on unrelated PRs is a true positive.

| ID | CVE | One-line | Fixed in |
|----|-----|----------|----------|
| PYSEC-2026-2090 | CVE-2026-48588 | `UpdateCacheMiddleware` / `cache_page()` cache cookie-varying responses when the request carries unrelated cookies → private data readable from the shared cache | 6.0.7 / 5.2.16 |
| PYSEC-2026-2091 | CVE-2026-53877 | `django.contrib.gis.gdal.GDALRaster` over-reads its in-memory buffer built from `bytes` → adjacent-memory disclosure / segfault on `vsi_buffer` | 6.0.7 / 5.2.16 |
| PYSEC-2026-2092 | CVE-2026-53878 | `DomainNameValidator` allows newlines → header injection if such a value reaches an HTTP response (Django core itself unaffected) | 6.0.7 / 5.2.16 |

**Affected-path check** — none of the three reach teatree's own code (defense-in-depth, not a live-exploit patch):

- **2090** — no `UpdateCacheMiddleware`/`FetchFromCacheMiddleware` registered, no `cache_page()`; admin is `DEBUG`-only, `ALLOWED_HOSTS` localhost-only.
- **2091** — no `django.contrib.gis` / `GDALRaster` usage.
- **2092** — no `DomainNameValidator` usage.

## Verification

`pip-audit` reproduced locally with the exact CI invocation (`--strict --vulnerability-service osv --disable-pip` against the `--no-default-groups --all-extras` export):

```
BEFORE (6.0.6)                               AFTER (6.0.7)
Found 3 known vulnerabilities in 1 package   No known vulnerabilities found
django 6.0.6 PYSEC-2026-2090 5.2.16,6.0.7
django 6.0.6 PYSEC-2026-2091 5.2.16,6.0.7
django 6.0.6 PYSEC-2026-2092 5.2.16,6.0.7
```

- `uv lock --upgrade-package django` → `django v6.0.6 -> v6.0.7`; diff is django-only (version + sdist/wheel hashes), `pyproject.toml` untouched.
- `makemigrations --check --dry-run` → **No changes detected** (bump wants no migration).
- `ruff check`, `ruff format --check`, `ty check`: green locally.
- Full suite: CI's required `test (3.13)` shard is the authoritative signal (the full suite was moved off the local path in #3106); the `uv-audit` gate confirms 0 findings.

## Architecture pre-check

Tactical change — a dependency lockfile bump touching only `uv.lock`, no `src/` change. The ten-check architecture gate does not fire (no `cli`/`core`/`scanners`/`agents`/`OverlayBase`/Protocol/new-module/BLUEPRINT surface touched).
