### PR TITLE
fix(deploy): freshbox bootstrap — all bind dirs, deterministic UID, digest-pinned base (closes #3439, closes #3438, closes #3452)

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -2,7 +2,10 @@
 # selected by $TEATREE_ROLE. Extends the dev/Dockerfile.test toolchain and adds
 # gh. The teatree source is NOT baked: it is cloned onto a volume at runtime and
 # installed editable by the init role, so the image is just the toolchain.
-FROM ubuntu:24.04
+#
+# Digest-pinned to the same ubuntu:24.04 manifest dev/Dockerfile.test pins, so a
+# retag of the floating tag can never silently change the deploy toolchain.
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 
 # Toolchain layer — ca-certificates, curl, git, jq, sqlite3, direnv, node 24, the
 # claude CLI (as in dev/Dockerfile.test) plus gh, plus pass/gnupg so the box can
@@ -65,6 +68,22 @@ RUN mkdir -p \
     chown -R teatree:teatree /home/teatree /opt/teatree
 
 COPY --chmod=0755 deploy/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# Align the runtime user to a DETERMINISTIC UID (the TEATREE_UID build arg,
+# default 1000). Every host bind mount is at path identity (see
+# deploy/README.md § UID invariant), so the container UID MUST equal the host
+# deploy user's UID or every bind mount is unwritable and init crash-loops on
+# its first write. Ubuntu 24.04 ships a stock `ubuntu` user already holding UID
+# 1000, so it is removed to free the id; the teatree user created above (at the
+# next free id) is renumbered onto TEATREE_UID and its already-populated home
+# tree is re-owned to the new id. A fresh box's first `adduser` is UID 1000, so
+# the default lines up with no extra step; override with
+# `--build-arg TEATREE_UID=<n>` when the deploy user is not 1000.
+ARG TEATREE_UID=1000
+RUN userdel -r ubuntu 2>/dev/null || true; \
+    usermod -u "${TEATREE_UID}" teatree && \
+    groupmod -g "${TEATREE_UID}" teatree && \
+    chown -R teatree:teatree /home/teatree /opt/teatree  # privacy-scan:allow
 
 # The deploy-managed default ~/.claude/settings.json template (#3359). The init
 # role generates the container's real settings.json from this (plus env overrides)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -68,6 +68,34 @@ from the operator's real DB.
 `teatree_src` and `teatree_uv` stay Docker-managed named volumes for now (later
 PRs handle code-mount modes).
 
+### UID invariant — the container user must equal the host deploy user
+
+Every state, credential, and session mount in the table above is a **host bind
+mount at path identity**, so each file on the host disk carries the host deploy
+user's numeric UID while the container writes it as the image's `teatree` user.
+Those two must be the **same UID**, or every bind mount is unwritable from inside
+the container and `init` crash-loops on its first write.
+
+`deploy/Dockerfile` therefore pins the container `teatree` user to a
+**deterministic UID** — the `TEATREE_UID` build arg, default **1000** — and removes
+Ubuntu 24.04's stock `ubuntu` user (which already occupies UID 1000) so `teatree`
+can claim it. A fresh box's first non-root user (`adduser teatree` in the bootstrap
+below) is UID 1000, so the default lines up with no extra step, and `deploy.sh`
+pre-creates every bind-mount source owned by that deploy user before the stack
+starts.
+
+If your deploy user is not UID 1000, build the image with a matching UID so the
+mounts stay writable:
+
+```bash
+docker compose -f deploy/docker-compose.yml build \
+    --build-arg TEATREE_UID="$(id -u)"
+```
+
+Changing the container UID on a box that already has bind-mount data written under
+the old UID requires a one-time `chown` of the bind sources to the new UID (stack
+stopped), otherwise the pre-existing files stay unwritable.
+
 ### One-time volume migration (operator step)
 
 A box that ran an older deploy has its state in Docker named volumes

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -50,14 +50,23 @@ git -C "$REPO_ROOT" fetch --prune origin
 git -C "$REPO_ROOT" pull --ff-only
 echo "deploy: deploying $(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD) @ $(git -C "$REPO_ROOT" rev-parse --short HEAD)"
 
-# The credential-plane bind sources must pre-exist owned by the deploy user —
-# dockerd would otherwise create a missing source ROOT-owned, locking the user
-# out of later `pass insert` provisioning. Empty dirs are the sane degradation
-# for an env-token box (init's preflight then falls through to CLAUDE_CODE_OAUTH_TOKEN).
+# EVERY host bind-mount SOURCE dir (compose x-teatree-common `volumes:`) must
+# pre-exist owned by the deploy user. A missing source is auto-created by dockerd
+# ROOT-owned, which locks the non-root container — whose UID must equal this
+# deploy user (see deploy/README.md § UID invariant) — out of that mount: the
+# credential plane then blocks `pass insert` provisioning, and the data + session
+# planes block the DB, worktree, workspace, and transcript writes so `init`
+# crash-loops on its first write. Empty dirs are the sane degradation for an
+# env-token box (init's preflight then falls through to CLAUDE_CODE_OAUTH_TOKEN).
+#
+# The credential plane (pass store + its GPG home) is mode 700; the data and
+# session planes take the default mode.
 install -d -m 700 "$HOME/.password-store" "$HOME/.gnupg"
-# The dream pass's transcript/memory input dir must pre-exist owned by the deploy
-# user — dockerd would otherwise create the missing bind source ROOT-owned.
-install -d "$HOME/.claude/projects"
+install -d \
+    "$HOME/.local/share/teatree" \
+    "$HOME/.local/share/teatree-worktrees" \
+    "$HOME/workspace/t3-workspaces" \
+    "$HOME/.claude/projects"
 
 # Surface the WHY on a build/up failure — `set -e` would otherwise exit before
 # the Action log sees anything but "exited (1)".

--- a/tests/test_deploy_freshbox_bootstrap.py
+++ b/tests/test_deploy_freshbox_bootstrap.py
@@ -1,0 +1,112 @@
+"""Fresh-box bootstrap invariants for the headless deploy substrate.
+
+Three failure modes broke a first deploy onto a clean box and are pinned here
+against the deploy files (the source of truth):
+
+- ``deploy/deploy.sh`` must pre-create EVERY host bind-mount source owned by the
+    deploy user. A source missing at ``up`` time is auto-created by dockerd
+    ROOT-owned, and the non-root container then cannot write it.
+- ``deploy/Dockerfile`` must give its runtime user a DETERMINISTIC UID (equal to
+    the host deploy user) so every path-identity bind mount is writable.
+- ``deploy/Dockerfile`` must digest-pin its base image to the same manifest that
+    ``dev/Dockerfile.test`` pins, so a floating-tag retag cannot change the
+    toolchain silently.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+DEPLOY_DIR = Path(__file__).resolve().parents[1] / "deploy"
+COMPOSE_FILE = DEPLOY_DIR / "docker-compose.yml"
+DEPLOY_SH = DEPLOY_DIR / "deploy.sh"
+DOCKERFILE = DEPLOY_DIR / "Dockerfile"
+DEV_DOCKERFILE = Path(__file__).resolve().parents[1] / "dev" / "Dockerfile.test"
+
+_HOME = "/home/teatree"  # privacy-scan:allow — the box's public, documented deploy home
+
+
+def _bind_sources() -> set[str]:
+    """Every host bind-mount SOURCE path the shared service list declares."""
+    compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+    volumes = compose["x-teatree-common"]["volumes"]
+    return {entry["source"] for entry in volumes if isinstance(entry, dict) and entry.get("type") == "bind"}
+
+
+def _install_d_targets(script: str) -> set[str]:
+    """The absolute paths ``deploy.sh`` pre-creates via ``install -d``.
+
+    Backslash line continuations are folded first so a multi-line ``install -d``
+    reads as one command; ``$HOME`` expands to the deploy user's home to match the
+    compose bind sources.
+    """
+    folded = re.sub(r"\\\n\s*", " ", script)
+    targets: set[str] = set()
+    for line in folded.splitlines():
+        if not line.strip().startswith("install -d"):
+            continue
+        targets.update(_HOME + suffix for suffix in re.findall(r'"\$HOME(/[^"]+)"', line))
+    return targets
+
+
+def _base_digest(dockerfile_text: str) -> str | None:
+    match = re.search(r"ubuntu:24\.04@(sha256:[0-9a-f]{64})", dockerfile_text)
+    return match.group(1) if match else None
+
+
+class TestDeployPreCreatesEveryBindSource:
+    def test_all_bind_sources_are_pre_created_owned_by_deploy_user(self) -> None:
+        created = _install_d_targets(DEPLOY_SH.read_text(encoding="utf-8"))
+        missing = _bind_sources() - created
+        assert not missing, f"deploy.sh does not pre-create bind sources: {sorted(missing)}"
+
+    def test_credential_plane_is_created_mode_700(self) -> None:
+        folded = re.sub(r"\\\n\s*", " ", DEPLOY_SH.read_text(encoding="utf-8"))
+        secret_lines = [
+            line for line in folded.splitlines() if line.strip().startswith("install -d") and ".password-store" in line
+        ]
+        assert secret_lines, "pass store must be pre-created"
+        for line in secret_lines:
+            assert "-m 700" in line, "credential-plane dirs must be created mode 700"
+
+
+class TestDeterministicRuntimeUid:
+    def test_uid_is_a_build_arg_defaulting_to_1000(self) -> None:
+        text = DOCKERFILE.read_text(encoding="utf-8")
+        assert re.search(r"^ARG TEATREE_UID=1000$", text, re.MULTILINE), (
+            "container UID must be a deterministic build arg defaulting to 1000"
+        )
+
+    def test_user_is_renumbered_to_the_arg_uid(self) -> None:
+        text = DOCKERFILE.read_text(encoding="utf-8")
+        assert re.search(r'usermod\b[^\n]*-u\s+"\$\{TEATREE_UID\}"[^\n]*\bteatree\b', text), (
+            "teatree user must be renumbered onto the deterministic TEATREE_UID"
+        )
+        assert re.search(r'groupmod\b[^\n]*-g\s+"\$\{TEATREE_UID\}"[^\n]*\bteatree\b', text), (
+            "teatree primary group must track the deterministic TEATREE_UID"
+        )
+
+    def test_stock_ubuntu_user_is_removed_to_free_uid_1000(self) -> None:
+        text = DOCKERFILE.read_text(encoding="utf-8")
+        assert re.search(r"userdel\b[^\n]*\bubuntu\b", text), (
+            "Ubuntu 24.04's stock 'ubuntu' user (UID 1000) must be removed first"
+        )
+
+
+class TestBaseImageDigestPin:
+    def test_deploy_base_is_digest_pinned(self) -> None:
+        assert _base_digest(DOCKERFILE.read_text(encoding="utf-8")) is not None, (
+            "deploy/Dockerfile FROM must be pinned by @sha256 digest"
+        )
+
+    def test_deploy_base_digest_matches_dev_dockerfile(self) -> None:
+        deploy_digest = _base_digest(DOCKERFILE.read_text(encoding="utf-8"))
+        dev_digest = _base_digest(DEV_DOCKERFILE.read_text(encoding="utf-8"))
+        assert dev_digest is not None, "dev/Dockerfile.test must digest-pin its base"
+        assert deploy_digest == dev_digest, "deploy and dev must pin the same ubuntu:24.04 manifest"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## What

Fresh-box bootstrap fixes so a first deploy onto a clean host comes up writable. Three deploy-substrate issues, all under `deploy/`:

- **Closes #3439** — `deploy/deploy.sh` now pre-creates **every** host bind-mount source owned by the deploy user. It previously created only 3 of the sources; the data-plane dirs were left for dockerd to auto-create **root-owned**, which locks the non-root container out of its own writes. Enumerated from the compose file there are **six** bind sources (the issue said five — `workspace/t3-workspaces` was also missing): the DB dir, worktrees, workspaces, pass store, GPG home, and the Claude session `projects` dir.
- **Closes #3438** — `deploy/Dockerfile` pins the container user to a **deterministic UID** (`TEATREE_UID` build arg, default **1000**). Ubuntu 24.04 ships a stock `ubuntu` user already holding UID 1000, so it is removed and `teatree` is renumbered onto 1000 (`usermod`/`groupmod`), re-owning its home tree. The invariant "container UID must equal the host deploy-user UID" is documented in `deploy/README.md`.
- **Closes #3452** — `deploy/Dockerfile` base image is digest-pinned to the same `ubuntu:24.04` manifest `dev/Dockerfile.test` pins (`sha256:4fbb8e6a...2d90`), so a retag of the floating tag can never silently change the deploy toolchain.

## Migration note — BREAKING for the running deployment

**The live box currently runs the container as UID 1001**, and every host bind-mount source is currently owned by 1001. This change makes the container UID **1000**. When it lands and the image rebuilds, the pre-existing bind-mount data (owned by 1001) becomes **unwritable** by the container (now 1000), so the operator MUST, at deploy time (stack stopped), either:

- **chown the bind sources to 1000**:
  ```
  docker compose -p teatree -f deploy/docker-compose.yml down
  sudo chown -R 1000:1000 \
      ~/.local/share/teatree ~/.local/share/teatree-worktrees \
      ~/workspace/t3-workspaces ~/.password-store ~/.gnupg ~/.claude/projects
  ```
- **or** keep the box on 1001 by building with `--build-arg TEATREE_UID=1001` (matches the current host deploy user).

Do not merge-and-forget: pick one of the above as part of rolling this out.

## Verification

- Built a minimal image from the pinned base running the exact user-alignment block: result is `uid=1000(teatree) gid=1000(teatree)`, home tree + `/opt/teatree` owned `1000:1000`, stock `ubuntu` user absent.
- New smoke test `tests/test_deploy_freshbox_bootstrap.py` pins all three fixes against the deploy files (bind-source pre-creation vs the compose sources, deterministic UID renumber, digest match with `dev/Dockerfile.test`).
- Local gates green: `prek`, `ruff check`/`format`, `t3 tool test-path-mirror`, the deploy tests, and the full pre-push CI-critical parity gate.

Substrate change — held for owner authorization; do not merge without the UID migration decided.
