### PR TITLE
fix(hooks): egress leak gate fails closed on visibility-probe error (closes #3442)

### DIFF
--- a/src/teatree/hooks/public_visibility.py
+++ b/src/teatree/hooks/public_visibility.py
@@ -1,36 +1,45 @@
 """Affirmative-public visibility scope for the pre-publish leak gates (#1415/#1213).
 
 The banned-terms (#1415) and quote-scanner (#1213) gates protect against
-leaking internal vocabulary / user quotes onto PUBLIC surfaces. They therefore
-enforce ONLY when the target repository is affirmatively known ``public``. For
-every OTHER case -- a ``private`` or ``internal`` repo, an unknown/unresolvable
-target, or an in-hook visibility lookup error -- the gate is SKIPPED (bias hard
-toward not firing): a non-public repo must never be falsely blocked.
+leaking internal vocabulary / user quotes onto PUBLIC surfaces. A segment is
+skip-eligible ONLY when its target is PROVABLY non-public: an allowlisted-private
+slug, an internal-namespace slug, or a ``private``/``internal`` probe verdict. A
+target the gate cannot prove non-public -- an affirmatively-``public`` probe
+verdict, OR a RESOLVABLE ``owner/repo`` slug whose visibility probe could not be
+confirmed (a network/API error, an absent ``gh``/``glab``, an unrecognised
+answer) -- is scanned. The probe-error case FAILS CLOSED: it is never a silent
+skip (#3442). This reconciles the Python scope with its bash mirror
+(:file:`scripts/hooks/refuse-public-push-with-leak.sh`, whose undetermined-
+visibility branch scans anyway) and the fail-closed-always leak-gate doctrine in
+:file:`hooks/CLAUDE.md` -- both now agree that an unconfirmed visibility on a
+resolvable target scans, never skips. The offline ``private_repos`` allowlist
+remains the reliable, network-free way to declare a private repo so an
+own-private post to it still skips without a probe.
 
 The visibility verdict is resolved from the command's OWN target (the
 ``--repo``/``-R`` flag, the ``gh``/``glab api`` URL path, or the cwd git remote
--- reusing ``publish_destination``'s resolver), then classified: an
-allowlisted-private slug, an internal-namespace slug, a ``private``/``internal``
-probe verdict, and an unknown verdict all resolve NON-public; only a ``public``
-probe verdict on a non-allowlisted slug is public. The verdict is day-cached
-per-repo by :func:`_repo_visibility.slug_visibility`, so repeated gate
+-- reusing ``publish_destination``'s resolver), then classified into
+:class:`_Visibility`: an allowlisted-private slug, an internal-namespace slug,
+and a ``private``/``internal`` probe verdict resolve ``NON_PUBLIC``; a ``public``
+probe verdict on a non-allowlisted slug is ``PUBLIC``; a resolvable slug the
+probe cannot confirm is ``UNKNOWN`` (fail closed -> scan). The verdict is
+day-cached per-repo by :func:`_repo_visibility.slug_visibility`, so repeated gate
 evaluations never re-probe.
 
 :func:`gate_skips_for_visibility` is the composed predicate the gates call. It
-keeps the ALL-SEGMENTS anti-leak posture of the destination classifier it
-replaced -- a ``$(...)``/transport construct, an unrecognised chained executable
-(``sh -c``/``make``/``./x.sh``), or a raw ``api`` WRITE whose URL does not
-resolve are all NON-skippable, so an obscured PUBLIC post can never hide behind
-a leading non-public segment -- but with the destination polarity FLIPPED: a
-segment is skip-eligible when its target is NOT affirmatively public (rather
-than only when provably-internal), so an unknown/unresolvable target now SKIPS
-instead of failing closed. A ``git commit`` segment defers to the landing-repo
-carve-out and the #703 pre-push backstop and is never skipped here.
+keeps the ALL-SEGMENTS anti-leak posture -- a ``$(...)``/transport construct, an
+unrecognised chained executable (``sh -c``/``make``/``./x.sh``), or a raw
+``api`` WRITE whose URL does not resolve are all NON-skippable, so an obscured
+PUBLIC post can never hide behind a leading non-public segment. A ``git commit``
+segment defers to the landing-repo carve-out and the #703 pre-push backstop and
+is never skipped here.
 
 This lives in its own module because :mod:`teatree.hooks.publish_destination`
 and :mod:`teatree.hooks._repo_visibility` are both at the per-file LOC cap.
 """
 
+import sys
+from enum import Enum
 from pathlib import Path
 
 from teatree.hooks import _commit_carve_out, _repo_visibility
@@ -54,59 +63,128 @@ _SKIP_PUBLISH = "skip-publish"  # skip-eligible AND counts as a repo-targeted pu
 _SKIP_INERT = "skip-inert"  # skip-eligible, not a publish (nav/local/api-read)
 
 
+class _Visibility(Enum):
+    """Three-valued affirmative-public visibility of a RESOLVED destination.
+
+    ``PUBLIC`` (confirmed-public probe verdict) and ``UNKNOWN`` (a resolvable
+    slug the probe could not confirm) both SCAN; only ``NON_PUBLIC`` (provably
+    private/internal) is skip-eligible. ``UNKNOWN`` is the fail-CLOSED case the
+    old boolean collapsed into "not public -> skip", which let a probe error on a
+    resolvable slug ride out unscanned (#3442).
+    """
+
+    PUBLIC = "public"
+    NON_PUBLIC = "non-public"
+    UNKNOWN = "unknown"
+
+
+def _destination_visibility(dest: Destination, *, config_path: Path | None) -> _Visibility:
+    """Classify a RESOLVED ``dest`` into :class:`_Visibility` for the leak-gate scope.
+
+    ``NON_PUBLIC`` (skip-eligible) when the target is PROVABLY non-public: an
+    empty / unexpanded-``$`` slug (no resolvable target to probe), an
+    ``internal_publish_namespaces`` match, a ``private_repos`` allowlist match, or
+    a ``private``/``internal`` (any non-``PUBLIC``, non-``None``) probe verdict.
+    ``PUBLIC`` only on a confirmed-``PUBLIC`` probe verdict for a non-allowlisted
+    slug. ``UNKNOWN`` when the slug IS probe-resolvable but the visibility probe
+    returns no verdict (``None`` -- a network/API error, an absent ``gh``/``glab``,
+    or an unrecognised answer): the fail-CLOSED case the gate must SCAN, mirroring
+    the bash pre-push gate and the fail-closed-always doctrine (#3442).
+
+    ``dest.forge`` qualifies a bare ``owner/repo`` slug up to its canonical host
+    so the host-keyed probe routes to the right tool.
+    """
+    slug = dest.slug.strip().lower()
+    if not slug or "$" in slug:
+        return _Visibility.NON_PUBLIC
+    if any(_repo_visibility.slug_namespace_matches(entry, slug) for entry in _internal_publish_namespaces(config_path)):
+        return _Visibility.NON_PUBLIC
+    if _repo_visibility.slug_is_allowlisted_private(slug, config_path):
+        return _Visibility.NON_PUBLIC
+    probe_slug = _repo_visibility.forge_qualified_slug(slug, dest.forge)
+    verdict = _repo_visibility.slug_visibility(probe_slug)
+    if verdict == _PUBLIC:
+        return _Visibility.PUBLIC
+    if verdict is None:
+        return _Visibility.UNKNOWN
+    return _Visibility.NON_PUBLIC
+
+
 def is_affirmatively_public(dest: Destination | None, *, config_path: Path | None = None) -> bool:
     """Return True iff ``dest`` resolves to an affirmatively-PUBLIC repo.
 
-    NON-public (False) when the slug is empty / carries an unexpanded ``$``,
-    matches an ``internal_publish_namespaces`` entry, matches a ``private_repos``
-    allowlist entry, or its ``gh``/``glab`` visibility verdict is anything other
-    than ``"PUBLIC"`` (``private``/``internal``/unknown). ``dest.forge`` qualifies
-    a bare ``owner/repo`` slug up to its canonical host so the host-keyed probe
-    routes to the right tool.
+    True ONLY on a confirmed-``PUBLIC`` probe verdict for a non-allowlisted slug
+    (:attr:`_Visibility.PUBLIC`); every other case -- private/internal/allowlisted
+    (``NON_PUBLIC``) and a resolvable slug the probe cannot confirm (``UNKNOWN``)
+    -- is False. Callers that must FAIL CLOSED on ``UNKNOWN`` (the leak-gate
+    scope) use :func:`_destination_visibility` directly rather than this boolean,
+    which cannot distinguish ``UNKNOWN`` from ``NON_PUBLIC``.
     """
     if dest is None:
         return False
-    slug = dest.slug.strip().lower()
-    if not slug or "$" in slug:
-        return False
-    if any(_repo_visibility.slug_namespace_matches(entry, slug) for entry in _internal_publish_namespaces(config_path)):
-        return False
-    if _repo_visibility.slug_is_allowlisted_private(slug, config_path):
-        return False
-    probe_slug = _repo_visibility.forge_qualified_slug(slug, dest.forge)
-    return _repo_visibility.slug_visibility(probe_slug) == _PUBLIC
+    return _destination_visibility(dest, config_path=config_path) is _Visibility.PUBLIC
 
 
-def _api_write_targets_non_public(words: list[str], *, config_path: Path | None = None) -> bool:
-    """Return True iff a raw ``api`` WRITE segment RESOLVES to a NON-public repo.
+def _signal_probe_error_scan(slug: str) -> None:
+    """Emit a loud, one-line stderr signal that a probe error drove a fail-CLOSED scan.
+
+    A probe-error-driven scan must NEVER be silent (#3442): this mirrors the bash
+    pre-push gate's ``echo ... >&2`` on undetermined visibility. Best-effort and
+    crash-proof -- a failed stderr write never breaks the fast hook.
+    """
+    try:
+        sys.stderr.write(
+            f"leak gate: could not confirm '{slug or '<repo>'}' repo visibility "
+            "(probe unavailable or errored) - scanning anyway (fail closed, #3442).\n"
+        )
+    except OSError:
+        return
+
+
+def _visibility_segment_verdict(dest: Destination, *, config_path: Path | None) -> str:
+    """Map a RESOLVED destination's :class:`_Visibility` to a segment verdict.
+
+    ``NON_PUBLIC`` -> :data:`_SKIP_PUBLISH` (skip-eligible). ``PUBLIC`` ->
+    :data:`_SCAN`. ``UNKNOWN`` (resolvable slug, unconfirmed probe) FAILS CLOSED
+    to :data:`_SCAN` and emits :func:`_signal_probe_error_scan` so the decision is
+    never silent (#3442).
+    """
+    visibility = _destination_visibility(dest, config_path=config_path)
+    if visibility is _Visibility.NON_PUBLIC:
+        return _SKIP_PUBLISH
+    if visibility is _Visibility.UNKNOWN:
+        _signal_probe_error_scan(dest.slug)
+    return _SCAN
+
+
+def _api_write_segment_verdict(words: list[str], *, config_path: Path | None) -> str:
+    """Segment verdict for a raw ``gh``/``glab api`` WRITE (see :func:`_visibility_segment_verdict`).
 
     A ``gh``/``glab api`` write carries its body only to the endpoint its URL
-    path names. When that path resolves to a repo slug that is affirmatively NOT
-    public (a probe-confirmed private/internal repo, or an allowlisted-private /
+    path names. When that path resolves to a PROVABLY non-public repo (a
+    probe-confirmed private/internal repo, or an allowlisted-private /
     internal-namespace slug), the write cannot leak to a public surface -- e.g. a
-    private customer MR-description PUT -- so it is skip-eligible. The slug must
-    come from the URL path itself (``via="api"``): an ``-R`` flag does not
+    private customer MR-description PUT -- so it is :data:`_SKIP_PUBLISH`. The slug
+    must come from the URL path itself (``via="api"``): an ``-R`` flag does not
     constrain a raw endpoint.
 
-    An UNRESOLVABLE endpoint is NOT skip-eligible (returns False -> the caller
-    forces a SCAN). Per this module's ALL-SEGMENTS anti-leak contract a raw api
-    WRITE with an unresolvable URL is non-skippable, because it is an immediate
-    public egress with no pre-push backstop and a leading non-public segment must
-    never route it around the leak scan. Unresolvable means: no ``api``
-    destination at all (a flagless call, an ambiguous unknown flag, a non-repo
-    endpoint), OR a slug carrying an unexpanded ``$`` (a ``$OWNER``/``$VAR`` that
-    could expand to a PUBLIC repo at run time -- e.g. ``gh api
-    "repos/$OWNER/repo/issues" -f body=...``). Only a slug that resolves to an
-    affirmatively non-public repo returns True.
+    An UNRESOLVABLE endpoint FAILS CLOSED to :data:`_SCAN`. Per this module's
+    ALL-SEGMENTS anti-leak contract a raw api WRITE with an unresolvable URL is
+    non-skippable, because it is an immediate public egress with no pre-push
+    backstop and a leading non-public segment must never route it around the leak
+    scan. Unresolvable means: no ``api`` destination at all (a flagless call, an
+    ambiguous unknown flag, a non-repo endpoint), OR a slug carrying an unexpanded
+    ``$`` (a ``$OWNER``/``$VAR`` that could expand to a PUBLIC repo at run time --
+    e.g. ``gh api "repos/$OWNER/repo/issues" -f body=...``). A slug that resolves
+    but whose probe cannot confirm visibility ALSO fails closed (``UNKNOWN`` via
+    :func:`_visibility_segment_verdict`, #3442).
     """
     if not words or words[0] not in {"gh", "glab"}:
-        return False
+        return _SCAN
     dest = _destination_from_api(words, words[0])
-    if dest is None or dest.via != "api":
-        return False
-    if "$" in dest.slug:
-        return False
-    return not is_affirmatively_public(dest, config_path=config_path)
+    if dest is None or dest.via != "api" or "$" in dest.slug:
+        return _SCAN
+    return _visibility_segment_verdict(dest, config_path=config_path)
 
 
 def _segment_visibility_verdict(
@@ -116,10 +194,11 @@ def _segment_visibility_verdict(
 
     A LIVE ``$(...)``/transport construct or an unrecognised chained executable
     forces :data:`_SCAN` (the ALL-SEGMENTS anti-leak posture); a repo-targeted
-    publish to an affirmatively-PUBLIC target forces :data:`_SCAN`; a repo-targeted
-    publish (structured or ``api`` WRITE) to a NON-public or UNRESOLVABLE target
-    is :data:`_SKIP_PUBLISH` (an unknown target skips, per #1415); an ``api``
-    read or an inert nav/local segment is :data:`_SKIP_INERT`.
+    publish to a PROVABLY non-public target is :data:`_SKIP_PUBLISH`; a
+    repo-targeted publish (structured or ``api`` WRITE) to an affirmatively-PUBLIC
+    OR probe-unconfirmed target forces :data:`_SCAN` (fail closed on a probe
+    error, #3442); an ``api`` read or an inert nav/local segment is
+    :data:`_SKIP_INERT`.
 
     ``raws`` carries each token's as-written source span (index-aligned with
     ``words``) so the substitution check fires only on a marker bash would actually
@@ -129,13 +208,13 @@ def _segment_visibility_verdict(
     if _segment_carries_substitution_or_transport(words, raws):
         return _SCAN
     if segment_is_api_write(words):
-        return _SKIP_PUBLISH if _api_write_targets_non_public(words, config_path=config_path) else _SCAN
+        return _api_write_segment_verdict(words, config_path=config_path)
     if segment_is_api_read(words):
         return _SKIP_INERT
     rest = strip_cd_prefix(words)
     dest = _destination_from_words(rest, cwd)
     if dest is not None:
-        return _SCAN if is_affirmatively_public(dest, config_path=config_path) else _SKIP_PUBLISH
+        return _visibility_segment_verdict(dest, config_path=config_path)
     if rest and rest[0] in {"gh", "glab"}:
         return _SKIP_PUBLISH
     return _SKIP_INERT if _segment_is_skip_inert(words) else _SCAN
@@ -146,14 +225,14 @@ def gate_skips_for_visibility(command: str, cwd: Path | None, *, config_path: Pa
 
     SKIP (True) only when EVERY top-level segment is provably safe on visibility
     grounds and at least one is a repo-targeted publish: the leak gate enforces
-    ONLY on an affirmatively-public target (#1415/#1213). A segment is safe when
-    it is one of:
+    on every target it cannot PROVE non-public (#1415/#1213, #3442). A segment is
+    safe when it is one of:
 
-    - a ``gh``/``glab``/``t3 review`` publish whose destination is NOT
-        affirmatively public (private/internal/unknown/unresolvable) and carries
-        no substitution/transport construct;
-    - a raw ``gh``/``glab api`` WRITE whose URL path resolves to a NON-public
-        repo (:func:`_api_write_targets_non_public`);
+    - a ``gh``/``glab``/``t3 review`` publish whose destination is PROVABLY
+        non-public (allowlisted-private / internal-namespace / probe-confirmed
+        private) and carries no substitution/transport construct;
+    - a raw ``gh``/``glab api`` WRITE whose URL path resolves to a PROVABLY
+        non-public repo (:func:`_api_write_segment_verdict`);
     - a read-only ``api`` GET (posts no body); or
     - a provably-inert navigation / local-only / git-transport segment
         (:func:`publish_destination._segment_is_skip_inert`).
@@ -162,11 +241,17 @@ def gate_skips_for_visibility(command: str, cwd: Path | None, *, config_path: Pa
 
     - any repo-targeted publish resolves to an affirmatively-PUBLIC repo (the
         gate must fire to catch a real public leak);
+    - any repo-targeted publish resolves to a RESOLVABLE slug whose visibility
+        the probe cannot confirm -- a network/API error, an absent ``gh``/``glab``,
+        or an unrecognised answer. This FAILS CLOSED (scans) and emits a loud
+        signal, mirroring the bash pre-push gate and the fail-closed-always
+        leak-gate doctrine (#3442); the offline ``private_repos`` allowlist is the
+        network-free way to keep an own-private post skip-eligible;
     - a segment carries a ``$(...)``/transport construct, is an unrecognised
         chained executable (``sh -c``/``make``/``./x.sh`` -- can shell out to a
         hidden public post), or is a raw ``api`` WRITE to an affirmatively-public
-        URL -- these keep the ALL-SEGMENTS anti-leak posture so an obscured public
-        post cannot hide behind a leading non-public segment;
+        or unresolvable URL -- these keep the ALL-SEGMENTS anti-leak posture so an
+        obscured public post cannot hide behind a leading non-public segment;
     - the command carries a ``git commit`` segment (the landing-repo carve-out
         and the #703 pre-push backstop own that surface, unchanged); or
     - the command has no repo-targeted publish segment at all (a Slack/curl post

--- a/src/teatree/hooks/publish_destination.py
+++ b/src/teatree/hooks/publish_destination.py
@@ -18,11 +18,15 @@ consumers:
     / ``private_repos`` allowlist match, or a CONFIRMED-PRIVATE probe verdict).
     An unknown/unresolvable target stays PUBLIC. This conservative classifier is
     consumed by the FSM-level :mod:`teatree.core.gates.privacy_gate`.
-- :func:`public_visibility.is_affirmatively_public` -- FAIL-OPEN. A destination
-    is public ONLY on a CONFIRMED-PUBLIC probe verdict for a non-allowlisted
-    slug; a private/internal/unknown/unresolvable target is NON-public. The
-    PreToolUse leak gates (#1415/#1213) use this so they enforce ONLY on an
-    affirmatively-public repo and never false-block a non-public one.
+- :func:`public_visibility.is_affirmatively_public` + the three-valued
+    :func:`public_visibility._destination_visibility` -- the PreToolUse leak-gate
+    scope. A destination is ``PUBLIC`` ONLY on a CONFIRMED-PUBLIC probe verdict
+    for a non-allowlisted slug, ``NON_PUBLIC`` when PROVABLY internal/private
+    (allowlist / internal-namespace / confirmed-private probe), and ``UNKNOWN``
+    when a RESOLVABLE slug's probe cannot confirm visibility. The leak gates
+    (#1415/#1213) SKIP only a ``NON_PUBLIC`` target and FAIL CLOSED (scan) on
+    ``PUBLIC`` and ``UNKNOWN`` -- a probe error on a resolvable target scans, never
+    skips (#3442), agreeing with the fail-closed bash pre-push mirror.
 
 The hook process is overlay-agnostic and cannot import ``OverlayConfig``; it
 reads the internal denylist from the canonical ``ConfigSetting`` DB via the

--- a/tests/teatree_agents/lane_b/test_gating.py
+++ b/tests/teatree_agents/lane_b/test_gating.py
@@ -89,13 +89,29 @@ class TestHardDenyReason:
         assert reason is not None
         assert "privacy/banned-term gate" in reason
 
-    def test_publish_high_finding_to_an_unresolvable_target_is_allowed(
+    def test_publish_high_finding_to_a_probe_error_target_is_denied(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # RED before the destination fix: Lane B denied ANY HIGH finding. Lane A
-        # SKIPS an unresolvable target (bias to not firing), so Lane B must too.
+        # #3442 fail closed: the target IS a resolvable ``owner/repo`` slug
+        # (``someowner/mystery``); only its visibility PROBE fails (None). A target
+        # the gate cannot PROVE non-public is scanned, so a HIGH finding is DENIED
+        # on both lanes -- a probe error must not route a leak out unscanned. Lane A
+        # and Lane B agree via the shared ``gate_skips_for_visibility`` predicate.
         self._isolate_visibility(tmp_path, monkeypatch, None)
         args = {"command": 'gh pr comment 5 --repo someowner/mystery --body "**User directive (verbatim):** go"'}
+        reason = hard_deny_reason("shell", args, cwd=tmp_path)
+        assert reason is not None
+        assert "privacy/banned-term gate" in reason
+
+    def test_publish_high_finding_to_a_genuinely_unresolvable_target_is_allowed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # #3442 scope guard: a GENUINELY unresolvable target -- no ``--repo`` flag
+        # and a cwd with no git remote, so the destination resolves to nothing at
+        # all -- is NOT the probe-error case and stays SKIPPED/ALLOWED (unchanged).
+        # This pins that fail-closed did NOT leak into the truly-unresolvable path.
+        self._isolate_visibility(tmp_path, monkeypatch, None)
+        args = {"command": 'gh pr comment 5 --body "**User directive (verbatim):** go"'}
         assert hard_deny_reason("shell", args, cwd=tmp_path) is None
 
     def test_publish_high_finding_to_a_private_target_is_allowed(

--- a/tests/teatree_agents/lane_b/test_parity.py
+++ b/tests/teatree_agents/lane_b/test_parity.py
@@ -340,17 +340,20 @@ class TestPrivacyGateParity:
         assert hard_deny_reason("shell", args, cwd=tmp_path) is None
         assert self._lane_a_denies("shell", args, tmp_path) is False
 
-    def test_unresolvable_target_high_finding_is_allowed_on_both_lanes(
+    def test_probe_error_target_high_finding_is_denied_on_both_lanes(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # The allow-on-unknown anti-vacuity proof — RED before the fix, where Lane B
-        # denied ANY HIGH finding while Lane A skips an unresolvable target (bias to
-        # not firing). A cold-hook target whose visibility cannot be resolved is NOT
-        # affirmatively public, so both lanes ALLOW it.
+        # #3442 fail closed: a HIGH body to a RESOLVABLE target whose visibility the
+        # probe cannot confirm (None) is NOT provably non-public, so BOTH lanes
+        # DENY it (parity preserved, in the fail-closed direction) -- a probe error
+        # must never route a leak out unscanned. The probe-CONFIRMED-PRIVATE row
+        # above stays the anti-over-block allow proof.
         monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
         args = self._post("someowner/mystery", self._HIGH_BODY)
-        assert hard_deny_reason("shell", args, cwd=tmp_path) is None
-        assert self._lane_a_denies("shell", args, tmp_path) is False
+        reason = hard_deny_reason("shell", args, cwd=tmp_path)
+        assert reason is not None
+        assert "privacy/banned-term gate" in reason
+        assert self._lane_a_denies("shell", args, tmp_path) is True
 
 
 class TestBashHardDenyCorpusParity:

--- a/tests/teatree_hooks/test_banned_terms_hook.py
+++ b/tests/teatree_hooks/test_banned_terms_hook.py
@@ -127,13 +127,15 @@ def _git(cwd: Path, *args: str) -> None:
 
 
 @pytest.mark.integration
-def test_banned_terms_skips_customer_term_to_unknown_visibility_target(
+def test_banned_terms_fails_closed_on_probe_error_for_resolvable_target(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # A target whose visibility is UNKNOWN in-hook (no probe tool resolvable, not
-    # in the allowlist) is NOT affirmatively public, so the leak gate SKIPS it
-    # entirely (#1415): the post is allowed with no deny. Bias hard toward not
-    # firing -- an unresolvable target is never treated as public.
+    # #3442 fail closed: a RESOLVABLE target (the cwd remote resolves the slug)
+    # whose visibility the probe cannot confirm (no probe tool resolvable, not in
+    # the allowlist) is NOT provably non-public, so the leak gate SCANS and the
+    # banned term BLOCKS -- a probe error is not a licence to skip. (A genuinely
+    # UNRESOLVABLE target -- no slug at all -- still skips; see
+    # ``test_live_hook_skips_unresolvable_target``.)
     home = Path(os.environ["HOME"])  # the conftest-isolated HOME
     _write_home_config(home, '[teatree]\nbanned_terms = ["acmewidget"]\n', monkeypatch, tmp_path)
 
@@ -143,8 +145,8 @@ def test_banned_terms_skips_customer_term_to_unknown_visibility_target(
     _git(repo, "remote", "add", "origin", "git@github.com:acme/secret-product.git")
 
     # The probe tool is unreachable in-hook -> visibility "unknown" -> the gate
-    # skips. Patching the resolver (not PATH) keeps the shell scanner's
-    # ``bash``/``grep`` reachable so a fire, if it happened, would find the term.
+    # fails closed and scans. Patching the resolver (not PATH) keeps the shell
+    # scanner's ``bash``/``grep`` reachable so the fire finds the term.
     monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
     monkeypatch.delenv("GH_REPO", raising=False)
 
@@ -156,8 +158,8 @@ def test_banned_terms_skips_customer_term_to_unknown_visibility_target(
     blocked = handle_banned_terms_pretool(data)
     captured = capsys.readouterr()
 
-    assert blocked is False
-    assert captured.out == ""  # no deny JSON
+    assert blocked is True
+    assert json.loads(captured.out)["permissionDecision"] == "deny"
 
 
 def test_banned_terms_allowed_when_target_resolvable_private(
@@ -1029,12 +1031,14 @@ def test_live_hook_blocks_customer_term_to_user_owned_non_teatree_public_repo(
     assert decision["permissionDecision"] == "deny"
 
 
-def test_live_hook_skips_customer_term_to_unknown_visibility_non_denylisted_repo(
+def test_live_hook_fails_closed_on_probe_error_for_non_denylisted_repo(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # MUST-SKIP: a non-denylisted target whose visibility the in-hook probe cannot
-    # resolve (the common cold-hook state) is NOT affirmatively public, so the leak
-    # gate SKIPS it (#1415) -- an unknown target is never treated as public.
+    # #3442 fail closed / MUST-FIRE: a non-denylisted target with a resolvable
+    # ``--repo`` slug whose visibility the in-hook probe cannot confirm is NOT
+    # provably non-public, so the leak gate SCANS and BLOCKS -- a probe error must
+    # never route a leak out unscanned, mirroring the bash pre-push gate. Declare a
+    # genuinely-private repo in ``private_repos`` to keep it skip-eligible offline.
     home = Path(os.environ["HOME"])
     _write_home_config(home, _DENYLIST_CONFIG, monkeypatch, tmp_path)
     monkeypatch.setattr(_repo_visibility, "_resolve_probe_tool", lambda _tool: None)
@@ -1048,8 +1052,8 @@ def test_live_hook_skips_customer_term_to_unknown_visibility_non_denylisted_repo
     blocked = handle_banned_terms_pretool(data)
     captured = capsys.readouterr()
 
-    assert blocked is False
-    assert captured.out == ""  # no deny JSON
+    assert blocked is True
+    assert json.loads(captured.out)["permissionDecision"] == "deny"
 
 
 def test_live_hook_skips_unresolvable_target(

--- a/tests/teatree_hooks/test_banned_terms_public_slug_with_term_blocks.py
+++ b/tests/teatree_hooks/test_banned_terms_public_slug_with_term_blocks.py
@@ -6,13 +6,14 @@ visibility check. An org/repo slug is attacker-controllable (``<term>-eng/tracke
 so a genuinely-public repo whose slug carries the term could silence the leak
 block.
 
-These tests pin the HARD invariant on the PUBLIC surface the leak gate now
-scopes to: a CONFIRMED-PUBLIC destination BLOCKS even when the slug carries the
-term (the slug-text match must not vouch for a public leak). An
-UNKNOWN-visibility destination is NOT affirmatively public, so the gate SKIPS it
-entirely (#1415 -- bias hard toward not firing). The companion
-``TestProvablyPrivateDestinationStillAllowed`` proves a provably-private
-destination is likewise skipped via the config allowlist.
+These tests pin the HARD invariant: a CONFIRMED-PUBLIC destination BLOCKS even
+when the slug carries the term (the slug-text match must not vouch for a public
+leak), AND a destination whose visibility the probe cannot confirm now FAILS
+CLOSED and BLOCKS too (#3442 -- a probe error is not a skip; the attacker-
+controllable ``<term>-eng/tracker`` slug can no longer silence the block by
+merely being unresolvable in-hook). The companion
+``TestProvablyPrivateDestinationStillAllowed`` proves a PROVABLY-private
+destination (declared in the ``private_repos`` allowlist) is still skipped.
 
 Synthetic terms only (``apple`` / ``democorp`` / ``othercorp``) -- the
 overlay-leak-tree runs on PRs.
@@ -124,7 +125,7 @@ class TestPublicSlugCarryingTermStillBlocks:
         assert term in decision["permissionDecisionReason"]
 
     @pytest.mark.parametrize(("command", "term"), _SLUG_CARRIES_TERM_EXPLOITS)
-    def test_unknown_visibility_destination_skips(
+    def test_probe_error_destination_fails_closed_and_blocks(
         self,
         command: str,
         term: str,
@@ -132,13 +133,17 @@ class TestPublicSlugCarryingTermStillBlocks:
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        # Indeterminate probe (tool absent in-hook). An unknown-visibility
-        # destination is NOT affirmatively public, so the leak gate SKIPS it
-        # entirely (#1415) -- the post is allowed, bias hard toward not firing.
+        # #3442 fail closed: an indeterminate probe (tool absent / API error) on a
+        # resolvable slug is NOT provably non-public, so the leak gate SCANS and the
+        # slug-carried term BLOCKS -- the attacker-controllable slug can no longer
+        # silence the block by being unresolvable in-hook. A genuinely-private repo
+        # declares itself in ``private_repos`` (see the companion class).
         _pin_probe(monkeypatch, None)
         blocked = handle_banned_terms_pretool(_bash(command))
-        assert blocked is False, "a banned term on an UNKNOWN-visibility destination must SKIP"
-        assert capsys.readouterr().out == ""  # no deny JSON
+        decision = json.loads(capsys.readouterr().out)
+        assert blocked is True, "a banned term on a probe-UNCONFIRMED destination must fail closed and BLOCK"
+        assert decision["permissionDecision"] == "deny"
+        assert term in decision["permissionDecisionReason"]
 
 
 class TestProvablyPrivateDestinationStillAllowed:

--- a/tests/teatree_hooks/test_public_visibility.py
+++ b/tests/teatree_hooks/test_public_visibility.py
@@ -1,18 +1,24 @@
-"""The pre-publish leak gates enforce ONLY on affirmatively-public targets (#1415/#1213).
+"""The pre-publish leak gates skip ONLY a PROVABLY non-public target (#1415/#1213, #3442).
 
 The banned-terms (#1415) and quote-scanner (#1213) PUBLISH gates protect against
-leaking internal vocabulary / user quotes onto PUBLIC surfaces, so they enforce
-ONLY when the target repository is affirmatively ``public``. For EVERY other case
--- a ``private``/``internal`` repo, or a target whose visibility cannot be
-resolved in-hook (the common cold-hook state) -- the gate is SKIPPED entirely
-(bias hard toward not firing: a non-public repo must never be falsely blocked).
+leaking internal vocabulary / user quotes onto PUBLIC surfaces. A leak scan is
+SKIPPED only when the target repository is PROVABLY non-public: an
+allowlisted-private / internal-namespace slug, or a probe-CONFIRMED
+private/internal repo. A target the gate cannot prove non-public -- an
+affirmatively-``public`` probe verdict, OR a RESOLVABLE ``owner/repo`` slug whose
+visibility probe could not be confirmed (a network/API error, an absent
+``gh``/``glab``, an unrecognised answer) -- is SCANNED. The probe-error case FAILS
+CLOSED (#3442): it agrees with the bash pre-push mirror
+(:file:`scripts/hooks/refuse-public-push-with-leak.sh`) and the fail-closed-always
+leak-gate doctrine, and it is never a silent skip.
 
-These tests drive BOTH live handlers across the three-visibility matrix with the
-forge visibility probe mocked (no ``gh``/``glab``, no network): a PUBLIC target
-carrying a leak FIRES, and both a PRIVATE and an UNRESOLVABLE target carrying the
-SAME leak SKIP. The public FIRE row is the anti-vacuity guard for the two SKIP
-rows -- it proves they are green because the target is non-public, not because
-the gate stopped detecting the leak. The unit block pins the polarity of the
+These tests drive BOTH live handlers across the visibility matrix with the forge
+visibility probe mocked (no ``gh``/``glab``, no network): a PUBLIC target carrying
+a leak FIRES, a probe-CONFIRMED-PRIVATE target carrying the SAME leak SKIPS, and a
+RESOLVABLE target whose probe cannot confirm visibility FIRES (fail closed). The
+private SKIP row is the anti-vacuity guard -- it proves the gate is green there
+because the target is provably non-public, not because it stopped detecting the
+leak. The unit block pins the polarity of the
 :func:`public_visibility.gate_skips_for_visibility` predicate the handlers call.
 """
 
@@ -124,20 +130,24 @@ def test_private_target_with_leak_skips(
 
 @pytest.mark.usefixtures("leak_home")
 @pytest.mark.parametrize(("handler", "leak_body", "reason_token"), _GATES)
-def test_unresolvable_target_with_leak_skips(
+def test_probe_error_resolvable_target_with_leak_fires(
     handler: Handler,
     leak_body: str,
     reason_token: str,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    # The SAME leak toward a target whose visibility the in-hook probe cannot
-    # resolve (returns None -- the common cold-hook / lookup-failure state) is NOT
-    # affirmatively public, so the gate SKIPS it (bias hard toward not firing).
+    # #3442 fail-closed: the SAME leak toward a RESOLVABLE ``owner/repo`` slug the
+    # in-hook probe cannot confirm (returns None -- a network/API error, absent
+    # tool, or unrecognised answer) is NOT provably non-public, so the gate FAILS
+    # CLOSED and SCANS -- the leak is denied, mirroring the bash pre-push gate.
+    # (Previously this skipped, letting a probe error ride the leak out unscanned.)
     monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
     blocked = handler(_post("someowner/mystery", leak_body))
-    assert blocked is False
-    assert capsys.readouterr().out == ""  # no deny JSON
+    decision = json.loads(capsys.readouterr().out)
+    assert blocked is True
+    assert decision["permissionDecision"] == "deny"
+    assert reason_token in decision["permissionDecisionReason"]
 
 
 class TestGateSkipsForVisibilityPolarity:
@@ -154,8 +164,10 @@ class TestGateSkipsForVisibilityPolarity:
     def test_confirmed_private_target_skips(self, monkeypatch: pytest.MonkeyPatch) -> None:
         assert self._skips("gh issue create --repo owner/private-svc --body x", monkeypatch, "PRIVATE") is True
 
-    def test_unresolvable_target_skips(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        assert self._skips("gh issue create --repo owner/mystery --body x", monkeypatch, None) is True
+    def test_probe_error_resolvable_target_does_not_skip(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # #3442: a resolvable slug whose probe cannot confirm visibility (None)
+        # FAILS CLOSED -- the gate scans, it does not skip.
+        assert self._skips("gh issue create --repo owner/mystery --body x", monkeypatch, None) is False
 
     def test_is_affirmatively_public_only_on_confirmed_public(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Distinct slugs so the per-slug day-cache does not carry the first
@@ -249,3 +261,72 @@ class TestInertSubstitutionMarkerInBodyValue:
         # Anti-vacuity: an inert marker does not weaken the gate on a PUBLIC target.
         cmd = "gh issue create --repo souliane/teatree --body 'name the `flag` here'"
         assert self._skips(cmd, monkeypatch, "PUBLIC") is False
+
+
+class TestProbeErrorFailsClosed:
+    """A visibility-probe error on a RESOLVABLE slug FAILS CLOSED, never silently skips (#3442).
+
+    The leak gate is fail-closed-always doctrine: it must SCAN every target it
+    cannot PROVE non-public. Before #3442 a probe error (``slug_visibility ->
+    None``) on a resolvable ``owner/repo`` slug made the gate SKIP -- the same
+    fail-OPEN the bash pre-push mirror was hardened against (§3f #14). These rows
+    pin the reconciled polarity: the structured post AND the raw ``api`` WRITE both
+    scan on a probe error, the decision is signalled on stderr (never silent), and
+    a PROVABLY-private target (allowlist / confirmed-private probe) still skips so
+    the fix does not over-block a declared-private repo.
+    """
+
+    @staticmethod
+    def _skips(command: str, monkeypatch: pytest.MonkeyPatch, verdict: str | None) -> bool:
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: verdict)
+        return public_visibility.gate_skips_for_visibility(command, cwd=None)
+
+    def test_structured_post_probe_error_does_not_skip(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # RED before #3442: probe None on a resolvable, non-allowlisted slug SKIPPED.
+        cmd = "gh issue create --repo someowner/mystery --body leak"
+        assert self._skips(cmd, monkeypatch, None) is False
+
+    def test_api_write_probe_error_does_not_skip(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A raw ``gh api`` WRITE whose URL resolves a slug the probe cannot confirm
+        # is an immediate public egress with no pre-push backstop -- fail closed.
+        cmd = "gh api repos/someowner/mystery/issues -f body=leak"
+        assert self._skips(cmd, monkeypatch, None) is False
+
+    def test_probe_error_scan_is_signalled_on_stderr(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # ALWAYS log a probe-error-driven decision so it is never silent (#3442),
+        # mirroring the bash gate's ``echo ... >&2`` on undetermined visibility.
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        public_visibility.gate_skips_for_visibility("gh issue create --repo someowner/mystery --body x", cwd=None)
+        err = capsys.readouterr().err
+        assert "someowner/mystery" in err
+        assert "fail closed" in err
+
+    def test_confirmed_private_probe_still_skips(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Anti-over-block: a probe-CONFIRMED-private target is provably non-public,
+        # so it still skips -- the fix narrows the scan to the UNCONFIRMED case.
+        cmd = "gh issue create --repo someowner/private-svc --body x"
+        assert self._skips(cmd, monkeypatch, "PRIVATE") is True
+
+    def test_allowlisted_private_skips_without_probe(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The offline allowlist is the network-free way to keep an own-private post
+        # skip-eligible even when the probe cannot run -- so the fail-closed change
+        # does not over-block a DECLARED-private repo.
+        db = tmp_path / "config.sqlite3"
+        conn = sqlite3.connect(str(db))
+        try:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS teatree_config_setting "
+                "(id INTEGER PRIMARY KEY, scope TEXT NOT NULL DEFAULT '', key TEXT NOT NULL, value TEXT NOT NULL)"
+            )
+            conn.execute(
+                "INSERT INTO teatree_config_setting (scope, key, value) VALUES ('', 'private_repos', ?)",
+                (json.dumps(["declaredowner/svc"]),),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
+        cmd = "gh issue create --repo declaredowner/svc --body x"
+        assert public_visibility.gate_skips_for_visibility(cmd, cwd=None, config_path=db) is True

--- a/tests/teatree_hooks/test_publish_destination.py
+++ b/tests/teatree_hooks/test_publish_destination.py
@@ -4,10 +4,11 @@
 publish command; ``is_public_destination`` classifies it FAIL-CLOSED
 (PUBLIC unless provably internal -- consumed by the FSM privacy gate);
 ``public_visibility.gate_skips_for_visibility`` is the composed predicate the
-banned-terms (#1415) / quote-scanner (#1213) gates call, which enforces ONLY on
-an affirmatively-PUBLIC target: a private/internal/unknown/unresolvable target
-SKIPS (bias hard toward not firing), while an affirmatively-public probe verdict
-scans.
+banned-terms (#1415) / quote-scanner (#1213) gates call: it SKIPS only a PROVABLY
+non-public target (allowlisted-private / internal-namespace / probe-confirmed
+private), and SCANS every target it cannot prove non-public -- an
+affirmatively-public probe verdict AND a resolvable slug whose probe cannot
+confirm visibility (fail closed on a probe error, #3442).
 
 Synthetic namespaces only (``internalcorp``, ``acme-internal``, the
 genuinely-public ``souliane/teatree``); the allowlist lives in the user's
@@ -442,12 +443,12 @@ class TestGateSkipsDestination:
 
 
 class TestInternalDenylistScoping:
-    """#1415/#1213 scope: enforce ONLY on an affirmatively-PUBLIC target.
+    """#1415/#1213 scope: SKIP only a PROVABLY non-public target (#3442 fail closed).
 
     A private internal namespace in ``internal_publish_namespaces`` (the
-    denylist) SKIPS; an affirmatively-PUBLIC probe verdict SCANS; and an
-    unknown/unresolvable target now SKIPS too (bias hard toward not firing so a
-    non-public repo is never falsely blocked). A non-repo surface (a Slack
+    denylist) SKIPS; an affirmatively-PUBLIC probe verdict SCANS; and a resolvable
+    target whose probe cannot confirm visibility FAILS CLOSED and SCANS too (#3442
+    -- a probe error is not a licence to skip). A non-repo surface (a Slack
     ``curl``) is not repo-scoped, so this scope leaves it to the gate's default.
     """
 
@@ -470,17 +471,17 @@ class TestInternalDenylistScoping:
         cmd = 'gh issue create -R ourorg/other-public-repo --body "customercorp leak"'
         assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is False
 
-    def test_unknown_visibility_non_denylisted_target_skips(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        # POLICY FLIP (#1415/#1213): a target not in the denylist whose
-        # visibility the in-hook probe cannot resolve (the common cold-hook
-        # state) is NOT affirmatively public, so the gate SKIPS -- bias hard
-        # toward not firing, never false-block a repo of unknown visibility.
+    def test_probe_error_non_denylisted_target_scans(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # #3442 fail closed: a resolvable target NOT in the denylist whose
+        # visibility the in-hook probe cannot confirm (returns None) is NOT
+        # provably non-public, so the gate SCANS (does not skip) -- mirroring the
+        # bash pre-push gate's undetermined-visibility branch. The offline
+        # ``private_repos`` allowlist is the network-free way to keep a genuinely
+        # private repo skip-eligible.
         cfg = _config(tmp_path, ["internal-eng"])
         monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
         cmd = 'gh issue create -R someowner/mystery --body "customercorp note"'
-        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is True
+        assert public_visibility.gate_skips_for_visibility(cmd, None, config_path=cfg) is False
 
     def test_non_repo_surface_is_not_scoped_out(self, tmp_path: Path) -> None:
         # A publish with no repo-targeted segment (a Slack ``curl``) is not

--- a/tests/teatree_hooks/test_publish_gate_golden_corpus.py
+++ b/tests/teatree_hooks/test_publish_gate_golden_corpus.py
@@ -615,19 +615,20 @@ class TestProbeResolvedTargetVisibility:
         cmd = 'gh issue comment 5 --repo someowner/open-svc --body "acmecorp domain note"'
         assert _verdict(cmd, cwd, empty_allowlist_config) == "block"
 
-    def test_unresolvable_target_skips(
+    def test_probe_error_target_fails_closed_and_blocks(
         self, empty_allowlist_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # must-ALLOW (#1415/#1213 policy): when the probe cannot prove the target
-        # PUBLIC (it returns the UNKNOWN ``None`` -- tool absent in-hook or auth
-        # differs) and the allowlist does not name it, the target is NOT
-        # affirmatively public, so the gate SKIPS -- bias hard toward not firing,
-        # never false-block a repo of unknown visibility.
+        # must-DENY (#3442 fail closed): when the probe cannot confirm the target's
+        # visibility (returns the UNKNOWN ``None`` -- tool absent in-hook or auth
+        # differs) and the allowlist does not name it, the target is NOT provably
+        # non-public, so the gate SCANS and the banned term BLOCKS -- mirroring the
+        # bash pre-push gate. A genuinely-private repo declares itself in the
+        # offline ``private_repos`` allowlist to stay skip-eligible.
         monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
         monkeypatch.delenv("GH_REPO", raising=False)
         cwd = self._public_cwd(tmp_path)
         cmd = 'gh issue comment 5 --repo unknown/mystery --body "acmecorp domain note"'
-        assert _verdict(cmd, cwd, empty_allowlist_config) == "allow"
+        assert _verdict(cmd, cwd, empty_allowlist_config) == "block"
 
     def test_clean_post_to_private_probe_target_never_blocks(
         self, empty_allowlist_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -654,15 +655,14 @@ class TestProbeResolvedTargetVisibility:
 
 
 class TestLeakGateEnforcesOnPublicTargetsOnly:
-    """The leak gate enforces on PUBLIC targets ONLY (the user's explicit rule).
+    """The leak gate skips ONLY a PROVABLY non-public target (the user's rule + #3442).
 
-    A customer/banned term is blocked when -- and only when -- the COMMAND's
-    resolved target is affirmatively PUBLIC. On ANY other target -- the user's
-    OWN private overlay repo, a customer's own (colleague) private repo, AND an
-    unknown/unresolvable target -- the gate does NOT block: it resolves the real
-    target from the command and skips the scan (bias hard toward not firing).
-    SYNTHETIC namespaces only; the private ones are proven private via the
-    allowlist and via the live ``gh`` probe shim.
+    A customer/banned term is allowed only when the COMMAND's resolved target is
+    PROVABLY non-public -- the user's OWN private overlay repo or a customer's own
+    (colleague) private repo, proven via the offline allowlist or the live ``gh``
+    probe. On an affirmatively-PUBLIC target it BLOCKS, and on a resolvable target
+    whose probe cannot confirm visibility it now FAILS CLOSED and BLOCKS too
+    (#3442 -- a probe error is not a skip). SYNTHETIC namespaces only.
     """
 
     @pytest.fixture
@@ -726,16 +726,17 @@ class TestLeakGateEnforcesOnPublicTargetsOnly:
         cmd = 'gh pr create --title "feat: x" --body "customercorp here"'
         assert _verdict(cmd, worktree, allowlist_config) == "allow"
 
-    def test_customer_term_to_unresolvable_target_skips(
+    def test_customer_term_to_probe_error_target_fails_closed(
         self, allowlist_config: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # #1415/#1213 policy: an undeclared target whose visibility cannot be
-        # determined (probe returns the UNKNOWN None) is NOT affirmatively public,
-        # so the gate SKIPS -- bias hard toward not firing.
+        # #3442 fail closed: an undeclared target whose visibility cannot be
+        # confirmed (probe returns the UNKNOWN None) is NOT provably non-public, so
+        # the gate SCANS and BLOCKS -- a probe error must never route a leak out
+        # unscanned. A genuinely-private repo is declared in ``private_repos``.
         monkeypatch.setattr(_repo_visibility, "probe_visibility", lambda _slug: None)
         cwd = self._public_cwd(tmp_path)
         cmd = 'gh issue comment 5 --repo unknown/mystery --body "customercorp note"'
-        assert _verdict(cmd, cwd, allowlist_config) == "allow"
+        assert _verdict(cmd, cwd, allowlist_config) == "block"
 
     def test_colleague_private_proven_only_by_probe_allows(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_refuse_public_push_with_leak.py
+++ b/tests/test_refuse_public_push_with_leak.py
@@ -855,5 +855,58 @@ class TestLeakGateRecomputesBaseFromRemoteTrackingRef:
         assert result.returncode == 0, result.stdout + result.stderr
 
 
+def _make_erroring_gh_shim(bin_dir: Path) -> None:
+    """Write a ``gh`` that is PRESENT on PATH but whose ``repo view`` FAILS.
+
+    Distinct from "no gh at all": the tool resolves, but the visibility API call
+    ERRORS (a network/auth failure). The bash gate then sees an empty verdict and
+    must fail CLOSED (scan anyway) -- the exact analogue of the Python leak gate's
+    ``slug_visibility -> None`` probe-error path (#3442).
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    shim = bin_dir / "gh"
+    shim.write_text(
+        '#!/usr/bin/env bash\necho "gh: could not reach api.github.com (probe error)" >&2\nexit 1\n',
+        encoding="utf-8",
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+class TestProbeErrorVisibilityFailsClosed:
+    """A visibility-PROBE ERROR fails CLOSED on the bash pre-push gate (#3442).
+
+    Distinct from the gh-ABSENT rows above: here ``gh`` is PRESENT but its
+    ``repo view`` errors (a network/auth failure), so the gate sees an empty
+    verdict and scans anyway (the ``*)`` undetermined branch). This is the bash
+    half of the #3442 reconciliation; the Python PreToolUse leak gate is held to
+    the SAME polarity (a resolvable slug whose probe cannot be confirmed is
+    scanned, never skipped) by
+    ``tests/teatree_hooks/test_public_visibility.py::TestProbeErrorFailsClosed``.
+    """
+
+    def test_bash_gate_scans_and_blocks_leak_when_probe_errors(self, tmp_path: Path) -> None:
+        # gh PRESENT but `repo view` ERRORS -> visibility undetermined -> fail
+        # CLOSED (scan) -> the planted secret blocks. The loud "fail closed"
+        # warning shows the undetermined path was taken (not a private skip).
+        work, _env = _clone_with_remote(tmp_path, "PUBLIC")
+        bin_dir = tmp_path / "errbin"
+        _make_erroring_gh_shim(bin_dir)
+        env = _hermetic_env()
+        env["PATH"] = f"{bin_dir}{os.pathsep}/usr/bin:/bin"
+        env["T3_PRIVACY_SCAN_CMD"] = f"{sys.executable} {SCAN}"
+        # privacy-scan:allow fixture -- a planted FAKE secret the gate-under-test must
+        # scan; annotated so this repo's own pre-push gate does not flag the diff line.
+        (work / "leak.txt").write_text("token = glpat-XXXXXXXXXXXXXXXX\n", encoding="utf-8")  # privacy-scan:allow
+        _git(work, "add", "leak.txt")
+        _git(work, "commit", "-m", "add config")
+
+        result = _run_hook(work, env, _push_stdin(work))
+
+        assert result.returncode == 1, result.stdout + result.stderr
+        combined = (result.stdout + result.stderr).lower()
+        assert "privacy" in combined
+        assert "fail closed" in combined
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary

Closes #3442.

The affirmative-public leak-gate scope (`teatree.hooks.public_visibility`) — the
PreToolUse banned-terms (#1415) / quote-scanner (#1213) gate — **skipped** the
leak scan whenever a repo-visibility probe returned no verdict (a network/API
error, an absent `gh`/`glab`, or an unrecognised answer) on a **resolvable**
`owner/repo` slug. That **fails OPEN**, contradicting:

- the bash pre-push mirror `scripts/hooks/refuse-public-push-with-leak.sh`, whose
  undetermined-visibility branch scans anyway (fail closed), and
- the fail-closed-always leak-gate doctrine in `hooks/CLAUDE.md`.

## Fix

Visibility is now three-valued (`_Visibility`: `PUBLIC` / `NON_PUBLIC` /
`UNKNOWN`). The gate **SKIPS only a PROVABLY non-public target** (allowlisted-
private, internal-namespace, or a probe-confirmed private/internal verdict) and
**SCANS** every target it cannot prove non-public:

- an affirmatively-`PUBLIC` verdict (unchanged), **and**
- a resolvable slug whose probe cannot be confirmed → **fail CLOSED** (`UNKNOWN`).

A probe-error-driven scan is **signalled on stderr** so it is never silent,
mirroring the bash gate. A **genuinely unresolvable** target (no slug at all,
e.g. a flagless create with no remote) is **unchanged** (still skips). The
offline `private_repos` allowlist stays the network-free way to keep an
own-private post skip-eligible, so a declared private repo is not over-blocked.

## Extra human review requested — polarity change

This PR **reverses the fail direction** of the leak gate on the
probe-error / unknown-visibility path (previously "bias hard toward not
firing"). Please scrutinise the polarity: it now **fails closed** on any
resolvable target whose visibility cannot be confirmed in-hook. The mitigation
against over-blocking a real private repo is the offline `private_repos`
allowlist (plus the existing `ALLOW_BANNED_TERM=1` escape). Several deliberate
#1415 / #1213 / #2597 tests that encoded the old fail-open behaviour were
flipped to assert fail-closed — please confirm this matches intent.

## Tests

- **RED-first** (`test_public_visibility.py::TestProbeErrorFailsClosed`): a probe
  error on a resolvable slug now scans (structured post and raw `api` WRITE), the
  decision is logged to stderr, and a probe-confirmed-private / allowlisted
  target still skips (anti-over-block).
- **Bash-mirror agreement**
  (`test_refuse_public_push_with_leak.py::TestProbeErrorVisibilityFailsClosed`):
  a `gh repo view` error makes the bash pre-push gate scan-and-block (fail
  closed) — the same verdict the Python gate now returns.
- Flipped the prior fail-open assertions across `test_public_visibility.py`,
  `test_publish_destination.py`, `test_publish_gate_golden_corpus.py`,
  `test_banned_terms_public_slug_with_term_blocks.py`, `test_banned_terms_hook.py`,
  and `lane_b/test_parity.py` to assert fail-closed, with updated docstrings.

## Gates run

- `pytest tests/teatree_hooks/` — green (affected files verified individually:
  public_visibility 25, golden-corpus classes 15, destination/public-slug/lane_b
  42, banned_terms_hook 36, bash mirror 2).
- `ruff check` + `ruff format --check` — clean (whole repo).
- module-health `--from-ref origin/main` — exit 0.
- `t3 tool test-path-mirror` — ratchet holds.
