### PR TITLE
fix(privacy-gate): scan the DB banned-terms list on the public forge-write seam

### DIFF
--- a/src/teatree/core/gates/privacy_gate.py
+++ b/src/teatree/core/gates/privacy_gate.py
@@ -216,6 +216,41 @@ def _overlay_privacy_rules() -> tuple[list[str], list[str]] | None:
         return None
 
 
+def _db_banned_terms() -> tuple[str, ...] | None:
+    """The DB-home ``banned_terms`` list to union into a PUBLIC-target scan, or ``None`` to fail CLOSED.
+
+    The customer codenames live in the DB-home ``banned_terms`` list (the source
+    the shell/CI gates scan), NOT in the overlay ``privacy_redact_terms`` (empty
+    by default). So the egress chokepoint scans a public body against the SAME
+    fail-closed source via :func:`teatree.hooks.banned_terms_cli.resolve_banned_terms`.
+    Posture mirrors that gate exactly:
+
+    * a resolved list (including the deliberate empty ``[]``) → those terms;
+    * a genuinely UNSET list (:class:`BannedTermsUnsetError`) → fail CLOSED
+        (``None``) only when ``banned_terms_required``, else the dev/solo no-op (``()``);
+    * any OTHER read failure → fail CLOSED (``None``): an unreadable ban source
+        must never silently degrade to "no terms" on a public target.
+    """
+    from teatree.hooks.banned_terms_cli import (  # noqa: PLC0415 — deferred hooks edge
+        banned_terms_required,
+        resolve_banned_terms,
+    )
+    from teatree.hooks.banned_terms_tree_scan import BannedTermsUnsetError  # noqa: PLC0415 — deferred hooks edge
+
+    try:
+        return resolve_banned_terms()
+    except BannedTermsUnsetError:
+        return None if banned_terms_required() else ()
+    except Exception as exc:  # noqa: BLE001 — an unreadable ban source fails CLOSED, never scan-less.
+        warn_throttled(
+            logger,
+            "privacy_gate:banned-terms-unreadable",
+            "publication privacy gate: banned-terms list unreadable (%s) — failing CLOSED",
+            exc,
+        )
+        return None
+
+
 def scan_outbound_text(*, text: str, target_repo: str, forge: str = "") -> PrivacyGateResult:
     """Scan outbound *text* bound for *target_repo* against the publication rules.
 
@@ -226,12 +261,19 @@ def scan_outbound_text(*, text: str, target_repo: str, forge: str = "") -> Priva
     CLOSED (scanned). *forge* (``"github"``/``"gitlab"``) routes a bare-slug
     visibility probe to the right tool.
 
-    When the target is public but the overlay's privacy rules cannot be resolved
-    (:func:`_overlay_privacy_rules` returns ``None`` — an overlay is present but
-    its redact/block rules could not be read), the gate REFUSES the publish with a
-    synthetic ``overlay-rules-unresolvable`` match: a confidentiality boundary must
-    fail CLOSED and loud, never scan a public target with only the two generic
-    built-ins while the overlay's own rules silently vanish.
+    On a PUBLIC target the scan vocabulary is the overlay's ``privacy_redact_terms``
+    UNIONED with the DB-home ``banned_terms`` list (:func:`_db_banned_terms`) — the
+    latter is where the customer codenames actually live, so scanning only the
+    overlay terms let a banned codename leak to a public forge. Both feed the same
+    whole-token :mod:`teatree.hooks.term_match` matcher via :func:`scan_for_publication`.
+
+    Two fail-CLOSED refusals guard a public target: when the overlay's privacy
+    rules cannot be resolved (:func:`_overlay_privacy_rules` returns ``None``) the
+    gate REFUSES with a synthetic ``overlay-rules-unresolvable`` match, and when the
+    banned-terms source is unreadable (:func:`_db_banned_terms` returns ``None``) it
+    REFUSES with a ``banned-terms-unresolvable`` match — a confidentiality boundary
+    must fail CLOSED and loud, never scan a public target while a configured term
+    source silently vanishes.
     """
     if not _target_is_public(target_repo, forge):
         return PrivacyGateResult(target_repo=target_repo, is_public=False)
@@ -249,11 +291,25 @@ def scan_outbound_text(*, text: str, target_repo: str, forge: str = "") -> Priva
             is_public=True,
             matches=(PrivacyMatch(pattern_name="overlay-rules-unresolvable", matched_text="", position=0),),
         )
+    banned = _db_banned_terms()
+    if banned is None:
+        warn_throttled(
+            logger,
+            f"privacy_gate:refuse-banned-unresolvable:{target_repo}",
+            "publication privacy gate: REFUSING public publish to %s — banned-terms list unresolvable "
+            "(failing CLOSED so a configured banned term cannot silently leak)",
+            target_repo,
+        )
+        return PrivacyGateResult(
+            target_repo=target_repo,
+            is_public=True,
+            matches=(PrivacyMatch(pattern_name="banned-terms-unresolvable", matched_text="", position=0),),
+        )
     redact_terms, block_patterns = rules
     return scan_for_publication(
         text=text,
         target_repo=target_repo,
         public_repos=[target_repo],
-        redact_terms=redact_terms,
+        redact_terms=list(dict.fromkeys([*redact_terms, *banned])),
         block_patterns=block_patterns,
     )

--- a/tests/teatree_core/test_send_proxy_forge_write.py
+++ b/tests/teatree_core/test_send_proxy_forge_write.py
@@ -25,6 +25,9 @@ from teatree.core.send_proxy import (
     forge_from_url,
     route_forge_write,
 )
+from teatree.hooks.banned_terms_tree_scan import BannedTermsUnsetError
+
+_BANNED_SOURCE_READ_FAILURE = "banned-terms DB read wedged"
 
 # These tests need pytest's monkeypatch + patch of privacy_gate internals, which
 # django.test.TestCase cannot provide — so pytest.mark.django_db is the right tool.
@@ -84,6 +87,118 @@ class TestRouteForgeWriteLeakGate:
     def test_leak_error_is_an_outbound_blocked_error(self) -> None:
         assert issubclass(OutboundLeakError, OutboundBlockedError)
         assert issubclass(SendBlockedError, OutboundBlockedError)
+
+
+class TestRouteForgeWriteBannedTermsLeakGate:
+    """The DB ``banned_terms`` list is scanned on the PUBLIC forge-write seam (security fix).
+
+    Reproduces the production config that leaked: the overlay's
+    ``privacy_redact_terms`` is EMPTY, but the customer codename lives in the
+    DB-home ``banned_terms`` list. The forge-write seam must union that list into
+    the public-target scan — the synthetic term ``acme`` stands in for the real
+    codename that leaked.
+    """
+
+    def test_db_banned_term_blocks_public_forge_write_with_empty_redact_terms(self) -> None:
+        with (
+            patch("teatree.core.gates.privacy_gate._target_is_public", return_value=True),
+            patch("teatree.core.gates.privacy_gate._overlay_privacy_rules", return_value=([], [])),
+            patch("teatree.hooks.banned_terms_cli.resolve_banned_terms", return_value=("acme",)),
+            pytest.raises(OutboundLeakError, match="privacy gate refused"),
+        ):
+            route_forge_write(
+                forge="github",
+                repo="souliane/teatree",
+                text="rolling out the acme-fork migration",
+                action="github_issue_create",
+                target="souliane/teatree",
+            )
+        assert SendAudit.objects.count() == 0
+
+    def test_clean_body_passes_when_banned_terms_set(self) -> None:
+        with (
+            patch("teatree.core.gates.privacy_gate._target_is_public", return_value=True),
+            patch("teatree.core.gates.privacy_gate._overlay_privacy_rules", return_value=([], [])),
+            patch("teatree.hooks.banned_terms_cli.resolve_banned_terms", return_value=("acme",)),
+        ):
+            out = route_forge_write(
+                forge="github",
+                repo="souliane/teatree",
+                text="rolling out a routine migration",
+                action="github_issue_create",
+                target="souliane/teatree",
+            )
+        assert out == "rolling out a routine migration"
+
+    def test_private_target_not_blocked_by_banned_term(self) -> None:
+        with (
+            patch("teatree.core.gates.privacy_gate._target_is_public", return_value=False),
+            patch("teatree.hooks.banned_terms_cli.resolve_banned_terms", return_value=("acme",)),
+        ):
+            out = route_forge_write(
+                forge="github",
+                repo="acme/private",
+                text="rolling out the acme-fork migration",
+                action="github_issue_create",
+                target="acme/private",
+            )
+        assert out == "rolling out the acme-fork migration"
+
+    def test_unreadable_banned_source_fails_closed_on_public_target(self) -> None:
+        def _boom() -> tuple[str, ...]:
+            raise RuntimeError(_BANNED_SOURCE_READ_FAILURE)
+
+        with (
+            patch("teatree.core.gates.privacy_gate._target_is_public", return_value=True),
+            patch("teatree.core.gates.privacy_gate._overlay_privacy_rules", return_value=([], [])),
+            patch("teatree.hooks.banned_terms_cli.resolve_banned_terms", side_effect=_boom),
+            pytest.raises(OutboundLeakError, match="banned-terms-unresolvable"),
+        ):
+            route_forge_write(
+                forge="github",
+                repo="souliane/teatree",
+                text="a perfectly ordinary note",
+                action="github_issue_create",
+                target="souliane/teatree",
+            )
+
+    def test_unset_not_required_is_a_dev_noop(self) -> None:
+        with (
+            patch("teatree.core.gates.privacy_gate._target_is_public", return_value=True),
+            patch("teatree.core.gates.privacy_gate._overlay_privacy_rules", return_value=([], [])),
+            patch(
+                "teatree.hooks.banned_terms_cli.resolve_banned_terms",
+                side_effect=BannedTermsUnsetError.for_key("banned_terms"),
+            ),
+            patch("teatree.hooks.banned_terms_cli.banned_terms_required", return_value=False),
+        ):
+            out = route_forge_write(
+                forge="github",
+                repo="souliane/teatree",
+                text="a perfectly ordinary note",
+                action="github_issue_create",
+                target="souliane/teatree",
+            )
+        assert out == "a perfectly ordinary note"
+
+    def test_unset_required_fails_closed_on_public_target(self) -> None:
+        with (
+            patch("teatree.core.gates.privacy_gate._target_is_public", return_value=True),
+            patch("teatree.core.gates.privacy_gate._overlay_privacy_rules", return_value=([], [])),
+            patch(
+                "teatree.hooks.banned_terms_cli.resolve_banned_terms",
+                side_effect=BannedTermsUnsetError.for_key("banned_terms"),
+            ),
+            patch("teatree.hooks.banned_terms_cli.banned_terms_required", return_value=True),
+            pytest.raises(OutboundLeakError, match="banned-terms-unresolvable"),
+        ):
+            route_forge_write(
+                forge="github",
+                repo="souliane/teatree",
+                text="a perfectly ordinary note",
+                action="github_issue_create",
+                target="souliane/teatree",
+            )
 
 
 class TestRouteForgeWriteSendProxy:


### PR DESCRIPTION
## Summary

The runtime forge-write leak gate built its scan vocabulary only from the active overlay's `privacy_redact_terms`, which is empty by default. As a result `scan_outbound_text` — the egress chokepoint every forge writer routes through (`route_forge_write` → the MCP `*_issue_create` / `*_issue_comment` tools, PR create/comment, the dream-loop filers, and the `t3` CLIs) — never consulted the DB-home `banned_terms` list. The overlay redact terms and the banned-terms list are two separate sources, and only the former was scanned on this seam, so a configured banned term could reach a public repo unscrubbed.

## Fix

At the shared egress chokepoint (`scan_outbound_text`), on a **PUBLIC** target the scan vocabulary is now the overlay's `privacy_redact_terms` **unioned** with the DB-home `banned_terms` list (`banned_terms_cli.resolve_banned_terms` — the same fail-closed source the shell/CI gates read). Both feed the existing whole-token `term_match` matcher via `scan_for_publication`, so a whole-token match raises `OutboundLeakError`. Placing it at the shared seam means the MCP tools, the loop writers, and the CLI writers all get it.

**Fail closed:**
- an unreadable banned-terms source refuses the public publish with a `banned-terms-unresolvable` match;
- a genuinely unset list follows the existing shell-gate posture — refuse only when `banned_terms_required`, otherwise a dev/solo no-op.

A private/provably-non-public target is untouched (clean pass), and the matcher reuses the whole-token `term_match` (no `\b` regex reintroduced).

## Tests

New tests reproduce the leaking production config — empty `privacy_redact_terms`, the term present only in the DB `banned_terms` list — at the `route_forge_write` level, using the synthetic placeholder term `acme`:
- a public forge write carrying the banned term **raises** `OutboundLeakError` (RED before this change, GREEN after);
- a clean body passes;
- a private target is not blocked;
- an unreadable banned source and an unset-but-required list fail closed;
- an unset, not-required list is a dev no-op.

## Architecture pre-check

### 1. BLUEPRINT alignment
Touches the privacy/leak-prevention gate on the outbound forge-write path. No FSM or model change.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition.

### 3. Extension-point contracts
No `OverlayBase` / scanner / Protocol change. Consumes the existing `banned_terms_cli.resolve_banned_terms` contract and the existing `term_match` matcher.

### 4. Component boundaries
Change lives in `teatree/core/gates/privacy_gate.py` (the gate) — the correct home for the shared scan seam. No new module.

### 5. Dependency direction
Adds a `teatree.core.gates` -> `teatree.hooks` import (`banned_terms_cli`, `banned_terms_tree_scan`), the same edge `privacy_gate` already uses for `term_match`. `uv run tach check`: All modules validated.

### 6. Test surface
`tests/teatree_core/test_send_proxy_forge_write.py::TestRouteForgeWriteBannedTermsLeakGate` — asserts the raise/pass/fail-closed behaviours at the `route_forge_write` entry seam; the must-block cases were observed RED before the fix.

### 7. Resilience invariants
Read-only scan (no external write). Idempotent (pure function of text + resolved sources). The banned-terms read fails **closed** on any error — an unreadable source refuses rather than silently degrading to "no terms".

### 8. Identity and key normalization
n/a — no identity/key normalization; term matching is delegated to the single shared `term_match` whole-token matcher, not re-implemented.

### 9. Behavior preservation / capability deletion
Purely additive — no existing behaviour removed, no matcher narrowed, no must-block test inverted. The overlay-redact and quote-anchor paths are unchanged; banned terms are unioned in.

### 10. Removability / harness-vs-data
Removable: the union and the `_db_banned_terms` helper can be reverted without cascade. The varying part (the term list) lives in data (the DB `banned_terms` setting); the gate stays the generic mechanism that reads it.
