### PR TITLE
fix(overlay): boot Django at the discovery seam so bare t3 survives a pre-set DJANGO_SETTINGS_MODULE (#3567)

### DIFF
--- a/src/teatree/core/overlay_loader.py
+++ b/src/teatree/core/overlay_loader.py
@@ -147,9 +147,7 @@ def get_overlay_for_repo(repo: str = ".") -> "OverlayBase | None":
                 matches.append(overlay)
                 break
 
-    if len(matches) == 1:
-        return matches[0]
-    return None
+    return matches[0] if len(matches) == 1 else None
 
 
 def get_all_overlays() -> "dict[str, OverlayBase]":
@@ -529,6 +527,12 @@ def _discover_overlays() -> "dict[str, OverlayBase]":
     import importlib.metadata  # noqa: PLC0415 — deferred: loaded only on this code path
 
     from teatree.core.overlay import OverlayBase  # noqa: PLC0415 — deferred: call-time import, kept lazy
+    from teatree.utils.django_bootstrap import ensure_django  # noqa: PLC0415 — deferred: call-time import, kept lazy
+
+    # ``ep.load()`` eagerly imports overlay modules that define Django models at
+    # module scope; a caller with ``DJANGO_SETTINGS_MODULE`` pre-set but ``setup()``
+    # unrun would otherwise hit ``AppRegistryNotReady`` here (#3567). Idempotent.
+    ensure_django()
 
     result: dict[str, OverlayBase] = {}
 

--- a/tests/test_overlay_loader.py
+++ b/tests/test_overlay_loader.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from typing import ClassVar
 from unittest.mock import patch
@@ -698,6 +699,46 @@ class TestPathOnlyOwnedScopes:
         overlays = {"t3-stub": {"class": "tests.test_overlay_loader:_StubOverlay"}}
         with self._patch_landscape(overlays, discovered={"t3-stub": overlay}):
             assert path_only_owned_scopes() == []
+
+
+class TestDiscoverOverlaysBootstrapsDjango:
+    """``_discover_overlays`` boots Django before eagerly importing overlay modules (#3567).
+
+    An entry-point overlay module (``teatree/contrib/t3_teatree/overlay.py``) does a
+    module-level ``from teatree.core.models import Worktree`` — a Django model class,
+    which needs the app registry populated. When the calling process's env already
+    carries ``DJANGO_SETTINGS_MODULE=teatree.settings`` but ``django.setup()`` has not
+    run, settings resolve fine (so the ``ImproperlyConfigured`` guard in
+    ``overlay_skill_metadata`` never fires) yet the model import raises
+    ``AppRegistryNotReady`` — crashing the very first bare ``t3`` command of a session.
+
+    Driven in a child interpreter with the env var pre-set and ``django.setup()``
+    unrun, mirroring an agent-session host that inherits the var from upstream of the
+    shell. Pre-fix the child exits non-zero with ``AppRegistryNotReady``; post-fix
+    ``_discover_overlays`` calls ``ensure_django`` first and resolves cleanly.
+    """
+
+    def _env_with_settings_preset(self) -> dict[str, str]:
+        env = os.environ.copy()
+        env["DJANGO_SETTINGS_MODULE"] = "teatree.settings"
+        return env
+
+    def test_discover_overlays_with_preset_settings_module_does_not_crash(self) -> None:
+        probe = (
+            "from teatree.core.overlay_loader import _discover_overlays\n"
+            "overlays = _discover_overlays()\n"
+            "print('discover-ok', sorted(overlays))\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=self._env_with_settings_preset(),
+        )
+        assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+        assert "AppRegistryNotReady" not in result.stderr
+        assert "discover-ok" in result.stdout
 
 
 # ── Test helpers ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #3567 — a bare `t3 <subcommand>` crashes with
`django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.` on any
host where the calling process's own environment already carries
`DJANGO_SETTINGS_MODULE=teatree.settings` but `django.setup()` has not run
(agent-session hosts that inherit the var from upstream of the shell). The
first bare `t3` command of the session — `t3 tool verify-gates`, the git-push
pre-push hook — hits it. The known workaround `env -u DJANGO_SETTINGS_MODULE
t3 ...` cost real time to rediscover each session.

## Root cause

`main()` → `register_overlay_commands()` → `OverlayAppBuilder.build()` →
`_register_overlay_tools()` → `overlay_skill_metadata()` → `get_overlay()` →
`_discover_overlays()` calls `ep.load()`, which eagerly imports each
entry-point overlay module. `teatree/contrib/t3_teatree/overlay.py` does a
module-level `from teatree.core.models import Worktree` — a Django model class
definition that needs the app registry populated.

The `overlay_skill_metadata` guard catches `ImproperlyConfigured` and falls
back to the default skills root. When `DJANGO_SETTINGS_MODULE` is **unset**,
the model import raises exactly that (settings unconfigured) and the guard
fires. When it is **pre-set**, settings resolve fine — so the guard never
fires — yet `django.setup()` still never ran, so the model import raises
`AppRegistryNotReady`, which is not caught, and the command crashes.

## Fix

Call the sanctioned `ensure_django()` chokepoint at the top of
`_discover_overlays()`, before the `ep.load()` loop (issue's suggested fix
#1). It is idempotent, so booting Django there fixes the seam regardless of
what `DJANGO_SETTINGS_MODULE` the parent process leaked in, and it covers
every caller of the discovery seam, not only the CLI-build path.

`get_overlay_for_repo`'s tail is folded into an idiomatic ternary
(behaviour-preserving) so the module stays under its 500-LOC cap without a
suppression.

## Test

`TestDiscoverOverlaysBootstrapsDjango` drives `_discover_overlays()` in a child
interpreter with `DJANGO_SETTINGS_MODULE=teatree.settings` pre-set and
`django.setup()` unrun — the exact reproduction. Observed RED with
`AppRegistryNotReady` before the fix, green after.

## Architecture pre-check — #3567

## 1. BLUEPRINT § alignment
§6 Overlay System — overlay discovery/loading (`_discover_overlays`,
`get_overlay`). No contract change; the discovery seam now self-boots Django
before eagerly importing overlay modules.

## 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition touched.

## 3. Extension-point contracts
`_discover_overlays()` / `get_overlay()` are the sole overlay-instantiation
seam; every consumer (`get_all_overlays`, `overlay_skill_metadata`,
`get_overlay_for_*`) reaches overlays through it. Boot happens once inside the
`lru_cache`d seam, so all consumers benefit without any per-caller change.

## 4. Component boundaries
`src/teatree/core/overlay_loader.py` — the overlay-loading module; the correct
home for a discovery-time precondition.

## 5. Dependency direction
Adds `teatree.core.overlay_loader` → `teatree.utils.django_bootstrap`
(core → utils, correct direction). `uv run tach check` → "All modules
validated!".

## 6. Test surface
`tests/test_overlay_loader.py::TestDiscoverOverlaysBootstrapsDjango` — a
subprocess with the env var pre-set asserts no `AppRegistryNotReady` and a
clean discovery. Anti-vacuous: observed RED on the pre-fix code.

## 7. Resilience invariants
n/a — no external write. `ensure_django()` is idempotent (repeat-safe across
nested dispatch).

## 8. Identity and key normalization
n/a — no identity/key handling changed.

## 9. Behavior preservation / capability deletion
n/a — purely additive at the seam. The `get_overlay_for_repo` ternary is a
behaviour-preserving rewrite of `if len == 1: return matches[0] / return None`.

## 10. Removability / harness-vs-data
Removable — deleting the single `ensure_django()` call reverts to prior
behaviour with no cascade. Harness-side is correct: booting Django is a code
precondition, not per-item data.
