### PR TITLE
fix(mcp): declare the teatree MCP server in the shipped .mcp.json (#3211)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,3 +1,8 @@
 {
-  "mcpServers": {}
+  "mcpServers": {
+    "teatree": {
+      "command": "t3",
+      "args": ["mcp", "serve"]
+    }
+  }
 }

--- a/tests/teatree_core/test_mcp_registration.py
+++ b/tests/teatree_core/test_mcp_registration.py
@@ -87,3 +87,19 @@ class TestVerifyTeatreeMcpRegistration:
         outcome = verify_teatree_mcp_registration(tmp_path)
 
         assert outcome.ok is False
+
+
+class TestShippedMcpJson:
+    """The committed repo-root ``.mcp.json`` must declare the teatree server.
+
+    Without it, every fresh install falls back to shelling out to the ``t3``
+    CLI instead of the ``mcp__teatree__*`` tools, and ``t3 setup`` / ``t3
+    doctor`` warn forever (the registrar is read-only and never writes it).
+    """
+
+    def test_repo_mcp_json_declares_teatree_server(self) -> None:
+        repo_root = Path(__file__).resolve().parents[2]
+
+        outcome = verify_teatree_mcp_registration(repo_root)
+
+        assert outcome.ok is True, outcome.message


### PR DESCRIPTION
## Summary

The plugin-bundled `.mcp.json` at the repo root shipped **empty** (`{"mcpServers": {}}`), so it declared **no** `teatree` MCP server. Every fresh install therefore got a `t3 setup` / `t3 doctor` WARN and silently fell back to shelling out to the `t3` CLI for structured reads instead of using the `mcp__teatree__*` tools. `McpServerRegistrar` is read-only (the file ships committed), so an empty committed file could never self-heal.

## Fix

Populate `.mcp.json` with the stdio declaration the verifier expects (`command: "t3"`, `args: ["mcp", "serve"]`, `EXPECTED_COMMAND` / `EXPECTED_ARGS`).

## Tests

- `TestShippedMcpJson::test_repo_mcp_json_declares_teatree_server` - asserts the **real committed** `.mcp.json` passes `verify_teatree_mcp_registration(repo_root)` (there was no such assertion before, which is why it regressed). Verified RED on the empty file, GREEN with the declaration.

Closes #3211
