### PR TITLE
fix(headless): surface the claude CLI subprocess stderr (unblock headless-lane diagnosis)

### DIFF
--- a/src/teatree/core/tasks.py
+++ b/src/teatree/core/tasks.py
@@ -123,8 +123,18 @@ def execute_headless_task(task_id: int, phase: str) -> dict[str, object]:
             phase=phase,
             overlay_skill_metadata=overlay.metadata.get_skill_metadata(),
         )
-    except Exception:
-        task_obj.complete_with_attempt(exit_code=1, error=traceback.format_exc())
+    except Exception as exc:
+        error = traceback.format_exc()
+        # Surface the ``claude`` CLI subprocess stderr. The claude-agent-sdk
+        # ``ProcessError`` stringifies to "Check stderr output for details" and
+        # carries the real cause on its ``.stderr`` attribute, which was being
+        # discarded — leaving every headless subprocess failure undiagnosable in
+        # the recorded attempt and the worker log. Fold it into both.
+        subprocess_stderr = getattr(exc, "stderr", None) or getattr(getattr(exc, "__cause__", None), "stderr", None)
+        if subprocess_stderr:
+            logger.exception("Task %s headless subprocess stderr:\n%s", task_obj.pk, subprocess_stderr)
+            error = f"{error}\n--- claude subprocess stderr ---\n{subprocess_stderr}"
+        task_obj.complete_with_attempt(exit_code=1, error=error)
         raise
     else:
         return {"attempt_id": attempt.pk, "exit_code": attempt.exit_code, "result": attempt.result}

--- a/tests/teatree_core/test_tasks.py
+++ b/tests/teatree_core/test_tasks.py
@@ -267,6 +267,45 @@ class TestExecuteHeadlessUnknownOverlay(TestCase):
         assert "ghost-overlay" in attempt.error
 
     @override_settings(**IMMEDIATE_BACKEND)
+    def test_headless_subprocess_stderr_is_recorded_on_the_attempt(self) -> None:
+        # A claude-agent-sdk ``ProcessError`` stringifies to "Check stderr output
+        # for details" and hides the real cause on ``.stderr``. The recorded
+        # attempt must carry that stderr so a headless failure is diagnosable.
+        from teatree.core import headless_dispatch as headless_dispatch_mod  # noqa: PLC0415
+        from teatree.core.tasks import execute_headless_task  # noqa: PLC0415
+
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket)
+        task = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            status=Task.Status.PENDING,
+            phase="architectural_review",
+        )
+
+        class _FakeProcessError(RuntimeError):
+            def __init__(self) -> None:
+                super().__init__("Command failed with exit code 1. Check stderr output for details")
+                self.stderr = "claude: error: OAuth token expired -- run `claude login`"
+
+        def _boom(*_args: object, **_kwargs: object) -> object:
+            raise _FakeProcessError
+
+        with (
+            patch.object(overlay_loader_mod, "_discover_overlays", return_value=_MOCK_OVERLAY),
+            patch.object(headless_dispatch_mod, "loop_dispatch_refusal", return_value=None),
+            patch.object(headless_dispatch_mod, "get_headless_runner", return_value=_boom),
+            pytest.raises(_FakeProcessError),
+        ):
+            execute_headless_task.func(task.pk, task.phase)
+
+        attempt = TaskAttempt.objects.get(task=task)
+        assert attempt.exit_code == 1
+        assert "claude subprocess stderr" in attempt.error
+        assert "OAuth token expired" in attempt.error
+
+    @override_settings(**IMMEDIATE_BACKEND)
     def test_failed_unknown_overlay_task_is_not_re_enqueued_next_drain(self) -> None:
         from teatree.core.tasks import execute_headless_task  # noqa: PLC0415
 


### PR DESCRIPTION
## Why

The headless lane is the factory's execution engine — and it is broken: **0 of 119 `execute_headless_task` runs have ever completed** (`done=0`, 13+ failed). A live drain shows the failure is `claude_agent_sdk._errors.ProcessError: Command failed with exit code 1`, i.e. the **`claude` CLI child process exits 1** — but the error is undiagnosable because the SDK's `ProcessError` stringifies to *"Check stderr output for details"* and the real cause lives on `.stderr`, which `execute_headless_task` **discarded** (it recorded only `traceback.format_exc()`).

(A direct `api.anthropic.com` call from the same container returns `200 OK`, so the credential works at the API level — the CLI/OAuth path is the broken one. Staying on the CLI is deliberate: the metered API path is too expensive for the factory.)

## What

In `execute_headless_task`'s failure path, extract the subprocess `stderr` (from the exception or its `__cause__`) and fold it into **both** the recorded `TaskAttempt.error` and the worker log (`logger.exception`). No behaviour change beyond diagnostics; the exception still re-raises.

## Test

RED-first `test_headless_subprocess_stderr_is_recorded_on_the_attempt`: a runner raising a `ProcessError`-shaped exception with `.stderr` now yields a recorded attempt whose error contains the stderr (fails on the old code, which recorded only the opaque traceback).

## Next

With this deployed, the next headless drain will show the real `claude` CLI stderr, which unblocks fixing the root cause (why the CLI child exits 1) — the actual repair that gets the factory dogfooding its own issues. Lead to chase: the legacy dashboard-era teatree drove the Claude SDK successfully, so git history of the SDK-invocation path likely shows what regressed.
