### PR TITLE
fix(tool): analyze-video honors all flags, spans full video, adds crop/sheet/forge-fetch

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -2500,7 +2500,8 @@ Usage: t3 tool [OPTIONS] COMMAND [ARGS]...
 │                      overlay's rules.                                        │
 │ repo-mode            Report whether the repo is solo (fix proactively) or    │
 │                      collaborative (flag, don't fix).                        │
-│ analyze-video        Decompose video into frames for AI analysis.            │
+│ analyze-video        Decompose a video into frames for AI analysis, or       │
+│                      verify its quality.                                     │
 │ bump-deps            Bump pyproject.toml dependencies from uv.lock.          │
 │ sonar-check          Run local SonarQube analysis via Docker.                │
 │ claude-handover      Show Claude handover telemetry and runtime              │
@@ -2640,12 +2641,23 @@ Usage: t3 tool repo-mode [OPTIONS] [REPO]
 #### `t3 tool analyze-video`
 
 ```
-Usage: t3 tool analyze-video [OPTIONS] VIDEO_PATH
+Usage: t3 tool analyze-video [OPTIONS] SOURCE
 
- Decompose video into frames for AI analysis.
+ Decompose a video into frames for AI analysis, or verify its quality.
+
+ ``source`` plus every flag passes straight through to
+ ``scripts/analyze_video.py``, which owns the flag definitions (#3116):
+ ``--interval N`` (0 derives from duration to span the whole video),
+ ``--max-frames N``, ``--scale W`` (default 1280px, 0 = native),
+ ``--crop top-bar|W:H:X:Y``, ``--contact-sheet ROWSxCOLS``,
+ ``--verify [--max-dead-lead S]`` (deterministic dead-lead gate, now
+ reachable to point at another author's video), ``--scene``,
+ ``--threshold T``, ``--output DIR``.
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
-│ *    video_path      TEXT  Path to video file [required]                     │
+│ *    source      TEXT  Video file path or URL (GitLab/GitHub upload URLs are │
+│                        fetched authenticated)                                │
+│                        [required]                                            │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │

--- a/scripts/analyze_video.py
+++ b/scripts/analyze_video.py
@@ -2,24 +2,46 @@
 
 Default mode extracts frames from a video file at a fixed interval using
 ffmpeg, producing numbered PNG images that an AI agent can read and analyze.
+Frames are scaled down (``--scale``) so a batch is readable without emitting
+native-resolution Retina PNGs; ``--crop`` and ``--contact-sheet`` derive the
+top-bar / interaction-strip views that make an analysis tractable.
+
+When the user does not pass ``--interval``, the interval is derived from the
+duration so the sampled frames span the WHOLE video — a long recording is never
+silently half-read. When the user forces an interval that cannot cover the
+duration within ``--max-frames``, an explicit coverage window and dropped-frame
+count is printed rather than quietly stopping partway.
 
 ``--verify`` mode runs the deterministic ``teatree.core.evidence.video_evidence`` check
 (leading blank/static pre-roll budget) and exits non-zero on failure — the same
-gate ``e2e post-test-plan`` machine-enforces — so a human or agent can check a
-recording directly before posting it.
+gate ``e2e post-test-plan`` machine-enforces — so a human or agent can point it
+at a recording (including a colleague's) before trusting it.
 
-Supports local files and URLs (downloaded first via curl).
+Supports local files and URLs. A GitLab project-upload URL is fetched through
+``glab api`` and a GitHub attachment through an authenticated ``curl``, because a
+plain ``curl`` against those returns login HTML rather than the file.
 """
 
+import math
+import re
 import shutil
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from urllib.parse import quote, urlparse
 
 import typer
 
 app = typer.Typer(add_completion=False)
+
+# Requiring a long hex secret keeps a repo path merely containing ``/uploads/``
+# from matching as a project-upload (``<host>/<path>/uploads/<secret>/<file>``).
+_GITLAB_UPLOAD_RE = re.compile(r"^https?://([^/]+)/(.+?)/uploads/([0-9a-fA-F]{16,})/(.+)$")
+
+_TOP_BAR_CROP = "crop=iw:ih*0.07:0:0"
+_CROP_GEOMETRY_FIELDS = 4
+_GRID_FIELDS = 2
 
 
 def _check_ffmpeg() -> str:
@@ -57,18 +79,117 @@ def _get_video_duration(ffmpeg_path: str, video_path: Path) -> float:
         return 0.0
 
 
+def _effective_interval(duration: float, max_frames: int, user_interval: float) -> float:
+    """Sampling interval to use: the user's when given, else one that spans the whole video.
+
+    Deriving ``duration / max_frames`` when the user passes no ``--interval``
+    makes the default cover the entire recording — the fix for a long video
+    being silently read only up to ``max_frames x 1.0s``.
+    """
+    if user_interval > 0:
+        return user_interval
+    if duration <= 0 or max_frames <= 0:
+        return 1.0
+    return duration / max_frames
+
+
+def _coverage(duration: float, interval: float, n_frames: int) -> tuple[float, int]:
+    """Return ``(last_covered_second, frames_dropped_past_cap)`` for a fixed-interval run."""
+    covered_end = max(0.0, (n_frames - 1) * interval)
+    if duration <= 0 or interval <= 0:
+        return covered_end, 0
+    total_possible = math.ceil(duration / interval)
+    return covered_end, max(0, total_possible - n_frames)
+
+
+def _crop_expr(crop: str) -> str:
+    """Translate a ``--crop`` value into an ffmpeg ``crop=`` filter, or '' for no crop."""
+    if not crop:
+        return ""
+    if crop == "top-bar":
+        return _TOP_BAR_CROP
+    parts = crop.split(":")
+    if len(parts) != _CROP_GEOMETRY_FIELDS or not all(p.strip() for p in parts):
+        msg = f"Invalid --crop {crop!r}: use 'top-bar' or W:H:X:Y"
+        raise ValueError(msg)
+    return f"crop={crop}"
+
+
+def _frame_filter(*, interval: float, scale: int, crop: str, scene: bool, threshold: float) -> str:
+    """Build the ffmpeg ``-vf`` filter graph for frame extraction (sample → crop → scale)."""
+    parts: list[str] = []
+    if scene:
+        parts.append(f"select='gt(scene\\,{threshold})',showinfo")
+    else:
+        parts.append(f"fps=1/{interval}")
+    crop_expr = _crop_expr(crop)
+    if crop_expr:
+        parts.append(crop_expr)
+    if scale > 0:
+        parts.append(f"scale='min({scale},iw)':-2")
+    return ",".join(parts)
+
+
+def _tile_filter(grid: str) -> str:
+    """Translate a ``ROWSxCOLS`` contact-sheet grid into an ffmpeg ``tile=COLSxROWS`` filter."""
+    parts = grid.lower().split("x")
+    bad_format = f"Invalid --contact-sheet {grid!r}: use ROWSxCOLS (e.g. 6x5)"
+    if len(parts) != _GRID_FIELDS:
+        raise ValueError(bad_format)
+    try:
+        rows, cols = int(parts[0]), int(parts[1])
+    except ValueError as exc:
+        raise ValueError(bad_format) from exc
+    if rows <= 0 or cols <= 0:
+        msg = f"Invalid --contact-sheet {grid!r}: rows and cols must be positive"
+        raise ValueError(msg)
+    return f"tile={cols}x{rows}"
+
+
+def _gh_token() -> str | None:
+    """Return the GitHub CLI auth token, or None when gh is absent/unauthenticated."""
+    if shutil.which("gh") is None:
+        return None
+    result = subprocess.run(["gh", "auth", "token"], capture_output=True, text=True)
+    token = result.stdout.strip()
+    return token or None
+
+
+def _fetch_plan(url: str, dest: Path, *, gh_token: str | None = None) -> tuple[list[str], bool]:
+    """Return ``(argv, capture_stdout)`` to fetch *url* into *dest*, using forge auth where needed.
+
+    A GitLab project-upload URL routes through ``glab api`` (its body is the raw
+    file on stdout); a GitHub attachment through an authenticated ``curl`` (the
+    token is sent only to github.com — curl drops it on the cross-host redirect
+    to the signed asset store). Everything else is a plain ``curl -o``.
+    """
+    gitlab = _GITLAB_UPLOAD_RE.match(url)
+    if gitlab is not None:
+        host, project, secret, filename = gitlab.groups()
+        filename = filename.split("?", maxsplit=1)[0]
+        argv = ["glab", "api"]
+        if host != "gitlab.com":
+            argv += ["--hostname", host]
+        argv.append(f"projects/{quote(project, safe='')}/uploads/{secret}/{filename}")
+        return argv, True
+
+    if urlparse(url).hostname == "github.com" and gh_token:
+        return ["curl", "-sL", "-H", f"Authorization: Bearer {gh_token}", "-o", str(dest), url], False
+
+    return ["curl", "-sL", "-o", str(dest), url], False
+
+
 def _download_url(url: str, dest: Path) -> Path:
-    """Download a URL to a local file."""
+    """Download a URL to a local file, authenticating for GitLab/GitHub forge uploads."""
     suffix = Path(url.split("?", maxsplit=1)[0]).suffix or ".mp4"
     local = dest / f"input{suffix}"
-    result = subprocess.run(
-        ["curl", "-sL", "-o", str(local), url],
-        capture_output=True,
-        text=True,
-    )
+    argv, capture_stdout = _fetch_plan(url, local, gh_token=_gh_token())
+    result = subprocess.run(argv, capture_output=True)
     if result.returncode != 0:
-        print(f"Error downloading {url}: {result.stderr}", file=sys.stderr)
+        print(f"Error downloading {url}: {result.stderr.decode(errors='replace')}", file=sys.stderr)
         raise typer.Exit(1)
+    if capture_stdout:
+        local.write_bytes(result.stdout)
     if not local.exists() or local.stat().st_size == 0:
         print(f"Error: downloaded file is empty: {local}", file=sys.stderr)
         raise typer.Exit(1)
@@ -108,20 +229,118 @@ def _run_verify(source: str, *, max_dead_lead: float) -> None:
     raise typer.Exit(1)
 
 
+def _build_contact_sheet(ffmpeg_path: str, frames: list[Path], out: Path, grid: str) -> Path:
+    """Tile *frames* into a single contact-sheet PNG under *out* and return its path."""
+    tile = _tile_filter(grid)
+    sheet = out / "contact_sheet.png"
+    pattern = str(frames[0].parent / "frame_%04d.png")
+    cmd = [ffmpeg_path, "-i", pattern, "-vf", tile, "-frames:v", "1", str(sheet), "-y"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"ffmpeg contact-sheet error:\n{result.stderr}", file=sys.stderr)
+        raise typer.Exit(1)
+    return sheet
+
+
+def _resolve_input(source: str, out: Path) -> Path:
+    """Resolve *source* to a local video path, downloading a URL into *out* first."""
+    if source.startswith(("http://", "https://")):
+        print(f"Downloading: {source}")
+        return _download_url(source, out)
+    path = Path(source).expanduser().resolve()
+    if not path.exists():
+        print(f"Error: file not found: {path}", file=sys.stderr)
+        raise typer.Exit(1)
+    return path
+
+
+def _extract_frames(ffmpeg_path: str, video_path: Path, out: Path, *, vf: str, ff_args: list[str]) -> list[Path]:
+    """Sample frames from the recording; exit non-zero when ffmpeg errors or produces nothing."""
+    cmd = [ffmpeg_path, "-i", str(video_path), "-vf", vf, *ff_args, str(out / "frame_%04d.png"), "-y"]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"ffmpeg error:\n{result.stderr}", file=sys.stderr)
+        raise typer.Exit(1)
+    frames = sorted(out.glob("frame_*.png"))
+    if not frames:
+        print("No frames extracted — video may be too short or corrupt.", file=sys.stderr)
+        raise typer.Exit(1)
+    return frames
+
+
+def _print_report(  # noqa: PLR0913
+    *,
+    video_path: Path,
+    duration: float,
+    interval: float,
+    scene: bool,
+    threshold: float,
+    scale: int,
+    out: Path,
+    frames: list[Path],
+    sheet: Path | None,
+) -> None:
+    """Print the summary, the covered window (with a loud drop warning), and frame paths."""
+    mode = f"scene detection (threshold={threshold})" if scene else f"every {interval:.2f}s"
+    print(f"Video: {video_path.name}")
+    print(f"Duration: {duration:.1f}s")
+    print(f"Mode: {mode}")
+    print(f"Frames extracted: {len(frames)}")
+    if scale > 0:
+        print(f"Scaled to: {scale}px wide (max)")
+    print(f"Output directory: {out}")
+
+    if not scene:
+        covered_end, dropped = _coverage(duration, interval, len(frames))
+        print(f"Coverage: 0.0s - {covered_end:.1f}s of {duration:.1f}s")
+        if dropped > 0:
+            print(
+                f"WARNING: {dropped} frame(s) past --max-frames were dropped; "
+                f"{covered_end:.1f}s-{duration:.1f}s is NOT covered. "
+                f"Lower --interval, raise --max-frames, or omit --interval to span the whole video.",
+            )
+
+    if sheet is not None:
+        print(f"Contact sheet: {sheet}")
+
+    print()
+    print("--- Frame paths (use Read tool to analyze) ---")
+    for f in frames:
+        idx = int(f.stem.split("_")[1]) - 1
+        ts = idx * interval if not scene else -1
+        ts_str = f" ({ts:.1f}s)" if ts >= 0 else ""
+        print(f"  {f}{ts_str}")
+
+
 @app.command()
 def main(  # noqa: PLR0913, PLR0917
-    source: str = typer.Argument(help="Video file path or URL"),
+    source: str = typer.Argument(help="Video file path or URL (GitLab/GitHub upload URLs are fetched authenticated)"),
     interval: float = typer.Option(
-        1.0,
+        0.0,
         "--interval",
         "-i",
-        help="Seconds between extracted frames (default: 1.0)",
+        help="Seconds between frames; 0 (default) derives one from duration to span the whole video",
     ),
     max_frames: int = typer.Option(
         30,
         "--max-frames",
         "-m",
         help="Maximum number of frames to extract (default: 30)",
+    ),
+    scale: int = typer.Option(
+        1280,
+        "--scale",
+        help="Scale frames to this width in px, preserving aspect; 0 keeps native resolution (default: 1280)",
+    ),
+    crop: str = typer.Option(
+        "",
+        "--crop",
+        help="Crop each frame: 'top-bar' preset (top ~7%) or explicit W:H:X:Y",
+    ),
+    contact_sheet: str = typer.Option(
+        "",
+        "--contact-sheet",
+        help="Tile the sampled frames into one image, grid ROWSxCOLS (e.g. 6x5)",
     ),
     output_dir: str = typer.Option(
         "",
@@ -154,13 +373,15 @@ def main(  # noqa: PLR0913, PLR0917
 ) -> None:
     """Decompose a video into frames for AI agent analysis, or verify its quality.
 
-    Default: extracts frames at a fixed interval (default: 1 per second) or at
-    scene changes, prints numbered PNG paths the agent can Read.
+    Default: extracts frames spanning the whole recording (interval derived from
+    duration unless ``--interval`` is given), scaled to ``--scale`` px wide, and
+    prints numbered PNG paths plus the covered window. ``--crop`` and
+    ``--contact-sheet`` derive the top-bar / interaction-strip views.
 
     ``--verify``: runs the deterministic ``teatree.core.evidence.video_evidence`` check
     (leading blank/static pre-roll budget) and exits non-zero when the recording
     opens with too much dead pre-roll — the same gate ``e2e post-test-plan``
-    enforces.
+    enforces, now reachable for a colleague's video too.
     """
     if verify:
         _run_verify(source, max_dead_lead=max_dead_lead)
@@ -168,89 +389,32 @@ def main(  # noqa: PLR0913, PLR0917
 
     ffmpeg_path = _check_ffmpeg()
 
-    # Resolve output directory
     if output_dir:
         out = Path(output_dir)
         out.mkdir(parents=True, exist_ok=True)
-        tmp_dir = None
     else:
-        tmp_dir = tempfile.mkdtemp(prefix="t3_video_")
-        out = Path(tmp_dir)
+        out = Path(tempfile.mkdtemp(prefix="t3_video_"))
 
-    # Handle URL vs local file
-    video_path: Path
-    if source.startswith(("http://", "https://")):
-        print(f"Downloading: {source}")
-        video_path = _download_url(source, out)
-    else:
-        video_path = Path(source).expanduser().resolve()
-        if not video_path.exists():
-            print(f"Error: file not found: {video_path}", file=sys.stderr)
-            raise typer.Exit(1)
-
-    # Get duration for summary
+    video_path = _resolve_input(source, out)
     duration = _get_video_duration(ffmpeg_path, video_path)
+    effective_interval = _effective_interval(duration, max_frames, interval)
 
-    # Build ffmpeg command
-    frame_pattern = str(out / "frame_%04d.png")
+    vf = _frame_filter(interval=effective_interval, scale=scale, crop=crop, scene=scene_detect, threshold=threshold)
+    ff_args = ["-vsync", "vfr", "-frames:v", str(max_frames)] if scene_detect else ["-frames:v", str(max_frames)]
+    frames = _extract_frames(ffmpeg_path, video_path, out, vf=vf, ff_args=ff_args)
+    sheet = _build_contact_sheet(ffmpeg_path, frames, out, contact_sheet) if contact_sheet else None
 
-    if scene_detect:
-        # Scene change detection: extract frames where scene changes
-        vf = f"select='gt(scene\\,{threshold})',showinfo"
-        cmd = [
-            ffmpeg_path,
-            "-i",
-            str(video_path),
-            "-vf",
-            vf,
-            "-vsync",
-            "vfr",
-            "-frames:v",
-            str(max_frames),
-            frame_pattern,
-            "-y",
-        ]
-    else:
-        # Fixed interval extraction
-        cmd = [
-            ffmpeg_path,
-            "-i",
-            str(video_path),
-            "-vf",
-            f"fps=1/{interval}",
-            "-frames:v",
-            str(max_frames),
-            frame_pattern,
-            "-y",
-        ]
-
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if result.returncode != 0:
-        print(f"ffmpeg error:\n{result.stderr}", file=sys.stderr)
-        raise typer.Exit(1)
-
-    # Collect and sort output frames
-    frames = sorted(out.glob("frame_*.png"))
-
-    if not frames:
-        print("No frames extracted — video may be too short or corrupt.", file=sys.stderr)
-        raise typer.Exit(1)
-
-    # Print summary
-    mode = f"scene detection (threshold={threshold})" if scene_detect else f"every {interval}s"
-    print(f"Video: {video_path.name}")
-    print(f"Duration: {duration:.1f}s")
-    print(f"Mode: {mode}")
-    print(f"Frames extracted: {len(frames)}")
-    print(f"Output directory: {out}")
-    print()
-    print("--- Frame paths (use Read tool to analyze) ---")
-    for f in frames:
-        # Calculate approximate timestamp
-        idx = int(f.stem.split("_")[1]) - 1
-        ts = idx * interval if not scene_detect else -1
-        ts_str = f" ({ts:.1f}s)" if ts >= 0 else ""
-        print(f"  {f}{ts_str}")
+    _print_report(
+        video_path=video_path,
+        duration=duration,
+        interval=effective_interval,
+        scene=scene_detect,
+        threshold=threshold,
+        scale=scale,
+        out=out,
+        frames=frames,
+        sheet=sheet,
+    )
 
 
 if __name__ == "__main__":

--- a/src/teatree/cli/tools.py
+++ b/src/teatree/cli/tools.py
@@ -188,12 +188,28 @@ def repo_mode(
     typer.echo(mode.value)
 
 
-@tool_app.command("analyze-video")
+@tool_app.command(
+    "analyze-video",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
 def analyze_video(
-    video_path: str = typer.Argument(..., help="Path to video file"),
+    ctx: typer.Context,
+    source: str = typer.Argument(
+        ..., help="Video file path or URL (GitLab/GitHub upload URLs are fetched authenticated)"
+    ),
 ) -> None:
-    """Decompose video into frames for AI analysis."""
-    ToolRunner.run_script("analyze_video", video_path)
+    """Decompose a video into frames for AI analysis, or verify its quality.
+
+    ``source`` plus every flag passes straight through to
+    ``scripts/analyze_video.py``, which owns the flag definitions (#3116):
+    ``--interval N`` (0 derives from duration to span the whole video),
+    ``--max-frames N``, ``--scale W`` (default 1280px, 0 = native),
+    ``--crop top-bar|W:H:X:Y``, ``--contact-sheet ROWSxCOLS``,
+    ``--verify [--max-dead-lead S]`` (deterministic dead-lead gate, now
+    reachable to point at another author's video), ``--scene``,
+    ``--threshold T``, ``--output DIR``.
+    """
+    ToolRunner.run_script("analyze_video", source, *ctx.args)
 
 
 @tool_app.command("bump-deps")

--- a/tests/test_analyze_video_script.py
+++ b/tests/test_analyze_video_script.py
@@ -1,0 +1,226 @@
+"""Tests for ``scripts/analyze_video.py`` — pure helpers and ffmpeg integration.
+
+Covers the defects from souliane/teatree#3116: silent truncation of long
+videos, no frame scaling, no crop/contact-sheet views, and no authenticated
+fetch for forge upload URLs. The pure helpers (interval derivation, coverage
+accounting, filter-graph building, fetch routing) are unit-tested; the
+end-to-end frame pipeline is exercised against a generated clip when ffmpeg is
+present.
+"""
+
+import shutil
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts import analyze_video as av
+
+_HAS_FFMPEG = shutil.which("ffmpeg") is not None
+
+
+class TestEffectiveInterval:
+    """Deriving a sampling interval that spans the whole video by default (#3116 defect 1)."""
+
+    def test_auto_interval_spans_full_duration(self):
+        """No user interval → derive one so max_frames span the whole video, not just the first 30s."""
+        assert av._effective_interval(51.4, 30, 0.0) == pytest.approx(51.4 / 30)
+
+    def test_user_interval_is_honored(self):
+        assert av._effective_interval(51.4, 30, 0.75) == pytest.approx(0.75)
+
+    def test_unprobeable_duration_falls_back(self):
+        assert av._effective_interval(0.0, 30, 0.0) == pytest.approx(1.0)
+
+
+class TestCoverage:
+    """Loud coverage accounting so partial coverage never reads as full (#3116 defect 1)."""
+
+    def test_dropped_tail_is_reported(self):
+        covered_end, dropped = av._coverage(51.4, 1.0, 30)
+        assert covered_end == pytest.approx(29.0)
+        assert dropped == 22
+
+    def test_full_coverage_drops_nothing(self):
+        covered_end, dropped = av._coverage(6.0, 0.2, 30)
+        assert dropped == 0
+        assert covered_end == pytest.approx(5.8)
+
+
+class TestFrameFilter:
+    """Frame filter-graph: scale + crop composition (#3116 defects 3 & 4)."""
+
+    def test_fixed_interval_with_default_scale(self):
+        vf = av._frame_filter(interval=1.0, scale=1280, crop="", scene=False, threshold=0.3)
+        assert vf == "fps=1/1.0,scale='min(1280,iw)':-2"
+
+    def test_scale_zero_keeps_native_resolution(self):
+        vf = av._frame_filter(interval=1.0, scale=0, crop="", scene=False, threshold=0.3)
+        assert vf == "fps=1/1.0"
+
+    def test_top_bar_crop_preset(self):
+        vf = av._frame_filter(interval=1.0, scale=0, crop="top-bar", scene=False, threshold=0.3)
+        assert vf == "fps=1/1.0,crop=iw:ih*0.07:0:0"
+
+    def test_scene_mode_uses_select_filter(self):
+        vf = av._frame_filter(interval=1.0, scale=0, crop="", scene=True, threshold=0.4)
+        assert vf.startswith("select='gt(scene")
+        assert "0.4" in vf
+
+
+class TestCropExpression:
+    def test_top_bar_preset(self):
+        assert av._crop_expr("top-bar") == "crop=iw:ih*0.07:0:0"
+
+    def test_explicit_geometry(self):
+        assert av._crop_expr("300:80:0:0") == "crop=300:80:0:0"
+
+    def test_empty_is_no_crop(self):
+        assert av._crop_expr("") == ""
+
+    def test_invalid_geometry_raises(self):
+        with pytest.raises(ValueError, match="crop"):
+            av._crop_expr("nonsense")
+
+
+class TestTileFilter:
+    """Contact-sheet grid parsing, ROWSxCOLS → ffmpeg tile=COLSxROWS (#3116 defect 4)."""
+
+    def test_grid_is_rows_by_cols(self):
+        assert av._tile_filter("6x5") == "tile=5x6"
+
+    def test_single_column_vertical_stack(self):
+        assert av._tile_filter("30x1") == "tile=1x30"
+
+    def test_invalid_grid_raises(self):
+        with pytest.raises(ValueError, match="contact-sheet"):
+            av._tile_filter("5")
+
+
+class TestFetchPlan:
+    """Authenticated fetch routing for forge upload URLs (#3116 defect 5)."""
+
+    _SECRET = "deadbeef" * 4  # a valid 32-hex upload secret, low-entropy so it is not a real credential
+
+    def test_gitlab_upload_uses_glab_api(self, tmp_path):
+        url = f"https://gitlab.com/mygroup/myproj/uploads/{self._SECRET}/screen.mov"
+        argv, capture_stdout = av._fetch_plan(url, tmp_path / "input.mov")
+        assert argv[:2] == ["glab", "api"]
+        assert argv[-1] == f"projects/mygroup%2Fmyproj/uploads/{self._SECRET}/screen.mov"
+        assert "--hostname" not in argv
+        assert capture_stdout is True
+
+    def test_self_managed_gitlab_passes_hostname(self, tmp_path):
+        url = f"https://gitlab.example.com/team/app/uploads/{self._SECRET}/rec.mov"
+        argv, _ = av._fetch_plan(url, tmp_path / "input.mov")
+        assert "--hostname" in argv
+        assert argv[argv.index("--hostname") + 1] == "gitlab.example.com"
+
+    def test_gitlab_upload_with_subgroups(self, tmp_path):
+        url = f"https://gitlab.com/grp/sub/app/uploads/{self._SECRET}/a.mov"
+        argv, _ = av._fetch_plan(url, tmp_path / "input.mov")
+        assert argv[-1] == f"projects/grp%2Fsub%2Fapp/uploads/{self._SECRET}/a.mov"
+
+    def test_github_attachment_uses_authenticated_curl(self, tmp_path):
+        url = "https://github.com/user-attachments/assets/deadbeef-1234"
+        argv, capture_stdout = av._fetch_plan(url, tmp_path / "input.mp4", gh_token="TESTTOKEN")
+        assert argv[0] == "curl"
+        assert "Authorization: Bearer TESTTOKEN" in argv
+        assert capture_stdout is False
+
+    def test_github_without_token_is_plain_curl(self, tmp_path):
+        url = "https://github.com/user-attachments/assets/deadbeef-1234"
+        argv, _ = av._fetch_plan(url, tmp_path / "input.mp4", gh_token=None)
+        assert argv[0] == "curl"
+        assert not any(a.startswith("Authorization") for a in argv)
+
+    def test_signed_githubusercontent_is_plain_curl(self, tmp_path):
+        url = "https://private-user-images.githubusercontent.com/x/y.mov?jwt=abc"
+        argv, _ = av._fetch_plan(url, tmp_path / "input.mov", gh_token="TESTTOKEN")
+        assert argv[0] == "curl"
+        assert not any(a.startswith("Authorization") for a in argv)
+
+    def test_plain_url_uses_curl(self, tmp_path):
+        argv, capture_stdout = av._fetch_plan("https://example.com/clip.mp4", tmp_path / "input.mp4")
+        assert argv[0] == "curl"
+        assert capture_stdout is False
+
+
+def _make_clip(path: Path, *, duration: int, size: str = "320x240") -> None:
+    ffmpeg = shutil.which("ffmpeg")
+    assert ffmpeg is not None
+    subprocess.run(
+        [
+            ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            f"testsrc=duration={duration}:size={size}:rate=24",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:v",
+            "libx264",
+            str(path),
+            "-y",
+        ],
+        check=True,
+    )
+
+
+def _run_script(*args: str) -> subprocess.CompletedProcess[str]:
+    script = Path(__file__).resolve().parent.parent / "scripts" / "analyze_video.py"
+    return subprocess.run([sys.executable, str(script), *args], capture_output=True, text=True, check=False)
+
+
+@pytest.mark.skipif(not _HAS_FFMPEG, reason="ffmpeg not installed")
+class TestFramePipeline:
+    """End-to-end frame extraction over a generated clip (#3116 defects 1, 3, 4)."""
+
+    def test_auto_interval_covers_full_duration(self, tmp_path):
+        video = tmp_path / "clip.mp4"
+        _make_clip(video, duration=6)
+        out = tmp_path / "frames"
+        result = _run_script(str(video), "--output", str(out))
+        assert result.returncode == 0, result.stderr
+        assert "Coverage:" in result.stdout
+        frames = sorted(out.glob("frame_*.png"))
+        assert len(frames) >= 20, result.stdout
+
+    def test_default_scale_shrinks_frames(self, tmp_path):
+        video = tmp_path / "clip.mp4"
+        _make_clip(video, duration=3, size="1920x1080")
+        out = tmp_path / "frames"
+        result = _run_script(str(video), "--output", str(out), "--scale", "640")
+        assert result.returncode == 0, result.stderr
+        frames = sorted(out.glob("frame_*.png"))
+        assert frames
+        width = _png_width(frames[0])
+        assert width == 640, width
+
+    def test_explicit_small_interval_warns_on_dropped_tail(self, tmp_path):
+        video = tmp_path / "clip.mp4"
+        _make_clip(video, duration=6)
+        out = tmp_path / "frames"
+        result = _run_script(str(video), "--output", str(out), "--interval", "0.1", "--max-frames", "10")
+        assert result.returncode == 0, result.stderr
+        assert "WARNING" in result.stdout
+        assert "dropped" in result.stdout.lower()
+
+    def test_contact_sheet_is_written(self, tmp_path):
+        video = tmp_path / "clip.mp4"
+        _make_clip(video, duration=4)
+        out = tmp_path / "frames"
+        result = _run_script(str(video), "--output", str(out), "--scale", "200", "--contact-sheet", "3x2")
+        assert result.returncode == 0, result.stderr
+        sheet = out / "contact_sheet.png"
+        assert sheet.exists(), result.stdout
+
+
+def _png_width(path: Path) -> int:
+    data = path.read_bytes()
+    return struct.unpack(">I", data[16:20])[0]

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -254,7 +254,66 @@ class TestToolCommands:
         with patch.object(ToolRunner, "run_script") as mock:
             result = runner.invoke(app, ["tool", "analyze-video", "/path/to/video.mp4"])
             assert result.exit_code == 0
-            mock.assert_called_once_with("analyze_video", "/path/to/video.mp4")
+            args = mock.call_args.args
+            assert args[0] == "analyze_video"
+            assert "/path/to/video.mp4" in args
+
+    def test_analyze_video_forwards_every_flag(self):
+        """Every script flag the CLI declares must reach the underlying script (#3116 defect 2)."""
+        with patch.object(ToolRunner, "run_script") as mock:
+            result = runner.invoke(
+                app,
+                [
+                    "tool",
+                    "analyze-video",
+                    "/vid.mov",
+                    "--interval",
+                    "0.75",
+                    "--max-frames",
+                    "12",
+                    "--scale",
+                    "800",
+                    "--crop",
+                    "top-bar",
+                    "--contact-sheet",
+                    "6x2",
+                    "--scene",
+                    "--threshold",
+                    "0.4",
+                    "--verify",
+                    "--max-dead-lead",
+                    "3.0",
+                    "--output",
+                    "/tmp/frames",
+                ],
+            )
+            assert result.exit_code == 0, result.stdout
+            args = list(mock.call_args.args)
+            assert args[0] == "analyze_video"
+            forwarded = args[1:]
+
+            def _pair(flag: str, value: str) -> bool:
+                return any(forwarded[i] == flag and forwarded[i + 1] == value for i in range(len(forwarded) - 1))
+
+            assert "/vid.mov" in forwarded
+            assert _pair("--interval", "0.75")
+            assert _pair("--max-frames", "12")
+            assert _pair("--scale", "800")
+            assert _pair("--crop", "top-bar")
+            assert _pair("--contact-sheet", "6x2")
+            assert _pair("--threshold", "0.4")
+            assert _pair("--max-dead-lead", "3.0")
+            assert _pair("--output", "/tmp/frames")
+            assert "--scene" in forwarded
+            assert "--verify" in forwarded
+
+    def test_analyze_video_verify_flag_reaches_gate(self):
+        """--verify is forwardable so a reviewer can point the dead-lead gate at a colleague's video (#3116)."""
+        with patch.object(ToolRunner, "run_script") as mock:
+            result = runner.invoke(app, ["tool", "analyze-video", "/vid.mov", "--verify", "--max-dead-lead", "2.5"])
+            assert result.exit_code == 0, result.stdout
+            forwarded = list(mock.call_args.args)[1:]
+            assert "--verify" in forwarded
 
     @pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg not installed")
     def test_analyze_video_script_extracts_frames(self, tmp_path):


### PR DESCRIPTION
Closes #3116.

`t3 tool analyze-video` silently truncated long videos, forwarded none of the script's flags, emitted native-resolution frames, and could not fetch forge upload URLs. This fixes all five reported defects.

## Defects fixed

| # | Defect | Fix |
|---|--------|-----|
| 1 | Silent truncation (30 frames × 1.0s capped coverage at 30s, no warning) | When `--interval` is omitted it is derived from duration so frames span the whole video. A forced interval that cannot cover the duration prints an explicit `Coverage: 0.0s - Xs of Ys` line and a loud `WARNING: N frame(s) past --max-frames were dropped` instead of stopping silently. |
| 2 | CLI wrapper forwarded nothing (declared only `video_path`) | The command is now a passthrough: `source` plus every flag reaches `scripts/analyze_video.py`, which owns the flag definitions. `--verify` (the deterministic dead-lead gate) is now reachable so a reviewer can point it at another author's video. |
| 3 | No frame scaling (native Retina PNGs, ~100 MB/run) | `--scale` defaults to 1280px wide (0 = native), never upscales. |
| 4 | No crop / contact sheet | `--crop` (`top-bar` preset = top ~7%, or explicit `W:H:X:Y`) and `--contact-sheet ROWSxCOLS` derive the top-bar / interaction-strip views. |
| 5 | No authenticated fetch for forge uploads | A GitLab project-upload URL routes through `glab api` (`--hostname` for self-managed); a GitHub attachment through an authenticated `curl`; other URLs stay plain `curl`. |

## Verification

- `tests/test_analyze_video_script.py` — pure helpers (interval derivation, coverage accounting, filter-graph, contact-sheet grid, fetch routing) + ffmpeg integration (auto-interval coverage, scale, loud drop warning, contact sheet). RED first (27 failing on pre-fix code), then green.
- `tests/test_cli_tools.py` — every flag is forwarded, `--verify` reaches the gate.
- 79 tests green; `ruff check`/`ruff format`/`ty` clean; `docs/generated/cli-reference.md` regenerated and in sync.

## Architecture pre-check — #3116

**1. BLUEPRINT § alignment** — n/a: a standalone `t3 tool` utility + `scripts/` script; no BLUEPRINT contract governs it and none is changed.

**2. FSM phase boundaries** — n/a: no `Ticket`/`Worktree` state transitions.

**3. Extension-point contracts** — n/a: no `OverlayBase`, scanner, hook, or `*Backend` Protocol touched.

**4. Component boundaries** — `src/teatree/cli/tools.py` stays a thin typer command (no business logic) that forwards to `scripts/analyze_video.py` (the standalone script that shells ffmpeg). The frame logic lives in the script, not the CLI layer.

**5. Dependency direction** — no new cross-module imports in `cli/`; the command delegates through the existing `ToolRunner.run_script`. `tach check` passes (no backwards edge).

**6. Test surface** — each behaviour has a named assertion (see Verification). Pure helpers are unit-tested; the pipeline is integration-tested against a generated clip; forwarding is tested via the typer `CliRunner`.

**7. Resilience invariants** — the only external interaction is shelling ffmpeg/glab/gh/curl on a read-only analysis. The script fails loud (non-zero exit) on ffmpeg/download errors; the loud coverage warning is the "no silent cap" fix itself. Idempotent (read-only); verify-by-re-read / fallback-transport / heartbeat n/a for a one-shot local analysis.

**8. Identity and key normalization** — n/a.

**9. Behavior preservation / capability deletion** — the CLI wrapper changed from a single-arg forwarder to a passthrough; the old `analyze-video <path>` invocation still works and no capability is removed. The script's *default* interval now auto-derives from duration (was a fixed 1.0s) — an intentional, documented behavior change that IS the truncation fix. No privacy/leak/security matcher is narrowed; no must-block test inverted.

**10. Removability / harness-vs-data** — the passthrough command and the pure helpers are self-contained and revert cleanly to the prior behaviour. Flag definitions are the CLI contract and live in one place (the script), not duplicated across the wrapper — the varying part (flags) is not hard-coded twice.

## Open questions & assumptions

- The `top-bar` preset is assumed to be the top 7% of frame height, per the issue.
- The GitHub authenticated path relies on `curl` dropping the `Authorization` header on the cross-host redirect to the signed asset store (curl's default `-L` behaviour), so signed `*.githubusercontent.com` URLs stay plain `curl`.
