### PR TITLE
refactor(loops): single enable-verdict + atomic two-plane control (loop authority)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -4158,8 +4158,8 @@ Usage: t3 loops [OPTIONS] COMMAND [ARGS]...
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
 │ list  List DB-configured autonomous loops: name, enabled, delay, last run,   │
 │       next due.                                                              │
-│ tick  Run ONE enabled, due loop by name — the per-loop primitive each native │
-│       Claude ``/loop`` fires (#2650).                                        │
+│ tick  Run ONE enabled, due loop by name — the per-loop primitive the         │
+│       loop-timer chain drives.                                               │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
@@ -4184,8 +4184,8 @@ Usage: t3 loops list [OPTIONS]
 ```
 Usage: t3 loops tick [OPTIONS]
 
- Run ONE enabled, due loop by name — the per-loop primitive each native Claude
- ``/loop`` fires (#2650).
+ Run ONE enabled, due loop by name — the per-loop primitive the loop-timer
+ chain drives.
 
  Scopes the tick to that single enabled, due ``Loop`` row, claiming the
  disjoint
@@ -4195,8 +4195,8 @@ Usage: t3 loops tick [OPTIONS]
  management command refuses it). Delegates to that management command.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --loop           TEXT  REQUIRED. Run ONE enabled, due DB Loop by name        │
-│                        (#2650) — what each native Claude `/loop` fires,      │
+│ --loop           TEXT  REQUIRED. Run ONE enabled, due DB Loop by name — what │
+│                        the self-rescheduling loop-timer chain drives,        │
 │                        claiming the per-loop `loop:<name>` lease. There is   │
 │                        no master tick: omitting --loop is a hard error.      │
 │ --overlay        TEXT  Restrict scanning to the named overlay (default:      │

--- a/src/teatree/cli/loops.py
+++ b/src/teatree/cli/loops.py
@@ -1,9 +1,11 @@
 """``t3 loops`` — DB-configured autonomous loops (#1796).
 
 ``t3 loops list`` prints the loops from the DB (read-only). ``t3 loops tick
---loop <name>`` runs ONE enabled, due loop — the per-loop primitive each native
-Claude ``/loop`` fires (#2650). There is NO master tick: ``t3 loops tick`` with no
-``--loop`` is a hard error. Per-loop management — add / edit / enable / disable —
+--loop <name>`` runs ONE enabled, due loop — the per-loop primitive the
+self-rescheduling loop-timer chain drives (:mod:`teatree.loops.timer_chains`, the
+sole driver since PR-28 retired the native-``/loop`` cron mirror). There is NO
+master tick: ``t3 loops tick`` with no ``--loop`` is a hard error. Per-loop
+management — add / edit / enable / disable —
 is via ``t3 loop enable`` / ``t3 loop disable`` + the Django admin (``Loop`` rows: name /
 prompt / delay / enabled). ORM access lives in the ``loops_tick`` / ``loops_list``
 management commands, not a plain typer command.
@@ -52,15 +54,15 @@ def tick_command(
         "",
         "--loop",
         help=(
-            "REQUIRED. Run ONE enabled, due DB Loop by name (#2650) — what each native Claude `/loop` "
-            "fires, claiming the per-loop `loop:<name>` lease. There is no master tick: omitting --loop "
-            "is a hard error."
+            "REQUIRED. Run ONE enabled, due DB Loop by name — what the self-rescheduling loop-timer "
+            "chain drives, claiming the per-loop `loop:<name>` lease. There is no master tick: omitting "
+            "--loop is a hard error."
         ),
     ),
     overlay: str = typer.Option("", "--overlay", help="Restrict scanning to the named overlay (default: all)."),
     json_output: bool = typer.Option(False, "--json", help="Emit the tick report as JSON."),
 ) -> None:
-    """Run ONE enabled, due loop by name — the per-loop primitive each native Claude ``/loop`` fires (#2650).
+    """Run ONE enabled, due loop by name — the per-loop primitive the loop-timer chain drives.
 
     Scopes the tick to that single enabled, due ``Loop`` row, claiming the disjoint
     per-loop ``loop:<name>`` lease so the per-loop loops run in parallel. **There is

--- a/src/teatree/core/management/commands/loop_state.py
+++ b/src/teatree/core/management/commands/loop_state.py
@@ -4,19 +4,18 @@ Backs ``t3 loop {pause,resume,disable,enable,status} <name>``. ORM access lives
 here (a management command, not a plain typer command) per the project's
 "anything touching the ORM is a management command" rule.
 
-The ``enable``/``disable``/``resume`` verbs move TWO planes in lock-step inside
-one transaction: the durable ``LoopState`` control tier (#1913) AND the
-row-level ``Loop.enabled`` column that the #2584 loop tick reads as its source
-of truth (``not row.enabled`` skips a loop). Before this, ``enable`` wrote only
-``LoopState`` and left ``Loop.enabled`` stale, so the verb reported "now enabled"
-while the loop was never ticked. ``pause`` is the reversible control-plane
-hold only — it does NOT flip the durable ``Loop.enabled`` row (a paused loop
-returns to running with ``resume`` without re-enabling a row that may have been
-deliberately ``disable``d).
+The ``enable``/``disable``/``resume`` verbs move TWO planes in lock-step: the
+durable ``LoopState`` control tier (#1913) AND the row-level ``Loop.enabled``
+column that the #2584 loop tick reads as its source of truth (``not row.enabled``
+skips a loop). The paired write is owned by ONE atomic manager method
+(``Loop.objects.disable`` / ``enable`` / ``resume``, holistic 3c#4) — the command
+only calls it, so no caller can leave one plane stale (the "reports enabled but
+never ticks" bug). ``pause`` is the reversible control-plane hold only — it does
+NOT flip the durable ``Loop.enabled`` row; ``resume`` (and ``enable``) then lift
+EITHER a pause or a disable and set ``Loop.enabled=True`` on both planes.
 
-Each transition is the atomic, idempotent ``LoopState`` upsert paired with the
-idempotent ``Loop.enabled`` update; the command re-reads and reports the LANDED
-status so the operator sees the verified state rather than an echo of the request.
+The command re-reads and reports the LANDED status so the operator sees the
+verified state rather than an echo of the request.
 
 ``status`` is the one strictly READ-ONLY verb: it reports the current durable
 state and writes nothing. Its output is phrased as a read (``status: <STATUS>``),
@@ -36,7 +35,6 @@ from collections.abc import Callable
 from typing import Annotated
 
 import typer
-from django.db import transaction
 from django_typer.management import TyperCommand, command
 
 from teatree.core.models import Loop, LoopState
@@ -132,9 +130,7 @@ class Command(TyperCommand):
     ) -> None:
         """Return *name* to ENABLED, clearing a pause OR a disable — both planes."""
         _require_known_loop(name, json_output=json_output, stdout_write=self.stdout.write)
-        with transaction.atomic():
-            LoopState.objects.resume(name)
-            Loop.objects.set_enabled(name, enabled=True)
+        Loop.objects.resume(name)
         _reconcile_timers()
         _report(name, json_output=json_output, stdout_write=self.stdout.write)
 
@@ -147,9 +143,7 @@ class Command(TyperCommand):
     ) -> None:
         """Move *name* into the durable DISABLED kill-switch — both planes."""
         _require_known_loop(name, json_output=json_output, stdout_write=self.stdout.write)
-        with transaction.atomic():
-            LoopState.objects.disable(name)
-            Loop.objects.set_enabled(name, enabled=False)
+        Loop.objects.disable(name)
         _reconcile_timers()
         _report(name, json_output=json_output, stdout_write=self.stdout.write)
 
@@ -162,9 +156,7 @@ class Command(TyperCommand):
     ) -> None:
         """Return *name* to ENABLED (alias of resume) — both planes."""
         _require_known_loop(name, json_output=json_output, stdout_write=self.stdout.write)
-        with transaction.atomic():
-            LoopState.objects.enable(name)
-            Loop.objects.set_enabled(name, enabled=True)
+        Loop.objects.enable(name)
         _reconcile_timers()
         _report(name, json_output=json_output, stdout_write=self.stdout.write)
 

--- a/src/teatree/core/models/loop.py
+++ b/src/teatree/core/models/loop.py
@@ -39,8 +39,10 @@ import datetime as dt
 from typing import ClassVar
 
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import models, transaction
 from django.utils import timezone
+
+from teatree.core.models.loop_state import LoopState
 
 
 class LoopManager(models.Manager["Loop"]):
@@ -49,10 +51,6 @@ class LoopManager(models.Manager["Loop"]):
     def enabled(self) -> "models.QuerySet[Loop]":
         """The enabled loops — the candidate set the loop-table fan-out considers each pass."""
         return self.filter(enabled=True)
-
-    def due(self, now: dt.datetime) -> "list[Loop]":
-        """Enabled loops whose cadence has elapsed (or that never ran)."""
-        return [loop for loop in self.enabled() if loop.is_due(now)]
 
     def mark_run(self, name: str, ts: dt.datetime) -> None:
         """Stamp ``last_run_at = ts`` for *name* — the cadence bump after a run.
@@ -84,13 +82,48 @@ class LoopManager(models.Manager["Loop"]):
 
         ``Loop.enabled`` is the row-level source of truth the #2584 loop tick
         reads (``not row.enabled`` skips a loop, independent of the durable
-        ``LoopState`` control plane). The ``enable`` / ``disable`` loop verbs move
-        this column in lock-step with their ``LoopState`` write so both planes
-        agree. A direct ``update`` is idempotent; a name with no row is a no-op
-        (returns ``0``) — the loop-config verbs still record their ``LoopState``
-        intent for a not-yet-seeded name.
+        ``LoopState`` control plane). :meth:`disable` / :meth:`enable` move this
+        column in lock-step with their ``LoopState`` write (one atomic method
+        owns the paired invariant) so both planes agree. A direct ``update`` is
+        idempotent; a name with no row is a no-op (returns ``0``) — the paired
+        methods still record their ``LoopState`` intent for a not-yet-seeded name.
         """
         return self.filter(name=name).update(enabled=enabled)
+
+    def disable(self, name: str) -> None:
+        """Durably disable *name* on BOTH planes atomically (#1913, #2584).
+
+        The single owner of the paired write the ``loop_state`` command used to
+        inline (holistic 3c#4): the ``DISABLED`` :class:`LoopState` kill-switch AND
+        the row-level ``enabled=False`` the #2584 tick reads move together in one
+        transaction, so no caller can leave one plane stale — the "reports enabled
+        but never ticks" bug this method exists to make impossible. A name with no
+        ``Loop`` row still records its durable ``LoopState`` intent (the row update
+        is a 0-row no-op).
+        """
+        with transaction.atomic():
+            LoopState.objects.disable(name)
+            self.set_enabled(name, enabled=False)
+
+    def enable(self, name: str) -> None:
+        """Re-enable *name* on BOTH planes atomically — clears EITHER a pause or a disable.
+
+        The inverse of :meth:`disable`: the ``ENABLED`` :class:`LoopState`
+        transition (which lifts a PAUSE or a DISABLE) AND ``enabled=True`` move
+        together, so both planes agree the loop runs again.
+        """
+        with transaction.atomic():
+            LoopState.objects.enable(name)
+            self.set_enabled(name, enabled=True)
+
+    def resume(self, name: str) -> None:
+        """Return *name* to running on BOTH planes — the pause-vocabulary alias of :meth:`enable`.
+
+        ``resume`` and ``enable`` are the one "make it run again" transition so a
+        loop is never stuck because the operator reached for the pause verb on a
+        disabled loop.
+        """
+        self.enable(name)
 
 
 class Loop(models.Model):

--- a/src/teatree/core/models/loop_state.py
+++ b/src/teatree/core/models/loop_state.py
@@ -70,6 +70,16 @@ class LoopStateManager(models.Manager["LoopState"]):
         """True iff *name* is in the ``ENABLED`` state (no pause, no disable)."""
         return self.status_of(name) is LoopStatus.ENABLED
 
+    def held_names(self) -> set[str]:
+        """Every loop name a durable ``PAUSED`` / ``DISABLED`` row holds — the tick's single bulk read.
+
+        One ``values_list`` over the small control table, so the loop-table fan-out
+        resolves every loop's hold from ONE query instead of a per-loop
+        :meth:`is_runnable` round-trip (#2584 N+1). An absent name (no row) is
+        ``ENABLED`` → not held, so it is simply not in the returned set.
+        """
+        return {name for name, status in self.values_list("name", "status") if status != LoopStatus.ENABLED.value}
+
     def is_paused(self, name: str) -> bool:
         return self.status_of(name) is LoopStatus.PAUSED
 

--- a/src/teatree/loop/loop_state_db.py
+++ b/src/teatree/loop/loop_state_db.py
@@ -1,19 +1,46 @@
-"""DB-backed LoopState control tier, read by loop NAME (#1913).
+"""DB-backed LoopState control tier + the single combined enable verdict (#1913, #2584).
 
-The single ORM read of the per-loop control plane both the tick gate
-(:meth:`teatree.loops.config.LoopsConfig.is_enabled`) and the review-claim
-chokepoint (:mod:`teatree.loop.review_claim_signals.review_loop_enabled`)
-consult — so the "is this loop durably paused/disabled?" answer cannot drift
-between them. It is the SINGLE disable authority (loop control is ``/loops`` +
-the DB only; there is no env kill-switch). A ``domain``-layer leaf depending
-only on :mod:`teatree.core.models` (a deferred, fail-safe read), so both the
-orchestration tick gate and the domain-layer review-claim signals leaf may
-import it downward.
+Two distinct facts gate a loop, and this module owns their read side. The
+``Loop.enabled`` column is the durable CONFIGURED/opt-in plane (a fresh install's
+seed default; a default-off loop ships ``enabled=False``). The ``LoopState`` row
+is the durable runtime CONTROL plane (``t3 loop pause`` / ``disable``, the
+restart-surviving 'pause everything', including the core ``dispatch`` loop), read
+here via :func:`loop_held_in_db`.
+
+:func:`loop_state_admits` is the ONE pure predicate that combines them
+(configured-enabled AND not runtime-held). Every enable-decision site resolves a
+loop through it, so the verdict can never drift into a tier-subset: the standalone
+:func:`loop_enabled` single-lookup (the off-live-tick daily loop gates —
+``directive``/``outer``/``dream`` tick commands + the per-loop connector
+preflight) and the live loop-table tick (:func:`teatree.loops.loop_table._loop_admitted`,
+which applies the same predicate over its already-bulk-loaded ``Loop`` rows + one
+bulk ``LoopState`` read) both call it. The timer-chain admission reuses the tick's
+verdict. The review-claim chokepoint
+(:func:`teatree.loop.review_claim_signals.review_loop_enabled`) is the ONE
+deliberate exception: by documented design (#79) it reads the ``LoopState`` arm
+ONLY (:func:`loop_held_in_db`), never ``Loop.enabled`` — a fail-open
+claim-suppression gate, not a loop-run decision.
+
+It is the SINGLE disable authority (loop control is ``/loops`` + the DB only;
+there is no env kill-switch and no ``[loops]`` toml fallback). A ``domain``-layer
+leaf depending only on :mod:`teatree.core.models` (a deferred, fail-safe read),
+so both the orchestration tick gate and the domain-layer review-claim signals
+leaf may import it downward.
 """
 
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def loop_state_admits(*, configured_enabled: bool, held: bool) -> bool:
+    """The combined enable verdict: a loop runs iff it is CONFIGURED-enabled AND not runtime-HELD.
+
+    The single predicate both :func:`loop_enabled` (single-lookup) and the live
+    loop-table tick apply, so the two planes are combined identically everywhere
+    and can never drift into a tier-subset verdict.
+    """
+    return configured_enabled and not held
 
 
 def loop_held_in_db(name: str) -> bool:
@@ -27,26 +54,48 @@ def loop_held_in_db(name: str) -> bool:
 
     FAIL SAFE: any error (DB unavailable, Django not configured, model
     unimportable) resolves to ``False`` (no hold) so an unreadable database can
-    never silently disable a loop.
+    never silently disable a loop. The swallow logs at WARNING — the global
+    kill-switch fails CLOSED on a read error, so this symmetric per-loop
+    fail-OPEN must be observable, not whispered at ``debug`` (holistic 3c#5): a
+    loop silently kept running past a durable PAUSE/DISABLE is exactly the
+    false-quiet class the fleet-safety work exists to surface.
     """
     try:
         from teatree.core.models import LoopState  # noqa: PLC0415
 
         return not LoopState.objects.is_runnable(name)
     except Exception:
-        logger.debug("LoopState read failed for %r — failing safe to no-hold (loop runs)", name, exc_info=True)
+        logger.warning("LoopState read failed for %r — failing safe to no-hold (loop runs)", name, exc_info=True)
         return False
 
 
-def loop_enabled(name: str) -> bool:
-    """The single enable verdict over the DB: ``Loop.enabled`` AND not ``LoopState``-held.
+def held_loop_names() -> set[str]:
+    """Every loop name a durable ``PAUSED`` / ``DISABLED`` row holds — the tick's bulk hold read.
 
-    The ONE function every enable-decision site routes through — the loop tick,
-    the dream cron gate, the review-claim chokepoint, and the #2650 cron mirror —
-    so the four can never drift back into a tier-subset verdict (one site keying on
-    ``Loop.enabled`` alone, another on ``LoopState`` alone). A loop is enabled iff
-    its durable ``Loop`` row carries ``enabled=True`` AND no ``LoopState``
-    pause/disable holds it.
+    The set form of :func:`loop_held_in_db` the loop-table fan-out consumes once
+    per tick (``name in held``) instead of a per-loop query (#2584 N+1). FAIL SAFE
+    symmetric with :func:`loop_held_in_db`: any read error resolves to the empty
+    set (no holds) so an unreadable DB can never silently disable every loop, and
+    it WARNS so the degraded read is observable.
+    """
+    try:
+        from teatree.core.models import LoopState  # noqa: PLC0415 (deferred, pre-app-registry — as loop_held_in_db)
+
+        return LoopState.objects.held_names()
+    except Exception:
+        logger.warning("LoopState bulk read failed — failing safe to no-holds (loops run)", exc_info=True)
+        return set()
+
+
+def loop_enabled(name: str) -> bool:
+    """The single-lookup combined enable verdict: ``Loop.enabled`` AND not ``LoopState``-held.
+
+    The single-query form of :func:`loop_state_admits` the off-live-tick daily
+    loop gates use (``directive``/``outer``/``dream`` tick commands + the per-loop
+    connector preflight): a loop is enabled iff its durable ``Loop`` row carries
+    ``enabled=True`` AND no ``LoopState`` pause/disable holds it. The live
+    loop-table tick reaches the SAME verdict through the same predicate over
+    bulk-loaded rows, so no site drifts into a tier-subset.
 
     A missing row or ``enabled=False`` is a real, deterministic disable (``False``).
     FAIL SAFE: a genuine read error (DB unavailable, Django not configured) resolves
@@ -60,9 +109,9 @@ def loop_enabled(name: str) -> bool:
     except Exception:
         logger.debug("Loop.enabled read failed for %r — failing safe to enabled", name, exc_info=True)
         return True
-    if row is None or not row.enabled:
+    if row is None:
         return False
-    return not loop_held_in_db(name)
+    return loop_state_admits(configured_enabled=row.enabled, held=loop_held_in_db(name))
 
 
-__all__ = ["loop_enabled", "loop_held_in_db"]
+__all__ = ["held_loop_names", "loop_enabled", "loop_held_in_db", "loop_state_admits"]

--- a/src/teatree/loop/review_claim_signals.py
+++ b/src/teatree/loop/review_claim_signals.py
@@ -38,11 +38,13 @@ def review_loop_enabled() -> bool:
     ``LoopState`` row durably stops review claims across a restart; an absent row
     or a runnable one leaves them running. This is the discovery-time claim gate,
     not a loop-run decision — it fails OPEN to enabled by design (#79 / #1913), so
-    it intentionally does NOT read the ``Loop.enabled`` column (the loop tick,
-    the dream cron gate, and the #2650 cron mirror gate on that combined verdict;
-    this chokepoint suppresses over-claiming and must never silently swallow every
-    review on an unreadable or absent row). There is no env kill-switch and no
-    ``[loops]`` toml fallback — loop control is ``/loops`` + the DB only.
+    it intentionally does NOT read the ``Loop.enabled`` column (the loop-run sites
+    — the loop tick and the off-live-tick loop gates — combine ``Loop.enabled``
+    AND the ``LoopState`` hold via
+    :func:`teatree.loop.loop_state_db.loop_state_admits`; this chokepoint
+    suppresses over-claiming and must never silently swallow every review on an
+    unreadable or absent row). There is no env kill-switch and no ``[loops]`` toml
+    fallback — loop control is ``/loops`` + the DB only.
 
     Fail-safe: any read error resolves to enabled so an unreadable source never
     silently suppresses every review — the discovery-time claim removal is what

--- a/src/teatree/loops/loop_table.py
+++ b/src/teatree/loops/loop_table.py
@@ -4,16 +4,19 @@ The cutover from the code-cadence tick: the fan-out no longer consults a
 code-cadence ledger to decide whether a mini-loop should fire — the DB ``Loop``
 row carries cadence + the enable toggle, and ``Loop.last_run_at`` is the single
 cadence ledger. #2584 closes the gap the #2513 cutover opened: a loop runs this
-tick iff it is NOT ``off_live_tick`` AND its ``Loop`` row is ``enabled`` and
-``is_due(now)`` (its own ``delay_seconds`` interval, or its ``daily_at``
-wall-clock schedule) AND ``LoopsConfig.is_enabled`` agrees. ``LoopsConfig.is_enabled``
-resolves through the durable ``LoopState`` control tier only (``t3 loop pause`` /
-``disable``, #1913) — there is no env kill-switch and no ``[loops]`` toml
-disabled-state tier. ``row.enabled`` AND ``LoopsConfig.is_enabled`` together are
-the single enable verdict (``Loop.enabled`` + ``loop_held_in_db``) — the same
-verdict the dream cron gate, the review-claim chokepoint, and the #2650 cron
-mirror resolve through ``teatree.loop.loop_state_db.loop_enabled``, so no
-enable-decision site drifts into a tier-subset.
+tick iff it is NOT ``off_live_tick`` AND its ``Loop`` row is ``is_due(now)`` (its
+own ``delay_seconds`` interval, or its ``daily_at`` wall-clock schedule) AND the
+combined enable verdict admits it. That verdict is
+:func:`teatree.loop.loop_state_db.loop_state_admits` — ``Loop.enabled`` (the
+configured/opt-in plane) AND not ``LoopState``-held (the durable runtime control
+tier: ``t3 loop pause`` / ``disable``, #1913) — there is no env kill-switch and no
+``[loops]`` toml disabled-state tier. The tick applies that ONE predicate over its
+already-bulk-loaded ``Loop`` rows plus a SINGLE bulk ``LoopState`` read (no
+per-loop hold query), and the standalone :func:`loop_enabled` single-lookup used
+by the off-live-tick daily loop gates applies the same predicate — so no
+enable-decision site drifts into a tier-subset. (The review-claim chokepoint
+reads the ``LoopState`` arm only, by documented design — see
+:mod:`teatree.loop.loop_state_db`.)
 
 **The ``script``/``prompt`` column is LOAD-BEARING (#2513 regression fix).** The
 fan-out no longer selects an admitted row's behaviour by a name-only registry
@@ -28,10 +31,10 @@ column, not by its name.
 
 An ``off_live_tick`` loop (the heavy ``dream`` consolidation pass, #1933 § 3) is
 NEVER picked up here — the live tick must not invoke its ``build_jobs`` or bump
-its ``last_run_at``; it is driven by its own low-frequency cron. The
-``LoopsConfig.is_enabled`` check runs BEFORE the cadence claim so a held loop is
-neither dispatched nor cadence-bumped — its anchor is preserved, not silently
-consumed. The fan-out then ATOMICALLY claims an admitted loop's ``last_run_at``
+its ``last_run_at``; it is driven by its own low-frequency cron. The combined
+enable verdict (the ``LoopState`` hold check) runs BEFORE the cadence claim so a
+held loop is neither dispatched nor cadence-bumped — its anchor is preserved, not
+silently consumed. The fan-out then ATOMICALLY claims an admitted loop's ``last_run_at``
 (a compare-and-swap on the anchor it read, :meth:`LoopManager.mark_run_if_unchanged`)
 BEFORE building its jobs, so two ticks that read the same anchor cannot both
 drive the loop — exactly one wins the claim and dispatches.
@@ -60,13 +63,13 @@ from typing import TYPE_CHECKING
 
 from teatree.core import availability
 from teatree.loop.job_identity import _ScannerJob
+from teatree.loop.loop_state_db import held_loop_names, loop_state_admits
 from teatree.loops.base import BuildJobsContext, MiniLoop
 from teatree.loops.registry import iter_loops
 
 if TYPE_CHECKING:
     from teatree.core.availability import Resolution
     from teatree.core.models import Loop
-    from teatree.loops.config import LoopsConfig
 
 logger = logging.getLogger(__name__)
 
@@ -90,27 +93,27 @@ def _resolve_dispatch_loop(row: "Loop", registry_by_name: dict[str, MiniLoop]) -
 
 
 def _loop_admitted(
-    row: "Loop | None", loop: MiniLoop, config: "LoopsConfig", now: dt.datetime, resolution: "Resolution"
+    row: "Loop | None", loop: MiniLoop, *, held: bool, now: dt.datetime, resolution: "Resolution"
 ) -> bool:
     """The unified enabled+due+reachable verdict for one loop — no cadence claim.
 
     A loop is admitted iff it is NOT ``off_live_tick`` (the heavy ``dream`` pass is
-    driven by its own low-frequency cron), it HAS a ``Loop`` row that is ``enabled``
-    and ``is_due(now)``, it is NOT ``colleague_facing`` while *resolution*
-    ``defers_questions`` (holiday-``away`` / ``autonomous_away``, #2904), AND
-    ``LoopsConfig.is_enabled`` agrees (the durable ``LoopState`` control tier — a
-    ``t3 loop pause`` / ``disable`` hold, #2584). The single source of truth both
-    :func:`build_loop_table_jobs` and the loop-timer chains
-    (:func:`admitted_loop_names`, via :func:`teatree.loops.timer_chains.loop_admitted`)
-    gate on, so the verdict can never drift.
+    driven by its own low-frequency cron), it HAS a ``Loop`` row that is
+    ``is_due(now)``, it is NOT ``colleague_facing`` while *resolution*
+    ``defers_questions`` (holiday-``away`` / ``autonomous_away``, #2904), AND the
+    combined enable verdict :func:`teatree.loop.loop_state_db.loop_state_admits`
+    admits it — ``Loop.enabled`` (configured) AND not *held* (the caller's bulk
+    ``LoopState`` read, #2584). The single verdict both :func:`build_loop_table_jobs`
+    and the loop-timer chains (:func:`admitted_loop_names`, via
+    :func:`teatree.loops.timer_chains.loop_admitted`) gate on, so it can never drift.
     """
     if loop.off_live_tick:
         return False
-    if row is None or not row.enabled or not row.is_due(now):
+    if row is None or not row.is_due(now):
         return False
     if row.colleague_facing and resolution.defers_questions:
         return False
-    return config.is_enabled(loop)
+    return loop_state_admits(configured_enabled=row.enabled, held=held)
 
 
 def admitted_loop_names(now: dt.datetime, *, only: str | None = None) -> list[str]:
@@ -124,15 +127,15 @@ def admitted_loop_names(now: dt.datetime, *, only: str | None = None) -> list[st
     drives one.
     """
     from teatree.core.models import Loop  # noqa: PLC0415
-    from teatree.loops.config import LoopsConfig  # noqa: PLC0415
 
-    config = LoopsConfig.load()
     resolution = availability.resolve_mode()
     rows = {row.name: row for row in Loop.objects.all()}
+    held = held_loop_names()
     return [
         loop.name
         for loop in iter_loops()
-        if (only is None or loop.name == only) and _loop_admitted(rows.get(loop.name), loop, config, now, resolution)
+        if (only is None or loop.name == only)
+        and _loop_admitted(rows.get(loop.name), loop, held=loop.name in held, now=now, resolution=resolution)
     ]
 
 
@@ -146,8 +149,8 @@ def build_loop_table_jobs(
     or bump its ``last_run_at``. A registry mini-loop with no ``Loop`` row is
     skipped (its config was never seeded). A loop whose row is disabled or
     not-due is skipped; a ``colleague_facing`` row is skipped while availability
-    defers questions (#2904); and a loop the :meth:`LoopsConfig.is_enabled`
-    verdict holds — a ``LoopState`` PAUSED/DISABLED row (#1913, #2584) — is
+    defers questions (#2904); and a loop the combined verdict holds — a
+    ``LoopState`` PAUSED/DISABLED row in the single bulk read (#1913, #2584) — is
     skipped too, ALL BEFORE ``mark_run``, so a held loop's cadence anchor is
     preserved.
 
@@ -170,18 +173,17 @@ def build_loop_table_jobs(
     again).
     """
     from teatree.core.models import Loop  # noqa: PLC0415
-    from teatree.loops.config import LoopsConfig  # noqa: PLC0415
 
-    config = LoopsConfig.load()
     resolution = availability.resolve_mode()
     registry = tuple(iter_loops())
     registry_by_name = {loop.name: loop for loop in registry}
     rows = {row.name: row for row in Loop.objects.all()}
+    held = held_loop_names()
     jobs: list[_ScannerJob] = []
     for loop in registry:
         if only is not None and loop.name != only:
             continue
-        if not _loop_admitted(rows.get(loop.name), loop, config, now, resolution):
+        if not _loop_admitted(rows.get(loop.name), loop, held=loop.name in held, now=now, resolution=resolution):
             continue
         row = rows[loop.name]
         # Atomically claim the cadence anchor BEFORE building jobs so two ticks

--- a/tests/teatree_core/models/test_loop.py
+++ b/tests/teatree_core/models/test_loop.py
@@ -15,7 +15,7 @@ from django.db import IntegrityError, transaction
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
-from teatree.core.models import Loop, Prompt
+from teatree.core.models import Loop, LoopState, LoopStatus, Prompt
 from teatree.loops.seed import DEFAULT_LOOPS
 
 
@@ -206,16 +206,6 @@ class TestLoopManager(TestCase):
         assert "demo-on" in names
         assert "demo-disabled" not in names
 
-    def test_due_returns_enabled_overdue_only(self) -> None:
-        now = timezone.now()
-        Loop.objects.create(name="demo-due", delay_seconds=60, prompt=_prompt())
-        Loop.objects.create(name="demo-cooling", delay_seconds=60, prompt=_prompt(), last_run_at=now)
-        Loop.objects.create(name="demo-due-off", delay_seconds=60, prompt=_prompt(), enabled=False)
-        due = {row.name for row in Loop.objects.due(now)}
-        assert "demo-due" in due
-        assert "demo-cooling" not in due
-        assert "demo-due-off" not in due
-
     def test_mark_run_sets_last_run_at(self) -> None:
         Loop.objects.create(name="demo-mark", delay_seconds=60, prompt=_prompt())
         ts = timezone.now()
@@ -232,6 +222,44 @@ class TestLoopManager(TestCase):
 
     def test_set_enabled_is_a_no_op_for_an_absent_row(self) -> None:
         assert Loop.objects.set_enabled("demo-absent", enabled=True) == 0
+
+
+class TestAtomicTwoPlaneControl(TestCase):
+    """``Loop.objects.disable/enable/resume`` own the paired two-plane write atomically.
+
+    The #2584 tick verdict gates on BOTH ``Loop.enabled`` AND the ``LoopState``
+    control tier. Before, the paired write lived in the ``loop_state`` command, so a
+    second programmatic caller of ``LoopState.objects.disable`` left ``Loop.enabled``
+    stale — the "reports enabled but never ticks" bug (holistic 3c#4). The single
+    atomic manager method makes half-application impossible.
+    """
+
+    def test_disable_writes_both_planes(self) -> None:
+        Loop.objects.create(name="demo-dis", delay_seconds=60, prompt=_prompt(), enabled=True)
+        Loop.objects.disable("demo-dis")
+        assert Loop.objects.get(name="demo-dis").enabled is False
+        assert LoopState.objects.status_of("demo-dis") is LoopStatus.DISABLED
+
+    def test_enable_writes_both_planes(self) -> None:
+        Loop.objects.create(name="demo-en", delay_seconds=60, prompt=_prompt(), enabled=False)
+        LoopState.objects.disable("demo-en")
+        Loop.objects.enable("demo-en")
+        assert Loop.objects.get(name="demo-en").enabled is True
+        assert LoopState.objects.status_of("demo-en") is LoopStatus.ENABLED
+
+    def test_resume_writes_both_planes(self) -> None:
+        Loop.objects.create(name="demo-res", delay_seconds=60, prompt=_prompt(), enabled=False)
+        LoopState.objects.pause("demo-res")
+        Loop.objects.resume("demo-res")
+        assert Loop.objects.get(name="demo-res").enabled is True
+        assert LoopState.objects.status_of("demo-res") is LoopStatus.ENABLED
+
+    def test_disable_records_loopstate_intent_for_an_unseeded_name(self) -> None:
+        # A name with no Loop row still records its durable LoopState intent (the
+        # row-level update is a 0-row no-op) — mirrors the pre-refactor command.
+        Loop.objects.disable("demo-unseeded")
+        assert LoopState.objects.status_of("demo-unseeded") is LoopStatus.DISABLED
+        assert not Loop.objects.filter(name="demo-unseeded").exists()
 
 
 class TestLoopSeed(TestCase):

--- a/tests/teatree_loop/test_loop_state_db.py
+++ b/tests/teatree_loop/test_loop_state_db.py
@@ -1,0 +1,82 @@
+"""teatree.loop.loop_state_db — the single combined enable verdict over the DB.
+
+``loop_state_admits`` is the ONE pure predicate every enable-decision site
+resolves through: the standalone ``loop_enabled`` single-lookup (the off-live-tick
+loop gates) and the live loop-table tick both apply it, so the verdict can never
+drift into a tier-subset. ``loop_held_in_db`` is the durable per-loop
+PAUSE/DISABLE read; it fails SAFE to no-hold on a read error but must WARN (not
+whisper at debug) so a silently-unheld loop is observable (#2584 / holistic 3c#5).
+"""
+
+from unittest.mock import patch
+
+import django.test
+
+from teatree.core.models import Loop, LoopState, Prompt
+from teatree.loop.loop_state_db import loop_enabled, loop_held_in_db, loop_state_admits
+
+
+class TestLoopStateAdmits(django.test.SimpleTestCase):
+    """The pure combined verdict: configured-enabled AND not runtime-held."""
+
+    def test_configured_and_unheld_admits(self) -> None:
+        assert loop_state_admits(configured_enabled=True, held=False) is True
+
+    def test_held_is_not_admitted_even_when_configured(self) -> None:
+        assert loop_state_admits(configured_enabled=True, held=True) is False
+
+    def test_not_configured_is_not_admitted_even_when_unheld(self) -> None:
+        assert loop_state_admits(configured_enabled=False, held=False) is False
+
+    def test_not_configured_and_held_is_not_admitted(self) -> None:
+        assert loop_state_admits(configured_enabled=False, held=True) is False
+
+
+@django.test.override_settings(USE_TZ=True)
+class TestLoopEnabledCombinedVerdict(django.test.TestCase):
+    """``loop_enabled(name)`` is ``Loop.enabled`` AND not ``LoopState``-held — one verdict."""
+
+    def _loop(self, name: str, *, enabled: bool = True) -> Loop:
+        prompt, _ = Prompt.objects.get_or_create(name=f"{name}-p", defaults={"body": "x"})
+        return Loop.objects.update_or_create(
+            name=name, defaults={"delay_seconds": 60, "prompt": prompt, "script": "", "enabled": enabled}
+        )[0]
+
+    def test_enabled_and_unheld_is_true(self) -> None:
+        self._loop("le-on")
+        assert loop_enabled("le-on") is True
+
+    def test_configured_disabled_is_false(self) -> None:
+        self._loop("le-off", enabled=False)
+        assert loop_enabled("le-off") is False
+
+    def test_loopstate_hold_stops_a_configured_loop(self) -> None:
+        self._loop("le-held")
+        LoopState.objects.disable("le-held")
+        assert loop_enabled("le-held") is False
+
+    def test_missing_row_is_false(self) -> None:
+        assert loop_enabled("le-absent") is False
+
+
+class TestLoopHeldFailsSafeButWarns(django.test.TestCase):
+    """A per-loop PAUSE/DISABLE read error fails OPEN (no hold) — but WARNS, never whispers.
+
+    The global kill-switch fails CLOSED on a read error; the symmetric per-loop
+    hold fails OPEN so an unreadable DB can never silently disable a loop. That
+    fail-open was swallowed at ``debug`` (#2584 / holistic 3c#5): a loop silently
+    kept running with NO observable signal. It must log at WARNING so the operator
+    can see the degraded read.
+    """
+
+    def test_read_error_returns_no_hold(self) -> None:
+        with patch.object(LoopState.objects, "is_runnable", side_effect=RuntimeError("db down")):
+            assert loop_held_in_db("review") is False
+
+    def test_read_error_logs_at_warning(self) -> None:
+        with (
+            patch.object(LoopState.objects, "is_runnable", side_effect=RuntimeError("db down")),
+            self.assertLogs("teatree.loop.loop_state_db", level="WARNING") as logs,
+        ):
+            loop_held_in_db("review")
+        assert any("review" in line for line in logs.output)

--- a/tests/teatree_loops/test_loop_table.py
+++ b/tests/teatree_loops/test_loop_table.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import django.test
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from teatree.core.availability import Resolution
@@ -404,6 +406,45 @@ class TestAtLeastOnceDoubleDeliveryIsACasNoOp(django.test.TestCase):
         assert "job-dd-once" in first
         assert second == []  # redelivery is a no-op
         assert Loop.objects.get(name="dd-once").last_run_at == claimed  # anchor unchanged by the redelivery
+
+
+@django.test.override_settings(USE_TZ=True)
+class TestLoopStateBulkLoadedOncePerTick(django.test.TestCase):
+    """The tick reads ``LoopState`` ONCE (bulk), never once-per-loop (holistic 3c#3).
+
+    The pre-fix ``_loop_admitted`` resolved the durable hold per loop via
+    ``LoopsConfig.is_enabled`` → ``loop_held_in_db`` → one ``teatree_loop_state``
+    SELECT for every registered loop (an N+1 on every tick while the ``Loop`` rows
+    were already bulk-loaded). The verdict now consumes a single bulk read.
+    """
+
+    @staticmethod
+    def _loop_state_query_count(ctx: CaptureQueriesContext) -> int:
+        return sum("teatree_loop_state" in q["sql"] for q in ctx.captured_queries)
+
+    def test_build_loop_table_jobs_reads_loop_state_at_most_once(self) -> None:
+        now = timezone.now()
+        registry = tuple(_mini(f"n1-{i}") for i in range(5))
+        for loop in registry:
+            Loop.objects.create(name=loop.name, delay_seconds=60, prompt=_prompt())
+        with (
+            patch("teatree.loops.loop_table.iter_loops", return_value=registry),
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            build_loop_table_jobs({}, now=now)
+        assert self._loop_state_query_count(ctx) <= 1
+
+    def test_admitted_loop_names_reads_loop_state_at_most_once(self) -> None:
+        now = timezone.now()
+        registry = tuple(_mini(f"n2-{i}") for i in range(5))
+        for loop in registry:
+            Loop.objects.create(name=loop.name, delay_seconds=60, prompt=_prompt())
+        with (
+            patch("teatree.loops.loop_table.iter_loops", return_value=registry),
+            CaptureQueriesContext(connection) as ctx,
+        ):
+            admitted_loop_names(now)
+        assert self._loop_state_query_count(ctx) <= 1
 
 
 @django.test.override_settings(USE_TZ=True)


### PR DESCRIPTION
## Burndown Unit 1 — Loop-enable / LoopState authority

Resolves the whole unit: the false "single enable verdict" invariant plus the dual-source-of-truth between `Loop.enabled` and `LoopState`. Behaviour-preserving refactor, **no migration**.

### Findings addressed

| Finding | What changed |
|---|---|
| **must-fix** — `loop_enabled()` docstring claims 4 sites route through it, but the tick inlines the verdict and review-claim reads LoopState-only | Extracted `loop_state_admits(configured_enabled, held)` — one pure predicate that BOTH `loop_enabled()` and the tick's `_loop_admitted` apply, so they provably can't drift. Docstrings corrected to name the *real* consumers and the by-design LoopState-only review-claim arm. |
| **should-fix 3c#1** — `loop_table.py` module docstring repeats the false claim | Rewritten to describe the shared predicate + single bulk LoopState read. |
| **should-fix 3c#2** — genuine dual source of truth for "enabled" | The two columns encode genuinely distinct facts (`Loop.enabled` = configured/opt-in seed plane; `LoopState` = runtime pause/disable). Resolved by making **reads** flow through one verdict (`loop_state_admits`) and **writes** through one atomic owner (below). Dropping `Loop.enabled` (needs a migration; default-off loops seeded `enabled=False`) or stopping the verbs writing it (breaks `enable` of a default-off loop) were both rejected as non-behaviour-preserving. |
| **should-fix 3c#3** — N+1 LoopState query per loop every tick | Tick bulk-loads once via `held_loop_names()` -> `LoopState.objects.held_names()`; `_loop_admitted` takes a precomputed `held: bool`. Guarded by a query-count test (was 5 queries for 5 loops, now <=1). |
| **should-fix 3c#4** — two-plane `disable` write lived in the command | Moved into one atomic `LoopManager.disable/enable/resume` (`transaction.atomic`), so no programmatic caller can half-apply it (the "reports enabled but never ticks" bug). |
| **should-fix 3c#5** — per-loop PAUSE/DISABLE read fails OPEN, swallowed at debug | `loop_held_in_db` (and the new `held_loop_names`) now log the fail-open at **WARNING** — symmetric with the global kill-switch which fails CLOSED. |
| **should-fix doc#9** — stale "#2650 cron mirror" named as a live consumer | Swept `loop_state_db` / `loop_table` / `review_claim_signals` / `cli/loops`: dropped the deleted plane, named the timer chain as the driver. |
| **nit doc#16** — stale pause rationale in the `loop_state` command | Reworded: pause holds LoopState only; resume/enable lift either hold and re-enable both planes. |
| **nit** — `LoopManager.due()` appears unused | Deleted (only its own test referenced it; `.enabled()` stays — used by `timer_reconciler` + `worker`). |

### Tests (RED-before, GREEN-after)

- `tests/teatree_loop/test_loop_state_db.py` (new) — `loop_state_admits` truth table; `loop_enabled` combined verdict; `loop_held_in_db` fail-open **logs at WARNING** (RED on the old `debug`).
- `tests/teatree_core/models/test_loop.py::TestAtomicTwoPlaneControl` — `disable/enable/resume` write both planes atomically + record intent for an unseeded name (RED: methods did not exist).
- `tests/teatree_loops/test_loop_table.py::TestLoopStateBulkLoadedOncePerTick` — LoopState read <=1 query for N loops (RED: was N).

Existing anti-vacuity guards stay green: `test_cross_plane_consistency`, `TestCadenceClaimIsAtomic` (concurrent-two-drivers -> exactly one), colleague-facing availability, and the command two-plane pins.

## Architecture pre-check — Unit 1 (Loop-enable / LoopState authority)

### 1. BLUEPRINT § alignment
Loop topology + the per-loop / no-master-tick invariant. No spec change: the enable verdict and the pause/disable control plane are unchanged in behaviour; only the internal seam (one predicate + one atomic write owner) and docstrings move.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition. `LoopState` is a control-plane row, not an FSM.

### 3. Extension-point contracts
No `OverlayBase` / scanner / hook / Protocol surface touched. `LoopManager` / `LoopStateManager` are internal model managers.

### 4. Component boundaries
`core/models` (managers + atomic write), `teatree.loop.loop_state_db` (the LoopState read seam — now owns the bulk `held_loop_names`), `teatree.loops.loop_table` (consumes the seam). No straddling.

### 5. Dependency direction
`teatree.loops.loop_table` -> `teatree.loop.loop_state_db` is an existing permitted eager edge (mirrors `loops/config.py`). `core.models.loop` -> `core.models.loop_state` is intra-package. `tach` + import-linter pass; no new backwards edge.

### 6. Test surface
Predicate -> `test_loop_state_db.py`; atomic two-plane write -> `test_loop.py::TestAtomicTwoPlaneControl`; N+1 -> `test_loop_table.py::TestLoopStateBulkLoadedOncePerTick`; log-level -> `test_loop_state_db.py::TestLoopHeldFailsSafeButWarns`.

### 7. Resilience invariants
The read seam fails **safe** (unreadable DB -> no hold, symmetric with the single-lookup) and now **WARNS** (observable). Atomic two-plane write is idempotent (each transition is an idempotent upsert/update) and transactional (no half-apply). No new external write.

### 8. Identity and key normalization
Loop name is the single key throughout; no bare/qualified split introduced; no strip/split-to-match.

### 9. Behavior preservation / capability deletion
Purely behaviour-preserving for the verdict (pinned by `test_cross_plane_consistency` + `test_loop_table`). Removed: dead `LoopManager.due()` (only its own test used it — verified by grep). No must-block test inverted.

### 10. Removability / harness-vs-data
`loop_state_admits` / `held_loop_names` are small, self-contained, reversible (deleting them reverts to the inline verdict). The varying part (which loops are held/configured) stays in data (`LoopState` rows + `Loop.enabled`); the harness is the generic verdict.

## Notes
- Away mode: draft PR, no colleague-facing actions.
- Untracked burndown unit (no ticket) -> opened with `gh pr create --draft` through the no-orphan pre-push hook.
