### PR TITLE
fix(deploy): pre-create ~/.claude teatree-owned — fixes init crash-loop full-factory outage

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -32,11 +32,16 @@ RUN useradd -m -d /home/teatree -s /bin/bash teatree
 # inherits teatree ownership (Docker seeds an empty volume from the image dir).
 # /opt/teatree/uv carries the runtime-installed teatree python + venv + shims so
 # all three services see the same t3.
+# ~/.claude/projects is pre-created (and so chowned to teatree below) BEFORE it is
+# used as the projects bind-mount target: without it, Docker creates the mount's
+# parent ~/.claude as ROOT at container start, so `t3 setup` cannot write
+# ~/.claude/settings.json and the init container crash-loops (whole factory down).
 RUN mkdir -p \
         /home/teatree/teatree \
         /home/teatree/.local/share/teatree \
         /home/teatree/.local/share/teatree-worktrees \
         /home/teatree/workspace/t3-workspaces \
+        /home/teatree/.claude/projects \
         /opt/teatree/uv && \
     # clone_root() resolves clones under ~/workspace, but the runtime clone
     # lives on the teatree_src volume at ~/teatree. Provisioning discovers the


### PR DESCRIPTION
## Outage fixed

The init container was crash-looping with:

```
PermissionError: [Errno 13] Permission denied: '/home/teatree/.claude/settings.json'
```

taking `teatree-worker` and `teatree-admin` (and every autonomous loop) down with it — a full-factory outage.

### Root cause

#3285 added a `~/.claude/projects` **bind-mount**. Its parent `~/.claude` does not exist in the image, so Docker creates it at container start — as **root**. `t3 setup` runs as `teatree` (uid 1001) and cannot write `~/.claude/settings.json` into a root-owned dir, so init dies and the dependent services never start.

### Fix

Pre-create `/home/teatree/.claude/projects` in the image `mkdir -p`, so it is covered by the existing `chown -R teatree:teatree /home/teatree`. The mount parent is then teatree-owned before the bind-mount lands, and setup always succeeds. Verified: rebuilt the image, `.claude` is now `1001:1001`, the stack is back up (init `Exited (0)`, worker `RUNNING`, 16 loops enabled).

### Prevents recurrence

Any future rebuild carries the teatree-owned `~/.claude`; Docker never gets to create it as root again.
