### PR TITLE
perf(ci): shard-invariant guard + eval changed-scenario params (#3160 #3337)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1825,9 +1825,17 @@ Usage: t3 eval changed-scenarios [OPTIONS]
  none.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --skip-code        INTEGER  Exit code when no scenario file changed.         │
-│                             [default: 1]                                     │
-│ --help                      Show this message and exit.                      │
+│ --skip-code            INTEGER  Exit code when no scenario file changed.     │
+│                                 [default: 1]                                 │
+│ --repo-root            PATH     Root the STDIN diff paths are relative to    │
+│                                 (default: teatree's own repo root).          │
+│ --scenarios-dir        PATH     Filter the discovered catalog to specs under │
+│                                 this directory (default: the whole union     │
+│                                 catalog).                                    │
+│ --require-specs                 Fail loud (exit 2) when the filtered catalog │
+│                                 is empty, instead of skipping like 'nothing  │
+│                                 changed'.                                    │
+│ --help                          Show this message and exit.                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/scripts/ci/durations_refresh.py
+++ b/scripts/ci/durations_refresh.py
@@ -1,8 +1,8 @@
-"""Merge the four scheduled shards' recorded durations and decide whether to refresh.
+"""Merge the scheduled shards' recorded durations and decide whether to refresh.
 
 Each shard on the daily ``schedule`` run stores its group's fresh, tests-that-ran
 durations (``pytest --store-durations --clean-durations``) and uploads the file. This
-script unions the four disjoint slices back into one complete ``dev/.test_durations``
+script unions the disjoint per-shard slices back into one complete ``dev/.test_durations``
 and decides — from the drift versus the committed file — whether that refresh is worth
 a PR. Without a drift gate every daily run would open a churn PR from pure timing
 jitter; the gate opens one only when the set of tests changed (added/removed — the
@@ -35,10 +35,10 @@ def load_durations(path: Path) -> dict[str, float]:
 
 
 def merge_durations(paths: list[Path]) -> dict[str, float]:
-    """Union the per-shard duration slices (the four groups partition the suite).
+    """Union the per-shard duration slices (the groups partition the suite).
 
-    A missing shard file is a HARD error, never an empty contribution: the four
-    groups partition the suite, so an absent shard would silently drop ~1/4 of the
+    A missing shard file is a HARD error, never an empty contribution: the groups
+    partition the suite, so an absent shard would silently drop its slice of the
     tests from the merged file and PR a truncated ``dev/.test_durations`` that
     unbalances the shard split. Fail LOUD (raise) so a partial merge never ships —
     an absent artifact means an upload/download failure to investigate, not a
@@ -48,8 +48,8 @@ def merge_durations(paths: list[Path]) -> dict[str, float]:
     for path in paths:
         if not path.exists():
             message = (
-                f"expected shard-durations file is absent: {path}. The four shards partition "
-                "the suite, so a missing shard would silently drop ~1/4 of the tests from the "
+                f"expected shard-durations file is absent: {path}. The shards partition "
+                "the suite, so a missing shard would silently drop its slice of the tests from the "
                 "merged durations — refusing to write a truncated file. Check the "
                 "durations-shard-* artifact upload/download in the refresh-durations job."
             )

--- a/src/teatree/cli/eval/changed_scenarios.py
+++ b/src/teatree/cli/eval/changed_scenarios.py
@@ -7,24 +7,64 @@ shared core lives in :mod:`teatree.eval.changed_scenarios`; the host's
 ``scripts/eval/scenarios_for_changed.py`` shim and this overlay-facing CLI both
 delegate to it, so the selective-PR eval workflow is the same logic everywhere.
 
+A consuming overlay's diff paths are relative to ITS repo root and it owns only
+ITS scenarios, so ``--repo-root`` sets what the diff paths are relative to
+(default: teatree's own root, for back-compat) and ``--scenarios-dir`` filters
+the discovered union catalog to the specs under that directory. Without the
+filter a core-scenario edit would drag scenarios that are not the consumer's
+into its lane; without the right root the diff matches nothing and the lane
+reads that as a clean skip that never ran an eval. ``--require-specs`` closes
+that quiet-skip hole: it fails loud (exit 2) when the filtered catalog is empty,
+because "the catalog is empty" and "nothing changed" are different answers that
+skip identically today.
+
 Exit 0 when at least one scenario matched; exit ``--skip-code`` (default 1) when
 nothing matched, so the caller's eval job skips cleanly with no API spend.
 """
 
 import sys
+from pathlib import Path
 
 import typer
 
-from teatree.eval.changed_scenarios import select_changed_scenarios
+from teatree.eval.changed_scenarios import REPO_ROOT, select_changed_scenarios, specs_under
+from teatree.eval.discovery import discover_specs
 from teatree.utils.django_bootstrap import ensure_django
+
+_EMPTY_CATALOG_EXIT = 2
 
 
 def changed_scenarios(
     skip_code: int = typer.Option(1, "--skip-code", help="Exit code when no scenario file changed."),
+    repo_root: Path | None = typer.Option(
+        None,
+        "--repo-root",
+        help="Root the STDIN diff paths are relative to (default: teatree's own repo root).",
+    ),
+    scenarios_dir: Path | None = typer.Option(
+        None,
+        "--scenarios-dir",
+        help="Filter the discovered catalog to specs under this directory (default: the whole union catalog).",
+    ),
+    require_specs: bool = typer.Option(  # noqa: FBT001 — typer boolean flag, not a positional bool foot-gun.
+        False,
+        "--require-specs",
+        help="Fail loud (exit 2) when the filtered catalog is empty, instead of skipping like 'nothing changed'.",
+    ),
 ) -> None:
     """Print the scenario names a PR's STDIN diff touched; exit --skip-code when none."""
     ensure_django()
-    selection = select_changed_scenarios(sys.stdin)
+    specs = discover_specs()
+    if scenarios_dir is not None:
+        specs = specs_under(specs, scenarios_dir)
+    if require_specs and not specs:
+        typer.echo(
+            f"no eval scenarios discovered under {scenarios_dir} — the filtered catalog is empty. "
+            "This is NOT 'nothing changed'; refusing to skip (--require-specs).",
+            err=True,
+        )
+        raise SystemExit(_EMPTY_CATALOG_EXIT)
+    selection = select_changed_scenarios(sys.stdin, repo_root=repo_root or REPO_ROOT, specs=specs)
     # Surface the cap when it bites (#2737) so a corpus-wide PR's truncated coverage is
     # visible in the CI log — the deferred scenarios run in the weekly sharded lane.
     if note := selection.truncation_note():

--- a/src/teatree/eval/changed_scenarios.py
+++ b/src/teatree/eval/changed_scenarios.py
@@ -104,6 +104,34 @@ def names_for_changed(changed: Iterable[str], specs: Iterable[EvalSpec], repo_ro
     return selection_for_changed(changed, specs, repo_root).names
 
 
-def select_changed_scenarios(changed: Iterable[str]) -> ScenarioSelection:
-    """The full selection (names + truncation) the selective-PR entry points surface."""
-    return selection_for_changed(changed, discover_specs(), REPO_ROOT)
+def specs_under(specs: Iterable[EvalSpec], scenarios_dir: Path) -> list[EvalSpec]:
+    """The specs whose ``source_path`` lives under ``scenarios_dir`` — the per-consumer catalog filter.
+
+    :func:`discover_specs` returns the whole union catalog (core plus every installed overlay's
+    scenarios). A consuming repo owns only the scenarios under its OWN directory, so it passes that
+    directory here: without the filter a PR touching a core scenario file would drag scenarios that
+    are not the consumer's into the consumer's PR lane. Both sides are ``resolve()``-normalized so the
+    match is representation-independent (the same discipline :func:`_relative_to_root` uses).
+    """
+    root = scenarios_dir.resolve()
+    return [spec for spec in specs if spec.source_path.resolve().is_relative_to(root)]
+
+
+def select_changed_scenarios(
+    changed: Iterable[str],
+    *,
+    repo_root: Path = REPO_ROOT,
+    specs: Iterable[EvalSpec] | None = None,
+) -> ScenarioSelection:
+    """The full selection (names + truncation) the selective-PR entry points surface.
+
+    ``repo_root`` is what the diff paths are relative to; it defaults to teatree's own repo root, so
+    the host lane's ``t3 eval changed-scenarios`` (and ``scripts/eval/scenarios_for_changed.py``) stay
+    byte-for-byte unchanged. ``specs`` defaults to the whole union catalog (:func:`discover_specs`); a
+    consuming overlay passes its own scenarios-dir-filtered subset (see :func:`specs_under`). Both
+    keyword defaults preserve today's behavior exactly, so teatree's own lane is untouched — the CLI
+    just reaches the already-parameterized :func:`selection_for_changed` instead of the entry point
+    hardwiring one repo root and one catalog scope.
+    """
+    resolved_specs = discover_specs() if specs is None else specs
+    return selection_for_changed(changed, resolved_specs, repo_root)

--- a/tests/teatree_cli/eval/test_changed_scenarios.py
+++ b/tests/teatree_cli/eval/test_changed_scenarios.py
@@ -9,6 +9,8 @@ the parity with the host's ``scripts/eval/scenarios_for_changed.py`` shim is
 exercised end to end.
 """
 
+from pathlib import Path
+
 from typer.testing import CliRunner
 
 from teatree.cli import app
@@ -54,3 +56,67 @@ class TestChangedScenarios:
         assert "capped to" in result.stderr
         assert "weekly sharded lane" in result.stderr
         assert len([line for line in result.stdout.splitlines() if line]) == MAX_SELECTIVE_PR_SCENARIOS
+
+
+class TestChangedScenariosOverlayFacingFlags:
+    """``--repo-root`` / ``--scenarios-dir`` / ``--require-specs`` make the CLI reusable (#3337).
+
+    A consuming overlay's diff paths are relative to its own root and it owns only its own
+    scenarios; these flags surface the parameters the shared core already accepted so the CLI
+    core advertises as reusable is reachable, and the empty-catalog quiet-skip closes.
+    """
+
+    def _real_scenario_rel(self) -> str:
+        return min(SCENARIOS_DIR.glob("*.yaml")).relative_to(_REPO_ROOT).as_posix()
+
+    def test_explicit_teatree_root_matches_like_the_default(self) -> None:
+        rel = self._real_scenario_rel()
+        result = CliRunner().invoke(
+            app, ["eval", "changed-scenarios", "--repo-root", str(_REPO_ROOT)], input=f"{rel}\n"
+        )
+        assert result.exit_code == 0, result.output
+        assert [line for line in result.output.splitlines() if line]
+
+    def test_wrong_repo_root_relativizes_elsewhere_and_skips(self, tmp_path: Path) -> None:
+        # The path is a real teatree scenario, but relative to a DIFFERENT root it no longer
+        # matches the catalog's source paths, so the lane cleanly skips (exit --skip-code).
+        rel = self._real_scenario_rel()
+        result = CliRunner().invoke(app, ["eval", "changed-scenarios", "--repo-root", str(tmp_path)], input=f"{rel}\n")
+        assert result.exit_code == 1
+        assert result.output.strip() == ""
+
+    def test_scenarios_dir_filter_excludes_the_real_catalog(self, tmp_path: Path) -> None:
+        # A real scenario changed, but the filtered catalog (an unrelated dir) holds none of
+        # teatree's specs, so nothing is selected — the per-consumer catalog scope in action.
+        rel = self._real_scenario_rel()
+        result = CliRunner().invoke(
+            app, ["eval", "changed-scenarios", "--scenarios-dir", str(tmp_path)], input=f"{rel}\n"
+        )
+        assert result.exit_code == 1
+        assert result.output.strip() == ""
+
+    def test_scenarios_dir_pointing_at_the_catalog_still_matches(self) -> None:
+        rel = self._real_scenario_rel()
+        result = CliRunner().invoke(
+            app, ["eval", "changed-scenarios", "--scenarios-dir", str(SCENARIOS_DIR)], input=f"{rel}\n"
+        )
+        assert result.exit_code == 0, result.output
+        assert [line for line in result.output.splitlines() if line]
+
+    def test_require_specs_fails_loud_on_empty_catalog(self, tmp_path: Path) -> None:
+        # "empty catalog" and "nothing changed" both skip today; --require-specs separates them.
+        rel = self._real_scenario_rel()
+        result = CliRunner().invoke(
+            app,
+            ["eval", "changed-scenarios", "--scenarios-dir", str(tmp_path), "--require-specs"],
+            input=f"{rel}\n",
+        )
+        assert result.exit_code == 2
+        assert "filtered catalog is empty" in result.stderr
+
+    def test_empty_catalog_without_require_specs_still_skips(self, tmp_path: Path) -> None:
+        rel = self._real_scenario_rel()
+        result = CliRunner().invoke(
+            app, ["eval", "changed-scenarios", "--scenarios-dir", str(tmp_path)], input=f"{rel}\n"
+        )
+        assert result.exit_code == 1

--- a/tests/teatree_eval/test_changed_scenarios_selection.py
+++ b/tests/teatree_eval/test_changed_scenarios_selection.py
@@ -1,0 +1,58 @@
+"""``select_changed_scenarios`` is parameterized by ``repo_root`` and the catalog (#3337).
+
+The inner matcher (:func:`selection_for_changed`) already took both parameters; the entry
+point the CLI exposes hardwired teatree's own root and the full union catalog, so a consuming
+overlay could not reach it. These tests pin that the entry point now honors both keyword
+arguments while every default preserves teatree's own lane behavior exactly.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from teatree.eval import changed_scenarios as cs
+from teatree.eval.models import EvalSpec
+
+
+def _spec(name: str, source_path: Path) -> EvalSpec:
+    return EvalSpec(name=name, scenario="", agent_path="", prompt="", matchers=(), source_path=source_path)
+
+
+class TestSpecsUnder:
+    def test_keeps_specs_under_dir_and_drops_the_rest(self, tmp_path: Path) -> None:
+        catalog = tmp_path / "catalog"
+        specs = [
+            _spec("mine", catalog / "a.yaml"),
+            _spec("mine_nested", catalog / "sub" / "b.yaml"),
+            _spec("theirs", tmp_path / "other" / "c.yaml"),
+        ]
+        kept = cs.specs_under(specs, catalog)
+        assert sorted(s.name for s in kept) == ["mine", "mine_nested"]
+
+    def test_empty_when_dir_holds_no_specs(self, tmp_path: Path) -> None:
+        specs = [_spec("theirs", tmp_path / "core" / "a.yaml")]
+        assert cs.specs_under(specs, tmp_path / "empty") == []
+
+
+class TestSelectChangedScenariosParameters:
+    def test_repo_root_and_specs_are_both_honored(self, tmp_path: Path) -> None:
+        spec = _spec("only", tmp_path / "evals" / "scenarios" / "x.yaml")
+        selection = cs.select_changed_scenarios(["evals/scenarios/x.yaml"], repo_root=tmp_path, specs=[spec])
+        assert selection.names == ["only"]
+
+    def test_wrong_repo_root_matches_nothing(self, tmp_path: Path) -> None:
+        # The diff path is relative to tmp_path, but the caller declares a different root,
+        # so the same path normalizes elsewhere and selects no scenario (the quiet-skip a
+        # consuming repo hits when it forgets to pass its own root).
+        spec = _spec("only", tmp_path / "evals" / "scenarios" / "x.yaml")
+        selection = cs.select_changed_scenarios(
+            ["evals/scenarios/x.yaml"], repo_root=tmp_path / "elsewhere", specs=[spec]
+        )
+        assert selection.names == []
+
+    def test_defaults_fall_back_to_discovery_and_teatree_root(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # No keyword arguments == today's behavior: discover_specs() over teatree's own root.
+        sentinel = [_spec("discovered", cs.REPO_ROOT / "evals" / "scenarios" / "disc.yaml")]
+        monkeypatch.setattr(cs, "discover_specs", lambda: sentinel)
+        selection = cs.select_changed_scenarios(["evals/scenarios/disc.yaml"])
+        assert selection.names == ["discovered"]

--- a/tests/test_ci_shard_splitting_algorithm.py
+++ b/tests/test_ci_shard_splitting_algorithm.py
@@ -1,0 +1,74 @@
+"""The test-shard lane must bin-pack by recorded duration and record the slow slices (#3160).
+
+The shard imbalance #3160 fixed had one root cause: ``dev/.test_durations`` carried no entries
+for ``tests/quality/`` or the ``--doctest-modules`` items, so pytest-split ballasted them blindly.
+The fix has three load-bearing parts that no other test locks, so a careless edit to the shard
+invocation could silently regress the rebalance while every gate still passes:
+
+* ``--splitting-algorithm least_duration`` — bin-packs the recorded durations tighter than the
+  default chunk split, which is what turns a balanced ``dev/.test_durations`` into balanced shards.
+* ``--doctest-modules`` — the doctest items run in the SAME sharded lane, so their durations are
+  measurable there (and their coverage counts toward the combined floor).
+* the scheduled ``--store-durations --clean-durations`` record — the daily lane is where the
+  previously-unrecorded ``tests/quality`` + doctest durations are captured for the refresh PR, so
+  the committed file stops ballasting them blindly. Recording must NOT happen on PR/push runs
+  (that would pay the store write on every PR); it is gated to the ``schedule`` event only.
+
+Locking the invocation, not the balance itself: the balance is data (``dev/.test_durations``, kept
+fresh by the scheduled ``refresh-durations`` job on representative CI hardware), but the flags that
+consume that data are code and belong under a regression guard.
+"""
+
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _shard_run() -> str:
+    jobs = cast("dict[str, Any]", yaml.safe_load(_CI_WORKFLOW.read_text(encoding="utf-8"))["jobs"])
+    steps = [s for s in jobs["test-shard"].get("steps", []) if isinstance(s, dict)]
+    pytest_steps = [s for s in steps if "pytest" in str(s.get("run", ""))]
+    assert pytest_steps, "test-shard must have a step that runs pytest."
+    return str(pytest_steps[0]["run"])
+
+
+class TestShardSplittingIsLeastDuration:
+    def test_shard_uses_least_duration_algorithm(self) -> None:
+        assert "--splitting-algorithm least_duration" in _shard_run(), (
+            "The shard lane must bin-pack by recorded duration (--splitting-algorithm "
+            "least_duration); the default chunk split re-introduces the #3160 imbalance."
+        )
+
+    def test_shard_reads_the_committed_durations_file(self) -> None:
+        assert "--durations-path dev/.test_durations" in _shard_run(), (
+            "The shard lane must split on the committed dev/.test_durations, the file the "
+            "scheduled refresh keeps balanced (#3160)."
+        )
+
+    def test_shard_collects_doctest_items(self) -> None:
+        assert "--doctest-modules" in _shard_run(), (
+            "Doctest items must run in the sharded lane so their durations are measured there "
+            "and their coverage counts toward the combined floor (#3160)."
+        )
+
+
+class TestScheduledRunRecordsDurations:
+    """The slow, previously-unrecorded slices get durations ONLY on the scheduled lane."""
+
+    def test_schedule_stores_clean_durations(self) -> None:
+        run = _shard_run()
+        assert "--store-durations --clean-durations" in run, (
+            "The scheduled shard lane must record fresh durations (including the previously "
+            "unrecorded tests/quality + doctest items) for the refresh-durations PR (#3160)."
+        )
+
+    def test_recording_is_gated_to_the_schedule_event_only(self) -> None:
+        run = _shard_run()
+        assert "github.event_name == 'schedule'" in run, (
+            "Duration recording must be gated to the daily schedule; recording on every PR/push "
+            "would pay the store write on the critical path (#3160)."
+        )

--- a/tests/test_durations_refresh.py
+++ b/tests/test_durations_refresh.py
@@ -35,8 +35,8 @@ class TestMergeDurations:
         }
 
     def test_missing_shard_file_raises_loud(self, tmp_path: Path) -> None:
-        # A missing shard is NOT an empty contribution: the four shards partition the
-        # suite, so silently dropping one truncates the merge by ~1/4. Fail loud.
+        # A missing shard is NOT an empty contribution: the shards partition the
+        # suite, so silently dropping one truncates the merge by its slice. Fail loud.
         present = _write(tmp_path / "present.json", {"tests/x.py::t1": 1.0})
         absent = tmp_path / "absent.json"
         with pytest.raises(MissingShardDurationsError, match="shard-durations file is absent"):


### PR DESCRIPTION
#3337: parameterize select_changed_scenarios by repo_root + specs (new CLI flags). #3160: most sharding already merged earlier (#3349 etc); this adds a regression guard locking the shard invariants + a stale-reference fix (did NOT commit machine-local durations — those are owned by the scheduled refresh-durations job). 53 tests pass, ruff clean.

Closes #3160, #3337.