### PR TITLE
fix: unblock push+PR-create (collaborator identity + coverage-gate cwd)

### DIFF
--- a/hooks/scripts/coverage_gate.py
+++ b/hooks/scripts/coverage_gate.py
@@ -1,0 +1,104 @@
+"""Per-diff coverage gate (§17.6 gate 12) — target-repo resolution + argv/finding.
+
+A bare sibling of ``hook_router.py`` (the shrink-only god-module): the coverage
+gate's pure helpers live here so the router stays under its module-health cap.
+
+The concern this owns is resolving the repo the GATED forge command actually
+targets. ``handle_block_uncovered_diff`` shells ``t3 tool diff-coverage`` on a
+merge-class ``gh pr create`` / ``glab mr create`` / ``gh pr ready``; that CLI
+defaults ``--repo`` to its own cwd. The cold PreToolUse hook inherits the
+SESSION's cwd, which — when the gated command ships a DIFFERENT worktree via a
+leading ``cd <worktree>`` — is not the PR's worktree at all. Measuring the
+session cwd then flags uncovered lines from an unrelated worktree's diff. The
+gate must measure the worktree the command runs in: its own leading ``cd``
+(anchored on the ambient cwd when relative), else the ambient cwd, walked up to
+the enclosing repo root. Resolution is fail-open: any uncertainty yields the
+ambient cwd (or ``None``), so the gate never wedges a create.
+"""
+
+import importlib
+import json
+import shutil
+from pathlib import Path
+
+from managed_repo import teatree_src_on_path
+
+
+def coverage_gate_repo_dir(command: str, cwd: str | None) -> Path | None:
+    """Return the repo root whose diff the gated forge command should be measured against.
+
+    The gated ``gh pr create`` / ``glab mr create`` / ``gh pr ready`` runs in its
+    own leading ``cd <dir>`` (a cross-worktree ship), NOT the session cwd the cold
+    hook inherits. Resolving that ``cd`` — anchored on the ambient *cwd* when
+    relative — and walking up to the enclosing repo root keeps the coverage
+    measurement on the PR's OWN worktree, never a sibling worktree's stray diff.
+
+    Fail-open: when neither a leading ``cd`` nor an ambient *cwd* resolves (or the
+    ``teatree`` src bootstrap the ``cd`` parser needs is unavailable), returns the
+    ambient *cwd* if any, else ``None`` — the caller then runs cwd-relative as
+    before, so a broken environment never denies a create.
+    """
+    ambient = Path(cwd) if cwd else None
+    try:
+        with teatree_src_on_path():
+            # ``teatree.hooks._commit_repo_dir`` is a private module reached from a
+            # cold-hook sibling; import it dynamically so the parsers stay a single
+            # source of truth without a static private-name import.
+            commit_repo_dir = importlib.import_module("teatree.hooks._commit_repo_dir")
+            cd_dir = commit_repo_dir.leading_cd_dir(command)
+            if cd_dir is not None:
+                parsed = Path(cd_dir)
+                target = parsed if parsed.is_absolute() or ambient is None else ambient / parsed
+            else:
+                target = ambient
+            if target is None:
+                return None
+            return commit_repo_dir.git_root_for_dir(target) or target
+    except Exception:  # noqa: BLE001 — cold hook must stay crash-proof; degrade to the ambient cwd
+        return ambient
+
+
+def diff_coverage_argv(repo_dir: Path | None) -> list[str] | None:
+    """Return the ``t3 tool diff-coverage --json`` argv keyed to *repo_dir*, or ``None``.
+
+    ``None`` when ``t3`` is not on PATH (the gate then fails open). ``--repo`` is
+    appended only when *repo_dir* resolved, so a cwd-relative run (the historical
+    behaviour) is preserved when no target could be pinned.
+    """
+    t3_bin = shutil.which("t3")
+    if t3_bin is None:
+        return None
+    argv = [t3_bin, "tool", "diff-coverage", "--json"]
+    if repo_dir is not None:
+        argv += ["--repo", str(repo_dir)]
+    return argv
+
+
+def diff_coverage_finding(stdout: str) -> str | None:
+    """Return a deny reason iff *stdout* is a report JSON with ``passes`` false.
+
+    The fail-open discriminator (#122). ``t3 tool diff-coverage --json`` emits
+    exactly ``{"passes": ..., "uncovered": [...], "unreferenced_symbols": [...]}``
+    on a successful measurement. A crash (e.g. the dev-only ``coverage`` module
+    missing from the installed ``t3`` env) produces a traceback on stderr and no
+    parseable JSON on stdout — so anything that is not a well-formed report with
+    ``passes is False`` is "not a finding" and the caller fails open.
+
+    Returns the human-readable finding summary when there IS a genuine finding,
+    else ``None`` (clean, crashed, or unparsable).
+    """
+    try:
+        report = json.loads(stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(report, dict) or report.get("passes") is not False:
+        return None
+    rows = [
+        f"  uncovered new lines in {entry.get('path')}: {entry.get('lines')}"
+        for entry in (report.get("uncovered") or [])
+        if isinstance(entry, dict)
+    ]
+    symbols = report.get("unreferenced_symbols") or []
+    if symbols:
+        rows.append(f"  new production symbols not referenced by any changed test: {sorted(symbols)}")
+    return "\n".join(rows)

--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -57,6 +57,9 @@ from classifier_relax_gate import (
 )
 from completion_claim_gate import handle_completion_claim_gate
 from config_overwrite_guard import handle_block_config_overwrite
+from coverage_gate import coverage_gate_repo_dir as _coverage_gate_repo_dir
+from coverage_gate import diff_coverage_argv as _diff_coverage_argv
+from coverage_gate import diff_coverage_finding as _diff_coverage_finding
 from cron_tracking import cron_cadence_seconds as _cron_cadence_seconds  # noqa: F401
 from cron_tracking import derive_loop_name as _derive_loop_name  # noqa: F401
 from cron_tracking import handle_track_cron_jobs
@@ -2548,44 +2551,6 @@ def _is_merge_class_mutation(data: dict) -> bool:
     return False
 
 
-def _diff_coverage_argv() -> list[str] | None:
-    t3_bin = shutil.which("t3")
-    if t3_bin:
-        return [t3_bin, "tool", "diff-coverage", "--json"]
-    return None
-
-
-def _diff_coverage_finding(stdout: str) -> str | None:
-    """Return a deny reason iff *stdout* is a report JSON with ``passes`` false.
-
-    The fail-open discriminator (#122). ``t3 tool diff-coverage --json``
-    emits exactly ``{"passes": ..., "uncovered": [...],
-    "unreferenced_symbols": [...]}`` on a successful measurement. A crash
-    (e.g. the dev-only ``coverage`` module missing from the installed
-    ``t3`` env) produces a traceback on stderr and no parseable JSON on
-    stdout — so anything that is not a well-formed report with
-    ``passes is False`` is "not a finding" and the caller fails open.
-
-    Returns the human-readable finding summary when there IS a genuine
-    finding, else ``None`` (clean, crashed, or unparsable).
-    """
-    try:
-        report = json.loads(stdout)
-    except (json.JSONDecodeError, ValueError):
-        return None
-    if not isinstance(report, dict) or report.get("passes") is not False:
-        return None
-    rows = [
-        f"  uncovered new lines in {entry.get('path')}: {entry.get('lines')}"
-        for entry in (report.get("uncovered") or [])
-        if isinstance(entry, dict)
-    ]
-    symbols = report.get("unreferenced_symbols") or []
-    if symbols:
-        rows.append(f"  new production symbols not referenced by any changed test: {sorted(symbols)}")
-    return "\n".join(rows)
-
-
 def handle_block_uncovered_diff(data: dict) -> bool:
     """Refuse a PR un-draft / non-draft create whose diff fails Gate 12.
 
@@ -2608,7 +2573,14 @@ def handle_block_uncovered_diff(data: dict) -> bool:
     if not _is_merge_class_mutation(data):
         return False
 
-    argv = _diff_coverage_argv()
+    # Measure the worktree the GATED command targets — its own leading ``cd``,
+    # else the harness cwd — NOT the cold hook's inherited session cwd. A
+    # cross-worktree ship (``cd <other-worktree> && gh pr create``) otherwise
+    # measured the session cwd's diff and flagged uncovered lines from an
+    # unrelated worktree.
+    command = data.get("tool_input", {}).get("command", "")
+    repo_dir = _coverage_gate_repo_dir(command, data.get("cwd"))
+    argv = _diff_coverage_argv(repo_dir)
     if argv is None:
         return False
 
@@ -2619,6 +2591,7 @@ def handle_block_uncovered_diff(data: dict) -> bool:
             text=True,
             check=False,
             timeout=30,
+            cwd=str(repo_dir) if repo_dir is not None else None,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         return False

--- a/src/teatree/backends/github/api.py
+++ b/src/teatree/backends/github/api.py
@@ -13,7 +13,7 @@ from typing import cast
 from urllib.parse import urlparse
 
 from teatree.types import RawAPIDict
-from teatree.utils.run import CompletedProcess, run_allowed_to_fail, run_checked
+from teatree.utils.run import CommandFailedError, CompletedProcess, run_allowed_to_fail, run_checked
 
 _ISSUE_URL_RE = re.compile(r"^/(?P<owner>[^/]+)/(?P<repo>[^/]+)/issues/(?P<number>\d+)/?$")
 
@@ -49,6 +49,33 @@ def gh_ambient_auth_available() -> bool:
     except FileNotFoundError:
         return False
     return result.returncode == 0
+
+
+def gh_can_push(repo_slug: str, *, token: str = "") -> bool | None:
+    """Whether the identity behind *token* (ambient ``gh`` when empty) has push access to *repo_slug*.
+
+    Reads ``repos/{slug}`` ``.permissions.push`` for the authenticated identity:
+    ``True`` / ``False`` on a definite answer, ``None`` when it cannot be
+    determined — no slug, ``gh`` absent, a network/auth error, an unreadable repo
+    (404), or an unparsable payload. :func:`teatree.backends.loader.get_code_host_for_repo`
+    reads ``None`` as "keep the configured token": a collaborator override must
+    be CERTAIN, so a transient probe failure never switches the PR-authoring
+    identity. This is the seam that keeps ``gh pr create``'s ``createPullRequest``
+    from running under a non-collaborator token when the logged-in ``gh`` account
+    is the collaborator (the "must be a collaborator" abort).
+    """
+    if not repo_slug:
+        return None
+    try:
+        result = _run_gh("gh", "api", f"repos/{repo_slug}", "--jq", ".permissions.push", token=token)
+    except (CommandFailedError, FileNotFoundError):
+        return None
+    answer = result.stdout.strip().lower()
+    if answer == "true":
+        return True
+    if answer == "false":
+        return False
+    return None
 
 
 def _gh_api_get(endpoint: str, *, token: str = "") -> object:

--- a/src/teatree/backends/loader.py
+++ b/src/teatree/backends/loader.py
@@ -11,7 +11,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, Literal
 
 from teatree.backends.github import GitHubCodeHost
-from teatree.backends.github.api import gh_ambient_auth_available
+from teatree.backends.github.api import gh_ambient_auth_available, gh_can_push
 from teatree.backends.gitlab import GitLabCodeHost
 from teatree.backends.gitlab.api import GitLabAPI
 from teatree.backends.gitlab.ci import GitLabCIService
@@ -25,7 +25,7 @@ from teatree.core.backend_protocols import (
     PrOpenState,
 )
 from teatree.core.send_proxy import read_posting_credential
-from teatree.utils import git
+from teatree.utils import git, git_remote
 from teatree.utils.forge import forge_from_remote
 
 if TYPE_CHECKING:
@@ -168,27 +168,75 @@ def get_code_host_for_repo(overlay: "OverlayBase", repo_path: str) -> CodeHostBa
     is not necessarily unauthenticated — ``_run_gh`` already inherits the
     ambient environment (and thus ``gh``'s own logged-in account) whenever
     no token is passed. So when the forge is GitHub and no token is
-    configured, this checks :func:`gh_ambient_auth_available` and, if it
-    passes, builds a ``GitHubCodeHost(token="")`` that relies on that
-    fallback rather than raising. GitLab has no equivalent: its REST
-    transport (``GitLabHTTPClient``) returns early on an empty token with
-    no ``glab`` call at all, so it keeps raising here.
+    configured, :func:`_github_host_for_repo` checks
+    :func:`gh_ambient_auth_available` and, if it passes, builds a
+    ``GitHubCodeHost(token="")`` that relies on that fallback rather than
+    raising. It ALSO prefers that logged-in account over a configured token
+    that provably cannot push to this repo — the non-collaborator ``gh pr
+    create`` → "must be a collaborator (createPullRequest)" abort. GitLab has
+    no equivalent: its REST transport (``GitLabHTTPClient``) returns early on
+    an empty token with no ``glab`` call at all, so it keeps raising here.
     """
     remote = git.remote_url(repo=repo_path)
     forge = forge_from_remote(remote) if remote else ""
     if not forge:
         return get_code_host(overlay)
+    if forge == "github":
+        return _github_host_for_repo(overlay, remote)
     backend = _host_backend(overlay, forge)
     if backend is not None:
         return backend
-    if forge == "github" and gh_ambient_auth_available():
-        return GitHubCodeHost(token="")
     msg = (
         f"repo origin resolves to the {forge} forge ({remote!r}) but the active "
         f"overlay has no {forge} credentials configured — cannot open a PR. "
         f"Configure a {forge} token for this overlay."
     )
     raise BackendResolutionError(msg)
+
+
+def _github_host_for_repo(overlay: "OverlayBase", remote: str) -> CodeHostBackend:
+    """Return the GitHub code host for *remote*'s repo, preferring the collaborator identity.
+
+    The configured GitHub token authors the PR unless it PROVABLY cannot push to
+    this repo while the ambient ``gh`` CLI account can — a bot/PAT configured for
+    other repos that is not a collaborator here, whose ``createPullRequest`` fails
+    "must be a collaborator". In that one case the logged-in ``gh`` account (the
+    collaborator) authors the PR. Falls back to the ambient account when no token
+    is configured (the #2946 carve-out), and raises when neither a token nor an
+    ambient ``gh`` login is available.
+    """
+    token = overlay.config.get_github_token()
+    slug = git_remote.slug_from_remote(remote)
+    if token and not _configured_token_blocked_but_ambient_can(slug, token=token):
+        return GitHubCodeHost(token=token)
+    if gh_ambient_auth_available():
+        return GitHubCodeHost(token="")
+    if token:
+        return GitHubCodeHost(token=token)
+    msg = (
+        f"repo origin resolves to the github forge ({remote!r}) but the active "
+        "overlay has no github credentials configured and no ambient gh login — "
+        "cannot open a PR. Configure a github token for this overlay."
+    )
+    raise BackendResolutionError(msg)
+
+
+def _configured_token_blocked_but_ambient_can(slug: str, *, token: str) -> bool:
+    """Whether *token* PROVABLY cannot push to *slug* while the ambient gh account can.
+
+    The single condition that overrides a configured token with the ambient
+    collaborator account. Both probes must be DEFINITE: the configured token
+    must return a definite ``push == false`` and the ambient account a definite
+    ``push == true``. Any uncertainty (no slug, ambient login absent, a
+    :func:`gh_can_push` ``None`` from a transient/parse error) leaves the
+    configured token in place — the PR-authoring identity never silently
+    switches on a flaky probe. The ambient probes run only after the configured
+    token is proven push-blocked, so a working token costs one ``repos/{slug}``
+    read and never touches the ambient account.
+    """
+    if not slug or gh_can_push(slug, token=token) is not False:
+        return False
+    return gh_ambient_auth_available() and gh_can_push(slug, token="") is True
 
 
 def get_messaging(overlay: "OverlayBase") -> MessagingBackend:

--- a/tests/teatree_backends/github/test_api.py
+++ b/tests/teatree_backends/github/test_api.py
@@ -1,0 +1,69 @@
+"""Direct anti-vacuous parser tests for :func:`gh_can_push`.
+
+``gh_can_push`` is security-critical: :func:`teatree.backends.loader.get_code_host_for_repo`
+overrides the configured PR-authoring token ONLY when the probe returns a
+CERTAIN ``True``, so a parser that silently returned ``None`` (drop the
+collaborator override) or ``True`` (run ``gh pr create`` under the wrong
+identity) on an ambiguous payload would be a real security regression. Every
+existing caller monkeypatches the whole function at the loader boundary, so the
+real ``stdout -> bool | None`` parse is never exercised. These tests drive the
+REAL function and stub only the ``gh`` subprocess boundary (``_run_gh``), so
+each parse branch is genuinely covered rather than mocked away.
+"""
+
+from subprocess import CompletedProcess
+
+import pytest
+
+from teatree.backends.github import api
+from teatree.utils.run import CommandFailedError
+
+
+def _stub_run_gh(stdout: str) -> "object":
+    """A ``_run_gh`` replacement that returns *stdout* from a zero-exit ``gh`` call."""
+
+    def _run(*args: str, token: str = "", timeout: float | None = None) -> CompletedProcess[str]:
+        return CompletedProcess(args=list(args), returncode=0, stdout=stdout, stderr="")
+
+    return _run
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ("true\n", True),  # trailing newline proves .strip() runs on real gh output
+        ("false\n", False),
+        ("null\n", None),  # .permissions absent → jq prints "null"
+        ("", None),  # empty stdout
+        ("maybe", None),  # non-bool payload
+    ],
+)
+def test_gh_can_push_parses_permission_payload(
+    monkeypatch: pytest.MonkeyPatch, payload: str, *, expected: bool | None
+) -> None:
+    monkeypatch.setattr(api, "_run_gh", _stub_run_gh(payload))
+    assert api.gh_can_push("owner/repo") is expected
+
+
+def test_gh_can_push_returns_none_when_the_probe_command_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed ``gh`` call (non-zero exit → CommandFailedError) is an uncertain answer, not push access."""
+
+    def _raise(*args: str, token: str = "", timeout: float | None = None) -> CompletedProcess[str]:
+        raise CommandFailedError(list(args), 1, "", "HTTP 404: Not Found")
+
+    monkeypatch.setattr(api, "_run_gh", _raise)
+    assert api.gh_can_push("owner/repo") is None
+
+
+def test_gh_can_push_returns_none_on_empty_slug_without_probing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty slug short-circuits to None BEFORE any subprocess runs."""
+    probed = False
+
+    def _spy(*args: str, token: str = "", timeout: float | None = None) -> CompletedProcess[str]:
+        nonlocal probed
+        probed = True
+        return CompletedProcess(args=list(args), returncode=0, stdout="true", stderr="")
+
+    monkeypatch.setattr(api, "_run_gh", _spy)
+    assert api.gh_can_push("") is None
+    assert probed is False

--- a/tests/teatree_backends/test_loader.py
+++ b/tests/teatree_backends/test_loader.py
@@ -293,9 +293,14 @@ class TestGetCodeHostForRepo:
         repo = _git_repo_with_origin(tmp_path / "gl", "git@gitlab.com:group/repo.git")
         assert isinstance(get_code_host_for_repo(overlay, repo), GitLabCodeHost)
 
-    def test_github_hosted_repo_resolves_github_even_when_gitlab_token_set(self, tmp_path: Path) -> None:
+    def test_github_hosted_repo_resolves_github_even_when_gitlab_token_set(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         overlay = _build_overlay()
         _stub_token(overlay, github="gh-tok", gitlab="gl-tok")
+        # The configured GitHub token can push here — keep it (no ambient probe,
+        # hermetic: never shell a real ``gh api``).
+        monkeypatch.setattr("teatree.backends.loader.gh_can_push", lambda _slug, *, token="": True)
         repo = _git_repo_with_origin(tmp_path / "gh", "git@github.com:souliane/teatree.git")
         assert isinstance(get_code_host_for_repo(overlay, repo), GitHubCodeHost)
 
@@ -350,19 +355,67 @@ class TestGetCodeHostForRepoGithubAmbientAuth:
 
         assert isinstance(result, GitHubCodeHost)
 
-    def test_configured_token_path_is_unchanged(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_configured_token_that_can_push_is_used_without_ambient_probe(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         overlay = _build_overlay()
         _stub_token(overlay, github="gh-tok")
-        # Ambient-auth check must never even run when a token is configured.
+        # The configured token CAN push to this repo, so it authors the PR and
+        # the ambient account is never consulted (a working token costs one
+        # ``repos/{slug}`` push probe and nothing more).
+        monkeypatch.setattr("teatree.backends.loader.gh_can_push", lambda _slug, *, token="": True)
         monkeypatch.setattr(
             "teatree.backends.loader.gh_ambient_auth_available",
-            lambda: (_ for _ in ()).throw(AssertionError("should not probe ambient auth when a token is set")),
+            lambda: (_ for _ in ()).throw(AssertionError("ambient must not be probed when the token can push")),
         )
         repo = _git_repo_with_origin(tmp_path / "gh-tok", "git@github.com:souliane/teatree.git")
 
         result = get_code_host_for_repo(overlay, repo)
 
         assert isinstance(result, GitHubCodeHost)
+        assert result._token == "gh-tok"
+
+    def test_non_collaborator_token_falls_back_to_ambient_collaborator(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The configured token is NOT a collaborator on this repo (its
+        # ``createPullRequest`` fails "must be a collaborator"), but the ambient
+        # ``gh`` CLI account IS. The collaborator identity must author the PR.
+        overlay = _build_overlay()
+        _stub_token(overlay, github="bot-token")
+
+        def fake_can_push(_slug: str, *, token: str = "") -> bool:
+            # Only the ambient (empty-token) identity can push here.
+            return token == ""
+
+        monkeypatch.setattr("teatree.backends.loader.gh_can_push", fake_can_push)
+        monkeypatch.setattr("teatree.backends.loader.gh_ambient_auth_available", lambda: True)
+        repo = _git_repo_with_origin(tmp_path / "gh-collab", "git@github.com:souliane/teatree.git")
+
+        result = get_code_host_for_repo(overlay, repo)
+
+        assert isinstance(result, GitHubCodeHost)
+        # The COLLABORATOR identity (ambient gh account, token="") authors the PR,
+        # NOT the configured non-collaborator token. Reverting the fix returns the
+        # bot token here and re-triggers the "must be a collaborator" abort.
+        assert result._token == ""
+
+    def test_non_collaborator_token_kept_when_ambient_also_cannot_push(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Neither the configured token nor the ambient account can push — never
+        # silently switch identity; keep the configured token so the real error
+        # surfaces rather than guessing an identity that also cannot create.
+        overlay = _build_overlay()
+        _stub_token(overlay, github="bot-token")
+        monkeypatch.setattr("teatree.backends.loader.gh_can_push", lambda _slug, *, token="": False)
+        monkeypatch.setattr("teatree.backends.loader.gh_ambient_auth_available", lambda: True)
+        repo = _git_repo_with_origin(tmp_path / "gh-nopush", "git@github.com:souliane/teatree.git")
+
+        result = get_code_host_for_repo(overlay, repo)
+
+        assert isinstance(result, GitHubCodeHost)
+        assert result._token == "bot-token"
 
     def test_raises_when_no_token_and_ambient_auth_unavailable(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_block_uncovered_diff_hook.py
+++ b/tests/test_block_uncovered_diff_hook.py
@@ -17,6 +17,7 @@ turns the block tests red — the anti-vacuity guarantee.
 
 import json
 import subprocess
+from pathlib import Path
 from unittest.mock import patch
 
 import hooks.scripts.hook_router as router
@@ -169,6 +170,75 @@ class TestAllowsCleanCases:
         with patch.object(router.subprocess, "run", side_effect=subprocess.TimeoutExpired("t3", 30)):
             data = {"tool_name": "Bash", "tool_input": {"command": "gh pr ready 42"}}
             assert handle_block_uncovered_diff(data) is False
+
+
+class TestMeasuresTheGatedCommandsWorktree:
+    """Measure the worktree the gated command targets, not the session cwd.
+
+    Anti-vacuity: the gate keys ``t3 tool diff-coverage`` to the worktree the
+    gated command TARGETS (its own leading ``cd``), never the cold hook's
+    inherited session cwd.
+
+    A cross-worktree ship — the session cwd is worktree Y, but the command ships
+    worktree X via ``cd X && gh pr create`` — must run ``t3 tool diff-coverage``
+    against X. Reverting the cwd-resolution fix measures Y and flags X's PR with
+    Y's unrelated uncovered lines (the ``wire.py`` false-flag).
+    """
+
+    def _worktree(self, root: Path, name: str) -> Path:
+        wt = root / name
+        (wt / ".git").mkdir(parents=True)
+        return wt
+
+    def test_measures_the_cd_target_worktree_not_the_session_cwd(self, tmp_path, monkeypatch):
+        x = self._worktree(tmp_path, "worktree-x")  # the PR's worktree (cd target)
+        y = self._worktree(tmp_path, "worktree-y")  # the session cwd (a DIFFERENT worktree)
+        monkeypatch.setattr(router.shutil, "which", lambda _: "/usr/local/bin/t3")
+        captured: dict = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            captured["cwd"] = kwargs.get("cwd")
+            return subprocess.CompletedProcess(args=argv, returncode=1, stdout=_finding_json(), stderr="")
+
+        with patch.object(router.subprocess, "run", side_effect=fake_run):
+            data = {
+                "tool_name": "Bash",
+                "tool_input": {"command": f"cd {x} && gh pr create --title t --body b"},
+                "cwd": str(y),
+            }
+            assert handle_block_uncovered_diff(data) is True
+
+        # The gate measured X (the cd target), never the session cwd Y.
+        assert "--repo" in captured["argv"]
+        repo_arg = captured["argv"][captured["argv"].index("--repo") + 1]
+        assert Path(repo_arg).resolve() == x.resolve()
+        assert Path(captured["cwd"]).resolve() == x.resolve()
+        assert str(y.resolve()) not in captured["argv"]
+
+    def test_falls_back_to_session_cwd_when_command_has_no_leading_cd(self, tmp_path, monkeypatch):
+        y = self._worktree(tmp_path, "session-cwd")
+        monkeypatch.setattr(router.shutil, "which", lambda _: "/usr/local/bin/t3")
+        captured: dict = {}
+
+        def fake_run(argv, **kwargs):
+            captured["argv"] = argv
+            captured["cwd"] = kwargs.get("cwd")
+            clean = json.dumps({"passes": True, "uncovered": [], "unreferenced_symbols": []})
+            return subprocess.CompletedProcess(args=argv, returncode=0, stdout=clean, stderr="")
+
+        with patch.object(router.subprocess, "run", side_effect=fake_run):
+            data = {
+                "tool_name": "Bash",
+                "tool_input": {"command": "gh pr create --title t --body b"},
+                "cwd": str(y),
+            }
+            assert handle_block_uncovered_diff(data) is False
+
+        # No leading cd → the gate measures the session cwd's OWN repo (correct
+        # when the command runs there), never a bare cwd-less run.
+        assert Path(captured["cwd"]).resolve() == y.resolve()
+        assert "--repo" in captured["argv"]
 
 
 class TestRegisteredInPreToolUseChain:

--- a/tests/test_hook_router_size_gate.py
+++ b/tests/test_hook_router_size_gate.py
@@ -22,7 +22,7 @@ _ROUTER = pathlib.Path(__file__).resolve().parent.parent / "hooks" / "scripts" /
 # The router's non-comment / non-blank LOC ceiling. Shrink-only: only ever
 # lowered, never raised. Measured the same way check_module_health._count_loc does.
 # Lowered by PR-28 c3, which removed the loop-registration nudge gate + helpers.
-_CEILING_LOC = 4698
+_CEILING_LOC = 4649
 
 
 def _count_loc(text: str) -> int:


### PR DESCRIPTION
## What

Two infra fixes on the push -> PR-creation path.

**A. PR creation resolves the collaborator identity per repo.**
`get_code_host_for_repo` built the GitHub host from the overlay's configured
token unconditionally. When that token's identity lacks push access to the
target repo (a token configured for other repos), `gh pr create`'s
`createPullRequest` fails "must be a collaborator" and aborts the pre-push
`ensure-pr` hook. The GitHub path now prefers the ambient `gh` CLI account
when it provably can push and the configured token provably cannot — decided
by a definite `repos/{slug}` `.permissions.push` probe (`gh_can_push`). Any
uncertainty keeps the configured token, so the PR-authoring identity never
switches on a flaky probe. A working token costs one push probe and never
touches the ambient account (the existing tokenless ambient carve-out is
unchanged).

**B. The per-diff coverage gate is scoped to the gated command's worktree.**
`handle_block_uncovered_diff` shelled `t3 tool diff-coverage` with the cold
PreToolUse hook's inherited session cwd. A cross-worktree `gh pr create`
(`cd <other-worktree> && ...`) then measured the session cwd's diff and flagged
uncovered lines from an unrelated worktree. The gate now resolves the gated
command's own leading `cd` (anchored on the ambient cwd, walked up to the repo
root) and passes it as `--repo`/`cwd`; it fails open to the ambient cwd. The
coverage helpers move to a bare sibling `coverage_gate.py`, net-shrinking the
module-health-capped router.

## Why

Both bugs block the critical push -> PR-create path. (A) aborts every push
whose pre-push `ensure-pr` tries to open a PR under a non-collaborator token;
(B) false-flags a PR whose diff lives in a different worktree than the session.

## Tests

- `tests/teatree_backends/test_loader.py` —
  `test_non_collaborator_token_falls_back_to_ambient_collaborator` (plus the
  ambient-also-blocked / working-token cases). Observed RED before the fix
  (asserts the resolved token is the collaborator's `""`, not the configured one).
- `tests/test_block_uncovered_diff_hook.py::TestMeasuresTheGatedCommandsWorktree`
  — `test_measures_the_cd_target_worktree_not_the_session_cwd` plus the
  session-cwd fallback. Observed RED before the fix (asserts `--repo`/`cwd`
  target the `cd` worktree, not the session cwd).

## Open questions & assumptions

- Assumed: `.permissions.push` is the right collaborator signal for PR creation
  (a non-collaborator returns `push: false`, a collaborator `push: true`) —
  verified against the live forge. (status: assumed)
- Assumed: the per-repo resolver seam only runs on ship / PR-create paths (not
  the read-heavy tick loop), so one `repos/{slug}` probe per ship is acceptable.
  (status: assumed)
