### PR TITLE
fix(loops): silence spurious WARNING for helper subpackages in loop registry (#3212)

### DIFF
--- a/src/teatree/loops/registry.py
+++ b/src/teatree/loops/registry.py
@@ -7,7 +7,11 @@ and returns the constants sorted alphabetically by name.
 
 Only true subpackages are considered (``sub.ispkg``), so the top-level helper
 modules (``base``, ``registry``, ``config``, ``run``, …) — plain ``.py`` files,
-not packages — are skipped by that check alone.
+not packages — are skipped by that check alone. Helper *subpackages* that carry
+no ``loop`` submodule (e.g. ``shared``, holding cross-loop utilities) are skipped
+silently: a missing ``teatree.loops.<sub>.loop`` is the expected shape, not an
+error, and only a ``loop`` module that exists but fails to import warrants a
+``WARNING``.
 """
 
 import importlib
@@ -29,7 +33,13 @@ def iter_loops() -> tuple[MiniLoop, ...]:
         try:
             mod = importlib.import_module(f"teatree.loops.{sub.name}.loop")
         except ImportError as exc:
-            logger.warning("Skipping loop %r — import failed: %s", sub.name, exc)
+            missing_own_loop = isinstance(exc, ModuleNotFoundError) and exc.name == f"teatree.loops.{sub.name}.loop"
+            if missing_own_loop:
+                # Helper subpackage with no ``loop`` submodule — expected, not an error.
+                logger.debug("Skipping %r — no loop submodule (helper package)", sub.name)
+            else:
+                # ``loop`` exists but its own import chain is broken — a real error.
+                logger.warning("Skipping loop %r — import failed: %s", sub.name, exc)
             continue
         mini_loop = getattr(mod, "MINI_LOOP", None)
         if not isinstance(mini_loop, MiniLoop):

--- a/tests/teatree_loops/test_registry.py
+++ b/tests/teatree_loops/test_registry.py
@@ -1,5 +1,10 @@
 """Registry — discover MINI_LOOP constants via pkgutil.iter_modules."""
 
+import importlib
+import logging
+import sys
+
+import teatree.loops as _loops_pkg
 from teatree.loops.base import MiniLoop
 from teatree.loops.registry import iter_loops
 
@@ -29,3 +34,43 @@ class TestIterLoops:
     def test_each_entry_is_a_mini_loop(self) -> None:
         for loop in iter_loops():
             assert isinstance(loop, MiniLoop)
+
+
+class TestHelperPackageDiscovery:
+    """Discovery separates a no-``loop`` helper package from a broken loop.
+
+    A subpackage that carries no ``loop`` submodule (expected, silent) must not
+    be conflated with a ``loop`` module that exists but fails to import (a real
+    error worth a WARNING).
+    """
+
+    def test_shared_helper_package_emits_no_warning(self, caplog) -> None:
+        # ``teatree.loops.shared`` is a real utilities subpackage with no
+        # ``loop`` submodule; discovery must skip it silently, not WARN on
+        # every tick (regression for the per-tick "Skipping loop 'shared'" spam).
+        with caplog.at_level(logging.WARNING, logger="teatree.loops.registry"):
+            iter_loops()
+        offenders = [r.getMessage() for r in caplog.records if "shared" in r.getMessage()]
+        assert offenders == [], offenders
+
+    def test_broken_loop_module_still_warns(self, caplog, tmp_path, monkeypatch) -> None:
+        # A subpackage whose ``loop`` module EXISTS but imports a missing
+        # dependency is a genuine error — it must still surface a WARNING and
+        # not be silenced along with the no-loop-submodule case.
+        pkg = "brokenloopfixture"
+        pkg_dir = tmp_path / pkg
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text("")
+        (pkg_dir / "loop.py").write_text("import teatree_missing_dependency_xyz\n")
+        monkeypatch.setattr(_loops_pkg, "__path__", [*_loops_pkg.__path__, str(tmp_path)])
+        importlib.invalidate_caches()
+        try:
+            with caplog.at_level(logging.WARNING, logger="teatree.loops.registry"):
+                iter_loops()
+            warned = [
+                r.getMessage() for r in caplog.records if pkg in r.getMessage() and "import failed" in r.getMessage()
+            ]
+            assert warned, [r.getMessage() for r in caplog.records]
+        finally:
+            sys.modules.pop(f"teatree.loops.{pkg}", None)
+            sys.modules.pop(f"teatree.loops.{pkg}.loop", None)


### PR DESCRIPTION
## Summary

`iter_loops()` imported `teatree.loops.<sub>.loop` for every subpackage and logged a WARNING whenever that import failed. The `shared` utilities subpackage has no `loop` submodule, so it emitted `Skipping loop 'shared' - import failed: No module named 'teatree.loops.shared.loop'` on **every** loop tick, flooding `teatree.log`.

## Fix

Distinguish a *missing* `loop` submodule (expected for helper packages like `shared`, now logged at `debug`) from a `loop` module that *exists but fails to import* (a real error, still `WARNING`), keyed on `ModuleNotFoundError.name`.

## Tests

- `test_shared_helper_package_emits_no_warning` - regression: the real `shared` package must produce no WARNING (verified RED on old code, GREEN with the fix).
- `test_broken_loop_module_still_warns` - a synthetic subpackage whose `loop.py` imports a missing dependency must still WARN (covers the real-error branch).

Closes #3212
