### PR TITLE
fix(loops): validate loop name in pause/resume/disable/enable/loop-state (#3117)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -3424,8 +3424,8 @@ Usage: t3 loop [OPTIONS] COMMAND [ARGS]...
 │                kill-switch.                                                  │
 │ enable         Enable a disabled mini-loop — return it to the ENABLED state  │
 │                (alias of resume).                                            │
-│ loop-state     Read a mini-loop's durable state, read-only (ENABLED when     │
-│                never touched; no mutation).                                  │
+│ loop-state     Read a known mini-loop's durable state, read-only (ENABLED    │
+│                when never touched; refuses an unknown name).                 │
 │ self-improve   Self-improving monitor — scheduled smell detection with a     │
 │                tiered action ladder. Runs as its own dedicated `/loop` slot  │
 │                on a separate `loop-self-improve` LoopLease so a long         │
@@ -3760,8 +3760,8 @@ Usage: t3 loop enable [OPTIONS] NAME
 ```
 Usage: t3 loop loop-state [OPTIONS] NAME
 
- Read a mini-loop's durable state, read-only (ENABLED when never touched; no
- mutation).
+ Read a known mini-loop's durable state, read-only (ENABLED when never touched;
+ refuses an unknown name).
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    name      TEXT  Mini-loop name. [required]                              │

--- a/docs/generated/cli/representative-output.md
+++ b/docs/generated/cli/representative-output.md
@@ -160,8 +160,8 @@ Usage: t3 loop [OPTIONS] COMMAND [ARGS]...
 │                kill-switch.                                                  │
 │ enable         Enable a disabled mini-loop — return it to the ENABLED state  │
 │                (alias of resume).                                            │
-│ loop-state     Read a mini-loop's durable state, read-only (ENABLED when     │
-│                never touched; no mutation).                                  │
+│ loop-state     Read a known mini-loop's durable state, read-only (ENABLED    │
+│                when never touched; refuses an unknown name).                 │
 │ self-improve   Self-improving monitor — scheduled smell detection with a     │
 │                tiered action ladder. Runs as its own dedicated `/loop` slot  │
 │                on a separate `loop-self-improve` LoopLease so a long         │

--- a/src/teatree/cli/loop_state.py
+++ b/src/teatree/cli/loop_state.py
@@ -76,7 +76,7 @@ def register(loop_app: typer.Typer) -> None:
         *,
         json_output: bool = typer.Option(False, "--json", help="Emit JSON."),
     ) -> None:
-        """Read a mini-loop's durable state, read-only (ENABLED when never touched; no mutation)."""
+        """Read a known mini-loop's durable state, read-only (ENABLED when never touched; refuses an unknown name)."""
         _delegate("status", name, json_output=json_output)
 
 

--- a/src/teatree/core/management/commands/loop_state.py
+++ b/src/teatree/core/management/commands/loop_state.py
@@ -22,10 +22,17 @@ status so the operator sees the verified state rather than an echo of the reques
 state and writes nothing. Its output is phrased as a read (``status: <STATUS>``),
 never the mutation verbs' ``is now <status>``, so inspecting a loop can never be
 mistaken for a pause/enable that just changed it.
+
+Every verb first validates the NAME against the real ``Loop`` rows (#3117): an
+unknown name is refused with a non-zero exit before any ``LoopState`` is read or
+written, so a typo can never report success and pause nothing, and
+``status <typo>`` can never resolve to the fall-through ``ENABLED`` for a loop
+that does not exist.
 """
 
 import json
 import logging
+from collections.abc import Callable
 from typing import Annotated
 
 import typer
@@ -54,6 +61,26 @@ def _reconcile_timers() -> None:
         logger.debug(
             "ensure_loop_timers after loop-state change failed — periodic reconciler will catch up", exc_info=True
         )
+
+
+def _require_known_loop(name: str, *, json_output: bool, stdout_write: Callable[[str], object]) -> None:
+    """Refuse a NAME with no matching ``Loop`` row before any ``LoopState`` read/write (#3117).
+
+    Every verb — the mutating ``pause``/``resume``/``disable``/``enable`` and the
+    read-only ``status`` — validates the name against the real ``Loop`` rows here
+    so a typo (``t3 loop pause <typo>``) can never report success and pause
+    nothing, and ``loop-state <typo>`` can never resolve to a fall-through
+    ``ENABLED`` for a loop that does not exist. Exits ``2`` (the loop-command
+    refusal convention), naming the loop and pointing at ``t3 loops list``.
+    """
+    if Loop.objects.filter(name=name).exists():
+        return
+    msg = f"no loop named {name!r} — run `t3 loops list` to see the known loops"
+    if json_output:
+        stdout_write(json.dumps({"name": name, "error": msg}, indent=2))
+    else:
+        stdout_write(f"ERROR  {msg}")
+    raise SystemExit(2)
 
 
 def _report(name: str, *, json_output: bool, stdout_write) -> None:  # noqa: ANN001
@@ -92,6 +119,7 @@ class Command(TyperCommand):
         json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
     ) -> None:
         """Move *name* into the reversible PAUSED hold."""
+        _require_known_loop(name, json_output=json_output, stdout_write=self.stdout.write)
         LoopState.objects.pause(name)
         _report(name, json_output=json_output, stdout_write=self.stdout.write)
 
@@ -103,6 +131,7 @@ class Command(TyperCommand):
         json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
     ) -> None:
         """Return *name* to ENABLED, clearing a pause OR a disable — both planes."""
+        _require_known_loop(name, json_output=json_output, stdout_write=self.stdout.write)
         with transaction.atomic():
             LoopState.objects.resume(name)
             Loop.objects.set_enabled(name, enabled=True)
@@ -117,6 +146,7 @@ class Command(TyperCommand):
         json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
     ) -> None:
         """Move *name* into the durable DISABLED kill-switch — both planes."""
+        _require_known_loop(name, json_output=json_output, stdout_write=self.stdout.write)
         with transaction.atomic():
             LoopState.objects.disable(name)
             Loop.objects.set_enabled(name, enabled=False)
@@ -131,6 +161,7 @@ class Command(TyperCommand):
         json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
     ) -> None:
         """Return *name* to ENABLED (alias of resume) — both planes."""
+        _require_known_loop(name, json_output=json_output, stdout_write=self.stdout.write)
         with transaction.atomic():
             LoopState.objects.enable(name)
             Loop.objects.set_enabled(name, enabled=True)
@@ -145,4 +176,5 @@ class Command(TyperCommand):
         json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
     ) -> None:
         """Read *name*'s durable state (ENABLED when no row exists) WITHOUT mutating it."""
+        _require_known_loop(name, json_output=json_output, stdout_write=self.stdout.write)
         _report_status(name, json_output=json_output, stdout_write=self.stdout.write)

--- a/src/teatree/core/management/commands/loops_list.py
+++ b/src/teatree/core/management/commands/loops_list.py
@@ -1,10 +1,13 @@
 """``manage.py loops_list`` — list DB-configured autonomous loops (#1796).
 
 Backs the read-only ``t3 loops list``. Reads :class:`teatree.core.models.Loop`
-rows and prints each loop's name, enabled state, cadence (interval or daily
-schedule), last run, next-due, and a ``[colleague-facing]`` tag (#2904) when the
-row is gated off during any availability-deferring mode. ORM access lives in a
-management command (the project's "anything touching the ORM is a management
+rows and prints each loop's name, effective admitted state, cadence (interval or
+daily schedule), last run, next-due, and a ``[colleague-facing]`` tag (#2904)
+when the row is gated off during any availability-deferring mode. The state
+column folds a :class:`teatree.core.models.LoopState` pause/disable hold into the
+row's ``enabled`` flag (#3117) — ``t3 loop pause`` holds a loop WITHOUT flipping
+``Loop.enabled``, so a pause is now confirmable at a glance. ORM access lives in
+a management command (the project's "anything touching the ORM is a management
 command" rule).
 
 Strictly read-only: ORM reads only — it never ticks, marks a run, or mutates a
@@ -19,11 +22,25 @@ import typer
 from django.utils import timezone
 from django_typer.management import TyperCommand
 
-from teatree.core.models import Loop
+from teatree.core.models import Loop, LoopState, LoopStatus
 
 _NEVER = "—"
 _SECONDS_PER_MINUTE = 60
 _SECONDS_PER_HOUR = 3600
+
+
+def _effective_state(loop: Loop, status: LoopStatus) -> str:
+    """The admitted state, folding a ``LoopState`` hold into the row's ``enabled`` flag.
+
+    ``t3 loop pause`` holds a loop via ``LoopState`` WITHOUT flipping
+    ``Loop.enabled``, so the row alone still reads ``enabled`` — this surfaces the
+    hold so a pause is confirmable at a glance (#3117).
+    """
+    if not loop.enabled or status is LoopStatus.DISABLED:
+        return "disabled"
+    if status is LoopStatus.PAUSED:
+        return "paused"
+    return "enabled"
 
 
 def _human_duration(seconds: float | None) -> str:
@@ -39,8 +56,9 @@ def _human_duration(seconds: float | None) -> str:
     return f"{hours}h{remainder // _SECONDS_PER_MINUTE:02d}m"
 
 
-def _next_label(loop: Loop, now: dt.datetime) -> str:
-    if not loop.enabled:
+def _next_label(loop: Loop, status: LoopStatus, now: dt.datetime) -> str:
+    # A held loop (paused/disabled) won't tick — its next-fire is meaningless.
+    if not loop.enabled or status is not LoopStatus.ENABLED:
         return _NEVER
     if loop.is_due(now):
         return "due"
@@ -50,10 +68,11 @@ def _next_label(loop: Loop, now: dt.datetime) -> str:
     return f"in {_human_duration((next_at - now).total_seconds())}"
 
 
-def _line(loop: Loop, now: dt.datetime) -> str:
-    enabled = "enabled" if loop.enabled else "disabled"
+def _line(loop: Loop, status: LoopStatus, now: dt.datetime) -> str:
+    state = _effective_state(loop, status)
     last = _human_duration(loop.seconds_since_run(now))
-    line = f"  {loop.name:<22} {enabled:<8} {loop.cadence_label:<13} last {last:<10} next {_next_label(loop, now)}"
+    nxt = _next_label(loop, status, now)
+    line = f"  {loop.name:<22} {state:<8} {loop.cadence_label:<13} last {last:<10} next {nxt}"
     if loop.colleague_facing:
         line += "  [colleague-facing]"
     return line
@@ -70,11 +89,12 @@ def _description_line(loop: Loop) -> str | None:
     return f"      {loop.description}"
 
 
-def _payload(loop: Loop, now: dt.datetime) -> dict[str, Any]:
+def _payload(loop: Loop, status: LoopStatus, now: dt.datetime) -> dict[str, Any]:
     next_at = loop.next_run_at()
     return {
         "name": loop.name,
         "enabled": loop.enabled,
+        "status": _effective_state(loop, status),
         "description": loop.description,
         "delay_seconds": loop.delay_seconds,
         "daily_at": loop.daily_at.strftime("%H:%M") if loop.daily_at else "",
@@ -96,12 +116,15 @@ class Command(TyperCommand):
     ) -> None:
         now = timezone.now()
         loops = list(Loop.objects.all())
+        # One read of the LoopState control plane; an absent name → ENABLED default.
+        held = {row.name: LoopStatus(row.status) for row in LoopState.objects.all()}
         if json_output:
-            self.stdout.write(json.dumps({"loops": [_payload(loop, now) for loop in loops]}, indent=2))
+            payload = [_payload(loop, held.get(loop.name, LoopStatus.ENABLED), now) for loop in loops]
+            self.stdout.write(json.dumps({"loops": payload}, indent=2))
             return
         self.stdout.write("loops:")
         for loop in loops:
-            self.stdout.write(_line(loop, now))
+            self.stdout.write(_line(loop, held.get(loop.name, LoopStatus.ENABLED), now))
             description_line = _description_line(loop)
             if description_line is not None:
                 self.stdout.write(description_line)

--- a/tests/teatree_cli/test_cli_loop_state.py
+++ b/tests/teatree_cli/test_cli_loop_state.py
@@ -6,9 +6,21 @@ from django.test import TestCase
 from typer.testing import CliRunner
 
 from teatree.cli.loop import loop_app
-from teatree.core.models import LoopState, LoopStatus
+from teatree.core.models import Loop, LoopState, LoopStatus
 
 runner = CliRunner()
+
+
+def _seed_loop(name: str) -> Loop:
+    """A real ``Loop`` row so the end-to-end paths have a loop to control.
+
+    Idempotent (``update_or_create``): the initial migration already seeds the
+    default loops, so a plain ``create`` would collide; and under
+    ``--no-migrations`` the seed is absent, so the row is created here instead.
+    """
+    return Loop.objects.update_or_create(
+        name=name, defaults={"script": f"src/teatree/loops/{name}/loop.py", "delay_seconds": 60}
+    )[0]
 
 
 class TestLoopStateCli:
@@ -57,6 +69,9 @@ class TestLoopStateCommandIsReadOnly(TestCase):
     operator can mistake for a pause/enable that just happened.
     """
 
+    def setUp(self) -> None:
+        _seed_loop("review")
+
     def test_loop_state_does_not_mutate_an_enabled_loop(self) -> None:
         result = runner.invoke(loop_app, ["loop-state", "review"])
         assert result.exit_code == 0, result.stdout
@@ -67,3 +82,30 @@ class TestLoopStateCommandIsReadOnly(TestCase):
         result = runner.invoke(loop_app, ["loop-state", "review"])
         assert "is now" not in result.stdout
         assert "ENABLED" in result.stdout
+
+
+class TestUnknownLoopNameRefused(TestCase):
+    """#3117: an unknown loop NAME is refused end-to-end — never silently paused, never reported ENABLED.
+
+    A typo in a safety command (``t3 loop pause <typo>``) used to print
+    ``OK … is now paused`` and pause nothing, and ``t3 loop loop-state <typo>``
+    used to print ``ENABLED`` for a loop that does not exist. Both now refuse
+    with a non-zero exit before touching ``LoopState``.
+    """
+
+    _BOGUS = "totally_bogus_loop_xyz"
+
+    def test_pause_unknown_name_exits_nonzero_and_writes_no_state(self) -> None:
+        result = runner.invoke(loop_app, ["pause", self._BOGUS])
+        assert result.exit_code != 0, result.stdout
+        assert not LoopState.objects.filter(name=self._BOGUS).exists()
+
+    def test_loop_state_unknown_name_refuses_and_never_reports_enabled(self) -> None:
+        result = runner.invoke(loop_app, ["loop-state", self._BOGUS])
+        assert result.exit_code != 0, result.stdout
+        assert "ENABLED" not in result.stdout
+
+    def test_refusal_names_the_loop_and_suggests_loops_list(self) -> None:
+        result = runner.invoke(loop_app, ["pause", self._BOGUS])
+        assert self._BOGUS in result.stdout
+        assert "t3 loops list" in result.stdout

--- a/tests/teatree_core/management/test_loop_state_command.py
+++ b/tests/teatree_core/management/test_loop_state_command.py
@@ -10,6 +10,7 @@ state, not just an echo of the request.
 import json
 from io import StringIO
 
+import pytest
 from django.core.management import call_command
 from django.test import TestCase
 
@@ -31,6 +32,12 @@ def _loop(name: str, *, enabled: bool) -> Loop:
 
 
 class TestLoopStateCommand(TestCase):
+    def setUp(self) -> None:
+        # Real loop rows: every verb now validates the name against the Loop table (#3117).
+        _loop("review", enabled=True)
+        _loop("ship", enabled=True)
+        _loop("tickets", enabled=True)
+
     def test_pause_sets_paused_status(self) -> None:
         _run("pause", "review")
         assert LoopState.objects.status_of("review") is LoopStatus.PAUSED
@@ -66,9 +73,10 @@ class TestLoopStateCommand(TestCase):
         assert payload["status"] == "disabled"
 
     def test_status_subcommand_reports_enabled_for_untouched_loop(self) -> None:
-        out = _run("status", "never-touched", "--json")
+        # A known loop with no LoopState row resolves to the ENABLED default.
+        out = _run("status", "tickets", "--json")
         payload = json.loads(out)
-        assert payload["name"] == "never-touched"
+        assert payload["name"] == "tickets"
         assert payload["status"] == "enabled"
 
 
@@ -80,6 +88,9 @@ class TestStatusSubcommandIsAReadNotAMutation(TestCase):
     pause/enable that had just changed the loop. The read now prints a
     status-shaped line, and never writes a ``LoopState`` row.
     """
+
+    def setUp(self) -> None:
+        _loop("review", enabled=True)
 
     def test_status_leaves_an_enabled_loop_enabled_and_writes_no_row(self) -> None:
         _run("status", "review")
@@ -139,9 +150,51 @@ class TestLoopStateSetsLoopRowEnabled(TestCase):
         _run("resume", "audit")
         assert Loop.objects.get(name="audit").enabled is True
 
-    def test_enable_disable_are_no_ops_for_a_name_with_no_loop_row(self) -> None:
-        # A control-plane verb on an unknown loop name still writes LoopState
-        # (the existing absent-row → ENABLED contract) and does not crash.
-        _run("disable", "no-such-loop")
-        assert LoopState.objects.status_of("no-such-loop") is LoopStatus.DISABLED
-        assert not Loop.objects.filter(name="no-such-loop").exists()
+
+class TestUnknownLoopNameRefused(TestCase):
+    """#3117: every verb refuses a name with no matching ``Loop`` row before touching ``LoopState``.
+
+    ``pause``/``resume``/``disable``/``enable``/``status`` on an unknown name used
+    to write (or, for ``status``, silently resolve to) a ``LoopState`` row for a
+    loop that does not exist — so a typo in a pause command reported success and
+    paused nothing. Each verb now exits non-zero, names the unknown loop, points
+    at ``t3 loops list``, and writes NO ``LoopState`` row.
+    """
+
+    _BOGUS = "totally_bogus_loop_xyz"
+
+    def _refuse(self, *args: str) -> str:
+        out = StringIO()
+        with pytest.raises(SystemExit) as caught:
+            call_command("loop_state", *args, self._BOGUS, stdout=out)
+        assert caught.value.code == 2
+        return out.getvalue()
+
+    def test_pause_unknown_name_refused_no_row(self) -> None:
+        out = self._refuse("pause")
+        assert self._BOGUS in out
+        assert "t3 loops list" in out
+        assert not LoopState.objects.filter(name=self._BOGUS).exists()
+
+    def test_resume_unknown_name_refused_no_row(self) -> None:
+        self._refuse("resume")
+        assert not LoopState.objects.filter(name=self._BOGUS).exists()
+
+    def test_disable_unknown_name_refused_no_row(self) -> None:
+        self._refuse("disable")
+        assert not LoopState.objects.filter(name=self._BOGUS).exists()
+
+    def test_enable_unknown_name_refused_no_row(self) -> None:
+        self._refuse("enable")
+        assert not LoopState.objects.filter(name=self._BOGUS).exists()
+
+    def test_status_unknown_name_refused_never_prints_enabled(self) -> None:
+        out = self._refuse("status")
+        assert "ENABLED" not in out.upper()
+        assert not LoopState.objects.filter(name=self._BOGUS).exists()
+
+    def test_known_loop_still_pauses(self) -> None:
+        # No-regression: a real loop still pauses.
+        _loop("dispatch", enabled=True)
+        _run("pause", "dispatch")
+        assert LoopState.objects.status_of("dispatch") is LoopStatus.PAUSED

--- a/tests/teatree_core/test_loops_list_command.py
+++ b/tests/teatree_core/test_loops_list_command.py
@@ -13,7 +13,7 @@ import django.test
 from django.core.management import call_command
 from django.utils import timezone
 
-from teatree.core.models import Loop, Prompt
+from teatree.core.models import Loop, LoopState, Prompt
 
 
 def _prompt(name: str = "demo-prompt") -> Prompt:
@@ -124,6 +124,39 @@ class TestLoopsListJson(django.test.TestCase):
         payload = json.loads(_run("--json"))
         demo = next(e for e in payload["loops"] if e["name"] == "demo-json-cf")
         assert demo["colleague_facing"] is True
+
+
+@django.test.override_settings(USE_TZ=True)
+class TestLoopsListReflectsPauseHold(django.test.TestCase):
+    """#3117 bonus: a ``LoopState`` pause/disable hold is visible in the state column.
+
+    ``t3 loop pause`` holds a loop via ``LoopState`` WITHOUT flipping
+    ``Loop.enabled``, so the row alone still read ``enabled`` — a pause was
+    invisible in ``t3 loops list``. The state column now folds in the hold so a
+    pause is confirmable at a glance.
+    """
+
+    def test_paused_loop_renders_paused_not_enabled(self) -> None:
+        Loop.objects.create(name="demo-held", delay_seconds=60, prompt=_prompt(), enabled=True)
+        LoopState.objects.pause("demo-held")
+        line = next(ln for ln in _run().splitlines() if ln.strip().startswith("demo-held"))
+        assert "paused" in line
+        assert "enabled" not in line
+        assert "next —" in line
+
+    def test_state_disabled_hold_renders_disabled(self) -> None:
+        Loop.objects.create(name="demo-killed", delay_seconds=60, prompt=_prompt(), enabled=True)
+        LoopState.objects.disable("demo-killed")
+        line = next(ln for ln in _run().splitlines() if ln.strip().startswith("demo-killed"))
+        assert "disabled" in line
+
+    def test_json_carries_effective_status(self) -> None:
+        Loop.objects.create(name="demo-held-json", delay_seconds=60, prompt=_prompt(), enabled=True)
+        LoopState.objects.pause("demo-held-json")
+        demo = next(e for e in json.loads(_run("--json"))["loops"] if e["name"] == "demo-held-json")
+        assert demo["status"] == "paused"
+        # ``enabled`` keeps its row-flag meaning for backward compatibility.
+        assert demo["enabled"] is True
 
 
 @django.test.override_settings(USE_TZ=True)


### PR DESCRIPTION
## What & why

`t3 loop pause/resume/disable/enable` and `t3 loop loop-state` accepted **any**
name and wrote (or, for `loop-state`, read) a durable `LoopState` row for it.
A typo in a safety command was silently a no-op:

```
t3 loop loop-state totally_bogus_loop_xyz   → status: ENABLED      (should refuse)
t3 loop pause totally_bogus_loop_xyz         → OK ... is now paused  (should refuse)
```

The operator believed the fleet was quiet when it wasn't. Closes #3117.

## Fix — all 5 verbs guarded

Each verb now validates the NAME against the real `Loop` rows **before** touching
`LoopState`, in `manage.py loop_state` (the single ORM chokepoint the CLI
delegates to). An unknown name is refused with exit `2`, names the loop, and
points at `t3 loops list`:

```
ERROR  no loop named 'totally_bogus_loop_xyz' — run `t3 loops list` to see the known loops
```

Handlers fixed (`src/teatree/core/management/commands/loop_state.py`): `pause`,
`resume`, `disable`, `enable`, `status` (backing `t3 loop loop-state`).

The manager-layer guard (making a `LoopState` row un-constructible at the model
layer) was intentionally **not** added — see Open questions below.

## Bonus — pause is now confirmable in `t3 loops list`

`t3 loop pause` holds a loop via `LoopState` **without** flipping `Loop.enabled`,
so `t3 loops list` still printed `enabled` for a paused loop. The state column now
folds the hold in (`enabled` / `paused` / `disabled`) and `--json` gains a
`status` field (the `enabled` row flag is unchanged for back-compat). ~15 LOC.

## Tests (TDD, RED observed first)

RED on the pre-fix code (pasted verbatim):

```
test_pause_unknown_name...  AssertionError: OK    loop 'totally_bogus_loop_xyz' is now paused.
test_loop_state_unknown...  AssertionError: loop 'totally_bogus_loop_xyz' status: ENABLED
```

Green after the fix. Coverage: unknown-name refusal for all 5 verbs (command +
end-to-end CLI), the exact repro, no-regression that the known loops still
pause/resume, and the bonus pause-visibility (paused loop renders `paused`,
`--json` carries `status`). Suites run green: the loop-state + loops-list files,
plus `tests/teatree_loops/`, `tests/teatree_loop/`, and the conformance
capability-surface walk (no regression).

## Live-DB junk-row cleanup

The two junk `LoopState` rows the repro created were removed via `manage.py`
(ORM, from the main clone against the canonical DB — no hand-editing):
`totally_bogus_loop_xyz` and the newline-joined name. Both confirmed gone.

Found a **third** junk row not in scope: `LoopState('ticket', disabled)` — a
typo of the real `tickets` loop, so `tickets` was never actually disabled. Left
in place (outside the explicit cleanup scope); happy to remove it on request.

## Architecture pre-check — #3117

**1. BLUEPRINT § alignment** — Loop control plane (`/loops`, §5.6 loop topology).
The claim: `t3 loop <verb> <name>` must refuse a name that is not a real `Loop`.

**2. FSM phase boundaries** — n/a (no `Ticket`/`Worktree` state transition).

**3. Extension-point contracts** — n/a (no `OverlayBase`/scanner/Protocol change).

**4. Component boundaries** — validation lives in the `loop_state` management
command (the ORM chokepoint the CLI already delegates to), matching the sibling
`loop_owner` refusal convention. The CLI layer is unchanged except a docstring.

**5. Dependency direction** — no new cross-module import; `Loop`/`LoopState` were
already imported by the touched commands. `tach` passed.

**6. Test surface** — command-level (`call_command` + `SystemExit(2)`), CLI-level
(`runner.invoke` + exit code / stdout), and `loops_list` render/JSON assertions.

**7. Resilience invariants** — no external write. The read-side `status_of`
fail-safe (absent row → ENABLED, hot tick path) is intentionally left untouched;
the operator-facing refusal is in the command layer only.

**8. Identity/key normalization** — the loop `name` is the canonical key on both
sides; validation is an exact-match existence check, no strip/split.

**9. Behavior preservation** — one behavior removed: writing/reading `LoopState`
for an unknown name (that was the bug). One pre-fix test that pinned it
(`test_enable_disable_are_no_ops_for_a_name_with_no_loop_row`) is replaced by the
refusal tests. No safety/privacy matcher narrowed.

**10. Removability / harness-vs-data** — the guard is one helper called at the top
of each verb; deleting it reverts cleanly. The known-loop set is data (`Loop`
rows), the guard is the generic mechanism reading it.

## Open questions & assumptions

- **Manager-layer guard deferred (assumption).** #3117 asks *ideally* to make a
  `LoopState` row un-constructible at the model layer, "at minimum guard the CLI
  paths" if that is a big change. It is: ~10 gating/config test files call
  `LoopState.objects.pause(...)` directly with real loop names but create **zero**
  `Loop` rows — they treat `LoopState` as a Loop-independent control plane. A
  manager guard would couple the two and churn all of them. The only production
  writer of `LoopState` is this management command, which is now fully guarded, so
  no junk row can be created through any production path. Guarding the command
  paths is the sanctioned minimum.
- **Third junk row `ticket`** left in place (see cleanup section) — remove on request.
- **Valid loop set = the `Loop` table.** The reactive infra loops
  (`slack_answer`/`self_improve`/`drain_queue`) are deliberately not `Loop` rows
  and are gated by their own `LoopLease`, never by `LoopState`, so refusing them
  here removes no working capability.
