### PR TITLE
fix(agents): raise on a refused credential and honour max_turns on the pydantic lane

### DIFF
--- a/src/teatree/agents/harness.py
+++ b/src/teatree/agents/harness.py
@@ -310,13 +310,17 @@ class PydanticAiHarness:
         # (OrcaRouter's OpenAI-compatible connection pool) closes cleanly on
         # exit — a bare ``Agent(...)`` never closes it, leaking a client per
         # dispatch until GC.
+        # A positive caller ``max_turns`` (an OneShotSpec cap, an eval override) wins over the
+        # lane's own ``request_limit``; ``0`` (a headless dispatch, an SDK-``None`` coercion)
+        # keeps ``request_limit`` — so every uncapped dispatch stays byte-identical.
+        request_limit = harness_options.max_turns if harness_options.max_turns > 0 else self._orca.request_limit
         async with agent:
             yield PydanticAiHarnessSession(
                 agent,
                 model_name=model.model_name,
                 history=self._history,
                 phase=self._phase,
-                request_limit=self._orca.request_limit,
+                request_limit=request_limit,
             )
 
 

--- a/src/teatree/agents/harness_options.py
+++ b/src/teatree/agents/harness_options.py
@@ -50,6 +50,10 @@ class HarnessOptions:
         already stripped in the adapter, so a backend uses this string as-is).
     *   ``cwd`` — the resolved task worktree (the Lane-B File System jail root).
     *   ``env`` — the pinned child-env overrides (merged over the ambient env by the tool layer).
+    *   ``max_turns`` — the caller's hard turn cap; a POSITIVE value wins over the lane's own
+        ``request_limit`` in :meth:`~teatree.agents.harness.PydanticAiHarness.open`. ``0``
+        (headless dispatch's value, and the SDK-``None`` coercion) leaves the run uncapped, so
+        every uncapped dispatch stays byte-identical.
     """
 
     model: str | None = None
@@ -57,6 +61,7 @@ class HarnessOptions:
     system_prompt: str = ""
     cwd: str | None = None
     env: dict[str, str] = field(default_factory=dict)
+    max_turns: int = 0
 
     @classmethod
     def from_sdk_options(cls, options: ClaudeAgentOptions) -> "HarnessOptions":
@@ -69,4 +74,7 @@ class HarnessOptions:
             # plain path string (a Path is more vendor/OS-coupled than its string form).
             cwd=str(options.cwd) if options.cwd else None,
             env=dict(options.env or {}),
+            # ``ClaudeAgentOptions.max_turns`` is ``int | None``; coerce SDK-``None`` (and 0) to
+            # 0 so only a genuinely positive cap wins over the lane's ``request_limit``.
+            max_turns=options.max_turns or 0,
         )

--- a/src/teatree/agents/one_shot.py
+++ b/src/teatree/agents/one_shot.py
@@ -20,11 +20,15 @@ result, and the model cannot run a tool or read code. Any failure of the turn
 itself (a missing ``claude`` binary, a timeout, an SDK/provider error) degrades
 to ``None`` so a best-effort aux turn never breaks its caller.
 
-A refused ambient environment is the ONE exception and RAISES
-:class:`~teatree.llm.credentials.CredentialError` instead: it is checked while
-building the options, before the turn is attempted, so it never reaches the
-degrade-to-``None`` handler. A base-URL redirect that silently answered ``None``
-would strand every caller on its fallback forever with nothing naming the cause.
+A refused credential RAISES :class:`~teatree.llm.credentials.CredentialError`
+instead of degrading — a misrouted endpoint or a missing metered key is an
+operator misconfiguration that must surface, not a turn that silently answered
+``None`` and stranded every caller on its fallback forever with nothing naming
+the cause. TWO refusal paths raise: the ambient base-URL guard, checked while
+building the options before the turn is attempted; and a credential the
+``pydantic_ai`` lane resolves LAZILY inside ``harness.open()`` (the OrcaRouter BYOK
+key or the native Anthropic key), which sits INSIDE the degrade-to-``None`` try and
+so is re-raised explicitly ahead of the blanket handler.
 """
 
 import asyncio
@@ -34,7 +38,7 @@ from claude_agent_sdk import AssistantMessage, ClaudeAgentOptions, TextBlock
 
 from teatree.agents.harness import Harness, resolve_harness
 from teatree.agents.model_tiering import resolve_tier
-from teatree.llm.credentials import reject_ambient_base_url_redirect
+from teatree.llm.credentials import CredentialError, reject_ambient_base_url_redirect
 
 # The empty-hooks ``settings`` blob that, with ``setting_sources=[]``, keeps the
 # clean-room turn from picking up the developer's hooks/personal context.
@@ -71,9 +75,9 @@ def _clean_room_options(spec: OneShotSpec) -> ClaudeAgentOptions:
 
     This turn pins no credential, so the spawned child inherits the ambient auth
     state AND an ambient ``ANTHROPIC_BASE_URL``. The redirect guard runs HERE rather
-    than inside :func:`run_one_shot`'s try, which swallows every exception: a
-    misconfiguration that silently routed a plan-authenticated turn to a third-party
-    endpoint is the one failure this helper must NOT degrade quietly into ``None``.
+    than inside :func:`run_one_shot`'s try, which degrades non-credential failures to
+    ``None``: a misconfiguration that silently routed a plan-authenticated turn to a
+    third-party endpoint is the one failure this helper must NOT degrade quietly into ``None``.
     """
     reject_ambient_base_url_redirect()
     return ClaudeAgentOptions(
@@ -112,15 +116,21 @@ def run_one_shot(prompt: str, spec: OneShotSpec, *, harness: Harness | None = No
     an SDK/provider error) — a best-effort aux turn must degrade quietly, never
     break its caller.
 
-    RAISES :class:`~teatree.llm.credentials.CredentialError` when the ambient
-    environment is refused. :func:`_clean_room_options` runs that check before the
-    ``try``, deliberately: a misrouted base URL is a configuration fault the
-    operator must see, not a turn that quietly produced no answer.
+    RAISES :class:`~teatree.llm.credentials.CredentialError` when a credential is
+    refused — the one failure that must NOT degrade to ``None``. Two paths raise:
+    :func:`_clean_room_options`'s ambient base-URL guard runs before the ``try``;
+    and on the ``pydantic_ai`` lane the metered credential resolves LAZILY inside
+    ``harness.open()`` (inside the ``try``), so ``CredentialError`` is re-raised
+    ahead of the blanket handler. A misrouted base URL or a missing metered key is
+    a configuration fault the operator must see, not a turn that quietly produced
+    no answer.
     """
     options = _clean_room_options(spec)
     resolved = harness if harness is not None else resolve_harness()
     try:
         text = asyncio.run(_run_turn(resolved, options, prompt, timeout_seconds=spec.timeout_seconds))
+    except CredentialError:
+        raise
     except Exception:  # noqa: BLE001 — the documented contract is "None on ANY failure"; heterogeneous backend errors
         return None
     return text.strip() or None

--- a/tests/teatree_agents/test_harness.py
+++ b/tests/teatree_agents/test_harness.py
@@ -967,6 +967,42 @@ class TestPydanticAiStepCap(TestCase):
 
         assert asyncio.run(drive()) == 4
 
+    def test_positive_max_turns_wins_over_request_limit(self) -> None:
+        harness = PydanticAiHarness(
+            model=TestModel(), config=PydanticAiModelConfig(orca=OrcaLaneConfig(request_limit=4))
+        )
+
+        async def drive() -> int | None:
+            async with harness.open(ClaudeAgentOptions(max_turns=3)) as session:
+                assert isinstance(session, PydanticAiHarnessSession)
+                return session._request_limit
+
+        assert asyncio.run(drive()) == 3
+
+    def test_zero_max_turns_keeps_the_lane_request_limit(self) -> None:
+        # Headless dispatch sends max_turns=0 → the lane's request_limit is untouched, so an
+        # uncapped dispatch stays byte-identical and only a positive caller cap changes behaviour.
+        harness = PydanticAiHarness(
+            model=TestModel(), config=PydanticAiModelConfig(orca=OrcaLaneConfig(request_limit=4))
+        )
+
+        async def drive() -> int | None:
+            async with harness.open(ClaudeAgentOptions(max_turns=0)) as session:
+                assert isinstance(session, PydanticAiHarnessSession)
+                return session._request_limit
+
+        assert asyncio.run(drive()) == 4
+
+    def test_zero_max_turns_and_no_request_limit_stays_uncapped(self) -> None:
+        harness = PydanticAiHarness(model=TestModel())
+
+        async def drive() -> bool:
+            async with harness.open(ClaudeAgentOptions(max_turns=0)) as session:
+                assert isinstance(session, PydanticAiHarnessSession)
+                return session._usage_limits() is None
+
+        assert asyncio.run(drive()) is True
+
     def test_default_setting_is_a_conservative_cap(self) -> None:
         assert get_effective_settings().pydantic_ai_request_limit == 5
 

--- a/tests/teatree_agents/test_harness_options.py
+++ b/tests/teatree_agents/test_harness_options.py
@@ -68,6 +68,15 @@ class TestHarnessOptionsFromSdk:
         assert neutral.model == "claude-sonnet-5"
         assert neutral.system_prompt == "hi"
 
+    def test_positive_max_turns_is_carried(self) -> None:
+        assert HarnessOptions.from_sdk_options(ClaudeAgentOptions(max_turns=3)).max_turns == 3
+
+    def test_sdk_none_and_zero_max_turns_coerce_to_zero(self) -> None:
+        # The SDK default is None and headless dispatch sends 0 — both mean "uncapped" → 0, so
+        # only a genuinely positive cap wins over the lane's request_limit downstream.
+        assert HarnessOptions.from_sdk_options(ClaudeAgentOptions()).max_turns == 0
+        assert HarnessOptions.from_sdk_options(ClaudeAgentOptions(max_turns=0)).max_turns == 0
+
 
 class TestVendorTypeDoesNotLeakPastOpen:
     """AH-2 acceptance: the provider-agnostic harness logic consumes ONLY HarnessOptions.

--- a/tests/teatree_agents/test_one_shot.py
+++ b/tests/teatree_agents/test_one_shot.py
@@ -134,3 +134,34 @@ class TestOneShotRefusesBaseUrlRedirect:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-key")
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         _clean_room_options(OneShotSpec(system_prompt="s"))
+
+
+class TestOneShotPydanticLaneCredentialRefusalRaises:
+    """A credential the ``pydantic_ai`` lane resolves LAZILY inside ``open`` RAISES, never None.
+
+    Unlike the ambient base-URL guard (checked before ``run_one_shot``'s try), this refusal
+    surfaces from INSIDE the degrade-to-None try, so it must be re-raised past the blanket
+    handler — a missing metered key is an operator misconfiguration to surface, not a silent
+    None that strands every caller on its fallback with nothing naming the cause.
+    """
+
+    def test_refused_lazy_credential_raises_credential_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("T3_CONFIG_DB", str(tmp_path / "absent.sqlite3"))
+        monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+        monkeypatch.setenv("ORCA_ROUTER_BASE_URL", "https://router.example.invalid/v1")
+        monkeypatch.delenv("ORCA_ROUTER_API_KEY", raising=False)
+        # model=None forces the REAL lazy OrcaRouter credential resolution inside open() — no
+        # network is reached, the credential refusal fires before the client is built.
+        harness = PydanticAiHarness(model=None)
+        with pytest.raises(CredentialError):
+            run_one_shot("q", OneShotSpec(system_prompt="p"), harness=harness)
+
+    def test_a_non_credential_backend_error_still_degrades_to_none(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The re-raise is narrow: every OTHER backend failure still collapses to None (the claude
+        # lane never raises CredentialError from open()), so a best-effort aux turn never breaks.
+        monkeypatch.setenv("T3_CONFIG_DB", str(tmp_path / "absent.sqlite3"))
+        assert run_one_shot("q", OneShotSpec(system_prompt="p"), harness=_RaisingHarness()) is None


### PR DESCRIPTION
Fixes two one-shot dispatch gaps on the `pydantic_ai` lane.

## E1 — one-shot RAISES on a refused credential

`run_one_shot`'s docstring promises a refused environment RAISES (that is why the ambient base-URL guard sits OUTSIDE the try). But on the `pydantic_ai` lane the credential resolves lazily inside `harness.open()`, which is INSIDE the blanket `except Exception: return None` — so a `CredentialError` was silently swallowed to `None`. Added `except CredentialError: raise` before the blanket handler and stated the full two-path contract in the docstring.

Blast radius: on the claude lane `open()` spawns the CLI child with ambient login and never raises `CredentialError`, so the new raise path is pydantic-lane-only. Both enclosing dispatch handlers already record the failure rather than crash the tick — verified:
- `simple_answer` -> `loop/slack_answer/cycle.py` per-unit `try/except Exception` increments `report.errors` and logs a WARNING.
- `ticket_short_describe` -> `core/management/commands/_deterministic_phases.py::run_deterministic_phase` `try/except` records a failed `TaskAttempt` (exit_code=1) and logs a WARNING.

## E2 — one-shot `max_turns` was dropped on this lane

`OneShotSpec.max_turns` reached `ClaudeAgentOptions.max_turns` (claude honours it) but `HarnessOptions.from_sdk_options` DROPPED it, and the pydantic session's `request_limit` came only from `OrcaLaneConfig`. Fix: added `max_turns` to `HarnessOptions`, copied it in `from_sdk_options` (SDK-`None`/0 coerced to 0), and let a POSITIVE value win over `request_limit` in `PydanticAiHarness.open`. Headless dispatches send `max_turns=0`, so positive-wins keeps every headless dispatch byte-identical; only genuinely-capped callers gain the cap.

## Tests (RED before GREEN)

- E1: pydantic lane with a lazily-refused credential -> RAISES `CredentialError` (was: returned `None`); a non-credential backend error still -> `None` (unchanged).
- E2: `HarnessOptions` built from SDK options carrying `max_turns=N (>0)` preserves it and it wins over `request_limit`; `max_turns=0` leaves the pydantic run uncapped (headless byte-identical).

Each new test confirmed RED on the pre-fix code, then GREEN.

## Architecture pre-check

**1. BLUEPRINT alignment** — narrow behavioural fix within the existing harness seam (`src/teatree/agents`); no BLUEPRINT section changes.

**2. FSM phase boundaries** — n/a, no `Ticket`/`Worktree` transitions.

**3. Extension-point contracts** — `HarnessOptions` is the neutral options value consumed by the `pydantic_ai` backend; the added field is additive with a `0` default, so `from_sdk_options` and every existing reader stay source-compatible. `Harness.open` signature unchanged.

**4. Component boundaries** — stays within `src/teatree/agents` (`one_shot.py`, `harness_options.py`, `harness.py`); no new module.

**5. Dependency direction** — no new cross-module import (`one_shot` already imports from `teatree.llm.credentials`); no backwards edge.

**6. Test surface** — `tests/teatree_agents/test_one_shot.py` (credential-raises + non-credential-degrades), `tests/teatree_agents/test_harness_options.py` (field carried, None/0 coerced), `tests/teatree_agents/test_harness.py::TestPydanticAiStepCap` (positive wins, zero keeps request_limit, zero+no-limit uncapped).

**7. Resilience invariants** — no new external write; the change makes a credential-read FAILURE fail loud instead of silent-empty, and the two enclosing dispatch handlers record the failure.

**8. Identity/key normalization** — n/a.

**9. Behavior preservation** — additive. E1 narrows the blanket `except` by re-raising ONE type; every other backend failure still degrades to `None` (covered by a test). E2 coerces SDK-`None`/0 to 0 so only a positive cap changes behaviour — no must-block test inverted.

**10. Removability / harness-vs-data** — both changes are a few lines each, revertible without cascade. The cap is caller data (`OneShotSpec.max_turns` -> `HarnessOptions.max_turns`) threaded through the generic seam, not hard-coded policy.
