### PR TITLE
fix(agents): reasoning effort was a no-op on the native Anthropic binding

### DIFF
--- a/src/teatree/agents/harness.py
+++ b/src/teatree/agents/harness.py
@@ -35,7 +35,7 @@ from typing import TYPE_CHECKING, Protocol, cast
 from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
 from pydantic_ai import Agent
 from pydantic_ai.models import Model
-from pydantic_ai.models.openai import OpenAIChatModel, OpenAIChatModelSettings, ReasoningEffort
+from pydantic_ai.models.openai import OpenAIChatModel, ReasoningEffort
 
 from teatree.agents.harness_options import HarnessOptions
 from teatree.agents.harness_registry import (
@@ -54,6 +54,7 @@ from teatree.agents.pydantic_ai_config import (
     OrcaLaneConfig,
     PydanticAiBinding,
     PydanticAiModelConfig,
+    build_model_settings,
     build_orca_provider,
     resolve_native_anthropic_model,
 )
@@ -288,8 +289,10 @@ class PydanticAiHarness:
         # the tool config, so the pydantic_ai (and future Vertex) path is vendor-type-free.
         harness_options = HarnessOptions.from_sdk_options(options)
         model = self._resolve_model(harness_options)
-        effort = resolve_effort(harness_options)
-        model_settings = OpenAIChatModelSettings(openai_reasoning_effort=effort) if effort else None
+        # The effort key is BINDING-specific (``openai_reasoning_effort`` vs
+        # ``anthropic_effort``) and a foreign key is dropped silently, so the settings
+        # are built per binding — see :func:`build_model_settings`.
+        model_settings = build_model_settings(model, resolve_effort(harness_options), binding=self._binding)
         # PR-03: a phased dispatch wires the phase-scoped, gated tool/MCP layer
         # onto the Agent (``toolsets=`` + ``tool_timeout=``); an un-phased one
         # keeps a bare text Agent (byte-identical to before the tool port). The

--- a/src/teatree/agents/pydantic_ai_config.py
+++ b/src/teatree/agents/pydantic_ai_config.py
@@ -9,10 +9,14 @@ module with no import cycle. Re-exported from ``teatree.agents.harness`` for bac
 
 from dataclasses import dataclass, field
 from enum import StrEnum
+from typing import cast
 
 from openai import AsyncOpenAI
 from pydantic_ai.models import Model
+from pydantic_ai.models.openai import OpenAIChatModelSettings, ReasoningEffort
+from pydantic_ai.profiles.anthropic import ANTHROPIC_THINKING_EFFORT_MAP, resolve_anthropic_effort
 from pydantic_ai.providers.openai import OpenAIProvider
+from pydantic_ai.settings import ModelSettings
 
 from teatree.agents.harness_options import HarnessOptions
 from teatree.agents.harness_registry import HarnessCapabilities
@@ -176,6 +180,52 @@ def resolve_native_anthropic_model(options: HarnessOptions) -> Model:
         raise NativeAnthropicUnavailableError(msg) from exc
     api_key = AnthropicApiKeyCredential().resolve()
     return AnthropicModel(model_name, provider=AnthropicProvider(api_key=api_key))
+
+
+def build_model_settings(
+    model: Model, effort: ReasoningEffort | None, *, binding: PydanticAiBinding
+) -> ModelSettings | None:
+    """The reasoning-effort model settings for *binding*, under the key its model READS.
+
+    The settings namespace is per-provider in pydantic_ai, so the effort key is
+    binding-specific and NOT interchangeable: an
+    :class:`~pydantic_ai.models.openai.OpenAIChatModel` reads
+    ``openai_reasoning_effort`` while an
+    :class:`~pydantic_ai.models.anthropic.AnthropicModel` reads ``anthropic_effort``
+    and ignores every foreign key silently. Handing the OpenAI-shaped settings to the
+    native Anthropic binding therefore dropped the resolved effort with no error — the
+    whole effort axis was a no-op on that lane.
+
+    The vocabularies differ too. ``HARNESS_EFFORT_SCALE[pydantic_ai]`` is the
+    OpenAI/router scale (it carries ``minimal``), while the Anthropic Messages API
+    accepts only ``low``/``medium``/``high``/``xhigh``/``max``. An explicitly-set
+    ``anthropic_effort`` is passed STRAIGHT to the wire by pydantic_ai (no profile
+    gate, no mapping), so ``minimal`` would 400. The translation therefore goes
+    through pydantic_ai's own canonical
+    :data:`~pydantic_ai.profiles.anthropic.ANTHROPIC_THINKING_EFFORT_MAP` via
+    :func:`~pydantic_ai.profiles.anthropic.resolve_anthropic_effort`, which also owns
+    the per-model ``xhigh`` passthrough decision — never a vocabulary re-invented here.
+    """
+    if effort is None:
+        return None
+    if binding is PydanticAiBinding.NATIVE_ANTHROPIC:
+        if effort not in ANTHROPIC_THINKING_EFFORT_MAP:
+            return None
+        # Built as a plain mapping rather than the ``AnthropicModelSettings`` TypedDict:
+        # that symbol lives in ``pydantic_ai.models.anthropic``, which imports the
+        # OPTIONAL ``anthropic`` extra. Naming it here — even under a lazy import —
+        # would couple this branch to an extra a router-only install does not carry,
+        # while the runtime shape is identical (a TypedDict IS a dict).
+        return cast(
+            "ModelSettings",
+            {
+                "anthropic_effort": resolve_anthropic_effort(
+                    effort,
+                    supports_xhigh=model.profile.get("anthropic_supports_xhigh_effort", False),
+                )
+            },
+        )
+    return cast("ModelSettings", OpenAIChatModelSettings(openai_reasoning_effort=effort))
 
 
 def build_orca_provider(*, lane: str, pass_path: str | None = None) -> OpenAIProvider:

--- a/tests/teatree_agents/test_harness_native_binding.py
+++ b/tests/teatree_agents/test_harness_native_binding.py
@@ -21,6 +21,7 @@ from teatree.agents.pydantic_ai_config import (
     NativeAnthropicUnavailableError,
     PydanticAiBinding,
     PydanticAiModelConfig,
+    build_model_settings,
     native_anthropic_model_name,
 )
 from teatree.agents.pydantic_ai_session import _router_reported_cost
@@ -107,6 +108,50 @@ class TestNativeModelNameFallback:
 
     def test_explicit_pin_passes_through_unchanged(self) -> None:
         assert native_anthropic_model_name(HarnessOptions(model="claude-opus-4-8")) == "claude-opus-4-8"
+
+
+class TestBindingSpecificEffortSettings:
+    """The reasoning effort must ride the key the SELECTED binding's model actually reads.
+
+    pydantic_ai namespaces model settings per provider and silently ignores a foreign
+    key, so the OpenAI-shaped ``openai_reasoning_effort`` handed to the native Anthropic
+    binding dropped the whole effort axis with no error. The vocabularies differ too:
+    the router scale carries ``minimal``, which the Anthropic Messages API rejects, and
+    an explicitly-set ``anthropic_effort`` is passed straight to the wire unmapped.
+    """
+
+    # ``build_model_settings`` reads only ``model.profile``, so the binding shape is
+    # provable without constructing a real AnthropicModel — keeping this hermetic and
+    # free of the optional ``anthropic`` extra. The real-model construction is covered
+    # by ``TestNativeBindingConstruction``.
+    _XHIGH = SimpleNamespace(profile={"anthropic_supports_xhigh_effort": True})
+    _NO_XHIGH = SimpleNamespace(profile={"anthropic_supports_xhigh_effort": False})
+
+    def test_router_binding_uses_the_openai_effort_key(self) -> None:
+        settings = build_model_settings(TestModel(), "high", binding=PydanticAiBinding.ROUTER)
+        assert settings == {"openai_reasoning_effort": "high"}
+
+    def test_native_binding_uses_the_anthropic_effort_key(self) -> None:
+        settings = build_model_settings(self._XHIGH, "high", binding=PydanticAiBinding.NATIVE_ANTHROPIC)
+        # The regression: NOT ``openai_reasoning_effort``, which AnthropicModel ignores.
+        assert settings == {"anthropic_effort": "high"}
+
+    def test_native_binding_maps_minimal_onto_the_anthropic_vocabulary(self) -> None:
+        # ``minimal`` is router-scale only; sent verbatim the Messages API 400s.
+        settings = build_model_settings(self._XHIGH, "minimal", binding=PydanticAiBinding.NATIVE_ANTHROPIC)
+        assert settings == {"anthropic_effort": "low"}
+
+    def test_native_binding_downgrades_xhigh_when_the_model_lacks_it(self) -> None:
+        assert build_model_settings(self._XHIGH, "xhigh", binding=PydanticAiBinding.NATIVE_ANTHROPIC) == {
+            "anthropic_effort": "xhigh"
+        }
+        assert build_model_settings(self._NO_XHIGH, "xhigh", binding=PydanticAiBinding.NATIVE_ANTHROPIC) == {
+            "anthropic_effort": "max"
+        }
+
+    def test_absent_effort_yields_no_settings_on_either_binding(self) -> None:
+        assert build_model_settings(TestModel(), None, binding=PydanticAiBinding.ROUTER) is None
+        assert build_model_settings(self._XHIGH, None, binding=PydanticAiBinding.NATIVE_ANTHROPIC) is None
 
 
 class TestRouterReportedCost:


### PR DESCRIPTION
pydantic_ai namespaces model settings per provider, so an `AnthropicModel` reads `anthropic_effort` and silently ignores the `openai_reasoning_effort` key the harness always built — the reasoning-effort axis was dropped on the native Anthropic lane. `build_model_settings()` now builds the settings per binding: the native binding emits `anthropic_effort`, translating the router-scale value (which carries `minimal`, invalid Anthropic vocabulary) through pydantic_ai's `ANTHROPIC_THINKING_EFFORT_MAP`; the router binding keeps `openai_reasoning_effort`.
