### PR TITLE
fix(loop): reclaim per-loop leases held by a dead session (#3571)

### DIFF
--- a/src/teatree/cli/doctor/self_heal.py
+++ b/src/teatree/cli/doctor/self_heal.py
@@ -1,12 +1,10 @@
 """Self-heal doctor checks — the H24 factory-outage detectors (owner directive #10).
 
-The recorded 2026 seven-hour silent freeze: the worker WAS the monitor, so when
-the worker/init container died the thing that would alert died with it, and
-NOBODY noticed. These crash-proof ``_check_*`` detectors surface the
-silent-failure classes that froze the factory as loud red findings so the
-in-daemon watchdog (the ``deploy/watchdog.sh`` sidecar container, kept alive by
-the Docker daemon independently of the stack it watches) can restart the stack
-and DM the owner:
+The worker WAS the monitor, so when it died the alerting died with it (the
+recorded seven-hour silent freeze). These crash-proof ``_check_*`` detectors
+surface the silent-failure classes as loud findings so the in-daemon watchdog
+(the ``deploy/watchdog.sh`` sidecar, kept alive by the Docker daemon independently
+of the stack it watches) can restart the stack and DM the owner:
 
 - a compose init container that exited non-zero / a worker stuck ``Created``,
 - a free worker flock while the loop machinery has queued, overdue work,
@@ -15,13 +13,13 @@ and DM the owner:
 - a PENDING ``interactive`` task under ``agent_runtime=headless`` (unrunnable),
 - a FAILED task on a still-live ticket (the silent-freeze signature),
 - a runtime clone that has drifted off its default branch,
-- a slack-drain sidecar failing every pass or gone silent, so inbound Slack stops being answered.
+- a slack-drain sidecar failing every pass or gone silent, so inbound Slack stops being answered,
+- a ``loop:<name>``/``t3-master`` lease held by a dead session past TTL (this one AUTO-REPAIRS).
 
-Each returns ``bool`` — ``False`` is a hard FAIL that reddens ``t3 doctor`` (and
-so the watchdog's ``t3 doctor --json``). Every check is crash-proof: any
-unexpected error degrades to a pass, because a self-heal detector that itself
-aborts the doctor run would recreate the very "monitor dies, alerting dies"
-failure this module exists to end.
+Each returns ``bool`` — ``False`` is a hard FAIL that reddens ``t3 doctor`` (and so
+the watchdog's ``t3 doctor --json``). Every check is crash-proof: any error degrades
+to a pass, since a detector that aborted the run would recreate the very "monitor
+dies, alerting dies" failure this module ends.
 """
 
 import base64
@@ -107,17 +105,12 @@ def _parse_compose_state_rows(text: str) -> list[tuple[str, str, str]]:
 def _compose_states_from_handoff() -> list[tuple[str, str, str]] | None:
     """Compose states handed off by the socket-holding watchdog, or ``None`` when absent.
 
-    ``t3 doctor`` runs inside ``teatree-admin``, which has the ``docker`` CLI but
-    NOT ``/var/run/docker.sock`` (only the watchdog mounts the socket), so a local
-    ``docker ps`` there cannot reach the daemon and the compose-stack detector would
-    silently pass every real outage. The watchdog — the ONE container with the
-    socket — gathers the states and passes them in via :data:`_COMPOSE_STATES_ENV`
-    (base64 of the same tab-separated ``docker ps`` output), so the detector runs in
-    the container that also has the DB-backed ``loop_runner_on`` gate.
-
-    ``None`` when the env var is unset / empty (a dev box, or a direct ``t3 doctor``
-    run) so the caller falls back to a LOCAL ``docker ps``. A malformed / non-base64
-    handoff also yields ``None`` (degrade to a pass) rather than a garbage verdict.
+    ``t3 doctor`` runs inside ``teatree-admin`` (docker CLI but no
+    ``/var/run/docker.sock``), so only the socket-holding watchdog can gather the
+    states; it passes them in via :data:`_COMPOSE_STATES_ENV` (base64 of the
+    tab-separated ``docker ps`` output). ``None`` when the env var is unset/empty
+    (caller falls back to a LOCAL ``docker ps``) or the handoff is malformed
+    (degrade to a pass, never a garbage verdict).
     """
     raw = os.environ.get(_COMPOSE_STATES_ENV, "").strip()
     if not raw:
@@ -153,18 +146,11 @@ class _Probe:
     def compose_container_states(project: str) -> list[tuple[str, str, str]] | None:
         """``(service, state, status)`` per container of *project*, or ``None`` when unreadable.
 
-        Prefers the watchdog handoff (:func:`_compose_states_from_handoff`): the
-        doctor runs inside a socket-LESS app container (``teatree-admin`` has the
-        ``docker`` CLI but not ``/var/run/docker.sock``), so a local ``docker ps``
-        cannot reach the daemon there and the detector would silently pass every
-        real outage. The socket-holding watchdog gathers the states and hands them
-        in, so the check runs where the DB-backed ``loop_runner_on`` gate lives.
-
-        Falls back to a LOCAL ``docker ps`` when no handoff is present (a dev box,
-        or a direct ``t3 doctor`` run on a machine WITH docker access). ``None``
-        means "cannot tell" (no handoff, and no ``docker`` on PATH / daemon down /
-        timeout) — the caller degrades to a pass, exactly as the MCP / Slack doctor
-        probes degrade when their tool is absent.
+        Prefers the watchdog handoff (:func:`_compose_states_from_handoff`), since the
+        doctor's socket-less app container cannot reach the daemon; falls back to a
+        LOCAL ``docker ps`` when no handoff is present (a dev box). ``None`` means
+        "cannot tell" (no handoff, no ``docker`` on PATH / daemon down / timeout) — the
+        caller degrades to a pass, as the MCP / Slack probes do when their tool is absent.
         """
         from teatree.utils.run import run_allowed_to_fail  # noqa: PLC0415 — deferred: keeps CLI startup light
 
@@ -552,6 +538,28 @@ def _check_slack_drain_alive() -> bool:
     return True
 
 
+def _check_dead_owner_lease() -> bool:
+    """AUTO-REPAIR (not just FAIL) a loop lease held by a dead session past TTL (#3571).
+
+    Reclaims every ``loop:<name>``/``t3-master`` lease whose owning session is provably
+    dead (crashed, or a reused / cross-namespace pid) and reports the heal. Conservative,
+    idempotent, best-effort — any error degrades to a pass rather than aborting the run.
+    """
+    try:
+        from teatree.core.models import LoopLease  # noqa: PLC0415 — deferred: ORM import needs the app registry
+
+        reclaimed = LoopLease.objects.reclaim_dead_owner_leases()
+    except Exception as exc:  # noqa: BLE001 — a self-heal probe must never crash the doctor run
+        typer.echo(f"WARN  Dead-owner-lease check crashed: {exc.__class__.__name__}: {exc}")
+        return True
+    if reclaimed:
+        typer.echo(
+            f"WARN  Auto-reclaimed {len(reclaimed)} loop lease(s) held by a dead session past TTL "
+            f"({', '.join(sorted(reclaimed))}) — returned to the pool for a live worker to drive."
+        )
+    return True
+
+
 def _now() -> dt.datetime:
     from django.utils import timezone  # noqa: PLC0415 — deferred: Django import at call time
 
@@ -573,6 +581,7 @@ def run_self_heal_checks() -> bool:
         _check_failed_tasks_on_live_tickets,
         _check_runtime_clone_on_default_branch,
         _check_slack_drain_alive,
+        _check_dead_owner_lease,
     )
     ok = True
     for check in checks:

--- a/src/teatree/cli/worker.py
+++ b/src/teatree/cli/worker.py
@@ -98,10 +98,20 @@ def status_command(*, json_output: bool = typer.Option(False, "--json", help="Em
 
     ensure_django()
 
+    from teatree.utils.singleton import (  # noqa: PLC0415 (deferred: no Django/DB at CLI import)
+        WORKER_SINGLETON,
+        default_pid_path,
+        flock_is_held,
+    )
+
     holder = _flock_holder_pid()
+    # The pid file can be missing/stale while a worker actually holds the kernel flock
+    # (the pid file is diagnostic; the flock is the lock). Fall back to the flock probe
+    # so status never prints a false "NOT running" while loops are advancing (#3571).
+    flock_held = flock_is_held(WORKER_SINGLETON, pid_path=default_pid_path(WORKER_SINGLETON))
     enabled, source = _resolve_kill_switch()
     timers = _timer_counts()
-    running = holder is not None
+    running = holder is not None or flock_held
 
     if json_output:
         typer.echo(
@@ -109,6 +119,7 @@ def status_command(*, json_output: bool = typer.Option(False, "--json", help="Em
                 {
                     "running": running,
                     "holder_pid": holder,
+                    "flock_held": flock_held,
                     "loop_runner_enabled": enabled,
                     "source": source,
                     "timers": timers,
@@ -117,7 +128,12 @@ def status_command(*, json_output: bool = typer.Option(False, "--json", help="Em
         )
         return
 
-    state = f"RUNNING (pid {holder})" if running else "NOT running"
+    if holder is not None:
+        state = f"RUNNING (pid {holder})"
+    elif flock_held:
+        state = "RUNNING (flock held; pid file missing/stale)"
+    else:
+        state = "NOT running"
     typer.echo(f"worker: {state}")
     typer.echo(f"loop_runner_enabled: {enabled} (from {source})")
     if enabled and not running:

--- a/src/teatree/core/loop_lease_manager.py
+++ b/src/teatree/core/loop_lease_manager.py
@@ -7,21 +7,24 @@ one self-describing module. ``teatree.core.managers`` re-exports the public
 symbols so existing ``from teatree.core.managers import …`` call sites are
 unchanged.
 
-t3-master liveness is PID-ANCHORED, not TTL-anchored: an owner that is
-alive but BUSY past the tick TTL fires no Stop self-pump, so no tick
-re-claims and its lease TTL-lapses while the owner process is still alive.
-``claim_ownership`` therefore treats a non-empty owner whose ``owner_pid``
-is alive as a LIVE owner — protected past its TTL against any non-
-``take_over`` claim from a DIFFERENT process. The one exception is a
-same-process self-reclaim across a session-id rotation (#2835): when the
-live owner's ``owner_pid`` is the requesting caller's own pid, context
-compaction rotated the session id but the OS process is unchanged, so the
-lease is re-anchored to the new session id and the claim wins — every slot
-self-heals on its next tick. The TTL is the FALLBACK release, used only
-when ``owner_pid`` is null or dead. The doctrine has no ``renew()`` and no
-background timer (#54): the per-tick re-claim IS the heartbeat.
+Liveness is slot-aware via ``_session_lease_is_live``'s ``trust_pid_past_ttl``.
+The GLOBAL ``t3-master`` slot is PID-ANCHORED: an alive ``owner_pid`` keeps the
+lease live past its TTL (a busy owner fires no self-pump so no tick re-claims),
+transferring only on process death or a ``--take-over`` — the TTL is the
+fallback release, and there is no ``renew()`` / background timer (#54): the
+per-tick re-claim IS the heartbeat. A ``loop:<name>`` PER-LOOP slot does NOT
+trust ``pid_alive`` past its TTL (#3571): a dead session's pid is routinely
+reused / cross-namespace, so once its TTL lapses the lease is reclaimable
+regardless of pid liveness (the per-tick re-claim is that session's heartbeat),
+while a fresh TTL still reads live — preserving the duplicate-worker guard
+(#3534). ``reclaim_dead_owner_leases`` runs that reclaim on a cadence from the
+worker supervisor, ``run_boot_sweeps`` (``t3 recover``), and the self-heal
+watchdog. A same-process self-reclaim across a session-id rotation (#2835:
+compaction rotates the id but not the process) re-anchors either slot's lease
+to the new id and wins.
 """
 
+import logging
 from datetime import datetime, timedelta
 from typing import NamedTuple
 
@@ -29,6 +32,8 @@ from django.db import models
 from django.db.models import F, Q
 from django.db.models.expressions import Combinable
 from django.utils import timezone
+
+logger = logging.getLogger(__name__)
 
 #: The single machine-wide t3-master owner lease slot — the global owner
 #: lease whose holder IS the t3 master (autonomous-lane redesign §8.3,
@@ -164,64 +169,39 @@ class LoopLeaseQuerySet(models.QuerySet):
         ttl_seconds: int = 1800,
         driver: str = "",
     ) -> tuple[bool, str]:
-        """Claim/refresh the persistent session-scoped t3-master row (#1073).
+        """Claim/refresh a persistent session-scoped owner slot (#1073).
 
         The pid-anchored CAS / per-tick heartbeat path — for the unconditional
         user hand-off that evicts a live claimant, see :meth:`take_over_ownership`.
+        Returns ``(won, current_owner_session)`` (the owner read back *after* the
+        write, so a loser reports WHO holds it). Liveness is the slot-aware
+        :meth:`_live_foreign_owner_session` verdict: a genuinely-live foreign owner
+        BLOCKS the claim (no write), otherwise the backend-agnostic conditional
+        UPDATE CAS reclaims an unclaimed / this-session / stale row (correct on the
+        production SQLite backend where ``select_for_update`` is a silent no-op —
+        the #786 B1 lesson). No ``renew()`` / background timer (#54): the per-tick
+        re-claim IS the heartbeat.
 
-        Returns ``(won, current_owner_session)``. Ownership liveness is
-        PID-ANCHORED: a live owner is a non-empty ``session_id`` whose lease
-        is live, where "live" means ``lease_expires_at > now`` OR
-        ``pid_alive(owner_pid)``. An alive owner process is therefore
-        protected past its tick TTL — the invariant is "the loop stays with
-        the existing session; it transfers ONLY on that session's process
-        termination or an explicit take-over." The TTL is the FALLBACK
-        release used only when ``owner_pid`` is null or dead. There is still
-        NO ``renew()`` and no background timer (#54 doctrine preserved): the
-        per-tick re-claim IS the heartbeat.
+        An anonymous caller (``session_id == ""``) never persists a row: it RUNS
+        iff there is no live owner (#1107 pure-cron), never erasing a live owner's
+        row. A same-process self-reclaim across a session-id rotation (#2835 —
+        compaction rotates the id but not the process, so ``owner_pid`` is the
+        caller's own) re-anchors the lease to the new id and WINS, so any slot
+        self-heals without a manual ``t3 loop claim --take-over``.
 
-        An anonymous caller (``session_id == ""``) NEVER persists a row: it
-        RUNS (``won=True``) iff there is no live owner and otherwise SKIPs
-        (``won=False``). Pure-cron / no-session deployments (#1107) still
-        run the tick when unowned, but the phantom "owned by nobody but not
-        expired" row can never form and a live owner's row is never erased.
-        A pid-anchored reclaim then applies: a lease whose ``owner_pid`` is
-        ALIVE and whose ``session_id`` is a *different* non-empty session
-        BLOCKS the claim even if its TTL has lapsed — UNLESS that alive
-        ``owner_pid`` is the requesting caller's OWN pid (#2835): a
-        post-compaction same-process self-reclaim. Compaction rotates the
-        session id but does not restart the durable session process, so the
-        live lease is still ours; it is RE-ANCHORED to the rotated session
-        id and the claim WINS. This is slot-agnostic, so the master
-        ``t3-master`` and every ``loop:<name>`` per-loop
-        slot self-heal on their next tick without a manual ``t3 loop claim
-        --take-over``. Otherwise the existing backend-agnostic
-        conditional-UPDATE CAS runs (correct on the
-        production SQLite backend where ``select_for_update`` is a silent
-        no-op — the #786 B1 lesson): the ``WHERE`` matches only when the
-        claim is unclaimed (``session_id=""``), already this session's
-        (refresh), or stale (expired / never set), so a concurrent refresh
-        between our read and the write is still guarded against.
-
-        On a win the row's ``session_id``/``acquired_at``/
-        ``lease_expires_at``/``owner_pid`` are set. The returned
-        ``current_owner_session`` is read back *after* the write so a
-        loser reports WHO actually holds it.
-
-        ``owner_pid`` (#1604): the durable session process id (the long-lived
-        session process, not the ephemeral hook/tick subprocess). Stored on
-        win so ``evict_stale_owner`` can distinguish a post-compaction
-        same-process self-reclaim (same pid → safe to evict) from a
-        genuinely different live session (different live pid → KEEP).
-        Callers that cannot resolve the session pid pass ``None``; the
-        stored null is treated conservatively as "unknown → KEEP" (INV4).
+        ``owner_pid`` (#1604) is the durable session process id (not the ephemeral
+        tick subprocess); stored so :meth:`evict_stale_owner` can distinguish a
+        same-process self-reclaim (same pid) from a live foreign session, and a
+        null is treated conservatively as "unknown → KEEP" (INV4).
         """
         now = timezone.now()
         expires = now + timedelta(seconds=ttl_seconds)
         self.get_or_create(name=name)
 
         row = self.filter(name=name).values("session_id", "owner_pid", "lease_expires_at").first()
-        live_owner = self._live_foreign_owner_session(row, session_id, now)
+        live_owner = self._live_foreign_owner_session(
+            row, session_id, now, trust_pid_past_ttl=not is_per_loop_owner_slot(name)
+        )
 
         if not session_id:
             # An anonymous caller never persists ownership. It RUNS iff
@@ -331,29 +311,25 @@ class LoopLeaseQuerySet(models.QuerySet):
 
     @staticmethod
     def _session_lease_is_live(
-        session_id: str, owner_pid: int | None, expires_at: datetime | None, now: datetime
+        session_id: str,
+        owner_pid: int | None,
+        expires_at: datetime | None,
+        now: datetime,
+        *,
+        trust_pid_past_ttl: bool,
     ) -> bool:
-        """Whether a non-empty session's lease is live (pid-anchored, #1073/#1604).
+        """Whether a non-empty session's lease is live (#1073/#1604/#3571).
 
-        The single liveness predicate shared by every caller so the three
-        (``claim_ownership``/``_live_foreign_owner_session``,
-        ``ownership_status``, and ``evict_stale_owner``) can never drift.
-
-        Liveness is PID-ANCHORED, and a DETERMINATE pid verdict DOMINATES
-        the TTL — the pid is the source of truth, the TTL only a fallback:
-
-        - an alive ``owner_pid`` is live even past an expired TTL (the
-            busy-owner-past-TTL window #1604 targets);
-        - a determinately-DEAD ``owner_pid`` is NOT live even within an
-            unexpired TTL — the owner process is gone, so the lease is
-            reclaimable and the TTL must never keep a crashed owner's loop
-            hostage until it lapses.
-
-        The TTL is consulted ONLY when the pid verdict is INDETERMINATE —
-        ``owner_pid`` is null (unknown), or ``pid_alive`` is unavailable
-        (``ImportError``). In that indeterminate case the lease fails
-        CLOSED to the TTL: unexpired ⇒ live (KEEP), expired ⇒ reclaimable.
-        An empty ``session_id`` is never live.
+        The single liveness predicate every caller shares so they can never
+        drift. A determinately-DEAD ``owner_pid`` is NOT live at ANY TTL. An
+        ALIVE ``owner_pid`` past an expired TTL depends on ``trust_pid_past_ttl``
+        — the #3571 crux, since a dead session's pid is routinely reused /
+        cross-namespace so an alive pid is not proof the session is alive:
+        ``True`` (``t3-master``) keeps it live past TTL (the #1604 busy-owner
+        protection); ``False`` (a ``loop:<name>`` slot) falls through to the TTL
+        so a lapsed TTL is reclaimable while a fresh TTL still reads live. An
+        INDETERMINATE pid (null, or ``pid_alive`` unavailable) fails CLOSED to
+        the TTL. An empty ``session_id`` is never live.
         """
         if not session_id:
             return False
@@ -363,32 +339,34 @@ class LoopLeaseQuerySet(models.QuerySet):
             except ImportError:
                 pid_alive = None  # type: ignore[assignment]
             if pid_alive is not None:
-                # Determinate pid verdict: alive ⇒ live, dead ⇒ not live —
-                # regardless of whether the TTL has lapsed.
-                return pid_alive(owner_pid)
-        # Indeterminate pid (null ``owner_pid``, or ``pid_alive``
-        # unavailable): the TTL is the sole release timer — fail closed.
+                if not pid_alive(owner_pid):
+                    return False
+                if trust_pid_past_ttl:
+                    return True
+                # Per-loop slot: an alive-but-possibly-reused pid does not
+                # extend liveness past the TTL; fall through to the TTL backstop.
         return expires_at is not None and expires_at > now
 
     @classmethod
-    def _live_foreign_owner_session(cls, row: dict | None, session_id: str, now: datetime) -> str:
+    def _live_foreign_owner_session(
+        cls, row: dict | None, session_id: str, now: datetime, *, trust_pid_past_ttl: bool
+    ) -> str:
         """The non-empty session of a live owner *other than* ``session_id``, or ``""``.
 
-        A live owner is pid-anchored via :meth:`_session_lease_is_live`: its
-        lease is unexpired (``lease_expires_at > now``) OR its ``owner_pid``
-        is alive. The same session refreshing its own claim is never
-        "foreign". Returns ``""`` when the slot is unowned, owned by
-        ``session_id`` itself, or owned by a dead/null-pid + expired owner
-        (reclaimable). A null ``owner_pid`` is decided by the TTL check
-        alone; a ``pid_alive`` ``ImportError`` fails open to reclaimable
-        (treated as not-live), which is safe because the pid branch is gated
-        behind an already-lapsed TTL.
+        Live is the slot-aware :meth:`_session_lease_is_live` verdict; the same
+        session refreshing its own claim is never "foreign". Returns ``""`` when
+        the slot is unowned, owned by ``session_id`` itself, or held by a
+        dead/expired (reclaimable) owner.
         """
         owner_session = (row or {}).get("session_id") or ""
         if owner_session == session_id:
             return ""
         is_live = cls._session_lease_is_live(
-            owner_session, (row or {}).get("owner_pid"), (row or {}).get("lease_expires_at"), now
+            owner_session,
+            (row or {}).get("owner_pid"),
+            (row or {}).get("lease_expires_at"),
+            now,
+            trust_pid_past_ttl=trust_pid_past_ttl,
         )
         return owner_session if is_live else ""
 
@@ -418,7 +396,9 @@ class LoopLeaseQuerySet(models.QuerySet):
         """
         now = timezone.now()
         row = self.filter(name=name).values("session_id", "owner_pid", "lease_expires_at").first()
-        owner = self._live_foreign_owner_session(row, session_id, now)
+        owner = self._live_foreign_owner_session(
+            row, session_id, now, trust_pid_past_ttl=not is_per_loop_owner_slot(name)
+        )
         if not owner:
             return ""
         return owner if self._pid_is_foreign((row or {}).get("owner_pid"), current_pid) else ""
@@ -432,20 +412,17 @@ class LoopLeaseQuerySet(models.QuerySet):
     ) -> int:
         """Evict the ``name`` lease iff it is safe to do so (#1604/#1675).
 
-        Decision table (INV1 / INV4 / #786 B1 backend-agnostic CAS).
-        Liveness is PID-ANCHORED via :meth:`_session_lease_is_live` — the
-        same predicate ``claim_ownership`` and ``ownership_status`` use —
-        so an owner that is alive but BUSY past its tick TTL is a LIVE
-        owner here too and is never blanked, while a determinately-DEAD
-        owner is reclaimable even within an unexpired TTL:
+        Decision table (INV1 / INV4 / #786 B1 backend-agnostic CAS). Liveness
+        routes through the slot-aware :meth:`_session_lease_is_live`, so a busy
+        ``t3-master`` owner is LIVE and never blanked (#1604) while a ``loop:
+        <name>`` owner past its TTL is NOT live regardless of a reused alive pid
+        and so is EVICTED (#3571):
 
-        - Not live — a determinately-DEAD ``owner_pid`` (at ANY TTL), or an
-            indeterminate pid (null / ``pid_alive`` unavailable) past an
-            EXPIRED TTL: EVICT (the owner is gone).
-        - Live (alive owner_pid, or unexpired TTL with an indeterminate
-            pid) + same pid: EVICT (post-compaction same-process
-            self-reclaim; session rotated its id — the pid match is the
-            safety condition, regardless of TTL).
+        - Not live — a determinately-DEAD ``owner_pid`` (ANY TTL); an
+            indeterminate pid past an EXPIRED TTL; or (per-loop) any owner past
+            an EXPIRED TTL: EVICT (the owning session is gone).
+        - Live + same pid: EVICT (post-compaction same-process self-reclaim —
+            the pid match is the safety condition, regardless of TTL).
         - Live + null owner_pid: KEEP (unknown process, INV4 bias).
         - Live + alive owner_pid != current_pid: KEEP (INV1, foreign lease).
 
@@ -471,7 +448,9 @@ class LoopLeaseQuerySet(models.QuerySet):
 
         expires_at = row["lease_expires_at"]
         stored_pid = row["owner_pid"]
-        is_live = self._session_lease_is_live(row["session_id"], stored_pid, expires_at, now)
+        is_live = self._session_lease_is_live(
+            row["session_id"], stored_pid, expires_at, now, trust_pid_past_ttl=not is_per_loop_owner_slot(name)
+        )
 
         if not is_live:
             # The owner is gone — either an expired TTL with an indeterminate
@@ -503,6 +482,36 @@ class LoopLeaseQuerySet(models.QuerySet):
             )
 
         return 0
+
+    def reclaim_dead_owner_leases(self, *, current_pid: int | None = None) -> list[str]:
+        """Orphan every owner-slot lease whose owning SESSION is provably dead (#3571).
+
+        The background reclaim the worker supervisor, ``run_boot_sweeps`` (``t3
+        recover``) and the self-heal watchdog run on a cadence so a dead session's
+        lease is returned to the pool instead of blocking the live worker forever.
+        Delegates the per-slot decision to :meth:`evict_stale_owner` (``keep_session_id
+        =""`` keeps nothing; ``current_pid=None`` so the same-process carve-out never
+        fires), which routes through the shared discriminator — a busy ``t3-master``
+        owner is KEPT (#1604), a per-loop lease past its TTL is reclaimed regardless of
+        a reused pid, a fresh-heartbeat owner is never touched. Idempotent and
+        conservative. Returns the reclaimed slot names; every eviction is logged loudly.
+        """
+        reclaimed: list[str] = []
+        owned = self.exclude(session_id="").values("name", "session_id", "owner_pid", "lease_expires_at")
+        for row in list(owned):
+            name = row["name"]
+            if not self.evict_stale_owner(name, keep_session_id="", current_pid=current_pid):
+                continue
+            reclaimed.append(name)
+            logger.warning(
+                "Reclaimed dead-owner loop lease %r (session %r, owner_pid %s, expired at %s): the owning "
+                "session is provably dead past TTL, returning the lease to the pool (#3571).",
+                name,
+                row["session_id"],
+                row["owner_pid"],
+                row["lease_expires_at"],
+            )
+        return reclaimed
 
     def heartbeat_ownership(self, name: str, *, session_id: str, ttl_seconds: int = 1800) -> bool:
         """Extend the t3-master lease IFF this session still holds it (#1073).
@@ -538,7 +547,9 @@ class LoopLeaseQuerySet(models.QuerySet):
             return OwnershipStatus(owner_session="", expires_at=None, is_live=False, generation=0, driver="")
         session = row["session_id"] or ""
         expires_at = row["lease_expires_at"]
-        is_live = self._session_lease_is_live(session, row["owner_pid"], expires_at, timezone.now())
+        is_live = self._session_lease_is_live(
+            session, row["owner_pid"], expires_at, timezone.now(), trust_pid_past_ttl=not is_per_loop_owner_slot(name)
+        )
         return OwnershipStatus(
             owner_session=session,
             expires_at=expires_at,

--- a/src/teatree/core/models/loop_lease.py
+++ b/src/teatree/core/models/loop_lease.py
@@ -39,18 +39,22 @@ different live pid → KEEP) from a post-compaction same-session restart
 (same pid → safe to evict). A null ``owner_pid`` is treated conservatively
 as "owner process unknown → KEEP" (INV4: bias toward preservation).
 
-t3-master liveness is PID-ANCHORED, not TTL-anchored. An owner that is
-alive but BUSY past the tick TTL fires no Stop self-pump, so no tick
-re-claims and the lease TTL-lapses while the owner process is still alive.
-``claim_ownership`` therefore treats a non-empty owner whose ``owner_pid``
-is alive as a LIVE owner — protected past its TTL against any non-
-``take_over`` claim from a DIFFERENT process — so the loop stays with the
-existing process and transfers ONLY on that process's termination or an
+The GLOBAL ``t3-master`` slot's liveness is PID-ANCHORED, not TTL-anchored.
+An owner that is alive but BUSY past the tick TTL fires no Stop self-pump, so
+no tick re-claims and the lease TTL-lapses while the owner process is still
+alive. ``claim_ownership`` therefore treats a non-empty ``t3-master`` owner
+whose ``owner_pid`` is alive as a LIVE owner — protected past its TTL against
+any non-``take_over`` claim from a DIFFERENT process — so the loop stays with
+the existing process and transfers ONLY on that process's termination or an
 explicit ``t3 loop claim --take-over``. A same-process session-id rotation
 (#2835: context compaction rotates the id but not the process) is NOT a
 transfer: the lease is re-anchored to the new session id and the same
 process keeps the loop. The TTL is the FALLBACK release, used only
-when ``owner_pid`` is null or dead. An anonymous caller (``session_id ==
+when ``owner_pid`` is null or dead. A ``loop:<name>`` PER-LOOP slot does NOT
+trust ``pid_alive`` past its TTL (#3571): a dead session's pid is routinely
+reused / cross-namespace, so once its TTL lapses the lease is reclaimable
+regardless of pid liveness (the per-tick re-claim is that session's
+heartbeat), while a fresh TTL still reads live. An anonymous caller (``session_id ==
 ""``, e.g. a Bash-tool tick that never sees the id, #1107) never persists
 ownership: it runs the tick when unowned but can never write the phantom
 "owned by nobody but not expired" row that previously enabled a fresh

--- a/src/teatree/core/worktree/recover.py
+++ b/src/teatree/core/worktree/recover.py
@@ -31,6 +31,7 @@ class BootSweepsDict(TypedDict):
     replayed_transitions: int
     reclaimed_claims: int
     reaped_claims: int
+    reclaimed_leases: int
 
 
 class OrphanDict(TypedDict):
@@ -109,6 +110,7 @@ class RecoverReport:
                 replayed_transitions=self.boot_sweeps.replayed_transitions,
                 reclaimed_claims=self.boot_sweeps.reclaimed_claims,
                 reaped_claims=self.boot_sweeps.reaped_claims,
+                reclaimed_leases=self.boot_sweeps.reclaimed_leases,
             ),
             data_loss_risk=[self._orphan_dict(o) for o in self.data_loss_risk],
             committed_unpushed=[self._orphan_dict(o) for o in self.committed_unpushed],
@@ -141,7 +143,8 @@ class RecoverReport:
         sweeps = self.boot_sweeps
         sweep_line = (
             f"boot sweeps: replayed={sweeps.replayed_transitions} "
-            f"reclaimed={sweeps.reclaimed_claims} reaped={sweeps.reaped_claims}"
+            f"reclaimed={sweeps.reclaimed_claims} reaped={sweeps.reaped_claims} "
+            f"leases={sweeps.reclaimed_leases}"
         )
         lines = [header, sweep_line]
         lines += self._render_orphans("Data-loss risk (unpushed)", self.data_loss_risk)

--- a/src/teatree/core/worktree/recovery_sweeps.py
+++ b/src/teatree/core/worktree/recovery_sweeps.py
@@ -1,10 +1,12 @@
 """Boot/tick recovery sweeps — the single SSOT shared by the loop and ``t3 recover``.
 
-Three idempotent sweeps, ordered so a recoverable row is rescued before a harsher
+Four idempotent sweeps, ordered so a recoverable row is rescued before a harsher
 sweep can fail it: ``replay_orphaned_transitions`` (#883) replays an FSM
 transition a mid-transition crash dropped; ``reclaim_orphaned_claims`` (#652)
 returns an expired-lease CLAIMED task to PENDING so another open session resumes
-it; ``reap_stale_claims`` fails any residual stale CLAIMED row.
+it; ``reap_stale_claims`` fails any residual stale CLAIMED row; and
+``reclaim_dead_owner_leases`` (#3571) orphans a ``loop:<name>``/``t3-master`` lease
+whose owning session is provably dead so the live worker stops SKIPping the loop.
 
 Lives in ``teatree.core`` (not ``teatree.loop``) so ``t3 recover`` (#1764) can
 compose it without ``core`` depending on ``loop`` — the dependency direction the
@@ -13,7 +15,7 @@ architecture enforces. ``loop/tick_recovery`` imports it from here.
 
 from dataclasses import dataclass
 
-from teatree.core.models import Task
+from teatree.core.models import LoopLease, Task
 
 
 @dataclass(frozen=True, slots=True)
@@ -23,12 +25,14 @@ class BootSweepCounts:
     replayed_transitions: int = 0
     reclaimed_claims: int = 0
     reaped_claims: int = 0
+    reclaimed_leases: int = 0
 
 
 def run_boot_sweeps() -> BootSweepCounts:
-    """Run the three sweeps in rescue-before-fail order and return per-sweep counts."""
+    """Run the sweeps in rescue-before-fail order and return per-sweep counts."""
     return BootSweepCounts(
         replayed_transitions=Task.objects.replay_orphaned_transitions(),
         reclaimed_claims=Task.objects.reclaim_orphaned_claims(),
         reaped_claims=Task.objects.reap_stale_claims(),
+        reclaimed_leases=len(LoopLease.objects.reclaim_dead_owner_leases()),
     )

--- a/src/teatree/loops/worker.py
+++ b/src/teatree/loops/worker.py
@@ -133,6 +133,19 @@ def _build_executor(queue_name: str, worker_id: str) -> "Worker":
     )
 
 
+def _reclaim_dead_owner_leases() -> None:
+    """Return every ``loop:<name>``/``t3-master`` lease held by a dead session to the pool (#3571).
+
+    The worker supervisor's runtime half of the dead-owner reclaim (``run_boot_sweeps``
+    owns the boot half): a loop whose owning session crashed — or whose pid was reused /
+    lives in another container namespace — is otherwise SKIPped by the live worker
+    forever. Lazy-imported so the module's import graph carries no Django/ORM edge.
+    """
+    from teatree.core.models import LoopLease  # noqa: PLC0415 — deferred: ORM import needs the app registry
+
+    LoopLease.objects.reclaim_dead_owner_leases()
+
+
 def _spawn_executor_thread(executor: _Executor) -> _Handle:
     """Run *executor* in a daemon thread that closes its DB connection on exit.
 
@@ -167,6 +180,7 @@ class WorkerSeams:
     make_executor: Callable[[str, str], _Executor] = _build_executor
     spawn: Callable[[_Executor], _Handle] = _spawn_executor_thread
     kill_ticks: Callable[[], object] = kill_live_tick_process_groups
+    reclaim_leases: Callable[[], object] = _reclaim_dead_owner_leases
     sleep: Callable[[float], None] = time.sleep
     poll_seconds: float = SUPERVISOR_POLL_SECONDS
     max_respawns: int = MAX_EXECUTOR_RESPAWNS
@@ -230,6 +244,13 @@ class LoopWorker:
             self._slots[i] = self._spawn_slot(slot.queue, slot.index, respawns=slot.respawns + 1)
         return False
 
+    def _reclaim_dead_owner_leases(self) -> None:
+        """Sweep dead-owner loop leases; a reclaim error must never crash the supervisor (#3571)."""
+        try:
+            self._seams.reclaim_leases()
+        except Exception:
+            logger.warning("Dead-owner loop-lease reclaim failed this poll; will retry next tick.", exc_info=True)
+
     def run(self) -> None:
         """Reconcile, expire stale jobs, start the executors, supervise (kill-switch + liveness), then join and exit."""
         seams = self._seams
@@ -249,6 +270,7 @@ class LoopWorker:
                 if self._respawn_dead_executors():
                     crashed = True
                     break
+                self._reclaim_dead_owner_leases()
         finally:
             self.request_stop()
             for slot in self._slots:

--- a/tests/teatree_cli/doctor/test_self_heal_dead_owner_lease.py
+++ b/tests/teatree_cli/doctor/test_self_heal_dead_owner_lease.py
@@ -1,0 +1,81 @@
+"""``_check_dead_owner_lease`` — the self-repairing dead-session loop-lease watchdog (#3571).
+
+Unlike the FAIL-only silent-freeze detectors, this one AUTO-REPAIRS: it reclaims a
+``loop:<name>``/``t3-master`` lease held by a provably-dead session past TTL and reports
+what it healed. Conservative + idempotent — a second run finds nothing to do.
+"""
+
+import datetime as dt
+import io
+from collections.abc import Callable
+from contextlib import redirect_stdout
+
+import pytest
+from django.utils import timezone
+
+from teatree.cli.doctor import self_heal
+from teatree.core.models import LoopLease
+
+# ast-grep-ignore: ac-django-no-pytest-django-db
+pytestmark = pytest.mark.django_db
+
+
+def _echoes(check: Callable[[], bool]) -> tuple[bool, str]:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        ok = check()
+    return ok, buf.getvalue()
+
+
+def _seed_dead(slot: str) -> None:
+    now = timezone.now()
+    LoopLease.objects.create(
+        name=slot,
+        session_id="dead-session",
+        owner_pid=None,
+        acquired_at=now - dt.timedelta(seconds=3600),
+        lease_expires_at=now - dt.timedelta(seconds=60),
+    )
+
+
+class DeadOwnerLeaseCheckTest:
+    def test_auto_repairs_and_reports_the_heal(self) -> None:
+        _seed_dead("loop:dispatch")
+
+        ok, out = _echoes(self_heal._check_dead_owner_lease)
+
+        assert ok is True, "an auto-healed lease is not a standing FAIL"
+        assert "loop:dispatch" in out
+        assert LoopLease.objects.get(name="loop:dispatch").session_id == ""
+
+    def test_idempotent_second_run_is_silent(self) -> None:
+        _seed_dead("loop:dispatch")
+
+        _echoes(self_heal._check_dead_owner_lease)
+        ok, out = _echoes(self_heal._check_dead_owner_lease)
+
+        assert ok is True
+        assert out == ""
+
+    def test_live_owner_is_never_touched(self) -> None:
+        now = timezone.now()
+        LoopLease.objects.create(
+            name="loop:dispatch",
+            session_id="live-session",
+            owner_pid=None,
+            acquired_at=now,
+            lease_expires_at=now + dt.timedelta(seconds=1800),
+        )
+
+        ok, out = _echoes(self_heal._check_dead_owner_lease)
+
+        assert ok is True
+        assert out == ""
+        assert LoopLease.objects.get(name="loop:dispatch").session_id == "live-session"
+
+    def test_registered_in_the_check_sequence(self) -> None:
+        _seed_dead("loop:dispatch")
+
+        assert self_heal.run_self_heal_checks() is not None
+        # The sweep runs as part of the aggregate, so the dead lease is cleared.
+        assert LoopLease.objects.get(name="loop:dispatch").session_id == ""

--- a/tests/teatree_cli/test_cli_worker.py
+++ b/tests/teatree_cli/test_cli_worker.py
@@ -23,7 +23,10 @@ runner = CliRunner()
 
 class TestWorkerStatus(django.test.TestCase):
     def test_status_reports_not_running_and_enabled_by_default(self) -> None:
-        with mock.patch.object(worker_cli, "_flock_holder_pid", return_value=None):
+        with (
+            mock.patch.object(worker_cli, "_flock_holder_pid", return_value=None),
+            mock.patch("teatree.utils.singleton.flock_is_held", return_value=False),
+        ):
             result = runner.invoke(worker_app, ["status"])
         assert result.exit_code == 0
         assert "NOT running" in result.stdout
@@ -41,6 +44,40 @@ class TestWorkerStatus(django.test.TestCase):
         assert payload["loop_runner_enabled"] is True
         assert payload["source"] == "default"
         assert isinstance(payload["timers"], dict)
+
+    def test_status_reports_running_via_flock_when_pid_file_absent(self) -> None:
+        # The flock is HELD by a live worker but the pid file is missing/stale, so
+        # `read_pid` returns None — status must not print a false "NOT running" (#3571).
+        with (
+            mock.patch.object(worker_cli, "_flock_holder_pid", return_value=None),
+            mock.patch("teatree.utils.singleton.flock_is_held", return_value=True),
+        ):
+            result = runner.invoke(worker_app, ["status"])
+        assert result.exit_code == 0
+        assert "NOT running" not in result.stdout
+        assert "RUNNING" in result.stdout
+        assert "t3 worker ensure" not in result.stdout
+
+    def test_status_json_flock_fallback_marks_running(self) -> None:
+        with (
+            mock.patch.object(worker_cli, "_flock_holder_pid", return_value=None),
+            mock.patch("teatree.utils.singleton.flock_is_held", return_value=True),
+        ):
+            result = runner.invoke(worker_app, ["status", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload["running"] is True
+        assert payload["holder_pid"] is None
+        assert payload["flock_held"] is True
+
+    def test_status_not_running_when_flock_free(self) -> None:
+        with (
+            mock.patch.object(worker_cli, "_flock_holder_pid", return_value=None),
+            mock.patch("teatree.utils.singleton.flock_is_held", return_value=False),
+        ):
+            result = runner.invoke(worker_app, ["status"])
+        assert result.exit_code == 0
+        assert "NOT running" in result.stdout
 
 
 class TestWorkerEnsure(django.test.TestCase):

--- a/tests/teatree_core/test_loop_lease_dead_session_reclaim.py
+++ b/tests/teatree_core/test_loop_lease_dead_session_reclaim.py
@@ -1,0 +1,175 @@
+"""Dead-session per-loop lease reclaim — the ``pid_alive``-forever trap (#3571).
+
+A ``loop:<name>`` lease anchored on a NON-null ``owner_pid`` was kept live forever
+whenever ``pid_alive(owner_pid)`` returned ``True`` — but a dead owner session's pid
+is routinely REUSED (or belongs to a DIFFERENT container namespace), so ``pid_alive``
+lies and the live worker SKIPs the loop indefinitely. The fix: for a per-loop slot the
+alive-pid verdict no longer overrides an EXPIRED TTL — the per-tick re-claim IS the
+owning session's heartbeat, so a lapsed TTL means the session stopped driving the loop
+and the lease is reclaimable. The global ``t3-master`` slot keeps its #1604 pid-anchored
+busy-owner protection (a live pid past TTL stays), so this must not regress it.
+"""
+
+import datetime as dt
+import logging
+
+import pytest
+from django.utils import timezone
+
+from teatree.core.models import LoopLease
+
+# ast-grep-ignore: ac-django-no-pytest-django-db
+pytestmark = pytest.mark.django_db
+
+_PER_LOOP_SLOT = "loop:dispatch"
+_MASTER_SLOT = "t3-master"
+_DEAD_SESSION = "dead-session"
+_LIVE_WORKER_SESSION = "live-worker"
+#: The dead owner's pid, still "alive" because it was reused by an unrelated process.
+_REUSED_PID = 4242
+#: The live worker's own distinct pid.
+_WORKER_PID = 100
+
+
+def _seed(slot: str, *, session_id: str, owner_pid: int | None, expires_delta_seconds: int) -> None:
+    now = timezone.now()
+    LoopLease.objects.create(
+        name=slot,
+        session_id=session_id,
+        owner_pid=owner_pid,
+        acquired_at=now - dt.timedelta(seconds=1800),
+        lease_expires_at=now + dt.timedelta(seconds=expires_delta_seconds),
+    )
+
+
+def _pid_alive(alive: set[int]):
+    return lambda pid: pid in alive
+
+
+class TestPerLoopDeadSessionReusedPid:
+    """A per-loop lease with a REUSED-but-alive pid past TTL is reclaimable (the bug)."""
+
+    def test_live_worker_claims_dead_session_lease(self) -> None:
+        _seed(_PER_LOOP_SLOT, session_id=_DEAD_SESSION, owner_pid=_REUSED_PID, expires_delta_seconds=-60)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("teatree.utils.singleton.pid_alive", _pid_alive({_REUSED_PID, _WORKER_PID}))
+            won, owner = LoopLease.objects.claim_ownership(
+                _PER_LOOP_SLOT, session_id=_LIVE_WORKER_SESSION, owner_pid=_WORKER_PID, ttl_seconds=1800
+            )
+
+        assert won is True, "a live worker must reclaim a per-loop lease whose owning session is dead"
+        assert owner == _LIVE_WORKER_SESSION
+        assert LoopLease.objects.get(name=_PER_LOOP_SLOT).session_id == _LIVE_WORKER_SESSION
+
+    def test_reclaim_sweep_orphans_it(self) -> None:
+        _seed(_PER_LOOP_SLOT, session_id=_DEAD_SESSION, owner_pid=_REUSED_PID, expires_delta_seconds=-60)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("teatree.utils.singleton.pid_alive", _pid_alive({_REUSED_PID}))
+            reclaimed = LoopLease.objects.reclaim_dead_owner_leases()
+
+        assert reclaimed == [_PER_LOOP_SLOT]
+        row = LoopLease.objects.get(name=_PER_LOOP_SLOT)
+        assert row.session_id == ""
+        assert row.owner_pid is None
+
+
+class TestPerLoopLiveOwnerNotStolen:
+    """A genuinely live owner (fresh heartbeat / fresh TTL) is never stolen — the #3534 guard."""
+
+    def test_fresh_heartbeat_blocks_takeover(self) -> None:
+        _seed(_PER_LOOP_SLOT, session_id=_DEAD_SESSION, owner_pid=_REUSED_PID, expires_delta_seconds=1800)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("teatree.utils.singleton.pid_alive", _pid_alive({_REUSED_PID, _WORKER_PID}))
+            won, owner = LoopLease.objects.claim_ownership(
+                _PER_LOOP_SLOT, session_id=_LIVE_WORKER_SESSION, owner_pid=_WORKER_PID, ttl_seconds=1800
+            )
+
+        assert won is False, "a fresh-heartbeat live owner must never be stolen (duplicate-run hazard)"
+        assert owner == _DEAD_SESSION
+        assert LoopLease.objects.get(name=_PER_LOOP_SLOT).session_id == _DEAD_SESSION
+
+    def test_reclaim_sweep_keeps_live_owner(self) -> None:
+        _seed(_PER_LOOP_SLOT, session_id="live-owner", owner_pid=_REUSED_PID, expires_delta_seconds=1800)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("teatree.utils.singleton.pid_alive", _pid_alive({_REUSED_PID}))
+            reclaimed = LoopLease.objects.reclaim_dead_owner_leases()
+
+        assert reclaimed == []
+        assert LoopLease.objects.get(name=_PER_LOOP_SLOT).session_id == "live-owner"
+
+
+class TestPerLoopIndeterminateOwnerTTL:
+    """A null-pid (indeterminate) owner falls back to the TTL: reclaimed once expired, kept while fresh."""
+
+    def test_expired_null_pid_is_reclaimed(self) -> None:
+        _seed(_PER_LOOP_SLOT, session_id=_DEAD_SESSION, owner_pid=None, expires_delta_seconds=-60)
+
+        reclaimed = LoopLease.objects.reclaim_dead_owner_leases()
+
+        assert reclaimed == [_PER_LOOP_SLOT]
+        assert LoopLease.objects.get(name=_PER_LOOP_SLOT).session_id == ""
+
+    def test_fresh_null_pid_is_kept(self) -> None:
+        _seed(_PER_LOOP_SLOT, session_id=_DEAD_SESSION, owner_pid=None, expires_delta_seconds=1800)
+
+        reclaimed = LoopLease.objects.reclaim_dead_owner_leases()
+
+        assert reclaimed == []
+        assert LoopLease.objects.get(name=_PER_LOOP_SLOT).session_id == _DEAD_SESSION
+
+
+class TestMasterSlotBusyOwnerPreserved:
+    """The global ``t3-master`` slot keeps its #1604 busy-owner-past-TTL protection (no regression)."""
+
+    def test_alive_pid_past_ttl_is_not_reclaimed(self) -> None:
+        _seed(_MASTER_SLOT, session_id="master", owner_pid=_REUSED_PID, expires_delta_seconds=-60)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("teatree.utils.singleton.pid_alive", _pid_alive({_REUSED_PID}))
+            reclaimed = LoopLease.objects.reclaim_dead_owner_leases()
+            won, owner = LoopLease.objects.claim_ownership(
+                _MASTER_SLOT, session_id="fresh", owner_pid=_WORKER_PID, ttl_seconds=1800
+            )
+
+        assert reclaimed == [], "a busy t3-master owner (alive pid) must be preserved past its TTL"
+        assert won is False
+        assert owner == "master"
+
+    def test_dead_pid_past_ttl_is_reclaimed(self) -> None:
+        _seed(_MASTER_SLOT, session_id="master", owner_pid=_REUSED_PID, expires_delta_seconds=-60)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("teatree.utils.singleton.pid_alive", _pid_alive(set()))
+            reclaimed = LoopLease.objects.reclaim_dead_owner_leases()
+
+        assert reclaimed == [_MASTER_SLOT], "a provably-dead t3-master owner is still reclaimed"
+
+
+class TestReclaimSweepProperties:
+    """Idempotence + loud logging of every eviction."""
+
+    def test_second_sweep_is_a_noop(self) -> None:
+        _seed(_PER_LOOP_SLOT, session_id=_DEAD_SESSION, owner_pid=None, expires_delta_seconds=-60)
+
+        first = LoopLease.objects.reclaim_dead_owner_leases()
+        second = LoopLease.objects.reclaim_dead_owner_leases()
+
+        assert first == [_PER_LOOP_SLOT]
+        assert second == []
+
+    def test_eviction_logs_loudly(self, caplog: pytest.LogCaptureFixture) -> None:
+        _seed(_PER_LOOP_SLOT, session_id=_DEAD_SESSION, owner_pid=None, expires_delta_seconds=-60)
+
+        with caplog.at_level(logging.WARNING, logger="teatree.core.loop_lease_manager"):
+            LoopLease.objects.reclaim_dead_owner_leases()
+
+        assert any(_PER_LOOP_SLOT in rec.getMessage() and _DEAD_SESSION in rec.getMessage() for rec in caplog.records)
+
+    def test_unowned_rows_are_never_touched(self) -> None:
+        LoopLease.objects.create(name="loop-tick", owner="", session_id="")
+
+        assert LoopLease.objects.reclaim_dead_owner_leases() == []

--- a/tests/teatree_core/test_loop_ownership.py
+++ b/tests/teatree_core/test_loop_ownership.py
@@ -584,14 +584,30 @@ class TestPerLoopOwnershipReusesGlobalMachinery(TestCase):
         assert won is True
         assert owner == "successor"
 
-    def test_per_loop_alive_pid_blocks_reclaim_past_ttl(self) -> None:
-        """pid-liveness guard fires per-loop too (busy owner past TTL is protected)."""
+    def test_per_loop_alive_pid_past_ttl_is_reclaimable(self) -> None:
+        """A per-loop lease past its TTL is reclaimed even with an alive pid (#3571).
+
+        The per-tick re-claim IS the owning session's heartbeat, so a lapsed TTL means
+        the session stopped driving this loop; the pid can be reused / cross-namespace,
+        so it is not trusted past the TTL for a ``loop:<name>`` slot. A FRESH-TTL live
+        owner is still protected — see ``test_per_loop_foreign_live_session_is_blocked``.
+        """
         slot = per_loop_owner_slot("dispatch")
         LoopLease.objects.claim_ownership(slot, session_id="busy", ttl_seconds=1, owner_pid=os.getpid())
         row = LoopLease.objects.get(name=slot)
         row.lease_expires_at = timezone.now() - timedelta(seconds=5)
         row.save(update_fields=["lease_expires_at"])
         won, owner = LoopLease.objects.claim_ownership(slot, session_id="newcomer")
+        assert won is True
+        assert owner == "newcomer"
+
+    def test_master_alive_pid_blocks_reclaim_past_ttl(self) -> None:
+        """The global ``t3-master`` slot keeps its #1604 busy-owner-past-TTL protection."""
+        LoopLease.objects.claim_ownership(T3_MASTER_SLOT, session_id="busy", ttl_seconds=1, owner_pid=os.getpid())
+        row = LoopLease.objects.get(name=T3_MASTER_SLOT)
+        row.lease_expires_at = timezone.now() - timedelta(seconds=5)
+        row.save(update_fields=["lease_expires_at"])
+        won, owner = LoopLease.objects.claim_ownership(T3_MASTER_SLOT, session_id="newcomer")
         assert won is False
         assert owner == "busy"
 

--- a/tests/teatree_core/test_recover_reclaims_dead_leases.py
+++ b/tests/teatree_core/test_recover_reclaims_dead_leases.py
@@ -1,0 +1,48 @@
+"""``run_boot_sweeps`` reclaims dead-session loop leases so ``t3 recover`` unblocks them (#3571).
+
+Before #3571 the boot sweep reclaimed only ``Task`` rows; a ``loop:<name>`` lease held by
+a dead session was invisible to it, so ``t3 recover`` never cleared the frozen loop.
+"""
+
+import datetime as dt
+
+import pytest
+from django.utils import timezone
+
+from teatree.core.models import LoopLease
+from teatree.core.worktree.recovery_sweeps import run_boot_sweeps
+
+# ast-grep-ignore: ac-django-no-pytest-django-db
+pytestmark = pytest.mark.django_db
+
+
+class TestBootSweepReclaimsDeadLeases:
+    def test_boot_sweep_reclaims_dead_session_lease(self) -> None:
+        now = timezone.now()
+        LoopLease.objects.create(
+            name="loop:dispatch",
+            session_id="dead-session",
+            owner_pid=None,
+            acquired_at=now - dt.timedelta(seconds=3600),
+            lease_expires_at=now - dt.timedelta(seconds=60),
+        )
+
+        counts = run_boot_sweeps()
+
+        assert counts.reclaimed_leases == 1
+        assert LoopLease.objects.get(name="loop:dispatch").session_id == ""
+
+    def test_boot_sweep_keeps_live_owner_lease(self) -> None:
+        now = timezone.now()
+        LoopLease.objects.create(
+            name="loop:dispatch",
+            session_id="live-session",
+            owner_pid=None,
+            acquired_at=now,
+            lease_expires_at=now + dt.timedelta(seconds=1800),
+        )
+
+        counts = run_boot_sweeps()
+
+        assert counts.reclaimed_leases == 0
+        assert LoopLease.objects.get(name="loop:dispatch").session_id == "live-session"

--- a/tests/teatree_loops/test_worker.py
+++ b/tests/teatree_loops/test_worker.py
@@ -80,8 +80,36 @@ def _make_worker(*, enabled, sleep, **seam_overrides):
         spawn=spawn,
         sleep=sleep,
         poll_seconds=0.0,
+        reclaim_leases=seam_overrides.get("reclaim_leases") or (lambda: None),
     )
     return LoopWorker(seams), built, handles
+
+
+def test_supervisor_reclaims_dead_owner_leases_each_poll() -> None:
+    reclaims: list[int] = []
+    states = iter([True, False])  # one supervised poll, then flip off
+    worker, _built, _ = _make_worker(
+        enabled=lambda: next(states, False),
+        sleep=lambda _s: None,
+        reclaim_leases=lambda: reclaims.append(1),
+    )
+    worker.run()
+    assert reclaims, "the supervisor must sweep dead-owner loop leases on its poll cadence (#3571)"
+
+
+def test_supervisor_survives_a_reclaim_error() -> None:
+    def _boom() -> None:
+        msg = "db hiccup"
+        raise RuntimeError(msg)
+
+    states = iter([True, False])
+    worker, _built, handles = _make_worker(
+        enabled=lambda: next(states, False),
+        sleep=lambda _s: None,
+        reclaim_leases=_boom,
+    )
+    worker.run()  # a reclaim error must never crash the supervisor
+    assert all(handle.joined for handle in handles)
 
 
 def test_reconciles_seeds_and_expires_before_starting_executors() -> None:


### PR DESCRIPTION
Closes #3571.

## Problem
Per-loop `loop:<name>` lease slots use the pid-anchored `claim_ownership`. Liveness was decided by `_session_lease_is_live`, which for a non-null `owner_pid` returned whatever `pid_alive(owner_pid)` said and never consulted the TTL. When the owning session was dead but its pid was **reused** or lived in **another container namespace**, `pid_alive` returned `True` → the claim was blocked with no write → the live worker SKIPped that loop **forever**. Nothing auto-reclaimed it: `evict_stale_owner()` had zero production callers, and `run_boot_sweeps` only reclaimed `Task` rows.

## Fix
1. **Liveness discriminator** — `_session_lease_is_live` gains a slot-aware `trust_pid_past_ttl`. The global `t3-master` slot keeps its #1604 busy-owner-past-TTL protection (an alive pid stays live). A `loop:<name>` per-loop slot no longer trusts an alive-but-possibly-reused pid past its TTL: the per-tick re-claim IS the owning session's heartbeat, so a lapsed TTL means the session stopped driving the loop and the lease is reclaimable — while a **fresh** TTL still reads live, preserving the #3534 duplicate-worker guard. A determinately-dead pid remains not-live at any TTL.
2. **Background reclaim** — `LoopLease.objects.reclaim_dead_owner_leases()` sweeps every owner-slot lease whose owning session is provably dead, routing each through `evict_stale_owner`, logging every eviction. It runs on the worker-supervisor poll cadence (`teatree.loops.worker`) and from `run_boot_sweeps` (so `t3 recover` clears dead `LoopLease` rows too).
3. **Self-heal watchdog** — a new `_check_dead_owner_lease` doctor check AUTO-REPAIRS (reclaims + reports the heal) instead of only reddening; conservative and idempotent.
4. **`t3 worker status` false alarm** — status now falls back to the kernel flock (`flock_is_held`) when the pid file is missing/stale, so it no longer prints a false "NOT running" while a worker holds the flock.

## Architecture pre-check — #3571

## 1. BLUEPRINT § alignment
Loop-ownership lease semantics (§5.6 loop topology / control plane). No doctrine contradiction — the pid-anchored `t3-master` contract is preserved; the per-loop TTL-backstop is an added, documented refinement. No BLUEPRINT prose stated the per-loop pid-forever behaviour, so no BLUEPRINT edit is needed (the pre-commit BLUEPRINT-sync gate passed).

## 2. FSM phase boundaries
n/a — no `Ticket.State`/`Worktree.State` transition. Lease reclaim is a row mutation, not an FSM transition.

## 3. Extension-point contracts
No `OverlayBase`/scanner/hook Protocol change. New consumers of the manager: `recovery_sweeps.run_boot_sweeps`, `teatree.loops.worker` supervisor, `self_heal._check_dead_owner_lease`.

## 4. Component boundaries
Discriminator + sweep in `core.loop_lease_manager` (manager/queryset logic); boot wiring in `core.worktree.recovery_sweeps`; runtime wiring in `loops.worker` (seam); watchdog in `cli.doctor.self_heal`; status fallback in `cli.worker`. Each stays in its layer.

## 5. Dependency direction
`loops.worker` and `cli.doctor.self_heal` reach `core.models.LoopLease` via lazy call-time imports (no new module-import edge). `core.worktree.recovery_sweeps` imports `core.models` (already a core→core edge). `tach` + import-linter pre-commit gates passed.

## 6. Test surface
- `_session_lease_is_live` discriminator: reused-pid-past-TTL reclaim, fresh-heartbeat not-stolen, indeterminate-null-pid before/after TTL, t3-master busy-owner preserved, dead-pid reclaimed (`tests/teatree_core/test_loop_lease_dead_session_reclaim.py`, `test_loop_ownership.py`).
- boot sweep count (`test_recover_reclaims_dead_leases.py`).
- worker supervisor invokes the reclaim seam + survives its error (`tests/teatree_loops/test_worker.py`).
- watchdog auto-repairs + idempotent + never touches a live owner (`tests/teatree_cli/doctor/test_self_heal_dead_owner_lease.py`).
- `t3 worker status` flock fallback (`tests/teatree_cli/test_cli_worker.py`).

## 7. Resilience invariants
verify-by-re-read: the eviction UPDATE re-asserts the not-live/dead-pid condition in its `WHERE` (backend-agnostic CAS), so a concurrent re-claim between read and write is never clobbered. idempotency: a second sweep finds the reclaimed rows already blank (no-op). heartbeat: the per-tick re-claim IS the lease heartbeat (fresh TTL). fallback-transport / sub-agent contract: n/a (no external write, no sub-agent).

## 8. Identity and key normalization
Slot keys stay canonical via the existing `per_loop_owner_slot` / `is_per_loop_owner_slot`; no stripping added. `trust_pid_past_ttl` is derived from `is_per_loop_owner_slot(name)` at each call site.

## 9. Behavior preservation / capability deletion
One intentional, ticket-directed behaviour change: a per-loop lease with an alive-but-reused pid past its TTL is now RECLAIMED, not blocked. The test that pinned the old behaviour (`test_per_loop_alive_pid_blocks_reclaim_past_ttl`) is updated to `..._is_reclaimable`, and a new `test_master_alive_pid_blocks_reclaim_past_ttl` pins that `t3-master`'s #1604 protection is preserved. This is not a safety/leak/privacy matcher; it is the exact bug #3571 identifies, with explicit ticket sign-off.

## 10. Removability / harness-vs-data
Removable: `reclaim_dead_owner_leases` and its three wiring points revert cleanly; the discriminator param defaults nowhere silently (explicit keyword). Harness (a correctness discriminator + sweep), not data — the per-loop-vs-master distinction is a structural key property, not a per-item policy a table would express.

## Verification
- Targeted + cross-tree consumer tests green (`test_loop_lease*`, `test_loop_ownership`, `test_worker`, `test_self_heal*`, `test_recover*`, statusline/hook/loops-tick consumers).
- `ruff check` + `ty check` clean; `makemigrations --check` clean (no model change).
- Pre-push gate green (`dev/push-gate.sh`: never-lockout contract + incremental push gate).
