### PR TITLE
Fix: statusline install must not crash t3 setup when settings.json is unwritable (headless init)

### DIFF
--- a/src/teatree/cli/doctor/checks.py
+++ b/src/teatree/cli/doctor/checks.py
@@ -598,9 +598,7 @@ def _check_dream_transcript_visibility() -> bool:
 
     try:
         root = default_projects_dir()
-        if root.is_dir() and (
-            any(root.glob("*/*.jsonl")) or any(root.glob("*/*/subagents/agent-*.jsonl"))
-        ):
+        if root.is_dir() and (any(root.glob("*/*.jsonl")) or any(root.glob("*/*/subagents/agent-*.jsonl"))):
             return True
     except Exception as exc:  # noqa: BLE001 — doctor check must never crash the run
         typer.echo(f"WARN  Dream-transcript-visibility check crashed: {exc.__class__.__name__}: {exc}")

--- a/src/teatree/cli/setup/command.py
+++ b/src/teatree/cli/setup/command.py
@@ -42,6 +42,8 @@ def _report_statusline_install(settings_json: Path, repo: Path) -> None:
         typer.echo("OK    Installed statusLine block into settings.json.")
     elif result is StatuslineInstall.ALREADY_PRESENT:
         typer.echo("OK    statusLine already configured — left untouched.")
+    elif result is StatuslineInstall.UNWRITABLE:
+        typer.echo("WARN  Could not write the statusline to settings.json (not writable) — skipping; setup continues.")
     else:
         typer.echo("WARN  settings.json unparsable — skipped statusLine install.")
 

--- a/src/teatree/cli/setup/statusline_installer.py
+++ b/src/teatree/cli/setup/statusline_installer.py
@@ -26,6 +26,7 @@ class StatuslineInstall(StrEnum):
     INSTALLED = "installed"
     ALREADY_PRESENT = "already-present"
     UNREADABLE = "unreadable"
+    UNWRITABLE = "unwritable"
 
 
 def statusline_command_path(repo: Path) -> str:
@@ -40,7 +41,11 @@ def install_statusline(settings_path: Path, repo: Path) -> StatuslineInstall:
     (:attr:`StatuslineInstall.ALREADY_PRESENT`) — the user's own choice wins.
     A missing file is created with just the block. An unparsable file is left
     alone (:attr:`StatuslineInstall.UNREADABLE`) so setup never corrupts hand-
-    edited JSON. The block is ``{"type": "command", "command": <abs path>}``.
+    edited JSON. A target the process cannot write — e.g. a root-owned
+    ``~/.claude`` in the headless container — degrades to
+    (:attr:`StatuslineInstall.UNWRITABLE`) instead of raising, so this
+    convenience write never aborts ``t3 setup``. The block is
+    ``{"type": "command", "command": <abs path>}``.
     """
     data: dict[str, Any] = {}
     if settings_path.is_file():
@@ -55,6 +60,9 @@ def install_statusline(settings_path: Path, repo: Path) -> StatuslineInstall:
             return StatuslineInstall.ALREADY_PRESENT
 
     data["statusLine"] = {"type": "command", "command": statusline_command_path(repo)}
-    settings_path.parent.mkdir(parents=True, exist_ok=True)
-    settings_path.write_text(json.dumps(data, indent=4) + "\n", encoding="utf-8")
+    try:
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(json.dumps(data, indent=4) + "\n", encoding="utf-8")
+    except OSError:
+        return StatuslineInstall.UNWRITABLE
     return StatuslineInstall.INSTALLED

--- a/tests/teatree_cli/setup/test_command.py
+++ b/tests/teatree_cli/setup/test_command.py
@@ -19,6 +19,12 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from teatree.cli.setup import command as setup_command
+from teatree.cli.setup.statusline_installer import StatuslineInstall
 
 _RUN_SETUP_PROBE = """
 from pathlib import Path
@@ -77,6 +83,25 @@ def _pre_bootstrap_env(home: Path) -> dict[str, str]:
     env.pop("XDG_DATA_HOME", None)
     env["HOME"] = str(home)
     return env
+
+
+class TestReportStatuslineInstallUnwritable:
+    """An unwritable settings.json warns and continues — it never aborts setup.
+
+    In the headless container the ``teatree`` user cannot write the root-owned
+    ``~/.claude/settings.json``; the installer degrades to
+    :attr:`StatuslineInstall.UNWRITABLE`, and the command must echo a WARN and
+    return normally so ``t3 setup`` (under ``set -euo pipefail``) exits 0.
+    """
+
+    def test_unwritable_warns_and_does_not_raise(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        settings = tmp_path / "settings.json"
+        repo = tmp_path / "repo"
+        with patch.object(setup_command, "install_statusline", return_value=StatuslineInstall.UNWRITABLE):
+            setup_command._report_statusline_install(settings, repo)
+        out = capsys.readouterr().out
+        assert "WARN" in out
+        assert "settings.json" in out
 
 
 class TestSetupBootstrapsDjangoBeforeDmProvisioning:

--- a/tests/teatree_cli/setup/test_statusline_installer.py
+++ b/tests/teatree_cli/setup/test_statusline_installer.py
@@ -3,6 +3,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from teatree.cli.setup.statusline_installer import StatuslineInstall, install_statusline, statusline_command_path
 
 
@@ -53,3 +55,22 @@ class TestInstallStatusline:
         settings.write_text("{ not json", encoding="utf-8")
         assert install_statusline(settings, repo) is StatuslineInstall.UNREADABLE
         assert settings.read_text(encoding="utf-8") == "{ not json"
+
+    def test_unwritable_target_returns_unwritable_without_raising(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A settings.json the user cannot write must never make setup fatal.
+
+        The headless container bind-mounts only ``~/.claude/projects``, so Docker
+        creates the parent ``~/.claude`` root-owned and the ``teatree`` user can
+        not write ``settings.json`` — the write must degrade to
+        :attr:`StatuslineInstall.UNWRITABLE`, never propagate ``PermissionError``.
+        """
+        repo = _repo(tmp_path)
+        settings = tmp_path / "cfg" / "settings.json"
+
+        def _deny(self: Path, *args: object, **kwargs: object) -> None:
+            raise PermissionError(13, "Permission denied", str(self))
+
+        monkeypatch.setattr(Path, "write_text", _deny)
+        assert install_statusline(settings, repo) is StatuslineInstall.UNWRITABLE


### PR DESCRIPTION
## Problem

The Docker `init` role runs `t3 setup` under `set -euo pipefail`. `install_statusline` did an unguarded `settings_path.parent.mkdir(...)` + `settings_path.write_text(...)` on `~/.claude/settings.json`.

In the headless container only `~/.claude/projects` is bind-mounted, so Docker creates the parent `~/.claude` **root-owned** and the `teatree` (uid 1001) user cannot write `settings.json`. The `PermissionError` propagated out of `t3 setup`, init exited 1, and worker/admin never started — the whole stack went down.

The read path was already guarded; only the write was unguarded.

## Fix

- `statusline_installer.py`: add `StatuslineInstall.UNWRITABLE`; wrap the `mkdir` + `write_text` in `try/except OSError` and return `UNWRITABLE` instead of raising.
- `command.py`: `_report_statusline_install` handles `UNWRITABLE` by echoing a WARN and continuing, so `run()` still exits 0.

A statusline convenience write is never fatal to setup.

## Tests

- `install_statusline` against an unwritable target returns `StatuslineInstall.UNWRITABLE` and does not raise (RED-first: previously propagated `PermissionError`).
- `_report_statusline_install` emits a WARN and does not raise when the installer returns `UNWRITABLE`.

Both suites green; `ruff check`/`format` clean; `dev/ci-parity-fast.sh` passed (676 passed, scoped push-gate).