### PR TITLE
fix(statusline): loop line shows preset/schedule + overrides-only, not every enabled loop (#3248)

### DIFF
--- a/src/teatree/core/management/commands/loops_tick.py
+++ b/src/teatree/core/management/commands/loops_tick.py
@@ -58,8 +58,8 @@ from teatree.core.loop_lease_manager import PER_LOOP_TICK_MUTEX_PREFIX, per_loop
 from teatree.core.models import LoopLease
 from teatree.loop.loop_cadences import loop_owner_ttl_seconds
 from teatree.loop.preset_resolution import active_overlay_scope
-from teatree.loop.statusline import set_preset_segment_reader
-from teatree.loops.preset_status import preset_line_chunk
+from teatree.loop.statusline import set_overridden_loops_reader, set_preset_segment_reader
+from teatree.loops.preset_status import overridden_loop_names, preset_line_chunk
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -316,18 +316,23 @@ class Command(TyperCommand):
         from teatree.loop.tick import run_tick  # noqa: PLC0415 — deferred: keeps command import light
         from teatree.loops.schedule import mini_loop_schedules  # noqa: PLC0415 — deferred: keeps command import light
 
-        # The statusline dedicated loop line shows every enabled loop with its own
-        # next-tick countdown (#1400) plus the active-preset segment (#3159); install
-        # the live DB-backed readers so this per-loop tick's render keeps the full
-        # loop line, then reset after the tick so the process-global seams never leak.
+        # The statusline dedicated loop line shows due-soon loops with their own
+        # next-tick countdowns (#1400) under the active-preset/schedule handle
+        # (#3159/#3248); install the live DB-backed readers so this per-loop tick's
+        # render carries that handle AND collapses the routine per-loop leases into
+        # it (the overridden-loops reader is what activates the collapse — so it is
+        # installed together with the preset segment that represents the folded
+        # loops), then reset after the tick so the process-global seams never leak.
         set_mini_loop_schedules_reader(mini_loop_schedules)
         set_preset_segment_reader(preset_line_chunk)
+        set_overridden_loops_reader(overridden_loop_names)
         try:
             request = self._build_request(overlay)
             report = run_tick(request, statusline_path=statusline_file, jobs_builder=_scoped_jobs_builder(loop))
         finally:
             set_mini_loop_schedules_reader(None)
             set_preset_segment_reader(None)
+            set_overridden_loops_reader(None)
             LoopLease.objects.release(tick_mutex, owner=owner)
 
         self._emit_report(report, json_output=json_output)

--- a/src/teatree/loop/statusline.py
+++ b/src/teatree/loop/statusline.py
@@ -30,6 +30,7 @@ from teatree.loop.statusline_loops import (
     mini_loops_anchor,
     overlays_anchor,
     set_mini_loop_schedules_reader,
+    set_overridden_loops_reader,
     set_preset_segment_reader,
 )
 from teatree.loop.statusline_render import (
@@ -59,6 +60,7 @@ __all__ = [
     "plain_link",
     "render",
     "set_mini_loop_schedules_reader",
+    "set_overridden_loops_reader",
     "set_preset_segment_reader",
     "statusline_for_slack",
 ]

--- a/src/teatree/loop/statusline_loop_chunks.py
+++ b/src/teatree/loop/statusline_loop_chunks.py
@@ -1,0 +1,295 @@
+"""Pure per-loop / mini-loop chunk formatters for the dedicated loop line.
+
+Split out of :mod:`teatree.loop.statusline_loops` so that module stays a thin
+orchestrator (DB-read seams, injected readers, the ``live_loops_anchor``
+assembly) and this one owns the presentation concern: turning a loop name plus a
+timing into the ``<name> <next-tick>`` chunk the loop line renders, colored by
+recency, plus the two chunk-list builders the line composes (the per-loop lease
+list and the due-soon mini-loop list).
+
+This module is a **leaf**: it imports only the ANSI palette and the per-loop
+scoping predicates, never :mod:`teatree.loop.statusline_loops` itself. Everything
+it needs from the orchestrator — the live leases, the driver map, the resolved
+override set, and the per-loop cadence resolver — is passed in as an argument, so
+there is no import cycle and the orchestrator's DB / cadence seams stay the single
+place tests stub.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from teatree.loop.loop_scoping import (
+    is_per_loop_owner_slot,
+    is_transient_tick_mutex,
+    loop_is_actively_ticking,
+    per_loop_chunk_visible,
+    per_loop_loop_name,
+)
+from teatree.loop.statusline_palette import (
+    _ANSI_DIM,
+    _ANSI_GREEN,
+    _ANSI_RED,
+    _ANSI_YELLOW,
+    _RECENCY_GREEN_FRACTION,
+    _RECENCY_YELLOW_FRACTION,
+    _SECONDS_PER_MINUTE,
+)
+
+#: A loop is due (and so survives the #3248 per-loop-lease collapse) when its next
+#: fire is now or within this horizon — the same window the ``due:`` mini-loop
+#: section applies, so the two due views stay consistent.
+_DUE_SOON_SECONDS = 300
+
+#: Resolve a loop name to its cadence in seconds. Injected by the orchestrator
+#: (``statusline_loops._cadence_for_loop``) so this leaf never reads config and the
+#: cadence seam stays the single place tests stub.
+type CadenceResolver = Callable[[str], int]
+
+
+@dataclass(frozen=True, slots=True)
+class LeaseRenderContext:
+    """The resolved inputs :func:`lease_chunks` renders a live lease against.
+
+    Bundles the four DB / config reads the orchestrator resolves for the whole
+    batch — the driver map, this session's owned ``loop:<name>`` slots, the
+    manually-overridden set (``None`` = no #3248 collapse), and the per-loop
+    cadence resolver — so the renderer takes one typed context rather than a wide
+    parameter list.
+    """
+
+    drivers: dict[str, tuple[str, str]]
+    owned_per_loop: set[str] | None
+    overridden: set[str] | None
+    cadence_of: CadenceResolver
+
+
+def _seconds_until(next_fire_at: datetime) -> float:
+    """Return seconds from now until *next_fire_at* (negative once overdue)."""
+    from django.utils import timezone  # noqa: PLC0415 — deferred: Django import at call time
+
+    return (next_fire_at - timezone.now()).total_seconds()
+
+
+def _relative_minutes(next_fire_at: datetime) -> str:
+    """Return the relative whole-minute countdown to *next_fire_at* (``11m`` / ``due``).
+
+    ``due`` once the instant is in the past — the loop fires on the
+    orchestrator's next tick. Always derived from the live clock at render
+    time so the value counts down across successive renders rather than
+    freezing on a cached string.
+    """
+    from django.utils import timezone  # noqa: PLC0415 — deferred: Django import at call time
+
+    delta_seconds = int((next_fire_at - timezone.now()).total_seconds())
+    if delta_seconds <= 0:
+        return "due"
+    minutes = max(1, round(delta_seconds / _SECONDS_PER_MINUTE))
+    return f"{minutes}m"
+
+
+def _short_loop_name(name: str) -> str:
+    """Strip the ``loop-`` prefix so ``loop-my-prs`` reads as ``my-prs``."""
+    return name.removeprefix("loop-")
+
+
+def _colorize_chunk(text: str, color: str, *, colorize: bool) -> str:
+    """Wrap *text* in *color*, resetting to the line's dim baseline (not full reset).
+
+    The whole loop line is wrapped in :data:`_ANSI_DIM` by
+    :func:`teatree.loop.statusline_render.render`, so a colored chunk resets
+    back to dim — never a full ANSI reset — to keep the ` · ` separators,
+    availability, and waiting segments dim around it.
+    """
+    if not colorize or not color:
+        return text
+    return f"{color}{text}{_ANSI_DIM}"
+
+
+def _loop_recency_color(seconds_until_tick: float | None, cadence_seconds: int) -> str:
+    """Map a loop's imminence to an ANSI color, RELATIVE to its own cadence.
+
+    The color tracks the fraction of the loop's cadence still remaining until
+    its next tick (``seconds_until_tick / cadence_seconds``): green when over
+    half the cadence is left (just ticked / plenty of time), yellow as it
+    approaches, red when it is about to tick or already overdue. Judging the
+    fraction rather than absolute seconds keeps the signal relative — the same
+    "120s until tick" reads green on an hourly loop and red on a 150s loop.
+
+    ``None`` seconds (no acquire instant / never fired) and a non-positive
+    cadence both fail safe to red (overdue / unknown).
+    """
+    if seconds_until_tick is None or cadence_seconds <= 0:
+        return _ANSI_RED
+    fraction = seconds_until_tick / cadence_seconds
+    if fraction >= _RECENCY_GREEN_FRACTION:
+        return _ANSI_GREEN
+    if fraction >= _RECENCY_YELLOW_FRACTION:
+        return _ANSI_YELLOW
+    return _ANSI_RED
+
+
+def _next_tick_minutes(name: str, acquired_at: datetime | None, cadence_of: CadenceResolver) -> str:
+    """Return *name*'s relative next-tick as whole minutes (``11m`` / ``due``).
+
+    Empty string when nothing useful is queryable (no acquire timestamp, no
+    resolvable cadence) — the caller then renders a name-only chunk rather
+    than invent a duration. Fails open on every cadence read.
+    """
+    if acquired_at is None:
+        return ""
+    try:
+        cadence = cadence_of(name)
+    except Exception:  # noqa: BLE001 — rendering is best-effort; a failure degrades to empty
+        return ""
+    return _relative_minutes(acquired_at + timedelta(seconds=cadence))
+
+
+def _loop_chunk(name: str, acquired_at: datetime | None, cadence_of: CadenceResolver) -> str:
+    """Render one ``<short-name> <next-tick>`` chunk for a live loop."""
+    tick = _next_tick_minutes(name, acquired_at, cadence_of)
+    suffix = f" {tick}" if tick else ""
+    return f"{_short_loop_name(name)}{suffix}"
+
+
+def _mini_loop_chunk(name: str, next_fire_at: datetime | None) -> str:
+    """Render one ``<name> <next-tick>`` chunk for an enabled mini-loop.
+
+    ``due`` when the loop has never fired (no marker → ``next_fire_at`` is
+    ``None``) or is already overdue; otherwise the relative whole-minute
+    countdown derived live from ``next_fire_at``.
+    """
+    tick = "due" if next_fire_at is None else _relative_minutes(next_fire_at)
+    return f"{name} {tick}"
+
+
+def _lease_recency_color(name: str, acquired_at: datetime | None, cadence_of: CadenceResolver) -> str:
+    """Resolve the recency color for an infra lease from its own cadence."""
+    try:
+        cadence = cadence_of(name)
+    except Exception:  # noqa: BLE001 — an unresolvable cadence degrades to the red recency color
+        return _ANSI_RED
+    seconds_until = _seconds_until(acquired_at + timedelta(seconds=cadence)) if acquired_at is not None else None
+    return _loop_recency_color(seconds_until, cadence)
+
+
+def _driver_suffix(name: str, drivers: dict[str, tuple[str, str]], *, colorize: bool) -> str:
+    """Return the ``·<driver>`` / ``·DRIVERLESS`` suffix for a per-loop owner chunk.
+
+    Only ``loop:<name>`` per-loop owner leases carry a driver chip in the shared
+    loop line (``t3-master`` has its own anchor; infra leases never do — pinning
+    edge-case 6, e.g. ``loop-reinstall`` renders no chip). An owned row (non-empty
+    ``session_id``) with a registered driver renders ``·<driver>`` palette-neutral;
+    an unowned row renders nothing.
+
+    A blank stored driver only warrants the ``·DRIVERLESS`` alert when the loop is
+    genuinely not ticking. A worker/cron tick runs anonymously (empty
+    ``session_id``), so :meth:`LoopLeaseQuerySet.claim_ownership` never rewrites the
+    owner lease and its stored ``driver`` fossilises blank while the loop ticks fine
+    (#3366). ``·DRIVERLESS`` means "claimed but never ticks", so a loop the cadence
+    ledger shows ticking (:func:`loop_is_actively_ticking`) suppresses the alert.
+    """
+    if not is_per_loop_owner_slot(name):
+        return ""
+    session_id, driver = drivers.get(name, ("", ""))
+    if not session_id:
+        return ""
+    if driver:
+        return f"·{driver}"
+    if loop_is_actively_ticking(name):
+        return ""
+    return "·" + _colorize_chunk("DRIVERLESS", _ANSI_YELLOW, colorize=colorize)
+
+
+def _lease_is_due_now(name: str, acquired_at: datetime | None, cadence_of: CadenceResolver) -> bool:
+    """Whether a per-loop lease is due now / within the #3248 due-soon horizon.
+
+    A never-acquired lease (no tick recorded yet) reads as due. Otherwise the
+    loop is due when its own cadence puts the next fire within
+    :data:`_DUE_SOON_SECONDS` — the same horizon the ``due:`` section applies to
+    the mini-loop crons, so the two due views stay consistent. Fails open to
+    ``True`` (surface the chunk) on any cadence-read error.
+    """
+    if acquired_at is None:
+        return True
+    try:
+        cadence = cadence_of(name)
+    except Exception:  # noqa: BLE001 — an unresolvable cadence keeps the chunk visible (never hide on error)
+        return True
+    return _seconds_until(acquired_at + timedelta(seconds=cadence)) <= _DUE_SOON_SECONDS
+
+
+def _lease_chunk_surfaces(
+    name: str, acquired_at: datetime | None, overridden: set[str] | None, cadence_of: CadenceResolver
+) -> bool:
+    """Whether a live lease still earns its own per-loop chunk (#3248 collapse).
+
+    Infra / master leases (``loop-tick``, ``reinstall`` and friends — anything
+    that is NOT a ``loop:<name>`` owner slot) always surface. A routine per-loop
+    ``loop:<name>`` owner slot — claimed for EVERY enabled loop by the shared
+    ``loop_runner`` — is collapsed into the preset/schedule handle unless it is
+    manually overridden away from that handle or due to fire now, so the loop
+    line stops listing every enabled loop.
+
+    ``overridden is None`` is the fail-open marker (no collapse selector injected,
+    or a resolver error): every chunk surfaces, i.e. today's behavior, so a broken
+    override read can never hide a loop the operator expects to see.
+    """
+    if overridden is None:
+        return True
+    if not is_per_loop_owner_slot(name):
+        return True
+    if per_loop_loop_name(name) in overridden:
+        return True
+    return _lease_is_due_now(name, acquired_at, cadence_of)
+
+
+def lease_chunks(
+    leases: list[tuple[str, datetime | None]], context: LeaseRenderContext, *, colorize: bool = False
+) -> list[str]:
+    """Return one ``<short-name> <next-tick>`` chunk per live lease this session shows.
+
+    The ``t3-master`` lease is excluded (a session-ownership token, not a work
+    loop) and the transient per-loop tick mutex ``loop-tick:<name>`` too (while it
+    is held the matching ``loop:<name>`` owner lease is held as well, so rendering
+    it would show the ticking loop twice). The ``loop:<name>`` leases are
+    per-session scoped via ``context.owned_per_loop``; the single ``loop_runner``
+    session drives one for EVERY enabled loop, so ``context.overridden`` (when not
+    ``None``) collapses the routine ones into the preset/schedule handle
+    (:func:`_lease_chunk_surfaces`) — infra / master leases always survive. When
+    *colorize* is set, each chunk is wrapped in its recency color.
+    """
+    cadence_of = context.cadence_of
+    return [
+        _colorize_chunk(
+            _loop_chunk(name, acquired_at, cadence_of),
+            _lease_recency_color(name, acquired_at, cadence_of),
+            colorize=colorize,
+        )
+        + _driver_suffix(name, context.drivers, colorize=colorize)
+        for name, acquired_at in leases
+        if name != "t3-master"
+        and not is_transient_tick_mutex(name)
+        and per_loop_chunk_visible(name, context.owned_per_loop)
+        and _lease_chunk_surfaces(name, acquired_at, context.overridden, cadence_of)
+    ]
+
+
+def mini_loop_chunks(schedules: list[tuple[str, datetime | None, int]], *, colorize: bool = False) -> list[str]:
+    """Return a ``<name> <next-tick>`` chunk per DUE-SOON domain mini-loop (#3248).
+
+    Companion to :func:`lease_chunks`: this renders the enabled domain crons from
+    the cadence ledger that are due now (never fired / overdue) or within
+    :data:`_DUE_SOON_SECONDS` — NOT the full loop list (presets/schedules are the
+    handle). Each carries its own next-tick countdown and (when *colorize* is set)
+    its cadence-relative recency color.
+    """
+    return [
+        _colorize_chunk(
+            _mini_loop_chunk(name, next_fire_at),
+            _loop_recency_color(None if next_fire_at is None else _seconds_until(next_fire_at), cadence),
+            colorize=colorize,
+        )
+        for name, next_fire_at, cadence in schedules
+        if next_fire_at is None or _seconds_until(next_fire_at) <= _DUE_SOON_SECONDS
+    ]

--- a/src/teatree/loop/statusline_loops.py
+++ b/src/teatree/loop/statusline_loops.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from teatree.loop.loop_cadences import (
@@ -8,22 +8,9 @@ from teatree.loop.loop_cadences import (
     self_improve_cadence_seconds,
     slack_answer_cadence_seconds,
 )
-from teatree.loop.loop_scoping import (
-    current_session_owned_per_loop_slots,
-    is_per_loop_owner_slot,
-    is_transient_tick_mutex,
-    loop_is_actively_ticking,
-    per_loop_chunk_visible,
-)
-from teatree.loop.statusline_palette import (
-    _ANSI_DIM,
-    _ANSI_GREEN,
-    _ANSI_RED,
-    _ANSI_YELLOW,
-    _RECENCY_GREEN_FRACTION,
-    _RECENCY_YELLOW_FRACTION,
-    _SECONDS_PER_MINUTE,
-)
+from teatree.loop.loop_scoping import current_session_owned_per_loop_slots
+from teatree.loop.statusline_loop_chunks import LeaseRenderContext, _colorize_chunk, lease_chunks, mini_loop_chunks
+from teatree.loop.statusline_palette import _ANSI_GREEN, _ANSI_RED, _ANSI_YELLOW
 
 if TYPE_CHECKING:
     from teatree.core.availability import Resolution
@@ -243,6 +230,53 @@ def _preset_segment() -> str:
         return ""
 
 
+# The set of manually-overridden loop names (#3248) is resolved up-stack in
+# :func:`teatree.loops.preset_status.overridden_loop_names` (the resolver lives
+# in ``teatree.loops``), injected through the same seam as the preset segment.
+# It gates the per-loop-lease collapse: a routine ``loop:<name>`` owner slot —
+# claimed for EVERY enabled loop by the shared ``loop_runner`` — is folded into
+# the preset/schedule handle unless it is manually overridden away from that
+# handle (or due to fire now). Absent injection (a quiet machine, a unit test)
+# the default reader signals ``None`` and NOTHING is collapsed — today's full
+# per-loop render — so the collapse never activates without the preset handle
+# that represents the folded loops also being present (both are injected
+# together by the ``loops_tick`` per-loop command).
+type OverriddenLoopsReader = Callable[[], set[str]]
+
+
+_overridden_loops_reader: OverriddenLoopsReader | None = None
+
+
+def set_overridden_loops_reader(reader: OverriddenLoopsReader | None) -> None:
+    """Install the up-stack manually-overridden-loop-names reader (``None`` resets to uninjected).
+
+    Mirrors :func:`set_preset_segment_reader`; the ``loops_tick`` per-loop
+    command installs it alongside the preset segment reader so the collapse and
+    the ``ovr:`` handle are always rendered together, then resets it after the
+    tick so the process-global seam never leaks.
+    """
+    global _overridden_loops_reader  # noqa: PLW0603 — process-global injection seam, mirrors set_preset_segment_reader
+    _overridden_loops_reader = reader
+
+
+def _overridden_loops() -> set[str] | None:
+    """Return the manually-overridden loop names, or ``None`` when no collapse applies.
+
+    ``None`` is the fail-open sentinel: no reader injected (a quiet machine, a
+    unit test) OR a resolver error. The caller reads ``None`` as "do not collapse
+    — keep every per-loop chunk", i.e. today's behavior, so a broken override
+    read can never hide a loop the operator expects to see. A resolved set
+    (possibly empty) activates the #3248 per-loop-lease collapse.
+    """
+    reader = _overridden_loops_reader
+    if reader is None:
+        return None
+    try:
+        return reader()
+    except Exception:  # noqa: BLE001 — rendering is best-effort; a failure degrades to no collapse
+        return None
+
+
 # Per-loop cadence resolution (#1400). Each named loop ticks on its own
 # schedule, so the next-tick countdown is ``acquired_at + cadence`` with the
 # loop's own cadence — not a single shared value. Unknown / future loops fall
@@ -274,42 +308,6 @@ def _cadence_seconds() -> int:
     return cadence_seconds()
 
 
-def _loop_recency_color(seconds_until_tick: float | None, cadence_seconds: int) -> str:
-    """Map a loop's imminence to an ANSI color, RELATIVE to its own cadence.
-
-    The color tracks the fraction of the loop's cadence still remaining until
-    its next tick (``seconds_until_tick / cadence_seconds``): green when over
-    half the cadence is left (just ticked / plenty of time), yellow as it
-    approaches, red when it is about to tick or already overdue. Judging the
-    fraction rather than absolute seconds keeps the signal relative — the same
-    "120s until tick" reads green on an hourly loop and red on a 150s loop.
-
-    ``None`` seconds (no acquire instant / never fired) and a non-positive
-    cadence both fail safe to red (overdue / unknown).
-    """
-    if seconds_until_tick is None or cadence_seconds <= 0:
-        return _ANSI_RED
-    fraction = seconds_until_tick / cadence_seconds
-    if fraction >= _RECENCY_GREEN_FRACTION:
-        return _ANSI_GREEN
-    if fraction >= _RECENCY_YELLOW_FRACTION:
-        return _ANSI_YELLOW
-    return _ANSI_RED
-
-
-def _colorize_chunk(text: str, color: str, *, colorize: bool) -> str:
-    """Wrap *text* in *color*, resetting to the line's dim baseline (not full reset).
-
-    The whole loop line is wrapped in :data:`_ANSI_DIM` by
-    :func:`teatree.loop.statusline_render.render`, so a colored chunk resets
-    back to dim — never a full ANSI reset — to keep the ` · ` separators,
-    availability, and waiting segments dim around it.
-    """
-    if not colorize or not color:
-        return text
-    return f"{color}{text}{_ANSI_DIM}"
-
-
 def loop_owner_anchor(status: "OwnershipStatus", this_session: str) -> tuple[str, str]:
     """Return ``(zone, line)`` for the foreign-hijack RED line (#1073, #1156).
 
@@ -339,84 +337,30 @@ def loop_owner_anchor(status: "OwnershipStatus", this_session: str) -> tuple[str
     return "action_needed", f"t3-master=session {short8} (NOT this session)"
 
 
-def _live_lease_chunks(*, colorize: bool = False) -> list[str]:
+def _live_lease_chunks(*, colorize: bool = False, handle_present: bool = False) -> list[str]:
     """Return one ``<short-name> <next-tick>`` chunk per live LoopLease this session shows.
 
-    The ``t3-master`` lease is excluded: it is a session-ownership token,
-    not a work loop, and its countdown is meaningless in the shared zones
-    file (the per-session owner badge in ``statusline.sh`` replaces that
-    signal). The transient per-loop tick mutex ``loop-tick:<name>`` (#2650) is
-    excluded too: it is a concurrency lock held only for the beat, and while it
-    is held the matching ``loop:<name>`` owner lease is held as well — so
-    rendering it would show the currently-ticking loop twice, once as
-    ``tick:<name>`` and once as ``loop:<name>``. The dedicated-loop
-    ``loop:<name>`` leases (#1834) are **per-session scoped** via
-    :mod:`teatree.loop.loop_scoping` — only the loops THIS session owns survive
-    (fail-open, byte-identical under the single-owner default). When *colorize*
-    is set, each chunk is wrapped in its recency color
-    (:func:`_loop_recency_color`); fails open to ``[]``.
+    The DB-read seam of the per-loop lease list: it reads the live leases, the
+    driver map, this session's owned ``loop:<name>`` slots, and — only when
+    *handle_present* (a governing preset/schedule segment is on the line to
+    represent the folded loops) — the injected override set, then hands them plus
+    the cadence resolver to :func:`teatree.loop.statusline_loop_chunks.lease_chunks`
+    for the pure formatting + #3248 collapse. With no handle (or no injected
+    selector) every lease surfaces — today's behavior — so a routine loop is never
+    hidden without the handle that represents it. Fails open to ``[]`` on a
+    lease-read error.
     """
     try:
         leases = _live_loop_leases()
     except Exception:  # noqa: BLE001 — rendering is best-effort; a lease-read failure degrades to no rows
         return []
-    owned_per_loop = current_session_owned_per_loop_slots()
-    drivers = _live_lease_drivers()
-    return [
-        _colorize_chunk(
-            _loop_chunk(name, acquired_at),
-            _lease_recency_color(name, acquired_at),
-            colorize=colorize,
-        )
-        + _driver_suffix(name, drivers, colorize=colorize)
-        for name, acquired_at in leases
-        if name != "t3-master" and not is_transient_tick_mutex(name) and per_loop_chunk_visible(name, owned_per_loop)
-    ]
-
-
-def _driver_suffix(name: str, drivers: dict[str, tuple[str, str]], *, colorize: bool) -> str:
-    """Return the ``·<driver>`` / ``·DRIVERLESS`` suffix for a per-loop owner chunk.
-
-    Only ``loop:<name>`` per-loop owner leases carry a driver chip in the shared
-    loop line (``t3-master`` has its own anchor; infra leases never do — pinning
-    edge-case 6, e.g. ``loop-reinstall`` renders no chip). An owned row (non-empty
-    ``session_id``) with a registered driver renders ``·<driver>`` palette-neutral;
-    an unowned row renders nothing.
-
-    A blank stored driver only warrants the ``·DRIVERLESS`` alert when the loop is
-    genuinely not ticking. A worker/cron tick runs anonymously (empty
-    ``session_id``), so :meth:`LoopLeaseQuerySet.claim_ownership` never rewrites the
-    owner lease and its stored ``driver`` fossilises blank while the loop ticks fine
-    (#3366). ``·DRIVERLESS`` means "claimed but never ticks", so a loop the cadence
-    ledger shows ticking (:func:`loop_is_actively_ticking`) suppresses the alert.
-    """
-    if not is_per_loop_owner_slot(name):
-        return ""
-    session_id, driver = drivers.get(name, ("", ""))
-    if not session_id:
-        return ""
-    if driver:
-        return f"·{driver}"
-    if loop_is_actively_ticking(name):
-        return ""
-    return "·" + _colorize_chunk("DRIVERLESS", _ANSI_YELLOW, colorize=colorize)
-
-
-def _lease_recency_color(name: str, acquired_at: datetime | None) -> str:
-    """Resolve the recency color for an infra lease from its own cadence."""
-    try:
-        cadence = _cadence_for_loop(name)
-    except Exception:  # noqa: BLE001 — an unresolvable cadence degrades to the red recency color
-        return _ANSI_RED
-    seconds_until = _seconds_until(acquired_at + timedelta(seconds=cadence)) if acquired_at is not None else None
-    return _loop_recency_color(seconds_until, cadence)
-
-
-def _seconds_until(next_fire_at: datetime) -> float:
-    """Return seconds from now until *next_fire_at* (negative once overdue)."""
-    from django.utils import timezone  # noqa: PLC0415 — deferred: Django import at call time
-
-    return (next_fire_at - timezone.now()).total_seconds()
+    context = LeaseRenderContext(
+        drivers=_live_lease_drivers(),
+        owned_per_loop=current_session_owned_per_loop_slots(),
+        overridden=_overridden_loops() if handle_present else None,
+        cadence_of=_cadence_for_loop,
+    )
+    return lease_chunks(leases, context, colorize=colorize)
 
 
 def live_loops_anchor(*, colorize: bool = False) -> list[str]:
@@ -468,14 +412,21 @@ def live_loops_anchor(*, colorize: bool = False) -> list[str]:
     :func:`teatree.loop.tick.run_tick`) pass the ``NO_COLOR``-resolved value.
     The availability and waiting segments stay the line's baseline dim.
 
-    Returns ``[]`` when neither an infra lease nor an enabled mini-loop is
-    active — silences the line entirely on a quiet machine. Fails open: any
-    DB / import error degrades to ``[]`` (or, for an individual segment,
-    drops just that segment) so a broken read can never blank the statusline.
+    Returns ``[]`` when no infra lease, no enabled mini-loop, and no governing
+    preset/schedule handle is active — silences the line entirely on a quiet
+    machine. When the routine per-loop leases are all folded into the preset
+    handle (#3248) but that handle is present, the line still renders the handle
+    (it represents the folded loops). Fails open: any DB / import error degrades
+    to ``[]`` (or, for an individual segment, drops just that segment) so a
+    broken read can never blank the statusline.
     """
-    leases = _live_lease_chunks(colorize=colorize)
+    # Resolve the preset/schedule handle first: it both leads the collapse
+    # decision (a routine per-loop lease is only folded when a handle is present
+    # to represent it) and keeps the line alive when every lease has folded away.
+    preset = _preset_segment()
+    leases = _live_lease_chunks(colorize=colorize, handle_present=bool(preset))
     due = _mini_loop_chunks(colorize=colorize)
-    if not leases and not due:
+    if not leases and not due and not preset:
         return []
 
     # Due-soon mini-loops ride a single ``due:`` section (#3248) rather than the
@@ -483,7 +434,6 @@ def live_loops_anchor(*, colorize: bool = False) -> list[str]:
     parts = [*leases]
     if due:
         parts.append("due: " + " ".join(due))
-    preset = _preset_segment()
     if preset:
         parts.append(preset)
     availability = _availability_segment()
@@ -538,95 +488,20 @@ def _waiting_count() -> int:
     return len(gather_waiting(""))
 
 
-def _short_loop_name(name: str) -> str:
-    """Strip the ``loop-`` prefix so ``loop-my-prs`` reads as ``my-prs``."""
-    return name.removeprefix("loop-")
-
-
-def _loop_chunk(name: str, acquired_at: datetime | None) -> str:
-    """Render one ``<short-name> <next-tick>`` chunk for a live loop."""
-    tick = _next_tick_minutes(name, acquired_at)
-    suffix = f" {tick}" if tick else ""
-    return f"{_short_loop_name(name)}{suffix}"
-
-
-def _next_tick_minutes(name: str, acquired_at: datetime | None) -> str:
-    """Return *name*'s relative next-tick as whole minutes (``11m`` / ``due``).
-
-    Empty string when nothing useful is queryable (no acquire timestamp, no
-    resolvable cadence) — the caller then renders a name-only chunk rather
-    than invent a duration. Fails open on every config read.
-    """
-    if acquired_at is None:
-        return ""
-    try:
-        cadence = _cadence_for_loop(name)
-    except Exception:  # noqa: BLE001 — rendering is best-effort; a failure degrades to empty
-        return ""
-    return _relative_minutes(acquired_at + timedelta(seconds=cadence))
-
-
-def _relative_minutes(next_fire_at: datetime) -> str:
-    """Return the relative whole-minute countdown to *next_fire_at* (``11m`` / ``due``).
-
-    ``due`` once the instant is in the past — the loop fires on the
-    orchestrator's next tick. Always derived from the live clock at render
-    time so the value counts down across successive renders rather than
-    freezing on a cached string.
-    """
-    from django.utils import timezone  # noqa: PLC0415 — deferred: Django import at call time
-
-    delta_seconds = int((next_fire_at - timezone.now()).total_seconds())
-    if delta_seconds <= 0:
-        return "due"
-    minutes = max(1, round(delta_seconds / _SECONDS_PER_MINUTE))
-    return f"{minutes}m"
-
-
-def _mini_loop_chunk(name: str, next_fire_at: datetime | None) -> str:
-    """Render one ``<name> <next-tick>`` chunk for an enabled mini-loop.
-
-    ``due`` when the loop has never fired (no marker → ``next_fire_at`` is
-    ``None``) or is already overdue; otherwise the relative whole-minute
-    countdown derived live from ``next_fire_at``.
-    """
-    tick = "due" if next_fire_at is None else _relative_minutes(next_fire_at)
-    return f"{name} {tick}"
-
-
-# Only loops due now (never-fired / overdue) or within this horizon appear on
-# the loop line (#3248) — the ``due:`` section replaces the full ~25-loop dump;
-# presets/schedules are the handle, so the line shows only what is imminent.
-_DUE_SOON_SECONDS = 300
-
-
 def _mini_loop_chunks(*, colorize: bool = False) -> list[str]:
     """Return a ``<name> <next-tick>`` chunk per DUE-SOON domain mini-loop (#3248).
 
-    Companion to :func:`_live_lease_chunks`: where that renders the infra
-    leases (``loop-tick`` and friends), this renders the enabled domain crons
-    from the cadence ledger (:func:`_mini_loop_schedules`) that are due now
-    (never fired / overdue) or within :data:`_DUE_SOON_SECONDS` — NOT the full
-    loop list (presets/schedules are the handle). Each carries its own
-    next-tick countdown and (when *colorize* is set) its cadence-relative
-    recency color. Composed into the ``due:`` section of :func:`live_loops_anchor`.
-
-    Returns ``[]`` when no mini-loop is due soon, or fails open to ``[]`` on any
-    DB / config read error so a broken ledger never blanks the line.
+    The DB-read seam of the ``due:`` section: reads the cadence ledger
+    (:func:`_mini_loop_schedules`) then hands the schedules to
+    :func:`teatree.loop.statusline_loop_chunks.mini_loop_chunks` for the due-soon
+    filter + formatting. Fails open to ``[]`` on any DB / config read error so a
+    broken ledger never blanks the line.
     """
     try:
         schedules = _mini_loop_schedules()
     except Exception:  # noqa: BLE001 — rendering is best-effort; a failure degrades to no chunks
         return []
-    return [
-        _colorize_chunk(
-            _mini_loop_chunk(name, next_fire_at),
-            _loop_recency_color(None if next_fire_at is None else _seconds_until(next_fire_at), cadence),
-            colorize=colorize,
-        )
-        for name, next_fire_at, cadence in schedules
-        if next_fire_at is None or _seconds_until(next_fire_at) <= _DUE_SOON_SECONDS
-    ]
+    return mini_loop_chunks(schedules, colorize=colorize)
 
 
 def mini_loops_anchor() -> list[str]:

--- a/src/teatree/loops/preset_status.py
+++ b/src/teatree/loops/preset_status.py
@@ -132,6 +132,19 @@ def manual_override_chunk(now: dt.datetime | None = None) -> str:
     return "ovr: " + " ".join(f"{name}{'+' if on else '-'}" for name, on in entries)
 
 
+def overridden_loop_names(now: dt.datetime | None = None) -> set[str]:
+    """The bare names of every loop manually overridden away from the preset/base verdict (#3248).
+
+    The statusline per-loop-lease collapse
+    (:func:`teatree.loop.statusline_loops.live_loops_anchor`) keeps a
+    ``loop:<name>`` chunk only for a manually-overridden loop; this is the
+    injected selector it reads. Sharing :func:`manual_override_entries`'
+    divergence logic keeps the surfaced lease chunks and the ``ovr:`` segment
+    from ever disagreeing about which loops diverge from the handle.
+    """
+    return {name for name, _ in manual_override_entries(now)}
+
+
 def preset_line_chunk(now: dt.datetime | None = None) -> str:
     """The composed schedule/preset/override statusline segment (#3248), or ``""`` when nothing governs.
 
@@ -170,6 +183,7 @@ __all__ = [
     "effective_verdicts",
     "manual_override_chunk",
     "manual_override_entries",
+    "overridden_loop_names",
     "preset_line_chunk",
     "schedule_chunk",
     "statusline_chunk",

--- a/tach.toml
+++ b/tach.toml
@@ -435,6 +435,7 @@ depends_on = [
   "teatree.loop.loop_scoping",
   "teatree.loop.statusline",
   "teatree.loop.statusline_loops",
+  "teatree.loop.statusline_loop_chunks",
   "teatree.loop.statusline_palette",
   "teatree.loop.statusline_render",
   "teatree.loop.url_specificity",
@@ -483,6 +484,11 @@ layer = "domain"
 depends_on = ["teatree.core.loop_lease_manager", "teatree.loop.session_identity"]
 
 [[modules]]
+path = "teatree.loop.statusline_loop_chunks"
+layer = "domain"
+depends_on = ["teatree.loop.loop_scoping", "teatree.loop.statusline_palette"]
+
+[[modules]]
 path = "teatree.loop.statusline_loops"
 layer = "domain"
 depends_on = [
@@ -490,6 +496,7 @@ depends_on = [
   "teatree.core",
   "teatree.loop.loop_cadences",
   "teatree.loop.loop_scoping",
+  "teatree.loop.statusline_loop_chunks",
   "teatree.loop.statusline_palette"
 ]
 

--- a/tests/quality/test_intra_loop_deferred_import_ratchet.py
+++ b/tests/quality/test_intra_loop_deferred_import_ratchet.py
@@ -285,9 +285,10 @@ class TestLoopStatuslineLoopsNode:
     filter — so ``statusline`` could not be a declared node (any eager edge into
     it would surface the cycle). PR-4 extracts the four pure ``os.environ``
     cadence readers into the ``teatree.loop.loop_cadences`` leaf; ``statusline_loops``
-    now reaches them, ``loop_scoping``, and the ``statusline_palette`` leaf via
-    eager DOWN edges, so the whole ``statusline`` facade is declarable and the
-    back-edge is structurally forbidden, not merely deferred out of sight.
+    now reaches them, ``loop_scoping``, the ``statusline_palette`` leaf, and the
+    ``statusline_loop_chunks`` chunk-formatter leaf via eager DOWN edges, so the whole
+    ``statusline`` facade is declarable and the back-edge is structurally forbidden,
+    not merely deferred out of sight.
     """
 
     def test_loop_cadences_is_a_pure_leaf_node(self) -> None:
@@ -312,12 +313,23 @@ class TestLoopStatuslineLoopsNode:
         # `loop_scoping` never reaches the orchestration-top parent.
         assert "teatree.loop" not in deps
 
+    def test_statusline_loop_chunks_is_a_leaf_over_scoping_and_palette(self) -> None:
+        # The pure chunk-formatter leaf (#3248): `statusline_loops` reaches it for the
+        # per-loop lease / mini-loop chunk rendering. It reaches only the two lower
+        # leaves it formats against and never the orchestration-top parent.
+        entry = _module_entry("teatree.loop.statusline_loop_chunks")
+        assert entry["layer"] == "domain"
+        deps = set(_depends_on("teatree.loop.statusline_loop_chunks"))
+        assert deps == {"teatree.loop.loop_scoping", "teatree.loop.statusline_palette"}
+        assert "teatree.loop" not in deps
+
     def test_statusline_loops_depends_only_on_declared_leaves(self) -> None:
         entry = _module_entry("teatree.loop.statusline_loops")
         assert entry["layer"] == "domain"
         loop_deps = {d for d in _depends_on("teatree.loop.statusline_loops") if d.startswith("teatree.loop")}
         assert loop_deps == {
             "teatree.loop.statusline_palette",
+            "teatree.loop.statusline_loop_chunks",
             "teatree.loop.loop_cadences",
             "teatree.loop.loop_scoping",
         }
@@ -340,6 +352,7 @@ class TestLoopStatuslineLoopsNode:
             "teatree.loop.session_identity",
             "teatree.loop.loop_scoping",
             "teatree.loop.statusline_loops",
+            "teatree.loop.statusline_loop_chunks",
             "teatree.loop.statusline",
         ):
             assert child in deps, child

--- a/tests/teatree_loop/test_statusline_loop_recency_color.py
+++ b/tests/teatree_loop/test_statusline_loop_recency_color.py
@@ -16,7 +16,7 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 from teatree.loop.statusline import live_loops_anchor
-from teatree.loop.statusline_loops import _loop_recency_color
+from teatree.loop.statusline_loop_chunks import _loop_recency_color
 from teatree.loop.statusline_palette import _ANSI_GREEN, _ANSI_RED, _ANSI_YELLOW
 
 

--- a/tests/teatree_loop/test_statusline_next_tick.py
+++ b/tests/teatree_loop/test_statusline_next_tick.py
@@ -20,8 +20,8 @@ from unittest.mock import patch
 
 from teatree.loop.dispatch import DispatchAction
 from teatree.loop.rendering import zones_for
-from teatree.loop.statusline import live_loops_anchor, mini_loops_anchor, render
-from teatree.loop.statusline_loops import _mini_loop_chunk
+from teatree.loop.statusline import live_loops_anchor, mini_loops_anchor, render, set_overridden_loops_reader
+from teatree.loop.statusline_loop_chunks import _mini_loop_chunk
 from teatree.loop.statusline_render import _format_duration
 
 
@@ -215,6 +215,97 @@ class TestLoopLineComposesLeasesAndMiniLoops:
         ):
             lines = live_loops_anchor(colorize=False)
         assert lines == ["due: resource_pressure 1m"], lines
+
+
+class TestPerLoopLeaseCollapse:
+    """#3248: the ``loop_runner`` drives a ``loop:<name>`` lease for EVERY enabled loop.
+
+    Rendering one chunk per live lease listed the whole loop table — the spam the
+    owner complained about. Under the injected override selector the loop line
+    keeps a per-loop chunk ONLY for a manually-overridden or due-now loop; every
+    routine ``loop_runner``-driven loop is folded into the preset/schedule handle.
+    """
+
+    @staticmethod
+    def _render_with_overridden(overridden: set[str] | None, leases: list[tuple[str, datetime]]) -> str:
+        """Render the loop line for *leases* with *overridden* injected (``None`` = uninjected)."""
+        with (
+            patch("teatree.loop.statusline_loops._live_loop_leases", return_value=leases),
+            patch("teatree.loop.statusline_loops._live_lease_drivers", return_value={}),
+            patch("teatree.loop.statusline_loops.current_session_owned_per_loop_slots", return_value=None),
+            patch("teatree.loop.statusline_loops._cadence_for_loop", return_value=600),
+            patch("teatree.loop.statusline_loops._mini_loop_schedules", return_value=[]),
+            patch("teatree.loop.statusline_loops._availability_segment", return_value=""),
+            patch("teatree.loop.statusline_loops._waiting_clause", return_value=""),
+            patch("teatree.loop.statusline_loops._preset_segment", return_value="preset engaged · ovr: audit+"),
+        ):
+            set_overridden_loops_reader((lambda: overridden) if overridden is not None else None)
+            try:
+                lines = live_loops_anchor(colorize=False)
+            finally:
+                set_overridden_loops_reader(None)
+        assert lines, "expected a loop line"
+        return lines[0]
+
+    def test_n_leased_only_one_overridden_shows_preset_plus_the_override(self) -> None:
+        # Five loop_runner-driven per-loop leases; only ``audit`` is manually
+        # overridden. The routine four (acquired now, next fire +600s, well past
+        # the due-soon horizon) must be folded into the preset handle — NOT listed.
+        now = datetime.now(UTC)
+        leases = [
+            ("loop:audit", now),  # overridden -> surfaces
+            ("loop:dispatch", now),  # routine -> folded away
+            ("loop:tickets", now),  # routine -> folded away
+            ("loop:ship", now),  # routine -> folded away
+            ("loop:inbox", now),  # routine -> folded away
+        ]
+        line = self._render_with_overridden({"audit"}, leases)
+        # The preset handle represents the folded loops:
+        assert "preset engaged" in line, line
+        # The single manual override surfaces:
+        assert "loop:audit" in line, line
+        # The routine loop_runner-driven, non-overridden loops are folded away:
+        for folded in ("loop:dispatch", "loop:tickets", "loop:ship", "loop:inbox"):
+            assert folded not in line, f"{folded} must be folded into the handle: {line}"
+
+    def test_due_now_loop_still_surfaces_even_when_not_overridden(self) -> None:
+        # ``due-only`` spec: a loop about to fire surfaces regardless of override.
+        now = datetime.now(UTC)
+        leases = [
+            ("loop:housekeeping", now - timedelta(seconds=595)),  # next fire +5s -> due -> surfaces
+            ("loop:tickets", now),  # +600s -> folded away
+        ]
+        line = self._render_with_overridden(set(), leases)
+        assert "loop:housekeeping" in line, line
+        assert "loop:tickets" not in line, line
+
+    def test_no_overrides_no_due_collapses_to_handle_only(self) -> None:
+        # No override, nothing due: the per-loop list is empty and only the
+        # preset handle remains (no per-loop spam).
+        now = datetime.now(UTC)
+        leases = [("loop:dispatch", now), ("loop:tickets", now), ("loop:ship", now)]
+        line = self._render_with_overridden(set(), leases)
+        assert "loop:" not in line, line
+        assert "preset engaged" in line, line
+
+    def test_infra_leases_always_survive_the_collapse(self) -> None:
+        # Infra / master leases (``loop-tick`` -> ``tick``, ``reinstall``) are not
+        # ``loop:<name>`` owner slots and always surface, even with overrides active.
+        now = datetime.now(UTC)
+        leases = [("loop-tick", now), ("reinstall", now), ("loop:dispatch", now)]
+        line = self._render_with_overridden(set(), leases)
+        assert "tick" in line, line
+        assert "reinstall" in line, line
+        assert "loop:dispatch" not in line, line
+
+    def test_fails_open_to_full_list_when_selector_uninjected(self) -> None:
+        # No reader injected (``None``): the collapse never activates, so every
+        # per-loop lease surfaces — today's behavior, never a hidden loop.
+        now = datetime.now(UTC)
+        leases = [("loop:dispatch", now), ("loop:tickets", now)]
+        line = self._render_with_overridden(None, leases)
+        assert "loop:dispatch" in line, line
+        assert "loop:tickets" in line, line
 
 
 class TestMiniLoopChunk:


### PR DESCRIPTION
## Problem

The statusline loop line rendered **one chunk per live `LoopLease`**. On this
deployment the single `loop_runner` session drives a `loop:<name>` owner lease
for **every enabled loop**, so the line systematically listed the whole loop
table (~11 `loop:<name>·loop_runner` chunks) instead of routing observation
through the preset/schedule handle that #3159 + #3248 built. #3311 collapsed the
mini-loop `due:` section but left these per-loop **lease** chunks untouched — so
the "systematically all enabled loops" spam remained.

## Fix

`live_loops_anchor` now resolves the preset/schedule handle first and folds a
routine `loop:<name>` per-loop lease into it **unless** the loop is manually
overridden away from the handle (`layer == override`) or due to fire now
(within the same `_DUE_SOON_SECONDS` horizon the `due:` section uses). Infra /
master leases (`loop-tick`, `reinstall`, …) and the driver / `DRIVERLESS`
suffix logic are untouched.

The collapse is gated on **both** a governing handle being present **and** an
injected override selector (`overridden_loop_names`, wired in `loops_tick`
beside the preset-segment reader — tach-safe injection seam, mirrors
`set_preset_segment_reader`). So a loop is never hidden without the handle that
represents it, and any resolver error / uninjected context **fails open** to the
full list (mirrors `preset_status.py`).

## Before / after (rendered against the live DB, same instant)

**Before:**
```
reinstall 12m · loop:audit due·loop_runner · loop:dispatch 11m·loop_runner · loop:idle_stack_reaper 11m·loop_runner · loop:inbox 11m·loop_runner · loop:local_stack_queue 12m·loop_runner · loop:pane_reaper 8m·loop_runner · loop:resource_pressure 12m·loop_runner · loop:ship 8m·loop_runner · loop:tickets 7m·loop_runner · due: … · preset ⚠engaged (manual) · ovr: triage_assessor+ · availability: … · waiting=2
```

**After:**
```
loop:audit due·loop_runner · due: … · preset ⚠engaged (manual) · ovr: triage_assessor+ · availability: … · waiting=2
```

The 8 non-due, non-overridden per-loop leases fold into the
`preset ⚠engaged (manual) · ovr: triage_assessor+` handle; only the due-now
`loop:audit` survives.

## Tests

RED-first `TestPerLoopLeaseCollapse` at the `live_loops_anchor` level
(`tests/teatree_loop/test_statusline_next_tick.py`): N `loop_runner`-leased
loops with only 1 overridden → the line shows the preset handle + that 1
override (+ any due), **not** all N. Also covers due-now-surfaces,
no-override-collapses-to-handle-only, infra-leases-always-survive, and
uninjected-selector-fails-open-to-full-list. Verified RED before the source
change (4/5 fail), GREEN after.

Refs #3248 #3159.
