### PR TITLE
fix(ci): CI-throughput residual reliability fixes (#3160)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -579,6 +579,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          # CI-2: persist the PAT (not the default GITHUB_TOKEN) as the git credential
+          # so the `git push` to the refresh branch is attributed to a real identity and
+          # TRIGGERS the required `test (3.13)` check. A push authenticated with
+          # GITHUB_TOKEN never fires downstream workflows (GitHub's recursion guard), so
+          # the refresh PR would sit forever without its required check and could never
+          # merge. The token guard in the PR step below fails loud if it is unset.
+          token: ${{ secrets.TEATREE_GH_TOKEN }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           pattern: durations-shard-*
@@ -601,9 +608,20 @@ jobs:
       - name: Open or update the durations-refresh PR
         if: steps.merge.outputs.refresh == 'true' && !cancelled()
         env:
-          GH_TOKEN: ${{ github.token }}
+          # CI-2: a PAT (TEATREE_GH_TOKEN), NOT the default GITHUB_TOKEN. A PR opened /
+          # a branch pushed with GITHUB_TOKEN never triggers the required `test (3.13)`
+          # check (GitHub suppresses workflow-triggered workflows), so such a refresh PR
+          # can never merge unaided. `gh pr create`/`gh pr view` read GH_TOKEN; the
+          # checkout above persists the same token for the `git push`.
+          GH_TOKEN: ${{ secrets.TEATREE_GH_TOKEN }}
         run: |
           set -euo pipefail
+          # Fail LOUD, never silently open an un-mergeable PR: without a CI-triggering
+          # token the required check never fires and the refresh stalls forever.
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::TEATREE_GH_TOKEN is unset. The durations-refresh PR must be opened with a PAT that triggers the required 'test (3.13)' check — the default GITHUB_TOKEN does not, so the PR could never merge. Set the TEATREE_GH_TOKEN secret." >&2
+            exit 1
+          fi
           if git diff --quiet dev/.test_durations; then
             echo "No net change to dev/.test_durations — nothing to open."
             exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -563,7 +563,10 @@ jobs:
   # previously-unrecorded `tests/quality` + doctest items). This job unions them
   # back into one complete file and, ONLY when the drift gate fires (test set
   # changed, or aggregate per-test time moved past the threshold — never on pure
-  # jitter), opens/updates a single dated refresh PR a human reviews and merges.
+  # jitter), opens/updates ONE single refresh PR a human reviews and merges.
+  # The refresh branch name is STABLE (`ci/test-durations-refresh`) and force-
+  # updated, so an unmerged refresh is UPDATED in place instead of stacking a new
+  # dated PR every day (which piled up conflicting PRs — #3160 residual CI-3).
   # Never gates a PR; a merge failure or empty diff is a no-op.
   refresh-durations:
     needs: test-shard
@@ -605,7 +608,9 @@ jobs:
             echo "No net change to dev/.test_durations — nothing to open."
             exit 0
           fi
-          BRANCH="chore/refresh-test-durations-$(date +%Y-%m-%d)"
+          # STABLE branch (CI-3): reused + force-updated so there is at most ONE open
+          # refresh PR, updated in place — never a new dated branch/PR each unmerged day.
+          BRANCH="ci/test-durations-refresh"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -B "$BRANCH"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -766,34 +766,31 @@ jobs:
           (run_heavy_python=false). Emitting a passing 'test (${{ matrix.python-version }})'
           so the required status context is satisfied without re-running the suite."
 
-  # GATE (heavy lane): order-dependence audit. Runs the order-fragile loop test
-  # subset under a SHUFFLED collection order (pytest-randomly) so a test that
+  # GATE (heavy lane): order-dependence audit. Runs a curated, order-safe slice of
+  # the suite under a SHUFFLED collection order (pytest-randomly) so a test that
   # leaks shared global state — a stray env var, an unreset singleton, a
   # module-level cache — and the victim it breaks cannot silently return
   # (souliane/teatree#2359 Class B). The heavy `test (3.13)` lane runs the suite
   # in its committed file order and so never exercises the polluter→victim
   # adjacency; this lane does.
   test-shuffle:
-    # WHY a SUBSET, not the whole suite: a small set of concurrency/timeout tests
-    # seed their isolated DB at import time and are only collectable in the
-    # suite's natural order, so a full-suite shuffle reds on an UNRELATED
-    # collection error. The Class B flakes live in ``tests/teatree_loop/``, which
-    # collects cleanly under shuffle — scoping here keeps the gate signal about
-    # order-dependence, not about that separate import-order fragility.
+    # WHY a CURATED SET, not the whole suite (widened #3160 residual CI-4): the
+    # Class B flakes this lane was built for live in ``tests/teatree_loop/`` (#2359),
+    # but the audit only has value over the tests it shuffles. The lane is widened to
+    # every ADDITIONAL directory empirically verified order-safe under ALL four
+    # matrixed seeds — both standalone AND shuffled TOGETHER in one ``-n0`` process
+    # (cross-directory polluter→victim adjacency): ``config``, ``teatree_config``,
+    # ``teatree_utils``, ``utils``, ``teatree_quality``, ``messaging``, ``cli_doctor``,
+    # ``conformance``, ``teatree_hooks`` (high-value — hooks mutate process-global
+    # env/cwd most often). ~6k tests, ~5-7 min serial per seed, under the 20-min cap.
     #
-    # WHY ``--group shuffle`` (not the default ``dev``): adding pytest-randomly to
-    # ``dev`` would shuffle every ``uv run pytest`` and the heavy coverage lane,
-    # destabilising them; the plugin is isolated to this lane.
-    #
-    # SEEDS: 7 is the recorded reproducer (it red'd 27 ``tests/teatree_loop/``
-    # tests on the pre-fix code); the others widen the order coverage. ``-n0`` is
-    # serial so a single in-process collection order is exercised end to end
-    # (xdist would isolate the polluter from the victim across workers). The four
-    # seeds are MATRIXED (was a serial ~11-min for-loop) so each runs as its own
-    # ~2.5-min parallel job — the failure-wave latency when shuffle is the slowest
-    # lane drops accordingly (#3160). `leak_sentinel_plugin` runs WARN-ONLY so a
-    # process-global env/cwd polluter is NAMED (not just its downstream victim)
-    # without failing the lane during the #3160 rollout week.
+    # STILL SCOPED-OUT (measured, not silent): ``teatree_core``, ``teatree_cli``,
+    # ``teatree_loops``, ``teatree_backends``, ``teatree_agents``, ``eval_replay``,
+    # ``integration``, ``django_db``, … are NOT yet in the lane — not verified
+    # order-safe under shuffle. Widening them needs the plan's step 1 (audit/fix the
+    # import-time DB seeding in the concurrency/timeout tests), a larger separate
+    # effort; add a dir here only after it passes shuffled (all four seeds) TOGETHER
+    # with this set.
     #
     # Heavy lane: PR-only AND skipped on a provably pure-docs diff
     # (preflight ``run_heavy_python=false``); any non-pure-docs PR runs it.
@@ -817,13 +814,32 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: ${{ matrix.python-version }}
+      # WHY ``--group shuffle`` (not the default ``dev``): adding pytest-randomly to
+      # ``dev`` would shuffle every ``uv run pytest`` and the heavy coverage lane,
+      # destabilising them; the plugin is isolated to this lane.
       - run: uv sync --group shuffle
-      - name: Run the order-fragile loop subset under shuffled collection (seed ${{ matrix.seed }})
+      # SEEDS: 7 is the recorded reproducer (it red'd 27 ``tests/teatree_loop/`` tests
+      # on the pre-fix code); the others widen order coverage. ``-n0`` is serial so a
+      # single in-process collection order runs end to end (xdist would isolate the
+      # polluter from the victim across workers). The four seeds are MATRIXED so each
+      # runs as its own ~5-7-min parallel job over the curated set (#3160).
+      # ``leak_sentinel_plugin`` runs WARN-ONLY: a process-global env/cwd polluter is
+      # NAMED (not just its downstream victim) without failing the lane.
+      - name: Run the curated order-safe set under shuffled collection (seed ${{ matrix.seed }})
         run: >
           uv run -p ${{ matrix.python-version }} pytest -n0 -q -p randomly
           --randomly-seed=${{ matrix.seed }}
           -p scripts.ci.leak_sentinel_plugin --leak-sentinel=warn
           tests/teatree_loop/
+          tests/config/
+          tests/teatree_config/
+          tests/teatree_utils/
+          tests/utils/
+          tests/teatree_quality/
+          tests/messaging/
+          tests/cli_doctor/
+          tests/conformance/
+          tests/teatree_hooks/
 
   # ── 6. Architecture / quality fitness gates ────────────────────────────────
 

--- a/scripts/ci/durations_refresh.py
+++ b/scripts/ci/durations_refresh.py
@@ -23,6 +23,10 @@ DEFAULT_DRIFT_RATIO_THRESHOLD = 0.15
 _MIN_ARGS = 2  # a durations path + at least one shard file
 
 
+class MissingShardDurationsError(FileNotFoundError):
+    """An expected per-shard durations file is absent — refuse to write a truncated merge."""
+
+
 def load_durations(path: Path) -> dict[str, float]:
     if not path.exists():
         return {}
@@ -31,9 +35,25 @@ def load_durations(path: Path) -> dict[str, float]:
 
 
 def merge_durations(paths: list[Path]) -> dict[str, float]:
-    """Union the per-shard duration slices (the four groups partition the suite)."""
+    """Union the per-shard duration slices (the four groups partition the suite).
+
+    A missing shard file is a HARD error, never an empty contribution: the four
+    groups partition the suite, so an absent shard would silently drop ~1/4 of the
+    tests from the merged file and PR a truncated ``dev/.test_durations`` that
+    unbalances the shard split. Fail LOUD (raise) so a partial merge never ships —
+    an absent artifact means an upload/download failure to investigate, not a
+    refresh to publish.
+    """
     merged: dict[str, float] = {}
     for path in paths:
+        if not path.exists():
+            message = (
+                f"expected shard-durations file is absent: {path}. The four shards partition "
+                "the suite, so a missing shard would silently drop ~1/4 of the tests from the "
+                "merged durations — refusing to write a truncated file. Check the "
+                "durations-shard-* artifact upload/download in the refresh-durations job."
+            )
+            raise MissingShardDurationsError(message)
         merged.update(load_durations(path))
     return merged
 
@@ -108,7 +128,15 @@ def main(argv: list[str] | None = None) -> int:
     shard_paths = [Path(a) for a in args[1:]]
 
     committed = load_durations(durations_path)
-    merged = merge_durations(shard_paths)
+    try:
+        merged = merge_durations(shard_paths)
+    except MissingShardDurationsError as exc:
+        # Fail LOUD: a missing shard would truncate the merge. Do NOT emit a refresh
+        # verdict and do NOT touch the committed file — the job step fails so the
+        # maintainer investigates the artifact instead of shipping a partial file.
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
     if not merged:
         print("No shard durations to merge — nothing recorded.", file=sys.stderr)
         _emit_output(False)

--- a/scripts/ci/leak_sentinel_plugin.py
+++ b/scripts/ci/leak_sentinel_plugin.py
@@ -13,6 +13,17 @@ down (so ``monkeypatch``'s own reversions are already applied). A mismatch is at
 to the test that produced it — the POLLUTER — turning a non-deterministic downstream
 red into a named, deterministic local failure.
 
+A per-test snapshot boundary is asymmetric for a MODULE / SESSION / CLASS / PACKAGE
+scoped fixture: it sets up during the FIRST test that uses it (after that test's
+baseline) and tears down during the LAST test (before that test's final snapshot), so a
+naive diff blames the first test for an ``env added`` and the last for an ``env removed``
+that the scoped fixture legitimately owns — a false positive on a well-behaved fixture.
+To avoid that the plugin watches ``pytest_fixture_setup`` / ``pytest_fixture_post_finalizer``
+for every non-function scope, records the exact env keys / cwd each scoped fixture owns,
+and excludes those from the per-test leak. A genuine per-test leak (a test body or a
+FUNCTION-scoped fixture that mutates env/cwd without restoring) is owned by no scoped
+fixture and is still flagged.
+
 Loaded opt-in via ``-p scripts.ci.leak_sentinel_plugin --leak-sentinel=<mode>``:
 
 - ``off`` (default) — the plugin registers nothing; zero overhead on a normal run.
@@ -72,6 +83,11 @@ class LeakDiff:
     def is_empty(self) -> bool:
         return not (self.env_added or self.env_removed or self.env_changed or self.cwd_from is not None)
 
+    @property
+    def all_env_keys(self) -> frozenset[str]:
+        """Every env key this diff touches (added, removed, or changed)."""
+        return frozenset(self.env_added) | frozenset(self.env_removed) | frozenset(self.env_changed)
+
     def describe(self) -> str:
         parts: list[str] = []
         if self.env_added:
@@ -90,14 +106,20 @@ def diff_snapshots(
     after: Snapshot,
     *,
     ignore: frozenset[str] = _VOLATILE_ENV_KEYS,
+    ignore_cwd: bool = False,
 ) -> LeakDiff:
-    """The process-global surface *after* left dirty relative to *before* (ignoring volatile keys)."""
+    """The process-global surface *after* left dirty relative to *before*.
+
+    ``ignore`` drops env keys never treated as a leak (volatile pytest keys, plus
+    keys a module/session-scoped fixture legitimately owns — see the plugin).
+    ``ignore_cwd`` suppresses the cwd delta when a scoped fixture owns the cwd change.
+    """
     before_env = {k: v for k, v in before.env.items() if k not in ignore}
     after_env = {k: v for k, v in after.env.items() if k not in ignore}
     added = tuple(sorted(set(after_env) - set(before_env)))
     removed = tuple(sorted(set(before_env) - set(after_env)))
     changed = tuple(sorted(k for k in set(before_env) & set(after_env) if before_env[k] != after_env[k]))
-    cwd_changed = before.cwd != after.cwd
+    cwd_changed = (not ignore_cwd) and before.cwd != after.cwd
     return LeakDiff(
         env_added=added,
         env_removed=removed,
@@ -144,13 +166,64 @@ class LeakSentinelPlugin:
         #: worker has no terminal, so its ``pytest_terminal_summary`` never fires;
         #: without this fan-in warn-mode names no polluter under xdist (CI-1).
         self._worker_leaks: list[tuple[str, str]] = []
+        #: Env keys / cwd each CURRENTLY-ACTIVE non-function-scoped fixture owns,
+        #: keyed by ``id(fixturedef)``. Populated when the scoped fixture sets up and
+        #: dropped when it finalizes, so the per-test diff never blames a scope
+        #: transition (first/last test of a module/session) on the test (CI-8).
+        self._scoped_owned: dict[int, tuple[frozenset[str], bool]] = {}
+        #: Env keys / cwd released by a scoped fixture DURING the current test's
+        #: teardown (the last test of its scope). Reset each test; excluded from that
+        #: test's diff so the fixture's teardown is not mistaken for a per-test leak.
+        self._released_env: set[str] = set()
+        self._released_cwd = False
 
     @pytest.hookimpl(hookwrapper=True)
-    def pytest_runtest_setup(self, item: pytest.Item) -> "Generator[None, object]":  # noqa: PLR6301 — pytest invokes this hookimpl on the registered plugin INSTANCE; it must stay a method
+    def pytest_runtest_setup(self, item: pytest.Item) -> "Generator[None, object]":
         # Pre-yield: BEFORE this item's fixtures set up, so the baseline predates any
         # monkeypatch-managed env/cwd the fixtures install (they revert symmetrically).
         item.stash[_BEFORE_KEY] = Snapshot.capture()
+        # Reset the per-test "released by a scoped fixture" record: the last-in-scope
+        # teardown that fires during THIS test's teardown populates it (below).
+        self._released_env = set()
+        self._released_cwd = False
         yield
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_fixture_setup(self, fixturedef: "pytest.FixtureDef[object]") -> "Generator[None, object]":
+        # A module/session/class/package-scoped fixture sets up ONCE, during the first
+        # test that uses it — after that test's baseline snapshot. Record exactly the
+        # env keys / cwd it introduces so the per-test diff does not blame that first
+        # test for state the fixture owns. Function-scoped fixtures revert per-test and
+        # need no tracking (a broken one that leaks is a real per-test leak).
+        if getattr(fixturedef, "scope", "function") == "function":
+            yield
+            return
+        before = Snapshot.capture()
+        yield
+        owned = diff_snapshots(before, Snapshot.capture())
+        if not owned.is_empty:
+            self._scoped_owned[id(fixturedef)] = (owned.all_env_keys, owned.cwd_from is not None)
+
+    @pytest.hookimpl
+    def pytest_fixture_post_finalizer(self, fixturedef: "pytest.FixtureDef[object]") -> None:
+        # A scoped fixture tears down during the LAST test of its scope. Drop it from
+        # the active-ownership set and mark its keys/cwd as released THIS test, so that
+        # test's diff excludes the fixture's teardown (an ``env removed`` it owns) too.
+        owned = self._scoped_owned.pop(id(fixturedef), None)
+        if owned is None:
+            return
+        owned_env, owns_cwd = owned
+        self._released_env |= set(owned_env)
+        self._released_cwd = self._released_cwd or owns_cwd
+
+    def _scoped_ignored(self) -> tuple[frozenset[str], bool]:
+        """Env keys / cwd currently owned by an active scoped fixture, plus any released this test."""
+        active_env: set[str] = set(self._released_env)
+        active_cwd = self._released_cwd
+        for owned_env, owns_cwd in self._scoped_owned.values():
+            active_env |= set(owned_env)
+            active_cwd = active_cwd or owns_cwd
+        return frozenset(active_env), active_cwd
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_teardown(self, item: pytest.Item) -> "Generator[None, object]":
@@ -158,7 +231,13 @@ class LeakSentinelPlugin:
         before = item.stash.get(_BEFORE_KEY, None)
         if before is None:
             return
-        diff = diff_snapshots(before, Snapshot.capture())
+        scoped_env, scoped_cwd = self._scoped_ignored()
+        diff = diff_snapshots(
+            before,
+            Snapshot.capture(),
+            ignore=_VOLATILE_ENV_KEYS | scoped_env,
+            ignore_cwd=scoped_cwd,
+        )
         if diff.is_empty:
             return
         self.leaks.append((item.nodeid, diff))

--- a/tests/test_ci_durations_refresh_workflow.py
+++ b/tests/test_ci_durations_refresh_workflow.py
@@ -35,6 +35,12 @@ def _pr_step() -> dict[str, Any]:
     return matches[0]
 
 
+def _checkout_step() -> dict[str, Any]:
+    matches = [s for s in _steps() if "actions/checkout" in str(s.get("uses", ""))]
+    assert matches, "refresh-durations must have an actions/checkout step."
+    return matches[0]
+
+
 class TestRefreshBranchIsStable:
     """CI-3: a STABLE branch name means at most one open refresh PR, updated in place."""
 
@@ -54,3 +60,34 @@ class TestRefreshBranchIsStable:
                 "The refresh branch name must NOT embed the date — a dated branch opens a "
                 "NEW PR every unmerged day, stacking conflicting PRs (CI-3)."
             )
+
+
+class TestRefreshPrTriggersCi:
+    """CI-2: the refresh PR must be opened with a token that fires the required check."""
+
+    def test_pr_step_uses_the_pat_not_github_token(self) -> None:
+        gh_token = str(_pr_step().get("env", {}).get("GH_TOKEN", ""))
+        assert "TEATREE_GH_TOKEN" in gh_token, (
+            "The refresh-PR step must use TEATREE_GH_TOKEN so the PR triggers the required "
+            "test (3.13) check; the default GITHUB_TOKEN never fires it (un-mergeable PR)."
+        )
+        assert "github.token" not in gh_token, (
+            "GH_TOKEN must NOT be the default github.token — a PR/push it authenticates never "
+            "triggers downstream workflows, so the required check never runs (CI-2)."
+        )
+
+    def test_checkout_persists_the_pat_for_push(self) -> None:
+        token = str(_checkout_step().get("with", {}).get("token", ""))
+        assert "TEATREE_GH_TOKEN" in token, (
+            "The checkout must persist TEATREE_GH_TOKEN so the `git push` to the refresh "
+            "branch is attributed to a real identity and re-triggers CI on updates (CI-2)."
+        )
+
+    def test_pr_step_fails_loud_when_token_unset(self) -> None:
+        run = str(_pr_step().get("run", ""))
+        guard_msg = (
+            "The refresh-PR step must fail LOUD when the CI-triggering token is unset, rather "
+            "than silently opening a PR whose required check never fires (CI-2)."
+        )
+        assert 'if [ -z "${GH_TOKEN:-}" ]' in run, guard_msg
+        assert "exit 1" in run, guard_msg

--- a/tests/test_ci_durations_refresh_workflow.py
+++ b/tests/test_ci_durations_refresh_workflow.py
@@ -1,0 +1,56 @@
+"""The scheduled durations-refresh job must open ONE mergeable refresh PR (#3160).
+
+Two residual reliability bugs are pinned here against the workflow YAML.
+
+CI-3: the refresh branch name must be STABLE (reused + force-updated), so an unmerged
+refresh is updated in place instead of stacking a new dated PR every day.
+
+CI-2: the refresh PR must be created/pushed with a token that TRIGGERS the required
+``test (3.13)`` check (a PAT, ``TEATREE_GH_TOKEN``) — the default ``GITHUB_TOKEN`` never
+fires it, so such a PR could never merge unaided. The step also fails LOUD when that
+token is unset rather than silently opening an un-mergeable PR.
+"""
+
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _refresh_job() -> dict[str, Any]:
+    jobs = cast("dict[str, Any]", yaml.safe_load(_CI_WORKFLOW.read_text(encoding="utf-8"))["jobs"])
+    return cast("dict[str, Any]", jobs["refresh-durations"])
+
+
+def _steps() -> list[dict[str, Any]]:
+    return [s for s in _refresh_job().get("steps", []) if isinstance(s, dict)]
+
+
+def _pr_step() -> dict[str, Any]:
+    matches = [s for s in _steps() if "Open or update" in str(s.get("name", ""))]
+    assert matches, "refresh-durations must have an 'Open or update ... refresh PR' step."
+    return matches[0]
+
+
+class TestRefreshBranchIsStable:
+    """CI-3: a STABLE branch name means at most one open refresh PR, updated in place."""
+
+    def test_branch_name_is_not_dated(self) -> None:
+        run = str(_pr_step().get("run", ""))
+        assert 'BRANCH="ci/test-durations-refresh"' in run, (
+            "The refresh branch must be the STABLE name ci/test-durations-refresh so an "
+            "unmerged refresh is force-updated in place, not stacked as a new PR each day."
+        )
+
+    def test_branch_does_not_embed_the_date(self) -> None:
+        run = str(_pr_step().get("run", ""))
+        branch_lines = [line for line in run.splitlines() if line.strip().startswith("BRANCH=")]
+        assert branch_lines, "The PR step must assign a BRANCH variable."
+        for line in branch_lines:
+            assert "$(date" not in line, (
+                "The refresh branch name must NOT embed the date — a dated branch opens a "
+                "NEW PR every unmerged day, stacking conflicting PRs (CI-3)."
+            )

--- a/tests/test_ci_shuffle_lane_scope.py
+++ b/tests/test_ci_shuffle_lane_scope.py
@@ -1,0 +1,62 @@
+"""The order-dependence (shuffle) lane audits a curated, order-safe set (#3160 CI-4).
+
+The lane was scoped to ``tests/teatree_loop/`` alone. It is widened to every
+additional directory empirically verified order-safe under all four matrixed seeds,
+both standalone and shuffled together in one process. This pins the widened set so a
+future edit that silently narrows the lane back to the loop dir turns red here, and
+keeps the original loop dir (the #2359 Class B reproducer home) in scope.
+"""
+
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+# The directories empirically confirmed order-safe under shuffle (seeds 7/1/13/100),
+# both standalone and shuffled together as one -n0 process.
+_WIDENED_DIRS = (
+    "tests/teatree_loop/",
+    "tests/config/",
+    "tests/teatree_config/",
+    "tests/teatree_utils/",
+    "tests/utils/",
+    "tests/teatree_quality/",
+    "tests/messaging/",
+    "tests/cli_doctor/",
+    "tests/conformance/",
+    "tests/teatree_hooks/",
+)
+
+
+def _shuffle_run() -> str:
+    jobs = cast("dict[str, Any]", yaml.safe_load(_CI_WORKFLOW.read_text(encoding="utf-8"))["jobs"])
+    steps = [s for s in jobs["test-shuffle"]["steps"] if isinstance(s, dict)]
+    run_steps = [str(s.get("run", "")) for s in steps if "randomly" in str(s.get("run", ""))]
+    assert run_steps, "test-shuffle must have a step that runs pytest under -p randomly."
+    return run_steps[0]
+
+
+class TestShuffleLaneScope:
+    def test_still_includes_the_loop_reproducer_dir(self) -> None:
+        assert "tests/teatree_loop/" in _shuffle_run(), (
+            "The shuffle lane must keep tests/teatree_loop/ — the #2359 Class B "
+            "order-dependence reproducer lives there."
+        )
+
+    def test_lane_is_widened_beyond_the_loop_dir(self) -> None:
+        run = _shuffle_run()
+        for directory in _WIDENED_DIRS:
+            assert directory in run, (
+                f"The shuffle lane must audit {directory} — it was confirmed order-safe under "
+                "all four matrixed seeds (CI-4). A missing dir silently narrows the audit."
+            )
+
+    def test_runs_serially_under_shuffle(self) -> None:
+        # -n0 (serial) is load-bearing: xdist would isolate a polluter from its victim
+        # across workers, defeating the whole order-dependence audit.
+        run = _shuffle_run()
+        assert "-n0" in run, "The shuffle lane must run serially (-n0) so one in-process order is exercised."
+        assert "-p randomly" in run, "The shuffle lane must load pytest-randomly."

--- a/tests/test_durations_refresh.py
+++ b/tests/test_durations_refresh.py
@@ -10,7 +10,13 @@ from pathlib import Path
 
 import pytest
 
-from scripts.ci.durations_refresh import decide_refresh, load_durations, main, merge_durations
+from scripts.ci.durations_refresh import (
+    MissingShardDurationsError,
+    decide_refresh,
+    load_durations,
+    main,
+    merge_durations,
+)
 
 
 def _write(path: Path, data: dict[str, float]) -> Path:
@@ -28,8 +34,13 @@ class TestMergeDurations:
             "tests/y.py::t3": 3.0,
         }
 
-    def test_missing_file_contributes_nothing(self, tmp_path: Path) -> None:
-        assert merge_durations([tmp_path / "absent.json"]) == {}
+    def test_missing_shard_file_raises_loud(self, tmp_path: Path) -> None:
+        # A missing shard is NOT an empty contribution: the four shards partition the
+        # suite, so silently dropping one truncates the merge by ~1/4. Fail loud.
+        present = _write(tmp_path / "present.json", {"tests/x.py::t1": 1.0})
+        absent = tmp_path / "absent.json"
+        with pytest.raises(MissingShardDurationsError, match="shard-durations file is absent"):
+            merge_durations([present, absent])
 
     def test_load_reads_floats(self, tmp_path: Path) -> None:
         assert load_durations(_write(tmp_path / "d.json", {"t": 4})) == {"t": 4.0}
@@ -91,3 +102,20 @@ class TestMainCli:
 
     def test_usage_error_without_shard_paths(self) -> None:
         assert main([]) == 2
+
+    def test_missing_shard_fails_loud_and_leaves_file_untouched(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # A truncated 3-of-4 merge must NEVER be written or PR'd. The absent shard
+        # errors the job (rc != 0), the committed file is preserved, and no refresh
+        # verdict is emitted (the PR-open step is gated on `refresh=true`).
+        durations = _write(tmp_path / ".test_durations", {"t1": 1.0})
+        present = _write(tmp_path / "shard-1.json", {"t1": 1.0, "t2": 2.0})
+        absent = tmp_path / "shard-2.json"
+        output = tmp_path / "gh_output"
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+        rc = main([str(durations), str(present), str(absent)])
+        assert rc == 1
+        assert json.loads(durations.read_text(encoding="utf-8")) == {"t1": 1.0}
+        assert "shard-2.json" in capsys.readouterr().err
+        assert not output.exists() or "refresh=" not in output.read_text(encoding="utf-8")

--- a/tests/test_leak_sentinel_plugin.py
+++ b/tests/test_leak_sentinel_plugin.py
@@ -52,6 +52,16 @@ class TestDiffSnapshots:
     def test_empty_diff_describes_to_empty_string(self) -> None:
         assert LeakDiff((), (), (), None, None).describe() == ""
 
+    def test_all_env_keys_unions_added_removed_changed(self) -> None:
+        before = Snapshot(env={"GONE": "1", "MUT": "2"}, cwd="/tmp")
+        after = Snapshot(env={"NEW": "9", "MUT": "changed"}, cwd="/tmp")
+        assert diff_snapshots(before, after).all_env_keys == frozenset({"NEW", "GONE", "MUT"})
+
+    def test_ignore_cwd_suppresses_the_cwd_delta(self) -> None:
+        diff = diff_snapshots(Snapshot(env={}, cwd="/a"), Snapshot(env={}, cwd="/b"), ignore_cwd=True)
+        assert diff.cwd_from is None
+        assert diff.is_empty
+
 
 _LEAKY_SUITE = """
 import os
@@ -70,6 +80,97 @@ def test_clean(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)                     # monkeypatch reverts -> not a leak
     assert True
 """
+
+
+# A module-scoped fixture sets+restores an env var and cwd; the sentinel must NOT
+# blame the first test for its setup nor the last for its teardown. A genuine per-test
+# leak sits in the middle and MUST still be named (anti-vacuous both directions).
+_SCOPED_FIXTURE_SUITE = """
+import os
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _module_env(tmp_path_factory):
+    origin = os.getcwd()
+    target = tmp_path_factory.mktemp("modcwd")
+    os.environ["_MODULE_SCOPED"] = "on"   # set ONCE at module setup (first test)...
+    os.chdir(target)
+    try:
+        yield
+    finally:
+        os.chdir(origin)                  # ...restored ONCE at module teardown (last test)
+        del os.environ["_MODULE_SCOPED"]
+
+
+def test_first():
+    assert os.environ["_MODULE_SCOPED"] == "on"
+
+
+def test_middle_leaks():
+    os.environ["_PER_TEST_LEAK"] = "dirty"   # genuine per-test leak -> POLLUTER
+
+
+def test_last():
+    assert os.environ["_MODULE_SCOPED"] == "on"
+"""
+
+
+# Only a well-behaved module-scoped fixture, no per-test leak: error mode must stay
+# GREEN. Before the scope-aware fix this red'd the first + last test (env/cwd added on
+# setup, removed on teardown), so a passing run here proves the false positive is gone.
+_SCOPED_CLEAN_SUITE = """
+import os
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _module_env():
+    os.environ["_MODULE_SCOPED"] = "on"
+    try:
+        yield
+    finally:
+        del os.environ["_MODULE_SCOPED"]
+
+
+def test_a():
+    assert os.environ["_MODULE_SCOPED"] == "on"
+
+
+def test_b():
+    assert os.environ["_MODULE_SCOPED"] == "on"
+"""
+
+
+def _run_suite_source(tmp_path: Path, source: str, mode: str) -> subprocess.CompletedProcess[str]:
+    (tmp_path / "test_toy_leaks.py").write_text(source, encoding="utf-8")
+    env = dict(_clean_env())
+    env["PYTHONPATH"] = str(_REPO_ROOT)
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "test_toy_leaks.py",
+            "-p",
+            "scripts.ci.leak_sentinel_plugin",
+            "-p",
+            "no:randomly",
+            f"--leak-sentinel={mode}",
+            "-p",
+            "no:cacheprovider",
+            "-p",
+            "no:xdist",
+            "-o",
+            "addopts=",
+            "-q",
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
 
 def _run_toy_suite(tmp_path: Path, mode: str, *, xdist_workers: int = 0) -> subprocess.CompletedProcess[str]:
@@ -156,6 +257,40 @@ class TestSentinelUnderXdist:
         combined = result.stdout + result.stderr
         assert result.returncode != 0, combined
         assert "leaked process-global state" in combined, combined
+
+
+@pytest.mark.integration
+class TestSentinelIgnoresScopedFixtures:
+    """A module/session-scoped fixture that sets+restores state is NOT a polluter (CI-8).
+
+    The per-test snapshot boundary is asymmetric for a scoped fixture: it sets up during
+    the first test (after that test's baseline) and tears down during the last (before
+    that test's final), so a naive diff blames the first test for the ``env added`` and
+    the last for the ``env removed`` the fixture legitimately owns. The scope-aware
+    tracking excludes those, while a genuine per-test leak is still named.
+    """
+
+    def test_scoped_fixture_not_flagged_but_per_test_leak_is(self, tmp_path: Path) -> None:
+        result = _run_suite_source(tmp_path, _SCOPED_FIXTURE_SUITE, "warn")
+        combined = result.stdout + result.stderr
+        assert result.returncode == 0, combined
+        # The module-scoped fixture's env var + cwd are its own — never a polluter.
+        assert "_MODULE_SCOPED" not in combined, combined
+        assert "test_first" not in combined.split("leak sentinel")[-1], combined
+        assert "test_last" not in combined.split("leak sentinel")[-1], combined
+        # ...but the genuine per-test leak in the middle IS named.
+        assert "POLLUTER test_toy_leaks.py::test_middle_leaks" in combined, combined
+        assert "_PER_TEST_LEAK" in combined, combined
+
+    def test_clean_scoped_fixture_suite_passes_error_mode(self, tmp_path: Path) -> None:
+        # Anti-vacuous the other direction: with only a well-behaved module fixture and
+        # NO per-test leak, error mode stays green. On the pre-fix code the first + last
+        # test errored on the scoped setup/teardown, so this run would have been RED.
+        result = _run_suite_source(tmp_path, _SCOPED_CLEAN_SUITE, "error")
+        combined = result.stdout + result.stderr
+        assert result.returncode == 0, combined
+        assert "leaked process-global state" not in combined, combined
+        assert "_MODULE_SCOPED" not in combined, combined
 
 
 def _clean_env() -> dict[str, str]:


### PR DESCRIPTION
Fixes the CI-throughput residual cluster from the final holistic review — five reliability bugs in the #3160 faster-and-better CI machinery. One commit per finding; each Python fix ships an anti-vacuous test.

## CI-3 (MEDIUM) — daily durations-refresh opened a NEW PR every unmerged day
The refresh branch embedded the date (`chore/refresh-test-durations-YYYY-MM-DD`), so every day a prior refresh sat unmerged it opened another conflicting PR. Now uses a STABLE branch (`ci/test-durations-refresh`) that is reused and force-updated, so at most one refresh PR is ever open and an unmerged one is updated in place. Matches the existing "single refresh PR" intent in the surrounding comment.
Evidence: `tests/test_ci_durations_refresh_workflow.py::TestRefreshBranchIsStable`.

## CI-2 (LOW) — refresh PR created with default GITHUB_TOKEN so required CI never triggered
A branch pushed / PR opened with `GITHUB_TOKEN` never fires the required `test (3.13)` check (GitHub's recursion guard), so the refresh PR could never merge unaided. Now created and pushed with `TEATREE_GH_TOKEN` — the PAT the repo already carries (`deploy-hetzner.yml`) — via the checkout token and `GH_TOKEN`, so the push and PR are attributed to a real identity and trigger the required check. The step fails LOUD when the token is unset instead of silently opening an un-mergeable PR. Combined with CI-3, a force-update to the stable branch re-fires CI on the one open refresh PR.
Evidence: `tests/test_ci_durations_refresh_workflow.py::TestRefreshPrTriggersCi`.

## CI-5 (LOW) — a missing shard-durations file silently yielded a truncated durations file
`merge_durations` treated an absent shard file as an empty dict, so a 3-of-4 merge (a failed artifact upload/download) silently produced — and PR'd — a durations file missing ~1/4 of the suite, unbalancing the shard split. The four shards partition the suite, so a missing shard is now a hard error: `merge_durations` raises `MissingShardDurationsError` and the CLI exits non-zero without touching the committed file or emitting a refresh verdict. The committed-baseline load stays tolerant.
Evidence: `tests/test_durations_refresh.py` (merge raises; CLI fails loud and leaves the file untouched). Anti-vacuous: the old code returned `{}`.

## CI-8 (LOW) — leak sentinel false-positived on module/session-scoped fixtures
The per-test snapshot boundary is asymmetric for a scoped fixture: it sets up during the first test using it and tears down during the last, so the naive diff blamed the first test for the `env added` and the last for the `env removed` the fixture legitimately owns. The plugin now tracks each non-function-scoped fixture's owned env keys / cwd via `pytest_fixture_setup` / `pytest_fixture_post_finalizer` and excludes them from the per-test leak; a genuine per-test leak is owned by no scoped fixture and is still named. Built on the current (CI-1 xdist fan-in) version — the fan-in is preserved.
Evidence: `tests/test_leak_sentinel_plugin.py::TestSentinelIgnoresScopedFixtures` — anti-vacuous both directions (a clean module-fixture suite passes in error mode; a per-test leak is still flagged). RED-before-fix confirmed: the old plugin errored `test_a`/`test_b` on the module fixture.

## CI-4 (LOW) — shuffle order-dependence gate scoped to one directory
The plan's step 1 (fix import-time DB seeding, then widen suite-wide) is a larger separate effort, so — per the finding's guidance not to half-do it — this widens to the additional directories empirically confirmed order-safe instead.

**Widened to** (alongside the original `tests/teatree_loop/`): `config`, `teatree_config`, `teatree_utils`, `utils`, `teatree_quality`, `messaging`, `cli_doctor`, `conformance`, `teatree_hooks`. Each confirmed order-safe under ALL four matrixed seeds (7/1/13/100), both standalone and shuffled TOGETHER in one `-n0` process (the cross-directory polluter→victim adjacency): 6031 tests, ~4:35–6:40 per seed, well under the 20-min cap. `teatree_hooks` is high-value — hooks mutate process-global env/cwd most often.

**Stays scoped-out** (documented in the ci.yml comment, not silent): `teatree_core`, `teatree_cli`, `teatree_loops`, `teatree_backends`, `teatree_agents`, `eval_replay`, `integration`, `django_db`, and the rest — not yet verified order-safe under shuffle; widening them requires the import-time-DB-seeding audit (plan step 1).
Evidence: `tests/test_ci_shuffle_lane_scope.py`.

## Verify
- `uv run ruff check` — All checks passed.
- All workflow YAML parses (`yaml.safe_load` over `.github/workflows/*.yml`).
- 35 new/changed tests pass; anti-vacuity confirmed for CI-5 and CI-8.
- Empirical shuffle runs on the widened set green across seeds 7/1/13/100.
- Pre-push leak gates (banned-terms, gitleaks, no-overlay-leak, #685 public-push) all passed; no `--no-verify`.
