### PR TITLE
fix(issue-implementer): dispatch an orchestrator task when an auto-implement issue is claimed

### DIFF
--- a/src/teatree/loop/scanners/issue_implementer.py
+++ b/src/teatree/loop/scanners/issue_implementer.py
@@ -142,6 +142,17 @@ class IssueImplementerScanner:
                             "url": url,
                             "raw": issue,
                             "overlay": self.overlay_name,
+                            # A claim IS an unconditional maker-side kickoff: the
+                            # triple gate (_issue_implementer_scanner_for) already
+                            # enforced enablement + concurrency budget, and the
+                            # TOCTOU-safe marker claim just committed this issue. The
+                            # shared t3:orchestrator persistence handler
+                            # (_handle_orchestrator) creates the Ticket + coding Task
+                            # only when auto_start is True, so a claimed issue that
+                            # omitted this flag dispatched an agent action that was
+                            # then silently dropped at persist time — the claim
+                            # stranded with no task (#3100/#3213).
+                            "auto_start": True,
                         },
                     )
                 )

--- a/tests/teatree_loop/test_issue_implementer_wiring.py
+++ b/tests/teatree_loop/test_issue_implementer_wiring.py
@@ -19,9 +19,11 @@ from django.test import TestCase
 from teatree.config import UserSettings
 from teatree.core.backend_factory import OverlayBackends
 from teatree.core.backend_protocols import CodeHostBackend
+from teatree.core.models import Task, Ticket
 from teatree.loop.dispatch import dispatch
 from teatree.loop.domain_jobs import jobs_for_domain
 from teatree.loop.job_identity import Domain
+from teatree.loop.persistence import persist_agent_actions
 from teatree.loop.scanner_factories import _issue_implementer_scanner_for
 from teatree.loop.scanners.issue_implementer import IssueImplementerScanner
 from teatree.loops.issue_implementer.loop import MINI_LOOP
@@ -229,3 +231,51 @@ class IssueImplementerMiniLoopTests(TestCase):
         agent_zones = [a.zone for a in actions if a.kind == "agent"]
         assert agent_zones == ["t3:orchestrator"]
         assert any(a.kind == "statusline" and a.zone == "action_needed" for a in actions)
+
+    def test_claimed_issue_persists_orchestrator_coding_task(self) -> None:
+        """A claimed auto-implement issue must produce the orchestrator dispatch — a real Ticket + coding Task.
+
+        Regression (#3100/#3213): the scanner claimed the issue (an
+        ``ImplementedIssueMarker`` row was written) and ``dispatch`` emitted the
+        ``t3:orchestrator`` agent action, but the emitted payload omitted
+        ``auto_start`` — so the shared ``_handle_orchestrator`` persistence handler
+        (which returns ``None`` unless ``auto_start is True``) silently dropped it.
+        No ``Ticket``/``Task`` was ever created and the claim stranded. This asserts
+        the WHOLE path scan → dispatch → persist yields the coding Task.
+        """
+        url = "https://github.com/souliane/teatree/issues/100"
+        host = _labelled_host(url)
+        with patch(
+            _PATCH_TARGET,
+            return_value=_settings(issue_implementer_enabled=True, issue_implementer_label="auto-implement"),
+        ):
+            jobs = MINI_LOOP.build_jobs(backends=[_backend_with_host(host)])
+        signals = [signal for job in jobs for signal in job.scanner.scan()]
+        claimed = [s for s in signals if s.kind == "issue_implementer.claimed"]
+
+        created = persist_agent_actions(dispatch(claimed))
+
+        assert len(created) == 1
+        task = created[0]
+        assert task.phase == "coding"
+        assert task.ticket.role == Ticket.Role.AUTHOR
+        assert task.ticket.issue_url == url
+
+    def test_claimed_issue_dispatch_never_double_dispatches(self) -> None:
+        """Re-persisting the same claimed-issue dispatch is a no-op (idempotency)."""
+        url = "https://github.com/souliane/teatree/issues/100"
+        host = _labelled_host(url)
+        with patch(
+            _PATCH_TARGET,
+            return_value=_settings(issue_implementer_enabled=True, issue_implementer_label="auto-implement"),
+        ):
+            jobs = MINI_LOOP.build_jobs(backends=[_backend_with_host(host)])
+        claimed = [s for job in jobs for s in job.scanner.scan() if s.kind == "issue_implementer.claimed"]
+        actions = dispatch(claimed)
+
+        first = persist_agent_actions(actions)
+        second = persist_agent_actions(actions)
+
+        assert len(first) == 1
+        assert second == []
+        assert Task.objects.filter(ticket__issue_url=url, phase="coding").count() == 1


### PR DESCRIPTION
## Root cause (confirmed with code evidence)

A claimed `auto-implement` issue creates an `ImplementedIssueMarker` but never produces a dispatched orchestrator Task/Ticket. The claim is stranded.

The signal DOES route correctly and DOES produce an `agent` dispatch action — the failure is at **persist time**, where the shared orchestrator handler drops it:

- `IssueImplementerScanner.scan()` emits `issue_implementer.claimed` with payload `{"url", "raw", "overlay"}` — **no `auto_start`** (`src/teatree/loop/scanners/issue_implementer.py:137-147`, pre-fix).
- Dispatch routes it via `AGENT_BY_KIND["issue_implementer.claimed"] -> "t3:orchestrator"` (`src/teatree/loop/dispatch_tables.py:54`) and emits `DispatchAction(kind="agent", zone="t3:orchestrator", payload=signal.payload)` — plus the statusline mirror (which is why the operator SEES the claim).
- At persist time the shared handler `_handle_orchestrator` returns `None` unless `auto_start is True`:

  ```python
  # src/teatree/loop/persistence.py:219-221
  def _handle_orchestrator(action):
      payload = action.payload
      if payload.get("auto_start") is not True:
          return None
  ```

So the agent action is **silently dropped** — no `Ticket`, no `Task`, no `t3:orchestrator` execution. And because `ImplementedIssueMarker` was already written during scan (`_claim`), the per-issue idempotency suppresses any retry: the claim strands (issues #3100, #3213).

### Why `codex:review` and `assigned_issue.ready` work but this did not
The sibling that shares this exact handler honors the documented contract: `AssignedIssuesScanner` sets `"auto_start": self.auto_start` in its payload (`src/teatree/loop/scanners/assigned_issues.py:128`). `_handle_orchestrator`'s own docstring states it "Only fires for `assigned_issue.ready` / `issue_implementer.claimed` signals that carry `auto_start=True`". The issue-implementer scanner simply never set it — a payload-contract violation, not a gate/trust/session problem. (Candidates (a) DB-loop drops signals, (b) a dispatch gate, and (d) a missing executor were all ruled out — dispatch and persistence run on the normal `loops_tick -> run_tick -> act_phase -> persist_agent_actions` path, and the reviewer/codex zones prove that path creates tasks.)

## The fix

Add `"auto_start": True` to the emitted `issue_implementer.claimed` payload (`src/teatree/loop/scanners/issue_implementer.py`). A claim IS an unconditional maker-side kickoff — the triple gate (`_issue_implementer_scanner_for`: enablement + concurrency budget) and the TOCTOU-safe marker claim have already committed the issue by the time the signal is emitted, so it must auto-start.

Idempotency and gates are preserved: `_handle_orchestrator` still `get_or_create`s on `issue_url`, checks `_has_open_task(phase="coding")` and `ticket.state == NOT_STARTED`, so re-emission never double-dispatches; the maker/checker boundary is untouched (no MergeClear, no new merge authority).

## Tests (`tests/teatree_loop/test_issue_implementer_wiring.py`)

- `test_claimed_issue_persists_orchestrator_coding_task` — the whole path scan -> dispatch -> **persist** yields an author Ticket + coding Task. RED before (persisted 0), GREEN after.
- `test_claimed_issue_dispatch_never_double_dispatches` — re-persisting the same claimed dispatch is a no-op; exactly one coding Task exists.

The pre-existing `test_enabled_loop_claims_and_dispatches_to_orchestrator` only asserted the `dispatch()` agent action — it stopped one step short of persistence, which is why the bug slipped through.

## Note on the two already-stranded issues
#3100 and #3213 already have `ImplementedIssueMarker` rows, so the scanner will not re-claim them; this fix repairs the path going forward. Recovering those two specific stranded claims needs a one-off marker clear (out of scope for this fix).
