### PR TITLE
refactor(notify): split notify + prompt to satisfy module-health cap

### DIFF
--- a/src/teatree/agents/coding_prompt.py
+++ b/src/teatree/agents/coding_prompt.py
@@ -1,0 +1,131 @@
+"""The coding-builder dispatch contract (split out of ``teatree.agents.prompt``).
+
+A headless builder loses every loaded skill (rules § Sub-Agent Limitations), so
+the architecture / code disciplines, the stack + overlay coding skills, and the
+CI-parity verify step must reach it inline. This module owns that self-contained
+concern — the forced-skill-load block + behavior-preservation + verify directive
+(:func:`_coding_phase_directive`) — shared by ``build_task_prompt`` and the
+coding branch of ``build_system_context`` so the contract cannot drift between
+the two builder entry points. One-directional dependency: ``prompt`` imports
+from here; nothing here imports ``prompt``.
+"""
+
+from teatree.agents.skill_injection import _ALWAYS_FULL_SKILLS, _explicit_load_name
+from teatree.skill_support.loading import FRAMEWORK_SKILL_NAMES
+
+_VERIFY_GATES_COMMAND = "t3 tool verify-gates"
+
+# Auto-injected into a long-running maker brief (PR-12): user-visible liveness
+# so a watchdog can tell "stuck" from "still working". The transport half is
+# PR-14's worker heartbeat; this is the brief-level cue the sub-agent acts on.
+_HEARTBEAT_DM_LINES: tuple[str, ...] = (
+    "",
+    "HEARTBEAT (long-running work): if this task runs long, emit a periodic user-visible",
+    "progress DM (`t3 <overlay> notify send`) — report progress, not silence. A watchdog",
+    "distinguishes a stuck run from a still-working one only if you check in.",
+)
+
+# The coding directive force-loads these two by name in its first lines, and
+# ``rules`` is always embedded in full — so they are never re-listed in the
+# resolved-stack skill-load block.
+_DIRECTIVE_FORCED_SKILLS = frozenset({"architecture-design", "code"}) | _ALWAYS_FULL_SKILLS
+
+
+def _stack_overlay_load_names(skills: list[str] | None, *, exclude: frozenset[str] = frozenset()) -> list[str]:
+    """Return the ordered framework-then-overlay skill names to force-load.
+
+    The resolved bundle minus the skills the directive already force-loads by
+    name (``architecture-design`` / ``code``) and ``rules`` (always embedded in
+    full). Framework skills (``ac-*`` / ``fastapi``) lead, then the overlay /
+    remaining coding skills. Single source of truth for both the directive's
+    load block and the system-context summary-suppression set so the two never
+    disagree on which skills are force-loaded (#1368). *exclude* drops the
+    phase's stage skills — a no-Skill-tool maker gets them embedded in full, so
+    a "load via the Skill tool" directive it cannot act on must not list them.
+    """
+    forced = _DIRECTIVE_FORCED_SKILLS | exclude
+    extra = [s for s in (skills or []) if _explicit_load_name(s) not in forced]
+    framework = [s for s in extra if _explicit_load_name(s) in FRAMEWORK_SKILL_NAMES]
+    overlay = [s for s in extra if _explicit_load_name(s) not in FRAMEWORK_SKILL_NAMES]
+    ordered: list[str] = []
+    for name in (*framework, *overlay):
+        load_name = _explicit_load_name(name)
+        if load_name not in ordered:
+            ordered.append(load_name)
+    return ordered
+
+
+def _stack_skill_load_lines(skills: list[str] | None, *, exclude: frozenset[str] = frozenset()) -> list[str]:
+    """Return the explicit "load the stack + overlay skills BEFORE code" block.
+
+    A dispatched builder does not inherit the parent's loaded skills and
+    auto-detect mis-fires when the worktree shape doesn't trip the detector
+    (#1368). The resolved bundle already carries the stack's framework skill
+    (``ac-django`` / ``ac-python`` / ``fastapi``) and the active overlay skill;
+    this turns each into a verbatim "load via the Skill tool" instruction
+    rather than letting it be demoted to the ignorable summary or left to
+    auto-detect. When the stack cannot be determined (empty / unresolved
+    bundle) a conservative default tells the builder to load its stack's
+    coding skill itself, so a code-touching dispatch can never go out with no
+    skill-load directive at all.
+    """
+    ordered = _stack_overlay_load_names(skills, exclude=exclude)
+    if not ordered:
+        return [
+            "REQUIRED: before writing code, also load your stack's coding skill via the Skill tool",
+            "(/ac-django for a Django repo, /ac-python for a Python repo) and the active overlay skill.",
+            "The stack could not be auto-resolved at dispatch — load them yourself; do NOT skip this.",
+            "",
+        ]
+    lines = ["REQUIRED: before writing code, also call the Skill tool for EACH of these stack/overlay skills:"]
+    lines.extend(f"  - /{name}" for name in ordered)
+    lines.extend(
+        (
+            "These carry the framework conventions and overlay-specific rules a dispatched builder",
+            "does not auto-load — do NOT rely on auto-detect.",
+            "",
+        )
+    )
+    return lines
+
+
+def _coding_phase_directive(
+    skills: list[str] | None = None, *, stage_exclude: frozenset[str] = frozenset()
+) -> list[str]:
+    """Return the forced-load + behavior-preservation + verify directive lines.
+
+    Symmetric to ``build_reviewer_dispatch_prompt``: a headless builder loses
+    every loaded skill (rules § Sub-Agent Limitations), so the architecture /
+    code disciplines, the stack + overlay coding skills, and the CI-parity
+    verify step must reach it inline. Shared by ``build_task_prompt`` (the loop
+    builder's work prompt) and the coding branch of ``build_system_context`` so
+    the contract cannot drift between the two builder entry points. *skills* is
+    the resolved bundle for the dispatch — its framework + overlay entries are
+    surfaced as an explicit load block (#1368).
+    """
+    return [
+        "REQUIRED: before writing code, call the Skill tool for /t3:architecture-design and /t3:code.",
+        "Do this FIRST — these carry the design-first and TDD disciplines a dispatched builder",
+        "does not auto-load.",
+        "",
+        *_stack_skill_load_lines(skills, exclude=stage_exclude),
+        "BEHAVIOR PRESERVATION (non-negotiable): When you rewrite or REPLACE existing code, first",
+        "enumerate every behavior/case the old code handled — especially safety/privacy/leak-gate",
+        "coverage and the regression tests that pin it — and preserve each, or STOP and request input.",
+        "NEVER silently narrow a gate; NEVER invert a must-block test to must-not-block; weakening a",
+        "public-repo privacy gate is a BLOCKER, not a self-approved trade-off.",
+        "",
+        "NO AI SIGNATURE: Never add an AI/Claude signature or footer to commit messages OR to PR/issue",
+        "bodies posted on the user's behalf (no 'Generated with Claude Code', no robot-emoji footer,",
+        "no Co-Authored-By).",
+        "",
+        "OPEN QUESTIONS & ASSUMPTIONS: list every open question (solved or not) and every assumption not",
+        "explicit from the spec in an 'Open questions & assumptions' section in BOTH the commit message",
+        "body AND the PR description (status: decided-by-user / assumed / open). See skills/ship § 5.",
+        "",
+        f"VERIFY (CI-parity): before declaring done, run `{_VERIFY_GATES_COMMAND}`. It runs BOTH the",
+        "commit-stage and push-stage hooks; a bare `prek run --all-files` SKIPS the push-stage gates",
+        "(comment-density, doc-update, ensure-pr, the public-repo leak gate) that CI",
+        "re-runs. Report its exit code as the green-proof — not a commit-stage-only run.",
+        *_HEARTBEAT_DM_LINES,
+    ]

--- a/src/teatree/agents/prompt.py
+++ b/src/teatree/agents/prompt.py
@@ -3,22 +3,17 @@
 import json
 from typing import cast
 
+from teatree.agents.coding_prompt import _VERIFY_GATES_COMMAND, _coding_phase_directive, _stack_overlay_load_names
 from teatree.agents.dispatch_preflight import (
     declared_seams_brief_lines,
     head_state_brief_lines,
     review_diff_brief_lines,
 )
-from teatree.agents.skill_injection import (
-    _ALWAYS_FULL_SKILLS,
-    _explicit_load_name,
-    _read_skill_contents,
-    _read_skill_contents_scoped,
-)
+from teatree.agents.skill_injection import _explicit_load_name, _read_skill_contents, _read_skill_contents_scoped
 from teatree.agents.stage_skill_prompt import stage_precedence_line, stage_skills_present
 from teatree.config.agent_spawn import resolve_agent_config
 from teatree.core.modelkit.phases import normalize_phase, resolve_fanout_directive
 from teatree.core.models import Task, Ticket
-from teatree.skill_support.loading import FRAMEWORK_SKILL_NAMES
 
 # The #1135 default ``pr_review_companion``. A headless reviewer must always
 # see the project review-quality bar in full, not the demoted summary.
@@ -50,18 +45,6 @@ def _parent_result_summary(task: Task) -> str:
         parts.append(f"Next steps: {', '.join(str(s) for s in steps[:10])}")
     return "\n".join(parts)
 
-
-_VERIFY_GATES_COMMAND = "t3 tool verify-gates"
-
-# Auto-injected into a long-running maker brief (PR-12): user-visible liveness
-# so a watchdog can tell "stuck" from "still working". The transport half is
-# PR-14's worker heartbeat; this is the brief-level cue the sub-agent acts on.
-_HEARTBEAT_DM_LINES: tuple[str, ...] = (
-    "",
-    "HEARTBEAT (long-running work): if this task runs long, emit a periodic user-visible",
-    "progress DM (`t3 <overlay> notify send`) — report progress, not silence. A watchdog",
-    "distinguishes a stuck run from a still-working one only if you check in.",
-)
 
 # Injected into a verification (review) brief (PR-12): the anti-rubber-stamp
 # contract — prove the change out first, then grade every quality dimension.
@@ -111,112 +94,6 @@ _ANSWER_RETURN_LINES: tuple[str, ...] = (
     "the phase is refused. If you cannot answer (missing context, a decision only the user can",
     "make), draft a clarifying-question reply as the `answer` text rather than returning nothing.",
 )
-
-
-# The coding directive force-loads these two by name in its first lines, and
-# ``rules`` is always embedded in full — so they are never re-listed in the
-# resolved-stack skill-load block.
-_DIRECTIVE_FORCED_SKILLS = frozenset({"architecture-design", "code"}) | _ALWAYS_FULL_SKILLS
-
-
-def _stack_overlay_load_names(skills: list[str] | None, *, exclude: frozenset[str] = frozenset()) -> list[str]:
-    """Return the ordered framework-then-overlay skill names to force-load.
-
-    The resolved bundle minus the skills the directive already force-loads by
-    name (``architecture-design`` / ``code``) and ``rules`` (always embedded in
-    full). Framework skills (``ac-*`` / ``fastapi``) lead, then the overlay /
-    remaining coding skills. Single source of truth for both the directive's
-    load block and the system-context summary-suppression set so the two never
-    disagree on which skills are force-loaded (#1368). *exclude* drops the
-    phase's stage skills — a no-Skill-tool maker gets them embedded in full, so
-    a "load via the Skill tool" directive it cannot act on must not list them.
-    """
-    forced = _DIRECTIVE_FORCED_SKILLS | exclude
-    extra = [s for s in (skills or []) if _explicit_load_name(s) not in forced]
-    framework = [s for s in extra if _explicit_load_name(s) in FRAMEWORK_SKILL_NAMES]
-    overlay = [s for s in extra if _explicit_load_name(s) not in FRAMEWORK_SKILL_NAMES]
-    ordered: list[str] = []
-    for name in (*framework, *overlay):
-        load_name = _explicit_load_name(name)
-        if load_name not in ordered:
-            ordered.append(load_name)
-    return ordered
-
-
-def _stack_skill_load_lines(skills: list[str] | None, *, exclude: frozenset[str] = frozenset()) -> list[str]:
-    """Return the explicit "load the stack + overlay skills BEFORE code" block.
-
-    A dispatched builder does not inherit the parent's loaded skills and
-    auto-detect mis-fires when the worktree shape doesn't trip the detector
-    (#1368). The resolved bundle already carries the stack's framework skill
-    (``ac-django`` / ``ac-python`` / ``fastapi``) and the active overlay skill;
-    this turns each into a verbatim "load via the Skill tool" instruction
-    rather than letting it be demoted to the ignorable summary or left to
-    auto-detect. When the stack cannot be determined (empty / unresolved
-    bundle) a conservative default tells the builder to load its stack's
-    coding skill itself, so a code-touching dispatch can never go out with no
-    skill-load directive at all.
-    """
-    ordered = _stack_overlay_load_names(skills, exclude=exclude)
-    if not ordered:
-        return [
-            "REQUIRED: before writing code, also load your stack's coding skill via the Skill tool",
-            "(/ac-django for a Django repo, /ac-python for a Python repo) and the active overlay skill.",
-            "The stack could not be auto-resolved at dispatch — load them yourself; do NOT skip this.",
-            "",
-        ]
-    lines = ["REQUIRED: before writing code, also call the Skill tool for EACH of these stack/overlay skills:"]
-    lines.extend(f"  - /{name}" for name in ordered)
-    lines.extend(
-        (
-            "These carry the framework conventions and overlay-specific rules a dispatched builder",
-            "does not auto-load — do NOT rely on auto-detect.",
-            "",
-        )
-    )
-    return lines
-
-
-def _coding_phase_directive(
-    skills: list[str] | None = None, *, stage_exclude: frozenset[str] = frozenset()
-) -> list[str]:
-    """Return the forced-load + behavior-preservation + verify directive lines.
-
-    Symmetric to ``build_reviewer_dispatch_prompt``: a headless builder loses
-    every loaded skill (rules § Sub-Agent Limitations), so the architecture /
-    code disciplines, the stack + overlay coding skills, and the CI-parity
-    verify step must reach it inline. Shared by ``build_task_prompt`` (the loop
-    builder's work prompt) and the coding branch of ``build_system_context`` so
-    the contract cannot drift between the two builder entry points. *skills* is
-    the resolved bundle for the dispatch — its framework + overlay entries are
-    surfaced as an explicit load block (#1368).
-    """
-    return [
-        "REQUIRED: before writing code, call the Skill tool for /t3:architecture-design and /t3:code.",
-        "Do this FIRST — these carry the design-first and TDD disciplines a dispatched builder",
-        "does not auto-load.",
-        "",
-        *_stack_skill_load_lines(skills, exclude=stage_exclude),
-        "BEHAVIOR PRESERVATION (non-negotiable): When you rewrite or REPLACE existing code, first",
-        "enumerate every behavior/case the old code handled — especially safety/privacy/leak-gate",
-        "coverage and the regression tests that pin it — and preserve each, or STOP and request input.",
-        "NEVER silently narrow a gate; NEVER invert a must-block test to must-not-block; weakening a",
-        "public-repo privacy gate is a BLOCKER, not a self-approved trade-off.",
-        "",
-        "NO AI SIGNATURE: Never add an AI/Claude signature or footer to commit messages OR to PR/issue",
-        "bodies posted on the user's behalf (no 'Generated with Claude Code', no robot-emoji footer,",
-        "no Co-Authored-By).",
-        "",
-        "OPEN QUESTIONS & ASSUMPTIONS: list every open question (solved or not) and every assumption not",
-        "explicit from the spec in an 'Open questions & assumptions' section in BOTH the commit message",
-        "body AND the PR description (status: decided-by-user / assumed / open). See skills/ship § 5.",
-        "",
-        f"VERIFY (CI-parity): before declaring done, run `{_VERIFY_GATES_COMMAND}`. It runs BOTH the",
-        "commit-stage and push-stage hooks; a bare `prek run --all-files` SKIPS the push-stage gates",
-        "(comment-density, doc-update, ensure-pr, the public-repo leak gate) that CI",
-        "re-runs. Report its exit code as the green-proof — not a commit-stage-only run.",
-        *_HEARTBEAT_DM_LINES,
-    ]
 
 
 def _task_header_lines(task: Task, extra: dict) -> list[str]:

--- a/src/teatree/core/notify.py
+++ b/src/teatree/core/notify.py
@@ -31,11 +31,12 @@ import re
 
 from django.db import DatabaseError, IntegrityError, transaction
 
-from teatree.config import get_effective_settings, load_config
+from teatree.config import get_effective_settings
 from teatree.core.backend_factory import messaging_from_overlay
 from teatree.core.backend_protocols import MessagingBackend
 from teatree.core.modelkit.notify_policy import NotifyAudience
 from teatree.core.models import BotPing, DeliveryClaim, OutboundClaim
+from teatree.core.notify_targets import resolve_user_channel, resolve_user_id
 from teatree.core.send_proxy import SendChannel, SendRequest, route_send
 from teatree.core.session_identity import current_session_id
 from teatree.slack_mrkdwn import normalize_slack_message, slack_linkify
@@ -265,8 +266,8 @@ def _maybe_stamp_answered(*, idempotency_key: str, answering_slack_ts: str) -> N
         if match is None:
             return
         ts = match.group(1)
-    # Deferred import (mirrors ``resolve_user_id`` / ``maybe_linkify``
-    # in this module): the answer-stamp is an opt-in side path; keeping
+    # Deferred import (mirrors ``maybe_linkify`` in this module): the
+    # answer-stamp is an opt-in side path; keeping
     # the model import out of ``teatree.core.notify`` import time avoids
     # perturbing the module-import graph that the on-behalf gate and
     # notify suites rely on.
@@ -430,82 +431,6 @@ def _feature_enabled() -> bool:
     return bool(getattr(settings_, "notify_user_via_bot", True))
 
 
-def resolve_user_id() -> str:
-    """Resolve the Slack user id to DM (overlay override → global → sole overlay → empty).
-
-    The per-overlay id comes from the DB overlays registry (still injected into
-    ``load_config().raw["overlays"]``); the GLOBAL fallback reads the DB-home
-    ``slack_user_id`` setting so every routing path agrees on the same order.
-
-    The final ``sole overlay`` tier is the env-independent fallback that mirrors
-    :func:`teatree.core.backend_factory.messaging_from_overlay` — the headless
-    worker that DMs the owner does NOT export ``T3_OVERLAY_NAME``, so the
-    overlay-scoped tier is skipped, and a fresh box carries no GLOBAL setting.
-    When exactly one overlay is registered there is no ambiguity, so its own
-    ``slack_user_id`` resolves without depending on the env var being set.
-    """
-    from teatree.config import cold_reader  # noqa: PLC0415 — deferred: call-time import, kept lazy
-
-    cfg = load_config().raw
-    overlay_name = os.environ.get("T3_OVERLAY_NAME", "")
-    overlays = cfg.get("overlays") or {}
-    if overlay_name and isinstance(overlays.get(overlay_name), dict):
-        user_id = overlays[overlay_name].get("slack_user_id", "")
-        if user_id:
-            return str(user_id)
-    global_id = cold_reader.str_setting("slack_user_id", default="")
-    if global_id:
-        return global_id
-    return _sole_overlay_field(overlays, "slack_user_id")
-
-
-def resolve_user_channel() -> str:
-    """Resolve the Slack DM channel id the user reads (overlay → global → sole overlay → empty).
-
-    The canonical resolver for the ``slack_user_channel`` config key,
-    walking the SAME overlay→global→sole-overlay→empty order :func:`resolve_user_id`
-    uses for ``slack_user_id``. Both DM-channel call sites (the bot→user
-    DM path and the live-post-approval CLI verifier) consult this single
-    helper, so a change to the resolution order can never drift between
-    two private copies (the config-trap the #126 redesign closes).
-
-    An empty return means no channel is configured; the caller treats it
-    as "open a DM to the resolved user_id" rather than pinning to a
-    specific ``D...`` channel.
-    """
-    from teatree.config import cold_reader  # noqa: PLC0415 — deferred: call-time import, kept lazy
-
-    cfg = load_config().raw
-    overlay_name = os.environ.get("T3_OVERLAY_NAME", "")
-    overlays = cfg.get("overlays") or {}
-    if overlay_name and isinstance(overlays.get(overlay_name), dict):
-        channel = overlays[overlay_name].get("slack_user_channel", "")
-        if channel:
-            return str(channel)
-    global_channel = cold_reader.str_setting("slack_user_channel", default="")
-    if global_channel:
-        return global_channel
-    return _sole_overlay_field(overlays, "slack_user_channel")
-
-
-def _sole_overlay_field(overlays: dict, key: str) -> str:
-    """Return the sole registered overlay's ``key`` value, or ``""``.
-
-    Env-independent fallback for the DM-target resolvers: when the active
-    overlay is ambiguous (``T3_OVERLAY_NAME`` unset in the headless worker)
-    and no GLOBAL setting is configured, a single registered overlay is
-    unambiguous — its own value is the right target. Returns ``""`` when
-    zero or more than one overlay is registered (ambiguous), so a
-    multi-overlay box never silently picks the wrong owner.
-    """
-    if len(overlays) != 1:
-        return ""
-    entry = next(iter(overlays.values()))
-    if not isinstance(entry, dict):
-        return ""
-    return str(entry.get(key, "") or "")
-
-
 def maybe_linkify(text: str) -> str:
     """Apply :func:`slack_linkify` using the active overlay's resolvers, if any.
 
@@ -653,4 +578,10 @@ def drain_undelivered_notifies(
     return delivered, len(rows)
 
 
-__all__ = ["NotifyKind", "drain_undelivered_notifies", "notify_user"]
+__all__ = [
+    "NotifyKind",
+    "drain_undelivered_notifies",
+    "notify_user",
+    "resolve_user_channel",
+    "resolve_user_id",
+]

--- a/src/teatree/core/notify_targets.py
+++ b/src/teatree/core/notify_targets.py
@@ -1,0 +1,94 @@
+"""DM-target resolution for the bot→user egress (split out of ``teatree.core.notify``).
+
+The "who does the bot DM, and on which channel" concern: the canonical
+``slack_user_id`` / ``slack_user_channel`` resolvers shared by every DM call
+site (the :func:`teatree.core.notify.notify_user` egress and the
+live-post-approval CLI verifier). Both walk the identical
+overlay→global→sole-overlay→empty order so a change to the resolution order can
+never drift between two private copies (the config-trap the #126 redesign
+closes). Re-exported from ``teatree.core.notify`` so existing
+``from teatree.core.notify import resolve_user_id`` call sites are unchanged.
+"""
+
+import os
+
+from teatree.config import load_config
+
+
+def resolve_user_id() -> str:
+    """Resolve the Slack user id to DM (overlay override → global → sole overlay → empty).
+
+    The per-overlay id comes from the DB overlays registry (still injected into
+    ``load_config().raw["overlays"]``); the GLOBAL fallback reads the DB-home
+    ``slack_user_id`` setting so every routing path agrees on the same order.
+
+    The final ``sole overlay`` tier is the env-independent fallback that mirrors
+    :func:`teatree.core.backend_factory.messaging_from_overlay` — the headless
+    worker that DMs the owner does NOT export ``T3_OVERLAY_NAME``, so the
+    overlay-scoped tier is skipped, and a fresh box carries no GLOBAL setting.
+    When exactly one overlay is registered there is no ambiguity, so its own
+    ``slack_user_id`` resolves without depending on the env var being set.
+    """
+    from teatree.config import cold_reader  # noqa: PLC0415 — deferred: call-time import, kept lazy
+
+    cfg = load_config().raw
+    overlay_name = os.environ.get("T3_OVERLAY_NAME", "")
+    overlays = cfg.get("overlays") or {}
+    if overlay_name and isinstance(overlays.get(overlay_name), dict):
+        user_id = overlays[overlay_name].get("slack_user_id", "")
+        if user_id:
+            return str(user_id)
+    global_id = cold_reader.str_setting("slack_user_id", default="")
+    if global_id:
+        return global_id
+    return _sole_overlay_field(overlays, "slack_user_id")
+
+
+def resolve_user_channel() -> str:
+    """Resolve the Slack DM channel id the user reads (overlay → global → sole overlay → empty).
+
+    The canonical resolver for the ``slack_user_channel`` config key,
+    walking the SAME overlay→global→sole-overlay→empty order :func:`resolve_user_id`
+    uses for ``slack_user_id``. Both DM-channel call sites (the bot→user
+    DM path and the live-post-approval CLI verifier) consult this single
+    helper, so a change to the resolution order can never drift between
+    two private copies (the config-trap the #126 redesign closes).
+
+    An empty return means no channel is configured; the caller treats it
+    as "open a DM to the resolved user_id" rather than pinning to a
+    specific ``D...`` channel.
+    """
+    from teatree.config import cold_reader  # noqa: PLC0415 — deferred: call-time import, kept lazy
+
+    cfg = load_config().raw
+    overlay_name = os.environ.get("T3_OVERLAY_NAME", "")
+    overlays = cfg.get("overlays") or {}
+    if overlay_name and isinstance(overlays.get(overlay_name), dict):
+        channel = overlays[overlay_name].get("slack_user_channel", "")
+        if channel:
+            return str(channel)
+    global_channel = cold_reader.str_setting("slack_user_channel", default="")
+    if global_channel:
+        return global_channel
+    return _sole_overlay_field(overlays, "slack_user_channel")
+
+
+def _sole_overlay_field(overlays: dict, key: str) -> str:
+    """Return the sole registered overlay's ``key`` value, or ``""``.
+
+    Env-independent fallback for the DM-target resolvers: when the active
+    overlay is ambiguous (``T3_OVERLAY_NAME`` unset in the headless worker)
+    and no GLOBAL setting is configured, a single registered overlay is
+    unambiguous — its own value is the right target. Returns ``""`` when
+    zero or more than one overlay is registered (ambiguous), so a
+    multi-overlay box never silently picks the wrong owner.
+    """
+    if len(overlays) != 1:
+        return ""
+    entry = next(iter(overlays.values()))
+    if not isinstance(entry, dict):
+        return ""
+    return str(entry.get(key, "") or "")
+
+
+__all__ = ["resolve_user_channel", "resolve_user_id"]


### PR DESCRIPTION
Follow-up to #3419: it pushed notify.py (501→528) and prompt.py (→534) over the 500-LOC module-health cap (non-required check, so it merged). Split by concern: notify.py→notify_targets.py (DM-target resolvers), prompt.py→coding_prompt.py (coding-builder dispatch contract). Pure code-move, re-exported, all call sites unchanged. Gates green.