### PR TITLE
fix(cleanup): worktree dirt probe now truly fails closed on git errors

### DIFF
--- a/src/teatree/core/cleanup/working_tree_dirt.py
+++ b/src/teatree/core/cleanup/working_tree_dirt.py
@@ -75,7 +75,7 @@ def real_uncommitted_reasons(wt_path: str, target: "_EffectiveTarget") -> list[s
     if not git.check(repo=wt_path, args=["rev-parse", "--verify", "--quiet", "HEAD"]):
         return _dangling_head_dirty_reasons(wt_path, target)
     try:
-        porcelain = git.status_porcelain(wt_path)
+        porcelain = git.status_porcelain_strict(wt_path)
     except CommandFailedError as exc:
         return [f"could not read working-tree status ({exc}) — keeping"]
     dirty = [
@@ -101,8 +101,8 @@ def _dangling_head_dirty_reasons(wt_path: str, target: "_EffectiveTarget") -> li
     if sha is None:
         return ["could not recover HEAD to check working-tree changes — keeping"]
     try:
-        changed = git.run(repo=wt_path, args=["diff", "--name-only", sha])
-        untracked = git.run(repo=wt_path, args=["ls-files", "--others", "--exclude-standard"])
+        changed = git.run_strict(repo=wt_path, args=["diff", "--name-only", sha])
+        untracked = git.run_strict(repo=wt_path, args=["ls-files", "--others", "--exclude-standard"])
     except CommandFailedError as exc:
         return [f"could not diff working tree against recovered HEAD ({exc}) — keeping"]
     dirty = [

--- a/tests/teatree_core/cleanup/test_working_tree_dirt.py
+++ b/tests/teatree_core/cleanup/test_working_tree_dirt.py
@@ -10,6 +10,7 @@ Happy paths run against real git under ``tmp_path``; the fail-closed error
 branches inject a ``CommandFailedError`` from the (unstoppable) git subprocess.
 """
 
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -19,6 +20,26 @@ from teatree.core.cleanup.working_tree_dirt import real_uncommitted_reasons
 from teatree.utils import git
 from teatree.utils.run import CommandFailedError
 from tests.teatree_core.cleanup._shared import _run_git
+
+
+def _corrupt_index(wt_dir: Path) -> None:
+    """Corrupt the real on-disk index for a worktree so ``git status`` itself fails.
+
+    A ``git worktree add`` checkout's ``.git`` is a *file* (a gitdir pointer),
+    not a directory, and each worktree has its own per-worktree index living
+    under the main repo's ``.git/worktrees/<name>/index`` — not
+    ``<wt_dir>/.git/index``. Resolve the real git-dir via ``rev-parse`` first.
+    """
+    result = subprocess.run(
+        ["git", "-C", str(wt_dir), "rev-parse", "--git-dir"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    git_dir = Path(result.stdout.strip())
+    if not git_dir.is_absolute():
+        git_dir = wt_dir / git_dir
+    (git_dir / "index").write_bytes(b"not a real git index")
 
 
 def _committed_worktree(tmp_path: Path) -> tuple[Path, _EffectiveTarget]:
@@ -90,7 +111,7 @@ class TestRealUncommittedReasons:
         boom = CommandFailedError(["git", "status"], 1, "", "index locked")
         with (
             patch("teatree.core.cleanup.working_tree_dirt.git.check", return_value=True),
-            patch("teatree.core.cleanup.working_tree_dirt.git.status_porcelain", side_effect=boom),
+            patch("teatree.core.cleanup.working_tree_dirt.git.status_porcelain_strict", side_effect=boom),
         ):
             reasons = real_uncommitted_reasons(str(wt_dir), target)
         assert reasons == [f"could not read working-tree status ({boom}) — keeping"]
@@ -99,11 +120,30 @@ class TestRealUncommittedReasons:
         wt_dir, target = _committed_worktree(tmp_path)
         with (
             patch("teatree.core.cleanup.working_tree_dirt.git.check", return_value=True),
-            patch("teatree.core.cleanup.working_tree_dirt.git.status_porcelain", return_value="\n M real.py"),
+            patch("teatree.core.cleanup.working_tree_dirt.git.status_porcelain_strict", return_value="\n M real.py"),
         ):
             reasons = real_uncommitted_reasons(str(wt_dir), target)
         assert len(reasons) == 1
         assert "real.py" in reasons[0]
+
+    def test_real_corrupt_index_fails_closed_not_clean(self, tmp_path: Path) -> None:
+        """A REAL (unmocked) git failure must be treated as dirty, not clean.
+
+        Regression for a bug where the probe called the lenient
+        :func:`teatree.utils.git.status_porcelain`, which swallows a non-zero
+        ``git status`` exit and returns whatever (possibly empty) stdout it got —
+        so a genuine read failure (corrupt index, lock contention) was
+        indistinguishable from a clean tree, and the reaper could wipe a
+        worktree it could not actually prove was safe to wipe. This test
+        corrupts the on-disk index directly (no mocking) so the underlying
+        ``git status --porcelain`` subprocess itself fails, the way it would
+        under real lock contention or disk corruption.
+        """
+        wt_dir, target = _committed_worktree(tmp_path)
+        _corrupt_index(wt_dir)
+        reasons = real_uncommitted_reasons(str(wt_dir), target)
+        assert reasons != []
+        assert "keeping" in reasons[0]
 
     def test_truncates_preview_beyond_limit(self, tmp_path: Path) -> None:
         wt_dir, target = _committed_worktree(tmp_path)
@@ -142,8 +182,21 @@ class TestDanglingHeadDirtReasons:
         with (
             patch("teatree.core.cleanup.working_tree_dirt.classify_orphan_ref", return_value=recovered),
             patch("teatree.core.cleanup.working_tree_dirt.git.check", return_value=False),
-            patch("teatree.core.cleanup.working_tree_dirt.git.run", side_effect=boom) as mock_run,
+            patch("teatree.core.cleanup.working_tree_dirt.git.run_strict", side_effect=boom) as mock_run,
         ):
             reasons = real_uncommitted_reasons(str(wt_dir), target)
         assert reasons == [f"could not diff working tree against recovered HEAD ({boom}) — keeping"]
         assert mock_run.called
+
+    def test_real_corrupt_index_fails_closed_for_dangling_head(self, tmp_path: Path) -> None:
+        """A REAL (unmocked) diff/ls-files failure on the dangling-HEAD path must fail closed too.
+
+        Same regression as the resolvable-HEAD case above, for the sibling
+        lenient calls (``git.run`` for ``diff``/``ls-files``) that also needed
+        to move to :func:`teatree.utils.git.run_strict`.
+        """
+        wt_dir, target = _dangling_head_worktree(tmp_path)
+        _corrupt_index(wt_dir)
+        reasons = real_uncommitted_reasons(str(wt_dir), target)
+        assert reasons != []
+        assert "keeping" in reasons[0]

--- a/tests/teatree_core/cleanup/test_working_tree_dirt.py
+++ b/tests/teatree_core/cleanup/test_working_tree_dirt.py
@@ -19,7 +19,7 @@ from teatree.core.cleanup.cleanup_orphan_ref import OrphanRefDecision
 from teatree.core.cleanup.working_tree_dirt import real_uncommitted_reasons
 from teatree.utils import git
 from teatree.utils.run import CommandFailedError
-from tests.teatree_core.cleanup._shared import _run_git
+from tests.teatree_core.cleanup._shared import _GIT, _run_git
 
 
 def _corrupt_index(wt_dir: Path) -> None:
@@ -31,7 +31,7 @@ def _corrupt_index(wt_dir: Path) -> None:
     ``<wt_dir>/.git/index``. Resolve the real git-dir via ``rev-parse`` first.
     """
     result = subprocess.run(
-        ["git", "-C", str(wt_dir), "rev-parse", "--git-dir"],
+        [_GIT, "-C", str(wt_dir), "rev-parse", "--git-dir"],
         check=True,
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary

Fixes a critical gap surfaced by independent cold review of #3321 (already merged): the new "fail-closed" dirty-worktree probe in `working_tree_dirt.py` documented (and tested via mocks) a fail-closed guarantee it did not actually have.

`real_uncommitted_reasons()` called the lenient `git.status_porcelain` / `git.run`, which swallow a non-zero git exit and return whatever (possibly empty) stdout they got. A genuine read failure -- corrupt index, lock contention, disk I/O error -- was therefore indistinguishable from a genuinely clean tree. On the unattended teardown path (`respect_liveness=False`), this probe is the *sole* remaining guard against wiping live/uncommitted work -- exactly the failure class this box has hit before (see `never-destructive-cleanup` / `clean-all-rowless-reaper-bug`).

## Fix

Switch both call sites to the `*_strict` variants (`status_porcelain_strict`, `run_strict`), which raise `CommandFailedError` on a non-zero exit -- so the existing `except CommandFailedError` handlers, which already correctly return a "keeping" dirty-reason, actually fire.

## Tests

- Repointed the two existing mocked fail-closed tests at the now-actually-called strict functions (they previously mocked the unused lenient functions, so they passed regardless of whether the real bug existed -- false confidence).
- Added two new integration tests that corrupt a *real* on-disk index (not mocked, following this repo's real-git-under-tmp_path doctrine) to reproduce the actual subprocess failure mode and prove the fix against it, for both the resolvable-HEAD and dangling-HEAD code paths.
- Confirmed green with the fix; the corrupted-index tests are deductively certain to fail against the pre-fix code (the lenient functions return `""` on failure, yielding `dirty=[]`, so `reasons=[]` -- contradicting `assert reasons != []`).

## Review chain

Found by an independent cold review of #3321 dispatched this session (identity `cold-reviewer/pr3321-20260717`) -- verdict HOLD on the already-merged PR, recommending an urgent fast-follow fix rather than a revert (the rest of #3321 is a substantial net improvement). This PR is that fast-follow. Needs an independent cold review before merge (maker != checker) -- flagging as top-priority in the handover for whoever picks this up next, given the box is being retired for a machine upgrade and no further agents are being dispatched this session.