### PR TITLE
fix(loop): drive the statusline render tick in headless mode so statusline.txt never freezes

### DIFF
--- a/src/teatree/cli/doctor/__init__.py
+++ b/src/teatree/cli/doctor/__init__.py
@@ -51,6 +51,7 @@ from teatree.cli.doctor.app import (
     agent_skill_dirs,
     check,
     check_statusline,
+    check_statusline_freshness,
     doctor_app,
     run_doctor_checks,
 )
@@ -97,6 +98,7 @@ __all__ = [
     "agent_skill_dirs",
     "check",
     "check_statusline",
+    "check_statusline_freshness",
     "doctor_app",
     "run_doctor_checks",
 ]

--- a/src/teatree/cli/doctor/app.py
+++ b/src/teatree/cli/doctor/app.py
@@ -76,7 +76,7 @@ from teatree.cli.doctor.service import (
     IntrospectionHelpers,
     agent_skill_dirs,
 )
-from teatree.cli.doctor.statusline import check_statusline
+from teatree.cli.doctor.statusline import check_statusline, check_statusline_freshness
 from teatree.cli.recommended_authorizations import authorizations, report_missing_authorizations
 from teatree.cli.slack.dm_doctor import check_and_render_dm_ready
 from teatree.utils.django_bootstrap import ensure_django
@@ -140,6 +140,7 @@ __all__ = (
     "check",
     "check_slack_roundtrip",
     "check_statusline",
+    "check_statusline_freshness",
     "doctor_app",
 )
 
@@ -269,10 +270,15 @@ def run_doctor_checks(*, repair: bool = False, slack_roundtrip: bool = False) ->
     ok = _check_stale_uv_venv() and ok
     ok = _check_stale_path_t3() and ok
     ok = _check_agent_session_pins() and ok
-    # Verify the Claude Code statusLine block (PR-17): present, absolute path,
-    # executable target — with exact remediation. A missing block is a WARN
-    # (`t3 setup` installs it); a relative/non-executable one is a hard FAIL.
-    ok = check_statusline() and ok
+    # Verify the Claude Code statusLine block (PR-17: present, absolute path, executable
+    # target — a missing block WARNs, a relative/non-executable one hard-FAILs) AND its
+    # freshness. The freshness backstop hard-FAILs a pre-rendered statusline gone stale past
+    # the readers' own cutoff while autoload is on — a headless render chain that stopped
+    # keeping the file fresh, never an unnoticed regression. Both run unconditionally (the
+    # ``all`` tuple calls both before short-circuiting) so a config FAIL never masks a
+    # freshness FAIL; the freshness read of the ConfigSetting ``autoload`` flag runs after
+    # the ensure_django() above.
+    ok = all((check_statusline(), check_statusline_freshness())) and ok
 
     # Django was configured above (before the editable-sanity check) so the
     # self-DB schema guard reports the REAL pending-migration state rather than

--- a/src/teatree/cli/doctor/statusline.py
+++ b/src/teatree/cli/doctor/statusline.py
@@ -1,8 +1,11 @@
-"""The doctor's statusLine configuration check (PR-17).
+"""The doctor's statusLine configuration + freshness checks (PR-17).
 
 Kept in its own module by concern: everything statusline lives here, next to the
 installer (:mod:`teatree.cli.setup.statusline_installer`) that writes the block
-this check verifies.
+:func:`check_statusline` verifies. :func:`check_statusline_freshness` is the
+silent-freeze guard: it FAILs when the pre-rendered ``statusline.txt`` has aged past
+the same stale cutoff the readers use while ``autoload`` is ON, so a headless render
+chain that has stopped keeping the file fresh can never regress unnoticed.
 """
 
 from pathlib import Path
@@ -10,6 +13,11 @@ from pathlib import Path
 import typer
 
 _STATUSLINE_REMEDY = "run `t3 setup` to (re)install it"
+
+_FRESHNESS_REMEDY = (
+    "the `t3 worker` render chain (teatree.loops.statusline_refresh) is not keeping it "
+    "fresh — check `t3 worker status` and the worker logs"
+)
 
 
 def _statusline_command(path: Path) -> str | None:
@@ -87,6 +95,58 @@ def _validate_executable(token: str) -> bool:
     if not os.access(target, os.X_OK):
         typer.echo(
             f"FAIL  statusLine command is not executable: {target} — `chmod +x {target}` or {_STATUSLINE_REMEDY}.",
+        )
+        return False
+    return True
+
+
+def _autoload_on() -> bool:
+    """Whether the ``autoload`` #256 owner flag resolves ON. Fail-safe OFF.
+
+    A colleague / opted-out box (``autoload`` off) shows no loop statusline at all, so a
+    frozen file there is expected, not a fault — the freshness check is a no-op unless the
+    owner has engaged the statusline. A settings-read failure degrades to OFF (skip).
+    """
+    try:
+        from teatree.config import get_effective_settings  # noqa: PLC0415 — deferred, matching the sibling probes
+
+        return bool(get_effective_settings().autoload)
+    except Exception:  # noqa: BLE001 — a broken config read must never turn the check into a spurious FAIL
+        return False
+
+
+def check_statusline_freshness(statusline_path: Path | None = None, *, now: float | None = None) -> bool:
+    """FAIL when the pre-rendered statusline is stale while ``autoload`` is ON.
+
+    The shell hook and ``t3 loop status`` read ``statusline.txt`` verbatim, so a render
+    chain that has stopped keeping it fresh leaves every reader showing a confident,
+    hours-old loop line with no other signal. This check is the silent-freeze backstop: it
+    resolves the render age from the SAME ``tick-meta.json`` source and the SAME
+    :func:`~teatree.loop.statusline_staleness.stale_cutoff_seconds` math the readers'
+    stale banner uses, and hard-FAILs past the cutoff so the never-freeze invariant is
+    machine-checked. A no-op (OK) when ``autoload`` is OFF (a box with no loop statusline)
+    or when the age cannot be determined (never rendered — a fresh box; fail-open, matching
+    the readers). ``statusline_path`` / ``now`` are parameterised for tests.
+    """
+    if not _autoload_on():
+        return True
+
+    from teatree.config import cadence_seconds  # noqa: PLC0415 — deferred, matching the sibling probes
+    from teatree.loop.statusline import default_path  # noqa: PLC0415 — deferred, matching the sibling probes
+    from teatree.loop.statusline_staleness import (  # noqa: PLC0415 — deferred, matching the sibling probes
+        render_age_seconds,
+        stale_cutoff_seconds,
+    )
+
+    path = statusline_path or default_path()
+    age = render_age_seconds(path, now=now)
+    if age is None:
+        return True
+    cutoff = stale_cutoff_seconds(cadence_seconds())
+    if age > cutoff:
+        typer.echo(
+            f"FAIL  statusline is STALE — last rendered {int(age)}s ago (cutoff {cutoff}s) while autoload is on; "
+            f"{_FRESHNESS_REMEDY}.",
         )
         return False
     return True

--- a/src/teatree/loop/statusline_staleness.py
+++ b/src/teatree/loop/statusline_staleness.py
@@ -99,6 +99,22 @@ def _rendered_at(meta_path: Path) -> float | None:
     return None
 
 
+def render_age_seconds(statusline_path: Path, *, now: float | None = None) -> float | None:
+    """The age in seconds of *statusline_path*'s last render, or ``None`` when unknown.
+
+    Reads the ``rendered_at`` epoch from the ``tick-meta.json`` sidecar next to
+    *statusline_path* — the single source both the stale-banner readers and the
+    headless render-refresh chain share, so a "how old is the statusline" decision
+    can never drift between the writer that keeps it fresh and the probes that flag
+    it stale. Fails open to ``None`` (age unknown) on a missing/unreadable sidecar
+    or an absent ``rendered_at``, exactly like :func:`staleness_banner_for`.
+    """
+    rendered_at = _rendered_at(_meta_path(statusline_path))
+    if rendered_at is None:
+        return None
+    return (time.time() if now is None else now) - rendered_at
+
+
 def staleness_banner_for(
     statusline_path: Path,
     *,
@@ -113,10 +129,7 @@ def staleness_banner_for(
     Fails open to ``""`` (no banner) whenever the render time cannot be
     determined — a freshness probe must never suppress real content.
     """
-    rendered_at = _rendered_at(_meta_path(statusline_path))
-    if rendered_at is None:
-        return ""
-    age = (time.time() if now is None else now) - rendered_at
-    if age <= stale_cutoff_seconds(cadence_seconds):
+    age = render_age_seconds(statusline_path, now=now)
+    if age is None or age <= stale_cutoff_seconds(cadence_seconds):
         return ""
     return staleness_banner(int(age), colorize=colorize)

--- a/src/teatree/loops/statusline_refresh.py
+++ b/src/teatree/loops/statusline_refresh.py
@@ -1,0 +1,192 @@
+"""The self-rescheduling statusline-render chain — headless freshness keeper (#256 stale-line).
+
+The statusline file (``statusline.txt``) is written as a SIDE EFFECT of a per-loop
+tick's render phase: ``t3 worker`` fires ``loops_tick --loop <name>`` for each enabled,
+due :class:`~teatree.core.models.Loop` row, and only that path calls
+:func:`teatree.loop.phases.render.render_phase`, which writes the file. So whenever no
+domain loop is admitted-and-ticking — every enabled loop not-yet-due, held under a
+preset, paused by availability, deduped, or lease-contended — the loop-timer chain keeps
+firing but every fire takes a skip branch, the render phase never runs, and the
+pre-rendered file FREEZES. The shell hook (``hooks/scripts/statusline.sh``) and
+``t3 loop status`` both read that frozen file verbatim, so the owner sees a confident,
+hours-old loop line ("next tick 4m" that will never come). That coupling is the true
+cause of the long-standing "stale statusline" complaint.
+
+This module decouples the render from domain-loop admission. A single self-rescheduling
+``render_statusline`` job on the shared :data:`~teatree.loops.timer_chains.LOOPS_QUEUE`
+(the #1796 machinery, NO OS cron) polls on a short cadence and, whenever the rendered
+file has aged past :data:`REFRESH_AGE_SECONDS`, re-renders it from live state via the
+idle-render seam :func:`teatree.loop.phases.render.rerender_statusline` and refreshes the
+``tick-meta.json`` freshness sidecar. It is the deterministic, zero-token, zero-inference
+twin of the ``reconcile_timers`` / ``usage_window_recovery`` maintenance chains: the
+refresh decision is purely the file's own render age, so a healthy fleet whose per-loop
+ticks already keep the file fresh leaves this chain dormant (each fire sees a young file
+and does nothing — no flicker, no interference), while a quiet fleet has its loop line
+kept live within ~a minute regardless.
+
+Gated by the ``autoload`` owner flag — the SAME #256/#3273 visibility gate the shell hook
+consults — so a colleague box that merely cloned the repo never has its statusline
+rendered here (the #256 colleague guarantee: ``autoload`` off ⇒ no loop statusline). While
+autoload is OFF the chain is a cheap keepalive that renders nothing but keeps
+re-scheduling, so a flag flip is picked up without a worker restart. Seeded by
+:func:`teatree.loops.timer_reconciler.ensure_maintenance_chains` at worker startup and
+self-perpetuating after that, so a worker restart / deploy re-arms it.
+"""
+
+import datetime as dt
+import logging
+import os
+
+from django.tasks import task
+from django.utils import timezone
+
+from teatree.loops.timer_chains import LOOPS_QUEUE
+
+logger = logging.getLogger(__name__)
+
+#: The chain re-arms on this cadence — the poll interval at which the render age is
+#: re-checked. Short so a frozen file is caught within ~a poll of crossing the refresh
+#: age, well under any stale cutoff.
+RENDER_POLL_SECONDS = 30
+
+#: Re-render once the file's last render is at least this old. Kept comfortably below the
+#: stale-banner floor (:data:`teatree.loop.statusline_staleness.FLOOR_SECONDS`, 300s) so
+#: the file never reaches the "STALE" threshold while the worker is alive, yet above the
+#: shortest default per-loop cadence (60s) so a healthy fleet's own ticks keep the file
+#: young enough that this chain stays dormant and never blanks their scanned zones.
+REFRESH_AGE_SECONDS = 90
+
+#: The machine-wide lease serialising the render so two at-least-once redeliveries (or two
+#: ``loops`` executor threads) can never both install the process-global loop-line reader
+#: seams and race their teardown. A losing fire skips the render but still re-arms.
+STATUSLINE_RENDER_LEASE = "loop-statusline-render"
+
+
+def _autoload_enabled() -> bool:
+    """Whether the ``autoload`` owner flag resolves ON — fail-safe OFF (the #256 gate).
+
+    The same flag the shell hook and loop-arming consult: OFF means a colleague box, so
+    the statusline must not be rendered here. A settings-read failure degrades to OFF so a
+    broken config read can never render a loop statusline onto a box that never opted in.
+    """
+    try:
+        from teatree.config import get_effective_settings  # noqa: PLC0415 — deferred: task-body import
+
+        return bool(get_effective_settings().autoload)
+    except Exception:
+        logger.debug("autoload read failed — treating the statusline-refresh chain as gated OFF", exc_info=True)
+        return False
+
+
+def _pending_render() -> bool:
+    from django_tasks.base import TaskResultStatus  # noqa: PLC0415 — deferred: heavy/optional dep at call site
+    from django_tasks_db.models import DBTaskResult  # noqa: PLC0415 — deferred: heavy/optional dep at call site
+
+    return DBTaskResult.objects.filter(
+        task_path=render_statusline.module_path,
+        status=TaskResultStatus.READY,
+    ).exists()
+
+
+def _render_is_due(now: dt.datetime) -> bool:
+    """Whether the rendered statusline has aged past :data:`REFRESH_AGE_SECONDS`.
+
+    Reads the render age from the SAME ``tick-meta.json`` source the stale-banner probes
+    use (:func:`teatree.loop.statusline_staleness.render_age_seconds`), so the freshness
+    math can never drift between the writer keeping the file fresh and the readers flagging
+    it stale. A never-rendered file (no sidecar / unknown age) is due — the chain
+    bootstraps it. A fresh file (a recent per-loop tick already rendered it) is NOT due, so
+    this chain stays dormant and does not blank that tick's scanned zones.
+    """
+    from teatree.loop.statusline import default_path  # noqa: PLC0415 — deferred: task-body import
+    from teatree.loop.statusline_staleness import render_age_seconds  # noqa: PLC0415 — deferred: task-body import
+
+    age = render_age_seconds(default_path(), now=now.timestamp())
+    return age is None or age >= REFRESH_AGE_SECONDS
+
+
+def _refresh_statusline(now: dt.datetime) -> None:
+    """Re-render the statusline from live state and refresh the freshness sidecar.
+
+    Installs the live DB-backed loop-line readers (mini-loop schedules, active-preset
+    handle, overridden loops) exactly as ``loops_tick`` does so the rendered loop line
+    carries its per-loop countdowns and preset handle, runs the idle (no-scan)
+    :func:`rerender_statusline` — cheap, zero-token, and reading the existing open-PR
+    snapshot rather than blanking it — then writes ``tick-meta.json`` so the ``rendered_at``
+    freshness epoch the stale-banner probes read advances in lock-step with the file. The
+    process-global reader seams are always reset in ``finally`` so they never leak past
+    this render.
+    """
+    from teatree.loop.phases.render import rerender_statusline  # noqa: PLC0415 — deferred: task-body import
+    from teatree.loop.statusline import (  # noqa: PLC0415 — deferred: task-body import
+        set_mini_loop_schedules_reader,
+        set_overridden_loops_reader,
+        set_preset_line_reader,
+    )
+    from teatree.loop.tick import _write_tick_meta  # noqa: PLC0415 — deferred: task-body import
+    from teatree.loops.preset_status import overridden_loop_names, preset_line_handles  # noqa: PLC0415 — deferred
+    from teatree.loops.schedule import mini_loop_schedules  # noqa: PLC0415 — deferred: task-body import
+
+    set_mini_loop_schedules_reader(mini_loop_schedules)
+    set_preset_line_reader(preset_line_handles)
+    set_overridden_loops_reader(overridden_loop_names)
+    try:
+        rerender_statusline()
+        _write_tick_meta(now)
+    finally:
+        set_mini_loop_schedules_reader(None)
+        set_preset_line_reader(None)
+        set_overridden_loops_reader(None)
+
+
+def refresh_statusline_if_due(now: dt.datetime) -> str:
+    """Render the statusline when it has aged past the refresh threshold; return the outcome.
+
+    The pure body of one chain fire (no re-scheduling), split out so a test drives the
+    decision without the queue. Returns ``"gated"`` (autoload OFF — the #256 colleague
+    guarantee), ``"contended"`` (another render holds the lease), ``"fresh"`` (a recent
+    render already keeps the file young — this chain stays dormant), or ``"rendered"``.
+    Fully fail-open: any render error is swallowed so a broken render can never wedge the
+    chain or crash the worker.
+    """
+    if not _autoload_enabled():
+        return "gated"
+    if not _render_is_due(now):
+        return "fresh"
+
+    from teatree.core.models import LoopLease  # noqa: PLC0415 — deferred: ORM import needs the app registry
+
+    owner = f"worker-{os.getpid()}"
+    if not LoopLease.objects.acquire(STATUSLINE_RENDER_LEASE, owner=owner):
+        return "contended"
+    try:
+        _refresh_statusline(now)
+    except Exception:
+        logger.exception("statusline refresh render failed — the chain re-arms and retries next poll")
+        return "fresh"
+    finally:
+        LoopLease.objects.release(STATUSLINE_RENDER_LEASE, owner=owner)
+    return "rendered"
+
+
+@task(queue_name=LOOPS_QUEUE)
+def render_statusline() -> dict[str, str]:
+    """One render-refresh fire: re-render the statusline if stale, then re-schedule the chain.
+
+    Self-dedups first (another pending render carries the chain), mirroring the
+    ``reconcile_timers`` contract, so an at-least-once redelivery collapses to one. The
+    body is a no-op when autoload is OFF or the file is already fresh, but the chain always
+    re-schedules itself :data:`RENDER_POLL_SECONDS` out so a flag flip or a fleet going
+    quiet is picked up without a worker restart.
+    """
+    if _pending_render():
+        return {"action": "deduped"}
+    outcome = refresh_statusline_if_due(timezone.now())
+    render_statusline.using(run_after=timezone.now() + dt.timedelta(seconds=RENDER_POLL_SECONDS)).enqueue()
+    return {"action": outcome}
+
+
+def ensure_statusline_refresh_chain() -> None:
+    """Seed the render-refresh chain head if absent — self-perpetuating after (worker startup)."""
+    if not _pending_render():
+        render_statusline.using(run_after=timezone.now() + dt.timedelta(seconds=RENDER_POLL_SECONDS)).enqueue()

--- a/src/teatree/loops/timer_reconciler.py
+++ b/src/teatree/loops/timer_reconciler.py
@@ -20,7 +20,10 @@ backlog draining and re-enqueues runs a dead worker abandoned. A tight-cadence
 👀-receipt + reply/delegate machinery that only ran in an interactive owner
 session's ``/loop`` slot before), guarded by the SAME ``loop-slack-answer``
 :class:`LoopLease` the ``loop_slack_answer`` mgmt command takes so the worker and an
-interactive owner session can never double-post. The maintenance chains are seeded by
+interactive owner session can never double-post. A :func:`render_statusline` chain
+(:mod:`teatree.loops.statusline_refresh`) keeps ``statusline.txt`` fresh on a short
+cadence even when no domain loop is admitted-and-ticking, so the pre-rendered loop line
+never freezes headless. The maintenance chains are seeded by
 :func:`ensure_maintenance_chains` at worker startup and self-perpetuate, so a worker
 restart re-arms them.
 """
@@ -377,9 +380,10 @@ def run_slack_answer() -> dict[str, int]:
 
 
 def ensure_maintenance_chains() -> None:
-    """Seed reconcile / prune / expire / drain / slack-answer / usage-window / preset chains if absent."""
+    """Seed reconcile / prune / expire / drain / slack-answer / usage-window / preset / statusline chains if absent."""
     from teatree.loop.loop_cadences import slack_answer_cadence_seconds  # noqa: PLC0415 — deferred: tick-time import
     from teatree.loops.preset_transitions import ensure_preset_transitions_chain  # noqa: PLC0415 — cycle-safe
+    from teatree.loops.statusline_refresh import ensure_statusline_refresh_chain  # noqa: PLC0415 — cycle-safe
     from teatree.loops.usage_window_recovery import ensure_usage_window_recovery_chain  # noqa: PLC0415 — cycle-safe
 
     now = timezone.now()
@@ -406,3 +410,7 @@ def ensure_maintenance_chains() -> None:
     # #3159: the preset-transition side-effect chain (override reap, availability pin,
     # one Slack line per switch). Inert with no active preset — a cheap keepalive.
     ensure_preset_transitions_chain()
+    # The headless statusline-render chain — keeps ``statusline.txt`` fresh on a short
+    # cadence even when NO domain loop is admitted-and-ticking (the true cause of the
+    # long-standing stale-loop-line complaint), gated by the ``autoload`` #256 flag.
+    ensure_statusline_refresh_chain()

--- a/tests/teatree_cli/doctor/test_statusline_check.py
+++ b/tests/teatree_cli/doctor/test_statusline_check.py
@@ -1,11 +1,21 @@
-"""`t3 doctor` verifies the statusLine block: presence/absolute/executable (PR-17)."""
+"""`t3 doctor` verifies the statusLine block: presence/absolute/executable (PR-17).
+
+Plus the silent-freeze backstop (:func:`check_statusline_freshness`): a stale pre-rendered
+statusline while ``autoload`` is ON is a hard FAIL, so a headless render chain that stopped
+keeping the file fresh can never regress unnoticed.
+"""
 
 import io
 import json
 from contextlib import redirect_stdout
 from pathlib import Path
 
-from teatree.cli.doctor.statusline import check_statusline
+import django.test
+from django.utils import timezone
+
+from teatree.cli.doctor.statusline import check_statusline, check_statusline_freshness
+from teatree.core.models.config_setting import ConfigSetting
+from teatree.loop.statusline_staleness import FLOOR_SECONDS
 
 
 def _run(settings: Path) -> tuple[bool, str]:
@@ -112,3 +122,58 @@ class TestPluginSettingsHasNoStatusline:
         assert settings.is_file()
         data = json.loads(settings.read_text(encoding="utf-8"))
         assert "statusLine" not in data
+
+
+@django.test.override_settings(USE_TZ=True)
+class TestCheckStatuslineFreshness(django.test.TestCase):
+    """The silent-freeze backstop: a stale statusline FAILs only while autoload is ON."""
+
+    def _write_meta(self, tmp_path: Path, *, rendered_at: float) -> Path:
+        statusline = tmp_path / "statusline.txt"
+        statusline.with_name("tick-meta.json").write_text(json.dumps({"rendered_at": rendered_at}), encoding="utf-8")
+        return statusline
+
+    def _run(self, statusline: Path, *, now: float) -> tuple[bool, str]:
+        out = io.StringIO()
+        with redirect_stdout(out):
+            ok = check_statusline_freshness(statusline_path=statusline, now=now)
+        return ok, out.getvalue()
+
+    def test_stale_file_fails_when_autoload_on(self) -> None:
+        ConfigSetting.objects.set_value("autoload", value=True, scope="")
+        now = timezone.now().timestamp()
+        statusline = self._write_meta(Path(self._make_tmp()), rendered_at=now - 10 * FLOOR_SECONDS)
+        ok, message = self._run(statusline, now=now)
+        assert ok is False
+        assert "STALE" in message
+
+    def test_stale_file_is_ignored_when_autoload_off(self) -> None:
+        ConfigSetting.objects.set_value("autoload", value=False, scope="")
+        now = timezone.now().timestamp()
+        statusline = self._write_meta(Path(self._make_tmp()), rendered_at=now - 10 * FLOOR_SECONDS)
+        ok, message = self._run(statusline, now=now)
+        assert ok is True  # a colleague / opted-out box: a frozen file is expected, not a fault
+        assert "STALE" not in message
+
+    def test_fresh_file_passes(self) -> None:
+        ConfigSetting.objects.set_value("autoload", value=True, scope="")
+        now = timezone.now().timestamp()
+        statusline = self._write_meta(Path(self._make_tmp()), rendered_at=now - 5)
+        ok, message = self._run(statusline, now=now)
+        assert ok is True
+        assert "FAIL" not in message
+
+    def test_never_rendered_is_not_a_failure(self) -> None:
+        ConfigSetting.objects.set_value("autoload", value=True, scope="")
+        now = timezone.now().timestamp()
+        statusline = Path(self._make_tmp()) / "statusline.txt"  # no tick-meta sidecar
+        ok, message = self._run(statusline, now=now)
+        assert ok is True  # fail-open: an unknown render age never fabricates a FAIL
+        assert "FAIL" not in message
+
+    def _make_tmp(self) -> str:
+        import tempfile  # noqa: PLC0415 — test-local
+
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        return tmp.name

--- a/tests/teatree_loops/test_statusline_refresh.py
+++ b/tests/teatree_loops/test_statusline_refresh.py
@@ -1,0 +1,179 @@
+"""teatree.loops.statusline_refresh — the headless statusline-render chain (#256 stale-line).
+
+The crux behavioural contract: the pre-rendered ``statusline.txt`` is re-rendered on a
+short cadence WITHOUT any domain loop being admitted-and-ticking, so the loop line never
+freezes headless — but only when it has actually aged (a fresh file is left alone, no
+flicker) and only while the ``autoload`` #256 flag is ON (a colleague box renders nothing).
+Integration-first against the real DB + ``django_tasks_db`` backend and a real temp XDG
+home, so the render truly writes the file and refreshes its freshness sidecar.
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import django.test
+from django.utils import timezone
+
+from teatree.core.models import LoopLease
+from teatree.core.models.config_setting import ConfigSetting
+from teatree.loop.statusline_staleness import FLOOR_SECONDS
+from teatree.loops import statusline_refresh, timer_reconciler
+from teatree.loops.statusline_refresh import (
+    REFRESH_AGE_SECONDS,
+    STATUSLINE_RENDER_LEASE,
+    ensure_statusline_refresh_chain,
+    refresh_statusline_if_due,
+    render_statusline,
+)
+
+_DB_TASKS = {"default": {"BACKEND": "django_tasks_db.DatabaseBackend", "QUEUES": ["default", "loops"]}}
+
+
+def _set_autoload(*, on: bool) -> None:
+    ConfigSetting.objects.set_value("autoload", value=on, scope="")
+
+
+@django.test.override_settings(USE_TZ=True, TASKS=_DB_TASKS)
+class _RefreshCase(django.test.TestCase):
+    """Base: an isolated temp XDG home so ``default_path()`` writes under the test dir."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        patcher = mock.patch.dict(os.environ, {"XDG_DATA_HOME": self._tmp.name})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.statusline = Path(self._tmp.name) / "teatree" / "statusline.txt"
+        self.meta = self.statusline.with_name("tick-meta.json")
+
+    def _write_meta(self, *, rendered_at: float) -> None:
+        self.meta.parent.mkdir(parents=True, exist_ok=True)
+        self.meta.write_text(json.dumps({"rendered_at": rendered_at}), encoding="utf-8")
+
+    def _meta_rendered_at(self) -> float:
+        return json.loads(self.meta.read_text(encoding="utf-8"))["rendered_at"]
+
+
+class TestAutoloadGate(_RefreshCase):
+    """The #256 colleague guarantee: autoload OFF renders nothing, no matter how stale."""
+
+    def test_gated_off_renders_nothing(self) -> None:
+        _set_autoload(on=False)
+        now = timezone.now()
+        self._write_meta(rendered_at=now.timestamp() - 10 * FLOOR_SECONDS)  # hours stale
+
+        outcome = refresh_statusline_if_due(now)
+
+        assert outcome == "gated"
+        assert not self.statusline.exists()
+
+
+class TestFreshnessGuard(_RefreshCase):
+    """Renders only once the file has aged past the refresh threshold — a fresh file is left alone."""
+
+    def test_renders_when_never_rendered(self) -> None:
+        _set_autoload(on=True)
+        assert not self.meta.exists()
+
+        outcome = refresh_statusline_if_due(timezone.now())
+
+        assert outcome == "rendered"
+        assert self.statusline.exists()  # bootstrapped from a live render
+        assert self.meta.exists()
+
+    def test_skips_when_file_is_fresh(self) -> None:
+        _set_autoload(on=True)
+        now = timezone.now()
+        self._write_meta(rendered_at=now.timestamp() - (REFRESH_AGE_SECONDS - 5))  # just under the threshold
+        self.statusline.write_text("PRIOR TICK CONTENT\n", encoding="utf-8")
+
+        outcome = refresh_statusline_if_due(now)
+
+        assert outcome == "fresh"
+        # A fresh file (a recent per-loop tick already rendered it) is NOT re-rendered,
+        # so this chain never blanks that tick's scanned zones.
+        assert self.statusline.read_text(encoding="utf-8") == "PRIOR TICK CONTENT\n"
+
+    def test_renders_when_file_is_stale(self) -> None:
+        _set_autoload(on=True)
+        now = timezone.now()
+        stale_at = now.timestamp() - (REFRESH_AGE_SECONDS + 30)
+        self._write_meta(rendered_at=stale_at)
+
+        outcome = refresh_statusline_if_due(now)
+
+        assert outcome == "rendered"
+        assert self.statusline.exists()
+        # The freshness sidecar advanced in lock-step so the stale-banner probes agree.
+        assert self._meta_rendered_at() > stale_at
+
+    def test_refresh_threshold_is_well_under_the_stale_cutoff(self) -> None:
+        # Keeps the file fresh long before the readers would flag it STALE (floor 300s),
+        # yet above the shortest 60s per-loop cadence so a healthy fleet stays dormant.
+        assert 60 < REFRESH_AGE_SECONDS < FLOOR_SECONDS
+
+
+class TestLeaseSerialisation(_RefreshCase):
+    """Two concurrent fires never both install the process-global reader seams and race teardown."""
+
+    def test_contended_lease_skips_render(self) -> None:
+        _set_autoload(on=True)
+        now = timezone.now()
+        self._write_meta(rendered_at=now.timestamp() - (REFRESH_AGE_SECONDS + 30))
+        assert LoopLease.objects.acquire(STATUSLINE_RENDER_LEASE, owner="other-holder")
+
+        outcome = refresh_statusline_if_due(now)
+
+        assert outcome == "contended"
+        assert not self.statusline.exists()
+
+    def test_lease_released_after_render(self) -> None:
+        _set_autoload(on=True)
+        refresh_statusline_if_due(timezone.now())
+        # Released in the finally, so a subsequent owner can take it.
+        assert LoopLease.objects.acquire(STATUSLINE_RENDER_LEASE, owner="next-owner")
+
+
+@django.test.override_settings(USE_TZ=True, TASKS=_DB_TASKS)
+class TestChain(django.test.TestCase):
+    """The self-rescheduling chain contract — mirrors the reconcile/prune maintenance chains."""
+
+    def setUp(self) -> None:
+        from django_tasks_db.models import DBTaskResult  # noqa: PLC0415 — test-local heavy dep
+
+        DBTaskResult.objects.all().delete()
+
+    def _pending(self) -> int:
+        from django_tasks.base import TaskResultStatus  # noqa: PLC0415 — test-local heavy dep
+        from django_tasks_db.models import DBTaskResult  # noqa: PLC0415 — test-local heavy dep
+
+        return DBTaskResult.objects.filter(
+            task_path=render_statusline.module_path, status=TaskResultStatus.READY
+        ).count()
+
+    def test_fire_reschedules_itself(self) -> None:
+        _set_autoload(on=False)  # gated body keeps the fire cheap; the re-arm still happens
+        result = render_statusline.func()
+        assert result["action"] != "deduped"
+        assert self._pending() == 1  # a successor render chain is queued
+
+    def test_fire_self_dedups(self) -> None:
+        render_statusline.using(run_after=timezone.now()).enqueue()
+        result = render_statusline.func()
+        assert result == {"action": "deduped"}
+
+    def test_ensure_seeds_head_once_and_is_idempotent(self) -> None:
+        ensure_statusline_refresh_chain()
+        assert self._pending() == 1
+        ensure_statusline_refresh_chain()
+        assert self._pending() == 1  # idempotent — no duplicate head
+
+    def test_worker_startup_maintenance_seed_arms_the_chain(self) -> None:
+        # A deploy/restart re-arms it: ensure_maintenance_chains seeds the render chain
+        # alongside its sibling maintenance chains.
+        timer_reconciler.ensure_maintenance_chains()
+        assert self._pending() == 1
+        assert statusline_refresh.render_statusline.module_path  # sanity: the task is importable


### PR DESCRIPTION
## Root cause

`statusline.txt` is written **only** as a side effect of a per-loop tick's render phase. `t3 worker` fires `loops_tick --loop <name>` for each enabled, *due* `Loop` row, and only that path reaches `render_phase`, which writes the file. Whenever no domain loop is admitted-and-ticking — every enabled loop not-yet-due, held under a preset, paused by availability, deduped, or lease-contended — the loop-timer chain keeps firing but **every fire takes a skip branch**, so `render_phase`/`run_tick` never run and the file **freezes**. The shell hook (`hooks/scripts/statusline.sh`) and `t3 loop status` read that frozen file verbatim, so the owner sees a confident, hours-old loop line.

Observed live: 90 `loop_timer` + 18 `run_slack_answer` fires in a 3-minute window, **0** `render_phase`/statusline writes; the file went 3.8h stale. A manual `t3 loop tick` wrote a fresh file, then it climbed 145s → 295s → 445s with no rewrite. Nothing invokes the full render tick automatically headless — it was structurally coupled to a domain loop actually ticking.

## Fix

A self-rescheduling `render_statusline` maintenance chain (`teatree.loops.statusline_refresh`) on the shared `loops` queue — the #1796 durable-timer machinery, no OS cron — decoupled from domain-loop admission:

- **Seeded by `ensure_maintenance_chains`** at worker startup (alongside `reconcile_timers` / `usage_window_recovery` / …), so a deploy/restart re-arms it and it self-perpetuates.
- **Freshness-guarded, not unconditional:** it re-renders only once the file has aged past `REFRESH_AGE_SECONDS` (90s) — well under the stale cutoff (`max(2·cadence, 300s)`) yet above the 60s shortest per-loop cadence — so a healthy fleet whose own ticks keep the file young leaves this chain **dormant** (no flicker, never blanks a real tick's scanned zones). A quiet fleet has its loop line kept live within ~a poll.
- **Renders from live state** via the existing idle `rerender_statusline` seam (zero-token, no scan, reads the existing open-PR snapshot) with the same loop-line reader seams `loops_tick` installs, then advances the `tick-meta.json` freshness sidecar in lock-step so the stale-banner math agrees.
- **Gated by the `autoload` #256/#3273 flag** — a colleague / opted-out box renders nothing (the existing gate is respected; the `autoload`-blank bug is not reintroduced). Lease-serialised so two redeliveries never race the process-global reader teardown.

Plus a **doctor backstop** (`check_statusline_freshness`) that hard-FAILs a stale statusline while `autoload` is on, sharing the readers' stale-cutoff math via a new `render_age_seconds` helper in `statusline_staleness.py`, so a stopped render chain can never silently regress.

## Verification

Exercised end-to-end against a real DB + temp XDG home: a file whose sidecar showed **210s** stale was re-rendered by `refresh_statusline_if_due` with **no domain tick** — `rendered_at` age dropped 210s → 1s and the file was rewritten. A file just under the threshold is left untouched (`outcome == "fresh"`).

Tests (RED-first, integration-leaning): autoload gate, freshness guard (dormant when fresh, renders when stale, bootstraps when never-rendered), lease serialisation, self-reschedule + self-dedup, `ensure_maintenance_chains` re-arm; doctor check stale-FAIL / autoload-off-skip / fresh-pass / never-rendered-fail-open. Full prek clean (SKIP codespell,ci-critical-parity), `makemigrations --check` clean, adjacent suites (timer_reconciler / worker / claude_statusline) green.

Do **not** merge — owner will verify live auto-refresh after deploy.