### PR TITLE
feat(e2e): runner owns target/artifacts/evidence + seam-assembled test plan (#3329 #3331)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -7316,6 +7316,10 @@ Usage: t3 teatree e2e external [OPTIONS]
  the spec's lane); overlay args go first, an explicit ``--playwright-args``
  follows so a caller can override.
 
+ The runner exports the out-of-repo ``T3_E2E_ARTIFACTS_DIR``
+ (``--artifacts-dir`` overrides; refused when it resolves inside a repo)
+ and the ``T3_E2E_CAPTURE_EVIDENCE`` flag (``--no-evidence`` opts out).
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --test-path                                   TEXT                           │
 │ --repo                                        TEXT                           │
@@ -7329,6 +7333,9 @@ Usage: t3 teatree e2e external [OPTIONS]
 │                                                        overriding the        │
 │                                                        .branch default (e.g. │
 │                                                        an open MR's branch). │
+│ --artifacts-dir                               TEXT                           │
+│ --no-evidence         --no-no-evidence                 [default:             │
+│                                                        no-no-evidence]       │
 │ --help                                                 Show this message and │
 │                                                        exit.                 │
 ╰──────────────────────────────────────────────────────────────────────────────╯
@@ -7343,7 +7350,10 @@ Usage: t3 teatree e2e project [OPTIONS]
 
  ``--target dev|qa|local`` is exported as ``T3_E2E_TARGET`` for the in-repo
  suite (same contract as the ``external`` runner); empty falls back to
- ``BASE_URL``-based inference.
+ ``BASE_URL``-based inference. The runner also exports the out-of-repo
+ ``T3_E2E_ARTIFACTS_DIR`` and the ``T3_E2E_CAPTURE_EVIDENCE`` flag on every
+ managed run (#3331); the ``external`` runner carries the
+ ``--artifacts-dir`` / ``--no-evidence`` overrides.
 
  Pass ``--update-snapshots`` to regenerate ``pytest-playwright-visual``
  baselines. Always do this inside the Docker image (the default) — the
@@ -7381,6 +7391,11 @@ Usage: t3 teatree e2e post-test-plan [OPTIONS]
  ``--manifest``). See :mod:`._test_plan.post`. ``post-evidence`` is a hidden,
  deprecated alias.
 
+ ``--from-seams`` (#3329) assembles the ``scenario-plan`` note from the
+ overlay seams instead of a manifest: it folds ``overlay.e2e.scenarios``,
+ the run's captures, and the recipe's recorded SHAs. ``--spec-path`` /
+ ``--artifacts-dir`` default to the recipe's recorded ``last_run``.
+
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --manifest                                   TEXT                            │
 │ --ticket                                     TEXT                            │
@@ -7410,6 +7425,9 @@ Usage: t3 teatree e2e post-test-plan [OPTIONS]
 │                                                    video:'on' instead.       │
 │                                                    [default:                 │
 │                                                    no-allow-no-video]        │
+│ --from-seams         --no-from-seams               [default: no-from-seams]  │
+│ --spec-path                                  TEXT                            │
+│ --artifacts-dir                              TEXT                            │
 │ --help                                             Show this message and     │
 │                                                    exit.                     │
 ╰──────────────────────────────────────────────────────────────────────────────╯

--- a/docs/generated/management-commands.json
+++ b/docs/generated/management-commands.json
@@ -208,6 +208,10 @@
           "name": "project"
         },
         {
+          "help": "Emit the ``{lane: [spec, ...]}`` split derived from the overlay's registered specs (#3329)",
+          "name": "lanes"
+        },
+        {
           "help": "Trigger E2E tests on a remote CI pipeline",
           "name": "trigger-ci"
         },

--- a/docs/generated/management-commands.md
+++ b/docs/generated/management-commands.md
@@ -104,6 +104,7 @@ Drive the idle-time memory-consolidation (dreaming) cron (#1933).
 | `run` | Run E2E tests — the one command that works for every overlay |
 | `external` | Run Playwright tests from an external repo (overlay repo, T3_PRIVATE_TESTS, or --repo) |
 | `project` | Run E2E tests from the project's own test directory |
+| `lanes` | Emit the ``{lane: [spec, ...]}`` split derived from the overlay's registered specs (#3329) |
 | `trigger-ci` | Trigger E2E tests on a remote CI pipeline |
 | `post-test-plan` | Post (or update) the ticket's single test-plan note from a manifest |
 | `tracked-manifest` | Print a manifest's authored half (run provenance stripped) for a private test repo to commit |

--- a/skills/e2e/SKILL.md
+++ b/skills/e2e/SKILL.md
@@ -381,7 +381,7 @@ Flags (all keyword-only):
 
 ### Artifact directory layout (Non-Negotiable)
 
-E2E artifacts live in a **dedicated directory per environment**, **outside every repo working tree**. The overlay exports the resolved root — the per-ticket workspace's `.t3-cache/artifacts` — as `T3_E2E_ARTIFACTS_DIR`; honour it rather than hard-coding a path. A capture for `env ∈ {dev, local}` lives at `$T3_E2E_ARTIFACTS_DIR/<TICKET>/<env>/<file>`. Writing captures to a **worktree-root** `artifacts/` puts binaries inside a product repo — the exact mistake the rule above forbids. Capture every screenshot and recording for a given env under that env's directory — never mix a dev and a local capture in one folder, and never dump artifacts at the ticket root. Examples:
+E2E artifacts live in a **dedicated directory per environment**, **outside every repo working tree**. The **runner** exports the resolved root — the per-ticket workspace's `.t3-cache/artifacts` — as `T3_E2E_ARTIFACTS_DIR` (core owns the path, so the no-artifacts-in-a-repo rule is structural, not each overlay re-deriving it; #3331). Override it with `--artifacts-dir` (refused when it resolves inside a repo working tree). Honour the variable rather than hard-coding a path. A capture for `env ∈ {dev, local}` lives at `$T3_E2E_ARTIFACTS_DIR/<TICKET>/<env>/<file>`. Writing captures to a **worktree-root** `artifacts/` puts binaries inside a product repo — the exact mistake the rule above forbids. Capture every screenshot and recording for a given env under that env's directory — never mix a dev and a local capture in one folder, and never dump artifacts at the ticket root. Examples:
 
 ```
 $T3_E2E_ARTIFACTS_DIR/8521/local/run.webm

--- a/src/teatree/core/e2e_scenario.py
+++ b/src/teatree/core/e2e_scenario.py
@@ -1,0 +1,84 @@
+"""E2E seam value types: the authoring ``Scenario`` + the runner→seam context (#3329, #3331).
+
+An overlay declares its per-feature acceptance scenarios as instances of the
+frozen :class:`Scenario` dataclass and returns them from
+:meth:`~teatree.core.overlay.OverlayE2E.scenarios`. Core owns the single
+authoring shape here — one definition every overlay ships instances of, rather
+than each overlay redeclaring the same field names beside its own ``Capture``
+type and hand-mapping into the render dict.
+
+:class:`E2eExtrasContext` is the frozen run context the runner hands
+:meth:`~teatree.core.overlay.OverlayE2E.env_extras` so an overlay's extras key
+off the *same* target core routed at (#3331). Both concerns live in this leaf
+module so ``teatree.core.overlay`` (the seam) and the runner both import them
+without a cycle.
+
+These are pure value objects: no ORM, no code host, no CLI. The
+authoring→render mapping (into the ``scenario-plan`` wire ``TypedDict``) lives
+with the assembler in
+:mod:`teatree.core.management.commands._test_plan.from_seams`.
+"""
+
+from dataclasses import dataclass, field
+
+_UI_MODALITY = "ui"
+_API_MODALITY = "api"
+
+
+@dataclass(frozen=True, slots=True)
+class E2eExtrasContext:
+    """The resolved run context the runner hands :meth:`OverlayE2E.env_extras`.
+
+    Every field is something core resolved for this run: ``target`` (the dual-env
+    target ``"dev"`` / ``"qa"`` / ``"local"`` core routed at), ``spec_path`` (the
+    selected Playwright spec), ``artifacts_dir`` (the out-of-repo capture root the
+    runner exported as ``T3_E2E_ARTIFACTS_DIR``), and ``compose_project`` (the
+    teatree-managed docker-compose project). An overlay reads these instead of
+    re-deriving them, so its extras can never disagree with core's routing. A
+    frozen context — not a widening parameter list — so a future field is an
+    additive change, not another signature break.
+    """
+
+    target: str = ""
+    spec_path: str = ""
+    artifacts_dir: str = ""
+    compose_project: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class Capture:
+    """One evidence capture a scenario declares: a named ``slot`` and its caption.
+
+    ``slot`` is the capture's stable identity — the assembler resolves it to a
+    file under the run's artifacts dir (``<slot>`` or ``<slot>.png``), so a
+    scenario names the captures it expects and core fails loud when a declared
+    slot has no file. ``caption`` is the human line rendered above the image.
+    """
+
+    slot: str
+    caption: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class Scenario:
+    """One acceptance scenario an overlay authors for a spec.
+
+    ``modality`` is ``"ui"`` (captioned screenshots) or ``"api"`` (a contract
+    check with no screenshot). A ``"ui"`` scenario declares the captures it
+    expects in ``captures``; an ``"api"`` scenario declares none. The render
+    side (``scenario-plan`` template) receives the resolved image markdown for
+    each capture — this authoring shape carries only the intent.
+    """
+
+    surface: str
+    title: str = ""
+    preconditions: str = ""
+    steps: tuple[str, ...] = ()
+    expected: str = ""
+    modality: str = _UI_MODALITY
+    captures: tuple[Capture, ...] = field(default_factory=tuple)
+
+    @property
+    def is_api(self) -> bool:
+        """True when the scenario is an API-contract check (no screenshot)."""
+        return self.modality == _API_MODALITY

--- a/src/teatree/core/factory/capabilities.py
+++ b/src/teatree/core/factory/capabilities.py
@@ -76,6 +76,9 @@ CAPABILITIES: tuple[Capability, ...] = (
     ),
     # Pre-existing JSON commands (already machine-drivable before PR-30).
     Capability("teatree checking show", json_output=True, exit_codes=("0",)),
+    Capability(
+        "teatree e2e lanes", json_output=True, exit_codes=("0",), note="--json emits the {lane: [spec]} CI matrix"
+    ),
     Capability("teatree env show", json_output=True, exit_codes=("0", "1"), note="--format json"),
     Capability("teatree db query", json_output=True, exit_codes=("0", "1")),
     Capability(

--- a/src/teatree/core/failed_e2e_watcher.py
+++ b/src/teatree/core/failed_e2e_watcher.py
@@ -1,0 +1,32 @@
+"""The :class:`FailedE2EWatcher` spec — capability E (#1295).
+
+A pure value object split out of :mod:`teatree.core.overlay` so the seam module
+stays under the per-file LOC cap. Re-exported from ``teatree.core.overlay`` for
+back-compat, so ``from teatree.core.overlay import FailedE2EWatcher`` keeps working.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class FailedE2EWatcher:
+    """One Slack-channel watcher spec for capability E (#1295).
+
+    The loop's ``FailedE2EPostsScanner`` consumes a list of these from
+    :meth:`~teatree.core.overlay.OverlayConfig.get_failed_e2e_watchers`; each
+    watcher tells the scanner which channel to poll, how to recognise a
+    failed-E2E post in that channel, how to extract the failing spec path from
+    one bullet, and which agent skill to dispatch with the extracted spec.
+
+    ``post_pattern`` is a regex applied to the *message text* — a match
+    means "this is a failed-E2E post". ``spec_pattern`` is a regex
+    applied to one bullet line and must yield the spec path in either
+    group(1) or the named group ``spec``; non-matching bullets are
+    skipped. ``agent_skill`` is the skill name (e.g. ``"t3:e2e"``) the
+    dispatcher routes the resulting signal to.
+    """
+
+    channel_id: str
+    post_pattern: str
+    spec_pattern: str
+    agent_skill: str = "t3:e2e"

--- a/src/teatree/core/intake/e2e_workitem.py
+++ b/src/teatree/core/intake/e2e_workitem.py
@@ -184,10 +184,12 @@ def resolve_environment(ticket: Ticket, *, at: str = "") -> EnvResolution:
 
 @dataclass(frozen=True)
 class RunProvenance:
-    """Which vanilla spec a run exercised, for DB-only reproducibility (#272).
+    """Which vanilla spec a run exercised + where its evidence lives, for DB-only reproducibility (#272, #3331).
 
     ``spec_path`` is the exact spec that ran; ``manifest_entry`` the
-    overlay-resolved manifest entry id (e.g. a CI lane). Both are
+    overlay-resolved manifest entry id (e.g. a CI lane); ``artifacts_dir`` the
+    out-of-repo artifacts root the runner exported for the run (so
+    ``post-test-plan --from-seams`` locates the captures after cleanup). All
     overlay-agnostic strings core never parses; empty values are dropped rather
     than stored, so an overlay with no per-spec manifest records exactly the
     pre-#272 shape (the default ``RunProvenance()`` is the no-op).
@@ -195,6 +197,7 @@ class RunProvenance:
 
     spec_path: str = ""
     manifest_entry: str = ""
+    artifacts_dir: str = ""
 
 
 _NO_PROVENANCE = RunProvenance()
@@ -220,12 +223,16 @@ def record_run(
     env: str = "local",
     provenance: RunProvenance = _NO_PROVENANCE,
 ) -> None:
-    """Record run provenance on the durable recipe (#794, #88, #272).
+    """Record run provenance on the durable recipe (#794, #88, #272, #3331).
 
     ``{result, timestamp, per_repo_shas, env}`` is written to ``last_run`` so
     a run is auditable after the workspace is cleaned. On a **green** run the
     SHA-set is promoted to ``last_green`` (the new baseline); a failed run
     records provenance but never moves the baseline.
+
+    ``provenance.artifacts_dir`` (#3331) is the out-of-repo artifacts root the
+    runner exported; recorded so ``post-test-plan --from-seams`` (#3329) defaults
+    the artifacts dir to the run's. Empty is dropped rather than stored.
 
     ``env`` is the environment the run executed against — ``"local"``
     (teatree-managed local stack, the default since ``e2e run`` resolves an
@@ -249,6 +256,8 @@ def record_run(
         last_run["spec_path"] = provenance.spec_path
     if provenance.manifest_entry:
         last_run["manifest_entry"] = provenance.manifest_entry
+    if provenance.artifacts_dir:
+        last_run["artifacts_dir"] = provenance.artifacts_dir
     recipe.last_run = last_run
     if result == "green":
         by_repo = {r.repo: r for r in recipe.repos}

--- a/src/teatree/core/management/commands/_e2e_lanes.py
+++ b/src/teatree/core/management/commands/_e2e_lanes.py
@@ -1,0 +1,62 @@
+"""The ``e2e lanes`` verb: derive ``{lane: [spec, ...]}`` from overlay seams (#3329).
+
+``run_provenance(spec_path)`` maps a spec to its lane, but there was no inverse —
+nothing emitted the split a CI matrix needs, so an overlay shipped a CLI command
+purely to invert its own map. Core owns the fold here: it enumerates the
+overlay's specs (:meth:`OverlayE2E.spec_paths`) and groups them by
+:meth:`OverlayE2E.run_provenance`, so the matrix derives from the manifest the
+overlay already registered rather than a hand-maintained spec glob.
+"""
+
+import json
+from collections.abc import Callable
+
+from teatree.core.overlay import OverlayBase
+
+#: The lane specs land under when the overlay records no ``run_provenance`` for
+#: them — surfaced explicitly rather than silently dropped, so a spec missing a
+#: lane is visible in the split instead of absent from the matrix.
+UNASSIGNED_LANE = "unassigned"
+
+
+def lane_split(overlay: OverlayBase) -> dict[str, list[str]]:
+    """Group the overlay's registered specs by their ``run_provenance`` lane.
+
+    Returns ``{lane: [spec, ...]}`` with both lanes and specs sorted, so the
+    emitted matrix is deterministic across runs.
+    """
+    grouped: dict[str, list[str]] = {}
+    for spec in overlay.e2e.spec_paths():
+        lane = overlay.e2e.run_provenance(spec) or UNASSIGNED_LANE
+        grouped.setdefault(lane, []).append(spec)
+    return {lane: sorted(specs) for lane, specs in sorted(grouped.items())}
+
+
+def run_lanes(
+    *,
+    as_json: bool,
+    names: bool,
+    lane: str,
+    overlay: OverlayBase,
+    write_out: Callable[[str], None],
+) -> dict[str, list[str]]:
+    """Emit the lane split for ``e2e lanes``; return it for programmatic callers.
+
+    ``lane`` filters to a single lane (empty keeps all). ``as_json`` prints the
+    ``{lane: [spec, ...]}`` object (a CI matrix); ``names`` prints every spec one
+    per line (a shell loop); the default prints one ``lane: spec, ...`` line per
+    lane.
+    """
+    split = lane_split(overlay)
+    if lane:
+        split = {lane: split.get(lane, [])}
+    if as_json:
+        write_out(json.dumps(split))
+    elif names:
+        for specs in split.values():
+            for spec in specs:
+                write_out(spec)
+    else:
+        for lane_name, specs in split.items():
+            write_out(f"{lane_name}: {', '.join(specs)}")
+    return split

--- a/src/teatree/core/management/commands/_e2e_run_workitem.py
+++ b/src/teatree/core/management/commands/_e2e_run_workitem.py
@@ -1,0 +1,74 @@
+"""The ``e2e run <work-item>`` keystone: resolve → ladder → run → record (#794).
+
+Split out of :mod:`.e2e` (the runner-owns-its-concerns split of #3331) so the
+work-item orchestration — resolve the Ticket, apply the environment ladder,
+dispatch the runner, and record ``{sha, result, artifacts_dir}`` to the durable
+recipe — lives in one module the thin ``run`` command delegates to.
+"""
+
+import os
+from collections.abc import Callable
+from dataclasses import replace
+
+from teatree.core.intake.e2e_workitem import record_run, resolve_environment, resolve_run_provenance
+from teatree.core.management.commands._e2e_runners import e2e_artifacts_root
+from teatree.core.models import Ticket
+from teatree.core.overlay_loader import get_overlay
+from teatree.utils import git
+
+
+def run_work_item(
+    *,
+    work_item: str,
+    at: str,
+    test_path: str,
+    dispatch: Callable[[], str],
+    write_err: Callable[[str], None],
+) -> str:
+    """Resolve the work item, run its e2e via *dispatch*, and record run provenance.
+
+    Deterministic outcome: either the e2e result, or a precise readiness failure
+    naming the exact provisioning gap (which repo at which ref). *dispatch* runs
+    the resolved runner (the caller binds the runner + flags); the recorded
+    ``last_run`` carries the SHA-set, the run provenance (#272), and the run's
+    out-of-repo artifacts root (#3331) so a later ``--from-seams`` assembly needs
+    no re-derivation.
+    """
+    try:
+        ticket = Ticket.objects.resolve(work_item)
+    except Ticket.DoesNotExist:
+        write_err(
+            f"No work item matching {work_item!r} (looked up by pk and issue_url). "
+            "Provision it first: t3 <overlay> workspace ticket <issue_url>",
+        )
+        raise SystemExit(2) from None
+
+    resolution = resolve_environment(ticket, at=at)
+    if resolution.rung != "existing":
+        refs = ", ".join(f"{repo}@{ref}" for repo, ref in sorted(resolution.provision_at.items()))
+        write_err(
+            f"E2E readiness failed for {ticket}: workspace not present on disk.\n"
+            f"Ladder rung '{resolution.rung}' requires provisioning: {refs or '(no repos in recipe)'}.\n"
+            "Provision the work item first: t3 <overlay> workspace ticket <issue_url>",
+        )
+        raise SystemExit(1)
+
+    per_repo_shas: dict[str, str] = {}
+    for repo, wt_path in resolution.repo_dirs.items():
+        try:
+            per_repo_shas[repo] = git.head_sha(repo=wt_path)
+        except Exception:  # noqa: BLE001 — an unresolvable head SHA degrades to empty, never aborts discovery
+            per_repo_shas[repo] = ""
+
+    first_repo_dir = next(iter(resolution.repo_dirs.values()))
+    os.environ["T3_ORIG_CWD"] = first_repo_dir
+    artifacts_dir = str(e2e_artifacts_root(first_repo_dir))
+    provenance = replace(resolve_run_provenance(get_overlay(), test_path), artifacts_dir=artifacts_dir)
+
+    try:
+        result = dispatch()
+    except SystemExit as exc:
+        record_run(ticket, result="red", per_repo_shas=per_repo_shas, provenance=provenance)
+        raise SystemExit(exc.code) from exc
+    record_run(ticket, result="green", per_repo_shas=per_repo_shas, provenance=provenance)
+    return result

--- a/src/teatree/core/management/commands/_e2e_runners.py
+++ b/src/teatree/core/management/commands/_e2e_runners.py
@@ -8,17 +8,68 @@ directory, and building the Playwright environment dict.
 """
 
 import os
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 
 import typer
 
 from teatree.config import E2ERepo, load_e2e_repos
-from teatree.core.intake.resolve import _find_env_cache, _get_user_cwd, _parse_env_file
+from teatree.core.e2e_scenario import E2eExtrasContext
+from teatree.core.intake.resolve import _find_env_cache, _get_user_cwd, _parse_env_file, resolve_worktree
 from teatree.core.overlay_loader import get_overlay
+from teatree.core.worktree.worktree_env import CACHE_DIRNAME
 from teatree.paths import get_data_dir
-from teatree.utils.run import CommandFailedError, run_checked
+from teatree.utils.run import CommandFailedError, run_checked, run_streamed
+
+#: The out-of-repo capture directory the runner exports as
+#: ``T3_E2E_ARTIFACTS_DIR`` (#3331): ``<ticket_dir>/.t3-cache/artifacts`` — a
+#: sibling of every repo working tree, never inside one. The env var whose value
+#: satisfies the "no artifacts inside a repo" rule core mandates, so the rule is
+#: structural (the runner sets it) rather than advisory (each overlay re-derives it).
+ARTIFACTS_ENV = "T3_E2E_ARTIFACTS_DIR"
+_ARTIFACTS_SUBDIR = "artifacts"
+
+#: The evidence-capture flag the runner exports on every managed run (#3331). A
+#: managed run through the runner captures evidence; a plain ``npx playwright`` /
+#: CI run leaves it unset — parity comes from omission, not from each overlay
+#: remembering to inject it.
+CAPTURE_EVIDENCE_ENV = "T3_E2E_CAPTURE_EVIDENCE"
+
+
+class ArtifactsDirInRepoError(RuntimeError):
+    """An explicit ``--artifacts-dir`` resolves inside a repo working tree.
+
+    Refused (#3331): captures written under a repo put binaries in a source tree
+    (#3091, the mistake the no-artifacts-in-a-repo rule already forbids), so an
+    explicitly-passed dir that sits inside any git working tree is a hard error.
+    """
+
+    def __init__(self, artifacts_dir: Path, repo_root: Path) -> None:
+        super().__init__(
+            f"--artifacts-dir {artifacts_dir} is inside the repo working tree {repo_root} "
+            "(a '.git' lives there). E2E artifacts must live outside every repo working tree — "
+            "pass a path under the out-of-repo .t3-cache/artifacts root, or omit --artifacts-dir "
+            "to let the runner derive it.",
+        )
+
+
+def e2e_artifacts_root(worktree_path: str) -> Path:
+    """Derive the out-of-repo artifacts root for a resolved worktree path.
+
+    ``<ticket_dir>/.t3-cache/artifacts`` — ``ticket_dir`` is the parent holding
+    the ticket's sibling repos, so the root is out of every repo working tree.
+    """
+    return Path(worktree_path).parent / CACHE_DIRNAME / _ARTIFACTS_SUBDIR
+
+
+def refuse_artifacts_dir_in_repo(artifacts_dir: Path) -> None:
+    """Raise :class:`ArtifactsDirInRepoError` when *artifacts_dir* sits inside a git working tree."""
+    resolved = artifacts_dir.expanduser()
+    for ancestor in (resolved, *resolved.parents):
+        if (ancestor / ".git").exists():
+            raise ArtifactsDirInRepoError(resolved, ancestor)
+
 
 _BRANCH_HELP = "Specs git ref, overriding the [e2e_repos.<name>].branch default (e.g. an open MR's branch)."
 BRANCH_OPTION = typer.Option("", "--branch", "--ref", help=_BRANCH_HELP)
@@ -92,17 +143,24 @@ class E2eEnvContext:
     test_path: str = ""
     compose_project: str | None = None
     env_cache_override: dict[str, str] | None = None
+    artifacts_dir: str = ""
+    capture_evidence: bool = True
 
 
 def make_e2e_env_context(
     test_path: str,
     compose_project: str | None,
     env_cache_override: dict[str, str] | None,
+    *,
+    artifacts_dir: str = "",
+    capture_evidence: bool = True,
 ) -> E2eEnvContext:
     return E2eEnvContext(
         test_path=test_path,
         compose_project=compose_project,
         env_cache_override=env_cache_override,
+        artifacts_dir=artifacts_dir,
+        capture_evidence=capture_evidence,
     )
 
 
@@ -257,9 +315,19 @@ def build_e2e_env(
     restored-Postgres ``DATABASE_URL`` injected, instead of defaulting to the
     directory basename and missing it. ``None`` (dev target) leaves it unset.
 
-    Overlay-specific env vars (e.g. ``CUSTOMER``) come from
-    :meth:`OverlayE2E.env_extras` — core only knows about ``BASE_URL``,
-    ``T3_E2E_TARGET``, ``COMPOSE_PROJECT_NAME``, ``T3_E2E_TEST_PATH`` and ``CI``.
+    *context.artifacts_dir* is the out-of-repo capture root the runner resolved;
+    it is exported as ``T3_E2E_ARTIFACTS_DIR`` so a capture lands outside every
+    working tree without the overlay re-deriving the path. *context.capture_evidence*
+    exports ``T3_E2E_CAPTURE_EVIDENCE`` on a managed run (opt out with
+    ``--no-evidence``); a plain / CI run leaves it unset.
+
+    The resolved target, spec path, artifacts dir and compose project are handed
+    to :meth:`OverlayE2E.env_extras` as a frozen :class:`E2eExtrasContext`, so an
+    overlay's extras key off the *same* target core routed at — never a re-derived
+    ``BASE_URL`` host regex. Overlay-specific env vars (e.g. ``CUSTOMER``) come
+    from that seam — core only knows about ``BASE_URL``, ``T3_E2E_TARGET``,
+    ``COMPOSE_PROJECT_NAME``, ``T3_E2E_TEST_PATH``, ``T3_E2E_ARTIFACTS_DIR``,
+    ``T3_E2E_CAPTURE_EVIDENCE`` and ``CI``.
     """
     env = {**os.environ}
     context = context or E2eEnvContext()
@@ -268,6 +336,10 @@ def build_e2e_env(
     env["T3_E2E_TARGET"] = target
     if context.compose_project:
         env["COMPOSE_PROJECT_NAME"] = context.compose_project
+    if context.artifacts_dir:
+        env[ARTIFACTS_ENV] = context.artifacts_dir
+    if context.capture_evidence:
+        env[CAPTURE_EVIDENCE_ENV] = "1"
 
     if context.env_cache_override is not None:
         env_cache = context.env_cache_override
@@ -276,7 +348,13 @@ def build_e2e_env(
         env_cache = _parse_env_file(envfile) if envfile is not None else {}
     if context.test_path:
         env_cache = {**env_cache, "T3_E2E_TEST_PATH": context.test_path}
-    for key, value in get_overlay().e2e.env_extras(env_cache).items():
+    extras_context = E2eExtrasContext(
+        target=target,
+        spec_path=context.test_path,
+        artifacts_dir=context.artifacts_dir,
+        compose_project=context.compose_project or "",
+    )
+    for key, value in get_overlay().e2e.env_extras(env_cache, context=extras_context).items():
         env.setdefault(key, value)
 
     if headed:
@@ -284,3 +362,87 @@ def build_e2e_env(
     else:
         env["CI"] = "1"
     return env
+
+
+@dataclass(frozen=True)
+class ProjectRunOptions:
+    """Flags for the in-repo ``project`` runner, resolved by the command."""
+
+    test_path: str = ""
+    resolved_target: str = ""
+    headed: bool = False
+    docker: bool = True
+    update_snapshots: bool = False
+    artifacts_dir: str = ""
+    capture_evidence: bool = True
+
+
+def _project_worktree_path() -> str:
+    """The resolved worktree path for the in-repo runner, or ``"."`` when unresolved."""
+    try:
+        worktree = resolve_worktree()
+    except Exception:  # noqa: BLE001 — an unresolvable worktree degrades to cwd, never aborts the run
+        return "."
+    return (worktree.extra or {}).get("worktree_path", ".") if worktree else "."
+
+
+def _managed_run_env(opts: ProjectRunOptions, settings_module: str) -> dict[str, str]:
+    """Env for the in-process pytest-playwright run: settings, target, artifacts, evidence, ``CI``."""
+    env = {**os.environ, "DJANGO_SETTINGS_MODULE": settings_module, "T3_E2E_TARGET": opts.resolved_target}
+    if opts.artifacts_dir:
+        env[ARTIFACTS_ENV] = opts.artifacts_dir
+    if opts.capture_evidence:
+        env[CAPTURE_EVIDENCE_ENV] = "1"
+    if opts.headed:
+        env.pop("CI", None)
+    else:
+        env["CI"] = "1"
+    return env
+
+
+def _docker_managed_env_flags(opts: ProjectRunOptions) -> list[str]:
+    """``-e KEY=VALUE`` flags carrying the managed-run vars into the compose ``e2e`` service."""
+    flags = ["-e", f"T3_E2E_TARGET={opts.resolved_target}"]
+    if opts.artifacts_dir:
+        flags.extend(["-e", f"{ARTIFACTS_ENV}={opts.artifacts_dir}"])
+    if opts.capture_evidence:
+        flags.extend(["-e", f"{CAPTURE_EVIDENCE_ENV}=1"])
+    return flags
+
+
+def run_project_suite(opts: ProjectRunOptions, *, write_err: Callable[[str], None]) -> str:
+    """Run the project's own e2e suite (in-repo pytest-playwright or the compose ``e2e`` service).
+
+    The runner owns the managed-run env: it exports ``T3_E2E_TARGET``, the
+    out-of-repo ``T3_E2E_ARTIFACTS_DIR``, and the ``T3_E2E_CAPTURE_EVIDENCE``
+    flag (#3331). Returns ``"E2E passed."`` on green; raises ``SystemExit`` with
+    the Playwright/pytest exit code on red.
+    """
+    wt_path = _project_worktree_path()
+    e2e_config = get_overlay().metadata.get_e2e_config()
+    settings_module = e2e_config.get("settings_module", "e2e.settings")
+    test_dir = opts.test_path or e2e_config.get("test_dir", "e2e/")
+
+    if opts.docker and not Path("/.dockerenv").exists():
+        compose_file = Path(wt_path) / "dev" / "docker-compose.yml"
+        if compose_file.is_file():
+            cmd = ["docker", "compose", "-f", str(compose_file), "run", "--rm"]
+            cmd.extend(_docker_managed_env_flags(opts))
+            cmd.extend(["e2e", test_dir])
+            if opts.update_snapshots:
+                cmd.append("--update-snapshots")
+            rc = run_streamed(cmd, cwd=wt_path, check=False)
+            if rc == 0:
+                return "E2E passed."
+            write_err(f"E2E failed (exit {rc}).")
+            raise SystemExit(rc)
+
+    cmd = ["uv", "run", "pytest", test_dir]
+    cmd.extend(["-o", f"DJANGO_SETTINGS_MODULE={settings_module}", "--no-cov", "-p", "no:tach", "-v"])
+    if opts.update_snapshots:
+        cmd.append("--update-snapshots")
+    rc = run_streamed(cmd, cwd=wt_path, env=_managed_run_env(opts, settings_module), check=False)
+    if rc == 0:
+        return "E2E passed."
+    write_err(f"E2E failed (exit {rc}).")
+    raise SystemExit(rc)

--- a/src/teatree/core/management/commands/_test_plan/from_seams.py
+++ b/src/teatree/core/management/commands/_test_plan/from_seams.py
@@ -1,0 +1,234 @@
+"""Assemble the ``scenario-plan`` test plan from overlay seams (``--from-seams``, #3329).
+
+Core already owns every input: the authored scenarios
+(:meth:`OverlayE2E.scenarios`), the run's captures (the artifacts dir), and the
+run provenance (``Ticket.extra['e2e_recipe']`` — the per-repo SHAs and env core
+recorded). This module is the fold that joins them into the note the renderer
+already knows how to draw, so an overlay ships the manifest and nothing else —
+no assembler, no post command, no duplicate ``Scenario`` type.
+
+Resolution and the fail-loud modes core should own live here (each was
+re-implemented per overlay): default the spec to the recipe's recorded
+``last_run.spec_path``; default the artifacts dir to the run's recorded root;
+fail loud when a declared capture slot has no file, when a spec has no authored
+scenarios, or when no per-repo SHAs are recorded.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from teatree.core.backend_factory import code_host_from_overlay
+from teatree.core.backend_protocols import CodeHostBackend
+from teatree.core.e2e_scenario import Scenario
+from teatree.core.intake.e2e_workitem import load_recipe
+from teatree.core.intake.resolve import WorktreeNotFoundError, resolve_worktree
+from teatree.core.management.commands._test_plan.post import (
+    _ON_BEHALF_ACTION,
+    PostTestPlanResult,
+    _create_or_update_note,
+    _resolve_ticket,
+    _verified_embed,
+    find_existing_note,
+)
+from teatree.core.management.commands._test_plan.render import (
+    TestPlanState,
+    TestPlanValidationError,
+    empty_state,
+    render_body,
+)
+from teatree.core.management.commands._test_plan.scenario import Scenario as RenderScenario
+from teatree.core.management.commands._test_plan.scenario import ScenarioImage
+from teatree.core.models import Ticket, Worktree
+from teatree.core.on_behalf_gate_recorded import OnBehalfPostBlockedError, on_behalf_block_message
+from teatree.core.on_behalf_post_receipt import notify_user_on_behalf_post
+from teatree.core.overlay_loader import get_overlay
+from teatree.core.send_proxy import forge_from_url, route_forge_write
+
+_SCENARIO_TEMPLATE = "scenario-plan"
+
+
+class FromSeamsError(TestPlanValidationError):
+    """A ``--from-seams`` assembly precondition failed; nothing is posted.
+
+    A subclass of :class:`TestPlanValidationError` so the command's single
+    ``except`` arm surfaces every fail-loud case (no recorded SHAs, no authored
+    scenarios, a declared capture slot with no file) as a non-zero exit with no
+    host side effect.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class SeamsRun:
+    """The run facts ``--from-seams`` folds, resolved from the recipe + CLI overrides."""
+
+    ticket_number: str
+    spec_path: str
+    artifacts_root: Path
+    env: str
+    per_repo_shas: dict[str, str]
+
+
+def resolve_seams_run(ticket: Ticket, *, spec_path: str, artifacts_dir: str) -> SeamsRun:
+    """Resolve the run to assemble from, defaulting the spec + artifacts dir to the recipe's.
+
+    Raises :class:`FromSeamsError` when no per-repo SHAs are recorded (there is
+    no run to assemble), when no spec resolves, or when no artifacts dir resolves.
+    """
+    last_run = load_recipe(ticket).last_run or {}
+    per_repo_shas = {str(k): str(v) for k, v in (last_run.get("per_repo_shas") or {}).items()}
+    if not per_repo_shas:
+        msg = (
+            f"No per-repo SHAs recorded for {ticket} — run the e2e first "
+            "(`t3 <overlay> e2e run <work-item>`) so a green run records the recipe."
+        )
+        raise FromSeamsError(msg)
+    resolved_spec = spec_path or str(last_run.get("spec_path") or "")
+    if not resolved_spec:
+        msg = "No spec to assemble: pass --spec-path, or run the e2e so the recipe records last_run.spec_path."
+        raise FromSeamsError(msg)
+    resolved_artifacts = artifacts_dir or str(last_run.get("artifacts_dir") or "")
+    if not resolved_artifacts:
+        msg = "No artifacts dir: pass --artifacts-dir, or run the e2e so the recipe records the run's artifacts root."
+        raise FromSeamsError(msg)
+    return SeamsRun(
+        ticket_number=ticket.ticket_number,
+        spec_path=resolved_spec,
+        artifacts_root=Path(resolved_artifacts),
+        env=str(last_run.get("env") or "local"),
+        per_repo_shas=per_repo_shas,
+    )
+
+
+def resolve_capture_file(run: SeamsRun, *, slot: str) -> Path:
+    """Resolve a declared capture ``slot`` to a file under ``<root>/<ticket>/<env>/``.
+
+    Tries ``<slot>`` then ``<slot>.png``. Raises :class:`FromSeamsError` naming
+    the slot when neither exists — a declared capture with no file is a hard
+    failure, not a silently-dropped image.
+    """
+    base = run.artifacts_root / run.ticket_number / run.env
+    for candidate in (base / slot, base / f"{slot}.png"):
+        if candidate.is_file():
+            return candidate
+    msg = f"Capture slot {slot!r} has no file under {base} (tried {slot} and {slot}.png)."
+    raise FromSeamsError(msg)
+
+
+def _render_scenario(host: CodeHostBackend, *, repo: str, scenario: Scenario, run: SeamsRun) -> RenderScenario:
+    """Map one authored :class:`Scenario` to the render ``TypedDict``, uploading its captures."""
+    images: list[ScenarioImage] = []
+    if not scenario.is_api:
+        for capture in scenario.captures:
+            filepath = resolve_capture_file(run, slot=capture.slot)
+            image_md = _verified_embed(
+                host, repo=repo, filepath=str(filepath), label=f"{scenario.surface} — {capture.slot}"
+            )
+            images.append({"slot": capture.slot, "caption": capture.caption, "image_md": image_md})
+    return {
+        "surface": scenario.surface,
+        "title": scenario.title,
+        "preconditions": scenario.preconditions,
+        "steps": list(scenario.steps),
+        "expected": scenario.expected,
+        "modality": "api" if scenario.is_api else "ui",
+        "actual_pass": True,
+        "images": images,
+    }
+
+
+def assemble_scenario_state(
+    host: CodeHostBackend, *, repo: str, title: str, scenarios: tuple[Scenario, ...], run: SeamsRun
+) -> TestPlanState:
+    """Fold the authored scenarios + the run's captures + the recorded SHAs into a note state."""
+    state = empty_state(ticket=run.ticket_number, title=title)
+    state["template"] = _SCENARIO_TEMPLATE
+    state["scenarios"] = [_render_scenario(host, repo=repo, scenario=scenario, run=run) for scenario in scenarios]
+    side = "dev" if run.env == "dev" else "local"
+    state[side]["commits"] = dict(run.per_repo_shas)
+    shas = ", ".join(f"{repo_name} `{sha}`" for repo_name, sha in sorted(run.per_repo_shas.items()))
+    state["environment"] = f"{run.env} — {shas}"
+    return state
+
+
+def _worktree_or_none() -> Worktree | None:
+    try:
+        return resolve_worktree()
+    except WorktreeNotFoundError:
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class FromSeamsRequest:
+    """The CLI inputs for ``post-test-plan --from-seams``: ticket + run overrides.
+
+    ``spec_path`` / ``artifacts_dir`` default (empty) to the recipe's recorded
+    ``last_run``; ``title`` overrides the note heading (empty → the issue URL).
+    """
+
+    ticket: str = ""
+    spec_path: str = ""
+    artifacts_dir: str = ""
+    title: str = ""
+
+
+def run_from_seams(
+    request: FromSeamsRequest,
+    *,
+    write_out: Callable[[str], None],
+    write_err: Callable[[str], None],
+) -> PostTestPlanResult:
+    """Assemble + post the ``scenario-plan`` note for a spec from the overlay seams.
+
+    Resolves the ticket, folds ``overlay.e2e.scenarios(spec)`` + the run's
+    captures + the recipe's recorded SHAs into the note, and creates-or-updates
+    the single test-plan note through the on-behalf gate. Any fail-loud
+    precondition writes to ``write_err`` and exits non-zero before any host side
+    effect.
+    """
+    host = code_host_from_overlay()
+    if host is None:
+        write_err("No code host configured (check overlay GitLab/GitHub token).")
+        raise SystemExit(1)
+    try:
+        result = _assemble_and_post(host, request)
+    except (TestPlanValidationError, OnBehalfPostBlockedError) as err:
+        write_err(str(err))
+        raise SystemExit(1) from err
+    write_out(f"  Test plan {result['action']} (from-seams) on {result['issue_url']} (comment {result['comment_id']}).")
+    return result
+
+
+def _assemble_and_post(host: CodeHostBackend, request: FromSeamsRequest) -> PostTestPlanResult:
+    resolved_ticket = _resolve_ticket(request.ticket, _worktree_or_none())
+    issue_url = str(resolved_ticket.issue_url)
+    run = resolve_seams_run(resolved_ticket, spec_path=request.spec_path, artifacts_dir=request.artifacts_dir)
+    scenarios = get_overlay().e2e.scenarios(run.spec_path)
+    if not scenarios:
+        msg = (
+            f"Spec {run.spec_path!r} has no authored scenarios "
+            "(overlay.e2e.scenarios returned none) — nothing to assemble."
+        )
+        raise FromSeamsError(msg)
+
+    if on_behalf_block_message(issue_url, _ON_BEHALF_ACTION):
+        raise OnBehalfPostBlockedError(issue_url, _ON_BEHALF_ACTION)
+    upload_repo = host.repo_for_issue_url(issue_url)
+    state = assemble_scenario_state(
+        host, repo=upload_repo, title=request.title.strip() or issue_url, scenarios=scenarios, run=run
+    )
+    body = render_body(state)
+    body = route_forge_write(
+        forge=forge_from_url(issue_url), repo=upload_repo, text=body, action=_ON_BEHALF_ACTION, target=issue_url
+    )
+    existing = find_existing_note(host.list_issue_comments(issue_url=issue_url), ticket_id=run.ticket_number)
+    match_id = existing.comment_id if existing else None
+    result, action, comment_id = _create_or_update_note(host, issue_url=issue_url, match_id=match_id, body=body)
+    notify_user_on_behalf_post(
+        target=issue_url,
+        action=_ON_BEHALF_ACTION,
+        destination=issue_url,
+        artifact_url=str(result.get("web_url") or result.get("html_url") or issue_url),
+        summary=f"Test plan (from-seams, {run.env}) on {issue_url}",
+    )
+    return PostTestPlanResult(issue_url=issue_url, comment_id=comment_id, envs=[run.env], action=action)

--- a/src/teatree/core/management/commands/e2e.py
+++ b/src/teatree/core/management/commands/e2e.py
@@ -10,7 +10,10 @@ from django_typer.management import TyperCommand, command
 
 from teatree.core.intake.resolve import resolve_worktree
 from teatree.core.management.commands import _e2e_discovery as _disc
+from teatree.core.management.commands import _e2e_lanes as _lanes
+from teatree.core.management.commands import _e2e_run_workitem as _workitem
 from teatree.core.management.commands import _e2e_runners as _runners
+from teatree.core.management.commands._test_plan import from_seams as _from_seams
 from teatree.core.management.commands._test_plan import post as _test_plan_post
 from teatree.core.management.commands._test_plan import tracked as _tracked_manifest
 from teatree.core.models import Ticket, Worktree
@@ -120,67 +123,14 @@ class Command(TyperCommand):
             branch=branch,
         )
         if work_item:
-            return self._run_work_item(work_item, at=at, opts=opts)
+            return _workitem.run_work_item(
+                work_item=work_item,
+                at=at,
+                test_path=opts.test_path,
+                dispatch=lambda: self._dispatch_runner(opts),
+                write_err=self.stderr.write,
+            )
         return self._dispatch_runner(opts)
-
-    def _run_work_item(
-        self,
-        work_item: str,
-        *,
-        at: str,
-        opts: DispatchOptions,
-    ) -> str:
-        """#794 keystone: resolve work item → ladder → run → record provenance.
-
-        Deterministic outcome: either the e2e result, or a precise readiness
-        failure naming the exact provisioning gap (which repo at which ref).
-        Auto-provisioning of the missing repo set is the larger follow-up; the
-        MVP runs an already-present workspace as-is and records the run's
-        SHA-set + result to the durable recipe keyed by ``issue_url``.
-        """
-        from teatree.core.intake.e2e_workitem import (  # noqa: PLC0415 — deferred: keeps command import light
-            record_run,
-            resolve_environment,
-            resolve_run_provenance,
-        )
-        from teatree.utils import git  # noqa: PLC0415 — deferred: keeps command import light
-
-        try:
-            ticket = Ticket.objects.resolve(work_item)
-        except Ticket.DoesNotExist:
-            self.stderr.write(
-                f"No work item matching {work_item!r} (looked up by pk and issue_url). "
-                "Provision it first: t3 <overlay> workspace ticket <issue_url>",
-            )
-            raise SystemExit(2) from None
-
-        resolution = resolve_environment(ticket, at=at)
-        if resolution.rung != "existing":
-            refs = ", ".join(f"{repo}@{ref}" for repo, ref in sorted(resolution.provision_at.items()))
-            self.stderr.write(
-                f"E2E readiness failed for {ticket}: workspace not present on disk.\n"
-                f"Ladder rung '{resolution.rung}' requires provisioning: {refs or '(no repos in recipe)'}.\n"
-                "Provision the work item first: t3 <overlay> workspace ticket <issue_url>",
-            )
-            raise SystemExit(1)
-
-        per_repo_shas: dict[str, str] = {}
-        for repo, wt_path in resolution.repo_dirs.items():
-            try:
-                per_repo_shas[repo] = git.head_sha(repo=wt_path)
-            except Exception:  # noqa: BLE001 — an unresolvable head SHA degrades to empty, never aborts discovery
-                per_repo_shas[repo] = ""
-
-        os.environ["T3_ORIG_CWD"] = next(iter(resolution.repo_dirs.values()))
-        provenance = resolve_run_provenance(get_overlay(), opts.test_path)
-
-        try:
-            result = self._dispatch_runner(opts)
-        except SystemExit as exc:
-            record_run(ticket, result="red", per_repo_shas=per_repo_shas, provenance=provenance)
-            raise SystemExit(exc.code) from exc
-        record_run(ticket, result="green", per_repo_shas=per_repo_shas, provenance=provenance)
-        return result
 
     def _dispatch_runner(self, opts: DispatchOptions) -> str:
         overlay = get_overlay()
@@ -300,6 +250,28 @@ class Command(TyperCommand):
             )
             raise SystemExit(2) from None
 
+    def _resolve_artifacts_dir(self, explicit: str) -> str:
+        """Resolve the out-of-repo E2E artifacts root the runner exports (#3331).
+
+        An explicit ``--artifacts-dir`` is honoured but REFUSED when it resolves
+        inside a repo working tree (captures never live in a source tree). Empty
+        derives ``<ticket_dir>/.t3-cache/artifacts`` from the resolved worktree;
+        an unresolvable worktree yields ``""`` (the var is simply not exported).
+        """
+        if explicit:
+            try:
+                _runners.refuse_artifacts_dir_in_repo(Path(explicit))
+            except _runners.ArtifactsDirInRepoError as exc:
+                self.stderr.write(str(exc))
+                raise SystemExit(2) from exc
+            return str(Path(explicit).expanduser())
+        try:
+            worktree = resolve_worktree()
+        except Exception:  # noqa: BLE001 — an unresolvable worktree degrades to no artifacts dir, never aborts
+            return ""
+        wt_path = (worktree.extra or {}).get("worktree_path", "") if worktree else ""
+        return str(_runners.e2e_artifacts_root(wt_path)) if wt_path else ""
+
     def _resolve_target(self, target: str) -> str:
         """Resolve the dual-env target deterministically.
 
@@ -327,6 +299,8 @@ class Command(TyperCommand):
         playwright_args: str = "",
         linked_to: int = 0,
         branch: str = _runners.BRANCH_OPTION,
+        artifacts_dir: str = "",
+        no_evidence: bool = False,
     ) -> str:
         """Run Playwright tests from an external repo (overlay repo, T3_PRIVATE_TESTS, or --repo).
 
@@ -365,6 +339,10 @@ class Command(TyperCommand):
         ``e2e.playwright_args(test_path)`` (e.g. ``-c <config>`` chosen by
         the spec's lane); overlay args go first, an explicit ``--playwright-args``
         follows so a caller can override.
+
+        The runner exports the out-of-repo ``T3_E2E_ARTIFACTS_DIR``
+        (``--artifacts-dir`` overrides; refused when it resolves inside a repo)
+        and the ``T3_E2E_CAPTURE_EVIDENCE`` flag (``--no-evidence`` opts out).
         """
         overlay_repo = _runners.overlay_e2e_repo(get_overlay().metadata.get_e2e_config())
         try:
@@ -392,7 +370,13 @@ class Command(TyperCommand):
             frontend_url,
             headed=headed,
             target=resolved_target,
-            context=_runners.make_e2e_env_context(test_path, worktree_compose_project, env_cache_override),
+            context=_runners.make_e2e_env_context(
+                test_path,
+                worktree_compose_project,
+                env_cache_override,
+                artifacts_dir=self._resolve_artifacts_dir(artifacts_dir),
+                capture_evidence=not no_evidence,
+            ),
         )
 
         self.stdout.write(f"  Running from: {private_tests_path}")
@@ -424,63 +408,26 @@ class Command(TyperCommand):
 
         ``--target dev|qa|local`` is exported as ``T3_E2E_TARGET`` for the in-repo
         suite (same contract as the ``external`` runner); empty falls back to
-        ``BASE_URL``-based inference.
+        ``BASE_URL``-based inference. The runner also exports the out-of-repo
+        ``T3_E2E_ARTIFACTS_DIR`` and the ``T3_E2E_CAPTURE_EVIDENCE`` flag on every
+        managed run (#3331); the ``external`` runner carries the
+        ``--artifacts-dir`` / ``--no-evidence`` overrides.
 
         Pass ``--update-snapshots`` to regenerate ``pytest-playwright-visual``
         baselines. Always do this inside the Docker image (the default) — the
         CI runner's Chromium renders fonts at different heights than macOS, so
         locally-generated baselines mismatch in CI.
         """
-        resolved_target = self._resolve_target(target)
-        try:
-            worktree = resolve_worktree()
-            wt_path = (worktree.extra or {}).get("worktree_path", ".") if worktree else "."
-        except Exception:  # noqa: BLE001 — an unresolvable worktree path degrades to cwd
-            wt_path = "."
-        overlay = get_overlay()
-        e2e_config = overlay.metadata.get_e2e_config()
-        settings_module = e2e_config.get("settings_module", "e2e.settings")
-        test_dir = test_path or e2e_config.get("test_dir", "e2e/")
-
-        if docker and not Path("/.dockerenv").exists():
-            compose_file = Path(wt_path) / "dev" / "docker-compose.yml"
-            if compose_file.is_file():
-                cmd = [
-                    "docker",
-                    "compose",
-                    "-f",
-                    str(compose_file),
-                    "run",
-                    "--rm",
-                    "-e",
-                    f"T3_E2E_TARGET={resolved_target}",
-                    "e2e",
-                    test_dir,
-                ]
-                if update_snapshots:
-                    cmd.append("--update-snapshots")
-                rc = run_streamed(cmd, cwd=wt_path, check=False)
-                if rc == 0:
-                    return "E2E passed."
-                self.stderr.write(f"E2E failed (exit {rc}).")
-                raise SystemExit(rc)
-
-        cmd = ["uv", "run", "pytest", test_dir]
-        cmd.extend(["-o", f"DJANGO_SETTINGS_MODULE={settings_module}", "--no-cov", "-p", "no:tach", "-v"])
-        if update_snapshots:
-            cmd.append("--update-snapshots")
-
-        env = {**os.environ, "DJANGO_SETTINGS_MODULE": settings_module, "T3_E2E_TARGET": resolved_target}
-        if headed:
-            env.pop("CI", None)
-        else:
-            env["CI"] = "1"
-
-        rc = run_streamed(cmd, cwd=wt_path, env=env, check=False)
-        if rc == 0:
-            return "E2E passed."
-        self.stderr.write(f"E2E failed (exit {rc}).")
-        raise SystemExit(rc)
+        opts = _runners.ProjectRunOptions(
+            test_path=test_path,
+            resolved_target=self._resolve_target(target),
+            headed=headed,
+            docker=docker,
+            update_snapshots=update_snapshots,
+            artifacts_dir=self._resolve_artifacts_dir(""),
+            capture_evidence=True,
+        )
+        return _runners.run_project_suite(opts, write_err=self.stderr.write)
 
     @command(name="post-test-plan")
     # ast-grep-ignore: ac-django-no-complexity-suppressions
@@ -495,6 +442,9 @@ class Command(TyperCommand):
         body_file: str = "",
         template: str = _TEMPLATE_OPTION,
         allow_no_video: bool = _ALLOW_NO_VIDEO_OPTION,
+        from_seams: bool = False,
+        spec_path: str = "",
+        artifacts_dir: str = "",
     ) -> _test_plan_post.PostTestPlanResult:
         """Post (or update) the ticket's single test-plan note from a manifest.
 
@@ -509,7 +459,17 @@ class Command(TyperCommand):
         posts a pre-authored body verbatim (no upload; mutually exclusive with
         ``--manifest``). See :mod:`._test_plan.post`. ``post-evidence`` is a hidden,
         deprecated alias.
+
+        ``--from-seams`` (#3329) assembles the ``scenario-plan`` note from the
+        overlay seams instead of a manifest: it folds ``overlay.e2e.scenarios``,
+        the run's captures, and the recipe's recorded SHAs. ``--spec-path`` /
+        ``--artifacts-dir`` default to the recipe's recorded ``last_run``.
         """
+        if from_seams:
+            request = _from_seams.FromSeamsRequest(
+                ticket=ticket, spec_path=spec_path, artifacts_dir=artifacts_dir, title=title
+            )
+            return _from_seams.run_from_seams(request, write_out=self.stdout.write, write_err=self.stderr.write)
         return _test_plan_post.run_post_test_plan(
             manifest=manifest,
             ticket=ticket,
@@ -528,6 +488,27 @@ class Command(TyperCommand):
         """Print a manifest's authored half (run provenance stripped) for a private test repo to commit."""
         return _tracked_manifest.run_tracked_manifest(
             manifest=manifest, write_out=self.stdout.write, write_err=self.stderr.write
+        )
+
+    @command()
+    def lanes(
+        self,
+        *,
+        json_output: Annotated[
+            bool, typer.Option("--json", help="Emit the {lane: [spec]} split as a JSON CI matrix.")
+        ] = False,
+        names: bool = False,
+        lane: str = "",
+    ) -> dict[str, list[str]]:
+        """Emit the ``{lane: [spec, ...]}`` split derived from the overlay's registered specs (#3329).
+
+        Core folds ``overlay.e2e.spec_paths()`` by ``run_provenance`` so a CI
+        matrix derives from the manifest the overlay already registered.
+        ``--json`` prints the object (a CI matrix); ``--names`` prints every spec
+        one per line (a shell loop); ``--lane <n>`` filters to one lane.
+        """
+        return _lanes.run_lanes(
+            as_json=json_output, names=names, lane=lane, overlay=get_overlay(), write_out=self.stdout.write
         )
 
     @command(name="retract-evidence")

--- a/src/teatree/core/models/types.py
+++ b/src/teatree/core/models/types.py
@@ -461,6 +461,12 @@ class E2ELastRunSerialized(TypedDict, total=False):
     # indistinguishable from a pre-#272 row.
     spec_path: str
     manifest_entry: str
+    # The out-of-repo artifacts root the runner exported as
+    # ``T3_E2E_ARTIFACTS_DIR`` for this run (#3331). Recorded so
+    # ``post-test-plan --from-seams`` (#3329) can default the artifacts dir to
+    # the run's after the workspace is cleaned, instead of the overlay
+    # re-deriving it. Absent on rows recorded before the runner owned the path.
+    artifacts_dir: str
 
 
 class E2ERecipeSerialized(TypedDict, total=False):

--- a/src/teatree/core/overlay.py
+++ b/src/teatree/core/overlay.py
@@ -3,7 +3,6 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from dataclasses import dataclass
 from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -12,6 +11,8 @@ import httpx
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from teatree.backends.types import Service
+from teatree.core.e2e_scenario import Capture, E2eExtrasContext, Scenario
+from teatree.core.failed_e2e_watcher import FailedE2EWatcher
 from teatree.core.gates.merge_guard import MergeGuard
 from teatree.core.modelkit.phases import canonicalize_stage_skill_keys, normalize_phase
 from teatree.core.overlay_metadata import OverlayMetadata
@@ -48,7 +49,9 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "DEFAULT_TRANSITION_EMOJIS",
     "BaseImageConfig",
+    "Capture",
     "DbImportStrategy",
+    "E2eExtrasContext",
     "FailedE2EWatcher",
     "HealthCheck",
     "MergeGuard",
@@ -63,6 +66,7 @@ __all__ = [
     "ProvisionStep",
     "RunCommand",
     "RunCommands",
+    "Scenario",
     "ServiceSpec",
     "SkillMetadata",
     "SymlinkSpec",
@@ -73,30 +77,6 @@ __all__ = [
 
 
 # ── Overlay configuration ────────────────────────────────────────────
-
-
-@dataclass(frozen=True, slots=True)
-class FailedE2EWatcher:
-    """One Slack-channel watcher spec for capability E (#1295).
-
-    The loop's ``FailedE2EPostsScanner`` consumes a list of these from
-    :meth:`OverlayConfig.get_failed_e2e_watchers`; each watcher tells the
-    scanner which channel to poll, how to recognise a failed-E2E post in
-    that channel, how to extract the failing spec path from one bullet,
-    and which agent skill to dispatch with the extracted spec.
-
-    ``post_pattern`` is a regex applied to the *message text* — a match
-    means "this is a failed-E2E post". ``spec_pattern`` is a regex
-    applied to one bullet line and must yield the spec path in either
-    group(1) or the named group ``spec``; non-matching bullets are
-    skipped. ``agent_skill`` is the skill name (e.g. ``"t3:e2e"``) the
-    dispatcher routes the resulting signal to.
-    """
-
-    channel_id: str
-    post_pattern: str
-    spec_pattern: str
-    agent_skill: str = "t3:e2e"
 
 
 DEFAULT_TRANSITION_EMOJIS: dict[str, str] = {
@@ -530,10 +510,27 @@ class OverlayRuntime:
         return []
 
 
-class OverlayE2E:
-    """End-to-end test concern — ``overlay.e2e``."""
+_EMPTY_EXTRAS_CONTEXT = E2eExtrasContext()
 
-    def env_extras(self, env_cache: dict[str, str]) -> dict[str, str]:
+
+class OverlayE2E:
+    """End-to-end test concern — ``overlay.e2e``.
+
+    The runner (``_e2e_runners``) OWNS target resolution, the artifacts dir, and
+    the evidence flag; it hands :meth:`env_extras` a frozen
+    :class:`E2eExtrasContext` so an overlay's extras key off the *same* target
+    core routed at — never a re-derived ``BASE_URL`` host regex (#3331).
+    """
+
+    def env_extras(
+        self, env_cache: dict[str, str], *, context: E2eExtrasContext = _EMPTY_EXTRAS_CONTEXT
+    ) -> dict[str, str]:
+        """Overlay-specific Playwright env vars (e.g. ``CUSTOMER``); ``{}`` default.
+
+        *env_cache* is the parsed per-worktree env file; *context* carries the run
+        facts core resolved. An overlay whose extras depend on the target reads
+        ``context.target`` rather than classifying ``BASE_URL`` by host.
+        """
         return {}
 
     def run_provenance(self, spec_path: str) -> str:
@@ -541,20 +538,22 @@ class OverlayE2E:
         return ""
 
     def playwright_args(self, spec_path: str) -> list[str]:
-        """Extra ``npx playwright test`` CLI args for *spec_path* (e.g. ``-c <config>``).
-
-        The args-sibling of :meth:`env_extras`: a multi-config Playwright suite
-        needs the runner to pass the right ``-c <config>`` per spec; the overlay
-        knows the lane->config mapping, core does not. Default ``[]``.
-        """
+        """Extra ``npx playwright test`` CLI args for *spec_path* (e.g. the lane's ``-c <config>``); ``[]`` default."""
         return []
 
-    def scenarios(self, spec_path: str) -> tuple:
-        """Return the per-feature acceptance scenarios for *spec_path*; ``()`` default.
+    def scenarios(self, spec_path: str) -> tuple[Scenario, ...]:
+        """The authored acceptance scenarios for *spec_path*; ``()`` default (#3329).
 
-        The overlay-agnostic seam the templated-test-plan renderer reads
-        scenarios through. Core never parses the scenario shape; it just threads
-        the tuple to the renderer.
+        Each element is a frozen :class:`~teatree.core.e2e_scenario.Scenario`
+        core owns — the single authoring shape ``--from-seams`` folds into the note.
+        """
+        return ()
+
+    def spec_paths(self) -> tuple[str, ...]:
+        """Enumerate the overlay's registered spec paths; ``()`` default (#3329).
+
+        The spec-enumeration seam ``e2e lanes`` folds over, grouping specs by
+        :meth:`run_provenance`; core cannot list an overlay's specs itself.
         """
         return ()
 

--- a/src/teatree/overlay_sdk/__init__.py
+++ b/src/teatree/overlay_sdk/__init__.py
@@ -42,6 +42,7 @@ Lane-B toolset registration, the context/cache plan) is re-exported from
 
 from teatree._overlay_api import __overlay_api_version__
 from teatree.config import clone_root, discover_overlays
+from teatree.core.e2e_scenario import Capture, E2eExtrasContext, Scenario
 from teatree.core.gates.merge_guard import MergeGuard
 from teatree.core.overlay import (
     DEFAULT_TRANSITION_EMOJIS,
@@ -122,6 +123,7 @@ __all__ = [
     "AttemptUsage",
     "BaseImageConfig",
     "CacheBreakpoint",
+    "Capture",
     "CommandFailedError",
     "CommandProbeSpec",
     "CompactionPolicy",
@@ -131,6 +133,7 @@ __all__ = [
     "CostReport",
     "DbImportStrategy",
     "DjangoDbImportConfig",
+    "E2eExtrasContext",
     "FailedE2EWatcher",
     "HTTPProbeSpec",
     "Harness",
@@ -157,6 +160,7 @@ __all__ = [
     "ResultEnvelopeError",
     "RunCommand",
     "RunCommands",
+    "Scenario",
     "SegmentStability",
     "ServiceSpec",
     "SkillMetadata",

--- a/tests/quality/deferred_import_pegs.toml
+++ b/tests/quality/deferred_import_pegs.toml
@@ -51,7 +51,7 @@
 "src/teatree/core/management/commands/db.py" = 1
 "src/teatree/core/management/commands/dogfood.py" = 1
 "src/teatree/core/management/commands/dream.py" = 2
-"src/teatree/core/management/commands/e2e.py" = 2
+"src/teatree/core/management/commands/e2e.py" = 1
 "src/teatree/core/management/commands/followup.py" = 2
 "src/teatree/core/management/commands/handover.py" = 1
 "src/teatree/core/management/commands/lifecycle.py" = 3

--- a/tests/quality/test_no_flat_core_regrowth.py
+++ b/tests/quality/test_no_flat_core_regrowth.py
@@ -48,7 +48,16 @@ _CORE_DIR = Path(__file__).resolve().parents[2] / "src" / "teatree" / "core"
 # notify.py to keep notify.py under the 500-LOC module-health cap. A flat sibling
 # of the notify leaves it serves (notify.py, send_proxy.py, reply_transport.py),
 # owned by no existing subpackage.
-PINNED_FLAT_CORE_MODULES = 69
+# 70: +e2e_scenario.py (#3329/#3331) — the e2e seam value types (the authoring
+# Scenario/Capture shapes + the runner→seam E2eExtrasContext). A genuine shared
+# root leaf: it must be importable by BOTH teatree.core.overlay (the OverlayE2E
+# seam) and _e2e_runners (the runner) with no cycle, so it cannot live under a
+# management-command subpackage (layering) nor models/; no existing subpackage owns it.
+# 71: +failed_e2e_watcher.py (#3329/#3331) — the FailedE2EWatcher value type split
+# out of overlay.py to keep it under the 500-LOC cap once OverlayE2E grew the
+# spec_paths seam. A pure overlay-config leaf consumed by the loop's
+# FailedE2EPostsScanner, owned by no existing subpackage (mirrors notify_targets.py).
+PINNED_FLAT_CORE_MODULES = 71
 
 
 def _flat_core_modules() -> list[str]:

--- a/tests/teatree_cli/test_capabilities.py
+++ b/tests/teatree_cli/test_capabilities.py
@@ -43,6 +43,7 @@ def _switch_handler_params() -> dict[str, set[str]]:
         availability,
         checking,
         do,
+        e2e,
         env,
         followup,
         questions,
@@ -65,6 +66,7 @@ def _switch_handler_params() -> dict[str, set[str]]:
         # so its real ``--json`` param lives on the registered typer callback.
         "teatree signals": signals.Command.typer_app.registered_commands[0].callback,
         "teatree checking show": checking.Command.show,
+        "teatree e2e lanes": e2e.Command.lanes,
         "teatree env show": env.Command.show,
         # ``do`` is a bare-``handle`` command (no subcommand token); django-typer
         # replaces the class ``handle`` attribute with a generic wrapper, so its

--- a/tests/teatree_core/conftest.py
+++ b/tests/teatree_core/conftest.py
@@ -76,7 +76,7 @@ class _CommandRuntime(OverlayRuntime):
 
 
 class _CommandE2E(OverlayE2E):
-    def env_extras(self, env_cache: dict[str, str]) -> dict[str, str]:
+    def env_extras(self, env_cache: dict[str, str], **_: object) -> dict[str, str]:
         variant = env_cache.get("WT_VARIANT", "")
         return {"CUSTOMER": variant} if variant else {}
 

--- a/tests/teatree_core/management/commands/_test_plan/test_from_seams.py
+++ b/tests/teatree_core/management/commands/_test_plan/test_from_seams.py
@@ -1,0 +1,177 @@
+"""Assemble the ``scenario-plan`` note from overlay seams — ``--from-seams`` (#3329)."""
+
+from pathlib import Path
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.management import call_command
+from django.test import TestCase
+
+from teatree.core.backend_protocols import UploadVerification
+from teatree.core.e2e_scenario import Capture, Scenario
+from teatree.core.intake.e2e_workitem import RunProvenance, record_run
+from teatree.core.management.commands._test_plan import from_seams as _from_seams
+from teatree.core.management.commands._test_plan.post import PostTestPlanResult
+from teatree.core.models import Ticket
+from teatree.core.overlay import OverlayE2E
+from tests.teatree_core.conftest import CommandOverlay
+
+_ISSUE_URL = "https://gitlab.com/org/repo/-/issues/8521"
+_TICKET_NUMBER = "8521"
+_SPEC = "e2e/specs/login.spec.ts"
+
+
+class _SeamsE2E(OverlayE2E):
+    def scenarios(self, spec_path: str) -> tuple[Scenario, ...]:
+        if spec_path != _SPEC:
+            return ()
+        return (
+            Scenario(
+                surface="Login",
+                title="Login works",
+                preconditions="signed out",
+                steps=("open the page", "submit"),
+                expected="dashboard renders",
+                captures=(Capture(slot="step1", caption="the login form"),),
+            ),
+        )
+
+
+class _SeamsOverlay(CommandOverlay):
+    e2e = _SeamsE2E()
+
+
+_MOCK_OVERLAY = {"test": _SeamsOverlay()}
+
+
+def _fake_host() -> MagicMock:
+    host = MagicMock()
+    host.repo_for_issue_url.return_value = "org/repo"
+    host.list_issue_comments.return_value = []
+    host.post_issue_comment.return_value = {"id": 99, "web_url": "u"}
+    host.upload_file.return_value = {"full_path": "/-/project/9/uploads/x/step1.png"}
+    host.verify_upload.return_value = UploadVerification(ok=True, embed_url="/uploads/x/step1.png")
+    return host
+
+
+class _FromSeamsBase(TestCase):
+    @pytest.fixture(autouse=True)
+    def _inject(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        self._monkeypatch = monkeypatch
+        self._tmp = tmp_path
+        # IMMEDIATE on-behalf mode: the post is not gated for the test's lifetime.
+        monkeypatch.setenv("T3_ON_BEHALF_POST_MODE", "immediate")
+        # No worktree — the ticket resolves via the explicit --ticket ref.
+        monkeypatch.setattr(
+            _from_seams,
+            "resolve_worktree",
+            MagicMock(side_effect=_from_seams.WorktreeNotFoundError("none")),
+        )
+
+    def _ticket_with_recipe(self, *, spec: str = _SPEC, shas: dict[str, str] | None = None) -> Path:
+        ticket = Ticket.objects.create(overlay="test", issue_url=_ISSUE_URL)
+        artifacts_root = self._tmp / "artifacts"
+        record_run(
+            ticket,
+            result="green",
+            per_repo_shas=shas if shas is not None else {"backend": "abc1234"},
+            env="local",
+            provenance=RunProvenance(spec_path=spec, artifacts_dir=str(artifacts_root)),
+        )
+        return artifacts_root
+
+    def _write_capture(self, artifacts_root: Path, *, slot: str = "step1") -> None:
+        env_dir = artifacts_root / _TICKET_NUMBER / "local"
+        env_dir.mkdir(parents=True, exist_ok=True)
+        (env_dir / f"{slot}.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    def _run(self, host: MagicMock, *, ticket: str, spec_path: str, artifacts_dir: str) -> PostTestPlanResult:
+        self._monkeypatch.setattr(_from_seams, "code_host_from_overlay", lambda: host)
+        request = _from_seams.FromSeamsRequest(ticket=ticket, spec_path=spec_path, artifacts_dir=artifacts_dir)
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            return _from_seams.run_from_seams(request, write_out=lambda _s: None, write_err=lambda _s: None)
+
+
+class TestAssembleAndPost(_FromSeamsBase):
+    def test_creates_scenario_plan_note_from_seams(self) -> None:
+        artifacts_root = self._ticket_with_recipe()
+        self._write_capture(artifacts_root)
+        host = _fake_host()
+
+        result = self._run(host, ticket=_ISSUE_URL, spec_path="", artifacts_dir="")
+
+        assert result["action"] == "created"
+        assert result["envs"] == ["local"]
+        host.post_issue_comment.assert_called_once()
+        body = host.post_issue_comment.call_args.kwargs["body"]
+        assert "<!-- t3-e2e-evidence ticket=8521 -->" in body
+        assert "### Scenario 1 — Login" in body
+        # The declared capture's uploaded embed and its caption render.
+        assert "](/uploads/x/step1.png)" in body
+        assert "the login form" in body
+        # The recorded SHA renders in the environment footer.
+        assert "backend `abc1234`" in body
+
+    def test_rerun_updates_the_single_note_in_place(self) -> None:
+        artifacts_root = self._ticket_with_recipe()
+        self._write_capture(artifacts_root)
+        host = _fake_host()
+        host.list_issue_comments.return_value = [{"id": 55, "body": "<!-- t3-e2e-evidence ticket=8521 -->\nprior"}]
+        host.update_issue_comment.return_value = {"id": 55}
+
+        result = self._run(host, ticket=_ISSUE_URL, spec_path="", artifacts_dir="")
+
+        assert result["action"] == "updated"
+        assert result["comment_id"] == 55
+        host.update_issue_comment.assert_called_once()
+        host.post_issue_comment.assert_not_called()
+
+
+class TestFailLoud(_FromSeamsBase):
+    def test_no_authored_scenarios_exits_nonzero_no_post(self) -> None:
+        self._ticket_with_recipe(spec="e2e/specs/unknown.spec.ts")
+        host = _fake_host()
+        with pytest.raises(SystemExit):
+            self._run(host, ticket=_ISSUE_URL, spec_path="", artifacts_dir="")
+        host.post_issue_comment.assert_not_called()
+
+    def test_missing_capture_file_exits_nonzero_no_post(self) -> None:
+        self._ticket_with_recipe()  # no capture written
+        host = _fake_host()
+        with pytest.raises(SystemExit):
+            self._run(host, ticket=_ISSUE_URL, spec_path="", artifacts_dir="")
+        host.post_issue_comment.assert_not_called()
+
+    def test_no_per_repo_shas_exits_nonzero(self) -> None:
+        self._ticket_with_recipe(shas={})
+        host = _fake_host()
+        with pytest.raises(SystemExit):
+            self._run(host, ticket=_ISSUE_URL, spec_path="", artifacts_dir="")
+        host.post_issue_comment.assert_not_called()
+
+
+class TestResolveSeamsRun(_FromSeamsBase):
+    def test_defaults_spec_and_artifacts_to_the_recipe(self) -> None:
+        artifacts_root = self._ticket_with_recipe()
+        ticket = Ticket.objects.get(issue_url=_ISSUE_URL)
+        run = _from_seams.resolve_seams_run(ticket, spec_path="", artifacts_dir="")
+        assert run.spec_path == _SPEC
+        assert run.artifacts_root == artifacts_root
+        assert run.env == "local"
+        assert run.per_repo_shas == {"backend": "abc1234"}
+
+
+class TestPostTestPlanFromSeamsCommand(_FromSeamsBase):
+    def test_command_from_seams_flag_assembles_and_posts(self) -> None:
+        artifacts_root = self._ticket_with_recipe()
+        self._write_capture(artifacts_root)
+        host = _fake_host()
+        self._monkeypatch.setattr(_from_seams, "code_host_from_overlay", lambda: host)
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            result = cast(
+                "dict[str, object]",
+                call_command("e2e", "post-test-plan", from_seams=True, ticket=_ISSUE_URL),
+            )
+        assert result["action"] == "created"
+        host.post_issue_comment.assert_called_once()

--- a/tests/teatree_core/management/commands/test_e2e_lanes.py
+++ b/tests/teatree_core/management/commands/test_e2e_lanes.py
@@ -1,0 +1,76 @@
+"""The ``e2e lanes`` verb: derive ``{lane: [spec, ...]}`` from overlay seams (#3329)."""
+
+import json
+from typing import cast
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from teatree.core.management.commands import _e2e_lanes as _lanes
+from teatree.core.overlay import OverlayE2E
+from tests.teatree_core.conftest import CommandOverlay
+
+_SPECS = (
+    "e2e/specs/login.spec.ts",
+    "e2e/specs/checkout.spec.ts",
+    "e2e/specs/orphan.spec.ts",
+)
+
+
+class _LanesE2E(OverlayE2E):
+    def spec_paths(self) -> tuple[str, ...]:
+        return _SPECS
+
+    def run_provenance(self, spec_path: str) -> str:
+        if "login" in spec_path:
+            return "smoke"
+        if "checkout" in spec_path:
+            return "smoke"
+        return ""  # orphan spec has no recorded lane
+
+
+class _LanesOverlay(CommandOverlay):
+    e2e = _LanesE2E()
+
+
+_MOCK_OVERLAY = {"test": _LanesOverlay()}
+
+
+class TestLaneSplit(TestCase):
+    def test_groups_specs_by_provenance_lane_sorted(self) -> None:
+        split = _lanes.lane_split(_LanesOverlay())
+        assert split == {
+            "smoke": ["e2e/specs/checkout.spec.ts", "e2e/specs/login.spec.ts"],
+            _lanes.UNASSIGNED_LANE: ["e2e/specs/orphan.spec.ts"],
+        }
+
+    def test_no_specs_yields_empty_split(self) -> None:
+        assert _lanes.lane_split(CommandOverlay()) == {}
+
+
+class TestRunLanes(TestCase):
+    def test_json_emits_the_matrix_object(self) -> None:
+        lines: list[str] = []
+        split = _lanes.run_lanes(as_json=True, names=False, lane="", overlay=_LanesOverlay(), write_out=lines.append)
+        assert json.loads(lines[0]) == split
+        assert split["smoke"] == ["e2e/specs/checkout.spec.ts", "e2e/specs/login.spec.ts"]
+
+    def test_names_emits_every_spec_one_per_line(self) -> None:
+        lines: list[str] = []
+        _lanes.run_lanes(as_json=False, names=True, lane="", overlay=_LanesOverlay(), write_out=lines.append)
+        assert set(lines) == set(_SPECS)
+
+    def test_lane_filter_restricts_to_one_lane(self) -> None:
+        lines: list[str] = []
+        split = _lanes.run_lanes(
+            as_json=True, names=False, lane="smoke", overlay=_LanesOverlay(), write_out=lines.append
+        )
+        assert set(split) == {"smoke"}
+
+
+class TestLanesCommand(TestCase):
+    def test_command_returns_the_split(self) -> None:
+        with patch("teatree.core.overlay_loader._discover_overlays", return_value=_MOCK_OVERLAY):
+            result = cast("dict[str, list[str]]", call_command("e2e", "lanes", json_output=True))
+        assert result["smoke"] == ["e2e/specs/checkout.spec.ts", "e2e/specs/login.spec.ts"]

--- a/tests/teatree_core/management/commands/test_e2e_runner_env.py
+++ b/tests/teatree_core/management/commands/test_e2e_runner_env.py
@@ -1,0 +1,100 @@
+"""The runner owns target propagation, the artifacts dir, and the evidence flag (#3331)."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from teatree.core.e2e_scenario import E2eExtrasContext
+from teatree.core.management.commands import _e2e_runners as _runners
+
+
+class _EchoE2E:
+    """An overlay e2e seam that echoes the resolved context into env vars."""
+
+    def env_extras(self, env_cache: dict[str, str], *, context: E2eExtrasContext) -> dict[str, str]:
+        _ = env_cache
+        return {
+            "SEEN_TARGET": context.target,
+            "SEEN_ARTIFACTS": context.artifacts_dir,
+            "SEEN_SPEC": context.spec_path,
+            "SEEN_COMPOSE": context.compose_project,
+        }
+
+
+def _echo_overlay() -> object:
+    return SimpleNamespace(e2e=_EchoE2E())
+
+
+def _build(**ctx_kwargs: object) -> dict[str, str]:
+    context = _runners.E2eEnvContext(env_cache_override={}, **ctx_kwargs)
+    with patch.object(_runners, "get_overlay", _echo_overlay):
+        return _runners.build_e2e_env("http://localhost:4200", headed=False, target="local", context=context)
+
+
+class TestArtifactsDirExport:
+    def test_exports_artifacts_dir_when_set(self) -> None:
+        env = _build(artifacts_dir="/tk/.t3-cache/artifacts")
+        assert env[_runners.ARTIFACTS_ENV] == "/tk/.t3-cache/artifacts"
+
+    def test_omits_artifacts_dir_when_empty(self) -> None:
+        env = _build(artifacts_dir="")
+        assert _runners.ARTIFACTS_ENV not in env
+
+
+class TestEvidenceFlag:
+    def test_managed_run_sets_evidence_flag(self) -> None:
+        env = _build(capture_evidence=True)
+        assert env[_runners.CAPTURE_EVIDENCE_ENV] == "1"
+
+    def test_no_evidence_omits_the_flag(self) -> None:
+        env = _build(capture_evidence=False)
+        assert _runners.CAPTURE_EVIDENCE_ENV not in env
+
+
+class TestTargetReachesTheSeam:
+    def test_resolved_context_is_handed_to_env_extras(self) -> None:
+        env = _build(artifacts_dir="/tk/a", test_path="e2e/login.spec.ts", compose_project="backend-wt7")
+        # The overlay read the SAME target core routed at — not a BASE_URL guess.
+        assert env["SEEN_TARGET"] == "local"
+        assert env["SEEN_ARTIFACTS"] == "/tk/a"
+        assert env["SEEN_SPEC"] == "e2e/login.spec.ts"
+        assert env["SEEN_COMPOSE"] == "backend-wt7"
+
+
+class TestArtifactsRootDerivation:
+    def test_root_is_out_of_repo_sibling(self) -> None:
+        root = _runners.e2e_artifacts_root("/work/ticket-42/backend")
+        assert root == Path("/work/ticket-42/.t3-cache/artifacts")
+
+
+class TestRefuseArtifactsDirInRepo:
+    def test_refuses_dir_inside_a_git_working_tree(self, tmp_path: Path) -> None:
+        repo = tmp_path / "product"
+        (repo / ".git").mkdir(parents=True)
+        inside = repo / "artifacts"
+        inside.mkdir()
+        with pytest.raises(_runners.ArtifactsDirInRepoError):
+            _runners.refuse_artifacts_dir_in_repo(inside)
+
+    def test_allows_dir_outside_every_repo(self, tmp_path: Path) -> None:
+        outside = tmp_path / "ticket" / ".t3-cache" / "artifacts"
+        outside.mkdir(parents=True)
+        _runners.refuse_artifacts_dir_in_repo(outside)  # no raise
+
+
+class TestProjectRunnerManagedEnv:
+    def test_managed_env_carries_artifacts_and_evidence(self) -> None:
+        opts = _runners.ProjectRunOptions(resolved_target="dev", artifacts_dir="/tk/a", capture_evidence=True)
+        env = _runners._managed_run_env(opts, "e2e.settings")
+        assert env["T3_E2E_TARGET"] == "dev"
+        assert env[_runners.ARTIFACTS_ENV] == "/tk/a"
+        assert env[_runners.CAPTURE_EVIDENCE_ENV] == "1"
+
+    def test_docker_flags_carry_the_managed_vars(self) -> None:
+        opts = _runners.ProjectRunOptions(resolved_target="local", artifacts_dir="/tk/a", capture_evidence=False)
+        flags = _runners._docker_managed_env_flags(opts)
+        assert "T3_E2E_TARGET=local" in flags
+        assert f"{_runners.ARTIFACTS_ENV}=/tk/a" in flags
+        assert all("CAPTURE_EVIDENCE" not in f for f in flags)

--- a/tests/teatree_core/management_commands/_overlays.py
+++ b/tests/teatree_core/management_commands/_overlays.py
@@ -138,7 +138,7 @@ class FullRuntime(OverlayRuntime):
 
 
 class FullE2E(OverlayE2E):
-    def env_extras(self, env_cache: dict[str, str]) -> dict[str, str]:
+    def env_extras(self, env_cache: dict[str, str], **_: object) -> dict[str, str]:
         variant = env_cache.get("WT_VARIANT", "")
         return {"CUSTOMER": variant} if variant else {}
 

--- a/tests/teatree_core/management_commands/test_e2e.py
+++ b/tests/teatree_core/management_commands/test_e2e.py
@@ -691,7 +691,7 @@ class TestE2eExternal(TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             captured_env_caches: list[dict[str, str]] = []
 
-            def _e2e_env_extras(self: object, env_cache: dict[str, str]) -> dict[str, str]:
+            def _e2e_env_extras(self: object, env_cache: dict[str, str], **_kwargs: object) -> dict[str, str]:
                 _ = self
                 captured_env_caches.append(dict(env_cache))
                 return {

--- a/tests/teatree_core/test_e2e_scenario.py
+++ b/tests/teatree_core/test_e2e_scenario.py
@@ -1,0 +1,48 @@
+"""The frozen authoring ``Scenario`` / ``Capture`` contract (#3329)."""
+
+import dataclasses
+
+import pytest
+
+from teatree.core.e2e_scenario import Capture, Scenario
+
+
+class TestCapture:
+    def test_slot_only_defaults_empty_caption(self) -> None:
+        capture = Capture(slot="step1")
+        assert capture.slot == "step1"
+        assert capture.caption == ""
+
+    def test_is_frozen(self) -> None:
+        capture = Capture(slot="step1", caption="the field")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            capture.slot = "other"  # type: ignore[misc]
+
+
+class TestScenario:
+    def test_surface_only_carries_sensible_defaults(self) -> None:
+        scenario = Scenario(surface="Login")
+        assert scenario.surface == "Login"
+        assert scenario.title == ""
+        assert scenario.steps == ()
+        assert scenario.captures == ()
+        assert scenario.modality == "ui"
+        assert scenario.is_api is False
+
+    def test_api_modality_flags_is_api(self) -> None:
+        scenario = Scenario(surface="Contract", modality="api")
+        assert scenario.is_api is True
+
+    def test_carries_captures_and_steps(self) -> None:
+        scenario = Scenario(
+            surface="Login",
+            steps=("open", "submit"),
+            captures=(Capture(slot="step1", caption="form"),),
+        )
+        assert scenario.steps == ("open", "submit")
+        assert scenario.captures[0].slot == "step1"
+
+    def test_is_frozen(self) -> None:
+        scenario = Scenario(surface="Login")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            scenario.surface = "other"  # type: ignore[misc]

--- a/tests/teatree_core/test_e2e_workitem.py
+++ b/tests/teatree_core/test_e2e_workitem.py
@@ -296,6 +296,25 @@ class ProvenanceTests(TestCase):
         assert "spec_path" not in recipe.last_run
         assert "manifest_entry" not in recipe.last_run
 
+    def test_artifacts_dir_provenance_is_recorded(self) -> None:
+        record_run(
+            self.ticket,
+            result="green",
+            per_repo_shas={"r": "s"},
+            provenance=RunProvenance(spec_path="e2e/x.spec.ts", artifacts_dir="/tk/.t3-cache/artifacts"),
+        )
+
+        recipe = load_recipe(self.ticket)
+        assert recipe.last_run is not None
+        assert recipe.last_run["artifacts_dir"] == "/tk/.t3-cache/artifacts"
+
+    def test_empty_artifacts_dir_is_not_recorded(self) -> None:
+        record_run(self.ticket, result="green", per_repo_shas={"r": "s"}, provenance=RunProvenance())
+
+        recipe = load_recipe(self.ticket)
+        assert recipe.last_run is not None
+        assert "artifacts_dir" not in recipe.last_run
+
 
 class GitHelpersTests(TestCase):
     def test_head_sha_returns_full_sha(self, tmp_path: Path | None = None) -> None:

--- a/tests/teatree_core/test_provisioning_contract.py
+++ b/tests/teatree_core/test_provisioning_contract.py
@@ -413,7 +413,7 @@ class WorktreeFsmTransitionTests(TestCase):
 
 
 class _FixedExtrasOverlayE2e(OverlayE2E):
-    def env_extras(self, env_cache: dict[str, str]) -> dict[str, str]:
+    def env_extras(self, env_cache: dict[str, str], **_: object) -> dict[str, str]:
         return {"E2E_CONTRACT_KEY": "from-overlay", "E2E_ONLY_OVERLAY": "filled"}
 
 

--- a/tests/teatree_overlay_sdk/test_overlay_sdk_surface.py
+++ b/tests/teatree_overlay_sdk/test_overlay_sdk_surface.py
@@ -32,6 +32,7 @@ EXPECTED_SURFACE: frozenset[str] = frozenset(
         "AttemptUsage",
         "BaseImageConfig",
         "CacheBreakpoint",
+        "Capture",
         "CommandFailedError",
         "CommandProbeSpec",
         "CompactionPolicy",
@@ -41,6 +42,7 @@ EXPECTED_SURFACE: frozenset[str] = frozenset(
         "CostReport",
         "DbImportStrategy",
         "DjangoDbImportConfig",
+        "E2eExtrasContext",
         "FailedE2EWatcher",
         "HTTPProbeSpec",
         "Harness",
@@ -67,6 +69,7 @@ EXPECTED_SURFACE: frozenset[str] = frozenset(
         "ResultEnvelopeError",
         "RunCommand",
         "RunCommands",
+        "Scenario",
         "SegmentStability",
         "ServiceSpec",
         "SkillMetadata",
@@ -156,11 +159,15 @@ EXPECTED_RUNTIME_SIGNATURES: dict[str, str] = {
 }
 
 EXPECTED_E2E_SIGNATURES: dict[str, str] = {
-    "env_extras": "(self, env_cache: dict[str, str]) -> dict[str, str]",
+    "env_extras": (
+        "(self, env_cache: dict[str, str], *, context: teatree.core.e2e_scenario.E2eExtrasContext = "
+        "E2eExtrasContext(target='', spec_path='', artifacts_dir='', compose_project='')) -> dict[str, str]"
+    ),
     "playwright_args": "(self, spec_path: str) -> list[str]",
     "preflight": ("(self, *, customer: str | None, base_url: str | None) -> list[collections.abc.Callable[[], None]]"),
     "run_provenance": "(self, spec_path: str) -> str",
-    "scenarios": "(self, spec_path: str) -> tuple",
+    "scenarios": "(self, spec_path: str) -> tuple[teatree.core.e2e_scenario.Scenario, ...]",
+    "spec_paths": "(self) -> tuple[str, ...]",
 }
 
 EXPECTED_REVIEW_SIGNATURES: dict[str, str] = {


### PR DESCRIPTION
Closes #3329. Closes #3331. e2e runner owns target→env propagation, artifacts-dir, evidence flag (frozen E2eExtrasContext); post-test-plan --from-seams assembly + e2e lanes verb; frozen Scenario dataclass exported via overlay_sdk.