### PR TITLE
feat(deploy): feed TEATREE_DISABLED_LOOPS from a repo variable

### DIFF
--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -95,6 +95,12 @@ jobs:
           T3_ADMIN_PASSWORD: ${{ secrets.T3_ADMIN_PASSWORD }}
           GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
+          # Repo VARIABLE (not a secret): the box's fleet-scoped loop split,
+          # consumed by the entrypoint's disable_fleet_scoped_loops. The
+          # fallback preserves the historical default when the variable is
+          # unset; the entrypoint validates every name and fails the deploy
+          # loudly on a typo.
+          TEATREE_DISABLED_LOOPS: ${{ vars.TEATREE_DISABLED_LOOPS || 'inbox,review,directive_loop' }}
         run: |
           SSH="ssh -p ${SSH_PORT} -i ${HOME}/.ssh/id_deploy -o UserKnownHostsFile=${HOME}/.ssh/known_hosts -o StrictHostKeyChecking=yes -o ConnectTimeout=20"
           TARGET="${SSH_USER}@${SERVER_IP}"
@@ -110,6 +116,7 @@ jobs:
             printf 'T3_ADMIN_PASSWORD=%s\n' "$T3_ADMIN_PASSWORD"
             printf 'GIT_AUTHOR_NAME=%s\n' "$GIT_AUTHOR_NAME"
             printf 'GIT_AUTHOR_EMAIL=%s\n' "$GIT_AUTHOR_EMAIL"
+            printf 'TEATREE_DISABLED_LOOPS=%s\n' "$TEATREE_DISABLED_LOOPS"
           } | $SSH "$TARGET" 'umask 077; cat > "$HOME/teatree-deploy/deploy/teatree.env"'
 
           # 3. Converge the stack (deploy.sh reads no secrets — compose's env_file does).


### PR DESCRIPTION
Plumbs the repo variable `TEATREE_DISABLED_LOOPS` (set to `inbox,directive_loop`) into `teatree.env`, with the historical `inbox,review,directive_loop` as fallback when the variable is unset. This makes the box's enabled `review` loop (the solo-overlay merge engine) survive redeploys instead of being re-disabled by `disable_fleet_scoped_loops` on every init. The entrypoint already validates every loop name and fails the deploy loudly on a typo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EyaPvyGQjoSdJ9vUsFwvt