### PR TITLE
fix(push-gate): run scoped doctest via the runner-prefix chokepoint, not sys.executable (#3205)

### DIFF
--- a/src/teatree/cli/push_gate_tools.py
+++ b/src/teatree/cli/push_gate_tools.py
@@ -10,13 +10,12 @@ human report) or executes the two scoped sweeps (``--run``, the driver
 """
 
 import json
-import sys
 from pathlib import Path
 
 import typer
 
 from teatree.config import get_effective_settings
-from teatree.quality.push_gate import PushGatePlan, resolve_plan, run_push_gate
+from teatree.quality.push_gate import PushGatePlan, pytest_prefix, resolve_plan, run_push_gate
 from teatree.utils.django_bootstrap import ensure_django
 
 
@@ -34,10 +33,11 @@ def _resolve_flag() -> bool:
         return False
 
 
-def _emit_cmd(plan: PushGatePlan) -> str:
+def _emit_cmd(plan: PushGatePlan, repo_root: Path) -> str:
     doctest = " ".join(str(t) for t in plan.doctest_targets) or "(none)"
     scope = "WHOLE-TREE" if plan.astgrep_scope is None else (" ".join(str(p) for p in plan.astgrep_scope) or "(none)")
-    return f"{sys.executable} -m pytest --doctest-modules {doctest}\nast-grep scope: {scope}"
+    invocation = " ".join(pytest_prefix(repo_root))
+    return f"{invocation} --doctest-modules {doctest}\nast-grep scope: {scope}"
 
 
 def _plan_as_dict(plan: PushGatePlan) -> dict:
@@ -72,7 +72,7 @@ def push_gate_command(
         typer.echo(json.dumps(_plan_as_dict(plan), indent=2))
         return
     if emit_cmd:
-        typer.echo(_emit_cmd(plan))
+        typer.echo(_emit_cmd(plan, cwd))
         return
     if run:
         result = run_push_gate(plan, repo_root=cwd)

--- a/src/teatree/quality/push_gate.py
+++ b/src/teatree/quality/push_gate.py
@@ -18,13 +18,13 @@ wedged push; CI's whole-tree scan is the guarantor. The whole-tree CI backstop i
 never on the push path alone.
 """
 
-import sys
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
 from teatree.quality.changed_set import ChangedSet, ChangedSetError, changed_paths, classify
 from teatree.quality.regression_scan import AstGrepUnavailableError, scan_findings
+from teatree.utils.django_db.runner import runner_prefix
 from teatree.utils.run import run_allowed_to_fail
 
 # The whole-tree doctest target — the FULL branch's ``--doctest-modules`` argument,
@@ -118,10 +118,22 @@ def resolve_plan(base_ref: str, *, enabled: bool, cwd: Path | None = None) -> Pu
     return plan_push_gate(changed, enabled=enabled)
 
 
+def pytest_prefix(repo_root: Path) -> list[str]:
+    """The pytest command prefix that runs from *repo_root*'s own environment.
+
+    ``sys.executable`` was WRONG here: under ``t3``'s ``uv tool install`` venv (the
+    local dev default) that interpreter has no pytest, so the gate exit-1'd on every
+    diff (#3205). Routing through :func:`runner_prefix` runs *repo_root*'s interpreter
+    (which carries pytest) and keeps the pipenv-vs-uv detection in its one chokepoint
+    (#1973), never a hand-rolled second ``uv run python`` prefix here.
+    """
+    return [*runner_prefix(repo_root), "-m", "pytest"]
+
+
 def _run_doctests(targets: Sequence[Path], repo_root: Path) -> bool:
     if not targets:
         return True
-    cmd = [sys.executable, "-m", "pytest", "--no-header", "-q", "--doctest-modules", *[str(t) for t in targets]]
+    cmd = [*pytest_prefix(repo_root), "--no-header", "-q", "--doctest-modules", *[str(t) for t in targets]]
     result = run_allowed_to_fail(cmd, expected_codes=None, cwd=repo_root)
     return result.returncode in {0, _PYTEST_NO_TESTS_COLLECTED}
 

--- a/tests/quality/test_push_gate_safety.py
+++ b/tests/quality/test_push_gate_safety.py
@@ -14,6 +14,7 @@ an unchanged module's stale docstring is main's/CI's concern, so the changed
 module is the only doctest target and no import graph is needed.
 """
 
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -31,6 +32,7 @@ from teatree.quality.push_gate import (
     run_push_gate,
 )
 from teatree.quality.regression_scan import AstGrepUnavailableError
+from teatree.utils.django_db.runner import runner_prefix
 
 
 def _changed(*entries: tuple[str, str]) -> ChangedSet:
@@ -227,6 +229,18 @@ class TestResolvePlanAndDoctestRunner:
         cmd = run.call_args.args[0]
         assert "--doctest-modules" in cmd
         assert "src/teatree/x.py" in cmd
+
+    def test_run_doctests_uses_project_interpreter_not_sys_executable(self) -> None:
+        # #3205: under `uv tool install`, sys.executable is the tool venv (no pytest),
+        # so the gate exit-1'd on every diff. It must invoke repo_root's own pytest via
+        # the runner-prefix chokepoint (#1973), never sys.executable and never a
+        # hand-rolled prefix.
+        with patch.object(push_gate_mod, "run_allowed_to_fail", return_value=SimpleNamespace(returncode=0)) as run:
+            _run_doctests((Path("src/teatree/x.py"),), Path.cwd())
+        cmd = run.call_args.args[0]
+        expected_prefix = [*runner_prefix(Path.cwd()), "-m", "pytest"]
+        assert cmd[: len(expected_prefix)] == expected_prefix
+        assert sys.executable not in cmd
 
     def test_run_doctests_reports_failure_on_real_doctest_failure(self) -> None:
         with patch.object(push_gate_mod, "run_allowed_to_fail", return_value=SimpleNamespace(returncode=1)):


### PR DESCRIPTION
fix(push-gate): run scoped doctest via the runner-prefix chokepoint, not sys.executable (#3205)

## What

`t3 tool push-gate --run` shelled the scoped `--doctest-modules` sweep through
`sys.executable`. When `t3` runs from its `uv tool install` venv (the local dev
default), that interpreter has no pytest, so the subprocess exited 1 with
`No module named pytest` on ANY diff — `dev/ci-parity-fast.sh` could never go
fully green locally, though CI (which runs the real gates under the project venv)
was unaffected.

Route the doctest sweep and the `--emit-cmd` display through a new
`pytest_prefix(repo_root)` that builds `[*runner_prefix(repo_root), "-m", "pytest"]`.
`runner_prefix` (`teatree.utils.django_db.runner`) is the **sole** sanctioned site
for a Python-interpreter prefix (#1973/#1976): it resolves `repo_root`'s own
environment (which carries pytest) via `uv --directory <repo> run python` and
handles the pipenv-vs-uv case.

## Why

Two problems in one fix:

1. **#3205** — `sys.executable` under `uv tool install` has no pytest, so the
   scoped doctest gate exit-1'd on every diff locally.
2. **The runner-prefix chokepoint (#1973/#1976).** A hand-rolled `uv run python`
   literal is exactly what `test_runner_prefix_chokepoint` (a CI-only fitness
   function) fails RED on — a second interpreter prefix silently diverges from the
   one pipenv-vs-uv detection. Routing through `runner_prefix` fixes #3205 *and*
   keeps the invocation on the single sanctioned prefix, so both go green.

The pytest args and the `{0, NO_TESTS_COLLECTED}` returncode semantics are
unchanged; no gate is narrowed.

## Architecture pre-check (#3205)

Tactical fix routed through the existing runner-prefix chokepoint — no new module,
no FSM/Protocol/OverlayBase surface. One new import
(`teatree.quality.push_gate` -> `teatree.utils.django_db.runner`; `utils` is
lower-level, `tach check` clean).

- **Behavior preservation:** the pytest args and the `{0, NO_TESTS_COLLECTED}`
  returncode semantics are unchanged; no gate is narrowed and no must-block test is
  inverted. `_emit_cmd`'s display string now shows the real invocation.
- **Test surface:** `tests/quality/test_push_gate_safety.py` asserts
  `_run_doctests` invokes `[*runner_prefix(cwd), "-m", "pytest"]` and never
  `sys.executable` (verified RED on a `sys.executable` revert, GREEN after);
  `tests/quality/test_runner_prefix_chokepoint.py` stays GREEN because no
  hand-rolled prefix literal remains.

## Open questions & assumptions

- **assumed:** `uv` (or pipenv, per the repo) is on PATH wherever the push gate
  runs — the entire dev flow already invokes commands through the runner prefix, so
  this is a standing prerequisite; a missing manager now raises loudly rather than
  false-greening.
- **assumed:** the `uv run` re-sync is a no-op when the env is current, adding no
  measurable latency to the fast push gate.
- **decided-by-issue:** fix per #3205 — run the doctest sweep via the project
  interpreter, routed through the runner-prefix chokepoint rather than a bare
  `uv run python -m pytest` literal so #1973's single-prefix invariant holds.
