### PR TITLE
fix(hooks): catch subprocess.TimeoutExpired in repo-visibility probes (fail-safe escape)

### DIFF
--- a/src/teatree/hooks/_repo_visibility.py
+++ b/src/teatree/hooks/_repo_visibility.py
@@ -25,7 +25,7 @@ from typing import Final, TypedDict
 
 from teatree.config import cold_reader
 from teatree.hooks import git_config_offline
-from teatree.utils.run import CommandFailedError, run_allowed_to_fail
+from teatree.utils.run import CommandFailedError, TimeoutExpired, run_allowed_to_fail
 
 
 class _VisibilityEntry(TypedDict):
@@ -171,7 +171,7 @@ def _origin_url_via_git(cwd: Path) -> str:
             env=_probe_env(),
             timeout=_PROBE_TIMEOUT_S,
         )
-    except (CommandFailedError, OSError):
+    except (CommandFailedError, OSError, TimeoutExpired):
         return ""
     return result.stdout.strip()
 
@@ -281,7 +281,7 @@ def _probe_gh(repo_path: str) -> str | None:
             env=_probe_env(),
             timeout=_PROBE_TIMEOUT_S,
         )
-    except (CommandFailedError, OSError):
+    except (CommandFailedError, OSError, TimeoutExpired):
         return None
     verdict = result.stdout.strip().upper()
     return verdict or None
@@ -302,7 +302,7 @@ def _probe_glab(repo_path: str) -> str | None:
             env=_probe_env(),
             timeout=_PROBE_TIMEOUT_S,
         )
-    except (CommandFailedError, OSError):
+    except (CommandFailedError, OSError, TimeoutExpired):
         return None
     try:
         project = json.loads(result.stdout)

--- a/tests/teatree_hooks/test_repo_visibility_probe.py
+++ b/tests/teatree_hooks/test_repo_visibility_probe.py
@@ -1,0 +1,85 @@
+"""A slow ``gh``/``glab`` visibility probe must fail SAFE, never propagate.
+
+:mod:`teatree.hooks._repo_visibility` runs each ``gh repo view`` / ``glab api``
+probe under a tight ``timeout`` so a hung forge call cannot block the caller.
+:func:`probe_visibility` documents a ``None`` (fail-safe "unknown") result on
+ANY probe error, and the git-remote resolver documents a ``""`` fail-safe. The
+probe subprocess raises :class:`subprocess.TimeoutExpired` on timeout, which is
+NOT a subclass of ``OSError``/``CommandFailedError`` — before this fix it escaped
+the ``except`` clauses and propagated.
+
+That escape is the root cause of the shuffled-collection CI red on
+``tests/teatree_loop/test_slack_broadcasts_own_author_identity.py``: the
+broadcast scanner's own-author skip calls
+:func:`teatree.core.review.author_trust.classify_author`, which probes repo
+visibility. A timed-out probe raised through ``classify_author`` into the
+scanner's broad ``except``, which logged "failed on message" and dropped the
+review-intent signal — so the colleague-MR broadcast dispatched nothing.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from teatree.core.review.author_trust import classify_author
+from teatree.hooks import _repo_visibility
+from teatree.utils.run import TimeoutExpired
+
+
+def _raise_timeout(cmd: object, *_args: object, **kwargs: object) -> object:
+    raise TimeoutExpired(cmd, kwargs.get("timeout"))
+
+
+@pytest.fixture(autouse=True)
+def _resolve_fake_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the probe find ``gh``/``glab``/``git`` so it reaches the subprocess call."""
+    monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda tool: f"/usr/bin/{tool}")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Route the visibility verdict cache under ``tmp_path`` so no on-disk verdict masks the probe."""
+    monkeypatch.setenv("T3_DATA_DIR", str(tmp_path / "viscache"))
+
+
+class TestProbeTimeoutFailsSafe:
+    """A timed-out probe returns the documented fail-safe verdict, never raises."""
+
+    def test_github_probe_timeout_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(_repo_visibility, "run_allowed_to_fail", _raise_timeout)
+
+        assert _repo_visibility.probe_visibility("github.com/octo/repo") is None
+
+    def test_gitlab_probe_timeout_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(_repo_visibility, "run_allowed_to_fail", _raise_timeout)
+
+        assert _repo_visibility.probe_visibility("gitlab.com/team/project") is None
+
+    def test_slug_is_private_timeout_is_not_private(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(_repo_visibility, "run_allowed_to_fail", _raise_timeout)
+
+        # An unresolvable (timed-out) probe must treat the repo as NOT private, not raise.
+        assert _repo_visibility.slug_is_private("github.com/octo/repo") is False
+
+
+class TestGitRemoteResolverTimeoutFailsSafe:
+    """The git-remote origin resolver returns ``""`` on a timed-out ``git`` call."""
+
+    def test_origin_url_via_git_timeout_returns_empty(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(_repo_visibility, "run_allowed_to_fail", _raise_timeout)
+
+        assert _repo_visibility._origin_url_via_git(tmp_path) == ""
+
+
+class TestClassifyAuthorSurvivesProbeTimeout:
+    """The scanner-facing seam is fail-safe: a timed-out probe yields the untrusted (public) verdict."""
+
+    def test_classify_author_does_not_raise_on_probe_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(_repo_visibility, "run_allowed_to_fail", _raise_timeout)
+
+        result = classify_author("team/project", "someone", host_kind="gitlab")
+
+        # Fail-safe direction: an unresolvable visibility is treated as PUBLIC, so an
+        # unknown author is untrusted — the caller keeps dispatching rather than crashing.
+        assert result.internal_repo is False
+        assert result.untrusted is True


### PR DESCRIPTION
## Problem

`src/teatree/hooks/_repo_visibility.py` runs each `gh`/`glab` visibility probe (and the git-remote origin resolver) under a 5s `subprocess.run(timeout=...)`, but the `except` clauses only caught `(CommandFailedError, OSError)`. `subprocess.TimeoutExpired` is a subclass of **neither**, so a slow/hung forge probe **escapes** and propagates — violating `probe_visibility`'s documented fail-safe-`None` contract.

Chain to the observed failure: the Slack broadcasts scanner's own-author skip calls `classify_author` → `repo_is_internal` → `slug_is_private` → the live probe. A timed-out probe raised `TimeoutExpired` up into `SlackBroadcastsScanner._scan_channel`'s broad `except Exception`, which logged `SlackBroadcastsScanner failed on message …` and dropped the signal. This surfaced as the flaky `test-shuffle (3.13, 1)` job on unrelated PRs (`test_colleague_mr_broadcast_still_dispatches` saw `[]` instead of `['slack.review_intent']`) — the shuffle only changed timing/adjacency enough to push CI's slow probe over the 5s timeout.

## Fix

Broaden the `except` at all three timeout-bounded call sites (`_probe_gh`, `_probe_glab`, `_origin_url_via_git`) to also catch `TimeoutExpired`, restoring the documented fail-safe (`None`/`""`). Scoped to the class of bug, not a single site.

## Verified

Regression test `tests/teatree_hooks/test_repo_visibility_probe.py` observed **RED** on unfixed code (forcing the probe to time out reproduces the exact `[] vs ['slack.review_intent']` failure), **GREEN** after. Affected-area run: 30 passed. `ruff`/format/`ty` clean.

This benefits every `classify_author` caller (all reviewing scanners + the merge keystone), not just the one flaky test.
