### PR TITLE
feat(handover): unique mirror filenames + orchestrator fast-push before termination (directives #7 #8)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -8529,13 +8529,26 @@ Usage: t3 teatree handover create [OPTIONS]
 
  No ``--to`` → the live ``t3-master`` slot holder; if none, parked
  for whichever session starts next. Always persists the
- :class:`SessionHandover` row AND mirrors it to the XDG file.
+ :class:`SessionHandover` row AND mirrors it to the XDG file. Then, per
+ directive #8, drives every in-flight sub-agent worktree through
+ leak-gated fast-push so their work is committed/pushed/PR'd BEFORE the
+ orchestrator terminates them.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --to          TEXT  Target session id. Omit to hand to the live loop owner,  │
-│                     else park for next.                                      │
-│ --json              Emit JSON.                                               │
-│ --help              Show this message and exit.                              │
+│ --to                                         TEXT  Target session id. Omit   │
+│                                                    to hand to the live loop  │
+│                                                    owner, else park for      │
+│                                                    next.                     │
+│ --drive-subagents    --no-drive-subagents          Fast-push in-flight       │
+│                                                    sub-agent worktrees       │
+│                                                    before they are           │
+│                                                    terminated (directive     │
+│                                                    #8).                      │
+│                                                    [default:                 │
+│                                                    drive-subagents]          │
+│ --json                                             Emit JSON.                │
+│ --help                                             Show this message and     │
+│                                                    exit.                     │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/core/handover.py
+++ b/src/teatree/core/handover.py
@@ -20,7 +20,10 @@ Target resolution (``create``):
 - otherwise ``""`` — parked for whichever session starts next to claim.
 """
 
+import contextlib
 import os
+import re
+import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -31,6 +34,8 @@ if TYPE_CHECKING:
 
 _SNAPSHOT_PREFIX = "t3-snapshot-"
 _SNAPSHOT_SUFFIX = "-precompact.md"
+_MIRROR_PREFIX = "handover-"
+_MIRROR_SUFFIX = ".md"
 
 
 def _state_dir() -> Path:
@@ -85,18 +90,70 @@ def resolve_target_session(explicit_to: str) -> str:
 
 
 def mirror_path() -> Path:
-    """The configured XDG file mirror path for the latest hand-off."""
+    """The configured XDG ``latest`` pointer for the most-recent hand-off.
+
+    This is the stable, well-known path a human (or a bootstrapping session)
+    reads to find the newest hand-off. The actual content lives in a
+    per-session UNIQUE sibling file (:func:`unique_mirror_path`); this path is
+    kept as a pointer to that newest file so concurrent hand-offs never clobber
+    each other's content.
+    """
     return get_effective_settings().handover_mirror_path
 
 
-def write_mirror(handover: "SessionHandover", path: Path | None = None) -> Path:
-    """Mirror *handover* to the human-readable XDG file (overwrites the single ``latest.md``).
+def _mirror_slug(value: str) -> str:
+    """A filename-safe slug of a session id: ``[A-Za-z0-9._-]`` runs, collapsed."""
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", value).strip("-.")
+    return cleaned or "unknown"
 
-    Best-effort framing: the parent dir is created. A target of ``""``
+
+def unique_mirror_path(handover: "SessionHandover", *, directory: Path) -> Path:
+    """The collision-safe per-hand-off mirror file inside *directory*.
+
+    Keyed on the ``from_session`` id AND the row's own ``created_at`` (a
+    DB-assigned, deterministic timestamp — NOT wall-clock read at write time),
+    so re-mirroring the same row is idempotent while two *different*
+    concurrent hand-offs — from different sessions, or the same session at
+    different instants — never resolve to the same file. This is the fix for
+    the fixed-``latest.md`` clobber (directive #7).
+    """
+    stamp = handover.created_at.strftime("%Y%m%dT%H%M%S_%f")
+    return directory / f"{_MIRROR_PREFIX}{_mirror_slug(handover.from_session)}-{stamp}{_MIRROR_SUFFIX}"
+
+
+def _update_latest_pointer(pointer: Path, unique: Path) -> None:
+    """Point the well-known ``latest`` path at the newest unique mirror.
+
+    Prefers a relative symlink (``latest.md`` → ``handover-<sess>-<stamp>.md``)
+    so the pointer moves atomically to the newest file; falls back to copying
+    the content when the platform/filesystem refuses symlinks. Best-effort: a
+    pointer-update failure never loses the already-written unique content.
+    """
+    if pointer.resolve() == unique.resolve():
+        return
+    try:
+        if pointer.is_symlink() or pointer.exists():
+            pointer.unlink()
+        pointer.symlink_to(unique.name)
+    except OSError:
+        with contextlib.suppress(OSError):
+            shutil.copyfile(unique, pointer)
+
+
+def write_mirror(handover: "SessionHandover", path: Path | None = None) -> Path:
+    """Mirror *handover* to a UNIQUE per-session file; repoint ``latest`` at it.
+
+    *path* is the well-known ``latest`` pointer (default: :func:`mirror_path`).
+    The content is written to a collision-safe sibling (:func:`unique_mirror_path`)
+    so concurrent hand-offs from multiple sessions never clobber one another,
+    and the ``latest`` pointer is moved to the newest file. Returns the UNIQUE
+    content file (the durable artifact), not the pointer. A target of ``""``
     renders as ``next-session`` so the file always names a recipient.
     """
-    target = path or mirror_path()
-    target.parent.mkdir(parents=True, exist_ok=True)
+    pointer = path or mirror_path()
+    directory = pointer.parent
+    directory.mkdir(parents=True, exist_ok=True)
+    unique = unique_mirror_path(handover, directory=directory)
     recipient = handover.to_session or "next-session"
     header = (
         f"# Session hand-off\n\n"
@@ -105,8 +162,9 @@ def write_mirror(handover: "SessionHandover", path: Path | None = None) -> Path:
         f"- created: {handover.created_at.isoformat()}\n\n"
         "---\n\n"
     )
-    target.write_text(header + handover.payload + "\n", encoding="utf-8")
-    return target
+    unique.write_text(header + handover.payload + "\n", encoding="utf-8")
+    _update_latest_pointer(pointer, unique)
+    return unique
 
 
 def create_handover(*, from_session: str, explicit_to: str) -> "tuple[SessionHandover, Path]":

--- a/src/teatree/core/handover_orchestration.py
+++ b/src/teatree/core/handover_orchestration.py
@@ -1,0 +1,152 @@
+"""Directive #8 — drive in-flight sub-agent worktrees through fast-push before termination.
+
+When a session hands off (or the orchestrator shuts down), a sub-agent still
+holding unpushed work would otherwise be killed with that work stranded on a
+volatile worktree. This module is the coupling the directive asks for: the
+orchestrator enumerates the clone's sub-agent worktrees that still carry pending
+work and runs the leak-gated :class:`~teatree.core.fast_push.FastPusher` on each,
+so the work is committed, pushed, and PR-upserted FIRST — "everybody follows the
+command" before anyone is terminated.
+
+Best-effort and idempotent: a clean (synced) worktree is skipped, the
+orchestrator's own worktree is excluded, and a push failure on one worktree is
+recorded and never blocks the others or the hand-off itself. The leak gates live
+inside ``FastPusher``, so nothing here can bypass them.
+"""
+
+import logging
+from collections.abc import Callable, Iterator, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from teatree.core.fast_push import FastPusher, FastPushOutcome
+from teatree.utils.git import WorktreeRecord, default_branch, list_worktrees, log_oneline, run, status_porcelain
+
+logger = logging.getLogger(__name__)
+
+_SUBAGENT_WORKTREES_DIRNAME = "worktrees"
+_SUBAGENT_PARENT_DIRNAME = ".claude"
+_SUBAGENT_DIR_PREFIX = "agent-"
+
+
+class _RunsFastPush(Protocol):
+    def run(self) -> FastPushOutcome: ...  # pragma: no branch
+
+
+PusherFactory = Callable[[Path], _RunsFastPush]
+
+
+@dataclass(frozen=True, slots=True)
+class SubagentPush:
+    """The outcome of driving one sub-agent worktree through fast-push."""
+
+    worktree: Path
+    branch: str
+    driven: bool
+    outcome: FastPushOutcome | None = None
+    error: str = ""
+
+
+def _is_subagent_worktree(path: Path) -> bool:
+    """True iff *path* is a spawned sub-agent worktree (``.claude/worktrees/agent-*``).
+
+    The orchestrator's OWN checkout and any human/ticket worktree live elsewhere;
+    only a direct ``agent-``-prefixed child of ``.claude/worktrees`` is a spawned
+    sub-agent whose unpushed work the hand-off must rescue.
+    """
+    return (
+        path.name.startswith(_SUBAGENT_DIR_PREFIX)
+        and path.parent.name == _SUBAGENT_WORKTREES_DIRNAME
+        and path.parent.parent.name == _SUBAGENT_PARENT_DIRNAME
+    )
+
+
+def _push_base(path: Path) -> str:
+    """The ref a push would advance past: the upstream, else ``origin/<default>``.
+
+    ``""`` when neither resolves (a repo with no default branch), which the
+    caller reads as "no unpushed commits provable" → skip.
+    """
+    upstream = run(repo=str(path), args=["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]).strip()
+    if upstream:
+        return upstream
+    try:
+        default = default_branch(str(path))
+    except (RuntimeError, ValueError):
+        return ""
+    return f"origin/{default}" if default else ""
+
+
+def _has_pending_work(path: Path) -> bool:
+    """True iff *path* has uncommitted changes OR commits not yet on the remote.
+
+    A dirty working tree is pending; so is a branch ahead of its push base
+    (unpushed commits, incl. a fresh feature branch that was never pushed). A
+    clean, fully-synced worktree has nothing to rescue and is skipped.
+    """
+    if status_porcelain(str(path)).strip():
+        return True
+    base = _push_base(path)
+    if not base:
+        return False
+    return bool(log_oneline(str(path), f"{base}..HEAD").strip())
+
+
+def in_flight_subagent_worktrees(repo: str = ".", *, exclude: Sequence[Path] = ()) -> Iterator[WorktreeRecord]:
+    """Yield the sub-agent worktrees of *repo*'s clone that still carry pending work.
+
+    Excludes any path in *exclude* (the orchestrator's own worktree) and every
+    non-sub-agent or clean worktree. Read-only enumeration over the single
+    ``git worktree list`` parse.
+    """
+    excluded = {p.resolve() for p in exclude}
+    for record in list_worktrees(repo):
+        path = record.path
+        if path.resolve() in excluded:
+            continue
+        if not _is_subagent_worktree(path):
+            continue
+        if not _has_pending_work(path):
+            continue
+        yield record
+
+
+def _default_pusher(worktree: Path) -> FastPusher:
+    message = f"chore(handover): fast-push checkpoint before termination ({worktree.name})"
+    return FastPusher(repo=worktree, message=message)
+
+
+def drive_subagents_to_fast_push(
+    repo: str = ".",
+    *,
+    exclude: Sequence[Path] = (),
+    pusher_factory: PusherFactory | None = None,
+) -> list[SubagentPush]:
+    """Drive every in-flight sub-agent worktree of *repo* through leak-gated fast-push.
+
+    The directive #8 coupling: called from the hand-off/shutdown seam so a
+    sub-agent's work is committed + pushed + PR-upserted BEFORE it can be
+    terminated. Each worktree is pushed independently and best-effort — a
+    failure on one is recorded on its :class:`SubagentPush` and never aborts the
+    rest. Returns one :class:`SubagentPush` per worktree acted on.
+    """
+    factory = pusher_factory or _default_pusher
+    pushes: list[SubagentPush] = []
+    for record in in_flight_subagent_worktrees(repo, exclude=exclude):
+        try:
+            outcome = factory(record.path).run()
+        except Exception as exc:
+            logger.exception("handover: fast-push failed for sub-agent worktree %s", record.path)
+            pushes.append(SubagentPush(worktree=record.path, branch=record.branch, driven=False, error=str(exc)))
+            continue
+        pushes.append(SubagentPush(worktree=record.path, branch=record.branch, driven=True, outcome=outcome))
+    return pushes
+
+
+__all__ = [
+    "PusherFactory",
+    "SubagentPush",
+    "drive_subagents_to_fast_push",
+    "in_flight_subagent_worktrees",
+]

--- a/src/teatree/core/management/commands/handover.py
+++ b/src/teatree/core/management/commands/handover.py
@@ -12,12 +12,14 @@ the project's "anything touching the ORM is a management command" rule.
 """
 
 import json
+from pathlib import Path
 from typing import Annotated
 
 import typer
 from django_typer.management import TyperCommand, command, initialize
 
 from teatree.core.handover import create_handover
+from teatree.core.handover_orchestration import SubagentPush, drive_subagents_to_fast_push
 from teatree.loop.session_identity import current_session_id
 
 
@@ -36,13 +38,23 @@ class Command(TyperCommand):
             str,
             typer.Option("--to", help="Target session id. Omit to hand to the live loop owner, else park for next."),
         ] = "",
+        drive_subagents: Annotated[
+            bool,
+            typer.Option(
+                "--drive-subagents/--no-drive-subagents",
+                help="Fast-push in-flight sub-agent worktrees before they are terminated (directive #8).",
+            ),
+        ] = True,
         json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
     ) -> None:
         """Hand this session's full durable state to another session.
 
         No ``--to`` → the live ``t3-master`` slot holder; if none, parked
         for whichever session starts next. Always persists the
-        :class:`SessionHandover` row AND mirrors it to the XDG file.
+        :class:`SessionHandover` row AND mirrors it to the XDG file. Then, per
+        directive #8, drives every in-flight sub-agent worktree through
+        leak-gated fast-push so their work is committed/pushed/PR'd BEFORE the
+        orchestrator terminates them.
         """
         from_session = current_session_id()
         if not from_session:
@@ -55,6 +67,7 @@ class Command(TyperCommand):
 
         handover, mirror = create_handover(from_session=from_session, explicit_to=to)
         recipient = handover.to_session or "next-session"
+        pushes = self._drive_subagents() if drive_subagents else []
         if json_output:
             self.stdout.write(
                 json.dumps(
@@ -64,12 +77,53 @@ class Command(TyperCommand):
                         "to_session": handover.to_session,
                         "parked_for_next": handover.is_for_next_session,
                         "mirror_path": str(mirror),
+                        "subagent_pushes": [self._push_json(push) for push in pushes],
                     },
                     indent=2,
                 )
             )
         else:
             self.stdout.write(f"OK    handed off to {recipient}; mirror written to {mirror}.")
+            for push in pushes:
+                self.stdout.write(f"      sub-agent {push.branch}: {self._push_summary(push)}")
+
+    def _drive_subagents(self) -> list[SubagentPush]:
+        """Fast-push in-flight sub-agent worktrees; a failure here never fails the hand-off.
+
+        The hand-off row + mirror are already durable, so the orchestration
+        step is best-effort: a git/network hiccup is logged and swallowed
+        rather than losing the recorded hand-off.
+        """
+        cwd = Path.cwd()
+        try:
+            return drive_subagents_to_fast_push(str(cwd), exclude=(cwd,))
+        except Exception:  # noqa: BLE001 — the hand-off is already persisted; sub-agent driving must not fail it
+            self.stderr.write(f"WARN  could not drive sub-agents to fast-push from {cwd} (hand-off still recorded).")
+            return []
+
+    @staticmethod
+    def _push_json(push: SubagentPush) -> dict[str, object]:
+        outcome = push.outcome
+        return {
+            "worktree": str(push.worktree),
+            "branch": push.branch,
+            "driven": push.driven,
+            "committed": bool(outcome and outcome.committed),
+            "pushed": bool(outcome and outcome.pushed),
+            "pr_url": outcome.pr_url if outcome else "",
+            "error": push.error,
+        }
+
+    @staticmethod
+    def _push_summary(push: SubagentPush) -> str:
+        if not push.driven:
+            return f"NOT pushed ({push.error or 'unknown error'})"
+        outcome = push.outcome
+        if outcome is None or not outcome.ok:
+            findings = "; ".join(f.detail for f in outcome.findings) if outcome else "no outcome"
+            return f"REFUSED ({findings})"
+        pr = f" PR {outcome.pr_url}" if outcome.pr_url else ""
+        return f"pushed (committed={outcome.committed}){pr}"
 
     @command()
     def whoami(

--- a/tests/quality/test_no_flat_core_regrowth.py
+++ b/tests/quality/test_no_flat_core_regrowth.py
@@ -62,7 +62,12 @@ _CORE_DIR = Path(__file__).resolve().parents[2] / "src" / "teatree" / "core"
 # with connector_preflight/connector_manifest/connector_keys; messaging_tokens with
 # send_proxy/notify/reply_transport; overlay_skills with overlay/overlay_loader/
 # overlay_metadata. None is owned by an existing subpackage.
-PINNED_FLAT_CORE_MODULES = 74
+# 75: +handover_orchestration.py (directive #8) — the hand-off/shutdown seam that
+# drives in-flight sub-agent worktrees through fast-push before termination. A
+# genuine new root concern bridging two flat root leaves — handover.py (the
+# hand-off record + mirror) and fast_push.py (the leak-gated ship lane) — owned by
+# no existing subpackage (merge/ is the keystone transition, not the hand-off seam).
+PINNED_FLAT_CORE_MODULES = 75
 
 
 def _flat_core_modules() -> list[str]:

--- a/tests/teatree_core/management_commands/test_handover.py
+++ b/tests/teatree_core/management_commands/test_handover.py
@@ -8,6 +8,8 @@ from io import StringIO
 import pytest
 from django.core.management import call_command
 
+from teatree.core.fast_push import FastPushOutcome
+from teatree.core.handover_orchestration import SubagentPush
 from teatree.core.models import LoopLease, SessionHandover
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
@@ -22,11 +24,20 @@ def _call(*args: str, **kwargs) -> str:
 
 @pytest.fixture(autouse=True)
 def _session(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
-    """Pin this 'session' id and isolate the snapshot dir + XDG mirror."""
+    """Pin this 'session' id and isolate the snapshot dir + XDG mirror.
+
+    Also stubs the directive-#8 sub-agent driver to a no-op so a hand-off in
+    the test process never fast-pushes the real repo's worktrees; the coupling
+    itself is asserted by ``TestHandoverDrivesSubagents`` with its own spy.
+    """
     monkeypatch.setenv("T3_LOOP_SESSION_ID", "this-session")
     monkeypatch.setenv("TEATREE_CLAUDE_STATUSLINE_STATE_DIR", str(tmp_path / "state"))
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "xdg"))
     (tmp_path / "state").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(
+        "teatree.core.management.commands.handover.drive_subagents_to_fast_push",
+        lambda *a, **k: [],
+    )
 
 
 class TestHandoverCreate:
@@ -62,6 +73,49 @@ class TestHandoverCreate:
         monkeypatch.setenv("T3_LOOP_REGISTRY_DIR", "/nonexistent-registry-dir")
         with pytest.raises(SystemExit):
             _call("handover", "create", json_output=True)
+
+
+class TestHandoverDrivesSubagents:
+    """Directive #8 — ``handover create`` drives in-flight sub-agents through fast-push."""
+
+    def test_create_invokes_the_subagent_driver_and_surfaces_pushes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[tuple] = []
+
+        def _spy(repo: str, **kwargs) -> list[SubagentPush]:
+            calls.append((repo, kwargs))
+            outcome = FastPushOutcome(ok=True, branch="feat/x", committed=True, pushed=True, pr_url="http://pr/1")
+            return [SubagentPush(worktree=pathlib.Path("/wt/agent-x"), branch="feat/x", driven=True, outcome=outcome)]
+
+        monkeypatch.setattr("teatree.core.management.commands.handover.drive_subagents_to_fast_push", _spy)
+
+        data = json.loads(_call("handover", "create", json_output=True))
+
+        assert calls, "handover create must drive sub-agents to fast-push (directive #8)"
+        pushes = data["subagent_pushes"]
+        assert pushes[0]["branch"] == "feat/x"
+        assert pushes[0]["pushed"] is True
+        assert pushes[0]["pr_url"] == "http://pr/1"
+
+    def test_no_drive_subagents_flag_skips_the_driver(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list = []
+        monkeypatch.setattr(
+            "teatree.core.management.commands.handover.drive_subagents_to_fast_push",
+            lambda *a, **k: calls.append((a, k)) or [],
+        )
+        data = json.loads(_call("handover", "create", drive_subagents=False, json_output=True))
+        assert calls == []
+        assert data["subagent_pushes"] == []
+
+    def test_driver_failure_never_fails_the_handover(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _boom(*_a, **_k) -> list:
+            msg = "git exploded"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr("teatree.core.management.commands.handover.drive_subagents_to_fast_push", _boom)
+        data = json.loads(_call("handover", "create", json_output=True))
+        assert data["ok"] is True
+        assert data["subagent_pushes"] == []
+        assert SessionHandover.objects.count() == 1
 
 
 class TestHandoverWhoami:

--- a/tests/teatree_core/test_handover_orchestration.py
+++ b/tests/teatree_core/test_handover_orchestration.py
@@ -1,0 +1,156 @@
+"""Directive #8 — orchestrator drives in-flight sub-agent worktrees through fast-push.
+
+Real git clones + linked worktrees under ``tmp_path`` (a local bare ``origin``);
+only the fast-pusher itself is faked (a recorder), so the enumeration + pending-work
+predicates run against real ``git worktree list`` / ``git status`` output.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from teatree.core.fast_push import FastPushOutcome
+from teatree.core.handover_orchestration import (
+    _has_pending_work,
+    _is_subagent_worktree,
+    drive_subagents_to_fast_push,
+    in_flight_subagent_worktrees,
+)
+from teatree.utils.run import run_checked
+
+
+@dataclass
+class RecordingPusher:
+    """A fake FastPusher: records the worktree it was built for, returns an OK outcome."""
+
+    worktree: Path
+    seen: list[Path]
+
+    def run(self) -> FastPushOutcome:
+        self.seen.append(self.worktree.resolve())
+        return FastPushOutcome(ok=True, branch=self.worktree.name, committed=True, pushed=True)
+
+
+@dataclass
+class PusherFactoryRecorder:
+    seen: list[Path] = field(default_factory=list)
+
+    def __call__(self, worktree: Path) -> RecordingPusher:
+        return RecordingPusher(worktree=worktree, seen=self.seen)
+
+
+def _git(*args: str, cwd: Path) -> None:
+    run_checked(["git", *args], cwd=cwd)
+
+
+@pytest.fixture
+def clone(tmp_path: Path) -> Path:
+    """A clone with a pushed ``main`` and ``origin/HEAD`` set, ready for worktrees."""
+    origin = tmp_path / "origin.git"
+    run_checked(["git", "init", "--bare", str(origin)])
+    work = tmp_path / "clone"
+    run_checked(["git", "init", "-b", "main", str(work)])
+    _git("config", "user.email", "agent@users.noreply.github.com", cwd=work)
+    _git("config", "user.name", "agent", cwd=work)
+    _git("remote", "add", "origin", str(origin), cwd=work)
+    (work / "README.md").write_text("seed\n")
+    _git("add", "-A", cwd=work)
+    _git("commit", "-m", "seed", cwd=work)
+    _git("push", "-u", "origin", "main", cwd=work)
+    _git("remote", "set-head", "origin", "main", cwd=work)
+    return work
+
+
+def _add_subagent_worktree(clone: Path, base: Path, name: str, branch: str) -> Path:
+    path = base / ".claude" / "worktrees" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _git("worktree", "add", "-b", branch, str(path), "main", cwd=clone)
+    return path
+
+
+class TestIsSubagentWorktree:
+    def test_agent_dir_under_claude_worktrees_is_a_subagent(self, tmp_path: Path) -> None:
+        assert _is_subagent_worktree(tmp_path / ".claude" / "worktrees" / "agent-abc")
+
+    def test_non_agent_prefixed_dir_is_not(self, tmp_path: Path) -> None:
+        assert not _is_subagent_worktree(tmp_path / ".claude" / "worktrees" / "ticket-123")
+
+    def test_agent_dir_elsewhere_is_not(self, tmp_path: Path) -> None:
+        assert not _is_subagent_worktree(tmp_path / "somewhere" / "agent-abc")
+
+
+class TestHasPendingWork:
+    def test_dirty_tree_is_pending(self, clone: Path, tmp_path: Path) -> None:
+        wt = _add_subagent_worktree(clone, tmp_path, "agent-dirty", "feat/dirty")
+        (wt / "scratch.txt").write_text("uncommitted\n")
+        assert _has_pending_work(wt)
+
+    def test_clean_synced_worktree_is_not_pending(self, clone: Path, tmp_path: Path) -> None:
+        wt = _add_subagent_worktree(clone, tmp_path, "agent-clean", "feat/clean")
+        assert not _has_pending_work(wt)
+
+    def test_unpushed_commit_beyond_default_is_pending(self, clone: Path, tmp_path: Path) -> None:
+        wt = _add_subagent_worktree(clone, tmp_path, "agent-ahead", "feat/ahead")
+        (wt / "new.txt").write_text("work\n")
+        _git("add", "-A", cwd=wt)
+        _git("commit", "-m", "unpushed work", cwd=wt)
+        assert _has_pending_work(wt)
+
+    def test_ahead_of_upstream_is_pending(self, clone: Path, tmp_path: Path) -> None:
+        wt = _add_subagent_worktree(clone, tmp_path, "agent-up", "feat/up")
+        _git("push", "-u", "origin", "feat/up", cwd=wt)
+        (wt / "more.txt").write_text("more\n")
+        _git("add", "-A", cwd=wt)
+        _git("commit", "-m", "beyond upstream", cwd=wt)
+        assert _has_pending_work(wt)
+
+
+class TestDriveSubagents:
+    def test_drives_only_pending_subagents_and_excludes_self(self, clone: Path, tmp_path: Path) -> None:
+        dirty = _add_subagent_worktree(clone, tmp_path, "agent-dirty", "feat/dirty")
+        (dirty / "scratch.txt").write_text("uncommitted\n")
+        _add_subagent_worktree(clone, tmp_path, "agent-clean", "feat/clean")  # clean+synced → skipped
+        # A dirty NON-sub-agent worktree must be left alone.
+        non_agent = tmp_path / "other" / "ticket-1"
+        non_agent.parent.mkdir(parents=True, exist_ok=True)
+        _git("worktree", "add", "-b", "feat/ticket", str(non_agent), "main", cwd=clone)
+        (non_agent / "scratch.txt").write_text("dirty\n")
+
+        recorder = PusherFactoryRecorder()
+        pushes = drive_subagents_to_fast_push(str(clone), exclude=(clone,), pusher_factory=recorder)
+
+        driven_paths = {p.worktree.resolve() for p in pushes}
+        assert driven_paths == {dirty.resolve()}
+        assert recorder.seen == [dirty.resolve()]
+        assert all(p.driven for p in pushes)
+
+    def test_excludes_the_orchestrators_own_worktree(self, clone: Path, tmp_path: Path) -> None:
+        self_wt = _add_subagent_worktree(clone, tmp_path, "agent-self", "feat/self")
+        (self_wt / "scratch.txt").write_text("uncommitted\n")
+
+        recorder = PusherFactoryRecorder()
+        pushes = drive_subagents_to_fast_push(str(clone), exclude=(self_wt,), pusher_factory=recorder)
+
+        assert pushes == []
+        assert recorder.seen == []
+
+    def test_a_pusher_failure_is_recorded_not_raised(self, clone: Path, tmp_path: Path) -> None:
+        dirty = _add_subagent_worktree(clone, tmp_path, "agent-boom", "feat/boom")
+        (dirty / "scratch.txt").write_text("uncommitted\n")
+
+        def _explode(_worktree: Path) -> RecordingPusher:
+            msg = "push failed"
+            raise RuntimeError(msg)
+
+        pushes = drive_subagents_to_fast_push(str(clone), exclude=(clone,), pusher_factory=_explode)
+
+        assert len(pushes) == 1
+        assert pushes[0].driven is False
+        assert "push failed" in pushes[0].error
+
+    def test_enumeration_yields_pending_subagents(self, clone: Path, tmp_path: Path) -> None:
+        dirty = _add_subagent_worktree(clone, tmp_path, "agent-e", "feat/e")
+        (dirty / "scratch.txt").write_text("uncommitted\n")
+        records = list(in_flight_subagent_worktrees(str(clone), exclude=(clone,)))
+        assert [r.path.resolve() for r in records] == [dirty.resolve()]

--- a/tests/teatree_core/test_handover_service.py
+++ b/tests/teatree_core/test_handover_service.py
@@ -62,21 +62,61 @@ class TestResolveTargetSession(TestCase):
 class TestWriteMirror(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.target = Path(self.enterContext(_tmp_env("XDG_STATE_HOME"))) / "m.md"
+        # ``pointer`` is the well-known ``latest`` path; content lands in a unique sibling.
+        self.pointer = Path(self.enterContext(_tmp_env("XDG_STATE_HOME"))) / "latest.md"
 
-    def test_mirror_writes_payload_and_recipient(self) -> None:
+    def test_mirror_writes_payload_to_unique_file_and_repoints_latest(self) -> None:
         row = SessionHandover.objects.create_handover(from_session="a", to_session="b", payload="BODY")
-        written = handover.write_mirror(row, self.target)
-        assert written == self.target
-        text = self.target.read_text(encoding="utf-8")
+        written = handover.write_mirror(row, self.pointer)
+        # Content lives in a UNIQUE per-session file, not the fixed pointer.
+        assert written != self.pointer
+        assert written.name.startswith("handover-")
+        assert "a" in written.name
+        text = written.read_text(encoding="utf-8")
         assert "from: `a`" in text
         assert "to: `b`" in text
         assert "BODY" in text
+        # ``latest`` resolves to the same content the unique file holds.
+        assert self.pointer.read_text(encoding="utf-8") == text
 
     def test_next_session_renders_as_next_session(self) -> None:
         row = SessionHandover.objects.create_handover(from_session="a", to_session="", payload="BODY")
-        handover.write_mirror(row, self.target)
-        assert "to: `next-session`" in self.target.read_text(encoding="utf-8")
+        written = handover.write_mirror(row, self.pointer)
+        assert "to: `next-session`" in written.read_text(encoding="utf-8")
+
+
+class TestUniqueMirrorNoClobber(TestCase):
+    """Directive #7 — concurrent hand-offs from different sessions must not clobber."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.pointer = Path(self.enterContext(_tmp_env("XDG_STATE_HOME"))) / "latest.md"
+
+    def test_two_concurrent_handoffs_write_distinct_files(self) -> None:
+        first = SessionHandover.objects.create_handover(from_session="sess-A", to_session="x", payload="FROM-A")
+        second = SessionHandover.objects.create_handover(from_session="sess-B", to_session="y", payload="FROM-B")
+
+        first_file = handover.write_mirror(first, self.pointer)
+        second_file = handover.write_mirror(second, self.pointer)
+
+        assert first_file != second_file
+        assert first_file.read_text(encoding="utf-8").find("FROM-A") != -1
+        assert second_file.read_text(encoding="utf-8").find("FROM-B") != -1
+        # The first session's mirror survived the second hand-off (no clobber).
+        assert "FROM-A" in first_file.read_text(encoding="utf-8")
+
+    def test_latest_pointer_tracks_the_newest_handover(self) -> None:
+        first = SessionHandover.objects.create_handover(from_session="sess-A", to_session="x", payload="FROM-A")
+        second = SessionHandover.objects.create_handover(from_session="sess-B", to_session="y", payload="FROM-B")
+
+        handover.write_mirror(first, self.pointer)
+        handover.write_mirror(second, self.pointer)
+
+        assert "FROM-B" in self.pointer.read_text(encoding="utf-8")
+
+    def test_remirroring_same_row_is_idempotent(self) -> None:
+        row = SessionHandover.objects.create_handover(from_session="sess-A", to_session="x", payload="BODY")
+        assert handover.write_mirror(row, self.pointer) == handover.write_mirror(row, self.pointer)
 
 
 class TestCreateHandover(TestCase):


### PR DESCRIPTION
Materializes directives #7 #8. #7: write_mirror writes unique per-session handover-<session>-<created_at>.md + latest symlink (no clobber on concurrent handoffs). #8: handover_orchestration.drive_subagents_to_fast_push runs leak-gated FastPusher on in-flight sub-agent worktrees before termination; coupled into handover create (--no-drive-subagents opt-out).