### PR TITLE
fix(dream): scan both /tmp and /var/tmp for task-output transcripts

### DIFF
--- a/src/teatree/loops/dream/engine.py
+++ b/src/teatree/loops/dream/engine.py
@@ -251,10 +251,18 @@ def default_projects_dir() -> Path:
     return Path.home() / ".claude" / "projects"
 
 
+#: Both roots task-output transcripts land under; the split is temporal residue (#3585).
+_TASK_OUTPUT_TMP_BASES: tuple[str, ...] = ("/tmp", "/var/tmp")  # noqa: S108 — fixed agent-controlled paths
+
+
 def _task_output_roots() -> list[Path]:
     uid = os.geteuid()
-    candidate = Path(f"/tmp/claude-{uid}")  # noqa: S108 — fixed agent-controlled path, not user input
-    return [candidate] if candidate.is_dir() else []
+    roots: dict[Path, Path] = {}
+    for base in _TASK_OUTPUT_TMP_BASES:
+        candidate = Path(base) / f"claude-{uid}"
+        if candidate.is_dir():
+            roots.setdefault(candidate.resolve(), candidate)
+    return list(roots.values())
 
 
 def _regular_file_mtime(path: Path) -> float | None:

--- a/tests/teatree_loops/dream/test_engine.py
+++ b/tests/teatree_loops/dream/test_engine.py
@@ -941,6 +941,48 @@ class TestEnumerateMembersTaskOutput:
         assert kinds == {"memory", "main", "subagent", "task_output"}
 
 
+class TestTaskOutputRoots:
+    def test_both_tmp_and_var_tmp_roots_globbed_when_both_exist(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        uid = os.geteuid()
+        base_tmp = tmp_path / "tmp"
+        base_var_tmp = tmp_path / "var_tmp"
+        (base_tmp / f"claude-{uid}").mkdir(parents=True)
+        (base_var_tmp / f"claude-{uid}").mkdir(parents=True)
+        monkeypatch.setattr(engine, "_TASK_OUTPUT_TMP_BASES", (str(base_tmp), str(base_var_tmp)))
+
+        roots = engine._task_output_roots()
+
+        assert roots == [base_tmp / f"claude-{uid}", base_var_tmp / f"claude-{uid}"]
+
+    def test_only_existing_roots_are_returned(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        uid = os.geteuid()
+        base_tmp = tmp_path / "tmp"
+        base_var_tmp = tmp_path / "var_tmp"
+        base_tmp.mkdir()  # base present but no claude-{uid} subdir under it
+        (base_var_tmp / f"claude-{uid}").mkdir(parents=True)
+        monkeypatch.setattr(engine, "_TASK_OUTPUT_TMP_BASES", (str(base_tmp), str(base_var_tmp)))
+
+        roots = engine._task_output_roots()
+
+        assert roots == [base_var_tmp / f"claude-{uid}"]
+
+    def test_roots_deduplicated_when_bases_resolve_to_the_same_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        uid = os.geteuid()
+        real_base = tmp_path / "real"
+        (real_base / f"claude-{uid}").mkdir(parents=True)
+        link_base = tmp_path / "link"
+        link_base.symlink_to(real_base)
+        monkeypatch.setattr(engine, "_TASK_OUTPUT_TMP_BASES", (str(real_base), str(link_base)))
+
+        roots = engine._task_output_roots()
+
+        assert roots == [real_base / f"claude-{uid}"]
+
+
 class TestEnumerateMembersMemoryFiles:
     def test_memory_md_picked_up_as_memory_kind(self, tmp_path: Path) -> None:
         memory_dir = tmp_path / "slug" / "memory"


### PR DESCRIPTION
## Summary

`_task_output_roots()` in the dream engine only globbed `/tmp/claude-{uid}`, so the idle-time dream pass missed task-output transcripts written under `/var/tmp/claude-{uid}` — where newer Claude Code and the headless factory land scratch once `TMPDIR=/var/tmp` is in effect. The two roots are temporal residue of the pre/post `TMPDIR=/var/tmp` split (see #3585 comments), so dream must read both defensively and never silently miss one.

This change makes `_task_output_roots()` return **both** `/tmp/claude-{uid}` and `/var/tmp/claude-{uid}` — each only when it is a directory — de-duplicated by resolved path so a `/var/tmp` symlink into `/tmp` cannot double-count.

Scope is exactly the dual-scan. The separately-tracked compose-env `TMPDIR` unification and the stale-`/tmp` cleanup called out in the issue comments are **not** part of this PR.

## Tests

- New `TestTaskOutputRoots` (RED before, GREEN after):
  - both roots globbed when both dirs exist
  - only existing roots returned
  - de-duplicated when two bases resolve to the same dir (symlink)

`uv run pytest tests/teatree_loops/dream/test_engine.py` — 80 passed. `uv run ruff check` clean.

## Architecture pre-check

Tactical single-function fix (a narrow root-enumeration bug in one helper, no new module, no Protocol/FSM/extension-point change) — skips the ten-check gate per the architecture-design skill.

Closes #3585
