### PR TITLE
fix(deploy): mount claude projects dir so the dream pass sees transcripts

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -55,6 +55,9 @@ echo "deploy: deploying $(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD) @ $(g
 # out of later `pass insert` provisioning. Empty dirs are the sane degradation
 # for an env-token box (init's preflight then falls through to CLAUDE_CODE_OAUTH_TOKEN).
 install -d -m 700 "$HOME/.password-store" "$HOME/.gnupg"
+# The dream pass's transcript/memory input dir must pre-exist owned by the deploy
+# user — dockerd would otherwise create the missing bind source ROOT-owned.
+install -d "$HOME/.claude/projects"
 
 # Surface the WHY on a build/up failure — `set -e` would otherwise exit before
 # the Action log sees anything but "exited (1)".

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -42,6 +42,18 @@ x-teatree-common: &teatree-common
     - type: bind
       source: /home/teatree/.gnupg
       target: /home/teatree/.gnupg
+    # Claude session plane: session transcripts + per-project memory corpus —
+    # the dream pass's input AND product (#3277 classifies dream's use as PRODUCT
+    # DATA: it reads transcripts and maintains */memory; runtime STATE still never
+    # resolves from assistant memory). Without this the containerized dream pass
+    # globs an empty ~/.claude/projects and every nightly consolidation is a
+    # permanent no-op (0 members). Path identity; rw — dream phases 4-6 write
+    # cross-links / MEMORY.md / decay archives, and container-run headless sessions
+    # persist their transcripts to the backed-up host disk. Scoped to projects/
+    # only, never the whole ~/.claude (credentials + settings stay host-only).
+    - type: bind
+      source: /home/teatree/.claude/projects
+      target: /home/teatree/.claude/projects
     - teatree_uv:/opt/teatree/uv
   init: true
 

--- a/src/teatree/cli/doctor/app.py
+++ b/src/teatree/cli/doctor/app.py
@@ -25,6 +25,7 @@ from teatree.cli.doctor.checks import (
     _check_connector_manifest,
     _check_dangling_editable_pth,
     _check_dream_staleness,
+    _check_dream_transcript_visibility,
     _check_editable_sanity,
     _check_entrypoint_is_primary_clone,
     _check_legacy_overlay_alias,
@@ -75,6 +76,7 @@ __all__ = (
     "_check_connector_manifest",
     "_check_dangling_editable_pth",
     "_check_dream_staleness",
+    "_check_dream_transcript_visibility",
     "_check_editable_sanity",
     "_check_entrypoint_is_primary_clone",
     "_check_legacy_overlay_alias",
@@ -598,6 +600,7 @@ def check() -> bool:
     # (not a hard FAIL): a stale dream cron means memories pile up unpromoted,
     # which the operator should fix, but it must not red the whole doctor run.
     _check_dream_staleness()
+    _check_dream_transcript_visibility()
 
     # Slack Socket Mode readiness (#106 / BLUEPRINT § B5). Extends the Slack scope
     # auto-management to the app-level (xapp-) token + socket-mode manifest: it

--- a/src/teatree/cli/doctor/checks.py
+++ b/src/teatree/cli/doctor/checks.py
@@ -576,6 +576,39 @@ def _check_dream_staleness() -> bool:
     typer.echo(
         "WARN  Dream consolidation is stale — no successful pass in 48h. "
         "Memories pile up unpromoted; schedule `t3 dream tick` (~04:00 cron) so "
-        "the cadence ledger advances, not just a one-off `t3 dream run` (#1933).",
+        "the cadence ledger advances, not just a one-off `t3 dream run` (#1933). "
+        "If `t3 dream run` reports 0 members, see the transcript-visibility check.",
+    )
+    return False
+
+
+def _check_dream_transcript_visibility() -> bool:
+    """Warn when the dream pass can see NO session transcripts at any age.
+
+    Keys on STRUCTURAL absence (projects dir missing, or zero ``*/*.jsonl`` /
+    subagent transcripts regardless of mtime) — not the 48h recency window — so a
+    genuinely quiet couple of days never false-alarms. In the Docker factory a
+    structurally empty projects dir means the ``~/.claude/projects`` bind mount is
+    missing from ``deploy/docker-compose.yml``: every dream pass then finds 0
+    members and is a permanent no-op (the marker is never stamped succeeded).
+    Complements :func:`_check_dream_staleness` (cadence) — this one names the
+    mount as the remedy. Crash-proof: any error degrades to OK.
+    """
+    from teatree.loops.dream.engine import default_projects_dir  # noqa: PLC0415 — deferred import
+
+    try:
+        root = default_projects_dir()
+        if root.is_dir() and (
+            any(root.glob("*/*.jsonl")) or any(root.glob("*/*/subagents/agent-*.jsonl"))
+        ):
+            return True
+    except Exception as exc:  # noqa: BLE001 — doctor check must never crash the run
+        typer.echo(f"WARN  Dream-transcript-visibility check crashed: {exc.__class__.__name__}: {exc}")
+        return False
+    typer.echo(
+        f"WARN  Dream sees 0 session transcripts under {root} (any age). In the "
+        "Docker factory this means the `~/.claude/projects` bind mount is missing "
+        "from deploy/docker-compose.yml — every dream pass finds 0 members and is "
+        "a permanent no-op (marker never stamped succeeded).",
     )
     return False

--- a/tests/teatree_cli/doctor/test_dream_transcript_visibility_check.py
+++ b/tests/teatree_cli/doctor/test_dream_transcript_visibility_check.py
@@ -1,0 +1,64 @@
+"""``_check_dream_transcript_visibility`` — the `t3 doctor` dream-blindness alarm.
+
+In the Dockerized factory the dream pass globs ``~/.claude/projects`` for session
+transcripts. When that dir is unmounted/empty the pass finds 0 members and is a
+permanent no-op — invisible until this check. Keys on STRUCTURAL absence (no
+``*/*.jsonl`` and no subagent transcript at any age), NOT the 48h recency window,
+so a quiet box never false-alarms.
+"""
+
+import io
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+from teatree.cli.doctor.checks import _check_dream_transcript_visibility
+
+
+def _patch_root(root: Path):
+    return patch("teatree.loops.dream.engine.default_projects_dir", return_value=root)
+
+
+class TestDreamTranscriptVisibility:
+    def test_missing_projects_dir_warns(self, tmp_path: Path) -> None:
+        with _patch_root(tmp_path / "absent"):
+            assert _check_dream_transcript_visibility() is False
+
+    def test_empty_projects_dir_warns(self, tmp_path: Path) -> None:
+        (tmp_path / "proj").mkdir()
+        with _patch_root(tmp_path):
+            assert _check_dream_transcript_visibility() is False
+
+    def test_main_transcript_present_ok(self, tmp_path: Path) -> None:
+        (tmp_path / "proj").mkdir()
+        (tmp_path / "proj" / "sess.jsonl").write_text("{}\n", encoding="utf-8")
+        with _patch_root(tmp_path):
+            assert _check_dream_transcript_visibility() is True
+
+    def test_only_subagent_transcript_present_ok(self, tmp_path: Path) -> None:
+        sub = tmp_path / "proj" / "session" / "subagents"
+        sub.mkdir(parents=True)
+        (sub / "agent-1.jsonl").write_text("{}\n", encoding="utf-8")
+        with _patch_root(tmp_path):
+            assert _check_dream_transcript_visibility() is True
+
+    def test_warn_message_names_the_mount(self, tmp_path: Path) -> None:
+        buf = io.StringIO()
+        with _patch_root(tmp_path / "absent"), redirect_stdout(buf):
+            _check_dream_transcript_visibility()
+        out = buf.getvalue()
+        assert "WARN" in out
+        assert "bind mount" in out
+        assert ".claude/projects" in out
+
+    def test_crash_degrades_to_false_with_warn(self) -> None:
+        buf = io.StringIO()
+        with (
+            patch(
+                "teatree.loops.dream.engine.default_projects_dir",
+                side_effect=RuntimeError("boom"),
+            ),
+            redirect_stdout(buf),
+        ):
+            assert _check_dream_transcript_visibility() is False
+        assert "RuntimeError" in buf.getvalue()

--- a/tests/test_deploy_bindmount_compose.py
+++ b/tests/test_deploy_bindmount_compose.py
@@ -37,8 +37,14 @@ CREDENTIAL_PLANE = {
     "/home/teatree/.password-store",
     "/home/teatree/.gnupg",
 }
+# The Claude session plane: the dream pass's transcript input + memory-corpus
+# product. Without it the containerized dream pass globs an empty projects dir
+# and every nightly consolidation is a permanent no-op.
+SESSION_PLANE = {
+    "/home/teatree/.claude/projects",
+}
 # Every host bind mount the shared list must carry, by canonical source path.
-ALL_BIND_SOURCES = EXTERNALIZED | CREDENTIAL_PLANE
+ALL_BIND_SOURCES = EXTERNALIZED | CREDENTIAL_PLANE | SESSION_PLANE
 # The two mounts that stay Docker-managed named volumes (later PRs handle these).
 KEPT_NAMED_VOLUMES = {"teatree_src", "teatree_uv"}
 REMOVED_NAMED_VOLUMES = {"teatree_data", "teatree_worktrees", "teatree_workspaces"}


### PR DESCRIPTION
Dreaming has never produced anything: in the Docker factory the dream pass globs an empty projects dir, finds 0 transcript members, and every nightly pass is a permanent no-op (marker never stamped succeeded).

This bind-mounts the host `~/.claude/projects` dir (rw, path-identity, projects-scoped so credentials + settings stay host-only) so dream sees session + subagent transcripts and maintains the memory corpus. #3277 classifies dream's use as product data; runtime STATE still never resolves from assistant memory. Adds a `t3 doctor` check that names the missing mount so this blindness is never silently invisible again.

Refs directive #10 (resilience). Root-caused by Fable after the owner flagged never seeing a single dreaming improvement.
