### PR TITLE
fix(agents): clamp an elapsed park forward instead of refusing it (follow-up to #3493)

### DIFF
--- a/src/teatree/agents/usage_window.py
+++ b/src/teatree/agents/usage_window.py
@@ -20,7 +20,7 @@ to today. This module owns the ``LimitCause`` → horizon resolution (it imports
 """
 
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from django.utils import timezone
 
@@ -39,6 +39,13 @@ _ROTATABLE_SUBSCRIPTION_CAUSES: frozenset[LimitCause] = frozenset(
 #: The ``UsageWindowState.cause`` recorded when the WHOLE subscription lane parked because
 #: every account drained — distinct from a single-account cause for audit / notify wording.
 _ALL_EXHAUSTED_CAUSE = "all_accounts_exhausted"
+#: How far ahead an ALREADY-ELAPSED reset is clamped when parking. A park keyed on a past
+#: instant is dead on arrival — ``usage_window_recovery`` clears it on its very next tick, so
+#: a caller that keeps re-deriving an elapsed reset re-parks at the poll cadence. A stale
+#: reset means the true re-arm instant is UNKNOWN (an outage artefact, a clock skew, an SDK
+#: processing delay), not that the lane is free, so the park is kept — just pushed far enough
+#: ahead to be a real quiesce and re-checked soon after.
+ELAPSED_RESET_GRACE = timedelta(minutes=5)
 
 
 def autorecovery_enabled() -> bool:
@@ -69,6 +76,18 @@ def effective_resets_at(cause: LimitCause, sdk_resets_at: datetime | None, now: 
     if horizon is None:
         return None
     return sdk_resets_at if sdk_resets_at is not None else now + horizon
+
+
+def _future_park_instant(reset: datetime, moment: datetime) -> datetime:
+    """*reset* if it is still ahead, else *moment* + :data:`ELAPSED_RESET_GRACE`.
+
+    The one clamp both park writers apply, so neither can persist a
+    :class:`~teatree.core.models.UsageWindowState` that the recovery chain clears on its very
+    next tick (a self-clearing window notifies the owner and re-parks at the poll cadence).
+    An elapsed reset is not evidence the lane is usable — only that the recorded instant is
+    stale — so the window is kept and re-checked after the grace, never dropped.
+    """
+    return reset if reset > moment else moment + ELAPSED_RESET_GRACE
 
 
 def _epoch_to_datetime(epoch: int | None) -> datetime | None:
@@ -103,6 +122,10 @@ def park_task_on_limit(
     reset = effective_resets_at(match.cause, _epoch_to_datetime(sdk_resets_at), moment)
     if reset is None:
         return None
+    # The SDK's own ``resets_at`` can arrive already elapsed (processing delay, clock skew),
+    # which would write a window the recovery chain clears immediately — same self-clearing
+    # class the all-exhausted path guards. Clamp here too so BOTH writers are covered.
+    reset = _future_park_instant(reset, moment)
     UsageWindowState.record_limit(lane=lane, cause=match.cause.value, resets_at=reset, now=moment)
     # #3159 item 6: auto-engage the low-power preset for the parked window's tenure
     # (default-off flag; never overwrites a live user override). Fail-soft — a park
@@ -190,37 +213,35 @@ def park_task_on_all_exhausted(
     """Park *task* behind an ALL-ACCOUNTS-exhausted lane (multi-account #C2) — or ``None``.
 
     Every configured account is spent, so there is no account to rotate to: park the WHOLE
-    lane keyed on *resets_at* (the earliest reset across accounts) so the existing
+    lane keyed on *resets_at* (the soonest instant ANY account frees up — see
+    ``AnthropicTokenUsage.frees_up_at``) so the existing
     ``usage_window_recovery`` chain auto-resumes the task when the soonest account frees up — a
-    quiesce, NOT a human escalation. ``None`` (caller records a terminal FAILED, as today) when
-    the flag is OFF, no reset is known (nothing to re-arm to), or the reset has ALREADY
-    PASSED — a park keyed on an elapsed instant is dead on arrival: the recovery chain clears
-    it on its very next tick and posts a "window restored" line, so a caller that keeps
-    re-deriving an elapsed reset would flood the owner with restore notifications at the poll
-    cadence. Refusing the park surfaces the real failure instead of hiding it behind a
-    self-clearing window.
+    quiesce, NOT a human escalation. ``None`` (caller records a terminal FAILED, as today) only
+    when the flag is OFF or no reset is known at all (nothing to re-arm to).
+
+    An ALREADY-ELAPSED *resets_at* is clamped to :data:`ELAPSED_RESET_GRACE` ahead rather than
+    refused. Parking on a past instant would be dead on arrival — the recovery chain clears it
+    on its very next tick — but REFUSING outright is worse than the churn it prevents: the
+    caller then records a terminal FAILED whose ``all tokens exhausted`` signature maps to
+    :attr:`LimitCause.SUBSCRIPTION_WEEKLY`, so the transient-requeue horizon is SEVEN DAYS. A
+    stale reset is normally an outage artefact that clears in minutes, so the grace clamp keeps
+    recovery at minutes scale while still keying the window in the FUTURE (no instant
+    self-clear).
     """
     if not autorecovery_enabled() or resets_at is None:
         return None
     moment = now or timezone.now()
-    if resets_at <= moment:
-        logger.warning(
-            "Task %s NOT parked — all %s accounts exhausted but the reported reset %s has already passed",
-            task.pk,
-            lane or "ambient",
-            resets_at.isoformat(),
-        )
-        return None
-    UsageWindowState.record_limit(lane=lane, cause=_ALL_EXHAUSTED_CAUSE, resets_at=resets_at, now=moment)
-    _auto_engage_low_power(resets_at, moment)
+    reset = _future_park_instant(resets_at, moment)
+    UsageWindowState.record_limit(lane=lane, cause=_ALL_EXHAUSTED_CAUSE, resets_at=reset, now=moment)
+    _auto_engage_low_power(reset, moment)
     logger.warning(
         "Task %s parked — all %s accounts exhausted; auto-resume at %s",
         task.pk,
         lane or "ambient",
-        resets_at.isoformat(),
+        reset.isoformat(),
     )
     reason = f"{LIMIT_PARKED_PREFIX}all configured subscription accounts exhausted — auto-resume at reset"
-    return _record_park(task, reason=reason, not_before=resets_at)
+    return _record_park(task, reason=reason, not_before=reset)
 
 
 def _auto_engage_low_power(reset: datetime, moment: datetime) -> None:

--- a/src/teatree/credential_config.py
+++ b/src/teatree/credential_config.py
@@ -109,8 +109,10 @@ class AllTokensExhaustedError(CredentialError):
 
     def __init__(self, message: str, *, earliest_reset: dt.datetime | None = None) -> None:
         super().__init__(message)
-        #: The soonest an account frees up — the earliest window reset across all exhausted
-        #: accounts, or ``None`` when no reset is known. NOT a token; a schedule instant.
+        #: The soonest an account frees up — the MINIMUM over exhausted accounts of each
+        #: account's own ``frees_up_at`` (itself the LATEST of that account's blocking-window
+        #: resets, since all of them must clear before it is usable). ``None`` when no
+        #: blocking window has a known reset. NOT a token; a schedule instant.
         self.earliest_reset = earliest_reset
 
 
@@ -368,8 +370,8 @@ def record_reactive_exhaustion_and_reselect(
 
     * returns the next healthy account's ``pass_path`` — another account is available, so the
         caller REQUEUES the task to rotate onto it rather than parking the whole lane;
-    * raises :class:`AllTokensExhaustedError` (carrying the earliest reset) when every account
-        is now exhausted, so the caller parks the lane for auto-resume at the soonest reset;
+    * raises :class:`AllTokensExhaustedError` (carrying the soonest instant any account frees
+        up) when every account is now exhausted, so the caller parks the lane for auto-resume;
     * returns ``None`` when nothing is routed (no sticky account — an ambient-env or single
         unrouted credential), so the caller falls back to the existing lane park unchanged.
     """

--- a/src/teatree/loops/usage_window_recovery.py
+++ b/src/teatree/loops/usage_window_recovery.py
@@ -131,10 +131,19 @@ def _wake_loops(now: dt.datetime) -> None:
 
 
 def _notify_recovered(*, cleared_pks: list[int], released: int, now: dt.datetime) -> None:
-    """Post ONE bot→user Slack line that the window(s) recovered — no-op-safe, never raises."""
+    """Post ONE bot→user Slack line that the window(s) recovered — no-op-safe, never raises.
+
+    Silent when the clear RELEASED NOTHING. The line's whole claim is "resumed the loop", so
+    with zero released tasks it reports a state change the owner cannot act on and did not
+    lose anything to. That is the shape every message in the observed flood had (313 windows,
+    315 DMs, ``released 0`` on every one): whatever re-opens a window in a tight loop, an
+    owner DM per cycle is noise. The INFO log below still records every clear for audit.
+    """
     from teatree.core.modelkit.notify_policy import NotifyAudience  # noqa: PLC0415 — deferred (cycle-safe)
     from teatree.core.notify import NotifyKind, notify_user  # noqa: PLC0415 — deferred import (cycle-safe / task-body)
 
+    if released == 0:
+        return
     key = "usage_window_recovered:" + "-".join(str(pk) for pk in sorted(cleared_pks))
     text = (
         f"Usage window restored {now:%H:%M} — cleared {len(cleared_pks)} window(s), "

--- a/tests/teatree_agents/test_usage_window.py
+++ b/tests/teatree_agents/test_usage_window.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 
 import teatree.agents.usage_window as usage_window_mod
 from teatree.agents.usage_window import (
+    ELAPSED_RESET_GRACE,
     effective_resets_at,
     maybe_park_for_active_window,
     park_or_rotate_on_limit,
@@ -429,12 +430,14 @@ class TestParkTaskOnAllExhausted(django.test.TestCase):
         assert park_task_on_all_exhausted(task, resets_at=None, lane="subscription") is None
         assert not UsageWindowState.objects.exists()
 
-    def test_an_already_elapsed_reset_is_not_parked(self) -> None:
-        """A park keyed on a past instant is dead on arrival — refuse it.
+    def test_an_already_elapsed_reset_is_clamped_forward_not_refused(self) -> None:
+        """A past reset still PARKS — clamped ahead — because refusing costs SEVEN DAYS.
 
-        The recovery chain would clear such a window on its very next tick and DM the owner
-        "usage window restored"; a caller that keeps re-deriving an elapsed reset therefore
-        floods the owner at the poll cadence instead of surfacing the real failure.
+        Parking on a past instant would be dead on arrival (the recovery chain clears it on
+        its very next tick and re-parks at the poll cadence). But refusing outright is worse:
+        the caller records a terminal FAILED whose ``all tokens exhausted`` signature maps to
+        ``SUBSCRIPTION_WEEKLY``, so the transient-requeue horizon becomes 7 days for what is
+        normally a minutes-long outage artefact.
         """
         _set_autorecovery(on=True)
         now = timezone.now()
@@ -444,5 +447,22 @@ class TestParkTaskOnAllExhausted(django.test.TestCase):
             task, resets_at=now - timedelta(seconds=1), lane=TaskAttempt.Lane.SUBSCRIPTION, now=now
         )
 
-        assert parked is None, "the caller falls back to its terminal path rather than parking"
-        assert not UsageWindowState.objects.exists(), "no self-clearing window is written"
+        assert parked is not None, "still parked — a stale reset must not become a terminal FAILED"
+        window = UsageWindowState.objects.active_for_lane(TaskAttempt.Lane.SUBSCRIPTION)
+        assert window is not None
+        assert window.resets_at == now + ELAPSED_RESET_GRACE, "clamped to the grace horizon"
+        assert not window.should_clear(now), "keyed in the FUTURE, so no instant self-clear + DM"
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING, "quiesced, not failed"
+
+    def test_a_future_reset_is_left_untouched(self) -> None:
+        _set_autorecovery(on=True)
+        now = timezone.now()
+        reset = now + timedelta(hours=3)
+        task = _claimed_task()
+
+        park_task_on_all_exhausted(task, resets_at=reset, lane=TaskAttempt.Lane.SUBSCRIPTION, now=now)
+
+        window = UsageWindowState.objects.active_for_lane(TaskAttempt.Lane.SUBSCRIPTION)
+        assert window is not None
+        assert window.resets_at == reset, "a real future reset is never clamped"

--- a/tests/teatree_loops/test_usage_window_recovery.py
+++ b/tests/teatree_loops/test_usage_window_recovery.py
@@ -115,6 +115,31 @@ class TestReArmsOnlyAfterReset(django.test.TestCase):
         recover_windows(reset)
         assert BotPing.objects.filter(idempotency_key__startswith="usage_window_recovered:").exists()
 
+    def test_a_clear_that_released_nothing_is_silent(self) -> None:
+        """No parked task released → no owner DM. The message claims "resumed the loop".
+
+        This is the shape of every message in the observed flood (313 windows opened in 24h,
+        315 DMs, ``released 0 parked task(s)`` on every single one): a window that opens and
+        clears without ever gating work is bookkeeping, not news. The clear still happens and
+        is still logged — only the Slack line is withheld.
+        """
+        now = timezone.now()
+        reset = now + timedelta(hours=5)
+        window = UsageWindowState.record_limit(
+            lane=TaskAttempt.Lane.SUBSCRIPTION,
+            cause=LimitCause.SUBSCRIPTION_SESSION.value,
+            resets_at=reset,
+            now=now,
+        )
+
+        outcome = recover_windows(reset)  # no parked task seeded
+
+        assert outcome.cleared == [window.pk], "the window still clears"
+        assert outcome.released == 0
+        window.refresh_from_db()
+        assert window.cleared_at is not None, "clearing is unaffected — only the DM is withheld"
+        assert not BotPing.objects.filter(idempotency_key__startswith="usage_window_recovered:").exists()
+
     def test_all_accounts_exhausted_park_auto_resumes_at_reset(self) -> None:
         # A task parked because every configured account drained must auto-resume at its reset.
         from teatree.agents.usage_window import park_task_on_all_exhausted  # noqa: PLC0415 — test-local

--- a/tests/test_credential_config.py
+++ b/tests/test_credential_config.py
@@ -210,6 +210,51 @@ class TestSelectorRouting(TestCase):
         assert soon.isoformat() in message, "the loud error names the soonest an account frees up"
         assert caught.value.earliest_reset == soon, "the earliest reset is carried as a datetime for the C2 park"
 
+    def test_earliest_reset_ignores_an_idle_windows_elapsed_reset(self) -> None:
+        """The DM-flood signature: rejected on 7d, idle 5h whose reset has already rolled past.
+
+        Pins the selector seam itself. Every other fixture here gives an account the SAME
+        instant for both windows, so ``earliest_reset`` and ``frees_up_at`` coincide and the
+        load-bearing ``_all_exhausted_error`` line could be reverted with the suite still
+        green. Here they diverge: the naive min-of-resets answer is the PAST 5h instant, which
+        is what parked a dead-on-arrival window and DM'd the owner once a minute.
+        """
+        now = timezone.now()
+        stale_5h = now - dt.timedelta(minutes=1)
+        blocking_7d = now + dt.timedelta(hours=14)
+        far_7d = now + dt.timedelta(days=3)
+        ConfigSetting.objects.set_value(_OAUTH_SETTING, ["anthropic/a/oauth", "anthropic/b/oauth"])
+        reader = _FakeReader(
+            {
+                "anthropic/a/oauth": RateLimitSnapshot(
+                    organization_id="org-1",
+                    unified_5h_status="allowed",
+                    unified_5h_utilization=0.0,  # idle — this window blocks NOTHING
+                    unified_5h_reset=stale_5h,
+                    unified_7d_status="rejected",
+                    unified_7d_utilization=1.0,
+                    unified_7d_reset=blocking_7d,
+                    retry_after=None,
+                ),
+                "anthropic/b/oauth": RateLimitSnapshot(
+                    organization_id="org-1",
+                    unified_5h_status="allowed",
+                    unified_5h_utilization=0.0,
+                    unified_5h_reset=stale_5h,
+                    unified_7d_status="rejected",
+                    unified_7d_utilization=1.0,
+                    unified_7d_reset=far_7d,
+                    retry_after=None,
+                ),
+            }
+        )
+
+        with _pass_echoes_path(), pytest.raises(AllTokensExhaustedError) as caught:
+            PassPathSelector(reader=reader).select(TokenKind.OAUTH)
+
+        assert caught.value.earliest_reset == blocking_7d, "the soonest BLOCKING window, not the idle 5h one"
+        assert caught.value.earliest_reset > now, "a park keyed on this must never be already elapsed"
+
 
 class TestSelectorRescueReprobe(TestCase):
     """#3406: a cached-exhausted verdict outlives a rolling window's real recovery.


### PR DESCRIPTION
Follow-up to #3493, addressing findings from its independent cold review.

#3493 fixed the root cause of the usage-window DM flood (`frees_up_at` — the reset of the window actually **blocking** an account, rather than the soonest reset on record). That part is correct and is unchanged here. But it also added a defense-in-depth guard that **refused** to park when the reset had already elapsed, and that guard is worse than the churn it prevents.

## The regression this fixes

A refused park sends the caller to a terminal FAILED. That error carries the `all tokens exhausted` signature, which `recoverable_exhaustion_cause` (`src/teatree/llm/anthropic_limits.py:167`) maps to `SUBSCRIPTION_WEEKLY` — so the transient-requeue horizon becomes **seven days** (`anthropic_limits.py:118`).

An elapsed reset is normally an outage artefact that clears in minutes: a failed probe, clock skew, an SDK processing delay. So #3493 traded a noisy loop for tasks sleeping up to a week. Two aggravating factors:

- `agents/headless.py:321` passes `resets_at=exc.earliest_reset` with **no fallback**, so a refusal there goes straight to FAILED.
- With no window recorded, the admission guard stops quiescing the lane — every queued dispatch burns its own attempt and fails individually, instead of one park covering them all.

## Changes

**1. Clamp forward instead of refusing.** `_future_park_instant` pushes an elapsed reset to `ELAPSED_RESET_GRACE` (5 min) ahead. The window is still keyed in the *future*, so it cannot self-clear on the next recovery tick and re-notify — while recovery stays at minutes scale. An elapsed reset means the true re-arm instant is **unknown**, not that the lane is free, so the park is kept rather than dropped.

**2. Both park writers share the clamp.** `park_task_on_limit` was unguarded and could persist the same self-clearing window from a delayed SDK `resets_at`. #3493's commit message claimed the class was closed when only one of the two writers was actually covered.

**3. A clear that released nothing is silent.** `_notify_recovered` returns early when `released == 0`. The line claims "resumed the loop", so with zero released tasks it reports a state change the owner cannot act on — and that is the shape of **all 315 flood DMs**, every one reading `released 0 parked task(s)`. The clear itself and its INFO log are unchanged; only the Slack line is withheld. This is the belt-and-braces guarantee that no future re-park loop can flood the owner again, whatever its cause.

**4. Pin the load-bearing selector line.** Every existing fixture gave an account the *same* instant for both windows, so `earliest_reset` and `frees_up_at` coincided — meaning #3493's actual fix could be reverted with the entire suite still green. `test_earliest_reset_ignores_an_idle_windows_elapsed_reset` drives them apart with the live flood signature (idle 5h whose reset has rolled past, rejected 7d in the future).

**5. Docstring truth-ups** for the sites still describing the old min-of-resets semantics (`AllTokensExhaustedError.earliest_reset`, `park_task_on_all_exhausted`, `record_reactive_exhaustion_and_reselect`).

## Testing

Regression tests observed **RED before the fix** (per `/t3:code` TDD discipline), verified by stashing `src/` against merged main:

- `test_a_clear_that_released_nothing_is_silent` — failed (`assert not True`: the DM was sent)
- `test_an_already_elapsed_reset_is_clamped_forward_not_refused` / `test_a_future_reset_is_left_untouched` — collection error (`ELAPSED_RESET_GRACE` absent on main)
- `test_earliest_reset_ignores_an_idle_windows_elapsed_reset` — passes on main by design; it *pins* the already-merged line so a revert goes red

210 tests pass across the model, agents, credential, recovery-loop, and headless suites. `bash dev/ci-parity.sh` was running at push time; CI here is the authoritative gate.

## Known follow-up (deliberately not in this PR)

The dash health band (`src/teatree/dash/health_bands.py:177`) still displays `earliest_reset`, so an exhausted account can show a past instant an operator may read as "back at". Display-only, and changing it churns a dataclass plus its tests — worth its own change.
