### PR TITLE
refactor(loops): shared hours_since() cadence gate + loop model/registry nits (unit 19)

### DIFF
--- a/src/teatree/core/models/loop.py
+++ b/src/teatree/core/models/loop.py
@@ -224,12 +224,24 @@ class Loop(models.Model):
         return self._as_local(self.last_run_at).date() < now_local.date()
 
     def _next_daily(self, now: dt.datetime) -> dt.datetime:
-        """The next wall-clock occurrence of ``daily_at`` (today if still ahead)."""
+        """The next wall-clock occurrence of ``daily_at`` (today if still ahead).
+
+        Each candidate slot is built as ``date + daily_at`` via
+        :func:`django.utils.timezone.make_aware`, not by mutating *now*:
+        ``now_local.replace(hour=…)`` would carry *now*'s UTC offset (and DST
+        ``fold``) onto the target wall-clock even when it lands on the other
+        side of a DST transition, and rolling to "tomorrow" with a 24h
+        ``timedelta`` would drift by the transition hour. Resolving the offset
+        from the active zone at the target instant keeps a non-UTC ``TIME_ZONE``
+        correct across spring-forward / fall-back (with ``TIME_ZONE="UTC"``, the
+        project default, there is no transition and the result is unchanged).
+        """
         now_local = self._as_local(now)
-        today_at = now_local.replace(hour=self.daily_at.hour, minute=self.daily_at.minute, second=0, microsecond=0)
-        if now_local.time() < self.daily_at:
-            return today_at
-        return today_at + dt.timedelta(days=1)
+        day = now_local.date() if now_local.time() < self.daily_at else now_local.date() + dt.timedelta(days=1)
+        naive_slot = dt.datetime.combine(day, self.daily_at)
+        if timezone.is_aware(now_local):
+            return timezone.make_aware(naive_slot, timezone.get_current_timezone())
+        return naive_slot
 
     @staticmethod
     def _as_local(when: dt.datetime) -> dt.datetime:

--- a/src/teatree/loop/scanners/architectural_review.py
+++ b/src/teatree/loop/scanners/architectural_review.py
@@ -46,6 +46,7 @@ Design notes
     (e.g. the GitLab approvals scanner). The ticket carries no FSM state.
 """
 
+import datetime as dt
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
@@ -55,7 +56,7 @@ from django.db import transaction
 from django.db.models import Count, Max, Q
 from django.utils import timezone
 
-from teatree.loop.scanners.base import ScanSignal
+from teatree.loop.scanners.base import ScanSignal, hours_since
 
 if TYPE_CHECKING:
     from teatree.core.models import Session as _Session
@@ -138,7 +139,7 @@ class ArchitecturalReviewScanner:
             status__in=_IN_FLIGHT_TASK_STATES,
         ).exists()
 
-    def _last_review_completed_at(self) -> object:
+    def _last_review_completed_at(self) -> dt.datetime | None:
         """Return the most recent review task's Session.started_at, or None.
 
         Returns ``None`` when no prior review task has been recorded for
@@ -154,7 +155,7 @@ class ArchitecturalReviewScanner:
         ).aggregate(ts=Max("session__started_at"))
         return aggregate["ts"]
 
-    def _evaluate_triggers(self, *, now: object, last_review_at: object) -> str | None:
+    def _evaluate_triggers(self, *, now: dt.datetime, last_review_at: dt.datetime | None) -> str | None:
         """Return the trigger name (``cadence`` / ``after_merge_count``) or None.
 
         Cadence wins over merge-count when both fire — the cadence is the
@@ -164,19 +165,14 @@ class ArchitecturalReviewScanner:
         """
         if last_review_at is None:
             return "bootstrap"
-        # ``now`` and ``last_review_at`` are ``datetime``s in practice;
-        # typed as ``object`` here to stay decoupled from ``Max()``'s
-        # return shape on the type checker. The subtraction is what
-        # matters, not the static type.
-        elapsed_hours = (now - last_review_at).total_seconds() / 3600.0  # type: ignore[operator]
-        if elapsed_hours >= self.cadence_hours:
+        if hours_since(last_review_at, now=now) >= self.cadence_hours:
             return "cadence"
         merges_since = self._count_merges_since(last_review_at)
         if merges_since >= self.after_merge_count:
             return "after_merge_count"
         return None
 
-    def _count_merges_since(self, last_review_at: object) -> int:
+    def _count_merges_since(self, last_review_at: dt.datetime) -> int:
         """Count tickets in this overlay whose latest merge transition is after *last_review_at*.
 
         We look at :class:`TicketTransition` rather than ``Ticket.state``

--- a/src/teatree/loop/scanners/backlog_sweep.py
+++ b/src/teatree/loop/scanners/backlog_sweep.py
@@ -35,6 +35,7 @@ Other invariants mirror ``scanning_news``:
     ``Session.started_at`` is the "last run" timestamp.
 """
 
+import datetime as dt
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
@@ -44,7 +45,7 @@ from django.db import transaction
 from django.db.models import Max
 from django.utils import timezone
 
-from teatree.loop.scanners.base import ScanSignal
+from teatree.loop.scanners.base import ScanSignal, hours_since
 
 if TYPE_CHECKING:
     from teatree.core.models import Session as _Session
@@ -132,7 +133,7 @@ class BacklogSweepScanner:
             status__in=_IN_FLIGHT_TASK_STATES,
         ).exists()
 
-    def _last_run_at(self) -> object:
+    def _last_run_at(self) -> dt.datetime | None:
         """Return the most recent task's Session.started_at, or None.
 
         ``None`` when no prior backlog-sweep task has been recorded — the
@@ -147,12 +148,11 @@ class BacklogSweepScanner:
         ).aggregate(ts=Max("session__started_at"))
         return aggregate["ts"]
 
-    def _evaluate_trigger(self, *, now: object, last_run_at: object) -> str | None:
+    def _evaluate_trigger(self, *, now: dt.datetime, last_run_at: dt.datetime | None) -> str | None:
         """Return the trigger name (``bootstrap`` / ``cadence``) or None."""
         if last_run_at is None:
             return "bootstrap"
-        elapsed_hours = (now - last_run_at).total_seconds() / 3600.0  # type: ignore[operator]
-        if elapsed_hours >= self.cadence_hours:
+        if hours_since(last_run_at, now=now) >= self.cadence_hours:
             return "cadence"
         return None
 

--- a/src/teatree/loop/scanners/base.py
+++ b/src/teatree/loop/scanners/base.py
@@ -5,6 +5,7 @@ Each scanner returns a list of ``ScanSignal``s. The dispatcher reads the
 note, webhook trigger) or hand off to a phase agent.
 """
 
+import datetime as dt
 from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
 
@@ -17,9 +18,26 @@ __all__ = [
     "ScannerErrorClass",
     "SignalPayload",
     "classify_gh_stderr",
+    "hours_since",
 ]
 
 type SignalPayload = dict[str, Any]
+
+
+def hours_since(earlier: dt.datetime, *, now: dt.datetime) -> float:
+    """Fractional hours from *earlier* to *now*.
+
+    The shared cadence-gate primitive for the once-per-N-hours scanners
+    (``backlog_sweep``, ``eval_local``, ``provision_smoke``,
+    ``architectural_review``, ``scanning_news``): each guards its own never-run
+    ``bootstrap`` case with a plain ``last_run_at is None`` check — which also
+    narrows the nullable ``Max("session__started_at")`` aggregate to a concrete
+    ``datetime`` — then calls this for the elapsed measurement. That replaces
+    five copy-pasted ``(now - earlier).total_seconds() / 3600.0`` sites, each of
+    which carried a ``# type: ignore[operator]`` only because the un-narrowed
+    ``object``-typed operand defeated the subtraction's type check.
+    """
+    return (now - earlier).total_seconds() / 3600.0
 
 
 def classify_gh_stderr(stderr: str) -> ScannerErrorClass:

--- a/src/teatree/loop/scanners/eval_local.py
+++ b/src/teatree/loop/scanners/eval_local.py
@@ -27,6 +27,7 @@ The scanner mirrors :mod:`teatree.loop.scanners.scanning_news`:
     long-running suite never blocks the tick.
 """
 
+import datetime as dt
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
@@ -36,7 +37,7 @@ from django.db import transaction
 from django.db.models import Max
 from django.utils import timezone
 
-from teatree.loop.scanners.base import ScanSignal
+from teatree.loop.scanners.base import ScanSignal, hours_since
 
 if TYPE_CHECKING:
     from teatree.core.models import Session as _Session
@@ -107,7 +108,7 @@ class EvalLocalScanner:
             status__in=_IN_FLIGHT_TASK_STATES,
         ).exists()
 
-    def _last_run_at(self) -> object:
+    def _last_run_at(self) -> dt.datetime | None:
         task_model = _task_model()
         if task_model is None:
             return None
@@ -117,11 +118,10 @@ class EvalLocalScanner:
         ).aggregate(ts=Max("session__started_at"))
         return aggregate["ts"]
 
-    def _evaluate_trigger(self, *, now: object, last_run_at: object) -> str | None:
+    def _evaluate_trigger(self, *, now: dt.datetime, last_run_at: dt.datetime | None) -> str | None:
         if last_run_at is None:
             return "bootstrap"
-        elapsed_hours = (now - last_run_at).total_seconds() / 3600.0  # type: ignore[operator]
-        if elapsed_hours >= self.cadence_hours:
+        if hours_since(last_run_at, now=now) >= self.cadence_hours:
             return "cadence"
         return None
 

--- a/src/teatree/loop/scanners/provision_smoke.py
+++ b/src/teatree/loop/scanners/provision_smoke.py
@@ -15,6 +15,7 @@ so the scanner has no responsibility for the verdict pipeline beyond
 keeping its cadence honest.
 """
 
+import datetime as dt
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
@@ -24,7 +25,7 @@ from django.db import transaction
 from django.db.models import Max
 from django.utils import timezone
 
-from teatree.loop.scanners.base import ScanSignal
+from teatree.loop.scanners.base import ScanSignal, hours_since
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -99,7 +100,7 @@ class ProvisionSmokeScanner:
             status__in=_IN_FLIGHT_TASK_STATES,
         ).exists()
 
-    def _last_run_at(self) -> object:
+    def _last_run_at(self) -> dt.datetime | None:
         task_model = _task_model()
         if task_model is None:
             return None
@@ -109,11 +110,10 @@ class ProvisionSmokeScanner:
         ).aggregate(ts=Max("session__started_at"))
         return aggregate["ts"]
 
-    def _evaluate_trigger(self, *, now: object, last_run_at: object) -> str | None:
+    def _evaluate_trigger(self, *, now: dt.datetime, last_run_at: dt.datetime | None) -> str | None:
         if last_run_at is None:
             return "bootstrap"
-        elapsed_hours = (now - last_run_at).total_seconds() / 3600.0  # type: ignore[operator]
-        if elapsed_hours >= self.cadence_hours:
+        if hours_since(last_run_at, now=now) >= self.cadence_hours:
             return "cadence"
         return None
 

--- a/src/teatree/loop/scanners/scanning_news.py
+++ b/src/teatree/loop/scanners/scanning_news.py
@@ -25,6 +25,7 @@ deliberately simpler:
     ``architectural_review``).
 """
 
+import datetime as dt
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
@@ -34,7 +35,7 @@ from django.db import transaction
 from django.db.models import Max
 from django.utils import timezone
 
-from teatree.loop.scanners.base import ScanSignal
+from teatree.loop.scanners.base import ScanSignal, hours_since
 
 if TYPE_CHECKING:
     from teatree.core.models import Session as _Session
@@ -124,7 +125,7 @@ class ScanningNewsScanner:
             status__in=_IN_FLIGHT_TASK_STATES,
         ).exists()
 
-    def _last_run_at(self) -> object:
+    def _last_run_at(self) -> dt.datetime | None:
         """Return the most recent task's Session.started_at, or None.
 
         ``None`` when no prior scanning-news task has been recorded — the
@@ -139,16 +140,11 @@ class ScanningNewsScanner:
         ).aggregate(ts=Max("session__started_at"))
         return aggregate["ts"]
 
-    def _evaluate_trigger(self, *, now: object, last_run_at: object) -> str | None:
+    def _evaluate_trigger(self, *, now: dt.datetime, last_run_at: dt.datetime | None) -> str | None:
         """Return the trigger name (``bootstrap`` / ``cadence``) or None."""
         if last_run_at is None:
             return "bootstrap"
-        # ``now`` and ``last_run_at`` are ``datetime``s in practice;
-        # typed as ``object`` here to stay decoupled from ``Max()``'s
-        # return shape on the type checker. The subtraction is what
-        # matters, not the static type.
-        elapsed_hours = (now - last_run_at).total_seconds() / 3600.0  # type: ignore[operator]
-        if elapsed_hours >= self.cadence_hours:
+        if hours_since(last_run_at, now=now) >= self.cadence_hours:
             return "cadence"
         return None
 

--- a/src/teatree/loops/registry.py
+++ b/src/teatree/loops/registry.py
@@ -6,9 +6,8 @@ module-level ``MINI_LOOP: MiniLoop`` constant in its ``loop`` submodule.
 and returns the constants sorted alphabetically by name.
 
 Only true subpackages are considered (``sub.ispkg``), so the top-level helper
-modules (``base``, ``registry``, ``config``, ``master``, ``run``, …) are skipped
-already; the named-exclusion set is a belt-and-suspenders guard for the few that
-share the package namespace.
+modules (``base``, ``registry``, ``config``, ``run``, …) — plain ``.py`` files,
+not packages — are skipped by that check alone.
 """
 
 import importlib
@@ -20,17 +19,11 @@ from teatree.loops.base import MiniLoop
 
 logger = logging.getLogger(__name__)
 
-_HELPER_MODULES: frozenset[str] = frozenset(
-    {"base", "registry", "config"},
-)
-
 
 def iter_loops() -> tuple[MiniLoop, ...]:
     """Walk ``teatree.loops`` subpackages and collect each ``MINI_LOOP``."""
     found: list[MiniLoop] = []
     for sub in pkgutil.iter_modules(_loops_pkg.__path__):
-        if sub.name in _HELPER_MODULES:
-            continue
         if not sub.ispkg:
             continue
         try:

--- a/tests/teatree_core/models/test_loop.py
+++ b/tests/teatree_core/models/test_loop.py
@@ -8,6 +8,7 @@ one-time seed of the autonomous loop set. Integration-first against the real DB;
 """
 
 import datetime as dt
+from unittest.mock import patch
 
 import pytest
 from django.core.exceptions import ValidationError
@@ -138,6 +139,32 @@ class TestLoopPromptScriptXor(TestCase):
         with pytest.raises(IntegrityError), transaction.atomic():
             Loop.objects.create(name="demo-script-no-delay-db", delay_seconds=None, prompt=None, script="run.py")
 
+    def test_clean_and_db_constraints_reject_the_same_shapes(self) -> None:
+        """``clean()`` and the two ``CheckConstraint``s are one predicate in two idioms.
+
+        The model expresses the prompt-XOR-script and script-requires-delay rules
+        twice — Python ``clean()`` (the ``full_clean`` path) and DB
+        ``CheckConstraint``s in a different idiom — so they can silently drift. This
+        pins that they AGREE: every invalid shape one gate rejects, the other
+        rejects too (else a row could pass one and fail the far one), and a valid
+        shape passes BOTH (anti-vacuity — the rejections are of real invalidity).
+        """
+        invalid_shapes = (
+            ("both", True, "run.py", 60),  # prompt AND script → XOR violated
+            ("neither", False, "", 60),  # prompt NOR script → XOR violated
+            ("script-no-delay", False, "run.py", None),  # script but no interval
+        )
+        for label, with_prompt, script, delay in invalid_shapes:
+            prompt = _prompt(f"p-agree-{label}") if with_prompt else None
+            fields = {"script": script, "delay_seconds": delay, "prompt": prompt}
+            with pytest.raises(ValidationError):
+                Loop(name=f"demo-clean-{label}", **fields).full_clean()
+            with pytest.raises(IntegrityError), transaction.atomic():
+                Loop.objects.create(name=f"demo-db-{label}", **fields)
+        valid = {"script": "run.py", "delay_seconds": 60, "prompt": None}
+        Loop(name="demo-agree-ok-clean", **valid).full_clean()
+        Loop.objects.create(name="demo-agree-ok-db", **valid)
+
 
 class TestLoopIntervalCadence(TestCase):
     def test_never_run_loop_is_due_no_age_no_next(self) -> None:
@@ -196,6 +223,49 @@ class TestLoopDailyCadence(TestCase):
     def test_next_run_at_returns_a_datetime(self) -> None:
         loop = Loop.objects.create(name="demo-daily", delay_seconds=86400, prompt=_prompt(), daily_at=dt.time(8, 0))
         assert loop.next_run_at() is not None
+
+
+@override_settings(USE_TZ=True, TIME_ZONE="Europe/Vienna")
+class TestLoopDailyCadenceDstSafe(TestCase):
+    """The daily slot's offset comes from the zone rules, not from *now* (DST).
+
+    ``next_run_at`` for a daily loop must resolve ``daily_at``'s wall-clock at the
+    slot's OWN instant. Building it by mutating *now* (``now_local.replace(hour=…)``)
+    carries *now*'s UTC offset and DST ``fold`` onto the target, so during the
+    fall-back overlap — when *now* itself sits on the ``fold=1`` side — the
+    ambiguous slot resolves to the SECOND (one-hour-late) occurrence. The DST-safe
+    slot is the FIRST (earlier) occurrence, the sooner "next" firing. With the
+    project default ``TIME_ZONE="UTC"`` there is no transition and nothing changes;
+    this pins the behaviour for a non-UTC install.
+    """
+
+    def test_ambiguous_fall_back_slot_takes_the_earlier_occurrence(self) -> None:
+        # Europe/Vienna fall-back 2026-10-25: 03:00 local → 02:00 local, so
+        # 02:00-02:59 is ambiguous (+02:00 first pass, +01:00 second pass).
+        loop = Loop.objects.create(name="demo-dst", delay_seconds=86400, prompt=_prompt(), daily_at=dt.time(2, 45))
+        # now = 01:30 UTC → Vienna 02:30 fold=1 (second pass); 02:30 < 02:45, so
+        # the slot is today's 02:45 wall-clock.
+        now = dt.datetime(2026, 10, 25, 1, 30, tzinfo=dt.UTC)
+        with patch("teatree.core.models.loop.timezone.now", return_value=now):
+            slot = loop.next_run_at()
+        assert slot is not None
+        # DST-safe: 02:45 +02:00 (first occurrence) = 00:45 UTC. The mutate-now
+        # bug would carry now's fold=1 offset (+01:00) → 01:45 UTC.
+        assert slot.astimezone(dt.UTC) == dt.datetime(2026, 10, 25, 0, 45, tzinfo=dt.UTC)
+
+    def test_next_slot_rolls_to_tomorrows_wall_clock_not_plus_24h(self) -> None:
+        # After the slot has passed today, the next firing is TOMORROW at the same
+        # wall-clock — resolved on tomorrow's date, not now + a rigid 24h that would
+        # drift by the transition hour across a DST boundary. 08:00 is unambiguous
+        # on both sides, so the assertion is a clean wall-clock identity.
+        loop = Loop.objects.create(name="demo-dst-roll", delay_seconds=86400, prompt=_prompt(), daily_at=dt.time(8, 0))
+        # now = 2026-10-25 10:00 Vienna (after 08:00, standard time +01:00 post-fallback).
+        now = dt.datetime(2026, 10, 25, 9, 0, tzinfo=dt.UTC)  # 10:00 Vienna
+        with patch("teatree.core.models.loop.timezone.now", return_value=now):
+            slot = loop.next_run_at()
+        assert slot is not None
+        assert timezone.localtime(slot).date() == dt.date(2026, 10, 26)
+        assert timezone.localtime(slot).time() == dt.time(8, 0)
 
 
 class TestLoopManager(TestCase):

--- a/tests/teatree_core/test_initial_migration_seed.py
+++ b/tests/teatree_core/test_initial_migration_seed.py
@@ -52,7 +52,14 @@ class TestInlinedSeedMatchesCanonicalSeed:
             )
             for spec in DEFAULT_LOOPS
         )
-        assert expected == _migration._DEFAULT_LOOPS
+        assert expected == _migration._DEFAULT_LOOPS, (
+            "Default-loops dataset drifted. The canonical set lives in THREE places that must "
+            "stay in lock-step — edit all three:\n"
+            "  1. src/teatree/loops/seed.py            (DEFAULT_LOOPS — the canonical source)\n"
+            "  2. src/teatree/core/migrations/0001_initial.py  (_DEFAULT_LOOPS — inlined, frozen history)\n"
+            "  3. this pin (tests/teatree_core/test_initial_migration_seed.py) + the "
+            "registry-parity pin (tests/conformance/test_registry_parity.py)"
+        )
 
     def test_inlined_arch_review_body_matches_the_canonical_body(self) -> None:
         assert _migration._ARCH_REVIEW_PROMPT_BODY == ARCH_REVIEW_PROMPT_BODY

--- a/tests/teatree_loop/scanners/test_base.py
+++ b/tests/teatree_loop/scanners/test_base.py
@@ -1,0 +1,32 @@
+"""Shared scanner-support primitives in ``teatree.loop.scanners.base``.
+
+``hours_since`` is the one cadence-gate helper the once-per-N-hours scanners
+(``backlog_sweep``, ``eval_local``, ``provision_smoke``, ``architectural_review``,
+``scanning_news``) share, replacing five copy-pasted
+``(now - last_run_at).total_seconds() / 3600.0  # type: ignore[operator]`` sites.
+Pure clock arithmetic — a unit test on the primitive; each scanner's DB-backed
+cadence behaviour (including its never-run ``bootstrap`` branch) is pinned in its
+own ``tests/teatree_loop/test_*_scanner.py``.
+"""
+
+import datetime as dt
+
+import pytest
+
+from teatree.loop.scanners.base import hours_since
+
+
+class TestHoursSince:
+    def test_whole_hours_elapsed(self) -> None:
+        now = dt.datetime(2026, 6, 16, 12, 0, tzinfo=dt.UTC)
+        earlier = now - dt.timedelta(hours=5)
+        assert hours_since(earlier, now=now) == pytest.approx(5.0)
+
+    def test_fractional_hours_elapsed(self) -> None:
+        now = dt.datetime(2026, 6, 16, 12, 0, tzinfo=dt.UTC)
+        earlier = now - dt.timedelta(hours=1, minutes=30)
+        assert hours_since(earlier, now=now) == pytest.approx(1.5)
+
+    def test_zero_when_earlier_is_now(self) -> None:
+        now = dt.datetime(2026, 6, 16, 12, 0, tzinfo=dt.UTC)
+        assert hours_since(now, now=now) == pytest.approx(0.0)


### PR DESCRIPTION
Holistic-review **unit 19** — de-duplicate the copy-pasted scanner cadence gate and clear the small loop-model / registry nits. Re-verified against current `origin/main` (post-#3146).

## Findings addressed

| Finding | Change |
|---|---|
| **3h#6** (should-fix) — 5 scanners copy-paste `(now - last_run_at).total_seconds()/3600.0  # type: ignore[operator]`; `last_run_at` typed `object` → real type-hole + duplication | New `hours_since()` in `loop/scanners/base.py`; `_last_run_at()` narrowed to `datetime | None`; each scanner guards the never-run `bootstrap` case with `is None` (which narrows the operand). All 5 `# type: ignore[operator]` removed. |
| **nit** `models/loop.py` `clean()` duplicates the two CheckConstraints | Added a test pinning that `clean()` and the DB constraints reject the same shapes (one predicate, two idioms). |
| **nit** `models/loop.py` `_next_daily`/`_as_local` `.replace(hour=…)` DST-unsafe | Rebuild each daily slot as `date + daily_at` via `timezone.make_aware` (resolves offset from the zone at the target instant); "tomorrow" is tomorrow's date, not `+24h`. |
| **nit** `loops/registry.py` `_HELPER_MODULES` frozenset is dead | Removed — `base`/`registry`/`config` are plain modules already skipped by `sub.ispkg`. |
| **nit** default-loops dataset in 3 places | The `test_initial_migration_seed.py` pin's failure message now names all three edit sites. |

## Tests (RED-before where behavioural)
- `TestLoopDailyCadenceDstSafe::test_ambiguous_fall_back_slot_takes_the_earlier_occurrence` — RED on the `.replace()` version (got `01:45Z`, expected `00:45Z`), GREEN after `make_aware`.
- `TestHoursSince` — new helper; symbol absent on `origin/main`, so the import was RED-before.
- `TestLoopPromptScriptXor::test_clean_and_db_constraints_reject_the_same_shapes` — the report-requested agreement pin.

## Gates
ruff / ty / ruff-format / test-path-mirror / makemigrations --check / gitleaks / banned-terms all green; 214 tests pass across the affected suites. TIME_ZONE default is UTC so the DST fix is behaviour-preserving for the default install.