### PR TITLE
fix(headless): claim initial lease at heartbeat window (900s) to stop self-reclaim

### DIFF
--- a/src/teatree/core/tasks.py
+++ b/src/teatree/core/tasks.py
@@ -18,6 +18,18 @@ from teatree.core.worktree.worktree_done import _DONE_TICKET_STATES
 
 logger = logging.getLogger(__name__)
 
+# The initial claim lease for a headless task must match the heartbeat's renewal
+# window (``agents.headless._LEASE_SECONDS`` = 900s), NOT ``Task.claim``'s 300s
+# default. The heartbeat only renews to 900s from the first tick (~60s); with the
+# 300s default the pre-first-tick window is just ~5 heartbeats, so under CPU
+# starvation (a loaded box running several coders) the first renewal slips past
+# 300s, the lease lapses, ``reclaim_orphaned_claims`` re-queues the still-running
+# task, and it aborts "lease lost: re-claimed by another worker" — a self-inflicted
+# reclaim. Claiming with 900s from the start closes that window. Kept equal to
+# ``_LEASE_SECONDS`` by ``test_headless_claim_lease_matches_heartbeat`` (core cannot
+# import the agents layer, so the value is duplicated and drift-guarded by test).
+_HEADLESS_CLAIM_LEASE_SECONDS = 900
+
 
 def _persist_intake_landscape(ticket: Ticket) -> None:
     """Bake the intake landscape survey into a durable artifact (#2541).
@@ -112,9 +124,11 @@ def execute_headless_task(task_id: int, phase: str) -> dict[str, object]:
         task_obj.complete_with_attempt(exit_code=1, error=routing_refusal, result={"routing_error": routing_refusal})
         return {"exit_code": 1, "routing_error": routing_refusal}
 
-    # Claim here (when the worker actually starts) instead of at enqueue time
+    # Claim here (when the worker actually starts) instead of at enqueue time.
+    # Use the heartbeat-matched lease so a starved first heartbeat cannot let the
+    # initial 300s window lapse and re-queue this live task (_HEADLESS_CLAIM_LEASE_SECONDS).
     if task_obj.status == Task.Status.PENDING:
-        task_obj.claim(claimed_by="headless-worker")
+        task_obj.claim(claimed_by="headless-worker", lease_seconds=_HEADLESS_CLAIM_LEASE_SECONDS)
     try:
         from teatree.core.headless_dispatch import get_headless_runner  # noqa: PLC0415 — deferred: call-time import
 

--- a/tests/teatree_core/test_tasks.py
+++ b/tests/teatree_core/test_tasks.py
@@ -1253,3 +1253,48 @@ class TestConsumePendingPhaseTasksNormalizesPhase(TestCase):
 
         zombie.refresh_from_db()
         assert zombie.status == Task.Status.COMPLETED
+
+
+class TestHeadlessClaimLease(TestCase):
+    @override_settings(**IMMEDIATE_BACKEND)
+    def test_headless_worker_claims_with_heartbeat_matched_lease(self) -> None:
+        # The initial claim lease must equal the heartbeat renewal window (900s),
+        # not Task.claim's 300s default: under CPU starvation a delayed first
+        # heartbeat lets the 300s lease lapse and reclaim_orphaned_claims re-queues
+        # the live task, which then aborts "lease lost: re-claimed by another worker".
+        from teatree.agents.headless import _LEASE_SECONDS  # noqa: PLC0415 — deferred: local test import
+        from teatree.core import headless_dispatch as headless_dispatch_mod  # noqa: PLC0415 — deferred: local
+        from teatree.core.tasks import (  # noqa: PLC0415 — deferred: local
+            _HEADLESS_CLAIM_LEASE_SECONDS,
+            execute_headless_task,
+        )
+
+        assert _HEADLESS_CLAIM_LEASE_SECONDS == _LEASE_SECONDS
+
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket)
+        task = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            execution_target=Task.ExecutionTarget.HEADLESS,
+            status=Task.Status.PENDING,
+            phase="coding",
+        )
+        captured: dict[str, float] = {}
+
+        class _StopAfterClaimError(RuntimeError):
+            """Sentinel raised in the fake runner to stop right after the claim."""
+
+        def _capture_lease(t: Task, **_kwargs: object) -> object:
+            t.refresh_from_db()
+            captured["seconds"] = (t.lease_expires_at - t.claimed_at).total_seconds()
+            raise _StopAfterClaimError
+
+        with (
+            patch.object(headless_dispatch_mod, "loop_dispatch_refusal", return_value=None),
+            patch.object(headless_dispatch_mod, "get_headless_runner", return_value=_capture_lease),
+            pytest.raises(_StopAfterClaimError),
+        ):
+            execute_headless_task.func(task.pk, task.phase)
+
+        assert captured["seconds"] == pytest.approx(_LEASE_SECONDS, abs=1)


### PR DESCRIPTION
## Problem

Under load the factory kept aborting live coding tasks with `stuck_loop: lease lost: re-claimed by another worker` — a **self-inflicted** reclaim, not a dual executor.

## Root cause

The headless worker claims a task with `Task.claim`'s **300s** default lease, but the heartbeat only renews to `agents.headless._LEASE_SECONDS` (**900s**) from its first tick (~60s). On a CPU-starved box (several coders at once) the first renewal slips past the 300s window → the lease lapses → `reclaim_orphaned_claims` re-queues the still-running task → it aborts.

## Fix

Claim the initial headless lease at 900s (the heartbeat window) so the pre-first-tick window can no longer lapse. A drift guard (`test_headless_worker_claims_with_heartbeat_matched_lease`) keeps the duplicated constant equal to `_LEASE_SECONDS` (core cannot import the agents layer).

## Test

New behavioural test captures `lease_expires_at - claimed_at == ~900s` at claim time; asserts the drift guard. Green single-process.