### PR TITLE
feat(deploy): auto-deploy to the box on every push to main

### DIFF
--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -1,12 +1,17 @@
-# One-click teatree headless deploy to an existing Hetzner box.
-# Manual trigger only. No box-identifying info lives here — the server name, SSH
-# user/port, host key, and IP all come from secrets, and the resolved IP is
-# masked out of the logs. Uses no third-party actions (nothing to SHA-pin); the
-# hcloud CLI is installed from a checksum-pinned release.
+# Teatree headless deploy to an existing Hetzner box.
+# Runs on every push to main (each merged PR) plus the manual trigger; the
+# deploy script is idempotent and the concurrency group serializes runs, so a
+# merge train converges the box to the newest main. No box-identifying info
+# lives here — the server name, SSH user/port, host key, and IP all come from
+# secrets, and the resolved IP is masked out of the logs. Uses no third-party
+# actions (nothing to SHA-pin); the hcloud CLI is installed from a
+# checksum-pinned release.
 name: Deploy teatree to Hetzner
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Adds `push: branches: [main]` to the Deploy-to-Hetzner triggers, so every merged PR converges the box automatically. `workflow_dispatch` stays for out-of-band redeploys.

## Why it's safe

- `deploy.sh` is idempotent (ff-only pull, rebuild, `compose up -d`, convergence check).
- The existing `deploy-hetzner` concurrency group with `cancel-in-progress: false` serializes runs; GitHub keeps at most one pending run per group, so a merge train collapses into the newest main instead of piling up deploys.
- Secrets-only box addressing is unchanged.

## Note

Pairs with #3195 — until that lands, a deploy refreshes the image but the runtime clone in the `teatree_src` volume stays stale, so auto-deploy only becomes fully effective once #3195 is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EyaPvyGQjoSdJ9vUsFwvt