### PR TITLE
fix(worktree): db-existence probe must not read a failed psql connection as absent (#3094)

### DIFF
--- a/src/teatree/core/runners/worktree_provision.py
+++ b/src/teatree/core/runners/worktree_provision.py
@@ -216,6 +216,7 @@ class WorktreeProvisionRunner(RunnerBase):
 
     def _run_db_import(self) -> bool:
         from teatree.utils.db import db_exists  # noqa: PLC0415
+        from teatree.utils.run import CommandFailedError  # noqa: PLC0415 — paired with the local db_exists import above
 
         worktree = self.worktree
         overlay = self.overlay
@@ -230,7 +231,10 @@ class WorktreeProvisionRunner(RunnerBase):
                 if db_exists(worktree.db_name, user=user, host=host, env=env or None):
                     logger.info("DB exists: %s — skipping import", worktree.db_name)
                     return True
-            except FileNotFoundError:
+            except (FileNotFoundError, CommandFailedError):
+                # Existence is unknown (psql binary missing, or the server was
+                # unreachable) — fall through to the import attempt, which fails
+                # loud on its own if the server is genuinely down (#3094).
                 pass
 
         env = {**os.environ, **overlay.provisioning.env_extra(worktree)}

--- a/src/teatree/core/worktree/reconcile.py
+++ b/src/teatree/core/worktree/reconcile.py
@@ -295,7 +295,13 @@ def _reconcile_overlay_dependent_stores(drift: Drift, wt: Worktree) -> None:
 
     if wt.db_name and wt.state != Worktree.State.CREATED:
         user, host, env = worktree_pg_connection(wt)
-        if not db_exists(wt.db_name, user=user, host=host, env=env or None):
+        try:
+            db_present = db_exists(wt.db_name, user=user, host=host, env=env or None)
+        except (CommandFailedError, FileNotFoundError):
+            # A probe that could not reach the server is not evidence the DB is
+            # gone — never report a live DB as missing drift (#3094).
+            db_present = True
+        if not db_present:
             drift.missing_dbs.append(MissingDB(worktree_pk=wt.pk, db_name=wt.db_name))
 
     if wt.state == Worktree.State.CREATED:

--- a/src/teatree/utils/db.py
+++ b/src/teatree/utils/db.py
@@ -84,9 +84,17 @@ def db_restore(db_name: str, dump_path: str) -> None:
 
 
 def db_exists(db_name: str, *, user: str = "", host: str = "", env: dict[str, str] | None = None) -> bool:
+    """Return whether *db_name* is present, having actually reached the server.
+
+    A psql that could not connect (fail-closed credential, container-only
+    network) is not evidence the database is absent — ``expected_codes=(0,)``
+    makes ``run_allowed_to_fail`` raise ``CommandFailedError`` on any non-zero
+    exit, so a caller surfaces the real reason instead of a false "does not
+    exist" (souliane/teatree#3094). Only a clean listing yields a bool.
+    """
     result = run_allowed_to_fail(
         ["psql", "-h", host or pg_host(), "-U", user or pg_user(), "-lqt"],
         env=env if env is not None else pg_env(),
-        expected_codes=None,
+        expected_codes=(0,),
     )
     return any(line.split("|")[0].strip() == db_name for line in result.stdout.splitlines() if line)

--- a/tests/teatree_core/test_provision_postconditions.py
+++ b/tests/teatree_core/test_provision_postconditions.py
@@ -2,12 +2,17 @@
 
 import tempfile
 from pathlib import Path
+from subprocess import CompletedProcess
 from types import SimpleNamespace
 
 from teatree.core.overlay import OverlayBase, OverlayProvisioning
-from teatree.core.provision.provision_postconditions import aggregate_provision_post_conditions
+from teatree.core.provision.provision_postconditions import (
+    aggregate_provision_post_conditions,
+    evaluate_post_conditions,
+)
 from teatree.core.worktree.worktree_env import CACHE_DIRNAME, CACHE_FILENAME
 from teatree.types import ProvisionStep
+from teatree.utils import run as utils_run_mod
 
 
 class _StubOverlayProvisioning(OverlayProvisioning):
@@ -89,6 +94,33 @@ def test_step_post_condition_is_included_and_evaluated():
         wt_dir, _cache = _provisioned_layout(Path(tmp))
         outcomes = _run(_StubOverlay(steps=(step,)), _worktree(wt_dir))
     assert outcomes["step:import-db"] is False
+
+
+def test_app_db_probe_fails_loud_when_psql_cannot_connect(monkeypatch):
+    """A live DB is never reported "does not exist" just because the host-side probe failed (souliane/teatree#3094).
+
+    When ``psql -lqt`` cannot connect (fail-closed credential, container-only
+    network), the ``app-db`` post-condition must fail loud with the real reason,
+    not assert non-existence of a database that is demonstrably live.
+    """
+
+    def fake_run(args, *, env=None, capture_output=False, text=False, check=False, **_kwargs):
+        if args and args[0] == "psql" and "-lqt" in args:
+            return CompletedProcess(args, 2, "", "psql: error: connection to server failed")
+        return CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(utils_run_mod.subprocess, "run", fake_run)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        wt_dir, _cache = _provisioned_layout(Path(tmp))
+        overlay = _StubOverlay(db_strategy={"kind": "dslr"})
+        outcomes, failures = evaluate_post_conditions(overlay, _worktree(wt_dir, db_name="wt_live"))
+
+    app_db = next(o for o in outcomes if o["name"] == "app-db")
+    assert app_db["passed"] is False
+    assert failures >= 1
+    assert "does not exist" not in app_db["reason"]
+    assert "connection" in app_db["reason"].lower()
 
 
 def test_no_probes_when_worktree_has_no_on_disk_path():

--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -141,6 +141,35 @@ def test_db_helpers_cover_env_exists_and_psql_fallback(monkeypatch: pytest.Monke
     assert commands[3][0] == "psql"
 
 
+def test_db_exists_raises_when_psql_cannot_connect(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A psql that could not connect is NOT evidence the database is absent (souliane/teatree#3094).
+
+    The host-side probe fails closed (missing credential, container-only
+    network) and psql exits non-zero with empty stdout. The old code accepted
+    any exit code and read the empty listing as "database does not exist" — a
+    false negative that made ``worktree status`` claim a live DB was missing.
+    The truthful contract raises so the caller surfaces the real reason.
+    """
+
+    def fake_run(
+        args: list[str],
+        *,
+        env: dict[str, str] | None = None,
+        capture_output: bool = False,
+        text: bool = False,
+        check: bool = False,
+        **_kwargs: object,
+    ) -> CompletedProcess[str]:
+        if args[0] == "psql" and "-lqt" in args:
+            return CompletedProcess(args, 2, "", "psql: error: connection to server failed")
+        return CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(utils_run_mod.subprocess, "run", fake_run)
+
+    with pytest.raises(utils_run_mod.CommandFailedError):
+        db.db_exists("wt_live")
+
+
 def test_db_restore_raises_when_restore_commands_fail(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_run(
         args: list[str],


### PR DESCRIPTION
fix(worktree): db-existence probe must not read a failed psql connection as absent (#3094)

## What

`worktree status` reported `[FAIL] app-db — database '<wt_db>' does not exist` while the database was demonstrably live (`worktree diagnose` green, E2E green in the same worktree). Agents then re-ran provisioning / a remote dump that was not needed.

Root cause: `db_exists()` ran `psql -lqt` with `expected_codes=None` (any exit code accepted) and inspected only stdout. When the host-side probe could not connect (a fail-closed credential, or the DB only reachable inside the container network), psql exited non-zero with an empty listing — which `any(...)` read as "database does not exist". A failed connection is not evidence of non-existence.

## Fix

- `db_exists()` now passes `expected_codes=(0,)`, so `run_allowed_to_fail` raises `CommandFailedError` on any non-zero psql exit. Only a clean listing yields a bool.
- The `app-db` post-condition's `Probe.check()` already converts the raise into a `[FAIL] app-db — CommandFailedError: <real reason>` — it fails loud with the actual connection reason instead of asserting non-existence.
- Caller audit — each handles the now-truthful "can't tell" per its own fail-safe direction:
  - `_reprovision_db_if_missing` already wraps in `try/except` and skips the heal on an inconclusive probe (was previously triggering a needless re-import).
  - `_run_db_import` broadened its catch to `(FileNotFoundError, CommandFailedError)` and falls through to the import attempt, which fails loud on its own if the server is genuinely down.
  - `reconcile` drift detection now treats an unreachable probe as "not missing" and never reports a live DB as `MissingDB`.

## Tests (RED first)

- `tests/utils/test_db.py::test_db_exists_raises_when_psql_cannot_connect` — was RED (`DID NOT RAISE`), now GREEN.
- `tests/teatree_core/test_provision_postconditions.py::test_app_db_probe_fails_loud_when_psql_cannot_connect` — was RED (`assert 'does not exist' not in reason`), now GREEN.

## docs

docs: n/a — bug fix preserving the existing probe contract, no user-visible command/flag/state change.

## Open questions & assumptions

- assumed: confirming existence the way the running stack does (in-container connect) is out of scope; the accepted fix is "fail loud with the reason, never assert non-existence" per the issue's own suggestion.

Closes #3094
