### PR TITLE
wip(chore): Django floor raise to >=6.0,<6.1 (alternate/earlier attempt)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
     rev: 1db0cbd209d6c4dc78191593942e6269fae99e8d  # 1.30.0
     hooks:
       - id: django-upgrade
-        args: [--target-version, "5.2"]
+        args: [--target-version, "6.0"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: fa93bc3224c614a0e9786d3e2d3d48edcca246eb  # v0.15.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   # PreToolUse hook used to treat that crash as a coverage finding (#122).
   "coverage>=7",
   "croniter>=6.2.2",
-  "django>=5.2,<6.1",
+  "django>=6,<6.1",
   "django-fsm-2>=4",
   "django-linear-migrations>=2.19",
   "django-rich>=2.2",

--- a/src/teatree/settings.py
+++ b/src/teatree/settings.py
@@ -170,7 +170,6 @@ STATIC_URL = "static/"
 # gunicorn (DEBUG off). Kept beside the canonical DB so a headless deploy writes
 # to the same operator-owned data dir it already provisions.
 STATIC_ROOT = str(_DATA_DIR / "staticfiles")
-DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 LOGGING = default_logging("teatree")
 

--- a/uv.lock
+++ b/uv.lock
@@ -3132,7 +3132,7 @@ requires-dist = [
     { name = "claude-agent-sdk", specifier = "==0.2.94" },
     { name = "coverage", specifier = ">=7" },
     { name = "croniter", specifier = ">=6.2.2" },
-    { name = "django", specifier = ">=5.2,<6.1" },
+    { name = "django", specifier = ">=6.0,<6.1" },
     { name = "django-fsm-2", specifier = ">=4" },
     { name = "django-linear-migrations", specifier = ">=2.19" },
     { name = "django-rich", specifier = ">=2.2" },


### PR DESCRIPTION
Preserved ahead of a permanent machine decommission (2026-07-17). Likely overlaps with #3370 (same goal, different branch) -- compare both before landing either. Per an independent agent's later report: prek run --all-files and makemigrations --check both clean, but the coverage suite was killed at ~68% under box CPU contention with one unidentified failing test around the 5-6% mark -- needs that failure triaged and the coverage run finished before this is trustworthy.