### PR TITLE
Expand recommended auto-mode authorizations (docker-exec provisioning, owner-id lookup, config writes)

### DIFF
--- a/skills/setup/references/recommended-automode-authorizations.md
+++ b/skills/setup/references/recommended-automode-authorizations.md
@@ -43,6 +43,18 @@ check and this doc derive from the same source). The current sentences are:
   ≠ loop, SHA-bound, live-green required checks, substrate needs a recorded
   human approver). Raw `gh pr merge` / `glab mr merge` is **not** authorized
   by this rule — it stays mechanically prohibited (#863).
+- **docker-exec-provisioning** — Allow `docker exec` into teatree deployment
+  containers and installing the teatree editable package with extras via `uv`
+  (e.g. `uv tool install --editable '<clone>[slack]'`) as part of Slack/deploy
+  setup and runtime provisioning in Docker.
+- **slack-owner-id-lookup** — Allow reading an overlay's own Slack workspace
+  data via its bot token (including `users.list` / `users.lookupByEmail`)
+  **strictly** to resolve or verify the owner's own Slack user id for DM-only
+  provisioning — never bulk member-PII export.
+- **provision-config-writes** — Allow teatree provisioning to write overlay
+  config state in the DB overlays registry (messaging backend, token
+  references, user id, DM channel) via `t3 setup` or
+  `t3 <overlay> config_setting set` during Slack or deploy setup.
 
 ## What is deliberately NOT in this set
 

--- a/src/teatree/cli/doctor/checks.py
+++ b/src/teatree/cli/doctor/checks.py
@@ -598,9 +598,7 @@ def _check_dream_transcript_visibility() -> bool:
 
     try:
         root = default_projects_dir()
-        if root.is_dir() and (
-            any(root.glob("*/*.jsonl")) or any(root.glob("*/*/subagents/agent-*.jsonl"))
-        ):
+        if root.is_dir() and (any(root.glob("*/*.jsonl")) or any(root.glob("*/*/subagents/agent-*.jsonl"))):
             return True
     except Exception as exc:  # noqa: BLE001 — doctor check must never crash the run
         typer.echo(f"WARN  Dream-transcript-visibility check crashed: {exc.__class__.__name__}: {exc}")

--- a/src/teatree/cli/recommended_authorizations.py
+++ b/src/teatree/cli/recommended_authorizations.py
@@ -109,6 +109,36 @@ RECOMMENDED_AUTHORIZATIONS: tuple[RecommendedAuthorization, ...] = (
         ),
         keyphrases=("ticket clear", "ticket merge"),
     ),
+    RecommendedAuthorization(
+        key="docker-exec-provisioning",
+        sentence=(
+            "Allow `docker exec` into teatree deployment containers and installing the "
+            "teatree editable package with extras via uv (e.g. "
+            "`uv tool install --editable '<clone>[slack]'`) as part of Slack/deploy "
+            "setup and runtime provisioning in Docker."
+        ),
+        keyphrases=("docker exec", "uv tool install"),
+    ),
+    RecommendedAuthorization(
+        key="slack-owner-id-lookup",
+        sentence=(
+            "Allow reading an overlay's own Slack workspace data via its bot token "
+            "(including `users.list` / `users.lookupByEmail`) STRICTLY to resolve or "
+            "verify the owner's own Slack user id for DM-only provisioning — never "
+            "bulk member-PII export."
+        ),
+        keyphrases=("users.list", "dm-only provisioning"),
+    ),
+    RecommendedAuthorization(
+        key="provision-config-writes",
+        sentence=(
+            "Allow teatree provisioning to write overlay config state in the DB "
+            "overlays registry (messaging backend, token references, user id, DM "
+            "channel) via `t3 setup` or `t3 <overlay> config_setting set` during "
+            "Slack or deploy setup."
+        ),
+        keyphrases=("config_setting set", "overlays registry"),
+    ),
 )
 
 

--- a/tests/teatree_cli/test_recommended_authorizations.py
+++ b/tests/teatree_cli/test_recommended_authorizations.py
@@ -173,6 +173,34 @@ class TestFindMissingAuthorizations:
         missing_keys = {r.key for r in find_missing_authorizations(path)}
         assert "gh-pr-merge-green-only" not in missing_keys
 
+    def test_new_provisioning_rules_absent_on_empty_settings(self, tmp_path):
+        path = tmp_path / "settings.json"
+        path.write_text(json.dumps({"autoMode": {"allow": []}}), encoding="utf-8")
+        missing_keys = {r.key for r in find_missing_authorizations(path)}
+        assert {
+            "docker-exec-provisioning",
+            "slack-owner-id-lookup",
+            "provision-config-writes",
+        } <= missing_keys
+
+    def test_new_provisioning_rules_covered_when_present(self, tmp_path):
+        covering = [
+            r.sentence
+            for r in RECOMMENDED_AUTHORIZATIONS
+            if r.key
+            in {
+                "docker-exec-provisioning",
+                "slack-owner-id-lookup",
+                "provision-config-writes",
+            }
+        ]
+        path = tmp_path / "settings.json"
+        path.write_text(json.dumps({"autoMode": {"allow": covering}}), encoding="utf-8")
+        missing_keys = {r.key for r in find_missing_authorizations(path)}
+        assert "docker-exec-provisioning" not in missing_keys
+        assert "slack-owner-id-lookup" not in missing_keys
+        assert "provision-config-writes" not in missing_keys
+
     def test_does_not_modify_the_settings_file(self, tmp_path):
         path = tmp_path / "settings.json"
         original = json.dumps({"autoMode": {"allow": ["something unrelated"]}})
@@ -191,6 +219,15 @@ class TestRecommendedSetIntegrity:
             assert rec.sentence.strip()
             assert rec.keyphrases
             assert all(p == p.lower() for p in rec.keyphrases)
+
+    def test_every_keyphrase_is_a_substring_of_its_own_lowered_sentence(self):
+        # The load-bearing invariant behind is_covered_by: pasting a rec's own
+        # sentence verbatim must cover that rec, which only holds when every
+        # keyphrase is a literal lowercase substring of the lowered sentence.
+        for rec in RECOMMENDED_AUTHORIZATIONS:
+            lowered = rec.sentence.lower()
+            for phrase in rec.keyphrases:
+                assert phrase in lowered, (rec.key, phrase)
 
     def test_no_user_specific_tokens_leak_into_generic_set(self):
         # The recommended set must stay teatree-generic — structural check


### PR DESCRIPTION
## Summary

Adds three tightly-scoped `RecommendedAuthorization` entries to `RECOMMENDED_AUTHORIZATIONS`, covering recurring legitimate teatree provisioning ops that were false-blocked. Behaviour is unchanged: `t3 doctor`/`t3 setup` DETECT-and-SUGGEST these (never apply — BLUEPRINT §11.4). No blanket/whole-tool grants; each sentence describes a specific capability.

New entries:
- **docker-exec-provisioning** — `docker exec` into teatree deployment containers + installing the editable package with extras via `uv tool install --editable '<clone>[slack]'` during Slack/deploy setup.
- **slack-owner-id-lookup** — read an overlay's own Slack workspace via its bot token (`users.list`/`users.lookupByEmail`) STRICTLY to resolve/verify the owner's own Slack user id for DM-only provisioning — not bulk member-PII export.
- **provision-config-writes** — write overlay config state in the DB overlays registry via `t3 setup` / `t3 <overlay> config_setting set`.

## Invariant

For each entry every keyphrase is a literal lowercase substring of its own `sentence` (how `is_covered_by` matches). A new whole-tuple test asserts this.

## Also updated
- `skills/setup/references/recommended-automode-authorizations.md` — mirrors the new authorizations.
- Tests: added the substring invariant test over the whole tuple, plus detection tests for the new keys (absent on empty settings, covered when the sentence is present).

## Tests
- `tests/teatree_cli/test_recommended_authorizations.py` — 33 passed
- `tests/teatree_cli/setup/test_command.py` — 2 passed
- `ruff check` / `ruff format` clean