### PR TITLE
fix(headless): renew the task lease with a starvation-resilient margin

### DIFF
--- a/src/teatree/agents/headless.py
+++ b/src/teatree/agents/headless.py
@@ -65,6 +65,19 @@ __all__ = ["HarnessOutcome", "LoopWatchdog", "TaskUsage", "run_headless"]
 
 _HEARTBEAT_INTERVAL = 60  # seconds
 
+# Lease duration the heartbeat renews to. The renewal runs as an asyncio task on
+# the SAME event loop the headless agent drives, so under CPU/event-loop
+# starvation (a loaded box running several coders at once) the ``sleep`` between
+# renewals stretches far past its nominal 60s. With the DB default 300s lease that
+# is only ~5 heartbeats of slack: a starved worker misses a few renewals, its OWN
+# ``reclaim_orphaned_claims`` scanner sees the lease expired and re-queues the task,
+# and the still-running coder then aborts with "lease lost: re-claimed by another
+# worker" — a self-inflicted reclaim, NOT a second executor. Renewing to 15x the
+# heartbeat interval widens the slack to ~15 min of continuous starvation before a
+# false lapse, which absorbs realistic load spikes. A genuinely dead session's task
+# still reclaims — just after the wider window.
+_LEASE_SECONDS = 15 * _HEARTBEAT_INTERVAL  # 900s
+
 _STUCK_LOOP_PREFIX = "stuck_loop: "
 _RESULT_ERROR_PREFIX = "result_error: "
 
@@ -399,7 +412,7 @@ def _renew_lease_closing_connection(task: Task) -> None:
     thread, which never closes itself — see :mod:`teatree.utils.thread_db`.
     """
     try:
-        task.renew_lease()
+        task.renew_lease(lease_seconds=_LEASE_SECONDS)
     finally:
         close_thread_db_connections()
 

--- a/tests/teatree_agents/test_headless.py
+++ b/tests/teatree_agents/test_headless.py
@@ -989,6 +989,31 @@ class TestDriveWithHeartbeat(TestCase):
         assert outcome.stuck_reason is None
         assert renew_count >= 1
 
+    def test_heartbeat_renews_with_a_starvation_resilient_lease(self) -> None:
+        # The heartbeat runs on the SAME starvable event loop, so it must renew to a
+        # lease well wider than the heartbeat interval — otherwise a loaded box's
+        # missed renewals let the worker's OWN reclaim scanner yank the live task's
+        # lease ("re-claimed by another worker"). Pin the renewed lease at >= 15x the
+        # heartbeat interval so realistic starvation cannot cause a false lapse.
+        seen_lease: list[int] = []
+
+        def capturing_renew(*, lease_seconds: int = 300, **_kwargs: object) -> None:
+            seen_lease.append(lease_seconds)
+
+        self.task.renew_lease = capturing_renew
+        messages = [_assistant_text("hello"), _result_message()]
+        watchdog = LoopWatchdog(max_runtime_seconds=0, max_turns=0, max_cost_usd=0.0)
+        with _fake_sdk(messages, delay=0.05), patch.object(headless_mod, "_HEARTBEAT_INTERVAL", 0.02):
+            asyncio.run(_drive_with_heartbeat(self.task, "p", self._options(), ClaudeSdkHarness(), watchdog=watchdog))
+
+        assert seen_lease, "the heartbeat must renew the lease at least once during the run"
+        assert min(seen_lease) == headless_mod._LEASE_SECONDS, (
+            "the heartbeat must renew with the starvation-resilient lease constant"
+        )
+        assert headless_mod._LEASE_SECONDS >= 900, (
+            "the renewed lease must be >= ~15 min so realistic event-loop starvation cannot cause a false lapse"
+        )
+
     def test_runtime_ceiling_interrupts_and_reports_stuck(self) -> None:
         # A stream that never terminates within the runtime ceiling is
         # interrupted and reported as a runtime breach.


### PR DESCRIPTION
## Problem

Coding tasks intermittently failed with `stuck_loop: lease lost for task N: re-claimed by another worker` (165 attempts across 50 tasks, clustered in high-load windows). The name is misleading: there is no second executor. Exactly one `t3 worker` holds the `WORKER_SINGLETON` flock and drains headless tasks; `t3 worker drain` (the drain-then-deploy waiter) never claims a task or takes the flock.

The real mechanism is a **self-inflicted reclaim under event-loop starvation**:

- The heartbeat renews the task lease to the DB default **300s** while sleeping **60s** between renewals — only ~5 heartbeats of slack.
- The renewal runs as an asyncio task on the **same event loop** the headless agent drives. On a loaded box (several coders running at once) the loop starves, `asyncio.sleep(60)` stretches well past 60s wall-clock, and a few renewals are missed.
- The worker's own `reclaim_orphaned_claims` scanner then sees the lease expired and re-queues the task. The still-running coder's next heartbeat finds the claim generation moved and aborts — "re-claimed by another worker", where the "other worker" is the same worker's next claim generation.

## Fix

Renew the lease to **15x the heartbeat interval (900s)** so ~15 min of continuous event-loop starvation is required before a false lapse — comfortably absorbing realistic load spikes. A genuinely dead session's task still reclaims, just after the wider window. The change is one isolated constant + call site; it does not touch the compare-and-swap claim/renew/reclaim logic.

## Tests

`tests/teatree_agents/test_headless.py::...::test_heartbeat_renews_with_a_starvation_resilient_lease` pins that the heartbeat renews with the wider lease (>= ~15 min). Full headless suite passes (105).
