### PR TITLE
fix(dash): hide REVIEW_POSTED terminal state behind the board toggle

### DIFF
--- a/src/teatree/dash/selectors.py
+++ b/src/teatree/dash/selectors.py
@@ -28,21 +28,20 @@ from teatree.dash.issue_link import issue_link
 State = Ticket.State
 
 # The four visual groupings (lifecycle order). The union of every grouped state
-# plus the toggle-hidden IGNORED equals ``Ticket.State`` exactly — pinned by
+# plus the toggle-hidden set equals ``Ticket.State`` exactly — pinned by
 # ``test_kanban_conformance``. A card keeps its own state sub-column within a
-# group; the grouping is purely visual. REVIEW_POSTED (reviewer terminal) sits
-# under "Reviewing", NOT "Landed": "Landed" is author work merged to main, so a
-# reviewer ghost must never read as merged-and-shipped there.
+# group; the grouping is purely visual.
 COLUMN_GROUPS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("Backlog", (State.NOT_STARTED, State.SCOPED)),
     ("Building", (State.STARTED, State.PLANNED, State.CODED, State.TESTED)),
-    ("Reviewing", (State.REVIEWED, State.SHIPPED, State.IN_REVIEW, State.REVIEW_POSTED)),
+    ("Reviewing", (State.REVIEWED, State.SHIPPED, State.IN_REVIEW)),
     ("Landed", (State.MERGED, State.RETROSPECTED, State.DELIVERED)),
 )
-# Hidden by default behind the board's ``ignored`` toggle (abandoned tickets).
-HIDDEN_STATES: tuple[str, ...] = (State.IGNORED,)
+# Terminal, non-actionable states hidden by default behind the board's toggle:
+# IGNORED (abandoned) and REVIEW_POSTED (reviewer finished cold-reviewing a PR).
+HIDDEN_STATES: tuple[str, ...] = (State.IGNORED, State.REVIEW_POSTED)
 
-# Every column the board renders, in lifecycle order (excludes IGNORED).
+# Every column the board renders, in lifecycle order (excludes HIDDEN_STATES).
 BOARD_COLUMNS: tuple[str, ...] = tuple(state for _group, states in COLUMN_GROUPS for state in states)
 
 # state -> group slug (backlog/building/reviewing/landed/ignored), the ONE mapping
@@ -107,12 +106,12 @@ class KanbanGroup:
 class KanbanBoard:
     groups: tuple[KanbanGroup, ...]
     include_ignored: bool
-    ignored: KanbanColumn | None = None
+    hidden: tuple[KanbanColumn, ...] = ()
 
     @property
     def total(self) -> int:
         shown = sum(column.count for group in self.groups for column in group.columns)
-        return shown + (self.ignored.count if self.ignored else 0)
+        return shown + sum(column.count for column in self.hidden)
 
 
 @dataclass(frozen=True, slots=True)
@@ -162,12 +161,12 @@ def build_kanban_columns(filters: BoardFilters | None = None) -> KanbanBoard:
         )
         for name, states in COLUMN_GROUPS
     )
-    ignored = (
-        KanbanColumn(state=State.IGNORED, label=_label(State.IGNORED), cards=tuple(by_state[State.IGNORED]))
+    hidden = (
+        tuple(KanbanColumn(state=state, label=_label(state), cards=tuple(by_state[state])) for state in HIDDEN_STATES)
         if active.include_ignored
-        else None
+        else ()
     )
-    return KanbanBoard(groups=groups, include_ignored=active.include_ignored, ignored=ignored)
+    return KanbanBoard(groups=groups, include_ignored=active.include_ignored, hidden=hidden)
 
 
 def _filtered_tickets(filters: BoardFilters) -> list[Ticket]:

--- a/src/teatree/dash/snapshots/board.html
+++ b/src/teatree/dash/snapshots/board.html
@@ -158,11 +158,6 @@
             <p class="column-empty">—</p>
           </div>
 
-          <div class="kanban-column" data-state="review_posted">
-            <h3><span>Review posted</span><span class="count">0</span></h3>
-            <p class="column-empty">—</p>
-          </div>
-
       </div>
     </section>
 

--- a/src/teatree/dash/templates/dash/partials/_columns.html
+++ b/src/teatree/dash/templates/dash/partials/_columns.html
@@ -3,9 +3,9 @@
     <span class="fsm-node" data-group="{{ group.name|lower }}"><span class="fsm-dot"></span>{{ group.name }}</span>
     {% if not forloop.last %}<span class="fsm-link" data-group="{{ group.name|lower }}"></span>{% endif %}
   {% endfor %}
-  {% if board.include_ignored and board.ignored %}
+  {% if board.include_ignored and board.hidden %}
     <span class="fsm-gap"></span>
-    <span class="fsm-node" data-group="ignored"><span class="fsm-dot"></span>Ignored</span>
+    <span class="fsm-node" data-group="ignored"><span class="fsm-dot"></span>Hidden</span>
   {% endif %}
 </div>
 <div class="kanban-groups">
@@ -22,14 +22,16 @@
       </div>
     </section>
   {% endfor %}
-  {% if board.include_ignored and board.ignored %}
+  {% if board.include_ignored and board.hidden %}
     <section class="kanban-group" data-group="ignored">
-      <h2>Ignored</h2>
+      <h2>Hidden</h2>
       <div class="kanban-columns">
-        <div class="kanban-column" data-state="{{ board.ignored.state }}">
-          <h3><span>{{ board.ignored.label }}</span><span class="count">{{ board.ignored.count }}</span></h3>
-          {% for card in board.ignored.cards %}{% include "dash/partials/_card.html" %}{% empty %}<p class="column-empty">—</p>{% endfor %}
+        {% for column in board.hidden %}
+        <div class="kanban-column" data-state="{{ column.state }}">
+          <h3><span>{{ column.label }}</span><span class="count">{{ column.count }}</span></h3>
+          {% for card in column.cards %}{% include "dash/partials/_card.html" %}{% empty %}<p class="column-empty">—</p>{% endfor %}
         </div>
+        {% endfor %}
       </div>
     </section>
   {% endif %}

--- a/tests/teatree_dash/test_kanban_conformance.py
+++ b/tests/teatree_dash/test_kanban_conformance.py
@@ -21,9 +21,10 @@ def test_every_state_appears_exactly_once() -> None:
     assert len(columns) == len(Ticket.State.values)
 
 
-def test_ignored_is_the_only_hidden_state() -> None:
-    assert HIDDEN_STATES == (Ticket.State.IGNORED,)
+def test_ignored_and_review_posted_are_the_hidden_states() -> None:
+    assert HIDDEN_STATES == (Ticket.State.IGNORED, Ticket.State.REVIEW_POSTED)
     assert Ticket.State.IGNORED not in BOARD_COLUMNS
+    assert Ticket.State.REVIEW_POSTED not in BOARD_COLUMNS
 
 
 def test_board_columns_are_grouped_in_lifecycle_order() -> None:
@@ -32,11 +33,10 @@ def test_board_columns_are_grouped_in_lifecycle_order() -> None:
     assert BOARD_COLUMNS[0] == Ticket.State.NOT_STARTED
 
 
-def test_review_posted_is_under_reviewing_not_landed() -> None:
-    """The reviewer terminal must not read as author-merged "Landed" work."""
-    groups = dict(COLUMN_GROUPS)
-    assert Ticket.State.REVIEW_POSTED in groups["Reviewing"]
-    assert Ticket.State.REVIEW_POSTED not in groups["Landed"]
-    # DELIVERED stays the author-merged terminal — Landed only.
-    assert Ticket.State.DELIVERED in groups["Landed"]
-    assert Ticket.State.DELIVERED not in groups["Reviewing"]
+def test_review_posted_is_hidden_not_in_any_column_group() -> None:
+    """The reviewer terminal is hidden behind the toggle, not stacked in an active column."""
+    grouped = {state for _name, states in COLUMN_GROUPS for state in states}
+    assert Ticket.State.REVIEW_POSTED not in grouped
+    assert Ticket.State.REVIEW_POSTED in HIDDEN_STATES
+    # DELIVERED stays the author-merged terminal — a visible "Landed" column.
+    assert Ticket.State.DELIVERED in dict(COLUMN_GROUPS)["Landed"]

--- a/tests/teatree_dash/test_selectors.py
+++ b/tests/teatree_dash/test_selectors.py
@@ -15,8 +15,8 @@ def _cards_by_state(board: KanbanBoard) -> dict[str, list[KanbanCard]]:
     for group in board.groups:
         for column in group.columns:
             cards[column.state] = list(column.cards)
-    if board.ignored is not None:
-        cards[board.ignored.state] = list(board.ignored.cards)
+    for column in board.hidden:
+        cards[column.state] = list(column.cards)
     return cards
 
 
@@ -55,6 +55,12 @@ class BuildKanbanColumnsTestCase(TestCase):
         assert _find_card(build_kanban_columns(), ignored.pk) is None
         shown = build_kanban_columns(BoardFilters(include_ignored=True))
         assert _find_card(shown, ignored.pk) is not None
+
+    def test_review_posted_hidden_by_default_and_shown_on_toggle(self) -> None:
+        posted = TicketFactory(state=State.REVIEW_POSTED)
+        assert _find_card(build_kanban_columns(), posted.pk) is None
+        shown = build_kanban_columns(BoardFilters(include_ignored=True))
+        assert _find_card(shown, posted.pk) is not None
 
     def test_active_dot_from_pending_task(self) -> None:
         ticket = TicketFactory(state=State.CODED)


### PR DESCRIPTION
## Summary

`Ticket.State.REVIEW_POSTED` is a terminal reviewer state (a cold review was posted on a PR), not active review work. The board grouped it under the active **Reviewing** column, so terminal reviewer ghosts stacked there and cluttered the active view.

Move `REVIEW_POSTED` out of the `Reviewing` `COLUMN_GROUP` and into `HIDDEN_STATES` alongside `IGNORED` — hidden by default, shown only via the board's existing hidden toggle. Same treatment as `IGNORED`: terminal and non-actionable.

The board's single `ignored` column generalizes to a `hidden` column tuple over `HIDDEN_STATES`, so both hidden states render under the toggle.

## Changes
- `selectors.py`: `REVIEW_POSTED` moved to `HIDDEN_STATES`; `KanbanBoard.ignored` → `KanbanBoard.hidden` tuple.
- `_columns.html`: render each hidden column under a "Hidden" group.
- Board snapshot regenerated (drops the `review_posted` column from the default view).
- `test_kanban_conformance`: union of grouped + hidden states still equals `Ticket.State`; `REVIEW_POSTED` asserted HIDDEN, not under Reviewing.
- `test_selectors`: added the REVIEW_POSTED hidden-by-default / shown-on-toggle case.

## Architecture pre-check
Tactical fix — a single module constant moves states between two existing tuples; no FSM transition, extension-point, or dependency-direction change. Behaviour preservation: `IGNORED` toggle behaviour is preserved and now shared; no matcher narrowed. Removability: trivial (revert the constant + snapshot).

Gate: `bash dev/ci-parity-fast.sh` passed (30106 passed).