### PR TITLE
fix(publish-gate): recognise glab -d short form as a body-bearing flag

### DIFF
--- a/src/teatree/hooks/_command_parser.py
+++ b/src/teatree/hooks/_command_parser.py
@@ -186,6 +186,12 @@ _BODY_FLAG_NAMES: Final[frozenset[str]] = frozenset(
 # Short body-bearing flags used by ``gh`` / ``glab`` / ``git commit``.
 _BODY_SHORT_FLAGS: Final[frozenset[str]] = frozenset({"-m", "-b"})
 
+# ``glab`` spells the MR/issue description short flag ``-d`` on ``create`` and
+# ``update``; ``gh`` uses ``-d`` for the boolean ``--draft``, so this short flag
+# is scoped to the ``glab`` leader only — extracting the next token as a body
+# for ``gh -d`` would misread its boolean draft switch.
+_GLAB_BODY_SHORT_FLAGS: Final[frozenset[str]] = frozenset({"-d"})
+
 # Long options for ``gh api`` / ``glab api`` field assignments.
 _API_FIELD_LONG_FLAGS: Final[frozenset[str]] = frozenset({"--field", "--raw-field"})
 _API_FIELD_SHORT_FLAGS: Final[frozenset[str]] = frozenset({"-f", "-F"})
@@ -215,7 +221,7 @@ def _walk_python_script(words: list[str], payloads: list[str]) -> None:
         i += 1
 
 
-def _walk_body_flags(words: list[str], raws: list[str], payloads: list[str], base: "Path | None") -> None:
+def _walk_body_flags(words: list[str], raws: list[str], payloads: list[str], base: "Path | None", leader: str) -> None:
     """Extract ``--body``/``--description``/``--message``/``--title``/``-m``/``-b`` payloads.
 
     Handles both space-separated (``--body "x"``) and equals-separated
@@ -229,7 +235,12 @@ def _walk_body_flags(words: list[str], raws: list[str], payloads: list[str], bas
     ``words``) so the resolver can tell a single-quoted INERT ``$(...)`` (the body
     is the literal text — scanned) from a live one — an embedded substitution in a
     body the gate can read is no longer mis-flagged as unresolvable.
+
+    ``leader`` selects the short-flag grammar: ``glab`` adds the ``-d``
+    description short flag it uses on ``mr``/``issue`` ``create``/``update``,
+    which ``gh`` uses for the boolean ``--draft`` and so is glab-only.
     """
+    short_flags = _BODY_SHORT_FLAGS | _GLAB_BODY_SHORT_FLAGS if leader == "glab" else _BODY_SHORT_FLAGS
     i = 0
     n = len(words)
     while i < n:
@@ -248,7 +259,7 @@ def _walk_body_flags(words: list[str], raws: list[str], payloads: list[str], bas
         if attached_handled:
             i += 1
             continue
-        if word in _BODY_SHORT_FLAGS and i + 1 < n:
+        if word in short_flags and i + 1 < n:
             payloads.append(resolve_inline_body_value(words[i + 1], base, raws[i + 1]))
             i += 2
             continue
@@ -362,8 +373,9 @@ def _walk_command_segment(segment: list[Token], payloads: list[str], ctx: "BodyF
         return
     first = canonical_forge_leader(all_words)
     # All segments get the generic body-flag walker since gh, glab, git,
-    # and t3 all accept ``--body``/``--message``/``-m``/``-b``.
-    _walk_body_flags(words, raws, payloads, ctx.base)
+    # and t3 all accept ``--body``/``--message``/``-m``/``-b``. The canonical
+    # leader selects glab's extra ``-d`` description short flag.
+    _walk_body_flags(words, raws, payloads, ctx.base, first)
     # ``t3 review`` posts carry the body as the positional NOTE (or the #32
     # ``--body-file``) and use ``--file`` as a diff ANCHOR, not a body-file —
     # extract the NOTE + ``--body-file`` body and SKIP the generic body-file

--- a/tests/teatree_hooks/test_publish_gate_golden_corpus.py
+++ b/tests/teatree_hooks/test_publish_gate_golden_corpus.py
@@ -508,6 +508,11 @@ _LEAK_SPELLINGS: list[tuple[str, str]] = [
     # unread (pre-fix, ``gh -F`` reached the api-field walker, the path matched
     # no ``field=value`` assignment, and the post was ALLOWED unscanned).
     ("gh short body-file unreadable", "gh pr create -R souliane/teatree --title x -F /nonexistent/body.md"),
+    # ``glab`` uses ``-d`` for the MR description on ``create`` and ``update``;
+    # pre-fix the parser recognised only the long ``--description``, so a body
+    # passed as ``-d`` extracted empty, scanned clean, and posted UNSCANNED.
+    ("glab short description -d create", 'glab mr create -R souliane/teatree -d "acmecorp"'),
+    ("glab short description -d update", 'glab mr update 7 -R souliane/teatree -d "acmecorp"'),
     ("interpreter sh -c forge", f'{_INTERNAL_LEAD}sh -c "{_PUBLIC_POST}"'),
     ("interpreter bash -c forge", f'{_INTERNAL_LEAD}bash -c "{_PUBLIC_POST}"'),
     ("interpreter eval forge", f'{_INTERNAL_LEAD}eval "{_PUBLIC_POST}"'),


### PR DESCRIPTION
## Summary

The pre-publish banned-terms/leak gate recognised `--description` as a body-bearing flag but not its short form `-d`. `glab` uses `-d` for the MR description on both `mr create` and `mr update`, so a body passed as `-d "text"` was extracted as the empty string, scanned clean, and posted **unscanned** — an under-scan leak, the same class as the earlier `gh -F`/`--body-file` short-form gap (souliane/teatree#3496).

## Fix

`src/teatree/hooks/_command_parser.py`: `_walk_body_flags` now takes the canonical forge leader and, for `glab`, adds `-d` to the recognised inline body short flags. Scoped to the `glab` leader only — `gh` uses `-d` for the boolean `--draft`, so treating its following token as a body would misread the draft switch (verified: `gh pr create -d "x"` extracts nothing; `glab mr create -d "x"` / `glab mr update -d "x"` extract the body).

## Tests (TDD)

Mirrored the existing `gh -F` short-form leak row in the golden must-DENY corpus (`tests/teatree_hooks/test_publish_gate_golden_corpus.py`): added `glab mr create -R souliane/teatree -d "acmecorp"` and the `mr update` form to `_LEAK_SPELLINGS`. Confirmed both go RED before the fix (`allow`) and GREEN after (`block`). Synthetic placeholder term (`acmecorp`) only. Full `tests/teatree_hooks/` suite: 2190 passed.

## Architecture pre-check

Tactical fix — a narrow flag-catalogue addition to an existing parser walker, no new module, no FSM boundary, no Protocol/extension-point change, no dependency edge. Behavior is purely additive (recognises one more short flag for one leader; nothing removed). `uv run ruff check` and `ty-check` clean.

Closes #3496