### PR TITLE
fix(discovery): canonicalize deploy-dirname overlay to the sole registered overlay

### DIFF
--- a/src/teatree/config/discovery.py
+++ b/src/teatree/config/discovery.py
@@ -146,7 +146,20 @@ def _canonical_active_overlay_name(directory_name: str) -> str:
         return directory_name
     if directory_name in ep_names:
         return directory_name
-    return _match_canonical_ep(directory_name, ep_names) or directory_name
+    canonical = _match_canonical_ep(directory_name, ep_names)
+    if canonical is not None:
+        return canonical
+    # A clone/deploy dir whose basename matches NO registered entry point —
+    # e.g. a ``teatree-deploy`` deploy dir against the sole ``t3-teatree``
+    # entry point — would otherwise leak the raw basename as the overlay
+    # anchor and stamp an undispatchable name onto every scanner ticket
+    # (souliane/teatree deploy-dirname leak). When exactly one overlay is
+    # installed there is no ambiguity: fold onto that single entry point.
+    # More than one installed overlay stays ambiguous, so the basename is
+    # preserved (multi-overlay behaviour intact).
+    if len(ep_names) == 1:
+        return next(iter(ep_names))
+    return directory_name
 
 
 def _resolve_ep_project_path(overlay_class: str) -> Path | None:

--- a/src/teatree/loop/global_scanner_factories.py
+++ b/src/teatree/loop/global_scanner_factories.py
@@ -36,6 +36,26 @@ from teatree.loop.scanners.notion_view import NotionLike
 from teatree.loop.scanners.self_update_ci import GhMainCiStatus
 
 
+def _active_overlay_anchor() -> str:
+    """Resolve the dispatchable overlay-anchor name for global per-overlay scanners.
+
+    Reads the active overlay via :func:`discover_active_overlay` and
+    canonicalizes the result through
+    :func:`teatree.core.overlay_loader.resolve_overlay_name` so a clone- or
+    deploy-directory basename that no registered overlay can dispatch (the
+    ``teatree-deploy`` deploy-dirname leak) is never stamped onto a scanner
+    ticket. Falls back to the canonical core overlay both when no overlay is
+    discovered AND when the discovered name is undispatchable — closing the
+    poison-pill seam (souliane/teatree#1959) at the write-site rather than
+    only at the drain guard.
+    """
+    from teatree.core.overlay_loader import resolve_overlay_name  # noqa: PLC0415 — tick-time import
+
+    active = discover_active_overlay()
+    raw = active.name if active is not None else _CANONICAL_CORE_OVERLAY
+    return resolve_overlay_name(raw) or _CANONICAL_CORE_OVERLAY
+
+
 def _dogfood_smoke_scanner() -> Scanner | None:
     """Wire the global provision-smoke scanner (#1308)."""
     from teatree.loop.scanners.provision_smoke import build_provision_smoke_scanner  # noqa: PLC0415 — tick-time import
@@ -195,8 +215,7 @@ def _idle_stack_reaper_scanner() -> IdleStackReaperScanner | None:
     settings = load_config().user
     if settings.idle_stack_reaper_disabled:
         return None
-    active = discover_active_overlay()
-    overlay_name = active.name if active is not None else _CANONICAL_CORE_OVERLAY
+    overlay_name = _active_overlay_anchor()
     return IdleStackReaperScanner(
         overlay=overlay_name,
         idle_minutes=settings.idle_stack_idle_minutes,
@@ -219,8 +238,7 @@ def _snapshot_warmer_scanner() -> SnapshotWarmerScanner | None:
         return None
     from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415 — deferred: loaded at tick time, not import
 
-    active = discover_active_overlay()
-    overlay_name = active.name if active is not None else _CANONICAL_CORE_OVERLAY
+    overlay_name = _active_overlay_anchor()
     try:
         overlay = get_overlay(overlay_name)
     except Exception:  # noqa: BLE001 — an unresolvable overlay means nothing to warm, not a tick crash
@@ -261,8 +279,7 @@ def _local_stack_queue_drainer_scanner() -> LocalStackQueueDrainerScanner | None
     settings = load_config().user
     if settings.local_stack_queue_disabled:
         return None
-    active = discover_active_overlay()
-    overlay_name = active.name if active is not None else _CANONICAL_CORE_OVERLAY
+    overlay_name = _active_overlay_anchor()
     return LocalStackQueueDrainerScanner(overlay=overlay_name)
 
 
@@ -310,8 +327,7 @@ def _scanning_news_scanner() -> ScanningNewsScanner | None:
     settings = load_config().user
     if settings.scanning_news_disabled:
         return None
-    active = discover_active_overlay()
-    overlay_name = active.name if active is not None else _CANONICAL_CORE_OVERLAY
+    overlay_name = _active_overlay_anchor()
     return ScanningNewsScanner(
         overlay_name=overlay_name,
         skill=settings.scanning_news_skill,
@@ -339,8 +355,7 @@ def _eval_local_scanner() -> EvalLocalScanner | None:
     settings = load_config().user
     if settings.eval_local_disabled:
         return None
-    active = discover_active_overlay()
-    overlay_name = active.name if active is not None else _CANONICAL_CORE_OVERLAY
+    overlay_name = _active_overlay_anchor()
     return EvalLocalScanner(
         overlay_name=overlay_name,
         skill=settings.eval_local_skill,
@@ -368,8 +383,7 @@ def _backlog_sweep_scanner() -> BacklogSweepScanner | None:
     settings = load_config().user
     if settings.backlog_sweep_disabled:
         return None
-    active = discover_active_overlay()
-    overlay_name = active.name if active is not None else _CANONICAL_CORE_OVERLAY
+    overlay_name = _active_overlay_anchor()
     return BacklogSweepScanner(
         overlay_name=overlay_name,
         skill=settings.backlog_sweep_skill,

--- a/tests/config/test_overlay_discovery.py
+++ b/tests/config/test_overlay_discovery.py
@@ -117,6 +117,60 @@ def test_discover_active_overlay_canonicalizes_clone_dir_name(tmp_path: Path, mo
     assert result.project_path == project
 
 
+def test_discover_active_overlay_folds_deploy_dirname_to_sole_overlay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A deploy dir named ``teatree-deploy`` folds onto the sole registered overlay.
+
+    The basename ``teatree-deploy`` matches neither ``t3-teatree`` exactly nor
+    the ``-teatree-deploy`` dash-suffix alias rule, so pre-fix it leaked through
+    unchanged and stamped an undispatchable overlay onto every scanner ticket
+    (tickets 6/7/8 stuck ``not_started``). With exactly one overlay installed
+    there is no ambiguity — resolve to that overlay's canonical entry-point name.
+    """
+    project = tmp_path / "teatree-deploy"
+    _write_manage_py(project, "active.settings")
+    monkeypatch.chdir(project)
+
+    ep = MagicMock()
+    ep.name = "t3-teatree"
+    ep.value = "t3_teatree.overlay:TeatreeOverlay"
+
+    with patch("importlib.metadata.entry_points", return_value=[ep]):
+        result = discover_active_overlay()
+
+    assert result is not None
+    assert result.name == "t3-teatree"
+    assert result.project_path == project
+
+
+def test_discover_active_overlay_dirname_kept_raw_when_multiple_overlays(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With >1 overlay installed an ambiguous basename is NOT force-folded.
+
+    The single-overlay fallback only fires when there is exactly one registered
+    entry point; multiple installed overlays make the choice ambiguous, so the
+    directory basename is preserved (existing multi-overlay behaviour intact).
+    """
+    project = tmp_path / "teatree-deploy"
+    _write_manage_py(project, "active.settings")
+    monkeypatch.chdir(project)
+
+    ep_a = MagicMock()
+    ep_a.name = "t3-teatree"
+    ep_a.value = "t3_teatree.overlay:TeatreeOverlay"
+    ep_b = MagicMock()
+    ep_b.name = "t3-acme"
+    ep_b.value = "acme_pkg.overlay:AcmeOverlay"
+
+    with patch("importlib.metadata.entry_points", return_value=[ep_a, ep_b]):
+        result = discover_active_overlay()
+
+    assert result is not None
+    assert result.name == "teatree-deploy"
+
+
 def test_discover_active_overlay_single_declared(
     config_db: Path,
     elsewhere: Path,

--- a/tests/teatree_loop/test_scanning_news_scanner.py
+++ b/tests/teatree_loop/test_scanning_news_scanner.py
@@ -349,6 +349,44 @@ class ScanningNewsWiringTests(TestCase):
         assert scanner is not None
         assert scanner.overlay_name == "t3-teatree"
 
+    def test_undispatchable_deploy_dirname_never_reaches_ticket(self) -> None:
+        """Deploy-dirname leak — an undispatchable discovered overlay is canonicalized before persistence.
+
+        On a box whose deploy dir is ``teatree-deploy`` (matching no registered
+        entry point), ``discover_active_overlay`` pre-fix returned that raw name
+        and the wiring stamped it onto the scanning-news ticket, creating the
+        poison-pill ``scanning-news://teatree-deploy`` row (ticket 6, stuck
+        ``not_started``). The write-site now canonicalizes through
+        ``resolve_overlay_name`` and falls back to the sole registered overlay,
+        so the undispatchable name is never persisted onto a ticket.
+        """
+        from teatree.config import OverlayEntry  # noqa: PLC0415
+        from teatree.core.models.ticket import Ticket  # noqa: PLC0415
+        from teatree.loop.global_scanner_factories import _scanning_news_scanner  # noqa: PLC0415
+
+        leaked = OverlayEntry(name="teatree-deploy", overlay_class="")
+        with (
+            patch(
+                "teatree.loop.global_scanner_factories.load_config",
+                return_value=type("Cfg", (), {"user": self._patched_settings()})(),
+            ),
+            patch(
+                "teatree.loop.global_scanner_factories.discover_active_overlay",
+                return_value=leaked,
+            ),
+        ):
+            scanner = _scanning_news_scanner()
+            assert scanner is not None
+            signals = scanner.scan()
+
+        assert scanner.overlay_name == "t3-teatree"
+        assert len(signals) == 1
+        assert signals[0].payload["overlay"] == "t3-teatree"
+        # The undispatchable deploy dirname must never be persisted onto a ticket.
+        assert not Ticket.objects.filter(overlay="teatree-deploy").exists()
+        assert not Ticket.objects.filter(issue_url="scanning-news://teatree-deploy").exists()
+        assert Ticket.objects.filter(issue_url="scanning-news://t3-teatree").exists()
+
     def test_wiring_falls_back_to_canonical_when_no_overlay_discovered(self) -> None:
         """Defensive default — no installed overlay still queues against the canonical name."""
         from teatree.loop.global_scanner_factories import _scanning_news_scanner  # noqa: PLC0415


### PR DESCRIPTION
## The leak

On a box whose deploy directory is `teatree-deploy`, `_discover_from_manage_py`
folds the active overlay name through `_canonical_active_overlay_name` ->
`_match_canonical_ep`, which only matches when `ep == alias` or
`ep.endswith("-<alias>")`. `teatree-deploy` matches NEITHER the sole registered
entry point (`t3-teatree`) exactly nor the `-teatree-deploy` dash-suffix rule,
so the raw basename `teatree-deploy` leaked through unchanged and got stamped as
the overlay anchor on every scanner-created ticket.

Result: tickets 6/7/8 (`scanning-news://teatree-deploy`,
`eval-local://teatree-deploy`, `dogfood-smoke://teatree-deploy`) are permanently
stuck `not_started` and their tasks are skipped by the poison-pill guards with
"unknown overlay 'teatree-deploy'" (`resolve_overlay_name("teatree-deploy")` is
`None` — undispatchable).

## The two-layer fix

1. **Discovery fold** (`src/teatree/config/discovery.py`) — in
   `_canonical_active_overlay_name`, when the folded/canonical name is NOT a
   registered entry point AND exactly one overlay is installed, fall back to
   that single entry point's canonical name. More than one installed overlay
   stays ambiguous, so the basename is preserved (existing multi-overlay
   behaviour intact). This fixes the root cause: `discover_active_overlay().name`
   now returns `t3-teatree` on a `teatree-deploy` box.

2. **Scanner write-site canonicalization** (`global_scanner_factories.py`) — a
   new shared `_active_overlay_anchor()` helper resolves the active overlay and
   canonicalizes it through `resolve_overlay_name`, falling back to the canonical
   core overlay when the discovered name is undispatchable. The six per-overlay
   global scanners (idle-stack reaper, snapshot warmer, local-stack drainer,
   scanning-news, eval-local, backlog-sweep) now route through it, so an
   undispatchable name can never reach a scanner ticket even if discovery ever
   regresses. The `scanning_news.py` scanner stays overlay-agnostic (stamps
   whatever the wiring hands it), so the canonicalization lives at the single
   wiring seam that feeds it — keeping the injection contract intact.

The genuinely-unknown-overlay skip sites (`core/tasks.py`, `core/signals.py`,
`core/worktree/worktree_tasks.py`) are untouched and still skip real unknown
overlays.

## Tests

- `tests/config/test_overlay_discovery.py::test_discover_active_overlay_folds_deploy_dirname_to_sole_overlay`
  — a `teatree-deploy` dir with the sole `t3-teatree` entry point resolves to
  `t3-teatree` (RED before, GREEN after).
- `tests/config/test_overlay_discovery.py::test_discover_active_overlay_dirname_kept_raw_when_multiple_overlays`
  — with >1 overlay installed the ambiguous basename is preserved (multi-overlay
  behaviour guard).
- `tests/teatree_loop/test_scanning_news_scanner.py::ScanningNewsWiringTests::test_undispatchable_deploy_dirname_never_reaches_ticket`
  — an undispatchable discovered overlay is canonicalized before any ticket is
  persisted; no `scanning-news://teatree-deploy` row is created (RED before,
  GREEN after).

Full discovery, scanning-news, provision-smoke, loop, config, and poison-pill
guard suites stay green.
