### PR TITLE
feat(deploy): direct-SSH deploy path (no hcloud) for non-Hetzner-Cloud boxes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,13 @@
-# Teatree headless deploy to an existing Hetzner box.
+# Teatree headless deploy to an existing box over direct SSH.
 # Runs on every push to main (each merged PR) plus the manual trigger; the
 # deploy script is idempotent and the concurrency group serializes runs, so a
-# merge train converges the box to the newest main. No box-identifying info
-# lives here — the server name, SSH user/port, host key, and IP all come from
-# secrets, and the resolved IP is masked out of the logs. Uses no third-party
-# actions (nothing to SHA-pin); the hcloud CLI is installed from a
-# checksum-pinned release.
-name: Deploy teatree to Hetzner
+# merge train converges the box to the newest main. The box is reached by a
+# fixed host/IP held in a secret (DEPLOY_SSH_HOST) — no cloud API resolves it,
+# so this works for a plain HostKey / bare-metal / any-provider box, not just
+# Hetzner Cloud. No box-identifying info lives here — the host/IP, SSH
+# user/port, host key, and private key all come from secrets, and the host/IP
+# is masked out of the logs. Uses no third-party actions (nothing to SHA-pin).
+name: Deploy teatree
 
 on:
   workflow_dispatch:
@@ -18,7 +19,7 @@ permissions:
 
 # Serialize deploys to one box; never cancel an in-flight convergence mid-run.
 concurrency:
-  group: deploy-hetzner
+  group: deploy
   cancel-in-progress: false
 
 jobs:
@@ -28,18 +29,15 @@ jobs:
     steps:
       - name: Validate required secrets
         env:
-          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
-          HETZNER_SERVER_NAME: ${{ secrets.HETZNER_SERVER_NAME }}
-          HETZNER_SSH_KEY: ${{ secrets.HETZNER_SSH_KEY }}
-          HETZNER_SSH_KNOWN_HOSTS: ${{ secrets.HETZNER_SSH_KNOWN_HOSTS }}
-          HETZNER_SSH_USER: ${{ secrets.HETZNER_SSH_USER }}
-          HETZNER_SSH_PORT: ${{ secrets.HETZNER_SSH_PORT }}
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          T3_ADMIN_USER: ${{ secrets.T3_ADMIN_USER }}
-          GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
-          GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
+          DEPLOY_SSH_HOST: ${{ secrets.DEPLOY_SSH_HOST }}
+          DEPLOY_SSH_USER: ${{ secrets.DEPLOY_SSH_USER }}
+          DEPLOY_SSH_PORT: ${{ secrets.DEPLOY_SSH_PORT }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
         run: |
-          # Three credentials are deliberately NOT required workflow secrets — the
+          # The five DEPLOY_SSH_* secrets are the direct-SSH connection plane and
+          # are strictly required — the box is unreachable without every one.
+          # Other credentials are deliberately NOT required workflow secrets: the
           # box holds them in its gpg-encrypted `pass` store, sourced at boot:
           #   * CLAUDE_CODE_OAUTH_TOKEN — anthropic/<account>/oauth-token
           #     (anthropic_oauth_pass_paths routing).
@@ -50,9 +48,8 @@ jobs:
           # NEITHER source, so omitting the secret cannot silently deploy a dead
           # loop.
           missing=0
-          for name in HCLOUD_TOKEN HETZNER_SERVER_NAME HETZNER_SSH_KEY HETZNER_SSH_KNOWN_HOSTS \
-                      HETZNER_SSH_USER HETZNER_SSH_PORT \
-                      T3_ADMIN_USER GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL; do
+          for name in DEPLOY_SSH_HOST DEPLOY_SSH_USER DEPLOY_SSH_PORT \
+                      DEPLOY_SSH_KEY DEPLOY_SSH_KNOWN_HOSTS; do
             if [ -z "${!name}" ]; then
               echo "MISSING SECRET $name - set it under Settings > Secrets and re-run"
               missing=1
@@ -60,43 +57,29 @@ jobs:
           done
           [ "$missing" -eq 0 ] || exit 1
 
-      - name: Install hcloud CLI (checksum-pinned)
+      - name: Mask deploy host
         env:
-          HCLOUD_VERSION: v1.66.0
-          HCLOUD_SHA256: 8b1a8598858232c491f58cbf65ce1bd0ec6f725114bb62ec967a20ab03e29a86
+          DEPLOY_SSH_HOST: ${{ secrets.DEPLOY_SSH_HOST }}
         run: |
-          curl -fsSL -o hcloud.tar.gz \
-            "https://github.com/hetznercloud/cli/releases/download/${HCLOUD_VERSION}/hcloud-linux-amd64.tar.gz"
-          echo "${HCLOUD_SHA256}  hcloud.tar.gz" | sha256sum -c -
-          tar -xzf hcloud.tar.gz hcloud
-          sudo install -m 0755 hcloud /usr/local/bin/hcloud
-          rm -f hcloud.tar.gz hcloud
-
-      - name: Resolve box IP (masked)
-        env:
-          HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
-          HETZNER_SERVER_NAME: ${{ secrets.HETZNER_SERVER_NAME }}
-        run: |
-          IP="$(hcloud server ip "$HETZNER_SERVER_NAME")"
-          echo "::add-mask::$IP"
-          echo "SERVER_IP=$IP" >> "$GITHUB_ENV"
+          echo "::add-mask::$DEPLOY_SSH_HOST"
+          echo "SERVER_HOST=$DEPLOY_SSH_HOST" >> "$GITHUB_ENV"
 
       - name: Configure SSH
         env:
-          HETZNER_SSH_KEY: ${{ secrets.HETZNER_SSH_KEY }}
-          HETZNER_SSH_KNOWN_HOSTS: ${{ secrets.HETZNER_SSH_KNOWN_HOSTS }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
         run: |
           mkdir -p "$HOME/.ssh"
           umask 077
-          printf '%s\n' "$HETZNER_SSH_KEY" > "$HOME/.ssh/id_deploy"
+          printf '%s\n' "$DEPLOY_SSH_KEY" > "$HOME/.ssh/id_deploy"
           chmod 600 "$HOME/.ssh/id_deploy"
-          printf '%s\n' "$HETZNER_SSH_KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
+          printf '%s\n' "$DEPLOY_SSH_KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
           chmod 600 "$HOME/.ssh/known_hosts"
 
       - name: Write box secrets file and deploy
         env:
-          SSH_USER: ${{ secrets.HETZNER_SSH_USER }}
-          SSH_PORT: ${{ secrets.HETZNER_SSH_PORT }}
+          SSH_USER: ${{ secrets.DEPLOY_SSH_USER }}
+          SSH_PORT: ${{ secrets.DEPLOY_SSH_PORT }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           T3_ADMIN_USER: ${{ secrets.T3_ADMIN_USER }}
           GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
@@ -118,7 +101,7 @@ jobs:
           TEATREE_BOX_USE_PASS: ${{ vars.TEATREE_BOX_USE_PASS || 'false' }}
         run: |
           SSH="ssh -p ${SSH_PORT} -i ${HOME}/.ssh/id_deploy -o UserKnownHostsFile=${HOME}/.ssh/known_hosts -o StrictHostKeyChecking=yes -o ConnectTimeout=20"
-          TARGET="${SSH_USER}@${SERVER_IP}"
+          TARGET="${SSH_USER}@${SERVER_HOST}"
 
           # 1. Ensure the build-context checkout exists on the box.
           $SSH "$TARGET" 'set -e; REMOTE_DIR="$HOME/teatree-deploy"; if [ ! -d "$REMOTE_DIR/.git" ]; then git clone https://github.com/souliane/teatree.git "$REMOTE_DIR"; fi; mkdir -p "$REMOTE_DIR/deploy"'

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,7 +1,7 @@
-# teatree headless deployment (Hetzner)
+# teatree headless deployment
 
-Run teatree headless on a single existing Hetzner ARM64 box (CAX21, 8 GB), driven
-by one manual GitHub Action. teatree runs the autonomous loop (`t3 worker`,
+Run teatree headless on a single existing box, reached over direct SSH, driven
+by one GitHub Action. teatree runs the autonomous loop (`t3 worker`,
 `agent_runtime=headless`), self-updates via its own loop, autostarts on reboot,
 and serves the Django admin on the box loopback for SSH-tunnel access.
 
@@ -10,10 +10,11 @@ overlay is the built-in `t3-teatree`.
 
 ## How the one-click deploy works
 
-`Actions → Deploy teatree to Hetzner → Run workflow` (`.github/workflows/deploy-hetzner.yml`):
+`Actions → Deploy teatree → Run workflow` (`.github/workflows/deploy.yml`):
 
-1. Installs a checksum-pinned `hcloud` CLI and resolves the box IP from the server
-   name (the IP is masked out of the logs immediately).
+1. Connects to the box at the fixed host/IP held in the `DEPLOY_SSH_HOST` secret
+   (masked out of the logs immediately) — no cloud API resolves it, so any
+   directly-reachable box works, not just a Hetzner Cloud one.
 2. Writes the SSH key + known_hosts from secrets, connects with strict host-key
    checking.
 3. Writes the box secrets file `deploy/teatree.env` over SSH (piped over stdin,
@@ -224,12 +225,11 @@ Do this once as an admin on the box.
 
 | Secret | Purpose |
 | --- | --- |
-| `HCLOUD_TOKEN` | Hetzner Cloud API token (read-only is enough) to resolve the box IP |
-| `HETZNER_SERVER_NAME` | the Cloud server name to resolve |
-| `HETZNER_SSH_USER` | the deploy user (e.g. `teatree`) |
-| `HETZNER_SSH_PORT` | the SSH port |
-| `HETZNER_SSH_KEY` | the deploy **private** SSH key |
-| `HETZNER_SSH_KNOWN_HOSTS` | the box's host key line(s) for strict checking |
+| `DEPLOY_SSH_HOST` | the box host/IP to SSH into directly (e.g. `82.25.60.50`) |
+| `DEPLOY_SSH_USER` | the deploy user (e.g. `teatree`) |
+| `DEPLOY_SSH_PORT` | the SSH port |
+| `DEPLOY_SSH_KEY` | the deploy **private** SSH key |
+| `DEPLOY_SSH_KNOWN_HOSTS` | the box's host key line(s) for strict checking |
 | `CLAUDE_CODE_OAUTH_TOKEN` | Claude Code OAuth token — the headless auth |
 | `T3_ADMIN_USER` | Django admin superuser name |
 | `GIT_AUTHOR_NAME` | git identity for the loop's commits |
@@ -302,7 +302,7 @@ a permission is missing (#3405, #3436). A classic PAT satisfies this with the si
 printf '%s' "<new-github-pat>" | pass insert -m -f github/souliane/pat
 ```
 
-Then re-run **Actions → Deploy teatree to Hetzner** (or restart the stack): the
+Then re-run **Actions → Deploy teatree** (or restart the stack): the
 entrypoint re-sources the rotated value from `pass` at boot. Because the token is no
 longer written into `teatree.env`, rotation is a `pass` update plus a redeploy —
 the deploy workflow never rewrites the on-disk secret file for it.


### PR DESCRIPTION
## What

Replace the Hetzner-Cloud-specific deploy workflow with a provider-neutral **direct-SSH** deploy. The box is now reached at a fixed host/IP held in a secret — no `hcloud` CLI, no Hetzner Cloud API resolution.

## Why

The target box is no longer a Hetzner Cloud server (it is a HostKey box at a fixed IP, unresolvable via `hcloud`). The old workflow installed a checksum-pinned `hcloud` CLI and resolved the box IP from `HCLOUD_TOKEN` + `HETZNER_SERVER_NAME`, which cannot work for a box outside Hetzner Cloud.

## Changes

- **Dropped hcloud entirely** — removed the `hcloud` CLI install step and the IP-resolution step. No `HCLOUD_TOKEN` / `HETZNER_SERVER_NAME` anywhere.
- **Renamed the connection secrets to provider-neutral names.** The workflow now connects directly to `DEPLOY_SSH_HOST`:
  - `DEPLOY_SSH_HOST` — the box host/IP to SSH into directly
  - `DEPLOY_SSH_USER` — the deploy user
  - `DEPLOY_SSH_PORT` — the SSH port
  - `DEPLOY_SSH_KEY` — the deploy private SSH key
  - `DEPLOY_SSH_KNOWN_HOSTS` — the box host key line(s) for strict checking
- **Required-secrets preflight** now checks exactly those five and fails loud (`MISSING SECRET …`) if any is empty.
- **Host/IP is still masked** out of the logs (`::add-mask::`), same as the old hcloud-resolved IP.
- **Renamed** `.github/workflows/deploy-hetzner.yml` → `.github/workflows/deploy.yml`; workflow `name:` → `Deploy teatree`; concurrency group → `deploy`. Header comment rewritten for direct-SSH / HostKey.
- `on: push: branches:[main]` + `workflow_dispatch` unchanged.
- **Everything else identical**: env-file write over stdin (mode 600, secrets never on argv/logs), the `deploy.sh` converge step, the `CLAUDE_CODE_OAUTH_TOKEN` / `T3_ADMIN_USER` / `GIT_AUTHOR_*` env-file lines, the `TEATREE_ENABLED_LOOPS` / `TEATREE_DISABLED_LOOPS` / `TEATREE_BOX_USE_PASS` repo-variable plumbing.
- **`deploy/README.md`** updated: title, one-click-deploy steps, and the repository-secrets table now document the direct-SSH secrets; no stale `HETZNER_*` / `HCLOUD_*` / `deploy-hetzner.yml` references remain.

## Validation

- `actionlint` on the workflow: clean (exit 0).
- YAML parses; `prek` on the changed files passes (check-yaml, markdownlint, banned-terms, gitleaks, editorconfig, codespell, …).
- There is no way to run the actual deploy from CI; not attempted.

## Owner action required

The owner must set these five GitHub Actions **secrets** (the automation PAT lacks `Secrets: write`):

| Secret | Value |
| --- | --- |
| `DEPLOY_SSH_HOST` | `82.25.60.50` |
| `DEPLOY_SSH_USER` | `teatree` |
| `DEPLOY_SSH_PORT` | the box SSH port |
| `DEPLOY_SSH_KNOWN_HOSTS` | `ssh-keyscan -p <port> 82.25.60.50` output (verify fingerprint out of band) |
| `DEPLOY_SSH_KEY` | the deploy private SSH key |

The old `HCLOUD_TOKEN` / `HETZNER_SERVER_NAME` / `HETZNER_SSH_*` secrets can be deleted after this merges.

Held as **draft** for owner review — do not merge until the secrets are set.
