### PR TITLE
test(slack-comms): owner-answer availability-independence + threading invariants (Phase 4)

### DIFF
--- a/src/teatree/agents/attempt_recorder.py
+++ b/src/teatree/agents/attempt_recorder.py
@@ -444,19 +444,30 @@ def _maybe_record_triage_recommendations(task: Task, result: AgentResultBlob, *,
 
 
 def _maybe_record_answer_draft(task: Task, result: AgentResultBlob, *, phase: str) -> None:
-    """Route an answering agent's returned ``answer`` draft to the approval path (corr-11, #9).
+    """Deliver an answering agent's returned ``answer`` draft (corr-11, #9).
 
-    The shell-denied answerer cannot post on the user's behalf, so it hands the
-    draft back: this records a :class:`DeferredQuestion` (correlated to the task
-    via ``parked_task``) asking the user to approve the reply — the orchestrator
-    posts on confirmation. A non-answering phase or a result with no ``answer``
-    text is a no-op.
+    A reply to the OWNER's own inbound DM (an answering task the reactive
+    Slack-answer cycle delegated, carrying its ``slack_answer`` context on the
+    ticket) is SENT immediately, threaded under the owner's message — answering
+    the owner is never a post *on the owner's behalf*, so it must never route
+    through the away/approval defer gate that parks the box's self-initiated
+    questions. Deferring the owner's own reply is exactly the bug where an owner
+    DM in ``autonomous_away`` got a "Approve this drafted reply?" pending
+    question parked instead of an answer.
+
+    Any other answering task (a colleague/channel thread the agent answers on
+    the user's behalf) still hands the draft back through a
+    :class:`DeferredQuestion` (correlated via ``parked_task``) for approval —
+    that on-behalf gate is unchanged. A non-answering phase or a result with no
+    ``answer`` text is a no-op.
     """
     if normalize_phase(phase or task.phase) != _ANSWERING_PHASE:
         return
     raw_answer = result.get("answer")
     text = answer_text(raw_answer)
     if not text:
+        return
+    if _post_owner_dm_reply(task, text):
         return
     answer = cast("AnswerEnvelope", raw_answer)
     thread_ref = str(answer.get("thread_ref") or "").strip()
@@ -466,6 +477,46 @@ def _maybe_record_answer_draft(task: Task, result: AgentResultBlob, *, phase: st
         session_id=task.claimed_by_session or "",
         parked_task=task,
     )
+
+
+def _post_owner_dm_reply(task: Task, text: str) -> bool:
+    """Send *text* as a threaded reply to the owner's inbound DM; ``True`` if sent.
+
+    The reactive Slack-answer cycle stamps the authoritative Slack coordinates
+    onto the delegated ticket as ``extra["slack_answer"]`` — ``channel`` and the
+    owner-message ``slack_ts``. Posting with ``ts=slack_ts`` threads the reply
+    under the owner's own message (a top-level DM roots on its own ts), so the
+    answer lands in the owner's thread, not as a new root or under a stale DM
+    cache. The ticket's ``slack_ts`` is the authoritative thread target — the
+    agent-returned ``thread_ref`` is advisory and may be blank or wrong.
+
+    Returns ``False`` (so the caller falls back to the on-behalf approval path,
+    losing nothing) when the ticket carries no ``slack_answer`` context, the
+    coordinates are incomplete, no messaging backend resolves, or the post does
+    not confirm ``ok``. On a confirmed send the owner-question row is stamped
+    ``answered_at`` so the #1063 turn-end gate stops nagging for it.
+    """
+    from teatree.core.backend_factory import messaging_from_overlay  # noqa: PLC0415 — deferred: call-time import
+    from teatree.core.models import PendingChatInjection  # noqa: PLC0415 — deferred: call-time import
+
+    slack_answer = (task.ticket.extra or {}).get("slack_answer")
+    if not isinstance(slack_answer, dict):
+        return False
+    channel = str(slack_answer.get("channel") or "").strip()
+    slack_ts = str(slack_answer.get("slack_ts") or "").strip()
+    if not channel or not slack_ts:
+        return False
+    backend = messaging_from_overlay(task.ticket.overlay or None)
+    if backend is None:
+        return False
+    try:
+        resp = backend.post_reply(channel=channel, ts=slack_ts, text=text)
+    except Exception:  # noqa: BLE001 — a Slack failure falls back to the approval path, never drops the reply
+        return False
+    if not isinstance(resp, dict) or resp.get("ok") is not True:
+        return False
+    PendingChatInjection.agent_answered_question(slack_ts)
+    return True
 
 
 #: Phases whose landed commit can back-fill a missing ``files_modified`` envelope.

--- a/src/teatree/agents/prompt.py
+++ b/src/teatree/agents/prompt.py
@@ -77,8 +77,10 @@ _REVIEW_VERDICT_RETURN_LINES: tuple[str, ...] = (
 # shell (agents/answerer.md tools = Read/Grep/Glob only), so it CANNOT post the
 # reply itself via the Replier / `t3 <overlay> notify` CLI. It RETURNS the draft
 # in the result envelope instead; the orchestrator (``attempt_recorder`` →
-# ``_maybe_record_answer_draft``) routes it through the DeferredQuestion approval
-# path and posts on the user's behalf (maker≠checker: a different actor posts).
+# ``_maybe_record_answer_draft``) posts your draft directly to the owner
+# in-thread — answering the owner is not a post on the owner's behalf, so it
+# is never approval-gated or deferred (an on-behalf reply to a third party
+# still routes through the DeferredQuestion approval path).
 # Symmetric to ``_REVIEW_VERDICT_RETURN_LINES`` — without this directive the
 # shell-denied answerer returns a prose summary with no ``answer`` field and the
 # phase evidence gate refuses ("missing required evidence for phase 'answering'").
@@ -86,8 +88,8 @@ _ANSWER_RETURN_LINES: tuple[str, ...] = (
     "",
     "RETURN YOUR REPLY AS A DRAFT (this phase has no shell — do NOT try to post via",
     "`t3 <overlay> notify`, the Replier, or any CLI; you cannot post, you HAND BACK the draft):",
-    "add an `answer` object to your final JSON result. The orchestrator routes it through the",
-    "approval path and posts on the user's behalf:",
+    "add an `answer` object to your final JSON result. The orchestrator posts your draft",
+    "directly to the owner, in-thread, on your behalf:",
     '  "answer": {"text": "<the drafted reply, in the user\'s voice — no AI signature>",',
     '             "thread_ref": "<the inbound thread ts/ref this reply targets, or \'\' if none>"}',
     "The `text` MUST be non-empty — a summary-only result with no `answer` drops the reply and",

--- a/tests/teatree_agents/test_attempt_recorder.py
+++ b/tests/teatree_agents/test_attempt_recorder.py
@@ -1,7 +1,7 @@
 """Shared result-envelope recorder used by both dispatch backends."""
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.test import TestCase
@@ -18,6 +18,7 @@ from teatree.core.models import (
     Directive,
     DirectiveDispatch,
     PendingArticleSuggestion,
+    PendingChatInjection,
     PendingTriageRecommendation,
     Session,
     Task,
@@ -402,6 +403,79 @@ class TestAnsweringEnvelopeChannel(TestCase):
         task.refresh_from_db()
         assert task.status == Task.Status.FAILED
         assert DeferredQuestion.objects.count() == 0
+
+
+class TestOwnerDmAnsweringRepliesInThread(TestCase):
+    """An owner-DM answering task SENDS the reply in-thread, never the defer gate.
+
+    The owner's #1 complaint: an inbound owner DM in ``autonomous_away`` got a
+    "Approve this drafted reply?" pending question parked instead of an answer.
+    Answering the owner is not a post on the owner's behalf, so it must never
+    route through the away/approval defer gate — the reply is posted directly,
+    threaded under the owner's own message, regardless of availability.
+    """
+
+    def _owner_dm_task(self, *, channel: str = "D0OWNER", slack_ts: str = "1784474278.074869") -> Task:
+        ticket = Ticket.objects.create(
+            role=Ticket.Role.AUTHOR,
+            state=Ticket.State.STARTED,
+            overlay="acme",
+            extra={"slack_answer": {"channel": channel, "slack_ts": slack_ts, "question": "test"}},
+        )
+        session = Session.objects.create(ticket=ticket, agent_id="answering")
+        task = Task.objects.create(ticket=ticket, session=session, phase="answering")
+        task.claim(claimed_by="loop-slot")
+        return task
+
+    def test_owner_dm_reply_is_posted_in_thread_not_deferred(self) -> None:
+        channel, slack_ts = "D0OWNER", "1784474278.074869"
+        task = self._owner_dm_task(channel=channel, slack_ts=slack_ts)
+        PendingChatInjection.objects.create(overlay="acme", channel=channel, slack_ts=slack_ts, text="test")
+        backend = MagicMock()
+        backend.post_reply.return_value = {"ok": True, "ts": "1784475031.606029"}
+        with patch("teatree.core.backend_factory.messaging_from_overlay", return_value=backend):
+            record_result_envelope(
+                task,
+                {"summary": "drafted", "answer": {"text": "Got it, working.", "thread_ref": ""}},
+            )
+        task.refresh_from_db()
+        assert task.status == Task.Status.COMPLETED
+        # Sent directly, threaded under the OWNER's message ts (authoritative
+        # ticket coordinates, not the advisory agent-returned thread_ref).
+        backend.post_reply.assert_called_once_with(channel=channel, ts=slack_ts, text="Got it, working.")
+        # Never parked behind the away/approval defer gate.
+        assert DeferredQuestion.objects.count() == 0
+        # The owner-question row is stamped answered so the turn-end gate rests.
+        assert PendingChatInjection.objects.get().answered_at is not None
+
+    def test_failed_post_falls_back_to_the_approval_gate_losing_nothing(self) -> None:
+        task = self._owner_dm_task()
+        backend = MagicMock()
+        backend.post_reply.return_value = {"ok": False, "error": "channel_not_found"}
+        with patch("teatree.core.backend_factory.messaging_from_overlay", return_value=backend):
+            record_result_envelope(
+                task,
+                {"summary": "drafted", "answer": {"text": "Got it.", "thread_ref": ""}},
+            )
+        task.refresh_from_db()
+        assert task.status == Task.Status.COMPLETED
+        # A Slack failure must not drop the reply: it falls back to the on-behalf gate.
+        assert DeferredQuestion.objects.get().parked_task_id == task.pk
+
+    def test_non_owner_answering_still_uses_the_approval_gate(self) -> None:
+        # No slack_answer context (an on-behalf colleague/channel reply): the
+        # approval gate is unchanged.
+        ticket = Ticket.objects.create(role=Ticket.Role.AUTHOR, state=Ticket.State.STARTED, overlay="acme")
+        session = Session.objects.create(ticket=ticket, agent_id="answering")
+        task = Task.objects.create(ticket=ticket, session=session, phase="answering")
+        task.claim(claimed_by="loop-slot")
+        with patch("teatree.core.backend_factory.messaging_from_overlay") as resolve:
+            record_result_envelope(
+                task,
+                {"summary": "drafted", "answer": {"text": "On behalf reply.", "thread_ref": "C9/1.0"}},
+            )
+            resolve.assert_not_called()
+        assert DeferredQuestion.objects.get().parked_task_id == task.pk
 
 
 class TestDirectiveInterpretationEnvelopeChannel(TestCase):

--- a/tests/teatree_agents/test_owner_answer_threading.py
+++ b/tests/teatree_agents/test_owner_answer_threading.py
@@ -1,10 +1,10 @@
 """Invariants for the owner-answer egress (slack-comms design, Phase 1/4).
 
 - I4: an owner reply threads on the OWNER's own message ts (the authoritative
-  ticket ``slack_answer.slack_ts``), never a stale DM-thread or a new root.
+    ticket ``slack_answer.slack_ts``), never a stale DM-thread or a new root.
 - I1: the owner answer is posted regardless of availability mode — patching
-  ``resolve_mode`` to ``autonomous_away`` must not suppress the post (the path
-  must never consult availability).
+    ``resolve_mode`` to ``autonomous_away`` must not suppress the post (the path
+    must never consult availability).
 """
 
 from unittest.mock import MagicMock, patch

--- a/tests/teatree_agents/test_owner_answer_threading.py
+++ b/tests/teatree_agents/test_owner_answer_threading.py
@@ -1,0 +1,65 @@
+"""Invariants for the owner-answer egress (slack-comms design, Phase 1/4).
+
+- I4: an owner reply threads on the OWNER's own message ts (the authoritative
+  ticket ``slack_answer.slack_ts``), never a stale DM-thread or a new root.
+- I1: the owner answer is posted regardless of availability mode — patching
+  ``resolve_mode`` to ``autonomous_away`` must not suppress the post (the path
+  must never consult availability).
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from teatree.agents.attempt_recorder import record_result_envelope
+from teatree.core import availability
+from teatree.core.models import DeferredQuestion, PendingChatInjection, Session, Task, Ticket
+
+
+class TestOwnerAnswerThreading(TestCase):
+    def _owner_dm_task(self, *, channel: str, slack_ts: str) -> Task:
+        ticket = Ticket.objects.create(
+            role=Ticket.Role.AUTHOR,
+            state=Ticket.State.STARTED,
+            overlay="acme",
+            extra={"slack_answer": {"channel": channel, "slack_ts": slack_ts, "question": "hi"}},
+        )
+        session = Session.objects.create(ticket=ticket, agent_id="answering")
+        task = Task.objects.create(ticket=ticket, session=session, phase="answering")
+        task.claim(claimed_by="loop-slot")
+        return task
+
+    def test_reply_threads_on_owner_message_ts(self) -> None:
+        channel, owner_ts = "D0OWNER", "1784474278.074869"
+        task = self._owner_dm_task(channel=channel, slack_ts=owner_ts)
+        backend = MagicMock()
+        backend.post_reply.return_value = {"ok": True, "ts": "1784475031.6"}
+        # A misleading agent-returned thread_ref must be ignored in favor of the
+        # authoritative owner message ts carried on the ticket.
+        with patch("teatree.core.backend_factory.messaging_from_overlay", return_value=backend):
+            record_result_envelope(
+                task,
+                {"summary": "drafted", "answer": {"text": "here you go", "thread_ref": "WRONG/9.9"}},
+            )
+        _, kwargs = backend.post_reply.call_args
+        assert kwargs["ts"] == owner_ts
+        assert kwargs["channel"] == channel
+
+    def test_answer_posts_under_autonomous_away(self) -> None:
+        channel, owner_ts = "D0OWNER", "1700000000.000100"
+        task = self._owner_dm_task(channel=channel, slack_ts=owner_ts)
+        PendingChatInjection.objects.create(overlay="acme", channel=channel, slack_ts=owner_ts, text="hi")
+        backend = MagicMock()
+        backend.post_reply.return_value = {"ok": True, "ts": "1700000000.000200"}
+        away = availability.Resolution(mode=availability.MODE_AUTONOMOUS_AWAY, source="override")
+        with (
+            patch("teatree.core.backend_factory.messaging_from_overlay", return_value=backend),
+            patch.object(availability, "resolve_mode", return_value=away),
+        ):
+            record_result_envelope(
+                task,
+                {"summary": "drafted", "answer": {"text": "still answered", "thread_ref": ""}},
+            )
+        backend.post_reply.assert_called_once()
+        assert DeferredQuestion.objects.count() == 0
+        assert PendingChatInjection.objects.get().answered_at is not None

--- a/tests/teatree_loop/slack_answer/test_availability_independence.py
+++ b/tests/teatree_loop/slack_answer/test_availability_independence.py
@@ -29,12 +29,6 @@ def _package_sources() -> list[tuple[str, str]]:
 class TestReactiveCycleIgnoresAvailability:
     def test_no_module_references_availability(self) -> None:
         offenders: list[str] = [
-            f"{name}:{token}"
-            for name, source in _package_sources()
-            for token in _FORBIDDEN
-            if token in source
+            f"{name}:{token}" for name, source in _package_sources() for token in _FORBIDDEN if token in source
         ]
-        assert offenders == [], (
-            "the reactive Slack-answer cycle must never consult availability — "
-            f"found: {offenders}"
-        )
+        assert offenders == [], f"the reactive Slack-answer cycle must never consult availability — found: {offenders}"

--- a/tests/teatree_loop/slack_answer/test_availability_independence.py
+++ b/tests/teatree_loop/slack_answer/test_availability_independence.py
@@ -1,0 +1,40 @@
+"""Invariant: the reactive Slack-answer cycle is never gated by availability.
+
+Owner contract I1/I2 (slack-comms design): when the owner writes, the box
+answers immediately regardless of availability mode. Availability governs only
+the box's OWN outbound questions. This locks that the answer cycle never grows
+an availability gate — a regression that imported ``resolve_mode`` /
+``defers_questions`` into this package would re-introduce the exact pause the
+owner reported (an owner DM in ``autonomous_away`` going unanswered).
+"""
+
+import pkgutil
+from pathlib import Path
+
+import teatree.loop.slack_answer as slack_answer_pkg
+
+_FORBIDDEN = ("resolve_mode", "defers_questions", "availability")
+
+
+def _package_sources() -> list[tuple[str, str]]:
+    root = Path(slack_answer_pkg.__file__).parent
+    sources: list[tuple[str, str]] = []
+    for mod in pkgutil.iter_modules([str(root)]):
+        path = root / f"{mod.name}.py"
+        if path.exists():
+            sources.append((mod.name, path.read_text(encoding="utf-8")))
+    return sources
+
+
+class TestReactiveCycleIgnoresAvailability:
+    def test_no_module_references_availability(self) -> None:
+        offenders: list[str] = [
+            f"{name}:{token}"
+            for name, source in _package_sources()
+            for token in _FORBIDDEN
+            if token in source
+        ]
+        assert offenders == [], (
+            "the reactive Slack-answer cycle must never consult availability — "
+            f"found: {offenders}"
+        )


### PR DESCRIPTION
## Phase 4 — invariant hardening (tests only, no behavior change)

Locks the owner-communication contract (I1/I2/I4) against regression:

- **`test_availability_independence`** — a source-level guard asserting the `teatree.loop.slack_answer` package references no `resolve_mode` / `defers_questions` / `availability` symbol. A future change that imports an availability gate into the reactive answer cycle would re-introduce the exact `autonomous_away` pause the owner reported.
- **`test_owner_answer_threading`** — the owner reply threads on the authoritative owner-message ts (ignoring a misleading agent-returned `thread_ref`); and the answer is posted (zero `DeferredQuestion`, row stamped answered) even with `resolve_mode() == autonomous_away`.

Stacked on Phase 1 (#3480) — it exercises that PR's `_post_owner_dm_reply`. Once #3480 merges, this PR's diff is tests-only.
