### PR TITLE
fix(deploy): serialize convergence so overlapping deploys never strand worker_quiescing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,15 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # Must exceed the worst-case deploy.sh runtime (worker drain up to
+    # TEATREE_DRAIN_TIMEOUT=1800s/30min + image build + up + health wait). If the
+    # job times out while the remote deploy.sh is still draining, GitHub releases
+    # the `deploy` concurrency group and starts the next run WHILE the abandoned
+    # remote deploy keeps running — overlapping drains that strand worker_quiescing
+    # ON. Keep this comfortably above the drain window so the job holds the group
+    # until the convergence truly finishes. deploy.sh's host flock is the hard
+    # backstop if the timeouts ever drift out of order again.
+    timeout-minutes: 50
     steps:
       - name: Validate required secrets
         env:

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -10,6 +10,41 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$SCRIPT_DIR/docker-compose.yml"
 ENV_FILE="$SCRIPT_DIR/teatree.env"
 
+# Single-convergence invariant (host flock). GitHub's `concurrency: deploy` group
+# serializes the WORKFLOW, but a remote deploy.sh can outlive its GitHub job — an
+# SSH drop does not kill the remote process, and the drain can run longer than the
+# job's timeout — so two runs could otherwise converge on the box at once. Two
+# overlapping worker drains each set `worker_quiescing` ON, and a lingering older
+# drain re-asserts it AFTER a newer run's fresh init cleared it, stranding
+# admission OFF indefinitely (the worker then admits ZERO new coding/planning
+# tasks — they pile up and dead-letter). A host flock guarantees exactly one
+# convergence at a time; a second invocation exits cleanly, since the holder always
+# fast-forwards to the latest main and GitHub re-fires for any later push.
+DEPLOY_LOCK="${TEATREE_DEPLOY_LOCK:-/tmp/teatree-deploy.lock}"
+exec 9>"$DEPLOY_LOCK"
+if ! flock -n 9; then
+    echo "deploy: another convergence already holds $DEPLOY_LOCK — exiting (it converges to latest main)." >&2
+    exit 0
+fi
+
+# Fail-safe against a stranded quiescing gate. If this run drains the worker (which
+# sets `worker_quiescing` ON) but then exits BEFORE the image swap that would
+# recreate the worker and clear the gate via its init (a mid-deploy failure under
+# `set -e`), the still-live OLD worker would stay quiesced forever. The EXIT trap
+# clears the gate so admission resumes. A no-op after a successful swap (the fresh
+# init already cleared it) and when no drain ran; best-effort, never fails the run.
+# Safe under the flock: no other convergence is running to own the gate.
+_DRAINED=false
+_SWAP_DONE=false
+_clear_quiescing_if_stranded() {
+    if [ "$_DRAINED" = true ] && [ "$_SWAP_DONE" = false ]; then
+        echo "deploy: exiting after a drain but before the swap — clearing worker_quiescing so admission resumes." >&2
+        docker compose -f "$COMPOSE_FILE" exec -T teatree-worker \
+            t3 teatree config_setting set worker_quiescing false >/dev/null 2>&1 || true
+    fi
+}
+trap _clear_quiescing_if_stranded EXIT
+
 # The admin can serve while the worker crash-loops, so a converged deploy must
 # confirm the worker process itself is running.
 worker_running() {
@@ -112,6 +147,7 @@ echo "deploy: worker sizing — cpus=${TEATREE_WORKER_CPUS:-<default>} mem_limit
 # admission resumes. Skipped when no worker is running (nothing to drain).
 if worker_running; then
     echo "deploy: draining teatree-worker (up to ${TEATREE_DRAIN_TIMEOUT:-1800}s for in-flight agents to finish) ..."
+    _DRAINED=true
     docker compose -f "$COMPOSE_FILE" exec -T teatree-worker \
         t3 worker drain --timeout "${TEATREE_DRAIN_TIMEOUT:-1800}" \
         || echo "deploy: drain window exceeded — proceeding (a stuck task re-queues via its lease lapse)"
@@ -124,6 +160,9 @@ docker compose -f "$COMPOSE_FILE" up -d --build || {
     docker compose -f "$COMPOSE_FILE" logs --tail 200 teatree-init teatree-worker teatree-admin
     exit 1
 } >&2
+# The swap completed: the fresh worker's init clears worker_quiescing, so the
+# stranded-gate fail-safe above becomes a no-op from here on.
+_SWAP_DONE=true
 
 # Wait for the admin dev server on the box loopback (init clone + install can
 # take a few minutes on first run).

--- a/tests/test_deploy_rolling_drain.py
+++ b/tests/test_deploy_rolling_drain.py
@@ -47,6 +47,31 @@ class TestDeployDebounce:
         assert "fetch --prune origin" in body
         assert "pull --ff-only" in body
 
+    def test_deploy_script_serializes_on_a_host_flock(self) -> None:
+        # A remote deploy.sh can outlive its GitHub job, defeating the workflow
+        # concurrency group; a host flock is the hard single-convergence backstop
+        # so overlapping drains can never strand worker_quiescing ON.
+        body = _DEPLOY_SH.read_text(encoding="utf-8")
+        assert "flock -n 9" in body, "deploy.sh must take a non-blocking host flock (fd 9)"
+        assert "DEPLOY_LOCK" in body
+        lock_at = body.find("flock -n 9")
+        drain_at = body.find("t3 worker drain")
+        assert lock_at != -1
+        assert drain_at != -1
+        assert lock_at < drain_at, (
+            "the flock guard must run BEFORE the worker drain, so a second convergence never starts a competing drain."
+        )
+
+    def test_job_timeout_exceeds_the_drain_window(self) -> None:
+        # If the GitHub job timeout is below the deploy.sh drain window, GitHub
+        # abandons a still-running remote deploy and releases the concurrency
+        # group early — the overlap that stranded admission. 1800s == 30 min.
+        timeout_minutes = int(_deploy_workflow()["jobs"]["deploy"]["timeout-minutes"])
+        assert timeout_minutes > 30, (
+            "deploy job timeout-minutes must exceed the 30-min (1800s) drain window plus "
+            "build/up/health, or GitHub abandons the in-flight deploy and overlaps runs."
+        )
+
 
 class TestDeployDrain:
     def test_deploy_script_drains_the_running_worker_before_the_swap(self) -> None:
@@ -65,6 +90,16 @@ class TestDeployDrain:
         assert "config_setting set worker_quiescing false" in body, (
             "entrypoint init must CLEAR worker_quiescing (a hard `set false`, not a "
             "provenance `seed`) so the fresh worker resumes admission after a deploy."
+        )
+
+    def test_deploy_clears_quiescing_when_stranded_before_the_swap(self) -> None:
+        # A run that drains (sets worker_quiescing ON) but dies before the image
+        # swap must clear the gate on EXIT so the still-live old worker resumes
+        # admission instead of staying quiesced forever.
+        body = _DEPLOY_SH.read_text(encoding="utf-8")
+        assert "trap _clear_quiescing_if_stranded EXIT" in body
+        assert "config_setting set worker_quiescing false" in body, (
+            "the stranded-gate fail-safe must clear worker_quiescing on abnormal exit."
         )
 
     def test_worker_has_a_stop_grace_period(self) -> None:


### PR DESCRIPTION
## Problem

Coding and planning tasks stopped advancing to a PR — every one failed and dead-lettered — while reviewing/debugging tasks kept completing.

Root cause: a **deploy storm** that stranded the worker's admission gate. The deploy workflow runs `deploy/deploy.sh` on every push to `main`. That script drains the running worker before the image swap, which sets `worker_quiescing = true` (the claim/admission chokepoint then admits ZERO new tasks) and waits up to 30 min for in-flight agents. Two things then compound:

1. The remote `deploy.sh` can **outlive its GitHub job** — an SSH drop does not kill the remote process, and the 30-min drain exceeds the job's `timeout-minutes`. GitHub then releases the `deploy` concurrency group and starts the next run while the abandoned deploy keeps running.
2. Overlapping deploys each set `worker_quiescing` ON, and a lingering older drain **re-asserts it after a newer run's fresh init cleared it**. Nothing then clears the gate, so the worker admits no new coding/planning claims — they pile up and dead-letter. Already-claimed reviewing/debugging tasks keep going because they renew their own leases (a path the gate does not touch), which is exactly why only the first-phase (fresh-claim) work regressed.

## Fix

One invariant — exactly one convergence at a time, and the gate is never left ON:

- **Host flock in `deploy.sh`** (non-blocking, before any convergence work). A second invocation exits cleanly; the holder always fast-forwards to the latest `main`, and GitHub re-fires for any later push. This is the hard backstop that does not depend on the workflow timeouts staying in order.
- **Stranded-gate fail-safe**: an `EXIT` trap clears `worker_quiescing` when a run drained but died before the image swap, so a mid-deploy failure never leaves the live worker quiesced. It is a no-op after a successful swap (the fresh init already cleared it) and when no drain ran.
- **Deploy job `timeout-minutes`** raised above the drain window so GitHub holds the concurrency group until the convergence truly finishes instead of abandoning a still-running remote deploy.

## Tests

`tests/test_deploy_rolling_drain.py` gains three pins: the host flock runs before the drain, the job timeout exceeds the drain window, and the stranded-gate trap clears the gate. Full file passes (9/9).
