### PR TITLE
perf(tests): restructure wip subprocess-bootstrap test to share DB migration + set

### DIFF
--- a/tests/db_alias.py
+++ b/tests/db_alias.py
@@ -1,0 +1,57 @@
+"""Shared helpers for tests that migrate a private, file-backed SQLite alias.
+
+Migrates to HEAD without touching the shared ``default`` test database
+(#2915). ``tests/`` is a package and sits on ``pythonpath`` (see
+``pyproject.toml``), so both ``tests/teatree_core/conftest.py`` (not itself
+a package) and top-level test modules can import from here without
+duplicating the router or the alias register/teardown boilerplate.
+"""
+
+from pathlib import Path
+
+from django.db import connections
+
+
+class RouteAllToAlias:
+    """Force every unscoped ORM query onto ``alias`` for one migrate call (#2915).
+
+    The ``core`` ``0001_initial`` loop/prompt seed runs a ``RunPython`` that reads
+    historical models via ``apps.get_model(...).objects`` with no
+    ``.using(...)`` — Django resolves that to ``DEFAULT_DB_ALIAS`` regardless
+    of which connection the surrounding ``migrate --database`` targets.
+    Installing this as the sole ``DATABASE_ROUTERS`` entry for the migrate
+    call reroutes those unscoped reads/writes onto the private alias instead
+    of leaking onto the shared ``default`` connection.
+    """
+
+    def __init__(self, alias: str) -> None:
+        self.alias = alias
+
+    def db_for_read(self, model: type, **hints: object) -> str:
+        return self.alias
+
+    def db_for_write(self, model: type, **hints: object) -> str:
+        return self.alias
+
+
+def register_sqlite_alias(alias: str, db_file: Path) -> None:
+    """Register a private, file-backed SQLite connection under ``alias``."""
+    connections.databases[alias] = {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": str(db_file),
+        "OPTIONS": {},
+        "ATOMIC_REQUESTS": False,
+        "AUTOCOMMIT": True,
+        "CONN_MAX_AGE": 0,
+        "CONN_HEALTH_CHECKS": False,
+        "TIME_ZONE": None,
+        "TEST": {},
+    }
+
+
+def teardown_sqlite_alias(alias: str) -> None:
+    """Close and unregister a private alias registered via :func:`register_sqlite_alias`."""
+    for conn in connections.all():
+        if conn.alias == alias:
+            conn.close()
+    connections.databases.pop(alias, None)

--- a/tests/teatree_core/conftest.py
+++ b/tests/teatree_core/conftest.py
@@ -10,13 +10,13 @@ from unittest.mock import patch
 
 import pytest
 from django.core.management import call_command
-from django.db import connections
 from django.test import override_settings
 
 from teatree.core.models import Worktree
 from teatree.core.models.review_verdict import ReviewVerdict
 from teatree.core.overlay import OverlayBase, OverlayE2E, OverlayReview, OverlayRuntime, ProvisionStep, RunCommands
 from teatree.core.overlay_loader import reset_overlay_cache
+from tests.db_alias import RouteAllToAlias, register_sqlite_alias, teardown_sqlite_alias
 
 
 def seed_merge_safe_verdict(
@@ -121,28 +121,6 @@ def mock_command_overlay() -> Iterator[None]:
         yield
 
 
-class _RouteAllToAlias:
-    """Force every unscoped ORM query onto ``alias`` for one migrate call (#2915).
-
-    The ``core`` ``0001_initial`` loop/prompt seed runs a ``RunPython`` that reads
-    historical models via ``apps.get_model(...).objects`` with no
-    ``.using(...)`` — Django resolves that to ``DEFAULT_DB_ALIAS`` regardless
-    of which connection the surrounding ``migrate --database`` targets.
-    Installing this as the sole ``DATABASE_ROUTERS`` entry for the migrate
-    call reroutes those unscoped reads/writes onto the private alias instead
-    of leaking onto the shared ``default`` connection.
-    """
-
-    def __init__(self, alias: str) -> None:
-        self.alias = alias
-
-    def db_for_read(self, model: type, **hints: object) -> str:
-        return self.alias
-
-    def db_for_write(self, model: type, **hints: object) -> str:
-        return self.alias
-
-
 @dataclass(frozen=True)
 class SchemaGuardAlias:
     """Factory for private, file-backed SQLite connections used by schema_guard tests (#2915)."""
@@ -168,7 +146,7 @@ def schema_guard_alias(tmp_path: Path, _unblocked_db: None) -> Iterator[SchemaGu
     xdist-worker-lifetime-reused ``default`` test database every other test in
     the worker relies on.
 
-    The ``_RouteAllToAlias`` router is installed for the alias's whole
+    The ``RouteAllToAlias`` router is installed for the alias's whole
     remaining lifetime, not just this factory's own migrate calls: the
     schema-guard functions under test (``migrate_self_db``,
     ``require_current_schema``) run their own ``migrate --database=<alias>``
@@ -189,18 +167,8 @@ def schema_guard_alias(tmp_path: Path, _unblocked_db: None) -> Iterator[SchemaGu
         """
         alias = f"sg_{uuid.uuid4().hex}"
         db_file = tmp_path / f"{alias}.sqlite3"
-        connections.databases[alias] = {
-            "ENGINE": "django.db.backends.sqlite3",
-            "NAME": str(db_file),
-            "OPTIONS": {},
-            "ATOMIC_REQUESTS": False,
-            "AUTOCOMMIT": True,
-            "CONN_MAX_AGE": 0,
-            "CONN_HEALTH_CHECKS": False,
-            "TIME_ZONE": None,
-            "TEST": {},
-        }
-        stack.enter_context(override_settings(DATABASE_ROUTERS=[_RouteAllToAlias(alias)]))
+        register_sqlite_alias(alias, db_file)
+        stack.enter_context(override_settings(DATABASE_ROUTERS=[RouteAllToAlias(alias)]))
         call_command("migrate", "--no-input", database=alias, verbosity=0)
         created.append(alias)
         return alias
@@ -215,7 +183,4 @@ def schema_guard_alias(tmp_path: Path, _unblocked_db: None) -> Iterator[SchemaGu
         yield SchemaGuardAlias(register_current=_register_current, make_stale=_make_stale)
 
     for alias in created:
-        for conn in connections.all():
-            if conn.alias == alias:
-                conn.close()
-        connections.databases.pop(alias, None)
+        teardown_sqlite_alias(alias)

--- a/tests/test_cli_wip.py
+++ b/tests/test_cli_wip.py
@@ -9,20 +9,22 @@ app builder attaches via :func:`teatree.cli.wip.register_wip_commands`.
 """
 
 import os
-import shutil
 import subprocess
 import sys
+import uuid
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 import typer
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from typer.testing import CliRunner
 
 from teatree.cli.wip import register_wip_commands
 from teatree.config import Wip, get_effective_settings
 from teatree.core.models import ConfigSetting
+from tests.db_alias import RouteAllToAlias, register_sqlite_alias, teardown_sqlite_alias
 
 runner = CliRunner()
 
@@ -155,13 +157,25 @@ raise SystemExit(result.exit_code)
 cheaply (imports only ``teatree.cli.wip`` + Typer, not the whole CLI tree)."""
 
 
+class SharedEnvAfterSet(NamedTuple):
+    """The class's isolated XDG env + the result of its one shared ``set`` subprocess."""
+
+    env: dict[str, str]
+    set_result: subprocess.CompletedProcess[str]
+
+
 @pytest.mark.timeout(180)
 class TestWipSetBootstrapsDjangoInRealProcess:
     """``wip set`` / ``show`` work from a process where Django is NOT pre-configured.
 
-    No in-process DB: each case spawns a clean subprocess against its OWN
-    isolated ``XDG_DATA_HOME`` SQLite control DB and asserts only on subprocess
-    output — so the class needs neither ``TestCase`` nor ``@pytest.mark.django_db``.
+    The class-scoped ``shared_env_after_set`` fixture migrates a private,
+    file-backed control DB in-process (the ``schema_guard_alias`` pattern
+    hoisted to ``tests/db_alias.py``) and runs ONE real ``wip set boost``
+    subprocess for the whole class. Both cases below assert only on that
+    shared subprocess result / a subsequent ``show`` subprocess read, never on
+    in-process DB state, so the class needs neither ``TestCase`` nor
+    ``@pytest.mark.django_db``. Neither test writes to the shared DB after the
+    fixture's ``set``, so the two are order-independent.
 
     The in-process :class:`~typer.testing.CliRunner` tests above all run inside
     pytest, where ``django.setup()`` has already configured settings, so they
@@ -185,36 +199,6 @@ class TestWipSetBootstrapsDjangoInRealProcess:
         env["PYTHONPATH"] = os.pathsep.join([str(self._SRC_ROOT), env.get("PYTHONPATH", "")]).rstrip(os.pathsep)
         return env
 
-    def _migrate(self, env: dict[str, str]) -> None:
-        subprocess.run(
-            [sys.executable, "-m", "teatree", "migrate", "--no-input"],
-            cwd=str(self._REPO_ROOT),
-            env={**env, "DJANGO_SETTINGS_MODULE": "teatree.settings"},
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-
-    @pytest.fixture(scope="class")
-    def migrated_xdg_template(self, tmp_path_factory: pytest.TempPathFactory) -> Path:
-        """A migrated control DB built ONCE for the class; each test copies it.
-
-        The subprocess ``teatree migrate`` replay is the whole cost of this class.
-        Paying it once and copying the result per test keeps the two independent
-        cases (set persists, show reads the persisted value) as separate,
-        order-independent shard nodes without a full migrate each — so the split
-        halves the hard shard floor this class was (#3160 item 5).
-        """
-        template = tmp_path_factory.mktemp("wip-migrated") / "xdg"
-        self._migrate(self._clean_env(template))
-        return template
-
-    def _copied_env(self, template: Path, dest: Path) -> dict[str, str]:
-        """A clean env over a per-test COPY of the migrated template DB."""
-        data_home = dest / "xdg"
-        shutil.copytree(template, data_home)
-        return self._clean_env(data_home)
-
     def _wip(self, env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
         """Invoke the ``wip`` typer subgroup in an UNbootstrapped subprocess."""
         return subprocess.run(
@@ -226,17 +210,49 @@ class TestWipSetBootstrapsDjangoInRealProcess:
             check=False,
         )
 
-    def test_set_persists_without_improperly_configured(self, migrated_xdg_template: Path, tmp_path: Path) -> None:
-        env = self._copied_env(migrated_xdg_template, tmp_path)
-        result = self._wip(env, "set", "boost")
+    @pytest.fixture(scope="class")
+    def shared_env_after_set(
+        self,
+        tmp_path_factory: pytest.TempPathFactory,
+        django_db_blocker: pytest.FixtureRequest,
+    ) -> SharedEnvAfterSet:
+        """Migrate a private control DB in-process, then run ONE ``set boost`` subprocess.
+
+        Migrating via ``call_command`` against a private, file-backed SQLite
+        alias (routed through :class:`~tests.db_alias.RouteAllToAlias` so the
+        ``core`` seed migration's unscoped ORM writes land on the alias, not
+        the shared ``default`` test DB) avoids the ``python -m teatree
+        migrate`` subprocess cold-start the previous per-class template paid.
+        The alias connection is closed before ``set`` runs so its
+        ``PRAGMA journal_mode=WAL`` open finds the file flushed. Only the
+        ``set`` subprocess below — the actual unbootstrapped-process behaviour
+        under test — still spawns a real process, and it is shared by both
+        cases in the class rather than paid once per test.
+        """
+        data_home = tmp_path_factory.mktemp("wip-xdg")
+        db_file = data_home / "teatree" / "db.sqlite3"
+        db_file.parent.mkdir(parents=True, exist_ok=True)
+
+        alias = f"wip_{uuid.uuid4().hex}"
+        register_sqlite_alias(alias, db_file)
+        try:
+            with django_db_blocker.unblock(), override_settings(DATABASE_ROUTERS=[RouteAllToAlias(alias)]):
+                call_command("migrate", "--no-input", database=alias, verbosity=0)
+        finally:
+            teardown_sqlite_alias(alias)
+
+        env = self._clean_env(data_home)
+        return SharedEnvAfterSet(env=env, set_result=self._wip(env, "set", "boost"))
+
+    def test_set_persists_without_improperly_configured(self, shared_env_after_set: SharedEnvAfterSet) -> None:
+        result = shared_env_after_set.set_result
         combined = result.stdout + result.stderr
         assert "ImproperlyConfigured" not in combined, combined
         assert "settings are not configured" not in combined, combined
         assert result.returncode == 0, combined
 
-    def test_show_reads_the_persisted_dial(self, migrated_xdg_template: Path, tmp_path: Path) -> None:
-        env = self._copied_env(migrated_xdg_template, tmp_path)
-        assert self._wip(env, "set", "boost").returncode == 0
+    def test_show_reads_the_persisted_dial(self, shared_env_after_set: SharedEnvAfterSet) -> None:
+        assert shared_env_after_set.set_result.returncode == 0
         # ``show`` must read the persisted dial, not silently fall back to the default.
-        shown = self._wip(env, "show")
+        shown = self._wip(shared_env_after_set.env, "show")
         assert shown.stdout.strip() == Wip.BOOST.value, shown.stdout + shown.stderr


### PR DESCRIPTION
## Summary
- `TestWipSetBootstrapsDjangoInRealProcess` (`tests/test_cli_wip.py`) previously spawned a `python -m teatree migrate` subprocess once per class, then had each of its 2 tests `copytree` that migrated template and spawn its own `wip set` subprocess (which itself spawns a nested `config_setting` subprocess) — ~6 Python cold-starts per class run, several with a full `django.setup()`.
- Replaces the subprocess migrate with an in-process `call_command("migrate", ...)` against a private, file-backed SQLite alias, routed through the same `RouteAllToAlias` pattern `schema_guard_alias` already used. Hoisted that router (+ alias register/teardown helpers) out of `tests/teatree_core/conftest.py` into a new shared `tests/db_alias.py` so both call sites share it — no duplication.
- Runs ONE shared `wip set boost` subprocess for the whole class via a class-scoped `shared_env_after_set` fixture instead of one per test; `test_show_reads_the_persisted_dial` now reads that shared state instead of independently re-running `set`.
- Test-only change — no `src/teatree/` product code touched. Test names are unchanged so `.test_durations` shard balancing stays valid.

## Verification
- **Hoist is behavior-neutral**: `tests/teatree_core/test_schema_guard.py::TestSchemaGuardOnPrivateAlias` (the only class using the hoisted router/helpers) — 4/4 passed (ran with `--timeout=0` to separate correctness from this box's heavy CPU contention; unrelated classes in that file timed out under contention but don't touch the hoisted code, so that's noise, not regression).
- **Isolation proven** for the restructured class: each test alone (82.84s / 59.90s), both together forward order (65.04s) and reversed order (104.71s), and `-n 2` (121.49s) — all green, no cross-test/order dependency.
- **Anti-vacuous check**: temporarily pointed the `show` subprocess at a fresh, unmigrated XDG dir instead of the shared fixture's env — `test_show_reads_the_persisted_dial` went RED (`medium` != `boost`) as expected, confirming the assertion genuinely reads the shared fixture's persisted dial rather than passing vacuously. Reverted before the commit that's on this branch (diffed to confirm no leftover mutation).
- `dev/ci-parity-fast.sh`: prek (all hooks incl. ruff/ty-check/comment-density/banned-terms/tach) + `makemigrations --check --dry-run` + `tests/quality` all green, except one pre-existing flake unrelated to this diff: `tests/quality/test_patch_targets_resolve.py::TestLiveTree::test_every_patch_string_target_resolves` hit pytest-timeout(60s) while importing the `anthropic` SDK's pydantic schema under this box's heavy xdist-worker contention; re-ran alone with `--timeout=0` and it passed in 17.56s. Doesn't touch any file in this diff and doesn't depend on the hoisted/restructured code.
- Full 93%-branch-coverage-floor `dev/ci-parity.sh` was not run to completion given this box's sustained heavy CPU contention (many concurrent agent sessions sharing 4 cores) and time budget; this is a test-only change so the floor is structurally unaffected, but CI's own coverage job is the final gate.

## Timing (this box, under heavy shared CPU contention from other concurrent agent sessions — expect a larger relative win on a quiet CI runner)
- Baseline (unmodified `main`): class run **timed out** at the 180s `@pytest.mark.timeout` (447.72s wall before hard failure).
- After this change: class run reliably passes in **~65-120s**.

## Open questions & assumptions
- Assumed settings-module equivalence between the in-process migrate (`tests.django_settings`) and the `set`/`show` subprocess's `teatree.settings`: verified against current `main` that only `teatree.core` has a `migrations/` directory among teatree apps under both settings modules, and neither `config_setting` nor `show` do a pending-migrations preflight — matches the original plan's stated risk.
- WAL conversion: the in-process-migrated alias file is closed (connection + registry pop) before the `set` subprocess opens it with `PRAGMA journal_mode=WAL`, so the conversion has clean write access.
- This PR was safety-net-committed mid-verification by a peer orchestrator session ahead of a possible machine migration (see the existing commit message) while I continued working in the same worktree; the verification steps above were completed after that commit landed, against the identical (diff-confirmed) working-tree state, so no new commit was needed.

Not merging — draft PR per the ongoing CI-speedup initiative's review process.
