### PR TITLE
fix(session): resolve CLAUDE_CODE_SESSION_ID in the session-id chain (#3554)

### DIFF
--- a/src/teatree/core/management/commands/loop_owner.py
+++ b/src/teatree/core/management/commands/loop_owner.py
@@ -13,9 +13,9 @@ Non-zero exits use ``raise SystemExit(N)`` — this runs under Django's
 
 #1107 — the ``claim`` no-session refusal below is now reachable far less
 often: ``current_session_id()`` gained a loop-registry fallback (read the
-``t3-loop-tick-owner`` record when both session-id env vars are absent),
+``t3-loop-tick-owner`` record when the session-id env vars are absent),
 so an agent-driven ``t3 loop claim`` (a Bash-tool subprocess that never
-sees ``CLAUDE_SESSION_ID`` as an env var) resolves the owner from the
+sees the session id as an env var) resolves the owner from the
 durable registry instead of hard-refusing. The refusal still fires only
 when there is genuinely no resolvable session id anywhere.
 """

--- a/src/teatree/core/management/commands/loop_self_improve.py
+++ b/src/teatree/core/management/commands/loop_self_improve.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING, Annotated, Any
 import typer
 from django_typer.management import TyperCommand
 
+from teatree.core.session_identity import session_id_from_env
+
 if TYPE_CHECKING:
     from teatree.loop.self_improve.schedule import TierResult
 
@@ -53,7 +55,7 @@ def _non_owner_session_id() -> str | None:
     env var is missing and the t3-master gate skips its check rather
     than refusing every CLI call.
     """
-    return os.environ.get("CLAUDE_SESSION_ID") or os.environ.get("T3_LOOP_SESSION_ID")
+    return session_id_from_env()
 
 
 def _session_owns_loop(session_id: str | None) -> bool:

--- a/src/teatree/core/management/commands/loop_slack_answer.py
+++ b/src/teatree/core/management/commands/loop_slack_answer.py
@@ -21,10 +21,12 @@ from typing import Annotated
 import typer
 from django_typer.management import TyperCommand
 
+from teatree.core.session_identity import session_id_from_env
+
 
 def _non_owner_session_id() -> str | None:
     """Read the current Claude session id from the env, ``None`` when absent."""
-    return os.environ.get("CLAUDE_SESSION_ID") or os.environ.get("T3_LOOP_SESSION_ID")
+    return session_id_from_env()
 
 
 def _session_owns_loop(session_id: str | None) -> bool:

--- a/src/teatree/core/session_identity.py
+++ b/src/teatree/core/session_identity.py
@@ -18,13 +18,23 @@ re-exporters are allowed to reach.
 
 #1107 — the headline incident root cause: Claude Code delivers the
 session id ONLY in the hook JSON payload, never as an env var inside a
-Bash-tool subprocess, so in agent-driven mode both env vars are empty and
-``current_session_id()`` returned ``""`` → ``t3 loop claim`` hard-refused
-→ t3-master could never be claimed → every owner-gated slot (#1075
-reactive answer, self-improve, the claim-next spawn pump) was permanently
-dead (131 user DMs reacted/answered never). The precedence is now:
+Bash-tool subprocess, so in agent-driven mode the session-id env vars are
+empty and ``current_session_id()`` returned ``""`` → ``t3 loop claim``
+hard-refused → t3-master could never be claimed → every owner-gated slot
+(#1075 reactive answer, self-improve, the claim-next spawn pump) was
+permanently dead (131 user DMs reacted/answered never). The precedence is
+now:
 
-    ``CLAUDE_SESSION_ID`` → ``T3_LOOP_SESSION_ID`` → loop-registry → ``""``
+    ``CLAUDE_SESSION_ID`` → ``CLAUDE_CODE_SESSION_ID`` → ``T3_LOOP_SESSION_ID`` → loop-registry → ``""``
+
+#3554 — Claude Code exports the live session id as ``CLAUDE_CODE_SESSION_ID``,
+not ``CLAUDE_SESSION_ID``, so a resolver reading only the old name fell
+through to ``""`` in every interactive session (``handover create``
+refused, ``loop whoami`` reported no session). ``CLAUDE_SESSION_ID`` is
+kept ahead of it for backward compatibility. The accepted names live in
+one place — :data:`SESSION_ID_ENV_VARS` — so a future upstream rename is a
+one-line change caught by a single pinning test rather than silent
+degradation at every call site.
 
 The durable session *pid* (the t3-master lease anchor) resolves with a
 parallel precedence so an env-restricted subprocess that cannot read the
@@ -50,6 +60,19 @@ and fails open (any OSError/JSON error → ``""``).
 import json
 import os
 from pathlib import Path
+
+# The session id lands under whichever name the harness exports it, most-
+# to least-preferred. ``CLAUDE_CODE_SESSION_ID`` is what a live Claude Code
+# session exports (#3554); ``CLAUDE_SESSION_ID`` is the legacy name kept for
+# backward compatibility; ``T3_LOOP_SESSION_ID`` is the test/manual override.
+# Single source of truth: ``teatree.hooks._hook_state`` redeclares the same
+# list (it cannot import across the module-boundary graph) and a test pins
+# the two in sync.
+SESSION_ID_ENV_VARS: tuple[str, ...] = (
+    "CLAUDE_SESSION_ID",
+    "CLAUDE_CODE_SESSION_ID",
+    "T3_LOOP_SESSION_ID",
+)
 
 # Deliberately redeclared (not imported) — ``teatree.core`` must not
 # depend on ``teatree.loop``/hooks. Mirrors ``hook_router._OWNER_LOOP``
@@ -164,23 +187,40 @@ def current_session_pid() -> int | None:
     return _coerce_pid(os.environ.get("T3_LOOP_SESSION_PID")) or _pid_from_loop_registry()
 
 
+def session_id_from_env() -> str | None:
+    """The active session id from :data:`SESSION_ID_ENV_VARS`, ``None`` when none is set.
+
+    The env-only slice of the resolver, shared with the loop-slot commands
+    (``loop_slack_answer`` / ``loop_self_improve``) whose t3-master gate
+    consults the registry separately and only needs the env value.
+    """
+    for name in SESSION_ID_ENV_VARS:
+        value = os.environ.get(name)
+        if value:
+            return value
+    return None
+
+
 def current_session_id() -> str:
     """The active Claude session id, or ``""`` when not resolvable.
 
-    ``CLAUDE_SESSION_ID`` is set by Claude Code; ``T3_LOOP_SESSION_ID`` is
-    the test/manual override. When both are absent (#1107: agent-driven
-    Bash-tool subprocesses never see the id as an env var) the loop
-    registry's ``t3-loop-tick-owner`` record is the lowest-precedence
+    Claude Code exports the id as ``CLAUDE_CODE_SESSION_ID`` (#3554);
+    ``CLAUDE_SESSION_ID`` is the legacy name kept ahead of it for backward
+    compatibility, and ``T3_LOOP_SESSION_ID`` is the test/manual override
+    (all three in :data:`SESSION_ID_ENV_VARS`). When none is set (#1107:
+    agent-driven Bash-tool subprocesses never see the id as an env var) the
+    loop registry's ``t3-loop-tick-owner`` record is the lowest-precedence
     fallback. Empty string means anonymous (no session) — the t3-master
     gate treats an anonymous caller as a non-owner whenever a live owner
     exists.
     """
-    return (
-        os.environ.get("CLAUDE_SESSION_ID")
-        or os.environ.get("T3_LOOP_SESSION_ID")
-        or _session_id_from_loop_registry()
-        or ""
-    )
+    return session_id_from_env() or _session_id_from_loop_registry() or ""
 
 
-__all__ = ["current_session_id", "current_session_pid", "owner_record"]
+__all__ = [
+    "SESSION_ID_ENV_VARS",
+    "current_session_id",
+    "current_session_pid",
+    "owner_record",
+    "session_id_from_env",
+]

--- a/src/teatree/hooks/_hook_state.py
+++ b/src/teatree/hooks/_hook_state.py
@@ -14,6 +14,25 @@ import os
 import sys
 from pathlib import Path
 
+# Redeclared (not imported): the module-boundary graph forbids
+# ``teatree.hooks`` importing ``teatree.core``. Kept in sync with
+# ``teatree.core.session_identity.SESSION_ID_ENV_VARS`` — a test pins the
+# two identical (#3554).
+_SESSION_ID_ENV_VARS: tuple[str, ...] = (
+    "CLAUDE_SESSION_ID",
+    "CLAUDE_CODE_SESSION_ID",
+    "T3_LOOP_SESSION_ID",
+)
+
+
+def _current_session_key() -> str:
+    """The session id under whichever name the harness exports it, ``""`` when none."""
+    for name in _SESSION_ID_ENV_VARS:
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value
+    return ""
+
 
 def hook_state_root() -> Path:
     """The single root for hook on-disk state.
@@ -38,16 +57,16 @@ def note_env_override_once(override_name: str) -> None:
     ``export`` or a Docker-composed env) silently disables every publish leak scan
     for the whole session. A session-keyed marker under :func:`hook_state_root`
     makes the standing disable VISIBLE without spamming every subsequent gated
-    call. With no ``CLAUDE_SESSION_ID`` (marker un-keyable) the NOTE is emitted
-    every time — still visible, never silent; a marker write failure still emits
-    the NOTE (the NOTE matters more than the dedup).
+    call. With no session id (marker un-keyable) the NOTE is emitted every time
+    — still visible, never silent; a marker write failure still emits the NOTE
+    (the NOTE matters more than the dedup).
     """
     message = (
         f"NOTE: {override_name}=1 is set in the process environment (os.environ), not on this "
         f"command — it disables the publish leak scan for EVERY publish this session. "
         f"Unset it if that was unintended.\n"
     )
-    session = os.environ.get("CLAUDE_SESSION_ID", "").strip()
+    session = _current_session_key()
     if not session:
         sys.stderr.write(message)
         return

--- a/tests/teatree_cli/test_cli_loop.py
+++ b/tests/teatree_cli/test_cli_loop.py
@@ -532,9 +532,10 @@ class TestLoopOwnerCli:
         assert "claimed loop slot" in result.stdout
         assert LoopLease.objects.get(name="t3-master").session_id == "cli-session"
 
-    def test_claim_without_session_id_exits_2(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
-        monkeypatch.delenv("T3_LOOP_SESSION_ID", raising=False)
+    def test_claim_without_session_id_exits_2(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+        for key in ("CLAUDE_SESSION_ID", "CLAUDE_CODE_SESSION_ID", "T3_LOOP_SESSION_ID"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("T3_LOOP_REGISTRY_DIR", str(tmp_path / "no-registry"))
         result = runner.invoke(loop_app, ["claim"])
 
         assert result.exit_code == 2
@@ -655,11 +656,12 @@ class TestLoopOwnerCli:
             "driverless": True,
         }
 
-    def test_claim_json_no_session_id_error_shape(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_claim_json_no_session_id_error_shape(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
         import json  # noqa: PLC0415
 
-        monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
-        monkeypatch.delenv("T3_LOOP_SESSION_ID", raising=False)
+        for key in ("CLAUDE_SESSION_ID", "CLAUDE_CODE_SESSION_ID", "T3_LOOP_SESSION_ID"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("T3_LOOP_REGISTRY_DIR", str(tmp_path / "no-registry"))
         result = runner.invoke(loop_app, ["claim", "--json"])
 
         assert result.exit_code == 2

--- a/tests/teatree_core/management_commands/test_handover.py
+++ b/tests/teatree_core/management_commands/test_handover.py
@@ -30,6 +30,8 @@ def _session(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     the test process never fast-pushes the real repo's worktrees; the coupling
     itself is asserted by ``TestHandoverDrivesSubagents`` with its own spy.
     """
+    for key in ("CLAUDE_SESSION_ID", "CLAUDE_CODE_SESSION_ID"):
+        monkeypatch.delenv(key, raising=False)
     monkeypatch.setenv("T3_LOOP_SESSION_ID", "this-session")
     monkeypatch.setenv("TEATREE_CLAUDE_STATUSLINE_STATE_DIR", str(tmp_path / "state"))
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "xdg"))
@@ -68,11 +70,21 @@ class TestHandoverCreate:
         assert pathlib.Path(mirror).is_file()
 
     def test_no_session_id_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
-        monkeypatch.delenv("T3_LOOP_SESSION_ID", raising=False)
+        for key in ("CLAUDE_SESSION_ID", "CLAUDE_CODE_SESSION_ID", "T3_LOOP_SESSION_ID"):
+            monkeypatch.delenv(key, raising=False)
         monkeypatch.setenv("T3_LOOP_REGISTRY_DIR", "/nonexistent-registry-dir")
         with pytest.raises(SystemExit):
             _call("handover", "create", json_output=True)
+
+    def test_claude_code_session_id_is_accepted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The #3554 bug: a live Claude Code session exports only ``CLAUDE_CODE_SESSION_ID``."""
+        for key in ("CLAUDE_SESSION_ID", "T3_LOOP_SESSION_ID"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("T3_LOOP_REGISTRY_DIR", "/nonexistent-registry-dir")
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "cc-session")
+        data = json.loads(_call("handover", "create", json_output=True))
+        assert data["ok"] is True
+        assert SessionHandover.objects.get().from_session == "cc-session"
 
 
 class TestHandoverDrivesSubagents:

--- a/tests/teatree_core/test_management_commands.py
+++ b/tests/teatree_core/test_management_commands.py
@@ -65,6 +65,8 @@ _MOCK_OVERLAY = {"test": CommandOverlay()}
 
 COMMAND_SETTINGS: dict[str, object] = {}
 
+_NO_SESSION_ENV = {"CLAUDE_SESSION_ID": "", "CLAUDE_CODE_SESSION_ID": "", "T3_LOOP_SESSION_ID": ""}
+
 
 class TestLifecycleCommands(TestCase):
     @override_settings(**COMMAND_SETTINGS)
@@ -396,7 +398,8 @@ class TestTasksListSession(TestCase):
 
     @override_settings(**COMMAND_SETTINGS)
     def test_anonymous_session_lists_nothing(self) -> None:
-        with patch.dict("os.environ", {"CLAUDE_SESSION_ID": "", "T3_LOOP_SESSION_ID": "", "XDG_DATA_HOME": ""}):
+        anon_env = {**_NO_SESSION_ENV, "XDG_DATA_HOME": ""}
+        with patch.dict("os.environ", anon_env):
             ticket = Ticket.objects.create(overlay="test")
             session = Session.objects.create(ticket=ticket, overlay="test", agent_id="claude-abc")
             Task.objects.create(ticket=ticket, session=session, phase="coding")
@@ -659,7 +662,7 @@ class TestReconcileChecklist(TestCase):
     @override_settings(**COMMAND_SETTINGS)
     def test_no_session_still_emits_the_discipline(self) -> None:
         out = io.StringIO()
-        with patch.dict("os.environ", {"CLAUDE_SESSION_ID": "", "T3_LOOP_SESSION_ID": ""}):
+        with patch.dict("os.environ", _NO_SESSION_ENV):
             call_command("tasks", "reconcile-checklist", stdout=out)
         printed = _strip_ansi(out.getvalue())
         # An anonymous caller has no session-scoped teatree tasks, but the

--- a/tests/teatree_core/test_session_identity.py
+++ b/tests/teatree_core/test_session_identity.py
@@ -22,16 +22,23 @@ from django.core.management import call_command
 from django.utils import timezone
 
 from teatree.core.models import LoopLease
-from teatree.core.session_identity import current_session_id, current_session_pid
+from teatree.core.session_identity import (
+    SESSION_ID_ENV_VARS,
+    current_session_id,
+    current_session_pid,
+    session_id_from_env,
+)
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
 pytestmark = pytest.mark.django_db
+
+_SESSION_ID_KEYS = {"CLAUDE_SESSION_ID", "CLAUDE_CODE_SESSION_ID", "T3_LOOP_SESSION_ID"}
 
 
 def _no_session_env() -> dict[str, str]:
     import os  # noqa: PLC0415
 
-    return {k: v for k, v in os.environ.items() if k not in {"CLAUDE_SESSION_ID", "T3_LOOP_SESSION_ID"}}
+    return {k: v for k, v in os.environ.items() if k not in _SESSION_ID_KEYS}
 
 
 class TestSessionIdRegistryFallback:
@@ -96,6 +103,51 @@ class TestSessionIdRegistryFallback:
         env = {k: v for k, v in _no_session_env().items() if k != "T3_LOOP_REGISTRY_DIR"}
         with patch.dict("os.environ", {**env, "XDG_DATA_HOME": str(tmp_path)}, clear=True):
             assert current_session_id() == "xdg-sess"
+
+
+class TestSessionIdEnvChain:
+    """The accepted session-id env-var names + their precedence (#3554).
+
+    Claude Code stopped exporting ``CLAUDE_SESSION_ID`` and now exports
+    ``CLAUDE_CODE_SESSION_ID``; the resolver read only the old name, so
+    every session-identity consumer silently degraded to ``""`` inside a
+    live session (``handover create`` refused, ``loop whoami`` reported no
+    session, the hook marker lost its per-session key). These pin the new
+    name in the chain so a future upstream rename fails loudly here rather
+    than going dark at every call site.
+    """
+
+    def test_claude_code_session_id_is_accepted(self) -> None:
+        assert "CLAUDE_CODE_SESSION_ID" in SESSION_ID_ENV_VARS
+
+    def test_env_resolves_claude_code_session_id(self, tmp_path: Path) -> None:
+        with patch.dict(
+            "os.environ",
+            {**_no_session_env(), "CLAUDE_CODE_SESSION_ID": "cc-sess", "T3_LOOP_REGISTRY_DIR": str(tmp_path)},
+            clear=True,
+        ):
+            assert session_id_from_env() == "cc-sess"
+            assert current_session_id() == "cc-sess"
+
+    def test_legacy_name_takes_precedence_over_claude_code(self) -> None:
+        with patch.dict(
+            "os.environ",
+            {**_no_session_env(), "CLAUDE_SESSION_ID": "legacy", "CLAUDE_CODE_SESSION_ID": "cc"},
+            clear=True,
+        ):
+            assert session_id_from_env() == "legacy"
+
+    def test_claude_code_takes_precedence_over_loop_override(self) -> None:
+        with patch.dict(
+            "os.environ",
+            {**_no_session_env(), "CLAUDE_CODE_SESSION_ID": "cc", "T3_LOOP_SESSION_ID": "loop"},
+            clear=True,
+        ):
+            assert session_id_from_env() == "cc"
+
+    def test_env_is_none_when_no_accepted_var_set(self) -> None:
+        with patch.dict("os.environ", _no_session_env(), clear=True):
+            assert session_id_from_env() is None
 
 
 class TestCurrentSessionPid:

--- a/tests/teatree_hooks/test_banned_terms_env_override_eval.py
+++ b/tests/teatree_hooks/test_banned_terms_env_override_eval.py
@@ -69,7 +69,8 @@ class TestAllowBannedTermEnvReachesWrapper:
     ) -> None:
         # An inherited-env override silently disables every publish scan — the
         # NOTE makes that standing disable visible (finding 7).
-        monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+        for key in ("CLAUDE_SESSION_ID", "CLAUDE_CODE_SESSION_ID", "T3_LOOP_SESSION_ID"):
+            monkeypatch.delenv(key, raising=False)
         monkeypatch.setenv("ALLOW_BANNED_TERM", "1")
         assert has_override("Bash", {"command": "gh issue create --body x"}) is True
         assert "ALLOW_BANNED_TERM=1 is set in the process environment" in capsys.readouterr().err

--- a/tests/teatree_hooks/test_hook_state.py
+++ b/tests/teatree_hooks/test_hook_state.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from teatree.core.session_identity import SESSION_ID_ENV_VARS
 from teatree.hooks import _hook_state
 from teatree.paths import DATA_DIR
 
@@ -28,7 +29,8 @@ class TestEnvOverrideNote:
     def test_no_session_notes_every_time(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+        for key in ("CLAUDE_SESSION_ID", "CLAUDE_CODE_SESSION_ID", "T3_LOOP_SESSION_ID"):
+            monkeypatch.delenv(key, raising=False)
         _hook_state.note_env_override_once("QUOTE_OK")
         _hook_state.note_env_override_once("QUOTE_OK")
         err = capsys.readouterr().err
@@ -43,6 +45,25 @@ class TestEnvOverrideNote:
         _hook_state.note_env_override_once("ALLOW_BANNED_TERM")
         err = capsys.readouterr().err
         assert err.count("ALLOW_BANNED_TERM=1 is set in the process environment") == 1
+
+    def test_claude_code_session_id_keys_the_marker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Claude Code exports ``CLAUDE_CODE_SESSION_ID``, not ``CLAUDE_SESSION_ID`` (#3554).
+
+        With only the new name set the marker must still be session-keyed so
+        the NOTE dedups once — not the un-keyable every-time path.
+        """
+        monkeypatch.setenv("T3_DATA_DIR", str(tmp_path / "state"))
+        monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+        monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "cc-sess")
+        _hook_state.note_env_override_once("QUOTE_OK")
+        _hook_state.note_env_override_once("QUOTE_OK")
+        err = capsys.readouterr().err
+        assert err.count("QUOTE_OK=1 is set in the process environment") == 1
+
+    def test_accepted_names_match_core_resolver(self) -> None:
+        assert _hook_state._SESSION_ID_ENV_VARS == SESSION_ID_ENV_VARS
 
     def test_marker_write_failure_still_notes(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]

--- a/tests/teatree_hooks/test_quote_scanner_env_override_eval.py
+++ b/tests/teatree_hooks/test_quote_scanner_env_override_eval.py
@@ -54,7 +54,8 @@ class TestQuoteOkEnvReachesWrapper:
     ) -> None:
         # An inherited-env override silently disables every publish scan — the
         # NOTE makes that standing disable visible (finding 7).
-        monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+        for key in ("CLAUDE_SESSION_ID", "CLAUDE_CODE_SESSION_ID", "T3_LOOP_SESSION_ID"):
+            monkeypatch.delenv(key, raising=False)
         monkeypatch.setenv("QUOTE_OK", "1")
         assert has_quote_ok_override("Bash", {"command": "gh pr create --body x"}) is True
         assert "QUOTE_OK=1 is set in the process environment" in capsys.readouterr().err


### PR DESCRIPTION
Fixes #3554.

Claude Code exports the live session id as `CLAUDE_CODE_SESSION_ID`, but `current_session_id()` read only the legacy `CLAUDE_SESSION_ID`, so it fell through to `""` in every interactive session. `handover create` refused ("no Claude session id"), `loop whoami` reported no session, and the hook env-override NOTE lost its per-session marker key (state that should be per-session stopped being per-session).

## What changed

- Add `CLAUDE_CODE_SESSION_ID` to the accepted names, ahead of `T3_LOOP_SESSION_ID` and behind `CLAUDE_SESSION_ID` (kept for backward compatibility). Precedence is now `CLAUDE_SESSION_ID` → `CLAUDE_CODE_SESSION_ID` → `T3_LOOP_SESSION_ID` → loop-registry → `""`.
- The accepted names live in one place, `SESSION_ID_ENV_VARS`, with an env-only `session_id_from_env()` helper that `current_session_id()` and the two loop-slot commands (`loop_slack_answer`, `loop_self_improve`) share. `teatree.hooks._hook_state` redeclares the same list across the module-boundary graph (hooks may not import core) and a test pins the two in sync, so a future upstream rename fails loudly at one pinning test rather than degrading silently at every call site.
- Correct the two docstrings that asserted `CLAUDE_SESSION_ID` was the Claude Code export.

## Architecture pre-check — #3554

**1. BLUEPRINT § alignment** — Tactical conformance fix to the session-identity primitive (`teatree.core.session_identity`, the #1073/#1107 loop-ownership seam). No BLUEPRINT change.

**2. FSM phase boundaries** — n/a, no transitions touched.

**3. Extension-point contracts** — n/a; no `OverlayBase`/scanner/Protocol surface changed.

**4. Component boundaries** — `teatree.core.session_identity` (the canonical resolver) plus its two `teatree.core.management.commands` consumers and the stdlib-only `teatree.hooks._hook_state`.

**5. Dependency direction** — the two commands now import `session_identity` (within `teatree.core`, an existing allowed edge); `_hook_state` redeclares the name list rather than importing across the `platform → domain` boundary. `tach check` clean.

**6. Test surface** — `TestSessionIdEnvChain` (precedence + `CLAUDE_CODE_SESSION_ID` resolves through `session_id_from_env` and `current_session_id`); `test_hook_state` (marker keys off the new name; the redeclared list matches `SESSION_ID_ENV_VARS`); `test_handover` (`handover create` succeeds with only `CLAUDE_CODE_SESSION_ID` set).

**7. Resilience invariants** — n/a, no external write.

**8. Identity and key normalization** — single source of truth `SESSION_ID_ENV_VARS`; no qualifier stripping.

**9. Behavior preservation** — purely additive: the legacy name and the registry fallback are unchanged; the new name is inserted into the chain.

**10. Removability / harness-vs-data** — self-contained; the accepted-names tuple is the varying part, isolated in one constant.
