### PR TITLE
refactor(eval): group runner-construction knobs into ApiRunnerParams (3f#13)

### DIFF
--- a/src/teatree/cli/eval/benchmark.py
+++ b/src/teatree/cli/eval/benchmark.py
@@ -20,7 +20,7 @@ from teatree.cli.eval.docker import DockerUnavailableError, run_eval_in_docker
 from teatree.cli.eval.metered_routing import should_route_to_docker, warn_local_metered
 from teatree.cli.eval.multi_trial import collect_matrix_rows, parse_model_tags
 from teatree.cli.eval.run_modes import RunGuards, persist_matrix_run
-from teatree.eval.backends import API_BACKEND, make_runner
+from teatree.eval.backends import API_BACKEND, ApiRunnerParams, make_runner
 from teatree.eval.benchmark import render_benchmark_json, render_benchmark_text, summarize_benchmark
 from teatree.eval.discovery import discover_specs
 from teatree.eval.models import EvalSpec
@@ -113,7 +113,8 @@ def benchmark(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 
     tags = parse_model_tags(models)
     specs = _select_specs(scenarios)
     runner = make_runner(
-        API_BACKEND, max_turns_override=max_turns, require_executed=True, max_budget_usd=max_budget_usd
+        API_BACKEND,
+        ApiRunnerParams(max_turns_override=max_turns, require_executed=True, max_budget_usd=max_budget_usd),
     )
     rows = collect_matrix_rows(specs, tags, runner=runner, trials=trials, require="any")
     RunGuards.executed(executed=sum(1 for row in rows if not row.skipped), collected=len(rows), required=True)

--- a/src/teatree/cli/eval/multi_trial.py
+++ b/src/teatree/cli/eval/multi_trial.py
@@ -25,7 +25,7 @@ from teatree.cli.eval.run_modes import (
     with_model,
 )
 from teatree.eval.api_runner import MAX_BUDGET_USD
-from teatree.eval.backends import API_BACKEND, EvalRunner, make_runner
+from teatree.eval.backends import API_BACKEND, ApiRunnerParams, EvalRunner, make_runner
 from teatree.eval.matrix import MatrixRow, render_matrix_html, render_matrix_json, render_matrix_text
 from teatree.eval.model_variant import ModelVariantError, parse_model_variants
 from teatree.eval.models import EvalSpec
@@ -123,10 +123,12 @@ def run_pass_at_k_lane(  # noqa: PLR0913 — each kwarg threads one `eval run` C
     )
     runner = make_runner(
         API_BACKEND,
-        max_turns_override=max_turns,
-        require_executed=require_executed,
-        max_budget_usd=max_budget_usd,
-        effort=effort,
+        ApiRunnerParams(
+            max_turns_override=max_turns,
+            require_executed=require_executed,
+            max_budget_usd=max_budget_usd,
+            effort=effort,
+        ),
     )
 
     def _trial(spec: EvalSpec) -> ScenarioResult:
@@ -246,10 +248,12 @@ def run_model_matrix_lane(  # noqa: PLR0913 — each kwarg threads one `eval run
     )
     runner = make_runner(
         API_BACKEND,
-        max_turns_override=max_turns,
-        require_executed=require_executed,
-        max_budget_usd=max_budget_usd,
-        effort=effort,
+        ApiRunnerParams(
+            max_turns_override=max_turns,
+            require_executed=require_executed,
+            max_budget_usd=max_budget_usd,
+            effort=effort,
+        ),
     )
     rows = collect_matrix_rows(specs, model_list, runner=runner, trials=trials, require=require, grader=grader)
     if output_format == "json":

--- a/src/teatree/cli/eval/single_trial.py
+++ b/src/teatree/cli/eval/single_trial.py
@@ -28,6 +28,7 @@ from teatree.cli.eval.run_modes import DEFAULT_COST_REGRESSION_TOLERANCE, RunGua
 from teatree.eval.backends import (
     API_BACKEND,
     TRANSCRIPT_BACKEND,
+    ApiRunnerParams,
     EvalRunner,
     TranscriptRunner,
     UnknownBackendError,
@@ -61,7 +62,7 @@ def make_escalation_runner(*, max_budget_usd: float, effort: EffortLevel | None)
     the transcript backend cannot produce a new trial. Held apart so the
     single-trial test harness can stub the escalation runner without a live model.
     """
-    return make_runner(API_BACKEND, max_budget_usd=max_budget_usd, effort=effort)
+    return make_runner(API_BACKEND, ApiRunnerParams(max_budget_usd=max_budget_usd, effort=effort))
 
 
 # ast-grep-ignore: ac-django-no-complexity-suppressions
@@ -99,11 +100,13 @@ def run_single_trial(  # noqa: PLR0913 — each kwarg threads one resolved `eval
     try:
         runner = make_runner(
             backend,
-            max_turns_override=max_turns,
+            ApiRunnerParams(
+                max_turns_override=max_turns,
+                require_executed=require_executed,
+                max_budget_usd=max_budget_usd,
+                effort=effort,
+            ),
             transcript_dir=transcript_dir,
-            require_executed=require_executed,
-            max_budget_usd=max_budget_usd,
-            effort=effort,
         )
     except UnknownBackendError as exc:
         typer.echo(str(exc), err=True)

--- a/src/teatree/eval/api_runner.py
+++ b/src/teatree/eval/api_runner.py
@@ -420,38 +420,47 @@ def load_agent_definition(agent_path: str, agent_sections: tuple[str, ...] = ())
     return text
 
 
+@dataclasses.dataclass(frozen=True, slots=True)
+class ApiRunnerParams:
+    """The construction knobs for :class:`ApiInProcessRunner`, grouped into one object.
+
+    Six knobs threaded one runner-construction concern each. Grouping them here
+    keeps the constructor a single parameter (so ``ApiInProcessRunner`` no longer
+    trips the too-many-arguments bar) and gives ``make_runner`` one value to build
+    and thread from the ``t3 eval run`` CLI.
+    """
+
+    #: ``None`` (the CI/production path, where ``make_runner`` passes no workspace
+    #: and the eval CLI's cwd is the teatree repo root) means "grant only the
+    #: neutral isolated temp dir" — NEVER the repo root, which would expose
+    #: ``evals/scenarios/*.yaml`` (the matcher/answer text) to the agent under
+    #: test. A test passes an explicit throwaway workspace to grant.
+    workspace: Path | None = None
+    max_turns_override: int | None = None
+    require_executed: bool = False
+    max_budget_usd: float = float(MAX_BUDGET_USD)
+    #: Lane-level representative reasoning effort. Applied when a scenario declares
+    #: no ``model@effort`` of its own (a declared effort wins).
+    effort: EffortLevel | None = None
+    #: The SELECTED eval credential's conflicting vars — the credential the
+    #: isolated child must NOT fall back to (the metered API key strips the OAuth
+    #: token; the subscription OAuth strips the API key). ``make_runner`` passes the
+    #: resolved eval credential's ``spec.conflicting_vars``; the default preserves
+    #: the pre-#2707-reversal metered strip for direct callers.
+    conflicting_vars: tuple[str, ...] = _DEFAULT_CONFLICTING_VARS
+
+
 class ApiInProcessRunner:
     """Run an :class:`EvalSpec` via the in-process Agent SDK and capture tool calls."""
 
-    # ast-grep-ignore: ac-django-no-complexity-suppressions
-    def __init__(  # noqa: PLR0913 — each kwarg is one runner-construction knob (workspace / turns / require / budget / effort / credential-conflicts); the list mirrors ``make_runner``'s contract.
-        self,
-        *,
-        workspace: Path | None = None,
-        max_turns_override: int | None = None,
-        require_executed: bool = False,
-        max_budget_usd: float = float(MAX_BUDGET_USD),
-        effort: EffortLevel | None = None,
-        conflicting_vars: tuple[str, ...] = _DEFAULT_CONFLICTING_VARS,
-    ) -> None:
-        # ``None`` (the CI/production path, where make_runner passes no workspace and
-        # the eval CLI's cwd is the teatree repo root) means "grant only the neutral
-        # isolated temp dir" — NEVER the repo root, which would expose
-        # evals/scenarios/*.yaml (the matcher/answer text) to the agent under test.
-        # A test passes an explicit throwaway workspace to grant.
-        self._workspace = workspace
-        self._max_turns_override = max_turns_override
-        self._require_executed = require_executed
-        self._max_budget_usd = max_budget_usd
-        #: Lane-level representative reasoning effort. Applied when a scenario
-        #: declares no ``model@effort`` of its own (a declared effort wins).
-        self._effort = effort
-        #: The SELECTED eval credential's conflicting vars — the credential the
-        #: isolated child must NOT fall back to (the metered API key strips the
-        #: OAuth token; the subscription OAuth strips the API key). ``make_runner``
-        #: passes the resolved eval credential's ``spec.conflicting_vars``; the
-        #: default preserves the pre-#2707-reversal metered strip for direct callers.
-        self._conflicting_vars = conflicting_vars
+    def __init__(self, params: ApiRunnerParams | None = None) -> None:
+        params = params or ApiRunnerParams()
+        self._workspace = params.workspace
+        self._max_turns_override = params.max_turns_override
+        self._require_executed = params.require_executed
+        self._max_budget_usd = params.max_budget_usd
+        self._effort = params.effort
+        self._conflicting_vars = params.conflicting_vars
 
     def _resolve_max_turns(self, spec: EvalSpec) -> int:
         """Override wins; else a clean-room budget is floored to :data:`CLEAN_ROOM_MIN_TURNS`."""

--- a/src/teatree/eval/backends.py
+++ b/src/teatree/eval/backends.py
@@ -39,9 +39,7 @@ import dataclasses
 from pathlib import Path
 from typing import Protocol
 
-from claude_agent_sdk.types import EffortLevel
-
-from teatree.eval.api_runner import MAX_BUDGET_USD, ApiInProcessRunner
+from teatree.eval.api_runner import ApiInProcessRunner, ApiRunnerParams
 from teatree.eval.model_resolution import resolve_eval_model
 from teatree.eval.models import EvalRun, EvalSpec
 from teatree.eval.subagent_transcript import is_subagent_transcript, subagent_run
@@ -63,17 +61,19 @@ class UnknownBackendError(ValueError):
     """Raised for a ``--backend`` value outside :data:`KNOWN_BACKENDS`."""
 
 
-# ast-grep-ignore: ac-django-no-complexity-suppressions
-def make_runner(  # noqa: PLR0913 — each kwarg threads one runner-construction knob (turns / budget / effort / require / transcript-dir) from the `t3 eval run` CLI; the list IS the backend contract.
+def make_runner(
     backend: str,
+    params: ApiRunnerParams | None = None,
     *,
-    max_turns_override: int | None = None,
     transcript_dir: Path | None = None,
-    require_executed: bool = False,
-    max_budget_usd: float = float(MAX_BUDGET_USD),
-    effort: EffortLevel | None = None,
 ) -> EvalRunner:
     """Build the eval runner for *backend*.
+
+    *params* carries the api-lane construction knobs (turns / budget / effort /
+    require) the ``t3 eval run`` CLI threads; the api branch overrides its
+    ``conflicting_vars`` with the SELECTED eval credential's strip set before
+    building the runner. The transcript lane uses only *transcript_dir*; the
+    ``pydantic_ai`` lane reads *params*' ``max_turns_override`` / ``effort``.
 
     ``"api"`` → the in-process Agent-SDK runner that RUNS the model fresh, on the
     credential the ``eval_credential`` knob selects (default subscription OAuth,
@@ -106,6 +106,7 @@ def make_runner(  # noqa: PLR0913 — each kwarg threads one runner-construction
     at a representative effort, not the model's default); the transcript runner
     ignores it.
     """
+    params = params or ApiRunnerParams()
     if backend == API_BACKEND:
         # Resolve the SELECTED eval credential (the ``eval_credential`` knob — default
         # subscription OAuth, reversing #2707) and export it, so the isolated child
@@ -121,13 +122,7 @@ def make_runner(  # noqa: PLR0913 — each kwarg threads one runner-construction
 
         credential = resolve_eval_credential()
         credential.export()
-        return ApiInProcessRunner(
-            max_turns_override=max_turns_override,
-            require_executed=require_executed,
-            max_budget_usd=max_budget_usd,
-            effort=effort,
-            conflicting_vars=credential.spec.conflicting_vars,
-        )
+        return ApiInProcessRunner(dataclasses.replace(params, conflicting_vars=credential.spec.conflicting_vars))
     if backend == TRANSCRIPT_BACKEND:
         return TranscriptRunner(transcript_dir=transcript_dir or Path.cwd())
     if backend == PYDANTIC_AI_BACKEND:
@@ -140,7 +135,7 @@ def make_runner(  # noqa: PLR0913 — each kwarg threads one runner-construction
             build_pydantic_ai_eval_runner,
         )
 
-        return build_pydantic_ai_eval_runner(max_turns_override=max_turns_override, effort=effort)
+        return build_pydantic_ai_eval_runner(max_turns_override=params.max_turns_override, effort=params.effort)
     msg = f"unknown eval backend {backend!r}; expected one of {', '.join(KNOWN_BACKENDS)}"
     raise UnknownBackendError(msg)
 

--- a/src/teatree/loops/dream/live_gate.py
+++ b/src/teatree/loops/dream/live_gate.py
@@ -55,12 +55,15 @@ def build_live_validator() -> LiveValidator:
     This is the OPT-IN path — ``t3 dream run --full`` supplies it; the nightly
     ``tick`` does NOT (it withholds, so nothing auto-lands without a metered check).
     """
-    from teatree.eval.api_runner import ApiInProcessRunner  # noqa: PLC0415
+    from teatree.eval.api_runner import (  # noqa: PLC0415 — lazy: the eval harness is imported only on the opt-in metered path, keeping the dream loop's import chain free of the SDK runner otherwise.
+        ApiInProcessRunner,
+        ApiRunnerParams,
+    )
     from teatree.eval.pass_at_k import run_pass_at_k  # noqa: PLC0415
     from teatree.eval.report import evaluate as evaluate_run  # noqa: PLC0415
 
     def _validate(spec: EvalSpec, *, trials: int, require: str) -> bool:
-        runner = ApiInProcessRunner(require_executed=True)
+        runner = ApiInProcessRunner(ApiRunnerParams(require_executed=True))
         return run_pass_at_k(spec, lambda s: evaluate_run(s, runner.run(s)), k=trials, require=require).ok
 
     return _validate

--- a/tests/eval_harness/test_backends.py
+++ b/tests/eval_harness/test_backends.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
-from teatree.eval.api_runner import MAX_BUDGET_USD, ApiInProcessRunner
+from teatree.eval.api_runner import MAX_BUDGET_USD, ApiInProcessRunner, ApiRunnerParams
 from teatree.eval.backends import API_BACKEND, TRANSCRIPT_BACKEND, TranscriptRunner, UnknownBackendError, make_runner
 from teatree.eval.models import EvalSpec, Matcher
 from teatree.llm.credentials import AnthropicSubscriptionCredential
@@ -62,7 +62,7 @@ class TestMakeRunner:
 
     def test_api_backend_threads_the_budget_override(self) -> None:
         with patch.dict(os.environ, {OAUTH_ENV: "oauth-test"}, clear=False):
-            runner = make_runner(API_BACKEND, max_budget_usd=2.0)
+            runner = make_runner(API_BACKEND, ApiRunnerParams(max_budget_usd=2.0))
         assert isinstance(runner, ApiInProcessRunner)
         assert runner._max_budget_usd == pytest.approx(2.0)
 

--- a/tests/eval_harness/test_virgin_isolation.py
+++ b/tests/eval_harness/test_virgin_isolation.py
@@ -28,7 +28,7 @@ import pytest
 from claude_agent_sdk import ResultMessage
 from django.test import TestCase
 
-from teatree.eval.api_runner import ApiInProcessRunner
+from teatree.eval.api_runner import ApiInProcessRunner, ApiRunnerParams
 from teatree.eval.isolation import isolated_claude_env
 from teatree.eval.judge import ClaudeJudge
 from teatree.eval.models import EvalRun, EvalSpec, EvalToolCall, JudgeSpec, Matcher
@@ -170,7 +170,7 @@ class TestRunnerIsolation:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            ApiInProcessRunner(workspace=tmp_path).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path)).run(spec)
         return captured
 
     def test_options_carry_empty_setting_sources(self, tmp_path: Path) -> None:
@@ -284,7 +284,7 @@ class TestCanaryNeverReachesChild:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            ApiInProcessRunner(workspace=project).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(workspace=project)).run(spec)
 
         options = captured["options"]
         assert options.setting_sources == []
@@ -326,6 +326,6 @@ class TestCanaryNeverReachesChild:
             max_turns=1,
             tools=(),
         )
-        result = ApiInProcessRunner(workspace=project).run(spec)
+        result = ApiInProcessRunner(ApiRunnerParams(workspace=project)).run(spec)
         assert CANARY not in result.raw_stdout
         assert CANARY not in result.raw_stderr

--- a/tests/quality/test_metered_runner_chokepoint.py
+++ b/tests/quality/test_metered_runner_chokepoint.py
@@ -101,8 +101,8 @@ class TestMeteredRunnerChokepoint:
     def test_predicate_catches_a_bare_construction(self, tmp_path: Path) -> None:
         bait = tmp_path / "bait.py"
         bait.write_text(
-            "from teatree.eval.api_runner import ApiInProcessRunner\n"
-            "runner = ApiInProcessRunner(max_turns_override=None)\n",
+            "from teatree.eval.api_runner import ApiInProcessRunner, ApiRunnerParams\n"
+            "runner = ApiInProcessRunner(ApiRunnerParams(require_executed=True))\n",
             encoding="utf-8",
         )
         assert _constructs_runner(bait)
@@ -110,8 +110,8 @@ class TestMeteredRunnerChokepoint:
     def test_predicate_ignores_make_runner_routing(self, tmp_path: Path) -> None:
         clean = tmp_path / "clean.py"
         clean.write_text(
-            "from teatree.eval.backends import API_BACKEND, make_runner\n"
-            "runner = make_runner(API_BACKEND, max_turns_override=None)\n",
+            "from teatree.eval.backends import API_BACKEND, ApiRunnerParams, make_runner\n"
+            "runner = make_runner(API_BACKEND, ApiRunnerParams(require_executed=True))\n",
             encoding="utf-8",
         )
         assert not _constructs_runner(clean)

--- a/tests/teatree_cli/eval/test_local_auth_resolution.py
+++ b/tests/teatree_cli/eval/test_local_auth_resolution.py
@@ -46,7 +46,7 @@ def _spec(name: str = "s", model: str = "claude-opus-4-8") -> EvalSpec:
 class _StubRunner:
     """Records that it was built; grades every scenario as a metered pass."""
 
-    def __init__(self, **_: Any) -> None:
+    def __init__(self, *_: Any, **__: Any) -> None:
         pass
 
     def run(self, spec: EvalSpec) -> EvalRun:

--- a/tests/teatree_cli/eval/test_multi_trial_effort.py
+++ b/tests/teatree_cli/eval/test_multi_trial_effort.py
@@ -1,7 +1,7 @@
 """Lane-level ``--effort`` threads into the metered runner the gating lanes build (#2192).
 
 The single-trial path threads the resolved ``--effort`` / ``METERED_DEFAULT_EFFORT``
-into ``make_runner(... effort=...)``; the always-metered pass@k (``--trials k>1``,
+into ``make_runner(..., ApiRunnerParams(effort=...))``; the always-metered pass@k (``--trials k>1``,
 the CI gate) and model-matrix lanes must do the SAME. They now build through that
 same ``make_runner`` chokepoint (so API-key resolution can never be bypassed),
 and so must pass the lane effort, or the calibration never reaches the metered gate.
@@ -11,12 +11,12 @@ lane effort is the default for scenarios that declare none.
 
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
 from unittest.mock import patch
 
 import pytest
 
 from teatree.cli.eval.multi_trial import run_model_matrix_lane, run_pass_at_k_lane
+from teatree.eval.api_runner import ApiRunnerParams
 from teatree.eval.models import EvalRun, EvalSpec
 from teatree.llm.credentials import AnthropicSubscriptionCredential
 
@@ -38,8 +38,8 @@ class _RecordingRunner:
 
     last_effort: str | None = None
 
-    def __init__(self, **kwargs: Any) -> None:
-        type(self).last_effort = kwargs.get("effort")
+    def __init__(self, params: ApiRunnerParams | None = None) -> None:
+        type(self).last_effort = None if params is None else params.effort
 
     def run(self, spec: EvalSpec) -> EvalRun:
         return EvalRun(

--- a/tests/teatree_cli/test_eval.py
+++ b/tests/teatree_cli/test_eval.py
@@ -16,6 +16,7 @@ from teatree.cli.eval.corpus import CorpusGradeRow
 from teatree.cli.eval.docker import DockerUnavailableError
 from teatree.cli.eval.run_modes import RunGuards, with_model
 from teatree.cli.eval.verdict import LaneResult
+from teatree.eval.api_runner import ApiRunnerParams
 from teatree.eval.coverage import CoverageReport, SkillCoverage
 from teatree.eval.model_resolution import resolve_eval_model
 from teatree.eval.models import EvalRun, EvalSpec, EvalToolCall, Matcher
@@ -438,11 +439,9 @@ class TestTranscriptReplay:
         captured: dict[str, object] = {}
 
         class _StubRunner:
-            def __init__(
-                self, *, max_turns_override: int | None = None, require_executed: bool = False, **_: object
-            ) -> None:
-                captured["max_turns_override"] = max_turns_override
-                captured["require_executed"] = require_executed
+            def __init__(self, params: ApiRunnerParams) -> None:
+                captured["max_turns_override"] = params.max_turns_override
+                captured["require_executed"] = params.require_executed
 
             def run(self, spec: EvalSpec) -> EvalRun:
                 return _run(spec.name, tool_calls=_PASSING_CALL)
@@ -462,8 +461,8 @@ class TestTranscriptReplay:
         captured: dict[str, object] = {}
 
         class _StubRunner:
-            def __init__(self, *, max_turns_override: int | None = None, **_: object) -> None:
-                captured["max_turns_override"] = max_turns_override
+            def __init__(self, params: ApiRunnerParams) -> None:
+                captured["max_turns_override"] = params.max_turns_override
 
             def run(self, spec: EvalSpec) -> EvalRun:
                 return _run(spec.name, tool_calls=_PASSING_CALL)
@@ -483,8 +482,8 @@ class TestTranscriptReplay:
         captured: dict[str, object] = {}
 
         class _StubRunner:
-            def __init__(self, *, max_turns_override: int | None = None, **_: object) -> None:
-                captured["max_turns_override"] = max_turns_override
+            def __init__(self, params: ApiRunnerParams) -> None:
+                captured["max_turns_override"] = params.max_turns_override
 
             def run(self, spec: EvalSpec) -> EvalRun:
                 return _run(spec.name, tool_calls=_PASSING_CALL)
@@ -504,10 +503,8 @@ class TestTranscriptReplay:
         captured: dict[str, object] = {}
 
         class _StubRunner:
-            def __init__(
-                self, *, max_turns_override: int | None = None, require_executed: bool = False, **_: object
-            ) -> None:
-                captured["require_executed"] = require_executed
+            def __init__(self, params: ApiRunnerParams) -> None:
+                captured["require_executed"] = params.require_executed
 
             def run(self, spec: EvalSpec) -> EvalRun:
                 return _run(spec.name, tool_calls=_PASSING_CALL, cost_usd=0.05)
@@ -1402,8 +1399,8 @@ class _BudgetCapturingRunner:
 
     last_max_budget_usd: float | None = None
 
-    def __init__(self, *_: object, max_budget_usd: float, **__: object) -> None:
-        type(self).last_max_budget_usd = max_budget_usd
+    def __init__(self, params: ApiRunnerParams) -> None:
+        type(self).last_max_budget_usd = params.max_budget_usd
 
     def run(self, spec: EvalSpec) -> EvalRun:
         return _run(spec.name, tool_calls=_PASSING_CALL, cost_usd=0.20)
@@ -1414,8 +1411,8 @@ class _EffortCapturingRunner:
 
     last_effort: object = "unset"
 
-    def __init__(self, *_: object, effort: object = None, **__: object) -> None:
-        type(self).last_effort = effort
+    def __init__(self, params: ApiRunnerParams) -> None:
+        type(self).last_effort = params.effort
 
     def run(self, spec: EvalSpec) -> EvalRun:
         return _run(spec.name, tool_calls=_PASSING_CALL, cost_usd=0.20)

--- a/tests/teatree_eval/test_api_runner.py
+++ b/tests/teatree_eval/test_api_runner.py
@@ -20,11 +20,13 @@ from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolUse
 from claude_agent_sdk.types import HookEventMessage
 
 from teatree.eval.api_runner import (
+    _DEFAULT_CONFLICTING_VARS,
     CLAUDE_RESOLVE_MAX_ATTEMPTS,
     DEFAULT_WATCHDOG_SECONDS,
     MAX_BUDGET_USD,
     WATCHDOG_SECONDS,
     ApiInProcessRunner,
+    ApiRunnerParams,
     BudgetExceededError,
     ClaudeCliMissingError,
     CleanRoomConfig,
@@ -184,7 +186,7 @@ class TestApiInProcessRunnerSkip:
             patch("teatree.eval.api_runner.shutil.which", return_value=None),
             pytest.raises(ClaudeCliMissingError),
         ):
-            ApiInProcessRunner(require_executed=True).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(require_executed=True)).run(spec)
 
 
 class TestApiInProcessRunnerCapture:
@@ -194,7 +196,7 @@ class TestApiInProcessRunnerCapture:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            run = ApiInProcessRunner(**kwargs).run(spec)
+            run = ApiInProcessRunner(ApiRunnerParams(**kwargs)).run(spec)
         return run, captured
 
     def test_captures_tool_calls_text_terminal_cost(self, tmp_path: Path) -> None:
@@ -394,7 +396,7 @@ class TestApiInProcessRunnerCapture:
             patch("teatree.eval.api_runner.WATCHDOG_SECONDS", 12.5),
             patch("teatree.eval.api_runner.asyncio.wait_for", _spy),
         ):
-            ApiInProcessRunner(workspace=tmp_path).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path)).run(spec)
         return captured.get("timeout")
 
     def test_per_scenario_watchdog_overrides_the_lane_default(self, tmp_path: Path) -> None:
@@ -459,7 +461,7 @@ class TestApiInProcessRunnerCapture:
             patch("teatree.eval.api_runner.query", _slow_query),
             patch("teatree.eval.api_runner.WATCHDOG_SECONDS", 0.01),
         ):
-            run = ApiInProcessRunner(workspace=tmp_path).run(spec)
+            run = ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path)).run(spec)
         assert run.terminal_reason == "timeout"
         assert run.is_error is True
 
@@ -503,7 +505,7 @@ class TestApiInProcessRunnerAgentDefinition:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            ApiInProcessRunner(**kwargs).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(**kwargs)).run(spec)
         return captured
 
     def test_raises_when_agent_definition_missing(self, tmp_path: Path) -> None:
@@ -519,7 +521,7 @@ class TestApiInProcessRunnerAgentDefinition:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             pytest.raises(FileNotFoundError),
         ):
-            ApiInProcessRunner(workspace=tmp_path).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path)).run(spec)
 
     def test_raises_when_agent_definition_empty(self, tmp_path: Path) -> None:
         agent = tmp_path / "empty.md"
@@ -536,7 +538,7 @@ class TestApiInProcessRunnerAgentDefinition:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             pytest.raises(ValueError, match="empty"),
         ):
-            ApiInProcessRunner(workspace=tmp_path).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path)).run(spec)
 
     def test_agent_sections_send_only_named_section_as_system_prompt(self, tmp_path: Path) -> None:
         agent = tmp_path / "rules.md"
@@ -621,7 +623,7 @@ class TestApiInProcessRunnerMessageMapping:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            run = ApiInProcessRunner(workspace=tmp_path).run(spec)
+            run = ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path)).run(spec)
         # The thinking block is dropped, the tool_use is captured, the system message ignored.
         assert [c.name for c in run.tool_calls] == ["Bash"]
         assert run.text_blocks == ()
@@ -647,7 +649,7 @@ class TestApiInProcessRunnerMessageMapping:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            ApiInProcessRunner(workspace=tmp_path).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path)).run(spec)
         assert captured["system_prompt_text"].strip()
 
     def test_relative_agent_path_not_found_raises(self, tmp_path: Path, monkeypatch) -> None:
@@ -666,7 +668,7 @@ class TestApiInProcessRunnerMessageMapping:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             pytest.raises(FileNotFoundError),
         ):
-            ApiInProcessRunner(workspace=tmp_path).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path)).run(spec)
 
 
 def _config(tmp_path: Path, *, max_budget_usd: float) -> CleanRoomConfig:
@@ -771,7 +773,7 @@ class TestBuildSdkOptionsSkillCatalog:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            ApiInProcessRunner(workspace=tmp_path).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path)).run(spec)
         assert captured["options"].skills == ["t3-widget", "widget-le"]
         assert len(captured["options"].plugins) == 1
 
@@ -782,7 +784,7 @@ class TestBuildSdkOptionsSkillCatalog:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            ApiInProcessRunner(workspace=tmp_path).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path)).run(spec)
         assert captured["options"].skills is None
         assert captured["options"].plugins == []
 
@@ -828,7 +830,7 @@ class TestCalibratedCaps:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            ApiInProcessRunner(workspace=tmp_path).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path)).run(spec)
         assert captured["options"].max_turns == DEFAULT_MAX_TURNS
 
     def test_clean_room_below_floor_turn_budget_is_lifted_to_the_floor(self, tmp_path: Path) -> None:
@@ -843,7 +845,7 @@ class TestCalibratedCaps:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            ApiInProcessRunner(workspace=tmp_path).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path)).run(spec)
         assert captured["options"].max_turns == CLEAN_ROOM_MIN_TURNS
 
     def test_under_load_below_floor_turn_budget_is_kept_unchanged(self, tmp_path: Path) -> None:
@@ -855,7 +857,7 @@ class TestCalibratedCaps:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            ApiInProcessRunner(workspace=tmp_path).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path)).run(spec)
         assert captured["options"].max_turns == 3
 
     def test_explicit_override_wins_over_the_clean_room_floor(self, tmp_path: Path) -> None:
@@ -867,7 +869,7 @@ class TestCalibratedCaps:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            ApiInProcessRunner(workspace=tmp_path, max_turns_override=2).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path, max_turns_override=2)).run(spec)
         assert captured["options"].max_turns == 2
 
 
@@ -928,7 +930,7 @@ class TestApiInProcessRunnerBudgetExceeded:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            return ApiInProcessRunner(workspace=spec.source_path.parent, **kwargs).run(spec)
+            return ApiInProcessRunner(ApiRunnerParams(workspace=spec.source_path.parent, **kwargs)).run(spec)
 
     def test_budget_exceeded_is_a_recorded_run_not_a_crash(self, tmp_path: Path) -> None:
         spec = _spec(tmp_path)
@@ -996,7 +998,7 @@ class TestApiInProcessRunnerCreditExhausted:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            return ApiInProcessRunner(workspace=spec.source_path.parent).run(spec)
+            return ApiInProcessRunner(ApiRunnerParams(workspace=spec.source_path.parent)).run(spec)
 
     def test_credit_balance_too_low_raises_credit_exhausted_not_generic(self, tmp_path: Path) -> None:
         # The billed ANTHROPIC_API_KEY at $0 surfaces HTTP 400 "credit balance is
@@ -1149,7 +1151,7 @@ class TestLargeSystemPromptDoesNotBlowArgMax:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            run = ApiInProcessRunner(workspace=tmp_path).run(spec)
+            run = ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path)).run(spec)
         assert run.terminal_reason == "success"
         assert run.is_error is False
         assert _HUGE_SYSTEM_PROMPT in captured["system_prompt_text"]
@@ -1170,7 +1172,7 @@ class TestSuccessResultIsNotAnError:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            return ApiInProcessRunner(workspace=spec.source_path.parent, **kwargs).run(spec)
+            return ApiInProcessRunner(ApiRunnerParams(workspace=spec.source_path.parent, **kwargs)).run(spec)
 
     def test_is_success_result_error_recognizes_the_marker(self) -> None:
         assert is_success_result_error("Claude Code returned an error result: success") is True
@@ -1233,7 +1235,7 @@ class TestApiInProcessRunnerMaxTurnsCapturesTrajectory:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            return ApiInProcessRunner(workspace=spec.source_path.parent, **kwargs).run(spec)
+            return ApiInProcessRunner(ApiRunnerParams(workspace=spec.source_path.parent, **kwargs)).run(spec)
 
     def test_max_turns_cap_keeps_the_tool_call_emitted_before_the_cap(self, tmp_path: Path) -> None:
         # The agent DID the expected tool call before turn 3, then hit the cap.
@@ -1700,7 +1702,7 @@ class TestDisallowedToolsFlowToOptions:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            ApiInProcessRunner(workspace=spec.source_path.parent, **kwargs).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(workspace=spec.source_path.parent, **kwargs)).run(spec)
         return captured
 
     def test_build_sdk_options_forwards_disallowed_tools(self, tmp_path: Path) -> None:
@@ -1926,7 +1928,7 @@ class TestDelegationScenarioGetsEmptyDenylist:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            ApiInProcessRunner(workspace=spec.source_path.parent).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(workspace=spec.source_path.parent)).run(spec)
         options = captured["options"]
         assert "Agent" in options.tools
         assert list(options.disallowed_tools) == []
@@ -1951,7 +1953,7 @@ class TestDelegationAgentsProvisioning:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            ApiInProcessRunner(workspace=spec.source_path.parent, **kwargs).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(workspace=spec.source_path.parent, **kwargs)).run(spec)
         return captured
 
     def test_spawn_tool_constant_is_agent(self) -> None:
@@ -2051,7 +2053,7 @@ class TestSpawningScenarioRunsAgainstEphemeralCheckout:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
             patch("teatree.eval.api_runner.query", query),
         ):
-            ApiInProcessRunner(workspace=spec.source_path.parent, **kwargs).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(workspace=spec.source_path.parent, **kwargs)).run(spec)
         return captured
 
     def _spawning_spec(self, spec_dir: Path) -> EvalSpec:
@@ -2213,7 +2215,7 @@ class TestRunnerRetriesTransientMissingClaude:
             patch("teatree.eval.api_runner.time.sleep", lambda _s: None),
             pytest.raises(ClaudeCliMissingError),
         ):
-            ApiInProcessRunner(require_executed=True).run(spec)
+            ApiInProcessRunner(ApiRunnerParams(require_executed=True)).run(spec)
 
 
 def _clean_room_config(
@@ -2310,3 +2312,40 @@ class TestProductionHooksRun:
         options = captured["options"]
         assert options.env["XDG_DATA_HOME"].startswith(options.cwd)
         assert options.env["T3_LOOP_REGISTRY_DIR"].startswith(options.cwd)
+
+
+class TestApiRunnerParams:
+    """The single :class:`ApiRunnerParams` object carries every runner-construction knob."""
+
+    def test_bare_construction_uses_the_param_defaults(self) -> None:
+        # ``ApiInProcessRunner()`` (the CI/production shape) grants no workspace, the
+        # cheap-lane budget floor, and the direct-caller conflicting-var default.
+        runner = ApiInProcessRunner()
+        assert runner._workspace is None
+        assert runner._max_turns_override is None
+        assert runner._require_executed is False
+        assert runner._max_budget_usd == pytest.approx(float(MAX_BUDGET_USD))
+        assert runner._effort is None
+        assert runner._conflicting_vars == _DEFAULT_CONFLICTING_VARS
+
+    def test_every_field_threads_from_the_params_object_to_the_runner(self, tmp_path: Path) -> None:
+        params = ApiRunnerParams(
+            workspace=tmp_path,
+            max_turns_override=7,
+            require_executed=True,
+            max_budget_usd=3.5,
+            effort="high",
+            conflicting_vars=("FOO", "BAR"),
+        )
+        runner = ApiInProcessRunner(params)
+        assert runner._workspace == tmp_path
+        assert runner._max_turns_override == 7
+        assert runner._require_executed is True
+        assert runner._max_budget_usd == pytest.approx(3.5)
+        assert runner._effort == "high"
+        assert runner._conflicting_vars == ("FOO", "BAR")
+
+    def test_params_object_is_frozen(self) -> None:
+        params = ApiRunnerParams()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            params.max_turns_override = 3  # type: ignore[misc]

--- a/tests/teatree_eval/test_cli_stub_fixture.py
+++ b/tests/teatree_eval/test_cli_stub_fixture.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import pytest
 
 from teatree.core.on_behalf_gate_recorded import format_on_behalf_block_message
-from teatree.eval.api_runner import ApiInProcessRunner
+from teatree.eval.api_runner import ApiInProcessRunner, ApiRunnerParams
 from teatree.eval.cli_stub_fixture import (
     KNOWN_CLI_STUBS,
     ON_BEHALF_ASK_BLOCK_TEXT,
@@ -203,7 +203,7 @@ def _spec(tmp_path: Path, *, cli_stubs: tuple[str, ...] = (), fixture: str = "")
 
 class TestResolveEvalTargetWiresPath:
     def test_stub_dir_prepended_to_env_path_when_declared(self, tmp_path: Path) -> None:
-        runner = ApiInProcessRunner(workspace=tmp_path)
+        runner = ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path))
         spec = _spec(tmp_path, cli_stubs=("t3",))
         with runner._resolve_eval_target(spec) as (_workspace, _cwd, env):
             first = env["PATH"].split(os.pathsep)[0]
@@ -211,7 +211,7 @@ class TestResolveEvalTargetWiresPath:
             assert os.access(Path(first) / "t3", os.X_OK)
 
     def test_path_untouched_when_no_cli_stubs(self, tmp_path: Path) -> None:
-        runner = ApiInProcessRunner(workspace=tmp_path)
+        runner = ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path))
         spec = _spec(tmp_path)
         base_path = os.environ.get("PATH", "")
         with runner._resolve_eval_target(spec) as (_workspace, _cwd, env):
@@ -219,7 +219,7 @@ class TestResolveEvalTargetWiresPath:
 
     def test_composes_with_git_repo_fixture(self, tmp_path: Path) -> None:
         # cli_stubs is a SEPARATE lever from `fixture`; a scenario may declare both.
-        runner = ApiInProcessRunner(workspace=tmp_path)
+        runner = ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path))
         spec = _spec(tmp_path, cli_stubs=("t3",), fixture="git_repo")
         with runner._resolve_eval_target(spec) as (workspace, cwd, env):
             assert (workspace / ".git").is_dir()  # the git_repo fixture provisioned

--- a/tests/teatree_eval/test_cost_reporting.py
+++ b/tests/teatree_eval/test_cost_reporting.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 import pytest
 from claude_agent_sdk import ResultMessage
 
-from teatree.eval.api_runner import ApiInProcessRunner
+from teatree.eval.api_runner import ApiInProcessRunner, ApiRunnerParams
 from teatree.eval.models import EvalRun, EvalSpec
 from teatree.eval.report import ScenarioResult, render_json, render_text
 from teatree.eval.transcript import StreamJsonEvent, extract_cost_usd
@@ -151,7 +151,7 @@ class TestRunnerCostCapture:
             patch("teatree.eval.api_runner.shutil.which", return_value="/usr/bin/claude"),
             patch("teatree.eval.api_runner.query", _query),
         ):
-            return ApiInProcessRunner(workspace=tmp_path).run(spec)
+            return ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path)).run(spec)
 
     def test_cost_captured_from_result_event(self, tmp_path: Path) -> None:
         run = self._run_with_cost(tmp_path, 0.01)

--- a/tests/teatree_loops/dream/test_promote.py
+++ b/tests/teatree_loops/dream/test_promote.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from teatree.core.review.review_findings import find_bare_references
+from teatree.eval.api_runner import ApiRunnerParams
 from teatree.eval.discovery import SCENARIOS_DIR
 from teatree.eval.loader import _parse_spec, load_eval_yaml
 from teatree.eval.models import EvalSpec
@@ -506,7 +507,7 @@ class ExtractedModulesTestCase(TestCase):
     def test_validator_builds_the_metered_runner_and_aggregates_pass_at_k(self) -> None:
         # Drive the returned ``_validate`` body with the metered runner construction
         # and pass@k aggregation faked, so the validator's real body is covered
-        # without a model call: it builds an ApiInProcessRunner(require_executed=True)
+        # without a model call: it builds an ApiInProcessRunner(ApiRunnerParams(require_executed=True))
         # and returns the pass@k verdict's ``.ok``. The validator's lazy imports bind
         # at build time, so build it INSIDE the patch context.
         from unittest.mock import MagicMock  # noqa: PLC0415
@@ -518,7 +519,7 @@ class ExtractedModulesTestCase(TestCase):
         ):
             validator: LiveValidator = build_live_validator()
             assert validator(spec, trials=3, require="any") is True
-        runner_cls.assert_called_once_with(require_executed=True)
+        runner_cls.assert_called_once_with(ApiRunnerParams(require_executed=True))
         assert run_k.call_args.kwargs == {"k": 3, "require": "any"}
 
     def test_synthetic_transcripts_round_trip_through_run_from_transcript(self) -> None:


### PR DESCRIPTION
## What

The eval constructors (`ApiInProcessRunner.__init__`, `teatree.eval.backends.make_runner`) each carried 6+ keyword knobs, which forced a `# noqa: PLR0913` + `ast-grep-ignore: ac-django-no-complexity-suppressions` suppression on both. This groups the runner-construction knobs into one frozen `ApiRunnerParams` dataclass and removes the now-unjustified suppressions — the 3f#13 deferral from Unit 3.

## How

- New `ApiRunnerParams` (frozen, slots) in `teatree.eval.api_runner`: `workspace / max_turns_override / require_executed / max_budget_usd / effort / conflicting_vars`, carrying the field-level docstrings the old `__init__` comments held.
- `ApiInProcessRunner(params=None)` — single parameter; the private `_workspace` / `_max_budget_usd` / … attributes and every runner behavior are unchanged.
- `make_runner(backend, params=None, *, transcript_dir=None)` — the api-lane knobs travel in `params`; the api branch overrides `conflicting_vars` with the resolved eval credential's strip set via `dataclasses.replace`; the transcript lane still takes only `transcript_dir`.
- Removed both `PLR0913` suppressions (ruff confirms neither constructor trips the arg bar now).
- ~70 call sites updated across `src/teatree/cli/eval/*`, `loops/dream/live_gate.py`, and the eval test suite — including the `**kwargs`-splat test helpers and the `test_metered_runner_chokepoint` source-shape gate's bait strings.

## Behavior-preserving

The AST chokepoint stays green — the metered runner is still constructed only in `teatree.eval.backends`. `mcp/server.py:100` `_ticket_search` is intentionally NOT touched (its noqa is a justified MCP tool surface).

## Tests

Anti-vacuous `TestApiRunnerParams` (RED-before: `ImportError: cannot import name 'ApiRunnerParams'`) asserts every field threads from the params object to the runner, bare-construction defaults, and frozen-ness. Existing eval suites stay green through the params object.

- eval + CLI + chokepoint + dream suites all green; leak gates (gitleaks, banned-terms, no-overlay-leak) pass; full pre-push gate passed.