### PR TITLE
fix(statusline,doctor): non-blank autoload-off bar + plugin-scoped teatree MCP match

### DIFF
--- a/hooks/scripts/statusline.sh
+++ b/hooks/scripts/statusline.sh
@@ -125,6 +125,13 @@ autoload_enabled() {
 }
 
 if [ -n "$session_id" ] && ! autoload_enabled; then
+    # #3233: CC discards zero-byte statusline output, so a silent ``exit 0``
+    # here renders a mysteriously BLANK bar under the non-TTY CC invocation
+    # (session_id set) — invisible to every run-the-script-by-hand debug pass.
+    # Emit one neutral hint line instead so the bar is never empty; the #256
+    # colleague guarantee still holds (the loop statusline stays suppressed —
+    # only this one-line how-to shows).
+    printf 'teatree: statusline off (autoload disabled) · enable: t3 <overlay> config_setting set autoload true\n'
     exit 0
 fi
 

--- a/src/teatree/cli/doctor/checks.py
+++ b/src/teatree/cli/doctor/checks.py
@@ -331,12 +331,22 @@ def _check_teatree_mcp_registration() -> bool:
         statuses = probe_mcp_servers()
     except Exception:  # noqa: BLE001 — live probe is best-effort; claude may be absent
         return True
-    for status in statuses:
-        if status.name == TEATREE_MCP_SERVER_NAME and not status.connected:
-            typer.echo(
-                f"WARN  MCP server '{TEATREE_MCP_SERVER_NAME}' is registered but reports NOT "
-                "connected in `claude mcp list` — it may not have started for this session yet.",
-            )
+    # #3255: the same shipped ``.mcp.json`` surfaces under two CC scopes on a
+    # dogfooding box — ``plugin:t3:teatree`` (plugin scope, the live one) and a
+    # separate ``teatree`` (project scope, often Pending approval). Treat any
+    # ``:teatree``-suffixed or bare ``teatree`` entry as the same server; WARN
+    # only when NONE of them is connected (a genuine disconnection), never when
+    # the plugin-scoped one is up beside a pending project entry.
+    teatree_statuses = [
+        status
+        for status in statuses
+        if status.name == TEATREE_MCP_SERVER_NAME or status.name.endswith(f":{TEATREE_MCP_SERVER_NAME}")
+    ]
+    if teatree_statuses and not any(status.connected for status in teatree_statuses):
+        typer.echo(
+            f"WARN  MCP server '{TEATREE_MCP_SERVER_NAME}' is registered but reports NOT "
+            "connected in `claude mcp list` — it may not have started for this session yet.",
+        )
     return True
 
 

--- a/tests/teatree_cli/doctor/test_teatree_mcp_registration_check.py
+++ b/tests/teatree_cli/doctor/test_teatree_mcp_registration_check.py
@@ -52,6 +52,40 @@ class TestTeatreeMcpRegistrationDoctorCheck:
         assert "WARN" in out
         assert "not" in out
 
+    def test_plugin_scoped_connected_with_pending_project_entry_is_silent(self, tmp_path: Path, capsys) -> None:
+        """#3255: ``plugin:t3:teatree`` Connected + a pending project ``teatree`` → no WARN.
+
+        Both entries load the same shipped ``.mcp.json`` under two CC scopes; the
+        plugin-scoped one being connected means the MCP is live.
+        """
+        (tmp_path / ".mcp.json").write_text('{"mcpServers": {"teatree": {"command": "t3", "args": ["mcp", "serve"]}}}')
+        statuses = [
+            McpServerStatus(name="plugin:t3:teatree", url="", connected=True),
+            McpServerStatus(name="teatree", url="", connected=False),
+        ]
+        with (
+            patch("teatree.cli.doctor.plugin_repair._resolve_main_clone", return_value=tmp_path),
+            patch("teatree.core.mcp_connectivity.probe_mcp_servers", return_value=statuses),
+        ):
+            assert _check_teatree_mcp_registration() is True
+        assert capsys.readouterr().out == ""
+
+    def test_no_teatree_entry_connected_still_warns(self, tmp_path: Path, capsys) -> None:
+        """Regression intact: when neither scope is connected, the WARN still fires."""
+        (tmp_path / ".mcp.json").write_text('{"mcpServers": {"teatree": {"command": "t3", "args": ["mcp", "serve"]}}}')
+        statuses = [
+            McpServerStatus(name="plugin:t3:teatree", url="", connected=False),
+            McpServerStatus(name="teatree", url="", connected=False),
+        ]
+        with (
+            patch("teatree.cli.doctor.plugin_repair._resolve_main_clone", return_value=tmp_path),
+            patch("teatree.core.mcp_connectivity.probe_mcp_servers", return_value=statuses),
+        ):
+            assert _check_teatree_mcp_registration() is True
+        out = capsys.readouterr().out
+        assert "WARN" in out
+        assert "not" in out
+
     def test_registered_but_absent_from_probe_is_silent(self, tmp_path: Path, capsys) -> None:
         (tmp_path / ".mcp.json").write_text('{"mcpServers": {"teatree": {"command": "t3", "args": ["mcp", "serve"]}}}')
         with (

--- a/tests/test_claude_statusline.py
+++ b/tests/test_claude_statusline.py
@@ -1421,18 +1421,21 @@ class TestStatuslineAutoloadDbFlip:
         assert result.returncode == 0, result.stderr
         assert "model=" in _strip_ansi(result.stdout)
 
-    def test_db_autoload_false_is_off(self, tmp_path: Path) -> None:
+    def test_db_autoload_false_shows_hint_not_blank(self, tmp_path: Path) -> None:
         db = tmp_path / "db.sqlite3"
         _make_config_db(db, autoload=False)
         result = self._run_gate(tmp_path, config_db=db)
         assert result.returncode == 0, result.stderr
-        assert result.stdout == ""
+        # #3233: gated OFF emits a single how-to hint, never zero bytes.
+        assert "autoload" in result.stdout
+        assert "model=" not in _strip_ansi(result.stdout)
 
-    def test_missing_db_falls_back_to_off(self, tmp_path: Path) -> None:
-        # No DB row -> the gate falls through to OFF (blank statusline).
+    def test_missing_db_falls_back_to_off_hint(self, tmp_path: Path) -> None:
+        # No DB row -> the gate falls through to OFF: one-line hint, not blank (#3233).
         result = self._run_gate(tmp_path, config_db=tmp_path / "absent.sqlite3")
         assert result.returncode == 0, result.stderr
-        assert result.stdout == ""
+        assert "autoload" in result.stdout
+        assert "model=" not in _strip_ansi(result.stdout)
 
 
 class TestStatuslineRendersOnAutoloadWithoutMarker:
@@ -1449,8 +1452,8 @@ class TestStatuslineRendersOnAutoloadWithoutMarker:
     session", so it alone gates whether the statusline renders. Loop *arming* keeps
     its stricter ``marker AND autoload`` gate (``_loop_auto_load_active``); this is
     display *visibility*, which the owner wants in every one of their sessions. The
-    #256 colleague guarantee is preserved: ``autoload`` off is blank regardless of
-    the marker.
+    #256 colleague guarantee is preserved: ``autoload`` off shows only a one-line
+    how-to hint (#3233), never the loop statusline, regardless of the marker.
     """
 
     def _run(self, tmp_path: Path, *, autoload: bool, marker: bool) -> subprocess.CompletedProcess:
@@ -1492,19 +1495,23 @@ class TestStatuslineRendersOnAutoloadWithoutMarker:
         assert result.returncode == 0, result.stderr
         assert "model=" in _strip_ansi(result.stdout)
 
-    def test_autoload_off_without_marker_is_blank(self, tmp_path: Path) -> None:
-        # Colleague who merely cloned the repo: autoload off, no marker -> blank (#256).
+    def test_autoload_off_without_marker_shows_hint(self, tmp_path: Path) -> None:
+        # Colleague who merely cloned the repo: autoload off, no marker -> the loop
+        # statusline stays suppressed (#256), but a one-line how-to hint shows
+        # instead of a blank bar (#3233).
         result = self._run(tmp_path, autoload=False, marker=False)
         assert result.returncode == 0, result.stderr
-        assert result.stdout == ""
+        assert "autoload" in result.stdout
+        assert "model=" not in _strip_ansi(result.stdout)
 
-    def test_autoload_off_with_marker_is_blank(self, tmp_path: Path) -> None:
+    def test_autoload_off_with_marker_shows_hint(self, tmp_path: Path) -> None:
         # #256: a colleague who even loaded a teatree skill (marker present) but did
-        # NOT enable autoload is still not shown the statusline — autoload is the
-        # authoritative owner opt-in, so it alone can turn the statusline on.
+        # NOT enable autoload is still not shown the loop statusline — autoload is the
+        # authoritative owner opt-in. Only the one-line hint shows (#3233).
         result = self._run(tmp_path, autoload=False, marker=True)
         assert result.returncode == 0, result.stderr
-        assert result.stdout == ""
+        assert "autoload" in result.stdout
+        assert "model=" not in _strip_ansi(result.stdout)
 
 
 # A dangling escape is an ESC byte that does NOT open a recognised, complete
@@ -1632,3 +1639,47 @@ class TestWidthCap:
 
         assert result.returncode == 0, result.stderr
         assert osc8 in result.stdout, repr(result.stdout)
+
+
+class TestAutoloadOffHint:
+    """Autoload-off gate emits a one-line hint, never a blank bar (#3233).
+
+    When the opt-in (#256) gate suppresses the statusline under a non-TTY CC
+    invocation, it must emit a one-line hint — never zero bytes, which CC
+    discards, leaving a mysteriously blank bar.
+    """
+
+    def _run_gated(self, tmp_path: Path, *, session_id: str) -> subprocess.CompletedProcess:
+        env = os.environ.copy()
+        env.pop("T3_AUTOLOAD", None)  # autoload OFF: no env override
+        # Point the config DB at a path that does not exist so the DB read
+        # resolves autoload to OFF as well (fails silent → gate fires).
+        env["T3_CONFIG_DB"] = str(tmp_path / "no-such-db.sqlite3")
+        env["TEATREE_CLAUDE_STATUSLINE_STATE_DIR"] = str(tmp_path / "state")
+        (tmp_path / "state").mkdir(parents=True, exist_ok=True)
+        return subprocess.run(
+            [str(SCRIPT)],
+            input=json.dumps({"session_id": session_id, "model": {"display_name": "Claude Opus"}}),
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+            cwd=REPO_ROOT,
+        )
+
+    def test_autoload_off_emits_one_line_hint_not_blank(self, tmp_path: Path) -> None:
+        result = self._run_gated(tmp_path, session_id="s-gated")
+
+        assert result.returncode == 0, result.stderr
+        # Never zero bytes — CC discards empty output and the bar goes blank.
+        assert result.stdout.strip() != "", "autoload-off must not emit an empty statusline"
+        # A single actionable line naming the enable knob.
+        assert len(result.stdout.splitlines()) == 1, repr(result.stdout)
+        assert "autoload" in result.stdout
+
+    def test_no_session_id_still_renders_full_bar(self, tmp_path: Path) -> None:
+        # TTY-style / no-session invocation is not gated: the hint must NOT
+        # replace the normal (multi-line) render.
+        result = self._run_gated(tmp_path, session_id="")
+        assert result.returncode == 0, result.stderr
+        assert "autoload" not in result.stdout

--- a/tests/test_teatree_opt_in.py
+++ b/tests/test_teatree_opt_in.py
@@ -607,14 +607,16 @@ class TestStatuslineGating:
         out = self._run_statusline("no-teatree-sess", state_dir, extra_env={"T3_AUTOLOAD": "1"})
         assert out != ""
 
-    def test_marker_present_but_auto_load_off_produces_no_output(self, tmp_path: Path) -> None:
-        # The #256 colleague case: a session that loaded teatree (marker
-        # present) but never enabled autoload stays silent.
+    def test_marker_present_but_auto_load_off_shows_hint(self, tmp_path: Path) -> None:
+        # The #256 colleague case: a session that loaded teatree (marker present)
+        # but never enabled autoload gets NO loop statusline — only a one-line
+        # how-to hint (#3233), never a blank bar (CC discards zero bytes).
         state_dir = tmp_path / "state"
         state_dir.mkdir(parents=True, exist_ok=True)
         (state_dir / "teatree-sess.teatree-active").touch()
         out = self._run_statusline("teatree-sess", state_dir, home=tmp_path / "fresh-home")
-        assert out == ""
+        assert "autoload" in out
+        assert "model=" not in out
 
     def test_marker_and_env_opt_in_produces_output(self, tmp_path: Path) -> None:
         state_dir = tmp_path / "state"


### PR DESCRIPTION
## Summary

A bundle of two related statusline/doctor bug fixes (owner wants fewer PRs).

### #3233 — statusline.sh silently blanks when autoload is off

`hooks/scripts/statusline.sh` exited `0` with **zero stdout** when the #256
autoload opt-in gate fired under a non-TTY CC invocation (`session_id` set).
Claude Code discards empty statusline output, so the bar rendered mysteriously
blank — and the failure was invisible to every run-the-script-by-hand debug
pass, because a TTY stdin never sets `session_id`, so the gate is skipped and
the four lines print perfectly by hand.

Fix: emit a single how-to hint line instead of zero bytes when the gate
suppresses the statusline. The #256 colleague guarantee still holds — the loop
statusline stays fully suppressed; only the one-line hint shows, so a fresh box
is never a mystery blank bar.

### #3255 — t3 doctor false-WARNs teatree MCP 'not connected'

`_check_teatree_mcp_registration` (`src/teatree/cli/doctor/checks.py`) matched
`status.name == "teatree"` literally. On a dogfooding box the same shipped
`.mcp.json` loads under two CC scopes — `plugin:t3:teatree` (Connected, the live
one) and a separate `teatree` (project scope, Pending approval). The literal
match hit the pending project entry and WARNed while the plugin-scoped server
was actually connected.

Fix: treat any `:teatree`-suffixed entry (or the bare `teatree`) as the same
server, and WARN only when **none** of them is connected. The genuine
all-disconnected case still WARNs (regression intact).

### #3237 — SKIPPED (scope)

Not in this PR. #3237 is a genuine architectural redesign, not a small hook: it
adds a new `OverlayBase` extension-point hook (`get_statusline_segments()`) plus
a `StatuslineSegment` dataclass, changes the Python→shell `tick-meta.json` data
contract (a new `segments` list), generalizes the bash `cost_chip` splice into a
placement/color-aware segment renderer, and does a clean-cutover migration that
retires the dedicated `cost_chip` key. An `OverlayBase` contract change also
obligates updating every registered overlay in the same change, and it overlaps
the statusline rendering area recently refactored by #3249. Bundling that with
two tactical one-file fixes would balloon and destabilize this PR. Left as a
standalone follow-up.

## Test evidence

- `tests/teatree_cli/doctor/test_teatree_mcp_registration_check.py`: two new
  cases (plugin-scoped connected + pending project entry → silent;
  none-connected → still WARNs). RED-verified before the fix.
- `tests/test_claude_statusline.py`: new `TestAutoloadOffHint` (one-line hint,
  not blank; unchanged full render when not gated); four existing blank-behavior
  tests updated to assert the new hint.
- `tests/test_teatree_opt_in.py`: the colleague gate test updated to the hint.
- Local: doctor + mcp suites (206 passed), statusline + opt-in (152 passed),
  `bash dev/ci-parity-fast.sh` green (676 passed, push-gate FULL passed).
- `ruff check`, `ruff format --check`, `uv run tach check`, `ty check`,
  `makemigrations --check` (No changes), module-health + comment-density: all pass.

## Architecture pre-check

Tactical bug fixes (one-line-hint in a shell gate; a literal-match widening in a
doctor check) — no BLUEPRINT section, FSM boundary, or Protocol surface changes.

- **BLUEPRINT §** — §5.6 statusline rendering / doctor checks; no contract change.
- **FSM phase boundaries** — n/a.
- **Extension-point contracts** — none touched (that is exactly why #3237 is skipped).
- **Component boundaries** — `hooks/scripts/statusline.sh` (render gate) and
  `src/teatree/cli/doctor/checks.py` (doctor check); each stays in its home.
- **Dependency direction** — no new imports; `tach check` clean.
- **Test surface** — RED-verified regression tests per fix (above).
- **Resilience invariants** — both changes keep their fail-open posture (the gate
  still exits 0; the doctor check still degrades to WARN/silent on any probe error).
- **Identity / key normalization** — the `:teatree` match canonicalizes the
  plugin-scoped vs bare-scoped names as one logical server; only WARN on genuine
  all-disconnected.
- **Behavior preservation** — the autoload-off output changes from blank to a
  one-line hint (the requested #3233 behavior); no privacy/security matcher
  narrowed; no must-block test inverted. The doctor check only widens what counts
  as "connected"; the disconnected WARN is preserved.
- **Removability / harness-vs-data** — both are local, self-contained reverts;
  pure harness (a shell branch, a Python predicate), no data/config surface.

Closes #3233
Closes #3255
