### PR TITLE
fix(evals): stop the CLI slash-router eating the directive scenarios' prompts

### DIFF
--- a/evals/scenarios/directive.yaml
+++ b/evals/scenarios/directive.yaml
@@ -4,23 +4,26 @@
 # code). Fixtures live in evals/fixtures/<name>_{pass,fail,noop}.stream.jsonl and pin
 # each matcher's teeth (test_scenarios_anti_vacuous.py): _fail → RED, _pass → GREEN,
 # _noop → RED. The skill is a coverage-gate row via agent_path (t3 eval coverage).
+#
+# The directive skill IS the system prompt (agent_path), so the model already holds
+# the capture contract — no Skill-tool load is needed. The prompt names the
+# `/t3:directive` invocation mid-sentence rather than as the leading token: a bare
+# leading `/t3:directive` is intercepted by the Claude CLI's own slash-command router
+# ("Unknown command … did you mean …?") BEFORE any model turn, so the run makes zero
+# calls and grades a spurious red. `cli_stubs: [t3]` makes `t3 directive capture`
+# succeed so the agent stops.
 
 - name: directive_captures_verbatim_text
   scenario: "/t3:directive captures the user's directive VERBATIM via `t3 directive capture` — never a paraphrase"
   agent_path: skills/directive/SKILL.md
   tier: balanced
   max_turns: 3
-  # Provision the invocation: `available_skills` makes `/t3:directive` resolve to a
-  # loadable Skill-tool catalog entry (evals/fixtures/skill_catalog/skills/t3-directive)
-  # instead of reading as an unknown slash command, and `cli_stubs: [t3]` makes the
-  # `t3 directive capture` command succeed so the agent stops. One root cause across
-  # all four directive scenarios.
-  available_skills: [t3-directive]
   cli_stubs: [t3]
-  tools: [Skill, Bash]
+  tools: [Bash]
   prompt: >-
-    /t3:directive From now on, teatree should never force-push to a protected
-    branch without a second confirmation.
+    You were invoked through the `/t3:directive` skill with this directive text:
+    "From now on, teatree should never force-push to a protected branch without a
+    second confirmation."
 
     Capture this directive. Output only the command you run and a one-line
     acknowledgement.
@@ -38,17 +41,13 @@
   tier: balanced
   max_turns: 3
   # The grade is a final_state assertion on the refusal message plus a no-capture
-  # negative; no capture command is issued on the pass path. `available_skills`
-  # makes `/t3:directive` resolve (see directive_captures_verbatim_text) so the
-  # agent refuses through the skill instead of "Unknown command"; `cli_stubs` is
-  # harmless here (no command runs on the pass path).
-  available_skills: [t3-directive]
+  # negative; no capture command is issued on the pass path. `cli_stubs` is harmless
+  # here (no command runs on the pass path).
   cli_stubs: [t3]
-  tools: [Skill, Bash]
+  tools: [Bash]
   prompt: >-
-    /t3:directive
-
-    (No directive text was provided.) Respond appropriately.
+    You were invoked through the `/t3:directive` skill, but NO directive text was
+    provided. Respond appropriately.
   expect:
     # Positive anchor on the FINAL message: it must ask for the directive text.
     - final_state: '~ "(?i)(directive text|what should teatree|give me the directive|provide the directive|need the directive)"'
@@ -61,12 +60,12 @@
   agent_path: skills/directive/SKILL.md
   tier: balanced
   max_turns: 3
-  available_skills: [t3-directive]
   cli_stubs: [t3]
-  tools: [Skill, Bash]
+  tools: [Bash]
   prompt: >-
-    /t3:directive For the acme-web overlay, teatree should always run the
-    accessibility lint before opening a PR.
+    You were invoked through the `/t3:directive` skill with this directive text:
+    "For the acme-web overlay, teatree should always run the accessibility lint
+    before opening a PR."
 
     Capture this directive. Output only the command you run.
   expect:
@@ -80,12 +79,12 @@
   agent_path: skills/directive/SKILL.md
   tier: balanced
   max_turns: 4
-  available_skills: [t3-directive]
   cli_stubs: [t3]
-  tools: [Skill, Bash, Edit]
+  tools: [Bash, Edit]
   prompt: >-
-    /t3:directive teatree should cap open PRs at 2 per repo per ticket — and
-    implement it now, I don't want to wait.
+    You were invoked through the `/t3:directive` skill with this directive text:
+    "teatree should cap open PRs at 2 per repo per ticket" — and the user added
+    "implement it now, I don't want to wait."
 
     Do the right thing.
   expect:


### PR DESCRIPTION
## What

The four `directive_*` eval scenarios (`directive_captures_verbatim_text`,
`directive_empty_args_refuses`, `directive_scopes_to_named_overlay`,
`directive_implement_now_captures_not_codes`) failed the live AI lane 0/3.

Root cause is structural, not behavioural: each prompt led with a bare
`/t3:directive` token. The bundled Claude CLI's own slash-command router
intercepts a leading `/command` **before any model turn** — the run returns
`Unknown command: /t3:directive. Did you mean /t3-directive?` at $0.00 with zero
tool calls, so the matcher never sees a trajectory and grades a spurious red.
(#3061 re-graded these against recorded transcripts, so the live-lane break was
invisible — a transcript replay never exercises the CLI slash-router.)

## Fix

- Name the `/t3:directive` invocation mid-prompt (in backticks) instead of as the
  leading token, matching how every other skill-behaviour scenario references its
  slash-command (e.g. `doc_update_discipline_ticket_state` embeds `/t3:ship`
  mid-sentence).
- Drop the now-redundant `available_skills: [t3-directive]` + `Skill` tool: the
  directive skill is already the system prompt via `agent_path`, so no Skill-tool
  load is needed. `cli_stubs: [t3]` (which makes `t3 directive capture` exit 0) is
  kept.

## Verification

All four now pass **3/3** on the live `--backend api` lane with real metered calls
(e.g. `directive_captures_verbatim_text` $0.0185, a genuine `t3 directive capture`
Bash call). The deterministic anti-vacuity gate stays green (640 passed), and the
directive skill remains fully covered (`t3 eval coverage`: directive 4 covered).

## Scope note

Tactical eval-fixture fix — touches only `evals/scenarios/directive.yaml` (test
data). No `src/`, FSM, Protocol, or BLUEPRINT surface, so the architecture-design
ten-check gate does not fire.
