### PR TITLE
feat(deploy): externalize factory state onto host bind mounts (PR-1 Docker unification)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -31,18 +31,49 @@ The stack is three services from one image (`deploy/Dockerfile`), selected by
 | `teatree-admin` | `t3 admin` | `unless-stopped` | Django admin under gunicorn on the box loopback `127.0.0.1:8000` (host networking); `DEBUG` off |
 
 `worker` and `admin` wait for `init` to complete, so the editable install on the
-shared clone happens exactly once. All three share named volumes, so the admin and
+shared clone happens exactly once. All three mount the same state, so the admin and
 the worker read the **same** `db.sqlite3` (WAL — safe concurrent reads):
 
-| Volume | Mount | Holds |
-| --- | --- | --- |
-| `teatree_src` | `/home/teatree/teatree` | the teatree clone (source) |
-| `teatree_data` | `/home/teatree/.local/share/teatree` | the canonical DB (`db.sqlite3`) |
-| `teatree_worktrees` | `/home/teatree/.local/share/teatree-worktrees` | per-worktree isolated DBs |
-| `teatree_workspaces` | `/home/teatree/workspace/t3-workspaces` | ticket worktrees |
-| `teatree_uv` | `/opt/teatree/uv` | the runtime teatree Python + venv + `t3` shims |
+| Mount | Path | Kind | Holds |
+| --- | --- | --- | --- |
+| `teatree_src` | `/home/teatree/teatree` | named volume | the teatree clone (source) |
+| DB dir | `/home/teatree/.local/share/teatree` | **host bind mount** | the canonical DB (`db.sqlite3`) + credentials + backups |
+| worktrees | `/home/teatree/.local/share/teatree-worktrees` | **host bind mount** | per-worktree isolated DBs |
+| workspaces | `/home/teatree/workspace/t3-workspaces` | **host bind mount** | ticket worktrees |
+| `teatree_uv` | `/opt/teatree/uv` | named volume | the runtime teatree Python + venv + `t3` shims |
 
-Re-running the workflow is **idempotent** — it converges the same stack.
+### External DB — one DB on the host disk
+
+The DB, worktrees, and workspaces are **host bind mounts at their canonical
+absolute paths**, not Docker-internal named volumes. The bind source and the
+container target are the identical path (path identity — `deploy/Dockerfile` sets
+no `XDG_DATA_HOME` and HOME is `/home/teatree` in both the container and the box),
+so the container and the host converge on **one** `db.sqlite3` on the host's
+daily-backed-up disk. There is no separate Docker-internal factory DB to drift
+from the operator's real DB.
+
+`teatree_src` and `teatree_uv` stay Docker-managed named volumes for now (later
+PRs handle code-mount modes).
+
+### One-time volume migration (operator step)
+
+A box that ran an older deploy has its state in Docker named volumes
+(`teatree_teatree_data`, `teatree_teatree_worktrees`, `teatree_teatree_workspaces`).
+`deploy/migrate-volume-data.sh` is a **one-time, idempotent, operator-run** step
+that moves that real factory state onto the host bind paths before the stack
+switches to bind mounts. Run it once, with the stack stopped:
+
+```bash
+docker compose -f deploy/docker-compose.yml down   # the script refuses while up
+sudo deploy/migrate-volume-data.sh                 # sudo: reads /var/lib/docker/volumes
+```
+
+It archives the existing host DB + backups (timestamped, never deleted) before
+overwriting them with the container volume's copy (the real factory state), then
+copies the credentials, worktrees, and workspaces across and brings the stack up.
+A fresh box with no prior volumes does not need this step.
+
+Re-running the deploy workflow is **idempotent** — it converges the same stack.
 
 ## Fleet role split — which loops run where
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -13,13 +13,23 @@ x-teatree-common: &teatree-common
     dockerfile: deploy/Dockerfile
   env_file:
     - teatree.env
-  # All services mount all volumes so admin and worker share ONE db.sqlite3
-  # (WAL — safe concurrent reads) and one editable install.
+  # All services mount all state so admin and worker share ONE db.sqlite3
+  # (WAL — safe concurrent reads) and one editable install. The DB, worktrees,
+  # and workspaces are HOST bind mounts at their canonical absolute paths, so the
+  # container and the host see the same files (path identity — no XDG knob). This
+  # puts the factory's DB on the same daily-backed-up host disk as the operator's
+  # real DB instead of a Docker-internal named volume.
   volumes:
     - teatree_src:/home/teatree/teatree
-    - teatree_data:/home/teatree/.local/share/teatree
-    - teatree_worktrees:/home/teatree/.local/share/teatree-worktrees
-    - teatree_workspaces:/home/teatree/workspace/t3-workspaces
+    - type: bind
+      source: /home/teatree/.local/share/teatree
+      target: /home/teatree/.local/share/teatree
+    - type: bind
+      source: /home/teatree/.local/share/teatree-worktrees
+      target: /home/teatree/.local/share/teatree-worktrees
+    - type: bind
+      source: /home/teatree/workspace/t3-workspaces
+      target: /home/teatree/workspace/t3-workspaces
     - teatree_uv:/opt/teatree/uv
   init: true
 
@@ -69,7 +79,4 @@ services:
 
 volumes:
   teatree_src:
-  teatree_data:
-  teatree_worktrees:
-  teatree_workspaces:
   teatree_uv:

--- a/deploy/migrate-volume-data.sh
+++ b/deploy/migrate-volume-data.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# One-time, idempotent migration from Docker named volumes to host bind mounts.
+#
+# PR-1 of the Docker unification externalized the factory's state onto the host
+# at its canonical absolute paths (see deploy/docker-compose.yml). Before that
+# change the DB, worktrees, and workspaces lived in Docker named volumes; this
+# script copies that real factory state out onto the host bind paths so nothing
+# is lost when the stack switches to bind mounts.
+#
+# SAFETY: the OPERATOR runs this, not the deploy workflow. It refuses to run
+# while the stack is up, ARCHIVES the existing host DB + backups (timestamped,
+# never deleted) BEFORE overwriting, then copies the volume contents onto the
+# host paths and brings the stack up. Per the design the CONTAINER volume holds
+# the real factory state, so the host DB is archived-then-overwritten from it.
+#
+# Reading /var/lib/docker/volumes needs root and `cp -a` must preserve the
+# teatree uid/gid, so run this with sudo:
+#
+#     sudo deploy/migrate-volume-data.sh
+#
+# Idempotent: safe to re-run — each run makes a fresh timestamped archive and
+# re-copies. Because the stack must be DOWN and the host is archived first, a
+# re-run can never lose data.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# All paths are overridable for testing; the defaults are the real box paths.
+COMPOSE_FILE="${MIGRATE_COMPOSE_FILE:-$SCRIPT_DIR/docker-compose.yml}"
+DOCKER="${MIGRATE_DOCKER:-docker}"
+
+HOST_DATA="${MIGRATE_HOST_DATA:-/home/teatree/.local/share/teatree}"
+HOST_WORKTREES="${MIGRATE_HOST_WORKTREES:-/home/teatree/.local/share/teatree-worktrees}"
+HOST_WORKSPACES="${MIGRATE_HOST_WORKSPACES:-/home/teatree/workspace/t3-workspaces}"
+
+VOL_DATA="${MIGRATE_VOL_DATA:-/var/lib/docker/volumes/teatree_teatree_data/_data}"
+VOL_WORKTREES="${MIGRATE_VOL_WORKTREES:-/var/lib/docker/volumes/teatree_teatree_worktrees/_data}"
+VOL_WORKSPACES="${MIGRATE_VOL_WORKSPACES:-/var/lib/docker/volumes/teatree_teatree_workspaces/_data}"
+
+ARCHIVE_ROOT="${MIGRATE_ARCHIVE_ROOT:-/home/teatree/.local/share}"
+
+step() { printf '==> %s\n' "$*"; }
+die() { printf 'migrate-volume-data: %s\n' "$*" >&2; exit 1; }
+
+refuse_if_stack_up() {
+    step "Checking the stack is stopped"
+    local running
+    running="$("$DOCKER" compose -f "$COMPOSE_FILE" ps -q 2>/dev/null || true)"
+    if [ -n "$running" ]; then
+        die "the stack is up. Stop it first, then re-run:
+    $DOCKER compose -f $COMPOSE_FILE down"
+    fi
+}
+
+require_volumes_readable() {
+    step "Checking the Docker volumes are readable"
+    local d
+    for d in "$VOL_DATA" "$VOL_WORKTREES" "$VOL_WORKSPACES"; do
+        [ -d "$d" ] || die "volume dir not found: $d — run with sudo, or the named volumes are already gone (migration already done?)."
+        [ -r "$d" ] || die "cannot read $d — run this script with sudo."
+    done
+}
+
+archive_host_state() {
+    # Timestamped, never deleted — the safety net before we overwrite the host DB.
+    local ts archive
+    ts="$(date +%Y%m%d-%H%M%S)"
+    archive="$ARCHIVE_ROOT/teatree-bindmount-archive-$ts"
+    step "Archiving the existing host DB + backups -> $archive"
+    mkdir -p "$archive"
+    local item
+    for item in db.sqlite3 db.sqlite3-wal db.sqlite3-shm; do
+        [ -e "$HOST_DATA/$item" ] && cp -a "$HOST_DATA/$item" "$archive/"
+    done
+    [ -d "$HOST_DATA/backups" ] && cp -a "$HOST_DATA/backups" "$archive/"
+    printf 'archived host state to %s\n' "$archive"
+}
+
+copy_volume_to_host() {
+    # KEEP the container volume's data (the real factory state) and lay it down on
+    # the host bind paths. `cp -a` preserves the teatree uid/gid so the container
+    # user can still read/write after the switch. Trailing /. copies dotfiles too
+    # (.password-store, .gnupg, instance_id, backups/).
+    step "Copying volume DB + credentials + backups -> $HOST_DATA"
+    mkdir -p "$HOST_DATA"
+    cp -a "$VOL_DATA/." "$HOST_DATA/"
+
+    step "Copying volume worktrees -> $HOST_WORKTREES"
+    mkdir -p "$HOST_WORKTREES"
+    cp -a "$VOL_WORKTREES/." "$HOST_WORKTREES/"
+
+    step "Copying volume workspaces -> $HOST_WORKSPACES"
+    mkdir -p "$HOST_WORKSPACES"
+    cp -a "$VOL_WORKSPACES/." "$HOST_WORKSPACES/"
+}
+
+bring_stack_up() {
+    step "Bringing the stack up on the host bind mounts"
+    "$DOCKER" compose -f "$COMPOSE_FILE" up -d
+}
+
+main() {
+    refuse_if_stack_up
+    require_volumes_readable
+    archive_host_state
+    copy_volume_to_host
+    bring_stack_up
+    step "Done. The factory state now lives on the host bind paths."
+}
+
+main "$@"

--- a/tests/test_deploy_bindmount_compose.py
+++ b/tests/test_deploy_bindmount_compose.py
@@ -1,0 +1,103 @@
+"""The headless stack externalizes its state onto host bind mounts.
+
+PR-1 of the Docker unification: the factory's DB, worktrees, and workspaces
+must live on the host at their canonical absolute paths (not in Docker named
+volumes), so the container and the host converge on ONE db.sqlite3 via path
+identity (`deploy/Dockerfile` sets no `XDG_DATA_HOME`, HOME is `/home/teatree`
+in both). These tests pin the compose file to bind mounts at those exact host
+paths and confirm the now-unused named-volume declarations are gone.
+
+Structure is parsed from the YAML directly (the source of truth); a golden
+`docker compose config` assertion runs too when a usable docker is present.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+COMPOSE_FILE = Path(__file__).resolve().parents[1] / "deploy" / "docker-compose.yml"
+
+# The three externalized mounts: canonical host path == container path (identity).
+EXTERNALIZED = {
+    "/home/teatree/.local/share/teatree",
+    "/home/teatree/.local/share/teatree-worktrees",
+    "/home/teatree/workspace/t3-workspaces",
+}
+# The two mounts that stay Docker-managed named volumes (later PRs handle these).
+KEPT_NAMED_VOLUMES = {"teatree_src", "teatree_uv"}
+REMOVED_NAMED_VOLUMES = {"teatree_data", "teatree_worktrees", "teatree_workspaces"}
+
+
+def _compose() -> dict:
+    return yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+
+
+def _common_volumes() -> list:
+    """The shared mount list every service inherits via `*teatree-common`."""
+    return _compose()["x-teatree-common"]["volumes"]
+
+
+class TestExternalizedBindMounts:
+    def test_state_dirs_are_bind_mounts_at_canonical_host_paths(self) -> None:
+        binds = {
+            entry["source"]: entry
+            for entry in _common_volumes()
+            if isinstance(entry, dict) and entry.get("type") == "bind"
+        }
+        assert set(binds) == EXTERNALIZED, "each externalized dir must be a host bind mount"
+        for source, entry in binds.items():
+            # Path identity: the host source and the container target are the same
+            # absolute path, so both see the same files with no XDG knob.
+            assert entry["target"] == source, f"{source}: bind target must equal host source"
+
+    def test_kept_named_volume_mounts_still_present(self) -> None:
+        named = {entry.split(":", 1)[0] for entry in _common_volumes() if isinstance(entry, str)}
+        assert named == KEPT_NAMED_VOLUMES
+
+    def test_no_state_dir_uses_a_named_volume_mount(self) -> None:
+        named = {entry.split(":", 1)[0] for entry in _common_volumes() if isinstance(entry, str)}
+        assert named.isdisjoint(REMOVED_NAMED_VOLUMES), "state dirs must not mount named volumes"
+
+
+class TestTopLevelVolumeDeclarations:
+    def test_unused_named_volume_declarations_removed(self) -> None:
+        declared = set(_compose().get("volumes") or {})
+        assert declared == KEPT_NAMED_VOLUMES
+        assert declared.isdisjoint(REMOVED_NAMED_VOLUMES)
+
+
+class TestDockerComposeConfigGolden:
+    """Golden: `docker compose config` resolves the same bind mounts end to end."""
+
+    def test_rendered_config_carries_the_bind_mounts(self, tmp_path: Path) -> None:
+        docker = shutil.which("docker")
+        if docker is None:
+            pytest.skip("docker not available for the golden config render")
+        # Render from an isolated copy with a stub env_file so we never touch the
+        # real box secrets; `config` neither builds nor starts anything.
+        work = tmp_path / "deploy"
+        work.mkdir()
+        (work / "docker-compose.yml").write_text(COMPOSE_FILE.read_text(encoding="utf-8"), encoding="utf-8")
+        (work / "teatree.env").write_text("T3_DEBUG=0\n", encoding="utf-8")
+        proc = subprocess.run(
+            [docker, "compose", "-f", str(work / "docker-compose.yml"), "config", "--format", "json"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            pytest.skip(f"docker compose config unusable here: {proc.stderr.strip()[:200]}")
+        rendered = json.loads(proc.stdout)
+        mounts = {m["source"]: m for svc in rendered["services"].values() for m in svc.get("volumes", [])}
+        for path in EXTERNALIZED:
+            assert path in mounts, f"{path} missing from rendered config"
+            assert mounts[path]["type"] == "bind"
+            assert mounts[path]["target"] == path
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_deploy_migrate_volume_data.py
+++ b/tests/test_deploy_migrate_volume_data.py
@@ -1,0 +1,186 @@
+"""Tests for the one-time named-volume -> host-bind-mount migration script.
+
+`deploy/migrate-volume-data.sh` is the SAFE operator step for PR-1 of the Docker
+unification: it archives the existing host DB (timestamped, never deleted),
+copies the real factory state out of the Docker named volumes onto the host bind
+paths, and brings the stack up. It must REFUSE while the stack is up and must
+ARCHIVE before it overwrites.
+
+Following the Test-Writing Doctrine (mirrors `test_deploy_entrypoint_disable_loops`
+and `test_refuse_public_push_with_leak`) these run the REAL script in a bash
+subprocess with a stub `docker` on PATH and every path env-overridden into
+`tmp_path` — nothing about the shell logic is reimplemented.
+"""
+
+import os
+import shutil
+import stat
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(shutil.which("bash") is None, reason="needs bash")
+
+SCRIPT = Path(__file__).resolve().parents[1] / "deploy" / "migrate-volume-data.sh"
+_BASH = shutil.which("bash") or "bash"
+
+
+def _write_docker_stub(bin_dir: Path) -> None:
+    """A `docker` shim: `compose ps -q` prints STUB_RUNNING_ID; `up` logs the call."""
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    shim = bin_dir / "docker"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        'args="$*"\n'
+        'case "$args" in\n'
+        '  *"ps -q"*) printf "%s" "${STUB_RUNNING_ID:-}"; exit 0 ;;\n'
+        '  *" up "*|*" up") echo "$args" >> "$STUB_UP_LOG"; exit 0 ;;\n'
+        "esac\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+class _Env:
+    """A prepared tmp filesystem: fake host dirs, fake volume dirs, stub docker."""
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.bin = tmp_path / "bin"
+        _write_docker_stub(self.bin)
+
+        self.host_data = tmp_path / "host" / "teatree"
+        self.host_worktrees = tmp_path / "host" / "teatree-worktrees"
+        self.host_workspaces = tmp_path / "host" / "t3-workspaces"
+        self.vol_data = tmp_path / "vol" / "data" / "_data"
+        self.vol_worktrees = tmp_path / "vol" / "worktrees" / "_data"
+        self.vol_workspaces = tmp_path / "vol" / "workspaces" / "_data"
+        self.archive_root = tmp_path / "host"
+        for d in (
+            self.host_data,
+            self.host_worktrees,
+            self.host_workspaces,
+            self.vol_data,
+            self.vol_worktrees,
+            self.vol_workspaces,
+        ):
+            d.mkdir(parents=True, exist_ok=True)
+
+        # The host DB the operator has today (about to be archived + overwritten).
+        (self.host_data / "db.sqlite3").write_text("HOST_DB_ORIGINAL", encoding="utf-8")
+        # The real factory state living in the container volume (must win).
+        (self.vol_data / "db.sqlite3").write_text("VOLUME_DB_FACTORY", encoding="utf-8")
+        (self.vol_data / "instance_id").write_text("iid-123", encoding="utf-8")
+        (self.vol_data / ".password-store").mkdir()
+        (self.vol_worktrees / "wt-1").write_text("worktree-state", encoding="utf-8")
+        (self.vol_workspaces / "ws-1").write_text("workspace-state", encoding="utf-8")
+
+        self.up_log = tmp_path / "up.log"
+        self.up_log.write_text("", encoding="utf-8")
+        self.compose = tmp_path / "docker-compose.yml"
+        self.compose.write_text("name: teatree\n", encoding="utf-8")
+
+    def run(self, *, running_id: str = "") -> subprocess.CompletedProcess[str]:
+        env = dict(os.environ)
+        env["PATH"] = f"{self.bin}{os.pathsep}{env['PATH']}"
+        env["STUB_RUNNING_ID"] = running_id
+        env["STUB_UP_LOG"] = str(self.up_log)
+        env["MIGRATE_DOCKER"] = "docker"
+        env["MIGRATE_COMPOSE_FILE"] = str(self.compose)
+        env["MIGRATE_HOST_DATA"] = str(self.host_data)
+        env["MIGRATE_HOST_WORKTREES"] = str(self.host_worktrees)
+        env["MIGRATE_HOST_WORKSPACES"] = str(self.host_workspaces)
+        env["MIGRATE_VOL_DATA"] = str(self.vol_data)
+        env["MIGRATE_VOL_WORKTREES"] = str(self.vol_worktrees)
+        env["MIGRATE_VOL_WORKSPACES"] = str(self.vol_workspaces)
+        env["MIGRATE_ARCHIVE_ROOT"] = str(self.archive_root)
+        return subprocess.run(
+            [_BASH, str(SCRIPT)],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+
+    def archives(self) -> list[Path]:
+        return sorted(self.archive_root.glob("teatree-bindmount-archive-*"))
+
+
+class TestScriptIsClean:
+    def test_bash_syntax_is_valid(self) -> None:
+        proc = subprocess.run([_BASH, "-n", str(SCRIPT)], capture_output=True, text=True, check=False)
+        assert proc.returncode == 0, proc.stderr
+
+    def test_shellcheck_clean(self) -> None:
+        shellcheck = shutil.which("shellcheck")
+        if shellcheck is None:
+            pytest.skip("shellcheck not installed")
+        proc = subprocess.run([shellcheck, str(SCRIPT)], capture_output=True, text=True, check=False)
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+class TestRefusesWhenStackUp:
+    def test_refuses_and_touches_nothing(self, tmp_path: Path) -> None:
+        env = _Env(tmp_path)
+        result = env.run(running_id="deadbeefcafe")
+        assert result.returncode != 0
+        assert "Stop it first" in result.stderr
+        # Nothing archived, nothing overwritten, stack not brought up.
+        assert env.archives() == []
+        assert (env.host_data / "db.sqlite3").read_text(encoding="utf-8") == "HOST_DB_ORIGINAL"
+        assert env.up_log.read_text(encoding="utf-8") == ""
+
+
+class TestArchivesBeforeOverwrite:
+    def test_host_db_archived_then_overwritten_from_volume(self, tmp_path: Path) -> None:
+        env = _Env(tmp_path)
+        result = env.run(running_id="")
+        assert result.returncode == 0, result.stderr
+
+        archives = env.archives()
+        assert len(archives) == 1, "exactly one timestamped archive per run"
+        # The original host DB is preserved in the archive (never deleted)...
+        assert (archives[0] / "db.sqlite3").read_text(encoding="utf-8") == "HOST_DB_ORIGINAL"
+        # ...and the host DB is now the real factory state from the volume.
+        assert (env.host_data / "db.sqlite3").read_text(encoding="utf-8") == "VOLUME_DB_FACTORY"
+
+    def test_credentials_worktrees_workspaces_copied(self, tmp_path: Path) -> None:
+        env = _Env(tmp_path)
+        assert env.run().returncode == 0
+        assert (env.host_data / "instance_id").read_text(encoding="utf-8") == "iid-123"
+        assert (env.host_data / ".password-store").is_dir()
+        assert (env.host_worktrees / "wt-1").read_text(encoding="utf-8") == "worktree-state"
+        assert (env.host_workspaces / "ws-1").read_text(encoding="utf-8") == "workspace-state"
+
+    def test_stack_brought_up_after_copy(self, tmp_path: Path) -> None:
+        env = _Env(tmp_path)
+        assert env.run().returncode == 0
+        assert "up" in env.up_log.read_text(encoding="utf-8")
+
+    def test_idempotent_rerun_archives_again_and_never_deletes(self, tmp_path: Path) -> None:
+        env = _Env(tmp_path)
+        assert env.run().returncode == 0
+        # Second run: host DB is already the factory value; a fresh archive of it
+        # is made and the first archive is untouched.
+        time.sleep(1)  # timestamped archive dir is second-resolution
+        assert env.run().returncode == 0
+        archives = env.archives()
+        assert len(archives) == 2, "each run makes its own archive; none are deleted"
+        assert (archives[0] / "db.sqlite3").read_text(encoding="utf-8") == "HOST_DB_ORIGINAL"
+
+
+class TestFailsLoudWhenVolumesMissing:
+    def test_missing_volume_dir_is_a_clear_error(self, tmp_path: Path) -> None:
+        env = _Env(tmp_path)
+        shutil.rmtree(env.vol_data)
+        result = env.run()
+        assert result.returncode != 0
+        assert "volume dir not found" in result.stderr
+        # Refused before archiving.
+        assert env.archives() == []
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary

PR-1 of the Docker unification (owner-approved, from a Fable design). Externalizes
the headless factory's state onto the host local disk via bind mounts, so there is
**ONE** DB outside Docker (the daily-backed-up host DB at
`~/.local/share/teatree/db.sqlite3`) instead of the current separate named-volume
DB living inside Docker. That split is why operator config + tickets diverge
between host and container.

## What changed

- **`deploy/docker-compose.yml`** — replace the `teatree_data` / `teatree_worktrees`
  / `teatree_workspaces` **named volumes** with **host bind mounts at the identical
  canonical absolute paths**:
  - `/home/teatree/.local/share/teatree`
  - `/home/teatree/.local/share/teatree-worktrees`
  - `/home/teatree/workspace/t3-workspaces`

  Bind source == container target, so the container and the host converge on one
  `db.sqlite3` by **path identity** — HOME is `/home/teatree` in both and
  `deploy/Dockerfile` sets no `XDG_DATA_HOME`, so no code/config knob is needed.
  `teatree_src` and `teatree_uv` stay named volumes for now (later PRs handle
  code-mount modes); the now-unused named-volume declarations are removed.

- **`deploy/migrate-volume-data.sh`** (new) — a one-shot, idempotent, SAFE
  migration the **OWNER** runs (not the deploy workflow). It:
  1. refuses to run while the stack is up (tells the operator to `down` first),
  2. archives the existing host DB + `backups/` (timestamped, **never deleted**),
  3. copies the container volume's contents (DB, `.password-store`, `.gnupg`,
     `backups/`, `instance_id`, worktrees, workspaces) from
     `/var/lib/docker/volumes/teatree_teatree_*/_data` onto the host bind paths —
     KEEPING the container volume's real factory state and archive-then-overwriting
     the host DB,
  4. brings the stack up.

  `set -euo pipefail`, prints each step, `cp -a` preserves the teatree uid/gid.
  Run with `sudo` (reads `/var/lib/docker/volumes`).

- **`deploy/README.md`** — documents the external-DB layout (host bind mounts,
  path identity) and that `migrate-volume-data.sh` is a one-time operator step.

## Tests

- `tests/test_deploy_bindmount_compose.py` — parses `deploy/docker-compose.yml` and
  asserts `type: bind` with `source == target` at each canonical host path, the
  kept named volumes remain, and the removed named-volume declarations are gone.
  Includes a golden `docker compose config --format json` render assertion (runs
  when docker is present, skips cleanly otherwise).
- `tests/test_deploy_migrate_volume_data.py` — runs the real script in a bash
  subprocess with a stub `docker` and env-overridden paths: `bash -n` +
  shellcheck-clean, refuses when the stack is up (touching nothing), archives the
  original host DB before overwriting it from the volume, copies
  credentials/worktrees/workspaces, brings the stack up, is idempotent across
  re-runs (never deletes an archive), and fails loud when a volume dir is missing.

## Notes / scope

- SUBSTRATE (`deploy/`) — code + script only. The migration is **not** run here and
  no container is restarted; this holds for owner sign-off before the operator runs
  `sudo deploy/migrate-volume-data.sh`.
- `bash dev/ci-parity-fast.sh` is green (676 passed); ruff + tach clean; each
  touched file is well under 500 LOC.

## Open questions & assumptions

- Assumes the box's Docker named volumes follow the compose `name: teatree`
  prefixing (`teatree_teatree_data`, etc.); the script's volume paths are
  env-overridable if a box differs.
- Assumes the container process uid equals the host `teatree` uid (both under
  `/home/teatree`), so `cp -a` lays down host-readable files — consistent with the
  path-identity design this PR relies on.
