### PR TITLE
refactor(ticket): split the Ticket god-object into facets + index ticket-number resolves

### DIFF
--- a/src/teatree/core/intake/resolve.py
+++ b/src/teatree/core/intake/resolve.py
@@ -150,8 +150,12 @@ def _ticket_by_number(number: str, *, overlay: str | None = None) -> Ticket | No
 
     ``ticket_number`` is a DERIVED, non-unique key (trailing digits of
     ``issue_url``, else the pk), so two tickets on different repos/forges can
-    share one. The match is done in Python over real tickets — synthetic
-    ``auto:`` rows are excluded so a hint never resolves back to a placeholder.
+    share one. The forge-number branch is served by the indexed ``issue_number``
+    column (denormalized on ``save``); the pk-fallback branch — a real ticket
+    whose ``issue_url`` carries no forge number, so ``ticket_number`` degrades to
+    ``str(pk)`` — is matched by pk. Both exclude synthetic ``auto:`` rows so a
+    hint never resolves back to a placeholder. Together they reproduce the old
+    O(all tickets) Python scan as an indexed lookup.
 
     When *overlay* is known (inferred from the resolving repo's remote) the
     candidates are narrowed to that overlay first, so a same-number ticket in a
@@ -160,11 +164,13 @@ def _ticket_by_number(number: str, *, overlay: str | None = None) -> Ticket | No
     arbitrary ``.first()`` that would cross-attach the worktree to the wrong
     ticket.
     """
-    matches = [
-        ticket
-        for ticket in Ticket.objects.exclude(issue_url="").exclude(issue_url__startswith="auto:")
-        if ticket.ticket_number == number
-    ]
+    real = Ticket.objects.exclude(issue_url="").exclude(issue_url__startswith="auto:")
+    matches = list(real.filter(issue_number=number))
+    if number.isdigit():
+        # ``issue_number`` is blank exactly when ``ticket_number`` falls back to
+        # ``str(pk)``, so the pk lookup is the fallback branch (never double-counts
+        # a row already matched above, whose ``issue_number`` is non-blank).
+        matches += list(real.filter(issue_number="", pk=int(number)))
     if overlay:
         scoped = [ticket for ticket in matches if ticket.overlay == overlay]
         if scoped:

--- a/src/teatree/core/migrations/0004_ticket_issue_number.py
+++ b/src/teatree/core/migrations/0004_ticket_issue_number.py
@@ -1,0 +1,37 @@
+from django.db import migrations, models
+
+from teatree.core.models.ticket_number import derive_issue_number
+
+
+def _backfill_issue_number(apps, schema_editor):
+    """Denormalize each existing ticket's forge issue number into the new column.
+
+    Mirrors ``Ticket.save`` exactly (``derive_issue_number(issue_url)``) so the
+    backfilled value equals what a subsequent save would write — the indexed
+    ``_ticket_by_number`` lookup then agrees with the ``ticket_number`` property
+    for every pre-existing row. Rows with a blank ``issue_url`` already hold the
+    correct ``""`` default and are skipped.
+    """
+    ticket_model = apps.get_model("core", "Ticket")
+    pending = []
+    for ticket in ticket_model.objects.exclude(issue_url="").only("pk", "issue_url", "issue_number"):
+        derived = derive_issue_number(ticket.issue_url)
+        if ticket.issue_number != derived:
+            ticket.issue_number = derived
+            pending.append(ticket)
+    ticket_model.objects.bulk_update(pending, ["issue_number"], batch_size=500)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0003_implementedissuemarker_claim_ref_sha"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="ticket",
+            name="issue_number",
+            field=models.CharField(blank=True, db_index=True, default="", max_length=32),
+        ),
+        migrations.RunPython(_backfill_issue_number, migrations.RunPython.noop),
+    ]

--- a/src/teatree/core/migrations/max_migration.txt
+++ b/src/teatree/core/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0003_implementedissuemarker_claim_ref_sha
+0004_ticket_issue_number

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -1,21 +1,19 @@
 import logging
-import re
 from typing import TYPE_CHECKING, ClassVar
 
-from django.apps import apps
-from django.db import models, transaction
-from django.utils import timezone
-from django_fsm import FSMField, TransitionNotAllowed, transition
+from django.db import models
+from django_fsm import FSMField, transition
 
-from teatree.config import Mode, get_effective_settings
 from teatree.core.managers import TicketManager
-from teatree.core.modelkit.gate_registry import get_gate, get_resolver
-from teatree.core.modelkit.phases import normalize_phase
+from teatree.core.modelkit.gate_registry import get_gate
 from teatree.core.modelkit.review_state import ReviewState
-from teatree.core.models.errors import DirtyWorktreeError, InvalidTransitionError
+from teatree.core.models.ticket_evidence import TicketEvidenceModel
 from teatree.core.models.ticket_ledger import retire_phase_ledger
-from teatree.core.models.ticket_worktree_checks import collect_dirty_worktree_paths, worktree_has_commits_ahead
-from teatree.core.models.types import validated_ticket_extra
+from teatree.core.models.ticket_number import derive_issue_number
+from teatree.core.models.ticket_overlay import TicketOverlayModel
+from teatree.core.models.ticket_phase_sessions import TicketPhaseSessionModel
+from teatree.core.models.ticket_scheduling import TicketSchedulingModel
+from teatree.core.models.ticket_status import TicketStatusModel
 from teatree.utils.url_slug import repo_namespaced_key as compute_repo_namespaced_key
 
 logger = logging.getLogger(__name__)
@@ -25,25 +23,23 @@ def _check_plan_artifact(ticket: object) -> bool:
     return bool(get_gate("plan_artifact")(ticket))
 
 
-def _auto_ship_enabled() -> bool:
-    return get_effective_settings().mode == Mode.AUTO
-
-
 if TYPE_CHECKING:
-    from teatree.core.models.session import Session
     from teatree.core.models.task import Task
-    from teatree.core.models.ticket_artifacts import PortResolver, TicketArtifacts
-    from teatree.core.models.types import (
-        AntiVacuityAttestation,
-        ReviewContext,
-        ReviewSkillRun,
-        TicketExtra,
-        TicketSiblingFields,
-    )
 
 
-# ast-grep-ignore: ac-django-no-complexity-suppressions
-class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method count reflects the lifecycle state graph, not poor encapsulation.
+# Composed via Django abstract-model facets (the framework's own model-decomposition
+# pattern) rather than composed attributes: the facets carry cohesive instance
+# behaviour while every method stays reachable as ``ticket.foo()``, so the large
+# consumer-facing API and the FSM state graph are preserved with zero call-site
+# churn. The concrete class owns the fields, the state graph, and ``save``.
+class Ticket(
+    TicketOverlayModel,
+    TicketPhaseSessionModel,
+    TicketSchedulingModel,
+    TicketEvidenceModel,
+    TicketStatusModel,
+    models.Model,
+):
     class State(models.TextChoices):
         NOT_STARTED = "not_started", "Not started"
         SCOPED = "scoped", "Scoped"
@@ -140,6 +136,11 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
     # does. Blank when `issue_url` is a PR/MR reference, a bare number, or
     # any other non-issue shape — see `repo_namespaced_key_from_path`.
     repo_namespaced_key = models.CharField(max_length=300, blank=True, default="", db_index=True)
+    # Denormalized forge issue number (trailing digits of `issue_url`, blank when
+    # there is none), kept in sync by ``save`` — the indexed backing that turns
+    # ``_ticket_by_number`` from an O(all tickets) Python scan into an O(1)
+    # lookup. The ``ticket_number`` property composes it with the pk fallback.
+    issue_number = models.CharField(max_length=32, blank=True, default="", db_index=True)
 
     objects = TicketManager()
 
@@ -166,67 +167,8 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
             self.overlay = self._infer_overlay()
         if not self.repo_namespaced_key and self.issue_url:
             self.repo_namespaced_key = compute_repo_namespaced_key(self.issue_url)
+        self.issue_number = derive_issue_number(self.issue_url)
         super().save(*args, **kwargs)  # type: ignore[arg-type]
-
-    def _infer_overlay(self) -> str:
-        """Derive overlay name from ``issue_url`` (see ``infer_overlay_for_url``)."""
-        return str(get_resolver("infer_overlay_for_url")(self.issue_url))
-
-    def apply_inferred_overlay(self, inferred: str) -> bool:
-        """Persist ``inferred`` overlay on a conclusive change (True when changed).
-
-        A blank inference never blanks out a manually-set attribution.
-        """
-        if not inferred or inferred == self.overlay:
-            return False
-        self.overlay = inferred
-        Ticket.objects.filter(pk=self.pk).update(overlay=inferred)
-        return True
-
-    def reconcile_overlay(self) -> bool:
-        """Re-infer ``overlay`` from ``issue_url`` and persist a correction."""
-        return self.apply_inferred_overlay(self._infer_overlay())
-
-    def has_dispatchable_overlay(self) -> bool:
-        """False only for a non-empty overlay that no longer resolves (#1959 poison-pill)."""
-        return not (self.overlay and get_resolver("resolve_overlay_name")(self.overlay) is None)
-
-    def has_active_work(self) -> bool:
-        """True iff this ticket has an open session or an active (pending/claimed) task.
-
-        The single owner of the ticket-liveness rule the reapers and the relocate
-        command consult — a busy ticket must never be torn down.
-        """
-        if self.sessions.filter(ended_at__isnull=True).exists():  # type: ignore[attr-defined]  # Django reverse FK
-            return True
-        # apps.get_model, not a direct import: task.py imports ticket.py at module scope (real cycle).
-        task_model = apps.get_model("core", "Task")
-        return self.tasks.filter(status__in=task_model.Status.active()).exists()  # type: ignore[attr-defined]  # Django reverse FK
-
-    def mark_remote_missing(self) -> None:
-        """Targeted UPDATE to set remote_missing; skips the FSM and save() overhead (#1875)."""
-        Ticket.objects.filter(pk=self.pk).update(remote_missing=True)
-        self.remote_missing = True
-
-    @property
-    def is_terminal(self) -> bool:
-        """True when the ticket is in a genuinely terminal/abandoned state (SHIPPED/MERGED/DELIVERED/IGNORED)."""
-        return self.state in self._TERMINAL_STATES
-
-    def may_expedite(self) -> bool:
-        """True iff this ticket may carry a human-authorized PENDING-checks waiver (PR-07).
-
-        The flag alone grants NO merge bypass — it only makes the per-CLEAR,
-        SHA-bound waiver ISSUABLE (§17.4.3 / ``MergeClear.expedite_pending_waived_by``).
-        """
-        return self.expedited
-
-    @property
-    def ticket_number(self) -> str:
-        match = re.search(r"(\d+)$", self.issue_url)
-        if match and match.group(1) != "0":
-            return match.group(1)
-        return str(self.pk)
 
     @transition(field=state, source=State.NOT_STARTED, target=State.SCOPED)
     def scope(
@@ -361,210 +303,6 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         must NOT complete active reviewing tasks — those paths skip the
         attestation that would justify it.
         """
-
-    def aggregate_phase_records(self) -> tuple[list[str], dict[str, dict[str, str]]]:
-        """Union the phase records across all of this ticket's sessions (#694).
-
-        Returns ``(visited_phases, phase_visits)`` merged across
-        ``self.sessions`` in creation order. ``visited_phases`` is a
-        de-duplicated list; ``phase_visits`` keeps the first recorded
-        ``agent_id`` per phase (earliest session wins) as a deterministic
-        audit trail of who recorded each phase — it is not consumed for
-        gate enforcement. The shipping gate consumes the ``visited_phases``
-        union because FSM-advancing ``visit-phase`` forks fresh sessions by
-        design — the required phases are legitimately scattered, and the
-        single source of truth is the ticket's lifecycle, not one session.
-        """
-        visited: list[str] = []
-        visits: dict[str, dict[str, str]] = {}
-        for session in self.sessions.order_by("pk"):  # ty: ignore[unresolved-attribute]
-            for phase in session.visited_phases or []:
-                if phase not in visited:
-                    visited.append(phase)
-            for phase, record in (session.phase_visits or {}).items():
-                if phase not in visits:
-                    visits[phase] = record
-        return visited, visits
-
-    def resolve_phase_session(self, *, agent_id: str = "loop") -> "Session":
-        """The single canonical phase-visit session for the attestation writers (#801).
-
-        Which ``Session`` a phase visit lands on was decided four
-        inconsistent ways (``ensure_session`` earliest+locked; the
-        ``lifecycle visit-phase`` CLI, the ``tasks`` phase-handoff
-        command each ``order_by("-pk")`` *latest* with an unlocked raw
-        blank-``agent_id`` create on miss; the ``pr`` gate *latest* as
-        its gate object). A CLI visit then wrote the *latest* session
-        while dispatch reused the *earliest*, splitting attestation
-        across sessions (#801). The three attestation writers now route
-        here; the read-only gate uses :meth:`find_phase_session`.
-
-        Policy: the **earliest** session (``order_by("pk")`` — the one
-        dispatch's attestation uses, so the ledger never splits),
-        selected/created inside one ``transaction.atomic()`` with the
-        ticket row ``select_for_update``-locked (dispatch callers have
-        no surrounding transaction, so concurrent loop ticks for the
-        same ``issue_url`` must serialise). Always returns a Session —
-        on miss it creates one with a guaranteed **non-blank**
-        ``agent_id`` (never the raw blank-``agent_id`` create that left
-        the ``phase_visits`` audit trail unattributed).
-        """
-        from teatree.core.models.session import Session  # noqa: PLC0415
-        from teatree.core.models.ticket import Ticket  # noqa: PLC0415
-
-        with transaction.atomic():
-            Ticket.objects.select_for_update().filter(pk=self.pk).first()
-            existing = self.sessions.order_by("pk").first()  # ty: ignore[unresolved-attribute]
-            if existing is not None:
-                return existing
-            return Session.objects.create(ticket=self, agent_id=agent_id.strip() or "loop")
-
-    def find_phase_session(self) -> "Session | None":
-        """Read-only canonical phase-visit session for the gate (#801).
-
-        Same earliest + ticket-row-locked selection policy as
-        :meth:`resolve_phase_session` but **never creates** — a gate
-        check must not have the side effect of minting a session.
-        """
-        from teatree.core.models.ticket import Ticket  # noqa: PLC0415
-
-        with transaction.atomic():
-            Ticket.objects.select_for_update().filter(pk=self.pk).first()
-            return self.sessions.order_by("pk").first()  # ty: ignore[unresolved-attribute]
-
-    def ensure_session(self, *, agent_id: str = "loop") -> "Session":
-        """Durable phase-attestation Session for this ticket (#748).
-
-        Thin alias of the canonical :meth:`resolve_phase_session` (#801
-        SSOT) — kept for its existing callers / API.
-        """
-        return self.resolve_phase_session(agent_id=agent_id)
-
-    def has_shippable_diff(self) -> bool:
-        """Return True iff at least one worktree has commits ahead of its base branch.
-
-        Used by ``review()`` to skip auto-scheduling shipping when there is
-        nothing to ship — typically meta-tracker tickets whose work already
-        landed via sibling PRs. Manual ``schedule_shipping()`` callers are not
-        gated.
-        """
-        worktree_model = apps.get_model("core", "Worktree")
-        return any(worktree_has_commits_ahead(wt) for wt in worktree_model.objects.filter(ticket=self))
-
-    def artifacts(self, *, port_resolver: "PortResolver | None" = None) -> "TicketArtifacts":
-        """Read-only artifact-discovery aggregation (#273) — see ``ticket_artifacts``."""
-        from teatree.core.models.ticket_artifacts import collect_ticket_artifacts  # noqa: PLC0415
-
-        return collect_ticket_artifacts(self, port_resolver=port_resolver)
-
-    def schedule_planning(self, *, parent_task: "Task | None" = None) -> "Task":
-        """Create a fresh headless planning task after provisioning completes."""
-        return self._schedule_headless(
-            "planning", "Auto-scheduled planning — produce a plan before coding", parent_task, require_author=True
-        )
-
-    def schedule_coding(self, *, parent_task: "Task | None" = None) -> "Task":
-        """Create a fresh headless coding task after planning completes.
-
-        Gated by ``plan_currency`` (SELFCATCH-3) on the normal author PLANNED→CODED flow
-        (the same gate ``code()`` runs): no coding task for a thin/legacy or seam-stale
-        plan. NO-OP unless ``require_plan_adequacy`` is on; synthetic corrective
-        re-entries that mint a coding task directly are exempt (they carry no plan).
-        """
-        return self._schedule_headless(
-            "coding",
-            "Auto-scheduled coding — implement the ticket",
-            parent_task,
-            require_author=True,
-            gate="plan_currency",
-        )
-
-    def _schedule_headless(
-        self,
-        phase: str,
-        reason: str,
-        parent_task: "Task | None",
-        *,
-        require_author: bool = False,
-        gate: str | None = None,
-    ) -> "Task":
-        """Shared fresh-session headless scheduler for the auto-FSM phase tasks.
-
-        Optionally enforces ``role=author`` and runs an FSM ``gate`` (the
-        plan-currency leak-close), then mints the ``phase`` Session + headless Task.
-        The session ``agent_id`` is the ``phase`` (``reviewing`` uses ``review``).
-        """
-        from teatree.core.models.session import Session  # noqa: PLC0415
-        from teatree.core.models.task import Task  # noqa: PLC0415
-
-        if require_author and self.role != self.Role.AUTHOR:
-            msg = f"schedule_{phase} requires role=author (got role={self.role!r})"
-            raise InvalidTransitionError(msg)
-        if gate is not None:
-            get_gate(gate)(self)
-        session = Session.objects.create(
-            ticket=self, agent_id="review" if normalize_phase(phase) == "reviewing" else phase
-        )
-        return Task.objects.create(
-            ticket=self,
-            session=session,
-            phase=phase,
-            execution_target=Task.ExecutionTarget.HEADLESS,
-            execution_reason=reason,
-            parent_task=parent_task,
-        )
-
-    def schedule_testing(self, *, parent_task: "Task | None" = None) -> "Task":
-        """Create a fresh headless testing task after coding completes."""
-        return self._schedule_headless("testing", "Auto-scheduled testing — run + QA the coding work", parent_task)
-
-    def schedule_review(self, *, parent_task: "Task | None" = None) -> "Task":
-        """Create a fresh headless review+retro task (new session for bias-free evaluation)."""
-        return self._schedule_headless("reviewing", "Auto-scheduled review + retro — fresh agent, no bias", parent_task)
-
-    def schedule_review_in_session(self, session: "Session", *, parent_task: "Task | None" = None) -> "Task":
-        """Create a review task within an existing session (sub-agent, not a new session)."""
-        from teatree.core.models.task import Task  # noqa: PLC0415
-
-        return Task.objects.create(
-            ticket=self,
-            session=session,
-            phase="reviewing",
-            execution_target=Task.ExecutionTarget.HEADLESS,
-            execution_reason="Auto-review before shipping — sub-agent in current session",
-            parent_task=parent_task,
-        )
-
-    def schedule_shipping(self, *, parent_task: "Task | None" = None) -> "Task":
-        """Create an INTERACTIVE shipping task; approval gating rides the reason.
-
-        Shipping is a loop-dispatched phase (``(author, shipping)`` →
-        ``t3:shipper``), so it runs as an in-session sub-agent
-        (subscription-covered), never a metered detached headless-SDK run — regardless of
-        auto mode. Auto mode no longer changes the execution *target*; it only
-        changes the *approval posture* the in-session shipper reads from
-        ``execution_reason`` (auto = push without waiting; otherwise = gate for
-        user approval first).
-        """
-        from teatree.core.models.session import Session  # noqa: PLC0415
-        from teatree.core.models.task import Task  # noqa: PLC0415
-
-        session = Session.objects.create(ticket=self, agent_id="shipping")
-        if _auto_ship_enabled():
-            reason = "Auto-scheduled shipping — auto mode, push will proceed without waiting for approval"
-        else:
-            reason = (
-                "Auto-scheduled shipping — gated for user approval "
-                "(set mode = auto via config_setting set, or T3_MODE=auto, to skip)"
-            )
-        return Task.objects.create(
-            ticket=self,
-            session=session,
-            phase="shipping",
-            execution_target=Task.ExecutionTarget.INTERACTIVE,
-            execution_reason=reason,
-            parent_task=parent_task,
-        )
 
     @transition(
         field=state,
@@ -809,211 +547,3 @@ class Ticket(models.Model):  # noqa: PLR0904 — FSM transition surface; method 
         extra = self._extra()
         extra["ignored_from"] = self.state
         self.extra = extra
-
-    def unignore(self) -> None:
-        if self.state != self.State.IGNORED:
-            msg = f"Can't unignore from state '{self.state}'"
-            raise TransitionNotAllowed(msg)
-        extra = self._extra()
-        previous = extra.pop("ignored_from", self.State.NOT_STARTED)
-        self.extra = extra
-        self.state = str(previous)
-
-    def _cancel_pending_tasks(self) -> None:
-        """Fail all pending/claimed tasks when reworking."""
-        from teatree.core.models.task import Task  # noqa: PLC0415
-
-        for task in self.tasks.filter(status__in=Task.Status.active()):  # type: ignore[attr-defined]  # Django reverse FK
-            task.fail()
-
-    def _refuse_if_worktree_dirty(self, phase: str) -> None:
-        """Preflight gate (#884): refuse the transition if a worktree is tracked-dirty.
-
-        Run at the top of the ``code``/``test``/``review``/``ship``
-        transition bodies. Dirty-collection rule and the no-auto-stash/
-        lease-reaper rationale live on :func:`collect_dirty_worktree_paths`
-        (#1983 LOC-ratchet split). On dirty: a loud :class:`DirtyWorktreeError`
-        names the dirty worktree(s) and the transition does not advance —
-        every production caller wraps the transition body in an outer
-        ``transaction.atomic``, so the raise rolls that whole atomic back.
-        """
-        dirty = collect_dirty_worktree_paths(self)
-        if not dirty:
-            return
-        joined = ", ".join(dirty)
-        msg = (
-            f"Refusing the '{phase}' transition for ticket {self} — uncommitted tracked "
-            f"changes in worktree(s): {joined}. Commit or discard them, then retry. "
-            f"(No auto-stash: teatree worktrees share one .git, so a stash is repo-global "
-            f"and could clobber another branch — #806.)"
-        )
-        raise DirtyWorktreeError(msg)
-
-    def _consume_pending_phase_tasks(self, phase: str) -> None:
-        """Mark non-terminal tasks for ``phase`` as COMPLETED.
-
-        FSM transitions advance ticket state via two paths: the task-driven
-        chain (``Task.complete()`` → ``_advance_ticket()`` → transition body),
-        and direct CLI/API calls (e.g. ``pr.py`` calling ``ticket.ship()``).
-        On the task-driven path the task is already COMPLETED before this runs
-        — the filter is empty and this is a no-op. On the direct path the
-        previously-scheduled phase task is orphaned in PENDING/CLAIMED and
-        would be picked up later as a zombie session; consume it now.
-
-        Matches any accepted phase spelling via ``pending_in_phase`` (#769,
-        the consume-side mirror of #757's ``completed_in_phase``): a raw
-        ``phase=phase`` filter missed a short-verb ``review`` task stored
-        by the unnormalized ``tasks create <id> review`` path, leaving it
-        as a zombie session.
-        """
-        from teatree.core.models.task import Task  # noqa: PLC0415
-
-        Task.objects.pending_in_phase(phase).filter(ticket=self).update(
-            status=Task.Status.COMPLETED,
-            claimed_at=None,
-            claimed_by="",
-            lease_expires_at=None,
-            heartbeat_at=None,
-        )
-
-    def _extra(self) -> "TicketExtra":
-        return validated_ticket_extra(self.extra)
-
-    def merge_extra(
-        self,
-        *,
-        set_keys: "TicketExtra | None" = None,
-        pop_keys: "list[str] | None" = None,
-        also_set: "TicketSiblingFields | None" = None,
-    ) -> None:
-        """Canonical locked read-modify-write of ``extra`` (#800 N3).
-
-        Several writers mutate shared ``extra`` JSON — ``pr_urls`` (ship
-        worker), ``visual_qa`` (the pre-push gate), ``reviewed_sha`` /
-        ``last_review_state`` (reviewer path). Done as an unlocked
-        ``self.extra = …; self.save(update_fields=["extra"])`` they
-        last-writer-clobber each other's key (the Haki-Benita
-        lost-update). This is the single primitive every ``extra``
-        mutation routes through, with the same shape as
-        ``Session.visit_phase``: the RMW runs in ``transaction.atomic()``
-        with the row ``select_for_update``-locked and **re-read from the
-        locked row** (not the possibly-stale in-memory instance), so a
-        concurrent writer's key survives the merge instead of being
-        overwritten. The locked re-read is what makes it correct on the
-        production SQLite backend (where ``select_for_update`` is a no-op
-        but the #804 ``BEGIN IMMEDIATE`` serialises the writers, so the
-        re-read sees the other writer's committed key).
-
-        ``also_set`` writes sibling **model fields** (``state``,
-        ``repos``, ``variant``, …) in the SAME locked ``UPDATE`` as
-        ``extra``. The tracker-sync paths legitimately co-write
-        ``extra`` with ``state``/``repos`` in one ``save`` — routing
-        them through here keeps that write atomic (no split into two
-        non-atomic writes) while still going through the single locked
-        primitive, so the SSOT holds with zero unlocked ``extra`` RMW
-        anywhere.
-        """
-        with transaction.atomic():
-            locked = type(self).objects.select_for_update().get(pk=self.pk)
-            merged = dict(locked.extra or {})
-            if set_keys:
-                merged.update(set_keys)
-            for key in pop_keys or []:
-                merged.pop(key, None)
-            self.extra = merged
-            for field, value in (also_set or {}).items():
-                setattr(self, field, value)
-            type(self).objects.filter(pk=self.pk).update(extra=merged, **(also_set or {}))
-
-    def record_review_skill_run(self, skill: str) -> None:
-        """Stamp durable evidence that the deep-review ``skill`` ran (#1539).
-
-        Written through the canonical locked ``merge_extra`` primitive so a
-        concurrent ``extra`` writer's key survives. The timestamp is UTC ISO
-        so the reviewing-phase gate's audit trail is timezone-unambiguous.
-        """
-        run: ReviewSkillRun = {"skill": skill, "at": timezone.now().isoformat()}
-        self.merge_extra(set_keys={"review_skill_run": run})
-
-    def record_review_context(self, work_item: str, documents: list[str], analysis: str) -> None:
-        """Stamp durable evidence the referenced context was retrieved + analyzed.
-
-        Reviewing carries the same responsibility as implementing: the
-        ``-> reviewing`` deep-retrieval gate (``teatree.core.gates.review_context_gate``)
-        reads this to refuse a verdict formed from the diff alone. ``work_item``
-        is the fetched ticket / work-item source, ``documents`` the downloaded
-        references, ``analysis`` how the implementation was checked against the
-        specified requirements. Written through the canonical locked
-        ``merge_extra`` primitive so a concurrent ``extra`` writer's key
-        survives; the timestamp is UTC ISO.
-        """
-        context: ReviewContext = {
-            "work_item": work_item,
-            "documents": list(documents),
-            "analysis": analysis,
-            "at": timezone.now().isoformat(),
-        }
-        self.merge_extra(set_keys={"review_context": context})
-
-    def record_anti_vacuity_attestation(
-        self,
-        head_sha: str,
-        ac_coverage: str,
-        proven_tests: list[str],
-        *,
-        no_new_tests: bool = False,
-    ) -> None:
-        """Stamp the SHA-bound anti-vacuity attestation backing review-request/merge (#1829).
-
-        ``head_sha`` binds the attestation to the exact tree the maker
-        self-reviewed; the anti-vacuity gate (``teatree.core.gates.anti_vacuity_gate``)
-        drops it when the live head moves. ``ac_coverage`` records how the diff
-        was mapped to the acceptance criteria. ``proven_tests`` lists every new
-        regression test proven anti-vacuous (revert fix -> RED); ``no_new_tests``
-        is the explicit "this diff adds no new regression test" claim so an
-        empty ``proven_tests`` can never silently pass. Written through the
-        canonical locked ``merge_extra`` primitive so a concurrent ``extra``
-        writer's key survives; the timestamp is UTC ISO.
-        """
-        attestation: AntiVacuityAttestation = {
-            "head_sha": head_sha.strip().lower(),
-            "ac_coverage": ac_coverage,
-            "proven_tests": list(proven_tests),
-            "no_new_tests": no_new_tests,
-            "at": timezone.now().isoformat(),
-        }
-        self.merge_extra(set_keys={"anti_vacuity_attestation": attestation})
-
-    def review_context_satisfied(self) -> bool:
-        """Whether the ``-> reviewing`` deep-retrieval precondition is met.
-
-        An FSM ``condition`` on ``review()``: the ``TESTED -> REVIEWED``
-        transition is mechanically refused (``TransitionNotAllowed``) when
-        ``require_review_context`` is on and no complete ``review_context``
-        artifact is recorded — so a verdict from the diff alone cannot advance
-        the FSM regardless of entry path. NO-OP (returns ``True``) when the knob
-        is off (opt-in default preserved).
-        """
-        return bool(get_gate("review_context_satisfied")(self))
-
-    def append_context(self, entry: str) -> str:
-        r"""Append a timestamped block to the durable per-ticket knowledge store (#627).
-
-        ``context`` is append-only: parallel sessions on the same ticket each
-        add their own ``\n\n[YYYY-MM-DD HH:MM] …`` block rather than
-        overwriting, so a later session never loses an earlier one's note
-        (open question 2 — append-only with timestamp prefixes). Returns the
-        full updated context. Refuses a blank entry — an empty note carries no
-        durable knowledge and would just add noise.
-        """
-        text = entry.strip()
-        if not text:
-            msg = "context entry is empty"
-            raise ValueError(msg)
-        stamp = timezone.localtime().strftime("%Y-%m-%d %H:%M")
-        with transaction.atomic():
-            locked = type(self).objects.select_for_update().get(pk=self.pk)
-            updated = f"{locked.context}\n\n[{stamp}] {text}"
-            self.context = updated
-            type(self).objects.filter(pk=self.pk).update(context=updated)
-        return updated

--- a/src/teatree/core/models/ticket_data.py
+++ b/src/teatree/core/models/ticket_data.py
@@ -1,0 +1,35 @@
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from django.db import models
+
+if TYPE_CHECKING:
+    from teatree.core.models.ticket import Ticket
+
+
+class TicketFacet(models.Model):
+    """Field-less abstract base carrying the type surface the ``Ticket`` facets share.
+
+    The concrete ``Ticket`` supplies the real fields/enums; each behaviour facet
+    (overlay attribution, phase sessions, scheduling, evidence, introspection)
+    subclasses this so its methods type-check against the model's fields without
+    redeclaring them. Abstract with no fields, so it contributes no migration and
+    the multiple-inheritance diamond into ``Ticket`` cannot clash.
+    """
+
+    class Meta:
+        abstract = True
+
+    if TYPE_CHECKING:
+        pk: int
+        issue_url: str
+        overlay: str
+        state: str
+        role: str
+        extra: dict[str, Any]
+        context: str
+        remote_missing: bool
+        expedited: bool
+        issue_number: str
+        State: type["Ticket.State"]
+        Role: type["Ticket.Role"]
+        _TERMINAL_STATES: ClassVar[frozenset[str]]

--- a/src/teatree/core/models/ticket_evidence.py
+++ b/src/teatree/core/models/ticket_evidence.py
@@ -1,0 +1,166 @@
+from typing import TYPE_CHECKING
+
+from django.db import transaction
+from django.utils import timezone
+
+from teatree.core.modelkit.gate_registry import get_gate
+from teatree.core.models.ticket_data import TicketFacet
+from teatree.core.models.types import validated_ticket_extra
+
+if TYPE_CHECKING:
+    from teatree.core.models.types import (
+        AntiVacuityAttestation,
+        ReviewContext,
+        ReviewSkillRun,
+        TicketExtra,
+        TicketSiblingFields,
+    )
+
+
+class TicketEvidenceModel(TicketFacet):
+    """The durable ``extra``/``context`` evidence store — one locked read-modify-write primitive (#800 N3)."""
+
+    class Meta:
+        abstract = True
+
+    def _extra(self) -> "TicketExtra":
+        return validated_ticket_extra(self.extra)
+
+    def merge_extra(
+        self,
+        *,
+        set_keys: "TicketExtra | None" = None,
+        pop_keys: "list[str] | None" = None,
+        also_set: "TicketSiblingFields | None" = None,
+    ) -> None:
+        """Canonical locked read-modify-write of ``extra`` (#800 N3).
+
+        Several writers mutate shared ``extra`` JSON — ``pr_urls`` (ship
+        worker), ``visual_qa`` (the pre-push gate), ``reviewed_sha`` /
+        ``last_review_state`` (reviewer path). Done as an unlocked
+        ``self.extra = …; self.save(update_fields=["extra"])`` they
+        last-writer-clobber each other's key (the Haki-Benita
+        lost-update). This is the single primitive every ``extra``
+        mutation routes through, with the same shape as
+        ``Session.visit_phase``: the RMW runs in ``transaction.atomic()``
+        with the row ``select_for_update``-locked and **re-read from the
+        locked row** (not the possibly-stale in-memory instance), so a
+        concurrent writer's key survives the merge instead of being
+        overwritten. The locked re-read is what makes it correct on the
+        production SQLite backend (where ``select_for_update`` is a no-op
+        but the #804 ``BEGIN IMMEDIATE`` serialises the writers, so the
+        re-read sees the other writer's committed key).
+
+        ``also_set`` writes sibling **model fields** (``state``,
+        ``repos``, ``variant``, …) in the SAME locked ``UPDATE`` as
+        ``extra``. The tracker-sync paths legitimately co-write
+        ``extra`` with ``state``/``repos`` in one ``save`` — routing
+        them through here keeps that write atomic (no split into two
+        non-atomic writes) while still going through the single locked
+        primitive, so the SSOT holds with zero unlocked ``extra`` RMW
+        anywhere.
+        """
+        with transaction.atomic():
+            locked = type(self).objects.select_for_update().get(pk=self.pk)
+            merged = dict(locked.extra or {})
+            if set_keys:
+                merged.update(set_keys)
+            for key in pop_keys or []:
+                merged.pop(key, None)
+            self.extra = merged
+            for field, value in (also_set or {}).items():
+                setattr(self, field, value)
+            type(self).objects.filter(pk=self.pk).update(extra=merged, **(also_set or {}))
+
+    def record_review_skill_run(self, skill: str) -> None:
+        """Stamp durable evidence that the deep-review ``skill`` ran (#1539).
+
+        Written through the canonical locked ``merge_extra`` primitive so a
+        concurrent ``extra`` writer's key survives. The timestamp is UTC ISO
+        so the reviewing-phase gate's audit trail is timezone-unambiguous.
+        """
+        run: ReviewSkillRun = {"skill": skill, "at": timezone.now().isoformat()}
+        self.merge_extra(set_keys={"review_skill_run": run})
+
+    def record_review_context(self, work_item: str, documents: list[str], analysis: str) -> None:
+        """Stamp durable evidence the referenced context was retrieved + analyzed.
+
+        Reviewing carries the same responsibility as implementing: the
+        ``-> reviewing`` deep-retrieval gate (``teatree.core.gates.review_context_gate``)
+        reads this to refuse a verdict formed from the diff alone. ``work_item``
+        is the fetched ticket / work-item source, ``documents`` the downloaded
+        references, ``analysis`` how the implementation was checked against the
+        specified requirements. Written through the canonical locked
+        ``merge_extra`` primitive so a concurrent ``extra`` writer's key
+        survives; the timestamp is UTC ISO.
+        """
+        context: ReviewContext = {
+            "work_item": work_item,
+            "documents": list(documents),
+            "analysis": analysis,
+            "at": timezone.now().isoformat(),
+        }
+        self.merge_extra(set_keys={"review_context": context})
+
+    def record_anti_vacuity_attestation(
+        self,
+        head_sha: str,
+        ac_coverage: str,
+        proven_tests: list[str],
+        *,
+        no_new_tests: bool = False,
+    ) -> None:
+        """Stamp the SHA-bound anti-vacuity attestation backing review-request/merge (#1829).
+
+        ``head_sha`` binds the attestation to the exact tree the maker
+        self-reviewed; the anti-vacuity gate (``teatree.core.gates.anti_vacuity_gate``)
+        drops it when the live head moves. ``ac_coverage`` records how the diff
+        was mapped to the acceptance criteria. ``proven_tests`` lists every new
+        regression test proven anti-vacuous (revert fix -> RED); ``no_new_tests``
+        is the explicit "this diff adds no new regression test" claim so an
+        empty ``proven_tests`` can never silently pass. Written through the
+        canonical locked ``merge_extra`` primitive so a concurrent ``extra``
+        writer's key survives; the timestamp is UTC ISO.
+        """
+        attestation: AntiVacuityAttestation = {
+            "head_sha": head_sha.strip().lower(),
+            "ac_coverage": ac_coverage,
+            "proven_tests": list(proven_tests),
+            "no_new_tests": no_new_tests,
+            "at": timezone.now().isoformat(),
+        }
+        self.merge_extra(set_keys={"anti_vacuity_attestation": attestation})
+
+    def review_context_satisfied(self) -> bool:
+        """Whether the ``-> reviewing`` deep-retrieval precondition is met.
+
+        An FSM ``condition`` on ``review()``: the ``TESTED -> REVIEWED``
+        transition is mechanically refused (``TransitionNotAllowed``) when
+        ``require_review_context`` is on and no complete ``review_context``
+        artifact is recorded — so a verdict from the diff alone cannot advance
+        the FSM regardless of entry path. NO-OP (returns ``True``) when the knob
+        is off (opt-in default preserved).
+        """
+        return bool(get_gate("review_context_satisfied")(self))
+
+    def append_context(self, entry: str) -> str:
+        r"""Append a timestamped block to the durable per-ticket knowledge store (#627).
+
+        ``context`` is append-only: parallel sessions on the same ticket each
+        add their own ``\n\n[YYYY-MM-DD HH:MM] …`` block rather than
+        overwriting, so a later session never loses an earlier one's note
+        (open question 2 — append-only with timestamp prefixes). Returns the
+        full updated context. Refuses a blank entry — an empty note carries no
+        durable knowledge and would just add noise.
+        """
+        text = entry.strip()
+        if not text:
+            msg = "context entry is empty"
+            raise ValueError(msg)
+        stamp = timezone.localtime().strftime("%Y-%m-%d %H:%M")
+        with transaction.atomic():
+            locked = type(self).objects.select_for_update().get(pk=self.pk)
+            updated = f"{locked.context}\n\n[{stamp}] {text}"
+            self.context = updated
+            type(self).objects.filter(pk=self.pk).update(context=updated)
+        return updated

--- a/src/teatree/core/models/ticket_number.py
+++ b/src/teatree/core/models/ticket_number.py
@@ -1,0 +1,19 @@
+import re
+
+# Trailing digits of an issue URL are its forge issue number; a ``/0`` suffix is a
+# placeholder no forge assigns to a real issue (issue numbers start at 1), so it is
+# treated as "no number" and falls back to the pk downstream.
+_TRAILING_DIGITS = re.compile(r"(\d+)$")
+
+
+def derive_issue_number(issue_url: str) -> str:
+    """The forge issue number encoded in *issue_url*, or ``""`` when there is none.
+
+    The single source of truth for the ``Ticket.issue_number`` denormalization,
+    the ``ticket_number`` property, and the backfill migration — so the persisted
+    indexed column and the derived property can never drift.
+    """
+    match = _TRAILING_DIGITS.search(issue_url)
+    if match and match.group(1) != "0":
+        return match.group(1)
+    return ""

--- a/src/teatree/core/models/ticket_overlay.py
+++ b/src/teatree/core/models/ticket_overlay.py
@@ -1,0 +1,32 @@
+from teatree.core.modelkit.gate_registry import get_resolver
+from teatree.core.models.ticket_data import TicketFacet
+
+
+class TicketOverlayModel(TicketFacet):
+    """Overlay attribution for a ticket: infer it from ``issue_url`` and keep it current."""
+
+    class Meta:
+        abstract = True
+
+    def _infer_overlay(self) -> str:
+        """Derive overlay name from ``issue_url`` (see ``infer_overlay_for_url``)."""
+        return str(get_resolver("infer_overlay_for_url")(self.issue_url))
+
+    def apply_inferred_overlay(self, inferred: str) -> bool:
+        """Persist ``inferred`` overlay on a conclusive change (True when changed).
+
+        A blank inference never blanks out a manually-set attribution.
+        """
+        if not inferred or inferred == self.overlay:
+            return False
+        self.overlay = inferred
+        type(self).objects.filter(pk=self.pk).update(overlay=inferred)
+        return True
+
+    def reconcile_overlay(self) -> bool:
+        """Re-infer ``overlay`` from ``issue_url`` and persist a correction."""
+        return self.apply_inferred_overlay(self._infer_overlay())
+
+    def has_dispatchable_overlay(self) -> bool:
+        """False only for a non-empty overlay that no longer resolves (#1959 poison-pill)."""
+        return not (self.overlay and get_resolver("resolve_overlay_name")(self.overlay) is None)

--- a/src/teatree/core/models/ticket_phase_sessions.py
+++ b/src/teatree/core/models/ticket_phase_sessions.py
@@ -1,0 +1,90 @@
+from typing import TYPE_CHECKING
+
+from django.db import transaction
+
+from teatree.core.models.ticket_data import TicketFacet
+
+if TYPE_CHECKING:
+    from teatree.core.models.session import Session
+
+
+class TicketPhaseSessionModel(TicketFacet):
+    """The canonical phase-visit session resolution and cross-session phase ledger (#694, #801)."""
+
+    class Meta:
+        abstract = True
+
+    def aggregate_phase_records(self) -> tuple[list[str], dict[str, dict[str, str]]]:
+        """Union the phase records across all of this ticket's sessions (#694).
+
+        Returns ``(visited_phases, phase_visits)`` merged across
+        ``self.sessions`` in creation order. ``visited_phases`` is a
+        de-duplicated list; ``phase_visits`` keeps the first recorded
+        ``agent_id`` per phase (earliest session wins) as a deterministic
+        audit trail of who recorded each phase — it is not consumed for
+        gate enforcement. The shipping gate consumes the ``visited_phases``
+        union because FSM-advancing ``visit-phase`` forks fresh sessions by
+        design — the required phases are legitimately scattered, and the
+        single source of truth is the ticket's lifecycle, not one session.
+        """
+        visited: list[str] = []
+        visits: dict[str, dict[str, str]] = {}
+        for session in self.sessions.order_by("pk"):  # ty: ignore[unresolved-attribute]
+            for phase in session.visited_phases or []:
+                if phase not in visited:
+                    visited.append(phase)
+            for phase, record in (session.phase_visits or {}).items():
+                if phase not in visits:
+                    visits[phase] = record
+        return visited, visits
+
+    def resolve_phase_session(self, *, agent_id: str = "loop") -> "Session":
+        """The single canonical phase-visit session for the attestation writers (#801).
+
+        Which ``Session`` a phase visit lands on was decided four
+        inconsistent ways (``ensure_session`` earliest+locked; the
+        ``lifecycle visit-phase`` CLI, the ``tasks`` phase-handoff
+        command each ``order_by("-pk")`` *latest* with an unlocked raw
+        blank-``agent_id`` create on miss; the ``pr`` gate *latest* as
+        its gate object). A CLI visit then wrote the *latest* session
+        while dispatch reused the *earliest*, splitting attestation
+        across sessions (#801). The three attestation writers now route
+        here; the read-only gate uses :meth:`find_phase_session`.
+
+        Policy: the **earliest** session (``order_by("pk")`` — the one
+        dispatch's attestation uses, so the ledger never splits),
+        selected/created inside one ``transaction.atomic()`` with the
+        ticket row ``select_for_update``-locked (dispatch callers have
+        no surrounding transaction, so concurrent loop ticks for the
+        same ``issue_url`` must serialise). Always returns a Session —
+        on miss it creates one with a guaranteed **non-blank**
+        ``agent_id`` (never the raw blank-``agent_id`` create that left
+        the ``phase_visits`` audit trail unattributed).
+        """
+        from teatree.core.models.session import Session  # noqa: PLC0415 — import cycle
+
+        with transaction.atomic():
+            type(self).objects.select_for_update().filter(pk=self.pk).first()
+            existing = self.sessions.order_by("pk").first()  # ty: ignore[unresolved-attribute]
+            if existing is not None:
+                return existing
+            return Session.objects.create(ticket=self, agent_id=agent_id.strip() or "loop")
+
+    def find_phase_session(self) -> "Session | None":
+        """Read-only canonical phase-visit session for the gate (#801).
+
+        Same earliest + ticket-row-locked selection policy as
+        :meth:`resolve_phase_session` but **never creates** — a gate
+        check must not have the side effect of minting a session.
+        """
+        with transaction.atomic():
+            type(self).objects.select_for_update().filter(pk=self.pk).first()
+            return self.sessions.order_by("pk").first()  # ty: ignore[unresolved-attribute]
+
+    def ensure_session(self, *, agent_id: str = "loop") -> "Session":
+        """Durable phase-attestation Session for this ticket (#748).
+
+        Thin alias of the canonical :meth:`resolve_phase_session` (#801
+        SSOT) — kept for its existing callers / API.
+        """
+        return self.resolve_phase_session(agent_id=agent_id)

--- a/src/teatree/core/models/ticket_scheduling.py
+++ b/src/teatree/core/models/ticket_scheduling.py
@@ -1,0 +1,190 @@
+from typing import TYPE_CHECKING
+
+from teatree.config import Mode, get_effective_settings
+from teatree.core.modelkit.gate_registry import get_gate
+from teatree.core.modelkit.phases import normalize_phase
+from teatree.core.models.errors import DirtyWorktreeError, InvalidTransitionError
+from teatree.core.models.ticket_data import TicketFacet
+from teatree.core.models.ticket_worktree_checks import collect_dirty_worktree_paths
+
+if TYPE_CHECKING:
+    from teatree.core.models.session import Session
+    from teatree.core.models.task import Task
+    from teatree.core.models.ticket import Ticket
+
+
+def _auto_ship_enabled() -> bool:
+    return get_effective_settings().mode == Mode.AUTO
+
+
+class TicketSchedulingModel(TicketFacet):
+    """Fresh-session phase-task scheduling, orphan-task consumption, and the dirty-worktree preflight."""
+
+    class Meta:
+        abstract = True
+
+    def schedule_planning(self, *, parent_task: "Task | None" = None) -> "Task":
+        """Create a fresh headless planning task after provisioning completes."""
+        return self._schedule_headless(
+            "planning", "Auto-scheduled planning — produce a plan before coding", parent_task, require_author=True
+        )
+
+    def schedule_coding(self, *, parent_task: "Task | None" = None) -> "Task":
+        """Create a fresh headless coding task after planning completes.
+
+        Gated by ``plan_currency`` (SELFCATCH-3) on the normal author PLANNED→CODED flow
+        (the same gate ``code()`` runs): no coding task for a thin/legacy or seam-stale
+        plan. NO-OP unless ``require_plan_adequacy`` is on; synthetic corrective
+        re-entries that mint a coding task directly are exempt (they carry no plan).
+        """
+        return self._schedule_headless(
+            "coding",
+            "Auto-scheduled coding — implement the ticket",
+            parent_task,
+            require_author=True,
+            gate="plan_currency",
+        )
+
+    def _schedule_headless(
+        self,
+        phase: str,
+        reason: str,
+        parent_task: "Task | None",
+        *,
+        require_author: bool = False,
+        gate: str | None = None,
+    ) -> "Task":
+        """Shared fresh-session headless scheduler for the auto-FSM phase tasks.
+
+        Optionally enforces ``role=author`` and runs an FSM ``gate`` (the
+        plan-currency leak-close), then mints the ``phase`` Session + headless Task.
+        The session ``agent_id`` is the ``phase`` (``reviewing`` uses ``review``).
+        """
+        from teatree.core.models.session import Session  # noqa: PLC0415 — import cycle
+        from teatree.core.models.task import Task  # noqa: PLC0415 — import cycle
+
+        if require_author and self.role != self.Role.AUTHOR:
+            msg = f"schedule_{phase} requires role=author (got role={self.role!r})"
+            raise InvalidTransitionError(msg)
+        if gate is not None:
+            get_gate(gate)(self)
+        session = Session.objects.create(
+            ticket=self, agent_id="review" if normalize_phase(phase) == "reviewing" else phase
+        )
+        return Task.objects.create(
+            ticket=self,
+            session=session,
+            phase=phase,
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            execution_reason=reason,
+            parent_task=parent_task,
+        )
+
+    def schedule_testing(self, *, parent_task: "Task | None" = None) -> "Task":
+        """Create a fresh headless testing task after coding completes."""
+        return self._schedule_headless("testing", "Auto-scheduled testing — run + QA the coding work", parent_task)
+
+    def schedule_review(self, *, parent_task: "Task | None" = None) -> "Task":
+        """Create a fresh headless review+retro task (new session for bias-free evaluation)."""
+        return self._schedule_headless("reviewing", "Auto-scheduled review + retro — fresh agent, no bias", parent_task)
+
+    def schedule_review_in_session(self, session: "Session", *, parent_task: "Task | None" = None) -> "Task":
+        """Create a review task within an existing session (sub-agent, not a new session)."""
+        from teatree.core.models.task import Task  # noqa: PLC0415 — import cycle
+
+        return Task.objects.create(
+            ticket=self,
+            session=session,
+            phase="reviewing",
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            execution_reason="Auto-review before shipping — sub-agent in current session",
+            parent_task=parent_task,
+        )
+
+    def schedule_shipping(self, *, parent_task: "Task | None" = None) -> "Task":
+        """Create an INTERACTIVE shipping task; approval gating rides the reason.
+
+        Shipping is a loop-dispatched phase (``(author, shipping)`` →
+        ``t3:shipper``), so it runs as an in-session sub-agent
+        (subscription-covered), never a metered detached headless-SDK run — regardless of
+        auto mode. Auto mode no longer changes the execution *target*; it only
+        changes the *approval posture* the in-session shipper reads from
+        ``execution_reason`` (auto = push without waiting; otherwise = gate for
+        user approval first).
+        """
+        from teatree.core.models.session import Session  # noqa: PLC0415 — import cycle
+        from teatree.core.models.task import Task  # noqa: PLC0415 — import cycle
+
+        session = Session.objects.create(ticket=self, agent_id="shipping")
+        if _auto_ship_enabled():
+            reason = "Auto-scheduled shipping — auto mode, push will proceed without waiting for approval"
+        else:
+            reason = (
+                "Auto-scheduled shipping — gated for user approval "
+                "(set mode = auto via config_setting set, or T3_MODE=auto, to skip)"
+            )
+        return Task.objects.create(
+            ticket=self,
+            session=session,
+            phase="shipping",
+            execution_target=Task.ExecutionTarget.INTERACTIVE,
+            execution_reason=reason,
+            parent_task=parent_task,
+        )
+
+    def _cancel_pending_tasks(self) -> None:
+        """Fail all pending/claimed tasks when reworking."""
+        from teatree.core.models.task import Task  # noqa: PLC0415 — import cycle
+
+        for task in self.tasks.filter(status__in=Task.Status.active()):  # type: ignore[attr-defined]  # Django reverse FK
+            task.fail()
+
+    def _refuse_if_worktree_dirty(self: "Ticket", phase: str) -> None:
+        """Preflight gate (#884): refuse the transition if a worktree is tracked-dirty.
+
+        Run at the top of the ``code``/``test``/``review``/``ship``
+        transition bodies. Dirty-collection rule and the no-auto-stash/
+        lease-reaper rationale live on :func:`collect_dirty_worktree_paths`
+        (#1983 LOC-ratchet split). On dirty: a loud :class:`DirtyWorktreeError`
+        names the dirty worktree(s) and the transition does not advance —
+        every production caller wraps the transition body in an outer
+        ``transaction.atomic``, so the raise rolls that whole atomic back.
+        """
+        dirty = collect_dirty_worktree_paths(self)
+        if not dirty:
+            return
+        joined = ", ".join(dirty)
+        msg = (
+            f"Refusing the '{phase}' transition for ticket {self} — uncommitted tracked "
+            f"changes in worktree(s): {joined}. Commit or discard them, then retry. "
+            f"(No auto-stash: teatree worktrees share one .git, so a stash is repo-global "
+            f"and could clobber another branch — #806.)"
+        )
+        raise DirtyWorktreeError(msg)
+
+    def _consume_pending_phase_tasks(self, phase: str) -> None:
+        """Mark non-terminal tasks for ``phase`` as COMPLETED.
+
+        FSM transitions advance ticket state via two paths: the task-driven
+        chain (``Task.complete()`` → ``_advance_ticket()`` → transition body),
+        and direct CLI/API calls (e.g. ``pr.py`` calling ``ticket.ship()``).
+        On the task-driven path the task is already COMPLETED before this runs
+        — the filter is empty and this is a no-op. On the direct path the
+        previously-scheduled phase task is orphaned in PENDING/CLAIMED and
+        would be picked up later as a zombie session; consume it now.
+
+        Matches any accepted phase spelling via ``pending_in_phase`` (#769,
+        the consume-side mirror of #757's ``completed_in_phase``): a raw
+        ``phase=phase`` filter missed a short-verb ``review`` task stored
+        by the unnormalized ``tasks create <id> review`` path, leaving it
+        as a zombie session.
+        """
+        from teatree.core.models.task import Task  # noqa: PLC0415 — import cycle
+
+        Task.objects.pending_in_phase(phase).filter(ticket=self).update(
+            status=Task.Status.COMPLETED,
+            claimed_at=None,
+            claimed_by="",
+            lease_expires_at=None,
+            heartbeat_at=None,
+        )

--- a/src/teatree/core/models/ticket_status.py
+++ b/src/teatree/core/models/ticket_status.py
@@ -1,0 +1,85 @@
+from typing import TYPE_CHECKING
+
+from django.apps import apps
+from django_fsm import TransitionNotAllowed
+
+from teatree.core.models.ticket_data import TicketFacet
+from teatree.core.models.ticket_number import derive_issue_number
+from teatree.core.models.ticket_worktree_checks import worktree_has_commits_ahead
+from teatree.core.models.types import validated_ticket_extra
+
+if TYPE_CHECKING:
+    from teatree.core.models.ticket import Ticket
+    from teatree.core.models.ticket_artifacts import PortResolver, TicketArtifacts
+
+
+class TicketStatusModel(TicketFacet):
+    """Identity/liveness/diff introspection and the small direct-write status flags."""
+
+    class Meta:
+        abstract = True
+
+    def has_active_work(self) -> bool:
+        """True iff this ticket has an open session or an active (pending/claimed) task.
+
+        The single owner of the ticket-liveness rule the reapers and the relocate
+        command consult — a busy ticket must never be torn down.
+        """
+        if self.sessions.filter(ended_at__isnull=True).exists():  # type: ignore[attr-defined]  # Django reverse FK
+            return True
+        # apps.get_model, not a direct import: task.py imports ticket.py at module scope (real cycle).
+        task_model = apps.get_model("core", "Task")
+        return self.tasks.filter(status__in=task_model.Status.active()).exists()  # type: ignore[attr-defined]  # Django reverse FK
+
+    def mark_remote_missing(self) -> None:
+        """Targeted UPDATE to set remote_missing; skips the FSM and save() overhead (#1875)."""
+        type(self).objects.filter(pk=self.pk).update(remote_missing=True)
+        self.remote_missing = True
+
+    @property
+    def is_terminal(self) -> bool:
+        """True when the ticket is in a genuinely terminal/abandoned state (SHIPPED/MERGED/DELIVERED/IGNORED)."""
+        return self.state in self._TERMINAL_STATES
+
+    def may_expedite(self) -> bool:
+        """True iff this ticket may carry a human-authorized PENDING-checks waiver (PR-07).
+
+        The flag alone grants NO merge bypass — it only makes the per-CLEAR,
+        SHA-bound waiver ISSUABLE (§17.4.3 / ``MergeClear.expedite_pending_waived_by``).
+        """
+        return self.expedited
+
+    @property
+    def ticket_number(self) -> str:
+        """Forge issue number derived from ``issue_url``, else the pk (see ``derive_issue_number``).
+
+        Denormalized into the indexed ``issue_number`` column for O(1) resolves;
+        this property keeps the pk fallback for rows carrying no forge number.
+        """
+        return derive_issue_number(self.issue_url) or str(self.pk)
+
+    def has_shippable_diff(self) -> bool:
+        """Return True iff at least one worktree has commits ahead of its base branch.
+
+        Used by ``review()`` to skip auto-scheduling shipping when there is
+        nothing to ship — typically meta-tracker tickets whose work already
+        landed via sibling PRs. Manual ``schedule_shipping()`` callers are not
+        gated.
+        """
+        worktree_model = apps.get_model("core", "Worktree")
+        return any(worktree_has_commits_ahead(wt) for wt in worktree_model.objects.filter(ticket=self))
+
+    def artifacts(self: "Ticket", *, port_resolver: "PortResolver | None" = None) -> "TicketArtifacts":
+        """Read-only artifact-discovery aggregation (#273) — see ``ticket_artifacts``."""
+        from teatree.core.models.ticket_artifacts import collect_ticket_artifacts  # noqa: PLC0415 — import cycle
+
+        return collect_ticket_artifacts(self, port_resolver=port_resolver)
+
+    def unignore(self: "Ticket") -> None:
+        if self.state != self.State.IGNORED:
+            msg = f"Can't unignore from state '{self.state}'"
+            raise TransitionNotAllowed(msg)
+        extra = validated_ticket_extra(self.extra)
+        previous = extra.pop("ignored_from", self.State.NOT_STARTED)
+        self.extra = extra
+        self.state = str(previous)

--- a/tests/quality/deferred_import_pegs.toml
+++ b/tests/quality/deferred_import_pegs.toml
@@ -73,7 +73,9 @@
 "src/teatree/core/models/auto_review_dispatch.py" = 3
 "src/teatree/core/models/review_loop.py" = 3
 "src/teatree/core/models/task.py" = 7
-"src/teatree/core/models/ticket.py" = 11
+"src/teatree/core/models/ticket_phase_sessions.py" = 1
+"src/teatree/core/models/ticket_scheduling.py" = 7
+"src/teatree/core/models/ticket_status.py" = 1
 "src/teatree/core/notify.py" = 4
 "src/teatree/core/on_behalf_egress.py" = 2
 "src/teatree/core/on_behalf_gate_recorded.py" = 6

--- a/tests/teatree_core/models/test_ticket_number_index.py
+++ b/tests/teatree_core/models/test_ticket_number_index.py
@@ -1,0 +1,88 @@
+"""The persisted, indexed ``issue_number`` denormalization (burndown Unit 5 3e#8).
+
+``_ticket_by_number`` used to load every non-synthetic ``Ticket`` and filter the
+DERIVED ``ticket_number`` in Python — O(all tickets) per worktree resolve, no
+index. The forge issue number is now denormalized into a real indexed
+``issue_number`` column (populated on ``save`` + backfilled by migration), so the
+resolve is a single indexed lookup. The ``ticket_number`` property (57 consumers)
+is unchanged: it composes ``issue_number`` derivation with the ``str(pk)`` fallback.
+"""
+
+from django.db import connection
+from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
+
+from teatree.core.intake.resolve import _ticket_by_number
+from teatree.core.models import Ticket
+from teatree.core.models.ticket_number import derive_issue_number
+
+
+class TestDeriveIssueNumber:
+    def test_trailing_number(self) -> None:
+        assert derive_issue_number("https://github.com/example/repo/issues/123") == "123"
+
+    def test_empty_url(self) -> None:
+        assert derive_issue_number("") == ""
+
+    def test_no_trailing_number(self) -> None:
+        assert derive_issue_number("https://example.com/no-number") == ""
+
+    def test_trailing_zero_is_not_a_real_issue(self) -> None:
+        assert derive_issue_number("https://github.com/example/repo/issues/0") == ""
+
+
+class TestIssueNumberColumn(TestCase):
+    def test_field_is_indexed(self) -> None:
+        field = Ticket._meta.get_field("issue_number")
+        assert field.db_index is True
+
+    def test_populated_from_issue_url_on_save(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://github.com/example/repo/issues/466")
+        ticket.refresh_from_db()
+        assert ticket.issue_number == "466"
+
+    def test_blank_when_url_has_no_trailing_number(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://example.com/no-number")
+        ticket.refresh_from_db()
+        assert ticket.issue_number == ""
+
+    def test_recomputed_when_issue_url_changes(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://github.com/example/repo/issues/1")
+        ticket.issue_url = "https://github.com/example/repo/issues/2"
+        ticket.save()
+        ticket.refresh_from_db()
+        assert ticket.issue_number == "2"
+
+    def test_ticket_number_property_still_falls_back_to_pk(self) -> None:
+        # The property surface (57 consumers) is unchanged: no forge number → pk.
+        ticket = Ticket.objects.create(issue_url="https://example.com/no-number")
+        assert ticket.ticket_number == str(ticket.pk)
+
+
+class TestTicketByNumberUsesIndexedColumn(TestCase):
+    def test_resolve_queries_the_indexed_column_not_a_full_python_scan(self) -> None:
+        Ticket.objects.create(issue_url="https://github.com/example/repo/issues/466")
+        with CaptureQueriesContext(connection) as captured:
+            _ticket_by_number("466")
+        sql = " ".join(q["sql"] for q in captured.captured_queries)
+        # The pre-fix code never filtered on a number column (it scanned in Python);
+        # the fix pushes the match into the DB WHERE clause on the indexed column.
+        assert "issue_number" in sql
+
+    def test_resolves_forge_number_ticket(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://a.example.com/x/issues/7")
+        assert _ticket_by_number("7") == ticket
+
+    def test_pk_fallback_ticket_still_resolves(self) -> None:
+        # A ticket whose issue_url carries no forge number resolves by its pk-derived
+        # ticket_number — the branch of the old Python filter the index must preserve.
+        ticket = Ticket.objects.create(issue_url="https://example.com/no-number")
+        assert _ticket_by_number(str(ticket.pk)) == ticket
+
+    def test_returns_none_when_no_match(self) -> None:
+        Ticket.objects.create(issue_url="https://a.example.com/x/issues/42")
+        assert _ticket_by_number("5") is None
+
+    def test_synthetic_auto_rows_are_never_resolved(self) -> None:
+        Ticket.objects.create(issue_url="auto:5-some-branch")
+        assert _ticket_by_number("5") is None

--- a/tests/teatree_core/models/test_ticket_structure.py
+++ b/tests/teatree_core/models/test_ticket_structure.py
@@ -1,0 +1,174 @@
+"""Structural guards for the ``Ticket`` god-object split (burndown Unit 5).
+
+``Ticket`` breached the repo's ``max-public-methods=25`` ceiling (47 public
+methods) and silenced it with a class-level PLR0904 suppression. The split moves
+cohesive instance-behaviour clusters onto composed abstract-model facets so the
+concrete ``Ticket`` body drops under the ceiling — WITHOUT changing the public API
+(every method stays reachable as ``ticket.foo()`` via the facets) or the FSM state
+graph. These tests pin all three properties.
+"""
+
+import inspect
+
+from teatree.core.models.ticket import Ticket
+
+# The public surface consumers call on a ``Ticket`` before the split — every name
+# must stay reachable on the concrete class afterwards (via the composed facets),
+# so no consumer call site breaks. Frozen: dropping one is an API regression.
+_PUBLIC_API: frozenset[str] = frozenset(
+    {
+        "aggregate_phase_records",
+        "append_context",
+        "apply_inferred_overlay",
+        "artifacts",
+        "code",
+        "ensure_session",
+        "find_phase_session",
+        "has_active_work",
+        "has_dispatchable_overlay",
+        "has_shippable_diff",
+        "ignore",
+        "is_terminal",
+        "mark_delivered",
+        "mark_merged",
+        "mark_remote_missing",
+        "mark_review_no_action",
+        "mark_reviewed_externally",
+        "may_expedite",
+        "merge_extra",
+        "plan",
+        "reconcile_merged",
+        "reconcile_overlay",
+        "reconcile_reviewed",
+        "record_anti_vacuity_attestation",
+        "record_review_context",
+        "record_review_skill_run",
+        "reopen",
+        "request_review",
+        "resolve_phase_session",
+        "retrospect",
+        "review",
+        "review_context_satisfied",
+        "rework",
+        "save",
+        "schedule_coding",
+        "schedule_planning",
+        "schedule_review",
+        "schedule_review_in_session",
+        "schedule_shipping",
+        "schedule_testing",
+        "scope",
+        "ship",
+        "start",
+        "test",
+        "ticket_number",
+        "unignore",
+    }
+)
+
+# The FSM state graph as it stands before the split — {transition: (sources, targets)}.
+# Behaviour-preserving means this map is byte-identical afterwards.
+_FSM_GRAPH: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
+    "code": (("planned",), ("coded",)),
+    "ignore": (
+        (
+            "coded",
+            "in_review",
+            "merged",
+            "not_started",
+            "planned",
+            "retrospected",
+            "reviewed",
+            "scoped",
+            "shipped",
+            "started",
+            "tested",
+        ),
+        ("ignored",),
+    ),
+    "mark_delivered": (("retrospected",), ("delivered",)),
+    "mark_merged": (("in_review", "merged"), ("merged",)),
+    "mark_review_no_action": (
+        ("coded", "delivered", "not_started", "planned", "reviewed", "scoped", "started", "tested"),
+        ("delivered",),
+    ),
+    "mark_reviewed_externally": (
+        ("coded", "not_started", "planned", "reviewed", "scoped", "started", "tested"),
+        ("delivered",),
+    ),
+    "plan": (("started",), ("planned",)),
+    "reconcile_merged": (
+        (
+            "coded",
+            "in_review",
+            "merged",
+            "not_started",
+            "planned",
+            "reviewed",
+            "scoped",
+            "shipped",
+            "started",
+            "tested",
+        ),
+        ("merged",),
+    ),
+    "reconcile_reviewed": (
+        ("coded", "in_review", "not_started", "planned", "retrospected", "reviewed", "scoped", "started", "tested"),
+        ("reviewed",),
+    ),
+    "reopen": (("in_review", "merged", "retrospected", "shipped"), ("started",)),
+    "request_review": (("shipped",), ("in_review",)),
+    "retrospect": (("merged", "retrospected"), ("retrospected",)),
+    "review": (("tested",), ("reviewed",)),
+    "rework": (("coded", "reviewed", "tested"), ("started",)),
+    "scope": (("not_started",), ("scoped",)),
+    "ship": (("reviewed", "shipped"), ("shipped",)),
+    "start": (("scoped", "started"), ("started",)),
+    "test": (("coded",), ("tested",)),
+}
+
+
+def _own_public_members(cls: type) -> set[str]:
+    """Public methods/properties defined directly in *cls*'s body (the PLR0904 shape).
+
+    Mirrors ruff's ``too-many-public-methods`` count: names in the class ``__dict__``
+    that are callable/property and neither private nor dunder. Inherited members
+    (from the composed facets) are excluded — exactly what the ceiling counts.
+    """
+    members: set[str] = set()
+    for name, value in vars(cls).items():
+        if name.startswith("_"):
+            continue
+        if isinstance(value, (staticmethod, classmethod, property)) or inspect.isfunction(value):
+            members.add(name)
+    return members
+
+
+def _fsm_graph(cls: type) -> dict[str, tuple[tuple[str, ...], tuple[str, ...]]]:
+    graph: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {}
+    for name, value in vars(cls).items():
+        fsm = getattr(value, "_django_fsm", None)
+        if fsm is None:
+            continue
+        sources = tuple(sorted(str(s) for s in fsm.transitions))
+        targets = tuple(sorted({str(t.target) for t in fsm.transitions.values()}))
+        graph[name] = (sources, targets)
+    return graph
+
+
+class TestGodObjectShrink:
+    def test_own_public_method_count_under_ceiling(self) -> None:
+        # pyproject sets lint.pylint.max-public-methods = 25; the concrete Ticket
+        # body must live under it with the facets carrying the rest.
+        assert len(_own_public_members(Ticket)) <= 25
+
+
+class TestPublicApiPreserved:
+    def test_every_pre_split_public_method_is_still_reachable(self) -> None:
+        missing = sorted(name for name in _PUBLIC_API if not hasattr(Ticket, name))
+        assert missing == []
+
+
+class TestFsmGraphUnchanged:
+    def test_transition_sources_and_targets_are_unchanged(self) -> None:
+        assert _fsm_graph(Ticket) == _FSM_GRAPH

--- a/tests/teatree_core/test_migration_squash_existing_db.py
+++ b/tests/teatree_core/test_migration_squash_existing_db.py
@@ -43,6 +43,7 @@ _CURRENT_GRAPH = frozenset(
         "0001_initial",
         "0002_implementedissuemarker_claimed_by_instance",
         "0003_implementedissuemarker_claim_ref_sha",
+        "0004_ticket_issue_number",
     }
 )
 

--- a/tests/teatree_core/test_ticket_issue_number_migration.py
+++ b/tests/teatree_core/test_ticket_issue_number_migration.py
@@ -1,0 +1,48 @@
+"""The ``0004`` backfill populates ``issue_number`` on pre-existing rows.
+
+A live dogfooded install already carries tickets with no ``issue_number`` column.
+The forward migration adds the indexed column AND backfills it from ``issue_url``
+so ``_ticket_by_number`` resolves those rows on day one — without waiting for each
+to be re-saved. Anti-vacuous: dropping the ``RunPython`` leaves the row on the
+``""`` AddField default and this goes RED.
+"""
+
+import pytest
+from django.core.management import call_command
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase
+
+_BEFORE = ("core", "0003_implementedissuemarker_claim_ref_sha")
+_AFTER = ("core", "0004_ticket_issue_number")
+_ISSUE_URL = "https://github.com/example/repo/issues/466"
+_NO_NUMBER_URL = "https://example.com/no-number"
+
+
+@pytest.mark.timeout(240)
+class TestIssueNumberBackfill(TransactionTestCase):
+    def setUp(self) -> None:
+        self.addCleanup(self._restore_head)
+
+    @staticmethod
+    def _restore_head() -> None:
+        connection.close()
+        call_command("migrate", "core", "--no-input", verbosity=0)
+
+    def test_backfill_derives_issue_number_from_issue_url(self) -> None:
+        executor = MigrationExecutor(connection)
+        executor.migrate([_BEFORE])
+        old_apps = executor.loader.project_state(_BEFORE).apps
+        old_ticket = old_apps.get_model("core", "Ticket")
+        # The 0003 schema has no issue_number column; the historical model's base
+        # save cannot set it, so the row lands column-less — exactly the fleet state.
+        numbered = old_ticket.objects.create(overlay="", issue_url=_ISSUE_URL)
+        blank = old_ticket.objects.create(overlay="", issue_url=_NO_NUMBER_URL)
+
+        executor = MigrationExecutor(connection)
+        executor.migrate([_AFTER])
+        new_apps = executor.loader.project_state(_AFTER).apps
+        new_ticket = new_apps.get_model("core", "Ticket")
+
+        assert new_ticket.objects.get(pk=numbered.pk).issue_number == "466"
+        assert new_ticket.objects.get(pk=blank.pk).issue_number == ""


### PR DESCRIPTION
## Summary

Burndown **Unit 5** — both findings on `core/models/ticket.py`.

- **must-fix (god-object):** `Ticket` was 1019 LOC / 47 public methods, breaching the repo's `max-public-methods=25` and silenced with a class-level PLR0904 suppression. Cohesive instance behaviour now composes onto five abstract-model facets; the concrete `Ticket` (fields + FSM state graph + manager + `save`) drops to **549 LOC / 19 own public methods** and the suppression is gone. Every method stays reachable as `ticket.foo()` via the facets, so **no consumer call site changes** and the **FSM graph is byte-identical**.
- **should-fix (3e#8):** `_ticket_by_number` loaded every non-synthetic `Ticket` and filtered the derived number in Python (O(all tickets) per worktree resolve). The forge issue number is denormalized into an **indexed `issue_number` column** (kept in sync by `save`, backfilled by migration `0004`), turning the resolve into an indexed lookup + a pk-fallback for numberless tickets. The `ticket_number` property is behaviour-identical.

### Facet split (composition shape)

| Facet (abstract model) | Concern |
|---|---|
| `TicketOverlayModel` | overlay attribution (`_infer_overlay`, `apply_inferred_overlay`, `reconcile_overlay`, `has_dispatchable_overlay`) |
| `TicketPhaseSessionModel` | phase-visit sessions + cross-session ledger |
| `TicketSchedulingModel` | phase-task scheduling, task consumption, dirty-worktree preflight |
| `TicketEvidenceModel` | durable `extra`/`context` writers (the one locked RMW primitive) |
| `TicketStatusModel` | identity/liveness/diff introspection + status flags |

`TicketFacet` is a field-less abstract base carrying the shared type surface (`TYPE_CHECKING` field/enum shims), so each facet type-checks against the model's fields without redeclaring them and contributes no migration.

## Migration

`0004_ticket_issue_number` — `AddField(issue_number, db_index=True)` + a `RunPython` backfill mirroring `save` exactly. It does **not** touch the squashed `0001_initial`; the #3140 name-reuse gate stays green (its current-graph frozenset gains the new name). `makemigrations --check` → **No changes detected**. Verified applying on a fresh DB and an old-chain DB.

## Test evidence

- `test_ticket_structure.py` — own-public-method count ≤ 25 (RED before: 47), full pre-split public API still reachable, FSM source/target graph unchanged.
- `test_ticket_number_index.py` — `issue_number` indexed + populated; `_ticket_by_number` filters on the indexed column (asserts SQL); forge-number, pk-fallback, `auto:` exclusion.
- `test_ticket_issue_number_migration.py` — the `0004` backfill derives `issue_number` for pre-existing rows (RED-confirmed without the `RunPython`).
- Consumer surface green: `tests/teatree_core` (7584), `tests/teatree_loop`/`teatree_cli`/`teatree_mcp` (3803). ty whole-tree, ruff, tach, jscpd, module-health, deferred-import ratchet, migration-squash gate all green.

## Architecture pre-check — burndown Unit 5

### 1. BLUEPRINT § alignment
§4 Domain Models (`Ticket` carries the session FSM). Behaviour-preserving refactor + one additive indexed field; no state-graph or extension-point contract changes, so no BLUEPRINT prose change.

### 2. FSM phase boundaries
None crossed. The 18 transitions stay on the concrete `Ticket`; sources/targets are byte-identical (pinned by `test_ticket_structure::TestFsmGraphUnchanged`).

### 3. Extension-point contracts
No `OverlayBase` / scanner / hook / `*Backend` Protocol touched. `Ticket`'s public API is unchanged; consumers unaffected.

### 4. Component boundaries
`src/teatree/core/models/` — one concern per module (the facets + the pure `ticket_number` helper), matching the "one model per module" core convention.

### 5. Dependency direction
Facets import the shared `TicketFacet` base and existing model helpers only; `resolve.py` gains no import. `uv run tach check` → all modules validated (no backwards edge).

### 6. Test surface
Structural guards (method count, API reachability, FSM graph), index behaviour + SQL-shape, and the migration backfill each have a named assertion; the migration-squash gate covers fresh + old-chain apply.

### 7. Resilience invariants
No new external write. The locked `extra`/`context` RMW (verify-by-re-read, idempotent) moved verbatim into `TicketEvidenceModel`.

### 8. Identity and key normalization
`ticket_number` derivation is centralized in one pure `derive_issue_number` used by the property, `save`, and the migration — the persisted `issue_number` and the derived property cannot drift.

### 9. Behavior preservation / capability deletion
Purely structural relocation; every pre-split public method enumerated and asserted still reachable. No matcher/gate narrowed; no must-block test inverted.

### 10. Removability / harness-vs-data
Facets are self-contained abstract bases; the split is reversible by re-inlining. `issue_number` is a query denormalization of existing data, not new policy.

## Open questions & assumptions

- **Assumed:** abstract-model facets (Django's native model-decomposition) over composed attributes. Composed attributes cannot preserve the flat `ticket.foo()` API without rewriting ~130 consumer call sites, which the behaviour-preserving mandate forbids. This is an intentional divergence from the "composition over mixins" style preference; the core `CLAUDE.md` permits documented divergence when following the framework's own pattern.
- **Assumed:** the `ticket_number` property stays behaviour-identical (57 consumers); `issue_number` is a query-only denormalization, not new API.
- **Decided-by-design:** deferred-import pegs relocated from `ticket.py` to the facets (net −2, two `type(self)` conversions). The repo-wide PLC0415 burndown is out of scope (Unit 20).
