### PR TITLE
fix: implement #3534

### DIFF
--- a/src/teatree/loop/transient_requeue.py
+++ b/src/teatree/loop/transient_requeue.py
@@ -46,12 +46,16 @@ COMPLETED silently. This is the fix for the redispatch flood on already-done tic
 state already answers.
 
 A FAILED task WITH A LIVE SUCCESSOR — a newer, still-active (PENDING/CLAIMED) sibling
-Task on the same ``(ticket, phase)`` — is likewise retired COMPLETED, never escalated
-(3534). A stuck-phase redispatch mints a fresh Task and can re-claim the predecessor's
-lease out from under it; the predecessor lands FAILED carrying a ``stuck_loop: lease
-lost … re-claimed`` breach even though the phase is recovering fine under the successor.
-Escalating it files a ``DeferredQuestion`` already stale at write time — the successor
-has the work, so the only correct answer is "ignore".
+Task on the same ``(ticket, phase)`` — is PARKED (left FAILED, stamped out of every
+future scan), never escalated (3534). A stuck-phase redispatch mints a fresh Task and
+can re-claim the predecessor's lease out from under it; the predecessor lands FAILED
+carrying a ``stuck_loop: lease lost … re-claimed`` breach even though the phase is
+recovering fine under the successor. Escalating it files a ``DeferredQuestion`` already
+stale at write time — the successor has the work, so the only correct answer is
+"ignore". The park deliberately does NOT mark the row COMPLETED: the phase has not
+finished (the successor is still mid-flight), and a COMPLETED row would become the
+ticket's newest completed task, so ``replay_orphaned_transitions`` would fire its phase
+transition on the next tick and silently advance the ticket past a phase nobody landed.
 
 A DEAD-REVIEW-TARGET FAILED task — a review/codex-review phase (``reviewing`` /
 ``codex_reviewing`` / ``codex_adversarial_reviewing`` / ``e2e_reviewing``) whose
@@ -104,6 +108,11 @@ _HALT_STAMP = "[repair-halt-parked]"
 #: out of the scan — the away-mode queue is never asked about a phase the ticket
 #: already advanced past (the 3366/3336/3352 redispatch-loop root cause).
 _SUPERSEDED_STAMP = "[superseded-retired]"
+#: Stamped onto ``execution_reason`` when a FAILED task is parked because a newer,
+#: still-active sibling Task holds its ``(ticket, phase)`` (#3534). The row stays
+#: FAILED — the phase has not completed — and drops out of the scan, so the stale
+#: predecessor neither escalates nor advances the ticket's FSM.
+_LIVE_SUCCESSOR_STAMP = "[superseded-parked]"
 
 #: Stamped onto ``execution_reason`` when a review/codex-review task is retired
 #: because its linked PR is provably MERGED/CLOSED. A review verdict can never land
@@ -161,14 +170,14 @@ def requeue_transient_failed() -> int:
 
 
 def _route_failed_task(task: Task, *, now: datetime, autorecovery: bool) -> int:
-    """Route ONE FAILED task to reopen / retire / corrective-retry / escalate. Returns the reopen count.
+    """Route ONE FAILED task to reopen / dispose / corrective-retry / escalate. Returns the reopen count.
 
     Isolated per task so :func:`requeue_transient_failed` can wrap it in a single
     ``try`` and keep sweeping when one row raises — a terminal FAILED task on a
-    non-terminal ticket is still never left silent (reopened, retired, retried, or
+    non-terminal ticket is still never left silent (reopened, disposed, retried, or
     escalated), it just can no longer take the whole tick down with it.
     """
-    if _retire_if_dead_artifact(task):
+    if _dispose_without_reopen(task):
         return 0
     error = _latest_error(task)
     if not error:
@@ -275,15 +284,17 @@ def _latest_error(task: Task) -> str:
 def _non_terminal_failed_tasks() -> list[Task]:
     """FAILED tasks on a non-terminal ticket, minus already-parked rows, attempts prefetched.
 
-    Excluding :data:`_HALT_STAMP`-stamped rows keeps the per-tick scan bounded as
-    dead letters pile up (a monotonically growing FAILED set would otherwise degrade
-    tick latency linearly); prefetching ``attempts`` removes the per-task N+1 that
-    :func:`_latest_error` would otherwise issue for every FAILED row.
+    Excluding the parked rows — :data:`_HALT_STAMP` (escalated) and
+    :data:`_LIVE_SUCCESSOR_STAMP` (a live successor holds the phase) — keeps the
+    per-tick scan bounded as dead letters pile up (a monotonically growing FAILED set
+    would otherwise degrade tick latency linearly); prefetching ``attempts`` removes the
+    per-task N+1 that :func:`_latest_error` would otherwise issue for every FAILED row.
     """
     return list(
         Task.objects.filter(status=Task.Status.FAILED)
         .exclude(ticket__state__in=Ticket._TERMINAL_STATES)  # noqa: SLF001 — the model's SSOT terminal set
         .exclude(execution_reason__contains=_HALT_STAMP)
+        .exclude(execution_reason__contains=_LIVE_SUCCESSOR_STAMP)
         .select_related("ticket")
         .prefetch_related("attempts"),
     )
@@ -345,25 +356,40 @@ def _stamp_halt(task: Task) -> None:
     Task.objects.filter(pk=task.pk).update(execution_reason=reason)
 
 
+def _dispose_without_reopen(task: Task) -> bool:
+    """Dispose of a FAILED row the sweep must neither reopen nor escalate; ``True`` if handled.
+
+    Two dispositions, differing in whether the phase's work is over. A DEAD ARTIFACT is
+    retired COMPLETED — nothing can still land, so the row's transition is inert. A row
+    with a LIVE SUCCESSOR is parked FAILED — its phase is unfinished and someone else is
+    finishing it, so marking it COMPLETED would advance the ticket over the successor.
+    """
+    if _retire_if_dead_artifact(task):
+        return True
+    if _has_live_successor(task):
+        _park_live_successor(task)
+        return True
+    return False
+
+
 def _retire_if_dead_artifact(task: Task) -> bool:
     """Retire a FAILED task whose phase output is already moot; ``True`` if retired.
 
-    Three ways a FAILED row becomes a dead artifact to retire (COMPLETED) rather than
+    Two ways a FAILED row becomes a dead artifact to retire (COMPLETED) rather than
     reopen or escalate:
 
-    * SUPERSEDED BY FSM — the ticket's FSM already reached this phase's output, so the
+    * SUPERSEDED — the ticket's FSM already reached this phase's output, so the
         row is a leftover of an earlier interrupted run (the ticket advanced on its own).
-    * SUPERSEDED BY A LIVE SUCCESSOR — a newer, still-active sibling Task holds this
-        ``(ticket, phase)`` (a redispatch that re-claimed the lease out from under this
-        row), so escalating it asks about a failure the system already recovered (#3534).
     * DEAD REVIEW TARGET — a review/codex-review phase whose linked PR is
         merged/closed, so a verdict can never land; re-dispatching only burns a
         session that re-confirms the close (#3556).
+
+    Both triggers are FSM-inert by construction — the ticket has already reached (or is
+    being moved to) its terminal answer, so the COMPLETED row's replayed transition
+    finds no matching guard. A live-successor row is NOT one of them: its phase is
+    unfinished, so it is parked FAILED by :func:`_park_live_successor` instead.
     """
     if task.ticket.has_completed_phase(task.phase):
-        _retire_superseded(task)
-        return True
-    if _has_live_successor(task):
         _retire_superseded(task)
         return True
     if _review_target_dead(task):
@@ -380,10 +406,19 @@ def _has_live_successor(task: Task) -> bool:
     carrying a ``stuck_loop: lease lost … re-claimed`` breach even though the phase is
     recovering fine under the successor — so escalating it files a ``DeferredQuestion``
     that was already stale at write time (the only correct answer was "ignore"). A
-    later-pk sibling in an ACTIVE state (PENDING/CLAIMED) is that live successor; retire
-    the predecessor as superseded. Only a strictly LATER row (``pk__gt``) counts, so the
-    newest FAILED row is never retired on the strength of an older sibling — a genuinely
-    blocked phase whose last row has no successor still escalates.
+    later-pk sibling in an ACTIVE state (PENDING/CLAIMED) is that live successor. Only a
+    strictly LATER row (``pk__gt``) counts, so the newest FAILED row is never parked on
+    the strength of an older sibling — a genuinely blocked phase whose last row has no
+    successor still escalates.
+
+    Checked on ANY failure class, not just the lease loss that motivated it: the breach
+    string is an unreliable discriminator (the same handoff surfaces under several
+    wordings), and a live successor makes the predecessor's error moot whatever it was.
+    The cost is that a parked row skips the :func:`_budget_halt_reason` check, which the
+    escalation path would otherwise run. That is bounded: the park grants no retry (the
+    row is never reopened), its ``TaskAttempt`` rows survive so ``phase_attempts`` still
+    counts them against the phase budget, and the successor carries the redispatcher's
+    own cap — so a doomed phase still hits its budget through the successor's own row.
     """
     return Task.objects.filter(
         ticket_id=task.ticket_id,  # ty: ignore[unresolved-attribute]
@@ -391,6 +426,27 @@ def _has_live_successor(task: Task) -> bool:
         status__in=Task.Status.active(),
         pk__gt=task.pk,
     ).exists()
+
+
+def _park_live_successor(task: Task) -> None:
+    """Park a FAILED task whose ``(ticket, phase)`` a live successor now holds. Idempotent.
+
+    Stamps :data:`_LIVE_SUCCESSOR_STAMP` so the row drops out of
+    :func:`_non_terminal_failed_tasks` and is never escalated again, via the same
+    ``UPDATE ... WHERE status=FAILED`` compare-and-swap the reopen/retire paths use.
+
+    The row stays FAILED on purpose. Its phase did not finish — the successor is still
+    mid-flight — so marking it COMPLETED (the ``_retire_superseded`` shape) would make it
+    the ticket's newest completed task and ``Task.objects.replay_orphaned_transitions``
+    would fire its phase transition on the next tick, advancing the ticket past work
+    nobody landed (a PLANNED ticket to CODED, a TESTED one through ``review()``).
+    """
+    if _LIVE_SUCCESSOR_STAMP in task.execution_reason:
+        return
+    reason = (
+        f"{task.execution_reason}\n{_LIVE_SUCCESSOR_STAMP}".strip() if task.execution_reason else _LIVE_SUCCESSOR_STAMP
+    )
+    Task.objects.filter(pk=task.pk, status=Task.Status.FAILED).update(execution_reason=reason)
 
 
 def _review_target_dead(task: Task) -> bool:

--- a/src/teatree/loop/transient_requeue.py
+++ b/src/teatree/loop/transient_requeue.py
@@ -45,6 +45,14 @@ COMPLETED silently. This is the fix for the redispatch flood on already-done tic
 (3366/3336/3352): the away-mode queue is never asked about a phase the ticket's own
 state already answers.
 
+A FAILED task WITH A LIVE SUCCESSOR — a newer, still-active (PENDING/CLAIMED) sibling
+Task on the same ``(ticket, phase)`` — is likewise retired COMPLETED, never escalated
+(3534). A stuck-phase redispatch mints a fresh Task and can re-claim the predecessor's
+lease out from under it; the predecessor lands FAILED carrying a ``stuck_loop: lease
+lost … re-claimed`` breach even though the phase is recovering fine under the successor.
+Escalating it files a ``DeferredQuestion`` already stale at write time — the successor
+has the work, so the only correct answer is "ignore".
+
 A DEAD-REVIEW-TARGET FAILED task — a review/codex-review phase (``reviewing`` /
 ``codex_reviewing`` / ``codex_adversarial_reviewing`` / ``e2e_reviewing``) whose
 linked PR is provably MERGED/CLOSED — is likewise retired COMPLETED (and its reviewer
@@ -73,7 +81,7 @@ from django.utils import timezone
 from teatree.agents.outage_classifier import is_transient_failure
 from teatree.agents.usage_window import autorecovery_enabled
 from teatree.core.modelkit.phase_tools import VERDICT_REVIEW_PHASES
-from teatree.core.modelkit.phases import normalize_phase
+from teatree.core.modelkit.phases import normalize_phase, phase_spellings
 from teatree.core.models import Task, TaskAttempt, Ticket
 from teatree.core.models.deferred_question import DeferredQuestion
 from teatree.core.models.task_repair import phase_attempts
@@ -340,11 +348,14 @@ def _stamp_halt(task: Task) -> None:
 def _retire_if_dead_artifact(task: Task) -> bool:
     """Retire a FAILED task whose phase output is already moot; ``True`` if retired.
 
-    Two ways a FAILED row becomes a dead artifact to retire (COMPLETED) rather than
+    Three ways a FAILED row becomes a dead artifact to retire (COMPLETED) rather than
     reopen or escalate:
 
-    * SUPERSEDED — the ticket's FSM already reached this phase's output, so the
+    * SUPERSEDED BY FSM — the ticket's FSM already reached this phase's output, so the
         row is a leftover of an earlier interrupted run (the ticket advanced on its own).
+    * SUPERSEDED BY A LIVE SUCCESSOR — a newer, still-active sibling Task holds this
+        ``(ticket, phase)`` (a redispatch that re-claimed the lease out from under this
+        row), so escalating it asks about a failure the system already recovered (#3534).
     * DEAD REVIEW TARGET — a review/codex-review phase whose linked PR is
         merged/closed, so a verdict can never land; re-dispatching only burns a
         session that re-confirms the close (#3556).
@@ -352,10 +363,34 @@ def _retire_if_dead_artifact(task: Task) -> bool:
     if task.ticket.has_completed_phase(task.phase):
         _retire_superseded(task)
         return True
+    if _has_live_successor(task):
+        _retire_superseded(task)
+        return True
     if _review_target_dead(task):
         _retire_dead_review(task)
         return True
     return False
+
+
+def _has_live_successor(task: Task) -> bool:
+    """Whether a newer, still-active sibling Task is handling *task*'s ``(ticket, phase)`` (#3534).
+
+    A stuck-phase redispatch mints a FRESH Task for the same ``(ticket, phase)`` and can
+    re-claim the predecessor's lease out from under it. The predecessor then lands FAILED
+    carrying a ``stuck_loop: lease lost … re-claimed`` breach even though the phase is
+    recovering fine under the successor — so escalating it files a ``DeferredQuestion``
+    that was already stale at write time (the only correct answer was "ignore"). A
+    later-pk sibling in an ACTIVE state (PENDING/CLAIMED) is that live successor; retire
+    the predecessor as superseded. Only a strictly LATER row (``pk__gt``) counts, so the
+    newest FAILED row is never retired on the strength of an older sibling — a genuinely
+    blocked phase whose last row has no successor still escalates.
+    """
+    return Task.objects.filter(
+        ticket_id=task.ticket_id,  # ty: ignore[unresolved-attribute]
+        phase__in=phase_spellings(normalize_phase(task.phase)),
+        status__in=Task.Status.active(),
+        pk__gt=task.pk,
+    ).exists()
 
 
 def _review_target_dead(task: Task) -> bool:

--- a/tests/teatree_loop/test_transient_requeue.py
+++ b/tests/teatree_loop/test_transient_requeue.py
@@ -288,6 +288,73 @@ class TestTransientRequeue(TestCase):
         assert task.status == Task.Status.FAILED
         assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
 
+    def test_lease_loss_with_live_successor_is_retired_not_escalated(self) -> None:
+        # 3534: worker A loses its lease because a redispatch minted a fresh task B
+        # for the same (ticket, phase) and B re-claimed the lease. A lands FAILED
+        # carrying the `stuck_loop: lease lost … re-claimed` breach even though the
+        # phase is recovering fine under B. The predecessor must retire silently —
+        # escalating it asks the human about a failure the system already superseded.
+        predecessor = _failed_task(phase="coding")
+        _add_failed_attempt(
+            predecessor,
+            error="stuck_loop: lease lost for task 1: re-claimed by another worker",
+        )
+        Task.objects.create(
+            ticket=predecessor.ticket,
+            session=predecessor.session,
+            phase="coding",
+            status=Task.Status.CLAIMED,
+        )
+
+        reopened = requeue_transient_failed()
+
+        predecessor.refresh_from_db()
+        assert reopened == 0
+        assert predecessor.status == Task.Status.COMPLETED
+        assert "[superseded-retired]" in predecessor.execution_reason
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 0
+
+    def test_failed_task_with_only_an_older_sibling_still_escalates(self) -> None:
+        # Directionality guard: the newest FAILED row must NOT be retired on the
+        # strength of an OLDER live sibling — only a LATER successor (higher pk)
+        # supersedes it. A genuinely blocked phase whose live sibling predates it
+        # is still a real halt that must escalate.
+        older = _failed_task(phase="coding")
+        newest = Task.objects.create(
+            ticket=older.ticket,
+            session=older.session,
+            phase="coding",
+            status=Task.Status.FAILED,
+        )
+        Task.objects.filter(pk=older.pk).update(status=Task.Status.CLAIMED)
+        _add_failed_attempt(newest, error="deterministic failure in phase 'coding'")
+
+        reopened = requeue_transient_failed()
+
+        newest.refresh_from_db()
+        assert reopened == 0
+        assert newest.status == Task.Status.FAILED
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
+
+    def test_failed_task_with_terminal_sibling_still_escalates(self) -> None:
+        # A COMPLETED/FAILED sibling is not a live successor — the phase is not being
+        # worked by anyone else, so a genuine deterministic failure must still escalate.
+        task = _failed_task(phase="coding")
+        _add_failed_attempt(task, error="deterministic failure in phase 'coding'")
+        Task.objects.create(
+            ticket=task.ticket,
+            session=task.session,
+            phase="coding",
+            status=Task.Status.COMPLETED,
+        )
+
+        reopened = requeue_transient_failed()
+
+        task.refresh_from_db()
+        assert reopened == 0
+        assert task.status == Task.Status.FAILED
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
+
     def test_churned_tasks_same_condition_collapse_to_one_question(self) -> None:
         # THE FLOOD FIX: a stuck phase mints a FRESH Task row every redispatch cycle.
         # Two FAILED tasks on the same (ticket, phase) failing IDENTICALLY are ONE

--- a/tests/teatree_loop/test_transient_requeue.py
+++ b/tests/teatree_loop/test_transient_requeue.py
@@ -20,6 +20,7 @@ from teatree.core.models import Session, Task, TaskAttempt, Ticket
 from teatree.core.models.config_setting import ConfigSetting
 from teatree.core.models.deferred_question import DeferredQuestion
 from teatree.core.repair_loop import max_phase_iterations
+from teatree.core.worktree.recovery_sweeps import run_boot_sweeps
 from teatree.llm.anthropic_limits import LimitCause, LimitMatch
 from teatree.loop.tick_recovery import _reap_stale_task_claims
 from teatree.loop.transient_requeue import requeue_transient_failed
@@ -288,12 +289,13 @@ class TestTransientRequeue(TestCase):
         assert task.status == Task.Status.FAILED
         assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
 
-    def test_lease_loss_with_live_successor_is_retired_not_escalated(self) -> None:
+    def test_lease_loss_with_live_successor_is_parked_not_escalated(self) -> None:
         # 3534: worker A loses its lease because a redispatch minted a fresh task B
         # for the same (ticket, phase) and B re-claimed the lease. A lands FAILED
         # carrying the `stuck_loop: lease lost … re-claimed` breach even though the
-        # phase is recovering fine under B. The predecessor must retire silently —
+        # phase is recovering fine under B. The predecessor must park silently —
         # escalating it asks the human about a failure the system already superseded.
+        # It stays FAILED (the phase never finished) and drops out of every later scan.
         predecessor = _failed_task(phase="coding")
         _add_failed_attempt(
             predecessor,
@@ -310,8 +312,11 @@ class TestTransientRequeue(TestCase):
 
         predecessor.refresh_from_db()
         assert reopened == 0
-        assert predecessor.status == Task.Status.COMPLETED
-        assert "[superseded-retired]" in predecessor.execution_reason
+        assert predecessor.status == Task.Status.FAILED
+        assert "[superseded-parked]" in predecessor.execution_reason
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 0
+        # The park is durable: a later sweep never resurrects it into an escalation.
+        assert requeue_transient_failed() == 0
         assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 0
 
     def test_failed_task_with_only_an_older_sibling_still_escalates(self) -> None:
@@ -354,6 +359,56 @@ class TestTransientRequeue(TestCase):
         assert reopened == 0
         assert task.status == Task.Status.FAILED
         assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
+
+    def test_live_successor_park_leaves_the_ticket_fsm_untouched(self) -> None:
+        # The park must not advance the ticket past a phase that never completed. A row
+        # marked COMPLETED becomes the newest completed task for its ticket, so the
+        # boot-sweep replay fires its phase transition and a PLANNED ticket silently
+        # reaches CODED while the successor is still mid-flight.
+        predecessor = _failed_task(phase="coding", state=Ticket.State.PLANNED)
+        _add_failed_attempt(
+            predecessor,
+            error="stuck_loop: lease lost for task 1: re-claimed by another worker",
+        )
+        Task.objects.create(
+            ticket=predecessor.ticket,
+            session=predecessor.session,
+            phase="coding",
+            status=Task.Status.CLAIMED,
+        )
+
+        assert requeue_transient_failed() == 0
+        counts = run_boot_sweeps()
+
+        predecessor.ticket.refresh_from_db()
+        assert counts.replayed_transitions == 0
+        assert predecessor.ticket.state == Ticket.State.PLANNED
+        assert not predecessor.ticket.tasks.completed_in_phase("coding").exists()
+
+    def test_live_successor_park_does_not_satisfy_the_review_completion_guard(self) -> None:
+        # Same skip on the review seam: a COMPLETED park row satisfies
+        # ``completed_in_phase("reviewing")`` — the guard on Ticket.review() /
+        # mark_reviewed_externally() — so the replay disposes a TESTED ticket as if a
+        # verdict had landed.
+        predecessor = _failed_task(phase="reviewing", state=Ticket.State.TESTED)
+        _add_failed_attempt(
+            predecessor,
+            error="stuck_loop: lease lost for task 1: re-claimed by another worker",
+        )
+        Task.objects.create(
+            ticket=predecessor.ticket,
+            session=predecessor.session,
+            phase="reviewing",
+            status=Task.Status.CLAIMED,
+        )
+
+        assert requeue_transient_failed() == 0
+        counts = run_boot_sweeps()
+
+        predecessor.ticket.refresh_from_db()
+        assert counts.replayed_transitions == 0
+        assert predecessor.ticket.state == Ticket.State.TESTED
+        assert not predecessor.ticket.tasks.completed_in_phase("reviewing").exists()
 
     def test_churned_tasks_same_condition_collapse_to_one_question(self) -> None:
         # THE FLOOD FIX: a stuck phase mints a FRESH Task row every redispatch cycle.


### PR DESCRIPTION
Closes #3534

A FAILED task whose lease was lost to a live successor no longer escalates a stale
`DeferredQuestion`. The predecessor's row is **parked FAILED** (stamped
`[superseded-parked]`, which `_non_terminal_failed_tasks` excludes) rather than retired
COMPLETED.

## Why not the retire path

`_retire_superseded` marks the row COMPLETED, and its "no FSM side effect" contract holds
only for its two pre-existing triggers — FSM-superseded (the replayed transition's guard
no longer matches) and dead-review (the ticket is already IGNORED). For the live-successor
trigger it does not: `has_completed_phase()` is false by construction and the ticket is
non-terminal, so the retired row becomes the ticket's newest COMPLETED task and
`Task.objects.replay_orphaned_transitions()` fires its phase transition on the next tick
(the sweep runs every tick via `run_boot_sweeps`). Measured on the previous head:

| scenario | previous head | now |
|---|---|---|
| PLANNED ticket, FAILED `coding` + CLAIMED successor | `replayed=1`, ticket → `coded` | `replayed=0`, ticket stays `planned` |
| TESTED ticket, FAILED `reviewing` + CLAIMED successor | `replayed=1`, ticket → `ignored` | `replayed=0`, ticket stays `tested` |

The retired row also satisfied `completed_in_phase("reviewing")` — the guard on
`Ticket.review()` / `mark_reviewed_externally()`. Both regression tests assert the ticket
state AND that guard; both were observed RED against the previous head.

## Successor check ordering

`_has_live_successor` runs ahead of the repair-budget check on any failure class, not just
the lease loss that motivated it — the breach string is an unreliable discriminator, and a
live successor makes the predecessor's error moot whatever it was. Documented in the
docstring as bounded: the park grants no retry, its `TaskAttempt` rows survive so
`phase_attempts` still budgets them, and the successor carries the redispatcher's own cap.
