### PR TITLE
Deploy: enable inbox on the DM box via sanctioned loop preset/override (t3 loop disable is emergency-only now)

### DIFF
--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -100,12 +100,15 @@ jobs:
           T3_ADMIN_PASSWORD: ${{ secrets.T3_ADMIN_PASSWORD }}
           GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
-          # Repo VARIABLE (not a secret): the box's fleet-scoped loop split,
-          # consumed by the entrypoint's disable_fleet_scoped_loops. The
-          # fallback preserves the historical default when the variable is
-          # unset; the entrypoint validates every name and fails the deploy
-          # loudly on a typo.
-          TEATREE_DISABLED_LOOPS: ${{ vars.TEATREE_DISABLED_LOOPS || 'inbox,review,directive_loop' }}
+          # Repo VARIABLES (not secrets): the box's fleet-scoped loop split,
+          # consumed by the entrypoint's apply_fleet_loop_policy. ENABLED loops
+          # are force-enabled here (clearing any stale hold — this box HOSTS the
+          # DM-only `inbox` loop); DISABLED loops are forced off (the colleague/
+          # human-facing `review`/`directive_loop` the laptop owns). The fallbacks
+          # are the box's shipped role; the entrypoint validates every name and
+          # fails the deploy loudly on a typo.
+          TEATREE_ENABLED_LOOPS: ${{ vars.TEATREE_ENABLED_LOOPS || 'inbox' }}
+          TEATREE_DISABLED_LOOPS: ${{ vars.TEATREE_DISABLED_LOOPS || 'review,directive_loop' }}
           # Repo VARIABLE: when 'true' the box's teatree.env gets NO Anthropic
           # env token even though the secret exists (the eval workflows still
           # need the secret) — the env source beats the pass rotation in
@@ -132,6 +135,7 @@ jobs:
             printf 'T3_ADMIN_PASSWORD=%s\n' "$T3_ADMIN_PASSWORD"
             printf 'GIT_AUTHOR_NAME=%s\n' "$GIT_AUTHOR_NAME"
             printf 'GIT_AUTHOR_EMAIL=%s\n' "$GIT_AUTHOR_EMAIL"
+            printf 'TEATREE_ENABLED_LOOPS=%s\n' "$TEATREE_ENABLED_LOOPS"
             printf 'TEATREE_DISABLED_LOOPS=%s\n' "$TEATREE_DISABLED_LOOPS"
           } | $SSH "$TARGET" 'umask 077; cat > "$HOME/teatree-deploy/deploy/teatree.env"'
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -104,18 +104,29 @@ the laptop's. The split:
 | **Laptop** | `review` (colleague PR review → Slack), `directive_loop` (asks the human via Slack) | `tickets` — the operator disables it by hand |
 | **Box** (this deploy) | `inbox` (DM-only owner Slack loop), `tickets` (issue scanning/dispatch) + all machine-local loops | `review`, `directive_loop` |
 
-The box enforces its side in `deploy/entrypoint.sh` (init role): after seeding
-config it calls `t3 loop disable <name>` — the single DB-backed per-loop control
-plane (`Loop.enabled` AND not `LoopState`-held, via `loop_state_admits`) — for each fleet-scoped loop.
-The disable is idempotent, so re-running the deploy converges.
+The box enforces its side in `deploy/entrypoint.sh` (init role) via
+`apply_fleet_loop_policy`, after seeding config. Per-loop enable/disable is now
+EMERGENCY-only (#3248) and, more importantly, admission resolves
+`hold > forced > preset > base` — so no preset, schedule, or `t3 loop override`
+can revive a loop a prior deploy left in a durable `LoopState` **hold** (older
+images ran `t3 loop disable inbox`). The step therefore drives the two
+authoritative planes:
 
-`TEATREE_DISABLED_LOOPS` (comma-separated) overrides the set the box disables. It
-defaults to `review,directive_loop` when unset, so a fresh deploy is safe
-with no configuration; an **empty** value disables nothing (every loop runs
-here). Set it in the box env file (`teatree.env`) to change the set. Because the
-deploy workflow rewrites `teatree.env` from repository secrets on every run, a
-persistent override belongs in that workflow's env-file writer (add a
-`TEATREE_DISABLED_LOOPS` line beside the others), not a hand-edit on the box.
+- **ENABLED set** (default `inbox`) → `t3 loop enable <name> --emergency`, the one
+  handle that clears a stale hold and sets `Loop.enabled=True`, so a box whose
+  `inbox` an older image disabled recovers. Idempotent.
+- **DISABLED set** (default `review,directive_loop`) → `t3 loop override <name> off`,
+  the sanctioned NON-emergency forced-off that replaces the deprecated
+  `t3 loop disable`. Forced-off beats the preset mask and the base config, so the
+  colleague/human-facing loops stay off here under any mode. Idempotent.
+
+`TEATREE_ENABLED_LOOPS` / `TEATREE_DISABLED_LOOPS` (comma-separated) override the
+defaults; an **empty** value acts on nothing. Every name in both lists is
+validated against the registered mini-loops first, so a typo fails the deploy
+loudly. Set them in the box env file (`teatree.env`) to change the split. Because
+the deploy workflow rewrites `teatree.env` from repository variables on every run,
+a persistent override belongs in that workflow's env-file writer (the
+`TEATREE_ENABLED_LOOPS` / `TEATREE_DISABLED_LOOPS` lines), not a hand-edit on the box.
 
 ## One-time bootstrap (on the box)
 

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -102,47 +102,81 @@ seed_setting() {
     fi
 }
 
-# Fleet role split: this instance must not run the loops another fleet member
-# owns. The box now HOSTS the DM-only Slack conversational loop for the owner
-# overlay, so `inbox` — the inbound-messaging scanners (Slack DM → PendingChatInjection,
-# review-intent, red-card, mentions) — MUST run here and is no longer disabled by
-# default. Only the COLLEAGUE-facing Slack loops the laptop owns stay off: `review`
-# (colleague PR review → Slack) and `directive_loop` (asks the human via Slack).
-# They are disabled through the one DB-backed per-loop control plane. `t3 loop
-# disable` is idempotent, so a re-deploy converges. TEATREE_DISABLED_LOOPS
-# (comma-separated, from teatree.env) overrides the default; an empty value runs
-# every loop here.
+# Fleet role split: this instance must run its own loops and NOT the loops another
+# fleet member owns. The box HOSTS the DM-only Slack conversational loop for the
+# owner overlay, so `inbox` — the inbound-messaging scanners (Slack DM →
+# PendingChatInjection, review-intent, red-card, mentions) — MUST run here; it
+# feeds the drain → 👀-ack → answer cycle that posts replies. The COLLEAGUE-facing
+# Slack loops the laptop owns stay off here: `review` (colleague PR review → Slack)
+# and `directive_loop` (asks the human via Slack).
 #
-# `t3 loop disable` exits 0 even on an unregistered name (it only flips a real
-# Loop row), so a typo would silently disable nothing and leave the real loop
-# running — a double-run against the laptop. Validate the WHOLE list against the
-# registered mini-loops first, so a bad value fails before anything is disabled.
-disable_fleet_scoped_loops() {
-    local raw="${TEATREE_DISABLED_LOOPS-review,directive_loop}"
+# Per-loop enable/disable/pause/resume is now EMERGENCY-only (#3248): the normal
+# handle is presets/schedules and the emergency per-loop handle is `t3 loop
+# override`. Neither presets, schedules, nor `t3 loop override` can express this
+# box's per-loop role, and — critically — none of them can lift a durable
+# `LoopState` HOLD: admission resolves hold > forced > preset > base, so a loop a
+# prior deploy left in a DISABLED hold (older images ran `t3 loop disable inbox`)
+# stays dead under any preset/schedule/override. Clearing a hold has exactly ONE
+# handle: `t3 loop enable`, which is emergency-gated. So this box declares its role
+# on the two authoritative planes that actually beat everything below them:
+#
+#   * ENABLED set (default `inbox`) → `t3 loop enable <name> --emergency`, which
+#     clears any stale hold AND sets `Loop.enabled=True`, so a box whose inbox a
+#     prior deploy durably disabled recovers. Idempotent (a no-op when already on).
+#   * DISABLED set (default `review,directive_loop`) → `t3 loop override <name> off`,
+#     the sanctioned, NON-emergency forced-off that supersedes the deprecated
+#     `t3 loop disable`. Forced-off beats the preset mask AND the base config, so a
+#     colleague/human-facing loop stays off here regardless of any mode the owner
+#     later selects. Idempotent.
+#
+# TEATREE_ENABLED_LOOPS / TEATREE_DISABLED_LOOPS (comma-separated, from teatree.env)
+# override the defaults; empty values act on nothing. Every name in BOTH lists is
+# validated against the registered mini-loops first, so a typo fails the deploy
+# loudly before anything is touched (rather than silently mis-configuring the box).
+apply_fleet_loop_policy() {
+    local enabled_raw="${TEATREE_ENABLED_LOOPS-inbox}"
+    local disabled_raw="${TEATREE_DISABLED_LOOPS-review,directive_loop}"
     local field loop registered
-    local fields=() requested=()
-    IFS=',' read -ra fields <<<"$raw"
+    local fields=() enable_loops=() disable_loops=()
+
+    IFS=',' read -ra fields <<<"$enabled_raw"
     for field in ${fields[@]+"${fields[@]}"}; do
         field="${field//[[:space:]]/}"
-        [ -n "$field" ] && requested+=("$field")
+        [ -n "$field" ] && enable_loops+=("$field")
     done
-    [ ${#requested[@]} -gt 0 ] || return 0
+    fields=()
+    IFS=',' read -ra fields <<<"$disabled_raw"
+    for field in ${fields[@]+"${fields[@]}"}; do
+        field="${field//[[:space:]]/}"
+        [ -n "$field" ] && disable_loops+=("$field")
+    done
+    [ $((${#enable_loops[@]} + ${#disable_loops[@]})) -gt 0 ] || return 0
 
     if ! registered="$(t3 loop list --json | jq -r '.mini_loops[].name')" || [ -z "$registered" ]; then
         echo "entrypoint: could not read the registered loops ('t3 loop list --json' failed or was empty) - confirm 't3 teatree db migrate' seeded the loops above and re-run Deploy" >&2
         exit 1
     fi
 
-    for loop in "${requested[@]}"; do
+    for loop in ${enable_loops[@]+"${enable_loops[@]}"} ${disable_loops[@]+"${disable_loops[@]}"}; do
         if ! grep -qxF "$loop" <<<"$registered"; then
-            echo "entrypoint: TEATREE_DISABLED_LOOPS names an unknown loop '${loop}' - valid loops are: $(tr '\n' ' ' <<<"$registered")- fix the value in teatree.env and re-run Deploy" >&2
+            echo "entrypoint: TEATREE_ENABLED_LOOPS/TEATREE_DISABLED_LOOPS names an unknown loop '${loop}' - valid loops are: $(tr '\n' ' ' <<<"$registered")- fix the value in teatree.env and re-run Deploy" >&2
             exit 1
         fi
     done
 
-    for loop in "${requested[@]}"; do
-        if ! t3 loop disable "$loop" --emergency; then
-            echo "entrypoint: 't3 loop disable ${loop}' FAILED - the DB-backed loop control plane is unreachable; confirm 't3 teatree db migrate' succeeded above and re-run Deploy" >&2
+    # ENABLE clears any durable hold (only `enable` can) and sets Loop.enabled=True.
+    for loop in ${enable_loops[@]+"${enable_loops[@]}"}; do
+        if ! t3 loop enable "$loop" --emergency; then
+            echo "entrypoint: 't3 loop enable ${loop} --emergency' FAILED - the DB-backed loop control plane is unreachable; confirm 't3 teatree db migrate' succeeded above and re-run Deploy" >&2
+            exit 1
+        fi
+    done
+
+    # DISABLE via the forced-off override plane (beats preset + base config), the
+    # sanctioned non-emergency successor to the now-refused `t3 loop disable`.
+    for loop in ${disable_loops[@]+"${disable_loops[@]}"}; do
+        if ! t3 loop override "$loop" off --reason "fleet policy (DM-only box): ${loop} must not run here"; then
+            echo "entrypoint: 't3 loop override ${loop} off' FAILED - the DB-backed loop control plane is unreachable; confirm 't3 teatree db migrate' succeeded above and re-run Deploy" >&2
             exit 1
         fi
     done
@@ -196,7 +230,7 @@ init)
     # The admin binds the box loopback (host networking), so auto-login fires for
     # the SSH-tunnelled 127.0.0.1 request — no admin password behind the tunnel.
     seed_setting admin_autologin_enabled true
-    disable_fleet_scoped_loops
+    apply_fleet_loop_policy
     echo "teatree-init: complete"
     ;;
 worker)

--- a/tests/test_deploy_entrypoint_disable_loops.py
+++ b/tests/test_deploy_entrypoint_disable_loops.py
@@ -7,12 +7,12 @@ and admission resolves ``hold > forced > preset > base`` — so no preset, sched
 or ``t3 loop override`` can revive a loop a prior deploy left in a durable
 ``LoopState`` hold (older images ran ``t3 loop disable inbox``). The step therefore:
 
-* force-enables the ENABLED set (default ``inbox``) with
-  ``t3 loop enable <name> --emergency`` — the ONE handle that clears a stale hold —
-  so the DM-only box's inbox recovers even from a prior durable disable, and
-* forces the DISABLED set (default ``review,directive_loop``) off with
-  ``t3 loop override <name> off`` — the sanctioned NON-emergency successor to the
-  now-refused ``t3 loop disable``.
+It force-enables the ENABLED set (default ``inbox``) with
+``t3 loop enable <name> --emergency`` — the ONE handle that clears a stale hold, so
+the DM-only box's inbox recovers even from a prior durable disable. It forces the
+DISABLED set (default ``review,directive_loop``) off with
+``t3 loop override <name> off`` — the sanctioned NON-emergency successor to the
+now-refused ``t3 loop disable``.
 
 It never calls the deprecated ``t3 loop disable``. Because a typo in either list
 would silently mis-configure the box, the step validates the whole requested set

--- a/tests/test_deploy_entrypoint_disable_loops.py
+++ b/tests/test_deploy_entrypoint_disable_loops.py
@@ -1,20 +1,31 @@
-"""Integration tests for the deploy entrypoint's fleet-loop disable step.
+"""Integration tests for the deploy entrypoint's fleet-loop policy step.
 
-`deploy/entrypoint.sh` (init role) disables the loops the headless box must
-not run — the COLLEAGUE-facing `review` / `directive_loop` — through
-`t3 loop disable`, driven by `TEATREE_DISABLED_LOOPS`. The box now hosts the
-DM-only Slack conversational loop, so `inbox` is NOT disabled by default. Because
-`t3 loop disable` exits 0 even on an unregistered name (it only flips a real
-`Loop` row), a typo in `TEATREE_DISABLED_LOOPS` would silently disable nothing and
-leave the real loop running — a double-run against the operator's laptop. The
-step therefore validates the whole requested list against the registered
-mini-loops (`t3 loop list --json`) and fails loudly, before disabling
-anything, on an unknown name.
+`deploy/entrypoint.sh` (init role) declares this box's per-loop role through
+`apply_fleet_loop_policy`, driven by `TEATREE_ENABLED_LOOPS` /
+`TEATREE_DISABLED_LOOPS`. Per-loop enable/disable is now EMERGENCY-only (#3248)
+and admission resolves ``hold > forced > preset > base`` — so no preset, schedule,
+or ``t3 loop override`` can revive a loop a prior deploy left in a durable
+``LoopState`` hold (older images ran ``t3 loop disable inbox``). The step therefore:
+
+* force-enables the ENABLED set (default ``inbox``) with
+  ``t3 loop enable <name> --emergency`` — the ONE handle that clears a stale hold —
+  so the DM-only box's inbox recovers even from a prior durable disable, and
+* forces the DISABLED set (default ``review,directive_loop``) off with
+  ``t3 loop override <name> off`` — the sanctioned NON-emergency successor to the
+  now-refused ``t3 loop disable``.
+
+It never calls the deprecated ``t3 loop disable``. Because a typo in either list
+would silently mis-configure the box, the step validates the whole requested set
+against the registered mini-loops (``t3 loop list --json``) and fails loudly,
+before touching anything, on an unknown name.
 
 In the spirit of the Test-Writing Doctrine these run the REAL shell function
 (extracted verbatim from `deploy/entrypoint.sh`) in a bash subprocess with a
 stub `t3` on PATH and real `jq` — nothing about the shell logic is
-reimplemented. This mirrors the standalone-shell-script tests
+reimplemented. The stub models the emergency gate (bare ``enable`` is refused
+with exit 2) and the ``disable`` refusal, exactly as the real CLI does, so the
+tests prove the function passes ``--emergency`` and never reaches for ``disable``.
+This mirrors the standalone-shell-script tests
 (`tests/test_refuse_public_push_with_leak.py`).
 """
 
@@ -23,6 +34,7 @@ import os
 import shutil
 import stat
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -37,7 +49,7 @@ _BASH = shutil.which("bash") or "bash"  # absolute path (the skipif guarantees i
 
 # The registered mini-loops the stub `t3 loop list --json` reports. `loop-tick`
 # sits under infra_slots to prove the validator keys on mini-loops only (it is
-# NOT a valid disable target).
+# NOT a valid target).
 _STUB_LOOP_STATUS = {
     "mini_loops": [
         {"name": "inbox"},
@@ -70,12 +82,16 @@ def _extract_shell_function(name: str) -> str:
 
 
 def _write_t3_stub(bin_dir: Path) -> None:
-    """A `t3` shim: reports the loop list from a file, records disable calls.
+    """A `t3` shim modelling the loop control CLI; records what the policy step calls.
 
     Behaviour is env-driven so one shim covers every case:
-    ``T3_LIST_JSON`` (file to emit for ``loop list``), ``T3_DISABLE_LOG``
-    (append each disabled name), ``T3_LIST_FAIL`` (make ``loop list`` exit
-    non-zero), ``T3_FAIL_LOOP`` (make ``loop disable`` fail for that name).
+    ``T3_LIST_JSON`` (file to emit for ``loop list``), ``T3_ENABLE_LOG`` /
+    ``T3_OVERRIDE_LOG`` / ``T3_DISABLE_LOG`` (append each acted-on name),
+    ``T3_LIST_FAIL`` (make ``loop list`` exit non-zero), ``T3_FAIL_LOOP`` (make the
+    acting verb fail for that name). It mirrors the real CLI's two gates: a bare
+    ``loop enable`` (no ``--emergency``) is refused with exit 2, and ``loop disable``
+    is refused outright (emergency-only) — so any use of the deprecated verb, or a
+    missing ``--emergency``, trips the function's loud-failure path.
     """
     bin_dir.mkdir(parents=True, exist_ok=True)
     shim = bin_dir / "t3"
@@ -86,11 +102,27 @@ def _write_t3_stub(bin_dir: Path) -> None:
         '  cat "$T3_LIST_JSON"\n'
         "  exit 0\n"
         "fi\n"
+        'if [ "${1:-}" = "loop" ] && [ "${2:-}" = "enable" ]; then\n'
+        '  name="$3"\n'
+        "  emergency=\n"
+        '  for arg in "$@"; do [ "$arg" = "--emergency" ] && emergency=1; done\n'
+        '  if [ -z "$emergency" ]; then echo "refused: per-loop enable is EMERGENCY-only" >&2; exit 2; fi\n'
+        '  echo "$name" >> "$T3_ENABLE_LOG"\n'
+        '  if [ "$name" = "${T3_FAIL_LOOP:-}" ]; then echo "boom" >&2; exit 1; fi\n'
+        "  echo \"OK    loop '$name' is now enabled.\"\n"
+        "  exit 0\n"
+        "fi\n"
+        'if [ "${1:-}" = "loop" ] && [ "${2:-}" = "override" ]; then\n'
+        '  name="$3"; state="$4"\n'
+        '  echo "$name $state" >> "$T3_OVERRIDE_LOG"\n'
+        '  if [ "$name" = "${T3_FAIL_LOOP:-}" ]; then echo "boom" >&2; exit 1; fi\n'
+        "  echo \"OK    loop '$name' override is now $state.\"\n"
+        "  exit 0\n"
+        "fi\n"
         'if [ "${1:-}" = "loop" ] && [ "${2:-}" = "disable" ]; then\n'
         '  echo "$3" >> "$T3_DISABLE_LOG"\n'
-        '  if [ "$3" = "${T3_FAIL_LOOP:-}" ]; then echo "boom" >&2; exit 1; fi\n'
-        "  echo \"OK    loop '$3' is now disabled.\"\n"
-        "  exit 0\n"
+        '  echo "refused: per-loop disable is EMERGENCY-only" >&2\n'
+        "  exit 2\n"
         "fi\n"
         "exit 0\n",
         encoding="utf-8",
@@ -98,28 +130,50 @@ def _write_t3_stub(bin_dir: Path) -> None:
     shim.chmod(shim.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
 
 
-def _run(tmp_path: Path, disabled: str | None, **stub_env: str) -> tuple[subprocess.CompletedProcess[str], list[str]]:
-    """Run the extracted function once; return (result, list of disabled names)."""
+@dataclass(frozen=True, slots=True)
+class _Outcome:
+    """What the policy step did: the exit result plus each verb's captured names."""
+
+    result: subprocess.CompletedProcess[str]
+    enabled: list[str]
+    overridden: list[str]  # "<name> <state>" per call
+    disabled: list[str]  # any deprecated `t3 loop disable` reach — must stay empty
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    enabled: str | None = None,
+    disabled: str | None = None,
+    **stub_env: str,
+) -> _Outcome:
+    """Run the extracted function once; return the captured outcome."""
     bin_dir = tmp_path / "bin"
     _write_t3_stub(bin_dir)
     list_json = tmp_path / "loops.json"
     list_json.write_text(json.dumps(_STUB_LOOP_STATUS), encoding="utf-8")
+    enable_log = tmp_path / "enabled.log"
+    override_log = tmp_path / "overridden.log"
     disable_log = tmp_path / "disabled.log"
-    disable_log.write_text("", encoding="utf-8")
+    for log in (enable_log, override_log, disable_log):
+        log.write_text("", encoding="utf-8")
 
-    func = _extract_shell_function("disable_fleet_scoped_loops")
+    func = _extract_shell_function("apply_fleet_loop_policy")
     harness = tmp_path / "harness.sh"
-    harness.write_text(f"set -euo pipefail\n{func}\ndisable_fleet_scoped_loops\n", encoding="utf-8")
+    harness.write_text(f"set -euo pipefail\n{func}\napply_fleet_loop_policy\n", encoding="utf-8")
 
     env = dict(os.environ)
     env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
     env["T3_LIST_JSON"] = str(list_json)
+    env["T3_ENABLE_LOG"] = str(enable_log)
+    env["T3_OVERRIDE_LOG"] = str(override_log)
     env["T3_DISABLE_LOG"] = str(disable_log)
     env.update(stub_env)
-    if disabled is None:
-        env.pop("TEATREE_DISABLED_LOOPS", None)
-    else:
-        env["TEATREE_DISABLED_LOOPS"] = disabled
+    for name, value in (("TEATREE_ENABLED_LOOPS", enabled), ("TEATREE_DISABLED_LOOPS", disabled)):
+        if value is None:
+            env.pop(name, None)
+        else:
+            env[name] = value
 
     result = subprocess.run(
         [_BASH, str(harness)],
@@ -128,64 +182,97 @@ def _run(tmp_path: Path, disabled: str | None, **stub_env: str) -> tuple[subproc
         check=False,
         env=env,
     )
-    disabled_names = [line for line in disable_log.read_text(encoding="utf-8").splitlines() if line]
-    return result, disabled_names
+
+    def _lines(path: Path) -> list[str]:
+        return [line for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+    return _Outcome(
+        result=result,
+        enabled=_lines(enable_log),
+        overridden=_lines(override_log),
+        disabled=_lines(disable_log),
+    )
 
 
-class TestDisableFleetScopedLoops:
-    def test_unset_disables_the_default_fleet_loops(self, tmp_path: Path) -> None:
-        # The box hosts the DM-only Slack conversational loop, so `inbox` runs
-        # here and is NOT in the default disabled set — only the colleague-facing
-        # `review` / `directive_loop` are.
-        result, disabled = _run(tmp_path, None)
-        assert result.returncode == 0, result.stderr
-        assert disabled == ["review", "directive_loop"]
+class TestApplyFleetLoopPolicy:
+    def test_defaults_enable_inbox_and_force_colleague_loops_off(self, tmp_path: Path) -> None:
+        # The DM-only box: `inbox` is force-enabled (recovering any stale hold),
+        # and the colleague-facing `review` / `directive_loop` are forced off — via
+        # the override plane, never the deprecated `t3 loop disable`.
+        out = _run(tmp_path)
+        assert out.result.returncode == 0, out.result.stderr
+        assert out.enabled == ["inbox"]
+        assert out.overridden == ["review off", "directive_loop off"]
+        assert out.disabled == [], "the deprecated `t3 loop disable` must never be called"
 
-    def test_explicit_subset_disables_only_those(self, tmp_path: Path) -> None:
-        result, disabled = _run(tmp_path, "inbox,review")
-        assert result.returncode == 0, result.stderr
-        assert disabled == ["inbox", "review"]
+    def test_enable_passes_emergency(self, tmp_path: Path) -> None:
+        # The stub refuses a bare `loop enable` (exit 2). A green run therefore
+        # proves the function passes `--emergency` — the only handle that lifts a
+        # durable hold so a previously-disabled inbox actually comes back.
+        out = _run(tmp_path, enabled="inbox", disabled="")
+        assert out.result.returncode == 0, out.result.stderr
+        assert out.enabled == ["inbox"]
+
+    def test_explicit_env_overrides_both_lists(self, tmp_path: Path) -> None:
+        out = _run(tmp_path, enabled="inbox,tickets", disabled="review")
+        assert out.result.returncode == 0, out.result.stderr
+        assert out.enabled == ["inbox", "tickets"]
+        assert out.overridden == ["review off"]
+        assert out.disabled == []
 
     def test_whitespace_and_trailing_comma_tolerated(self, tmp_path: Path) -> None:
-        result, disabled = _run(tmp_path, "inbox, review, ,")
-        assert result.returncode == 0, result.stderr
-        assert disabled == ["inbox", "review"]
+        out = _run(tmp_path, enabled="inbox, ,", disabled="review, directive_loop ,")
+        assert out.result.returncode == 0, out.result.stderr
+        assert out.enabled == ["inbox"]
+        assert out.overridden == ["review off", "directive_loop off"]
 
-    def test_empty_value_disables_nothing_and_succeeds(self, tmp_path: Path) -> None:
-        result, disabled = _run(tmp_path, "")
-        assert result.returncode == 0, result.stderr
-        assert disabled == []
+    def test_both_empty_is_a_noop_and_succeeds(self, tmp_path: Path) -> None:
+        out = _run(tmp_path, enabled="", disabled="")
+        assert out.result.returncode == 0, out.result.stderr
+        assert out.enabled == []
+        assert out.overridden == []
+        assert out.disabled == []
 
-    def test_unknown_loop_fails_before_disabling_anything(self, tmp_path: Path) -> None:
-        """A typo must fail loudly AND disable nothing — the whole point of the gate.
+    def test_unknown_enabled_loop_fails_before_acting(self, tmp_path: Path) -> None:
+        """A typo in the ENABLED list must fail loudly AND touch nothing."""
+        out = _run(tmp_path, enabled="inbxo", disabled="review")
+        assert out.result.returncode != 0
+        assert out.enabled == []
+        assert out.overridden == [], "a bad list must not act on any loop"
+        assert "unknown loop 'inbxo'" in out.result.stderr
+        assert "valid loops are:" in out.result.stderr
 
-        `revieww` is unregistered; `inbox` precedes it in the list. Validation
-        happens up front, so NOTHING is disabled even though a valid name came
-        first — the box is never left half-configured.
-        """
-        result, disabled = _run(tmp_path, "inbox,revieww")
-        assert result.returncode != 0
-        assert disabled == [], "a bad list must not disable any loop"
-        assert "unknown loop 'revieww'" in result.stderr
-        assert "valid loops are:" in result.stderr
+    def test_unknown_disabled_loop_fails_before_acting(self, tmp_path: Path) -> None:
+        """A typo in the DISABLED list is caught up front, before any enable runs."""
+        out = _run(tmp_path, enabled="inbox", disabled="revieww")
+        assert out.result.returncode != 0
+        assert out.enabled == [], "validation precedes every action — even a valid enable"
+        assert out.overridden == []
+        assert "unknown loop 'revieww'" in out.result.stderr
 
     def test_infra_slot_name_is_not_a_valid_target(self, tmp_path: Path) -> None:
-        """`loop-tick` is an infra slot, not a disable-able mini-loop → rejected."""
-        result, disabled = _run(tmp_path, "loop-tick")
-        assert result.returncode != 0
-        assert disabled == []
-        assert "unknown loop 'loop-tick'" in result.stderr
+        """`loop-tick` is an infra slot, not a mini-loop → rejected."""
+        out = _run(tmp_path, enabled="loop-tick", disabled="")
+        assert out.result.returncode != 0
+        assert out.enabled == []
+        assert "unknown loop 'loop-tick'" in out.result.stderr
 
-    def test_disable_failure_is_loud(self, tmp_path: Path) -> None:
-        result, _ = _run(tmp_path, "inbox,review", T3_FAIL_LOOP="review")
-        assert result.returncode != 0
-        assert "'t3 loop disable review' FAILED" in result.stderr
+    def test_enable_failure_is_loud(self, tmp_path: Path) -> None:
+        out = _run(tmp_path, enabled="inbox", disabled="review", T3_FAIL_LOOP="inbox")
+        assert out.result.returncode != 0
+        assert "'t3 loop enable inbox --emergency' FAILED" in out.result.stderr
+
+    def test_override_failure_is_loud(self, tmp_path: Path) -> None:
+        out = _run(tmp_path, enabled="inbox", disabled="review", T3_FAIL_LOOP="review")
+        assert out.result.returncode != 0
+        assert "'t3 loop override review off' FAILED" in out.result.stderr
 
     def test_unreadable_loop_list_fails_loud(self, tmp_path: Path) -> None:
-        result, disabled = _run(tmp_path, "inbox", T3_LIST_FAIL="1")
-        assert result.returncode != 0
-        assert disabled == []
-        assert "could not read the registered loops" in result.stderr
+        out = _run(tmp_path, enabled="inbox", disabled="review", T3_LIST_FAIL="1")
+        assert out.result.returncode != 0
+        assert out.enabled == []
+        assert out.overridden == []
+        assert "could not read the registered loops" in out.result.stderr
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

On the headless Docker box, `deploy/entrypoint.sh` (init role) called
`t3 loop disable <name>` for each `TEATREE_DISABLED_LOOPS`. That verb is now
**EMERGENCY-only** (#3248) — without `--emergency` it refuses with exit 1,
crashing `init` and taking the whole stack down.

Second bug: on the DM-only Slack box the `inbox` loop **must be enabled** (it
feeds `PendingChatInjection` -> the slack-answer cycle that posts replies), but
it stayed disabled. Two causes:
1. the deploy workflow's `TEATREE_DISABLED_LOOPS` default *still contained
   `inbox`* (`inbox,review,directive_loop`), so the deployed value disabled it; and
2. loop admission resolves **`hold > forced > preset > base`**, so a prior
   deploy's durable `LoopState` **DISABLED hold** on inbox (older images ran
   `t3 loop disable inbox`) could not be lifted by any preset, schedule, or
   `t3 loop override` — all of those sit *below* the hold.

## Why not a preset / schedule?

Presets and schedules are **global mode masks that sit below the hold plane**.
They cannot express a single box's per-loop role, and — decisively — cannot
lift a durable hold. `t3 loop override` (the ungated forced plane) also sits
below the hold. Clearing a hold has exactly **one** handle: `t3 loop enable` /
`resume`, which is emergency-gated. So the box declares its role on the two
authoritative planes that actually beat everything below them.

## Fix — `apply_fleet_loop_policy`

- **ENABLED set** (default `inbox`) -> `t3 loop enable <name> --emergency`: the
  one handle that clears a stale hold *and* sets `Loop.enabled=True`, so a box
  whose inbox an older image disabled recovers. Idempotent.
- **DISABLED set** (default `review,directive_loop`) -> `t3 loop override <name> off`:
  the sanctioned **non-emergency** forced-off that supersedes the deprecated
  `t3 loop disable`. Forced-off beats the preset mask and base config, so the
  colleague/human-facing loops stay off here under any mode the owner selects.
  Idempotent.

Both lists are validated against the registered mini-loops (`t3 loop list --json`)
up front, so a typo fails the deploy loudly before anything is touched. The
deprecated `t3 loop disable` is **never** called. Driven by
`TEATREE_ENABLED_LOOPS` / `TEATREE_DISABLED_LOOPS` (from `teatree.env`) so it
stays fleet-configurable.

## Changes

- `deploy/entrypoint.sh` — rename `disable_fleet_scoped_loops` ->
  `apply_fleet_loop_policy`; new mechanism + rewritten comment block.
- `.github/workflows/deploy-hetzner.yml` — split into `TEATREE_ENABLED_LOOPS`
  (default `inbox`) / `TEATREE_DISABLED_LOOPS` (default `review,directive_loop`,
  `inbox` dropped); write both into `teatree.env`.
- `deploy/README.md` — document the two planes and the two env vars.
- `tests/test_deploy_entrypoint_disable_loops.py` — the extracted-shell-function
  test now models the preset/override CLI (bare `enable` refused without
  `--emergency`; `disable` refused outright), and asserts inbox-enabled +
  review/directive forced-off + `t3 loop disable` never called.