### PR TITLE
perf(ci): slim preflight sync + gate mutation-full before syncing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,14 @@ jobs:
           # Fail-safe: if the diff command errors, feed an empty list,
           # which the classifier maps to all=true (run everything).
           git diff --name-only "origin/$BASE_REF...HEAD" > changed_paths.txt || true
-          uv run python scripts/ci/changed_lanes.py < changed_paths.txt
+          # The classifier heads EVERY heavy lane serially (test-shard, test,
+          # test-shuffle, mutation-diff all `needs: preflight`), so it must be
+          # cheap. It imports only teatree.quality.changed_set (stdlib + PyYAML),
+          # so run it with `--no-project --with pyyaml` (PYTHONPATH=src) instead
+          # of the implicit full dev-group `uv sync` a plain `uv run` triggers.
+          # If that import chain ever grows a heavier dep the ImportError reds
+          # this job (blocks, never skips) — the fail-safe direction (#132).
+          PYTHONPATH=src uv run --no-project --with pyyaml python scripts/ci/changed_lanes.py < changed_paths.txt
 
   # ── 2. Fast static checks ──────────────────────────────────────────────────
 
@@ -946,7 +953,11 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.13"
-      - run: uv sync --group mutation
+      # Decide FIRST, sync only if we will actually run: almost every PR is not
+      # the first of the ISO week, so the expensive `uv sync --group mutation`
+      # (below) and the mutation run are skipped for it. The gate script imports
+      # only stdlib, so it runs with `--no-project` — no dependency install to
+      # reach the decision.
       - name: Decide whether this is the first PR of the ISO week
         id: gate
         env:
@@ -962,11 +973,14 @@ jobs:
               --jq '[.[] | {number: .number, created_at: .created_at}]' > prs.json; then
             echo "WARNING: could not fetch the PR list — running mutation (run-when-uncertain)." >&2
             echo "run_mutation=true" >> "$GITHUB_OUTPUT"
-          elif uv run python scripts/eval/first_pr_of_week.py --mrs-file prs.json --current-iid "$PR_NUMBER" --skip-code 1; then
+          elif uv run --no-project python scripts/eval/first_pr_of_week.py --mrs-file prs.json --current-iid "$PR_NUMBER" --skip-code 1; then
             echo "run_mutation=true" >> "$GITHUB_OUTPUT"
           else
             echo "run_mutation=false" >> "$GITHUB_OUTPUT"
           fi
+      - name: Install the mutation toolchain (only when this run will mutate)
+        if: steps.gate.outputs.run_mutation == 'true'
+        run: uv sync --group mutation
       - name: Full-scope mutation run (warn-first)
         if: steps.gate.outputs.run_mutation == 'true'
         run: uv run t3 mutation run --all


### PR DESCRIPTION
## What

Two zero-behaviour-change CI overhead trims from a broader CI-speedup effort (planned via Fable):

**1. `preflight` no longer does a full dev-group `uv sync`.** It heads every heavy lane serially (`test-shard`, `test`, `test-shuffle`, `mutation-diff` all `needs: preflight`), so its cost is on the critical path. Its only work is running `scripts/ci/changed_lanes.py`, whose import chain (`teatree.quality.changed_set`) needs only stdlib + PyYAML — so it now runs `uv run --no-project --with pyyaml` (PYTHONPATH=src). Verified locally: installs 1 package (~30ms) vs a full 151-package sync.

**2. `mutation-full` decides first-PR-of-week BEFORE syncing.** Almost every PR is not the first of the ISO week, so `uv sync --group mutation` + the mutation run are now conditional on the gate. The gate script is stdlib-only (`uv run --no-project`).

## Quality invariants preserved
- Classifier behaviour, `fetch-depth: 0`, and exported `run_heavy_python`/`all` outputs unchanged.
- A heavier import in the classifier chain would ImportError → RED preflight (blocks, never skips) — the fail-safe direction (#132).
- The mutation `run-when-uncertain` fail-safe (PR list unfetchable → run) is unchanged.

## Verification
CI-structure meta-tests green locally — **575 passed**, incl. `test_ci_diff_scoped_lanes.py`, `test_ci_gates_fail_loud.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)