### PR TITLE
fix(cli): make t3 recover --requeue parse instead of erroring 'No such command'

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -4953,6 +4953,15 @@ Usage: t3 task cancel [OPTIONS]
 Usage: t3 recover [OPTIONS] COMMAND [ARGS]...
 
  Find (and optionally recover) work stranded by a network-outage death (#1764).
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --requeue              Reopen genuinely-incomplete FAILED (incl.             │
+│                        outage-death) tasks.                                  │
+│ --json                 Emit the structured report as JSON.                   │
+│ --overlay        TEXT  Which overlay's manage.py runs the report (default:   │
+│                        active overlay).                                      │
+│ --help                 Show this message and exit.                           │
+╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ### `t3 dogfood`

--- a/src/teatree/cli/recover.py
+++ b/src/teatree/cli/recover.py
@@ -34,22 +34,32 @@ def _resolve_overlay() -> tuple[Path | None, str]:
 
 @recover_app.callback(invoke_without_command=True)
 def recover(
+    *,
     requeue: Annotated[
         bool,
         typer.Option("--requeue", help="Reopen genuinely-incomplete FAILED (incl. outage-death) tasks."),
+    ] = False,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Emit the structured report as JSON."),
     ] = False,
     overlay: Annotated[
         str,
         typer.Option("--overlay", help="Which overlay's manage.py runs the report (default: active overlay)."),
     ] = "",
 ) -> None:
-    """Forward `t3 recover [--requeue]` to `t3 <overlay> recover`.
+    """Forward `t3 recover [--requeue] [--json]` to `t3 <overlay> recover`.
 
     The flags are declared explicitly (not a raw ``ctx.args`` passthrough) so
     Typer's group parser does not mis-read a leading ``--requeue`` as a
-    subcommand name (`No such command '--requeue'`). ``recover`` takes only
-    ``--requeue``; the default is the dry-run report.
+    subcommand name (`No such command '--requeue'`). ``--requeue`` reopens FAILED
+    tasks and ``--json`` emits the structured report; both forward to the
+    management command for parity, and the default is the dry-run report.
     """
     project_path, overlay_name = _resolve_overlay()
-    forwarded = ["--requeue"] if requeue else []
+    forwarded: list[str] = []
+    if requeue:
+        forwarded.append("--requeue")
+    if json_output:
+        forwarded.append("--json")
     managepy(project_path, "recover", *forwarded, overlay_name=overlay or overlay_name)

--- a/src/teatree/cli/recover.py
+++ b/src/teatree/cli/recover.py
@@ -10,6 +10,7 @@ surfaced for salvage (push to a PR), not auto-captured.
 """
 
 from pathlib import Path
+from typing import Annotated
 
 import typer
 
@@ -19,11 +20,6 @@ recover_app = typer.Typer(
     name="recover",
     no_args_is_help=False,
     help="Find (and optionally recover) work stranded by a network-outage death (#1764).",
-    context_settings={
-        "allow_extra_args": True,
-        "allow_interspersed_args": False,
-        "ignore_unknown_options": True,
-    },
 )
 
 
@@ -36,32 +32,24 @@ def _resolve_overlay() -> tuple[Path | None, str]:
     return active.project_path, active.name
 
 
-def _split_overlay_flag(args: list[str]) -> tuple[str, list[str]]:
-    """Pull a leading-or-anywhere ``--overlay <name>`` / ``--overlay=<name>`` out of *args*.
+@recover_app.callback(invoke_without_command=True)
+def recover(
+    requeue: Annotated[
+        bool,
+        typer.Option("--requeue", help="Reopen genuinely-incomplete FAILED (incl. outage-death) tasks."),
+    ] = False,
+    overlay: Annotated[
+        str,
+        typer.Option("--overlay", help="Which overlay's manage.py runs the report (default: active overlay)."),
+    ] = "",
+) -> None:
+    """Forward `t3 recover [--requeue]` to `t3 <overlay> recover`.
 
-    Returns ``(overlay_name, remaining_args)``. ``--overlay`` selects which
-    overlay's ``manage.py`` runs the report; the rest forward unchanged.
+    The flags are declared explicitly (not a raw ``ctx.args`` passthrough) so
+    Typer's group parser does not mis-read a leading ``--requeue`` as a
+    subcommand name (`No such command '--requeue'`). ``recover`` takes only
+    ``--requeue``; the default is the dry-run report.
     """
-    overlay = ""
-    rest: list[str] = []
-    it = iter(args)
-    for arg in it:
-        if arg == "--overlay":
-            overlay = next(it, "")
-        elif arg.startswith("--overlay="):
-            overlay = arg.split("=", 1)[1]
-        else:
-            rest.append(arg)
-    return overlay, rest
-
-
-@recover_app.callback(
-    invoke_without_command=True,
-    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
-    add_help_option=False,
-)
-def recover(ctx: typer.Context) -> None:
-    """Forward `t3 recover [flags]` to `t3 <overlay> recover`."""
-    overlay_override, forwarded = _split_overlay_flag(ctx.args)
     project_path, overlay_name = _resolve_overlay()
-    managepy(project_path, "recover", *forwarded, overlay_name=overlay_override or overlay_name)
+    forwarded = ["--requeue"] if requeue else []
+    managepy(project_path, "recover", *forwarded, overlay_name=overlay or overlay_name)

--- a/tests/teatree_core/test_recover.py
+++ b/tests/teatree_core/test_recover.py
@@ -11,11 +11,13 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from io import StringIO
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.core.management import call_command
 from django.test import TestCase
 
+from teatree.cli import recover as cli_recover
 from teatree.core.gates.orphan_guard import BranchReport, BranchStatus
 from teatree.core.models import Session, Task, TaskAttempt, Ticket
 from teatree.core.worktree.recover import RecoverReport, gather_recover_report, requeue_failed_tasks
@@ -253,6 +255,22 @@ class TestRecoverCliForwarding(TestCase):
             cli_recover.recover(requeue=True, overlay="")
 
         managepy.assert_called_once_with(Path("/proj"), "recover", "--requeue", overlay_name="acme")
+
+    def test_json_flag_forwards_the_flag(self) -> None:
+        """Regression: `t3 recover --json` must forward `--json` (parity with manage.py recover).
+
+        The old ``ctx.args`` passthrough forwarded any flag; the explicit-option
+        rewrite must keep declaring and forwarding ``--json`` or the documented
+        shortcut breaks while the management command still supports it.
+        """
+        active = SimpleNamespace(project_path=Path("/proj"), name="acme")
+        with (
+            patch("teatree.config.discover_active_overlay", return_value=active),
+            patch("teatree.cli.recover.managepy") as managepy,
+        ):
+            cli_recover.recover(requeue=False, json_output=True, overlay="")
+
+        managepy.assert_called_once_with(Path("/proj"), "recover", "--json", overlay_name="acme")
 
     def test_overlay_flag_overrides_active_overlay(self) -> None:
         from teatree.cli import recover as cli_recover  # noqa: PLC0415

--- a/tests/teatree_core/test_recover.py
+++ b/tests/teatree_core/test_recover.py
@@ -225,41 +225,64 @@ class TestRecoverCommand(TestCase):
         assert payload["reopened_task_pks"] == []
 
 
-class TestSplitOverlayFlag(TestCase):
-    def test_splits_space_and_equals_forms_and_keeps_rest(self) -> None:
-        from teatree.cli.recover import _split_overlay_flag  # noqa: PLC0415
-
-        assert _split_overlay_flag(["--overlay", "acme", "--json"]) == ("acme", ["--json"])
-        assert _split_overlay_flag(["--overlay=acme", "--requeue"]) == ("acme", ["--requeue"])
-        assert _split_overlay_flag(["--json"]) == ("", ["--json"])
-
-
 class TestRecoverCliForwarding(TestCase):
-    def test_forwards_to_managepy_with_resolved_overlay(self) -> None:
+    def test_dry_run_forwards_no_flags(self) -> None:
         from types import SimpleNamespace  # noqa: PLC0415
 
         from teatree.cli import recover as cli_recover  # noqa: PLC0415
 
         active = SimpleNamespace(project_path=Path("/proj"), name="acme")
-        ctx = SimpleNamespace(args=["--json"])
         with (
             patch("teatree.config.discover_active_overlay", return_value=active),
             patch("teatree.cli.recover.managepy") as managepy,
         ):
-            cli_recover.recover(ctx)
+            cli_recover.recover(requeue=False, overlay="")
 
-        managepy.assert_called_once_with(Path("/proj"), "recover", "--json", overlay_name="acme")
+        managepy.assert_called_once_with(Path("/proj"), "recover", overlay_name="acme")
 
-    def test_overlay_flag_overrides_active_overlay(self) -> None:
+    def test_requeue_forwards_the_flag(self) -> None:
         from types import SimpleNamespace  # noqa: PLC0415
 
         from teatree.cli import recover as cli_recover  # noqa: PLC0415
 
-        ctx = SimpleNamespace(args=["--overlay", "other", "--requeue"])
+        active = SimpleNamespace(project_path=Path("/proj"), name="acme")
+        with (
+            patch("teatree.config.discover_active_overlay", return_value=active),
+            patch("teatree.cli.recover.managepy") as managepy,
+        ):
+            cli_recover.recover(requeue=True, overlay="")
+
+        managepy.assert_called_once_with(Path("/proj"), "recover", "--requeue", overlay_name="acme")
+
+    def test_overlay_flag_overrides_active_overlay(self) -> None:
+        from teatree.cli import recover as cli_recover  # noqa: PLC0415
+
         with (
             patch("teatree.config.discover_active_overlay", return_value=None),
             patch("teatree.cli.recover.managepy") as managepy,
         ):
-            cli_recover.recover(ctx)
+            cli_recover.recover(requeue=True, overlay="other")
 
         managepy.assert_called_once_with(None, "recover", "--requeue", overlay_name="other")
+
+    def test_requeue_flag_parses_at_cli_not_read_as_subcommand(self) -> None:
+        """Regression: `t3 recover --requeue` must PARSE, not fail 'No such command'.
+
+        The prior raw ``ctx.args`` passthrough let Typer's group parser treat a
+        leading ``--requeue`` as a subcommand name; declaring it as an explicit
+        option fixes that.
+        """
+        from typer.testing import CliRunner  # noqa: PLC0415
+
+        from teatree.cli.recover import recover_app  # noqa: PLC0415
+
+        with (
+            patch("teatree.config.discover_active_overlay", return_value=None),
+            patch("teatree.cli.recover.managepy") as managepy,
+        ):
+            result = CliRunner().invoke(recover_app, ["--requeue"])
+
+        assert result.exit_code == 0, result.output
+        assert "No such command" not in result.output
+        managepy.assert_called_once()
+        assert "--requeue" in managepy.call_args.args


### PR DESCRIPTION
## Summary
`t3 recover --requeue` failed with `No such command '--requeue'` — the documented remedy for outage-stranded FAILED tasks was unusable (only a raw `manage.py recover --requeue` worked).

The forwarder used a raw `ctx.args` passthrough on a Typer group, so a leading `--requeue` was parsed as a subcommand name. Declare `--requeue`/`--overlay` as explicit options so Typer parses them, then forward to the overlay's `manage.py recover`.

## Tests
Regression test invokes the CLI with `--requeue` and asserts it parses + forwards; drops the obsolete `_split_overlay_flag` helper. `tests/teatree_core/test_recover.py`.
