### PR TITLE
fix(agents): rotate accounts before parking + quiesce-and-auto-resume on all-exhausted (multi-account Anthropic resilience)

### DIFF
--- a/src/teatree/agents/headless.py
+++ b/src/teatree/agents/headless.py
@@ -39,10 +39,15 @@ from teatree.agents.headless_usage import _attempt_usage
 from teatree.agents.pydantic_ai_resume import maybe_persist_on_park
 from teatree.agents.reader_profile import is_reader_phase, reader_child_env, reader_env_hermetic
 from teatree.agents.skill_bundle import active_overlay_stage_skills, resolve_skill_bundle
-from teatree.agents.usage_window import maybe_park_for_active_window, park_task_on_limit
+from teatree.agents.usage_window import (
+    maybe_park_for_active_window,
+    park_or_rotate_on_limit,
+    park_task_on_all_exhausted,
+)
 from teatree.config import AgentHarnessProvider, get_effective_settings
 from teatree.core.models import LeaseLostError, Task, TaskAttempt
 from teatree.core.models.ticket_worktree_checks import dispatch_worktree_path
+from teatree.credential_config import AllTokensExhaustedError
 from teatree.llm.anthropic_limits import LimitMatch, classify_limit, classify_rate_limit_type
 from teatree.llm.credentials import CredentialError
 from teatree.skill_support.loading import SkillLoadingPolicy
@@ -347,11 +352,11 @@ def _admission_park_or_child_env(
     if admission_park is not None:
         _restore_unconsumed_resume_thread(harness)
         return admission_park
-    return _resolve_child_env_or_failure(task, harness, provider, phase=phase)
+    return _resolve_child_env_or_failure(task, harness, provider, lane=lane, phase=phase)
 
 
 def _resolve_child_env_or_failure(
-    task: Task, harness: Harness, provider: AgentHarnessProvider | None, *, phase: str = ""
+    task: Task, harness: Harness, provider: AgentHarnessProvider | None, *, lane: str = "", phase: str = ""
 ) -> dict[str, str] | TaskAttempt | None:
     """Resolve the ``claude`` CLI child env for a :class:`~teatree.agents.harness.ClaudeSdkHarness` dispatch.
 
@@ -380,6 +385,13 @@ def _resolve_child_env_or_failure(
     try:
         base_env = _provider_child_env(provider, scope=_overlay_scope(task))
     except CredentialError as exc:
+        # #C2: every configured account drained (an ``AllTokensExhaustedError``) → quiesce the
+        # lane and auto-resume at the earliest reset rather than escalating to a human; any
+        # other credential gap (or flag-off) records the loud terminal FAILED as before.
+        if isinstance(exc, AllTokensExhaustedError):
+            parked = park_task_on_all_exhausted(task, resets_at=exc.earliest_reset, lane=lane)
+            if parked is not None:
+                return parked
         logger.warning("Refusing dispatch for task %s: %s", task.pk, exc)
         return _record_failure(task, error=str(exc))
     if is_reader_phase(phase):
@@ -403,7 +415,7 @@ def _outcome_failure(task: Task, outcome: HarnessOutcome, *, lane: str = "") -> 
     limit = _limit_match(outcome.result_message, outcome.rate_limit_info)
     if limit is not None:
         sdk_resets_at = outcome.rate_limit_info.resets_at if outcome.rate_limit_info is not None else None
-        parked = park_task_on_limit(task, limit, sdk_resets_at=sdk_resets_at, lane=lane)
+        parked = park_or_rotate_on_limit(task, limit, sdk_resets_at=sdk_resets_at, lane=lane)
         if parked is not None:
             return parked
         reason = limit.as_reason()

--- a/src/teatree/agents/usage_window.py
+++ b/src/teatree/agents/usage_window.py
@@ -30,6 +30,16 @@ from teatree.llm.anthropic_limits import LimitCause, LimitMatch, window_horizon
 
 logger = logging.getLogger(__name__)
 
+#: The subscription causes a mid-run limit can ROTATE off (an account hit its 5h/weekly
+#: window while others may still be healthy). A transient rate limit is lane-wide and
+#: API-credit exhaustion has no rotation, so both stay on the plain lane park.
+_ROTATABLE_SUBSCRIPTION_CAUSES: frozenset[LimitCause] = frozenset(
+    {LimitCause.SUBSCRIPTION_SESSION, LimitCause.SUBSCRIPTION_WEEKLY},
+)
+#: The ``UsageWindowState.cause`` recorded when the WHOLE subscription lane parked because
+#: every account drained — distinct from a single-account cause for audit / notify wording.
+_ALL_EXHAUSTED_CAUSE = "all_accounts_exhausted"
+
 
 def autorecovery_enabled() -> bool:
     """Whether ``limit_autorecovery_enabled`` resolves ON — fail-safe OFF.
@@ -106,6 +116,98 @@ def park_task_on_limit(
         reset.isoformat(),
     )
     return _record_park(task, reason=f"{LIMIT_PARKED_PREFIX}{match.as_reason()}", not_before=reset)
+
+
+def park_or_rotate_on_limit(
+    task: Task, match: LimitMatch, *, sdk_resets_at: int | None, lane: str, now: datetime | None = None
+) -> TaskAttempt | None:
+    """Reactive limit handler: rotate accounts before parking (multi-account #C1), or park.
+
+    On a subscription session/weekly limit, record the CURRENT account exhausted and
+    re-consult the credential selector (routing scope = the task's ticket overlay): if another
+    account is still healthy, REQUEUE the task to rotate onto it (no lane park) so the next
+    dispatch runs on the fresh account; only when every account is exhausted does the whole
+    lane park (auto-resume at the earliest reset). A single unrouted credential, a transient
+    rate limit, or an API-credit cause falls through to :func:`park_task_on_limit` unchanged.
+    ``None`` (→ caller records a terminal FAILED, byte-identical to today) when the flag is OFF
+    or the cause has no time-based recovery.
+    """
+    if not autorecovery_enabled():
+        return None
+    moment = now or timezone.now()
+    reset = effective_resets_at(match.cause, _epoch_to_datetime(sdk_resets_at), moment)
+    if reset is None:
+        return None
+    if lane == TaskAttempt.Lane.SUBSCRIPTION and match.cause in _ROTATABLE_SUBSCRIPTION_CAUSES:
+        scope = task.ticket.overlay or ""  # the overlay the per-account selector routes for
+        rotated = _rotate_or_none(task, match, reset=reset, scope=scope, moment=moment)
+        if rotated is not None:
+            return rotated
+    return park_task_on_limit(task, match, sdk_resets_at=sdk_resets_at, lane=lane, now=moment)
+
+
+def _rotate_or_none(
+    task: Task, match: LimitMatch, *, reset: datetime, scope: str, moment: datetime
+) -> TaskAttempt | None:
+    """Record the current account exhausted + reselect: requeue to rotate, park if all spent, else ``None``.
+
+    ``None`` means nothing was routed (no sticky account), so the caller falls back to the
+    plain lane park. The credential import is call-time so the domain credential factory is
+    only pulled in when a subscription limit actually fires.
+    """
+    from teatree.credential_config import (  # noqa: PLC0415 — call-time import (domain credential factory)
+        AllTokensExhaustedError,
+        record_reactive_exhaustion_and_reselect,
+    )
+
+    weekly = match.cause is LimitCause.SUBSCRIPTION_WEEKLY
+    try:
+        healthy = record_reactive_exhaustion_and_reselect(scope=scope, resets_at=reset, weekly=weekly, now=moment)
+    except AllTokensExhaustedError as exc:
+        return park_task_on_all_exhausted(
+            task, resets_at=exc.earliest_reset or reset, lane=TaskAttempt.Lane.SUBSCRIPTION, now=moment
+        )
+    if healthy is None:
+        return None
+    logger.info("Task %s rotating off an exhausted subscription account to a healthy one", task.pk)
+    return _requeue_for_rotation(task, moment=moment)
+
+
+def _requeue_for_rotation(task: Task, *, moment: datetime) -> TaskAttempt:
+    """Return *task* to the queue immediately (PENDING) so the next dispatch rotates accounts.
+
+    Records the same ``limit_parked:`` audit attempt shape :func:`_record_park` uses (excluded
+    from the repair budget — a rotation is a scheduling event, not a work iteration), then
+    parks with ``not_before`` at *moment* so the task is claimable on the next tick.
+    """
+    reason = f"{LIMIT_PARKED_PREFIX}rotating to a healthy subscription account (an account hit its window)"
+    return _record_park(task, reason=reason, not_before=moment)
+
+
+def park_task_on_all_exhausted(
+    task: Task, *, resets_at: datetime | None, lane: str, now: datetime | None = None
+) -> TaskAttempt | None:
+    """Park *task* behind an ALL-ACCOUNTS-exhausted lane (multi-account #C2) — or ``None``.
+
+    Every configured account is spent, so there is no account to rotate to: park the WHOLE
+    lane keyed on *resets_at* (the earliest reset across accounts) so the existing
+    ``usage_window_recovery`` chain auto-resumes the task when the soonest account frees up — a
+    quiesce, NOT a human escalation. ``None`` (caller records a terminal FAILED, as today) when
+    the flag is OFF or no reset is known (nothing to re-arm to).
+    """
+    if not autorecovery_enabled() or resets_at is None:
+        return None
+    moment = now or timezone.now()
+    UsageWindowState.record_limit(lane=lane, cause=_ALL_EXHAUSTED_CAUSE, resets_at=resets_at, now=moment)
+    _auto_engage_low_power(resets_at, moment)
+    logger.warning(
+        "Task %s parked — all %s accounts exhausted; auto-resume at %s",
+        task.pk,
+        lane or "ambient",
+        resets_at.isoformat(),
+    )
+    reason = f"{LIMIT_PARKED_PREFIX}all configured subscription accounts exhausted — auto-resume at reset"
+    return _record_park(task, reason=reason, not_before=resets_at)
 
 
 def _auto_engage_low_power(reset: datetime, moment: datetime) -> None:

--- a/src/teatree/credential_config.py
+++ b/src/teatree/credential_config.py
@@ -49,6 +49,7 @@ from django.utils import timezone
 from teatree.core.models.anthropic_active_pick import AnthropicActivePick
 from teatree.core.models.anthropic_token_usage import REJECTED_STATUS, AnthropicTokenUsage, TokenHealthReading
 from teatree.core.models.config_setting import GLOBAL_SCOPE, ConfigSetting
+from teatree.llm.anthropic_limits import ALL_TOKENS_EXHAUSTED_SIGNATURE
 from teatree.llm.credentials import (
     AnthropicApiKeyCredential,
     AnthropicSubscriptionCredential,
@@ -101,8 +102,16 @@ class AllTokensExhaustedError(CredentialError):
 
     A :class:`CredentialError` subclass so the existing headless / eval
     ``except CredentialError`` handlers record it as a loud dispatch refusal. The
-    message names the earliest known reset so the operator knows when work can resume.
+    message names the earliest known reset so the operator knows when work can resume;
+    :attr:`earliest_reset` carries the same instant as a datetime so the headless
+    quiesce-and-auto-resume park (multi-account #C2) can key its release on it.
     """
+
+    def __init__(self, message: str, *, earliest_reset: dt.datetime | None = None) -> None:
+        super().__init__(message)
+        #: The soonest an account frees up — the earliest window reset across all exhausted
+        #: accounts, or ``None`` when no reset is known. NOT a token; a schedule instant.
+        self.earliest_reset = earliest_reset
 
 
 class PassPathSelector:
@@ -155,7 +164,7 @@ class PassPathSelector:
         if chosen is None:
             chosen = self._rescue_reprobe(kind, configured, now)
         if chosen is None:
-            raise AllTokensExhaustedError(self._all_exhausted_message(kind))
+            raise self._all_exhausted_error(kind)
 
         AnthropicActivePick.objects.set_pick(kind.value, scope, chosen)
         if fell_back_across_scopes:
@@ -264,16 +273,18 @@ class PassPathSelector:
         return list(seen)
 
     @staticmethod
-    def _all_exhausted_message(kind: TokenKind) -> str:
+    def _all_exhausted_error(kind: TokenKind) -> AllTokensExhaustedError:
         candidates = PassPathSelector._all_configured_paths(kind)
         rows = AnthropicTokenUsage.objects.filter(pass_path__in=candidates)
         resets = [row.earliest_reset for row in rows if row.is_exhausted and row.earliest_reset is not None]
-        when = f" — earliest reset {min(resets).isoformat()}" if resets else ""
+        earliest = min(resets) if resets else None
+        when = f" — earliest reset {earliest.isoformat()}" if earliest is not None else ""
         # Name the candidate accounts so the operator knows exactly which ones to
         # refill/check. A ``pass_path`` is a store path (already persisted, logged in
         # ``select``), never the token value — safe to surface in the loud error.
         accounts = f" (accounts: {', '.join(candidates)})" if candidates else ""
-        return f"all configured Anthropic {kind.value} accounts are exhausted{accounts}{when}"
+        message = f"all configured Anthropic {kind.value} {ALL_TOKENS_EXHAUSTED_SIGNATURE}{accounts}{when}"
+        return AllTokensExhaustedError(message, earliest_reset=earliest)
 
 
 def reading_from(snapshot: RateLimitSnapshot) -> TokenHealthReading:
@@ -320,6 +331,49 @@ def _as_path_list(stored: object) -> list[str]:
 
 
 _SELECTOR = PassPathSelector()
+
+
+def _record_account_exhausted(pass_path: str, *, resets_at: dt.datetime, weekly: bool, now: dt.datetime) -> None:
+    """Cache *pass_path* as exhausted until *resets_at* so the selector routes off it.
+
+    A weekly hit blocks the 7d window, else the 5h one; the verdict is trusted until the
+    reset. Only the ``pass_path`` health verdict is written — the token is never read here.
+    """
+    reading = TokenHealthReading(
+        organization_id="",
+        utilization_5h=0.0 if weekly else 1.0,
+        utilization_7d=1.0 if weekly else 0.0,
+        status_5h="",
+        status_7d=REJECTED_STATUS if weekly else "",
+        reset_5h=None if weekly else resets_at,
+        reset_7d=resets_at if weekly else None,
+    )
+    AnthropicTokenUsage.objects.record(pass_path, reading, now=now)
+
+
+def record_reactive_exhaustion_and_reselect(
+    *, scope: str, resets_at: dt.datetime, weekly: bool, now: dt.datetime | None = None
+) -> str | None:
+    """Record the CURRENT subscription account exhausted after a mid-run limit, then re-select.
+
+    A mid-run 5h/weekly limit is observed by the SDK, NOT the health cache — so without
+    recording it the selector's sticky pick would route the SAME spent account again. This
+    marks the sticky OAuth account for *scope* exhausted (its ``resets_at`` cached so the
+    verdict is trusted until the window re-arms) and re-consults the selector:
+
+    * returns the next healthy account's ``pass_path`` — another account is available, so the
+        caller REQUEUES the task to rotate onto it rather than parking the whole lane;
+    * raises :class:`AllTokensExhaustedError` (carrying the earliest reset) when every account
+        is now exhausted, so the caller parks the lane for auto-resume at the soonest reset;
+    * returns ``None`` when nothing is routed (no sticky account — an ambient-env or single
+        unrouted credential), so the caller falls back to the existing lane park unchanged.
+    """
+    moment = now or timezone.now()
+    current = AnthropicActivePick.objects.pick_for(TokenKind.OAUTH.value, scope)
+    if current is None:
+        return None
+    _record_account_exhausted(current, resets_at=resets_at, weekly=weekly, now=moment)
+    return _SELECTOR.select(TokenKind.OAUTH, scope)
 
 
 def resolve_subscription_credential(*, scope: str = GLOBAL_SCOPE) -> AnthropicSubscriptionCredential:

--- a/src/teatree/llm/anthropic_limits.py
+++ b/src/teatree/llm/anthropic_limits.py
@@ -139,6 +139,14 @@ RECOVERABLE_EXHAUSTION_CAUSES: frozenset[LimitCause] = frozenset(
     {LimitCause.SUBSCRIPTION_SESSION, LimitCause.SUBSCRIPTION_WEEKLY, LimitCause.RATE_LIMIT},
 )
 
+#: The stable signature substring an all-accounts-exhausted failure carries, SHARED by the
+#: selector that BUILDS the message (``teatree.credential_config``'s ``AllTokensExhaustedError``)
+#: and the recoverable-cause reader HERE, so the two can never drift. A task that landed FAILED
+#: with EVERY configured account drained (auto-recovery on but not parked — e.g. the flag flipped
+#: mid-run, or a non-parking lane) is window-recoverable, NOT a defect: it is auto-requeued once
+#: capacity returns rather than escalated to a human as a failure.
+ALL_TOKENS_EXHAUSTED_SIGNATURE = "accounts are exhausted"
+
 
 def recoverable_exhaustion_cause(error: str) -> LimitCause | None:
     """The time-recoverable exhaustion cause a FAILED attempt's *error* names, or ``None``.
@@ -147,11 +155,18 @@ def recoverable_exhaustion_cause(error: str) -> LimitCause | None:
     (:meth:`LimitMatch.as_reason`), so the token before the first ``:`` is the machine
     cause marker. This maps that marker back to its :class:`LimitCause`, but ONLY for a
     cause with a time-based window reset (session / weekly / transient rate limit) — the
-    signal the idle auto-requeue (#3407) keys on. Returns ``None`` for any non-limit error
-    AND for API-credit exhaustion (no timed recovery), so only a genuinely
-    window-recoverable failure is ever auto-requeued; the rest stay on their existing path.
+    signal the idle auto-requeue (#3407) keys on. An all-accounts-exhausted failure
+    (:data:`ALL_TOKENS_EXHAUSTED_SIGNATURE`) is treated as the WEEKLY cause — the safe upper
+    bound on when an account frees up — so a drained-lane task auto-requeues instead of
+    escalating. Returns ``None`` for any non-limit error AND for API-credit exhaustion (no
+    timed recovery), so only a genuinely window-recoverable failure is ever auto-requeued;
+    the rest stay on their existing path.
     """
-    if not error or ":" not in error:
+    if not error:
+        return None
+    if ALL_TOKENS_EXHAUSTED_SIGNATURE in error.casefold():
+        return LimitCause.SUBSCRIPTION_WEEKLY
+    if ":" not in error:
         return None
     marker = error.split(":", 1)[0].strip().casefold()
     for cause in RECOVERABLE_EXHAUSTION_CAUSES:

--- a/tests/teatree_agents/test_headless.py
+++ b/tests/teatree_agents/test_headless.py
@@ -471,6 +471,80 @@ class TestRunHeadlessTypedRateLimitWindow(TestCase):
         assert "seven_day_sonnet" in attempt.error
 
 
+class TestRunHeadlessAllAccountsExhausted(TestCase):
+    """Multi-account #C2: with EVERY subscription account drained, a dispatch QUIESCES.
+
+    Pre-dispatch the credential selector raises ``AllTokensExhaustedError``; the headless
+    runner must PARK the task (auto-resume at the earliest reset) rather than record a
+    terminal FAILED that a human is later pinged about. Flag-off is byte-identical to today
+    (the drained lane still records a loud FAILED).
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.ticket = Ticket.objects.create()
+
+    def _seed_exhausted(self, pass_path: str, *, reset: Any) -> None:
+        from teatree.core.models import AnthropicTokenUsage  # noqa: PLC0415 — test-local
+        from teatree.core.models.anthropic_token_usage import REJECTED_STATUS, TokenHealthReading  # noqa: PLC0415
+
+        AnthropicTokenUsage.objects.record(
+            pass_path,
+            TokenHealthReading(
+                organization_id="org-1",
+                utilization_5h=0.1,
+                utilization_7d=1.0,
+                status_5h="allowed",
+                status_7d=REJECTED_STATUS,
+                reset_5h=None,
+                reset_7d=reset,
+            ),
+        )
+
+    def _configure_three_exhausted_accounts(self) -> Any:
+        from datetime import timedelta  # noqa: PLC0415 — test-local
+
+        from django.utils import timezone  # noqa: PLC0415 — test-local
+
+        ConfigSetting.objects.set_value("agent_harness_provider", "subscription_oauth")
+        ConfigSetting.objects.set_value("anthropic_oauth_pass_paths", ["acct/1/oauth", "acct/2/oauth", "acct/3/oauth"])
+        earliest = timezone.now() + timedelta(hours=1)
+        self._seed_exhausted("acct/1/oauth", reset=timezone.now() + timedelta(hours=4))
+        self._seed_exhausted("acct/2/oauth", reset=earliest)  # the soonest to free up
+        self._seed_exhausted("acct/3/oauth", reset=timezone.now() + timedelta(hours=3))
+        return earliest
+
+    def test_all_exhausted_parks_and_auto_resumes_not_failed(self) -> None:
+        from teatree.core.models import UsageWindowState  # noqa: PLC0415 — test-local
+
+        ConfigSetting.objects.set_value("limit_autorecovery_enabled", value=True)
+        earliest = self._configure_three_exhausted_accounts()
+        with _fake_sdk([]):  # the run parks pre-dispatch; the SDK is never opened
+            session = Session.objects.create(ticket=self.ticket)
+            task = Task.objects.create(ticket=self.ticket, session=session)
+            attempt = run_headless(task, phase="coding", overlay_skill_metadata={})
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING, "PARKED for auto-resume, NOT terminal FAILED"
+        assert task.not_before == earliest, "parked until the earliest account frees up"
+        assert attempt.error.startswith("limit_parked: ")
+        window = UsageWindowState.objects.active_for_lane(TaskAttempt.Lane.SUBSCRIPTION)
+        assert window is not None
+        assert window.resets_at == earliest
+
+    def test_flag_off_records_the_terminal_failed_as_today(self) -> None:
+        ConfigSetting.objects.set_value("limit_autorecovery_enabled", value=False)
+        self._configure_three_exhausted_accounts()
+        with _fake_sdk([]):
+            session = Session.objects.create(ticket=self.ticket)
+            task = Task.objects.create(ticket=self.ticket, session=session)
+            attempt = run_headless(task, phase="coding", overlay_skill_metadata={})
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED, "flag off → byte-identical to today (loud FAILED)"
+        assert "exhausted" in attempt.error
+
+
 def test_limit_match_prefers_the_typed_window_over_the_result_text() -> None:
     # The result text names no limit phrase; the rejected typed window is the only
     # signal, so _limit_match classifies WEEKLY from it (the fallback would be None).

--- a/tests/teatree_agents/test_usage_window.py
+++ b/tests/teatree_agents/test_usage_window.py
@@ -12,8 +12,24 @@ import django.test
 from django.utils import timezone
 
 import teatree.agents.usage_window as usage_window_mod
-from teatree.agents.usage_window import effective_resets_at, maybe_park_for_active_window, park_task_on_limit
-from teatree.core.models import LIMIT_PARKED_PREFIX, Session, Task, TaskAttempt, Ticket, UsageWindowState
+from teatree.agents.usage_window import (
+    effective_resets_at,
+    maybe_park_for_active_window,
+    park_or_rotate_on_limit,
+    park_task_on_all_exhausted,
+    park_task_on_limit,
+)
+from teatree.core.models import (
+    LIMIT_PARKED_PREFIX,
+    AnthropicActivePick,
+    AnthropicTokenUsage,
+    Session,
+    Task,
+    TaskAttempt,
+    Ticket,
+    UsageWindowState,
+)
+from teatree.core.models.anthropic_token_usage import REJECTED_STATUS, TokenHealthReading
 from teatree.core.models.config_setting import ConfigSetting
 from teatree.llm.anthropic_limits import LimitCause, LimitMatch
 
@@ -45,7 +61,45 @@ def _claimed_task() -> Task:
 
 
 _SESSION_MATCH = LimitMatch(phrase="five_hour", cause=LimitCause.SUBSCRIPTION_SESSION)
+_WEEKLY_MATCH = LimitMatch(phrase="seven_day", cause=LimitCause.SUBSCRIPTION_WEEKLY)
 _CREDIT_MATCH = LimitMatch(phrase="out_of_credits", cause=LimitCause.API_CREDIT)
+_RATE_LIMIT_MATCH = LimitMatch(phrase="rate limit", cause=LimitCause.RATE_LIMIT)
+
+_OAUTH_SETTING = "anthropic_oauth_pass_paths"
+
+
+def _seed_healthy(pass_path: str) -> None:
+    """Cache *pass_path* as a fresh, healthy account so the selector routes to it with no probe."""
+    AnthropicTokenUsage.objects.record(
+        pass_path,
+        TokenHealthReading(
+            organization_id="org-1",
+            utilization_5h=0.1,
+            utilization_7d=0.1,
+            status_5h="allowed",
+            status_7d="allowed",
+            reset_5h=None,
+            reset_7d=None,
+        ),
+        now=timezone.now(),
+    )
+
+
+def _seed_exhausted(pass_path: str, *, reset: datetime) -> None:
+    """Cache *pass_path* as a fresh, exhausted account (7d rejected until *reset*)."""
+    AnthropicTokenUsage.objects.record(
+        pass_path,
+        TokenHealthReading(
+            organization_id="org-1",
+            utilization_5h=0.1,
+            utilization_7d=1.0,
+            status_5h="allowed",
+            status_7d=REJECTED_STATUS,
+            reset_5h=None,
+            reset_7d=reset,
+        ),
+        now=timezone.now(),
+    )
 
 
 class TestEffectiveResetsAt(django.test.SimpleTestCase):
@@ -208,3 +262,169 @@ class TestAdmissionGuard(django.test.TestCase):
         )
         task = _claimed_task()
         assert maybe_park_for_active_window(task, lane=TaskAttempt.Lane.SUBSCRIPTION, now=now) is None
+
+
+class TestParkOrRotateOnLimit(django.test.TestCase):
+    """Multi-account #C1: a mid-run subscription limit ROTATES to a healthy account before parking.
+
+    One account hitting its 5h/weekly window must NOT park the whole subscription lane while
+    other accounts are healthy — that stranded the healthy accounts. The reactive handler
+    records the current account exhausted and re-consults the selector: another healthy account
+    → REQUEUE (rotate, no lane park); every account spent → park the lane for auto-resume.
+    """
+
+    def setUp(self) -> None:
+        _set_autorecovery(on=True)
+
+    def test_rotates_to_a_healthy_account_without_parking_the_lane(self) -> None:
+        # account-1 hit its 5h limit mid-run; account-2 is healthy → the next dispatch must
+        # route to account-2 and NO usage-window (lane park) is recorded.
+        now = timezone.now()
+        reset = now + timedelta(hours=3)
+        ConfigSetting.objects.set_value(_OAUTH_SETTING, ["acct/1/oauth", "acct/2/oauth", "acct/3/oauth"])
+        AnthropicActivePick.objects.set_pick("oauth", "", "acct/1/oauth")  # the account that hit the limit
+        _seed_healthy("acct/2/oauth")
+        task = _claimed_task()
+
+        parked = park_or_rotate_on_limit(
+            task,
+            _SESSION_MATCH,
+            sdk_resets_at=int(reset.timestamp()),
+            lane=TaskAttempt.Lane.SUBSCRIPTION,
+            now=now,
+        )
+
+        assert parked is not None, "the task is requeued (an audit attempt is recorded), never failed"
+        assert parked.error.startswith(LIMIT_PARKED_PREFIX)
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING, "requeued to rotate, NOT terminal FAILED"
+        assert task.not_before is not None
+        assert task.not_before <= now, "claimable immediately on the next tick"
+        assert not UsageWindowState.objects.exists(), "no lane park while a healthy account remains — C1"
+        assert AnthropicActivePick.objects.pick_for("oauth", "") == "acct/2/oauth", "the sticky pick rotated"
+        exhausted = AnthropicTokenUsage.objects.get(pass_path="acct/1/oauth")
+        assert exhausted.is_exhausted, "the spent account is recorded exhausted so the selector routes off it"
+
+    def test_all_accounts_exhausted_parks_the_lane_keyed_on_earliest_reset(self) -> None:
+        # account-1 hits its limit and the other accounts are ALREADY exhausted → there is no
+        # account to rotate to, so the whole lane parks (auto-resume at the earliest reset).
+        now = timezone.now()
+        soon = now + timedelta(hours=1)
+        later = now + timedelta(hours=4)
+        ConfigSetting.objects.set_value(_OAUTH_SETTING, ["acct/1/oauth", "acct/2/oauth"])
+        AnthropicActivePick.objects.set_pick("oauth", "", "acct/1/oauth")
+        _seed_exhausted("acct/2/oauth", reset=soon)
+        task = _claimed_task()
+
+        parked = park_or_rotate_on_limit(
+            task,
+            _WEEKLY_MATCH,
+            sdk_resets_at=int(later.timestamp()),  # account-1's own reset — later than account-2's
+            lane=TaskAttempt.Lane.SUBSCRIPTION,
+            now=now,
+        )
+
+        assert parked is not None
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING, "parked, not FAILED"
+        window = UsageWindowState.objects.active_for_lane(TaskAttempt.Lane.SUBSCRIPTION)
+        assert window is not None, "all accounts spent → the whole lane parks"
+        # parked until the EARLIEST account frees up, not account-1's later reset
+        assert window.resets_at == soon
+        assert task.not_before == soon
+
+    def test_single_account_still_parks_the_lane_as_today(self) -> None:
+        # No regression for the single-account deployment: its only account hitting the limit
+        # has nowhere to rotate, so it parks the lane exactly like the pre-rotation behaviour.
+        now = timezone.now()
+        reset = (now + timedelta(hours=5)).replace(microsecond=0)  # epoch round-trips whole seconds
+        ConfigSetting.objects.set_value(_OAUTH_SETTING, ["only/oauth"])
+        AnthropicActivePick.objects.set_pick("oauth", "", "only/oauth")
+        task = _claimed_task()
+
+        parked = park_or_rotate_on_limit(
+            task,
+            _SESSION_MATCH,
+            sdk_resets_at=int(reset.timestamp()),
+            lane=TaskAttempt.Lane.SUBSCRIPTION,
+            now=now,
+        )
+
+        assert parked is not None
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING
+        assert task.not_before == reset
+        window = UsageWindowState.objects.active_for_lane(TaskAttempt.Lane.SUBSCRIPTION)
+        assert window is not None
+        assert window.resets_at == reset
+
+    def test_transient_rate_limit_parks_the_lane_without_rotating(self) -> None:
+        # A transient 429 is lane-wide, not account-specific — it parks the lane (5-min horizon)
+        # and never consults the per-account selector, so no account is marked exhausted.
+        now = timezone.now()
+        ConfigSetting.objects.set_value(_OAUTH_SETTING, ["acct/1/oauth", "acct/2/oauth"])
+        AnthropicActivePick.objects.set_pick("oauth", "", "acct/1/oauth")
+        task = _claimed_task()
+
+        parked = park_or_rotate_on_limit(
+            task, _RATE_LIMIT_MATCH, sdk_resets_at=None, lane=TaskAttempt.Lane.SUBSCRIPTION, now=now
+        )
+
+        assert parked is not None
+        window = UsageWindowState.objects.active_for_lane(TaskAttempt.Lane.SUBSCRIPTION)
+        assert window is not None
+        assert window.cause == LimitCause.RATE_LIMIT.value
+        # no account rotation for a lane-wide 429
+        assert not AnthropicTokenUsage.objects.filter(pass_path="acct/1/oauth").exists()
+
+    def test_inert_when_flag_off(self) -> None:
+        _set_autorecovery(on=False)
+        now = timezone.now()
+        ConfigSetting.objects.set_value(_OAUTH_SETTING, ["acct/1/oauth", "acct/2/oauth"])
+        AnthropicActivePick.objects.set_pick("oauth", "", "acct/1/oauth")
+        task = _claimed_task()
+        assert (
+            park_or_rotate_on_limit(
+                task,
+                _SESSION_MATCH,
+                sdk_resets_at=int((now + timedelta(hours=3)).timestamp()),
+                lane=TaskAttempt.Lane.SUBSCRIPTION,
+                now=now,
+            )
+            is None
+        ), "flag off → caller records the terminal FAILED, byte-identical to today"
+        assert not UsageWindowState.objects.exists()
+        assert not AnthropicTokenUsage.objects.exists()
+
+
+class TestParkTaskOnAllExhausted(django.test.TestCase):
+    """Multi-account #C2: every account drained → PARK the lane for auto-resume, never a human ping."""
+
+    def test_parks_the_lane_keyed_on_the_earliest_reset(self) -> None:
+        _set_autorecovery(on=True)
+        now = timezone.now()
+        reset = now + timedelta(hours=2)
+        task = _claimed_task()
+        parked = park_task_on_all_exhausted(task, resets_at=reset, lane=TaskAttempt.Lane.SUBSCRIPTION, now=now)
+        assert parked is not None
+        assert parked.error.startswith(LIMIT_PARKED_PREFIX)
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING, "PARKED, not FAILED — no human escalation"
+        assert task.not_before == reset
+        window = UsageWindowState.objects.active_for_lane(TaskAttempt.Lane.SUBSCRIPTION)
+        assert window is not None
+        assert window.resets_at == reset
+
+    def test_inert_when_flag_off(self) -> None:
+        _set_autorecovery(on=False)
+        task = _claimed_task()
+        assert (
+            park_task_on_all_exhausted(task, resets_at=timezone.now() + timedelta(hours=1), lane="subscription") is None
+        )
+        assert not UsageWindowState.objects.exists()
+
+    def test_no_reset_is_not_parked(self) -> None:
+        _set_autorecovery(on=True)
+        task = _claimed_task()
+        assert park_task_on_all_exhausted(task, resets_at=None, lane="subscription") is None
+        assert not UsageWindowState.objects.exists()

--- a/tests/teatree_llm/test_anthropic_limits.py
+++ b/tests/teatree_llm/test_anthropic_limits.py
@@ -6,6 +6,7 @@ import pytest
 from claude_agent_sdk.types import RateLimitType
 
 from teatree.llm.anthropic_limits import (
+    ALL_TOKENS_EXHAUSTED_SIGNATURE,
     LimitCause,
     LimitMatch,
     classify_limit,
@@ -161,3 +162,8 @@ class TestRecoverableExhaustionCause:
         assert recoverable_exhaustion_cause("AssertionError: expected 3 got 4") is None
         assert recoverable_exhaustion_cause("outage_death: connection refused") is None
         assert recoverable_exhaustion_cause("") is None
+
+    def test_all_accounts_exhausted_is_window_recoverable_not_a_human_escalation(self) -> None:
+        # A FAILED task with every configured account drained must auto-requeue, never escalate.
+        error = f"all configured Anthropic oauth {ALL_TOKENS_EXHAUSTED_SIGNATURE} (accounts a, b)"
+        assert recoverable_exhaustion_cause(error) is LimitCause.SUBSCRIPTION_WEEKLY

--- a/tests/teatree_loops/test_usage_window_recovery.py
+++ b/tests/teatree_loops/test_usage_window_recovery.py
@@ -115,6 +115,29 @@ class TestReArmsOnlyAfterReset(django.test.TestCase):
         recover_windows(reset)
         assert BotPing.objects.filter(idempotency_key__startswith="usage_window_recovered:").exists()
 
+    def test_all_accounts_exhausted_park_auto_resumes_at_reset(self) -> None:
+        # A task parked because every configured account drained must auto-resume at its reset.
+        from teatree.agents.usage_window import park_task_on_all_exhausted  # noqa: PLC0415 — test-local
+
+        _set_autorecovery(on=True)
+        now = timezone.now()
+        reset = now + timedelta(hours=2)
+        task = _parked_task(not_before=now)  # placeholder; the park below sets the real gate
+        Task.objects.filter(pk=task.pk).update(status=Task.Status.CLAIMED, not_before=None)
+        task.refresh_from_db()
+
+        parked = park_task_on_all_exhausted(task, resets_at=reset, lane=TaskAttempt.Lane.SUBSCRIPTION, now=now)
+        assert parked is not None
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING
+        assert task.not_before == reset
+
+        assert recover_windows(now + timedelta(hours=1)).released == 0, "still parked before the reset"
+        outcome = recover_windows(reset)
+        assert outcome.released == 1
+        task.refresh_from_db()
+        assert task.not_before is None, "auto-resumed at the reset — claimable again"
+
     def test_credit_window_is_never_auto_cleared(self) -> None:
         # A null-reset (API-credit) window has no time-based recovery — never cleared here.
         now = timezone.now()

--- a/tests/test_credential_config.py
+++ b/tests/test_credential_config.py
@@ -208,6 +208,7 @@ class TestSelectorRouting(TestCase):
         message = str(caught.value)
         assert "exhausted" in message
         assert soon.isoformat() in message, "the loud error names the soonest an account frees up"
+        assert caught.value.earliest_reset == soon, "the earliest reset is carried as a datetime for the C2 park"
 
 
 class TestSelectorRescueReprobe(TestCase):


### PR DESCRIPTION
## What

Phase-1 code fixes so multi-account Anthropic exhaustion **rotates then quiesces** correctly (config already set live: `anthropic_oauth_pass_paths` = 3 accounts, `agent_harness_provider=subscription_oauth`). Both fixes are behind `limit_autorecovery_enabled` (default **off**).

### C1 — rotate before parking
When one subscription account hit its 5h/weekly window mid-run, `park_task_on_limit` parked the whole subscription **lane**, and the admission guard then parked every subsequent subscription dispatch — stranding the other healthy accounts.

Now `_outcome_failure` routes a reactive subscription limit through `park_or_rotate_on_limit`: it records the **current** account exhausted in `AnthropicTokenUsage` (with its `resets_at`) and re-consults the selector. If another account is healthy → the task is **requeued** (no lane park) so the next dispatch rotates to it. Only when the selector reports all accounts exhausted does the lane park. A transient 429, an API-credit cause, or a single unrouted credential falls through to the original lane park unchanged.

### C2 — all-exhausted → quiesce + auto-resume (not human escalation)
`AllTokensExhaustedError` is now caught **distinctly** in the headless credential-resolution path and routed to a `park_task_on_all_exhausted` park keyed on `AllTokensExhaustedError.earliest_reset` (the earliest reset across accounts, now carried on the error as a datetime). The existing `usage_window_recovery` chain auto-resumes at reset. `recoverable_exhaustion_cause` also recognises the all-exhausted signature (`ALL_TOKENS_EXHAUSTED_SIGNATURE`, shared with the selector) so a drained-lane FAILED task is auto-requeued, never escalated to a `DeferredQuestion`.

Net: all accounts drained → tasks **PARK** (not FAIL, not human-ping) → auto-resume when the earliest account's window resets. Flag-off is byte-identical to today.

## Token security
No token is ever logged or returned — only `pass_path` + parsed health persist; the token stays env-pipe only.

## RED-first test evidence
All new tests were observed **RED against pre-fix `src`** (stash-verified), then GREEN:

- `TestParkOrRotateOnLimit::test_rotates_to_a_healthy_account_without_parking_the_lane` — account-1 hits 5h limit → sticky rotates to account-2, no `UsageWindowState`. Pre-fix: ImportError (function absent).
- `TestRunHeadlessAllAccountsExhausted::test_all_exhausted_parks_and_auto_resumes_not_failed` — 3 exhausted → task PARKED (not FAILED) keyed on earliest reset. Pre-fix RED: `AssertionError: PARKED for auto-resume, NOT terminal FAILED`.
- `test_all_accounts_exhausted_park_auto_resumes_at_reset` — `usage_window_recovery.recover_windows` releases the parked task at reset.
- `TestParkOrRotateOnLimit::test_single_account_still_parks_the_lane_as_today` — single-account no regression.
- `test_all_accounts_exhausted_is_window_recoverable_not_a_human_escalation` — `recoverable_exhaustion_cause` → `SUBSCRIPTION_WEEKLY` (never escalates).
- `test_all_accounts_exhausted_raises_naming_the_earliest_reset` — pre-fix RED: `AttributeError: no attribute 'earliest_reset'`.

## Gates (local)
`242 passed` across the touched agents/usage_window/credential/limits/recovery/transient_requeue tests (and again under `--randomly-seed=7`). Clean: `ruff check` + `ruff format`, `makemigrations --check` (no changes), module-health (exit 0), test-path-mirror (ledger holds), `tach check`, `import-linter` (3 contracts kept). `tests/conformance`/`tests/quality` could not complete locally due to a host `/tmp` tmpfs quota exhaustion (environment, unrelated to this diff) — CI will run them.

Do not merge — draft for owner draft-check + merge; flag flip on the box after verification.