### PR TITLE
fix(deploy): freshbox bootstrap — host-derived container UID, all bind dirs, digest-pinned base (closes #3439, closes #3438, closes #3452)

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -2,7 +2,10 @@
 # selected by $TEATREE_ROLE. Extends the dev/Dockerfile.test toolchain and adds
 # gh. The teatree source is NOT baked: it is cloned onto a volume at runtime and
 # installed editable by the init role, so the image is just the toolchain.
-FROM ubuntu:24.04
+#
+# Digest-pinned to the same ubuntu:24.04 manifest dev/Dockerfile.test pins, so a
+# retag of the floating tag can never silently change the deploy toolchain.
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 
 # Toolchain layer — ca-certificates, curl, git, jq, sqlite3, direnv, node 24, the
 # claude CLI (as in dev/Dockerfile.test) plus gh, plus pass/gnupg so the box can
@@ -65,6 +68,24 @@ RUN mkdir -p \
     chown -R teatree:teatree /home/teatree /opt/teatree
 
 COPY --chmod=0755 deploy/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# Align the runtime user to the HOST deploy user's UID (the TEATREE_UID build
+# arg). Every host bind mount is at path identity (see deploy/README.md § UID
+# invariant), so the container UID MUST equal the host deploy user's UID or every
+# bind mount is unwritable and init crash-loops on its first write. deploy.sh
+# derives this from the host at deploy time (`id -u` of the deploy user) and
+# passes it as the build arg, so the image always matches whatever box builds it.
+# The default is 1001 — the live box's deploy user, and also the UID `useradd`
+# below lands on unaided (Ubuntu 24.04 ships a stock `ubuntu` user already holding
+# UID 1000, so the teatree user created above takes the next free id, 1001). The
+# stock `ubuntu` user is removed to free UID 1000 for boxes whose deploy user is
+# 1000; the teatree user is then renumbered onto TEATREE_UID (a no-op when it
+# already equals 1001) and its already-populated home tree re-owned to that id.
+ARG TEATREE_UID=1001
+RUN userdel -r ubuntu 2>/dev/null || true; \
+    usermod -u "${TEATREE_UID}" teatree && \
+    groupmod -g "${TEATREE_UID}" teatree && \
+    chown -R teatree:teatree /home/teatree /opt/teatree  # privacy-scan:allow
 
 # The deploy-managed default ~/.claude/settings.json template (#3359). The init
 # role generates the container's real settings.json from this (plus env overrides)

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -83,6 +83,43 @@ from the operator's real DB.
 `teatree_src` and `teatree_uv` stay Docker-managed named volumes for now (later
 PRs handle code-mount modes).
 
+### UID invariant — the container user must equal the host deploy user
+
+Every state, credential, and session mount in the table above is a **host bind
+mount at path identity**, so each file on the host disk carries the host deploy
+user's numeric UID while the container writes it as the image's `teatree` user.
+Those two must be the **same UID**, or every bind mount is unwritable from inside
+the container and `init` crash-loops on its first write.
+
+`deploy.sh` therefore **derives the container UID from the host at deploy time**:
+it runs as the deploy user, reads that user's UID (`id -u`), and exports it as the
+`TEATREE_UID` build arg (compose reads `${TEATREE_UID}` into the image build). The
+image build then renumbers its `teatree` user onto that UID and removes Ubuntu
+24.04's stock `ubuntu` user (which occupies UID 1000) so the id is free. Because the
+container UID is taken from whatever box runs the build, **the invariant holds on
+any box with no manual step** — the live box (deploy user 1001) rebuilds at 1001
+with no chown, and a fresh box lands on its own deploy user's UID.
+
+The default UID, used when nothing exports `TEATREE_UID` (the `ARG TEATREE_UID`
+default in `deploy/Dockerfile`, and the `${TEATREE_UID:-1001}` default in
+`deploy/docker-compose.yml`), is **1001** — the live box's deploy user, and the UID
+`useradd teatree` lands on unaided inside the image (UID 1000 is taken by the stock
+`ubuntu` user, so `teatree` takes the next free id, 1001). `deploy.sh` also
+pre-creates every bind-mount source owned by the deploy user before the stack
+starts.
+
+A bare `docker compose build` (no `deploy.sh`) uses that 1001 default. To build for
+a different deploy user by hand, export or pass the UID explicitly:
+
+```bash
+TEATREE_UID="$(id -u)" docker compose -f deploy/docker-compose.yml build
+# or: docker compose -f deploy/docker-compose.yml build --build-arg TEATREE_UID="$(id -u)"
+```
+
+Changing the container UID on a box that already has bind-mount data written under
+the old UID requires a one-time `chown` of the bind sources to the new UID (stack
+stopped), otherwise the pre-existing files stay unwritable.
+
 ### One-time volume migration (operator step)
 
 A box that ran an older deploy has its state in Docker named volumes

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -50,14 +50,38 @@ git -C "$REPO_ROOT" fetch --prune origin
 git -C "$REPO_ROOT" pull --ff-only
 echo "deploy: deploying $(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD) @ $(git -C "$REPO_ROOT" rev-parse --short HEAD)"
 
-# The credential-plane bind sources must pre-exist owned by the deploy user —
-# dockerd would otherwise create a missing source ROOT-owned, locking the user
-# out of later `pass insert` provisioning. Empty dirs are the sane degradation
-# for an env-token box (init's preflight then falls through to CLAUDE_CODE_OAUTH_TOKEN).
+# EVERY host bind-mount SOURCE dir (compose x-teatree-common `volumes:`) must
+# pre-exist owned by the deploy user. A missing source is auto-created by dockerd
+# ROOT-owned, which locks the non-root container — whose UID must equal this
+# deploy user (see deploy/README.md § UID invariant) — out of that mount: the
+# credential plane then blocks `pass insert` provisioning, and the data + session
+# planes block the DB, worktree, workspace, and transcript writes so `init`
+# crash-loops on its first write. Empty dirs are the sane degradation for an
+# env-token box (init's preflight then falls through to CLAUDE_CODE_OAUTH_TOKEN).
+#
+# The credential plane (pass store + its GPG home) is mode 700; the data and
+# session planes take the default mode.
 install -d -m 700 "$HOME/.password-store" "$HOME/.gnupg"
-# The dream pass's transcript/memory input dir must pre-exist owned by the deploy
-# user — dockerd would otherwise create the missing bind source ROOT-owned.
-install -d "$HOME/.claude/projects"
+install -d \
+    "$HOME/.local/share/teatree" \
+    "$HOME/.local/share/teatree-worktrees" \
+    "$HOME/workspace/t3-workspaces" \
+    "$HOME/.claude/projects"
+
+# Derive the container's runtime UID from the HOST at deploy time (#3438). Every
+# bind mount above is at path identity, so the container's teatree user MUST hold
+# the same UID as the host deploy user or every mount is unwritable and init
+# crash-loops (see deploy/README.md § UID invariant). deploy.sh runs AS the deploy
+# user, so its own UID is the source of truth; it is passed to the image build
+# (compose reads ${TEATREE_UID} into the TEATREE_UID build arg). Falls back to the
+# owner of the pre-existing data dir, then to 1001 (the live box's deploy user, and
+# the Dockerfile's default) if both are somehow unreadable. This keeps a rebuild on
+# THIS box at 1001 (no breakage, no chown) and a fresh box at its own deploy UID.
+TEATREE_UID="$(id -u 2>/dev/null || true)"
+[ -n "$TEATREE_UID" ] || TEATREE_UID="$(stat -c %u "$HOME/.local/share/teatree" 2>/dev/null || true)"
+[ -n "$TEATREE_UID" ] || TEATREE_UID=1001
+export TEATREE_UID
+echo "deploy: container UID (host deploy user) — TEATREE_UID=$TEATREE_UID"
 
 # Derive the worker container's compose CPU/RAM caps from the REAL host at deploy
 # time (#3432). deploy.sh runs UNCAPPED on the host, so ram_probe reads true host

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -16,6 +16,12 @@ x-teatree-common: &teatree-common
   build:
     context: ..
     dockerfile: deploy/Dockerfile
+    # The container's runtime UID must equal the host deploy user's UID (path-
+    # identity bind mounts — see deploy/README.md § UID invariant). deploy.sh
+    # exports TEATREE_UID from the host (`id -u`); the default matches the image's
+    # own ARG default (1001) for a bare `compose build` with no deploy.sh.
+    args:
+      TEATREE_UID: ${TEATREE_UID:-1001}
   env_file:
     - teatree.env
   # All services mount all state so admin and worker share ONE db.sqlite3
@@ -154,6 +160,10 @@ services:
     build:
       context: ..
       dockerfile: deploy/Dockerfile
+      # Same shared image, so the UID build arg must match the anchor's (see
+      # deploy/README.md § UID invariant); default 1001 tracks the ARG default.
+      args:
+        TEATREE_UID: ${TEATREE_UID:-1001}
     environment:
       TEATREE_ROLE: watchdog
       TEATREE_WATCHDOG_INTERVAL: "300"

--- a/tests/test_deploy_freshbox_bootstrap.py
+++ b/tests/test_deploy_freshbox_bootstrap.py
@@ -1,0 +1,140 @@
+"""Fresh-box bootstrap invariants for the headless deploy substrate.
+
+Three failure modes broke a first deploy onto a clean box and are pinned here
+against the deploy files (the source of truth):
+
+- ``deploy/deploy.sh`` must pre-create EVERY host bind-mount source owned by the
+    deploy user. A source missing at ``up`` time is auto-created by dockerd
+    ROOT-owned, and the non-root container then cannot write it.
+- The container's runtime UID must equal the HOST deploy user's UID so every
+    path-identity bind mount is writable: ``deploy.sh`` derives it from the host
+    (``id -u``) and passes it through ``deploy/docker-compose.yml`` into the
+    ``deploy/Dockerfile`` ``TEATREE_UID`` build arg, which defaults to 1001 (the
+    live box's deploy user) when nothing exports it.
+- ``deploy/Dockerfile`` must digest-pin its base image to the same manifest that
+    ``dev/Dockerfile.test`` pins, so a floating-tag retag cannot change the
+    toolchain silently.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+DEPLOY_DIR = Path(__file__).resolve().parents[1] / "deploy"
+COMPOSE_FILE = DEPLOY_DIR / "docker-compose.yml"
+DEPLOY_SH = DEPLOY_DIR / "deploy.sh"
+DOCKERFILE = DEPLOY_DIR / "Dockerfile"
+DEV_DOCKERFILE = Path(__file__).resolve().parents[1] / "dev" / "Dockerfile.test"
+
+_HOME = "/home/teatree"  # privacy-scan:allow — the box's public, documented deploy home
+
+
+def _bind_sources() -> set[str]:
+    """Every host bind-mount SOURCE path the shared service list declares."""
+    compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+    volumes = compose["x-teatree-common"]["volumes"]
+    return {entry["source"] for entry in volumes if isinstance(entry, dict) and entry.get("type") == "bind"}
+
+
+def _install_d_targets(script: str) -> set[str]:
+    """The absolute paths ``deploy.sh`` pre-creates via ``install -d``.
+
+    Backslash line continuations are folded first so a multi-line ``install -d``
+    reads as one command; ``$HOME`` expands to the deploy user's home to match the
+    compose bind sources.
+    """
+    folded = re.sub(r"\\\n\s*", " ", script)
+    targets: set[str] = set()
+    for line in folded.splitlines():
+        if not line.strip().startswith("install -d"):
+            continue
+        targets.update(_HOME + suffix for suffix in re.findall(r'"\$HOME(/[^"]+)"', line))
+    return targets
+
+
+def _base_digest(dockerfile_text: str) -> str | None:
+    match = re.search(r"ubuntu:24\.04@(sha256:[0-9a-f]{64})", dockerfile_text)
+    return match.group(1) if match else None
+
+
+class TestDeployPreCreatesEveryBindSource:
+    def test_all_bind_sources_are_pre_created_owned_by_deploy_user(self) -> None:
+        created = _install_d_targets(DEPLOY_SH.read_text(encoding="utf-8"))
+        missing = _bind_sources() - created
+        assert not missing, f"deploy.sh does not pre-create bind sources: {sorted(missing)}"
+
+    def test_credential_plane_is_created_mode_700(self) -> None:
+        folded = re.sub(r"\\\n\s*", " ", DEPLOY_SH.read_text(encoding="utf-8"))
+        secret_lines = [
+            line for line in folded.splitlines() if line.strip().startswith("install -d") and ".password-store" in line
+        ]
+        assert secret_lines, "pass store must be pre-created"
+        for line in secret_lines:
+            assert "-m 700" in line, "credential-plane dirs must be created mode 700"
+
+
+class TestHostDerivedRuntimeUid:
+    def test_uid_is_a_build_arg_defaulting_to_1001(self) -> None:
+        text = DOCKERFILE.read_text(encoding="utf-8")
+        assert re.search(r"^ARG TEATREE_UID=1001$", text, re.MULTILINE), (
+            "container UID must be a build arg defaulting to 1001 (the live box's deploy user)"
+        )
+
+    def test_user_is_renumbered_to_the_arg_uid(self) -> None:
+        text = DOCKERFILE.read_text(encoding="utf-8")
+        assert re.search(r'usermod\b[^\n]*-u\s+"\$\{TEATREE_UID\}"[^\n]*\bteatree\b', text), (
+            "teatree user must be renumbered onto the TEATREE_UID build arg"
+        )
+        assert re.search(r'groupmod\b[^\n]*-g\s+"\$\{TEATREE_UID\}"[^\n]*\bteatree\b', text), (
+            "teatree primary group must track the TEATREE_UID build arg"
+        )
+
+    def test_stock_ubuntu_user_is_removed_to_free_uid_1000(self) -> None:
+        text = DOCKERFILE.read_text(encoding="utf-8")
+        assert re.search(r"userdel\b[^\n]*\bubuntu\b", text), (
+            "Ubuntu 24.04's stock 'ubuntu' user (UID 1000) must be removed first"
+        )
+
+    def test_deploy_sh_derives_uid_from_the_host_deploy_user(self) -> None:
+        text = DEPLOY_SH.read_text(encoding="utf-8")
+        assert re.search(r'TEATREE_UID="\$\(id -u', text), (
+            "deploy.sh must derive the container UID from the host deploy user via `id -u`"
+        )
+        assert re.search(r"\bexport TEATREE_UID\b", text), (
+            "deploy.sh must export TEATREE_UID so compose reads it into the build arg"
+        )
+        assert re.search(r"TEATREE_UID=1001\b", text), (
+            "deploy.sh must fall back to 1001 (the live box's deploy user) if derivation fails"
+        )
+        # No hardcoded 1000 default may sneak back in — that would break the live box.
+        assert not re.search(r"TEATREE_UID=1000\b", text), "deploy.sh must not hardcode UID 1000"
+
+    def test_compose_plumbs_the_uid_build_arg_defaulting_to_1001(self) -> None:
+        compose = yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))
+        anchor_args = compose["x-teatree-common"]["build"]["args"]
+        assert anchor_args["TEATREE_UID"] == "${TEATREE_UID:-1001}", (
+            "the shared build must pass TEATREE_UID through, defaulting to 1001"
+        )
+        watchdog_args = compose["services"]["teatree-watchdog"]["build"]["args"]
+        assert watchdog_args["TEATREE_UID"] == "${TEATREE_UID:-1001}", (
+            "the standalone watchdog build shares the image and must pass the same UID arg"
+        )
+
+
+class TestBaseImageDigestPin:
+    def test_deploy_base_is_digest_pinned(self) -> None:
+        assert _base_digest(DOCKERFILE.read_text(encoding="utf-8")) is not None, (
+            "deploy/Dockerfile FROM must be pinned by @sha256 digest"
+        )
+
+    def test_deploy_base_digest_matches_dev_dockerfile(self) -> None:
+        deploy_digest = _base_digest(DOCKERFILE.read_text(encoding="utf-8"))
+        dev_digest = _base_digest(DEV_DOCKERFILE.read_text(encoding="utf-8"))
+        assert dev_digest is not None, "dev/Dockerfile.test must digest-pin its base"
+        assert deploy_digest == dev_digest, "deploy and dev must pin the same ubuntu:24.04 manifest"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Re-lands the FRESHBOX deploy bootstrap (supersedes #3461) on a fresh branch off the latest `main`, made **UID-safe** so it cannot break the live box on the next rebuild.

Closes #3439, closes #3438, closes #3452.

## What changed vs the superseded #3461
The original defaulted `TEATREE_UID=1000`, which would have re-owned the container to 1000 while the live box's host bind-mount files are **1001**-owned — breaking every mount on the next rebuild. This version derives the UID from the host and defaults to 1001.

## UID safety
- `deploy/deploy.sh` **derives the container UID from the host deploy user at deploy time** (`id -u`, falling back to `stat -c %u` of the data dir, then `1001`) and exports it as the `TEATREE_UID` build arg.
- `deploy/docker-compose.yml` plumbs `${TEATREE_UID:-1001}` into both build sections (shared anchor + standalone watchdog — same image).
- `deploy/Dockerfile` `ARG TEATREE_UID` default changed `1000` -> `1001` (the live box's UID, and the id `useradd teatree` lands on unaided since the stock `ubuntu` user holds 1000). `usermod -u 1001` on an already-1001 user is a verified no-op (exit 0).
- **Net effect:** on THIS box the build is UID 1001 (no breakage, no chown); on a fresh box the container UID matches that box's deploy user automatically. No hardcoded 1000 default anywhere.

## Retained from FRESHBOX (#3439, #3452)
- `deploy.sh` pre-creates EVERY host bind-mount source (data, worktrees, workspaces, pass store, GPG home, Claude projects dir) owned by the deploy user, so dockerd never auto-creates a source root-owned.
- Base image digest-pinned to the same `ubuntu:24.04` manifest `dev/Dockerfile.test` pins.

## Tests
`tests/test_deploy_freshbox_bootstrap.py` pins: all bind sources pre-created + mode-700 credential plane; UID is a build arg defaulting to 1001; `deploy.sh` derives it via `id -u`, exports it, falls back to 1001, and never hardcodes 1000; compose plumbs the arg to both builds; base image digest-pinned and matching dev.

Draft pending CI. The old #3461 should be closed as superseded.
