### PR TITLE
feat(test-db): template-clone app DB into test DB + container-ready migrate env (#3326 #3328)

### DIFF
--- a/src/teatree/quality/affected_tests.py
+++ b/src/teatree/quality/affected_tests.py
@@ -69,12 +69,22 @@ class Selection:
     changed_tests: tuple[str, ...] = ()
     warnings: tuple[str, ...] = ()
 
-    def pytest_args(self) -> list[str]:
-        create = ["--create-db"] if self.create_db else []
+    def pytest_args(self, *, test_db_cloned: bool = False) -> list[str]:
+        """Positional pytest args for this selection.
+
+        ``create_db`` normally emits ``--create-db`` (pytest-django replays every
+        migration from zero). When the caller has already refreshed the test DB via
+        the opt-in template clone (:func:`teatree.utils.django_db.prepare_test_db`,
+        souliane/teatree#3326), pass ``test_db_cloned=True`` so the same drift
+        instead emits ``--reuse-db``: the freshly cloned DB is current, and a
+        ``--create-db`` would wipe it and replay. Default (``False``) is
+        byte-identical to the pre-#3326 behaviour.
+        """
+        db = (["--reuse-db"] if test_db_cloned else ["--create-db"]) if self.create_db else []
         if self.full:
-            return create  # empty positionals ⇒ the runner executes the whole suite
+            return db  # empty positionals ⇒ the runner executes the whole suite
         doctest = ["--doctest-modules", *self.doctest_targets] if self.doctest_targets else []
-        return [*create, *self.test_files, *doctest, *self.floor_dirs]
+        return [*db, *self.test_files, *doctest, *self.floor_dirs]
 
     def report(self) -> str:
         if self.full:

--- a/src/teatree/utils/django_db/__init__.py
+++ b/src/teatree/utils/django_db/__init__.py
@@ -13,19 +13,34 @@ submodules while keeping ``teatree.utils.django_db`` a stable import path:
 - :mod:`~teatree.utils.django_db.dslr` — DSLR snapshot primitives.
 - :mod:`~teatree.utils.django_db.reconcile` — renumbered-migration reconcile.
 - :mod:`~teatree.utils.django_db.snapshot_warmer` — out-of-band snapshot refresh.
+- :mod:`~teatree.utils.django_db.testdb_clone` — clone the app DB into the test DB, re-cloning on drift (#3326).
 """
 
 from teatree.utils.django_db.config import DjangoDbImportConfig
 from teatree.utils.django_db.dslr import prune_dslr_snapshots
+from teatree.utils.django_db.helpers import is_loopback_host, rewrite_url_host, url_host
 from teatree.utils.django_db.importer import DjangoDbImporter, django_db_import
 from teatree.utils.django_db.restore import validate_dump
 from teatree.utils.django_db.runner import runner_prefix
+from teatree.utils.django_db.testdb_clone import (
+    TestDbCloneResult,
+    clone_app_db_to_test_db,
+    migrations_drifted,
+    prepare_test_db,
+)
 
 __all__ = [
     "DjangoDbImportConfig",
     "DjangoDbImporter",
+    "TestDbCloneResult",
+    "clone_app_db_to_test_db",
     "django_db_import",
+    "is_loopback_host",
+    "migrations_drifted",
+    "prepare_test_db",
     "prune_dslr_snapshots",
+    "rewrite_url_host",
     "runner_prefix",
+    "url_host",
     "validate_dump",
 ]

--- a/src/teatree/utils/django_db/config.py
+++ b/src/teatree/utils/django_db/config.py
@@ -14,6 +14,21 @@ from subprocess import CompletedProcess
 #: docker image (every dependency baked in) and returns the result. Core calls
 #: it only as a fallback when the host runner fails with an import/config error
 #: — the signature of an unverified, dep-incomplete host venv (#1977).
+#:
+#: **Forward-key contract (souliane/teatree#3328).** The ``env`` mapping core
+#: passes is already *container-oriented*: its ``DATABASE_URL`` host has been
+#: rewritten to :attr:`DjangoDbImportConfig.docker_db_host` when that is set, so
+#: the implementation must forward it verbatim — never rebuild the URL from a
+#: host-side ``POSTGRES_HOST``. The keys the container MUST receive for the
+#: migrate to target the intended database are:
+#:
+#: - ``DATABASE_URL`` — the (already host-rewritten) connection string.
+#: - ``DISABLE_DATABASE_SSL`` — core sets this for the local/ref migrate.
+#: - every key of ``migrate_env_extra`` — the overlay's settings selectors.
+#:
+#: Dropping any of these runs the migrate under different settings than core
+#: intended (a silently wrong migrate), so an implementation that filters ``env``
+#: down to a curated subset must include all of the above.
 DockerizedMigrate = Callable[[list[str], dict[str, str]], CompletedProcess[str]]
 
 
@@ -32,3 +47,10 @@ class DjangoDbImportConfig:
     dslr_snapshot: str = ""
     dump_path: str = ""
     dockerized_migrate: DockerizedMigrate | None = None
+    #: The host the container reaches its Postgres at (souliane/teatree#3328). When
+    #: set, core rewrites ``DATABASE_URL``'s host to this value before handing the
+    #: env to :attr:`dockerized_migrate`, so a URL built from the host-side
+    #: ``POSTGRES_HOST`` cannot silently migrate a different database inside the
+    #: container. Empty (the default) means no rewrite — byte-identical to the
+    #: pre-#3328 behaviour, for an overlay that already shims the host itself.
+    docker_db_host: str = ""

--- a/src/teatree/utils/django_db/helpers.py
+++ b/src/teatree/utils/django_db/helpers.py
@@ -8,6 +8,52 @@ import os
 
 from teatree.utils.run import run_allowed_to_fail
 
+#: Host literals that mean "this same host" and therefore never survive the move
+#: into a container's network namespace (souliane/teatree#3328). A ``DATABASE_URL``
+#: carrying one of these, handed to a dockerized migrate without a rewrite, is the
+#: known-bad combination that can silently migrate a *different* Postgres.
+_LOOPBACK_HOSTS: frozenset[str] = frozenset({"localhost", "::1"})
+
+
+def is_loopback_host(host: str) -> bool:
+    """Whether *host* is a loopback literal that is meaningless inside a container."""
+    return host in _LOOPBACK_HOSTS or host.startswith("127.")
+
+
+def rewrite_url_host(url: str, host: str) -> str:
+    """Return *url* with its network host replaced by *host*, preserving all else.
+
+    User, password, port, scheme, path, query and fragment are kept verbatim —
+    only the host component of the authority changes. This is the host→container
+    handoff every ``dockerized_migrate`` implementer needs (souliane/teatree#3328):
+    a URL built host-side names a host that does not resolve to the intended
+    database inside the container's network namespace.
+
+    >>> rewrite_url_host("postgres://u:p%40ss@localhost:5432/db", "postgres-svc")
+    'postgres://u:p%40ss@postgres-svc:5432/db'
+    >>> rewrite_url_host("postgres://localhost/db", "10.0.0.5")
+    'postgres://10.0.0.5/db'
+    """
+    from urllib.parse import urlsplit, urlunsplit  # noqa: PLC0415 — deferred: only this path needs it
+
+    parts = urlsplit(url)
+    userinfo = ""
+    if parts.username is not None:
+        userinfo = parts.username
+        if parts.password is not None:
+            userinfo += f":{parts.password}"
+        userinfo += "@"
+    port = f":{parts.port}" if parts.port is not None else ""
+    netloc = f"{userinfo}{host}{port}"
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+
+
+def url_host(url: str) -> str:
+    """The host component of *url*, or ``""`` when it carries none."""
+    from urllib.parse import urlsplit  # noqa: PLC0415 — deferred: only this path needs it
+
+    return urlsplit(url).hostname or ""
+
 
 def _pg_args() -> tuple[str, str, dict[str, str]]:
     # Deferred so importing the engine facade never eagerly pulls the psycopg-backed

--- a/src/teatree/utils/django_db/importer.py
+++ b/src/teatree/utils/django_db/importer.py
@@ -26,7 +26,15 @@ from teatree.utils import bad_artifacts
 from teatree.utils.django_db import dslr as _dslr
 from teatree.utils.django_db import reconcile as _reconcile
 from teatree.utils.django_db.config import DjangoDbImportConfig
-from teatree.utils.django_db.helpers import _ensure_ref_db, _local_db_url, _pg_args, _terminate_connections
+from teatree.utils.django_db.helpers import (
+    _ensure_ref_db,
+    _local_db_url,
+    _pg_args,
+    _terminate_connections,
+    is_loopback_host,
+    rewrite_url_host,
+    url_host,
+)
 from teatree.utils.django_db.migrate import _MAX_MIGRATE_RETRIES, _MigrateResult
 from teatree.utils.django_db.reconcile import is_config_error as _is_config_error
 from teatree.utils.django_db.restore import validate_dump
@@ -190,11 +198,36 @@ class DjangoDbImporter:
         prefix (#1973).
         """
         if self._migrate_via_docker and self.cfg.dockerized_migrate is not None:
-            return self.cfg.dockerized_migrate(manage_args, run_env)
+            return self.cfg.dockerized_migrate(manage_args, self._containerized_env(run_env))
         runner = runner_prefix(Path(self.cfg.main_repo_path))
         return run_allowed_to_fail(
             [*runner, *manage_args], cwd=self.cfg.main_repo_path, env=run_env, expected_codes=None
         )
+
+    def _containerized_env(self, run_env: dict[str, str]) -> dict[str, str]:
+        """Make *run_env*'s ``DATABASE_URL`` correct inside the container (souliane/teatree#3328).
+
+        The URL is built host-side, so its host is meaningless in the container's
+        network namespace. With ``docker_db_host`` set, rewrite the host to it.
+        With it empty, a loopback-literal host is the known-bad combination that
+        can silently migrate a *different* Postgres — warn loudly rather than
+        proceed into that case.
+        """
+        url = run_env.get("DATABASE_URL", "")
+        docker_host = self.cfg.docker_db_host
+        if docker_host:
+            if url:
+                return {**run_env, "DATABASE_URL": rewrite_url_host(url, docker_host)}
+            return run_env
+        if url and is_loopback_host(url_host(url)):
+            self.stderr.write(
+                f"  WARNING: dockerized migrate got a loopback DATABASE_URL host "
+                f"({url_host(url)!r}) and no docker_db_host is set — the container may "
+                "reach a DIFFERENT database at the same host:port. Set "
+                "DjangoDbImportConfig.docker_db_host to the host the container reaches "
+                "Postgres at (souliane/teatree#3328).\n"
+            )
+        return run_env
 
     def _try_fake_failing_migration(self, combined: str, stdout: str, run_env: dict[str, str]) -> str:
         """Try to fake a failing migration. Returns empty string on success, error message on failure."""

--- a/src/teatree/utils/django_db/testdb_clone.py
+++ b/src/teatree/utils/django_db/testdb_clone.py
@@ -1,0 +1,149 @@
+"""Template-clone the app DB into the test DB, re-cloning only on migration drift.
+
+souliane/teatree#3326. Core already template-clones a Postgres database in
+seconds for the *application* DB (``importer._copy_ref_to_ticket`` — drop, then
+``createdb -T``); nothing applied it to the *test* DB, so any overlay with a
+provisioned app DB and a non-trivial migration history paid a full ``--create-db``
+migration replay (minutes) on every test-DB rebuild.
+
+This module is the missing in-between: reuse the existing clone primitives to
+template-copy the app DB onto the test DB, and gate the copy on ``django_migrations``
+drift — equal → reuse the test DB (``--reuse-db``), different → re-clone (a cheap
+``createdb -T``, never a replay).
+
+**Fail toward re-cloning.** The drift check must never mistake an unreadable state
+for "in sync": a missing test DB, a connection error, or an unexpected
+``django_migrations`` shape all read as *drift*, so uncertainty re-clones rather
+than reusing a possibly-stale schema. Opt-in and off by default — no caller that
+does not invoke :func:`prepare_test_db` changes behaviour.
+"""
+
+import enum
+import sys
+from typing import ClassVar, TextIO
+
+from teatree.utils.db import pg_env, pg_host, pg_user
+from teatree.utils.django_db.helpers import _terminate_connections
+from teatree.utils.run import run_allowed_to_fail
+
+
+class TestDbCloneResult(enum.Enum):
+    """Outcome of :func:`prepare_test_db`, mapped to the pytest DB flag by the caller."""
+
+    # A dunder, so enum treats it as a plain attribute (not a member): it tells pytest's
+    # --doctest-modules collector not to mistake this ``Test``-prefixed class for a suite.
+    __test__: ClassVar[bool] = False
+
+    REUSED = "reused"  # django_migrations matched — the existing test DB is current
+    RECLONED = "recloned"  # drift (or uncertainty) — re-cloned from the app DB in seconds
+    FAILED = "failed"  # a re-clone was needed but could not run — fall back to a migration replay
+
+    @property
+    def is_current(self) -> bool:
+        """Whether the test DB is now schema-current — i.e. pytest should ``--reuse-db``.
+
+        ``FAILED`` is the only non-current outcome: the caller keeps ``--create-db``
+        so pytest-django replays migrations rather than trusting a stale DB.
+        """
+        return self is not TestDbCloneResult.FAILED
+
+
+def _migration_signature(
+    db_name: str, *, host: str, user: str, env: dict[str, str]
+) -> frozenset[tuple[str, str]] | None:
+    """The ``(app, name)`` set from *db_name*'s ``django_migrations``, or ``None`` if unreadable.
+
+    ``None`` is the uncertainty signal (missing DB, connection error, absent table,
+    unexpected row shape) — callers treat it as drift and re-clone, never as a match.
+    """
+    result = run_allowed_to_fail(
+        [
+            "psql",
+            "-h",
+            host,
+            "-U",
+            user,
+            "-d",
+            db_name,
+            "-tAqc",
+            "SELECT app, name FROM django_migrations",
+        ],
+        env=env,
+        expected_codes=None,
+    )
+    if result.returncode != 0:
+        return None
+    applied: set[tuple[str, str]] = set()
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        app, sep, name = stripped.partition("|")
+        if not sep:
+            return None
+        applied.add((app.strip(), name.strip()))
+    return frozenset(applied)
+
+
+def migrations_drifted(app_db: str, test_db: str, *, host: str, user: str, env: dict[str, str]) -> bool:
+    """Whether *test_db*'s applied migrations differ from *app_db*'s.
+
+    Returns ``True`` (drift → re-clone) whenever either database's
+    ``django_migrations`` cannot be read as a clean set — the fail-toward-re-clone
+    bias. Only two clean, equal signatures return ``False`` (reuse the test DB).
+    """
+    app_signature = _migration_signature(app_db, host=host, user=user, env=env)
+    test_signature = _migration_signature(test_db, host=host, user=user, env=env)
+    if app_signature is None or test_signature is None:
+        return True
+    return app_signature != test_signature
+
+
+def clone_app_db_to_test_db(*, app_db: str, test_db: str, host: str, user: str, env: dict[str, str]) -> bool:
+    """Template-copy *app_db* onto *test_db* in seconds. Returns whether the copy succeeded.
+
+    Mirrors ``importer._copy_ref_to_ticket``: ``dropdb --force`` (PG 13+) atomically
+    terminates connections to the old test DB before dropping — otherwise a
+    reconnecting worker races ``createdb`` into "database already exists" — then
+    ``createdb -T`` template-copies the app DB. Connections to the *template* are
+    terminated too: Postgres refuses ``-T`` while the source has active sessions.
+    """
+    drop = run_allowed_to_fail(
+        ["dropdb", "-h", host, "-U", user, "--if-exists", "--force", test_db],
+        env=env,
+        expected_codes=None,
+    )
+    if drop.returncode != 0:
+        return False
+    _terminate_connections(app_db, host, user, env)
+    created = run_allowed_to_fail(
+        ["createdb", "-h", host, "-U", user, test_db, "-T", app_db],
+        env=env,
+        expected_codes=None,
+    )
+    return created.returncode == 0
+
+
+def prepare_test_db(*, app_db: str, test_db: str, stdout: TextIO | None = None) -> TestDbCloneResult:
+    """Bring *test_db* up to date from *app_db* the fast way, returning the outcome.
+
+    The Postgres connection is resolved from the environment (``pg_host`` /
+    ``pg_user`` / ``pg_env``), mirroring the importer. No drift → reuse the test DB
+    untouched (:attr:`TestDbCloneResult.REUSED`). Drift or uncertainty →
+    template-copy the app DB onto it (:attr:`~TestDbCloneResult.RECLONED`), which is
+    a ``createdb -T``, not a migration replay. If that copy cannot run, report
+    :attr:`~TestDbCloneResult.FAILED` so the caller falls back to ``--create-db``.
+    """
+    out = stdout if stdout is not None else sys.stdout
+    host, user, env = pg_host(), pg_user(), pg_env()
+
+    if not migrations_drifted(app_db, test_db, host=host, user=user, env=env):
+        out.write(f"  Test DB {test_db} matches {app_db} (django_migrations in sync) — reusing.\n")
+        return TestDbCloneResult.REUSED
+
+    if clone_app_db_to_test_db(app_db=app_db, test_db=test_db, host=host, user=user, env=env):
+        out.write(f"  Re-cloned {test_db} from {app_db} (migration drift) via createdb -T — seconds, not a replay.\n")
+        return TestDbCloneResult.RECLONED
+
+    out.write(f"  WARNING: Could not clone {app_db} -> {test_db}; falling back to a migration replay.\n")
+    return TestDbCloneResult.FAILED

--- a/tests/teatree_quality/test_affected_tests.py
+++ b/tests/teatree_quality/test_affected_tests.py
@@ -231,6 +231,24 @@ class TestPytestArgs:
         # The doctest flag precedes its target module path.
         assert args.index("--doctest-modules") < args.index("src/teatree/foo/bar.py")
 
+    def test_cloned_test_db_swaps_create_db_for_reuse_db(self) -> None:
+        # souliane/teatree#3326: once the opt-in template clone has refreshed the
+        # test DB, a migration diff must NOT replay (--create-db would wipe the
+        # fresh clone) — it reuses the already-current DB instead.
+        sel = _select(_changed(("M", "src/teatree/core/migrations/0002_thing.py")))
+        assert sel.create_db
+        assert "--create-db" in sel.pytest_args()
+        cloned = sel.pytest_args(test_db_cloned=True)
+        assert "--reuse-db" in cloned
+        assert "--create-db" not in cloned
+
+    def test_cloned_flag_is_inert_without_create_db(self) -> None:
+        # No migration ⇒ create_db is False ⇒ the clone flag adds no DB arg either way.
+        sel = _select(_changed(("M", "src/teatree/foo/bar.py")))
+        assert not sel.create_db
+        assert "--reuse-db" not in sel.pytest_args(test_db_cloned=True)
+        assert "--create-db" not in sel.pytest_args(test_db_cloned=True)
+
 
 class TestBuildSelectionFailSafe:
     def test_tach_unavailable_forces_full(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/teatree_utils/django_db/test_dockerized_migrate_host.py
+++ b/tests/teatree_utils/django_db/test_dockerized_migrate_host.py
@@ -1,0 +1,118 @@
+"""Container-ready migrate env: URL host rewrite + the loopback warning (souliane/teatree#3328).
+
+The dockerized migrate seam builds ``DATABASE_URL`` host-side, where the host is
+meaningless inside the container's network namespace. These tests pin the rewrite
+helper and the importer's dispatch: the env handed to a fake ``dockerized_migrate``
+carries the REWRITTEN host, while the host-side runner keeps the original.
+"""
+
+import dataclasses
+import io
+from pathlib import Path
+from subprocess import CompletedProcess
+from typing import Any
+
+import pytest
+
+from teatree.utils import run as run_mod
+from teatree.utils.django_db import DjangoDbImportConfig, DjangoDbImporter
+from teatree.utils.django_db.helpers import is_loopback_host, rewrite_url_host, url_host
+
+_LOOPBACK_URL = "postgres://u:p@localhost:5432/db"
+
+
+def _make_importer(tmp_path: Path, **cfg_overrides: Any) -> DjangoDbImporter:
+    cfg = DjangoDbImportConfig(
+        ref_db_name="development-acme",
+        ticket_db_name="wt_42_acme",
+        main_repo_path=str(tmp_path),
+        dump_dir=str(tmp_path / ".data"),
+        dump_glob="*development-acme*.pgsql",
+        ci_dump_glob=".gitlab/dump_after_migration.*.sql.gz",
+        **cfg_overrides,
+    )
+    return DjangoDbImporter(cfg, stdout=io.StringIO(), stderr=io.StringIO())
+
+
+def _capture_env(importer: DjangoDbImporter, sink: dict[str, str]) -> DjangoDbImporter:
+    """Rebind the importer's dockerized_migrate to one that records the env it is handed."""
+    importer.cfg = dataclasses.replace(
+        importer.cfg, dockerized_migrate=lambda _a, env: sink.update(env) or CompletedProcess([], 0)
+    )
+    importer._migrate_via_docker = True
+    return importer
+
+
+class TestRewriteUrlHost:
+    def test_replaces_only_the_host(self) -> None:
+        assert rewrite_url_host(_LOOPBACK_URL, "postgres-svc") == "postgres://u:p@postgres-svc:5432/db"
+
+    def test_preserves_encoded_password_user_port_and_path(self) -> None:
+        out = rewrite_url_host("postgres://user:p%40ss@127.0.0.1:6543/db?sslmode=require", "10.0.0.5")
+        assert out == "postgres://user:p%40ss@10.0.0.5:6543/db?sslmode=require"
+
+    def test_rewrites_hostless_authority(self) -> None:
+        assert rewrite_url_host("postgres://localhost/db", "db-host") == "postgres://db-host/db"
+
+
+class TestUrlHost:
+    def test_extracts_host(self) -> None:
+        assert url_host("postgres://u:p@db.internal:5432/x") == "db.internal"
+
+    def test_empty_when_absent(self) -> None:
+        assert url_host("") == ""
+
+
+class TestIsLoopbackHost:
+    @pytest.mark.parametrize("host", ["localhost", "127.0.0.1", "127.1.2.3", "::1"])
+    def test_loopback_literals(self, host: str) -> None:
+        assert is_loopback_host(host)
+
+    @pytest.mark.parametrize("host", ["db", "postgres-svc", "10.0.0.5", "example.com"])
+    def test_routable_hosts(self, host: str) -> None:
+        assert not is_loopback_host(host)
+
+
+class TestContainerizedEnv:
+    """``_run_migrate`` dispatch: the container gets a container-oriented env."""
+
+    def test_rewrites_database_url_host_for_the_container(self, tmp_path: Path) -> None:
+        seen: dict[str, str] = {}
+        importer = _capture_env(_make_importer(tmp_path, docker_db_host="postgres-svc"), seen)
+        importer._run_migrate(["manage.py", "migrate"], {"DATABASE_URL": _LOOPBACK_URL})
+        assert seen["DATABASE_URL"] == "postgres://u:p@postgres-svc:5432/db"
+
+    def test_host_side_runner_keeps_original_host(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Anti-vacuity: only the container env is rewritten; the host-side runner
+        # (docker OFF) must still receive the ORIGINAL host — a test that merely
+        # checked "a URL is present" would pass against the buggy pre-#3328 code.
+        captured: dict[str, str] = {}
+        monkeypatch.setattr(
+            run_mod.subprocess,
+            "run",
+            lambda _args, **kw: captured.update(kw["env"]) or CompletedProcess([], 0, "", ""),
+        )
+        importer = _make_importer(tmp_path, docker_db_host="postgres-svc")
+        importer._migrate_via_docker = False
+        importer._run_migrate(["manage.py", "migrate"], {"DATABASE_URL": _LOOPBACK_URL})
+        assert captured["DATABASE_URL"] == _LOOPBACK_URL
+
+    def test_empty_docker_host_leaves_url_untouched(self, tmp_path: Path) -> None:
+        seen: dict[str, str] = {}
+        importer = _capture_env(_make_importer(tmp_path), seen)
+        importer._run_migrate(["manage.py", "migrate"], {"DATABASE_URL": "postgres://u:p@remote-db:5432/db"})
+        assert seen["DATABASE_URL"] == "postgres://u:p@remote-db:5432/db"
+
+    def test_warns_on_loopback_host_without_docker_db_host(self, tmp_path: Path) -> None:
+        importer = _capture_env(_make_importer(tmp_path), {})
+        importer.stderr = io.StringIO()
+        importer._run_migrate(["manage.py", "migrate"], {"DATABASE_URL": _LOOPBACK_URL})
+        warning = importer.stderr.getvalue()
+        assert "loopback" in warning
+        assert "docker_db_host" in warning
+
+    def test_no_warning_when_docker_db_host_set(self, tmp_path: Path) -> None:
+        importer = _capture_env(_make_importer(tmp_path, docker_db_host="postgres-svc"), {})
+        importer.stderr = io.StringIO()
+        importer._run_migrate(["manage.py", "migrate"], {"DATABASE_URL": _LOOPBACK_URL})
+        assert importer.stderr.getvalue() == ""

--- a/tests/teatree_utils/django_db/test_testdb_clone.py
+++ b/tests/teatree_utils/django_db/test_testdb_clone.py
@@ -1,0 +1,158 @@
+"""Template-clone the app DB into the test DB, re-cloning on migration drift (souliane/teatree#3326).
+
+The Postgres CLIs (``psql``/``createdb``/``dropdb``) are the unstoppable external
+here, so they are stubbed at the ``subprocess.run`` seam — the same seam the sibling
+django_db tests stub. Everything above it (drift verdict, clone command shape,
+fail-toward-re-clone bias, the orchestrator's outcome mapping) is exercised for real.
+"""
+
+import io
+from subprocess import CompletedProcess
+
+import pytest
+
+from teatree.utils import run as run_mod
+from teatree.utils.django_db import (
+    TestDbCloneResult as CloneResult,  # aliased: a bare ``Test*`` name is collected as a test class
+)
+from teatree.utils.django_db import clone_app_db_to_test_db, migrations_drifted, prepare_test_db
+
+_HOST, _USER, _ENV = "localhost", "u", {"PGPASSWORD": "pw"}
+
+
+class FakePg:
+    """Stub ``subprocess.run`` for the pg CLIs, keyed on the command and target DB."""
+
+    def __init__(
+        self,
+        migrations: dict[str, list[str] | None],
+        *,
+        dropdb_ok: bool = True,
+        createdb_ok: bool = True,
+    ) -> None:
+        # db name -> its django_migrations rows as "app|name" lines, or None = unreadable.
+        self.migrations = migrations
+        self.dropdb_ok = dropdb_ok
+        self.createdb_ok = createdb_ok
+        self.commands: list[list[str]] = []
+
+    def __call__(self, args: list[str], **_kwargs: object) -> CompletedProcess[str]:
+        self.commands.append(args)
+        tool = args[0]
+        if tool == "psql" and "-tAqc" in args:
+            db = args[args.index("-d") + 1]
+            rows = self.migrations.get(db)
+            if rows is None:
+                return CompletedProcess(args, 1, "", f'database "{db}" does not exist')
+            return CompletedProcess(args, 0, "".join(f"{row}\n" for row in rows), "")
+        if tool == "dropdb":
+            return CompletedProcess(args, 0 if self.dropdb_ok else 1, "", "")
+        if tool == "createdb":
+            return CompletedProcess(args, 0 if self.createdb_ok else 1, "", "")
+        return CompletedProcess(args, 0, "", "")  # psql terminate-connections
+
+    def tools(self) -> list[str]:
+        return [cmd[0] for cmd in self.commands]
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, fake: FakePg) -> FakePg:
+    monkeypatch.setattr(run_mod.subprocess, "run", fake)
+    return fake
+
+
+def _drifted() -> bool:
+    return migrations_drifted("app", "test", host=_HOST, user=_USER, env=_ENV)
+
+
+class TestMigrationsDrifted:
+    def test_identical_signatures_are_not_drift(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        rows = ["app|0001_initial", "app|0002_thing"]
+        _install(monkeypatch, FakePg({"app": rows, "test": list(reversed(rows))}))
+        assert _drifted() is False  # order-independent (compared as a set)
+
+    def test_different_applied_sets_are_drift(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install(monkeypatch, FakePg({"app": ["app|0001", "app|0002"], "test": ["app|0001"]}))
+        assert _drifted() is True
+
+    def test_unreadable_test_db_reads_as_drift(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Missing/erroring test DB must never be mistaken for "in sync".
+        _install(monkeypatch, FakePg({"app": ["app|0001"], "test": None}))
+        assert _drifted() is True
+
+    def test_unreadable_app_db_reads_as_drift(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install(monkeypatch, FakePg({"app": None, "test": ["app|0001"]}))
+        assert _drifted() is True
+
+    def test_malformed_row_reads_as_drift(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A row without the expected "app|name" shape is uncertainty, not a match.
+        _install(monkeypatch, FakePg({"app": ["app|0001"], "test": ["garbage-no-separator"]}))
+        assert _drifted() is True
+
+    def test_blank_lines_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install(monkeypatch, FakePg({"app": ["app|0001", ""], "test": ["app|0001"]}))
+        assert _drifted() is False
+
+
+class TestCloneAppDbToTestDb:
+    def _clone(self) -> bool:
+        return clone_app_db_to_test_db(app_db="app", test_db="test", host=_HOST, user=_USER, env=_ENV)
+
+    def test_success_issues_forced_drop_then_template_createdb(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _install(monkeypatch, FakePg({}))
+        assert self._clone() is True
+        assert fake.tools() == ["dropdb", "psql", "createdb"]  # drop → terminate template conns → createdb -T
+        drop = fake.commands[0]
+        assert "--force" in drop  # PG 13+ atomic connection-terminate before drop
+        assert "--if-exists" in drop
+        assert drop[-1] == "test"
+        createdb = fake.commands[-1]
+        assert createdb[-2:] == ["-T", "app"]
+
+    def test_failed_dropdb_aborts_before_createdb(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _install(monkeypatch, FakePg({}, dropdb_ok=False))
+        assert self._clone() is False
+        assert "createdb" not in fake.tools()
+
+    def test_failed_createdb_reports_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install(monkeypatch, FakePg({}, createdb_ok=False))
+        assert self._clone() is False
+
+
+class TestPrepareTestDb:
+    """``prepare_test_db`` resolves the pg connection from the environment (subprocess faked)."""
+
+    def _prepare(self, monkeypatch: pytest.MonkeyPatch) -> tuple[CloneResult, str]:
+        # A concrete env so pg_host/user/env resolve deterministically; the subprocess
+        # is faked, so these values only shape the (unasserted) command, not behaviour.
+        monkeypatch.setenv("POSTGRES_HOST", "db.local")
+        monkeypatch.setenv("POSTGRES_USER", "importer")
+        monkeypatch.setenv("POSTGRES_PASSWORD", "pw")
+        out = io.StringIO()
+        return prepare_test_db(app_db="app", test_db="test", stdout=out), out.getvalue()
+
+    def test_in_sync_reuses_without_cloning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _install(monkeypatch, FakePg({"app": ["app|0001"], "test": ["app|0001"]}))
+        result, _ = self._prepare(monkeypatch)
+        assert result is CloneResult.REUSED
+        assert "createdb" not in fake.tools()  # no clone when the DB is already current
+
+    def test_drift_reclones(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _install(monkeypatch, FakePg({"app": ["app|0001", "app|0002"], "test": ["app|0001"]}))
+        result, _ = self._prepare(monkeypatch)
+        assert result is CloneResult.RECLONED
+        assert "createdb" in fake.tools()
+
+    def test_clone_failure_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _install(monkeypatch, FakePg({"app": ["app|0001"], "test": None}, createdb_ok=False))
+        result, message = self._prepare(monkeypatch)
+        assert result is CloneResult.FAILED
+        assert "replay" in message
+
+
+class TestIsCurrent:
+    def test_reused_and_recloned_are_current(self) -> None:
+        assert CloneResult.REUSED.is_current
+        assert CloneResult.RECLONED.is_current
+
+    def test_failed_is_not_current(self) -> None:
+        assert not CloneResult.FAILED.is_current


### PR DESCRIPTION
Closes #3326. Closes #3328. clone_app_db_to_test_db + migrations_drifted (fail-toward-reclone) wired via --reuse-db; rewrite_url_host + docker_db_host forward-key contract for dockerized migrate.