### PR TITLE
chore(config): default issue_implementer concurrency 3 + intake cadence 30m

### DIFF
--- a/src/teatree/config/settings_loop_flags.py
+++ b/src/teatree/config/settings_loop_flags.py
@@ -63,7 +63,7 @@ class _LoopFlagAndCredentialSettings:
     # overlay's ``OverlayConfig`` supplies the value BELOW any DB/env override.
     admission_policy: AdmissionPolicy = AdmissionPolicy.ASSIGNED_AND_LABELED
     # Cap on simultaneously in-flight auto-implement tickets.
-    issue_implementer_max_concurrent: int = 1
+    issue_implementer_max_concurrent: int = 3
     # Internal dispatch-rate floor (hours) between auto-implement pickups.
     issue_implementer_cadence_hours: int = 1
     # Fleet-safety Stage 2 kill-switch (default OFF). When ON, the cross-instance

--- a/src/teatree/core/migrations/0001_initial.py
+++ b/src/teatree/core/migrations/0001_initial.py
@@ -155,10 +155,10 @@ _DEFAULT_LOOPS = (
     ),
     (
         "issue_implementer",
-        3600,
+        1800,
         None,
         None,
-        "Discovers and claims labelled backlog issues to auto-implement, kicking off the maker pipeline; hourly, default-off behind a triple gate.",
+        "Discovers and claims labelled backlog issues to auto-implement, kicking off the maker pipeline; every 30m, default-off behind a triple gate.",
         False,
         False,
     ),

--- a/src/teatree/loops/seed.py
+++ b/src/teatree/loops/seed.py
@@ -183,9 +183,9 @@ DEFAULT_LOOPS: tuple[LoopSeedSpec, ...] = (
     ),
     LoopSeedSpec(
         "issue_implementer",
-        3600,
+        1800,
         "Discovers and claims labelled backlog issues to auto-implement, kicking off the "
-        "maker pipeline; hourly, default-off behind a triple gate.",
+        "maker pipeline; every 30m, default-off behind a triple gate.",
     ),
     LoopSeedSpec(
         "triage_assessor",

--- a/tests/config/test_home_resolution.py
+++ b/tests/config/test_home_resolution.py
@@ -48,7 +48,7 @@ class TestDbHomeResolution(TestCase):
         ConfigSetting.objects.set_value("issue_implementer_max_concurrent", value=7)
         assert get_effective_settings().issue_implementer_max_concurrent == 7
         ConfigSetting.objects.clear("issue_implementer_max_concurrent")
-        assert get_effective_settings().issue_implementer_max_concurrent == 1
+        assert get_effective_settings().issue_implementer_max_concurrent == 3
 
     def test_newly_db_home_field_resolves_from_db_row(self) -> None:
         ConfigSetting.objects.set_value("repo_mode", "solo")

--- a/tests/config/test_load_config.py
+++ b/tests/config/test_load_config.py
@@ -89,7 +89,7 @@ class TestDbTierDefaults(TestCase):
         settings = get_effective_settings()
         assert settings.issue_implementer_enabled is False
         assert settings.issue_implementer_label == ""
-        assert settings.issue_implementer_max_concurrent == 1
+        assert settings.issue_implementer_max_concurrent == 3
         assert settings.issue_implementer_cadence_hours == 1
 
     def test_e2e_confidence_threshold_default(self) -> None:

--- a/tests/teatree_loops/test_seed.py
+++ b/tests/teatree_loops/test_seed.py
@@ -93,6 +93,16 @@ class TestSeedDefaultLoops(django.test.TestCase):
         seed_default_loops_and_prompts()
         assert Loop.objects.get(name="inbox").enabled is False
 
+    def test_issue_implementer_seeds_a_thirty_minute_cadence(self) -> None:
+        seed_default_loops_and_prompts()
+        assert Loop.objects.get(name="issue_implementer").delay_seconds == 1800
+
+    def test_reseed_preserves_an_operator_tuned_cadence(self) -> None:
+        seed_default_loops_and_prompts()
+        Loop.objects.filter(name="issue_implementer").update(delay_seconds=900)
+        seed_default_loops_and_prompts()
+        assert Loop.objects.get(name="issue_implementer").delay_seconds == 900
+
     def test_default_loops_satisfy_the_prompt_xor_script_constraint(self) -> None:
         # Every seeded row must hold exactly one of prompt-FK / script (the DB
         # CheckConstraint) — a seed that violated it would raise on create.


### PR DESCRIPTION
issue_implementer_max_concurrent 1->3, loop cadence 1h->30m. Operator rows untouched on re-seed.