### PR TITLE
fix(worktree): keep env cache out of every repo working tree (#3097)

### DIFF
--- a/src/teatree/core/intake/resolve.py
+++ b/src/teatree/core/intake/resolve.py
@@ -2,8 +2,9 @@
 
 Resolution order:
 
-1. Walk up from CWD looking for the env cache copy → parse
-    ``TICKET_DIR`` → match against ``Worktree.extra["worktree_path"]``
+1. Walk up from CWD to the worktree's out-of-repo ``.t3-cache/`` sibling
+    holding the env cache → parse ``TICKET_DIR`` → match against
+    ``Worktree.extra["worktree_path"]``
 2. Match CWD directly against ``Worktree.extra["worktree_path"]``
 3. Detect git worktree from filesystem and auto-register in DB
 
@@ -21,7 +22,7 @@ from django.core.exceptions import ImproperlyConfigured
 from teatree.core.intake.ticket_kind_classification import classify_ticket_kind
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay_loader import get_all_overlays, get_overlay_for_repo
-from teatree.core.worktree.worktree_env import CACHE_FILENAME
+from teatree.core.worktree.worktree_env import CACHE_DIRNAME, CACHE_FILENAME
 from teatree.core.worktree.worktree_paths import _candidate_paths
 from teatree.utils import git
 
@@ -85,14 +86,15 @@ def _parse_env_file(path: Path) -> dict[str, str]:
 def _find_env_cache(cwd: str) -> Path | None:
     """Walk up from *cwd* looking for the env cache.
 
-    The in-worktree env cache is a regular file copy (since #1316) of the
-    canonical cache under ``.t3-cache/``; ``is_file()`` returns True for
-    that copy and False for missing entries, so a worktree whose copy was
-    never generated is naturally skipped.
+    The env cache lives at ``<ticket_dir>/.t3-cache/.t3-env.cache`` — a
+    sibling of the repo working tree, never inside it (souliane/teatree#3097).
+    Walking up from a directory inside the worktree reaches ``ticket_dir``
+    and finds its ``.t3-cache/.t3-env.cache``; ``is_file()`` is False for a
+    worktree whose cache was never generated, so it is naturally skipped.
     """
     cwd_path = Path(cwd)
     for parent in [cwd_path, *cwd_path.parents]:
-        candidate = parent / CACHE_FILENAME
+        candidate = parent / CACHE_DIRNAME / CACHE_FILENAME
         if candidate.is_file():
             return candidate
     return None
@@ -461,8 +463,8 @@ def resolve_worktree(path: str = "", ticket_hint: Ticket | None = None) -> Workt
     """
     cwd = str(Path(path).resolve()) if path else _get_user_cwd()
 
-    # 1. Walk up from CWD to find the env cache (a regular file copy of
-    #    the canonical file in .t3-cache/, since #1316).
+    # 1. Walk up from CWD to the .t3-cache/ sibling holding the env cache
+    #    (out-of-repo, never copied into a repo tree, since #3097).
     envfile = _find_env_cache(cwd)
     if envfile is not None:
         env = _parse_env_file(envfile)

--- a/src/teatree/core/intake/resolve.py
+++ b/src/teatree/core/intake/resolve.py
@@ -84,17 +84,20 @@ def _parse_env_file(path: Path) -> dict[str, str]:
 
 
 def _find_env_cache(cwd: str) -> Path | None:
-    """Walk up from *cwd* looking for the env cache.
+    """Walk up from *cwd* looking for the repo's env cache.
 
-    The env cache lives at ``<ticket_dir>/.t3-cache/.t3-env.cache`` — a
-    sibling of the repo working tree, never inside it (souliane/teatree#3097).
-    Walking up from a directory inside the worktree reaches ``ticket_dir``
-    and finds its ``.t3-cache/.t3-env.cache``; ``is_file()`` is False for a
+    The env cache lives at ``<ticket_dir>/.t3-cache/<repo>/.t3-env.cache`` —
+    under the out-of-repo ``.t3-cache/`` sibling of the repo working tree,
+    keyed per repo so sibling repos of one ticket do not share one file
+    (souliane/teatree#3097). Each walked directory is treated as a candidate
+    repo worktree dir: its cache is ``<parent>/.t3-cache/<dir-name>/.t3-env.cache``.
+    Walking up from inside a repo reaches the repo dir and finds its own cache;
+    a sibling repo's cache is never returned. ``is_file()`` is False for a
     worktree whose cache was never generated, so it is naturally skipped.
     """
     cwd_path = Path(cwd)
     for parent in [cwd_path, *cwd_path.parents]:
-        candidate = parent / CACHE_DIRNAME / CACHE_FILENAME
+        candidate = parent.parent / CACHE_DIRNAME / parent.name / CACHE_FILENAME
         if candidate.is_file():
             return candidate
     return None

--- a/src/teatree/core/provision/provision_postconditions.py
+++ b/src/teatree/core/provision/provision_postconditions.py
@@ -5,7 +5,7 @@ state promises — the env cache, the application database, each provision step'
 own resource — have since been deleted out from under it. The aggregate probe
 here is the truth test ``worktree status`` evaluates: a ``provisioned`` worktree
 is *really* provisioned only if every one of these post-conditions still holds.
-Deleting ``.t3-cache/.t3-env.cache`` or the worktree DB flips one to FAIL, so
+Deleting ``.t3-cache/<repo>/.t3-env.cache`` or the worktree DB flips one to FAIL, so
 ``worktree status`` refuses green with a non-zero exit.
 
 The probes reuse :class:`teatree.core.worktree.readiness.Probe` — a check_fn returning a

--- a/src/teatree/core/runners/worktree_provision.py
+++ b/src/teatree/core/runners/worktree_provision.py
@@ -12,7 +12,7 @@ from teatree.core.overlay_loader import get_overlay_for_worktree
 from teatree.core.provision.provision_timebox import alert_provision_user, run_timeboxed_db_import
 from teatree.core.provision.step_runner import ProvisionReport, StepResult, run_provision_steps, run_step
 from teatree.core.runners.base import RunnerBase, RunnerResult
-from teatree.core.worktree.worktree_env import CACHE_FILENAME, worktree_pg_connection, write_env_cache
+from teatree.core.worktree.worktree_env import CACHE_DIRNAME, CACHE_FILENAME, worktree_pg_connection, write_env_cache
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +97,7 @@ def _setup_worktree_dir(wt_path: str, worktree: Worktree, overlay: OverlayBase) 
     """
     if not wt_path or not Path(wt_path).is_dir():
         return None
-    core_lines = [f"dotenv {CACHE_FILENAME}"]
+    core_lines = [f"dotenv ../{CACHE_DIRNAME}/{CACHE_FILENAME}"]
     _append_envrc_lines(wt_path, core_lines + overlay.provisioning.envrc_lines(worktree))
     result = run_step("direnv-allow", ["direnv", "allow", wt_path], check=False)
     if not result.success:

--- a/src/teatree/core/runners/worktree_provision.py
+++ b/src/teatree/core/runners/worktree_provision.py
@@ -97,7 +97,8 @@ def _setup_worktree_dir(wt_path: str, worktree: Worktree, overlay: OverlayBase) 
     """
     if not wt_path or not Path(wt_path).is_dir():
         return None
-    core_lines = [f"dotenv ../{CACHE_DIRNAME}/{CACHE_FILENAME}"]
+    repo_name = Path(wt_path).name
+    core_lines = [f"dotenv ../{CACHE_DIRNAME}/{repo_name}/{CACHE_FILENAME}"]
     _append_envrc_lines(wt_path, core_lines + overlay.provisioning.envrc_lines(worktree))
     result = run_step("direnv-allow", ["direnv", "allow", wt_path], check=False)
     if not result.success:

--- a/src/teatree/core/worktree/worktree_env.py
+++ b/src/teatree/core/worktree/worktree_env.py
@@ -13,7 +13,6 @@ truth.
 
 import os
 import platform
-import shutil
 import stat
 from dataclasses import dataclass
 from pathlib import Path
@@ -191,18 +190,19 @@ def render_env_cache(worktree: Worktree, *, overlay: "OverlayBase | None" = None
 
 
 def write_env_cache(worktree: Worktree, *, overlay: "OverlayBase | None" = None) -> EnvCacheSpec | None:
-    """Write the env cache and copy it into the repo worktree.
+    """Write the env cache to the out-of-repo ``.t3-cache/`` home.
 
     Idempotent.  Writes the file ``chmod 444``.  Callers that modify the
     DB should call this afterwards to refresh the cache.
 
-    The in-worktree copy at ``<wt_path>/.t3-env.cache`` is a real file,
-    not a symlink: when the worktree is bind-mounted into a Docker
-    container, a symlink pointing at the host-absolute cache path
-    dangles inside the container (errno 22 on stat). A real-file copy
-    survives any mount layout. Drift detection still compares the
-    canonical file under ``.t3-cache/`` against a fresh DB render, so
-    the worktree-local copy is just a consumer-facing convenience.
+    The single copy lives at ``<ticket_dir>/.t3-cache/.t3-env.cache`` — a
+    sibling of every repo working tree, never inside one (souliane/teatree#3097,
+    same principle as #3096). A generated file inside a repo tree surfaces as
+    untracked where that repo's ignore file does not list it, and a sibling repo
+    can end up committing another repo's generated cache. Consumers read it from
+    the sibling: the worktree's ``.envrc`` sources ``../.t3-cache/.t3-env.cache``
+    and ``_find_env_cache`` walks up to the same path. Any stale in-worktree copy
+    from a pre-#3097 provision is removed here.
     """
     spec = render_env_cache(worktree, overlay=overlay)
     if spec is None:
@@ -212,16 +212,14 @@ def write_env_cache(worktree: Worktree, *, overlay: "OverlayBase | None" = None)
     wt_path = Path(extra["worktree_path"])
 
     spec.path.parent.mkdir(parents=True, exist_ok=True)
-    # Remove read-only bit before overwrite, then re-chmod 444.
     if spec.path.exists():
         spec.path.chmod(stat.S_IWUSR | stat.S_IRUSR)
     spec.path.write_text(spec.content, encoding="utf-8")
     spec.path.chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)  # 0o444
 
-    repo_copy = wt_path / CACHE_FILENAME
-    if repo_copy.is_symlink() or repo_copy.exists():
-        repo_copy.unlink()
-    shutil.copy2(spec.path, repo_copy)
+    stale_repo_copy = wt_path / CACHE_FILENAME
+    if stale_repo_copy.is_symlink() or stale_repo_copy.exists():
+        stale_repo_copy.unlink()
 
     return spec
 

--- a/src/teatree/core/worktree/worktree_env.py
+++ b/src/teatree/core/worktree/worktree_env.py
@@ -1,6 +1,6 @@
-"""Generate the per-ticket env cache.
+"""Generate the per-repo env cache.
 
-The cache file lives at ``<ticket_dir>/.t3-cache/.t3-env.cache`` and is
+The cache file lives at ``<ticket_dir>/.t3-cache/<repo>/.t3-env.cache`` and is
 regenerated on every ``t3 <overlay> worktree start``.  It is **not** the source of
 truth — the DB is.  The file is ``chmod 444`` to discourage manual edits,
 and its header calls out that edits are pointless.
@@ -76,8 +76,20 @@ def compose_project(worktree: Worktree) -> str:
     return f"{worktree.repo_path}-wt{ticket.pk}" if ticket else worktree.repo_path
 
 
+def _cache_path_for(wt_path: Path) -> Path:
+    """Per-repo env-cache path ``<ticket_dir>/.t3-cache/<repo>/.t3-env.cache``.
+
+    Out of every repo working tree (the #3097 guarantee), yet keyed on the
+    repo's own worktree dir name so sibling repos of one ticket
+    (``ticket_dir/backend``, ``ticket_dir/frontend``) do not collapse onto a
+    single ``ticket_dir/.t3-cache/.t3-env.cache`` where the last writer wins
+    and hands the other repo the wrong ``COMPOSE_PROJECT_NAME``.
+    """
+    return wt_path.parent / CACHE_DIRNAME / wt_path.name / CACHE_FILENAME
+
+
 def env_cache_path(worktree: Worktree) -> Path | None:
-    """Return the canonical env-cache path ``<ticket_dir>/.t3-cache/.t3-env.cache``.
+    """Return the canonical env-cache path ``<ticket_dir>/.t3-cache/<repo>/.t3-env.cache``.
 
     ``None`` when the worktree has not been materialised on disk yet (no
     ``worktree_path``), so a caller checking the cache's presence can tell
@@ -89,7 +101,7 @@ def env_cache_path(worktree: Worktree) -> Path | None:
     wt_path = worktree.worktree_path
     if not wt_path:
         return None
-    return Path(wt_path).parent / CACHE_DIRNAME / CACHE_FILENAME
+    return _cache_path_for(Path(wt_path))
 
 
 def _docker_host_address() -> str:
@@ -160,7 +172,7 @@ def render_env_cache(worktree: Worktree, *, overlay: "OverlayBase | None" = None
     wt_path_str = extra.get("worktree_path")
     if not wt_path_str:
         return None
-    ticket_dir = Path(wt_path_str).parent
+    wt_path = Path(wt_path_str)
 
     if overlay is None:
         overlay = get_overlay_for_worktree(worktree)
@@ -185,7 +197,7 @@ def render_env_cache(worktree: Worktree, *, overlay: "OverlayBase | None" = None
     ordered_keys = tuple(k for k in pairs if k not in secret_keys)
     body = "\n".join(f"{k}={pairs[k]}" for k in ordered_keys) + "\n"
 
-    cache_path = ticket_dir / CACHE_DIRNAME / CACHE_FILENAME
+    cache_path = _cache_path_for(wt_path)
     return EnvCacheSpec(path=cache_path, keys=ordered_keys, content=_HEADER + body)
 
 
@@ -195,13 +207,16 @@ def write_env_cache(worktree: Worktree, *, overlay: "OverlayBase | None" = None)
     Idempotent.  Writes the file ``chmod 444``.  Callers that modify the
     DB should call this afterwards to refresh the cache.
 
-    The single copy lives at ``<ticket_dir>/.t3-cache/.t3-env.cache`` — a
-    sibling of every repo working tree, never inside one (souliane/teatree#3097,
-    same principle as #3096). A generated file inside a repo tree surfaces as
-    untracked where that repo's ignore file does not list it, and a sibling repo
-    can end up committing another repo's generated cache. Consumers read it from
-    the sibling: the worktree's ``.envrc`` sources ``../.t3-cache/.t3-env.cache``
-    and ``_find_env_cache`` walks up to the same path. Any stale in-worktree copy
+    The copy lives at ``<ticket_dir>/.t3-cache/<repo>/.t3-env.cache`` — under
+    the out-of-repo ``.t3-cache/`` sibling of every repo working tree, never
+    inside one (souliane/teatree#3097, same principle as #3096). It is keyed on
+    the repo's own worktree dir name so sibling repos of one ticket do not
+    collapse onto a single file where the last writer wins. A generated file
+    inside a repo tree surfaces as untracked where that repo's ignore file does
+    not list it, and a sibling repo can end up committing another repo's
+    generated cache. Consumers read it from the sibling: the worktree's
+    ``.envrc`` sources ``../.t3-cache/<repo>/.t3-env.cache`` and
+    ``_find_env_cache`` walks up to the same path. Any stale in-worktree copy
     from a pre-#3097 provision is removed here.
     """
     spec = render_env_cache(worktree, overlay=overlay)

--- a/tests/teatree_core/management_commands/test_e2e.py
+++ b/tests/teatree_core/management_commands/test_e2e.py
@@ -534,9 +534,10 @@ class TestE2eExternal(TestCase):
             tmp_path = Path(tmp)
             wt_dir = tmp_path / "worktree"
             wt_dir.mkdir()
-            # The env cache lives out-of-repo in the ticket dir's .t3-cache/
-            # sibling, never inside the repo working tree (souliane/teatree#3097).
-            cache_dir = wt_dir.parent / ".t3-cache"
+            # The env cache lives out-of-repo under the ticket dir's .t3-cache/
+            # sibling, per repo, never inside the repo working tree
+            # (souliane/teatree#3097).
+            cache_dir = wt_dir.parent / ".t3-cache" / wt_dir.name
             cache_dir.mkdir(parents=True, exist_ok=True)
             (cache_dir / ".t3-env.cache").write_text(f"WT_VARIANT=acme\nTICKET_DIR={tmp_path}\n", encoding="utf-8")
             private_dir = tmp_path / "private"
@@ -702,10 +703,10 @@ class TestE2eExternal(TestCase):
             backend_wt_dir = tmp_path / "backend-worktree"
             backend_wt_dir.mkdir()
             # The env cache lives in the linked backend ticket's out-of-repo
-            # .t3-cache/ sibling, never inside the repo working tree
+            # .t3-cache/ sibling, per repo, never inside the repo working tree
             # (souliane/teatree#3097) — overlay extras (CUSTOMER, app
             # credentials) are sourced from there.
-            cache_dir = backend_wt_dir.parent / ".t3-cache"
+            cache_dir = backend_wt_dir.parent / ".t3-cache" / backend_wt_dir.name
             cache_dir.mkdir(parents=True, exist_ok=True)
             (cache_dir / ".t3-env.cache").write_text(
                 f"WT_VARIANT=tenant-child\nTICKET_DIR={backend_wt_dir.parent}\n",
@@ -803,9 +804,10 @@ class TestE2eExternal(TestCase):
             tmp_path = Path(tmp)
             backend_wt_dir = tmp_path / "backend-worktree"
             backend_wt_dir.mkdir()
-            # The env cache lives out-of-repo in the ticket dir's .t3-cache/
-            # sibling, never inside the repo working tree (souliane/teatree#3097).
-            cache_dir = backend_wt_dir.parent / ".t3-cache"
+            # The env cache lives out-of-repo under the ticket dir's .t3-cache/
+            # sibling, per repo, never inside the repo working tree
+            # (souliane/teatree#3097).
+            cache_dir = backend_wt_dir.parent / ".t3-cache" / backend_wt_dir.name
             cache_dir.mkdir(parents=True, exist_ok=True)
             (cache_dir / ".t3-env.cache").write_text(
                 f"WT_VARIANT=acme\nTICKET_DIR={backend_wt_dir.parent}\n",

--- a/tests/teatree_core/management_commands/test_e2e.py
+++ b/tests/teatree_core/management_commands/test_e2e.py
@@ -534,7 +534,11 @@ class TestE2eExternal(TestCase):
             tmp_path = Path(tmp)
             wt_dir = tmp_path / "worktree"
             wt_dir.mkdir()
-            (wt_dir / ".t3-env.cache").write_text(f"WT_VARIANT=acme\nTICKET_DIR={tmp_path}\n", encoding="utf-8")
+            # The env cache lives out-of-repo in the ticket dir's .t3-cache/
+            # sibling, never inside the repo working tree (souliane/teatree#3097).
+            cache_dir = wt_dir.parent / ".t3-cache"
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            (cache_dir / ".t3-env.cache").write_text(f"WT_VARIANT=acme\nTICKET_DIR={tmp_path}\n", encoding="utf-8")
             private_dir = tmp_path / "private"
             private_dir.mkdir()
 
@@ -697,9 +701,13 @@ class TestE2eExternal(TestCase):
             tmp_path = Path(tmp)
             backend_wt_dir = tmp_path / "backend-worktree"
             backend_wt_dir.mkdir()
-            # The env cache lives on the linked backend worktree — overlay
-            # extras (CUSTOMER, app credentials) are sourced from there.
-            (backend_wt_dir / ".t3-env.cache").write_text(
+            # The env cache lives in the linked backend ticket's out-of-repo
+            # .t3-cache/ sibling, never inside the repo working tree
+            # (souliane/teatree#3097) — overlay extras (CUSTOMER, app
+            # credentials) are sourced from there.
+            cache_dir = backend_wt_dir.parent / ".t3-cache"
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            (cache_dir / ".t3-env.cache").write_text(
                 f"WT_VARIANT=tenant-child\nTICKET_DIR={backend_wt_dir.parent}\n",
                 encoding="utf-8",
             )
@@ -795,7 +803,11 @@ class TestE2eExternal(TestCase):
             tmp_path = Path(tmp)
             backend_wt_dir = tmp_path / "backend-worktree"
             backend_wt_dir.mkdir()
-            (backend_wt_dir / ".t3-env.cache").write_text(
+            # The env cache lives out-of-repo in the ticket dir's .t3-cache/
+            # sibling, never inside the repo working tree (souliane/teatree#3097).
+            cache_dir = backend_wt_dir.parent / ".t3-cache"
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            (cache_dir / ".t3-env.cache").write_text(
                 f"WT_VARIANT=acme\nTICKET_DIR={backend_wt_dir.parent}\n",
                 encoding="utf-8",
             )

--- a/tests/teatree_core/management_commands/test_lifecycle.py
+++ b/tests/teatree_core/management_commands/test_lifecycle.py
@@ -165,7 +165,7 @@ class TestLifecycleSetup(TestCase):
             # db_name keys on the unique Ticket pk, not the derived ticket_number.
             assert worktree.db_name == f"wt_{worktree.ticket_id}_acmebank"
 
-            cache_file = tmp_path / ".t3-cache" / ".t3-env.cache"
+            cache_file = tmp_path / ".t3-cache" / wt_dir.name / ".t3-env.cache"
             cache_body = cache_file.read_text(encoding="utf-8")
             assert "WT_VARIANT=acmebank" in cache_body
             assert f"WT_DB_NAME=wt_{worktree.ticket_id}_acmebank" in cache_body
@@ -461,9 +461,9 @@ class TestLifecycleSetup(TestCase):
             tmp_path = Path(tmp)
             wt_dir = tmp_path / "backend"
             wt_dir.mkdir()
-            # Create env cache in parent (ticket dir)
-            cache_dir = tmp_path / ".t3-cache"
-            cache_dir.mkdir()
+            # Env cache lives out-of-repo under the ticket dir, per repo.
+            cache_dir = tmp_path / ".t3-cache" / wt_dir.name
+            cache_dir.mkdir(parents=True)
             (cache_dir / ".t3-env.cache").write_text("WT_DB_NAME=test\n")
 
             ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/115")
@@ -938,8 +938,8 @@ class TestLifecycleDiagnose(TestCase):
             wt_dir.mkdir()
             # .git file marks this as a worktree (not a main clone)
             (wt_dir / ".git").write_text("gitdir: /tmp/.git/worktrees/backend")
-            cache_dir = tmp_path / ".t3-cache"
-            cache_dir.mkdir()
+            cache_dir = tmp_path / ".t3-cache" / wt_dir.name
+            cache_dir.mkdir(parents=True)
             (cache_dir / ".t3-env.cache").write_text("WT_DB_NAME=wt_120\n")
 
             ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/120")

--- a/tests/teatree_core/management_commands/test_worktree.py
+++ b/tests/teatree_core/management_commands/test_worktree.py
@@ -103,8 +103,8 @@ class TestStatusEnforcesProvisionPostConditions(TestCase):
     def _provisioned_worktree(self, root: Path) -> tuple[Worktree, Path]:
         wt_dir = root / "repo"
         wt_dir.mkdir()
-        cache = root / CACHE_DIRNAME / CACHE_FILENAME
-        cache.parent.mkdir()
+        cache = root / CACHE_DIRNAME / wt_dir.name / CACHE_FILENAME
+        cache.parent.mkdir(parents=True)
         cache.write_text("WT_DB_NAME=x\n", encoding="utf-8")
         worktree = Worktree.objects.create(
             ticket=self.ticket,

--- a/tests/teatree_core/test_env_command.py
+++ b/tests/teatree_core/test_env_command.py
@@ -194,8 +194,8 @@ class TestEnvMigrateSecrets(TestCase):
             ticket_dir.mkdir()
             wt_path = ticket_dir / "backend"
             wt_path.mkdir()
-            cache_dir = ticket_dir / CACHE_DIRNAME
-            cache_dir.mkdir()
+            cache_dir = ticket_dir / CACHE_DIRNAME / wt_path.name
+            cache_dir.mkdir(parents=True)
             cache_file = cache_dir / CACHE_FILENAME
             cache_file.write_text("FOO=bar\nPOSTGRES_PASSWORD=top-secret\n", encoding="utf-8")
 
@@ -237,8 +237,8 @@ class TestEnvMigrateSecrets(TestCase):
             ticket_dir.mkdir()
             wt_path = ticket_dir / "backend"
             wt_path.mkdir()
-            cache_dir = ticket_dir / CACHE_DIRNAME
-            cache_dir.mkdir()
+            cache_dir = ticket_dir / CACHE_DIRNAME / wt_path.name
+            cache_dir.mkdir(parents=True)
             cache_file = cache_dir / CACHE_FILENAME
             cache_file.write_text(
                 "FOO=bar\nPOSTGRES_PASSWORD_PASS_KEY=teatree/wt/7/postgres\n",
@@ -273,8 +273,8 @@ class TestEnvMigrateSecrets(TestCase):
             ticket_dir.mkdir()
             wt_path = ticket_dir / "backend"
             wt_path.mkdir()
-            cache_dir = ticket_dir / CACHE_DIRNAME
-            cache_dir.mkdir()
+            cache_dir = ticket_dir / CACHE_DIRNAME / wt_path.name
+            cache_dir.mkdir(parents=True)
             cache_file = cache_dir / CACHE_FILENAME
             cache_file.write_text("POSTGRES_PASSWORD=needs-migration\n", encoding="utf-8")
 

--- a/tests/teatree_core/test_provision_postconditions.py
+++ b/tests/teatree_core/test_provision_postconditions.py
@@ -39,8 +39,8 @@ def _provisioned_layout(root: Path) -> tuple[Path, Path]:
     """Return ``(wt_dir, env_cache)`` for a well-formed provisioned worktree."""
     wt_dir = root / "repo"
     wt_dir.mkdir()
-    cache = root / CACHE_DIRNAME / CACHE_FILENAME
-    cache.parent.mkdir()
+    cache = root / CACHE_DIRNAME / wt_dir.name / CACHE_FILENAME
+    cache.parent.mkdir(parents=True)
     cache.write_text("WT_DB_NAME=x\n", encoding="utf-8")
     return wt_dir, cache
 

--- a/tests/teatree_core/test_resolve.py
+++ b/tests/teatree_core/test_resolve.py
@@ -72,24 +72,31 @@ class TestParseEnvFile:
         assert result == {"URL": "http://host?a=b"}
 
 
+def _write_cache(ticket_dir: Path) -> Path:
+    cache = ticket_dir / ".t3-cache" / ".t3-env.cache"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text("TICKET_DIR=/some/path\n", encoding="utf-8")
+    return cache
+
+
 class TestFindEnvCache:
-    def test_found_in_cwd(self, tmp_path: Path) -> None:
-        envfile = tmp_path / ".t3-env.cache"
-        envfile.write_text("TICKET_DIR=/some/path\n", encoding="utf-8")
+    def test_found_in_worktree_sibling_from_cwd(self, tmp_path: Path) -> None:
+        cache = _write_cache(tmp_path)
+        worktree = tmp_path / "backend"
+        worktree.mkdir()
 
-        result = _find_env_cache(str(tmp_path))
+        result = _find_env_cache(str(worktree))
 
-        assert result == envfile
+        assert result == cache
 
-    def test_found_in_parent(self, tmp_path: Path) -> None:
-        envfile = tmp_path / ".t3-env.cache"
-        envfile.write_text("TICKET_DIR=/some/path\n", encoding="utf-8")
-        child = tmp_path / "sub" / "deep"
+    def test_found_walking_up_from_subdir(self, tmp_path: Path) -> None:
+        cache = _write_cache(tmp_path)
+        child = tmp_path / "backend" / "sub" / "deep"
         child.mkdir(parents=True)
 
         result = _find_env_cache(str(child))
 
-        assert result == envfile
+        assert result == cache
 
     def test_not_found(self, tmp_path: Path) -> None:
         child = tmp_path / "a" / "b"
@@ -100,14 +107,14 @@ class TestFindEnvCache:
         assert result is None
 
     def test_broken_symlink_is_ignored(self, tmp_path: Path) -> None:
-        """Broken symlinks are not returned.
+        """A broken symlink at the canonical path is not returned.
 
-        Under a Docker mount that does not include the ticket dir, the
-        worktree's ``.t3-env.cache`` symlink stays present but its target
-        disappears; returning it would crash downstream ``read_text``.
+        ``is_file()`` is False for a dangling link, so a downstream
+        ``read_text`` can never be handed a broken target.
         """
-        link = tmp_path / ".t3-env.cache"
-        link.symlink_to(tmp_path / "does-not-exist" / ".t3-env.cache")
+        cache_dir = tmp_path / ".t3-cache"
+        cache_dir.mkdir()
+        (cache_dir / ".t3-env.cache").symlink_to(tmp_path / "does-not-exist" / ".t3-env.cache")
 
         result = _find_env_cache(str(tmp_path))
 
@@ -180,7 +187,8 @@ class TestResolveWorktree(TestCase):
             extra={"worktree_path": str(self._tmp_path / "ticket-dir")},
         )
 
-        envfile = self._tmp_path / ".t3-env.cache"
+        envfile = self._tmp_path / ".t3-cache" / ".t3-env.cache"
+        envfile.parent.mkdir(parents=True, exist_ok=True)
         envfile.write_text(f"TICKET_DIR={self._tmp_path / 'ticket-dir'}\n", encoding="utf-8")
         self._monkeypatch.setenv("T3_ORIG_CWD", str(self._tmp_path))
 
@@ -257,7 +265,8 @@ class TestResolveWorktree(TestCase):
 
     def test_env_file_without_ticket_dir(self) -> None:
         """When .t3-env.cache exists but has no TICKET_DIR, fall through to CWD match."""
-        envfile = self._tmp_path / ".t3-env.cache"
+        envfile = self._tmp_path / ".t3-cache" / ".t3-env.cache"
+        envfile.parent.mkdir(parents=True, exist_ok=True)
         envfile.write_text("SOME_OTHER_KEY=value\n", encoding="utf-8")
         self._monkeypatch.setenv("T3_ORIG_CWD", str(self._tmp_path))
 
@@ -306,7 +315,8 @@ class TestResolveWorktreeRejectsMainClone(TestCase):
         # main clone (the stale/mis-recorded condition the guard catches).
         cwd = self._tmp_path / "elsewhere"
         cwd.mkdir()
-        envfile = cwd / ".t3-env.cache"
+        envfile = cwd / ".t3-cache" / ".t3-env.cache"
+        envfile.parent.mkdir(parents=True, exist_ok=True)
         envfile.write_text(f"TICKET_DIR={main_clone}\n", encoding="utf-8")
         self._monkeypatch.setenv("T3_ORIG_CWD", str(cwd))
 
@@ -953,14 +963,15 @@ class TestRefreshReusedRowRefusesPathSteal(TestCase):
         assert row.extra["keep"] == "me"
 
 
-class TestResolveModuleDocstringMatchesCopyShape:
-    """Guard against re-introducing the pre-#1316 "symlink" wording.
+class TestResolveModuleDocstringMatchesCacheLocation:
+    """Guard the env-cache resolution docs against a stale mental model.
 
-    The in-worktree env cache is a regular file copy (since #1316), not a
-    symlink. The module-level docstring, the ``_find_env_cache`` docstring,
-    and the inline comment in ``resolve_worktree`` must describe it that
-    way — otherwise readers chasing a Docker bind-mount failure will be
-    led back to the pre-fix mental model.
+    The env cache is the out-of-repo ``.t3-cache/`` sibling of the worktree,
+    never copied into a repo tree (#3097) and never a symlink. The module
+    docstring, the ``_find_env_cache`` docstring, and the inline comment in
+    ``resolve_worktree`` must describe it that way — otherwise a reader
+    chasing an untracked-file or bind-mount failure is led back to the
+    pre-fix mental model.
 
     Anti-vacuous: revert any of these sites to the word "symlink" and the
     relevant assertion goes red.
@@ -973,30 +984,29 @@ class TestResolveModuleDocstringMatchesCopyShape:
         docstring = resolve_module.__doc__ or ""
         assert "symlink" not in docstring.lower(), (
             "module docstring still describes the env cache as a symlink; "
-            "since #1316 the in-worktree cache is a regular file copy"
+            "since #3097 it is the out-of-repo .t3-cache/ sibling"
         )
         assert "env cache" in docstring, (
             "module docstring must still mention the env cache as the first resolution anchor"
         )
 
-    def test_find_env_cache_docstring_describes_copy_not_symlink(self) -> None:
+    def test_find_env_cache_docstring_does_not_mention_symlink(self) -> None:
         docstring = _find_env_cache.__doc__ or ""
-        assert "worktree symlinks" not in docstring, (
-            "_find_env_cache docstring still claims the in-worktree cache "
-            "is a symlink; since #1316 it is a regular file copy"
+        assert "symlink" not in docstring.lower(), (
+            "_find_env_cache docstring still describes the env cache as a "
+            "symlink; since #3097 it is the out-of-repo .t3-cache/ sibling"
         )
 
     def test_resolve_worktree_step1_comment_does_not_mention_symlink(self) -> None:
         source = self._resolve_source()
-        # Locate the step-1 walk-up block inside resolve_worktree.
-        marker = "# 1. Walk up from CWD to find the env cache"
+        marker = "# 1. Walk up from CWD to the .t3-cache/ sibling"
         assert marker in source, "step-1 walk-up comment moved or was removed"
         start = source.index(marker)
         block = source[start : start + 200]
         assert "symlink" not in block.lower(), (
             f"step-1 inline comment in resolve_worktree still mentions "
-            f"'symlink'; since #1316 the in-worktree env cache is a "
-            f"regular file copy. Offending block:\n{block}"
+            f"'symlink'; since #3097 the env cache is the out-of-repo "
+            f".t3-cache/ sibling. Offending block:\n{block}"
         )
 
 

--- a/tests/teatree_core/test_resolve.py
+++ b/tests/teatree_core/test_resolve.py
@@ -72,8 +72,8 @@ class TestParseEnvFile:
         assert result == {"URL": "http://host?a=b"}
 
 
-def _write_cache(ticket_dir: Path) -> Path:
-    cache = ticket_dir / ".t3-cache" / ".t3-env.cache"
+def _write_cache(ticket_dir: Path, repo: str = "backend") -> Path:
+    cache = ticket_dir / ".t3-cache" / repo / ".t3-env.cache"
     cache.parent.mkdir(parents=True, exist_ok=True)
     cache.write_text("TICKET_DIR=/some/path\n", encoding="utf-8")
     return cache
@@ -81,7 +81,7 @@ def _write_cache(ticket_dir: Path) -> Path:
 
 class TestFindEnvCache:
     def test_found_in_worktree_sibling_from_cwd(self, tmp_path: Path) -> None:
-        cache = _write_cache(tmp_path)
+        cache = _write_cache(tmp_path, "backend")
         worktree = tmp_path / "backend"
         worktree.mkdir()
 
@@ -90,13 +90,23 @@ class TestFindEnvCache:
         assert result == cache
 
     def test_found_walking_up_from_subdir(self, tmp_path: Path) -> None:
-        cache = _write_cache(tmp_path)
+        cache = _write_cache(tmp_path, "backend")
         child = tmp_path / "backend" / "sub" / "deep"
         child.mkdir(parents=True)
 
         result = _find_env_cache(str(child))
 
         assert result == cache
+
+    def test_sibling_repo_cache_is_not_returned(self, tmp_path: Path) -> None:
+        """From inside one repo, the sibling repo's cache is never returned."""
+        _write_cache(tmp_path, "frontend")
+        backend = tmp_path / "backend"
+        backend.mkdir()
+
+        result = _find_env_cache(str(backend))
+
+        assert result is None
 
     def test_not_found(self, tmp_path: Path) -> None:
         child = tmp_path / "a" / "b"
@@ -112,11 +122,13 @@ class TestFindEnvCache:
         ``is_file()`` is False for a dangling link, so a downstream
         ``read_text`` can never be handed a broken target.
         """
-        cache_dir = tmp_path / ".t3-cache"
-        cache_dir.mkdir()
+        cache_dir = tmp_path / ".t3-cache" / "backend"
+        cache_dir.mkdir(parents=True)
         (cache_dir / ".t3-env.cache").symlink_to(tmp_path / "does-not-exist" / ".t3-env.cache")
+        worktree = tmp_path / "backend"
+        worktree.mkdir()
 
-        result = _find_env_cache(str(tmp_path))
+        result = _find_env_cache(str(worktree))
 
         assert result is None
 
@@ -179,18 +191,19 @@ class TestResolveWorktree(TestCase):
         self._tmp_path = tmp_path
 
     def test_from_env_worktree_file(self) -> None:
+        wt_dir = self._tmp_path / "backend"
         ticket = Ticket.objects.create()
         wt = Worktree.objects.create(
             ticket=ticket,
             repo_path="backend",
             branch="feature",
-            extra={"worktree_path": str(self._tmp_path / "ticket-dir")},
+            extra={"worktree_path": str(wt_dir)},
         )
 
-        envfile = self._tmp_path / ".t3-cache" / ".t3-env.cache"
+        envfile = self._tmp_path / ".t3-cache" / "backend" / ".t3-env.cache"
         envfile.parent.mkdir(parents=True, exist_ok=True)
-        envfile.write_text(f"TICKET_DIR={self._tmp_path / 'ticket-dir'}\n", encoding="utf-8")
-        self._monkeypatch.setenv("T3_ORIG_CWD", str(self._tmp_path))
+        envfile.write_text(f"TICKET_DIR={wt_dir}\n", encoding="utf-8")
+        self._monkeypatch.setenv("T3_ORIG_CWD", str(wt_dir))
 
         result = resolve_worktree()
 
@@ -265,10 +278,11 @@ class TestResolveWorktree(TestCase):
 
     def test_env_file_without_ticket_dir(self) -> None:
         """When .t3-env.cache exists but has no TICKET_DIR, fall through to CWD match."""
-        envfile = self._tmp_path / ".t3-cache" / ".t3-env.cache"
+        cwd = self._tmp_path / "backend"
+        envfile = self._tmp_path / ".t3-cache" / "backend" / ".t3-env.cache"
         envfile.parent.mkdir(parents=True, exist_ok=True)
         envfile.write_text("SOME_OTHER_KEY=value\n", encoding="utf-8")
-        self._monkeypatch.setenv("T3_ORIG_CWD", str(self._tmp_path))
+        self._monkeypatch.setenv("T3_ORIG_CWD", str(cwd))
 
         with pytest.raises(WorktreeNotFoundError):
             resolve_worktree()
@@ -315,7 +329,7 @@ class TestResolveWorktreeRejectsMainClone(TestCase):
         # main clone (the stale/mis-recorded condition the guard catches).
         cwd = self._tmp_path / "elsewhere"
         cwd.mkdir()
-        envfile = cwd / ".t3-cache" / ".t3-env.cache"
+        envfile = cwd.parent / ".t3-cache" / cwd.name / ".t3-env.cache"
         envfile.parent.mkdir(parents=True, exist_ok=True)
         envfile.write_text(f"TICKET_DIR={main_clone}\n", encoding="utf-8")
         self._monkeypatch.setenv("T3_ORIG_CWD", str(cwd))

--- a/tests/teatree_core/test_run_command.py
+++ b/tests/teatree_core/test_run_command.py
@@ -217,9 +217,10 @@ class TestE2eExternalCommand(TestCase):
 
             worktree_dir = tmp_path / "workspace" / "backend"
             worktree_dir.mkdir(parents=True)
-            # The env cache lives out-of-repo in the ticket dir's .t3-cache/
-            # sibling, never inside the repo working tree (souliane/teatree#3097).
-            cache_dir = worktree_dir.parent / ".t3-cache"
+            # The env cache lives out-of-repo under the ticket dir's .t3-cache/
+            # sibling, per repo, never inside the repo working tree
+            # (souliane/teatree#3097).
+            cache_dir = worktree_dir.parent / ".t3-cache" / worktree_dir.name
             cache_dir.mkdir(parents=True, exist_ok=True)
             envfile = cache_dir / ".t3-env.cache"
             envfile.write_text("WT_VARIANT=acme\n", encoding="utf-8")

--- a/tests/teatree_core/test_run_command.py
+++ b/tests/teatree_core/test_run_command.py
@@ -217,7 +217,11 @@ class TestE2eExternalCommand(TestCase):
 
             worktree_dir = tmp_path / "workspace" / "backend"
             worktree_dir.mkdir(parents=True)
-            envfile = worktree_dir / ".t3-env.cache"
+            # The env cache lives out-of-repo in the ticket dir's .t3-cache/
+            # sibling, never inside the repo working tree (souliane/teatree#3097).
+            cache_dir = worktree_dir.parent / ".t3-cache"
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            envfile = cache_dir / ".t3-env.cache"
             envfile.write_text("WT_VARIANT=acme\n", encoding="utf-8")
 
             ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/80", variant="acme")

--- a/tests/teatree_core/test_workflows.py
+++ b/tests/teatree_core/test_workflows.py
@@ -233,14 +233,22 @@ class TestLifecycleProvision(TestCase):
         assert wt_backend.extra.get("provisioned_by_overlay") is True
         assert wt_frontend.extra.get("provisioned_by_overlay") is True
 
-        envfile = ticket_dir / ".t3-cache" / ".t3-env.cache"
-        assert envfile.is_file(), "env cache should be generated during setup"
-        env_content = envfile.read_text()
-        assert "WT_VARIANT=testclient" in env_content
-        assert f"WT_DB_NAME=wt_{wt_backend.ticket_id}_testclient" in env_content
-        assert "DJANGO_SETTINGS_MODULE=" in env_content
-        # No copy lands inside any repo working tree (#3097) — the single
-        # cache is the out-of-repo .t3-cache/ sibling.
+        # Each repo gets its OWN cache under the out-of-repo .t3-cache/ sibling
+        # (#3097 follow-up) — provisioning the frontend second must not clobber
+        # the backend's cache.
+        backend_cache = ticket_dir / ".t3-cache" / "backend" / ".t3-env.cache"
+        frontend_cache = ticket_dir / ".t3-cache" / "frontend" / ".t3-env.cache"
+        assert backend_cache.is_file(), "backend env cache should be generated during setup"
+        assert frontend_cache.is_file(), "frontend env cache should be generated during setup"
+        backend_content = backend_cache.read_text()
+        assert "WT_VARIANT=testclient" in backend_content
+        assert f"WT_DB_NAME=wt_{wt_backend.ticket_id}_testclient" in backend_content
+        assert "DJANGO_SETTINGS_MODULE=" in backend_content
+        # Each repo's cache carries its OWN compose project, not the sibling's.
+        assert f"COMPOSE_PROJECT_NAME=backend-wt{wt_backend.ticket_id}" in backend_content
+        assert f"COMPOSE_PROJECT_NAME=frontend-wt{wt_frontend.ticket_id}" in frontend_cache.read_text()
+        # No copy lands inside any repo working tree (#3097) — the caches are
+        # the out-of-repo .t3-cache/ siblings.
         assert not (ticket_dir / "backend" / ".t3-env.cache").exists()
         assert not (ticket_dir / "frontend" / ".t3-env.cache").exists()
 

--- a/tests/teatree_core/test_workflows.py
+++ b/tests/teatree_core/test_workflows.py
@@ -239,14 +239,10 @@ class TestLifecycleProvision(TestCase):
         assert "WT_VARIANT=testclient" in env_content
         assert f"WT_DB_NAME=wt_{wt_backend.ticket_id}_testclient" in env_content
         assert "DJANGO_SETTINGS_MODULE=" in env_content
-        # Per-repo copies are regular files, not symlinks (#1313) — a
-        # host-absolute symlink would dangle inside a bind-mounted container.
-        backend_copy = ticket_dir / "backend" / ".t3-env.cache"
-        frontend_copy = ticket_dir / "frontend" / ".t3-env.cache"
-        assert backend_copy.is_file()
-        assert not backend_copy.is_symlink()
-        assert frontend_copy.is_file()
-        assert not frontend_copy.is_symlink()
+        # No copy lands inside any repo working tree (#3097) — the single
+        # cache is the out-of-repo .t3-cache/ sibling.
+        assert not (ticket_dir / "backend" / ".t3-env.cache").exists()
+        assert not (ticket_dir / "frontend" / ".t3-env.cache").exists()
 
     @override_settings(**WORKFLOW_SETTINGS)
     def test_start_transitions_to_services_up(self) -> None:

--- a/tests/teatree_core/test_worktree_env.py
+++ b/tests/teatree_core/test_worktree_env.py
@@ -275,13 +275,9 @@ class TestWriteEnvCache(TestCase):
             mode = stat.S_IMODE(spec.path.stat().st_mode)
             assert mode == 0o444
 
-            # Real file in repo — not a symlink (#1313). A symlink would dangle
-            # inside a bind-mounted container because the target is a host-only
-            # absolute path.
-            repo_copy = wt_path / CACHE_FILENAME
-            assert not repo_copy.is_symlink()
-            assert repo_copy.is_file()
-            assert repo_copy.read_text(encoding="utf-8") == spec.path.read_text(encoding="utf-8")
+            # No copy inside the repo working tree (#3097) — the cache is the
+            # sole out-of-repo file under ``.t3-cache/``.
+            assert not (wt_path / CACHE_FILENAME).exists()
 
     def test_shared_postgres_adds_host(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -328,48 +324,43 @@ class TestWriteEnvCache(TestCase):
             assert "MYAPP_BASE_IMAGE=myapp-local:base" in spec.content
 
 
-class TestRepoCopyNotSymlink(TestCase):
-    """Regression for #1313 — the in-worktree copy must be a real file.
+class TestNoRepoWorkingTreeCopy(TestCase):
+    """Regression for #3097 — the cache must not be copied into a repo tree.
 
-    A symlink at ``<wt_path>/.t3-env.cache`` pointing at the host-absolute
-    cache path dangles inside a bind-mounted container, breaking any
-    in-container reader of the env file (pipenv, dotenv, plain ``stat``)
-    with errno 22.
+    A generated file inside a repo working tree surfaces as untracked in any
+    sibling repo whose ignore file does not list it, and an agent staging
+    everything can commit it onto a merge request. The single copy lives in
+    the out-of-repo ``.t3-cache/`` sibling of the worktree (the #3096
+    principle); consumers read it from there.
     """
 
-    def test_repo_copy_is_regular_file(self) -> None:
+    def test_cache_not_written_inside_repo_working_tree(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             wt, wt_path = _make_worktree(tmp, ticket_name="t-r1", ticket_url="https://ex.com/r1", db_name="wt_r1")
             with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_COMMAND):
                 spec = write_env_cache(wt)
             assert spec is not None
-            repo_copy = wt_path / CACHE_FILENAME
-            assert not repo_copy.is_symlink()
-            assert repo_copy.is_file()
+            assert not (wt_path / CACHE_FILENAME).exists()
+            assert list(wt_path.iterdir()) == []
 
-    def test_repo_copy_content_equals_source(self) -> None:
+    def test_canonical_cache_lives_outside_the_worktree(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             wt, wt_path = _make_worktree(tmp, ticket_name="t-r2", ticket_url="https://ex.com/r2", db_name="wt_r2")
             with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_COMMAND):
                 spec = write_env_cache(wt)
             assert spec is not None
-            repo_copy = wt_path / CACHE_FILENAME
-            assert repo_copy.read_text(encoding="utf-8") == spec.path.read_text(encoding="utf-8")
+            assert wt_path not in spec.path.parents
+            assert spec.path == wt_path.parent / CACHE_DIRNAME / CACHE_FILENAME
+            assert spec.path.is_file()
 
-    def test_repo_copy_survives_source_deletion(self) -> None:
-        """A real file is independent of the source — symlinks would dangle."""
+    def test_stale_in_worktree_copy_is_removed_on_regenerate(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             wt, wt_path = _make_worktree(tmp, ticket_name="t-r3", ticket_url="https://ex.com/r3", db_name="wt_r3")
+            stale = wt_path / CACHE_FILENAME
+            stale.write_text("leftover from a pre-#3097 provision\n", encoding="utf-8")
             with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_COMMAND):
-                spec = write_env_cache(wt)
-            assert spec is not None
-            repo_copy = wt_path / CACHE_FILENAME
-            expected = spec.path.read_text(encoding="utf-8")
-            spec.path.chmod(stat.S_IWUSR | stat.S_IRUSR)
-            spec.path.unlink()
-            assert repo_copy.is_file()
-            assert not repo_copy.is_symlink()
-            assert repo_copy.read_text(encoding="utf-8") == expected
+                write_env_cache(wt)
+            assert not stale.exists()
 
 
 class TestDetectDrift(TestCase):

--- a/tests/teatree_core/test_worktree_env.py
+++ b/tests/teatree_core/test_worktree_env.py
@@ -16,6 +16,7 @@ from teatree.core.worktree.worktree_env import (
     CACHE_DIRNAME,
     CACHE_FILENAME,
     detect_drift,
+    env_cache_path,
     load_overrides,
     render_env_cache,
     set_override,
@@ -265,7 +266,9 @@ class TestWriteEnvCache(TestCase):
 
             assert spec is not None
             assert spec.path.name == CACHE_FILENAME
-            assert spec.path.parent.name == CACHE_DIRNAME
+            # Per repo, under the out-of-repo .t3-cache/ sibling.
+            assert spec.path.parent.name == wt_path.name
+            assert spec.path.parent.parent.name == CACHE_DIRNAME
             content = spec.path.read_text(encoding="utf-8")
             assert "# GENERATED" in content
             assert "WT_VARIANT=acme" in content
@@ -350,7 +353,7 @@ class TestNoRepoWorkingTreeCopy(TestCase):
                 spec = write_env_cache(wt)
             assert spec is not None
             assert wt_path not in spec.path.parents
-            assert spec.path == wt_path.parent / CACHE_DIRNAME / CACHE_FILENAME
+            assert spec.path == wt_path.parent / CACHE_DIRNAME / wt_path.name / CACHE_FILENAME
             assert spec.path.is_file()
 
     def test_stale_in_worktree_copy_is_removed_on_regenerate(self) -> None:
@@ -361,6 +364,76 @@ class TestNoRepoWorkingTreeCopy(TestCase):
             with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_COMMAND):
                 write_env_cache(wt)
             assert not stale.exists()
+
+
+def _make_sibling_worktree(ticket: Ticket, ticket_dir: Path, repo: str, db_name: str) -> tuple[Worktree, Path]:
+    wt_path = ticket_dir / repo
+    wt_path.mkdir()
+    wt = Worktree.objects.create(
+        overlay="test",
+        ticket=ticket,
+        repo_path=repo,
+        branch="feature",
+        db_name=db_name,
+        extra={"worktree_path": str(wt_path)},
+    )
+    return wt, wt_path
+
+
+class TestPerRepoEnvCache(TestCase):
+    """Sibling repos of one ticket each get their own env cache (#3097 follow-up).
+
+    #3097 moved the cache out of every repo working tree, but derived its
+    path from ``ticket_dir`` alone — identical for every repo sharing the
+    ticket dir (the standard multi-repo layout ``ticket_dir/backend``,
+    ``ticket_dir/frontend``). The second repo's write then clobbered the
+    first, so the non-last-writer's direnv/shell sourced the wrong repo's
+    ``COMPOSE_PROJECT_NAME``. The cache must be per repo AND out of every
+    repo tree.
+
+    RED before the fix: both repos resolve to one shared path, so the
+    backend cache carries the frontend's ``COMPOSE_PROJECT_NAME``.
+    """
+
+    def test_sibling_repos_get_distinct_cache_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ticket_dir = Path(tmp) / "ac-42-ticket"
+            ticket_dir.mkdir()
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://ex.com/42")
+            backend, backend_path = _make_sibling_worktree(ticket, ticket_dir, "backend", "wt_be")
+            frontend, frontend_path = _make_sibling_worktree(ticket, ticket_dir, "frontend", "wt_fe")
+
+            be_cache = env_cache_path(backend)
+            fe_cache = env_cache_path(frontend)
+
+            assert be_cache != fe_cache
+            # Out of every repo working tree (the #3097 guarantee).
+            assert backend_path not in be_cache.parents
+            assert frontend_path not in fe_cache.parents
+            # Both under the one shared out-of-repo .t3-cache/ sibling.
+            assert be_cache.parents[1] == ticket_dir / CACHE_DIRNAME
+            assert fe_cache.parents[1] == ticket_dir / CACHE_DIRNAME
+
+    def test_each_repo_cache_holds_its_own_compose_project(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ticket_dir = Path(tmp) / "ac-42-ticket"
+            ticket_dir.mkdir()
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://ex.com/42")
+            backend, _ = _make_sibling_worktree(ticket, ticket_dir, "backend", "wt_be")
+            frontend, _ = _make_sibling_worktree(ticket, ticket_dir, "frontend", "wt_fe")
+
+            with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_COMMAND):
+                write_env_cache(backend)
+                # Provisioning the sibling second must NOT clobber the first.
+                write_env_cache(frontend)
+
+            be_content = env_cache_path(backend).read_text(encoding="utf-8")
+            fe_content = env_cache_path(frontend).read_text(encoding="utf-8")
+
+            assert f"COMPOSE_PROJECT_NAME=backend-wt{ticket.pk}" in be_content
+            assert f"COMPOSE_PROJECT_NAME=frontend-wt{ticket.pk}" in fe_content
+            # The last writer never leaks its project into the sibling's cache.
+            assert f"COMPOSE_PROJECT_NAME=frontend-wt{ticket.pk}" not in be_content
 
 
 class TestDetectDrift(TestCase):

--- a/tests/teatree_core/test_worktree_env_multi_overlay.py
+++ b/tests/teatree_core/test_worktree_env_multi_overlay.py
@@ -133,7 +133,8 @@ class TestProvisionRunnerEnvCacheOnMultiOverlayHost(_MultiOverlayEnvTest):
             wt = self._worktree(tmp, overlay=OVERLAY_B)
             result = WorktreeProvisionRunner(wt).run()
             assert result.ok, result.detail
-            spec_path = Path(wt.worktree_path).parent / ".t3-cache" / ".t3-env.cache"
+            wt_dir = Path(wt.worktree_path)
+            spec_path = wt_dir.parent / ".t3-cache" / wt_dir.name / ".t3-env.cache"
             assert spec_path.is_file()
             assert f"MARKER={OVERLAY_B}" in spec_path.read_text(encoding="utf-8")
 


### PR DESCRIPTION
Closes #3097.

## Problem
`write_env_cache` copied the generated `.t3-env.cache` into each repo worktree root as a real file. In a multi-repo workspace, a repo whose committed ignore file does not list it surfaces the generated cache as untracked — and an agent staging everything to preserve work can commit another repo's generated cache onto a merge request.

## Fix
Apply the #3096 principle (artifacts live outside every repo, in the per-ticket out-of-repo home): keep the single copy in `<ticket_dir>/.t3-cache/.t3-env.cache` and repoint the consumers there instead of copying into each repo root.

- `write_env_cache` no longer writes an in-worktree copy; it removes any stale copy from a pre-fix provision on regenerate.
- The worktree `.envrc` now sources `../.t3-cache/.t3-env.cache`.
- `_find_env_cache` walks up to the `.t3-cache/` sibling.

The bind-mount rationale for the in-tree real-file copy no longer applies: the `.envrc` dotenv and compose `env_file:` consumers read the sibling host-side, not from inside a container.

## Tests
- RED first: `TestNoRepoWorkingTreeCopy` asserts the cache is not written inside the repo working tree (and a stale copy is swept). Confirmed failing on pre-fix code, green after.
- Updated `_find_env_cache` / `resolve_worktree` / workflow tests for the sibling location; the docstring guard now pins the out-of-repo `.t3-cache/` framing.

## Open questions & assumptions
- Assumes overlay compose files reference the cache via `env_file:` resolved host-side (as the issue states); no teatree-core compose file referenced the in-tree copy.