### PR TITLE
fix(resilience): watchdog red-findings DM + surface slack-drain failures

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -340,6 +340,43 @@ ensure_clone() {
     git clone "$REPO_URL" "$CLONE_DIR"
 }
 
+# Drain + 👀-ack inbound Slack on a cadence, SURFACING failures (#3443). The old
+# `t3 slack check >/dev/null 2>&1 || true` swallowed every error, so a drain that
+# could not boot Django looked identical to a healthy one and nobody ever saw it.
+#
+# `t3 slack check` exits 0 when it drained messages and 1 with NO output when the
+# queue was empty (the common, healthy case on a quiet box) — so a non-zero exit
+# is NOT itself a failure. A REAL failure is a non-zero exit that ALSO produced
+# output (a Django boot traceback, a DB error). Those increment a consecutive-
+# failure counter and are logged to stderr (visible in `docker compose logs
+# teatree-slack-listener`); an empty-queue exit never does.
+#
+# Each pass rewrites a heartbeat file that `t3 doctor` reads from another
+# container to surface a stuck/failed drain (self_heal `_check_slack_drain_alive`).
+# The heartbeat path mirrors teatree.paths.DATA_DIR ($HOME/.local/share/teatree) —
+# the filename is pinned to the doctor side by tests/test_deploy_slack_listener.py.
+slack_drain_loop() {
+    local interval="${SLACK_CHECK_INTERVAL_SECONDS:-15}"
+    local heartbeat="${SLACK_DRAIN_HEARTBEAT:-$HOME/.local/share/teatree/slack-drain-heartbeat.json}"
+    local consecutive=0 last_ok=null now out rc
+    mkdir -p "$(dirname "$heartbeat")"
+    while true; do
+        now="$(date +%s)"
+        out="$(t3 slack check 2>&1)" && rc=0 || rc=$?
+        if [ "$rc" -eq 0 ] || { [ "$rc" -eq 1 ] && [ -z "$out" ]; }; then
+            consecutive=0
+            last_ok="$now"
+        else
+            consecutive=$((consecutive + 1))
+            echo "entrypoint: slack drain (t3 slack check) FAILED rc=$rc (consecutive=$consecutive):" >&2
+            printf '%s\n' "$out" >&2
+        fi
+        printf '{"updated_at": %s, "interval_seconds": %s, "consecutive_failures": %s, "last_ok_at": %s}\n' \
+            "$now" "$interval" "$consecutive" "$last_ok" >"$heartbeat"
+        sleep "$interval"
+    done
+}
+
 case "$ROLE" in
 init)
     init_preflight
@@ -402,11 +439,11 @@ slack-listener)
     # slot is not bootstrapped under `t3 worker` in headless, so the listener's
     # captures would never reach an observable state without this. `t3 slack
     # check` drains the JSONL queue and, unlike the drain-queue loop, is NOT
-    # gated by the worker singleton. Failure-tolerant (`|| true`) and
-    # backgrounded so a non-zero check never trips `set -e` or crashes the
-    # foreground listener.
-    SLACK_CHECK_INTERVAL_SECONDS=15
-    ( while true; do t3 slack check >/dev/null 2>&1 || true; sleep "$SLACK_CHECK_INTERVAL_SECONDS"; done ) &
+    # gated by the worker singleton. `slack_drain_loop` backgrounds the cadence
+    # (so `exec t3 slack listen` stays the foreground process), never trips
+    # `set -e`, and — unlike the old `|| true` — logs real failures to stderr and
+    # writes a heartbeat `t3 doctor` reads to catch a stuck/failed drain (#3443).
+    slack_drain_loop &
     exec t3 slack listen
     ;;
 admin)

--- a/deploy/watchdog.sh
+++ b/deploy/watchdog.sh
@@ -91,6 +91,28 @@ notify_owner() {
   fi
 }
 
+# Run `t3 doctor check --json` in the first REACHABLE exec service, capturing its
+# stdout into DOCTOR_RAW regardless of doctor's exit code. This is the heart of
+# the #3440 fix: a red-findings verdict exits NON-ZERO yet is a healthy RUN of
+# doctor, so the watchdog must NOT read a non-zero exit as "unreachable" (that
+# made the red-findings DM path below dead code). Reachability is probed
+# separately (a trivial `exec ... true`); only a genuinely unreachable service
+# falls through to the next one. Returns 0 when a service was reached (DOCTOR_RAW
+# set, possibly empty), 125 when NO exec service could be reached at all.
+run_doctor() {
+  local svc
+  DOCTOR_RAW=""
+  for svc in $EXEC_SERVICES; do
+    if compose exec -T "$svc" true >/dev/null 2>&1; then
+      # `|| true`: doctor exits non-zero on red findings; keep its stdout, drop
+      # the exit code (set -e must not abort, and the code is NOT the signal).
+      DOCTOR_RAW="$(compose exec -T "$svc" t3 doctor check --json 2>/dev/null || true)"
+      return 0
+    fi
+  done
+  return 125
+}
+
 run_pass() {
   log "restarting any down services (gated on init state)"
   if ! restart_down_services; then
@@ -100,18 +122,28 @@ run_pass() {
     return 0
   fi
 
-  local raw
-  if ! raw="$(exec_in_stack t3 doctor check --json)"; then
-    printf 'teatree watchdog: could not run `t3 doctor` in any service (%s) — the stack is unreachable even after `up -d`. SSH in and inspect `docker compose -p %s ps`.' "$EXEC_SERVICES" "$PROJECT" \
+  if ! run_doctor; then
+    # No exec service could be reached at all — a genuine transport failure, the
+    # ONLY case that is truly "unreachable" (distinct from doctor running and
+    # returning a red verdict, which is handled below).
+    printf 'teatree watchdog: could not exec `t3 doctor` in any service (%s) — the stack is unreachable even after `up -d`. SSH in and inspect `docker compose -p %s ps`.' "$EXEC_SERVICES" "$PROJECT" \
       | notify_owner "watchdog:doctor-unreachable:$(date -u +%Y%m%d%H)"
     return 0
   fi
 
-  # Keep only the JSON line (doctor may print incidental lines before it).
+  # Branch on the PRESENCE of a parseable JSON verdict, NOT on doctor's exit code
+  # (#3440). Keep only the JSON line (doctor may print incidental lines before it).
+  # `|| true`: no match makes the pipeline exit non-zero under `set -o pipefail`,
+  # which would abort here before the no-verdict branch could fire.
   local json
-  json="$(printf '%s\n' "$raw" | grep '"ok"' | tail -n 1)"
+  json="$(printf '%s\n' "$DOCTOR_RAW" | grep '"ok"' | tail -n 1 || true)"
   if [ -z "$json" ]; then
-    log "doctor produced no JSON verdict — treating as healthy"
+    # Doctor was reachable but emitted no parseable verdict: a half-crashed doctor
+    # is itself a RED condition, not a healthy pass (the old code treated it as
+    # healthy and stayed silent). DM once per hour so a persistent breakage is seen.
+    log "doctor reachable but produced no JSON verdict — treating as RED"
+    printf 'teatree watchdog: `t3 doctor check --json` ran but produced NO parseable verdict — doctor may be crashing on the box. SSH in and run `t3 doctor check` in `docker compose -p %s exec teatree-admin`.' "$PROJECT" \
+      | notify_owner "watchdog:doctor-no-verdict:$(date -u +%Y%m%d%H)"
     return 0
   fi
 
@@ -143,11 +175,14 @@ run_loop() {
   done
 }
 
-# Extract the FAIL messages from the doctor JSON. Uses python3 (present on the box)
-# and degrades to a generic body when it is absent.
+# Extract the FAIL messages from the doctor JSON (read on stdin). Uses python3
+# (present on the box) and degrades to a generic body when it is absent. Uses
+# `python3 -c` rather than a `-` heredoc: a `python3 - <<'PY'` feeds the heredoc
+# as the PROGRAM on stdin, leaving `sys.stdin` at EOF so the piped verdict is
+# never read — the body would always be the generic fallback.
 _extract_fail_body() {
   if command -v python3 >/dev/null 2>&1; then
-    python3 - <<'PY'
+    python3 -c '
 import json, sys
 try:
     data = json.load(sys.stdin)
@@ -155,7 +190,7 @@ try:
 except Exception:
     fails = []
 print("\n".join(f"- {m}" for m in fails) if fails else "- (see `t3 doctor check` on the box for detail)")
-PY
+'
   else
     printf '%s' "- one or more red findings (install python3 on the box for detail, or run \`t3 doctor check\`)"
   fi
@@ -170,8 +205,14 @@ _stable_key() {
   fi
 }
 
-if [ "${1:-}" = "--loop" ]; then
-  run_loop
-else
-  run_pass
+# Run the dispatch only when EXECUTED, not when sourced — so a test can source
+# this file and drive `run_pass` / `run_doctor` in isolation with stubbed docker.
+# `run_loop` re-invokes the script with `bash "$SELF"`, which is an execution, so
+# the default single pass still fires there.
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  if [ "${1:-}" = "--loop" ]; then
+    run_loop
+  else
+    run_pass
+  fi
 fi

--- a/src/teatree/cli/doctor/checks_slack_roundtrip.py
+++ b/src/teatree/cli/doctor/checks_slack_roundtrip.py
@@ -26,10 +26,13 @@ doctor exit code — a silent break must be a doctor failure, not a surprise. Sl
 stays optional: with no Slack-backed overlay the check is a silent no-op.
 """
 
+import contextlib
 import datetime as dt
+import json
 import os
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 
 import typer
 
@@ -42,6 +45,55 @@ _UNANSWERED_STALENESS = dt.timedelta(minutes=5)
 
 #: The durable ``Loop`` row that gates the reactive Slack-answer / DM-inbound work.
 _ANSWER_LOOP = "inbox"
+
+#: How many consecutive doctor runs the round-trip probe may crash before the gate
+#: stops crash-OPENING and FAILs loud (#3443). A crashed probe reveals nothing, so
+#: below the threshold a one-off blip stays a WARN; a probe that crashes run after
+#: run is itself a break the operator must see, not a silently-green comms gate.
+_MAX_CONSECUTIVE_CRASHES = 3
+#: The durable consecutive-crash tally lives here under ``teatree.paths.DATA_DIR``.
+_CRASH_COUNTER_FILENAME = "slack-roundtrip-crash-count.json"
+
+
+@dataclass(frozen=True, slots=True)
+class _CrashCounter:
+    """A durable count of back-to-back crashed round-trip runs (crash-tolerant I/O).
+
+    Persisted so "consecutive" spans doctor invocations, not one process. All
+    reads/writes degrade silently — a counter that cannot be read/written must
+    never itself crash or falsely redden the doctor run.
+    """
+
+    path: Path
+
+    @classmethod
+    def default(cls) -> "_CrashCounter":
+        # Under the box data dir (``$HOME/.local/share/teatree`` == ``teatree.paths.DATA_DIR``
+        # in the non-worktree deploy container the watchdog runs doctor in). Resolved from
+        # ``Path.home()`` at call time — NOT the import-bound ``DATA_DIR`` constant — so the
+        # test HOME-isolation fixture redirects it per test; otherwise a full-doctor test
+        # whose round-trip probe crashes (no DB) would bump one shared real-box counter
+        # across tests and flip a WARN into a FAIL.
+        return cls(Path.home() / ".local" / "share" / "teatree" / _CRASH_COUNTER_FILENAME)
+
+    def _read(self) -> int:
+        try:
+            return int(json.loads(self.path.read_text(encoding="utf-8"))["consecutive_crashes"])
+        except (OSError, ValueError, TypeError, KeyError, json.JSONDecodeError):
+            return 0
+
+    def bump(self) -> int:
+        count = self._read() + 1
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            self.path.write_text(json.dumps({"consecutive_crashes": count}) + "\n", encoding="utf-8")
+        except OSError:
+            pass
+        return count
+
+    def reset(self) -> None:
+        with contextlib.suppress(OSError):
+            self.path.unlink(missing_ok=True)
 
 
 @dataclass(frozen=True, slots=True)
@@ -276,19 +328,35 @@ def check_slack_roundtrip(
     deep: bool = False,
     env: dict[str, str] | None = None,
     echo: Callable[[str], object] = typer.echo,
+    crash_counter: "_CrashCounter | None" = None,
 ) -> bool:
     """Run the Slack round-trip probes, render each finding, and return the pass/fail verdict.
 
     Gates the overall doctor exit code (unlike the surfacing-only DM-readiness
-    check): a FAIL reddens the run. Crash-proof — any unexpected error degrades to
-    a WARN + OK so a check bug never crashes or falsely reddens the doctor run
-    (the actual comms-break signals are FAILs from probes that ran).
+    check): a FAIL reddens the run. A single crashed run degrades to a WARN + OK so
+    a transient check bug never falsely reddens the run — but a probe that crashes
+    :data:`_MAX_CONSECUTIVE_CRASHES` runs in a row stops crash-OPENING and FAILs
+    loud (#3443), because a permanently-blind comms gate silently passing is the
+    very failure this check exists to catch. A successful run resets the tally.
     """
+    counter = crash_counter or _CrashCounter.default()
     try:
         outcome = run_slack_roundtrip_probes(deep=deep, env=env)
     except Exception as exc:  # noqa: BLE001 — a doctor check must never crash the run
-        echo(f"WARN  Slack round-trip check crashed: {exc.__class__.__name__}: {exc}")
+        count = counter.bump()
+        if count >= _MAX_CONSECUTIVE_CRASHES:
+            echo(
+                f"FAIL  Slack round-trip: check crashed {count} runs in a row (latest "
+                f"{exc.__class__.__name__}: {exc}) — the comms gate has been blind for {count} consecutive "
+                "doctor runs; failing loud instead of crash-opening. Fix the round-trip probe."
+            )
+            return False
+        echo(
+            f"WARN  Slack round-trip check crashed ({count}/{_MAX_CONSECUTIVE_CRASHES}): "
+            f"{exc.__class__.__name__}: {exc} — degrading to a pass this run."
+        )
         return True
+    counter.reset()
     for finding in outcome.findings:
         echo(f"{finding.level.value:<5} Slack round-trip: {finding.message}")
     return outcome.ok

--- a/src/teatree/cli/doctor/self_heal.py
+++ b/src/teatree/cli/doctor/self_heal.py
@@ -14,7 +14,8 @@ and DM the owner:
 - a READY loop timer stale past 2x its cadence (a wedged drain),
 - a PENDING ``interactive`` task under ``agent_runtime=headless`` (unrunnable),
 - a FAILED task on a still-live ticket (the silent-freeze signature),
-- a runtime clone that has drifted off its default branch.
+- a runtime clone that has drifted off its default branch,
+- a slack-drain sidecar failing every pass or gone silent, so inbound Slack stops being answered.
 
 Each returns ``bool`` — ``False`` is a hard FAIL that reddens ``t3 doctor`` (and
 so the watchdog's ``t3 doctor --json``). Every check is crash-proof: any
@@ -27,9 +28,12 @@ import datetime as dt
 import json
 import shutil
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 
 import typer
+
+from teatree.paths import DATA_DIR
 
 #: The compose project the box runs the factory under (``deploy/docker-compose.yml``).
 _COMPOSE_PROJECT = "teatree"
@@ -41,6 +45,28 @@ _LONG_RUNNING_SERVICES = ("teatree-worker", "teatree-admin")
 _DOWN_STATES = frozenset({"created", "exited", "dead", "restarting", "paused"})
 #: The tab-separated ``service\tstate\tstatus`` fields the docker probe emits.
 _STATE_ROW_FIELDS = 3
+
+#: The slack-drain sidecar heartbeat filename under :data:`teatree.paths.DATA_DIR`
+#: (the shared data bind mount). ``deploy/entrypoint.sh``'s ``slack_drain_loop``
+#: rewrites it every pass; doctor — running in another container — reads it here.
+#: The filename is pinned to the entrypoint by ``tests/test_deploy_slack_listener.py``.
+_SLACK_DRAIN_HEARTBEAT_FILENAME = "slack-drain-heartbeat.json"
+#: A drain that has failed this many passes in a row is a real, non-transient break.
+_MAX_DRAIN_CONSECUTIVE_FAILURES = 5
+#: The heartbeat must refresh within max(this x its interval, floor) or the sidecar
+#: is dead/wedged. The multiplier absorbs a slow pass; the floor covers a fast cadence.
+_DRAIN_HEARTBEAT_STALE_MULTIPLIER = 4
+_DRAIN_HEARTBEAT_STALE_FLOOR_SECONDS = 120
+
+
+@dataclass(frozen=True, slots=True)
+class DrainBeat:
+    """One parsed slack-drain heartbeat: when it last ran and its failure streak."""
+
+    updated_at: dt.datetime
+    consecutive_failures: int
+    interval_seconds: int
+
 
 #: A READY loop timer older than this multiple of its cadence is a stalled drain.
 _STALE_TIMER_CADENCE_MULTIPLIER = 2
@@ -192,6 +218,28 @@ class _Probe:
             message = line[len(token) :].strip() if level != "INFO" else line.strip()
             findings.append({"level": level, "message": message})
         return findings
+
+    @staticmethod
+    def slack_drain_heartbeat() -> "DrainBeat | None":
+        """The slack-drain sidecar's last heartbeat, or ``None`` when absent/unreadable.
+
+        ``None`` means the box runs no slack-drain sidecar (a dev machine, or a
+        deploy without the listener) OR the file is unparsable — the caller
+        degrades to a pass, never a false FAIL. Read from
+        :data:`teatree.paths.DATA_DIR` so a test can repoint the whole probe by
+        patching that name on this module.
+        """
+        path = DATA_DIR / _SLACK_DRAIN_HEARTBEAT_FILENAME
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+            updated = dt.datetime.fromtimestamp(int(raw["updated_at"]), tz=dt.UTC)
+            return DrainBeat(
+                updated_at=updated,
+                consecutive_failures=int(raw["consecutive_failures"]),
+                interval_seconds=int(raw.get("interval_seconds", 0)),
+            )
+        except (OSError, ValueError, TypeError, KeyError, json.JSONDecodeError):
+            return None
 
 
 def _check_compose_stack() -> bool:
@@ -401,6 +449,44 @@ def _check_runtime_clone_on_default_branch() -> bool:
     return False
 
 
+def _check_slack_drain_alive() -> bool:
+    """FAIL when the slack-drain sidecar is failing every pass or has gone silent.
+
+    The ``teatree-slack-listener`` service drains inbound Slack every ~15s
+    (``deploy/entrypoint.sh`` ``slack_drain_loop``) and rewrites a heartbeat with
+    its consecutive-failure count. A drain failing pass after pass (``t3 slack
+    check`` erroring — Django won't boot, DB unreachable) or a heartbeat gone
+    stale (the loop died or hung) both mean captured DMs never reach the answer
+    pipeline: teatree reacts 👀 but silently stops answering. Best-effort — an
+    absent/unreadable heartbeat (no sidecar on this box) degrades to a pass.
+    """
+    try:
+        beat = _Probe.slack_drain_heartbeat()
+        now = _now()
+    except Exception as exc:  # noqa: BLE001 — a self-heal probe must never crash the doctor run
+        typer.echo(f"WARN  Slack-drain check crashed: {exc.__class__.__name__}: {exc}")
+        return True
+    if beat is None:
+        return True
+    stale_after = max(_DRAIN_HEARTBEAT_STALE_MULTIPLIER * beat.interval_seconds, _DRAIN_HEARTBEAT_STALE_FLOOR_SECONDS)
+    age = (now - beat.updated_at).total_seconds()
+    if age > stale_after:
+        typer.echo(
+            f"FAIL  Slack-drain heartbeat is stale ({int(age)}s old, past {stale_after}s) — the "
+            f"`teatree-slack-listener` drain loop has died or hung, so inbound Slack is no longer drained "
+            f"or answered. Restart it: `docker compose -p {_COMPOSE_PROJECT} up -d teatree-slack-listener`."
+        )
+        return False
+    if beat.consecutive_failures >= _MAX_DRAIN_CONSECUTIVE_FAILURES:
+        typer.echo(
+            f"FAIL  Slack drain has failed {beat.consecutive_failures} passes in a row — `t3 slack check` "
+            f"keeps erroring in the `teatree-slack-listener` sidecar, so captured DMs never get 👀-acked or "
+            f"answered. Inspect `docker compose -p {_COMPOSE_PROJECT} logs teatree-slack-listener`."
+        )
+        return False
+    return True
+
+
 def _now() -> dt.datetime:
     from django.utils import timezone  # noqa: PLC0415 — deferred: Django import at call time
 
@@ -421,6 +507,7 @@ def run_self_heal_checks() -> bool:
         _check_interactive_task_under_headless,
         _check_failed_tasks_on_live_tickets,
         _check_runtime_clone_on_default_branch,
+        _check_slack_drain_alive,
     )
     ok = True
     for check in checks:

--- a/tests/cli_doctor/test_slack_roundtrip.py
+++ b/tests/cli_doctor/test_slack_roundtrip.py
@@ -216,11 +216,69 @@ class TestRenderAndGate(_HealthyBaseline):
         assert any("Slack round-trip:" in line and "FAIL" in line for line in lines)
 
     def test_check_is_crash_proof(self) -> None:
+        # A SINGLE crashed run still degrades to OK (a WARN), never reddens the run.
+        import tempfile  # noqa: PLC0415 — test-local
+        from pathlib import Path  # noqa: PLC0415 — test-local
+
+        from teatree.cli.doctor.checks_slack_roundtrip import _CrashCounter  # noqa: PLC0415 — test-local
+
         lines: list[str] = []
+        with tempfile.TemporaryDirectory() as d:
+            counter = _CrashCounter(Path(d) / "crash.json")
+            with patch(
+                "teatree.cli.slack.provision._slack_overlays",
+                side_effect=RuntimeError("boom"),
+            ):
+                ok = check_slack_roundtrip(echo=lines.append, crash_counter=counter)
+        assert ok is True  # one crash degrades to OK, never crashes/reddens the run
+        assert any("crashed" in line for line in lines)
+
+
+class TestConsecutiveCrashGate(_HealthyBaseline):
+    """A probe that crashes run after run stops crash-OPENING and FAILs loud (#3443)."""
+
+    def _crash_once(self, counter: object, lines: list[str]) -> bool:
         with patch(
             "teatree.cli.slack.provision._slack_overlays",
             side_effect=RuntimeError("boom"),
         ):
-            ok = check_slack_roundtrip(echo=lines.append)
-        assert ok is True  # a check bug degrades to OK, never crashes/reddens the run
-        assert any("crashed" in line for line in lines)
+            return check_slack_roundtrip(echo=lines.append, crash_counter=counter)
+
+    def test_fails_after_max_consecutive_crashes(self) -> None:
+        import tempfile  # noqa: PLC0415 — test-local
+        from pathlib import Path  # noqa: PLC0415 — test-local
+
+        from teatree.cli.doctor.checks_slack_roundtrip import (  # noqa: PLC0415 — test-local import
+            _MAX_CONSECUTIVE_CRASHES,
+            _CrashCounter,
+        )
+
+        lines: list[str] = []
+        with tempfile.TemporaryDirectory() as d:
+            counter = _CrashCounter(Path(d) / "crash.json")
+            verdicts = [self._crash_once(counter, lines) for _ in range(_MAX_CONSECUTIVE_CRASHES)]
+        # Every run before the last is a WARN+pass; the threshold run FAILs.
+        assert verdicts[:-1] == [True] * (_MAX_CONSECUTIVE_CRASHES - 1)
+        assert verdicts[-1] is False
+        assert any("FAIL" in line and "runs in a row" in line for line in lines)
+
+    def test_a_successful_run_resets_the_streak(self) -> None:
+        import tempfile  # noqa: PLC0415 — test-local
+        from pathlib import Path  # noqa: PLC0415 — test-local
+
+        from teatree.cli.doctor.checks_slack_roundtrip import (  # noqa: PLC0415 — test-local import
+            _MAX_CONSECUTIVE_CRASHES,
+            _CrashCounter,
+        )
+
+        lines: list[str] = []
+        with tempfile.TemporaryDirectory() as d:
+            counter = _CrashCounter(Path(d) / "crash.json")
+            # Crash up to one short of the threshold...
+            for _ in range(_MAX_CONSECUTIVE_CRASHES - 1):
+                assert self._crash_once(counter, lines) is True
+            # ...a healthy run resets the tally (no overlay → silent no-op pass)...
+            with patch("teatree.cli.slack.provision._slack_overlays", return_value=[]):
+                assert check_slack_roundtrip(echo=lines.append, crash_counter=counter) is True
+            # ...so the very next crash is a WARN again, not a FAIL.
+            assert self._crash_once(counter, lines) is True

--- a/tests/teatree_cli/doctor/test_self_heal.py
+++ b/tests/teatree_cli/doctor/test_self_heal.py
@@ -369,3 +369,69 @@ class ParseFindingsTest(TestCase):
 
     def test_blank_lines_skipped(self) -> None:
         assert self_heal._Probe.parse_findings("\n\n  \n") == []
+
+
+class SlackDrainCheckTest(TestCase):
+    """`_check_slack_drain_alive` reads the sidecar heartbeat another container writes.
+
+    Functional: writes a real heartbeat JSON to a tmp DATA_DIR and runs the check,
+    so the probe's parse and the FAIL/degrade logic are exercised together.
+    """
+
+    def setUp(self) -> None:
+        import tempfile  # noqa: PLC0415 — test-local
+
+        self._dir = tempfile.mkdtemp()
+        self._patch = mock.patch(f"{_MOD}.DATA_DIR", Path(self._dir))
+        self._patch.start()
+        self.addCleanup(self._patch.stop)
+
+    def _write_beat(self, *, age_seconds: int, consecutive: int, interval: int = 15) -> None:
+        import time  # noqa: PLC0415 — test-local
+
+        beat = {
+            "updated_at": int(time.time()) - age_seconds,
+            "interval_seconds": interval,
+            "consecutive_failures": consecutive,
+            "last_ok_at": int(time.time()) - age_seconds,
+        }
+        (Path(self._dir) / "slack-drain-heartbeat.json").write_text(_json.dumps(beat), encoding="utf-8")
+
+    def test_absent_heartbeat_degrades_to_pass(self) -> None:
+        ok, out = _echoes(self_heal._check_slack_drain_alive)
+        assert ok is True
+        assert out == ""
+
+    def test_fresh_healthy_heartbeat_is_ok(self) -> None:
+        self._write_beat(age_seconds=5, consecutive=0)
+        ok, out = _echoes(self_heal._check_slack_drain_alive)
+        assert ok is True
+        assert out == ""
+
+    def test_stale_heartbeat_fails(self) -> None:
+        # No refresh for well past max(4x interval, 120s) — the drain loop died/hung.
+        self._write_beat(age_seconds=600, consecutive=0)
+        ok, out = _echoes(self_heal._check_slack_drain_alive)
+        assert ok is False
+        assert "FAIL" in out
+        assert "stale" in out
+
+    def test_consecutive_failures_fail(self) -> None:
+        self._write_beat(age_seconds=5, consecutive=self_heal._MAX_DRAIN_CONSECUTIVE_FAILURES)
+        ok, out = _echoes(self_heal._check_slack_drain_alive)
+        assert ok is False
+        assert "FAIL" in out
+        assert "failed" in out
+
+    def test_a_few_failures_but_fresh_is_ok(self) -> None:
+        # Below the threshold and freshly beating — a transient blip, not a break.
+        self._write_beat(age_seconds=5, consecutive=self_heal._MAX_DRAIN_CONSECUTIVE_FAILURES - 1)
+        ok, out = _echoes(self_heal._check_slack_drain_alive)
+        assert ok is True
+        assert out == ""
+
+    def test_unparsable_heartbeat_degrades_to_pass(self) -> None:
+        (Path(self._dir) / "slack-drain-heartbeat.json").write_text("{not json", encoding="utf-8")
+        ok, out = _echoes(self_heal._check_slack_drain_alive)
+        assert ok is True
+        assert out == ""

--- a/tests/test_deploy_slack_listener.py
+++ b/tests/test_deploy_slack_listener.py
@@ -1,3 +1,4 @@
+# test-path: cross-cutting — drives deploy/entrypoint.sh + docker-compose.yml + the doctor drain-heartbeat contract.
 """The Slack Socket-Mode receiver runs as its own Docker service.
 
 Inbound Slack (a DM reply, a mention, an emoji reaction) only reaches the loop
@@ -13,8 +14,13 @@ Structure is parsed from the deploy sources directly (the source of truth),
 mirroring `tests/test_deploy_bindmount_compose.py`.
 """
 
+import json
+import os
+import shutil
+import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 DEPLOY = Path(__file__).resolve().parents[1] / "deploy"
@@ -29,6 +35,25 @@ class TestInitInstallsSlackExtra:
         # Without the [slack] extra slack_sdk is absent and the receiver logs
         # "slack_sdk not installed" then no-ops — inbound Slack never arrives.
         assert '"$CLONE_DIR[slack]"' in ENTRYPOINT
+
+
+_BASH = shutil.which("bash") or "bash"
+_TIMEOUT = shutil.which("timeout") or "timeout"
+
+
+def _drain_loop_body() -> str:
+    """The verbatim source of the top-level ``slack_drain_loop`` shell function."""
+    lines: list[str] = []
+    capturing = False
+    for line in ENTRYPOINT.splitlines():
+        if line.startswith("slack_drain_loop() {"):
+            capturing = True
+        if capturing:
+            lines.append(line)
+            if line == "}":
+                return "\n".join(lines)
+    not_found = "slack_drain_loop function not found in entrypoint.sh"
+    raise AssertionError(not_found)
 
 
 class TestSlackListenerRole:
@@ -46,21 +71,37 @@ class TestSlackListenerRole:
         # listener's captured DMs never reach an observable (👀-acked) state.
         # `t3 slack check` drains the JSONL queue and is NOT worker-singleton
         # gated (unlike the drain-queue loop).
-        arm = self._arm
-        assert "t3 slack check" in arm
-        assert "while true; do" in arm, "the drain must run on a repeating cadence, not once"
+        body = _drain_loop_body()
+        assert "t3 slack check" in body
+        assert "while true; do" in body, "the drain must run on a repeating cadence, not once"
 
-    def test_drain_loop_is_failure_tolerant_and_backgrounded(self) -> None:
-        # `set -euo pipefail` at the top must never let a non-zero `t3 slack
-        # check` crash the service: the `|| true` swallows the exit code and
-        # the `( … ) &` backgrounds the loop so `exec t3 slack listen` stays
-        # the foreground process.
+    def test_drain_loop_is_backgrounded_before_the_foreground_exec(self) -> None:
+        # `slack_drain_loop &` backgrounds the cadence so `exec t3 slack listen`
+        # stays the foreground process; it must start BEFORE the exec, or exec
+        # would replace the shell before the loop is ever launched.
         arm = self._arm
-        assert "t3 slack check >/dev/null 2>&1 || true" in arm
+        assert "slack_drain_loop &" in arm
         assert "&\n" in arm, "the drain loop must be backgrounded"
-        # The background drain must be started BEFORE the foreground exec, or
-        # exec would replace the shell before the loop is ever launched.
-        assert arm.index("while true; do") < arm.index("exec t3 slack listen")
+        # `rindex` for the exec: an earlier mention lives in the explanatory comment.
+        assert arm.index("slack_drain_loop &") < arm.rindex("exec t3 slack listen")
+
+    def test_drain_failures_are_surfaced_not_swallowed(self) -> None:
+        # #3443: the old `>/dev/null 2>&1 || true` hid every error. The loop must
+        # now log real failures to stderr with a consecutive-failure counter and
+        # never re-introduce the output-swallowing form in the active loop body.
+        body = _drain_loop_body()
+        assert "t3 slack check >/dev/null 2>&1 || true" not in body
+        assert ">&2" in body, "drain failures must be logged to stderr"
+        assert "consecutive" in body, "the loop must track a consecutive-failure counter"
+
+    def test_drain_writes_a_heartbeat_doctor_reads(self) -> None:
+        # The heartbeat filename is the doctor↔entrypoint contract; the doctor
+        # side (`self_heal._SLACK_DRAIN_HEARTBEAT_FILENAME`) must name the same file.
+        from teatree.cli.doctor.self_heal import _SLACK_DRAIN_HEARTBEAT_FILENAME  # noqa: PLC0415 — test-local import
+
+        body = _drain_loop_body()
+        assert _SLACK_DRAIN_HEARTBEAT_FILENAME in body
+        assert "consecutive_failures" in body, "the heartbeat must carry the failure count doctor gates on"
 
     def test_role_is_documented_and_validated(self) -> None:
         # The required-role prompt and the unknown-role guard both name it, so a
@@ -97,7 +138,63 @@ class TestComposeSlackListenerService:
         assert SHARED_DB_MOUNT in sources
 
 
-if __name__ == "__main__":
-    import pytest
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("timeout") is None,
+    reason="needs bash + timeout (present in the deploy image and CI)",
+)
+class TestSlackDrainLoopExecution:
+    """Run the REAL `slack_drain_loop` (extracted verbatim) with a stub `t3`.
 
+    `t3 slack check` exits 1-with-no-output on an empty queue (healthy) and
+    non-zero-with-output on a real failure; the loop must tell them apart, log
+    only real failures to stderr, and record the streak in the heartbeat doctor
+    reads.
+    """
+
+    def _run(self, tmp_path: Path, check_body: str) -> tuple[str, dict]:
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        t3 = bin_dir / "t3"
+        # The stub answers only `t3 slack check`; anything else is a no-op success.
+        t3.write_text(
+            '#!/usr/bin/env bash\nif [ "$1 $2" = "slack check" ]; then\n' + check_body + "\nfi\nexit 0\n",
+            encoding="utf-8",
+        )
+        t3.chmod(0o755)
+        heartbeat = tmp_path / "hb.json"
+        harness = tmp_path / "harness.sh"
+        harness.write_text(f"set -euo pipefail\n{_drain_loop_body()}\nslack_drain_loop\n", encoding="utf-8")
+        env = dict(os.environ)
+        env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+        env["SLACK_CHECK_INTERVAL_SECONDS"] = "0.2"
+        env["SLACK_DRAIN_HEARTBEAT"] = str(heartbeat)
+        proc = subprocess.run(
+            [_TIMEOUT, "1", _BASH, str(harness)],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+        beat = json.loads(heartbeat.read_text(encoding="utf-8")) if heartbeat.exists() else {}
+        return proc.stderr, beat
+
+    def test_real_failure_is_logged_and_counted(self, tmp_path: Path) -> None:
+        stderr, beat = self._run(tmp_path, 'echo "Traceback: DB unreachable" >&2\nexit 2')
+        assert "FAILED" in stderr
+        assert "Traceback: DB unreachable" in stderr, "the real error output must reach the logs"
+        assert beat.get("consecutive_failures", 0) >= 1
+
+    def test_empty_queue_is_not_a_failure(self, tmp_path: Path) -> None:
+        # exit 1 with NO output = empty queue on a quiet box; must not count/log.
+        stderr, beat = self._run(tmp_path, "exit 1")
+        assert "FAILED" not in stderr
+        assert beat.get("consecutive_failures", -1) == 0
+
+    def test_drained_messages_reset_the_streak(self, tmp_path: Path) -> None:
+        stderr, beat = self._run(tmp_path, 'echo "{\\"overlay\\": \\"acme\\"}"\nexit 0')
+        assert "FAILED" not in stderr
+        assert beat.get("consecutive_failures", -1) == 0
+
+
+if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_deploy_watchdog.py
+++ b/tests/test_deploy_watchdog.py
@@ -1,0 +1,116 @@
+"""The in-daemon watchdog's red-findings DM path (deploy/watchdog.sh, #3440).
+
+`t3 doctor check --json` exits NON-ZERO when it ran and found red findings (it
+still prints a parseable ``{"ok": false, ...}`` verdict). The watchdog used to
+read any non-zero exit as "stack unreachable", so a genuine red verdict was
+misreported as unreachable and the findings-DM path was dead code. The fix keys
+on the PRESENCE of a parseable verdict, not the exit code.
+
+These run the REAL `run_pass` (the script is sourced, its dispatch guarded so it
+does not auto-run) with a stub `docker` on PATH that models `docker compose`:
+init complete, the stack reachable, and `t3 doctor` emitting a chosen verdict.
+The owner DM is captured to a file so each branch's message is asserted.
+"""
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+WATCHDOG = Path(__file__).resolve().parents[1] / "deploy" / "watchdog.sh"
+_BASH = shutil.which("bash") or "bash"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None or shutil.which("python3") is None,
+    reason="needs bash + jq + python3 (present in the deploy image and CI)",
+)
+
+_RED_VERDICT = '{"ok": false, "findings": [{"level": "FAIL", "message": "Compose service teatree-worker is exited"}]}'
+_GREEN_VERDICT = '{"ok": true, "findings": []}'
+
+
+def _write_docker_stub(bin_dir: Path) -> None:
+    """A `docker` shim modelling the `docker compose` calls run_pass makes.
+
+    ``STUB_INIT_PS`` is the init service's `ps --format json` row; ``STUB_TRUE_RC``
+    is the reachability probe's exit code (non-zero → unreachable); a doctor `exec`
+    prints ``STUB_DOCTOR_JSON`` and exits ``STUB_DOCTOR_RC``; a `notify send` exec
+    captures the piped DM body to ``STUB_NOTIFY_FILE``.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    shim = bin_dir / "docker"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        '[ "$1" = compose ] || exit 0\n'
+        "shift\n"
+        'while [ "${1:-}" = -p ] || [ "${1:-}" = -f ]; do shift 2; done\n'
+        'sub="${1:-}"; shift || true\n'
+        'case "$sub" in\n'
+        '  ps) printf "%s\\n" "$STUB_INIT_PS" ;;\n'
+        "  up) exit 0 ;;\n"
+        "  exec)\n"
+        '    [ "${1:-}" = -T ] && shift\n'
+        "    shift || true\n"
+        '    rest="$*"\n'
+        '    case "$rest" in\n'
+        '      true) exit "${STUB_TRUE_RC:-0}" ;;\n'
+        '      *"doctor check --json"*) printf "%s\\n" "$STUB_DOCTOR_JSON"; exit "${STUB_DOCTOR_RC:-1}" ;;\n'
+        '      *"notify send"*) cat >"$STUB_NOTIFY_FILE"; exit 0 ;;\n'
+        "      *) exit 0 ;;\n"
+        "    esac\n"
+        "    ;;\n"
+        "  *) exit 0 ;;\n"
+        "esac\n",
+        encoding="utf-8",
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _run_pass(tmp_path: Path, **stub_env: str) -> str:
+    """Source watchdog.sh, run one `run_pass`, and return the captured owner DM (or "")."""
+    bin_dir = tmp_path / "bin"
+    _write_docker_stub(bin_dir)
+    notify_file = tmp_path / "dm.txt"
+    harness = tmp_path / "harness.sh"
+    harness.write_text(f'set -uo pipefail\nsource "{WATCHDOG}"\nrun_pass\n', encoding="utf-8")
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["STUB_NOTIFY_FILE"] = str(notify_file)
+    env.setdefault("STUB_INIT_PS", '{"State":"exited","ExitCode":0}')
+    env.setdefault("STUB_DOCTOR_JSON", _GREEN_VERDICT)
+    env.update(stub_env)
+    subprocess.run([_BASH, str(harness)], capture_output=True, text=True, check=False, env=env)
+    return notify_file.read_text(encoding="utf-8") if notify_file.exists() else ""
+
+
+class TestWatchdogRunPass:
+    def test_red_findings_verdict_dms_the_findings_not_unreachable(self, tmp_path: Path) -> None:
+        # doctor RAN and found reds → exit 1 WITH a parseable verdict. This must
+        # take the findings-DM path (the #3440 regression sent "unreachable").
+        dm = _run_pass(tmp_path, STUB_DOCTOR_JSON=_RED_VERDICT, STUB_DOCTOR_RC="1")
+        assert "red findings" in dm
+        assert "teatree-worker" in dm, "the FAIL message must be in the DM body"
+        assert "unreachable" not in dm
+
+    def test_green_verdict_sends_no_dm(self, tmp_path: Path) -> None:
+        dm = _run_pass(tmp_path, STUB_DOCTOR_JSON=_GREEN_VERDICT, STUB_DOCTOR_RC="0")
+        assert dm == ""
+
+    def test_unreachable_stack_dms_unreachable(self, tmp_path: Path) -> None:
+        # No exec service is reachable (the probe fails) → the ONLY true-unreachable case.
+        dm = _run_pass(tmp_path, STUB_TRUE_RC="1")
+        assert "unreachable" in dm
+
+    def test_reachable_but_no_verdict_is_treated_as_red(self, tmp_path: Path) -> None:
+        # doctor ran but emitted no parseable verdict — a half-crashed doctor is a
+        # RED condition, not a silent healthy pass.
+        dm = _run_pass(tmp_path, STUB_DOCTOR_JSON="garbage with no verdict line", STUB_DOCTOR_RC="1")
+        assert "no parseable verdict" in dm.lower()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## #3440 — watchdog red-findings path was dead code

`t3 doctor check --json` exits non-zero when it *ran* and found red findings (it still prints a parseable `{"ok": false, ...}` verdict). `deploy/watchdog.sh` treated any non-zero exit as "stack unreachable", so a genuine red verdict was misreported as unreachable and the findings-DM path never fired.

- Branch on the **presence of a parseable `--json` verdict**, not the exit code. A reachable service that produced no verdict is treated as RED (a half-crashed doctor), and only a true transport failure (no exec service reachable) is "unreachable".
- Fix `_extract_fail_body`: a `python3 - <<HEREDOC` fed the heredoc as the program on stdin, leaving `sys.stdin` at EOF, so the DM body was always the generic fallback. Switched to `python3 -c` so the piped verdict reaches the parser and the DM lists the actual FAIL findings.
- Guard the verdict extraction against `set -o pipefail` (a `grep` no-match would abort before the no-verdict branch).

## #3443 — slack-drain sidecar swallowed output; round-trip check crash-opened

- `deploy/entrypoint.sh`: the drain sidecar discarded stdout/stderr. It now logs real failures to stderr with a consecutive-failure counter (distinguishing an empty-queue `exit 1` with no output, the healthy quiet-box case, from a genuine error) and writes a heartbeat file.
- New `t3 doctor` self-heal detector (`_check_slack_drain_alive`) reads that heartbeat from another container and FAILs on a stale heartbeat (dead/hung loop) or a run of consecutive failures.
- The Slack round-trip check (`checks_slack_roundtrip`) no longer crash-OPENS: it FAILs after N consecutive crashed runs instead of silently passing, so a permanently-blind comms gate is surfaced.

Tests lean functional (real files under `tmp_path`, extracted shell functions run under `bash` with stubbed `t3`/`docker`), RED-first on the watchdog red-findings -> DM path and the crash-open -> FAIL path.

Closes #3440
Closes #3443