### PR TITLE
fix(fleet): make the ship-time claim fence resolve by issue_url+overlay (dead-fence B1)

### DIFF
--- a/src/teatree/core/fleet/wire.py
+++ b/src/teatree/core/fleet/wire.py
@@ -158,12 +158,23 @@ def ticket_claim_is_lost(ticket: "Ticket", repo: str) -> bool:
     the ref infra is unreachable so ownership cannot be confirmed (fail CLOSED).
     ``False`` when the switch is off, no claim exists, or we still hold it — so a
     non-fleet ship is never affected.
+
+    The marker is resolved by its own natural key ``(issue_url, overlay)`` — the key
+    ``ImplementedIssueMarkerManager.cache_from_fleet_claim`` populates on the dispatch
+    path. The marker's ``ticket`` FK is never set in production, so keying the fence
+    on ``ticket`` would find nothing and leave the fence a permanent no-op.
     """
     if not fleet_claim_enabled(ticket.overlay):
         return False
+    if not ticket.issue_url:
+        return False
     from teatree.core.models import ImplementedIssueMarker  # noqa: PLC0415 — leaf import kept out of module load
 
-    marker = ImplementedIssueMarker.objects.filter(ticket=ticket).exclude(claim_ref_sha="").order_by("-id").first()
+    marker = (
+        ImplementedIssueMarker.objects.filter(issue_url=ticket.issue_url, overlay=ticket.overlay)
+        .exclude(claim_ref_sha="")
+        .first()
+    )
     if marker is None:
         return False
     return not issue_claim_still_held(marker.issue_url, marker.claim_ref_sha, repo)

--- a/tests/teatree_core/fleet/test_claim_wire.py
+++ b/tests/teatree_core/fleet/test_claim_wire.py
@@ -144,11 +144,16 @@ class TestShipFenceGate(TestCase):
         holder = init_client(tmp / "holder", bare)
         claim = fleet_claim.acquire(_ISSUE, repo=str(holder), remote="origin")
         assert claim is not None
-        ticket = Ticket.objects.create(overlay="acme", state=Ticket.State.REVIEWED)
+        ticket = Ticket.objects.create(overlay="acme", issue_url=_ISSUE, state=Ticket.State.REVIEWED)
         worktree = Worktree.objects.create(
             ticket=ticket, overlay="acme", repo_path=str(holder), branch="feat", extra={"worktree_path": str(holder)}
         )
-        ImplementedIssueMarker.objects.create(issue_url=_ISSUE, overlay="acme", ticket=ticket, claim_ref_sha=claim.sha)
+        # Build the marker through the REAL production path — the manager NEVER sets
+        # the ticket FK, so the fence must resolve it by the marker's (issue_url,
+        # overlay) natural key, exactly as it will in production.
+        ImplementedIssueMarker.objects.cache_from_fleet_claim(
+            _ISSUE, "acme", claim_ref_sha=claim.sha, claimed_by_instance=claim.instance_id
+        )
         return ticket, worktree, claim.sha, bare
 
     def test_off_switch_is_a_no_op(self) -> None:
@@ -176,9 +181,19 @@ class TestShipFenceGate(TestCase):
         assert failure["allowed"] is False
         assert "no longer held by this instance" in failure["error"]
 
-    def test_ticket_without_fleet_claim_is_a_no_op(self) -> None:
+    def test_ticket_with_issue_url_but_no_marker_is_a_no_op(self) -> None:
         tmp = self._tmp()
         init_bare(tmp / "origin.git")
+        ticket = Ticket.objects.create(overlay="acme", issue_url=_ISSUE, state=Ticket.State.REVIEWED)
+        worktree = Worktree.objects.create(
+            ticket=ticket, overlay="acme", repo_path=str(tmp), branch="feat", extra={"worktree_path": str(tmp)}
+        )
+        with patch.object(fleet_claim_wire, "fleet_claim_enabled", return_value=True):
+            assert run_fleet_claim_fence_gate(ticket, worktree) is None
+
+    def test_ticket_without_issue_url_is_a_no_op(self) -> None:
+        # A ticket with no issue_url cannot carry a fleet claim to fence — short-circuit.
+        tmp = self._tmp()
         ticket = Ticket.objects.create(overlay="acme", state=Ticket.State.REVIEWED)
         worktree = Worktree.objects.create(
             ticket=ticket, overlay="acme", repo_path=str(tmp), branch="feat", extra={"worktree_path": str(tmp)}
@@ -188,8 +203,10 @@ class TestShipFenceGate(TestCase):
 
     def test_fence_fails_closed_when_ref_infra_unreachable(self) -> None:
         tmp = self._tmp()
-        ticket = Ticket.objects.create(overlay="acme", state=Ticket.State.REVIEWED)
-        ImplementedIssueMarker.objects.create(issue_url=_ISSUE, overlay="acme", ticket=ticket, claim_ref_sha="a" * 40)
+        ticket = Ticket.objects.create(overlay="acme", issue_url=_ISSUE, state=Ticket.State.REVIEWED)
+        ImplementedIssueMarker.objects.cache_from_fleet_claim(
+            _ISSUE, "acme", claim_ref_sha="a" * 40, claimed_by_instance="box-holder"
+        )
         broken = init_client(tmp / "broken", tmp / "absent.git")  # origin absent -> ls-remote raises
         with patch.object(fleet_claim_wire, "fleet_claim_enabled", return_value=True):
             assert fleet_claim_wire.ticket_claim_is_lost(ticket, str(broken)) is True
@@ -287,8 +304,10 @@ class TestExecuteShipFence(TestCase):
         thief = init_client(tmp / "thief", bare)
         claim = fleet_claim.acquire(_ISSUE, repo=str(holder), remote="origin")
         assert claim is not None
-        ticket = Ticket.objects.create(overlay="acme", state=Ticket.State.SHIPPED)
-        ImplementedIssueMarker.objects.create(issue_url=_ISSUE, overlay="acme", ticket=ticket, claim_ref_sha=claim.sha)
+        ticket = Ticket.objects.create(overlay="acme", issue_url=_ISSUE, state=Ticket.State.SHIPPED)
+        ImplementedIssueMarker.objects.cache_from_fleet_claim(
+            _ISSUE, "acme", claim_ref_sha=claim.sha, claimed_by_instance=claim.instance_id
+        )
         assert fleet_claim.steal_if_expired(_ISSUE, repo=str(thief), remote="origin", now=1e12) is not None
 
         from teatree.core.runners.ship import ShipExecutor  # noqa: PLC0415 — test-local
@@ -315,8 +334,10 @@ class TestExecuteShipFence(TestCase):
         thief = init_client(tmp / "thief", bare)
         claim = fleet_claim.acquire(_ISSUE, repo=str(holder), remote="origin")
         assert claim is not None
-        ticket = Ticket.objects.create(overlay="acme", state=Ticket.State.SHIPPED)
-        ImplementedIssueMarker.objects.create(issue_url=_ISSUE, overlay="acme", ticket=ticket, claim_ref_sha=claim.sha)
+        ticket = Ticket.objects.create(overlay="acme", issue_url=_ISSUE, state=Ticket.State.SHIPPED)
+        ImplementedIssueMarker.objects.cache_from_fleet_claim(
+            _ISSUE, "acme", claim_ref_sha=claim.sha, claimed_by_instance=claim.instance_id
+        )
 
         from teatree.core.runners.ship import ShipExecutor  # noqa: PLC0415 — test-local
 
@@ -347,7 +368,9 @@ class TestEnsurePrFence(TestCase):
         claim = fleet_claim.acquire(_ISSUE, repo=str(holder), remote="origin")
         assert claim is not None
         ticket = Ticket.objects.create(overlay="acme", issue_url=_ISSUE, state=Ticket.State.REVIEWED)
-        ImplementedIssueMarker.objects.create(issue_url=_ISSUE, overlay="acme", ticket=ticket, claim_ref_sha=claim.sha)
+        ImplementedIssueMarker.objects.cache_from_fleet_claim(
+            _ISSUE, "acme", claim_ref_sha=claim.sha, claimed_by_instance=claim.instance_id
+        )
         assert fleet_claim.steal_if_expired(_ISSUE, repo=str(thief), remote="origin", now=1e12) is not None
 
         from teatree.core.management.commands._ensure_pr import (  # noqa: PLC0415 — test-local


### PR DESCRIPTION
## What & why

The ship-time fleet-claim fence (`ticket_claim_is_lost` in `src/teatree/core/fleet/wire.py`) resolved the claim marker with `filter(ticket=ticket)`. But the production dispatch path builds the marker via `ImplementedIssueMarkerManager.cache_from_fleet_claim`, which only stamps `(issue_url, overlay, claim_ref_sha, claimed_by_instance)` and never sets the `ticket` FK. No code anywhere populates that FK, so the filter matched nothing in production and the fence returned `False` unconditionally — a permanent no-op at all three chokepoints (the ship gate, `execute_ship`, and `ensure-pr`).

Consequence: an instance that dies past the TTL, is stolen, then revives would push its branch and open its PR under a claim it no longer holds — the exact split-brain the fence exists to prevent. The fence lives behind the default-off `fleet_claim_enabled` flag, so it is inert until the flag is enabled, but the defect is real once the flag is on.

This fixes the dead-fence B1 defect that shipped to `main` via #3131.

## The fix

Key the lookup on the marker's own `(issue_url, overlay)` natural key — the fields `cache_from_fleet_claim` actually populates — with a short-circuit for a ticket that carries no `issue_url` (nothing to fence). The atomic compare-and-swap primitive in `claim.py` is untouched; the fencing-token logic was already correct, it was just unreachable.

## RED → GREEN proof

The fence tests were vacuous: they fabricated the marker via `objects.create(..., ticket=ticket, ...)`, a state the real path cannot produce, so they passed against the dead fence. Every fence marker is now rebuilt through the real `cache_from_fleet_claim` path and each ticket carries a real `issue_url`.

Against the old `filter(ticket=ticket)` code, five fence tests failed (the fence never fired):

- `TestShipFenceGate::test_blocks_when_claim_was_stolen` — `assert None is not None`
- `TestShipFenceGate::test_fence_fails_closed_when_ref_infra_unreachable` — `assert False is True`
- `TestExecuteShipFence::test_push_and_open_aborts_without_pushing_when_claim_stolen` — fell through the dead fence into the push path
- `TestExecuteShipFence::test_re_fences_between_the_push_and_the_pr_open` — same fall-through
- `TestEnsurePrFence::test_orphan_pr_gate_blocks_under_a_lost_claim` — `assert None is not None`

After keying on `(issue_url, overlay)`: all 20 in the file green; full scoped `tests/teatree_core/fleet/` = 62 passed. The still-held and no-marker cases stay green.

Local gates: `ruff check`, `ruff format --check`, `tach check`, `lint-imports`, `ty check` all pass.

## Architecture pre-check

Narrow single-call-site bug fix (one query key inside `ticket_claim_is_lost`) — the tactical-fix carve-out applies. No FSM transition, no Protocol/OverlayBase surface, no new module, no dependency-direction change. Behaviour preserved: the fence's stolen / unreachable / still-held / no-claim branches are unchanged; only the marker lookup key moves from the never-populated `ticket` FK to the populated `(issue_url, overlay)` key.

## Open questions & assumptions

- Assumed: in production the ticket the fence sees carries the same `issue_url` + `overlay` the dispatch stamped on the marker (both derive from the same issue URL). Verified `cache_from_fleet_claim` persists all four fields the fence needs.
- Assumed: keying on both `issue_url` and `overlay` (the marker's unique constraint) is correct rather than `issue_url` alone — the fence already gates on `ticket.overlay` for the kill-switch, so the two stay consistent.
