### PR TITLE
feat(deploy): self-contained baked image with runtime-clone update path (closes #3451)

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,186 @@
+# Publish the self-contained teatree headless deploy image to a registry (#3451).
+#
+# The image (deploy/Dockerfile) BAKES a pinned source@ref + the managed Python
+# interpreter + the locked editable install, so a box that PULLS a published tag
+# boots deterministically and offline — no on-box build, no cold github/PyPI/astral
+# fetch at first boot. The runtime clone stays the in-loop self-update path; this
+# workflow only produces the reproducible artifact to pull.
+#
+# REGISTRY IS CONFIGURABLE. The default is GitHub Container Registry (ghcr.io)
+# authenticated with the built-in GITHUB_TOKEN — the SAME pattern CI already uses
+# for the test image (.github/workflows/ci.yml build-image), so no owner-provisioned
+# secret is required for the default path. To publish to a DIFFERENT registry, set
+# the repo VARIABLES and SECRET documented in deploy/README.md § "Publishing the
+# self-contained image". Uses no third-party actions (only actions/checkout, GitHub-
+# owned and SHA-pinned) — mirrors the deploy workflow's no-third-party-actions stance.
+#
+# OWNER-INFRA NOTE: this workflow's PUSH step cannot be validated without the
+# target registry. On a fork PR or when registry credentials do not resolve it
+# runs in BUILD-ONLY mode (proves the image builds, pushes nothing).
+name: Publish teatree image
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (branch/tag/SHA) to bake and publish. Defaults to the triggering commit."
+        required: false
+        default: ""
+  push:
+    branches: [main]
+    # Rebuild only when something baked into the image changes. Source-only commits
+    # still self-update the runtime clone via origin fast-forward, so they need no
+    # fresh image; a box that wants the newer bake pulls the next tag this produces.
+    paths: &bake-paths
+      - deploy/Dockerfile
+      - deploy/entrypoint.sh
+      - deploy/claude-settings.template.json
+      - uv.lock
+      - pyproject.toml
+      - .github/workflows/publish-image.yml
+  # On a PR touching the baked inputs, BUILD-ONLY (never push) so the Dockerfile
+  # bake is validated in CI without needing the registry — the honest answer to
+  # "can the publish path be CI-validated?" for the build half.
+  pull_request:
+    paths: *bake-paths
+
+permissions:
+  contents: read
+  packages: write
+
+# One publish at a time; never cancel an in-flight push mid-layer.
+concurrency:
+  group: publish-image
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # A dispatch may target an arbitrary ref; default checkout is the
+          # triggering commit. The baked source@ref is pinned to this same commit.
+          ref: ${{ github.event.inputs.ref || github.sha }}
+
+      - name: Resolve image refs, tags, and push mode
+        id: meta
+        env:
+          # Optional overrides for a NON-ghcr registry (repo Settings > Variables).
+          REGISTRY_VAR: ${{ vars.TEATREE_IMAGE_REGISTRY }}
+          IMAGE_NAME_VAR: ${{ vars.TEATREE_IMAGE_NAME }}
+          # 'true' only for a fork PR (no push access to the registry).
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+          # A custom-registry token is optional; its presence flips login to the
+          # custom path. Empty for the default ghcr/GITHUB_TOKEN path.
+          REGISTRY_TOKEN: ${{ secrets.TEATREE_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+          REPO_LC="$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')"
+          REGISTRY="${REGISTRY_VAR:-ghcr.io}"
+          IMAGE_NAME="${IMAGE_NAME_VAR:-${REPO_LC}-headless}"
+          # The baked source@ref MUST be an ORIGIN-reachable commit — the Dockerfile
+          # clones origin and checks it out. On a pull_request `github.sha` is the
+          # ephemeral merge commit (not on origin), so bake the PR HEAD (its pushed
+          # branch tip) instead; on push/dispatch the checked-out HEAD is on origin.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            SOURCE_REF="${{ github.event.pull_request.head.sha }}"
+          else
+            SOURCE_REF="$(git rev-parse HEAD)"
+          fi
+          SHORT_SHA="$(git rev-parse --short "$SOURCE_REF")"
+          # Reproducible primary tag: keyed on the BAKED toolchain (Dockerfile +
+          # entrypoint + lockfile + project metadata) AND the source commit, so the
+          # same inputs always mint the same tag and different source never collides.
+          LOCK_KEY="${{ hashFiles('deploy/Dockerfile', 'deploy/entrypoint.sh', 'uv.lock', 'pyproject.toml') }}"
+          PRIMARY_TAG="${LOCK_KEY:0:16}-${SHORT_SHA}"
+          IMAGE="${REGISTRY}/${IMAGE_NAME}"
+          {
+            echo "image=${IMAGE}"
+            echo "primary=${IMAGE}:${PRIMARY_TAG}"
+            echo "sha_tag=${IMAGE}:sha-${SHORT_SHA}"
+            echo "latest=${IMAGE}:latest"
+            echo "registry=${REGISTRY}"
+            echo "source_ref=${SOURCE_REF}"
+          } >> "$GITHUB_OUTPUT"
+          # Decide push mode. A PR only ever validates the build (never publishes);
+          # fork PRs never have registry write; a custom registry needs its token
+          # secret present; the default ghcr path uses GITHUB_TOKEN.
+          MODE=registry
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            MODE=local
+          elif [ "${IS_FORK:-}" = "true" ]; then
+            MODE=local
+          elif [ "$REGISTRY" != "ghcr.io" ] && [ -z "${REGISTRY_TOKEN:-}" ]; then
+            echo "publish: registry '$REGISTRY' is non-ghcr but TEATREE_REGISTRY_TOKEN is unset - building WITHOUT pushing. Set the secret (see deploy/README.md) to publish." >&2
+            MODE=local
+          fi
+          echo "mode=${MODE}" >> "$GITHUB_OUTPUT"
+          echo "publish: image=${IMAGE} primary_tag=${PRIMARY_TAG} mode=${MODE}"
+
+      - name: Log in to the registry
+        if: steps.meta.outputs.mode == 'registry'
+        env:
+          REGISTRY: ${{ steps.meta.outputs.registry }}
+          # ghcr default: the built-in token (no owner secret). Custom registry:
+          # the operator-provisioned user + token.
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REGISTRY_USER: ${{ secrets.TEATREE_REGISTRY_USER }}
+          REGISTRY_TOKEN: ${{ secrets.TEATREE_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ "$REGISTRY" = "ghcr.io" ]; then
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          else
+            echo "$REGISTRY_TOKEN" | docker login "$REGISTRY" -u "${REGISTRY_USER:?TEATREE_REGISTRY_USER must be set for a custom registry}" --password-stdin
+          fi
+
+      - name: Build the self-contained image
+        env:
+          PRIMARY: ${{ steps.meta.outputs.primary }}
+          SHA_TAG: ${{ steps.meta.outputs.sha_tag }}
+          SOURCE_REF: ${{ steps.meta.outputs.source_ref }}
+          MODE: ${{ steps.meta.outputs.mode }}
+        run: |
+          set -euo pipefail
+          # An already-published primary tag is reproducible — skip the rebuild.
+          if [ "$MODE" = registry ] && docker manifest inspect "$PRIMARY" >/dev/null 2>&1; then
+            echo "publish: $PRIMARY already exists - skipping build (baked inputs unchanged)."
+            echo "SKIP_BUILD=1" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          # Bake the resolved origin-reachable commit as source@ref so the image and
+          # its tag pin together. Building requires network (as the apt/node/uv layers
+          # do); the RUNTIME is what becomes deterministic and offline-capable.
+          docker build \
+            -f deploy/Dockerfile \
+            --build-arg "TEATREE_SOURCE_REF=${SOURCE_REF}" \
+            -t "$PRIMARY" \
+            -t "$SHA_TAG" \
+            .
+
+      - name: Push the image (registry mode only)
+        if: steps.meta.outputs.mode == 'registry' && env.SKIP_BUILD != '1'
+        env:
+          IMAGE: ${{ steps.meta.outputs.image }}
+          PRIMARY: ${{ steps.meta.outputs.primary }}
+          SHA_TAG: ${{ steps.meta.outputs.sha_tag }}
+          LATEST: ${{ steps.meta.outputs.latest }}
+        run: |
+          set -euo pipefail
+          docker push "$PRIMARY"
+          docker push "$SHA_TAG"
+          # `latest` tracks main's tip so a box's `.env` can pin TEATREE_IMAGE to a
+          # fixed primary tag (reproducible) or float on latest (auto-newest bake).
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            docker tag "$PRIMARY" "$LATEST"
+            docker push "$LATEST"
+          fi
+          echo "publish: pushed $PRIMARY (+ sha tag$( [ "${{ github.ref }}" = "refs/heads/main" ] && echo ' + latest'))"
+
+      - name: Build-only summary (no registry push)
+        if: steps.meta.outputs.mode == 'local'
+        run: |
+          echo "publish: BUILD-ONLY (fork PR or unresolved custom-registry creds) - the image built but was not pushed." >&2
+          echo "publish: set the registry vars/secret per deploy/README.md to publish." >&2

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,7 +1,11 @@
-# teatree headless deployment image — one image, three roles (init/worker/admin)
-# selected by $TEATREE_ROLE. Extends the dev/Dockerfile.test toolchain and adds
-# gh. The teatree source is NOT baked: it is cloned onto a volume at runtime and
-# installed editable by the init role, so the image is just the toolchain.
+# teatree headless deployment image — one image, five roles (init/worker/admin/
+# slack-listener/watchdog) selected by $TEATREE_ROLE. Extends the
+# dev/Dockerfile.test toolchain and adds gh. The image is SELF-CONTAINED (#3451):
+# it BAKES a pinned source@ref + the managed Python interpreter + the locked
+# editable install (see the bake stage near the end), so a fresh box with only
+# the image + secrets boots deterministically and offline. The runtime clone on
+# the teatree_src volume stays the self-update path — the entrypoint fast-forwards
+# it from origin when online and runs the baked snapshot when offline.
 #
 # Digest-pinned to the same ubuntu:24.04 manifest dev/Dockerfile.test pins, so a
 # retag of the floating tag can never silently change the deploy toolchain.
@@ -123,3 +127,31 @@ ENV PATH="/opt/teatree/uv/bin:/home/teatree/.local/bin:${PATH}" \
     GNUPGHOME=/home/teatree/.gnupg
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+# ============================================================
+# Bake the product — source@ref + interpreter + LOCKED editable install (#3451).
+# Kept as the FINAL build stage (after the ENTRYPOINT metadata declaration,
+# which has no build-time effect): the source-ref-pinned bake is the most
+# volatile layer, so putting it last maximizes cache reuse of the stable
+# toolchain/ENV/ENTRYPOINT layers above.
+# Mirrors dev/Dockerfile.test:19-34 (bake the managed Python + `uv` locked deps so
+# nothing is cold-resolved from PyPI/astral at runtime), extended to also bake the
+# pinned SOURCE and the editable `t3` tool. Both bake targets sit UNDER the two
+# named volumes (teatree_src -> $TEATREE_CLONE_DIR, teatree_uv -> /opt/teatree/uv):
+# Docker seeds a FRESH volume from the image content at the mount path, so a fresh
+# box inherits the baked clone + Python + tool and boots offline with zero fetches.
+# An already-provisioned box keeps its populated volumes (the bake is shadowed) and
+# self-updates via the entrypoint's origin fast-forward — the runtime clone remains
+# the in-loop `t3 update` path (epic #3445), so this bake changes only FRESH-box boot.
+#
+# TEATREE_SOURCE_REF pins the baked commit (default `main`; the publish workflow
+# passes the exact build SHA so the image and its lockfile-keyed tag can never
+# drift). The clone keeps its full `.git` so the runtime fast-forward and `t3
+# update` work. Building requires network (as the apt/node/uv layers already do) —
+# it is the RUNTIME that becomes deterministic and offline-capable.
+ARG TEATREE_SOURCE_REF=main
+RUN git clone "$TEATREE_REPO_URL" "$TEATREE_CLONE_DIR" && \
+    git -C "$TEATREE_CLONE_DIR" checkout --quiet "$TEATREE_SOURCE_REF" && \
+    uv python install 3.13 && \
+    uv tool install --editable "${TEATREE_CLONE_DIR}[slack]" --python 3.13 && \
+    uv tool install prek==0.3.13

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -3,7 +3,10 @@
 Run teatree headless on a single existing Hetzner ARM64 box (CAX21, 8 GB), driven
 by one manual GitHub Action. teatree runs the autonomous loop (`t3 worker`,
 `agent_runtime=headless`), self-updates via its own loop, autostarts on reboot,
-and serves the Django admin on the box loopback for SSH-tunnel access.
+and serves the Django admin on the box loopback for SSH-tunnel access. The image
+is **self-contained** — it bakes a pinned source@ref + interpreter + locked deps
+so a fresh box boots deterministically and offline; see
+[Self-contained image](#self-contained-image--bake--publish-3451).
 
 This is **teatree-only** — no customer or product overlays. The only registered
 overlay is the built-in `t3-teatree`.
@@ -119,6 +122,84 @@ TEATREE_UID="$(id -u)" docker compose -f deploy/docker-compose.yml build
 Changing the container UID on a box that already has bind-mount data written under
 the old UID requires a one-time `chown` of the bind sources to the new UID (stack
 stopped), otherwise the pre-existing files stay unwritable.
+
+## Self-contained image — bake + publish (#3451)
+
+The image is **self-contained**: `deploy/Dockerfile` bakes a pinned source@ref +
+the managed Python 3.13 interpreter + the locked editable `t3` install (the same
+`uv sync --locked` reproducibility pattern as `dev/Dockerfile.test`, extended to
+also bake the source and the tool). So a fresh box with only the image + secrets
+boots deterministically and **offline** — first boot no longer clones the repo or
+cold-resolves the dependency graph from github/PyPI/astral.
+
+**How the two named volumes inherit the bake.** Docker seeds a *fresh* named
+volume from the image content at the mount path, so on a brand-new box the empty
+`teatree_src` → `~/teatree` and `teatree_uv` → `/opt/teatree/uv`
+volumes are seeded with the baked clone, interpreter, and tool. An
+already-provisioned box keeps its populated volumes (the bake is shadowed) and
+converges via the runtime clone's origin fast-forward — so the bake changes only
+**fresh-box** first boot; existing boxes are unaffected.
+
+**Boot mode — online vs. offline (`deploy/entrypoint.sh`).** The entrypoint picks
+its mode from a bare origin reachability probe (`network_up`):
+
+- **online** — fast-forward the runtime clone from origin and refresh the editable
+  install; `t3 update` remains the in-loop self-update path;
+- **offline** — run the baked snapshot as-is, with zero fetches. Set
+  `TEATREE_FORCE_OFFLINE=1` to force this pinned no-fetch boot deliberately.
+
+Note the GitHub **token preflight** (`assert_gh_token_permissions`) still contacts
+`api.github.com`, so a fully air-gapped box cannot pass init — the loop needs
+GitHub to function. The bake removes the *source + dependency* fetches (the
+github/PyPI/astral blips that made first boot non-deterministic), not the loop's
+own GitHub access.
+
+### Pulling a published image instead of building on the box
+
+`docker-compose.yml` resolves the image as `${TEATREE_IMAGE:-teatree-headless:latest}`.
+Leaving `TEATREE_IMAGE` unset builds locally from `deploy/Dockerfile` (the current
+on-box flow, unchanged). To PULL a published, self-contained tag, set
+`TEATREE_IMAGE` to the registry ref in a `.env` file next to `docker-compose.yml`
+(or in the deploy shell):
+
+```bash
+# deploy/.env  (compose-interpolation env, NOT the container env_file teatree.env)
+TEATREE_IMAGE=ghcr.io/<owner>/teatree-headless:<lockkey>-<shortsha>
+```
+
+`.env` adjacency keeps the value identical for the host deploy AND the
+path-identity-mounted watchdog, so both resolve the same image; the watchdog's
+`up -d --no-recreate` never recreates a running container on a value change anyway.
+
+### Publishing the self-contained image
+
+`.github/workflows/publish-image.yml` builds `deploy/Dockerfile` (pinning
+`--build-arg TEATREE_SOURCE_REF=<commit>` to the built commit) and pushes it. Tags:
+
+- `<lockkey>-<shortsha>` — reproducible primary tag, keyed on the baked toolchain
+  (`deploy/Dockerfile` + `deploy/entrypoint.sh` + `uv.lock` + `pyproject.toml`)
+  **and** the source commit;
+- `sha-<shortsha>` — the exact source commit;
+- `latest` — main's tip (float on it, or pin a primary tag for reproducibility).
+
+**Registry is configurable. The default needs no owner-provisioned secret:** it
+publishes to **ghcr.io** authenticated with the workflow's built-in `GITHUB_TOKEN`
+(the same pattern CI already uses for its test image) at
+`ghcr.io/<owner>/teatree-headless`. To publish elsewhere, the owner sets:
+
+| Kind | Name | Purpose | Needed when |
+| --- | --- | --- | --- |
+| Variable | `TEATREE_IMAGE_REGISTRY` | registry host (default `ghcr.io`) | non-ghcr registry |
+| Variable | `TEATREE_IMAGE_NAME` | image path (default `<owner>/teatree-headless`) | custom image name |
+| Secret | `TEATREE_REGISTRY_USER` | registry login user | non-ghcr registry |
+| Secret | `TEATREE_REGISTRY_TOKEN` | registry login token/password | non-ghcr registry |
+
+On a fork PR, or a custom registry with no `TEATREE_REGISTRY_TOKEN`, the workflow
+runs **build-only** (proves the image builds, pushes nothing). For the default
+ghcr path the repo/org must allow the package (GHCR is enabled by default on
+GitHub-hosted repos); a first publish creates the package, which the owner can
+then make public or keep private (a private package still pulls on the box with a
+`packages: read` token).
 
 ### One-time volume migration (operator step)
 
@@ -344,8 +425,11 @@ the deploy workflow never rewrites the on-disk secret file for it.
 - **Autostart on reboot:** the compose `restart: unless-stopped` policy plus Docker
   enabled on boot bring the worker and admin back after a reboot.
 - **Updates:** teatree self-updates in-loop via `t3 update` (deferred reinstall on
-  the editable clone). There is **no** second workflow and no quiescence probe — a
-  re-run of the deploy workflow is only needed for infra/compose/image changes.
+  the editable clone), and the entrypoint fast-forwards the runtime clone from
+  origin on every (online) boot — the baked snapshot is only the *first-boot* /
+  offline floor, never a replacement for in-loop self-update. There is **no**
+  second workflow and no quiescence probe — a re-run of the deploy workflow is only
+  needed for infra/compose/image changes.
 
 ## Running the `t3` CLI on the box (#3232)
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -12,7 +12,14 @@
 name: teatree
 
 x-teatree-common: &teatree-common
-  image: teatree-headless:latest
+  # Pull a PUBLISHED self-contained image by setting TEATREE_IMAGE (the publish
+  # workflow's lockfile-keyed tag, #3451) in a `.env` next to this file or in the
+  # deploy shell; leaving it unset builds locally from deploy/Dockerfile (the
+  # current on-box flow, unchanged). `.env` adjacency keeps the value identical
+  # for the host deploy AND the path-identity-mounted watchdog, so both resolve
+  # the same image; the watchdog's `up -d --no-recreate` never recreates a running
+  # container on a value change regardless.
+  image: ${TEATREE_IMAGE:-teatree-headless:latest}
   build:
     context: ..
     dockerfile: deploy/Dockerfile
@@ -22,6 +29,9 @@ x-teatree-common: &teatree-common
     # own ARG default (1001) for a bare `compose build` with no deploy.sh.
     args:
       TEATREE_UID: ${TEATREE_UID:-1001}
+      # Pin the baked source@ref (#3451). Defaults to `main`; the publish workflow
+      # passes the exact build SHA so the image and its lockfile-keyed tag pin together.
+      TEATREE_SOURCE_REF: ${TEATREE_SOURCE_REF:-main}
   env_file:
     - teatree.env
   # All services mount all state so admin and worker share ONE db.sqlite3
@@ -156,7 +166,7 @@ services:
   # and a depends_on on init — all of which the watchdog must NOT have. It needs
   # only the docker socket + a read-only view of this checkout.
   teatree-watchdog:
-    image: teatree-headless:latest
+    image: ${TEATREE_IMAGE:-teatree-headless:latest}
     build:
       context: ..
       dockerfile: deploy/Dockerfile
@@ -164,6 +174,7 @@ services:
       # deploy/README.md § UID invariant); default 1001 tracks the ARG default.
       args:
         TEATREE_UID: ${TEATREE_UID:-1001}
+        TEATREE_SOURCE_REF: ${TEATREE_SOURCE_REF:-main}
     environment:
       TEATREE_ROLE: watchdog
       TEATREE_WATCHDOG_INTERVAL: "300"

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -382,9 +382,38 @@ apply_fleet_loop_policy() {
     done
 }
 
+# True (0) when the box has working outbound connectivity to the git origin.
+# It is the switch between the two boot modes the self-contained image supports
+# (#3451): ONLINE fast-forwards the runtime clone from origin (self-update stays
+# the in-loop `t3 update` path); OFFLINE runs the image's BAKED snapshot as-is,
+# so a fresh box with only the image + secrets boots deterministically with zero
+# fetches. `init_preflight` validates gh auth BEFORE this runs, so a non-zero
+# `ls-remote` here is a genuine network fault, not a bad token (a bare
+# reachability probe — no auth needed just to decide online/offline, and the
+# public repo answers anonymously). `TEATREE_FORCE_OFFLINE=1|true|yes` forces the
+# baked path for an operator who wants a pinned no-fetch boot, and is the seam the
+# entrypoint smoke test drives to exercise both branches without real network.
+network_up() {
+    case "${TEATREE_FORCE_OFFLINE:-}" in
+        1 | true | yes) return 1 ;;
+    esac
+    git ls-remote --quiet --exit-code "$REPO_URL" HEAD >/dev/null 2>&1
+}
+
 ensure_clone() {
     if [ -e "$CLONE_DIR/.git" ]; then
-        # The clone lives in a shared volume that outlives the image, so a
+        if ! network_up; then
+            # OFFLINE: run the baked snapshot as-is. The runtime clone was seeded
+            # from the image's baked source (fresh box) or is a prior online
+            # boot's clone, so the stack runs with zero fetches; the origin
+            # fast-forward self-update below (and in-loop `t3 update`) resumes on
+            # the next boot with connectivity.
+            local baked_sha
+            baked_sha="$(git -C "$CLONE_DIR" rev-parse --short HEAD 2>/dev/null || echo '?')"
+            echo "entrypoint: network unreachable - running the BAKED snapshot at $baked_sha (skipping origin fast-forward; self-update resumes when the network returns)" >&2
+            return 0
+        fi
+        # ONLINE. The clone lives in a shared volume that outlives the image, so a
         # redeploy must bring it current or the stack keeps serving the code
         # from the first boot. SELF-HEAL: a stray feature branch checked out on
         # the runtime clone (or one whose upstream was deleted after its PR
@@ -405,6 +434,14 @@ ensure_clone() {
             exit 1
         }
         return 0
+    fi
+    # No runtime clone: an image built WITHOUT the #3451 bake stage (or an empty
+    # teatree_src volume the baked source never seeded). Bootstrapping the source
+    # from scratch needs the network; the published image bakes a clone here so a
+    # fresh box never reaches this branch.
+    if ! network_up; then
+        echo "entrypoint: no runtime clone at $CLONE_DIR and the network is unreachable - cannot bootstrap the source offline (the published image bakes a clone here so a fresh box needs no first-boot fetch). Restore connectivity and re-run Deploy" >&2
+        exit 1
     fi
     git clone "$REPO_URL" "$CLONE_DIR"
 }
@@ -450,18 +487,35 @@ case "$ROLE" in
 init)
     init_preflight
     ensure_clone
-    uv python install 3.13
-    # The [slack] extra pulls slack_sdk so the slack-listener role's Socket-Mode
-    # receiver can open its WebSocket. Without it `t3 slack listen` degrades to a
-    # no-op ("slack_sdk not installed") and inbound Slack never reaches the loop.
-    uv tool install --editable "$CLONE_DIR[slack]" --reinstall --python 3.13
-    # prek (the pre-commit reimplementation) is a DEV-group dependency, so the
-    # editable tool install above does NOT provide it. Worktree provisioning
-    # (`prek_hook.install`) and the base-clone commit/push gates need `prek` on
-    # PATH; install it as a standalone uv tool (pinned to the lockfile) into the
-    # shared teatree_uv volume so every role sees it. Runtime (not Dockerfile):
-    # /opt/teatree/uv is a named volume that shadows any image-baked install.
-    uv tool install prek==0.3.13
+    # Resolve the interpreter + editable install + prek. The self-contained image
+    # (#3451) BAKES all three (and seeds them onto the teatree_uv volume on a fresh
+    # box), so this is a fast no-op refresh when online and is skipped entirely when
+    # offline — first boot never cold-resolves the dependency graph from PyPI/astral.
+    if network_up; then
+        uv python install 3.13
+        # The [slack] extra pulls slack_sdk so the slack-listener role's Socket-Mode
+        # receiver can open its WebSocket. Without it `t3 slack listen` degrades to a
+        # no-op ("slack_sdk not installed") and inbound Slack never reaches the loop.
+        uv tool install --editable "${CLONE_DIR}[slack]" --reinstall --python 3.13
+        # prek (the pre-commit reimplementation) is a DEV-group dependency, so the
+        # editable tool install above does NOT provide it. Worktree provisioning
+        # (`prek_hook.install`) and the base-clone commit/push gates need `prek` on
+        # PATH; install it as a standalone uv tool (pinned to the lockfile) into the
+        # shared teatree_uv volume so every role sees it. Runtime (not Dockerfile):
+        # /opt/teatree/uv is a named volume that shadows any image-baked install.
+        uv tool install prek==0.3.13
+    else
+        # OFFLINE: the interpreter, editable install, and prek are baked into the
+        # image, so init proceeds with no cold fetch. Fail loud only if the image
+        # was built WITHOUT the bake stage (no baked t3/prek to fall back on).
+        echo "entrypoint: offline - using the baked interpreter + editable install + prek from the image (skipping the cold uv sync)" >&2
+        for baked_tool in t3 prek; do
+            command -v "$baked_tool" >/dev/null 2>&1 || {
+                echo "entrypoint: offline and no baked '$baked_tool' on PATH - this image was built without the #3451 bake stage, so it cannot bootstrap offline. Restore connectivity and re-run Deploy" >&2
+                exit 1
+            }
+        done
+    fi
     # Install the commit/push gate hooks on the base clone's SHARED hooks dir
     # (git links every worktree to it), so the privacy leak gate (#685), the
     # foreign-MR guard, banned-terms, and the push gates actually fire on the

--- a/tests/test_deploy_entrypoint_baked_snapshot.py
+++ b/tests/test_deploy_entrypoint_baked_snapshot.py
@@ -1,0 +1,162 @@
+# test-path: cross-cutting — drives deploy/entrypoint.sh clone/offline branch (no src mirror).
+"""Integration tests for the deploy entrypoint's baked-snapshot boot logic (#3451).
+
+The self-contained image bakes a pinned source clone into the ``teatree_src``
+volume, so ``deploy/entrypoint.sh`` must choose its boot mode at runtime:
+
+* **online** — fast-forward the runtime clone from origin (self-update stays in-loop);
+* **offline** — run the BAKED snapshot as-is, with zero fetches (deterministic boot).
+
+``network_up`` is the switch (``TEATREE_FORCE_OFFLINE`` forces the baked path);
+``ensure_clone`` branches on it. Per the Test-Writing Doctrine these run the REAL
+shell functions (extracted verbatim from the entrypoint) in a bash subprocess
+against a REAL local git origin under ``tmp_path`` — nothing about the shell logic
+is reimplemented, and no network is touched. This mirrors the sibling
+entrypoint tests (``test_deploy_entrypoint_disable_loops.py``,
+``test_deploy_entrypoint_token_preflight.py``).
+"""
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("git") is None,
+    reason="needs bash + git (both present in the deploy image and CI)",
+)
+
+ENTRYPOINT = Path(__file__).resolve().parents[1] / "deploy" / "entrypoint.sh"
+_BASH = shutil.which("bash") or "bash"
+_GIT = shutil.which("git") or "git"
+
+# A deterministic identity for the fixture commits — never the operator's.
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "t",
+    "GIT_AUTHOR_EMAIL": "t@example.invalid",  # privacy-scan:allow
+    "GIT_COMMITTER_NAME": "t",
+    "GIT_COMMITTER_EMAIL": "t@example.invalid",  # privacy-scan:allow
+}
+
+
+def _extract_shell_function(name: str) -> str:
+    """Return the verbatim source of shell function *name* from the entrypoint."""
+    body: list[str] = []
+    capturing = False
+    for line in ENTRYPOINT.read_text(encoding="utf-8").splitlines():
+        if line.startswith(f"{name}() {{"):
+            capturing = True
+        if capturing:
+            body.append(line)
+            if line == "}":
+                return "\n".join(body)
+    not_found = f"function {name!r} not found in {ENTRYPOINT}"
+    raise AssertionError(not_found)
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        [_GIT, "-C", str(cwd), *args],
+        check=True,
+        env={**_GIT_ENV, "HOME": str(cwd)},
+        capture_output=True,
+        text=True,
+    )
+
+
+def _head(cwd: Path) -> str:
+    return subprocess.run(
+        [_GIT, "-C", str(cwd), "rev-parse", "HEAD"], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+@dataclass(frozen=True, slots=True)
+class _Origin:
+    """A local git origin plus a runtime clone deliberately left one commit behind."""
+
+    url: Path  # the bare origin (stands in for TEATREE_REPO_URL)
+    clone: Path  # the runtime clone (stands in for TEATREE_CLONE_DIR), at commit1
+    commit1: str  # the clone's baked HEAD
+    commit2: str  # origin's tip — where an online fast-forward lands
+
+
+def _make_origin_and_clone(tmp_path: Path) -> _Origin:
+    """A bare origin at commit2 and a clone pinned at commit1 (one behind)."""
+    origin = tmp_path / "origin.git"
+    subprocess.run([_GIT, "init", "--bare", "-b", "main", str(origin)], check=True, capture_output=True)
+
+    seed = tmp_path / "seed"
+    subprocess.run([_GIT, "clone", str(origin), str(seed)], check=True, capture_output=True)
+    (seed / "a.txt").write_text("one\n", encoding="utf-8")
+    _git(seed, "add", "a.txt")
+    _git(seed, "commit", "-m", "commit1")
+    _git(seed, "push", "origin", "main")
+
+    clone = tmp_path / "clone"
+    subprocess.run([_GIT, "clone", str(origin), str(clone)], check=True, capture_output=True)
+    commit1 = _head(clone)
+
+    # Advance origin so the clone is one fast-forwardable commit behind.
+    (seed / "b.txt").write_text("two\n", encoding="utf-8")
+    _git(seed, "add", "b.txt")
+    _git(seed, "commit", "-m", "commit2")
+    _git(seed, "push", "origin", "main")
+    commit2 = _head(seed)
+
+    return _Origin(url=origin, clone=clone, commit1=commit1, commit2=commit2)
+
+
+def _run_ensure_clone(
+    tmp_path: Path, *, clone_dir: Path, repo_url: Path, force_offline: bool
+) -> subprocess.CompletedProcess[str]:
+    """Run the extracted ``network_up`` + ``ensure_clone`` against a local origin."""
+    harness = tmp_path / "harness.sh"
+    harness.write_text(
+        "set -euo pipefail\n"
+        f'CLONE_DIR="{clone_dir}"\n'
+        f'REPO_URL="{repo_url}"\n'
+        f"{_extract_shell_function('network_up')}\n"
+        f"{_extract_shell_function('ensure_clone')}\n"
+        "ensure_clone\n",
+        encoding="utf-8",
+    )
+    env = {**_GIT_ENV, "HOME": str(tmp_path), "PATH": Path(_GIT).parent.as_posix() + ":/usr/bin:/bin"}
+    if force_offline:
+        env["TEATREE_FORCE_OFFLINE"] = "1"
+    return subprocess.run([_BASH, str(harness)], capture_output=True, text=True, check=False, env=env)
+
+
+class TestEnsureCloneOnline:
+    def test_existing_clone_fast_forwards_from_origin(self, tmp_path: Path) -> None:
+        origin = _make_origin_and_clone(tmp_path)
+        result = _run_ensure_clone(tmp_path, clone_dir=origin.clone, repo_url=origin.url, force_offline=False)
+        assert result.returncode == 0, result.stderr
+        # Online: the runtime clone advanced to origin's tip.
+        assert _head(origin.clone) == origin.commit2
+
+    def test_missing_clone_is_cloned_when_online(self, tmp_path: Path) -> None:
+        origin = _make_origin_and_clone(tmp_path)
+        fresh = tmp_path / "fresh"
+        result = _run_ensure_clone(tmp_path, clone_dir=fresh, repo_url=origin.url, force_offline=False)
+        assert result.returncode == 0, result.stderr
+        assert (fresh / ".git").exists()
+
+
+class TestEnsureCloneOffline:
+    def test_existing_clone_runs_baked_snapshot_without_fetching(self, tmp_path: Path) -> None:
+        origin = _make_origin_and_clone(tmp_path)
+        result = _run_ensure_clone(tmp_path, clone_dir=origin.clone, repo_url=origin.url, force_offline=True)
+        assert result.returncode == 0, result.stderr
+        # Offline: the clone stayed on its BAKED commit — no fast-forward happened.
+        assert _head(origin.clone) == origin.commit1
+        assert "BAKED snapshot" in result.stderr
+
+    def test_missing_clone_fails_loud_when_offline(self, tmp_path: Path) -> None:
+        origin = _make_origin_and_clone(tmp_path)
+        fresh = tmp_path / "fresh"
+        result = _run_ensure_clone(tmp_path, clone_dir=fresh, repo_url=origin.url, force_offline=True)
+        assert result.returncode != 0
+        assert not (fresh / ".git").exists()
+        assert "cannot bootstrap the source offline" in result.stderr

--- a/tests/test_deploy_slack_listener.py
+++ b/tests/test_deploy_slack_listener.py
@@ -34,7 +34,8 @@ class TestInitInstallsSlackExtra:
     def test_editable_install_pulls_the_slack_extra(self) -> None:
         # Without the [slack] extra slack_sdk is absent and the receiver logs
         # "slack_sdk not installed" then no-ops — inbound Slack never arrives.
-        assert '"$CLONE_DIR[slack]"' in ENTRYPOINT
+        # Braced form (`${CLONE_DIR}`) so the expansion is shellcheck-clean (SC1087).
+        assert '--editable "${CLONE_DIR}[slack]"' in ENTRYPOINT
 
 
 _BASH = shutil.which("bash") or "bash"


### PR DESCRIPTION
Re-lands the self-contained baked image (originally #3465) on top of current `main`, resolving the conflicts introduced by the three deploy PRs that merged since #3465 was cut (CRED #3463, FRESHBOX #3470). Closes #3451; supersedes #3465 (which should be closed as superseded).

## What this does

Bakes a pinned `source@ref` + the managed Python interpreter + the locked editable `t3` install into the deploy image, so a fresh box with only the image + secrets boots deterministically and offline. The runtime clone on the `teatree_src` volume stays the self-update path: the entrypoint fast-forwards it from origin when online and runs the baked snapshot when offline (`TEATREE_FORCE_OFFLINE=1` forces the pinned no-fetch boot). Adds a ghcr publish workflow (`.github/workflows/publish-image.yml`).

## Conflict resolution (both sides kept)

- **`deploy/Dockerfile`** — FRESHBOX's host-derived `TEATREE_UID` (default 1001) + digest-pinned base, combined with the IMAGE bake stage (`ARG TEATREE_SOURCE_REF`, `uv` locked editable install). The bake stage is placed as the final build layer (after the `ENTRYPOINT` metadata declaration, which has no build-time effect) so the most volatile layer sits last for cache reuse.
- **`deploy/entrypoint.sh`** — CRED's secrets-from-`pass` sourcing + IMAGE's `network_up`/offline-bake branch (both function sets present).
- **`deploy/docker-compose.yml`** — CRED env + FRESHBOX `${TEATREE_UID}` + IMAGE `${TEATREE_IMAGE}`/`${TEATREE_SOURCE_REF}` build-args, merged in both the common anchor and the watchdog block.
- **`deploy/README.md`** — kept both the UID-invariant section and the self-contained-image section.
- `.github/workflows/deploy-hetzner.yml` needed no change (the IMAGE publish is a separate workflow file; CRED's env-writer change on `main` is untouched).

## Gates

prek (all hooks), `ruff check`/`format`, deploy smoke tests (docker/compose parse, entrypoint baked-snapshot, freshbox, worker-sizing), `tests/quality` + `tests/conformance`, capabilities, and `t3 tool test-path-mirror` all pass locally. Full pre-push gate passed.
