### PR TITLE
fix(deploy): key slack-drain health on stdout, not folded stderr warnings

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -542,8 +542,11 @@ ensure_clone() {
 # `t3 slack check` exits 0 when it drained messages and 1 with NO output when the
 # queue was empty (the common, healthy case on a quiet box) — so a non-zero exit
 # is NOT itself a failure. A REAL failure is a non-zero exit that ALSO produced
-# output (a Django boot traceback, a DB error). Those increment a consecutive-
-# failure counter and are logged to stderr (visible in `docker compose logs
+# STDOUT (a Django boot traceback, a DB error). STDERR is captured SEPARATELY:
+# every t3 invocation emits a benign WARNING there (an overlay's skills-root
+# notice), so folding it into the emptiness test (2>&1) would misread every
+# empty-queue poll as a failure. Real failures increment a consecutive-failure
+# counter and log BOTH streams to stderr (visible in `docker compose logs
 # teatree-slack-listener`); an empty-queue exit never does.
 #
 # Each pass rewrites a heartbeat file that `t3 doctor` reads from another
@@ -553,11 +556,13 @@ ensure_clone() {
 slack_drain_loop() {
     local interval="${SLACK_CHECK_INTERVAL_SECONDS:-15}"
     local heartbeat="${SLACK_DRAIN_HEARTBEAT:-$HOME/.local/share/teatree/slack-drain-heartbeat.json}"
-    local consecutive=0 last_ok=null now out rc
+    local consecutive=0 last_ok=null now out err rc errfile
+    errfile="$(mktemp)"
+    trap 'rm -f "$errfile"' EXIT
     mkdir -p "$(dirname "$heartbeat")"
     while true; do
         now="$(date +%s)"
-        out="$(t3 slack check 2>&1)" && rc=0 || rc=$?
+        out="$(t3 slack check 2>"$errfile")" && rc=0 || rc=$?
         if [ "$rc" -eq 0 ] || { [ "$rc" -eq 1 ] && [ -z "$out" ]; }; then
             consecutive=0
             last_ok="$now"
@@ -565,6 +570,8 @@ slack_drain_loop() {
             consecutive=$((consecutive + 1))
             echo "entrypoint: slack drain (t3 slack check) FAILED rc=$rc (consecutive=$consecutive):" >&2
             printf '%s\n' "$out" >&2
+            err="$(cat "$errfile")"
+            [ -n "$err" ] && printf '%s\n' "$err" >&2
         fi
         printf '{"updated_at": %s, "interval_seconds": %s, "consecutive_failures": %s, "last_ok_at": %s}\n' \
             "$now" "$interval" "$consecutive" "$last_ok" >"$heartbeat"

--- a/tests/test_deploy_slack_listener.py
+++ b/tests/test_deploy_slack_listener.py
@@ -191,6 +191,26 @@ class TestSlackDrainLoopExecution:
         assert "FAILED" not in stderr
         assert beat.get("consecutive_failures", -1) == 0
 
+    def test_benign_stderr_warning_on_empty_queue_is_not_a_failure(self, tmp_path: Path) -> None:
+        # Every t3 invocation emits a benign WARNING to STDERR (e.g. an overlay's
+        # skills-root notice). On an empty queue (rc=1, empty STDOUT) that warning
+        # must NOT be mistaken for a failure — the emptiness test keys on stdout,
+        # not on stderr folded in via 2>&1.
+        stderr, beat = self._run(
+            tmp_path,
+            'echo "WARNING teatree.cli.overlay skills root declared but no tool-commands.json found" >&2\nexit 1',
+        )
+        assert "FAILED" not in stderr
+        assert beat.get("consecutive_failures", -1) == 0
+
+    def test_rc1_with_stdout_content_is_a_failure(self, tmp_path: Path) -> None:
+        # rc=1 but WITH stdout content is a real failure (a crash that printed to
+        # stdout then exited 1), not an empty-queue poll.
+        stderr, beat = self._run(tmp_path, 'echo "boot error on stdout"\nexit 1')
+        assert "FAILED" in stderr
+        assert "boot error on stdout" in stderr
+        assert beat.get("consecutive_failures", 0) >= 1
+
     def test_drained_messages_reset_the_streak(self, tmp_path: Path) -> None:
         stderr, beat = self._run(tmp_path, 'echo "{\\"overlay\\": \\"acme\\"}"\nexit 0')
         assert "FAILED" not in stderr


### PR DESCRIPTION
## Summary

The Slack-drain health classifier in `deploy/entrypoint.sh` (`slack_drain_loop`) misclassified healthy empty-queue polls as failures. It captured `t3 slack check` with `2>&1`, folding stderr into `$out`. Every `t3` invocation emits a benign WARNING to stderr (an overlay's skills-root notice), so on an empty queue `rc=1` with empty stdout still produced a non-empty `$out` — the `[ -z "$out" ]` emptiness test failed and the poll was counted as a failure.

Effect on the deployed box: a perpetually-climbing `consecutive_failures` in the drain heartbeat file, which tripped `t3 doctor`'s `_check_slack_drain_alive` self-heal into needless restarts of the listener.

## Fix

Capture stdout and stderr separately. The emptiness test now keys on **stdout** (the real failure signal — a Django boot traceback / DB error). Stderr is captured to a temp file and still logged on a genuine failure so real tracebacks stay visible in `docker compose logs teatree-slack-listener`.

Classifier behavior preserved:
- `rc=0` -> OK (drained messages)
- `rc=1` AND empty **stdout** -> OK (empty queue, the common quiet case)
- otherwise -> FAILURE (increments the counter, logs stdout + stderr)

A benign stderr WARNING on an empty queue no longer counts as a failure; genuine errors still do.

## Test evidence (RED -> GREEN)

New RED test `test_benign_stderr_warning_on_empty_queue_is_not_a_failure` (rc=1, benign stderr warning, empty stdout) failed on the pre-fix `2>&1` code:

```
E       AssertionError: assert 'FAILED' not in 'entrypoint:...json found\n'
E         entrypoint: slack drain (t3 slack check) FAILED rc=1 (consecutive=1):
```

After the fix, all 16 tests in `tests/test_deploy_slack_listener.py` pass, including the new `test_rc1_with_stdout_content_is_a_failure` guard (a real failure with stdout content still counts).

`shellcheck deploy/entrypoint.sh` is clean.

## Architecture pre-check

**1. BLUEPRINT alignment** — deploy entrypoint / doctor drain-heartbeat contract; no BLUEPRINT section change (shell classifier bug fix within an existing surface).

**2. FSM phase boundaries** — n/a, no `Ticket.State`/`Worktree.State` transition.

**3. Extension-point contracts** — n/a, no `OverlayBase`/scanner/hook/Protocol change. The doctor-side heartbeat filename contract is unchanged.

**4. Component boundaries** — `deploy/entrypoint.sh` shell function only; the mirroring test stays in `tests/test_deploy_slack_listener.py`.

**5. Dependency direction** — n/a, no Python imports added.

**6. Test surface** — the new tests drive the verbatim-extracted `slack_drain_loop` with a stub `t3`, asserting stderr logging and the heartbeat `consecutive_failures` count for each of: benign-stderr empty queue, rc=1-with-stdout failure, rc=2 failure, drained, empty queue.

**7. Resilience invariants** — the drain heartbeat (verify-by-re-read via the doctor container, fallback surface for a stuck/failed drain) is preserved; the fix removes a false-positive failure signal so the heartbeat now reflects reality.

**8. Identity/key normalization** — n/a.

**9. Behavior preservation** — the `rc=0` / `rc=1`-empty / otherwise-failure classification is preserved; the only change is that the emptiness test reads stdout instead of stdout+stderr, and stderr is still logged on failure (no diagnostic output dropped). No must-block test inverted.

**10. Removability / harness-vs-data** — self-contained within the one shell function; revertible in isolation. Correctly harness-level (a stream-handling fix), no data/config surface.

## Open questions & assumptions

- Assumes a genuine drain failure exits with either a non-1 rc or `rc=1` with stdout content — the documented `t3 slack check` contract. A failure that exits exactly `rc=1` with empty stdout and its trace only on stderr would read as an empty queue; this matches the pre-existing intent (the classifier has always keyed emptiness on the non-stderr channel) and the verified live signal (`t3 slack check 2>/dev/null` exits 1 with empty stdout on an empty queue).
