### PR TITLE
feat(setup): register + enable pyright-lsp plugin for live type diagnostics + doctor check

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -17,7 +17,9 @@ FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebff
 # (anthropic_oauth_pass_paths) instead of a single env token. ttyd backs the
 # admin dashboard's loopback "Debug session" terminal (#3263). The Docker CLI
 # + compose plugin (CLI only, NO engine) let the watchdog role drive the host
-# daemon over the mounted socket.
+# daemon over the mounted socket. The npm `pyright` package provides the
+# `pyright-langserver` binary the pyright-lsp Claude plugin execs to give factory
+# agents live Python type diagnostics while coding (`t3 setup` enables the plugin).
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends \
         ca-certificates curl direnv git gnupg jq pass sqlite3 ttyd && \
@@ -36,7 +38,7 @@ RUN apt-get update -qq && \
         > /etc/apt/sources.list.d/docker.list && \
     apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends gh docker-ce-cli docker-compose-plugin && \
-    npm install -g @anthropic-ai/claude-code && \
+    npm install -g @anthropic-ai/claude-code pyright && \
     npm cache clean --force && \
     rm -rf /var/lib/apt/lists/*
 

--- a/deploy/claude-settings.template.json
+++ b/deploy/claude-settings.template.json
@@ -2,7 +2,8 @@
   "model": "claude-opus-4-8",
   "autoCompactEnabled": true,
   "enabledPlugins": {
-    "t3@souliane": true
+    "t3@souliane": true,
+    "pyright-lsp@claude-plugins-official": true
   },
   "permissions": {
     "defaultMode": "acceptEdits",

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -167,6 +167,16 @@ Teatree ships a `hooks.json` that Claude Code loads automatically. `t3 setup` re
 
 Verify the registration: `t3 doctor check` (it reports the registered plugin and its `installPath`).
 
+`t3 setup` also registers + enables the external `pyright-lsp@claude-plugins-official`
+plugin (from the `anthropics/claude-plugins-official` marketplace) via the `claude
+plugin` CLI, so agents get LIVE pyright type diagnostics while coding instead of only
+catching type errors at CI. It is best-effort/offline-safe (an unreachable marketplace
+WARNs and continues) and needs `pyright-langserver` (npm `pyright`, baked into the
+deploy image) on PATH — `t3 doctor check` advisory-WARNs when the plugin is disabled or
+the langserver is missing. Both plugins are pinned in the managed
+`deploy/claude-settings.template.json` `enabledPlugins`, so every seeded container
+enables them and the host drift check re-asserts them.
+
 The hooks cover these events:
 
 | Event | Matcher | Purpose |

--- a/src/teatree/cli/doctor/app.py
+++ b/src/teatree/cli/doctor/app.py
@@ -46,6 +46,7 @@ from teatree.cli.doctor.checks_mcp import (
     _check_teatree_mcp_registration,
 )
 from teatree.cli.doctor.checks_resources import (
+    _check_pyright_lsp_plugin,
     _check_tmp_tmpfs_headroom,
     _check_worker_memory_cap,
     _check_worker_skills_present,
@@ -110,6 +111,7 @@ __all__ = (
     "_check_marker_jam",
     "_check_mcp_connectivity",
     "_check_provision_concurrency_from_host",
+    "_check_pyright_lsp_plugin",
     "_check_single_db",
     "_check_singletons",
     "_check_skills",
@@ -186,11 +188,14 @@ def _optional_tooling_advisories() -> None:
     container and on a host that never opted in. The tmpfs-headroom check WARNs when
     a RAM-backed ``/tmp`` is filling toward ENOSPC (the fill that wedges the box);
     runtime temp is routed to disk and the watchdog trims stale scratch on a cadence.
+    The pyright-lsp advisory WARNs when the plugin that gives agents live pyright type
+    diagnostics is not enabled, or its ``pyright-langserver`` is missing from PATH.
     (The critical worker gates — skills-present and memory-adequate — are HARD FAILs
     in :func:`run_doctor_checks`, not advisories here.)
     """
     _check_ttyd_for_dashboard()
     _check_chrome_devtools_mcp_suggestion()
+    _check_pyright_lsp_plugin()
     _check_docker_workflow_wired()
     _check_tmp_tmpfs_headroom()
 

--- a/src/teatree/cli/doctor/checks_resources.py
+++ b/src/teatree/cli/doctor/checks_resources.py
@@ -10,6 +10,8 @@ hygiene) so each module stays a single concern under the module-health LOC cap.
 
 import json
 import os
+import shutil
+from collections.abc import Callable
 from pathlib import Path
 from typing import cast
 
@@ -30,6 +32,13 @@ _MIN_MOUNT_FIELDS = 3
 # small — and not needing the loop's skills — is correct and must NOT be flagged.
 _AGENT_ROLE = "worker"
 _CLAUDE_PLUGIN_ID = "t3@souliane"
+
+# The external pyright-lsp plugin + the language-server binary it drives. ADVISORY
+# only (a productivity aid, never a worker gate): `t3 setup` registers + enables the
+# plugin, and the npm `pyright` package (baked into the image) provides
+# `pyright-langserver`, which the plugin execs to deliver live type diagnostics.
+_PYRIGHT_PLUGIN_ID = "pyright-lsp@claude-plugins-official"
+_PYRIGHT_LANGSERVER = "pyright-langserver"
 _DEFAULT_WORKER_FLOOR_GIB = 4
 _BYTES_PER_GIB = 1024**3
 # cgroup v1's "unlimited" is a near-2**63 page-aligned sentinel, and cgroup v2 uses
@@ -235,3 +244,37 @@ def _check_worker_skills_present(*, role: str | None = None, home: Path | None =
         "container (or redeploy); the worker entrypoint now refuses to start without it."
     )
     return False
+
+
+def _check_pyright_lsp_plugin(*, home: Path | None = None, which: Callable[[str], str | None] | None = None) -> bool:
+    """ADVISORY: verify the pyright-lsp plugin is enabled AND its langserver is on PATH.
+
+    pyright-lsp gives factory agents LIVE pyright type diagnostics while coding, so a
+    type error surfaces in-session instead of only at CI. It is a productivity aid,
+    NOT a worker gate — every finding is a WARN and this NEVER gates the doctor exit
+    code (always returns ``True``), matching the sibling advisory checks. ``t3 setup``
+    registers + enables the plugin; its language server (``pyright-langserver``, from
+    the npm ``pyright`` package baked into the image) must be on PATH for the plugin to
+    start. WARNs with an actionable remediation when either is missing. ``which`` is
+    injectable for tests (defaults to :func:`shutil.which`). Crash-proof — any read
+    error degrades to a silent pass so this diagnostic never aborts the doctor run.
+    """
+    resolve = shutil.which if which is None else which
+    try:
+        enabled = _read_json_object((home or Path.home()) / ".claude" / "settings.json").get("enabledPlugins")
+    except OSError:
+        return True
+    if not (isinstance(enabled, dict) and cast("JsonObject", enabled).get(_PYRIGHT_PLUGIN_ID) is True):
+        typer.echo(
+            "WARN  pyright-lsp plugin is not enabled — factory agents get no LIVE pyright type "
+            "diagnostics while coding (type errors surface only at CI). Run `t3 setup` to register "
+            "+ enable it (advisory only; nothing is gated)."
+        )
+        return True
+    if resolve(_PYRIGHT_LANGSERVER) is None:
+        typer.echo(
+            f"WARN  pyright-lsp plugin is enabled but `{_PYRIGHT_LANGSERVER}` is not on PATH — the "
+            "language server cannot start, so there are no live type diagnostics. Install it with "
+            "`npm install -g pyright` (advisory only; nothing is gated)."
+        )
+    return True

--- a/src/teatree/cli/setup/claude_settings.py
+++ b/src/teatree/cli/setup/claude_settings.py
@@ -3,7 +3,8 @@
 ``deploy/claude-settings.template.json`` is the single source of truth for the
 managed Claude Code config — model, ``permissions.defaultMode`` /
 ``permissions.allow``, ``autoMode.allow``, ``enabledPlugins`` (the ``t3@souliane``
-skills plugin), and the managed ``env`` (tool-use concurrency plus ``TMPDIR`` /
+skills plugin plus ``pyright-lsp@claude-plugins-official`` for live type
+diagnostics), and the managed ``env`` (tool-use concurrency plus ``TMPDIR`` /
 ``PYTEST_DEBUG_TEMPROOT`` routing agent and pytest scratch to DISK, off the box's
 small RAM-backed ``/tmp`` tmpfs). The
 worker containers seed it into ``~/.claude/settings.json`` in
@@ -53,6 +54,7 @@ MANAGED_KEY_PATHS: tuple[tuple[str, ...], ...] = (
     ("env", "TMPDIR"),
     ("env", "PYTEST_DEBUG_TEMPROOT"),
     ("enabledPlugins", "t3@souliane"),
+    ("enabledPlugins", "pyright-lsp@claude-plugins-official"),
 )
 
 # The managed allow-list paths carrying set-union / superset semantics: the

--- a/src/teatree/cli/setup/command.py
+++ b/src/teatree/cli/setup/command.py
@@ -20,7 +20,7 @@ from teatree.cli.setup.apm import ApmInstaller, strip_apm_hooks
 from teatree.cli.setup.clone import find_main_clone, validate_repo
 from teatree.cli.setup.docker_alias import DockerAliasInstaller
 from teatree.cli.setup.mcp_registrar import McpServerRegistrar
-from teatree.cli.setup.plugin_registrar import PluginRegistrar
+from teatree.cli.setup.plugin_registrar import PluginRegistrar, PyrightPluginRegistrar
 from teatree.cli.setup.skill_linker import CORE_EXCLUDED_SKILLS, SkillLinker
 from teatree.cli.setup.statusline_installer import StatuslineInstall, install_statusline
 from teatree.cli.setup.tool_installer import ToolInstaller
@@ -168,6 +168,12 @@ def run(
 
     if not skip_plugin:
         PluginRegistrar(repo).install()
+        # Register + enable the external pyright-lsp plugin (anthropics/claude-plugins-official)
+        # so factory agents get LIVE pyright type diagnostics while coding, instead of
+        # shipping type errors that only CI catches. Best-effort/offline-safe — an
+        # unreachable marketplace WARNs and continues; its `pyright-langserver` runtime
+        # dep is baked into the image and advisory-checked by `t3 doctor`.
+        PyrightPluginRegistrar().install()
         # Confirm the structured-search MCP server (`t3 mcp serve`, #1023) is
         # still wired via the plugin-bundled `.mcp.json` (#2863) — read-only,
         # idempotent, warns loudly rather than silently regressing agents back

--- a/src/teatree/cli/setup/plugin_registrar.py
+++ b/src/teatree/cli/setup/plugin_registrar.py
@@ -7,9 +7,21 @@ from pathlib import Path
 
 import typer
 
+from teatree.utils.run import TimeoutExpired, run_allowed_to_fail
+
 _PLUGIN_NAME = "t3"
 _MARKETPLACE_NAME = "souliane"
 _PLUGIN_ID = f"{_PLUGIN_NAME}@{_MARKETPLACE_NAME}"
+
+_PYRIGHT_MARKETPLACE = "claude-plugins-official"
+_PYRIGHT_MARKETPLACE_SOURCE = "anthropics/claude-plugins-official"
+_PYRIGHT_PLUGIN_NAME = "pyright-lsp"
+_PYRIGHT_PLUGIN_ID = f"{_PYRIGHT_PLUGIN_NAME}@{_PYRIGHT_MARKETPLACE}"
+
+# Bound for a ``claude plugin`` CLI call — it clones + validates the remote
+# marketplace / plugin, so an unreachable network must time out and continue
+# rather than hang setup.
+_CLAUDE_CLI_TIMEOUT_S = 120
 
 
 def _read_json(path: Path) -> dict:
@@ -30,6 +42,29 @@ def _settings_path() -> Path:
     """Return the resolved settings.json path (follows symlinks)."""
     path = Path.home() / ".claude" / "settings.json"
     return path.resolve() if path.is_file() else path
+
+
+def _set_enabled_plugin(plugin_id: str) -> bool:
+    """Ensure ``plugin_id`` is enabled in settings.json; return True when it changed."""
+    resolved = _settings_path()
+    data = _read_json(resolved)
+    plugins = data.setdefault("enabledPlugins", {})
+    if plugins.get(plugin_id) is True:
+        return False
+    plugins[plugin_id] = True
+    _write_json(resolved, data)
+    return True
+
+
+def _plugin_installed(plugin_id: str) -> bool:
+    """True when ``plugin_id`` has an installed_plugins.json entry with a live ``installPath``."""
+    plugins = _read_json(Path.home() / ".claude" / "plugins" / "installed_plugins.json").get("plugins", {})
+    entries = plugins.get(plugin_id) if isinstance(plugins, dict) else None
+    if not (isinstance(entries, list) and entries):
+        return False
+    first = entries[0]
+    install_path = first.get("installPath") if isinstance(first, dict) else None
+    return isinstance(install_path, str) and bool(install_path) and Path(install_path).is_dir()
 
 
 class PluginRegistrar:
@@ -139,3 +174,61 @@ class PluginRegistrar:
             "lastUpdated": now,
         }
         _write_json(marketplaces_json, data)
+
+
+class PyrightPluginRegistrar:
+    """Register + enable the external ``pyright-lsp`` plugin for live type diagnostics.
+
+    Unlike :class:`PluginRegistrar` — which writes the plugin JSON directly for the
+    LOCAL ``souliane`` marketplace clone — ``pyright-lsp`` lives in the remote
+    ``anthropics/claude-plugins-official`` marketplace, whose on-disk cache is a git
+    clone Claude Code manages. Registration therefore goes through the ``claude
+    plugin`` CLI (the same mechanism Claude Code itself uses): ``marketplace add``
+    clones + validates the marketplace, ``install`` clones the plugin into the cache
+    and enables it. Both are idempotent. Offline-safe: an unreachable marketplace
+    WARNs and returns ``False`` (setup continues) rather than aborting — matching the
+    other best-effort setup steps.
+
+    The plugin gives factory agents LIVE pyright type diagnostics while coding, so a
+    type error surfaces in-session instead of only at CI. Its language server
+    (``pyright-langserver``, from the npm ``pyright`` package) must be on PATH for the
+    plugin to start — ``t3 doctor`` advisory-WARNs when it is not.
+    """
+
+    def install(self) -> bool:
+        """Register + enable ``pyright-lsp`` via the ``claude plugin`` CLI (idempotent, offline-safe)."""
+        if _plugin_installed(_PYRIGHT_PLUGIN_ID):
+            _set_enabled_plugin(_PYRIGHT_PLUGIN_ID)
+            typer.echo(f"OK    Plugin {_PYRIGHT_PLUGIN_ID} already registered — enabled.")
+            return True
+        claude = shutil.which("claude")
+        if claude is None:
+            typer.echo("WARN  `claude` not on PATH — skipped pyright-lsp plugin registration; setup continues.")
+            return False
+        if not self._run_claude(claude, "plugin", "marketplace", "add", _PYRIGHT_MARKETPLACE_SOURCE):
+            typer.echo(
+                f"WARN  Could not add the {_PYRIGHT_MARKETPLACE} marketplace (offline?) — "
+                "pyright-lsp skipped; setup continues.",
+            )
+            return False
+        if not self._run_claude(claude, "plugin", "install", _PYRIGHT_PLUGIN_ID):
+            typer.echo("WARN  Could not install pyright-lsp (offline?) — skipped; setup continues.")
+            return False
+        _set_enabled_plugin(_PYRIGHT_PLUGIN_ID)
+        typer.echo(f"OK    Plugin {_PYRIGHT_PLUGIN_ID} registered + enabled for live pyright diagnostics.")
+        return True
+
+    @staticmethod
+    def _run_claude(claude: str, *args: str) -> bool:
+        """Run ``claude <args>`` via the audited wrapper; return True on exit 0.
+
+        ``expected_codes=None`` accepts any exit code (this method judges success on
+        the return code itself), so a non-zero exit is a non-fatal ``False`` rather
+        than a raise. A timeout or spawn error (``claude`` vanished) is likewise a
+        non-fatal ``False`` so an unreachable marketplace never aborts setup.
+        """
+        try:
+            result = run_allowed_to_fail([claude, *args], expected_codes=None, timeout=_CLAUDE_CLI_TIMEOUT_S)
+        except (OSError, TimeoutExpired):
+            return False
+        return result.returncode == 0

--- a/tests/teatree_cli/doctor/test_pyright_lsp_check.py
+++ b/tests/teatree_cli/doctor/test_pyright_lsp_check.py
@@ -1,0 +1,64 @@
+"""Tests for ``_check_pyright_lsp_plugin`` — advisory live-type-diagnostics aid.
+
+pyright-lsp gives factory agents LIVE pyright type diagnostics while coding, so a
+type error surfaces in-session instead of only at CI. It is a productivity aid, not
+a worker gate: the check WARNs when the plugin is not enabled, or when its
+``pyright-langserver`` is missing from PATH, but NEVER gates the doctor exit code
+(always returns ``True``) and never FAILs.
+"""
+
+import io
+import json
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from teatree.cli.doctor.checks_resources import _check_pyright_lsp_plugin
+
+_PLUGIN_ID = "pyright-lsp@claude-plugins-official"
+
+
+def _write_settings(home: Path, enabled: dict[str, object]) -> None:
+    (home / ".claude").mkdir(parents=True, exist_ok=True)
+    (home / ".claude" / "settings.json").write_text(json.dumps({"enabledPlugins": enabled}), encoding="utf-8")
+
+
+def _run(home: Path, *, langserver_on_path: bool) -> tuple[bool, str]:
+    def _which(name: str) -> str | None:
+        return f"/usr/bin/{name}" if langserver_on_path else None
+
+    out = io.StringIO()
+    with redirect_stdout(out):
+        ok = _check_pyright_lsp_plugin(home=home, which=_which)
+    return ok, out.getvalue()
+
+
+class TestCheckPyrightLspPlugin:
+    def test_silent_pass_when_enabled_and_langserver_present(self, tmp_path: Path) -> None:
+        _write_settings(tmp_path, {_PLUGIN_ID: True})
+        ok, message = _run(tmp_path, langserver_on_path=True)
+        assert ok is True
+        assert message.strip() == ""
+
+    def test_warns_when_plugin_not_enabled(self, tmp_path: Path) -> None:
+        _write_settings(tmp_path, {"t3@souliane": True})
+        ok, message = _run(tmp_path, langserver_on_path=True)
+        assert ok is True  # advisory only — never gates
+        assert "WARN" in message
+        assert "pyright-lsp" in message
+        assert "t3 setup" in message
+        assert "FAIL" not in message
+
+    def test_warns_when_langserver_missing_from_path(self, tmp_path: Path) -> None:
+        _write_settings(tmp_path, {_PLUGIN_ID: True})
+        ok, message = _run(tmp_path, langserver_on_path=False)
+        assert ok is True  # advisory only — never gates
+        assert "WARN" in message
+        assert "pyright-langserver" in message
+        assert "npm install -g pyright" in message
+        assert "FAIL" not in message
+
+    def test_never_gates_when_settings_absent(self, tmp_path: Path) -> None:
+        # No ~/.claude/settings.json at all → treated as "not enabled", WARN only.
+        ok, message = _run(tmp_path, langserver_on_path=True)
+        assert ok is True
+        assert "FAIL" not in message

--- a/tests/teatree_cli/setup/test_claude_settings.py
+++ b/tests/teatree_cli/setup/test_claude_settings.py
@@ -330,6 +330,42 @@ class TestEnabledPluginsManagedConfig:
         assert "enabledPlugins.t3@souliane" in managed_key_drift(_COMMITTED_TEMPLATE, target_path, env={})
 
 
+class TestPyrightLspPluginManagedConfig:
+    """The committed template enables ``pyright-lsp@claude-plugins-official``, managed + drift-guarded.
+
+    The pyright-lsp plugin gives factory agents LIVE pyright type diagnostics while
+    coding. The template pins it enabled and it is managed, so every seeded container
+    enables it and the host drift check re-asserts it (mirroring the t3 skills plugin).
+    """
+
+    _PLUGIN_PATH: tuple[str, ...] = ("enabledPlugins", "pyright-lsp@claude-plugins-official")
+
+    def _committed(self) -> dict[str, object]:
+        return json.loads(_COMMITTED_TEMPLATE.read_text(encoding="utf-8"))
+
+    def test_template_enables_the_pyright_plugin(self) -> None:
+        assert _dig(self._committed(), self._PLUGIN_PATH) is True
+
+    def test_enabled_plugin_path_is_managed(self) -> None:
+        assert self._PLUGIN_PATH in MANAGED_KEY_PATHS
+
+    def test_drift_detected_when_plugin_disabled_on_host(self, tmp_path: Path) -> None:
+        target = self._committed()
+        target["enabledPlugins"]["pyright-lsp@claude-plugins-official"] = False  # type: ignore[index]
+        target_path = _write(tmp_path / "t.json", target)
+        assert "enabledPlugins.pyright-lsp@claude-plugins-official" in managed_key_drift(
+            _COMMITTED_TEMPLATE, target_path, env={}
+        )
+
+    def test_drift_preserves_pyright_entry_alongside_t3(self, tmp_path: Path) -> None:
+        # Both managed plugin keys are asserted; a host enabling both drifts on neither.
+        target = self._committed()
+        target_path = _write(tmp_path / "t.json", target)
+        drift = managed_key_drift(_COMMITTED_TEMPLATE, target_path, env={})
+        assert "enabledPlugins.t3@souliane" not in drift
+        assert "enabledPlugins.pyright-lsp@claude-plugins-official" not in drift
+
+
 class TestMainScript:
     def test_renders_resolved_template_to_stdout(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch

--- a/tests/teatree_cli/setup/test_pyright_plugin_registrar.py
+++ b/tests/teatree_cli/setup/test_pyright_plugin_registrar.py
@@ -1,0 +1,109 @@
+"""Tests for ``PyrightPluginRegistrar`` — external pyright-lsp plugin registration.
+
+``t3 setup`` registers + enables the ``pyright-lsp@claude-plugins-official`` plugin
+so factory agents get LIVE pyright type diagnostics while coding. Unlike the local
+``t3@souliane`` plugin (whose JSON is written directly), pyright-lsp lives in a
+remote marketplace, so registration is driven through the ``claude plugin`` CLI. The
+step is idempotent and offline-safe: an unreachable marketplace WARNs and continues
+rather than aborting setup.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from teatree.cli.setup.plugin_registrar import PyrightPluginRegistrar
+
+_PLUGIN_ID = "pyright-lsp@claude-plugins-official"
+_MARKETPLACE_SOURCE = "anthropics/claude-plugins-official"
+
+
+def _read_enabled(home: Path) -> dict[str, object]:
+    settings = home / ".claude" / "settings.json"
+    if not settings.is_file():
+        return {}
+    return json.loads(settings.read_text()).get("enabledPlugins", {})
+
+
+class TestPyrightPluginRegistrarInstall:
+    def test_adds_marketplace_installs_and_enables(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+        monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/claude")
+
+        calls: list[list[str]] = []
+
+        class _Result:
+            returncode = 0
+
+        def _run(cmd: list[str], **_kwargs: object) -> _Result:
+            calls.append(cmd)
+            return _Result()
+
+        monkeypatch.setattr("subprocess.run", _run)
+
+        assert PyrightPluginRegistrar().install() is True
+
+        # Both CLI steps ran, in order: marketplace add, then install.
+        assert calls[0][1:] == ["plugin", "marketplace", "add", _MARKETPLACE_SOURCE]
+        assert calls[1][1:] == ["plugin", "install", _PLUGIN_ID]
+        # And the plugin is enabled in settings.json (the managed drift key).
+        assert _read_enabled(tmp_path).get(_PLUGIN_ID) is True
+
+    def test_skips_network_when_already_installed_but_still_enables(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+        # A live installed_plugins.json entry with an existing installPath dir.
+        install_path = tmp_path / "cache" / "pyright-lsp"
+        install_path.mkdir(parents=True)
+        plugins_dir = tmp_path / ".claude" / "plugins"
+        plugins_dir.mkdir(parents=True)
+        (plugins_dir / "installed_plugins.json").write_text(
+            json.dumps({"version": 2, "plugins": {_PLUGIN_ID: [{"installPath": str(install_path)}]}})
+        )
+
+        def _boom(*_args: object, **_kwargs: object) -> object:
+            msg = "the claude CLI must not be shelled out when already installed"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr("subprocess.run", _boom)
+        monkeypatch.setattr("shutil.which", _boom)
+
+        assert PyrightPluginRegistrar().install() is True
+        assert _read_enabled(tmp_path).get(_PLUGIN_ID) is True
+
+    def test_offline_marketplace_add_warns_and_continues(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+        monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/claude")
+
+        class _Result:
+            returncode = 1  # marketplace add fails (offline)
+
+        monkeypatch.setattr("subprocess.run", lambda _cmd, **_kwargs: _Result())
+
+        assert PyrightPluginRegistrar().install() is False  # non-fatal
+        out = capsys.readouterr().out
+        assert "WARN" in out
+        # Never enabled when it could not be registered.
+        assert _read_enabled(tmp_path).get(_PLUGIN_ID) is None
+
+    def test_missing_claude_cli_warns_and_continues(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+        monkeypatch.setattr("shutil.which", lambda _name: None)
+
+        assert PyrightPluginRegistrar().install() is False
+        assert "WARN" in capsys.readouterr().out
+
+    def test_run_claude_returns_false_on_timeout(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        import subprocess  # noqa: PLC0415 — local to the test that stubs it
+
+        def _timeout(*_args: object, **_kwargs: object) -> object:
+            raise subprocess.TimeoutExpired(cmd="claude", timeout=1)
+
+        monkeypatch.setattr("subprocess.run", _timeout)
+        assert PyrightPluginRegistrar._run_claude("/usr/bin/claude", "plugin", "list") is False


### PR DESCRIPTION
Adds pyright-lsp plugin registration to t3 setup, a managed enabledPlugins entry, and a t3 doctor advisory, so factory agents get live pyright type diagnostics while coding (today type mistakes surface only in CI).

Findings: pyright-lsp lives in the remote anthropics/claude-plugins-official marketplace (declared name claude-plugins-official, GitHub source), plugin id pyright-lsp@claude-plugins-official. Registered via the claude plugin CLI (marketplace add + install), the right mechanism for a remote marketplace. Its language server pyright-langserver ships in the npm pyright package, now added to the deploy image.

Changes: new PyrightPluginRegistrar in t3 setup (idempotent, offline-tolerant, via run_allowed_to_fail); pyright-lsp added to managed enabledPlugins in claude-settings.template.json + MANAGED_KEY_PATHS; new t3 doctor advisory _check_pyright_lsp_plugin (WARN only); pyright added to deploy/Dockerfile npm install; skills/setup/SKILL.md updated.

Tests cover the registrar, the doctor advisory, and the settings-template managed entry. Verified end-to-end against a fresh HOME. Green locally: ruff, ty-check, setup/doctor tests, test-path-mirror, module-health, comment-density, makemigrations --check, scoped prek.
