### PR TITLE
feat(bootstrap): token-scope preflight + seed autoMode + host-derived concurrency + unified config (#3405 #3408 #3409 #3410)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -179,7 +179,7 @@ Do this once as an admin on the box.
 | `HETZNER_SSH_KEY` | the deploy **private** SSH key |
 | `HETZNER_SSH_KNOWN_HOSTS` | the box's host key line(s) for strict checking |
 | `CLAUDE_CODE_OAUTH_TOKEN` | Claude Code OAuth token — the headless auth |
-| `TEATREE_GH_TOKEN` | GitHub token for the loop (clone/read/PRs) |
+| `TEATREE_GH_TOKEN` | GitHub token for the loop. Needs **write** on `issues`, `pull_requests`, and `contents` (plus `metadata: read`) — `init` preflights these and fails loud if any is missing (#3405) |
 | `T3_ADMIN_USER` | Django admin superuser name |
 | `T3_ADMIN_PASSWORD` | Django admin superuser password |
 | `GIT_AUTHOR_NAME` | git identity for the loop's commits |

--- a/deploy/claude-settings.template.json
+++ b/deploy/claude-settings.template.json
@@ -20,8 +20,15 @@
   "autoMode": {
     "allow": [
       "Defer to teatree's own commit, push, and merge gates rather than re-judging them — they are the authoritative control plane on this deploy.",
+      "Allow editing ~/.claude/settings.json and files under ~/.claude/hooks/ — teatree manages its own hooks and settings registration there.",
       "Allow editing, writing, and deleting files inside t3 worktrees as part of the normal lifecycle (implementation, cleanup).",
-      "Allow local-dev lifecycle and verification commands (pkill, docker, docker compose, npm, npx, curl, sed) needed to run and verify a change."
+      "Allow local-dev lifecycle and verification commands (pkill, docker, docker compose, pipenv, playwright, npm, npx, curl, sed) when run as part of a t3 lifecycle or verification step.",
+      "Allow `gh pr merge` ONLY when the PR's required CI checks are all green (mergeStateStatus CLEAN); otherwise it stays gated.",
+      "Allow `t3 <overlay> lifecycle visit-phase <id> <phase> --agent-id ...` for recording phase attestation.",
+      "Allow the sanctioned merge path — `t3 <overlay> ticket clear ...` (orchestrator, independent reviewer identity) followed by `t3 <overlay> ticket merge <clear_id>` (agent executes) — for all blast classes including substrate/self-improvement, with safety enforced in the MergeClear preconditions (independent reviewer != loop, SHA-bound, live-green required checks, substrate needs a recorded human approver). Raw `gh pr merge` / `glab mr merge` is NOT authorized by this rule.",
+      "Allow `docker exec` into teatree deployment containers and installing the teatree editable package with extras via uv (e.g. `uv tool install --editable '<clone>[slack]'`) as part of Slack/deploy setup and runtime provisioning in Docker.",
+      "Allow reading an overlay's own Slack workspace data via its bot token (including `users.list` / `users.lookupByEmail`) STRICTLY to resolve or verify the owner's own Slack user id for DM-only provisioning — never bulk member-PII export.",
+      "Allow teatree provisioning to write overlay config state in the DB overlays registry (messaging backend, token references, user id, DM channel) via `t3 setup` or `t3 <overlay> config_setting set` during Slack or deploy setup."
     ]
   },
   "env": {

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -70,6 +70,60 @@ anthropic_credential_decrypts() {
     pass show "${entry%.gpg}" >/dev/null 2>&1
 }
 
+# Parse ``owner/repo`` from the https/ssh clone URL (empty when unparsable).
+gh_repo_slug() {
+    local url="${TEATREE_REPO_URL:-$REPO_URL}"
+    url="${url#https://github.com/}"
+    url="${url#ssh://git@github.com/}"
+    url="${url#git@github.com:}"
+    url="${url%.git}"
+    local owner="${url%%/*}" rest="${url#*/}" repo
+    repo="${rest%%/*}"
+    if [ -n "$owner" ] && [ -n "$repo" ] && [ "$owner" != "$url" ]; then
+        printf '%s/%s' "$owner" "$repo"
+    fi
+}
+
+# True (0) when a side-effect-free write probe is DENIED — i.e. the token lacks
+# the permission. GitHub returns "Resource not accessible by personal access
+# token" at the route level for a missing write permission, before it validates
+# the (non-existent) target, so nothing is ever created or changed.
+_gh_perm_denied() {
+    local out
+    out="$(gh api --method "$1" "$2" 2>&1 || true)"
+    grep -qi "not accessible" <<<"$out"
+}
+
+# Probe that TEATREE_GH_TOKEN carries the WRITE permissions the loop actually
+# needs (#3405). ``gh auth status`` only proves the token authenticates — a token
+# with ``issues: read`` but not ``issues: write`` passes it, then every
+# ``gh issue edit/close/comment`` fails LATE, mid-run, with "Resource not
+# accessible by personal access token" — a silent block on autonomy. Each write
+# permission is probed with a mutation aimed at a resource id that cannot exist
+# (issue/PR 0, a bogus ref): a permitted token gets a harmless 404, a denied
+# token gets the route-level 403. FAIL the deploy loudly naming each missing
+# permission. Mirrors ``teatree.core.gates.gh_token_preflight`` (pinned by a test).
+assert_gh_token_permissions() {
+    local slug missing=()
+    slug="$(gh_repo_slug)"
+    if [ -z "$slug" ]; then
+        echo "entrypoint: could not resolve the GitHub repo slug from '${TEATREE_REPO_URL:-$REPO_URL}' - skipping token-permission preflight" >&2
+        return 0
+    fi
+    if ! gh api "repos/$slug" >/dev/null 2>&1; then
+        echo "entrypoint: TEATREE_GH_TOKEN cannot read repos/$slug (metadata: read) - the token has no access to the repo. Grant it and re-run Deploy" >&2
+        exit 1
+    fi
+    _gh_perm_denied PATCH "repos/$slug/issues/0" && missing+=("issues: write")
+    _gh_perm_denied PATCH "repos/$slug/pulls/0" && missing+=("pull_requests: write")
+    _gh_perm_denied PATCH "repos/$slug/git/refs/heads/teatree-preflight-nonexistent" && missing+=("contents: write")
+    if [ ${#missing[@]} -gt 0 ]; then
+        echo "entrypoint: TEATREE_GH_TOKEN is missing GitHub permission(s): ${missing[*]} - the loop's 'gh issue'/'gh pr'/push writes will fail mid-run with 'Resource not accessible by personal access token'. Grant them on the token and re-run Deploy" >&2
+        exit 1
+    fi
+    echo "teatree-init: GitHub token permissions verified (issues/pull_requests/contents write present on $slug)"
+}
+
 # Fail loud, early, and actionably when a required runtime token is missing or
 # does not authenticate — otherwise a green deploy hides a dead loop.
 init_preflight() {
@@ -90,6 +144,10 @@ init_preflight() {
         echo "entrypoint: TEATREE_GH_TOKEN does not authenticate with GitHub - rotate the token and re-run Deploy" >&2
         exit 1
     fi
+    # #3405: authentication is not authorization - verify the token can WRITE the
+    # resources the loop mutates (issues/pull_requests/contents), failing loud now
+    # rather than mid-run with 'Resource not accessible by personal access token'.
+    assert_gh_token_permissions
 }
 
 # Provision ~/.claude/settings.json so the containerized (headless) agent is
@@ -317,7 +375,11 @@ init)
     seed_setting agent_harness '"claude_sdk"'
     seed_setting agent_runtime '"headless"'
     seed_setting loop_runner_enabled true
-    seed_setting provision_max_concurrency 1
+    # #3409: seed provision concurrency as 0 = AUTO so the runtime derives it from
+    # THIS host (nCPU/2, cgroup-aware) instead of pinning a per-box value that a
+    # migration onto a bigger box would carry forward as a stale serialization.
+    # `t3 doctor` additionally auto-clears a stale small-box pin left in the DB.
+    seed_setting provision_max_concurrency 0
     seed_setting provision_ram_ceiling_percent 75
     seed_setting max_concurrent_local_stacks 1
     # The admin binds the box loopback (host networking), so auto-login fires for

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -3420,8 +3420,14 @@ Usage: t3 setup [OPTIONS] COMMAND [ARGS]...
  First-time setup and global skill management.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --skip-plugin          Skip Claude CLI plugin registration.                  │
-│ --help                 Show this message and exit.                           │
+│ --skip-plugin             Skip Claude CLI plugin registration.               │
+│ --write-automode          Deep-merge the committed Claude-settings template  │
+│                           (recommended autoMode grants + managed keys) into  │
+│                           ~/.claude/settings.json. Requires --yes (or        │
+│                           TEATREE_WRITE_AUTOMODE=1).                         │
+│ --yes                     Consent to teatree editing ~/.claude/settings.json │
+│                           (see --write-automode).                            │
+│ --help                    Show this message and exit.                        │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Commands ───────────────────────────────────────────────────────────────────╮
 │ slack-bot               Register or update a per-overlay Slack bot and store │

--- a/src/teatree/cli/doctor/app.py
+++ b/src/teatree/cli/doctor/app.py
@@ -14,6 +14,12 @@ from importlib.metadata import PackageNotFoundError
 import typer
 
 from teatree.cli.doctor.checks_availability import _check_availability_override_staleness
+from teatree.cli.doctor.checks_bootstrap import (
+    _check_claude_settings_drift,
+    _check_gh_token_permissions,
+    _check_provision_concurrency_from_host,
+    run_bootstrap_checks,
+)
 from teatree.cli.doctor.checks_docker import _check_docker_workflow_wired
 from teatree.cli.doctor.checks_environment import (
     _check_configured_review_skills,
@@ -83,6 +89,7 @@ __all__ = (
     "_check_agent_session_pins",
     "_check_availability_override_staleness",
     "_check_chrome_devtools_mcp_suggestion",
+    "_check_claude_settings_drift",
     "_check_configured_review_skills",
     "_check_connector_manifest",
     "_check_dangling_editable_pth",
@@ -91,10 +98,12 @@ __all__ = (
     "_check_dream_transcript_visibility",
     "_check_editable_sanity",
     "_check_entrypoint_is_primary_clone",
+    "_check_gh_token_permissions",
     "_check_legacy_overlay_alias",
     "_check_loop_presets",
     "_check_marker_jam",
     "_check_mcp_connectivity",
+    "_check_provision_concurrency_from_host",
     "_check_single_db",
     "_check_singletons",
     "_check_skills",
@@ -144,6 +153,22 @@ def check(
     # must be turned into the process exit code here — a `t3 doctor check && …`
     # in CI/hooks and the watchdog's non-JSON path both key on it (#3313).
     raise typer.Exit(code=0 if ok else 1)
+
+
+def _optional_tooling_advisories() -> None:
+    """Surfacing-only advisories for optional tooling (never gate the exit code).
+
+    #3263 WARNs when this box serves the admin dashboard but its loopback
+    "Debug session" terminal's ttyd is missing. #3271 INFO-suggests the OPTIONAL
+    chrome-devtools MCP e2e/debug aid when absent (teatree's runtime requires zero
+    MCP). #3232 WARNs when the operator opted into the containerized ``t3`` workflow
+    but a piece the wrapper depends on (compose stack, the executable ``deploy/t3``
+    entry, the docker CLI, a non-drifted alias path) is missing — silent inside a
+    container and on a host that never opted in.
+    """
+    _check_ttyd_for_dashboard()
+    _check_chrome_devtools_mcp_suggestion()
+    _check_docker_workflow_wired()
 
 
 def run_doctor_checks(*, repair: bool = False) -> bool:
@@ -215,20 +240,9 @@ def run_doctor_checks(*, repair: bool = False) -> bool:
     # the default-ON loops are silently dead until `t3 worker ensure` spawns one.
     ok = _check_worker_running() and ok
 
-    # #3263: the admin dashboard's loopback "Debug session" terminal needs ttyd;
-    # WARN when this box serves the dashboard but ttyd is missing. Surfacing-only.
-    _check_ttyd_for_dashboard()
-
-    # #3271: INFO-suggest the OPTIONAL chrome-devtools MCP e2e/debug aid when it is
-    # absent. Never a WARN/FAIL and never gates — teatree's runtime requires zero MCP.
-    _check_chrome_devtools_mcp_suggestion()
-
-    # #3232: WARN when the operator has opted into the containerized `t3` workflow
-    # (a `t3 setup`-installed shell alias) but a piece the wrapper depends on is
-    # missing/stale — the compose stack, the executable `deploy/t3` entry, the
-    # docker CLI, or a non-drifted alias path. Silent inside a container and on a
-    # host that never opted in. Surfacing-only — never gates the exit code.
-    _check_docker_workflow_wired()
+    # Optional-tooling advisories (ttyd / chrome-devtools MCP / containerized-t3
+    # wiring) — all surfacing-only, never gating the exit code.
+    _optional_tooling_advisories()
 
     # H24 self-heal (owner directive #10): the hard-FAIL silent-freeze detectors —
     # dead compose containers, a free worker flock over overdue loop work, a
@@ -253,6 +267,13 @@ def run_doctor_checks(*, repair: bool = False) -> bool:
     # force it with `t3 loop reclaim-markers`. Reads the ORM, so it runs
     # post-ensure_django.
     _check_marker_jam()
+
+    # Fresh-box bootstrap-hardening gates (umbrella #3404): the GitHub token lacks a
+    # write permission the loop needs (#3405, hard FAIL); a stale small-box
+    # provision_max_concurrency pin carried onto a bigger host (#3409, auto-clear);
+    # host ~/.claude/settings.json drifted from the committed template (#3410, WARN).
+    # Post-ensure_django — the concurrency autofix reads the ORM.
+    ok = run_bootstrap_checks() and ok
 
     # Pre-investigation stale-clone hard-fail gate (#948). Surfaces at
     # session start so a bug-investigation sub-agent cannot start root-

--- a/src/teatree/cli/doctor/checks_bootstrap.py
+++ b/src/teatree/cli/doctor/checks_bootstrap.py
@@ -1,0 +1,195 @@
+"""Fresh-box bootstrap-hardening doctor checks (umbrella #3404).
+
+Three gates that turn silent late failures on a freshly-provisioned or migrated
+box into loud, up-front ones:
+
+- :func:`_check_gh_token_permissions` (#3405) — the GitHub token authenticates but
+    is missing a write permission the loop needs (``issues``/``pull_requests``/
+    ``contents``). Mirrors ``deploy/entrypoint.sh``'s ``init_preflight`` probe.
+- :func:`_check_provision_concurrency_from_host` (#3409) — a stale small-box
+    ``provision_max_concurrency`` pin throttling a more capable host; auto-clears
+    it so the runtime auto-derives from the host.
+- :func:`_check_claude_settings_drift` (#3410) — the host ``~/.claude/settings.json``
+    managed keys disagree with the one committed template the containers seed from.
+
+Each is crash-proof (any inspection error degrades to a pass/WARN) so a bootstrap
+diagnostic never aborts the whole doctor run.
+"""
+
+import os
+from pathlib import Path
+
+import typer
+
+from teatree.utils.run import CommandFailedError, run_allowed_to_fail
+
+
+def _teatree_repo_root() -> Path | None:
+    """The installed teatree clone root (``…/src/teatree`` → repo).
+
+    ``teatree.__file__`` is ``<repo>/src/teatree/__init__.py``; the repo root is
+    its third parent — the same derivation ``_check_entrypoint_is_primary_clone``
+    uses. Typed ``| None`` so callers can treat a future non-editable/packaged
+    layout (no repo root) uniformly with the template-absent skip.
+    """
+    import teatree  # noqa: PLC0415 — deferred: keeps CLI startup light
+
+    return Path(teatree.__file__).resolve().parents[2]
+
+
+def _slug_from_repo_url(url: str) -> str | None:
+    """Parse ``owner/repo`` out of an https or ssh GitHub remote URL, else ``None``."""
+    text = url.strip()
+    for prefix in ("https://github.com/", "git@github.com:", "ssh://git@github.com/"):
+        if text.startswith(prefix):
+            text = text[len(prefix) :]
+            break
+    else:
+        return None
+    owner, sep, rest = text.removesuffix(".git").partition("/")
+    repo = rest.partition("/")[0]
+    return f"{owner}/{repo}" if sep and owner and repo else None
+
+
+def _resolve_repo_slug() -> str | None:
+    """Resolve the ``owner/repo`` the deploy token operates on.
+
+    Prefers ``TEATREE_REPO_URL`` (the deploy env), falling back to the teatree
+    clone's ``origin`` remote. ``None`` when neither yields a GitHub slug — the
+    caller then skips the token probe rather than guessing.
+    """
+    env_url = os.environ.get("TEATREE_REPO_URL", "").strip()
+    if env_url:
+        env_slug = _slug_from_repo_url(env_url)
+        if env_slug is not None:
+            return env_slug
+    repo = _teatree_repo_root()
+    if repo is None:
+        return None
+    try:
+        remote = run_allowed_to_fail(["git", "-C", str(repo), "remote", "get-url", "origin"], expected_codes=None)
+    except (OSError, CommandFailedError):
+        return None
+    return _slug_from_repo_url(remote.stdout) if remote.returncode == 0 else None
+
+
+def _check_gh_token_permissions() -> bool:
+    """FAIL when the GitHub token authenticates but lacks a write permission the loop needs (#3405).
+
+    Mirrors ``deploy/entrypoint.sh``'s ``init_preflight`` in Python so the same
+    late-failure — ``Resource not accessible by personal access token`` mid-run —
+    is caught by ``t3 doctor`` too. Skips (passes) when the probe cannot reach a
+    confident verdict: ``gh`` absent, no resolvable repo slug, or the API
+    unreachable — a network fault must never redden the run or page the owner.
+    A genuinely missing write permission is a hard FAIL naming each scope.
+    """
+    from teatree.core.gates.gh_token_preflight import probe_token_permissions  # noqa: PLC0415 — deferred import
+
+    slug = _resolve_repo_slug()
+    if slug is None:
+        return True
+    try:
+        probe = probe_token_permissions(slug)
+    except Exception as exc:  # noqa: BLE001 — a probe failure warns and passes, never blocks doctor
+        typer.echo(f"WARN  Could not probe the GitHub token permissions: {exc}")
+        return True
+    if probe.indeterminate_reason is not None:
+        return True
+    if not probe.missing:
+        return True
+    typer.echo(
+        f"FAIL  The GitHub token cannot exercise {', '.join(probe.missing)} on {slug} — "
+        "the loop's `gh issue`/`gh pr`/push writes will fail mid-run with "
+        "'Resource not accessible by personal access token'. Grant the missing "
+        "permission(s) on TEATREE_GH_TOKEN and re-deploy, then re-run `t3 doctor check`."
+    )
+    return False
+
+
+def _check_provision_concurrency_from_host(*, apply: bool = True) -> bool:
+    """Auto-clear a stale small-box ``provision_max_concurrency`` pin on a bigger host (#3409).
+
+    A box migrated onto more cores must not silently keep the old box's
+    hard-serialized ``provision_max_concurrency`` pin. When the DB carries an
+    explicit pin STRICTLY BELOW the host-derived auto value (``nCPU/2``,
+    cgroup-aware), this clears the row so the runtime auto-derives from the host,
+    and WARNs (a green, surfacing-only outcome — the pin is fixed). A pin at or
+    above the host auto, or no pin at all, passes silently. Reads the ORM, so it
+    runs post-``ensure_django``. Crash-proof.
+    """
+    from teatree.core.models.config_setting import ConfigSetting  # noqa: PLC0415 — deferred (ORM)
+    from teatree.utils.ram_probe import default_provision_concurrency  # noqa: PLC0415 — deferred import
+
+    try:
+        pinned = ConfigSetting.objects.get_effective("provision_max_concurrency")
+        if not isinstance(pinned, int) or isinstance(pinned, bool) or pinned <= 0:
+            return True
+        host_auto = default_provision_concurrency()
+        if pinned >= host_auto:
+            return True
+        if apply:
+            ConfigSetting.objects.clear("provision_max_concurrency")
+        typer.echo(
+            f"WARN  Cleared a stale provision_max_concurrency={pinned} pin below this host's "
+            f"auto-derived {host_auto} (nCPU/2) — it hard-serialized provisioning carried over "
+            f"from a smaller box. Concurrency now auto-derives from the host; re-pin explicitly "
+            f"with `t3 teatree config_setting set provision_max_concurrency <N>` if intended."
+        )
+    except Exception as exc:  # noqa: BLE001 — a doctor check must never crash the run
+        typer.echo(f"WARN  provision-concurrency check crashed: {exc.__class__.__name__}: {exc}")
+    return True
+
+
+def _check_claude_settings_drift() -> bool:
+    """WARN when the host ~/.claude/settings.json managed keys drift from the committed template (#3410).
+
+    ``deploy/claude-settings.template.json`` is the single source of truth the
+    containers seed from; the host should agree on the managed keys (model,
+    permission mode + allow-list, ``autoMode.allow`` grants, tool-use concurrency)
+    so host and container never diverge. Surfacing-only (never gates the exit
+    code): teatree edits the user's settings only on explicit
+    ``t3 setup --write-automode --yes``. Skips when the template is absent (a
+    non-editable/packaged install). Crash-proof.
+    """
+    from teatree.cli.setup.claude_settings import managed_key_drift  # noqa: PLC0415 — deferred (cycle)
+
+    try:
+        repo = _teatree_repo_root()
+        if repo is None:
+            return True
+        template = repo / "deploy" / "claude-settings.template.json"
+        if not template.is_file():
+            return True
+        target = Path.home() / ".claude" / "settings.json"
+        drift = managed_key_drift(template, target)
+        if drift:
+            typer.echo(
+                f"WARN  Host ~/.claude/settings.json disagrees with {template.name} on: "
+                f"{', '.join(drift)}. Host and containers should share the one managed config. "
+                f"Reconcile with `t3 setup --write-automode --yes`."
+            )
+    except Exception as exc:  # noqa: BLE001 — a doctor check must never crash the run
+        typer.echo(f"WARN  Claude-settings drift check crashed: {exc.__class__.__name__}: {exc}")
+    return True
+
+
+def run_bootstrap_checks(*, apply: bool = True) -> bool:
+    """Run every bootstrap-hardening check; return ``False`` iff a hard gate fails.
+
+    Only the token-permission gate (#3405) affects the verdict — the concurrency
+    autofix (#3409) and the settings-drift check (#3410) are surfacing-only and
+    always pass. Runs post-``ensure_django`` (the concurrency autofix reads the
+    ORM). ``apply`` is threaded to the concurrency autofix for tests.
+    """
+    ok = _check_gh_token_permissions()
+    _check_provision_concurrency_from_host(apply=apply)
+    _check_claude_settings_drift()
+    return ok
+
+
+__all__ = [
+    "_check_claude_settings_drift",
+    "_check_gh_token_permissions",
+    "_check_provision_concurrency_from_host",
+    "run_bootstrap_checks",
+]

--- a/src/teatree/cli/setup/claude_settings.py
+++ b/src/teatree/cli/setup/claude_settings.py
@@ -1,0 +1,124 @@
+"""Host-side Claude settings merge from the one committed template (#3410, #3408).
+
+``deploy/claude-settings.template.json`` is the single source of truth for the
+managed Claude Code config — model, ``permissions.defaultMode`` /
+``permissions.allow``, ``autoMode.allow``, and the tool-use-concurrency env. The
+worker containers seed it into ``~/.claude/settings.json`` in
+``deploy/entrypoint.sh`` (``seed_claude_settings``, a ``jq '.[0] * .[1]'`` deep
+merge). This module gives the HOST the identical merge so the interactive box
+and the containers can never drift: :func:`write_host_claude_settings` deep-merges
+the same template into the host's ``~/.claude/settings.json``, preserving
+user-specific keys (``statusLine``, any extra host rules) while asserting the
+managed keys.
+
+:func:`deep_merge` mirrors ``jq``'s ``*`` operator exactly — objects merge
+recursively, every non-object value (scalars AND arrays) is replaced by the
+override — so the host and container settings resolve byte-for-byte the same
+managed config. :func:`managed_key_drift` powers the ``t3 doctor`` gate that
+verifies the host agrees with the template.
+"""
+
+import json
+from pathlib import Path
+from typing import cast
+
+# The managed leaf keys the template owns, addressed as dotted paths into the
+# settings object. Everything else in ``~/.claude/settings.json`` (statusLine,
+# user rules) is the operator's and is never asserted. Drift on any of these is
+# what the doctor gate reports.
+MANAGED_KEY_PATHS: tuple[tuple[str, ...], ...] = (
+    ("model",),
+    ("permissions", "defaultMode"),
+    ("permissions", "allow"),
+    ("autoMode", "allow"),
+    ("env", "CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY"),
+)
+
+
+def deep_merge(base: dict[str, object], override: dict[str, object]) -> dict[str, object]:
+    """Return ``base`` deep-merged with ``override`` (override wins), mirroring ``jq '.[0] * .[1]'``.
+
+    Object values are merged recursively; every non-object value — scalars and
+    arrays alike — is replaced wholesale by ``override``'s. Neither input is
+    mutated. This is the exact semantics ``seed_claude_settings`` uses
+    container-side, so a host merge and a container seed of the same template
+    produce the same managed config.
+    """
+    merged: dict[str, object] = dict(base)
+    for key, override_value in override.items():
+        base_value = merged.get(key)
+        if isinstance(base_value, dict) and isinstance(override_value, dict):
+            merged[key] = deep_merge(cast("dict[str, object]", base_value), cast("dict[str, object]", override_value))
+        else:
+            merged[key] = override_value
+    return merged
+
+
+def _load_json_object(path: Path) -> dict[str, object]:
+    """Load ``path`` as a JSON object, or ``{}`` when absent/empty/not an object."""
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def write_host_claude_settings(template_path: Path, target_path: Path) -> dict[str, object]:
+    """Deep-merge ``template_path`` into ``target_path`` (creating it if absent); return the result.
+
+    The existing target is the LEFT operand and the template is the RIGHT, so the
+    template's managed keys win while the operator's unmanaged keys survive —
+    identical to the container seed. The parent directory is created if needed.
+    Raises ``FileNotFoundError`` when the template is missing (a packaging bug the
+    caller should surface, not swallow).
+    """
+    template = _load_json_object(template_path)
+    if not template:
+        msg = f"claude-settings template missing or empty: {template_path}"
+        raise FileNotFoundError(msg)
+    merged = deep_merge(_load_json_object(target_path), template)
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.write_text(json.dumps(merged, indent=2) + "\n", encoding="utf-8")
+    return merged
+
+
+def _dig(data: dict[str, object], path: tuple[str, ...]) -> object | None:
+    """Return the value at dotted ``path`` in ``data``, or ``None`` when any hop is absent."""
+    cursor: object = data
+    for key in path:
+        if not isinstance(cursor, dict):
+            return None
+        cursor_dict = cast("dict[str, object]", cursor)
+        if key not in cursor_dict:
+            return None
+        cursor = cursor_dict[key]
+    return cursor
+
+
+def managed_key_drift(template_path: Path, target_path: Path) -> list[str]:
+    """Return the dotted managed keys where ``target`` disagrees with the ``template``.
+
+    A key is drifted when the target's value differs from the template's (a key
+    the template does not carry is not managed and never drifts). An absent
+    target file drifts every managed key. Read-only — never writes either file.
+    """
+    template = _load_json_object(template_path)
+    target = _load_json_object(target_path)
+    drifted: list[str] = []
+    for path in MANAGED_KEY_PATHS:
+        template_value = _dig(template, path)
+        if template_value is None:
+            continue
+        if _dig(target, path) != template_value:
+            drifted.append(".".join(path))
+    return drifted
+
+
+__all__ = [
+    "MANAGED_KEY_PATHS",
+    "deep_merge",
+    "managed_key_drift",
+    "write_host_claude_settings",
+]

--- a/src/teatree/cli/setup/command.py
+++ b/src/teatree/cli/setup/command.py
@@ -8,6 +8,7 @@ The ``run`` callback wires together the composed units
 clone-resolution helpers. Each concern lives in its own sibling module.
 """
 
+import os
 from pathlib import Path
 
 import typer
@@ -36,6 +37,45 @@ setup_app = typer.Typer(
 )
 
 
+def _write_automode_consented(*, yes: bool) -> bool:
+    """True when the operator explicitly consented to writing managed settings.
+
+    Consent is an explicit ``--yes`` or a truthy ``TEATREE_WRITE_AUTOMODE`` env
+    (the non-interactive/provisioning consent channel). Teatree edits the user's
+    ``~/.claude/settings.json`` only under this explicit grant — the classifier
+    whitelist stays the operator's final say (BLUEPRINT §11.4).
+    """
+    return yes or os.environ.get("TEATREE_WRITE_AUTOMODE", "").strip().lower() in {"1", "true", "yes"}
+
+
+def _maybe_write_managed_settings(repo: Path, settings_json: Path, *, write_automode: bool, yes: bool) -> None:
+    """Deep-merge the committed Claude-settings template into ``settings_json`` on consent (#3408/#3410).
+
+    ``deploy/claude-settings.template.json`` is the single source of truth for the
+    managed keys (model, permission mode + allow-list, ``autoMode.allow`` recommended
+    grants, tool-use concurrency). With ``--write-automode`` and explicit consent this
+    applies the SAME deep merge the container seed uses, so host and container never
+    drift. Without consent it only points the operator at the flag — it never writes.
+    """
+    if not write_automode:
+        return
+    if not _write_automode_consented(yes=yes):
+        typer.echo(
+            "WARN  --write-automode needs explicit consent — re-run with `--yes` "
+            "(or set TEATREE_WRITE_AUTOMODE=1) to deep-merge the managed Claude settings.",
+        )
+        return
+    from teatree.cli.setup.claude_settings import write_host_claude_settings  # noqa: PLC0415 — lazy CLI import
+
+    template = repo / "deploy" / "claude-settings.template.json"
+    try:
+        write_host_claude_settings(template, settings_json)
+    except FileNotFoundError:
+        typer.echo(f"WARN  No Claude-settings template at {template} — skipped --write-automode.")
+        return
+    typer.echo(f"OK    Merged managed Claude settings from {template.name} into {settings_json}.")
+
+
 def _report_statusline_install(settings_json: Path, repo: Path) -> None:
     """Install the Claude Code statusLine block and echo the outcome (PR-17)."""
     result = install_statusline(settings_json, repo)
@@ -54,6 +94,15 @@ def run(
     ctx: typer.Context,
     *,
     skip_plugin: bool = typer.Option(False, "--skip-plugin", help="Skip Claude CLI plugin registration."),
+    write_automode: bool = typer.Option(
+        False,
+        "--write-automode",
+        help="Deep-merge the committed Claude-settings template (recommended autoMode grants + managed keys) "
+        "into ~/.claude/settings.json. Requires --yes (or TEATREE_WRITE_AUTOMODE=1).",
+    ),
+    yes: bool = typer.Option(
+        False, "--yes", help="Consent to teatree editing ~/.claude/settings.json (see --write-automode)."
+    ),
 ) -> None:
     """Install and configure teatree skills globally.
 
@@ -154,6 +203,11 @@ def run(
     from teatree.cli.recommended_authorizations import report_missing_authorizations  # noqa: PLC0415 — lazy CLI import
 
     report_missing_authorizations(typer.echo)
+
+    # #3408/#3410: on explicit consent, WRITE the managed settings (recommended
+    # autoMode grants + model/permissions/env) from the one committed template so
+    # a fresh box is classifier-unblocked and host+container stay in lockstep.
+    _maybe_write_managed_settings(repo, settings_json, write_automode=write_automode, yes=yes)
 
     if self_db_unmigrated:
         raise typer.Exit(code=1)

--- a/src/teatree/core/gates/gh_token_preflight.py
+++ b/src/teatree/core/gates/gh_token_preflight.py
@@ -1,0 +1,138 @@
+"""GitHub token permission preflight (#3405).
+
+The deploy loop drives GitHub through ``gh`` with ``TEATREE_GH_TOKEN``. A token
+that authenticates (``gh auth status`` green) but lacks a *write* permission the
+loop needs — ``issues: write`` for labelling/closing, ``pull_requests: write``
+for opening/merging, ``contents: write`` for pushing — does not fail at deploy
+time. It fails much later, mid-run, with ``Resource not accessible by personal
+access token`` on the first ``gh issue edit`` / ``gh pr merge`` — a silent,
+hard-to-diagnose block on autonomy.
+
+This probes the token's *effective* permissions up front so the failure is a
+one-line bootstrap error instead of a late runtime surprise. The probe is
+side-effect-free: each write permission is checked with a mutation aimed at a
+resource number that never exists (issue/PR ``0``, a bogus ref), so a token that
+*has* the permission gets a harmless ``404`` while a token that *lacks* it gets
+the route-level ``403 Resource not accessible`` GitHub returns before it ever
+loads the resource. Nothing is created, edited, or deleted either way.
+
+``deploy/entrypoint.sh`` runs the same contract in pure bash during ``init``
+(before the editable install exists, so it cannot call ``t3``); the
+``teatree.cli.doctor`` mirror check and this module share the canonical
+:data:`REQUIRED_PERMISSION_LABELS`, and a test pins the entrypoint's labels to
+it so the two implementations cannot drift.
+"""
+
+import shutil
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from teatree.utils.run import run_allowed_to_fail
+
+# The permissions the deploy loop actually exercises, in report order. The
+# labels are the human ``"<permission>: <level>"`` form GitHub's fine-grained
+# token UI uses, so an operator can map a FAIL straight onto a token setting.
+# Pinned to ``deploy/entrypoint.sh`` by ``tests/test_deploy_entrypoint_token_preflight``.
+REQUIRED_PERMISSION_LABELS: tuple[str, ...] = (
+    "metadata: read",
+    "issues: write",
+    "pull_requests: write",
+    "contents: write",
+)
+
+# Substrings (lowercased) in a ``gh api`` failure that mean the *token* is
+# denied — a permission/visibility signal, not a transient network fault. Used
+# to tell "the token lacks this" apart from "the API was unreachable".
+_DENIED_SIGNALS: tuple[str, ...] = (
+    "not accessible",  # "Resource not accessible by personal access token / integration"
+    "not found",  # a fine-grained token with no access sees the repo as 404
+    "bad credentials",
+    "requires authentication",
+    "must be authenticated",
+)
+
+# The single write-permission signal: GitHub returns exactly this at the route
+# level for a token missing the permission, before validating the target.
+_FORBIDDEN_SIGNAL = "not accessible"
+
+# (permission label, gh-api argv template) for the three write probes. Each
+# mutates a resource id that cannot exist, so a permitted token gets a 404 and a
+# denied token gets a 403 — never a real write.
+_WRITE_PROBES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("issues: write", ("--method", "PATCH", "repos/{slug}/issues/0", "-f", "state=open")),
+    ("pull_requests: write", ("--method", "PATCH", "repos/{slug}/pulls/0", "-f", "state=open")),
+    ("contents: write", ("--method", "PATCH", "repos/{slug}/git/refs/heads/teatree-preflight-nonexistent")),
+)
+
+type GhRunner = Callable[[list[str]], tuple[int, str]]
+
+
+@dataclass(frozen=True)
+class GhTokenProbe:
+    """Outcome of a token-permission probe.
+
+    ``missing`` is the denied permission labels (empty == the token has every
+    required permission). ``indeterminate_reason`` is set only when the probe
+    could not run to a verdict (``gh`` absent, or the API unreachable) — the
+    caller then skips rather than failing on a network fault.
+    """
+
+    missing: tuple[str, ...]
+    indeterminate_reason: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return not self.missing and self.indeterminate_reason is None
+
+
+def _default_run(args: list[str]) -> tuple[int, str]:
+    """Run ``gh <args>`` capturing combined stdout+stderr; ``(returncode, text)``.
+
+    Routes through :func:`teatree.utils.run.run_allowed_to_fail` (the subprocess
+    chokepoint) with ``expected_codes=None`` — a ``gh api`` 4xx is an expected
+    probe outcome, not an error to raise on.
+    """
+    result = run_allowed_to_fail(["gh", *args], expected_codes=None)
+    return result.returncode, f"{result.stdout}\n{result.stderr}"
+
+
+def _has_signal(text: str, signals: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return any(signal in lowered for signal in signals)
+
+
+def probe_token_permissions(slug: str, run: GhRunner | None = None) -> GhTokenProbe:
+    """Probe whether ``gh``'s token holds every :data:`REQUIRED_PERMISSION_LABELS` on *slug*.
+
+    ``slug`` is ``owner/repo``. Returns a :class:`GhTokenProbe`. Metadata is
+    probed first with a read (``GET repos/{slug}``): if the token cannot even
+    read the repo the write probes cannot be interpreted (a no-access token 404s
+    on everything), so the metadata failure short-circuits. A non-permission
+    failure of the metadata read (network) yields an *indeterminate* result so a
+    caller never fails the deploy/doctor on an unreachable API.
+    """
+    run = run or _default_run
+    if shutil.which("gh") is None:
+        return GhTokenProbe(missing=(), indeterminate_reason="gh CLI not found on PATH")
+
+    meta_code, meta_out = run([f"repos/{slug}"])
+    if meta_code != 0:
+        if _has_signal(meta_out, _DENIED_SIGNALS):
+            return GhTokenProbe(missing=("metadata: read",))
+        return GhTokenProbe(missing=(), indeterminate_reason=f"could not read repos/{slug} (API unreachable?)")
+
+    missing: list[str] = []
+    for label, template in _WRITE_PROBES:
+        args = [part.format(slug=slug) for part in template]
+        _code, out = run(args)
+        if _FORBIDDEN_SIGNAL in out.lower():
+            missing.append(label)
+    return GhTokenProbe(missing=tuple(missing))
+
+
+__all__ = [
+    "REQUIRED_PERMISSION_LABELS",
+    "GhRunner",
+    "GhTokenProbe",
+    "probe_token_permissions",
+]

--- a/src/teatree/utils/ram_probe.py
+++ b/src/teatree/utils/ram_probe.py
@@ -74,17 +74,71 @@ def read_ram_used_percent() -> float:
     return 0.0
 
 
+def _cgroup_v2_cpu_quota() -> int | None:
+    """Cores permitted by the cgroup-v2 CPU quota, or ``None`` when unlimited/absent.
+
+    ``/sys/fs/cgroup/cpu.max`` holds ``"<quota> <period>"`` (or ``"max <period>"``
+    when uncapped). A capped container reports a quota well below the host's
+    physical cores, so honouring it keeps :func:`available_cpu_count` from
+    reading the host's 8 cores inside a 2-core-capped container (#3409). Rounds
+    the quota/period ratio up and floors at 1 — a fractional sub-core quota still
+    admits one worker. Any read/parse failure degrades to ``None`` (treated as
+    "no cgroup cap"), never raising.
+    """
+    from pathlib import Path  # noqa: PLC0415 — deferred: loaded only on this code path
+
+    try:
+        quota_raw, _, period_raw = Path("/sys/fs/cgroup/cpu.max").read_text(encoding="utf-8").strip().partition(" ")
+        if quota_raw == "max":
+            return None
+        quota, period = int(quota_raw), int(period_raw)
+    except (OSError, ValueError):
+        return None
+    if quota <= 0 or period <= 0:
+        return None
+    return max(1, -(-quota // period))  # ceil division, floored at 1
+
+
+def available_cpu_count() -> int:
+    """Cores actually available to THIS process — cgroup/affinity-aware (#3409).
+
+    A container capped below the host must not derive its concurrency from the
+    host's physical core count. The minimum of every signal we can read is the
+    honest ceiling: CPU-affinity (``os.process_cpu_count`` on 3.13, else
+    ``sched_getaffinity``), the physical ``os.cpu_count``, and the cgroup-v2 CPU
+    quota. Floored at 1 so a caller always gets a usable positive count.
+    """
+    candidates: list[int] = []
+    process_cpu_count = getattr(os, "process_cpu_count", None)
+    if process_cpu_count is not None:
+        affinity = process_cpu_count()
+        if affinity:
+            candidates.append(affinity)
+    elif hasattr(os, "sched_getaffinity"):
+        candidates.append(len(os.sched_getaffinity(0)))
+    physical = os.cpu_count()
+    if physical:
+        candidates.append(physical)
+    quota = _cgroup_v2_cpu_quota()
+    if quota is not None:
+        candidates.append(quota)
+    return max(1, min(candidates)) if candidates else 1
+
+
 def default_provision_concurrency(cpu_count: int | None = None) -> int:
     """nCPU-derived default concurrency cap for parallel worktree provisioning.
 
     Each worktree's provision subprocess is I/O-heavy (network, DB, docker)
     but still spends real CPU time (Django boot, ``migrate``, ``uv sync``).
-    Half the host's logical cores — floored at 1 — keeps enough headroom for
-    the RAM-based admission gate to still matter on a cold multi-repo
-    provision instead of every core being saturated the instant it fires.
+    Half the process's *available* logical cores — floored at 1 — keeps enough
+    headroom for the RAM-based admission gate to still matter on a cold
+    multi-repo provision instead of every core being saturated the instant it
+    fires. The available-core read is cgroup/affinity-aware
+    (:func:`available_cpu_count`) so a capped container derives from its cap,
+    not the host (#3409).
     """
-    n = cpu_count if cpu_count is not None else (os.cpu_count() or 2)
+    n = cpu_count if cpu_count is not None else available_cpu_count()
     return max(1, n // 2)
 
 
-__all__ = ["default_provision_concurrency", "read_ram_used_percent"]
+__all__ = ["available_cpu_count", "default_provision_concurrency", "read_ram_used_percent"]

--- a/tests/teatree_cli/doctor/test_bootstrap_checks.py
+++ b/tests/teatree_cli/doctor/test_bootstrap_checks.py
@@ -1,0 +1,128 @@
+"""Tests for the fresh-box bootstrap-hardening doctor checks (#3405/#3409/#3410)."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from teatree.cli.doctor.checks_bootstrap import (
+    _check_claude_settings_drift,
+    _check_gh_token_permissions,
+    _check_provision_concurrency_from_host,
+    _slug_from_repo_url,
+)
+from teatree.core.gates.gh_token_preflight import GhTokenProbe
+from teatree.core.models.config_setting import ConfigSetting
+
+
+class TestSlugFromRepoUrl:
+    def test_https(self) -> None:
+        assert _slug_from_repo_url("https://github.com/souliane/teatree.git") == "souliane/teatree"
+
+    def test_ssh(self) -> None:
+        assert _slug_from_repo_url("git@github.com:souliane/teatree.git") == "souliane/teatree"
+
+    def test_non_github(self) -> None:
+        assert _slug_from_repo_url("https://gitlab.com/x/y.git") is None
+
+
+class TestGhTokenPermissionsCheck:
+    def test_skips_when_no_slug(self) -> None:
+        with patch("teatree.cli.doctor.checks_bootstrap._resolve_repo_slug", return_value=None):
+            assert _check_gh_token_permissions() is True
+
+    def test_passes_when_token_has_every_permission(self) -> None:
+        with (
+            patch("teatree.cli.doctor.checks_bootstrap._resolve_repo_slug", return_value="o/r"),
+            patch(
+                "teatree.core.gates.gh_token_preflight.probe_token_permissions",
+                return_value=GhTokenProbe(missing=()),
+            ),
+        ):
+            assert _check_gh_token_permissions() is True
+
+    def test_fails_loud_on_missing_permission(self, capsys) -> None:
+        with (
+            patch("teatree.cli.doctor.checks_bootstrap._resolve_repo_slug", return_value="o/r"),
+            patch(
+                "teatree.core.gates.gh_token_preflight.probe_token_permissions",
+                return_value=GhTokenProbe(missing=("issues: write",)),
+            ),
+        ):
+            ok = _check_gh_token_permissions()
+        assert ok is False
+        assert "issues: write" in capsys.readouterr().out
+
+    def test_indeterminate_probe_skips(self) -> None:
+        with (
+            patch("teatree.cli.doctor.checks_bootstrap._resolve_repo_slug", return_value="o/r"),
+            patch(
+                "teatree.core.gates.gh_token_preflight.probe_token_permissions",
+                return_value=GhTokenProbe(missing=(), indeterminate_reason="API unreachable"),
+            ),
+        ):
+            assert _check_gh_token_permissions() is True
+
+
+class TestProvisionConcurrencyFromHost(TestCase):
+    def test_clears_stale_pin_below_host_auto(self) -> None:
+        ConfigSetting.objects.set_value("provision_max_concurrency", 1)
+        with patch("teatree.utils.ram_probe.default_provision_concurrency", return_value=4):
+            ok = _check_provision_concurrency_from_host()
+        assert ok is True
+        # The stale small-box pin is cleared so the runtime auto-derives.
+        assert ConfigSetting.objects.get_effective("provision_max_concurrency") is None
+
+    def test_leaves_pin_at_or_above_host_auto(self) -> None:
+        ConfigSetting.objects.set_value("provision_max_concurrency", 8)
+        with patch("teatree.utils.ram_probe.default_provision_concurrency", return_value=4):
+            _check_provision_concurrency_from_host()
+        assert ConfigSetting.objects.get_effective("provision_max_concurrency") == 8
+
+    def test_noop_when_unpinned(self) -> None:
+        with patch("teatree.utils.ram_probe.default_provision_concurrency", return_value=4):
+            assert _check_provision_concurrency_from_host() is True
+        assert ConfigSetting.objects.get_effective("provision_max_concurrency") is None
+
+    def test_apply_false_reports_without_clearing(self) -> None:
+        ConfigSetting.objects.set_value("provision_max_concurrency", 1)
+        with patch("teatree.utils.ram_probe.default_provision_concurrency", return_value=4):
+            _check_provision_concurrency_from_host(apply=False)
+        assert ConfigSetting.objects.get_effective("provision_max_concurrency") == 1
+
+
+class TestClaudeSettingsDrift:
+    def _stage(self, tmp_path: Path, template_payload: dict, target_payload: dict | None) -> tuple[Path, Path]:
+        repo = tmp_path / "repo"
+        (repo / "deploy").mkdir(parents=True)
+        (repo / "deploy" / "claude-settings.template.json").write_text(json.dumps(template_payload), encoding="utf-8")
+        home = tmp_path / "home"
+        if target_payload is not None:
+            (home / ".claude").mkdir(parents=True)
+            (home / ".claude" / "settings.json").write_text(json.dumps(target_payload), encoding="utf-8")
+        return repo, home
+
+    def test_warns_on_drift(self, tmp_path: Path, capsys, monkeypatch) -> None:
+        repo, home = self._stage(tmp_path, {"model": "new"}, {"model": "old"})
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: home))
+        with patch("teatree.cli.doctor.checks_bootstrap._teatree_repo_root", return_value=repo):
+            ok = _check_claude_settings_drift()
+        assert ok is True  # surfacing-only, never gates
+        out = capsys.readouterr().out
+        assert "WARN" in out
+        assert "model" in out
+
+    def test_silent_when_aligned(self, tmp_path: Path, capsys, monkeypatch) -> None:
+        repo, home = self._stage(tmp_path, {"model": "same"}, {"model": "same", "statusLine": {"x": 1}})
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: home))
+        with patch("teatree.cli.doctor.checks_bootstrap._teatree_repo_root", return_value=repo):
+            _check_claude_settings_drift()
+        assert "WARN" not in capsys.readouterr().out
+
+    def test_skips_when_template_absent(self, tmp_path: Path, monkeypatch) -> None:
+        repo = tmp_path / "repo"
+        (repo / "deploy").mkdir(parents=True)  # no template
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path / "home"))
+        with patch("teatree.cli.doctor.checks_bootstrap._teatree_repo_root", return_value=repo):
+            assert _check_claude_settings_drift() is True

--- a/tests/teatree_cli/setup/test_claude_settings.py
+++ b/tests/teatree_cli/setup/test_claude_settings.py
@@ -1,0 +1,95 @@
+"""Tests for the host Claude-settings template merge (#3410, #3408).
+
+Real temp JSON files stand in for ``~/.claude/settings.json`` and the committed
+template — the merge is exercised end-to-end, nothing about the deep-merge logic
+is reimplemented.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from teatree.cli.setup.claude_settings import deep_merge, managed_key_drift, write_host_claude_settings
+
+
+def _write(path: Path, payload: object) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+class TestDeepMerge:
+    def test_override_wins_on_scalars(self) -> None:
+        assert deep_merge({"a": 1, "b": 2}, {"b": 9}) == {"a": 1, "b": 9}
+
+    def test_objects_merge_recursively(self) -> None:
+        merged = deep_merge({"p": {"x": 1, "y": 2}}, {"p": {"y": 9, "z": 3}})
+        assert merged == {"p": {"x": 1, "y": 9, "z": 3}}
+
+    def test_arrays_are_replaced_not_concatenated(self) -> None:
+        # jq '.[0] * .[1]' semantics: arrays are values, replaced wholesale.
+        assert deep_merge({"allow": ["a", "b"]}, {"allow": ["c"]}) == {"allow": ["c"]}
+
+    def test_inputs_are_not_mutated(self) -> None:
+        base = {"p": {"x": 1}}
+        deep_merge(base, {"p": {"y": 2}})
+        assert base == {"p": {"x": 1}}
+
+
+class TestWriteHostClaudeSettings:
+    def test_creates_target_from_template_when_absent(self, tmp_path: Path) -> None:
+        template = _write(tmp_path / "tpl.json", {"model": "m", "autoMode": {"allow": ["x"]}})
+        target = tmp_path / "home" / ".claude" / "settings.json"
+        result = write_host_claude_settings(template, target)
+        assert target.is_file()
+        assert result["model"] == "m"
+        assert json.loads(target.read_text())["autoMode"]["allow"] == ["x"]
+
+    def test_preserves_unmanaged_keys_and_asserts_managed(self, tmp_path: Path) -> None:
+        template = _write(tmp_path / "tpl.json", {"model": "new", "autoMode": {"allow": ["managed"]}})
+        target = _write(
+            tmp_path / "settings.json",
+            {"model": "old", "statusLine": {"type": "command"}, "autoMode": {"allow": ["user"]}},
+        )
+        result = write_host_claude_settings(template, target)
+        # statusLine (unmanaged) survives; model + autoMode.allow (managed) win.
+        assert result["statusLine"] == {"type": "command"}
+        assert result["model"] == "new"
+        written = json.loads(target.read_text())
+        assert written["autoMode"]["allow"] == ["managed"]
+
+    def test_missing_template_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            write_host_claude_settings(tmp_path / "nope.json", tmp_path / "out.json")
+
+
+class TestManagedKeyDrift:
+    def _template(self, tmp_path: Path) -> Path:
+        return _write(
+            tmp_path / "tpl.json",
+            {
+                "model": "m",
+                "permissions": {"defaultMode": "acceptEdits", "allow": ["Bash(git:*)"]},
+                "autoMode": {"allow": ["grant"]},
+                "env": {"CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY": "4"},
+            },
+        )
+
+    def test_no_drift_when_managed_keys_match(self, tmp_path: Path) -> None:
+        template = self._template(tmp_path)
+        target = _write(tmp_path / "t.json", {**json.loads(template.read_text()), "statusLine": {"x": 1}})
+        assert managed_key_drift(template, target) == []
+
+    def test_absent_target_drifts_every_managed_key(self, tmp_path: Path) -> None:
+        template = self._template(tmp_path)
+        drift = managed_key_drift(template, tmp_path / "absent.json")
+        assert "model" in drift
+        assert "autoMode.allow" in drift
+        assert "permissions.defaultMode" in drift
+
+    def test_reports_only_the_diverged_key(self, tmp_path: Path) -> None:
+        template = self._template(tmp_path)
+        data = json.loads(template.read_text())
+        data["autoMode"]["allow"] = ["different"]
+        target = _write(tmp_path / "t.json", data)
+        assert managed_key_drift(template, target) == ["autoMode.allow"]

--- a/tests/teatree_cli/setup/test_write_automode.py
+++ b/tests/teatree_cli/setup/test_write_automode.py
@@ -1,0 +1,68 @@
+"""Tests for `t3 setup --write-automode` consent gating (#3408).
+
+The full ``t3 setup`` callback does heavy clone-resolution/tool-install work, so
+these exercise the two units that implement the flag —
+``_write_automode_consented`` and ``_maybe_write_managed_settings`` — directly.
+The merge itself is covered by ``test_claude_settings_merge``; here the concern
+is that teatree writes the user's settings ONLY on explicit consent.
+"""
+
+import json
+from pathlib import Path
+
+from teatree.cli.setup.command import _maybe_write_managed_settings, _write_automode_consented
+
+
+class TestConsent:
+    def test_yes_flag_consents(self) -> None:
+        assert _write_automode_consented(yes=True) is True
+
+    def test_no_consent_by_default(self, monkeypatch) -> None:
+        monkeypatch.delenv("TEATREE_WRITE_AUTOMODE", raising=False)
+        assert _write_automode_consented(yes=False) is False
+
+    def test_env_consent(self, monkeypatch) -> None:
+        monkeypatch.setenv("TEATREE_WRITE_AUTOMODE", "1")
+        assert _write_automode_consented(yes=False) is True
+
+    def test_env_falsey_does_not_consent(self, monkeypatch) -> None:
+        monkeypatch.setenv("TEATREE_WRITE_AUTOMODE", "0")
+        assert _write_automode_consented(yes=False) is False
+
+
+def _repo_with_template(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "deploy").mkdir(parents=True)
+    (repo / "deploy" / "claude-settings.template.json").write_text(
+        json.dumps({"model": "m", "autoMode": {"allow": ["grant"]}}),
+        encoding="utf-8",
+    )
+    return repo
+
+
+class TestMaybeWriteManagedSettings:
+    def test_noop_without_flag(self, tmp_path: Path) -> None:
+        repo = _repo_with_template(tmp_path)
+        target = tmp_path / "settings.json"
+        _maybe_write_managed_settings(repo, target, write_automode=False, yes=True)
+        assert not target.exists()
+
+    def test_noop_without_consent(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.delenv("TEATREE_WRITE_AUTOMODE", raising=False)
+        repo = _repo_with_template(tmp_path)
+        target = tmp_path / "settings.json"
+        _maybe_write_managed_settings(repo, target, write_automode=True, yes=False)
+        assert not target.exists()
+
+    def test_writes_on_flag_and_consent(self, tmp_path: Path) -> None:
+        repo = _repo_with_template(tmp_path)
+        target = tmp_path / "settings.json"
+        _maybe_write_managed_settings(repo, target, write_automode=True, yes=True)
+        assert json.loads(target.read_text())["autoMode"]["allow"] == ["grant"]
+
+    def test_missing_template_is_graceful(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        (repo / "deploy").mkdir(parents=True)  # no template file
+        target = tmp_path / "settings.json"
+        _maybe_write_managed_settings(repo, target, write_automode=True, yes=True)
+        assert not target.exists()

--- a/tests/teatree_core/gates/test_gh_token_preflight.py
+++ b/tests/teatree_core/gates/test_gh_token_preflight.py
@@ -1,0 +1,111 @@
+"""Unit tests for the GitHub token permission probe (#3405).
+
+The only boundary faked is the ``gh`` runner (an unstoppable external subprocess /
+network); the probe's classification logic runs for real against modelled ``gh
+api`` outputs.
+"""
+
+from unittest.mock import patch
+
+from teatree.core.gates.gh_token_preflight import REQUIRED_PERMISSION_LABELS, probe_token_permissions
+
+_SLUG = "souliane/teatree"
+_NOT_ACCESSIBLE = '{"message":"Resource not accessible by personal access token"}'
+_NOT_FOUND = '{"message":"Not Found"}'
+
+
+def _runner(responses: dict[str, tuple[int, str]]):
+    """A fake gh runner keyed by a distinctive substring of the endpoint arg.
+
+    The metadata read (no ``--method``) is matched by its ``repos/<slug>`` needle;
+    write probes (``--method`` present) are matched by their resource needle so
+    the metadata needle — a substring of every write endpoint — never shadows them.
+    """
+
+    def run(args: list[str]) -> tuple[int, str]:
+        joined = " ".join(args)
+        is_write = "--method" in args
+        for needle, outcome in responses.items():
+            if needle not in joined:
+                continue
+            if is_write == (needle != f"repos/{_SLUG}"):
+                return outcome
+        return (0, "{}")
+
+    return run
+
+
+class TestProbeTokenPermissions:
+    def test_all_present_when_writes_404(self) -> None:
+        # A permitted token gets 404 (resource id 0 doesn't exist) on every write.
+        run = _runner(
+            {
+                "repos/souliane/teatree": (0, "{}"),
+                "issues/0": (1, _NOT_FOUND),
+                "pulls/0": (1, _NOT_FOUND),
+                "refs/heads": (1, _NOT_FOUND),
+            }
+        )
+        with patch("teatree.core.gates.gh_token_preflight.shutil.which", return_value="/usr/bin/gh"):
+            probe = probe_token_permissions(_SLUG, run=run)
+        assert probe.ok
+        assert probe.missing == ()
+
+    def test_missing_issues_write_detected(self) -> None:
+        run = _runner(
+            {
+                "repos/souliane/teatree": (0, "{}"),
+                "issues/0": (1, _NOT_ACCESSIBLE),
+                "pulls/0": (1, _NOT_FOUND),
+                "refs/heads": (1, _NOT_FOUND),
+            }
+        )
+        with patch("teatree.core.gates.gh_token_preflight.shutil.which", return_value="/usr/bin/gh"):
+            probe = probe_token_permissions(_SLUG, run=run)
+        assert probe.missing == ("issues: write",)
+        assert not probe.ok
+
+    def test_multiple_missing_reported_in_order(self) -> None:
+        run = _runner(
+            {
+                "repos/souliane/teatree": (0, "{}"),
+                "issues/0": (1, _NOT_ACCESSIBLE),
+                "pulls/0": (1, _NOT_ACCESSIBLE),
+                "refs/heads": (1, _NOT_FOUND),
+            }
+        )
+        with patch("teatree.core.gates.gh_token_preflight.shutil.which", return_value="/usr/bin/gh"):
+            probe = probe_token_permissions(_SLUG, run=run)
+        assert probe.missing == ("issues: write", "pull_requests: write")
+
+    def test_metadata_denied_short_circuits(self) -> None:
+        # A token that cannot even read the repo: the write probes are meaningless.
+        run = _runner({"repos/souliane/teatree": (1, _NOT_ACCESSIBLE)})
+        with patch("teatree.core.gates.gh_token_preflight.shutil.which", return_value="/usr/bin/gh"):
+            probe = probe_token_permissions(_SLUG, run=run)
+        assert probe.missing == ("metadata: read",)
+
+    def test_metadata_network_failure_is_indeterminate(self) -> None:
+        # A non-permission failure (network) must not be read as a missing scope.
+        run = _runner({"repos/souliane/teatree": (1, "connection reset by peer")})
+        with patch("teatree.core.gates.gh_token_preflight.shutil.which", return_value="/usr/bin/gh"):
+            probe = probe_token_permissions(_SLUG, run=run)
+        assert probe.missing == ()
+        assert probe.indeterminate_reason is not None
+        assert not probe.ok
+
+    def test_gh_absent_is_indeterminate(self) -> None:
+        with patch("teatree.core.gates.gh_token_preflight.shutil.which", return_value=None):
+            probe = probe_token_permissions(_SLUG, run=_runner({}))
+        assert probe.indeterminate_reason is not None
+        assert "gh" in probe.indeterminate_reason.lower()
+
+
+class TestRequiredLabels:
+    def test_labels_are_the_four_loop_permissions(self) -> None:
+        assert REQUIRED_PERMISSION_LABELS == (
+            "metadata: read",
+            "issues: write",
+            "pull_requests: write",
+            "contents: write",
+        )

--- a/tests/teatree_docker/test_deploy_headless_config.py
+++ b/tests/teatree_docker/test_deploy_headless_config.py
@@ -12,6 +12,7 @@ import json
 import stat
 from pathlib import Path
 
+from teatree.cli.recommended_authorizations import RECOMMENDED_AUTHORIZATIONS
 from teatree.docker.workflow import COMPOSE_REL, WRAPPER_REL
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -59,6 +60,14 @@ class TestHeadlessClaudeSettings:
     def test_env_concurrency_is_a_positive_int(self) -> None:
         data = self._settings()
         assert int(data["env"]["CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY"]) > 0
+
+    def test_automode_carries_every_recommended_authorization(self) -> None:
+        # #3408/#3410: the template's autoMode.allow is the single source both host
+        # (`t3 setup --write-automode`) and container seed apply, so it must carry the
+        # full recommended set — a fresh box is then classifier-unblocked everywhere.
+        allow = self._settings()["autoMode"]["allow"]
+        for rec in RECOMMENDED_AUTHORIZATIONS:
+            assert rec.sentence in allow, f"template autoMode.allow is missing the {rec.key!r} recommendation"
 
 
 class TestEntrypointAndDockerfileWiring:

--- a/tests/teatree_utils/test_ram_probe.py
+++ b/tests/teatree_utils/test_ram_probe.py
@@ -5,8 +5,10 @@ from unittest.mock import patch
 import pytest
 
 from teatree.utils.ram_probe import (
+    _cgroup_v2_cpu_quota,
     _linux_ram_used_percent,
     _macos_ram_used_percent,
+    available_cpu_count,
     default_provision_concurrency,
     read_ram_used_percent,
 )
@@ -62,6 +64,49 @@ def test_default_provision_concurrency_floors_at_one() -> None:
     assert default_provision_concurrency(cpu_count=0) == 1
 
 
-def test_default_provision_concurrency_reads_os_cpu_count_when_unset() -> None:
-    with patch("teatree.utils.ram_probe.os.cpu_count", return_value=6):
+def test_default_provision_concurrency_reads_available_cpu_when_unset() -> None:
+    with patch("teatree.utils.ram_probe.available_cpu_count", return_value=6):
         assert default_provision_concurrency() == 3
+
+
+def test_available_cpu_count_takes_the_minimum_signal() -> None:
+    # A host with 8 physical cores but a 2-core cgroup quota must derive from 2.
+    with (
+        patch("os.process_cpu_count", return_value=8),
+        patch("teatree.utils.ram_probe.os.cpu_count", return_value=8),
+        patch("teatree.utils.ram_probe._cgroup_v2_cpu_quota", return_value=2),
+    ):
+        assert available_cpu_count() == 2
+
+
+def test_available_cpu_count_ignores_absent_cgroup_cap() -> None:
+    with (
+        patch("os.process_cpu_count", return_value=4),
+        patch("teatree.utils.ram_probe.os.cpu_count", return_value=4),
+        patch("teatree.utils.ram_probe._cgroup_v2_cpu_quota", return_value=None),
+    ):
+        assert available_cpu_count() == 4
+
+
+def test_available_cpu_count_floors_at_one() -> None:
+    with (
+        patch("os.process_cpu_count", return_value=None),
+        patch("teatree.utils.ram_probe.os.cpu_count", return_value=None),
+        patch("teatree.utils.ram_probe._cgroup_v2_cpu_quota", return_value=None),
+    ):
+        assert available_cpu_count() == 1
+
+
+def test_cgroup_v2_cpu_quota_parses_capped() -> None:
+    with patch("pathlib.Path.read_text", return_value="150000 100000\n"):  # 1.5 cores → ceil 2
+        assert _cgroup_v2_cpu_quota() == 2
+
+
+def test_cgroup_v2_cpu_quota_unlimited_is_none() -> None:
+    with patch("pathlib.Path.read_text", return_value="max 100000\n"):
+        assert _cgroup_v2_cpu_quota() is None
+
+
+def test_cgroup_v2_cpu_quota_missing_file_is_none() -> None:
+    with patch("pathlib.Path.read_text", side_effect=OSError):
+        assert _cgroup_v2_cpu_quota() is None

--- a/tests/test_deploy_entrypoint_token_preflight.py
+++ b/tests/test_deploy_entrypoint_token_preflight.py
@@ -1,0 +1,158 @@
+# test-path: cross-cutting — drives deploy/entrypoint.sh + teatree.core.gates.gh_token_preflight (no src mirror).
+"""Integration tests for the deploy entrypoint's GitHub token-permission preflight (#3405).
+
+`deploy/entrypoint.sh`'s ``assert_gh_token_permissions`` verifies TEATREE_GH_TOKEN
+carries the WRITE permissions the loop mutates (issues / pull_requests / contents)
+rather than only that it authenticates — otherwise a read-only token fails LATE,
+mid-run, with "Resource not accessible by personal access token".
+
+Per the Test-Writing Doctrine these run the REAL shell functions (extracted
+verbatim from the entrypoint) in a bash subprocess with a stub `gh` on PATH that
+models GitHub's route-level 403 for a denied write permission and 404 for a
+permitted one. The stub's per-endpoint verdict is env-driven so one shim covers
+every case. A companion assertion pins the shell's permission labels to the
+Python mirror (`teatree.core.gates.gh_token_preflight`) so the two implementations of
+the same contract cannot drift.
+"""
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from teatree.core.gates.gh_token_preflight import REQUIRED_PERMISSION_LABELS
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None,
+    reason="needs bash (present in the deploy image and CI)",
+)
+
+ENTRYPOINT = Path(__file__).resolve().parents[1] / "deploy" / "entrypoint.sh"
+_BASH = shutil.which("bash") or "bash"
+_NOT_ACCESSIBLE = "Resource not accessible by personal access token"
+
+
+def _extract_shell_function(name: str) -> str:
+    """Return the verbatim source of shell function *name* from the entrypoint."""
+    body: list[str] = []
+    capturing = False
+    for line in ENTRYPOINT.read_text(encoding="utf-8").splitlines():
+        if line.startswith(f"{name}() {{"):
+            capturing = True
+        if capturing:
+            body.append(line)
+            if line == "}":
+                return "\n".join(body)
+    not_found = f"function {name!r} not found in {ENTRYPOINT}"
+    raise AssertionError(not_found)
+
+
+def _write_gh_stub(bin_dir: Path) -> None:
+    """A `gh` shim modelling GitHub's write-permission responses.
+
+    ``GH_META_FAIL`` makes the metadata read (``gh api repos/<slug>``) fail with
+    the given text. ``GH_DENY`` is a space-separated set of endpoint substrings
+    for which a write probe returns the 403 "Resource not accessible" body;
+    every other write probe returns a 404 (permitted-but-nonexistent). Exit code
+    is non-zero for any 4xx, exactly as real `gh api` behaves.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    shim = bin_dir / "gh"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        'args="$*"\n'
+        # metadata read: `gh api repos/<slug>` with no --method
+        'if [[ "$args" != *"--method"* && "$args" == *"api repos/"* ]]; then\n'
+        '  if [ -n "${GH_META_FAIL:-}" ]; then echo "$GH_META_FAIL" >&2; exit 1; fi\n'
+        '  echo "{}"; exit 0\n'
+        "fi\n"
+        # write probes: deny listed endpoints, else 404
+        "for needle in ${GH_DENY:-}; do\n"
+        '  if [[ "$args" == *"$needle"* ]]; then echo "' + _NOT_ACCESSIBLE + '" >&2; exit 1; fi\n'
+        "done\n"
+        'echo "{\\"message\\":\\"Not Found\\"}" >&2; exit 1\n',
+        encoding="utf-8",
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _run(tmp_path: Path, **stub_env: str) -> subprocess.CompletedProcess[str]:
+    """Run the extracted preflight once with the stub `gh` on PATH."""
+    bin_dir = tmp_path / "bin"
+    _write_gh_stub(bin_dir)
+
+    func = "\n\n".join(
+        _extract_shell_function(name) for name in ("gh_repo_slug", "_gh_perm_denied", "assert_gh_token_permissions")
+    )
+    harness = tmp_path / "harness.sh"
+    harness.write_text(
+        f'set -euo pipefail\nREPO_URL="${{REPO_URL:-}}"\n{func}\nassert_gh_token_permissions\n',
+        encoding="utf-8",
+    )
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env.setdefault("TEATREE_REPO_URL", "https://github.com/souliane/teatree.git")
+    env.update(stub_env)
+    return subprocess.run([_BASH, str(harness)], capture_output=True, text=True, check=False, env=env)
+
+
+class TestAssertGhTokenPermissions:
+    def test_all_permissions_present_passes(self, tmp_path: Path) -> None:
+        out = _run(tmp_path, GH_DENY="")
+        assert out.returncode == 0, out.stderr
+        assert "permissions verified" in out.stdout
+
+    def test_missing_issues_write_fails_loud(self, tmp_path: Path) -> None:
+        out = _run(tmp_path, GH_DENY="issues/0")
+        assert out.returncode != 0
+        assert "issues: write" in out.stderr
+        assert "Resource not accessible" in out.stderr
+
+    def test_all_writes_missing_lists_each(self, tmp_path: Path) -> None:
+        out = _run(tmp_path, GH_DENY="issues/0 pulls/0 refs/heads")
+        assert out.returncode != 0
+        for label in ("issues: write", "pull_requests: write", "contents: write"):
+            assert label in out.stderr
+
+    def test_metadata_unreadable_fails_loud(self, tmp_path: Path) -> None:
+        out = _run(tmp_path, GH_META_FAIL="Not Found")
+        assert out.returncode != 0
+        assert "metadata: read" in out.stderr
+
+    def test_unparseable_slug_skips_gracefully(self, tmp_path: Path) -> None:
+        out = _run(tmp_path, TEATREE_REPO_URL="file:///local/mirror", GH_DENY="issues/0")
+        # No GitHub slug → skip the probe, do not fail the deploy.
+        assert out.returncode == 0, out.stderr
+        assert "could not resolve the GitHub repo slug" in out.stderr
+
+
+class TestGhRepoSlug:
+    def _slug(self, tmp_path: Path, url: str) -> str:
+        func = _extract_shell_function("gh_repo_slug")
+        harness = tmp_path / "slug.sh"
+        harness.write_text(f'set -euo pipefail\nREPO_URL=""\n{func}\ngh_repo_slug\n', encoding="utf-8")
+        env = dict(os.environ)
+        env["TEATREE_REPO_URL"] = url
+        return subprocess.run(
+            [_BASH, str(harness)], capture_output=True, text=True, check=False, env=env
+        ).stdout.strip()
+
+    def test_https_url(self, tmp_path: Path) -> None:
+        assert self._slug(tmp_path, "https://github.com/souliane/teatree.git") == "souliane/teatree"
+
+    def test_ssh_url(self, tmp_path: Path) -> None:
+        assert self._slug(tmp_path, "git@github.com:souliane/teatree.git") == "souliane/teatree"
+
+    def test_non_github_url_is_empty(self, tmp_path: Path) -> None:
+        assert self._slug(tmp_path, "https://gitlab.com/x/y.git") == ""
+
+
+def test_shell_labels_match_python_mirror() -> None:
+    """The shell probe and the Python mirror must name the same four permissions."""
+    text = ENTRYPOINT.read_text(encoding="utf-8")
+    for label in REQUIRED_PERMISSION_LABELS:
+        assert label in text, f"entrypoint.sh must probe {label!r} (pinned to REQUIRED_PERMISSION_LABELS)"


### PR DESCRIPTION
Closes #3405. Closes #3408. Closes #3409. Closes #3410. init_preflight probes gh token perms + fails loud; t3 setup --write-automode seeds recommended autoMode.allow; cgroup-aware host-derived concurrency doctor autofix; claude-settings.template.json single source with host/container deep-merge + drift check.