### PR TITLE
fix(tests): sync _FakeUserSettings with promoted overlay code-default fields

### DIFF
--- a/tests/integration/slack_bridge_e2e/conftest.py
+++ b/tests/integration/slack_bridge_e2e/conftest.py
@@ -45,6 +45,7 @@ import pytest
 from teatree.backends.slack import http as slack_http
 from teatree.config.enums import Autonomy as _Autonomy
 from teatree.config.enums import OnBehalfPostMode as _OnBehalfPostMode
+from teatree.types import DEFAULT_MR_TITLE_REGEX as _DEFAULT_MR_TITLE_REGEX
 from teatree.types import SlackVoiceClassifierMode as _VoiceClassifierMode
 from teatree.types import SpeakConfig as _SpeakConfig
 
@@ -199,6 +200,23 @@ class _FakeUserSettings:
     autonomy: _Autonomy = _Autonomy.BABYSIT
     on_behalf_post_mode: _OnBehalfPostMode = _OnBehalfPostMode.DRAFT_OR_ASK
     speak: _SpeakConfig = field(default_factory=_SpeakConfig)
+    # #36 / #3115 ``get_effective_settings`` rebuilds settings via
+    # ``dataclasses.replace(base, **layered)`` where ``layered`` carries the
+    # overlay CODE-DEFAULT tier — every key in
+    # ``PROMOTED_OVERLAY_CODE_DEFAULT_KEYS``. ``replace`` re-invokes
+    # ``base.__class__(**changes)``, so each promoted key MUST be a field here or
+    # the rebuild raises ``TypeError`` (surfaces only when the active overlay
+    # resolves and populates the tier — a cwd-basename-dependent path, hence
+    # invisible to CI's ``/app`` checkout; see ``test_fake_config_fidelity``).
+    # Mirror the real ``UserSettings`` defaults so the fixture stays a structural
+    # subset.
+    review_skill: str = ""
+    architectural_review_skill: str = "ac-reviewing-codebase"
+    scanning_news_skill: str = "scanning-news"
+    eval_local_skill: str = "eval"
+    backlog_sweep_skill: str = "sweeping-tickets"
+    dogfood_smoke_skill: str = "dogfood-smoke"
+    mr_title_regex: str = _DEFAULT_MR_TITLE_REGEX
 
 
 @dataclass

--- a/tests/integration/slack_bridge_e2e/test_fake_config_fidelity.py
+++ b/tests/integration/slack_bridge_e2e/test_fake_config_fidelity.py
@@ -1,0 +1,71 @@
+"""Guard the ``_FakeUserSettings`` test double against ``UserSettings`` drift.
+
+The fortress fakes ``UserSettings`` via ``conftest._FakeUserSettings`` so the
+backend factory can resolve identities / voice-classifier mode without a real
+config store. ``get_effective_settings`` rebuilds the settings with
+``dataclasses.replace(base, **layered)`` where ``layered`` carries the overlay
+CODE-DEFAULT tier — every key in ``PROMOTED_OVERLAY_CODE_DEFAULT_KEYS`` (#36).
+``replace`` re-invokes ``base.__class__(**changes)``, so a promoted key the fake
+does not declare raises ``TypeError`` and reds the fortress.
+
+That crash is invisible to CI purely by accident of the checkout directory
+name: the code-default tier is populated only when the active overlay resolves,
+and active-overlay resolution folds the *cwd basename* onto the ``t3-teatree``
+entry point (``discovery._match_canonical_ep`` — the ``-teatree`` suffix rule).
+CI runs from ``/app`` (basename ``app`` — no fold → no active overlay → empty
+code defaults → ``replace`` never sees the promoted keys), so the fortress stays
+green there while a dev clone named ``teatree`` folds, populates the tier, and
+goes red. These guards assert the fake/real-settings contract DIRECTLY so the
+drift is caught deterministically in every environment, cwd-independent.
+"""
+
+from dataclasses import fields, replace
+
+import pytest
+
+from teatree.config.overlay_code_defaults import PROMOTED_OVERLAY_CODE_DEFAULT_KEYS
+from teatree.config.settings import UserSettings
+from tests.integration.slack_bridge_e2e.conftest import _FakeUserSettings
+
+pytestmark = pytest.mark.integration
+
+
+class TestFakeUserSettingsFidelity:
+    """``_FakeUserSettings`` must stay a faithful structural subset of ``UserSettings``."""
+
+    def test_declares_every_promoted_overlay_code_default_key(self) -> None:
+        """RED if a promoted code-default key is missing from the fake.
+
+        The exact drift #3115 introduced: promoting ``dogfood_smoke_skill`` (and
+        the six other constants) to the overlay code-default tier without adding
+        them to the fake. ``get_effective_settings`` then feeds every promoted key
+        to ``replace(_FakeUserSettings(), ...)`` and the missing field raises.
+        """
+        fake_field_names = {f.name for f in fields(_FakeUserSettings)}
+        missing = PROMOTED_OVERLAY_CODE_DEFAULT_KEYS - fake_field_names
+        assert not missing, f"_FakeUserSettings is missing promoted code-default fields: {sorted(missing)}"
+
+    def test_is_a_structural_subset_of_real_user_settings(self) -> None:
+        """RED if the fake grows a field the real ``UserSettings`` does not have.
+
+        A fake that mirrors non-existent settings is not a faithful subset and
+        would let a test pass against a field production never carries.
+        """
+        real_field_names = {f.name for f in fields(UserSettings)}
+        fake_field_names = {f.name for f in fields(_FakeUserSettings)}
+        extra = fake_field_names - real_field_names
+        assert not extra, f"_FakeUserSettings declares fields absent from UserSettings: {sorted(extra)}"
+
+    def test_absorbs_the_full_code_default_layer_via_replace(self) -> None:
+        """RED if ``replace(fake, **promoted_defaults)`` raises — the production shape.
+
+        Mirrors ``get_effective_settings``'s ``replace(base, **layered)`` with the
+        real defaults for every promoted key, so this guard fails identically to
+        the fortress whenever the fake cannot absorb the code-default tier —
+        regardless of cwd/overlay resolution.
+        """
+        real = UserSettings()
+        promoted_defaults = {key: getattr(real, key) for key in PROMOTED_OVERLAY_CODE_DEFAULT_KEYS}
+        merged = replace(_FakeUserSettings(), **promoted_defaults)
+        for key, value in promoted_defaults.items():
+            assert getattr(merged, key) == value


### PR DESCRIPTION
## Problem

The `slack_bridge_e2e` fortress fakes `UserSettings` via `conftest._FakeUserSettings`. `get_effective_settings` rebuilds settings with `dataclasses.replace(base, **layered)` where `layered` carries the overlay CODE-DEFAULT tier — every key in `PROMOTED_OVERLAY_CODE_DEFAULT_KEYS` (#36 / #3115). `replace` re-invokes `base.__class__(**changes)`, so a promoted key the fake does not declare raises `TypeError` and reds the fortress:

```
TypeError: _FakeUserSettings.__init__() got an unexpected keyword argument 'dogfood_smoke_skill'
```

(The offending key varies run-to-run — `dogfood_smoke_skill`, `backlog_sweep_skill`, … — because the promoted-key set is a `frozenset` and hash order is randomized. All seven were missing.)

#3115 promoted seven constants to the code-default tier without updating the fake.

## Why CI stayed green (the root gap)

The tests were **never excluded from CI** — `pytest-split` routes the uncatalogued fortress (zero entries in `dev/.test_durations`) into shard **group 1**, which ran and passed. The failure is **cwd-coupled**, not missing-from-CI:

- The code-default tier is populated only when the **active overlay resolves**.
- Active-overlay resolution folds the **cwd basename** onto the `t3-teatree` entry point (`discovery._match_canonical_ep`, the `-teatree` suffix rule).
- CI runs from `WORKDIR /app` → basename `app` → no fold → no active overlay → `overlay_code_defaults("")` returns `{}` → `replace` never sees the promoted keys → **green**.
- A dev clone named `teatree` folds to `t3-teatree` → tier populated → `replace(fake, …)` → **red**. (A worktree named `wf_…` also stays green, same as CI.)

So the outcome depended on the ambient checkout directory name — invisible to CI purely by accident of `/app`.

## Fix

1. `conftest.py`: add all seven promoted fields to `_FakeUserSettings`, mirroring the real `UserSettings` defaults, so the fake stays a structural subset that survives the `replace()` rebuild regardless of overlay resolution.
2. `test_fake_config_fidelity.py`: three **cwd-independent** guards — the fake declares every `PROMOTED_OVERLAY_CODE_DEFAULT_KEYS` field, stays a structural subset of `UserSettings`, and absorbs the full code-default layer via `replace()`. These fail deterministically in **any** environment (including CI's `/app`), closing the visibility gap so a future promotion can't silently drift the fake again.

## Anti-vacuous evidence (RED-before)

- New guards RED against the unfixed fake **in the worktree** (basename `wf_…`, the CI-equivalent path): `test_declares_every_promoted_overlay_code_default_key` (AssertionError, all 7 missing) and `test_absorbs_the_full_code_default_layer_via_replace` (TypeError). This proves the guard catches the drift cwd-independently.
- Original fortress RED reproduced from a `teatree`-basename clone: 3 failed (`test_iter_overlay_backends_path_only_toml_works`, `test_messaging_from_overlay_returns_correct_backend_for_named_overlay`, `test_iter_overlay_backends_yields_all_overlays_with_messaging`).
- After the fix: full fortress `59 passed` (56 + 3 guards); guard file `3 passed`.

Gates: ruff check/format, ty-check, test-path-mirror (ledger exact), banned-terms, gitleaks, no-overlay-leak, refuse-public-push-with-leak — all pass. Pushed via the pre-push hook (souliane), no bypass.