### PR TITLE
fix(eval): shard the full-suite eval-ci-heal across parallel CI jobs + adaptive single-trial

### DIFF
--- a/.github/workflows/eval-ci-heal.yml
+++ b/.github/workflows/eval-ci-heal.yml
@@ -9,9 +9,30 @@
 # invocation `eval.yml` / `eval-pr-reusable.yml` already prove — it reinvents
 # nothing about HOW the eval runs, only WHICH scenarios and WHAT it uploads.
 #
+# WHY SHARDED (souliane/teatree#3202)
+#   The FULL suite (~231 scenarios) cannot finish in ONE eval step inside any
+#   reasonable per-step timeout — a single invocation timed out at ~127/231, its
+#   retry re-ran from scratch and timed out again, and NO JSON was produced. So the
+#   full suite is FANNED OUT across a parallel matrix of `shards` legs: each leg
+#   runs `t3 eval run --shard <index>/<total>`, a deterministic partition by
+#   scenario name (every scenario in exactly one shard, none dropped or duplicated),
+#   so every leg meters a bounded subset well under the step cap. A final `combine`
+#   job merges every shard's per-scenario JSON into ONE `eval-heal-<sha>.json` with
+#   the same §2.4 schema, so the `t3 eval ci-status` download path is unchanged.
+#
+# ADAPTIVE SINGLE-TRIAL (souliane/teatree#3202)
+#   The eval runs SINGLE-TRIAL by default with `--escalate-on-fail`: a passing
+#   scenario runs ONCE (halving the base spend of the retired blanket pass@2, which
+#   ran every scenario twice), and only a scenario that FAILS its single trial is
+#   re-run at higher trials to confirm — the lane reds only on a confirmed failure,
+#   a flake recovers.
+#
 # INPUTS
 #   * scenarios  — comma-joined scenario names (the red subset a heal re-trigger
-#                  re-runs). EMPTY (default) = the full suite, in ONE invocation.
+#                  re-runs). EMPTY (default) = the full suite, sharded. A NON-empty
+#                  subset is NOT sharded — one leg runs the named subset loop.
+#   * shards     — how many parallel legs the full suite fans out across (default 8;
+#                  ignored when `scenarios` is non-empty).
 #   * credential — subscription_oauth (default, no per-token bill) | metered_api_key.
 #   * pr_ref     — the branch to check out and eval (default: the dispatched ref),
 #                  so the workflow definition can live on main while the eval runs
@@ -31,9 +52,10 @@
 #
 # PUBLISH SAFETY
 #   The `eval-heal-<sha>` JSON is publish-safe BY CONSTRUCTION (only spec identity +
-#   verdict + triage discriminators — no transcript). The per-trial transcript
-#   (`eval-heal-transcript-<sha>`) is PRIVATE: the heal loop downloads it to the box
-#   for the fix agent to read; it is NEVER published.
+#   verdict + triage discriminators — no transcript), and the merge only folds those
+#   already-sanitized rows, so the combined artifact stays publish-safe. The per-trial
+#   transcript (`eval-heal-transcript-<sha>-<shard>`) is PRIVATE: the heal loop
+#   downloads it to the box for the fix agent to read; it is NEVER published.
 # ============================================================
 
 name: Eval CI heal
@@ -42,9 +64,14 @@ on:
   workflow_dispatch:
     inputs:
       scenarios:
-        description: "Comma-joined scenario names to run (the red subset). Empty = the full suite."
+        description: "Comma-joined scenario names to run (the red subset). Empty = the full suite, sharded."
         required: false
         default: ""
+        type: string
+      shards:
+        description: "Parallel shards the full suite fans out across (default 8; ignored for a named subset)."
+        required: false
+        default: "8"
         type: string
       credential:
         description: "Eval credential (subscription_oauth | metered_api_key). Default subscription_oauth — no per-token bill, a depleting usage window; metered_api_key is per-token cost, no window."
@@ -62,12 +89,49 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # EVAL: run the heal subset (or the full suite) in the CI container, emitting the
-  # publish-safe JSON + the private transcript. FAIL LOUD on a hang — the job cap
-  # sits just above the 2x80min eval-step budget so a wedge is killed, not stalled.
+  # PREPARE: resolve the checked-out head SHA once (every shard + the combine job
+  # key their artifact names on it) and compute the shard matrix. Empty `scenarios`
+  # fans the full suite out across `shards` legs; a named subset emits ONE unsharded
+  # leg. The helper imports nothing from teatree, so no `uv sync` is needed here.
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.sha.outputs.sha }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ inputs.pr_ref || github.ref }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.13"
+      # Resolve the ACTUAL checked-out SHA (pr_ref may differ from github.sha) so
+      # the JSON's head_sha and every artifact name key on the tree that was eval'd.
+      - name: Resolve the checked-out head SHA
+        id: sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Compute the shard matrix
+        id: matrix
+        env:
+          EVAL_SHARDS: ${{ inputs.shards }}
+          EVAL_SCENARIOS: ${{ inputs.scenarios }}
+        run: |
+          MATRIX="$(python scripts/eval/shard_matrix.py --shards "$EVAL_SHARDS" --scenarios "$EVAL_SCENARIOS")"
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "Shard matrix: $MATRIX"
+
+  # EVAL: run ONE shard of the full suite (or the whole named subset) in the CI
+  # container, emitting the publish-safe JSON + the private transcript. A red shard
+  # does not cancel the others — each leg's verdict is independent. The job cap sits
+  # just above the 2x80min eval-step budget so a wedge is killed, not stalled.
   eval:
+    needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -93,30 +157,40 @@ jobs:
           claude --version
       - name: Migrate the self-DB (the eval run-history ledger persists into it)
         run: uv run python -m teatree migrate --no-input
-      # Resolve the ACTUAL checked-out SHA (pr_ref may differ from github.sha) so the
-      # JSON's head_sha and the artifact names key on the tree that was eval'd.
-      - name: Resolve the checked-out head SHA
-        id: sha
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      # A filesystem-safe per-shard artifact suffix ('1/8' -> '1-8', empty subset
+      # token -> 'subset'), computed BEFORE the eval so each leg's summary JSON and
+      # transcript are uniquely named — a shared basename would collide under
+      # `merge-multiple` in the combine job and drop all but one shard's results.
+      - name: Filesystem-safe per-shard artifact suffix
+        id: artifact
+        env:
+          EVAL_SHARD: ${{ matrix.shard }}
+        run: |
+          if [ -z "$EVAL_SHARD" ]; then
+            echo "suffix=subset" >> "$GITHUB_OUTPUT"
+          else
+            echo "suffix=${EVAL_SHARD//\//-}" >> "$GITHUB_OUTPUT"
+          fi
       # Run the eval IN the CI image (dev/Dockerfile.test), exactly as eval.yml does:
-      # `--backend api` on the in-process Agent SDK, `--trials 2 --require any` (the
-      # right-sized pass@k), `--effort high` (a single representative tier),
+      # `--backend api` on the in-process Agent SDK, `--escalate-on-fail` (the ADAPTIVE
+      # single-trial-with-escalation default — a passing scenario runs once, a real
+      # failure escalates to pass@k), `--effort high` (a single representative tier),
       # `--require-executed` armed unconditionally, `--docker` routing through the
       # image with the SELECTED credential forwarded via docker `-e`. EMPTY scenarios
-      # = the full suite in ONE invocation; a comma-joined subset loops one
-      # `t3 eval run <name>` per scenario (the eval-pr-reusable.yml shape) since the
-      # positional NAME filter runs one scenario. All caller values ride env vars
-      # (never inlined into a run line). Both the JSON and the transcript land in the
-      # ONE writable artifacts dir (the docker runner mounts a single parent).
-      - name: Behavioral eval — the heal subset (in Docker)
+      # = ONE shard of the full suite (`--shard $EVAL_SHARD`); a comma-joined subset
+      # loops one `t3 eval run <name>` per scenario (the eval-pr-reusable.yml shape).
+      # All caller values ride env vars (never inlined into a run line). Both the JSON
+      # and the transcript land in the ONE writable artifacts dir (a single mounted parent).
+      - name: Behavioral eval — one shard (in Docker)
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           T3_EVAL_CREDENTIAL: ${{ inputs.credential || 'subscription_oauth' }}
-          GITHUB_SHA: ${{ steps.sha.outputs.sha }}
+          GITHUB_SHA: ${{ needs.prepare.outputs.sha }}
           EVAL_SCENARIOS: ${{ inputs.scenarios }}
-          EVAL_TRIALS: "2"
+          EVAL_SHARD: ${{ matrix.shard }}
+          SUFFIX: ${{ steps.artifact.outputs.suffix }}
           HEAL_DIR: ${{ runner.temp }}/heal
         with:
           timeout_minutes: 80
@@ -126,40 +200,105 @@ jobs:
             set -euo pipefail
             mkdir -p "$HEAL_DIR"
             if [ -z "$EVAL_SCENARIOS" ]; then
-              uv run t3 eval run --backend api --trials "$EVAL_TRIALS" --require any \
-                --effort high --require-executed --docker \
-                --transcript-html "$HEAL_DIR/eval-transcripts.html" \
-                --summary-json "$HEAL_DIR/eval-heal.json"
+              uv run t3 eval run --backend api --escalate-on-fail \
+                --effort high --require-executed --docker --shard "$EVAL_SHARD" \
+                --transcript-html "$HEAL_DIR/eval-transcripts-$SUFFIX.html" \
+                --summary-json "$HEAL_DIR/eval-heal-shard-$SUFFIX.json"
             else
               rc=0
               IFS=',' read -ra NAMES <<< "$EVAL_SCENARIOS"
               for name in "${NAMES[@]}"; do
                 name="$(echo "$name" | xargs)"
                 [ -z "$name" ] && continue
-                uv run t3 eval run "$name" --backend api --trials "$EVAL_TRIALS" --require any \
+                uv run t3 eval run "$name" --backend api --escalate-on-fail \
                   --effort high --require-executed --docker \
                   --transcript-html "$HEAL_DIR/eval-transcripts-$name.html" \
                   --summary-json "$HEAL_DIR/eval-heal-$name.json" || rc=$?
               done
               exit "$rc"
             fi
-      # The PUBLISH-SAFE per-scenario JSON (triage class, no transcript) — the
-      # artifact the heal loop downloads and triages. `if: always()` so a red run
-      # still publishes it (a red run is precisely when the reds must be triaged).
-      - name: Upload the publish-safe per-scenario JSON
+      # This shard's PUBLISH-SAFE per-scenario JSON (triage class, no transcript) —
+      # the combine job merges every shard's JSON into the one `eval-heal-<sha>`.
+      # `if: always()` so a red shard still publishes it (a red run is precisely when
+      # the reds must be triaged). The per-shard suffix keeps parallel legs distinct.
+      - name: Upload this shard's publish-safe per-scenario JSON
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
-          name: eval-heal-${{ steps.sha.outputs.sha }}
+          name: eval-heal-shard-${{ needs.prepare.outputs.sha }}-${{ steps.artifact.outputs.suffix }}
           path: ${{ runner.temp }}/heal/eval-heal*.json
           if-no-files-found: warn
-      # The PRIVATE per-trial transcript (reasoning + tool calls) — downloaded to the
-      # box for the fix agent, NEVER published. `if: always()` so a red run still
-      # captures it (the transcript is exactly what a fix diagnoses).
-      - name: Upload the private per-trial transcript
+      # This shard's PRIVATE per-trial transcript (reasoning + tool calls) —
+      # downloaded to the box for the fix agent, NEVER published. `if: always()` so
+      # a red shard still captures it (the transcript is exactly what a fix diagnoses).
+      - name: Upload this shard's private per-trial transcript
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
-          name: eval-heal-transcript-${{ steps.sha.outputs.sha }}
+          name: eval-heal-transcript-${{ needs.prepare.outputs.sha }}-${{ steps.artifact.outputs.suffix }}
           path: ${{ runner.temp }}/heal/eval-transcripts*.html
+          if-no-files-found: warn
+
+  # COMBINE: fold every shard's publish-safe per-scenario JSON into ONE
+  # `eval-heal-<sha>.json` (totals summed, scenarios concatenated — the same §2.4
+  # schema), so the `t3 eval ci-status` download path reads the combined run exactly
+  # as it read a single-invocation run. `if: always()` so a red shard still merges
+  # (a red run is when the reds must be triaged); the merge only folds already-
+  # sanitized rows, so the combined artifact stays publish-safe. Guarded on prepare
+  # success — there is nothing to combine if the matrix never computed.
+  combine:
+    needs: [prepare, eval]
+    if: always() && needs.prepare.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ inputs.pr_ref || github.ref }}
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
+        with:
+          enable-cache: true
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.13"
+      - name: Sync dependencies (retry on transient network failure)
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60  # v4
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: uv sync
+      # Pull every shard's publish-safe JSON into one dir (`merge-multiple` flattens
+      # the per-artifact subdirs). Only the `eval-heal-shard-<sha>-*` JSONs — never
+      # the private `eval-heal-transcript-*` HTML.
+      - name: Download every shard's publish-safe JSON
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          path: ${{ runner.temp }}/shards
+          pattern: eval-heal-shard-${{ needs.prepare.outputs.sha }}-*
+          merge-multiple: true
+      # Merge the per-shard JSONs into ONE §2.4 `eval-heal-<sha>.json` — totals
+      # summed, scenarios concatenated. `--sha`/`--generated-at` are injected (never
+      # computed in the merge), so the fold is deterministic. Only publish-safe rows
+      # are read, so the combined artifact carries no transcript.
+      - name: Merge the shard JSONs into one eval-heal-<sha>.json
+        env:
+          SHA: ${{ needs.prepare.outputs.sha }}
+          SHARDS_DIR: ${{ runner.temp }}/shards
+          OUT_DIR: ${{ runner.temp }}/combined
+        run: |
+          set -euo pipefail
+          mkdir -p "$OUT_DIR"
+          GENERATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          uv run t3 eval merge-summary-json "$SHARDS_DIR" \
+            --sha "$SHA" --generated-at "$GENERATED_AT" \
+            --out "$OUT_DIR/eval-heal-$SHA.json"
+      # Upload the ONE merged JSON under the `eval-heal-<sha>` name the
+      # `t3 eval ci-status` download path resolves — the combine seam that keeps the
+      # sharded run indistinguishable from a single-invocation run to every consumer.
+      - name: Upload the merged publish-safe eval-heal JSON
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: eval-heal-${{ needs.prepare.outputs.sha }}
+          path: ${{ runner.temp }}/combined/eval-heal-*.json
           if-no-files-found: warn

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1542,6 +1542,8 @@ Usage: t3 eval [OPTIONS] COMMAND [ARGS]...
 │                         --skip-code (non-list payload exits 2).              │
 │ merge-summaries         Merge per-shard summary markdown into one dashboard  │
 │                         (to --out or stdout).                                │
+│ merge-summary-json      Merge per-shard eval-heal summary JSONs into one     │
+│                         §2.4 JSON (to --out or stdout).                      │
 │ prepare-transcript      Emit the per-scenario prompts for a LOCAL            │
 │                         transcript-backend eval run.                         │
 │ history                 Show recent eval runs and per-scenario pass-rate     │
@@ -1902,6 +1904,31 @@ Usage: t3 eval merge-summaries [OPTIONS] INPUTS...
 │                                here).                                        │
 │                                [required]                                    │
 │    --out                 PATH  Write the dashboard to this path instead of   │
+│                                stdout.                                       │
+│    --help                      Show this message and exit.                   │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 eval merge-summary-json`
+
+```
+Usage: t3 eval merge-summary-json [OPTIONS] INPUTS...
+
+ Merge per-shard eval-heal summary JSONs into one §2.4 JSON (to --out or
+ stdout).
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    inputs      INPUTS...  Per-shard summary .json files, or a directory of │
+│                             them.                                            │
+│                             [required]                                       │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ *  --sha                 TEXT  The commit SHA the run measured (injected).   │
+│                                [required]                                    │
+│ *  --generated-at        TEXT  ISO-8601 timestamp (injected; never computed  │
+│                                here).                                        │
+│                                [required]                                    │
+│    --out                 PATH  Write the merged JSON to this path instead of │
 │                                stdout.                                       │
 │    --help                      Show this message and exit.                   │
 ╰──────────────────────────────────────────────────────────────────────────────╯

--- a/evals/README.md
+++ b/evals/README.md
@@ -204,7 +204,8 @@ t3 eval label review                          # validate every label loads + eve
 t3 eval changed-scenarios < changed-files.txt # CI primitive: print the scenario names a PR's STDIN diff touched (selective-PR gate); exit --skip-code when none
 t3 eval merged-prs-since --prs-file prs.json --days 7  # CI primitive: exit 0 iff any PR merged in the window (the scheduled-eval no-PR guard); else --skip-code
 t3 eval merge-summaries summaries/ --run-url … --sha … --generated-at …  # CI primitive: merge per-shard sanitized summaries into one weekly dashboard
-t3 eval ci-trigger --ref <pr-branch>          # CI heal loop: dispatch eval-ci-heal (workflow_dispatch, scenarios/credential/pr_ref inputs) against a PR branch; prints the head SHA the run keys on (non-blocking)
+t3 eval merge-summary-json shards/ --sha … --generated-at … --out eval-heal-<sha>.json  # CI heal loop: fold per-shard publish-safe --summary-json artifacts into one eval-heal-<sha> JSON (totals summed, scenarios concatenated)
+t3 eval ci-trigger --ref <pr-branch>          # CI heal loop: dispatch eval-ci-heal (workflow_dispatch, scenarios/shards/credential/pr_ref inputs) against a PR branch; prints the head SHA the run keys on (non-blocking)
 t3 eval ci-status --ref <pr-branch>           # CI heal loop: resolve a PR branch's newest eval-ci-heal run and print its structured verdict + triaged reds (non-blocking)
 ```
 
@@ -220,7 +221,11 @@ reuses teatree's eval CI instead of duplicating it.
 dispatches the `eval-ci-heal` workflow against a PR branch and reports the
 `(branch, head_sha)` the monitor keys on; `ci-status` resolves that run and
 returns the structured verdict plus the triaged reds. Both are non-blocking (they
-dispatch/read and return) so the orchestrator owns the wait.
+dispatch/read and return) so the orchestrator owns the wait. The full suite is
+sharded across a parallel matrix inside `eval-ci-heal` (the `shards` input, default
+8); each shard uploads its own publish-safe `--summary-json`, and the workflow's
+`combine` job folds them with `merge-summary-json` into the ONE `eval-heal-<sha>`
+JSON `ci-status` downloads — so the shard fan-out is invisible to the heal loop.
 
 The deterministic regression lane is wired into prek under its explicit name:
 `eval-pinned-regressions` runs at the **pre-push** stage (real git/FSM work) —

--- a/scripts/eval/shard_matrix.py
+++ b/scripts/eval/shard_matrix.py
@@ -1,0 +1,56 @@
+r"""Emit the eval-ci-heal SHARD matrix JSON for the full-suite heal workflow.
+
+The CI-eval heal workflow runs the behavioral eval against a PR branch. The FULL
+suite (empty ``scenarios`` input) is ~231 scenarios — far too many for one CI step
+to finish inside the per-step timeout, so it is fanned out across a parallel matrix
+of ``--shards`` legs. Each leg runs ``t3 eval run --shard <index>/<total>``, a
+deterministic partition by scenario name (every scenario in exactly one shard, none
+dropped or duplicated — :func:`teatree.eval.lane_shard.filter_specs_by_shard`), so
+every leg meters a bounded subset that fits the step budget.
+
+A red-subset re-run (a NON-empty ``scenarios`` input — the reds a heal re-trigger
+re-runs) is NOT sharded: it is already a small named set, so it emits a SINGLE leg
+with an empty shard token and the eval job runs the per-scenario loop over the
+named subset unchanged.
+
+The matrix is emitted as a JSON array of ``{"shard"}`` objects to stdout, ready for
+``echo "matrix=$(...)" >> "$GITHUB_OUTPUT"``. This helper imports nothing from
+teatree — the shard token slices the LIVE catalog in-container at run time, so the
+matrix is a pure function of the shard count and whether a subset was requested.
+"""
+
+import argparse
+import json
+import sys
+
+
+def shard_matrix(shards: int, scenarios: str) -> list[dict[str, str]]:
+    """The ``{"shard"}`` matrix legs for *shards* shards, or a single unsharded leg.
+
+    A non-empty *scenarios* (a red-subset re-run) is never sharded — one leg with
+    an empty shard token runs the named subset loop. Otherwise the full suite fans
+    out ``shards`` legs, ``1/shards`` .. ``shards/shards``.
+    """
+    if scenarios.strip():
+        return [{"shard": ""}]
+    if shards < 1:
+        msg = f"--shards must be >= 1, got {shards}"
+        raise SystemExit(msg)
+    return [{"shard": f"{index}/{shards}"} for index in range(1, shards + 1)]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--shards", type=int, required=True, help="Number of parallel shards for the full suite.")
+    parser.add_argument(
+        "--scenarios",
+        default="",
+        help="Comma-joined red subset; non-empty = a single unsharded leg (no full-suite fan-out).",
+    )
+    args = parser.parse_args(argv)
+    print(json.dumps(shard_matrix(args.shards, args.scenarios)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/teatree/cli/eval/_registration.py
+++ b/src/teatree/cli/eval/_registration.py
@@ -22,6 +22,7 @@ from teatree.cli.eval.history import history_command
 from teatree.cli.eval.label import label_app
 from teatree.cli.eval.lanes import coverage, pinned_regressions
 from teatree.cli.eval.merge_summaries import merge_summaries
+from teatree.cli.eval.merge_summary_json import merge_summary_json
 from teatree.cli.eval.merged_prs_since import merged_prs_since
 from teatree.cli.eval.negative_control import negative_control
 from teatree.cli.eval.prepare_transcript import prepare_transcript
@@ -46,6 +47,7 @@ def register_imported_commands(eval_app: typer.Typer) -> None:
     eval_app.command("ci-status")(ci_status)
     eval_app.command("merged-prs-since")(merged_prs_since)
     eval_app.command("merge-summaries")(merge_summaries)
+    eval_app.command("merge-summary-json")(merge_summary_json)
     eval_app.command("prepare-transcript")(prepare_transcript)
     eval_app.command("history")(history_command)
     eval_app.add_typer(corpus_app, name="corpus")

--- a/src/teatree/cli/eval/merge_summary_json.py
+++ b/src/teatree/cli/eval/merge_summary_json.py
@@ -1,0 +1,34 @@
+"""``t3 eval merge-summary-json`` — combine per-shard eval-heal summary JSONs.
+
+The full-suite CI heal run shards across a parallel matrix; each shard uploads its
+own publish-safe per-scenario ``--summary-json``. This subcommand reads every
+per-shard JSON (a directory or explicit paths) and writes ONE ``eval-heal-<sha>``
+JSON with the same §2.4 schema — totals summed, scenarios concatenated — so the
+``t3 eval ci-status`` download path reads the combined run unchanged. The shared
+core lives in :mod:`teatree.eval.summary_json_merge`; only publish-safe rows are
+read, so the merged artifact carries no transcript.
+
+``--sha`` and ``--generated-at`` are PASSED IN (never computed here), mirroring
+``t3 eval merge-summaries``, so the merge is deterministic. Writes to ``--out``
+when given, else stdout.
+"""
+
+from pathlib import Path
+
+import typer
+
+from teatree.eval.summary_json_merge import merge_summary_json as _merge_summary_json
+
+
+def merge_summary_json(
+    inputs: list[str] = typer.Argument(..., help="Per-shard summary .json files, or a directory of them."),
+    sha: str = typer.Option(..., "--sha", help="The commit SHA the run measured (injected)."),
+    generated_at: str = typer.Option(..., "--generated-at", help="ISO-8601 timestamp (injected; never computed here)."),
+    out: Path | None = typer.Option(None, "--out", help="Write the merged JSON to this path instead of stdout."),
+) -> None:
+    """Merge per-shard eval-heal summary JSONs into one §2.4 JSON (to --out or stdout)."""
+    merged = _merge_summary_json(inputs, head_sha=sha, generated_at=generated_at)
+    if out is not None:
+        out.write_text(merged, encoding="utf-8")
+    else:
+        typer.echo(merged)

--- a/src/teatree/eval/summary_json_merge.py
+++ b/src/teatree/eval/summary_json_merge.py
@@ -1,0 +1,74 @@
+"""Merge per-shard publish-safe ``--summary-json`` artifacts into one (§2.4).
+
+The CI heal workflow shards the full suite across a parallel matrix; each shard
+uploads its own publish-safe per-scenario ``--summary-json`` (the same §2.4 schema
+:func:`teatree.eval.summary_json.render_summary_json` produces). This module reads
+every per-shard JSON (a directory or explicit paths) and folds them into ONE
+``eval-heal-<sha>`` payload with the identical schema: the ``totals`` summed and
+the ``scenarios`` concatenated, so the existing ``t3 eval ci-status`` download
+path reads the combined run exactly as it read a single-invocation run.
+
+Only the already-sanitized per-shard rows are read — no transcript ever enters
+here, so the merged artifact stays publish-safe by construction. ``head_sha`` and
+``generated_at`` are PASSED IN (never computed here), mirroring
+:func:`teatree.eval.summaries.merge_summaries`, so the merge is deterministic and
+unit-testable.
+"""
+
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from teatree.eval.triage import ScenarioRecord
+
+_TOTALS_KEYS = ("total", "passed", "failed", "skipped")
+
+
+def summary_json_files(inputs: list[str]) -> list[Path]:
+    """Expand *inputs* (files or directories) to the per-shard ``*.json`` paths, sorted."""
+    paths: list[Path] = []
+    for raw in inputs:
+        path = Path(raw)
+        if path.is_dir():
+            paths.extend(sorted(path.glob("*.json")))
+        elif path.is_file():
+            paths.append(path)
+    return paths
+
+
+def merge_summary_payloads(
+    payloads: Sequence[Mapping[str, Any]], *, head_sha: str, generated_at: str
+) -> dict[str, Any]:
+    """Fold per-shard §2.4 payloads into one — totals summed, scenarios concatenated.
+
+    A shard with distinct ``model`` values is joined into a sorted comma list so
+    the field stays informative and deterministic; a run whose shards all agree
+    keeps its single model string.
+    """
+    scenarios: list[ScenarioRecord] = []
+    totals = dict.fromkeys(_TOTALS_KEYS, 0)
+    for payload in payloads:
+        shard_scenarios = payload.get("scenarios")
+        if isinstance(shard_scenarios, list):
+            scenarios.extend(shard_scenarios)
+        shard_totals = payload.get("totals")
+        if isinstance(shard_totals, Mapping):
+            for key in _TOTALS_KEYS:
+                totals[key] += int(shard_totals.get(key, 0))
+    models = sorted({str(payload.get("model", "")) for payload in payloads} - {"", "unknown"})
+    return {
+        "generated_at": generated_at,
+        "model": ",".join(models) if models else "unknown",
+        "head_sha": head_sha,
+        "totals": totals,
+        "scenarios": scenarios,
+    }
+
+
+def merge_summary_json(inputs: list[str], *, head_sha: str, generated_at: str) -> str:
+    """Read every per-shard summary JSON and render the merged §2.4 JSON string."""
+    payloads = [json.loads(path.read_text(encoding="utf-8")) for path in summary_json_files(inputs)]
+    merged = merge_summary_payloads(payloads, head_sha=head_sha, generated_at=generated_at)
+    return json.dumps(merged, indent=2)

--- a/tests/eval_replay/test_shard_matrix.py
+++ b/tests/eval_replay/test_shard_matrix.py
@@ -1,0 +1,55 @@
+"""``scripts/eval/shard_matrix.py`` emits the eval-ci-heal shard matrix JSON.
+
+The full suite (empty ``scenarios``) fans out ``--shards`` legs of ``i/N`` shard
+tokens; a red-subset re-run (non-empty ``scenarios``) is NOT sharded — one leg
+with an empty token runs the named subset loop. The helper imports nothing from
+teatree, so the shard token slices the live catalog in-container at run time.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "shard_matrix",
+    Path(__file__).parents[2] / "scripts" / "eval" / "shard_matrix.py",
+)
+assert _SPEC is not None
+assert _SPEC.loader is not None
+_MOD = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MOD)
+
+shard_matrix = _MOD.shard_matrix
+main = _MOD.main
+
+
+class TestShardMatrix:
+    def test_full_suite_fans_out_n_shard_legs(self) -> None:
+        legs = shard_matrix(8, "")
+        assert legs == [{"shard": f"{i}/8"} for i in range(1, 9)]
+
+    def test_subset_is_a_single_unsharded_leg(self) -> None:
+        assert shard_matrix(8, "alpha,beta") == [{"shard": ""}]
+
+    def test_whitespace_only_scenarios_still_shards_the_full_suite(self) -> None:
+        assert shard_matrix(3, "   ") == [{"shard": "1/3"}, {"shard": "2/3"}, {"shard": "3/3"}]
+
+    def test_zero_shards_fails_loud(self) -> None:
+        with pytest.raises(SystemExit):
+            shard_matrix(0, "")
+
+
+class TestCli:
+    def test_main_prints_the_matrix_json(self, capsys: pytest.CaptureFixture[str]) -> None:
+        code = main(["--shards", "6"])
+        assert code == 0
+        legs = json.loads(capsys.readouterr().out)
+        assert len(legs) == 6
+        assert legs[0] == {"shard": "1/6"}
+
+    def test_main_subset_prints_one_leg(self, capsys: pytest.CaptureFixture[str]) -> None:
+        code = main(["--shards", "6", "--scenarios", "alpha"])
+        assert code == 0
+        assert json.loads(capsys.readouterr().out) == [{"shard": ""}]

--- a/tests/teatree_cli/eval/test_eval_ci_heal_workflow.py
+++ b/tests/teatree_cli/eval/test_eval_ci_heal_workflow.py
@@ -7,6 +7,14 @@ enforcement, that it reuses the exact in-Docker `t3 eval run --backend api
 --docker --require-executed` invocation and emits the publish-safe `--summary-json`
 artifact + the private transcript, and the injection-safe env-var pattern (no
 caller input inlined into a run line).
+
+The full suite (~231 scenarios) is FANNED OUT across a parallel matrix of shards
+(souliane/teatree#3202): a `prepare` job computes the `{shard}` matrix, the `eval`
+job runs one `--shard <index>/<total>` leg per matrix entry, and a `combine` job
+merges every shard's per-scenario JSON into ONE `eval-heal-<sha>.json`. The eval
+runs single-trial with `--escalate-on-fail` (the adaptive default) — the retired
+blanket `--trials 2` pass@2 must be gone. These assertions FAIL if the sharding,
+the combine job, or the adaptive single-trial invocation is missing.
 """
 
 from pathlib import Path
@@ -26,6 +34,10 @@ def _on(workflow: dict[str, Any]) -> dict[str, Any]:
     return cast("dict[str, Any]", workflow.get("on", workflow.get(True)))
 
 
+def _jobs() -> dict[str, Any]:
+    return cast("dict[str, Any]", _load()["jobs"])
+
+
 def _text() -> str:
     return _WORKFLOW.read_text(encoding="utf-8")
 
@@ -35,10 +47,16 @@ class TestTrigger:
         on = _on(_load())
         assert set(on) == {"workflow_dispatch"}
 
-    def test_exposes_the_three_inputs(self) -> None:
+    def test_exposes_the_inputs(self) -> None:
         inputs = _on(_load())["workflow_dispatch"]["inputs"]
-        assert set(inputs) == {"scenarios", "credential", "pr_ref"}
+        assert set(inputs) == {"scenarios", "shards", "credential", "pr_ref"}
         assert inputs["credential"]["default"] == "subscription_oauth"
+
+    def test_shards_input_has_a_sensible_default(self) -> None:
+        inputs = _on(_load())["workflow_dispatch"]["inputs"]
+        # A default in the recommended 6-8 range so each shard's worst case stays
+        # comfortably under the per-step timeout.
+        assert 6 <= int(inputs["shards"]["default"]) <= 8
 
 
 class TestCredentialWiring:
@@ -66,19 +84,69 @@ class TestReusesTheDockerEvalInvocation:
         assert "--summary-json" in _text()
 
 
-class TestArtifacts:
-    def test_uploads_the_publish_safe_json_and_the_private_transcript(self) -> None:
+class TestAdaptiveSingleTrial:
+    def test_uses_escalate_on_fail_not_blanket_pass_at_2(self) -> None:
         text = _text()
-        assert "eval-heal-${{ steps.sha.outputs.sha }}" in text
-        assert "eval-heal-transcript-${{ steps.sha.outputs.sha }}" in text
+        # The adaptive single-trial default: a passing scenario runs once, a real
+        # failure escalates. The retired blanket pass@2 must be gone.
+        assert "--escalate-on-fail" in text
+        assert "--trials 2" not in text
+        assert "--require any" not in text
+        assert "EVAL_TRIALS" not in text
+
+
+class TestSharding:
+    def test_prepare_job_computes_the_shard_matrix(self) -> None:
+        prepare = _jobs()["prepare"]
+        assert "scripts/eval/shard_matrix.py" in _text()
+        assert "matrix" in prepare["outputs"]
+        assert "sha" in prepare["outputs"]
+
+    def test_eval_job_fans_out_over_the_matrix(self) -> None:
+        eval_job = _jobs()["eval"]
+        assert eval_job["needs"] == "prepare"
+        strategy = eval_job["strategy"]
+        # A red shard must not cancel its siblings — each leg's verdict is independent.
+        assert strategy["fail-fast"] is False
+        assert "fromJSON(needs.prepare.outputs.matrix)" in str(strategy["matrix"]["include"])
+
+    def test_eval_leg_runs_one_shard_of_the_catalog(self) -> None:
+        assert "--shard" in _text()
+        # The full-suite leg passes the matrix shard token through to the CLI.
+        assert "matrix.shard" in _text()
+
+
+class TestCombineJob:
+    def test_combine_needs_prepare_and_eval(self) -> None:
+        combine = _jobs()["combine"]
+        assert set(combine["needs"]) == {"prepare", "eval"}
+        # `always()` so a red shard still merges — a red run is when reds are triaged.
+        assert "always()" in combine["if"]
+
+    def test_combine_downloads_shard_jsons_and_merges_them(self) -> None:
+        text = _text()
+        assert "eval-heal-shard-${{ needs.prepare.outputs.sha }}-*" in text
+        assert "merge-summary-json" in text
+
+    def test_combine_uploads_the_one_eval_heal_sha_artifact(self) -> None:
+        # The download path (`t3 eval ci-status`) resolves the artifact by the
+        # `eval-heal-<sha>` name — the combine job is what produces it now.
+        assert "eval-heal-${{ needs.prepare.outputs.sha }}" in _text()
+
+
+class TestArtifacts:
+    def test_uploads_the_per_shard_json_and_transcript(self) -> None:
+        text = _text()
+        assert "eval-heal-shard-${{ needs.prepare.outputs.sha }}-${{ steps.artifact.outputs.suffix }}" in text
+        assert "eval-heal-transcript-${{ needs.prepare.outputs.sha }}-${{ steps.artifact.outputs.suffix }}" in text
 
 
 class TestInjectionSafety:
     def test_caller_inputs_are_routed_through_env_not_inlined_into_run(self) -> None:
-        # A caller-supplied input (scenarios / credential / pr_ref) is bound to an
-        # env var and referenced as $VAR in the shell — never interpolated as
+        # A caller-supplied input (scenarios / shards / credential / pr_ref) is bound
+        # to an env var and referenced as $VAR in the shell — never interpolated as
         # ${{ inputs.* }} directly inside a `run:` / retry `command:` body.
         for line in _text().splitlines():
             stripped = line.strip()
-            if stripped.startswith(("uv run", "echo ", "for ", "if ", "npm ", "claude ")):
+            if stripped.startswith(("uv run", "echo ", "for ", "if ", "npm ", "claude ", "python ")):
                 assert "${{ inputs." not in stripped, f"inlined input in a run line — {stripped!r}"

--- a/tests/teatree_cli/eval/test_merge_summary_json_cli.py
+++ b/tests/teatree_cli/eval/test_merge_summary_json_cli.py
@@ -1,0 +1,78 @@
+"""``t3 eval merge-summary-json`` combines per-shard eval-heal JSONs into one.
+
+The reusable subcommand reads N per-shard publish-safe ``--summary-json`` files
+and emits ONE §2.4 JSON — totals summed, scenarios concatenated, ``--sha`` /
+``--generated-at`` injected (never computed here, so the merge is deterministic).
+Exercised through the real typer CLI so the workflow's combine-job invocation is
+covered end to end.
+"""
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from teatree.cli import app
+
+_SHA = "0123456789abcdef0123456789abcdef01234567"
+_META = ["--sha", _SHA, "--generated-at", "2026-07-13T06:00:00Z"]
+
+_SHARD_A = {
+    "generated_at": "2026-07-13T05:00:00Z",
+    "model": "claude-sonnet-4-6",
+    "head_sha": _SHA,
+    "totals": {"total": 2, "passed": 1, "failed": 1, "skipped": 0},
+    "scenarios": [
+        {"name": "zeta", "lane": "clean_room", "verdict": "pass", "triage_class": None},
+        {"name": "alpha", "lane": "under_load", "verdict": "fail", "triage_class": "behavioral"},
+    ],
+}
+_SHARD_B = {
+    "generated_at": "2026-07-13T05:30:00Z",
+    "model": "claude-sonnet-4-6",
+    "head_sha": _SHA,
+    "totals": {"total": 1, "passed": 1, "failed": 0, "skipped": 0},
+    "scenarios": [{"name": "beta", "lane": "clean_room", "verdict": "pass", "triage_class": None}],
+}
+
+
+def _write_shards(tmp_path: Path) -> Path:
+    shard_dir = tmp_path / "heal"
+    shard_dir.mkdir()
+    (shard_dir / "eval-heal-shard-1-2.json").write_text(json.dumps(_SHARD_A), encoding="utf-8")
+    (shard_dir / "eval-heal-shard-2-2.json").write_text(json.dumps(_SHARD_B), encoding="utf-8")
+    return shard_dir
+
+
+class TestMergeSummaryJson:
+    def test_merges_a_directory_to_one_payload_with_summed_totals(self, tmp_path: Path) -> None:
+        shard_dir = _write_shards(tmp_path)
+        result = CliRunner().invoke(app, ["eval", "merge-summary-json", str(shard_dir), *_META])
+        assert result.exit_code == 0, result.output
+        merged = json.loads(result.output)
+        assert merged["totals"] == {"total": 3, "passed": 2, "failed": 1, "skipped": 0}
+        assert {scenario["name"] for scenario in merged["scenarios"]} == {"zeta", "alpha", "beta"}
+
+    def test_injected_sha_and_timestamp_are_written(self, tmp_path: Path) -> None:
+        shard_dir = _write_shards(tmp_path)
+        result = CliRunner().invoke(app, ["eval", "merge-summary-json", str(shard_dir), *_META])
+        merged = json.loads(result.output)
+        assert merged["head_sha"] == _SHA
+        assert merged["generated_at"] == "2026-07-13T06:00:00Z"
+
+    def test_out_flag_writes_the_merged_file(self, tmp_path: Path) -> None:
+        shard_dir = _write_shards(tmp_path)
+        out_path = tmp_path / f"eval-heal-{_SHA}.json"
+        result = CliRunner().invoke(app, ["eval", "merge-summary-json", str(shard_dir), *_META, "--out", str(out_path)])
+        assert result.exit_code == 0, result.output
+        merged = json.loads(out_path.read_text(encoding="utf-8"))
+        assert merged["totals"]["total"] == 3
+
+    def test_empty_dir_yields_a_valid_empty_payload(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        result = CliRunner().invoke(app, ["eval", "merge-summary-json", str(empty), *_META])
+        assert result.exit_code == 0, result.output
+        merged = json.loads(result.output)
+        assert merged["totals"]["total"] == 0
+        assert merged["scenarios"] == []

--- a/tests/teatree_eval/test_summary_json_merge.py
+++ b/tests/teatree_eval/test_summary_json_merge.py
@@ -1,0 +1,104 @@
+"""Merge per-shard publish-safe ``--summary-json`` artifacts into one (§2.4).
+
+The CI heal workflow shards the full suite across a parallel matrix; each shard
+uploads its own publish-safe per-scenario ``--summary-json``. The merge folds them
+into ONE ``eval-heal-<sha>`` JSON with the identical §2.4 schema — totals summed,
+scenarios concatenated — so the ``t3 eval ci-status`` download path reads the
+combined run exactly as it read a single-invocation run. ``head_sha`` /
+``generated_at`` are injected (never computed here), so the merge is deterministic.
+"""
+
+import json
+from pathlib import Path
+
+from teatree.eval.summary_json_merge import merge_summary_json, merge_summary_payloads, summary_json_files
+
+_SHA = "0123456789abcdef0123456789abcdef01234567"
+_AT = "2026-07-13T06:00:00Z"
+
+_SHARD_A = {
+    "generated_at": "2026-07-13T05:00:00Z",
+    "model": "claude-sonnet-4-6",
+    "head_sha": _SHA,
+    "totals": {"total": 2, "passed": 1, "failed": 1, "skipped": 0},
+    "scenarios": [
+        {"name": "zeta", "lane": "clean_room", "verdict": "pass", "triage_class": None},
+        {"name": "alpha", "lane": "under_load", "verdict": "fail", "triage_class": "behavioral"},
+    ],
+}
+_SHARD_B = {
+    "generated_at": "2026-07-13T05:30:00Z",
+    "model": "claude-sonnet-4-6",
+    "head_sha": _SHA,
+    "totals": {"total": 2, "passed": 1, "failed": 0, "skipped": 1},
+    "scenarios": [
+        {"name": "beta", "lane": "clean_room", "verdict": "pass", "triage_class": None},
+        {"name": "gamma", "lane": "clean_room", "verdict": "skip", "triage_class": "no_coverage"},
+    ],
+}
+
+
+class TestMergePayloads:
+    def test_totals_are_summed_across_shards(self) -> None:
+        merged = merge_summary_payloads([_SHARD_A, _SHARD_B], head_sha=_SHA, generated_at=_AT)
+        assert merged["totals"] == {"total": 4, "passed": 2, "failed": 1, "skipped": 1}
+
+    def test_scenarios_are_concatenated_across_shards(self) -> None:
+        merged = merge_summary_payloads([_SHARD_A, _SHARD_B], head_sha=_SHA, generated_at=_AT)
+        names = [scenario["name"] for scenario in merged["scenarios"]]
+        assert names == ["zeta", "alpha", "beta", "gamma"]
+
+    def test_injected_sha_and_timestamp_win_over_the_per_shard_values(self) -> None:
+        merged = merge_summary_payloads([_SHARD_A, _SHARD_B], head_sha=_SHA, generated_at=_AT)
+        assert merged["head_sha"] == _SHA
+        assert merged["generated_at"] == _AT
+
+    def test_a_single_model_survives_the_merge(self) -> None:
+        merged = merge_summary_payloads([_SHARD_A, _SHARD_B], head_sha=_SHA, generated_at=_AT)
+        assert merged["model"] == "claude-sonnet-4-6"
+
+    def test_distinct_models_are_joined_deterministically(self) -> None:
+        other = {**_SHARD_B, "model": "claude-opus-4-8"}
+        merged = merge_summary_payloads([_SHARD_A, other], head_sha=_SHA, generated_at=_AT)
+        assert merged["model"] == "claude-opus-4-8,claude-sonnet-4-6"
+
+    def test_empty_input_yields_a_valid_empty_payload(self) -> None:
+        merged = merge_summary_payloads([], head_sha=_SHA, generated_at=_AT)
+        assert merged["totals"] == {"total": 0, "passed": 0, "failed": 0, "skipped": 0}
+        assert merged["scenarios"] == []
+        assert merged["model"] == "unknown"
+
+    def test_no_transcript_key_can_enter_the_merge(self) -> None:
+        # The merge only forwards the already-sanitized per-shard rows; it never
+        # invents a transcript key, so the combined artifact stays publish-safe.
+        merged = merge_summary_payloads([_SHARD_A, _SHARD_B], head_sha=_SHA, generated_at=_AT)
+        blob = json.dumps(merged)
+        for banned in ("text_blocks", "tool_calls", "rationale", "raw_stdout"):
+            assert banned not in blob
+
+
+class TestFileReader:
+    def _write(self, root: Path) -> Path:
+        shard_dir = root / "heal"
+        shard_dir.mkdir()
+        (shard_dir / "eval-heal-shard-1-2.json").write_text(json.dumps(_SHARD_A), encoding="utf-8")
+        (shard_dir / "eval-heal-shard-2-2.json").write_text(json.dumps(_SHARD_B), encoding="utf-8")
+        return shard_dir
+
+    def test_reads_every_json_in_a_directory(self, tmp_path: Path) -> None:
+        shard_dir = self._write(tmp_path)
+        paths = summary_json_files([str(shard_dir)])
+        assert [p.name for p in paths] == ["eval-heal-shard-1-2.json", "eval-heal-shard-2-2.json"]
+
+    def test_merge_summary_json_reads_a_directory_and_renders_the_string(self, tmp_path: Path) -> None:
+        shard_dir = self._write(tmp_path)
+        rendered = merge_summary_json([str(shard_dir)], head_sha=_SHA, generated_at=_AT)
+        merged = json.loads(rendered)
+        assert merged["totals"]["total"] == 4
+        assert {scenario["name"] for scenario in merged["scenarios"]} == {"zeta", "alpha", "beta", "gamma"}
+
+    def test_explicit_file_paths_are_read(self, tmp_path: Path) -> None:
+        shard_dir = self._write(tmp_path)
+        one = shard_dir / "eval-heal-shard-1-2.json"
+        rendered = merge_summary_json([str(one)], head_sha=_SHA, generated_at=_AT)
+        assert json.loads(rendered)["totals"]["total"] == 2


### PR DESCRIPTION
The full-suite eval-ci-heal run timed out (231 scenarios × blanket pass@2 > the 80-min step cap) and produced no JSON. This shards the full suite across a parallel matrix (each shard < the step timeout), merges per-shard summary JSONs into one, and switches from blanket --trials 2 to the adaptive single-trial-with-escalation default. Unblocks the full-suite eval-green proof (#3202). No leak; JSON stays publish-safe.