### PR TITLE
fix(backends): build GitHubCodeHost from ambient gh auth when no token is wired

### DIFF
--- a/src/teatree/backends/loader.py
+++ b/src/teatree/backends/loader.py
@@ -34,30 +34,60 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _github_host(overlay: "OverlayBase") -> GitHubCodeHost | None:
+    """Return a GitHub code host for *overlay*, or ``None`` when unauthenticated.
+
+    An explicit ``get_github_token()`` authors requests; failing that, the
+    ambient ``gh`` CLI login (:func:`gh_ambient_auth_available`) backs an
+    empty-token host so a gh-CLI-only box still surfaces GitHub PRs/issues/
+    reviews — the same carve-out :func:`_github_host_for_repo` already applies
+    on the ship path (#2946). Only a box with neither returns ``None``.
+
+    The ambient probe shells out to ``gh auth status``, so it runs lazily —
+    only when no explicit token is present. No memoization here: the
+    ``backend_factory`` registry already caches resolved backends per process.
+    """
+    github_token = overlay.config.get_github_token()
+    if github_token:
+        return GitHubCodeHost(token=github_token)
+    if gh_ambient_auth_available():
+        return GitHubCodeHost(token="")
+    return None
+
+
 def get_code_host(overlay: "OverlayBase") -> CodeHostBackend | None:
     """Return the configured CodeHostBackend for *overlay*, or ``None``.
 
     Selection follows ``overlay.config.code_host``; falls back to inspecting
-    the available tokens when the field is unset.
+    the available tokens when the field is unset. An ambient ``gh`` login backs
+    a tokenless GitHub host, but only after every explicitly-configured host —
+    an explicit GitLab token outranks it (see :func:`_github_host`).
 
     Pre-#976 single-platform callers — anything that wires a single host
     into a Django view or CLI command — keep calling this. The multi-host
     loop scanner stack calls :func:`get_code_hosts` instead.
     """
     choice = overlay.config.code_host
-    github_token = overlay.config.get_github_token()
+    if choice not in {"", "github", "gitlab"}:
+        msg = f"Unknown code_host: {choice!r}"
+        raise ValueError(msg)
+
+    if choice == "github":
+        return _github_host(overlay)
+
     gitlab_token = overlay.config.get_gitlab_token()
-
-    if choice == "github" or (not choice and github_token):
-        return GitHubCodeHost(token=github_token) if github_token else None
-
-    if choice == "gitlab" or (not choice and gitlab_token):
+    if choice == "gitlab":
         return GitLabCodeHost(token=gitlab_token, base_url=overlay.config.gitlab_url) if gitlab_token else None
 
-    if choice in {"", "github", "gitlab"}:
-        return None
-    msg = f"Unknown code_host: {choice!r}"
-    raise ValueError(msg)
+    # Auto mode: an explicit GitHub token wins, then an explicit GitLab token,
+    # then — only when no explicit host resolved — an ambient gh login (or
+    # ``None``). Ambient GitHub must rank below ANY explicitly-configured host.
+    github_token = overlay.config.get_github_token()
+    if github_token:
+        return GitHubCodeHost(token=github_token)
+    if gitlab_token:
+        return GitLabCodeHost(token=gitlab_token, base_url=overlay.config.gitlab_url)
+    return _github_host(overlay)
 
 
 def get_code_hosts(overlay: "OverlayBase") -> list[CodeHostBackend]:
@@ -74,38 +104,51 @@ def get_code_hosts(overlay: "OverlayBase") -> list[CodeHostBackend]:
     other token resolves. Empty / auto picks both whenever tokens resolve.
     """
     choice = overlay.config.code_host
+    if choice not in {"", "github", "gitlab"}:
+        msg = f"Unknown code_host: {choice!r}"
+        raise ValueError(msg)
+
     hosts: list[CodeHostBackend] = []
-    github_token = overlay.config.get_github_token()
     gitlab_token = overlay.config.get_gitlab_token()
 
     if choice == "github":
-        if github_token:
-            hosts.append(GitHubCodeHost(token=github_token))
+        github_host = _github_host(overlay)
+        if github_host is not None:
+            hosts.append(github_host)
         return hosts
     if choice == "gitlab":
         if gitlab_token:
             hosts.append(GitLabCodeHost(token=gitlab_token, base_url=overlay.config.gitlab_url))
         return hosts
-    if choice not in {"", "github", "gitlab"}:
-        msg = f"Unknown code_host: {choice!r}"
-        raise ValueError(msg)
 
-    # Auto mode: build one host per token that resolves. GitHub first so
-    # ``OverlayBackends.host`` (= ``hosts[0]``) preserves the legacy
-    # GitHub-wins-when-both-set precedence that single-platform callers
-    # downstream depend on.
+    # Auto mode: build one host per token that resolves. An explicit GitHub
+    # token goes first so ``OverlayBackends.host`` (= ``hosts[0]``) preserves
+    # the legacy GitHub-wins-when-both-set precedence single-platform callers
+    # depend on. Then GitLab. Then — only when NO explicit GitHub token — an
+    # ambient gh login is appended LAST, so an ambient-only GitHub host is
+    # primary solely when it is the sole host and never usurps an explicitly
+    # configured GitLab host.
+    github_token = overlay.config.get_github_token()
     if github_token:
         hosts.append(GitHubCodeHost(token=github_token))
     if gitlab_token:
         hosts.append(GitLabCodeHost(token=gitlab_token, base_url=overlay.config.gitlab_url))
+    if not github_token:
+        ambient_github = _github_host(overlay)
+        if ambient_github is not None:
+            hosts.append(ambient_github)
     return hosts
 
 
 def _host_backend(overlay: "OverlayBase", forge: Literal["github", "gitlab"]) -> CodeHostBackend | None:
-    """Build the backend for a resolved *forge* token, or ``None`` if no token."""
+    """Build the backend for a resolved *forge*, or ``None`` when unauthenticated.
+
+    GitHub falls back to the ambient ``gh`` login when no token is wired (see
+    :func:`_github_host`); GitLab's REST transport has no ambient path, so it
+    stays token-gated.
+    """
     if forge == "github":
-        token = overlay.config.get_github_token()
-        return GitHubCodeHost(token=token) if token else None
+        return _github_host(overlay)
     token = overlay.config.get_gitlab_token()
     return GitLabCodeHost(token=token, base_url=overlay.config.gitlab_url) if token else None
 

--- a/tests/teatree_backends/test_loader.py
+++ b/tests/teatree_backends/test_loader.py
@@ -13,6 +13,7 @@ from teatree.backends.github import GitHubCodeHost
 from teatree.backends.gitlab import GitLabCodeHost
 from teatree.backends.gitlab.ci import GitLabCIService
 from teatree.backends.loader import (
+    _host_backend,
     get_ci_service,
     get_code_host,
     get_code_host_for_repo,
@@ -63,7 +64,8 @@ def _stub_token(overlay: OverlayBase, *, github: str = "", gitlab: str = "", sla
     overlay.config.get_slack_token = lambda: slack  # type: ignore[method-assign]
 
 
-def test_get_code_host_returns_none_when_no_token() -> None:
+def test_get_code_host_returns_none_when_no_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("teatree.backends.loader.gh_ambient_auth_available", lambda: False)
     overlay = _build_overlay()
     _stub_token(overlay)
     assert get_code_host(overlay) is None
@@ -118,14 +120,16 @@ def test_get_code_hosts_honours_explicit_gitlab_choice() -> None:
     assert [type(h).__name__ for h in hosts] == [GitLabCodeHost.__name__]
 
 
-def test_get_code_hosts_returns_empty_when_no_tokens_resolve() -> None:
+def test_get_code_hosts_returns_empty_when_no_tokens_resolve(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("teatree.backends.loader.gh_ambient_auth_available", lambda: False)
     overlay = _build_overlay()
     _stub_token(overlay)
     assert get_code_hosts(overlay) == []
 
 
-def test_get_code_hosts_explicit_choice_returns_empty_without_token() -> None:
+def test_get_code_hosts_explicit_choice_returns_empty_without_token(monkeypatch: pytest.MonkeyPatch) -> None:
     """Pinning a platform but having no token for it surfaces as an empty list."""
+    monkeypatch.setattr("teatree.backends.loader.gh_ambient_auth_available", lambda: False)
     overlay = _build_overlay(code_host="github")
     _stub_token(overlay)
     assert get_code_hosts(overlay) == []
@@ -139,6 +143,76 @@ def test_get_code_hosts_raises_on_unknown_choice() -> None:
     _stub_token(overlay)
     with pytest.raises(ValueError, match="Unknown code_host"):
         get_code_hosts(overlay)
+
+
+class TestOverlayScopedAmbientGithub:
+    """A gh-CLI-only box builds a GitHub host for the overlay-scoped resolvers.
+
+    ``get_github_token()`` returns ``""`` when auth lives purely in the ``gh``
+    CLI login (no PAT wired into the overlay). Pre-fix, ``get_code_hosts``
+    returned ``[]``, ``OverlayBackends.host`` was ``None``, and every
+    host-dependent loop scanner was silently disabled. The overlay-scoped
+    resolvers now mirror the ``_github_host_for_repo`` ambient carve-out: an
+    empty-token ``GitHubCodeHost`` backs the logged-in ``gh`` account.
+    """
+
+    def test_get_code_hosts_builds_ambient_github_when_no_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("teatree.backends.loader.gh_ambient_auth_available", lambda: True)
+        overlay = _build_overlay()
+        _stub_token(overlay)
+        hosts = get_code_hosts(overlay)
+        assert [type(h).__name__ for h in hosts] == [GitHubCodeHost.__name__]
+
+    def test_get_code_host_builds_ambient_github_when_no_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("teatree.backends.loader.gh_ambient_auth_available", lambda: True)
+        overlay = _build_overlay()
+        _stub_token(overlay)
+        host = get_code_host(overlay)
+        assert isinstance(host, GitHubCodeHost)
+
+    def test_host_backend_builds_ambient_github_when_no_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("teatree.backends.loader.gh_ambient_auth_available", lambda: True)
+        overlay = _build_overlay()
+        _stub_token(overlay)
+        assert isinstance(_host_backend(overlay, "github"), GitHubCodeHost)
+
+    def test_no_ambient_and_no_token_stays_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Regression guard: the no-auth path is unchanged when ambient gh is absent."""
+        monkeypatch.setattr("teatree.backends.loader.gh_ambient_auth_available", lambda: False)
+        overlay = _build_overlay()
+        _stub_token(overlay)
+        assert get_code_hosts(overlay) == []
+        assert get_code_host(overlay) is None
+        assert _host_backend(overlay, "github") is None
+
+    def test_explicit_token_builds_single_host_not_duplicated_by_ambient(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An explicit token authors the sole host — the ambient path never duplicates it."""
+        monkeypatch.setattr("teatree.backends.loader.gh_ambient_auth_available", lambda: True)
+        overlay = _build_overlay()
+        _stub_token(overlay, github="gh-explicit")
+        hosts = get_code_hosts(overlay)
+        assert [type(h).__name__ for h in hosts] == [GitHubCodeHost.__name__]
+        assert cast("GitHubCodeHost", hosts[0])._token == "gh-explicit"
+        assert cast("GitHubCodeHost", get_code_host(overlay))._token == "gh-explicit"
+
+    def test_explicit_gitlab_keeps_primary_over_ambient_github(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An explicit GitLab token outranks an ambient-only GitHub host for hosts[0]."""
+        monkeypatch.setattr("teatree.backends.loader.gh_ambient_auth_available", lambda: True)
+        overlay = _build_overlay()
+        _stub_token(overlay, gitlab="gl-explicit")
+        hosts = get_code_hosts(overlay)
+        assert isinstance(hosts[0], GitLabCodeHost)
+        assert [type(h).__name__ for h in hosts] == [GitLabCodeHost.__name__, GitHubCodeHost.__name__]
+        # Singular resolver stays consistent: explicit gitlab wins.
+        assert isinstance(get_code_host(overlay), GitLabCodeHost)
+
+    def test_pinned_gitlab_never_builds_ambient_github(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("teatree.backends.loader.gh_ambient_auth_available", lambda: True)
+        overlay = _build_overlay(code_host="gitlab")
+        _stub_token(overlay, gitlab="gl-explicit")
+        hosts = get_code_hosts(overlay)
+        assert all(not isinstance(h, GitHubCodeHost) for h in hosts)
+        assert not isinstance(get_code_host(overlay), GitHubCodeHost)
 
 
 def test_get_messaging_default_is_noop() -> None:
@@ -287,7 +361,8 @@ def test_get_code_host_for_url_falls_back_to_default_for_unknown_domain() -> Non
     assert isinstance(result, GitHubCodeHost)
 
 
-def test_get_code_host_for_url_returns_none_when_no_matching_token() -> None:
+def test_get_code_host_for_url_returns_none_when_no_matching_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("teatree.backends.loader.gh_ambient_auth_available", lambda: False)
     overlay = _build_overlay()
     _stub_token(overlay)
     assert get_code_host_for_url(overlay, "https://github.com/org/repo/issues/1") is None


### PR DESCRIPTION
## Symptom

On a box authenticated purely via the `gh` CLI login (no PAT wired into the overlay), every host-dependent loop scanner — `issue_implementer`, `assigned_issues`, `my_prs`, `reviewer_prs`, `issue_disposition` — was **silently disabled**. `pr_sweep` still worked because it builds `GhPrApiClient(token="")`, which falls back to the `gh` CLI. Nothing errored; the scanners just never ran.

## Root cause

The overlay-scoped code-host resolvers in `src/teatree/backends/loader.py` only built a `GitHubCodeHost` when an explicit token string resolved (`overlay.config.get_github_token()` truthy). With gh-CLI-only auth `get_github_token()` returns `""`, so `get_code_hosts()` returned `[]`, `OverlayBackends.host` was `None`, and the fan-out had no host to scan. The design already supported gh-CLI-only auth everywhere except overlay host construction — `_github_host_for_repo` on the ship path already had the `gh`-ambient carve-out (#2946).

## Fix

Extend that same precedent to the overlay-scoped resolvers. A new private helper `_github_host(overlay)`:

- explicit `get_github_token()` truthy → `GitHubCodeHost(token=github_token)`
- elif `gh_ambient_auth_available()` → `GitHubCodeHost(token="")`
- else `None`

It is used by `get_code_host` (singular), `get_code_hosts` (plural), and `_host_backend(_, "github")`. The ambient probe (`gh auth status`) runs lazily — only when no explicit token is present. No memoization: `backend_factory` already caches resolved backends per process.

## Ordering invariants preserved

An ambient-only GitHub host must never usurp an explicitly-configured host:

1. **Explicit-token GitHub keeps primary position** — `get_code_hosts` still appends explicit GitHub first (`hosts[0]` precedence).
2. **An explicit GitLab token beats an ambient-only GitHub host.** In `get_code_hosts` auto mode: explicit github (if token), then gitlab (if token), then — only when no explicit github token — the ambient github host appended LAST, so it is primary only when it is the sole host. `get_code_host` auto mode mirrors this: explicit github, then explicit gitlab, then ambient github (or None).
3. `choice == "github"` with no token → ambient github (or None); `choice == "gitlab"` unchanged (never returns github); unknown choice still raises `ValueError`.
4. `_host_backend(_, "github")` uses `_github_host`; `"gitlab"` unchanged (its REST transport has no ambient path).

## Tests

New RED-first class `TestOverlayScopedAmbientGithub` in `tests/teatree_backends/test_loader.py`, patching `teatree.backends.loader.gh_ambient_auth_available`:

- no token + ambient True → `get_code_hosts` yields exactly one `GitHubCodeHost`; `get_code_host` non-None; `_host_backend(_, "github")` non-None
- no token + ambient False → empty/None (no-auth regression guard)
- explicit token + ambient True → one host from the token, not duplicated, token preserved
- GitLab token + no github token + ambient True → `hosts[0]` is the GitLabCodeHost, GitHub appears only after it
- pinned `gitlab` + ambient True → no GitHubCodeHost ever

Existing no-token tests were made hermetic (patch ambient False) so they stay valid regression guards for the no-auth path.

Closes the onboarding gap where a gh-CLI-only box gets `host=None` and its scanners are silently disabled.
