### PR TITLE
fix(loop): don't count usage-limit failures toward the exhaustion-recovery stall budget

### DIFF
--- a/src/teatree/core/models/task_repair.py
+++ b/src/teatree/core/models/task_repair.py
@@ -14,6 +14,7 @@ from teatree.core.models.task import Task
 from teatree.core.models.task_attempt import TaskAttempt
 from teatree.core.models.usage_window_state import LIMIT_PARKED_PREFIX
 from teatree.core.repair_loop import IterationStalled, MaxIterationsExceeded, requeue_verdict
+from teatree.llm.anthropic_limits import recoverable_exhaustion_cause
 
 
 def phase_attempts(task: Task) -> list[TaskAttempt]:
@@ -26,15 +27,25 @@ def phase_attempts(task: Task) -> list[TaskAttempt]:
     A usage-window limit-park (Directive #3) is EXCLUDED: its ``TaskAttempt`` records a
     scheduling event, not a work iteration, so it must not burn the per-phase iteration
     budget nor trip the identical-failure stall detector during a multi-hour outage.
+
+    A window-recoverable exhaustion FAILURE (subscription session/weekly or a transient
+    rate limit — see :func:`~teatree.llm.anthropic_limits.recoverable_exhaustion_cause`)
+    is EXCLUDED for the same reason: capacity ran out, the run never executed a work
+    iteration. It lands FAILED (not parked) when limit auto-recovery is off or on a
+    non-parking lane, so it carries no ``LIMIT_PARKED_PREFIX`` — counting it would let two
+    identical capacity dips trip the stall detector and spuriously dead-letter the phase.
+    API-credit exhaustion (no timed reset) is NOT excluded: it is a real halt the operator
+    must clear, so it keeps burning the budget and may escalate.
     """
-    return list(
+    attempts = (
         TaskAttempt.objects.filter(
             task__ticket_id=task.ticket_id,  # ty: ignore[unresolved-attribute]
             task__phase__in=phase_spellings(normalize_phase(task.phase)),
         )
         .exclude(error__startswith=LIMIT_PARKED_PREFIX)
-        .order_by("pk"),
+        .order_by("pk")
     )
+    return [attempt for attempt in attempts if recoverable_exhaustion_cause(attempt.error) is None]
 
 
 def check_requeue_allowed(task: Task) -> None:

--- a/src/teatree/loop/stuck_ticket_redispatch.py
+++ b/src/teatree/loop/stuck_ticket_redispatch.py
@@ -31,6 +31,7 @@ from teatree.core.models.deferred_question import DeferredQuestion
 from teatree.core.models.errors import InvalidTransitionError
 from teatree.core.models.usage_window_state import LIMIT_PARKED_PREFIX
 from teatree.core.repair_loop import IterationStalled, MaxIterationsExceeded, requeue_verdict
+from teatree.llm.anthropic_limits import recoverable_exhaustion_cause
 
 logger = logging.getLogger(__name__)
 
@@ -183,15 +184,24 @@ def _budget_halt_reason(ticket: Ticket, *, phase: str) -> str | None:
 
 
 def _phase_attempts(ticket: Ticket, *, phase: str) -> list[TaskAttempt]:
-    """WORK attempts of *ticket*'s ``(ticket, normalized-phase)``, oldest first (limit-parks excluded)."""
-    return list(
+    """WORK attempts of *ticket*'s ``(ticket, normalized-phase)``, oldest first.
+
+    Both a usage-window limit-PARK (``LIMIT_PARKED_PREFIX``) and a window-recoverable
+    exhaustion FAILURE (session/weekly/rate-limit — see
+    :func:`~teatree.llm.anthropic_limits.recoverable_exhaustion_cause`) are excluded: a
+    capacity dip never executed a work iteration, so it must not burn the repair budget
+    nor trip the identical-failure stall — otherwise two limit hits spuriously halt the
+    re-dispatch and page a human. API-credit exhaustion (no timed reset) still counts.
+    """
+    attempts = (
         TaskAttempt.objects.filter(
             task__ticket_id=ticket.pk,
             task__phase__in=phase_spellings(normalize_phase(phase)),
         )
         .exclude(error__startswith=LIMIT_PARKED_PREFIX)
-        .order_by("pk"),
+        .order_by("pk")
     )
+    return [attempt for attempt in attempts if recoverable_exhaustion_cause(attempt.error) is None]
 
 
 def _escalate_once(ticket: Ticket, *, reason: str) -> None:

--- a/tests/teatree_loop/test_stuck_ticket_redispatch.py
+++ b/tests/teatree_loop/test_stuck_ticket_redispatch.py
@@ -19,6 +19,7 @@ from teatree.core.models.deferred_question import DeferredQuestion
 from teatree.core.models.errors import InvalidTransitionError
 from teatree.core.models.transition import TicketTransition
 from teatree.core.repair_loop import max_phase_iterations
+from teatree.llm.anthropic_limits import LimitCause, LimitMatch
 from teatree.loop.stuck_ticket_redispatch import (
     DEFAULT_STUCK_IDLE_HOURS,
     _idle_threshold_hours,
@@ -166,6 +167,31 @@ class TestStuckTicketRedispatch(TestCase):
         # Idempotent: a second sweep neither schedules nor spams another escalation.
         assert redispatch_stuck_tickets() == 0
         assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
+
+    def test_repeated_exhaustion_failures_do_not_halt_redispatch(self) -> None:
+        # A stuck ticket whose recent phase attempts all died on the session limit must
+        # NOT be treated as a stalled/doomed phase: usage-limit failures are capacity
+        # dips, not defects, so they must not burn the repair budget nor trip the
+        # identical-failure stall. The ticket is re-dispatched, never escalated.
+        ticket = _stuck_ticket(state=Ticket.State.STARTED)
+        err = LimitMatch(phrase="5-hour limit", cause=LimitCause.SUBSCRIPTION_SESSION).as_reason()
+        for _ in range(2):
+            session = Session.objects.create(ticket=ticket, agent_id="planning")
+            task = Task.objects.create(ticket=ticket, session=session, phase="planning", status=Task.Status.FAILED)
+            attempt = TaskAttempt.objects.create(
+                task=task,
+                execution_target=task.execution_target,
+                ended_at=timezone.now(),
+                exit_code=1,
+                error=err,
+            )
+            TaskAttempt.objects.filter(pk=attempt.pk).update(started_at=timezone.now() - timedelta(hours=48))
+
+        scheduled = redispatch_stuck_tickets()
+
+        assert scheduled == 1
+        assert ticket.tasks.filter(phase="planning", status=Task.Status.PENDING).count() == 1
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 0
 
     def _burn_planning_budget(self, ticket: Ticket) -> None:
         for i in range(max_phase_iterations()):

--- a/tests/teatree_loop/test_transient_requeue.py
+++ b/tests/teatree_loop/test_transient_requeue.py
@@ -433,6 +433,34 @@ class TestExhaustionAutoRequeue(TestCase):
         assert task.status == Task.Status.FAILED
         assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
 
+    def test_repeated_session_limit_is_reopened_not_escalated_as_a_stall(self) -> None:
+        # Two identical session-limit FAILED attempts in a row record two identical
+        # error_fingerprints. The stall detector must NOT count usage-limit failures:
+        # a capacity dip repeated across a window is auto-recovered once the horizon
+        # elapses, never dead-lettered + paged to a human.
+        task = _failed_task()
+        err = _exhaustion_error(LimitCause.SUBSCRIPTION_SESSION)
+        _add_failed_attempt(task, error=err, ended_at=timezone.now() - timedelta(hours=6))
+        _add_failed_attempt(task, error=err, ended_at=timezone.now() - timedelta(hours=6))
+
+        assert requeue_transient_failed() == 1
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 0
+
+    def test_repeated_rate_limit_is_reopened_not_escalated_as_a_stall(self) -> None:
+        # Same invariant for the transient rate-limit cause (a distinct recoverable
+        # window): repeated identical rate-limit failures must not trip the stall.
+        task = _failed_task()
+        err = LimitMatch(phrase="rate limit", cause=LimitCause.RATE_LIMIT).as_reason()
+        _add_failed_attempt(task, error=err, ended_at=timezone.now() - timedelta(hours=1))
+        _add_failed_attempt(task, error=err, ended_at=timezone.now() - timedelta(hours=1))
+
+        assert requeue_transient_failed() == 1
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 0
+
     def test_flag_off_keeps_the_pre_3407_escalation(self) -> None:
         ConfigSetting.objects.set_value("limit_autorecovery_enabled", value=False)
         task = _failed_task()


### PR DESCRIPTION
## The bug (HIGH-severity correctness)

A task that hits a subscription **session/weekly** or **transient rate** limit while `limit_autorecovery_enabled` is ON (or on a non-parking lane) lands `FAILED` and records its reason via `LimitMatch.as_reason()` as e.g. `subscription_session: session limit — …`. That string carries **no** `LIMIT_PARKED_PREFIX`.

The phase-attempt collectors that feed the #2009 repair-loop budget/stall check — `task_repair.phase_attempts` (used by `transient_requeue._budget_halt_reason` / `_requeue_on_window_reset` and `Task.check_requeue_allowed`) and `stuck_ticket_redispatch._phase_attempts` — excluded **only** `LIMIT_PARKED_PREFIX` attempts. So two such capacity dips in a row produced two identical `error_fingerprint`s, tripped `requeue_verdict`s identical-failure stall detector (`IterationStalled`), and the task was **dead-lettered + a human paged** with a "doomed failure" `DeferredQuestion` — after only **2 usage-limit hits**. This violates the module invariant that a capacity dip is never escalated, and it feeds the chronic exhaustion-stall pain.

## The fix

Exclude any attempt whose error resolves via `recoverable_exhaustion_cause(...)` (the canonical time-recoverable capacity/limit classifier: session / weekly / rate-limit) from the phase-attempt count, in **both** chokepoints. Applied consistently so the reclaim, window-reset auto-requeue, and stuck-ticket re-dispatch paths all stop counting usage-limit failures toward the stall/iteration budget.

- **API-credit** exhaustion (no timed reset → `recoverable_exhaustion_cause` returns `None`) is deliberately **still counted**, so a genuine operator-action halt can still escalate.
- Genuine repeated **non-exhaustion** errors (real code/test failures) still escalate exactly as before — no over-suppression.

## Tests (RED→GREEN)

- `test_transient_requeue.py`: two identical `subscription_session` failures (and a rate-limit variant) after the window horizon are now **REQUEUED**, not escalated — both FAILED before the fix, PASS after.
- `test_stuck_ticket_redispatch.py`: a stuck ticket whose recent phase attempts all died on the session limit is **re-dispatched**, not halted/paged — FAILED before, PASS after.
- Existing guardrail tests (identical non-exhaustion double-failure escalates; api-credit escalates) still pass.

Full `tests/teatree_loop` (2619 passed), `tests/quality`/`tests/conformance`/capabilities doctest (green in isolation — 4 apparent timeouts were box-contention only), ruff, `ty`, `makemigrations --check`, and `test-path-mirror` all pass.

> Opened as **draft**: this alters task-escalation behavior and must be owner-reviewed before any auto-merge.