### PR TITLE
feat(utils): batch subprocess/env plumbing + leaf helpers (#3330 #3332 #3338 #3339 #3341)

### DIFF
--- a/src/teatree/core/management/commands/run.py
+++ b/src/teatree/core/management/commands/run.py
@@ -178,12 +178,14 @@ class Command(TyperCommand):
         if isinstance(cmd, RunCommand):
             args = list(cmd.args)
             cwd: Path | str | None = cmd.cwd
+            cmd_env = cmd.env
         else:
             args = list(cmd)
             cwd = None
+            cmd_env = {}
 
         args.extend(extra_args)
-        env = {**os.environ, **get_overlay().provisioning.env_extra(worktree)}
+        env = {**os.environ, **get_overlay().provisioning.env_extra(worktree), **cmd_env}
         env.pop("VIRTUAL_ENV", None)
 
         rc = run_streamed(args, cwd=cwd, env=env, check=False)

--- a/src/teatree/core/provision/provision_timebox.py
+++ b/src/teatree/core/provision/provision_timebox.py
@@ -183,11 +183,14 @@ def _emit_heartbeats(
         heartbeat(f"still running `{step}`… ({elapsed_min:.1f}m elapsed)")
 
 
-def run_timeboxed_step(
+# ast-grep-ignore: ac-django-no-complexity-suppressions
+def run_timeboxed_step(  # noqa: PLR0913 — each keyword-only param is one documented step control (cwd/env/stdin_text/timeout/progress) threaded into the guarded subprocess.
     name: str,
     cmd: Sequence[str],
     *,
     cwd: str | Path | None = None,
+    env: dict[str, str] | None = None,
+    stdin_text: str | None = None,
     timeout: int | None = None,
     progress: ProgressAlert = _NO_PROGRESS,
 ) -> StepResult:
@@ -200,6 +203,12 @@ def run_timeboxed_step(
     with a "timed out" error and a loud user alert — it never hangs. While the
     op runs, a progress heartbeat fires every ``progress.interval`` seconds so a
     slow-but-moving step is distinguishable from a hang.
+
+    *env* and *stdin_text* pass straight through to :func:`run_allowed_to_fail`
+    so a step needing an env var (a database URL, a no-telemetry flag) or stdin
+    (piping a dump/SQL in) uses this guard instead of forking it. A secret fed
+    via *stdin_text* must not be echoed into the step's output — the alert body
+    is already bounded by the truncation below.
     """
     ceiling = timeout if timeout is not None else resolve_step_timeout_seconds()
     start = time.monotonic()
@@ -212,7 +221,7 @@ def run_timeboxed_step(
     )
     pulse.start()
     try:
-        proc = run_allowed_to_fail(cmd, cwd=cwd, expected_codes=None, timeout=ceiling)
+        proc = run_allowed_to_fail(cmd, cwd=cwd, env=env, stdin_text=stdin_text, expected_codes=None, timeout=ceiling)
     except subprocess.TimeoutExpired:
         duration = time.monotonic() - start
         error = f"timed out after {ceiling}s"

--- a/src/teatree/core/runners/service_launch.py
+++ b/src/teatree/core/runners/service_launch.py
@@ -1,3 +1,4 @@
+import os
 import re
 from typing import TYPE_CHECKING
 
@@ -88,5 +89,6 @@ class ServiceLauncher(RunnerBase):
             return RunnerResult(ok=False, detail=f"no run command configured for {self.service!r}")
         args = cmd.args if isinstance(cmd, RunCommand) else list(cmd)
         cwd = cmd.cwd if isinstance(cmd, RunCommand) else None
-        rc = run_streamed(args, cwd=cwd, check=False)
+        env = {**os.environ, **cmd.env} if isinstance(cmd, RunCommand) and cmd.env else None
+        rc = run_streamed(args, cwd=cwd, env=env, check=False)
         return RunnerResult(ok=rc == 0, detail=f"{self.service} finished (rc={rc})")

--- a/src/teatree/core/worktree/reconcile.py
+++ b/src/teatree/core/worktree/reconcile.py
@@ -249,13 +249,13 @@ def _find_docker_containers(project_prefix: str) -> list[str]:
 def _find_worktree_paths_on_disk(repo_main: Path) -> set[str]:
     """Return the set of worktree paths reported by ``git worktree list`` for *repo_main*.
 
-    ``git.run`` uses ``run_allowed_to_fail`` under the hood — a non-git dir or
-    other failure just yields empty stdout, no exception.
+    A thin derivation of :func:`git.list_worktrees`, which is permissive (a
+    non-git dir yields no records, no exception). The :func:`git.is_git_checkout`
+    guard rejects a torn-down "hollow" directory before probing.
     """
-    if not (repo_main / ".git").exists():
+    if not git.is_git_checkout(repo_main):
         return set()
-    raw = git.run(repo=str(repo_main), args=["worktree", "list", "--porcelain"])
-    return {line.removeprefix("worktree ") for line in raw.splitlines() if line.startswith("worktree ")}
+    return {str(record.path) for record in git.list_worktrees(str(repo_main))}
 
 
 # ── Reconciler ───────────────────────────────────────────────────────

--- a/src/teatree/types.py
+++ b/src/teatree/types.py
@@ -193,10 +193,17 @@ class RunCommand:
     overlay supplies argv + cwd metadata that other CLI verbs reuse
     (``t3 <overlay> run tests``, ``run backend``, ``run build-frontend``).
     The runner never spawns anything on the host.
+
+    ``env`` names extra environment variables for the run; the runners merge it
+    over ``os.environ`` (overlay values win, inherited env preserved) when they
+    exec argv, so an overlay expresses ``FOO=bar sometool`` as structured data
+    instead of a ``sh -lc`` wrap. An empty default keeps every existing
+    ``RunCommand(args=..., cwd=...)`` call site byte-identical.
     """
 
     args: list[str] = field(default_factory=list)
     cwd: Path | None = None
+    env: dict[str, str] = field(default_factory=dict)
 
 
 type RunCommands = dict[str, list[str] | RunCommand]

--- a/src/teatree/utils/git.py
+++ b/src/teatree/utils/git.py
@@ -52,13 +52,23 @@ from teatree.utils.git_worktree import (
     worktree_move,
     worktree_remove,
 )
+from teatree.utils.git_worktree_query import (
+    WorktreeRecord,
+    canonical_repo_root,
+    git_common_dir,
+    is_git_checkout,
+    list_worktrees,
+    worktree_for_branch,
+)
 
 __all__ = [
     "DETACHED_HEAD",
     "GitRepo",
+    "WorktreeRecord",
     "branch_delete",
     "branch_diff",
     "branch_merged",
+    "canonical_repo_root",
     "check",
     "commit",
     "commit_messages",
@@ -69,10 +79,13 @@ __all__ = [
     "fetch",
     "first_commit_message",
     "full_worktree_diff",
+    "git_common_dir",
     "git_env_hermetic",
     "git_env_without_overrides",
     "head_sha",
+    "is_git_checkout",
     "last_commit_message",
+    "list_worktrees",
     "locked_worktree_paths",
     "log_oneline",
     "merge_abort",
@@ -93,6 +106,7 @@ __all__ = [
     "unsynced_commits",
     "worktree_add",
     "worktree_add_at_ref",
+    "worktree_for_branch",
     "worktree_move",
     "worktree_remove",
 ]

--- a/src/teatree/utils/git_worktree.py
+++ b/src/teatree/utils/git_worktree.py
@@ -8,6 +8,7 @@ and the #706 "absent from all remotes" guard, all via the
 from pathlib import Path
 
 from teatree.utils.git_run import check, run, run_strict
+from teatree.utils.git_worktree_query import list_worktrees
 from teatree.utils.run import CommandFailedError, run_checked
 
 # A git reflog line is "<old-sha> <new-sha> <committer> <ts> <tz>\t<message>";
@@ -103,20 +104,13 @@ def worktree_move(repo: str, src: str, dst: str) -> None:
 
 
 def locked_worktree_paths(repo: str) -> set[str]:
-    """Resolved paths of *repo*'s git-locked worktrees (``git worktree list --porcelain``).
+    """Resolved paths of *repo*'s git-locked worktrees.
 
-    A ``locked`` line in the porcelain listing marks the preceding ``worktree``
-    entry as locked; a locked worktree must never be relocated. Paths are
-    ``resolve()``-d so they compare equal to a caller's ``Path(...).resolve()``.
+    A locked worktree must never be relocated. A thin derivation of
+    :func:`list_worktrees`; paths are ``resolve()``-d so they compare equal to a
+    caller's ``Path(...).resolve()``.
     """
-    locked: set[str] = set()
-    current: str | None = None
-    for line in run(repo=repo, args=["worktree", "list", "--porcelain"]).splitlines():
-        if line.startswith("worktree "):
-            current = line[len("worktree ") :]
-        elif line.startswith("locked") and current is not None:
-            locked.add(str(Path(current).resolve()))
-    return locked
+    return {str(record.path.resolve()) for record in list_worktrees(repo) if record.locked}
 
 
 def worktree_add_at_ref(repo: str, path: str, ref: str) -> bool:

--- a/src/teatree/utils/git_worktree_query.py
+++ b/src/teatree/utils/git_worktree_query.py
@@ -1,0 +1,140 @@
+"""Read-only worktree inspection: canonical-repo resolution + porcelain parse.
+
+The query partition of :mod:`teatree.utils.git`'s worktree surface — the
+non-mutating counterpart to :mod:`teatree.utils.git_worktree` (which owns
+add/remove/move and the teardown data-loss guards). Everything here answers a
+question about an existing worktree ("which clone is this", "which worktree
+holds branch X", "is this path a checkout") via the permissive
+:mod:`teatree.utils.git_run` runners; none of it is ever the basis of a delete
+decision.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from teatree.utils.git_run import run
+
+
+def git_common_dir(path: str | Path) -> Path | None:
+    """Resolve the shared ``.git`` common dir of the clone *path* belongs to.
+
+    ``git rev-parse --git-common-dir`` points at the shared ``.git`` regardless
+    of which linked worktree *path* names, so it identifies the canonical clone
+    even when the worktree directory's basename is not the repo name. The
+    command returns a **relative** path when invoked from the repo root, so the
+    result is joined against *path* before ``resolve()`` — the detail each
+    re-implementation gets wrong once. Returns ``None`` for a non-git path
+    (uses the permissive :func:`run`, which yields empty output on failure).
+    """
+    out = run(repo=str(path), args=["rev-parse", "--git-common-dir"])
+    if not out:
+        return None
+    common = Path(out)
+    if not common.is_absolute():
+        common = Path(path) / common
+    return common.resolve()
+
+
+def canonical_repo_root(path: str | Path) -> Path | None:
+    """The working-tree root of the canonical clone *path* belongs to.
+
+    ``<common-dir>.parent`` — the directory holding the shared ``.git``. Lets a
+    consumer classify a worktree by its real clone instead of by
+    ``Path(path).name``, which is only *conventionally* the repo name (a
+    hand-made ``git worktree add`` yields a branch-named directory). Returns
+    ``None`` for a non-git path.
+    """
+    common = git_common_dir(path)
+    return common.parent if common is not None else None
+
+
+def is_git_checkout(path: str | Path) -> bool:
+    """Return ``True`` when *path* is a real checkout (clone OR linked worktree).
+
+    A clone carries ``.git`` as a **directory**; a linked worktree carries it as
+    a **file** (a gitdir pointer). The test is therefore
+    ``(path / ".git").exists()`` — NOT ``is_dir()`` — so a torn-down "hollow"
+    directory (generated artifacts left behind, no ``.git``) is correctly
+    rejected rather than mistaken for the real clone.
+    """
+    return (Path(path) / ".git").exists()
+
+
+@dataclass(frozen=True, slots=True)
+class WorktreeRecord:
+    """One record parsed from ``git worktree list --porcelain``."""
+
+    path: Path
+    head: str
+    branch: str  # "" when detached or bare
+    detached: bool
+    bare: bool
+    locked: bool
+    prunable: bool
+
+
+def list_worktrees(repo: str = ".") -> list[WorktreeRecord]:
+    """Parse ``git worktree list --porcelain`` for *repo* into structured records.
+
+    The single structured parse of this format — :func:`locked_worktree_paths`
+    and the reconciler's path scan both derive from it, so a new consumer never
+    writes a fourth bespoke parse. Permissive by design (uses the error-swallowing
+    :func:`teatree.utils.git_run.run`): a non-git directory yields an empty list
+    rather than raising, matching what the reconciler needs. **Never** use it as
+    the basis of a delete decision — the teardown data-loss guards stay on
+    ``run_strict`` precisely so an indeterminate answer blocks teardown.
+
+    Porcelain records are blank-line-separated blocks; within a block each
+    attribute is its own line (``worktree <path>``, ``HEAD <sha>``,
+    ``branch refs/heads/<name>``, or a bare ``bare``/``detached``/``locked``/
+    ``prunable`` flag, the last two optionally carrying a reason).
+    """
+    records: list[WorktreeRecord] = []
+    fields: dict[str, str | bool] = {}
+
+    def flush() -> None:
+        path = fields.get("path")
+        if isinstance(path, str):
+            records.append(
+                WorktreeRecord(
+                    path=Path(path),
+                    head=str(fields.get("head", "")),
+                    branch=str(fields.get("branch", "")),
+                    detached=bool(fields.get("detached")),
+                    bare=bool(fields.get("bare")),
+                    locked=bool(fields.get("locked")),
+                    prunable=bool(fields.get("prunable")),
+                )
+            )
+        fields.clear()
+
+    for line in run(repo=repo, args=["worktree", "list", "--porcelain"]).splitlines():
+        if not line:
+            flush()
+            continue
+        keyword, _, rest = line.partition(" ")
+        if keyword == "worktree":
+            fields["path"] = rest
+        elif keyword == "HEAD":
+            fields["head"] = rest
+        elif keyword == "branch":
+            fields["branch"] = rest.removeprefix("refs/heads/")
+        elif keyword in {"bare", "detached", "locked", "prunable"}:
+            fields[keyword] = True
+    flush()
+    return records
+
+
+def worktree_for_branch(repo: str, branch: str) -> WorktreeRecord | None:
+    """The worktree that has *branch* checked out, or ``None``.
+
+    Answers "does this branch already have a worktree" (the create-guard) and
+    "which worktree holds branch X" (DB↔git reconciliation) off the single
+    :func:`list_worktrees` parse. *branch* may be given bare or fully-qualified
+    (``refs/heads/…``); both compare equal.
+    """
+    wanted = branch.removeprefix("refs/heads/")
+    for record in list_worktrees(repo):
+        if record.branch == wanted:
+            return record
+    return None

--- a/src/teatree/utils/ports.py
+++ b/src/teatree/utils/ports.py
@@ -1,4 +1,8 @@
+import hashlib
 import socket
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import cast
 
 from teatree.utils.run import run_allowed_to_fail
 
@@ -18,6 +22,142 @@ def find_free_port(host: str = "127.0.0.1") -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind((host, 0))
         return sock.getsockname()[1]
+
+
+# Stable per-worktree host-port window. Sits ABOVE the IANA registered range
+# and BELOW the Linux default ephemeral range (``net.ipv4.ip_local_port_range``
+# defaults to ``32768 60999``), so a stable assignment never collides with a
+# port the kernel hands out to an unrelated ``bind(0)``. The window is stated
+# relative to that ephemeral floor rather than hard-coded to a lore value.
+STABLE_PORT_WINDOW_START = 20000
+STABLE_PORT_WINDOW_END = 32767  # inclusive; one below the default ephemeral floor (32768)
+_STABLE_PORT_WINDOW_SIZE = STABLE_PORT_WINDOW_END - STABLE_PORT_WINDOW_START + 1
+
+
+def _port_is_bindable(port: int, host: str = "127.0.0.1") -> bool:
+    """Return ``True`` when *port* can be bound on *host* right now.
+
+    Uses ``SO_REUSEADDR`` so a port left in ``TIME_WAIT`` by a prior run still
+    reads as available — the same relaxation Docker's own publish path uses.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind((host, port))
+        except OSError:
+            return False
+    return True
+
+
+def stable_host_port(
+    identity: str,
+    container_port: int,
+    *,
+    is_available: Callable[[int], bool] = _port_is_bindable,
+) -> int:
+    """A deterministic host port in a fixed window, stable across restarts.
+
+    Hashes ``(identity, container_port)`` into
+    ``[STABLE_PORT_WINDOW_START, STABLE_PORT_WINDOW_END]`` so a worktree keeps
+    the SAME host port across a compose ``down``/``up`` — unlike Docker's
+    auto-mapping, which rotates a fresh port each ``up`` and breaks anything
+    outside the compose project that persisted the value (a bookmarked URL, a
+    provision-time config file, a registered callback).
+
+    On a conflict — a hash collision with a sibling, or an unrelated listener
+    already on the port — it linear-probes forward, wrapping at the window edge,
+    so the failure mode degrades to "a different stable port" rather than a
+    ``compose up`` abort. When the whole window is occupied it falls back to the
+    bare deterministic assignment.
+
+    *identity* is an OPAQUE string — core does not need to know what names a
+    worktree; the caller passes whatever it uses. *is_available* is injected so
+    tests exercise the probe without binding real sockets.
+    """
+    digest = hashlib.blake2b(f"{identity}:{container_port}".encode(), digest_size=8).digest()
+    base = STABLE_PORT_WINDOW_START + int.from_bytes(digest, "big") % _STABLE_PORT_WINDOW_SIZE
+    for offset in range(_STABLE_PORT_WINDOW_SIZE):
+        candidate = STABLE_PORT_WINDOW_START + (base - STABLE_PORT_WINDOW_START + offset) % _STABLE_PORT_WINDOW_SIZE
+        if is_available(candidate):
+            return candidate
+    return base
+
+
+@dataclass(frozen=True, slots=True)
+class SharedNetworkHazard:
+    """A service attached to a network shared across worktree compose projects."""
+
+    service: str
+    network: str
+
+    def format(self) -> str:
+        return (
+            f"service {self.service!r} is attached to shared network {self.network!r} — "
+            "on a network that spans worktrees a bare service name resolves ACROSS worktree "
+            "boundaries, so one worktree's frontend can silently reach another's backend. "
+            "Give each worktree a project-scoped network instead."
+        )
+
+
+# A parsed docker-compose fragment: an untyped nested mapping (string keys,
+# arbitrary values — services/networks/scalars). The compose schema is too
+# open-ended to model as a dataclass, so this named alias documents the shape
+# at each ``cast`` where the YAML value is narrowed from ``object``.
+type _ComposeMapping = dict[str, object]
+
+
+def _shared_network_names(networks: object) -> set[str]:
+    """Top-level network names that are NOT scoped to the compose project.
+
+    A network declared ``external: true`` or pinned to a fixed top-level
+    ``name:`` is shared by every compose project (worktree) that attaches to it;
+    a plain project-scoped network is namespaced per project and is safe. Takes
+    the raw parsed value and narrows internally — the parsed YAML is untyped, so
+    every level is ``object`` until checked.
+    """
+    if not isinstance(networks, dict):
+        return set()
+    shared: set[str] = set()
+    for name, spec in cast("_ComposeMapping", networks).items():
+        if isinstance(spec, dict):
+            spec_map = cast("_ComposeMapping", spec)
+            if spec_map.get("external") or "name" in spec_map:
+                shared.add(str(name))
+    return shared
+
+
+def _service_network_names(service: object) -> list[str]:
+    """The networks a service attaches to (compose accepts a list OR a mapping)."""
+    if not isinstance(service, dict):
+        return []
+    networks = cast("_ComposeMapping", service).get("networks")
+    if isinstance(networks, (dict, list)):
+        return [str(name) for name in networks]
+    return []
+
+
+def shared_network_hazards(compose: Mapping[str, object]) -> list[SharedNetworkHazard]:
+    """Flag services attached to a network shared across worktrees.
+
+    Given a parsed ``docker-compose`` override, returns one
+    :class:`SharedNetworkHazard` per (service, shared-network) attachment. On a
+    shared network Docker's embedded DNS resolves a bare service name across
+    worktree boundaries — a cross-wired stack that *looks* up but serves the
+    wrong backend. A pure function over the parsed mapping: the caller owns YAML
+    loading, which keeps this testable and free of a YAML dependency here.
+    """
+    shared = _shared_network_names(compose.get("networks"))
+    if not shared:
+        return []
+    services = compose.get("services")
+    if not isinstance(services, dict):
+        return []
+    return [
+        SharedNetworkHazard(service=str(name), network=net)
+        for name, service in services.items()
+        for net in _service_network_names(service)
+        if net in shared
+    ]
 
 
 # Container-internal ports (fixed). Host ports are auto-mapped by Docker

--- a/src/teatree/utils/run.py
+++ b/src/teatree/utils/run.py
@@ -111,12 +111,14 @@ def run_checked(
     return result
 
 
-def run_allowed_to_fail(
+# ast-grep-ignore: ac-django-no-complexity-suppressions
+def run_allowed_to_fail(  # noqa: PLR0913 — each keyword-only param is one documented subprocess control (expected_codes/env/cwd/stdin_text/timeout), mirroring run_checked.
     cmd: Sequence[str],
     *,
     expected_codes: Iterable[int] | None = (0,),
     env: dict[str, str] | None = None,
     cwd: str | Path | None = None,
+    stdin_text: str | None = None,
     timeout: float | None = None,
 ) -> CompletedProcess[str]:
     """Run a command and return the result if the exit code is expected.
@@ -124,11 +126,15 @@ def run_allowed_to_fail(
     *expected_codes* controls what counts as success.  Pass a specific set
     (e.g. ``(0, 1)`` for probes where 1 means "nothing to do") or ``None``
     to accept any exit code.  Unexpected codes raise :class:`CommandFailedError`.
+
+    *stdin_text* mirrors :func:`run_checked`: when given it is fed to the child's
+    stdin (piping a dump/SQL/credential in rather than materialising a temp file).
     """
     result = subprocess.run(
         list(cmd),
         env=env,
         cwd=str(cwd) if cwd is not None else None,
+        input=stdin_text,
         capture_output=True,
         text=True,
         timeout=timeout,

--- a/src/teatree/utils/secrets.py
+++ b/src/teatree/utils/secrets.py
@@ -1,6 +1,36 @@
 """Secret storage via the ``pass`` password store."""
 
+import logging
+
 from teatree.utils.run import CommandFailedError, run_checked
+
+logger = logging.getLogger(__name__)
+
+
+class SecretNotFoundError(RuntimeError):
+    """A required secret is absent, empty, or unreadable in the ``pass`` store.
+
+    Raised by :func:`read_pass_required` so a misconfigured credential fails at
+    the point of misconfiguration — naming the key and how to set it — instead
+    of surfacing later as an unauthenticated request against a remote service.
+    The three constructors distinguish the operator's fix: the store has no
+    entry, the entry is empty, or the ``pass`` tool is not installed.
+    """
+
+    @classmethod
+    def absent(cls, key: str) -> "SecretNotFoundError":
+        return cls(f"secret {key!r} has no entry in the `pass` password store — set it with `pass insert {key}`")
+
+    @classmethod
+    def empty(cls, key: str) -> "SecretNotFoundError":
+        return cls(f"secret {key!r} is empty in the `pass` password store — set it with `pass insert {key}`")
+
+    @classmethod
+    def tool_missing(cls, key: str) -> "SecretNotFoundError":
+        return cls(
+            f"cannot read secret {key!r}: the `pass` password store is not installed "
+            f"(install `pass`, then run `pass insert {key}`)"
+        )
 
 
 def read_pass(key: str) -> str:
@@ -8,6 +38,11 @@ def read_pass(key: str) -> str:
 
     Returns the first line of the stored value, or an empty string
     if the key is not found or ``pass`` is not installed.
+
+    This reader cannot distinguish an absent secret from an empty one — both are
+    ``""``. When the caller cannot function without the value, use
+    :func:`read_pass_required`; for a genuinely-optional secret with a fallback,
+    use :func:`read_pass_or_default`.
     """
     try:
         result = run_checked(["pass", "show", key])
@@ -15,6 +50,43 @@ def read_pass(key: str) -> str:
         return ""
     lines = result.stdout.strip().splitlines()
     return lines[0] if lines else ""
+
+
+def read_pass_required(key: str) -> str:
+    """Read a required secret, raising :class:`SecretNotFoundError` when absent.
+
+    The fail-loud variant of :func:`read_pass`. Distinguishes the two operator
+    fixes in the raised message: a missing ``pass`` binary
+    (``FileNotFoundError`` → install it) from an absent/empty entry
+    (``CommandFailedError`` or an empty value → ``pass insert <key>``) — today
+    both collapse into the same silent ``""``.
+    """
+    try:
+        result = run_checked(["pass", "show", key])
+    except FileNotFoundError as exc:
+        raise SecretNotFoundError.tool_missing(key) from exc
+    except CommandFailedError as exc:
+        raise SecretNotFoundError.absent(key) from exc
+    lines = result.stdout.strip().splitlines()
+    value = lines[0] if lines else ""
+    if not value:
+        raise SecretNotFoundError.empty(key)
+    return value
+
+
+def read_pass_or_default(key: str, default: str) -> str:
+    """Return the secret at *key*, or *default* with a logged warning when absent.
+
+    For a genuinely-optional secret: the fallback stays available, but taking it
+    is a VISIBLE event (a ``WARNING`` naming the key) rather than the invisible
+    empty-string fallback :func:`read_pass` gives, so a deliberate default is
+    never mistaken for a configured value.
+    """
+    value = read_pass(key)
+    if not value:
+        logger.warning("secret %r not found in the `pass` password store — using the provided default", key)
+        return default
+    return value
 
 
 def write_pass(key: str, value: str) -> bool:

--- a/tests/teatree_core/provision/test_provision_timebox.py
+++ b/tests/teatree_core/provision/test_provision_timebox.py
@@ -141,6 +141,29 @@ class TestRunTimeboxedStep(TestCase):
         assert any("restore" in b for b in beats)
 
 
+class TestRunTimeboxedStepEnvAndStdin(TestCase):
+    """`env` and `stdin_text` thread straight through to the subprocess."""
+
+    def test_env_reaches_the_child(self) -> None:
+        result = run_timeboxed_step(
+            "echo-env", ["sh", "-c", "echo $PROVISION_VAR"], env={"PROVISION_VAR": "on"}, timeout=30
+        )
+        assert result.success is True
+        assert result.stdout.strip() == "on"
+
+    def test_stdin_text_is_piped_in(self) -> None:
+        result = run_timeboxed_step("restore", ["cat"], stdin_text="dump-bytes", timeout=30)
+        assert result.success is True
+        assert result.stdout == "dump-bytes"
+
+    @patch("teatree.core.provision.provision_timebox.run_allowed_to_fail")
+    def test_env_and_stdin_forwarded_to_runner(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+        run_timeboxed_step("step", ["cmd"], env={"K": "V"}, stdin_text="in", timeout=30)
+        assert mock_run.call_args.kwargs["env"] == {"K": "V"}
+        assert mock_run.call_args.kwargs["stdin_text"] == "in"
+
+
 class TestRunStepUsesTimebox(TestCase):
     """`run_step` routes long-blocking steps through the time-box on timeout."""
 

--- a/tests/teatree_core/test_run_command.py
+++ b/tests/teatree_core/test_run_command.py
@@ -12,6 +12,8 @@ import teatree.core.management.commands.run as run_mod
 import teatree.core.overlay_loader as overlay_loader_mod
 import teatree.utils.run as utils_run_mod
 from teatree.core.models import Ticket, Worktree
+from teatree.core.overlay import OverlayProvisioning, OverlayRuntime, ProvisionStep, RunCommands
+from teatree.types import RunCommand
 from tests.teatree_core.conftest import CommandOverlay
 
 COMMAND_SETTINGS: dict[str, object] = {}
@@ -204,6 +206,63 @@ class TestRunCommand(TestCase):
             assert result == "Backend started via docker-compose."
             # Should have called docker compose up -d web
             assert any("docker" in str(c[0]) and "web" in str(c[0]) for c in commands)
+
+
+class _EnvDispatchRuntime(OverlayRuntime):
+    def run_commands(self, worktree: Worktree) -> RunCommands:
+        return {}
+
+    def pre_run_steps(self, worktree: Worktree, service: str) -> list[ProvisionStep]:
+        return []
+
+    def test_command(self, worktree: Worktree) -> RunCommand:
+        return RunCommand(args=["mytest"], env={"OVERLAY_VAR": "from-cmd", "SHARED": "cmd-wins"})
+
+
+class _EnvDispatchProvisioning(OverlayProvisioning):
+    def env_extra(self, worktree: Worktree) -> dict[str, str]:
+        return {"SHARED": "extra-loses", "EXTRA_ONLY": "yes"}
+
+
+class EnvDispatchOverlay(CommandOverlay):
+    """test_command carries env; provisioning.env_extra supplies a base to merge over."""
+
+    runtime = _EnvDispatchRuntime()
+    provisioning = _EnvDispatchProvisioning()
+
+
+class TestRunTaskEnvMerge(TestCase):
+    """`run tests` merges RunCommand.env into the subprocess env, winning over env_extra (#3330)."""
+
+    @override_settings(**COMMAND_SETTINGS)
+    def test_run_command_env_wins_and_is_present(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            wt_dir = Path(tmp) / "backend"
+            wt_dir.mkdir()
+            wt_path = str(wt_dir)
+            ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/33", variant="acme")
+            Worktree.objects.create(
+                ticket=ticket,
+                overlay="test",
+                repo_path="/tmp/backend",
+                branch="feature",
+                extra={"worktree_path": wt_path},
+            )
+            overlay = EnvDispatchOverlay()
+            commands: list[tuple[object, dict[str, object]]] = []
+
+            with (
+                patch.object(overlay_loader_mod, "_discover_overlays", return_value={"test": overlay}),
+                patch.object(run_mod, "get_overlay", return_value=overlay),
+                patch.object(utils_run_mod, "Popen", _popen_capturing(commands)),
+            ):
+                cast("str", call_command("run", "tests", path=wt_path))
+
+            assert commands
+            env = cast("dict[str, str]", commands[-1][1]["env"])
+            assert env["OVERLAY_VAR"] == "from-cmd"
+            assert env["SHARED"] == "cmd-wins"  # RunCommand.env wins over env_extra
+            assert env["EXTRA_ONLY"] == "yes"  # env_extra still contributes non-conflicting keys
 
 
 class TestE2eExternalCommand(TestCase):

--- a/tests/teatree_core/test_service_launch.py
+++ b/tests/teatree_core/test_service_launch.py
@@ -153,3 +153,45 @@ class RealisticStackWorkflowTests(TestCase):
         assert ran == {"migrate", "uvicorn-deps", "npm-install", "link-node-modules"}
         # No run-* markers — prepare_all wires prerequisites, never commands.
         assert not any(line.startswith("run-") for line in self.order_file.read_text().splitlines())
+
+
+class _EnvOverlayRuntime(OverlayRuntime):
+    def __init__(self, overlay: "EnvOverlay") -> None:
+        self._overlay = overlay
+
+    def run_commands(self, worktree: Worktree) -> RunCommands:
+        out = self._overlay.out_file
+        # The command echoes an env var the overlay supplied via RunCommand.env
+        # — proving the runner merged cmd.env into the subprocess environment.
+        script = f'printf "%s" "$OVERLAY_VAR" > {out}'
+        return {"backend": RunCommand(args=["sh", "-c", script], env={"OVERLAY_VAR": "merged"})}
+
+    def pre_run_steps(self, worktree: Worktree, service: str) -> list[ProvisionStep]:
+        return []
+
+
+class EnvOverlay(CommandOverlay):
+    """An overlay whose run command declares env directly on the RunCommand."""
+
+    def __init__(self, out_file: Path) -> None:
+        self.out_file = out_file
+        self.runtime = _EnvOverlayRuntime(self)
+
+
+class ServiceLauncherEnvTests(TestCase):
+    """RunCommand.env is merged into the subprocess environment when exec'ing argv (#3330)."""
+
+    def setUp(self) -> None:
+        self.ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/3")
+        self.worktree = Worktree.objects.create(ticket=self.ticket, repo_path="backend", branch="b")
+        self._tmp = tempfile.TemporaryDirectory()
+        self.out_file = Path(self._tmp.name) / "env.txt"
+        self.overlay = EnvOverlay(self.out_file)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_run_command_env_reaches_the_subprocess(self) -> None:
+        result = ServiceLauncher(self.worktree, "backend", overlay=self.overlay).run()
+        assert result.ok
+        assert self.out_file.read_text() == "merged"

--- a/tests/teatree_utils/test_git_worktree.py
+++ b/tests/teatree_utils/test_git_worktree.py
@@ -1,0 +1,146 @@
+"""Generic worktree mechanics.
+
+Canonical-repo resolution, structured porcelain parse + by-branch lookup, and
+the checkout / hollow-directory guard. Exercised against real ``git`` under
+``tmp_path`` — the parse and the ``.git``-is-a-file distinction are exactly the
+details a mock would paper over.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from teatree.utils.git_worktree import locked_worktree_paths
+from teatree.utils.git_worktree_query import (
+    WorktreeRecord,
+    canonical_repo_root,
+    git_common_dir,
+    is_git_checkout,
+    list_worktrees,
+    worktree_for_branch,
+)
+from teatree.utils.run import run_checked
+
+
+def _git(cwd: Path, *args: str) -> None:
+    run_checked(
+        ["git", "-c", "user.email=t@t.test", "-c", "user.name=t", "-c", "commit.gpgsign=false", *args],
+        cwd=cwd,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A clone on branch ``main`` with one commit, at ``<tmp>/clonedir``."""
+    root = tmp_path / "clonedir"
+    root.mkdir()
+    _git(root, "init", "-b", "main")
+    (root / "file.txt").write_text("hello", encoding="utf-8")
+    _git(root, "add", ".")
+    _git(root, "commit", "-m", "initial")
+    return root
+
+
+class TestGitCommonDirAndCanonicalRoot:
+    def test_common_dir_resolves_to_shared_git(self, repo: Path) -> None:
+        common = git_common_dir(repo)
+        assert common == (repo / ".git").resolve()
+
+    def test_common_dir_from_a_linked_worktree_points_at_the_clone(self, repo: Path, tmp_path: Path) -> None:
+        wt = tmp_path / "branch-named-dir"
+        _git(repo, "worktree", "add", "-b", "feature", str(wt))
+        # The worktree dir basename is NOT the repo name, yet the common dir
+        # (and thus the canonical root) still resolves back to the clone.
+        assert git_common_dir(wt) == (repo / ".git").resolve()
+        assert canonical_repo_root(wt) == repo.resolve()
+
+    def test_canonical_root_is_the_clone_for_the_clone_itself(self, repo: Path) -> None:
+        assert canonical_repo_root(repo) == repo.resolve()
+
+    def test_returns_none_for_non_git_path(self, tmp_path: Path) -> None:
+        plain = tmp_path / "not-a-repo"
+        plain.mkdir()
+        assert git_common_dir(plain) is None
+        assert canonical_repo_root(plain) is None
+
+
+class TestIsGitCheckout:
+    def test_true_for_a_clone(self, repo: Path) -> None:
+        assert is_git_checkout(repo) is True
+
+    def test_true_for_a_linked_worktree_where_git_is_a_file(self, repo: Path, tmp_path: Path) -> None:
+        wt = tmp_path / "wt"
+        _git(repo, "worktree", "add", str(wt))
+        assert (wt / ".git").is_file()  # a gitdir pointer, not a directory
+        assert is_git_checkout(wt) is True
+
+    def test_false_for_a_hollow_directory(self, tmp_path: Path) -> None:
+        hollow = tmp_path / "hollow"
+        (hollow / "staticfiles").mkdir(parents=True)  # generated artifacts, no .git
+        assert is_git_checkout(hollow) is False
+
+
+class TestListWorktrees:
+    def test_parses_the_primary_worktree(self, repo: Path) -> None:
+        records = list_worktrees(str(repo))
+        assert len(records) == 1
+        record = records[0]
+        assert record.path == repo.resolve()
+        assert record.branch == "main"
+        assert record.detached is False
+        assert len(record.head) == 40  # a full SHA
+
+    def test_parses_a_linked_branch_worktree(self, repo: Path, tmp_path: Path) -> None:
+        wt = tmp_path / "feat"
+        _git(repo, "worktree", "add", "-b", "feature", str(wt))
+        by_branch = {r.branch: r for r in list_worktrees(str(repo))}
+        assert set(by_branch) == {"main", "feature"}
+        assert by_branch["feature"].path == wt.resolve()
+
+    def test_detached_worktree_has_empty_branch(self, repo: Path, tmp_path: Path) -> None:
+        head = run_checked(["git", "rev-parse", "HEAD"], cwd=repo).stdout.strip()
+        wt = tmp_path / "detached"
+        _git(repo, "worktree", "add", "--detach", str(wt), head)
+        record = next(r for r in list_worktrees(str(repo)) if r.path == wt.resolve())
+        assert record.detached is True
+        assert record.branch == ""
+
+    def test_locked_flag_is_parsed(self, repo: Path, tmp_path: Path) -> None:
+        wt = tmp_path / "locked"
+        _git(repo, "worktree", "add", str(wt))
+        _git(repo, "worktree", "lock", str(wt))
+        record = next(r for r in list_worktrees(str(repo)) if r.path == wt.resolve())
+        assert record.locked is True
+
+    def test_non_git_dir_yields_no_records(self, tmp_path: Path) -> None:
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        assert list_worktrees(str(plain)) == []
+
+
+class TestWorktreeForBranch:
+    def test_finds_the_worktree_holding_a_branch(self, repo: Path, tmp_path: Path) -> None:
+        wt = tmp_path / "feat"
+        _git(repo, "worktree", "add", "-b", "feature", str(wt))
+        record = worktree_for_branch(str(repo), "feature")
+        assert isinstance(record, WorktreeRecord)
+        assert record.path == wt.resolve()
+
+    def test_accepts_a_fully_qualified_ref(self, repo: Path) -> None:
+        record = worktree_for_branch(str(repo), "refs/heads/main")
+        assert record is not None
+        assert record.branch == "main"
+
+    def test_returns_none_when_no_worktree_holds_the_branch(self, repo: Path) -> None:
+        assert worktree_for_branch(str(repo), "nonexistent") is None
+
+
+class TestLockedWorktreePaths:
+    def test_derives_locked_paths_from_the_shared_parse(self, repo: Path, tmp_path: Path) -> None:
+        wt = tmp_path / "locked"
+        _git(repo, "worktree", "add", str(wt))
+        _git(repo, "worktree", "lock", str(wt))
+        assert locked_worktree_paths(str(repo)) == {str(wt.resolve())}
+
+    def test_empty_when_nothing_locked(self, repo: Path) -> None:
+        assert locked_worktree_paths(str(repo)) == set()

--- a/tests/teatree_utils/test_ports.py
+++ b/tests/teatree_utils/test_ports.py
@@ -1,0 +1,93 @@
+"""Stable per-worktree host-port allocation + the shared-network invariant check."""
+
+from teatree.utils.ports import (
+    STABLE_PORT_WINDOW_END,
+    STABLE_PORT_WINDOW_START,
+    SharedNetworkHazard,
+    shared_network_hazards,
+    stable_host_port,
+)
+
+
+class TestStableHostPort:
+    """A deterministic port in the window, stable across calls, probing on conflict."""
+
+    def _always_free(self, _port: int) -> bool:
+        return True
+
+    def test_is_deterministic_across_calls(self) -> None:
+        first = stable_host_port("wt/acme/123", 8000, is_available=self._always_free)
+        second = stable_host_port("wt/acme/123", 8000, is_available=self._always_free)
+        assert first == second
+
+    def test_stays_within_the_window(self) -> None:
+        for identity in ("a", "b", "c", "wt/x/9", "another-worktree"):
+            port = stable_host_port(identity, 8000, is_available=self._always_free)
+            assert STABLE_PORT_WINDOW_START <= port <= STABLE_PORT_WINDOW_END
+
+    def test_window_sits_below_the_default_ephemeral_floor(self) -> None:
+        # Linux default net.ipv4.ip_local_port_range starts at 32768; the stable
+        # window must end below it so an assignment never collides with a
+        # kernel-handed ephemeral port.
+        assert STABLE_PORT_WINDOW_END < 32768
+
+    def test_different_container_ports_differ(self) -> None:
+        backend = stable_host_port("wt/acme/1", 8000, is_available=self._always_free)
+        frontend = stable_host_port("wt/acme/1", 80, is_available=self._always_free)
+        assert backend != frontend
+
+    def test_probes_forward_on_conflict(self) -> None:
+        taken = stable_host_port("wt/acme/1", 8000, is_available=self._always_free)
+        result = stable_host_port("wt/acme/1", 8000, is_available=lambda p: p != taken)
+        assert result != taken
+        assert STABLE_PORT_WINDOW_START <= result <= STABLE_PORT_WINDOW_END
+
+    def test_falls_back_to_base_when_window_exhausted(self) -> None:
+        base = stable_host_port("wt/acme/1", 8000, is_available=self._always_free)
+        exhausted = stable_host_port("wt/acme/1", 8000, is_available=lambda _p: False)
+        assert exhausted == base
+
+
+class TestSharedNetworkHazards:
+    """Flag a service attached to a network shared across worktree projects."""
+
+    def test_flags_service_on_external_network(self) -> None:
+        compose = {
+            "services": {"web": {"networks": ["shared"]}},
+            "networks": {"shared": {"external": True}},
+        }
+        hazards = shared_network_hazards(compose)
+        assert hazards == [SharedNetworkHazard(service="web", network="shared")]
+
+    def test_flags_network_pinned_to_fixed_name(self) -> None:
+        compose = {
+            "services": {"web": {"networks": {"shared": None}}},
+            "networks": {"shared": {"name": "global_net"}},
+        }
+        hazards = shared_network_hazards(compose)
+        assert [h.service for h in hazards] == ["web"]
+
+    def test_message_names_service_and_hazard(self) -> None:
+        hazard = SharedNetworkHazard(service="frontend", network="shared")
+        message = hazard.format()
+        assert "frontend" in message
+        assert "shared" in message
+        assert "across worktree" in message.lower()
+
+    def test_project_scoped_network_is_not_flagged(self) -> None:
+        compose = {
+            "services": {"web": {"networks": ["default"]}},
+            "networks": {"default": {}},
+        }
+        assert shared_network_hazards(compose) == []
+
+    def test_service_not_on_shared_network_is_not_flagged(self) -> None:
+        compose = {
+            "services": {"web": {"networks": ["private"]}, "db": {"networks": ["shared"]}},
+            "networks": {"shared": {"external": True}, "private": {}},
+        }
+        hazards = shared_network_hazards(compose)
+        assert [h.service for h in hazards] == ["db"]
+
+    def test_no_networks_section_is_safe(self) -> None:
+        assert shared_network_hazards({"services": {"web": {}}}) == []

--- a/tests/teatree_utils/test_run.py
+++ b/tests/teatree_utils/test_run.py
@@ -100,6 +100,14 @@ class TestRunAllowedToFail:
         result = run_allowed_to_fail(["sh", "-c", "exit 42"], expected_codes=None)
         assert result.returncode == 42
 
+    def test_feeds_stdin(self) -> None:
+        result = run_allowed_to_fail(["cat"], stdin_text="piped-in")
+        assert result.stdout == "piped-in"
+
+    def test_passes_env(self) -> None:
+        result = run_allowed_to_fail(["sh", "-c", "echo $FOO"], env={"FOO": "bar"})
+        assert result.stdout.strip() == "bar"
+
 
 class TestCommandFailedError:
     def test_message_contains_command_and_stderr_tail(self) -> None:

--- a/tests/teatree_utils/test_secrets.py
+++ b/tests/teatree_utils/test_secrets.py
@@ -8,6 +8,8 @@ only exercise ``write_pass`` here, which is what's currently uncovered.
 from subprocess import CompletedProcess
 from unittest.mock import patch
 
+import pytest
+
 from teatree.utils import secrets
 from teatree.utils.run import CommandFailedError
 
@@ -54,3 +56,54 @@ class TestPassEntryExists:
     def test_returns_false_when_pass_returns_empty(self) -> None:
         with patch("teatree.utils.secrets.read_pass", return_value=""):
             assert secrets.pass_entry_exists("acme/token") is False
+
+
+class TestReadPassRequired:
+    """The fail-loud reader: raise (naming the key) on absent/empty/missing-tool."""
+
+    def test_returns_value_on_happy_path(self) -> None:
+        result = CompletedProcess(args=[], returncode=0, stdout="s3cret\nother\n", stderr="")
+        with patch("teatree.utils.secrets.run_checked", return_value=result):
+            assert secrets.read_pass_required("acme/token") == "s3cret"
+
+    def test_raises_and_names_key_when_entry_absent(self) -> None:
+        with (
+            patch("teatree.utils.secrets.run_checked", side_effect=CommandFailedError(["pass"], 1, "", "nope")),
+            pytest.raises(secrets.SecretNotFoundError, match="acme/token"),
+        ):
+            secrets.read_pass_required("acme/token")
+
+    def test_absent_message_hints_pass_insert(self) -> None:
+        with (
+            patch("teatree.utils.secrets.run_checked", side_effect=CommandFailedError(["pass"], 1, "", "")),
+            pytest.raises(secrets.SecretNotFoundError, match="pass insert acme/token"),
+        ):
+            secrets.read_pass_required("acme/token")
+
+    def test_raises_when_entry_is_empty(self) -> None:
+        result = CompletedProcess(args=[], returncode=0, stdout="\n", stderr="")
+        with (
+            patch("teatree.utils.secrets.run_checked", return_value=result),
+            pytest.raises(secrets.SecretNotFoundError, match="empty"),
+        ):
+            secrets.read_pass_required("acme/token")
+
+    def test_missing_tool_message_differs_from_absent_entry(self) -> None:
+        with (
+            patch("teatree.utils.secrets.run_checked", side_effect=FileNotFoundError),
+            pytest.raises(secrets.SecretNotFoundError, match="not installed"),
+        ):
+            secrets.read_pass_required("acme/token")
+
+
+class TestReadPassOrDefault:
+    """The warn-on-default reader: value when present, default + WARNING when not."""
+
+    def test_returns_secret_when_present(self) -> None:
+        with patch("teatree.utils.secrets.read_pass", return_value="live"):
+            assert secrets.read_pass_or_default("acme/token", "fallback") == "live"
+
+    def test_returns_default_and_warns_when_absent(self, caplog: pytest.LogCaptureFixture) -> None:
+        with patch("teatree.utils.secrets.read_pass", return_value=""), caplog.at_level("WARNING"):
+            assert secrets.read_pass_or_default("acme/token", "fallback") == "fallback"
+        assert "acme/token" in caplog.text


### PR DESCRIPTION
Foundational batch: RunCommand.env, run_timeboxed_step env/stdin, utils.ports/secrets/git_worktree helpers. 187 tests pass, ruff clean.

Closes #3330, #3332, #3338, #3339, #3341.