### PR TITLE
fix(gates): quote-scanner attribution prose, private-repo leak FP, classifier session FP-grant, MR-desc quote truncation

### DIFF
--- a/hooks/scripts/mr_cli_fields.py
+++ b/hooks/scripts/mr_cli_fields.py
@@ -14,6 +14,7 @@ hook and when imported as ``hooks.scripts.hook_router`` in tests.
 """
 
 import re
+import shlex
 from pathlib import Path
 from urllib.parse import unquote
 
@@ -99,6 +100,47 @@ def _looks_dynamic_value(match: "re.Match[str] | None") -> bool:
     return bool(_DYNAMIC_VALUE_RE.search(match.group("val")))
 
 
+def _shlex_flag_value(command: str, flag: str) -> tuple[bool, str | None]:
+    """Return ``(parsed, value)`` for *flag*'s value via a shlex split of *command*.
+
+    ``parsed`` is ``False`` when the command cannot be shlex-split (unbalanced
+    quotes, an unterminated construct) — the caller then keeps the
+    truncation-prone regex value, preserving today's behaviour for those
+    commands. ``value`` is ``None`` when the flag is absent; otherwise it is the
+    flag's value with all internal quoting resolved correctly — a body mixing an
+    apostrophe and a double-quoted phrase, single-quote escaping, backslash-
+    escaped inner quotes — for both the ``--flag value`` and ``--flag=value``
+    spellings. shlex reads the raw command exactly as bash would tokenize it, so
+    the value no longer truncates at the first inner quote char (#3300).
+    """
+    try:
+        tokens = shlex.split(command, comments=False, posix=True)
+    except ValueError:
+        return False, None
+    prefix = f"{flag}="
+    for i, token in enumerate(tokens):
+        if token == flag:
+            return True, tokens[i + 1] if i + 1 < len(tokens) else ""
+        if token.startswith(prefix):
+            return True, token[len(prefix) :]
+    return True, None
+
+
+def _resolved_literal_value(command: str, flag: str, regex_match: "re.Match[str]") -> str:
+    """Return the full literal value of *flag*, un-truncated via shlex (#3300).
+
+    The caller has already cleared the value as non-dynamic (a literal, not an
+    unexpanded ``$(…)``/``$VAR``), so the shlex-resolved argument is the real
+    body. Falls back to the regex capture when the command cannot be shlex-split
+    or shlex does not see the flag (the regex matched a looser span), so no
+    command that parses today changes verdict beyond gaining the full body.
+    """
+    parsed, value = _shlex_flag_value(command, flag)
+    if parsed and value is not None:
+        return value
+    return regex_match.group("val")
+
+
 def _read_message_file(command: str) -> str | None:
     """Read a file-based message arg (``-F``/``--description-file``/etc.).
 
@@ -137,7 +179,7 @@ def _extract_inline_or_file_desc(command: str) -> str | None:
     if inline is not None and inline.group("val"):
         if _looks_dynamic_value(inline):
             return None
-        return inline.group("val")
+        return _resolved_literal_value(command, "--description", inline)
     if _MR_DESC_FLAG_PRESENT_RE.search(command):
         from_file = _read_message_file(command)
         if from_file is not None:
@@ -173,7 +215,7 @@ def extract_cli_mr_fields(command: str) -> tuple[str, str] | None:
     description = _extract_inline_or_file_desc(command)
     if description is None:
         return None
-    title = title_match.group("val") if title_match else ""
+    title = _resolved_literal_value(command, "--title", title_match) if title_match else ""
     if operation == "update":
         desc_present = bool(_MR_DESC_FLAG_PRESENT_RE.search(command))
         if title_match is None and not desc_present:

--- a/tests/test_validate_mr_metadata_hook.py
+++ b/tests/test_validate_mr_metadata_hook.py
@@ -504,6 +504,61 @@ class TestDynamicValueIsSkipped:
         assert self._fields_for("glab mr create --description 'x'") == ("", "x")
 
 
+class TestMixedQuoteDescriptionCapturedInFull:
+    """A ``--description`` mixing ``'`` and ``"`` is captured whole, not truncated (#3300).
+
+    The old non-greedy regex ended the capture at the next occurrence of the
+    OPENING quote char, so a body carrying both an apostrophe (``doesn't``) and a
+    double-quoted phrase truncated — the gate then validated only the leading
+    fragment and rejected a compliant description for a required section present
+    past the first quote. shlex yields the true argument value regardless of the
+    body's internal quoting.
+    """
+
+    def test_apostrophe_and_double_quoted_phrase_body_is_captured_whole(self):
+        # A single-quoted description whose body contains an apostrophe (shell-
+        # escaped ``'\''``) AND a double-quoted phrase, with a required section
+        # placed AFTER the first inner quote so truncation would drop it.
+        desc = (
+            "fix(x): mixed quotes (proj#1)\n\n"
+            "## What\n"
+            "GitLab'\\''s handling of a \"quoted phrase\" doesn'\\''t truncate the body.\n\n"
+            "## Security & privacy impact\nnone"
+        )
+        cmd = f"glab mr create --title 'fix(x): mixed quotes (proj#1)' --description '{desc}'"
+        _title, description = _fields(cmd)
+        assert '"quoted phrase"' in description
+        assert description.count("doesn't") == 1
+        assert "## Security & privacy impact" in description
+
+    def test_double_quoted_body_with_escaped_quotes_and_apostrophe_is_whole(self):
+        # The mirror case: a double-quoted description whose body carries escaped
+        # ``\"`` double quotes and a bare apostrophe.
+        cmd = (
+            "glab mr create --title 'fix(x): quoting (proj#1)' "
+            '--description "fix(x): quoting (proj#1)\n\n## What\n'
+            'It doesn\'t drop the \\"quoted\\" tail.\n\n## Security & privacy impact\nnone"'
+        )
+        _title, description = _fields(cmd)
+        assert '"quoted"' in description
+        assert "## Security & privacy impact" in description
+
+    def test_equals_spelling_mixed_quote_title_is_whole(self):
+        # The ``--title=<value>`` equals spelling resolves the full value too.
+        cmd = "glab mr create --title='fix(x): a \"quoted\" title (proj#1)' --description 'fix(x): a (proj#1)'"
+        title, _description = _fields(cmd)
+        assert title == 'fix(x): a "quoted" title (proj#1)'
+
+    def test_unparseable_command_falls_back_to_regex_capture(self):
+        # An unbalanced quote ELSEWHERE in the command makes shlex raise; the gate
+        # must not crash — it falls back to the regex capture of the (locally
+        # balanced) --description value rather than skipping validation.
+        cmd = "glab mr create --title 'fix(x): t (proj#1)' --description 'clean body' && echo \"dangling"
+        title, description = _fields(cmd)
+        assert title == "fix(x): t (proj#1)"
+        assert description == "clean body"
+
+
 class TestEmbeddedTriggerIsNotAnMrMutation:
     """The trigger phrase inside a quoted arg / heredoc body is NOT a mutation.
 


### PR DESCRIPTION
This bundle set out to fix four gate/scanner false-positives. Three of the
four were already fixed on `main` by recently-merged PRs; this PR implements
the one that remained.

## Implemented

### #3300 — MR-metadata gate truncates `--description` at the first quote char

`hooks/scripts/mr_cli_fields.py` extracted `--title`/`--description` with a
non-greedy regex (`--description[ =]+(['"])(?P<val>.*?)\1`) that ended the
capture at the next occurrence of the opening quote char. A body legitimately
mixing an apostrophe (`doesn't`) and a double-quoted phrase truncated — the
gate validated only the leading fragment and rejected a fully compliant
description for a required section present past the first quote.

Fix: resolve the flag value with `shlex`, which reads the raw command exactly
as bash tokenizes it and yields the true argument value regardless of internal
quoting. The raw-regex dynamic-value check still runs first, so an unexpanded
command-substitution / variable reference in a double-quoted body is skipped
unchanged (never-lockout); an unparseable command falls back to the regex
capture, so no command that parses today changes verdict beyond gaining the
full body.

Closes #3300

## Skipped — already fixed on `main` (verified in code)

- **#3240** (quote-scanner attribution prose) — fixed by #3290 (`6ffe6997`):
  `quote_scanner._QUOTE_EVIDENCE_REQUIRED` + `_adjacent_region` + `_LONG_QUOTE_RE`
  keep `the-user-said-colon` / `heading-user-mandate` HIGH only when a 20+-char
  double-quoted span sits in the adjacent paragraph, else they downgrade to MEDIUM.
- **#3252** (classifier denied-self-bypass poisoning + session FP-grant) — fixed by
  #3291 (`c8f802cc`): `deny_circuit_breaker` folds the call signature into
  `_deny_fingerprint` (poisoning fix) and records a per-fingerprint
  `[fp-confirmed: …]` grant in `<session>.fp-grants` (session-scoped FP grant).
- **#3251** (publish/leak gates FP on private-repo git/glab ops) — the dominant
  reported symptom (banned-terms firing on private-repo `git`/`glab` operations +
  the private work-item-URL carve-out) is fixed by #3290 (`Closes #3251`). The
  residual quote-scanner `fail-closed-sentinel` on an *undeclared*-private
  `git commit` with an unreadable `-F` body was deliberately deferred by #3290; a
  safe fix requires either narrowing a public-leak matcher (needs explicit
  sign-off per the architecture-design gate §9) or adding verbatim-quote detection
  to the pre-push privacy scan — which the push gate runs over full code diffs, a
  real new-FP risk. Out of safe scope for a false-positive-reduction bundle; the
  documented mitigation (declare the repo in `private_repos`, prefer inline `-m`)
  stands.

## Architecture pre-check

Tactical parsing-precision fix to one hook helper (`mr_cli_fields.py`); no
Protocol / FSM / extension-point / dependency-direction change.

- **Component boundaries:** stays in `hooks/scripts/` (the MR-metadata gate's
  CLI field-extraction concern); no new module.
- **Test surface:** `tests/test_validate_mr_metadata_hook.py::TestMixedQuoteDescriptionCapturedInFull`
  — RED-first (observed truncating to the leading fragment before the fix),
  covering the single- and double-quoted mixed bodies, the `--flag=value`
  spelling, and the shlex-unparseable fallback. All existing dynamic-value-skip
  and embedded-trigger tests stay green.
- **Behavior preservation:** the dynamic-value skip and file-based description
  fallback are unchanged; shlex only un-truncates a value the dynamic check
  already cleared as literal.
