### PR TITLE
refactor(worktree): de-shim branch classification, signal never-authorizes (U15)

### DIFF
--- a/src/teatree/cli/_update_reconcile.py
+++ b/src/teatree/cli/_update_reconcile.py
@@ -7,8 +7,8 @@ N, behind M]`` and ``--ff-only`` aborts. :func:`reconcile_squash_merged`
 self-heals it — but only when the unique commits are provably already upstream.
 
 The subject classifier
-(:func:`teatree.core.worktree.branch_classification.classify_branch_commits`) is only a
-cheap PRE-FILTER: it buckets ``squash_merged`` by canonicalized-subject
+(:func:`teatree.core.worktree.branch_classification.prefilter_branch_commits_by_subject`)
+is only a cheap PRE-FILTER: it buckets ``squash_merged`` by canonicalized-subject
 membership alone, with no content/patch-id/tree check, so a genuine commit can
 slip past it (subject collision, amended content, evil-merge). The destructive
 ``git reset --hard`` is authorized by the AUTHORITATIVE *content* gate instead —
@@ -29,7 +29,10 @@ from typing import TYPE_CHECKING
 
 import typer
 
-from teatree.core.worktree.branch_classification import classify_branch_commits, content_equivalence_blockers
+from teatree.core.worktree.branch_classification import (
+    content_equivalence_blockers,
+    prefilter_branch_commits_by_subject,
+)
 
 if TYPE_CHECKING:
     from teatree.cli.update import RepoUpdate
@@ -73,8 +76,8 @@ def reconcile_squash_merged(name: str, repo: Path, old_sha: str, pull_stderr: st
     SKIPPED earlier), so a reconcile here always acts on the default branch.
 
     Data-loss-free by construction. The subject classifier
-    (:func:`classify_branch_commits`) is only a cheap PRE-FILTER — it must NOT
-    authorize the destructive ``git reset --hard``, because it buckets by
+    (:func:`prefilter_branch_commits_by_subject`) is only a cheap PRE-FILTER — it
+    must NOT authorize the destructive ``git reset --hard``, because it buckets by
     canonicalized-subject membership alone with NO content/patch-id/tree check: a
     genuine un-upstreamed commit whose subject collides with an unrelated upstream
     subject (vector B), an amended commit that added content after the original
@@ -103,7 +106,7 @@ def reconcile_squash_merged(name: str, repo: Path, old_sha: str, pull_stderr: st
     default_branch = _default_branch(repo)
     target = f"origin/{default_branch}" if default_branch else "origin/main"
     branch = _current_branch(repo)
-    classification = classify_branch_commits(str(repo), branch, target=target)
+    classification = prefilter_branch_commits_by_subject(str(repo), branch, target=target)
 
     if classification.genuinely_ahead:
         return _refuse_reconcile(

--- a/src/teatree/cli/update.py
+++ b/src/teatree/cli/update.py
@@ -17,8 +17,8 @@ For teatree core (``$T3_REPO``) and every registered overlay repo, this:
     because the clone's local commits already landed *squash-merged* upstream
     (the recurring overlay brick — ``[ahead N, behind M]`` with N already-upstream
     duplicates), the clone SELF-HEALS. The subject classifier
-    (``core.branch_classification.classify_branch_commits``) is only a cheap
-    PRE-FILTER — it must NOT authorize the destructive reset (it matches by
+    (``core.branch_classification.prefilter_branch_commits_by_subject``) is only a
+    cheap PRE-FILTER — it must NOT authorize the destructive reset (it matches by
     canonicalized subject alone, with no content check). Before any
     ``git reset --hard origin/<default>`` an AUTHORITATIVE content gate runs:
     the reset proceeds ONLY when ``git cherry origin/<default> HEAD`` reports

--- a/src/teatree/core/cleanup/cleanup.py
+++ b/src/teatree/core/cleanup/cleanup.py
@@ -1,11 +1,11 @@
 """Shared worktree cleanup logic used by sync (auto-clean on merge) and workspace commands.
 
 The squash-merge-aware classification this module relies on lives in
-:mod:`teatree.core.worktree.branch_classification`; the data-loss guards and the
-worktree-teardown orchestration live here. The names re-exported below keep the
-import surface (``from teatree.core.cleanup.cleanup import classify_branch_commits``,
-``cleanup_mod._branch_pr_is_merged``) stable for the management commands and the
-sync backends that funnel through this seam.
+:mod:`teatree.core.worktree.branch_classification` — the single home of both the
+subject pre-filter and the authoritative content gate. This module imports only
+the helpers its own data-loss guards call; every other consumer imports the
+classifier from ``branch_classification`` directly (no back-compat re-export shim).
+The data-loss guards and the worktree-teardown orchestration live here.
 """
 
 import logging
@@ -26,14 +26,9 @@ from teatree.core.models import Worktree
 from teatree.core.overlay_loader import get_overlay_for_worktree
 from teatree.core.worktree._overlay_teardown import reap_external_resources, run_overlay_cleanup_steps
 from teatree.core.worktree.branch_classification import (
-    BranchClassification,
-    BranchCommit,
     _branch_pr_is_merged,
     _branch_tree_matches_squash,
-    _pr_merge_commit_sha,
-    classify_branch_commits,
     content_equivalence_blockers,
-    probe_host_cli,
 )
 from teatree.core.worktree.clone_paths import resolve_clone_path
 from teatree.core.worktree.worktree_env import compose_project, worktree_pg_connection
@@ -44,16 +39,9 @@ from teatree.utils.postgres_secret import remove_postgres_pass_entry
 from teatree.utils.run import CommandFailedError
 
 __all__ = [
-    "BranchClassification",
-    "BranchCommit",
     "CleanupResult",
     "WorktreeBusyError",
-    "_branch_pr_is_merged",
-    "_branch_tree_matches_squash",
-    "_pr_merge_commit_sha",
-    "classify_branch_commits",
     "cleanup_worktree",
-    "probe_host_cli",
 ]
 
 logger = logging.getLogger(__name__)
@@ -168,8 +156,8 @@ def _raise_if_genuinely_ahead(repo_main: str, worktree: Worktree, target: _Effec
     via the worktree-dir probe).
 
     **Content-equivalence authorizes the destroy, not subject-match (#2609).**
-    :func:`classify_branch_commits` is a cheap SUBJECT recognizer — it cannot
-    authorize a force-delete, because a genuine un-upstreamed commit whose subject
+    :func:`prefilter_branch_commits_by_subject` is a cheap SUBJECT recognizer — it
+    cannot authorize a force-delete, because a genuine un-upstreamed commit whose subject
     collides with an already-upstreamed subject (a routine ``docs: update skills``)
     drains into ``squash_merged`` and would falsely empty ``genuinely_ahead``. The
     AUTHORITATIVE gate is :func:`content_equivalence_blockers` (``git cherry``

--- a/src/teatree/core/gates/orphan_guard.py
+++ b/src/teatree/core/gates/orphan_guard.py
@@ -22,8 +22,12 @@ from dataclasses import dataclass
 from enum import StrEnum
 
 from teatree.config import clone_root
-from teatree.core.cleanup.cleanup import _branch_tree_matches_squash, classify_branch_commits, probe_host_cli
 from teatree.core.models import Worktree
+from teatree.core.worktree.branch_classification import (
+    _branch_tree_matches_squash,
+    prefilter_branch_commits_by_subject,
+    probe_host_cli,
+)
 from teatree.core.worktree.clone_paths import resolve_clone_path
 from teatree.utils import git
 from teatree.utils.run import CommandFailedError
@@ -83,8 +87,8 @@ def _origin_default_branch_target(repo: str) -> str:
     """Resolve ``origin/<default-branch>`` for the repo, defaulting to ``origin/main``.
 
     A repo whose default branch is ``master`` (or any non-``main`` name) was
-    misclassified as SYNCED because :func:`classify_branch_commits` defaulted
-    to ``origin/main``. Resolving the actual default via ``git symbolic-ref
+    misclassified as SYNCED because :func:`prefilter_branch_commits_by_subject`
+    defaulted to ``origin/main``. Resolving the actual default via ``git symbolic-ref
     refs/remotes/origin/HEAD`` makes the comparison authoritative.
     """
     try:
@@ -96,7 +100,7 @@ def _origin_default_branch_target(repo: str) -> str:
 def classify_branch(repo: str, branch: str) -> BranchReport:
     """Classify ``branch`` in ``repo`` as synced, open PR, or orphan (unpushed / pushed)."""
     target = _origin_default_branch_target(repo)
-    classification = classify_branch_commits(repo, branch, target=target)
+    classification = prefilter_branch_commits_by_subject(repo, branch, target=target)
     ahead = len(classification.genuinely_ahead)
 
     if ahead == 0:

--- a/src/teatree/core/worktree/branch_classification.py
+++ b/src/teatree/core/worktree/branch_classification.py
@@ -57,18 +57,27 @@ class BranchCommit:
 
 
 @dataclass(frozen=True)
-class BranchClassification:
-    """Structured view of a branch's unsynced commits, split by disposition.
+class SubjectPrefilterResult:
+    """A subject-only pre-filter of a branch's unsynced commits — NEVER authorizes a destroy.
+
+    The bucketing is by canonicalized SUBJECT membership alone, with no
+    content/patch-id/tree check, so it can only *recognize* a likely
+    squash-merged candidate cheaply — it must never be the sole gate on a
+    destructive action. :func:`content_equivalence_blockers` is the authoritative
+    content gate every destructive caller passes instead.
 
     ``squash_merged`` — subject matches a commit on the target branch, so the
-    content is already integrated (typical squash-merge case, including the
-    ``relax:`` → ``feat:`` prefix rewrite).
+    content is *probably* already integrated (typical squash-merge case,
+    including the ``relax:`` → ``feat:`` prefix rewrite). A subject collision with
+    an unrelated upstream commit lands a genuine commit here — hence pre-filter
+    only.
 
     ``merge_commits`` — commits with multiple parents (Merge branch 'main' into
-    feature). They carry no net content of their own and are safe to discard.
+    feature). They carry no net content of their own and are usually safe to
+    discard, but an evil-merge can, so the content gate still has final say.
 
-    ``genuinely_ahead`` — everything else. The branch has work that does not
-    appear on the target, so removing it would lose content.
+    ``genuinely_ahead`` — everything else. The branch has work whose subject does
+    not appear on the target.
     """
 
     squash_merged: list[BranchCommit] = field(default_factory=list)
@@ -123,8 +132,14 @@ def _canonicalize_subject(subject: str) -> str:
     return stripped.lower()
 
 
-def classify_branch_commits(repo: str, branch: str, target: str = "origin/main") -> BranchClassification:
-    """Split the branch's unsynced commits into squash-merged / merge / genuinely-ahead buckets.
+def prefilter_branch_commits_by_subject(repo: str, branch: str, target: str = "origin/main") -> SubjectPrefilterResult:
+    """Subject-only PRE-FILTER of the branch's unsynced commits — NEVER authorizes a destroy.
+
+    Buckets into squash-merged / merge / genuinely-ahead by canonicalized SUBJECT
+    alone. This is a cheap recognizer, NOT an authorizer: a genuine un-upstreamed
+    commit whose subject collides with an already-upstreamed subject slips into
+    ``squash_merged``, so no destructive caller may act on this result without the
+    authoritative :func:`content_equivalence_blockers` content gate confirming it.
 
     Runs two git log invocations: one to list branch commits not on any remote
     (same as :func:`git.unsynced_commits`), one to fetch subjects on ``target``
@@ -139,7 +154,7 @@ def classify_branch_commits(repo: str, branch: str, target: str = "origin/main")
         repo=repo,
         args=["log", branch, "--not", target, "--format=%H%x00%P%x00%s"],
     )
-    classification = BranchClassification()
+    classification = SubjectPrefilterResult()
     if not raw.strip():
         return classification
 
@@ -169,8 +184,8 @@ def content_equivalence_blockers(repo: str, branch: str, target: str = "origin/m
     """Return the commit(s) on ``branch`` NOT provably content-equivalent to ``target``.
 
     The AUTHORITATIVE content gate every destructive caller must pass before
-    destroying ``branch`` (#2609). :func:`classify_branch_commits` buckets by
-    canonicalized SUBJECT alone — fine to *recognize* a forge-squash-merged
+    destroying ``branch`` (#2609). :func:`prefilter_branch_commits_by_subject`
+    buckets by canonicalized SUBJECT alone — fine to *recognize* a forge-squash-merged
     candidate, but unsafe to *authorize* a destroy: a genuine un-upstreamed
     commit whose subject collides with an already-upstreamed subject (a routine
     ``docs: update skills``), an amended commit that added content after the
@@ -205,17 +220,6 @@ def content_equivalence_blockers(repo: str, branch: str, target: str = "origin/m
         return [*blockers, "(git rev-list --merges failed — merge check inconclusive)"]
     blockers.extend(sha.strip() for sha in merges.splitlines() if sha.strip())
     return blockers
-
-
-def branch_content_upstream(repo: str, branch: str, target: str = "origin/main") -> bool:
-    """Whether every commit on ``branch`` is provably content-equivalent to ``target``.
-
-    The boolean view of :func:`content_equivalence_blockers`: ``True`` only when
-    the content gate found NO blocker, so destroying ``branch`` loses nothing.
-    ``False`` on any blocker AND on any inconclusive git error (the helper fails
-    closed) — destruction requires positive proof.
-    """
-    return not content_equivalence_blockers(repo, branch, target)
 
 
 def _pr_merge_commit_sha(repo: str, branch: str) -> str:

--- a/src/teatree/core/worktree/reconcile.py
+++ b/src/teatree/core/worktree/reconcile.py
@@ -308,7 +308,9 @@ def _reconcile_overlay_dependent_stores(drift: Drift, wt: Worktree) -> None:
         drift.orphan_containers.extend(OrphanContainer(name=n) for n in _find_docker_containers(compose_project(wt)))
 
 
-def _collect_stale_worktree_dirs(drift: Drift, worktrees: list[Worktree], ticket: Ticket, workspace: Path) -> None:
+def _collect_stale_worktree_dirs(
+    drift: Drift, worktrees: list[Worktree], ticket: Ticket, clone_workspace: Path
+) -> None:
     """Append :class:`StaleWorktreeDir` findings for unclaimed git worktrees."""
     stored_paths: list[str] = [
         str(wt.extra["worktree_path"]) for wt in worktrees if (wt.extra or {}).get("worktree_path")
@@ -318,7 +320,7 @@ def _collect_stale_worktree_dirs(drift: Drift, worktrees: list[Worktree], ticket
     # ``-`` (or the string ends), never a substring of a longer number.
     ticket_anchor = re.compile(rf"(?:^|[/-]){re.escape(ticket.ticket_number)}(?:[-/]|$)")
     for wt in worktrees:
-        repo_main = resolve_clone_path(workspace, wt) or workspace / wt.repo_path
+        repo_main = resolve_clone_path(clone_workspace, wt) or clone_workspace / wt.repo_path
         for path_str in _find_worktree_paths_on_disk(repo_main):
             if paths_match(path_str, repo_main):
                 continue
@@ -385,7 +387,9 @@ def _default_target_ref(repo: Path) -> str:
         return _FALLBACK_TARGET
 
 
-def _done_but_unmerged_for_ticket(ticket: Ticket, worktrees: list[Worktree], workspace: Path) -> DoneButUnmerged | None:
+def _done_but_unmerged_for_ticket(
+    ticket: Ticket, worktrees: list[Worktree], clone_workspace: Path
+) -> DoneButUnmerged | None:
     """DoneButUnmerged when a done-claiming ticket has no merge evidence and its branch is not upstream.
 
     Requires a probeable branch to prove the negative: a done-claiming ticket with
@@ -400,7 +404,7 @@ def _done_but_unmerged_for_ticket(ticket: Ticket, worktrees: list[Worktree], wor
         return None
     verdicts: list[tuple[str, RedundancyVerdict]] = []
     for wt in worktrees:
-        repo = resolve_clone_path(workspace, wt)
+        repo = resolve_clone_path(clone_workspace, wt)
         if repo is None or not repo.is_dir():
             continue
         verdict = branch_redundancy(str(repo), wt.branch, _default_target_ref(repo))
@@ -439,8 +443,13 @@ def _duplicate_scope_for_ticket(
     return DuplicateScope(issue_number=issue_number, paths=[own, *foreign])
 
 
-def _collect_work_state_drift(drift: Drift, ticket: Ticket, worktrees: list[Worktree], workspace: Path) -> None:
+def _collect_work_state_drift(drift: Drift, ticket: Ticket, worktrees: list[Worktree], clone_workspace: Path) -> None:
     """Append the three work-tracking-truth findings (SELFCATCH-1) for one ticket.
+
+    Two distinct workspace roots are threaded here and must not be conflated:
+    ``clone_workspace`` (:func:`clone_root`) locates the bare clones the
+    done-but-unmerged probe reads, while the duplicate-scope finder walks the
+    :func:`worktree_root` tree where the checked-out worktrees live.
 
     Read-only: every finder SURFACES drift and never mutates — auto-push and
     auto-delete stay gated behind the destructive commands.
@@ -449,7 +458,7 @@ def _collect_work_state_drift(drift: Drift, ticket: Ticket, worktrees: list[Work
         finding = _unpushed_work_for_worktree(wt)
         if finding is not None:
             drift.unpushed_work.append(finding)
-    done = _done_but_unmerged_for_ticket(ticket, worktrees, workspace)
+    done = _done_but_unmerged_for_ticket(ticket, worktrees, clone_workspace)
     if done is not None:
         drift.done_but_unmerged.append(done)
     dup = _duplicate_scope_for_ticket(ticket, worktrees, worktree_root())
@@ -460,13 +469,13 @@ def _collect_work_state_drift(drift: Drift, ticket: Ticket, worktrees: list[Work
 def reconcile_ticket(ticket: Ticket) -> Drift:
     """Walk every state store and return a typed ``Drift`` for *ticket*."""
     drift = Drift(ticket_pk=ticket.pk)
-    workspace = clone_root()
+    clone_workspace = clone_root()
     worktrees = list(Worktree.objects.filter(ticket=ticket))
 
     for wt in worktrees:
         _reconcile_worktree_row(drift, wt)
-    _collect_stale_worktree_dirs(drift, worktrees, ticket, workspace)
-    _collect_work_state_drift(drift, ticket, worktrees, workspace)
+    _collect_stale_worktree_dirs(drift, worktrees, ticket, clone_workspace)
+    _collect_work_state_drift(drift, ticket, worktrees, clone_workspace)
     return drift
 
 

--- a/tests/teatree_core/cleanup/test_branch_classifier_deshim.py
+++ b/tests/teatree_core/cleanup/test_branch_classifier_deshim.py
@@ -1,0 +1,62 @@
+"""The branch classifier lives ONLY in ``worktree.branch_classification`` (no shim).
+
+Guards the #2609-era de-shim: the subject classifier and the content gate were
+consolidated into :mod:`teatree.core.worktree.branch_classification`, and the
+back-compat re-export shim on :mod:`teatree.core.cleanup.cleanup` was deleted
+(no-deprecated-aliases rule). This test fails if any of the re-export shim
+creeps back, and pins the "signals-never-authorizes" rename of the subject
+pre-filter.
+"""
+
+from teatree.core.cleanup import cleanup as cleanup_mod
+from teatree.core.worktree import branch_classification
+
+
+class TestBranchClassifierIsCanonicalOnly:
+    """The classifier API is reachable only from its canonical module."""
+
+    def test_cleanup_does_not_re_export_the_subject_prefilter(self) -> None:
+        """``cleanup.cleanup`` no longer re-exports the branch classifier surface.
+
+        The management commands and sync backends must import the classifier
+        from :mod:`teatree.core.worktree.branch_classification` directly; the
+        old ``from teatree.core.cleanup.cleanup import ...`` seam is gone.
+        """
+        for shimmed in (
+            "SubjectPrefilterResult",
+            "BranchClassification",
+            "BranchCommit",
+            "prefilter_branch_commits_by_subject",
+            "classify_branch_commits",
+            "probe_host_cli",
+            "_pr_merge_commit_sha",
+        ):
+            assert not hasattr(cleanup_mod, shimmed), (
+                f"cleanup.cleanup must not re-export {shimmed!r} — import it from "
+                "teatree.core.worktree.branch_classification"
+            )
+
+    def test_cleanup_all_lists_only_its_own_surface(self) -> None:
+        """``cleanup.__all__`` carries none of the branch-classifier names."""
+        classifier_surface = {
+            "SubjectPrefilterResult",
+            "BranchClassification",
+            "BranchCommit",
+            "prefilter_branch_commits_by_subject",
+            "classify_branch_commits",
+            "probe_host_cli",
+            "_pr_merge_commit_sha",
+            "content_equivalence_blockers",
+        }
+        assert classifier_surface.isdisjoint(set(cleanup_mod.__all__))
+
+    def test_subject_prefilter_is_renamed_to_signal_never_authorizes(self) -> None:
+        """The subject engine is ``prefilter_*`` — the old ``classify_*`` name is gone."""
+        assert hasattr(branch_classification, "prefilter_branch_commits_by_subject")
+        assert hasattr(branch_classification, "SubjectPrefilterResult")
+        assert not hasattr(branch_classification, "classify_branch_commits")
+        assert not hasattr(branch_classification, "BranchClassification")
+
+    def test_dead_content_upstream_boolean_view_is_removed(self) -> None:
+        """The zero-caller ``branch_content_upstream`` public API is deleted."""
+        assert not hasattr(branch_classification, "branch_content_upstream")

--- a/tests/teatree_core/cleanup/test_cleanup_worktree.py
+++ b/tests/teatree_core/cleanup/test_cleanup_worktree.py
@@ -27,7 +27,7 @@ _patch_overlay = patch("teatree.core.cleanup.cleanup.get_overlay_for_worktree")
 # The origin/main hygiene gate is now authorized by the CONTENT gate (#2609),
 # not subject-match — so a test that drives the gate patches
 # ``content_equivalence_blockers``, the helper every destructive caller funnels
-# through, rather than the cheap ``classify_branch_commits`` recognizer.
+# through, rather than the cheap ``prefilter_branch_commits_by_subject`` recognizer.
 _patch_content = patch("teatree.core.cleanup.cleanup.content_equivalence_blockers")
 # Pin the #2205 merged-evidence override to False so tests that set
 # ``commits_absent_from_all_remotes`` to a non-empty list still hit the

--- a/tests/teatree_core/cleanup/test_content_equivalence.py
+++ b/tests/teatree_core/cleanup/test_content_equivalence.py
@@ -1,6 +1,6 @@
 """Content-equivalence authorization for the destructive clean-all paths (#2609).
 
-``classify_branch_commits`` buckets a branch's commits ``squash_merged`` purely
+``prefilter_branch_commits_by_subject`` buckets a branch's commits ``squash_merged`` purely
 by canonicalized-SUBJECT membership in the last N upstream subjects, with NO
 content/patch-id check. Subject-matching is fine to *recognize* a forge-squash-
 merged candidate (a squash creates a new SHA), but it is unsafe to *authorize*
@@ -28,7 +28,7 @@ from django.test import TestCase
 
 from teatree.core.cleanup.cleanup import CleanupResult, cleanup_worktree
 from teatree.core.models import Ticket, Worktree
-from teatree.core.worktree.branch_classification import branch_content_upstream, content_equivalence_blockers
+from teatree.core.worktree.branch_classification import content_equivalence_blockers
 from tests.teatree_core.cleanup._shared import _GIT, _clean_env, _run_git
 
 
@@ -108,7 +108,6 @@ class TestContentEquivalenceHelper(TestCase):
 
         assert blockers, "subject-colliding genuine commit must be a content-equivalence blocker"
         assert genuine_sha in blockers
-        assert branch_content_upstream(str(self.clone), "main", "origin/main") is False
 
     def test_genuinely_upstreamed_branch_has_no_blockers(self) -> None:
         """A commit whose patch already landed upstream (real squash-merge) is proven upstream."""
@@ -121,7 +120,6 @@ class TestContentEquivalenceHelper(TestCase):
         blockers = content_equivalence_blockers(str(self.clone), "main", "origin/main")
 
         assert blockers == [], "a patch-equivalent (squash-merged) commit must not block"
-        assert branch_content_upstream(str(self.clone), "main", "origin/main") is True
 
     def test_merge_commit_in_range_is_a_blocker(self) -> None:
         """A merge commit (no single patch-id) conservatively blocks — it may carry unique content."""
@@ -137,7 +135,6 @@ class TestContentEquivalenceHelper(TestCase):
         blockers = content_equivalence_blockers(str(self.clone), "main", "origin/main")
 
         assert blockers, "a merge commit in the unique range must conservatively block"
-        assert branch_content_upstream(str(self.clone), "main", "origin/main") is False
 
     def test_fails_closed_on_git_error(self) -> None:
         """An inconclusive content check (unresolvable target) REFUSES — never an empty pass."""
@@ -145,14 +142,13 @@ class TestContentEquivalenceHelper(TestCase):
 
         assert blockers, "an inconclusive git probe must report a blocker, not an empty pass"
         assert any("inconclusive" in b for b in blockers)
-        assert branch_content_upstream(str(self.clone), "main", "origin/does-not-exist") is False
 
 
 class TestCleanAllRefusesSubjectCollision(TestCase):
     """The clean-all force-DELETE path must REQUIRE content-equivalence (#2609).
 
     The data-loss scenario: a branch with a GENUINE un-upstreamed commit whose
-    subject collides with an upstream subject. ``classify_branch_commits`` drains
+    subject collides with an upstream subject. ``prefilter_branch_commits_by_subject`` drains
     it into ``squash_merged`` so ``genuinely_ahead`` is empty, and the branch is
     PUSHED to its own remote ref (so the #706 ``_raise_if_unpushed`` guard
     passes). Before this fix ``_raise_if_genuinely_ahead`` returned early on the

--- a/tests/teatree_core/test_orphan_guard.py
+++ b/tests/teatree_core/test_orphan_guard.py
@@ -4,20 +4,20 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.test import TestCase
 
-from teatree.core.cleanup.cleanup import BranchClassification, BranchCommit
 from teatree.core.gates.orphan_guard import BranchReport, BranchStatus, classify_branch, find_orphans_in_workspace
 from teatree.core.models import Ticket, Worktree
+from teatree.core.worktree.branch_classification import BranchCommit, SubjectPrefilterResult
 from teatree.utils.run import CommandFailedError
 from tests.teatree_core.cleanup._shared import _run_git
 
-_patch_classify = patch("teatree.core.gates.orphan_guard.classify_branch_commits")
+_patch_classify = patch("teatree.core.gates.orphan_guard.prefilter_branch_commits_by_subject")
 _patch_tree_match = patch("teatree.core.gates.orphan_guard._branch_tree_matches_squash")
 _patch_open_pr = patch("teatree.core.gates.orphan_guard.find_open_pr")
 _patch_git = patch("teatree.core.gates.orphan_guard.git")
 
 
-def _classification(ahead: list[BranchCommit] | None = None) -> BranchClassification:
-    return BranchClassification(genuinely_ahead=ahead or [])
+def _classification(ahead: list[BranchCommit] | None = None) -> SubjectPrefilterResult:
+    return SubjectPrefilterResult(genuinely_ahead=ahead or [])
 
 
 def _commit(sha: str = "abc", subject: str = "feat: x") -> BranchCommit:
@@ -234,7 +234,7 @@ class TestFindOrphansInWorkspace(TestCase):
 class TestClassifyBranchRespectsRepoDefaultBranch:
     """Real-git integration: ``classify_branch`` must use the repo's actual default branch.
 
-    ``classify_branch_commits`` defaults to ``target="origin/main"``; on a repo
+    ``prefilter_branch_commits_by_subject`` defaults to ``target="origin/main"``; on a repo
     whose default branch is ``master`` (or anything else), one-commit-ahead-of-
     master was misclassified as SYNCED because the comparison was against the
     non-existent ``origin/main``.

--- a/tests/teatree_core/worktree/test_branch_pr_is_merged.py
+++ b/tests/teatree_core/worktree/test_branch_pr_is_merged.py
@@ -14,7 +14,7 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
-from teatree.core.cleanup.cleanup import _branch_pr_is_merged
+from teatree.core.worktree.branch_classification import _branch_pr_is_merged
 
 
 def _dispatch(gh_stdout: str, glab_stdout: str) -> Callable[..., subprocess.CompletedProcess[str]]:

--- a/tests/teatree_core/worktree/test_prefilter_branch_commits_by_subject.py
+++ b/tests/teatree_core/worktree/test_prefilter_branch_commits_by_subject.py
@@ -1,11 +1,11 @@
-"""``classify_branch_commits`` bucketing logic.
+"""``prefilter_branch_commits_by_subject`` bucketing logic.
 
 Split verbatim from the former monolithic ``tests/teatree_core/test_cleanup.py``
-(souliane/teatree#443). These pure-logic cases drive the classifier directly
-with a mocked ``teatree.core.cleanup.cleanup.git.run_strict`` (#2937: the classifier's
-git calls fail loud on a real git error, so the happy-path mock target moved
-from the lenient ``git.run`` to the strict runner); no bucketing behavior
-change.
+(souliane/teatree#443). These pure-logic cases drive the subject pre-filter
+directly with a mocked ``teatree.core.worktree.branch_classification.git.run_strict``
+(#2937: the classifier's git calls fail loud on a real git error, so the
+happy-path mock target moved from the lenient ``git.run`` to the strict runner);
+no bucketing behavior change.
 """
 
 from unittest.mock import MagicMock, patch
@@ -13,73 +13,77 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.test import TestCase
 
-from teatree.core.cleanup.cleanup import BranchClassification, BranchCommit, classify_branch_commits
+from teatree.core.worktree.branch_classification import (
+    BranchCommit,
+    SubjectPrefilterResult,
+    prefilter_branch_commits_by_subject,
+)
 
 
-class TestClassifyBranchCommits(TestCase):
-    """``classify_branch_commits`` sorts branch-local commits into three buckets.
+class TestPrefilterBranchCommitsBySubject(TestCase):
+    """``prefilter_branch_commits_by_subject`` sorts branch-local commits into three buckets.
 
     The classifier is the foundation for squash-merge-aware cleanup: it lets
     the caller distinguish content already on the default branch (under a new
     SHA, via squash-merge) from work that still needs pushing.
     """
 
-    @patch("teatree.core.cleanup.cleanup.git.run_strict")
+    @patch("teatree.core.worktree.branch_classification.git.run_strict")
     def test_empty_when_no_unsynced_commits(self, mock_run: MagicMock) -> None:
         mock_run.side_effect = ["", ""]  # unsynced log empty, target log empty
-        result = classify_branch_commits("/repo", "feature")
-        assert result == BranchClassification(squash_merged=[], merge_commits=[], genuinely_ahead=[])
+        result = prefilter_branch_commits_by_subject("/repo", "feature")
+        assert result == SubjectPrefilterResult(squash_merged=[], merge_commits=[], genuinely_ahead=[])
 
-    @patch("teatree.core.cleanup.cleanup.git.run_strict")
+    @patch("teatree.core.worktree.branch_classification.git.run_strict")
     def test_subject_match_with_pr_suffix_marks_squash_merged(self, mock_run: MagicMock) -> None:
         branch_log = "abc123\x00parent1\x00fix(ui): button alignment"
         target_log = "fix(ui): button alignment (#42)\nfeat(core): unrelated"
         mock_run.side_effect = [branch_log, target_log]
 
-        result = classify_branch_commits("/repo", "feature")
+        result = prefilter_branch_commits_by_subject("/repo", "feature")
 
         assert result.squash_merged == [BranchCommit(sha="abc123", subject="fix(ui): button alignment", is_merge=False)]
         assert result.genuinely_ahead == []
 
-    @patch("teatree.core.cleanup.cleanup.git.run_strict")
+    @patch("teatree.core.worktree.branch_classification.git.run_strict")
     def test_strips_type_prefix_for_relax_to_feat_rewrite(self, mock_run: MagicMock) -> None:
         """Branch has ``relax: X (#140)``; main has ``feat(fsm): X (#140) (#368)`` — same content, different prefix."""
         branch_log = "def456\x00parent1\x00relax: transition-driven workflow (#140)"
         target_log = "feat(fsm): transition-driven workflow (#140) (#368)"
         mock_run.side_effect = [branch_log, target_log]
 
-        result = classify_branch_commits("/repo", "feature")
+        result = prefilter_branch_commits_by_subject("/repo", "feature")
 
         assert len(result.squash_merged) == 1
         assert result.squash_merged[0].sha == "def456"
         assert result.genuinely_ahead == []
 
-    @patch("teatree.core.cleanup.cleanup.git.run_strict")
+    @patch("teatree.core.worktree.branch_classification.git.run_strict")
     def test_merge_commit_detected_via_multiple_parents(self, mock_run: MagicMock) -> None:
         branch_log = "mrg001\x00parent1 parent2\x00Merge branch 'main' into feature"
         target_log = ""
         mock_run.side_effect = [branch_log, target_log]
 
-        result = classify_branch_commits("/repo", "feature")
+        result = prefilter_branch_commits_by_subject("/repo", "feature")
 
         assert len(result.merge_commits) == 1
         assert result.merge_commits[0].is_merge is True
         assert result.genuinely_ahead == []
         assert result.squash_merged == []
 
-    @patch("teatree.core.cleanup.cleanup.git.run_strict")
+    @patch("teatree.core.worktree.branch_classification.git.run_strict")
     def test_genuinely_ahead_when_no_subject_match(self, mock_run: MagicMock) -> None:
         branch_log = "new001\x00parent1\x00fix(hooks): strip trailing whitespace"
         target_log = "chore(deps): bump pytest\nfeat(config): add t3.mode"
         mock_run.side_effect = [branch_log, target_log]
 
-        result = classify_branch_commits("/repo", "feature")
+        result = prefilter_branch_commits_by_subject("/repo", "feature")
 
         assert result.squash_merged == []
         assert len(result.genuinely_ahead) == 1
         assert result.genuinely_ahead[0].sha == "new001"
 
-    @patch("teatree.core.cleanup.cleanup.git.run_strict")
+    @patch("teatree.core.worktree.branch_classification.git.run_strict")
     def test_mixed_buckets(self, mock_run: MagicMock) -> None:
         branch_log = (
             "sha1\x00p1\x00feat(config): add setting\n"
@@ -89,25 +93,25 @@ class TestClassifyBranchCommits(TestCase):
         target_log = "feat(config): add setting (#100)\nchore: unrelated"
         mock_run.side_effect = [branch_log, target_log]
 
-        result = classify_branch_commits("/repo", "feature")
+        result = prefilter_branch_commits_by_subject("/repo", "feature")
 
         assert [c.sha for c in result.squash_merged] == ["sha1"]
         assert [c.sha for c in result.merge_commits] == ["sha2"]
         assert [c.sha for c in result.genuinely_ahead] == ["sha3"]
 
-    @patch("teatree.core.cleanup.cleanup.git.run_strict")
+    @patch("teatree.core.worktree.branch_classification.git.run_strict")
     def test_unsynced_fully_merged_via_squash_returns_empty_genuinely_ahead(self, mock_run: MagicMock) -> None:
         """Every unsynced commit has a subject match on target → branch is safe to clean."""
         branch_log = "sha1\x00p1\x00feat(config): generic per-overlay override\nsha2\x00p1\x00fix: trailing whitespace"
         target_log = "feat(config): generic per-overlay override (#375)\nfix: trailing whitespace (#200)"
         mock_run.side_effect = [branch_log, target_log]
 
-        result = classify_branch_commits("/repo", "feature")
+        result = prefilter_branch_commits_by_subject("/repo", "feature")
 
         assert result.genuinely_ahead == []
         assert len(result.squash_merged) == 2
 
-    @patch("teatree.core.cleanup.cleanup.git.run_strict")
+    @patch("teatree.core.worktree.branch_classification.git.run_strict")
     def test_release_note_suffix_on_target_matches_plain_local_subject(self, mock_run: MagicMock) -> None:
         """Regression for #387 — target carries ``[flag] (url) (#NNN)``, local has only the plain subject."""
         branch_log = "sha1\x00p1\x00fix(ship,workspace): pre-push main merge + t3 pr create over raw gh/glab"
@@ -117,12 +121,12 @@ class TestClassifyBranchCommits(TestCase):
         )
         mock_run.side_effect = [branch_log, target_log]
 
-        result = classify_branch_commits("/repo", "feature")
+        result = prefilter_branch_commits_by_subject("/repo", "feature")
 
         assert [c.sha for c in result.squash_merged] == ["sha1"]
         assert result.genuinely_ahead == []
 
-    @patch("teatree.core.cleanup.cleanup.git.run_strict")
+    @patch("teatree.core.worktree.branch_classification.git.run_strict")
     def test_release_note_suffix_on_both_sides_matches(self, mock_run: MagicMock) -> None:
         """Both local and target carry the release-note suffix — canonicalization must strip from both."""
         branch_log = (
@@ -135,24 +139,24 @@ class TestClassifyBranchCommits(TestCase):
         )
         mock_run.side_effect = [branch_log, target_log]
 
-        result = classify_branch_commits("/repo", "feature")
+        result = prefilter_branch_commits_by_subject("/repo", "feature")
 
         assert [c.sha for c in result.squash_merged] == ["sha1"]
         assert result.genuinely_ahead == []
 
-    @patch("teatree.core.cleanup.cleanup.git.run_strict")
+    @patch("teatree.core.worktree.branch_classification.git.run_strict")
     def test_plain_subjects_without_release_note_suffix_still_match(self, mock_run: MagicMock) -> None:
         """Fallback case — neither title has a release-note suffix (e.g. ``chore:`` without ticket)."""
         branch_log = "sha1\x00p1\x00chore(prek): move pip-audit to manual stage"
         target_log = "chore(prek): move pip-audit to manual stage (#383)"
         mock_run.side_effect = [branch_log, target_log]
 
-        result = classify_branch_commits("/repo", "feature")
+        result = prefilter_branch_commits_by_subject("/repo", "feature")
 
         assert [c.sha for c in result.squash_merged] == ["sha1"]
         assert result.genuinely_ahead == []
 
-    @patch("teatree.core.cleanup.cleanup.git.run_strict")
+    @patch("teatree.core.worktree.branch_classification.git.run_strict")
     def test_git_failure_on_unsynced_log_propagates_instead_of_empty_classification(
         self,
         mock_run: MagicMock,
@@ -168,4 +172,4 @@ class TestClassifyBranchCommits(TestCase):
         )
 
         with pytest.raises(CommandFailedError):
-            classify_branch_commits("owner/repo", "feature")
+            prefilter_branch_commits_by_subject("owner/repo", "feature")

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -32,7 +32,7 @@ from teatree.cli.update import (
     _reinstall_and_resetup,
     update_repo,
 )
-from teatree.core.worktree.branch_classification import branch_content_upstream, content_equivalence_blockers
+from teatree.core.worktree.branch_classification import content_equivalence_blockers
 
 
 def _git(cwd: Path, *args: str) -> str:
@@ -979,7 +979,6 @@ class TestContentGateFailsSafe:
         blockers = content_equivalence_blockers(str(clone), "main", "origin/does-not-exist")
         assert blockers, "an inconclusive content probe must report a blocker, not an empty pass"
         assert "inconclusive" in blockers[0]
-        assert branch_content_upstream(str(clone), "main", "origin/does-not-exist") is False
 
 
 class TestRunCallback:


### PR DESCRIPTION
## Unit 15 — Worktree / branch-classification de-shim + safe-split

Burndown of the holistic-review findings for the branch classifier. Re-verified against current origin/main (post #3146).

### Findings addressed
- **should-fix (3e#2)** — Half-migrated branch-classifier back-compat shim on `core/cleanup/cleanup.py`. Deleted the re-export shim (import block + `__all__`); `cleanup` now keeps only the three helpers its own data-loss guards call (`_branch_pr_is_merged`, `_branch_tree_matches_squash`, `content_equivalence_blockers`). Repointed `core/gates/orphan_guard.py` (and the tests that imported the shimmed names) at `core.worktree.branch_classification` directly. `cli/_update_reconcile.py` already imported from the canonical module on current main.
- **should-fix (3e#9)** — The subject-based classifier read as authoritative while sharing a file with the content gate. Renamed to signal pre-filter-only, never-authorizes: `classify_branch_commits` -> `prefilter_branch_commits_by_subject`, `BranchClassification` -> `SubjectPrefilterResult`, with docstrings spelling out that only `content_equivalence_blockers` authorizes a destroy. Confirmed no destroy-authorizing caller reads the subject pre-filter (both consumers pair it with the content gate; orphan_guard is read-only).
- **nit** — Deleted the zero-caller `branch_content_upstream` public API. Renamed the `reconcile.py` work-state helpers' clone-root parameter to `clone_workspace` so it no longer reads similarly to the `worktree_root()` threaded to the duplicate-scope finder.

### Tests (anti-vacuous, RED-before)
- New `test_branch_classifier_deshim.py` guards that `cleanup.cleanup` no longer re-exports the classifier surface, `__all__` carries none of it, the rename landed, and `branch_content_upstream` is gone. Observed RED (4 failing) before, GREEN after.
- Repointed + renamed the bucket tests to the canonical module (moved under `tests/teatree_core/worktree/` for the test-path-mirror ratchet); dropped the dead-API assertions.

### Gates
- ruff, tach, import-linter, ty-check: pass. Leak gates (gitleaks, banned-terms, no-overlay-leak, privacy push gate): pass. test-path-mirror ratchet holds. Targeted suites: 279 passing. Full pre-push gate (FULL, triggered by the rename): pass.

Draft — human is away.