### PR TITLE
fix: harden overlay resolution, intake gating, resource probes, and scanner-phase dispatch

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -4737,6 +4737,8 @@ Usage: t3 loop schedule [OPTIONS] COMMAND [ARGS]...
 │ show          Show a schedule's ordered slots, or (no arg) the active one.   │
 │ set-active    Activate a schedule — the single write that switches calendars │
 │               (normal ↔ holiday).                                            │
+│ set-timezone  Set a schedule's timezone so its wall-clock slots fire         │
+│               locally, not in the project zone.                              │
 │ clear-active  Clear the active schedule so no L2 layer applies.              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
@@ -4780,6 +4782,24 @@ Usage: t3 loop schedule set-active [OPTIONS] NAME
 
 ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
 │ *    name      TEXT  [required]                                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────╮
+│ --json                                                                       │
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+##### `t3 loop schedule set-timezone`
+
+```
+Usage: t3 loop schedule set-timezone [OPTIONS] NAME ZONE
+
+ Set a schedule's timezone so its wall-clock slots fire locally, not in the
+ project zone.
+
+╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+│ *    name      TEXT  [required]                                              │
+│ *    zone      TEXT  [required]                                              │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --json                                                                       │

--- a/docs/generated/management-commands.json
+++ b/docs/generated/management-commands.json
@@ -541,6 +541,10 @@
           "name": "set-active"
         },
         {
+          "help": "Set *name*'s slot timezone \u2014 the lever that makes its wall-clock slots fire locally",
+          "name": "set-timezone"
+        },
+        {
           "help": "Clear the active schedule so no L2 layer applies (presets only via override)",
           "name": "clear-active"
         }

--- a/docs/generated/management-commands.md
+++ b/docs/generated/management-commands.md
@@ -270,6 +270,7 @@ List/show/set-active/clear-active loop schedules (#3159).
 | `show` | Show a schedule's ordered slots (weekdays at a start time, then the preset) |
 | `list` | List every schedule with its timezone, slot count, and the ACTIVE marker |
 | `set-active` | Activate *name* — the single ``active_loop_schedule`` write that switches calendars |
+| `set-timezone` | Set *name*'s slot timezone — the lever that makes its wall-clock slots fire locally |
 | `clear-active` | Clear the active schedule so no L2 layer applies (presets only via override) |
 
 ## `loop_self_improve`

--- a/src/teatree/backends/gitlab/sync.py
+++ b/src/teatree/backends/gitlab/sync.py
@@ -21,6 +21,7 @@ from teatree.backends.gitlab.sync_issues import fetch_assigned_issues, fetch_iss
 from teatree.backends.gitlab.sync_prs import _PRContext, extract_repo_path, upsert_ticket_from_pr
 from teatree.backends.gitlab.sync_terminal import detect_closed_prs, detect_merged_prs
 from teatree.backends.slack.review_sync import fetch_review_permalinks
+from teatree.core.intake.label_admission import LabelPolicy
 from teatree.core.models import Ticket
 from teatree.core.sync import _overlay_name
 from teatree.types import LAST_SYNC_CACHE_KEY, PENDING_REVIEWS_CACHE_KEY, SyncBackend, SyncResult
@@ -73,7 +74,16 @@ class GitLabSyncBackend(SyncBackend):
             ctx = _PRContext(raw=raw, repo_short=repo_short, client=client, project=project)
             upsert_ticket_from_pr(ctx, result, username=username, overlay_name=overlay_name)
 
-        fetch_assigned_issues(host, username, result, overlay_name=overlay_name)
+        fetch_assigned_issues(
+            host,
+            username,
+            result,
+            overlay_name=overlay_name,
+            label_policy=LabelPolicy(
+                ready_labels=tuple(overlay.config.ready_labels),
+                exclude_labels=tuple(overlay.config.exclude_labels),
+            ),
+        )
 
         if overlay_name:
             Ticket.objects.in_flight().filter(overlay="").update(overlay=overlay_name)

--- a/src/teatree/backends/gitlab/sync_issues.py
+++ b/src/teatree/backends/gitlab/sync_issues.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 import httpx
 
 from teatree.backends.gitlab import GitLabCodeHost
+from teatree.core.intake.label_admission import LabelPolicy
 from teatree.core.intake.ticket_kind_classification import classify_ticket_kind
 from teatree.core.models import Ticket
 from teatree.types import SyncResult
@@ -31,12 +32,20 @@ def fetch_assigned_issues(
     result: SyncResult,
     *,
     overlay_name: str = "",
+    label_policy: LabelPolicy | None = None,
 ) -> None:
     """Upsert tickets for issues assigned to *username* that have no PR yet.
 
     Tickets keyed by the same ``issue_url`` are consolidated with PR-based
     tickets so each ticket is represented by a single row.
+
+    This is the second issue intake alongside the ``assigned_issues`` scanner,
+    so it runs the same :func:`intake_admits` label gate: an assignment alone
+    is not a nomination, and a ticket created here is work the operator never
+    picked. The gate covers row *creation* only — an issue already tracked is
+    still reconciled, whatever its labels now say.
     """
+    policy = label_policy or LabelPolicy()
     try:
         issues = host.list_assigned_issues(assignee=username)
     except httpx.HTTPError as exc:
@@ -63,6 +72,8 @@ def fetch_assigned_issues(
 
         raw_labels = issue.get("labels")
         labels = [str(label) for label in raw_labels] if isinstance(raw_labels, list) else []
+        if not policy.admits(labels):
+            continue
         issue_title = str(issue.get("title", ""))
         Ticket.objects.create(
             issue_url=issue_url,

--- a/src/teatree/cli/loop/schedule.py
+++ b/src/teatree/cli/loop/schedule.py
@@ -1,4 +1,4 @@
-"""``t3 loop schedule {list,show,set-active,clear-active}`` — the weekly schedule surface (#3159).
+"""``t3 loop schedule {list,show,set-active,set-timezone,clear-active}`` — the weekly schedule surface (#3159).
 
 Thin typer verbs delegating to the ``loop_schedule`` Django management command
 (the ``cli.loop.state`` pattern). :func:`register` attaches the ``schedule``
@@ -24,7 +24,7 @@ def _delegate(*args: str, json_output: bool = False) -> None:
 
 
 def register(loop_app: typer.Typer) -> None:
-    """Attach the ``schedule`` subgroup (list/show/set-active/clear-active) onto loop_app."""
+    """Attach the ``schedule`` subgroup (list/show/set-active/set-timezone/clear-active) onto loop_app."""
     schedule_app = typer.Typer(
         name="schedule", no_args_is_help=True, help="Weekly preset schedules — the L2 calendar (#3159)."
     )
@@ -52,6 +52,16 @@ def register(loop_app: typer.Typer) -> None:
     ) -> None:
         """Activate a schedule — the single write that switches calendars (normal ↔ holiday)."""
         _delegate("set-active", name, json_output=json_output)
+
+    @schedule_app.command("set-timezone")
+    def set_timezone_command(
+        name: Annotated[str, typer.Argument()],
+        zone: Annotated[str, typer.Argument()],
+        *,
+        json_output: Annotated[bool, typer.Option("--json")] = False,
+    ) -> None:
+        """Set a schedule's timezone so its wall-clock slots fire locally, not in the project zone."""
+        _delegate("set-timezone", name, zone, json_output=json_output)
 
     @schedule_app.command("clear-active")
     def clear_active_command(*, json_output: Annotated[bool, typer.Option("--json")] = False) -> None:

--- a/src/teatree/config/discovery.py
+++ b/src/teatree/config/discovery.py
@@ -114,25 +114,29 @@ def discover_active_overlay() -> OverlayEntry | None:
 def _discover_from_manage_py() -> OverlayEntry | None:
     """Walk up from cwd to find a manage.py and extract its settings module.
 
-    The directory basename names the overlay, but a clone dir can differ from
-    the registered entry-point name (``teatree`` on disk vs the registered
-    ``t3-teatree``). ``_canonical_active_overlay_name`` folds the basename onto
-    the registered entry point so every consumer — most importantly the scanners
-    that stamp ``ticket.overlay`` — writes the dispatchable name, never a stale
-    alias that the queue then can't resolve (souliane/teatree#1959).
+    The settings module is the authoritative name source, not the directory
+    basename: a clone dir is named freely and drifts from the registered
+    entry-point name (``acme-factory`` on disk against a registered
+    ``t3-acme``), while the settings module names the Django project that IS
+    the overlay (``acme.settings`` → ``acme`` → ``t3-acme``). The basename
+    remains the fallback. ``_canonical_active_overlay_name`` folds whichever
+    resolves onto the registered entry point so every consumer — most
+    importantly the scanners that stamp ``ticket.overlay`` — writes the
+    dispatchable name, never a stale alias the queue then can't resolve
+    (souliane/teatree#1959).
     """
     for directory in [Path.cwd(), *Path.cwd().parents]:
         manage_py = directory / "manage.py"
         if manage_py.is_file():
             settings_module = _extract_settings_module(manage_py)
             if settings_module:
-                name = _canonical_active_overlay_name(directory.name)
+                name = _canonical_active_overlay_name(directory.name, settings_module=settings_module)
                 return OverlayEntry(name=name, overlay_class="", project_path=directory)
     return None
 
 
-def _canonical_active_overlay_name(directory_name: str) -> str:
-    """Fold a clone-directory basename onto its registered entry-point name, if one exists.
+def _canonical_active_overlay_name(directory_name: str, *, settings_module: str = "") -> str:
+    """Fold a clone dir / settings module onto its registered entry-point name, if one exists.
 
     Stays inside the ``platform`` layer (``config``): reads the entry-point
     names directly and reuses the local ``_match_canonical_ep`` alias rule
@@ -146,9 +150,11 @@ def _canonical_active_overlay_name(directory_name: str) -> str:
         return directory_name
     if directory_name in ep_names:
         return directory_name
-    canonical = _match_canonical_ep(directory_name, ep_names)
-    if canonical is not None:
-        return canonical
+    settings_package = settings_module.split(".", maxsplit=1)[0]
+    for alias in (settings_package, directory_name):
+        canonical = _match_canonical_ep(alias, ep_names) if alias else None
+        if canonical is not None:
+            return canonical
     # A clone/deploy dir whose basename matches NO registered entry point —
     # e.g. a ``teatree-deploy`` deploy dir against the sole ``t3-teatree``
     # entry point — would otherwise leak the raw basename as the overlay

--- a/src/teatree/core/intake/label_admission.py
+++ b/src/teatree/core/intake/label_admission.py
@@ -1,0 +1,42 @@
+"""The label gate every issue-intake path runs before it creates work.
+
+Two intakes turn an assigned issue into work: the ``assigned_issues`` scanner
+(loop signals) and ``t3 <overlay> followup sync`` (``Ticket`` rows). Both answer
+to the same overlay policy, so the predicate lives here rather than in either
+caller — an intake that carries its own copy, or none at all, silently picks up
+issues the operator never nominated.
+
+An empty ``ready_labels`` admits everything, so an overlay that has not opted
+into an allowlist keeps its pre-allowlist intake behaviour.
+"""
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+
+def intake_admits(
+    labels: Iterable[str],
+    ready_labels: Iterable[str],
+    exclude_labels: Iterable[str],
+) -> bool:
+    present = set(labels)
+    allowlist = set(ready_labels)
+    if allowlist and not present & allowlist:
+        return False
+    return not present & set(exclude_labels)
+
+
+@dataclass(frozen=True, slots=True)
+class LabelPolicy:
+    """An overlay's allowlist/denylist as one value, for threading through intake layers.
+
+    The scanner already holds the two lists as its own fields; the sync path
+    crosses several call layers, where one policy argument beats two parallel
+    ones that can drift apart.
+    """
+
+    ready_labels: tuple[str, ...] = ()
+    exclude_labels: tuple[str, ...] = ()
+
+    def admits(self, labels: Iterable[str]) -> bool:
+        return intake_admits(labels, self.ready_labels, self.exclude_labels)

--- a/src/teatree/core/management/commands/_deterministic_phases.py
+++ b/src/teatree/core/management/commands/_deterministic_phases.py
@@ -20,6 +20,7 @@ import logging
 import traceback
 from collections.abc import Callable
 
+from teatree.core.management.commands.ticket_short_describe import describe_ticket
 from teatree.core.modelkit.phases import SHORT_DESCRIBE_PHASE, normalize_phase
 from teatree.core.models import Task
 
@@ -32,10 +33,6 @@ PhaseRunner = Callable[[Task], str]
 
 
 def _run_short_describe(task: Task) -> str:
-    from teatree.core.management.commands.ticket_short_describe import (  # noqa: PLC0415 — deferred: Django app registry
-        describe_ticket,
-    )
-
     lines: list[str] = []
     describe_ticket(int(task.ticket_id), stdout_write=lines.append)  # ty: ignore[unresolved-attribute]
     return "\n".join(lines)

--- a/src/teatree/core/management/commands/_deterministic_phases.py
+++ b/src/teatree/core/management/commands/_deterministic_phases.py
@@ -1,0 +1,71 @@
+"""Phases the headless worker executes deterministically, never as a generic agent spawn.
+
+Most headless phases are agentic: the worker builds a ticket-work brief and drives a
+model through it. A few are not — they are fixed data transformations that happen to be
+scheduled as ``Task`` rows so a loop scanner does not have to run an LLM inline
+(``no synchronous LLM in scan()``). Dispatching one of those through the agentic path
+hands it the generic *"Work on ticket N — check git log, code, test, run
+``t3 tool verify-gates``"* brief, which contradicts its least-privilege toolset: the
+brief demands the shell the phase is (correctly) denied, so the agent follows its own
+stop-rule, records ``needs_user_input`` and parks. The scanner's dedup filter ignores
+FAILED, so the next tick re-enqueues it — a retry storm of unanswerable questions.
+
+Registering a phase here routes it to its own implementation instead, so its empty tool
+allowance is never contradicted by a brief written for a different kind of work. It lives
+beside the headless task command (``tasks.py``) that consults it — a ``_``-prefixed module
+so Django never mistakes it for a management command.
+"""
+
+import logging
+import traceback
+from collections.abc import Callable
+
+from teatree.core.modelkit.phases import SHORT_DESCRIBE_PHASE, normalize_phase
+from teatree.core.models import Task
+
+logger = logging.getLogger(__name__)
+
+#: A runner takes the claimed task and returns the human-readable outcome line(s) it
+#: wants recorded on the ``TaskAttempt``. Raising is fine — the caller records the
+#: traceback as a failed attempt, the same contract the agentic path has.
+PhaseRunner = Callable[[Task], str]
+
+
+def _run_short_describe(task: Task) -> str:
+    from teatree.core.management.commands.ticket_short_describe import (  # noqa: PLC0415 — deferred: Django app registry
+        describe_ticket,
+    )
+
+    lines: list[str] = []
+    describe_ticket(int(task.ticket_id), stdout_write=lines.append)  # ty: ignore[unresolved-attribute]
+    return "\n".join(lines)
+
+
+_RUNNERS: dict[str, PhaseRunner] = {SHORT_DESCRIBE_PHASE: _run_short_describe}
+
+
+def deterministic_phase_runner(phase: str) -> PhaseRunner | None:
+    """The deterministic runner for *phase*, or ``None`` when it dispatches agentically."""
+    return _RUNNERS.get(normalize_phase(phase))
+
+
+def run_deterministic_phase(task: Task) -> dict[str, str] | None:
+    """Execute *task* deterministically when its phase is non-agentic, else ``None``.
+
+    A non-agentic phase (``short_describe``) runs its own implementation rather than a
+    generic ticket-work brief its least-privilege toolset cannot satisfy. Failures are
+    recorded through the same durable recorder as the agentic path, so a raise never
+    leaves the task stuck CLAIMED. ``None`` means the phase dispatches agentically.
+    """
+    runner = deterministic_phase_runner(task.phase)
+    if runner is None:
+        return None
+    try:
+        outcome = runner(task)
+    except Exception:  # noqa: BLE001 — a deterministic-phase failure is recorded durably, never escapes.
+        error = traceback.format_exc()
+        logger.warning("Task %s: deterministic phase %r raised", task.pk, task.phase)
+        task.complete_with_attempt(exit_code=1, error=error, result={"phase_error": error})
+        return {"exit_code": "1", "phase_error": error}
+    attempt = task.complete_with_attempt(exit_code=0, result={"summary": outcome})
+    return {"exit_code": "0", "attempt_id": str(attempt.pk)}

--- a/src/teatree/core/management/commands/_e2e_discovery.py
+++ b/src/teatree/core/management/commands/_e2e_discovery.py
@@ -14,13 +14,38 @@ from teatree.core.models import Ticket, Worktree
 from teatree.core.worktree.worktree_env import compose_project
 from teatree.utils.ports import get_service_port
 
+# Both loopback literals, IPv4 first (the common case). Literals rather than
+# resolving ``localhost``: a host whose ``/etc/hosts`` maps the name to one
+# family only would hide a listener on the other — the very failure below.
+_LOOPBACK_ADDRESSES: tuple[tuple[int, str], ...] = (
+    (socket.AF_INET, "127.0.0.1"),
+    (socket.AF_INET6, "::1"),
+)
+# Per-address connect timeout. ``discover_frontend_port`` scans 11 ports, so
+# the worst case is 11 x len(_LOOPBACK_ADDRESSES) x this — halving the old
+# single-family 0.3s keeps that ceiling exactly where it was.
+_LOOPBACK_CONNECT_TIMEOUT = 0.15
+
 
 def detect_local_port(port: int) -> int | None:
-    """Return *port* if something is listening on localhost, else None."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.settimeout(0.3)
-        if s.connect_ex(("127.0.0.1", port)) == 0:
-            return port
+    """Return *port* if something is listening on localhost, else None.
+
+    Probes both loopback families rather than IPv4 alone. Node dev servers
+    (``nx serve`` and friends) bind ``::1`` only on a host that prefers IPv6,
+    and an ``AF_INET``-only probe cannot see them: ``curl`` against
+    ``[::1]:4200`` answers 200 while ``127.0.0.1:4200`` is refused. That made
+    :func:`discover_frontend_port` report no frontend and aborted
+    ``e2e external --target local`` with "Frontend not running" on a host
+    whose frontend was up and serving.
+    """
+    for family, address in _LOOPBACK_ADDRESSES:
+        try:
+            with socket.socket(family, socket.SOCK_STREAM) as probe:
+                probe.settimeout(_LOOPBACK_CONNECT_TIMEOUT)
+                if probe.connect_ex((address, port)) == 0:
+                    return port
+        except OSError:
+            continue  # family unavailable on this host (e.g. IPv6 disabled)
     return None
 
 

--- a/src/teatree/core/management/commands/loop_schedule.py
+++ b/src/teatree/core/management/commands/loop_schedule.py
@@ -1,4 +1,4 @@
-"""``manage.py loop_schedule`` — list/show/set-active/clear-active loop schedules (#3159).
+"""``manage.py loop_schedule`` — list/show/set-active/set-timezone/clear-active schedules (#3159).
 
 Backs ``t3 loop schedule …``. A schedule is a named weekly calendar of slots; the
 active one is the ``active_loop_schedule`` ``ConfigSetting`` (global scope). Setting
@@ -8,6 +8,7 @@ management command" rule).
 """
 
 import json
+import zoneinfo
 from typing import Annotated, Any, NoReturn
 
 import typer
@@ -57,7 +58,7 @@ class Command(TyperCommand):
         for schedule in schedules:
             marker = " *ACTIVE*" if schedule.name == active else ""
             self.stdout.write(
-                f"  {schedule.name:<20} tz={schedule.timezone or 'local':<18} {schedule.slots.count()} slots{marker}"
+                f"  {schedule.name:<20} tz={schedule.timezone_label:<18} {schedule.slots.count()} slots{marker}"
             )
         if not active:
             self.stdout.write("  (no active schedule — presets apply only via a manual override)")
@@ -96,7 +97,7 @@ class Command(TyperCommand):
                 )
             )
             return
-        self.stdout.write(f"schedule {schedule.name} (tz={schedule.timezone or 'local'}): {schedule.description}")
+        self.stdout.write(f"schedule {schedule.name} (tz={schedule.timezone_label}): {schedule.description}")
         for slot in slots:
             self.stdout.write(f"  {_slot_days(slot):<28} {slot.start_time.strftime('%H:%M')} -> {slot.preset_name}")
 
@@ -112,6 +113,40 @@ class Command(TyperCommand):
             self._refuse(f"no schedule named {name!r} — run `t3 loop schedule list`", json_output=json_output)
         ConfigSetting.objects.set_value(ACTIVE_SCHEDULE_SETTING, name)
         self._emit({"active": name}, f"active schedule is now {name!r}.", json_output=json_output)
+
+    @command(name="set-timezone")
+    def set_timezone(
+        self,
+        name: Annotated[str, typer.Argument(help="Schedule to retime.")],
+        zone: Annotated[str, typer.Argument(help="IANA zone key, e.g. Europe/Vienna.")],
+        *,
+        json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
+    ) -> None:
+        """Set *name*'s slot timezone — the lever that makes its wall-clock slots fire locally.
+
+        A schedule seeded without a timezone resolves to ``settings.TIME_ZONE``,
+        so its 08:00 slot fires at 08:00 UTC rather than 08:00 where the operator
+        is. The per-schedule column is the correct lever; the project zone stays
+        UTC. Validated here at WRITE time so an unknown key is refused once
+        instead of warned about on every tick.
+        """
+        schedule = ModeSchedule.objects.filter(name=name).first()
+        if schedule is None:
+            self._refuse(f"no schedule named {name!r} — run `t3 loop schedule list`", json_output=json_output)
+        try:
+            zoneinfo.ZoneInfo(zone)
+        except (zoneinfo.ZoneInfoNotFoundError, ValueError):
+            self._refuse(
+                f"unknown timezone {zone!r} — expected an IANA key like 'Europe/Vienna'",
+                json_output=json_output,
+            )
+        schedule.timezone = zone
+        schedule.save(update_fields=["timezone", "updated_at"])
+        self._emit(
+            {"name": name, "timezone": zone},
+            f"schedule {name!r} now resolves its slots in {zone}.",
+            json_output=json_output,
+        )
 
     @command(name="clear-active")
     def clear_active(self, *, json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False) -> None:

--- a/src/teatree/core/management/commands/tasks.py
+++ b/src/teatree/core/management/commands/tasks.py
@@ -13,6 +13,7 @@ from teatree.agents.prompt import build_interactive_context
 from teatree.agents.skill_bundle import resolve_skill_bundle
 from teatree.core.intake.ticket_kind_classification import classify_ticket_kind
 from teatree.core.machine_output import emit
+from teatree.core.management.commands._deterministic_phases import run_deterministic_phase
 from teatree.core.management.commands.tasks_session_view import (
     TaskRow,
     render_reconcile_checklist,
@@ -512,6 +513,11 @@ class Command(TyperCommand):
         if refusal is not None:
             task.complete_with_attempt(exit_code=1, error=refusal, result={"routing_error": refusal})
             return {"exit_code": "1", "routing_error": refusal}
+
+        # A non-agentic phase (``short_describe``) runs its own implementation, not a
+        # generic ticket-work brief its least-privilege toolset cannot satisfy.
+        if (deterministic := run_deterministic_phase(task)) is not None:
+            return deterministic
 
         # Durable failure recording, the same semantics ``execute_headless_task``
         # applies (souliane/teatree#2192): ``run_headless`` can RAISE on an SDK

--- a/src/teatree/core/management/commands/ticket_short_describe.py
+++ b/src/teatree/core/management/commands/ticket_short_describe.py
@@ -99,7 +99,7 @@ def _summarize(title: str) -> str:
     return lines[-1].strip().strip('"').strip("'")
 
 
-def _describe_one(ticket_id: int, *, stdout_write: Callable[[str], object]) -> None:
+def describe_ticket(ticket_id: int, *, stdout_write: Callable[[str], object]) -> None:
     from teatree.core.models import Ticket  # noqa: PLC0415 — deferred: ORM import needs the app registry
 
     ticket = Ticket.objects.filter(pk=ticket_id).first()
@@ -158,7 +158,7 @@ class Command(TyperCommand):
         if all_missing:
             _describe_all_missing(stdout_write=self.stdout.write)
         else:
-            _describe_one(ticket_id, stdout_write=self.stdout.write)
+            describe_ticket(ticket_id, stdout_write=self.stdout.write)
 
 
 __all__ = ["BaseCommand", "Command"]

--- a/src/teatree/core/modelkit/phase_tools.py
+++ b/src/teatree/core/modelkit/phase_tools.py
@@ -153,6 +153,23 @@ _TOOLS_BY_PHASE: Final[dict[str, frozenset[str]]] = {
     # the provision smoke, so it needs the shell (read-only+shell, mirroring
     # ``bughunt``/``shipping``); it never mutates source through the write tools.
     "dogfood_smoke": _READ_ONLY | {"shell"},
+    # ``eval_local`` shells out to run the scoped eval suite (``t3 eval run``), the
+    # same read-only+shell shape as ``dogfood_smoke``: it executes a suite and
+    # reports, it never mutates source.
+    "eval_local": _READ_ONLY | {"shell"},
+    # ``backlog_sweep`` triages the issue tracker — it reads the tracker over the
+    # forge CLI (shell) and the web, and records close/fold PROPOSALS behind the
+    # scanner's ask-gate. NO write/edit: a sweep produces proposals, never commits.
+    "backlog_sweep": _READ_ONLY | _WEB | {"shell"},
+    # ``short_describe`` turns a cached issue title into a <=40 char statusline
+    # summary. It is a pure text transformation over data already on the ``Ticket``
+    # row, so it needs NO tool at all — and MUST NOT get the shell: the scanner
+    # enqueues one per undescribed ticket, so granting it write/shell would turn a
+    # few hundred summarisation dispatches a day into autonomous ticket-implementing
+    # agents. Executed deterministically (``deterministic_phase_runner``) rather than
+    # as a generic agent spawn, so the empty allowance is never contradicted by a
+    # ticket-work brief.
+    "short_describe": _NONE,
 }
 
 

--- a/src/teatree/core/modelkit/phases.py
+++ b/src/teatree/core/modelkit/phases.py
@@ -144,7 +144,18 @@ SUBAGENT_BY_PHASE: dict[tuple[str, str], str] = {
 #: own token from this set.
 ARCHITECTURAL_REVIEW_PHASE: str = "architectural_review"
 DOGFOOD_SMOKE_PHASE: str = "dogfood_smoke"
-SCANNER_DISPATCHED_PHASES: frozenset[str] = frozenset({ARCHITECTURAL_REVIEW_PHASE, DOGFOOD_SMOKE_PHASE})
+EVAL_LOCAL_PHASE: str = "eval_local"
+BACKLOG_SWEEP_PHASE: str = "backlog_sweep"
+SHORT_DESCRIBE_PHASE: str = "short_describe"
+SCANNER_DISPATCHED_PHASES: frozenset[str] = frozenset(
+    {
+        ARCHITECTURAL_REVIEW_PHASE,
+        DOGFOOD_SMOKE_PHASE,
+        EVAL_LOCAL_PHASE,
+        BACKLOG_SWEEP_PHASE,
+        SHORT_DESCRIBE_PHASE,
+    }
+)
 
 #: Every canonical FSM phase plus every reactive/dispatch-only phase registered
 #: in ``SUBAGENT_BY_PHASE`` (``debugging``/``bughunt``/``answering``/…) and every

--- a/src/teatree/core/models/loop_schedule.py
+++ b/src/teatree/core/models/loop_schedule.py
@@ -15,6 +15,7 @@ shape only, referencing presets **by name** so a deleted preset fails open.
 from typing import ClassVar
 
 from django.db import models
+from django.utils import timezone as django_timezone
 
 
 class ModeSchedule(models.Model):
@@ -31,7 +32,17 @@ class ModeSchedule(models.Model):
         ordering: ClassVar = ["name"]
 
     def __str__(self) -> str:
-        return f"loop-schedule<{self.name} tz={self.timezone or 'local'}>"
+        return f"loop-schedule<{self.name} tz={self.timezone_label}>"
+
+    @property
+    def timezone_label(self) -> str:
+        """Display form of ``timezone``.
+
+        An unset value resolves to the *project* zone, not the operator's local
+        one — naming it "local" reads as "your wall clock" and hides that slots
+        seeded without a timezone fire in ``settings.TIME_ZONE``.
+        """
+        return self.timezone or f"{django_timezone.get_current_timezone_name()} (default)"
 
 
 _MAX_WEEKDAY = 6  # Python weekday(): Sunday

--- a/src/teatree/core/models/scanned_broadcast.py
+++ b/src/teatree/core/models/scanned_broadcast.py
@@ -8,9 +8,18 @@ on ``(channel, slack_ts)`` deduplicates and the stored classification lets
 follow-up ticks observe what's already been done.
 
 The lifecycle mirrors :class:`ReviewAssignment`: one row per
-``(channel, slack_ts)``, monotonic state transitions, optional reviewer-task
-linkage for audit, no double dispatch when the row already exists with the
-same classification.
+``(channel, slack_ts)``, monotonic state transitions, reviewer-task linkage,
+no double dispatch while a reviewer task covers the row.
+
+Idempotency is not the emission gate
+------------------------------------
+
+The ledger answers "have I seen this broadcast?"; ``reviewer_task_id``
+answers "did a reviewer actually get dispatched for it?". Gating emission on
+the former makes a broadcast reviewable exactly once ever — so a dispatch lost
+to a dead worker, a failed task, or an exhausted budget leaves that review
+permanently unreachable. :attr:`ScannedBroadcast.awaiting_reviewer_dispatch`
+is the emission gate; the unique constraint remains the idempotency key.
 
 State machine
 -------------
@@ -105,11 +114,11 @@ class ScannedBroadcast(models.Model):
     def record(cls, observation: BroadcastObservation) -> "ScannedBroadcast | None":
         """Insert one row idempotently on ``(channel, slack_ts)``.
 
-        Returns the new row on first observation, ``None`` if a row for
-        this broadcast already exists with the same classification. When
-        the classification changes (pending → all_merged once the last
-        open MR closes), the row is updated and returned so the caller
-        can re-react on Slack.
+        Returns the new row on first observation, and again on any later
+        observation the caller still has work for: a changed classification
+        (pending → all_merged once the last open MR closes) or a pending
+        broadcast no reviewer task covers. ``None`` means there is nothing
+        left to do for this broadcast.
         """
         if not observation.channel or not observation.slack_ts:
             return None
@@ -130,7 +139,7 @@ class ScannedBroadcast(models.Model):
             # does not override a row marked manual — only an explicit reset does.
             return None
         if row.classification == observation.classification:
-            return None
+            return row if row.awaiting_reviewer_dispatch else None
         row.classification = observation.classification
         row.mr_urls = list(observation.mr_urls)
         row.reclassified_at = timezone.now()
@@ -164,6 +173,26 @@ class ScannedBroadcast(models.Model):
         if updated:
             self.refresh_from_db(fields=["classification", "manually_classified", "manually_classified_at"])
         return bool(updated)
+
+    @property
+    def awaiting_reviewer_dispatch(self) -> bool:
+        """True when this pending broadcast has no reviewer task covering it.
+
+        Having *seen* a broadcast before is idempotency, not coverage — the
+        review only became reachable if a reviewer task was actually created.
+        A row whose task was never recorded, was deleted, or FAILED lost its
+        emission and must be re-emitted. A COMPLETED task still counts as
+        covered: the review happened, and the broadcast signal carries no head
+        SHA for the downstream at-head dedup to key on, so re-emitting on it
+        would re-review on every tick.
+        """
+        if self.classification != self.Classification.PENDING:
+            return False
+        if not self.reviewer_task_id.isdigit():
+            return True
+        from teatree.core.models.task import Task  # noqa: PLC0415 — lazy: avoids the models import cycle
+
+        return not Task.objects.filter(pk=self.reviewer_task_id).exclude(status=Task.Status.FAILED).exists()
 
     def attach_reviewer_task(self, task_id: str) -> bool:
         """Persist the dispatched reviewer-task id on this broadcast row.

--- a/src/teatree/core/models/scanned_broadcast.py
+++ b/src/teatree/core/models/scanned_broadcast.py
@@ -54,6 +54,8 @@ from typing import ClassVar
 from django.db import models
 from django.utils import timezone
 
+from teatree.core.models.task import Task
+
 
 @dataclass(frozen=True, slots=True)
 class BroadcastObservation:
@@ -190,8 +192,6 @@ class ScannedBroadcast(models.Model):
             return False
         if not self.reviewer_task_id.isdigit():
             return True
-        from teatree.core.models.task import Task  # noqa: PLC0415 — lazy: avoids the models import cycle
-
         return not Task.objects.filter(pk=self.reviewer_task_id).exclude(status=Task.Status.FAILED).exists()
 
     def attach_reviewer_task(self, task_id: str) -> bool:

--- a/src/teatree/loop/persistence.py
+++ b/src/teatree/loop/persistence.py
@@ -24,7 +24,7 @@ from teatree.core.models.auto_implement import mark_auto_implement
 from teatree.core.models.ticket_external_review import schedule_external_review
 from teatree.loop.dispatch import DispatchAction
 from teatree.loop.dispatch_gates import claim_red_mr_fix
-from teatree.loop.dispatch_tables import PERSISTED_AT_SOURCE_ZONES
+from teatree.loop.dispatch_tables import PERSISTED_AT_SOURCE_ZONES, ActionPayload
 
 if TYPE_CHECKING:
     from teatree.core.models.types import TicketExtra
@@ -161,7 +161,9 @@ def _handle_reviewer(action: DispatchAction) -> Task | None:
         # review of the genuinely new revision (the recorded APPROVED
         # belonged to the old SHA).
         ticket.merge_extra(set_keys={"reviewed_sha": head_sha}, pop_keys=["last_review_state"])
-    if _has_open_task(ticket, phase="reviewing"):
+    open_task = _open_task_in_phase(ticket, phase="reviewing")
+    if open_task is not None:
+        _link_broadcast_reviewer_task(payload, open_task)
         return None
     if _already_reviewed_at_head(ticket, head_sha):
         # #959 defect 2: the MR was already independently reviewed AND
@@ -174,7 +176,27 @@ def _handle_reviewer(action: DispatchAction) -> Task | None:
         # above, so a genuinely new revision is still reviewed.
         logger.debug("PR %s already approved at head %s — not re-enqueuing review", pr_url, head_sha)
         return None
-    return schedule_external_review(ticket)
+    task = schedule_external_review(ticket)
+    _link_broadcast_reviewer_task(payload, task)
+    return task
+
+
+def _link_broadcast_reviewer_task(payload: ActionPayload, task: Task | None) -> None:
+    """Record the covering reviewer task on the ``ScannedBroadcast`` row that emitted it.
+
+    Closes the broadcast ledger's emission gate: until the row knows which task
+    covers it, ``ScannedBroadcast.awaiting_reviewer_dispatch`` keeps re-emitting
+    the review intent every tick. Best-effort — a broadcast that has since been
+    deleted must never break the dispatch it is auditing.
+    """
+    broadcast_id = payload.get("broadcast_id")
+    if not broadcast_id or task is None:
+        return
+    from teatree.core.models import ScannedBroadcast  # noqa: PLC0415 — lazy: avoids the models import cycle
+
+    row = ScannedBroadcast.objects.filter(pk=broadcast_id).first()
+    if row is not None:
+        row.attach_reviewer_task(str(task.pk))
 
 
 def _already_reviewed_at_head(ticket: Ticket, head_sha: str) -> bool:
@@ -267,12 +289,16 @@ def _link_claimed_marker(ticket: Ticket, issue_url: str) -> None:
     ).update(ticket=ticket, state=ImplementedIssueMarker.State.TICKET_CREATED)
 
 
-def _has_open_task(ticket: Ticket, *, phase: str) -> bool:
+def _open_task_in_phase(ticket: Ticket, *, phase: str) -> Task | None:
     # #769 audit: match any accepted phase spelling (short verb or
     # gerund) via the shared SSOT helper, not a raw ``phase=phase``
     # filter that would miss a short-verb ``code`` task and let the
     # orchestrator create a duplicate.
-    return Task.objects.pending_in_phase(phase).filter(ticket=ticket).exists()
+    return Task.objects.pending_in_phase(phase).filter(ticket=ticket).first()
+
+
+def _has_open_task(ticket: Ticket, *, phase: str) -> bool:
+    return _open_task_in_phase(ticket, phase=phase) is not None
 
 
 def _get_or_create_ticket(

--- a/src/teatree/loop/scanners/active_tickets.py
+++ b/src/teatree/loop/scanners/active_tickets.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, cast
 
 from django.apps import apps
 
+from teatree.core.modelkit.phases import SHORT_DESCRIBE_PHASE
 from teatree.loop.scanners.base import ScanSignal
 
 logger = logging.getLogger(__name__)
@@ -92,7 +93,7 @@ def _enqueue_short_describe(ticket: "Ticket") -> None:
 
     existing = Task.objects.filter(
         ticket=ticket,
-        phase="short_describe",
+        phase=SHORT_DESCRIBE_PHASE,
         status__in=[Task.Status.PENDING, Task.Status.CLAIMED, Task.Status.COMPLETED],
     )
     if existing.exists():
@@ -101,7 +102,7 @@ def _enqueue_short_describe(ticket: "Ticket") -> None:
     Task.objects.create(
         ticket=ticket,
         session=session,
-        phase="short_describe",
+        phase=SHORT_DESCRIBE_PHASE,
         execution_target=Task.ExecutionTarget.HEADLESS,
         subject=f"Summarize #{ticket.ticket_number}",
         execution_reason="Auto-scheduled short_describe — generate terminal-friendly ticket summary",

--- a/src/teatree/loop/scanners/assigned_issues.py
+++ b/src/teatree/loop/scanners/assigned_issues.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, cast
 from django.apps import apps
 
 from teatree.core.backend_protocols import CodeHostBackend
+from teatree.core.intake.label_admission import intake_admits
 from teatree.loop.scanners.base import ScanSignal
 from teatree.types import RawAPIDict
 
@@ -108,9 +109,7 @@ class AssignedIssuesScanner:
         signals: list[ScanSignal] = []
         for issue in issues:
             labels = _issue_labels(issue)
-            if self.ready_labels and not any(label in labels for label in self.ready_labels):
-                continue
-            if self.exclude_labels and any(label in labels for label in self.exclude_labels):
+            if not intake_admits(labels, self.ready_labels, self.exclude_labels):
                 continue
             url = _issue_url(issue)
             if url and url in tracked:

--- a/src/teatree/loop/scanners/backlog_sweep.py
+++ b/src/teatree/loop/scanners/backlog_sweep.py
@@ -45,6 +45,7 @@ from django.db import transaction
 from django.db.models import Max
 from django.utils import timezone
 
+from teatree.core.modelkit.phases import BACKLOG_SWEEP_PHASE
 from teatree.loop.scanners.base import ScanSignal, hours_since
 
 if TYPE_CHECKING:
@@ -54,8 +55,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-#: Canonical phase token written to ``Task.phase`` for backlog-sweep tasks.
-BACKLOG_SWEEP_PHASE = "backlog_sweep"
+#: Canonical phase token written to ``Task.phase`` for backlog-sweep tasks. Owned by the
+#: canonical phase vocabulary and re-exported here, so the phase can never exist without
+#: a declared ``SCANNER_DISPATCHED_PHASES`` producer + tool-least-privilege entry.
 
 #: States that mean a sweep task is still in-flight (cannot queue a dupe).
 _IN_FLIGHT_TASK_STATES: frozenset[str] = frozenset({"pending", "claimed"})

--- a/src/teatree/loop/scanners/eval_local.py
+++ b/src/teatree/loop/scanners/eval_local.py
@@ -37,6 +37,7 @@ from django.db import transaction
 from django.db.models import Max
 from django.utils import timezone
 
+from teatree.core.modelkit.phases import EVAL_LOCAL_PHASE
 from teatree.loop.scanners.base import ScanSignal, hours_since
 
 if TYPE_CHECKING:
@@ -46,8 +47,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-#: Canonical phase token written to ``Task.phase`` for local-eval tasks.
-EVAL_LOCAL_PHASE = "eval_local"
+#: Canonical phase token written to ``Task.phase`` for local-eval tasks. Owned by the
+#: canonical phase vocabulary and re-exported here, so the phase can never exist without
+#: a declared ``SCANNER_DISPATCHED_PHASES`` producer + tool-least-privilege entry.
 
 #: States that mean an eval task is still in-flight (cannot queue a dupe).
 _IN_FLIGHT_TASK_STATES: frozenset[str] = frozenset({"pending", "claimed"})

--- a/src/teatree/utils/ram_probe.py
+++ b/src/teatree/utils/ram_probe.py
@@ -17,6 +17,7 @@ instead of a baked-in 3-core cap that made host-derived concurrency a no-op.
 
 import os
 import platform
+import re
 import sys
 
 # Reserve for the light sibling containers (admin 512m + slack-listener 512m +
@@ -27,6 +28,29 @@ _SIBLING_RESERVE_MIB = 1280
 _HOST_HEADROOM = 0.8
 # Never cap the worker below 2 GiB even on a tiny host (a single headless run needs it).
 _WORKER_MIN_MIB = 2048
+# ``vm_stat`` states its own page size on the header line; only fall back to the
+# Intel-era 4 KiB when that line cannot be read (see :func:`_macos_page_size`).
+_VM_STAT_PAGE_SIZE_RE = re.compile(r"page size of (\d+) bytes")
+_DEFAULT_PAGE_SIZE = 4096
+
+
+def _macos_page_size(vm_stat_output: str) -> int:
+    """Page size (bytes) declared by ``vm_stat``'s header, or 4096 when unreadable.
+
+    Not a constant: Apple Silicon uses 16384-byte pages where Intel used 4096,
+    and ``vm_stat`` reports page COUNTS. Assuming 4 KiB on an arm64 Mac scales
+    the reclaimable total (free + inactive pages) down 4x, so a 24 GiB host with
+    ~7 GB free reads back as ~93% used instead of ~70%. That phantom pressure
+    made :func:`teatree.core.gates.provision_admission_gate.check_provision_admission`
+    hold every ``worktree start`` against its 85% ceiling. ``vm_stat`` states the
+    real size on its first line, so read it rather than guess.
+
+    The 4096 fallback keeps an unparsable header on the historical arithmetic
+    instead of raising — consistent with this module degrading rather than
+    crashing a caller.
+    """
+    match = _VM_STAT_PAGE_SIZE_RE.search(vm_stat_output)
+    return int(match.group(1)) if match else _DEFAULT_PAGE_SIZE
 
 
 def _macos_ram_used_percent() -> float:
@@ -46,7 +70,7 @@ def _macos_ram_used_percent() -> float:
         stat = run_checked([vm_stat], timeout=2).stdout
     except (CommandFailedError, ValueError, OSError, TimeoutError):
         return 0.0
-    page_size, free_pages, inactive_pages = 4096, 0, 0
+    page_size, free_pages, inactive_pages = _macos_page_size(stat), 0, 0
     for line in stat.splitlines():
         if line.startswith("Pages free:"):
             free_pages = int(line.split(":")[1].strip().rstrip("."))

--- a/tests/config/test_overlay_discovery.py
+++ b/tests/config/test_overlay_discovery.py
@@ -144,6 +144,35 @@ def test_discover_active_overlay_folds_deploy_dirname_to_sole_overlay(
     assert result.project_path == project
 
 
+def test_discover_active_overlay_canonicalizes_via_settings_module(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A clone dir matching no entry point resolves through its settings module.
+
+    ``acme-factory`` matches neither ``t3-acme`` exactly nor the dash-suffix
+    alias rule, and the sole-overlay fallback cannot fire with two installed —
+    so pre-fix the raw basename leaked out as an undispatchable overlay anchor.
+    ``acme.settings`` names the Django project that IS the overlay.
+    """
+    project = tmp_path / "acme-factory"
+    _write_manage_py(project, "acme.settings")
+    monkeypatch.chdir(project)
+
+    ep_acme = MagicMock()
+    ep_acme.name = "t3-acme"
+    ep_acme.value = "acme_overlay.overlay:AcmeOverlay"
+    ep_teatree = MagicMock()
+    ep_teatree.name = "t3-teatree"
+    ep_teatree.value = "t3_teatree.overlay:TeatreeOverlay"
+
+    with patch("importlib.metadata.entry_points", return_value=[ep_acme, ep_teatree]):
+        result = discover_active_overlay()
+
+    assert result is not None
+    assert result.name == "t3-acme"
+    assert result.project_path == project
+
+
 def test_discover_active_overlay_dirname_kept_raw_when_multiple_overlays(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/teatree_backends/gitlab/test_sync_issues.py
+++ b/tests/teatree_backends/gitlab/test_sync_issues.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 from django.test import TestCase
 
 from teatree.backends.gitlab.sync_issues import fetch_assigned_issues
+from teatree.core.intake.label_admission import LabelPolicy
 from teatree.core.models import Ticket
 from teatree.types import SyncResult
 
@@ -55,3 +56,44 @@ class TestGitLabAssignedIssueSyncClassifiesKind(TestCase):
             labels=["debug"],
         )
         assert ticket.kind == Ticket.Kind.FEATURE
+
+
+class TestGitLabAssignedIssueSyncHonoursTheLabelGate(TestCase):
+    """The second intake answers to the same allowlist as the ``assigned_issues`` scanner.
+
+    Assignment alone is not a nomination — an issue the operator never labelled
+    ready must not become a Ticket row here just because it is assigned.
+    """
+
+    URL = "https://gitlab.com/o/r/-/issues/720"
+
+    def _sync(self, *, labels: list[str], ready: tuple[str, ...], exclude: tuple[str, ...] = ()) -> None:
+        host = MagicMock()
+        host.list_assigned_issues.return_value = [{"web_url": self.URL, "title": "Some issue", "labels": labels}]
+        fetch_assigned_issues(
+            host,
+            "me",
+            SyncResult(),
+            overlay_name="acme",
+            label_policy=LabelPolicy(ready_labels=ready, exclude_labels=exclude),
+        )
+
+    def test_issue_without_a_ready_label_creates_no_ticket(self) -> None:
+        self._sync(labels=["backend"], ready=("ready-for-dev",))
+
+        assert not Ticket.objects.filter(issue_url=self.URL).exists()
+
+    def test_issue_with_a_ready_label_creates_a_ticket(self) -> None:
+        self._sync(labels=["ready-for-dev"], ready=("ready-for-dev",))
+
+        assert Ticket.objects.filter(issue_url=self.URL).exists()
+
+    def test_excluded_issue_creates_no_ticket(self) -> None:
+        self._sync(labels=["ready-for-dev", "blocked"], ready=("ready-for-dev",), exclude=("blocked",))
+
+        assert not Ticket.objects.filter(issue_url=self.URL).exists()
+
+    def test_empty_allowlist_still_admits_everything(self) -> None:
+        self._sync(labels=["backend"], ready=())
+
+        assert Ticket.objects.filter(issue_url=self.URL).exists()

--- a/tests/teatree_core/intake/test_label_admission.py
+++ b/tests/teatree_core/intake/test_label_admission.py
@@ -1,0 +1,51 @@
+"""The shared label gate every issue-intake path runs before creating work."""
+
+from teatree.core.intake.label_admission import LabelPolicy, intake_admits
+
+READY = ("ready-for-dev",)
+EXCLUDE = ("blocked",)
+
+
+class TestEmptyAllowlistAdmitsEverything:
+    def test_no_policy_at_all_admits(self) -> None:
+        assert intake_admits(["anything"], (), ()) is True
+
+    def test_no_labels_and_no_policy_admits(self) -> None:
+        assert intake_admits([], (), ()) is True
+
+    def test_empty_ready_labels_admits_an_unlabelled_issue(self) -> None:
+        assert intake_admits([], (), EXCLUDE) is True
+
+
+class TestAllowlist:
+    def test_admits_when_a_ready_label_is_present(self) -> None:
+        assert intake_admits(["ready-for-dev", "backend"], READY, ()) is True
+
+    def test_refuses_when_no_ready_label_is_present(self) -> None:
+        assert intake_admits(["backend"], READY, ()) is False
+
+    def test_refuses_an_unlabelled_issue(self) -> None:
+        assert intake_admits([], READY, ()) is False
+
+
+class TestDenylist:
+    def test_refuses_when_an_exclude_label_is_present(self) -> None:
+        assert intake_admits(["ready-for-dev", "blocked"], READY, EXCLUDE) is False
+
+    def test_denylist_applies_without_an_allowlist(self) -> None:
+        assert intake_admits(["blocked"], (), EXCLUDE) is False
+
+    def test_admits_when_ready_and_not_excluded(self) -> None:
+        assert intake_admits(["ready-for-dev"], READY, EXCLUDE) is True
+
+
+class TestLabelPolicyCarriesTheSameDecision:
+    def test_default_policy_admits_everything(self) -> None:
+        assert LabelPolicy().admits(["anything"]) is True
+
+    def test_policy_delegates_to_the_shared_predicate(self) -> None:
+        policy = LabelPolicy(ready_labels=READY, exclude_labels=EXCLUDE)
+
+        assert policy.admits(["ready-for-dev"]) is True
+        assert policy.admits(["backend"]) is False
+        assert policy.admits(["ready-for-dev", "blocked"]) is False

--- a/tests/teatree_core/management/test_loop_schedule_command.py
+++ b/tests/teatree_core/management/test_loop_schedule_command.py
@@ -1,4 +1,4 @@
-"""``manage.py loop_schedule`` — list/show/set-active/clear-active against a real DB."""
+"""``manage.py loop_schedule`` — list/show/set-active/set-timezone/clear-active against a real DB."""
 
 import datetime as dt
 import io
@@ -54,3 +54,58 @@ class TestLoopScheduleCommand(django.test.TestCase):
         payload = json.loads(_run("show", "standard", json_output=True))
         assert payload["slots"][0]["preset"] == "engaged"
         assert payload["slots"][0]["start_time"] == "08:00"
+
+
+@django.test.override_settings(USE_TZ=True, TIME_ZONE="UTC")
+class TestSetTimezone(django.test.TestCase):
+    def _seeded(self) -> ModeSchedule:
+        """A schedule as ``preset_seed`` leaves it: no timezone, so slots resolve in UTC."""
+        return ModeSchedule.objects.create(name="standard", timezone="")
+
+    def test_writes_the_zone(self) -> None:
+        schedule = self._seeded()
+
+        _run("set-timezone", "standard", "Europe/Vienna")
+
+        schedule.refresh_from_db()
+        assert schedule.timezone == "Europe/Vienna"
+
+    def test_refuses_an_unknown_zone_without_writing(self) -> None:
+        schedule = self._seeded()
+
+        with pytest.raises(SystemExit):
+            _run("set-timezone", "standard", "Mars/Olympus_Mons")
+
+        schedule.refresh_from_db()
+        assert schedule.timezone == ""
+
+    def test_refuses_an_unknown_schedule(self) -> None:
+        with pytest.raises(SystemExit):
+            _run("set-timezone", "ghost", "Europe/Vienna")
+
+    def test_json_output_reports_the_written_zone(self) -> None:
+        self._seeded()
+
+        payload = json.loads(_run("set-timezone", "standard", "Europe/Vienna", json_output=True))
+
+        assert payload == {"name": "standard", "timezone": "Europe/Vienna"}
+
+
+@django.test.override_settings(USE_TZ=True, TIME_ZONE="UTC")
+class TestUnsetTimezoneRendersHonestly(django.test.TestCase):
+    """An empty timezone means the project zone, not the operator's local one."""
+
+    def test_list_names_the_project_zone(self) -> None:
+        ModeSchedule.objects.create(name="standard", timezone="")
+
+        assert "tz=UTC (default)" in _run("list")
+
+    def test_show_names_the_project_zone(self) -> None:
+        ModeSchedule.objects.create(name="standard", timezone="")
+
+        assert "tz=UTC (default)" in _run("show", "standard")
+
+    def test_an_explicit_zone_is_rendered_as_is(self) -> None:
+        ModeSchedule.objects.create(name="standard", timezone="Europe/Vienna")
+
+        assert "tz=Europe/Vienna" in _run("list")

--- a/tests/teatree_core/management_commands/test_deterministic_phases.py
+++ b/tests/teatree_core/management_commands/test_deterministic_phases.py
@@ -1,0 +1,77 @@
+"""The headless worker runs non-agentic phases deterministically, not as an agent spawn.
+
+``short_describe`` is a fixed text transformation over the ``Ticket`` row, so it is
+routed to its own runner rather than handed a ticket-work brief its empty toolset
+cannot satisfy. Every other phase resolves to ``None`` (dispatches agentically).
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from teatree.core.management.commands._deterministic_phases import deterministic_phase_runner, run_deterministic_phase
+from teatree.core.models import Session, Task, Ticket
+
+_SUMMARIZE = "teatree.core.management.commands.ticket_short_describe._summarize"
+_RUNNERS = "teatree.core.management.commands._deterministic_phases._RUNNERS"
+
+
+def _short_describe_task(title: str = "add dark mode toggle") -> Task:
+    ticket = Ticket.objects.create(overlay="t3-teatree", extra={"issue_title": title})
+    session = Session.objects.create(ticket=ticket, agent_id="short-describe")
+    return Task.objects.create(ticket=ticket, session=session, phase="short_describe")
+
+
+class TestDeterministicPhaseRunner(TestCase):
+    def test_short_describe_resolves_to_a_runner(self) -> None:
+        assert deterministic_phase_runner("short_describe") is not None
+
+    def test_an_agentic_phase_resolves_to_none(self) -> None:
+        assert deterministic_phase_runner("coding") is None
+
+    def test_short_describe_runner_writes_the_summary(self) -> None:
+        task = _short_describe_task()
+        runner = deterministic_phase_runner(task.phase)
+        assert runner is not None
+
+        with patch(_SUMMARIZE, return_value="dark mode toggle"):
+            outcome = runner(task)
+
+        task.ticket.refresh_from_db()
+        assert task.ticket.short_description == "dark mode toggle"
+        assert str(task.ticket.pk) in outcome
+
+
+class TestRunDeterministicPhase(TestCase):
+    def test_agentic_phase_returns_none(self) -> None:
+        task = _short_describe_task()
+        task.phase = "coding"
+
+        assert run_deterministic_phase(task) is None
+
+    def test_success_records_a_completed_attempt(self) -> None:
+        task = _short_describe_task()
+
+        with patch(_SUMMARIZE, return_value="dark mode toggle"):
+            result = run_deterministic_phase(task)
+
+        assert result is not None
+        assert result["exit_code"] == "0"
+        task.refresh_from_db()
+        assert task.status == Task.Status.COMPLETED
+
+    def test_a_raising_runner_records_a_failed_attempt_and_does_not_escape(self) -> None:
+        task = _short_describe_task()
+
+        def _boom(_task: Task) -> str:
+            message = "kaboom"
+            raise RuntimeError(message)
+
+        with patch(_RUNNERS, {"short_describe": _boom}):
+            result = run_deterministic_phase(task)
+
+        assert result is not None
+        assert result["exit_code"] == "1"
+        assert "kaboom" in result["phase_error"]
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED

--- a/tests/teatree_core/management_commands/test_ticket_short_describe.py
+++ b/tests/teatree_core/management_commands/test_ticket_short_describe.py
@@ -18,10 +18,10 @@ from django.test import TestCase
 from teatree.core.management.commands.ticket_short_describe import (
     _FALLBACK_LEN,
     _describe_all_missing,
-    _describe_one,
     _generate_short_description,
     _summarize,
     _truncation_fallback,
+    describe_ticket,
 )
 from teatree.core.models import Ticket
 
@@ -126,14 +126,14 @@ class TestDescribeOne(TestCase):
     def test_missing_ticket_emits_noop_and_exits_one(self) -> None:
         captured: list[str] = []
         with pytest.raises(SystemExit) as excinfo:
-            _describe_one(99999, stdout_write=captured.append)
+            describe_ticket(99999, stdout_write=captured.append)
         assert excinfo.value.code == 1
         assert any("no ticket with id=99999" in line for line in captured)
 
     def test_ticket_without_title_is_noop(self) -> None:
         ticket = Ticket.objects.create(overlay="t3-teatree", extra={})
         captured: list[str] = []
-        _describe_one(ticket.pk, stdout_write=captured.append)
+        describe_ticket(ticket.pk, stdout_write=captured.append)
         assert any("has no extra['issue_title']" in line for line in captured)
         ticket.refresh_from_db()
         assert ticket.short_description == ""
@@ -145,7 +145,7 @@ class TestDescribeOne(TestCase):
         )
         captured: list[str] = []
         with patch(_SUMMARIZE, return_value="dogfood smoke scanner"):
-            _describe_one(ticket.pk, stdout_write=captured.append)
+            describe_ticket(ticket.pk, stdout_write=captured.append)
         ticket.refresh_from_db()
         assert ticket.short_description == "dogfood smoke scanner"
 
@@ -201,7 +201,7 @@ class TestCommandDescribeMethod(TestCase):
             cmd.describe(ticket_id=0, all_missing=False)
         assert excinfo.value.code == 2
 
-    def test_describe_with_ticket_id_calls_describe_one(self) -> None:
+    def test_describe_with_ticket_id_calls_describe_ticket(self) -> None:
         cmd = self._command()
         ticket = Ticket.objects.create(
             overlay="t3-teatree",

--- a/tests/teatree_core/modelkit/test_scanner_phase_tool_registry.py
+++ b/tests/teatree_core/modelkit/test_scanner_phase_tool_registry.py
@@ -1,0 +1,112 @@
+"""Every phase a loop SCANNER writes to ``Task.phase`` must carry an explicit tool entry.
+
+The #3386 totality lane (``tests/conformance/test_registry_parity.py``) derives its
+producer set from the HAND-MAINTAINED ``SCANNER_DISPATCHED_PHASES`` literal, so it can
+only see a scanner phase somebody remembered to add there. Three did not get added —
+``short_describe`` (a bare literal in ``active_tickets.py``, no constant at all),
+``eval_local`` and ``backlog_sweep`` — so ``tools_for_phase`` resolved them through the
+deny-by-default read-only fallback and Lane A injected ``Bash``/``Write``/``Edit`` into
+``ClaudeAgentOptions.disallowed_tools``. Their briefs still told them to run ``git log``
+and ``t3 tool verify-gates``, so every dispatch stalled on an unanswerable question.
+
+This lane derives the producer set from the scanner SOURCE instead of a literal: it AST-
+walks ``teatree/loop/scanners/`` for the ``phase=`` keyword of every task creation and
+resolves each token against the imported module (so a token reached through an imported
+constant resolves as readily as a bare literal). A new scanner therefore cannot slip
+through by forgetting to update a set — which is exactly how all three of these did.
+"""
+
+import ast
+import importlib
+from pathlib import Path
+from types import ModuleType
+
+from django.test import TestCase
+
+import teatree.loop.scanners as scanners_pkg
+from teatree.agents._headless_options import _disallowed_tools_for_phase
+from teatree.core.modelkit.phase_tools import _TOOLS_BY_PHASE, tools_for_phase
+from teatree.core.modelkit.phases import SCANNER_DISPATCHED_PHASES, SUBAGENT_BY_PHASE, normalize_phase
+
+_SCANNER_DIR = Path(scanners_pkg.__file__).parent
+
+
+def _resolve(node: ast.expr, module: ModuleType) -> str:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name):
+        value = getattr(module, node.id, None)
+        return value if isinstance(value, str) else ""
+    if isinstance(node, ast.Attribute):
+        value = getattr(getattr(module, getattr(node.value, "id", ""), None), node.attr, None)
+        return value if isinstance(value, str) else ""
+    return ""
+
+
+def _phase_tokens_in(module: ModuleType) -> set[str]:
+    tree = ast.parse(Path(module.__file__ or "").read_text(encoding="utf-8"))
+    tokens = {
+        _resolve(keyword.value, module)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        for keyword in node.keywords
+        if keyword.arg == "phase"
+    }
+    return tokens - {""}
+
+
+def _scanner_dispatched_phase_tokens() -> set[str]:
+    tokens: set[str] = set()
+    for path in sorted(_SCANNER_DIR.glob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        tokens |= _phase_tokens_in(importlib.import_module(f"{scanners_pkg.__name__}.{path.stem}"))
+    return tokens
+
+
+class TestScannerDispatchedPhasesCarryExplicitToolEntries(TestCase):
+    def test_the_source_scan_actually_finds_scanner_phases(self) -> None:
+        # Control: a derivation that silently found nothing would make every
+        # assertion below vacuously green. Both a bare-literal phase
+        # (``short_describe``) and an imported-constant phase
+        # (``architectural_review``) must resolve, or the scan has a blind spot.
+        found = _scanner_dispatched_phase_tokens()
+        assert {"short_describe", "architectural_review", "dogfood_smoke"} <= found, found
+
+    def test_every_scanner_written_phase_has_an_explicit_tool_entry(self) -> None:
+        missing = sorted(
+            phase for phase in _scanner_dispatched_phase_tokens() if normalize_phase(phase) not in _TOOLS_BY_PHASE
+        )
+        assert not missing, (
+            f"scanner-dispatched phase(s) {missing} resolve through the deny-by-default "
+            "read-only fallback, so Lane A denies Bash/Write/Edit on every dispatch"
+        )
+
+    def test_every_scanner_written_phase_is_a_producer_the_totality_lane_sees(self) -> None:
+        # A phase is visible to the #3386 lane through EITHER route: the scanner
+        # set, or a ``(role, phase)`` dispatch row. Absent from both, its tool
+        # entry is unguarded and a later edit can silently drop it again.
+        visible = {normalize_phase(phase) for phase in SCANNER_DISPATCHED_PHASES} | {
+            normalize_phase(phase) for _role, phase in SUBAGENT_BY_PHASE
+        }
+        invisible = sorted(
+            phase for phase in _scanner_dispatched_phase_tokens() if normalize_phase(phase) not in visible
+        )
+        assert not invisible, f"{invisible} are producers no totality lane covers"
+
+    def test_eval_local_can_run_the_eval_suite_shell(self) -> None:
+        tools = tools_for_phase("eval_local")
+        assert {"shell", "read_file"} <= tools
+        assert "write_file" not in tools
+
+
+class TestHeadlessSpawnKeepsItsShell(TestCase):
+    def test_scanner_dispatched_shell_phase_is_not_denied_bash(self) -> None:
+        assert "Bash" not in _disallowed_tools_for_phase("eval_local")
+
+    def test_summariser_phase_is_never_granted_write_tools(self) -> None:
+        # ``short_describe`` produces a <=40 char string; granting it the shell
+        # would turn ~300 summarisation dispatches a day into autonomous
+        # ticket-implementation agents.
+        denied = _disallowed_tools_for_phase("short_describe")
+        assert {"Write", "Edit", "Bash"} <= set(denied)

--- a/tests/teatree_core/models/test_scanned_broadcast.py
+++ b/tests/teatree_core/models/test_scanned_broadcast.py
@@ -1,0 +1,111 @@
+"""Tests for :class:`ScannedBroadcast` — the review-broadcast ledger and its emission gate.
+
+The ledger key ``(channel, slack_ts)`` makes re-scanning safe. What it must
+NOT do is double as the emission gate: a broadcast whose reviewer task was
+never created, was deleted, or FAILED is a review that never reached anyone,
+and it has to be re-emitted. ``awaiting_reviewer_dispatch`` is that gate.
+"""
+
+from django.test import TestCase
+
+from teatree.core.models import BroadcastObservation, ScannedBroadcast, Session, Task, Ticket
+
+CHANNEL = "C0DEMOCHAN1"
+TS = "1779201478.501469"
+MR_OPEN = "https://gitlab.example.com/team/project/-/merge_requests/7432"
+
+
+def _observe(classification: str = ScannedBroadcast.Classification.PENDING) -> BroadcastObservation:
+    return BroadcastObservation(
+        channel=CHANNEL,
+        slack_ts=TS,
+        mr_urls=[MR_OPEN],
+        classification=classification,
+        overlay="teatree",
+    )
+
+
+def _reviewer_task(status: Task.Status = Task.Status.PENDING) -> Task:
+    ticket = Ticket.objects.create(issue_url=MR_OPEN, role=Ticket.Role.REVIEWER, overlay="teatree")
+    session = Session.objects.create(ticket=ticket, agent_id="t3:reviewer")
+    return Task.objects.create(ticket=ticket, session=session, phase="reviewing", status=status)
+
+
+class TestEmissionIsNotGatedOnLedgerNovelty(TestCase):
+    def test_seen_row_without_reviewer_task_re_emits(self) -> None:
+        first = ScannedBroadcast.record(_observe())
+        assert first is not None
+
+        assert ScannedBroadcast.record(_observe()) is not None
+
+    def test_seen_row_with_live_reviewer_task_does_not_re_emit(self) -> None:
+        row = ScannedBroadcast.record(_observe())
+        assert row is not None
+        row.attach_reviewer_task(str(_reviewer_task().pk))
+
+        assert ScannedBroadcast.record(_observe()) is None
+
+    def test_seen_row_with_completed_reviewer_task_does_not_re_emit(self) -> None:
+        """A finished review is covered — re-emitting would re-review every tick.
+
+        The broadcast signal carries no head SHA, so the downstream
+        ``_already_reviewed_at_head`` dedup fails open and cannot suppress it.
+        """
+        row = ScannedBroadcast.record(_observe())
+        assert row is not None
+        row.attach_reviewer_task(str(_reviewer_task(Task.Status.COMPLETED).pk))
+
+        assert ScannedBroadcast.record(_observe()) is None
+
+    def test_seen_row_with_failed_reviewer_task_re_emits(self) -> None:
+        row = ScannedBroadcast.record(_observe())
+        assert row is not None
+        row.attach_reviewer_task(str(_reviewer_task(Task.Status.FAILED).pk))
+
+        assert ScannedBroadcast.record(_observe()) is not None
+
+    def test_seen_row_whose_reviewer_task_was_deleted_re_emits(self) -> None:
+        row = ScannedBroadcast.record(_observe())
+        assert row is not None
+        task = _reviewer_task()
+        row.attach_reviewer_task(str(task.pk))
+        task.delete()
+
+        assert ScannedBroadcast.record(_observe()) is not None
+
+    def test_all_merged_row_never_re_emits(self) -> None:
+        merged = _observe(ScannedBroadcast.Classification.ALL_MERGED)
+        assert ScannedBroadcast.record(merged) is not None
+
+        assert ScannedBroadcast.record(merged) is None
+
+    def test_sticky_manual_classification_still_suppresses(self) -> None:
+        row = ScannedBroadcast.record(_observe())
+        assert row is not None
+        row.mark_manually_classified(ScannedBroadcast.Classification.PENDING)
+
+        assert ScannedBroadcast.record(_observe()) is None
+
+    def test_classification_change_still_returns_the_row(self) -> None:
+        assert ScannedBroadcast.record(_observe()) is not None
+
+        upgraded = ScannedBroadcast.record(_observe(ScannedBroadcast.Classification.ALL_MERGED))
+
+        assert upgraded is not None
+        assert upgraded.classification == ScannedBroadcast.Classification.ALL_MERGED
+        assert upgraded.reclassified_at is not None
+
+
+class TestAwaitingReviewerDispatch(TestCase):
+    def test_pending_row_with_no_task_id_is_awaiting(self) -> None:
+        row = ScannedBroadcast.record(_observe())
+        assert row is not None
+
+        assert row.awaiting_reviewer_dispatch is True
+
+    def test_pending_row_with_non_numeric_task_id_is_awaiting(self) -> None:
+        row = ScannedBroadcast.record(_observe())
+        assert row is not None
+        row.attach_reviewer_task("not-a-pk")
+
+        assert row.awaiting_reviewer_dispatch is True

--- a/tests/teatree_core/test_e2e_frontend_discovery.py
+++ b/tests/teatree_core/test_e2e_frontend_discovery.py
@@ -1,11 +1,49 @@
+import socket
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
-from teatree.core.management.commands._e2e_discovery import resolve_linked_worktree
+from teatree.core.management.commands._e2e_discovery import detect_local_port, resolve_linked_worktree
 from teatree.core.management.commands.e2e import _ticket_frontend_projects
 from teatree.core.models import Ticket, Worktree
 from teatree.core.worktree.worktree_env import compose_project
+
+
+class LocalPortDetectionTests(SimpleTestCase):
+    """The local-port scan must see a listener on either loopback family."""
+
+    @staticmethod
+    def _listener(family: int, address: str) -> socket.socket:
+        """An OS-assigned listening socket bound to *address* only."""
+        server = socket.socket(family, socket.SOCK_STREAM)
+        server.bind((address, 0))
+        server.listen(1)
+        return server
+
+    def test_detects_ipv6_only_listener(self) -> None:
+        # `nx serve` binds ::1 only on an IPv6-preferring host, so an
+        # IPv4-only probe aborts `e2e external` with "Frontend not running"
+        # while the dev server is happily serving on [::1]:4200.
+        if not socket.has_ipv6:
+            self.skipTest("interpreter built without IPv6 support")
+        try:
+            server = self._listener(socket.AF_INET6, "::1")
+        except OSError:
+            self.skipTest("host has no IPv6 loopback")
+        with server:
+            port = server.getsockname()[1]
+            assert detect_local_port(port) == port
+
+    def test_detects_ipv4_only_listener(self) -> None:
+        with self._listener(socket.AF_INET, "127.0.0.1") as server:
+            port = server.getsockname()[1]
+            assert detect_local_port(port) == port
+
+    def test_returns_none_when_nothing_listens(self) -> None:
+        with self._listener(socket.AF_INET, "127.0.0.1") as server:
+            port = server.getsockname()[1]
+        # The listener is closed now, so its port is free again.
+        assert detect_local_port(port) is None
 
 
 class TicketFrontendProjectsTests(TestCase):

--- a/tests/teatree_loop/test_persistence.py
+++ b/tests/teatree_loop/test_persistence.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from teatree.core.backend_protocols import ReviewState
-from teatree.core.models import ImplementedIssueMarker, Task, Ticket
+from teatree.core.models import BroadcastObservation, ImplementedIssueMarker, ScannedBroadcast, Task, Ticket
 from teatree.loop.dispatch import DispatchAction
 from teatree.loop.persistence import persist_agent_actions
 from tests.factories import ImplementedIssueMarkerFactory
@@ -55,6 +55,46 @@ class TestPersistReviewer(TestCase):
         # Open reviewing task already exists → no new Task created.
         assert second == []
         assert Task.objects.filter(ticket__issue_url=action.payload["url"]).count() == 1
+
+    def test_links_the_reviewer_task_back_to_its_broadcast_row(self) -> None:
+        """The broadcast ledger learns which task covers it, closing its emission gate."""
+        row = ScannedBroadcast.record(
+            BroadcastObservation(
+                channel="C0DEMOCHAN1",
+                slack_ts="1779201478.501469",
+                mr_urls=["https://example.com/owner/repo/pull/42"],
+                classification=ScannedBroadcast.Classification.PENDING,
+            )
+        )
+        assert row is not None
+        action = self._action()
+        action.payload["broadcast_id"] = row.pk
+
+        created = persist_agent_actions([action])
+
+        row.refresh_from_db()
+        assert row.reviewer_task_id == str(created[0].pk)
+        assert row.awaiting_reviewer_dispatch is False
+
+    def test_links_an_already_open_reviewer_task_back_to_its_broadcast_row(self) -> None:
+        """A re-emitted broadcast whose review is already in flight still converges."""
+        action = self._action()
+        first = persist_agent_actions([action])
+        row = ScannedBroadcast.record(
+            BroadcastObservation(
+                channel="C0DEMOCHAN1",
+                slack_ts="1779201499.123456",
+                mr_urls=["https://example.com/owner/repo/pull/42"],
+                classification=ScannedBroadcast.Classification.PENDING,
+            )
+        )
+        assert row is not None
+        action.payload["broadcast_id"] = row.pk
+
+        assert persist_agent_actions([action]) == []
+
+        row.refresh_from_db()
+        assert row.reviewer_task_id == str(first[0].pk)
 
     def test_updates_reviewed_sha_when_author_pushes(self) -> None:
         first = self._action(head_sha="abc123")

--- a/tests/teatree_loop/test_slack_broadcasts_scanner.py
+++ b/tests/teatree_loop/test_slack_broadcasts_scanner.py
@@ -21,7 +21,7 @@ import pytest
 from django.db import OperationalError
 from django.test import TestCase
 
-from teatree.core.models import ScannedBroadcast
+from teatree.core.models import ScannedBroadcast, Session, Task, Ticket
 from teatree.loop.scanners.slack_broadcast_mr_classifier import GlabGhMrStateClassifier
 from teatree.loop.scanners.slack_broadcasts import ConnectChannelBotRestrictedError, MrState, SlackBroadcastsScanner
 from teatree.types import RawAPIDict
@@ -429,26 +429,50 @@ class TestSkipsBroadcastsAlreadyEyesReactedByColleague(TestCase):
 
 
 class TestIdempotency(TestCase):
-    def test_idempotent_rescan_is_a_noop(self) -> None:
-        backend = FakeMessaging()
-        history = {CHANNEL: [_message(f"{MR_OPEN}", TS_A)]}
-        states = {MR_OPEN: MrState(url=MR_OPEN, merged=False, approved=False)}
-        scanner = SlackBroadcastsScanner(
+    def _pending_scanner(self, backend: FakeMessaging) -> SlackBroadcastsScanner:
+        return SlackBroadcastsScanner(
             backend=backend,
             channels=[CHANNEL],
-            fetch_channel_history=_fetcher(history),
-            classify_mrs=_classifier(states),
+            fetch_channel_history=_fetcher({CHANNEL: [_message(f"{MR_OPEN}", TS_A)]}),
+            classify_mrs=_classifier({MR_OPEN: MrState(url=MR_OPEN, merged=False, approved=False)}),
         )
+
+    def test_rescan_reuses_the_single_ledger_row(self) -> None:
+        backend = FakeMessaging()
+        scanner = self._pending_scanner(backend)
+
+        scanner.scan()
+        scanner.scan()
+
+        # No discovery-time claim reaction on either scan (#113/#86).
+        assert backend.react_calls == []
+        assert ScannedBroadcast.objects.filter(channel=CHANNEL, slack_ts=TS_A).count() == 1
+
+    def test_rescan_re_emits_while_no_reviewer_task_covers_the_row(self) -> None:
+        """The ledger is the dedup key, not the emission gate.
+
+        A dispatch lost before a reviewer task existed — dead worker, exhausted
+        budget, a stopped review loop — would otherwise make this review
+        permanently unreachable. Duplicate work is prevented downstream, where
+        ``persist_agent_actions`` reuses the open reviewing Task.
+        """
+        scanner = self._pending_scanner(FakeMessaging())
 
         first = scanner.scan()
         second = scanner.scan()
 
         assert len(first) == 1
-        assert second == []
-        # No discovery-time claim reaction on either scan (#113/#86); the
-        # second scan no-ops on the idempotency row.
-        assert backend.react_calls == []
-        assert ScannedBroadcast.objects.filter(channel=CHANNEL, slack_ts=TS_A).count() == 1
+        assert [signal.payload["mr_url"] for signal in second] == [MR_OPEN]
+
+    def test_rescan_stops_emitting_once_a_reviewer_task_covers_the_row(self) -> None:
+        scanner = self._pending_scanner(FakeMessaging())
+        scanner.scan()
+        row = ScannedBroadcast.objects.get(channel=CHANNEL, slack_ts=TS_A)
+        ticket = Ticket.objects.create(issue_url=MR_OPEN, role=Ticket.Role.REVIEWER)
+        session = Session.objects.create(ticket=ticket, agent_id="t3:reviewer")
+        row.attach_reviewer_task(str(Task.objects.create(ticket=ticket, session=session, phase="reviewing").pk))
+
+        assert scanner.scan() == []
 
     def test_pending_to_all_merged_reclassifies_and_reacts_green(self) -> None:
         backend = FakeMessaging()

--- a/tests/teatree_utils/test_ram_probe.py
+++ b/tests/teatree_utils/test_ram_probe.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from subprocess import CompletedProcess
 from unittest.mock import patch
 
 import pytest
@@ -49,6 +50,56 @@ def test_read_ram_used_percent_unknown_platform_returns_zero() -> None:
 def test_macos_probe_no_binaries_returns_zero() -> None:
     with patch("shutil.which", return_value=None):
         assert _macos_ram_used_percent() == pytest.approx(0.0)
+
+
+class TestMacosPageSize:
+    """The mac probe must read the page size off ``vm_stat``, never assume 4 KiB.
+
+    Apple Silicon reports 16384-byte pages. Assuming 4096 shrinks the
+    reclaimable total 4x, which reads back as a near-full host and makes
+    ``check_provision_admission`` hold every provision on a host with GBs free.
+    """
+
+    # A real arm64 capture (24 GiB host): free + inactive = 470274 reclaimable pages.
+    _TOTAL_BYTES = 25769803776
+    _RECLAIMABLE_PAGES = 83371 + 386903
+    _VM_STAT_16K = """Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                                    83371.
+Pages active:                                  397317.
+Pages inactive:                               386903.
+Pages speculative:                               9228.
+Pages wired down:                              383587.
+"""
+
+    def _probe(self, vm_stat_output: str) -> float:
+        """Run the mac probe against *vm_stat_output* with a fixed ``hw.memsize``."""
+
+        def fake_run(cmd, **_kwargs):
+            stdout = str(self._TOTAL_BYTES) if "hw.memsize" in cmd else vm_stat_output
+            return CompletedProcess(args=cmd, returncode=0, stdout=stdout, stderr="")
+
+        with (
+            patch("shutil.which", side_effect=lambda name: f"/usr/bin/{name}"),
+            patch("teatree.utils.run.run_checked", side_effect=fake_run),
+        ):
+            return _macos_ram_used_percent()
+
+    def _expected_percent(self, page_size: int) -> float:
+        used = self._TOTAL_BYTES - self._RECLAIMABLE_PAGES * page_size
+        return used * 100.0 / self._TOTAL_BYTES
+
+    def test_uses_the_page_size_from_the_vm_stat_header(self) -> None:
+        assert self._probe(self._VM_STAT_16K) == pytest.approx(self._expected_percent(16384))
+
+    def test_does_not_fall_back_to_a_hardcoded_four_kib_page(self) -> None:
+        # The 4 KiB reading of this same capture is ~92.5% — a phantom that
+        # trips the 85% provision-admission ceiling on a host with ~7 GB free.
+        assert self._probe(self._VM_STAT_16K) != pytest.approx(self._expected_percent(4096))
+
+    def test_unparsable_header_falls_back_to_four_kib(self) -> None:
+        # "Can't tell" keeps the historical 4 KiB arithmetic rather than raising.
+        headerless = self._VM_STAT_16K.replace("(page size of 16384 bytes)", "(page size unknown)")
+        assert self._probe(headerless) == pytest.approx(self._expected_percent(4096))
 
 
 def test_linux_probe_missing_proc_meminfo_returns_zero() -> None:


### PR DESCRIPTION
## Summary

Seven independent correctness fixes across overlay resolution, issue intake, resource probes, and headless scanner-phase dispatch. Each is self-contained with its own unit test.

1. **Active-overlay name resolution** (`config/discovery.py`) — resolve the active overlay from the Django settings module before the clone-directory basename, so a freely-named clone can't leak an undispatchable overlay anchor when more than one overlay is installed and the sole-overlay fallback can't fire.
2. **Review broadcasts emit exactly once** (`core/models/scanned_broadcast.py`, `loop/persistence.py`) — separate the idempotency ledger from the emission gate with `awaiting_reviewer_dispatch`. A review whose reviewer task was never created, was deleted, or FAILED is re-emitted instead of dropped forever; the loop now links the covering reviewer task back onto the broadcast row so a re-emitted broadcast converges.
3. **Loop schedule timezone** (`core/models/loop_schedule.py`, `core/management/commands/loop_schedule.py`, `cli/loop/schedule.py`) — add a `set-timezone` verb (validated at write time via `zoneinfo`) and a `timezone_label` that renders an unset value as the project zone rather than the misleading `local`.
4. **`ready_labels` enforced on both intake paths** (`core/intake/label_admission.py`, `loop/scanners/assigned_issues.py`, `backends/gitlab/sync_issues.py`, `backends/gitlab/sync.py`) — one shared `intake_admits` / `LabelPolicy` predicate now gates both the scanner and the GitLab assigned-issue sync path (previously ungated, creating a ticket row for every assigned issue). An empty allowlist still admits everything.
5. **macOS RAM probe page size** (`utils/ram_probe.py`) — read the page size from the `vm_stat` header instead of assuming 4 KiB, so an arm64 host no longer over-reports RAM pressure and holds every provision. Unparsable header degrades to the historical 4 KiB rather than raising.
6. **Local port detection over IPv6** (`core/management/commands/_e2e_discovery.py`) — probe both loopback families so an IPv6-only dev server is detected rather than reported as not running; the per-address timeout halves to keep the 11-port scan's worst-case ceiling.
7. **Scanner-dispatched phase tool allowances** (`core/modelkit/phases.py`, `core/modelkit/phase_tools.py`, `core/management/commands/_deterministic_phases.py`, `core/management/commands/tasks.py`, the three scanners) — register `eval_local`, `backlog_sweep`, and `short_describe` as scanner-dispatched phases with least-privilege tool entries; run the non-agentic `short_describe` deterministically so its empty allowance is never contradicted by a ticket-work brief. A source-derived registry test AST-walks the scanners so a future phase can't slip the totality lane.

## Architecture pre-check

**1. BLUEPRINT § alignment** — §5.6 (loop topology / scanner-dispatched phases), §6 (overlay system / active-overlay resolution), §17.1 (FSM transitions). No contradiction; no BLUEPRINT change required.

**2. FSM phase boundaries** — no new `Ticket.State` transition. `short_describe`/`eval_local`/`backlog_sweep` are existing scanner-dispatched headless phases; this only registers their tokens + tool allowances.

**3. Extension-point contracts** — no `OverlayBase` hook change. `label_admission` is consumed by the `assigned_issues` scanner and the GitLab sync path; the GitHub backend has no issue-intake path today (noted for parity if one is added).

**4. Component boundaries** — new predicate in `core/intake` (domain), new phase-runner registry co-located with the headless task command under `core/management/commands/_deterministic_phases.py` (a `_`-prefixed module so Django doesn't treat it as a command). It lives in `core.management` rather than `agents` to respect the tach layering (agents/domain must not import a management command/interface).

**5. Dependency direction** — `uv run tach check` passes. No backwards edges introduced; the phase-runner registry stays within the `core.management` node.

**6. Test surface** — each fix ships a failing-first unit test: `test_ram_probe.py::TestMacosPageSize`, `test_e2e_frontend_discovery.py::LocalPortDetectionTests`, `test_overlay_discovery.py::test_discover_active_overlay_canonicalizes_via_settings_module`, `test_scanned_broadcast.py`, `test_persistence.py` (write-back), `test_slack_broadcasts_scanner.py` (emission-repeat vs covered), `test_loop_schedule_command.py::TestSetTimezone`/`TestUnsetTimezoneRendersHonestly`, `test_label_admission.py`, `test_sync_issues.py::TestGitLabAssignedIssueSyncHonoursTheLabelGate`, `test_scanner_phase_tool_registry.py` (source-derived, with an anti-vacuity control), `test_deterministic_phases.py`.

**7. Resilience invariants** — the broadcast fix is idempotent (unique constraint stays the key) and converges (write-back links the covering task); the deterministic runner records failures through the same durable `complete_with_attempt` recorder as the agentic path, never escaping.

**8. Identity/key normalization** — the overlay-name fix canonicalizes UP (settings package → registered entry point) via the existing alias rule, never stripping a qualifier to force a match.

**9. Behavior preservation** — no capability removed. The `_describe_one` → `describe_ticket` rename updates all call sites; the scanner phase literals now re-export from the canonical vocabulary rather than defining their own copies.

**10. Removability / harness-vs-data** — each fix is a self-contained module or predicate that reverts cleanly. Label policy is data (`ready_labels`/`exclude_labels` config) read by a generic predicate; the phase-runner registry is a small dict the harness reads.

## Testing

`uv run pytest` across the touched subsystems: 4457 passed. `uv run ruff check`, `uv run ty check`, and `uv run tach check` all pass. No migration needed (the schedule change adds a property, not a field).
