### PR TITLE
fix(deploy): stop the inbox loop being re-masked on every restart

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -164,10 +164,47 @@ apply_fleet_loop_policy() {
         fi
     done
 
+    # A loop in BOTH lists is a contradiction: the ENABLE pass forces it on, then
+    # the DISABLE pass would immediately force it off (admission resolves
+    # forced > preset > base), leaving a sanctioned-enabled loop silently MASKED
+    # on every init. This is exactly how `inbox` regressed (teatree.env carried it
+    # in both lists). ENABLED wins (it is the stronger, emergency-gated signal and
+    # the operator's explicit "must run here"): drop such loops from the disable
+    # set and WARN loudly. Resolving rather than `exit 1` is deliberate — a hard
+    # failure here would crash-loop init on an already-deployed box that carries
+    # the overlap (the very config that shipped), turning a silent mask into an
+    # outage. The warning tells the operator to de-dup teatree.env.
+    local pruned_disable=()
+    for loop in ${disable_loops[@]+"${disable_loops[@]}"}; do
+        local overlaps=
+        for other in ${enable_loops[@]+"${enable_loops[@]}"}; do
+            if [ "$loop" = "$other" ]; then
+                overlaps=1
+                break
+            fi
+        done
+        if [ -n "$overlaps" ]; then
+            echo "entrypoint: loop '${loop}' is in BOTH TEATREE_ENABLED_LOOPS and TEATREE_DISABLED_LOOPS - keeping it ENABLED (would otherwise be re-masked every restart); remove it from TEATREE_DISABLED_LOOPS in teatree.env to silence this warning" >&2
+        else
+            pruned_disable+=("$loop")
+        fi
+    done
+    disable_loops=(${pruned_disable[@]+"${pruned_disable[@]}"})
+
     # ENABLE clears any durable hold (only `enable` can) and sets Loop.enabled=True.
+    # It does NOT lift a stale forced-OFF override — so a loop this box left in the
+    # DISABLED set on a PRIOR deploy stays masked even after being promoted to the
+    # ENABLED set here (the override outlives the config change in LoopState). Clear
+    # the override right after enabling so a sanctioned-enabled loop can never remain
+    # forced off by leftover state; `clear` is neutral, so a still-enabled loop keeps
+    # running via Loop.enabled=True.
     for loop in ${enable_loops[@]+"${enable_loops[@]}"}; do
         if ! t3 loop enable "$loop" --emergency; then
             echo "entrypoint: 't3 loop enable ${loop} --emergency' FAILED - the DB-backed loop control plane is unreachable; confirm 't3 teatree db migrate' succeeded above and re-run Deploy" >&2
+            exit 1
+        fi
+        if ! t3 loop override "$loop" clear --reason "fleet policy: ${loop} is sanctioned-enabled here; drop any stale forced-off override from a prior deploy"; then
+            echo "entrypoint: 't3 loop override ${loop} clear' FAILED - the DB-backed loop control plane is unreachable; confirm 't3 teatree db migrate' succeeded above and re-run Deploy" >&2
             exit 1
         fi
     done

--- a/tests/test_deploy_entrypoint_disable_loops.py
+++ b/tests/test_deploy_entrypoint_disable_loops.py
@@ -303,8 +303,7 @@ class TestApplyFleetLoopPolicy:
         assert out.overridden == ["inbox clear", "review off"]
 
     def test_enable_clears_stale_forced_off_override(self, tmp_path: Path) -> None:
-        """Enabling a loop also clears any override, so a forced-off left by a prior
-        deploy's DISABLED set can't keep a now-ENABLED loop masked.
+        """Enabling a loop clears any override so a stale forced-off can't keep it masked.
 
         `t3 loop enable` lifts holds but NOT a forced-off override; without the
         follow-up `clear`, promoting a loop from the DISABLED to the ENABLED set

--- a/tests/test_deploy_entrypoint_disable_loops.py
+++ b/tests/test_deploy_entrypoint_disable_loops.py
@@ -115,7 +115,7 @@ def _write_t3_stub(bin_dir: Path) -> None:
         'if [ "${1:-}" = "loop" ] && [ "${2:-}" = "override" ]; then\n'
         '  name="$3"; state="$4"\n'
         '  echo "$name $state" >> "$T3_OVERRIDE_LOG"\n'
-        '  if [ "$name" = "${T3_FAIL_LOOP:-}" ]; then echo "boom" >&2; exit 1; fi\n'
+        '  if [ "$name" = "${T3_FAIL_LOOP:-}" ] || [ "$name" = "${T3_FAIL_OVERRIDE_LOOP:-}" ]; then echo "boom" >&2; exit 1; fi\n'
         "  echo \"OK    loop '$name' override is now $state.\"\n"
         "  exit 0\n"
         "fi\n"
@@ -202,7 +202,10 @@ class TestApplyFleetLoopPolicy:
         out = _run(tmp_path)
         assert out.result.returncode == 0, out.result.stderr
         assert out.enabled == ["inbox"]
-        assert out.overridden == ["review off", "directive_loop off"]
+        # `inbox clear` drops any stale forced-off override left by a prior deploy
+        # so the sanctioned-enabled inbox can never stay masked; then the
+        # colleague loops are forced off.
+        assert out.overridden == ["inbox clear", "review off", "directive_loop off"]
         assert out.disabled == [], "the deprecated `t3 loop disable` must never be called"
 
     def test_enable_passes_emergency(self, tmp_path: Path) -> None:
@@ -217,14 +220,14 @@ class TestApplyFleetLoopPolicy:
         out = _run(tmp_path, enabled="inbox,tickets", disabled="review")
         assert out.result.returncode == 0, out.result.stderr
         assert out.enabled == ["inbox", "tickets"]
-        assert out.overridden == ["review off"]
+        assert out.overridden == ["inbox clear", "tickets clear", "review off"]
         assert out.disabled == []
 
     def test_whitespace_and_trailing_comma_tolerated(self, tmp_path: Path) -> None:
         out = _run(tmp_path, enabled="inbox, ,", disabled="review, directive_loop ,")
         assert out.result.returncode == 0, out.result.stderr
         assert out.enabled == ["inbox"]
-        assert out.overridden == ["review off", "directive_loop off"]
+        assert out.overridden == ["inbox clear", "review off", "directive_loop off"]
 
     def test_both_empty_is_a_noop_and_succeeds(self, tmp_path: Path) -> None:
         out = _run(tmp_path, enabled="", disabled="")
@@ -273,6 +276,50 @@ class TestApplyFleetLoopPolicy:
         assert out.enabled == []
         assert out.overridden == []
         assert "could not read the registered loops" in out.result.stderr
+
+    def test_loop_in_both_lists_stays_enabled_with_warning(self, tmp_path: Path) -> None:
+        """A loop in BOTH lists stays ENABLED (not re-masked) — this was the `inbox` bug.
+
+        The ENABLE pass forces inbox on; the DISABLE pass would then force it off
+        on every init, leaving it silently masked. ENABLED wins: the loop is
+        dropped from the disable set and a loud warning surfaces the misconfig.
+        Resolving (not `exit 1`) is deliberate so an already-deployed box carrying
+        the overlap doesn't crash-loop init.
+        """
+        out = _run(tmp_path, enabled="inbox", disabled="inbox")
+        assert out.result.returncode == 0, out.result.stderr
+        assert out.enabled == ["inbox"]
+        # only the enable-path clear ran; inbox was NOT forced off.
+        assert out.overridden == ["inbox clear"]
+        assert "in BOTH" in out.result.stderr
+        assert "keeping it ENABLED" in out.result.stderr
+
+    def test_overlap_prunes_only_the_shared_loop(self, tmp_path: Path) -> None:
+        """Overlap resolution drops only the shared loop; other disables still apply."""
+        out = _run(tmp_path, enabled="inbox", disabled="inbox,review")
+        assert out.result.returncode == 0, out.result.stderr
+        assert out.enabled == ["inbox"]
+        assert out.overridden == ["inbox clear", "review off"]
+
+    def test_enable_clears_stale_forced_off_override(self, tmp_path: Path) -> None:
+        """Enabling a loop also clears any override, so a forced-off left by a prior
+        deploy's DISABLED set can't keep a now-ENABLED loop masked.
+
+        `t3 loop enable` lifts holds but NOT a forced-off override; without the
+        follow-up `clear`, promoting a loop from the DISABLED to the ENABLED set
+        between deploys would leave it masked by the stale override.
+        """
+        out = _run(tmp_path, enabled="inbox", disabled="")
+        assert out.result.returncode == 0, out.result.stderr
+        assert out.enabled == ["inbox"]
+        assert out.overridden == ["inbox clear"]
+
+    def test_enable_path_override_clear_failure_is_loud(self, tmp_path: Path) -> None:
+        """A failing override-clear on the enable path aborts loudly (control plane down)."""
+        out = _run(tmp_path, enabled="inbox", disabled="", T3_FAIL_OVERRIDE_LOOP="inbox")
+        assert out.result.returncode != 0
+        assert out.enabled == ["inbox"], "enable ran before the clear failed"
+        assert "'t3 loop override inbox clear' FAILED" in out.result.stderr
 
 
 if __name__ == "__main__":

--- a/tests/test_deploy_entrypoint_disable_loops.py
+++ b/tests/test_deploy_entrypoint_disable_loops.py
@@ -115,7 +115,8 @@ def _write_t3_stub(bin_dir: Path) -> None:
         'if [ "${1:-}" = "loop" ] && [ "${2:-}" = "override" ]; then\n'
         '  name="$3"; state="$4"\n'
         '  echo "$name $state" >> "$T3_OVERRIDE_LOG"\n'
-        '  if [ "$name" = "${T3_FAIL_LOOP:-}" ] || [ "$name" = "${T3_FAIL_OVERRIDE_LOOP:-}" ]; then echo "boom" >&2; exit 1; fi\n'
+        '  if [ "$name" = "${T3_FAIL_LOOP:-}" ] || [ "$name" = "${T3_FAIL_OVERRIDE_LOOP:-}" ]; '
+        'then echo "boom" >&2; exit 1; fi\n'
         "  echo \"OK    loop '$name' override is now $state.\"\n"
         "  exit 0\n"
         "fi\n"


### PR DESCRIPTION
## Summary
Fix the recurring `inbox` loop being re-masked (forced-off override) on every container restart.

`deploy/teatree.env` shipped `inbox` in BOTH `TEATREE_ENABLED_LOOPS` and `TEATREE_DISABLED_LOOPS`; `apply_fleet_loop_policy()` enabled it then immediately forced it off, so admission (hold>forced>preset>base) left the sanctioned-enabled inbox silently masked after each init.

## Changes
- **Overlap resolution**: a loop in both lists now stays ENABLED and is pruned from the disable set with a loud warning (rather than being forced off). Resolving instead of `exit 1` avoids crash-looping init on an already-deployed box that carries the overlap.
- **Enable-path override clear**: `enable` lifts holds but not a stale forced-OFF override, so a loop promoted from the DISABLED set on a prior deploy stayed masked — clear the override right after enabling.

## Tests
Extends `tests/test_deploy_entrypoint_disable_loops.py` (15 pass; shellcheck-clean).
