### PR TITLE
feat(deploy): option-b Anthropic credential routing via a box pass store

### DIFF
--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -41,9 +41,14 @@ jobs:
           GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
         run: |
+          # CLAUDE_CODE_OAUTH_TOKEN is deliberately NOT required: a box whose
+          # pass store is provisioned with anthropic/<account>/oauth-token
+          # entries (anthropic_oauth_pass_paths routing) runs without the env
+          # token — the entrypoint preflight fails loud when NEITHER source
+          # exists, so removing the secret cannot silently deploy a dead loop.
           missing=0
           for name in HCLOUD_TOKEN HETZNER_SERVER_NAME HETZNER_SSH_KEY HETZNER_SSH_KNOWN_HOSTS \
-                      HETZNER_SSH_USER HETZNER_SSH_PORT CLAUDE_CODE_OAUTH_TOKEN TEATREE_GH_TOKEN \
+                      HETZNER_SSH_USER HETZNER_SSH_PORT TEATREE_GH_TOKEN \
                       T3_ADMIN_USER T3_ADMIN_PASSWORD GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL; do
             if [ -z "${!name}" ]; then
               echo "MISSING SECRET $name - set it under Settings > Secrets and re-run"
@@ -109,8 +114,13 @@ jobs:
           $SSH "$TARGET" 'set -e; REMOTE_DIR="$HOME/teatree-deploy"; if [ ! -d "$REMOTE_DIR/.git" ]; then git clone https://github.com/souliane/teatree.git "$REMOTE_DIR"; fi; mkdir -p "$REMOTE_DIR/deploy"'
 
           # 2. Write the secrets file (piped over stdin — never on argv or in logs; mode 600).
+          # The Anthropic env token is written only when the secret exists; without
+          # it the box resolves credentials via its pass store (option-b routing),
+          # and an absent env line is what lets the pass rotation actually win.
           {
-            printf 'CLAUDE_CODE_OAUTH_TOKEN=%s\n' "$CLAUDE_CODE_OAUTH_TOKEN"
+            if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+              printf 'CLAUDE_CODE_OAUTH_TOKEN=%s\n' "$CLAUDE_CODE_OAUTH_TOKEN"
+            fi
             printf 'TEATREE_GH_TOKEN=%s\n' "$TEATREE_GH_TOKEN"
             printf 'T3_ADMIN_USER=%s\n' "$T3_ADMIN_USER"
             printf 'T3_ADMIN_PASSWORD=%s\n' "$T3_ADMIN_PASSWORD"

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -5,10 +5,12 @@
 FROM ubuntu:24.04
 
 # Toolchain layer — ca-certificates, curl, git, jq, sqlite3, direnv, node 24, the
-# claude CLI (as in dev/Dockerfile.test) plus gh. No pass/gpg (auth is token-only).
+# claude CLI (as in dev/Dockerfile.test) plus gh, plus pass/gnupg so the box can
+# route the Anthropic credential through a per-account pass store
+# (anthropic_oauth_pass_paths) instead of a single env token.
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends \
-        ca-certificates curl direnv git jq sqlite3 && \
+        ca-certificates curl direnv git gnupg jq pass sqlite3 && \
     curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
     apt-get install -y -qq --no-install-recommends nodejs && \
     install -m 0755 -d /etc/apt/keyrings && \
@@ -52,11 +54,16 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 # it explicitly to that same canonical value would make paths.py refuse every
 # loop-provisioned worktree (CanonicalDBFromWorktreeError) and defeat the
 # teatree_worktrees auto-isolation volume.
+# The pass store and its GPG home live under the teatree_data volume so a
+# provisioned multi-account credential store survives container recreation
+# (the container HOME itself is image-backed and reset on every deploy).
 ENV PATH="/opt/teatree/uv/bin:/home/teatree/.local/bin:${PATH}" \
     UV_TOOL_DIR=/opt/teatree/uv/tools \
     UV_TOOL_BIN_DIR=/opt/teatree/uv/bin \
     UV_PYTHON_INSTALL_DIR=/opt/teatree/uv/python \
     TEATREE_CLONE_DIR=/home/teatree/teatree \
-    TEATREE_REPO_URL=https://github.com/souliane/teatree.git
+    TEATREE_REPO_URL=https://github.com/souliane/teatree.git \
+    PASSWORD_STORE_DIR=/home/teatree/.local/share/teatree/.password-store \
+    GNUPGHOME=/home/teatree/.local/share/teatree/.gnupg
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -30,10 +30,27 @@ git config --global user.email "${GIT_AUTHOR_EMAIL:-teatree@localhost}"
 git config --global init.defaultBranch main
 git config --global --add safe.directory "$CLONE_DIR"
 
+# The pass store's GPG home rides the teatree_data volume (see Dockerfile ENV);
+# gpg refuses a home directory that is readable by group/other, and volume
+# copy-up does not preserve the mode a provisioning run set. Every role fixes
+# the mode before anything reads a credential.
+if [ -n "${GNUPGHOME:-}" ] && [ -d "$GNUPGHOME" ]; then
+    chmod 700 "$GNUPGHOME"
+fi
+
+# True when the box pass store holds at least one Anthropic account entry —
+# the option-b credential source (anthropic_oauth_pass_paths routing).
+pass_store_has_anthropic() {
+    pass ls anthropic >/dev/null 2>&1
+}
+
 # Fail loud, early, and actionably when a required runtime token is missing or
 # does not authenticate — otherwise a green deploy hides a dead loop.
 init_preflight() {
-    : "${CLAUDE_CODE_OAUTH_TOKEN:?MISSING CLAUDE_CODE_OAUTH_TOKEN - set the repo secret and re-run Deploy}"
+    if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && ! pass_store_has_anthropic; then
+        echo "entrypoint: no Anthropic credential - set the CLAUDE_CODE_OAUTH_TOKEN repo secret, OR provision the box pass store (anthropic/<account>/oauth-token entries) and set anthropic_oauth_pass_paths - then re-run Deploy" >&2
+        exit 1
+    fi
     : "${TEATREE_GH_TOKEN:?MISSING TEATREE_GH_TOKEN - set the repo secret and re-run Deploy}"
     : "${GIT_AUTHOR_NAME:?MISSING GIT_AUTHOR_NAME - set the repo secret and re-run Deploy}"
     : "${GIT_AUTHOR_EMAIL:?MISSING GIT_AUTHOR_EMAIL - set the repo secret and re-run Deploy}"


### PR DESCRIPTION
Enables multi-account Anthropic credential rotation on the headless box. Env token beats pass in `llm/credentials` resolution, so as long as the deploy wrote `CLAUDE_CODE_OAUTH_TOKEN` into `teatree.env`, `anthropic_oauth_pass_paths` routing could never engage on the box.

- **Dockerfile**: install `pass`/`gnupg`; pin `PASSWORD_STORE_DIR` and `GNUPGHOME` onto the `teatree_data` volume (container HOME is image-backed and reset each deploy).
- **entrypoint**: chmod 700 the GPG home on every role start (volume copy-up loses modes); init preflight now accepts either the env token or a provisioned `anthropic/<account>/oauth-token` pass entry, still failing loud when neither exists.
- **workflow**: `CLAUDE_CODE_OAUTH_TOKEN` becomes optional and its `teatree.env` line is written only when the secret is set — deleting the secret is the deliberate switch to pass-store routing.

Provisioning (one-time, after this deploys): generate a no-passphrase key in the container, `pass init`, insert the account tokens, set `anthropic_oauth_pass_paths`, delete the repo secret, redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EyaPvyGQjoSdJ9vUsFwvt