### PR TITLE
fix(dream): decode transcript content so cluster citations ground (materializes memory-consolidation)

### DIFF
--- a/src/teatree/loops/dream/engine.py
+++ b/src/teatree/loops/dream/engine.py
@@ -489,8 +489,33 @@ def write_clusters(
     return WriteOutcome(written=written, rejected=rejected)
 
 
+#: Unicode punctuation folded to its ASCII equivalent before the grounding
+#: substring test. A decoded transcript may carry a smart quote / em-dash where the
+#: model's citation used the straight form (or the reverse), so both operands are
+#: folded SYMMETRICALLY (:func:`normalize_ws` runs on the snippet index AND on the
+#: citation). This stays a strict substring test — a canonical form on both sides,
+#: never a fuzzy / token-overlap match — so an invented citation is still rejected.
+_PUNCT_FOLD = str.maketrans(
+    {
+        "\u2018": "'",  # left single quotation mark
+        "\u2019": "'",  # right single quotation mark
+        "\u201a": "'",  # single low-9 quotation mark
+        "\u201b": "'",  # single high-reversed-9 quotation mark
+        "\u201c": '"',  # left double quotation mark
+        "\u201d": '"',  # right double quotation mark
+        "\u201e": '"',  # double low-9 quotation mark
+        "\u201f": '"',  # double high-reversed-9 quotation mark
+        "\u2013": "-",  # en dash
+        "\u2014": "-",  # em dash
+        "\u2015": "-",  # horizontal bar
+        "\u2212": "-",  # minus sign
+        "\u2026": "...",  # horizontal ellipsis
+    }
+)
+
+
 def normalize_ws(text: str) -> str:
-    return " ".join(text.split())
+    return " ".join(text.translate(_PUNCT_FOLD).split())
 
 
 def cluster_is_grounded(cluster: DistilledCluster, snippet_texts: dict[str, str]) -> bool:

--- a/src/teatree/loops/dream/transcript_extract.py
+++ b/src/teatree/loops/dream/transcript_extract.py
@@ -23,9 +23,11 @@ Without these keepers the keyword gate filtered fresh user-correction and user-a
 prose out before the distiller ever saw it — the gap this module closes.
 """
 
+import json
 import re
 from collections import Counter
 from collections.abc import Sequence
+from typing import Any, cast
 
 #: Transcript lines worth keeping on keyword alone — the rest is chatter that
 #: must never reach the LLM prompt. Necessary-not-sufficient: a line also
@@ -211,7 +213,7 @@ def high_signal_lines(raw: str) -> str:
     lines = raw.splitlines()
     repeated = _repeated_user_turns(lines)
     kept = [
-        line
+        decode_transcript_line(line)
         for line in lines
         if any(signal in line for signal in TRANSCRIPT_SIGNALS)
         or looks_like_user_correction(line)
@@ -220,6 +222,121 @@ def high_signal_lines(raw: str) -> str:
         or line.strip() in repeated
     ]
     return "\n".join(kept)
+
+
+#: Message-envelope ``type`` / ``role`` values whose content is human prose the
+#: distiller cites. A line carrying one of these is decoded to readable text; any
+#: other line (a queue-operation, an attachment, a non-JSON marker) is passed
+#: through verbatim.
+_ROLE_MESSAGE_TYPES = frozenset({"user", "assistant"})
+
+
+def _as_mapping(value: object) -> dict[str, Any] | None:
+    """A JSON object as a ``str``-keyed mapping, or ``None`` — the one ``Any`` chokepoint.
+
+    ``json.loads`` is untyped, so every decoded value arrives as ``object``. Narrowing
+    it here (once) keeps the ``Any`` confined to this helper and lets every caller stay
+    strictly typed against ``dict[str, Any]``.
+    """
+    return cast("dict[str, Any]", value) if isinstance(value, dict) else None
+
+
+def _as_text(value: object) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _message_role(obj: dict[str, Any]) -> str | None:
+    """The ``user`` / ``assistant`` role of a transcript object, across envelope shapes."""
+    kind = obj.get("type")
+    if isinstance(kind, str) and kind in _ROLE_MESSAGE_TYPES:
+        return kind
+    message = _as_mapping(obj.get("message"))
+    if message is not None:
+        role = message.get("role")
+        if isinstance(role, str) and role in _ROLE_MESSAGE_TYPES:
+            return role
+    role = obj.get("role")
+    if isinstance(role, str) and role in _ROLE_MESSAGE_TYPES:
+        return role
+    return None
+
+
+def _stringify_block(block: object) -> str:
+    """Flatten one content block to its human-readable text, adding no re-escaping.
+
+    ``text`` / ``thinking`` blocks carry the prose a citation quotes; a
+    ``tool_result`` recurses into its (already-decoded) content so a gate BLOCK /
+    DENIED reason survives; a ``tool_use`` contributes only its bare tool name so no
+    JSON-escaped input payload re-enters the decoded stream.
+    """
+    if isinstance(block, str):
+        return block
+    mapping = _as_mapping(block)
+    if mapping is None:
+        return ""
+    block_type = mapping.get("type")
+    if block_type in {"text", "thinking"}:
+        return _as_text(mapping.get("text") or mapping.get("thinking") or "")
+    if block_type == "tool_result":
+        return _stringify_content(mapping.get("content"))
+    if block_type == "tool_use":
+        return _as_text(mapping.get("name"))
+    return _as_text(mapping.get("text"))
+
+
+def _stringify_content(content: object) -> str:
+    """Flatten a message ``content`` (string, or a list of content blocks) to text."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(part for part in (_stringify_block(block) for block in content) if part)
+    return ""
+
+
+def _flatten_message_text(obj: dict[str, Any]) -> str:
+    """The decoded, human-readable text of a transcript message across envelope shapes."""
+    message = _as_mapping(obj.get("message"))
+    source = message.get("content") if message is not None else obj.get("content")
+    parts = [_stringify_content(source)]
+    text = obj.get("text")
+    if isinstance(text, str):
+        parts.append(text)
+    return " ".join(part for part in parts if part).strip()
+
+
+def decode_transcript_line(line: str) -> str:
+    r"""Render one raw JSONL transcript line as decoded, single-line human text.
+
+    Signal DETECTION runs on the RAW escaped JSONL (:func:`high_signal_lines` — the
+    regexes need the JSON envelope), but the distiller prompt and the grounding index
+    must share ONE decoded representation: a model quotes the human-readable content
+    it is shown as its verbatim citation, and that citation can only be a substring of
+    the grounding snippet when the snippet holds the SAME decoded form. A raw line
+    keeps JSON escapes (``\u2014`` for an em-dash, ``\"`` for ``"``, ``\n`` for a
+    newline), so the decoded citation is never a substring of it — the mismatch that
+    rejected every transcript-cited cluster as ungrounded.
+
+    A user/assistant turn is flattened to ``{"role": "<role>"} <text>`` on a SINGLE
+    line: the JSON role tag is retained so the per-line role heuristics
+    (:func:`looks_like_user_correction` / :func:`looks_like_user_ask`, reused by the
+    ``compliance`` and weight paths) keep working on the decoded stream, and the
+    content is JSON-decoded so a citation grounds. A line that does not parse, is not
+    a role message, or carries no extractable text is returned verbatim, so a plain
+    signal marker still passes through unchanged.
+    """
+    try:
+        obj = _as_mapping(json.loads(line))
+    except (ValueError, TypeError):
+        return line
+    if obj is None:
+        return line
+    role = _message_role(obj)
+    if role is None:
+        return line
+    text = _flatten_message_text(obj)
+    if not text:
+        return line
+    return f'{{"role": "{role}"}} {" ".join(text.split())}'
 
 
 def user_ask_lines(raw: str) -> str:
@@ -235,6 +352,7 @@ def user_ask_lines(raw: str) -> str:
 
 __all__ = [
     "TRANSCRIPT_SIGNALS",
+    "decode_transcript_line",
     "high_signal_lines",
     "looks_like_learning",
     "looks_like_user_ask",

--- a/tests/teatree_loops/dream/test_engine.py
+++ b/tests/teatree_loops/dream/test_engine.py
@@ -1,10 +1,12 @@
 """Tests for the dream distillation engine SEAM (#1933)."""
 
+import json
 import os
 import tempfile
 import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import ClassVar
 from unittest.mock import patch
 
 import pytest
@@ -22,7 +24,9 @@ from teatree.loops.dream.engine import (
     WeightedSnippet,
     WriteOutcome,
     build_extract,
+    cluster_is_grounded,
     enumerate_members,
+    normalize_ws,
     run_consolidation,
     write_clusters,
 )
@@ -586,6 +590,140 @@ class CorrectionProseProducesGroundedClusterTestCase(TestCase):
             run_consolidation(overlay="", since=None, dry_run=False, distiller=_distill)
 
         assert ConsolidatedMemory.objects.filter(cluster_key="learning").count() == 1
+
+
+class EscapedJsonlCitationGroundsTestCase(TestCase):
+    r"""A citation of a real .jsonl turn grounds once transcript content is decoded (#1933).
+
+    A raw session ``.jsonl`` line JSON-escapes its content — an em-dash is ``\u2014``,
+    an inner quote is ``\"``, a newline is ``\n``. The distiller reads the DECODED
+    human text and quotes it verbatim, so before the extract shared that one decoded
+    form the decoded citation was never a substring of the escaped snippet and every
+    transcript-cited cluster was rejected as ungrounded. These tests pin the decoded
+    representation AND prove the anti-hallucination substring gate still has teeth.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+
+    @staticmethod
+    def _realistic_session_jsonl() -> str:
+        """A byte-for-byte realistic session transcript: content is JSON-escaped."""
+        return "\n".join(
+            json.dumps(obj)
+            for obj in (
+                {"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "noise"}]}},
+                {
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": 'stop — do not build a new "banner" again\nI told you not to',
+                    },
+                },
+            )
+        )
+
+    def _member(self) -> TranscriptMember:
+        path = self.tmp / "session.jsonl"
+        path.write_text(self._realistic_session_jsonl())
+        return TranscriptMember(path=path, kind="main")
+
+    def test_fixture_is_genuinely_escaped_on_disk(self) -> None:
+        # Guards the test itself: if the fixture stopped escaping, the bug it
+        # reproduces would silently vanish and the grounding assertion would be vacuous.
+        on_disk = (self._member()).path.read_text()
+        assert "\\u2014" in on_disk
+        assert '\\"banner\\"' in on_disk
+
+    def test_snippet_text_is_decoded_not_escaped(self) -> None:
+        extract = build_extract([self._member()])
+        joined = "\n".join(s.text for s in extract.snippets)
+        assert "—" in joined
+        assert '"banner"' in joined
+        assert "\\u2014" not in joined
+        assert '\\"' not in joined
+
+    def test_decoded_citation_grounds(self) -> None:
+        # RED before the fix: the decoded quote is not a substring of the escaped
+        # snippet, so the ledger rejected the cluster and recorded nothing.
+        member = self._member()
+
+        def _distill(extract: ConsolidationExtract) -> list[DistilledCluster]:
+            snippet = extract.snippets[0]
+            return [
+                DistilledCluster(
+                    cluster_key="grounded",
+                    rule="Do not rebuild what the user told you not to.",
+                    source_files=[str(snippet.path)],
+                    is_binding=True,
+                    verified_citation='do not build a new "banner" again I told you not to',
+                    durable_destination="",
+                )
+            ]
+
+        with patch.object(engine, "enumerate_members", return_value=[member]):
+            run_consolidation(overlay="", since=None, dry_run=False, distiller=_distill)
+
+        assert ConsolidatedMemory.objects.filter(cluster_key="grounded").count() == 1
+
+    def test_hallucinated_citation_is_still_rejected(self) -> None:
+        # The gate MUST keep its teeth: an invented quote that never appears in the
+        # decoded transcript is rejected, not recorded.
+        member = self._member()
+
+        def _distill(extract: ConsolidationExtract) -> list[DistilledCluster]:
+            snippet = extract.snippets[0]
+            return [
+                DistilledCluster(
+                    cluster_key="hallucinated",
+                    rule="A rule the transcript never supports.",
+                    source_files=[str(snippet.path)],
+                    is_binding=False,
+                    verified_citation="the user demanded a full rewrite of the auth layer",
+                    durable_destination="",
+                )
+            ]
+
+        with patch.object(engine, "enumerate_members", return_value=[member]):
+            result = run_consolidation(overlay="", since=None, dry_run=False, distiller=_distill)
+
+        assert result.clusters_recorded == 0
+        assert result.clusters_rejected == 1
+        assert ConsolidatedMemory.objects.filter(cluster_key="hallucinated").count() == 0
+
+
+class GroundingPunctuationFoldTestCase(TestCase):
+    """The grounding substring test folds smart/straight punctuation symmetrically (#1933).
+
+    A decoded transcript may carry a straight quote where the model's citation used a
+    curly one (or the reverse). Folding both operands to one canonical form keeps a
+    genuine citation grounded while remaining a strict substring test — an invented
+    quote is still rejected.
+    """
+
+    _SNIPPET: ClassVar[dict[str, str]] = {
+        "/s.jsonl": normalize_ws('{"role": "user"} do not ship the "beta" build tonight')
+    }
+
+    def _cluster(self, citation: str) -> DistilledCluster:
+        return DistilledCluster(
+            cluster_key="k",
+            rule="r",
+            source_files=["/s.jsonl"],
+            is_binding=False,
+            verified_citation=citation,
+            durable_destination="",
+        )
+
+    def test_smart_quote_citation_grounds_against_straight_quote_snippet(self) -> None:
+        assert cluster_is_grounded(self._cluster("do not ship the “beta” build"), self._SNIPPET)
+
+    def test_em_dash_citation_grounds_against_hyphen_snippet(self) -> None:
+        snippet = {"/s.jsonl": normalize_ws('{"role": "user"} stop - do not build a new banner')}
+        assert cluster_is_grounded(self._cluster("stop — do not build a new banner"), snippet)
+
+    def test_invented_citation_still_rejected_after_fold(self) -> None:
+        assert not cluster_is_grounded(self._cluster("ship the “release” build now"), self._SNIPPET)
 
 
 class WeightedSnippetTestCase(TestCase):

--- a/tests/teatree_loops/dream/test_transcript_extract.py
+++ b/tests/teatree_loops/dream/test_transcript_extract.py
@@ -1,8 +1,11 @@
 """Tests for the dream transcript line-keeping concern (#1933)."""
 
+import json
+
 from django.test import TestCase
 
 from teatree.loops.dream.transcript_extract import (
+    decode_transcript_line,
     high_signal_lines,
     looks_like_learning,
     looks_like_user_ask,
@@ -229,3 +232,61 @@ class HighSignalLinesTestCase(TestCase):
         learning = '{"type":"assistant","text":"root caused the empty owner crash to a missing tenant filter"}'
         raw = f'{{"type":"assistant","text":"row noise"}}\n{learning}'
         assert "root caused the empty owner crash" in high_signal_lines(raw)
+
+    def test_kept_line_is_decoded_not_escaped(self) -> None:
+        # The distiller prompt and the grounding index must share ONE decoded form:
+        # an escaped em-dash / inner quote decodes so a model's verbatim citation of
+        # the human text is a real substring of the kept snippet.
+        raw = json.dumps({"type": "user", "message": {"role": "user", "content": 'stop — the "banner", again'}})
+        kept = high_signal_lines(raw)
+        assert 'stop — the "banner", again' in kept
+        assert "\\u2014" not in kept
+        assert '\\"' not in kept
+
+
+class DecodeTranscriptLineTestCase(TestCase):
+    """The raw JSONL line → decoded, single-line human text seam that lets citations ground (#1933)."""
+
+    def test_decodes_escaped_message_content(self) -> None:
+        raw = json.dumps({"type": "user", "message": {"role": "user", "content": 'do not build a new "banner" — stop'}})
+        assert decode_transcript_line(raw) == '{"role": "user"} do not build a new "banner" — stop'
+
+    def test_retains_role_tag_so_correction_heuristic_still_fires(self) -> None:
+        # compliance + the weight ladder re-run looks_like_user_correction on the
+        # DECODED stream; the retained JSON role tag keeps that per-line signal alive.
+        raw = json.dumps({"type": "user", "message": {"role": "user", "content": "do not do that again"}})
+        decoded = decode_transcript_line(raw)
+        assert looks_like_user_correction(decoded)
+
+    def test_flattens_content_block_list(self) -> None:
+        raw = json.dumps(
+            {"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": "a finding"}]}}
+        )
+        assert decode_transcript_line(raw) == '{"role": "assistant"} a finding'
+
+    def test_collapses_internal_newlines_to_one_line(self) -> None:
+        raw = json.dumps({"type": "user", "message": {"role": "user", "content": "line one\nline two"}})
+        assert decode_transcript_line(raw) == '{"role": "user"} line one line two'
+
+    def test_tool_result_content_is_decoded(self) -> None:
+        raw = json.dumps(
+            {
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "content": [{"type": "text", "text": "DENIED by gate"}]}],
+                },
+            }
+        )
+        assert decode_transcript_line(raw) == '{"role": "user"} DENIED by gate'
+
+    def test_non_json_line_passes_through_unchanged(self) -> None:
+        assert decode_transcript_line("BINDING: never push to a red branch") == "BINDING: never push to a red branch"
+
+    def test_non_message_json_passes_through_unchanged(self) -> None:
+        raw = json.dumps({"type": "queue-operation", "operation": "enqueue"})
+        assert decode_transcript_line(raw) == raw
+
+    def test_top_level_text_shape_is_decoded(self) -> None:
+        raw = json.dumps({"type": "user", "text": "please open the PR"})
+        assert decode_transcript_line(raw) == '{"role": "user"} please open the PR'


### PR DESCRIPTION
Dream engine rejected transcript clusters as ungrounded (model cites decoded text vs JSON-escaped snippet). Decode transcript to shared human-readable form (signal detection stays on raw JSONL); symmetric smart-quote/dash fold in normalize_ws. Gate stays a strict substring test — invented citations still rejected (regression tested).