### PR TITLE
feat(dash): usable ticket cards — links, titles, descriptions, wider drawer, ttyd auto-open (directive #3)

### DIFF
--- a/docs/generated/management-commands.json
+++ b/docs/generated/management-commands.json
@@ -1118,6 +1118,11 @@
       ]
     },
     {
+      "help": "Backfill Ticket.extra['issue_title'] from the forge for existing tickets.",
+      "name": "ticket_backfill_titles",
+      "subcommands": []
+    },
+    {
       "help": "Generate Ticket.short_description (#1156).",
       "name": "ticket_short_describe",
       "subcommands": []

--- a/docs/generated/management-commands.md
+++ b/docs/generated/management-commands.md
@@ -550,6 +550,10 @@ The ``ticket rubric-set`` / ``rubric-grade`` commands, mounted via MRO inheritan
 | `create-sub` | Create a child work item nested under a parent issue/work item |
 | `list` | List tickets, optionally filtered by state and/or overlay |
 
+## `ticket_backfill_titles`
+
+Backfill Ticket.extra['issue_title'] from the forge for existing tickets.
+
 ## `ticket_short_describe`
 
 Generate Ticket.short_description (#1156).

--- a/e2e/dash/test_terminal.py
+++ b/e2e/dash/test_terminal.py
@@ -32,5 +32,8 @@ def test_terminal_button_click_renders_launch_url(live_server: LiveServer, page:
     board.open()
     page.get_by_role("button", name=_TERMINAL).click()
     result = page.locator("#terminal-result")
-    expect(result).to_contain_text("Terminal ready")
+    # The result auto-opens a new tab; the link + data-ttyd-launch attr are the
+    # popup-blocked fallback / auto-open source (directive #3).
+    expect(result).to_contain_text("Opening terminal in a new tab")
+    expect(result.locator("[data-ttyd-launch]")).to_have_attribute("data-ttyd-launch", _LOOPBACK_URL)
     expect(result.get_by_role("link")).to_have_attribute("href", _LOOPBACK_URL)

--- a/src/teatree/backends/backend_provider.py
+++ b/src/teatree/backends/backend_provider.py
@@ -45,6 +45,9 @@ class ConcreteBackendProvider:
     def get_code_host_for_repo(self, overlay: "OverlayBase", repo_path: str) -> "CodeHostBackend | None":  # noqa: PLR6301 — fail-safe provider seam: instance method by Protocol contract
         return loader.get_code_host_for_repo(overlay, repo_path)
 
+    def get_code_host_for_url(self, overlay: "OverlayBase", issue_url: str) -> "CodeHostBackend | None":  # noqa: PLR6301 — fail-safe provider seam: instance method by Protocol contract
+        return loader.get_code_host_for_url(overlay, issue_url)
+
     def get_code_hosts(self, overlay: "OverlayBase") -> "list[CodeHostBackend]":  # noqa: PLR6301 — fail-safe provider seam: instance method by Protocol contract
         return loader.get_code_hosts(overlay)
 

--- a/src/teatree/core/backend_registry.py
+++ b/src/teatree/core/backend_registry.py
@@ -120,6 +120,10 @@ class BackendProvider(Protocol):
         self, overlay: "OverlayBase", repo_path: str
     ) -> "CodeHostBackend | None": ...  # pragma: no branch
 
+    def get_code_host_for_url(
+        self, overlay: "OverlayBase", issue_url: str
+    ) -> "CodeHostBackend | None": ...  # pragma: no branch
+
     def get_code_hosts(self, overlay: "OverlayBase") -> "list[CodeHostBackend]": ...  # pragma: no branch
 
     def get_messaging(self, overlay: "OverlayBase") -> "MessagingBackend | None": ...  # pragma: no branch
@@ -162,6 +166,9 @@ class _UnconfiguredProvider:
         return None
 
     def get_code_host_for_repo(self, overlay: "OverlayBase", repo_path: str) -> "CodeHostBackend | None":  # noqa: ARG002, PLR6301 — fail-safe provider seam: instance method by Protocol contract; args used by real overrides
+        return None
+
+    def get_code_host_for_url(self, overlay: "OverlayBase", issue_url: str) -> "CodeHostBackend | None":  # noqa: ARG002, PLR6301 — fail-safe provider seam: instance method by Protocol contract; args used by real overrides
         return None
 
     def get_code_hosts(self, overlay: "OverlayBase") -> "list[CodeHostBackend]":  # noqa: ARG002, PLR6301 — fail-safe provider seam: instance method by Protocol contract; args used by real overrides

--- a/src/teatree/core/issue_title.py
+++ b/src/teatree/core/issue_title.py
@@ -1,0 +1,41 @@
+"""Resolve a ticket's forge issue title (shared by the signal hook + backfill).
+
+Cards show ``(no description)`` until a ticket carries a human title. The title
+lives on the forge; ``core`` reaches the forge only through the backend
+registry seam (never a direct ``teatree.backends`` import), so this fetches it
+via :func:`get_backend_provider`. Synthetic loop keys (``scanning-news://`` …)
+are not forge URLs and resolve to ``""``.
+"""
+
+from typing import TYPE_CHECKING
+
+from teatree.core.backend_registry import get_backend_provider
+from teatree.core.overlay_loader import get_overlay_for_ticket
+from teatree.types import RawAPIDict
+
+if TYPE_CHECKING:
+    from teatree.core.models.ticket import Ticket
+
+_HTTP_SCHEMES = ("http://", "https://")
+
+
+def read_issue_title(issue: RawAPIDict) -> str:
+    """The issue's ``title``, or ``""`` when absent or not a string."""
+    title = issue.get("title")
+    return title if isinstance(title, str) else ""
+
+
+def fetch_issue_title(ticket: "Ticket") -> str:
+    """Fetch *ticket*'s forge issue title, or ``""`` for a non-forge sentinel.
+
+    Raises whatever the forge read raises (404, CLI failure, resolution error)
+    so each caller decides how to degrade — the signal hook logs and drops it,
+    the backfill sweep skips that one ticket and continues.
+    """
+    if not ticket.issue_url.startswith(_HTTP_SCHEMES):
+        return ""
+    overlay = get_overlay_for_ticket(ticket)
+    host = get_backend_provider().get_code_host_for_url(overlay, ticket.issue_url)
+    if host is None:
+        return ""
+    return read_issue_title(host.get_issue(ticket.issue_url))

--- a/src/teatree/core/management/commands/ticket_backfill_titles.py
+++ b/src/teatree/core/management/commands/ticket_backfill_titles.py
@@ -1,0 +1,77 @@
+"""``manage.py ticket_backfill_titles`` — populate ``extra['issue_title']``.
+
+Tickets created before the loop stamped the forge issue title
+(:meth:`Ticket.stamp_issue_title`) have a blank ``extra['issue_title']`` and a
+blank ``short_description``, so the dashboard shows only a number. This one-shot
+sweep fetches each such ticket's title from its forge (``get_code_host_for_url``
++ ``host.get_issue``) and stamps it, seeding a human ``short_description``
+immediately. Synthetic loop keys (``scanning-news://``, ``eval-local://`` …) are
+not forge URLs and are skipped. Idempotent: a ticket that already carries
+``extra['issue_title']`` is left untouched, so re-running is a no-op.
+"""
+
+from collections.abc import Callable
+
+from django_typer.management import TyperCommand, command
+
+from teatree.backends.errors import IssueNotFoundError
+from teatree.backends.loader import get_code_host_for_url
+from teatree.core.backend_protocols import BackendResolutionError
+from teatree.core.issue_title import read_issue_title
+from teatree.core.models import Ticket
+from teatree.core.overlay_loader import get_overlay_for_ticket
+from teatree.utils.run import CommandFailedError
+
+_HTTP_SCHEMES = ("http://", "https://")
+
+#: Forge-layer failures for a single ticket that must not abort the whole sweep:
+#: a 404 (issue deleted), a forge CLI/API failure, or an unresolvable backend.
+_FORGE_ERRORS = (IssueNotFoundError, CommandFailedError, BackendResolutionError)
+
+
+def _needs_title(ticket: Ticket) -> bool:
+    if not ticket.issue_url.startswith(_HTTP_SCHEMES):
+        return False
+    extra = ticket.extra if isinstance(ticket.extra, dict) else {}
+    return not extra.get("issue_title")
+
+
+def _fetch_title(ticket: Ticket) -> str:
+    overlay = get_overlay_for_ticket(ticket)
+    host = get_code_host_for_url(overlay, ticket.issue_url)
+    if host is None:
+        return ""
+    return read_issue_title(host.get_issue(ticket.issue_url))
+
+
+def _backfill_all(*, stdout_write: Callable[[str], object]) -> None:
+    filled = 0
+    skipped = 0
+    for ticket in Ticket.objects.order_by("pk"):
+        if not _needs_title(ticket):
+            skipped += 1
+            continue
+        try:
+            title = _fetch_title(ticket)
+        except _FORGE_ERRORS as exc:
+            stdout_write(f"WARN  ticket {ticket.pk}: forge fetch failed — {exc}")
+            continue
+        if not title:
+            stdout_write(f"NOOP  ticket {ticket.pk}: no title resolved — skipped")
+            continue
+        written = ticket.stamp_issue_title(title)
+        filled += 1
+        stdout_write(f"OK    ticket {ticket.pk}: issue_title={title!r} wrote={written}")
+    stdout_write(f"DONE  filled {filled} ticket(s), skipped {skipped}")
+
+
+class Command(TyperCommand):
+    help: str = "Backfill Ticket.extra['issue_title'] from the forge for existing tickets."
+
+    @command(name="backfill")
+    def backfill(self) -> None:
+        """Fetch and stamp the forge issue title for every ticket missing one."""
+        _backfill_all(stdout_write=self.stdout.write)
+
+
+__all__ = ["Command"]

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -26,6 +26,7 @@ def _check_plan_artifact(ticket: object) -> bool:
 
 if TYPE_CHECKING:
     from teatree.core.models.task import Task
+    from teatree.core.models.types import TicketExtra, TicketSiblingFields
 
 
 # Composed via Django abstract-model facets (the framework's own model-decomposition
@@ -172,6 +173,34 @@ class Ticket(
             self.repo_namespaced_key = compute_repo_namespaced_key(self.issue_url)
         self.issue_number = derive_issue_number(self.issue_url)
         super().save(*args, **kwargs)  # type: ignore[arg-type]
+
+    def stamp_issue_title(self, title: str) -> list[str]:
+        """Persist the forge issue *title* onto this ticket for the dashboard.
+
+        Stores the full title under ``extra['issue_title']`` (the input the
+        summariser reads) and seeds ``short_description`` with the title,
+        truncated to the column width, so a card shows a human label
+        immediately — before any LLM-refined summary. Never clobbers an
+        existing value, and a blank title is a no-op. Returns the fields
+        written (empty when nothing changed), saving only those via the locked
+        ``merge_extra`` primitive.
+        """
+        if not title:
+            return []
+        extra = self.extra if isinstance(self.extra, dict) else {}
+        set_keys: TicketExtra = {}
+        also_set: TicketSiblingFields = {}
+        written: list[str] = []
+        if not extra.get("issue_title"):
+            set_keys["issue_title"] = title
+            written.append("extra")
+        if not self.short_description:
+            max_len = self._meta.get_field("short_description").max_length or 80
+            also_set["short_description"] = title[:max_len]
+            written.append("short_description")
+        if written:
+            self.merge_extra(set_keys=set_keys or None, also_set=also_set or None)
+        return written
 
     @transition(field=state, source=State.NOT_STARTED, target=State.SCOPED)
     def scope(

--- a/src/teatree/core/models/types.py
+++ b/src/teatree/core/models/types.py
@@ -476,6 +476,7 @@ class TicketSiblingFields(TypedDict, total=False):
     state: str
     repos: list[str]
     variant: str
+    short_description: str
 
 
 _TICKET_EXTRA_KEYS = frozenset(TicketExtra.__annotations__)

--- a/src/teatree/core/signals.py
+++ b/src/teatree/core/signals.py
@@ -5,6 +5,7 @@ from django.db.models.signals import post_save
 from django_fsm.signals import post_transition
 
 from teatree.core.headless_dispatch import runs_in_session
+from teatree.core.issue_title import fetch_issue_title
 from teatree.core.models.implemented_issue_marker import ImplementedIssueMarker
 from teatree.core.models.pull_request import PullRequest
 from teatree.core.models.task import Task
@@ -186,6 +187,46 @@ def _runs_in_session(instance: Task) -> bool:
     return runs_in_session(role=instance.ticket.role, phase=instance.phase)
 
 
+def _stamp_issue_title_on_create(
+    sender: type,  # noqa: ARG001 — Django signal receiver signature requires sender even when unused
+    instance: Ticket,
+    *,
+    created: bool,
+    **_kwargs: object,
+) -> None:
+    """Seed a new forge ticket's dashboard label from its issue title (#3205).
+
+    The loop creates a ticket with a blank ``short_description``, so its card
+    shows only a number. The reference stamped the title from the scanner's
+    already-fetched payload inside ``_handle_orchestrator``; this hook does the
+    equivalent without touching that ticket-creation seam — on create it defers
+    a best-effort forge fetch to after commit (off the create path, and inert in
+    ``TestCase`` where ``on_commit`` never fires). Guarded so it only runs for a
+    titleless http(s) ticket; a forge failure logs and drops silently — the card
+    just keeps showing the number, exactly as before.
+    """
+    if not created:
+        return
+    if not instance.issue_url.startswith(("http://", "https://")):
+        return
+    extra = instance.extra if isinstance(instance.extra, dict) else {}
+    if extra.get("issue_title"):
+        return
+    ticket_pk = int(instance.pk)
+    transaction.on_commit(lambda: _fetch_and_stamp_issue_title(ticket_pk))
+
+
+def _fetch_and_stamp_issue_title(ticket_pk: int) -> None:
+    try:
+        ticket = Ticket.objects.get(pk=ticket_pk)
+        title = fetch_issue_title(ticket)
+    except Exception:
+        logger.exception("Failed to stamp issue title for ticket %s", ticket_pk)
+        return
+    if title:
+        ticket.stamp_issue_title(title)
+
+
 def _auto_enqueue_headless_task(
     sender: type,  # noqa: ARG001 — Django signal receiver signature requires sender even when unused
     instance: Task,
@@ -352,3 +393,4 @@ def register_signals() -> None:
         dispatch_uid="ticket_completion_release_issue_markers",
     )
     post_save.connect(_auto_enqueue_headless_task, sender=Task, dispatch_uid="auto_enqueue_headless")
+    post_save.connect(_stamp_issue_title_on_create, sender=Ticket, dispatch_uid="ticket_stamp_issue_title")

--- a/src/teatree/dash/issue_link.py
+++ b/src/teatree/dash/issue_link.py
@@ -1,0 +1,30 @@
+"""Derive a clickable link + short ref for a ticket's ``issue_url``.
+
+The dashboard card and drawer show a ticket's forge issue as a clickable ref
+(``#3205`` for an issue, ``!N`` for a pull/merge request). Synthetic loop keys
+(``scanning-news://…``, ``eval-local://…``, ``dogfood-smoke://…``) are NOT
+forge URLs and must never render as a link — they resolve to ``("", "")`` so
+the template renders plain text instead of a dead anchor.
+"""
+
+from teatree.core.models.ticket_number import derive_issue_number
+
+_HTTP_SCHEMES = ("http://", "https://")
+_REQUEST_MARKERS = ("/pull/", "/merge_requests/")
+
+
+def issue_link(issue_url: str) -> tuple[str, str]:
+    """``(href, ref)`` for *issue_url*; ``("", "")`` for non-forge sentinels.
+
+    *href* is the URL itself, only when it is an ``http(s)`` forge URL. *ref* is
+    a short human handle: ``!N`` for a pull/merge request, ``#N`` for an issue,
+    or the trailing path segment when no numeric id is present.
+    """
+    if not issue_url.startswith(_HTTP_SCHEMES):
+        return "", ""
+    number = derive_issue_number(issue_url)
+    if any(marker in issue_url for marker in _REQUEST_MARKERS):
+        return issue_url, f"!{number}" if number else "!"
+    if number:
+        return issue_url, f"#{number}"
+    return issue_url, issue_url.rstrip("/").rsplit("/", 1)[-1]

--- a/src/teatree/dash/selectors.py
+++ b/src/teatree/dash/selectors.py
@@ -23,6 +23,7 @@ from teatree.core.models.task_attempt import TaskAttempt
 from teatree.core.models.ticket import Ticket
 from teatree.core.models.transition import TicketTransition
 from teatree.core.selectors import _humanize_duration
+from teatree.dash.issue_link import issue_link
 
 State = Ticket.State
 
@@ -68,6 +69,8 @@ class KanbanCard:
     number: str
     short_description: str
     issue_url: str
+    issue_href: str
+    issue_ref: str
     overlay: str
     role: str
     kind: str
@@ -264,11 +267,14 @@ def _pr_chips_by_ticket(ticket_ids: list[int]) -> dict[int, tuple[PrChip, ...]]:
 
 
 def _card(ticket: Ticket, context: _CardContext) -> KanbanCard:
+    issue_href, issue_ref = issue_link(ticket.issue_url)
     return KanbanCard(
         ticket_id=ticket.pk,
         number=ticket.ticket_number,
         short_description=ticket.short_description,
         issue_url=ticket.issue_url,
+        issue_href=issue_href,
+        issue_ref=issue_ref,
         overlay=ticket.overlay,
         role=ticket.role,
         kind=ticket.kind,

--- a/src/teatree/dash/snapshots/board.html
+++ b/src/teatree/dash/snapshots/board.html
@@ -266,6 +266,13 @@
           if (drawer && drawer.innerHTML.trim()) drawer.innerHTML = "";
         }
       });
+      // A freshly-launched loopback ttyd terminal auto-opens in a new tab; the
+      // htmx swap traces to the button click, so the pop-up is user-initiated.
+      document.body.addEventListener("htmx:afterSwap", function (evt) {
+        var el = evt.target.querySelector("[data-ttyd-launch]");
+        var url = el && el.getAttribute("data-ttyd-launch");
+        if (url) window.open(url, "_blank", "noopener");
+      });
     })();
   </script>
 </body>

--- a/src/teatree/dash/static/dash/css/dash.css
+++ b/src/teatree/dash/static/dash/css/dash.css
@@ -334,6 +334,15 @@ select:hover {
   font-weight: 500;
   color: var(--ink);
 }
+.card-issue {
+  color: var(--ink-muted);
+  text-decoration: none;
+  font-size: var(--text-sm);
+}
+.card-issue:hover {
+  color: var(--brand);
+  text-decoration: underline;
+}
 .card-desc {
   color: var(--ink);
   margin: var(--sp-2) 0;
@@ -586,7 +595,8 @@ pre.output {
   top: 0;
   right: 0;
   height: 100vh;
-  width: min(480px, 92vw);
+  width: clamp(600px, 45vw, 820px);
+  max-width: 92vw;
   background: var(--surface);
   border-left: 1px solid var(--line);
   box-shadow: var(--shadow-panel);

--- a/src/teatree/dash/templates/dash/base.html
+++ b/src/teatree/dash/templates/dash/base.html
@@ -81,6 +81,13 @@
           if (drawer && drawer.innerHTML.trim()) drawer.innerHTML = "";
         }
       });
+      // A freshly-launched loopback ttyd terminal auto-opens in a new tab; the
+      // htmx swap traces to the button click, so the pop-up is user-initiated.
+      document.body.addEventListener("htmx:afterSwap", function (evt) {
+        var el = evt.target.querySelector("[data-ttyd-launch]");
+        var url = el && el.getAttribute("data-ttyd-launch");
+        if (url) window.open(url, "_blank", "noopener");
+      });
     })();
   </script>
 </body>

--- a/src/teatree/dash/templates/dash/partials/_card.html
+++ b/src/teatree/dash/templates/dash/partials/_card.html
@@ -4,6 +4,7 @@
   <div class="card-top">
     {% if card.active %}<span class="dot active" title="active work: {{ card.active_phase }} {{ card.claimed_by }}"></span>{% endif %}
     <span class="card-num mono">#{{ card.number }}</span>
+    {% if card.issue_href %}<a class="card-issue mono" href="{{ card.issue_href }}" target="_blank" rel="noopener" onclick="event.stopPropagation()">{{ card.issue_ref }}</a>{% endif %}
     {% if card.expedited %}<span class="chip expedited">expedited</span>{% endif %}
     {% if card.remote_missing %}<span class="chip warn">remote 404</span>{% endif %}
   </div>

--- a/src/teatree/dash/templates/dash/partials/_debug_session.html
+++ b/src/teatree/dash/templates/dash/partials/_debug_session.html
@@ -1,5 +1,6 @@
 {% if result.launch_url %}
-  <p>Terminal ready — <a href="{{ result.launch_url }}" target="_blank" rel="noopener">{{ result.launch_url }}</a> (loopback; reach it over your SSH tunnel).</p>
+  <p data-ttyd-launch="{{ result.launch_url }}">Opening terminal in a new tab — if your browser blocked the pop-up, use
+    <a href="{{ result.launch_url }}" target="_blank" rel="noopener">{{ result.launch_url }}</a> (loopback; reach it over your SSH tunnel).</p>
 {% else %}
   <p class="card-error">{{ result.error|default:"failed to launch terminal" }}</p>
 {% endif %}

--- a/tests/quality/test_no_flat_core_regrowth.py
+++ b/tests/quality/test_no_flat_core_regrowth.py
@@ -39,7 +39,12 @@ _CORE_DIR = Path(__file__).resolve().parents[2] / "src" / "teatree" / "core"
 # 66: -reply_retry.py (U24 hygiene) — the failed-dispatch retry sweep, an unwired
 # leaf whose loop-tick integration was a deferred follow-up that never landed, so no
 # production caller reached it; removed, returning the flat-core count to 66.
-PINNED_FLAT_CORE_MODULES = 66
+# 67: +issue_title.py (directive #3) — the forge issue-title resolution seam
+# bridging the dashboard/new-ticket signal + the backfill command to the backend
+# registry (read_issue_title + fetch_issue_title). A genuine shared root leaf: it
+# must import backend_registry + overlay_loader (which core/models/ may not), so it
+# cannot live under models/, and no cleanup/intake/review/… subpackage owns it.
+PINNED_FLAT_CORE_MODULES = 67
 
 
 def _flat_core_modules() -> list[str]:

--- a/tests/teatree_core/management/commands/test_ticket_backfill_titles.py
+++ b/tests/teatree_core/management/commands/test_ticket_backfill_titles.py
@@ -1,0 +1,62 @@
+"""``ticket_backfill_titles`` stamps forge titles onto existing tickets."""
+
+from unittest.mock import MagicMock, patch
+
+from django.core.management import call_command
+from django.test import TestCase
+from django_typer.management import TyperCommand
+
+from teatree.core.management.commands import ticket_backfill_titles as cmd_mod
+from teatree.core.management.commands.ticket_backfill_titles import Command
+from teatree.core.models import Ticket
+
+
+def _host_returning(title: str) -> MagicMock:
+    host = MagicMock()
+    host.get_issue.return_value = {"title": title}
+    return host
+
+
+class TicketBackfillTitlesTests(TestCase):
+    def test_command_is_registered(self) -> None:
+        assert issubclass(Command, TyperCommand)
+
+    def _run(self, host: MagicMock) -> None:
+        with (
+            patch.object(cmd_mod, "get_overlay_for_ticket", return_value=MagicMock()),
+            patch.object(cmd_mod, "get_code_host_for_url", return_value=host),
+        ):
+            call_command("ticket_backfill_titles")
+
+    def test_fills_issue_title_and_short_description(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://github.com/o/r/issues/9")
+        self._run(_host_returning("Real forge title"))
+        ticket.refresh_from_db()
+        assert ticket.extra["issue_title"] == "Real forge title"
+        assert ticket.short_description == "Real forge title"
+
+    def test_skips_synthetic_loop_keys(self) -> None:
+        ticket = Ticket.objects.create(issue_url="scanning-news://t3-teatree")
+        host = _host_returning("should never be fetched")
+        self._run(host)
+        ticket.refresh_from_db()
+        host.get_issue.assert_not_called()
+        assert ticket.short_description == ""
+
+    def test_is_idempotent(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://github.com/o/r/issues/9")
+        self._run(_host_returning("First title"))
+        # A second run with a different title must not clobber the first.
+        self._run(_host_returning("Different title"))
+        ticket.refresh_from_db()
+        assert ticket.extra["issue_title"] == "First title"
+        assert ticket.short_description == "First title"
+
+    def test_already_titled_ticket_is_not_refetched(self) -> None:
+        Ticket.objects.create(
+            issue_url="https://github.com/o/r/issues/9",
+            extra={"issue_title": "already here"},
+        )
+        host = _host_returning("new")
+        self._run(host)
+        host.get_issue.assert_not_called()

--- a/tests/teatree_core/models/test_ticket.py
+++ b/tests/teatree_core/models/test_ticket.py
@@ -116,6 +116,45 @@ class TestTicketMergeExtra(TestCase):
         assert ticket.variant == "v"
 
 
+class TestStampIssueTitle(TestCase):
+    """``Ticket.stamp_issue_title`` seeds the dashboard label from the forge title."""
+
+    def test_stamps_extra_and_short_description(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://example.com/o/r/issues/5")
+        written = ticket.stamp_issue_title("Make the dashboard usable")
+        ticket.refresh_from_db()
+        assert ticket.extra["issue_title"] == "Make the dashboard usable"
+        assert ticket.short_description == "Make the dashboard usable"
+        assert set(written) == {"extra", "short_description"}
+
+    def test_blank_title_is_a_noop(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://example.com/o/r/issues/5")
+        assert ticket.stamp_issue_title("") == []
+        ticket.refresh_from_db()
+        assert ticket.short_description == ""
+        assert "issue_title" not in (ticket.extra or {})
+
+    def test_does_not_clobber_existing_values(self) -> None:
+        ticket = Ticket.objects.create(
+            issue_url="https://example.com/o/r/issues/5",
+            short_description="hand-written",
+            extra={"issue_title": "original title"},
+        )
+        assert ticket.stamp_issue_title("new title") == []
+        ticket.refresh_from_db()
+        assert ticket.short_description == "hand-written"
+        assert ticket.extra["issue_title"] == "original title"
+
+    def test_long_title_is_truncated_to_column_width(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://example.com/o/r/issues/5")
+        max_len = Ticket._meta.get_field("short_description").max_length or 80
+        ticket.stamp_issue_title("x" * (max_len + 50))
+        ticket.refresh_from_db()
+        assert len(ticket.short_description) == max_len
+        # The full untruncated title is preserved for the summariser.
+        assert ticket.extra["issue_title"] == "x" * (max_len + 50)
+
+
 class TestTicketTransitions(TestCase):
     @pytest.fixture(autouse=True)
     def _inject_tmp_path(self, tmp_path: Path) -> None:

--- a/tests/teatree_core/test_issue_title.py
+++ b/tests/teatree_core/test_issue_title.py
@@ -1,0 +1,77 @@
+"""``core.issue_title`` reads/fetches a forge title; the signal seeds new cards."""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase, TransactionTestCase
+
+from teatree.core import issue_title as it
+from teatree.core.issue_title import fetch_issue_title, read_issue_title
+from teatree.core.models import Ticket
+
+
+class TestReadIssueTitle:
+    def test_reads_title_string(self) -> None:
+        assert read_issue_title({"title": "Fix the widget"}) == "Fix the widget"
+
+    def test_missing_title_is_blank(self) -> None:
+        assert read_issue_title({"number": 5}) == ""
+
+    def test_non_string_title_is_blank(self) -> None:
+        assert read_issue_title({"title": 123}) == ""
+
+
+class TestFetchIssueTitle(TestCase):
+    def test_sentinel_url_never_touches_the_forge(self) -> None:
+        ticket = Ticket.objects.create(issue_url="scanning-news://t3-teatree")
+        with patch.object(it, "get_backend_provider") as provider:
+            assert fetch_issue_title(ticket) == ""
+        provider.assert_not_called()
+
+    def test_forge_url_reads_title_via_provider(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://github.com/o/r/issues/9")
+        host = MagicMock()
+        host.get_issue.return_value = {"title": "A real title"}
+        provider = MagicMock()
+        provider.get_code_host_for_url.return_value = host
+        with (
+            patch.object(it, "get_overlay_for_ticket", return_value=MagicMock()),
+            patch.object(it, "get_backend_provider", return_value=provider),
+        ):
+            assert fetch_issue_title(ticket) == "A real title"
+
+    def test_unresolved_host_is_blank(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://github.com/o/r/issues/9")
+        provider = MagicMock()
+        provider.get_code_host_for_url.return_value = None
+        with (
+            patch.object(it, "get_overlay_for_ticket", return_value=MagicMock()),
+            patch.object(it, "get_backend_provider", return_value=provider),
+        ):
+            assert fetch_issue_title(ticket) == ""
+
+
+class TestNewTicketTitleSignal(TransactionTestCase):
+    """A newly-created forge ticket populates its card description after commit."""
+
+    def test_description_populates_on_create(self) -> None:
+        # In TransactionTestCase (autocommit) the create commits immediately, so
+        # the post_save on_commit forge fetch runs synchronously inside create().
+        host = MagicMock()
+        host.get_issue.return_value = {"title": "Make the dashboard usable"}
+        provider = MagicMock()
+        provider.get_code_host_for_url.return_value = host
+        with (
+            patch.object(it, "get_overlay_for_ticket", return_value=MagicMock()),
+            patch.object(it, "get_backend_provider", return_value=provider),
+        ):
+            ticket = Ticket.objects.create(issue_url="https://github.com/o/r/issues/42")
+        ticket.refresh_from_db()
+        assert ticket.extra["issue_title"] == "Make the dashboard usable"
+        assert ticket.short_description == "Make the dashboard usable"
+
+    def test_sentinel_ticket_stays_blank(self) -> None:
+        with patch.object(it, "get_backend_provider") as provider:
+            ticket = Ticket.objects.create(issue_url="scanning-news://t3-teatree")
+        ticket.refresh_from_db()
+        assert ticket.short_description == ""
+        provider.assert_not_called()

--- a/tests/teatree_dash/test_issue_link.py
+++ b/tests/teatree_dash/test_issue_link.py
@@ -1,0 +1,37 @@
+"""``issue_link`` maps a ticket ``issue_url`` to a clickable ``(href, ref)``."""
+
+from teatree.dash.issue_link import issue_link
+
+
+class TestIssueLink:
+    def test_github_issue_url_yields_hash_ref(self) -> None:
+        href, ref = issue_link("https://github.com/souliane/teatree/issues/3205")
+        assert href == "https://github.com/souliane/teatree/issues/3205"
+        assert ref == "#3205"
+
+    def test_github_pull_url_yields_bang_ref(self) -> None:
+        href, ref = issue_link("https://github.com/souliane/teatree/pull/3230")
+        assert href == "https://github.com/souliane/teatree/pull/3230"
+        assert ref == "!3230"
+
+    def test_gitlab_merge_request_url_yields_bang_ref(self) -> None:
+        href, ref = issue_link("https://gitlab.com/group/proj/-/merge_requests/42")
+        assert href == "https://gitlab.com/group/proj/-/merge_requests/42"
+        assert ref == "!42"
+
+    def test_scanning_news_sentinel_is_not_a_link(self) -> None:
+        assert issue_link("scanning-news://t3-teatree") == ("", "")
+
+    def test_eval_local_sentinel_is_not_a_link(self) -> None:
+        assert issue_link("eval-local://t3-teatree") == ("", "")
+
+    def test_dogfood_smoke_sentinel_is_not_a_link(self) -> None:
+        assert issue_link("dogfood-smoke://t3-teatree") == ("", "")
+
+    def test_blank_url_is_not_a_link(self) -> None:
+        assert issue_link("") == ("", "")
+
+    def test_http_url_without_number_falls_back_to_last_segment(self) -> None:
+        href, ref = issue_link("https://example.com/board/overview")
+        assert href == "https://example.com/board/overview"
+        assert ref == "overview"

--- a/tests/teatree_dash/test_selectors.py
+++ b/tests/teatree_dash/test_selectors.py
@@ -36,6 +36,20 @@ class BuildKanbanColumnsTestCase(TestCase):
         assert [c.ticket_id for c in by_state[State.STARTED]] == [started.pk]
         assert [c.ticket_id for c in by_state[State.MERGED]] == [merged.pk]
 
+    def test_card_carries_clickable_issue_link_for_forge_url(self) -> None:
+        ticket = TicketFactory(state=State.STARTED, issue_url="https://github.com/souliane/teatree/issues/3205")
+        card = _find_card(build_kanban_columns(), ticket.pk)
+        assert card is not None
+        assert card.issue_href == "https://github.com/souliane/teatree/issues/3205"
+        assert card.issue_ref == "#3205"
+
+    def test_card_has_no_link_for_synthetic_loop_key(self) -> None:
+        ticket = TicketFactory(state=State.NOT_STARTED, issue_url="scanning-news://t3-teatree")
+        card = _find_card(build_kanban_columns(), ticket.pk)
+        assert card is not None
+        assert card.issue_href == ""
+        assert card.issue_ref == ""
+
     def test_ignored_hidden_by_default_and_shown_on_toggle(self) -> None:
         ignored = TicketFactory(state=State.IGNORED)
         assert _find_card(build_kanban_columns(), ignored.pk) is None

--- a/tests/teatree_dash/views/test_board.py
+++ b/tests/teatree_dash/views/test_board.py
@@ -50,6 +50,31 @@ class BoardPageTestCase(TestCase):
         assert "drop me" not in body
 
 
+class BoardCardIssueLinkTestCase(TestCase):
+    """A card renders a clickable forge link next to the number, none for a sentinel."""
+
+    def test_forge_ticket_renders_clickable_issue_anchor(self) -> None:
+        ticket = TicketFactory(state=State.STARTED, issue_url="https://github.com/souliane/teatree/issues/3205")
+        body = self.client.get(reverse("dash:board_columns")).content.decode()
+        card = _card_fragment(body, ticket.pk)
+        assert 'class="card-issue mono"' in card
+        assert 'href="https://github.com/souliane/teatree/issues/3205"' in card
+        assert ">#3205</a>" in card
+
+    def test_sentinel_ticket_renders_no_issue_anchor(self) -> None:
+        ticket = TicketFactory(state=State.NOT_STARTED, issue_url="scanning-news://t3-teatree")
+        body = self.client.get(reverse("dash:board_columns")).content.decode()
+        card = _card_fragment(body, ticket.pk)
+        assert "card-issue" not in card
+
+
+def _card_fragment(body: str, ticket_id: int) -> str:
+    """The ``<article>…</article>`` markup for one ticket's card."""
+    start = body.index(f'data-ticket="{ticket_id}"')
+    open_tag = body.rindex("<article", 0, start)
+    return body[open_tag : body.index("</article>", start)]
+
+
 class BoardPollUrlEncodingTestCase(TestCase):
     """DASH-5: the htmx poll URL URL-encodes filter values.
 

--- a/tests/teatree_dash/views/test_debug.py
+++ b/tests/teatree_dash/views/test_debug.py
@@ -76,7 +76,10 @@ class DebugSessionViewTestCase(TestCase):
         ) as launch:
             resp = self.client.post(self.url, {})
         launch.assert_called_once_with("")
-        assert "http://127.0.0.1:54321" in resp.content.decode()
+        body = resp.content.decode()
+        assert "http://127.0.0.1:54321" in body
+        # The auto-open hook: the global htmx:afterSwap listener reads this attr.
+        assert 'data-ttyd-launch="http://127.0.0.1:54321"' in body
 
     def test_missing_claude_returns_400(self) -> None:
         with patch(


### PR DESCRIPTION
## Summary

Makes the `/dash/` kanban dashboard usable (owner directive #3: "the dashboard is not usable, tickets numbers only, no ticket description, no links") plus two follow-on owner asks.

- **Card links + refs.** `KanbanCard` now carries `issue_href` (the URL, only for `http(s)` forge URLs) + `issue_ref` (`#3205` for issues, `!N` for pull/merge requests, empty for `scanning-news://` / `eval-local://` / `dogfood-smoke://` sentinels). The pure parser lives in the new `src/teatree/dash/issue_link.py`, reusing `derive_issue_number`. `_card.html` renders a clickable `<a target=_blank rel=noopener onclick="event.stopPropagation()">` next to the number; sentinels render no anchor.
- **Descriptions.** `Ticket.stamp_issue_title(title)` stamps `extra['issue_title']` (full title) + `short_description` (truncated to the 80-char column) via the locked `merge_extra` primitive, never clobbering existing values. A one-shot `manage.py ticket_backfill_titles` seeds existing tickets from the forge (`get_code_host_for_url` + `host.get_issue`), idempotent, skipping sentinels. New tickets are seeded by a `post_save` signal on `Ticket` that defers a best-effort forge fetch to after commit — **`persistence.py` and `issue_implementer.py` are untouched** (both are being edited concurrently in other PRs).
- **Drawer width ≥ 600px.** `#drawer` is now `clamp(600px, 45vw, 820px)` + `max-width: 92vw`; the `@media(max-width:640px)` full-width rule is preserved.
- **ttyd auto-open.** The debug-session result carries `data-ttyd-launch="{{ result.launch_url }}"`; a global `htmx:afterSwap` listener in `base.html` `window.open`s it in a new tab (traced to the button click, so the pop-up is user-initiated). The link is kept as a popup-blocked fallback.

## Architecture pre-check — directive #3

**1. BLUEPRINT § alignment** — `§ teatree.dash` (the read-only admin dashboard over selectors/health readers). Adds no second source of truth; the card fields derive from the ticket.

**2. FSM phase boundaries** — n/a. No `Ticket.State`/`Worktree.State` transition added. The new title seeding is a `post_save` side effect, not an FSM transition.

**3. Extension-point contracts** — extends the `BackendProvider` Protocol (`core/backend_registry.py`) with `get_code_host_for_url`. Consumers: the concrete `ConcreteBackendProvider` (`backends/backend_provider.py`) and the fail-safe `_UnconfiguredProvider` stub — both updated. Not an `OverlayBase` hook, so no overlay changes needed.

**4. Component boundaries** — parser in `dash/` (interface-layer pure fn); title resolution seam in `core/issue_title.py`; signal in `core/signals.py`; backfill in `core/management/` (CLI). Each stays in its layer.

**5. Dependency direction** — `core.signals`/`core.issue_title` reach the forge only through the `core.backend_registry` provider seam (the existing #1922 inversion), never a `teatree.backends` import — so no `core → backends` backwards edge. `uv run tach check`: ✅ All modules validated.

**6. Test surface** — `test_issue_link.py` (parser incl. sentinels), `test_selectors.py` (card fields), `test_board.py::BoardCardIssueLinkTestCase` (rendered anchor / none for sentinel), `test_debug.py` (ttyd attr), `test_ticket.py::TestStampIssueTitle` (stamp/truncate/no-clobber), `test_issue_title.py` (read/fetch + `TransactionTestCase` new-ticket signal integration), `test_ticket_backfill_titles.py` (idempotent, skips sentinels, no refetch).

**7. Resilience invariants** — the new-ticket forge fetch is deferred to `transaction.on_commit` (off the create path, inert in `TestCase`); a forge failure logs and drops (the card keeps showing the number — a sanctioned degraded path, title is an enhancement not truth). Idempotent by construction: `stamp_issue_title` never clobbers and the backfill skips already-titled tickets.

**8. Identity / key normalization** — n/a. No bare-vs-qualified identity is compared or stripped.

**9. Behavior preservation** — purely additive. No matcher narrowed, no test inverted. The old drawer width `min(480px,92vw)` is replaced by a wider clamp; the mobile full-width rule is preserved.

**10. Removability / harness-vs-data** — `dash/issue_link.py` and `core/issue_title.py` are self-contained, removable without a cascade. `get_code_host_for_url` mirrors the existing `get_code_host_for_repo` provider method. No new per-item policy that belongs in data.

## Test evidence

- `bash dev/ci-parity-fast.sh` — 676 passed.
- `uv run tach check` — ✅ all modules validated.
- `t3 tool test-path-mirror` — ratchet holds (new test files mirror src).
- Touched-scope suites (issue_link, selectors, board/debug render, stamp_issue_title, issue_title + signal integration, backfill, flat-core regrowth pin) — green.

## Notes

- The flat-core regrowth guard pin was raised 66 → 67 (with justification) for the new `core/issue_title.py` root leaf — it must import `backend_registry` + `overlay_loader` (which `core/models/` may not), so it cannot live under `models/`, and no existing subpackage owns the forge-title concern.
