### PR TITLE
fix(agents): fail loud on an empty headless run instead of false SUCCESS

### DIFF
--- a/src/teatree/agents/headless.py
+++ b/src/teatree/agents/headless.py
@@ -531,6 +531,10 @@ async def _collect(session: HarnessSession, prompt: str) -> HarnessOutcome:
     )
 
 
+#: Head of the agent's prose folded into a no-envelope refusal for diagnosis.
+_NO_ENVELOPE_TEXT_HEAD_CHARS = 500
+
+
 def _record_success(task: Task, outcome: HarnessOutcome, *, phase: str = "", lane: str = "") -> TaskAttempt:
     """Record a successful SDK run via the shared recorder.
 
@@ -539,12 +543,29 @@ def _record_success(task: Task, outcome: HarnessOutcome, *, phase: str = "", lan
     SDK path and the in-session ``record-attempt`` path can never drift on the
     result-envelope contract. *lane* is the resolved Layer-2 lane
     (souliane/teatree#657) this dispatch authenticated through.
+
+    When the agent emits NO parseable JSON result envelope, the phase decides
+    the outcome. ``prompt.py`` demands a final JSON object from every phase, so
+    prose-only output is a contract violation: for a phase NOT in
+    :data:`~teatree.agents.result_schema.PROSE_SUMMARY_ACCEPTED_PHASES` this
+    records a FAILED attempt with a ``no_result_envelope:`` diagnostic rather
+    than laundering the prose into a false success. The exempt phases
+    (``scoping``, ``retro``) keep the ``{"summary": ...}`` fallback unchanged.
+    This is lane-agnostic — both harness backends funnel through here.
     """
     from teatree.agents.attempt_recorder import record_result_envelope  # noqa: PLC0415 — deferred: call-time import
     from teatree.agents.headless_result import parse_result  # noqa: PLC0415 — deferred: call-time import
+    from teatree.agents.result_schema import prose_summary_accepted  # noqa: PLC0415 — deferred: call-time import
 
     result = parse_result(outcome.agent_text)
     if not result:
+        if not prose_summary_accepted(phase or task.phase):
+            head = outcome.agent_text.strip()[:_NO_ENVELOPE_TEXT_HEAD_CHARS]
+            error = (
+                "no_result_envelope: agent produced no JSON result envelope; "
+                f"refusing to record success (agent text head: {head!r})"
+            )
+            return _record_failure(task, exit_code=0, error=error)
         result = {"summary": outcome.agent_text[:1000]}
 
     maybe_persist_on_park(task, result, outcome.thread)  # (#2886)

--- a/src/teatree/agents/result_schema.py
+++ b/src/teatree/agents/result_schema.py
@@ -27,7 +27,7 @@ class FileChange(TypedDict, total=False):
     lines_removed: int
 
 
-class TestResult(TypedDict, total=False):
+class SingleTestResult(TypedDict, total=False):
     name: str
     passed: bool
     duration_seconds: float
@@ -180,7 +180,7 @@ class AgentResult(TypedDict, total=False):
     summary: str
     plan_text: str
     files_modified: list[FileChange]
-    tests_run: list[TestResult]
+    tests_run: list[SingleTestResult]
     tests_passed: int
     tests_failed: int
     decisions: list[str]
@@ -394,8 +394,11 @@ RESULT_JSON_SCHEMA: JSONSchema = {
 #: - ``answering``: an ``answer`` draft returned — same shell-denied hand-back;
 #:   a summary-only run dropped the drafted reply.
 #:
-#: Phases not in this map (``scoping``, ``retro``) carry no evidence
-#: requirement — they are intentionally lightweight.
+#: Phases not in this map carry no evidence requirement. Of those, the
+#: intentionally-lightweight ``scoping`` and ``retro`` phases additionally
+#: accept a prose-only summary when the agent emits no JSON envelope at all —
+#: see :data:`PROSE_SUMMARY_ACCEPTED_PHASES`, the sibling that gates the
+#: no-envelope fallback for every OTHER uncovered phase.
 PHASE_REQUIRED_EVIDENCE: dict[str, tuple[str, ...]] = {
     "planning": ("plan_text",),
     "coding": ("files_modified",),
@@ -414,6 +417,21 @@ PHASE_REQUIRED_EVIDENCE: dict[str, tuple[str, ...]] = {
 def required_evidence_for_phase(phase: str) -> tuple[str, ...]:
     """Return the accepted evidence fields for ``phase`` (empty if none required)."""
     return PHASE_REQUIRED_EVIDENCE.get(normalize_phase(phase), ())
+
+
+#: Phases whose no-envelope run may still record the prose-only ``{"summary":
+#: ...}`` fallback — exactly the intentionally-lightweight phases the sibling
+#: :data:`PHASE_REQUIRED_EVIDENCE` block calls out. Data, not harness logic: a
+#: run on ANY other phase that emits no JSON result envelope is a contract
+#: violation (``prompt.py`` demands a final JSON object from every phase), so
+#: ``_record_success`` refuses it rather than laundering prose into a false
+#: success. Widen this table — never the harness — to exempt a new phase.
+PROSE_SUMMARY_ACCEPTED_PHASES: frozenset[str] = frozenset({"scoping", "retro"})
+
+
+def prose_summary_accepted(phase: str) -> bool:
+    """Whether ``phase`` may record a prose summary when the agent emits no JSON envelope."""
+    return normalize_phase(phase) in PROSE_SUMMARY_ACCEPTED_PHASES
 
 
 type AgentResultBlob = dict[str, object]

--- a/tests/teatree_agents/test_headless.py
+++ b/tests/teatree_agents/test_headless.py
@@ -142,6 +142,9 @@ class TestRunHeadless(TestCase):
         assert task.status == Task.Status.COMPLETED
 
     def test_no_json_fails_phase_with_evidence_requirement(self) -> None:
+        # A no-JSON run on a non-exempt phase is refused for the root cause (no
+        # result envelope at all) BEFORE the per-field evidence gate — the more
+        # precise diagnostic. The outcome (FAILED) is unchanged.
         with _fake_sdk([_assistant_text("no structured output"), _result_message()]):
             session = Session.objects.create(ticket=self.ticket)
             task = Task.objects.create(ticket=self.ticket, session=session)
@@ -150,7 +153,7 @@ class TestRunHeadless(TestCase):
 
         task.refresh_from_db()
         assert attempt.exit_code == 0
-        assert "files_modified" in attempt.error
+        assert attempt.error.startswith("no_result_envelope:")
         assert task.status == Task.Status.FAILED
 
     def test_fails_when_result_violates_schema(self) -> None:

--- a/tests/teatree_agents/test_headless_no_envelope_guard.py
+++ b/tests/teatree_agents/test_headless_no_envelope_guard.py
@@ -1,0 +1,135 @@
+"""Regression tests for the no-result-envelope guard in ``_record_success``.
+
+The generic task prompt (``prompt.py``) demands a final JSON result object from
+every phase, so prose-only output is a contract violation. Before this guard,
+``_record_success`` manufactured ``{"summary": prose[:1000]}`` for ANY phase
+absent from ``PHASE_REQUIRED_EVIDENCE`` — laundering a no-envelope run into a
+false SUCCESS (task COMPLETED, FSM advanced) on both the claude-SDK and
+pydantic-ai lanes.
+
+The guard is lane-agnostic: both lanes funnel through the single shared
+``_record_success`` chokepoint. A no-envelope run on a non-exempt phase now
+records a FAILED attempt with a ``no_result_envelope:`` diagnostic and does NOT
+advance the FSM. The exempt phases (``scoping``, ``retro``) keep the prose
+fallback unchanged — pinned by ``test_headless``'s untouched scoping test.
+"""
+
+import contextlib
+from collections.abc import AsyncIterator, Iterator
+from typing import Any, Self
+from unittest.mock import patch
+
+from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+from django.test import TestCase
+from pydantic_ai.models.test import TestModel
+
+import teatree.agents.harness as harness_mod
+import teatree.agents.headless as headless_mod
+from teatree.agents.harness import PydanticAiHarness
+from teatree.agents.headless import TaskUsage, run_headless
+from teatree.core.models import Session, Task, Ticket
+
+_PROSE = "I finished the work but forgot to emit the JSON result envelope."
+
+
+class _FakeSdkClient:
+    """Async-context SDK stand-in yielding fixed assistant text + a success result."""
+
+    def __init__(self, agent_text: str) -> None:
+        self._agent_text = agent_text
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        return None
+
+    async def query(self, _prompt: str) -> None:
+        return None
+
+    async def receive_response(self) -> AsyncIterator[Any]:
+        yield AssistantMessage(content=[TextBlock(text=self._agent_text)], model="claude-opus-4-8[1m]")
+        yield ResultMessage(
+            subtype="success",
+            duration_ms=10,
+            duration_api_ms=8,
+            is_error=False,
+            num_turns=1,
+            session_id="s1",
+        )
+
+    async def interrupt(self) -> None:
+        return None
+
+
+@contextlib.contextmanager
+def _fake_sdk(agent_text: str) -> Iterator[None]:
+    def _make_client(**_: object) -> _FakeSdkClient:
+        return _FakeSdkClient(agent_text)
+
+    snapshot = TaskUsage(turns=0, cost_usd=0.0)
+    with (
+        patch.object(headless_mod.shutil, "which", return_value="/usr/bin/claude"),
+        patch.object(harness_mod, "ClaudeSDKClient", _make_client),
+        patch.object(headless_mod.TaskUsage, "for_task", classmethod(lambda cls, task: snapshot)),
+    ):
+        yield
+
+
+class TestNoEnvelopeGuardIsLaneAgnostic(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.ticket = Ticket.objects.create()
+
+    def _assert_refused(self, attempt: Any, task: Task, session: Session) -> None:
+        task.refresh_from_db()
+        session.refresh_from_db()
+        assert task.status == Task.Status.FAILED, (
+            f"a no-envelope run on a non-exempt phase must FAIL; got status={task.status}"
+        )
+        assert attempt.error.startswith("no_result_envelope:"), (
+            f"the refusal must carry the greppable diagnostic prefix; got: {attempt.error!r}"
+        )
+        assert "debugging" not in (session.visited_phases or []), (
+            f"the FSM must NOT advance on a refused no-envelope run; visited={session.visited_phases}"
+        )
+
+    def test_claude_lane_prose_only_on_nonexempt_phase_is_refused(self) -> None:
+        # Claude-SDK lane (fake-SDK scaffold): pure prose, no JSON envelope, on a
+        # non-exempt phase (``debugging``) → refused, FSM not advanced.
+        session = Session.objects.create(ticket=self.ticket, agent_id="agent-1")
+        task = Task.objects.create(ticket=self.ticket, session=session, phase="debugging")
+
+        with _fake_sdk(_PROSE):
+            attempt = run_headless(task, phase="debugging", overlay_skill_metadata={})
+
+        self._assert_refused(attempt, task, session)
+
+    def test_pydantic_ai_lane_prose_only_on_nonexempt_phase_is_refused(self) -> None:
+        # pydantic-ai lane (TestModel double): same prose-only run, same phase →
+        # same refusal. Proves the guard is genuinely shared, not lane-conditional.
+        session = Session.objects.create(ticket=self.ticket, agent_id="agent-1")
+        task = Task.objects.create(ticket=self.ticket, session=session, phase="debugging")
+
+        fake_harness = PydanticAiHarness(model=TestModel(custom_output_text=_PROSE))
+        with (
+            patch.object(headless_mod, "resolve_harness", return_value=fake_harness),
+            patch.object(headless_mod.TaskUsage, "for_task", classmethod(lambda cls, task: TaskUsage(0, 0.0))),
+        ):
+            attempt = run_headless(task, phase="debugging", overlay_skill_metadata={})
+
+        self._assert_refused(attempt, task, session)
+
+    def test_exempt_phase_keeps_prose_fallback(self) -> None:
+        # Behaviour preservation: an exempt phase (``retro``) still records the
+        # prose summary fallback and COMPLETES — byte-identical to before.
+        session = Session.objects.create(ticket=self.ticket, agent_id="agent-1")
+        task = Task.objects.create(ticket=self.ticket, session=session, phase="retro")
+
+        with _fake_sdk(_PROSE):
+            attempt = run_headless(task, phase="retro", overlay_skill_metadata={})
+
+        task.refresh_from_db()
+        assert attempt.exit_code == 0
+        assert attempt.result["summary"] == _PROSE[:1000]
+        assert task.status == Task.Status.COMPLETED

--- a/tests/teatree_agents/test_result_schema.py
+++ b/tests/teatree_agents/test_result_schema.py
@@ -9,10 +9,13 @@ channels let it hand the work back through the result envelope, and
 from typing import Any, cast
 
 from teatree.agents.result_schema import (
+    PROSE_SUMMARY_ACCEPTED_PHASES,
     RESULT_JSON_SCHEMA,
     DirectiveCandidateEnvelope,
+    SingleTestResult,
     candidate_carries_payload,
     check_evidence,
+    prose_summary_accepted,
     required_evidence_for_phase,
 )
 
@@ -189,3 +192,31 @@ class TestDirectiveCandidateEvidenceGate:
     def test_a_real_candidate_satisfies_the_gate(self) -> None:
         result = {"directive_candidate": {"is_directive": True, "normalized_constraint": "at most 1 open PR"}}
         assert check_evidence(result, "directive_reading") == ""
+
+
+class TestProseSummaryAcceptedPhases:
+    """The no-envelope fallback is accepted only for the intentionally-light phases."""
+
+    def test_the_exempt_table_is_exactly_scoping_and_retro(self) -> None:
+        assert frozenset({"scoping", "retro"}) == PROSE_SUMMARY_ACCEPTED_PHASES
+
+    def test_exempt_phases_accept_the_prose_fallback(self) -> None:
+        assert prose_summary_accepted("scoping")
+        assert prose_summary_accepted("retro")
+
+    def test_aliases_normalize_before_the_lookup(self) -> None:
+        # ``scope``/``retrospect`` normalize UP to the canonical exempt tokens.
+        assert prose_summary_accepted("scope")
+        assert prose_summary_accepted("RETROSPECT")
+
+    def test_non_exempt_phases_refuse_the_prose_fallback(self) -> None:
+        assert not prose_summary_accepted("debugging")
+        assert not prose_summary_accepted("coding")
+        assert not prose_summary_accepted("reviewing")
+
+
+class TestSingleTestResultShape:
+    def test_carries_the_per_test_result_fields(self) -> None:
+        entry: SingleTestResult = {"name": "test_x", "passed": True, "duration_seconds": 0.1}
+        assert entry["name"] == "test_x"
+        assert entry["passed"] is True


### PR DESCRIPTION
fix(agents): fail loud on an empty headless run instead of false SUCCESS

## Why

An empty headless run — one whose agent emits no parseable JSON result envelope — was recorded as a false SUCCESS. `_record_success` (`agents/headless.py`) manufactured `{"summary": prose[:1000]}` for any phase whose agent produced no JSON, and `record_result_envelope` (`agents/result_schema.py` / `attempt_recorder.py`) accepted it for every phase absent from `PHASE_REQUIRED_EVIDENCE`. Since the generic task prompt (`agents/prompt.py`) demands a final JSON object from every phase, prose-only output is a contract violation the fallback laundered into a COMPLETED task that advanced the FSM.

Both harness backends (claude-SDK and pydantic-ai) funnel through the single `_record_success` chokepoint, so the fix is shared, not lane-conditional.

## What

- New `PROSE_SUMMARY_ACCEPTED_PHASES = {scoping, retro}` beside `PHASE_REQUIRED_EVIDENCE` in `agents/result_schema.py` — data, in the same vocabulary module as its sibling table, with a `prose_summary_accepted(phase)` helper mirroring `required_evidence_for_phase`.
- `_record_success`: when the agent emits no JSON envelope AND the normalised phase is not exempt, record FAILED (clean refusal, `exit_code=0`) with a greppable `no_result_envelope:` diagnostic plus a truncated head of the agent text; the FSM does not advance. Exempt phases keep the `{"summary": ...}` fallback byte-identically.
- Docstring/comment alignment on `_record_success` and the `PHASE_REQUIRED_EVIDENCE` block.

The no-envelope guard is phase-agnostic and targets exactly the observed failure. No evidence entries were added for the other uncovered phases — that needs per-phase domain judgement and is out of scope; widen the exempt table (data) to lighten a new phase, never the harness.

Bundled: rename the `result_schema` TypedDict `TestResult` → `SingleTestResult`. The `Test*` name is falsely collected by pytest's `python_classes`; bringing `result_schema.py` into the push-gate's scoped `--doctest-modules` set turned that collection warning (`filterwarnings=error`) into an exit-2 gate failure. Rename dodges the collector with no suppression; the type is internal to `result_schema.py` (one reference), so blast radius is nil.

## Intentional behaviour change

A run on a non-exempt, evidence-free phase (e.g. `debugging`) that emits zero parseable JSON previously COMPLETED and advanced the FSM; it now FAILS. Mitigation: a clean refusal with a greppable `no_result_envelope:` prefix, and the exempt table is data — widenable without touching the harness. The existing `test_no_json_fails_phase_with_evidence_requirement` (a no-JSON `coding` run) now asserts the sharper `no_result_envelope:` root cause instead of the per-field evidence message; its outcome (FAILED) is unchanged.

## Tests (RED before GREEN)

- `test_headless_no_envelope_guard.py` — a pydantic-ai `TestModel` twin and a claude fake-SDK twin, both emitting pure prose on `debugging`. Observed RED (COMPLETED, FSM advanced) before the guard; GREEN after (FAILED, `no_result_envelope:`, FSM not advanced). Proves the guard is genuinely shared across both lanes.
- An exempt-phase (`retro`) case pins the prose fallback stays COMPLETE.
- `test_result_schema.py` — direct unit tests for `prose_summary_accepted` (exempt/alias/non-exempt) and `SingleTestResult`.
- The pinned `scoping` fallback test in `test_headless.py` stays green untouched (behaviour-preservation proof).

## Architecture pre-check — no-envelope-guard

## 1. BLUEPRINT § alignment
Sub-agent return-contract / phase-evidence family (#1284; §17.8 phase-agent execution). No BLUEPRINT section documents the prose fallback specifically; the contract lives in the `_record_success` / `PHASE_REQUIRED_EVIDENCE` docstrings, which are updated in this change.

## 2. FSM phase boundaries
No new `Ticket.State`/`Worktree.State` transitions. The change gates whether a no-envelope run advances the FSM at all: a refused run calls `task.fail()` (no phase visit, no ticket advance), identical to the existing evidence-gate refusal.

## 3. Extension-point contracts
No `OverlayBase` / scanner / hook / Protocol surface touched. Both `Harness` implementations already route through `_record_success`; no per-backend branch added.

## 4. Component boundaries
`agents/result_schema.py` owns the phase-evidence vocabulary (the sibling table lives here); `agents/headless.py` owns the runner decision. Data in the vocabulary module, decision in the runner — no straddle.

## 5. Dependency direction
`headless.py` already imports from `result_schema` (call-time, deferred). No new cross-module edge; `tach` passes (pre-commit hook green).

## 6. Test surface
`test_headless_no_envelope_guard.py` (both lanes + exempt), `test_result_schema.py` (helper + type), and the updated `test_no_json_fails_phase_with_evidence_requirement`; each behaviour regresses to a named assertion. RED observed before GREEN.

## 7. Resilience invariants
No external write. The guard makes a no-envelope run fail-loud (idempotent: a re-dispatch re-runs the task); no new heartbeat/transport surface.

## 8. Identity and key normalization
Phase tokens are normalized up to canonical form via `normalize_phase` at the boundary (`prose_summary_accepted`), matching the sibling `required_evidence_for_phase`. No qualifier-stripping.

## 9. Behavior preservation / capability deletion
The exempt phases (`scoping`, `retro`) keep the fallback byte-identically. No must-block test inverted to must-not-block — the `coding` no-JSON case still FAILS (sharper diagnostic). The one deliberate change (non-exempt no-JSON: COMPLETE → FAIL) is the correctness fix, stated above.

## 10. Removability / harness-vs-data
Removable: delete the guard block in `_record_success` + the table to revert. Harness-vs-data: the varying part (which phases tolerate prose) is a data table; the harness is the generic mechanism reading it.
