### PR TITLE
fix(hooks): pre-push gates are inert under prek (stdin not forwarded)

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -218,6 +218,23 @@ init)
     # receiver can open its WebSocket. Without it `t3 slack listen` degrades to a
     # no-op ("slack_sdk not installed") and inbound Slack never reaches the loop.
     uv tool install --editable "$CLONE_DIR[slack]" --reinstall --python 3.13
+    # prek (the pre-commit reimplementation) is a DEV-group dependency, so the
+    # editable tool install above does NOT provide it. Worktree provisioning
+    # (`prek_hook.install`) and the base-clone commit/push gates need `prek` on
+    # PATH; install it as a standalone uv tool (pinned to the lockfile) into the
+    # shared teatree_uv volume so every role sees it. Runtime (not Dockerfile):
+    # /opt/teatree/uv is a named volume that shadows any image-baked install.
+    uv tool install prek==0.3.13
+    # Install the commit/push gate hooks on the base clone's SHARED hooks dir
+    # (git links every worktree to it), so the privacy leak gate (#685), the
+    # foreign-MR guard, banned-terms, and the push gates actually fire on the
+    # loop's pushes. Without this the migrated box had an EMPTY .git/hooks and
+    # every gate was silently bypassed. Idempotent; harden the baked PREK path
+    # to a PATH lookup (souliane/teatree#1462) so a torn-down worktree can't
+    # leave a stale absolute path in the shared hook.
+    ( cd "$CLONE_DIR" && prek install -f \
+        && sed -i 's#^PREK="/opt/teatree/uv/tools/prek/bin/prek"#PREK="prek"#' \
+            .git/hooks/pre-push .git/hooks/pre-commit .git/hooks/commit-msg 2>/dev/null )
     t3 setup
     t3 teatree db migrate
     # Values are JSON: enum strings are quoted, booleans and ints are bare.

--- a/scripts/hooks/refuse-public-push-with-leak.sh
+++ b/scripts/hooks/refuse-public-push-with-leak.sh
@@ -47,8 +47,8 @@
 set -euo pipefail
 
 ZERO="0000000000000000000000000000000000000000"
-remote_name="${1:-origin}"
-remote_url="${2:-}"
+remote_name="${PRE_COMMIT_REMOTE_NAME:-${1:-origin}}"
+remote_url="${PRE_COMMIT_REMOTE_URL:-${2:-}}"
 
 if [ -z "${remote_url}" ]; then
   remote_url=$(git remote get-url "${remote_name}" 2>/dev/null || true)
@@ -105,6 +105,21 @@ findings_code=${T3_PRIVACY_FINDINGS_EXIT_CODE:-3}
 default_ref=$(git symbolic-ref --short refs/remotes/"${remote_name}"/HEAD 2>/dev/null || true)
 default_branch=${default_ref#"${remote_name}"/}
 default_branch=${default_branch:-main}
+
+# Ref updates arrive on stdin under git's native pre-push protocol. But when the
+# hook runs through prek/pre-commit (the `.pre-commit-config.yaml` wiring), the
+# runner CONSUMES stdin itself and exposes the push range via PRE_COMMIT_* env
+# vars — the hook then reads an EMPTY stdin and silently passes every push (the
+# gate is inert). Capture stdin; when empty but PRE_COMMIT_TO_REF is set,
+# synthesize the one ref-update line from the env so the loop below enforces
+# under BOTH invocation paths (souliane/teatree: prek does not forward pre-push
+# stdin to `language: system` hooks).
+refs_input=$(cat)
+if [ -z "${refs_input//[[:space:]]/}" ] && [ -n "${PRE_COMMIT_TO_REF:-}" ]; then
+  refs_input=$(printf '%s %s %s %s\n' \
+    "${PRE_COMMIT_LOCAL_BRANCH:-HEAD}" "${PRE_COMMIT_TO_REF}" \
+    "${PRE_COMMIT_REMOTE_BRANCH:-HEAD}" "${PRE_COMMIT_FROM_REF:-$ZERO}")
+fi
 
 blocked=0
 while read -r local_ref local_sha remote_ref remote_sha; do
@@ -183,6 +198,6 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     sed 's/^/  /' "${report}" 2>/dev/null || cat "${report}" 2>/dev/null || true
   fi
   rm -f "${report}"
-done
+done <<< "${refs_input}"
 
 exit "${blocked}"

--- a/scripts/hooks/refuse-push-to-foreign-mr.sh
+++ b/scripts/hooks/refuse-push-to-foreign-mr.sh
@@ -36,8 +36,8 @@
 set -euo pipefail
 
 ZERO="0000000000000000000000000000000000000000"
-remote_name="${1:-origin}"
-remote_url="${2:-}"
+remote_name="${PRE_COMMIT_REMOTE_NAME:-${1:-origin}}"
+remote_url="${PRE_COMMIT_REMOTE_URL:-${2:-}}"
 
 if [ -z "${remote_url}" ]; then
   remote_url=$(git remote get-url "${remote_name}" 2>/dev/null || true)
@@ -63,6 +63,16 @@ command -v gh >/dev/null 2>&1 || exit 0  # no gh — fail open
 our_login=$(gh api user --jq '.login' 2>/dev/null | tr -d '[:space:]' || true)
 [ -n "${our_login}" ] || exit 0
 our_login_lc=$(printf '%s' "${our_login}" | tr '[:upper:]' '[:lower:]')
+
+# See refuse-public-push-with-leak.sh: prek/pre-commit consume the pre-push
+# stdin and expose PRE_COMMIT_* instead, so a stdin-only hook is inert under the
+# prek wrapper. Fall back to the env-synthesized ref line when stdin is empty.
+refs_input=$(cat)
+if [ -z "${refs_input//[[:space:]]/}" ] && [ -n "${PRE_COMMIT_TO_REF:-}" ]; then
+  refs_input=$(printf '%s %s %s %s\n' \
+    "${PRE_COMMIT_LOCAL_BRANCH:-HEAD}" "${PRE_COMMIT_TO_REF}" \
+    "${PRE_COMMIT_REMOTE_BRANCH:-HEAD}" "${PRE_COMMIT_FROM_REF:-$ZERO}")
+fi
 
 blocked=0
 while read -r local_ref local_sha _remote_ref _remote_sha; do
@@ -108,6 +118,6 @@ while read -r local_ref local_sha _remote_ref _remote_sha; do
   echo "  A worktree opened to INSPECT a colleague's MR is read-only (see /t3:rules § never push to a colleague's open MR branch)."
   echo "  For a genuine co-authoring push, add [push-to-foreign-mr-ok: <reason>] to a commit message in the push range."
   blocked=1
-done
+done <<< "${refs_input}"
 
 exit "${blocked}"


### PR DESCRIPTION
## The bug

`prek` does **not** forward git's pre-push ref-update stdin to `language: system` hooks. It consumes stdin itself and instead exposes the push range through environment variables:

`PRE_COMMIT_FROM_REF` / `PRE_COMMIT_TO_REF` / `PRE_COMMIT_REMOTE_NAME` / `PRE_COMMIT_REMOTE_URL` / `PRE_COMMIT_LOCAL_BRANCH` / `PRE_COMMIT_REMOTE_BRANCH`

Both pre-push gates read the push range **only** from stdin. Under the prek-installed wrapper they therefore receive **zero bytes**, iterate over nothing, scan nothing, and exit 0 — passing every push.

Consequence: the privacy leak gate (#685) and the foreign-MR guard (#2211) have been **silently inert** whenever hooks run via prek. They never failed; they just never ran.

## Proof

A real leak commit was pushed through the *actual* prek pre-push wrapper to a throwaway local remote:

- prek reported the hook **"Passed"** and the branch was pushed (**exit 0**) — despite `home_path`, `private_ip` and `api_key` findings present in the diff.
- A standalone minimal prek repo confirmed `STDIN_BYTES=0` in a `language: system` pre-push hook.

With the env-var fallback patched in, on the same wrapper:

| case | result |
|---|---|
| clean push | exit 0 — allowed |
| leak push | exit 1 — **blocked**, findings reported |

## The fix

Both hooks now capture stdin into `refs_input`. If it is empty **and** `PRE_COMMIT_TO_REF` is set, they synthesize the single ref-update line from the `PRE_COMMIT_*` env vars and feed the existing loop via `done <<< "${refs_input}"`.

This is backward compatible by construction: **stdin still wins** for native git pre-push, and the env fallback engages only when stdin is empty. `remote_name` / `remote_url` likewise prefer `PRE_COMMIT_REMOTE_NAME` / `PRE_COMMIT_REMOTE_URL`, falling back to the positional args git passes.

## Secondary fix: prek was never installed

`prek==0.3.13` is pinned in the **dev** dependency group, but the init role installs `uv tool install --editable "$CLONE_DIR[slack]"` — runtime + slack extras only. So `prek` was absent from the box entirely and `.git/hooks` was **empty**: every commit/push gate silently bypassed, not just the two above.

`deploy/entrypoint.sh` now:

- installs `prek==0.3.13` as a standalone `uv tool` **at runtime, not in the Dockerfile** — `/opt/teatree/uv` is a named volume that shadows any image-baked install;
- runs `prek install -f` on the base clone's shared hooks dir (git links every worktree to it);
- hardens the baked `PREK="/opt/teatree/uv/tools/prek/bin/prek"` line to a plain PATH lookup (souliane/teatree#1462), so a torn-down worktree cannot leave a stale absolute path in the shared hook.

## Why this was never caught

The existing unit test only exercises `bash <hook>` directly, feeding it real stdin. It never runs the hook **through the prek wrapper**, which is the only path where the stdin starvation appears. A regression test that drives the hook via prek would close this gap.

## Verification

- `bash -n` clean on all three files.
- Manual privacy scan over `origin/main..HEAD` before pushing: **clean, 0 findings** (necessary here precisely because the gate is inert on this box). Note the scanner also warns that the DB-home `banned_terms` list is present-but-unset, so that one detector is currently inert; the remaining detectors ran.
