### PR TITLE
Autonomous Slack drain in headless: periodic `t3 slack check` in the slack-listener service

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -192,6 +192,16 @@ slack-listener)
     # drains, acks with 👀, and dispatches. `t3 slack listen` exits non-zero
     # when no overlay is Slack-enabled; `restart: unless-stopped` then simply
     # keeps a harmless retry loop on a box that has no Slack overlay yet.
+    #
+    # Drain + 👀-ack captured DMs on a cadence: the reactive loop-drain-queue
+    # slot is not bootstrapped under `t3 worker` in headless, so the listener's
+    # captures would never reach an observable state without this. `t3 slack
+    # check` drains the JSONL queue and, unlike the drain-queue loop, is NOT
+    # gated by the worker singleton. Failure-tolerant (`|| true`) and
+    # backgrounded so a non-zero check never trips `set -e` or crashes the
+    # foreground listener.
+    SLACK_CHECK_INTERVAL_SECONDS=15
+    ( while true; do t3 slack check >/dev/null 2>&1 || true; sleep "$SLACK_CHECK_INTERVAL_SECONDS"; done ) &
     exec t3 slack listen
     ;;
 admin)

--- a/tests/test_deploy_slack_listener.py
+++ b/tests/test_deploy_slack_listener.py
@@ -32,10 +32,35 @@ class TestInitInstallsSlackExtra:
 
 
 class TestSlackListenerRole:
+    @property
+    def _arm(self) -> str:
+        return ENTRYPOINT.split("slack-listener)", 1)[1].split(";;", 1)[0]
+
     def test_role_execs_slack_listen(self) -> None:
         assert "slack-listener)" in ENTRYPOINT
-        arm = ENTRYPOINT.split("slack-listener)", 1)[1].split(";;", 1)[0]
-        assert "exec t3 slack listen" in arm
+        assert "exec t3 slack listen" in self._arm
+
+    def test_role_drains_captured_dms_on_a_cadence(self) -> None:
+        # The reactive loop-drain-queue slot is not bootstrapped under `t3
+        # worker` in headless, so without a periodic `t3 slack check` the
+        # listener's captured DMs never reach an observable (👀-acked) state.
+        # `t3 slack check` drains the JSONL queue and is NOT worker-singleton
+        # gated (unlike the drain-queue loop).
+        arm = self._arm
+        assert "t3 slack check" in arm
+        assert "while true; do" in arm, "the drain must run on a repeating cadence, not once"
+
+    def test_drain_loop_is_failure_tolerant_and_backgrounded(self) -> None:
+        # `set -euo pipefail` at the top must never let a non-zero `t3 slack
+        # check` crash the service: the `|| true` swallows the exit code and
+        # the `( … ) &` backgrounds the loop so `exec t3 slack listen` stays
+        # the foreground process.
+        arm = self._arm
+        assert "t3 slack check >/dev/null 2>&1 || true" in arm
+        assert "&\n" in arm, "the drain loop must be backgrounded"
+        # The background drain must be started BEFORE the foreground exec, or
+        # exec would replace the shell before the loop is ever launched.
+        assert arm.index("while true; do") < arm.index("exec t3 slack listen")
 
     def test_role_is_documented_and_validated(self) -> None:
         # The required-role prompt and the unknown-role guard both name it, so a


### PR DESCRIPTION
## Problem

The Slack round-trip is live in Docker (#3288): the `teatree-slack-listener` service runs `t3 slack listen`, capturing inbound DMs to the JSONL queue. BUT nothing drains that queue autonomously in headless:

- The reactive `loop-drain-queue` slot is registered by an owner-session bootstrap that does NOT run under `t3 worker`.
- The in-process tick drain (`drain_ready_batch` in `src/teatree/loop/queue_drain.py`) stands down while a live worker holds the worker singleton.

So captured replies never get drained / 👀-acked / turned into observable state without a manual `t3 slack check`.

## Fix

The `slack-listener` role in `deploy/entrypoint.sh` now backgrounds a failure-tolerant loop that runs `t3 slack check` every 15s, then `exec t3 slack listen` in the foreground.

Why this is safe:

- `t3 slack check` (`check_command` in `src/teatree/cli/slack/listen.py`) drains the JSONL queue via `drain_event_queue()`, 👀-acks each user message via the on-behalf egress, then `commit_drain()`. It acquires **no** singleton — only `listen_command` takes the `slack-listener` lock (a different lock), and the worker-singleton skip lives only in the DB-task-queue drain path, not here.
- The Slack JSONL event queue and the DB task queue are disjoint, so there is no double-processing.
- `set -euo pipefail` cannot crash the service: the `|| true` swallows a non-zero check and the `( … ) &` backgrounds the loop so `exec t3 slack listen` remains the foreground process. Verified with `bash -n`.

## Tests

Extended `tests/test_deploy_slack_listener.py` with structural assertions on the `slack-listener)` arm: it runs `t3 slack check` in a `while true` loop, the drain is `|| true` + backgrounded, the loop is started before `exec t3 slack listen`, and it still execs the listener. Mirrors the parse-the-source pattern already in that file.

## Verification

- `uv run pytest tests/test_deploy_slack_listener.py` — 9 passed
- `uvx prek run ruff-format --all-files` / `ruff-check --all-files` — Passed (no reformat)
- `bash dev/ci-parity-fast.sh` — passed (676 tests; push-gate FULL fail-safe on the unclassifiable `deploy/entrypoint.sh` path, expected)