### PR TITLE
refactor(admin): decouple loopback auto-login from INTERNAL_IPS

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -150,7 +150,11 @@ verify the fingerprint out of band).
   boundary**. A non-loopback request is never auto-logged-in, even with the flag
   on, so exposing the port off-loopback cannot open the admin. `T3_ADMIN_USER` /
   `T3_ADMIN_PASSWORD` still seed that superuser row deterministically (they matter
-  as a password only when auto-login does not apply).
+  as a password only when auto-login does not apply). Because the boundary is
+  *loopback identity*, any same-host process — or a same-host reverse proxy — that
+  reaches `127.0.0.1:8000` is trusted as superuser, so keep the box's local access
+  as tight as its SSH access and never place a same-host reverse proxy in front of
+  the admin.
 
 - **No Tailscale.** SSH is the only inbound port. This works with a corporate VPN
   up — the tunnel rides your normal SSH access.
@@ -170,10 +174,12 @@ verify the fingerprint out of band).
 
 - **Headless orchestration is still maturing** — expect to babysit early runs via
   the admin dashboard and `docker compose logs` (and Slack once you wire it up).
-- **The admin runs under gunicorn** (a production WSGI server) behind a loopback +
-  SSH tunnel — never expose it publicly. Both long-running services (worker AND
-  admin) run with `DEBUG` off to avoid `connection.queries` growth; `/admin/`
-  mounts independent of `DEBUG`, so nothing here relies on it.
+- **The admin runs under gunicorn** (a production WSGI server) bound to the box
+  loopback behind an SSH tunnel — never expose it publicly, and never place a
+  same-host reverse proxy in front of it: the auto-login trust model treats any
+  local `127.0.0.1` client (a proxy included) as superuser. Both long-running
+  services (worker AND admin) run with `DEBUG` off to avoid `connection.queries`
+  growth; `/admin/` mounts independent of `DEBUG`, so nothing here relies on it.
 - **The OAuth token shares your weekly Claude quota and does not auto-refresh** —
   rotate `CLAUDE_CODE_OAUTH_TOKEN` manually and re-run the workflow when it expires.
 - **teatree-only:** this deployment never clones or references any customer or

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -48,10 +48,12 @@ services:
 
   # Django admin (gunicorn), DEBUG off like the worker — /admin/ mounts
   # unconditionally now, so the admin no longer needs DEBUG (and inherits the
-  # same connection.queries-leak fix). Bound to the BOX loopback via host
-  # networking so the auto-login middleware sees a genuine 127.0.0.1 client: a
-  # published bridge port NATs the source to the docker gateway, which would
-  # fail the loopback check. Reach it via an SSH tunnel.
+  # same connection.queries-leak fix). Host networking binds it to the BOX
+  # loopback (127.0.0.1:8000): the SSH tunnel is the security boundary, and the
+  # middleware sees a genuine 127.0.0.1 client (a published bridge port would NAT
+  # the source to the docker gateway). With a loopback-only bind the middleware's
+  # loopback check is defense-in-depth against a bind misconfig, not the primary
+  # gate. Host port 8000 must be free on the box. Reach it via an SSH tunnel.
   teatree-admin:
     <<: *teatree-common
     environment:

--- a/src/teatree/core/middleware.py
+++ b/src/teatree/core/middleware.py
@@ -2,7 +2,6 @@
 
 from typing import TYPE_CHECKING
 
-from django.conf import settings
 from django.contrib.auth import get_user_model, login
 
 from teatree.config import get_effective_settings
@@ -27,7 +26,7 @@ class LocalAdminAutoLoginMiddleware:
     BOTH hold:
 
     * the ``admin_autologin_enabled`` setting is on (DB-home, default on), and
-    * the request originates from loopback (``127.0.0.1`` / ``::1`` / ``INTERNAL_IPS``).
+    * the request originates from loopback (``127.0.0.1`` / ``::1``).
 
     The loopback check is the hard security boundary — auto-login NEVER fires for
     a non-loopback request, even with the flag on — so a non-loopback deployment
@@ -55,11 +54,15 @@ class LocalAdminAutoLoginMiddleware:
 
 
 def _request_is_loopback(request: "HttpRequest") -> bool:
-    """Whether the request's client address is a loopback / internal address.
+    """Whether the request's client address is a loopback address.
 
-    A published bridge port NATs the source to the docker gateway, so the deploy
-    binds the admin to a real loopback interface (host networking) to keep this a
-    genuine ``127.0.0.1`` behind the SSH tunnel.
+    Reads ``REMOTE_ADDR`` (the real peer address), never a forwarded header — a
+    ``X-Forwarded-For: 127.0.0.1`` from a non-loopback client cannot spoof it.
+    The hardcoded loopback set IS the boundary; it is deliberately NOT widened by
+    ``settings.INTERNAL_IPS``, so this superuser-auth gate stays decoupled from a
+    debug-toolbar knob (a non-loopback IP added there for debugging could never
+    widen who is auto-logged-in). A published bridge port NATs the source to the
+    docker gateway, so the deploy binds the admin to a real loopback interface
+    (host networking) to keep this a genuine ``127.0.0.1`` behind the SSH tunnel.
     """
-    remote_addr = request.META.get("REMOTE_ADDR", "")
-    return remote_addr in _LOOPBACK_IPS or remote_addr in set(settings.INTERNAL_IPS)
+    return request.META.get("REMOTE_ADDR", "") in _LOOPBACK_IPS

--- a/tests/teatree_core/test_middleware.py
+++ b/tests/teatree_core/test_middleware.py
@@ -14,8 +14,8 @@ _NON_LOOPBACK = "10.0.0.7"
 
 
 class LocalAdminAutoLoginTestCase(TestCase):
-    def _run(self, path: str = "/admin/", *, remote_addr: str = _LOOPBACK, user=None):
-        request = RequestFactory().get(path, REMOTE_ADDR=remote_addr)
+    def _run(self, path: str = "/admin/", *, remote_addr: str = _LOOPBACK, user=None, **extra: str):
+        request = RequestFactory().get(path, REMOTE_ADDR=remote_addr, **extra)
         request.user = user if user is not None else AnonymousUser()
         middleware = LocalAdminAutoLoginMiddleware(lambda _req: "ok")
         with patch("teatree.core.middleware.login") as login_mock:
@@ -39,6 +39,15 @@ class LocalAdminAutoLoginTestCase(TestCase):
         # keeps an off-loopback admin port from silently opening the dashboard.
         get_user_model().objects.create_superuser("admin", password="x")
         login_mock = self._run(remote_addr=_NON_LOOPBACK)
+        login_mock.assert_not_called()
+
+    def test_forwarded_header_cannot_spoof_loopback(self) -> None:
+        # SECURITY: the check reads REMOTE_ADDR, never a forwarded header. A
+        # non-loopback client sending `X-Forwarded-For: 127.0.0.1` must NOT be
+        # auto-logged-in — locks the property against a future regression that
+        # starts trusting forwarded headers.
+        get_user_model().objects.create_superuser("admin", password="x")
+        login_mock = self._run(remote_addr=_NON_LOOPBACK, HTTP_X_FORWARDED_FOR=_LOOPBACK)
         login_mock.assert_not_called()
 
     def test_not_logged_in_when_flag_off(self) -> None:


### PR DESCRIPTION
Follow-up to #3134 (merged before this review-fix could push). The loopback auto-login gate trusted settings.INTERNAL_IPS on top of the hardcoded 127.0.0.1/::1 boundary — coupling a superuser-auth boundary to a debug-toolbar setting, so a future dev widening INTERNAL_IPS for debug reasons would silently widen who gets auto-logged-in as superuser. Drops INTERNAL_IPS from the check (the hardcoded loopback frozenset is the boundary), adds a test that a forged X-Forwarded-For 127.0.0.1 with a non-loopback REMOTE_ADDR does NOT auto-login, and tightens the deploy README/compose notes. Security review of #3134 was PASS; this closes the one latent footgun it flagged.