### PR TITLE
docs(config): correct stale config_agent path to config.agent_spawn (§10.1.2)

### DIFF
--- a/docs/blueprint/configuration.md
+++ b/docs/blueprint/configuration.md
@@ -495,7 +495,7 @@ t3 <overlay> config_setting set privacy '"strict"' --overlay client-project
 
 The `[agent]` table holds the model/effort settings for spawned sub-agents and
 the interactive main agent. It is read with a raw `tomllib` parse
-(`config_agent.resolve_agent_config` + `model_tiering._load_phase_model_overrides`),
+(`config.agent_spawn.resolve_agent_config` + `model_tiering._load_phase_model_overrides`),
 independent of the per-overlay `[teatree]` merge — these are session-scoped
 spawn inputs, not overridable `UserSettings`.
 


### PR DESCRIPTION
## What

Correct a single stale module reference in the BLUEPRINT configuration appendix.
`docs/blueprint/configuration.md` §10.1.2 still named `config_agent.resolve_agent_config`
as the reader of the `[agent]` TOML table.

## Why

Unit 9 (landed in #3146) did a verbatim move of `src/teatree/config_agent.py` →
`src/teatree/config/agent_spawn.py` and deleted the old module. The live reader is
now `config.agent_spawn.resolve_agent_config` (verified at `src/teatree/config/agent_spawn.py:289`);
`config_agent` survives in `src/` only as a comment in `core/modelkit/phases.py`.
The stale prose reference violates the repo's own **no-stale-references** rule
(CLAUDE.md § "No stale references") and is exactly the docs-truth (DT) class the
redesign burndown targeted — this was the last residual occurrence in any
hand-written prose surface (grep across `docs/`, `skills/`, `BLUEPRINT.md`,
`README.md` is now clean).

## Testing

Pure documentation change, no `src`/migration/coverage impact. `prek run --files
docs/blueprint/configuration.md` green (banned-terms, secret-scan, overlay-name,
codespell, ty-check, tach, README-catalogue drift); pre-commit + pre-push leak
gates green.
