### PR TITLE
refactor(backends): unit 13 cleanup — provider rename, glab dedup, typed cache

### DIFF
--- a/src/teatree/backends/backend_provider.py
+++ b/src/teatree/backends/backend_provider.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from teatree.types import SyncBackend
 
 
-class SlackBackendProvider:
+class ConcreteBackendProvider:
     def get_code_host(self, overlay: "OverlayBase") -> "CodeHostBackend | None":  # noqa: PLR6301
         return loader.get_code_host(overlay)
 
@@ -98,4 +98,4 @@ class SlackBackendProvider:
 
 
 def install_backend_provider() -> None:
-    register_backend_provider(SlackBackendProvider())
+    register_backend_provider(ConcreteBackendProvider())

--- a/src/teatree/backends/forge_merge_rpc.py
+++ b/src/teatree/backends/forge_merge_rpc.py
@@ -14,6 +14,7 @@ import json
 import os
 import shutil
 from collections.abc import Callable
+from typing import cast
 
 from teatree.core.backend_protocols import ROLLUP_QUERY_FAILED, ForgeMergeResult, PrMergeState
 from teatree.types import RawAPIDict
@@ -209,45 +210,43 @@ class GlabMergeRpc:
     def __init__(self, run: Runner) -> None:
         self._run = run
 
-    def fetch_live_head_sha(self, *, slug: str, pr_id: int) -> str:
+    def _fetch_mr(self, *, slug: str, pr_id: int) -> RawAPIDict | None:
+        """Fetch and JSON-parse the ``merge_requests/{id}`` object; ``None`` on any error.
+
+        The head-SHA, merge-state, draft-flag, and author reads all pull the
+        same MR object; this centralises the ``glab api`` call plus the
+        ``json.loads`` / dict-shape guard so each reader is just its field
+        extraction. ``None`` covers a non-zero rc, an empty body, a JSON parse
+        failure, or a non-object payload.
+        """
         rc, out, _ = self._run(["api", f"projects/{glab_project_path(slug)}/merge_requests/{pr_id}"])
         if rc != 0 or not out.strip():
-            return ""
+            return None
         try:
             data = json.loads(out)
         except json.JSONDecodeError:
-            return ""
-        if not isinstance(data, dict):
-            return ""
-        return str(data.get("sha") or "")
+            return None
+        return data if isinstance(data, dict) else None
+
+    def fetch_live_head_sha(self, *, slug: str, pr_id: int) -> str:
+        mr = self._fetch_mr(slug=slug, pr_id=pr_id)
+        return str(mr.get("sha") or "") if mr is not None else ""
 
     def fetch_pr_merge_state(self, *, slug: str, pr_id: int) -> PrMergeState:
-        rc, out, _ = self._run(["api", f"projects/{glab_project_path(slug)}/merge_requests/{pr_id}"])
-        if rc != 0 or not out.strip():
+        mr = self._fetch_mr(slug=slug, pr_id=pr_id)
+        if mr is None:
             return PrMergeState(state="", merge_commit_oid="")
-        try:
-            data = json.loads(out)
-        except json.JSONDecodeError:
-            return PrMergeState(state="", merge_commit_oid="")
-        if not isinstance(data, dict):
-            return PrMergeState(state="", merge_commit_oid="")
-        state = str(data.get("state") or "").upper()  # "merged" → "MERGED" (parity with GitHub)
-        oid = str(data.get("merge_commit_sha") or data.get("squash_commit_sha") or "")
+        state = str(mr.get("state") or "").upper()  # "merged" → "MERGED" (parity with GitHub)
+        oid = str(mr.get("merge_commit_sha") or mr.get("squash_commit_sha") or "")
         return PrMergeState(state=state, merge_commit_oid=oid)
 
     def fetch_pr_is_draft(self, *, slug: str, pr_id: int) -> bool:
-        rc, out, _ = self._run(["api", f"projects/{glab_project_path(slug)}/merge_requests/{pr_id}"])
-        if rc != 0 or not out.strip():
-            return False
-        try:
-            data = json.loads(out)
-        except json.JSONDecodeError:
-            return False
-        if not isinstance(data, dict):
+        mr = self._fetch_mr(slug=slug, pr_id=pr_id)
+        if mr is None:
             return False
         # ``draft`` is canonical on modern GitLab; ``work_in_progress`` is the legacy
         # field kept for compatibility — accept either.
-        return bool(data.get("draft") or data.get("work_in_progress"))
+        return bool(mr.get("draft") or mr.get("work_in_progress"))
 
     def fetch_pr_author(self, *, slug: str, pr_id: int) -> str:
         """The MR author ``username`` — the §17.4.3 author-gate input (#1773).
@@ -256,17 +255,13 @@ class GlabMergeRpc:
         keystone (an author that cannot be proved trusted does not auto-merge
         on a public repo).
         """
-        rc, out, _ = self._run(["api", f"projects/{glab_project_path(slug)}/merge_requests/{pr_id}"])
-        if rc != 0 or not out.strip():
+        mr = self._fetch_mr(slug=slug, pr_id=pr_id)
+        if mr is None:
             return ""
-        try:
-            data = json.loads(out)
-        except json.JSONDecodeError:
+        author = mr.get("author")
+        if not isinstance(author, dict):
             return ""
-        if not isinstance(data, dict):
-            return ""
-        author = data.get("author")
-        return str(author.get("username") or "") if isinstance(author, dict) else ""
+        return str(cast("RawAPIDict", author).get("username") or "")
 
     def fetch_required_checks_rollup(self, *, slug: str, pr_id: int) -> list[RawAPIDict]:
         rc, out, _ = self._run(["api", f"projects/{glab_project_path(slug)}/merge_requests/{pr_id}/pipelines"])

--- a/src/teatree/backends/gitlab/api.py
+++ b/src/teatree/backends/gitlab/api.py
@@ -68,10 +68,19 @@ class GitLabHTTPClient:
         self._project_cache: dict[str, ProjectInfo] = {}
         self._response_cache: dict[str, tuple[float, object]] = {}
 
-    def _get_cached(self, cache_key: str, ttl: int) -> object | None:
+    def _get_cached[T](self, cache_key: str, ttl: int) -> T | None:
+        """Return the fresh cached value for *cache_key*, or ``None`` when missing/stale.
+
+        The cache is heterogeneous (each ``get_*`` method stores its own return
+        shape under a prefixed key), so the stored value is ``object``. The
+        caller binds ``T`` at the call site by annotating the receiving local —
+        every writer/reader pair for a given key agrees on the shape — which
+        confines the unavoidable dynamic hop to this one ``cast`` instead of a
+        per-call-site suppression at each of the seven cache-hit returns.
+        """
         entry = self._response_cache.get(cache_key)
         if entry is not None and (time.monotonic() - entry[0]) < ttl:
-            return entry[1]
+            return cast("T", entry[1])
         return None
 
     def _set_cached(self, cache_key: str, value: object) -> None:
@@ -237,9 +246,9 @@ class GitLabAPI(GitLabHTTPClient):
     def get_work_item_status(self, project_path: str, iid: int) -> str | None:
         """Fetch the Status widget value for a GitLab work item via GraphQL."""
         cache_key = f"work_item_status:{project_path}:{iid}"
-        cached = self._get_cached(cache_key, _TTL_WORK_ITEM)
+        cached: str | None = self._get_cached(cache_key, _TTL_WORK_ITEM)
         if cached is not None:
-            return cached  # type: ignore[return-value]
+            return cached
         data = self.graphql(WORK_ITEM_STATUS_QUERY, {"projectPath": project_path, "iid": str(iid)})
         result = status_from_work_item_payload(data)
         self._set_cached(cache_key, result)
@@ -386,9 +395,9 @@ class GitLabAPI(GitLabHTTPClient):
     def get_mr_pipeline(self, project_id: int, mr_iid: int) -> dict[str, str | None]:
         """Return the latest pipeline status and URL for an MR."""
         cache_key = f"pipeline:{project_id}:{mr_iid}"
-        cached = self._get_cached(cache_key, _TTL_PIPELINE)
+        cached: dict[str, str | None] | None = self._get_cached(cache_key, _TTL_PIPELINE)
         if cached is not None:
-            return cached  # type: ignore[return-value]
+            return cached
         data = self.get_json(f"projects/{project_id}/merge_requests/{mr_iid}/pipelines?per_page=1")
         if isinstance(data, list) and data:
             pipeline = data[0]
@@ -404,9 +413,9 @@ class GitLabAPI(GitLabHTTPClient):
     def get_mr_approvals(self, project_id: int, mr_iid: int) -> dict[str, object]:
         """Return approval count, required count, and approver names for an MR."""
         cache_key = f"approvals:{project_id}:{mr_iid}"
-        cached = self._get_cached(cache_key, _TTL_APPROVALS)
+        cached: RawMR | None = self._get_cached(cache_key, _TTL_APPROVALS)
         if cached is not None:
-            return cached  # type: ignore[return-value]
+            return cached
         data = self.get_json(f"projects/{project_id}/merge_requests/{mr_iid}/approvals")
         if isinstance(data, dict):
             approved_by = data.get("approved_by", [])
@@ -438,9 +447,9 @@ class GitLabAPI(GitLabHTTPClient):
     def get_issue(self, project_id: int, issue_iid: int) -> dict[str, object] | None:
         """Fetch a single issue by project ID and IID."""
         cache_key = f"issue:{project_id}:{issue_iid}"
-        cached = self._get_cached(cache_key, _TTL_ISSUE)
+        cached: RawMR | None = self._get_cached(cache_key, _TTL_ISSUE)
         if cached is not None:
-            return cached  # type: ignore[return-value]
+            return cached
         data = self.get_json(f"projects/{project_id}/issues/{issue_iid}")
         result = data if isinstance(data, dict) else None
         self._set_cached(cache_key, result)
@@ -449,9 +458,9 @@ class GitLabAPI(GitLabHTTPClient):
     def get_mr_discussions(self, project_id: int, mr_iid: int) -> list[dict[str, object]]:
         """Fetch all discussion threads for a merge request."""
         cache_key = f"discussions:{project_id}:{mr_iid}"
-        cached = self._get_cached(cache_key, _TTL_DISCUSSIONS)
+        cached: list[RawMR] | None = self._get_cached(cache_key, _TTL_DISCUSSIONS)
         if cached is not None:
-            return cached  # type: ignore[return-value]
+            return cached
         result = self.get_json_paginated(f"projects/{project_id}/merge_requests/{mr_iid}/discussions?per_page=100")
         self._set_cached(cache_key, result)
         return result
@@ -459,9 +468,9 @@ class GitLabAPI(GitLabHTTPClient):
     def get_draft_notes_count(self, project_id: int, mr_iid: int) -> int:
         """Return the number of unpublished draft notes on a merge request."""
         cache_key = f"draft_notes:{project_id}:{mr_iid}"
-        cached = self._get_cached(cache_key, _TTL_DISCUSSIONS)
+        cached: int | None = self._get_cached(cache_key, _TTL_DISCUSSIONS)
         if cached is not None:
-            return cached  # type: ignore[return-value]
+            return cached
         data = self.get_json(f"projects/{project_id}/merge_requests/{mr_iid}/draft_notes?per_page=100")
         count = len(data) if isinstance(data, list) else 0
         self._set_cached(cache_key, count)
@@ -535,9 +544,9 @@ class GitLabAPI(GitLabHTTPClient):
 
     def current_username(self) -> str:
         cache_key = "username"
-        cached = self._get_cached(cache_key, _TTL_USERNAME)
+        cached: str | None = self._get_cached(cache_key, _TTL_USERNAME)
         if cached is not None:
-            return cached  # type: ignore[return-value]
+            return cached
         data = self.get_json("user")
         result = str(data.get("username", "")) if isinstance(data, dict) else ""
         self._set_cached(cache_key, result)

--- a/src/teatree/backends/loader.py
+++ b/src/teatree/backends/loader.py
@@ -258,17 +258,14 @@ def get_messaging(overlay: "OverlayBase") -> MessagingBackend:
     choice = overlay.config.messaging_backend or "noop"
     if choice == "slack":
         token_ref = overlay.config.slack_token_ref
-        user_token_ref = getattr(overlay.config, "user_token_ref", "")
         return SlackBotBackend(
             bot_token=read_posting_credential(f"{token_ref}-bot") if token_ref else overlay.config.get_slack_token(),
             app_token=read_posting_credential(f"{token_ref}-app") if token_ref else "",
-            user_token=read_posting_credential(user_token_ref),
+            user_token=read_posting_credential(overlay.config.user_token_ref),
             user_id=overlay.config.slack_user_id,
             # Setup-time provisioned IM channel id (#1342) — see
-            # ``OverlayConfig.slack_dm_channel_id``. ``getattr`` keeps older
-            # third-party overlay subclasses (that pre-date the field)
-            # working without an explicit default.
-            dm_channel_id=getattr(overlay.config, "slack_dm_channel_id", ""),
+            # ``OverlayConfig.slack_dm_channel_id``.
+            dm_channel_id=overlay.config.slack_dm_channel_id,
             degrade_bad_user_token=True,
         )
     if choice == "noop":
@@ -277,7 +274,12 @@ def get_messaging(overlay: "OverlayBase") -> MessagingBackend:
     raise ValueError(msg)
 
 
-@lru_cache(maxsize=1)
+# Bounded so multiple overlays (each keyed on its own token/url) coexist —
+# ``maxsize=1`` evicted the previous overlay's service on every alternating
+# resolve, rebuilding the GitLabAPI client each time. Realistic setups run a
+# handful of overlays, so a small ceiling avoids the thrash without unbounded
+# growth on token rotation.
+@lru_cache(maxsize=8)
 def get_ci_service(
     *,
     gitlab_token: str = "",

--- a/tests/integration/slack_bridge_e2e/test_routing.py
+++ b/tests/integration/slack_bridge_e2e/test_routing.py
@@ -95,13 +95,13 @@ class TestPerOverlayBotRouting:
         }
         pass_lookup = {"ref-bot": "xoxb-toml", "ref-app": "xapp-toml"}
 
-        from teatree.backends.backend_provider import SlackBackendProvider  # noqa: PLC0415
+        from teatree.backends.backend_provider import ConcreteBackendProvider  # noqa: PLC0415
 
         # A real provider keeps ``build_slack_messaging`` live (so the TOML
         # overlay builds a real ``SlackBotBackend``); only the entry-point
         # credential resolution is neutralised — the synthetic ``py-overlay``
         # has no live backends.
-        provider = SlackBackendProvider()
+        provider = ConcreteBackendProvider()
 
         # Justified scaffolding (#1066 nit 2): synthetic entry-point + TOML
         # overlays injected via patched ``get_all_overlays`` /

--- a/tests/teatree_backends/test_loader.py
+++ b/tests/teatree_backends/test_loader.py
@@ -250,6 +250,22 @@ def test_reset_backend_caches_clears_ci() -> None:
     assert get_ci_service() is None
 
 
+def test_get_ci_service_cache_survives_a_second_overlay() -> None:
+    """Two overlays' CI services coexist in the cache — no maxsize=1 thrash.
+
+    A user running two overlays (each with its own GitLab token/url) resolves a
+    CI service per overlay. With ``maxsize=1`` the second overlay evicted the
+    first, so re-resolving the first rebuilt it on every alternating call. The
+    cache must hold both: re-resolving the first overlay after the second is a
+    hit (same instance), not a rebuild.
+    """
+    reset_backend_caches()
+    first = get_ci_service(gitlab_token="tok-a", gitlab_url="https://a.example/api/v4")
+    get_ci_service(gitlab_token="tok-b", gitlab_url="https://b.example/api/v4")
+    first_again = get_ci_service(gitlab_token="tok-a", gitlab_url="https://a.example/api/v4")
+    assert first is first_again
+
+
 def test_get_code_host_for_url_returns_github_for_github_url() -> None:
     overlay = _build_overlay()
     _stub_token(overlay, github="gh-tok", gitlab="gl-tok")

--- a/tests/teatree_core/test_backend_registry.py
+++ b/tests/teatree_core/test_backend_registry.py
@@ -8,9 +8,9 @@ from teatree.core import backend_registry
 class TestBackendProviderRegistry:
     def test_backends_ready_registers_the_real_provider(self) -> None:
         """``BackendsConfig.ready()`` ran at django.setup() — the real provider resolves."""
-        from teatree.backends.backend_provider import SlackBackendProvider  # noqa: PLC0415
+        from teatree.backends.backend_provider import ConcreteBackendProvider  # noqa: PLC0415
 
-        assert isinstance(backend_registry.get_backend_provider(), SlackBackendProvider)
+        assert isinstance(backend_registry.get_backend_provider(), ConcreteBackendProvider)
 
     def test_unconfigured_provider_builds_nothing(self) -> None:
         """Fail-SAFE: with no provider registered, builds degrade to None/empty (no crash)."""


### PR DESCRIPTION
Burndown **Unit 13 — Backends cleanup** from the holistic-review plan. Re-verified every finding against current origin/main (post #3146). Human is AWAY — draft only.

## Findings implemented

| Finding | Change |
|---|---|
| **3f#7** (should) `backend_provider.py` | Renamed `SlackBackendProvider` → `ConcreteBackendProvider` (it provides *every* backend, not just Slack); updated the two test references. |
| **3f#8** (should) `loader.py` | Dropped the `getattr(overlay.config, "user_token_ref"/"slack_dm_channel_id", "")` duck-typing in `get_messaging` — both fields already exist on base `OverlayConfig` with defaults, so direct attribute access is correct and typed. |
| **3f#9** (should) `forge_merge_rpc.py` | `GlabMergeRpc`: extracted `_fetch_mr` so `fetch_live_head_sha` / `fetch_pr_merge_state` / `fetch_pr_is_draft` / `fetch_pr_author` share one `glab api …/merge_requests/{id}` call + the `json.loads`/dict-shape guard instead of four copies. |
| **3h#7** (should) `gitlab/api.py` | Made `_get_cached` generic (`_get_cached[T]`) so the seven cache-hit returns type-check via one internal `cast` — removed all 7 `# type: ignore[return-value]`. Call sites bind `T` by annotating the receiving local. |
| **nit** `loader.py` | `get_ci_service` `lru_cache` `maxsize=1 → 8` so two overlays' CI services coexist without evict-thrash; added a RED-before regression test. |

## Deferred (blocked / out-of-scope) — with evidence

- **PLR6301 per-file-ignore nit** (`backend_provider.py`): the `check_quality_gates` pre-commit hook **hard-blocks** adding any `per-file-ignore` to `pyproject.toml` (src, non-exempt) with **no sanctioned override**. Converting the 11 inline `# noqa: PLR6301` to a per-file-ignore would require flipping a safety gate — declined in AWAY mode. The inline noqas stay as-is.
- **3f#10** (should) — *narrow the Protocol return types to `backends/types` TypedDicts*: **not achievable in-unit**. A `TypedDict` is not assignable to `dict[str, object]` under `ty` (verified with a probe), so enforcing these shapes requires migrating the whole `CodeHostBackend`/`CIService`/`MessagingBackend` Protocol surface off `RawAPIDict` across `core/backend_protocols.py` + all 5 backend implementations + every mutating caller. Disproportionate and cross-unit for this burndown unit; the `types.py` docstring already documents the deliberate tradeoff. Recommend a dedicated typed-payloads epic (overlaps report 3h#8).

## Tests / gates
- RED-before regression: `tests/teatree_backends/test_loader.py::test_get_ci_service_cache_survives_a_second_overlay` (fails at `maxsize=1`, passes at `8`).
- Refactor findings are behaviour-preserving; the existing backends + merge-keystone + slack-routing suites pin them and stay green (`tests/teatree_backends/`, `tests/teatree_core/test_merge_execution*.py`, `tests/integration/slack_bridge_e2e/test_routing.py`).
- Local gates pass: `ruff`, `ty`, `tach`, `module-health`, `quality-gates`, and the leak gates (gitleaks / banned-terms / no-overlay-leak). Push-stage public-leak gate passed.

No tracked DB ticket exists for this plan-driven unit, so the PR was opened with `gh pr create --draft` rather than `t3 pr create`.