### PR TITLE
fix(dogfood): strip inherited DJANGO_SETTINGS_MODULE before shelling out to t3

### DIFF
--- a/src/teatree/loop/dogfood_smoke.py
+++ b/src/teatree/loop/dogfood_smoke.py
@@ -19,6 +19,7 @@ runner; they never re-implement the orchestration shape.
 """
 
 import logging
+import os
 import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
@@ -128,6 +129,20 @@ def _decode_subprocess_output(raw: bytes | str | None) -> str:
     return raw
 
 
+def _clean_subprocess_env() -> dict[str, str]:
+    """Strip an inherited ``DJANGO_SETTINGS_MODULE`` for the step's ``t3`` child.
+
+    This process has already bootstrapped Django by the time a step runs,
+    which leaks ``DJANGO_SETTINGS_MODULE`` into ``os.environ`` (``ensure_django()``'s
+    ``setdefault``). A pre-set value crashes the child's overlay-entry-point
+    import with ``AppRegistryNotReady`` before it ever reaches its own command
+    body — the same class of leak :func:`teatree.cli.overlay._base_env` and
+    :func:`teatree.self_update._self_db_migrate_env` strip for their own
+    subprocess calls.
+    """
+    return {key: value for key, value in os.environ.items() if key != "DJANGO_SETTINGS_MODULE"}
+
+
 def run_t3_command(step: SmokeStep) -> StepResult:
     """Default runner: shell out to the step's CLI command.
 
@@ -143,6 +158,7 @@ def run_t3_command(step: SmokeStep) -> StepResult:
             step.command,
             expected_codes=None,
             timeout=step.timeout_seconds,
+            env=_clean_subprocess_env(),
         )
     except TimeoutExpired as exc:
         elapsed = time.monotonic() - started

--- a/tests/teatree_loop/test_dogfood_smoke.py
+++ b/tests/teatree_loop/test_dogfood_smoke.py
@@ -380,3 +380,30 @@ class TestRunT3CommandRunner:
         assert "partial stderr" in result.stderr
         assert "partial" in result.stdout
         assert result.elapsed_seconds >= 0
+
+    def test_run_t3_command_strips_inherited_django_settings_module(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Regression: a leaked ``DJANGO_SETTINGS_MODULE`` breaks the child (#3516).
+
+        It crashes the child's overlay-entry-point import with
+        ``AppRegistryNotReady`` (a dogfood-smoke run against a process that
+        already bootstrapped Django). Every other subprocess-spawning path in
+        this codebase (``cli/overlay.py:_base_env()``,
+        ``self_update.py:_self_db_migrate_env()``) strips the inherited var
+        before shelling out to a bare ``t3`` command; this runner must too.
+        """
+        from subprocess import CompletedProcess  # noqa: PLC0415 -- test-local, see #3516
+        from unittest.mock import patch  # noqa: PLC0415 -- test-local, see #3516
+
+        from teatree.loop.dogfood_smoke import run_t3_command  # noqa: PLC0415 -- test-local, see #3516
+
+        monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "teatree.settings")
+        monkeypatch.setenv("SOME_OTHER_VAR", "keep-me")
+        step = SmokeStep(name="workspace_ticket", command=("t3", "teatree", "workspace", "ticket"))
+        fake = CompletedProcess(args=step.command, returncode=0, stdout="ok", stderr="")
+        with patch("teatree.loop.dogfood_smoke.run_allowed_to_fail", return_value=fake) as mock_run:
+            run_t3_command(step)
+
+        passed_env = mock_run.call_args.kwargs["env"]
+        assert passed_env is not None
+        assert "DJANGO_SETTINGS_MODULE" not in passed_env
+        assert passed_env["SOME_OTHER_VAR"] == "keep-me"


### PR DESCRIPTION
## Summary
- `run_t3_command` shelled out to each provision-smoke step's `t3 <overlay> ...` command with no `env` override, inheriting the harness process's own `os.environ` verbatim.
- By the time a step runs, the harness has already bootstrapped Django (`ensure_django()`'s `os.environ.setdefault("DJANGO_SETTINGS_MODULE", ...)`), which leaks the var into every child `t3` invocation and crashes `register_overlay_commands()`'s eager entry-point import with `AppRegistryNotReady` — before `workspace_ticket` (the smoke's first step) can even run.
- Fix mirrors the existing stripping pattern already used elsewhere in the codebase (`cli/overlay.py:_base_env()`, `self_update.py:_self_db_migrate_env()`).

Confirmed live: `t3 dogfood overlay-provision-smoke --overlay teatree` now gets past `workspace_ticket` (previously failed there every time).

Fixes #3516.

## Test plan
- [x] New regression test (`test_run_t3_command_strips_inherited_django_settings_module`) observed RED against the pre-fix code, GREEN after
- [x] `uv run pytest tests/teatree_loop/test_dogfood_smoke.py` — 36 passed
- [x] `t3 tool verify-gates` — commit + push stage gates all green
- [x] Live-ran `t3 dogfood overlay-provision-smoke --overlay teatree` before/after — confirms the fix resolves the reported crash