### PR TITLE
fix(worktree): idempotent provisioning and psql-guarded clean-all so the factory stops stranding worktrees

### DIFF
--- a/src/teatree/core/management/commands/_workspace/cleanup.py
+++ b/src/teatree/core/management/commands/_workspace/cleanup.py
@@ -5,6 +5,8 @@ stays under the module-health LOC cap. Functions are kept private (``_``
 prefix) because the only public surface is the ``clean-all`` subcommand.
 """
 
+import logging
+import shutil
 from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -24,6 +26,9 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from teatree.core.worktree.reconcile import Drift
+
+
+logger = logging.getLogger(__name__)
 
 
 # Regenerable artifacts a clean-working-tree probe must ignore: provisioning
@@ -338,8 +343,53 @@ def prune_branches(repo: str) -> list[str]:
     return cleaned
 
 
+# The Postgres client binaries the orphan-DB prune shells out to. A deployment
+# whose worktree databases are NOT Postgres (a SQLite-only box) has neither, and
+# ``subprocess`` answers a missing binary with ``FileNotFoundError`` — NOT a
+# non-zero return code — which is precisely why the prune's ``returncode != 0``
+# check below could not absorb it.
+_PG_CLIENT_BINARIES = ("psql", "dropdb")
+
+
+def _postgres_client_installed() -> bool:
+    """Whether this deployment can talk to Postgres at all — the orphan-DB prune's gate.
+
+    The ``wt_*`` databases the prune targets exist only where the worktree DB
+    backend IS Postgres; such a deployment necessarily has the Postgres client on
+    PATH, because the prune's own ``psql`` listing and ``dropdb`` removal are how
+    those databases are managed. Their ABSENCE is therefore the signal that this
+    box provisions no Postgres worktree databases and there is nothing to prune.
+    Probing PATH (rather than shelling the binary and catching the crash) keeps
+    the skip cheap and silent.
+    """
+    missing = [binary for binary in _PG_CLIENT_BINARIES if shutil.which(binary) is None]
+    if not missing:
+        return True
+    logger.debug(
+        "Skipping the Postgres orphan-database prune: %s not on PATH — this deployment provisions no "
+        "Postgres worktree databases, so there are no orphan wt_* databases to drop. Every other "
+        "clean-all pass is unaffected.",
+        ", ".join(missing),
+    )
+    return False
+
+
 def drop_orphan_databases() -> list[str]:
-    """Drop Postgres databases matching wt_* that don't belong to any worktree."""
+    """Drop Postgres databases matching wt_* that don't belong to any worktree.
+
+    A no-op — never a crash — on a deployment with no Postgres client
+    (souliane/teatree#3234). This is the FIRST destructive pass ``clean-all`` runs
+    after the done-worktree reaper, and it used to shell ``psql`` unconditionally.
+    On a SQLite-only box that raised ``FileNotFoundError``, which
+    :func:`run_allowed_to_fail` does not convert into a non-zero exit, so the
+    exception escaped and aborted the ENTIRE reaper: merged worktrees, stale
+    branches, orphan stashes and dangling registrations were all left behind. A
+    missing Postgres client must never abort clean-all — the pass is skipped with
+    a debug line and the remaining passes run to completion.
+    """
+    if not _postgres_client_installed():
+        return []
+
     from teatree.utils.db import pg_env, pg_host, pg_user  # noqa: PLC0415 — deferred: keeps command import light
 
     result = run_allowed_to_fail(

--- a/src/teatree/core/runners/provision.py
+++ b/src/teatree/core/runners/provision.py
@@ -1,5 +1,7 @@
 import logging
+import shutil
 from contextlib import suppress
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -8,9 +10,10 @@ from teatree.core.models import Ticket, Worktree
 from teatree.core.public_identity import is_public_github_remote, set_local_noreply_identity
 from teatree.core.runners.base import RunnerBase, RunnerResult
 from teatree.core.worktree.clone_paths import find_clone_path
-from teatree.core.worktree.worktree_paths import ticket_dir_for
+from teatree.core.worktree.worktree_paths import paths_match, ticket_dir_for
 from teatree.utils import git
 from teatree.utils.git_guard import guard_repo_remote_slug, is_github_slug
+from teatree.utils.run import CommandFailedError
 
 if TYPE_CHECKING:
     from teatree.core.models.types import TicketExtra
@@ -34,6 +37,164 @@ def _clone_dir_from_worktree(worktree_path: str) -> Path | None:
     if not common_path.is_absolute():
         common_path = (Path(worktree_path) / common_path).resolve()
     return common_path.parent
+
+
+@dataclass(frozen=True, slots=True)
+class _RegisteredWorktree:
+    """One entry from ``git worktree list --porcelain`` — what git believes exists."""
+
+    path: str
+    branch: str
+
+    @property
+    def on_disk(self) -> bool:
+        return Path(self.path).is_dir()
+
+
+def _registered_worktrees(clone: str) -> list[_RegisteredWorktree]:
+    """Every worktree git has REGISTERED for *clone*, including the main checkout.
+
+    Git's registration — not the filesystem — is what refuses a ``git worktree
+    add``: a branch is "already checked out" while any registration claims it, even
+    one whose directory was deleted. Reading the registrations is therefore the only
+    way to see the leftover that blocks provisioning. A detached entry has no
+    ``branch`` line and yields an empty ``branch``.
+    """
+    entries: list[_RegisteredWorktree] = []
+    path = ""
+    branch = ""
+    for line in git.run(repo=clone, args=["worktree", "list", "--porcelain"]).splitlines():
+        if line.startswith("worktree "):
+            if path:
+                entries.append(_RegisteredWorktree(path=path, branch=branch))
+            path, branch = line.removeprefix("worktree "), ""
+        elif line.startswith("branch refs/heads/"):
+            branch = line.removeprefix("branch refs/heads/")
+    if path:
+        entries.append(_RegisteredWorktree(path=path, branch=branch))
+    return entries
+
+
+def _holds_unsalvageable_work(wt_path: str) -> bool:
+    """Whether tearing down *wt_path* would destroy the only copy of some work.
+
+    The #706 data-loss guard, mirroring
+    :func:`teatree.core.worktree.reconcile._unpushed_work_for_worktree` and the
+    ``recover`` sweeps: a worktree is protected when it holds uncommitted changes,
+    or when its HEAD carries commits reachable from NO remote. ``--not --remotes``
+    is empty as soon as the tip was pushed anywhere, so a pushed-but-unmerged branch
+    is correctly reapable while a genuinely-local tip is not.
+
+    **Fails closed.** An inconclusive probe (``CommandFailedError`` — corrupt repo,
+    dangling ref, no commits yet) is treated as "carries work": for a destructive
+    decision, "we could not prove this is safe to delete" must protect the worktree,
+    never sacrifice it.
+    """
+    if not Path(wt_path).is_dir():
+        return False
+    if git.status_porcelain(wt_path).strip():
+        return True
+    try:
+        return bool(git.commits_absent_from_all_remotes(wt_path, "HEAD"))
+    except CommandFailedError:
+        return True
+
+
+def _tear_down_worktree(clone: str, wt_path: str, branch: str) -> None:
+    """Force-remove a work-free worktree, prune the registration, drop a dangling branch.
+
+    Only ever reached once the checkout has been PROVEN free of unpushed work (see
+    :func:`_holds_unsalvageable_work`) or its directory is already gone, so nothing
+    recoverable is lost. ``git worktree prune`` is what actually frees the branch —
+    a registration whose dir was deleted still makes git refuse the branch as
+    "already checked out".
+
+    The branch ref is dropped with ``git branch -d`` (never ``-D``): git's own
+    unmerged-branch guard is the unmerged-and-unreferenced check, so a branch still
+    carrying commits is KEPT and the caller's recreate simply reuses it via the
+    existing no-``-b`` retry. Deleting it when it IS merged is what lets a retry
+    branch cleanly off the current default instead of resurrecting a stale tip.
+    """
+    if Path(wt_path).is_dir():
+        git.worktree_remove(clone, wt_path)
+    git.run(repo=clone, args=["worktree", "prune"])
+    if branch:
+        git.check(repo=clone, args=["branch", "-d", branch])
+
+
+def _reconcile_leftover_worktree(clone: Path, wt_path: Path, branch: str) -> str | None:
+    """Make the scope's worktree slot creatable, or ADOPT what is already there (#3234).
+
+    Provisioning must be idempotent. A prior attempt that failed DOWNSTREAM of
+    ``git worktree add`` leaves the worktree and/or the branch behind; ``git worktree
+    add`` then refuses the path (it exists) AND the branch (it is "already checked
+    out"), so provision failed with "failed to create worktrees for: <repo>" and the
+    ticket stayed at ``started`` forever — every retry hitting the identical wall.
+
+    Returns the path to ADOPT (provisioning is then a no-op over an existing
+    checkout), or ``None`` when the slot is now clear for ``git worktree add``:
+
+    - a healthy registration at the expected path on the CORRECT branch → adopt it;
+    - a registration whose directory is GONE → stale git admin; pruned, then recreate;
+    - a leftover holding the branch at ANOTHER path, or one sitting at the expected
+        path on the WRONG branch → torn down (guarded) and recreated;
+    - a leftover carrying work absent from every remote → NEVER destroyed: adopted in
+        place when it is on the scope's branch, and otherwise left alone so the caller
+        fails loudly rather than silently deleting the only copy of that work.
+    """
+    clone_str, wt_str = str(clone), str(wt_path)
+
+    # A registration whose dir was deleted still holds its branch hostage. Prune
+    # first so the survey below sees only registrations git will really enforce.
+    if any(not entry.on_disk for entry in _registered_worktrees(clone_str)):
+        git.run(repo=clone_str, args=["worktree", "prune"])
+
+    leftovers = [entry for entry in _registered_worktrees(clone_str) if not paths_match(entry.path, clone_str)]
+    at_path = next((entry for entry in leftovers if paths_match(entry.path, wt_str)), None)
+    on_branch = next((entry for entry in leftovers if entry.branch == branch), None)
+
+    if at_path is not None and at_path.branch == branch:
+        logger.info("Adopting the existing worktree for %s at %s (idempotent re-provision)", branch, wt_str)
+        return wt_str
+
+    for leftover in (at_path, on_branch):
+        if leftover is None:
+            continue
+        if _holds_unsalvageable_work(leftover.path):
+            if leftover.branch == branch:
+                logger.warning(
+                    "Leftover worktree for %s at %s carries work that exists on no remote — adopting it "
+                    "in place instead of recreating at %s. Push or salvage it to move the worktree.",
+                    branch,
+                    leftover.path,
+                    wt_str,
+                )
+                return leftover.path
+            logger.error(
+                "Cannot provision %s at %s: a worktree on branch %s is in the way and carries work that "
+                "exists on no remote. Refusing to destroy it — push or salvage that work, then retry.",
+                branch,
+                wt_str,
+                leftover.branch,
+            )
+            return None
+        logger.warning(
+            "Cleaning up a broken leftover worktree at %s (branch %s) before provisioning %s at %s",
+            leftover.path,
+            leftover.branch or "(detached)",
+            branch,
+            wt_str,
+        )
+        _tear_down_worktree(clone_str, leftover.path, leftover.branch)
+
+    # A directory git does not know about — a prior ``git worktree add`` that died
+    # mid-checkout — still blocks the add. It holds no git history (git has no
+    # registration for it), so removing it cannot lose committed work.
+    if wt_path.is_dir():
+        logger.warning("Removing a partial non-worktree directory left at %s before provisioning", wt_str)
+        shutil.rmtree(wt_path, ignore_errors=True)
+
+    return None
 
 
 class WorktreeProvisioner(RunnerBase):
@@ -225,8 +386,13 @@ class WorktreeProvisioner(RunnerBase):
             guard_repo_remote_slug(str(repo_path), repo_name)
 
         wt_path = ticket_dir / Path(repo_name).name
-        if wt_path.exists():
-            return str(wt_path), repo_path
+
+        # #3234: reconcile whatever a prior failed attempt left behind BEFORE adding.
+        # A leftover worktree/branch makes ``git worktree add`` refuse both the path
+        # and the branch, which stranded the ticket at ``started`` forever.
+        adopted = _reconcile_leftover_worktree(repo_path, wt_path, branch)
+        if adopted is not None:
+            return adopted, repo_path
 
         git.pull_ff_only(str(repo_path))
 
@@ -237,6 +403,33 @@ class WorktreeProvisioner(RunnerBase):
             logger.warning("Failed to create worktree for %s at %s", repo_name, wt_path)
             return None
 
+        try:
+            WorktreeProvisioner._finalize(repo_path, wt_path)
+        except Exception:
+            # #3234: a step that fails AFTER the worktree exists must not strand it —
+            # the leftover is exactly what refuses the next ``git worktree add``. The
+            # checkout was created moments ago and carries no work, so tearing it down
+            # is free and leaves the retry a clean slate. Fail the provision loudly:
+            # a half-provisioned worktree is not a usable one.
+            logger.exception(
+                "Provision step failed after creating the worktree for %s at %s — tearing it down so the "
+                "retry starts clean (#3234).",
+                repo_name,
+                wt_path,
+            )
+            _tear_down_worktree(str(repo_path), str(wt_path), branch)
+            return None
+
+        return str(wt_path), repo_path
+
+    @staticmethod
+    def _finalize(repo_path: Path, wt_path: Path) -> None:
+        """The post-``worktree add`` steps. Raising here tears the new worktree back down.
+
+        Kept separate from :meth:`_create` so every step that runs AFTER the checkout
+        exists sits behind one rollback boundary — a new step cannot be added without
+        inheriting the teardown-on-failure contract (#3234).
+        """
         pv = repo_path / ".python-version"
         pv_dest = wt_path / ".python-version"
         if pv.is_file() and not pv_dest.exists():
@@ -251,21 +444,11 @@ class WorktreeProvisioner(RunnerBase):
         # host-stripped slug — ``is_public_github_remote`` must see the
         # host to refuse a non-github (e.g. gitlab) remote whose bare
         # ``owner/repo`` would otherwise be resolved against github.com.
+        #
+        # #3234: a failure here now ROLLS THE WORKTREE BACK rather than logging and
+        # carrying on. The old fail-open left a worktree with the inherited identity
+        # in place (the #755 lesson said "surface it loudly"), but a surfaced warning
+        # on a worktree that still gets committed from is the same leak by a slower
+        # route — and the stranded checkout then blocked its own re-provision.
         if is_public_github_remote(git.remote_url(str(repo_path))):
-            try:
-                set_local_noreply_identity(str(wt_path))
-            except Exception:
-                # Do NOT silently swallow — if this fails the worktree
-                # keeps the inherited identity and the condition recurs
-                # invisibly (the #755 fail-open lesson). Surface it
-                # loudly; the worktree is still usable but this needs
-                # action, not a soft warning.
-                logger.exception(
-                    "Failed to set the configured noreply git identity on public "
-                    "souliane worktree %s — commits here may use the inherited "
-                    "identity (#762). Set the clone-local git identity before "
-                    "committing.",
-                    wt_path,
-                )
-
-        return str(wt_path), repo_path
+            set_local_noreply_identity(str(wt_path))

--- a/tests/teatree_core/management_commands/test_workspace.py
+++ b/tests/teatree_core/management_commands/test_workspace.py
@@ -1744,6 +1744,44 @@ class TestWorkspaceCleanAll(TestCase):
 
     @_no_prune
     @_no_stash
+    @_no_orphan_isolated_roots
+    @_no_orphan_docker
+    @_no_dslr_prune
+    @_no_liveness
+    @_patch_overlays(FULL_OVERLAY)
+    @override_settings(**SETTINGS)
+    def test_missing_psql_does_not_abort_the_reaper(self) -> None:
+        """souliane/teatree#3234: a SQLite-only box has no ``psql`` — clean-all must still run.
+
+        The orphan-DB prune is the FIRST destructive pass after the done-reaper, so
+        a ``FileNotFoundError`` escaping it took the whole reaper down with it. This
+        drives the REAL :func:`drop_orphan_databases` (note the absent
+        ``_no_orphan_dbs`` patch) on a box where the Postgres client is not
+        installed, and pins that clean-all completes AND still tears down the merged
+        worktree fixture.
+        """
+        with tempfile.TemporaryDirectory() as tmp_s:
+            tmp = Path(tmp_s)
+            _make_squash_merged_worktree(tmp, ticket_number="3234")
+
+            with (
+                _pg_client_missing(),
+                patch.object(ws_cleanup_mod, "run_allowed_to_fail", side_effect=_pg_binary_not_installed),
+                patch.object(workspace_mod, "_worktree_root", return_value=tmp),
+                patch.object(provision_mod, "clone_root", return_value=tmp),
+                patch.object(provision_mod, "worktree_root", return_value=tmp),
+                patch.object(cleanup_mod, "drop_db"),
+                patch("teatree.core.runners.worktree_start.docker_compose_down"),
+            ):
+                # Pre-fix this raised FileNotFoundError: No such file or directory: 'psql'.
+                call_command("workspace", "clean-all")
+
+            assert Worktree.objects.count() == 0, (
+                "the merged worktree was not reaped — a missing psql aborted the whole reaper"
+            )
+
+    @_no_prune
+    @_no_stash
     @_no_orphan_dbs
     @_no_orphan_isolated_roots
     @_no_orphan_docker
@@ -2497,9 +2535,40 @@ class TestStashBranch(TestCase):
         assert ws_stash_mod._stash_branch("stash@{0}: On (no branch): detached work") == ""
 
 
+def _pg_client_present() -> AbstractContextManager[object]:
+    """Pretend the Postgres client binaries ARE on PATH (the postgres-backend box).
+
+    The orphan-DB prune is guarded on the Postgres client being installed
+    (souliane/teatree#3234), so every test that exercises the prune ITSELF must
+    pin that probe rather than inherit the host's PATH — otherwise the suite is
+    green on a developer box with postgres installed and red on the SQLite-only
+    CI/deploy box (or vice versa).
+    """
+    return patch.object(ws_cleanup_mod.shutil, "which", side_effect=lambda binary: f"/usr/bin/{binary}")
+
+
+def _pg_client_missing() -> AbstractContextManager[object]:
+    """The SQLite-only box: no ``psql`` / ``dropdb`` anywhere on PATH."""
+    return patch.object(ws_cleanup_mod.shutil, "which", return_value=None)
+
+
+def _pg_binary_not_installed(cmd: list[str], **_kw: object) -> MagicMock:
+    """Stand in for ``subprocess`` on a box with no Postgres client.
+
+    A missing binary raises ``FileNotFoundError`` from ``subprocess.run`` — it is
+    NOT a non-zero return code, which is exactly why the prune's pre-existing
+    ``returncode != 0`` check could not absorb it and the whole reaper died.
+    """
+    if cmd and cmd[0] in {"psql", "dropdb"}:
+        msg = f"[Errno 2] No such file or directory: {cmd[0]!r}"
+        raise FileNotFoundError(msg)
+    return MagicMock(returncode=0, stdout="")
+
+
 class TestDropOrphanDatabasesFailure(TestCase):
     def test_returns_empty_when_psql_fails(self) -> None:
         with (
+            _pg_client_present(),
             patch.object(utils_run_mod, "subprocess") as mock_sp,
             patch.object(db_mod, "pg_env", return_value={}),
             patch.object(db_mod, "pg_host", return_value="localhost"),
@@ -2509,6 +2578,37 @@ class TestDropOrphanDatabasesFailure(TestCase):
             result = ws_cleanup_mod.drop_orphan_databases()
 
         assert result == []
+
+
+class TestDropOrphanDatabasesWithoutPostgres(TestCase):
+    """souliane/teatree#3234: the orphan-DB prune must not exist on a SQLite-only box.
+
+    The prune shells ``psql``/``dropdb`` unconditionally. On a deployment with no
+    Postgres client those binaries are absent, ``subprocess`` raises
+    ``FileNotFoundError`` (never a non-zero exit), and the exception escaped the
+    prune and aborted the ENTIRE ``clean-all`` reaper — so merged worktrees, stale
+    branches, orphan stashes and dangling registrations were all left uncleaned.
+    """
+
+    def test_prune_is_skipped_when_the_postgres_client_is_absent(self) -> None:
+        with (
+            _pg_client_missing(),
+            patch.object(ws_cleanup_mod, "run_allowed_to_fail", side_effect=_pg_binary_not_installed) as run_probe,
+        ):
+            result = ws_cleanup_mod.drop_orphan_databases()
+
+        assert result == []
+        # The missing binary must be detected BEFORE it is shelled out to.
+        run_probe.assert_not_called()
+
+    def test_skip_is_reported_at_debug_level(self) -> None:
+        with (
+            _pg_client_missing(),
+            self.assertLogs(ws_cleanup_mod.__name__, level="DEBUG") as logs,
+        ):
+            ws_cleanup_mod.drop_orphan_databases()
+
+        assert any("psql" in line for line in logs.output)
 
 
 class TestWorktreeBranches(TestCase):
@@ -2616,6 +2716,7 @@ class TestDropOrphanDatabases(TestCase):
             return MagicMock(returncode=0)
 
         with (
+            _pg_client_present(),
             patch.object(utils_run_mod, "subprocess") as mock_sp,
             patch.object(db_mod, "pg_env", return_value={}),
             patch.object(db_mod, "pg_host", return_value="localhost"),

--- a/tests/teatree_core/test_runners_provision.py
+++ b/tests/teatree_core/test_runners_provision.py
@@ -6,6 +6,7 @@ worker. The worker runs ``WorktreeProvisioner`` and on success schedules
 the coding task.
 """
 
+import shutil
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -771,6 +772,186 @@ class TestWorktreeProvisionerAdopt(TestCase):
         wt = Worktree.objects.get(ticket=ticket, repo_path="myrepo")
         assert (wt.extra or {}).get("worktree_path") == str(worktree)
         assert (wt.extra or {}).get("clone_path") == str(discovered)
+
+
+class TestWorktreeProvisionerIsIdempotent(TestCase):
+    """souliane/teatree#3234: a leftover worktree must never strand the ticket forever.
+
+    A prior provision that died downstream leaves the git worktree and/or the
+    branch behind. ``git worktree add`` then REFUSES both the path (it exists) and
+    the branch (it is "already checked out"), so ``_create`` logged "Failed to
+    create worktree" and every retry failed identically — the ticket sat at
+    ``started`` forever with no way out but a manual ``git worktree remove``.
+
+    Provisioning is now idempotent: a healthy leftover for the scope is ADOPTED, a
+    broken one (registered-but-missing dir, wrong branch, non-git partial) is
+    cleaned up and recreated, and a leftover carrying work that exists on NO remote
+    is NEVER destroyed — it is adopted in place. Real git under ``tmp_path``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _tmp_workspace(self, tmp_path: Path) -> None:
+        self.tmp = tmp_path
+        self.workspace = tmp_path / "workspace"
+        self.workspace.mkdir()
+
+    def _clone(self, repo: str = "repo-a") -> Path:
+        """A real clone with one commit on ``main``, PUSHED to a real ``origin``.
+
+        The origin is load-bearing, not scenery: the teardown guard asks whether a
+        leftover's commits are absent from every remote, so a remote-less fixture
+        would make even the base commit look like unpushed work and every leftover
+        would be protected. A real clone always has an origin; so does this one.
+        """
+        origin = self.tmp / "origin" / f"{repo}.git"
+        git.run_strict(repo=str(self.tmp), args=["init", "-q", "--bare", "-b", "main", str(origin)])
+
+        clone = self.workspace / repo
+        clone.mkdir(parents=True)
+        git.run_strict(repo=str(clone), args=["init", "-q", "-b", "main"])
+        git.run_strict(repo=str(clone), args=["config", "user.email", "t@example.com"])
+        git.run_strict(repo=str(clone), args=["config", "user.name", "t"])
+        git.run_strict(repo=str(clone), args=["remote", "add", "origin", str(origin)])
+        (clone / "README.md").write_text("x\n", encoding="utf-8")
+        git.run_strict(repo=str(clone), args=["add", "-A"])
+        git.run_strict(repo=str(clone), args=["commit", "-q", "-m", "init"])
+        git.run_strict(repo=str(clone), args=["push", "-q", "-u", "origin", "main"])
+        return clone
+
+    def _add_worktree(self, clone: Path, path: Path, branch: str) -> Path:
+        git.run_strict(repo=str(clone), args=["worktree", "add", "-q", "-b", branch, str(path)])
+        return path
+
+    @staticmethod
+    def _commit(worktree: Path, name: str, body: str) -> None:
+        (worktree / name).write_text(body, encoding="utf-8")
+        git.run_strict(repo=str(worktree), args=["add", "-A"])
+        git.run_strict(repo=str(worktree), args=["commit", "-q", "-m", f"add {name}"])
+
+    def _provision(self, branch: str, *, repo: str = "repo-a", public_remote: bool = False) -> tuple[Any, Ticket]:
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://example.com/issues/3234",
+            repos=[repo],
+            extra={"branch": branch, "description": "x"},
+        )
+        with (
+            patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.core.runners.provision.clone_root", return_value=self.workspace),
+            patch("teatree.core.runners.provision.worktree_root", return_value=self.workspace),
+            # The clones have no remote: pin the two network-adjacent seams so the
+            # test exercises the worktree lifecycle, not git's remote plumbing.
+            patch("teatree.core.runners.provision.git.pull_ff_only", return_value=True),
+            patch("teatree.core.runners.provision.is_public_github_remote", return_value=public_remote),
+        ):
+            return WorktreeProvisioner(ticket).run(), ticket
+
+    def _recorded_path(self, ticket: Ticket) -> str:
+        wt = Worktree.objects.get(ticket=ticket, repo_path="repo-a")
+        return str((wt.extra or {}).get("worktree_path") or "")
+
+    def test_registered_worktree_whose_dir_is_gone_is_pruned_and_recreated(self) -> None:
+        # The reported strand (#3205 / #1308): the leftover worktree's DIRECTORY was
+        # removed but git still has it registered, so the branch reads as "already
+        # checked out at <missing path>" and BOTH `worktree add` attempts are refused.
+        clone = self._clone()
+        branch = "3234-stale-registration"
+        wt_path = self.workspace / branch / "repo-a"
+        self._add_worktree(clone, wt_path, branch)
+        shutil.rmtree(wt_path)
+
+        result, ticket = self._provision(branch)
+
+        assert result.ok is True, result.detail
+        assert (wt_path / ".git").exists(), "the worktree was not recreated after the stale registration"
+        assert git.current_branch(str(wt_path)) == branch
+        assert self._recorded_path(ticket) == str(wt_path)
+
+    def test_leftover_worktree_holding_the_branch_elsewhere_is_cleaned_and_recreated(self) -> None:
+        # The scope's branch is checked out at some OTHER path (a prior attempt under
+        # a different ticket dir). git refuses to check the branch out twice, so the
+        # add at the expected path was refused. The work-free leftover is reaped.
+        clone = self._clone()
+        branch = "3234-elsewhere"
+        stale = self._add_worktree(clone, self.tmp / "old-location", branch)
+
+        result, ticket = self._provision(branch)
+
+        assert result.ok is True, result.detail
+        wt_path = self.workspace / branch / "repo-a"
+        assert (wt_path / ".git").exists(), "the worktree was not recreated at the expected path"
+        assert git.current_branch(str(wt_path)) == branch
+        assert not stale.exists(), "the work-free leftover worktree was not cleaned up"
+        assert self._recorded_path(ticket) == str(wt_path)
+
+    def test_worktree_at_the_expected_path_on_the_wrong_branch_is_recreated(self) -> None:
+        # A partial prior attempt left a checkout of the WRONG branch exactly where
+        # this scope's worktree belongs. It used to be adopted blindly on the strength
+        # of the path existing, so the ticket coded on someone else's branch.
+        clone = self._clone()
+        branch = "3234-right-branch"
+        wt_path = self.workspace / branch / "repo-a"
+        self._add_worktree(clone, wt_path, "3234-wrong-branch")
+
+        result, ticket = self._provision(branch)
+
+        assert result.ok is True, result.detail
+        assert git.current_branch(str(wt_path)) == branch, "provisioned onto the WRONG branch"
+        assert self._recorded_path(ticket) == str(wt_path)
+
+    def test_healthy_matching_worktree_is_adopted_untouched(self) -> None:
+        # The plain idempotency case: the scope's worktree is already there, on the
+        # right branch. Adopt it — never re-create it, and never lose its commits.
+        clone = self._clone()
+        branch = "3234-adopt"
+        wt_path = self.workspace / branch / "repo-a"
+        self._add_worktree(clone, wt_path, branch)
+        self._commit(wt_path, "work.txt", "in progress\n")
+
+        result, ticket = self._provision(branch)
+
+        assert result.ok is True, result.detail
+        assert (wt_path / "work.txt").read_text(encoding="utf-8") == "in progress\n"
+        assert git.current_branch(str(wt_path)) == branch
+        assert self._recorded_path(ticket) == str(wt_path)
+
+    def test_leftover_carrying_unpushed_work_is_adopted_never_destroyed(self) -> None:
+        # The data-loss guard (#706, mirrored from reconcile/recover): the leftover is
+        # in the WRONG place, so the cleanup path would normally reap it — but its
+        # commits exist on NO remote. Destroying it would be the only copy of that
+        # work. It is adopted where it stands instead.
+        clone = self._clone()
+        branch = "3234-precious"
+        stale = self._add_worktree(clone, self.tmp / "old-location", branch)
+        self._commit(stale, "work.txt", "precious\n")
+
+        result, ticket = self._provision(branch)
+
+        assert result.ok is True, result.detail
+        assert stale.is_dir(), "a leftover with unpushed commits was DESTROYED"
+        assert (stale / "work.txt").read_text(encoding="utf-8") == "precious\n"
+        assert self._recorded_path(ticket) == str(stale), "the surviving worktree must be the one recorded"
+
+    def test_failed_step_after_creation_leaves_no_stranded_worktree(self) -> None:
+        # A provision STEP that fails after `git worktree add` succeeded must tear the
+        # just-created worktree down, so the retry starts from a clean slate instead of
+        # tripping over its own leftover. The worktree is provably work-free — it was
+        # created moments ago — so the teardown can never lose anything.
+        clone = self._clone()
+        branch = "3234-step-failure"
+        wt_path = self.workspace / branch / "repo-a"
+
+        with patch(
+            "teatree.core.runners.provision.set_local_noreply_identity",
+            side_effect=RuntimeError("identity step blew up"),
+        ):
+            result, ticket = self._provision(branch, public_remote=True)
+
+        assert result.ok is False, "a failed provision step must fail the provision, not pass silently"
+        assert not wt_path.exists(), "the failed provision stranded its worktree on disk"
+        registered = git.run(repo=str(clone), args=["worktree", "list", "--porcelain"])
+        assert str(wt_path) not in registered, "the failed provision stranded a git worktree registration"
+        assert Worktree.objects.filter(ticket=ticket, repo_path="repo-a").count() == 0
 
 
 class TestWorktreeProvisionerGuardsWrongRepo(TestCase):


### PR DESCRIPTION
Two related worktree-lifecycle bugs that together let the factory strand tickets with no way out.

## Bug 1 — provisioning was not idempotent, stranding the ticket forever

`WorktreeProvisioner._create` ran `git worktree add` against whatever a prior failed attempt left behind. Git refuses **both** the path (it exists) and the branch (it is already checked out — even when the registration's directory was deleted), so provision failed with `failed to create worktrees for: <repo>` (`provision.py:237`) and the ticket sat at `started` forever, every retry hitting the identical wall. Reproduced live on tickets #3205 and #1308.

Provisioning now reconciles the leftover before adding (`_reconcile_leftover_worktree`):

- a healthy registration at the expected path on the **correct** branch is **adopted**;
- a registration whose **directory is gone** is stale git admin — pruned, then recreated;
- a leftover holding the branch **elsewhere**, or one at the expected path on the **wrong** branch, is torn down (guarded) and recreated;
- a leftover carrying commits absent from **every** remote is **never destroyed** — it is adopted in place, mirroring the `reconcile.py` / `recover.py` data-loss guards (`commits_absent_from_all_remotes`, failing closed on an inconclusive probe). Branch refs are dropped with `git branch -d`, never `-D`, so git's own unmerged-branch guard is the check.

A provision **step** that fails *after* the worktree was created now tears that worktree back down (`_finalize` + rollback), so a retry starts clean instead of tripping over its own leftover.

## Bug 2 — `workspace clean-all` crashed on a box without Postgres

`drop_orphan_databases` shelled `psql` unconditionally. A missing binary raises `FileNotFoundError` — **not** a non-zero exit — so `run_allowed_to_fail`'s `returncode != 0` check could not absorb it. On a SQLite-only deployment the exception escaped and aborted the **entire** reaper: merged worktrees, stale branches, orphan stashes and dangling registrations were all left uncleaned.

The prune is now gated on the Postgres client being installed and skips with a `logger.debug` otherwise; every other clean-all pass runs to completion.

## Tests (RED before, GREEN after)

`tests/teatree_core/test_runners_provision.py::TestWorktreeProvisionerIsIdempotent` — real git under `tmp_path`, with a real `origin` (load-bearing: the teardown guard asks whether commits are absent from every remote):

- `test_registered_worktree_whose_dir_is_gone_is_pruned_and_recreated`
- `test_leftover_worktree_holding_the_branch_elsewhere_is_cleaned_and_recreated`
- `test_worktree_at_the_expected_path_on_the_wrong_branch_is_recreated`
- `test_healthy_matching_worktree_is_adopted_untouched`
- `test_leftover_carrying_unpushed_work_is_adopted_never_destroyed`
- `test_failed_step_after_creation_leaves_no_stranded_worktree`

`tests/teatree_core/management_commands/test_workspace.py`:

- `TestDropOrphanDatabasesWithoutPostgres::test_prune_is_skipped_when_the_postgres_client_is_absent`
- `TestDropOrphanDatabasesWithoutPostgres::test_skip_is_reported_at_debug_level`
- `TestWorkspaceCleanAll::test_missing_psql_does_not_abort_the_reaper` — drives the real prune and asserts clean-all still reaps a merged worktree
- the two pre-existing orphan-DB tests now pin the `psql`-present probe, so they are hermetic instead of silently inheriting the host's PATH

With the source fixes reverted, 10 of these fail (the reported `failed to create worktrees for: repo-a` and the `psql` FileNotFoundError); with them, all pass.

Closes #3234