### PR TITLE
fix(agents): resolve overlay stage skills once per dispatch; unify embed/warn path (#3206)

### DIFF
--- a/src/teatree/agents/headless.py
+++ b/src/teatree/agents/headless.py
@@ -40,7 +40,7 @@ from teatree.agents.headless_usage import _attempt_usage
 from teatree.agents.pydantic_ai_resume import maybe_persist_on_park
 from teatree.agents.reader_profile import is_reader_phase, reader_child_env, reader_env_hermetic
 from teatree.agents.result_schema import RESULT_JSON_SCHEMA
-from teatree.agents.skill_bundle import resolve_skill_bundle
+from teatree.agents.skill_bundle import active_overlay_stage_skills, resolve_skill_bundle
 from teatree.agents.usage_window import maybe_park_for_active_window, park_task_on_limit
 from teatree.config import AgentHarnessProvider, get_effective_settings
 from teatree.core.models import Task, TaskAttempt
@@ -231,10 +231,15 @@ def run_headless(
         return backend
     harness = backend
 
+    # Resolve the overlay's stage skills ONCE and thread the list into every
+    # consumer (#3206). Re-resolving per prompt builder re-warns on a
+    # misconfigured skill and re-reads its SKILL.md path for nothing.
+    stage_skills = active_overlay_stage_skills(phase)
     skills = resolve_skill_bundle(
         phase=phase,
         overlay_skill_metadata=overlay_skill_metadata,
         worktree_path=dispatch_worktree_path(task.ticket),
+        stage_skills=stage_skills,
     )
 
     provider = get_effective_settings().agent_harness_provider
@@ -245,9 +250,13 @@ def run_headless(
         return child_env_result
     child_env = child_env_result
 
-    prompt = build_task_prompt(task, skills=skills)
-    lifecycle_skill = SkillLoadingPolicy.lifecycle_for_phase(phase)
-    system_context = build_system_context(task, skills=skills, lifecycle_skill=lifecycle_skill)
+    prompt = build_task_prompt(task, skills=skills, stage_skills=stage_skills)
+    system_context = build_system_context(
+        task,
+        skills=skills,
+        lifecycle_skill=SkillLoadingPolicy.lifecycle_for_phase(phase),
+        stage_skills=stage_skills,
+    )
     options = _build_options(task, system_context, phase=phase, skills=skills, env=child_env)
 
     try:

--- a/src/teatree/agents/prompt.py
+++ b/src/teatree/agents/prompt.py
@@ -213,12 +213,14 @@ def _task_header_lines(task: Task, extra: dict) -> list[str]:
     return lines
 
 
-def build_task_prompt(task: Task, *, skills: list[str] | None = None) -> str:
+def build_task_prompt(task: Task, *, skills: list[str] | None = None, stage_skills: list[str] | None = None) -> str:
     """Build a work prompt for a headless agent.
 
     *skills* is the resolved skill bundle for the dispatch; on the coding phase
     its framework + overlay entries are injected as an explicit skill-load
     block so a code-touching dispatch never relies on auto-detect (#1368).
+    *stage_skills* threads the dispatch's single overlay stage-skill resolution
+    (#3206) so this builder reuses it rather than re-resolving.
     """
     ticket: Ticket = task.ticket
     extra = ticket.extra if isinstance(ticket.extra, dict) else {}
@@ -243,7 +245,8 @@ def build_task_prompt(task: Task, *, skills: list[str] | None = None) -> str:
     )
 
     if normalize_phase(task.phase) == "coding":
-        stage_exclude = frozenset(_explicit_load_name(s) for s in stage_skills_present(task, skills or []))
+        present = stage_skills_present(task, skills or [], configured=stage_skills)
+        stage_exclude = frozenset(_explicit_load_name(s) for s in present)
         lines.extend(
             (
                 "",
@@ -440,7 +443,9 @@ def _phase_specific_lines(
     return ()
 
 
-def build_system_context(task: Task, *, skills: list[str], lifecycle_skill: str = "") -> str:
+def build_system_context(
+    task: Task, *, skills: list[str], lifecycle_skill: str = "", stage_skills: list[str] | None = None
+) -> str:
     """Build the system context for headless (SDK) execution.
 
     When *lifecycle_skill* is provided, only the lifecycle skill and rules
@@ -449,6 +454,8 @@ def build_system_context(task: Task, *, skills: list[str], lifecycle_skill: str 
     and ``code-review`` are additionally embedded in full, and any remaining
     overlay review companion skills get a verbatim "load before reviewing"
     instruction, so a headless reviewer reviews WITH the overlay's conventions.
+    *stage_skills* threads the dispatch's single overlay stage-skill resolution
+    (#3206) so this builder reuses it rather than re-resolving.
     """
     lines = ["You are a TeaTree headless agent executing a task."]
     lines.extend((f"Task ID: {task.pk}", f"Ticket: {task.ticket.ticket_number}"))
@@ -459,7 +466,7 @@ def build_system_context(task: Task, *, skills: list[str], lifecycle_skill: str 
     if parent_summary:
         lines.extend(("", "# Prior Task Result", "", parent_summary))
 
-    stage_present = stage_skills_present(task, skills)
+    stage_present = stage_skills_present(task, skills, configured=stage_skills)
     stage_exclude = frozenset(_explicit_load_name(s) for s in stage_present)
 
     if skills:

--- a/src/teatree/agents/skill_bundle.py
+++ b/src/teatree/agents/skill_bundle.py
@@ -158,7 +158,17 @@ def resolve_skill_bundle(
     overlay_skill_metadata: SkillMetadata,
     skill_index: SkillIndex | None = None,
     worktree_path: str | Path | None = None,
+    stage_skills: list[str] | None = None,
 ) -> list[str]:
+    """Resolve the phase's skill bundle for a dispatch.
+
+    *stage_skills* threads the dispatch's single ``active_overlay_stage_skills``
+    resolution (#3206) so a dispatch that also builds the prompts does not
+    re-resolve (re-warn / re-read SKILL.md) per builder; when absent it is
+    resolved here.
+    """
+    if stage_skills is None:
+        stage_skills = active_overlay_stage_skills(phase)
     policy = SkillLoadingPolicy()
     result = policy.select_for_runtime_phase(
         cwd=_dispatch_cwd(worktree_path),
@@ -168,6 +178,6 @@ def resolve_skill_bundle(
         companion_skills=active_overlay_companion_skills(),
         pr_review_companion=active_overlay_pr_review_companion(),
         review_skills=active_overlay_review_skills(),
-        stage_skills=active_overlay_stage_skills(phase),
+        stage_skills=stage_skills,
     )
     return result.skills

--- a/src/teatree/agents/skill_injection.py
+++ b/src/teatree/agents/skill_injection.py
@@ -47,10 +47,32 @@ def _find_skill_md(name: str, skills_dir: Path | None = None) -> Path | None:
     return candidate if candidate.is_file() else None
 
 
-def _find_skill_md_in_dirs(name: str, skills_dirs: Sequence[Path]) -> Path | None:
-    """First ``<dir>/<name>/SKILL.md`` across *skills_dirs*, in order."""
+def _bare_skill_name(name: str) -> str:
+    """Reduce a skill reference to its on-disk directory name.
+
+    A reference reaches this helper qualified (``t3:rules``), as a bare name
+    (``rules``), or as an explicit path (``skills/rules/SKILL.md``). Each maps
+    to the ``skills/<dir>/SKILL.md`` directory that holds the body, so the
+    namespace qualifier and any path prefix are dropped to the directory name —
+    the filesystem key both the embed and the unresolvable-warning check resolve
+    against.
+    """
+    tail = name.rsplit(":", 1)[-1]
+    if tail.endswith("/SKILL.md"):
+        return Path(tail).parent.name
+    return Path(tail).name
+
+
+def _resolve_skill_md(name: str, skills_dirs: Sequence[Path]) -> Path | None:
+    """Find the first ``<dir>/<skill>/SKILL.md`` across *skills_dirs*, in order.
+
+    The single skill-reference resolver: the embed, the sub-agent preamble, and
+    the stage-skill unresolvable-warning check all route through it, so the
+    warning and the actual embed can never disagree on a skill's path (#3206).
+    """
+    bare = _bare_skill_name(name)
     for sd in skills_dirs:
-        found = _find_skill_md(name, sd)
+        found = _find_skill_md(bare, sd)
         if found is not None:
             return found
     return None
@@ -66,9 +88,9 @@ def _read_skill_contents(skills: list[str], *, skills_dir: Path | None = None) -
     dirs = _resolve_dirs(skills_dir)
     sections: list[str] = []
     for name in skills:
-        skill_md = _find_skill_md_in_dirs(name, dirs)
+        skill_md = _resolve_skill_md(name, dirs)
         if skill_md is not None:
-            sections.append(_skill_section(name, skill_md.read_text(encoding="utf-8")))
+            sections.append(_skill_section(_bare_skill_name(name), skill_md.read_text(encoding="utf-8")))
     return "\n\n".join(sections)
 
 
@@ -112,9 +134,9 @@ def _read_skill_contents_scoped(
     explicit_names: list[str] = []
     for name in skills:
         if _is_primary(name, primary_skills):
-            skill_md = _find_skill_md_in_dirs(name, dirs)
+            skill_md = _resolve_skill_md(name, dirs)
             if skill_md is not None:
-                sections.append(_skill_section(name, skill_md.read_text(encoding="utf-8")))
+                sections.append(_skill_section(_bare_skill_name(name), skill_md.read_text(encoding="utf-8")))
         elif name in explicit or _explicit_load_name(name) in explicit:
             explicit_names.append(name)
         elif name in suppress or _explicit_load_name(name) in suppress:
@@ -132,31 +154,6 @@ def _read_skill_contents_scoped(
         summary += "\n".join(f"- {name}: available — load if needed" for name in companion_names)
         sections.append(summary)
     return "\n\n".join(sections)
-
-
-def _bare_skill_name(name: str) -> str:
-    """Reduce a skill reference to its on-disk directory name.
-
-    A reference reaches this helper qualified (``t3:rules``), as a bare name
-    (``rules``), or as an explicit path (``skills/rules/SKILL.md``). Each maps
-    to the ``skills/<dir>/SKILL.md`` directory that holds the body, so the
-    namespace qualifier and any path prefix are dropped to the directory name —
-    the filesystem key the preamble resolves against.
-    """
-    tail = name.rsplit(":", 1)[-1]
-    if tail.endswith("/SKILL.md"):
-        return Path(tail).parent.name
-    return Path(tail).name
-
-
-def _resolve_skill_md(name: str, skills_dirs: Sequence[Path]) -> Path | None:
-    """Find the first ``<dir>/<skill>/SKILL.md`` across *skills_dirs*, in order."""
-    bare = _bare_skill_name(name)
-    for sd in skills_dirs:
-        found = _find_skill_md(bare, sd)
-        if found is not None:
-            return found
-    return None
 
 
 _SUBAGENT_PREAMBLE_HEADER = (

--- a/src/teatree/agents/stage_skill_prompt.py
+++ b/src/teatree/agents/stage_skill_prompt.py
@@ -11,18 +11,25 @@ from teatree.agents.skill_injection import _explicit_load_name
 from teatree.core.models import Task
 
 
-def stage_skills_present(task: Task, skills: list[str]) -> list[str]:
+def stage_skills_present(task: Task, skills: list[str], *, configured: list[str] | None = None) -> list[str]:
     """The overlay's configured stage skills for *task*'s phase, present in *skills*.
 
     Only stage skills actually in the resolved bundle are scoped, so an
-    unresolvable one is not falsely surfaced as embedded.
+    unresolvable one is not falsely surfaced as embedded. *configured* threads
+    the dispatch's single ``active_overlay_stage_skills`` resolution (#3206) so
+    the prompt builders reuse it instead of re-resolving (which re-warns and
+    re-reads SKILL.md); when absent, it is resolved here.
     """
-    from teatree.agents.skill_bundle import active_overlay_stage_skills  # noqa: PLC0415 — deferred: call-time import
+    if configured is None:
+        from teatree.agents.skill_bundle import (  # noqa: PLC0415 — deferred: call-time import
+            active_overlay_stage_skills,
+        )
 
-    configured = set(active_overlay_stage_skills(task.phase))
-    if not configured:
+        configured = active_overlay_stage_skills(task.phase)
+    configured_set = set(configured)
+    if not configured_set:
         return []
-    return [s for s in skills if _explicit_load_name(s) in configured]
+    return [s for s in skills if _explicit_load_name(s) in configured_set]
 
 
 def stage_precedence_line(stage_skills: list[str]) -> str:

--- a/tests/teatree_agents/test_headless.py
+++ b/tests/teatree_agents/test_headless.py
@@ -195,6 +195,54 @@ class TestRunHeadless(TestCase):
         assert "Need design decision" in followup.execution_reason
 
 
+class _UnresolvableStageConfig:
+    """An overlay config declaring one stage skill with no SKILL.md on disk."""
+
+    def get_stage_skills(self, phase: str) -> list[str]:
+        return ["ghost-stage-skill-xyz"]
+
+
+class TestRunHeadlessStageSkillResolution(TestCase):
+    """#3206: the overlay stage skills resolve exactly once per dispatch.
+
+    ``run_headless`` builds the bundle plus both prompts; before the fix each of
+    those three re-ran ``active_overlay_stage_skills`` — three warning lines and
+    three SKILL.md-lookup passes for one misconfigured skill.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.ticket = Ticket.objects.create()
+
+    def test_stage_skills_resolved_once_per_dispatch(self) -> None:
+        result = {"summary": "Done", "files_modified": [{"path": "src/x.py", "action": "modified"}]}
+        with (
+            _fake_sdk(_success_stream(result)),
+            patch("teatree.agents.headless.active_overlay_stage_skills", return_value=[]) as dispatch_resolve,
+            # The bundle + both prompt builders reach this binding only when they
+            # re-resolve; a threaded dispatch must leave it untouched.
+            patch("teatree.agents.skill_bundle.active_overlay_stage_skills") as reresolve,
+        ):
+            session = Session.objects.create(ticket=self.ticket)
+            task = Task.objects.create(ticket=self.ticket, session=session, phase="coding")
+            run_headless(task, phase="coding", overlay_skill_metadata={})
+        assert dispatch_resolve.call_count == 1
+        reresolve.assert_not_called()
+
+    def test_unresolvable_stage_skill_warns_once_per_dispatch(self) -> None:
+        result = {"summary": "Done", "files_modified": [{"path": "src/x.py", "action": "modified"}]}
+        with (
+            _fake_sdk(_success_stream(result)),
+            patch("teatree.agents.skill_bundle._active_overlay_config", return_value=_UnresolvableStageConfig()),
+            self.assertLogs("teatree.agents.skill_bundle", level="WARNING") as logs,
+        ):
+            session = Session.objects.create(ticket=self.ticket)
+            task = Task.objects.create(ticket=self.ticket, session=session, phase="coding")
+            run_headless(task, phase="coding", overlay_skill_metadata={})
+        ghost_warnings = [line for line in logs.output if "ghost-stage-skill-xyz" in line]
+        assert len(ghost_warnings) == 1
+
+
 class TestRunHeadlessRoutingRefusal(TestCase):
     """The loop-dispatch billing guard refuses a registered phase before any SDK call.
 

--- a/tests/teatree_agents/test_prompt.py
+++ b/tests/teatree_agents/test_prompt.py
@@ -28,6 +28,16 @@ class TestBuildTaskPrompt(TestCase):
         assert "42" in prompt
         assert "https://example.com/issues/42" in prompt
 
+    def test_threaded_stage_skills_not_reresolved(self) -> None:
+        # #3206: build_task_prompt reuses the dispatch-resolved stage skills.
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket)
+        task = Task.objects.create(ticket=ticket, session=session, phase="coding")
+
+        with patch("teatree.agents.skill_bundle.active_overlay_stage_skills") as resolver:
+            build_task_prompt(task, skills=["code"], stage_skills=[])
+        resolver.assert_not_called()
+
     def test_includes_title_and_labels(self) -> None:
         ticket = Ticket.objects.create(
             issue_url="https://example.com/issues/1",
@@ -143,6 +153,17 @@ class TestBuildSystemContext(TestCase):
         # skill content is read from default skills_dir, not tmp_dir — so skill will not be found.
         # The test verifies the code path is exercised (lines 78-81).
         assert "TeaTree headless agent" in ctx
+
+    def test_threaded_stage_skills_not_reresolved(self) -> None:
+        # #3206: the dispatch resolves the overlay stage skills once and threads
+        # them in; build_system_context must reuse that list, not re-resolve.
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket)
+        task = Task.objects.create(ticket=ticket, session=session, phase="coding")
+
+        with patch("teatree.agents.skill_bundle.active_overlay_stage_skills") as resolver:
+            build_system_context(task, skills=["code"], lifecycle_skill="code", stage_skills=[])
+        resolver.assert_not_called()
 
     def test_reviewing_phase(self) -> None:
         ticket = Ticket.objects.create()

--- a/tests/teatree_agents/test_skill_bundle.py
+++ b/tests/teatree_agents/test_skill_bundle.py
@@ -8,6 +8,7 @@ fall-back.
 
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.test import TestCase
@@ -79,3 +80,34 @@ class TestResolveSkillBundleWorktreeScoping(TestCase):
             assert skill_bundle._dispatch_cwd(tmp) == Path(tmp)
         assert skill_bundle._dispatch_cwd(None) == Path.cwd()
         assert skill_bundle._dispatch_cwd("") == Path.cwd()
+
+
+class TestResolveSkillBundleStageSkillThreading(TestCase):
+    def test_threaded_stage_skills_bypass_internal_resolution(self) -> None:
+        # #3206: when the dispatch pre-resolves the overlay stage skills and
+        # threads them in, resolve_skill_bundle must not re-resolve them.
+        captured: dict[str, object] = {}
+
+        def _spy(self: SkillLoadingPolicy, *, stage_skills: object, **kwargs: object) -> object:
+            captured["stage_skills"] = stage_skills
+            return SimpleNamespace(skills=[])
+
+        with (
+            patch("teatree.agents.skill_bundle.active_overlay_stage_skills") as resolver,
+            patch.object(SkillLoadingPolicy, "select_for_runtime_phase", _spy),
+        ):
+            resolve_skill_bundle(
+                phase="coding",
+                overlay_skill_metadata={},
+                stage_skills=["backend-dev"],
+            )
+        resolver.assert_not_called()
+        assert captured["stage_skills"] == ["backend-dev"]
+
+    def test_resolves_internally_when_not_threaded(self) -> None:
+        with (
+            patch("teatree.agents.skill_bundle.active_overlay_stage_skills", return_value=["x"]) as resolver,
+            patch.object(SkillLoadingPolicy, "select_for_runtime_phase", return_value=SimpleNamespace(skills=[])),
+        ):
+            resolve_skill_bundle(phase="coding", overlay_skill_metadata={})
+        resolver.assert_called_once_with("coding")

--- a/tests/teatree_agents/test_skill_injection.py
+++ b/tests/teatree_agents/test_skill_injection.py
@@ -7,6 +7,7 @@ from teatree.agents.skill_injection import (
     _is_primary,
     _read_skill_contents,
     _read_skill_contents_scoped,
+    _resolve_skill_md,
     build_subagent_skill_preamble,
     harness_skills_dirs,
 )
@@ -38,6 +39,44 @@ def test_read_skill_contents_multiple_skills(tmp_path: Path) -> None:
     result = _read_skill_contents(["skill-a", "skill-b"], skills_dir=tmp_path)
     assert "--- SKILL: skill-a ---" in result
     assert "--- SKILL: skill-b ---" in result
+
+
+# --- embed path agrees with the warn/resolve path (#3206) ---
+# The unresolvable-warning check resolves via ``_resolve_skill_md`` (bare-name
+# strip); the embed must resolve the same reference forms, or a namespaced /
+# path-form stage skill warns as "resolvable" yet is silently dropped from the
+# embed (or vice versa). Every case below asserts warn-resolution and embed agree.
+
+
+def test_read_skill_contents_embeds_namespaced_name_like_the_resolver(tmp_path: Path) -> None:
+    _write_skill(tmp_path, "backend-dev", "# backend-dev body")
+
+    assert _resolve_skill_md("t3:backend-dev", [tmp_path]) is not None
+    result = _read_skill_contents(["t3:backend-dev"], skills_dir=tmp_path)
+    assert "--- SKILL: backend-dev ---" in result
+    assert "# backend-dev body" in result
+
+
+def test_read_skill_contents_embeds_path_form_name_like_the_resolver(tmp_path: Path) -> None:
+    _write_skill(tmp_path, "rules", "# rules body")
+
+    assert _resolve_skill_md("skills/rules/SKILL.md", [tmp_path]) is not None
+    result = _read_skill_contents(["skills/rules/SKILL.md"], skills_dir=tmp_path)
+    assert "--- SKILL: rules ---" in result
+    assert "# rules body" in result
+
+
+def test_read_scoped_embeds_namespaced_primary_like_the_resolver(tmp_path: Path) -> None:
+    _write_skill(tmp_path, "backend-dev", "# backend-dev body")
+
+    assert _resolve_skill_md("t3:backend-dev", [tmp_path]) is not None
+    result = _read_skill_contents_scoped(
+        ["t3:backend-dev"],
+        primary_skills={"t3:backend-dev"},
+        skills_dir=tmp_path,
+    )
+    assert "--- SKILL: backend-dev ---" in result
+    assert "# backend-dev body" in result
 
 
 # --- _is_primary ---

--- a/tests/teatree_agents/test_stage_skill_prompt.py
+++ b/tests/teatree_agents/test_stage_skill_prompt.py
@@ -21,6 +21,17 @@ def test_stage_skills_present_empty_when_none_configured() -> None:
         assert stage_skills_present(_task("coding"), ["rules", "code"]) == []
 
 
+def test_stage_skills_present_uses_threaded_configured_without_reresolving() -> None:
+    # A pre-resolved list threaded from the dispatch (#3206) is used as-is; the
+    # per-dispatch resolver must not run a second time inside this call.
+    with patch("teatree.agents.skill_bundle.active_overlay_stage_skills") as resolver:
+        present = stage_skills_present(
+            _task("coding"), ["rules", "backend-dev", "code"], configured=["backend-dev", "absent"]
+        )
+    assert present == ["backend-dev"]
+    resolver.assert_not_called()
+
+
 def test_stage_precedence_line_names_the_skills_and_is_additive() -> None:
     line = stage_precedence_line(["backend-dev", "frontend-dev"])
     assert "backend-dev" in line


### PR DESCRIPTION
Closes #3206.

Follow-up to #3200 cold-review nits.

## What changed

**(1) Stage skills resolved once per dispatch.** `active_overlay_stage_skills(phase)` ran 2-3x per headless dispatch — once in `resolve_skill_bundle` and once via `stage_skills_present` in each of `build_task_prompt` and `build_system_context`. Each call re-ran `_warn_unresolvable_stage_skills`, so a misconfigured stage skill produced duplicate WARNING lines and redundant SKILL.md path lookups. `run_headless` now resolves it once and threads the list through `resolve_skill_bundle`, `build_task_prompt`, and `build_system_context` (each takes an optional `stage_skills` / `configured`, resolving internally only when it is absent — so every other caller is byte-identical).

**(2) Embed and warn paths unified on the skill's on-disk key.** The unresolvable-warning check resolved via `_resolve_skill_md` (bare-name strip through `_bare_skill_name`), while the embed used `_find_skill_md_in_dirs` (no strip). A namespaced (`t3:backend-dev`) or path-form (`skills/x/SKILL.md`) stage-skill name could make the warning and the actual embed disagree. Both paths now route through the single `_resolve_skill_md` resolver and label sections with the bare name; `_find_skill_md_in_dirs` is deleted. Cosmetic today (stage config uses bare names), correct for any qualified/path form.

## Test

RED-first, each observed failing on the pre-fix code:
- `test_headless.py::TestRunHeadlessStageSkillResolution` — one resolution per dispatch and one warning line for a misconfigured stage skill (pre-fix: 3 resolutions / 3 warnings).
- `test_skill_injection.py` — a namespaced/path-form name that the warn check resolves is also embedded (pre-fix: empty embed).
- Threading contract tests on `stage_skills_present`, `build_task_prompt`, `build_system_context`, `resolve_skill_bundle`.

All 186 tests in the changed modules + 236 dependent tests pass; ruff + ty clean. `dev/ci-parity.sh` green except the pre-existing `banned-terms is unset` host-config gap (unrelated to this diff).

## Architecture pre-check — #3206

### 1. BLUEPRINT § alignment
Touches the sub-agent dispatch skill-injection path (`src/teatree/agents/`). No BLUEPRINT contract change — a within-module efficiency + correctness fix.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition touched.

### 3. Extension-point contracts
No `OverlayBase` / scanner / hook / Protocol surface changed. `resolve_skill_bundle`, `build_task_prompt`, `build_system_context`, and `stage_skills_present` gain optional keyword params that default to prior behavior, so existing callers (`pane_spawn`, `tasks`, `loop_dispatch`, `build_interactive_context`) are unaffected.

### 4. Component boundaries
Stays entirely in `src/teatree/agents/` (dispatch prompt building). No straddle.

### 5. Dependency direction
No new cross-module import — `headless.py` already imported from `skill_bundle`; added `active_overlay_stage_skills` to the existing import line. tach passed in ci-parity.

### 6. Test surface
`tests/teatree_agents/test_headless.py` (resolve-once / warn-once), `test_skill_injection.py` (embed==warn), `test_prompt.py` / `test_stage_skill_prompt.py` / `test_skill_bundle.py` (threading, no re-resolution).

### 7. Resilience invariants
n/a — no external write introduced. The change removes a redundant read (idempotent-by-construction: same threaded list consumed by every builder).

### 8. Identity and key normalization
Directly relevant. The skill reference has a bare (`rules`), qualified (`t3:rules`), and path (`skills/rules/SKILL.md`) form; `_bare_skill_name` is the single normalizer to the on-disk directory key, and both the embed and the warn check now resolve through the one `_resolve_skill_md` that applies it — closing the divergence where warn and embed disagreed.

### 9. Behavior preservation / capability deletion
`_find_skill_md_in_dirs` deleted; its two callers now use `_resolve_skill_md`, which is a strict superset (same lookup plus namespace/path strip). No must-block test inverted; no matcher narrowed. Section labels change from the raw reference to the bare name only for qualified/path forms, which the current bare-name config never exercises.

### 10. Removability / harness-vs-data
Removable: the optional `stage_skills` params default to internal resolution, so reverting the threading is a local change with no cascade. Harness-side by nature (prompt-building logic); no per-item policy that belongs in data.
