### PR TITLE
fix(provision): scope overlay env to the DB import, never leak it into the loop

### DIFF
--- a/src/teatree/core/management/commands/db.py
+++ b/src/teatree/core/management/commands/db.py
@@ -1,7 +1,6 @@
 """Database operations: migrate, refresh, restore from CI, reset passwords, introspect."""
 
 import json
-import os
 import sys
 
 import typer
@@ -15,6 +14,7 @@ from teatree.core.intake.resolve import resolve_worktree
 from teatree.core.overlay_loader import get_overlay
 from teatree.types import SqlRow
 from teatree.utils.approval import ApprovalRefusedError
+from teatree.utils.env import patched_environ
 
 #: Leading SQL keywords allowed past the cheap pre-filter of ``db query``.
 #: This is a *best-effort* guard, not a proof of read-only-ness: leading-token
@@ -207,39 +207,36 @@ class Command(TyperCommand):
 
         self.stdout.write(f"Refreshing DB '{worktree.db_name}' (force={force})...")
 
-        # Set overlay env vars so pg tools can connect with the right credentials
-        env = {**os.environ, **overlay.provisioning.env_extra(worktree)}
-        env.pop("VIRTUAL_ENV", None)
-        os.environ.update(overlay.provisioning.env_extra(worktree))
+        # Overlay env (and the VIRTUAL_ENV drop) lets the host pg tools connect with the
+        # right credentials, scoped to the DB work so it never bleeds into the process.
+        with patched_environ(overlay.provisioning.env_extra(worktree), remove=("VIRTUAL_ENV",)):
+            # #955: --fresh-dump must force slow_import. The remote-dump branch
+            # in DjangoDbImporter.run() sits *after* the `if not slow_import:
+            # return False` guard (which itself follows the early DSLR return),
+            # so without this the flag silently degrades to "restore the stale
+            # local DSLR snapshot" instead of fetching a fresh remote dump.
+            success = overlay.provisioning.db_import(
+                worktree,
+                force=force,
+                slow_import=fresh_dump,
+                dslr_snapshot=dslr_snapshot,
+                dump_path=dump_path,
+                approve_remote_dump=fresh_dump,
+            )
+            if not success:
+                self.stderr.write(f"DB import failed for {worktree.db_name}. Check output above for details.")
+                raise SystemExit(1)
 
-        # Run the overlay's import logic
-        # #955: --fresh-dump must force slow_import. The remote-dump branch
-        # in DjangoDbImporter.run() sits *after* the `if not slow_import:
-        # return False` guard (which itself follows the early DSLR return),
-        # so without this the flag silently degrades to "restore the stale
-        # local DSLR snapshot" instead of fetching a fresh remote dump.
-        success = overlay.provisioning.db_import(
-            worktree,
-            force=force,
-            slow_import=fresh_dump,
-            dslr_snapshot=dslr_snapshot,
-            dump_path=dump_path,
-            approve_remote_dump=fresh_dump,
-        )
-        if not success:
-            self.stderr.write(f"DB import failed for {worktree.db_name}. Check output above for details.")
-            raise SystemExit(1)
+            # Run post-DB steps (migrations, collectstatic, etc.)
+            for step in overlay.provisioning.post_db_steps(worktree):
+                self.stdout.write(f"  Running post-DB step: {step.name}")
+                step.callable()
 
-        # Run post-DB steps (migrations, collectstatic, etc.)
-        for step in overlay.provisioning.post_db_steps(worktree):
-            self.stdout.write(f"  Running post-DB step: {step.name}")
-            step.callable()
-
-        # Reset passwords
-        reset_step = overlay.provisioning.reset_passwords_command(worktree)
-        if reset_step:  # pragma: no branch
-            self.stdout.write("  Resetting passwords...")
-            reset_step.callable()
+            # Reset passwords
+            reset_step = overlay.provisioning.reset_passwords_command(worktree)
+            if reset_step:  # pragma: no branch
+                self.stdout.write("  Resetting passwords...")
+                reset_step.callable()
 
         # FSM transition
         worktree.db_refresh()

--- a/src/teatree/core/runners/provision.py
+++ b/src/teatree/core/runners/provision.py
@@ -147,7 +147,8 @@ class WorktreeProvisioner(RunnerBase):
 
         created = self._create(clones_root, repo_name, ticket_dir, branch, adopt_path=adopt_path)
         if created is None:
-            worktree.delete()
+            if existing is None:
+                worktree.delete()  # roll back only the row we just created, never a reused one
             return None
 
         wt_path, clone_path = created

--- a/src/teatree/core/runners/ship.py
+++ b/src/teatree/core/runners/ship.py
@@ -60,21 +60,18 @@ def get_overlay_publish_gates() -> list[str]:
 
 
 def should_close_ticket(extra: Mapping[str, object] | None, *, setting_enabled: bool) -> bool:
-    """Resolve the effective close-on-merge disposition for a PR.
+    """Resolve the close-on-merge disposition from the pre-computed ``extra['more_prs_coming']`` flag.
 
-    The default is **close-on-merge**: a merged PR should systematically
-    close its referenced issue when the overlay's auto-close setting is
-    enabled. Suppression is the exception, applied only on an explicit
-    "more PRs are coming for this ticket/issue" signal — a declared
-    partial PR or an umbrella issue with remaining tracked scope, recorded
-    as ``extra['more_prs_coming']``. This preserves the umbrella/partial
-    protection (``feedback_partial_pr_never_closes_umbrella_issue``)
-    without defeating the setting for standalone single-target bug PRs.
+    Close-on-merge is the default: a merged PR keeps its ``Closes/Fixes #N``
+    keywords when the overlay's auto-close setting is enabled. This reads the
+    single ``extra['more_prs_coming']`` boolean and suppresses the close when
+    it is set — the caller is what detects a declared partial PR or a still-open
+    umbrella issue and records the flag
+    (``feedback_partial_pr_never_closes_umbrella_issue``).
 
-    Returns ``True`` when ``Closes/Fixes #N`` keywords must be kept so the
+    Returns ``True`` when the ``Closes/Fixes #N`` keywords must be kept so the
     platform auto-closes the issue on merge; ``False`` when they must be
-    rewritten to ``Relates to`` (setting disabled, or an explicit
-    follow-up opt-out is set).
+    rewritten to ``Relates to`` (setting disabled, or ``more_prs_coming`` set).
     """
     if not setting_enabled:
         return False

--- a/src/teatree/core/runners/worktree_provision.py
+++ b/src/teatree/core/runners/worktree_provision.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import time
 from pathlib import Path
 
@@ -13,6 +12,7 @@ from teatree.core.provision.provision_timebox import alert_provision_user, run_t
 from teatree.core.provision.step_runner import ProvisionReport, StepResult, run_provision_steps, run_step
 from teatree.core.runners.base import RunnerBase, RunnerResult
 from teatree.core.worktree.worktree_env import CACHE_DIRNAME, CACHE_FILENAME, worktree_pg_connection, write_env_cache
+from teatree.utils.env import patched_environ
 
 logger = logging.getLogger(__name__)
 
@@ -238,14 +238,15 @@ class WorktreeProvisionRunner(RunnerBase):
                 # loud on its own if the server is genuinely down (#3094).
                 pass
 
-        env = {**os.environ, **overlay.provisioning.env_extra(worktree)}
-        env.pop("VIRTUAL_ENV", None)
-        os.environ.update(env)
+        # The overlay env (and the VIRTUAL_ENV drop that keeps host pg tools off the
+        # loop's venv) is scoped to the import so it never bleeds into the next
+        # provision of the long-lived loop process.
         # #2244: a child blocked on its PIPE (no DSLR snapshot) must abort loud, never hang the provision.
-        imported = run_timeboxed_db_import(
-            lambda: overlay.provisioning.db_import(worktree, slow_import=self.slow_import),
-            repo=worktree.repo_path,
-        )
+        with patched_environ(overlay.provisioning.env_extra(worktree), remove=("VIRTUAL_ENV",)):
+            imported = run_timeboxed_db_import(
+                lambda: overlay.provisioning.db_import(worktree, slow_import=self.slow_import),
+                repo=worktree.repo_path,
+            )
         if imported:
             extra = worktree.extra or {}
             extra.pop("db_import_failures", None)

--- a/src/teatree/utils/env.py
+++ b/src/teatree/utils/env.py
@@ -1,0 +1,29 @@
+"""Scoped ``os.environ`` mutation that always restores the prior state."""
+
+import os
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+
+
+@contextmanager
+def patched_environ(overrides: Mapping[str, str], *, remove: tuple[str, ...] = ()) -> Iterator[None]:
+    """Apply *overrides* to ``os.environ`` (dropping *remove* keys) for the block, then restore.
+
+    Only the touched keys are saved and restored, so a concurrent, unrelated
+    ``os.environ`` change survives. A permanent ``os.environ`` mutation in the
+    long-lived loop process would bleed one worktree's overlay env into every
+    later provision; scoping it to the block is the fix.
+    """
+    touched = set(overrides) | set(remove)
+    saved = {key: os.environ.get(key) for key in touched}
+    try:
+        os.environ.update(overrides)
+        for key in remove:
+            os.environ.pop(key, None)
+        yield
+    finally:
+        for key, previous in saved.items():
+            if previous is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = previous

--- a/tests/teatree_core/management_commands/_overlays.py
+++ b/tests/teatree_core/management_commands/_overlays.py
@@ -359,6 +359,39 @@ class _RemotePathProvisioning(FullProvisioning):
             return importer.run(slow_import=slow_import, allow_remote_dump=approve_remote_dump)
 
 
+DB_ENV_PROBE = "T3_DB_REFRESH_ENV_BLEED_PROBE"
+
+
+class _EnvCaptureProvisioning(FullProvisioning):
+    """Records the ``os.environ`` state seen during ``db_import`` + reset step."""
+
+    def __init__(self) -> None:
+        self.seen: dict[str, object] = {}
+
+    def env_extra(self, worktree: Worktree) -> dict[str, str]:
+        return {DB_ENV_PROBE: "applied"}
+
+    def db_import(self, worktree: Worktree, **kwargs: object) -> bool:
+        self.seen["import_probe"] = os.environ.get(DB_ENV_PROBE)
+        self.seen["import_virtual_env"] = os.environ.get("VIRTUAL_ENV")
+        return True
+
+    def reset_passwords_command(self, worktree: Worktree) -> ProvisionStep | None:
+        def _capture() -> None:
+            self.seen["reset_probe"] = os.environ.get(DB_ENV_PROBE)
+
+        return ProvisionStep(name="reset-passwords", callable=_capture)
+
+
+class EnvCaptureOverlay(FullOverlay):
+    """Overlay recording the env visible during ``db refresh`` — proves no bleed."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.provisioning = _EnvCaptureProvisioning()
+        self.seen = self.provisioning.seen
+
+
 class _PreRunRuntime(FullRuntime):
     def pre_run_steps(self, worktree: Worktree, service: str) -> list[ProvisionStep]:
         def _log_step() -> None:
@@ -428,6 +461,9 @@ PRE_RUN_OVERLAY = "tests.teatree_core.management_commands._overlays.PreRunOverla
 
 
 REMOTE_PATH_RECORDING_OVERLAY = "tests.teatree_core.management_commands._overlays.RemotePathRecordingOverlay"
+
+
+ENV_CAPTURE_OVERLAY = "tests.teatree_core.management_commands._overlays.EnvCaptureOverlay"
 
 
 SETTINGS: dict[str, object] = {}

--- a/tests/teatree_core/management_commands/test_db.py
+++ b/tests/teatree_core/management_commands/test_db.py
@@ -1,6 +1,7 @@
 """Tests for the db management command."""
 
 import io
+import os
 import tempfile
 from pathlib import Path
 from typing import cast
@@ -15,6 +16,8 @@ from teatree.core.models import Ticket, Worktree
 from teatree.core.overlay_loader import get_overlay
 from teatree.utils.approval import ApprovalRefusedError
 from tests.teatree_core.management_commands._overlays import (
+    DB_ENV_PROBE,
+    ENV_CAPTURE_OVERLAY,
     FAILING_IMPORT_OVERLAY,
     FULL_OVERLAY,
     MINIMAL_OVERLAY,
@@ -78,6 +81,44 @@ class TestDbRefresh(TestCase):
             worktree.save()
 
             result = cast("str", call_command("db", "refresh", path=str(wt_dir)))
+
+            assert "refreshed" in result.lower()
+
+    @_patch_overlays(ENV_CAPTURE_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_overlay_env_scoped_to_db_work_not_leaked(self) -> None:
+        """`db refresh` must not leak the overlay env into the process.
+
+        The command used to `os.environ.update(env_extra)` and never restore it
+        (its `VIRTUAL_ENV` drop was a no-op). The env is now scoped to the DB
+        work — applied during db_import + reset, then restored.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            wt_dir = Path(tmp) / "test"
+            wt_dir.mkdir()
+            ticket = Ticket.objects.create(overlay="test")
+            worktree = Worktree.objects.create(
+                overlay="test",
+                ticket=ticket,
+                repo_path="/tmp/test",
+                branch="feature",
+                extra={"worktree_path": str(wt_dir)},
+            )
+            worktree.provision()
+            worktree.save()
+
+            with patch.dict(os.environ, {"VIRTUAL_ENV": "/loop/venv"}, clear=False):
+                os.environ.pop(DB_ENV_PROBE, None)
+                result = cast("str", call_command("db", "refresh", path=str(wt_dir)))
+
+                seen = get_overlay().seen
+                # Applied during the DB work (behaviour preserved), venv dropped …
+                assert seen["import_probe"] == "applied"
+                assert seen["import_virtual_env"] is None
+                assert seen["reset_probe"] == "applied"
+                # … restored afterward: no bleed into the process.
+                assert DB_ENV_PROBE not in os.environ
+                assert os.environ.get("VIRTUAL_ENV") == "/loop/venv"
 
             assert "refreshed" in result.lower()
 

--- a/tests/teatree_core/test_runner_db_import.py
+++ b/tests/teatree_core/test_runner_db_import.py
@@ -11,6 +11,7 @@ the runner aborts the provision (``ok=False``) before any provision or
 post-db step runs — pytest must never get a worktree with no test DB.
 """
 
+import os
 import threading
 from pathlib import Path
 from typing import Any
@@ -135,6 +136,81 @@ class TestRunnerSkipsDbImportWhenNoDbName(TestCase):
         assert overlay.db_import_calls == 1
         assert overlay.provision_steps_calls == 0
         assert overlay.post_db_steps_calls == 0
+
+
+_ENV_PROBE = "T3_WT_ENV_BLEED_PROBE"
+
+
+class _EnvCapturingProvisioning(_RecordingOverlayProvisioning):
+    """Records the ``os.environ`` state visible inside ``db_import``."""
+
+    def __init__(self, overlay: "_RecordingOverlay", captured: dict[str, str | None]) -> None:
+        super().__init__(overlay)
+        self._captured = captured
+
+    def env_extra(self, worktree: Worktree) -> dict[str, str]:
+        return {_ENV_PROBE: "applied"}
+
+    def db_import(self, worktree: Worktree, **kwargs: Any) -> bool:
+        self._overlay.db_import_calls += 1
+        self._captured["probe"] = os.environ.get(_ENV_PROBE)
+        self._captured["virtual_env"] = os.environ.get("VIRTUAL_ENV")
+        return self._overlay._db_import_result
+
+
+class _EnvCapturingOverlay(_RecordingOverlay):
+    def __init__(self) -> None:
+        super().__init__()
+        self.env_inside: dict[str, str | None] = {}
+        self.provisioning = _EnvCapturingProvisioning(self, self.env_inside)
+
+
+class TestRunnerScopesOverlayEnvToDbImport(TestCase):
+    """The overlay env applied for the DB import must not bleed into the loop process.
+
+    ``_run_db_import`` used to ``os.environ.update(env_extra)`` and never restore
+    it (and its ``VIRTUAL_ENV`` drop was a no-op), so one worktree's overlay env
+    leaked into every subsequent provision of the long-lived loop process. The
+    env is now scoped to the import and restored afterward.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _tmp_workspace(self, tmp_path: Path) -> None:
+        self.wt_path = tmp_path / "worktree"
+        self.wt_path.mkdir()
+
+    def _make_worktree(self) -> Worktree:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/i/envbleed")
+        return Worktree.objects.create(
+            overlay="test",
+            ticket=ticket,
+            repo_path="backend",
+            branch="feature",
+            db_name="wt_envbleed",
+            extra={"worktree_path": str(self.wt_path)},
+        )
+
+    def test_overlay_env_visible_during_import_and_restored_after(self) -> None:
+        worktree = self._make_worktree()
+        overlay = _EnvCapturingOverlay()
+
+        with (
+            patch("teatree.core.runners.worktree_provision._setup_worktree_dir", return_value=None),
+            patch("teatree.utils.db.db_exists", return_value=False),
+            patch.dict(os.environ, {"VIRTUAL_ENV": "/loop/venv"}, clear=False),
+        ):
+            os.environ.pop(_ENV_PROBE, None)
+            result = WorktreeProvisionRunner(worktree, overlay=overlay).run()
+
+            # The env WAS applied for the import (behaviour preserved) with the
+            # loop's venv dropped so host pg tools ignore it …
+            assert overlay.env_inside["probe"] == "applied"
+            assert overlay.env_inside["virtual_env"] is None
+            # … and fully restored afterward: no bleed into the process.
+            assert _ENV_PROBE not in os.environ
+            assert os.environ.get("VIRTUAL_ENV") == "/loop/venv"
+
+        assert result.ok is True, result.detail
 
 
 class _BlockingDbImportOverlayProvisioning(_RecordingOverlayProvisioning):

--- a/tests/teatree_core/test_runners_provision.py
+++ b/tests/teatree_core/test_runners_provision.py
@@ -140,6 +140,33 @@ class TestWorktreeProvisioner(TestCase):
         assert "repo-a" in result.detail
         assert Worktree.objects.filter(ticket=ticket, repo_path="repo-a").count() == 0
 
+    def test_reused_row_survives_when_worktree_add_fails(self) -> None:
+        # A prior partial provision left a Worktree row with NO worktree_path.
+        # A subsequent failed `git worktree add` must NOT delete that reused row
+        # — only a JUST-created row is rolled back (the docstring contract).
+        repo_dir = self.workspace / "repo-a"
+        repo_dir.mkdir()
+        (repo_dir / ".git").mkdir()
+        ticket = self._scoped_ticket(repos=["repo-a"], branch="ac-repo-a-77-x")
+        reused = Worktree.objects.create(
+            ticket=ticket,
+            overlay="test",
+            repo_path="repo-a",
+            branch="ac-repo-a-77-x",
+        )
+
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            self._patch_workspace_dir(),
+            patch("teatree.core.runners.provision.git.worktree_add", return_value=False),
+            patch("teatree.core.runners.provision.git.pull_ff_only", return_value=True),
+        ):
+            result = WorktreeProvisioner(ticket).run()
+
+        assert result.ok is False
+        assert "repo-a" in result.detail
+        assert Worktree.objects.filter(pk=reused.pk).exists()
+
     def test_returns_failure_when_no_clone_found_anywhere(self) -> None:
         not_a_repo = self.workspace / "no-git"
         not_a_repo.mkdir()

--- a/tests/teatree_utils/test_env.py
+++ b/tests/teatree_utils/test_env.py
@@ -1,0 +1,49 @@
+"""Tests for ``teatree.utils.env.patched_environ`` — scoped os.environ mutation."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from teatree.utils.env import patched_environ
+
+_PROBE = "T3_PATCHED_ENVIRON_PROBE"
+
+
+def test_override_applied_inside_and_restored_after() -> None:
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop(_PROBE, None)
+        with patched_environ({_PROBE: "inside"}):
+            assert os.environ[_PROBE] == "inside"
+        assert _PROBE not in os.environ
+
+
+def test_pre_existing_value_is_restored_not_dropped() -> None:
+    with patch.dict(os.environ, {_PROBE: "original"}, clear=False):
+        with patched_environ({_PROBE: "temporary"}):
+            assert os.environ[_PROBE] == "temporary"
+        assert os.environ[_PROBE] == "original"
+
+
+def test_removed_key_is_dropped_inside_and_restored_after() -> None:
+    with patch.dict(os.environ, {_PROBE: "present"}, clear=False):
+        with patched_environ({}, remove=(_PROBE,)):
+            assert _PROBE not in os.environ
+        assert os.environ[_PROBE] == "present"
+
+
+def test_state_restored_even_when_block_raises() -> None:
+    boom = "boom"
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop(_PROBE, None)
+        with pytest.raises(RuntimeError), patched_environ({_PROBE: "inside"}):
+            raise RuntimeError(boom)
+        assert _PROBE not in os.environ
+
+
+def test_unrelated_key_survives() -> None:
+    other = "T3_PATCHED_ENVIRON_UNRELATED"
+    with patch.dict(os.environ, {other: "kept"}, clear=False):
+        with patched_environ({_PROBE: "inside"}, remove=("VIRTUAL_ENV",)):
+            assert os.environ[other] == "kept"
+        assert os.environ[other] == "kept"


### PR DESCRIPTION
## Summary

The worktree provision runner (`_run_db_import`) and the `db refresh` command
applied the overlay's `env_extra` to `os.environ` with `os.environ.update(...)`
and never restored it. In the long-lived loop process that provisions many
worktrees, one worktree's overlay env bled into every subsequent operation. The
`VIRTUAL_ENV` drop was also a latent no-op — `dict.update` never deletes a key
absent from the payload, so the drop never actually took effect.

The fix adds `teatree.utils.env.patched_environ` — a scoped per-key save/restore
context manager generalising the existing `notify.py` pattern — and wraps the DB
work in it at both sites. The overlay env is applied for the import (host pg
tools read it via `pg_env`) and restored afterward; the intended `VIRTUAL_ENV`
drop now actually takes effect for the import subprocess.

Two same-subsystem nits are bundled:

- `_provision_repo` deleted a **reused** `Worktree` row on a failed `git worktree
  add`, contradicting its docstring ("the just-created row is rolled back"); it
  now rolls back only a row it created.
- `should_close_ticket`'s docstring overstated its logic; tightened to reflect it
  reads only the pre-computed `extra['more_prs_coming']` flag.

## Tests (anti-vacuous, RED→GREEN)

- `tests/teatree_utils/test_env.py` — `patched_environ` apply / restore /
  remove-key / restore-on-raise contract.
- `test_runner_db_import.py::TestRunnerScopesOverlayEnvToDbImport` — overlay env
  visible during the import with `VIRTUAL_ENV` dropped, fully restored after
  (RED pre-fix: `VIRTUAL_ENV` still present + probe leaked past `run()`).
- `test_db.py::TestDbRefresh::test_overlay_env_scoped_to_db_work_not_leaked` —
  the same guarantee for `db refresh`.
- `test_runners_provision.py::...::test_reused_row_survives_when_worktree_add_fails`
  — a reused row survives a failed `git worktree add` (RED pre-fix: the reused
  row was deleted).

Each behavioural test was confirmed RED against the pre-fix code (revert the fix
→ red, restore → green).

## Architecture pre-check

**1. BLUEPRINT § alignment** — § 6 Overlay System / workspace provisioning; no
contract change, a leak fix behind the existing `overlay.provisioning` seam.

**2. FSM phase boundaries** — n/a. No `Worktree`/`Ticket` state transition changes
(the `db refresh` FSM `db_refresh()` call is unchanged and now runs after the env
is restored).

**3. Extension-point contracts** — none changed. `OverlayProvisioning.env_extra`
/ `db_import` signatures are untouched; the env is applied around the existing
`db_import` call, not threaded through it.

**4. Component boundaries** — new leaf helper in `teatree/utils/env.py` (generic
`os.environ` scoping, no Django/overlay coupling); the two call-site edits stay in
`core/runners/` and `core/management/commands/`.

**5. Dependency direction** — `core.runners` / `core.management.commands` →
`teatree.utils.env` (leaf). No backwards edge; `tach check` green.

**6. Test surface** — `patched_environ` contract test + one env-scoping regression
per call site + the provision row-deletion regression (all listed above).

**7. Resilience invariants** — the only external effect is the `os.environ`
mutation; it is now idempotent-safe (per-key save/restore, restored even on an
exception via `finally`). No new network/DB writes.

**8. Identity/key normalization** — n/a.

**9. Behavior preservation** — the overlay env is still applied for the import
(host pg tools). Post-db/provision steps run in containers (`docker compose_run`)
or with explicit `env=`, so they never relied on the ambient host mutation —
scoping to the import is behaviour-preserving. No must-block test inverted.

**10. Removability / harness-vs-data** — `patched_environ` is a self-contained
helper; deleting it touches only its two call sites. Pure harness (a context
manager), no per-item policy to move into data.

## Open questions & assumptions

- Env scope = the DB import call. Verified the overlay's post-db/provision steps
  are container-based or pass `env=` explicitly, so they never needed the ambient
  host mutation.
- The `except Exception` at `worktree_provision.py:279` "missing `# noqa: BLE001`"
  nit is a **no-op**: ruff's BLE001 exempts `logger.exception` handlers (line 279),
  so adding the noqa would trip RUF100 (unused-noqa). The sibling at line 63 carries
  the noqa only because it uses `logger.debug`. Left unchanged — verified.
