### PR TITLE
fix(loop): per-item fault isolation + no-ended_at requeue (closes #3444, closes #3441)

### DIFF
--- a/src/teatree/loop/stuck_ticket_redispatch.py
+++ b/src/teatree/loop/stuck_ticket_redispatch.py
@@ -67,13 +67,28 @@ def redispatch_stuck_tickets() -> int:
         # the dead-letter set never grows the per-tick work (bounded sweep, #8).
         if ticket.pk in already_escalated:
             continue
-        phase = _STATE_PHASE[ticket.state]
-        halt = _budget_halt_reason(ticket, phase=phase)
-        if halt is not None:
-            _escalate_once(ticket, reason=halt)
-            continue
-        scheduled += _redispatch(ticket, phase=phase)
+        # Per-item fault isolation (#3441): one poison ticket (a budget query that blows
+        # up, a scheduling method that raises unexpectedly) must NOT abort the sweep and
+        # strand every OTHER stuck ticket. Record it loudly and move on.
+        try:
+            scheduled += _redispatch_one(ticket)
+        except Exception:
+            logger.exception("Stuck-redispatch skipped ticket %s after an unexpected error", ticket.pk)
     return scheduled
+
+
+def _redispatch_one(ticket: Ticket) -> int:
+    """Schedule ONE stuck ticket's implied phase within budget, else escalate. Returns 0/1.
+
+    Isolated per ticket so :func:`redispatch_stuck_tickets` can wrap it in a single
+    ``try`` and keep sweeping when one row raises.
+    """
+    phase = _STATE_PHASE[ticket.state]
+    halt = _budget_halt_reason(ticket, phase=phase)
+    if halt is not None:
+        _escalate_once(ticket, reason=halt)
+        return 0
+    return _redispatch(ticket, phase=phase)
 
 
 def _already_escalated_ticket_pks() -> set[int]:

--- a/src/teatree/loop/tick_recovery.py
+++ b/src/teatree/loop/tick_recovery.py
@@ -29,12 +29,16 @@ def _reap_stale_task_claims(errors: dict[str, str] | None = None) -> None:
     compose the ``agents``/``core`` surfaces, so they run here rather than in the
     core-only ``run_boot_sweeps``.
 
-    Each sweep runs in its OWN ``try`` so a ``RuntimeError`` from the FIRST never skips
-    the other two (the old shared ``suppress(RuntimeError)`` let one boot-sweep failure
+    Each sweep runs in its OWN ``try`` so ANY exception from the FIRST never skips the
+    other two (the old shared ``suppress(RuntimeError)`` let one boot-sweep failure
     silently disable transient-requeue AND stuck-redispatch, and recovery itself failed
-    invisibly). A failure is logged and recorded in *errors* (rendered in the tick's
-    ``action_needed``), so a DB-blocked pytest-django harness still renders while a real
-    recovery failure surfaces loudly instead of freezing the factory in silence.
+    invisibly). The catch is the broad ``Exception`` (#3441): a sweep can raise more than
+    ``RuntimeError`` — a ``DatabaseError`` on a poison row, a ``ValueError`` from a
+    classifier — and one unhandled exception used to abort the whole recovery step. A
+    failure is logged and recorded in *errors* (rendered in the tick's ``action_needed``),
+    so a DB-blocked pytest-django harness still renders (its ``RuntimeError: Database
+    access not allowed`` lands in *errors* exactly as before) while a real recovery
+    failure surfaces loudly instead of freezing the factory in silence.
     """
     from teatree.core.worktree.recovery_sweeps import run_boot_sweeps  # noqa: PLC0415 — deferred: loaded at tick time
     from teatree.loop import stuck_ticket_redispatch, transient_requeue  # noqa: PLC0415 — deferred: loaded at tick time
@@ -47,8 +51,8 @@ def _reap_stale_task_claims(errors: dict[str, str] | None = None) -> None:
     for label, sweep in sweeps:
         try:
             sweep()
-        except RuntimeError as exc:
-            logger.warning("Recovery sweep %s failed: %s", label, exc)
+        except Exception as exc:
+            logger.exception("Recovery sweep %s failed", label)
             if errors is not None:
                 errors[label] = f"{type(exc).__name__}: {exc}"
 

--- a/src/teatree/loop/transient_requeue.py
+++ b/src/teatree/loop/transient_requeue.py
@@ -123,27 +123,48 @@ def requeue_transient_failed() -> int:
     autorecovery = autorecovery_enabled()
     reopened = 0
     for task in _non_terminal_failed_tasks():
-        if task.ticket.has_completed_phase(task.phase):
-            # SUPERSEDED: the ticket's FSM already reached this phase's output, so this
-            # FAILED row is a dead artifact of an earlier interrupted run. Retire it
-            # silently — never escalate a question the ticket's own state answers.
-            _retire_superseded(task)
-            continue
-        error = _latest_error(task)
-        if not error:
-            # No recorded error → neither transient nor deterministic; must not freeze.
-            _escalate_once(task, reason="failed with no recorded error")
-        elif is_transient_failure(error):
-            halt = _budget_halt_reason(task)
-            if halt is None:
-                reopened += _reopen(task)
-            else:
-                _escalate_once(task, reason=halt)
-        elif (cause := recoverable_exhaustion_cause(error)) is not None and autorecovery:
-            reopened += _requeue_on_window_reset(task, cause, now=now)
-        else:
-            reopened += _handle_deterministic(task)
+        # Per-item fault isolation (#3441): a single poison row (a corrupt attempt, a
+        # classifier blow-up, a scheduling error) must NOT abort the sweep and strand
+        # every OTHER loop's FAILED tasks. Record the failure loudly and move on.
+        try:
+            reopened += _route_failed_task(task, now=now, autorecovery=autorecovery)
+        except Exception:
+            logger.exception(
+                "Transient-requeue skipped task %s (ticket %s) after an unexpected error",
+                task.pk,
+                task.ticket_id,  # ty: ignore[unresolved-attribute]
+            )
     return reopened
+
+
+def _route_failed_task(task: Task, *, now: datetime, autorecovery: bool) -> int:
+    """Route ONE FAILED task to reopen / retire / corrective-retry / escalate. Returns the reopen count.
+
+    Isolated per task so :func:`requeue_transient_failed` can wrap it in a single
+    ``try`` and keep sweeping when one row raises — a terminal FAILED task on a
+    non-terminal ticket is still never left silent (reopened, retired, retried, or
+    escalated), it just can no longer take the whole tick down with it.
+    """
+    if task.ticket.has_completed_phase(task.phase):
+        # SUPERSEDED: the ticket's FSM already reached this phase's output, so this
+        # FAILED row is a dead artifact of an earlier interrupted run. Retire it
+        # silently — never escalate a question the ticket's own state answers.
+        _retire_superseded(task)
+        return 0
+    error = _latest_error(task)
+    if not error:
+        # No recorded error → neither transient nor deterministic; must not freeze.
+        _escalate_once(task, reason="failed with no recorded error")
+        return 0
+    if is_transient_failure(error):
+        halt = _budget_halt_reason(task)
+        if halt is None:
+            return _reopen(task)
+        _escalate_once(task, reason=halt)
+        return 0
+    if (cause := recoverable_exhaustion_cause(error)) is not None and autorecovery:
+        return _requeue_on_window_reset(task, cause, now=now)
+    return _handle_deterministic(task)
 
 
 def _requeue_on_window_reset(task: Task, cause: LimitCause, *, now: datetime) -> int:
@@ -156,11 +177,20 @@ def _requeue_on_window_reset(task: Task, cause: LimitCause, *, now: datetime) ->
     retried forever). Before the horizon it is left FAILED and re-checked on a later tick
     — NOT escalated, because a capacity dip is not a doomed defect. Returns the reopen
     count (0 or 1).
+
+    The horizon is anchored on the last attempt's ``ended_at`` when present, else on its
+    ``started_at`` (#3444). A crashed / killed attempt can land FAILED having never
+    recorded ``ended_at``; the old ``ended is None`` guard stranded such a task FOREVER
+    (never past the horizon, never reopened, never escalated). ``started_at`` is
+    ``auto_now_add`` so it is always set — anchoring on it makes the window elapse from a
+    slightly earlier instant, which requeues the task rather than silently stranding it.
     """
     horizon = window_horizon(cause)
     last = _latest_attempt(task)
-    ended = last.ended_at if last is not None else None
-    if horizon is None or ended is None or ended + horizon > now:
+    if horizon is None or last is None:
+        return 0
+    anchor = last.ended_at or last.started_at
+    if anchor + horizon > now:
         return 0
     halt = _budget_halt_reason(task)
     if halt is not None:

--- a/tests/teatree_loop/test_stuck_ticket_redispatch.py
+++ b/tests/teatree_loop/test_stuck_ticket_redispatch.py
@@ -87,6 +87,29 @@ class TestStuckTicketRedispatch(TestCase):
         assert scheduled == 0
         assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
 
+    def test_poison_ticket_does_not_abort_the_sweep(self) -> None:
+        # #3441: one stuck ticket whose per-item processing raises an unexpected
+        # exception must NOT abort the sweep and strand every OTHER stuck ticket. The
+        # poison ticket is skipped (logged, left as-is), the healthy one still schedules.
+        poison = _stuck_ticket(state=Ticket.State.STARTED)  # created first ⇒ processed first
+        healthy = _stuck_ticket(state=Ticket.State.STARTED)
+
+        def _raise_on_poison(ticket: Ticket, *, phase: str) -> str | None:
+            if ticket.pk == poison.pk:
+                msg = "budget query blew up on the poison ticket"
+                raise ValueError(msg)
+            return None
+
+        with patch(
+            "teatree.loop.stuck_ticket_redispatch._budget_halt_reason",
+            side_effect=_raise_on_poison,
+        ):
+            scheduled = redispatch_stuck_tickets()
+
+        assert scheduled == 1  # the healthy ticket was scheduled despite the poison one
+        assert healthy.tasks.filter(phase="planning", status=Task.Status.PENDING).count() == 1
+        assert poison.tasks.count() == 0  # the poison ticket is skipped, never fatal
+
     def test_bad_idle_threshold_setting_falls_back_to_default(self) -> None:
         with override_settings(STUCK_TICKET_IDLE_HOURS="not-a-number"):
             assert _idle_threshold_hours() == DEFAULT_STUCK_IDLE_HOURS

--- a/tests/teatree_loop/test_tick_recovery.py
+++ b/tests/teatree_loop/test_tick_recovery.py
@@ -49,6 +49,29 @@ class TestReapStaleTaskClaims(TestCase):
         assert transient.status == Task.Status.PENDING
         assert stuck.tasks.filter(phase="planning", status=Task.Status.PENDING).count() == 1
 
+    def test_a_non_runtimeerror_sweep_failure_is_isolated_and_recorded(self) -> None:
+        # #3441: a sweep can raise more than RuntimeError (a DatabaseError on a poison
+        # row, a ValueError from a classifier). The old ``except RuntimeError`` let such
+        # an exception abort the whole recovery step; the broadened ``except Exception``
+        # must isolate it — record it in the errors sink AND still run the later sweeps.
+        transient = self._transient_failed_task()
+        stuck = self._stuck_started_ticket()
+        errors: dict[str, str] = {}
+
+        with patch(
+            "teatree.core.worktree.recovery_sweeps.run_boot_sweeps",
+            side_effect=ValueError("boot sweep hit a poison row"),
+        ):
+            _reap_stale_task_claims(errors)
+
+        # The non-RuntimeError failure was recorded, not propagated...
+        assert "recovery:boot_sweeps" in errors
+        assert "ValueError" in errors["recovery:boot_sweeps"]
+        # ...and the other two sweeps still ran despite it.
+        transient.refresh_from_db()
+        assert transient.status == Task.Status.PENDING
+        assert stuck.tasks.filter(phase="planning", status=Task.Status.PENDING).count() == 1
+
     def _transient_failed_task(self) -> Task:
         ticket = Ticket.objects.create(role=Ticket.Role.AUTHOR, state=Ticket.State.STARTED)
         session = Session.objects.create(ticket=ticket, agent_id="coding")

--- a/tests/teatree_loop/test_transient_requeue.py
+++ b/tests/teatree_loop/test_transient_requeue.py
@@ -11,6 +11,7 @@ never reopened. The hardest pin: it NEVER retries endlessly.
 """
 
 from datetime import datetime, timedelta
+from unittest import mock
 
 from django.test import TestCase
 from django.utils import timezone
@@ -58,6 +59,30 @@ class TestTransientRequeue(TestCase):
         assert task.status == Task.Status.PENDING
         # A second pass finds it PENDING (no longer FAILED) — no double reopen.
         assert requeue_transient_failed() == 0
+
+    def test_poison_row_does_not_abort_the_sweep(self) -> None:
+        # #3441: one FAILED task whose processing raises an unexpected exception must NOT
+        # abort the whole sweep and strand every OTHER loop's recoverable task. The poison
+        # row is skipped (left FAILED, logged), the healthy row still recovers.
+        poison = _failed_task()  # created first ⇒ lower pk ⇒ processed first
+        _add_failed_attempt(poison, error="outage_death: poison row")
+        healthy = _failed_task()
+        _add_failed_attempt(healthy, error="outage_death: connection refused")
+
+        def _raise_on_poison(error: str) -> bool:
+            if "poison" in error:
+                msg = "classifier blew up on the poison row"
+                raise ValueError(msg)
+            return True
+
+        with mock.patch("teatree.loop.transient_requeue.is_transient_failure", side_effect=_raise_on_poison):
+            reopened = requeue_transient_failed()
+
+        healthy.refresh_from_db()
+        poison.refresh_from_db()
+        assert reopened == 1
+        assert healthy.status == Task.Status.PENDING  # the sweep kept going past the poison row
+        assert poison.status == Task.Status.FAILED  # the poison row is skipped, never fatal
 
     def test_empty_error_failed_task_is_escalated_not_frozen(self) -> None:
         # A FAILED task with NO recorded error matches neither the transient nor the
@@ -350,6 +375,36 @@ class TestExhaustionAutoRequeue(TestCase):
         task.refresh_from_db()
         assert task.status == Task.Status.PENDING
         # No human question — a capacity dip is auto-recovered, not escalated.
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 0
+
+    def test_session_limit_task_with_no_ended_at_is_reopened_not_stranded(self) -> None:
+        # #3444: a limit-killed attempt can land FAILED having NEVER recorded ended_at
+        # (a crash/kill after the failure classification, before the row was finalized).
+        # The old ``ended is None`` guard stranded such a task forever — never past the
+        # horizon, never reopened, never escalated. The horizon must anchor on started_at
+        # so the task still requeues once the window has elapsed.
+        task = _failed_task()
+        _add_failed_attempt(task, error=_exhaustion_error(LimitCause.SUBSCRIPTION_SESSION))
+        # The attempt started 6h ago (past the 5h window) and never recorded an end.
+        TaskAttempt.objects.filter(task=task).update(started_at=timezone.now() - timedelta(hours=6), ended_at=None)
+
+        assert requeue_transient_failed() == 1
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING
+        # A capacity dip auto-recovers — no human question.
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 0
+
+    def test_no_ended_at_task_is_left_failed_before_the_window_resets(self) -> None:
+        # The started_at fallback must still RESPECT the horizon: an attempt that started
+        # only 1h ago (no ended_at) has not cleared the 5h window and must be left FAILED
+        # for a later tick, not reopened prematurely.
+        task = _failed_task()
+        _add_failed_attempt(task, error=_exhaustion_error(LimitCause.SUBSCRIPTION_SESSION))
+        TaskAttempt.objects.filter(task=task).update(started_at=timezone.now() - timedelta(hours=1), ended_at=None)
+
+        assert requeue_transient_failed() == 0
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
         assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 0
 
     def test_session_limit_task_is_left_failed_before_the_window_resets(self) -> None:


### PR DESCRIPTION
## Summary

Hardens the loop recovery sweeps against two failure modes.

### #3444 — exhaustion auto-requeue no longer strands a no-`ended_at` task
`transient_requeue._requeue_on_window_reset` anchored the usage-window horizon on the last attempt's `ended_at`. A crashed/killed attempt can land FAILED having never recorded `ended_at`, so the old `ended is None` guard stranded it forever (never past the horizon, never reopened, never escalated). The horizon now falls back to `started_at` (`auto_now_add`, always set) when `ended_at` is absent, so the task requeues once the window elapses — while still respecting the horizon before it.

### #3441 — loop recovery sweeps gain per-item fault isolation
- `tick_recovery._reap_stale_task_claims`: the per-sweep guard is broadened from `except RuntimeError` to `except Exception` (a sweep can raise a `DatabaseError`/`ValueError`), recorded in the errors sink; the pytest-django DB-blocked path still lands in `errors` exactly as before.
- `transient_requeue.requeue_transient_failed` and `stuck_ticket_redispatch.redispatch_stuck_tickets`: each per-item body is wrapped in `try/except Exception` that records the failure via `logger.exception` and continues, so one poison row no longer aborts every other loop's recovery. Routing logic is extracted into `_route_failed_task` / `_redispatch_one` for a single clean per-item try.

## Tests
RED-first, integration-style (real DB rows, real routing): a stranded no-`ended_at` task now requeues; a poison row / non-RuntimeError sweep failure is isolated and the healthy rows still recover. Verified failing before the fix and passing after.

Closes #3444
Closes #3441