### PR TITLE
perf(ci): build the test image once (ghcr, deps baked), shards pull it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,6 +507,62 @@ jobs:
 
   # ── 5. Test suite ──────────────────────────────────────────────────────────
 
+  # Build the shared test image ONCE per (dev/Dockerfile.test + uv.lock) hash and
+  # push it to ghcr, so the 6 `test-shard` jobs PULL one prebuilt, deps-baked
+  # image instead of each rebuilding the image AND cold-resolving the whole
+  # dependency set from PyPI at `docker run` time — that per-shard cold work
+  # (6x every run) was the bulk of the ~485s test-shard critical path. The build
+  # is SKIPPED entirely when the tag already exists (a run whose Dockerfile+lock
+  # are unchanged), so steady-state cost is one manifest check. Fork PRs cannot
+  # push to ghcr (read-only token, no secrets), so they set `mode=local` and each
+  # shard builds the image in-job — the package can stay PRIVATE (same-repo runs
+  # pull it with the job's `packages: read` token; forks never touch it).
+  # Same heavy-lane gating as test-shard: PR-only skip on a provably pure-docs
+  # diff; always runs on push/schedule (fail-safe-unknown, #132).
+  build-image:
+    needs: preflight
+    if: >
+      always() &&
+      (github.event_name != 'pull_request' ||
+      needs.preflight.outputs.run_heavy_python == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+      mode: ${{ steps.meta.outputs.mode }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Resolve the image ref (tag = hash of Dockerfile + lockfile) and push mode
+        id: meta
+        env:
+          # Empty on push/schedule and same-repo PRs; 'true' only for a fork PR.
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          KEY="${{ hashFiles('dev/Dockerfile.test', 'uv.lock') }}"
+          REPO_LC="$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
+          echo "image=ghcr.io/${REPO_LC}-test:${KEY}" >> "$GITHUB_OUTPUT"
+          if [ "$IS_FORK" = "true" ]; then
+            echo "mode=local" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=registry" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Log in to ghcr
+        if: steps.meta.outputs.mode == 'registry'
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Build and push the test image (skipped when the tag already exists)
+        if: steps.meta.outputs.mode == 'registry'
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+        run: |
+          if docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
+            echo "Image $IMAGE already exists — skipping build (Dockerfile + uv.lock unchanged)."
+            exit 0
+          fi
+          docker build -f dev/Dockerfile.test -t "$IMAGE" .
+          docker push "$IMAGE"
+
   # GATE (heavy lane): one of the 6 coverage SHARDS. Each shard runs a
   # duration-balanced sixth of the suite (pytest-split `--splits 6 --group N`)
   # in Docker WITH `--cov --cov-branch --doctest-modules` but NO floor and NO
@@ -521,13 +577,17 @@ jobs:
     # (preflight ``run_heavy_python=false``). On push-to-main and on the
     # schedule (no PR diff to classify) and on any non-pure-docs PR it
     # runs unconditionally — fail-safe-unknown. (#132)
-    needs: preflight
+    needs: [preflight, build-image]
     if: >
       always() &&
+      needs.build-image.result == 'success' &&
       (github.event_name != 'pull_request' ||
       needs.preflight.outputs.run_heavy_python == 'true')
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     strategy:
       fail-fast: false
       matrix:
@@ -535,15 +595,21 @@ jobs:
         group: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4
-      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7
-        with:
-          context: .
-          file: dev/Dockerfile.test
-          load: true
-          tags: teatree-test-${{ matrix.python-version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      # Pull the prebuilt, deps-baked image that `build-image` produced (one
+      # manifest fetch + layer pull), instead of rebuilding + cold-syncing it in
+      # every shard. Fork PRs (mode=local) build it in-job — the ghcr package can
+      # stay private since forks never pull it.
+      - name: Obtain the prebuilt test image
+        env:
+          IMAGE: ${{ needs.build-image.outputs.image }}
+          MODE: ${{ needs.build-image.outputs.mode }}
+        run: |
+          if [ "$MODE" = "registry" ]; then
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+            docker pull "$IMAGE"
+          else
+            docker build -f dev/Dockerfile.test -t "$IMAGE" .
+          fi
       # Shard N/6: pytest-split slices collection by `dev/.test_durations`;
       # `-n auto` parallelises WITHIN the shard. `--cov --cov-branch --doctest-modules`
       # measure exactly what the old monolithic lane did, but `--cov-report=`
@@ -567,10 +633,9 @@ jobs:
         run: >
           docker run --rm
           -v "$PWD":/app
-          -e UV_PROJECT_ENVIRONMENT=/tmp/.venv
           -e COVERAGE_FILE=/app/coverage.shard${{ matrix.group }}
           -e PYTHONPATH=/app
-          teatree-test-${{ matrix.python-version }}
+          ${{ needs.build-image.outputs.image }}
           uv run --group shard -p ${{ matrix.python-version }} pytest --no-header -q -n auto
           -o cache_dir=/tmp/.pytest_cache
           --doctest-modules --cov --cov-branch --cov-report= --cov-fail-under=0

--- a/dev/Dockerfile.test
+++ b/dev/Dockerfile.test
@@ -1,4 +1,9 @@
-FROM ubuntu:latest AS base
+# Pin the base by digest, not the floating `latest`/`24.04` tag: an unpinned
+# base moves its digest several times a month, and every move cache-busts every
+# layer below — so all 6 CI test shards do the full apt+node+uv rebuild at once
+# (souliane/teatree CI-speedup). Digest = ubuntu:24.04 as of 2026-07-16. Bump it
+# deliberately (dependabot's docker ecosystem can automate this).
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90 AS base
 RUN apt-get update -qq && \
     apt-get install -y -qq ca-certificates curl direnv git jq sqlite3 >/dev/null 2>&1 && \
     curl -fsSL https://deb.nodesource.com/setup_24.x | bash - >/dev/null 2>&1 && \

--- a/dev/Dockerfile.test
+++ b/dev/Dockerfile.test
@@ -15,3 +15,20 @@ USER testuser
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh -s -- -q 2>/dev/null
 ENV PATH="/home/testuser/.local/bin:$PATH"
 WORKDIR /app
+
+# Bake the interpreter + LOCKED third-party dependencies INTO the image so each
+# CI shard no longer resolves + installs the whole dependency set cold from PyPI
+# at `docker run` time — that per-shard cold sync (6x every run) was the bulk of
+# the ~485s test-shard critical path. Only pyproject.toml + uv.lock are needed to
+# resolve the graph; `--no-install-project` bakes third-party deps but NOT the
+# teatree project itself, which is installed editable from the bind-mounted /app
+# at runtime (seconds). CI tags this image `hash(dev/Dockerfile.test, uv.lock)`,
+# so this baked layer and the lockfile can never drift — a lock bump mints a new
+# tag and rebuilds. The baked venv lives OUTSIDE /app so the runtime
+# `-v "$PWD":/app` bind mount does not shadow it. `dev/docker-compose.yml`,
+# `dev/test-matrix.sh`, and src/teatree/cli/eval/docker.py override
+# UV_PROJECT_ENVIRONMENT for their own flows and are unaffected.
+ENV UV_PROJECT_ENVIRONMENT=/home/testuser/venv \
+    UV_PYTHON_INSTALL_DIR=/home/testuser/.local/uv-python
+COPY --chown=testuser:testuser pyproject.toml uv.lock ./
+RUN uv sync --locked --no-install-project --group shard -p 3.13


### PR DESCRIPTION
## What (the core CI-speedup change)
The 6 `test-shard` jobs each rebuilt `dev/Dockerfile.test` **and** cold-resolved the entire dependency set from PyPI at `docker run` time — because the lockfile never entered the image, it was never the cache reference. That per-shard cold work (6× every run) is the bulk of the ~485s `test-shard` critical path.

**`build-image` job** — builds the image **once** per `hash(dev/Dockerfile.test, uv.lock)`, pushes to ghcr, and **skips the build entirely when the tag exists**. The 6 shards `docker pull` that one image.

**`dev/Dockerfile.test` bakes interpreter + locked deps** (`uv sync --locked --no-install-project --group shard`), so the runtime `uv sync` disappears — each shard only installs the editable project (seconds).

Expected: `test-shard` critical path **≈485s → ~260–320s**.

## ghcr specifics
- Package can stay **private**: same-repo shards pull with a `packages: read` token; **fork PRs** set `mode=local` and build in-job (never pull).
- First CI run creates `ghcr.io/souliane/teatree-test` and pays one build; subsequent runs on the same lock hit the tag and skip.
- ⚠️ **Only live CI can verify** the ghcr push→pull round-trip and that the org allows `GITHUB_TOKEN` to create packages. If blocked by org policy, `build-image` reds — surface for a settings tweak.

## Quality invariants (unchanged)
- Shard pytest run-text keeps every flag pinned by `test_coverage_floor_guard.py`.
- Required `test (3.13)` context, exact-partition assertion, 93% combiner floor, per-module floors, scheduled durations-refresh — all untouched.
- A failed build reds the required context (`test-shard` gates on `needs.build-image.result == 'success'`).
- Eval (`cli/eval/docker.py`) mounts repo `:ro` + overrides `UV_PROJECT_ENVIRONMENT` → baked venv shadowed, no change.

## Verification
- Baked image **builds**; **48-test slice passes in-container** against the baked venv.
- CI-structure meta-tests green (sole failure = load-flaky ReDoS timing bound, green in isolation 2/2).

**Stacked on #3315** — auto-retargets to `main` when that merges.