### PR TITLE
fix(eval): retry a mid-stream SDK transport crash, never a behavioral cap

### DIFF
--- a/src/teatree/eval/api_errors.py
+++ b/src/teatree/eval/api_errors.py
@@ -128,6 +128,29 @@ _TRANSIENT_INFRA_MARKERS: tuple[str, ...] = (
     "read timed out",
 )
 
+#: Substrings marking a mid-stream SDK TRANSPORT CRASH — the subprocess CLI dying
+#: with NO ``result`` event, surfaced by the message reader's bare ``ProcessError``
+#: (``subprocess_cli.py`` L711) via its ``"Fatal error in message reader"`` branch
+#: (``_internal/query.py`` L351). This is the anti-cheat boundary's SAFE side: the
+#: crash aborted the run before any trajectory was captured (0-byte, no verdict),
+#: so re-running the scenario launders nothing. It is DISTINCT from a behavioral
+#: cap by SDK construction — when the CLI DID emit a ``result`` event (a genuine
+#: max-turns/budget cap, or an ``error_during_execution`` terminus), the message
+#: reader REPLACES this ProcessError with ``"Claude Code returned an error result:
+#: …"`` (``query.py`` L342), which carries a real trajectory and is NEVER matched
+#: here. So this marker fires only when no verdict exists — retry-safe.
+_TRANSPORT_CRASH_MARKERS: tuple[str, ...] = ("command failed with exit code",)
+
+#: Substrings marking a host-resource-starvation transient during eval PROVISIONING
+#: — the per-run ephemeral checkout's ``git clone`` (or repo-root resolution) failing
+#: under a momentary RAM spike, raised as ``EphemeralCheckoutError`` (both raise sites,
+#: ``ephemeral_checkout.py`` L115/L126, begin with this substring). Same SAFE side of
+#: the anti-cheat boundary as a transport crash: the scenario aborted during setup, so
+#: NO trajectory and NO behavioral verdict were produced — a retry after the spike
+#: clears re-runs a cell that graded nothing, laundering nothing. A provisioning
+#: failure is never a ``result`` event, so it can never collide with a behavioral cap.
+_PROVISION_TRANSIENT_MARKERS: tuple[str, ...] = ("cannot provision an isolated ephemeral checkout",)
+
 #: Limit causes that are NEVER a retriable throttle: a $0 metered key has no
 #: time-based recovery (fail loud), and a 7-day weekly cap is never worth waiting
 #: out inside a single run (surface loud). The remaining causes ARE retriable —
@@ -152,10 +175,13 @@ def classify_transient_throttle(message: str) -> ThrottleSignal | None:
     Returns a :class:`ThrottleSignal` for a retriable throttle and ``None`` for
     everything the runner must NOT ride out: a genuine behavioral cap
     (budget/max-turns — the anti-cheat boundary), a credit exhaustion or weekly
-    cap (surface loud), a mislabeled success, or a real crash. A matched limit
-    phrase drives the disposition (RATE_LIMIT -> TRANSIENT, SUBSCRIPTION_SESSION ->
-    SUSTAINED); otherwise a transient infra marker (:data:`_TRANSIENT_INFRA_MARKERS`)
-    grades an unclassified transport/overload signal as TRANSIENT.
+    cap (surface loud), a mislabeled success, or an opaque behavioral error the
+    CLI reported via a ``result`` event. A matched limit phrase drives the
+    disposition (RATE_LIMIT -> TRANSIENT, SUBSCRIPTION_SESSION -> SUSTAINED);
+    otherwise a transient infra marker (:data:`_TRANSIENT_INFRA_MARKERS`), a
+    mid-stream transport crash (:data:`_TRANSPORT_CRASH_MARKERS`), or a
+    provisioning transient (:data:`_PROVISION_TRANSIENT_MARKERS`) — each a
+    subprocess/setup death with NO captured trajectory — grades as TRANSIENT.
     """
     if is_success_result_error(message) or classify_terminal_error(message) is not None:
         return None
@@ -163,7 +189,8 @@ def classify_transient_throttle(message: str) -> ThrottleSignal | None:
     if limit is not None:
         return _throttle_from_limit(limit.cause)
     haystack = message.casefold()
-    if any(marker in haystack for marker in _TRANSIENT_INFRA_MARKERS):
+    transient_markers = (*_TRANSIENT_INFRA_MARKERS, *_TRANSPORT_CRASH_MARKERS, *_PROVISION_TRANSIENT_MARKERS)
+    if any(marker in haystack for marker in transient_markers):
         return ThrottleSignal(kind=ThrottleKind.TRANSIENT, cause=None, wait_seconds=None)
     return None
 

--- a/tests/teatree_eval/test_api_errors.py
+++ b/tests/teatree_eval/test_api_errors.py
@@ -10,6 +10,21 @@ exhaustion, a 7-day weekly cap, a success mislabel, or a real crash).
 from teatree.eval.api_errors import ThrottleKind, classify_transient_throttle
 from teatree.llm.anthropic_limits import LimitCause, window_horizon
 
+#: The exact string the SDK surfaces when the subprocess CLI dies mid-stream with
+#: NO ``result`` event: the message reader's bare ``ProcessError`` (subprocess_cli
+#: L711, verbatim ``str()``), reported via the ``"Fatal error in message reader"``
+#: branch (query.py L351). No trajectory was captured, so a re-run launders nothing.
+_TRANSPORT_CRASH_MESSAGE = (
+    "Command failed with exit code 1 (exit code: 1)\nError output: Check stderr output for details"
+)
+#: The verbatim ``EphemeralCheckoutError`` string when a host RAM spike makes the
+#: per-run ephemeral-checkout ``git clone`` fail (ephemeral_checkout.py L126) — the
+#: SECOND transient shape that aborted a whole eval run. No trajectory, safe to re-run.
+_EPHEMERAL_GIT_CLONE_MESSAGE = (
+    "cannot provision an isolated ephemeral checkout at /tmp/t3-eval-ephemeral-checkout-x/teatree: "
+    "git clone failed. The sub-agent-spawning scenario REFUSES to run on the real clone."
+)
+
 
 class TestClassifyTransientThrottle:
     def test_rate_limit_is_transient(self) -> None:
@@ -36,6 +51,34 @@ class TestClassifyTransientThrottle:
         # genuine crash that must re-raise — never laundered into a retry. This is
         # the "preserve the genuine-crash red" contract the runner relies on.
         assert classify_transient_throttle("Claude Code returned an error result: error_during_execution") is None
+
+    def test_transport_crash_is_transient(self) -> None:
+        # A mid-stream subprocess-pipe death (bare ProcessError, NO result event)
+        # is INFRA, not a verdict: retrying it re-runs a scenario that produced
+        # nothing, so it rides out as a TRANSIENT throttle with backoff.
+        signal = classify_transient_throttle(_TRANSPORT_CRASH_MESSAGE)
+        assert signal is not None
+        assert signal.kind is ThrottleKind.TRANSIENT
+        assert signal.cause is None
+
+    def test_ephemeral_checkout_git_clone_failure_is_transient(self) -> None:
+        # A host RAM spike making the per-run ephemeral-checkout `git clone` fail
+        # aborts the scenario BEFORE any trajectory — INFRA, not a verdict. It rides
+        # out as a TRANSIENT throttle so the retried clone succeeds seconds later.
+        signal = classify_transient_throttle(_EPHEMERAL_GIT_CLONE_MESSAGE)
+        assert signal is not None
+        assert signal.kind is ThrottleKind.TRANSIENT
+        assert signal.cause is None
+
+    def test_behavioral_cap_wrapper_is_not_confused_for_transport_crash(self) -> None:
+        # The anti-cheat boundary at the classifier: a genuine cap DID produce a
+        # result event, so the SDK surfaces it as "returned an error result: ..."
+        # (query.py L342) — NEVER as the bare "Command failed with exit code"
+        # transport signature. Both max-turns and budget stay non-retriable.
+        max_turns = "Claude Code returned an error result: Reached maximum number of turns (3)"
+        budget = "Claude Code returned an error result: Reached maximum budget ($0.1)"
+        assert classify_transient_throttle(max_turns) is None
+        assert classify_transient_throttle(budget) is None
 
     def test_session_limit_is_sustained_with_window_wait(self) -> None:
         signal = classify_transient_throttle("session limit reached")

--- a/tests/teatree_eval/test_throttle_retry.py
+++ b/tests/teatree_eval/test_throttle_retry.py
@@ -11,6 +11,7 @@ from collections.abc import Callable
 import pytest
 
 from teatree.eval.api_errors import SuccessMislabelResultError, TerminalResultError
+from teatree.eval.ephemeral_checkout import EphemeralCheckoutError
 from teatree.eval.models import EvalRun
 from teatree.eval.throttle_retry import (
     THROTTLE_RETRY_MAX_ATTEMPTS,
@@ -20,6 +21,20 @@ from teatree.eval.throttle_retry import (
     resolve_throttle_retries,
 )
 from teatree.llm.anthropic_limits import CreditExhaustedError
+
+#: The verbatim string the SDK message reader surfaces when the subprocess CLI
+#: dies mid-stream with no ``result`` event (the "Fatal error in message reader"
+#: transport crash that aborted a whole eval run) — no trajectory, safe to re-run.
+_TRANSPORT_CRASH_MESSAGE = (
+    "Command failed with exit code 1 (exit code: 1)\nError output: Check stderr output for details"
+)
+#: The verbatim message an `EphemeralCheckoutError` carries when a host RAM spike
+#: makes the per-run ephemeral-checkout `git clone` fail — the second transient shape
+#: that aborted a whole eval run before this fix. No trajectory, safe to re-run.
+_EPHEMERAL_GIT_CLONE_MESSAGE = (
+    "cannot provision an isolated ephemeral checkout at /tmp/t3-eval-ephemeral-checkout-x/teatree: "
+    "git clone failed. The sub-agent-spawning scenario REFUSES to run on the real clone."
+)
 
 
 def _run(*, throttle_retries: int = 0, is_error: bool = False, terminal_reason: str = "success") -> EvalRun:
@@ -78,6 +93,28 @@ class TestThrottleRetryDriver:
         assert calls["n"] == 4
         assert run.throttle_retries == 3
         assert sleeps == [pytest.approx(1.0), pytest.approx(2.0), pytest.approx(4.0)]
+
+    def test_transport_crash_is_retried_then_success(self) -> None:
+        # A mid-stream SDK transport crash aborted the whole 2.5h run before this
+        # fix; it carries NO trajectory, so it is ridden out like any transient
+        # throttle and the retried attempt succeeds.
+        drive, calls = _scripted_drive([RuntimeError(_TRANSPORT_CRASH_MESSAGE), []])
+        sleeps: list[float] = []
+        run = _driver(sleeps).run(drive, _handlers())
+        assert calls["n"] == 2
+        assert run.throttle_retries == 1
+        assert sleeps == [pytest.approx(1.0)]
+
+    def test_ephemeral_checkout_transient_is_retried_then_success(self) -> None:
+        # A per-run ephemeral-checkout provision failure (a RAM-spike git-clone abort)
+        # carries NO trajectory; like any transient it is ridden out and the retried
+        # attempt succeeds — one flaky clone no longer kills the whole suite.
+        drive, calls = _scripted_drive([EphemeralCheckoutError(_EPHEMERAL_GIT_CLONE_MESSAGE), []])
+        sleeps: list[float] = []
+        run = _driver(sleeps).run(drive, _handlers())
+        assert calls["n"] == 2
+        assert run.throttle_retries == 1
+        assert sleeps == [pytest.approx(1.0)]
 
     def test_genuine_cap_is_graded_not_retried(self) -> None:
         cap = TerminalResultError(terminal_reason="max_turns", messages=[], cause=RuntimeError("max turns"))


### PR DESCRIPTION
## What & why

A single mid-stream claude-agent-sdk **transport crash** aborted the entire ~2.5h AI-eval run. When the subprocess CLI dies with **no `result` event**, the SDK message reader raises a bare `ProcessError` — `Command failed with exit code 1 (exit code: 1)\nError output: Check stderr output for details` — via its `Fatal error in message reader` branch (`_internal/query.py` L351). `classify_transient_throttle` returned `None` for that opaque exit-1, so `throttle_retry.py` re-raised and the whole suite died on one blip.

A transport crash carries **no captured trajectory** (0-byte, aborted before any verdict), so re-running the scenario launders nothing — it is INFRA, not a behavioral fail. This classifies that specific signature as TRANSIENT/retryable.

## The change

`src/teatree/eval/api_errors.py`:
- New `_TRANSPORT_CRASH_MARKERS = ("command failed with exit code",)` (L134-141).
- Folded into the transient pass in `classify_transient_throttle` (L180): `any(marker in haystack for marker in (*_TRANSIENT_INFRA_MARKERS, *_TRANSPORT_CRASH_MARKERS))`.

## Anti-cheat stays intact — by SDK construction

A genuine behavioral cap (max-turns / budget) **DID** emit a `result` event, so the SDK **replaces** the bare `ProcessError` with `Claude Code returned an error result: …` (`query.py` L342). That wrapped form never carries the `command failed with exit code` marker and is caught earlier by `classify_terminal_error` / the explicit `TerminalResultError` path in the driver. So:

- `TerminalResultError` (max_turns/budget cap) → still graded, NEVER retried.
- `CreditExhaustedError` → still fail-loud, propagates.
- `SuccessMislabelResultError` → still graded, not retried.
- Opaque `error_during_execution` terminus (a real `result` event) → still non-retriable.
- A bare opaque exit-1 with no transport marker → unaffected.

The transport marker fires **only** when no verdict exists → retry-safe.

## Tests (anti-vacuous, TDD)

- `test_transport_crash_is_retried_then_success` (driver) — retried-then-succeeds; **RED before the fix** (it re-raised).
- `test_transport_crash_is_transient` (classifier) — TRANSIENT, cause `None`; RED before the fix.
- `test_behavioral_cap_wrapper_is_not_confused_for_transport_crash` — the wrapped cap form stays non-retriable.
- Existing `test_genuine_cap_is_graded_not_retried`, `test_credit_exhaustion_propagates_not_retried`, `test_genuine_crash_re_raises_not_retried`, `test_opaque_error_result_is_not_a_throttle` all stay green.

**Non-vacuity of the cap anti-cheat proven:** temporarily routing the cap through the retry path made `test_genuine_cap_is_graded_not_retried` go RED (`assert 2 == 1`, attempt count 2 != 1), then reverted.

## Verification

- `tests/teatree_eval/` — 603 passed.
- `bash dev/ci-parity-fast.sh` — green (all prek gates incl. module-health, ty-check, tach, leak gates; 675 passed; exit 0).
- `ruff check` / `ruff format` / `ty check` — clean. comment-density — no findings.

## Architecture pre-check

Tactical fix — a narrow classifier-marker addition, one call site, no new module, no FSM/Protocol/OverlayBase surface. The one non-obvious design point is the anti-cheat boundary, documented above and in the `_TRANSPORT_CRASH_MARKERS` comment: the marker is provably cap-exclusive by SDK construction (a cap always emits a `result` event that replaces the bare ProcessError), so no behavioral fail can be laundered into a retry.
