### PR TITLE
fix(deploy): fast-forward the existing runtime clone in init

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -97,6 +97,15 @@ disable_fleet_scoped_loops() {
 
 ensure_clone() {
     if [ -e "$CLONE_DIR/.git" ]; then
+        # The clone lives in a shared volume that outlives the image, so a
+        # redeploy must bring it current or the stack keeps serving the code
+        # from the first boot. Fast-forward only, and fail loud on divergence —
+        # silently serving stale code is worse than a red deploy.
+        git -C "$CLONE_DIR" fetch --prune origin
+        git -C "$CLONE_DIR" merge --ff-only "@{upstream}" || {
+            echo "entrypoint: $CLONE_DIR cannot fast-forward to its upstream - the runtime clone has local commits or a diverged branch; reconcile it on the box and re-run Deploy" >&2
+            exit 1
+        }
         return 0
     fi
     git clone "$REPO_URL" "$CLONE_DIR"


### PR DESCRIPTION
## Problem

`ensure_clone()` in `deploy/entrypoint.sh` returns early whenever the shared `teatree_src` volume already holds a clone — it never fetches. So every redeploy after the first boot rebuilds the image and updates the box-side build checkout, but the services keep serving the volume's original code.

Observed on the box today: the Deploy workflow went green at `5c877777` while the runtime clone still served `2abcf546` (May), which is why `/dash/` 404'd after a successful deploy.

## Fix

When the clone exists, init now runs `git fetch --prune` + `git merge --ff-only @{upstream}` before the editable reinstall. Divergence (local commits on the runtime clone) exits 1 instead of silently serving stale code — worker/admin gate on init success, so the deploy convergence check goes red and the message says what to reconcile.

## Verification

- `bash -n` clean.
- The equivalent manual sequence (ff the volume clone, recreate the stack so init re-runs the reinstall + migrate) is exactly what restored `/dash/` on the box today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EyaPvyGQjoSdJ9vUsFwvt