### PR TITLE
fix(dash): confirm before firing state-changing dashboard actions (#3264)

### DIFF
--- a/e2e/dash/conftest.py
+++ b/e2e/dash/conftest.py
@@ -56,3 +56,16 @@ def console_guard(page: Page) -> ConsoleGuard:
     page.on("requestfailed", guard.on_request_failed)
     page.on("response", guard.on_response)
     return guard
+
+
+@pytest.fixture
+def accept_dialogs(page: Page) -> None:
+    """Auto-accept native JS dialogs (drawer ``confirm()`` / htmx ``hx-confirm``).
+
+    Playwright dismisses every native dialog by default (#3264/#3265 guard the
+    state-changing dashboard actions behind such a dialog), which would cancel the
+    guarded action before its request ever fires. A spec that must exercise the
+    accepted path registers this handler so the guarded POST proceeds. Specs that
+    assert the prompt itself register their own recording handler instead.
+    """
+    page.on("dialog", lambda dialog: dialog.accept())

--- a/e2e/dash/test_drawer.py
+++ b/e2e/dash/test_drawer.py
@@ -4,7 +4,7 @@ Card-click opens it, only legal FSM transitions render, executing one moves the
 card, history rows show, and Esc / the close button dismiss it (#3162).
 """
 
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Dialog, Page, expect
 from pytest_django.live_server_helper import LiveServer
 
 from e2e.dash.pom import BoardPage, SeededBoard
@@ -33,14 +33,54 @@ def test_only_legal_transitions_render(live_server: LiveServer, page: Page, seed
     expect(drawer.root.get_by_role("button", name="ship", exact=True)).to_have_count(0)
 
 
-def test_executing_a_transition_moves_the_card(live_server: LiveServer, page: Page, seeded_board: SeededBoard) -> None:
+def test_confirming_the_transition_moves_the_card(
+    live_server: LiveServer, page: Page, seeded_board: SeededBoard
+) -> None:
     board = BoardPage(page, live_server.url)
     board.open()
     drawer = board.open_drawer_for(seeded_board.backlog.pk)
+    # The transition button is guarded by a native confirm() (#3264/#3265). Record
+    # + accept the prompt explicitly (Playwright dismisses dialogs by default) to
+    # prove BOTH that the prompt appears AND that accepting fires the guarded POST.
+    prompts: list[str] = []
+
+    def _accept(dialog: Dialog) -> None:
+        prompts.append(dialog.message)
+        dialog.accept()
+
+    page.on("dialog", _accept)
     drawer.transition_buttons.filter(has_text="scope").click()
-    # The POST redirects to the board; the card is now in the SCOPED column.
+    expected = f"Transition #{seeded_board.backlog.ticket_number} to scope?"
+    if prompts != [expected]:
+        msg = f"confirm prompt was {prompts!r}, expected [{expected!r}]"
+        raise AssertionError(msg)
+    # The accepted POST redirects to the board; the card is now in the SCOPED column.
     expect(board.card_in_column(State.SCOPED, seeded_board.backlog.pk)).to_be_visible()
     expect(board.card_in_column(State.NOT_STARTED, seeded_board.backlog.pk)).to_have_count(0)
+
+
+def test_dismissing_the_transition_confirm_keeps_the_card(
+    live_server: LiveServer, page: Page, seeded_board: SeededBoard
+) -> None:
+    board = BoardPage(page, live_server.url)
+    board.open()
+    drawer = board.open_drawer_for(seeded_board.backlog.pk)
+    # Dismissing the confirm() must cancel the transition — the guard's whole point.
+    prompts: list[str] = []
+
+    def _dismiss(dialog: Dialog) -> None:
+        prompts.append(dialog.message)
+        dialog.dismiss()
+
+    page.on("dialog", _dismiss)
+    drawer.transition_buttons.filter(has_text="scope").click()
+    expected = f"Transition #{seeded_board.backlog.ticket_number} to scope?"
+    if prompts != [expected]:
+        msg = f"confirm prompt was {prompts!r}, expected [{expected!r}]"
+        raise AssertionError(msg)
+    # No POST fired: the card stays put in its original column.
+    expect(board.card_in_column(State.NOT_STARTED, seeded_board.backlog.pk)).to_be_visible()
+    expect(board.card_in_column(State.SCOPED, seeded_board.backlog.pk)).to_have_count(0)
 
 
 def test_transition_history_rows_render(live_server: LiveServer, page: Page, seeded_board: SeededBoard) -> None:

--- a/e2e/dash/test_terminal.py
+++ b/e2e/dash/test_terminal.py
@@ -26,7 +26,7 @@ def test_terminal_button_visible_on_board(live_server: LiveServer, page: Page) -
     expect(page.get_by_role("button", name=_TERMINAL)).to_be_visible()
 
 
-@pytest.mark.usefixtures("seeded_board")
+@pytest.mark.usefixtures("seeded_board", "accept_dialogs")
 def test_terminal_button_click_renders_launch_url(live_server: LiveServer, page: Page) -> None:
     board = BoardPage(page, live_server.url)
     board.open()

--- a/src/teatree/dash/snapshots/board.html
+++ b/src/teatree/dash/snapshots/board.html
@@ -41,6 +41,7 @@
       carries the CSRF token. #}
       <button type="button" class="dash-btn" data-terminal
         hx-post="/dash/debug/session/" hx-target="#terminal-result" hx-swap="innerHTML"
+        hx-confirm="Start a loopback debug session?"
         aria-label="Open a loopback terminal session">
         <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true">
           <path fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" d="M2 3h12v10H2zM4.5 6.5l2 1.5-2 1.5M8.5 10h3"/>

--- a/src/teatree/dash/templates/dash/base.html
+++ b/src/teatree/dash/templates/dash/base.html
@@ -37,6 +37,7 @@
       carries the CSRF token. #}
       <button type="button" class="dash-btn" data-terminal
         hx-post="{% url 'dash:debug_session' %}" hx-target="#terminal-result" hx-swap="innerHTML"
+        hx-confirm="Start a loopback debug session?"
         aria-label="Open a loopback terminal session">
         <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true">
           <path fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" d="M2 3h12v10H2zM4.5 6.5l2 1.5-2 1.5M8.5 10h3"/>

--- a/src/teatree/dash/templates/dash/health.html
+++ b/src/teatree/dash/templates/dash/health.html
@@ -14,9 +14,9 @@
       {% csrf_token %}
       {% for spec in command_buttons %}
         {% if spec.needs_loop %}
-          <span class="field-group"><input type="text" name="loop" placeholder="loop name"><button class="dash-btn" name="command" value="{{ spec.key }}">{{ spec.label }}</button></span>
+          <span class="field-group"><input type="text" name="loop" placeholder="loop name"><button class="dash-btn" name="command" value="{{ spec.key }}" hx-confirm="Run {{ spec.label }}?">{{ spec.label }}</button></span>
         {% else %}
-          <button class="dash-btn" name="command" value="{{ spec.key }}">{{ spec.label }}</button>
+          <button class="dash-btn" name="command" value="{{ spec.key }}" hx-confirm="Run {{ spec.label }}?">{{ spec.label }}</button>
         {% endif %}
       {% endfor %}
     </form>

--- a/src/teatree/dash/templates/dash/partials/_drawer.html
+++ b/src/teatree/dash/templates/dash/partials/_drawer.html
@@ -17,7 +17,7 @@
     <form class="toolbar" method="post" action="{% url 'dash:ticket_transition' detail.ticket_id %}">
       {% csrf_token %}
       {% for name in detail.available_transitions %}
-        <button class="dash-btn primary" name="action" value="{{ name }}">{{ name }}</button>
+        <button class="dash-btn primary" name="action" value="{{ name }}" onclick="return confirm('Transition #{{ detail.number|escapejs }} to {{ name|escapejs }}?')">{{ name }}</button>
       {% endfor %}
     </form>
   {% else %}
@@ -79,7 +79,7 @@
   <h3>Debug session</h3>
   <form method="post" action="{% url 'dash:debug_session' %}" hx-post="{% url 'dash:debug_session' %}" hx-target="#debug-session-result" hx-swap="innerHTML">
     {% csrf_token %}
-    <button class="dash-btn" type="submit">Debug session (loopback ttyd)</button>
+    <button class="dash-btn" type="submit" hx-confirm="Start a loopback debug session?">Debug session (loopback ttyd)</button>
   </form>
   <div id="debug-session-result"></div>
 </div>

--- a/tests/teatree_dash/views/test_health.py
+++ b/tests/teatree_dash/views/test_health.py
@@ -44,6 +44,17 @@ class HealthPageTestCase(TestCase):
         body = resp.content.decode()
         assert "t3 doctor check" in body
 
+    def test_command_buttons_carry_confirmation(self) -> None:
+        # #3264: allowlisted commands run a shell action — confirm before firing.
+        body = self.client.get(reverse("dash:health")).content.decode()
+        assert "hx-confirm=" in body
+        assert "Run t3 doctor check?" in body
+
+    def test_terminal_button_carries_confirmation(self) -> None:
+        # #3264: the always-visible loopback terminal spawns a session — confirm first.
+        body = self.client.get(reverse("dash:health")).content.decode()
+        assert "Start a loopback debug session?" in body
+
 
 class HealthAccessGateTestCase(TestCase):
     """DASH-2: the health page + its bands poll partial carry the same loopback gate.

--- a/tests/teatree_dash/views/test_tickets.py
+++ b/tests/teatree_dash/views/test_tickets.py
@@ -69,3 +69,17 @@ class TicketDrawerGetTestCase(TestCase):
     def test_drawer_404_for_missing_ticket(self) -> None:
         resp = self.client.get(reverse("dash:ticket_drawer", args=[999999]))
         assert resp.status_code == 404
+
+    def test_transition_buttons_carry_confirmation_naming_state(self) -> None:
+        # #3264: a transition button must prompt before firing the FSM POST, and the
+        # prompt must name the ticket + the target action so an accidental click is caught.
+        ticket = TicketFactory(state=State.NOT_STARTED)
+        body = self.client.get(reverse("dash:ticket_drawer", args=[ticket.pk])).content.decode()
+        assert "return confirm(" in body
+        assert f"Transition #{ticket.ticket_number} to scope?" in body
+
+    def test_debug_session_button_carries_confirmation(self) -> None:
+        ticket = TicketFactory(state=State.STARTED)
+        body = self.client.get(reverse("dash:ticket_drawer", args=[ticket.pk])).content.decode()
+        assert "hx-confirm=" in body
+        assert "Start a loopback debug session?" in body


### PR DESCRIPTION
## Summary
Dashboard state-changing actions fired their POST immediately on click with no
confirmation. An accidental click on a drawer "Actions" transition button moved a
ticket through its FSM with no undo prompt (`_drawer.html:16-21`), and the
allowlisted debug-command buttons and the loopback debug-session triggers had the
same immediate-fire behaviour.

## Fix
A confirmation step naming the action + ticket now guards every state-changing
dashboard action:

- **Transition buttons** (`_drawer.html`) carry a JS `confirm()` — the Actions form
  is a plain POST, not htmx — prompting `Transition #<id> to <action>?`.
- **Allowlisted command buttons** (`health.html`) carry `hx-confirm="Run <label>?"`.
- **Debug-session buttons** — the drawer's `Debug session (loopback ttyd)` and the
  always-visible header `Terminal` button (`base.html`) — carry
  `hx-confirm="Start a loopback debug session?"`.

Read-only navigation (nav links, board filters) is untouched. The board HTML
snapshot is regenerated for the base-template `hx-confirm` addition.

## Tests
- `test_transition_buttons_carry_confirmation_naming_state` — the rendered transition
  button carries the `confirm(` handler and names the ticket + target action.
- `test_debug_session_button_carries_confirmation` / `test_terminal_button_carries_confirmation`
  — the debug/terminal triggers carry `hx-confirm`.
- `test_command_buttons_carry_confirmation` — the allowlisted command buttons carry
  `hx-confirm` naming the command.

All observed RED before the template change, GREEN after. Full `tests/teatree_dash`
suite (120) and `dev/ci-parity-fast.sh` (676) green.

## Architecture pre-check
Tactical UI fix — templates + tests only, no `src/teatree/{cli,core,agents}` code,
no FSM/Protocol/OverlayBase surface, no new module. The ten-check architecture gate
does not fire for a template-only change. Behaviour is purely additive (a confirm
prompt); no existing behaviour removed.

Closes #3264
