### PR TITLE
fix(deploy): dedicated credential-plane bind mounts — restore factory after #3262 orphaned the pass store

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -59,16 +59,19 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 # it explicitly to that same canonical value would make paths.py refuse every
 # loop-provisioned worktree (CanonicalDBFromWorktreeError) and defeat the
 # teatree_worktrees auto-isolation volume.
-# The pass store and its GPG home live under the teatree_data volume so a
-# provisioned multi-account credential store survives container recreation
-# (the container HOME itself is image-backed and reset on every deploy).
+# The pass store and its GPG home are a DEDICATED credential-plane bind mount
+# (compose), decoupled from the data dir at their canonical host paths — so a
+# data-dir change can never orphan the provisioned credential store again (#3262
+# did exactly that by moving the data dir to a bind mount while these ENV paths
+# still pointed inside it). These now equal pass/gpg defaults for this HOME; kept
+# explicit for grep-ability and so a mountless standalone run still resolves.
 ENV PATH="/opt/teatree/uv/bin:/home/teatree/.local/bin:${PATH}" \
     UV_TOOL_DIR=/opt/teatree/uv/tools \
     UV_TOOL_BIN_DIR=/opt/teatree/uv/bin \
     UV_PYTHON_INSTALL_DIR=/opt/teatree/uv/python \
     TEATREE_CLONE_DIR=/home/teatree/teatree \
     TEATREE_REPO_URL=https://github.com/souliane/teatree.git \
-    PASSWORD_STORE_DIR=/home/teatree/.local/share/teatree/.password-store \
-    GNUPGHOME=/home/teatree/.local/share/teatree/.gnupg
+    PASSWORD_STORE_DIR=/home/teatree/.password-store \
+    GNUPGHOME=/home/teatree/.gnupg
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -37,10 +37,21 @@ the worker read the **same** `db.sqlite3` (WAL — safe concurrent reads):
 | Mount | Path | Kind | Holds |
 | --- | --- | --- | --- |
 | `teatree_src` | `/home/teatree/teatree` | named volume | the teatree clone (source) |
-| DB dir | `/home/teatree/.local/share/teatree` | **host bind mount** | the canonical DB (`db.sqlite3`) + credentials + backups |
+| DB dir | `/home/teatree/.local/share/teatree` | **host bind mount** | the canonical DB (`db.sqlite3`) + backups |
 | worktrees | `/home/teatree/.local/share/teatree-worktrees` | **host bind mount** | per-worktree isolated DBs |
 | workspaces | `/home/teatree/workspace/t3-workspaces` | **host bind mount** | ticket worktrees |
+| pass store | `/home/teatree/.password-store` | **host bind mount** | the gpg-encrypted secret store (Anthropic OAuth token, …) |
+| GPG home | `/home/teatree/.gnupg` | **host bind mount** | the private key that decrypts the pass store |
 | `teatree_uv` | `/opt/teatree/uv` | named volume | the runtime teatree Python + venv + `t3` shims |
+
+The **credential plane** (`~/.password-store` + `~/.gnupg`) is a dedicated pair of
+bind mounts, deliberately decoupled from the data dir: the container's
+`PASSWORD_STORE_DIR`/`GNUPGHOME` point at these canonical host paths, so a future
+change to the data-dir mount can never orphan the provisioned credential store (as
+happened when #3262 moved the data dir to a bind mount while these paths still
+pointed inside it). Secrets stay gpg-encrypted on the host disk, outside the
+backed-up data dir. A box using the `CLAUDE_CODE_OAUTH_TOKEN` env path instead just
+leaves these dirs empty (`deploy.sh` pre-creates them owned by the deploy user).
 
 ### External DB — one DB on the host disk
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -50,6 +50,12 @@ git -C "$REPO_ROOT" fetch --prune origin
 git -C "$REPO_ROOT" pull --ff-only
 echo "deploy: deploying $(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD) @ $(git -C "$REPO_ROOT" rev-parse --short HEAD)"
 
+# The credential-plane bind sources must pre-exist owned by the deploy user —
+# dockerd would otherwise create a missing source ROOT-owned, locking the user
+# out of later `pass insert` provisioning. Empty dirs are the sane degradation
+# for an env-token box (init's preflight then falls through to CLAUDE_CODE_OAUTH_TOKEN).
+install -d -m 700 "$HOME/.password-store" "$HOME/.gnupg"
+
 # Surface the WHY on a build/up failure — `set -e` would otherwise exit before
 # the Action log sees anything but "exited (1)".
 docker compose -f "$COMPOSE_FILE" up -d --build || {

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -30,6 +30,18 @@ x-teatree-common: &teatree-common
     - type: bind
       source: /home/teatree/workspace/t3-workspaces
       target: /home/teatree/workspace/t3-workspaces
+    # Credential plane: the host-provisioned pass store + its GPG home, as
+    # DEDICATED mounts decoupled from the data dir (a data-dir change must never
+    # orphan credentials again, as #3262 did). Path identity; rw — gpg-agent
+    # binds its socket and lock files inside GNUPGHOME on a headless box, and the
+    # slack/postgres secret writers insert into pass at runtime. Secrets stay
+    # gpg-encrypted on the host disk, OUTSIDE the backed-up data dir.
+    - type: bind
+      source: /home/teatree/.password-store
+      target: /home/teatree/.password-store
+    - type: bind
+      source: /home/teatree/.gnupg
+      target: /home/teatree/.gnupg
     - teatree_uv:/opt/teatree/uv
   init: true
 

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -30,11 +30,11 @@ git config --global user.email "${GIT_AUTHOR_EMAIL:-teatree@localhost}"
 git config --global init.defaultBranch main
 git config --global --add safe.directory "$CLONE_DIR"
 
-# The pass store's GPG home rides the teatree_data volume (see Dockerfile ENV);
-# gpg refuses a home directory that is readable by group/other, and volume
-# copy-up does not preserve the mode a provisioning run set. Every role fixes
-# the mode before anything reads a credential.
-if [ -n "${GNUPGHOME:-}" ] && [ -d "$GNUPGHOME" ]; then
+# The GPG home is a dedicated bind mount of the host ~/.gnupg (see Dockerfile ENV
+# + docker-compose credential plane); gpg refuses a home directory readable by
+# group/other. Fix the mode before anything reads a credential — but only when
+# the mount is writable (a hardened read-only mount would EROFS here under -e).
+if [ -n "${GNUPGHOME:-}" ] && [ -d "$GNUPGHOME" ] && [ -w "$GNUPGHOME" ]; then
     chmod 700 "$GNUPGHOME"
 fi
 
@@ -44,12 +44,29 @@ pass_store_has_anthropic() {
     pass ls anthropic >/dev/null 2>&1
 }
 
+# True when an anthropic/ entry actually DECRYPTS — `pass ls` only proves the
+# .gpg files exist, not that gpg can read them (the private key may be absent or
+# gpg-agent unable to start). Exit-code only; the plaintext never leaves gpg.
+anthropic_credential_decrypts() {
+    local store="${PASSWORD_STORE_DIR:-$HOME/.password-store}" entry
+    entry="$(find "$store/anthropic" -type f -name '*.gpg' 2>/dev/null | head -1)"
+    [ -n "$entry" ] || return 1
+    entry="${entry#"$store/"}"
+    pass show "${entry%.gpg}" >/dev/null 2>&1
+}
+
 # Fail loud, early, and actionably when a required runtime token is missing or
 # does not authenticate — otherwise a green deploy hides a dead loop.
 init_preflight() {
-    if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && ! pass_store_has_anthropic; then
-        echo "entrypoint: no Anthropic credential - set the CLAUDE_CODE_OAUTH_TOKEN repo secret, OR provision the box pass store (anthropic/<account>/oauth-token entries) and set anthropic_oauth_pass_paths - then re-run Deploy" >&2
-        exit 1
+    if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+        if ! pass_store_has_anthropic; then
+            echo "entrypoint: no Anthropic credential - no CLAUDE_CODE_OAUTH_TOKEN and the pass store has no anthropic/ entries. Is host ~/.password-store bind-mounted and provisioned (anthropic/<account>/oauth-token)? See deploy/README.md - then re-run Deploy" >&2
+            exit 1
+        fi
+        if ! anthropic_credential_decrypts; then
+            echo "entrypoint: the pass store lists anthropic/ entries but gpg cannot DECRYPT them - the GPG private key is missing from $GNUPGHOME or gpg-agent cannot start (is host ~/.gnupg bind-mounted with the decryption key?) - then re-run Deploy" >&2
+            exit 1
+        fi
     fi
     : "${TEATREE_GH_TOKEN:?MISSING TEATREE_GH_TOKEN - set the repo secret and re-run Deploy}"
     : "${GIT_AUTHOR_NAME:?MISSING GIT_AUTHOR_NAME - set the repo secret and re-run Deploy}"

--- a/tests/test_deploy_bindmount_compose.py
+++ b/tests/test_deploy_bindmount_compose.py
@@ -73,7 +73,7 @@ class TestExternalizedBindMounts:
         # The pass store + GPG home must be their own mounts (not nested under the
         # data dir), so externalizing/moving the data dir never orphans them again.
         binds = self._bind_mounts()
-        assert CREDENTIAL_PLANE <= set(binds), "pass store + GPG home must be host bind mounts"
+        assert set(binds) >= CREDENTIAL_PLANE, "pass store + GPG home must be host bind mounts"
         for source in CREDENTIAL_PLANE:
             assert not source.startswith("/home/teatree/.local/share/teatree"), (
                 f"{source}: credential plane must be decoupled from the data dir"

--- a/tests/test_deploy_bindmount_compose.py
+++ b/tests/test_deploy_bindmount_compose.py
@@ -4,8 +4,11 @@ PR-1 of the Docker unification: the factory's DB, worktrees, and workspaces
 must live on the host at their canonical absolute paths (not in Docker named
 volumes), so the container and the host converge on ONE db.sqlite3 via path
 identity (`deploy/Dockerfile` sets no `XDG_DATA_HOME`, HOME is `/home/teatree`
-in both). These tests pin the compose file to bind mounts at those exact host
-paths and confirm the now-unused named-volume declarations are gone.
+in both). The credential plane (the host pass store + its GPG home) is a further
+dedicated bind mount, decoupled from the data dir so a data-dir change can never
+orphan the provisioned credential store again (the #3262 regression). These tests
+pin the compose file to bind mounts at those exact host paths and confirm the
+now-unused named-volume declarations are gone.
 
 Structure is parsed from the YAML directly (the source of truth); a golden
 `docker compose config` assertion runs too when a usable docker is present.
@@ -21,12 +24,21 @@ import yaml
 
 COMPOSE_FILE = Path(__file__).resolve().parents[1] / "deploy" / "docker-compose.yml"
 
-# The three externalized mounts: canonical host path == container path (identity).
+# The three externalized state mounts: canonical host path == container path.
 EXTERNALIZED = {
     "/home/teatree/.local/share/teatree",
     "/home/teatree/.local/share/teatree-worktrees",
     "/home/teatree/workspace/t3-workspaces",
 }
+# The credential plane: the host pass store + its GPG home, DEDICATED bind mounts
+# decoupled from the data dir so a data-dir change can never orphan the
+# provisioned credential store again (#3262 regression). Also path identity.
+CREDENTIAL_PLANE = {
+    "/home/teatree/.password-store",
+    "/home/teatree/.gnupg",
+}
+# Every host bind mount the shared list must carry, by canonical source path.
+ALL_BIND_SOURCES = EXTERNALIZED | CREDENTIAL_PLANE
 # The two mounts that stay Docker-managed named volumes (later PRs handle these).
 KEPT_NAMED_VOLUMES = {"teatree_src", "teatree_uv"}
 REMOVED_NAMED_VOLUMES = {"teatree_data", "teatree_worktrees", "teatree_workspaces"}
@@ -42,17 +54,30 @@ def _common_volumes() -> list:
 
 
 class TestExternalizedBindMounts:
-    def test_state_dirs_are_bind_mounts_at_canonical_host_paths(self) -> None:
-        binds = {
+    def _bind_mounts(self) -> dict:
+        return {
             entry["source"]: entry
             for entry in _common_volumes()
             if isinstance(entry, dict) and entry.get("type") == "bind"
         }
-        assert set(binds) == EXTERNALIZED, "each externalized dir must be a host bind mount"
+
+    def test_state_dirs_are_bind_mounts_at_canonical_host_paths(self) -> None:
+        binds = self._bind_mounts()
+        assert set(binds) == ALL_BIND_SOURCES, "every state + credential dir must be a host bind mount"
         for source, entry in binds.items():
             # Path identity: the host source and the container target are the same
             # absolute path, so both see the same files with no XDG knob.
             assert entry["target"] == source, f"{source}: bind target must equal host source"
+
+    def test_credential_plane_is_a_dedicated_bind_mount(self) -> None:
+        # The pass store + GPG home must be their own mounts (not nested under the
+        # data dir), so externalizing/moving the data dir never orphans them again.
+        binds = self._bind_mounts()
+        assert CREDENTIAL_PLANE <= set(binds), "pass store + GPG home must be host bind mounts"
+        for source in CREDENTIAL_PLANE:
+            assert not source.startswith("/home/teatree/.local/share/teatree"), (
+                f"{source}: credential plane must be decoupled from the data dir"
+            )
 
     def test_kept_named_volume_mounts_still_present(self) -> None:
         named = {entry.split(":", 1)[0] for entry in _common_volumes() if isinstance(entry, str)}
@@ -93,7 +118,7 @@ class TestDockerComposeConfigGolden:
             pytest.skip(f"docker compose config unusable here: {proc.stderr.strip()[:200]}")
         rendered = json.loads(proc.stdout)
         mounts = {m["source"]: m for svc in rendered["services"].values() for m in svc.get("volumes", [])}
-        for path in EXTERNALIZED:
+        for path in ALL_BIND_SOURCES:
             assert path in mounts, f"{path} missing from rendered config"
             assert mounts[path]["type"] == "bind"
             assert mounts[path]["target"] == path


### PR DESCRIPTION
## Problem

PR #3262 (externalize DB) moved the container data dir `/home/teatree/.local/share/teatree` from a named volume to a host bind mount. But the container's `PASSWORD_STORE_DIR`/`GNUPGHOME` (Dockerfile ENV) pointed *inside* that dir. Pre-#3262 the named volume held the provisioned pass store + GPG home; post-#3262 the bind mount points at the host dir, which has no `.password-store`/`.gnupg` there (the host store is the standard `~/.password-store`). So in-container `pass ls anthropic` returns empty, `entrypoint.sh init_preflight()` finds neither an env token nor a pass entry, `exit 1`s, and worker/admin (`service_completed_successfully`) never start — the factory goes down.

## Fix

Dedicated **credential-plane** bind mounts for `~/.password-store` + `~/.gnupg` at their canonical paths, **decoupled from the data dir** so a future data-dir change can never orphan the credential store again. Point `PASSWORD_STORE_DIR`/`GNUPGHOME` at the standard host paths. Secrets stay gpg-encrypted on host disk, outside the backed-up data dir — nothing in cleartext.

- `deploy/docker-compose.yml`: two dedicated `bind` mounts (path identity, rw — gpg-agent binds its socket + lock files inside `GNUPGHOME` on a headless box).
- `deploy/Dockerfile`: ENV → `PASSWORD_STORE_DIR=/home/teatree/.password-store`, `GNUPGHOME=/home/teatree/.gnupg`; comment rewritten.
- `deploy/entrypoint.sh`: guard the `chmod` for a read-only mount (`-w`); upgrade preflight to probe an actual **decrypt** (`anthropic_credential_decrypts`), not just `pass ls`, with a **split diagnostic** that names this exact failure class (empty store vs. lists-but-won't-decrypt).
- `deploy/deploy.sh`: `install -d -m 700` the credential-plane sources so dockerd never creates them root-owned (sane degradation for a `CLAUDE_CODE_OAUTH_TOKEN` env-token box: dirs empty, preflight falls through to the env token).
- `tests/test_deploy_bindmount_compose.py`: pin the credential plane as dedicated bind mounts, decoupled from the data dir (6/6 pass).
- `deploy/README.md`: mount table + credential-plane note.

## Verified

Live on the box: rebuilt the `teatree` stack from this branch → init `Exited (0)`, worker + admin `Up`, `t3 worker status` = `RUNNING (pid 7)`, 16 loops enabled. In-container decrypt probe: `DECRYPT_OK`.

## Follow-ups (separate PRs)

- `t3 doctor` check pinning "container can reach the Anthropic credential".
- pass-first refactor: all secrets in `pass`, GH CI secret becomes a `pass insert` feeder, de-secret `teatree.env` (needs store-layout sign-off).

Refs #3262.
