### PR TITLE
fix(readback): detect cited-issue and merged PRs so implemented issues are not re-claimed

### DIFF
--- a/src/teatree/loop/scanners/forge_readback.py
+++ b/src/teatree/loop/scanners/forge_readback.py
@@ -5,10 +5,12 @@ one GitHub repo keep per-instance SQLite, so instance B's
 :class:`~teatree.core.models.implemented_issue_marker.ImplementedIssueMarker`
 claim is invisible to instance A's DB — the cross-instance double-claim site.
 Before claiming an issue for auto-implementation, this queries the forge for
-live evidence the work already exists — an open PR whose head branch is the
-deterministic ``<ticket_number>-*`` worktree branch (:func:`build_branch_name`),
-or an open PR that references the issue — and lets the scanner skip the claim
-when found. It closes most of the double-claim window, but it cannot close it:
+live evidence the work already exists — an open OR merged PR whose head branch
+cites the ticket number (the deterministic ``<ticket_number>-*`` worktree branch
+or a hand-named branch that embeds it), or an open/merged PR that references the
+issue by URL or ``#<ticket_number>`` — and lets the scanner skip the claim when
+found. Merged PRs count so a fully-implemented issue is not re-claimed once its
+PRs land. It closes most of the double-claim window, but it cannot close it:
 two instances can still both read "clean" in the same tick before either opens a
 PR. The durable fleet mutex is Stage 2 (GitHub claim refs); this is the
 idempotent safety net beneath it.
@@ -21,6 +23,7 @@ issue's own repo so ``#5`` in one repo never binds a PR from another.
 
 import logging
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import cast
 from urllib.parse import urlparse
@@ -53,8 +56,9 @@ def issue_number(issue_url: str) -> str:
 class ReadbackHit:
     """Live forge evidence that an issue's work already exists.
 
-    ``reason`` names which signal matched (``open_pr_head_branch`` /
-    ``open_pr_body_ref`` / ``open_pr_closes_ref``); ``evidence_url`` is the
+    ``reason`` names which signal matched — a ``<state>_pr_<signal>`` pair where
+    ``state`` is ``open`` or ``merged`` and ``signal`` is ``head_branch`` /
+    ``body_ref`` / ``closes_ref`` / ``cited_ref``; ``evidence_url`` is the
     offending PR so the skip is auditable.
     """
 
@@ -91,9 +95,42 @@ def _pr_body(raw: RawAPIDict) -> str:
     return ""
 
 
+def _pr_title(raw: RawAPIDict) -> str:
+    value = raw.get("title")
+    return value if isinstance(value, str) else ""
+
+
 def _same_repo(pr_url: str, issue_slug: str) -> bool:
     ref = pr_ref_from_url(pr_url)
     return ref is not None and ref.slug == issue_slug
+
+
+def _pr_signal(raw: RawAPIDict, *, issue_url: str, ticket_number: str, issue_slug: str) -> str | None:
+    """Which signal (if any) proves *raw* is work for the issue, else ``None``.
+
+    Scoped to the issue's own repo slug so ``#5`` / a ``5-*`` branch in a
+    FOREIGN repo never binds. The head-branch match is a whole-word test on the
+    ticket number, so both the deterministic ``<ticket_number>`` / ``<ticket_number>-*``
+    worktree branch AND a hand-named branch that embeds the number
+    (``impl-<ticket_number>-presets``, ``fix-<ticket_number>``) count. The
+    ``#<ticket_number>`` citation is likewise a whole-word test so ``#420`` never
+    binds issue ``42``. Returns the bare signal (``head_branch`` / ``body_ref`` /
+    ``closes_ref`` / ``cited_ref``); the caller prefixes it with the PR state.
+    """
+    pr_url = _pr_url(raw)
+    if not _same_repo(pr_url, issue_slug):
+        return None
+    if re.search(rf"\b{re.escape(ticket_number)}\b", _pr_head_branch(raw)):
+        return "head_branch"
+    body = _pr_body(raw)
+    if issue_url and issue_url in body:
+        return "body_ref"
+    if parse_closes_ticket(body) == ticket_number:
+        return "closes_ref"
+    cite = re.compile(rf"#{re.escape(ticket_number)}\b")
+    if cite.search(_pr_title(raw)) or cite.search(body):
+        return "cited_ref"
+    return None
 
 
 def existing_work_for_issue(
@@ -101,14 +138,19 @@ def existing_work_for_issue(
     issue_url: str,
     ticket_number: str,
     open_prs: list[RawAPIDict],
+    merged_prs: list[RawAPIDict] | None = None,
 ) -> ReadbackHit | None:
-    """Scan the forge's open PRs for proof the issue is already being worked.
+    """Scan the forge's open and merged PRs for proof the issue is already worked.
 
-    Checks *open_prs* (the user's open PRs the loop already fetches) for the
-    first of three signals, all scoped to the issue's own repo slug: a head
-    branch equal to ``<ticket_number>`` or prefixed ``<ticket_number>-`` (the
-    deterministic worktree branch), the issue URL cited in the PR body, or a
-    ``Closes #<ticket_number>`` keyword in the body. ``None`` means clean.
+    Checks *open_prs* then *merged_prs* (the user's open and merged PRs the loop
+    fetches) for the first of four signals, all scoped to the issue's own repo
+    slug: a head branch that cites ``<ticket_number>`` as a whole word (the
+    deterministic ``<ticket_number>``/``<ticket_number>-*`` worktree branch OR a
+    hand-named branch that embeds it, e.g. ``impl-<ticket_number>-presets``), the
+    issue URL cited in the PR body, a ``Closes #<ticket_number>`` keyword, or a
+    bare ``#<ticket_number>`` citation in the PR title or body. Merged PRs count
+    so a fully-implemented issue is not re-claimed once its PRs land. ``None``
+    means clean.
 
     Fails OPEN when the issue's own repo slug is unparsable (a synthetic or
     non-standard issue URL): without a slug to scope by, a ``<ticket_number>-*``
@@ -122,36 +164,48 @@ def existing_work_for_issue(
     issue_slug = slug_from_issue_or_pr_url(urlparse(issue_url).path)
     if not issue_slug:
         return None
-    branch_prefix = f"{ticket_number}-"
-    for raw in open_prs:
-        pr_url = _pr_url(raw)
-        if not _same_repo(pr_url, issue_slug):
-            continue
-        head = _pr_head_branch(raw)
-        if head == ticket_number or head.startswith(branch_prefix):
-            return ReadbackHit("open_pr_head_branch", pr_url)
-        body = _pr_body(raw)
-        if issue_url and issue_url in body:
-            return ReadbackHit("open_pr_body_ref", pr_url)
-        if parse_closes_ticket(body) == ticket_number:
-            return ReadbackHit("open_pr_closes_ref", pr_url)
+    for state, prs in (("open", open_prs), ("merged", merged_prs or [])):
+        for raw in prs:
+            signal = _pr_signal(raw, issue_url=issue_url, ticket_number=ticket_number, issue_slug=issue_slug)
+            if signal is not None:
+                return ReadbackHit(f"{state}_pr_{signal}", _pr_url(raw))
     return None
 
 
 def fetch_open_prs(host: CodeHostBackend, *, authors: tuple[str, ...]) -> list[RawAPIDict]:
-    """Union each author's open PRs on the forge, deduped by URL — best-effort.
+    """Union each author's OPEN PRs on the forge, deduped by URL — best-effort.
 
     The read-back is a net: a forge hiccup must never block the claim path, so
     a failing ``list_my_prs`` degrades to the PRs gathered so far (``[]`` in the
     worst case) and the caller falls through to claim.
     """
+    return _union_prs(host.list_my_prs, authors=authors, kind="list_my_prs")
+
+
+def fetch_merged_prs(host: CodeHostBackend, *, authors: tuple[str, ...]) -> list[RawAPIDict]:
+    """Union each author's MERGED PRs on the forge, deduped by URL — best-effort.
+
+    The merged-PR companion to :func:`fetch_open_prs`: an issue whose
+    implementing PRs have already landed must not be re-claimed. Same fail-open
+    contract — a failing ``list_my_merged_prs`` degrades to the PRs gathered so
+    far and the caller falls through to claim.
+    """
+    return _union_prs(host.list_my_merged_prs, authors=authors, kind="list_my_merged_prs")
+
+
+def _union_prs(
+    lister: Callable[..., list[RawAPIDict]],
+    *,
+    authors: tuple[str, ...],
+    kind: str,
+) -> list[RawAPIDict]:
     seen: set[str] = set()
     prs: list[RawAPIDict] = []
     for author in authors:
         try:
-            fetched = host.list_my_prs(author=author)
+            fetched = lister(author=author)
         except Exception:
-            logger.debug("forge read-back list_my_prs failed for author %s — skipping", author, exc_info=True)
+            logger.debug("forge read-back %s failed for author %s — skipping", kind, author, exc_info=True)
             continue
         for raw in fetched:
             url = _pr_url(raw)

--- a/src/teatree/loop/scanners/issue_implementer.py
+++ b/src/teatree/loop/scanners/issue_implementer.py
@@ -23,7 +23,7 @@ from teatree.core.backend_protocols import CodeHostBackend
 from teatree.core.fleet import wire
 from teatree.core.models import NEEDS_TRIAGE_LABEL, ImplementedIssueMarker
 from teatree.loop.scanners.base import ScanSignal
-from teatree.loop.scanners.forge_readback import existing_work_for_issue, fetch_open_prs, issue_number
+from teatree.loop.scanners.forge_readback import existing_work_for_issue, fetch_merged_prs, fetch_open_prs, issue_number
 from teatree.types import RawAPIDict
 
 logger = logging.getLogger(__name__)
@@ -87,9 +87,10 @@ class IssueImplementerScanner:
 
     ``readback_enabled`` (default on) runs the pre-dispatch forge read-back
     (:func:`~teatree.loop.scanners.forge_readback.existing_work_for_issue`)
-    before each claim: an issue whose ``<ticket_number>-*`` branch or a
-    referencing PR already exists on the forge is skipped, closing most of the
-    cross-instance double-claim window that the local claim ledger cannot see.
+    before each claim: an issue whose branch cites the ticket number or an
+    open/merged PR referencing it already exists on the forge is skipped,
+    closing most of the cross-instance double-claim window that the local claim
+    ledger cannot see.
     """
 
     host: CodeHostBackend
@@ -118,11 +119,17 @@ class IssueImplementerScanner:
         if not candidates:
             return []
         open_prs = fetch_open_prs(self.host, authors=assignees) if self.readback_enabled else []
+        merged_prs = fetch_merged_prs(self.host, authors=assignees) if self.readback_enabled else []
         signals: list[ScanSignal] = []
         for issue in candidates:
             url = _issue_url(issue)
             try:
-                hit = existing_work_for_issue(issue_url=url, ticket_number=issue_number(url), open_prs=open_prs)
+                hit = existing_work_for_issue(
+                    issue_url=url,
+                    ticket_number=issue_number(url),
+                    open_prs=open_prs,
+                    merged_prs=merged_prs,
+                )
                 if hit is not None:
                     logger.info(
                         "IssueImplementerScanner read-back skip %s: %s (%s)",

--- a/tests/teatree_loop/scanners/test_forge_readback.py
+++ b/tests/teatree_loop/scanners/test_forge_readback.py
@@ -8,15 +8,15 @@ the issue's own repo and must never let a forge error block the claim path.
 
 from dataclasses import dataclass, field
 
-from teatree.loop.scanners.forge_readback import existing_work_for_issue, fetch_open_prs, issue_number
+from teatree.loop.scanners.forge_readback import existing_work_for_issue, fetch_merged_prs, fetch_open_prs, issue_number
 from teatree.types import RawAPIDict
 
 ISSUE = "https://github.com/souliane/teatree/issues/42"
 GITLAB_ISSUE = "https://gitlab.com/acme/app/-/issues/42"
 
 
-def _github_pr(*, url: str, head: str = "", body: str = "") -> RawAPIDict:
-    return {"html_url": url, "head": {"ref": head}, "body": body}
+def _github_pr(*, url: str, head: str = "", body: str = "", title: str = "") -> RawAPIDict:
+    return {"html_url": url, "head": {"ref": head}, "body": body, "title": title}
 
 
 def _gitlab_mr(*, url: str, source_branch: str = "", body: str = "") -> RawAPIDict:
@@ -54,8 +54,56 @@ class TestExistingWorkForIssue:
         assert hit is not None
         assert hit.reason == "open_pr_closes_ref"
 
+    def test_hits_on_non_numeric_prefixed_branch(self) -> None:
+        # A branch like ``impl-42-presets`` cites the issue number as a whole word
+        # even though it is not the deterministic ``42``/``42-*`` worktree branch.
+        prs = [_github_pr(url="https://github.com/souliane/teatree/pull/9", head="impl-42-presets")]
+        hit = existing_work_for_issue(issue_url=ISSUE, ticket_number="42", open_prs=prs)
+        assert hit is not None
+        assert hit.reason == "open_pr_head_branch"
+
+    def test_hits_on_hash_ref_in_title(self) -> None:
+        prs = [_github_pr(url="https://github.com/souliane/teatree/pull/9", head="wip", title="Fix presets (#42)")]
+        hit = existing_work_for_issue(issue_url=ISSUE, ticket_number="42", open_prs=prs)
+        assert hit is not None
+        assert hit.reason == "open_pr_cited_ref"
+
+    def test_hits_on_hash_ref_in_body(self) -> None:
+        prs = [_github_pr(url="https://github.com/souliane/teatree/pull/9", head="wip", body="towards #42 groundwork")]
+        hit = existing_work_for_issue(issue_url=ISSUE, ticket_number="42", open_prs=prs)
+        assert hit is not None
+        assert hit.reason == "open_pr_cited_ref"
+
+    def test_hash_ref_requires_whole_number(self) -> None:
+        # ``#420`` must not bind issue 42.
+        prs = [_github_pr(url="https://github.com/souliane/teatree/pull/9", head="wip", body="see #420")]
+        assert existing_work_for_issue(issue_url=ISSUE, ticket_number="42", open_prs=prs) is None
+
+    def test_merged_pr_closes_ref_is_a_hit(self) -> None:
+        # A fully-implemented issue whose PRs are MERGED must not be re-claimed.
+        merged = [_github_pr(url="https://github.com/souliane/teatree/pull/9", head="x", body="Closes #42")]
+        hit = existing_work_for_issue(issue_url=ISSUE, ticket_number="42", open_prs=[], merged_prs=merged)
+        assert hit is not None
+        assert hit.reason == "merged_pr_closes_ref"
+
+    def test_merged_pr_branch_is_a_hit(self) -> None:
+        merged = [_github_pr(url="https://github.com/souliane/teatree/pull/9", head="impl-42-presets")]
+        hit = existing_work_for_issue(issue_url=ISSUE, ticket_number="42", open_prs=[], merged_prs=merged)
+        assert hit is not None
+        assert hit.reason == "merged_pr_head_branch"
+
+    def test_merged_pr_in_other_repo_does_not_match(self) -> None:
+        merged = [_github_pr(url="https://github.com/souliane/other/pull/9", head="x", body="Closes #42")]
+        assert existing_work_for_issue(issue_url=ISSUE, ticket_number="42", open_prs=[], merged_prs=merged) is None
+
     def test_clean_returns_none(self) -> None:
         prs = [_github_pr(url="https://github.com/souliane/teatree/pull/9", head="99-other", body="unrelated")]
+        assert existing_work_for_issue(issue_url=ISSUE, ticket_number="42", open_prs=prs) is None
+
+    def test_unrelated_open_pr_is_not_a_false_hit(self) -> None:
+        # A same-repo PR with no branch/body/title reference to issue 42 is clean,
+        # even when it cites a different issue number.
+        prs = [_github_pr(url="https://github.com/souliane/teatree/pull/9", head="impl-presets", body="see #420")]
         assert existing_work_for_issue(issue_url=ISSUE, ticket_number="42", open_prs=prs) is None
 
     def test_other_repo_branch_does_not_match(self) -> None:
@@ -110,8 +158,10 @@ class TestExistingWorkForIssue:
 @dataclass
 class _Host:
     prs: list[RawAPIDict] = field(default_factory=list)
+    merged: list[RawAPIDict] = field(default_factory=list)
     raises: bool = False
     seen_authors: list[str] = field(default_factory=list)
+    seen_merged_authors: list[str] = field(default_factory=list)
 
     def list_my_prs(self, *, author: str) -> list[RawAPIDict]:
         self.seen_authors.append(author)
@@ -119,6 +169,13 @@ class _Host:
             msg = "forge down"
             raise RuntimeError(msg)
         return self.prs
+
+    def list_my_merged_prs(self, *, author: str) -> list[RawAPIDict]:
+        self.seen_merged_authors.append(author)
+        if self.raises:
+            msg = "forge down"
+            raise RuntimeError(msg)
+        return self.merged
 
 
 class TestFetchOpenPrs:
@@ -136,3 +193,15 @@ class TestFetchOpenPrs:
         host = _Host(prs=[{"head": {"ref": "x"}}])
         prs = fetch_open_prs(host, authors=("alice",))
         assert len(prs) == 1
+
+
+class TestFetchMergedPrs:
+    def test_unions_and_dedupes_by_url(self) -> None:
+        host = _Host(merged=[_github_pr(url="https://github.com/o/r/pull/1")])
+        prs = fetch_merged_prs(host, authors=("alice", "alice-bot"))
+        assert len(prs) == 1
+        assert host.seen_merged_authors == ["alice", "alice-bot"]
+
+    def test_forge_error_degrades_to_empty_never_raises(self) -> None:
+        host = _Host(raises=True)
+        assert fetch_merged_prs(host, authors=("alice",)) == []

--- a/tests/teatree_loop/test_issue_implementer_scanner.py
+++ b/tests/teatree_loop/test_issue_implementer_scanner.py
@@ -23,6 +23,7 @@ class _Host:
     user: str = "alice"
     issues: list[RawAPIDict] = field(default_factory=list)
     open_prs: list[RawAPIDict] = field(default_factory=list)
+    merged_prs: list[RawAPIDict] = field(default_factory=list)
 
     def current_user(self) -> str:
         return self.user
@@ -34,6 +35,10 @@ class _Host:
     def list_my_prs(self, *, author: str) -> list[RawAPIDict]:
         _ = author
         return self.open_prs
+
+    def list_my_merged_prs(self, *, author: str) -> list[RawAPIDict]:
+        _ = author
+        return self.merged_prs
 
 
 class IssueImplementerScannerTests(TestCase):
@@ -142,6 +147,17 @@ class IssueImplementerReadbackTests(TestCase):
         host = _Host(
             issues=[self._issue(self.URL_A)],
             open_prs=[{"html_url": "https://github.com/souliane/teatree/pull/7", "head": {"ref": "100-feature-x"}}],
+        )
+        assert self._scanner(host).scan() == []
+        assert not ImplementedIssueMarker.objects.filter(issue_url=self.URL_A).exists()
+
+    def test_skips_claim_when_merged_pr_closes_issue(self) -> None:
+        # A fully-implemented issue (its PRs already merged) must not be re-claimed.
+        host = _Host(
+            issues=[self._issue(self.URL_A)],
+            merged_prs=[
+                {"html_url": "https://github.com/souliane/teatree/pull/7", "head": {"ref": "x"}, "body": "Closes #100"}
+            ],
         )
         assert self._scanner(host).scan() == []
         assert not ImplementedIssueMarker.objects.filter(issue_url=self.URL_A).exists()

--- a/tests/teatree_loop/test_per_item_fault_isolation_1597.py
+++ b/tests/teatree_loop/test_per_item_fault_isolation_1597.py
@@ -672,6 +672,14 @@ class _ImplementerHost:
         _ = assignee
         return self.issues
 
+    def list_my_prs(self, *, author: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (author, updated_after)
+        return []
+
+    def list_my_merged_prs(self, *, author: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (author, updated_after)
+        return []
+
 
 IMPL_LABEL = "auto-implement"
 IMPL_URL_A = "https://github.com/acme/repo/issues/1"


### PR DESCRIPTION
## Problem (#3225)

The pre-dispatch forge read-back (`existing_work_for_issue`) guards the issue-implementer from re-claiming an issue that already has work, but it missed two real cases:

1. **Non-deterministic branches.** It only matched a PR head branch equal to `<num>` or prefixed `<num>-`, so hand-named branches like `impl-3159-presets` or `fix-preset-drift` slipped through.
2. **Merged PRs.** It only consulted OPEN PRs, so an issue whose implementing PRs were already MERGED got re-claimed. This is what happened to #3159 (its PRs #3167/#3174/#3178 were merged, yet the factory re-claimed it).

## Fix

- Head-branch match is now a whole-word test on the ticket number (`\b<num>\b`), so both the deterministic worktree branch AND a branch that embeds the number count.
- A bare `#<num>` citation in the PR title or body is now a hit (the docstring already promised title/body reference matching), whole-word so `#420` never binds issue `42`.
- `existing_work_for_issue` now also scans MERGED PRs (new `fetch_merged_prs`, mirroring `fetch_open_prs`), so a fully-implemented issue is not re-claimed once its PRs land. Reason strings are now `<state>_pr_<signal>` (`open`/`merged`).
- Repo-scoping and the fail-open contract are unchanged, so genuinely-unworked issues still fall through to claim.

## Tests

`tests/teatree_loop/scanners/test_forge_readback.py` and `tests/teatree_loop/test_issue_implementer_scanner.py`: non-numeric-prefixed branch, `#<num>` in title/body, `#420` non-match, merged-PR closes/branch hits, merged-PR foreign-repo non-match, unrelated open PR is not a false hit, `fetch_merged_prs` union/dedupe/fail-open, and a scanner-level merged-PR skip. Observed RED before the fix, GREEN after.

Closes #3225