### PR TITLE
perf(ci): pin the test image base by digest

### DIFF
--- a/dev/Dockerfile.test
+++ b/dev/Dockerfile.test
@@ -1,4 +1,9 @@
-FROM ubuntu:latest AS base
+# Pin the base by digest, not the floating `latest`/`24.04` tag: an unpinned
+# base moves its digest several times a month, and every move cache-busts every
+# layer below — so all 6 CI test shards do the full apt+node+uv rebuild at once
+# (souliane/teatree CI-speedup). Digest = ubuntu:24.04 as of 2026-07-16. Bump it
+# deliberately (dependabot's docker ecosystem can automate this).
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90 AS base
 RUN apt-get update -qq && \
     apt-get install -y -qq ca-certificates curl direnv git jq sqlite3 >/dev/null 2>&1 && \
     curl -fsSL https://deb.nodesource.com/setup_24.x | bash - >/dev/null 2>&1 && \


### PR DESCRIPTION
## What
`dev/Dockerfile.test` used `FROM ubuntu:latest`. An unpinned base moves its digest several times a month; each move cache-busts every layer below, so all 6 `test-shard` jobs do the full apt + node + uv rebuild simultaneously (minutes each) on an otherwise no-op run. This pins the base to the current `ubuntu:24.04` digest.

## Why (part of the CI-speedup series)
Diagnosis of the 485s `test-shard` critical path: the unpinned base causes intermittent full-rebuild storms across all 6 shards. This is the trivial first step; the structural win (build the image **once** → ghcr keyed on `hash(Dockerfile, uv.lock)`, **bake locked deps** so the per-shard cold `uv sync` disappears) is the stacked follow-up.

## Verification
- Built the image from the pinned digest locally — exit 0; `uv` + `claude` present; Ubuntu 24.04.
- No test asserts on the `FROM` line (grep-verified).

## Note
Bump the digest deliberately; the docker ecosystem can be added to `.github/dependabot.yml` to automate it (follow-up).