### PR TITLE
fix(loop): bounded retry-or-escalate for the silent-stall class (transient-FAILED requeue + landing verification)

### DIFF
--- a/src/teatree/agents/attempt_recorder.py
+++ b/src/teatree/agents/attempt_recorder.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, cast
 
 from django.utils import timezone
 
+from teatree.agents.landing_verification import landing_verification_error
 from teatree.agents.outage_classifier import outage_signature
 from teatree.agents.result_schema import (
     RESULT_JSON_SCHEMA,
@@ -124,8 +125,14 @@ def record_result_envelope(
     """Record *result* as a ``TaskAttempt`` and drive the ``Task`` to terminal.
 
     Validation order: schema-key check → OUTAGE check (#1764) → per-phase
-    evidence gate (#1284) — a failure on any records a FAILED attempt and fails
-    the task (``exit_code=0`` so it reads as a clean refusal, not a crash). The
+    evidence gate (#1284) → LANDING check (coding/debugging must have committed) —
+    a failure on any records a FAILED attempt and fails the task (``exit_code=0``
+    so it reads as a clean refusal, not a crash). The landing check re-reads the
+    ticket worktree's git state so a coder that reported ``files_modified`` while
+    nothing was committed (the yield-without-landing stall) lands FAILED with a
+    ``landing_unverified`` diagnostic — which the bounded auto-requeue sweep then
+    retries-if-transient / escalates, instead of the ticket FSM silently
+    advancing over unlanded work. The
     outage check runs BEFORE the evidence gate so an outage death that happens
     to carry evidence (the "API error laundered as a completion" class) still
     lands FAILED with the diagnostic signature, never COMPLETED — the ticket FSM
@@ -147,6 +154,10 @@ def record_result_envelope(
     evidence_error = check_evidence(result, phase or task.phase)
     if evidence_error:
         return _record_failure(task, error=evidence_error)
+
+    landing_error = landing_verification_error(task, phase=phase)
+    if landing_error:
+        return _record_failure(task, error=landing_error)
 
     server_side_error = _record_returned_envelopes(task, result, phase=phase)
     if server_side_error:

--- a/src/teatree/agents/landing_verification.py
+++ b/src/teatree/agents/landing_verification.py
@@ -1,0 +1,59 @@
+"""Verify a coding/debugging result actually landed a commit (root-cause gate).
+
+The coder-yield stall: a coding sub-agent spawns a background test agent and
+yields with no terminal ResultMessage, or reports ``files_modified`` while
+nothing was committed. ``PHASE_REQUIRED_EVIDENCE["coding"]`` is self-reported —
+it proves the agent *claimed* file changes, not that they landed. This gate
+re-reads the ticket worktree's git state at completion time and refuses with a
+``landing_unverified`` failure unless a new commit actually exists.
+
+Fail-open on the unverifiable: when the ticket has no materialised worktree on
+disk (a headless run with no checkout, a pre-provision task), there is nothing
+to verify, so the gate returns ``""`` and completion proceeds as before —
+"couldn't determine" is never "did not land" (the same posture as
+:func:`teatree.core.models.ticket_worktree_checks.worktree_tracked_dirty_path`).
+"""
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from teatree.core.modelkit.phases import normalize_phase
+from teatree.core.models.ticket_worktree_checks import worktree_has_commits_ahead, worktree_tracked_dirty_path
+
+if TYPE_CHECKING:
+    from teatree.core.models.task import Task
+    from teatree.core.models.worktree import Worktree
+
+_LANDING_VERIFIED_PHASES = frozenset({"coding", "debugging"})
+
+_UNVERIFIED_PREFIX = "landing_unverified:"
+
+
+def landing_verification_error(task: "Task", *, phase: str = "") -> str:
+    """Return a ``landing_unverified:`` error if a coding/debugging result did not land, else ``""``.
+
+    Refuses when a checkable ticket worktree has uncommitted tracked changes (the
+    files were edited but never committed) or no commit ahead of its base (HEAD
+    never advanced). A non-coding/debugging phase, or a ticket with no checkable
+    worktree, is a no-op (``""``).
+    """
+    if normalize_phase(phase or task.phase) not in _LANDING_VERIFIED_PHASES:
+        return ""
+    checkable = [wt for wt in task.ticket.worktrees.all() if _on_disk_repo(wt)]
+    if not checkable:
+        return ""
+    for wt in checkable:
+        dirty_path = worktree_tracked_dirty_path(wt)
+        if dirty_path is not None:
+            return f"{_UNVERIFIED_PREFIX} uncommitted tracked changes in {dirty_path} — files_modified never committed"
+    if not any(worktree_has_commits_ahead(wt) for wt in checkable):
+        branch = checkable[0].branch or "(detached)"
+        return f"{_UNVERIFIED_PREFIX} no new commit on {branch} — HEAD has not advanced past the base"
+    return ""
+
+
+def _on_disk_repo(worktree: "Worktree") -> bool:
+    """Whether *worktree* has a materialised on-disk path a git check can read."""
+    extra = worktree.extra if isinstance(worktree.extra, dict) else {}
+    path = extra.get("worktree_path") or worktree.repo_path
+    return bool(path) and Path(path).is_dir()

--- a/src/teatree/agents/landing_verification.py
+++ b/src/teatree/agents/landing_verification.py
@@ -19,10 +19,10 @@ from typing import TYPE_CHECKING
 
 from teatree.core.modelkit.phases import normalize_phase
 from teatree.core.models.ticket_worktree_checks import worktree_has_commits_ahead, worktree_tracked_dirty_path
+from teatree.core.models.worktree import Worktree
 
 if TYPE_CHECKING:
     from teatree.core.models.task import Task
-    from teatree.core.models.worktree import Worktree
 
 _LANDING_VERIFIED_PHASES = frozenset({"coding", "debugging"})
 
@@ -39,7 +39,7 @@ def landing_verification_error(task: "Task", *, phase: str = "") -> str:
     """
     if normalize_phase(phase or task.phase) not in _LANDING_VERIFIED_PHASES:
         return ""
-    checkable = [wt for wt in task.ticket.worktrees.all() if _on_disk_repo(wt)]
+    checkable = [wt for wt in Worktree.objects.filter(ticket=task.ticket) if _on_disk_repo(wt)]
     if not checkable:
         return ""
     for wt in checkable:

--- a/src/teatree/agents/outage_classifier.py
+++ b/src/teatree/agents/outage_classifier.py
@@ -78,3 +78,44 @@ def outage_signature(result: AgentResultBlob, *, error: str = "") -> str:
             if phrase in haystack:
                 return f"{_API_ERROR_PHRASE} + {phrase}"
     return ""
+
+
+# Namespaced markers a FAILED attempt's ``error`` carries when the death was an
+# infrastructure interruption rather than a deterministic defect. Each is emitted
+# by exactly one recording seam: ``outage_death:`` by the recorder (#1764),
+# ``result_error:`` by the headless driver for the #1764 "genuine FAILED run"
+# class (a missing terminal ResultMessage OR an ``is_error`` result — both
+# transient), ``provision_failed:`` by a worktree/provisioning step, and
+# ``landing_unverified:`` by the completion chokepoint when a coder yielded
+# without committing. A deterministic refusal (evidence gate, schema, review
+# verdict, a real assertion/test failure, a ``stuck_loop`` runaway) matches none.
+_TRANSIENT_MARKERS = (
+    "outage_death:",
+    "result_error:",
+    "provision_failed:",
+    "landing_unverified:",
+)
+
+
+def transient_failure_signature(error: str) -> str:
+    """Return the transient signature of a FAILED attempt's *error*, or ``""``.
+
+    A non-empty return means the failure was an infrastructure interruption the
+    bounded auto-requeue sweep MAY reopen; ``""`` means a deterministic failure
+    that must stay terminal FAILED. Keys on the namespaced markers above, plus a
+    raw connection / "API Error + connection" signature in the error text (an
+    outage death whose envelope was never stamped with the ``outage_death:``
+    prefix). Case-insensitive.
+    """
+    haystack = error.casefold()
+    if not haystack.strip():
+        return ""
+    for marker in _TRANSIENT_MARKERS:
+        if marker in haystack:
+            return marker.rstrip(": ")
+    return outage_signature({}, error=error)
+
+
+def is_transient_failure(error: str) -> bool:
+    """Whether a FAILED attempt's *error* classifies as a transient interruption."""
+    return bool(transient_failure_signature(error))

--- a/src/teatree/loop/tick_recovery.py
+++ b/src/teatree/loop/tick_recovery.py
@@ -18,17 +18,25 @@ logger = logging.getLogger(__name__)
 
 
 def _reap_stale_task_claims() -> None:
-    """Run the boot sweeps from the loop tick, swallowing a DB-blocked harness.
+    """Run the boot sweeps + transient auto-requeue from the loop tick, swallowing a DB-blocked harness.
 
     Best-effort wrapper over :func:`teatree.core.worktree.recovery_sweeps.run_boot_sweeps`
-    (the single SSOT, shared with ``t3 recover``): if the test harness blocks DB
-    access (pytest-django without a ``db`` marker), the loop tick should still
-    render scanners and signals.
+    (the single SSOT, shared with ``t3 recover``) plus
+    :func:`teatree.loop.transient_requeue.requeue_transient_failed` — the bounded
+    reopen of transient-FAILED tasks (an outage/provision-fail/coder-yield that
+    RETURNED a failure, which the crashed-session boot sweeps never rescue). The
+    transient requeue lives in the loop layer (it composes the ``agents``
+    classifier with the ``core`` model), so it is called here rather than folded
+    into the core-only ``run_boot_sweeps``. If the test harness blocks DB access
+    (pytest-django without a ``db`` marker), the loop tick should still render
+    scanners and signals.
     """
     from teatree.core.worktree.recovery_sweeps import run_boot_sweeps  # noqa: PLC0415 — deferred: loaded at tick time
+    from teatree.loop.transient_requeue import requeue_transient_failed  # noqa: PLC0415 — deferred: loaded at tick time
 
     with contextlib.suppress(RuntimeError):
         run_boot_sweeps()
+        requeue_transient_failed()
 
 
 def _persist_agent_dispatches(report: "TickReport") -> None:

--- a/src/teatree/loop/transient_requeue.py
+++ b/src/teatree/loop/transient_requeue.py
@@ -56,7 +56,7 @@ def _transient_failed_candidates() -> list[Task]:
         .select_related("ticket")
     )
     for task in failed:
-        last = task.attempts.order_by("-pk").first()  # ty: ignore[unresolved-attribute]
+        last = task.attempts.order_by("-pk").first()
         if last is not None and is_transient_failure(last.error):
             candidates.append(task)
     return candidates
@@ -75,7 +75,7 @@ def _budget_halt_reason(task: Task) -> str | None:
     last_two = [a.error_fingerprint for a in attempts[-2:] if a.error_fingerprint]
     try:
         requeue_verdict(
-            ticket_id=task.ticket_id,  # ty: ignore[unresolved-attribute]
+            ticket_id=task.ticket.pk,
             phase=normalize_phase(task.phase),
             iteration_count=len(attempts),
             last_two_fingerprints=last_two,
@@ -119,7 +119,7 @@ def _escalate_once(task: Task, *, reason: str) -> None:
     ).exists()
     if already:
         return
-    where = task.ticket.issue_url or f"ticket {task.ticket_id}"
+    where = task.ticket.issue_url or f"ticket {task.ticket.pk}"
     question = (
         f"{marker} Auto-retry halted on {where} (phase {normalize_phase(task.phase)!r}): {reason} "
         "Re-queueing is stopped so it does not retry a doomed failure forever. "

--- a/src/teatree/loop/transient_requeue.py
+++ b/src/teatree/loop/transient_requeue.py
@@ -1,0 +1,128 @@
+"""Bounded auto-requeue of transient-FAILED tasks — the retry, hard-bounded.
+
+``Task.fail()`` is terminal: a task that RETURNS a failure envelope (an outage,
+a provisioning-step failure, an incomplete run, a coder yield that landed no
+commit) lands FAILED and stays there forever — the crashed-session reclaim
+(``reclaim_orphaned_claims``) only rescues expired-lease CLAIMED rows, never a
+returned failure. This tick sweep reopens such a row (FAILED → PENDING) so the
+next dispatch resumes it.
+
+The retry is HARD-BOUNDED by the #2009 repair-loop budget so it can never retry
+endlessly (it would always fail): a ticket-phase at its iteration cap, or stalled
+on two consecutive identical failures, is NOT reopened and is escalated LOUDLY
+via a durable :class:`DeferredQuestion` (§17.1 invariant 9) — never silently,
+never forever. Only a TRANSIENT last-attempt failure is a candidate; a
+DETERMINISTIC failure (a test failure, an assertion, a schema/evidence refusal)
+stays terminal FAILED.
+
+Lives in ``teatree.loop`` (orchestration): it needs both the transient classifier
+(``teatree.agents``) and the ``Task`` model (``teatree.core.models``), which sit
+in the same ``domain`` layer and so cannot import each other — only an
+orchestration-layer module may compose both.
+"""
+
+import logging
+
+from teatree.agents.outage_classifier import is_transient_failure
+from teatree.core.modelkit.phases import normalize_phase
+from teatree.core.models import Task, Ticket
+from teatree.core.models.deferred_question import DeferredQuestion
+from teatree.core.models.task_repair import phase_attempts
+from teatree.core.repair_loop import IterationStalled, MaxIterationsExceeded, requeue_verdict
+
+logger = logging.getLogger(__name__)
+
+_ESCALATION_MARKER = "[repair-halt task={pk}]"
+
+
+def requeue_transient_failed() -> int:
+    """Reopen transient-FAILED tasks within the repair budget; escalate the rest. Returns the reopen count."""
+    reopened = 0
+    for task in _transient_failed_candidates():
+        halt = _budget_halt_reason(task)
+        if halt is None:
+            reopened += _reopen(task)
+        else:
+            _escalate_once(task, reason=halt)
+    return reopened
+
+
+def _transient_failed_candidates() -> list[Task]:
+    """FAILED tasks on a non-terminal ticket whose LATEST attempt is a transient failure."""
+    candidates: list[Task] = []
+    failed = (
+        Task.objects.filter(status=Task.Status.FAILED)
+        .exclude(ticket__state__in=Ticket._TERMINAL_STATES)  # noqa: SLF001 — the model's SSOT terminal set
+        .select_related("ticket")
+    )
+    for task in failed:
+        last = task.attempts.order_by("-pk").first()  # ty: ignore[unresolved-attribute]
+        if last is not None and is_transient_failure(last.error):
+            candidates.append(task)
+    return candidates
+
+
+def _budget_halt_reason(task: Task) -> str | None:
+    """Return the loud halt reason if *task*'s phase is out of budget, else ``None`` (may requeue).
+
+    Uses the pure :func:`~teatree.core.repair_loop.requeue_verdict` over the SAME
+    recorded attempts the reclaim path budgets on, WITHOUT the escalation side
+    effect of ``Task.check_requeue_allowed`` — this sweep escalates both the cap
+    AND the stall itself (idempotently), which that helper does only for the
+    stall.
+    """
+    attempts = phase_attempts(task)
+    last_two = [a.error_fingerprint for a in attempts[-2:] if a.error_fingerprint]
+    try:
+        requeue_verdict(
+            ticket_id=task.ticket_id,  # ty: ignore[unresolved-attribute]
+            phase=normalize_phase(task.phase),
+            iteration_count=len(attempts),
+            last_two_fingerprints=last_two,
+        )
+    except (MaxIterationsExceeded, IterationStalled) as exc:
+        return str(exc)
+    return None
+
+
+def _reopen(task: Task) -> int:
+    """CAS FAILED → PENDING; returns 1 on the winning transition, 0 if already moved.
+
+    A single conditional ``UPDATE ... WHERE status=FAILED`` (the same
+    backend-agnostic compare-and-swap ``reclaim_orphaned_claims`` uses) so a
+    concurrent tick that already reopened the row updates 0 rows and does not
+    double-dispatch.
+    """
+    return Task.objects.filter(pk=task.pk, status=Task.Status.FAILED).update(
+        status=Task.Status.PENDING,
+        claimed_at=None,
+        claimed_by="",
+        claimed_by_session="",
+        lease_expires_at=None,
+        heartbeat_at=None,
+    )
+
+
+def _escalate_once(task: Task, *, reason: str) -> None:
+    """Record a durable escalation for a budget-halted task, once per task.
+
+    Idempotent: a per-task marker in the question text dedups so a halted FAILED
+    row re-scanned every tick escalates exactly once rather than spamming the
+    away-mode question queue. Reuses the §17.1 invariant 9 surface (statusline /
+    ``t3 teatree questions list`` / the Slack DM drain).
+    """
+    marker = _ESCALATION_MARKER.format(pk=task.pk)
+    already = DeferredQuestion.objects.filter(
+        answered_at__isnull=True,
+        dismissed_at__isnull=True,
+        question__contains=marker,
+    ).exists()
+    if already:
+        return
+    where = task.ticket.issue_url or f"ticket {task.ticket_id}"
+    question = (
+        f"{marker} Auto-retry halted on {where} (phase {normalize_phase(task.phase)!r}): {reason} "
+        "Re-queueing is stopped so it does not retry a doomed failure forever. "
+        "How should it proceed — investigate, rework, or ignore?"
+    )
+    DeferredQuestion.record(question, session_id=str(task.session_id or ""))  # ty: ignore[unresolved-attribute]

--- a/tests/quality/deferred_import_pegs.toml
+++ b/tests/quality/deferred_import_pegs.toml
@@ -121,4 +121,9 @@
 "src/teatree/loop/scanners/slack_mentions.py" = 1
 "src/teatree/loop/sweep_on_demand.py" = 2
 "src/teatree/loop/tick_freshness.py" = 2
-"src/teatree/loop/tick_recovery.py" = 2
+# The tick-time transient auto-requeue (`from teatree.loop.transient_requeue import
+# requeue_transient_failed`) is deferred for the same reason as the sibling
+# `run_boot_sweeps` import beside it — loaded at tick time so importing
+# `tick_recovery` never pulls the Django-model-touching sweep into the loop
+# module-load path.
+"src/teatree/loop/tick_recovery.py" = 3

--- a/tests/teatree_agents/test_attempt_recorder.py
+++ b/tests/teatree_agents/test_attempt_recorder.py
@@ -1,5 +1,6 @@
 """Shared result-envelope recorder used by both dispatch backends."""
 
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -21,8 +22,10 @@ from teatree.core.models import (
     Task,
     TaskAttempt,
     Ticket,
+    Worktree,
 )
 from teatree.verification.url_check import UrlCheckResult, UrlCheckStatus
+from tests.teatree_core.models._shared import _init_repo_with_branch
 
 
 def _valid_sketch(**overrides: object) -> dict[str, object]:
@@ -133,6 +136,58 @@ class TestRecordResultEnvelope(TestCase):
         record_result_envelope(task, {"summary": "x", "bogus": True})
         task.refresh_from_db()
         assert task.status == Task.Status.FAILED
+
+
+class TestLandingVerifiedCompletion(TestCase):
+    """A coding result completes only when a commit actually landed (root-cause gate)."""
+
+    @pytest.fixture(autouse=True)
+    def _inject_tmp_path(self, tmp_path: Path) -> None:
+        self._tmp_path = tmp_path
+
+    def _claimed(self, *, phase: str = "coding") -> Task:
+        ticket = Ticket.objects.create(role=Ticket.Role.AUTHOR, state=Ticket.State.STARTED)
+        session = Session.objects.create(ticket=ticket, agent_id=phase)
+        task = Task.objects.create(ticket=ticket, session=session, phase=phase)
+        task.claim(claimed_by="loop-slot")
+        return task
+
+    def _attach_worktree(self, ticket: Ticket, *, commits_ahead: int) -> Path:
+        repo_dir = self._tmp_path / f"repo-{ticket.pk}"
+        branch = f"feature-{ticket.pk}"
+        _init_repo_with_branch(repo_dir, branch=branch, commits_ahead=commits_ahead)
+        Worktree.objects.create(
+            ticket=ticket,
+            repo_path=str(repo_dir),
+            branch=branch,
+            extra={"worktree_path": str(repo_dir)},
+        )
+        return repo_dir
+
+    def test_files_modified_without_commit_is_refused(self) -> None:
+        task = self._claimed()
+        self._attach_worktree(task.ticket, commits_ahead=0)
+        record_result_envelope(
+            task,
+            {"summary": "done", "files_modified": [{"path": "a.py", "action": "modified"}]},
+        )
+        task.refresh_from_db()
+        task.ticket.refresh_from_db()
+        latest = task.attempts.order_by("-pk").first()
+        assert task.status == Task.Status.FAILED
+        assert task.ticket.state == Ticket.State.STARTED  # FSM did NOT advance
+        assert latest is not None
+        assert latest.error.startswith("landing_unverified:")
+
+    def test_files_modified_with_real_commit_completes(self) -> None:
+        task = self._claimed()
+        self._attach_worktree(task.ticket, commits_ahead=1)
+        record_result_envelope(
+            task,
+            {"summary": "done", "files_modified": [{"path": "f0.txt", "action": "created"}]},
+        )
+        task.refresh_from_db()
+        assert task.status == Task.Status.COMPLETED
 
 
 class TestScanningNewsEnvelopeChannel(TestCase):

--- a/tests/teatree_agents/test_landing_verification.py
+++ b/tests/teatree_agents/test_landing_verification.py
@@ -1,0 +1,76 @@
+"""Landing verification for coding/debugging results (root-cause of the coder-yield stall).
+
+A coding/debugging task that claims ``files_modified`` but landed no commit — the
+coder spawned a background agent and yielded, or edited without committing — must
+NOT be recorded COMPLETED. The completion chokepoint re-reads the ticket
+worktree's git state and refuses with a ``landing_unverified`` failure unless a
+new commit actually exists (HEAD advanced past the base, worktree not
+dirty-uncommitted). When no materialised worktree is checkable, the gate
+fails open — "couldn't verify" is not "did not land".
+"""
+
+from pathlib import Path
+
+import pytest
+from django.test import TestCase
+
+from teatree.agents.landing_verification import landing_verification_error
+from teatree.core.models import Session, Task, Ticket, Worktree
+from tests.teatree_core.models._shared import _init_repo_with_branch
+
+
+class TestLandingVerification(TestCase):
+    @pytest.fixture(autouse=True)
+    def _inject_tmp_path(self, tmp_path: Path) -> None:
+        self._tmp_path = tmp_path
+
+    def _task(self, *, phase: str = "coding") -> Task:
+        ticket = Ticket.objects.create(role=Ticket.Role.AUTHOR, state=Ticket.State.STARTED)
+        session = Session.objects.create(ticket=ticket, agent_id=phase)
+        return Task.objects.create(ticket=ticket, session=session, phase=phase)
+
+    def _attach_worktree(self, ticket: Ticket, *, commits_ahead: int) -> Path:
+        repo_dir = self._tmp_path / f"repo-{ticket.pk}"
+        branch = f"feature-{ticket.pk}"
+        _init_repo_with_branch(repo_dir, branch=branch, commits_ahead=commits_ahead)
+        Worktree.objects.create(
+            ticket=ticket,
+            repo_path=str(repo_dir),
+            branch=branch,
+            extra={"worktree_path": str(repo_dir)},
+        )
+        return repo_dir
+
+    def test_commit_landed_and_clean_is_verified(self) -> None:
+        task = self._task()
+        self._attach_worktree(task.ticket, commits_ahead=1)
+        assert landing_verification_error(task) == ""
+
+    def test_no_new_commit_is_refused(self) -> None:
+        task = self._task()
+        self._attach_worktree(task.ticket, commits_ahead=0)
+        error = landing_verification_error(task)
+        assert error.startswith("landing_unverified:")
+        assert "commit" in error.lower()
+
+    def test_uncommitted_tracked_change_is_refused(self) -> None:
+        task = self._task()
+        repo_dir = self._attach_worktree(task.ticket, commits_ahead=1)
+        (repo_dir / "f0.txt").write_text("edited but not committed\n")
+        error = landing_verification_error(task)
+        assert error.startswith("landing_unverified:")
+        assert "uncommitted" in error.lower()
+
+    def test_debugging_phase_is_also_verified(self) -> None:
+        task = self._task(phase="debugging")
+        self._attach_worktree(task.ticket, commits_ahead=0)
+        assert landing_verification_error(task).startswith("landing_unverified:")
+
+    def test_non_coding_phase_is_skipped(self) -> None:
+        task = self._task(phase="reviewing")
+        self._attach_worktree(task.ticket, commits_ahead=0)
+        assert landing_verification_error(task) == ""
+
+    def test_no_worktree_fails_open(self) -> None:
+        task = self._task()
+        assert landing_verification_error(task) == ""

--- a/tests/teatree_agents/test_outage_classifier.py
+++ b/tests/teatree_agents/test_outage_classifier.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from teatree.agents.outage_classifier import is_outage_death
+from teatree.agents.outage_classifier import is_outage_death, is_transient_failure, transient_failure_signature
 
 
 @pytest.mark.parametrize(
@@ -53,3 +53,53 @@ def test_legit_completion_is_not_outage() -> None:
 
 def test_empty_result_is_not_outage() -> None:
     assert is_outage_death({}) is False
+
+
+class TestTransientFailureClassifier:
+    """The FAILED-attempt error-string classifier the bounded auto-requeue sweep consults.
+
+    A transient failure is an infrastructure interruption (outage envelope,
+    provisioning-step failure, an incomplete run that left no terminal
+    ResultMessage, a coder yield that landed no commit). A deterministic failure
+    (a test failure, an assertion, a real bug, a schema/evidence refusal) is NOT
+    transient and must stay terminal FAILED.
+    """
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            "outage_death: connection refused",
+            "provision_failed: db import returned 0 rows",
+            "result_error: no terminal ResultMessage — the run ended without completing",
+            "result_error: subtype=error_during_execution — api_error_status=529",
+            "landing_unverified: no new commit on the branch",
+            "Unable to connect to API",
+            "API Error: connection reset by peer",
+        ],
+    )
+    def test_transient_errors_are_classified_transient(self, error: str) -> None:
+        assert is_transient_failure(error) is True
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            "missing required evidence for phase 'coding': result must include one of [files_modified]",
+            "Agent result contains unexpected keys: bogus",
+            "review verdict recording refused: reviewer identity is a maker role",
+            "AssertionError: expected 3 got 4",
+            "test_widget_renders FAILED: ValueError",
+            "stuck_loop: turns ceiling exceeded",
+            "Added API Error handling and retries",
+            "",
+        ],
+    )
+    def test_deterministic_errors_are_not_transient(self, error: str) -> None:
+        assert is_transient_failure(error) is False
+
+    def test_signature_names_the_matched_class(self) -> None:
+        assert transient_failure_signature("outage_death: x").startswith("outage_death")
+        assert transient_failure_signature("landing_unverified: y").startswith("landing_unverified")
+        assert transient_failure_signature("AssertionError: nope") == ""
+
+    def test_classification_is_case_insensitive(self) -> None:
+        assert is_transient_failure("RESULT_ERROR: NO TERMINAL RESULTMESSAGE") is True

--- a/tests/teatree_loop/test_transient_requeue.py
+++ b/tests/teatree_loop/test_transient_requeue.py
@@ -1,0 +1,137 @@
+"""Bounded auto-requeue of transient-FAILED tasks — the retry, hard-bounded.
+
+A task that RETURNS a transient failure (an outage envelope, a provisioning-step
+failure, an incomplete run, a coder yield that landed no commit) lands terminal
+FAILED and, before this sweep, stayed there forever with no retry. The sweep
+reopens it (FAILED → PENDING) so the loop resumes — but ONLY within the #2009
+repair-loop budget: a phase at its iteration cap, or stalled on two identical
+failures, is NOT reopened and is escalated LOUDLY via a durable
+``DeferredQuestion``. A DETERMINISTIC failure (a test failure, an assertion) is
+never reopened. The hardest pin: it NEVER retries endlessly.
+"""
+
+from django.test import TestCase
+from django.utils import timezone
+
+from teatree.core.models import Session, Task, TaskAttempt, Ticket
+from teatree.core.models.deferred_question import DeferredQuestion
+from teatree.core.repair_loop import max_phase_iterations
+from teatree.loop.tick_recovery import _reap_stale_task_claims
+from teatree.loop.transient_requeue import requeue_transient_failed
+
+
+def _failed_task(*, phase: str = "coding", state: str = Ticket.State.STARTED) -> Task:
+    ticket = Ticket.objects.create(role=Ticket.Role.AUTHOR, state=state)
+    session = Session.objects.create(ticket=ticket, agent_id=phase)
+    return Task.objects.create(ticket=ticket, session=session, phase=phase, status=Task.Status.FAILED)
+
+
+def _add_failed_attempt(task: Task, *, error: str) -> None:
+    TaskAttempt.objects.create(
+        task=task,
+        execution_target=task.execution_target,
+        ended_at=timezone.now(),
+        exit_code=1,
+        error=error,
+    )
+    Task.objects.filter(pk=task.pk).update(status=Task.Status.FAILED)
+
+
+class TestTransientRequeue(TestCase):
+    def test_transient_failed_task_is_reopened_once(self) -> None:
+        task = _failed_task()
+        _add_failed_attempt(task, error="outage_death: connection refused")
+
+        reopened = requeue_transient_failed()
+
+        task.refresh_from_db()
+        assert reopened == 1
+        assert task.status == Task.Status.PENDING
+        # A second pass finds it PENDING (no longer FAILED) — no double reopen.
+        assert requeue_transient_failed() == 0
+
+    def test_deterministic_failed_task_is_not_reopened(self) -> None:
+        task = _failed_task()
+        _add_failed_attempt(task, error="AssertionError: expected 3 got 4")
+
+        assert requeue_transient_failed() == 0
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+
+    def test_failed_task_on_terminal_ticket_is_not_reopened(self) -> None:
+        task = _failed_task(state=Ticket.State.SHIPPED)
+        _add_failed_attempt(task, error="outage_death: connection refused")
+
+        assert requeue_transient_failed() == 0
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+
+    def test_identical_double_failure_is_escalated_not_reopened(self) -> None:
+        task = _failed_task()
+        _add_failed_attempt(task, error="result_error: no terminal ResultMessage")
+        _add_failed_attempt(task, error="result_error: no terminal ResultMessage")
+
+        reopened = requeue_transient_failed()
+
+        task.refresh_from_db()
+        assert reopened == 0
+        assert task.status == Task.Status.FAILED
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
+
+    def test_budget_exhausted_is_escalated_not_reopened(self) -> None:
+        cap = max_phase_iterations()
+        task = _failed_task()
+        # DISTINCT transient errors so no stall — the CAP is what stops it.
+        for i in range(cap):
+            _add_failed_attempt(task, error=f"result_error: attempt {'x' * (i + 1)} died")
+
+        reopened = requeue_transient_failed()
+
+        task.refresh_from_db()
+        assert reopened == 0
+        assert task.status == Task.Status.FAILED
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
+
+    def test_tick_recovery_reopens_transient_failed(self) -> None:
+        # The sweep is wired into the loop tick's recovery step, not just callable.
+        task = _failed_task()
+        _add_failed_attempt(task, error="outage_death: connection refused")
+
+        _reap_stale_task_claims()
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING
+
+    def test_bounded_never_retries_endlessly(self) -> None:
+        cap = max_phase_iterations()
+        task = _failed_task()
+        distinct_errors = [
+            "outage_death: alpha",
+            "result_error: beta gone",
+            "provision_failed: gamma missing",
+            "landing_unverified: delta uncommitted",
+            "outage_death: epsilon",
+            "result_error: zeta gone",
+            "provision_failed: eta missing",
+        ]
+        reopens = 0
+        for error in distinct_errors:
+            _add_failed_attempt(task, error=error)
+            reopens += requeue_transient_failed()
+            task.refresh_from_db()
+
+        # Reopens are bounded by the per-phase cap — never once per tick forever.
+        assert reopens == cap - 1
+        assert task.status == Task.Status.FAILED
+
+        # Escalated exactly once; re-running the sweep many more times never
+        # reopens again and never spams another escalation.
+        questions_after_exhaustion = DeferredQuestion.objects.filter(answered_at__isnull=True).count()
+        assert questions_after_exhaustion == 1
+        for _ in range(10):
+            assert requeue_transient_failed() == 0
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1


### PR DESCRIPTION
## Summary

Eliminates the #1 silent-bottleneck class: a headless task that **RETURNS** a
transient failure (outage / provision-fail / coder-yield) lands terminal
`FAILED` and stalls forever with no retry, and a coding task that "completes"
without actually committing advances the FSM over unlanded work.

`reclaim_orphaned_claims` only rescues expired-lease `CLAIMED` rows (a crashed
session) — never a task that returned a failure envelope. And
`PHASE_REQUIRED_EVIDENCE["coding"]=("files_modified",)` is **self-reported** — no
commit is verified.

This PR converts the whole silent-stall class into **retry-or-escalate**, with
the retry **hard-bounded** so it can never retry endlessly.

## Part A — bounded auto-requeue of transient-FAILED tasks (the retry, BOUNDED)

- `agents/outage_classifier.py` gains a pure error-string classifier
  `is_transient_failure` / `transient_failure_signature`: an **outage envelope**
  (`outage_death:` / raw connection phrase), a **provisioning-step failure**
  (`provision_failed:`), an **incomplete run** (`result_error:`, incl. *no
  terminal ResultMessage*), and a **coder yield** (`landing_unverified:`, Part B)
  are transient; a **deterministic** failure (a test failure, an assertion, a
  schema/evidence/verdict refusal, a `stuck_loop` runaway) is not, and is never
  retried.
- New `loop/transient_requeue.py` sweep reopens a transient-`FAILED` task
  (`FAILED → PENDING` via a status compare-and-swap), **hard-bounded by the
  #2009 repair-loop budget**: a ticket-phase at its iteration cap **or** stalled
  on two consecutive identical failures is **NOT** reopened and is escalated
  **LOUDLY** via a durable `DeferredQuestion` (§17.1 invariant 9), idempotent per
  task so a halted row never spams. It can never retry endlessly.
- Wired into the loop tick recovery beside `run_boot_sweeps`. The sweep composes
  the `agents` classifier with the `core` model, so it lives in the `loop`
  (orchestration) layer — `core.models → agents` would be a same-layer backwards
  edge.

## Part B — root cause: verify a coding task actually landed a commit (the fix)

- `record_result_envelope` re-reads the ticket worktree's git state for the
  `coding`/`debugging` phases and refuses completion with `landing_unverified`
  unless a **new commit actually exists** (HEAD advanced past the base, worktree
  not dirty-uncommitted). Reuses `ticket_worktree_checks.worktree_has_commits_ahead`
  / `worktree_tracked_dirty_path`. No checkable worktree → fail-open ("couldn't
  verify" is not "did not land").
- This turns a silent yield-without-landing into a real `FAILED` that Part A then
  retries-if-transient / escalates, instead of a stall.

## Tests

- `test_outage_classifier` — transient vs deterministic error strings.
- `test_transient_requeue` — requeue-once, deterministic-not-requeued,
  terminal-ticket-skipped, identical-double → escalated, budget-exhausted →
  escalated, tick-recovery wiring, and the hardest pin: **bounded, NEVER retries
  endlessly** (proven anti-vacuous — without the budget bound it reopens every
  tick forever).
- `test_landing_verification` + `test_attempt_recorder` — no-commit →
  `landing_unverified`, real commit → accepted, dirty-worktree refused,
  debugging covered, no-worktree fails open.

`bash dev/ci-parity-fast.sh` green; `ruff` + `uv run tach check` clean;
`t3 tool test-path-mirror` ledger exact.

## Architecture pre-check — fix/no-silent-stall

**1. BLUEPRINT § alignment** — §5.6 Loop Topology / §17.4 orchestrator-decides,
loop-executes / repair-loop #2009. Extends the boot/tick recovery sweeps with a
fourth budget-bounded sweep and the completion chokepoint with a landing gate. No
new FSM state.

**2. FSM phase boundaries** — Task `FAILED → PENDING` (existing `Task.reopen`
semantics) via a CAS UPDATE; no `Ticket.State` transition added. The landing gate
keeps a coding/debugging task `FAILED` instead of `COMPLETED`, so the ticket FSM
does NOT advance over unlanded work.

**3. Extension-point contracts** — no `OverlayBase` / scanner-registry / Protocol
change. Reuses `outage_classifier`, `repair_loop.requeue_verdict`, and
`ticket_worktree_checks`.

**4. Component boundaries** — pure classifier in `agents/outage_classifier.py`;
`agents/landing_verification.py` (leaf); `loop/transient_requeue.py`
(orchestration sweep). `core/worktree/recovery_sweeps.py` cannot import `agents`
(same-layer edge), so the transient sweep lives in `loop` and is called from
`loop/tick_recovery`.

**5. Dependency direction** — `core.models → agents` is a same-layer (domain)
backwards edge → forbidden; the sweep lives in `teatree.loop` (orchestration)
which may import both. New intra-loop deferred import pegged in
`deferred_import_pegs.toml`. `uv run tach check` passes.

**6. Test surface** — see Tests above; the never-endless bound and
`landing_unverified` are the load-bearing pins.

**7. Resilience invariants** — verify-by-re-read (landing gate re-reads git; sweep
re-checks `status=FAILED` in the CAS); fallback-transport (escalation via durable
`DeferredQuestion`); idempotency (reopen CAS + escalate-once dedup marker);
heartbeat n/a (per-tick sweep); sub-agent return contract unchanged.

**8. Identity and key normalization** — phase tokens normalized via
`normalize_phase` at every boundary (`coding`/`debugging`).

**9. Behavior preservation / capability deletion** — purely additive. `Task.fail`
stays terminal; the sweep is a NEW reopen path bounded by the existing #2009
budget. The landing gate only ADDS a refusal for coding/debugging **with a
checkable worktree**; no worktree → fail-open (existing recorder tests
unchanged). No must-block test inverted.

**10. Removability / harness-vs-data** — removable: delete the sweep call in
`tick_recovery` + the landing gate line in the recorder → reverts to prior
behavior, no cascade. The cap is already a setting (`MAX_PHASE_ITERATIONS`); the
transient classifier is fixed harness policy.

## Open questions & assumptions

- **Assumption:** the `landing_unverified` gate fails **open** when no on-disk
  worktree is checkable — in production a coding task always has a materialised
  worktree; a headless run with no checkout genuinely cannot be verified. This
  preserves every existing recorder test (no-worktree tickets still complete).
- **Assumption:** "HEAD advanced past the base" is measured as commits ahead of
  the worktree's base branch (merge-base / `origin/<default>`), reusing the
  existing `worktree_has_commits_ahead` helper. In a repair re-run where a prior
  cycle already committed, the branch legitimately has a landed commit, so the
  gate passes — the budget (Part A) bounds re-runs regardless.
- **Assumption:** the `provision_failed:` transient marker is the canonical
  prefix a provisioning-step failure carries; the classifier recognizes it as the
  policy half. Outage / incomplete-run / coder-yield are wired end-to-end today.
- **SUBSTRATE-adjacent** (core loop + completion chokepoint) — held for owner
  sign-off, as expected.

## Not merging

Opened for review; not merged.
