### PR TITLE
fix(mcp,slack): wire MCP into lifecycle sub-agents, detect deleted review messages, noop-overlay Slack resolution

### DIFF
--- a/src/teatree/agents/_headless_options.py
+++ b/src/teatree/agents/_headless_options.py
@@ -140,7 +140,35 @@ def _build_options(
         options.env = env
     if is_reader_phase(phase):
         _apply_reader_tool_lockdown(options)
+    else:
+        _wire_teatree_mcp_server(options)
     return options
+
+
+def _wire_teatree_mcp_server(options: ClaudeAgentOptions) -> None:
+    """Inject teatree's own local-stdio MCP server so lifecycle sub-agents reach it (#3242).
+
+    Claude Code does not forward a local-stdio server (``t3 mcp serve``) to a
+    sub-agent, and it ignores the ``mcpServers`` frontmatter on a plugin-provided
+    sub-agent definition — so the shipped ``.mcp.json`` alone never gives the
+    dispatched coder/reviewer/shipper the ``mcp__teatree__*`` structured-read
+    tools; they fall back to shelling out to the ``t3`` CLI. The headless
+    dispatch owns its options, so it wires the server explicitly here. The
+    launch command mirrors ``.mcp.json`` (:mod:`teatree.core.mcp_registration`
+    is the single source of truth). Skipped for the #116 reader, which stays
+    hermetic (:func:`_apply_reader_tool_lockdown`).
+    """
+    from teatree.core.mcp_registration import (  # noqa: PLC0415 — deferred: keeps the option-build import light
+        EXPECTED_ARGS,
+        EXPECTED_COMMAND,
+        TEATREE_MCP_SERVER_NAME,
+    )
+
+    existing = options.mcp_servers if isinstance(options.mcp_servers, dict) else {}
+    options.mcp_servers = {
+        **existing,
+        TEATREE_MCP_SERVER_NAME: {"type": "stdio", "command": EXPECTED_COMMAND, "args": list(EXPECTED_ARGS)},
+    }
 
 
 def _apply_reader_tool_lockdown(options: ClaudeAgentOptions) -> None:

--- a/src/teatree/backends/slack/client.py
+++ b/src/teatree/backends/slack/client.py
@@ -250,13 +250,21 @@ def _ts_key(ts: str) -> float:
         return 0.0
 
 
+# Slack ``conversations.replies`` errors that PROVE the thread/root is gone
+# (deleted), as opposed to a transient read failure — see #3292.
+_DELETION_ERRORS = frozenset({"thread_not_found", "message_not_found"})
+
+
 def read_thread_activity(request: SlackThreadActivityRequest) -> ThreadActivityRead:
     """Read one thread's liveness + latest activity via ``conversations.replies``.
 
     Returns the thread parent's presence (``exists``), the parent ``ts``, the
     newest reply ``ts``, and whether the parent carries any reaction. An httpx
-    transport error propagates so the caller can fail safe. ``ok=False`` on a
-    non-ok API body; ``exists=False`` when the parent message is gone.
+    transport error propagates so the caller can fail safe. A deletion API error
+    (``thread_not_found`` / ``message_not_found``) and a ``subtype:"tombstone"``
+    root are both proof of deletion → ``ok=True, exists=False``; every other
+    ``ok:false`` body (ratelimited, auth) stays ``ok=False`` so the caller
+    suppresses rather than re-posts on an uncertain read (#3292).
     """
     if not request.token or not request.channel_id or not request.thread_ts:
         return ThreadActivityRead(ok=True, exists=False)
@@ -270,11 +278,23 @@ def read_thread_activity(request: SlackThreadActivityRequest) -> ThreadActivityR
         data = response.json()
 
     if not data.get("ok"):
+        # A deleted root/thread comes back as an ``ok:false`` API error
+        # (``thread_not_found`` / ``message_not_found``) — that is proof of
+        # DELETION, not a read failure, so it must read as ``ok=True,
+        # exists=False`` and let the reclaim → re-post branch fire (#3292).
+        # Every other ``ok:false`` (ratelimited, auth) stays fail-safe:
+        # ``ok=False`` ⇒ the guard suppresses rather than re-posting on doubt.
+        if data.get("error") in _DELETION_ERRORS:
+            return ThreadActivityRead(ok=True, exists=False)
         return ThreadActivityRead(ok=False, exists=False)
     messages = data.get("messages")
     if not isinstance(messages, list) or not messages:
         return ThreadActivityRead(ok=True, exists=False)
     parent = messages[0] if isinstance(messages[0], dict) else {}
+    # A tombstone root (parent deleted, replies survive) is gone — do not count
+    # ``messages[0]`` as "exists" just because the array is non-empty (#3292).
+    if parent.get("subtype") == "tombstone":
+        return ThreadActivityRead(ok=True, exists=False)
     reply_tss = [str(m.get("ts", "")) for m in messages[1:] if isinstance(m, dict) and m.get("ts")]
     return ThreadActivityRead(
         ok=True,

--- a/src/teatree/config/settings.py
+++ b/src/teatree/config/settings.py
@@ -173,6 +173,7 @@ OVERLAY_OVERRIDABLE_SETTINGS: dict[str, Callable[[Any], Any]] = {
     "pull_main_clone_cadence_hours": _parse_strict_int,
     "review_nag_enabled": _parse_strict_bool,
     "review_request_dedup_window_days": _parse_overridable_positive_int(30),
+    "review_request_dedup_max_pages": _parse_overridable_positive_int(5),
     "mr_title_regex": _parse_strict_str,
     "issue_implementer_enabled": _parse_strict_bool,
     "issue_implementer_label": _parse_strict_str,
@@ -1186,6 +1187,13 @@ class _PrePublishGateSettings:
     # Slack, not the DB row's age, decides. Fail-safe positive int: a
     # non-positive / mistyped value degrades to 30. Per-overlay overridable.
     review_request_dedup_window_days: int = 30
+    # Channel-scan page cap for the review-request live dedup read (#3292 part 4).
+    # The guard pages ``conversations.history`` up to this many times when
+    # deciding POST vs SUPPRESS; the old hard-coded 5 could leave a ~30-day
+    # window unreachable on a busy channel, so an old MANUAL user post fell
+    # outside the scan and the request was duplicated. Fail-safe positive int:
+    # a non-positive / mistyped value degrades to 5. Per-overlay overridable.
+    review_request_dedup_max_pages: int = 5
     # Orchestrator-execution-boundary gate (#115, §17.6 gate 2). When
     # enabled (default), the main agent is blocked from running a HEAVY /
     # long-running foreground Bash command (test suite, build, dev

--- a/src/teatree/core/backend_factory.py
+++ b/src/teatree/core/backend_factory.py
@@ -157,6 +157,48 @@ def _build_messaging(overlay_name: str) -> MessagingBackend | None:
     return backend
 
 
+def configured_messaging_from_overlay(overlay_name: str | None = None) -> MessagingBackend | None:
+    """Like :func:`messaging_from_overlay`, but honours the MCP resolver contract (#3299).
+
+    Returns ``None`` when the overlay's ``messaging_backend`` resolves to
+    ``"noop"``/empty — i.e. the overlay declares ``Service.SLACK`` but has no
+    real messaging transport. ``messaging_from_overlay`` returns a *truthy*
+    :class:`~teatree.backends.messaging_noop.NoopMessagingBackend` there, which
+    :func:`~teatree.mcp.service_resolver.resolve_declaring_overlay_client` would
+    wrongly accept — stopping the search before it reaches the overlay that
+    actually carries the Slack credentials. The MCP Slack group passes THIS seam
+    to the resolver so the noop declarer is skipped, restoring the resolver's
+    documented "``None`` when unconfigured" contract at the source. Every other
+    caller keeps the no-``None``-guard :func:`messaging_from_overlay`.
+    """
+    if _resolved_messaging_backend(overlay_name) in {"", "noop"}:
+        return None
+    return messaging_from_overlay(overlay_name)
+
+
+def _resolved_messaging_backend(overlay_name: str | None) -> str:
+    """The overlay's effective ``messaging_backend`` choice (``""`` when unresolvable)."""
+    key = _active_overlay_name(overlay_name)
+    try:
+        overlay = get_overlay(key or None)
+    except ImproperlyConfigured:
+        return _toml_messaging_backend(key)
+    return overlay.config.messaging_backend or ""
+
+
+def _toml_messaging_backend(overlay_name: str) -> str:
+    """The ``messaging_backend`` value of a path-only TOML overlay entry (``""`` when absent)."""
+    if not overlay_name:
+        return ""
+    from teatree.config import load_config  # noqa: PLC0415 — deferred: call-time import, kept lazy
+
+    overlays = load_config().raw.get("overlays") or {}
+    cfg = overlays.get(overlay_name)
+    if not isinstance(cfg, dict):
+        return ""
+    return str(cfg.get("messaging_backend", "") or "")
+
+
 def ci_service_from_overlay(overlay_name: str | None = None) -> CIService | None:
     """Build a CI-service backend using the active overlay's credentials."""
     key = _active_overlay_name(overlay_name)
@@ -510,6 +552,7 @@ __all__ = [
     "ci_service_from_overlay",
     "code_host_for_repo_from_overlay",
     "code_host_from_overlay",
+    "configured_messaging_from_overlay",
     "iter_overlay_backends",
     "messaging_from_overlay",
     "notion_client_from_overlay",

--- a/src/teatree/core/gates/review_request_guard.py
+++ b/src/teatree/core/gates/review_request_guard.py
@@ -69,6 +69,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _DEFAULT_READ_TIMEOUT = 8.0
+# Static fallback page cap; the live default is config-driven — see
+# :func:`_default_options` (``review_request_dedup_max_pages``, default 5).
 _MAX_PAGES = 5
 # Static fallback only; the live default window is config-driven — see
 # :func:`_default_options` (``review_request_dedup_window_days``, default 30).
@@ -145,6 +147,7 @@ class GuardOptions:
     recency_window: dt.timedelta = _FALLBACK_RECENCY_WINDOW
     read_timeout: float = _DEFAULT_READ_TIMEOUT
     now: dt.datetime | None = None
+    max_pages: int = _MAX_PAGES
 
 
 def _default_options() -> GuardOptions:
@@ -152,11 +155,17 @@ def _default_options() -> GuardOptions:
 
     ``review_request_dedup_window_days`` (default 30) replaces the old
     hard-coded 24h — so live Slack, not the DB row's age, decides.
+    ``review_request_dedup_max_pages`` (default 5) makes the channel-scan page
+    cap configurable so a ~30-day window is actually reachable on a busy
+    channel (#3292 part 4).
     """
     from teatree.config import get_effective_settings  # noqa: PLC0415 — deferred: Django settings at call time
 
-    days = get_effective_settings().review_request_dedup_window_days
-    return GuardOptions(recency_window=dt.timedelta(days=days))
+    settings = get_effective_settings()
+    return GuardOptions(
+        recency_window=dt.timedelta(days=settings.review_request_dedup_window_days),
+        max_pages=settings.review_request_dedup_max_pages,
+    )
 
 
 def _live_matches(
@@ -178,7 +187,7 @@ def _live_matches(
         channel_id=target.channel_id,
         channel_name=target.channel_name,
         pr_urls=[canonical],
-        max_pages=_MAX_PAGES,
+        max_pages=opts.max_pages,
         oldest_ts=f"{oldest.timestamp():.6f}",
         timeout=opts.read_timeout,
     )
@@ -224,13 +233,18 @@ def _live_decision(
     return None
 
 
-def _read_thread_activity(target: GuardTarget, thread_ts: str, opts: GuardOptions):  # noqa: ANN202 — provider-owned ThreadActivityReadLike; a return annotation would force a core→backends type import
-    """Routed-token ``conversations.replies`` read for one thread; ``None`` on transport failure."""
+def _read_thread_activity(target: GuardTarget, thread_ts: str, opts: GuardOptions, *, channel_id: str = ""):  # noqa: ANN202 — provider-owned ThreadActivityReadLike; a return annotation would force a core→backends type import
+    """Routed-token ``conversations.replies`` read for one thread; ``None`` on transport failure.
+
+    Reads in *channel_id* when supplied — the channel the post was RECORDED
+    under (#3292 part 3) — so a review-channel change since the post does not
+    read the wrong channel and mis-decide; falls back to the target channel.
+    """
     from teatree.core.backend_registry import ThreadActivitySpec, get_backend_provider  # noqa: PLC0415 — lazy import
 
     spec = ThreadActivitySpec(
         token=target.token,
-        channel_id=target.channel_id,
+        channel_id=channel_id or target.channel_id,
         thread_ts=thread_ts,
         timeout=opts.read_timeout,
     )
@@ -263,7 +277,7 @@ def _posted_row_terminal(
     post = ReviewRequestPost.objects.filter(mr_url=canonical).first()
     if post is None or not post.slack_thread_ts:
         return None
-    read = _read_thread_activity(target, post.slack_thread_ts, opts)
+    read = _read_thread_activity(target, post.slack_thread_ts, opts, channel_id=post.slack_channel_id)
     if read is None or not read.ok:
         return GuardDecision(action="suppress", reason="read_failed_failsafe")
     if read.exists:

--- a/src/teatree/mcp/services_slack.py
+++ b/src/teatree/mcp/services_slack.py
@@ -2,9 +2,10 @@
 
 Registered only when a registered overlay declares ``Service.SLACK``. The
 messaging client is resolved through
-:func:`teatree.core.backend_factory.messaging_from_overlay` (a core seam), never
-a direct ``teatree.backends.slack`` import, so the transport-boundary fitness
-test holds. The reads stay read-only; the one write (``slack_react``) routes
+:func:`teatree.core.backend_factory.configured_messaging_from_overlay` (a core
+seam that returns ``None`` for a noop-messaging declarer so the resolver reaches
+the credentialed overlay — #3299), never a direct ``teatree.backends.slack``
+import, so the transport-boundary fitness test holds. The reads stay read-only; the one write (``slack_react``) routes
 through :class:`~teatree.core.on_behalf_egress.OnBehalfSlackEgress` — the single
 colleague-surface Slack egress owner — so the #117 send-proxy, the on-behalf
 approval gate, and the after-post notify receipt all fire (a self-DM reaction is
@@ -19,7 +20,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
 from teatree.backends.types import Service
-from teatree.core.backend_factory import messaging_from_overlay
+from teatree.core.backend_factory import configured_messaging_from_overlay
 from teatree.core.backend_protocols import MessagingBackend
 from teatree.core.on_behalf_egress import OnBehalfPostBlockedError, OnBehalfSlackEgress
 from teatree.mcp.service_resolver import resolve_declaring_overlay_client
@@ -39,8 +40,11 @@ INSTRUCTIONS = (
 
 
 def _client() -> MessagingBackend:
+    # ``configured_messaging_from_overlay`` (not ``messaging_from_overlay``) so a
+    # noop-messaging overlay that declares ``Service.SLACK`` without credentials
+    # is skipped and the resolver reaches the overlay that has them (#3299).
     return resolve_declaring_overlay_client(
-        Service.SLACK, messaging_from_overlay, description="Slack messaging backend"
+        Service.SLACK, configured_messaging_from_overlay, description="Slack messaging backend"
     )
 
 

--- a/tests/config/test_settings_field_golden.py
+++ b/tests/config/test_settings_field_golden.py
@@ -154,6 +154,7 @@ GOLDEN_USER_SETTINGS_FIELDS: frozenset[str] = frozenset(
         "resource_pressure_disabled",
         "resource_pressure_min_free_interval_minutes",
         "review_nag_enabled",
+        "review_request_dedup_max_pages",
         "review_request_dedup_window_days",
         "review_request_post_disabled",
         "review_skill",

--- a/tests/teatree_agents/test_headless_least_privilege.py
+++ b/tests/teatree_agents/test_headless_least_privilege.py
@@ -81,3 +81,19 @@ class TestBuildOptionsHarnessPin(TestCase):
         coding = self._options_for("coding")
         assert coding.setting_sources is None
         assert coding.strict_mcp_config is False
+
+    def test_lifecycle_dispatch_wires_the_teatree_mcp_server(self) -> None:
+        # #3242: plugin sub-agents ignore the mcpServers frontmatter, so the
+        # headless lifecycle dispatch must inject the teatree local-stdio server
+        # itself — otherwise coder/reviewer/shipper come up without mcp__teatree__*
+        # and fall back to shelling out to the CLI for every structured read.
+        for phase in ("coding", "reviewing", "testing", "shipping"):
+            server = self._options_for(phase).mcp_servers.get("teatree")
+            assert server is not None, phase
+            assert server["command"] == "t3"
+            assert list(server["args"]) == ["mcp", "serve"]
+
+    def test_reader_dispatch_never_wires_the_teatree_mcp_server(self) -> None:
+        # The quarantined reader stays hermetic: no MCP config of any origin,
+        # including teatree's own server.
+        assert self._options_for("directive_reading").mcp_servers == {}

--- a/tests/teatree_backends/test_thread_activity_read.py
+++ b/tests/teatree_backends/test_thread_activity_read.py
@@ -92,10 +92,43 @@ class TestThreadGone:
         assert read.ok is True
         assert read.exists is False
 
+    def test_thread_not_found_error_is_proof_of_deletion(self) -> None:
+        # #3292 part 1: Slack returns ``ok:false thread_not_found`` for a deleted
+        # root — that is DELETION, not a read failure. It must read as
+        # ``ok=True, exists=False`` so the reclaim → re-post branch fires.
+        fake = FakeClient(payload={"ok": False, "error": "thread_not_found"})
+        read = _read(fake)
+        assert read.ok is True
+        assert read.exists is False
+
+    def test_message_not_found_error_is_proof_of_deletion(self) -> None:
+        fake = FakeClient(payload={"ok": False, "error": "message_not_found"})
+        read = _read(fake)
+        assert read.ok is True
+        assert read.exists is False
+
+    def test_tombstone_root_counts_as_gone(self) -> None:
+        # #3292 part 2: a tombstone root (parent deleted, replies survive) must
+        # NOT count as "exists" just because ``messages[0]`` is present.
+        fake = FakeClient(
+            payload={"ok": True, "messages": [{"ts": _THREAD_TS, "subtype": "tombstone"}, {"ts": "1700000500.000200"}]}
+        )
+        read = _read(fake)
+        assert read.ok is True
+        assert read.exists is False
+
 
 class TestReadFailure:
     def test_api_not_ok_reports_not_ok(self) -> None:
         fake = FakeClient(payload={"ok": False, "error": "channel_not_found"})
+        read = _read(fake)
+        assert read.ok is False
+        assert read.exists is False
+
+    def test_ratelimited_is_a_read_failure_not_deletion(self) -> None:
+        # #3292 part 1: every non-deletion ``ok:false`` (rate limit, auth) stays
+        # fail-safe (read failure ⇒ suppress) — never mistaken for "gone".
+        fake = FakeClient(payload={"ok": False, "error": "ratelimited"})
         read = _read(fake)
         assert read.ok is False
         assert read.exists is False

--- a/tests/teatree_config/test_review_request_dedup_max_pages.py
+++ b/tests/teatree_config/test_review_request_dedup_max_pages.py
@@ -1,0 +1,25 @@
+"""``review_request_dedup_max_pages`` — configurable channel-scan page cap (#3292 part 4)."""
+
+from teatree.config.settings import OVERLAY_OVERRIDABLE_SETTINGS, UserSettings
+
+
+class TestDedupMaxPagesDefault:
+    def test_default_is_five(self) -> None:
+        assert UserSettings().review_request_dedup_max_pages == 5
+
+
+class TestDedupMaxPagesParser:
+    """Fail-safe positive int: a non-positive / mistyped value degrades to 5."""
+
+    def test_parser_accepts_a_positive_override(self) -> None:
+        parse = OVERLAY_OVERRIDABLE_SETTINGS["review_request_dedup_max_pages"]
+        assert parse("20") == 20
+
+    def test_parser_degrades_non_positive_to_default(self) -> None:
+        parse = OVERLAY_OVERRIDABLE_SETTINGS["review_request_dedup_max_pages"]
+        assert parse("0") == 5
+        assert parse("-3") == 5
+
+    def test_parser_degrades_mistyped_to_default(self) -> None:
+        parse = OVERLAY_OVERRIDABLE_SETTINGS["review_request_dedup_max_pages"]
+        assert parse("not-a-number") == 5

--- a/tests/teatree_core/test_backend_factory.py
+++ b/tests/teatree_core/test_backend_factory.py
@@ -16,11 +16,13 @@ from teatree.backends.gitlab.ci import GitLabCIService
 from teatree.backends.notion import NotionClient
 from teatree.backends.sentry import SentryClient
 from teatree.backends.slack.bot import SlackBotBackend
+from teatree.backends.types import Service
 from teatree.core import backend_factory
 from teatree.core.backend_factory import (
     ci_service_from_overlay,
     code_host_for_repo_from_overlay,
     code_host_from_overlay,
+    configured_messaging_from_overlay,
     messaging_from_overlay,
     notion_client_from_overlay,
     reset_backend_caches,
@@ -28,6 +30,7 @@ from teatree.core.backend_factory import (
 )
 from teatree.core.backend_protocols import BackendResolutionError
 from teatree.core.overlay import OverlayBase, OverlayConfig
+from teatree.mcp.service_resolver import resolve_declaring_overlay_client
 
 
 @pytest.fixture(autouse=True)
@@ -185,6 +188,59 @@ def test_messaging_from_overlay_delegates_to_loader() -> None:
 
     assert result == "sentinel"
     get_messaging_mock.assert_called_once()
+
+
+class _SlackOverlay(OverlayBase):
+    config = OverlayConfig(messaging_backend="slack", required_third_party_services=frozenset({Service.SLACK}))
+
+    def get_repos(self):
+        return []
+
+    def get_provision_steps(self, worktree):
+        return []
+
+
+class _NoopSlackOverlay(OverlayBase):
+    """Declares Service.SLACK but defaults ``messaging_backend`` to noop (#3299)."""
+
+    config = OverlayConfig(required_third_party_services=frozenset({Service.SLACK}))
+
+    def get_repos(self):
+        return []
+
+    def get_provision_steps(self, worktree):
+        return []
+
+
+class TestConfiguredMessagingFromOverlay:
+    """`configured_messaging_from_overlay` honours the MCP resolver contract (#3299).
+
+    ``messaging_from_overlay`` returns a truthy ``NoopMessagingBackend`` for a
+    noop overlay, which the declaring-overlay resolver wrongly accepts; the
+    configured seam returns ``None`` there so the resolver keeps searching.
+    """
+
+    def test_returns_none_when_overlay_messaging_is_noop(self) -> None:
+        with _patch_overlay(_NoopSlackOverlay):
+            assert configured_messaging_from_overlay("test") is None
+
+    def test_returns_backend_when_overlay_declares_slack(self) -> None:
+        with (
+            _patch_overlay(_SlackOverlay),
+            patch("teatree.backends.loader.get_messaging", return_value="sentinel"),
+        ):
+            assert configured_messaging_from_overlay("test") == "sentinel"
+
+    def test_resolver_reaches_second_overlay_past_a_noop_slack_declarer(self) -> None:
+        overlays = {"noop-first": _NoopSlackOverlay(), "real-second": _SlackOverlay()}
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value=overlays),
+            patch("teatree.backends.loader.get_messaging", return_value="real-slack"),
+        ):
+            client = resolve_declaring_overlay_client(
+                Service.SLACK, configured_messaging_from_overlay, description="Slack messaging backend"
+            )
+        assert client == "real-slack"
 
 
 def test_reset_backend_caches_clears_all_caches() -> None:

--- a/tests/teatree_core/test_review_request_guard.py
+++ b/tests/teatree_core/test_review_request_guard.py
@@ -23,6 +23,8 @@ from teatree.core.gates.review_request_guard import (
     GuardDecision,
     GuardOptions,
     GuardTarget,
+    _default_options,
+    _live_matches,
     peek_should_post_review_request,
     reconcile_out_of_band,
     resolve_guard_target,
@@ -712,6 +714,68 @@ class TestStaleOrphanReclaim(TestCase):
             )
         assert decision.action == "suppress"
         assert decision.reason == "read_failed_failsafe"
+
+
+class TestPostedRowProbesRecordedChannel(TestCase):
+    """The posted-row verify reads the thread in the channel the post was RECORDED under (#3292 part 3)."""
+
+    def test_thread_read_uses_recorded_channel_not_current_target(self) -> None:
+        recorded_channel = "C_RECORDED"
+        ReviewRequestPost.objects.create(
+            mr_url=_MR_URL,
+            slack_channel_id=recorded_channel,
+            slack_thread_ts="1700000000.000100",
+            done_at=None,
+            created_at=timezone.now() - dt.timedelta(days=40),
+        )
+        fake = FakeClient(
+            pages=[{"ok": True, "messages": [], "has_more": False}],
+            replies={"ok": True, "messages": [{"ts": "1700000000.000100", "text": _MR_URL}]},
+        )
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(slack_client.httpx, "Client", lambda **kw: _bind(fake, kw))
+            # The review channel changed since the post — the current target is a
+            # different channel than the one recorded on the row.
+            decision = should_post_review_request(
+                mr_url=_MR_URL,
+                target=GuardTarget(channel_id="C_NEW_TARGET", channel_name=_CHANNEL_NAME, token="xoxb-bot"),
+            )
+        assert decision.action == "suppress"
+        replies_calls = [c for c in fake.get_calls if "conversations.replies" in str(c["url"])]
+        assert replies_calls, "the posted-row verify must live-read the thread"
+        params = replies_calls[0]["params"]
+        assert isinstance(params, dict)
+        assert params["channel"] == recorded_channel
+
+
+class TestConfigurableMaxPages(TestCase):
+    """The channel-scan page cap is configurable so a ~30-day window is reachable (#3292 part 4)."""
+
+    def test_default_options_reads_the_configured_page_cap(self) -> None:
+        with patch(
+            "teatree.config.get_effective_settings",
+            return_value=type(
+                "S", (), {"review_request_dedup_window_days": 30, "review_request_dedup_max_pages": 42}
+            )(),
+        ):
+            assert _default_options().max_pages == 42
+
+    def test_live_matches_passes_the_options_page_cap_to_the_scan(self) -> None:
+        captured: dict[str, object] = {}
+
+        class _Provider:
+            @staticmethod
+            def read_recent_review_matches(spec):
+                captured["max_pages"] = spec.max_pages
+                return type("R", (), {"ok": True, "matches": []})()
+
+        with patch("teatree.core.backend_registry.get_backend_provider", return_value=_Provider()):
+            _live_matches(
+                _MR_URL,
+                GuardTarget(channel_id=_CHANNEL_ID, channel_name=_CHANNEL_NAME, token="xoxb-bot"),
+                GuardOptions(max_pages=17),
+            )
+        assert captured["max_pages"] == 17
 
 
 class TestPeekPostedRowVerification(TestCase):


### PR DESCRIPTION
Bundles three MCP/Slack fixes. TDD: a RED test was observed failing before each behaviour change.

## Closes

- Closes #3242 — Lifecycle sub-agents can't reach the teatree MCP server
- Closes #3292 — review-request thread-verify never detects a really-deleted Slack message
- Closes #3299 — MCP Slack read tools return empty when a noop-messaging overlay declares Service.SLACK first

## #3242 — wire MCP into lifecycle sub-agents

Claude Code does not forward a local-stdio MCP server to sub-agents and ignores the `mcpServers` frontmatter on plugin-provided sub-agent definitions, so the shipped `.mcp.json` alone never gives the dispatched coder/reviewer/shipper the `mcp__teatree__*` tools — they fall back to shelling out to the `t3` CLI. The headless dispatch owns its `ClaudeAgentOptions`, so `_build_options` now injects teatree's own server (`t3 mcp serve`, sourced from `teatree.core.mcp_registration`) for every non-reader phase. The quarantined #116 reader stays hermetic (no MCP config of any origin).

## #3292 — detect a really-deleted review thread

- `read_thread_activity` now treats `thread_not_found` / `message_not_found` as **proof of deletion** (`ok=True, exists=False` → reclaim → re-post), while every other `ok:false` (ratelimited, auth) stays fail-safe (suppress on uncertainty). A `subtype:"tombstone"` root (parent deleted, replies survive) counts as gone.
- The posted-row verify reads the thread in the channel the post was **recorded** under (falling back to the target channel), so a review-channel change since the post does not read the wrong channel and mis-decide.
- The channel-scan page cap is configurable via the new `review_request_dedup_max_pages` setting (default 5, per-overlay overridable) so a ~30-day dedup window is reachable on a busy channel.

## #3299 — noop-overlay Slack resolution

`resolve_declaring_overlay_client` accepts the first declaring overlay whose builder returns non-`None`; `messaging_from_overlay` returns a **truthy** `NoopMessagingBackend` for a noop overlay, so the resolver stopped there and never reached the overlay holding the Slack credentials. New `configured_messaging_from_overlay` returns `None` when the overlay's `messaging_backend` resolves to `noop`/empty; the MCP Slack group passes that seam to the resolver. `messaging_from_overlay` is unchanged for every other caller's no-`None`-guard contract.

## Architecture pre-check — #3242 / #3292 / #3299

## 1. BLUEPRINT § alignment
No new capability or FSM phase; three targeted fixes to existing seams (agent dispatch options, the review-request live-dedup guard, and the MCP declaring-overlay resolver). No BLUEPRINT section changes.

## 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition added or moved.

## 3. Extension-point contracts
No `OverlayBase` / scanner / hook / `*Backend` Protocol surface changed. `configured_messaging_from_overlay` is a new sibling of the existing `*_from_overlay` factory seams; `read_thread_activity` keeps its `ThreadActivityReadLike` shape (only the ok/exists mapping changed).

## 4. Component boundaries
Each change lands in its owning module: agent dispatch → `teatree.agents._headless_options`; deletion detection → `teatree.backends.slack.client`; recorded-channel probe + page cap → `teatree.core.gates.review_request_guard`; resolver seam → `teatree.core.backend_factory`; setting → `teatree.config.settings`. `mcp/services_slack.py` swaps one core seam import — no transport import added.

## 5. Dependency direction
No new cross-module import direction. `_headless_options` already depends on `teatree.core`; `services_slack` already imports from `teatree.core.backend_factory`. `tach`, `import-linter`, and the transport-boundary fitness pass green.

## 6. Test surface
- #3242: `test_headless_least_privilege.py` — coding/reviewing/testing/shipping phases carry the `teatree` MCP server; the reader never does.
- #3292: `test_thread_activity_read.py` — `thread_not_found`/`message_not_found`/tombstone read as gone, ratelimited stays a read failure; `test_review_request_guard.py` — the posted-row verify reads the recorded channel, and `_live_matches` passes the configured page cap.
- #3299: `test_backend_factory.py` — `configured_messaging_from_overlay` returns `None` for a noop overlay and the resolver reaches the second, credentialed overlay.

## 7. Resilience invariants
The deletion-detection change preserves fail-safe-on-uncertainty (only the two named deletion errors flip to "gone"; every other `ok:false` still suppresses). The `_reclaim_posted_row` conditional UPDATE (idempotency backstop) is unchanged. No new external write.

## 8. Identity and key normalization
n/a — no bare-vs-qualified identity introduced. The resolver already keys on the overlay name; the fix only corrects which builder result counts as "configured".

## 9. Behavior preservation / capability deletion
Purely additive at the seams. `read_thread_activity`'s prior branches are preserved: empty `messages` still → `ok=True, exists=False`; a generic `ok:false` still → `ok=False`. No must-block test inverted. `messaging_from_overlay` behaviour is untouched for its existing callers.

## 10. Removability / harness-vs-data
All three fixes are self-contained and revertible without a cascade. The page cap is data (a `UserSettings` field), not hard-coded harness policy — the varying part lives in config; the harness reads it.
