### PR TITLE
feat(loop): skip exhausted Anthropic accounts + auto-requeue on window reset (#3406 #3407)

### DIFF
--- a/src/teatree/credential_config.py
+++ b/src/teatree/credential_config.py
@@ -27,9 +27,12 @@ exhausted:
 *   On a cache miss / expiry each candidate is probed once (the reader), its health
     row upserted, and the first non-exhausted one is pinned as the new sticky pick.
 *   When the overlay's own accounts are all exhausted the selector falls back to ANY
-    other configured account (across overlays); when none anywhere is usable it raises
-    :class:`AllTokensExhaustedError` (a :class:`CredentialError`) naming the earliest
-    reset, so an all-accounts-spent condition halts agent work loudly.
+    other configured account (across overlays); when every account's CACHED verdict still
+    reads exhausted, a last-ditch live re-probe (:meth:`PassPathSelector._rescue_reprobe`,
+    cooldown-throttled) runs first — a rolling 5h window frees capacity before its recorded
+    reset, so a recovered account is rescued rather than stranding the loop. Only when the
+    rescue also finds nothing usable does it raise :class:`AllTokensExhaustedError` (a
+    :class:`CredentialError`) naming the earliest reset, halting agent work loudly.
 
 The token that signs a probe is never logged or returned; only its ``pass_path`` and
 parsed health are persisted.
@@ -67,6 +70,13 @@ if TYPE_CHECKING:
     from teatree.config.agent_enums import EvalCredential
 
 logger = logging.getLogger(__name__)
+
+#: A cached-exhausted verdict is trusted until its recorded window reset, but a rolling
+#: 5h window frees capacity continuously — well before that reset. When every account
+#: reads exhausted, :meth:`PassPathSelector._rescue_reprobe` re-probes live before
+#: declaring a hard stall; this cooldown skips any account probed more recently than
+#: this, so a spinning all-exhausted dispatch loop cannot storm the rate-limit API.
+_RESCUE_REPROBE_COOLDOWN = dt.timedelta(seconds=60)
 
 
 class TokenKind(StrEnum):
@@ -119,8 +129,11 @@ class PassPathSelector:
         union — a bare eval shell (no active overlay → :data:`GLOBAL_SCOPE`) still routes
         to an overlay-scoped account without a manual env export. An empty union (nothing
         configured anywhere) returns ``None`` so the caller fails loud downstream.
-        Raises :class:`AllTokensExhaustedError` when a configured list has no usable
-        account anywhere.
+        When every account's CACHED verdict reads exhausted, a last-ditch live
+        :meth:`_rescue_reprobe` runs before the hard fail — a rolling 5h window frees
+        capacity before its recorded reset, so a recovered account is rescued here rather
+        than after its full reset. Raises :class:`AllTokensExhaustedError` only when the
+        rescue re-probe also finds no usable account anywhere.
         """
         configured = self._configured_paths(kind, scope)
         fell_back_across_scopes = False
@@ -139,6 +152,8 @@ class PassPathSelector:
         if chosen is None:
             others = [path for path in self._all_configured_paths(kind) if path not in configured]
             chosen = self._first_usable(kind, others, now)
+        if chosen is None:
+            chosen = self._rescue_reprobe(kind, configured, now)
         if chosen is None:
             raise AllTokensExhaustedError(self._all_exhausted_message(kind))
 
@@ -167,6 +182,31 @@ class PassPathSelector:
             if row is not None and row.is_fresh(now):
                 if not row.is_exhausted:
                     return pass_path
+                continue
+            probed = self._probe(kind, pass_path, now)
+            if probed is not None and not probed.is_exhausted:
+                return pass_path
+        return None
+
+    def _rescue_reprobe(self, kind: TokenKind, configured: list[str], now: dt.datetime) -> str | None:
+        """Last-ditch live re-probe before declaring every account exhausted (#3406).
+
+        The normal path trusts a FRESH cached-exhausted verdict without re-probing, and an
+        exhausted row is cached until its recorded window reset. But a subscription 5h
+        window is ROLLING — capacity returns continuously, well before that reset — so a
+        cached-exhausted verdict can outlive the real exhaustion and strand the loop on
+        "all accounts exhausted" while an account has in fact recovered. When every
+        candidate reads exhausted, this re-probes each account LIVE (ignoring cache
+        freshness) and returns the first that recovered, bounding the stall to
+        :data:`_RESCUE_REPROBE_COOLDOWN` past real recovery rather than the full reset. The
+        cooldown skips any account probed within that window, so a spinning all-exhausted
+        dispatch loop cannot storm the rate-limit API — one live re-probe per account per
+        cooldown is enough to catch a rolling-window recovery.
+        """
+        candidates = configured + [path for path in self._all_configured_paths(kind) if path not in configured]
+        for pass_path in candidates:
+            row = AnthropicTokenUsage.objects.filter(pass_path=pass_path).first()
+            if row is not None and (now - row.checked_at) < _RESCUE_REPROBE_COOLDOWN:
                 continue
             probed = self._probe(kind, pass_path, now)
             if probed is not None and not probed.is_exhausted:

--- a/src/teatree/llm/anthropic_limits.py
+++ b/src/teatree/llm/anthropic_limits.py
@@ -132,6 +132,34 @@ def window_horizon(cause: LimitCause) -> timedelta | None:
     return WINDOW_HORIZON[cause]
 
 
+#: The exhaustion causes whose window RESETS on a timer — the ones an idle auto-requeue
+#: (#3407) may reopen once the horizon elapses. :data:`LimitCause.API_CREDIT` is excluded:
+#: a $0 balance has no timed reset, so a credit-killed task is never auto-requeued.
+RECOVERABLE_EXHAUSTION_CAUSES: frozenset[LimitCause] = frozenset(
+    {LimitCause.SUBSCRIPTION_SESSION, LimitCause.SUBSCRIPTION_WEEKLY, LimitCause.RATE_LIMIT},
+)
+
+
+def recoverable_exhaustion_cause(error: str) -> LimitCause | None:
+    """The time-recoverable exhaustion cause a FAILED attempt's *error* names, or ``None``.
+
+    A limit-killed attempt records its reason as ``"<cause>: <phrase> — <remediation>"``
+    (:meth:`LimitMatch.as_reason`), so the token before the first ``:`` is the machine
+    cause marker. This maps that marker back to its :class:`LimitCause`, but ONLY for a
+    cause with a time-based window reset (session / weekly / transient rate limit) — the
+    signal the idle auto-requeue (#3407) keys on. Returns ``None`` for any non-limit error
+    AND for API-credit exhaustion (no timed recovery), so only a genuinely
+    window-recoverable failure is ever auto-requeued; the rest stay on their existing path.
+    """
+    if not error or ":" not in error:
+        return None
+    marker = error.split(":", 1)[0].strip().casefold()
+    for cause in RECOVERABLE_EXHAUSTION_CAUSES:
+        if marker == cause.value:
+            return cause
+    return None
+
+
 #: Operator-facing remediation per cause. The API-credit message names the
 #: console explicitly and never says "subscription"; the two subscription
 #: messages name their own reset cadence so session and weekly read distinctly.

--- a/src/teatree/loop/transient_requeue.py
+++ b/src/teatree/loop/transient_requeue.py
@@ -26,6 +26,18 @@ freeze silently; it is routed straight to the escalation path. The invariant: a
 terminal FAILED task on a non-terminal ticket ALWAYS escalates or retries-once,
 never freezes silently.
 
+An EXHAUSTION-killed FAILED task — one that died on a Claude usage-window limit (a
+subscription 5h/weekly window or a transient rate limit, recorded ``<cause>: …`` by
+``LimitMatch.as_reason``) — is NOT a defect and must not be escalated to a human as one.
+While ``limit_autorecovery_enabled`` is ON, such a task is auto-requeued once its window
+HORIZON has elapsed since the last failed attempt (the deterministic, probe-free twin of
+``usage_window_recovery`` for tasks that ALREADY landed FAILED — a limit hit while the
+flag was off, or on a non-parking lane); before the horizon it is left FAILED and
+re-checked on a later tick, never escalated (a capacity dip is not a doomed failure).
+API-credit exhaustion is excluded (no timed reset) and stays on the escalation path. With
+the flag OFF the branch is inert — an exhaustion failure follows the deterministic path
+exactly as before, so the flag-off behaviour is byte-identical.
+
 A SUPERSEDED FAILED task — one whose phase output the ticket's FSM already reached
 (``ticket.has_completed_phase``) — is NOT escalated at all: it is a dead artifact of
 an earlier interrupted run while the ticket advanced on its own, so it is retired
@@ -47,10 +59,14 @@ orchestration-layer module may compose both.
 """
 
 import logging
+from datetime import datetime
+
+from django.utils import timezone
 
 from teatree.agents.outage_classifier import is_transient_failure
+from teatree.agents.usage_window import autorecovery_enabled
 from teatree.core.modelkit.phases import normalize_phase
-from teatree.core.models import Task, Ticket
+from teatree.core.models import Task, TaskAttempt, Ticket
 from teatree.core.models.deferred_question import DeferredQuestion
 from teatree.core.models.task_repair import phase_attempts
 from teatree.core.repair_loop import (
@@ -59,6 +75,7 @@ from teatree.core.repair_loop import (
     requeue_verdict,
     terminal_reason_fingerprint,
 )
+from teatree.llm.anthropic_limits import LimitCause, recoverable_exhaustion_cause, window_horizon
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +119,8 @@ def requeue_transient_failed() -> int:
     already-parked rows excluded, so the per-tick cost stays bounded as dead letters
     accumulate.
     """
+    now = timezone.now()
+    autorecovery = autorecovery_enabled()
     reopened = 0
     for task in _non_terminal_failed_tasks():
         if task.ticket.has_completed_phase(task.phase):
@@ -120,9 +139,34 @@ def requeue_transient_failed() -> int:
                 reopened += _reopen(task)
             else:
                 _escalate_once(task, reason=halt)
+        elif (cause := recoverable_exhaustion_cause(error)) is not None and autorecovery:
+            reopened += _requeue_on_window_reset(task, cause, now=now)
         else:
             reopened += _handle_deterministic(task)
     return reopened
+
+
+def _requeue_on_window_reset(task: Task, cause: LimitCause, *, now: datetime) -> int:
+    """Reopen an exhaustion-killed task once its window has reset; else leave it FAILED (#3407).
+
+    A task that died on a subscription session/weekly or transient rate limit is
+    window-recoverable: capacity RETURNS at a known horizon after the failure. Once
+    ``window_horizon(cause)`` has elapsed since the last failed attempt, the task is
+    reopened within the #2009 budget (an over-budget one is escalated LOUDLY, never
+    retried forever). Before the horizon it is left FAILED and re-checked on a later tick
+    — NOT escalated, because a capacity dip is not a doomed defect. Returns the reopen
+    count (0 or 1).
+    """
+    horizon = window_horizon(cause)
+    last = _latest_attempt(task)
+    ended = last.ended_at if last is not None else None
+    if horizon is None or ended is None or ended + horizon > now:
+        return 0
+    halt = _budget_halt_reason(task)
+    if halt is not None:
+        _escalate_once(task, reason=halt)
+        return 0
+    return _reopen(task)
 
 
 def _handle_deterministic(task: Task) -> int:
@@ -167,10 +211,16 @@ def _corrective_reopen(task: Task) -> int:
     )
 
 
+def _latest_attempt(task: Task) -> TaskAttempt | None:
+    """The newest attempt from the prefetched ``attempts`` (no extra query), or ``None``."""
+    attempts = sorted(task.attempts.all(), key=lambda a: a.pk)  # ty: ignore[unresolved-attribute]  # Django reverse FK
+    return attempts[-1] if attempts else None
+
+
 def _latest_error(task: Task) -> str:
     """The newest attempt's error, read from the prefetched ``attempts`` (no extra query)."""
-    attempts = sorted(task.attempts.all(), key=lambda a: a.pk)  # ty: ignore[unresolved-attribute]  # Django reverse FK
-    return attempts[-1].error if attempts else ""
+    attempt = _latest_attempt(task)
+    return attempt.error if attempt is not None else ""
 
 
 def _non_terminal_failed_tasks() -> list[Task]:

--- a/tests/teatree_llm/test_anthropic_limits.py
+++ b/tests/teatree_llm/test_anthropic_limits.py
@@ -5,7 +5,13 @@ from typing import cast
 import pytest
 from claude_agent_sdk.types import RateLimitType
 
-from teatree.llm.anthropic_limits import LimitCause, LimitMatch, classify_limit, classify_rate_limit_type
+from teatree.llm.anthropic_limits import (
+    LimitCause,
+    LimitMatch,
+    classify_limit,
+    classify_rate_limit_type,
+    recoverable_exhaustion_cause,
+)
 
 
 class TestClassifyLimit:
@@ -133,3 +139,25 @@ class TestClassifyRateLimitType:
         assert classify_rate_limit_type(None) is None
         # A future/unknown window value falls through to the phrase fallback.
         assert classify_rate_limit_type(cast("RateLimitType", "made_up_window")) is None
+
+
+class TestRecoverableExhaustionCause:
+    """The recorded-``error`` marker a window-recoverable exhaustion failure carries (#3407)."""
+
+    @pytest.mark.parametrize(
+        "cause",
+        [LimitCause.SUBSCRIPTION_SESSION, LimitCause.SUBSCRIPTION_WEEKLY, LimitCause.RATE_LIMIT],
+    )
+    def test_recognises_the_reason_marker_a_recoverable_limit_records(self, cause: LimitCause) -> None:
+        # The real string a limit-killed attempt stores (``LimitMatch.as_reason``).
+        error = LimitMatch(phrase="5-hour limit", cause=cause).as_reason()
+        assert recoverable_exhaustion_cause(error) is cause
+
+    def test_api_credit_has_no_timed_recovery_and_is_never_auto_requeued(self) -> None:
+        error = LimitMatch(phrase="out of credits", cause=LimitCause.API_CREDIT).as_reason()
+        assert recoverable_exhaustion_cause(error) is None
+
+    def test_a_non_limit_error_is_not_a_recoverable_exhaustion(self) -> None:
+        assert recoverable_exhaustion_cause("AssertionError: expected 3 got 4") is None
+        assert recoverable_exhaustion_cause("outage_death: connection refused") is None
+        assert recoverable_exhaustion_cause("") is None

--- a/tests/teatree_loop/test_transient_requeue.py
+++ b/tests/teatree_loop/test_transient_requeue.py
@@ -10,12 +10,16 @@ failures, is NOT reopened and is escalated LOUDLY via a durable
 never reopened. The hardest pin: it NEVER retries endlessly.
 """
 
+from datetime import datetime, timedelta
+
 from django.test import TestCase
 from django.utils import timezone
 
 from teatree.core.models import Session, Task, TaskAttempt, Ticket
+from teatree.core.models.config_setting import ConfigSetting
 from teatree.core.models.deferred_question import DeferredQuestion
 from teatree.core.repair_loop import max_phase_iterations
+from teatree.llm.anthropic_limits import LimitCause, LimitMatch
 from teatree.loop.tick_recovery import _reap_stale_task_claims
 from teatree.loop.transient_requeue import requeue_transient_failed
 
@@ -26,15 +30,20 @@ def _failed_task(*, phase: str = "coding", state: str = Ticket.State.STARTED) ->
     return Task.objects.create(ticket=ticket, session=session, phase=phase, status=Task.Status.FAILED)
 
 
-def _add_failed_attempt(task: Task, *, error: str) -> None:
+def _add_failed_attempt(task: Task, *, error: str, ended_at: datetime | None = None) -> None:
     TaskAttempt.objects.create(
         task=task,
         execution_target=task.execution_target,
-        ended_at=timezone.now(),
+        ended_at=ended_at or timezone.now(),
         exit_code=1,
         error=error,
     )
     Task.objects.filter(pk=task.pk).update(status=Task.Status.FAILED)
+
+
+def _exhaustion_error(cause: LimitCause) -> str:
+    """The real ``error`` string a limit-killed attempt records (``LimitMatch.as_reason``)."""
+    return LimitMatch(phrase="5-hour limit", cause=cause).as_reason()
 
 
 class TestTransientRequeue(TestCase):
@@ -315,4 +324,70 @@ class TestTransientRequeue(TestCase):
             assert requeue_transient_failed() == 0
         task.refresh_from_db()
         assert task.status == Task.Status.FAILED
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
+
+
+class TestExhaustionAutoRequeue(TestCase):
+    """#3407: exhaustion-killed FAILED tasks auto-requeue once their window resets.
+
+    A task that died on a subscription session/weekly or transient rate limit is a
+    capacity failure, not a defect — while ``limit_autorecovery_enabled`` is ON it is
+    reopened once the window HORIZON has elapsed, never escalated to a human. API-credit
+    exhaustion (no timed reset) and the flag-off path keep the existing escalation.
+    """
+
+    def setUp(self) -> None:
+        ConfigSetting.objects.set_value("limit_autorecovery_enabled", value=True)
+
+    def test_session_limit_task_is_reopened_after_the_window_resets(self) -> None:
+        task = _failed_task()
+        # The 5h session window has elapsed since the failure → capacity is back.
+        _add_failed_attempt(
+            task, error=_exhaustion_error(LimitCause.SUBSCRIPTION_SESSION), ended_at=timezone.now() - timedelta(hours=6)
+        )
+
+        assert requeue_transient_failed() == 1
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING
+        # No human question — a capacity dip is auto-recovered, not escalated.
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 0
+
+    def test_session_limit_task_is_left_failed_before_the_window_resets(self) -> None:
+        task = _failed_task()
+        # Only 1h since the failure — the 5h window has not reset yet.
+        _add_failed_attempt(
+            task, error=_exhaustion_error(LimitCause.SUBSCRIPTION_SESSION), ended_at=timezone.now() - timedelta(hours=1)
+        )
+
+        assert requeue_transient_failed() == 0
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+        # Left FAILED for a later tick — NOT escalated (it is a timed wait, not a defect).
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 0
+
+    def test_api_credit_task_is_escalated_not_auto_requeued(self) -> None:
+        # A $0 balance has no timed reset → it must not be auto-requeued; it stays on the
+        # deterministic path and is escalated so the operator adds credits.
+        task = _failed_task()
+        _add_failed_attempt(
+            task, error=_exhaustion_error(LimitCause.API_CREDIT), ended_at=timezone.now() - timedelta(days=30)
+        )
+
+        assert requeue_transient_failed() == 0
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
+
+    def test_flag_off_keeps_the_pre_3407_escalation(self) -> None:
+        ConfigSetting.objects.set_value("limit_autorecovery_enabled", value=False)
+        task = _failed_task()
+        _add_failed_attempt(
+            task, error=_exhaustion_error(LimitCause.SUBSCRIPTION_SESSION), ended_at=timezone.now() - timedelta(hours=6)
+        )
+
+        assert requeue_transient_failed() == 0
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+        # Byte-identical to before #3407: an exhaustion failure follows the deterministic
+        # escalation path while the flag is off.
         assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1

--- a/tests/test_credential_config.py
+++ b/tests/test_credential_config.py
@@ -210,6 +210,43 @@ class TestSelectorRouting(TestCase):
         assert soon.isoformat() in message, "the loud error names the soonest an account frees up"
 
 
+class TestSelectorRescueReprobe(TestCase):
+    """#3406: a cached-exhausted verdict outlives a rolling window's real recovery.
+
+    An exhausted health row is trusted until its recorded reset, but a 5h window frees
+    capacity continuously — so when every account reads exhausted the selector re-probes
+    LIVE before declaring a hard stall, rescuing an account that has since recovered
+    rather than stranding the loop until the full recorded reset.
+    """
+
+    def test_rescue_reprobes_a_cached_exhausted_account_that_recovered(self) -> None:
+        ConfigSetting.objects.set_value(_OAUTH_SETTING, ["anthropic/a/oauth", "anthropic/b/oauth"])
+        stale = timezone.now() - dt.timedelta(minutes=5)
+        reset = timezone.now() + dt.timedelta(hours=4)
+        # Both cached EXHAUSTED (fresh until their far reset), so the cache-respecting
+        # path would hard-fail — but account b has since recovered.
+        for path in ("anthropic/a/oauth", "anthropic/b/oauth"):
+            AnthropicTokenUsage.objects.record(path, reading_from(_snapshot(u5=0.99, reset=reset)), now=stale)
+        reader = _FakeReader({"anthropic/a/oauth": _snapshot(u5=0.99, reset=reset), "anthropic/b/oauth": _snapshot()})
+        with _pass_echoes_path():
+            chosen = PassPathSelector(reader=reader).select(TokenKind.OAUTH)
+        assert chosen == "anthropic/b/oauth", "the rescue re-probe routes to the recovered account"
+        assert reader.calls == ["anthropic/a/oauth", "anthropic/b/oauth"], "only the rescue path re-probes"
+
+    def test_rescue_cooldown_skips_a_just_probed_account(self) -> None:
+        # A just-probed exhausted account is NOT re-probed within the cooldown, so a
+        # spinning all-exhausted dispatch loop cannot storm the rate-limit API.
+        ConfigSetting.objects.set_value(_OAUTH_SETTING, ["anthropic/a/oauth"])
+        reset = timezone.now() + dt.timedelta(hours=4)
+        AnthropicTokenUsage.objects.record(
+            "anthropic/a/oauth", reading_from(_snapshot(u5=0.99, reset=reset)), now=timezone.now()
+        )
+        reader = _FakeReader({"anthropic/a/oauth": _snapshot()})  # would read healthy IF re-probed
+        with _pass_echoes_path(), pytest.raises(AllTokensExhaustedError):
+            PassPathSelector(reader=reader).select(TokenKind.OAUTH)
+        assert reader.calls == [], "a just-probed account is not re-probed within the cooldown"
+
+
 class TestSelectorCrossScopeFallback(TestCase):
     """A requested scope with no routing falls back to the cross-scope union.
 


### PR DESCRIPTION
Closes #3406. Closes #3407. Live re-probe rescues a recovered cached-exhausted account before AllTokensExhausted (60s cooldown); auto-requeue exhaustion-killed FAILED tasks once the window horizon elapses (session/weekly/rate_limit; api_credit excluded). Directly addresses the silent-freeze root cause.