### PR TITLE
fix(statusline): overlays + health + availability on line 1

### DIFF
--- a/src/teatree/loop/phases/render.py
+++ b/src/teatree/loop/phases/render.py
@@ -22,7 +22,7 @@ from teatree.loop.domain_jobs import _identity_groups_for_overlay
 from teatree.loop.job_identity import _ScannerJob
 from teatree.loop.manual_pr_reconcile import reconcile_manual_prs
 from teatree.loop.phases.orchestrate import orchestrate_phase
-from teatree.loop.rendering import _populate_health_chip, _populate_overlays_anchor, zones_for
+from teatree.loop.rendering import _populate_dashboard_head, zones_for
 from teatree.loop.statusline import StatuslineZones, render
 from teatree.loop.tick_freshness import _write_tick_meta
 
@@ -57,9 +57,7 @@ def render_phase(
         _orchestrate(request, statusline_path=statusline_path)
     else:
         zones = StatuslineZones()
-        _populate_live_loops_in_anchors(zones, colorize=colorize)
-        _populate_overlays_anchor(zones)
-        _populate_health_chip(zones, colorize=colorize)
+        _populate_dashboard_head(zones, colorize=colorize)
     _write_open_prs_cache(report.signals, target=statusline_path)
     _reconcile_manual_prs(report.signals)
     _populate_open_prs_in_anchors(zones, target=statusline_path, colorize=colorize)
@@ -167,27 +165,6 @@ def _identity_aliases_for_request(request: "TickRequest") -> tuple[tuple[str, ..
     return tuple(groups)
 
 
-def _populate_live_loops_in_anchors(zones: StatuslineZones, *, colorize: bool | None = None) -> None:
-    """Append one anchor line per live LoopLease row.
-
-    Used by the idle (empty-jobs) render so even an idle tick still surfaces
-    the running loops. The active path goes through
-    :func:`teatree.loop.rendering._populate_live_loops_anchor` via
-    :func:`teatree.loop.rendering.zones_for` and must not double-populate.
-    *colorize* threads the per-loop recency coloring through.
-
-    Fails open: any import/query error degrades to a no-op.
-    """
-    try:
-        from teatree.loop.statusline import colorize_enabled, live_loops_anchor  # noqa: PLC0415 — tick-time import
-    except Exception:  # noqa: BLE001 — the statusline import is best-effort; a failure degrades to no anchor
-        return
-    try:
-        zones.anchors.extend(live_loops_anchor(colorize=colorize_enabled(colorize=colorize)))
-    except Exception:  # noqa: BLE001 — rendering is best-effort; a failure degrades to no anchor
-        return
-
-
 def _write_open_prs_cache(signals: "list[ScanSignal]", *, target: Path | None) -> None:
     """Snapshot the tick's open PRs to the ``open-prs.json`` sidecar.
 
@@ -247,11 +224,11 @@ def _populate_open_prs_in_anchors(zones: StatuslineZones, *, target: Path | None
 def _populate_loop_owner_anchor(zones: StatuslineZones) -> None:
     """Append the foreign-hijack t3-master RED line.
 
-    The live-loops anchor (the single dedicated loop line folding all live
-    LoopLease rows) is populated separately by
-    :func:`teatree.loop.rendering._populate_live_loops_anchor`. This function
-    is responsible only for the foreign-hijack RED line surfaced when a
-    different live session holds ``t3-master``.
+    The dashboard head line (the single dedicated line folding the live loops,
+    overlays, and health) is populated separately by
+    :func:`teatree.loop.rendering._populate_dashboard_head`. This function is
+    responsible only for the foreign-hijack RED line surfaced when a different
+    live session holds ``t3-master``.
 
     Fails open: any import/query error degrades to a no-op so a broken
     t3-master read can never blank the statusline.
@@ -289,7 +266,7 @@ def rerender_statusline(target: Path | None = None, *, colorize: bool | None = N
     PR a real scan had recorded, blanking the anchor until the next full tick.
     """
     zones = StatuslineZones()
-    _populate_live_loops_in_anchors(zones, colorize=colorize)
+    _populate_dashboard_head(zones, colorize=colorize)
     _populate_open_prs_in_anchors(zones, target=target, colorize=colorize)
     _populate_loop_owner_anchor(zones)
     return render(zones, target=target, colorize=colorize)

--- a/src/teatree/loop/rendering.py
+++ b/src/teatree/loop/rendering.py
@@ -24,15 +24,7 @@ from teatree.loop.rendering_classification import _ClassifiedActions, _classify_
 from teatree.loop.rendering_items import _IssueRef, _OverlayActionRefs, _PRRef
 from teatree.loop.rendering_permalinks import build_review_post_permalinks, enrich_pr_refs_with_permalinks
 from teatree.loop.rendering_zones import _MAX_PER_STATE, _populate_overlay_zones, _render_action_line, _render_pr_group
-from teatree.loop.statusline import (
-    StatuslineEntry,
-    StatuslineZones,
-    ZoneItem,
-    colorize_enabled,
-    health_chip,
-    live_loops_anchor,
-    overlays_anchor,
-)
+from teatree.loop.statusline import StatuslineEntry, StatuslineZones, ZoneItem, colorize_enabled, dashboard_head_anchor
 
 __all__ = [
     "_ClassifiedActions",
@@ -42,8 +34,7 @@ __all__ = [
     "_classify_actions",
     "_issue_ref_from",
     "_overlay_search_base",
-    "_populate_health_chip",
-    "_populate_overlays_anchor",
+    "_populate_dashboard_head",
     "_render_action_line",
     "_render_pr_group",
     "cost_chip_lines",
@@ -71,12 +62,11 @@ def zones_for(
     """
     colorize = colorize_enabled(colorize=colorize)
     zones = StatuslineZones()
-    # The dedicated loop line must stay line 1 (#130/#1400) — statusline.sh
-    # prepends the per-session t3-master badge to it; the live availability
-    # segment rides on that line too (#1678).
-    _populate_live_loops_anchor(zones, colorize=colorize)
-    _populate_overlays_anchor(zones)
-    _populate_health_chip(zones, colorize=colorize)
+    # The consolidated dashboard head must stay line 1 (#130/#1400) —
+    # statusline.sh prepends the per-session t3-master badge to it. It folds the
+    # loop line (which carries the availability segment, #1678) with the
+    # overlays summary and the health chip onto that one line.
+    _populate_dashboard_head(zones, colorize=colorize)
     c = _classify_actions(actions, identity_aliases)
     ticket_index = build_ticket_index(actions)
     enrich_pr_refs_with_permalinks(c, build_review_post_permalinks(actions))
@@ -117,26 +107,15 @@ def _overlay_search_base(overlay: str) -> str:
     return "https://github.com/search?type=issues&q="
 
 
-def _populate_overlays_anchor(zones: StatuslineZones) -> None:
-    """Append the ``overlays: a · b · c`` configured-overlays summary line (#1663).
+def _populate_dashboard_head(zones: StatuslineZones, *, colorize: bool | None = None) -> None:
+    """Append the consolidated dashboard head line — loops + overlays + health.
 
-    :func:`~teatree.loop.statusline.overlays_anchor` is itself fail-open, so
-    this wrapper exists only to do the append. Surfaces the multi-overlay
-    context directly instead of only when a ticket/PR happens to carry an
-    ``[ov]`` prefix.
+    :func:`~teatree.loop.statusline.dashboard_head_anchor` folds the loop line
+    (carrying availability, #1678), the configured-overlays summary, and the
+    health chip onto ONE line and is itself fail-open, so this wrapper only
+    resolves the ``NO_COLOR`` decision and does the append.
     """
-    zones.anchors.extend(overlays_anchor())
-
-
-def _populate_health_chip(zones: StatuslineZones, *, colorize: bool | None = None) -> None:
-    """Append the global-health chip (``health: ● N``) to the anchors zone (PR-17).
-
-    :func:`~teatree.loop.statusline.health_chip` reads the persisted verdict
-    read-only and is itself fail-open, so this wrapper only resolves the
-    ``NO_COLOR`` decision (matching the empty-jobs render path's ``bool | None``)
-    and does the append.
-    """
-    zones.anchors.extend(health_chip(colorize=colorize_enabled(colorize=colorize)))
+    zones.anchors.extend(dashboard_head_anchor(colorize=colorize_enabled(colorize=colorize)))
 
 
 def _append_capped_other(zones: StatuslineZones, other: list[tuple[str, StatuslineEntry]]) -> None:
@@ -161,21 +140,6 @@ def _append_capped_other(zones: StatuslineZones, other: list[tuple[str, Statusli
         overflow = len(entries) - _MAX_PER_STATE
         if overflow > 0:
             zone_list.append(f"(+{overflow} more)")
-
-
-def _populate_live_loops_anchor(zones: StatuslineZones, *, colorize: bool = False) -> None:
-    """Append one anchor line per live :class:`LoopLease` row (#1163).
-
-    Multi-loop visibility: the user runs ``loop-tick``, ``t3-master``,
-    ``loop-self-improve``, ``loop-slack-answer``, ``loop-slot`` in parallel
-    — surfacing each gives the at-a-glance count the prior single
-    ``t3-master=…`` anchor hid. *colorize* threads the per-loop recency
-    coloring into :func:`~teatree.loop.statusline.live_loops_anchor`.
-
-    :func:`~teatree.loop.statusline.live_loops_anchor` is itself fail-open,
-    so this wrapper exists only to do the append.
-    """
-    zones.anchors.extend(live_loops_anchor(colorize=colorize))
 
 
 def cost_chip_lines() -> list[str]:

--- a/src/teatree/loop/statusline.py
+++ b/src/teatree/loop/statusline.py
@@ -23,6 +23,7 @@ home (``teatree.loop.statusline``); identity is preserved so
 
 from teatree.loop.statusline_loops import (
     availability_segment,
+    dashboard_head_anchor,
     health_chip,
     live_loops_anchor,
     loop_owner_anchor,
@@ -48,6 +49,7 @@ __all__ = [
     "ZoneItem",
     "availability_segment",
     "colorize_enabled",
+    "dashboard_head_anchor",
     "default_path",
     "health_chip",
     "live_loops_anchor",

--- a/src/teatree/loop/statusline_loops.py
+++ b/src/teatree/loop/statusline_loops.py
@@ -107,6 +107,22 @@ def health_chip(*, colorize: bool = False) -> list[str]:
     return [f"health: {dot}{count}"]
 
 
+def dashboard_head_anchor(*, colorize: bool = False) -> list[str]:
+    """Return the single consolidated dashboard head line, or ``[]``.
+
+    Folds the live-loops line (which already carries the availability segment,
+    #1678), the configured-overlays summary, and the global-health chip onto
+    ONE line joined by the loop line's own `` · `` separator — so overlays and
+    health stop each wasting a whole row. Every source is individually
+    fail-open, so a broken read drops only its own segment; the line is ``[]``
+    only when all three are empty.
+    """
+    parts = [*live_loops_anchor(colorize=colorize), *overlays_anchor(), *health_chip(colorize=colorize)]
+    if not parts:
+        return []
+    return [" · ".join(parts)]
+
+
 def _live_loop_leases() -> list[tuple[str, datetime | None]]:
     """Return ``(loop_name, acquired_at)`` for every currently-live LoopLease.
 

--- a/tests/quality/deferred_import_pegs.toml
+++ b/tests/quality/deferred_import_pegs.toml
@@ -115,7 +115,7 @@
 "src/teatree/loop/domain_jobs.py" = 2
 "src/teatree/loop/global_scanner_factories.py" = 1
 "src/teatree/loop/loop_scoping.py" = 1
-"src/teatree/loop/phases/render.py" = 9
+"src/teatree/loop/phases/render.py" = 8
 "src/teatree/loop/scanners/failed_e2e_posts.py" = 1
 "src/teatree/loop/scanners/outbound_audit_overlay_verifiers.py" = 5
 "src/teatree/loop/scanners/slack_mentions.py" = 1

--- a/tests/teatree_loop/test_dashboard_head_anchor.py
+++ b/tests/teatree_loop/test_dashboard_head_anchor.py
@@ -1,0 +1,130 @@
+"""The consolidated dashboard head line (loops + availability + overlays + health).
+
+The owner asked for overlays and health to stop each wasting a whole row:
+``dashboard_head_anchor`` folds the live-loops line (which already carries the
+availability segment, #1678), the configured-overlays summary, and the
+global-health chip onto ONE line. These regression-lock that overlays and
+health ride the same first line as the loops, never separate rows.
+"""
+
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from teatree.core.factory.operational_health import HealthReport, HealthStatus
+from teatree.core.models.known_issue import KnownIssue
+from teatree.loop.rendering import zones_for
+from teatree.loop.statusline import dashboard_head_anchor, render
+from teatree.loop.tick import TickRequest, run_tick
+
+
+def _health(status: HealthStatus, count: int) -> HealthReport:
+    issues = tuple(KnownIssue(fingerprint=f"f{i}", severity="warning", summary="s") for i in range(count))
+    return HealthReport(status=status, open_issues=issues)
+
+
+def _live_lease() -> list[tuple[str, datetime]]:
+    return [("loop-tick", datetime.now(UTC) - timedelta(seconds=60))]
+
+
+class TestDashboardHeadAnchor:
+    """Pure formatter: the four segments fold onto exactly one line."""
+
+    def test_folds_loops_availability_overlays_health_onto_one_line(self) -> None:
+        with (
+            patch("teatree.loop.statusline_loops._live_loop_leases", return_value=_live_lease()),
+            patch("teatree.loop.statusline_loops._cadence_for_loop", return_value=720),
+            patch("teatree.loop.statusline_loops._availability_segment", return_value="availability: away (override)"),
+            patch("teatree.loop.statusline_loops._configured_overlay_names", return_value=["t3-teatree"]),
+            patch("teatree.core.factory.operational_health.read_health", return_value=_health(HealthStatus.RED, 3)),
+        ):
+            lines = dashboard_head_anchor(colorize=False)
+        assert len(lines) == 1, repr(lines)
+        line = lines[0]
+        assert "tick 11m" in line, line
+        assert "availability: away (override)" in line, line
+        assert "overlays: t3-teatree" in line, line
+        assert "health: ● 3" in line, line
+
+    def test_no_loops_still_folds_overlays_and_health_onto_one_line(self) -> None:
+        with (
+            patch("teatree.loop.statusline_loops._live_loop_leases", return_value=[]),
+            patch("teatree.loop.statusline_loops._configured_overlay_names", return_value=["alpha", "beta"]),
+            patch("teatree.core.factory.operational_health.read_health", return_value=_health(HealthStatus.GREEN, 0)),
+        ):
+            lines = dashboard_head_anchor(colorize=False)
+        assert lines == ["overlays: alpha · beta · health: ●"], repr(lines)
+
+    def test_empty_when_nothing_to_show(self) -> None:
+        with (
+            patch("teatree.loop.statusline_loops._live_loop_leases", return_value=[]),
+            patch("teatree.loop.statusline_loops._configured_overlay_names", return_value=[]),
+            patch("teatree.core.factory.operational_health.read_health", side_effect=RuntimeError("boom")),
+        ):
+            assert dashboard_head_anchor(colorize=False) == []
+
+    def test_fails_open_per_segment(self) -> None:
+        # A broken overlays read drops only its segment; loops + health survive.
+        with (
+            patch("teatree.loop.statusline_loops._live_loop_leases", return_value=_live_lease()),
+            patch("teatree.loop.statusline_loops._cadence_for_loop", return_value=720),
+            patch("teatree.loop.statusline_loops._availability_segment", return_value=""),
+            patch(
+                "teatree.loop.statusline_loops._configured_overlay_names",
+                side_effect=RuntimeError("config broken"),
+            ),
+            patch("teatree.core.factory.operational_health.read_health", return_value=_health(HealthStatus.GREEN, 0)),
+        ):
+            lines = dashboard_head_anchor(colorize=False)
+        assert len(lines) == 1, repr(lines)
+        assert "overlays:" not in lines[0], lines[0]
+        assert "health: ●" in lines[0], lines[0]
+
+
+# ast-grep-ignore: ac-django-no-pytest-django-db
+@pytest.mark.django_db
+class TestDashboardHeadConsolidatesRows:
+    """overlays and health no longer occupy their own zones rows."""
+
+    def _overlays_and_health_row_count(self, body: str) -> tuple[int, int]:
+        overlay_rows = sum(1 for ln in body.splitlines() if "overlays:" in ln)
+        health_rows = sum(1 for ln in body.splitlines() if "health: ●" in ln)
+        return overlay_rows, health_rows
+
+    def test_zones_for_puts_overlays_health_on_the_loop_line(self, tmp_path: Path) -> None:
+        with (
+            patch("teatree.loop.statusline_loops._live_loop_leases", return_value=_live_lease()),
+            patch("teatree.loop.statusline_loops._cadence_for_loop", return_value=720),
+            patch("teatree.loop.statusline_loops._configured_overlay_names", return_value=["alpha", "beta"]),
+            patch("teatree.core.factory.operational_health.read_health", return_value=_health(HealthStatus.YELLOW, 1)),
+        ):
+            zones = zones_for([], colorize=False)
+            target = tmp_path / "sl.txt"
+            render(zones, target=target, colorize=False)
+        body = target.read_text(encoding="utf-8")
+        loop_lines = [ln for ln in body.splitlines() if "tick 11m" in ln]
+        assert len(loop_lines) == 1, body
+        # The overlays + health segments ride that single loop line.
+        assert "overlays: alpha · beta" in loop_lines[0], body
+        assert "health: ● 1" in loop_lines[0], body
+        # And they do not also appear on their own separate rows.
+        assert self._overlays_and_health_row_count(body) == (1, 1), body
+
+    def test_empty_jobs_tick_folds_overlays_health_onto_loop_line(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as d,
+            patch("teatree.loop.statusline_loops._live_loop_leases", return_value=_live_lease()),
+            patch("teatree.loop.statusline_loops._cadence_for_loop", return_value=720),
+            patch("teatree.loop.statusline_loops._configured_overlay_names", return_value=["alpha"]),
+            patch("teatree.core.factory.operational_health.read_health", return_value=_health(HealthStatus.RED, 2)),
+        ):
+            sl = Path(d) / "sl.txt"
+            run_tick(TickRequest(scanners=[]), statusline_path=sl, colorize=False)
+            body = sl.read_text(encoding="utf-8")
+        loop_lines = [ln for ln in body.splitlines() if "tick 11m" in ln]
+        assert len(loop_lines) == 1, body
+        assert "overlays: alpha" in loop_lines[0], body
+        assert "health: ● 2" in loop_lines[0], body

--- a/tests/teatree_loop/test_statusline_multiloop.py
+++ b/tests/teatree_loop/test_statusline_multiloop.py
@@ -116,13 +116,13 @@ class TestPopulateLoopsAnchorIntegration:
     """The rendering layer emits the consolidated line for live LoopLease rows."""
 
     def test_emits_consolidated_line_when_loops_live(self) -> None:
-        from teatree.loop.rendering import _populate_live_loops_anchor  # noqa: PLC0415
+        from teatree.loop.rendering import _populate_dashboard_head  # noqa: PLC0415
 
         _make_lease("loop-tick", expires_in=timedelta(minutes=30))
         _make_lease("loop-self-improve", expires_in=timedelta(minutes=30))
 
         zones = StatuslineZones()
-        _populate_live_loops_anchor(zones)
+        _populate_dashboard_head(zones)
 
         joined = "\n".join(item if isinstance(item, str) else item.text for item in zones.anchors)
         assert "tick" in joined, repr(joined)


### PR DESCRIPTION
## What

Fold the **overlays**, **health**, and **availability** segments onto the
statusline's first dashboard line, instead of overlays and health each taking a
whole row of their own.

Owner request (verbatim): *"a single line for overlays and health is a waste.
please put them on the first line, as well as availability."*

## Why the change is Python-side, not in `statusline.sh`

`hooks/scripts/statusline.sh` does **not** compose these segments — a grep for
`health` / `availab` in it returns nothing. They are rendered Python-side into
the pre-rendered zones file by `t3 loop tick`; `statusline.sh` only `cat`s that
file after its own `model / ctx / rate-limit` header. `availability` already
rode the loop line (`live_loops_anchor`, #1678); `overlays_anchor()` and
`health_chip()` each emitted a **separate** anchor row. So the fix belongs where
the rows are built. `statusline.sh` is unchanged — its existing line-1 handling
(t3-master badge prepend, width cap) already works with the consolidated line.

## How

- New `dashboard_head_anchor()` in `statusline_loops.py` joins
  `live_loops_anchor()` (carrying availability) + `overlays_anchor()` +
  `health_chip()` with the loop line's own ` · ` separator into one line.
- Both zone-assembly paths — `zones_for` (active tick) and the idle / `rerender`
  tick path in `phases/render.py` — now populate that single head via
  `_populate_dashboard_head`, replacing the three separate populate wrappers
  (`_populate_live_loops_anchor`, `_populate_overlays_anchor`,
  `_populate_health_chip`, `_populate_live_loops_in_anchors` deleted).
- Health color coding (green / yellow / red dot) is preserved. `rerender_statusline`
  now also surfaces overlays/health, matching the full render.

## Rendered evidence (`cat -A`, non-TTY, realistic Claude stdin JSON)

BEFORE — the dashboard was three rows:

```
tick 11m · self-improve 11m · availability: autonomous_away (override)
overlays: t3-teatree
health: ● 3
```

AFTER — one row carries all three (verified with color and `NO_COLOR`, exit 0):

```
t3-master: unclaimed · tick 11m · self-improve 11m · availability: autonomous_away (override) · overlays: t3-teatree · health: ● 3
```

In the colored run the health dot is red (`\e[1;31m`) for the RED / 3-issue
verdict — green is never shown when unhealthy.

## Architecture pre-check

1. **BLUEPRINT §** — §5.6 Loop Topology / statusline rendering; no contract change.
2. **FSM phase boundaries** — n/a (no `Ticket`/`Worktree` transition).
3. **Extension-point contracts** — none; no `OverlayBase` / scanner / Protocol touched.
4. **Component boundaries** — stays in `src/teatree/loop/` (rendering). `dashboard_head_anchor` sits beside the three functions it composes in `statusline_loops.py`.
5. **Dependency direction** — no new cross-module import; `uv run tach check` → "All modules validated!".
6. **Test surface** — `tests/teatree_loop/test_dashboard_head_anchor.py`: folds all four segments onto one line, no-loops still folds overlays+health, empty → `[]`, per-segment fail-open, and both assembly paths put overlays/health on the loop line (not separate rows). Multiloop wiring test updated to the new populate seam.
7. **Resilience invariants** — read-only render; every segment source stays individually fail-open (a broken read drops only its segment, never blanks the line).
8. **Identity / key normalization** — n/a.
9. **Behavior preservation** — overlays/health content preserved, only their layout folds (the requested change). `rerender_statusline` gains overlays/health (info gain, consistency). No privacy/security matcher narrowed; no must-block test inverted.
10. **Removability / harness-vs-data** — one consolidator function + one populate wrapper; revert is local to these two modules. Pure harness (rendering), no data/config surface.

## Test evidence

- `tests/teatree_loop/` + `tests/test_claude_statusline.py`: **2503 passed**.
- `tests/teatree_loop/phases/test_render.py` + loop-owner refresh: **16 passed**.
- `uv run tach check`, `ruff check`, `ruff format --check`, `ty-check`, `makemigrations --check` (No changes), `test-path-mirror` (ratchet holds): all pass.
