### PR TITLE
ci: faster & better — shard rebalance, resource-aware concurrency, pollution sentinel (#3160)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,6 +516,14 @@ jobs:
       # combiner can prove the shards partition the suite exactly once
       # (`--group shard` installs pytest-split; PYTHONPATH=/app makes the
       # `-p scripts.ci.shard_stats_plugin` import resolve at plugin-load time).
+      # `--splitting-algorithm least_duration` bin-packs the recorded durations
+      # tighter than the default chunk split (#3160). `leak_sentinel_plugin` runs
+      # WARN-ONLY here so a process-global env/cwd polluter is NAMED suite-wide
+      # (across the four shards) without ever failing the required context —
+      # the #3160 rollout mode. On the daily `schedule` only, `--store-durations
+      # --clean-durations` records THIS shard's fresh, tests-that-ran durations
+      # (each group's clean slice) for the `refresh-durations` merge job below;
+      # PR/push runs never pay the store write.
       - name: Test shard ${{ matrix.group }}/4 (coverage, no floor — partial data)
         run: >
           docker run --rm
@@ -528,8 +536,11 @@ jobs:
           -o cache_dir=/tmp/.pytest_cache
           --doctest-modules --cov --cov-branch --cov-report= --cov-fail-under=0
           --splits 4 --group ${{ matrix.group }} --durations-path dev/.test_durations
+          --splitting-algorithm least_duration
           -p scripts.ci.shard_stats_plugin
           --shard-stats-out=/app/shard-stats.${{ matrix.group }}.json
+          -p scripts.ci.leak_sentinel_plugin --leak-sentinel=warn
+          ${{ github.event_name == 'schedule' && '--store-durations --clean-durations' || '' }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         if: always()
         with:
@@ -537,6 +548,77 @@ jobs:
           path: |
             coverage.shard${{ matrix.group }}
             shard-stats.${{ matrix.group }}.json
+      # Scheduled run only: the fresh durations this shard just recorded, so the
+      # `refresh-durations` job can merge the four groups into one balanced file.
+      - name: Upload this shard's recorded durations (scheduled refresh source)
+        if: github.event_name == 'schedule'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: durations-shard-${{ matrix.group }}
+          path: dev/.test_durations
+
+  # MAINTENANCE (scheduled only): keep `dev/.test_durations` from rotting (#3160).
+  # The four shards on the daily cron each recorded their group's fresh, clean
+  # durations (`--store-durations --clean-durations` above, including the
+  # previously-unrecorded `tests/quality` + doctest items). This job unions them
+  # back into one complete file and, ONLY when the drift gate fires (test set
+  # changed, or aggregate per-test time moved past the threshold — never on pure
+  # jitter), opens/updates a single dated refresh PR a human reviews and merges.
+  # Never gates a PR; a merge failure or empty diff is a no-op.
+  refresh-durations:
+    needs: test-shard
+    if: github.event_name == 'schedule' && needs.test-shard.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          pattern: durations-shard-*
+          path: /tmp/durations-shards
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.13"
+      - name: Merge shard durations and decide whether to refresh
+        id: merge
+        run: >
+          uv run -p 3.13 python scripts/ci/durations_refresh.py
+          dev/.test_durations
+          /tmp/durations-shards/durations-shard-1/.test_durations
+          /tmp/durations-shards/durations-shard-2/.test_durations
+          /tmp/durations-shards/durations-shard-3/.test_durations
+          /tmp/durations-shards/durations-shard-4/.test_durations
+      - name: Open or update the durations-refresh PR
+        if: steps.merge.outputs.refresh == 'true' && !cancelled()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet dev/.test_durations; then
+            echo "No net change to dev/.test_durations — nothing to open."
+            exit 0
+          fi
+          BRANCH="chore/refresh-test-durations-$(date +%Y-%m-%d)"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add dev/.test_durations
+          git commit -m "chore(ci): refresh dev/.test_durations from the shard lane (#3160)"
+          git push --force-with-lease origin "$BRANCH"
+          if ! gh pr view "$BRANCH" --json number -q .number 2>/dev/null; then
+            gh pr create \
+              --title "chore(ci): refresh test shard durations" \
+              --body "Automated refresh of \`dev/.test_durations\`, recorded from the CI shard lane on the daily scheduled run (with \`--doctest-modules\`, so \`tests/quality\` and doctest items are now measured). Rebalances the pytest-split shards; the combiner's exact-partition assertion and 93% floor are unchanged. Review and merge when green." \
+              --base main \
+              --label "ci"
+          fi
 
   # GATE (heavy lane): the COMBINER. Its job key + matrix produce the EXACT
   # required `test (3.13)` check context (unchanged from the old monolithic job).
@@ -683,7 +765,12 @@ jobs:
     # SEEDS: 7 is the recorded reproducer (it red'd 27 ``tests/teatree_loop/``
     # tests on the pre-fix code); the others widen the order coverage. ``-n0`` is
     # serial so a single in-process collection order is exercised end to end
-    # (xdist would isolate the polluter from the victim across workers).
+    # (xdist would isolate the polluter from the victim across workers). The four
+    # seeds are MATRIXED (was a serial ~11-min for-loop) so each runs as its own
+    # ~2.5-min parallel job — the failure-wave latency when shuffle is the slowest
+    # lane drops accordingly (#3160). `leak_sentinel_plugin` runs WARN-ONLY so a
+    # process-global env/cwd polluter is NAMED (not just its downstream victim)
+    # without failing the lane during the #3160 rollout week.
     #
     # Heavy lane: PR-only AND skipped on a provably pure-docs diff
     # (preflight ``run_heavy_python=false``); any non-pure-docs PR runs it.
@@ -698,6 +785,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.13"]
+        seed: [7, 1, 13, 100]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
@@ -707,15 +795,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --group shuffle
-      - name: Run the order-fragile loop subset under shuffled collection
-        run: |
-          set -euo pipefail
-          for seed in 7 1 13 100; do
-            echo "::group::pytest-randomly seed=$seed"
-            uv run -p ${{ matrix.python-version }} pytest -n0 -q -p randomly \
-              --randomly-seed="$seed" tests/teatree_loop/
-            echo "::endgroup::"
-          done
+      - name: Run the order-fragile loop subset under shuffled collection (seed ${{ matrix.seed }})
+        run: >
+          uv run -p ${{ matrix.python-version }} pytest -n0 -q -p randomly
+          --randomly-seed=${{ matrix.seed }}
+          -p scripts.ci.leak_sentinel_plugin --leak-sentinel=warn
+          tests/teatree_loop/
 
   # ── 6. Architecture / quality fitness gates ────────────────────────────────
 

--- a/dev/ci-shard.sh
+++ b/dev/ci-shard.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Reproduce ONE CI test shard's EXACT slice locally, before pushing (#3160).
+#
+# A shard-only red ("green locally, red in shard 3") happens because the CI
+# `test-shard` matrix runs a duration-balanced QUARTER of the suite in the tree's
+# committed order — a slice/adjacency no ordinary local run reproduces. This runs
+# the same pytest-split slice with the SAME flags the CI shard uses
+# (`--splits 4 --group N --durations-path dev/.test_durations
+# --splitting-algorithm least_duration --doctest-modules`), so the failing shard
+# is reproducible on your box.
+#
+# The leak sentinel runs WARN by default (names any process-global env/cwd
+# polluter without failing); set `LEAK_SENTINEL=error` to turn the polluter into
+# a hard local failure. Append `-n0` for the deterministic serial order that most
+# faithfully reproduces an order-dependent shard red (xdist honours the last -n).
+#
+# Usage:
+#   dev/ci-shard.sh <group>                 # group of 4, e.g. dev/ci-shard.sh 3
+#   dev/ci-shard.sh <group> --splits <N>    # a different split count
+#   dev/ci-shard.sh 3 -n0                    # serial, deterministic order
+#   LEAK_SENTINEL=error dev/ci-shard.sh 3    # fail the polluter locally
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+GROUP="${1:?usage: dev/ci-shard.sh <group 1..N> [--splits N] [extra pytest args]}"
+shift
+
+SPLITS=4
+if [ "${1:-}" = "--splits" ]; then
+    SPLITS="${2:?--splits needs a value}"
+    shift 2
+fi
+
+LEAK_MODE="${LEAK_SENTINEL:-warn}"
+
+echo "=== CI shard ${GROUP}/${SPLITS} (least_duration split, leak-sentinel=${LEAK_MODE}) ==="
+exec uv run --group shard pytest --no-header -q -n auto \
+    --doctest-modules --cov --cov-branch --cov-report= --cov-fail-under=0 \
+    --splits "${SPLITS}" --group "${GROUP}" \
+    --durations-path dev/.test_durations \
+    --splitting-algorithm least_duration \
+    -p scripts.ci.leak_sentinel_plugin --leak-sentinel="${LEAK_MODE}" \
+    "$@"

--- a/scripts/ci/durations_refresh.py
+++ b/scripts/ci/durations_refresh.py
@@ -1,0 +1,129 @@
+"""Merge the four scheduled shards' recorded durations and decide whether to refresh.
+
+Each shard on the daily ``schedule`` run stores its group's fresh, tests-that-ran
+durations (``pytest --store-durations --clean-durations``) and uploads the file. This
+script unions the four disjoint slices back into one complete ``dev/.test_durations``
+and decides — from the drift versus the committed file — whether that refresh is worth
+a PR. Without a drift gate every daily run would open a churn PR from pure timing
+jitter; the gate opens one only when the set of tests changed (added/removed — the
+decisive staleness signal, e.g. the currently-unrecorded ``tests/quality`` + doctests)
+or the aggregate per-test time moved beyond a threshold.
+
+Exit 0 always on a successful merge; the refresh verdict is emitted as ``refresh=...``
+to ``$GITHUB_OUTPUT`` (and stdout) for the workflow to gate the PR-open step on.
+"""
+
+import dataclasses
+import json
+import os
+import sys
+from pathlib import Path
+
+DEFAULT_DRIFT_RATIO_THRESHOLD = 0.15
+_MIN_ARGS = 2  # a durations path + at least one shard file
+
+
+def load_durations(path: Path) -> dict[str, float]:
+    if not path.exists():
+        return {}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return {str(k): float(v) for k, v in data.items()}
+
+
+def merge_durations(paths: list[Path]) -> dict[str, float]:
+    """Union the per-shard duration slices (the four groups partition the suite)."""
+    merged: dict[str, float] = {}
+    for path in paths:
+        merged.update(load_durations(path))
+    return merged
+
+
+@dataclasses.dataclass(frozen=True)
+class RefreshDecision:
+    should_refresh: bool
+    reason: str
+    added: int
+    removed: int
+    drift_ratio: float
+
+
+def decide_refresh(
+    committed: dict[str, float],
+    merged: dict[str, float],
+    *,
+    drift_ratio_threshold: float = DEFAULT_DRIFT_RATIO_THRESHOLD,
+) -> RefreshDecision:
+    """Refresh when tests were added/removed, or aggregate per-test time drifted past the threshold."""
+    added = sorted(set(merged) - set(committed))
+    removed = sorted(set(committed) - set(merged))
+    shared = set(committed) & set(merged)
+    committed_total = sum(committed.values()) or 1.0
+    abs_drift = sum(abs(merged[k] - committed[k]) for k in shared)
+    drift_ratio = abs_drift / committed_total
+
+    if added or removed:
+        return RefreshDecision(
+            should_refresh=True,
+            reason=f"test set changed: +{len(added)} / -{len(removed)}",
+            added=len(added),
+            removed=len(removed),
+            drift_ratio=drift_ratio,
+        )
+    if drift_ratio > drift_ratio_threshold:
+        return RefreshDecision(
+            should_refresh=True,
+            reason=f"aggregate duration drift {drift_ratio:.1%} > {drift_ratio_threshold:.0%}",
+            added=0,
+            removed=0,
+            drift_ratio=drift_ratio,
+        )
+    return RefreshDecision(
+        should_refresh=False,
+        reason=f"within threshold (drift {drift_ratio:.1%}, no test-set change)",
+        added=0,
+        removed=0,
+        drift_ratio=drift_ratio,
+    )
+
+
+def write_durations(path: Path, durations: dict[str, float]) -> None:
+    path.write_text(json.dumps(durations, sort_keys=True, indent=4) + "\n", encoding="utf-8")
+
+
+def _emit_output(refresh: bool) -> None:
+    line = f"refresh={'true' if refresh else 'false'}"
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with Path(github_output).open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) < _MIN_ARGS:
+        print("usage: durations_refresh.py <durations-path> <shard-durations.json> ...", file=sys.stderr)
+        return 2
+
+    durations_path = Path(args[0])
+    shard_paths = [Path(a) for a in args[1:]]
+
+    committed = load_durations(durations_path)
+    merged = merge_durations(shard_paths)
+    if not merged:
+        print("No shard durations to merge — nothing recorded.", file=sys.stderr)
+        _emit_output(False)
+        return 0
+
+    decision = decide_refresh(committed, merged)
+    print(
+        f"Merged {len(shard_paths)} shard files: {len(committed)} -> {len(merged)} tests. "
+        f"Refresh: {decision.should_refresh} ({decision.reason})."
+    )
+    if decision.should_refresh:
+        write_durations(durations_path, merged)
+    _emit_output(decision.should_refresh)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/leak_sentinel_plugin.py
+++ b/scripts/ci/leak_sentinel_plugin.py
@@ -1,0 +1,167 @@
+"""Pytest plugin: fail the POLLUTER that leaks process-global state, not its victim.
+
+An order-dependent shard/shuffle red ("green locally, red in shard 3") is almost
+always a test that mutates a process-global surface and never restores it: a later
+VICTIM test then fails because it inherited the dirty state. The traceback points at
+the victim, so the polluter hides and the failure is non-deterministic.
+
+This plugin snapshots the known process-global surface — ``os.environ`` and the cwd,
+the two ``conftest.py``'s ``monkeypatch``-managed fixtures do NOT auto-revert when a
+test mutates them DIRECTLY (``os.environ[k] = v`` / ``os.chdir(...)`` instead of the
+``monkeypatch`` seam) — BEFORE each test's fixtures set up and AFTER they fully tear
+down (so ``monkeypatch``'s own reversions are already applied). A mismatch is attributed
+to the test that produced it — the POLLUTER — turning a non-deterministic downstream
+red into a named, deterministic local failure.
+
+Loaded opt-in via ``-p scripts.ci.leak_sentinel_plugin --leak-sentinel=<mode>``:
+
+- ``off`` (default) — the plugin registers nothing; zero overhead on a normal run.
+- ``warn`` — record every leak and print a terminal summary naming each polluter,
+    never failing the run (the rollout mode: surface polluters without breaking CI).
+- ``error`` — additionally fail (error at teardown) the polluting test, so a leak
+    reds the lane deterministically.
+"""
+
+import dataclasses
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from _pytest.terminal import TerminalReporter
+
+_OPTION = "--leak-sentinel"
+_MODE_OFF = "off"
+_MODE_WARN = "warn"
+_MODE_ERROR = "error"
+_MODES = (_MODE_OFF, _MODE_WARN, _MODE_ERROR)
+
+#: Env vars pytest/coverage mutate per-test; a change here is never a real leak.
+_VOLATILE_ENV_KEYS: frozenset[str] = frozenset({"PYTEST_CURRENT_TEST"})
+
+
+@dataclasses.dataclass(frozen=True)
+class Snapshot:
+    env: dict[str, str]
+    cwd: str
+
+    @classmethod
+    def capture(cls) -> "Snapshot":
+        try:
+            cwd = str(Path.cwd())
+        except OSError:
+            # A test that left cwd in a since-deleted dir is itself a leak; record the
+            # unavailability rather than crashing so the diff still names the polluter.
+            cwd = "<unavailable>"
+        return cls(env=dict(os.environ), cwd=cwd)
+
+
+@dataclasses.dataclass(frozen=True)
+class LeakDiff:
+    env_added: tuple[str, ...]
+    env_removed: tuple[str, ...]
+    env_changed: tuple[str, ...]
+    cwd_from: str | None
+    cwd_to: str | None
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.env_added or self.env_removed or self.env_changed or self.cwd_from is not None)
+
+    def describe(self) -> str:
+        parts: list[str] = []
+        if self.env_added:
+            parts.append(f"env added {list(self.env_added)}")
+        if self.env_removed:
+            parts.append(f"env removed {list(self.env_removed)}")
+        if self.env_changed:
+            parts.append(f"env changed {list(self.env_changed)}")
+        if self.cwd_from is not None:
+            parts.append(f"cwd {self.cwd_from!r} -> {self.cwd_to!r}")
+        return "; ".join(parts)
+
+
+def diff_snapshots(
+    before: Snapshot,
+    after: Snapshot,
+    *,
+    ignore: frozenset[str] = _VOLATILE_ENV_KEYS,
+) -> LeakDiff:
+    """The process-global surface *after* left dirty relative to *before* (ignoring volatile keys)."""
+    before_env = {k: v for k, v in before.env.items() if k not in ignore}
+    after_env = {k: v for k, v in after.env.items() if k not in ignore}
+    added = tuple(sorted(set(after_env) - set(before_env)))
+    removed = tuple(sorted(set(before_env) - set(after_env)))
+    changed = tuple(sorted(k for k in set(before_env) & set(after_env) if before_env[k] != after_env[k]))
+    cwd_changed = before.cwd != after.cwd
+    return LeakDiff(
+        env_added=added,
+        env_removed=removed,
+        env_changed=changed,
+        cwd_from=before.cwd if cwd_changed else None,
+        cwd_to=after.cwd if cwd_changed else None,
+    )
+
+
+class LeakDetectedError(Exception):
+    """Raised at teardown in ``error`` mode to fail the polluting test itself."""
+
+
+_BEFORE_KEY: "pytest.StashKey[Snapshot]" = pytest.StashKey()
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        _OPTION,
+        action="store",
+        default=_MODE_OFF,
+        choices=_MODES,
+        help="Detect the test that leaks env/cwd process-global state: off (default), warn, or error.",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    mode = config.getoption(_OPTION)
+    if mode != _MODE_OFF:
+        config.pluginmanager.register(LeakSentinelPlugin(mode), "leak-sentinel-plugin")
+
+
+class LeakSentinelPlugin:
+    def __init__(self, mode: str) -> None:
+        self._mode = mode
+        self.leaks: list[tuple[str, LeakDiff]] = []
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_setup(self, item: pytest.Item) -> "Generator[None, object]":  # noqa: PLR6301 — pytest invokes this hookimpl on the registered plugin INSTANCE; it must stay a method
+        # Pre-yield: BEFORE this item's fixtures set up, so the baseline predates any
+        # monkeypatch-managed env/cwd the fixtures install (they revert symmetrically).
+        item.stash[_BEFORE_KEY] = Snapshot.capture()
+        yield
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_teardown(self, item: pytest.Item) -> "Generator[None, object]":
+        yield  # run the actual teardown (monkeypatch.undo + fixture finalizers) FIRST
+        before = item.stash.get(_BEFORE_KEY, None)
+        if before is None:
+            return
+        diff = diff_snapshots(before, Snapshot.capture())
+        if diff.is_empty:
+            return
+        self.leaks.append((item.nodeid, diff))
+        if self._mode == _MODE_ERROR:
+            message = (
+                f"{item.nodeid} leaked process-global state ({diff.describe()}). "
+                "Restore any env/cwd it mutates — prefer the monkeypatch fixture, which reverts for you."
+            )
+            raise LeakDetectedError(message)
+
+    def pytest_terminal_summary(self, terminalreporter: "TerminalReporter") -> None:
+        if not self.leaks:
+            return
+        terminalreporter.section(f"leak sentinel ({self._mode})")
+        for nodeid, diff in self.leaks:
+            terminalreporter.write_line(f"POLLUTER {nodeid}: {diff.describe()}")

--- a/src/teatree/loops/worker.py
+++ b/src/teatree/loops/worker.py
@@ -1,8 +1,10 @@
 """The long-lived ``t3 worker`` — the singleton executor pool for the timer chains (#1796).
 
-One process runs K=4 programmatic ``django_tasks_db`` :class:`Worker` executor
-threads — 2 pinned to the ``loops`` queue, 2 to ``default`` — so a heavy headless
-``default`` job can never starve a reactive loop timer, and vice-versa. A
+One process runs programmatic ``django_tasks_db`` :class:`Worker` executor threads —
+2 pinned to the ``loops`` queue and a host-scaled ``default`` pool (floored at 2,
+:func:`default_queue_executor_count`) — so a heavy headless ``default`` job can never
+starve a reactive loop timer, and a deep backlog of independent headless work still
+drains in parallel on a bigger box instead of one-or-two-at-a-time. A
 supervisor thread re-reads the ``loop_runner_enabled`` kill-switch every ~5 s and
 stops every executor on a flip-off or a SIGTERM/SIGINT, joining and — after the join
 timeout — SIGKILLing any in-flight tick process group the join left orphaned, then
@@ -20,21 +22,43 @@ import os
 import threading
 import time
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol
 
 from teatree.loop.queue_drain import expire_stale_default_jobs
 from teatree.loops.timer_chains import _loop_runner_enabled, kill_live_tick_process_groups
 from teatree.loops.timer_reconciler import ensure_loop_timers, ensure_maintenance_chains
+from teatree.utils.ram_probe import default_provision_concurrency
 
 if TYPE_CHECKING:
     from django_tasks_db.management.commands.db_worker import Worker
 
 logger = logging.getLogger(__name__)
 
-#: The executor pool: 2 threads pinned to ``loops`` (reactive timers), 2 to
-#: ``default`` (FSM/headless work), so neither lane starves the other.
-EXECUTOR_QUEUES: tuple[str, ...] = ("loops", "loops", "default", "default")
+#: Reactive-timer executors pinned to the ``loops`` queue — fixed at 2 so a heavy
+#: headless ``default`` job can never starve a loop timer.
+LOOPS_EXECUTOR_COUNT = 2
+#: The prior hardcoded ``default``-queue width; now the FLOOR so a small box keeps
+#: the old minimum while a bigger box scales up.
+DEFAULT_QUEUE_FLOOR = 2
+
+
+def default_queue_executor_count() -> int:
+    """Host-scaled width of the ``default`` (FSM/headless) executor pool, floored at 2.
+
+    A deep backlog of independent PRs drained through a fixed 2 threads reviews and
+    merges one-or-two-at-a-time regardless of host size. Scaling with the shared
+    PR-01 resource ceiling (:func:`default_provision_concurrency` — half the logical
+    cores) lets an idle multi-core box run more phase work in parallel; the floor
+    preserves the prior minimum on a 1-2 core box.
+    """
+    return max(DEFAULT_QUEUE_FLOOR, default_provision_concurrency())
+
+
+def build_executor_queues() -> tuple[str, ...]:
+    """The executor pool: 2 ``loops`` threads + a host-scaled ``default`` pool."""
+    return ("loops",) * LOOPS_EXECUTOR_COUNT + ("default",) * default_queue_executor_count()
+
 
 #: The supervisor re-reads the kill-switch on this cadence — a flip-off stops
 #: further dispatch within ~this many seconds.
@@ -102,7 +126,7 @@ class WorkerSeams:
     kill_ticks: Callable[[], object] = kill_live_tick_process_groups
     sleep: Callable[[float], None] = time.sleep
     poll_seconds: float = SUPERVISOR_POLL_SECONDS
-    executor_queues: tuple[str, ...] = EXECUTOR_QUEUES
+    executor_queues: tuple[str, ...] = field(default_factory=build_executor_queues)
 
 
 class LoopWorker:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,6 +129,25 @@ def _reset_webhook_rate_limiter() -> Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
+def _restore_django_settings_module() -> Iterator[None]:
+    """Revert any ``DJANGO_SETTINGS_MODULE`` an in-process CLI test set process-globally.
+
+    A test that invokes a ``t3`` typer command in-process (``ensure_django()``) sets
+    ``DJANGO_SETTINGS_MODULE`` in ``os.environ`` and never restores it, leaking a value
+    a LATER test's subprocess then inherits — the order-dependent shard/shuffle class the
+    #3160 leak sentinel catches. Restore-only (snapshot-and-put-back, never touching the
+    value at setup) so a well-behaved test is unaffected and only the leak is reverted.
+    """
+    absent = object()
+    before: object = os.environ.get("DJANGO_SETTINGS_MODULE", absent)
+    yield
+    if before is absent:
+        os.environ.pop("DJANGO_SETTINGS_MODULE", None)
+    else:
+        os.environ["DJANGO_SETTINGS_MODULE"] = before  # type: ignore[assignment]
+
+
+@pytest.fixture(autouse=True)
 def _isolate_scope_cache() -> Iterator[None]:
     """Reset the process-singleton token-scope cache with a no-op banner sink (PR-19).
 

--- a/tests/teatree_loops/test_worker.py
+++ b/tests/teatree_loops/test_worker.py
@@ -1,8 +1,9 @@
 """teatree.loops.worker — the singleton executor pool + supervisor (#1796).
 
 Pure supervision/lifecycle logic with injected collaborators — no real threads, DB,
-or clock. Verifies startup reconciliation, the pinned executor split (2 ``loops`` /
-2 ``default``), and that a kill-switch flip-off OR a stop signal tears the pool down.
+or clock. Verifies startup reconciliation, the executor split (2 ``loops`` + a
+host-scaled ``default`` pool floored at 2), and that a kill-switch flip-off OR a
+stop signal tears the pool down.
 """
 
 import contextlib
@@ -17,7 +18,15 @@ from django_tasks_db.models import DBTaskResult
 
 from teatree.core.tasks import refresh_followup_snapshot
 from teatree.loops import timer_chains
-from teatree.loops.worker import EXECUTOR_QUEUES, LoopWorker, WorkerSeams
+from teatree.loops import worker as worker_mod
+from teatree.loops.worker import (
+    DEFAULT_QUEUE_FLOOR,
+    LOOPS_EXECUTOR_COUNT,
+    LoopWorker,
+    WorkerSeams,
+    build_executor_queues,
+    default_queue_executor_count,
+)
 from teatree.utils.run import spawn_session_leader
 from teatree.utils.singleton import pid_alive
 
@@ -82,15 +91,32 @@ def test_reconciles_seeds_and_expires_before_starting_executors() -> None:
     # blind-fires the instant the worker starts (the default-ON flip's load-jam class).
     assert order[:3] == ["reconcile", "seed", "expire"]
     assert order[3] == "spawn"
-    assert order.count("spawn") == len(EXECUTOR_QUEUES)
+    assert order.count("spawn") == len(build_executor_queues())
 
 
-def test_pins_two_loops_and_two_default_executors() -> None:
+def test_default_queue_scales_with_host_cores(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 4 default executors on a host whose shared PR-01 ceiling is 4 (an 8-core box).
+    monkeypatch.setattr(worker_mod, "default_provision_concurrency", lambda: 4)
+    assert default_queue_executor_count() == 4
+    queues = build_executor_queues()
+    assert queues.count("loops") == LOOPS_EXECUTOR_COUNT == 2
+    assert queues.count("default") == 4
+
+
+def test_default_queue_floored_at_two_on_a_small_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A 1-2 core box floors at the prior hardcoded minimum, never below.
+    monkeypatch.setattr(worker_mod, "default_provision_concurrency", lambda: 1)
+    assert default_queue_executor_count() == DEFAULT_QUEUE_FLOOR == 2
+
+
+def test_pins_two_loops_and_host_scaled_default_executors(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Patch BEFORE _make_worker so the WorkerSeams default_factory reads the host size.
+    monkeypatch.setattr(worker_mod, "default_provision_concurrency", lambda: 3)
     worker, built, _ = _make_worker(enabled=lambda: False, sleep=lambda _s: None)
     worker.run()
     queues = [executor.queue for executor in built]
     assert queues.count("loops") == 2
-    assert queues.count("default") == 2
+    assert queues.count("default") == 3
 
 
 def test_kill_switch_flip_off_stops_and_joins_all_executors() -> None:

--- a/tests/test_durations_refresh.py
+++ b/tests/test_durations_refresh.py
@@ -1,0 +1,93 @@
+"""Merge + drift-gate for the scheduled shard-durations refresh (#3160).
+
+Unit arm: the pure merge/decision logic. Integration arm: the ``main`` CLI over real
+files, asserting it writes the merged file only when the refresh gate fires and emits
+the ``refresh=`` verdict to ``$GITHUB_OUTPUT`` exactly as the workflow reads it.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.durations_refresh import decide_refresh, load_durations, main, merge_durations
+
+
+def _write(path: Path, data: dict[str, float]) -> Path:
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+class TestMergeDurations:
+    def test_unions_disjoint_shard_slices(self, tmp_path: Path) -> None:
+        a = _write(tmp_path / "a.json", {"tests/x.py::t1": 1.0, "tests/x.py::t2": 2.0})
+        b = _write(tmp_path / "b.json", {"tests/y.py::t3": 3.0})
+        assert merge_durations([a, b]) == {
+            "tests/x.py::t1": 1.0,
+            "tests/x.py::t2": 2.0,
+            "tests/y.py::t3": 3.0,
+        }
+
+    def test_missing_file_contributes_nothing(self, tmp_path: Path) -> None:
+        assert merge_durations([tmp_path / "absent.json"]) == {}
+
+    def test_load_reads_floats(self, tmp_path: Path) -> None:
+        assert load_durations(_write(tmp_path / "d.json", {"t": 4})) == {"t": 4.0}
+
+
+class TestDecideRefresh:
+    def test_refreshes_when_tests_added(self) -> None:
+        decision = decide_refresh({"t1": 1.0}, {"t1": 1.0, "t2": 2.0})
+        assert decision.should_refresh
+        assert decision.added == 1
+        assert "test set changed" in decision.reason
+
+    def test_refreshes_when_tests_removed(self) -> None:
+        decision = decide_refresh({"t1": 1.0, "gone": 9.0}, {"t1": 1.0})
+        assert decision.should_refresh
+        assert decision.removed == 1
+
+    def test_refreshes_on_large_aggregate_drift(self) -> None:
+        # Same test set, but the timings doubled -> 100% drift, well past 15%.
+        decision = decide_refresh({"t1": 1.0, "t2": 1.0}, {"t1": 2.0, "t2": 2.0})
+        assert decision.should_refresh
+        assert decision.drift_ratio == pytest.approx(1.0)
+        assert "duration drift" in decision.reason
+
+    def test_holds_within_threshold(self) -> None:
+        # 5% jitter, no set change -> no PR churn.
+        decision = decide_refresh({"t1": 1.0}, {"t1": 1.05})
+        assert not decision.should_refresh
+        assert decision.drift_ratio == pytest.approx(0.05)
+
+    def test_holds_on_identical_input(self) -> None:
+        same = {"t1": 1.0, "t2": 2.0}
+        assert not decide_refresh(same, dict(same)).should_refresh
+
+
+class TestMainCli:
+    def test_writes_and_signals_refresh_when_set_changed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        durations = _write(tmp_path / ".test_durations", {"t1": 1.0})
+        shard = _write(tmp_path / "shard-1.json", {"t1": 1.0, "t2": 2.0})
+        output = tmp_path / "gh_output"
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+        rc = main([str(durations), str(shard)])
+        assert rc == 0
+        assert "refresh=true" in output.read_text(encoding="utf-8")
+        assert json.loads(durations.read_text(encoding="utf-8")) == {"t1": 1.0, "t2": 2.0}
+
+    def test_leaves_file_untouched_and_signals_false_within_threshold(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        durations = _write(tmp_path / ".test_durations", {"t1": 1.0})
+        shard = _write(tmp_path / "shard-1.json", {"t1": 1.02})
+        output = tmp_path / "gh_output"
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+        rc = main([str(durations), str(shard)])
+        assert rc == 0
+        assert "refresh=false" in output.read_text(encoding="utf-8")
+        # Untouched: the committed file is preserved when the gate does not fire.
+        assert json.loads(durations.read_text(encoding="utf-8")) == {"t1": 1.0}
+
+    def test_usage_error_without_shard_paths(self) -> None:
+        assert main([]) == 2

--- a/tests/test_leak_sentinel_plugin.py
+++ b/tests/test_leak_sentinel_plugin.py
@@ -1,0 +1,137 @@
+"""The leak-sentinel plugin: name the POLLUTER that leaks env/cwd, not its victim.
+
+Unit arm: the pure snapshot/diff logic. Integration arm: a real ``pytest`` subprocess
+over a toy suite where one test leaks an env var and one leaks cwd — the plugin must
+name the polluter in ``warn`` mode (without failing the run) and error the polluter in
+``error`` mode, while a well-behaved suite stays clean.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.leak_sentinel_plugin import LeakDiff, Snapshot, diff_snapshots
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestDiffSnapshots:
+    def test_clean_when_nothing_changed(self) -> None:
+        snap = Snapshot(env={"A": "1", "B": "2"}, cwd="/tmp")
+        assert diff_snapshots(snap, snap).is_empty
+
+    def test_flags_added_and_removed_and_changed_env_keys(self) -> None:
+        before = Snapshot(env={"KEEP": "1", "GONE": "2", "MUT": "3"}, cwd="/tmp")
+        after = Snapshot(env={"KEEP": "1", "NEW": "9", "MUT": "changed"}, cwd="/tmp")
+        diff = diff_snapshots(before, after)
+        assert diff.env_added == ("NEW",)
+        assert diff.env_removed == ("GONE",)
+        assert diff.env_changed == ("MUT",)
+        assert not diff.is_empty
+        assert "env added ['NEW']" in diff.describe()
+
+    def test_flags_cwd_change(self) -> None:
+        diff = diff_snapshots(Snapshot(env={}, cwd="/a"), Snapshot(env={}, cwd="/b"))
+        assert diff.cwd_from == "/a"
+        assert diff.cwd_to == "/b"
+        assert "cwd '/a' -> '/b'" in diff.describe()
+
+    def test_volatile_keys_are_ignored(self) -> None:
+        before = Snapshot(env={"PYTEST_CURRENT_TEST": "one"}, cwd="/tmp")
+        after = Snapshot(env={"PYTEST_CURRENT_TEST": "two"}, cwd="/tmp")
+        assert diff_snapshots(before, after).is_empty
+
+    def test_capture_reads_live_process_surface(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("_LEAK_SENTINEL_PROBE", "present")
+        snap = Snapshot.capture()
+        assert snap.env["_LEAK_SENTINEL_PROBE"] == "present"
+        assert snap.cwd == str(Path.cwd())
+
+    def test_empty_diff_describes_to_empty_string(self) -> None:
+        assert LeakDiff((), (), (), None, None).describe() == ""
+
+
+_LEAKY_SUITE = """
+import os
+
+
+def test_env_polluter():
+    os.environ["_SENTINEL_LEAK"] = "dirty"  # never restored -> polluter
+
+
+def test_cwd_polluter(tmp_path):
+    os.chdir(tmp_path)  # never restored -> polluter
+
+
+def test_clean(monkeypatch, tmp_path):
+    monkeypatch.setenv("_SENTINEL_OK", "reverts")  # monkeypatch reverts -> not a leak
+    monkeypatch.chdir(tmp_path)                     # monkeypatch reverts -> not a leak
+    assert True
+"""
+
+
+def _run_toy_suite(tmp_path: Path, mode: str) -> subprocess.CompletedProcess[str]:
+    (tmp_path / "test_toy_leaks.py").write_text(_LEAKY_SUITE, encoding="utf-8")
+    env = dict(_clean_env())
+    env["PYTHONPATH"] = str(_REPO_ROOT)
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "test_toy_leaks.py",
+            "-p",
+            "scripts.ci.leak_sentinel_plugin",
+            "-p",
+            "no:randomly",
+            f"--leak-sentinel={mode}",
+            "-p",
+            "no:cacheprovider",
+            "-o",
+            "addopts=",
+            "-q",
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.integration
+class TestSentinelNamesThePolluter:
+    def test_warn_mode_names_polluters_without_failing_the_run(self, tmp_path: Path) -> None:
+        result = _run_toy_suite(tmp_path, "warn")
+        combined = result.stdout + result.stderr
+        # warn mode never reds the run: all three toy tests still pass.
+        assert result.returncode == 0, combined
+        assert "POLLUTER test_toy_leaks.py::test_env_polluter" in combined, combined
+        assert "_SENTINEL_LEAK" in combined
+        assert "POLLUTER test_toy_leaks.py::test_cwd_polluter" in combined, combined
+        # the monkeypatch-clean test is never flagged.
+        assert "test_clean" not in combined.split("leak sentinel")[-1]
+
+    def test_error_mode_fails_the_polluter(self, tmp_path: Path) -> None:
+        result = _run_toy_suite(tmp_path, "error")
+        combined = result.stdout + result.stderr
+        assert result.returncode != 0, combined
+        assert "leaked process-global state" in combined, combined
+        assert "test_env_polluter" in combined
+
+    def test_off_mode_is_silent(self, tmp_path: Path) -> None:
+        result = _run_toy_suite(tmp_path, "off")
+        combined = result.stdout + result.stderr
+        assert result.returncode == 0, combined
+        assert "POLLUTER" not in combined
+        assert "leak sentinel" not in combined
+
+
+def _clean_env() -> dict[str, str]:
+    import os  # noqa: PLC0415 — local so the module stays a thin plugin test
+
+    # Strip GIT_* so an inline pre-commit ``pytest`` run's exported git env can't leak
+    # into the toy subprocess (AGENTS.md § Test-Writing Doctrine).
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}


### PR DESCRIPTION
ci: faster+better — shard rebalance, resource-aware concurrency, pollution sentinel (#3160)

Makes the CI test lane pack tighter, name order-dependent polluters instead of
their victims, and lets `t3 worker` use a bigger box. Implements teatree #3160.

## What changed (5 items)

1. **Shard rebalance.** The four `test-shard` matrix legs now bin-pack with
   `--splitting-algorithm least_duration` (tighter than the default chunk split),
   and a scheduled-only `refresh-durations` job keeps `dev/.test_durations` from
   rotting: on the daily cron each shard records its clean, tests-that-ran slice
   (`--store-durations --clean-durations`, now including the previously-unrecorded
   `tests/quality` + doctest items), and `scripts/ci/durations_refresh.py` unions
   the four disjoint slices back into one file. A drift gate opens a single dated
   refresh PR only when the test set changed or aggregate time moved past a
   threshold — never on pure jitter. PR/push runs never pay the store write.

2. **Resource-aware concurrency.** `src/teatree/loops/worker.py`: the `default`
   (FSM/headless) executor pool is no longer a hardcoded 2 — it is host-scaled via
   `default_queue_executor_count()` → `teatree.utils.ram_probe.default_provision_concurrency()`
   (half the logical cores), floored at 2 so a 1–2 core box keeps the old minimum.
   The `loops` pool stays fixed at 2, so a heavy headless job can never starve a
   reactive loop timer while a deep backlog still drains in parallel on a big box.

3. **Pollution sentinel.** New `scripts/ci/leak_sentinel_plugin.py` snapshots the
   process-global surface (`os.environ`, cwd) around each test and attributes a
   leak to the POLLUTER, not its downstream victim. It runs `--leak-sentinel=warn`
   (WARN-only) across the four shards and the four shuffle-seed jobs — the #3160
   rollout mode: it names polluters suite-wide without ever failing the required
   context. The one known leak it caught (`DJANGO_SETTINGS_MODULE` left set by an
   in-process CLI test) is actually fixed by a restore-only autouse fixture,
   `_restore_django_settings_module`, in `tests/conftest.py`.

4. **Test-shuffle matrix.** The `tests/teatree_loop/` order-fragile subset now runs
   its four `pytest-randomly` seeds `[7, 1, 13, 100]` as parallel matrix jobs (each
   ~2.5 min) instead of one serial ~11-min for-loop, so the failure-wave latency
   when shuffle is the slowest lane drops accordingly. Seed 7 remains the recorded
   reproducer; `-n0` serial collection is preserved so the in-process order is
   exercised end to end.

5. **Small wins.** `dev/ci-shard.sh` reproduces ONE CI shard's exact slice locally
   with the same flags (`--splits 4 --group N --splitting-algorithm least_duration
   --doctest-modules`, leak sentinel WARN by default, `LEAK_SENTINEL=error` to make
   a polluter a hard local red), so a "green locally, red in shard 3" is
   reproducible before pushing.

## Reasoned deferrals

- **review/CI overlap** — starting the independent cold review while the shards are
  still running was considered but deferred: it couples two gates that stay cleaner
  sequential, and the win is small next to the shard/shuffle latency this PR cuts.
- **6 shards** — going from 4 to 6 shards is deferred until the refreshed durations
  show 4-way balance is actually the wall-clock bottleneck; more shards also add
  per-runner startup/container overhead, so it is not a free win.
- **180s split** — targeting a fixed ~180s per-shard budget (rather than an even
  4-way split) is deferred: it needs a trustworthy durations file first, which is
  exactly what the scheduled refresh job here sets up.
- **host-side combine** — combining the four shards' coverage on the host instead
  of inside the container is deferred, to keep the combiner's exact-partition
  assertion and the 93% floor running in the single place they already run.

## Architecture pre-check

- **Component boundary:** `teatree/loops/worker.py` — the singleton `t3 worker`
  executor pool. The concurrency change is contained to this module (the split
  builders `build_executor_queues` / `default_queue_executor_count`); the
  supervisor, kill-switch, and queue seams are untouched.
- **New dependency edge:** `teatree.loops → teatree.utils.ram_probe` — tach-verified
  clean (`tach check` → "✅ All modules validated"). `worker.py` imports only
  `default_provision_concurrency` (the shared PR-01 resource ceiling), reusing the
  existing provisioning-concurrency helper rather than introducing a second one.
- **Test surface:** `tests/teatree_loops/test_worker.py` — the host-scaling behavior
  is covered by patching `default_provision_concurrency` at the module seam:
  scales up on a big box, floors at 2 on a small one, and the pinned `loops`=2 split
  is asserted alongside the host-scaled `default` width.

## Open questions & assumptions

- assumed: WARN-only is the right rollout mode for the leak sentinel this week — it
  names polluters across every shard/shuffle lane without reddening the required
  context; flip to `error` once the surfaced polluters are drained.
- assumed: the daily `schedule` is the right cadence for the durations refresh; the
  drift gate keeps it from opening churn PRs on timing jitter.
- open: whether 4 shards / 4 shuffle seeds stays optimal after a full durations
  refresh — revisit the 6-shard and 180s-split deferrals then.

docs: n/a — CI workflow + dev-tooling change; no user-facing `t3` command, SKILL, FSM state, or setting added.
