### PR TITLE
fix(loop): repo-scope issue-implementer intake to owned repos (firehose + cross-repo claim hole)

### DIFF
--- a/src/teatree/backends/github/client.py
+++ b/src/teatree/backends/github/client.py
@@ -236,14 +236,14 @@ class GitHubCodeHost:  # noqa: PLR0904 — method count reflects the CodeHostBac
         query = quote_plus(f"is:issue is:open assignee:{assignee}")
         return _gh_api_search_paginated(f"search/issues?q={query}&per_page=100", token=self._token)
 
-    def list_authored_issues(self, *, author: str) -> list[RawAPIDict]:
-        """Open issues *author* FILED — the issue-implementer's trusted-author intake query (#3235).
+    def list_authored_issues(self, *, author: str, repo_slugs: tuple[str, ...] = ()) -> list[RawAPIDict]:
+        """Open issues *author* FILED — the trusted-author intake query (#3235).
 
-        Distinct from :meth:`list_assigned_issues`: intake is decided by who WROTE
-        the issue, not by who it landed on, so the factory can pick up an untriaged,
-        unassigned, unlabelled issue the moment a trusted human files it.
+        *repo_slugs* AND OR-ed ``repo:owner/name`` qualifiers in, scoping intake to the
+        factory's own repos; empty keeps GitHub's cross-repo author search (the pre-scope
+        firehose + cross-repo claim hole this closes — see the commit body).
         """
-        query = quote_plus(f"is:issue is:open author:{author}")
+        query = quote_plus(f"is:issue is:open author:{author}" + "".join(f" repo:{s}" for s in repo_slugs))
         return _gh_api_search_paginated(f"search/issues?q={query}&per_page=100", token=self._token)
 
     def create_issue(

--- a/src/teatree/backends/gitlab/api.py
+++ b/src/teatree/backends/gitlab/api.py
@@ -131,24 +131,29 @@ class GitLabAPI(GitLabHTTPClient):
         *,
         per_page: int = 100,
         updated_after: str | None = None,
+        project_slugs: tuple[str, ...] = (),
     ) -> list[RawMR]:
-        """Fetch all open issues (and work items) AUTHORED by *author* across accessible projects.
+        """Fetch all open issues (and work items) AUTHORED by *author*.
 
         The author-scoped sibling of :meth:`list_open_issues_for_assignee`, backing the
         issue-implementer's trusted-author intake (#3235): ``author_username``, never
         ``assignee_username`` — a trusted human's issue is actionable the moment they
         file it, with no triage, assignment, or label.
+
+        *project_slugs* scopes the query to each named project's issues endpoint (the
+        repos the factory owns); empty keeps the global ``scope=all`` search — matching
+        the pre-scope behaviour, which returns issues from every accessible project and
+        so admits a cross-repo intake the factory must not implement.
         """
-        query: dict[str, str | int] = {
-            "state": "opened",
-            "author_username": author,
-            "scope": "all",
-            "per_page": per_page,
-        }
+        base: dict[str, str | int] = {"state": "opened", "author_username": author, "per_page": per_page}
         if updated_after:
-            query["updated_after"] = updated_after
-        params = urlencode(query)
-        return self.get_json_paginated(f"issues?{params}")
+            base["updated_after"] = updated_after
+        if not project_slugs:
+            return self.get_json_paginated(f"issues?{urlencode({**base, 'scope': 'all'})}")
+        issues: list[RawMR] = []
+        for slug in project_slugs:
+            issues.extend(self.get_json_paginated(f"projects/{slug.replace('/', '%2F')}/issues?{urlencode(base)}"))
+        return issues
 
     def list_open_mrs_as_reviewer(
         self,

--- a/src/teatree/backends/gitlab/client.py
+++ b/src/teatree/backends/gitlab/client.py
@@ -179,9 +179,9 @@ class GitLabCodeHost:  # noqa: PLR0904 — method count reflects the CodeHostBac
     def list_assigned_issues(self, *, assignee: str) -> list[RawAPIDict]:
         return self._client.list_open_issues_for_assignee(assignee)
 
-    def list_authored_issues(self, *, author: str) -> list[RawAPIDict]:
-        """Open issues *author* FILED — the issue-implementer's trusted-author intake query (#3235)."""
-        return self._client.list_open_issues_for_author(author)
+    def list_authored_issues(self, *, author: str, repo_slugs: tuple[str, ...] = ()) -> list[RawAPIDict]:
+        """Open issues *author* FILED, scoped to *repo_slugs* (empty = global) — intake query (#3235)."""
+        return self._client.list_open_issues_for_author(author, project_slugs=repo_slugs)
 
     def list_prs(self, *, repo: str, state: str = "", author: str = "") -> list[RawAPIDict]:
         return _pr_reads.list_project_prs(self._client, self._resolve_project(repo), state=state, author=author)

--- a/src/teatree/core/backend_protocols.py
+++ b/src/teatree/core/backend_protocols.py
@@ -272,7 +272,12 @@ class CodeHostBackend(Protocol):
 
     def list_assigned_issues(self, *, assignee: str) -> list[RawAPIDict]: ...  # pragma: no branch
 
-    def list_authored_issues(self, *, author: str) -> list[RawAPIDict]: ...  # pragma: no branch
+    def list_authored_issues(
+        self,
+        *,
+        author: str,
+        repo_slugs: tuple[str, ...] = (),
+    ) -> list[RawAPIDict]: ...  # pragma: no branch
 
     def create_issue(
         self,

--- a/src/teatree/loop/scanner_factories.py
+++ b/src/teatree/loop/scanner_factories.py
@@ -18,6 +18,7 @@ from teatree.config import (
     get_effective_settings,
 )
 from teatree.core.backend_factory import OverlayBackends
+from teatree.core.merge import normalize_repo_slug
 from teatree.core.models import ImplementedIssueMarker
 from teatree.core.worktree.clone_paths import find_clone_path
 from teatree.loop.job_identity import _TUPLE_PAIR
@@ -45,6 +46,8 @@ from teatree.loop.substrate_pinger import NotifyWithFallbackSubstratePinger
 if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
+
+    from teatree.core.overlay import OverlayBase
 
 logger = logging.getLogger(__name__)
 
@@ -301,6 +304,24 @@ def _architectural_review_scanner_for(backend: OverlayBackends) -> Architectural
     )
 
 
+def _owned_repo_slugs(overlay: "OverlayBase | None") -> tuple[str, ...]:
+    """The ``owner/name`` slugs of the repos this overlay works in — the intake scope.
+
+    Unions the overlay's followup repos (where the factory files and picks up issues)
+    with its declared merge-candidate working repos (e.g. an ``e2e`` companion), each
+    normalized up to ``owner/repo``. An overlay with no repo declarations (or none at
+    all) yields ``()`` — the scanner then keeps the pre-scope global author search.
+    """
+    if overlay is None:
+        return ()
+    slugs: list[str] = []
+    for value in (*overlay.review.merge_candidate_repo_slugs(), *overlay.metadata.get_followup_repos()):
+        slug = normalize_repo_slug(value)
+        if slug and slug not in slugs:
+            slugs.append(slug)
+    return tuple(slugs)
+
+
 def _issue_implementer_scanner_for(backend: OverlayBackends) -> IssueImplementerScanner | None:
     """Build a per-overlay issue-implementer scanner behind the triple gate (#1553, #3235).
 
@@ -369,6 +390,7 @@ def _issue_implementer_scanner_for(backend: OverlayBackends) -> IssueImplementer
         trusted_authors=tuple(sorted(effective_trusted_issue_authors(settings))),
         require_label=settings.issue_implementer_require_label,
         identities=backend.identities,
+        repo_slugs=_owned_repo_slugs(backend.overlay),
         can_claim=can_claim,
     )
 

--- a/src/teatree/loop/scanners/issue_implementer.py
+++ b/src/teatree/loop/scanners/issue_implementer.py
@@ -193,6 +193,11 @@ class IssueImplementerScanner:
     trusted_authors: tuple[str, ...] = field(default_factory=tuple)
     require_label: bool = False
     identities: tuple[str, ...] = field(default_factory=tuple)
+    #: The overlay's OWN repo slugs (``owner/name``). Every author query is scoped to
+    #: them, so a trusted human's issue on a repo the factory does not own is never
+    #: fetched — closing both the cross-repo firehose and the cross-repo claim hole.
+    #: Empty keeps the pre-scope global author search (back-compat).
+    repo_slugs: tuple[str, ...] = field(default_factory=tuple)
     name: str = "issue_implementer"
     readback_enabled: bool = True
     #: When False (budget full, or require_label with no label) this tick only
@@ -340,15 +345,23 @@ class IssueImplementerScanner:
     def _collect_unique_issues(self, trusted: frozenset[str]) -> list[RawAPIDict]:
         """Union each TRUSTED author's open issues, deduped by URL.
 
-        Author-scoped by construction: the forge is asked ONLY about the humans in the
-        trusted union, so a stranger's issue is not merely rejected downstream — it is
-        never fetched at all. Sorted so the query fan-out (and hence the claim order
-        under a tight concurrency budget) is deterministic across ticks.
+        Author- AND repo-scoped by construction: the forge is asked ONLY about the humans
+        in the trusted union, each query bound to :attr:`repo_slugs` (the overlay's own
+        repos), so a stranger's issue — and a trusted human's issue on a repo the factory
+        does not own — is never fetched at all. An app handle (``app/github-actions``, any
+        ``/``-containing handle) is skipped outright: it can never author a real intake, so
+        its query is pure waste (and, unscoped, the 1000-result cross-repo firehose). Sorted
+        so the query fan-out (and hence the claim order under a tight concurrency budget) is
+        deterministic across ticks.
         """
         seen_urls: set[str] = set()
         issues: list[RawAPIDict] = []
         for author in sorted(trusted):
-            for issue in self.host.list_authored_issues(author=author):
+            # An app handle (``app/github-actions``) can never author a real intake —
+            # its ``author:`` query is pure waste (and, unscoped, a firehose). Skip it.
+            if "/" in author:
+                continue
+            for issue in self.host.list_authored_issues(author=author, repo_slugs=self.repo_slugs):
                 url = _issue_url(issue)
                 if url and url in seen_urls:
                     continue

--- a/tests/quality/test_chokepoints.py
+++ b/tests/quality/test_chokepoints.py
@@ -251,6 +251,7 @@ _NON_CONTENT_PARAMS = frozenset(
         "self",
         "issue_url",
         "repo",
+        "repo_slugs",
         "parent_url",
         "comment_id",
         "slug",

--- a/tests/teatree_backends/test_code_host_protocol_coverage.py
+++ b/tests/teatree_backends/test_code_host_protocol_coverage.py
@@ -152,6 +152,7 @@ _ISSUE_SCOPED_READ_SIGNATURES: dict[str, list[tuple[str, inspect._ParameterKind]
     ],
     "list_authored_issues": [
         ("author", inspect.Parameter.KEYWORD_ONLY),
+        ("repo_slugs", inspect.Parameter.KEYWORD_ONLY),
     ],
 }
 

--- a/tests/teatree_backends/test_gitlab_code_host.py
+++ b/tests/teatree_backends/test_gitlab_code_host.py
@@ -272,7 +272,20 @@ def test_list_authored_issues_delegates_to_client() -> None:
     result = host.list_authored_issues(author="trusted-colleague")
 
     assert result == [{"iid": 4, "title": "Issue 4"}]
-    client.list_open_issues_for_author.assert_called_once_with("trusted-colleague")
+    client.list_open_issues_for_author.assert_called_once_with("trusted-colleague", project_slugs=())
+
+
+def test_list_authored_issues_scopes_to_project_slugs() -> None:
+    """repo_slugs plumb through to the client as ``project_slugs`` — the cross-repo firehose fix."""
+    client = MagicMock(spec=GitLabAPI)
+    client.list_open_issues_for_author.return_value = []
+    host = GitLabCodeHost(client=client)
+
+    host.list_authored_issues(author="trusted-colleague", repo_slugs=("org/repo", "org/other"))
+
+    client.list_open_issues_for_author.assert_called_once_with(
+        "trusted-colleague", project_slugs=("org/repo", "org/other")
+    )
 
 
 def test_post_pr_comment_returns_error_when_project_not_resolved() -> None:

--- a/tests/teatree_backends/test_protocols.py
+++ b/tests/teatree_backends/test_protocols.py
@@ -147,8 +147,8 @@ class _FakeCodeHost:
         _ = assignee
         return []
 
-    def list_authored_issues(self, *, author: str) -> list[dict[str, object]]:
-        _ = author
+    def list_authored_issues(self, *, author: str, repo_slugs: tuple[str, ...] = ()) -> list[dict[str, object]]:
+        _ = author, repo_slugs
         return []
 
     def create_issue(

--- a/tests/teatree_loop/test_issue_implementer_scanner.py
+++ b/tests/teatree_loop/test_issue_implementer_scanner.py
@@ -41,13 +41,21 @@ class _Host:
     merged_prs: list[RawAPIDict] = field(default_factory=list)
     #: Every author handle the scanner asked the forge about — the intake surface.
     queried_authors: list[str] = field(default_factory=list)
+    #: The ``repo_slugs`` passed with each query — the repo-scope surface.
+    queried_repo_slugs: list[tuple[str, ...]] = field(default_factory=list)
 
     def current_user(self) -> str:
         return self.user
 
-    def list_authored_issues(self, *, author: str) -> list[RawAPIDict]:
+    def list_authored_issues(self, *, author: str, repo_slugs: tuple[str, ...] = ()) -> list[RawAPIDict]:
         self.queried_authors.append(author)
-        return list(self.authored.get(author, []))
+        self.queried_repo_slugs.append(repo_slugs)
+        issues = list(self.authored.get(author, []))
+        # Model the forge's ``repo:`` qualifier: a scoped query returns only issues
+        # whose repo slug is in the requested set (an unscoped query returns all).
+        if repo_slugs:
+            issues = [issue for issue in issues if _issue_repo_slug(issue) in repo_slugs]
+        return issues
 
     def list_my_prs(self, *, author: str) -> list[RawAPIDict]:
         _ = author
@@ -61,6 +69,12 @@ class _Host:
 def _issue(url: str, *, author: str, labels: list[str] | None = None, state: str = "open") -> RawAPIDict:
     """A GitHub-shaped issue payload (``user.login`` is the author)."""
     return {"web_url": url, "title": "do it", "labels": labels or [], "state": state, "user": {"login": author}}
+
+
+def _issue_repo_slug(issue: RawAPIDict) -> str:
+    """``owner/repo`` parsed from a GitHub issue web URL (``.../owner/repo/issues/N``)."""
+    parts = str(issue.get("web_url", "")).split("/")
+    return "/".join(parts[3:5]) if len(parts) >= 6 else ""
 
 
 class _PublicRepoTestCase(TestCase):
@@ -429,3 +443,53 @@ class IssueImplementerReadbackTests(_PublicRepoTestCase):
         signals = self._scanner(host, readback_enabled=False).scan()
 
         assert [s.payload["url"] for s in signals] == [self.URL_A]
+
+
+class IssueImplementerRepoScopeTests(_PublicRepoTestCase):
+    """Repo-scoped intake — app handles skipped, cross-repo issues refused (the firehose fix).
+
+    Two failures the pre-fix scanner had: (1) it queried EVERY trusted handle,
+    including the ``app/github-actions`` CI-bot row, whose ``author:`` search
+    returns a 1000-result firehose of bot issues from all of GitHub; (2) it never
+    scoped the query to the overlay's own repos, so a trusted human's issue filed
+    on SOMEONE ELSE's public repo passed the author gate and got claimed — a
+    cross-repo safety hole, not just noise.
+    """
+
+    OVERLAY_REPO = "souliane/teatree"
+    FOREIGN_URL = "https://github.com/stranger/other-repo/issues/7"
+
+    def test_app_handle_is_never_queried(self) -> None:
+        """A ``/``-containing handle (app/github-actions) can't author issues — skipped, no wasted query."""
+        TrustedIdentity.objects.create(platform=TrustedIdentity.Platform.GITHUB, handle="app/github-actions")
+        host = _Host(authored={OWNER: [_issue(self.URL_A, author=OWNER)]})
+
+        self._scanner(host, repo_slugs=(self.OVERLAY_REPO,)).scan()
+
+        assert not any("/" in handle for handle in host.queried_authors)
+
+    def test_repo_slugs_are_plumbed_into_every_query(self) -> None:
+        host = _Host(authored={OWNER: [_issue(self.URL_A, author=OWNER)]})
+
+        self._scanner(host, repo_slugs=(self.OVERLAY_REPO,)).scan()
+
+        assert host.queried_repo_slugs
+        assert all(slugs == (self.OVERLAY_REPO,) for slugs in host.queried_repo_slugs)
+
+    def test_trusted_author_issue_on_foreign_repo_is_not_claimed(self) -> None:
+        """The cross-repo SAFETY pin: an owner issue on someone else's repo is never claimed."""
+        host = _Host(authored={OWNER: [_issue(self.FOREIGN_URL, author=OWNER)]})
+
+        signals = self._scanner(host, repo_slugs=(self.OVERLAY_REPO,)).scan()
+
+        assert signals == []
+        assert not ImplementedIssueMarker.objects.filter(issue_url=self.FOREIGN_URL).exists()
+
+    def test_trusted_author_issue_on_own_repo_is_still_claimed(self) -> None:
+        """Regression: an owner issue on the overlay's OWN repo is claimed as before."""
+        host = _Host(authored={OWNER: [_issue(self.URL_A, author=OWNER)]})
+
+        signals = self._scanner(host, repo_slugs=(self.OVERLAY_REPO,)).scan()
+
+        assert [s.payload["url"] for s in signals] == [self.URL_A]
+        assert ImplementedIssueMarker.objects.filter(issue_url=self.URL_A, overlay=self.OVERLAY).exists()

--- a/tests/teatree_loop/test_issue_implementer_wiring.py
+++ b/tests/teatree_loop/test_issue_implementer_wiring.py
@@ -37,14 +37,23 @@ from tests.factories import ImplementedIssueMarkerFactory
 _PATCH_TARGET = "teatree.loop.scanner_factories._effective_settings_for_overlay"
 
 
-def _backend(name: str = "acme") -> OverlayBackends:
+def _backend(name: str = "acme", overlay: object = None) -> OverlayBackends:
     return OverlayBackends(
         name=name,
         hosts=(MagicMock(spec=CodeHostBackend),),
         messaging=None,
         ready_labels=(),
         identities=("alice",),
+        overlay=overlay,
     )
+
+
+def _overlay_with_repos(*, followup: list[str], merge_candidates: list[str] | None = None) -> MagicMock:
+    """A minimal overlay stub exposing the repo-slug hooks the factory resolves."""
+    overlay = MagicMock()
+    overlay.metadata.get_followup_repos.return_value = followup
+    overlay.review.merge_candidate_repo_slugs.return_value = merge_candidates or []
+    return overlay
 
 
 def _authored_host(*urls: str, author: str = "alice") -> CodeHostBackend:
@@ -104,6 +113,21 @@ class IssueImplementerGateTests(TestCase):
             scanner = _issue_implementer_scanner_for(_backend())
         assert isinstance(scanner, IssueImplementerScanner)
         assert set(scanner.trusted_authors) == {"souliane", "trusted-colleague"}
+
+    def test_owned_repo_slugs_are_resolved_from_the_overlay(self) -> None:
+        """The builder scopes intake to the overlay's own repos — the cross-repo firehose fix."""
+        overlay = _overlay_with_repos(followup=["souliane/teatree"], merge_candidates=["souliane/teatree-e2e"])
+        with patch(_PATCH_TARGET, return_value=_enabled()):
+            scanner = _issue_implementer_scanner_for(_backend(overlay=overlay))
+        assert isinstance(scanner, IssueImplementerScanner)
+        assert set(scanner.repo_slugs) == {"souliane/teatree", "souliane/teatree-e2e"}
+
+    def test_no_overlay_leaves_repo_slugs_empty(self) -> None:
+        """A backend with no overlay keeps intake unscoped (back-compat, no crash)."""
+        with patch(_PATCH_TARGET, return_value=_enabled()):
+            scanner = _issue_implementer_scanner_for(_backend())
+        assert isinstance(scanner, IssueImplementerScanner)
+        assert scanner.repo_slugs == ()
 
     def test_require_label_flag_is_plumbed_to_the_scanner(self) -> None:
         with patch(

--- a/tests/teatree_loop/test_per_item_fault_isolation_1597.py
+++ b/tests/teatree_loop/test_per_item_fault_isolation_1597.py
@@ -670,8 +670,8 @@ class _ImplementerHost:
     def current_user(self) -> str:
         return self.user
 
-    def list_authored_issues(self, *, author: str) -> list[RawAPIDict]:
-        _ = author
+    def list_authored_issues(self, *, author: str, repo_slugs: tuple[str, ...] = ()) -> list[RawAPIDict]:
+        _ = author, repo_slugs
         return self.issues
 
     def list_my_prs(self, *, author: str, updated_after: str | None = None) -> list[RawAPIDict]:

--- a/tests/test_github_backend.py
+++ b/tests/test_github_backend.py
@@ -697,6 +697,27 @@ class TestGitHubCodeHost:
             token="tok",
         )
 
+    def test_list_authored_issues_scopes_search_to_repo_slugs(self) -> None:
+        """repo_slugs AND OR-ed ``repo:owner/name`` qualifiers into the search — the cross-repo firehose fix."""
+        with patch.object(github_mod, "_gh_api_search_paginated", return_value=[]) as mock_search:
+            host = GitHubCodeHost(token="tok")
+            host.list_authored_issues(
+                author="souliane",
+                repo_slugs=("souliane/teatree", "souliane/other"),
+            )
+        query = mock_search.call_args.args[0]
+        assert "repo%3Asouliane%2Fteatree" in query
+        assert "repo%3Asouliane%2Fother" in query
+        assert "author%3Asouliane" in query
+
+    def test_list_authored_issues_without_repo_slugs_is_unscoped(self) -> None:
+        """Empty repo_slugs keeps today's global author query (back-compat)."""
+        with patch.object(github_mod, "_gh_api_search_paginated", return_value=[]) as mock_search:
+            host = GitHubCodeHost(token="tok")
+            host.list_authored_issues(author="souliane")
+        query = mock_search.call_args.args[0]
+        assert "repo%3A" not in query
+
     def test_list_authored_issues_returns_empty_when_no_results(self) -> None:
         with patch.object(github_mod, "_gh_api_search_paginated", return_value=[]):
             host = GitHubCodeHost()

--- a/tests/utils/test_gitlab_api_queries.py
+++ b/tests/utils/test_gitlab_api_queries.py
@@ -246,6 +246,26 @@ def test_list_open_issues_for_author_returns_empty_on_no_pages(monkeypatch: pyte
     assert client.list_open_issues_for_author("trusted-colleague") == []
 
 
+def test_list_open_issues_for_author_scopes_to_projects(monkeypatch: pytest.MonkeyPatch) -> None:
+    """project_slugs query each project's issues endpoint — the cross-repo firehose fix."""
+    client = gitlab_api.GitLabAPI(token="test-token")
+    captured_endpoints: list[str] = []
+
+    def _capture(endpoint: str) -> list[dict[str, object]]:
+        captured_endpoints.append(endpoint)
+        return [{"iid": len(captured_endpoints)}]
+
+    monkeypatch.setattr(client, "get_json_paginated", _capture)
+
+    result = client.list_open_issues_for_author("trusted-colleague", project_slugs=("org/repo", "org/other"))
+
+    assert result == [{"iid": 1}, {"iid": 2}]
+    assert captured_endpoints[0].startswith("projects/org%2Frepo/issues?")
+    assert captured_endpoints[1].startswith("projects/org%2Fother/issues?")
+    assert "author_username=trusted-colleague" in captured_endpoints[0]
+    assert "state=opened" in captured_endpoints[0]
+
+
 def test_list_recently_merged_mrs_returns_data(monkeypatch: pytest.MonkeyPatch) -> None:
     client = gitlab_api.GitLabAPI(token="test-token")
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

The issue-implementer intake had two coupled defects rooted in the trusted-author
fan-out:

1. **Intake firehose.** The scanner's trusted set unions config `{souliane,
   adrien-oper}` with the DB `TrustedIdentity` tier, which includes an
   `app/github-actions` row (the CI-bot merge-keystone trust path). The scanner
   then ran one forge query per handle. `list_authored_issues(author="app/github-actions")`
   issued the GitHub search `is:issue is:open author:app/github-actions`, returning
   the 1000-result cap of `github-actions[bot]` issues from **all of GitHub**. That
   query can also never match a real intake (issue payload author is
   `github-actions[bot]`), so it was pure waste on top of being a firehose.

2. **Cross-repo claim safety hole.** The backend query `is:issue is:open
   author:{author}` had **no `repo:` scoping**. An issue a trusted human filed on
   *someone else's* public repo passed the author gate and got claimed — the
   factory would implement an issue in a repo it does not own.

Both are closed by repo-scoping the intake query to the overlay's own repos and
skipping app-style (`/`-containing) handles.

## Changes

- `CodeHostBackend` Protocol + both backends gain `list_authored_issues(*, author,
  repo_slugs: tuple[str, ...] = ())`. Empty `repo_slugs` keeps today's behaviour
  (back-compat).
  - **GitHub**: OR-es `repo:owner/name` qualifiers into the search string.
  - **GitLab**: queries each project's issues endpoint (`projects/{slug}/issues`)
    when scoped; keeps the global `scope=all` search when unscoped.
- `_issue_implementer_scanner_for` resolves the overlay's owned repo slugs (union
  of `review.merge_candidate_repo_slugs()` + `metadata.get_followup_repos()`,
  each normalized to `owner/repo`) and passes them to the scanner, threaded through
  `_collect_unique_issues` so every `list_authored_issues` call is repo-scoped.
- `_collect_unique_issues` skips any trusted handle containing `/` — an app handle
  can't author an issue, so its query is elided entirely (belt-and-braces against
  trust-tier growth).

The `app/github-actions` `TrustedIdentity` row is untouched — it remains the
merge-keystone CI-bot trust path; this change only stops the intake loop from
querying it.

## Tests

- GitHub client: `list_authored_issues(author, repo_slugs=(...))` builds a search
  containing the URL-encoded `repo:` qualifiers; empty `repo_slugs` → no `repo:`
  qualifier (back-compat).
- GitLab client + api: `repo_slugs` plumb through as `project_slugs`, which query
  per-project endpoints.
- Scanner (recording fake host modelling the forge's `repo:` filter): a
  `/`-containing handle is never queried; a trusted-author issue on a repo NOT in
  the overlay's slugs is **not** claimed (the cross-repo safety pin); a
  trusted-author issue on the overlay's own repo is still claimed (regression).
- Factory: owned repo slugs are resolved from the overlay; a backend with no
  overlay keeps intake unscoped.

The cross-repo safety test and the repo-scope tests were observed RED before the
fix (the safety test emits a claim signal for the foreign-repo issue on the
unscoped code path).

## Architecture pre-check — intake-repo-scope

### 1. BLUEPRINT § alignment
§5.6 Loop Topology / the issue-implementer intake path (#3235). Intake stays
author-gated; this narrows the *fetch* surface to owned repos — it does not
loosen any gate.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition changes.

### 3. Extension-point contracts
`CodeHostBackend` Protocol method signature changed. Consumers: `GitHubCodeHost`,
`GitLabCodeHost` (both updated), the `IssueImplementerScanner` caller, and the
protocol-coverage + protocol-conformance contract tests (updated). New overlay
hooks consumed read-only: `OverlayReview.merge_candidate_repo_slugs()` and
`OverlayMetadata.get_followup_repos()` (both already exist; no new hook added).

### 4. Component boundaries
Backend query lives in `teatree.backends.{github,gitlab}`; scanning/scoping logic
in `teatree.loop.scanners` + `teatree.loop.scanner_factories`; the Protocol in
`teatree.core`. No straddling.

### 5. Dependency direction
`scanner_factories` adds `from teatree.core.merge import normalize_repo_slug`
(`teatree.loop` → `teatree.core`, an allowed edge). `uv run tach check`: all
modules validated.

### 6. Test surface
Each behaviour has a named assertion: GitHub `repo:` qualifier presence/absence,
GitLab per-project endpoints, scanner app-handle skip, cross-repo non-claim,
own-repo claim, factory slug resolution. The cross-repo safety assertion was
verified anti-vacuous (RED on the unscoped path).

### 7. Resilience invariants
No new external write. The read is additive and back-compatible (empty
`repo_slugs` = prior behaviour). Idempotent claim path unchanged.

### 8. Identity and key normalization
Repo slugs are canonicalized UP to `owner/repo` via the existing
`normalize_repo_slug` boundary — no stripping to force a match.

### 9. Behavior preservation / capability deletion
Purely additive to the query surface: empty `repo_slugs` preserves the exact
prior query on both forges. No matcher narrowed, no must-block test inverted. The
`app/github-actions` trust row is preserved.

### 10. Removability / harness-vs-data
Removable: reverting the `repo_slugs` default to unused restores prior behaviour
with no call-site cascade. Harness-vs-data: the *scope* is data — resolved from
the overlay's declared repos, not hard-coded — so a new owned repo needs no code
change.

## Open questions & assumptions

- Owned-repo resolution unions `merge_candidate_repo_slugs()` +
  `get_followup_repos()`. For the teatree overlay this yields `souliane/teatree`.
  An overlay that declares neither yields empty slugs and keeps intake unscoped
  (back-compat) — the pre-existing author gate still refuses strangers, so this is
  safe, just not repo-narrowed for such an overlay.
