### PR TITLE
fix(loop): collapse repair-halt question flood + retire superseded dead tasks

### DIFF
--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -81,6 +81,31 @@ class Ticket(
     _TERMINAL_STATES: ClassVar[frozenset[str]] = frozenset(
         {State.SHIPPED, State.MERGED, State.DELIVERED, State.IGNORED},
     )
+    # The linear author work-state progression (excludes the terminal set and the
+    # off-ladder IN_REVIEW/RETROSPECTED branch states). A ticket at index i has
+    # produced every phase output up to and including index i — the ordering
+    # ``has_completed_phase`` reads to tell a live phase apart from a superseded one.
+    _WORK_STATE_ORDER: ClassVar[tuple[str, ...]] = (
+        State.NOT_STARTED,
+        State.SCOPED,
+        State.STARTED,
+        State.PLANNED,
+        State.CODED,
+        State.TESTED,
+        State.REVIEWED,
+        State.SHIPPED,
+    )
+    # The work-state each author phase PRODUCES on success. A FAILED task whose
+    # phase output the ticket's FSM already reached is SUPERSEDED — an earlier
+    # interrupted run left the dead row while the ticket advanced on its own — so
+    # re-dispatching or escalating that task only floods the away-mode queue.
+    _PHASE_PRODUCES_STATE: ClassVar[dict[str, str]] = {
+        "planning": State.PLANNED,
+        "coding": State.CODED,
+        "testing": State.TESTED,
+        "reviewing": State.REVIEWED,
+        "shipping": State.SHIPPED,
+    }
     # NOTE: a class-body comprehension cannot see the enclosing ``State``
     # (Python scoping); enumerate explicitly and assert completeness in a
     # test so a future added state is caught rather than silently dropped.

--- a/src/teatree/core/models/ticket_data.py
+++ b/src/teatree/core/models/ticket_data.py
@@ -33,3 +33,5 @@ class TicketFacet(models.Model):
         State: type["Ticket.State"]
         Role: type["Ticket.Role"]
         _TERMINAL_STATES: ClassVar[frozenset[str]]
+        _WORK_STATE_ORDER: ClassVar[tuple[str, ...]]
+        _PHASE_PRODUCES_STATE: ClassVar[dict[str, str]]

--- a/src/teatree/core/models/ticket_introspection.py
+++ b/src/teatree/core/models/ticket_introspection.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 from django.apps import apps
 
+from teatree.core.modelkit.phases import normalize_phase
 from teatree.core.models.ticket_data import TicketFacet
 from teatree.core.models.ticket_number import derive_issue_number
 from teatree.core.models.ticket_worktree_checks import worktree_has_commits_ahead
@@ -33,6 +34,24 @@ class TicketIntrospectionModel(TicketFacet):
     def is_terminal(self) -> bool:
         """True when the ticket is in a genuinely terminal/abandoned state (SHIPPED/MERGED/DELIVERED/IGNORED)."""
         return self.state in self._TERMINAL_STATES
+
+    def has_completed_phase(self, phase: str) -> bool:
+        """True when the FSM state has already reached the state *phase* produces.
+
+        A FAILED task for such a phase is SUPERSEDED: the ticket's own FSM advanced
+        past that phase's output (an earlier interrupted run left the dead row), so
+        re-dispatching or escalating it only floods the away-mode DeferredQuestion
+        queue with a question that is already answered by the ticket's state. The
+        transient-requeue sweep retires such tasks silently instead of asking the
+        owner. An unknown phase, or a state off the linear work ladder
+        (IN_REVIEW/RETROSPECTED/…), is conservatively treated as NOT completed —
+        the safe default that escalates rather than silently drops a live task.
+        """
+        produces = self._PHASE_PRODUCES_STATE.get(normalize_phase(phase))
+        order = self._WORK_STATE_ORDER
+        if produces is None or self.state not in order:
+            return False
+        return order.index(self.state) >= order.index(produces)
 
     def may_expedite(self) -> bool:
         """True iff this ticket may carry a human-authorized PENDING-checks waiver (PR-07).

--- a/src/teatree/loop/transient_requeue.py
+++ b/src/teatree/loop/transient_requeue.py
@@ -26,10 +26,19 @@ freeze silently; it is routed straight to the escalation path. The invariant: a
 terminal FAILED task on a non-terminal ticket ALWAYS escalates or retries-once,
 never freezes silently.
 
+A SUPERSEDED FAILED task — one whose phase output the ticket's FSM already reached
+(``ticket.has_completed_phase``) — is NOT escalated at all: it is a dead artifact of
+an earlier interrupted run while the ticket advanced on its own, so it is retired
+COMPLETED silently. This is the fix for the redispatch flood on already-done tickets
+(3366/3336/3352): the away-mode queue is never asked about a phase the ticket's own
+state already answers.
+
 A once-escalated task is stamped (:data:`_HALT_STAMP` in ``execution_reason``) and
 excluded from every subsequent scan, so the dead-letter set never grows the per-tick
-work unboundedly and an answered/dismissed question can never resurrect a fresh
-escalation for the same halted row.
+work unboundedly. The ``DeferredQuestion`` itself is deduped by a STABLE key —
+``(ticket, phase, failure-fingerprint)``, NOT the task pk — so the fresh ``Task`` rows
+a stuck phase mints each redispatch cycle collapse to ONE open question instead of one
+per cycle (the observed 10-15x duplicate flood).
 
 Lives in ``teatree.loop`` (orchestration): it needs both the transient classifier
 (``teatree.agents``) and the ``Task`` model (``teatree.core.models``), which sit
@@ -44,15 +53,24 @@ from teatree.core.modelkit.phases import normalize_phase
 from teatree.core.models import Task, Ticket
 from teatree.core.models.deferred_question import DeferredQuestion
 from teatree.core.models.task_repair import phase_attempts
-from teatree.core.repair_loop import IterationStalled, MaxIterationsExceeded, requeue_verdict
+from teatree.core.repair_loop import (
+    IterationStalled,
+    MaxIterationsExceeded,
+    requeue_verdict,
+    terminal_reason_fingerprint,
+)
 
 logger = logging.getLogger(__name__)
 
-_ESCALATION_MARKER = "[repair-halt task={pk}]"
 #: Stamped onto ``execution_reason`` when a task is escalated (dead-lettered), so it
 #: is excluded from every future scan — bounds per-tick work and makes the escalation
 #: durably once-per-task regardless of whether the question is later answered.
 _HALT_STAMP = "[repair-halt-parked]"
+#: Stamped onto ``execution_reason`` when a SUPERSEDED FAILED task is retired (its
+#: phase output the ticket's FSM already reached). It is marked COMPLETED and drops
+#: out of the scan — the away-mode queue is never asked about a phase the ticket
+#: already advanced past (the 3366/3336/3352 redispatch-loop root cause).
+_SUPERSEDED_STAMP = "[superseded-retired]"
 
 #: Phases whose omitted-envelope refusal earns the one-shot corrective retry.
 _CORRECTIVE_PHASES = frozenset({"coding", "debugging"})
@@ -86,6 +104,12 @@ def requeue_transient_failed() -> int:
     """
     reopened = 0
     for task in _non_terminal_failed_tasks():
+        if task.ticket.has_completed_phase(task.phase):
+            # SUPERSEDED: the ticket's FSM already reached this phase's output, so this
+            # FAILED row is a dead artifact of an earlier interrupted run. Retire it
+            # silently — never escalate a question the ticket's own state answers.
+            _retire_superseded(task)
+            continue
         error = _latest_error(task)
         if not error:
             # No recorded error → neither transient nor deterministic; must not freeze.
@@ -210,9 +234,11 @@ def _reopen(task: Task) -> int:
 def _stamp_halt(task: Task) -> None:
     """Park *task* out of future scans by stamping :data:`_HALT_STAMP` onto ``execution_reason``.
 
-    Idempotent — a no-op once the stamp is present. This is the durable dedup: an
-    escalated row is excluded from :func:`_non_terminal_failed_tasks`, so answering
-    or dismissing the question can never resurrect a fresh escalation for it.
+    Idempotent — a no-op once the stamp is present. The per-task park: an escalated
+    row is excluded from :func:`_non_terminal_failed_tasks`, so answering or dismissing
+    the question can never resurrect a fresh escalation for THIS row. Cross-row
+    collapse of the fresh ``Task`` rows a stuck phase mints each cycle is the separate
+    job of the stable ``dedupe_marker`` (:func:`_escalation_marker`).
     """
     if _HALT_STAMP in task.execution_reason:
         return
@@ -220,24 +246,63 @@ def _stamp_halt(task: Task) -> None:
     Task.objects.filter(pk=task.pk).update(execution_reason=reason)
 
 
-def _escalate_once(task: Task, *, reason: str) -> None:
-    """Record a durable escalation for a halted task, exactly once per task, then park it.
+def _retire_superseded(task: Task) -> None:
+    """Mark a SUPERSEDED FAILED task COMPLETED via CAS, stamping the reason. Idempotent.
 
-    The row is stamped so it drops out of every future scan; the DeferredQuestion is
-    deduped across ALL questions (answered or not) by a per-task marker, so a halted
-    FAILED row can never spam the away-mode queue nor re-escalate once its question is
-    answered/dismissed. Reuses the §17.1 invariant 9 surface (statusline /
-    ``t3 teatree questions list`` / the Slack DM drain).
+    The ticket's FSM already reached this phase's output (``has_completed_phase``),
+    so the dead FAILED row is retired instead of escalated — the same
+    ``UPDATE ... WHERE status=FAILED`` compare-and-swap the reopen path uses, so a
+    concurrent tick updates 0 rows and does not double-write. No FSM side effect and
+    no ``DeferredQuestion``: the ticket's own state already answers the question.
     """
-    marker = _ESCALATION_MARKER.format(pk=task.pk)
-    already = DeferredQuestion.objects.filter(question__contains=marker).exists()
+    reason = f"{task.execution_reason}\n{_SUPERSEDED_STAMP}".strip() if task.execution_reason else _SUPERSEDED_STAMP
+    Task.objects.filter(pk=task.pk, status=Task.Status.FAILED).update(
+        status=Task.Status.COMPLETED,
+        claimed_at=None,
+        claimed_by="",
+        claimed_by_session="",
+        lease_expires_at=None,
+        heartbeat_at=None,
+        execution_reason=reason,
+    )
+
+
+def _escalation_marker(task: Task) -> str:
+    """Stable dedupe key for a halted task's escalation — ``(ticket, phase, failure)``.
+
+    Keyed on the ticket + canonical phase + the NORMALIZED failure fingerprint, NOT
+    the task pk: a stuck phase mints a FRESH ``Task`` row every redispatch cycle, so a
+    per-task key filed one identical question per cycle (the observed 10-15x flood).
+    Keying on the underlying standing condition instead collapses every churned row
+    that fails the same way to ONE open ``DeferredQuestion``. A genuinely different
+    failure (different fingerprint) keeps its own key, so a real new problem still
+    surfaces. Truncated to fit the indexed ``dedupe_marker`` column (max 64).
+    """
+    fingerprint = terminal_reason_fingerprint(_latest_error(task))
+    phase = normalize_phase(task.phase)
+    return f"repair-halt:{task.ticket_id}:{phase}:{fingerprint}"[:64]  # ty: ignore[unresolved-attribute]
+
+
+def _escalate_once(task: Task, *, reason: str) -> None:
+    """Record a durable escalation for a halted task, then park the row. Deduped by condition.
+
+    The row is stamped (:data:`_HALT_STAMP`) so it drops out of every future scan; the
+    ``DeferredQuestion`` is deduped by the STABLE :func:`_escalation_marker` (ticket +
+    phase + failure fingerprint) through the model's indexed ``dedupe_marker`` — so the
+    fresh ``Task`` rows a stuck phase mints each redispatch cycle collapse to a SINGLE
+    open question instead of one per cycle. Reuses the §17.1 invariant 9 surface
+    (statusline / ``t3 teatree questions list`` / the Slack DM drain).
+    """
     _stamp_halt(task)
-    if already:
-        return
     where = task.ticket.issue_url or f"ticket {task.ticket.pk}"
+    phase = normalize_phase(task.phase)
     question = (
-        f"{marker} Auto-retry halted on {where} (phase {normalize_phase(task.phase)!r}): {reason} "
+        f"[repair-halt ticket={task.ticket.pk} phase={phase!r}] Auto-retry halted on {where}: {reason} "
         "Re-queueing is stopped so it does not retry a doomed failure forever. "
         "How should it proceed — investigate, rework, or ignore?"
     )
-    DeferredQuestion.record(question, session_id=str(task.session_id or ""))  # ty: ignore[unresolved-attribute]
+    DeferredQuestion.record(
+        question,
+        session_id=str(task.session_id or ""),  # ty: ignore[unresolved-attribute]
+        dedupe_marker=_escalation_marker(task),
+    )

--- a/tests/teatree_core/models/test_ticket.py
+++ b/tests/teatree_core/models/test_ticket.py
@@ -574,3 +574,33 @@ class TestTicketArtifacts(TestCase):
 
         with pytest.raises(AttributeError):
             artifacts.ticket_id = 99  # frozen dataclass rejects mutation
+
+
+class TestHasCompletedPhase(TestCase):
+    """``Ticket.has_completed_phase`` tells a live phase apart from a superseded one.
+
+    True iff the FSM state has already reached the state the phase produces, so the
+    transient-requeue sweep can retire a dead FAILED task whose output the ticket
+    already has instead of escalating an already-answered away-mode question.
+    """
+
+    def test_phase_at_or_before_state_is_completed(self) -> None:
+        ticket = Ticket.objects.create(state=Ticket.State.TESTED)
+
+        # testing produces TESTED (== state) and coding produces CODED (< state): both done.
+        assert ticket.has_completed_phase("testing") is True
+        assert ticket.has_completed_phase("coding") is True
+        assert ticket.has_completed_phase("test") is True  # short-verb spelling normalizes
+
+    def test_phase_beyond_state_is_not_completed(self) -> None:
+        ticket = Ticket.objects.create(state=Ticket.State.TESTED)
+
+        # reviewing produces REVIEWED (> state): the ticket has NOT reached it.
+        assert ticket.has_completed_phase("reviewing") is False
+        assert ticket.has_completed_phase("shipping") is False
+
+    def test_unknown_or_off_ladder_is_conservatively_incomplete(self) -> None:
+        # An unknown phase and an off-ladder state both default to NOT completed —
+        # the safe answer that escalates rather than silently retiring a live task.
+        assert Ticket.objects.create(state=Ticket.State.TESTED).has_completed_phase("bughunt") is False
+        assert Ticket.objects.create(state=Ticket.State.IN_REVIEW).has_completed_phase("coding") is False

--- a/tests/teatree_core/models/test_ticket_facet_composition.py
+++ b/tests/teatree_core/models/test_ticket_facet_composition.py
@@ -54,6 +54,7 @@ class TestStatusFacetCohesionSplit:
         assert _own_public_members(TicketIntrospectionModel) == {
             "has_active_work",
             "is_terminal",
+            "has_completed_phase",
             "may_expedite",
             "ticket_number",
             "has_shippable_diff",

--- a/tests/teatree_loop/test_transient_requeue.py
+++ b/tests/teatree_loop/test_transient_requeue.py
@@ -222,6 +222,69 @@ class TestTransientRequeue(TestCase):
         assert task.status == Task.Status.FAILED
         assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 0
 
+    def test_superseded_failed_task_is_retired_not_escalated(self) -> None:
+        # 3366/3336/3352: a ticket whose FSM already reached a phase's output
+        # (state TESTED ⇒ testing done) can still carry a stale FAILED testing task
+        # from an earlier interrupted run. It must be retired silently — never
+        # escalated as an away-mode question the ticket's own state already answers.
+        task = _failed_task(phase="testing", state=Ticket.State.TESTED)
+        _add_failed_attempt(task, error="result_error: no terminal ResultMessage")
+        _add_failed_attempt(task, error="result_error: no terminal ResultMessage")
+
+        reopened = requeue_transient_failed()
+
+        task.refresh_from_db()
+        assert reopened == 0
+        assert task.status == Task.Status.COMPLETED  # retired, not left FAILED
+        assert "[superseded-retired]" in task.execution_reason
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 0
+
+    def test_live_phase_not_yet_reached_still_escalates(self) -> None:
+        # Boundary guard: a FAILED task for a phase the ticket has NOT reached
+        # (state TESTED, phase reviewing ⇒ produces REVIEWED, not yet reached) is a
+        # genuinely blocked phase — it must still escalate, never be silently retired.
+        task = _failed_task(phase="reviewing", state=Ticket.State.TESTED)
+        _add_failed_attempt(task, error="missing required evidence for phase 'reviewing'")
+        _add_failed_attempt(task, error="missing required evidence for phase 'reviewing'")
+
+        reopened = requeue_transient_failed()
+
+        task.refresh_from_db()
+        assert reopened == 0
+        assert task.status == Task.Status.FAILED
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
+
+    def test_churned_tasks_same_condition_collapse_to_one_question(self) -> None:
+        # THE FLOOD FIX: a stuck phase mints a FRESH Task row every redispatch cycle.
+        # Two FAILED tasks on the same (ticket, phase) failing IDENTICALLY are ONE
+        # standing condition — they must collapse to a single open DeferredQuestion,
+        # not one per task (the observed 10-15x duplicate flood).
+        ticket = Ticket.objects.create(role=Ticket.Role.AUTHOR, state=Ticket.State.TESTED)
+        for _ in range(2):
+            session = Session.objects.create(ticket=ticket, agent_id="review")
+            task = Task.objects.create(ticket=ticket, session=session, phase="reviewing", status=Task.Status.FAILED)
+            _add_failed_attempt(task, error="missing required evidence for phase 'reviewing'")
+
+        requeue_transient_failed()
+
+        # One condition ⇒ one question, despite two distinct FAILED task rows.
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
+
+    def test_distinct_conditions_do_not_over_collapse(self) -> None:
+        # Guard on the dedup: two DIFFERENT failures on the same (ticket, phase) are
+        # two conditions — they must NOT collapse into one, or a real second problem
+        # would be hidden behind the first.
+        ticket = Ticket.objects.create(role=Ticket.Role.AUTHOR, state=Ticket.State.TESTED)
+        errors = ("missing required evidence for phase 'reviewing'", "AssertionError: reviewer crashed")
+        for error in errors:
+            session = Session.objects.create(ticket=ticket, agent_id="review")
+            task = Task.objects.create(ticket=ticket, session=session, phase="reviewing", status=Task.Status.FAILED)
+            _add_failed_attempt(task, error=error)
+
+        requeue_transient_failed()
+
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 2
+
     def test_bounded_never_retries_endlessly(self) -> None:
         cap = max_phase_iterations()
         task = _failed_task()


### PR DESCRIPTION
Stops the away-mode question spam at the source. (A) repair-halt DeferredQuestions dedup on a stable dedupe_marker repair-halt:{ticket}:{phase}:{fingerprint} instead of task.pk (a fresh Task per redispatch minted a new identical question every tick → the 10-15x flood). (B) superseded FAILED tasks on tickets whose FSM already advanced past that phase (3366/3336/3352) are silently retired COMPLETED via CAS — no question. Both resolve mechanically, no owner input. Full suite 28183 passed, all gates green.