### PR TITLE
fix(merge): class self-governance + migration diffs as substrate (close the guardrail-loosening hole)

### DIFF
--- a/src/teatree/core/models/merge_clear.py
+++ b/src/teatree/core/models/merge_clear.py
@@ -56,18 +56,34 @@ _COMPONENT_ROLE_WORDS = frozenset({"maker", "coding", "loop"})
 
 # A diff is substrate — independent of the reviewer's ``blast_class`` label —
 # when it touches the merge keystone, the architecture spec, a governance doc,
-# or the factory's OWN self-governance seams (the trust classifier, the intake
-# gate, the PreToolUse/Stop safety hooks). The label defaults to ``logic`` (the
-# orchestrator's judgment), so a change a human forgot to mark would otherwise
-# auto-merge silently under ``autonomy = full``. This path detector makes the
-# substrate guarantee label-independent (invariant 4): the change is substrate
-# if its diff is. The self-governance seams (#3244) are held because an
-# autonomous PR that widened the trusted-author set, loosened the fork gate, or
-# disabled a safety hook must NEVER auto-merge itself on agent-only review — the
-# factory cannot loosen its own guardrails unattended.
+# or the factory's OWN self-governance seams. Those seams are: the merge/CLEAR
+# classifier and the cold-review record that DEFINE the trust boundary itself
+# (``merge_clear.py`` — this module — and ``review_verdict.py``, the maker≠checker
+# guard), every merge/safety gate (``core/gates/``), the trust classifier
+# (``author_trust.py``), the intake gate (``issue_implementer.py`` /
+# ``scanner_factories.py``), the autonomy/trust configuration (``config/`` —
+# autonomy tiers and the ``substrate_auto_merge_authorized_by`` default), the
+# on-behalf authorisation gate (``on_behalf_gate.py``), and the PreToolUse/Stop
+# safety hooks (``hooks/``). Schema migrations (``core/migrations/``, incl.
+# destructive DROP / data-rewrites) are substrate too: they mutate the durable
+# governance store itself — this gap is why #3464's migration auto-merged as
+# logic. The label defaults to ``logic`` (the orchestrator's judgment), so a
+# change a human forgot to mark would otherwise auto-merge silently under
+# ``autonomy = full``. This path detector makes the substrate guarantee
+# label-independent (invariant 4): the change is substrate if its diff is. The
+# self-governance seams (#3244) are held because an autonomous PR that widened
+# the trusted-author set, loosened a gate, edited the classifier that judges
+# itself, or shipped a destructive migration must NEVER auto-merge itself on
+# agent-only review — the factory cannot loosen its own guardrails unattended.
 _SUBSTRATE_PATH_PREFIXES = (
     "src/teatree/core/merge/",
+    "src/teatree/core/models/merge_clear.py",
+    "src/teatree/core/models/review_verdict.py",
+    "src/teatree/core/gates/",
+    "src/teatree/core/migrations/",
     "src/teatree/core/review/author_trust.py",
+    "src/teatree/config/",
+    "src/teatree/on_behalf_gate.py",
     "src/teatree/loop/scanners/issue_implementer.py",
     "src/teatree/loop/scanner_factories.py",
     "hooks/",
@@ -77,15 +93,21 @@ _SUBSTRATE_FILE_NAMES = frozenset({"BLUEPRINT.md", "CLAUDE.md", "AGENTS.md"})
 
 
 def diff_paths_are_substrate(paths: "Iterable[str]") -> bool:
-    """True iff any of *paths* is a substrate path (merge keystone / spec / governance / self-governance).
+    """True iff any of *paths* is a substrate path (keystone / spec / governance / self-governance / migrations).
 
     Substrate paths are: anything under ``src/teatree/core/merge/`` (the merge
     keystone), the architecture spec (``BLUEPRINT.md`` and ``docs/blueprint/``),
-    the governance docs (``CLAUDE.md`` / ``AGENTS.md`` at any depth), and the
-    factory's self-governance seams (#3244) — the trust classifier
-    (``author_trust.py``), the intake gate (``issue_implementer.py`` /
-    ``scanner_factories.py``), and the safety hooks (``hooks/``). Matching is on
-    whole path components after stripping a leading ``./`` or ``/`` so a
+    the governance docs (``CLAUDE.md`` / ``AGENTS.md`` at any depth), the
+    factory's self-governance seams (#3244) — the merge/CLEAR classifier and
+    cold-review record that DEFINE the trust boundary (``merge_clear.py`` /
+    ``review_verdict.py``), every merge/safety gate (``core/gates/``), the trust
+    classifier (``author_trust.py``), the intake gate (``issue_implementer.py`` /
+    ``scanner_factories.py``), the autonomy/trust config (``config/``), the
+    on-behalf gate (``on_behalf_gate.py``) and the safety hooks (``hooks/``) — and
+    schema migrations (``core/migrations/``, incl. destructive DROP / data
+    rewrites, which mutate the durable governance store). Directory/file prefixes
+    match after stripping a leading ``./`` or ``/``; the bare governance file
+    names (``BLUEPRINT.md`` etc.) match on the final path component so a
     look-alike sibling (``BLUEPRINT.md.bak``, ``src/teatree/core/merger/``) is not
     misclassified.
     """

--- a/tests/teatree_core/models/test_merge_clear_substrate_paths.py
+++ b/tests/teatree_core/models/test_merge_clear_substrate_paths.py
@@ -51,6 +51,51 @@ class TestDiffPathsAreSubstrate:
         assert diff_paths_are_substrate(["src/teatree/loop/scanners/issue_implementer.py"]) is True
         assert diff_paths_are_substrate(["src/teatree/loop/scanner_factories.py"]) is True
 
+    def test_merge_classifier_module_is_substrate(self) -> None:
+        # The module that DEFINES the trust boundary must class itself substrate:
+        # a PR loosening this very classifier can no longer auto-merge as logic.
+        assert diff_paths_are_substrate(["src/teatree/core/models/merge_clear.py"]) is True
+
+    def test_review_verdict_record_is_substrate(self) -> None:
+        # The cold-review record + maker!=checker guard is a trust seam.
+        assert diff_paths_are_substrate(["src/teatree/core/models/review_verdict.py"]) is True
+
+    def test_merge_safety_gate_is_substrate(self) -> None:
+        # Every gate under core/gates/ enforces a merge/safety invariant.
+        assert diff_paths_are_substrate(["src/teatree/core/gates/merge_guard.py"]) is True
+
+    def test_schema_migration_is_substrate(self) -> None:
+        # A schema change (incl. destructive DROP / data-rewrite) mutates the
+        # durable governance store -> substrate, never a silent logic auto-merge
+        # (this gap is why #3464's migration auto-merged).
+        assert diff_paths_are_substrate(["src/teatree/core/migrations/0001_initial.py"]) is True
+
+    def test_autonomy_config_is_substrate(self) -> None:
+        # config/ holds the autonomy tiers and the substrate_auto_merge_authorized_by
+        # default -> editing it changes how the factory governs itself.
+        assert diff_paths_are_substrate(["src/teatree/config/settings.py"]) is True
+
+    def test_on_behalf_gate_is_substrate(self) -> None:
+        assert diff_paths_are_substrate(["src/teatree/on_behalf_gate.py"]) is True
+
+    def test_ordinary_cli_check_is_not_substrate(self) -> None:
+        # A clearly-logic path (a doctor check) stays logic after the widening.
+        assert diff_paths_are_substrate(["src/teatree/cli/doctor/checks.py"]) is False
+
+    def test_ordinary_test_file_is_not_substrate(self) -> None:
+        assert diff_paths_are_substrate(["tests/teatree_core/models/test_merge_clear_substrate_paths.py"]) is False
+
+    def test_models_sibling_is_not_substrate(self) -> None:
+        # The widening pins merge_clear.py / review_verdict.py exactly — an
+        # unrelated model in core/models/ must NOT become substrate.
+        assert diff_paths_are_substrate(["src/teatree/core/models/ticket.py"]) is False
+
+    def test_config_lookalike_is_not_substrate(self) -> None:
+        # config/ has a trailing slash -> a sibling like configuration.py or the
+        # cli/config.py helper is not the autonomy-config package.
+        assert diff_paths_are_substrate(["src/teatree/cli/config.py"]) is False
+        assert diff_paths_are_substrate(["src/teatree/core/migrationsx/x.py"]) is False
+
     def test_safety_hooks_are_substrate(self) -> None:
         assert diff_paths_are_substrate(["hooks/scripts/question_gates.py"]) is True
 


### PR DESCRIPTION
## The hole this closes

The substrate merge-classifier (`diff_paths_are_substrate()` /
`_SUBSTRATE_PATH_PREFIXES` in `core/models/merge_clear.py`) enumerated the merge
keystone, the spec/governance docs, and a few self-governance seams — but it
**omitted the files that implement the trust boundary itself**. A PR touching any
of these was therefore classed `logic` (the `blast_class` default) and, under
`autonomy = full`, the merge-loop could auto-merge it green + non-draft with **no
owner `--human-authorize`**:

- `core/models/merge_clear.py` — the classifier + `is_non_reviewer_role` (a PR
  loosening *this very gate* could merge itself as logic)
- `core/models/review_verdict.py` — the cold-review record + maker≠checker guard
- `core/gates/` — every merge/safety gate
- `core/migrations/` — schema changes, **including destructive DROP / data-rewrite**
- `config/` — autonomy tiers and the `substrate_auto_merge_authorized_by` default
- `on_behalf_gate.py` — the on-behalf authorisation gate

**Exploit:** a maker-authored PR that edits a merge/safety gate, widens the
autonomy config, edits the classifier that judges it, or ships a destructive
migration would auto-merge unattended as `logic` — the factory loosening its own
guardrails with no human in the loop. This is also **why #3464's migration
auto-merged as logic**.

## The fix

Extend `_SUBSTRATE_PATH_PREFIXES` to pin these self-governance files
(`merge_clear.py`, `review_verdict.py`, `on_behalf_gate.py`) and cover the
`core/gates/`, `core/migrations/`, and `config/` directories, so **any diff
touching them classes `substrate`** and holds for owner `--human-authorize`
regardless of the reviewer's label. Scoped precisely: unrelated `core/models/`
files (e.g. `ticket.py`) stay logic — only the two governance models are pinned;
directory prefixes carry a trailing slash so look-alike siblings
(`cli/config.py`, `core/merger/`) are not misclassified.

## Verification (RED-first)

New tests in `test_merge_clear_substrate_paths.py` assert
`diff_paths_are_substrate()` is `True` for each newly-covered path and stays
`False` for a clearly-logic path (a doctor check, a test file, an unrelated
model, a `config`-lookalike). Confirmed the 6 new "is substrate" assertions FAIL
on `origin/main` and PASS after this change.

> Substrate + safety-critical: opened as **draft** on purpose. Do not auto-merge
> — it needs owner authorization (the ironic case the fix itself protects).
