### PR TITLE
fix(e2e): strip run provenance from the tracked test-plan manifest (#3092)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -6663,6 +6663,8 @@ Usage: t3 teatree e2e [OPTIONS] COMMAND [ARGS]...
 │ project           Run E2E tests from the project's own test directory.       │
 │ post-test-plan    Post/update the ticket's single test-plan note             │
 │                   (side-by-side Dev|Local test plan) from a manifest.        │
+│ tracked-manifest  Print a manifest's authored half (run provenance stripped) │
+│                   for a private test repo to commit.                         │
 │ retract-evidence  Withdraw the ticket's single test-plan note.               │
 │ post-evidence     [Deprecated] Alias for post-test-plan (renamed; kept one   │
 │                   release for back-compat).                                  │
@@ -6887,6 +6889,20 @@ Usage: t3 teatree e2e post-test-plan [OPTIONS]
 │                                                    no-allow-no-video]        │
 │ --help                                             Show this message and     │
 │                                                    exit.                     │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 teatree e2e tracked-manifest`
+
+```
+Usage: t3 teatree e2e tracked-manifest [OPTIONS]
+
+ Print a manifest's authored half (run provenance stripped) for a private test
+ repo to commit.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --manifest        TEXT                                                       │
+│ --help                  Show this message and exit.                          │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/docs/generated/management-commands.json
+++ b/docs/generated/management-commands.json
@@ -211,6 +211,10 @@
           "name": "post-test-plan"
         },
         {
+          "help": "Print a manifest's authored half (run provenance stripped) for a private test repo to commit",
+          "name": "tracked-manifest"
+        },
+        {
           "help": "Withdraw the ticket's single test-plan note",
           "name": "retract-evidence"
         },

--- a/docs/generated/management-commands.md
+++ b/docs/generated/management-commands.md
@@ -102,6 +102,7 @@ Drive the idle-time memory-consolidation (dreaming) cron (#1933).
 | `project` | Run E2E tests from the project's own test directory |
 | `trigger-ci` | Trigger E2E tests on a remote CI pipeline |
 | `post-test-plan` | Post (or update) the ticket's single test-plan note from a manifest |
+| `tracked-manifest` | Print a manifest's authored half (run provenance stripped) for a private test repo to commit |
 | `retract-evidence` | Withdraw the ticket's single test-plan note |
 | `post-evidence` | Deprecated alias for ``post-test-plan`` (renamed; kept one release for back-compat) |
 

--- a/skills/e2e/SKILL.md
+++ b/skills/e2e/SKILL.md
@@ -253,6 +253,8 @@ Three kinds of file get confused for one another — classify before deciding wh
 
 The **run provenance** is DB-home, not in the tree — never re-derive it from files. `Ticket.extra['e2e_recipe']` records the run's sha and env; the rubric score lives on the `Rubric` model and the posted-note URL on `E2eMandatoryRun.posted_url`.
 
+A **private** test repo that legitimately tracks its manifest (the artifacts are the deliverable there) must commit only the *authored* half — never the per-run commit SHAs / `missing_on_dev`, which churn the file on every push (#3092). `t3 <overlay> e2e tracked-manifest --manifest <path>` prints that authored half (the top-level `dev`/`local` provenance blocks removed) so two runs produce a byte-identical tracked file. Keep the full manifest out-of-repo for `post-test-plan`; commit the stripped output.
+
 A loose `seed-*.py` under `artifacts/` is a smell: fixture logic escaped the spec. Fold it into the spec's fixture and delete the script, or the next run silently depends on a human having executed it by hand.
 
 ## Test-Plan Authoring

--- a/src/teatree/cli/django_groups.py
+++ b/src/teatree/cli/django_groups.py
@@ -141,6 +141,10 @@ DJANGO_GROUPS: dict[str, DjangoGroup] = {
                 "post-test-plan",
                 "Post/update the ticket's single test-plan note (side-by-side Dev|Local test plan) from a manifest.",
             ),
+            (
+                "tracked-manifest",
+                "Print a manifest's authored half (run provenance stripped) for a private test repo to commit.",
+            ),
             ("retract-evidence", "Withdraw the ticket's single test-plan note."),
             (
                 "post-evidence",

--- a/src/teatree/core/management/commands/_test_plan/tracked.py
+++ b/src/teatree/core/management/commands/_test_plan/tracked.py
@@ -1,0 +1,77 @@
+"""The tracked (authored-only) view of a test-plan manifest (teatree #3092).
+
+A run manifest mixes two lifetimes: durable authored intent (workflow names,
+human ``steps``, the claim→capture mapping) and ephemeral run provenance
+(per-repo commit SHAs, ``missing_on_dev``) that goes stale the moment anything
+is pushed. Tracking the whole file in a private test repo therefore churns it on
+every run. :func:`strip_run_provenance` drops the top-level ``dev``/``local``
+provenance blocks so the committed file is byte-stable across runs; the full
+manifest stays out-of-repo for ``post-test-plan`` and provenance stays DB-home
+(``Ticket.extra['e2e_recipe']``).
+"""
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from teatree.core.management.commands._test_plan.render import TestPlanValidationError
+
+if TYPE_CHECKING:
+    from teatree.types import RawAPIDict
+
+_PROVENANCE_SIDES = ("dev", "local")
+_PROVENANCE_KEYS = ("commits", "missing_on_dev")
+
+
+def strip_run_provenance(manifest_json: str) -> str:
+    """Return *manifest_json* with the ephemeral ``dev``/``local`` run provenance removed.
+
+    Drops the per-repo commit SHAs and ``missing_on_dev`` from the top-level
+    side blocks (and a side block that is left with nothing but provenance),
+    keeping the authored intent and its key order so two runs that differ only in
+    provenance serialise to identical bytes.
+    """
+    try:
+        data = json.loads(manifest_json)
+    except json.JSONDecodeError as exc:
+        msg = f"--manifest is not valid JSON: {exc}"
+        raise TestPlanValidationError(msg) from None
+    if not isinstance(data, dict):
+        msg = "--manifest must be a JSON object."
+        raise TestPlanValidationError(msg)
+    tracked: RawAPIDict = {}
+    for key, value in data.items():
+        if key in _PROVENANCE_SIDES and isinstance(value, dict):
+            residual = {k: v for k, v in value.items() if k not in _PROVENANCE_KEYS}
+            if residual:
+                tracked[key] = residual
+            continue
+        tracked[key] = value
+    return json.dumps(tracked, indent=2, ensure_ascii=False) + "\n"
+
+
+def run_tracked_manifest(
+    manifest: str,
+    *,
+    write_out: Callable[[str], None],
+    write_err: Callable[[str], None],
+) -> str:
+    """Read a manifest (path or inline JSON), strip its run provenance, and write the result.
+
+    The authored manifest is written to ``write_out`` (and returned) for a
+    private test repo to commit. An empty ``--manifest`` or invalid JSON is
+    written to ``write_err`` and re-raised as ``SystemExit(1)``.
+    """
+    if not manifest.strip():
+        write_err("--manifest is required (a path to, or inline string of, the test-plan manifest JSON).")
+        raise SystemExit(1)
+    path = Path(manifest)
+    manifest_json = path.read_text(encoding="utf-8") if path.is_file() else manifest
+    try:
+        tracked = strip_run_provenance(manifest_json)
+    except TestPlanValidationError as err:
+        write_err(str(err))
+        raise SystemExit(1) from err
+    write_out(tracked)
+    return tracked

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -12,6 +12,7 @@ from teatree.core.intake.resolve import resolve_worktree
 from teatree.core.management.commands import _e2e_discovery as _disc
 from teatree.core.management.commands import _e2e_runners as _runners
 from teatree.core.management.commands._test_plan import post as _test_plan_post
+from teatree.core.management.commands._test_plan import tracked as _tracked_manifest
 from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay_loader import get_overlay
 from teatree.core.worktree.worktree_env import compose_project
@@ -521,6 +522,13 @@ class Command(TyperCommand):
             body_file=body_file,
             template=template,
             allow_no_video=allow_no_video,
+        )
+
+    @command(name="tracked-manifest")
+    def tracked_manifest(self, *, manifest: str = "") -> str:
+        """Print a manifest's authored half (run provenance stripped) for a private test repo to commit."""
+        return _tracked_manifest.run_tracked_manifest(
+            manifest=manifest, write_out=self.stdout.write, write_err=self.stderr.write
         )
 
     @command(name="retract-evidence")

--- a/tests/teatree_core/management/commands/_test_plan/test_tracked_manifest.py
+++ b/tests/teatree_core/management/commands/_test_plan/test_tracked_manifest.py
@@ -1,0 +1,129 @@
+"""Tests for the tracked-manifest transform (teatree #3092).
+
+A test-plan ``manifest.json`` mixes two lifetimes: durable authored intent
+(workflow names, human ``steps``, the claim→capture mapping) and ephemeral run
+provenance (per-repo commit SHAs, ``missing_on_dev``) that goes stale the moment
+anything is pushed. Tracking the whole file therefore churns it every run.
+
+``strip_run_provenance`` produces the *tracked* half — the authored manifest
+with the top-level ``dev``/``local`` provenance blocks removed — so the file a
+private test repo commits is stable across runs. The full manifest (with
+provenance) stays out-of-repo for ``post-test-plan``.
+"""
+
+import json
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+from django.test import SimpleTestCase
+
+from teatree.core.management.commands._test_plan import render as _render
+from teatree.core.management.commands._test_plan.tracked import run_tracked_manifest, strip_run_provenance
+
+
+def _run_manifest(*, dev_sha: str, local_sha: str, missing: list[str]) -> str:
+    """A full manifest for one run: identical authored intent, run-specific provenance."""
+    return json.dumps(
+        {
+            "ticket": "8521",
+            "mrs": ["https://gitlab.com/group/client/-/merge_requests/6331"],
+            "dev": {"commits": {"client": dev_sha}, "missing_on_dev": missing},
+            "local": {"commits": {"client": local_sha}},
+            "workflows": [
+                {
+                    "workflow": "Login",
+                    "steps": ["Open the app", "Click Login", "Expect the dashboard"],
+                    "dev": {"video": None, "images": []},
+                    "local": {"video": "local/run.webm", "images": ["local/step1.png"]},
+                }
+            ],
+        }
+    )
+
+
+class StripRunProvenanceTests(SimpleTestCase):
+    def test_two_runs_produce_byte_identical_tracked_manifest(self) -> None:
+        first = _run_manifest(dev_sha="aaaa111", local_sha="bbbb222", missing=["client!6331 (unmerged)"])
+        second = _run_manifest(dev_sha="cccc333", local_sha="dddd444", missing=["client!6331 (draft)"])
+
+        assert strip_run_provenance(first) == strip_run_provenance(second)
+
+    def test_tracked_manifest_carries_no_run_provenance(self) -> None:
+        tracked = strip_run_provenance(_run_manifest(dev_sha="aaaa111", local_sha="bbbb222", missing=["x"]))
+
+        for stale in ("aaaa111", "bbbb222", "commits", "missing_on_dev"):
+            assert stale not in tracked
+        data = json.loads(tracked)
+        assert "dev" not in data
+        assert "local" not in data
+
+    def test_tracked_manifest_preserves_authored_intent(self) -> None:
+        data = json.loads(strip_run_provenance(_run_manifest(dev_sha="a", local_sha="b", missing=[])))
+
+        assert data["ticket"] == "8521"
+        assert data["mrs"] == ["https://gitlab.com/group/client/-/merge_requests/6331"]
+        assert data["workflows"][0]["workflow"] == "Login"
+        assert data["workflows"][0]["steps"] == ["Open the app", "Click Login", "Expect the dashboard"]
+        assert data["workflows"][0]["local"]["images"] == ["local/step1.png"]
+
+    def test_tracked_manifest_still_parses_with_workflow_captures(self) -> None:
+        base = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(base, ignore_errors=True))
+        (base / "step1.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"0" * 64)
+        tracked = strip_run_provenance(
+            json.dumps(
+                {
+                    "ticket": "8521",
+                    "workflows": [
+                        {
+                            "workflow": "Login",
+                            "steps": ["Open the app"],
+                            "local": {"images": ["step1.png"]},
+                        }
+                    ],
+                    "local": {"commits": {"client": "deadbeef"}},
+                }
+            )
+        )
+        manifest = _render.parse_manifest(tracked, base_dir=base)
+
+        assert manifest.local.present
+        assert manifest.local.commits == {}
+        assert list(manifest.local.workflows) == ["Login"]
+
+    def test_invalid_json_is_rejected(self) -> None:
+        with pytest.raises(_render.TestPlanValidationError):
+            strip_run_provenance("{not json")
+
+    def test_non_object_manifest_is_rejected(self) -> None:
+        with pytest.raises(_render.TestPlanValidationError):
+            strip_run_provenance("[]")
+
+
+class RunTrackedManifestTests(SimpleTestCase):
+    def test_reads_path_strips_provenance_and_writes_to_stdout(self) -> None:
+        base = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(base, ignore_errors=True))
+        path = base / "manifest.json"
+        path.write_text(_run_manifest(dev_sha="aaaa111", local_sha="bbbb222", missing=["x"]), encoding="utf-8")
+        out: list[str] = []
+
+        result = run_tracked_manifest(str(path), write_out=out.append, write_err=lambda _m: None)
+
+        assert result == "".join(out)
+        assert "aaaa111" not in result
+        assert "commits" not in result
+
+    def test_empty_manifest_exits_non_zero(self) -> None:
+        errors: list[str] = []
+        with pytest.raises(SystemExit):
+            run_tracked_manifest("", write_out=lambda _m: None, write_err=errors.append)
+        assert errors
+
+    def test_invalid_json_exits_non_zero(self) -> None:
+        errors: list[str] = []
+        with pytest.raises(SystemExit):
+            run_tracked_manifest("{bad", write_out=lambda _m: None, write_err=errors.append)
+        assert errors

--- a/tests/test_cli_overlay_groups.py
+++ b/tests/test_cli_overlay_groups.py
@@ -77,6 +77,13 @@ def test_e2e_group_exposes_retract_evidence() -> None:
     assert "retract-evidence" in _e2e_subcommands()
 
 
+def test_e2e_group_exposes_tracked_manifest() -> None:
+    # #3092: ``tracked-manifest`` prints the authored half of a manifest so a
+    # private test repo can commit a byte-stable file; without a DJANGO_GROUPS
+    # bridge entry it would be unreachable from the installed CLI.
+    assert "tracked-manifest" in _e2e_subcommands()
+
+
 def test_e2e_subcommands_map_to_real_command_methods() -> None:
     for name in _e2e_subcommands():
         assert hasattr(E2eCommand, name.replace("-", "_")), name


### PR DESCRIPTION
## What / Why

The e2e test-plan `manifest.json` mixes two lifetimes: durable **authored intent** (workflow names, human `steps`, the claim→capture mapping) and ephemeral **run provenance** (per-repo commit SHAs, `missing_on_dev`) that goes stale the moment anything is pushed. A private test repo that legitimately tracks its manifest therefore churns the file on every run. #3091/#3096 moved the artifact roots out of the tree but left this provenance inside the manifest.

## Change

- New module `src/teatree/core/management/commands/_test_plan/tracked.py`:
  - `strip_run_provenance(manifest_json)` — pure transform that drops the top-level `dev`/`local` provenance blocks (`commits` + `missing_on_dev`), keeping the authored half and its key order.
  - `run_tracked_manifest(...)` — reads a manifest (path/inline) and prints the stripped result.
- New CLI command `t3 <overlay> e2e tracked-manifest --manifest <path>` prints the authored half for a private test repo to commit.
- Two runs that differ only in provenance now serialise to a **byte-identical** tracked file. Provenance stays DB-home (`Ticket.extra['e2e_recipe']`) and in the out-of-repo run manifest that `post-test-plan` still consumes.

**No behavior change:** `render.py`/`post.py` and `post-test-plan` are untouched (not in the diff); full manifests render exactly as before.

## Tests (TDD)

`tests/teatree_core/management/commands/_test_plan/test_tracked_manifest.py` — RED first (observed `ImportError`, then a byte-identity assertion that fails against a no-op transform). Covers byte-identity across two runs, provenance removal, authored-intent preservation, re-parse of the stripped manifest, invalid-input handling, and the `run_tracked_manifest` entry point. Plus a catalog assertion in `tests/test_cli_overlay_groups.py`.

## Open questions & assumptions

- **assumed:** the tracked/authored manifest is produced by the new command for a private test repo to commit; `post-test-plan` keeps consuming the full out-of-repo manifest unchanged (no DB-fill of commits at post time). The issue's alternate proposal — have `post-test-plan` resolve commits from the DB — was not taken because the DB `per_repo_shas` keys are repo paths while the manifest commit keys are repo short-names, so a DB-fill risks mismatched/broken commit links and a behavior change; left as a follow-up.
- **assumed:** stripping removes only the two known provenance keys per side and drops a side block left empty, preserving all other authored keys and order.

docs: updated `skills/e2e/SKILL.md` and the generated CLI reference for the new command.

Closes #3092