### PR TITLE
fix(doctor,setup): provision and verify pyright-langserver for the enabled pyright-lsp plugin (#3568)

### DIFF
--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -171,9 +171,11 @@ Verify the registration: `t3 doctor check` (it reports the registered plugin and
 plugin (from the `anthropics/claude-plugins-official` marketplace) via the `claude
 plugin` CLI, so agents get LIVE pyright type diagnostics while coding instead of only
 catching type errors at CI. It is best-effort/offline-safe (an unreachable marketplace
-WARNs and continues) and needs `pyright-langserver` (npm `pyright`, baked into the
-deploy image) on PATH — `t3 doctor check` advisory-WARNs when the plugin is disabled or
-the langserver is missing. Both plugins are pinned in the managed
+WARNs and continues) and needs `pyright-langserver` on PATH — setup provisions it
+idempotently (`npm install -g --prefix ~/.local pyright`, skipped when already present).
+`t3 doctor check` advisory-WARNs when the plugin is disabled, but HARD-FAILs when the
+plugin is enabled and the langserver is missing (the enabled LSP would silently never
+start). Both plugins are pinned in the managed
 `deploy/claude-settings.template.json` `enabledPlugins`, so every seeded container
 enables them and the host drift check re-asserts them.
 

--- a/src/teatree/cli/doctor/app.py
+++ b/src/teatree/cli/doctor/app.py
@@ -189,14 +189,12 @@ def _optional_tooling_advisories() -> None:
     container and on a host that never opted in. The tmpfs-headroom check WARNs when
     a RAM-backed ``/tmp`` is filling toward ENOSPC (the fill that wedges the box);
     runtime temp is routed to disk and the watchdog trims stale scratch on a cadence.
-    The pyright-lsp advisory WARNs when the plugin that gives agents live pyright type
-    diagnostics is not enabled, or its ``pyright-langserver`` is missing from PATH.
-    (The critical worker gates — skills-present and memory-adequate — are HARD FAILs
-    in :func:`run_doctor_checks`, not advisories here.)
+    (The critical worker gates — skills-present, memory-adequate, and the enabled
+    pyright-lsp plugin's langserver being provisioned — are HARD FAILs in
+    :func:`run_doctor_checks`, not advisories here.)
     """
     _check_ttyd_for_dashboard()
     _check_chrome_devtools_mcp_suggestion()
-    _check_pyright_lsp_plugin()
     _check_docker_workflow_wired()
     _check_tmp_tmpfs_headroom()
 
@@ -215,6 +213,21 @@ def _run_worker_gates() -> bool:
     skills = _check_worker_skills_present()
     memory = _check_worker_memory_cap()
     return running and skills and memory
+
+
+def _check_enabled_but_unprovisioned() -> bool:
+    """The "enabled but not provisioned → FAIL" family (epic #3445).
+
+    A dependency the operator ENABLED but nothing installed reads as configured while
+    silently doing nothing: a ``review_skill`` naming an absent SKILL.md (#3352), or the
+    ``pyright-lsp`` plugin enabled without its ``pyright-langserver`` binary (#3568, the
+    LSP never starts). Both HARD-FAIL. Each runs independently (no short-circuit) so
+    every finding is emitted; returns their AND. The review-skill check reads the
+    ConfigSetting store, so the caller runs this after :func:`ensure_django`.
+    """
+    review_skills = _check_configured_review_skills()
+    pyright_lsp = _check_pyright_lsp_plugin()
+    return review_skills and pyright_lsp
 
 
 def run_doctor_checks(*, repair: bool = False, slack_roundtrip: bool = False) -> bool:
@@ -265,7 +278,11 @@ def run_doctor_checks(*, repair: bool = False, slack_roundtrip: bool = False) ->
     # must resolve to an installed SKILL.md. Runs after ensure_django() above — it
     # reads the effective ConfigSetting-store values, whose DB tier is live only
     # once Django is configured.
-    ok = _check_configured_review_skills() and ok
+    # #3352 + #3568: the "enabled but not provisioned → FAIL" gates (epic #3445) —
+    # a configured-but-absent review skill, or the pyright-lsp plugin enabled without
+    # its `pyright-langserver` binary (the LSP then silently never starts). Runs after
+    # ensure_django() above: the review-skill check reads the ConfigSetting store.
+    ok = _check_enabled_but_unprovisioned() and ok
     ok = _check_single_db() and ok
     ok = _check_stale_uv_venv() and ok
     ok = _check_stale_path_t3() and ok

--- a/src/teatree/cli/doctor/checks_resources.py
+++ b/src/teatree/cli/doctor/checks_resources.py
@@ -33,12 +33,15 @@ _MIN_MOUNT_FIELDS = 3
 _AGENT_ROLE = "worker"
 _CLAUDE_PLUGIN_ID = "t3@souliane"
 
-# The external pyright-lsp plugin + the language-server binary it drives. ADVISORY
-# only (a productivity aid, never a worker gate): `t3 setup` registers + enables the
-# plugin, and the npm `pyright` package (baked into the image) provides
-# `pyright-langserver`, which the plugin execs to deliver live type diagnostics.
+# The external pyright-lsp plugin + the language-server binary it drives. `t3 setup`
+# registers + enables the plugin AND provisions `pyright-langserver` (npm `pyright`),
+# which the plugin execs to deliver live type diagnostics. Enabled-but-unprovisioned
+# is a HARD FAIL (#3568): the plugin then silently never starts, so a green doctor
+# would misreport a dead LSP as healthy. A merely-disabled plugin is a config choice
+# and stays an advisory WARN.
 _PYRIGHT_PLUGIN_ID = "pyright-lsp@claude-plugins-official"
 _PYRIGHT_LANGSERVER = "pyright-langserver"
+_PYRIGHT_INSTALL_CMD = "npm install -g --prefix ~/.local pyright"
 _DEFAULT_WORKER_FLOOR_GIB = 4
 _BYTES_PER_GIB = 1024**3
 # cgroup v1's "unlimited" is a near-2**63 page-aligned sentinel, and cgroup v2 uses
@@ -247,17 +250,17 @@ def _check_worker_skills_present(*, role: str | None = None, home: Path | None =
 
 
 def _check_pyright_lsp_plugin(*, home: Path | None = None, which: Callable[[str], str | None] | None = None) -> bool:
-    """ADVISORY: verify the pyright-lsp plugin is enabled AND its langserver is on PATH.
+    """FAIL when the pyright-lsp plugin is enabled but its langserver is not provisioned (#3568).
 
-    pyright-lsp gives factory agents LIVE pyright type diagnostics while coding, so a
-    type error surfaces in-session instead of only at CI. It is a productivity aid,
-    NOT a worker gate — every finding is a WARN and this NEVER gates the doctor exit
-    code (always returns ``True``), matching the sibling advisory checks. ``t3 setup``
-    registers + enables the plugin; its language server (``pyright-langserver``, from
-    the npm ``pyright`` package baked into the image) must be on PATH for the plugin to
-    start. WARNs with an actionable remediation when either is missing. ``which`` is
-    injectable for tests (defaults to :func:`shutil.which`). Crash-proof — any read
-    error degrades to a silent pass so this diagnostic never aborts the doctor run.
+    pyright-lsp gives factory agents LIVE pyright type diagnostics while coding. The
+    enabled plugin execs ``pyright-langserver`` (npm ``pyright``); when that binary is
+    missing the LSP silently never starts, so the enabled-but-unprovisioned state is a
+    HARD FAIL (returns ``False``) under the epic #3445 "enabled but not provisioned →
+    FAIL" principle — otherwise a green doctor misreports a dead LSP as healthy. The
+    plugin merely being disabled is a config choice, so that stays an advisory WARN
+    (returns ``True``). ``which`` is injectable for tests (defaults to
+    :func:`shutil.which`). Crash-proof — any read error degrades to a silent pass so
+    this diagnostic never aborts the doctor run.
     """
     resolve = shutil.which if which is None else which
     try:
@@ -273,8 +276,9 @@ def _check_pyright_lsp_plugin(*, home: Path | None = None, which: Callable[[str]
         return True
     if resolve(_PYRIGHT_LANGSERVER) is None:
         typer.echo(
-            f"WARN  pyright-lsp plugin is enabled but `{_PYRIGHT_LANGSERVER}` is not on PATH — the "
-            "language server cannot start, so there are no live type diagnostics. Install it with "
-            "`npm install -g pyright` (advisory only; nothing is gated)."
+            f"FAIL  pyright-lsp plugin is enabled but `{_PYRIGHT_LANGSERVER}` is not on PATH — the "
+            "language server cannot start, so the enabled LSP silently delivers no live type "
+            f"diagnostics. Install it: `{_PYRIGHT_INSTALL_CMD}` (or re-run `t3 setup`)."
         )
+        return False
     return True

--- a/src/teatree/cli/setup/command.py
+++ b/src/teatree/cli/setup/command.py
@@ -174,6 +174,10 @@ def run(
         # unreachable marketplace WARNs and continues; its `pyright-langserver` runtime
         # dep is baked into the image and advisory-checked by `t3 doctor`.
         PyrightPluginRegistrar().install()
+        # #3568: register+enable is not enough — the plugin execs `pyright-langserver`,
+        # so provision that binary (npm `pyright` into ~/.local) when it is missing.
+        # Idempotent (skips when already on PATH) and offline-safe (WARNs, continues).
+        PyrightPluginRegistrar.ensure_langserver()
         # Confirm the structured-search MCP server (`t3 mcp serve`, #1023) is
         # still wired via the plugin-bundled `.mcp.json` (#2863) — read-only,
         # idempotent, warns loudly rather than silently regressing agents back

--- a/src/teatree/cli/setup/plugin_registrar.py
+++ b/src/teatree/cli/setup/plugin_registrar.py
@@ -17,11 +17,16 @@ _PYRIGHT_MARKETPLACE = "claude-plugins-official"
 _PYRIGHT_MARKETPLACE_SOURCE = "anthropics/claude-plugins-official"
 _PYRIGHT_PLUGIN_NAME = "pyright-lsp"
 _PYRIGHT_PLUGIN_ID = f"{_PYRIGHT_PLUGIN_NAME}@{_PYRIGHT_MARKETPLACE}"
+# The binary the enabled plugin execs; provisioned from the npm ``pyright`` package
+# into ``~/.local`` (a user-writable prefix on PATH) so no root/global write is needed.
+_PYRIGHT_LANGSERVER = "pyright-langserver"
 
 # Bound for a ``claude plugin`` CLI call — it clones + validates the remote
 # marketplace / plugin, so an unreachable network must time out and continue
 # rather than hang setup.
 _CLAUDE_CLI_TIMEOUT_S = 120
+# ``npm install`` fetches + builds the package; a longer bound than the CLI calls.
+_NPM_INSTALL_TIMEOUT_S = 300
 
 
 def _read_json(path: Path) -> dict:
@@ -54,6 +59,12 @@ def _set_enabled_plugin(plugin_id: str) -> bool:
     plugins[plugin_id] = True
     _write_json(resolved, data)
     return True
+
+
+def _plugin_enabled(plugin_id: str) -> bool:
+    """True when ``plugin_id`` is enabled in the managed settings.json."""
+    enabled = _read_json(_settings_path()).get("enabledPlugins", {})
+    return isinstance(enabled, dict) and enabled.get(plugin_id) is True
 
 
 def _plugin_installed(plugin_id: str) -> bool:
@@ -191,8 +202,9 @@ class PyrightPluginRegistrar:
 
     The plugin gives factory agents LIVE pyright type diagnostics while coding, so a
     type error surfaces in-session instead of only at CI. Its language server
-    (``pyright-langserver``, from the npm ``pyright`` package) must be on PATH for the
-    plugin to start — ``t3 doctor`` advisory-WARNs when it is not.
+    (``pyright-langserver``, npm ``pyright``) must be on PATH for the plugin to start;
+    :meth:`ensure_langserver` provisions it, and ``t3 doctor`` HARD-FAILs when the
+    plugin is enabled but the binary is missing (#3568).
     """
 
     def install(self) -> bool:
@@ -216,6 +228,49 @@ class PyrightPluginRegistrar:
             return False
         _set_enabled_plugin(_PYRIGHT_PLUGIN_ID)
         typer.echo(f"OK    Plugin {_PYRIGHT_PLUGIN_ID} registered + enabled for live pyright diagnostics.")
+        return True
+
+    @staticmethod
+    def ensure_langserver() -> bool:
+        """Provision ``pyright-langserver`` when the enabled plugin's binary is missing (#3568).
+
+        The enabled plugin execs ``pyright-langserver``; without it on PATH the LSP
+        silently never starts and agents get no live type diagnostics. Installs it
+        idempotently from the npm ``pyright`` package into ``~/.local`` (a user-writable
+        prefix on PATH). A no-op when the plugin is not enabled or the binary is already
+        present. Offline-safe: a missing ``npm`` or a failed/timed-out install WARNs and
+        continues, matching the other best-effort setup steps. Returns True only when
+        the binary is present (already, or after a successful install).
+        """
+        if not _plugin_enabled(_PYRIGHT_PLUGIN_ID):
+            return False
+        if shutil.which(_PYRIGHT_LANGSERVER) is not None:
+            typer.echo(f"OK    {_PYRIGHT_LANGSERVER} already on PATH — skipped npm install.")
+            return True
+        npm = shutil.which("npm")
+        if npm is None:
+            typer.echo(
+                f"WARN  `npm` not on PATH — cannot install {_PYRIGHT_LANGSERVER}; the enabled "
+                "pyright-lsp LSP will not start. Setup continues."
+            )
+            return False
+        prefix = str(Path.home() / ".local")
+        try:
+            result = run_allowed_to_fail(
+                [npm, "install", "-g", "--prefix", prefix, "pyright"],
+                expected_codes=None,
+                timeout=_NPM_INSTALL_TIMEOUT_S,
+            )
+        except (OSError, TimeoutExpired):
+            typer.echo(f"WARN  `npm install` for pyright did not run — {_PYRIGHT_LANGSERVER} missing; setup continues.")
+            return False
+        if result.returncode != 0:
+            typer.echo(
+                f"WARN  `npm install -g --prefix {prefix} pyright` failed (offline?) — "
+                f"{_PYRIGHT_LANGSERVER} missing; setup continues."
+            )
+            return False
+        typer.echo(f"OK    Installed pyright ({_PYRIGHT_LANGSERVER}) via npm for the pyright-lsp LSP.")
         return True
 
     @staticmethod

--- a/tests/teatree_cli/doctor/test_pyright_lsp_check.py
+++ b/tests/teatree_cli/doctor/test_pyright_lsp_check.py
@@ -1,10 +1,10 @@
-"""Tests for ``_check_pyright_lsp_plugin`` — advisory live-type-diagnostics aid.
+"""Tests for ``_check_pyright_lsp_plugin`` — enabled-but-unprovisioned LSP gate (#3568).
 
-pyright-lsp gives factory agents LIVE pyright type diagnostics while coding, so a
-type error surfaces in-session instead of only at CI. It is a productivity aid, not
-a worker gate: the check WARNs when the plugin is not enabled, or when its
-``pyright-langserver`` is missing from PATH, but NEVER gates the doctor exit code
-(always returns ``True``) and never FAILs.
+pyright-lsp gives factory agents LIVE pyright type diagnostics while coding. Under
+the epic #3445 "enabled but not provisioned → FAIL" principle the check hard-FAILs
+when the plugin is ENABLED but its ``pyright-langserver`` binary is not on PATH — the
+LSP would silently never start. The plugin merely being disabled is a config choice,
+so that case stays an advisory WARN.
 """
 
 import io
@@ -48,17 +48,22 @@ class TestCheckPyrightLspPlugin:
         assert "t3 setup" in message
         assert "FAIL" not in message
 
-    def test_warns_when_langserver_missing_from_path(self, tmp_path: Path) -> None:
+    def test_fails_when_enabled_but_langserver_missing(self, tmp_path: Path) -> None:
         _write_settings(tmp_path, {_PLUGIN_ID: True})
         ok, message = _run(tmp_path, langserver_on_path=False)
-        assert ok is True  # advisory only — never gates
-        assert "WARN" in message
+        assert ok is False  # enabled-but-unprovisioned is a hard FAIL (#3568)
+        assert "FAIL" in message
         assert "pyright-langserver" in message
-        assert "npm install -g pyright" in message
-        assert "FAIL" not in message
+        assert "npm install -g --prefix ~/.local pyright" in message
 
     def test_never_gates_when_settings_absent(self, tmp_path: Path) -> None:
         # No ~/.claude/settings.json at all → treated as "not enabled", WARN only.
         ok, message = _run(tmp_path, langserver_on_path=True)
+        assert ok is True
+        assert "FAIL" not in message
+
+    def test_never_gates_when_settings_absent_even_without_langserver(self, tmp_path: Path) -> None:
+        # Plugin disabled AND no binary → the disabled config choice never FAILs.
+        ok, message = _run(tmp_path, langserver_on_path=False)
         assert ok is True
         assert "FAIL" not in message

--- a/tests/teatree_cli/setup/test_pyright_plugin_registrar.py
+++ b/tests/teatree_cli/setup/test_pyright_plugin_registrar.py
@@ -107,3 +107,69 @@ class TestPyrightPluginRegistrarInstall:
 
         monkeypatch.setattr("subprocess.run", _timeout)
         assert PyrightPluginRegistrar._run_claude("/usr/bin/claude", "plugin", "list") is False
+
+
+def _enable_plugin(home: Path) -> None:
+    settings = home / ".claude"
+    settings.mkdir(parents=True, exist_ok=True)
+    (settings / "settings.json").write_text(json.dumps({"enabledPlugins": {_PLUGIN_ID: True}}), encoding="utf-8")
+
+
+class TestPyrightLangserverProvision:
+    """``ensure_langserver`` installs the npm ``pyright`` binary the enabled plugin execs (#3568)."""
+
+    def test_noop_when_langserver_already_present(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+        _enable_plugin(tmp_path)
+        monkeypatch.setattr("shutil.which", lambda name: f"/usr/bin/{name}")  # everything present
+
+        def _boom(*_args: object, **_kwargs: object) -> object:
+            msg = "npm must not run when pyright-langserver is already on PATH"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr("subprocess.run", _boom)
+        assert PyrightPluginRegistrar().ensure_langserver() is True
+
+    def test_installs_via_npm_when_missing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+        _enable_plugin(tmp_path)
+
+        def _which(name: str) -> str | None:
+            return "/usr/bin/npm" if name == "npm" else None  # langserver missing, npm present
+
+        monkeypatch.setattr("shutil.which", _which)
+
+        calls: list[list[str]] = []
+
+        class _Result:
+            returncode = 0
+
+        def _run(cmd: list[str], **_kwargs: object) -> _Result:
+            calls.append(cmd)
+            return _Result()
+
+        monkeypatch.setattr("subprocess.run", _run)
+
+        assert PyrightPluginRegistrar().ensure_langserver() is True
+        assert calls == [["/usr/bin/npm", "install", "-g", "--prefix", str(tmp_path / ".local"), "pyright"]]
+
+    def test_skips_when_plugin_not_enabled(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+        # No settings.json → plugin not enabled → nothing to provision.
+
+        def _boom(*_args: object, **_kwargs: object) -> object:
+            msg = "no npm/which lookup when the plugin is not enabled"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr("subprocess.run", _boom)
+        assert PyrightPluginRegistrar().ensure_langserver() is False
+
+    def test_warns_and_continues_when_npm_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+        _enable_plugin(tmp_path)
+        monkeypatch.setattr("shutil.which", lambda _name: None)  # neither langserver nor npm
+
+        assert PyrightPluginRegistrar().ensure_langserver() is False
+        assert "WARN" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

The `pyright-lsp@claude-plugins-official` plugin is enabled in the managed `~/.claude/settings.json`, but nothing installed the `pyright-langserver` binary the plugin execs — so the LSP silently never started, agents got no live type diagnostics, and the only signal was a soft SessionStart WARN. Fixes #3568.

Two parts, mirroring epic #3445's "enabled but not provisioned → FAIL" principle:

- **`t3 doctor`**: `_check_pyright_lsp_plugin` now **hard-FAILs** (gates the exit code) when the plugin is ENABLED but `pyright-langserver` is not on PATH, with the exact remediation `npm install -g --prefix ~/.local pyright`. A merely-disabled plugin stays an advisory WARN. The check moved out of the surfacing-only advisories into `run_doctor_checks`, grouped with the configured-review-skill gate into `_check_enabled_but_unprovisioned` (the shared enabled-but-unprovisioned family).
- **`t3 setup`**: `PyrightPluginRegistrar.ensure_langserver` provisions the binary idempotently (`npm install -g --prefix ~/.local pyright`), skips when already on PATH, and is offline-safe (WARNs and continues). Wired in after the plugin registration.

## Architecture pre-check — #3568

### 1. BLUEPRINT § alignment
No BLUEPRINT change — this extends existing `t3 doctor` / `t3 setup` provisioning surfaces. `skills/setup/SKILL.md` updated to describe the new FAIL + provisioning step (documentation alignment).

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition.

### 3. Extension-point contracts
n/a — no `OverlayBase` / scanner / hook / Protocol surface touched. `_check_pyright_lsp_plugin` and `PyrightPluginRegistrar` are internal CLI helpers.

### 4. Component boundaries
`src/teatree/cli/doctor/` (the check) and `src/teatree/cli/setup/` (the provisioning) — the modules that already own these two surfaces. No straddle.

### 5. Dependency direction
No new cross-module imports; setup already depends on `teatree.utils.run`. `tach` gate passed in the pre-commit run.

### 6. Test surface
- `tests/teatree_cli/doctor/test_pyright_lsp_check.py`: enabled + binary-missing → FAIL (returns `False`, message carries the exact install command); disabled → WARN/pass; disabled-without-binary → pass; enabled + present → silent pass. Observed RED (`assert True is False`) before the fix.
- `tests/teatree_cli/setup/test_pyright_plugin_registrar.py`: `ensure_langserver` no-op when present, runs the exact `npm install -g --prefix ~/.local pyright` when missing, skips when the plugin is disabled, WARNs when npm is absent. Observed RED (`AttributeError`) before the method existed.

### 7. Resilience invariants
The npm install is **idempotent** (skipped when `pyright-langserver` is already on PATH). External write (npm subprocess) is offline-safe: a missing `npm` or a failed/timed-out install WARNs and continues, never aborting setup — matching the sibling best-effort steps. No re-read needed (the doctor check is the verify surface).

### 8. Identity and key normalization
n/a — no bare-vs-qualified identity handling. The plugin id is a single canonical constant.

### 9. Behavior preservation / capability deletion
The previous WARN-only advisory for the enabled-but-missing case is **intentionally strengthened to FAIL** (the whole point of #3568); the disabled-plugin WARN is preserved. No safety/privacy matcher narrowed; no must-block test inverted.

### 10. Removability / harness-vs-data
Removable: both additions are self-contained (`_check_enabled_but_unprovisioned` groups two existing gates; `ensure_langserver` is one static method + one call site). The plugin id / binary name live as module constants (config-shaped), the mechanism stays generic.

## Test evidence

```
uv run pytest tests/teatree_cli/doctor/ tests/teatree_cli/setup/ -q  →  296 passed
uv run ruff check <changed files>  →  All checks passed!
```
