### PR TITLE
t3 ticket transition help omits plan/reconcile_reviewed/ignore/unignore (#3541)

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -9145,11 +9145,10 @@ Usage: t3 teatree ticket [OPTIONS] COMMAND [ARGS]...
 ```
 Usage: t3 teatree ticket transition [OPTIONS] TICKET_ID TRANSITION_NAME
 
- Transition a ticket to a new state.
-
- Accepts any of the allowed transition names: scope, start, code, test,
- review, ship, request_review, mark_merged, retrospect, mark_delivered,
- rework, mark_review_no_action.
+ Transition a ticket to a new state. Allowed transition names: scope, start,
+ plan, code, test, review, ship, request_review, mark_merged, retrospect,
+ mark_delivered, rework, mark_review_no_action, reconcile_reviewed, ignore,
+ unignore.
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    ticket_id            INTEGER  [required]                                │

--- a/docs/generated/management-commands.json
+++ b/docs/generated/management-commands.json
@@ -1060,7 +1060,7 @@
           "name": "plan"
         },
         {
-          "help": "Transition a ticket to a new state",
+          "help": "Transition a ticket to a new state. Allowed transition names: scope, start, plan, code, test, review, ship, request_review, mark_merged, retrospect, mark_delivered, rework, mark_review_no_action, reconcile_reviewed, ignore, unignore",
           "name": "transition"
         },
         {

--- a/docs/generated/management-commands.md
+++ b/docs/generated/management-commands.md
@@ -535,7 +535,7 @@ The ``ticket rubric-set`` / ``rubric-grade`` commands, mounted via MRO inheritan
 | `show` | Show a ticket's state plus the per-phase ``attempt N/max`` budget (#2009) |
 | `expedite` | Flag a ticket as expedite/release-blocker (``--off`` clears it) (PR-07) |
 | `plan` | Record a PlanArtifact and advance the ticket STARTED → PLANNED |
-| `transition` | Transition a ticket to a new state |
+| `transition` | Transition a ticket to a new state. Allowed transition names: scope, start, plan, code, test, review, ship, request_review, mark_merged, retrospect, mark_delivered, rework, mark_review_no_action, reconcile_reviewed, ignore, unignore |
 | `clear` | Issue a per-diff CLEAR — the orchestrator's only merge output (BLUEPRINT §17.4.2) |
 | `comment` | Post a comment to an issue or work item by its URL |
 | `sync-completions` | Check post-ship tickets against upstream issues and advance completed ones |

--- a/src/teatree/core/management/commands/_transition_names.py
+++ b/src/teatree/core/management/commands/_transition_names.py
@@ -1,11 +1,14 @@
-"""The CLI-allowed ticket transition names.
+"""The CLI-allowed ticket transition names — the single source of truth.
 
-Split out of ``ticket.py`` (the cap-bound command god-module) as a pure data
-constant the ``transition`` command validates against — the FSM owns the actual
+Split out of ``ticket.py`` (the cap-bound command god-module) as pure data the
+``transition`` command validates against AND derives its ``--help`` text from, so
+the allow-list and the documented list can never drift. The FSM owns the actual
 transitions; this is only the CLI's allow-list of names it will dispatch.
 """
 
-ALLOWED_TRANSITIONS = {
+# Ordered in FSM-ladder order so the derived help reads top-to-bottom; the
+# validated allow-list below is this same set.
+ALLOWED_TRANSITION_NAMES: tuple[str, ...] = (
     "scope",
     "start",
     "plan",
@@ -34,4 +37,10 @@ ALLOWED_TRANSITIONS = {
     # the CLI merely refused to dispatch.
     "ignore",
     "unignore",
-}
+)
+
+ALLOWED_TRANSITIONS = frozenset(ALLOWED_TRANSITION_NAMES)
+
+TRANSITION_HELP = (
+    "Transition a ticket to a new state. Allowed transition names: " + ", ".join(ALLOWED_TRANSITION_NAMES) + "."
+)

--- a/src/teatree/core/management/commands/ticket.py
+++ b/src/teatree/core/management/commands/ticket.py
@@ -17,7 +17,7 @@ from teatree.core.management.commands._plan_commands import PlanCommands
 from teatree.core.management.commands._rubric_commands import RubricCommands
 from teatree.core.management.commands._sweep_commands import SweepCommands
 from teatree.core.management.commands._ticket_show import TicketShowCommands
-from teatree.core.management.commands._transition_names import ALLOWED_TRANSITIONS
+from teatree.core.management.commands._transition_names import ALLOWED_TRANSITIONS, TRANSITION_HELP
 from teatree.core.management.commands._transition_refusals import review_context_refusal
 from teatree.core.merge import MergePreconditionError, resolve_pr_repo_slug
 from teatree.core.models import ClearIssuanceError, ClearRequest, MergeClear, ReviewVerdict, Ticket
@@ -84,14 +84,9 @@ class Command(
     SweepCommands,
     TyperCommand,
 ):
-    @command()
+    @command(help=TRANSITION_HELP)
     def transition(self, ticket_id: int, transition_name: str) -> dict[str, object]:
-        """Transition a ticket to a new state.
-
-        Accepts any of the allowed transition names: scope, start, code, test,
-        review, ship, request_review, mark_merged, retrospect, mark_delivered,
-        rework, mark_review_no_action.
-        """
+        """Transition a ticket to a new state; see ``--help`` for the allowed names."""
         if transition_name not in ALLOWED_TRANSITIONS:
             return {"error": f"Unknown transition: {transition_name}"}
 

--- a/tests/teatree_core/management/commands/test_transition_names.py
+++ b/tests/teatree_core/management/commands/test_transition_names.py
@@ -1,0 +1,30 @@
+"""The `ticket transition` help must list exactly ALLOWED_TRANSITIONS (drift lock)."""
+
+from teatree.core.management.commands._transition_names import ALLOWED_TRANSITIONS
+from teatree.core.management.commands.ticket import Command
+
+
+def _transition_command_help() -> str:
+    """The effective help typer surfaces for `ticket transition` (``help=`` else docstring)."""
+    stack = [Command().typer_app]
+    while stack:
+        current = stack.pop()
+        for info in current.registered_commands:
+            name = info.name or (info.callback.__name__ if info.callback else "")
+            if name == "transition":
+                doc = info.callback.__doc__ if info.callback else None
+                return info.help or doc or ""
+        stack.extend(group.typer_instance for group in current.registered_groups)
+    return ""
+
+
+def _documented_transition_names(help_text: str) -> set[str]:
+    """The comma-separated names listed after 'transition names:' in the help."""
+    _, _, listed = help_text.partition("transition names:")
+    return {name.strip() for name in listed.split(".", 1)[0].split(",") if name.strip()}
+
+
+def test_help_documents_exactly_allowed_transitions() -> None:
+    help_text = _transition_command_help()
+    assert "transition names:" in help_text  # command found and carries the derived help
+    assert _documented_transition_names(help_text) == set(ALLOWED_TRANSITIONS)


### PR DESCRIPTION
## Summary

`t3 <overlay> ticket transition --help` documented only 12 of the 16 names its allow-list (`_transition_names.ALLOWED_TRANSITIONS`) actually accepts. The four that had drifted out: `plan`, `reconcile_reviewed`, `ignore`, `unignore`.

## Fix — single source of truth (no re-drift)

`_transition_names.py` now defines an ordered `ALLOWED_TRANSITION_NAMES` tuple; the validated `ALLOWED_TRANSITIONS` frozenset and the `TRANSITION_HELP` string both derive from it. The `transition` command passes that string as typer's `help=`, which overrides the docstring — so the documented list and the enforced allow-list are the same data. Drift is impossible by construction rather than hand-synced.

## Test

`tests/teatree_core/management/commands/test_transition_names.py` extracts the transition names from the command's surfaced help and asserts they exactly equal `ALLOWED_TRANSITIONS`. Confirmed RED on the pre-fix code (missing the 4 names), GREEN after.

## Architecture pre-check — #3541

Tactical conformance fix (help text derives from an existing constant); the ten-check gate does not fire. No FSM/Protocol/dependency surface changed.

- Behavior preservation: the docstring transition list was replaced by the derived help, a strict superset (all 16 vs 12). No capability removed.
- Test surface: the new test locks the surfaced help to ALLOWED_TRANSITIONS; any future divergence fails CI.

## Verification

- pytest test_transition_names.py + test_management_commands.py — green
- ruff check / ty check on the changed files — clean
- Regenerated docs/generated/cli-reference.md and management-commands.md
