### PR TITLE
fix(agents): pydantic_ai lane reports failure instead of crashing

### DIFF
--- a/src/teatree/agents/pydantic_ai_resume.py
+++ b/src/teatree/agents/pydantic_ai_resume.py
@@ -83,6 +83,15 @@ def maybe_persist_on_park(task: Task, result: AgentResultBlob, thread: "list[Mod
 
     An ordinary completed run (or one with no ``thread`` — claude_sdk, or a
     watchdog-interrupted run) has nothing to resume.
+
+    Known limitation (souliane/teatree#3605): this persists ONLY on a
+    ``needs_user_input`` park, keyed under *task*'s pk, and
+    :func:`rehydrate_thread_for_resume` walks ``parent_task`` only. A
+    usage-LIMIT-parked run (``usage_window.park_or_rotate_on_limit``) re-queues as
+    ITSELF, so it neither persists here nor rehydrates on resume — it resumes with
+    a fresh conversation. The fix (persist under the task's own pk on a limit-park +
+    rehydrate from ``task`` itself) is tracked separately; a cache miss is a cost,
+    never an error.
     """
     if result.get("needs_user_input") and thread:
         persist_parked_thread(task, thread)

--- a/src/teatree/agents/pydantic_ai_session.py
+++ b/src/teatree/agents/pydantic_ai_session.py
@@ -11,12 +11,14 @@ back-compat (``from teatree.agents.harness import PydanticAiHarnessSession``).
 
 import asyncio
 import json
+import uuid
 from collections.abc import AsyncIterator, Iterator
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock, ToolResultBlock, ToolUseBlock
 from pydantic_ai import Agent
+from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError, UnexpectedModelBehavior, UsageLimitExceeded
 from pydantic_ai.messages import ModelRequest, ModelResponse, RetryPromptPart, ToolCallPart, ToolReturnPart
 from pydantic_ai.usage import UsageLimits
 
@@ -48,6 +50,19 @@ def _router_reported_cost(run_usage: object) -> float | None:
         if isinstance(value, int | float) and not isinstance(value, bool) and value >= 0:
             return float(value)
     return None
+
+
+def _error_turns(stream: "StreamedRunResult[None, str] | None") -> int:
+    """Turns actually made when a run ERRORED, from the stream's usage — else ``1``.
+
+    ``None`` when the error hit ``run_stream`` entry before the first request (no
+    stream bound); a ``0`` request count degrades to ``1`` so a failed attempt
+    always records at least the one turn it attempted.
+    """
+    if stream is None:
+        return 1
+    requests = stream.usage.requests
+    return requests if requests > 0 else 1
 
 
 def _tool_blocks_since(messages: "list[ModelMessage]", start: int) -> "Iterator[AssistantMessage]":
@@ -124,6 +139,21 @@ class PydanticAiHarnessSession:
     keeps ``message_history`` across calls, matching ``ClaudeSDKClient``'s
     contract — proved by :mod:`tests.teatree_agents.test_harness`.
 
+    A provider/run error is mapped into the same TRUTHFUL terminal
+    ``ResultMessage`` the claude_sdk lane yields rather than propagated raw: a
+    :class:`~pydantic_ai.exceptions.ModelHTTPError` (an Anthropic 429/529 body) →
+    ``is_error=True`` carrying its ``api_error_status``, a
+    :class:`~pydantic_ai.exceptions.ModelAPIError` /
+    :class:`~pydantic_ai.exceptions.UnexpectedModelBehavior` /
+    :class:`~pydantic_ai.exceptions.ContentFilterError` → the same status-less
+    shape, and a :class:`~pydantic_ai.exceptions.UsageLimitExceeded` (the run hit
+    its own step cap) → ``subtype="error_max_turns"``. The driver's failure
+    taxonomy keys on ``is_error``, so the park/rotate path becomes reachable and a
+    programming error still propagates to a durable ``sdk_error`` FAILED.
+    ``num_turns`` is the run's real ``RunUsage.requests`` count (not a hardcoded
+    ``1``), and every terminal message carries the stable per-session
+    :attr:`session_id`.
+
     ``interrupt`` cancels the pydantic_ai ``StreamedRunResult`` (stops token
     generation, closes the underlying connection, records the interrupted state
     in message history) AND the local drain task, and sets ``_interrupted`` so
@@ -166,6 +196,11 @@ class PydanticAiHarnessSession:
         # ``run_stream`` so a cheap-model maker can't drift on a long tool loop;
         # ``None``/``<= 0`` leaves the run uncapped (the ``claude_sdk`` behaviour).
         self._request_limit = request_limit
+        # A stable per-session id stamped onto EVERY terminal ``ResultMessage``
+        # (success and error), so the attempt recorder (:func:`headless._attempt_usage`)
+        # persists a non-empty ``agent_session_id`` — the claude_sdk lane always
+        # carries one; pydantic_ai has no server-side session, so teatree mints it.
+        self._session_id = uuid.uuid4().hex
         self._pending_prompt: str | None = None
         self._active_task: asyncio.Task[str] | None = None
         self._active_stream: StreamedRunResult[None, str] | None = None
@@ -175,6 +210,11 @@ class PydanticAiHarnessSession:
     def history(self) -> "list[ModelMessage]":
         """The accumulated conversation so far (seed + every completed turn)."""
         return self._history
+
+    @property
+    def session_id(self) -> str:
+        """The stable per-session id stamped onto every terminal ``ResultMessage``."""
+        return self._session_id
 
     async def query(self, prompt: str) -> None:
         self._pending_prompt = prompt
@@ -194,27 +234,49 @@ class PydanticAiHarnessSession:
             if self._phase
             else self._history
         )
-        async with self._agent.run_stream(
-            prompt, message_history=sent_history, usage_limits=self._usage_limits()
-        ) as stream:
-            self._active_stream = stream
-            task = asyncio.ensure_future(self._drain(stream))
-            self._active_task = task
-            try:
-                text = await task
-            except asyncio.CancelledError:
-                if self._interrupted:
-                    return
-                task.cancel()
-                with suppress(asyncio.CancelledError):
-                    await task
-                raise
-            finally:
-                self._active_task = None
-                self._active_stream = None
-            all_messages = stream.all_messages()
-            self._history = all_messages
-            run_usage = stream.usage
+        stream_for_usage: StreamedRunResult[None, str] | None = None
+        try:
+            async with self._agent.run_stream(
+                prompt, message_history=sent_history, usage_limits=self._usage_limits()
+            ) as stream:
+                stream_for_usage = stream
+                self._active_stream = stream
+                task = asyncio.ensure_future(self._drain(stream))
+                self._active_task = task
+                try:
+                    text = await task
+                except asyncio.CancelledError:
+                    if self._interrupted:
+                        return
+                    task.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await task
+                    raise
+                finally:
+                    self._active_task = None
+                    self._active_stream = None
+                all_messages = stream.all_messages()
+                self._history = all_messages
+                run_usage = stream.usage
+        except UsageLimitExceeded as exc:
+            # The run hit its OWN per-run request cap (``_request_limit``) — a genuine
+            # FAILED, NOT a park: its message names no rate/usage-limit phrase, so
+            # ``classify_limit`` never mistakes it for a recoverable window.
+            yield self._error_result(exc, subtype="error_max_turns", num_turns=_error_turns(stream_for_usage))
+            return
+        except ModelHTTPError as exc:
+            yield self._error_result(
+                exc,
+                subtype="error_during_execution",
+                num_turns=_error_turns(stream_for_usage),
+                api_error_status=exc.status_code,
+            )
+            return
+        except (ModelAPIError, UnexpectedModelBehavior) as exc:
+            # A provider/run error with no HTTP status (``ContentFilterError`` is a
+            # ``UnexpectedModelBehavior``, ``ModelHTTPError`` is caught above).
+            yield self._error_result(exc, subtype="error_during_execution", num_turns=_error_turns(stream_for_usage))
+            return
         # Surface this turn's tool calls/results in the seam's tool-block
         # vocabulary BEFORE the final text, so a tool-emitting Lane-B session
         # looks to the driver exactly like the claude_sdk lane's.
@@ -226,8 +288,8 @@ class PydanticAiHarnessSession:
             duration_ms=0,
             duration_api_ms=0,
             is_error=False,
-            num_turns=1,
-            session_id="",
+            num_turns=run_usage.requests,
+            session_id=self._session_id,
             # #3157 E5: pass the metered router's OWN reported cost through when it surfaces
             # one, so the attempt records the real figure (flagged not-estimated) instead of
             # the price-table guess; ``None`` (the common case) falls back to the estimate.
@@ -239,6 +301,30 @@ class PydanticAiHarnessSession:
                 "cache_creation_input_tokens": run_usage.cache_write_tokens,
             },
             result=text,
+            model_usage={self._model_name: {}},
+        )
+
+    def _error_result(
+        self, exc: Exception, *, subtype: str, num_turns: int, api_error_status: int | None = None
+    ) -> ResultMessage:
+        """A truthful terminal ``ResultMessage`` for a provider/run error (``is_error=True``).
+
+        The SAME error-shaped envelope the claude_sdk lane yields, so the driver's
+        failure taxonomy (:func:`headless._limit_match` / ``_error_result_reason``)
+        keys on ``is_error`` and classifies (or fails) it without special-casing the
+        transport. ``api_error_status`` carries the HTTP status for a
+        :class:`~pydantic_ai.exceptions.ModelHTTPError` (rendered by
+        ``_error_result_reason``), ``None`` otherwise.
+        """
+        return ResultMessage(
+            subtype=subtype,
+            duration_ms=0,
+            duration_api_ms=0,
+            is_error=True,
+            num_turns=num_turns,
+            session_id=self._session_id,
+            result=str(exc),
+            api_error_status=api_error_status,
             model_usage={self._model_name: {}},
         )
 

--- a/src/teatree/llm/anthropic_limits.py
+++ b/src/teatree/llm/anthropic_limits.py
@@ -38,8 +38,12 @@ credits``, ``seven-day limit``, ``5-hour limit``, ``five-hour limit``. One entry
 is mapped on API semantics rather than a literal match: ``quota exceeded`` — in
 the binary the literal string is only the libc "Disk quota exceeded" error, so it
 is mapped to the transient :data:`LimitCause.RATE_LIMIT` (the API's rate-quota
-wording, keeping pre-PR parity), never to a subscription or credit cause. A
-credit-empty condition is never laundered into a subscription-quota report.
+wording, keeping pre-PR parity), never to a subscription or credit cause. Two
+entries — ``rate_limit_error`` and ``overloaded_error`` — are Anthropic API
+error-body ``type`` literals (the ``{"error": {"type": ...}}`` code an HTTP 429
+resp. 529 carries), NOT CLI-grepped strings; both map to the transient
+:data:`LimitCause.RATE_LIMIT`. A credit-empty condition is never laundered into a
+subscription-quota report.
 """
 
 import dataclasses
@@ -88,7 +92,13 @@ _SIGNATURES: tuple[tuple[str, LimitCause], ...] = (
     ("five-hour limit", LimitCause.SUBSCRIPTION_SESSION),  # human-readable rendering
     ("session limit", LimitCause.SUBSCRIPTION_SESSION),  # CLI x12
     ("usage limit", LimitCause.SUBSCRIPTION_SESSION),  # CLI x31
-    # Transient API rate / quota limit (HTTP 429).
+    # Transient API rate / quota limit (HTTP 429 / 529). The two ``*_error`` codes
+    # are Anthropic API error-body ``type`` literals, not CLI-grepped prose (a 429
+    # body carries ``rate_limit_error``, a 529 carries ``overloaded_error``); both
+    # precede the space-separated ``rate limit`` prose so an error body classifies
+    # on its structured code first.
+    ("rate_limit_error", LimitCause.RATE_LIMIT),  # API 429 error-code literal
+    ("overloaded_error", LimitCause.RATE_LIMIT),  # API 529 error-code literal
     ("rate limit", LimitCause.RATE_LIMIT),  # CLI x81
     ("quota exceeded", LimitCause.RATE_LIMIT),  # API rate-quota wording (see docstring)
 )

--- a/tests/teatree_agents/test_harness.py
+++ b/tests/teatree_agents/test_harness.py
@@ -21,9 +21,11 @@ import pytest
 from claude_agent_sdk import AssistantMessage, ClaudeAgentOptions, ResultMessage, TextBlock
 from django.test import TestCase
 from pydantic_ai import Agent
-from pydantic_ai.messages import ModelMessage
-from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.exceptions import ModelHTTPError, UsageLimitExceeded
+from pydantic_ai.messages import ModelMessage, ModelRequest, ToolReturnPart
+from pydantic_ai.models.function import AgentInfo, DeltaToolCall, FunctionModel
 from pydantic_ai.models.test import TestModel
+from pydantic_ai.toolsets import FunctionToolset
 
 import teatree.agents.harness as harness_mod
 import teatree.agents.headless as headless_mod
@@ -50,7 +52,7 @@ from teatree.agents.pydantic_ai_config import (
 )
 from teatree.agents.pydantic_ai_resume import persist_parked_thread
 from teatree.config import get_effective_settings
-from teatree.core.models import ConfigSetting, Session, Task, TaskAttempt, Ticket
+from teatree.core.models import ConfigSetting, Session, Task, TaskAttempt, Ticket, UsageWindowState
 from teatree.llm.credentials import CredentialError, OrcaRouterProviderConfig
 from tests.teatree_agents._sdk_fake import FakeHarness, FakeHarnessSession, assistant_text, result_message
 
@@ -356,6 +358,195 @@ class TestRunHeadlessDrivesPydanticAiHarness(TestCase):
         # the parked ancestor thread was restored, so the resume is recoverable.
         self.ticket.refresh_from_db()
         assert str(parked.pk) in self.ticket.extra.get("pydantic_ai_threads", {})
+
+
+def _raising_stream(exc: Exception) -> object:
+    """A ``FunctionModel`` stream function that raises *exc* on the model request.
+
+    The trailing ``yield`` is unreachable but required so pydantic_ai treats the
+    coroutine as an async generator (a streamed FunctionModel).
+    """
+
+    async def stream_fn(_messages: object, _info: AgentInfo) -> AsyncIterator[str]:
+        await asyncio.sleep(0)
+        raise exc
+        yield ""
+
+    return stream_fn
+
+
+async def _tool_then_text_stream(messages: object, _info: AgentInfo) -> AsyncIterator[object]:
+    """Request 1 issues a ``ping`` tool call; request 2 (after the return) yields text.
+
+    Two model requests, so ``RunUsage.requests == 2`` — the fixture the num_turns
+    and request-cap tests drive against.
+    """
+    await asyncio.sleep(0)
+    returned = any(
+        isinstance(part, ToolReturnPart)
+        for message in (messages if isinstance(messages, list) else [])
+        if isinstance(message, ModelRequest)
+        for part in message.parts
+    )
+    if returned:
+        yield "final answer"
+    else:
+        yield {0: DeltaToolCall(name="ping", json_args="{}", tool_call_id="c1")}
+
+
+def _ping_toolset() -> FunctionToolset[None]:
+    toolset: FunctionToolset[None] = FunctionToolset()
+    toolset.add_function(lambda: "pong", name="ping")
+    return toolset
+
+
+def test_pydantic_ai_session_stamps_a_stable_nonempty_session_id() -> None:
+    # A minted session_id is stamped on EVERY terminal ResultMessage and is stable
+    # across turns (RED: the hardcoded "" gave the attempt no agent_session_id).
+    session = PydanticAiHarnessSession(Agent(TestModel(custom_output_text="hi")), model_name="m")
+
+    async def drive() -> list[ResultMessage]:
+        results: list[ResultMessage] = []
+        for _ in range(2):
+            await session.query("go")
+            results.extend([m async for m in session.receive_response() if isinstance(m, ResultMessage)])
+        return results
+
+    results = asyncio.run(drive())
+    assert len(results) == 2
+    assert results[0].session_id
+    assert results[0].session_id == results[1].session_id == session.session_id
+
+
+def test_pydantic_ai_sessions_mint_distinct_session_ids() -> None:
+    first = PydanticAiHarnessSession(Agent(TestModel()), model_name="m")
+    second = PydanticAiHarnessSession(Agent(TestModel()), model_name="m")
+    assert first.session_id
+    assert second.session_id
+    assert first.session_id != second.session_id
+
+
+def test_pydantic_ai_num_turns_reflects_the_request_count() -> None:
+    # A tool-call turn followed by a text turn is TWO model requests, so the
+    # terminal ResultMessage reports num_turns == 2 (RED: the hardcoded 1).
+    agent: Agent[None, str] = Agent(FunctionModel(stream_function=_tool_then_text_stream), toolsets=[_ping_toolset()])
+    session = PydanticAiHarnessSession(agent, model_name="m")
+
+    async def drive() -> list[object]:
+        await session.query("hi")
+        return [message async for message in session.receive_response()]
+
+    result = next(m for m in asyncio.run(drive()) if isinstance(m, ResultMessage))
+    assert result.num_turns == 2
+
+
+def test_pydantic_ai_session_maps_the_request_cap_to_error_max_turns() -> None:
+    # A real per-run request cap (request_limit=1) against a model that wants a
+    # 2nd request raises UsageLimitExceeded, which the session reports as an
+    # is_error ResultMessage(subtype="error_max_turns") — a genuine FAILED whose
+    # text does NOT phrase-match the limit classifier (so it never parks).
+    from teatree.llm.anthropic_limits import classify_limit  # noqa: PLC0415 — test-local
+
+    agent: Agent[None, str] = Agent(FunctionModel(stream_function=_tool_then_text_stream), toolsets=[_ping_toolset()])
+    session = PydanticAiHarnessSession(agent, model_name="m", request_limit=1)
+
+    async def drive() -> list[object]:
+        await session.query("hi")
+        return [message async for message in session.receive_response()]
+
+    result = next(m for m in asyncio.run(drive()) if isinstance(m, ResultMessage))
+    assert result.is_error is True
+    assert result.subtype == "error_max_turns"
+    assert classify_limit(str(result.result)) is None
+
+
+class TestRunHeadlessPydanticAiFailureReporting(TestCase):
+    """A pydantic_ai provider/run error is REPORTED through the driver, never a raw crash.
+
+    The seam maps the error into the same ``is_error`` ``ResultMessage`` the
+    claude_sdk lane yields, so the driver's failure taxonomy (park/rotate or a
+    recorded FAILED) fires without any transport special-casing. Before the fix a
+    429 propagated raw out of ``asyncio.run`` and ``run_headless`` re-raised it (a
+    ``sdk_error`` FAILED-with-traceback), leaving the park path unreachable.
+    """
+
+    def setUp(self) -> None:
+        self.ticket = Ticket.objects.create()
+        self.session = Session.objects.create(ticket=self.ticket, agent_id="agent-1")
+        self.task = Task.objects.create(ticket=self.ticket, session=self.session, phase="coding")
+        ConfigSetting.objects.set_value("agent_harness", "pydantic_ai")
+
+    def _run_raising(self, exc: Exception) -> TaskAttempt:
+        harness = PydanticAiHarness(model=FunctionModel(stream_function=_raising_stream(exc)))
+        with (
+            patch.object(headless_mod, "resolve_harness", return_value=harness),
+            patch.object(headless_mod.TaskUsage, "for_task", classmethod(lambda cls, task: TaskUsage(0, 0.0))),
+        ):
+            attempt = run_headless(self.task, phase="coding", overlay_skill_metadata={})
+        self.task.refresh_from_db()
+        return attempt
+
+    def test_rate_limit_error_parks_when_autorecovery_on(self) -> None:
+        ConfigSetting.objects.set_value("limit_autorecovery_enabled", value=True)
+        exc = ModelHTTPError(status_code=429, model_name="m", body={"error": {"type": "rate_limit_error"}})
+        attempt = self._run_raising(exc)
+
+        assert self.task.status == Task.Status.PENDING, "PARKED for auto-resume, not a raw crash"
+        assert "limit_parked: " in attempt.error
+        assert "rate_limit" in attempt.error
+        assert "Traceback" not in attempt.error
+        window = UsageWindowState.objects.active_for_lane(TaskAttempt.Lane.METERED)
+        assert window is not None
+        assert window.cause == "rate_limit"
+
+    def test_rate_limit_error_fails_cleanly_when_autorecovery_off(self) -> None:
+        ConfigSetting.objects.set_value("limit_autorecovery_enabled", value=False)
+        exc = ModelHTTPError(status_code=429, model_name="m", body={"error": {"type": "rate_limit_error"}})
+        attempt = self._run_raising(exc)
+
+        assert self.task.status == Task.Status.FAILED
+        assert attempt.error.startswith("rate_limit: ")
+        assert "Traceback" not in attempt.error, "a classified limit failure, never a raw traceback"
+
+    def test_overloaded_error_529_is_a_rate_limit(self) -> None:
+        ConfigSetting.objects.set_value("limit_autorecovery_enabled", value=True)
+        exc = ModelHTTPError(status_code=529, model_name="m", body={"error": {"type": "overloaded_error"}})
+        attempt = self._run_raising(exc)
+
+        assert self.task.status == Task.Status.PENDING
+        assert "rate_limit" in attempt.error
+        window = UsageWindowState.objects.active_for_lane(TaskAttempt.Lane.METERED)
+        assert window is not None
+        assert window.cause == "rate_limit"
+
+    def test_credit_body_400_is_api_credit_and_never_parks(self) -> None:
+        # API-credit exhaustion has no timed window, so even with auto-recovery ON
+        # it FAILS loud (add credits) and never parks.
+        ConfigSetting.objects.set_value("limit_autorecovery_enabled", value=True)
+        exc = ModelHTTPError(
+            status_code=400,
+            model_name="m",
+            body={"error": {"type": "invalid_request_error", "message": "credit balance is too low"}},
+        )
+        attempt = self._run_raising(exc)
+
+        assert self.task.status == Task.Status.FAILED
+        assert attempt.error.startswith("api_credit: ")
+        assert "console.anthropic.com" in attempt.error
+        assert "subscription" not in attempt.error.casefold()
+        assert UsageWindowState.objects.active_for_lane(TaskAttempt.Lane.METERED) is None
+
+    def test_usage_limit_exceeded_fails_error_max_turns_and_never_parks(self) -> None:
+        # The run hit its own per-run request cap — a genuine FAILED (error_max_turns),
+        # never a park, never a raw traceback.
+        ConfigSetting.objects.set_value("limit_autorecovery_enabled", value=True)
+        exc = UsageLimitExceeded("The next request would exceed the request_limit of 1")
+        attempt = self._run_raising(exc)
+
+        assert self.task.status == Task.Status.FAILED
+        assert "error_max_turns" in attempt.error
+        assert "Traceback" not in attempt.error
+        assert UsageWindowState.objects.active_for_lane(TaskAttempt.Lane.METERED) is None
 
 
 class TestRunHeadlessCachedResumeParity(TestCase):

--- a/tests/teatree_eval/test_pydantic_ai_runner.py
+++ b/tests/teatree_eval/test_pydantic_ai_runner.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 
 import pytest
 from django.test import TestCase
+from pydantic_ai.exceptions import ModelHTTPError
 from pydantic_ai.models.function import AgentInfo, DeltaToolCall, FunctionModel
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.models.test import TestModel
@@ -102,6 +103,22 @@ class TestNonClaudeScenarioRunsGreen:
         runner = PydanticAiRunner(model=FunctionModel(stream_function=stream_fn))
         result = evaluate(spec, runner.run(spec))
         assert not result.passed
+
+    def test_a_provider_error_folds_into_the_run_not_a_scenario_crash(self) -> None:
+        # A provider error (a 429) now surfaces as an is_error EvalRun — the seam
+        # maps it to an is_error ResultMessage the runner collects — rather than
+        # propagating out of ``runner.run`` and crashing the whole scenario
+        # (RED: ``runner.run`` raised ModelHTTPError).
+        exc = ModelHTTPError(status_code=429, model_name="m", body={"error": {"type": "rate_limit_error"}})
+
+        async def stream_fn(_messages: object, _info: AgentInfo) -> AsyncIterator[object]:
+            await asyncio.sleep(0)
+            raise exc
+            yield ""  # unreachable; marks stream_fn as an async generator
+
+        spec = _spec(Matcher(kind="positive", tool="Bash", arg_path="command", operator="contains", value="x"))
+        run = PydanticAiRunner(model=FunctionModel(stream_function=stream_fn)).run(spec)
+        assert run.is_error is True
 
     def test_a_text_only_model_produces_graded_text(self) -> None:
         spec = _spec(Matcher(kind="positive", tool="Bash", arg_path="command", operator="contains", value="x"))

--- a/tests/teatree_llm/test_anthropic_limits.py
+++ b/tests/teatree_llm/test_anthropic_limits.py
@@ -38,6 +38,10 @@ class TestClassifyLimit:
             # Transient API rate / quota limit.
             ("HTTP 429: rate limit exceeded, retry later", LimitCause.RATE_LIMIT),
             ("Anthropic API quota exceeded; please back off and retry.", LimitCause.RATE_LIMIT),
+            # Anthropic API error-body ``type`` codes: a 429 carries rate_limit_error,
+            # a 529 carries overloaded_error — both transient (retry shortly).
+            ('status_code: 429, body: {"error": {"type": "rate_limit_error"}}', LimitCause.RATE_LIMIT),
+            ('status_code: 529, body: {"error": {"type": "overloaded_error"}}', LimitCause.RATE_LIMIT),
         ],
     )
     def test_classifies_each_real_signal_distinctly(self, text: str, cause: LimitCause) -> None:


### PR DESCRIPTION
## Summary

The `pydantic_ai` `HarnessSession` — the single seam translating pydantic_ai output into the `claude_agent_sdk` message vocabulary — hardcoded a success-shaped terminal `ResultMessage` (`subtype="success"`, `is_error=False`, `num_turns=1`, `session_id=""`). A provider/run error therefore propagated raw out of `asyncio.run` and was recorded as an `sdk_error` FAILED-with-traceback; the driver's `is_error`-keyed failure taxonomy (limit classification, park/rotate) never saw it, so the park/rotate path was unreachable.

The fix maps provider/run errors **in the session**, leaving the driver's transport-agnostic invariant intact:

- `ModelHTTPError` → `error_during_execution`, `is_error=True`, carrying `api_error_status`
- `ModelAPIError` / `UnexpectedModelBehavior` / `ContentFilterError` → same shape, no status
- `UsageLimitExceeded` (the run hit its own step cap) → `error_max_turns` — a genuine FAILED whose text never phrase-matches the limit classifier, so it never parks
- `CancelledError` interrupt disambiguation and programming-error propagation (durable `sdk_error`) are unchanged

Also:
- `num_turns` now reflects the run's real `RunUsage.requests` count.
- A stable per-session uuid is minted in `__init__` and stamped on every terminal `ResultMessage`, so the attempt records a non-empty `agent_session_id`.
- `classify_limit` gains the Anthropic API error-body `type` literals `rate_limit_error` (429) and `overloaded_error` (529) → `RATE_LIMIT`, so a folded HTTP-error body classifies and the park/rotate path is reachable.
- The eval lane (`PydanticAiRunner._drive` reuses this session) now folds a provider error into the run as an `is_error` result instead of crashing the scenario.

A known limit-park resume gap (a limit-parked run resumes with a fresh conversation) is documented at the park path and tracked separately.

## Architecture pre-check

**1. BLUEPRINT § alignment** — § Loop Topology (Lane-B / harness seam). The seam stays the single translation point; the driver is untouched (both module docstrings' stated invariant).

**2. FSM phase boundaries** — n/a. No `Task`/`Worktree` transition added; a mapped limit error re-enters the existing park (`PENDING`) vs FAILED paths through the unchanged driver.

**3. Extension-point contracts** — `HarnessSession` surface only; both existing consumers (`headless._collect` driver, `PydanticAiRunner._drive` eval lane) covered by tests. No Protocol signature change.

**4. Component boundaries** — `agents/pydantic_ai_session.py` (transport seam) and `llm/anthropic_limits.py` (classifier). No straddle.

**5. Dependency direction** — no new cross-module import; `tach check` green in the push gate.

**6. Test surface** — session-level (num_turns, session_id, error→ResultMessage shape, request-cap→error_max_turns), run_headless integration (429 park/off-fail, 529 rate_limit, 400 api_credit never-parked, UsageLimitExceeded FAILED never-parked), classifier unit rows, eval-lane fold-not-crash.

**7. Resilience invariants** — no new external write. The change makes a transport error TRUTHFUL so the existing idempotent park/recovery path handles it.

**8. Identity/key normalization** — n/a.

**9. Behavior preservation** — success path byte-identical except the two truthful fields (`num_turns`, `session_id`) that were previously hardcoded; `CancelledError` handling preserved verbatim; classifier additions are additive (no phrase removed, no must-block test inverted).

**10. Removability / harness-vs-data** — self-contained: the error handler reverts to the prior raise-through by deletion. Classifier phrases live in the existing `_SIGNATURES` data table, not new harness logic.
