### PR TITLE
fix(loop): retire review tasks whose linked PR is closed/merged

### DIFF
--- a/src/teatree/loop/transient_requeue.py
+++ b/src/teatree/loop/transient_requeue.py
@@ -45,6 +45,13 @@ COMPLETED silently. This is the fix for the redispatch flood on already-done tic
 (3366/3336/3352): the away-mode queue is never asked about a phase the ticket's own
 state already answers.
 
+A DEAD-REVIEW-TARGET FAILED task — a review/codex-review phase (``reviewing`` /
+``codex_reviewing`` / ``codex_adversarial_reviewing`` / ``e2e_reviewing``) whose
+linked PR is provably MERGED/CLOSED — is likewise retired COMPLETED (and its reviewer
+ticket IGNORED), never reopened: a verdict can never land on a dead PR, so
+re-dispatching only burns a session that re-confirms the close (3556). Fail-OPEN on an
+UNKNOWN PR state so a transient forge hiccup never retires a live review.
+
 A once-escalated task is stamped (:data:`_HALT_STAMP` in ``execution_reason``) and
 excluded from every subsequent scan, so the dead-letter set never grows the per-tick
 work unboundedly. The ``DeferredQuestion`` itself is deduped by a STABLE key —
@@ -65,6 +72,7 @@ from django.utils import timezone
 
 from teatree.agents.outage_classifier import is_transient_failure
 from teatree.agents.usage_window import autorecovery_enabled
+from teatree.core.modelkit.phase_tools import VERDICT_REVIEW_PHASES
 from teatree.core.modelkit.phases import normalize_phase
 from teatree.core.models import Task, TaskAttempt, Ticket
 from teatree.core.models.deferred_question import DeferredQuestion
@@ -88,6 +96,13 @@ _HALT_STAMP = "[repair-halt-parked]"
 #: out of the scan — the away-mode queue is never asked about a phase the ticket
 #: already advanced past (the 3366/3336/3352 redispatch-loop root cause).
 _SUPERSEDED_STAMP = "[superseded-retired]"
+
+#: Stamped onto ``execution_reason`` when a review/codex-review task is retired
+#: because its linked PR is provably MERGED/CLOSED. A review verdict can never land
+#: on a dead PR, so re-dispatching only burns a session that re-confirms the close
+#: (#3556). The task is marked COMPLETED and the reviewer ticket is IGNORED so it
+#: drops out of every active scan instead of re-dispatching indefinitely.
+_DEAD_REVIEW_STAMP = "[dead-review-retired]"
 
 #: Phases whose omitted-envelope refusal earns the one-shot corrective retry.
 _CORRECTIVE_PHASES = frozenset({"coding", "debugging"})
@@ -145,11 +160,7 @@ def _route_failed_task(task: Task, *, now: datetime, autorecovery: bool) -> int:
     non-terminal ticket is still never left silent (reopened, retired, retried, or
     escalated), it just can no longer take the whole tick down with it.
     """
-    if task.ticket.has_completed_phase(task.phase):
-        # SUPERSEDED: the ticket's FSM already reached this phase's output, so this
-        # FAILED row is a dead artifact of an earlier interrupted run. Retire it
-        # silently — never escalate a question the ticket's own state answers.
-        _retire_superseded(task)
+    if _retire_if_dead_artifact(task):
         return 0
     error = _latest_error(task)
     if not error:
@@ -324,6 +335,76 @@ def _stamp_halt(task: Task) -> None:
         return
     reason = f"{task.execution_reason}\n{_HALT_STAMP}".strip() if task.execution_reason else _HALT_STAMP
     Task.objects.filter(pk=task.pk).update(execution_reason=reason)
+
+
+def _retire_if_dead_artifact(task: Task) -> bool:
+    """Retire a FAILED task whose phase output is already moot; ``True`` if retired.
+
+    Two ways a FAILED row becomes a dead artifact to retire (COMPLETED) rather than
+    reopen or escalate:
+
+    * SUPERSEDED — the ticket's FSM already reached this phase's output, so the
+        row is a leftover of an earlier interrupted run (the ticket advanced on its own).
+    * DEAD REVIEW TARGET — a review/codex-review phase whose linked PR is
+        merged/closed, so a verdict can never land; re-dispatching only burns a
+        session that re-confirms the close (#3556).
+    """
+    if task.ticket.has_completed_phase(task.phase):
+        _retire_superseded(task)
+        return True
+    if _review_target_dead(task):
+        _retire_dead_review(task)
+        return True
+    return False
+
+
+def _review_target_dead(task: Task) -> bool:
+    """Whether *task* is a review phase whose linked PR is provably MERGED/CLOSED (#3556).
+
+    Only a verdict-review phase consults the forge; every other phase returns
+    ``False`` without a network read. The linked PR is the reviewer ticket's own
+    ``issue_url`` (a codex/review ticket is keyed on the PR url). Fail-OPEN via
+    :func:`~teatree.backends.loader.pr_is_merged_or_closed`: an UNKNOWN/indefinite
+    state returns ``False`` so a transient forge hiccup never retires a live review.
+    """
+    if normalize_phase(task.phase) not in VERDICT_REVIEW_PHASES:
+        return False
+    from teatree.backends.loader import pr_is_merged_or_closed  # noqa: PLC0415 - deferred: backends/core cycle
+
+    return pr_is_merged_or_closed(task.ticket.issue_url)
+
+
+def _retire_dead_review(task: Task) -> None:
+    """Retire a dead-review task COMPLETED and IGNORE its reviewer ticket. Idempotent.
+
+    The review target is merged/closed, so the phase output can never land - mark the
+    task COMPLETED (dropping it out of the FAILED scan) via the same
+    ``UPDATE ... WHERE status=FAILED`` compare-and-swap the retire/reopen paths use,
+    then transition the ticket to IGNORED when the FSM allows it so the reviewer ticket
+    stops surfacing as active. No ``DeferredQuestion``: a closed PR is not a defect a
+    human needs to triage.
+    """
+    reason = f"{task.execution_reason}\n{_DEAD_REVIEW_STAMP}".strip() if task.execution_reason else _DEAD_REVIEW_STAMP
+    Task.objects.filter(pk=task.pk, status=Task.Status.FAILED).update(
+        status=Task.Status.COMPLETED,
+        claimed_at=None,
+        claimed_by="",
+        claimed_by_session="",
+        lease_expires_at=None,
+        heartbeat_at=None,
+        execution_reason=reason,
+    )
+    _ignore_ticket_if_allowed(task.ticket)
+
+
+def _ignore_ticket_if_allowed(ticket: Ticket) -> None:
+    """Transition *ticket* to IGNORED when the FSM permits it; a no-op otherwise."""
+    from django_fsm import can_proceed  # noqa: PLC0415 - deferred: FSM import at call time
+
+    if not can_proceed(ticket.ignore):
+        return
+    ticket.ignore()
+    ticket.save()
 
 
 def _retire_superseded(task: Task) -> None:

--- a/tests/teatree_loop/test_transient_requeue.py
+++ b/tests/teatree_loop/test_transient_requeue.py
@@ -474,3 +474,72 @@ class TestExhaustionAutoRequeue(TestCase):
         # Byte-identical to before #3407: an exhaustion failure follows the deterministic
         # escalation path while the flag is off.
         assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
+
+
+class TestDeadReviewTargetRetired(TestCase):
+    """A review/codex-review task whose linked PR is CLOSED/MERGED is retired, not re-dispatched (#3556)."""
+
+    @staticmethod
+    def _reviewer_task(*, phase: str = "codex_reviewing") -> Task:
+        ticket = Ticket.objects.create(
+            role=Ticket.Role.REVIEWER,
+            state=Ticket.State.NOT_STARTED,
+            issue_url="https://github.com/souliane/teatree/pull/3542",
+        )
+        session = Session.objects.create(ticket=ticket, agent_id=phase)
+        return Task.objects.create(ticket=ticket, session=session, phase=phase, status=Task.Status.FAILED)
+
+    def test_closed_pr_review_task_is_retired_not_reopened(self) -> None:
+        task = self._reviewer_task()
+        # A transient-classified error would otherwise reopen the task every tick.
+        _add_failed_attempt(task, error="outage_death: agent stopped after confirming PR closed")
+
+        with mock.patch("teatree.backends.loader.pr_is_merged_or_closed", return_value=True):
+            reopened = requeue_transient_failed()
+
+        task.refresh_from_db()
+        task.ticket.refresh_from_db()
+        assert reopened == 0
+        assert task.status == Task.Status.COMPLETED  # retired, not re-queued
+        assert task.ticket.state == Ticket.State.IGNORED  # terminal — drops from active scans
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 0
+
+    def test_adversarial_review_phase_is_also_retired(self) -> None:
+        task = self._reviewer_task(phase="codex_adversarial_reviewing")
+        _add_failed_attempt(task, error="outage_death: agent stopped after confirming PR closed")
+
+        with mock.patch("teatree.backends.loader.pr_is_merged_or_closed", return_value=True):
+            reopened = requeue_transient_failed()
+
+        task.refresh_from_db()
+        assert reopened == 0
+        assert task.status == Task.Status.COMPLETED
+
+    def test_live_pr_review_task_still_reopens(self) -> None:
+        # Control: the retire path is gated on a provably-dead PR. A live/UNKNOWN PR
+        # (fail-open False) must still reopen the transient failure exactly as before.
+        task = self._reviewer_task()
+        _add_failed_attempt(task, error="outage_death: connection refused")
+
+        with mock.patch("teatree.backends.loader.pr_is_merged_or_closed", return_value=False):
+            reopened = requeue_transient_failed()
+
+        task.refresh_from_db()
+        assert reopened == 1
+        assert task.status == Task.Status.PENDING
+
+    def test_non_review_phase_is_not_pr_gated(self) -> None:
+        # Control: a non-review phase never consults PR state — a dead PR must not
+        # short-circuit an ordinary coding retry.
+        ticket = Ticket.objects.create(role=Ticket.Role.AUTHOR, state=Ticket.State.STARTED)
+        session = Session.objects.create(ticket=ticket, agent_id="coding")
+        task = Task.objects.create(ticket=ticket, session=session, phase="coding", status=Task.Status.FAILED)
+        _add_failed_attempt(task, error="outage_death: connection refused")
+
+        with mock.patch("teatree.backends.loader.pr_is_merged_or_closed", return_value=True) as dead:
+            reopened = requeue_transient_failed()
+
+        task.refresh_from_db()
+        assert reopened == 1
+        assert task.status == Task.Status.PENDING
+        dead.assert_not_called()


### PR DESCRIPTION
## Problem

Reviewer tickets keyed on a PR URL (created by the codex-review dispatch) kept
being re-dispatched to `codex_reviewing` every tick after their PR was already
CLOSED/MERGED. Each re-dispatch burned an agent session that only re-verified the
PR is dead and stopped. Observed 2-4x each on the wp-checkpoint reviewer tickets
(#3542/#3543/#3544/#3548), all superseded by a merged PR.

Root cause: the transient-requeue sweep (`_route_failed_task`) reopens a
transient-classified FAILED task without consulting the review target's live
state. A review/codex-review phase whose linked PR is merged/closed is dead work
— a verdict can never land there — but nothing checked that before reopening.

## Fix

`_route_failed_task` now retires such a task instead of reopening/escalating it:
a review/codex-review phase (`VERDICT_REVIEW_PHASES`) whose linked PR is provably
MERGED/CLOSED is marked COMPLETED and its reviewer ticket transitioned to IGNORED
(dropping it out of active scans). Reuses the existing fail-open
`pr_is_merged_or_closed` helper, so an UNKNOWN/indefinite PR state still reopens
exactly as before — a transient forge hiccup never retires a live review. Gated
on the review-phase set, so a non-review phase never triggers a forge read.

Closes #3556

## Architecture pre-check — #3556

## 1. BLUEPRINT § alignment
§17.1 invariant 9 (loud-not-forever) + the repair-loop budget doctrine. This adds
a terminal disposition (retire) for a dead review target alongside the existing
SUPERSEDED retire — same "never re-dispatch a phase the world already answered"
principle.

## 2. FSM phase boundaries
Adds a `NOT_STARTED → IGNORED` reviewer-ticket transition via the existing
`Ticket.ignore()` (guarded by `can_proceed`). No new FSM states or transitions.

## 3. Extension-point contracts
None. No OverlayBase/scanner/hook/Protocol surface changed.

## 4. Component boundaries
`teatree.loop.transient_requeue` (orchestration) — the module that already owns
the FAILED-task routing. Reuses `teatree.backends.loader.pr_is_merged_or_closed`
(the same seam the reviewer-dispatch gate uses) and `VERDICT_REVIEW_PHASES`.

## 5. Dependency direction
Adds `from teatree.core.modelkit.phase_tools import VERDICT_REVIEW_PHASES` (core,
same layer already imported) and a deferred `teatree.backends.loader` import
(backends↔core cycle, mirrors `dispatch_gates`). `uv run tach check` → all modules
validated.

## 6. Test surface
`tests/teatree_loop/test_transient_requeue.py::TestDeadReviewTargetRetired`:
closed-PR review task retired (not reopened) + ticket IGNORED; adversarial phase
also retired; live/UNKNOWN PR still reopens (control); non-review phase never
consults PR state (control, `assert_not_called`). RED confirmed by reverting the
fix (2 retire tests fail `assert 1 == 0`).

## 7. Resilience invariants
Idempotency: retire is a `WHERE status=FAILED` compare-and-swap; ticket ignore is
`can_proceed`-guarded — both no-op on a re-run. Fail-open: an UNKNOWN PR state
reopens as before. No new external write.

## 8. Identity and key normalization
Phase membership checked via `normalize_phase(task.phase) in VERDICT_REVIEW_PHASES`
— canonicalizes up before comparison; no qualifier-stripping.

## 9. Behavior preservation / capability deletion
Purely additive — a new early-return branch. Live/UNKNOWN-PR reopen and every
existing disposition are unchanged (the two control tests pin this). No matcher
narrowed, no test inverted.

## 10. Removability / harness-vs-data
Removable: deleting the branch reverts to the prior reopen behavior with zero call-
site fallout. Harness side: the disposition is FSM/gate logic, not per-item config
— the varying part (which PR is dead) is read live, not tabulated.
