### PR TITLE
build(deps): pin claude-agent-sdk==0.2.94 to avoid the 0.2.113 AskUserQuestion chip regression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,12 @@ dependencies = [
   # boundary inside the async tools; declared alongside since it is imported
   # directly by ``teatree.mcp.server``.
   "asgiref>=3.8",
-  "claude-agent-sdk>=0.2.94",
+  # EXACT pin, not a floor: a ``>=`` floor let the installed t3 drift to
+  # 0.2.113 (with claude CLI 2.1.204), which emits a markdown
+  # ``**AskUserQuestion**`` chip instead of a ``tool_use`` block — breaking the
+  # eval AskUserQuestion flow and the question-drain. 0.2.94 is the known-green
+  # build; any bump must be deliberate and re-verified (souliane/teatree#3125).
+  "claude-agent-sdk==0.2.94",
   # ``t3 tool diff-coverage`` and ``t3 ci coverage`` are RUNTIME commands
   # that import ``coverage`` (utils/diff_coverage.py, utils/coverage_floor.py).
   # It must be present in the installed tool env, not only the dev group —

--- a/tests/test_claude_agent_sdk_pin.py
+++ b/tests/test_claude_agent_sdk_pin.py
@@ -1,0 +1,46 @@
+"""Guards the exact pin of ``claude-agent-sdk`` (souliane/teatree#3125).
+
+A ``>=`` floor let the installed ``t3`` env drift from the known-green
+``0.2.94`` to ``0.2.113`` (with claude CLI 2.1.204), which emits a markdown
+``**AskUserQuestion**`` chip instead of a ``tool_use`` block — breaking the eval
+AskUserQuestion flow and the question-drain (``teatree.eval.message_mapping``
+only maps a ``ToolUseBlock`` to a ``tool_use`` event; a text chip is never
+mapped). The constraint must stay an EXACT pin so any bump is deliberate.
+"""
+
+import tomllib
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_LOCK = _REPO_ROOT / "uv.lock"
+
+_PINNED_VERSION = "0.2.94"
+_PACKAGE = "claude-agent-sdk"
+
+
+def _sdk_constraint() -> str:
+    deps = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))["project"]["dependencies"]
+    matches = [d for d in deps if d.replace(" ", "").startswith(_PACKAGE)]
+    assert len(matches) == 1, f"expected exactly one {_PACKAGE} dependency, got {matches}"
+    return matches[0].replace(" ", "")
+
+
+def _locked_version() -> str:
+    lock = tomllib.loads(_LOCK.read_text(encoding="utf-8"))
+    matches = [p["version"] for p in lock["package"] if p["name"] == _PACKAGE]
+    assert len(matches) == 1, f"expected exactly one locked {_PACKAGE}, got {matches}"
+    return matches[0]
+
+
+class TestClaudeAgentSdkPin:
+    def test_pyproject_pins_sdk_exactly_not_a_floor(self) -> None:
+        constraint = _sdk_constraint()
+        assert constraint == f"{_PACKAGE}=={_PINNED_VERSION}", (
+            f"claude-agent-sdk must be an EXACT pin ({_PACKAGE}=={_PINNED_VERSION}), "
+            f"never a >= floor — a floor let the env drift to the 0.2.113 chip "
+            f"regression (#3125). Got: {constraint!r}"
+        )
+
+    def test_lock_resolves_sdk_to_pinned_version(self) -> None:
+        assert _locked_version() == _PINNED_VERSION

--- a/uv.lock
+++ b/uv.lock
@@ -3080,7 +3080,7 @@ ui = [
 requires-dist = [
     { name = "asgiref", specifier = ">=3.8" },
     { name = "browser-cookie3", marker = "extra == 'notion'", specifier = ">=0.20" },
-    { name = "claude-agent-sdk", specifier = ">=0.2.94" },
+    { name = "claude-agent-sdk", specifier = "==0.2.94" },
     { name = "coverage", specifier = ">=7" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "django", specifier = ">=5.2,<6.1" },


### PR DESCRIPTION
build(deps): pin claude-agent-sdk==0.2.94 to avoid the 0.2.113 AskUserQuestion chip regression

## What
- Change `claude-agent-sdk>=0.2.94` (a floor) to an exact pin `==0.2.94` in `pyproject.toml`, with a WHY comment.
- `uv lock` so the lock records `specifier = "==0.2.94"` (resolves to 0.2.94; no bad transitive claude CLI — the CLI is bundled inside the SDK wheel, not a separate PyPI dep, so pinning the SDK pins the CLI).
- Add `tests/test_claude_agent_sdk_pin.py` — a pyproject-invariant guard asserting the constraint stays an exact pin and the lock resolves to the pinned version.

## Why
The `>=` floor let the installed `t3` drift to 0.2.113 (with claude CLI 2.1.204), which emits a markdown `**AskUserQuestion**` chip instead of a `tool_use` block. `teatree.eval.message_mapping` only maps a `ToolUseBlock` to a `tool_use` event, so a text chip is never mapped — breaking the eval AskUserQuestion flow and the question-drain. 0.2.94 is the known-green build.

## Test
RED→green: with the `>=` floor the pin test fails; after pinning it passes.
```
tests/test_claude_agent_sdk_pin.py::TestClaudeAgentSdkPin::test_pyproject_pins_sdk_exactly_not_a_floor  RED (floor) → GREEN (pinned)
tests/test_claude_agent_sdk_pin.py::TestClaudeAgentSdkPin::test_lock_resolves_sdk_to_pinned_version      GREEN
```
Scoped SDK-touching eval/question tests stay green (159 passed): `test_message_mapping`, `test_api_runner`, `test_asks_decisions_one_at_a_time_anti_vacuous`.

No behavioral RED-then-green is possible for a pure runtime pin (the chip behavior lives in the SDK/CLI, not reproducible in a unit test without the bad build) — the guard is the pyproject-invariant test, which IS genuinely RED against the old floor.

docs: n/a — dependency pin + guard test, no user-visible behaviour change.

Closes #3125

Open questions & assumptions:
- assumed: 0.2.94 is the pin target (the known-green build), not a newer unverified version.
- assumed: `gh pr create` per the task brief (workflow subagent, no t3 ticket session lifecycle).
