### PR TITLE
fix(privacy-gate): fail closed on undetermined push visibility + shell-lexer fuzz corpus (U17 §3f#14, §3g#9)

### DIFF
--- a/scripts/hooks/refuse-public-push-with-leak.sh
+++ b/scripts/hooks/refuse-public-push-with-leak.sh
@@ -33,11 +33,14 @@
 # with the remote's default branch as the comparison base.
 #
 # Visibility is resolved via `gh repo view <owner>/<repo> --json
-# visibility`. When `gh` is unavailable or the visibility cannot be
-# determined, the gate fails OPEN (passes through) — it is a safety net
-# layered on top of the privacy scan in retro/contribute, not the only
-# line of defence, and blocking every push on a gh-less machine would
-# break the workflow.
+# visibility`. The gate SKIPS the scan only when the remote is KNOWN to be
+# private/internal. Every undetermined case — no owner/repo shape, no
+# `gh`, a `gh` error, or an unrecognised answer — fails CLOSED and the
+# diff is scanned anyway, so a leak never rides out on a gh-less machine
+# or an unparsable remote (§3f #14; was fail-open). "Fail closed" here
+# means "scan anyway", NOT "block anyway": the scan still fails OPEN on a
+# scanner crash and blocks ONLY on a real finding, so a clean push on a
+# machine without `gh` is unaffected.
 #
 # Wired via prek in `.pre-commit-config.yaml` (stages: [push]) so it
 # ships with the repo and needs no per-machine bootstrap.
@@ -59,18 +62,36 @@ fi
 #   git@github.com:owner/repo(.git)  # privacy-scan:allow doc example
 slug=$(printf '%s' "${remote_url}" \
   | sed -E 's#^[^:]+://[^/]+/##; s#^git@[^:]+:##; s#\.git$##')
+
+# Resolve visibility only when we have an owner/repo shape AND gh. Any
+# other path leaves it empty (undetermined).
+visibility=""
 case "${slug}" in
-  */*) : ;;
-  *) exit 0 ;;  # not an owner/repo shape — cannot ask gh, fail open
+  */*)
+    if command -v gh >/dev/null 2>&1; then
+      visibility=$(gh repo view "${slug}" --json visibility \
+        --jq '.visibility' 2>/dev/null || true)
+      # Normalise (gh emits PUBLIC/PRIVATE/INTERNAL).
+      visibility=$(printf '%s' "${visibility}" | tr '[:lower:]' '[:upper:]')
+    fi
+    ;;
 esac
 
-command -v gh >/dev/null 2>&1 || exit 0  # no gh — fail open
-
-visibility=$(gh repo view "${slug}" --json visibility \
-  --jq '.visibility' 2>/dev/null || true)
-# Normalise (gh emits PUBLIC/PRIVATE/INTERNAL).
-visibility=$(printf '%s' "${visibility}" | tr '[:lower:]' '[:upper:]')
-[ "${visibility}" = "PUBLIC" ] || exit 0  # private/internal/unknown → pass
+case "${visibility}" in
+  PRIVATE | INTERNAL)
+    exit 0  # KNOWN non-public remote — nothing reaches public history
+    ;;
+  PUBLIC)
+    : ;;  # confirmed public — scan
+  *)
+    # Undetermined visibility (no owner/repo shape, no gh, a gh error, or
+    # an unrecognised answer). Fail CLOSED: scan anyway. The scan itself
+    # still fails OPEN on a scanner crash and blocks ONLY on a real
+    # finding, so a clean push on a gh-less machine still passes — only an
+    # actual leak is stopped. Warn loudly so the undetermined path shows.
+    echo "⚠ push privacy gate: could not confirm '${slug:-<remote>}' visibility (gh unavailable or unrecognised) — scanning anyway (fail closed, §3f #14)." >&2
+    ;;
+esac
 
 scan_cmd=${T3_PRIVACY_SCAN_CMD:-t3 tool privacy-scan}
 

--- a/tests/teatree_hooks/test_shell_lexer_fuzz.py
+++ b/tests/teatree_hooks/test_shell_lexer_fuzz.py
@@ -1,0 +1,169 @@
+r"""Fuzz / property corpus for the hand-rolled bash tokenizer (§3g #9).
+
+``_shell_lexer`` is an adversarial-input tokenizer maintained by hand
+(ANSI-C ``$'...'`` decode, metachar splitting, heredoc-body consumption).
+It sits under the quote-scanner, banned-terms, publish-surface and
+self-rescue gates, so a crash or a lost source span there silently blows a
+hole in every one of those gates. Example-based tests (``test_shell_lexer``)
+pin specific decodings; this file pins the *structural invariants* that must
+hold for **every** input — the properties a cat-and-mouse tokenizer is most
+likely to regress on when a new escape or metachar case is bolted on.
+
+The generator is a self-contained, deterministic LCG (Knuth's MMIX
+constants) rather than ``random`` — a fixed-seed corpus reproduces a
+regression byte-for-byte across machines and Python builds, and it keeps the
+test free of the stdlib PRNG (so no crypto-suitability lint carve-out).
+
+Invariants asserted here, empirically validated to hold over the generated
+corpus and required by the lexer's consumers.
+
+Totality — ``tokenize`` never raises on any byte soup. An adversary controls
+the command string; an unhandled ``IndexError`` mid-scan would crash the
+PreToolUse hook and (fail-open) wave the command through.
+
+Populated span — every emitted token carries a non-empty ``raw``. The
+self-rescue env-prefix strip and the publish classifier read ``raw``
+verbatim; an empty span desynchronises them.
+
+Ordered, non-overlapping spans — each token's ``raw`` is locatable in the
+source at or after the previous token's span. The tokens are a left-to-right
+cover of the input, never a reordering or a fabrication.
+
+Determinism — tokenizing the same string twice yields equal tokens.
+
+Downstream totality — ``split_commands``, ``is_command_separator`` and
+``raw_substitution_sees_live`` never raise on the lexer's own output, and
+every token in a split segment is drawn from the original token list.
+"""
+
+import pytest
+
+from teatree.hooks._shell_lexer import Token, is_command_separator, raw_substitution_sees_live, split_commands, tokenize
+
+# A metachar-dense alphabet: single chars plus the multi-char openers that
+# drive the lexer's hardest branches (command/arith substitution, ANSI-C
+# quoting, heredoc, boolean operators, backtick). Sampling uniformly from
+# this set produces the malformed, half-open, deeply-nested strings that a
+# hand-rolled scanner is most likely to choke on.
+_ALPHABET: tuple[str, ...] = (
+    "a", "b", "c", " ", "\t", "\n", "\r", ";", "|", "&", "<", ">",
+    "(", ")", "'", '"', "$", "\\", "{", "}", "=", "#",
+    "$(", "`", "<<", "<<-", "$'", "&&", "||", "2>&1", "'\\''",
+)  # fmt: skip
+
+_FUZZ_ITERATIONS = 4000
+_MAX_TOKENS = 60
+_SEED = 0xC0FFEE
+_MASK64 = (1 << 64) - 1
+
+
+class _Lcg:
+    """A tiny deterministic PRNG (Knuth MMIX LCG) — reproducible, import-free."""
+
+    def __init__(self, seed: int) -> None:
+        self._state = seed & _MASK64
+
+    def next_int(self, bound: int) -> int:
+        """A pseudo-random int in ``[0, bound)`` (bound assumed positive)."""
+        self._state = (self._state * 6364136223846793005 + 1442695040888963407) & _MASK64
+        # Use the high bits (better distributed than the low bits of an LCG).
+        return (self._state >> 33) % bound
+
+    def command(self) -> str:
+        length = self.next_int(_MAX_TOKENS + 1)
+        return "".join(_ALPHABET[self.next_int(len(_ALPHABET))] for _ in range(length))
+
+
+def _assert_ordered_nonoverlapping_spans(command: str, tokens: list[Token]) -> None:
+    """Every ``raw`` is findable in ``command`` at/after the prior span end."""
+    cursor = 0
+    for tok in tokens:
+        assert tok.raw != "", f"empty raw span in {command!r}"
+        idx = command.find(tok.raw, cursor)
+        assert idx >= 0, f"raw {tok.raw!r} not found from {cursor} in {command!r}"
+        cursor = idx + len(tok.raw)
+
+
+def _assert_all_invariants(command: str) -> None:
+    tokens = tokenize(command)  # totality — must not raise
+    _assert_ordered_nonoverlapping_spans(command, tokens)
+
+    # Determinism: a second pass yields structurally equal tokens.
+    assert tokenize(command) == tokens
+
+    # Downstream consumers never raise and stay consistent with the tokens.
+    segments = split_commands(tokens)
+    assert isinstance(segments, list)
+    original = {id(tok) for tok in tokens}
+    for segment in segments:
+        assert isinstance(segment, list)
+        for tok in segment:
+            assert id(tok) in original, "split_commands fabricated a token"
+    for tok in tokens:
+        # These are plain predicates over a token; assert only that they are
+        # total (no raise) — their semantics are pinned in the example tests.
+        assert isinstance(is_command_separator(tok), bool)
+    assert isinstance(raw_substitution_sees_live(command, ("$(", "`", "${")), bool)
+
+
+class TestShellLexerFuzzCorpus:
+    def test_seeded_fuzz_preserves_invariants(self) -> None:
+        """A seeded (reproducible) sweep of metachar-dense byte soup.
+
+        The seed is fixed so a regression reproduces deterministically; the
+        alphabet is metachar-heavy so the hard lexer branches actually fire.
+        """
+        rng = _Lcg(_SEED)
+        for _ in range(_FUZZ_ITERATIONS):
+            _assert_all_invariants(rng.command())
+
+    def test_generator_is_deterministic_across_runs(self) -> None:
+        """Two LCGs from the same seed emit an identical corpus (reproducible)."""
+        a = _Lcg(_SEED)
+        b = _Lcg(_SEED)
+        assert [a.command() for _ in range(50)] == [b.command() for _ in range(50)]
+
+    # Curated adversarial strings — the shapes a hand-rolled bash tokenizer
+    # historically mishandles: half-open constructs, escape-at-EOF, deeply
+    # nested substitution, mixed line endings, heredoc-looking fragments.
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "",
+            " ",
+            "\\",  # lone trailing backslash (line-continuation with no next line)
+            "\\\n",  # backslash-newline (line continuation) at EOF
+            "'",  # unterminated single quote
+            '"',  # unterminated double quote
+            "$'",  # unterminated ANSI-C quote
+            "$'\\x",  # truncated ANSI-C hex escape
+            "$'\\u12",  # truncated ANSI-C unicode escape
+            "$'\\0",  # truncated ANSI-C octal escape
+            "$'\\'",  # escaped quote inside ANSI-C, then EOF
+            "`",  # lone backtick
+            "$(",  # unterminated command substitution
+            "$((",  # unterminated arithmetic expansion
+            "${",  # unterminated parameter expansion
+            "$($($(",  # deeply nested, all unterminated
+            "a$(b`c$'d'e`f)g",  # nested sub + backtick + ansi-c interleaved
+            "<<",  # bare heredoc operator, no delimiter
+            "cat <<'EOF'",  # heredoc with no body and no closing delimiter
+            "cat <<-EOF\n\tbody\n\tEOF",  # tab-stripped heredoc
+            "cat << EOF\nline1\nline2\nEOF\nnext",  # full heredoc then a command
+            "a;;;|||&&&\n\n\r\r",  # metachar storm
+            "'A'=1",  # quoted assignment-shaped word (the raw invariant case)
+            "x 2>&1 >>log <in |& y",  # redirect-ish words and operators
+            "\r\n\r\n",  # only CRLF operators
+            "#comment only",  # a pure comment line
+            "a #trailing comment\nb",  # comment then a real command
+            "$'\\xff\\377\\u00e9\\U0001F600'",  # dense valid ANSI-C escapes
+        ],
+    )
+    def test_adversarial_strings_hold_invariants(self, command: str) -> None:
+        _assert_all_invariants(command)
+
+    def test_long_metachar_run_does_not_blow_the_stack(self) -> None:
+        """A long run of nested openers must scan iteratively, not recurse to death."""
+        _assert_all_invariants("$(" * 500)
+        _assert_all_invariants("`" * 500)
+        _assert_all_invariants("a | " * 500)

--- a/tests/test_refuse_public_push_with_leak.py
+++ b/tests/test_refuse_public_push_with_leak.py
@@ -15,6 +15,7 @@ fixed visibility. Nothing about git or the filesystem is mocked.
 import os
 import stat
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -102,9 +103,15 @@ def _clone_with_remote(tmp_path: Path, gh_visibility: str) -> tuple[Path, dict[s
     return work, env
 
 
-def _run_hook(cwd: Path, env: dict[str, str], stdin: str) -> subprocess.CompletedProcess[str]:
+def _run_hook(
+    cwd: Path,
+    env: dict[str, str],
+    stdin: str,
+    remote_url: str = "https://github.com/acme/widget.git",
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["bash", str(HOOK), "origin", "https://github.com/acme/widget.git"],  # noqa: S607
+        # `bash <hook>` on PATH is git's real pre-push invocation shape; test-only driver.
+        ["bash", str(HOOK), "origin", remote_url],  # noqa: S607 — bash resolved via PATH is the hook's real invocation
         cwd=cwd,
         input=stdin,
         capture_output=True,
@@ -200,16 +207,22 @@ class TestRefusePublicPushWithLeak:
 
         assert result.returncode == 0, result.stdout + result.stderr
 
-    def test_passthrough_when_gh_unavailable(self, tmp_path: Path) -> None:
-        """No gh on PATH → visibility unknown → fail open (do not block).
+    def test_scans_and_blocks_leak_when_gh_unavailable(self, tmp_path: Path) -> None:
+        """No gh on PATH → visibility undetermined → fail CLOSED (scan anyway).
 
-        The gate is a safety net, not the only line of defence; blocking
-        every push on a machine without gh would break the workflow.
+        The gate now skips the scan only when the remote is KNOWN to be
+        private/internal. An undetermined remote (no gh) still gets
+        scanned, so a real leak cannot ride out to a public remote from a
+        gh-less machine (privacy-gate fail-closed hardening, §3f #14).
         """
         work, env = _clone_with_remote(tmp_path, "PUBLIC")
         # Keep system bins (bash/git) but drop the gh shim dir so `gh`
-        # is genuinely unavailable.
+        # is genuinely unavailable. Pin the scan command to this venv's
+        # interpreter by absolute path so the scanner still runs (a bare
+        # `python3` on the stripped PATH would miss the test deps and
+        # crash the scanner, masking the leak behind its fail-open path).
         env["PATH"] = "/usr/bin:/bin"
+        env["T3_PRIVACY_SCAN_CMD"] = f"{sys.executable} {SCAN}"
         (work / "leak.txt").write_text(
             "token = glpat-XXXXXXXXXXXXXXXX\n",
             encoding="utf-8",
@@ -219,7 +232,49 @@ class TestRefusePublicPushWithLeak:
 
         result = _run_hook(work, env, _push_stdin(work))
 
+        assert result.returncode == 1, result.stdout + result.stderr
+        combined = (result.stdout + result.stderr).lower()
+        assert "privacy" in combined
+
+    def test_allows_clean_push_when_gh_unavailable(self, tmp_path: Path) -> None:
+        """Undetermined visibility + a clean diff still passes.
+
+        Fail-closed means "scan anyway", not "block anyway": the scan
+        blocks only on a real finding, so a clean push on a gh-less
+        machine is unaffected (§3f #14).
+        """
+        work, env = _clone_with_remote(tmp_path, "PUBLIC")
+        env["PATH"] = "/usr/bin:/bin"
+        env["T3_PRIVACY_SCAN_CMD"] = f"{sys.executable} {SCAN}"
+        (work / "feature.txt").write_text("a clean new feature line\n", encoding="utf-8")
+        _git(work, "add", "feature.txt")
+        _git(work, "commit", "-m", "add feature")
+
+        result = _run_hook(work, env, _push_stdin(work))
+
         assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_non_github_remote_shape_scans_and_blocks_leak(self, tmp_path: Path) -> None:
+        """A remote URL with no owner/repo shape is undetermined → scan.
+
+        Previously a non-owner/repo slug exited 0 (fail open). Now it is
+        treated as undetermined visibility and the diff is scanned, so a
+        leak to an unrecognised remote is still caught (§3f #14).
+        """
+        work, env = _clone_with_remote(tmp_path, "PUBLIC")
+        (work / "leak.txt").write_text(
+            "token = glpat-XXXXXXXXXXXXXXXX\n",
+            encoding="utf-8",
+        )
+        _git(work, "add", "leak.txt")
+        _git(work, "commit", "-m", "add config")
+
+        # Drive the hook with a bare, non-owner/repo remote URL.
+        result = _run_hook(work, env, _push_stdin(work), remote_url="https://example.invalid/no-slug-here")
+
+        assert result.returncode == 1, result.stdout + result.stderr
+        combined = (result.stdout + result.stderr).lower()
+        assert "privacy" in combined
 
     def test_annotated_fixture_does_not_block_but_real_leak_in_same_diff_does(self, tmp_path: Path) -> None:
         """The allow-annotation is line-scoped, not a file-level exclusion.


### PR DESCRIPTION
## Unit 17 (partial) — hooks structure hardening

Burndown Unit 17. Implements the two bounded, high-value findings; the three god-file/package mega-refactors are verify-then-deferred with evidence (see below) because they are the single hottest, most safety-critical file/dir in the repo and unsafe to land blind while the owner is AWAY and cannot review the diff.

### Implemented

**§3f #14 (nit, security) — push-leak fence failed OPEN on undetermined visibility.**
scripts/hooks/refuse-public-push-with-leak.sh exited 0 (skipped the scan) on no owner/repo shape, no gh, a gh error, or an unrecognised visibility answer. Now it SKIPS the scan only when the remote is KNOWN private/internal; every undetermined case fails closed and scans the diff, warning loudly. Fail-closed here means scan-anyway, not block-anyway — the scan still fails open on a scanner crash and blocks only on a real finding, so a clean push on a gh-less machine is unaffected.
- Tests (RED-before, observed failing on the fail-open code): test_scans_and_blocks_leak_when_gh_unavailable, test_non_github_remote_shape_scans_and_blocks_leak (both returncode 0 pre-fix), plus test_allows_clean_push_when_gh_unavailable. Inverted the stale test_passthrough_when_gh_unavailable.

**§3g #9 (should) — no fuzz/property corpus for the hand-rolled bash tokenizer.**
Adds tests/teatree_hooks/test_shell_lexer_fuzz.py: a deterministic (self-contained LCG, no random) fuzz + adversarial corpus pinning the structural invariants _shell_lexer must uphold for every input — totality, populated + ordered non-overlapping raw spans, determinism, downstream totality of split_commands/is_command_separator/raw_substitution_sees_live. Non-vacuity proven by mutation: fabricating a token span made 25/30 corpus cases fail.

### Verify-then-deferred (evidence)

- §3g #6 banned-terms consolidation + tree rename: #3139 landed banned_term_registry (registry-first dual-read), but the terms logic still spans 8 modules and a full consolidation + one-tree rename is a large cross-file rename touching hooks.json and every importer.
- §3g #8 package-ify hooks/scripts/: still a flat dir (no __init__.py) with the sys.path.insert + sys.modules alias dual-mode hack (hook_router.py:37-48). Making it a package rewrites hooks.json command paths, run-hook.sh, ~50 bare sibling imports and every subprocess/import test.
- §3g #7 13 private re-exports in hook_router for test patching: only 4 are referenced by tests, and those tests deliberately assert re-export reachability as the PR-09 extraction contract — removing them rewrites a tested seam for debatable net gain.
- §3i #3 decompose hook_router.py (now 6627 LOC / 208 top-level defs, ~13x the 500 cap): a multi-thousand-line move of the layer that gates every tool call; the plan itself couples it with §3g #8.

The plan notes §3g #6/#8/#3i #3 should be done together to avoid re-touching; doing that safely needs an interactive human reviewer, so it is left for a dedicated, reviewable PR.

### Gates
- Leak gates: gitleaks PASS, banned-terms PASS (commit + pre-push).
- ruff-check / ruff-format / ty-check / editorconfig / codespell / no-overlay-leak / gate-relaxation / module-health PASS.
- test-path-mirror: ratchet holds (new file mirrors teatree.hooks._shell_lexer).
- 72 tests green across the touched suites.

Draft — AWAY mode, no colleague-facing action.