### PR TITLE
fix(statusline): collapse loops under an engaged preset + spelled-out schedule→preset→overdue→forced layout

### DIFF
--- a/src/teatree/core/management/commands/loops_tick.py
+++ b/src/teatree/core/management/commands/loops_tick.py
@@ -58,8 +58,8 @@ from teatree.core.loop_lease_manager import PER_LOOP_TICK_MUTEX_PREFIX, per_loop
 from teatree.core.models import LoopLease
 from teatree.loop.loop_cadences import loop_owner_ttl_seconds
 from teatree.loop.preset_resolution import active_overlay_scope
-from teatree.loop.statusline import set_overridden_loops_reader, set_preset_segment_reader
-from teatree.loops.preset_status import overridden_loop_names, preset_line_chunk
+from teatree.loop.statusline import set_overridden_loops_reader, set_preset_line_reader
+from teatree.loops.preset_status import overridden_loop_names, preset_line_handles
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -324,14 +324,14 @@ class Command(TyperCommand):
         # installed together with the preset segment that represents the folded
         # loops), then reset after the tick so the process-global seams never leak.
         set_mini_loop_schedules_reader(mini_loop_schedules)
-        set_preset_segment_reader(preset_line_chunk)
+        set_preset_line_reader(preset_line_handles)
         set_overridden_loops_reader(overridden_loop_names)
         try:
             request = self._build_request(overlay)
             report = run_tick(request, statusline_path=statusline_file, jobs_builder=_scoped_jobs_builder(loop))
         finally:
             set_mini_loop_schedules_reader(None)
-            set_preset_segment_reader(None)
+            set_preset_line_reader(None)
             set_overridden_loops_reader(None)
             LoopLease.objects.release(tick_mutex, owner=owner)
 

--- a/src/teatree/loop/statusline.py
+++ b/src/teatree/loop/statusline.py
@@ -22,6 +22,7 @@ home (``teatree.loop.statusline``); identity is preserved so
 """
 
 from teatree.loop.statusline_loops import (
+    PresetLineHandles,
     availability_segment,
     dashboard_head_anchor,
     health_chip,
@@ -31,7 +32,7 @@ from teatree.loop.statusline_loops import (
     overlays_anchor,
     set_mini_loop_schedules_reader,
     set_overridden_loops_reader,
-    set_preset_segment_reader,
+    set_preset_line_reader,
 )
 from teatree.loop.statusline_render import (
     StatuslineEntry,
@@ -45,6 +46,7 @@ from teatree.loop.statusline_render import (
 )
 
 __all__ = [
+    "PresetLineHandles",
     "StatuslineEntry",
     "StatuslineZones",
     "ZoneItem",
@@ -61,6 +63,6 @@ __all__ = [
     "render",
     "set_mini_loop_schedules_reader",
     "set_overridden_loops_reader",
-    "set_preset_segment_reader",
+    "set_preset_line_reader",
     "statusline_for_slack",
 ]

--- a/src/teatree/loop/statusline_loop_chunks.py
+++ b/src/teatree/loop/statusline_loop_chunks.py
@@ -275,14 +275,36 @@ def lease_chunks(
     ]
 
 
+def _mini_loop_due_soon(next_fire_at: datetime | None) -> bool:
+    """Whether a mini-loop is a ``due:`` candidate: never fired, overdue, or due-soon.
+
+    The section only ever shows crons whose next fire is now or within
+    :data:`_DUE_SOON_SECONDS` — the same horizon :func:`_lease_is_due_now`
+    applies to the per-loop leases, so the two due views stay consistent.
+    """
+    return next_fire_at is None or _seconds_until(next_fire_at) <= _DUE_SOON_SECONDS
+
+
+def _mini_loop_overdue(next_fire_at: datetime | None) -> bool:
+    """Whether a mini-loop is GENUINELY late: never fired, or its fire instant is now/past.
+
+    The exception the collapsed ``overdue:`` section surfaces by name — a cron
+    that has slipped its cadence (or never fired at all), NOT one merely due-soon
+    on its normal cadence (which the engaged preset handle already represents).
+    """
+    return next_fire_at is None or _seconds_until(next_fire_at) <= 0
+
+
 def mini_loop_chunks(schedules: list[tuple[str, datetime | None, int]], *, colorize: bool = False) -> list[str]:
     """Return a ``<name> <next-tick>`` chunk per DUE-SOON domain mini-loop (#3248).
 
-    Companion to :func:`lease_chunks`: this renders the enabled domain crons from
-    the cadence ledger that are due now (never fired / overdue) or within
-    :data:`_DUE_SOON_SECONDS` — NOT the full loop list (presets/schedules are the
-    handle). Each carries its own next-tick countdown and (when *colorize* is set)
-    its cadence-relative recency color.
+    Companion to :func:`lease_chunks` and the no-preset ``due:`` path: renders the
+    enabled domain crons from the cadence ledger that are due now (never fired /
+    overdue) or within :data:`_DUE_SOON_SECONDS` — NOT the full loop list. Each
+    carries its own next-tick countdown and (when *colorize* is set) its
+    cadence-relative recency color. When a preset governs the line the caller
+    instead surfaces only the overdue exceptions by name via
+    :func:`overdue_mini_loop_names`.
     """
     return [
         _colorize_chunk(
@@ -291,5 +313,18 @@ def mini_loop_chunks(schedules: list[tuple[str, datetime | None, int]], *, color
             colorize=colorize,
         )
         for name, next_fire_at, cadence in schedules
-        if next_fire_at is None or _seconds_until(next_fire_at) <= _DUE_SOON_SECONDS
+        if _mini_loop_due_soon(next_fire_at)
     ]
+
+
+def overdue_mini_loop_names(schedules: list[tuple[str, datetime | None, int]]) -> list[str]:
+    """Return the names of genuinely-overdue / never-fired domain mini-loops (#3494).
+
+    The engaged-preset ``overdue:`` path: the domain crons collapse into the
+    preset handle and only the exceptions the handle does NOT represent — the ones
+    that have slipped their cadence or never fired (:func:`_mini_loop_overdue`) —
+    surface, by bare name (no per-item countdown; they are all past due). The
+    schedule source already returns the crons sorted by name, so the order is
+    deterministic.
+    """
+    return [name for name, next_fire_at, _cadence in schedules if _mini_loop_overdue(next_fire_at)]

--- a/src/teatree/loop/statusline_loops.py
+++ b/src/teatree/loop/statusline_loops.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -9,7 +10,13 @@ from teatree.loop.loop_cadences import (
     slack_answer_cadence_seconds,
 )
 from teatree.loop.loop_scoping import current_session_owned_per_loop_slots
-from teatree.loop.statusline_loop_chunks import LeaseRenderContext, _colorize_chunk, lease_chunks, mini_loop_chunks
+from teatree.loop.statusline_loop_chunks import (
+    LeaseRenderContext,
+    _colorize_chunk,
+    lease_chunks,
+    mini_loop_chunks,
+    overdue_mini_loop_names,
+)
 from teatree.loop.statusline_palette import _ANSI_GREEN, _ANSI_RED, _ANSI_YELLOW
 
 if TYPE_CHECKING:
@@ -18,12 +25,14 @@ if TYPE_CHECKING:
 
 
 def availability_segment(resolution: "Resolution") -> str:
-    """Return the loop line's availability segment (#58, #1678).
+    """Return the loop line's availability segment (#58, #1678, #3494).
 
-    Renders ``availability: <present|away> (<source>)`` so the user reads the
-    currently-resolved availability and which layer decided it (override /
-    schedule / default) at a glance, as one ``·``-separated segment of the
-    dedicated loop line.
+    Renders ``availability: <present|away>`` — spelled out, so the user reads the
+    currently-resolved availability at a glance as one ``·``-separated segment of
+    the dedicated loop line. The deciding layer (override / schedule / default) is
+    intentionally NOT shown here: the owner's clarified layout keeps the segment to
+    the bare state, and the ``preset:`` / ``schedule:`` handles already surface the
+    governing layer.
 
     The ``availability:`` label is deliberately distinct from the config
     ``Mode`` enum (auto/interactive) and other ``mode=`` usages, which the bare
@@ -33,7 +42,7 @@ def availability_segment(resolution: "Resolution") -> str:
 
     if resolution.mode not in VALID_MODES:
         return ""
-    return f"availability: {resolution.mode} ({resolution.source})"
+    return f"availability: {resolution.mode}"
 
 
 def _configured_overlay_names() -> list[str]:
@@ -197,37 +206,60 @@ def _mini_loop_schedules() -> list[MiniLoopSchedule]:
     return _mini_loop_schedules_reader()
 
 
-# The active-preset statusline segment (#3159) is resolved up-stack in
-# :func:`teatree.loops.preset_status.statusline_chunk` (the resolver lives in
-# ``teatree.loops``), injected here through the same seam as the mini-loop
-# reader. Absent injection (a quiet machine, a unit test) the default reader
-# returns ``""`` and the preset segment is simply omitted — never a crash.
-type PresetSegmentReader = Callable[[], str]
+@dataclass(frozen=True, slots=True)
+class PresetLineHandles:
+    """The three ordered handles the loop line renders around the loop chunks (#3494).
+
+    The summary handles LEAD the line and the per-loop overrides trail the loops,
+    so the single up-stack reader resolves the three sub-segments separately
+    rather than pre-joining them:
+
+    *   ``schedule`` — the active weekly schedule, spelled out:
+        ``schedule: standard`` or ``schedule: none active`` (always shown).
+    *   ``preset`` — the governing preset: ``preset: <name>`` (schedule-driven)
+        or ``preset: manual`` (manual override); ``""`` when none governs.
+    *   ``override`` — the ``forced ON: <names>`` / ``forced OFF: <names>``
+        per-loop manual-override segment; ``""`` when none diverge.
+
+    The renderer drops the empty ones.
+    """
+
+    schedule: str
+    preset: str
+    override: str
 
 
-def _empty_preset_segment() -> str:
-    return ""
+# The active preset/schedule/override handles (#3159, #3248, #3494) are resolved
+# up-stack in :func:`teatree.loops.preset_status.preset_line_handles` (the resolver
+# lives in ``teatree.loops``), injected here through the same seam as the mini-loop
+# reader. Absent injection (a quiet machine, a unit test) the default reader returns
+# empty handles and the preset segments are simply omitted — never a crash.
+type PresetLineReader = Callable[[], PresetLineHandles]
 
 
-_preset_segment_reader: PresetSegmentReader = _empty_preset_segment
+def _empty_preset_handles() -> PresetLineHandles:
+    return PresetLineHandles(schedule="", preset="", override="")
 
 
-def set_preset_segment_reader(reader: PresetSegmentReader | None) -> None:
-    """Install the up-stack active-preset segment reader (``None`` resets to empty)."""
-    global _preset_segment_reader  # noqa: PLW0603 — process-global injection seam, mirrors set_mini_loop_schedules_reader
-    _preset_segment_reader = reader or _empty_preset_segment
+_preset_line_reader: PresetLineReader = _empty_preset_handles
 
 
-def _preset_segment() -> str:
-    """Return the active-preset statusline segment (``preset heads-down →19:00``), or ``""``.
+def set_preset_line_reader(reader: PresetLineReader | None) -> None:
+    """Install the up-stack preset-line handles reader (``None`` resets to empty)."""
+    global _preset_line_reader  # noqa: PLW0603 — process-global injection seam, mirrors set_mini_loop_schedules_reader
+    _preset_line_reader = reader or _empty_preset_handles
 
-    Fails open to ``""`` on any read error so a broken preset resolver never
-    blanks the loop line.
+
+def _preset_line_handles() -> PresetLineHandles:
+    """Return the active schedule / preset / override handles, or empty ones.
+
+    Fails open to empty handles on any read error so a broken preset resolver
+    never blanks the loop line.
     """
     try:
-        return _preset_segment_reader()
-    except Exception:  # noqa: BLE001 — rendering is best-effort; a failure degrades to empty
-        return ""
+        return _preset_line_reader()
+    except Exception:  # noqa: BLE001 — rendering is best-effort; a failure degrades to empty handles
+        return _empty_preset_handles()
 
 
 # The set of manually-overridden loop names (#3248) is resolved up-stack in
@@ -250,12 +282,12 @@ _overridden_loops_reader: OverriddenLoopsReader | None = None
 def set_overridden_loops_reader(reader: OverriddenLoopsReader | None) -> None:
     """Install the up-stack manually-overridden-loop-names reader (``None`` resets to uninjected).
 
-    Mirrors :func:`set_preset_segment_reader`; the ``loops_tick`` per-loop
-    command installs it alongside the preset segment reader so the collapse and
+    Mirrors :func:`set_preset_line_reader`; the ``loops_tick`` per-loop
+    command installs it alongside the preset-line reader so the collapse and
     the ``ovr:`` handle are always rendered together, then resets it after the
     tick so the process-global seam never leaks.
     """
-    global _overridden_loops_reader  # noqa: PLW0603 — process-global injection seam, mirrors set_preset_segment_reader
+    global _overridden_loops_reader  # noqa: PLW0603 — process-global injection seam, mirrors set_preset_line_reader
     _overridden_loops_reader = reader
 
 
@@ -367,81 +399,105 @@ def live_loops_anchor(*, colorize: bool = False) -> list[str]:
     """Return the single dedicated loop line for the dashboard (#1400, #130).
 
     Single line, prepended at the top of the statusline so the user's
-    "which loops are running, when does each tick next, and am I blocked?"
-    question is answered with one glance:
+    "what governs now, what's overdue, and am I blocked?" question is answered
+    with one glance. Spelled-out, labeled order (#3494):
 
-        ``tick 11m · dispatch 2m · tickets 4m · news 18m · waiting: 2 questions``
+        ``schedule: none active · preset: manual · overdue: snapshot_warmer,
+        triage_assessor · forced ON: triage_assessor · availability: present ·
+        4 waiting``
 
-    Shape:
+    Shape, in render order:
 
-    *   the line leads with the live loops' own chunks. The line is only
-        ever rendered when at least one loop or cron is active; when none
-        is, the function returns ``[]`` and the line is silenced entirely
-        (no ``idle`` line is shown). The ``tick <next-tick>`` chunk already
-        carries the loop's liveness, so no separate ``loop running`` state
-        word precedes it. The foreign-hijack case is NOT shown here — it is
-        RED and routed to the action line by :func:`loop_owner_anchor`.
-    *   one ``<short-name> <next-tick>`` chunk per live infra
-        :class:`~teatree.core.models.LoopLease` (``tick``,
-        ``self-improve``, ``slack-answer``) — see :func:`_live_lease_chunks`.
-    *   one ``<name> <next-tick>`` chunk per ENABLED domain mini-loop /
-        cron (``dispatch``, ``tickets``, ``review``, ``ship``, ``inbox``,
-        ``resource_pressure``, …) — see :func:`_mini_loop_chunks`. Every
-        chunk's ``<next-tick>`` is the RELATIVE whole-minute countdown to
-        THAT loop's own next fire (``2m``), derived live from its own
-        cadence and last-fired instant — not one shared constant — so a
-        fast 60s cron and a slow 1h cron show different countdowns and the
-        whole line counts down across renders. ``due`` replaces the
-        duration when a loop is overdue or has never fired.
-    *   ``availability: <present|away> (<source>)`` — the currently-resolved
-        availability, read live at render time (:func:`_availability_segment`)
-        so the user always sees the present/away value and which layer decided
-        it, never a cached one.
-    *   ``waiting=N`` — appended ONLY when N > 0 things are waiting on the
-        user across the durable waiting-on-you lane (unresolved questions,
-        PRs awaiting a merge authorization, pending review requests, manual
-        items — :func:`teatree.core.waiting.gather_waiting`), so the dashboard
-        surfaces "you owe N things" without the user hunting for them.
+    *   ``schedule: <name>`` / ``schedule: none active`` — the active weekly
+        schedule, always spelled out (:func:`teatree.loops.preset_status.schedule_chunk`).
+    *   ``preset: <name>`` (schedule-driven) / ``preset: manual`` (manual
+        override) — the governing preset, or omitted when none governs. An
+        ENGAGED preset is the summary handle the domain loops fold under.
+    *   the loop section:
 
-    Each per-loop chunk is colored by its imminence relative to its own
-    cadence (:func:`_loop_recency_color`) when *colorize* is on — green when
-    it just ticked / has plenty of time, yellow as it approaches, red when it
-    is about to tick or overdue — so the user reads at a glance which loops
-    are fresh and which are due. *colorize* defaults to ``False`` (the
-    plain-text builder output); the render orchestrators (:func:`zones_for`,
-    :func:`teatree.loop.tick.run_tick`) pass the ``NO_COLOR``-resolved value.
-    The availability and waiting segments stay the line's baseline dim.
+        -   with a preset engaged, ``overdue: <name>, <name>`` — ONLY the
+            genuinely-overdue / never-fired domain crons; the routine due-soon
+            ones fold into the preset handle (:func:`_overdue_mini_loop_names`).
+        -   with no preset, the full due-soon ``due: <name> <next-tick> …``
+            countdown list (:func:`_mini_loop_chunks`) — every chunk's
+            ``<next-tick>`` is the RELATIVE whole-minute countdown to THAT loop's
+            own next fire, so a fast 60s cron and a slow 1h cron differ and the
+            line counts down across renders.
+    *   ``forced ON: <names>`` / ``forced OFF: <names>`` — the per-loop manual
+        overrides that diverge from the preset/base verdict.
+    *   ``availability: <present|away>`` — the currently-resolved availability,
+        read live at render time (:func:`_availability_segment`).
+    *   ``N waiting`` — appended ONLY when N > 0 things are waiting on the user
+        across the durable waiting-on-you lane (unresolved questions, PRs awaiting
+        a merge authorization, pending review requests, manual items —
+        :func:`teatree.core.waiting.gather_waiting`).
+    *   the live infra :class:`~teatree.core.models.LoopLease` chunks (``tick``,
+        ``self-improve``, ``slack-answer``, ``reinstall``) — kept unobtrusive at
+        the TAIL (:func:`_live_lease_chunks`), never between the preset and the
+        loops. The per-loop ``loop:<name>`` owner leases fold into the preset
+        handle (#3248); the foreign-hijack case is NOT shown here — it is RED and
+        routed to the action line by :func:`loop_owner_anchor`.
 
-    Returns ``[]`` when no infra lease, no enabled mini-loop, and no governing
-    preset/schedule handle is active — silences the line entirely on a quiet
-    machine. When the routine per-loop leases are all folded into the preset
-    handle (#3248) but that handle is present, the line still renders the handle
-    (it represents the folded loops). Fails open: any DB / import error degrades
-    to ``[]`` (or, for an individual segment, drops just that segment) so a
-    broken read can never blank the statusline.
+    Each chunk is colored by its imminence relative to its own cadence
+    (:func:`_loop_recency_color`) when *colorize* is on. *colorize* defaults to
+    ``False`` (the plain-text builder output); the render orchestrators
+    (:func:`zones_for`, :func:`teatree.loop.tick.run_tick`) pass the
+    ``NO_COLOR``-resolved value.
+
+    Returns ``[]`` when nothing substantive is live — no schedule / preset /
+    override handle, no loop section, and no infra lease — silencing the line on a
+    quiet machine (the availability and waiting decorations never keep an
+    otherwise-empty line alive). Fails open: any DB / import error degrades to
+    ``[]`` (or, for an individual segment, drops just that segment) so a broken
+    read can never blank the statusline.
     """
-    # Resolve the preset/schedule handle first: it both leads the collapse
-    # decision (a routine per-loop lease is only folded when a handle is present
-    # to represent it) and keeps the line alive when every lease has folded away.
-    preset = _preset_segment()
-    leases = _live_lease_chunks(colorize=colorize, handle_present=bool(preset))
-    due = _mini_loop_chunks(colorize=colorize)
-    if not leases and not due and not preset:
+    # Resolve the schedule / preset / override handles first. The schedule and
+    # preset lead the line as the summary handles the loops fold under, and an
+    # ENGAGED PRESET (manual override or a schedule-driven one) drives the collapse
+    # decision — a routine per-loop lease is only folded when a preset is present
+    # to represent it, and the domain crons then show only their genuinely-overdue
+    # exceptions. The override segment trails the loops it annotates.
+    handles = _preset_line_handles()
+    governing = bool(handles.preset)
+    leases = _live_lease_chunks(colorize=colorize, handle_present=governing)
+
+    # Under an engaged preset the domain crons collapse to a single ``overdue:``
+    # label listing only the genuinely-overdue / never-fired exceptions; with no
+    # preset the full due-soon ``due:`` countdown list renders (today's behavior).
+    if governing:
+        overdue = _overdue_mini_loop_names()
+        loop_section = "overdue: " + ", ".join(overdue) if overdue else ""
+    else:
+        due = _mini_loop_chunks(colorize=colorize)
+        loop_section = "due: " + " ".join(due) if due else ""
+
+    # The line is silenced only when nothing substantive is live — no schedule /
+    # preset / override handle, no loop section, and no infra lease. The
+    # availability and waiting segments are trailing decorations that never keep
+    # an otherwise-empty line alive (a quiet machine shows no loop line).
+    substantive = handles.schedule or handles.preset or handles.override or loop_section or leases
+    if not substantive:
         return []
 
-    # Due-soon mini-loops ride a single ``due:`` section (#3248) rather than the
-    # old full per-loop dump; the infra leases keep leading the line.
-    parts = [*leases]
-    if due:
-        parts.append("due: " + " ".join(due))
-    if preset:
-        parts.append(preset)
+    # Order (#3494): schedule -> preset -> loops (overdue/due) -> overrides ->
+    # availability -> waiting -> infra leases (kept unobtrusive at the tail, never
+    # between the preset and the loops).
+    parts: list[str] = []
+    if handles.schedule:
+        parts.append(handles.schedule)
+    if handles.preset:
+        parts.append(handles.preset)
+    if loop_section:
+        parts.append(loop_section)
+    if handles.override:
+        parts.append(handles.override)
     availability = _availability_segment()
     if availability:
         parts.append(availability)
     waiting = _waiting_clause()
     if waiting:
         parts.append(waiting)
+    parts.extend(leases)
     return [" · ".join(parts)]
 
 
@@ -462,7 +518,7 @@ def _availability_segment() -> str:
 
 
 def _waiting_clause() -> str:
-    """Return ``waiting=N`` when N > 0 things wait on the user, else ``""`` (PR-21).
+    """Return ``N waiting`` when N > 0 things wait on the user, else ``""`` (PR-21).
 
     Fails open to ``""`` (no clause) on any read error so a broken
     :func:`teatree.core.waiting.gather_waiting` read never blanks the loop line.
@@ -473,7 +529,7 @@ def _waiting_clause() -> str:
         return ""
     if count <= 0:
         return ""
-    return f"waiting={count}"
+    return f"{count} waiting"
 
 
 def _waiting_count() -> int:
@@ -491,8 +547,8 @@ def _waiting_count() -> int:
 def _mini_loop_chunks(*, colorize: bool = False) -> list[str]:
     """Return a ``<name> <next-tick>`` chunk per DUE-SOON domain mini-loop (#3248).
 
-    The DB-read seam of the ``due:`` section: reads the cadence ledger
-    (:func:`_mini_loop_schedules`) then hands the schedules to
+    The DB-read seam of the ``due:`` section (the no-preset path): reads the
+    cadence ledger (:func:`_mini_loop_schedules`) then hands the schedules to
     :func:`teatree.loop.statusline_loop_chunks.mini_loop_chunks` for the due-soon
     filter + formatting. Fails open to ``[]`` on any DB / config read error so a
     broken ledger never blanks the line.
@@ -502,6 +558,23 @@ def _mini_loop_chunks(*, colorize: bool = False) -> list[str]:
     except Exception:  # noqa: BLE001 — rendering is best-effort; a failure degrades to no chunks
         return []
     return mini_loop_chunks(schedules, colorize=colorize)
+
+
+def _overdue_mini_loop_names() -> list[str]:
+    """Return the names of genuinely-overdue / never-fired domain mini-loops (#3494).
+
+    The DB-read seam of the ``overdue:`` section (the engaged-preset path): reads
+    the cadence ledger (:func:`_mini_loop_schedules`) then hands the schedules to
+    :func:`teatree.loop.statusline_loop_chunks.overdue_mini_loop_names` — the
+    collapsed exceptions the preset handle does NOT already represent. Fails open
+    to ``[]`` on any DB / config read error so a broken ledger never blanks the
+    line.
+    """
+    try:
+        schedules = _mini_loop_schedules()
+    except Exception:  # noqa: BLE001 — rendering is best-effort; a failure degrades to no names
+        return []
+    return overdue_mini_loop_names(schedules)
 
 
 def mini_loops_anchor() -> list[str]:

--- a/src/teatree/loops/preset_status.py
+++ b/src/teatree/loops/preset_status.py
@@ -19,6 +19,7 @@ from django.utils import timezone
 
 from teatree.loop.loop_state_db import control_planes_in_db, loop_state_admits
 from teatree.loop.preset_resolution import ActivePreset, preset_state_for, resolve_active_preset
+from teatree.loop.statusline_loops import PresetLineHandles
 
 
 @dataclass(frozen=True, slots=True)
@@ -71,32 +72,41 @@ def effective_verdicts(now: dt.datetime | None = None) -> list[LoopVerdict]:
 
 
 def statusline_chunk(now: dt.datetime | None = None) -> str:
-    """The one-chunk preset segment, or ``""`` when no preset governs.
+    """The one-chunk preset segment, or ``""`` when no preset governs (#3494).
 
-    Schedule-governed → ``preset engaged →19:00``. A MANUAL override (#3248) is
-    flagged ``preset ⚠heads-down (manual →21:00)`` so the operator sees the
-    active schedule is NOT the one governing. Sourced from the SAME resolver as
-    ``preset show`` so the two never disagree.
+    Spelled out for the loop line: a MANUAL override renders ``preset: manual``
+    (the layer, not the underlying preset name — the operator's cue that the
+    active schedule is NOT the one governing); a schedule-driven preset renders
+    ``preset: <name>``. A boundary is appended when the preset expires at a known
+    time (``preset: manual →21:00``). Sourced from the SAME resolver as ``preset
+    show`` so the two never disagree.
     """
     summary = active_summary(now)
     if summary is None:
         return ""
     boundary = _boundary_hhmm(summary.until)
     if summary.layer == "override":
-        return f"preset ⚠{summary.name} (manual{boundary})"
-    return f"preset {summary.name}{boundary}"
+        return f"preset: manual{boundary}"
+    return f"preset: {summary.name}{boundary}"
 
 
 def schedule_chunk() -> str:
-    """The active-schedule segment ``sched standard``, or ``""`` when no schedule is active."""
+    """The active-schedule segment, always spelled out (#3494).
+
+    ``schedule: <name>`` when a weekly schedule is active, else ``schedule: none
+    active`` — the schedule handle is always shown so the operator reads the
+    schedule state at a glance even when none governs. Fails open to ``schedule:
+    none active`` on a broken read.
+    """
     from teatree.core.models import ConfigSetting  # noqa: PLC0415 — deferred import (cycle-safe / pre-app-registry)
     from teatree.loop.preset_resolution import ACTIVE_SCHEDULE_SETTING  # noqa: PLC0415 — deferred: cycle-safe
 
     try:
         raw = ConfigSetting.objects.get_effective(ACTIVE_SCHEDULE_SETTING)
-    except Exception:  # noqa: BLE001 — rendering is best-effort; a broken read degrades to no segment
-        return ""
-    return f"sched {raw.strip()}" if isinstance(raw, str) and raw.strip() else ""
+    except Exception:  # noqa: BLE001 — rendering is best-effort; a broken read degrades to "none active"
+        return "schedule: none active"
+    name = raw.strip() if isinstance(raw, str) else ""
+    return f"schedule: {name}" if name else "schedule: none active"
 
 
 def manual_override_entries(now: dt.datetime | None = None) -> list[tuple[str, bool]]:
@@ -104,8 +114,9 @@ def manual_override_entries(now: dt.datetime | None = None) -> list[tuple[str, b
 
     Returns ``(loop_name, forced_on)`` for every loop whose live FORCED value
     differs from what the preset (else base ``Loop.enabled``) would decide - the
-    ``ovr:`` statusline section. A force that agrees with the underlying verdict
-    is not surfaced (it changes nothing). Sorted by name; fails open to ``[]``.
+    ``forced ON:`` / ``forced OFF:`` statusline section. A force that agrees with
+    the underlying verdict is not surfaced (it changes nothing). Sorted by name;
+    fails open to ``[]``.
     """
     from teatree.core.models import Loop  # noqa: PLC0415 — deferred import (cycle-safe / pre-app-registry)
 
@@ -125,11 +136,23 @@ def manual_override_entries(now: dt.datetime | None = None) -> list[tuple[str, b
 
 
 def manual_override_chunk(now: dt.datetime | None = None) -> str:
-    """The ``ovr: review- news+`` per-loop manual-override segment, or ``""`` when none diverge."""
+    """The spelled-out per-loop manual-override segment, or ``""`` when none diverge (#3494).
+
+    Splits the diverging forces into ``forced ON: <names>`` and ``forced OFF:
+    <names>`` (each a comma-separated, name-sorted list), joined with the loop
+    line's mid-dot when both are present — e.g. ``forced ON: triage_assessor``.
+    """
     entries = manual_override_entries(now)
     if not entries:
         return ""
-    return "ovr: " + " ".join(f"{name}{'+' if on else '-'}" for name, on in entries)
+    on = [name for name, forced_on in entries if forced_on]
+    off = [name for name, forced_on in entries if not forced_on]
+    parts = []
+    if on:
+        parts.append("forced ON: " + ", ".join(on))
+    if off:
+        parts.append("forced OFF: " + ", ".join(off))
+    return " · ".join(parts)
 
 
 def overridden_loop_names(now: dt.datetime | None = None) -> set[str]:
@@ -139,20 +162,40 @@ def overridden_loop_names(now: dt.datetime | None = None) -> set[str]:
     (:func:`teatree.loop.statusline_loops.live_loops_anchor`) keeps a
     ``loop:<name>`` chunk only for a manually-overridden loop; this is the
     injected selector it reads. Sharing :func:`manual_override_entries`'
-    divergence logic keeps the surfaced lease chunks and the ``ovr:`` segment
-    from ever disagreeing about which loops diverge from the handle.
+    divergence logic keeps the surfaced lease chunks and the ``forced ON:`` /
+    ``forced OFF:`` segment from ever disagreeing about which loops diverge from
+    the handle.
     """
     return {name for name, _ in manual_override_entries(now)}
 
 
-def preset_line_chunk(now: dt.datetime | None = None) -> str:
-    """The composed schedule/preset/override statusline segment (#3248), or ``""`` when nothing governs.
+def preset_line_handles(now: dt.datetime | None = None) -> PresetLineHandles:
+    """The three ordered loop-line handles (#3494): schedule, preset, per-loop overrides.
 
-    Joins the non-empty ``sched``, ``preset`` (with the ⚠manual marker), and
-    ``ovr:`` sub-segments with the mid-dot. The single injected preset-segment
-    reader the loop line renders, replacing the bare ``statusline_chunk``.
+    The injected reader the statusline loop line renders (installed by the
+    ``loops_tick`` per-loop command). Sourced from the SAME resolvers as
+    ``preset show`` / ``loops list``, so the observability surfaces never
+    disagree. The renderer places the schedule and preset handles ahead of the
+    loop chunks and the ``forced ON:`` / ``forced OFF:`` overrides after them.
     """
-    parts = [chunk for chunk in (schedule_chunk(), statusline_chunk(now), manual_override_chunk(now)) if chunk]
+    return PresetLineHandles(
+        schedule=schedule_chunk(),
+        preset=statusline_chunk(now),
+        override=manual_override_chunk(now),
+    )
+
+
+def preset_line_chunk(now: dt.datetime | None = None) -> str:
+    """The composed schedule/preset/override statusline segment (#3248, #3494).
+
+    Joins the non-empty ``schedule:``, ``preset:``, and ``forced ON:`` /
+    ``forced OFF:`` sub-segments with the mid-dot — the single-string bundled
+    view of :func:`preset_line_handles` for surfaces that want one flat segment.
+    Always at least ``schedule: none active`` (the schedule handle is always
+    shown).
+    """
+    handles = preset_line_handles(now)
+    parts = [chunk for chunk in (handles.schedule, handles.preset, handles.override) if chunk]
     return " · ".join(parts)
 
 
@@ -185,6 +228,7 @@ __all__ = [
     "manual_override_entries",
     "overridden_loop_names",
     "preset_line_chunk",
+    "preset_line_handles",
     "schedule_chunk",
     "statusline_chunk",
 ]

--- a/tests/teatree_loop/test_availability_anchor.py
+++ b/tests/teatree_loop/test_availability_anchor.py
@@ -1,8 +1,9 @@
-"""Tests for the availability segment on the loop line (#58, #1678).
+"""Tests for the availability segment on the loop line (#58, #1678, #3494).
 
-The loop line carries an ``availability: <present|away>
-(<source>)`` segment reflecting the currently-resolved availability, read
-live at render time. The label is deliberately distinct from the config
+The loop line carries an ``availability: <present|away>`` segment reflecting
+the currently-resolved availability, read live at render time. The deciding
+layer is intentionally not shown (the owner's spelled-out layout keeps the
+segment to the bare state). The label is deliberately distinct from the config
 ``Mode`` enum (auto/interactive) and from other ``mode=`` usages, and the
 old standalone ``mode=away`` line is gone.
 """
@@ -20,11 +21,11 @@ from teatree.loop.statusline import availability_segment, live_loops_anchor
 
 
 class TestAvailabilitySegment:
-    def test_present_segment_shows_explicit_label_and_source(self) -> None:
-        assert availability_segment(Resolution(mode="present", source="default")) == "availability: present (default)"
+    def test_present_segment_shows_explicit_label(self) -> None:
+        assert availability_segment(Resolution(mode="present", source="default")) == "availability: present"
 
-    def test_away_segment_shows_explicit_label_and_source(self) -> None:
-        assert availability_segment(Resolution(mode="away", source="schedule")) == "availability: away (schedule)"
+    def test_away_segment_shows_explicit_label(self) -> None:
+        assert availability_segment(Resolution(mode="away", source="schedule")) == "availability: away"
 
     def test_label_is_unambiguous_not_bare_mode(self) -> None:
         segment = availability_segment(Resolution(mode="away", source="override"))
@@ -57,19 +58,22 @@ class TestAvailabilitySegmentRidesLoopLineLive:
     def test_segment_tracks_a_live_away_then_present_flip(self, override_file: Path) -> None:
         write_override(MODE_AWAY)
         away_line = self._loop_line()
-        assert away_line.startswith("tick "), away_line
-        assert "· availability: away (override)" in away_line, away_line
+        # Infra leases sit at the tail; the availability segment reads the bare
+        # state with no deciding-layer source.
+        assert away_line.endswith("tick 10m"), away_line
+        assert "availability: away" in away_line, away_line
+        assert "(override)" not in away_line, away_line
 
         write_override(MODE_PRESENT)
         present_line = self._loop_line()
-        assert "· availability: present (override)" in present_line, present_line
+        assert "availability: present" in present_line, present_line
         assert "away" not in present_line, present_line
 
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db
 class TestWaitingCountCoversAllKinds:
-    """The loop-line ``waiting=N`` counts the whole waiting-on-you lane (PR-21)."""
+    """The loop-line ``N waiting`` counts the whole waiting-on-you lane (PR-21)."""
 
     def _loop_line(self) -> str:
         acquired_at = datetime.now(UTC) - timedelta(seconds=120)
@@ -89,4 +93,4 @@ class TestWaitingCountCoversAllKinds:
         WaitingItem.objects.add("chase finance")
         DeferredQuestion.record("deploy now?")
         # Two distinct kinds → the count is all-kinds, not questions-only.
-        assert "waiting=2" in self._loop_line()
+        assert "2 waiting" in self._loop_line()

--- a/tests/teatree_loop/test_statusline_dashboard_rework.py
+++ b/tests/teatree_loop/test_statusline_dashboard_rework.py
@@ -204,6 +204,7 @@ class TestLoopLineStateAndWaiting:
         with (
             patch("teatree.loop.statusline_loops._live_loop_leases", return_value=leases),
             patch("teatree.loop.statusline_loops._cadence_for_loop", return_value=720),
+            patch("teatree.loop.statusline_loops._availability_segment", return_value=""),
             patch("teatree.loop.statusline_loops._waiting_count", return_value=0),
         ):
             lines = live_loops_anchor()
@@ -220,7 +221,7 @@ class TestLoopLineStateAndWaiting:
             patch("teatree.loop.statusline_loops._waiting_count", return_value=2),
         ):
             lines = live_loops_anchor()
-        assert "waiting=2" in lines[0], lines[0]
+        assert "2 waiting" in lines[0], lines[0]
 
     def test_no_waiting_clause_when_no_pending(self) -> None:
         acquired_at = datetime.now(UTC) - timedelta(seconds=60)
@@ -239,6 +240,7 @@ class TestLoopLineStateAndWaiting:
         with (
             patch("teatree.loop.statusline_loops._live_loop_leases", return_value=leases),
             patch("teatree.loop.statusline_loops._cadence_for_loop", return_value=720),
+            patch("teatree.loop.statusline_loops._availability_segment", return_value=""),
             patch("teatree.loop.statusline_loops._waiting_count", side_effect=RuntimeError("db down")),
         ):
             lines = live_loops_anchor()

--- a/tests/teatree_loop/test_statusline_loop_owner_first.py
+++ b/tests/teatree_loop/test_statusline_loop_owner_first.py
@@ -62,7 +62,8 @@ class TestLoopRunningTokenDropped:
             patch("teatree.loop.statusline_loops._waiting_count", return_value=2),
         ):
             lines = live_loops_anchor()
-        assert lines == ["tick 10m · waiting=2"], lines
+        # #3494: ``N waiting`` spelled out; infra leases kept at the tail.
+        assert lines == ["2 waiting · tick 10m"], lines
 
     def test_still_empty_when_no_loops_live(self) -> None:
         with (

--- a/tests/teatree_loop/test_statusline_multiloop.py
+++ b/tests/teatree_loop/test_statusline_multiloop.py
@@ -23,6 +23,7 @@ different zone (``action_needed``).
 """
 
 from datetime import timedelta
+from unittest.mock import patch
 
 import pytest
 from django.utils import timezone
@@ -51,12 +52,13 @@ class TestLiveLoopsAnchor:
         _make_lease("loop-self-improve", expires_in=timedelta(minutes=30))
         _make_lease("loop-slack-answer", expires_in=timedelta(minutes=30))
 
-        lines = live_loops_anchor()
+        with patch("teatree.loop.statusline_loops._availability_segment", return_value=""):
+            lines = live_loops_anchor()
 
         assert len(lines) == 1, repr(lines)
         line = lines[0]
-        # The redundant leading state word is gone — the line leads with a
-        # loop chunk (leases sort by name → ``self-improve`` first here).
+        # The redundant leading state word is gone — with no other segments the
+        # line leads with a loop chunk (leases sort by name → ``self-improve``).
         assert "loop running" not in line, line
         assert line.startswith("self-improve"), line
         # The useless headline count is gone; each loop's short name appears.

--- a/tests/teatree_loop/test_statusline_next_tick.py
+++ b/tests/teatree_loop/test_statusline_next_tick.py
@@ -20,8 +20,15 @@ from unittest.mock import patch
 
 from teatree.loop.dispatch import DispatchAction
 from teatree.loop.rendering import zones_for
-from teatree.loop.statusline import live_loops_anchor, mini_loops_anchor, render, set_overridden_loops_reader
-from teatree.loop.statusline_loop_chunks import _mini_loop_chunk
+from teatree.loop.statusline import (
+    live_loops_anchor,
+    mini_loops_anchor,
+    render,
+    set_overridden_loops_reader,
+    set_preset_line_reader,
+)
+from teatree.loop.statusline_loop_chunks import _mini_loop_chunk, overdue_mini_loop_names
+from teatree.loop.statusline_loops import PresetLineHandles
 from teatree.loop.statusline_render import _format_duration
 
 
@@ -65,6 +72,7 @@ class TestConsolidatedLoopAnchor:
         with (
             patch("teatree.loop.statusline_loops._live_loop_leases", return_value=leases),
             patch("teatree.loop.statusline_loops._cadence_for_loop", return_value=720),
+            patch("teatree.loop.statusline_loops._availability_segment", return_value=""),
         ):
             lines = live_loops_anchor()
         assert len(lines) == 1, repr(lines)
@@ -199,8 +207,9 @@ class TestLoopLineComposesLeasesAndMiniLoops:
             patch("teatree.loop.statusline_loops._availability_segment", return_value=""),
         ):
             lines = live_loops_anchor(colorize=False)
-        # #3248: due-soon mini-loops ride the ``due:`` section; leases lead.
-        assert lines == ["tick 10m · due: dispatch 2m"], lines
+        # #3248: due-soon mini-loops ride the ``due:`` section; #3494 keeps the
+        # infra leases unobtrusive at the tail.
+        assert lines == ["due: dispatch 2m · tick 10m"], lines
 
     def test_line_renders_for_mini_loops_even_with_no_live_lease(self) -> None:
         # The user's complaint: crons were invisible when no infra lease was
@@ -237,7 +246,10 @@ class TestPerLoopLeaseCollapse:
             patch("teatree.loop.statusline_loops._mini_loop_schedules", return_value=[]),
             patch("teatree.loop.statusline_loops._availability_segment", return_value=""),
             patch("teatree.loop.statusline_loops._waiting_clause", return_value=""),
-            patch("teatree.loop.statusline_loops._preset_segment", return_value="preset engaged · ovr: audit+"),
+            patch(
+                "teatree.loop.statusline_loops._preset_line_handles",
+                return_value=PresetLineHandles(schedule="", preset="preset engaged", override="ovr: audit+"),
+            ),
         ):
             set_overridden_loops_reader((lambda: overridden) if overridden is not None else None)
             try:
@@ -306,6 +318,165 @@ class TestPerLoopLeaseCollapse:
         line = self._render_with_overridden(None, leases)
         assert "loop:dispatch" in line, line
         assert "loop:tickets" in line, line
+
+
+class TestMiniLoopOverdueCollapse:
+    """#3494: under an engaged preset the domain crons collapse to ``overdue: <names>``.
+
+    Complaint: with a preset engaged the ``due:`` list dumped every enabled
+    mini-loop that happened to be due-soon on its normal cadence. The engaged
+    preset is the summary handle — routine due-soon crons fold into it, and only
+    the genuinely-overdue / never-fired exceptions surface, under a single
+    ``overdue:`` label listing their bare names (no redundant per-item ``due``).
+    """
+
+    @staticmethod
+    def _render(preset: str, schedules: list[tuple[str, datetime | None, int]]) -> str:
+        with (
+            patch("teatree.loop.statusline_loops._live_loop_leases", return_value=[]),
+            patch("teatree.loop.statusline_loops._mini_loop_schedules", return_value=schedules),
+            patch("teatree.loop.statusline_loops._availability_segment", return_value=""),
+            patch("teatree.loop.statusline_loops._waiting_count", return_value=0),
+            patch(
+                "teatree.loop.statusline_loops._preset_line_handles",
+                return_value=PresetLineHandles(schedule="schedule: none active", preset=preset, override=""),
+            ),
+        ):
+            lines = live_loops_anchor(colorize=False)
+        assert lines, "expected a loop line"
+        return lines[0]
+
+    def test_only_overdue_and_never_fired_surface_under_one_label(self) -> None:
+        now = datetime.now(UTC)
+        schedules = [
+            ("dispatch", now + timedelta(seconds=60), 600),  # routine due-soon -> folded
+            ("inbox", now + timedelta(seconds=60), 600),  # routine due-soon -> folded
+            ("review", now + timedelta(seconds=180), 600),  # routine due-soon -> folded
+            ("snapshot_warmer", None, 600),  # never-fired -> overdue
+            ("triage_assessor", now - timedelta(seconds=5), 600),  # overdue
+        ]
+        line = self._render("preset: manual", schedules)
+        # One ``overdue:`` label, comma-separated names, no per-item "due":
+        assert "overdue: snapshot_warmer, triage_assessor" in line, line
+        assert "snapshot_warmer due" not in line, line
+        assert "· due:" not in line, line  # not the no-preset ``due:`` countdown list
+        # Routine due-soon crons fold into the preset handle:
+        for folded in ("dispatch", "inbox", "review"):
+            assert folded not in line, f"{folded} must fold into the preset handle: {line}"
+
+    def test_no_overdue_loops_omits_the_overdue_section(self) -> None:
+        now = datetime.now(UTC)
+        schedules = [
+            ("dispatch", now + timedelta(seconds=60), 600),
+            ("inbox", now + timedelta(seconds=60), 600),
+        ]
+        line = self._render("preset: manual", schedules)
+        assert "overdue:" not in line, line
+        assert "dispatch" not in line, line
+
+    def test_no_preset_engaged_keeps_every_due_soon_loop(self) -> None:
+        # The collapse is preset-gated: with no preset the full due-soon ``due:``
+        # countdown list renders (today's behavior) — never over-collapsed.
+        now = datetime.now(UTC)
+        schedules = [
+            ("dispatch", now + timedelta(seconds=60), 600),
+            ("inbox", now + timedelta(seconds=60), 600),
+        ]
+        line = self._render("", schedules)  # preset empty -> not governing
+        assert "due: dispatch 1m inbox 1m" in line, line
+        assert "overdue:" not in line, line
+
+
+class TestOverdueMiniLoopNames:
+    """The pure ``overdue_mini_loop_names`` selector (#3494)."""
+
+    def test_keeps_only_overdue_and_never_fired_by_name(self) -> None:
+        now = datetime.now(UTC)
+        schedules = [
+            ("dispatch", now + timedelta(seconds=60), 600),  # due-soon, not overdue -> dropped
+            ("snapshot_warmer", None, 600),  # never fired -> kept
+            ("triage_assessor", now - timedelta(seconds=5), 600),  # overdue -> kept
+        ]
+        assert overdue_mini_loop_names(schedules) == ["snapshot_warmer", "triage_assessor"]
+
+    def test_empty_when_nothing_overdue(self) -> None:
+        now = datetime.now(UTC)
+        assert overdue_mini_loop_names([("dispatch", now + timedelta(seconds=60), 600)]) == []
+
+
+class TestPresetLineReaderInjection:
+    """``set_preset_line_reader`` installs the up-stack handles reader (#3494)."""
+
+    def test_injected_reader_drives_the_line_handles(self) -> None:
+        handles = PresetLineHandles(schedule="schedule: standard", preset="preset: manual", override="")
+        with (
+            patch("teatree.loop.statusline_loops._live_loop_leases", return_value=[]),
+            patch("teatree.loop.statusline_loops._mini_loop_schedules", return_value=[]),
+            patch("teatree.loop.statusline_loops._availability_segment", return_value=""),
+            patch("teatree.loop.statusline_loops._waiting_count", return_value=0),
+        ):
+            set_preset_line_reader(lambda: handles)
+            try:
+                line = live_loops_anchor(colorize=False)[0]
+            finally:
+                set_preset_line_reader(None)
+        assert line == "schedule: standard · preset: manual", line
+
+    def test_reset_to_none_silences_the_handles(self) -> None:
+        with (
+            patch("teatree.loop.statusline_loops._live_loop_leases", return_value=[]),
+            patch("teatree.loop.statusline_loops._mini_loop_schedules", return_value=[]),
+        ):
+            set_preset_line_reader(None)
+            assert live_loops_anchor(colorize=False) == []
+
+
+class TestLoopLineSegmentOrder:
+    """#3494: the loop line reads schedule -> preset -> overdue -> forced -> availability -> waiting.
+
+    The schedule and preset handles LEAD the line (the summary handles the loops
+    fold under), then the collapsed ``overdue:`` exceptions, then the ``forced
+    ON:`` overrides, then availability and waiting. Infra leases (``reinstall``)
+    are kept unobtrusive at the tail — never between the preset and the loops.
+    """
+
+    def test_matches_the_owner_option_a_layout(self) -> None:
+        now = datetime.now(UTC)
+        with (
+            patch("teatree.loop.statusline_loops._live_loop_leases", return_value=[("reinstall", now)]),
+            patch("teatree.loop.statusline_loops._live_lease_drivers", return_value={}),
+            patch("teatree.loop.statusline_loops.current_session_owned_per_loop_slots", return_value=None),
+            patch("teatree.loop.statusline_loops._cadence_for_loop", return_value=600),
+            patch(
+                "teatree.loop.statusline_loops._mini_loop_schedules",
+                return_value=[("snapshot_warmer", None, 600), ("triage_assessor", now - timedelta(seconds=5), 600)],
+            ),
+            patch("teatree.loop.statusline_loops._availability_segment", return_value="availability: present"),
+            patch("teatree.loop.statusline_loops._waiting_count", return_value=4),
+            patch(
+                "teatree.loop.statusline_loops._preset_line_handles",
+                return_value=PresetLineHandles(
+                    schedule="schedule: none active",
+                    preset="preset: manual",
+                    override="forced ON: triage_assessor",
+                ),
+            ),
+        ):
+            line = live_loops_anchor(colorize=False)[0]
+        positions = [
+            line.index("schedule: none active"),
+            line.index("preset: manual"),
+            line.index("overdue: snapshot_warmer, triage_assessor"),
+            line.index("forced ON: triage_assessor"),
+            line.index("availability: present"),
+            line.index("4 waiting"),
+            line.index("reinstall"),  # infra lease kept at the tail
+        ]
+        assert positions == sorted(positions), line
+        # No cryptic forms leak in:
+        assert "ovr:" not in line, line
+        assert "⚠" not in line, line
+        assert "waiting=" not in line, line
 
 
 class TestMiniLoopChunk:
@@ -396,6 +567,7 @@ class TestZonesForIntegration:
         with (
             patch("teatree.loop.statusline_loops._live_loop_leases", return_value=leases),
             patch("teatree.loop.statusline_loops._cadence_for_loop", return_value=720),
+            patch("teatree.loop.statusline_loops._availability_segment", return_value=""),
         ):
             zones = zones_for([], colorize=False)
         target = tmp_path / "statusline.txt"

--- a/tests/teatree_loop/test_statusline_refinements_1163.py
+++ b/tests/teatree_loop/test_statusline_refinements_1163.py
@@ -229,6 +229,7 @@ class TestLiveLoopsAnchor:
         with (
             patch("teatree.loop.statusline_loops._live_loop_leases", return_value=leases),
             patch("teatree.loop.statusline_loops._cadence_for_loop", return_value=720),
+            patch("teatree.loop.statusline_loops._availability_segment", return_value=""),
         ):
             lines = live_loops_anchor()
         assert len(lines) == 1

--- a/tests/teatree_loops/test_preset_status.py
+++ b/tests/teatree_loops/test_preset_status.py
@@ -27,6 +27,7 @@ from teatree.loops.preset_status import (
     manual_override_chunk,
     manual_override_entries,
     preset_line_chunk,
+    preset_line_handles,
     schedule_chunk,
     statusline_chunk,
 )
@@ -78,19 +79,20 @@ class TestStatuslineChunk(django.test.TestCase):
     def test_empty_when_no_preset(self) -> None:
         assert statusline_chunk() == ""
 
-    def test_manual_override_carries_the_warning_marker(self) -> None:
-        # A manually-overridden preset (#3248) is flagged ⚠ … (manual) so the
-        # operator sees the schedule is not the one governing.
+    def test_manual_override_reads_preset_manual(self) -> None:
+        # A manually-overridden preset (#3494) reads ``preset: manual`` — the
+        # layer, not the preset name — so the operator sees the schedule is not
+        # the one governing.
         LoopPreset.objects.create(name="heads-down", entries={})
         LoopPresetOverride.objects.set_override("heads-down")
-        assert statusline_chunk() == "preset ⚠heads-down (manual)"
+        assert statusline_chunk() == "preset: manual"
 
     def test_manual_override_includes_the_boundary_when_bounded(self) -> None:
         LoopPreset.objects.create(name="heads-down", entries={})
         until = timezone.now() + dt.timedelta(hours=3)
         LoopPresetOverride.objects.create(preset_name="heads-down", until=until)
         chunk = statusline_chunk()
-        assert chunk.startswith("preset ⚠heads-down (manual →")
+        assert chunk.startswith("preset: manual →")
 
 
 @django.test.override_settings(USE_TZ=True, TIME_ZONE="UTC")
@@ -98,11 +100,11 @@ class TestScheduleAndOverrideChunks(django.test.TestCase):
     def test_schedule_chunk_names_the_active_schedule(self) -> None:
 
         ConfigSetting.objects.set_value(ACTIVE_SCHEDULE_SETTING, "standard")
-        assert schedule_chunk() == "sched standard"
+        assert schedule_chunk() == "schedule: standard"
 
-    def test_schedule_chunk_empty_without_active_schedule(self) -> None:
+    def test_schedule_chunk_reads_none_active_without_active_schedule(self) -> None:
 
-        assert schedule_chunk() == ""
+        assert schedule_chunk() == "schedule: none active"
 
     def test_manual_override_entries_only_divergent_forced_loops(self) -> None:
 
@@ -123,21 +125,47 @@ class TestScheduleAndOverrideChunks(django.test.TestCase):
         LoopState.objects.override("ov-same", on=True)
         assert manual_override_entries() == []
 
-    def test_manual_override_chunk_renders_signs(self) -> None:
+    def test_manual_override_chunk_spells_out_forced_state(self) -> None:
 
         _loop("ov-a", enabled=True)
         _loop("ov-b", enabled=True)
         LoopState.objects.override("ov-a", on=False)
         LoopState.objects.override("ov-b", on=True)
-        # ov-b forced-on matches base → not divergent; only ov-a shows.
-        assert manual_override_chunk() == "ovr: ov-a-"
+        # ov-b forced-on matches base → not divergent; only ov-a (forced OFF) shows.
+        assert manual_override_chunk() == "forced OFF: ov-a"
+
+    def test_manual_override_chunk_groups_on_and_off(self) -> None:
+
+        _loop("ov-on", enabled=False)
+        _loop("ov-off", enabled=True)
+        LoopState.objects.override("ov-on", on=True)  # diverges from base OFF
+        LoopState.objects.override("ov-off", on=False)  # diverges from base ON
+        assert manual_override_chunk() == "forced ON: ov-on · forced OFF: ov-off"
 
 
 @django.test.override_settings(USE_TZ=True, TIME_ZONE="UTC")
 class TestPresetLineChunk(django.test.TestCase):
-    def test_empty_when_nothing_governs(self) -> None:
+    def test_shows_schedule_none_active_when_nothing_governs(self) -> None:
+        # The schedule handle is always spelled out, so the bundled view is never
+        # empty — it reads ``schedule: none active`` on a quiet machine.
+        assert preset_line_chunk() == "schedule: none active"
 
-        assert preset_line_chunk() == ""
+    def test_preset_line_handles_resolves_the_three_handles(self) -> None:
+        _loop("plh-review", enabled=True)
+        ConfigSetting.objects.set_value(ACTIVE_SCHEDULE_SETTING, "standard")
+        LoopPreset.objects.create(name="heads-down", entries={})
+        LoopPresetOverride.objects.set_override("heads-down")
+        LoopState.objects.override("plh-review", on=False)
+        handles = preset_line_handles()
+        assert handles.schedule == "schedule: standard"
+        assert handles.preset == "preset: manual"
+        assert handles.override == "forced OFF: plh-review"
+
+    def test_preset_line_handles_quiet_machine_shows_only_schedule(self) -> None:
+        handles = preset_line_handles()
+        assert handles.schedule == "schedule: none active"
+        assert handles.preset == ""
+        assert handles.override == ""
 
     def test_composes_schedule_preset_and_overrides(self) -> None:
 
@@ -147,7 +175,7 @@ class TestPresetLineChunk(django.test.TestCase):
         LoopPresetOverride.objects.set_override("heads-down")
         LoopState.objects.override("pl-review", on=False)
         chunk = preset_line_chunk()
-        assert chunk == "sched standard · preset ⚠heads-down (manual) · ovr: pl-review-"
+        assert chunk == "schedule: standard · preset: manual · forced OFF: pl-review"
 
     def test_schedule_governed_has_no_manual_marker(self) -> None:
 
@@ -158,7 +186,7 @@ class TestPresetLineChunk(django.test.TestCase):
         )
         ConfigSetting.objects.set_value(ACTIVE_SCHEDULE_SETTING, "standard")
         chunk = preset_line_chunk()
-        # Schedule-governed → no ⚠manual marker; sched + preset only.
-        assert chunk.startswith("sched standard · preset engaged")
+        # Schedule-governed → the preset is named (not "manual"); no ⚠ marker.
+        assert chunk.startswith("schedule: standard · preset: engaged")
         assert "⚠" not in chunk
         assert "manual" not in chunk


### PR DESCRIPTION
fix(statusline): collapse loops under an engaged preset + spelled-out schedule to preset to overdue to forced layout

## Why

The loop line dumped every due-soon mini-loop under an engaged preset, ordered loops before preset, and used terse tokens. This switches to a spelled-out labeled layout.

Same real state (no active schedule, manual preset, triage_assessor forced on, snapshot_warmer and triage_assessor overdue, present, 4 waiting).

Previous render:

    preset engaged (manual) . reinstall 12m . due: snapshot_warmer due triage_assessor due . ovr: triage_assessor+ . availability: present (default) . waiting=4

New render (verified):

    schedule: none active . preset: manual . overdue: snapshot_warmer, triage_assessor . forced ON: triage_assessor . availability: present . 4 waiting

## What

- Collapse under an engaged preset: routine due-soon domain crons fold into the preset handle; only genuinely-overdue / never-fired exceptions surface under one overdue label. With no preset, the full due-soon due list renders (unchanged). Preset-gated.
- Order: schedule, preset, loops (overdue/due), overrides, availability, waiting. Infra leases kept at the tail, never between the preset and the loops.
- Spelled-out wording: schedule (name / none active), preset (name / manual), forced ON / forced OFF, availability (state, source dropped), N waiting.
- The bundled handle is split into three ordered PresetLineHandles, injected via set_preset_line_reader.

## Tests

test_statusline_next_tick.py (TestMiniLoopOverdueCollapse, TestLoopLineSegmentOrder, TestOverdueMiniLoopNames, TestPresetLineReaderInjection), plus wording updates across test_preset_status.py, test_availability_anchor.py, and the dashboard / owner-first / multiloop statusline tests. Full tests/teatree_loop + tests/teatree_loops green (3756 passed). prek clean.