### PR TITLE
fix(cli): bootstrap Django at the top of t3 agent so it runs standalone

### DIFF
--- a/src/teatree/cli/agent.py
+++ b/src/teatree/cli/agent.py
@@ -100,6 +100,8 @@ def agent(
     skill: list[str] = AGENT_SKILL_OPTION,
 ) -> None:
     """Launch Claude Code with auto-detected project context."""
+    ensure_django()
+
     from teatree.cli import _find_project_root  # noqa: PLC0415 — deferred: breaks agent ↔ cli cycle
     from teatree.config import discover_active_overlay  # noqa: PLC0415 — deferred: keeps CLI startup light
     from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415 — deferred: keeps CLI startup light

--- a/tests/teatree_cli/test_agent_bootstrap.py
+++ b/tests/teatree_cli/test_agent_bootstrap.py
@@ -1,0 +1,114 @@
+"""``t3 agent`` bootstraps Django before touching the overlay/config layer.
+
+``t3 agent`` is a plain Typer command reachable before ``django.setup()`` has
+run (the ``t3`` console script never configures Django — see
+``t3_bootstrap._main``). Its body calls ``discover_active_overlay()`` /
+``get_overlay()`` / ``get_effective_settings()``, all of which touch the Django
+app registry. Run standalone — from any directory with no ``manage.py`` — the
+command therefore crashed with ``django.core.exceptions.ImproperlyConfigured:
+Requested setting INSTALLED_APPS, but settings are not configured`` (and its
+``AppRegistryNotReady`` sibling once the settings module is set). The command
+body must call :func:`teatree.utils.django_bootstrap.ensure_django` before any
+overlay/config access, mirroring every other ORM-touching Typer command.
+
+These tests pin the invariant via subprocesses (a clean child interpreter with
+``DJANGO_SETTINGS_MODULE`` unset, the pre-bootstrap state a normal shell
+invocation starts from) so a future refactor cannot silently re-break it. The
+in-process ``tests/test_cli.py`` coverage cannot catch this regression: pytest
+already configured Django for the whole test process, so the app registry is
+ready there regardless of whether the command bootstraps it.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _clean_env() -> dict[str, str]:
+    """Return an env without ``DJANGO_SETTINGS_MODULE`` — the pre-bootstrap state.
+
+    Mirrors how the user invokes ``t3 agent`` from a normal shell: no Django
+    settings module is pre-exported, the CLI is responsible for setting it.
+    """
+    env = os.environ.copy()
+    env.pop("DJANGO_SETTINGS_MODULE", None)
+    return env
+
+
+class TestAgentCommandBootstrapsDjango:
+    """`t3 agent` bootstraps Django before the overlay/config layer runs.
+
+    A child interpreter invokes the command with ``DJANGO_SETTINGS_MODULE``
+    unset and from a directory with no ``manage.py``. ``shutil.which`` is
+    patched so the ``claude`` binary is always "found" (making the test
+    deterministic on hosts with or without Claude Code installed) and
+    ``os.execvp`` is patched to a no-op so the real process is not replaced.
+    Nothing else is mocked: the command runs the genuine
+    ``discover_active_overlay`` / ``get_overlay`` / ``get_effective_settings``
+    path, which is exactly what raised ``ImproperlyConfigured`` before the fix.
+    """
+
+    def test_agent_does_not_raise_improperly_configured(self, tmp_path: Path) -> None:
+        probe = (
+            "from unittest.mock import patch\n"
+            "from typer.testing import CliRunner\n"
+            "import teatree.cli.agent as agent_mod\n"
+            "from teatree.cli import app\n"
+            "\n"
+            "runner = CliRunner()\n"
+            "with patch('shutil.which', return_value='/usr/bin/claude'), \\\n"
+            "     patch.object(agent_mod.os, 'execvp') as execvp:\n"
+            "    result = runner.invoke(app, ['agent', 'fix the sync bug'])\n"
+            "if result.exception is not None:\n"
+            "    import traceback\n"
+            "    traceback.print_exception(\n"
+            "        type(result.exception), result.exception, result.exception.__traceback__\n"
+            "    )\n"
+            "    print('OUTPUT:', result.output)\n"
+            "    raise SystemExit(2)\n"
+            "assert execvp.called, 'command did not reach the claude launch'\n"
+            "assert result.exit_code == 0, result.output\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+            env=_clean_env(),
+        )
+        assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        assert "ImproperlyConfigured" not in result.stdout
+        assert "ImproperlyConfigured" not in result.stderr
+        assert "AppRegistryNotReady" not in result.stdout
+        assert "AppRegistryNotReady" not in result.stderr
+
+
+class TestAgentHelpIsBootstrapSafe:
+    """`t3 agent --help` renders without Django configured.
+
+    Help rendering does not touch the ORM, but this is a cheap guard that the
+    command entry stays wired into the Typer app and reachable from the
+    pre-bootstrap ``t3`` console-script path.
+    """
+
+    def test_agent_help_does_not_raise_improperly_configured(self, tmp_path: Path) -> None:
+        probe = (
+            "from typer.testing import CliRunner\n"
+            "from teatree.cli import app\n"
+            "\n"
+            "result = CliRunner().invoke(app, ['agent', '--help'])\n"
+            "assert result.exit_code == 0, result.output\n"
+            "assert 'Launch Claude Code' in result.output, result.output\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+            env=_clean_env(),
+        )
+        assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        assert "ImproperlyConfigured" not in result.stderr


### PR DESCRIPTION
## Problem

Running `t3 agent "<prompt>"` standalone — outside a teatree repo, from any directory with no `manage.py` — crashed with:

```
django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS,
but settings are not configured.
```

(and its `AppRegistryNotReady` sibling once the settings module is set).

The `t3` console script never configures Django (`t3_bootstrap._main`), so a plain Typer command body is responsible for bootstrapping it before touching the ORM. `agent()` calls `discover_active_overlay()` / `get_overlay()` / `get_effective_settings()` — all of which touch the Django app registry — without ever calling `django.setup()`. `ensure_django()` was only reached inside `_detect_agent_ticket_status`, which early-returns when there is no `manage.py` in cwd, so standalone invocation never bootstrapped Django and crashed at the first overlay access.

## Fix

Call `ensure_django()` at the very top of the `agent()` command body, before any overlay/config access — mirroring how every other ORM-touching Typer command bootstraps Django. `ensure_django()` is idempotent (`setdefault` + `django.setup()` no-op after first call), so this is safe when Django is already configured.

## Tests

New `tests/teatree_cli/test_agent_bootstrap.py` (mirrors the existing `test_review_django_bootstrap.py` subprocess pattern):

- `TestAgentCommandBootstrapsDjango::test_agent_does_not_raise_improperly_configured` — invokes the `agent` command in a clean child interpreter (`DJANGO_SETTINGS_MODULE` unset, cwd with no `manage.py`), patching only `shutil.which` and `os.execvp` so the real `discover_active_overlay` / `get_overlay` / `get_effective_settings` path runs. Asserts no `ImproperlyConfigured` / `AppRegistryNotReady` and a clean exit. Verified RED before the fix (crashes at `get_overlay()`), GREEN after.
- `TestAgentHelpIsBootstrapSafe::test_agent_help_does_not_raise_improperly_configured` — cheap smoke that `t3 agent --help` renders from the pre-bootstrap path.

The in-process `tests/test_cli.py` coverage cannot catch this regression: pytest configures Django for the whole test process, so the app registry is already ready there regardless of whether the command bootstraps it. The subprocess gives the genuine pre-bootstrap state.

## Gates

- `uv run ruff check` + `uv run ruff format --check` on changed files: clean
- `uv run pytest tests/teatree_cli/test_agent_bootstrap.py`: 2 passed
- `uv run python manage.py makemigrations --check --dry-run`: No changes detected
- `bash dev/ci-parity-fast.sh`: exit 0 (prek + migration-graph + scoped tests/quality + push-gate)
