### PR TITLE
feat(doctor): verify Slack round-trip comms for headless teatree (#3411)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -2663,10 +2663,12 @@ Usage: t3 doctor check [OPTIONS]
  Verify imports, required tools, and editable-install sanity.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --repair          Re-point a relocated/hijacked t3 editable install at the   │
-│                   expected checkout (#3231).                                 │
-│ --json            Emit findings as JSON for the watchdog container.          │
-│ --help            Show this message and exit.                                │
+│ --repair                   Re-point a relocated/hijacked t3 editable install │
+│                            at the expected checkout (#3231).                 │
+│ --slack-roundtrip          Deep Slack round-trip: additionally run a LIVE    │
+│                            auth.test per Slack backend (#3411).              │
+│ --json                     Emit findings as JSON for the watchdog container. │
+│ --help                     Show this message and exit.                       │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/cli/doctor/app.py
+++ b/src/teatree/cli/doctor/app.py
@@ -47,6 +47,7 @@ from teatree.cli.doctor.checks_mcp import (
 )
 from teatree.cli.doctor.checks_runtime import _check_singletons, _check_ttyd_for_dashboard, _check_worker_running
 from teatree.cli.doctor.checks_session import _check_account_switch, _check_agent_session_pins, _check_slack_socket_mode
+from teatree.cli.doctor.checks_slack_roundtrip import check_slack_roundtrip
 from teatree.cli.doctor.dev_sources import (
     _find_host_project_root,
     _find_teatree_pyproject_from_cwd,
@@ -127,6 +128,7 @@ __all__ = (
     "_write_dev_sources_marker",
     "agent_skill_dirs",
     "check",
+    "check_slack_roundtrip",
     "check_statusline",
     "doctor_app",
 )
@@ -140,15 +142,20 @@ def check(
         "--repair",
         help="Re-point a relocated/hijacked t3 editable install at the expected checkout (#3231).",
     ),
+    slack_roundtrip: bool = typer.Option(
+        False,
+        "--slack-roundtrip",
+        help="Deep Slack round-trip: additionally run a LIVE auth.test per Slack backend (#3411).",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit findings as JSON for the watchdog container."),
 ) -> None:
     """Verify imports, required tools, and editable-install sanity."""
     if json_output:
         from teatree.cli.doctor.self_heal import check_as_json  # noqa: PLC0415 — deferred: --json path only
 
-        ok = check_as_json(lambda: run_doctor_checks(repair=repair))
+        ok = check_as_json(lambda: run_doctor_checks(repair=repair, slack_roundtrip=slack_roundtrip))
     else:
-        ok = run_doctor_checks(repair=repair)
+        ok = run_doctor_checks(repair=repair, slack_roundtrip=slack_roundtrip)
     # Standalone Click discards a command's return value, so the pass/fail bool
     # must be turned into the process exit code here — a `t3 doctor check && …`
     # in CI/hooks and the watchdog's non-JSON path both key on it (#3313).
@@ -171,12 +178,13 @@ def _optional_tooling_advisories() -> None:
     _check_docker_workflow_wired()
 
 
-def run_doctor_checks(*, repair: bool = False) -> bool:
+def run_doctor_checks(*, repair: bool = False, slack_roundtrip: bool = False) -> bool:
     """Run every doctor check; return ``False`` if any hard-FAILs.
 
     The pure-boolean core the ``check`` command turns into the process exit code.
     Direct callers — ``_doctor_default`` and the ``--json`` surface — reuse it so
-    the pass/fail verdict is computed in exactly one place.
+    the pass/fail verdict is computed in exactly one place. ``slack_roundtrip``
+    turns on the deep live-``auth.test`` mode of the Slack round-trip gate (#3411).
     """
     try:
         import django  # noqa: PLC0415, F401 — deferred: Django import at call time; re-export
@@ -317,6 +325,16 @@ def run_doctor_checks(*, repair: bool = False) -> bool:
     # via the overlay factory. Surfacing-only (never gates the exit code): Slack
     # is optional and must never become mandatory.
     check_and_render_dm_ready()
+
+    # Slack round-trip comms (#3411): the "reacts-but-never-answers" detector. When
+    # a Slack backend is configured, actively verify the FULL loop — outbound egress
+    # resolves, the owner id resolves (the empty-string headless bug), the listener
+    # is live, the inbox answer loop is enabled+unmasked with a worker draining it,
+    # and no real message sits reacted-👀 but unanswered. Unlike the surfacing-only
+    # DM-readiness check above, THIS gates the exit code: a silent round-trip break
+    # must be a doctor FAILURE, not a surprise. `--slack-roundtrip` adds a live
+    # auth.test. A silent no-op with no Slack-backed overlay (Slack stays optional).
+    ok = check_slack_roundtrip(deep=slack_roundtrip) and ok
 
     # In-session `/login` account-switch recovery (#1916). Runs after
     # ``ensure_django`` because it builds messaging backends via the overlay

--- a/src/teatree/cli/doctor/checks_slack_roundtrip.py
+++ b/src/teatree/cli/doctor/checks_slack_roundtrip.py
@@ -1,0 +1,302 @@
+"""``t3 doctor`` — active Slack round-trip comms verification for headless teatree (#3411).
+
+The "reacts-but-never-answers" detector. Headless teatree in Docker RECEIVES a
+Slack DM and REACTS (👀 ack) but never POSTS an answer back — a silent half-broken
+round-trip that no prior health check caught. This gate verifies the FULL comms
+loop whenever a Slack backend is configured and hard-FAILs (red + non-zero doctor
+exit) the moment teatree would react-but-never-answer:
+
+1. **Outbound** — every Slack-backed overlay resolves to a real (non-no-op)
+    messaging backend, so a reply CAN be posted. ``--slack-roundtrip`` additionally
+    runs a LIVE ``auth.test`` per backend (proves the bot token actually reaches
+    Slack, not just that config is present).
+2. **Owner resolution** — the global :func:`teatree.core.notify.resolve_user_id`
+    the headless egress calls resolves NON-empty. The empty-string headless failure
+    (``T3_OVERLAY_NAME`` unset, no global setting) is exactly the observed bug: the
+    answer pipeline silently NOOPs its reply.
+3. **Inbound listener** — the Socket-Mode ``slack-listener`` singleton is live, so
+    inbound events are being queued at all.
+4. **Answer pipeline** — the ``inbox`` loop is enabled + unmasked and a loop worker
+    is draining the queue, so a queued message actually gets answered.
+5. **Evidence** — no message sits reacted-👀 but never loop-replied past the
+    staleness window (the smoking gun of the observed bug, read from real traffic).
+
+Unlike the surfacing-only Slack DM-readiness check, THIS check gates the overall
+doctor exit code — a silent break must be a doctor failure, not a surprise. Slack
+stays optional: with no Slack-backed overlay the check is a silent no-op.
+"""
+
+import datetime as dt
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import typer
+
+from teatree.cli.slack.socket_doctor import Level
+
+#: A message reacted 👀 but never loop-replied for longer than this is the
+#: "reacts-but-never-answers" signature read from real inbound traffic. Generous
+#: relative to the ~20s answer cadence so a mid-flight cycle never false-alarms.
+_UNANSWERED_STALENESS = dt.timedelta(minutes=5)
+
+#: The durable ``Loop`` row that gates the reactive Slack-answer / DM-inbound work.
+_ANSWER_LOOP = "inbox"
+
+
+@dataclass(frozen=True, slots=True)
+class RoundtripFinding:
+    """One round-trip observation the doctor renders on its own line."""
+
+    level: Level
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class RoundtripOutcome:
+    """The full set of round-trip findings across the comms loop."""
+
+    findings: tuple[RoundtripFinding, ...]
+
+    @property
+    def ok(self) -> bool:
+        """``False`` iff any finding hard-FAILs — the value that gates the doctor exit code."""
+        return not any(finding.level is Level.FAIL for finding in self.findings)
+
+
+def _is_headless(env: dict[str, str]) -> bool:
+    """Whether this box is a headless Docker deployment (the entrypoint always sets ``TEATREE_ROLE``).
+
+    A missing listener is a hard FAIL only headless — that is where the operator
+    steers via Slack and a down receiver silently breaks autonomy. On a plain
+    interactive host (no ``TEATREE_ROLE``) it degrades to a WARN: the operator is
+    at the keyboard and may simply not be running the receiver.
+    """
+    return bool(env.get("TEATREE_ROLE"))
+
+
+def _probe_outbound(overlays: list[str], *, deep: bool) -> list[RoundtripFinding]:
+    """Every Slack overlay resolves to a real backend that can post — the reply egress.
+
+    A no-op / absent backend means the bot tokens are missing: teatree can react
+    (a reaction needs no post) yet never answer. ``deep`` additionally runs a live
+    ``auth.test`` so a present-but-invalid bot token is caught, not just an absent one.
+    """
+    from teatree.backends.messaging_noop import NoopMessagingBackend  # noqa: PLC0415 — deferred: keep import light
+    from teatree.core.backend_factory import messaging_from_overlay  # noqa: PLC0415 — deferred: ORM-backed factory
+
+    findings: list[RoundtripFinding] = []
+    for overlay in overlays:
+        backend = messaging_from_overlay(overlay)
+        if backend is None or isinstance(backend, NoopMessagingBackend):
+            findings.append(
+                RoundtripFinding(
+                    Level.FAIL,
+                    f"[{overlay}] outbound Slack egress is DEAD — resolves to a no-op backend despite "
+                    "messaging_backend=slack, so teatree can react 👀 but never post an answer. Bot tokens "
+                    "missing at the `slack_token_ref` pass entry; run `t3 setup slack-bot`.",
+                )
+            )
+            continue
+        if deep:
+            findings.append(_probe_auth_test(overlay, backend))
+    return findings
+
+
+def _probe_auth_test(overlay: str, backend: object) -> RoundtripFinding:
+    """Live ``auth.test`` for one backend (``--slack-roundtrip`` deep mode).
+
+    Proves the bot token actually reaches Slack and is authenticated — the active
+    outbound half of the round-trip. A backend without an ``auth_test`` seam (a
+    non-Slack backend that slipped through) degrades to a WARN.
+    """
+    auth_test = getattr(backend, "auth_test", None)
+    if not callable(auth_test):
+        return RoundtripFinding(Level.WARN, f"[{overlay}] backend exposes no auth.test seam — skipped live probe.")
+    try:
+        body = auth_test()
+    except Exception as exc:  # noqa: BLE001 — a live probe error is a finding, never a crash
+        return RoundtripFinding(
+            Level.FAIL,
+            f"[{overlay}] live Slack auth.test FAILED ({exc.__class__.__name__}: {exc}) — the bot token cannot "
+            "reach/authenticate to Slack; teatree cannot post answers. Re-mint the bot token (`t3 setup slack-bot`).",
+        )
+    if not isinstance(body, dict) or not body.get("ok"):
+        return RoundtripFinding(
+            Level.FAIL,
+            f"[{overlay}] live Slack auth.test returned not-ok ({body!r}) — the bot token is missing/invalid; "
+            "teatree cannot post answers. Re-mint the bot token (`t3 setup slack-bot`).",
+        )
+    return RoundtripFinding(Level.OK, f"[{overlay}] live Slack auth.test ok (bot {body.get('user_id', '?')}).")
+
+
+def _probe_owner_resolution() -> RoundtripFinding:
+    """The global owner id the headless egress DMs resolves non-empty (THE observed bug).
+
+    :func:`teatree.core.notify.resolve_user_id` is the exact resolver the headless
+    worker calls with no ``T3_OVERLAY_NAME`` exported. An empty result is the
+    react-but-never-answer root: the answer pipeline silently NOOPs its reply.
+    """
+    from teatree.core.notify import resolve_user_id  # noqa: PLC0415 — deferred: config read at call time
+
+    if resolve_user_id():
+        return RoundtripFinding(Level.OK, "owner id resolves for the headless egress (resolve_user_id non-empty).")
+    return RoundtripFinding(
+        Level.FAIL,
+        "owner id does NOT resolve (resolve_user_id empty) — the headless answer pipeline reacts 👀 but silently "
+        "NOOPs its reply. Set the owner id: `pass slack/user-id` + `t3 setup`, or set the global `slack_user_id` "
+        "so the worker (no T3_OVERLAY_NAME) resolves it.",
+    )
+
+
+def _probe_listener(*, headless: bool) -> RoundtripFinding:
+    """The Socket-Mode ``slack-listener`` singleton is live so inbound events are queued.
+
+    Uses the SAME flock + pid path :func:`teatree.cli.slack.listen.listen_command`
+    holds. A down listener means NOTHING inbound is received — a hard FAIL headless
+    (autonomy is broken), a WARN on an interactive host that may not run a receiver.
+    """
+    from teatree.backends.slack.receiver import default_queue_path  # noqa: PLC0415 — deferred: keep import light
+    from teatree.utils.singleton import flock_is_held  # noqa: PLC0415 — deferred: keep import light
+
+    pid_path = default_queue_path().with_name("slack-listener.pid")
+    if flock_is_held("slack-listener", pid_path=pid_path):
+        return RoundtripFinding(Level.OK, "slack-listener receiver is live (inbound events are being queued).")
+    level = Level.FAIL if headless else Level.WARN
+    return RoundtripFinding(
+        level,
+        "slack-listener receiver is DOWN — no inbound Slack event is being received, so teatree can never answer. "
+        "Restart it: `t3 slack listen` (in Docker, the `teatree-slack-listener` service).",
+    )
+
+
+def _probe_answer_pipeline() -> list[RoundtripFinding]:
+    """The answer path is live: the ``inbox`` loop is enabled + unmasked AND a worker drains it.
+
+    A paused/disabled/preset-masked ``inbox`` loop, or a ``loop_runner_enabled``
+    kill-switch OFF, or no worker holding the flock, all leave a queued message
+    forever unanswered — teatree reacts but never answers.
+    """
+    from teatree.config import get_effective_settings  # noqa: PLC0415 — deferred: keep import light
+    from teatree.loop.loop_state_db import loop_enabled  # noqa: PLC0415 — deferred: ORM-backed read
+    from teatree.utils.singleton import WORKER_SINGLETON, flock_is_held  # noqa: PLC0415 — deferred: keep import light
+
+    findings: list[RoundtripFinding] = []
+    if not loop_enabled(_ANSWER_LOOP):
+        findings.append(
+            RoundtripFinding(
+                Level.FAIL,
+                f"the `{_ANSWER_LOOP}` answer loop is masked (paused / disabled / preset-forced-off) — queued "
+                f"messages are never answered. Enable it: `t3 loop enable {_ANSWER_LOOP}` and clear any override "
+                f"(`t3 loop override {_ANSWER_LOOP} clear`).",
+            )
+        )
+    settings = get_effective_settings()
+    if not settings.loop_runner_enabled:
+        findings.append(
+            RoundtripFinding(
+                Level.FAIL,
+                "the loop runner is OFF (loop_runner_enabled=false) — no headless answer cycle runs; teatree reacts "
+                "but never answers. Re-enable the loop runner.",
+            )
+        )
+    elif not flock_is_held(WORKER_SINGLETON):
+        findings.append(
+            RoundtripFinding(
+                Level.FAIL,
+                "no loop worker holds the flock — the reactive Slack-answer cycle never runs, so queued messages are "
+                "never answered. Start one: `t3 worker ensure`.",
+            )
+        )
+    if not findings:
+        findings.append(RoundtripFinding(Level.OK, "answer pipeline is live (inbox loop enabled, worker draining)."))
+    return findings
+
+
+def _probe_unanswered_evidence(*, now: dt.datetime | None = None) -> RoundtripFinding | None:
+    """Real-traffic proof of the bug: a message reacted 👀 but never loop-replied.
+
+    Reads :class:`PendingChatInjection` for rows that got the eyes receipt
+    (``eyes_reacted_at`` set) yet were never answered/acked/delegated
+    (``loop_replied_at`` and ``answered_at`` both null) beyond the staleness
+    window. That is precisely reacts-but-never-answers, observed rather than
+    inferred. Returns ``None`` when there is no such evidence.
+    """
+    from django.utils import timezone  # noqa: PLC0415 — deferred: Django import at call time
+
+    from teatree.core.models import PendingChatInjection  # noqa: PLC0415 — deferred: ORM import needs the registry
+
+    cutoff = (now or timezone.now()) - _UNANSWERED_STALENESS
+    stale = PendingChatInjection.objects.filter(
+        eyes_reacted_at__isnull=False,
+        loop_replied_at__isnull=True,
+        answered_at__isnull=True,
+        received_at__lt=cutoff,
+    ).count()
+    if stale == 0:
+        return None
+    return RoundtripFinding(
+        Level.FAIL,
+        f"reacts-but-never-answers CONFIRMED — {stale} Slack message(s) were reacted 👀 but never answered for over "
+        f"{int(_UNANSWERED_STALENESS.total_seconds() // 60)}m. The answer pipeline is half-broken: check owner "
+        "resolution, the loop worker, and Anthropic capacity (a masked/exhausted answer loop).",
+    )
+
+
+def run_slack_roundtrip_probes(
+    *,
+    deep: bool = False,
+    env: dict[str, str] | None = None,
+    now: dt.datetime | None = None,
+) -> RoundtripOutcome:
+    """Verify the full Slack comms loop; return the structured findings (gating).
+
+    A silent no-op with no Slack-backed overlay (Slack is optional). ``deep`` adds
+    the live ``auth.test`` outbound probe (``t3 doctor check --slack-roundtrip``).
+    """
+    from teatree.cli.slack.provision import _slack_overlays  # noqa: PLC0415 — deferred: ORM-backed registry read
+
+    overlays = _slack_overlays()
+    if not overlays:
+        return RoundtripOutcome(findings=())
+
+    resolved_env = env if env is not None else dict(os.environ)
+    findings: list[RoundtripFinding] = []
+    findings.extend(_probe_outbound(overlays, deep=deep))
+    findings.extend((_probe_owner_resolution(), _probe_listener(headless=_is_headless(resolved_env))))
+    findings.extend(_probe_answer_pipeline())
+    evidence = _probe_unanswered_evidence(now=now)
+    if evidence is not None:
+        findings.append(evidence)
+    return RoundtripOutcome(findings=tuple(findings))
+
+
+def check_slack_roundtrip(
+    *,
+    deep: bool = False,
+    env: dict[str, str] | None = None,
+    echo: Callable[[str], object] = typer.echo,
+) -> bool:
+    """Run the Slack round-trip probes, render each finding, and return the pass/fail verdict.
+
+    Gates the overall doctor exit code (unlike the surfacing-only DM-readiness
+    check): a FAIL reddens the run. Crash-proof — any unexpected error degrades to
+    a WARN + OK so a check bug never crashes or falsely reddens the doctor run
+    (the actual comms-break signals are FAILs from probes that ran).
+    """
+    try:
+        outcome = run_slack_roundtrip_probes(deep=deep, env=env)
+    except Exception as exc:  # noqa: BLE001 — a doctor check must never crash the run
+        echo(f"WARN  Slack round-trip check crashed: {exc.__class__.__name__}: {exc}")
+        return True
+    for finding in outcome.findings:
+        echo(f"{finding.level.value:<5} Slack round-trip: {finding.message}")
+    return outcome.ok
+
+
+__all__ = [
+    "RoundtripFinding",
+    "RoundtripOutcome",
+    "check_slack_roundtrip",
+    "run_slack_roundtrip_probes",
+]

--- a/src/teatree/core/factory/capabilities.py
+++ b/src/teatree/core/factory/capabilities.py
@@ -87,6 +87,12 @@ CAPABILITIES: tuple[Capability, ...] = (
         exit_codes=("0", "1"),
         note="human outcome line (salvaged/deleted/branch/pr), not a JSON document",
     ),
+    Capability(
+        "doctor check",
+        json_output=True,
+        exit_codes=("0", "1"),
+        note="--json for the watchdog; --slack-roundtrip adds the deep live Slack round-trip probe (#3411)",
+    ),
     Capability("cost", json_output=True, exit_codes=("0",)),
     Capability("tokens", json_output=True, exit_codes=("0",)),
     Capability("config show", json_output=True, exit_codes=("0",)),

--- a/tests/cli_doctor/test_slack_roundtrip.py
+++ b/tests/cli_doctor/test_slack_roundtrip.py
@@ -1,0 +1,218 @@
+# test-path: cross-cutting
+"""``t3 doctor`` Slack round-trip comms gate (#3411) — the reacts-but-never-answers detector.
+
+Functional coverage of :mod:`teatree.cli.doctor.checks_slack_roundtrip`: seeds real
+``Loop`` / ``PendingChatInjection`` rows in the test DB and stubs only the genuinely
+external seams (the config-resolution resolvers, the process-liveness flock, the
+overlay backend factory, the live ``auth.test``). Every scenario asserts on the
+structured :class:`RoundtripOutcome` and its ``ok`` verdict — the value that gates
+the overall doctor exit code.
+"""
+
+import contextlib
+import datetime as dt
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from teatree.backends.messaging_noop import NoopMessagingBackend
+from teatree.cli.doctor.checks_slack_roundtrip import Level, check_slack_roundtrip, run_slack_roundtrip_probes
+from teatree.core.models import Loop, PendingChatInjection
+from teatree.utils.singleton import WORKER_SINGLETON
+
+
+class _FakeSlackBackend:
+    """A non-no-op messaging backend with a controllable ``auth.test`` seam."""
+
+    def __init__(self, auth_body: object = None, auth_raises: Exception | None = None) -> None:
+        self._auth_body = auth_body if auth_body is not None else {"ok": True, "user_id": "BOT1"}
+        self._auth_raises = auth_raises
+
+    def auth_test(self) -> object:
+        if self._auth_raises is not None:
+            raise self._auth_raises
+        return self._auth_body
+
+
+def _messages(outcome) -> str:
+    return " || ".join(f.message for f in outcome.findings)
+
+
+class _HealthyBaseline(TestCase):
+    """Base with a fully-healthy round-trip; each subclass breaks exactly one seam."""
+
+    def setUp(self) -> None:
+        # The `inbox` answer loop is seeded enabled by 0001_initial; ensure it is
+        # ENABLED with no LoopState hold so loop_enabled("inbox") is True.
+        Loop.objects.update_or_create(name="inbox", defaults={"enabled": True})
+        self._backend = _FakeSlackBackend()
+        self._stack = contextlib.ExitStack()
+        self.overlays = self._stack.enter_context(
+            patch("teatree.cli.slack.provision._slack_overlays", return_value=["acme"])
+        )
+        self.messaging = self._stack.enter_context(
+            patch("teatree.core.backend_factory.messaging_from_overlay", return_value=self._backend)
+        )
+        self.resolve_user_id = self._stack.enter_context(
+            patch("teatree.core.notify.resolve_user_id", return_value="U_OWNER")
+        )
+        # A live listener AND a live worker both hold their flocks by default.
+        self.flock = self._stack.enter_context(
+            patch("teatree.utils.singleton.flock_is_held", side_effect=lambda *_a, **_k: True)
+        )
+        self.addCleanup(self._stack.close)
+
+
+class TestHealthyRoundtrip(_HealthyBaseline):
+    def test_all_ok_and_gate_passes(self) -> None:
+        outcome = run_slack_roundtrip_probes(env={"TEATREE_ROLE": "worker"})
+        assert outcome.ok
+        assert all(f.level is Level.OK for f in outcome.findings), _messages(outcome)
+
+
+class TestGatingSkip(TestCase):
+    def test_no_slack_overlay_is_a_silent_noop(self) -> None:
+        with patch("teatree.cli.slack.provision._slack_overlays", return_value=[]):
+            outcome = run_slack_roundtrip_probes()
+        assert outcome.ok
+        assert outcome.findings == ()
+
+
+class TestOutboundEgress(_HealthyBaseline):
+    def test_noop_backend_fails_loudly(self) -> None:
+        self.messaging.return_value = NoopMessagingBackend()
+        outcome = run_slack_roundtrip_probes(env={"TEATREE_ROLE": "worker"})
+        assert not outcome.ok
+        assert "outbound Slack egress is DEAD" in _messages(outcome)
+
+
+class TestOwnerResolution(_HealthyBaseline):
+    def test_empty_owner_id_is_the_reacts_but_never_answers_root(self) -> None:
+        self.resolve_user_id.return_value = ""
+        outcome = run_slack_roundtrip_probes(env={"TEATREE_ROLE": "worker"})
+        assert not outcome.ok
+        assert "resolve_user_id empty" in _messages(outcome)
+
+
+class TestListenerLiveness(_HealthyBaseline):
+    def _listener_down(self, name: str, *_a, **_k) -> bool:
+        return name != "slack-listener"
+
+    def test_listener_down_is_hard_fail_headless(self) -> None:
+        self.flock.side_effect = self._listener_down
+        outcome = run_slack_roundtrip_probes(env={"TEATREE_ROLE": "slack-listener"})
+        assert not outcome.ok
+        assert "slack-listener receiver is DOWN" in _messages(outcome)
+
+    def test_listener_down_degrades_to_warn_on_interactive_host(self) -> None:
+        self.flock.side_effect = self._listener_down
+        outcome = run_slack_roundtrip_probes(env={})
+        assert outcome.ok  # a WARN, not a hard FAIL, off a headless deployment
+        assert any(f.level is Level.WARN and "receiver is DOWN" in f.message for f in outcome.findings)
+
+
+class TestAnswerPipeline(_HealthyBaseline):
+    def test_masked_inbox_loop_fails(self) -> None:
+        Loop.objects.filter(name="inbox").update(enabled=False)
+        outcome = run_slack_roundtrip_probes(env={"TEATREE_ROLE": "worker"})
+        assert not outcome.ok
+        assert "answer loop is masked" in _messages(outcome)
+
+    def test_loop_runner_off_fails(self) -> None:
+        with patch("teatree.config.get_effective_settings") as settings:
+            settings.return_value.loop_runner_enabled = False
+            outcome = run_slack_roundtrip_probes(env={"TEATREE_ROLE": "worker"})
+        assert not outcome.ok
+        assert "loop runner is OFF" in _messages(outcome)
+
+    def test_no_worker_flock_fails(self) -> None:
+        self.flock.side_effect = lambda name, *_a, **_k: name != WORKER_SINGLETON
+        outcome = run_slack_roundtrip_probes(env={"TEATREE_ROLE": "worker"})
+        assert not outcome.ok
+        assert "no loop worker holds the flock" in _messages(outcome)
+
+
+class TestUnansweredEvidence(_HealthyBaseline):
+    def test_stale_reacted_but_unanswered_message_confirms_the_bug(self) -> None:
+        old = timezone.now() - dt.timedelta(minutes=30)
+        PendingChatInjection.objects.create(
+            overlay="acme",
+            channel="D1",
+            slack_ts="1.1",
+            text="please answer this",
+            received_at=old,
+            eyes_reacted_at=old,
+        )
+        outcome = run_slack_roundtrip_probes(env={"TEATREE_ROLE": "worker"})
+        assert not outcome.ok
+        assert "reacts-but-never-answers CONFIRMED" in _messages(outcome)
+
+    def test_recently_reacted_message_does_not_false_alarm(self) -> None:
+        now = timezone.now()
+        PendingChatInjection.objects.create(
+            overlay="acme",
+            channel="D1",
+            slack_ts="2.2",
+            text="please answer this",
+            received_at=now,
+            eyes_reacted_at=now,
+        )
+        outcome = run_slack_roundtrip_probes(env={"TEATREE_ROLE": "worker"})
+        assert outcome.ok
+
+    def test_answered_message_is_not_flagged(self) -> None:
+        old = timezone.now() - dt.timedelta(minutes=30)
+        PendingChatInjection.objects.create(
+            overlay="acme",
+            channel="D1",
+            slack_ts="3.3",
+            text="please answer this",
+            received_at=old,
+            eyes_reacted_at=old,
+            loop_replied_at=old,
+        )
+        outcome = run_slack_roundtrip_probes(env={"TEATREE_ROLE": "worker"})
+        assert outcome.ok
+
+
+class TestDeepRoundtrip(_HealthyBaseline):
+    def test_live_auth_test_ok(self) -> None:
+        outcome = run_slack_roundtrip_probes(deep=True, env={"TEATREE_ROLE": "worker"})
+        assert outcome.ok
+        assert any("live Slack auth.test ok" in f.message for f in outcome.findings)
+
+    def test_live_auth_test_not_ok_fails(self) -> None:
+        self._backend._auth_body = {"ok": False, "error": "invalid_auth"}
+        outcome = run_slack_roundtrip_probes(deep=True, env={"TEATREE_ROLE": "worker"})
+        assert not outcome.ok
+        assert "live Slack auth.test returned not-ok" in _messages(outcome)
+
+    def test_live_auth_test_raise_fails(self) -> None:
+        self._backend._auth_raises = RuntimeError("boom")
+        outcome = run_slack_roundtrip_probes(deep=True, env={"TEATREE_ROLE": "worker"})
+        assert not outcome.ok
+        assert "live Slack auth.test FAILED" in _messages(outcome)
+
+    def test_default_mode_skips_the_live_probe(self) -> None:
+        outcome = run_slack_roundtrip_probes(deep=False, env={"TEATREE_ROLE": "worker"})
+        assert not any("auth.test" in f.message for f in outcome.findings)
+
+
+class TestRenderAndGate(_HealthyBaseline):
+    def test_check_renders_each_finding_and_returns_verdict(self) -> None:
+        self.resolve_user_id.return_value = ""
+        lines: list[str] = []
+        ok = check_slack_roundtrip(env={"TEATREE_ROLE": "worker"}, echo=lines.append)
+        assert ok is False
+        assert any("Slack round-trip:" in line and "FAIL" in line for line in lines)
+
+    def test_check_is_crash_proof(self) -> None:
+        lines: list[str] = []
+        with patch(
+            "teatree.cli.slack.provision._slack_overlays",
+            side_effect=RuntimeError("boom"),
+        ):
+            ok = check_slack_roundtrip(echo=lines.append)
+        assert ok is True  # a check bug degrades to OK, never crashes/reddens the run
+        assert any("crashed" in line for line in lines)

--- a/tests/teatree_cli/doctor/test_self_heal.py
+++ b/tests/teatree_cli/doctor/test_self_heal.py
@@ -306,13 +306,15 @@ class DoctorJsonSurfaceTest(TestCase):
 
         captured: dict[str, bool] = {}
 
-        def _run_checks(*, repair: bool = False) -> bool:
+        def _run_checks(*, repair: bool = False, slack_roundtrip: bool = False) -> bool:
             captured["repair"] = repair
+            captured["slack_roundtrip"] = slack_roundtrip
             return True
 
         with mock.patch.object(doctor_app_mod, "run_doctor_checks", side_effect=_run_checks):
             result = CliRunner().invoke(cli_app, ["doctor", "check", "--json"])
         assert captured["repair"] is False
+        assert captured["slack_roundtrip"] is False
         assert result.exit_code == 0
 
     def test_json_with_repair_threads_repair_true(self) -> None:
@@ -321,13 +323,31 @@ class DoctorJsonSurfaceTest(TestCase):
 
         captured: dict[str, bool] = {}
 
-        def _run_checks(*, repair: bool = False) -> bool:
+        def _run_checks(*, repair: bool = False, slack_roundtrip: bool = False) -> bool:
             captured["repair"] = repair
+            captured["slack_roundtrip"] = slack_roundtrip
             return True
 
         with mock.patch.object(doctor_app_mod, "run_doctor_checks", side_effect=_run_checks):
             CliRunner().invoke(cli_app, ["doctor", "check", "--json", "--repair"])
         assert captured["repair"] is True
+        assert captured["slack_roundtrip"] is False
+
+    def test_json_with_slack_roundtrip_threads_true(self) -> None:
+        """`--json --slack-roundtrip` threads `slack_roundtrip=True` without disturbing `repair` (#3411)."""
+        import teatree.cli.doctor.app as doctor_app_mod  # noqa: PLC0415
+
+        captured: dict[str, bool] = {}
+
+        def _run_checks(*, repair: bool = False, slack_roundtrip: bool = False) -> bool:
+            captured["repair"] = repair
+            captured["slack_roundtrip"] = slack_roundtrip
+            return True
+
+        with mock.patch.object(doctor_app_mod, "run_doctor_checks", side_effect=_run_checks):
+            CliRunner().invoke(cli_app, ["doctor", "check", "--json", "--slack-roundtrip"])
+        assert captured["slack_roundtrip"] is True
+        assert captured["repair"] is False
 
     def test_check_without_json_does_not_route_to_json(self) -> None:
         with (

--- a/tests/teatree_cli/test_capabilities.py
+++ b/tests/teatree_cli/test_capabilities.py
@@ -39,6 +39,7 @@ def _switch_handler_params() -> dict[str, set[str]]:
     from teatree.cli import info as cli_info  # noqa: PLC0415
     from teatree.cli import tokens as cli_tokens  # noqa: PLC0415
     from teatree.cli.config import show as cli_config_show  # noqa: PLC0415
+    from teatree.cli.doctor import app as cli_doctor_app  # noqa: PLC0415 — lazy: no Django bootstrap at module import
     from teatree.core.management.commands import (  # noqa: PLC0415
         availability,
         checking,
@@ -72,6 +73,7 @@ def _switch_handler_params() -> dict[str, set[str]]:
         # replaces the class ``handle`` attribute with a generic wrapper, so its
         # real params live on the registered typer callback, not on ``Command.handle``.
         "teatree do": do.Command.typer_app.registered_commands[0].callback,
+        "doctor check": cli_doctor_app.check,
         "cost": cli_cost.cost,
         "tokens": cli_tokens.tokens,
         "config show": cli_config_show,

--- a/tests/teatree_core/management_commands/test_e2e.py
+++ b/tests/teatree_core/management_commands/test_e2e.py
@@ -256,6 +256,16 @@ class TestE2eRunWorkItem(TestCase):
     provenance on the durable recipe.
     """
 
+    def setUp(self) -> None:
+        # ``run_work_item`` sets ``os.environ["T3_ORIG_CWD"]`` as a live-process
+        # side effect (fine for the short-lived CLI, a cross-test leak under
+        # pytest). Snapshot + restore the whole environment around each test so
+        # the addition is stripped afterwards and never pollutes a shared shard.
+        super().setUp()
+        env_patch = patch.dict(os.environ, clear=False)
+        env_patch.start()
+        self.addCleanup(env_patch.stop)
+
     def _git(self, path: Path, *args: str) -> None:
         subprocess.run([_GIT, "-C", str(path), *args], check=True, capture_output=True, text=True)
 


### PR DESCRIPTION
Closes #3411. t3 doctor gate detecting reacts-but-never-answers: outbound backend + resolve_user_id non-empty + listener flock live + inbox loop enabled/unmasked + no stale reacted-but-unanswered PendingChatInjection. --slack-roundtrip deep mode with live auth.test.