### PR TITLE
fix(deploy): link the runtime clone into clone_root so fleet claims resolve

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -38,6 +38,11 @@ RUN mkdir -p \
         /home/teatree/.local/share/teatree-worktrees \
         /home/teatree/workspace/t3-workspaces \
         /opt/teatree/uv && \
+    # clone_root() resolves clones under ~/workspace, but the runtime clone
+    # lives on the teatree_src volume at ~/teatree — without this link the
+    # fleet-claim wire finds no local clone for the repo and fails safe
+    # (never claims), silently disabling the issue-implementer intake.
+    ln -s /home/teatree/teatree /home/teatree/workspace/teatree && \
     chown -R teatree:teatree /home/teatree /opt/teatree
 
 COPY --chmod=0755 deploy/entrypoint.sh /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
With `fleet_claim_enabled=true`, `wire._resolve_clone` looks for a local clone of the issue's repo under `clone_root()` (`~/workspace/<repo>`). The box's runtime clone lives at `~/teatree` (the `teatree_src` volume), so every acquire failed safe — `fleet_claim ON but no local clone resolves … failing safe (not claiming)` — and the issue-implementer intake was silently dead on the box. A build-time symlink (`~/workspace/teatree -> ~/teatree`) makes the clone resolvable; verified live on the box (the same link applied by hand let the scanner claim and dispatch immediately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EyaPvyGQjoSdJ9vUsFwvt