### PR TITLE
fix(agents): broaden is_tool_lack_selfreport to catch review-phase tool-lack leaks (INTERNAL audience)

### DIFF
--- a/src/teatree/core/models/deferred_question.py
+++ b/src/teatree/core/models/deferred_question.py
@@ -51,20 +51,32 @@ def question_fingerprint(text: str) -> str:
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:32]
 
 
-#: Signals in an agent's own ``needs_user_input`` reason that mark it a tool-lack /
-#: wrong-toolset DISPATCH fault — "this session has no shell/gh to do its job",
-#: "hand off to a session with the standard toolset" — rather than a genuine
-#: decision the owner must make. A capability negation (lack/no/without/missing/
-#: denied) sitting next to a tool word (shell/bash/gh/tool/toolset), the bare
-#: "shell-denied", or the "needs a session with tools" hand-off phrasing all match.
+#: Signals that a ``needs_user_input`` reason is a tool-lack / mis-provisioned
+#: DISPATCH fault — a session reporting it lacks the tools / checkout / access to do
+#: its assigned work — not a genuine decision the owner must make. Any one branch is
+#: sufficient. Each keys on a signal owner *decision* questions do not carry, so a
+#: real "how should I proceed on X?" ("cannot decide", "no clean approach") stays
+#: OWNER_QUESTION. Branches (4)-(7) were added after (1)-(3) still leaked review
+#: parks that reported the same fault by its consequence/symptom (#201/#202).
 _TOOL_LACK_SELFREPORT_RE = re.compile(
     r"(?:"
+    # (1) capability negation adjacent to a tool word
     r"\b(?:lack|lacks|lacking|no|without|missing|denied|deprived of)\b[^.]{0,40}?"
     r"\b(?:shell|bash|gh|tool|tools|toolset)\b"
-    r"|\bshell[- ]?denied\b"
-    r"|\bneeds?\b[^.]{0,40}?\bsession\b[^.]{0,40}?\btool"
+    r"|\bshell[- ]?denied\b"  # (2) bare "shell-denied"
+    r"|\bneeds?\b[^.]{0,40}?\bsession\b[^.]{0,40}?\btool"  # (3) hand-off phrasings
     r"|\bsession with (?:the )?(?:standard )?tool"
     r"|\bpicked up by (?:a )?session\b"
+    # (4) dispatch-provisioning phrase ("tool access") — only in a provisioning report
+    r"|\btool access\b"
+    # (5) no accessible checkout / working tree / working copy / repo access
+    r"|\bno\b[^.]{0,30}?\b(?:accessible )?(?:checkout|working tree|working copy|repo(?:sitory)? access)\b"
+    # (6) internal task-context tools (TaskGet/TaskList/TaskRead) returning nothing
+    r"|\btask(?:get|list|read)\b[^.]{0,60}?\b(?:returned nothing|nothing|empty|unavailable|no rows)\b"
+    # (7) inability to do tool-requiring work (the consequence phrasing of a lack)
+    r"|\b(?:cannot|can't|can not|unable to|couldn't|could not)\b[^.]{0,60}?"
+    r"\b(?:inspect|make code changes|run the required|run [^.]{0,20}?verify-gates|verify-gates"
+    r"|clone|check ?out|apply the patch)\b"
     r")",
     re.IGNORECASE,
 )
@@ -74,13 +86,14 @@ def is_tool_lack_selfreport(text: str) -> bool:
     """True if *text* is an agent's own "I lack the tools to proceed" dispatch fault.
 
     An agent that stops with ``needs_user_input`` because its session was
-    dispatched WITHOUT the shell / ``gh`` / toolset its own work needs is reporting
-    a DISPATCH fault — a phase mis-provisioned for its job — not asking the owner to
-    decide anything. Surfacing that self-report to the owner's DM is the exact leak
-    this classifier defends (it reached the owner as "*Pending question* … This
-    session lacks any shell/write tool …"): the box asking the owner to compensate
-    for its own mis-provisioning. Such a reason is recorded ``INTERNAL`` — logged /
-    statusline-only, re-routed — never surfaced as an owner question.
+    dispatched WITHOUT the shell / ``gh`` / toolset / checkout its own work needs is
+    reporting a DISPATCH fault — a phase mis-provisioned for its job — not asking the
+    owner to decide anything. Surfacing that self-report to the owner's DM is the
+    exact leak this classifier defends (it reached the owner as "*Pending question* …
+    This session lacks any shell/write tool …", and later as the review-phase
+    "launched without … tool access, so I cannot inspect the PR diff …" / "no shell,
+    TaskGet/TaskList returned nothing" leaks). Such a reason is recorded ``INTERNAL``
+    — logged / statusline-only, never DM'd. See ``_TOOL_LACK_SELFREPORT_RE``.
     """
     return bool(_TOOL_LACK_SELFREPORT_RE.search(_WHITESPACE_RE.sub(" ", text.strip())))
 

--- a/tests/teatree_core/models/test_task_handoff.py
+++ b/tests/teatree_core/models/test_task_handoff.py
@@ -5,10 +5,13 @@ dispatched without the shell / ``gh`` / toolset its own work needs is reporting 
 DISPATCH fault, not asking the owner a question. That self-report must be recorded
 ``INTERNAL`` (logged / statusline-only, never DM'd) — the exact owner-DM leak this
 guards reached the owner as "*Pending question* … This session lacks any
-shell/write tool …" from BOTH a scanning-news park and the recurring
-architectural-review daemon (#186). The classifier is phase-independent, so it
-covers every such phase. An ordinary needs-input reason is a genuine owner question
-and keeps the default ``OWNER_QUESTION`` audience.
+shell/write tool …" from a scanning-news park, the recurring architectural-review
+daemon (#186), and — after the first fix shipped — two review-phase parks that
+reported the same fault by its consequence/symptom instead ("launched without
+Bash/Edit/Write/Agent tool access, so I cannot inspect the PR diff", #201; "no
+shell, TaskGet/TaskList returned nothing", #202). The classifier is
+phase-independent, so it covers every such phase. An ordinary needs-input reason is
+a genuine owner question and keeps the default ``OWNER_QUESTION`` audience.
 """
 
 from django.test import TestCase
@@ -59,7 +62,61 @@ class TestRecordDeferredQuestionAudience(TestCase):
         row = record_deferred_question(task)
         assert row.audience == DeferredQuestion.Audience.INTERNAL
 
+    def test_codex_review_no_tool_access_self_report_is_internal(self) -> None:
+        # #201: a codex_reviewing park that leaked to the owner's DM AFTER #3488 —
+        # the reason reports its consequence ("cannot inspect the PR diff", "make
+        # code changes", "run the required verify-gates") and its remedy ("relaunched
+        # with full tool access") rather than the bare "no shell" #3488 keyed on.
+        task = self._headless_task_with_reason(
+            "This session was launched without Bash/Edit/Write/Agent tool access, so I cannot "
+            "inspect the PR diff locally, make code changes, or run the required "
+            "`t3 tool verify-gates` green-proof, nor post the codex adversarial review comment via "
+            "`gh pr comment`. Need either the session relaunched with full tool access, or explicit "
+            "guidance on how to proceed read-only.",
+            phase="codex_reviewing",
+        )
+        row = record_deferred_question(task)
+        assert row.audience == DeferredQuestion.Audience.INTERNAL
+
+    def test_review_no_task_context_self_report_is_internal(self) -> None:
+        # #202: a reviewing park that leaked AFTER #3488 — the missing capability is
+        # reported as its symptom (no shell, TaskGet/TaskList returned nothing), a
+        # dispatch fault the owner must never be asked to compensate for.
+        task = self._headless_task_with_reason(
+            "Ticket 187's body/state and the full Slack thread weren't available in this phase "
+            "(no shell, TaskGet/TaskList returned nothing for it), so I can't confirm what concrete "
+            "action is being asked about beyond a generic acknowledgment.",
+            phase="reviewing",
+        )
+        row = record_deferred_question(task)
+        assert row.audience == DeferredQuestion.Audience.INTERNAL
+
+    def test_internal_self_report_is_excluded_from_owner_dm_drain(self) -> None:
+        # The audience is not cosmetic: an INTERNAL row must never enter the owner DM
+        # drain (``unmirrored_pending`` filters to OWNER_QUESTION), so the leak the
+        # #201/#202 reports caused cannot recur even once recorded.
+        task = self._headless_task_with_reason(
+            "This session was launched without Bash/Edit/Write/Agent tool access, so I cannot "
+            "inspect the PR diff or run the required verify-gates green-proof.",
+            phase="codex_reviewing",
+        )
+        row = record_deferred_question(task)
+        assert row.audience == DeferredQuestion.Audience.INTERNAL
+        assert row.pk not in {r.pk for r in DeferredQuestion.unmirrored_pending()}
+
     def test_ordinary_question_keeps_owner_audience(self) -> None:
         task = self._headless_task_with_reason("Should I merge PR #7 now, or wait for the release branch to cut first?")
+        row = record_deferred_question(task)
+        assert row.audience == DeferredQuestion.Audience.OWNER_QUESTION
+
+    def test_review_phase_owner_decision_keeps_owner_audience(self) -> None:
+        # A genuine reviewing-phase decision question — no tool-lack / dispatch signal
+        # — must stay OWNER_QUESTION and reach the owner. The broadening must not
+        # sweep real "how should I proceed on X?" questions into INTERNAL.
+        task = self._headless_task_with_reason(
+            "Two of the review findings conflict — should I block the PR on the missing migration, "
+            "or accept it and file a follow-up ticket? Which do you prefer?",
+            phase="reviewing",
+        )
         row = record_deferred_question(task)
         assert row.audience == DeferredQuestion.Audience.OWNER_QUESTION

--- a/tests/teatree_core/test_deferred_question_model.py
+++ b/tests/teatree_core/test_deferred_question_model.py
@@ -118,6 +118,29 @@ class TestToolLackSelfReport:
             "This must be picked up by a session with the standard toolset.",
             "I need a session with the tools to complete this.",
             "Missing the gh CLI, so I can't open the PR.",
+            # #201 (codex_reviewing) — leaked AFTER the first fix: the fault is
+            # reported by its consequence, not the bare "no shell" token.
+            (
+                "This session was launched without Bash/Edit/Write/Agent tool access, so I cannot "
+                "inspect the PR diff locally, make code changes, or run the required "
+                "`t3 tool verify-gates` green-proof, nor post the codex adversarial review comment "
+                "via `gh pr comment`. Need either the session relaunched with full tool access, or "
+                "explicit guidance on how to proceed read-only."
+            ),
+            # #202 (reviewing) — leaked AFTER the first fix: the fault is reported as
+            # its symptom (no shell, internal task-context tools returned nothing).
+            (
+                "Ticket 187's body/state and the full Slack thread weren't available in this phase "
+                "(no shell, TaskGet/TaskList returned nothing for it), so I can't confirm what "
+                "concrete action is being asked about beyond a generic acknowledgment."
+            ),
+            # Isolated signals each phrasing carries, asserted alone so the class is
+            # caught even when only one signal is present.
+            "I cannot inspect the PR diff locally.",
+            "Need the session relaunched with full tool access.",
+            "TaskGet/TaskList returned nothing for it.",
+            "This phase has no accessible checkout of the repo.",
+            "I cannot run the required verify-gates green-proof.",
         ],
     )
     def test_tool_lack_phrasings_are_classified(self, text: str) -> None:
@@ -130,6 +153,14 @@ class TestToolLackSelfReport:
             "The design has two viable approaches — which do you prefer?",
             "I don't have enough context about the rollout plan to continue.",
             "Should I write the migration now or in a follow-up?",
+            # Genuine review-phase decision — no tool-lack signal — must stay owner.
+            "Two findings conflict; should I block the PR or file a follow-up ticket?",
+            # Near-miss owner questions that brush the new signal words without being
+            # a lack report: deciding to "check out" a branch, a "which tool" pick, a
+            # "cannot decide" judgment gap.
+            "Should I check out the release branch or stay on main?",
+            "Which tool should I use to profile the endpoint?",
+            "I cannot decide between the two migration strategies — which do you prefer?",
         ],
     )
     def test_genuine_owner_questions_are_not_classified(self, text: str) -> None:


### PR DESCRIPTION
## Problem

`is_tool_lack_selfreport()` (#3488) routes an agent's own "I lack the tools to do my job" `needs_user_input` self-report to `INTERNAL` audience so it is never DM'd to the owner. Two review-phase parks still leaked to the owner's DM as `OWNER_QUESTION` after #3488 deployed:

- **#201** (`codex_reviewing`): "This session was launched without Bash/Edit/Write/Agent tool access, so I cannot inspect the PR diff locally, make code changes, or run the required `t3 tool verify-gates` green-proof … Need either the session relaunched with full tool access, or explicit guidance on how to proceed read-only."
- **#202** (`reviewing`): "… the full Slack thread weren't available in this phase (no shell, TaskGet/TaskList returned nothing for it) — can't confirm what concrete action is being asked about …"

## Root cause

The #3488 regex keys on a capability negation sitting *adjacent* to a tool word (`no shell`, `without Bash`, `lacks … tool`) plus a few hand-off phrasings. That is brittle: a review park often reports the *consequence* of the missing capability ("cannot inspect the PR diff", "make code changes", "run the required verify-gates"), the *remedy* ("relaunched with full tool access"), or the *symptom* ("TaskGet/TaskList returned nothing", "no accessible checkout") — none of which places a negation next to a tool word. Those phrasings fell through to the default `OWNER_QUESTION` and reached the owner DM.

## Fix

Broaden `_TOOL_LACK_SELFREPORT_RE` with four robustness branches keyed on the tool-lack/dispatch-failure signal class (a session reporting it lacks the tools/checkout/access to do its assigned work), each chosen for signals a genuine owner *decision* question does not carry:

4. `tool access` — the provisioning phrase (launched without / relaunched with full / no tool access).
5. `no accessible checkout` / no working tree / no repo access.
6. an internal task-context tool (`TaskGet`/`TaskList`/`TaskRead`) reporting nothing.
7. inability to do tool-requiring work — `cannot inspect` / `make code changes` / `run the required` / `verify-gates` / `clone` / `check out` / `apply the patch`.

The existing (1)-(3) branches are unchanged, so every #3488 case still classifies. Guarded against over-match: the negatives suite includes near-miss owner questions that brush the new words without being a lack report — "Should I check out the release branch or stay on main?", "Which tool should I use to profile?", "I cannot decide between the two migration strategies" — all stay `OWNER_QUESTION`.

## Tests (RED-first)

- Classifier unit cases: verbatim #201/#202 + isolated fragments assert `True`; new near-miss owner questions assert `False`.
- Routing integration (`record_deferred_question`): #201 (`codex_reviewing`) and #202 (`reviewing`) record `audience=INTERNAL` and are excluded from the owner DM drain (`unmirrored_pending`); a genuine review-phase decision stays `OWNER_QUESTION`.

53 tests pass; full prek clean on changed files (SKIP codespell,ci-critical-parity).
