### PR TITLE
fix(loop): never fail silent — salvage committed work, corrective-retry, re-dispatch stuck tickets

### DIFF
--- a/src/teatree/agents/attempt_recorder.py
+++ b/src/teatree/agents/attempt_recorder.py
@@ -45,7 +45,11 @@ from teatree.core.models import (
     ReviewVerdictError,
     Task,
     TaskAttempt,
+    Worktree,
 )
+from teatree.core.models.ticket_worktree_checks import worktree_has_commits_ahead
+from teatree.utils import git
+from teatree.utils.run import CommandFailedError
 from teatree.utils.url_slug import pr_ref_from_url
 
 if TYPE_CHECKING:
@@ -145,23 +149,26 @@ def record_result_envelope(
     usage = usage or AttemptUsage()
     schema_error = validate_result_keys(result)
     if schema_error:
-        return _record_failure(task, error=schema_error)
+        return _record_failure(task, error=schema_error, result=result)
 
     signature = outage_signature(result)
     if signature:
-        return _record_failure(task, error=f"outage_death: {signature}")
+        return _record_failure(task, error=f"outage_death: {signature}", result=result)
 
     evidence_error = check_evidence(result, phase or task.phase)
     if evidence_error:
-        return _record_failure(task, error=evidence_error)
+        salvaged = _salvage_coding_result(task, result, phase=phase)
+        if salvaged is None:
+            return _record_failure(task, error=evidence_error, result=result)
+        result = salvaged
 
     landing_error = landing_verification_error(task, phase=phase)
     if landing_error:
-        return _record_failure(task, error=landing_error)
+        return _record_failure(task, error=landing_error, result=result)
 
     server_side_error = _record_returned_envelopes(task, result, phase=phase)
     if server_side_error:
-        return _record_failure(task, error=server_side_error)
+        return _record_failure(task, error=server_side_error, result=result)
 
     _maybe_record_plan_artifact(task, result, phase=phase)
     _maybe_record_article_suggestions(task, result, phase=phase)
@@ -404,13 +411,71 @@ def _maybe_record_answer_draft(task: Task, result: AgentResultBlob, *, phase: st
     )
 
 
-def _record_failure(task: Task, *, error: str) -> TaskAttempt:
+#: Phases whose landed commit can back-fill a missing ``files_modified`` envelope.
+_SALVAGEABLE_PHASES = frozenset({"coding", "debugging"})
+
+
+def _salvage_coding_result(task: Task, result: AgentResultBlob, *, phase: str) -> AgentResultBlob | None:
+    """Return *result* with ``files_modified`` synthesized from the landed commit, or ``None``.
+
+    The #3263 recovery: a coder committed real work but omitted the trailing
+    ``files_modified`` envelope, so the evidence gate refuses and the branch is
+    stranded. When the ticket worktree has a NEW commit ahead of its base AND is
+    clean (``landing_verification_error`` passes — so this never salvages dirty or
+    commit-less work), the committed diff's file paths ARE the evidence: synthesize
+    ``files_modified`` from them so the task COMPLETES on the real landed work.
+    ``None`` for a non-coding phase, or when there is nothing clean to salvage —
+    the caller then records the honest evidence refusal.
+    """
+    if normalize_phase(phase or task.phase) not in _SALVAGEABLE_PHASES:
+        return None
+    if landing_verification_error(task, phase=phase):
+        return None
+    files = _committed_file_changes(task)
+    if not files:
+        return None
+    salvaged = dict(result)
+    salvaged["files_modified"] = files
+    return salvaged
+
+
+def _committed_file_changes(task: Task) -> list[dict[str, str]]:
+    """``files_modified`` entries for the first ticket worktree with a commit ahead, else ``[]``."""
+    for worktree in Worktree.objects.filter(ticket=task.ticket):
+        if not worktree_has_commits_ahead(worktree):
+            continue
+        paths = _committed_paths(worktree)
+        if paths:
+            return [{"path": path, "action": "modified"} for path in paths]
+    return []
+
+
+def _committed_paths(worktree: Worktree) -> list[str]:
+    # Reached only after ``worktree_has_commits_ahead`` proved a valid path + branch.
+    repo_path = (worktree.extra or {}).get("worktree_path") or worktree.repo_path
+    base = _base_ref(repo_path)
+    try:
+        out = git.run(repo=repo_path, args=["diff", "--name-only", f"{base}..{worktree.branch}"])
+    except (CommandFailedError, OSError):
+        return []
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def _base_ref(repo_path: str) -> str:
+    try:
+        return f"origin/{git.default_branch(repo_path)}"
+    except (CommandFailedError, RuntimeError):
+        return "main"
+
+
+def _record_failure(task: Task, *, error: str, result: AgentResultBlob | None = None) -> TaskAttempt:
     attempt = TaskAttempt.objects.create(
         task=task,
         execution_target=task.execution_target,
         ended_at=timezone.now(),
         exit_code=0,
         error=error,
+        result=result or {},
     )
     task.fail()
     return attempt

--- a/src/teatree/loop/stuck_ticket_redispatch.py
+++ b/src/teatree/loop/stuck_ticket_redispatch.py
@@ -1,0 +1,191 @@
+"""Re-dispatch stuck non-terminal tickets — the drain, hard-bounded (PR-5).
+
+A ticket can freeze in a non-terminal work-state with ZERO open tasks, no open
+PR, and no recent activity: its FSM reads ``started``/``planned``/… but nothing is
+scheduled to advance it, and the report-only stale scanner never re-dispatches.
+This tick sweep schedules the phase task the ticket's state implies
+(``started`` → planning, ``planned`` → coding, …), so the frozen ticket resumes.
+
+The re-dispatch is HARD-BOUNDED by the #2009 repair-loop budget: a ticket-phase
+at its iteration cap, or stalled on two consecutive identical failures, is NOT
+re-dispatched and is escalated LOUDLY via a durable :class:`DeferredQuestion`
+(§17.1 invariant 9). Only AUTHOR tickets idle longer than the threshold with no
+work in flight are candidates — a ticket with an open task or open PR is already
+being worked and is left alone.
+
+Lives in ``teatree.loop`` (orchestration): it composes the ``core`` ticket-
+scheduling methods with the ``core`` repair-loop budget over a housekeeping sweep.
+"""
+
+import logging
+from datetime import datetime
+
+from django.conf import settings
+from django.db.models import Max
+from django.utils import timezone
+
+from teatree.core.modelkit.phases import normalize_phase, phase_spellings
+from teatree.core.models import PullRequest, Task, TaskAttempt, Ticket
+from teatree.core.models.deferred_question import DeferredQuestion
+from teatree.core.models.errors import InvalidTransitionError
+from teatree.core.models.usage_window_state import LIMIT_PARKED_PREFIX
+from teatree.core.repair_loop import IterationStalled, MaxIterationsExceeded, requeue_verdict
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_STUCK_IDLE_HOURS = 6
+
+_ESCALATION_MARKER = "[stuck-redispatch-halt ticket={pk}]"
+
+#: The non-terminal work-states a stuck ticket re-dispatches from, mapped to the
+#: phase the state implies. NOT_STARTED / SCOPED await provisioning (excluded);
+#: terminal states have nothing left to do.
+_STATE_PHASE: dict[str, str] = {
+    Ticket.State.STARTED: "planning",
+    Ticket.State.PLANNED: "coding",
+    Ticket.State.CODED: "testing",
+    Ticket.State.TESTED: "reviewing",
+    Ticket.State.REVIEWED: "shipping",
+}
+
+
+def redispatch_stuck_tickets() -> int:
+    """Schedule the implied phase task for each stuck ticket within budget; escalate the rest.
+
+    Returns the number of tickets re-dispatched (a fresh phase task scheduled).
+    """
+    now = timezone.now()
+    threshold = _idle_threshold_hours()
+    scheduled = 0
+    for ticket in _stuck_candidates(now=now, threshold_hours=threshold):
+        phase = _STATE_PHASE[ticket.state]
+        halt = _budget_halt_reason(ticket, phase=phase)
+        if halt is not None:
+            _escalate_once(ticket, reason=halt)
+            continue
+        scheduled += _redispatch(ticket, phase=phase)
+    return scheduled
+
+
+def _stuck_candidates(*, now: datetime, threshold_hours: int) -> list[Ticket]:
+    """AUTHOR tickets in a work-state with no open task, no open PR, idle past the threshold."""
+    tickets = (
+        Ticket.objects.filter(state__in=_STATE_PHASE.keys(), role=Ticket.Role.AUTHOR)
+        .exclude(tasks__status__in=Task.Status.active())
+        .exclude(pull_requests__isnull=False, pull_requests__state__in=_OPEN_PR_STATES)
+        .distinct()
+    )
+    return [t for t in tickets if _is_idle(t, now=now, threshold_hours=threshold_hours)]
+
+
+#: PR states that count as "open" (a merged PR does not keep a ticket alive).
+_OPEN_PR_STATES = frozenset(
+    {PullRequest.State.OPEN, PullRequest.State.REVIEW_REQUESTED, PullRequest.State.APPROVED},
+)
+
+
+def _is_idle(ticket: Ticket, *, now: datetime, threshold_hours: int) -> bool:
+    """Whether *ticket*'s last recorded activity is older than *threshold_hours*.
+
+    Activity is the newest :class:`TaskAttempt` start or :class:`TicketTransition`
+    — the same signal the stale scanner reads. A ticket with NO activity record at
+    all cannot be aged, so it is conservatively treated as NOT idle (the ``start``
+    transition always writes a transition row, so a genuinely stuck ticket always
+    has one).
+    """
+    last = _last_activity(ticket)
+    if last is None:
+        return False
+    return (now - last).total_seconds() >= threshold_hours * 3600
+
+
+def _last_activity(ticket: Ticket) -> datetime | None:
+    last_attempt = ticket.tasks.aggregate(ts=Max("attempts__started_at"))["ts"]  # ty: ignore[unresolved-attribute]  # Django reverse FK
+    if last_attempt is not None:
+        return last_attempt
+    return ticket.transitions.aggregate(ts=Max("created_at"))["ts"]  # ty: ignore[unresolved-attribute]  # Django reverse FK
+
+
+def _redispatch(ticket: Ticket, *, phase: str) -> int:
+    """Schedule the phase task *ticket*'s state implies; escalate on a scheduling refusal. Returns 0/1."""
+    try:
+        _schedule_for_state(ticket)
+    except InvalidTransitionError as exc:
+        _escalate_once(ticket, reason=f"could not schedule {phase!r}: {exc}")
+        return 0
+    return 1
+
+
+def _schedule_for_state(ticket: Ticket) -> Task:
+    state = ticket.state
+    if state == Ticket.State.STARTED:
+        return ticket.schedule_planning()
+    if state == Ticket.State.PLANNED:
+        return ticket.schedule_coding()
+    if state == Ticket.State.CODED:
+        return ticket.schedule_testing()
+    if state == Ticket.State.TESTED:
+        return ticket.schedule_review()
+    return ticket.schedule_shipping()
+
+
+def _budget_halt_reason(ticket: Ticket, *, phase: str) -> str | None:
+    """Return the loud halt reason if *ticket*'s phase is out of repair budget, else ``None``."""
+    attempts = _phase_attempts(ticket, phase=phase)
+    last_two = [a.error_fingerprint for a in attempts[-2:] if a.error_fingerprint]
+    try:
+        requeue_verdict(
+            ticket_id=ticket.pk,
+            phase=normalize_phase(phase),
+            iteration_count=len(attempts),
+            last_two_fingerprints=last_two,
+        )
+    except (MaxIterationsExceeded, IterationStalled) as exc:
+        return str(exc)
+    return None
+
+
+def _phase_attempts(ticket: Ticket, *, phase: str) -> list[TaskAttempt]:
+    """WORK attempts of *ticket*'s ``(ticket, normalized-phase)``, oldest first (limit-parks excluded)."""
+    return list(
+        TaskAttempt.objects.filter(
+            task__ticket_id=ticket.pk,
+            task__phase__in=phase_spellings(normalize_phase(phase)),
+        )
+        .exclude(error__startswith=LIMIT_PARKED_PREFIX)
+        .order_by("pk"),
+    )
+
+
+def _escalate_once(ticket: Ticket, *, reason: str) -> None:
+    """Record a durable escalation for a budget-halted stuck ticket, once per ticket.
+
+    Idempotent: a per-ticket marker in the question text dedups so a halted stuck
+    ticket re-scanned every tick escalates exactly once. Reuses the §17.1
+    invariant 9 surface (statusline / ``t3 teatree questions list`` / Slack DM).
+    """
+    marker = _ESCALATION_MARKER.format(pk=ticket.pk)
+    already = DeferredQuestion.objects.filter(
+        answered_at__isnull=True,
+        dismissed_at__isnull=True,
+        question__contains=marker,
+    ).exists()
+    if already:
+        return
+    where = ticket.issue_url or f"ticket {ticket.pk}"
+    question = (
+        f"{marker} Stuck ticket {where} (state {ticket.state!r}) has no work in flight but "
+        f"re-dispatch is halted: {reason} Auto-scheduling is stopped so it does not re-run a "
+        "doomed phase forever. How should it proceed — investigate, rework, or ignore?"
+    )
+    DeferredQuestion.record(question, session_id="")
+
+
+def _idle_threshold_hours() -> int:
+    """Configured stuck-idle threshold (``STUCK_TICKET_IDLE_HOURS``, floor 1)."""
+    raw = getattr(settings, "STUCK_TICKET_IDLE_HOURS", DEFAULT_STUCK_IDLE_HOURS)
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_STUCK_IDLE_HOURS
+    return max(1, value)

--- a/src/teatree/loop/tick_recovery.py
+++ b/src/teatree/loop/tick_recovery.py
@@ -24,19 +24,21 @@ def _reap_stale_task_claims() -> None:
     (the single SSOT, shared with ``t3 recover``) plus
     :func:`teatree.loop.transient_requeue.requeue_transient_failed` — the bounded
     reopen of transient-FAILED tasks (an outage/provision-fail/coder-yield that
-    RETURNED a failure, which the crashed-session boot sweeps never rescue). The
-    transient requeue lives in the loop layer (it composes the ``agents``
-    classifier with the ``core`` model), so it is called here rather than folded
-    into the core-only ``run_boot_sweeps``. If the test harness blocks DB access
-    (pytest-django without a ``db`` marker), the loop tick should still render
-    scanners and signals.
+    RETURNED a failure, which the crashed-session boot sweeps never rescue) — plus
+    :func:`teatree.loop.stuck_ticket_redispatch.redispatch_stuck_tickets` — the
+    bounded re-dispatch of stuck non-terminal tickets with no work in flight. Both
+    live in the loop layer (they compose the ``agents``/``core`` surfaces), so they
+    are called here rather than folded into the core-only ``run_boot_sweeps``. If
+    the test harness blocks DB access (pytest-django without a ``db`` marker), the
+    loop tick should still render scanners and signals.
     """
     from teatree.core.worktree.recovery_sweeps import run_boot_sweeps  # noqa: PLC0415 — deferred: loaded at tick time
-    from teatree.loop.transient_requeue import requeue_transient_failed  # noqa: PLC0415 — deferred: loaded at tick time
+    from teatree.loop import stuck_ticket_redispatch, transient_requeue  # noqa: PLC0415 — deferred: loaded at tick time
 
     with contextlib.suppress(RuntimeError):
         run_boot_sweeps()
-        requeue_transient_failed()
+        transient_requeue.requeue_transient_failed()
+        stuck_ticket_redispatch.redispatch_stuck_tickets()
 
 
 def _persist_agent_dispatches(report: "TickReport") -> None:

--- a/src/teatree/loop/transient_requeue.py
+++ b/src/teatree/loop/transient_requeue.py
@@ -11,9 +11,17 @@ The retry is HARD-BOUNDED by the #2009 repair-loop budget so it can never retry
 endlessly (it would always fail): a ticket-phase at its iteration cap, or stalled
 on two consecutive identical failures, is NOT reopened and is escalated LOUDLY
 via a durable :class:`DeferredQuestion` (§17.1 invariant 9) — never silently,
-never forever. Only a TRANSIENT last-attempt failure is a candidate; a
-DETERMINISTIC failure (a test failure, an assertion, a schema/evidence refusal)
-stays terminal FAILED.
+never forever.
+
+A DETERMINISTIC failure (a test failure, an assertion, a schema/evidence refusal)
+is NOT reopened blindly, but it must never sit silent either. On a non-terminal
+ticket, a coding/debugging failure whose last attempt was an omitted-envelope
+refusal (the coder emitted no trailing ``files_modified`` JSON) gets exactly ONE
+bounded corrective retry — reopened with the emit-the-envelope instruction
+appended to its prompt. Any other deterministic failure, and any envelope refusal
+that already spent its one corrective retry, is escalated via the SAME
+:class:`DeferredQuestion` path. The invariant: a terminal FAILED task on a
+non-terminal ticket ALWAYS escalates or retries-once, never freezes silently.
 
 Lives in ``teatree.loop`` (orchestration): it needs both the transient classifier
 (``teatree.agents``) and the ``Task`` model (``teatree.core.models``), which sit
@@ -34,9 +42,31 @@ logger = logging.getLogger(__name__)
 
 _ESCALATION_MARKER = "[repair-halt task={pk}]"
 
+#: Phases whose omitted-envelope refusal earns the one-shot corrective retry.
+_CORRECTIVE_PHASES = frozenset({"coding", "debugging"})
+#: Idempotency stamp appended to ``execution_reason`` when the corrective retry
+#: fires — its presence means the one retry was already spent (escalate next time).
+_CORRECTIVE_MARKER = "[auto-corrective-retry]"
+_CORRECTIVE_INSTRUCTION = (
+    "your last run omitted the required trailing JSON result envelope with files_modified — emit it."
+)
+#: Error substrings that mark a malformed / missing result envelope (as opposed
+#: to a genuine defect like an assertion or test failure).
+_ENVELOPE_REFUSAL_MARKERS = (
+    "missing required evidence",
+    "unexpected keys",
+    "result is not valid json",
+    "result must be a json object",
+)
+
 
 def requeue_transient_failed() -> int:
-    """Reopen transient-FAILED tasks within the repair budget; escalate the rest. Returns the reopen count."""
+    """Reopen transient-FAILED tasks within budget; corrective-retry-or-escalate deterministic ones.
+
+    Returns the count of tasks reopened (transient reopens + corrective retries).
+    A terminal FAILED task on a non-terminal ticket is NEVER left silent: it is
+    reopened, corrective-retried once, or escalated via ``DeferredQuestion``.
+    """
     reopened = 0
     for task in _transient_failed_candidates():
         halt = _budget_halt_reason(task)
@@ -44,22 +74,78 @@ def requeue_transient_failed() -> int:
             reopened += _reopen(task)
         else:
             _escalate_once(task, reason=halt)
+    for task in _deterministic_failed_candidates():
+        reopened += _handle_deterministic(task)
     return reopened
+
+
+def _handle_deterministic(task: Task) -> int:
+    """Corrective-retry a spent-envelope coding failure once, else escalate. Returns the reopen count."""
+    halt = _budget_halt_reason(task)
+    if halt is not None:
+        _escalate_once(task, reason=halt)
+        return 0
+    if _is_corrective_candidate(task):
+        return _corrective_reopen(task)
+    _escalate_once(task, reason=_latest_error(task) or "deterministic failure")
+    return 0
+
+
+def _is_corrective_candidate(task: Task) -> bool:
+    """Whether *task* is an omitted-envelope coding refusal that has not yet been corrective-retried."""
+    if normalize_phase(task.phase) not in _CORRECTIVE_PHASES:
+        return False
+    if _CORRECTIVE_MARKER in task.execution_reason:
+        return False
+    error = _latest_error(task).casefold()
+    return any(marker in error for marker in _ENVELOPE_REFUSAL_MARKERS)
+
+
+def _corrective_reopen(task: Task) -> int:
+    """CAS FAILED → PENDING appending the emit-the-envelope instruction to the prompt.
+
+    Uses the same conditional ``UPDATE ... WHERE status=FAILED`` compare-and-swap
+    as :func:`_reopen` so a concurrent tick that already reopened the row updates 0
+    rows and does not re-append the note.
+    """
+    note = f"{_CORRECTIVE_MARKER} {_CORRECTIVE_INSTRUCTION}"
+    new_reason = f"{task.execution_reason}\n{note}".strip() if task.execution_reason else note
+    return Task.objects.filter(pk=task.pk, status=Task.Status.FAILED).update(
+        status=Task.Status.PENDING,
+        claimed_at=None,
+        claimed_by="",
+        claimed_by_session="",
+        lease_expires_at=None,
+        heartbeat_at=None,
+        execution_reason=new_reason,
+    )
+
+
+def _latest_error(task: Task) -> str:
+    last = task.attempts.order_by("-pk").first()  # ty: ignore[unresolved-attribute]  # Django reverse FK
+    return last.error if last is not None else ""
 
 
 def _transient_failed_candidates() -> list[Task]:
     """FAILED tasks on a non-terminal ticket whose LATEST attempt is a transient failure."""
-    candidates: list[Task] = []
-    failed = (
+    return [task for task in _non_terminal_failed_tasks() if is_transient_failure(_latest_error(task))]
+
+
+def _deterministic_failed_candidates() -> list[Task]:
+    """FAILED tasks on a non-terminal ticket whose LATEST attempt is a DETERMINISTIC failure."""
+    return [
+        task
+        for task in _non_terminal_failed_tasks()
+        if _latest_error(task) and not is_transient_failure(_latest_error(task))
+    ]
+
+
+def _non_terminal_failed_tasks() -> list[Task]:
+    return list(
         Task.objects.filter(status=Task.Status.FAILED)
         .exclude(ticket__state__in=Ticket._TERMINAL_STATES)  # noqa: SLF001 — the model's SSOT terminal set
-        .select_related("ticket")
+        .select_related("ticket"),
     )
-    for task in failed:
-        last = task.attempts.order_by("-pk").first()
-        if last is not None and is_transient_failure(last.error):
-            candidates.append(task)
-    return candidates
 
 
 def _budget_halt_reason(task: Task) -> str | None:

--- a/tests/teatree_agents/test_attempt_recorder.py
+++ b/tests/teatree_agents/test_attempt_recorder.py
@@ -75,16 +75,24 @@ class TestRecordResultEnvelope(TestCase):
 
     def test_outage_death_fails_task_without_advancing_ticket(self) -> None:
         task = self._claimed()
-        attempt = record_result_envelope(
-            task,
-            {"summary": "Unable to connect to API", "files_modified": [{"path": "a.py", "action": "modified"}]},
-        )
+        blob = {"summary": "Unable to connect to API", "files_modified": [{"path": "a.py", "action": "modified"}]}
+        attempt = record_result_envelope(task, blob)
         task.refresh_from_db()
         task.ticket.refresh_from_db()
         assert task.status == Task.Status.FAILED
         assert task.ticket.state == Ticket.State.STARTED
-        assert attempt.result == {}
+        # The offending blob is persisted on the FAILED attempt for debuggability,
+        # not discarded (PR-3): a failure the operator cannot inspect is a dead end.
+        assert attempt.result == blob
         assert attempt.error.startswith("outage_death:")
+
+    def test_failed_attempt_persists_the_offending_result_blob(self) -> None:
+        task = self._claimed()
+        blob = {"summary": "nothing changed"}  # coding evidence refusal, no files_modified
+        attempt = record_result_envelope(task, blob)
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+        assert attempt.result == blob
 
     def test_outage_death_takes_precedence_over_evidence_gate(self) -> None:
         task = self._claimed()
@@ -152,9 +160,9 @@ class TestLandingVerifiedCompletion(TestCase):
         task.claim(claimed_by="loop-slot")
         return task
 
-    def _attach_worktree(self, ticket: Ticket, *, commits_ahead: int) -> Path:
-        repo_dir = self._tmp_path / f"repo-{ticket.pk}"
-        branch = f"feature-{ticket.pk}"
+    def _attach_worktree(self, ticket: Ticket, *, commits_ahead: int, suffix: str = "") -> Path:
+        repo_dir = self._tmp_path / f"repo-{ticket.pk}{suffix}"
+        branch = f"feature-{ticket.pk}{suffix}"
         _init_repo_with_branch(repo_dir, branch=branch, commits_ahead=commits_ahead)
         Worktree.objects.create(
             ticket=ticket,
@@ -188,6 +196,58 @@ class TestLandingVerifiedCompletion(TestCase):
         )
         task.refresh_from_db()
         assert task.status == Task.Status.COMPLETED
+
+    def test_evidence_refusal_with_committed_work_is_salvaged_and_completed(self) -> None:
+        # #3263: the coder committed real work but omitted the files_modified
+        # envelope. Rather than refuse and strand the branch, the recorder
+        # synthesizes files_modified from the committed diff and COMPLETES.
+        task = self._claimed()
+        self._attach_worktree(task.ticket, commits_ahead=1)
+        attempt = record_result_envelope(task, {"summary": "implemented but forgot the envelope"})
+        task.refresh_from_db()
+        assert task.status == Task.Status.COMPLETED
+        salvaged = attempt.result.get("files_modified")
+        assert salvaged == [{"path": "f0.txt", "action": "modified"}]
+
+    def test_evidence_refusal_without_commit_still_fails(self) -> None:
+        # No committed work to salvage — the refusal stands (the transient
+        # requeue sweep then gives the bounded corrective retry / escalates).
+        task = self._claimed()
+        self._attach_worktree(task.ticket, commits_ahead=0)
+        record_result_envelope(task, {"summary": "did nothing, no envelope"})
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+
+    def test_evidence_refusal_with_dirty_uncommitted_work_is_not_salvaged(self) -> None:
+        # A commit exists but tracked changes are uncommitted: landing would
+        # refuse, so there is nothing clean to salvage — the task fails.
+        task = self._claimed()
+        repo_dir = self._attach_worktree(task.ticket, commits_ahead=1)
+        (repo_dir / "f0.txt").write_text("edited but not committed\n")
+        record_result_envelope(task, {"summary": "half done"})
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+
+    def test_salvage_skips_commitless_worktree_and_uses_the_committed_one(self) -> None:
+        # A ticket with two clean worktrees, only one carrying a commit: the
+        # salvage skips the commit-less one and synthesizes from the committed one.
+        task = self._claimed()
+        self._attach_worktree(task.ticket, commits_ahead=0)
+        self._attach_worktree(task.ticket, commits_ahead=1, suffix="b")
+        attempt = record_result_envelope(task, {"summary": "committed in one repo, no envelope"})
+        task.refresh_from_db()
+        assert task.status == Task.Status.COMPLETED
+        assert attempt.result.get("files_modified") == [{"path": "f0.txt", "action": "modified"}]
+
+    def test_salvage_fails_closed_when_the_diff_read_errors(self) -> None:
+        # A commit landed (landing passes) but the name-only diff read errors —
+        # the salvage yields nothing rather than completing on unknowable work.
+        task = self._claimed()
+        self._attach_worktree(task.ticket, commits_ahead=1)
+        with patch("teatree.agents.attempt_recorder.git.run", side_effect=OSError("boom")):
+            record_result_envelope(task, {"summary": "committed but diff read broke"})
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
 
 
 class TestScanningNewsEnvelopeChannel(TestCase):

--- a/tests/teatree_loop/test_stuck_ticket_redispatch.py
+++ b/tests/teatree_loop/test_stuck_ticket_redispatch.py
@@ -79,7 +79,7 @@ class TestStuckTicketRedispatch(TestCase):
         assert ticket.tasks.count() == 0
 
     def test_scheduling_refusal_is_escalated(self) -> None:
-        ticket = _stuck_ticket(state=Ticket.State.STARTED)
+        _stuck_ticket(state=Ticket.State.STARTED)
 
         with patch.object(Ticket, "schedule_planning", side_effect=InvalidTransitionError("gate refused")):
             scheduled = redispatch_stuck_tickets()

--- a/tests/teatree_loop/test_stuck_ticket_redispatch.py
+++ b/tests/teatree_loop/test_stuck_ticket_redispatch.py
@@ -1,0 +1,152 @@
+"""Re-dispatch of stuck non-terminal tickets — the drain, hard-bounded (PR-5).
+
+A non-terminal ticket with ZERO open tasks, no open PR, and no recent activity
+is frozen: the FSM reads a work-state but nothing is scheduled to advance it, and
+the report-only stale scanner never re-dispatches. This sweep schedules the task
+the ticket's state implies (started→planning, planned→coding, …), bounded by the
+#2009 repair budget, escalating LOUDLY via a ``DeferredQuestion`` when the budget
+is exhausted — so a stuck ticket is drained or surfaced, never left silent.
+"""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from teatree.core.models import Session, Task, TaskAttempt, Ticket
+from teatree.core.models.deferred_question import DeferredQuestion
+from teatree.core.models.errors import InvalidTransitionError
+from teatree.core.models.transition import TicketTransition
+from teatree.core.repair_loop import max_phase_iterations
+from teatree.loop.stuck_ticket_redispatch import (
+    DEFAULT_STUCK_IDLE_HOURS,
+    _idle_threshold_hours,
+    redispatch_stuck_tickets,
+)
+from teatree.loop.tick_recovery import _reap_stale_task_claims
+
+
+def _stuck_ticket(*, state: str = Ticket.State.STARTED, idle_hours: int = 48) -> Ticket:
+    ticket = Ticket.objects.create(role=Ticket.Role.AUTHOR, state=state)
+    transition = TicketTransition.objects.create(ticket=ticket, from_state="scoped", to_state=state)
+    TicketTransition.objects.filter(pk=transition.pk).update(
+        created_at=timezone.now() - timedelta(hours=idle_hours),
+    )
+    return ticket
+
+
+class TestStuckTicketRedispatch(TestCase):
+    def test_stuck_started_ticket_schedules_planning(self) -> None:
+        ticket = _stuck_ticket(state=Ticket.State.STARTED)
+
+        scheduled = redispatch_stuck_tickets()
+
+        assert scheduled == 1
+        planning = ticket.tasks.filter(phase="planning", status=Task.Status.PENDING)
+        assert planning.count() == 1
+
+    def test_stuck_planned_ticket_schedules_coding(self) -> None:
+        ticket = _stuck_ticket(state=Ticket.State.PLANNED)
+
+        assert redispatch_stuck_tickets() == 1
+        assert ticket.tasks.filter(phase="coding", status=Task.Status.PENDING).count() == 1
+
+    def test_stuck_coded_ticket_schedules_testing(self) -> None:
+        ticket = _stuck_ticket(state=Ticket.State.CODED)
+
+        assert redispatch_stuck_tickets() == 1
+        assert ticket.tasks.filter(phase="testing", status=Task.Status.PENDING).count() == 1
+
+    def test_stuck_tested_ticket_schedules_reviewing(self) -> None:
+        ticket = _stuck_ticket(state=Ticket.State.TESTED)
+
+        assert redispatch_stuck_tickets() == 1
+        assert ticket.tasks.filter(phase="reviewing", status=Task.Status.PENDING).count() == 1
+
+    def test_stuck_reviewed_ticket_schedules_shipping(self) -> None:
+        ticket = _stuck_ticket(state=Ticket.State.REVIEWED)
+
+        assert redispatch_stuck_tickets() == 1
+        assert ticket.tasks.filter(phase="shipping", status=Task.Status.PENDING).count() == 1
+
+    def test_ticket_with_no_activity_record_is_left_alone(self) -> None:
+        # No transition and no task means idleness cannot be measured; the sweep
+        # must not re-dispatch a ticket it cannot prove is stale.
+        ticket = Ticket.objects.create(role=Ticket.Role.AUTHOR, state=Ticket.State.STARTED)
+
+        assert redispatch_stuck_tickets() == 0
+        assert ticket.tasks.count() == 0
+
+    def test_scheduling_refusal_is_escalated(self) -> None:
+        ticket = _stuck_ticket(state=Ticket.State.STARTED)
+
+        with patch.object(Ticket, "schedule_planning", side_effect=InvalidTransitionError("gate refused")):
+            scheduled = redispatch_stuck_tickets()
+
+        assert scheduled == 0
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
+
+    def test_bad_idle_threshold_setting_falls_back_to_default(self) -> None:
+        with override_settings(STUCK_TICKET_IDLE_HOURS="not-a-number"):
+            assert _idle_threshold_hours() == DEFAULT_STUCK_IDLE_HOURS
+
+    def test_ticket_with_an_open_task_is_left_alone(self) -> None:
+        ticket = _stuck_ticket()
+        session = Session.objects.create(ticket=ticket, agent_id="planning")
+        Task.objects.create(ticket=ticket, session=session, phase="planning", status=Task.Status.PENDING)
+
+        assert redispatch_stuck_tickets() == 0
+        assert ticket.tasks.filter(phase="planning").count() == 1
+
+    def test_recently_active_ticket_is_left_alone(self) -> None:
+        ticket = _stuck_ticket(idle_hours=0)
+
+        assert redispatch_stuck_tickets() == 0
+        assert ticket.tasks.count() == 0
+
+    def test_terminal_ticket_is_left_alone(self) -> None:
+        ticket = _stuck_ticket(state=Ticket.State.MERGED)
+
+        assert redispatch_stuck_tickets() == 0
+        assert ticket.tasks.count() == 0
+
+    def test_ticket_with_an_open_pr_is_left_alone(self) -> None:
+        ticket = _stuck_ticket()
+        ticket.pull_requests.create(url="https://ex.com/pr/1", repo="acme/app", iid="1")
+
+        assert redispatch_stuck_tickets() == 0
+        assert ticket.tasks.count() == 0
+
+    def test_budget_exhausted_ticket_is_escalated_not_scheduled(self) -> None:
+        ticket = _stuck_ticket(state=Ticket.State.STARTED)
+        cap = max_phase_iterations()
+        # A run of prior distinct planning-phase failures burns the repair budget.
+        for i in range(cap):
+            session = Session.objects.create(ticket=ticket, agent_id="planning")
+            task = Task.objects.create(ticket=ticket, session=session, phase="planning", status=Task.Status.FAILED)
+            attempt = TaskAttempt.objects.create(
+                task=task,
+                execution_target=task.execution_target,
+                ended_at=timezone.now(),
+                exit_code=1,
+                error=f"planning failed run {'x' * (i + 1)}",
+            )
+            # The failures are stale — the ticket has been sitting since they ran.
+            TaskAttempt.objects.filter(pk=attempt.pk).update(started_at=timezone.now() - timedelta(hours=48))
+
+        scheduled = redispatch_stuck_tickets()
+
+        assert scheduled == 0
+        assert ticket.tasks.filter(phase="planning", status=Task.Status.PENDING).count() == 0
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
+        # Idempotent: a second sweep neither schedules nor spams another escalation.
+        assert redispatch_stuck_tickets() == 0
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
+
+    def test_wired_into_tick_recovery(self) -> None:
+        ticket = _stuck_ticket(state=Ticket.State.STARTED)
+
+        _reap_stale_task_claims()
+
+        assert ticket.tasks.filter(phase="planning", status=Task.Status.PENDING).count() == 1

--- a/tests/teatree_loop/test_tick_recovery.py
+++ b/tests/teatree_loop/test_tick_recovery.py
@@ -1,0 +1,46 @@
+"""Boot/tick recovery step wiring — the housekeeping sweeps run every tick.
+
+``_reap_stale_task_claims`` chains the boot sweeps, the transient auto-requeue,
+and the stuck-ticket re-dispatch so a returned-failure task and a frozen ticket
+both self-heal from the loop tick, never only from an explicit ``t3 recover``.
+"""
+
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from teatree.core.models import Session, Task, TaskAttempt, Ticket
+from teatree.core.models.transition import TicketTransition
+from teatree.loop.tick_recovery import _reap_stale_task_claims
+
+
+class TestReapStaleTaskClaims(TestCase):
+    def test_runs_the_transient_requeue_and_the_stuck_redispatch(self) -> None:
+        transient = self._transient_failed_task()
+        stuck = self._stuck_started_ticket()
+
+        _reap_stale_task_claims()
+
+        transient.refresh_from_db()
+        assert transient.status == Task.Status.PENDING
+        assert stuck.tasks.filter(phase="planning", status=Task.Status.PENDING).count() == 1
+
+    def _transient_failed_task(self) -> Task:
+        ticket = Ticket.objects.create(role=Ticket.Role.AUTHOR, state=Ticket.State.STARTED)
+        session = Session.objects.create(ticket=ticket, agent_id="coding")
+        task = Task.objects.create(ticket=ticket, session=session, phase="coding", status=Task.Status.FAILED)
+        TaskAttempt.objects.create(
+            task=task,
+            execution_target=task.execution_target,
+            ended_at=timezone.now(),
+            exit_code=1,
+            error="outage_death: connection refused",
+        )
+        return task
+
+    def _stuck_started_ticket(self) -> Ticket:
+        ticket = Ticket.objects.create(role=Ticket.Role.AUTHOR, state=Ticket.State.STARTED)
+        transition = TicketTransition.objects.create(ticket=ticket, from_state="scoped", to_state="started")
+        TicketTransition.objects.filter(pk=transition.pk).update(created_at=timezone.now() - timedelta(hours=48))
+        return ticket

--- a/tests/teatree_loop/test_transient_requeue.py
+++ b/tests/teatree_loop/test_transient_requeue.py
@@ -104,6 +104,99 @@ class TestTransientRequeue(TestCase):
         task.refresh_from_db()
         assert task.status == Task.Status.PENDING
 
+    def test_deterministic_evidence_refusal_gets_one_corrective_retry(self) -> None:
+        # A coding task that landed FAILED on a missing files_modified envelope,
+        # with NO committed work to salvage, gets ONE bounded corrective retry:
+        # reopened PENDING with the envelope-emit instruction appended to the
+        # prompt (execution_reason). A terminal FAILED on a non-terminal ticket
+        # must never sit silent.
+        task = _failed_task()
+        _add_failed_attempt(
+            task,
+            error="missing required evidence for phase 'coding': result must include one of [files_modified]",
+        )
+
+        reopened = requeue_transient_failed()
+
+        task.refresh_from_db()
+        assert reopened == 1
+        assert task.status == Task.Status.PENDING
+        assert "files_modified" in task.execution_reason
+        assert "envelope" in task.execution_reason.lower()
+
+    def test_deterministic_refusal_after_corrective_retry_is_escalated(self) -> None:
+        task = _failed_task()
+        _add_failed_attempt(
+            task,
+            error="missing required evidence for phase 'coding': result must include one of [files_modified]",
+        )
+        # First sweep: the corrective retry reopens it.
+        assert requeue_transient_failed() == 1
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING
+
+        # It fails AGAIN with a different deterministic error (no stall) — the
+        # corrective retry was already spent, so it must escalate, not retry.
+        _add_failed_attempt(task, error="AssertionError: still no envelope emitted")
+
+        reopened = requeue_transient_failed()
+
+        task.refresh_from_db()
+        assert reopened == 0
+        assert task.status == Task.Status.FAILED
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
+
+    def test_non_envelope_deterministic_failure_is_escalated_not_retried(self) -> None:
+        # A real test failure is not an omitted-envelope class: no corrective
+        # retry (the envelope note would be misleading) — escalate so it never
+        # sits silent.
+        task = _failed_task()
+        _add_failed_attempt(task, error="AssertionError: expected 3 got 4")
+
+        reopened = requeue_transient_failed()
+
+        task.refresh_from_db()
+        assert reopened == 0
+        assert task.status == Task.Status.FAILED
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
+
+    def test_deterministic_non_coding_failure_is_escalated_not_retried(self) -> None:
+        # A planning evidence refusal is not a coder-envelope class: the coder
+        # note would be wrong, so no corrective retry — escalate instead.
+        task = _failed_task(phase="planning")
+        _add_failed_attempt(task, error="missing required evidence for phase 'planning'")
+
+        reopened = requeue_transient_failed()
+
+        task.refresh_from_db()
+        assert reopened == 0
+        assert task.status == Task.Status.FAILED
+        assert "[auto-corrective-retry]" not in task.execution_reason
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
+
+    def test_deterministic_failure_over_budget_is_escalated(self) -> None:
+        cap = max_phase_iterations()
+        task = _failed_task()
+        for i in range(cap):
+            _add_failed_attempt(task, error=f"AssertionError variant {'x' * (i + 1)}")
+
+        reopened = requeue_transient_failed()
+
+        task.refresh_from_db()
+        assert reopened == 0
+        assert task.status == Task.Status.FAILED
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
+
+    def test_deterministic_failure_on_terminal_ticket_is_left_alone(self) -> None:
+        task = _failed_task(state=Ticket.State.SHIPPED)
+        _add_failed_attempt(task, error="AssertionError: expected 3 got 4")
+
+        assert requeue_transient_failed() == 0
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 0
+
     def test_bounded_never_retries_endlessly(self) -> None:
         cap = max_phase_iterations()
         task = _failed_task()


### PR DESCRIPTION
## Summary

Three unattended self-heal fixes so the factory drains or escalates a task/ticket
failure instead of freezing silently (owner directive #10 — H24 auto-repair). The
"never fail silent + salvage + retry + re-dispatch" plane.

### 1. Never fail silent + salvage committed work (`attempt_recorder.py`)

- A FAILED attempt now **persists the offending result blob** (it was discarded, so
  failures were un-debuggable).
- On a coding/debugging **evidence refusal**, the recorder runs the landing check
  first: when the ticket worktree has a **new commit ahead of its base AND is
  clean**, it synthesizes `files_modified` from `git diff --name-only <base>..<branch>`
  and **COMPLETES** the task instead of stranding the branch. This recovers the
  #3263 class — the coder committed real work but omitted the trailing envelope.
  Dirty or commit-less work is never salvaged (landing must pass first).

### 2. Bounded corrective retry + always-escalate (`transient_requeue.py`)

- A **deterministic** FAILED task on a non-terminal ticket no longer sits silent.
  A coding/debugging omitted-envelope refusal gets **exactly one** bounded
  corrective retry — the emit-the-envelope instruction is appended to the task's
  prompt (`execution_reason`) and the task is reopened PENDING.
- Any other deterministic failure, or an envelope refusal that already spent its
  one retry, **escalates** via the same `DeferredQuestion` path the budget-halt
  path uses. Invariant: a terminal FAILED task on a non-terminal ticket ALWAYS
  retries-once or escalates — never freezes. Bounded by the #2009 repair budget.

### 3. Stuck-ticket re-dispatcher (new `stuck_ticket_redispatch.py`)

- A new tick sweep: a non-terminal **author** ticket with zero open tasks, no open
  PR, and no recent activity is re-dispatched to the phase its state implies
  (started→planning, planned→coding, coded→testing, tested→reviewing,
  reviewed→shipping), bounded by the #2009 repair budget, escalating on
  exhaustion. Drains the frozen `started` tickets (#3255 / #3271 / #3273).
- Wired into the housekeeping recovery step (`tick_recovery._reap_stale_task_claims`)
  alongside the transient requeue.

## Tests (RED-first regression)

- Evidence refusal with a committed clean worktree → task COMPLETES with
  synthesized `files_modified`; without a commit / when dirty → still FAILED.
- Deterministic failure with no commit → one bounded corrective retry, then
  escalates (DeferredQuestion created); non-coding / over-budget → escalates.
- Stuck started-ticket with no tasks → the sweep schedules planning; open task /
  open PR / recently-active / terminal → left alone; budget-exhausted → escalated.

New modules are at 100% line+branch coverage. Full `tests/teatree_agents/` +
`tests/teatree_loop/` suites: 3288 passed, 0 failed.

## Architecture pre-check

### 1. BLUEPRINT § alignment
§17.1 invariant 9 (durable away-mode escalation via `DeferredQuestion`) and the
#2009 repair-loop budget. The FSM contract is unchanged — these are recovery
sweeps over existing states, not new transitions.

### 2. FSM phase boundaries
No new `Ticket`/`Worktree` states or transitions. The stuck sweep only invokes the
existing `schedule_*` methods (planning/coding/testing/reviewing/shipping); the
recorder's salvage only changes whether an existing `coding` task COMPLETEs vs
FAILs. n/a for new transitions.

### 3. Extension-point contracts
No `OverlayBase` / scanner-registration / `*Backend` Protocol change. The new sweep
is a plain function called from `tick_recovery`, not a registered `Scanner`, so no
overlay adoption is required.

### 4. Component boundaries
`teatree.agents` (recorder — result→attempt), `teatree.loop` (both sweeps —
orchestration composing `agents` + `core`). The stuck sweep lives in `teatree.loop`
because it composes core scheduling with the core repair budget over a housekeeping
tick, matching the sibling `transient_requeue`.

### 5. Dependency direction
`agents→utils.git` and `agents→core.models` are existing allowed edges;
`loop→core.models`/`core.repair_loop` likewise. `uv run tach check` → all modules
validated (no backwards edge).

### 6. Test surface
`tests/teatree_agents/test_attempt_recorder.py` (salvage + blob-persist),
`tests/teatree_loop/test_transient_requeue.py` (corrective-retry/escalate),
`tests/teatree_loop/test_stuck_ticket_redispatch.py` (sweep). Each asserts the
observable contract (task status, DeferredQuestion count, scheduled phase task).

### 7. Resilience invariants
- **verify-by-re-read**: salvage re-reads the worktree git state at completion time.
- **fallback-transport**: budget-halt / non-retryable failures fall back to the
  durable `DeferredQuestion` surface.
- **idempotency**: reopen + corrective-retry use a CAS `UPDATE ... WHERE
  status=FAILED`; the corrective note is stamped once (`[auto-corrective-retry]`
  marker); escalations dedup on a per-task/per-ticket marker.
- **heartbeat**: n/a (sweeps are synchronous tick steps).
- **sub-agent return contract**: the recorder consumes the structured result blob.

### 8. Identity and key normalization
Phase comparisons go through `normalize_phase` at every boundary; no bare/qualified
key stripping introduced.

### 9. Behavior preservation / capability deletion
Additive on the failure paths. The one change to prior behavior: `_record_failure`
now persists the result blob (was `{}`) and a coding evidence refusal with a clean
landed commit now COMPLETEs rather than FAILs — both intentional, guarded by tests
(the outage/dirty/no-commit refusals still FAIL). No safety/privacy matcher
narrowed; no must-block test inverted.

### 10. Removability / harness-vs-data
Both sweeps are self-contained functions removable by dropping their two call lines
in `tick_recovery` — no cascade. The idle threshold is data (`STUCK_TICKET_IDLE_HOURS`
setting, default 6h); the phase mapping and budget are harness (FSM/policy logic).
