### PR TITLE
fix(tokens): parse Anthropic unified reset headers as Unix epoch seconds

### DIFF
--- a/src/teatree/llm/rate_limits.py
+++ b/src/teatree/llm/rate_limits.py
@@ -26,7 +26,7 @@ real network; the default transport uses ``httpx``.
 
 The header names follow Anthropic's response-header conventions and are centralised as
 module constants so a naming drift is a one-line fix. ``utilization`` is a 0.0-1.0
-fraction; ``*-reset`` is an RFC 3339 timestamp parsed to a tz-aware UTC ``datetime``;
+fraction; ``*-reset`` is Unix epoch seconds parsed to a tz-aware UTC ``datetime``;
 ``retry-after`` is whole seconds.
 """
 
@@ -319,12 +319,15 @@ def _parse_int(raw: str | None) -> int | None:
 
 
 def _parse_reset(raw: str | None) -> dt.datetime | None:
+    """Fold a unified-window ``*-reset`` header into a tz-aware UTC ``datetime``.
+
+    Anthropic emits the reset instant as Unix epoch **seconds** (e.g. ``"1784476200"``),
+    NOT an RFC 3339 timestamp; ``None`` when the header is absent or not an integer.
+    """
     if not raw:
         return None
     try:
-        parsed = dt.datetime.fromisoformat(raw)
+        epoch_seconds = int(raw)
     except ValueError:
         return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=dt.UTC)
-    return parsed.astimezone(dt.UTC)
+    return dt.datetime.fromtimestamp(epoch_seconds, tz=dt.UTC)

--- a/tests/teatree_llm/test_rate_limits.py
+++ b/tests/teatree_llm/test_rate_limits.py
@@ -47,10 +47,10 @@ _FULL_HEADERS = {
     _RETRY_AFTER: "42",
     _5H_STATUS: "allowed",
     _5H_UTIL: "0.30",
-    _5H_RESET: "2026-07-01T18:00:00Z",
+    _5H_RESET: "1782928800",  # Unix epoch seconds == 2026-07-01T18:00:00Z
     _7D_STATUS: "allowed_warning",
     _7D_UTIL: "0.80",
-    _7D_RESET: "2026-07-08T00:00:00+00:00",
+    _7D_RESET: "1783468800",  # Unix epoch seconds == 2026-07-08T00:00:00Z
 }
 
 _METERED_HEADERS = {
@@ -142,9 +142,10 @@ class TestHeaderParsing:
         assert snap.retry_after is None
         assert snap.unified_5h_reset is None
 
-    def test_naive_reset_timestamp_is_assumed_utc(self) -> None:
-        snap = _read(200, {_5H_RESET: "2026-07-01T18:00:00"})
-        assert snap.unified_5h_reset == dt.datetime(2026, 7, 1, 18, 0, tzinfo=dt.UTC)
+    def test_epoch_seconds_reset_parses_to_tz_aware_utc(self) -> None:
+        # Anthropic sends the reset instant as Unix epoch seconds, not an ISO timestamp.
+        snap = _read(200, {_5H_RESET: "1784476200"})
+        assert snap.unified_5h_reset == dt.datetime(2026, 7, 19, 15, 50, tzinfo=dt.UTC)
 
 
 class TestDefaultTransport:


### PR DESCRIPTION
## Problem
`t3 tokens` renders a **5h reset** and **weekly reset** column, but both always showed `—` for every OAuth account — even for EXHAUSTED accounts, which is exactly when knowing the reset time matters most.

## Root cause
Anthropic emits the `anthropic-ratelimit-unified-{5h,7d}-reset` headers as **Unix epoch seconds** (e.g. `"1784476200"`), not an RFC 3339 timestamp. `rate_limits._parse_reset` called `datetime.fromisoformat`, which raised `ValueError` on every real value and returned `None`. So `unified_5h_reset` / `unified_7d_reset` were always `None` — the utilization headers (plain floats) parsed fine, which is why only the reset columns were blank.

The `AnthropicTokenUsage` cache columns (`reset_5h`/`reset_7d`) and the `token_report` render path were already correct; they were just being fed `None`.

## Blast radius (all fixed by the one-line parse fix)
- `t3 tokens` 5h-reset / weekly-reset columns
- loop park-on-all-exhausted auto-requeue timing (`earliest_reset`)
- dashboard "earliest reset" column

## Fix
Parse the header as epoch seconds via `datetime.fromtimestamp(int(raw), tz=UTC)`. Updated the rate-limit tests, which had fed ISO strings that never matched the real wire format, to use real epoch-seconds headers.

## Verification
Confirmed end-to-end against live Anthropic headers (no DB mutation): both a WARNING and an EXHAUSTED account now render real reset datetimes in the `5h reset` / `weekly reset` cells. Targeted suites green (`test_rate_limits`, `test_token_report`, `test_anthropic_token_usage`, `test_credential_config`), `ruff`, scoped `ty`, `makemigrations --check` (no new migration — columns already existed), doctest-modules, path-mirror, quality/conformance shape.