### PR TITLE
fix(tests): re-indent shard-splitting docstring bullets to 4-space (.editorconfig)

### DIFF
--- a/tests/test_ci_shard_splitting_algorithm.py
+++ b/tests/test_ci_shard_splitting_algorithm.py
@@ -6,13 +6,13 @@ The fix has three load-bearing parts that no other test locks, so a careless edi
 invocation could silently regress the rebalance while every gate still passes:
 
 * ``--splitting-algorithm least_duration`` — bin-packs the recorded durations tighter than the
-  default chunk split, which is what turns a balanced ``dev/.test_durations`` into balanced shards.
+    default chunk split, which is what turns a balanced ``dev/.test_durations`` into balanced shards.
 * ``--doctest-modules`` — the doctest items run in the SAME sharded lane, so their durations are
-  measurable there (and their coverage counts toward the combined floor).
+    measurable there (and their coverage counts toward the combined floor).
 * the scheduled ``--store-durations --clean-durations`` record — the daily lane is where the
-  previously-unrecorded ``tests/quality`` + doctest durations are captured for the refresh PR, so
-  the committed file stops ballasting them blindly. Recording must NOT happen on PR/push runs
-  (that would pay the store write on every PR); it is gated to the ``schedule`` event only.
+    previously-unrecorded ``tests/quality`` + doctest durations are captured for the refresh PR, so
+    the committed file stops ballasting them blindly. Recording must NOT happen on PR/push runs
+    (that would pay the store write on every PR); it is gated to the ``schedule`` event only.
 
 Locking the invocation, not the balance itself: the balance is data (``dev/.test_durations``, kept
 fresh by the scheduled ``refresh-durations`` job on representative CI hardware), but the flags that


### PR DESCRIPTION
fix(tests): re-indent shard-splitting docstring bullets to 4-space (.editorconfig)

## What

Re-indents the 4 continuation lines under the bullet list in
`tests/test_ci_shard_splitting_algorithm.py`'s module docstring from a
2-space hanging indent to 4-space, matching the repo's `.editorconfig`
`[*.py]` rule (`indent_size = 4`, enforced by `editorconfig-checker`).

## Why

Discovered while shipping ticket #3336: `main`'s `lint` CI job is
currently failing on this pre-existing whitespace issue
(introduced by #3400/#3160's shard-splitting-algorithm test), which
blocks a clean green CI on every subsequent PR's whole-tree lint scan.
Isolated per the ship skill's "Isolate Unrelated Fixes" rule — a
docstring-only reindent, no behavior change.

docs: n/a — docstring whitespace-only fix, no user-visible or contract change

Open questions & assumptions:
- assumed: 4-space re-indent (vs. removing the hanging indent entirely) preserves the visual bullet-continuation intent while satisfying `.editorconfig`; no other convention change made.
