### PR TITLE
fix(gates): batch safety/publish false-positive fixes (#3240 #3252 #3357 #3343 #3344)

### DIFF
--- a/hooks/scripts/hook_router.py
+++ b/hooks/scripts/hook_router.py
@@ -110,6 +110,7 @@ from hooks.scripts.loop_owner_db import db_owner_is_current_session as _db_owner
 from hooks.scripts.loop_registrations import emit_loop_registrations, is_bare_loop_tick_prompt
 from hooks.scripts.loop_state_self_pump_gate import db_loop_state_suppresses_self_pump
 from hooks.scripts.main_clone_guard import handle_block_main_clone_mutation
+from hooks.scripts.managed_repo import cwd_teatree_managed_state as _cwd_is_teatree_managed
 from hooks.scripts.managed_repo import file_is_inside_worktree as _file_is_inside_worktree
 from hooks.scripts.managed_repo import is_agent_state_path as _is_agent_state_path
 from hooks.scripts.managed_repo import load_protected_branches as _load_protected_branches
@@ -124,7 +125,7 @@ from hooks.scripts.mr_cli_fields import (
     cli_update_is_title_only,
     extract_cli_mr_fields,
     extract_mr_target_repo,
-    merge_target_is_managed,
+    merge_target_managed_state,
 )
 from hooks.scripts.no_self_reviewer_assign import handle_block_self_reviewer_assign
 from hooks.scripts.orchestration_boundary_signals import PYTEST_VERB_FINDER as _PYTEST_VERB_FINDER
@@ -162,6 +163,7 @@ from hooks.scripts.state_files import append_line, read_lines
 from hooks.scripts.stop_snapshot_slot import handle_stop_snapshot_slot
 from hooks.scripts.stop_snapshot_slot import open_prs_for_repo as _open_prs_for_repo
 from hooks.scripts.stop_snapshot_slot import run_prepare_stop_best_effort as _run_prepare_stop_best_effort
+from hooks.scripts.subagent_hint import suppress_self_auth_hint_for_subagent as _suppress_self_auth_hint_for_subagent
 from hooks.scripts.subagent_no_commit import handle_subagent_stop_no_commit
 from hooks.scripts.subagent_skill_gate import is_file_safe, unreferenced_demand_reason
 from hooks.scripts.teatree_settings import autoload_enabled as _autoload_enabled
@@ -333,7 +335,11 @@ def emit_pretooluse_deny(reason: str, *, gate_id: str | None = None) -> bool:
     decision = _apply_deny_circuit_breaker(reason)
     if decision.allow:
         return False
-    return _write_pretooluse_deny(decision.reason, gate_id=gate_id)
+    # A sub-agent deny must not advertise the ALLOW_*/QUOTE_OK self-bypass hint it
+    # cannot self-authorize (the classifier-denied retry poisoned its context) —
+    # rewrite the hint to escalation guidance, deny unchanged (#3252, sibling leaf).
+    reason_out = _suppress_self_auth_hint_for_subagent(decision.reason, _current_hook_context()[1])
+    return _write_pretooluse_deny(reason_out, gate_id=gate_id)
 
 
 def _write_pretooluse_deny(reason: str, *, gate_id: str | None = None) -> bool:
@@ -5240,8 +5246,9 @@ _OUT_OF_BAND_MERGE_REASON = (
     "MergeClear validation, SHA-binding, privacy/AI-signature scan, mark_merged). "
     "Use the sanctioned keystone transition `t3 <overlay> ticket merge <clear_id>` "
     "(BLUEPRINT §17.1 invariant 8 / §17.4). If this repo is genuinely not "
-    "teatree-managed and the cwd could not be resolved, run the merge from inside "
-    "the repo's working tree so the gate can classify it. kill-switch: `t3 <overlay> gate raw-merge disable`."
+    "teatree-managed, name the target explicitly with `--repo <owner>/<repo>` (or "
+    "a full forge URL) so the gate classifies it from the command itself and never "
+    "consults the cwd. kill-switch: `t3 <overlay> gate raw-merge disable`."
 )
 
 
@@ -5261,35 +5268,6 @@ def _is_raw_merge_api_write(command: str) -> bool:
             return raw_merge_detect.is_raw_merge_api_write(command)
     except Exception:  # noqa: BLE001 (fail-closed: a broken import must not weaken the merge gate)
         return True
-
-
-def _cwd_is_teatree_managed(cwd: Path) -> bool | None:
-    """Whether *cwd* belongs to a teatree-managed repo.
-
-    Returns ``True`` (managed — keep the keystone-merge block), ``False``
-    (unmanaged — allow a raw merge), or ``None`` (cannot classify — the
-    caller fails safe and BLOCKS). Reuses ``publish_surface.slug_for_cwd``
-    for slug resolution so the host/owner/repo shape matches the
-    private-repo carve-out's.
-    """
-    slugs, paths = _overlay_managed_repo_signals()
-    for base in paths:
-        # is_relative_to, not relative_to: a non-subpath returns False instead
-        # of raising ValueError, which the suppress() below does NOT catch — an
-        # uncaught crash here makes the crash-proof dispatcher fail OPEN.
-        with contextlib.suppress(OSError, RuntimeError):
-            if cwd.resolve().is_relative_to(base):
-                return True
-    try:
-        with _teatree_src_on_path():
-            from teatree.hooks import publish_surface  # noqa: PLC0415 — deferred: cold-hook import after sys.path setup
-
-            slug = publish_surface.slug_for_cwd(cwd).lower()
-    except Exception:  # noqa: BLE001 — crash-proof hook: any failure degrades silently, never breaks the tool call
-        return None
-    if not slug:
-        return None
-    return any(entry in slug for entry in slugs)
 
 
 def _invokes_raw_merge_subcommand(command: str) -> bool:
@@ -5322,9 +5300,10 @@ def handle_block_out_of_band_merge(data: dict) -> bool:
     mutation (mergePullRequest / enablePullRequestAutoMerge / mergeBranch) has an
     unresolvable node-id target, so it is blocked (fail-closed).
 
-    Otherwise classification keys on the merge TARGET (parsed from the command),
-    not the cwd — a managed-repo target is BLOCKED regardless of cwd; when none
-    parses, the cwd-keyed fallback (#126) allows only a confidently-unmanaged cwd.
+    Otherwise classification keys on the merge TARGET via a tri-state
+    (:func:`merge_target_managed_state`): a managed target is BLOCKED regardless of
+    cwd; a confidently-unmanaged target is ALLOWED on its own evidence; only when NO
+    target parses does the cwd-keyed fallback (#126) run (#3343).
     """
     if data.get("tool_name") != "Bash":
         return False
@@ -5339,10 +5318,17 @@ def handle_block_out_of_band_merge(data: dict) -> bool:
         return _fail_open_or_deny(data, _OUT_OF_BAND_MERGE_REASON)
     if not _invokes_raw_merge_subcommand(command) and not _is_raw_merge_api_write(command):
         return False
-    if not merge_target_is_managed(command, _overlay_managed_repo_signals()[0]):
+    # Tri-state target classification (#3343): a managed target → BLOCK regardless
+    # of cwd; a confidently-UNMANAGED target → ALLOW on its own evidence, never
+    # keyed off cwd (the bug: a non-git cwd forced a deny on a classifiable target).
+    # Only a NON-resolvable target (None) consults the cwd fallback (#126), allowing
+    # a confidently-unmanaged cwd (a non-classifiable cwd fails safe to BLOCK).
+    target_state = merge_target_managed_state(command, _overlay_managed_repo_signals()[0])
+    if target_state is None:
         cwd = _resolve_cwd_repo(data)
-        if cwd is not None and _cwd_is_teatree_managed(cwd) is False:
-            return False
+        target_state = not (cwd is not None and _cwd_is_teatree_managed(cwd) is False)
+    if target_state is False:
+        return False
     return _fail_open_or_deny(data, _OUT_OF_BAND_MERGE_REASON)
 
 

--- a/hooks/scripts/managed_repo.py
+++ b/hooks/scripts/managed_repo.py
@@ -60,7 +60,7 @@ def teatree_src_on_path() -> Iterator[None]:
                 sys.path.remove(src_dir)
 
 
-def db_overlays_registry() -> dict[str, Any] | None:
+def _db_overlays_registry() -> dict[str, Any] | None:
     """The DB-home ``overlays`` registry dict, or ``None`` on any absence/failure.
 
     The cold-hook twin of ``loader._inject_db_registries``: reads the canonical
@@ -83,10 +83,10 @@ def db_overlays_registry() -> dict[str, Any] | None:
 def overlays_registry() -> dict[str, Any]:
     """The effective overlay registry: the DB-home ``overlays`` ``ConfigSetting`` row.
 
-    Reads the migrated ``overlays`` row DB-only via :func:`db_overlays_registry`.
+    Reads the migrated ``overlays`` row DB-only via :func:`_db_overlays_registry`.
     ``{}`` when the DB read yields nothing/empty or fails.
     """
-    return db_overlays_registry() or {}
+    return _db_overlays_registry() or {}
 
 
 def load_protected_branches() -> set[str]:
@@ -206,6 +206,38 @@ def repo_root_is_teatree_managed(repo_root: str) -> bool:
     except Exception:  # noqa: BLE001 — crash-proof hook: any failure degrades silently, never breaks the tool call
         return False
     return any(entry in slug for entry in slugs) if slug else False
+
+
+def cwd_teatree_managed_state(cwd: Path) -> bool | None:
+    """Tri-state: whether *cwd* belongs to a teatree-managed repo.
+
+    Returns ``True`` (managed — the out-of-band merge gate keeps the keystone-merge
+    block), ``False`` (unmanaged — allow a raw merge), or ``None`` (cannot classify
+    — the caller fails SAFE and BLOCKS). This is the fail-SAFE-to-``None`` twin of
+    :func:`repo_root_is_teatree_managed` (which fails OPEN to ``False`` for its
+    protected-branch / main-clone consumers); the merge gate needs "unknown" kept
+    distinct from "unmanaged" so an unresolvable cwd blocks rather than allows.
+    Reuses :func:`overlay_managed_repo_signals` and ``publish_surface.slug_for_cwd``
+    so the host/owner/repo shape matches the rest of the managed-repo machinery.
+    """
+    slugs, paths = overlay_managed_repo_signals()
+    for base in paths:
+        # is_relative_to, not relative_to: a non-subpath returns False instead
+        # of raising ValueError, which the suppress() below does NOT catch — an
+        # uncaught crash here makes the crash-proof dispatcher fail OPEN.
+        with contextlib.suppress(OSError, RuntimeError):
+            if cwd.resolve().is_relative_to(base):
+                return True
+    try:
+        with teatree_src_on_path():
+            from teatree.hooks import publish_surface  # noqa: PLC0415 — deferred: cold-hook import after sys.path setup
+
+            slug = publish_surface.slug_for_cwd(cwd).lower()
+    except Exception:  # noqa: BLE001 — crash-proof hook: any failure degrades silently, never breaks the tool call
+        return None
+    if not slug:
+        return None
+    return any(entry in slug for entry in slugs)
 
 
 def resolve_branch_and_root(parent: str) -> tuple[str, str] | None:

--- a/hooks/scripts/mr_cli_fields.py
+++ b/hooks/scripts/mr_cli_fields.py
@@ -306,20 +306,33 @@ def extract_mr_target_repo(command: str) -> str | None:
     return None
 
 
-def merge_target_is_managed(command: str, managed_slugs: list[str]) -> bool:
-    """Whether the command's MR-TARGET slug names a teatree-managed repo.
+def merge_target_managed_state(command: str, managed_slugs: list[str]) -> bool | None:
+    """Tri-state classification of the command's MR-TARGET repo (#3343).
 
-    Classifies the merge TARGET (parsed by :func:`extract_mr_target_repo`),
-    NOT the agent's cwd, so a raw merge form aimed at a managed repo is caught
-    regardless of where it runs. Returns ``True`` only when a target slug
-    parses AND contains one of the ``managed_slugs`` signal substrings (the
-    same offline set the cwd-keyed check uses). A non-parseable target — a
-    numeric GitLab project id, or a bare ``gh pr merge <n>`` with no
-    ``--repo`` — returns ``False`` so the caller falls back to its cwd-keyed
-    classification (the established fail-safe).
+    Classifies the merge TARGET (parsed by :func:`extract_mr_target_repo`), NOT
+    the agent's cwd, so a raw merge form aimed at a managed repo is caught
+    regardless of where it runs. ``True`` — a target slug PARSES and matches a
+    ``managed_slugs`` signal (managed → the caller BLOCKS). ``False`` — a target
+    resolves to a real ``owner/repo`` namespace (contains a ``/``) matching no
+    managed signal (a CONFIDENT unmanaged verdict → the caller ALLOWS on the
+    target's own evidence, never consulting cwd). ``None`` — NO RESOLVABLE target:
+    none parses at all (a bare ``gh pr merge <n>``), OR the parsed target is an
+    OPAQUE id the offline slug set cannot classify (a numeric GitLab ``projects/5``
+    id, which could well BE a managed repo whose slug is unresolvable offline) →
+    the caller falls back to its cwd-keyed classification (never-lockout fail-safe).
+
+    The plain ``bool`` this replaces conflated the last two states: a
+    confidently-unmanaged TARGET was indistinguishable from NO target, so it always
+    fell through to the cwd rule and a non-git cwd denied a merge the gate never
+    meant to block. Mirroring the tri-state ``cwd_teatree_managed_state`` shape
+    makes ``None`` expressible (#3343).
     """
     target = extract_mr_target_repo(command)
     if target is None:
-        return False
+        return None
     target_lower = target.strip().lower()
-    return bool(target_lower) and any(entry in target_lower for entry in managed_slugs)
+    # Only a namespaced ``owner/repo`` slug is classifiable offline; an opaque id
+    # (no ``/``) cannot be confirmed unmanaged, so defer to the cwd fail-safe.
+    if "/" not in target_lower:
+        return None
+    return any(entry in target_lower for entry in managed_slugs)

--- a/hooks/scripts/subagent_hint.py
+++ b/hooks/scripts/subagent_hint.py
@@ -1,0 +1,57 @@
+"""Sub-agent deny-hint rewriting (#3252) — a bare sibling of the router split.
+
+The banned-terms / quote-scanner leak denies advertise a false-positive escape
+hatch as a leading override env prefix (``ALLOW_BANNED_TERM=1`` / ``QUOTE_OK=1``).
+A SUB-AGENT cannot self-authorize that bypass: the auto-mode classifier denies the
+retry as an "unauthorized safety-gate bypass", which poisoned the sub-agent's whole
+context. :func:`suppress_self_auth_hint_for_subagent` rewrites the hint at the
+router's ``emit_pretooluse_deny`` chokepoint when the call is from a sub-agent (a
+non-empty ``agent_id``), pointing it at the route it CAN take — escalate to the
+main agent / user — while the deny itself stays fail-closed. A main-agent deny
+keeps the verbatim escape-hatch hint.
+
+Extracted from ``hook_router`` (the #2384 router-shrink contract: a new concern
+goes in a bare sibling, never the god-module) and imported back into the router.
+Cold-import safe: stdlib only, no Django / ``teatree.core``.
+"""
+
+import re
+import sys
+
+from hooks.scripts.orchestration_boundary_signals import call_is_from_subagent
+
+# Alias both identities so a bare ``from subagent_hint import ...`` (live hook,
+# whose dir is on sys.path) and the ``hooks.scripts.subagent_hint`` form
+# (subprocess / test import) resolve the SAME module object.
+sys.modules.setdefault("subagent_hint", sys.modules[__name__])
+sys.modules.setdefault("hooks.scripts.subagent_hint", sys.modules[__name__])
+
+# The self-authorize hint sentence the leak-gate deny messages emit: "If the match
+# is a false positive, re-issue the command with a leading <ENV>=1 env prefix (e.g.
+# `<ENV>=1 <command>`)." Matched as a unit so the whole sentence is replaced.
+_SELF_AUTH_HINT_RE = re.compile(
+    r"If the match is a false positive, re-issue the command with a leading "
+    r"\w+=1 env prefix \(e\.g\. `[^`]*`\)\."
+)
+_SUBAGENT_ESCALATE_HINT = (
+    "If the match is a false positive, do NOT retry with a self-bypass env prefix "
+    "— a sub-agent cannot self-authorize it (the retry is denied as a safety-gate "
+    "bypass); report the false positive to the main agent / user, who can authorize it."
+)
+
+
+def suppress_self_auth_hint_for_subagent(reason: str, data: dict) -> str:
+    """Rewrite a self-authorize escape-hatch hint when the deny is for a sub-agent.
+
+    Sub-agents (:func:`call_is_from_subagent`) cannot self-authorize the
+    ``ALLOW_*=1`` / ``QUOTE_OK=1`` override, so the verbatim hint would only lead
+    them into a classifier-denied retry loop (#3252). Main-agent denies keep the
+    hint unchanged. Never raises — on any unexpected shape the reason is returned
+    untouched (the deny must always be emitted).
+    """
+    try:
+        if not call_is_from_subagent(data):
+            return reason
+        return _SELF_AUTH_HINT_RE.sub(_SUBAGENT_ESCALATE_HINT, reason)
+    except Exception:  # noqa: BLE001 — a hint-rewrite fault must never drop the deny; emit the original.
+        return reason

--- a/src/teatree/hooks/_gh_glab_hiding.py
+++ b/src/teatree/hooks/_gh_glab_hiding.py
@@ -36,7 +36,7 @@ heaviest consumer; publish_surface re-imports both.
 import re
 from typing import Final
 
-from teatree.hooks._shell_lexer import TokenKind, split_commands, tokenize
+from teatree.hooks._shell_lexer import TokenKind, raw_substitution_sees_live, split_commands, tokenize
 
 # A leading ``KEY=value`` token is an inline env assignment, not the
 # command name -- bash applies it to the command's environment. Skipped
@@ -82,12 +82,18 @@ _CD_WITH_PATH_WORD_COUNT: Final[int] = 2
 _BARE_SHORT_FLAG_LEN: Final[int] = 2
 
 
-def command_segments(command: str) -> list[list[str]]:
-    """Return the WORD-value lists of every ``&&``/``;``/``|``/``&``/newline segment.
+def command_segments_with_raw(command: str) -> list[tuple[list[str], list[str]]]:
+    """Return each segment's decoded WORD values PAIRED with their raw source spans.
 
-    Each segment's leading inline env assignments (``FOO=1 gh ...``) are
-    stripped, mirroring :func:`publish_surface.is_git_commit_command`, so a
-    posting verb behind an env prefix is still seen. Empty segments are dropped.
+    Same segment splitting and leading-env-assignment stripping as
+    :func:`command_segments`, but each segment carries a second list — the
+    verbatim ``Token.raw`` source span of every retained word, index-aligned with
+    its decoded value. The raw span preserves quoting the decoded value has
+    dropped, which is what lets a consumer tell a LIVE substitution (unquoted /
+    double-quoted, bash expands it) from an INERT one (inside single quotes, bash
+    passes it verbatim) — a distinction the decoded value alone cannot make
+    (#3357). :func:`command_segments` is a view over this so the two can never
+    drift.
 
     The banned-terms SCANNER inspects the WHOLE payload (it finds a term in
     any segment), so the carve-out must inspect every segment too -- a
@@ -95,14 +101,26 @@ def command_segments(command: str) -> list[list[str]]:
     a true command, not noise, and ignoring it over-blocks a legitimate
     private-repo post.
     """
-    segments: list[list[str]] = []
+    segments: list[tuple[list[str], list[str]]] = []
     for segment in split_commands(tokenize(command)):
-        words = [tok.value for tok in segment if tok.kind is TokenKind.WORD]
-        while words and ENV_ASSIGNMENT_RE.fullmatch(words[0]):
-            words = words[1:]
-        if words:
-            segments.append(words)
+        word_tokens = [tok for tok in segment if tok.kind is TokenKind.WORD]
+        while word_tokens and ENV_ASSIGNMENT_RE.fullmatch(word_tokens[0].value):
+            word_tokens = word_tokens[1:]
+        if word_tokens:
+            segments.append(([tok.value for tok in word_tokens], [tok.raw for tok in word_tokens]))
     return segments
+
+
+def command_segments(command: str) -> list[list[str]]:
+    """Return the WORD-value lists of every ``&&``/``;``/``|``/``&``/newline segment.
+
+    A view over :func:`command_segments_with_raw` (dropping the raw spans) so the
+    decoded-word splitting the two expose can never drift. Each segment's leading
+    inline env assignments (``FOO=1 gh ...``) are stripped, mirroring
+    :func:`publish_surface.is_git_commit_command`, so a posting verb behind an env
+    prefix is still seen. Empty segments are dropped.
+    """
+    return [words for words, _ in command_segments_with_raw(command)]
 
 
 def strip_benign_prefix(words: list[str]) -> list[str] | None:
@@ -140,6 +158,29 @@ def token_has_substitution_marker(token: str) -> bool:
     (``--body "$(gh ... --repo PUBLIC ...)"``) just as easily as a bare token.
     """
     return any(marker in token for marker in _SUBSTITUTION_MARKERS)
+
+
+def raw_has_live_substitution(raw: str) -> bool:
+    """Return True iff a substitution marker in ``raw`` is one bash would EXPAND.
+
+    Reads the token's as-written source span rather than its decoded value:
+    ``$(``/``<(``/``>(``/backtick is expanded by bash only when it is unquoted or
+    inside DOUBLE quotes; inside SINGLE quotes it is inert literal text bash passes
+    verbatim. Delegates the quote-aware walk to the shared lexer state machine
+    (:func:`_shell_lexer.raw_substitution_sees_live`), the same walker the two
+    sibling pre-publish raw-span checks (``_body_file_resolution`` /
+    ``_publish_detection``) already use — so all three classify a substitution
+    identically (#3357).
+
+    An EMPTY raw span is treated as LIVE (fail closed): an in-process caller that
+    constructed a token without a source span cannot prove the marker inert, so
+    the gate keeps scanning. This is the quote-aware replacement for
+    :func:`token_has_substitution_marker`, which fired on the decoded value and so
+    could not tell an inert single-quoted marker from a live one.
+    """
+    if not raw:
+        return True
+    return raw_substitution_sees_live(raw, _SUBSTITUTION_MARKERS)
 
 
 def token_is_transport_construct(token: str) -> bool:

--- a/src/teatree/hooks/public_visibility.py
+++ b/src/teatree/hooks/public_visibility.py
@@ -34,7 +34,7 @@ and :mod:`teatree.hooks._repo_visibility` are both at the per-file LOC cap.
 from pathlib import Path
 
 from teatree.hooks import _commit_carve_out, _repo_visibility
-from teatree.hooks._gh_glab_hiding import command_segments
+from teatree.hooks._gh_glab_hiding import command_segments_with_raw
 from teatree.hooks._publish_detection import segment_is_api_read, segment_is_api_write
 from teatree.hooks.publish_destination import (
     Destination,
@@ -109,17 +109,24 @@ def _api_write_targets_non_public(words: list[str], *, config_path: Path | None 
     return not is_affirmatively_public(dest, config_path=config_path)
 
 
-def _segment_visibility_verdict(words: list[str], cwd: Path | None, *, config_path: Path | None) -> str:
+def _segment_visibility_verdict(
+    words: list[str], raws: list[str], cwd: Path | None, *, config_path: Path | None
+) -> str:
     """Classify one top-level segment as :data:`_SCAN` / :data:`_SKIP_PUBLISH` / :data:`_SKIP_INERT`.
 
-    A ``$(...)``/transport construct or an unrecognised chained executable forces
-    :data:`_SCAN` (the ALL-SEGMENTS anti-leak posture); a repo-targeted publish
-    to an affirmatively-PUBLIC target forces :data:`_SCAN`; a repo-targeted
+    A LIVE ``$(...)``/transport construct or an unrecognised chained executable
+    forces :data:`_SCAN` (the ALL-SEGMENTS anti-leak posture); a repo-targeted
+    publish to an affirmatively-PUBLIC target forces :data:`_SCAN`; a repo-targeted
     publish (structured or ``api`` WRITE) to a NON-public or UNRESOLVABLE target
     is :data:`_SKIP_PUBLISH` (an unknown target skips, per #1415); an ``api``
     read or an inert nav/local segment is :data:`_SKIP_INERT`.
+
+    ``raws`` carries each token's as-written source span (index-aligned with
+    ``words``) so the substitution check fires only on a marker bash would actually
+    expand -- an inert marker inside a single-quoted body value does not force a
+    scan on a private-target post (#3357).
     """
-    if _segment_carries_substitution_or_transport(words):
+    if _segment_carries_substitution_or_transport(words, raws):
         return _SCAN
     if segment_is_api_write(words):
         return _SKIP_PUBLISH if _api_write_targets_non_public(words, config_path=config_path) else _SCAN
@@ -167,12 +174,12 @@ def gate_skips_for_visibility(command: str, cwd: Path | None, *, config_path: Pa
     """
     if _commit_carve_out.command_has_git_commit_segment(command):
         return False
-    segments = command_segments(command)
+    segments = command_segments_with_raw(command)
     if not segments:
         return False
     saw_repo_publish = False
-    for words in segments:
-        verdict = _segment_visibility_verdict(words, cwd, config_path=config_path)
+    for words, raws in segments:
+        verdict = _segment_visibility_verdict(words, raws, cwd, config_path=config_path)
         if verdict == _SCAN:
             return False
         if verdict == _SKIP_PUBLISH:

--- a/src/teatree/hooks/publish_destination.py
+++ b/src/teatree/hooks/publish_destination.py
@@ -46,7 +46,7 @@ from typing import Final
 
 from teatree.config import cold_reader
 from teatree.hooks._command_parser import first_segment_words
-from teatree.hooks._gh_glab_hiding import token_has_substitution_marker, token_is_transport_construct
+from teatree.hooks._gh_glab_hiding import raw_has_live_substitution, token_is_transport_construct
 from teatree.hooks._python_rest_detection import find_python_forge_rest_urls, is_python_leader
 from teatree.hooks._repo_visibility import (
     forge_qualified_slug,
@@ -421,17 +421,28 @@ def resolve_publish_destination(command: str, cwd: Path | None = None) -> Destin
     return _destination_from_words(first_segment_words(command), cwd)
 
 
-def _segment_carries_substitution_or_transport(words: list[str]) -> bool:
-    """Return True iff any token is a substitution marker or transport construct.
+def _segment_carries_substitution_or_transport(words: list[str], raws: list[str]) -> bool:
+    """Return True iff any token is a LIVE substitution or a transport construct.
 
-    A ``$(...)`` / backtick / process-substitution token, or a
-    redirection/here-doc/group-opener token, can run a SECOND command (a
-    public post) when the shell expands the line -- so the gate must NOT skip
-    and must scan instead. Mirrors the carve-out's fail-closed posture on
-    these constructs (a quoted flag value carrying ``$(...)`` still trips the
-    substitution check, since a public post can hide inside a body value).
+    A ``$(...)`` / backtick / process-substitution that bash would EXPAND, or a
+    redirection/here-doc/group-opener token, can run a SECOND command (a public
+    post) when the shell processes the line -- so the gate must NOT skip and must
+    scan instead.
+
+    The substitution half reads each token's as-written source span (``raws``,
+    index-aligned with ``words``) via :func:`raw_has_live_substitution` rather than
+    its decoded value: a marker inside a SINGLE-quoted body value is inert literal
+    text bash passes verbatim (``--body 'name the `flag` here'``), so it cannot
+    launch a second command and must NOT force a scan on an otherwise
+    private-target post (#3357). A marker that is unquoted or inside DOUBLE quotes
+    still expands, so it still scans -- the exact live-versus-inert distinction the
+    sibling opaque-transport check already makes. An empty raw span fails closed
+    (treated as live). The transport-construct half stays on the decoded ``words``,
+    where it belongs.
     """
-    return any(token_has_substitution_marker(token) or token_is_transport_construct(token) for token in words)
+    if any(raw_has_live_substitution(raw) for raw in raws):
+        return True
+    return any(token_is_transport_construct(token) for token in words)
 
 
 def _segment_is_skip_inert(words: list[str]) -> bool:

--- a/src/teatree/loop/substrate_pinger.py
+++ b/src/teatree/loop/substrate_pinger.py
@@ -24,6 +24,15 @@ class NotifyWithFallbackSubstratePinger:
     """
 
     def ping(self, *, text: str, idempotency_key: str) -> None:  # noqa: PLR6301 — instance method satisfies the injected SubstratePinger Protocol.
+        # One kwarg per line, deliberately: gitleaks' generic-api-key rule keys off
+        # a ``…key=`` prefix and then captures the following high-entropy-looking
+        # text. On the one-line call it ran the capture on past ``idempotency_key=``
+        # onto ``audience=NotifyAudience.INTERNAL`` (an enum reference, no secret) and
+        # false-tripped the repo's own secret gate (#3344). Breaking each kwarg onto
+        # its own line stops the capture running across kwargs.
         notify_with_fallback(
-            text=text, kind=NotifyKind.INFO, idempotency_key=idempotency_key, audience=NotifyAudience.INTERNAL
+            text=text,
+            kind=NotifyKind.INFO,
+            idempotency_key=idempotency_key,
+            audience=NotifyAudience.INTERNAL,
         )

--- a/tests/teatree_hooks/test_public_visibility.py
+++ b/tests/teatree_hooks/test_public_visibility.py
@@ -199,3 +199,53 @@ class TestApiWriteUnresolvableDoesNotSkip:
     def test_confirmed_public_api_write_does_not_skip(self, monkeypatch: pytest.MonkeyPatch) -> None:
         cmd = "gh api repos/souliane/teatree/issues -f body=x"
         assert self._skips(cmd, monkeypatch, "PUBLIC") is False
+
+
+class TestInertSubstitutionMarkerInBodyValue:
+    """A substitution marker forces a SCAN only when bash would EXPAND it (#3357).
+
+    ``_segment_carries_substitution_or_transport`` used to fire on the DECODED
+    token value, so a ``$(``/backtick inside a SINGLE-quoted body value -- inert
+    literal text bash passes verbatim (markdown inline code naming a flag/module
+    is the everyday case) -- forced a SCAN and preempted the #3251 private-target
+    skip, hard-blocking an ordinary private-target post. The fix reads the token's
+    as-written source span so an INERT single-quoted marker no longer forces the
+    scan, while the SECURITY invariants stand: a LIVE substitution (unquoted or
+    double-quoted) still scans on EVERY target, and any marker toward a PUBLIC
+    target still scans.
+    """
+
+    @staticmethod
+    def _skips(command: str, monkeypatch: pytest.MonkeyPatch, verdict: str | None) -> bool:
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: verdict)
+        return public_visibility.gate_skips_for_visibility(command, cwd=None)
+
+    def test_single_quoted_backtick_in_body_toward_private_skips(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Inert markdown inline code in a private-target body value: the false trip.
+        cmd = "gh issue create --repo owner/private-svc --body 'name the `flag` here'"
+        assert self._skips(cmd, monkeypatch, "PRIVATE") is True
+
+    def test_single_quoted_command_substitution_in_body_toward_private_skips(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cmd = "gh issue create --repo owner/private-svc --body 'run $(gh issue create) now'"
+        assert self._skips(cmd, monkeypatch, "PRIVATE") is True
+
+    def test_unquoted_live_substitution_toward_private_still_scans(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A LIVE substitution can launch a hidden second command (a public post),
+        # so it must NEVER skip -- not even toward a private primary target.
+        cmd = "gh issue create --repo owner/private-svc --body $(cmd)"
+        assert self._skips(cmd, monkeypatch, "PRIVATE") is False
+
+    def test_double_quoted_live_substitution_toward_private_still_scans(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cmd = 'gh issue create --repo owner/private-svc --body "run $(cmd)"'
+        assert self._skips(cmd, monkeypatch, "PRIVATE") is False
+
+    def test_plain_private_body_skips(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cmd = "gh issue create --repo owner/private-svc --body plainbody"
+        assert self._skips(cmd, monkeypatch, "PRIVATE") is True
+
+    def test_inert_marker_toward_public_target_still_scans(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Anti-vacuity: an inert marker does not weaken the gate on a PUBLIC target.
+        cmd = "gh issue create --repo souliane/teatree --body 'name the `flag` here'"
+        assert self._skips(cmd, monkeypatch, "PUBLIC") is False

--- a/tests/teatree_loop/test_substrate_pinger_gitleaks_shape.py
+++ b/tests/teatree_loop/test_substrate_pinger_gitleaks_shape.py
@@ -1,0 +1,45 @@
+"""Regression: the substrate-pinger notify call must not false-trip gitleaks (#3344).
+
+``gitleaks``' ``generic-api-key`` rule keys off a ``…key=`` prefix and then
+captures the following high-entropy-looking text. When the ``notify_with_fallback``
+call was one ~105-char line, the capture ran on past ``idempotency_key=`` onto
+``audience=NotifyAudience.INTERNAL`` (an enum reference, no secret) and the repo's
+own secret gate false-tripped on a clean checkout. Breaking each kwarg onto its own
+line (kept expanded by ruff's magic trailing comma) stops the capture running across
+kwargs. This test pins the source shape so a future reflow cannot silently
+re-collapse the call and reintroduce the finding.
+"""
+
+import re
+from pathlib import Path
+
+from teatree.loop import substrate_pinger
+
+# A ``…key=`` assignment followed on the SAME physical line by a later
+# ``Name=Enum.MEMBER`` reference — the exact one-line shape gitleaks captured.
+_GITLEAKS_CAPTURE_SHAPE = re.compile(r"\w*key\s*=\s*\S+.*\b\w+\s*=\s*\w+\.\w+")
+
+
+def _source_lines() -> list[str]:
+    return Path(substrate_pinger.__file__).read_text(encoding="utf-8").splitlines()
+
+
+class TestSubstratePingerNotifyShape:
+    def test_no_line_carries_a_key_assignment_before_an_enum_kwarg(self) -> None:
+        offenders = [line for line in _source_lines() if _GITLEAKS_CAPTURE_SHAPE.search(line)]
+        assert offenders == [], (
+            "A `...key=` assignment shares a physical line with a later "
+            "`Name=Enum.MEMBER` kwarg — gitleaks' generic-api-key rule captures "
+            f"onto the enum reference (#3344). Offending line(s): {offenders}"
+        )
+
+    def test_idempotency_key_and_audience_are_on_separate_lines(self) -> None:
+        lines = _source_lines()
+        idempotency = next((i for i, line in enumerate(lines) if "idempotency_key=idempotency_key" in line), None)
+        audience = next((i for i, line in enumerate(lines) if "audience=NotifyAudience.INTERNAL" in line), None)
+        assert idempotency is not None
+        assert audience is not None
+        assert idempotency != audience, (
+            "idempotency_key and audience kwargs collapsed onto one line — this "
+            "reintroduces the gitleaks generic-api-key false positive (#3344)."
+        )

--- a/tests/test_hook_router_out_of_band_merge.py
+++ b/tests/test_hook_router_out_of_band_merge.py
@@ -338,6 +338,53 @@ class TestClassifiesMergeTargetNotCwd:
         assert capsys.readouterr().out.strip() == ""
 
 
+class TestUnmanagedTargetAllowedRegardlessOfCwd:
+    """A confidently-unmanaged ``--repo`` TARGET is allowed on its own evidence (#3343).
+
+    The old bool target classifier could not tell "confidently-unmanaged
+    target" from "no target parsed": a confidently-unmanaged ``--repo`` always fell
+    through to the cwd rule, and a NON-git cwd (a multi-repo workspace parent)
+    classified as ``None`` there and DENIED a merge the gate never meant to block —
+    with the same command allowed only because the shell happened to sit inside the
+    repo's worktree. The tri-state resolves the target on its own evidence, so the
+    verdict no longer depends on where the shell is sitting.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _seed_overlays(tmp_path, _MANAGED_OVERLAYS, monkeypatch)
+
+    _UNMANAGED_MERGE = "gh pr merge 9 --repo example-org/public-repo --squash"
+
+    def test_unmanaged_target_from_non_git_parent_cwd_is_allowed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # cwd is a NON-git multi-repo workspace parent — pre-fix this DENIED
+        # because the unmanaged target fell through to the (unclassifiable) cwd.
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        assert router.handle_block_out_of_band_merge(_merge_event(self._UNMANAGED_MERGE, workspace)) is False
+        assert capsys.readouterr().out.strip() == ""
+
+    def test_unmanaged_target_from_repo_cwd_is_allowed(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Same command, same tokens, from inside the repo's worktree — allowed too.
+        repo = _repo_with_remote(tmp_path / "wt", "git@github.com:example-org/public-repo.git")
+        assert router.handle_block_out_of_band_merge(_merge_event(self._UNMANAGED_MERGE, repo)) is False
+        assert capsys.readouterr().out.strip() == ""
+
+    def test_numeric_gitlab_project_id_still_fails_safe_to_cwd(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # An opaque numeric ``projects/<id>`` is NOT a confidently-unmanaged slug —
+        # it stays cwd-keyed, so from a MANAGED cwd it still BLOCKS (fail-safe).
+        repo = _repo_with_remote(tmp_path / "wt", "git@gitlab.com:example-org/private-repo.git")
+        command = "glab api projects/5/merge_requests/9/merge --method POST"
+        assert router.handle_block_out_of_band_merge(_merge_event(command, repo)) is True
+        assert _parse_deny(capsys) is not None
+
+
 # ── cwd classifier must not crash-fail-open with an overlay path configured ───
 #
 # `_cwd_is_teatree_managed` iterated each overlay `path` base with

--- a/tests/test_hook_router_size_gate.py
+++ b/tests/test_hook_router_size_gate.py
@@ -25,7 +25,9 @@ _ROUTER = pathlib.Path(__file__).resolve().parent.parent / "hooks" / "scripts" /
 # hooks/scripts/handlers/ per-domain package behind the routing table.
 # Lowered by #81 step 1, which extracted the shared forge-API detection
 # (effective-method + endpoint regexes/classifiers) into hooks/scripts/forge_api_detect.py.
-_CEILING_LOC = 4515
+# Lowered by #3343, which moved the tri-state cwd-managed classifier into the
+# managed_repo sibling (cwd_teatree_managed_state).
+_CEILING_LOC = 4493
 
 
 def _count_loc(text: str) -> int:

--- a/tests/test_hook_router_subagent_hint_suppression.py
+++ b/tests/test_hook_router_subagent_hint_suppression.py
@@ -1,0 +1,83 @@
+# test-path: cross-cutting — drives hooks/scripts/hook_router.py + subagent_hint.py; no src/teatree/ mirror.
+"""A sub-agent deny must not advertise a self-authorize escape hatch (#3252).
+
+The banned-terms / quote-scanner leak denies tell the operator to re-issue with a
+leading ``ALLOW_BANNED_TERM=1`` / ``QUOTE_OK=1`` env prefix. A SUB-AGENT cannot
+self-authorize that bypass: the auto-mode classifier denies the retry as an
+"unauthorized safety-gate bypass", which poisoned the sub-agent's whole context.
+The router rewrites the hint at the ``emit_pretooluse_deny`` chokepoint when the
+call is from a sub-agent (a non-empty ``agent_id``), pointing it at the route it
+CAN take — escalate to the main agent / user — while the deny itself stays
+fail-closed. A main-agent deny keeps the verbatim escape-hatch hint.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import hooks.scripts.hook_router as router
+from teatree.hooks import banned_terms_scanner
+
+
+@pytest.fixture(autouse=True)
+def _breaker_context(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Isolate the deny-streak state and pin the per-process hook context so the
+    # emit chokepoint can read the (main-vs-sub) agent origin.
+    monkeypatch.setattr(router, "STATE_DIR", tmp_path / "state")
+    router.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(router, "_CURRENT_EVENT", "PreToolUse")
+
+
+def _emit_reason(capsys: pytest.CaptureFixture[str], reason: str) -> str:
+    assert router.emit_pretooluse_deny(reason) is True
+    payload = json.loads(capsys.readouterr().out.strip())
+    return payload["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+class TestSubagentSelfAuthHintSuppression:
+    _BANNED_DENY = banned_terms_scanner.format_block_message("acmecorp")
+
+    def test_main_agent_keeps_verbatim_escape_hatch_hint(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(router, "_CURRENT_DATA", {"session_id": "s-main", "tool_name": "Bash"})
+        emitted = _emit_reason(capsys, self._BANNED_DENY)
+        assert "ALLOW_BANNED_TERM=1" in emitted
+        assert "re-issue the command with a leading" in emitted
+
+    def test_subagent_hint_is_rewritten_to_escalation(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            router, "_CURRENT_DATA", {"session_id": "s-sub", "tool_name": "Bash", "agent_id": "agent-7"}
+        )
+        emitted = _emit_reason(capsys, self._BANNED_DENY)
+        # The escape-hatch hint is gone; the escalation guidance replaces it.
+        assert "re-issue the command with a leading" not in emitted
+        assert "cannot self-authorize" in emitted
+        assert "main agent / user" in emitted
+        # The deny itself is UNCHANGED — still fail-closed, still names the gate.
+        assert emitted.startswith("BLOCKED: banned-terms posting gate")
+        assert "acmecorp" in emitted
+
+
+class TestSuppressHelperUnit:
+    """Direct unit coverage of the rewrite predicate."""
+
+    _HINTED = (
+        "BLOCKED: some gate. If the match is a false positive, re-issue the command "
+        "with a leading QUOTE_OK=1 env prefix (e.g. `QUOTE_OK=1 <command>`)."
+    )
+
+    def test_main_agent_unchanged(self) -> None:
+        assert router._suppress_self_auth_hint_for_subagent(self._HINTED, {}) == self._HINTED
+
+    def test_subagent_rewrites(self) -> None:
+        out = router._suppress_self_auth_hint_for_subagent(self._HINTED, {"agent_id": "a-1"})
+        assert "QUOTE_OK=1 env prefix" not in out
+        assert "cannot self-authorize" in out
+
+    def test_subagent_reason_without_hint_is_untouched(self) -> None:
+        plain = "BLOCKED: out-of-band merge on a managed repo."
+        assert router._suppress_self_auth_hint_for_subagent(plain, {"agent_id": "a-1"}) == plain


### PR DESCRIPTION
#3357 raw-span substitution precision (does NOT weaken live-$() scanning); #3343 tri-state merge_target_managed_state + actionable deny msg; #3252 sub-agent hint suppression (poison-fix/grant already landed via #3291); #3344 gitleaks-shape reformat; #3240 already resolved by #3290 (verified). 2089 hooks tests pass, ruff clean. NOTE: hook_router.py at 4514/4515 size-ceiling slack.

Closes #3240, #3252, #3357, #3343, #3344.