### PR TITLE
fix(gate): scan only newly-public commits in the pre-push leak gate

### DIFF
--- a/scripts/hooks/refuse-public-push-with-leak.sh
+++ b/scripts/hooks/refuse-public-push-with-leak.sh
@@ -28,9 +28,11 @@
 # Git invokes a pre-push hook as:  hook <remote-name> <remote-url>
 # and feeds ref updates on stdin, one per line:
 #   <local-ref> <local-sha> <remote-ref> <remote-sha>
-# A deleted ref has local-sha all-zeros (skip it). For a new remote ref
-# the remote-sha is all-zeros, so the gate falls back to the merge-base
-# with the remote's default branch as the comparison base.
+# A deleted ref has local-sha all-zeros (skip it). The scanned set is the
+# commits reachable from the pushed sha but from no already-public ref —
+# `<local-sha> --not <origin/default> [<remote-sha>]` — never a single
+# linear `<remote-sha>..<local-sha>` range, which a merge-forward inflates
+# with the whole of `main` (#3523).
 #
 # Visibility is resolved via `gh repo view <owner>/<repo> --json
 # visibility`. The gate SKIPS the scan only when the remote is KNOWN to be
@@ -151,23 +153,41 @@ while read -r local_ref local_sha remote_ref remote_sha; do
   [ -n "${local_sha:-}" ] || continue
   [ "${local_sha}" != "${ZERO}" ] || continue  # branch deletion — skip
 
+  # The push newly exposes the commits reachable from the pushed sha but
+  # from NO already-public ref: `origin/<default>` plus, when it is
+  # confirmed to be the branch's own remote tip, the reported remote_sha.
+  # A single linear `remote_sha..HEAD` range instead spans every commit a
+  # merge-forward brought in from `main` — all of it already public, and
+  # every finding and non-noreply identity in it a false positive (#3523).
+  public_tips=()
+  default_tip=$(git rev-parse --verify --quiet \
+    "refs/remotes/${remote_name}/${default_branch}^{commit}" 2>/dev/null || true)
+  if [ -n "${default_tip}" ]; then
+    public_tips+=("${default_tip}")
+  fi
   if [ "${remote_sha}" != "${ZERO}" ] && [ -n "${remote_sha}" ] \
     && _remote_sha_is_trusted_base "${remote_ref}" "${remote_sha}"; then
-    base="${remote_sha}"
-  else
-    base=$(git merge-base "${local_sha}" \
-      "refs/remotes/${remote_name}/${default_branch}" 2>/dev/null || true)
+    remote_tip=$(git rev-parse --verify --quiet "${remote_sha}^{commit}" 2>/dev/null || true)
+    if [ -n "${remote_tip}" ]; then
+      public_tips+=("${remote_tip}")
+    fi
   fi
 
-  if [ -n "${base}" ]; then
-    diff=$(git diff "${base}" "${local_sha}" 2>/dev/null || true)
-    msgs=$(git log --format='%B' "${base}..${local_sha}" 2>/dev/null || true)
-  else
-    # No comparison point (brand-new repo / unknown base): scan the
-    # whole tree at the pushed sha rather than skipping the gate.
-    diff=$(git show "${local_sha}" 2>/dev/null || true)
-    msgs=$(git log --format='%B' "${local_sha}" 2>/dev/null || true)
+  # No resolvable public tip (brand-new repo, unknown sha, shallow clone):
+  # fail CLOSED by subtracting nothing, so the whole history reachable from
+  # the pushed sha is scanned — wider, never narrower.
+  new_commits=("${local_sha}")
+  if [ ${#public_tips[@]} -gt 0 ]; then
+    new_commits+=("--not" "${public_tips[@]}")
   fi
+
+  # `--patch --cc` under an explicit `--format` emits each newly-public
+  # commit's message body and its patch with no commit header, so the
+  # author/committer emails below are judged only by the noreply guard and
+  # never by the scanner's generic email matcher. `--cc` keeps a merge's
+  # conflict resolutions — content in neither parent — in scope while
+  # leaving the already-public content the merge carried over out of it.
+  content=$(git log --format='%B' --patch --cc "${new_commits[@]}" 2>/dev/null || true)
 
   # Author / committer email is metadata `git diff` and `%B` never show,
   # yet it lands in public history forever. On a PUBLIC remote every
@@ -175,13 +195,8 @@ while read -r local_ref local_sha remote_ref remote_sha; do
   # (`([0-9]+\+)?<login>@users.noreply.github.com`); anything else — a
   # real/deliverable address such as a customer-domain email inherited
   # from local git config — is blocked (#730).
-  if [ -n "${base}" ]; then
-    author_range="${base}..${local_sha}"
-  else
-    author_range="${local_sha}"
-  fi
   noreply_re='^([0-9]+\+)?[A-Za-z0-9-]+@users\.noreply\.github\.com$'
-  bad_idents=$(git log --format='%ae%n%ce' "${author_range}" 2>/dev/null \
+  bad_idents=$(git log --format='%ae%n%ce' "${new_commits[@]}" 2>/dev/null \
     | grep -v -E "${noreply_re}" | sort -u || true)
   if [ -n "${bad_idents}" ]; then
     echo "✗ refuse: push to PUBLIC repo '${slug}' has a non-noreply commit identity on '${local_ref}'."
@@ -190,20 +205,20 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     printf '%s\n' "${bad_idents}" | sed 's/^/    /'
     echo "  Allowed shape: <id>+<login>@users.noreply.github.com (GitHub noreply)."
     echo "  Rewrite the range's author/committer to the repo's GitHub noreply identity, then re-push:"
-    echo "    git filter-branch --env-filter '...' -- ${author_range}"
+    echo "    git filter-branch --env-filter '...' -- ${new_commits[*]}"
     echo "  (public-repo privacy gate #730 — see /t3:rules § public-repo commit author identity)"
     blocked=1
   fi
 
   # Commit messages and trailers reach public history exactly like file
   # content does (a `Co-authored-by:` line carrying an internal/customer
-  # address is the canonical case). `git diff` excludes them, so scan the
-  # range's message bodies alongside the diff (#703).
-  [ -n "${diff}${msgs}" ] || continue
+  # address is the canonical case), so they are scanned alongside the
+  # patches rather than excluded the way `git diff` excludes them (#703).
+  [ -n "${content}" ] || continue
 
   report=$(mktemp "${TMPDIR:-/tmp}/t3-privacy-gate.XXXXXX")
   scan_rc=0
-  { printf '%s\n' "${diff}"; printf '%s\n' "${msgs}"; } | ${scan_cmd} - >"${report}" 2>&1 || scan_rc=$?
+  printf '%s\n' "${content}" | ${scan_cmd} - >"${report}" 2>&1 || scan_rc=$?
   if [ "${scan_rc}" -eq "${findings_code}" ]; then
     echo "✗ refuse: push to PUBLIC repo '${slug}' carries privacy findings on '${local_ref}'."
     echo "  Findings (line / category / redacted match):"

--- a/tests/test_refuse_public_push_with_leak.py
+++ b/tests/test_refuse_public_push_with_leak.py
@@ -22,6 +22,13 @@ import pytest
 
 HOOK = Path(__file__).resolve().parents[1] / "scripts" / "hooks" / "refuse-public-push-with-leak.sh"
 SCAN = Path(__file__).resolve().parents[1] / "scripts" / "privacy_scan.py"
+ZERO_SHA = "0" * 40
+# Planted fixture values the gate-under-test must flag; annotated so this
+# repo's own pre-push gate does not flag the test source itself.
+_PLANTED_SECRET = "token = glpat-XXXXXXXXXXXXXXXX\n"  # privacy-scan:allow fixture
+_PLANTED_HOME_PATH = "see /Users/someone/secret/path\n"  # privacy-scan:allow fixture
+_SQUASH_COMMITTER = "noreply@github.com"  # privacy-scan:allow fixture
+_REAL_EMAIL = "real.dev@internal.example"  # privacy-scan:allow fixture
 
 
 def _hermetic_env() -> dict[str, str]:
@@ -853,6 +860,137 @@ class TestLeakGateRecomputesBaseFromRemoteTrackingRef:
         result = _run_hook_synth(work, env, to_ref=head, from_ref=tip)
 
         assert result.returncode == 0, result.stdout + result.stderr
+
+
+class TestLeakGateScansOnlyNewlyPublicCommits:
+    """A merge-forward push must not re-judge ``main``'s own history (#3523).
+
+    When a feature branch merges ``origin/main`` into itself, the linear range
+    ``remote_sha..HEAD`` spans every commit the merge brought in — all of it
+    already public. The gate must scan the commits reachable from HEAD but NOT
+    from any already-public ref (``origin/main`` AND the branch's own remote
+    tip), so main's findings and main's committer identities are never
+    re-reported against the branch.
+    """
+
+    _FEATURE_STDIN = "refs/heads/feature {head} refs/heads/feature {tip}\n"
+
+    def _merge_forward(
+        self,
+        tmp_path: Path,
+        *,
+        main_content: str = _PLANTED_HOME_PATH,
+        main_committer: str = _SQUASH_COMMITTER,
+    ) -> tuple[Path, dict[str, str], str, str]:
+        """Feature branch pushed at F1, then merged with an advanced ``main``.
+
+        ``main`` carries both a content finding and a non-noreply (GitHub
+        squash-merge) committer identity — the two false-positive classes the
+        stale linear range produced on PR #3523.
+        """
+        origin = tmp_path / "origin"
+        _make_repo(origin)
+        _git(origin, "checkout", "-b", "feature")
+        feature_tip = _commit_file(origin, "feature.txt", "existing feature line\n", "seed feature branch")
+        _git(origin, "checkout", "main")
+        _commit_file(origin, "prior.txt", main_content, "prior PR merged on main")
+        _commit_file(
+            origin,
+            "squashed.txt",
+            "a line squash-merged via the GitHub web UI\n",
+            "prior PR squash-merged on main",
+            committer_email=main_committer,
+        )
+
+        work, env = _public_work_clone(tmp_path, origin)
+        _git(work, "checkout", "feature")
+        _git(work, "merge", "origin/main", "-m", "merge origin/main into feature")
+        return work, env, _rev(work, "HEAD"), feature_tip
+
+    def test_merge_forward_with_findings_only_on_main_is_allowed(self, tmp_path: Path) -> None:
+        work, env, head, tip = self._merge_forward(tmp_path)
+
+        result = _run_hook(work, env, self._FEATURE_STDIN.format(head=head, tip=tip))
+
+        assert result.returncode == 0, (
+            "already-public main content must not be re-scanned: " + result.stdout + result.stderr
+        )
+
+    def test_merge_forward_does_not_re_judge_main_commit_identities(self, tmp_path: Path) -> None:
+        work, env, head, tip = self._merge_forward(tmp_path, main_content="a clean prior line\n")
+
+        result = _run_hook(work, env, self._FEATURE_STDIN.format(head=head, tip=tip))
+
+        assert result.returncode == 0, (
+            "already-public main identities must not be re-judged: " + result.stdout + result.stderr
+        )
+        assert _SQUASH_COMMITTER not in result.stdout
+
+    def test_branch_finding_on_top_of_merge_forward_still_blocks(self, tmp_path: Path) -> None:
+        work, env, _head, tip = self._merge_forward(tmp_path)
+        head = _commit_file(work, "leak.txt", _PLANTED_SECRET, "add config")
+
+        result = _run_hook(work, env, self._FEATURE_STDIN.format(head=head, tip=tip))
+
+        assert result.returncode == 1, "a genuinely new leak must still block: " + result.stdout + result.stderr
+        assert "privacy" in (result.stdout + result.stderr).lower()
+
+    def test_branch_identity_on_top_of_merge_forward_still_blocks(self, tmp_path: Path) -> None:
+        work, env, _head, tip = self._merge_forward(tmp_path, main_content="a clean prior line\n")
+        head = _commit_file(
+            work,
+            "extra.txt",
+            "another clean feature line\n",
+            "extend feature",
+            committer_email=_REAL_EMAIL,
+        )
+
+        result = _run_hook(work, env, self._FEATURE_STDIN.format(head=head, tip=tip))
+
+        assert result.returncode == 1, "a new non-noreply identity must block: " + result.stdout + result.stderr
+        assert _REAL_EMAIL in result.stdout
+
+    def test_amended_history_is_still_scanned(self, tmp_path: Path) -> None:
+        """A force-push whose ``remote_sha`` is no longer an ancestor of HEAD.
+
+        Excluding the old remote tip must not exclude the rewritten commit —
+        it is unreachable from every public ref, so it is genuinely new.
+        """
+        origin = tmp_path / "origin"
+        _make_repo(origin)
+        _git(origin, "checkout", "-b", "feature")
+        tip = _commit_file(origin, "feature.txt", "existing feature line\n", "seed feature branch")
+        _git(origin, "checkout", "main")
+        work, env = _public_work_clone(tmp_path, origin)
+        _git(work, "checkout", "feature")
+        _git(work, "reset", "--hard", "HEAD~1")
+        head = _commit_file(work, "leak.txt", _PLANTED_SECRET, "rewritten feature")
+
+        result = _run_hook(work, env, self._FEATURE_STDIN.format(head=head, tip=tip))
+
+        assert result.returncode == 1, "amended history must still be scanned: " + result.stdout + result.stderr
+        assert "privacy" in (result.stdout + result.stderr).lower()
+
+    def test_undeterminable_public_set_fails_closed(self, tmp_path: Path) -> None:
+        """No resolvable ``origin/<default>`` → scan wider, never narrower.
+
+        With no public ref to subtract, the whole history reachable from the
+        pushed sha is scanned, so a finding that predates the branch still
+        blocks rather than riding out on an unknown base.
+        """
+        origin = tmp_path / "origin"
+        _make_repo(origin)
+        _commit_file(origin, "prior.txt", _PLANTED_HOME_PATH, "prior PR merged on main")
+        work, env = _public_work_clone(tmp_path, origin)
+        _git(work, "checkout", "-b", "feature")
+        head = _commit_file(work, "feature.txt", "a clean new feature line\n", "add feature")
+        _git(work, "update-ref", "-d", "refs/remotes/origin/HEAD")
+        _git(work, "update-ref", "-d", "refs/remotes/origin/main")
+
+        result = _run_hook(work, env, self._FEATURE_STDIN.format(head=head, tip=ZERO_SHA))
+
+        assert result.returncode == 1, "an undeterminable public set must fail closed: " + result.stdout + result.stderr
+        assert "home_path" in result.stdout, result.stdout
 
 
 def _make_erroring_gh_shim(bin_dir: Path) -> None:


### PR DESCRIPTION
## Needs owner sign-off — this changes a privacy/leak gate's range computation

Per `/t3:architecture-design` check 9, any change to the coverage of a privacy/leak matcher or gate is an owner decision, not a self-approve. **This PR does not touch what `t3 tool privacy-scan` considers a finding** — only *which commits* the pre-push gate feeds it. Please confirm the range rule below before merging.

## The false positive

`scripts/hooks/refuse-public-push-with-leak.sh` computed its scan range as a single linear `remote_sha..HEAD`. On a **merge-forward** push — a feature branch that merges `origin/main` into itself — that range spans every commit the merge brought in, all of it already public. The gate then reports findings and non-noreply commit identities that trace entirely to `main`'s own history.

Observed on the branch behind [#3523](https://github.com/souliane/teatree/pull/3523): the push was refused with **14 privacy findings** (`home_path`, `email`, private-IP categories) plus `non-noreply commit identity: noreply@github.com` — the latter being GitHub's own squash-merge committer on three of `main`'s commits. Every finding traced to `main`.

Scanning only the genuinely-new content was clean:

```
BASE=$(git merge-base HEAD origin/main)
{ git diff "$BASE" HEAD; git log --format='%B' "$BASE"..HEAD; } | t3 tool privacy-scan -
→ Privacy scan: clean (0 findings)
```

The hook's own `_remote_sha_is_trusted_base` already documents this false-positive class for #3414 (a stale base re-including already-public immutable commits). This is the same class on the code path that fallback does not cover.

## The fix

The scanned set is now the commits reachable from the pushed sha but from **no** already-public ref — `HEAD --not origin/<default> [remote_sha]` — rather than the linear `remote_sha..HEAD`. The identity check uses the same set, so a merge-forward never re-judges `main`'s committers.

Not weakened:

- A genuinely new commit is still scanned, including on a force-push or amended history where `remote_sha` is not an ancestor of `HEAD` (it is unreachable from every public ref, so it stays in the set).
- Where no public tip resolves — brand-new repo, unknown sha, shallow clone — the gate subtracts **nothing** and scans the whole reachable history. Fail closed: wider, never narrower. This is strictly wider than the previous `git show <sha>` fallback, which only ever scanned the tip commit's patch.
- The reported remote sha is still trusted as public only under the existing #3414 check; an untrusted synthesized value widens the scan rather than narrowing it.
- Patches are emitted under an explicit `--format`, so commit headers no longer feed the scanner's generic `email` matcher — author/committer identity is judged solely by the dedicated noreply guard, which is unchanged. `--cc` keeps a merge's conflict resolutions (content in neither parent) in scope.

## Tests

New `TestLeakGateScansOnlyNewlyPublicCommits` in `tests/test_refuse_public_push_with_leak.py`, integration-leaning throughout (real `git` under `tmp_path`, a real `gh` shim, the real scanner — nothing mocked):

| Test | Expectation |
|---|---|
| `test_merge_forward_with_findings_only_on_main_is_allowed` | allowed — the regression |
| `test_merge_forward_does_not_re_judge_main_commit_identities` | allowed |
| `test_branch_finding_on_top_of_merge_forward_still_blocks` | refused |
| `test_branch_identity_on_top_of_merge_forward_still_blocks` | refused |
| `test_amended_history_is_still_scanned` | refused |
| `test_undeterminable_public_set_fails_closed` | refused |

**Anti-vacuity checked explicitly.** Reverting the hook to its `origin/main` version and re-running the new class turns 3 of the 6 red — the two merge-forward regressions plus the fail-closed case (which pre-fix blocked only incidentally, on a commit header's own noreply address; it now asserts the `home_path` category so it cannot pass for the wrong reason). The 3 refusal cases stay green before and after, proving the change narrows the range without blinding the gate.

Suite: `36 passed` for the hook file, `29545 passed, 52 skipped, 5 xfailed` whole-tree. `ruff check` / `ruff format --check` clean on the touched files; `shellcheck` clean on the hook. This branch's own push cleared the real pre-push gate.

## Architecture pre-check

1. **BLUEPRINT § alignment** — no BLUEPRINT change; the public-repo identity/leak contract in `/t3:rules` § "Public-Repo Commit Author Identity" is unchanged (same matcher, same accepted shape).
2. **FSM phase boundaries** — n/a, no `Ticket.State` / `Worktree.State` transition.
3. **Extension-point contracts** — n/a. `src/teatree/core/fast_push.py` mirrors only the *identity* rule and already uses `origin/<default>..HEAD`, which is not affected by the merge-forward inflation; grepped and left unchanged.
4. **Component boundaries** — `scripts/hooks/`, the pre-push hook's own range computation. No new module.
5. **Dependency direction** — no imports added.
6. **Test surface** — the six rows above; each asserts the gate's exit code, and the refusal rows assert the specific reported category/identity.
7. **Resilience invariants** — n/a for external writes; the relevant invariant here is fail-closed on an undeterminable public set, pinned by `test_undeterminable_public_set_fails_closed`.
8. **Identity and key normalization** — refs are canonicalized up to a commit sha via `rev-parse --verify --quiet '<ref>^{commit}'` at one boundary; an unresolvable ref drops out of the exclusion set (widening), never silently matches.
9. **Behavior preservation / capability deletion** — the deliberate narrowing is the subject of this PR and needs the sign-off above. Enumerated: (a) already-public `main` commits are no longer re-scanned — the intended fix; (b) commit *headers* are no longer fed to the scanner — the emails there are judged by the noreply guard instead, so no identity coverage is lost; (c) a merge commit's carried-over content is out of scope, but its conflict resolutions stay in via `--cc`. Nothing else is dropped, and no must-block test was inverted — the pre-existing 30 tests pass unchanged.
10. **Removability / harness-vs-data** — self-contained in one hook; reverting the range block restores the prior behavior with no call-site cascade. The rule belongs in the harness (it is derived from git reachability, not per-repo policy), so nothing moves to config.
