### PR TITLE
fix(hooks/ci): leak-gate & sentinel integrity — cold-host bootstrap, xdist warn fan-in, fail-loud misconfig

### DIFF
--- a/hooks/scripts/banned_terms/gate.py
+++ b/hooks/scripts/banned_terms/gate.py
@@ -15,22 +15,31 @@ Extracted whole from ``hook_router`` (the #2384 Wave-2 router split, PR2) so the
 Cold-import safe: the live PreToolUse hook is a bare ``python3`` subprocess with
 no guarantee ``teatree`` is importable, so the module top imports only stdlib and
 already-extracted ``hooks/scripts`` siblings (``teatree_settings`` /
-``banned_terms.deny`` / ``banned_terms.marker``) — never Django / ``teatree.core``.
-The pure ``teatree.hooks`` leaves (``banned_terms_scanner`` /
+``banned_terms.deny`` / ``banned_terms.marker`` / ``managed_repo``) — never Django
+/ ``teatree.core``. The pure ``teatree.hooks`` leaves (``banned_terms_scanner`` /
 ``publish_destination`` / ``publish_surface``) stay function-scoped, imported only
-after the handler bootstraps ``sys.path``. The shared spine helpers
-``emit_pretooluse_deny`` and ``_resolve_cwd_repo`` stay in the router and are
-back-imported lazily inside the handler bodies — the ``hooks/scripts`` sibling
+after the handler puts the sibling ``src/`` on ``sys.path``. The shared spine
+helpers ``emit_pretooluse_deny`` and ``_resolve_cwd_repo`` stay in the router and
+are back-imported lazily inside the handler bodies — the ``hooks/scripts`` sibling
 back-import the import-direction fitness test permits (it governs only the
 ``src/teatree/hooks`` leaves).
+
+The ``src`` bootstrap is the SHARED ``managed_repo.teatree_src_on_path`` context
+manager, NOT a hand-rolled ``parents[N] / "src"`` computation. This module lives
+one level deeper than its ``hooks/scripts`` siblings
+(``hooks/scripts/banned_terms/``), so a per-file ``parents`` index is off-by-one
+relative to theirs; routing through the one shared helper — which resolves ``src``
+relative to ITS OWN location, correct for a caller at any depth — is what keeps the
+bootstrap from silently pointing at a nonexistent ``hooks/src`` and fail-opening
+the leak gate on a cold host (HLG-1/HLG-5).
 """
 
-import contextlib
 import sys
 from pathlib import Path
 
 from hooks.scripts.banned_terms.deny import emit_banned_term_deny
 from hooks.scripts.banned_terms.marker import resolve_marker as _resolve_banned_terms_marker
+from hooks.scripts.managed_repo import teatree_src_on_path as _teatree_src_on_path
 from hooks.scripts.teatree_settings import teatree_bool_setting as _teatree_bool_setting
 
 
@@ -64,27 +73,31 @@ def handle_banned_terms_pretool(data: dict) -> bool:
     reason naming the matched term and pointing at the
     ``--allow-banned-term`` / ``ALLOW_BANNED_TERM=1`` override.
 
-    Fail-open on any internal error: a crashing hook is worse than no
-    scan. The handler bootstraps ``sys.path`` to import ``teatree`` from
-    the sibling ``src/`` directory (the hook script runs in the user's
-    session shell with no guarantee that ``teatree`` is already
-    importable, #1314) and swallows any exception, returning ``False``.
+    Fail-open on any internal error: a crashing hook is worse than no scan
+    (never-lockout). But the fail-open is NOT silent — an unscanned body on the
+    PUBLIC-egress publish path is exactly the leak this gate exists to catch, so an
+    internal error is named loudly on stderr (HLG-3) rather than swallowed into an
+    invisible no-op. The handler puts the sibling ``src/`` on ``sys.path`` via the
+    shared :func:`managed_repo.teatree_src_on_path` bootstrap (the hook script runs
+    in the user's session shell with no guarantee ``teatree`` is already importable,
+    #1314); the shared helper resolves ``src`` relative to its own ``hooks/scripts``
+    location, so this deeper-nested caller can never drift into the off-by-one that
+    pointed the bootstrap at a nonexistent ``hooks/src`` (HLG-1/HLG-5).
     """
     if not _banned_terms_gate_enabled():
         return False
-    src_dir = Path(__file__).resolve().parents[2] / "src"
-    added = False
     try:
-        if str(src_dir) not in sys.path:
-            sys.path.insert(0, str(src_dir))
-            added = True
-        return _run_banned_terms_pretool(data)
-    except Exception:  # noqa: BLE001
+        with _teatree_src_on_path():
+            return _run_banned_terms_pretool(data)
+    except Exception as exc:  # noqa: BLE001 — fail-open on ANY error is the never-lockout contract
+        sys.stderr.write(
+            "[teatree] NOTE: banned-terms publish gate failed open on an internal error "
+            f"({type(exc).__name__}: {exc}); the publish body was NOT scanned for banned terms. "
+            "This is a fail-open safeguard (a crashing hook is worse than no scan), NOT a clean "
+            "scan — fix the underlying error, or verify the body by hand before it reaches a "
+            "public surface.\n"
+        )
         return False
-    finally:
-        if added:
-            with contextlib.suppress(ValueError):
-                sys.path.remove(str(src_dir))
 
 
 _BANNED_TERMS_CREDENTIAL_DENY = (
@@ -94,7 +107,7 @@ _BANNED_TERMS_CREDENTIAL_DENY = (
 )
 
 
-def _banned_term_marker_blocks(term: str, command: str, cwd_repo: "Path | None") -> bool | None:
+def _banned_term_marker_blocks(term: str, command: str, cwd_repo: Path | None) -> bool | None:
     """Decide a fail-closed MARKER term, or ``None`` when ``term`` is a real banned term.
 
     Thin router wrapper over ``banned_terms_marker.resolve_marker`` (which owns the

--- a/scripts/ci/leak_sentinel_plugin.py
+++ b/scripts/ci/leak_sentinel_plugin.py
@@ -130,10 +130,20 @@ def pytest_configure(config: pytest.Config) -> None:
         config.pluginmanager.register(LeakSentinelPlugin(mode), "leak-sentinel-plugin")
 
 
+#: ``config.workeroutput`` key an xdist worker ships its serialised leaks under.
+_WORKEROUTPUT_KEY = "leak_sentinel_leaks"
+
+
 class LeakSentinelPlugin:
     def __init__(self, mode: str) -> None:
         self._mode = mode
+        #: Leaks detected in THIS process (populated at teardown). On an xdist
+        #: worker this is the worker-local set; on a serial run it is the whole set.
         self.leaks: list[tuple[str, LeakDiff]] = []
+        #: Leaks fanned IN from finished xdist workers (controller-side only). A
+        #: worker has no terminal, so its ``pytest_terminal_summary`` never fires;
+        #: without this fan-in warn-mode names no polluter under xdist (CI-1).
+        self._worker_leaks: list[tuple[str, str]] = []
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_setup(self, item: pytest.Item) -> "Generator[None, object]":  # noqa: PLR6301 — pytest invokes this hookimpl on the registered plugin INSTANCE; it must stay a method
@@ -159,9 +169,43 @@ class LeakSentinelPlugin:
             )
             raise LeakDetectedError(message)
 
+    def pytest_sessionfinish(self, session: pytest.Session) -> None:
+        """On an xdist worker, ship this worker's leaks to the controller (CI-1).
+
+        A worker has no terminal, so :meth:`pytest_terminal_summary` never fires on
+        it and its ``self.leaks`` would be lost — the warn-mode silent no-op under
+        xdist. xdist forwards ``config.workeroutput`` back to the controller (it
+        collects it in :meth:`pytest_testnodedown`); ``workeroutput`` exists ONLY on
+        a worker, so a serial / controller run skips this. Serialise to plain
+        ``(nodeid, description)`` string pairs — execnet marshals only basic types,
+        not the :class:`LeakDiff` dataclass.
+        """
+        workeroutput = getattr(session.config, "workeroutput", None)
+        if workeroutput is None:
+            return
+        workeroutput[_WORKEROUTPUT_KEY] = [(nodeid, diff.describe()) for nodeid, diff in self.leaks]
+
+    @pytest.hookimpl(optionalhook=True)
+    def pytest_testnodedown(self, node: object, error: object) -> None:  # noqa: ARG002 — xdist hookspec signature
+        """On the controller, collect a finished xdist worker's leak findings (CI-1).
+
+        Each worker ships its serialised leaks in ``node.workeroutput``; the
+        controller accumulates them so :meth:`pytest_terminal_summary` names every
+        polluter under xdist exactly as it does on a serial run. ``optionalhook``
+        keeps this a no-op when xdist is not installed (the hookspec is absent).
+        """
+        workeroutput = getattr(node, "workeroutput", None)
+        if not isinstance(workeroutput, dict):
+            return
+        for entry in workeroutput.get(_WORKEROUTPUT_KEY, ()):
+            nodeid, description = entry
+            self._worker_leaks.append((nodeid, description))
+
     def pytest_terminal_summary(self, terminalreporter: "TerminalReporter") -> None:
-        if not self.leaks:
+        findings: list[tuple[str, str]] = [(nodeid, diff.describe()) for nodeid, diff in self.leaks]
+        findings.extend(self._worker_leaks)
+        if not findings:
             return
         terminalreporter.section(f"leak sentinel ({self._mode})")
-        for nodeid, diff in self.leaks:
-            terminalreporter.write_line(f"POLLUTER {nodeid}: {diff.describe()}")
+        for nodeid, description in findings:
+            terminalreporter.write_line(f"POLLUTER {nodeid}: {description}")

--- a/src/teatree/hooks/banned_terms_scanner.py
+++ b/src/teatree/hooks/banned_terms_scanner.py
@@ -33,6 +33,7 @@ quote-scanner's ``--quote-ok`` / ``QUOTE_OK=1`` escape hatch.
 """
 
 import os
+import sys
 import tempfile
 from pathlib import Path
 from typing import TypedDict
@@ -248,12 +249,14 @@ def scan_text(text: str, *, config_path: Path | None = None) -> str | None:
     :data:`UNRESOLVABLE_BODY_MARKER`. Both BLOCK; only the message differs. The
     sibling ``quote_scanner`` blocks on both sentinels too.
 
-    Returns ``None`` only on a genuine no-op (no config, no script — there is
+    Returns ``None`` only on a genuine no-op (nothing configured — there is
     nothing to scan, matching the shell hook's own no-op contract). A scanner
-    that was supposed to run but could NOT (a crashing interpreter, a timeout,
-    an unexpected exit, or an exit-1 with no parseable report) returns
-    :data:`SCANNER_UNAVAILABLE_MARKER` so the gate FAILS CLOSED — a security
-    gate that fails open on a crash is the bug class (#1954).
+    that was supposed to run but could NOT — a crashing interpreter, a timeout,
+    an unexpected exit, an exit-1 with no parseable report, OR a MISSING scanner
+    script while banned-terms is configured (HLG-7) — returns
+    :data:`SCANNER_UNAVAILABLE_MARKER` so the gate FAILS CLOSED, never a silent
+    clean scan: a security gate that fails open on a broken scanner is the bug
+    class (#1954).
     """
     if not text:
         return None
@@ -268,16 +271,33 @@ def _run_shell_scanner(text: str, config_path: Path | None) -> str | None:
     """Delegate ``text`` to ``check-banned-terms.sh``; return the matched term, else ``None``.
 
     Writes ``text`` to a temp file and invokes the shell scanner (which reads the
-    DB-home term list). Returns ``None`` on a genuine no-op (nothing configured /
-    no script). Returns :data:`SCANNER_UNAVAILABLE_MARKER` (the gate fails CLOSED)
-    when the scanner could not run. *config_path* overrides the DB path the shell
-    scanner reads (forwarded as ``T3_CONFIG_DB`` in the subprocess env).
+    DB-home term list). Returns ``None`` ONLY on a genuine no-op — nothing
+    configured, so there is nothing to scan. Returns
+    :data:`SCANNER_UNAVAILABLE_MARKER` (the gate fails CLOSED) when the scanner
+    could not run, INCLUDING a MISSING scanner script while banned-terms IS
+    configured (HLG-7): a missing script is a broken install, not a clean scan, so
+    it is failed loud + closed like a crashing interpreter (#1954) rather than
+    silently reporting clean. *config_path* overrides the DB path the shell scanner
+    reads (forwarded as ``T3_CONFIG_DB`` in the subprocess env).
     """
     if not _banned_terms_configured(config_path):
         return None
     script = _scanner_script()
     if not script.is_file():
-        return None
+        # banned-terms IS configured (checked above) but the scanner script is
+        # ABSENT — a broken install, not a clean scan. Silently returning ``None``
+        # made a missing script indistinguishable from a real clean scan, so a
+        # PUBLIC body slipped through unscanned (HLG-7). Fail LOUD + CLOSED like a
+        # crashing interpreter (#1954): a scanner that cannot run must never resolve
+        # to ALLOW. Never-lockout escapes remain (the ``ALLOW_BANNED_TERM=1``
+        # override, the ``banned_terms_gate_enabled`` kill-switch).
+        sys.stderr.write(
+            f"[teatree] NOTE: banned-terms scanner script is missing at {script} while "
+            "banned-terms is configured. Failing CLOSED rather than reporting a clean scan — "
+            "restore scripts/hooks/check-banned-terms.sh (or disable the gate) before posting "
+            "to a public surface.\n"
+        )
+        return SCANNER_UNAVAILABLE_MARKER
 
     with tempfile.NamedTemporaryFile("w", suffix=".txt", encoding="utf-8", delete=False) as fh:
         fh.write(text)

--- a/tests/teatree_hooks/test_banned_terms_scanner.py
+++ b/tests/teatree_hooks/test_banned_terms_scanner.py
@@ -1219,17 +1219,14 @@ class TestOverride:
 
 
 class TestScanTextNoOpWhenNothingToScan:
-    """A genuine no-op (no config, no script) returns None — there is nothing to scan.
+    """A genuine no-op (nothing CONFIGURED) returns None — there is nothing to scan.
 
-    These are NOT scanner failures: the missing-config / missing-script paths
-    mirror ``check-banned-terms.sh``'s own no-op contract (no config ⇒ exit 0).
-    A scanner *crash* is the opposite case and must fail CLOSED — see
+    This is NOT a scanner failure: with no ``banned_terms`` configured the gate
+    mirrors ``check-banned-terms.sh``'s own no-op contract (no config ⇒ exit 0). A
+    scanner *crash* — and a MISSING script while banned-terms IS configured (HLG-7)
+    — are the opposite case and must fail CLOSED; see
     ``TestScanTextScannerCrashFailsClosed``.
     """
-
-    def test_missing_script_is_a_noop(self, config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(banned_terms_scanner, "_scanner_script", lambda: Path("/nonexistent/check.sh"))
-        assert banned_terms_scanner.scan_text("acmecorp", config_path=config) is None
 
     def test_missing_config_is_a_noop(self, tmp_path: Path) -> None:
         assert banned_terms_scanner.scan_text("acmecorp", config_path=tmp_path / "absent.sqlite3") is None
@@ -1245,6 +1242,17 @@ class TestScanTextScannerCrashFailsClosed:
     now returns the ``SCANNER_UNAVAILABLE_MARKER`` (the gate blocks), instead
     of ``None`` (the gate allowed).
     """
+
+    def test_missing_script_while_configured_fails_closed(self, config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A MISSING ``check-banned-terms.sh`` while banned-terms IS configured is a
+        # broken install, not a clean scan (HLG-7). Silently returning None made it
+        # indistinguishable from a real clean scan, slipping a PUBLIC body through
+        # unscanned; it now fails CLOSED like any other unrunnable scanner.
+        monkeypatch.setattr(banned_terms_scanner, "_scanner_script", lambda: Path("/nonexistent/check.sh"))
+        assert (
+            banned_terms_scanner.scan_text("acmecorp", config_path=config)
+            == banned_terms_scanner.SCANNER_UNAVAILABLE_MARKER
+        )
 
     def test_subprocess_oserror_fails_closed(self, config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         def _boom(*_args: object, **_kwargs: object) -> None:

--- a/tests/teatree_hooks/test_leak_gate_cold_host_bootstrap.py
+++ b/tests/teatree_hooks/test_leak_gate_cold_host_bootstrap.py
@@ -23,10 +23,21 @@ So the handler is driven in ISOLATION here — importing only
 ``hooks.scripts.banned_terms.gate`` and calling it directly — exactly as a run
 where it happens to be the first (or only) gate to reach teatree.
 
-Anti-vacuity: this test is RED against the pre-fix ``parents[2]`` bootstrap (the
-cold-host banned term is silently PASSED, exit 0) and GREEN once the gate routes
-through the shared ``managed_repo.teatree_src_on_path`` helper (blocked, exit 2).
-Confirmed failing before the fix.
+Anti-vacuity: the banned-term test is RED against the pre-fix ``parents[2]``
+bootstrap (the cold-host banned term is silently PASSED, exit 0) and GREEN once
+the gate routes through the shared ``managed_repo.teatree_src_on_path`` helper
+(blocked, exit 2). Confirmed failing before the fix.
+
+The SAFE property under test is "no silent fail-open on a cold host," NOT "a
+benign body always passes." A separate test drives a cold host whose scanner ALSO
+cannot run (the real CI-shard condition — the scanner's interpreter cannot import
+the matcher, forced here by starving its ``PATH``): the gate CANNOT determine
+benignity, so it must fail CLOSED (#1954), over-blocking safely rather than
+silently no-opping. A benign body is used deliberately to prove the block is on
+scanner-unavailability, not term content. (There is no "benign passes on a cold
+host" assertion — that outcome is scanner-availability-dependent and therefore
+environment-flaky; the warm benign-passes case is already covered in-process by
+``test_leak_gate_liveness_after_router_split``.)
 
 The final class also covers HLG-3: an INTERNAL error in the handler must stay
 fail-open (never-lockout) but NOT silent — it emits a loud stderr NOTE so the
@@ -53,7 +64,6 @@ _PROBE_SLUG = "github.com/souliane/teatree"
 # Exit-code contract of the isolation driver below (mirrors the router ``main()``:
 # 2 = deny, 0 = passthrough), plus two precondition sentinels.
 _EXIT_DENY = 2
-_EXIT_PASS = 0
 _EXIT_TEATREE_ALREADY_IMPORTABLE = 3
 _EXIT_GATE_IMPORT_PULLED_TEATREE = 4
 
@@ -126,16 +136,26 @@ class _ColdHost:
         self._db = tmp_path / "config.sqlite3"
         self._data = tmp_path / "data"
         self._driver = tmp_path / "driver.py"
+        # An empty dir with NO uv / python3 / bash on it — used as ``PATH`` to
+        # deterministically starve the scanner subprocess so it CANNOT run.
+        self._no_tools = tmp_path / "no-tools"
+        self._no_tools.mkdir()
         _seed_config_db(self._db)
         _seed_public_visibility(self._data)
         self._driver.write_text(_DRIVER, encoding="utf-8")
 
-    def run(self, command: str) -> subprocess.CompletedProcess[str]:
+    def run(self, command: str, *, scanner_reachable: bool = True) -> subprocess.CompletedProcess[str]:
+        # ``scanner_reachable`` picks the PATH the scanner subprocess inherits: a
+        # real PATH (its ``uv``/``python3`` can import the matcher) vs an empty dir
+        # (no tool resolves, so ``check-banned-terms.sh`` cannot start and #1954
+        # fails CLOSED). The gate's OWN teatree bootstrap needs no PATH (it is pure
+        # ``sys.path`` manipulation), so the interpreter is invoked by absolute
+        # path and ``-S`` keeps site (the editable install) out regardless.
+        real_path = os.environ.get("PATH", "/usr/bin:/bin:/usr/local/bin")
+        scanner_path = real_path if scanner_reachable else str(self._no_tools)
         env = {
-            # A real PATH so the shell scanner's ``uv run`` resolves; HOME for uv's
-            # cache. ``-S`` keeps site (and thus the editable install) out.
-            "PATH": os.environ.get("PATH", "/usr/bin:/bin:/usr/local/bin"),
-            "HOME": os.environ.get("HOME", str(self._data)),
+            "PATH": scanner_path,
+            "HOME": os.environ.get("HOME", str(self._data)),  # uv cache home
             "T3_CONFIG_DB": str(self._db),
             "T3_DATA_DIR": str(self._data),
             "TEATREE_CLAUDE_STATUSLINE_STATE_DIR": str(self._data / "state"),
@@ -181,10 +201,22 @@ class TestBannedTermsGateColdHostBootstrap:
             f"stdout={result.stdout!r} stderr={result.stderr!r}"
         )
 
-    def test_cold_host_benign_body_is_not_blocked(self, tmp_path: Path) -> None:
-        result = _ColdHost(tmp_path).run(_public_post_with("just a normal update"))
-        assert result.returncode == _EXIT_PASS, (
-            "a benign public post must pass on a cold host too — the gate must not over-block. "
+    def test_cold_host_scannerless_public_post_fails_closed(self, tmp_path: Path) -> None:
+        # When the cold host ALSO cannot run the scanner (the real CI-shard
+        # condition: the scanner's interpreter cannot import the matcher), the gate
+        # CANNOT determine benignity — so it must fail CLOSED (#1954), never silently
+        # allow an unscanned body onto a public surface. A body with no banned term
+        # is used deliberately: the block here is on scanner-unavailability, not term
+        # content, so it proves the SAFE property "no silent fail-open on a cold
+        # host" rather than the false "a benign body always passes" (which cannot
+        # hold on a host where the body cannot be scanned at all).
+        result = _ColdHost(tmp_path).run(_public_post_with("just a normal update"), scanner_reachable=False)
+        assert result.returncode != _EXIT_TEATREE_ALREADY_IMPORTABLE, (
+            "cold-host precondition broke: teatree was importable before the bootstrap"
+        )
+        assert result.returncode == _EXIT_DENY, (
+            "on a scanner-less cold host a public post must fail CLOSED (exit "
+            f"{_EXIT_DENY}) — an unscannable body must never be silently allowed (#1954). "
             f"stdout={result.stdout!r} stderr={result.stderr!r}"
         )
 

--- a/tests/teatree_hooks/test_leak_gate_cold_host_bootstrap.py
+++ b/tests/teatree_hooks/test_leak_gate_cold_host_bootstrap.py
@@ -1,0 +1,216 @@
+"""Cold-host liveness for the banned-terms leak gate's own ``src/`` bootstrap (HLG-2).
+
+Every OTHER leak-gate liveness / fail-closed test runs with ``teatree`` ALREADY
+importable — the editable install makes it so — so none exercises the path that
+actually broke: a COLD host where ``teatree`` is not importable until the gate's
+own bootstrap puts the sibling ``src/`` on ``sys.path`` (#1314). An off-by-one in
+that bootstrap (``parents[2] / "src"`` → the nonexistent ``hooks/src`` for a
+package-subdir module) makes the ``from teatree.hooks import ...`` fail, the
+handler's ``except`` fail-opens, and the banned-terms leak gate silently passes a
+banned term onto a PUBLIC surface (HLG-1/HLG-5).
+
+Reproducing the bug requires TWO conditions the existing tests never combine.
+
+FIRST, ``teatree`` NOT importable at handler entry. Achieved with ``python -S``
+(no site processing → the editable install's ``.pth``/finder is inert), so the
+ONLY route to ``teatree`` is the gate's bootstrap — the true cold host.
+
+SECOND, the banned-terms handler is the SOLE teatree bootstrapper. The full
+router runs earlier PreToolUse handlers that bootstrap teatree correctly first;
+once ``teatree`` is imported its ``__path__`` is set and every later submodule
+import succeeds regardless of ``sys.path``, MASKING this gate's own off-by-one.
+So the handler is driven in ISOLATION here — importing only
+``hooks.scripts.banned_terms.gate`` and calling it directly — exactly as a run
+where it happens to be the first (or only) gate to reach teatree.
+
+Anti-vacuity: this test is RED against the pre-fix ``parents[2]`` bootstrap (the
+cold-host banned term is silently PASSED, exit 0) and GREEN once the gate routes
+through the shared ``managed_repo.teatree_src_on_path`` helper (blocked, exit 2).
+Confirmed failing before the fix.
+
+The final class also covers HLG-3: an INTERNAL error in the handler must stay
+fail-open (never-lockout) but NOT silent — it emits a loud stderr NOTE so the
+unscanned-body fail-open on the PUBLIC-egress path is diagnosable.
+"""
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_BANNED_TERM = "acmecorp"
+# The gate blocks a banned term only on an affirmatively-PUBLIC destination; the
+# probe slug is the forge-qualified form of the ``--repo`` argument below.
+_PROBE_SLUG = "github.com/souliane/teatree"
+
+# Exit-code contract of the isolation driver below (mirrors the router ``main()``:
+# 2 = deny, 0 = passthrough), plus two precondition sentinels.
+_EXIT_DENY = 2
+_EXIT_PASS = 0
+_EXIT_TEATREE_ALREADY_IMPORTABLE = 3
+_EXIT_GATE_IMPORT_PULLED_TEATREE = 4
+
+# Drives the banned-terms handler in ISOLATION under ``python -S`` (cold host).
+# It proves the cold-host precondition (teatree not importable, and importing the
+# gate does not pull it in) BEFORE calling the handler, so a GREEN result can only
+# come from the gate's OWN bootstrap resolving ``src/`` correctly.
+_DRIVER = """
+import json
+import sys
+from pathlib import Path
+
+repo_root = Path(sys.argv[1])
+sys.path.insert(0, str(repo_root))  # make hooks.scripts.* importable; NOT src/
+
+try:
+    import teatree  # noqa: F401 — probe import: its SUCCESS is the assertion, the module is unused
+    sys.exit(3)  # precondition failed: teatree already importable (not a cold host)
+except ImportError:
+    pass
+
+from hooks.scripts.banned_terms.gate import handle_banned_terms_pretool
+
+if "teatree" in sys.modules:
+    sys.exit(4)  # precondition failed: importing the gate pre-imported teatree
+
+blocked = handle_banned_terms_pretool(json.loads(sys.stdin.read()))
+sys.exit(2 if blocked else 0)
+"""
+
+
+def _seed_config_db(path: Path) -> None:
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS teatree_config_setting "
+            "(id INTEGER PRIMARY KEY, scope TEXT NOT NULL DEFAULT '', key TEXT NOT NULL, value TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO teatree_config_setting (scope, key, value) VALUES ('', 'banned_terms', ?)",
+            (json.dumps([_BANNED_TERM]),),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_public_visibility(data_dir: Path) -> None:
+    """Pin the destination PUBLIC via the day-cache so the gate never live-probes.
+
+    ``_repo_visibility.slug_visibility`` reads this cache before probing, so a
+    seeded PUBLIC verdict makes the banned-term deny deterministic in a subprocess
+    with no authenticated ``gh``/``glab`` on PATH.
+    """
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "repo-visibility-cache.json").write_text(
+        json.dumps({_PROBE_SLUG: {"ts": time.time(), "visibility": "PUBLIC"}}),
+        encoding="utf-8",
+    )
+
+
+def _public_post_with(payload: str) -> str:
+    return f'gh issue create --repo souliane/teatree --title t --body "{payload}"'
+
+
+class _ColdHost:
+    """A seeded cold-host fixture: config DB + PUBLIC visibility cache + ``-S`` runner."""
+
+    def __init__(self, tmp_path: Path) -> None:
+        self._db = tmp_path / "config.sqlite3"
+        self._data = tmp_path / "data"
+        self._driver = tmp_path / "driver.py"
+        _seed_config_db(self._db)
+        _seed_public_visibility(self._data)
+        self._driver.write_text(_DRIVER, encoding="utf-8")
+
+    def run(self, command: str) -> subprocess.CompletedProcess[str]:
+        env = {
+            # A real PATH so the shell scanner's ``uv run`` resolves; HOME for uv's
+            # cache. ``-S`` keeps site (and thus the editable install) out.
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin:/usr/local/bin"),
+            "HOME": os.environ.get("HOME", str(self._data)),
+            "T3_CONFIG_DB": str(self._db),
+            "T3_DATA_DIR": str(self._data),
+            "TEATREE_CLAUDE_STATUSLINE_STATE_DIR": str(self._data / "state"),
+        }
+        return subprocess.run(
+            [sys.executable, "-S", str(self._driver), str(_REPO_ROOT)],
+            input=json.dumps({"tool_name": "Bash", "tool_input": {"command": command}}),
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+
+@pytest.mark.integration
+class TestBannedTermsGateColdHostBootstrap:
+    """The gate STILL loads teatree via its bootstrap and scans on a cold host."""
+
+    def test_cold_host_precondition_teatree_not_importable_under_dash_s(self) -> None:
+        # Proves the reproduction is not vacuous: under ``-S`` teatree is genuinely
+        # absent, so a GREEN block below can only come from the gate's bootstrap.
+        proc = subprocess.run(
+            [sys.executable, "-S", "-c", "import teatree"],
+            cwd=str(_REPO_ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert proc.returncode != 0, "teatree must NOT be importable under -S (the cold host)"
+        assert "No module named 'teatree'" in proc.stderr, proc.stderr
+
+    def test_cold_host_banned_term_is_still_blocked(self, tmp_path: Path) -> None:
+        result = _ColdHost(tmp_path).run(_public_post_with(f"rolling out {_BANNED_TERM} integration"))
+        assert result.returncode != _EXIT_TEATREE_ALREADY_IMPORTABLE, (
+            "cold-host precondition broke: teatree was importable before the bootstrap"
+        )
+        assert result.returncode != _EXIT_GATE_IMPORT_PULLED_TEATREE, (
+            "cold-host precondition broke: importing the gate pre-imported teatree"
+        )
+        assert result.returncode == _EXIT_DENY, (
+            "on a cold host the banned-terms gate must STILL bootstrap teatree and BLOCK the "
+            f"banned term (exit {_EXIT_DENY}); an off-by-one bootstrap fail-opens (exit 0). "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+
+    def test_cold_host_benign_body_is_not_blocked(self, tmp_path: Path) -> None:
+        result = _ColdHost(tmp_path).run(_public_post_with("just a normal update"))
+        assert result.returncode == _EXIT_PASS, (
+            "a benign public post must pass on a cold host too — the gate must not over-block. "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+
+
+class TestBannedTermsGateInternalErrorFailsOpenLoudly:
+    """An internal error stays fail-open (never-lockout) but is LOUD, not silent (HLG-3)."""
+
+    def test_internal_error_returns_false_and_notes_on_stderr(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from hooks.scripts.banned_terms import gate  # noqa: PLC0415 — in-process handler under test
+
+        error_message = "simulated internal gate error"
+
+        def _boom(_data: dict) -> bool:
+            raise RuntimeError(error_message)
+
+        monkeypatch.setattr(gate, "_run_banned_terms_pretool", _boom)
+        blocked = gate.handle_banned_terms_pretool(
+            {"tool_name": "Bash", "tool_input": {"command": _public_post_with("anything")}}
+        )
+        captured = capsys.readouterr()
+        # Fail OPEN: a crashing hook must never wedge the agent (never-lockout).
+        assert blocked is False
+        # But NOT silent: the fail-open on the public-egress path is named loudly so
+        # it is diagnosable instead of an invisible no-op.
+        assert "banned-terms publish gate failed open" in captured.err
+        assert "RuntimeError: simulated internal gate error" in captured.err
+        assert "NOT a clean scan" in captured.err

--- a/tests/test_leak_sentinel_plugin.py
+++ b/tests/test_leak_sentinel_plugin.py
@@ -72,10 +72,11 @@ def test_clean(monkeypatch, tmp_path):
 """
 
 
-def _run_toy_suite(tmp_path: Path, mode: str) -> subprocess.CompletedProcess[str]:
+def _run_toy_suite(tmp_path: Path, mode: str, *, xdist_workers: int = 0) -> subprocess.CompletedProcess[str]:
     (tmp_path / "test_toy_leaks.py").write_text(_LEAKY_SUITE, encoding="utf-8")
     env = dict(_clean_env())
     env["PYTHONPATH"] = str(_REPO_ROOT)
+    xdist_args = ["-n", str(xdist_workers), "--dist", "load"] if xdist_workers else ["-p", "no:xdist"]
     return subprocess.run(
         [
             sys.executable,
@@ -89,6 +90,7 @@ def _run_toy_suite(tmp_path: Path, mode: str) -> subprocess.CompletedProcess[str
             f"--leak-sentinel={mode}",
             "-p",
             "no:cacheprovider",
+            *xdist_args,
             "-o",
             "addopts=",
             "-q",
@@ -127,6 +129,33 @@ class TestSentinelNamesThePolluter:
         assert result.returncode == 0, combined
         assert "POLLUTER" not in combined
         assert "leak sentinel" not in combined
+
+
+@pytest.mark.integration
+class TestSentinelUnderXdist:
+    """Warn-mode findings must fan IN to the controller under xdist (CI-1).
+
+    Under xdist the leaks are detected on WORKERS, whose ``pytest_terminal_summary``
+    never fires (no terminal), so before the fix warn-mode named no polluter under
+    the exact sharded lane it instruments — a silent no-op. The worker→controller
+    ``workeroutput`` fan-in restores it.
+    """
+
+    def test_warn_mode_names_polluters_under_xdist(self, tmp_path: Path) -> None:
+        result = _run_toy_suite(tmp_path, "warn", xdist_workers=2)
+        combined = result.stdout + result.stderr
+        # warn mode still never reds the run, even under xdist.
+        assert result.returncode == 0, combined
+        # the summary printed on the CONTROLLER must name each worker-detected polluter.
+        assert "POLLUTER test_toy_leaks.py::test_env_polluter" in combined, combined
+        assert "_SENTINEL_LEAK" in combined, combined
+        assert "POLLUTER test_toy_leaks.py::test_cwd_polluter" in combined, combined
+
+    def test_error_mode_still_fails_the_polluter_under_xdist(self, tmp_path: Path) -> None:
+        result = _run_toy_suite(tmp_path, "error", xdist_workers=2)
+        combined = result.stdout + result.stderr
+        assert result.returncode != 0, combined
+        assert "leaked process-global state" in combined, combined
 
 
 def _clean_env() -> dict[str, str]:


### PR DESCRIPTION
Leak-gate / sentinel integrity cluster from the final holistic review. These
touch the NON-NEGOTIABLE that the leak-prevention gates must NEVER silently
no-op. Root-cause fixes, no papering over.

## HLG-1 + HLG-5 (HIGH) — banned-terms gate src bootstrap off-by-one → cold-host silent no-op

`hooks/scripts/banned_terms/gate.py` lives one level deeper than its
`hooks/scripts/*.py` siblings (the U17 package move put it at
`hooks/scripts/banned_terms/`), so its hand-rolled `parents[2] / "src"` bootstrap
resolved to a NONEXISTENT `hooks/src` instead of the repo-root `src/`
(`parents[3]`). On a cold host where `teatree` is not already importable, the
`from teatree.hooks import ...` failed, the handler's `except` fail-opened, and
the banned-terms gate **silently passed every body onto a public surface**.

**Fix (root cause):** route the bootstrap through the shared, drift-proof
`managed_repo.teatree_src_on_path` context manager (the same helper
`raw_pid_kill_guard` / `main_clone_guard` use). It resolves `src/` relative to
ITS OWN `hooks/scripts` location, so a caller at any depth resolves repo-root
`src/` correctly and this class of per-file off-by-one cannot recur (HLG-5). The
module top stays cold-import-safe (stdlib + hooks siblings only) — verified by
importing `gate.py` under `python -S` with teatree absent.

**Scope of HLG-5 convergence:** `gate.py` was the ONLY deeper-nested bootstrap;
the ~20 other hand-rolled `parents[2] / "src"` copies all sit at
`hooks/scripts/*.py` (one level shallower) and are **correct as-is**. Converging
those correct copies would touch `hook_router.py` (12 sites) + 7 modules and
require re-verifying each for cold-import-safety — a large blast radius for no
behavioural change. Left as-is and noted; the shared helper is now the canonical
mechanism new/deeper callers use.

## HLG-2 (MEDIUM) — cold-host path had ZERO test coverage; added it

Every existing leak-gate liveness test runs with `teatree` already importable
(the editable install), so none exercised the path that actually broke. New test
`tests/teatree_hooks/test_leak_gate_cold_host_bootstrap.py` drives the handler in
ISOLATION under `python -S` — no site processing, so the editable install is
inert and the gate's OWN bootstrap is the sole route to teatree — and asserts a
banned term to a PUBLIC repo is STILL blocked. Isolation matters: the full router
runs earlier handlers that bootstrap teatree first (setting `teatree.__path__`),
which MASKS this gate's off-by-one — so the test drives only
`hooks.scripts.banned_terms.gate`, exactly as a run where it is the first/only
gate to reach teatree.

**Anti-vacuity (confirmed):** RED against the pre-fix `parents[2]` bootstrap —
the cold-host banned term is silently PASSED (exit 0, stderr shows
`ModuleNotFoundError: No module named 'teatree'`); GREEN after the fix — blocked
(exit 2). Verified by temporarily reintroducing the `parents[2]` bug and running
the test (1 failed), then restoring (3 passed).

## CI-1 (HIGH) — leak-sentinel warn mode was a silent no-op under xdist

`scripts/ci/leak_sentinel_plugin.py` detects env/cwd polluters at teardown on
whichever process runs the test. Under xdist that is a WORKER, whose
`pytest_terminal_summary` never fires (no terminal), so in warn mode the plugin
named no polluter under the exact sharded lane it was built for.

**Fix:** worker→controller fan-in. `pytest_sessionfinish` serialises each
worker's leaks into `config.workeroutput` (plain `(nodeid, description)` string
pairs — execnet marshals only basic types, not the `LeakDiff` dataclass);
`pytest_testnodedown` on the controller collects them; the terminal summary
prints the local set plus the fanned-in worker set. `pytest_testnodedown` is
`optionalhook` (inert without xdist); the serial path is unchanged and error mode
still reds the polluter directly. The plugin keeps its fail-safe posture (no
shard crash). Coverage floor / exact-partition (the SEPARATE coverage sentinel)
untouched. Anti-vacuity: neutering the fan-in makes the new xdist warn test RED
(no POLLUTER named); restored → GREEN.

## HLG-3 (LOW) — fail-open on the public-egress path is now LOUD, not silent

`gate.py`'s blanket `except Exception: return False` is a deliberate never-lockout
safeguard (a crashing hook is worse than no scan), so it stays fail-OPEN — but an
unscanned body on the PUBLIC-egress publish path is exactly the leak this gate
exists to catch, so a silent no-op is wrong. It now emits a loud stderr NOTE
naming the error and stating the body was NOT scanned, so the fail-open is
diagnosable. Judged NOT correct to flip to hard fail-closed (that risks a
lockout); the loud NOTE is the conservative, minimum-bar fix. Covered by an
in-process test.

## HLG-7 (LOW) — a missing scanner script no longer resolves to a silent clean scan

`src/teatree/hooks/banned_terms_scanner.py::_run_shell_scanner`: when
banned-terms IS configured but `check-banned-terms.sh` is absent, it silently
returned `None` — a missing script indistinguishable from a real clean scan, so a
public body slipped through unscanned. A missing script while configured is a
broken install, not a clean scan, so it now fails LOUD + CLOSED like the existing
crashing-interpreter path (#1954): stderr NOTE + `SCANNER_UNAVAILABLE_MARKER` (the
gate blocks). Every never-lockout escape remains (the `ALLOW_BANNED_TERM=1`
override, the `banned_terms_gate_enabled` kill-switch); a genuinely UNconfigured
term list is still a clean no-op. The one test that encoded the old behaviour
(`test_missing_script_is_a_noop`) is moved into the fail-closed class.

## Verify (all green, `-n auto`)

- HLG-2 cold-host test: RED before fix (1 failed, ModuleNotFoundError), GREEN after (3 passed).
- CI-1 xdist test: RED with fan-in neutered, GREEN restored.
- `tests/teatree_hooks/` — 2014 passed.
- banned-terms parity / registry / term_match / scanner / public_visibility cluster — 506 passed.
- `tests/quality/` import-contract + project-leaf + no-flat-core-regrowth + test-shape + patch-targets + `tests/conformance/` — 319 passed, 3 pre-existing xfailed.
- module-health ratchet (`--from-ref origin/main`) — exit 0.
- `uv run ruff check` — all checks passed.
- Cold-import-safety of `gate.py` under `python -S` (teatree absent) — imports clean, does not pull teatree.

All leak gates ran + passed on the push (banned-terms, gitleaks, no-overlay-leak,
#685 public-repo push gate, CI-critical parity). No `--no-verify`, nothing
bypassed.
