### PR TITLE
fix(deploy): entrypoint loop-disable must pass --emergency (fixes init crash-loop outage from #3248)

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -141,7 +141,7 @@ disable_fleet_scoped_loops() {
     done
 
     for loop in "${requested[@]}"; do
-        if ! t3 loop disable "$loop"; then
+        if ! t3 loop disable "$loop" --emergency; then
             echo "entrypoint: 't3 loop disable ${loop}' FAILED - the DB-backed loop control plane is unreachable; confirm 't3 teatree db migrate' succeeded above and re-run Deploy" >&2
             exit 1
         fi


### PR DESCRIPTION
## Outage fix

`deploy/entrypoint.sh` (`disable_fleet_scoped_loops`) calls `t3 loop disable "$loop"` to turn off fleet-scoped loops (`review`, `directive_loop`, etc.) at boot. Since **#3248** made per-loop `enable/disable/pause/resume` **EMERGENCY-only** (normal handle is now `t3 loop preset use` / `t3 loop override --emergency`), that plain call is now **refused**, and the entrypoint treats the failure as "the DB-backed loop control plane is unreachable" → `exit 1`.

Result: with any non-empty `TEATREE_DISABLED_LOOPS`, **`teatree-init` crash-loops and the whole stack (worker/admin/slack-listener) never starts** — a full-factory outage. Observed live on this box (init failed on `t3 loop disable inbox`).

## Fix

Pass `--emergency` to force the per-loop verb (the documented escape for the emergency-only control-plane), preserving the entrypoint's boot-time disable semantics.

## Note

Recovered the live box by emptying `TEATREE_DISABLED_LOOPS` (skips the failing call); this PR is the durable fix so a future deploy that sets disabled-loops doesn't re-trigger the outage.
