### PR TITLE
fix(tests): repair two main-red pins (leaf-count #3421, resurface #3419)

### DIFF
--- a/tests/quality/test_no_flat_core_regrowth.py
+++ b/tests/quality/test_no_flat_core_regrowth.py
@@ -44,7 +44,11 @@ _CORE_DIR = Path(__file__).resolve().parents[2] / "src" / "teatree" / "core"
 # registry (read_issue_title + fetch_issue_title). A genuine shared root leaf: it
 # must import backend_registry + overlay_loader (which core/models/ may not), so it
 # cannot live under models/, and no cleanup/intake/review/… subpackage owns it.
-PINNED_FLAT_CORE_MODULES = 68
+# 69: +notify_targets.py (#3421) — the owner-DM target resolution split out of
+# notify.py to keep notify.py under the 500-LOC module-health cap. A flat sibling
+# of the notify leaves it serves (notify.py, send_proxy.py, reply_transport.py),
+# owned by no existing subpackage.
+PINNED_FLAT_CORE_MODULES = 69
 
 
 def _flat_core_modules() -> list[str]:

--- a/tests/teatree_core/management_commands/test_questions_resurface.py
+++ b/tests/teatree_core/management_commands/test_questions_resurface.py
@@ -139,7 +139,7 @@ class TestResurfaceText:
         assert "Ship?" in text
         assert "Yes — go" in text
         assert "No" in text
-        assert f"questions answer {row.pk}" in text
+        assert "reply in this thread to answer" in text
 
     def test_malformed_options_json_is_tolerated(self) -> None:
         row = DeferredQuestion.record("Broken?", options_json="{not json", session_id="s-1")


### PR DESCRIPTION
main is red on test (3.13): (1) test_flat_core_leaf_count_is_pinned — #3421 added core/notify_targets.py (68→69 leaves) without bumping the pin; (2) test_renders_question_id_and_options — #3419 reworded resurface text but left the old CLI assertion. Both blocked every PR. Fixes both. Verified 12 passed.