### PR TITLE
fix(loops): drain the headless queue and stop the FSM no-opping silently (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,12 +188,14 @@ the `Ticket` model's `@transition` decorators; edit the model, not the diagram
 stateDiagram-v2
     [*] --> not_started
     not_started --> scoped : scope
+    not_started --> coded : code_direct
     not_started --> reviewed : reconcile_reviewed
     not_started --> merged : reconcile_merged
     not_started --> delivered : mark_review_no_action
     not_started --> delivered : mark_reviewed_externally
     not_started --> ignored : ignore
     scoped --> started : start
+    scoped --> coded : code_direct
     scoped --> reviewed : reconcile_reviewed
     scoped --> merged : reconcile_merged
     scoped --> delivered : mark_review_no_action
@@ -201,6 +203,7 @@ stateDiagram-v2
     scoped --> ignored : ignore
     started --> started : start
     started --> planned : plan
+    started --> coded : code_direct
     started --> reviewed : reconcile_reviewed
     started --> merged : reconcile_merged
     started --> delivered : mark_review_no_action

--- a/docs/generated/diagrams/ticket-lifecycle.md
+++ b/docs/generated/diagrams/ticket-lifecycle.md
@@ -5,12 +5,14 @@
 stateDiagram-v2
     [*] --> not_started
     not_started --> scoped : scope
+    not_started --> coded : code_direct
     not_started --> reviewed : reconcile_reviewed
     not_started --> merged : reconcile_merged
     not_started --> delivered : mark_review_no_action
     not_started --> delivered : mark_reviewed_externally
     not_started --> ignored : ignore
     scoped --> started : start
+    scoped --> coded : code_direct
     scoped --> reviewed : reconcile_reviewed
     scoped --> merged : reconcile_merged
     scoped --> delivered : mark_review_no_action
@@ -18,6 +20,7 @@ stateDiagram-v2
     scoped --> ignored : ignore
     started --> started : start
     started --> planned : plan
+    started --> coded : code_direct
     started --> reviewed : reconcile_reviewed
     started --> merged : reconcile_merged
     started --> delivered : mark_review_no_action

--- a/src/teatree/core/models/auto_implement.py
+++ b/src/teatree/core/models/auto_implement.py
@@ -1,0 +1,50 @@
+"""Auto-implement marker for the issue-implementer direct-coding flow.
+
+``persistence._handle_orchestrator`` schedules a ``coding`` task directly on a
+freshly-created NOT_STARTED author ticket — the issue-implementer auto-start
+path deliberately skips the scope/plan phases. When that coding task completes
+the ticket is still in an early state, so the normal ``coding -> code()`` guard
+(``source=PLANNED``) cannot fire and :meth:`Task._apply_phase_transition` would
+silently no-op (the wedge that left tickets 35/36 with completed coding yet zero
+transitions and no PR).
+
+This marker, stamped on ``Ticket.extra`` via the canonical locked
+``merge_extra``, records that the ticket is on the plan-skipped direct-coding
+path, so the coding-completion transition path advances it via
+``Ticket.code_direct`` from an early state — reachable ONLY for a marked ticket,
+so the normal author flow's plan gate is never weakened.
+
+Lives at module scope (not on ``Ticket``) to keep the model under the
+module-health LOC cap; semantically a sibling of ``external_delivery`` and
+``trivial_plan_skip``.
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from teatree.core.models.ticket import Ticket
+
+_MARKER_KEY = "auto_implement"
+
+
+def mark_auto_implement(ticket: "Ticket") -> None:
+    """Mark *ticket* as the plan-skipped issue-implementer direct-coding flow.
+
+    Written through the ticket's canonical locked ``merge_extra`` so a
+    concurrent ``extra`` writer's key survives.
+    """
+    ticket.merge_extra(set_keys={_MARKER_KEY: True})
+
+
+def is_auto_implement(ticket: object) -> bool:
+    """Whether *ticket* carries the auto-implement direct-coding marker.
+
+    Typed ``object`` (like the sibling ``ticket._check_plan_artifact`` predicate)
+    so it slots directly into a ``django_fsm`` ``@transition`` ``conditions=[...]``
+    list — whose contract is ``Callable[[Model], bool]`` — without a wrapper
+    lambda. Fail-safe: a missing or malformed ``extra`` reads as ``False`` (not
+    auto-implement), so a garbled row can never widen the ``code_direct`` gate.
+    """
+    extra = getattr(ticket, "extra", None)
+    extra = extra if isinstance(extra, dict) else {}
+    return extra.get(_MARKER_KEY) is True

--- a/src/teatree/core/models/task.py
+++ b/src/teatree/core/models/task.py
@@ -9,6 +9,7 @@ from django_fsm import FSMField, TransitionNotAllowed
 
 from teatree.core.managers import TaskManager
 from teatree.core.modelkit.phases import SUBAGENT_BY_PHASE, phase_spellings
+from teatree.core.models.auto_implement import is_auto_implement
 from teatree.core.models.errors import InvalidTransitionError
 from teatree.core.models.external_delivery import not_under_external_delivery_q
 from teatree.core.models.session import Session
@@ -16,6 +17,35 @@ from teatree.core.models.ticket import Ticket
 
 if TYPE_CHECKING:
     from teatree.core.models.task_attempt import TaskAttempt
+
+#: The lifecycle-FSM target state each phase's completion should reach. A
+#: completed phase task whose ticket sits BEHIND its target with no matching
+#: guard is a genuine wedge (escalate); at-or-past is an idempotent replay
+#: (no-op). A phase absent here is free-form work with no FSM transition.
+_PHASE_TARGET_STATE: dict[str, str] = {
+    "scoping": Ticket.State.STARTED,
+    "planning": Ticket.State.PLANNED,
+    "coding": Ticket.State.CODED,
+    "testing": Ticket.State.TESTED,
+    "reviewing": Ticket.State.REVIEWED,
+    "shipping": Ticket.State.SHIPPED,
+}
+#: Lifecycle order used to compare a ticket's position to a phase's target.
+#: Terminal/abandoned IGNORED is intentionally absent — it is never a wedge.
+_STATE_ORDER: list[str] = [
+    Ticket.State.NOT_STARTED,
+    Ticket.State.SCOPED,
+    Ticket.State.STARTED,
+    Ticket.State.PLANNED,
+    Ticket.State.CODED,
+    Ticket.State.TESTED,
+    Ticket.State.REVIEWED,
+    Ticket.State.SHIPPED,
+    Ticket.State.IN_REVIEW,
+    Ticket.State.MERGED,
+    Ticket.State.RETROSPECTED,
+    Ticket.State.DELIVERED,
+]
 
 
 class Task(models.Model):
@@ -414,6 +444,18 @@ class Task(models.Model):
             elif phase == "coding" and ticket.state == Ticket.State.PLANNED:
                 ticket.code(parent_task=self)
                 ticket.save()
+            elif (
+                phase == "coding"
+                and ticket.state in {Ticket.State.NOT_STARTED, Ticket.State.SCOPED, Ticket.State.STARTED}
+                and is_auto_implement(ticket)
+            ):
+                # The issue-implementer auto-start path schedules coding directly
+                # on a fresh NOT_STARTED author ticket (no scope/plan phase), so
+                # the coding-completion cannot match the PLANNED-source ``code()``
+                # guard above. ``code_direct`` is the plan-skipped sibling, gated
+                # on the auto-implement marker, so the normal flow is untouched.
+                ticket.code_direct(parent_task=self)
+                ticket.save()
             elif phase == "testing" and ticket.state == Ticket.State.CODED:
                 ticket.test(passed=True, parent_task=self)
                 ticket.save()
@@ -436,8 +478,66 @@ class Task(models.Model):
                 ticket.ship()
                 ticket.save()
             else:
+                self._escalate_unmatched_phase_transition(phase=phase, ticket=ticket)
                 return False
         return True
+
+    def _escalate_unmatched_phase_transition(self, *, phase: str, ticket: Ticket) -> None:
+        """Escalate a genuine FSM wedge instead of the silent ``return False`` (#10).
+
+        The FSM invariant: a lifecycle phase transition must never fail silently.
+        When a completed phase task matches NO guard in
+        :meth:`_apply_phase_transition`, the no-op is one of two things — an
+        idempotent replay (the ticket has ALREADY advanced past this phase's
+        target — a parallel child task, or a replay of an already-applied
+        transition — expected, must NOT escalate), or a genuine wedge (the
+        phase's work completed but the ticket is BEHIND the phase's target with
+        no guard able to advance it — the class that left tickets 35/36 with
+        completed coding yet zero transitions — must escalate, never drop).
+
+        The two are told apart by comparing the ticket's state position to the
+        phase's target state: at-or-past target is an idempotent replay; behind
+        target is a wedge. A free-form (non-lifecycle) phase has no target and
+        is expected to no-op. A terminal/abandoned ticket is never a wedge.
+        """
+        target = _PHASE_TARGET_STATE.get(phase)
+        # IGNORED is the one state absent from _STATE_ORDER (terminal/abandoned,
+        # never a wedge); excluding it here means ticket.state is always in the
+        # order below, so the index lookups cannot raise.
+        if target is None or ticket.state == Ticket.State.IGNORED:
+            return
+        if _STATE_ORDER.index(ticket.state) >= _STATE_ORDER.index(target):
+            return  # idempotent replay — the ticket already advanced past this phase's target
+        self._record_stuck_transition_question(phase=phase, ticket=ticket)
+
+    def _record_stuck_transition_question(self, *, phase: str, ticket: Ticket) -> None:
+        """Record a durable, deduped ``DeferredQuestion`` for an FSM wedge (§17.1 inv 9).
+
+        Reuses the away-mode escalation queue (statusline / ``t3 teatree
+        questions list`` / Slack DM drain) rather than a new surface — the same
+        channel ``task_repair._escalate_stall`` uses. Deduped per (ticket,
+        phase) on ``tool_use_id`` so an at-least-once replay of the same wedge
+        does not flood the queue.
+        """
+        from teatree.core.models.deferred_question import DeferredQuestion  # noqa: PLC0415 — ORM/app-registry
+
+        dedup_key = f"fsm-wedge:{ticket.pk}:{phase}"
+        already = DeferredQuestion.objects.filter(
+            tool_use_id=dedup_key,
+            answered_at__isnull=True,
+            dismissed_at__isnull=True,
+        ).exists()
+        if already:
+            return
+        where = ticket.issue_url or f"ticket {ticket.pk}"
+        question = (
+            f"FSM wedge on {where}: the {phase!r} phase completed (task {self.pk}) but no "
+            f"lifecycle transition matched from state {ticket.state!r}, so the ticket cannot "
+            f"advance and is stuck before {phase!r}. How should it proceed — rework the "
+            f"earlier phases, or ignore?"
+        )
+        session_id: int | None = self.session_id  # ty: ignore[unresolved-attribute]
+        DeferredQuestion.record(question, session_id=str(session_id or ""), tool_use_id=dedup_key)
 
     def _record_phase_visit(self) -> None:
         """Record this task's phase on its session as completion happens (#694).

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -7,6 +7,7 @@ from django_fsm import FSMField, transition
 from teatree.core.managers import TicketManager
 from teatree.core.modelkit.gate_registry import get_gate
 from teatree.core.modelkit.review_state import ReviewState
+from teatree.core.models.auto_implement import is_auto_implement
 from teatree.core.models.ticket_evidence import TicketEvidenceModel
 from teatree.core.models.ticket_introspection import TicketIntrospectionModel
 from teatree.core.models.ticket_ledger import retire_phase_ledger
@@ -256,6 +257,32 @@ class Ticket(
     @transition(field=state, source=State.PLANNED, target=State.CODED)
     def code(self, *, parent_task: "Task | None" = None) -> None:
         get_gate("plan_currency")(self)  # SELFCATCH-3: refuse a thin/stale plan (NO-OP unless flag on).
+        self._refuse_if_worktree_dirty("coding")
+        self._consume_pending_phase_tasks("coding")
+        self.schedule_testing(parent_task=parent_task)
+
+    @transition(
+        field=state,
+        source=[State.NOT_STARTED, State.SCOPED, State.STARTED],
+        target=State.CODED,
+        conditions=[is_auto_implement],
+    )
+    def code_direct(self, *, parent_task: "Task | None" = None) -> None:
+        """Advance a plan-skipped auto-implement ticket straight to CODED.
+
+        The issue-implementer auto-start path
+        (``persistence._handle_orchestrator``) schedules a ``coding`` task
+        directly, skipping the scope/plan phases, so the normal ``code()`` guard
+        (``source=PLANNED``) can never fire when that task completes — the wedge
+        that left tickets with completed coding yet zero transitions and no PR.
+        This is the plan-skipped sibling of ``code()``, reachable ONLY for a
+        ticket carrying the ``auto_implement`` marker (the ``is_auto_implement``
+        condition), so the normal author flow's plan gate is untouched. Unlike
+        ``code()`` it runs no ``plan_currency`` gate (there is no plan to check),
+        but it keeps the same dirty-worktree preflight and schedules testing, so
+        the FSM proceeds coding -> testing -> reviewing -> shipping instead of
+        silently no-opping.
+        """
         self._refuse_if_worktree_dirty("coding")
         self._consume_pending_phase_tasks("coding")
         self.schedule_testing(parent_task=parent_task)

--- a/src/teatree/core/models/types.py
+++ b/src/teatree/core/models/types.py
@@ -129,6 +129,13 @@ class TicketExtra(TypedDict, total=False):
     # PlanArtifact) and ``execute_provision`` (skips the auto-planner). See
     # ``TrivialPlanSkip``.
     trivial_plan_skip: "TrivialPlanSkip"
+    # Plan-skipped issue-implementer direct-coding marker: stamped by
+    # ``persistence._handle_orchestrator`` when it schedules a ``coding`` task
+    # directly on a fresh NOT_STARTED author ticket (no scope/plan phase). Read
+    # by ``auto_implement.is_auto_implement`` — the ``Ticket.code_direct``
+    # condition that lets a coding-completion advance the FSM from an early
+    # state without weakening the normal author flow's plan gate.
+    auto_implement: bool
     # #2663 dream-promote = fix-and-merge: a Ticket scheduled to fix a grounded
     # dream gap. ``dream_gap_key`` is the stable gap identity (also the umbrella
     # checkbox marker); ``dream_memory_cluster_key`` links back to the

--- a/src/teatree/core/tasks.py
+++ b/src/teatree/core/tasks.py
@@ -130,8 +130,7 @@ def execute_headless_task(task_id: int, phase: str) -> dict[str, object]:
         return {"attempt_id": attempt.pk, "exit_code": attempt.exit_code, "result": attempt.result}
 
 
-@task()
-def drain_headless_queue() -> dict[str, list[int]]:
+def drain_headless_queue_body() -> dict[str, list[int]]:
     """Auto-enqueue pending headless tasks for execution (safety net), failing poison rows.
 
     Tasks the in-session ``/loop`` owns (``runs_in_session`` — a loop-dispatched
@@ -141,23 +140,43 @@ def drain_headless_queue() -> dict[str, list[int]]:
     ``agent_runtime`` those phase tasks are headless and ``runs_in_session`` is
     ``False``, so they drain like any other headless work.
 
+    Under ``agent_runtime=headless`` the drain ALSO adopts stale
+    ``execution_target=interactive`` pending rows — phase tasks created during a
+    laptop ``/loop`` era whose target was routed INTERACTIVE, then orphaned when
+    the box moved to the headless lane with no interactive session ever alive to
+    dispatch them (the undispatchable-forever class the "codex_reviewing"
+    backlog was in). Each is ``route_to_headless``-d before dispatch, permanently
+    closing the laptop->box orphan. Under ``agent_runtime=interactive`` the
+    interactive rows are the ``/loop`` slot's job and are left untouched.
+
     A task whose ticket names a non-empty unknown overlay is failed permanently
     rather than re-enqueued (souliane/teatree#1959): re-enqueuing it would crash
     ``execute_headless_task`` on every tick forever — the poison pill this drain
     must not keep feeding. A blank overlay is the ambient single-overlay default
     and stays dispatchable.
+
+    This is the plain body shared by the ``@task drain_headless_queue`` (the
+    default-queue safety net) and the loops-queue maintenance chain
+    (:func:`teatree.loops.timer_reconciler.drain_headless_chain`) that schedules
+    it, so the two call sites can never drift.
     """
+    from teatree.config import AgentRuntime, get_effective_settings  # noqa: PLC0415 — deferred: call-time import
     from teatree.core.headless_dispatch import runs_in_session  # noqa: PLC0415 — deferred: call-time import, kept lazy
 
+    headless_runtime = get_effective_settings().agent_runtime is AgentRuntime.HEADLESS
+    targets = [Task.ExecutionTarget.HEADLESS]
+    if headless_runtime:
+        targets.append(Task.ExecutionTarget.INTERACTIVE)
     pending = (
         Task.objects.filter(
-            execution_target=Task.ExecutionTarget.HEADLESS,
+            execution_target__in=targets,
             status=Task.Status.PENDING,
         )
         .select_related("ticket")
-        .only("pk", "phase", "ticket__role", "ticket__overlay")
+        .only("pk", "phase", "execution_target", "ticket__role", "ticket__overlay")
     )
     enqueued: list[int] = []
+    rerouted: list[int] = []
     failed_unknown_overlay: list[int] = []
     for task_obj in pending:
         if runs_in_session(role=task_obj.ticket.role, phase=task_obj.phase):
@@ -169,9 +188,20 @@ def drain_headless_queue() -> dict[str, list[int]]:
             task_obj.complete_with_attempt(exit_code=1, error=reason, result={"unknown_overlay": reason})
             failed_unknown_overlay.append(task_obj.pk)
             continue
+        if task_obj.execution_target == Task.ExecutionTarget.INTERACTIVE:
+            task_obj.route_to_headless(
+                reason="Stale interactive row adopted by headless drain (laptop->box orphan, agent_runtime=headless)"
+            )
+            rerouted.append(task_obj.pk)
         execute_headless_task.enqueue(task_obj.pk, task_obj.phase)
         enqueued.append(task_obj.pk)
-    return {"enqueued": enqueued, "failed_unknown_overlay": failed_unknown_overlay}
+    return {"enqueued": enqueued, "rerouted": rerouted, "failed_unknown_overlay": failed_unknown_overlay}
+
+
+@task()
+def drain_headless_queue() -> dict[str, list[int]]:
+    """The default-queue ``@task`` wrapper around :func:`drain_headless_queue_body`."""
+    return drain_headless_queue_body()
 
 
 @task()

--- a/src/teatree/loop/persistence.py
+++ b/src/teatree/loop/persistence.py
@@ -20,6 +20,7 @@ from django.db import transaction
 
 from teatree.core.intake.ticket_kind_classification import TicketOrigin, classify_ticket_kind
 from teatree.core.models import ImplementedIssueMarker, Task, Ticket
+from teatree.core.models.auto_implement import mark_auto_implement
 from teatree.core.models.ticket_external_review import schedule_external_review
 from teatree.loop.dispatch import DispatchAction
 from teatree.loop.dispatch_gates import claim_red_mr_fix
@@ -245,6 +246,11 @@ def _handle_orchestrator(action: DispatchAction) -> Task | None:
         return None
     if _has_open_task(ticket, phase="coding") or ticket.state != Ticket.State.NOT_STARTED:
         return None
+    # Mark the plan-skipped direct-coding path BEFORE scheduling coding, so the
+    # coding-completion transition (``Task._apply_phase_transition`` ->
+    # ``Ticket.code_direct``) can advance this NOT_STARTED ticket instead of
+    # silently no-opping the way it did for tickets 35/36 (#10).
+    mark_auto_implement(ticket)
     return ticket.schedule_coding()
 
 

--- a/src/teatree/loops/timer_reconciler.py
+++ b/src/teatree/loops/timer_reconciler.py
@@ -44,6 +44,15 @@ PRUNE_RETENTION_SECONDS = 86400
 EXPIRE_INTERVAL_SECONDS = 3600
 #: Grace past a tick's deadline before its still-RUNNING timer is deemed stranded.
 STUCK_GRACE_SECONDS = 60
+#: The headless-queue drain + stuck-run reaper cadence — the safety net that
+#: keeps the headless backlog draining (``drain_headless_queue`` was previously
+#: never scheduled from anywhere) and re-enqueues runs a dead worker abandoned.
+DRAIN_INTERVAL_SECONDS = 300
+#: A live headless run renews its ``Task`` lease from the heartbeat thread every
+#: few seconds; the default claim lease is 300s. A RUNNING ``execute_headless_task``
+#: whose ``Task`` lease has lapsed past this window has a dead worker — its
+#: heartbeat stopped — so the ``DBTaskResult`` is stranded and must be reaped.
+HEADLESS_LEASE_SECONDS = 300
 
 
 def timer_chain_loop_names() -> set[str]:
@@ -201,8 +210,118 @@ def expire_stale_jobs() -> dict[str, int]:
     return {"retired": sum(retired.values())}
 
 
+class _StuckHeadlessRunError(RuntimeError):
+    """Recorded on a stranded ``execute_headless_task`` DBTaskResult reaped by the reconciler."""
+
+
+def _headless_task_id(row) -> int | None:  # noqa: ANN001 — duck-typed DBTaskResult handle
+    """The ``Task`` pk a ``execute_headless_task`` DBTaskResult carries as its first arg."""
+    args = row.args_kwargs.get("args") or []
+    if not args:
+        return None
+    first = args[0]
+    return first if isinstance(first, int) else None
+
+
+def _headless_run_is_dead(task, row, now: dt.datetime) -> bool:  # noqa: ANN001 — duck-typed handles
+    """Whether a RUNNING ``execute_headless_task`` row is a dead-worker orphan.
+
+    The per-run liveness signal is the ``Task`` lease: the headless runner's
+    heartbeat thread renews it every few seconds, so a live run always keeps
+    ``lease_expires_at`` in the future. A run is dead when its heartbeat has
+    stopped — the lease is absent (the claim was lease-reclaimed back to PENDING)
+    or lapsed into the past. The ``started_at`` floor rules out the brief window
+    between the row going RUNNING and the worker claiming + setting the lease, so
+    a just-started healthy run is never reaped. A vanished ``Task`` row leaves an
+    orphaned DBTaskResult that is likewise dead (and un-re-enqueueable).
+    """
+    from teatree.core.models import Task  # noqa: PLC0415 — deferred: ORM import needs the app registry
+
+    if row.started_at is None:
+        return False
+    if row.started_at > now - dt.timedelta(seconds=HEADLESS_LEASE_SECONDS + STUCK_GRACE_SECONDS):
+        return False
+    if task is None:
+        return True
+    lease = task.lease_expires_at
+    heartbeat_live = task.status == Task.Status.CLAIMED and lease is not None and lease > now
+    return not heartbeat_live
+
+
+def reap_stuck_headless_runs() -> dict[str, int]:
+    """Fail dead-worker ``execute_headless_task`` runs and re-enqueue their live tasks (#10).
+
+    ``timer_reconciler`` recovers only stranded ``loop_timer`` rows, and
+    ``expire_stale_ready_jobs`` touches only READY rows — so a ``DBTaskResult``
+    left RUNNING when a worker died mid-run wedges forever: the Task's lease is
+    reclaimed back to PENDING but ``execute_headless_task``'s auto-enqueue fires
+    only on post_save creation, so it is never re-run. This reaper closes that
+    gap: each RUNNING ``execute_headless_task`` past its lease+grace with a dead
+    heartbeat is marked FAILED (reversible, inspectable — no hard delete), and
+    when its ``Task`` row is still non-terminal a fresh ``execute_headless_task``
+    is enqueued so the work resumes. The claim CAS in ``execute_headless_task``
+    makes a redundant re-enqueue safe (a second run loses the claim and fails
+    cleanly, never double-executes).
+    """
+    from django_tasks.base import TaskResultStatus  # noqa: PLC0415 — deferred: heavy/optional dep at call site
+    from django_tasks_db.models import DBTaskResult  # noqa: PLC0415 — deferred: heavy/optional dep at call site
+
+    from teatree.core.models import Task  # noqa: PLC0415 — deferred: ORM import needs the app registry
+    from teatree.core.tasks import execute_headless_task  # noqa: PLC0415 — deferred: task-body import
+
+    now = timezone.now()
+    running = DBTaskResult.objects.filter(
+        task_path=execute_headless_task.module_path,
+        status=TaskResultStatus.RUNNING,
+    )
+    counts = {"failed": 0, "reenqueued": 0}
+    for row in running:
+        task_id = _headless_task_id(row)
+        if task_id is None:
+            continue  # a malformed row with no identifiable Task — leave it untouched.
+        task = Task.objects.filter(pk=task_id).first()
+        if not _headless_run_is_dead(task, row, now):
+            continue
+        row.set_failed(_StuckHeadlessRunError(f"execute_headless_task {row.id} RUNNING past lease+grace; worker dead"))
+        counts["failed"] += 1
+        if task is not None and task.status not in Task.Status.terminal():
+            execute_headless_task.enqueue(task.pk, task.phase)
+            counts["reenqueued"] += 1
+    if any(counts.values()):
+        logger.info("reap_stuck_headless_runs: %s", counts)
+    return counts
+
+
+@task(queue_name=LOOPS_QUEUE)
+def drain_headless_chain() -> dict[str, int]:
+    """Reap dead headless runs, drain the pending headless backlog, re-schedule ~5min out.
+
+    The scheduled home of ``drain_headless_queue`` — it was defined but NEVER
+    scheduled from anywhere, so the pending headless backlog only drained on the
+    post_save auto-enqueue (missed on a lease-reclaim / stale interactive row).
+    Seeded by :func:`ensure_maintenance_chains` at worker startup and
+    self-perpetuating, like its sibling reconcile/prune/expire chains. Runs on
+    the ``loops`` queue and enqueues onto ``default`` (it never runs the heavy
+    headless work itself). Self-dedups first so an at-least-once redelivery
+    collapses to one.
+    """
+    from teatree.core.tasks import drain_headless_queue_body  # noqa: PLC0415 — deferred: task-body import
+
+    if _pending_for_path(drain_headless_chain.module_path):
+        return {"deduped": 1}
+    reaped = reap_stuck_headless_runs()
+    drained = drain_headless_queue_body()
+    drain_headless_chain.using(run_after=timezone.now() + dt.timedelta(seconds=DRAIN_INTERVAL_SECONDS)).enqueue()
+    return {
+        "reaped_failed": reaped["failed"],
+        "reaped_reenqueued": reaped["reenqueued"],
+        "drained": len(drained["enqueued"]),
+        "rerouted": len(drained["rerouted"]),
+    }
+
+
 def ensure_maintenance_chains() -> None:
-    """Seed the reconcile + prune + stale-job-expiry + usage-window-recovery + preset chains if absent."""
+    """Seed the reconcile + prune + expire + drain + usage-window-recovery + preset chains if absent."""
     from teatree.loops.preset_transitions import ensure_preset_transitions_chain  # noqa: PLC0415 — cycle-safe
     from teatree.loops.usage_window_recovery import ensure_usage_window_recovery_chain  # noqa: PLC0415 — cycle-safe
 
@@ -213,6 +332,12 @@ def ensure_maintenance_chains() -> None:
         prune_task_results.using(run_after=now + dt.timedelta(seconds=PRUNE_INTERVAL_SECONDS)).enqueue()
     if not _pending_for_path(expire_stale_jobs.module_path):
         expire_stale_jobs.using(run_after=now + dt.timedelta(seconds=EXPIRE_INTERVAL_SECONDS)).enqueue()
+    # #10: the headless-queue drain + dead-run reaper. ``drain_headless_queue``
+    # had zero call sites, so the pending headless backlog only drained on the
+    # post_save auto-enqueue — a lease-reclaimed or stale-interactive row was
+    # never re-dispatched. Seeding it here is the "actually run the drain" fix.
+    if not _pending_for_path(drain_headless_chain.module_path):
+        drain_headless_chain.using(run_after=now + dt.timedelta(seconds=DRAIN_INTERVAL_SECONDS)).enqueue()
     # Directive #3: the self-rescheduling usage-window re-arm chain. Its body is inert while
     # ``limit_autorecovery_enabled`` is OFF, so seeding it unconditionally is dark-safe.
     ensure_usage_window_recovery_chain()

--- a/tests/quality/deferred_import_pegs.toml
+++ b/tests/quality/deferred_import_pegs.toml
@@ -76,7 +76,7 @@
 "src/teatree/core/model_registries.py" = 5
 "src/teatree/core/models/auto_review_dispatch.py" = 3
 "src/teatree/core/models/review_loop.py" = 3
-"src/teatree/core/models/task.py" = 7
+"src/teatree/core/models/task.py" = 8
 # artifacts() defers `from teatree.core.models.ticket_artifacts import
 # collect_ticket_artifacts` (a real import cycle: ticket_artifacts imports the
 # ticket models back). The method — and its deferral — moved here from

--- a/tests/teatree_core/models/test_auto_implement.py
+++ b/tests/teatree_core/models/test_auto_implement.py
@@ -1,0 +1,33 @@
+"""``teatree.core.models.auto_implement`` — the plan-skipped direct-coding marker (#10)."""
+
+from django.test import TestCase
+
+from teatree.core.models import Ticket
+from teatree.core.models.auto_implement import is_auto_implement, mark_auto_implement
+
+
+class TestAutoImplementMarker(TestCase):
+    def test_unmarked_ticket_is_not_auto_implement(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", role=Ticket.Role.AUTHOR)
+        assert is_auto_implement(ticket) is False
+
+    def test_marked_ticket_reads_back_true(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", role=Ticket.Role.AUTHOR)
+        mark_auto_implement(ticket)
+        ticket.refresh_from_db()
+        assert is_auto_implement(ticket) is True
+
+    def test_marker_survives_a_concurrent_extra_writer(self) -> None:
+        # merge_extra is the canonical locked RMW — a sibling key must survive.
+        ticket = Ticket.objects.create(overlay="test", role=Ticket.Role.AUTHOR)
+        ticket.merge_extra(set_keys={"description": "hello"})
+        mark_auto_implement(ticket)
+        ticket.refresh_from_db()
+        assert is_auto_implement(ticket) is True
+        assert ticket.extra["description"] == "hello"
+
+    def test_malformed_extra_reads_as_not_auto_implement(self) -> None:
+        # Fail-safe: a non-dict extra can never widen the code_direct gate.
+        ticket = Ticket(overlay="test", role=Ticket.Role.AUTHOR)
+        ticket.extra = None
+        assert is_auto_implement(ticket) is False

--- a/tests/teatree_core/models/test_ticket_structure.py
+++ b/tests/teatree_core/models/test_ticket_structure.py
@@ -70,6 +70,7 @@ _PUBLIC_API: frozenset[str] = frozenset(
 # Behaviour-preserving means this map is byte-identical afterwards.
 _FSM_GRAPH: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
     "code": (("planned",), ("coded",)),
+    "code_direct": (("not_started", "scoped", "started"), ("coded",)),
     "ignore": (
         (
             "coded",

--- a/tests/teatree_core/test_task_apply_phase_transition.py
+++ b/tests/teatree_core/test_task_apply_phase_transition.py
@@ -122,3 +122,107 @@ class TestApplyPhaseTransitionChainsParentTask(TestCase):
         assert ticket.state == Ticket.State.TESTED
         review = Task.objects.get(ticket=ticket, phase="reviewing")
         assert review.parent_task_id == testing_task.pk
+
+
+class TestApplyPhaseTransitionAutoImplement(TestCase):
+    """#10: an auto-implement author ticket advances on coding completion.
+
+    ``persistence._handle_orchestrator`` schedules a ``coding`` task directly on
+    a fresh NOT_STARTED author ticket, so the completion cannot match the
+    PLANNED-source ``code()`` guard. Before ``code_direct`` this no-opped
+    silently — tickets 35/36 spent budget on coding yet advanced NOTHING.
+    """
+
+    def _completed_coding_task(self, ticket: Ticket) -> Task:
+        session = Session.objects.create(ticket=ticket, agent_id="coding")
+        return Task.objects.create(ticket=ticket, session=session, phase="coding", status=Task.Status.COMPLETED)
+
+    def test_coding_completion_on_not_started_auto_implement_advances_to_coded(self) -> None:
+        from teatree.core.models.auto_implement import mark_auto_implement  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(overlay="test", role=Ticket.Role.AUTHOR, state=Ticket.State.NOT_STARTED)
+        mark_auto_implement(ticket)
+        coding_task = self._completed_coding_task(ticket)
+
+        fired = coding_task._apply_phase_transition()
+
+        ticket.refresh_from_db()
+        assert fired is True, "an auto-implement ticket must advance on coding completion, not silently no-op"
+        assert ticket.state == Ticket.State.CODED
+        testing = Task.objects.get(ticket=ticket, phase="testing")
+        assert testing.parent_task_id == coding_task.pk
+
+    def test_coding_completion_on_unmarked_early_ticket_does_not_advance(self) -> None:
+        # Behavior preservation: without the marker, code_direct is unreachable —
+        # a plain NOT_STARTED author ticket's coding completion must NOT advance
+        # (it escalates instead; see TestApplyPhaseTransitionEscalation).
+        ticket = Ticket.objects.create(overlay="test", role=Ticket.Role.AUTHOR, state=Ticket.State.NOT_STARTED)
+        coding_task = self._completed_coding_task(ticket)
+
+        fired = coding_task._apply_phase_transition()
+
+        ticket.refresh_from_db()
+        assert fired is False
+        assert ticket.state == Ticket.State.NOT_STARTED
+
+
+class TestApplyPhaseTransitionEscalation(TestCase):
+    """#10 invariant: an FSM lifecycle transition must never fail silently.
+
+    When no guard matches AND the ticket is behind the phase's target (a genuine
+    wedge, not an idempotent replay), a durable ``DeferredQuestion`` is recorded
+    so the operator is told, instead of the old silent ``return False``.
+    """
+
+    def _completed_task(self, ticket: Ticket, phase: str) -> Task:
+        session = Session.objects.create(ticket=ticket, agent_id=phase)
+        return Task.objects.create(ticket=ticket, session=session, phase=phase, status=Task.Status.COMPLETED)
+
+    def test_wedged_coding_completion_records_a_deferred_question(self) -> None:
+        from teatree.core.models.deferred_question import DeferredQuestion  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(overlay="test", role=Ticket.Role.AUTHOR, state=Ticket.State.NOT_STARTED)
+        coding_task = self._completed_task(ticket, "coding")
+
+        fired = coding_task._apply_phase_transition()
+
+        assert fired is False
+        pending = DeferredQuestion.pending()
+        assert pending.count() == 1, "a genuine FSM wedge must escalate, never silently drop"
+        assert "FSM wedge" in pending.first().question
+
+    def test_wedge_escalation_is_deduped_across_replays(self) -> None:
+        from teatree.core.models.deferred_question import DeferredQuestion  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(overlay="test", role=Ticket.Role.AUTHOR, state=Ticket.State.NOT_STARTED)
+        coding_task = self._completed_task(ticket, "coding")
+
+        coding_task._apply_phase_transition()
+        coding_task._apply_phase_transition()
+
+        assert DeferredQuestion.pending().count() == 1, "an at-least-once replay must not flood the question queue"
+
+    def test_idempotent_replay_past_target_does_not_escalate(self) -> None:
+        from teatree.core.models.deferred_question import DeferredQuestion  # noqa: PLC0415
+
+        # A coding task completing on a ticket already advanced to TESTED (past
+        # coding's CODED target) is an idempotent replay, not a wedge.
+        ticket = Ticket.objects.create(overlay="test", role=Ticket.Role.AUTHOR, state=Ticket.State.TESTED)
+        coding_task = self._completed_task(ticket, "coding")
+
+        fired = coding_task._apply_phase_transition()
+
+        assert fired is False
+        assert DeferredQuestion.pending().count() == 0, "an idempotent replay must not escalate"
+
+    def test_free_form_phase_does_not_escalate(self) -> None:
+        from teatree.core.models.deferred_question import DeferredQuestion  # noqa: PLC0415
+
+        # A non-lifecycle phase (no FSM target) legitimately no-ops.
+        ticket = Ticket.objects.create(overlay="test", role=Ticket.Role.AUTHOR, state=Ticket.State.NOT_STARTED)
+        task = self._completed_task(ticket, "architectural_review")
+
+        fired = task._apply_phase_transition()
+
+        assert fired is False
+        assert DeferredQuestion.pending().count() == 0

--- a/tests/teatree_core/test_tasks.py
+++ b/tests/teatree_core/test_tasks.py
@@ -13,6 +13,7 @@ from teatree.core.models import AttachmentManifest, Session, Task, TaskAttempt, 
 from teatree.core.runners.base import RunnerResult
 from teatree.core.tasks import (
     drain_headless_queue,
+    drain_headless_queue_body,
     execute_provision,
     execute_retrospect,
     execute_ship,
@@ -138,14 +139,22 @@ class TestDrainHeadlessQueue(TestCase):
         with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY):
             result = drain_headless_queue.enqueue()
 
-        assert result.return_value == {"enqueued": [pending.pk], "failed_unknown_overlay": []}
+        assert result.return_value == {"enqueued": [pending.pk], "rerouted": [], "failed_unknown_overlay": []}
 
     @override_settings(**IMMEDIATE_BACKEND)
     def test_skips_when_no_pending_tasks(self) -> None:
         with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY):
             result = drain_headless_queue.enqueue()
 
-        assert result.return_value == {"enqueued": [], "failed_unknown_overlay": []}
+        assert result.return_value == {"enqueued": [], "rerouted": [], "failed_unknown_overlay": []}
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_body_returns_empty_result_on_empty_queue(self) -> None:
+        # The shared body the @task wrapper and the maintenance chain both call.
+        with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY):
+            result = drain_headless_queue_body()
+
+        assert result == {"enqueued": [], "rerouted": [], "failed_unknown_overlay": []}
 
     @override_settings(**IMMEDIATE_BACKEND)
     def test_unknown_overlay_task_is_failed_not_enqueued(self) -> None:
@@ -162,9 +171,59 @@ class TestDrainHeadlessQueue(TestCase):
         with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY):
             result = drain_headless_queue.enqueue()
 
-        assert result.return_value == {"enqueued": [], "failed_unknown_overlay": [poison.pk]}
+        assert result.return_value == {"enqueued": [], "rerouted": [], "failed_unknown_overlay": [poison.pk]}
         poison.refresh_from_db()
         assert poison.status == Task.Status.FAILED
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_stale_interactive_row_is_rerouted_and_dispatched_under_headless_runtime(self) -> None:
+        # A phase task created during the laptop /loop era: a loop-dispatched
+        # (author, coding) pair routed INTERACTIVE, orphaned once the box moved
+        # to the headless lane with no interactive session to dispatch it. Under
+        # agent_runtime=headless the drain adopts it: route_to_headless + dispatch.
+        from teatree.config import AgentRuntime  # noqa: PLC0415
+
+        ticket = Ticket.objects.create(overlay="test", role=Ticket.Role.AUTHOR)
+        session = Session.objects.create(ticket=ticket, overlay="test")
+        stale = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            execution_target=Task.ExecutionTarget.INTERACTIVE,
+            status=Task.Status.PENDING,
+            phase="coding",
+        )
+
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY),
+            patch("teatree.config.get_effective_settings") as mock_settings,
+        ):
+            mock_settings.return_value.agent_runtime = AgentRuntime.HEADLESS
+            result = drain_headless_queue.enqueue()
+
+        assert result.return_value == {"enqueued": [stale.pk], "rerouted": [stale.pk], "failed_unknown_overlay": []}
+        stale.refresh_from_db()
+        assert stale.execution_target == Task.ExecutionTarget.HEADLESS
+
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_interactive_row_is_left_untouched_under_interactive_runtime(self) -> None:
+        # Under the default interactive runtime the /loop slot owns interactive
+        # rows — the drain must not adopt them (that would double-dispatch).
+        ticket = Ticket.objects.create(overlay="test", role=Ticket.Role.AUTHOR)
+        session = Session.objects.create(ticket=ticket, overlay="test")
+        interactive = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            execution_target=Task.ExecutionTarget.INTERACTIVE,
+            status=Task.Status.PENDING,
+            phase="coding",
+        )
+
+        with patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY):
+            result = drain_headless_queue.enqueue()
+
+        assert result.return_value == {"enqueued": [], "rerouted": [], "failed_unknown_overlay": []}
+        interactive.refresh_from_db()
+        assert interactive.execution_target == Task.ExecutionTarget.INTERACTIVE
 
 
 class TestExecuteHeadlessUnknownOverlay(TestCase):

--- a/tests/teatree_loop/test_persistence_zone_handlers.py
+++ b/tests/teatree_loop/test_persistence_zone_handlers.py
@@ -198,6 +198,29 @@ class TestRedCardZoneRevived(TestCase):
         assert second == []
 
 
+class TestAutoStartOrchestratorMarksAutoImplement(TestCase):
+    """#10: the auto-start orchestrator stamps the auto_implement marker before coding."""
+
+    def _signal(self, *, url: str = "https://x/issue/900") -> ScanSignal:
+        return ScanSignal(
+            kind="assigned_issue.ready",
+            summary=f"Ready to start: {url}",
+            payload={"url": url, "auto_start": True, "overlay": "acme"},
+        )
+
+    def test_auto_start_ticket_is_marked_auto_implement(self) -> None:
+        from teatree.core.models.auto_implement import is_auto_implement  # noqa: PLC0415
+
+        created = persist_agent_actions(_agent_actions(self._signal()))
+
+        assert len(created) == 1
+        task = created[0]
+        assert task.phase == "coding"
+        assert task.ticket.role == Ticket.Role.AUTHOR
+        task.ticket.refresh_from_db()
+        assert is_auto_implement(task.ticket) is True, "the orchestrator must mark the direct-coding path"
+
+
 class TestE2eFixZoneRevived(TestCase):
     def _signal(self, *, spec: str = "e2e/specs/login.spec.ts") -> ScanSignal:
         return ScanSignal(

--- a/tests/teatree_loops/test_timer_reconciler.py
+++ b/tests/teatree_loops/test_timer_reconciler.py
@@ -12,8 +12,10 @@ from django.utils import timezone
 from django_tasks.base import TaskResultStatus
 from django_tasks_db.models import DBTaskResult, get_date_max
 
-from teatree.core.models import Loop
+from teatree.core.models import Loop, Session, Task, Ticket
+from teatree.core.tasks import execute_headless_task
 from teatree.loops import timer_chains, timer_reconciler
+from teatree.loops.timer_reconciler import reap_stuck_headless_runs
 
 _DB_TASKS = {"default": {"BACKEND": "django_tasks_db.DatabaseBackend", "QUEUES": ["default", "loops"]}}
 
@@ -105,10 +107,26 @@ class TestMaintenanceChains(django.test.TestCase):
         assert DBTaskResult.objects.filter(task_path=timer_reconciler.reconcile_timers.module_path).count() == 1
         assert DBTaskResult.objects.filter(task_path=timer_reconciler.prune_task_results.module_path).count() == 1
         assert DBTaskResult.objects.filter(task_path=timer_reconciler.expire_stale_jobs.module_path).count() == 1
+        # #10: the headless-queue drain chain is seeded too (it had no other home).
+        assert DBTaskResult.objects.filter(task_path=timer_reconciler.drain_headless_chain.module_path).count() == 1
         # Idempotent: a second call adds no duplicates.
         timer_reconciler.ensure_maintenance_chains()
         assert DBTaskResult.objects.filter(task_path=timer_reconciler.reconcile_timers.module_path).count() == 1
         assert DBTaskResult.objects.filter(task_path=timer_reconciler.expire_stale_jobs.module_path).count() == 1
+        assert DBTaskResult.objects.filter(task_path=timer_reconciler.drain_headless_chain.module_path).count() == 1
+
+    def test_drain_headless_chain_reschedules_itself(self) -> None:
+        result = timer_reconciler.drain_headless_chain.func()
+        assert "deduped" not in result
+        pending = DBTaskResult.objects.filter(
+            task_path=timer_reconciler.drain_headless_chain.module_path, status=TaskResultStatus.READY
+        )
+        assert pending.count() == 1  # a successor drain chain is queued
+
+    def test_drain_headless_chain_self_dedups(self) -> None:
+        timer_reconciler.drain_headless_chain.using(run_after=timezone.now()).enqueue()
+        result = timer_reconciler.drain_headless_chain.func()
+        assert result == {"deduped": 1}
 
     def test_expire_stale_jobs_reschedules_itself(self) -> None:
         result = timer_reconciler.expire_stale_jobs.func()
@@ -157,3 +175,117 @@ class TestMaintenanceChains(django.test.TestCase):
         assert result["pruned"] == 1
         assert not DBTaskResult.objects.filter(id=old.id).exists()
         assert DBTaskResult.objects.filter(id=recent.id).exists()
+
+
+@django.test.override_settings(USE_TZ=True, TASKS=_DB_TASKS)
+class TestReapStuckHeadlessRuns(django.test.TestCase):
+    """#10: a ``execute_headless_task`` left RUNNING by a dead worker is reaped + re-enqueued."""
+
+    def setUp(self) -> None:
+        DBTaskResult.objects.all().delete()
+
+    def _claimed_task(self, *, lease_delta_seconds: int, status: str = Task.Status.CLAIMED) -> Task:
+        ticket = Ticket.objects.create(overlay="test", role=Ticket.Role.AUTHOR)
+        session = Session.objects.create(ticket=ticket, overlay="test")
+        return Task.objects.create(
+            ticket=ticket,
+            session=session,
+            phase="architectural_review",
+            status=status,
+            claimed_by="headless-worker",
+            lease_expires_at=timezone.now() + dt.timedelta(seconds=lease_delta_seconds),
+        )
+
+    def _running_headless_row(self, task: Task, *, age_seconds: int) -> DBTaskResult:
+        result = execute_headless_task.enqueue(task.pk, task.phase)
+        DBTaskResult.objects.filter(id=result.id).update(
+            status=TaskResultStatus.RUNNING,
+            started_at=timezone.now() - dt.timedelta(seconds=age_seconds),
+        )
+        return DBTaskResult.objects.get(id=result.id)
+
+    def _dead_age(self) -> int:
+        return timer_reconciler.HEADLESS_LEASE_SECONDS + timer_reconciler.STUCK_GRACE_SECONDS + 60
+
+    def test_dead_run_is_failed_and_task_reenqueued(self) -> None:
+        task = self._claimed_task(lease_delta_seconds=-120)  # heartbeat stopped: lease lapsed
+        row = self._running_headless_row(task, age_seconds=self._dead_age())
+
+        counts = reap_stuck_headless_runs()
+
+        assert counts == {"failed": 1, "reenqueued": 1}
+        row.refresh_from_db()
+        assert row.status == TaskResultStatus.FAILED
+        ready = DBTaskResult.objects.filter(task_path=execute_headless_task.module_path, status=TaskResultStatus.READY)
+        assert ready.count() == 1, "the non-terminal task must be re-enqueued for a fresh run"
+
+    def test_live_run_with_fresh_lease_is_not_reaped(self) -> None:
+        # Old RUNNING row, but the heartbeat is still renewing the lease → alive.
+        task = self._claimed_task(lease_delta_seconds=+200)
+        row = self._running_headless_row(task, age_seconds=self._dead_age())
+
+        counts = reap_stuck_headless_runs()
+
+        assert counts == {"failed": 0, "reenqueued": 0}
+        row.refresh_from_db()
+        assert row.status == TaskResultStatus.RUNNING
+
+    def test_recently_started_run_within_floor_is_not_reaped(self) -> None:
+        # A just-claimed run whose lease is briefly unset is protected by the floor.
+        task = self._claimed_task(lease_delta_seconds=-10)
+        row = self._running_headless_row(task, age_seconds=30)
+
+        counts = reap_stuck_headless_runs()
+
+        assert counts == {"failed": 0, "reenqueued": 0}
+        row.refresh_from_db()
+        assert row.status == TaskResultStatus.RUNNING
+
+    def test_dead_run_with_terminal_task_is_failed_but_not_reenqueued(self) -> None:
+        task = self._claimed_task(lease_delta_seconds=-120, status=Task.Status.COMPLETED)
+        self._running_headless_row(task, age_seconds=self._dead_age())
+
+        counts = reap_stuck_headless_runs()
+
+        assert counts == {"failed": 1, "reenqueued": 0}
+        assert not DBTaskResult.objects.filter(
+            task_path=execute_headless_task.module_path, status=TaskResultStatus.READY
+        ).exists()
+
+    def test_running_row_with_no_started_at_is_not_reaped(self) -> None:
+        # A row claimed-but-not-yet-started has no started_at → never a dead run.
+        task = self._claimed_task(lease_delta_seconds=-120)
+        result = execute_headless_task.enqueue(task.pk, task.phase)
+        DBTaskResult.objects.filter(id=result.id).update(status=TaskResultStatus.RUNNING, started_at=None)
+
+        counts = reap_stuck_headless_runs()
+
+        assert counts == {"failed": 0, "reenqueued": 0}
+
+    def test_orphaned_run_whose_task_is_gone_is_failed_not_reenqueued(self) -> None:
+        # The Task row vanished (cascade delete) but its RUNNING DBTaskResult
+        # lingers — an orphan: fail it, nothing to re-enqueue.
+        task = self._claimed_task(lease_delta_seconds=-120)
+        row = self._running_headless_row(task, age_seconds=self._dead_age())
+        task.delete()
+
+        counts = reap_stuck_headless_runs()
+
+        assert counts == {"failed": 1, "reenqueued": 0}
+        row.refresh_from_db()
+        assert row.status == TaskResultStatus.FAILED
+
+    def test_headless_run_with_no_args_is_skipped(self) -> None:
+        # A malformed row carrying no args resolves to no task id and is left alone.
+        DBTaskResult.objects.create(
+            task_path=execute_headless_task.module_path,
+            args_kwargs={"args": [], "kwargs": {}},
+            backend_name="default",
+            status=TaskResultStatus.RUNNING,
+            started_at=timezone.now() - dt.timedelta(seconds=self._dead_age()),
+            run_after=get_date_max(),
+        )
+
+        counts = reap_stuck_headless_runs()
+
+        assert counts == {"failed": 0, "reenqueued": 0}


### PR DESCRIPTION
## Summary

Two resilience fixes so the factory's task queue drains and its FSM never no-ops silently (owner directive #10, H24 auto-repair). Verified against the Fable investigation's root causes.

### Queue draining + wedge recovery

- **The drain now actually runs.** `core/tasks.drain_headless_queue` had **zero call sites** — the pending headless backlog only ever drained on the `post_save` auto-enqueue. Its logic is extracted into `drain_headless_queue_body`, and a self-perpetuating `loops/timer_reconciler.drain_headless_chain` (loops queue) is seeded by `ensure_maintenance_chains` at worker boot, alongside the sibling reconcile/prune/expire chains.
- **Stale `interactive` rows are adopted.** Under `agent_runtime=headless` the drain now includes pending `execution_target=interactive` rows and `route_to_headless()`-es them before dispatch — the laptop-`/loop`-era orphans (the `codex_reviewing` backlog) that were undispatchable forever once the box moved to the headless lane. Under `agent_runtime=interactive` those rows are the `/loop` slot's job and are left untouched.
- **Dead-worker runs are reaped.** `reap_stuck_headless_runs` fails `execute_headless_task` `DBTaskResult` rows left RUNNING past lease+grace with a dead heartbeat (the `Task` lease stops being renewed) and re-enqueues the run when the `Task` row is still non-terminal — closing the wedge where a lease-reclaimed task was never re-dispatched (auto-enqueue fires only on creation). FAILED is reversible/inspectable, never hard-deleted.

### FSM must not no-op silently

- **`code_direct`** — a plan-skipped sibling of `code()`, reachable ONLY for a ticket carrying the `auto_implement` marker (an `is_auto_implement` FSM condition), advances an issue-implementer auto-start ticket from `{not_started, scoped, started}` to `CODED` on coding completion. `persistence._handle_orchestrator` stamps the marker before scheduling coding. The normal author `PLANNED → code()` plan gate is untouched.
- **Escalate, never silent `return False`.** When a completed lifecycle-phase task matches no guard in `Task._apply_phase_transition` **and** the ticket is behind the phase's target state (a genuine wedge, not an idempotent replay), a durable `DeferredQuestion` is recorded (deduped per ticket+phase). This is the class that left tickets 35/36 with completed coding ($20/$15 spent) yet zero transitions and no PR.

## Test evidence (RED-first)

- (a) a pending `interactive` task under `agent_runtime=headless` → drain re-routes + dispatches it (`test_stale_interactive_row_is_rerouted_and_dispatched_under_headless_runtime`); left untouched under interactive runtime.
- (b) a `DBTaskResult` stuck RUNNING past lease with a dead heartbeat → reaper fails + re-enqueues (`test_dead_run_is_failed_and_task_reenqueued`); a live/fresh-lease run and a just-started run are not reaped; a terminal task is failed but not re-enqueued.
- (c) coding completion on a `not_started` auto-implement ticket → advances to `CODED` (`test_coding_completion_on_not_started_auto_implement_advances_to_coded`); an unmarked stuck ticket escalates via `DeferredQuestion` (`test_wedged_coding_completion_records_a_deferred_question`); an idempotent replay past target does not escalate.

`bash dev/ci-parity.sh` run locally: every hook green except `banned-terms` (fails on unset `banned_terms` — a known host env gap, not this diff). `tach check`, `ty check`, `ruff`, `editorconfig`, `makemigrations --check`, and the FSM-diagram drift gate all pass; the Ticket FSM diagram + `deferred_import_pegs.toml` + FSM-graph golden were regenerated/updated for the new transition and deferred import.

## Architecture pre-check — #10

### 1. BLUEPRINT § alignment
§5.6 Loop Topology (the drain/reap ride a self-perpetuating maintenance chain, like reconcile/prune/expire); §4 Domain Models (a new `Ticket` FSM transition); §17.4 orchestrator-decides / loop-executes (the loop's own FSM stamps no marker — only `_handle_orchestrator` does).

### 2. FSM phase boundaries
Adds `Ticket.code_direct`: `{not_started, scoped, started} → coded`, gated by the `is_auto_implement` condition. `Task._apply_phase_transition` routes an auto-implement ticket's coding completion through it; every other completed lifecycle phase that matches no guard and sits behind its target now escalates instead of silently no-opping. `code()` (source `PLANNED`) is unchanged.

### 3. Extension-point contracts
No `OverlayBase` / scanner / hook / `*Backend` Protocol change. `TicketExtra` gains an additive `auto_implement: bool` key. The drain has one shared body consumed by both the `@task` wrapper and the maintenance chain, so the two call sites cannot drift.

### 4. Component boundaries
Marker data + FSM transition on the `Ticket` model (`core/models`); shared drain body in `core/tasks`; the maintenance chain + dead-run reaper in `loops/timer_reconciler` (orchestration); the marker stamp at the `loop/persistence` orchestrator seam.

### 5. Dependency direction
`teatree.loops → teatree.core` (the chain imports the drain body + the reaper's ORM/task deps) — an allowed edge. `uv run tach check` → "All modules validated!". No backwards edge.

### 6. Test surface
`test_task_apply_phase_transition.py` (code_direct advance, escalation, dedup, idempotent-replay-no-escalate, free-form-no-escalate); `test_auto_implement.py` (marker set/read/fail-safe); `test_tasks.py::TestDrainHeadlessQueue` (reroute under headless, untouched under interactive); `test_timer_reconciler.py::TestReapStuckHeadlessRuns` + drain-chain seeding/dedup/reschedule; `test_ticket_structure.py` FSM-graph golden updated.

### 7. Resilience invariants
verify-by-re-read (the reaper reads the live `Task` lease, the heartbeat-renewed signal); idempotency (the claim CAS makes a redundant re-enqueue a clean no-run; the drain chain self-dedups; the escalation is deduped per ticket+phase); fallback-transport (a dead run is FAILED — reversible, inspectable — never deleted; a genuine wedge is captured as a durable `DeferredQuestion`, never dropped); heartbeat (the reaper keys deadness on the run's stopped heartbeat, not a box-global flock, so an orphaned run under a new worker is still reaped). sub-agent return contract: n/a.

### 8. Identity and key normalization
No bare/qualified identity form introduced. Phase tokens are normalized via `normalize_phase` before the target-state lookup, matching the existing `_apply_phase_transition` branches.

### 9. Behavior preservation / capability deletion
`code()` and its `plan_currency` gate are untouched — `code_direct` is a SEPARATE transition gated on the `auto_implement` marker, so the normal author flow's plan gate is not weakened. No must-block test was inverted. The drain's return dict gained a `rerouted` key; the three existing `TestDrainHeadlessQueue` assertions were updated. Interactive-runtime drain behavior is preserved (regression test asserts interactive rows stay untouched).

### 10. Removability / harness-vs-data
The auto-implement marker is DATA (a `Ticket.extra` key); the mechanism is harness. `code_direct` is self-contained — removing it reverts to the escalation path with no cascade. The drain chain + reaper are removable maintenance chains (deleting them reverts to the pre-fix "drain never runs" behavior). The wedge/replay decision is a small harness map (`_PHASE_TARGET_STATE` / `_STATE_ORDER`).
