### PR TITLE
fix(deploy): link the runtime clone into the org-prefixed clone root

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -39,10 +39,16 @@ RUN mkdir -p \
         /home/teatree/workspace/t3-workspaces \
         /opt/teatree/uv && \
     # clone_root() resolves clones under ~/workspace, but the runtime clone
-    # lives on the teatree_src volume at ~/teatree — without this link the
-    # fleet-claim wire finds no local clone for the repo and fails safe
-    # (never claims), silently disabling the issue-implementer intake.
-    ln -s /home/teatree/teatree /home/teatree/workspace/teatree && \
+    # lives on the teatree_src volume at ~/teatree. Provisioning discovers the
+    # base clone with find_clone_path(clone_root, "souliane/teatree"), which
+    # matches the ORG-PREFIXED path ~/workspace/souliane/teatree (the slug's
+    # literal), NOT a bare ~/workspace/teatree — so the link must carry the
+    # owner segment. Without the org-prefixed link, `workspace ticket` fails at
+    # worktree provisioning ("No git clone found for souliane/teatree") and the
+    # issue-implementer intake is silently disabled. This mirrors the host
+    # layout (~/workspace/souliane/teatree -> the teatree clone).
+    mkdir -p /home/teatree/workspace/souliane && \
+    ln -s /home/teatree/teatree /home/teatree/workspace/souliane/teatree && \
     chown -R teatree:teatree /home/teatree /opt/teatree
 
 COPY --chmod=0755 deploy/entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/tests/test_deploy_clone_discovery_symlink.py
+++ b/tests/test_deploy_clone_discovery_symlink.py
@@ -1,0 +1,88 @@
+# test-path: cross-cutting
+"""The headless image links the runtime clone into the ORG-PREFIXED clone root.
+
+The runtime clone lives on the ``teatree_src`` volume at ``/home/teatree/teatree``,
+but ``clone_root()`` resolves source clones under ``~/workspace``. Provisioning a
+worktree calls ``find_clone_path(clone_root, "souliane/teatree")``, which matches
+the slug's literal path ``~/workspace/souliane/teatree`` — a bare
+``~/workspace/teatree`` link (no owner segment) is invisible to that lookup, so
+``workspace ticket`` fails at worktree provisioning ("No git clone found for
+souliane/teatree") and the issue-implementer intake is silently disabled.
+
+These tests pin the image to the org-prefixed discovery link and cross-check the
+same layout resolves through the real ``find_clone_path`` (a RED-before-fix guard:
+the old bare ``workspace/teatree`` link fails both).
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from teatree.core.worktree.clone_paths import find_clone_path
+
+DOCKERFILE = Path(__file__).resolve().parents[1] / "deploy" / "Dockerfile"
+
+# The container's fixed layout the image must construct.
+CLONE_DIR = "/home/teatree/teatree"
+CLONE_ROOT = "/home/teatree/workspace"
+REPO_SLUG = "souliane/teatree"
+DISCOVERY_LINK = f"{CLONE_ROOT}/{REPO_SLUG}"
+
+
+def _dockerfile_text() -> str:
+    return DOCKERFILE.read_text(encoding="utf-8")
+
+
+class TestDockerfileDiscoveryLink:
+    def test_org_prefixed_symlink_points_the_clone_root_at_the_runtime_clone(self) -> None:
+        # `ln -s <CLONE_DIR> <CLONE_ROOT>/souliane/teatree` — the slug's literal
+        # path, so find_clone_path(clone_root, "souliane/teatree") resolves.
+        text = _dockerfile_text()
+        assert re.search(rf"ln -s {re.escape(CLONE_DIR)} {re.escape(DISCOVERY_LINK)}\b", text), (
+            "Dockerfile must symlink the runtime clone into the ORG-PREFIXED clone root "
+            f"({DISCOVERY_LINK} -> {CLONE_DIR})"
+        )
+
+    def test_org_parent_dir_is_created_before_the_link(self) -> None:
+        # The owner dir must exist for `ln` to place the link inside it.
+        assert re.search(rf"mkdir -p {re.escape(CLONE_ROOT)}/souliane\b", _dockerfile_text())
+
+    def test_no_bare_non_org_discovery_link(self) -> None:
+        # A bare `workspace/teatree` link is invisible to the slug lookup — the
+        # exact regression this fix removes. (t3-workspaces is a different path.)
+        assert not re.search(rf"ln -s \S+ {re.escape(CLONE_ROOT)}/teatree\b", _dockerfile_text())
+
+
+class TestFindClonePathResolvesContainerLayout:
+    """The Dockerfile layout, reconstructed under tmp_path, resolves the slug.
+
+    Mirrors the container exactly: the real clone lives OUTSIDE the clone root,
+    reached only through the org-prefixed symlink.
+    """
+
+    def test_slug_resolves_through_org_prefixed_symlink_to_external_clone(self, tmp_path: Path) -> None:
+        clone = tmp_path / "teatree"  # stands in for /home/teatree/teatree
+        (clone / ".git").mkdir(parents=True)
+        clone_root = tmp_path / "workspace"
+        (clone_root / "souliane").mkdir(parents=True)
+        (clone_root / "souliane" / "teatree").symlink_to(clone)
+
+        resolved = find_clone_path(clone_root, REPO_SLUG)
+        assert resolved == clone_root / "souliane" / "teatree"
+        assert (resolved / ".git").is_dir()
+
+    def test_bare_non_org_symlink_does_not_resolve_the_slug(self, tmp_path: Path) -> None:
+        # The old container layout: link at workspace/teatree (no owner) — the
+        # slug lookup misses it, reproducing the provisioning failure.
+        clone = tmp_path / "teatree"
+        (clone / ".git").mkdir(parents=True)
+        clone_root = tmp_path / "workspace"
+        clone_root.mkdir()
+        (clone_root / "teatree").symlink_to(clone)
+
+        assert find_clone_path(clone_root, REPO_SLUG) is None
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Problem

The Dockerized headless factory could not implement any issue: `t3 teatree workspace ticket <issue_url>` (and the autonomous issue_implementer path) failed at worktree provisioning with:

```
WARNING teatree.core.runners.provision No git clone found for souliane/teatree under
/home/teatree/workspace (looked at /home/teatree/workspace/souliane/teatree and one-level subdirs)
Provisioning failed: failed to create worktrees for: souliane/teatree
```

## Root cause

The runtime clone lives on the `teatree_src` volume at `/home/teatree/teatree`, but `clone_root()` resolves source clones under `~/workspace`. Provisioning discovers the base clone via `find_clone_path(clone_root, "souliane/teatree")`, which matches the slug's literal path `~/workspace/souliane/teatree`.

The image linked the clone at a bare `~/workspace/teatree` (no owner segment). That link resolves the *basename* lookup (`find_clone_path(root, "teatree")`) but is invisible to the *slug* lookup the provisioner actually performs — the one-level scan looks for `~/workspace/<something>/teatree`, never a top-level `~/workspace/teatree` that is itself the clone. So the slug returned `None`, provisioning failed, and the issue-implementer intake was silently disabled (it fails safe / never claims when it finds no local clone).

The host layout already uses the correct org-prefixed path (`~/workspace/souliane/teatree`); only the container image diverged.

## Fix

Create the org-prefixed link `~/workspace/souliane/teatree -> /home/teatree/teatree` in the image, mirroring the host layout and the path `find_clone_path` documents as canonical. The clone itself stays on the persistent `teatree_src` volume; the link is baked into the image so it is recreated on every container recreate — no new bind mount needed.

## Tests

`tests/test_deploy_clone_discovery_symlink.py`:
- Dockerfile conformance: the org-prefixed discovery link is present, its owner dir is created, and no bare non-org discovery link remains (RED on the old image, GREEN on the fix).
- `find_clone_path` behavioral: the slug resolves through an org-prefixed symlink to a clone living *outside* the clone root (the container's exact scenario), and the old bare link does not resolve the slug.

## Live verification

Rebuilt the worker image from this branch and recreated the `teatree` stack:

```
$ docker compose -p teatree -f deploy/docker-compose.yml exec -T teatree-worker \
    t3 teatree workspace ticket https://github.com/souliane/teatree/issues/3255
  souliane/teatree: worktree #5
Ticket #30 — worktrees in .../t3-workspaces/t3-teatree/3255-.../
  Branch: 3255-t3-doctor-false-warns-teatree-mcp-not-co
```

Worktree materialised on disk on the expected branch. The prior "No git clone found" / "Provisioning failed" error is gone — the factory can now provision worktrees and implement issues.
