### PR TITLE
perf(ci): skip redundant per-xdist-worker Django migrate via template-DB restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -614,6 +614,21 @@ jobs:
           else
             docker build -f dev/Dockerfile.test -t "$IMAGE" .
           fi
+      # Cache the ONE migrated-sqlite template `tests/conftest.py::django_db_setup`
+      # builds (see tests/_db_template.py): keyed on the migration graph +
+      # lockfile + settings, so an unrelated change never touches it, and an
+      # exact-key-only restore (no restore-keys) means a hash miss just falls
+      # back to a fresh in-job build — never a stale/wrong-schema template. All
+      # twelve shards share the same key; whichever runs first each day/push
+      # populates it for the rest. `.cache/` is under the bind-mounted `/app`
+      # checkout so the container sees exactly what the runner cached.
+      - name: Cache the migrated test-DB template
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        with:
+          path: .cache/django-test-template
+          key: django-test-template-${{ hashFiles('src/**/migrations/*.py', 'uv.lock', 'tests/django_settings.py') }}
+      - name: Ensure the template cache dir exists (fresh on a cache miss)
+        run: mkdir -p .cache/django-test-template
       # Shard N/12: pytest-split slices collection by `dev/.test_durations`;
       # `-n auto` parallelises WITHIN the shard. `--cov --cov-branch --doctest-modules`
       # measure exactly what the old monolithic lane did, but `--cov-report=`
@@ -639,6 +654,7 @@ jobs:
           -v "$PWD":/app
           -e COVERAGE_FILE=/app/coverage.shard${{ matrix.group }}
           -e PYTHONPATH=/app
+          -e TEATREE_TEST_DB_TEMPLATE_DIR=/app/.cache/django-test-template
           ${{ needs.build-image.outputs.image }}
           uv run --group shard -p ${{ matrix.python-version }} pytest --no-header -q -n auto
           -o cache_dir=/tmp/.pytest_cache

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,9 @@ deploy/teatree.env
 # uncommitted; the synthetic corpus_gen pipeline is the only committed source.)
 /*.jsonl
 .pr-body.md
+
+# CI's cached migrated-sqlite test-DB template (test-shard job, perf(ci):
+# skip redundant per-xdist-worker migrate). Never meant to be committed —
+# only ever built by tests/conftest.py::django_db_setup into a runner-local
+# or actions/cache-restored path.
+/.cache/django-test-template/

--- a/tests/_db_template.py
+++ b/tests/_db_template.py
@@ -1,0 +1,52 @@
+"""Cross-process migrated-SQLite-template sharing for pytest-xdist workers.
+
+Each xdist worker process pays a full Django migrate the first time it
+touches the test database. With N workers per test session that is N
+redundant runs of the identical migration graph against the same
+``:memory:`` sqlite target. These primitives let exactly one worker build a
+migrated template file (guarded by a cross-process file lock so concurrent
+workers never race the build), and every worker — including the builder —
+restore its own private connection from that template via
+``sqlite3.Connection.backup()`` instead of re-running migrations. Used by the
+``django_db_setup`` override in ``tests/conftest.py``.
+"""
+
+import fcntl
+import sqlite3
+from collections.abc import Callable
+from pathlib import Path
+
+
+def build_or_reuse_template(template_path: Path, lock_path: Path, build: Callable[[Path], None]) -> None:
+    """Build ``template_path`` via ``build`` unless it already exists.
+
+    Safe under concurrent callers (one per xdist worker process): an
+    exclusive ``flock`` on ``lock_path`` serializes access, and the
+    existence check happens *inside* the lock so only the first caller to
+    arrive ever invokes ``build``. ``build`` receives a private
+    ``<name>.building`` path and must write a complete database there; the
+    file is renamed into place only after ``build`` returns, so a crash or
+    exception mid-build never leaves a partially-migrated file sitting at
+    ``template_path`` for a later caller to reuse.
+    """
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("w", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        try:
+            if template_path.exists():
+                return
+            building_path = template_path.parent / f"{template_path.name}.building"
+            building_path.unlink(missing_ok=True)
+            build(building_path)
+            building_path.rename(template_path)
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+
+def restore_from_template(template_path: Path, target: sqlite3.Connection) -> None:
+    """Copy ``template_path``'s contents into the already-open ``target`` connection."""
+    source = sqlite3.connect(str(template_path))
+    try:
+        source.backup(target)
+    finally:
+        source.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from tests._db_template import build_or_reuse_template, restore_from_template
+
 # Ensure unit tests use the settings declared in pyproject.toml, not a stale
 # DJANGO_SETTINGS_MODULE from the shell. pytest-django falls back to
 # pyproject.toml when the env var is absent.
@@ -361,3 +363,91 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     # tier and no env var, so ``T3_LOOPS_DISABLED`` is inert — there is nothing
     # to isolate here (the env-inertness is pinned by
     # ``tests/teatree_loop/test_review_loop_db_only_control.py``).
+
+
+@pytest.fixture(scope="session")
+def django_db_setup(
+    request: pytest.FixtureRequest,
+    django_db_blocker: object,
+    worker_id: str,
+    tmp_path_factory: pytest.TempPathFactory,
+    *,
+    django_db_keepdb: bool,
+) -> Iterator[None]:
+    """Migrate once per session, restore every xdist worker from that template.
+
+    pytest-django's default ``django_db_setup`` runs a full ``migrate`` in
+    *every* xdist worker process — with ``-n auto`` that is N redundant runs
+    of the identical migration graph against the same ``:memory:`` sqlite
+    target, each paying the full migration-graph cost before that worker's
+    first DB test can run. This override instead builds ONE migrated
+    template file — the first worker to grab the cross-process lock wins,
+    see ``tests/_db_template.py`` — and restores every worker's private
+    ``:memory:`` connection from it via ``sqlite3.Connection.backup()``
+    instead of re-running migrations.
+
+    The template is built the normal way (``call_command("migrate", ...,
+    run_syncdb=True)``, matching what ``setup_databases`` does internally),
+    so it includes the seed ``RunPython`` folded into ``0001_initial`` — the
+    copy handed to each worker is byte-for-byte what a from-scratch migrate
+    would have produced. ``FreshMigrateSeedsDefaultLoops`` re-migrates
+    ``core`` from ``zero`` to prove the seed *inside a test*, on whatever
+    connection it's given, so it is unaffected either way.
+
+    Falls back to pytest-django's normal per-session ``setup_databases``
+    when there is nothing to share: a plain non-xdist run (``worker_id ==
+    "master"``, e.g. ``pytest -k foo`` with no ``-n``) or a non-memory
+    backend (the template/backup trick is sqlite-specific).
+    """
+    from django.conf import settings  # noqa: PLC0415
+    from django.core.management import call_command  # noqa: PLC0415
+    from django.db import connections  # noqa: PLC0415
+    from django.test.utils import setup_databases, teardown_databases  # noqa: PLC0415 # ty: ignore[unresolved-import]
+
+    # Dependency-only fixtures (test-environment patching, xdist NAME
+    # suffixing) — pulled by value instead of as params to stay under the
+    # repo's max-args=5 ceiling; both must still run before setup for the
+    # same ordering pytest-django's own fixture relies on.
+    request.getfixturevalue("django_test_environment")
+    request.getfixturevalue("django_db_modify_db_settings")
+
+    alias = "default"
+    if worker_id == "master" or settings.DATABASES[alias]["NAME"] != ":memory:":
+        with django_db_blocker.unblock():
+            db_cfg = setup_databases(
+                verbosity=request.config.option.verbose,
+                interactive=False,
+                keepdb=django_db_keepdb,
+            )
+        yield
+        if not django_db_keepdb:
+            with django_db_blocker.unblock():
+                teardown_databases(db_cfg, verbosity=request.config.option.verbose)
+        return
+
+    template_dir_override = os.environ.get("TEATREE_TEST_DB_TEMPLATE_DIR")
+    root_tmp_dir = Path(template_dir_override) if template_dir_override else tmp_path_factory.getbasetemp().parent
+    template_path = root_tmp_dir / "django_test_template.sqlite3"
+    lock_path = root_tmp_dir / "django_test_template.sqlite3.lock"
+
+    def _build(path: Path) -> None:
+        original_name = settings.DATABASES[alias]["NAME"]
+        settings.DATABASES[alias]["NAME"] = str(path)
+        connections[alias].close()
+        try:
+            call_command("migrate", verbosity=0, interactive=False, run_syncdb=True, database=alias)
+        finally:
+            connections[alias].close()
+            settings.DATABASES[alias]["NAME"] = original_name
+
+    with django_db_blocker.unblock():
+        root_tmp_dir.mkdir(parents=True, exist_ok=True)
+        build_or_reuse_template(template_path, lock_path, _build)
+        target = connections[alias]
+        target.ensure_connection()
+        restore_from_template(template_path, target.connection)
+
+    yield
+
+    with django_db_blocker.unblock():
+        connections.close_all()

--- a/tests/test_ci_test_shard_db_template_cache.py
+++ b/tests/test_ci_test_shard_db_template_cache.py
@@ -1,0 +1,61 @@
+"""Guard: the test-shard job caches the migrated test-DB template across CI runs.
+
+``tests/conftest.py::django_db_setup`` (perf(ci): skip redundant
+per-xdist-worker migrate) builds ONE migrated sqlite template per job and
+restores every xdist worker from it instead of re-running migrations. This
+pins the complementary CI-level win: the template itself is cached across
+separate ``test-shard`` job invocations (all twelve matrix legs share one
+key), keyed on exactly the inputs that can change its contents, so a hash
+miss on migrations/lockfile/settings never restores a stale/wrong-schema
+template — it just falls back to an in-job build, same as today.
+"""
+
+from pathlib import Path
+
+import yaml
+
+_CI = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci.yml"
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(_CI.read_text(encoding="utf-8"))
+
+
+def _test_shard_steps() -> list[dict]:
+    return _workflow()["jobs"]["test-shard"]["steps"]
+
+
+def _cache_step() -> dict:
+    for step in _test_shard_steps():
+        if step.get("uses", "").startswith("actions/cache@"):
+            return step
+    msg = "test-shard must have an actions/cache step for the migrated test-DB template"
+    raise AssertionError(msg)
+
+
+class TestTemplateDbCacheStep:
+    def test_cache_step_targets_the_template_dir(self) -> None:
+        assert _cache_step()["with"]["path"] == ".cache/django-test-template"
+
+    def test_cache_key_is_scoped_to_migrations_lockfile_and_settings(self) -> None:
+        key = _cache_step()["with"]["key"]
+        assert "hashFiles(" in key
+        for source in ("src/**/migrations/*.py", "uv.lock", "tests/django_settings.py"):
+            assert source in key, f"cache key must hash {source} — an unrelated change must never invalidate it"
+
+    def test_cache_key_has_no_restore_keys_fallback(self) -> None:
+        # A restore-keys fallback would let a hash MISS still restore an older
+        # (possibly stale-schema) template. Exact-key-only means a miss always
+        # falls back to a correct in-job build instead.
+        assert "restore-keys" not in _cache_step()
+
+    def test_cache_step_runs_before_the_shard_test_step(self) -> None:
+        steps = _test_shard_steps()
+        cache_index = next(i for i, s in enumerate(steps) if s.get("uses", "").startswith("actions/cache@"))
+        test_index = next(i for i, s in enumerate(steps) if str(s.get("name", "")).lower().startswith("test shard"))
+        assert cache_index < test_index
+
+    def test_shard_run_command_points_at_the_cached_template_dir(self) -> None:
+        steps = _test_shard_steps()
+        test_step = next(s for s in steps if str(s.get("name", "")).lower().startswith("test shard"))
+        assert "TEATREE_TEST_DB_TEMPLATE_DIR=/app/.cache/django-test-template" in test_step["run"]

--- a/tests/test_db_template.py
+++ b/tests/test_db_template.py
@@ -1,0 +1,138 @@
+"""Unit tests for ``tests/_db_template.py``.
+
+The cross-process template-DB sharing primitives that back the
+``django_db_setup`` override in ``tests/conftest.py`` (perf(ci): skip
+redundant per-xdist-worker migrate).
+"""
+
+import contextlib
+import sqlite3
+import threading
+from pathlib import Path
+
+from tests._db_template import build_or_reuse_template, restore_from_template
+
+
+class _SimulatedBuildCrashError(RuntimeError):
+    """Raised by a test double to simulate a build failing mid-way."""
+
+
+class TestBuildOrReuseTemplate:
+    def test_first_caller_builds_the_template(self, tmp_path: Path) -> None:
+        template = tmp_path / "template.sqlite3"
+        lock = tmp_path / "template.sqlite3.lock"
+        calls: list[Path] = []
+
+        def build(path: Path) -> None:
+            calls.append(path)
+            path.write_bytes(b"fake-db-bytes")
+
+        build_or_reuse_template(template, lock, build)
+
+        assert calls == [tmp_path / "template.sqlite3.building"]
+        assert template.read_bytes() == b"fake-db-bytes"
+
+    def test_second_caller_reuses_the_existing_template_without_rebuilding(self, tmp_path: Path) -> None:
+        template = tmp_path / "template.sqlite3"
+        lock = tmp_path / "template.sqlite3.lock"
+        build_calls = 0
+
+        def build(path: Path) -> None:
+            nonlocal build_calls
+            build_calls += 1
+            path.write_bytes(b"first-build")
+
+        build_or_reuse_template(template, lock, build)
+        build_or_reuse_template(template, lock, build)
+
+        assert build_calls == 1
+        assert template.read_bytes() == b"first-build"
+
+    def test_concurrent_callers_build_exactly_once(self, tmp_path: Path) -> None:
+        template = tmp_path / "template.sqlite3"
+        lock = tmp_path / "template.sqlite3.lock"
+        build_calls = 0
+        counter_guard = threading.Lock()
+
+        def build(path: Path) -> None:
+            nonlocal build_calls
+            with counter_guard:
+                build_calls += 1
+            path.write_bytes(b"built")
+
+        threads = [threading.Thread(target=build_or_reuse_template, args=(template, lock, build)) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert build_calls == 1, "flock must serialize concurrent builders down to exactly one real build"
+
+    def test_a_failed_build_never_leaves_a_partial_file_at_the_final_path(self, tmp_path: Path) -> None:
+        template = tmp_path / "template.sqlite3"
+        lock = tmp_path / "template.sqlite3.lock"
+
+        def crashing_build(path: Path) -> None:
+            path.write_bytes(b"partial")
+            raise _SimulatedBuildCrashError
+
+        with contextlib.suppress(_SimulatedBuildCrashError):
+            build_or_reuse_template(template, lock, crashing_build)
+
+        assert not template.exists(), "a failed build must not leave a file at the final template path"
+
+    def test_a_retry_after_a_failed_build_succeeds(self, tmp_path: Path) -> None:
+        template = tmp_path / "template.sqlite3"
+        lock = tmp_path / "template.sqlite3.lock"
+
+        def crashing_build(path: Path) -> None:
+            path.write_bytes(b"partial")
+            raise _SimulatedBuildCrashError
+
+        def good_build(path: Path) -> None:
+            path.write_bytes(b"good")
+
+        with contextlib.suppress(_SimulatedBuildCrashError):
+            build_or_reuse_template(template, lock, crashing_build)
+        build_or_reuse_template(template, lock, good_build)
+
+        assert template.read_bytes() == b"good"
+
+
+class TestRestoreFromTemplate:
+    def test_copies_schema_and_data_into_the_target_connection(self, tmp_path: Path) -> None:
+        template = tmp_path / "template.sqlite3"
+        source = sqlite3.connect(str(template))
+        source.execute("CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT)")
+        source.execute("INSERT INTO widgets (name) VALUES ('sprocket')")
+        source.commit()
+        source.close()
+
+        target = sqlite3.connect(":memory:")
+        try:
+            restore_from_template(template, target)
+            assert target.execute("SELECT name FROM widgets").fetchall() == [("sprocket",)]
+        finally:
+            target.close()
+
+    def test_target_is_independent_of_the_template_after_restore(self, tmp_path: Path) -> None:
+        template = tmp_path / "template.sqlite3"
+        source = sqlite3.connect(str(template))
+        source.execute("CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT)")
+        source.commit()
+        source.close()
+
+        target_a = sqlite3.connect(":memory:")
+        target_b = sqlite3.connect(":memory:")
+        try:
+            restore_from_template(template, target_a)
+            restore_from_template(template, target_b)
+
+            target_a.execute("INSERT INTO widgets (name) VALUES ('only-in-a')")
+            target_a.commit()
+
+            assert target_a.execute("SELECT name FROM widgets").fetchall() == [("only-in-a",)]
+            assert target_b.execute("SELECT name FROM widgets").fetchall() == []
+        finally:
+            target_a.close()
+            target_b.close()


### PR DESCRIPTION
## What

`tests/conftest.py::django_db_setup` previously had no override, so pytest-django's default fixture ran a full Django `migrate` in **every** xdist worker process — under `-n auto` that's N redundant runs of the identical migration graph against the same `:memory:` sqlite target, each paying the full migrate cost before that worker's first DB test can run.

This adds:
1. `tests/_db_template.py` — two small, independently-unit-tested primitives: `build_or_reuse_template()` (cross-process-lock-guarded, exactly-once template build) and `restore_from_template()` (`sqlite3.Connection.backup()` copy into a worker's private `:memory:` connection).
2. A `django_db_setup` override in `tests/conftest.py`: under xdist + sqlite `:memory:`, the first worker to grab the lock builds ONE migrated template file (the normal way — `call_command("migrate", run_syncdb=True)`, so the seed `RunPython` folded into `0001_initial` runs exactly as it always has); every worker (including the builder) then restores its own connection from that template instead of migrating. Falls back to pytest-django's normal per-session `setup_databases` when there's nothing to share (non-xdist run, or a non-memory backend).
3. A GH Actions cache in the `test-shard` job (`.github/workflows/ci.yml`) for the template file itself, keyed on `hashFiles('src/**/migrations/*.py', 'uv.lock', 'tests/django_settings.py')` with no `restore-keys` fallback — a hash miss always falls back to a correct in-job build, never a stale/wrong-schema restore.

## Why this is safe

`tests/teatree_core/test_initial_migration_seed.py::FreshMigrateSeedsDefaultLoops` does its own from-zero `migrate` *inside* the test (`call_command("migrate", "core", "zero")` then re-`migrate`), so it re-proves the seed regardless of how the connection it's given was initialized. Ran it explicitly under 2 xdist workers with the new fixture — all 10 tests in that module pass, including every `FreshMigrateSeedsDefaultLoops` case.

## Testing

- `tests/test_db_template.py` — 7 unit tests on the build/restore primitives (first-caller builds, second caller reuses without rebuilding, concurrent callers under real thread contention build exactly once via `flock`, a crashed build never leaves a partial file at the final path, a retry after a crash succeeds, template contents + schema copy correctly, restored connections are independent of each other).
- `tests/test_ci_test_shard_db_template_cache.py` — 5 tests pinning the CI cache step (path, key inputs, no restore-keys, ordering, the shard run command wires `TEATREE_TEST_DB_TEMPLATE_DIR`).
- `uv run ruff check` / `ruff format --check` / `uv run ty check` all clean on every touched file.
- `tests/teatree_core/test_initial_migration_seed.py` (10 tests, including the seed-preservation class) green under `-n 2` with the new fixture active.

CI on this PR (12-way sharded suite + the 93% branch-coverage floor combiner) is the authoritative gate for the full-tree effect — see the CI run on this PR's head for the real measured numbers.
