### PR TITLE
perf(ci): converge the lint job onto the prebuilt Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,18 @@
 #
 # JOB GROUPS (in order of appearance below)
 #   1. Lane routing          — preflight
-#   2. Fast static checks    — lint, blueprint-cross-pr
+#   2. Fast static checks    — lint (runs prek INSIDE the prebuilt `-lint`
+#                              Docker image built by `build-image` in group 5
+#                              below — `needs: build-image`, UNCONDITIONAL, so
+#                              lint runs even on pure-docs PRs), blueprint-cross-pr
 #   3. Docs integrity        — doc-update-gate, module-health-gate,
 #                              comment-density-warning, docs-drift
 #   4. Signal & ratchet      — test-shape (advisory),
 #                              test-path-mirror (ratchet gate)
-#   5. Test suite            — test-shard (12-way coverage matrix),
+#   5. Test suite            — build-image (builds/pushes BOTH the `-test` and
+#                              `-lint` tags; unconditional, feeds group 2's
+#                              `lint` job as well as this group), test-shard
+#                              (12-way coverage matrix),
 #                              test (combiner = required `test (3.13)`),
 #                              test-shim
 #   6. Architecture / quality fitness gates — mutation-diff, mutation-full,
@@ -147,25 +153,47 @@ jobs:
 
   # ── 2. Fast static checks ──────────────────────────────────────────────────
 
-  # GATE: ruff/prek lint + migration-graph linearity; runs on every push and PR.
+  # GATE: ruff/prek lint + migration-graph linearity; runs on every push and PR,
+  # INCLUDING pure-docs PRs (prek covers markdownlint/codespell/doc generators —
+  # its whole point). Runs INSIDE the prebuilt `-lint` image (`needs:
+  # build-image`) so prek's hook environments are already baked instead of
+  # cold-installed at run time — CI lint/Docker convergence (souliane/teatree
+  # CI-speedup). SAME hooks, SAME SKIP list as before: this is a venue-only
+  # change, `check_gate_relaxation.py`/`check_quality_gates.py` semantics are
+  # untouched. Obtain-image step matches the `test-shard` pattern: pull for a
+  # same-repo run, in-job local build for a fork PR (`mode=local`).
   lint:
+    needs: build-image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
-        with:
-          enable-cache: true
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
-        with:
-          python-version: "3.13"
-      - run: uv sync
-      # Run prek from the locked project venv (`uv run`) so the prek RUNNER
+      - name: Obtain the prebuilt lint image
+        env:
+          IMAGE: ${{ needs.build-image.outputs.image_lint }}
+          MODE: ${{ needs.build-image.outputs.mode }}
+        run: |
+          if [ "$MODE" = "registry" ]; then
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+            docker pull "$IMAGE"
+          else
+            docker build -f dev/Dockerfile.test --target lint -t "$IMAGE" .
+          fi
+      # Run prek from the image's locked venv (`uv run`) so the prek RUNNER
       # version is exactly the one the lockfile pins (prek==0.3.13) — identical
       # to the documented local gate, which also runs `uv run prek`
       # (dev/ci-parity.sh). This closes the runner-version gap that let a hook
       # pass locally and fail here (or the reverse); a lockfile bump moves local
-      # and CI together in one step (#3236).
-      - name: prek (all hooks, all files) — locked runner
+      # and CI together in one step (#3236). Chained with the migration-graph
+      # linearity check in ONE `docker run` (a second invocation would just
+      # re-start the container for no benefit): two PRs branching a migration
+      # off the same parent each pass locally and pass their own CI, then merge
+      # into a forked graph with multiple leaf nodes that ``migrate`` refuses to
+      # run. ``makemigrations --check`` raises ``Conflicting migrations
+      # detected`` (exit 1) on a forked graph, failing the PR before it lands.
+      - name: prek (all hooks, all files) + makemigrations --check — locked runner, in Docker
         env:
           SKIP: pytest,uv-audit,cyclonedx-sbom
           # Dual-env during the banned-term-registry transition: the legacy
@@ -174,13 +202,14 @@ jobs:
           # cutover (empty until then ⇒ no behaviour change).
           T3_BANNED_TERMS: ${{ secrets.TEATREE_BANNED_TERMS }}
           TEATREE_TERM_REGISTRY: ${{ secrets.TEATREE_TERM_REGISTRY }}
-        run: uv run prek run --all-files
-      # Migration-graph linearity gate. Two PRs branching a migration off
-      # the same parent each pass locally and pass their own CI, then merge
-      # into a forked graph with multiple leaf nodes that ``migrate`` refuses
-      # to run. ``makemigrations --check`` raises ``Conflicting migrations
-      # detected`` (exit 1) on a forked graph, failing the PR before it lands.
-      - run: uv run python manage.py makemigrations --check --dry-run
+        run: >
+          docker run --rm
+          -v "$PWD":/app
+          -e SKIP
+          -e T3_BANNED_TERMS
+          -e TEATREE_TERM_REGISTRY
+          ${{ needs.build-image.outputs.image_lint }}
+          bash -c "uv run prek run --all-files && uv run python manage.py makemigrations --check --dry-run"
 
   # GATE (PR-only): catches two concurrent PRs both adding the same §17.N
   # invariant number — local pre-commit can't see sibling PRs.
@@ -511,38 +540,47 @@ jobs:
   # push it to ghcr, so the 12 `test-shard` jobs PULL one prebuilt, deps-baked
   # image instead of each rebuilding the image AND cold-resolving the whole
   # dependency set from PyPI at `docker run` time — that per-shard cold work
-  # (6x every run) was the bulk of the ~485s test-shard critical path. The build
-  # is SKIPPED entirely when the tag already exists (a run whose Dockerfile+lock
-  # are unchanged), so steady-state cost is one manifest check. Fork PRs cannot
-  # push to ghcr (read-only token, no secrets), so they set `mode=local` and each
-  # shard builds the image in-job — the package can stay PRIVATE (same-repo runs
-  # pull it with the job's `packages: read` token; forks never touch it).
-  # Same heavy-lane gating as test-shard: PR-only skip on a provably pure-docs
-  # diff; always runs on push/schedule (fail-safe-unknown, #132).
+  # (6x every run) was the bulk of the ~485s test-shard critical path. Also
+  # builds and pushes a second `-lint:${KEY_LINT}` tag from the Dockerfile's
+  # `lint` stage (`FROM base`, bakes prek's hook environments) so the `lint`
+  # job below can pull a ready image instead of cold-installing every hook env
+  # at `prek run` time — CI lint/Docker convergence (souliane/teatree
+  # CI-speedup). Both builds are SKIPPED entirely when their tag already
+  # exists, so steady-state cost is two manifest checks. Fork PRs cannot push
+  # to ghcr (read-only token, no secrets), so they set `mode=local` and each
+  # downstream job (test-shard, lint) builds the image IT needs in-job — the
+  # packages can stay PRIVATE (same-repo runs pull them with the job's
+  # `packages: read` token; forks never touch them).
+  # UNCONDITIONAL — no preflight gating, no `needs: preflight`. The `lint` job
+  # below always needs an image (lint must run on pure-docs PRs too:
+  # markdownlint/codespell/doc generators are its whole point), and steady-state
+  # cost here is a manifest check either way.
   build-image:
-    needs: preflight
-    if: >
-      always() &&
-      (github.event_name != 'pull_request' ||
-      needs.preflight.outputs.run_heavy_python == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     outputs:
       image: ${{ steps.meta.outputs.image }}
+      image_lint: ${{ steps.meta.outputs.image_lint }}
       mode: ${{ steps.meta.outputs.mode }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - name: Resolve the image ref (tag = hash of Dockerfile + lockfile) and push mode
+      - name: Resolve the image refs (tag = hash of inputs) and push mode
         id: meta
         env:
           # Empty on push/schedule and same-repo PRs; 'true' only for a fork PR.
           IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
         run: |
           KEY="${{ hashFiles('dev/Dockerfile.test', 'uv.lock') }}"
+          # Widened key (adds .pre-commit-config.yaml): a hook-rev bump alone
+          # must mint a fresh lint tag so baked hook envs can never silently go
+          # stale. A tag MISS degrades gracefully — prek just cold-installs
+          # whichever repo changed.
+          KEY_LINT="${{ hashFiles('dev/Dockerfile.test', 'uv.lock', '.pre-commit-config.yaml') }}"
           REPO_LC="$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
           echo "image=ghcr.io/${REPO_LC}-test:${KEY}" >> "$GITHUB_OUTPUT"
+          echo "image_lint=ghcr.io/${REPO_LC}-lint:${KEY_LINT}" >> "$GITHUB_OUTPUT"
           if [ "$IS_FORK" = "true" ]; then
             echo "mode=local" >> "$GITHUB_OUTPUT"
           else
@@ -560,8 +598,19 @@ jobs:
             echo "Image $IMAGE already exists — skipping build (Dockerfile + uv.lock unchanged)."
             exit 0
           fi
-          docker build -f dev/Dockerfile.test -t "$IMAGE" .
+          docker build -f dev/Dockerfile.test --target base -t "$IMAGE" .
           docker push "$IMAGE"
+      - name: Build and push the lint image (skipped when the tag already exists)
+        if: steps.meta.outputs.mode == 'registry'
+        env:
+          IMAGE_LINT: ${{ steps.meta.outputs.image_lint }}
+        run: |
+          if docker manifest inspect "$IMAGE_LINT" >/dev/null 2>&1; then
+            echo "Image $IMAGE_LINT already exists — skipping build (Dockerfile + uv.lock + pre-commit config unchanged)."
+            exit 0
+          fi
+          docker build -f dev/Dockerfile.test --target lint -t "$IMAGE_LINT" .
+          docker push "$IMAGE_LINT"
 
   # GATE (heavy lane): one of the 12 coverage SHARDS. Each shard runs a
   # duration-balanced twelfth of the suite (pytest-split `--splits 12 --group N`)
@@ -612,7 +661,10 @@ jobs:
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
             docker pull "$IMAGE"
           else
-            docker build -f dev/Dockerfile.test -t "$IMAGE" .
+            # --target base: the Dockerfile is multi-stage (a `lint` stage now
+            # follows `base`), so the target must be pinned explicitly — an
+            # untargeted build would silently produce the LAST stage instead.
+            docker build -f dev/Dockerfile.test --target base -t "$IMAGE" .
           fi
       # Shard N/12: pytest-split slices collection by `dev/.test_durations`;
       # `-n auto` parallelises WITHIN the shard. `--cov --cov-branch --doctest-modules`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,3 +50,11 @@ push gate (scoped doctest + ast-grep, FULL on any uncertainty, behind the
 default-TRUE `incremental_push_gate` flag — ON scopes the diff, OFF is the pre-#122
 whole-tree run; the CI whole-tree backstop is untouched). The broad `tests/quality`
 dir is CI-only (it ran ~420s locally — the `test (3.13)` shard covers it whole-tree).
+
+**CI's `lint` job runs prek inside a prebuilt Docker image** (`dev/Dockerfile.test`'s
+`lint` stage, `FROM base`, bakes prek's per-hook environments — same hooks, same
+`SKIP` list as before, a venue-only change). `bash dev/ci-parity.sh`'s step 1 stays
+host-native (`uv run prek run --all-files`) by default; set `LINT_DOCKER=1` to run
+that step inside a locally-built `lint` image instead, for an exact CI-lint
+reproduction (catches an environment-only lint difference the host-native run
+cannot see).

--- a/dev/Dockerfile.test
+++ b/dev/Dockerfile.test
@@ -32,3 +32,31 @@ ENV UV_PROJECT_ENVIRONMENT=/home/testuser/venv \
     UV_PYTHON_INSTALL_DIR=/home/testuser/.local/uv-python
 COPY --chown=testuser:testuser pyproject.toml uv.lock ./
 RUN uv sync --locked --no-install-project --group shard -p 3.13
+
+# ============================================================
+# `lint` stage — bakes prek's per-hook environments (node/go/python
+# toolchains, one per pinned repo+rev in .pre-commit-config.yaml) into the
+# image so CI's `lint` job pulls a ready image instead of cold-installing every
+# hook env at `prek run` time — that cold install (~74s) was the bulk of the
+# bare-runner lint job's ~161s prek step (souliane/teatree CI-speedup).
+# PREK_HOME lives OUTSIDE /app (same trick as UV_PROJECT_ENVIRONMENT above) so
+# the lint job's `-v "$PWD":/app` bind mount can never shadow the baked envs.
+# `install-hooks` needs a real git repo, so a throwaway one is init'd here and
+# removed after baking — it is never the checkout the lint job actually lints
+# (that comes from the bind mount at runtime). `safe.directory /app` is baked
+# because the lint job bind-mounts the HOST checkout (owned by the runner's
+# uid) into this image's `testuser` (a different uid); without it every hook
+# that shells out to git (banned-terms, blueprint-sync, gate-relaxation, the
+# `no-commit-on-merged-branch` safety hooks, …) hits git's dubious-ownership
+# refusal. This stage is tagged on a WIDER key than the `-test` tag above
+# (`hash(dev/Dockerfile.test, uv.lock, .pre-commit-config.yaml)`) so a hook-rev
+# bump alone mints a fresh tag — baked envs can never silently go stale. A tag
+# MISS just degrades gracefully: prek cold-installs whichever repo changed.
+# ============================================================
+FROM base AS lint
+ENV PREK_HOME=/home/testuser/.prek
+COPY --chown=testuser:testuser .pre-commit-config.yaml ./
+RUN git init -q . && \
+    git config --global --add safe.directory /app && \
+    uv run --no-sync prek install-hooks && \
+    rm -rf .git

--- a/dev/ci-parity.sh
+++ b/dev/ci-parity.sh
@@ -17,10 +17,25 @@ cd "$(dirname "$0")/.."
 # else runs exactly as CI's `lint` job does. Override with SKIP=... if needed.
 export SKIP="${SKIP:-uv-audit,cyclonedx-sbom}"
 
-echo "=== [1/5] prek (all hooks, all files) -- CI lint job ==="
-# `uv run` so the prek RUNNER is the lockfile-pinned version (prek==0.3.13), the
-# exact one CI's lint job runs — not whatever standalone prek is on PATH (#3236).
-uv run prek run --all-files
+if [ "${LINT_DOCKER:-0}" = "1" ]; then
+  echo "=== [1/5] prek (all hooks, all files) -- CI lint job, IN DOCKER (LINT_DOCKER=1) ==="
+  # Exact CI-lint reproduction: build the same `lint` Dockerfile stage CI's
+  # `build-image` job bakes (prek's hook environments pre-installed) and run
+  # the identical `prek run --all-files` inside it, bind-mounting the working
+  # tree the same way the CI `lint` job does. Builds locally rather than
+  # pulling the ghcr-pushed tag, so this stays a zero-setup opt-in (no
+  # registry auth needed) — a genuine environment-only lint difference (a
+  # baked hook env vs whatever `uv run prek` resolves on the host) surfaces
+  # here that the plain host-native invocation below can never catch.
+  docker build -q -f dev/Dockerfile.test --target lint -t teatree-lint-local . >/dev/null
+  docker run --rm -v "$PWD":/app -e SKIP -e T3_BANNED_TERMS -e TEATREE_TERM_REGISTRY teatree-lint-local \
+    bash -c "uv run prek run --all-files"
+else
+  echo "=== [1/5] prek (all hooks, all files) -- CI lint job ==="
+  # `uv run` so the prek RUNNER is the lockfile-pinned version (prek==0.3.13), the
+  # exact one CI's lint job runs — not whatever standalone prek is on PATH (#3236).
+  uv run prek run --all-files
+fi
 
 echo "=== [2/5] makemigrations --check --dry-run -- migration-graph linearity ==="
 uv run python manage.py makemigrations --check --dry-run

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -9,6 +9,10 @@ x-base: &base
   build:
     context: ..
     dockerfile: dev/Dockerfile.test
+    # The Dockerfile is multi-stage (a `lint` stage bakes prek's hook envs FROM
+    # base); pin the target explicitly so an untargeted build never silently
+    # produces the LAST stage instead.
+    target: base
   volumes:
     - ..:/app:ro
   environment:

--- a/dev/test-matrix.sh
+++ b/dev/test-matrix.sh
@@ -20,10 +20,13 @@ fi
 total=${#versions[@]}
 current=0
 
-# Build (or reuse cached) test image
+# Build (or reuse cached) test image. --target base: the Dockerfile is
+# multi-stage (a `lint` stage bakes prek's hook envs FROM base), so the target
+# must be pinned explicitly — an untargeted build would silently produce the
+# LAST stage instead.
 if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
     echo "=== Building test image (first run only) ==="
-    docker build -q -t "$IMAGE" -f dev/Dockerfile.test . >/dev/null
+    docker build -q -t "$IMAGE" -f dev/Dockerfile.test --target base . >/dev/null
     echo
 fi
 

--- a/src/teatree/cli/eval/docker.py
+++ b/src/teatree/cli/eval/docker.py
@@ -116,7 +116,12 @@ def _build_image(root: Path) -> int:
     # No ``-q``: a quiet build emits NOTHING until it finishes, so a slow/hung
     # image build is indistinguishable from a wedged runner. Streaming the build
     # log makes the build's progress (and any stall) visible in the CI log.
-    return run_streamed(["docker", "build", "-t", DOCKER_IMAGE, "-f", _DOCKERFILE, "."], cwd=root, check=False)
+    # ``--target base``: the Dockerfile is multi-stage (a ``lint`` stage bakes
+    # prek's hook envs FROM base), so the target must be pinned explicitly — an
+    # untargeted build would silently produce the LAST stage instead.
+    return run_streamed(
+        ["docker", "build", "-t", DOCKER_IMAGE, "-f", _DOCKERFILE, "--target", "base", "."], cwd=root, check=False
+    )
 
 
 def _artifacts_mount_flags(artifacts_dir: Path | None) -> list[str]:


### PR DESCRIPTION
## Summary

CI-speedup follow-up (B1/B2/B3 in the CI-speedup initiative): the `lint` job ran bare on the runner while `test-shard` already pulls a prebuilt, deps-baked ghcr image. This converges `lint` onto the same Docker-image pattern.

- **`dev/Dockerfile.test`**: adds a `lint` stage (`FROM base`) that bakes prek's per-hook environments via `prek install-hooks` (node/go/python toolchains, including gitleaks' Go toolchain). `PREK_HOME` lives outside `/app` (same trick as `UV_PROJECT_ENVIRONMENT`) so the runtime bind mount can't shadow it, and `git config --global --add safe.directory /app` is baked in so git-invoking hooks work against the bind-mounted checkout.
- **`build-image`**: now unconditional (dropped the `needs: preflight` / diff-gating), and builds/pushes a second `-lint:${KEY}` tag alongside the existing `-test:${KEY}` tag. The lint tag's key is widened to `hashFiles(dev/Dockerfile.test, uv.lock, .pre-commit-config.yaml)` so a hook-rev bump alone mints a fresh tag — baked envs can never silently go stale; a miss just degrades to prek cold-installing the one changed repo.
- **`lint` job**: pulls the prebuilt `-lint` image (or builds it in-job for fork PRs, matching `test-shard`'s `mode=local` pattern) and runs the exact same `uv run prek run --all-files` + `makemigrations --check --dry-run` inside `docker run`, with the same `SKIP` list and secrets. Venue-only change — no hook set, `SKIP` list, or gate semantics moved (`check_gate_relaxation.py` / `check_quality_gates.py` untouched).
- Every other bare `docker build -f dev/Dockerfile.test` call site (`test-shard`'s fork fallback, `dev/test-matrix.sh`, `dev/docker-compose.yml`, the eval docker runner in `src/teatree/cli/eval/docker.py`) now pins `--target base` explicitly, since the Dockerfile became multi-stage and an untargeted build would otherwise silently produce the new `lint` stage instead of the test image.
- **`dev/ci-parity.sh`**: optional `LINT_DOCKER=1` runs step 1 inside a locally-built `lint` image for an exact CI-lint reproduction; unset stays host-native (local git hooks stay native, as designed — this only converges CI's venue).

Local hooks are intentionally left native (container-per-commit is exactly the friction the push-gate design rejects, and prek's locked version already keeps local/CI in parity per #3236) — this PR touches only `lint` + `build-image`/`Dockerfile.test`.

Root cause taken: the **baked-image** approach (not the `actions/cache` fallback) — `prek install-hooks` baked cleanly in a local `docker build --target lint` (gitleaks' Go toolchain, semgrep, ast-grep, node hooks all installed fine; no blocker hit).

## Verification performed locally

- `docker build -f dev/Dockerfile.test --target lint .` succeeds (bakes hook envs, ~5GB image, confirmed with `PREK_HOME` and `safe.directory` present via `docker run --rm <image> ...` with no bind mount).
- A full `docker run --rm -v "$PWD":/app ... uv run prek run --all-files` against a standalone checkout (mimicking `actions/checkout`'s detached-HEAD, self-contained `.git`) passes every hook, with **no cold hook-env installs** at run time (envs already baked).
- `--target base` still builds correctly and runs correctly with the bind mount (verified both un-mounted, confirming no `lint`-stage leakage into `base`, and mounted).
- The new `LINT_DOCKER=1` path in `dev/ci-parity.sh` verified end-to-end (build + run) against a self-contained snapshot of the current diff.
- `uv run prek run --all-files` (host) and `manage.py makemigrations --check --dry-run` pass clean against this diff — including the anti-relaxation gate (`check_gate_relaxation.py`) and the quality-gates commit-msg hook, checked manually since this worktree's git hooks weren't installed.
- Targeted pytest: `tests/test_ci_diff_scoped_lanes.py`, `tests/test_changed_lanes_classifier.py`, `tests/teatree_cli/test_eval_docker.py`, `tests/test_ci_gates_fail_loud.py`, `tests/test_ci_tree_gates_run_on_prs.py`, `tests/test_ci_concurrency.py`, `tests/test_repo_root_minimal.py` — 111 passed, none touched.
- ci.yml YAML re-parsed and job wiring (`needs`/`if`/`outputs`) spot-checked programmatically.

CI's own `lint` job run on this PR is the real before/after timing comparison (bare-runner baseline was ~178s job / ~161s prek step per the CI-speedup measurements; this PR should land close to `test-shard`'s pull-cost floor, ~23s, on subsequent runs once the `-lint` tag is cached).

## Test plan

- [x] Local `docker build --target lint` + `docker run` verification (see above)
- [x] Local `docker build --target base` regression check (other Dockerfile consumers)
- [x] `dev/ci-parity.sh LINT_DOCKER=1` end-to-end verification
- [x] Targeted pytest suite (111 tests, all green)
- [ ] CI green on this PR, including the `lint` job itself (self-hosting check) and the unaffected gates (coverage floor, mutation lanes, security/quality gates) confirming no collateral change