### PR TITLE
fix(hooks): leak-gate base from remote-tracking ref not stale PRE_COMMIT_FROM_REF (#3414)

### DIFF
--- a/scripts/hooks/refuse-public-push-with-leak.sh
+++ b/scripts/hooks/refuse-public-push-with-leak.sh
@@ -115,18 +115,44 @@ default_branch=${default_branch:-main}
 # under BOTH invocation paths (souliane/teatree: prek does not forward pre-push
 # stdin to `language: system` hooks).
 refs_input=$(cat)
+synthesized=0
 if [ -z "${refs_input//[[:space:]]/}" ] && [ -n "${PRE_COMMIT_TO_REF:-}" ]; then
+  synthesized=1
   refs_input=$(printf '%s %s %s %s\n' \
     "${PRE_COMMIT_LOCAL_BRANCH:-HEAD}" "${PRE_COMMIT_TO_REF}" \
     "${PRE_COMMIT_REMOTE_BRANCH:-HEAD}" "${PRE_COMMIT_FROM_REF:-$ZERO}")
 fi
+
+# Is ${sha} the TRUE base to diff against for this ref update? On git's
+# native pre-push protocol the reported remote_sha IS the real remote-side
+# tip, so it is always authoritative. On the prek synthesized-from-env path
+# the value is `PRE_COMMIT_FROM_REF`, which git reports as a STALE ancestor
+# (a weeks-old `main` commit) for the first push of a long-lived branch that
+# merged `main` since it was created (#3414) — NOT all-zeros and NOT the
+# current tip. Trusting it re-includes dozens of already-public, immutable
+# commits and false-positives the identity guard and the content scan.
+# Trust the synthesized remote_sha ONLY when it is confirmed to be the
+# current tip of the branch's remote-tracking ref (i.e. the branch already
+# exists on the remote and this is an update push); otherwise fall back to
+# the merge-base with the remote default branch, the true new-content range.
+_remote_sha_is_trusted_base() {
+  local remote_ref="$1" sha="$2"
+  [ "${synthesized}" = "1" ] || return 0  # native stdin — git's sha is authoritative
+  local branch="${remote_ref#refs/heads/}"
+  [ -n "${branch}" ] && [ "${branch}" != "HEAD" ] || return 1
+  local tracked
+  tracked=$(git rev-parse --verify --quiet \
+    "refs/remotes/${remote_name}/${branch}" 2>/dev/null || true)
+  [ -n "${tracked}" ] && [ "${tracked}" = "${sha}" ]
+}
 
 blocked=0
 while read -r local_ref local_sha remote_ref remote_sha; do
   [ -n "${local_sha:-}" ] || continue
   [ "${local_sha}" != "${ZERO}" ] || continue  # branch deletion — skip
 
-  if [ "${remote_sha}" != "${ZERO}" ] && [ -n "${remote_sha}" ]; then
+  if [ "${remote_sha}" != "${ZERO}" ] && [ -n "${remote_sha}" ] \
+    && _remote_sha_is_trusted_base "${remote_ref}" "${remote_sha}"; then
     base="${remote_sha}"
   else
     base=$(git merge-base "${local_sha}" \

--- a/tests/test_refuse_public_push_with_leak.py
+++ b/tests/test_refuse_public_push_with_leak.py
@@ -585,5 +585,275 @@ class TestRefusePublicPushWithNonNoreplyAuthor:
         assert result.returncode == 0, result.stdout + result.stderr
 
 
+def _rev(repo: Path, ref: str) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", ref],  # noqa: S607
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+        env=_hermetic_env(),
+    ).stdout.strip()
+
+
+def _commit_file(
+    repo: Path,
+    filename: str,
+    content: str,
+    msg: str,
+    *,
+    committer_email: str | None = None,
+) -> str:
+    """Commit ``content`` to ``repo``; optionally forge the committer email.
+
+    A forged committer email (e.g. GitHub's web-UI squash identity
+    ``noreply@github.com``) models an already-public commit whose metadata
+    the #730 identity guard flags — the exact shape that false-positives
+    when a stale range re-includes it (#3414). Only the email matters to the
+    gate (it scans ``%ae``/``%ce``), so the committer name is left fixed.
+    """
+    (repo / filename).write_text(content, encoding="utf-8")
+    _git(repo, "add", filename)
+    if committer_email is not None:
+        env = _hermetic_env()
+        env["GIT_AUTHOR_NAME"] = _NOREPLY_NAME
+        env["GIT_AUTHOR_EMAIL"] = _NOREPLY_EMAIL
+        env["GIT_COMMITTER_NAME"] = "Forged Identity"
+        env["GIT_COMMITTER_EMAIL"] = committer_email
+        subprocess.run(
+            ["git", "commit", "-m", msg],  # noqa: S607
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            env=env,
+        )
+    else:
+        _git(repo, "commit", "-m", msg)
+    return _rev(repo, "HEAD")
+
+
+def _public_work_clone(tmp_path: Path, origin: Path) -> tuple[Path, dict[str, str]]:
+    """Clone an already-populated ``origin`` into a PUBLIC-remote work tree.
+
+    Unlike ``_clone_with_remote`` (which builds its own single-commit
+    origin), this takes a caller-populated origin so the test controls the
+    already-public history the stale-range false positive depends on.
+    """
+    work = tmp_path / "work"
+    _git(tmp_path, "clone", str(origin), str(work))
+    _git(work, "config", "user.email", _NOREPLY_EMAIL)
+    _git(work, "config", "user.name", _NOREPLY_NAME)
+    _git(work, "remote", "set-url", "origin", "https://github.com/acme/widget.git")
+    bin_dir = tmp_path / "bin"
+    _make_gh_shim(bin_dir, "PUBLIC")
+    env = _hermetic_env()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["T3_PRIVACY_SCAN_CMD"] = f"{sys.executable} {SCAN}"
+    return work, env
+
+
+_REMOTE_URL = "https://github.com/acme/widget.git"
+
+
+def _run_hook_synth(
+    work: Path,
+    env: dict[str, str],
+    *,
+    to_ref: str,
+    from_ref: str,
+    remote_branch: str = "refs/heads/feature",
+) -> subprocess.CompletedProcess[str]:
+    """Drive the hook through the prek synthesized-from-env path (empty stdin).
+
+    prek consumes pre-push stdin and hands the range to the hook via
+    ``PRE_COMMIT_*`` env vars, so the hook reads EMPTY stdin and synthesizes
+    the ref-update line. ``from_ref`` is what prek passes as ``remote_sha`` —
+    which git reports as a STALE ancestor for the first push of a branch that
+    merged main (#3414). ``remote_branch`` doubles as the local branch (the
+    push maps the branch onto its own name on the remote).
+    """
+    synth = dict(env)
+    synth["PRE_COMMIT_REMOTE_NAME"] = "origin"
+    synth["PRE_COMMIT_TO_REF"] = to_ref
+    synth["PRE_COMMIT_FROM_REF"] = from_ref
+    synth["PRE_COMMIT_LOCAL_BRANCH"] = remote_branch
+    synth["PRE_COMMIT_REMOTE_BRANCH"] = remote_branch
+    return subprocess.run(
+        ["bash", str(HOOK), "origin", _REMOTE_URL],  # noqa: S607 — bash on PATH is the hook's real invocation
+        cwd=work,
+        input="",
+        capture_output=True,
+        text=True,
+        check=False,
+        env=synth,
+    )
+
+
+class TestLeakGateRecomputesBaseFromRemoteTrackingRef:
+    """#3414 — the synthesized-from-env range must not trust a stale ``PRE_COMMIT_FROM_REF``.
+
+    prek reports ``PRE_COMMIT_FROM_REF`` as the push's ``remote_sha``. For
+    the first push of a long-lived branch that merged ``main`` since it was
+    created, git reports that value as a weeks-old ``main`` ancestor — NOT
+    all-zeros and NOT the current ``origin/main`` tip. Trusting it as the
+    scan base re-includes dozens of already-public, already-merged commits,
+    so the identity guard and the content scan false-positive on immutable
+    public history. The fix recomputes the base from the real
+    remote-tracking ref (merge-base with the remote default branch) unless
+    the reported sha is confirmed to be the branch's actual remote tip.
+    """
+
+    def _origin_with_public_identity_commit(self, tmp_path: Path) -> tuple[Path, str, str]:
+        """origin/main = C0 (clean) → C1 (GitHub web-UI squash committer).
+
+        Returns (origin, c0, c1). C1's committer email ``noreply@github.com``
+        is NOT the ``<id>+<login>@users.noreply.github.com`` shape the #730
+        guard accepts, so any range that re-includes C1 trips the identity
+        block — the classic already-public false positive.
+        """
+        origin = tmp_path / "origin"
+        _make_repo(origin)
+        c0 = _rev(origin, "HEAD")
+        c1 = _commit_file(
+            origin,
+            "merged_from_main.txt",
+            "a line merged via the GitHub web UI\n",
+            "prior PR squash-merged on main",
+            committer_email="noreply@github.com",
+        )
+        return origin, c0, c1
+
+    def test_stale_from_ref_no_longer_false_positives_on_public_identity(self, tmp_path: Path) -> None:
+        """RED before fix: a stale range re-includes an already-public non-noreply commit.
+
+        The branch's OWN new commit is clean (noreply identity, clean
+        content), but ``PRE_COMMIT_FROM_REF`` points at C0 — before the
+        already-public ``noreply@github.com`` squash commit C1. The current
+        hook trusts C0 as the base, so ``C0..HEAD`` re-includes C1 and the
+        identity guard blocks a legitimate first push. The fix must scan only
+        the true new-content range (``origin/main..HEAD``), which excludes C1.
+        """
+        origin, c0, _c1 = self._origin_with_public_identity_commit(tmp_path)
+        work, env = _public_work_clone(tmp_path, origin)
+        _git(work, "checkout", "-b", "feature")
+        head = _commit_file(work, "feature.txt", "a clean new feature line\n", "add feature")
+
+        result = _run_hook_synth(work, env, to_ref=head, from_ref=c0)
+
+        assert result.returncode == 0, (
+            "stale FROM_REF must not re-flag already-public identity: " + result.stdout + result.stderr
+        )
+
+    def test_stale_from_ref_no_longer_false_positives_on_public_content(self, tmp_path: Path) -> None:
+        """RED before fix: a stale range re-includes already-public flagged CONTENT.
+
+        C1 (already public on main) legitimately contains an internal-looking
+        path. The branch's own new commit is clean. A stale ``C0`` base scans
+        ``C0..HEAD``, re-flagging C1's content; the true ``origin/main..HEAD``
+        range is clean.
+        """
+        origin = tmp_path / "origin"
+        _make_repo(origin)
+        c0 = _rev(origin, "HEAD")
+        _commit_file(
+            origin,
+            "prior.txt",
+            "see /Users/someone/secret/path\n",
+            "prior PR merged on main",
+        )
+        work, env = _public_work_clone(tmp_path, origin)
+        _git(work, "checkout", "-b", "feature")
+        head = _commit_file(work, "feature.txt", "a clean new feature line\n", "add feature")
+
+        result = _run_hook_synth(work, env, to_ref=head, from_ref=c0)
+
+        assert result.returncode == 0, (
+            "stale FROM_REF must not re-flag already-public content: " + result.stdout + result.stderr
+        )
+
+    def test_real_leak_in_new_commit_still_blocks_under_stale_from_ref(self, tmp_path: Path) -> None:
+        """Anti-vacuity: narrowing the base must NOT let a real new leak through.
+
+        Same stale ``C0`` base, but the branch's own new commit plants a real
+        secret. The true ``origin/main..HEAD`` range still contains it, so the
+        gate must block both before AND after the fix — the fix narrows the
+        scan, it does not weaken it.
+        """
+        origin, c0, _c1 = self._origin_with_public_identity_commit(tmp_path)
+        work, env = _public_work_clone(tmp_path, origin)
+        _git(work, "checkout", "-b", "feature")
+        head = _commit_file(work, "leak.txt", "token = glpat-XXXXXXXXXXXXXXXX\n", "add config")
+
+        result = _run_hook_synth(work, env, to_ref=head, from_ref=c0)
+
+        assert result.returncode == 1, "a real new-commit leak must still block: " + result.stdout + result.stderr
+        assert "privacy" in (result.stdout + result.stderr).lower()
+
+    def test_real_identity_leak_in_new_commit_still_blocks_under_stale_from_ref(self, tmp_path: Path) -> None:
+        """Anti-vacuity for the identity guard: a real non-noreply NEW commit still blocks.
+
+        The stale base excludes the already-public C1, but the branch's own
+        new commit carries a real customer-domain committer email. That is a
+        genuine PII leak in new history and must block after the fix.
+        """
+        origin, c0, _c1 = self._origin_with_public_identity_commit(tmp_path)
+        work, env = _public_work_clone(tmp_path, origin)
+        _git(work, "checkout", "-b", "feature")
+        head = _commit_file(
+            work,
+            "feature.txt",
+            "a clean new feature line\n",
+            "add feature",
+            committer_email="real.dev@internal.example",
+        )
+
+        result = _run_hook_synth(work, env, to_ref=head, from_ref=c0)
+
+        assert result.returncode == 1, (
+            "a real new-commit identity leak must still block: " + result.stdout + result.stderr
+        )
+        assert "noreply" in (result.stdout + result.stderr)
+
+    def test_trusts_real_remote_branch_tip_and_still_blocks_update_leak(self, tmp_path: Path) -> None:
+        """When the branch already exists on the remote, the real tip IS the base — and leaks still block.
+
+        Here ``PRE_COMMIT_FROM_REF`` is the genuine current tip of
+        ``refs/remotes/origin/feature`` (a branch-update push, not a first
+        push), so the fix trusts it as the base. A leak in the update range
+        must still block — proving the trust path is preserved, not widened
+        away.
+        """
+        origin = tmp_path / "origin"
+        _make_repo(origin)
+        _git(origin, "checkout", "-b", "feature")
+        tip = _commit_file(origin, "feature.txt", "existing feature line\n", "seed feature branch")
+        _git(origin, "checkout", "main")
+        work, env = _public_work_clone(tmp_path, origin)
+        _git(work, "checkout", "feature")
+        head = _commit_file(work, "leak.txt", "token = glpat-XXXXXXXXXXXXXXXX\n", "update feature")
+
+        result = _run_hook_synth(work, env, to_ref=head, from_ref=tip)
+
+        assert result.returncode == 1, (
+            "a leak in a branch-update range must still block: " + result.stdout + result.stderr
+        )
+        assert "privacy" in (result.stdout + result.stderr).lower()
+
+    def test_clean_update_from_real_remote_tip_passes(self, tmp_path: Path) -> None:
+        """Anti-vacuity companion: a clean branch-update from the real tip passes."""
+        origin = tmp_path / "origin"
+        _make_repo(origin)
+        _git(origin, "checkout", "-b", "feature")
+        tip = _commit_file(origin, "feature.txt", "existing feature line\n", "seed feature branch")
+        _git(origin, "checkout", "main")
+        work, env = _public_work_clone(tmp_path, origin)
+        _git(work, "checkout", "feature")
+        head = _commit_file(work, "more.txt", "another clean feature line\n", "extend feature")
+
+        result = _run_hook_synth(work, env, to_ref=head, from_ref=tip)
+
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Closes #3414. RED->GREEN + anti-vacuity: real leaks still block.