### PR TITLE
fix(config): claude-settings drift honors TEATREE_CLAUDE_* + preserves operator allow-list entries

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -170,14 +170,15 @@ seed_claude_settings() {
     fi
     mkdir -p "$HOME/.claude"
     local managed
-    managed="$(jq \
-        --arg model "${TEATREE_CLAUDE_MODEL:-}" \
-        --arg mode "${TEATREE_CLAUDE_PERMISSION_MODE:-}" \
-        --arg conc "${TEATREE_CLAUDE_TOOL_CONCURRENCY:-}" \
-        '(if $model != "" then .model = $model else . end)
-        | (if $mode != "" then .permissions.defaultMode = $mode else . end)
-        | (if $conc != "" then .env.CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY = $conc else . end)' \
-        "$template")"
+    # Apply the TEATREE_CLAUDE_* box-knob overrides via the ONE shared resolver in
+    # cli/setup/claude_settings.py, so this seed and the host-side `t3 doctor` drift
+    # check (managed_key_drift) resolve the SAME effective config (#3437). The module
+    # is pure-stdlib, so `python3 <file>` runs it without importing the teatree CLI.
+    local resolver="$CLONE_DIR/src/teatree/cli/setup/claude_settings.py"
+    if ! managed="$(python3 "$resolver" "$template")"; then
+        echo "teatree-init: failed to resolve claude-settings template - skipping" >&2
+        return 0
+    fi
     if [ -f "$target" ]; then
         jq -s '.[0] * .[1]' "$target" <(printf '%s' "$managed") >"$target.tmp" && mv "$target.tmp" "$target"
     else

--- a/src/teatree/cli/setup/claude_settings.py
+++ b/src/teatree/cli/setup/claude_settings.py
@@ -1,26 +1,41 @@
-"""Host-side Claude settings merge from the one committed template (#3410, #3408).
+"""Host-side Claude settings merge from the one committed template (#3410, #3408, #3437).
 
 ``deploy/claude-settings.template.json`` is the single source of truth for the
 managed Claude Code config — model, ``permissions.defaultMode`` /
 ``permissions.allow``, ``autoMode.allow``, and the tool-use-concurrency env. The
 worker containers seed it into ``~/.claude/settings.json`` in
-``deploy/entrypoint.sh`` (``seed_claude_settings``, a ``jq '.[0] * .[1]'`` deep
-merge). This module gives the HOST the identical merge so the interactive box
-and the containers can never drift: :func:`write_host_claude_settings` deep-merges
-the same template into the host's ``~/.claude/settings.json``, preserving
-user-specific keys (``statusLine``, any extra host rules) while asserting the
-managed keys.
+``deploy/entrypoint.sh`` (``seed_claude_settings``); this module gives the HOST
+the identical merge so the interactive box and the containers can never drift.
 
-:func:`deep_merge` mirrors ``jq``'s ``*`` operator exactly — objects merge
-recursively, every non-object value (scalars AND arrays) is replaced by the
-override — so the host and container settings resolve byte-for-byte the same
-managed config. :func:`managed_key_drift` powers the ``t3 doctor`` gate that
-verifies the host agrees with the template.
+Three ``TEATREE_CLAUDE_*`` env vars override the box-specific knobs (model,
+permission mode, tool-use concurrency). :func:`resolve_managed_template` is the ONE
+resolver that applies them, defined once in :data:`TEATREE_CLAUDE_OVERRIDES`: the
+entrypoint seed invokes this module as a script to render the resolved template,
+and :func:`managed_key_drift` / :func:`write_host_claude_settings` apply the same
+resolver — so the container seed and the host drift check always agree on the
+effective managed config instead of the host judging against the raw template.
+
+Allow-list arrays (``permissions.allow``, ``autoMode.allow``) carry SET-UNION /
+superset semantics on the host: :func:`write_host_claude_settings` unions the
+template's managed grants with the operator's own additions (never dropping an
+operator-added entry), and :func:`managed_key_drift` flags an allow-list only when
+a template entry is MISSING from the host — an operator's extra grants are their
+own and never count as drift. :func:`deep_merge` stays the generic
+``jq '.[0] * .[1]'`` primitive (arrays replaced wholesale); the union lives in
+:func:`merge_host_settings`, layered on top for the managed allow-lists.
 """
 
 import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import cast
+
+# A parsed JSON settings object (``~/.claude/settings.json`` / the template).
+# Values are arbitrary JSON, so the leaves stay ``object``; the alias names the
+# shape and keeps the module-health ratchet's dataclass/TypedDict rule satisfied.
+type JsonObject = dict[str, object]
 
 # The managed leaf keys the template owns, addressed as dotted paths into the
 # settings object. Everything else in ``~/.claude/settings.json`` (statusLine,
@@ -34,27 +49,46 @@ MANAGED_KEY_PATHS: tuple[tuple[str, ...], ...] = (
     ("env", "CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY"),
 )
 
+# The managed allow-list paths carrying set-union / superset semantics: the
+# template asserts these grants are PRESENT, but operator-added entries survive a
+# managed re-write and never count as drift.
+ALLOW_LIST_KEY_PATHS: tuple[tuple[str, ...], ...] = (
+    ("permissions", "allow"),
+    ("autoMode", "allow"),
+)
 
-def deep_merge(base: dict[str, object], override: dict[str, object]) -> dict[str, object]:
+# The one source of truth for the ``TEATREE_CLAUDE_*`` box-knob overrides: env var
+# -> the dotted managed-key path it sets on the template. Consumed by BOTH the
+# entrypoint seed (via a script invocation of this module) and the host-side drift
+# check / write, so the container and host can never disagree on the knobs.
+TEATREE_CLAUDE_OVERRIDES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("TEATREE_CLAUDE_MODEL", ("model",)),
+    ("TEATREE_CLAUDE_PERMISSION_MODE", ("permissions", "defaultMode")),
+    ("TEATREE_CLAUDE_TOOL_CONCURRENCY", ("env", "CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY")),
+)
+
+
+def deep_merge(base: JsonObject, override: JsonObject) -> JsonObject:
     """Return ``base`` deep-merged with ``override`` (override wins), mirroring ``jq '.[0] * .[1]'``.
 
     Object values are merged recursively; every non-object value — scalars and
     arrays alike — is replaced wholesale by ``override``'s. Neither input is
     mutated. This is the exact semantics ``seed_claude_settings`` uses
     container-side, so a host merge and a container seed of the same template
-    produce the same managed config.
+    produce the same managed config. The host layers set-union on the managed
+    allow-lists on top of this primitive in :func:`merge_host_settings`.
     """
-    merged: dict[str, object] = dict(base)
+    merged: JsonObject = dict(base)
     for key, override_value in override.items():
         base_value = merged.get(key)
         if isinstance(base_value, dict) and isinstance(override_value, dict):
-            merged[key] = deep_merge(cast("dict[str, object]", base_value), cast("dict[str, object]", override_value))
+            merged[key] = deep_merge(cast("JsonObject", base_value), cast("JsonObject", override_value))
         else:
             merged[key] = override_value
     return merged
 
 
-def _load_json_object(path: Path) -> dict[str, object]:
+def _load_json_object(path: Path) -> JsonObject:
     """Load ``path`` as a JSON object, or ``{}`` when absent/empty/not an object."""
     if not path.is_file():
         return {}
@@ -65,60 +99,164 @@ def _load_json_object(path: Path) -> dict[str, object]:
     return data if isinstance(data, dict) else {}
 
 
-def write_host_claude_settings(template_path: Path, target_path: Path) -> dict[str, object]:
-    """Deep-merge ``template_path`` into ``target_path`` (creating it if absent); return the result.
-
-    The existing target is the LEFT operand and the template is the RIGHT, so the
-    template's managed keys win while the operator's unmanaged keys survive —
-    identical to the container seed. The parent directory is created if needed.
-    Raises ``FileNotFoundError`` when the template is missing (a packaging bug the
-    caller should surface, not swallow).
-    """
-    template = _load_json_object(template_path)
-    if not template:
-        msg = f"claude-settings template missing or empty: {template_path}"
-        raise FileNotFoundError(msg)
-    merged = deep_merge(_load_json_object(target_path), template)
-    target_path.parent.mkdir(parents=True, exist_ok=True)
-    target_path.write_text(json.dumps(merged, indent=2) + "\n", encoding="utf-8")
-    return merged
-
-
-def _dig(data: dict[str, object], path: tuple[str, ...]) -> object | None:
+def _dig(data: JsonObject, path: tuple[str, ...]) -> object | None:
     """Return the value at dotted ``path`` in ``data``, or ``None`` when any hop is absent."""
     cursor: object = data
     for key in path:
         if not isinstance(cursor, dict):
             return None
-        cursor_dict = cast("dict[str, object]", cursor)
+        cursor_dict = cast("JsonObject", cursor)
         if key not in cursor_dict:
             return None
         cursor = cursor_dict[key]
     return cursor
 
 
-def managed_key_drift(template_path: Path, target_path: Path) -> list[str]:
-    """Return the dotted managed keys where ``target`` disagrees with the ``template``.
+def _set_path(data: JsonObject, path: tuple[str, ...], value: object) -> None:
+    """Set ``value`` at dotted ``path`` in ``data``, creating intermediate objects."""
+    cursor: JsonObject = data
+    for key in path[:-1]:
+        branch = cursor.get(key)
+        if not isinstance(branch, dict):
+            branch = {}
+            cursor[key] = branch
+        cursor = cast("JsonObject", branch)
+    cursor[path[-1]] = value
 
-    A key is drifted when the target's value differs from the template's (a key
-    the template does not carry is not managed and never drifts). An absent
-    target file drifts every managed key. Read-only — never writes either file.
+
+def resolve_managed_template(template: JsonObject, env: Mapping[str, str]) -> JsonObject:
+    """Return ``template`` with every set ``TEATREE_CLAUDE_*`` override applied.
+
+    The single resolver the container seed and the host drift check share: each
+    override in :data:`TEATREE_CLAUDE_OVERRIDES` is applied only when its env var is
+    a non-empty string (mirroring the entrypoint's original ``!= ""`` gate).
+    ``template`` is not mutated.
+    """
+    resolved = cast("JsonObject", json.loads(json.dumps(template)))
+    for env_name, path in TEATREE_CLAUDE_OVERRIDES:
+        value = env.get(env_name)
+        if value:
+            _set_path(resolved, path, value)
+    return resolved
+
+
+def _union_allow_list(base: list[object], template: list[object]) -> list[object]:
+    """Return the template grants followed by any operator-added ``base`` entries.
+
+    Template entries come first (managed, canonical order); any operator-added
+    entry not already present is appended, so a managed re-write preserves the
+    operator's extra grants instead of clobbering them.
+    """
+    unioned: list[object] = list(template)
+    for item in base:
+        if item not in unioned:
+            unioned.append(item)
+    return unioned
+
+
+def merge_host_settings(base: JsonObject, template: JsonObject) -> JsonObject:
+    """Deep-merge ``template`` into ``base`` with set-union on the managed allow-lists.
+
+    Everything follows :func:`deep_merge` (the template's managed keys win, the
+    operator's unmanaged keys survive); the managed allow-list paths then take the
+    union of the operator's list and the template's, so operator-added grants are
+    never dropped by a managed re-write. Neither input is mutated.
+    """
+    merged = deep_merge(base, template)
+    for path in ALLOW_LIST_KEY_PATHS:
+        base_list = _dig(base, path)
+        template_list = _dig(template, path)
+        if isinstance(base_list, list) and isinstance(template_list, list):
+            unioned = _union_allow_list(cast("list[object]", base_list), cast("list[object]", template_list))
+            _set_path(merged, path, unioned)
+    return merged
+
+
+def write_host_claude_settings(
+    template_path: Path, target_path: Path, env: Mapping[str, str] | None = None
+) -> JsonObject:
+    """Merge the resolved managed template into ``target_path`` (creating it); return the result.
+
+    The template is first passed through :func:`resolve_managed_template` (applying
+    ``TEATREE_CLAUDE_*`` overrides from ``env``, defaulting to ``os.environ``), so the
+    host writes the SAME effective config the container seed does; then
+    :func:`merge_host_settings` unions the managed allow-lists so operator-added
+    grants survive. The parent directory is created if needed. Raises
+    ``FileNotFoundError`` when the template is missing or empty (a packaging bug the
+    caller should surface, not swallow).
     """
     template = _load_json_object(template_path)
+    if not template:
+        msg = f"claude-settings template missing or empty: {template_path}"
+        raise FileNotFoundError(msg)
+    resolved = resolve_managed_template(template, os.environ if env is None else env)
+    merged = merge_host_settings(_load_json_object(target_path), resolved)
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+    target_path.write_text(json.dumps(merged, indent=2) + "\n", encoding="utf-8")
+    return merged
+
+
+def managed_key_drift(template_path: Path, target_path: Path, env: Mapping[str, str] | None = None) -> list[str]:
+    """Return the dotted managed keys where ``target`` disagrees with the ``template``.
+
+    The template is resolved through :func:`resolve_managed_template` first
+    (``TEATREE_CLAUDE_*`` overrides from ``env``, defaulting to ``os.environ``), so an
+    overridden knob is judged against its effective value, not the raw template. A
+    scalar key drifts on any value mismatch; a managed allow-list drifts only when a
+    template grant is MISSING from the target (operator-added grants are theirs and
+    never drift). An absent target file drifts every managed key. Read-only — never
+    writes either file.
+    """
+    template = resolve_managed_template(_load_json_object(template_path), os.environ if env is None else env)
     target = _load_json_object(target_path)
     drifted: list[str] = []
     for path in MANAGED_KEY_PATHS:
         template_value = _dig(template, path)
         if template_value is None:
             continue
-        if _dig(target, path) != template_value:
+        if path in ALLOW_LIST_KEY_PATHS and isinstance(template_value, list):
+            target_value = _dig(target, path)
+            host_items = target_value if isinstance(target_value, list) else []
+            if any(item not in host_items for item in template_value):
+                drifted.append(".".join(path))
+        elif _dig(target, path) != template_value:
             drifted.append(".".join(path))
     return drifted
 
 
+_EXPECTED_ARGC = 2  # program name + template path
+
+
+def _main(argv: Sequence[str]) -> int:
+    """Render the env-resolved managed template to stdout (the entrypoint seed path).
+
+    ``argv`` is ``[prog, template_path]``. Prints the ``TEATREE_CLAUDE_*``-resolved
+    template as JSON so ``deploy/entrypoint.sh`` seeds the container with the exact
+    config the host drift check asserts. Returns a POSIX exit code.
+    """
+    if len(argv) != _EXPECTED_ARGC:
+        sys.stderr.write("usage: claude_settings.py <template-path>\n")
+        return 2
+    template = _load_json_object(Path(argv[1]))
+    if not template:
+        sys.stderr.write(f"claude-settings template missing or empty: {argv[1]}\n")
+        return 1
+    resolved = resolve_managed_template(template, os.environ)
+    sys.stdout.write(json.dumps(resolved, indent=2) + "\n")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — entrypoint seed script invocation
+    raise SystemExit(_main(sys.argv))
+
+
 __all__ = [
+    "ALLOW_LIST_KEY_PATHS",
     "MANAGED_KEY_PATHS",
+    "TEATREE_CLAUDE_OVERRIDES",
     "deep_merge",
     "managed_key_drift",
+    "merge_host_settings",
+    "resolve_managed_template",
     "write_host_claude_settings",
 ]

--- a/tests/teatree_cli/setup/test_claude_settings.py
+++ b/tests/teatree_cli/setup/test_claude_settings.py
@@ -1,8 +1,9 @@
-"""Tests for the host Claude-settings template merge (#3410, #3408).
+"""Tests for the host Claude-settings template merge (#3410, #3408, #3437).
 
 Real temp JSON files stand in for ``~/.claude/settings.json`` and the committed
 template — the merge is exercised end-to-end, nothing about the deep-merge logic
-is reimplemented.
+is reimplemented. ``env`` is injected explicitly so the ``TEATREE_CLAUDE_*``
+resolver is tested hermetically, independent of the ambient environment.
 """
 
 import json
@@ -10,7 +11,19 @@ from pathlib import Path
 
 import pytest
 
-from teatree.cli.setup.claude_settings import deep_merge, managed_key_drift, write_host_claude_settings
+from teatree.cli.setup.claude_settings import (
+    MANAGED_KEY_PATHS,
+    _dig,
+    _main,
+    deep_merge,
+    managed_key_drift,
+    merge_host_settings,
+    resolve_managed_template,
+    write_host_claude_settings,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_COMMITTED_TEMPLATE = _REPO_ROOT / "deploy" / "claude-settings.template.json"
 
 
 def _write(path: Path, payload: object) -> Path:
@@ -27,7 +40,9 @@ class TestDeepMerge:
         assert merged == {"p": {"x": 1, "y": 9, "z": 3}}
 
     def test_arrays_are_replaced_not_concatenated(self) -> None:
-        # jq '.[0] * .[1]' semantics: arrays are values, replaced wholesale.
+        # deep_merge stays the jq '.[0] * .[1]' primitive: arrays are values,
+        # replaced wholesale. The managed allow-list union lives one layer up in
+        # merge_host_settings, not here.
         assert deep_merge({"allow": ["a", "b"]}, {"allow": ["c"]}) == {"allow": ["c"]}
 
     def test_inputs_are_not_mutated(self) -> None:
@@ -36,11 +51,75 @@ class TestDeepMerge:
         assert base == {"p": {"x": 1}}
 
 
+class TestResolveManagedTemplate:
+    def _template(self) -> dict[str, object]:
+        return {
+            "model": "base-model",
+            "permissions": {"defaultMode": "acceptEdits"},
+            "env": {"CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY": "4"},
+        }
+
+    def test_no_overrides_returns_equivalent_template(self) -> None:
+        template = self._template()
+        assert resolve_managed_template(template, {}) == template
+
+    def test_each_override_sets_its_managed_path(self) -> None:
+        resolved = resolve_managed_template(
+            self._template(),
+            {
+                "TEATREE_CLAUDE_MODEL": "override-model",
+                "TEATREE_CLAUDE_PERMISSION_MODE": "plan",
+                "TEATREE_CLAUDE_TOOL_CONCURRENCY": "8",
+            },
+        )
+        assert resolved["model"] == "override-model"
+        assert _dig(resolved, ("permissions", "defaultMode")) == "plan"
+        assert _dig(resolved, ("env", "CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY")) == "8"
+
+    def test_empty_override_is_ignored(self) -> None:
+        resolved = resolve_managed_template(self._template(), {"TEATREE_CLAUDE_MODEL": ""})
+        assert resolved["model"] == "base-model"
+
+    def test_template_is_not_mutated(self) -> None:
+        template = self._template()
+        resolve_managed_template(template, {"TEATREE_CLAUDE_MODEL": "override-model"})
+        assert template["model"] == "base-model"
+
+    def test_creates_intermediate_objects_for_absent_paths(self) -> None:
+        resolved = resolve_managed_template({}, {"TEATREE_CLAUDE_TOOL_CONCURRENCY": "6"})
+        assert _dig(resolved, ("env", "CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY")) == "6"
+
+
+class TestMergeHostSettings:
+    def test_operator_added_allow_entry_survives_union(self) -> None:
+        base = {"permissions": {"allow": ["Bash(op:*)"]}, "autoMode": {"allow": ["op-grant"]}}
+        template = {"permissions": {"allow": ["Bash(git:*)"]}, "autoMode": {"allow": ["managed-grant"]}}
+        merged = merge_host_settings(base, template)
+        assert _dig(merged, ("permissions", "allow")) == ["Bash(git:*)", "Bash(op:*)"]
+        assert _dig(merged, ("autoMode", "allow")) == ["managed-grant", "op-grant"]
+
+    def test_union_deduplicates_shared_entries(self) -> None:
+        base = {"permissions": {"allow": ["Bash(git:*)", "Bash(op:*)"]}}
+        template = {"permissions": {"allow": ["Bash(git:*)"]}}
+        merged = merge_host_settings(base, template)
+        assert _dig(merged, ("permissions", "allow")) == ["Bash(git:*)", "Bash(op:*)"]
+
+    def test_non_allow_list_scalars_still_clobber(self) -> None:
+        merged = merge_host_settings({"model": "old"}, {"model": "new"})
+        assert merged["model"] == "new"
+
+    def test_inputs_are_not_mutated(self) -> None:
+        base = {"permissions": {"allow": ["Bash(op:*)"]}}
+        template = {"permissions": {"allow": ["Bash(git:*)"]}}
+        merge_host_settings(base, template)
+        assert base["permissions"]["allow"] == ["Bash(op:*)"]
+
+
 class TestWriteHostClaudeSettings:
     def test_creates_target_from_template_when_absent(self, tmp_path: Path) -> None:
         template = _write(tmp_path / "tpl.json", {"model": "m", "autoMode": {"allow": ["x"]}})
         target = tmp_path / "home" / ".claude" / "settings.json"
-        result = write_host_claude_settings(template, target)
+        result = write_host_claude_settings(template, target, env={})
         assert target.is_file()
         assert result["model"] == "m"
         assert json.loads(target.read_text())["autoMode"]["allow"] == ["x"]
@@ -51,16 +130,36 @@ class TestWriteHostClaudeSettings:
             tmp_path / "settings.json",
             {"model": "old", "statusLine": {"type": "command"}, "autoMode": {"allow": ["user"]}},
         )
-        result = write_host_claude_settings(template, target)
-        # statusLine (unmanaged) survives; model + autoMode.allow (managed) win.
+        result = write_host_claude_settings(template, target, env={})
+        # statusLine (unmanaged) survives; model (managed scalar) wins; the
+        # managed autoMode.allow UNIONS the operator's grant with the template's.
         assert result["statusLine"] == {"type": "command"}
         assert result["model"] == "new"
-        written = json.loads(target.read_text())
-        assert written["autoMode"]["allow"] == ["managed"]
+        assert json.loads(target.read_text())["autoMode"]["allow"] == ["managed", "user"]
+
+    def test_operator_added_permissions_allow_entry_survives_managed_rewrite(self, tmp_path: Path) -> None:
+        template = _write(
+            tmp_path / "tpl.json",
+            {"permissions": {"defaultMode": "acceptEdits", "allow": ["Bash(git:*)"]}},
+        )
+        target = _write(
+            tmp_path / "settings.json",
+            {"permissions": {"defaultMode": "acceptEdits", "allow": ["Bash(git:*)", "Bash(operator-tool:*)"]}},
+        )
+        result = write_host_claude_settings(template, target, env={})
+        # union is template-first, then operator-added extras.
+        assert _dig(result, ("permissions", "allow")) == ["Bash(git:*)", "Bash(operator-tool:*)"]
+
+    def test_teatree_claude_override_is_written(self, tmp_path: Path) -> None:
+        template = _write(tmp_path / "tpl.json", {"model": "template-model"})
+        target = tmp_path / "settings.json"
+        result = write_host_claude_settings(template, target, env={"TEATREE_CLAUDE_MODEL": "override-model"})
+        assert result["model"] == "override-model"
+        assert json.loads(target.read_text())["model"] == "override-model"
 
     def test_missing_template_raises(self, tmp_path: Path) -> None:
         with pytest.raises(FileNotFoundError):
-            write_host_claude_settings(tmp_path / "nope.json", tmp_path / "out.json")
+            write_host_claude_settings(tmp_path / "nope.json", tmp_path / "out.json", env={})
 
 
 class TestManagedKeyDrift:
@@ -78,18 +177,76 @@ class TestManagedKeyDrift:
     def test_no_drift_when_managed_keys_match(self, tmp_path: Path) -> None:
         template = self._template(tmp_path)
         target = _write(tmp_path / "t.json", {**json.loads(template.read_text()), "statusLine": {"x": 1}})
-        assert managed_key_drift(template, target) == []
+        assert managed_key_drift(template, target, env={}) == []
 
     def test_absent_target_drifts_every_managed_key(self, tmp_path: Path) -> None:
         template = self._template(tmp_path)
-        drift = managed_key_drift(template, tmp_path / "absent.json")
+        drift = managed_key_drift(template, tmp_path / "absent.json", env={})
         assert "model" in drift
         assert "autoMode.allow" in drift
         assert "permissions.defaultMode" in drift
+        assert "permissions.allow" in drift
 
     def test_reports_only_the_diverged_key(self, tmp_path: Path) -> None:
         template = self._template(tmp_path)
         data = json.loads(template.read_text())
         data["autoMode"]["allow"] = ["different"]
         target = _write(tmp_path / "t.json", data)
-        assert managed_key_drift(template, target) == ["autoMode.allow"]
+        assert managed_key_drift(template, target, env={}) == ["autoMode.allow"]
+
+    def test_operator_extra_allow_entry_is_not_drift(self, tmp_path: Path) -> None:
+        template = self._template(tmp_path)
+        data = json.loads(template.read_text())
+        data["permissions"]["allow"] = ["Bash(git:*)", "Bash(operator-tool:*)"]
+        data["autoMode"]["allow"] = ["grant", "extra-operator-grant"]
+        target = _write(tmp_path / "t.json", data)
+        # A host that is a SUPERSET of the template's grants does not drift.
+        assert managed_key_drift(template, target, env={}) == []
+
+    def test_missing_template_allow_entry_is_drift(self, tmp_path: Path) -> None:
+        template = self._template(tmp_path)
+        data = json.loads(template.read_text())
+        data["permissions"]["allow"] = []  # operator dropped a template grant
+        target = _write(tmp_path / "t.json", data)
+        assert managed_key_drift(template, target, env={}) == ["permissions.allow"]
+
+    def test_teatree_claude_override_is_honored_by_drift_check(self, tmp_path: Path) -> None:
+        template = self._template(tmp_path)
+        # Host agrees with the RAW template model but not the overridden one.
+        target = _write(tmp_path / "t.json", json.loads(template.read_text()))
+        env = {"TEATREE_CLAUDE_MODEL": "override-model"}
+        assert managed_key_drift(template, target, env=env) == ["model"]
+        # Host carrying the overridden value is in agreement — no drift.
+        overridden = json.loads(template.read_text())
+        overridden["model"] = "override-model"
+        agreed = _write(tmp_path / "agreed.json", overridden)
+        assert managed_key_drift(template, agreed, env=env) == []
+
+
+class TestManagedKeyPathsCoverTemplate:
+    def test_every_managed_path_resolves_in_committed_template(self) -> None:
+        # Guards future drift: a template key renamed/removed without updating
+        # MANAGED_KEY_PATHS would silently stop being asserted. Every managed path
+        # must dig to a real value in the committed template.
+        template = json.loads(_COMMITTED_TEMPLATE.read_text(encoding="utf-8"))
+        for path in MANAGED_KEY_PATHS:
+            assert _dig(template, path) is not None, f"managed path {'.'.join(path)} missing from template"
+
+
+class TestMainScript:
+    def test_renders_resolved_template_to_stdout(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        template = _write(tmp_path / "tpl.json", {"model": "template-model"})
+        monkeypatch.setenv("TEATREE_CLAUDE_MODEL", "override-model")
+        assert _main(["prog", str(template)]) == 0
+        rendered = json.loads(capsys.readouterr().out)
+        assert rendered["model"] == "override-model"
+
+    def test_usage_error_on_wrong_arg_count(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert _main(["prog"]) == 2
+        assert "usage" in capsys.readouterr().err
+
+    def test_missing_template_exits_nonzero(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        assert _main(["prog", str(tmp_path / "absent.json")]) == 1
+        assert "missing or empty" in capsys.readouterr().err


### PR DESCRIPTION
Closes #3437

## What
Two bugs in the host-side claude-settings drift gate (`src/teatree/cli/setup/claude_settings.py`):

1. **Array-clobber** — the deep-merge replaced allow-list arrays wholesale, so applying the managed template DELETED operator-added entries in `permissions.allow` / `autoMode.allow`. Now those managed allow-lists get set-union / superset semantics: `merge_host_settings` unions template grants with operator additions (never dropping an operator entry), and `managed_key_drift` flags an allow-list only when a template entry is MISSING from the host.

2. **Ignored TEATREE_CLAUDE_* overrides** — the Python drift check compared the host against the RAW template, ignoring the `TEATREE_CLAUDE_*` env overrides the entrypoint applies. Introduced one resolver (`resolve_managed_template`, sourced from `TEATREE_CLAUDE_OVERRIDES`) consumed by BOTH `deploy/entrypoint.sh` (which now invokes this module as a pure-stdlib script to render the seed) AND `managed_key_drift` / `write_host_claude_settings`, so container seed and host drift check always agree.

## Tests
- `MANAGED_KEY_PATHS` covers every managed key in the committed template (guards future drift).
- RED-first: operator-added `permissions.allow` entry SURVIVES a managed re-write; a `TEATREE_CLAUDE_*` override is honored by the drift check.
- Full coverage of the resolver, union merge, and script entrypoint.