### PR TITLE
style: unblock main lint — ruff-format checks.py under CI-pinned 0.15.1

### DIFF
--- a/src/teatree/cli/doctor/checks.py
+++ b/src/teatree/cli/doctor/checks.py
@@ -598,9 +598,7 @@ def _check_dream_transcript_visibility() -> bool:
 
     try:
         root = default_projects_dir()
-        if root.is_dir() and (
-            any(root.glob("*/*.jsonl")) or any(root.glob("*/*/subagents/agent-*.jsonl"))
-        ):
+        if root.is_dir() and (any(root.glob("*/*.jsonl")) or any(root.glob("*/*/subagents/agent-*.jsonl"))):
             return True
     except Exception as exc:  # noqa: BLE001 — doctor check must never crash the run
         typer.echo(f"WARN  Dream-transcript-visibility check crashed: {exc.__class__.__name__}: {exc}")


### PR DESCRIPTION
## Problem

`main`'s `src/teatree/cli/doctor/checks.py` fails the CI `ruff-format` hook, so **every open PR that merges `main` inherits a red lint check**.

Root cause: #3285 added `_check_dream_transcript_visibility()` formatted with a newer local ruff (0.15.12), but the CI `ruff-pre-commit` hook is pinned to **0.15.1**, which collapses the wrapped `if` conditional onto one line. The version gap is #3236.

## Fix

Run the CI-pinned `ruff@0.15.1 format` on the one offending file. Pure formatting — a wrapped conditional collapses to a single line; **no semantic change**.

## Why a standalone hotfix

Unblocks `main`'s lint immediately, ahead of the larger #3236 runner-pin PR. Merge this first, then the other open PRs go green without each carrying a duplicate `checks.py` reformat.
