### PR TITLE
fix(doctor,watchdog): collapse overdue-timer alarm + stop hourly re-DM spam (Phase 3)

### DIFF
--- a/deploy/watchdog.sh
+++ b/deploy/watchdog.sh
@@ -113,12 +113,17 @@ run_doctor() {
   return 125
 }
 
+# The three hard-outage alarms below key on a DAILY bucket (`%Y%m%d`), not an
+# hourly one: `notify_user` dedups on the key, so an hourly bucket re-DM'd the
+# identical "stack down" alarm every hour (13+ overnight copies observed). A
+# daily bucket collapses a persisting unchanged outage to at most one DM/day
+# while still re-alerting each day it persists and on a next-day recurrence.
 run_pass() {
   log "restarting any down services (gated on init state)"
   if ! restart_down_services; then
     # The stack could not even be brought up — the strongest outage signal.
     printf 'teatree watchdog: `docker compose up -d` FAILED on the box — the stack is DOWN and could not be restarted. SSH in and inspect `docker compose -p %s logs`.' "$PROJECT" \
-      | notify_owner "watchdog:compose-up-failed:$(date -u +%Y%m%d%H)"
+      | notify_owner "watchdog:compose-up-failed:$(date -u +%Y%m%d)"
     return 0
   fi
 
@@ -127,7 +132,7 @@ run_pass() {
     # ONLY case that is truly "unreachable" (distinct from doctor running and
     # returning a red verdict, which is handled below).
     printf 'teatree watchdog: could not exec `t3 doctor` in any service (%s) — the stack is unreachable even after `up -d`. SSH in and inspect `docker compose -p %s ps`.' "$EXEC_SERVICES" "$PROJECT" \
-      | notify_owner "watchdog:doctor-unreachable:$(date -u +%Y%m%d%H)"
+      | notify_owner "watchdog:doctor-unreachable:$(date -u +%Y%m%d)"
     return 0
   fi
 
@@ -140,10 +145,10 @@ run_pass() {
   if [ -z "$json" ]; then
     # Doctor was reachable but emitted no parseable verdict: a half-crashed doctor
     # is itself a RED condition, not a healthy pass (the old code treated it as
-    # healthy and stayed silent). DM once per hour so a persistent breakage is seen.
+    # healthy and stayed silent). DM at most once per day so a persistent breakage is seen.
     log "doctor reachable but produced no JSON verdict — treating as RED"
     printf 'teatree watchdog: `t3 doctor check --json` ran but produced NO parseable verdict — doctor may be crashing on the box. SSH in and run `t3 doctor check` in `docker compose -p %s exec teatree-admin`.' "$PROJECT" \
-      | notify_owner "watchdog:doctor-no-verdict:$(date -u +%Y%m%d%H)"
+      | notify_owner "watchdog:doctor-no-verdict:$(date -u +%Y%m%d)"
     return 0
   fi
 

--- a/src/teatree/cli/doctor/self_heal.py
+++ b/src/teatree/cli/doctor/self_heal.py
@@ -350,11 +350,22 @@ def _check_stale_loop_timer() -> bool:
         return True
     if not overdue:
         return True
-    for name, run_after, threshold in overdue:
+    # Collapse to ONE FAIL summary keyed on the SET of overdue timers (sorted
+    # names, no timestamps): the watchdog RED body-hash keys on FAIL messages, so
+    # a volatile ``run_after`` in the summary would churn the hash and re-DM the
+    # whole bundle every pass even when the set is unchanged (#slack-comms). The
+    # per-timer ``run_after`` detail goes on non-FAIL lines — visible in
+    # ``t3 doctor``, excluded from the dedup body.
+    names = sorted(name for name, _run_after, _threshold in overdue)
+    typer.echo(
+        f"FAIL  {len(names)} loop timer(s) READY but overdue past 2x cadence: "
+        f"{', '.join(names)}. The drain is stalled; check the worker "
+        f"(`t3 worker ensure` / worker logs)."
+    )
+    for name, run_after, threshold in sorted(overdue):
         typer.echo(
-            f"FAIL  Loop timer {name!r} is READY but overdue — due {run_after.isoformat()}, past "
-            f"2x its {threshold // _STALE_TIMER_CADENCE_MULTIPLIER}s cadence. The drain is stalled; "
-            f"check the worker (`t3 worker ensure` / worker logs)."
+            f"INFO    {name}: due {run_after.isoformat()}, past 2x its "
+            f"{threshold // _STALE_TIMER_CADENCE_MULTIPLIER}s cadence."
         )
     return False
 

--- a/tests/teatree_cli/doctor/test_self_heal.py
+++ b/tests/teatree_cli/doctor/test_self_heal.py
@@ -133,6 +133,38 @@ class LoopWorkerAliveCheckTest(TestCase):
         assert "WARN" in out
 
 
+class StaleLoopTimerCollapseTest(TestCase):
+    """Overdue timers collapse to one timestamp-free FAIL summary (#slack-comms Phase 3)."""
+
+    def test_many_overdue_timers_render_one_fail_line(self) -> None:
+        overdue = [
+            ("inbox", timezone.now() - dt.timedelta(hours=1), 600),
+            ("ship", timezone.now() - dt.timedelta(hours=2), 600),
+            ("review", timezone.now() - dt.timedelta(hours=3), 600),
+        ]
+        with mock.patch(f"{_MOD}._Probe.overdue_ready_timers", return_value=overdue):
+            ok, out = _echoes(self_heal._check_stale_loop_timer)
+        assert ok is False
+        fail_lines = [ln for ln in out.splitlines() if ln.startswith("FAIL")]
+        assert len(fail_lines) == 1
+        # the set of names is named on the one summary line
+        for name in ("inbox", "review", "ship"):
+            assert name in fail_lines[0]
+
+    def test_fail_summary_has_no_volatile_timestamp(self) -> None:
+        # The watchdog RED body-hash keys on FAIL messages; an isoformat timestamp
+        # there would churn the key every pass. Timestamps live on non-FAIL detail.
+        run_after = timezone.now() - dt.timedelta(hours=5)
+        overdue = [("inbox", run_after, 600)]
+        with mock.patch(f"{_MOD}._Probe.overdue_ready_timers", return_value=overdue):
+            _ok, out = _echoes(self_heal._check_stale_loop_timer)
+        fail_lines = [ln for ln in out.splitlines() if ln.startswith("FAIL")]
+        assert fail_lines
+        assert run_after.isoformat() not in fail_lines[0]
+        # the timestamp detail is still surfaced (on a non-FAIL line)
+        assert run_after.isoformat() in out
+
+
 class StrandedHeadlessCheckTest(TestCase):
     def test_running_headless_with_free_flock_fails(self) -> None:
         stranded = [("501", timezone.now() - dt.timedelta(hours=2))]


### PR DESCRIPTION
## Problem (Fable design, Behavior 3 — owner feed pollution)

- **6× re-alerts + 9-line dumps.** `self_heal._check_stale_loop_timer` emitted one `FAIL` line **per** overdue timer, each embedding `run_after.isoformat()`. The watchdog RED alarm keys its idempotency on the concatenated FAIL messages, so a shifting timestamp churned the body-hash and re-DM'd the **whole** doctor bundle (including the unchanged "11 failed tickets" list) on every pass — observed 6× in 90 min. One line per timer also produced the "9 loop-timer-overdue lines in a single message" wall.
- **13× hourly re-alarms.** `deploy/watchdog.sh` keyed three hard-outage alarms on an **hourly** bucket (`date -u +%Y%m%d%H`). `notify_user` dedups on the key, so an hourly bucket is a fresh key every hour → the identical "stack down / doctor unreachable" alarm re-DM'd hourly (13+ overnight copies).

## Fix (Phase 3, surgical)

- **Collapse + de-timestamp the overdue-timer FAIL.** One timestamp-free `FAIL` summary keyed on the **sorted set** of overdue timer names (stable while the set is unchanged; re-alerts only on membership change). Per-timer `run_after` detail moves to non-`FAIL` lines — still visible in `t3 doctor`, excluded from the watchdog dedup body. This stabilizes the RED body-hash and collapses the dump.
- **Daily, not hourly, outage bucket.** The three hard-outage alarms key on `%Y%m%d` — at most one DM/day for a persisting unchanged outage (down 24×), still re-alerting each day and on a next-day recurrence.

## Tests (RED-first)

`StaleLoopTimerCollapseTest`: many overdue timers → exactly one `FAIL` line naming the set; the `FAIL` summary carries no `isoformat` timestamp while the detail is still surfaced.

## Scope

These are the surgical fixes for the **observed** symptoms. The full Fable Phase 3 build — a reusable `notify_finding(check_id, entities, …)` helper with finding-identity dedup, a 1h→3h→12h→daily escalation ledger over `BotPing`, one-line "✓ resolved" on clear, and a `t3 … notify finding` command that `watchdog.sh` calls instead of hand-rolled keys — is the remaining Phase-3 work and is intentionally not in this PR.
