### PR TITLE
fix(loop): gate worker running-checks on the flock, not a pid file that read_pid orphans (#3617)

### DIFF
--- a/src/teatree/cli/doctor/checks_runtime.py
+++ b/src/teatree/cli/doctor/checks_runtime.py
@@ -10,18 +10,24 @@ import typer
 
 
 def _check_singletons() -> bool:
-    """Clean up stale pid files for known singleton processes."""
+    """Report a singleton lock file that is stale AND idle (no live flock holder).
+
+    Never unlinks: the lock file is the ``flock`` anchor, so removing one that a
+    live worker holds orphans its kernel lock and blinds every later probe (#3617).
+    A stale pid alongside a FREE flock is harmless (the next start reuses the file
+    in place) — reported for visibility only, not reaped.
+    """
     from teatree.utils.singleton import (  # noqa: PLC0415 (deferred: keeps the doctor-check import light)
         WORKER_SINGLETON,
         default_pid_path,
+        flock_is_held,
         read_pid,
     )
 
     for name in (WORKER_SINGLETON, "slack-listener", "loop-tick"):
         path = default_pid_path(name)
-        had_file = path.is_file()
-        if read_pid(path) is None and had_file:
-            typer.echo(f"OK    Cleared stale {name} pid file")
+        if path.is_file() and read_pid(path) is None and not flock_is_held(name, pid_path=path):
+            typer.echo(f"OK    {name} pid file is stale but idle (reused in place on next start)")
     return True
 
 

--- a/src/teatree/loop/queue_drain.py
+++ b/src/teatree/loop/queue_drain.py
@@ -153,16 +153,17 @@ def a_worker_is_running() -> bool:
     completed the #5 deprecation of the pre-#1796 ``teatree-worker`` singleton). The
     probe imports the SAME constant the workers acquire — so the name can never drift
     — and stands the in-process tick drain down while it is alive, so the two never
-    claim the same rows. ``read_pid`` reports the live holder (and reaps a stale pid
-    file) without acquiring the lock, so probing here never disturbs a running worker.
+    claim the same rows. It reads the KERNEL flock, not the recorded pid: a stale/dead
+    pid in the lock file can never blind the stand-down while a worker is live, and a
+    recycled pid can never fake a holder (#3617). The non-blocking probe acquires and
+    releases when free, so it never disturbs a running worker.
     """
     from teatree.utils.singleton import (  # noqa: PLC0415 — deferred: keeps queue_drain cold-import cheap
         WORKER_SINGLETON,
-        default_pid_path,
-        read_pid,
+        flock_is_held,
     )
 
-    return read_pid(default_pid_path(WORKER_SINGLETON)) is not None
+    return flock_is_held(WORKER_SINGLETON)
 
 
 def expire_stale_ready_jobs(*, threshold_hours: int | None = None, queue_name: str | None = None) -> dict[str, int]:

--- a/src/teatree/utils/singleton.py
+++ b/src/teatree/utils/singleton.py
@@ -65,21 +65,22 @@ def default_pid_path(name: str) -> Path:
 def read_pid(pid_path: Path) -> int | None:
     """Return the live pid recorded at ``pid_path``, or ``None``.
 
-    Diagnostic helper (consumed by ``t3 doctor``). Returns ``None`` when
-    the file is missing, malformed, or the recorded pid is dead, and
-    removes the file in the malformed/dead cases. Safe alongside the
-    ``flock``: a live holder always keeps its own (live) pid in the
-    file, so this never unlinks an actively-held lock file.
+    Diagnostic helper (consumed by ``t3 doctor``). Returns ``None`` when the
+    file is missing, malformed, or the recorded pid is dead. It NEVER unlinks
+    the file: the lock file is the ``flock`` anchor, so removing it orphans a
+    live holder's kernel lock on the (now unlinked) inode — every later
+    :func:`flock_is_held` probe then opens a fresh inode, reads "free", and a
+    second worker acquires the singleton next to the live one (#3617). The
+    stale pid is harmless: the next acquirer reuses the file in place
+    (``ftruncate`` + rewrite in :func:`singleton`).
     """
     if not pid_path.is_file():
         return None
     raw = pid_path.read_text(encoding="utf-8").strip()
     if not raw.isdigit():
-        pid_path.unlink(missing_ok=True)
         return None
     pid = int(raw)
     if not pid_alive(pid):
-        pid_path.unlink(missing_ok=True)
         return None
     return pid
 

--- a/tests/teatree_cli/test_cli_worker.py
+++ b/tests/teatree_cli/test_cli_worker.py
@@ -7,6 +7,8 @@ refuses (with the reason) otherwise. The DB-touching paths run under a real test
 """
 
 import json
+import threading
+from pathlib import Path
 from unittest import mock
 
 import django.test
@@ -14,9 +16,10 @@ import pytest
 from typer.testing import CliRunner
 
 import teatree.cli.worker as worker_cli
-from teatree.cli.doctor.checks_runtime import _check_worker_running
+from teatree.cli.doctor.checks_runtime import _check_singletons, _check_worker_running
 from teatree.cli.worker import worker_app
 from teatree.loop.drain import DrainOutcome, DrainReport
+from teatree.utils import singleton as singleton_mod
 
 runner = CliRunner()
 
@@ -119,6 +122,93 @@ class TestWorkerEnsure(django.test.TestCase):
             result = runner.invoke(worker_app, ["ensure"])
         assert result.exit_code == 1
         assert "error" in result.stdout
+
+
+def test_ensure_is_a_no_op_for_a_live_flock_holder_with_a_stale_pid_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The end-to-end #3617 bug: a live worker holds the flock, its lock file records
+    # a dead pid, and a prior diagnostic `read_pid` reap (status/doctor) ran. `ensure`
+    # must still detect the live holder via the flock and spawn NOTHING.
+
+    monkeypatch.setattr(singleton_mod, "DATA_DIR", tmp_path)
+    path = singleton_mod.default_pid_path(singleton_mod.WORKER_SINGLETON)
+
+    ready, release = threading.Event(), threading.Event()
+
+    def _hold() -> None:
+        with singleton_mod.singleton(singleton_mod.WORKER_SINGLETON, pid_path=path):
+            ready.set()
+            release.wait(timeout=10)
+
+    holder = threading.Thread(target=_hold)
+    holder.start()
+    try:
+        assert ready.wait(timeout=5), "holder never acquired the flock"
+        path.write_text("999999999\n", encoding="utf-8")  # stale pid clobbers the live holder's file
+        singleton_mod.read_pid(path)  # a prior status/doctor reap — must NOT orphan the flock
+
+        spawns: list[bool] = []
+        with (
+            mock.patch.object(worker_cli, "_resolve_kill_switch", return_value=(True, "default")),
+            mock.patch(
+                "teatree.utils.worker_spawn.spawn_detached_worker",
+                side_effect=lambda: spawns.append(True) or True,
+            ),
+        ):
+            result = runner.invoke(worker_app, ["ensure", "--json"])
+    finally:
+        release.set()
+        holder.join(timeout=5)
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["action"] == "already-running"
+    assert spawns == []
+
+
+def test_check_singletons_reports_a_stale_idle_lock_file_without_unlinking(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+
+    monkeypatch.setattr(singleton_mod, "DATA_DIR", tmp_path)
+    path = singleton_mod.default_pid_path(singleton_mod.WORKER_SINGLETON)
+    path.write_text("999999999\n", encoding="utf-8")  # dead pid, no flock held
+
+    echoed: list[str] = []
+    with mock.patch("teatree.cli.doctor.checks_runtime.typer.echo", side_effect=echoed.append):
+        assert _check_singletons() is True
+    assert path.is_file()  # never unlinked
+    assert any("stale but idle" in line for line in echoed)
+
+
+def test_check_singletons_leaves_a_live_flock_holders_file_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+
+    monkeypatch.setattr(singleton_mod, "DATA_DIR", tmp_path)
+    path = singleton_mod.default_pid_path(singleton_mod.WORKER_SINGLETON)
+
+    ready, release = threading.Event(), threading.Event()
+
+    def _hold() -> None:
+        with singleton_mod.singleton(singleton_mod.WORKER_SINGLETON, pid_path=path):
+            ready.set()
+            release.wait(timeout=10)
+
+    holder = threading.Thread(target=_hold)
+    holder.start()
+    try:
+        assert ready.wait(timeout=5), "holder never acquired the flock"
+        path.write_text("999999999\n", encoding="utf-8")  # stale pid, but the flock IS held
+        echoed: list[str] = []
+        with mock.patch("teatree.cli.doctor.checks_runtime.typer.echo", side_effect=echoed.append):
+            assert _check_singletons() is True
+    finally:
+        release.set()
+        holder.join(timeout=5)
+
+    assert path.is_file()
+    assert not any("stale but idle" in line for line in echoed)  # a live holder is never flagged
 
 
 class TestWorkerDrain(django.test.TestCase):

--- a/tests/teatree_loop/test_queue_drain.py
+++ b/tests/teatree_loop/test_queue_drain.py
@@ -11,7 +11,9 @@ in-process against the ephemeral test DB, never the canonical queue.
 """
 
 import datetime as dt
-import os
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
@@ -198,32 +200,77 @@ class TestDrainReadyBatch:
 
         assert a_worker_is_running() is False
 
+    def test_a_worker_is_running_reads_the_flock_not_the_recorded_pid(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A live pid recorded in the file but NO flock held — the probe reads the kernel
+        # lock (free), never the recyclable pid (which pid-file blindness read as "held"): #3617.
+        import os  # noqa: PLC0415 — test-local deferred import (#3617)
+
+        from teatree.loop.queue_drain import a_worker_is_running  # noqa: PLC0415 — test-local deferred import (#3617)
+        from teatree.utils import singleton as singleton_mod  # noqa: PLC0415 — test-local: patch the module attr
+        from teatree.utils.singleton import WORKER_SINGLETON  # noqa: PLC0415 — test-local deferred import (#3617)
+
+        monkeypatch.setattr(singleton_mod, "DATA_DIR", tmp_path)
+        (tmp_path / f"{WORKER_SINGLETON}.pid").write_text(f"{os.getpid()}\n", encoding="utf-8")
+
+        assert a_worker_is_running() is False
+
 
 # ast-grep-ignore: ac-django-no-pytest-django-db
 @pytest.mark.django_db(transaction=True)
 class TestWorkerSingletonProbe:
     """The drain stands down for the REAL worker singleton, never a wrong-name ghost (#5).
 
-    The probe must read the SAME constant every worker acquires — the one
+    The probe reads the SAME constant every worker acquires — the one
     ``WORKER_SINGLETON`` (the #1796 :class:`LoopWorker` AND the ``t3 <overlay> worker``
-    db_worker spawner, after PR-28 completed the #5 deprecation of ``teatree-worker``).
-    A pid file at it forces the tick drain to stand down.
+    db_worker spawner, after PR-28 completed the #5 deprecation of ``teatree-worker``) —
+    via the KERNEL flock, not the recorded pid (#3617). A live flock holder forces the
+    tick drain to stand down; a stale pid alone (no live holder) does not.
     """
 
-    def _hold_pid(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, name: str) -> None:
+    @contextmanager
+    def _hold_flock(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, name: str) -> Iterator[None]:
         from teatree.utils import singleton as singleton_mod  # noqa: PLC0415 — test-local: patch the module attr
 
         monkeypatch.setattr(singleton_mod, "DATA_DIR", tmp_path)
-        (tmp_path / f"{name}.pid").write_text(f"{os.getpid()}\n", encoding="utf-8")
+        ready, release = threading.Event(), threading.Event()
+
+        def _hold() -> None:
+            with singleton_mod.singleton(name, pid_path=tmp_path / f"{name}.pid"):
+                ready.set()
+                release.wait(timeout=10)
+
+        holder = threading.Thread(target=_hold)
+        holder.start()
+        try:
+            assert ready.wait(timeout=5), "holder never acquired the flock"
+            yield
+        finally:
+            release.set()
+            holder.join(timeout=5)
 
     def test_drain_stands_down_for_live_worker_singleton(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         from teatree.utils.singleton import WORKER_SINGLETON  # noqa: PLC0415 — test-local deferred import
 
         refresh_followup_snapshot.enqueue()
-        self._hold_pid(tmp_path, monkeypatch, WORKER_SINGLETON)
-
-        assert drain_ready_batch(max_jobs=5) == 0
+        with self._hold_flock(tmp_path, monkeypatch, WORKER_SINGLETON):
+            assert drain_ready_batch(max_jobs=5) == 0
         assert DBTaskResult.objects.get().status == TaskResultStatus.READY
+
+    def test_drain_stands_up_for_a_stale_pid_with_no_live_holder(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A dead pid in the lock file but NO live flock holder: the drain must PROCEED,
+        # never blocked by a ghost pid (the flock, not the pid, is the truth — #3617).
+        from teatree.utils import singleton as singleton_mod  # noqa: PLC0415 — test-local: patch the module attr
+        from teatree.utils.singleton import WORKER_SINGLETON  # noqa: PLC0415 — test-local deferred import
+
+        monkeypatch.setattr(singleton_mod, "DATA_DIR", tmp_path)
+        (tmp_path / f"{WORKER_SINGLETON}.pid").write_text("999999999\n", encoding="utf-8")
+        refresh_followup_snapshot.enqueue()
+
+        assert drain_ready_batch(max_jobs=5) == 1
 
     def test_drain_proceeds_when_no_singleton_pid_is_held(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/teatree_utils/test_singleton.py
+++ b/tests/teatree_utils/test_singleton.py
@@ -31,17 +31,19 @@ class TestReadPid:
     def test_missing_file_returns_none(self, tmp_path: Path) -> None:
         assert read_pid(tmp_path / "absent.pid") is None
 
-    def test_dead_pid_is_cleaned(self, tmp_path: Path) -> None:
+    def test_dead_pid_returns_none_but_preserves_the_lock_file(self, tmp_path: Path) -> None:
+        # The lock file is the flock anchor — unlinking it orphans a live holder's
+        # kernel lock (the inode), so read_pid never removes it (#3617).
         path = tmp_path / "dead.pid"
         path.write_text("999999999\n", encoding="utf-8")
         assert read_pid(path) is None
-        assert not path.is_file()
+        assert path.is_file()
 
-    def test_garbled_pid_is_cleaned(self, tmp_path: Path) -> None:
+    def test_garbled_pid_returns_none_but_preserves_the_lock_file(self, tmp_path: Path) -> None:
         path = tmp_path / "garbled.pid"
         path.write_text("not-a-number\n", encoding="utf-8")
         assert read_pid(path) is None
-        assert not path.is_file()
+        assert path.is_file()
 
     def test_live_pid_is_returned(self, tmp_path: Path) -> None:
         path = tmp_path / "alive.pid"
@@ -130,3 +132,15 @@ class TestFlockIsHeld:
         path = tmp_path / "t.pid"
         path.write_text(f"{os.getpid()}\n", encoding="utf-8")
         assert flock_is_held("t", pid_path=path) is False
+
+    def test_stays_visible_after_a_stale_pid_read(self, tmp_path: Path) -> None:
+        # A live worker holds the flock while its lock file records a dead pid (a
+        # clobber, or the truncate-write window). A diagnostic `read_pid` reap must
+        # not unlink the file — doing so orphans the flock's inode and every later
+        # probe opens a fresh inode reading "free", spawning a duplicate worker (#3617).
+        path = tmp_path / "t.pid"
+        with singleton("t", pid_path=path):
+            path.write_text("999999999\n", encoding="utf-8")
+            assert read_pid(path) is None
+            assert path.is_file()
+            assert flock_is_held("t", pid_path=path) is True

--- a/tests/test_slack_listen.py
+++ b/tests/test_slack_listen.py
@@ -128,7 +128,8 @@ class TestStatusCommand:
 
         assert result.exit_code == 1
         assert "not running" in result.stdout
-        assert not pid_file.is_file()
+        # read_pid reuses the flock file in place; unlinking it would orphan a live holder's lock (#3617).
+        assert pid_file.is_file()
 
     def test_garbled_pid_file(self, tmp_path: Path) -> None:
         pid_file = tmp_path / "slack-listener.pid"
@@ -138,7 +139,8 @@ class TestStatusCommand:
 
         assert result.exit_code == 1
         assert "not running" in result.stdout
-        assert not pid_file.is_file()
+        # read_pid reuses the flock file in place; unlinking it would orphan a live holder's lock (#3617).
+        assert pid_file.is_file()
 
     def test_running_pid(self, tmp_path: Path) -> None:
         pid_file = tmp_path / "slack-listener.pid"


### PR DESCRIPTION
Closes #3617.

## Problem
`t3 worker ensure` and `t3 worker status` already probed the kernel flock (`flock_is_held`), but the probe was silently blinded. `read_pid` unlinked the lock file whenever it held a dead / malformed / empty pid (e.g. during the singleton's `ftruncate`+write window). Unlinking orphans the live worker's flock on the now-unlinked inode; the next `flock_is_held` opens a fresh inode, reads "free", and a second `t3 worker` acquires the singleton next to the live one. Two workers then drain the queue and thrash leases (`stuck_loop: lease lost … re-claimed by another worker`), failing every coding/planning task.

## Fix
- `read_pid` no longer unlinks the lock file — the lock file is the flock anchor, so removing it orphans a live holder's kernel lock. A stale pid is harmless: the next acquirer reuses the file in place (`ftruncate` + rewrite in `singleton`).
- `a_worker_is_running` (the tick-drain stand-down probe) now reads `flock_is_held`, matching its own docstring, so a stale/dead pid can never blind the stand-down.
- `_check_singletons` stops unlinking and only reports a stale-but-idle lock file (no live flock holder).

## Regression tests (each verified to fail on the pre-fix code)
- `test_stays_visible_after_a_stale_pid_read` — a live flock-holder + a stale pid the diagnostic `read_pid` reaps → flock stays visible, lock file preserved.
- `test_ensure_is_a_no_op_for_a_live_flock_holder_with_a_stale_pid_file` — the end-to-end `ensure` no-op: real flock held, stale pid, prior `read_pid` reap → `ensure` reports `already-running` and spawns nothing.
- `test_a_worker_is_running_reads_the_flock_not_the_recorded_pid` — a live pid with no flock reads `False` (discriminates flock-based from pid-based).
- `_check_singletons` reports a stale-idle file without unlinking, and leaves a live holder's file untouched.

## Architecture pre-check — #3617

### 1. BLUEPRINT § alignment
§5.6 Loop Topology (the worker-singleton / loop-timer plane). No doctrine change — the flock is already the documented lock; this restores the probe's fidelity to it.

### 2. FSM phase boundaries
n/a — no `Ticket.State` / `Worktree.State` transition. Lock-file/flock handling only.

### 3. Extension-point contracts
No `OverlayBase` / scanner / hook / Protocol change.

### 4. Component boundaries
`read_pid` in `utils.singleton` (the lock primitive), the stand-down probe in `loop.queue_drain`, the doctor check in `cli.doctor.checks_runtime`. Each stays in its layer.

### 5. Dependency direction
No new cross-module imports; `queue_drain` swaps `read_pid`→`flock_is_held` (same `utils.singleton` module).

### 6. Test surface
`tests/teatree_utils/test_singleton.py`, `tests/teatree_cli/test_cli_worker.py`, `tests/teatree_loop/test_queue_drain.py` — listed above, each verified RED on the pre-fix code.

### 7. Resilience invariants
The flock is the source of truth (verify-by-kernel-lock, not the recorded pid); the probe is non-blocking (acquires+releases when free, never disturbs a live holder); idempotent (a stale pid is reused in place, never orphaned).

### 8. Identity and key normalization
n/a — one `WORKER_SINGLETON` constant, read by every probe.

### 9. Behavior preservation / capability deletion
`read_pid` drops its unlink side effect (the bug) — the diagnostic read value (live pid / `None`) is unchanged; `_check_singletons` no longer unlinks (that mutation was itself the hazard) and now reports the stale-idle case. Two must-block regression tests updated from "file is cleaned" to "file is preserved" — the ticket-directed behavior change, not a coverage drop.

### 10. Removability / harness-vs-data
Removable: each change reverts cleanly in isolation. Harness (a lock-primitive correctness fix), not data.
