### PR TITLE
test(env): make assert-nothing command tests assert real outcomes (#3510)

### DIFF
--- a/tests/teatree_core/management_commands/test_lifecycle.py
+++ b/tests/teatree_core/management_commands/test_lifecycle.py
@@ -15,6 +15,7 @@ from django.utils.module_loading import import_string
 import teatree.core.gates.local_stack_gate as local_stack_gate_mod
 import teatree.core.management.commands.worktree as worktree_mod
 import teatree.core.overlay_loader as overlay_loader_mod
+import teatree.core.runners.worktree_provision as worktree_provision_mod
 import teatree.utils.db as db_mod
 import teatree.utils.run as utils_run_mod
 from teatree.core.models import Session, Ticket, Worktree
@@ -202,7 +203,7 @@ class TestLifecycleSetup(TestCase):
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
     def test_runs_post_db_steps(self) -> None:
-        """Setup runs post-DB steps from the overlay via the step runner."""
+        """Setup runs post-DB steps then the reset step, in that order."""
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
 
@@ -217,15 +218,29 @@ class TestLifecycleSetup(TestCase):
                 extra={"worktree_path": str(wt_dir)},
             )
 
-            # FullProvisioning.reset_passwords_command returns a step with callable=lambda: None.
-            # The step runner invokes callables directly (no subprocess).
-            # Verify setup completes without error — the step runner handles execution.
-            call_command("worktree", "provision", path=str(wt_dir))
+            ran: list[str] = []
+            overlay = import_string(FULL_OVERLAY)()
+            overlay.provisioning = type(overlay.provisioning)()
+            overlay.provisioning.post_db_steps = lambda wt: [
+                ProvisionStep(name="migrate", callable=lambda: ran.append("migrate")),
+            ]
+            overlay.provisioning.reset_passwords_command = lambda wt: ProvisionStep(
+                name="reset", callable=lambda: ran.append("reset")
+            )
+
+            with (
+                patch.object(overlay_loader_mod, "_discover_overlays", return_value={"test": overlay}),
+                patch.object(utils_run_mod, "subprocess"),
+            ):
+                call_command("worktree", "provision", path=str(wt_dir))
+
+            # The reset step is appended after post-DB steps by the runner.
+            assert ran == ["migrate", "reset"]
 
     @_patch_overlays(POST_DB_OVERLAY)
     @override_settings(**SETTINGS)
     def test_runs_post_db_steps_with_commands(self) -> None:
-        """Setup iterates post-DB steps and runs their callables via the step runner."""
+        """Setup iterates every post-DB step and invokes each callable in order."""
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
 
@@ -240,9 +255,21 @@ class TestLifecycleSetup(TestCase):
                 extra={"worktree_path": str(wt_dir)},
             )
 
-            # PostDbStepsOverlay returns named callable steps.
-            # The step runner invokes each callable and tracks results.
-            call_command("worktree", "provision", path=str(wt_dir))
+            ran: list[str] = []
+            overlay = import_string(POST_DB_OVERLAY)()
+            overlay.provisioning = type(overlay.provisioning)()
+            overlay.provisioning.post_db_steps = lambda wt: [
+                ProvisionStep(name="run-migrations", callable=lambda: ran.append("run-migrations")),
+                ProvisionStep(name="collectstatic", callable=lambda: ran.append("collectstatic")),
+            ]
+
+            with (
+                patch.object(overlay_loader_mod, "_discover_overlays", return_value={"test": overlay}),
+                patch.object(utils_run_mod, "subprocess"),
+            ):
+                call_command("worktree", "provision", path=str(wt_dir))
+
+            assert ran == ["run-migrations", "collectstatic"]
 
     @_patch_overlays(PRE_RUN_OVERLAY)
     @override_settings(**SETTINGS)
@@ -392,8 +419,8 @@ class TestLifecycleSetup(TestCase):
 
     @_patch_overlays(FULL_OVERLAY)
     @override_settings(**SETTINGS)
-    def test_skips_envfile_message_when_no_path(self) -> None:
-        """Setup skips 'Written:' message when write_env_cache returns None."""
+    def test_skips_wrote_cache_log_when_render_returns_none(self) -> None:
+        """The 'Wrote env cache' log is skipped when write_env_cache returns None."""
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
 
@@ -419,10 +446,15 @@ class TestLifecycleSetup(TestCase):
             with (
                 patch.object(worktree_mod, "get_overlay", return_value=mock_overlay),
                 patch.object(utils_run_mod, "subprocess") as mock_sp,
-                patch("teatree.core.runners.worktree_provision.write_env_cache", return_value=None),
+                patch.object(worktree_provision_mod, "write_env_cache", return_value=None) as mock_write,
+                patch.object(worktree_provision_mod, "logger") as mock_logger,
             ):
                 mock_sp.run.return_value = MagicMock(returncode=0)
                 call_command("worktree", "provision", path=str(wt_path))
+
+            mock_write.assert_called_once()
+            wrote_cache_logs = [c for c in mock_logger.info.call_args_list if "Wrote env cache" in str(c.args)]
+            assert wrote_cache_logs == []
 
     # NOTE: the former ``test_prints_diagnostic_summary`` was removed — the
     # ``Command._print_diagnostics`` helper is gone; the structured health

--- a/tests/teatree_core/test_env_command.py
+++ b/tests/teatree_core/test_env_command.py
@@ -1,6 +1,8 @@
 """Integration tests for ``t3 env`` management command."""
 
+import json
 from dataclasses import dataclass
+from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
@@ -33,6 +35,7 @@ class TestEnvShow(TestCase):
     def test_show_renders_env_from_db(self) -> None:
         ticket = _make_ticket()
         wt = _make_worktree(ticket)
+        out = StringIO()
         with (
             patch("teatree.core.management.commands.env.resolve_worktree", return_value=wt),
             patch(
@@ -40,25 +43,37 @@ class TestEnvShow(TestCase):
                 return_value=_FakeSpec("# header\n\nFOO=bar\nBAZ=qux"),
             ),
         ):
-            call_command("env", "show", "--path", "/tmp/wt/repo")
+            result = call_command("env", "show", "--path", "/tmp/wt/repo", stdout=out)
+        assert result == 0
+        rendered = out.getvalue()
+        # Comment/blank lines are dropped; each KEY=VALUE pair is printed verbatim.
+        assert "FOO=bar" in rendered
+        assert "BAZ=qux" in rendered
+        assert "# header" not in rendered
 
     def test_show_json_format(self) -> None:
         ticket = _make_ticket()
         wt = _make_worktree(ticket)
+        out = StringIO()
         with (
             patch("teatree.core.management.commands.env.resolve_worktree", return_value=wt),
             patch("teatree.core.management.commands.env.render_env_cache", return_value=_FakeSpec("FOO=bar")),
         ):
-            call_command("env", "show", "--path", "/tmp/wt/repo", "--format", "json")
+            result = call_command("env", "show", "--path", "/tmp/wt/repo", "--format", "json", stdout=out)
+        assert result == 0
+        assert json.loads(out.getvalue()) == {"FOO": "bar"}
 
     def test_show_returns_error_when_not_provisioned(self) -> None:
         ticket = _make_ticket()
         wt = _make_worktree(ticket)
+        err = StringIO()
         with (
             patch("teatree.core.management.commands.env.resolve_worktree", return_value=wt),
             patch("teatree.core.management.commands.env.render_env_cache", return_value=None),
         ):
-            call_command("env", "show", "--path", "/tmp/wt/repo")
+            result = call_command("env", "show", "--path", "/tmp/wt/repo", stderr=err)
+        assert result == 1
+        assert "not provisioned" in err.getvalue()
 
 
 class TestEnvSetVar(TestCase):
@@ -73,16 +88,22 @@ class TestEnvSetVar(TestCase):
             mock_set.assert_called_once_with(wt, "MY_KEY", "my_value")
 
     def test_set_var_rejects_missing_equals(self) -> None:
-        call_command("env", "set-var", "NOEQUALS", "--path", "/tmp/wt/repo")
+        err = StringIO()
+        result = call_command("env", "set-var", "NOEQUALS", "--path", "/tmp/wt/repo", stderr=err)
+        assert result == 2
+        assert "expected KEY=VALUE" in err.getvalue()
 
     def test_set_var_reports_value_error(self) -> None:
         ticket = _make_ticket()
         wt = _make_worktree(ticket)
+        err = StringIO()
         with (
             patch("teatree.core.management.commands.env.resolve_worktree", return_value=wt),
             patch("teatree.core.management.commands.env.set_override", side_effect=ValueError("core key")),
         ):
-            call_command("env", "set-var", "BAD=val", "--path", "/tmp/wt/repo")
+            result = call_command("env", "set-var", "BAD=val", "--path", "/tmp/wt/repo", stderr=err)
+        assert result == 1
+        assert "core key" in err.getvalue()
 
 
 class TestEnvUnset(TestCase):
@@ -100,28 +121,39 @@ class TestEnvUnset(TestCase):
     def test_unset_nonexistent_key(self) -> None:
         ticket = _make_ticket()
         wt = _make_worktree(ticket)
+        err = StringIO()
         with patch("teatree.core.management.commands.env.resolve_worktree", return_value=wt):
-            call_command("env", "unset", "NOPE", "--path", "/tmp/wt/repo")
+            result = call_command("env", "unset", "NOPE", "--path", "/tmp/wt/repo", stderr=err)
+        assert result == 1
+        assert "no override named NOPE" in err.getvalue()
 
 
 class TestEnvOverrides(TestCase):
     def test_lists_overrides(self) -> None:
         ticket = _make_ticket()
         wt = _make_worktree(ticket)
+        out = StringIO()
         with (
             patch("teatree.core.management.commands.env.resolve_worktree", return_value=wt),
             patch("teatree.core.management.commands.env.load_overrides", return_value={"A": "1", "B": "2"}),
         ):
-            call_command("env", "overrides", "--path", "/tmp/wt/repo")
+            result = call_command("env", "overrides", "--path", "/tmp/wt/repo", stdout=out)
+        assert result == 0
+        rendered = out.getvalue()
+        assert "A=1" in rendered
+        assert "B=2" in rendered
 
     def test_lists_empty_overrides(self) -> None:
         ticket = _make_ticket()
         wt = _make_worktree(ticket)
+        out = StringIO()
         with (
             patch("teatree.core.management.commands.env.resolve_worktree", return_value=wt),
             patch("teatree.core.management.commands.env.load_overrides", return_value={}),
         ):
-            call_command("env", "overrides", "--path", "/tmp/wt/repo")
+            result = call_command("env", "overrides", "--path", "/tmp/wt/repo", stdout=out)
+        assert result == 0
+        assert "(no overrides)" in out.getvalue()
 
 
 class TestEnvSystemCheckCollision(TestCase):
@@ -159,20 +191,26 @@ class TestEnvCheck(TestCase):
     def test_check_in_sync(self) -> None:
         ticket = _make_ticket()
         wt = _make_worktree(ticket)
+        out = StringIO()
         with (
             patch("teatree.core.management.commands.env.resolve_worktree", return_value=wt),
             patch("teatree.core.management.commands.env.detect_drift", return_value=(False, "/tmp/cache")),
         ):
-            call_command("env", "check", "--path", "/tmp/wt/repo")
+            result = call_command("env", "check", "--path", "/tmp/wt/repo", stdout=out)
+        assert result == 0
+        assert "env cache in sync with DB" in out.getvalue()
 
     def test_check_drifted(self) -> None:
         ticket = _make_ticket()
         wt = _make_worktree(ticket)
+        err = StringIO()
         with (
             patch("teatree.core.management.commands.env.resolve_worktree", return_value=wt),
             patch("teatree.core.management.commands.env.detect_drift", return_value=(True, "/tmp/cache")),
         ):
-            call_command("env", "check", "--path", "/tmp/wt/repo")
+            result = call_command("env", "check", "--path", "/tmp/wt/repo", stderr=err)
+        assert result == 1
+        assert "env cache stale at /tmp/cache" in err.getvalue()
 
 
 class TestEnvMigrateSecrets(TestCase):


### PR DESCRIPTION
## What

Fixes [#3510](https://github.com/souliane/teatree/issues/3510): assert-nothing tests that patch a collaborator, run `call_command`, then inspect neither stdout, the DB, nor the mock — so they pass regardless of behaviour.

`tests/teatree_core/test_env_command.py` was the headline: 16 tests, only 8 asserts. Ten tests asserted nothing. The clearest pair — `test_check_in_sync` / `test_check_drifted` — stubbed `detect_drift` to opposite values yet asserted byte-identically nothing, so drift detection was untested.

## Fix

- **`test_env_command.py` (10 tests):** each now asserts the observable outcome via captured `StringIO` — stdout content, return code, or stderr. `test_check_in_sync` asserts the in-sync stdout; `test_check_drifted` asserts the stale-cache stderr + `rc=1` (opposite observable outcomes). `show`/`overrides`/`set-var`/`unset` assert their rendered lines and exit codes.
- **`test_lifecycle.py` (3 tests):** three genuine assert-nothing tests fixed. The two post-db-step tests now assert every step callable ran in order (via the existing `_track_reset` tracking-callable pattern). The env-cache-log test asserts the `Wrote env cache` log is skipped when the render returns `None`; its stale `Written:` name/docstring is refreshed to match the current log line.

## Anti-vacuity

Every fixed test was proven able to FAIL: the production code was temporarily mutated (invert the drift branch, blank the rendered pairs/return codes, skip the post-db callables, always log the wrote-cache line) and each fixed test was confirmed RED, then the code restored.

## Left as-is (must-not-raise idiom)

The remaining `call_command` no-assert tests are the legitimate must-not-raise gate idiom — they assert a previously-crashing path no longer raises:

- `test_workspace.py` overlay-resolution + positional-id tests (`Pre-#941 this would raise SystemExit`, `survives a missing T3_OVERLAY_NAME`)
- `test_speak_dm.py::test_no_backend_is_clean_noop` (`# must not raise`)

These are among the excluded "must-not-raise" candidates the issue says to leave untouched.

## Architecture pre-check — #3510

Tactical test-only change (no `src/` behaviour touched) — the architecture gate does not fire. No FSM, extension-point, or dependency-direction impact.

## Test surface

`uv run pytest tests/teatree_core/test_env_command.py tests/teatree_core/management_commands/test_lifecycle.py` → 55 passed. `uv run ruff check` clean.
