### PR TITLE
fix(merge): resolve required checks from the readable rules endpoint so a 403 protection read stops failing green PRs

### DIFF
--- a/src/teatree/backends/forge_merge_rpc.py
+++ b/src/teatree/backends/forge_merge_rpc.py
@@ -65,6 +65,82 @@ def glab_project_path(slug: str) -> str:
     return slug.replace("/", "%2F")
 
 
+def _github_rules_required_contexts(rc: int, out: str, err: str) -> set[str] | None:
+    """Required contexts from the effective-rules endpoint, or ``None`` when unreadable.
+
+    ``repos/<slug>/rules/branches/<base>`` is readable with a fine-grained PAT's
+    ``contents``/``metadata`` read and returns the effective required checks from
+    BOTH classic branch protection AND rulesets — the PAT-readable source the
+    §17.4.3 step-3 required set should prefer. Unions
+    ``parameters.required_status_checks[].context`` across every
+    ``required_status_checks`` rule.
+
+    A determinate ``set()`` (possibly empty) is returned for any readable,
+    parseable list — an empty set means the branch has no ``required_status_checks``
+    rule (no gate). ``None`` signals an INDETERMINATE read (non-zero rc, unparsable
+    body, or a non-list payload) so the caller can fall back to the legacy
+    protection endpoint before deciding whether to fail closed.
+    """
+    del err  # the caller distinguishes readable/unreadable via rc + body parseability
+    if rc != 0:
+        return None
+    try:
+        data = json.loads(out) if out.strip() else []
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, list):
+        return None
+    contexts: set[str] = set()
+    for rule in data:
+        if not isinstance(rule, dict) or rule.get("type") != "required_status_checks":
+            continue
+        params = rule.get("parameters")
+        if not isinstance(params, dict):
+            continue
+        for check in params.get("required_status_checks") or []:
+            if isinstance(check, dict) and isinstance(check.get("context"), str) and check["context"]:
+                contexts.add(check["context"])
+    return contexts
+
+
+def _github_protection_required_contexts(rc: int, out: str, err: str) -> set[str] | None:
+    """Required contexts from the legacy branch-protection endpoint, or ``None`` if unreadable.
+
+    ``None`` signals an INDETERMINATE read — a fine-grained PAT WITHOUT the
+    "Administration" permission gets HTTP 403 ("Resource not accessible by personal
+    access token" / "must have admin") on this endpoint, and a 5xx / network /
+    unparsable body is equally unreadable. On ``None`` the caller falls back to the
+    rules-endpoint result rather than failing closed on this source alone.
+
+    A determinate ``set()`` is returned for a genuine "no classic protection" 404
+    (``Branch not protected`` / ``Required status checks not enabled`` / ``Not
+    Found``); otherwise the UNION of the legacy ``contexts`` array and the newer
+    ``checks[].context`` array (GitHub returns both; either may carry a name).
+    """
+    if rc != 0:
+        body = f"{out}\n{err}".lower()
+        # ``base`` is already confirmed a real branch, so a 404 here can only mean
+        # "no protection configured" — never "no such branch". A 403 (no Admin
+        # permission), 5xx, or network error is NOT determinate → ``None``.
+        if "branch not protected" in body or "required status checks not enabled" in body or "not found" in body:
+            return set()
+        return None
+    try:
+        data = json.loads(out) if out.strip() else {}
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    contexts: set[str] = set()
+    for ctx in data.get("contexts") or []:
+        if isinstance(ctx, str) and ctx:
+            contexts.add(ctx)
+    for check in data.get("checks") or []:
+        if isinstance(check, dict) and isinstance(check.get("context"), str) and check["context"]:
+            contexts.add(check["context"])
+    return contexts
+
+
 class GhMergeRpc:
     """GitHub ``gh`` merge-RPC argv + payload parsing — raw I/O for one host."""
 
@@ -135,22 +211,30 @@ class GhMergeRpc:
         return [entry for entry in rollup if isinstance(entry, dict)]
 
     def fetch_required_status_check_contexts(self, *, slug: str, pr_id: int) -> list[RawAPIDict]:
-        """Branch-protection required-status-check contexts for the PR's base branch.
+        """Required-status-check contexts for the PR's base branch — §17.4.3 step 3.
 
-        The AUTHORITATIVE required set for §17.4.3 step 3: only a context the
-        repo's branch protection lists as a required status check may block the
-        merge. A check NOT in this set (``eval``, advisory lanes, …) never blocks
-        regardless of its conclusion.
+        The AUTHORITATIVE required set: only a context the repo requires as a status
+        check may block the merge. A check NOT in this set (``eval``, advisory lanes,
+        …) never blocks regardless of its conclusion.
 
-        Returns ``[ROLLUP_QUERY_FAILED]`` (fail CLOSED) when the base branch or
-        the ``branches/<base>/protection/required_status_checks`` endpoint cannot
-        be read — an indeterminate required set must refuse the merge, never fall
-        open. Returns ``[]`` when the base branch genuinely has no required-status-
-        check protection (the determinate "no required gate" 404 the forge raises
-        with a ``Branch not protected`` / ``Required status checks not enabled``
-        body — no gate → green). Otherwise one ``{"context": <name>}`` entry per
-        required context, the UNION of the legacy ``contexts`` array and the newer
-        ``checks[].context`` array (GitHub returns both; either may carry a name).
+        Resolved from TWO sources and unioned so a fine-grained PAT still gets a
+        determinate answer. The preferred source is the effective-rules endpoint
+        ``repos/<slug>/rules/branches/<base>``, readable with a fine-grained PAT's
+        ``contents``/``metadata`` read, which returns the effective required checks
+        from BOTH classic branch protection AND rulesets. The legacy endpoint
+        ``branches/<base>/protection/required_status_checks`` is the union fallback,
+        but a fine-grained PAT WITHOUT "Administration" gets HTTP 403 on it; a 403
+        here is treated as INDETERMINATE for this source, NOT a hard failure — the
+        rules-endpoint result stands.
+
+        Returns one ``{"context": <name>}`` entry per required context (the union of
+        the two readable sources), or ``[]`` when at least one source is readable and
+        determinately reports NO required gate (no gate → green, mergeable).
+
+        Returns ``[ROLLUP_QUERY_FAILED]`` (fail CLOSED) STRICTLY when the required
+        set is genuinely indeterminate: the base branch cannot be read, or NEITHER
+        endpoint could be read (both error non-deterministically / unparsable). A
+        real inability to determine the required set must still refuse the merge.
         """
         rc, out, _ = self._run(
             ["pr", "view", str(pr_id), "--repo", slug, "--json", "baseRefName", "--jq", ".baseRefName"],
@@ -158,28 +242,21 @@ class GhMergeRpc:
         base = out.strip()
         if rc != 0 or not base:
             return [ROLLUP_QUERY_FAILED]
-        rc, out, err = self._run(["api", f"repos/{slug}/branches/{base}/protection/required_status_checks"])
-        if rc != 0:
-            body = f"{out}\n{err}".lower()
-            # `base` was already confirmed a real branch above, so a 404 here
-            # can only mean "no protection configured" — never "no such branch".
-            if "branch not protected" in body or "required status checks not enabled" in body or "not found" in body:
-                return []
+        rules_rc, rules_out, rules_err = self._run(["api", f"repos/{slug}/rules/branches/{base}"])
+        rules_contexts = _github_rules_required_contexts(rules_rc, rules_out, rules_err)
+        prot_rc, prot_out, prot_err = self._run(
+            ["api", f"repos/{slug}/branches/{base}/protection/required_status_checks"],
+        )
+        protection_contexts = _github_protection_required_contexts(prot_rc, prot_out, prot_err)
+        determinate = [contexts for contexts in (rules_contexts, protection_contexts) if contexts is not None]
+        if not determinate:
+            # Neither the rules endpoint nor the legacy protection endpoint could be
+            # read — the required set is genuinely indeterminate → fail CLOSED.
             return [ROLLUP_QUERY_FAILED]
-        try:
-            data = json.loads(out) if out.strip() else {}
-        except json.JSONDecodeError:
-            return [ROLLUP_QUERY_FAILED]
-        if not isinstance(data, dict):
-            return [ROLLUP_QUERY_FAILED]
-        contexts: set[str] = set()
-        for ctx in data.get("contexts") or []:
-            if isinstance(ctx, str) and ctx:
-                contexts.add(ctx)
-        for check in data.get("checks") or []:
-            if isinstance(check, dict) and isinstance(check.get("context"), str) and check["context"]:
-                contexts.add(check["context"])
-        return [{"context": ctx} for ctx in sorted(contexts)]
+        union: set[str] = set()
+        for contexts in determinate:
+            union |= contexts
+        return [{"context": ctx} for ctx in sorted(union)]
 
     def fetch_pr_changed_paths(self, *, slug: str, pr_id: int) -> list[str]:
         rc, out, _ = self._run(

--- a/tests/teatree_core/merge/test_ci_rollup.py
+++ b/tests/teatree_core/merge/test_ci_rollup.py
@@ -42,20 +42,51 @@ def _rollup_names(rollup: list[dict[str, object]]) -> list[str]:
     return names
 
 
+def _rules_payload(*contexts: str) -> str:
+    """A ``repos/<slug>/rules/branches/<base>`` body with one ``required_status_checks`` rule.
+
+    Mirrors the effective-rules endpoint the fine-grained PAT CAN read: a JSON list
+    of rules, each with a ``type``; the ``required_status_checks`` rule carries the
+    required contexts under ``parameters.required_status_checks[].context``.
+    """
+    return json.dumps(
+        [
+            {"type": "pull_request", "parameters": {}},
+            {
+                "type": "required_status_checks",
+                "parameters": {
+                    "required_status_checks": [{"context": ctx} for ctx in contexts],
+                    "strict_required_status_checks_policy": True,
+                },
+            },
+        ],
+    )
+
+
+# The default rules-endpoint response for the legacy stubs: an INDETERMINATE read
+# (5xx) so a failing protection endpoint reproduces the pre-fix "both sources
+# unreadable → fail closed" behaviour instead of being rescued by a readable
+# rules endpoint. Tests that exercise the rules-endpoint rescue script it explicitly.
+_RULES_UNREADABLE: tuple[int, str, str] = (1, "", "HTTP 500: server error")
+
+
 def _gh_stub(
     rollup: list[dict[str, object]],
     *,
     required: list[str] | None = None,
     protection_rc: int = 0,
     protection_body: str | None = None,
+    rules: tuple[int, str, str] = _RULES_UNREADABLE,
 ) -> Callable[[list[str]], tuple[int, str, str]]:
-    """A ``gh`` runner answering the statusCheckRollup AND branch-protection queries.
+    """A ``gh`` runner answering the statusCheckRollup, rules, AND branch-protection queries.
 
     *required* is the branch-protection ``required_status_checks`` context set the
     repo reports. When ``None`` it defaults to every name present in *rollup* — so
     the dedupe tests, which treat all checks as required, keep their semantics.
     *protection_rc* / *protection_body* simulate a failed (or "no protection")
-    branch-protection fetch — the fail-closed / no-gate paths.
+    branch-protection fetch — the fail-closed / no-gate paths. *rules* scripts the
+    PAT-readable effective-rules endpoint; it defaults to an indeterminate read so a
+    failing protection endpoint alone still fails closed.
     """
     contexts = _rollup_names(rollup) if required is None else required
 
@@ -65,6 +96,8 @@ def _gh_stub(
             return (0, json.dumps(rollup), "")
         if "baseRefName" in joined:
             return (0, "main", "")
+        if "rules/branches" in joined:
+            return rules
         if "required_status_checks" in joined:
             if protection_rc != 0:
                 return (protection_rc, "", protection_body or "api error")
@@ -80,8 +113,15 @@ def _verdict(
     required: list[str] | None = None,
     protection_rc: int = 0,
     protection_body: str | None = None,
+    rules: tuple[int, str, str] = _RULES_UNREADABLE,
 ) -> str:
-    stub = _gh_stub(rollup, required=required, protection_rc=protection_rc, protection_body=protection_body)
+    stub = _gh_stub(
+        rollup,
+        required=required,
+        protection_rc=protection_rc,
+        protection_body=protection_body,
+        rules=rules,
+    )
     with patch("teatree.backends.forge_merge_rpc.gh_runner", return_value=stub):
         return CodeHostQuery.for_ref(PrRef(slug=_SLUG, pr_id=_PR_ID)).required_checks_status()
 
@@ -198,6 +238,69 @@ class TestRequiredContextsGate:
         # means no required-status-check gate exists, so the merge is allowed.
         rollup = [_failed("eval")]
         assert _verdict(rollup, protection_rc=1, protection_body="HTTP 404: Branch not protected") == "green"
+
+
+class TestRulesEndpointRequiredSetResolution:
+    """The §17.4.3-step-3 required set resolves from the PAT-readable rules endpoint.
+
+    A fine-grained PAT WITHOUT "Administration" gets HTTP 403 on the legacy
+    ``branches/<base>/protection/required_status_checks`` endpoint, but CAN read
+    ``repos/<slug>/rules/branches/<base>``. The verdict must resolve the required
+    set from the readable rules endpoint so an all-green PR merges — while a
+    genuinely indeterminate required set (NEITHER endpoint readable) still fails
+    closed (souliane/teatree merge-gate 403 bug).
+    """
+
+    _PAT_403 = "HTTP 403: Resource not accessible by personal access token"
+
+    def test_403_protection_rescued_by_rules_all_green(self) -> None:
+        # Protection 403s (no Admin); the rules endpoint IS readable and lists the
+        # required contexts. Every required context is green → the merge is ALLOWED.
+        rollup = [_green("lint"), _green("test (3.13)"), _failed("eval")]
+        verdict = _verdict(
+            rollup,
+            protection_rc=1,
+            protection_body=self._PAT_403,
+            rules=(0, _rules_payload("lint", "test (3.13)"), ""),
+        )
+        assert verdict == "green"
+
+    def test_403_protection_rescued_by_rules_failed_required_still_blocks(self) -> None:
+        # The real-failure path must not regress: protection 403, rules readable and
+        # requiring ``test (3.13)``, whose live check is FAILURE → still REFUSED.
+        rollup = [_green("lint"), _failed("test (3.13)")]
+        verdict = _verdict(
+            rollup,
+            protection_rc=1,
+            protection_body=self._PAT_403,
+            rules=(0, _rules_payload("lint", "test (3.13)"), ""),
+        )
+        assert verdict == "failed"
+
+    def test_403_protection_and_rules_have_no_required_rule_is_green(self) -> None:
+        # Protection 403, and the readable rules endpoint has NO required_status_checks
+        # rule → determinate "no gate" → green (mergeable), NOT fail-closed.
+        rollup = [_failed("eval")]
+        verdict = _verdict(
+            rollup,
+            protection_rc=1,
+            protection_body=self._PAT_403,
+            rules=(0, json.dumps([{"type": "pull_request", "parameters": {}}]), ""),
+        )
+        assert verdict == "green"
+
+    def test_both_endpoints_unreadable_fails_closed(self) -> None:
+        # The fail-closed invariant: NEITHER the rules endpoint NOR the protection
+        # endpoint could be read (both 5xx / non-deterministic) → the required set
+        # is genuinely indeterminate → the merge is REFUSED.
+        rollup = _all_required_green()
+        verdict = _verdict(
+            rollup,
+            protection_rc=1,
+            protection_body=self._PAT_403,
+            rules=(1, "", "HTTP 500: server error"),
+        )
+        assert verdict == "failed"
 
 
 class TestDedupeNewestPerName:
@@ -413,13 +516,20 @@ def _contexts_runner(
     base: str = "main",
     base_rc: int = 0,
     protection: tuple[int, str, str],
+    rules: tuple[int, str, str] = _RULES_UNREADABLE,
 ) -> Callable[[list[str]], tuple[int, str, str]]:
-    """A ``gh`` runner scripting the base-branch then branch-protection calls."""
+    """A ``gh`` runner scripting the base-branch, rules, then branch-protection calls.
+
+    *rules* defaults to an indeterminate read so a protection-only failure still
+    fails closed; the rules-endpoint rescue paths script it explicitly.
+    """
 
     def run(argv: list[str]) -> tuple[int, str, str]:
         joined = " ".join(argv)
         if "baseRefName" in joined:
             return (base_rc, base, "")
+        if "rules/branches" in joined:
+            return rules
         if "required_status_checks" in joined:
             return protection
         return (0, "", "")
@@ -558,3 +668,72 @@ class TestRequiredStatusCheckContextsTransport:
         # rc==0 with an empty body → no required-status-check rule → no gate.
         result = self._contexts(_contexts_runner(protection=(0, "", "")))
         assert result == []
+
+    _PAT_403 = "HTTP 403: Resource not accessible by personal access token"
+
+    def test_403_protection_rescued_by_rules_endpoint_contexts(self) -> None:
+        # The fine-grained-PAT bug: protection 403s, but the rules endpoint IS
+        # readable and lists the required contexts — the required set resolves from
+        # it (NOT ROLLUP_QUERY_FAILED).
+        result = self._contexts(
+            _contexts_runner(
+                protection=(1, "", self._PAT_403),
+                rules=(0, _rules_payload("lint", "sbom"), ""),
+            ),
+        )
+        assert sorted(str(entry["context"]) for entry in result) == ["lint", "sbom"]
+
+    def test_403_protection_and_rules_no_required_rule_is_empty_no_gate(self) -> None:
+        # Protection 403, and the readable rules endpoint has NO required_status_checks
+        # rule → determinate "no gate" → empty required set (green), not fail-closed.
+        result = self._contexts(
+            _contexts_runner(
+                protection=(1, "", self._PAT_403),
+                rules=(0, json.dumps([{"type": "pull_request", "parameters": {}}]), ""),
+            ),
+        )
+        assert result == []
+
+    def test_protection_404_and_no_rules_is_empty_no_gate(self) -> None:
+        # Protection determinately unprotected (404) AND the rules endpoint readable
+        # with no required rule → determinate no gate → empty required set.
+        result = self._contexts(
+            _contexts_runner(
+                protection=(1, "", "HTTP 404: Branch not protected"),
+                rules=(0, "[]", ""),
+            ),
+        )
+        assert result == []
+
+    def test_rules_and_protection_contexts_are_unioned(self) -> None:
+        # Both sources readable — the required set is the UNION (each source may
+        # carry a name the other omits: classic protection vs a ruleset).
+        result = self._contexts(
+            _contexts_runner(
+                protection=(0, json.dumps({"contexts": ["lint"]}), ""),
+                rules=(0, _rules_payload("sbom", "test (3.13)"), ""),
+            ),
+        )
+        assert sorted(str(entry["context"]) for entry in result) == ["lint", "sbom", "test (3.13)"]
+
+    def test_both_endpoints_unreadable_fails_closed(self) -> None:
+        # The fail-closed invariant: NEITHER endpoint readable (both 5xx / 403 with
+        # no determinate no-gate body) → genuinely indeterminate → refuse.
+        result = self._contexts(
+            _contexts_runner(
+                protection=(1, "", self._PAT_403),
+                rules=(1, "", "HTTP 500: server error"),
+            ),
+        )
+        assert rollup_query_failed(result)
+
+    def test_unparseable_rules_falls_back_to_protection(self) -> None:
+        # The rules endpoint returns garbage (indeterminate for that source), but
+        # protection is readable → the required set still resolves from protection.
+        result = self._contexts(
+            _contexts_runner(
+                protection=(0, json.dumps({"contexts": ["lint"]}), ""),
+                rules=(0, "{not json", ""),
+            ),
+        )
+        assert sorted(str(entry["context"]) for entry in result) == ["lint"]


### PR DESCRIPTION
## The bug (merge gate reads GREEN PRs as required-checks "failed" under a fine-grained PAT)

`fetch_required_status_check_contexts` resolves the authoritative required-status-check set for the §17.4.3 step-3 merge precondition by calling `gh api repos/<slug>/branches/<base>/protection/required_status_checks`.

A fine-grained PAT **without the "Administration" permission** gets **HTTP 403** ("Resource not accessible by personal access token") on that endpoint. The old code mapped only "branch not protected" / "required status checks not enabled" / "not found" bodies to `[]` (determinate, no gate -> green); a 403 matched none of those, so it returned `[ROLLUP_QUERY_FAILED]` (fail-closed). Downstream that renders as required-checks = "failed" and **refuses every merge, even when all live checks are green**.

Verified live: the protection endpoint 403s, but `gh api repos/<slug>/rules/branches/<base>` (the effective-rules endpoint) **is** readable with the same PAT.

## The fix

The required set now resolves from **two sources, unioned**:

1. **`repos/<slug>/rules/branches/<base>`** (the effective-rules endpoint) - readable with a fine-grained PAT's contents/metadata read. It returns the effective required checks from **both** classic branch protection and rulesets. Required contexts are unioned across every `required_status_checks` rule's `parameters.required_status_checks[].context`. This is the preferred source.
2. **The legacy protection endpoint** is kept as a union/fallback source, but a **403** ("resource not accessible" / "must have admin") is now treated as **indeterminate for that source only** - the rules-endpoint result stands instead of failing closed.

Each source resolves to `set[str]` (determinate, possibly empty = no gate) or `None` (indeterminate/unreadable). The union of all determinate sources is returned; `[]` when at least one source determinately reports no gate (green, mergeable).

## The preserved fail-closed invariant

`[ROLLUP_QUERY_FAILED]` (fail closed) is still returned - strictly - when the required set is **genuinely indeterminate**: the base branch cannot be read, or **neither** endpoint could be read (both error non-deterministically / unparseable). A real inability to determine the required set still refuses the merge. The downstream fail-closed evaluation is unchanged; only the required-set *resolution* was fixed.

## Tests

New coverage in `tests/teatree_core/merge/test_ci_rollup.py` (both transport-level and verdict-level), observed RED before the fix and GREEN after:

- 403 protection + rules endpoint supplies contexts X,Y -> `{X,Y}` (not `ROLLUP_QUERY_FAILED`).
- 403 protection + rules endpoint has no `required_status_checks` rule -> `[]` (green).
- protection 404 (not protected) + rules readable/no rule -> `[]`.
- both endpoints unreadable (403 + 5xx) -> `[ROLLUP_QUERY_FAILED]` (still fail-closed - invariant pinned).
- determinate required set + a FAILED live required check -> still blocks (real-failure path not regressed).
- both sources readable -> union; unparseable rules falls back to protection.

Only the unstoppable external (the `gh` subprocess) is mocked; the resolution/classification under test is real.
