### PR TITLE
fix(agents): give every sub-agent definition the Skill tool

### DIFF
--- a/agents/answerer.md
+++ b/agents/answerer.md
@@ -8,6 +8,7 @@ tools:
   - Read
   - Grep
   - Glob
+  - Skill
 skills:
   - rules
   - workspace

--- a/agents/bughunter.md
+++ b/agents/bughunter.md
@@ -8,6 +8,7 @@ tools:
   - Bash
   - Grep
   - Glob
+  - Skill
 skills:
   - rules
   - debug

--- a/agents/coder.md
+++ b/agents/coder.md
@@ -10,6 +10,7 @@ tools:
   - Bash
   - Grep
   - Glob
+  - Skill
 skills:
   - rules
   - workspace

--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -10,6 +10,7 @@ tools:
   - Bash
   - Grep
   - Glob
+  - Skill
 skills:
   - rules
   - workspace

--- a/agents/e2e.md
+++ b/agents/e2e.md
@@ -10,6 +10,7 @@ tools:
   - Bash
   - Grep
   - Glob
+  - Skill
 skills:
   - rules
   - workspace

--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -10,6 +10,7 @@ tools:
   - Glob
   - Bash
   - Agent
+  - Skill
 skills:
   - rules
   - workspace

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -9,6 +9,7 @@ tools:
   - Bash
   - Grep
   - Glob
+  - Skill
 skills:
   - rules
   - workspace

--- a/agents/scanning-news.md
+++ b/agents/scanning-news.md
@@ -9,6 +9,7 @@ tools:
   - Grep
   - Glob
   - WebFetch
+  - Skill
 skills:
   - rules
   - workspace

--- a/agents/shipper.md
+++ b/agents/shipper.md
@@ -8,6 +8,7 @@ tools:
   - Bash
   - Grep
   - Glob
+  - Skill
 skills:
   - rules
   - workspace

--- a/agents/tester.md
+++ b/agents/tester.md
@@ -10,6 +10,7 @@ tools:
   - Bash
   - Grep
   - Glob
+  - Skill
 skills:
   - rules
   - workspace

--- a/agents/triage-assessor.md
+++ b/agents/triage-assessor.md
@@ -9,6 +9,7 @@ tools:
   - Grep
   - Glob
   - WebFetch
+  - Skill
 skills:
   - rules
   - platforms

--- a/tests/teatree_agents/test_agent_definition_tools.py
+++ b/tests/teatree_agents/test_agent_definition_tools.py
@@ -1,0 +1,67 @@
+"""Every ``agents/*.md`` definition must expose the ``Skill`` tool.
+
+A sub-agent spawned through the harness ``Agent`` tool receives exactly the tools
+its definition's ``tools:`` allowlist names. Omitting ``Skill`` closes BOTH skill
+channels at once: the agent cannot load a skill itself, and the ``skills:``
+frontmatter it declares is honoured only by teatree's OWN dispatch path
+(``build_system_context`` / ``_read_skill_contents``), which a raw ``Agent``-tool
+spawn bypasses. The observed symptom was sub-agents reporting that the ``Skill``
+tool was not in their toolset and then running without their mandated skills.
+
+``Skill`` only loads instructions into context — it grants no write capability —
+so a read-only agent (reviewer, planner, triage-assessor) carries it safely.
+
+The frontmatter is parsed from the real repo ``agents/*.md`` files on disk, never
+a fixture copy, so a future definition added without ``Skill`` fails here.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from django.test import TestCase
+
+#: Repo-root ``agents/`` directory — the canonical sub-agent definitions the
+#: ``Agent`` tool resolves a ``t3:<name>`` value against.
+AGENTS_DIR: Path = Path(__file__).resolve().parents[2] / "agents"
+
+SKILL_TOOL = "Skill"
+
+
+def _frontmatter(path: Path) -> dict[str, Any]:
+    """Parse the leading ``---``-delimited YAML frontmatter block of *path*."""
+    _, _, after_open = path.read_text(encoding="utf-8").partition("---\n")
+    block, _, _ = after_open.partition("\n---")
+    return yaml.safe_load(block) or {}
+
+
+class TestAgentDefinitionsExposeTheSkillTool(TestCase):
+    def test_agents_dir_holds_definitions(self) -> None:
+        # Anti-vacuity floor: an empty glob would make every check below pass.
+        assert sorted(AGENTS_DIR.glob("*.md")), f"no agent definitions found under {AGENTS_DIR}"
+
+    def test_every_explicit_tools_allowlist_includes_skill(self) -> None:
+        offenders: dict[str, list[str]] = {}
+        for path in sorted(AGENTS_DIR.glob("*.md")):
+            tools = _frontmatter(path).get("tools")
+            if tools is not None and SKILL_TOOL not in tools:
+                offenders[path.name] = tools
+        assert offenders == {}, (
+            f"agent definitions whose 'tools:' allowlist omits {SKILL_TOOL!r}: {offenders}. "
+            "A sub-agent spawned via the Agent tool gets exactly this allowlist, so without "
+            f"{SKILL_TOOL!r} it can load no skill at all — and its 'skills:' frontmatter is "
+            "honoured only by teatree's own dispatch, which a raw Agent spawn bypasses."
+        )
+
+    def test_definitions_without_a_tools_key_never_deny_skill(self) -> None:
+        # A definition naming no 'tools:' inherits the full toolset and reaches
+        # Skill already; adding an allowlist there would NARROW it. Such a
+        # definition must not claw Skill back via 'disallowedTools:' either.
+        for path in sorted(AGENTS_DIR.glob("*.md")):
+            frontmatter = _frontmatter(path)
+            if frontmatter.get("tools") is not None:
+                continue
+            denied = frontmatter.get("disallowedTools") or []
+            assert SKILL_TOOL not in denied, (
+                f"{path.name} inherits the full toolset but denies {SKILL_TOOL!r} — it could load no skill"
+            )


### PR DESCRIPTION
## The bug

Sub-agent definitions in `agents/*.md` declare an explicit `tools:` allowlist that omitted `Skill`. That closed **both** skill channels at once:

1. **No `Skill` tool.** A sub-agent spawned through the harness `Agent` tool receives exactly the tools its allowlist names. Without `Skill` in the list, it cannot load any skill itself.
2. **`skills:` frontmatter is not universal.** The `skills:` key each definition declares is honoured only by teatree's *own* dispatch path (`build_system_context` / `_read_skill_contents` in `src/teatree/agents/prompt.py`). A raw `Agent`-tool spawn bypasses that path entirely.

**Observed symptom:** four sub-agents in a row reported that the `Skill` tool was not in their toolset, could not load their mandated language and workspace convention skills, and then silently ran their whole task without them.

## The change

`Skill` is appended to the 11 definitions carrying an explicit `tools:` list:

`answerer` · `bughunter` · `coder` · `debugger` · `e2e` · `orchestrator` · `planner` · `scanning-news` · `shipper` · `tester` · `triage-assessor`

Four definitions have **no** `tools:` key — `e2e-review`, `followup`, `review-request`, `reviewer`. They already inherit the full toolset and narrow it via `disallowedTools:`, so they reach `Skill` today; introducing an allowlist there would *narrow* them. They are left untouched.

## Why read-only agents get `Skill` too

`Skill` only loads instructions into context. It grants no write capability, spawns nothing, and reaches no network — so it does not widen the blast radius of a read-only agent (`reviewer`, `planner`, `triage-assessor`, and the `disallowedTools:` four). The real risk runs the other way: a reviewer that cannot load the project's review conventions reviews against nothing.

## Test

`tests/teatree_agents/test_agent_definition_tools.py` parses the **real** `agents/*.md` frontmatter from disk — never a fixture copy — so a future definition added without `Skill` fails the suite. It also asserts that the no-`tools:` definitions never claw `Skill` back via `disallowedTools:`.

**Anti-vacuity proof.** Removing `Skill` from one file (`agents/shipper.md`) and re-running turns the test RED and names the offender:

```text
E       AssertionError: agent definitions whose 'tools:' allowlist omits 'Skill': {'shipper.md': ['Read', 'Bash', 'Grep', 'Glob']}. A sub-agent spawned via the Agent tool gets exactly this allowlist, so without 'Skill' it can load no skill at all — and its 'skills:' frontmatter is honoured only by teatree's own dispatch, which a raw Agent spawn bypasses.
```

Restored, it is green again.

## Gates

| Gate | Result |
|---|---|
| `uv run pytest tests/teatree_agents/ tests/teatree_core/test_phase_agent_conformance.py` | 916 passed, 2 skipped, 18 subtests passed |
| `uv run ruff check` | All checks passed |
| `uv run ruff format --check` | 3347 files already formatted |
| `uv run prek run --files <changed>` | all 30 hooks Passed (incl. `ruff check`, `tach`, `ty-check`, `markdownlint-cli2`, `banned-terms`, `Validate agent skill references resolve`) |

No lint was suppressed; no `# noqa` added.

## Remaining gap (follow-up, not fixed here)

Adding the tool lets an agent load a skill — nothing yet **makes** it load the `skills:` it declares on a raw `Agent`-tool spawn. That frontmatter is still honoured only by teatree's own dispatch path. Closing that second half (e.g. injecting the declared skills into the spawn prompt, or a startup assertion that the declared skills were loaded) is deliberately left as follow-up.
