### PR TITLE
fix(agents): force plan_text / article_suggestions in the phase result envelope (#3584)

### DIFF
--- a/src/teatree/agents/prompt.py
+++ b/src/teatree/agents/prompt.py
@@ -1,6 +1,7 @@
 """Build agent prompts from ticket and task context."""
 
 import json
+from collections.abc import Callable
 from typing import cast
 
 from teatree.agents.coding_prompt import _VERIFY_GATES_COMMAND, _coding_phase_directive, _stack_overlay_load_names
@@ -95,6 +96,38 @@ _ANSWER_RETURN_LINES: tuple[str, ...] = (
     "The `text` MUST be non-empty — a summary-only result with no `answer` drops the reply and",
     "the phase is refused. If you cannot answer (missing context, a decision only the user can",
     "make), draft a clarifying-question reply as the `answer` text rather than returning nothing.",
+)
+
+# Injected into a headless planning brief (#3584): the phase evidence gate
+# (``PHASE_REQUIRED_EVIDENCE["planning"]``) refuses a run whose result envelope
+# omits ``plan_text``, so the planner MUST place the full plan under that key —
+# not only as prose or a PlanArtifact. Without this reinforcing directive the
+# planner produced a plan but returned a summary-only envelope, and the attempt
+# was refused for "missing required evidence for phase 'planning'" then re-run.
+# Symmetric to ``_REVIEW_VERDICT_RETURN_LINES`` / ``_ANSWER_RETURN_LINES``.
+_PLAN_RETURN_LINES: tuple[str, ...] = (
+    "",
+    "RETURN YOUR PLAN IN THE ENVELOPE (the phase evidence gate refuses a run with no `plan_text`):",
+    "your final JSON result MUST carry the full implementation plan under the `plan_text` key:",
+    '  "plan_text": "<the complete plan — file-level changes, data model, API contracts, test',
+    '                strategy, and the E2E test plan / Acceptance scenarios section when UI-visible>"',
+    "A summary-only result with no `plan_text` drops the plan and the phase is refused, wasting the run.",
+)
+
+# Injected into a headless scanning_news brief (#3584): the shell-denied scanner
+# cannot enqueue candidates itself, so it RETURNS them, and the phase evidence
+# gate (``PHASE_REQUIRED_EVIDENCE["scanning_news"]``) refuses a run whose envelope
+# omits ``article_suggestions``. Symmetric to ``_ANSWER_RETURN_LINES``.
+_ARTICLE_SUGGESTIONS_RETURN_LINES: tuple[str, ...] = (
+    "",
+    "RETURN YOUR CANDIDATES AS SUGGESTIONS (this phase has no shell — do NOT try to file issues",
+    "via `t3 <overlay>` or `gh`; you cannot enqueue, you HAND BACK the candidates):",
+    "add an `article_suggestions` array to your final JSON result. The orchestrator queues each",
+    "behind the per-article ask-gate (a PendingArticleSuggestion) for the user's approval:",
+    '  "article_suggestions": [{"title": "<article title>", "url": "<article url>",',
+    '                           "rationale": "<one-line why-this-matters for teatree>"}]',
+    "Each item's `url` MUST be non-empty. A summary-only result with no `article_suggestions`",
+    "silently drops the scan and the phase is refused, wasting the run.",
 )
 
 
@@ -266,11 +299,17 @@ def _intake_landscape_lines(task: Task) -> tuple[str, ...]:
 
 
 def _planning_phase_lines(task: Task) -> tuple[str, ...]:
-    """The headless ``PHASE: planning`` block — intake survey (#2541) + opted-in fan-out."""
+    """The headless ``PHASE: planning`` block — intake survey (#2541), envelope directive (#3584), opted-in fan-out."""
     lines = list(_intake_landscape_lines(task))
+    lines.extend(_PLAN_RETURN_LINES)
     if fanout := _phase_fanout_directive(task):
         lines.extend(("", "PHASE: planning", fanout))
     return tuple(lines)
+
+
+def _scanning_news_phase_lines() -> tuple[str, ...]:
+    """The headless ``PHASE: scanning_news`` block — RETURN the article_suggestions envelope (#3584)."""
+    return ("", "PHASE: scanning_news", *_ARTICLE_SUGGESTIONS_RETURN_LINES)
 
 
 def _reviewing_phase_lines(task: Task) -> tuple[str, ...]:
@@ -360,15 +399,20 @@ def _phase_specific_lines(
             *head_state_brief_lines(task),
             *_coding_phase_directive(skills, stage_exclude=stage_exclude),
         )
-    if phase == "planning":
-        return _planning_phase_lines(task)
-    if phase == "reviewing":
-        return _reviewing_phase_lines(task)
-    if phase == "answering":
-        return _answering_phase_lines(task)
-    if phase == "shipping":
-        return _shipping_phase_lines()
-    return ()
+    builder = _PHASE_BLOCK_BUILDERS.get(phase)
+    return builder(task) if builder is not None else ()
+
+
+#: Per-phase trailing-block builders (excluding coding, which needs *skills* +
+#: *stage_exclude* and stays a special case in ``_phase_specific_lines``). Keyed
+#: on the canonical phase token; a phase absent here carries no trailing block.
+_PHASE_BLOCK_BUILDERS: dict[str, Callable[[Task], tuple[str, ...]]] = {
+    "planning": _planning_phase_lines,
+    "reviewing": _reviewing_phase_lines,
+    "answering": _answering_phase_lines,
+    "scanning_news": lambda _task: _scanning_news_phase_lines(),
+    "shipping": lambda _task: _shipping_phase_lines(),
+}
 
 
 def build_system_context(

--- a/tests/teatree_agents/test_prompt.py
+++ b/tests/teatree_agents/test_prompt.py
@@ -265,6 +265,32 @@ class TestBuildSystemContext(TestCase):
         ctx = build_system_context(task, skills=[])
         assert "INTAKE LANDSCAPE SURVEY" not in ctx
 
+    def test_planning_brief_instructs_returning_the_plan_text_envelope(self) -> None:
+        # #3584: PHASE_REQUIRED_EVIDENCE["planning"] refuses a run whose envelope
+        # omits `plan_text`, so the brief MUST tell the planner to carry the full
+        # plan under that key — otherwise the plan is produced but the attempt is
+        # refused for "missing required evidence for phase 'planning'" and re-run.
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket)
+        task = Task.objects.create(ticket=ticket, session=session, phase="planning")
+
+        ctx = build_system_context(task, skills=[])
+        assert "plan_text" in ctx
+        assert "the phase evidence gate refuses a run with no `plan_text`" in ctx
+
+    def test_scanning_news_brief_instructs_returning_the_article_suggestions_envelope(self) -> None:
+        # #3584: PHASE_REQUIRED_EVIDENCE["scanning_news"] refuses a run whose envelope
+        # omits `article_suggestions`, so the shell-denied scanner's brief MUST tell it
+        # to RETURN the candidates rather than try to enqueue them itself.
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket)
+        task = Task.objects.create(ticket=ticket, session=session, phase="scanning_news")
+
+        ctx = build_system_context(task, skills=[])
+        assert "PHASE: scanning_news" in ctx
+        assert "article_suggestions" in ctx
+        assert "rationale" in ctx
+
     def test_shipping_phase_embeds_reviewer_dispatch_skill_block(self) -> None:
         ticket = Ticket.objects.create()
         session = Session.objects.create(ticket=ticket)

--- a/tests/teatree_agents/test_prompt_phase_alias_parity.py
+++ b/tests/teatree_agents/test_prompt_phase_alias_parity.py
@@ -49,7 +49,8 @@ class TestPhaseSpecificLinesAlias(TestCase):
         assert self._lines("ship") == self._lines("shipping")
 
     def test_non_phase_is_empty(self) -> None:
-        assert self._lines("scanning_news") == ()
+        # A phase with no per-phase trailing block (retro carries no dispatch directive).
+        assert self._lines("retro") == ()
 
 
 class TestBuildSystemContextReviewScoping(TestCase):

--- a/tests/teatree_cli/eval/test_run_credential_flag.py
+++ b/tests/teatree_cli/eval/test_run_credential_flag.py
@@ -52,9 +52,15 @@ class TestApplyCredentialOverride:
         apply_credential_override(None)
         assert PROVIDER_ENV_VAR not in os.environ
 
-    def test_each_accepted_value_pins_the_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_each_accepted_value_pins_the_provider(self) -> None:
+        # Reset with a DIRECT pop, not ``monkeypatch.delenv``: ``apply_credential_override``
+        # sets ``PROVIDER_ENV_VAR`` straight on ``os.environ``, so a mid-loop ``delenv``
+        # makes monkeypatch capture that intermediate value and RESTORE it at teardown —
+        # which runs after the autouse ``_restore_provider_pin`` cleanup, leaking the pin
+        # into unrelated tests (a shell-denied ``SimpleTestCase`` reading the provider then
+        # hits the DB and fails). The autouse fixture is the sole restore authority.
         for value in ("subscription_oauth", "api_key"):
-            monkeypatch.delenv(PROVIDER_ENV_VAR, raising=False)
+            os.environ.pop(PROVIDER_ENV_VAR, None)
             apply_credential_override(value)
             assert os.environ[PROVIDER_ENV_VAR] == value
 


### PR DESCRIPTION
Fixes #3584.

## Problem
`teatree_taskattempt` showed `outcome='refusal'` rows on the **planning** phase (4x) and **scanning_news** (1x): the agent produced the plan / the news candidates, but the result envelope omitted the gate-required key (`plan_text` / `article_suggestions`). `PHASE_REQUIRED_EVIDENCE` then refused the attempt for missing phase evidence and re-ran it — wasted tokens/session for a shape mismatch, not a real failure.

## Fix (issue's preferred route 2 — force the key)
The reviewing (`review_verdict`) and answering (`answer`) phases already ship an explicit "RETURN this key in your final JSON" directive in the headless system context — that reinforcing directive is exactly what makes the agent place its work under the gate-required key. Planning and scanning_news lacked it.

- Planning now carries `_PLAN_RETURN_LINES`: the planner is told its final JSON MUST carry the full plan under `plan_text` (a summary-only envelope drops the plan and the phase is refused).
- scanning_news gets its first per-phase trailing block, `_ARTICLE_SUGGESTIONS_RETURN_LINES`: the shell-denied scanner is told to hand back its candidates under `article_suggestions`.
- `_phase_specific_lines` switches from an if-chain to a `phase -> builder` dispatch map (coding stays a special case for its `skills`/`stage_exclude` args), keeping the return-count within the lint bound.

## Tests
- `test_planning_brief_instructs_returning_the_plan_text_envelope` — the planning brief carries `plan_text` and the gate-refusal cue.
- `test_scanning_news_brief_instructs_returning_the_article_suggestions_envelope` — the scanning_news brief carries `PHASE: scanning_news` + `article_suggestions` + `rationale`.
- Both observed RED against the pre-fix prompt, GREEN with the fix.
- Updated `test_non_phase_is_empty` to use `retro` (scanning_news is now a handled phase).

## Architecture pre-check

1. **BLUEPRINT alignment** — BLUEPRINT §5.2 / §17.8 (per-phase agent dispatch); the phase evidence contract (#1284). Additive; no section contradicted.
2. **FSM phase boundaries** — n/a, no `Ticket.State`/`Worktree.State` transition touched. planning/scanning_news are dispatch phases already registered in `SUBAGENT_BY_PHASE`.
3. **Extension-point contracts** — n/a; no `OverlayBase`/scanner/Protocol surface changed. Consumes existing `PHASE_REQUIRED_EVIDENCE`.
4. **Component boundaries** — `src/teatree/agents/prompt.py` (prompt building) only; no logic leaks into core/cli.
5. **Dependency direction** — no new cross-module import (added `collections.abc.Callable` only). No backwards edge.
6. **Test surface** — `tests/teatree_agents/test_prompt.py` asserts each phase brief carries its envelope directive; refusal path already covered by the existing `check_evidence` tests.
7. **Resilience invariants** — n/a; no external write. The change strengthens the existing idempotent evidence gate (fewer wasted re-runs).
8. **Identity/key normalization** — phase tokens resolved through the single `normalize_phase` at the dispatch boundary; unchanged.
9. **Behavior preservation** — purely additive prompt text + an equivalent if-chain -> dict refactor of `_phase_specific_lines` (same outputs; parity test updated only because scanning_news moved from unhandled to handled).
10. **Removability / harness-vs-data** — the two directive blocks and the builder map are self-contained; deleting them reverts to prior behavior. Directive text is prompt data alongside the existing `_REVIEW_VERDICT_RETURN_LINES` / `_ANSWER_RETURN_LINES` siblings — same harness-vs-data side as the established pattern.
