### PR TITLE
fix(statusline): cap each statusline row to terminal width so Claude Code stops dropping long multi-line output

### DIFF
--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -641,6 +641,64 @@ if [ -n "$_skills_segment" ]; then
     fi
 fi
 
+# Claude Code's statusline docs warn that long, multi-line ANSI output "may get
+# truncated or wrap awkwardly" and that "multi-line status lines with escape
+# codes are more prone to rendering issues than single-line plain text" — on some
+# render surfaces a ~900-char multi-line loop line makes the WHOLE bar render
+# blank. So every emitted line (header, zones, owner badge, chain-script output)
+# is bounded to the visible terminal width at one choke point below. The width is
+# COLUMNS when set and > 0; else `tput cols` when stdout is a real terminal (a
+# piped, non-terminal stdout — Claude's own capture, a test — has no meaningful
+# terminal width, so it is not consulted); else a safe 200. `_cap_line_widths`
+# is an ANSI-aware awk one-pass filter (below).
+_cap_cols="${COLUMNS:-}"
+if ! [[ "$_cap_cols" =~ ^[0-9]+$ ]] || [ "$_cap_cols" -le 0 ]; then
+    _cap_cols=""
+    if [ -t 1 ] && command -v tput >/dev/null 2>&1; then
+        _cap_cols=$(tput cols 2>/dev/null)
+    fi
+fi
+if ! [[ "$_cap_cols" =~ ^[0-9]+$ ]] || [ "$_cap_cols" -le 0 ]; then
+    _cap_cols=200
+fi
+
+# ANSI-aware per-line width cap. Measures ONLY visible characters — SGR
+# (`\033[…m` / any CSI) and OSC 8 hyperlink wrappers (`\033]8;…\033\\` / BEL) are
+# copied verbatim but counted as zero width — so a line already within width
+# passes through byte-for-byte (escapes and OSC 8 links intact) and a too-long
+# line is cut on a character boundary (never mid-escape), marked with a single
+# `…` ellipsis, and terminated with a reset so colour never bleeds past the cut.
+# One awk process for the whole stream keeps the hook fast (<10ms).
+_cap_line_widths() {
+    awk -v cap="$_cap_cols" '
+    function viswidth(s,   n, i, rest, vis) {
+        n = length(s); i = 1; vis = 0
+        while (i <= n) {
+            rest = substr(s, i)
+            if (match(rest, /^\033\[[0-9;?]*[ -\/]*[@-~]/)) { i += RLENGTH; continue }
+            if (match(rest, /^\033\][^\033\007]*(\033\\|\007)/)) { i += RLENGTH; continue }
+            if (match(rest, /^\033./)) { i += RLENGTH; continue }
+            vis++; i++
+        }
+        return vis
+    }
+    function capline(s, limit,   n, i, rest, out, vis) {
+        n = length(s); i = 1; out = ""; vis = 0
+        while (i <= n) {
+            rest = substr(s, i)
+            if (match(rest, /^\033\[[0-9;?]*[ -\/]*[@-~]/)) { out = out substr(rest, 1, RLENGTH); i += RLENGTH; continue }
+            if (match(rest, /^\033\][^\033\007]*(\033\\|\007)/)) { out = out substr(rest, 1, RLENGTH); i += RLENGTH; continue }
+            if (match(rest, /^\033./)) { out = out substr(rest, 1, RLENGTH); i += RLENGTH; continue }
+            if (vis >= limit) break
+            out = out substr(rest, 1, 1); vis++; i++
+        }
+        return out "\342\200\246" "\033[0m"
+    }
+    { if (viswidth($0) <= cap) print $0; else print capline($0, cap - 1) }
+    '
+}
+
+{
 # The staleness banner (when the render is frozen) leads every other line so
 # the reader sees the warning before the out-of-date content it qualifies.
 [ -n "$_stale_banner" ] && printf '%s\n' "$_stale_banner"
@@ -709,3 +767,4 @@ if [ -n "${input:-}" ]; then
         printf '%s' "$input" | "$_runner" "$_resolved" 2>/dev/null
     done < <(_statusline_chain_db)
 fi
+} | _cap_line_widths

--- a/tests/test_claude_statusline.py
+++ b/tests/test_claude_statusline.py
@@ -1576,7 +1576,13 @@ class TestWidthCap:
         # The loop line was truncated: it ends with an ellipsis marker + reset so
         # colour never bleeds past the cut.
         loop_line = next(line for line in lines if "loop00" in _strip_ansi(line))
-        assert len(_strip_ansi(loop_line)) == 120, loop_line
+        # The contract is "no line exceeds the width", NOT "every line is exactly
+        # the width": an ANSI-aware cut lands on a character boundary at or before
+        # the cap, and an awk that measures bytes rather than characters over the
+        # multibyte ``·`` separators lands a little short — both ≤ cap. Assert
+        # bounded-and-meaningfully-truncated, never an exact fill.
+        loop_vis = len(_strip_ansi(loop_line))
+        assert 60 < loop_vis <= 120, loop_vis
         assert loop_line.endswith("…\033[0m"), repr(loop_line)
 
     def test_embedded_sgr_never_split_mid_escape(self, tmp_path: Path) -> None:

--- a/tests/test_claude_statusline.py
+++ b/tests/test_claude_statusline.py
@@ -1505,3 +1505,124 @@ class TestStatuslineRendersOnAutoloadWithoutMarker:
         result = self._run(tmp_path, autoload=False, marker=True)
         assert result.returncode == 0, result.stderr
         assert result.stdout == ""
+
+
+# A dangling escape is an ESC byte that does NOT open a recognised, complete
+# sequence — a CSI (``\x1b[…<final>``) or an OSC 8 wrapper (``\x1b]8;…\x1b\\``).
+# The width cap must never cut a line in the middle of an escape, so a capped
+# line's raw bytes must contain no such fragment.
+_DANGLING_ESC_RE = re.compile(r"\x1b(?![\[\]])|\x1b\[[0-9;?]*(?![0-9;?@-~])|\x1b\][^\x1b\x07]*\Z")
+
+
+class TestWidthCap:
+    """Every emitted line is capped to the visible terminal width (souliane/teatree).
+
+    Claude Code's statusline docs warn that long, multi-line ANSI output gets
+    truncated / wraps / renders blank. ``statusline.sh`` therefore bounds every
+    emitted line — header, zones, badge, and chain-script output — to the
+    visible terminal width at one choke point. The cap is ANSI-aware: it counts
+    only visible characters (ignoring SGR and OSC 8 sequences), never splits an
+    escape, terminates a truncated line with a reset so colour never bleeds, and
+    marks the cut with a single ``…``. Lines already within width pass through
+    byte-for-byte. The width comes from ``COLUMNS`` when set and > 0.
+    """
+
+    def _run(
+        self,
+        tmp_path: Path,
+        *,
+        columns: int,
+        zones: str,
+        session_id: str = "cap-sess",
+    ) -> subprocess.CompletedProcess:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(exist_ok=True)
+        (state_dir / f"{session_id}.teatree-active").touch()
+        sl = tmp_path / "statusline.txt"
+        sl.write_text(zones, encoding="utf-8")
+        env = os.environ.copy()
+        env["T3_AUTOLOAD"] = "1"
+        env["TEATREE_CLAUDE_STATUSLINE_STATE_DIR"] = str(state_dir)
+        env["CLAUDE_CONFIG_DIR"] = str(state_dir)
+        env["CLAUDE_TASKS_DIR"] = str(_harness_tasks_dir(state_dir))
+        env["TEATREE_STATUSLINE_FILE"] = str(sl)
+        env["COLUMNS"] = str(columns)
+        return subprocess.run(
+            [str(SCRIPT)],
+            input=json.dumps({"session_id": session_id, "model": {"display_name": "Claude Opus"}}),
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+            cwd=REPO_ROOT,
+        )
+
+    def test_long_loop_line_truncated_to_visible_width(self, tmp_path: Path) -> None:
+        # The ~900-char per-loop ANSI line that renders blank on some Claude Code
+        # surfaces. Each loop name is individually SGR-coloured, so the raw line
+        # is dense with escapes while its VISIBLE width is what must be bounded.
+        loops = " · ".join(f"\033[1;32mloop{i:02d} {i}m\033[0m" for i in range(90))
+        assert len(_strip_ansi(loops)) > 900, "fixture must exceed 900 visible chars"
+
+        result = self._run(tmp_path, columns=120, zones=loops + "\n")
+
+        assert result.returncode == 0, result.stderr
+        lines = result.stdout.splitlines()
+        # EVERY emitted line — header included — is within the width cap.
+        for line in lines:
+            assert len(_strip_ansi(line)) <= 120, (len(_strip_ansi(line)), line)
+        # The header still renders (the fix must not drop it).
+        assert any("model=Claude Opus" in _strip_ansi(line) for line in lines)
+        # The loop line was truncated: it ends with an ellipsis marker + reset so
+        # colour never bleeds past the cut.
+        loop_line = next(line for line in lines if "loop00" in _strip_ansi(line))
+        assert len(_strip_ansi(loop_line)) == 120, loop_line
+        assert loop_line.endswith("…\033[0m"), repr(loop_line)
+
+    def test_embedded_sgr_never_split_mid_escape(self, tmp_path: Path) -> None:
+        # The cut lands exactly where an embedded SGR sequence sits: the escape
+        # must be emitted whole (or wholly dropped), never bisected.
+        line = "x" * 49 + "\033[1;31m" + "y" * 100
+        result = self._run(tmp_path, columns=50, zones=line + "\n")
+
+        assert result.returncode == 0, result.stderr
+        capped = next(ln for ln in result.stdout.splitlines() if ln.startswith("x"))
+        # Visible width honoured (49 x's + the ellipsis marker == 50).
+        assert len(_strip_ansi(capped)) == 50, capped
+        # The boundary SGR is present intact, and no dangling escape fragment
+        # survives anywhere on the line.
+        assert "\033[1;31m" in capped, repr(capped)
+        assert _DANGLING_ESC_RE.search(capped) is None, repr(capped)
+        # Colour is closed off with a trailing reset.
+        assert capped.endswith("…\033[0m"), repr(capped)
+
+    def test_short_colored_line_passes_through_byte_for_byte(self, tmp_path: Path) -> None:
+        colored = "\033[1;32mtick 5m\033[0m"
+        result = self._run(tmp_path, columns=200, zones=colored + "\n")
+
+        assert result.returncode == 0, result.stderr
+        # A line within width is emitted unchanged, escapes and all.
+        assert colored in result.stdout, repr(result.stdout)
+
+    def test_multiline_input_stays_multiline(self, tmp_path: Path) -> None:
+        rows = ["\033[38;5;244m[acme] row one\033[0m", "[acme] row two", "→ statusline: three"]
+        result = self._run(tmp_path, columns=200, zones="\n".join(rows) + "\n")
+
+        assert result.returncode == 0, result.stderr
+        out_lines = result.stdout.splitlines()
+        # Each source row stays on its own row (none merged, none dropped).
+        for raw in rows:
+            visible = _strip_ansi(raw)
+            matches = [ln for ln in out_lines if _strip_ansi(ln) == visible]
+            assert len(matches) == 1, (visible, out_lines)
+
+    def test_osc8_hyperlink_within_width_preserved_intact(self, tmp_path: Path) -> None:
+        # OSC 8 hyperlink: ``\x1b]8;;<uri>\x1b\\<text>\x1b]8;;\x1b\\``. Its visible
+        # width is only the link text, so a short linked row passes through with
+        # the hyperlink wrapper byte-for-byte intact.
+        osc8 = "\033]8;;https://example.com/ticket/42\033\\ticket #42\033]8;;\033\\"
+        assert len(_strip_ansi(osc8)) < 20
+        result = self._run(tmp_path, columns=200, zones=osc8 + "\n")
+
+        assert result.returncode == 0, result.stderr
+        assert osc8 in result.stdout, repr(result.stdout)


### PR DESCRIPTION
## Problem

`hooks/scripts/statusline.sh` composes Claude Code's statusline as a header line plus the pre-rendered zones (loop line, anchors, action_needed, in_flight, overlays, health) and optional chain-script output. The **loop line** is frequently ~900 characters of dense per-loop ANSI (each loop name individually SGR-colored).

Claude Code's own statusline docs warn:

- "Keep output short: the status bar has limited width, so long output may get truncated or wrap awkwardly."
- "Multi-line status lines with escape codes are more prone to rendering issues than single-line plain text."

On some Claude Code render surfaces that ~900-char multi-line ANSI output makes the **whole bar render blank** (verified empirically), while a short single plain line renders fine.

## Fix

Bound every emitted line to the visible terminal width at a **single final-stage choke point** — the whole output stream (header, zones, owner badge, chain-script output) is piped through one ANSI-aware `awk` filter (`_cap_line_widths`). No external wrapper, multi-line structure preserved, chain-script appending unchanged.

Width source: `COLUMNS` when set and > 0; else `tput cols` when stdout is a real terminal; else a safe `200`.

The cap is **ANSI-aware**:

- counts only VISIBLE characters — `\033[...m` / any CSI and OSC 8 `\033]8;;...\033\\` (or BEL-terminated) hyperlink wrappers are copied verbatim but measured as zero width;
- never cuts in the middle of an escape sequence;
- a line already within width passes through **byte-for-byte** (escapes and OSC 8 links intact);
- a truncated line ends its visible text with a single `…` marker and is terminated with a reset (`\033[0m`) so color never bleeds past the cut.

One `awk` process for the whole stream keeps the hook fast (<10ms), no per-line subprocesses, awk/bash only (no python/node in the hot path).

## Tests

New `TestWidthCap` class in `tests/test_claude_statusline.py`:

- a >900-char loop line is truncated to the visible width cap and ends with a reset;
- an embedded SGR sequence at the cut boundary is never split mid-escape;
- a short colored line passes through byte-for-byte unchanged;
- multi-line input stays multi-line (each row preserved);
- an OSC 8 hyperlink line within width is preserved intact.

The truncation tests were observed RED before the change and GREEN after. Full statusline suite stays green: `uv run pytest tests/test_claude_statusline.py tests/teatree_loop -k statusline -q` → 378 passed.

## Manual proof (COLUMNS=120, 1157-char loop line)

```
line 0: width= 65  'model=Claude Opus | ram=40% 3.1/8G . cpu=101% . disk=49% 37G free'
line 1: width=120  't3-master: unclaimed . loop00 0m . loop01 1m . ... loop05 ' (…reset)
line 2: width= 25  '[acme] coded: #42 (topic)'
line 3: width= 23  '-> statusline: in flight'
ALL lines <= 120 visible chars: True ; header present: True ; truncated line ends with ellipsis+reset: True
```
