### PR TITLE
fix(slack): robust headless egress + answering evidence + owner-reply message

### DIFF
--- a/src/teatree/agents/prompt.py
+++ b/src/teatree/agents/prompt.py
@@ -90,6 +90,29 @@ _REVIEW_VERDICT_RETURN_LINES: tuple[str, ...] = (
     "Use verdict=hold with the blocking findings when the change must not merge yet.",
 )
 
+# Injected into a headless answering brief: the answering phase is denied the
+# shell (agents/answerer.md tools = Read/Grep/Glob only), so it CANNOT post the
+# reply itself via the Replier / `t3 <overlay> notify` CLI. It RETURNS the draft
+# in the result envelope instead; the orchestrator (``attempt_recorder`` →
+# ``_maybe_record_answer_draft``) routes it through the DeferredQuestion approval
+# path and posts on the user's behalf (maker≠checker: a different actor posts).
+# Symmetric to ``_REVIEW_VERDICT_RETURN_LINES`` — without this directive the
+# shell-denied answerer returns a prose summary with no ``answer`` field and the
+# phase evidence gate refuses ("missing required evidence for phase 'answering'").
+_ANSWER_RETURN_LINES: tuple[str, ...] = (
+    "",
+    "RETURN YOUR REPLY AS A DRAFT (this phase has no shell — do NOT try to post via",
+    "`t3 <overlay> notify`, the Replier, or any CLI; you cannot post, you HAND BACK the draft):",
+    "add an `answer` object to your final JSON result. The orchestrator routes it through the",
+    "approval path and posts on the user's behalf:",
+    '  "answer": {"text": "<the drafted reply, in the user\'s voice — no AI signature>",',
+    '             "thread_ref": "<the inbound thread ts/ref this reply targets, or \'\' if none>"}',
+    "The `text` MUST be non-empty — a summary-only result with no `answer` drops the reply and",
+    "the phase is refused. If you cannot answer (missing context, a decision only the user can",
+    "make), draft a clarifying-question reply as the `answer` text rather than returning nothing.",
+)
+
+
 # The coding directive force-loads these two by name in its first lines, and
 # ``rules`` is always embedded in full — so they are never re-listed in the
 # resolved-stack skill-load block.
@@ -388,6 +411,30 @@ def _reviewing_phase_lines(task: Task) -> tuple[str, ...]:
     return tuple(lines)
 
 
+def _answering_phase_lines(task: Task) -> tuple[str, ...]:
+    """The headless ``PHASE: answering`` block — draft, then RETURN the answer envelope.
+
+    The shell-denied answerer cannot post the reply itself; it hands the draft
+    back and the orchestrator posts on confirmation. Surfaces the inbound thread
+    context (``ticket.extra["slack_answer"]``, populated by the reactive
+    slack-answer cycle) best-effort so the agent knows what ``thread_ref`` to
+    fill; absent for the event-router dispatch shape, which carries the thread
+    on the routed ``IncomingEvent`` the answerer skill reads.
+    """
+    lines = ["", "PHASE: answering", "Read the thread context and draft a concise reply in the user's voice."]
+    ticket_extra = task.ticket.extra if isinstance(task.ticket.extra, dict) else {}
+    slack_answer = ticket_extra.get("slack_answer")
+    if isinstance(slack_answer, dict):
+        thread_ts = str(slack_answer.get("slack_ts") or "")
+        question = str(slack_answer.get("question") or "")
+        if thread_ts:
+            lines.append(f"Inbound Slack thread ts (use as `thread_ref`): {thread_ts}")
+        if question:
+            lines.append(f"The user's message: {question}")
+    lines.extend(_ANSWER_RETURN_LINES)
+    return tuple(lines)
+
+
 def _shipping_phase_lines() -> tuple[str, ...]:
     """The headless ``PHASE: shipping`` auto-review-gate block."""
     reviewer_dispatch = build_reviewer_dispatch_prompt(
@@ -438,6 +485,8 @@ def _phase_specific_lines(
         return _planning_phase_lines(task)
     if phase == "reviewing":
         return _reviewing_phase_lines(task)
+    if phase == "answering":
+        return _answering_phase_lines(task)
     if phase == "shipping":
         return _shipping_phase_lines()
     return ()

--- a/src/teatree/core/notify.py
+++ b/src/teatree/core/notify.py
@@ -431,11 +431,18 @@ def _feature_enabled() -> bool:
 
 
 def resolve_user_id() -> str:
-    """Resolve the Slack user id to DM (overlay override → global → empty).
+    """Resolve the Slack user id to DM (overlay override → global → sole overlay → empty).
 
     The per-overlay id comes from the DB overlays registry (still injected into
     ``load_config().raw["overlays"]``); the GLOBAL fallback reads the DB-home
     ``slack_user_id`` setting so every routing path agrees on the same order.
+
+    The final ``sole overlay`` tier is the env-independent fallback that mirrors
+    :func:`teatree.core.backend_factory.messaging_from_overlay` — the headless
+    worker that DMs the owner does NOT export ``T3_OVERLAY_NAME``, so the
+    overlay-scoped tier is skipped, and a fresh box carries no GLOBAL setting.
+    When exactly one overlay is registered there is no ambiguity, so its own
+    ``slack_user_id`` resolves without depending on the env var being set.
     """
     from teatree.config import cold_reader  # noqa: PLC0415 — deferred: call-time import, kept lazy
 
@@ -446,14 +453,17 @@ def resolve_user_id() -> str:
         user_id = overlays[overlay_name].get("slack_user_id", "")
         if user_id:
             return str(user_id)
-    return cold_reader.str_setting("slack_user_id", default="")
+    global_id = cold_reader.str_setting("slack_user_id", default="")
+    if global_id:
+        return global_id
+    return _sole_overlay_field(overlays, "slack_user_id")
 
 
 def resolve_user_channel() -> str:
-    """Resolve the Slack DM channel id the user reads (overlay override → global → empty).
+    """Resolve the Slack DM channel id the user reads (overlay → global → sole overlay → empty).
 
     The canonical resolver for the ``slack_user_channel`` config key,
-    walking the SAME overlay→global→empty order :func:`resolve_user_id`
+    walking the SAME overlay→global→sole-overlay→empty order :func:`resolve_user_id`
     uses for ``slack_user_id``. Both DM-channel call sites (the bot→user
     DM path and the live-post-approval CLI verifier) consult this single
     helper, so a change to the resolution order can never drift between
@@ -472,7 +482,28 @@ def resolve_user_channel() -> str:
         channel = overlays[overlay_name].get("slack_user_channel", "")
         if channel:
             return str(channel)
-    return cold_reader.str_setting("slack_user_channel", default="")
+    global_channel = cold_reader.str_setting("slack_user_channel", default="")
+    if global_channel:
+        return global_channel
+    return _sole_overlay_field(overlays, "slack_user_channel")
+
+
+def _sole_overlay_field(overlays: dict, key: str) -> str:
+    """Return the sole registered overlay's ``key`` value, or ``""``.
+
+    Env-independent fallback for the DM-target resolvers: when the active
+    overlay is ambiguous (``T3_OVERLAY_NAME`` unset in the headless worker)
+    and no GLOBAL setting is configured, a single registered overlay is
+    unambiguous — its own value is the right target. Returns ``""`` when
+    zero or more than one overlay is registered (ambiguous), so a
+    multi-overlay box never silently picks the wrong owner.
+    """
+    if len(overlays) != 1:
+        return ""
+    entry = next(iter(overlays.values()))
+    if not isinstance(entry, dict):
+        return ""
+    return str(entry.get(key, "") or "")
 
 
 def maybe_linkify(text: str) -> str:

--- a/src/teatree/core/notify_question_drains.py
+++ b/src/teatree/core/notify_question_drains.py
@@ -44,7 +44,7 @@ def _resurface_text(row: DeferredQuestion) -> str:
         label = opt.get("label", "")
         desc = opt.get("description", "")
         lines.append(f"  {i}. {label}" + (f" — {desc}" if desc else ""))
-    lines.append(f"\n_Answer with_ `t3 teatree questions answer {row.pk} <text>`")
+    lines.append("\n_Just reply in this thread to answer._")
     return "\n".join(lines)
 
 

--- a/tests/teatree_agents/test_prompt.py
+++ b/tests/teatree_agents/test_prompt.py
@@ -197,6 +197,42 @@ class TestBuildSystemContext(TestCase):
         assert "review_verdict" in ctx
         assert "do NOT try `t3 <overlay> review record`" in ctx
 
+    def test_answering_phase(self) -> None:
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket)
+        task = Task.objects.create(ticket=ticket, session=session, phase="answering")
+
+        ctx = build_system_context(task, skills=[])
+        assert "PHASE: answering" in ctx
+
+    def test_answering_brief_instructs_returning_the_answer_envelope(self) -> None:
+        # The answering phase has no shell (agents/answerer.md tools = Read/Grep/Glob),
+        # so the brief MUST tell the answerer to RETURN an `answer` envelope rather than
+        # try to post itself — otherwise the phase evidence gate refuses the run for
+        # "missing required evidence for phase 'answering'".
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket)
+        task = Task.objects.create(ticket=ticket, session=session, phase="answering")
+
+        ctx = build_system_context(task, skills=[])
+        assert '"answer"' in ctx
+        assert "thread_ref" in ctx
+        assert "do NOT try to post" in ctx
+
+    def test_answering_brief_surfaces_slack_thread_context(self) -> None:
+        # When the reactive slack-answer cycle stamps the inbound thread onto
+        # ticket.extra["slack_answer"], the brief surfaces the ts (as thread_ref)
+        # and the user's message so the agent can fill the envelope.
+        ticket = Ticket.objects.create(
+            extra={"slack_answer": {"channel": "C1", "slack_ts": "1700000000.0001", "question": "is it ready?"}}
+        )
+        session = Session.objects.create(ticket=ticket)
+        task = Task.objects.create(ticket=ticket, session=session, phase="answering")
+
+        ctx = build_system_context(task, skills=[])
+        assert "1700000000.0001" in ctx
+        assert "is it ready?" in ctx
+
     def test_coding_brief_carries_heartbeat_dm_block(self) -> None:
         # PR-12: a long-running maker brief auto-injects the heartbeat-DM cue.
         ticket = Ticket.objects.create()

--- a/tests/teatree_core/test_notify_question_drains_message.py
+++ b/tests/teatree_core/test_notify_question_drains_message.py
@@ -1,0 +1,42 @@
+"""The DeferredQuestion resurface DM must be Slack-reply-only, never a host CLI.
+
+The owner reads Slack DMs and has NO host-CLI access — every interaction is in
+Slack. The resurface/mirror message the drains post therefore must NOT tell the
+owner to run ``t3 <overlay> questions answer …``; the owner just replies in the
+thread and the reply scanner binds the answer.
+"""
+
+import json
+
+from django.test import TestCase
+
+from teatree.core.models import DeferredQuestion
+from teatree.core.notify_question_drains import _resurface_text
+
+
+class TestResurfaceMessageHasNoHostCli(TestCase):
+    def test_message_carries_no_t3_cli_instruction(self) -> None:
+        row = DeferredQuestion.record(question="Should I merge PR #7?", session_id="s1")
+
+        text = _resurface_text(row)
+
+        # No host-CLI instruction of any kind — the owner cannot run one.
+        assert "t3 " not in text
+        assert "questions answer" not in text
+        assert "Answer with" not in text
+        # It DOES tell the owner to reply in the thread instead.
+        assert "reply" in text.lower()
+        assert "thread" in text.lower()
+
+    def test_message_still_renders_question_and_options(self) -> None:
+        row = DeferredQuestion.record(
+            question="Pick a rollout",
+            options_json=json.dumps([{"label": "canary", "description": "10% first"}]),
+            session_id="s2",
+        )
+
+        text = _resurface_text(row)
+
+        assert "Pick a rollout" in text
+        assert "canary" in text
+        assert "t3 " not in text

--- a/tests/teatree_core/test_resolve_user_channel.py
+++ b/tests/teatree_core/test_resolve_user_channel.py
@@ -111,6 +111,59 @@ class TestResolveUserChannel:
         assert notify.resolve_user_channel() == "D-OVERLAY"
 
 
+class TestSoleOverlayFallback:
+    """Env-independent fallback: a single registered overlay resolves without ``T3_OVERLAY_NAME``.
+
+    The headless worker that DMs the owner does NOT export ``T3_OVERLAY_NAME``,
+    so the overlay-scoped tier is skipped; a fresh box carries no GLOBAL
+    ``slack_user_id`` / ``slack_user_channel``. When exactly one overlay is
+    registered there is no ambiguity, so its own values resolve — mirroring
+    ``backend_factory.messaging_from_overlay``'s single-overlay resolution.
+    """
+
+    def test_user_id_resolves_from_sole_overlay_without_env_or_global(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+        _write_cfg(tmp_path, monkeypatch, overlays={"acme": {"slack_user_id": "U-SOLE"}})
+
+        assert notify.resolve_user_id() == "U-SOLE"
+
+    def test_channel_resolves_from_sole_overlay_without_env_or_global(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+        _write_cfg(tmp_path, monkeypatch, overlays={"acme": {"slack_user_channel": "D-SOLE"}})
+
+        assert notify.resolve_user_channel() == "D-SOLE"
+
+    def test_global_still_wins_over_sole_overlay(self, tmp_path, monkeypatch) -> None:
+        # The sole-overlay tier is the LAST resort — a configured global keeps priority.
+        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+        _write_cfg(
+            tmp_path,
+            monkeypatch,
+            global_user_id="U-GLOBAL",
+            global_channel="D-GLOBAL",
+            overlays={"acme": {"slack_user_id": "U-SOLE", "slack_user_channel": "D-SOLE"}},
+        )
+
+        assert notify.resolve_user_id() == "U-GLOBAL"
+        assert notify.resolve_user_channel() == "D-GLOBAL"
+
+    def test_multiple_overlays_stay_ambiguous(self, tmp_path, monkeypatch) -> None:
+        # Two registered overlays with no env selector and no global: never guess —
+        # a multi-overlay box must not silently pick the wrong owner.
+        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+        _write_cfg(
+            tmp_path,
+            monkeypatch,
+            overlays={
+                "acme": {"slack_user_id": "U-ACME", "slack_user_channel": "D-ACME"},
+                "beta": {"slack_user_id": "U-BETA", "slack_user_channel": "D-BETA"},
+            },
+        )
+
+        assert notify.resolve_user_id() == ""
+        assert notify.resolve_user_channel() == ""
+
+
 class TestLiveApprovalCliUsesCanonicalResolver:
     """The live-post-approval CLI resolves its DM channel through the canonical helper."""
 


### PR DESCRIPTION
Three fixes so headless teatree reliably ANSWERS the owner on Slack. (1) resolve_user_id/resolve_user_channel single-overlay fallback (headless NOOPd every DM). (2) add the answering-phase dispatch-prompt branch so the answerer returns the {answer} envelope → passes the evidence gate → teatree actually replies. (3) owner-reply message drops the host-CLI instruction (owner has no host access) → just reply in-thread. Tests + gates green.