### PR TITLE
fix(lane-b): deny MCP toolsets on an empty phase allowance

### DIFF
--- a/src/teatree/agents/lane_b/toolsets.py
+++ b/src/teatree/agents/lane_b/toolsets.py
@@ -4,7 +4,9 @@ The one place the capability toolsets, the phase-scoping filter, the hard-deny
 wrapper, the soft-gate approval, and the MCP toolsets are composed into the list
 ``PydanticAiHarness`` passes as ``Agent(toolsets=...)``. Composition order (inner
 to outer): capabilities → phase filter → hard-deny wrapper → soft-gate approval;
-MCP toolsets ride alongside (read-only, never phase-filtered).
+the read-only MCP toolsets ride alongside, EXCEPT for an empty (non-``None``)
+phase allowance — a ``_NONE`` phase (``short_describe``, ``directive_reading``)
+may call nothing, so no MCP attaches past the phase filter.
 """
 
 from dataclasses import dataclass
@@ -42,8 +44,10 @@ def build_lane_b_toolsets(config: LaneBToolConfig, *, soft_gated: frozenset[str]
     ``write_file`` is allowed, so a read-only phase's toolset carries no mutation
     surface even before the runtime filter. The composed capabilities are wrapped
     in :class:`HardDenyToolset` (the shared-registry hard-deny) and, when a soft
-    gate is configured, in the native ``approval_required`` deferral. MCP toolsets
-    (read-only) are appended un-filtered.
+    gate is configured, in the native ``approval_required`` deferral. The read-only
+    MCP toolsets are appended un-filtered — UNLESS the phase allowance is a
+    non-``None`` empty set (a ``_NONE`` phase), which exposes nothing and so gets
+    no MCP either.
     """
     allowed = tools_for_phase(config.phase) if config.phase else None
     capability_toolsets: list[AbstractToolset[None]] = []
@@ -64,5 +68,8 @@ def build_lane_b_toolsets(config: LaneBToolConfig, *, soft_gated: frozenset[str]
     if soft_gated:
         gated = gated.approval_required(make_soft_gate_predicate(soft_gated))
 
-    toolsets: list[AbstractToolset[None]] = [gated, *build_mcp_toolsets()]
+    # A _NONE-phase allowance (empty, but NOT None) means the phase may call
+    # nothing — so no MCP toolset may attach past the phase filter either.
+    mcp_toolsets: list[AbstractToolset[None]] = [] if allowed is not None and not allowed else build_mcp_toolsets()
+    toolsets: list[AbstractToolset[None]] = [gated, *mcp_toolsets]
     return LaneBToolsets(toolsets=toolsets, needs_deferred_output=bool(soft_gated))

--- a/tests/teatree_agents/lane_b/test_toolsets.py
+++ b/tests/teatree_agents/lane_b/test_toolsets.py
@@ -15,7 +15,10 @@ from pydantic_ai import Agent
 from pydantic_ai.agent import AgentRunResult
 from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart
 from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.toolsets.abstract import AbstractToolset
+from pydantic_ai.toolsets.combined import CombinedToolset
 
+from teatree.agents.lane_b import toolsets as toolsets_module
 from teatree.agents.lane_b.config import LaneBToolConfig
 from teatree.agents.lane_b.toolsets import build_lane_b_toolsets
 from tests.teatree_agents.lane_b._managed_clone import linked_worktree, managed_main_clone
@@ -111,6 +114,25 @@ class TestHardDenyWithinAssembledToolsets:
             p for m in result.all_messages() for p in getattr(m, "parts", []) if type(p).__name__ == "ToolReturnPart"
         ]
         assert any("marker" in str(p.content) for p in returns)
+
+
+class TestMcpHonoursEmptyPhaseAllowance:
+    def _pin_sentinel_mcp(self, monkeypatch: pytest.MonkeyPatch) -> AbstractToolset[None]:
+        sentinel: AbstractToolset[None] = CombinedToolset([])
+        monkeypatch.setattr(toolsets_module, "build_mcp_toolsets", lambda: [sentinel])
+        return sentinel
+
+    def test_none_phase_gets_no_mcp(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # short_describe maps to the empty (NON-None) allowance — it may call NOTHING,
+        # so no MCP toolset may attach past the phase filter.
+        sentinel = self._pin_sentinel_mcp(monkeypatch)
+        config = LaneBToolConfig(fs_root=tmp_path, phase="short_describe")
+        assert sentinel not in build_lane_b_toolsets(config).toolsets
+
+    def test_work_phase_still_gets_mcp(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        sentinel = self._pin_sentinel_mcp(monkeypatch)
+        config = LaneBToolConfig(fs_root=tmp_path, phase="coding")
+        assert sentinel in build_lane_b_toolsets(config).toolsets
 
 
 def test_no_model_requests_are_allowed() -> None:


### PR DESCRIPTION
## Summary

`build_lane_b_toolsets` appended the MCP toolsets *after* the phase filter (hard-deny + soft-gate), so a `_NONE`-phase allowance — `short_describe` / `directive_reading`, designed to expose nothing — would still get the MCP toolset once the `fastmcp` extra is installed. Latent today (no `fastmcp` on the box) but a real least-privilege bypass.

Fix: when the computed phase allowance is a non-`None` empty frozenset, attach no MCP toolsets (return just the gated capability toolset). No `"mcp"` token is added to `ALL_TOOLS` / per-phase allowances — the guard is the minimal closure of the hole.

The two docstrings that claimed MCP is "never phase-filtered" are corrected.

## Test

- monkeypatch `build_mcp_toolsets` to a sentinel toolset; assert the sentinel is ABSENT for `short_describe` (a `_NONE` phase) and PRESENT for `coding` (a normal work phase). RED observed on the empty-phase case before the guard; both green after.

## Architecture pre-check

1. **BLUEPRINT § alignment** — least-privilege per-phase tool table (`phase_tools.py`), the `_NONE` context-firewall profile (#116). No contract change.
2. **FSM phase boundaries** — n/a (no transition).
3. **Extension-point contracts** — n/a; internal to Lane-B toolset assembly.
4. **Component boundaries** — `src/teatree/agents/lane_b/toolsets.py`, the sole composer of `Agent(toolsets=...)`.
5. **Dependency direction** — no new import; `tach` unaffected.
6. **Test surface** — `tests/teatree_agents/lane_b/test_toolsets.py::TestMcpHonoursEmptyPhaseAllowance`.
7. **Resilience invariants** — n/a (no external write).
8. **Identity/key normalization** — n/a.
9. **Behavior preservation** — additive tightening; non-empty and `None` allowances keep MCP exactly as before (preservation test pins `coding`).
10. **Removability / harness-vs-data** — one-line guard, trivially removable; belongs in the harness (it reads the existing per-phase data table).
