### PR TITLE
fix(loop): reconcile a stranded pre-merged ticket whose PR merged out-of-keystone (#3540)

### DIFF
--- a/src/teatree/loop/merged_ticket_reconcile.py
+++ b/src/teatree/loop/merged_ticket_reconcile.py
@@ -1,0 +1,88 @@
+"""Advance a ticket stranded in a pre-merged FSM state whose PR already merged (#3540).
+
+The #3540 wedge: an author-role ticket entered via a NON-LADDER phase
+(``debugging``/``bughunt``/``retro`` produce no work-state — they are absent from
+``Ticket._PHASE_PRODUCES_STATE``) whose PR merged OUTSIDE the keystone sits at its
+entry state (``NOT_STARTED`` in the incident) forever. Every automatic exit is
+closed at once: the two ``NOT_STARTED`` -> terminal hatches
+(``mark_reviewed_externally`` / ``mark_review_no_action``) are reviewer-only, the
+author ladder's ``review()`` requires ``TESTED``, and ``reconcile_merged`` — which
+DOES accept every pre-merged state for ANY role — is only ever driven by the merge
+keystone (``merge.execution.record_merge_and_advance``). An out-of-keystone merge
+therefore never reconciles the ticket, stranding it until a human transitions it.
+
+This idempotent tick pass closes it structurally: every ticket in a pre-merged,
+non-terminal state whose linked ``PullRequest`` row is MERGED is driven through
+``reconcile_merged()`` — role- and phase-agnostic, so a ``debugging``-only author
+ticket exits like any other. The ``merge_evidence`` gate still guards the
+transition (a keystone ``MergeAudit`` row OR a live, fail-closed forge probe), so a
+row that is not really merged never advances. Per-row isolation: one poison ticket
+is logged and skipped, never aborting the sweep.
+
+Lives in ``teatree.loop`` (orchestration): it composes the ``core`` FSM transition
+with the merged ``PullRequest`` rows the tick already reconciled, run right after
+:mod:`teatree.loop.manual_pr_reconcile` so a row flipped to MERGED this same tick
+reconciles its ticket without waiting for the next one.
+"""
+
+import logging
+from typing import TYPE_CHECKING
+
+from django_fsm import can_proceed
+
+from teatree.core.models.errors import InvalidTransitionError
+
+if TYPE_CHECKING:
+    from teatree.core.models import Ticket
+
+logger = logging.getLogger(__name__)
+
+
+def reconcile_merged_tickets() -> int:
+    """Drive every ticket stranded in a pre-merged state with a merged PR to MERGED.
+
+    Returns the number of tickets advanced. Idempotent — a re-run finds the
+    already-MERGED tickets excluded, so it changes nothing.
+    """
+    count = 0
+    for ticket in _stranded_tickets():
+        try:
+            if _reconcile_one(ticket):
+                count += 1
+        except InvalidTransitionError as exc:
+            # The merge_evidence gate refused (no MergeAudit row and the forge could
+            # not confirm the merge). Fail-closed by design — the PR row is not
+            # trustworthy evidence on its own — so this is a quiet skip, not an error.
+            logger.debug("Merged-ticket reconcile skipped ticket %s: %s", ticket.pk, exc)
+        except Exception:
+            logger.exception("Merged-ticket reconcile skipped ticket %s after an unexpected error", ticket.pk)
+    return count
+
+
+def _stranded_tickets() -> list["Ticket"]:
+    from teatree.core.models import PullRequest, Ticket  # noqa: PLC0415 — ORM import needs the app registry
+
+    # Every ticket with a merged PR row that has not yet reached MERGED. MERGED is
+    # excluded to skip the keystone-idempotent self-transition (re-firing the gate
+    # buys nothing); the remaining ``reconcile_merged`` source membership — which
+    # pointedly refuses the post-merged/abandoned states (RETROSPECTED/DELIVERED/
+    # IGNORED) so the FSM is never dragged backward — is enforced per row by the
+    # ``can_proceed`` guard in :func:`_reconcile_one`, so the source list stays the
+    # FSM's single source of truth rather than a copy that could drift.
+    return list(
+        Ticket.objects.filter(pull_requests__state=PullRequest.State.MERGED)
+        .exclude(state=Ticket.State.MERGED)
+        .distinct()
+    )
+
+
+def _reconcile_one(ticket: "Ticket") -> bool:
+    if not can_proceed(ticket.reconcile_merged):
+        return False
+    ticket.reconcile_merged()
+    ticket.save()
+    logger.info(
+        "Reconciled ticket %s to MERGED — PR merged out-of-keystone left it stranded (#3540)",
+        ticket.pk,
+    )
+    return True

--- a/src/teatree/loop/phases/render.py
+++ b/src/teatree/loop/phases/render.py
@@ -21,6 +21,7 @@ from teatree.config import get_effective_settings
 from teatree.loop.domain_jobs import _identity_groups_for_overlay
 from teatree.loop.job_identity import _ScannerJob
 from teatree.loop.manual_pr_reconcile import reconcile_manual_prs
+from teatree.loop.merged_ticket_reconcile import reconcile_merged_tickets
 from teatree.loop.phases.orchestrate import orchestrate_phase
 from teatree.loop.rendering import _populate_dashboard_head, zones_for
 from teatree.loop.statusline import StatuslineZones, render
@@ -60,6 +61,7 @@ def render_phase(
         _populate_dashboard_head(zones, colorize=colorize)
     _write_open_prs_cache(report.signals, target=statusline_path)
     _reconcile_manual_prs(report.signals)
+    _reconcile_merged_tickets()
     _populate_open_prs_in_anchors(zones, target=statusline_path, colorize=colorize)
     if jobs and report.errors:
         zones.action_needed.append(f"scanner errors: {', '.join(report.errors)}")
@@ -199,6 +201,21 @@ def _reconcile_manual_prs(signals: "list[ScanSignal]") -> None:
     try:
         reconcile_manual_prs(signals)
     except Exception:  # noqa: BLE001 — the manual-PR reconcile is best-effort; a failure degrades to no-op
+        return
+
+
+def _reconcile_merged_tickets() -> None:
+    """Advance any ticket stranded in a pre-merged state whose PR already merged (#3540).
+
+    Runs after :func:`_reconcile_manual_prs` so a row flipped to MERGED this same
+    tick reconciles its ticket immediately. Closes the out-of-keystone-merge wedge
+    where an author ticket entered via a non-ladder phase (``debugging``) has no
+    automatic exit from ``NOT_STARTED``. Fails open: any error degrades to a no-op
+    so a bad row can never abort the tick.
+    """
+    try:
+        reconcile_merged_tickets()
+    except Exception:  # noqa: BLE001 — the merged-ticket reconcile is best-effort; a failure degrades to no-op
         return
 
 

--- a/tests/teatree_loop/phases/test_render.py
+++ b/tests/teatree_loop/phases/test_render.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 from django.test import TestCase
 
+from teatree.core.models import PullRequest, Ticket
 from teatree.loop.dispatch import dispatch
 from teatree.loop.job_identity import _ScannerJob
 from teatree.loop.phases import render_phase
@@ -95,6 +96,32 @@ class TestRenderPhaseReconcilesManualPrs(TestCase):
         render_phase(report, TickRequest(), jobs=[_job("my_prs")], statusline_path=self.sl, colorize=False)
 
         assert PullRequest.objects.filter(url=url).count() == 1
+
+
+class TestRenderPhaseReconcilesMergedTickets(TestCase):
+    """render_phase drives a stranded pre-merged ticket to MERGED (#3540)."""
+
+    @pytest.fixture(autouse=True)
+    def _tmp(self, tmp_path: Path) -> None:
+        self.sl = tmp_path / "statusline.txt"
+
+    def test_author_not_started_with_merged_pr_reaches_merged(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", role=Ticket.Role.AUTHOR, state=Ticket.State.NOT_STARTED)
+        PullRequest.objects.create(
+            ticket=ticket,
+            url="https://github.com/souliane/teatree/pull/3540",
+            repo="souliane/teatree",
+            iid="3540",
+            overlay="test",
+            state=PullRequest.State.MERGED,
+        )
+        report = TickReport(started_at=_NOW, signals=[])
+        report.actions = dispatch(report.signals, errors=report.errors)
+
+        render_phase(report, TickRequest(), jobs=[], statusline_path=self.sl, colorize=False)
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.MERGED
 
 
 def test_render_phase_idle_renders_statusline_without_jobs(tmp_path: Path) -> None:

--- a/tests/teatree_loop/test_merged_ticket_reconcile.py
+++ b/tests/teatree_loop/test_merged_ticket_reconcile.py
@@ -1,0 +1,170 @@
+"""Merged-ticket reconcile — the #3540 out-of-keystone-merge wedge escape.
+
+An author-role ticket entered via a non-ladder phase (``debugging`` produces no
+work-state) whose PR merged outside the keystone has NO automatic exit from its
+entry state: both ``NOT_STARTED`` -> terminal hatches are reviewer-only, and
+``reconcile_merged`` is only ever driven by the keystone. This sweep is the
+missing driver — it fires ``reconcile_merged`` for any pre-merged ticket with a
+merged ``PullRequest`` row, role- and phase-agnostic, guarded by
+``merge_evidence`` so an untrustworthy row never advances.
+"""
+
+import contextlib
+from collections.abc import Iterator
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from teatree.config import UserSettings
+from teatree.core.gates import merge_evidence_gate
+from teatree.core.models import MergeAudit, MergeClear, PullRequest, Ticket
+from teatree.loop import merged_ticket_reconcile
+from teatree.loop.merged_ticket_reconcile import reconcile_merged_tickets
+
+_FORTY_HEX = "a" * 40
+
+
+@contextlib.contextmanager
+def _merge_evidence(*, required: bool) -> Iterator[None]:
+    with patch.object(
+        merge_evidence_gate,
+        "get_effective_settings",
+        return_value=UserSettings(require_merge_evidence=required),
+    ):
+        yield
+
+
+def _merged_pr(ticket: Ticket) -> PullRequest:
+    return PullRequest.objects.create(
+        ticket=ticket,
+        url=f"https://github.com/souliane/teatree/pull/{ticket.pk}",
+        repo="souliane/teatree",
+        iid=str(ticket.pk),
+        overlay=ticket.overlay,
+        state=PullRequest.State.MERGED,
+    )
+
+
+def _audit_for(ticket: Ticket) -> None:
+    clear = MergeClear.objects.create(
+        ticket=ticket,
+        pr_id=ticket.pk,
+        slug="souliane/teatree",
+        reviewed_sha=_FORTY_HEX,
+        reviewer_identity="cold-reviewer",
+        gh_verify_result=MergeClear.VerifyResult.GREEN,
+        blast_class=MergeClear.BlastClass.LOGIC,
+    )
+    MergeAudit.objects.create(clear=clear, merged_sha=_FORTY_HEX, required_checks_status="green")
+
+
+class TestReconcileMergedTickets(TestCase):
+    def test_author_not_started_with_merged_pr_reaches_merged(self) -> None:
+        """The #3540 incident shape: author ticket at NOT_STARTED, PR merged -> MERGED."""
+        ticket = Ticket.objects.create(overlay="test", role=Ticket.Role.AUTHOR, state=Ticket.State.NOT_STARTED)
+        _merged_pr(ticket)
+
+        assert reconcile_merged_tickets() == 1
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.MERGED
+
+    def test_advances_every_pre_merged_state(self) -> None:
+        pre_merged = [
+            Ticket.State.NOT_STARTED,
+            Ticket.State.SCOPED,
+            Ticket.State.STARTED,
+            Ticket.State.PLANNED,
+            Ticket.State.CODED,
+            Ticket.State.TESTED,
+            Ticket.State.REVIEWED,
+            Ticket.State.SHIPPED,
+            Ticket.State.IN_REVIEW,
+        ]
+        for state in pre_merged:
+            ticket = Ticket.objects.create(overlay="test", state=state)
+            _merged_pr(ticket)
+
+        assert reconcile_merged_tickets() == len(pre_merged)
+        assert set(Ticket.objects.values_list("state", flat=True)) == {Ticket.State.MERGED}
+
+    def test_ticket_without_a_merged_pr_is_left_alone(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.NOT_STARTED)
+        PullRequest.objects.create(
+            ticket=ticket,
+            url="https://github.com/souliane/teatree/pull/1",
+            repo="souliane/teatree",
+            iid="1",
+            overlay="test",
+            state=PullRequest.State.OPEN,
+        )
+
+        assert reconcile_merged_tickets() == 0
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.NOT_STARTED
+
+    def test_post_merged_states_are_never_dragged_backward(self) -> None:
+        for state in (Ticket.State.MERGED, Ticket.State.RETROSPECTED, Ticket.State.DELIVERED, Ticket.State.IGNORED):
+            ticket = Ticket.objects.create(overlay="test", state=state)
+            _merged_pr(ticket)
+
+        assert reconcile_merged_tickets() == 0
+        assert Ticket.State.MERGED not in set(
+            Ticket.objects.exclude(state=Ticket.State.MERGED).values_list("state", flat=True)
+        )
+        assert set(Ticket.objects.values_list("state", flat=True)) == {
+            Ticket.State.MERGED,
+            Ticket.State.RETROSPECTED,
+            Ticket.State.DELIVERED,
+            Ticket.State.IGNORED,
+        }
+
+    def test_is_idempotent(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.NOT_STARTED)
+        _merged_pr(ticket)
+
+        assert reconcile_merged_tickets() == 1
+        assert reconcile_merged_tickets() == 0
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.MERGED
+
+    def test_gate_on_without_evidence_is_a_fail_closed_skip(self) -> None:
+        """merge_evidence ON + no MergeAudit + forge cannot confirm -> ticket left stranded, no crash."""
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.NOT_STARTED)
+        _merged_pr(ticket)
+
+        with (
+            _merge_evidence(required=True),
+            patch.object(merge_evidence_gate, "forge_confirms_merged", return_value=False),
+        ):
+            assert reconcile_merged_tickets() == 0
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.NOT_STARTED
+
+    def test_gate_on_with_merge_audit_advances(self) -> None:
+        ticket = Ticket.objects.create(overlay="t3-teatree", state=Ticket.State.NOT_STARTED)
+        _merged_pr(ticket)
+        _audit_for(ticket)
+
+        with _merge_evidence(required=True):
+            assert reconcile_merged_tickets() == 1
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.MERGED
+
+    def test_one_poison_ticket_does_not_abort_the_sweep(self) -> None:
+        good = Ticket.objects.create(overlay="test", state=Ticket.State.NOT_STARTED)
+        _merged_pr(good)
+        bad = Ticket.objects.create(overlay="test", state=Ticket.State.STARTED)
+        _merged_pr(bad)
+
+        real_one = merged_ticket_reconcile._reconcile_one
+
+        def _boom(ticket: Ticket) -> bool:
+            if ticket.pk == bad.pk:
+                msg = "boom"
+                raise RuntimeError(msg)
+            return real_one(ticket)
+
+        with patch.object(merged_ticket_reconcile, "_reconcile_one", _boom):
+            assert reconcile_merged_tickets() == 1
+        good.refresh_from_db()
+        assert good.state == Ticket.State.MERGED


### PR DESCRIPTION
Closes #3540.

## Problem

An author-role ticket entered via a **non-ladder phase** (`debugging`/`bughunt`/`retro` produce no work-state — they are absent from `Ticket._PHASE_PRODUCES_STATE`) whose PR merged **outside the merge keystone** has no automatic exit from its entry state (`NOT_STARTED` in the incident, ticket 184 / PR #3493). Every automatic exit is closed at once:

- both `NOT_STARTED` → terminal hatches (`mark_reviewed_externally` / `mark_review_no_action`) carry `role == REVIEWER` conditions;
- the author ladder's `review()` requires `source=TESTED`, unreachable from `NOT_STARTED`;
- `reconcile_merged` **does** accept every pre-merged state for any role, but it is only ever driven by the merge keystone — an out-of-keystone merge never fires it.

The ticket stranded until a human ran `ticket transition 184 ignore`, and it tripped the doctor silent-freeze FAIL (the #3492 signal-erosion class).

## Fix

Add the missing **driver**: a tick pass (`teatree.loop.merged_ticket_reconcile`) that fires `reconcile_merged()` for every ticket in a pre-merged, non-terminal state whose linked `PullRequest` row is MERGED — role- and phase-agnostic, so a `debugging`-only author ticket exits like any other. Guarded by the existing `merge_evidence` gate (a keystone `MergeAudit` row OR a live fail-closed forge probe), so a row that is not really merged never advances. Idempotent, per-row isolated, wired into the render phase right after `manual_pr_reconcile` so a row flipped to MERGED this same tick reconciles its ticket without waiting for the next.

Scoped to the reconcilable case (a merged `PullRequest` row exists) — the general wedge class, matching the regression test the issue asks for. The exact incident had *no* PR row (the PR merged before any open-PR scan created one); recovering that requires a forge-search-by-issue fallback (issue direction 3), deliberately left out of scope as the heavier change.

## Architecture pre-check — #3540

### 1. BLUEPRINT § alignment
§17.4 (orchestrator-decides / loop-executes) + §4 domain-model FSM: an out-of-keystone PR-merge must reconcile the ticket FSM. Reuses the existing `reconcile_merged` transition; no new state or transition.

### 2. FSM phase boundaries
No new/moved transition. Drives the existing `reconcile_merged` (any pre-merged source → `MERGED`); source membership is enforced per-row by `django_fsm.can_proceed`, and the `merge_evidence` gate guards the body.

### 3. Extension-point contracts
No `OverlayBase` / scanner-registration / Protocol change. New loop helper only; consumes `PullRequest` + `Ticket` models.

### 4. Component boundaries
`src/teatree/loop/` (orchestration) — composes the `core` FSM transition over the merged `PullRequest` rows the tick already reconciled. Invoked from `loop/phases/render.py`.

### 5. Dependency direction
loop → core (models, `merge_evidence` via the FSM body) — the sanctioned direction. `uv run tach check` green (pre-commit + ci-parity).

### 6. Test surface
`tests/teatree_loop/test_merged_ticket_reconcile.py` (author-NOT_STARTED→MERGED, every pre-merged state, no-merged-PR left alone, post-merged never dragged backward, idempotent, gate-on fail-closed skip, gate-on MergeAudit advances, per-row isolation) + `tests/teatree_loop/phases/test_render.py::TestRenderPhaseReconcilesMergedTickets` (render seam wires it in).

### 7. Resilience invariants
Idempotent (already-MERGED excluded + `can_proceed` guard); verify-by-re-read is the `merge_evidence` forge probe; per-row `try/except` isolation; the render seam fails open.

### 8. Identity and key normalization
n/a — no bare/qualified identity handling.

### 9. Behavior preservation / capability deletion
n/a — purely additive; no existing behavior removed, no matcher narrowed, no test inverted.

### 10. Removability / harness-vs-data
Fully removable — a self-contained module + one call site in `render.py`; deleting both reverts to the prior behavior with no cascade. Harness side is correct: the "which state reconciles" policy is the FSM's own source list (read via `can_proceed`), not duplicated here.

## Verification
- `tests/teatree_loop/test_merged_ticket_reconcile.py` + `tests/teatree_loop/phases/test_render.py` — green locally (`--no-migrations --reuse-db`).
- `bash dev/ci-parity-fast.sh` — exit 0 (scoped prek, `makemigrations --check`, affected tests, incremental push gate).
- Full pre-commit + pre-push gate suite green on commit + push.
