### PR TITLE
fix: bug-hunt med batch — egress fail-closed, jq init guard, live compose-stack detector, gh write-probe indeterminate

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -228,9 +228,12 @@ init_preflight() {
 # deploy/claude-settings.template.json; three env vars override the box-specific knobs.
 # Deploy-managed keys WIN over an existing file (a redeploy re-asserts the intended
 # config) while UNMANAGED keys the later `t3 setup` adds — notably statusLine — are
-# preserved (`jq '.[0] * .[1]'` deep-merges, right wins). MUST run before `t3 setup`.
+# preserved (`jq '.[0] * .[1]'` deep-merges, right wins). A pre-existing INVALID
+# settings.json is REPLACED with the managed config (the merge cannot parse it, and a
+# corrupt file downstream bricks `t3 setup` / the `claude` CLI). MUST run before
+# `t3 setup`.
 seed_claude_settings() {
-    local template="/usr/local/share/teatree/claude-settings.template.json"
+    local template="${TEATREE_CLAUDE_SETTINGS_TEMPLATE:-/usr/local/share/teatree/claude-settings.template.json}"
     local target="$HOME/.claude/settings.json"
     if [ ! -f "$template" ]; then
         echo "teatree-init: no claude-settings template at $template - skipping (agent runs on CLI defaults)" >&2
@@ -247,9 +250,23 @@ seed_claude_settings() {
         echo "teatree-init: failed to resolve claude-settings template - skipping" >&2
         return 0
     fi
-    if [ -f "$target" ]; then
-        jq -s '.[0] * .[1]' "$target" <(printf '%s' "$managed") >"$target.tmp" && mv "$target.tmp" "$target"
+    # Deep-merge over an EXISTING valid file (right wins) so unmanaged keys survive;
+    # but a pre-existing INVALID settings.json cannot be parsed by the merge and, left
+    # in place, bricks `t3 setup` / the `claude` CLI and silently drops the managed
+    # config. Validate first and REPLACE a corrupt (or unmergeable) file with the
+    # managed config rather than aborting init or leaving it broken.
+    if [ -f "$target" ] && jq -e . "$target" >/dev/null 2>&1; then
+        if jq -s '.[0] * .[1]' "$target" <(printf '%s' "$managed") >"$target.tmp" 2>/dev/null; then
+            mv "$target.tmp" "$target"
+        else
+            rm -f "$target.tmp"
+            echo "teatree-init: could not merge existing ~/.claude/settings.json - replacing it with the managed config" >&2
+            printf '%s\n' "$managed" >"$target"
+        fi
     else
+        if [ -f "$target" ]; then
+            echo "teatree-init: existing ~/.claude/settings.json is not valid JSON - replacing it with the managed config" >&2
+        fi
         printf '%s\n' "$managed" >"$target"
     fi
     echo "teatree-init: provisioned ~/.claude/settings.json (model=$(jq -r .model "$target"), mode=$(jq -r .permissions.defaultMode "$target"))"

--- a/deploy/watchdog.sh
+++ b/deploy/watchdog.sh
@@ -91,6 +91,21 @@ notify_owner() {
   fi
 }
 
+# Gather the compose container states from the daemon socket and base64-encode them
+# for handoff to `t3 doctor`. This watchdog is the ONLY container with
+# /var/run/docker.sock, while `t3 doctor` runs in a socket-less app container whose
+# own `docker ps` cannot reach the daemon — so without this handoff the doctor's
+# compose-stack detector (crash-looping init / down worker) silently passes every
+# real outage. Empty on any docker/base64 failure — the doctor then degrades to a
+# pass exactly as it did before this handoff, and its other detectors still run.
+compose_states_b64() {
+  local ps
+  ps="$(docker ps --all \
+        --filter "label=com.docker.compose.project=$PROJECT" \
+        --format '{{.Label "com.docker.compose.service"}}'$'\t''{{.State}}'$'\t''{{.Status}}' 2>/dev/null)" || return 0
+  printf '%s' "$ps" | base64 -w0 2>/dev/null || true
+}
+
 # Run `t3 doctor check --json` in the first REACHABLE exec service, capturing its
 # stdout into DOCTOR_RAW regardless of doctor's exit code. This is the heart of
 # the #3440 fix: a red-findings verdict exits NON-ZERO yet is a healthy RUN of
@@ -100,13 +115,16 @@ notify_owner() {
 # falls through to the next one. Returns 0 when a service was reached (DOCTOR_RAW
 # set, possibly empty), 125 when NO exec service could be reached at all.
 run_doctor() {
-  local svc
+  local svc states_b64
   DOCTOR_RAW=""
+  states_b64="$(compose_states_b64)"
   for svc in $EXEC_SERVICES; do
     if compose exec -T "$svc" true >/dev/null 2>&1; then
       # `|| true`: doctor exits non-zero on red findings; keep its stdout, drop
       # the exit code (set -e must not abort, and the code is NOT the signal).
-      DOCTOR_RAW="$(compose exec -T "$svc" t3 doctor check --json 2>/dev/null || true)"
+      # `-e TEATREE_DOCTOR_COMPOSE_PS`: hand the socket-only container states to the
+      # doctor's compose-stack detector, which cannot reach the daemon itself.
+      DOCTOR_RAW="$(compose exec -T -e "TEATREE_DOCTOR_COMPOSE_PS=$states_b64" "$svc" t3 doctor check --json 2>/dev/null || true)"
       return 0
     fi
   done

--- a/src/teatree/cli/doctor/self_heal.py
+++ b/src/teatree/cli/doctor/self_heal.py
@@ -24,8 +24,10 @@ aborts the doctor run would recreate the very "monitor dies, alerting dies"
 failure this module exists to end.
 """
 
+import base64
 import datetime as dt
 import json
+import os
 import shutil
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -37,6 +39,10 @@ from teatree.paths import DATA_DIR
 
 #: The compose project the box runs the factory under (``deploy/docker-compose.yml``).
 _COMPOSE_PROJECT = "teatree"
+#: Env var the socket-holding watchdog uses to hand compose container states to
+#: ``t3 doctor`` (base64 of the ``docker ps`` tab-rows); see
+#: :func:`_compose_states_from_handoff`.
+_COMPOSE_STATES_ENV = "TEATREE_DOCTOR_COMPOSE_PS"
 #: The one-shot prep service — a non-zero exit is a crash-looping init.
 _INIT_SERVICE = "teatree-init"
 #: The long-running services expected to stay ``running`` while loops are enabled.
@@ -82,6 +88,47 @@ _STRANDED_HEADLESS_GRACE_SECONDS = 900
 _BOX_RUNTIME_CLONE = Path("/home/teatree/teatree")
 
 
+def _parse_compose_state_rows(text: str) -> list[tuple[str, str, str]]:
+    """Parse tab-separated ``docker ps`` lines into ``(service, state, status)`` tuples.
+
+    Each line carries three tab-separated fields -- service, state, status (the
+    probe's ``--format``); the state is lower-cased for the down-state comparison.
+    Malformed / short lines are dropped so a partial read never yields a garbage
+    verdict.
+    """
+    rows: list[tuple[str, str, str]] = []
+    for line in text.splitlines():
+        parts = line.split("\t")
+        if len(parts) == _STATE_ROW_FIELDS and parts[0]:
+            rows.append((parts[0], parts[1].strip().lower(), parts[2].strip()))
+    return rows
+
+
+def _compose_states_from_handoff() -> list[tuple[str, str, str]] | None:
+    """Compose states handed off by the socket-holding watchdog, or ``None`` when absent.
+
+    ``t3 doctor`` runs inside ``teatree-admin``, which has the ``docker`` CLI but
+    NOT ``/var/run/docker.sock`` (only the watchdog mounts the socket), so a local
+    ``docker ps`` there cannot reach the daemon and the compose-stack detector would
+    silently pass every real outage. The watchdog — the ONE container with the
+    socket — gathers the states and passes them in via :data:`_COMPOSE_STATES_ENV`
+    (base64 of the same tab-separated ``docker ps`` output), so the detector runs in
+    the container that also has the DB-backed ``loop_runner_on`` gate.
+
+    ``None`` when the env var is unset / empty (a dev box, or a direct ``t3 doctor``
+    run) so the caller falls back to a LOCAL ``docker ps``. A malformed / non-base64
+    handoff also yields ``None`` (degrade to a pass) rather than a garbage verdict.
+    """
+    raw = os.environ.get(_COMPOSE_STATES_ENV, "").strip()
+    if not raw:
+        return None
+    try:
+        decoded = base64.b64decode(raw).decode("utf-8")
+    except (ValueError, UnicodeDecodeError):
+        return None
+    return _parse_compose_state_rows(decoded)
+
+
 class _Probe:
     """Crash-tolerant reads of the loop/worker/clone state the checks aggregate.
 
@@ -104,16 +151,26 @@ class _Probe:
 
     @staticmethod
     def compose_container_states(project: str) -> list[tuple[str, str, str]] | None:
-        """``(service, state, status)`` per container of *project*, or ``None`` when docker is unreachable.
+        """``(service, state, status)`` per container of *project*, or ``None`` when unreadable.
 
-        ``None`` means "cannot tell" (no ``docker`` on PATH, daemon down, or the
-        probe timed out) — the caller degrades to a pass, exactly as the MCP /
-        Slack doctor probes degrade when their tool is absent. Inside the worker
-        container (no docker socket) this returns ``None`` and the watchdog's own
-        ``docker compose up -d`` remains the actual container-restart repair.
+        Prefers the watchdog handoff (:func:`_compose_states_from_handoff`): the
+        doctor runs inside a socket-LESS app container (``teatree-admin`` has the
+        ``docker`` CLI but not ``/var/run/docker.sock``), so a local ``docker ps``
+        cannot reach the daemon there and the detector would silently pass every
+        real outage. The socket-holding watchdog gathers the states and hands them
+        in, so the check runs where the DB-backed ``loop_runner_on`` gate lives.
+
+        Falls back to a LOCAL ``docker ps`` when no handoff is present (a dev box,
+        or a direct ``t3 doctor`` run on a machine WITH docker access). ``None``
+        means "cannot tell" (no handoff, and no ``docker`` on PATH / daemon down /
+        timeout) — the caller degrades to a pass, exactly as the MCP / Slack doctor
+        probes degrade when their tool is absent.
         """
         from teatree.utils.run import run_allowed_to_fail  # noqa: PLC0415 — deferred: keeps CLI startup light
 
+        handoff = _compose_states_from_handoff()
+        if handoff is not None:
+            return handoff
         docker = shutil.which("docker")
         if docker is None:
             return None
@@ -135,12 +192,7 @@ class _Probe:
             return None
         if completed.returncode != 0:
             return None
-        rows: list[tuple[str, str, str]] = []
-        for line in completed.stdout.splitlines():
-            parts = line.split("\t")
-            if len(parts) == _STATE_ROW_FIELDS and parts[0]:
-                rows.append((parts[0], parts[1].strip().lower(), parts[2].strip()))
-        return rows
+        return _parse_compose_state_rows(completed.stdout)
 
     @staticmethod
     def _cadence_seconds(loop_row: object) -> int:
@@ -247,10 +299,12 @@ def _check_compose_stack() -> bool:
 
     A non-zero init exit is a crash-looping prep container (nothing downstream
     starts); a worker/admin container stuck ``Created``/``Exited`` while
-    ``loop_runner_enabled`` is ON is a silently dead factory. Best-effort: when
-    docker is unreachable (the common in-container case, no socket) the probe
-    returns ``None`` and this degrades to a pass — the watchdog's own
-    ``docker compose up -d`` is the real container-restart repair.
+    ``loop_runner_enabled`` is ON is a silently dead factory. The container states
+    come from the watchdog handoff (:func:`_compose_states_from_handoff`) since the
+    doctor runs in a socket-less app container; only when neither the handoff nor a
+    local ``docker ps`` can read the daemon (a dev box) does the probe return
+    ``None`` and this degrade to a pass — the watchdog's own ``docker compose up
+    -d`` is the real container-restart repair.
     """
     try:
         states = _Probe.compose_container_states(_COMPOSE_PROJECT)

--- a/src/teatree/core/gates/gh_token_preflight.py
+++ b/src/teatree/core/gates/gh_token_preflight.py
@@ -18,7 +18,10 @@ permission it lacks. Each write permission is checked with a side-effect-free
 mutation aimed at a resource number that never exists (issue/PR ``0``, a bogus
 ref): a token that *has* the permission gets a harmless ``404``, a token that
 *lacks* it gets the ``403`` GitHub returns before it ever loads the resource.
-Nothing is created, edited, or deleted either way.
+Nothing is created, edited, or deleted either way. A write probe that reaches
+NEITHER verdict -- a transport/network fault, no ``403`` and no ``404`` -- is
+*indeterminate*, never read as a grant: the deploy skips (a network blip must not
+falsely certify a token) rather than passing preflight then failing mid-run.
 
 A **classic** PAT does NOT get that route-level ``403`` — the write probe would
 fail *open* for it. Instead GitHub reports a classic token's granted scopes in
@@ -40,6 +43,7 @@ it so the two implementations cannot drift.
 import shutil
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Literal
 
 from teatree.utils.run import run_allowed_to_fail
 
@@ -68,6 +72,18 @@ _DENIED_SIGNALS: tuple[str, ...] = (
 # The single write-permission signal: GitHub returns exactly this at the route
 # level for a token missing the permission, before validating the target.
 _FORBIDDEN_SIGNAL = "not accessible"
+
+# Substrings that mean a write probe REACHED the route past the write-authorization
+# gate: a token WITH the permission gets a 404/422 on the deliberately non-existent
+# target (never a 403 ``not accessible``). Their presence -- or a zero exit code --
+# means the permission is PRESENT. Their ABSENCE, with no ``not accessible`` denial,
+# means the probe never reached a verdict (a transport/network fault) -> indeterminate.
+_WRITE_REACHED_SIGNALS: tuple[str, ...] = (
+    "not found",  # 404 on the non-existent issue/PR/ref (JSON body and gh's message)
+    "(http ",  # gh appends the HTTP status on any reached response (e.g. "(HTTP 404)")
+)
+
+type _WriteVerdict = Literal["denied", "present", "indeterminate"]
 
 # (permission label, gh-api argv template) for the three write probes. Each
 # mutates a resource id that cannot exist, so a permitted token gets a 404 and a
@@ -102,8 +118,10 @@ class GhTokenProbe:
 
     ``missing`` is the denied permission labels (empty == the token has every
     required permission). ``indeterminate_reason`` is set only when the probe
-    could not run to a verdict (``gh`` absent, or the API unreachable) — the
-    caller then skips rather than failing on a network fault.
+    could not run to a verdict (``gh`` absent, the metadata read unreachable, or a
+    write probe that reached no 403/404) — the caller then skips rather than
+    failing on a network fault. A genuine denial always takes precedence over an
+    indeterminate write probe, so a real permission gap is never masked.
     """
 
     missing: tuple[str, ...]
@@ -129,6 +147,24 @@ def _default_run(args: list[str]) -> tuple[int, str]:
 def _has_signal(text: str, signals: tuple[str, ...]) -> bool:
     lowered = text.lower()
     return any(signal in lowered for signal in signals)
+
+
+def _write_probe_verdict(code: int, out: str) -> _WriteVerdict:
+    """Classify one write probe as ``denied`` / ``present`` / ``indeterminate``.
+
+    ``denied`` when GitHub returned the route-level 403 :data:`_FORBIDDEN_SIGNAL`
+    (the token lacks the permission). ``present`` when the probe REACHED a verdict
+    past the write-authorization gate -- a zero exit or a :data:`_WRITE_REACHED_SIGNALS`
+    (404/422) response on the non-existent target. ``indeterminate`` otherwise: a
+    non-zero exit with NEITHER signal is a transport/network fault, NOT a grant --
+    the fail-open the old ``not accessible``-only test collapsed into ``present``.
+    """
+    lowered = out.lower()
+    if _FORBIDDEN_SIGNAL in lowered:
+        return "denied"
+    if code == 0 or _has_signal(lowered, _WRITE_REACHED_SIGNALS):
+        return "present"
+    return "indeterminate"
 
 
 def _oauth_scopes(headers_text: str) -> frozenset[str] | None:
@@ -176,13 +212,34 @@ def probe_token_permissions(slug: str, run: GhRunner | None = None) -> GhTokenPr
             return GhTokenProbe(missing=())
         return GhTokenProbe(missing=_WRITE_PERMISSION_LABELS)
 
+    return _probe_fine_grained_writes(slug, run)
+
+
+def _probe_fine_grained_writes(slug: str, run: GhRunner) -> GhTokenProbe:
+    """Per-route write probes for a fine-grained PAT: classify each, then aggregate.
+
+    A genuine denial is a definite gap -> report it (a loud FAIL) even alongside a
+    transient probe, so a real permission gap is never masked. Only when NO probe
+    was denied but one could not reach a verdict do we return indeterminate, so a
+    network blip on a write probe SKIPS the preflight rather than falsely certifying
+    (or falsely failing) the token.
+    """
     missing: list[str] = []
+    indeterminate: list[str] = []
     for label, template in _WRITE_PROBES:
         args = [part.format(slug=slug) for part in template]
-        _code, out = run(args)
-        if _FORBIDDEN_SIGNAL in out.lower():
+        code, out = run(args)
+        verdict = _write_probe_verdict(code, out)
+        if verdict == "denied":
             missing.append(label)
-    return GhTokenProbe(missing=tuple(missing))
+        elif verdict == "indeterminate":
+            indeterminate.append(label)
+    if missing:
+        return GhTokenProbe(missing=tuple(missing))
+    if indeterminate:
+        reason = f"write probe(s) did not reach a verdict: {', '.join(indeterminate)} (API unreachable?)"
+        return GhTokenProbe(missing=(), indeterminate_reason=reason)
+    return GhTokenProbe(missing=())
 
 
 __all__ = [

--- a/tests/teatree_cli/doctor/test_self_heal.py
+++ b/tests/teatree_cli/doctor/test_self_heal.py
@@ -6,6 +6,7 @@ present, and degrades to a pass when it cannot read the state — a self-heal
 detector must never itself abort the doctor run.
 """
 
+import base64
 import datetime as dt
 import io
 import json as _json
@@ -89,6 +90,69 @@ class ComposeStackCheckTest(TestCase):
         ):
             ok, _out = _echoes(self_heal._check_compose_stack)
         assert ok is True
+
+
+class ComposeStackWatchdogHandoffTest(TestCase):
+    """The compose-stack detector must WORK where it runs, not silently pass.
+
+    ``t3 doctor`` runs inside ``teatree-admin``, which has the ``docker`` CLI but
+    NO ``/var/run/docker.sock`` (only the watchdog mounts the socket), so a local
+    ``docker ps`` fails and the detector used to return ``None`` -> pass, making a
+    crash-looping init / down worker undetectable in production (dead code). The
+    socket-holding watchdog now hands the states in via the
+    ``TEATREE_DOCTOR_COMPOSE_PS`` env var (base64 of the same ``docker ps`` output);
+    the probe reads that handoff even when the local ``docker`` cannot reach the
+    daemon, so a real outage FAILs and reaches the owner DM.
+    """
+
+    @staticmethod
+    def _handoff(rows: list[tuple[str, str, str]]) -> str:
+        text = "\n".join("\t".join(row) for row in rows)
+        return base64.b64encode(text.encode("utf-8")).decode("ascii")
+
+    def test_handoff_states_used_when_local_docker_unreachable(self) -> None:
+        # No local docker socket (CLI absent stands in for "cannot reach daemon"),
+        # yet the watchdog handoff carries a crash-looped init: the probe must
+        # return those states instead of None. RED before the handoff branch.
+        env = {"TEATREE_DOCTOR_COMPOSE_PS": self._handoff([("teatree-init", "exited", "Exited (1) ago")])}
+        with (
+            mock.patch(f"{_MOD}.shutil.which", return_value=None),
+            mock.patch.dict("os.environ", env, clear=False),
+        ):
+            states = self_heal._Probe.compose_container_states("teatree")
+        assert states == [("teatree-init", "exited", "Exited (1) ago")]
+
+    def test_down_stack_fails_via_handoff_without_socket(self) -> None:
+        # End to end: no socket + a handoff-supplied crash-looped init -> the
+        # detector FAILs (does not silently pass), so the watchdog DMs the owner.
+        env = {"TEATREE_DOCTOR_COMPOSE_PS": self._handoff([("teatree-init", "exited", "Exited (1) ago")])}
+        with (
+            mock.patch(f"{_MOD}.shutil.which", return_value=None),
+            mock.patch.dict("os.environ", env, clear=False),
+        ):
+            ok, out = _echoes(self_heal._check_compose_stack)
+        assert ok is False
+        assert "teatree-init" in out
+
+    def test_no_handoff_and_no_socket_still_degrades_to_pass(self) -> None:
+        # Anti-over-block: a dev box (no watchdog handoff, no socket) must still
+        # degrade to a pass, never a false FAIL.
+        with (
+            mock.patch(f"{_MOD}.shutil.which", return_value=None),
+            mock.patch.dict("os.environ", {"TEATREE_DOCTOR_COMPOSE_PS": ""}, clear=False),
+        ):
+            states = self_heal._Probe.compose_container_states("teatree")
+        assert states is None
+
+    def test_malformed_handoff_falls_back_to_none(self) -> None:
+        # A corrupt base64 handoff must not crash; with no local socket it yields
+        # None (degrade to pass), never a partial/garbage verdict.
+        with (
+            mock.patch(f"{_MOD}.shutil.which", return_value=None),
+            mock.patch.dict("os.environ", {"TEATREE_DOCTOR_COMPOSE_PS": "!!!not base64!!!"}, clear=False),
+        ):
+            states = self_heal._Probe.compose_container_states("teatree")
+        assert states is None
 
 
 class LoopWorkerAliveCheckTest(TestCase):

--- a/tests/teatree_core/gates/test_gh_token_preflight.py
+++ b/tests/teatree_core/gates/test_gh_token_preflight.py
@@ -108,6 +108,70 @@ class TestProbeTokenPermissions:
         assert "gh" in probe.indeterminate_reason.lower()
 
 
+class TestWriteProbeIndeterminate:
+    """A write probe that fails to REACH a verdict is INDETERMINATE, not present.
+
+    The per-route write probe reads a genuine grant as a 404 (resource absent) and
+    a missing permission as a 403 ``not accessible``. A TRANSIENT/network failure of
+    a write probe returns NEITHER string, so the old loop — which only appended to
+    ``missing`` on the 403 signal and discarded the return code — silently recorded
+    the failed probe as permission PRESENT. A token genuinely missing the permission
+    then passed preflight and failed mid-run. The fix treats a probe that reached no
+    definitive 403/404 verdict as indeterminate (fail closed to a skip/warn, never a
+    false grant).
+    """
+
+    def test_transient_write_probe_is_indeterminate_not_present(self) -> None:
+        # RED before the fix: the transient issues probe (no `not accessible`, no
+        # reached-route signal) was counted as PRESENT, so probe.ok was True.
+        run = _runner(
+            {
+                "repos/souliane/teatree": (0, "{}"),
+                "issues/0": (1, "error connecting to api.github.com: connection reset by peer"),
+                "pulls/0": (1, _NOT_FOUND),
+                "refs/heads": (1, _NOT_FOUND),
+            }
+        )
+        with patch("teatree.core.gates.gh_token_preflight.shutil.which", return_value="/usr/bin/gh"):
+            probe = probe_token_permissions(_SLUG, run=run)
+        assert probe.missing == ()
+        assert probe.indeterminate_reason is not None
+        assert "issues: write" in probe.indeterminate_reason
+        assert not probe.ok
+
+    def test_genuine_denial_takes_precedence_over_transient(self) -> None:
+        # A real 403 denial must be reported (loud FAIL) even when another probe is
+        # transient — the denial is a definite gap, not masked by the indeterminate.
+        run = _runner(
+            {
+                "repos/souliane/teatree": (0, "{}"),
+                "issues/0": (1, _NOT_ACCESSIBLE),
+                "pulls/0": (1, "curl: (6) could not resolve host"),
+                "refs/heads": (1, _NOT_FOUND),
+            }
+        )
+        with patch("teatree.core.gates.gh_token_preflight.shutil.which", return_value="/usr/bin/gh"):
+            probe = probe_token_permissions(_SLUG, run=run)
+        assert probe.missing == ("issues: write",)
+        assert not probe.ok
+
+    def test_http_status_marker_counts_as_reached(self) -> None:
+        # Real `gh` prints `(HTTP 404)` on a reached route; that is present, not
+        # indeterminate, even without the bare `Not Found` JSON body.
+        run = _runner(
+            {
+                "repos/souliane/teatree": (0, "{}"),
+                "issues/0": (1, "gh: Sub-issues are disabled (HTTP 422)"),
+                "pulls/0": (1, "gh: Not Found (HTTP 404)"),
+                "refs/heads": (1, "gh: Not Found (HTTP 404)"),
+            }
+        )
+        with patch("teatree.core.gates.gh_token_preflight.shutil.which", return_value="/usr/bin/gh"):
+            probe = probe_token_permissions(_SLUG, run=run)
+        assert probe.ok
+        assert probe.missing == ()
+
+
 class TestClassicPatScope:
     """A classic PAT is judged by its ``X-OAuth-Scopes`` header.
 

--- a/tests/test_deploy_entrypoint_seed_claude_settings.py
+++ b/tests/test_deploy_entrypoint_seed_claude_settings.py
@@ -1,0 +1,105 @@
+# test-path: cross-cutting — drives deploy/entrypoint.sh (no src mirror).
+"""Integration tests for the entrypoint's ~/.claude/settings.json provisioning.
+
+`deploy/entrypoint.sh`'s `seed_claude_settings` writes the deploy-managed Claude
+Code settings before `t3 setup` runs, deep-merging (`jq '.[0] * .[1]'`, right
+wins) over any EXISTING file so unmanaged keys (`statusLine`, added later by
+`t3 setup`) survive a redeploy. A pre-existing settings.json that is INVALID JSON
+must be REPLACED with the managed config, not left corrupt: the merge cannot parse
+it, and a corrupt settings.json downstream bricks `t3 setup` / the `claude` CLI
+and silently drops the managed model + permission mode. The guard keeps init
+crash-proof against a hand-corrupted or partially-written settings file.
+
+These run the REAL shell function (extracted verbatim) in a bash subprocess with
+the REAL committed template and the REAL pure-stdlib resolver, so the merge /
+repair / fresh-write contract is exercised end to end with real `jq`.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="needs bash + jq (present in the deploy image and CI)",
+)
+
+_REPO = Path(__file__).resolve().parents[1]
+ENTRYPOINT = _REPO / "deploy" / "entrypoint.sh"
+TEMPLATE = _REPO / "deploy" / "claude-settings.template.json"
+_BASH = shutil.which("bash") or "bash"
+
+
+def _extract_shell_function(name: str) -> str:
+    """Return the verbatim source of shell function *name* from the entrypoint."""
+    body: list[str] = []
+    capturing = False
+    for line in ENTRYPOINT.read_text(encoding="utf-8").splitlines():
+        if line.startswith(f"{name}() {{"):
+            capturing = True
+        if capturing:
+            body.append(line)
+            if line == "}":
+                return "\n".join(body)
+    not_found = f"function {name!r} not found in {ENTRYPOINT}"
+    raise AssertionError(not_found)
+
+
+def _run_seed(tmp_path: Path, existing: str | None) -> tuple[Path, subprocess.CompletedProcess[str]]:
+    """Run `seed_claude_settings` with *existing* content pre-seeded (or no file).
+
+    Returns the resolved settings.json path and the completed process. Uses the
+    REAL committed template + resolver so the merge is exercised with real `jq`.
+    """
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True, exist_ok=True)
+    target = home / ".claude" / "settings.json"
+    if existing is not None:
+        target.write_text(existing, encoding="utf-8")
+    func = _extract_shell_function("seed_claude_settings")
+    harness = tmp_path / "harness.sh"
+    harness.write_text(f"set -euo pipefail\n{func}\nseed_claude_settings\n", encoding="utf-8")
+    proc = subprocess.run(
+        [_BASH, str(harness)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            "HOME": str(home),
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "CLONE_DIR": str(_REPO),
+            "TEATREE_CLAUDE_SETTINGS_TEMPLATE": str(TEMPLATE),
+        },
+    )
+    return target, proc
+
+
+class TestSeedClaudeSettings:
+    def test_corrupt_existing_settings_is_replaced_not_bricked(self, tmp_path: Path) -> None:
+        # RED before the guard: an invalid pre-existing settings.json made the merge
+        # jq fail, leaving the corrupt file in place (managed keys silently dropped,
+        # downstream `t3 setup` / `claude` CLI choke on it). It must be REPLACED.
+        target, proc = _run_seed(tmp_path, existing="{invalid json, not parseable")
+        assert proc.returncode == 0, proc.stderr
+        parsed = json.loads(target.read_text(encoding="utf-8"))  # must be valid JSON now
+        assert parsed["model"] == "claude-opus-4-8"
+
+    def test_no_existing_file_writes_managed_config(self, tmp_path: Path) -> None:
+        target, proc = _run_seed(tmp_path, existing=None)
+        assert proc.returncode == 0, proc.stderr
+        parsed = json.loads(target.read_text(encoding="utf-8"))
+        assert parsed["model"] == "claude-opus-4-8"
+
+    def test_valid_existing_file_merge_preserves_unmanaged_keys(self, tmp_path: Path) -> None:
+        # Anti-regression: a VALID existing file still deep-merges so an unmanaged
+        # key (`statusLine`, added later by `t3 setup`) survives the redeploy while
+        # the managed model wins.
+        existing = json.dumps({"statusLine": {"type": "command", "command": "mine"}, "model": "stale"})
+        target, proc = _run_seed(tmp_path, existing=existing)
+        assert proc.returncode == 0, proc.stderr
+        parsed = json.loads(target.read_text(encoding="utf-8"))
+        assert parsed["model"] == "claude-opus-4-8"  # managed key wins
+        assert parsed["statusLine"] == {"type": "command", "command": "mine"}  # unmanaged survives

--- a/tests/test_deploy_watchdog.py
+++ b/tests/test_deploy_watchdog.py
@@ -12,6 +12,7 @@ init complete, the stack reachable, and `t3 doctor` emitting a chosen verdict.
 The owner DM is captured to a file so each branch's message is asserted.
 """
 
+import base64
 import os
 import shutil
 import stat
@@ -44,7 +45,12 @@ def _write_docker_stub(bin_dir: Path) -> None:
     shim = bin_dir / "docker"
     shim.write_text(
         "#!/usr/bin/env bash\n"
-        '[ "$1" = compose ] || exit 0\n'
+        # A bare `docker ps` (NOT `docker compose ps`) is the watchdog's socket-only
+        # compose-state gather — serve STUB_DOCKER_PS so the handoff can be asserted.
+        'if [ "$1" != compose ]; then\n'
+        '  [ "$1" = ps ] && printf "%s\\n" "$STUB_DOCKER_PS"\n'
+        "  exit 0\n"
+        "fi\n"
         "shift\n"
         'while [ "${1:-}" = -p ] || [ "${1:-}" = -f ]; do shift 2; done\n'
         'sub="${1:-}"; shift || true\n'
@@ -52,6 +58,7 @@ def _write_docker_stub(bin_dir: Path) -> None:
         '  ps) printf "%s\\n" "$STUB_INIT_PS" ;;\n'
         "  up) exit 0 ;;\n"
         "  exec)\n"
+        '    printf "%s\\n" "$*" >>"${STUB_EXEC_LOG:-/dev/null}"\n'
         '    [ "${1:-}" = -T ] && shift\n'
         "    shift || true\n"
         '    rest="$*"\n'
@@ -80,11 +87,17 @@ def _run_pass(tmp_path: Path, **stub_env: str) -> str:
     env = dict(os.environ)
     env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
     env["STUB_NOTIFY_FILE"] = str(notify_file)
+    env["STUB_EXEC_LOG"] = str(tmp_path / "exec.log")
     env.setdefault("STUB_INIT_PS", '{"State":"exited","ExitCode":0}')
     env.setdefault("STUB_DOCTOR_JSON", _GREEN_VERDICT)
     env.update(stub_env)
     subprocess.run([_BASH, str(harness)], capture_output=True, text=True, check=False, env=env)
     return notify_file.read_text(encoding="utf-8") if notify_file.exists() else ""
+
+
+def _exec_log(tmp_path: Path) -> str:
+    log = tmp_path / "exec.log"
+    return log.read_text(encoding="utf-8") if log.exists() else ""
 
 
 class TestWatchdogRunPass:
@@ -110,6 +123,30 @@ class TestWatchdogRunPass:
         # RED condition, not a silent healthy pass.
         dm = _run_pass(tmp_path, STUB_DOCTOR_JSON="garbage with no verdict line", STUB_DOCTOR_RC="1")
         assert "no parseable verdict" in dm.lower()
+
+
+class TestWatchdogComposeStateHandoff:
+    """The socket-holding watchdog hands compose states to the socket-less doctor.
+
+    `t3 doctor` runs in an app container with the `docker` CLI but no
+    `/var/run/docker.sock`, so its own compose-stack probe cannot reach the daemon.
+    The watchdog (the ONE container with the socket) gathers `docker ps` and passes
+    it to the doctor via `-e TEATREE_DOCTOR_COMPOSE_PS=<base64>`, so the detector
+    actually runs. Without the handoff the detector is dead code in production.
+    """
+
+    def test_docker_ps_states_forwarded_to_doctor_as_base64(self, tmp_path: Path) -> None:
+        ps_rows = "teatree-init\texited\tExited (1) 2 minutes ago"
+        _run_pass(tmp_path, STUB_DOCKER_PS=ps_rows, STUB_DOCTOR_JSON=_GREEN_VERDICT, STUB_DOCTOR_RC="0")
+        expected = base64.b64encode(ps_rows.encode("utf-8")).decode("ascii")
+        exec_log = _exec_log(tmp_path)
+        assert f"TEATREE_DOCTOR_COMPOSE_PS={expected}" in exec_log
+
+    def test_handoff_flag_present_even_when_states_empty(self, tmp_path: Path) -> None:
+        # An empty `docker ps` still forwards the (empty) handoff, never omitting the
+        # flag — so the exec shape is stable and the doctor falls back cleanly.
+        _run_pass(tmp_path, STUB_DOCKER_PS="", STUB_DOCTOR_JSON=_GREEN_VERDICT, STUB_DOCTOR_RC="0")
+        assert "TEATREE_DOCTOR_COMPOSE_PS=" in _exec_log(tmp_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Four medium-severity bugs from a teatree bug hunt, each confirmed with a RED-first regression test before the fix. One commit, all four fixes.

## 1. Leak-gate fail-OPEN on an unresolvable publish
`src/teatree/hooks/public_visibility.py` — `_segment_visibility_verdict` (was line ~219). A leading `gh`/`glab` publish whose target could not be resolved (no `-R` flag, forge-URL, or reachable remote) returned `_SKIP_PUBLISH`, so a `gh pr create --body '<banned term>'` with an unresolvable remote **skipped** the leak scan. Now fails **closed** to `_SCAN` with a loud stderr signal, matching the bash pre-push mirror's undetermined-visibility branch and `is_public_destination` (None → PUBLIC → scan).

## 2. jq crash-loop / silent brick of init on an invalid settings.json
`deploy/entrypoint.sh` — `seed_claude_settings` (was line ~251). The `jq '.[0] * .[1]'` merge over an existing `~/.claude/settings.json` was never validated; a corrupt file left the merge failing and the corrupt file **in place**, silently dropping the managed config and bricking `t3 setup` / the `claude` CLI. Now validates first (`jq -e .`) and **replaces** a corrupt/unmergeable file with the managed config. Template path made overridable (`TEATREE_CLAUDE_SETTINGS_TEMPLATE`) for the new bash-level test (real `jq` under `tmp_path`).

## 3. Inert compose-stack self-heal detector
`src/teatree/cli/doctor/self_heal.py` (`_Probe.compose_container_states`, was line ~508) + `deploy/watchdog.sh`. `t3 doctor` runs inside `teatree-admin`, which has the docker CLI but **no** `/var/run/docker.sock` (only the watchdog mounts it), so the local `docker ps` failed → `None` → the crash-looping-init / down-worker detector **always passed** (dead code). The socket-holding watchdog now gathers the states and hands them to the doctor via `TEATREE_DOCTOR_COMPOSE_PS` (base64), so the detector runs in the container that also has the DB-backed `loop_runner_on` gate — a real outage now FAILs and DMs the owner.

## 4. gh_token write-probe fail-open
`src/teatree/core/gates/gh_token_preflight.py` — `probe_token_permissions` write-probe loop. It keyed only on the 403 `not accessible` string and discarded the return code, so a **transient/network** probe failure was recorded as permission **present** → a token genuinely missing a write permission passed preflight then failed mid-run. Now classifies each probe **denied / present / indeterminate**; a probe reaching no 403/404 verdict is indeterminate (skip), while a genuine denial always takes precedence. CRED #3436 already fixed the classic-PAT scope check (X-OAuth-Scopes) and the metadata-transient retry — this is the **separate write-probe-loop** fail-open it did not cover. (The bash mirror `_gh_write_probe_denied` retains the same grep, but in an init-safe direction — a transient there does not crash-loop init; flagged as a follow-up, not fixed here to keep init's critical path untouched.)

## Verification
- RED-first tests observed failing before each fix, green after.
- Per-subsystem tests (111), `tests/conformance` + `test_capabilities.py` (122 passed / 3 xfailed), `tests/quality` (679 passed / 1 skipped).
- `makemigrations --check` clean, `t3 tool test-path-mirror` ratchet holds, `ruff check` + `ruff format` clean, `shellcheck deploy/entrypoint.sh` clean, module-health under cap for both touched modules.
