### PR TITLE
fix(evals): throttle-aware retry + AIMD concurrency for the metered api runner

### DIFF
--- a/src/teatree/eval/api_errors.py
+++ b/src/teatree/eval/api_errors.py
@@ -8,9 +8,13 @@ and defines the trajectory-carrying exceptions (:class:`TerminalResultError`,
 :class:`SuccessMislabelResultError`) the runner raises mid-stream and grades.
 """
 
+import dataclasses
 import re
+from enum import Enum
 
 from claude_agent_sdk import Message
+
+from teatree.llm.anthropic_limits import LimitCause, classify_limit, window_horizon
 
 BUDGET_EXCEEDED_REASON = "budget_exceeded"
 MAX_TURNS_REASON = "max_turns"
@@ -73,6 +77,95 @@ def is_success_result_error(message: str) -> bool:
     ``result`` event is already in the captured messages).
     """
     return _SUCCESS_RESULT_MARKER in message
+
+
+class ThrottleKind(Enum):
+    """The retry disposition a transient throttle demands.
+
+    ``TRANSIENT`` clears within minutes (a 429, an overloaded 529, a dropped
+    stream, a generic under-load exit-1) and is ridden out with fast exponential
+    backoff. ``SUSTAINED`` is a rolling subscription-window cap that needs a
+    (bounded) window wait before the token frees up.
+    """
+
+    TRANSIENT = "transient"
+    SUSTAINED = "sustained"
+
+
+@dataclasses.dataclass(frozen=True)
+class ThrottleSignal:
+    """A throttle graded from a raw SDK error message: its kind, cause, and wait.
+
+    ``cause`` is the classified :class:`~teatree.llm.anthropic_limits.LimitCause`
+    when a limit phrase matched, else ``None`` for a generic transient drop.
+    ``wait_seconds`` carries the SUSTAINED window horizon (the caller clamps it to
+    a bounded cap); it is ``None`` for a TRANSIENT signal, which uses the caller's
+    exponential backoff instead.
+    """
+
+    kind: ThrottleKind
+    cause: LimitCause | None
+    wait_seconds: float | None
+
+
+#: Substrings marking a TRANSIENT throttle/transport signal the phrase taxonomy
+#: does not carry. Kept DELIBERATELY specific: an OPAQUE SDK error result with no
+#: recognizable throttle signature is NOT laundered into a retry — it re-raises as
+#: a genuine crash (the "preserve the genuine-crash red" contract). ``overloaded``
+#: is HTTP 529; ``too many requests`` / ``rate_limit_error`` are the 429 status
+#: text and API error type; the rest are dropped-stream signatures under load.
+_TRANSIENT_INFRA_MARKERS: tuple[str, ...] = (
+    "overloaded",
+    "too many requests",
+    "rate_limit_error",
+    "connection error",
+    "connection reset",
+    "connection aborted",
+    "server disconnected",
+    "peer closed connection",
+    "incomplete read",
+    "stream error",
+    "read timed out",
+)
+
+#: Limit causes that are NEVER a retriable throttle: a $0 metered key has no
+#: time-based recovery (fail loud), and a 7-day weekly cap is never worth waiting
+#: out inside a single run (surface loud). The remaining causes ARE retriable —
+#: RATE_LIMIT as TRANSIENT, SUBSCRIPTION_SESSION as a bounded SUSTAINED window wait.
+_NEVER_RETRY_CAUSES: frozenset[LimitCause] = frozenset({LimitCause.API_CREDIT, LimitCause.SUBSCRIPTION_WEEKLY})
+
+
+def _throttle_from_limit(cause: LimitCause) -> ThrottleSignal | None:
+    """Map a matched limit *cause* to its retry disposition, or ``None`` when never-retriable."""
+    if cause in _NEVER_RETRY_CAUSES:
+        return None
+    if cause is LimitCause.SUBSCRIPTION_SESSION:
+        horizon = window_horizon(cause)
+        wait = horizon.total_seconds() if horizon is not None else None
+        return ThrottleSignal(kind=ThrottleKind.SUSTAINED, cause=cause, wait_seconds=wait)
+    return ThrottleSignal(kind=ThrottleKind.TRANSIENT, cause=cause, wait_seconds=None)
+
+
+def classify_transient_throttle(message: str) -> ThrottleSignal | None:
+    """Grade an SDK error *message* into a retry disposition, or ``None`` if not a throttle.
+
+    Returns a :class:`ThrottleSignal` for a retriable throttle and ``None`` for
+    everything the runner must NOT ride out: a genuine behavioral cap
+    (budget/max-turns — the anti-cheat boundary), a credit exhaustion or weekly
+    cap (surface loud), a mislabeled success, or a real crash. A matched limit
+    phrase drives the disposition (RATE_LIMIT -> TRANSIENT, SUBSCRIPTION_SESSION ->
+    SUSTAINED); otherwise a transient infra marker (:data:`_TRANSIENT_INFRA_MARKERS`)
+    grades an unclassified transport/overload signal as TRANSIENT.
+    """
+    if is_success_result_error(message) or classify_terminal_error(message) is not None:
+        return None
+    limit = classify_limit(message)
+    if limit is not None:
+        return _throttle_from_limit(limit.cause)
+    haystack = message.casefold()
+    if any(marker in haystack for marker in _TRANSIENT_INFRA_MARKERS):
+        return ThrottleSignal(kind=ThrottleKind.TRANSIENT, cause=None, wait_seconds=None)
+    return None
 
 
 def budget_amount_from_message(message: str) -> float | None:

--- a/src/teatree/eval/api_runner.py
+++ b/src/teatree/eval/api_runner.py
@@ -37,6 +37,7 @@ The async ``query`` is bridged to the sync :meth:`ApiInProcessRunner.run` via
 
 import asyncio
 import dataclasses
+import functools
 import os
 import shutil
 import time
@@ -68,6 +69,7 @@ from teatree.eval.models import CLEAN_ROOM_LANE, CLEAN_ROOM_MIN_TURNS, EvalRun, 
 from teatree.eval.production_hooks import has_hook_events, hooked_env, t3_plugin, teatree_root
 from teatree.eval.prompt_framing import LIVE_ENV_FRAMING
 from teatree.eval.system_prompt_file import spill_system_prompt
+from teatree.eval.throttle_retry import THROTTLE_MAX_ATTEMPTS, ThrottleRetryDriver, ThrottleRetryHandlers
 from teatree.eval.toolset import (
     build_delegation_agents,
     compute_available_tools,
@@ -424,10 +426,12 @@ def load_agent_definition(agent_path: str, agent_sections: tuple[str, ...] = ())
 class ApiRunnerParams:
     """The construction knobs for :class:`ApiInProcessRunner`, grouped into one object.
 
-    Six knobs threaded one runner-construction concern each. Grouping them here
-    keeps the constructor a single parameter (so ``ApiInProcessRunner`` no longer
-    trips the too-many-arguments bar) and gives ``make_runner`` one value to build
-    and thread from the ``t3 eval run`` CLI.
+    Threads one runner-construction concern each. Grouping them here keeps the
+    constructor a single parameter (so ``ApiInProcessRunner`` no longer trips the
+    too-many-arguments bar) and gives ``make_runner`` one value to build and thread
+    from the ``t3 eval run`` CLI. The final three (``sleep``, ``rand``,
+    ``throttle_max_attempts``) are the transient-throttle-retry seams — injectable
+    so the bounded backoff is testable without real time or a real RNG.
     """
 
     #: ``None`` (the CI/production path, where ``make_runner`` passes no workspace
@@ -448,6 +452,15 @@ class ApiRunnerParams:
     #: resolved eval credential's ``spec.conflicting_vars``; the default preserves
     #: the pre-#2707-reversal metered strip for direct callers.
     conflicting_vars: tuple[str, ...] = _DEFAULT_CONFLICTING_VARS
+    #: Throttle-retry seams threaded to :class:`~teatree.eval.throttle_retry.ThrottleRetryDriver`.
+    #: ``sleep`` / ``rand`` (the jitter RNG returning ``[0, 1)``) are injectable so a
+    #: test asserts the backoff schedule without real time or a real RNG; ``None``
+    #: keeps the driver's defaults (real time / a system RNG). ``throttle_max_attempts``
+    #: ``None`` resolves to the env-overridable
+    #: :data:`~teatree.eval.throttle_retry.THROTTLE_MAX_ATTEMPTS` (``0`` disables retry).
+    sleep: Callable[[float], None] | None = None
+    rand: Callable[[], float] | None = None
+    throttle_max_attempts: int | None = None
 
 
 class ApiInProcessRunner:
@@ -461,6 +474,15 @@ class ApiInProcessRunner:
         self._max_budget_usd = params.max_budget_usd
         self._effort = params.effort
         self._conflicting_vars = params.conflicting_vars
+        max_attempts = (
+            params.throttle_max_attempts if params.throttle_max_attempts is not None else THROTTLE_MAX_ATTEMPTS
+        )
+        driver = ThrottleRetryDriver(max_attempts=max_attempts)
+        if params.sleep is not None:
+            driver = dataclasses.replace(driver, sleep=params.sleep)
+        if params.rand is not None:
+            driver = dataclasses.replace(driver, rand=params.rand)
+        self._retry = driver
 
     def _resolve_max_turns(self, spec: EvalSpec) -> int:
         """Override wins; else a clean-room budget is floored to :data:`CLEAN_ROOM_MIN_TURNS`."""
@@ -491,37 +513,41 @@ class ApiInProcessRunner:
         clean_room_prompt = load_agent_definition(spec.agent_path, spec.agent_sections) + LIVE_ENV_FRAMING
         system_prompt = build_system_prompt(spec, clean_room_prompt=clean_room_prompt)
         max_turns = self._resolve_max_turns(spec)
-        try:
-            messages = asyncio.run(self._drive(spec, system_prompt=system_prompt, max_turns=max_turns))
-        except TimeoutError:
-            return self._terminal_run(spec, terminal_reason="timeout")
-        except TerminalResultError as terminal:
-            return self._terminal_capped_run(spec, terminal)
-        except SuccessMislabelResultError as mislabel:
-            return self._success_mislabel_run(spec, mislabel)
+
+        def _drive_once() -> list[Message]:
+            return asyncio.run(self._drive(spec, system_prompt=system_prompt, max_turns=max_turns))
+
+        handlers = ThrottleRetryHandlers(
+            grade_success=functools.partial(self._grade_success, spec),
+            grade_cap=functools.partial(self._terminal_capped_run, spec),
+            grade_mislabel=functools.partial(self._success_mislabel_run, spec),
+            # A throttle that outlasted its retry budget surfaces loud as an errored
+            # run stamped with the retry count (visible to the AIMD governor).
+            surface_throttled=lambda reason, retries: dataclasses.replace(
+                self._terminal_run(spec, terminal_reason=reason), throttle_retries=retries
+            ),
+        )
+        return self._retry.run(_drive_once, handlers)
+
+    def _grade_success(self, spec: EvalSpec, messages: list[Message], retries: int) -> EvalRun:
+        # A hooked run that captured ZERO hook events means the shipped plugin did
+        # NOT register (the lane silently degraded to raw-model measurement) — fail
+        # loud rather than report a spurious pass. Otherwise grade the trajectory and
+        # carry the retry count for the AIMD governor.
         if spec.production_hooks and not has_hook_events(messages):
-            # A hooked run that captured ZERO hook events means the shipped plugin
-            # did NOT register — the lane silently degraded back to raw-model
-            # measurement. Fail loud (is_error) rather than report a spurious pass,
-            # mirroring the all-skipped gate's philosophy.
             return self._terminal_run(spec, terminal_reason="hooks_not_registered")
-        return eval_run_from_messages(spec, messages)
+        run = eval_run_from_messages(spec, messages)
+        return dataclasses.replace(run, throttle_retries=retries) if retries else run
 
     def _terminal_capped_run(self, spec: EvalSpec, terminal: TerminalResultError) -> EvalRun:
-        """Grade a run the SDK terminated at a known cap (budget/max-turns).
+        """Grade a run the SDK capped (budget/max-turns) on its REAL partial trajectory.
 
-        When the agent produced a trajectory before the cap, grade the REAL
-        trajectory: build via :func:`eval_run_from_messages` so the matchers
-        decide pass/fail on what the agent actually did, then stamp the classified
-        ``terminal_reason`` (so the renderer shows ``max_turns``/``budget_exceeded``)
-        and clear ``is_error`` — a capped run that satisfied its matchers must not
-        be forced to FAIL; the cap is surfaced via ``terminal_reason``, not by
-        marking the run errored. Recover cost from the message's ``($X)`` (budget),
-        else from any captured ``ResultMessage`` cost; when neither names a cost (a
-        max-turns run with no metered result) cost is ``0.0``, with the
-        ``terminal_reason`` making the incompleteness visible. Only when NOTHING
-        was captured does it fall back to the empty :meth:`_terminal_run` shape —
-        whose budget cost floors to the cap, the existing over-budget behavior.
+        A capped run that satisfied its matchers must not be forced to FAIL: grade the
+        captured messages, stamp the classified ``terminal_reason``, and clear
+        ``is_error`` (the cap is surfaced via ``terminal_reason``, not the error flag).
+        Cost comes from the message's ``($X)``, else a captured ``ResultMessage``, else
+        ``0.0``; a run that captured NOTHING falls back to the empty
+        :meth:`_terminal_run` (whose budget cost floors to the cap).
         """
         message_amount = budget_amount_from_message(str(terminal.cause))
         if not terminal.messages:
@@ -543,16 +569,12 @@ class ApiInProcessRunner:
 
     @staticmethod
     def _success_mislabel_run(spec: EvalSpec, mislabel: SuccessMislabelResultError) -> EvalRun:
-        """Grade a finished SUCCESS the CLI mislabeled by exiting non-zero.
+        """Grade a finished SUCCESS the CLI mislabeled by exiting non-zero on the ``success`` subtype.
 
-        The captured ``result`` event reads ``subtype="success"`` but carries a
-        stray ``is_error=True`` (the CLI exited non-zero on the success subtype).
-        Grade the REAL trajectory via :func:`eval_run_from_messages` so the
-        matchers decide pass/fail, then clear ``is_error`` — exactly the correction
-        :meth:`_terminal_capped_run` applies — so a finished, all-matchers-pass run
-        is not forced to FAIL on the flag alone (:attr:`ScenarioResult.passed` fails
-        on ``is_error`` BEFORE consulting matchers). The ``terminal_reason`` already
-        reads ``success`` and is left untouched — this is a finished run, not a cap.
+        The captured trajectory is graded and ``is_error`` cleared (the same correction
+        :meth:`_terminal_capped_run` applies), so a finished, all-matchers-pass run is
+        not forced to FAIL on the stray flag alone — ``ScenarioResult.passed`` fails on
+        ``is_error`` BEFORE consulting matchers.
         """
         graded = eval_run_from_messages(spec, mislabel.messages)
         return dataclasses.replace(graded, is_error=False)
@@ -595,25 +617,15 @@ class ApiInProcessRunner:
     def _resolve_eval_target(self, spec: EvalSpec) -> Iterator[tuple[Path, str, dict[str, str]]]:
         """Yield ``(workspace, cwd, env)`` — ISOLATED to a throwaway for spawning scenarios.
 
-        A non-spawning scenario keeps the existing clean-room shape: the
-        configured ``workspace``, the :func:`isolated_claude_env` neutral cwd, and
-        the personal-context-redirected env.
-
-        A SUB-AGENT-SPAWNING scenario (:func:`scenario_exposes_subagent_spawn`)
-        additionally runs against a per-run EPHEMERAL CHECKOUT: ``workspace`` (the
-        SDK ``add_dirs`` grant) and ``cwd`` both point at the throwaway, and the env
-        is overlaid by :func:`ephemeral_checkout_env` so ``import teatree`` and
-        ``git`` resolve into the throwaway rather than the developer's real clone.
-        Without this, a spawned sub-agent locates the real clone via the editable
-        install + shared ``.git`` (a neutral cwd does NOT block that) and does
-        destructive git work on it — the corruption this isolation prevents.
-
-        A scenario declaring ``cli_stubs`` additionally gets a throwaway ``bin/`` of
-        inert CLI stubs prepended to ``PATH`` (a SEPARATE lever from ``fixture``, so
-        the two compose): the correct ``t3``/``gh``/``glab`` command resolves and
-        exits 0 instead of erroring, so the agent stops rather than wandering into a
-        ``max_turns`` cap-taint. The stubs hold no state; the matchers still grade
-        the CALL, so negatives keep full teeth.
+        A non-spawning scenario keeps the clean-room shape (configured ``workspace``,
+        neutral :func:`isolated_claude_env` cwd, personal-context-redirected env). A
+        SUB-AGENT-SPAWNING scenario additionally runs against a per-run EPHEMERAL
+        CHECKOUT so a spawned sub-agent cannot reach the developer's real clone via the
+        editable install + shared ``.git`` and do destructive git work on it — the
+        corruption this isolation exists to prevent. A ``cli_stubs`` scenario also gets a
+        throwaway ``bin/`` of inert stubs on ``PATH`` (composes with ``fixture``) so the
+        correct ``t3``/``gh``/``glab`` exits 0 instead of wandering into a cap-taint; the
+        matchers still grade the CALL, so negatives keep full teeth.
         """
         with ExitStack() as stack:
             env, cwd = stack.enter_context(isolated_claude_env(self._conflicting_vars))

--- a/src/teatree/eval/models.py
+++ b/src/teatree/eval/models.py
@@ -432,3 +432,9 @@ class EvalRun:
     #: carry no hook stream). Additive: the report reads it to annotate a
     #: gate-assisted pass; grading never consults it.
     gate_events: tuple[GateEvent, ...] = ()
+    #: Count of transient-throttle retries this run rode out before it completed
+    #: (0 on a run that hit no rate limit). The AIMD concurrency governor
+    #: (``parallel.py``) reads it as the throttle signal: ``>0`` multiplicatively
+    #: shrinks the shared permit count, ``0``-and-clean grows it back — so a
+    #: throttled suite backs its parallel load off the single shared OAuth token.
+    throttle_retries: int = 0

--- a/src/teatree/eval/parallel.py
+++ b/src/teatree/eval/parallel.py
@@ -24,7 +24,10 @@ the dead key), so it is NOT swallowed into per-scenario reds — it propagates p
 
 import concurrent.futures
 import threading
+import time
 import traceback
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 
 from teatree.eval.backends import EvalRunner
 from teatree.eval.models import EvalRun, EvalSpec
@@ -37,6 +40,95 @@ _SUITE_ABORTED_MESSAGE = "suite aborted: a prior scenario exhausted the metered 
 
 DEFAULT_PARALLEL = 1
 MAX_PARALLEL = 20
+
+#: AIMD concurrency-governor tuning. A throttle event MULTIPLICATIVELY halves the
+#: permit ceiling toward :data:`CONCURRENCY_FLOOR`; :data:`GROW_AFTER_CLEARS`
+#: consecutive clean completions ADDITIVELY grow it one step back toward the worker
+#: count. :data:`SHRINK_COOLDOWN_SECONDS` keeps a burst of near-simultaneous
+#: throttles from collapsing the ceiling in a single step.
+CONCURRENCY_FLOOR = 1
+GROW_AFTER_CLEARS = 3
+SHRINK_COOLDOWN_SECONDS = 5.0
+
+
+class ConcurrencyGovernor:
+    """An AIMD ceiling over the concurrent in-flight runs, shared across the pool.
+
+    Standard congestion control for the metered lane's ONE shared OAuth token: the
+    permit ceiling starts at the worker count and each :meth:`slot` acquisition
+    blocks while the in-flight count is already at the ceiling. A throttle event (a
+    run that rode out >=1 Layer-2 retry, i.e. ``throttle_retries > 0``)
+    MULTIPLICATIVELY halves the ceiling toward :data:`CONCURRENCY_FLOOR`;
+    :data:`GROW_AFTER_CLEARS` consecutive clean completions ADDITIVELY grow it one
+    step back toward the worker count. A genuine (non-throttle) error is neutral —
+    it neither shrinks nor grows. The floor of 1 guarantees forward progress, so
+    the governor can never deadlock the pool.
+    """
+
+    def __init__(
+        self,
+        workers: int,
+        *,
+        floor: int = CONCURRENCY_FLOOR,
+        grow_after: int = GROW_AFTER_CLEARS,
+        cooldown: float = SHRINK_COOLDOWN_SECONDS,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._workers = workers
+        self._floor = max(1, min(floor, workers))
+        self._grow_after = grow_after
+        self._cooldown = cooldown
+        self._clock = clock
+        self._limit = workers
+        self._active = 0
+        self._clean_streak = 0
+        self._last_shrink = float("-inf")
+        self._cond = threading.Condition()
+
+    @property
+    def limit(self) -> int:
+        with self._cond:
+            return self._limit
+
+    @contextmanager
+    def slot(self) -> Iterator[None]:
+        with self._cond:
+            while self._active >= self._limit:
+                self._cond.wait()
+            self._active += 1
+        try:
+            yield
+        finally:
+            with self._cond:
+                self._active -= 1
+                self._cond.notify_all()
+
+    def record_completion(self, run: EvalRun) -> None:
+        """Feed a finished run's throttle signal into the ceiling: shrink, grow, or neutral."""
+        if run.throttle_retries > 0:
+            self._shrink()
+        elif not run.is_error:
+            self._grow()
+
+    def _shrink(self) -> None:
+        with self._cond:
+            now = self._clock()
+            if now - self._last_shrink < self._cooldown:
+                return
+            self._last_shrink = now
+            self._clean_streak = 0
+            self._limit = max(self._floor, self._limit // 2)
+            self._cond.notify_all()
+
+    def _grow(self) -> None:
+        with self._cond:
+            self._clean_streak += 1
+            if self._clean_streak < self._grow_after:
+                return
+            self._clean_streak = 0
+            if self._limit < self._workers:
+                self._limit += 1
+                self._cond.notify_all()
 
 
 def run_specs(runner: EvalRunner, specs: list[EvalSpec], *, parallel: int = DEFAULT_PARALLEL) -> list[EvalRun]:
@@ -63,15 +155,22 @@ def run_specs(runner: EvalRunner, specs: list[EvalSpec], *, parallel: int = DEFA
     # though every spec was submitted to the pool up front (workers pull from the
     # queue faster than the consumer could cancel them otherwise).
     aborted = threading.Event()
+    # An AIMD governor over the shared OAuth token: each worker acquires a slot,
+    # and a throttled completion shrinks the ceiling so the suite backs its
+    # parallel load off the token (grown back on clean completions).
+    governor = ConcurrencyGovernor(workers)
 
     def _guarded(spec: EvalSpec) -> EvalRun:
         if aborted.is_set():
             raise CreditExhaustedError(_SUITE_ABORTED_MESSAGE)
         try:
-            return _safe_run(runner, spec)
+            with governor.slot():
+                run = _safe_run(runner, spec)
         except CreditExhaustedError:
             aborted.set()
             raise
+        governor.record_completion(run)
+        return run
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
         futures = {pool.submit(_guarded, spec): index for index, spec in enumerate(specs)}

--- a/src/teatree/eval/throttle_retry.py
+++ b/src/teatree/eval/throttle_retry.py
@@ -1,0 +1,155 @@
+"""Bounded transient-throttle retry envelope for the metered in-process eval runner.
+
+Parallel scenarios share ONE OAuth token, so a rate-limit burst turns per-token
+limits into false reds unless a run rides them out. :class:`ThrottleRetryDriver`
+wraps one attempt-producing ``drive`` callable in a bounded retry loop: a TRANSIENT
+throttle backs off exponentially (1, 2, 4, 8, 16s capped at 30s + jitter), a
+SUSTAINED one waits the classified window clamped to a bounded cap, and the
+empty-trajectory watchdog ``TimeoutError`` is ridden out too. A genuine cap, a
+credit exhaustion, or a mislabeled success is graded by the caller's
+:class:`ThrottleRetryHandlers` — NEVER retried, so a real behavioral fail is never
+laundered into a passing retry. The runner-specific grading stays in the caller;
+only the retry orchestration and backoff schedule live here.
+"""
+
+import dataclasses
+import os
+import random
+import time
+from collections.abc import Callable
+
+from claude_agent_sdk import Message
+
+from teatree.eval.api_errors import (
+    SuccessMislabelResultError,
+    TerminalResultError,
+    ThrottleKind,
+    ThrottleSignal,
+    classify_transient_throttle,
+)
+from teatree.eval.models import EvalRun
+from teatree.llm.anthropic_limits import CreditExhaustedError
+
+#: Bounded retry envelope. A TRANSIENT throttle backs off exponentially (base ->
+#: cap) plus jitter to de-correlate the concurrent retries on the shared token;
+#: override the attempt count via ``T3_EVAL_THROTTLE_RETRIES`` (0 disables retry).
+THROTTLE_RETRY_MAX_ATTEMPTS = 5
+_THROTTLE_RETRIES_ENV_VAR = "T3_EVAL_THROTTLE_RETRIES"
+THROTTLE_BACKOFF_BASE_SECONDS = 1.0
+THROTTLE_BACKOFF_CAP_SECONDS = 30.0
+THROTTLE_BACKOFF_JITTER_SECONDS = 1.0
+#: A SUSTAINED (rolling subscription-window) wait is bounded so a genuine ~5h
+#: session cap SURFACES loud after a finite wait instead of hanging forever; the
+#: classified window horizon (hours) is clamped down to this cap.
+THROTTLE_WINDOW_WAIT_MAX_SECONDS = 600.0
+#: A system RNG for the backoff jitter so concurrent workers on the shared token
+#: draw independent jitter (de-correlating retries, avoiding a thundering herd); a
+#: test injects a deterministic ``rand`` in its place.
+_JITTER_RNG = random.SystemRandom()
+#: A watchdog ``TimeoutError`` leaves an EMPTY trajectory (``asyncio.wait_for``
+#: discards the partial run on cancel) — the infra-hang signature, ridden out as a
+#: TRANSIENT throttle.
+_TIMEOUT_THROTTLE = ThrottleSignal(kind=ThrottleKind.TRANSIENT, cause=None, wait_seconds=None)
+
+
+def resolve_throttle_retries() -> int:
+    """The bounded retry attempt count, ``T3_EVAL_THROTTLE_RETRIES`` overriding the default.
+
+    A missing/empty/unparsable value yields the default; an explicit ``0`` is
+    honored (disables the retry) — only a negative value falls back.
+    """
+    raw = os.environ.get(_THROTTLE_RETRIES_ENV_VAR, "").strip()
+    if not raw:
+        return THROTTLE_RETRY_MAX_ATTEMPTS
+    try:
+        value = int(raw)
+    except ValueError:
+        return THROTTLE_RETRY_MAX_ATTEMPTS
+    return value if value >= 0 else THROTTLE_RETRY_MAX_ATTEMPTS
+
+
+THROTTLE_MAX_ATTEMPTS = resolve_throttle_retries()
+
+
+def throttle_reason(signal: ThrottleSignal, attempts: int) -> str:
+    """The terminal reason for a throttle that outlasted its bounded retry budget.
+
+    Names the throttle so an exhausted rate limit surfaces loud as a distinct,
+    honest red — never mislabeled as a behavioral fail.
+    """
+    label = signal.cause.value if signal.cause is not None else signal.kind.value
+    return f"throttled: {label} (exhausted {attempts} retries)"
+
+
+@dataclasses.dataclass(frozen=True)
+class ThrottleRetryHandlers:
+    """The caller's per-terminus graders — how each outcome becomes an ``EvalRun``.
+
+    ``grade_success`` takes the captured messages and the retry count (so the run
+    carries ``throttle_retries``); ``grade_cap`` / ``grade_mislabel`` grade a genuine
+    cap / mislabeled success without retry; ``surface_throttled`` builds the loud red
+    for a throttle that outlasted the retry budget.
+    """
+
+    grade_success: Callable[[list[Message], int], EvalRun]
+    grade_cap: Callable[[TerminalResultError], EvalRun]
+    grade_mislabel: Callable[[SuccessMislabelResultError], EvalRun]
+    surface_throttled: Callable[[str, int], EvalRun]
+
+
+@dataclasses.dataclass(frozen=True)
+class ThrottleRetryDriver:
+    """Drive an attempt-producing callable with bounded transient-throttle retry.
+
+    ``sleep`` and ``rand`` are injectable so the backoff schedule is testable
+    without real time or a real RNG.
+    """
+
+    max_attempts: int
+    sleep: Callable[[float], None] = time.sleep
+    rand: Callable[[], float] = _JITTER_RNG.random
+
+    def run(self, drive: Callable[[], list[Message]], handlers: ThrottleRetryHandlers) -> EvalRun:
+        attempt = 0
+        while True:
+            try:
+                messages = drive()
+            except CreditExhaustedError:
+                # A $0 metered key is terminal for the WHOLE suite, not a per-run
+                # throttle — propagate so the caller aborts (never retried).
+                raise
+            except TerminalResultError as cap:
+                # A GENUINE behavioral cap (budget/max_turns). Retrying it would hide
+                # a real fail behind a backoff, so it is graded, never retried.
+                return handlers.grade_cap(cap)
+            except SuccessMislabelResultError as mislabel:
+                return handlers.grade_mislabel(mislabel)
+            except Exception as exc:
+                if isinstance(exc, TimeoutError):
+                    signal, reason = _TIMEOUT_THROTTLE, "timeout"
+                else:
+                    signal = classify_transient_throttle(str(exc))
+                    if signal is None:
+                        raise  # a non-throttle is a genuine crash — preserve its red
+                    reason = throttle_reason(signal, attempt)
+                next_attempt = self._next_attempt(signal, attempt)
+                if next_attempt is None:
+                    return handlers.surface_throttled(reason, attempt)
+                attempt = next_attempt
+                continue
+            return handlers.grade_success(messages, attempt)
+
+    def _next_attempt(self, signal: ThrottleSignal, attempt: int) -> int | None:
+        """Sleep the backoff and return the next attempt index, or ``None`` when the budget is spent."""
+        if attempt >= self.max_attempts:
+            return None
+        self.sleep(self._delay(signal, attempt))
+        return attempt + 1
+
+    def _delay(self, signal: ThrottleSignal, attempt: int) -> float:
+        """A bounded window wait for SUSTAINED, else jittered exponential backoff."""
+        if signal.kind is ThrottleKind.SUSTAINED:
+            window = signal.wait_seconds if signal.wait_seconds is not None else THROTTLE_WINDOW_WAIT_MAX_SECONDS
+            return min(window, THROTTLE_WINDOW_WAIT_MAX_SECONDS)
+        backoff = min(THROTTLE_BACKOFF_BASE_SECONDS * (2**attempt), THROTTLE_BACKOFF_CAP_SECONDS)
+        return backoff + self.rand() * THROTTLE_BACKOFF_JITTER_SECONDS

--- a/tests/teatree_eval/test_api_errors.py
+++ b/tests/teatree_eval/test_api_errors.py
@@ -1,0 +1,72 @@
+"""Throttle classification beside the terminal-error classifier for the eval runner.
+
+The metered ``api`` lane drives many parallel scenarios through ONE shared OAuth
+token, so a burst turns per-token rate limits into false reds. Layer 1 grades a
+raw SDK error message into a retry disposition — TRANSIENT (fast backoff),
+SUSTAINED (window wait), or ``None`` (never a throttle: a genuine cap, credit
+exhaustion, a 7-day weekly cap, a success mislabel, or a real crash).
+"""
+
+from teatree.eval.api_errors import ThrottleKind, classify_transient_throttle
+from teatree.llm.anthropic_limits import LimitCause, window_horizon
+
+
+class TestClassifyTransientThrottle:
+    def test_rate_limit_is_transient(self) -> None:
+        signal = classify_transient_throttle("Claude Code returned an error result: rate limit exceeded (429)")
+        assert signal is not None
+        assert signal.kind is ThrottleKind.TRANSIENT
+        assert signal.cause is LimitCause.RATE_LIMIT
+
+    def test_overloaded_is_transient(self) -> None:
+        signal = classify_transient_throttle("Overloaded")
+        assert signal is not None
+        assert signal.kind is ThrottleKind.TRANSIENT
+
+    def test_dropped_stream_is_transient(self) -> None:
+        # A transport drop under load (a reset connection) carries no limit phrase
+        # but is a transient infra signature, so it is ridden out.
+        signal = classify_transient_throttle("peer closed connection unexpectedly")
+        assert signal is not None
+        assert signal.kind is ThrottleKind.TRANSIENT
+        assert signal.cause is None
+
+    def test_opaque_error_result_is_not_a_throttle(self) -> None:
+        # An SDK error result carrying NO recognizable throttle signature is a
+        # genuine crash that must re-raise — never laundered into a retry. This is
+        # the "preserve the genuine-crash red" contract the runner relies on.
+        assert classify_transient_throttle("Claude Code returned an error result: error_during_execution") is None
+
+    def test_session_limit_is_sustained_with_window_wait(self) -> None:
+        signal = classify_transient_throttle("session limit reached")
+        assert signal is not None
+        assert signal.kind is ThrottleKind.SUSTAINED
+        assert signal.cause is LimitCause.SUBSCRIPTION_SESSION
+        horizon = window_horizon(LimitCause.SUBSCRIPTION_SESSION)
+        assert horizon is not None
+        assert signal.wait_seconds == horizon.total_seconds()
+
+    def test_api_credit_is_never_retried(self) -> None:
+        # A $0 metered key has no time-based recovery — fail loud, never retry.
+        assert classify_transient_throttle("credit balance is too low") is None
+
+    def test_weekly_limit_is_never_retried(self) -> None:
+        # A 7-day wait is never right inside a single run — surface loud, don't wait.
+        assert classify_transient_throttle("weekly limit reached") is None
+
+    def test_max_turns_cap_is_never_a_throttle(self) -> None:
+        # The anti-cheat boundary: a genuine behavioral cap must not be laundered
+        # into a retry that hides the real fail behind a backoff.
+        assert classify_transient_throttle("Reached maximum number of turns (3)") is None
+
+    def test_budget_cap_is_never_a_throttle(self) -> None:
+        assert classify_transient_throttle("Reached maximum budget ($0.1)") is None
+
+    def test_success_mislabel_is_not_a_throttle(self) -> None:
+        assert classify_transient_throttle("Claude Code returned an error result: success") is None
+
+    def test_genuine_crash_is_not_a_throttle(self) -> None:
+        # A real bug carries no SDK error-result marker and no limit phrase — it
+        # must re-raise as a genuine red, never be swallowed into a retry.
+        assert classify_transient_throttle("TypeError: 'NoneType' object is not subscriptable") is None
+        assert classify_transient_throttle("KeyError: 'foo'") is None

--- a/tests/teatree_eval/test_api_runner.py
+++ b/tests/teatree_eval/test_api_runner.py
@@ -48,6 +48,7 @@ from teatree.eval.models import (
 )
 from teatree.eval.production_hooks import t3_plugin, teatree_root
 from teatree.eval.system_prompt_file import resolve_system_prompt, spill_system_prompt
+from teatree.eval.throttle_retry import THROTTLE_WINDOW_WAIT_MAX_SECONDS
 from teatree.eval.toolset import (
     DELEGATION_SUBAGENT_NAME,
     KNOWN_BUILTIN_TOOLS,
@@ -461,7 +462,9 @@ class TestApiInProcessRunnerCapture:
             patch("teatree.eval.api_runner.query", _slow_query),
             patch("teatree.eval.api_runner.WATCHDOG_SECONDS", 0.01),
         ):
-            run = ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path)).run(spec)
+            # throttle_max_attempts=0 disables the transient-throttle retry so a
+            # persistently-timing-out query surfaces the timeout run immediately.
+            run = ApiInProcessRunner(ApiRunnerParams(workspace=tmp_path, throttle_max_attempts=0)).run(spec)
         assert run.terminal_reason == "timeout"
         assert run.is_error is True
 
@@ -2349,3 +2352,174 @@ class TestApiRunnerParams:
         params = ApiRunnerParams()
         with pytest.raises(dataclasses.FrozenInstanceError):
             params.max_turns_override = 3  # type: ignore[misc]
+
+
+def _scripted_query(script: list[BaseException | list[Any]]):
+    """A ``query`` stub that walks *script* on successive calls, one per SDK attempt.
+
+    Each entry consumed on an attempt is either a ``BaseException`` (raised BEFORE
+    any message yields, exactly as the SDK surfaces an error-result mid-stream) or a
+    list of messages to yield. The last entry repeats if the runner attempts more
+    times than the script is long. ``calls["n"]`` records how many attempts the SDK
+    was actually driven for — the observable that proves a retry did (or did NOT)
+    happen.
+    """
+    calls: dict[str, int] = {"n": 0}
+
+    async def _query(*, prompt: str, options: Any = None, **_: Any) -> AsyncIterator[Any]:
+        await asyncio.sleep(0)
+        index = min(calls["n"], len(script) - 1)
+        calls["n"] += 1
+        step = script[index]
+        if isinstance(step, BaseException):
+            raise step
+        for message in step:
+            yield message
+
+    return _query, calls
+
+
+class TestThrottleRetry:
+    """Layer 2: bounded transient-throttle retry around the SDK drive.
+
+    A parallel metered suite shares ONE OAuth token, so a rate-limit burst turns
+    into false reds unless a run rides it out. These pin that a TRANSIENT/SUSTAINED
+    throttle is retried (with backoff) while a GENUINE cap, credit exhaustion, or
+    weekly cap is NEVER retried — the anti-cheat boundary that keeps a real
+    behavioral fail from being laundered into a passing retry.
+    """
+
+    def _run(
+        self,
+        spec: EvalSpec,
+        script: list[BaseException | list[Any]],
+        **params: Any,
+    ) -> tuple[Any, dict[str, int], list[float]]:
+        query, calls = _scripted_query(script)
+        sleeps: list[float] = []
+        runner_params = ApiRunnerParams(
+            workspace=params.pop("workspace", None),
+            sleep=sleeps.append,
+            rand=lambda: 0.0,
+            **params,
+        )
+        with (
+            patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
+            patch("teatree.eval.api_runner.query", query),
+        ):
+            run = ApiInProcessRunner(runner_params).run(spec)
+        return run, calls, sleeps
+
+    def test_rate_limit_is_retried_then_succeeds(self, tmp_path: Path) -> None:
+        spec = _spec(tmp_path)
+        throttle = RuntimeError("Claude Code returned an error result: rate limit exceeded (429)")
+        run, calls, sleeps = self._run(spec, [throttle, [_result()]], workspace=tmp_path)
+        assert calls["n"] == 2  # one retry after the throttle, then success
+        assert run.is_error is False
+        assert run.throttle_retries == 1
+        assert sleeps == [pytest.approx(1.0)]  # first backoff = base 1s, jitter pinned to 0
+
+    def test_repeated_throttles_back_off_exponentially(self, tmp_path: Path) -> None:
+        spec = _spec(tmp_path)
+        throttle = RuntimeError("Overloaded")
+        run, calls, sleeps = self._run(spec, [throttle, throttle, throttle, [_result()]], workspace=tmp_path)
+        assert calls["n"] == 4
+        assert run.throttle_retries == 3
+        assert sleeps == [pytest.approx(1.0), pytest.approx(2.0), pytest.approx(4.0)]
+
+    def test_genuine_max_turns_cap_is_not_retried(self, tmp_path: Path) -> None:
+        # THE anti-cheat test. The script would "succeed" on a 2nd attempt, so if
+        # the runner WRONGLY retried the cap the run would flip to a false pass.
+        # It must instead surface the cap on the FIRST attempt, ungraded by retry.
+        spec = _spec(tmp_path)
+        cap = RuntimeError("Claude Code returned an error result: Reached maximum number of turns (3)")
+        run, calls, sleeps = self._run(spec, [cap, [_result()]], workspace=tmp_path)
+        assert calls["n"] == 1  # NOT retried — the cap surfaces immediately
+        assert run.terminal_reason == "max_turns"
+        assert run.is_error is True
+        assert run.throttle_retries == 0
+        assert sleeps == []
+
+    def test_budget_cap_is_not_retried(self, tmp_path: Path) -> None:
+        spec = _spec(tmp_path)
+        cap = RuntimeError("Claude Code returned an error result: Reached maximum budget ($0.1)")
+        run, calls, sleeps = self._run(spec, [cap, [_result()]], workspace=tmp_path)
+        assert calls["n"] == 1
+        assert run.terminal_reason == "budget_exceeded"
+        assert run.is_error is True
+        assert sleeps == []
+
+    def test_api_credit_exhaustion_fails_loud_not_retried(self, tmp_path: Path) -> None:
+        spec = _spec(tmp_path)
+        credit = RuntimeError("credit balance is too low")
+        query, calls = _scripted_query([credit, [_result()]])
+        sleeps: list[float] = []
+        runner_params = ApiRunnerParams(workspace=tmp_path, sleep=sleeps.append, rand=lambda: 0.0)
+        with (
+            patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
+            patch("teatree.eval.api_runner.query", query),
+            pytest.raises(CreditExhaustedError),
+        ):
+            ApiInProcessRunner(runner_params).run(spec)
+        assert calls["n"] == 1  # a $0 key is terminal for the suite — never retried
+        assert sleeps == []
+
+    def test_weekly_limit_fails_loud_not_retried(self, tmp_path: Path) -> None:
+        spec = _spec(tmp_path)
+        weekly = RuntimeError("Claude Code returned an error result: weekly limit reached")
+        query, calls = _scripted_query([weekly, [_result()]])
+        sleeps: list[float] = []
+        runner_params = ApiRunnerParams(workspace=tmp_path, sleep=sleeps.append, rand=lambda: 0.0)
+        with (
+            patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
+            patch("teatree.eval.api_runner.query", query),
+            pytest.raises(RuntimeError, match="weekly limit"),
+        ):
+            ApiInProcessRunner(runner_params).run(spec)
+        assert calls["n"] == 1  # a 7-day wait is never right inside a run
+        assert sleeps == []
+
+    def test_session_window_wait_is_bounded_by_the_cap(self, tmp_path: Path) -> None:
+        spec = _spec(tmp_path)
+        session = RuntimeError("Claude Code returned an error result: session limit reached")
+        run, calls, sleeps = self._run(spec, [session, [_result()]], workspace=tmp_path)
+        assert calls["n"] == 2
+        assert run.is_error is False
+        # The ~5h session horizon is clamped to the bounded window cap so a real
+        # session cap surfaces loud after a finite wait, never hangs forever.
+        assert sleeps == [pytest.approx(THROTTLE_WINDOW_WAIT_MAX_SECONDS)]
+
+    def test_empty_trajectory_timeout_is_retried(self, tmp_path: Path) -> None:
+        # The infra-hang signature: an empty-trajectory watchdog timeout is ridden
+        # out like any transient throttle, not immediately red'd.
+        spec = _spec(tmp_path)
+        run, calls, sleeps = self._run(spec, [TimeoutError(), [_result()]], workspace=tmp_path)
+        assert calls["n"] == 2
+        assert run.is_error is False
+        assert run.throttle_retries == 1
+        assert sleeps == [pytest.approx(1.0)]
+
+    def test_genuine_crash_re_raises_not_retried(self, tmp_path: Path) -> None:
+        spec = _spec(tmp_path)
+        crash = RuntimeError("TypeError: 'NoneType' object is not subscriptable")
+        query, calls = _scripted_query([crash, [_result()]])
+        sleeps: list[float] = []
+        runner_params = ApiRunnerParams(workspace=tmp_path, sleep=sleeps.append, rand=lambda: 0.0)
+        with (
+            patch("teatree.eval.api_runner.shutil.which", return_value="/usr/local/bin/claude"),
+            patch("teatree.eval.api_runner.query", query),
+            pytest.raises(RuntimeError, match="NoneType"),
+        ):
+            ApiInProcessRunner(runner_params).run(spec)
+        assert calls["n"] == 1  # a real crash preserves the genuine-crash red
+        assert sleeps == []
+
+    def test_exhausted_transient_throttle_surfaces_loud(self, tmp_path: Path) -> None:
+        spec = _spec(tmp_path)
+        throttle = RuntimeError("Overloaded")
+        run, calls, sleeps = self._run(spec, [throttle], workspace=tmp_path, throttle_max_attempts=2)
+        assert calls["n"] == 3  # initial attempt + 2 bounded retries, all throttled
+        assert run.is_error is True
+        assert run.throttle_retries == 2
+        assert "throttled" in run.terminal_reason
+        assert sleeps == [pytest.approx(1.0), pytest.approx(2.0)]

--- a/tests/teatree_eval/test_parallel.py
+++ b/tests/teatree_eval/test_parallel.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from teatree.eval.models import EvalRun, EvalSpec, Matcher
-from teatree.eval.parallel import DEFAULT_PARALLEL, run_specs
+from teatree.eval.parallel import DEFAULT_PARALLEL, ConcurrencyGovernor, run_specs
 from teatree.llm.anthropic_limits import CreditExhaustedError
 
 
@@ -168,3 +168,90 @@ class TestCreditExhaustedAbortsTheSuite:
             run_specs(runner, specs, parallel=4)
         # Pending scenarios were cancelled, so NOT all eight ran on the dead key.
         assert runner.ran < len(specs)
+
+
+def _completed(name: str, *, throttle_retries: int = 0, is_error: bool = False) -> EvalRun:
+    return EvalRun(
+        spec_name=name,
+        tool_calls=(),
+        text_blocks=(),
+        terminal_reason="throttled" if is_error else "success",
+        is_error=is_error,
+        raw_stdout="",
+        raw_stderr="",
+        throttle_retries=throttle_retries,
+    )
+
+
+class TestConcurrencyGovernor:
+    """Layer 3: an AIMD governor backs the shared permit count off a throttle.
+
+    Standard congestion control: a throttle event (a run that rode out one or more
+    Layer-2 retries) multiplicatively HALVES the permit ceiling toward a floor of 1;
+    N consecutive clean completions ADDITIVELY grow it one step back toward the
+    worker count. A cooldown keeps a burst of near-simultaneous throttles from
+    collapsing the ceiling in one step.
+    """
+
+    def test_starts_at_the_worker_count(self) -> None:
+        assert ConcurrencyGovernor(8).limit == 8
+
+    def test_throttle_multiplicatively_halves_toward_a_floor_of_one(self) -> None:
+        gov = ConcurrencyGovernor(8, cooldown=0.0)
+        gov.record_completion(_completed("a", throttle_retries=1))
+        assert gov.limit == 4
+        gov.record_completion(_completed("b", throttle_retries=2))
+        assert gov.limit == 2
+        gov.record_completion(_completed("c", throttle_retries=1))
+        assert gov.limit == 1
+        gov.record_completion(_completed("d", throttle_retries=1))
+        assert gov.limit == 1  # floored at 1, never 0
+
+    def test_clean_completions_additively_grow_back_toward_workers(self) -> None:
+        gov = ConcurrencyGovernor(8, cooldown=0.0, grow_after=3)
+        gov.record_completion(_completed("a", throttle_retries=1))  # 8 -> 4
+        assert gov.limit == 4
+        for i in range(2):
+            gov.record_completion(_completed(f"c{i}"))
+        assert gov.limit == 4  # not yet N clean completions
+        gov.record_completion(_completed("c2"))  # third clean -> +1
+        assert gov.limit == 5
+
+    def test_a_clean_run_never_grows_past_the_worker_count(self) -> None:
+        gov = ConcurrencyGovernor(2, grow_after=1)
+        for i in range(5):
+            gov.record_completion(_completed(f"c{i}"))
+        assert gov.limit == 2
+
+    def test_cooldown_suppresses_a_second_immediate_shrink(self) -> None:
+        clock = {"t": 0.0}
+        gov = ConcurrencyGovernor(8, cooldown=5.0, clock=lambda: clock["t"])
+        gov.record_completion(_completed("a", throttle_retries=1))  # 8 -> 4
+        assert gov.limit == 4
+        gov.record_completion(_completed("b", throttle_retries=1))  # within cooldown -> ignored
+        assert gov.limit == 4
+        clock["t"] = 10.0
+        gov.record_completion(_completed("c", throttle_retries=1))  # cooldown elapsed -> 4 -> 2
+        assert gov.limit == 2
+
+    def test_a_non_throttle_error_neither_shrinks_nor_grows(self) -> None:
+        gov = ConcurrencyGovernor(8, cooldown=0.0, grow_after=1)
+        gov.record_completion(_completed("a", throttle_retries=1))  # 8 -> 4
+        assert gov.limit == 4
+        gov.record_completion(_completed("crash", is_error=True))  # a genuine crash is neutral
+        assert gov.limit == 4
+
+
+class TestRunSpecsGovernorIntegration:
+    def test_run_specs_drains_every_spec_even_when_every_run_throttles(self, tmp_path: Path) -> None:
+        # Every run reports a throttle, so the governor shrinks toward its floor.
+        # The floor of 1 keeps progress, so all specs still complete in order — the
+        # governed path must never deadlock nor drop a spec.
+        specs = [_spec(tmp_path, name=f"s{i}") for i in range(6)]
+
+        class _AlwaysThrottled:
+            def run(self, spec: EvalSpec) -> EvalRun:
+                return _completed(spec.name, throttle_retries=1)
+
+        runs = run_specs(_AlwaysThrottled(), specs, parallel=4)
+        assert [r.spec_name for r in runs] == [s.name for s in specs]

--- a/tests/teatree_eval/test_throttle_retry.py
+++ b/tests/teatree_eval/test_throttle_retry.py
@@ -1,0 +1,166 @@
+"""Bounded transient-throttle retry envelope for the metered in-process eval runner.
+
+The driver rides out a TRANSIENT/SUSTAINED throttle (and the empty-trajectory
+watchdog timeout) with bounded backoff, while a genuine cap, credit exhaustion, or
+mislabeled success is graded by the caller's handlers — never retried, the
+anti-cheat boundary that keeps a real behavioral fail from becoming a passing retry.
+"""
+
+from collections.abc import Callable
+
+import pytest
+
+from teatree.eval.api_errors import SuccessMislabelResultError, TerminalResultError
+from teatree.eval.models import EvalRun
+from teatree.eval.throttle_retry import (
+    THROTTLE_RETRY_MAX_ATTEMPTS,
+    THROTTLE_WINDOW_WAIT_MAX_SECONDS,
+    ThrottleRetryDriver,
+    ThrottleRetryHandlers,
+    resolve_throttle_retries,
+)
+from teatree.llm.anthropic_limits import CreditExhaustedError
+
+
+def _run(*, throttle_retries: int = 0, is_error: bool = False, terminal_reason: str = "success") -> EvalRun:
+    return EvalRun(
+        spec_name="s",
+        tool_calls=(),
+        text_blocks=(),
+        terminal_reason=terminal_reason,
+        is_error=is_error,
+        raw_stdout="",
+        raw_stderr="",
+        throttle_retries=throttle_retries,
+    )
+
+
+def _handlers() -> ThrottleRetryHandlers:
+    return ThrottleRetryHandlers(
+        grade_success=lambda messages, retries: _run(throttle_retries=retries),
+        grade_cap=lambda cap: _run(terminal_reason="capped", is_error=True),
+        grade_mislabel=lambda mislabel: _run(terminal_reason="mislabel"),
+        surface_throttled=lambda reason, retries: _run(terminal_reason=reason, is_error=True, throttle_retries=retries),
+    )
+
+
+def _scripted_drive(script: list[BaseException | list]) -> tuple[Callable[[], list], dict[str, int]]:
+    calls: dict[str, int] = {"n": 0}
+
+    def _drive() -> list:
+        index = min(calls["n"], len(script) - 1)
+        calls["n"] += 1
+        step = script[index]
+        if isinstance(step, BaseException):
+            raise step
+        return step
+
+    return _drive, calls
+
+
+def _driver(sleeps: list[float], *, max_attempts: int = THROTTLE_RETRY_MAX_ATTEMPTS) -> ThrottleRetryDriver:
+    return ThrottleRetryDriver(max_attempts=max_attempts, sleep=sleeps.append, rand=lambda: 0.0)
+
+
+class TestThrottleRetryDriver:
+    def test_transient_throttle_retried_then_success(self) -> None:
+        drive, calls = _scripted_drive([RuntimeError("Overloaded"), []])
+        sleeps: list[float] = []
+        run = _driver(sleeps).run(drive, _handlers())
+        assert calls["n"] == 2
+        assert run.throttle_retries == 1
+        assert sleeps == [pytest.approx(1.0)]
+
+    def test_repeated_throttles_back_off_exponentially(self) -> None:
+        drive, calls = _scripted_drive([RuntimeError("Overloaded")] * 3 + [[]])
+        sleeps: list[float] = []
+        run = _driver(sleeps).run(drive, _handlers())
+        assert calls["n"] == 4
+        assert run.throttle_retries == 3
+        assert sleeps == [pytest.approx(1.0), pytest.approx(2.0), pytest.approx(4.0)]
+
+    def test_genuine_cap_is_graded_not_retried(self) -> None:
+        cap = TerminalResultError(terminal_reason="max_turns", messages=[], cause=RuntimeError("max turns"))
+        drive, calls = _scripted_drive([cap, []])
+        sleeps: list[float] = []
+        run = _driver(sleeps).run(drive, _handlers())
+        assert calls["n"] == 1  # NOT retried — the cap surfaces immediately
+        assert run.terminal_reason == "capped"
+        assert sleeps == []
+
+    def test_success_mislabel_is_graded_not_retried(self) -> None:
+        mislabel = SuccessMislabelResultError(messages=[], cause=RuntimeError("mislabel"))
+        drive, calls = _scripted_drive([mislabel, []])
+        sleeps: list[float] = []
+        run = _driver(sleeps).run(drive, _handlers())
+        assert calls["n"] == 1
+        assert run.terminal_reason == "mislabel"
+
+    def test_credit_exhaustion_propagates_not_retried(self) -> None:
+        drive, calls = _scripted_drive([CreditExhaustedError("credits gone"), []])
+        sleeps: list[float] = []
+        with pytest.raises(CreditExhaustedError):
+            _driver(sleeps).run(drive, _handlers())
+        assert calls["n"] == 1
+        assert sleeps == []
+
+    def test_genuine_crash_re_raises_not_retried(self) -> None:
+        drive, calls = _scripted_drive([RuntimeError("TypeError: not subscriptable"), []])
+        sleeps: list[float] = []
+        with pytest.raises(RuntimeError, match="not subscriptable"):
+            _driver(sleeps).run(drive, _handlers())
+        assert calls["n"] == 1
+        assert sleeps == []
+
+    def test_empty_trajectory_timeout_is_retried(self) -> None:
+        drive, calls = _scripted_drive([TimeoutError(), []])
+        sleeps: list[float] = []
+        run = _driver(sleeps).run(drive, _handlers())
+        assert calls["n"] == 2
+        assert run.throttle_retries == 1
+
+    def test_session_window_wait_is_bounded_by_the_cap(self) -> None:
+        drive, calls = _scripted_drive([RuntimeError("session limit reached"), []])
+        sleeps: list[float] = []
+        run = _driver(sleeps).run(drive, _handlers())
+        assert calls["n"] == 2
+        assert run.is_error is False
+        assert sleeps == [pytest.approx(THROTTLE_WINDOW_WAIT_MAX_SECONDS)]
+
+    def test_exhausted_throttle_surfaces_loud(self) -> None:
+        drive, calls = _scripted_drive([RuntimeError("Overloaded")])
+        sleeps: list[float] = []
+        driver = ThrottleRetryDriver(max_attempts=2, sleep=sleeps.append, rand=lambda: 0.0)
+        run = driver.run(drive, _handlers())
+        assert calls["n"] == 3  # initial attempt + 2 bounded retries, all throttled
+        assert run.is_error is True
+        assert run.throttle_retries == 2
+        assert "throttled" in run.terminal_reason
+        assert sleeps == [pytest.approx(1.0), pytest.approx(2.0)]
+
+    def test_zero_max_attempts_disables_retry(self) -> None:
+        drive, calls = _scripted_drive([RuntimeError("Overloaded")])
+        sleeps: list[float] = []
+        driver = ThrottleRetryDriver(max_attempts=0, sleep=sleeps.append, rand=lambda: 0.0)
+        run = driver.run(drive, _handlers())
+        assert calls["n"] == 1
+        assert run.is_error is True
+        assert sleeps == []
+
+
+class TestResolveThrottleRetries:
+    def test_default_when_unset(self, monkeypatch) -> None:
+        monkeypatch.delenv("T3_EVAL_THROTTLE_RETRIES", raising=False)
+        assert resolve_throttle_retries() == THROTTLE_RETRY_MAX_ATTEMPTS
+
+    def test_zero_is_honored(self, monkeypatch) -> None:
+        monkeypatch.setenv("T3_EVAL_THROTTLE_RETRIES", "0")
+        assert resolve_throttle_retries() == 0
+
+    def test_negative_falls_back(self, monkeypatch) -> None:
+        monkeypatch.setenv("T3_EVAL_THROTTLE_RETRIES", "-1")
+        assert resolve_throttle_retries() == THROTTLE_RETRY_MAX_ATTEMPTS
+
+    def test_unparsable_falls_back(self, monkeypatch) -> None:
+        monkeypatch.setenv("T3_EVAL_THROTTLE_RETRIES", "abc")
+        assert resolve_throttle_retries() == THROTTLE_RETRY_MAX_ATTEMPTS


### PR DESCRIPTION
## What

The metered `t3 eval run --backend api` lane drives many parallel scenarios through **one** shared OAuth token. Before this change the runner had no throttle retry, so a rate-limit burst turned per-token limits into **false reds** — exit-1/timeout crashes and cap-truncation on scenarios whose behaviour was actually correct. Three layers make the runner ride out throttling instead of red'ing correct scenarios.

## The three layers

| Layer | File:line | What it does |
|---|---|---|
| **1 — classify** | `src/teatree/eval/api_errors.py:140` `classify_transient_throttle()` | Grades a raw SDK error into a `ThrottleSignal`: **TRANSIENT** (429 / overloaded / dropped stream), **SUSTAINED** (session window), or `None`. Reuses the `anthropic_limits` taxonomy (`classify_limit`, `LimitCause`, `WINDOW_HORIZON`). Returns `None` for every non-throttle: a genuine budget/max_turns cap, credit exhaustion, a 7-day weekly cap, a success mislabel, and an opaque error result. |
| **2 — bounded retry** | `src/teatree/eval/throttle_retry.py:105` `ThrottleRetryDriver.run()` (composed by `ApiInProcessRunner.run` in `api_runner.py:496`) | Wraps the SDK drive in a bounded retry loop. TRANSIENT → exponential backoff (1,2,4,8,16s cap 30s + jitter); SUSTAINED → the classified window clamped to `THROTTLE_WINDOW_WAIT_MAX_SECONDS` (600s) so a session cap surfaces loud; empty-trajectory watchdog timeout is ridden out too. `TerminalResultError` / `CreditExhaustedError` / `SuccessMislabelResultError` propagate **UNCHANGED** — never retried. Retry count rides out on `EvalRun.throttle_retries`. |
| **3 — AIMD concurrency** | `src/teatree/eval/parallel.py:60` `ConcurrencyGovernor` (wired into `run_specs`) | A shared permit ceiling each pooled run acquires. A throttled completion multiplicatively **halves** the ceiling (floor 1, with cooldown); N clean completions additively **grow** it back toward the worker count. Standard congestion control over the one shared token. |

Params are module constants (env `T3_EVAL_THROTTLE_RETRIES`) with injectable `sleep`/`rand`/`clock` seams so the backoff and governor are tested without real time or a real RNG.

## Anti-cheat (the critical guarantee)

A genuine `max_turns`/`budget` cap is **NOT retried** — retrying it would launder a real behavioral fail into a passing retry. Proven by `test_genuine_max_turns_cap_is_not_retried` (and its budget sibling): the mocked query is scripted to "succeed" on a 2nd attempt, so a wrong retry would flip the run to a false pass. The test asserts the drive is called exactly **once** and the run surfaces as `terminal_reason == "max_turns"`. Anti-vacuity was verified by temporarily injecting the "retry the cap" defect and observing both tests go RED (`calls == 2`), then reverting.

## Tests (mocked — no real API)

- `test_api_errors.py` — Layer 1 classification (rate-limit → TRANSIENT, session → SUSTAINED window wait, credit / weekly / cap / mislabel / opaque-error → `None`).
- `test_throttle_retry.py` — Layer 2 driver: retried-then-success, exponential backoff, cap/mislabel/credit not retried, genuine crash re-raises, timeout retried, session window bounded, exhaustion surfaces loud.
- `test_api_runner.py::TestThrottleRetry` — Layer 2 through the runner incl. the anti-cheat test.
- `test_parallel.py::TestConcurrencyGovernor` — Layer 3 AIMD shrink-on-throttle / grow-on-clear / cooldown / floor.

## Deviation from the triage

The triage listed a bare "generic exit-1 with no terminal marker" as TRANSIENT. That conflicts with the existing anti-vacuity contract (`test_non_credit_error_still_propagates_unchanged` et al. — an opaque error result must propagate as a genuine crash) **and** the triage's own "preserve the genuine-crash red" requirement. I took the conservative reading: only explicit throttle/transport signatures (429/overloaded/rate-limit/connection-drop) retry; an opaque error result still re-raises. Rate limits carry recognizable text and are caught; the timeout vector is also caught.

## Verify

- `bash dev/ci-parity-fast.sh` green (prek gates + `makemigrations --check` + push gate).
- Full `tests/teatree_eval/` green (596 passed); ruff + ty clean; module-health under cap.
- `t3 eval --backend api` deliberately NOT run (another agent may hold the OAuth token); all tests mock the runner.

## Architecture pre-check — fix-eval-runner-throttle

### 1. BLUEPRINT § alignment
Eval harness internals (metered `api` runner + bounded concurrent driver). No FSM/BLUEPRINT contract touched — additive resilience on an existing lane.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition.

### 3. Extension-point contracts
No `OverlayBase` / scanner / hook / `*Backend` Protocol changed. The `EvalRunner` Protocol (`run(spec) -> EvalRun`) is unchanged — the governor couples through the additive `EvalRun.throttle_retries` field, not a signature change.

### 4. Component boundaries
`src/teatree/eval/` (harness). New `throttle_retry.py` isolates the retry concern (constants + `ThrottleRetryDriver` + handlers) from `api_runner.py`, composed via `functools.partial` handlers — keeps `api_runner` under the module-health LOC cap.

### 5. Dependency direction
`throttle_retry` → `api_errors`, `models`, `anthropic_limits` (all lower-level); `api_runner` → `throttle_retry`; `parallel` → `models`. No backwards edge. `uv run tach check` clean (via `ci-parity-fast`).

### 6. Test surface
Per behaviour: classification (`test_api_errors.py`), retry/anti-cheat (`test_throttle_retry.py`, `test_api_runner.py::TestThrottleRetry`), AIMD (`test_parallel.py::TestConcurrencyGovernor`). Each regression observed RED before green; anti-cheat proven non-vacuous via defect injection.

### 7. Resilience invariants
This change **is** a resilience feature: idempotency (a retried run is a fresh clean-room attempt), fallback (bounded surface-loud on exhaustion, never an infinite hang), and a structured signal (`throttle_retries`) the governor routes on. No new external write.

### 8. Identity and key normalization
n/a — no identity/key with bare vs qualified forms.

### 9. Behavior preservation / capability deletion
Additive. The four existing anti-vacuity contracts (an opaque non-cap error result must propagate as a genuine crash) are **preserved** — the transient classifier is deliberately narrow (explicit signatures only). No must-block/must-propagate test was inverted.

### 10. Removability / harness-vs-data
`throttle_retry.py` is self-contained and removable (its consumers are `api_runner`'s composition + `parallel`'s governor). Tuning lives in data/env (`T3_EVAL_THROTTLE_RETRIES`, module constants); the harness reads it.
