### PR TITLE
chore: raise Django floor to 6.0 and modernize with django-upgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,10 +55,10 @@ repos:
   # Target is the supported floor (django>=X.Y in pyproject.toml) so rewrites stay
   # compatible with every Django version the project supports.
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: 1db0cbd209d6c4dc78191593942e6269fae99e8d  # 1.30.0
+    rev: 5adcd2667f92470d6637737d60c5d3fc00105e6b  # 1.31.1
     hooks:
       - id: django-upgrade
-        args: [--target-version, "5.2"]
+        args: [--target-version, "6.0"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: fa93bc3224c614a0e9786d3e2d3d48edcca246eb  # v0.15.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   # PreToolUse hook used to treat that crash as a coverage finding (#122).
   "coverage>=7",
   "croniter>=6.2.2",
-  "django>=5.2,<6.1",
+  "django>=6,<6.1",
   "django-fsm-2>=4",
   "django-linear-migrations>=2.19",
   "django-rich>=2.2",

--- a/src/teatree/settings.py
+++ b/src/teatree/settings.py
@@ -170,7 +170,6 @@ STATIC_URL = "static/"
 # gunicorn (DEBUG off). Kept beside the canonical DB so a headless deploy writes
 # to the same operator-owned data dir it already provisions.
 STATIC_ROOT = str(_DATA_DIR / "staticfiles")
-DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 LOGGING = default_logging("teatree")
 

--- a/tests/test_django_upgrade_hook.py
+++ b/tests/test_django_upgrade_hook.py
@@ -38,13 +38,19 @@ def _django_upgrade_repo() -> dict[str, Any] | None:
 
 
 def _django_floor_version() -> str:
-    """The minimum supported Django version from the ``django>=X.Y`` pin."""
+    """The minimum supported Django version, as ``major.minor``, from the ``django>=`` pin.
+
+    ``pyproject-fmt`` strips a ``.0`` patch/minor (``django>=6.0`` is normalized to
+    ``django>=6``), so a bare-major floor is widened back to ``major.minor`` to
+    match django-upgrade's ``--target-version`` form (e.g. ``"6.0"``).
+    """
     data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
     deps: list[str] = data["project"]["dependencies"]
     django_pin = next(dep for dep in deps if re.match(r"^django\b", dep))
-    match = re.search(r">=\s*(\d+\.\d+)", django_pin)
-    assert match, f"Could not parse a '>=X.Y' floor from the Django pin: {django_pin!r}"
-    return match.group(1)
+    match = re.search(r">=\s*(\d+)(?:\.(\d+))?", django_pin)
+    assert match, f"Could not parse a '>=X[.Y]' floor from the Django pin: {django_pin!r}"
+    major, minor = match.group(1), match.group(2) or "0"
+    return f"{major}.{minor}"
 
 
 class TestDjangoUpgradeHook:

--- a/uv.lock
+++ b/uv.lock
@@ -3132,7 +3132,7 @@ requires-dist = [
     { name = "claude-agent-sdk", specifier = "==0.2.94" },
     { name = "coverage", specifier = ">=7" },
     { name = "croniter", specifier = ">=6.2.2" },
-    { name = "django", specifier = ">=5.2,<6.1" },
+    { name = "django", specifier = ">=6.0,<6.1" },
     { name = "django-fsm-2", specifier = ">=4" },
     { name = "django-linear-migrations", specifier = ">=2.19" },
     { name = "django-rich", specifier = ">=2.2" },


### PR DESCRIPTION
## Summary
- Raises the Django floor `django>=5.2,<6.1` -> `django>=6.0,<6.1` (Django is already pinned to 6.0.7 in uv.lock; this formalizes the floor now that 5.2 support is being dropped as part of the Python 3.14 migration).
- Bumps the `django-upgrade` pre-commit hook to `--target-version 6.0` (rev 1.30.0 -> 1.31.1).
- Runs a one-time whole-tree django-upgrade pass: drops the now-redundant explicit `DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"` in `src/teatree/settings.py` (BigAutoField is the Django 6.0 default; verified via `django.setup()` that the setting resolves identically without the explicit line).

This is PR1 of 4 in a Fable-planned Python 3.13->3.14 migration sequence, fully independent of the other three PRs, safe to land anytime.

## Verification done locally
- `makemigrations --check --dry-run`: no changes detected
- `ruff check` / `ruff format`: clean, no changes needed beyond the fixer's rewrite
- `ty check` on the touched file: all checks passed
- Manual settings resolution check confirming `DEFAULT_AUTO_FIELD` still resolves to `django.db.models.BigAutoField`
- `tests/teatree_core` subset run locally: 4 failures observed, all pytest-timeout (>60s) on tests unrelated to this change (`test_branch_ref_gone.py`, `test_dream.py`, `test_workspace.py`, `test_plan_currency_gate.py`) under heavy local box contention (multiple concurrent worktrees running full suites) - not related to this diff. CI (isolated runners) is the authoritative gate for the full sharded suite and coverage floor - not yet confirmed there.

## Test plan
- [ ] Full sharded CI suite green
- [ ] 93% branch-coverage floor holds
- [ ] Independent cold review (maker != checker) before merge via the sanctioned keystone