### PR TITLE
fix(loops): keep owner-intake loops runnable across redeploys (#3632)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,12 +102,14 @@ jobs:
           # Repo VARIABLES (not secrets): the box's fleet-scoped loop split,
           # consumed by the entrypoint's apply_fleet_loop_policy. ENABLED loops
           # are force-enabled here (clearing any stale hold — this box HOSTS the
-          # DM-only `inbox` loop); DISABLED loops are forced off (the colleague/
-          # human-facing `review`/`directive_loop` the laptop owns). The fallbacks
-          # are the box's shipped role; the entrypoint validates every name and
-          # fails the deploy loudly on a typo.
+          # DM-only `inbox` loop); DISABLED loops are forced off (the colleague-
+          # facing `review` loop the laptop owns). `directive_loop` is owner-intake
+          # (#3632) — it interprets the owner's captured directives, so it is NOT
+          # masked here (masking it left 20 owner directives uninterpreted for ~8
+          # days). The entrypoint additionally prunes any owner-intake loop from the
+          # DISABLED set, validates every name, and fails the deploy loudly on a typo.
           TEATREE_ENABLED_LOOPS: ${{ vars.TEATREE_ENABLED_LOOPS || 'inbox' }}
-          TEATREE_DISABLED_LOOPS: ${{ vars.TEATREE_DISABLED_LOOPS || 'review,directive_loop' }}
+          TEATREE_DISABLED_LOOPS: ${{ vars.TEATREE_DISABLED_LOOPS || 'review' }}
           # Repo VARIABLE: when 'true' the box's teatree.env gets NO Anthropic
           # env token even though the secret exists (the eval workflows still
           # need the secret) — the env source beats the pass rotation in

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -249,10 +249,16 @@ authoritative planes:
 - **ENABLED set** (default `inbox`) → `t3 loop enable <name> --emergency`, the one
   handle that clears a stale hold and sets `Loop.enabled=True`, so a box whose
   `inbox` an older image disabled recovers. Idempotent.
-- **DISABLED set** (default `review,directive_loop`) → `t3 loop override <name> off`,
-  the sanctioned NON-emergency forced-off that replaces the deprecated
+- **DISABLED set** (default `review`) → `t3 loop override <name> off`, the
+  sanctioned NON-emergency forced-off that replaces the deprecated
   `t3 loop disable`. Forced-off beats the preset mask and the base config, so the
-  colleague/human-facing loops stay off here under any mode. Idempotent.
+  colleague-facing `review` loop stays off here under any mode. Idempotent.
+- **OWNER-INTAKE loops are never forced off** (`t3 loop intake-loops` —
+  `directive_loop` / `dispatch` / `inbox`). They interpret the owner's captured
+  directives and deliver deferred owner questions; `autonomous_away` means the
+  human is unreachable *now*, so that intent must QUEUE for later, not be dropped
+  unread. Any intake loop listed in `TEATREE_DISABLED_LOOPS` is pruned (with a
+  warning) before the DISABLED set is applied, so a redeploy can never re-mask it.
 
 `TEATREE_ENABLED_LOOPS` / `TEATREE_DISABLED_LOOPS` (comma-separated) override the
 defaults; an **empty** value acts on nothing. Every name in both lists is

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -359,8 +359,14 @@ seed_setting() {
 # owner overlay, so `inbox` — the inbound-messaging scanners (Slack DM →
 # PendingChatInjection, review-intent, red-card, mentions) — MUST run here; it
 # feeds the drain → 👀-ack → answer cycle that posts replies. The COLLEAGUE-facing
-# Slack loops the laptop owns stay off here: `review` (colleague PR review → Slack)
-# and `directive_loop` (asks the human via Slack).
+# Slack loop the laptop owns stays off here: `review` (colleague PR review → Slack).
+#
+# OWNER-INTAKE loops are NEVER forced off here (#3632): `directive_loop` interprets
+# the owner's captured directives and `dispatch` posts deferred owner questions.
+# `autonomous_away` means the human is unreachable *now* — captured intent must
+# QUEUE for later, not be dropped unread. A prior default forced `directive_loop`
+# off on every deploy, so captured owner directives sat uninterpreted for days; the
+# owner-intake set (`t3 loop intake-loops`) is pruned from the DISABLED set below.
 #
 # Per-loop enable/disable/pause/resume is now EMERGENCY-only (#3248): the normal
 # handle is presets/schedules and the emergency per-loop handle is `t3 loop
@@ -375,11 +381,12 @@ seed_setting() {
 #   * ENABLED set (default `inbox`) → `t3 loop enable <name> --emergency`, which
 #     clears any stale hold AND sets `Loop.enabled=True`, so a box whose inbox a
 #     prior deploy durably disabled recovers. Idempotent (a no-op when already on).
-#   * DISABLED set (default `review,directive_loop`) → `t3 loop override <name> off`,
-#     the sanctioned, NON-emergency forced-off that supersedes the deprecated
+#   * DISABLED set (default `review`) → `t3 loop override <name> off`, the
+#     sanctioned, NON-emergency forced-off that supersedes the deprecated
 #     `t3 loop disable`. Forced-off beats the preset mask AND the base config, so a
 #     colleague/human-facing loop stays off here regardless of any mode the owner
-#     later selects. Idempotent.
+#     later selects. Idempotent. Owner-intake loops (`t3 loop intake-loops`) are
+#     pruned from this set before it is applied, so they can never be re-masked.
 #
 # TEATREE_ENABLED_LOOPS / TEATREE_DISABLED_LOOPS (comma-separated, from teatree.env)
 # override the defaults; empty values act on nothing. Every name in BOTH lists is
@@ -387,8 +394,8 @@ seed_setting() {
 # loudly before anything is touched (rather than silently mis-configuring the box).
 apply_fleet_loop_policy() {
     local enabled_raw="${TEATREE_ENABLED_LOOPS-inbox}"
-    local disabled_raw="${TEATREE_DISABLED_LOOPS-review,directive_loop}"
-    local field loop registered
+    local disabled_raw="${TEATREE_DISABLED_LOOPS-review}"
+    local field loop registered intake
     local fields=() enable_loops=() disable_loops=()
 
     IFS=',' read -ra fields <<<"$enabled_raw"
@@ -416,6 +423,13 @@ apply_fleet_loop_policy() {
         fi
     done
 
+    # The owner-intake loops (single source of truth in Python) that must never be
+    # forced off, so the owner's captured intent is always at least ingested (#3632).
+    if ! intake="$(t3 loop intake-loops)"; then
+        echo "entrypoint: could not read the owner-intake loop set ('t3 loop intake-loops' failed) - confirm the t3 install is healthy and re-run Deploy" >&2
+        exit 1
+    fi
+
     # A loop in BOTH lists is a contradiction: the ENABLE pass forces it on, then
     # the DISABLE pass would immediately force it off (admission resolves
     # forced > preset > base), leaving a sanctioned-enabled loop silently MASKED
@@ -437,6 +451,8 @@ apply_fleet_loop_policy() {
         done
         if [ -n "$overlaps" ]; then
             echo "entrypoint: loop '${loop}' is in BOTH TEATREE_ENABLED_LOOPS and TEATREE_DISABLED_LOOPS - keeping it ENABLED (would otherwise be re-masked every restart); remove it from TEATREE_DISABLED_LOOPS in teatree.env to silence this warning" >&2
+        elif grep -qxF "$loop" <<<"$intake"; then
+            echo "entrypoint: loop '${loop}' is an OWNER-INTAKE loop (interprets directives / delivers owner questions) - NOT forcing it off; the owner's captured intent must always be ingested, even under autonomous_away. Remove it from TEATREE_DISABLED_LOOPS in teatree.env to silence this warning" >&2
         else
             pruned_disable+=("$loop")
         fi

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -3977,6 +3977,8 @@ Usage: t3 loop [OPTIONS] COMMAND [ARGS]...
 │                  emit it.                                                    │
 │ list             Print LIVE loop status: each loop's enabled state, cadence, │
 │                  last fire, and next tick.                                   │
+│ intake-loops     Print each owner-intake loop name (never fleet-masked off), │
+│                  one per line, sorted.                                       │
 │ reclaim-markers  Release orphaned non-terminal markers whose ticket is       │
 │                  terminal/gone, freeing intake budget.                       │
 │ pause            Pause a mini-loop durably (#1913) — EMERGENCY-only; prefer  │
@@ -4252,6 +4254,19 @@ Usage: t3 loop list [OPTIONS]
 │ --json          Emit the live loop status as JSON.                           │
 │ --all           Also show the per-loop owning sessions (cross-session health │
 │                 view, #1834).                                                │
+│ --help          Show this message and exit.                                  │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+#### `t3 loop intake-loops`
+
+```
+Usage: t3 loop intake-loops [OPTIONS]
+
+ Print each owner-intake loop name (never fleet-masked off), one per line,
+ sorted.
+
+╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --help          Show this message and exit.                                  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```

--- a/docs/generated/cli/representative-output.md
+++ b/docs/generated/cli/representative-output.md
@@ -154,6 +154,8 @@ Usage: t3 loop [OPTIONS] COMMAND [ARGS]...
 │                  emit it.                                                    │
 │ list             Print LIVE loop status: each loop's enabled state, cadence, │
 │                  last fire, and next tick.                                   │
+│ intake-loops     Print each owner-intake loop name (never fleet-masked off), │
+│                  one per line, sorted.                                       │
 │ reclaim-markers  Release orphaned non-terminal markers whose ticket is       │
 │                  terminal/gone, freeing intake budget.                       │
 │ pause            Pause a mini-loop durably (#1913) — EMERGENCY-only; prefer  │

--- a/src/teatree/cli/loop/app.py
+++ b/src/teatree/cli/loop/app.py
@@ -32,6 +32,7 @@ import typer
 from teatree.agents import permission_modes
 from teatree.cli.loop.claim_next import claim_next_command
 from teatree.cli.loop.drain_queue import drain_queue_app
+from teatree.cli.loop.intake_loops import intake_loops_command
 from teatree.cli.loop.listing import list_command
 from teatree.cli.loop.owner import register as register_loop_owner
 from teatree.cli.loop.preset import register as register_loop_preset
@@ -392,6 +393,10 @@ loop_app.command("claim-next")(claim_next_command)
 # #1744 — the read-only live loop-status view. Split off (same module-health
 # reason) and registered as a flat ``t3 loop list``.
 loop_app.command("list")(list_command)
+
+# #3632 — the DB-free owner-intake loop names the deploy fleet policy must never
+# force off; a flat ``t3 loop intake-loops`` the entrypoint reseed reads.
+loop_app.command("intake-loops")(intake_loops_command)
 
 # #3275 — the on-demand issue-marker reconciler: flat ``t3 loop reclaim-markers``.
 # The sanctioned way to unjam stranded intake budget (raw SQL is classifier-blocked).

--- a/src/teatree/cli/loop/intake_loops.py
+++ b/src/teatree/cli/loop/intake_loops.py
@@ -1,0 +1,21 @@
+"""``t3 loop intake-loops`` — print the owner-intake loop names (#3632).
+
+Prints the canonical :data:`teatree.loops.fleet_policy.OWNER_INTAKE_LOOPS` set,
+one name per line, sorted. DB-free (a pure constant), so the deploy entrypoint's
+``apply_fleet_loop_policy`` can read it cheaply to prune owner-intake loops from
+the fleet DISABLED set — the single source of truth shared by the shell reseed and
+the Python resolution tests, so the two can never drift.
+"""
+
+import typer
+
+from teatree.loops.fleet_policy import OWNER_INTAKE_LOOPS
+
+
+def intake_loops_command() -> None:
+    """Print each owner-intake loop name (never fleet-masked off), one per line, sorted."""
+    for name in sorted(OWNER_INTAKE_LOOPS):
+        typer.echo(name)
+
+
+__all__ = ["intake_loops_command"]

--- a/src/teatree/loops/fleet_policy.py
+++ b/src/teatree/loops/fleet_policy.py
@@ -1,0 +1,64 @@
+"""Owner-intake loops the fleet role policy must never mask off (#3632).
+
+The deploy entrypoint's ``apply_fleet_loop_policy`` declares this box's per-loop
+role by forcing the ``TEATREE_DISABLED_LOOPS`` set OFF on every deploy (a durable
+``LoopState`` override that beats preset + base config). That reseed re-applies on
+every redeploy, so a loop listed there is re-masked each time the stack comes up —
+an operator's ``t3 loop override <name> on`` is wiped by the next deploy.
+
+``directive_loop`` (interprets the owner's captured directives), ``dispatch`` (the
+scanner that POSTS deferred owner questions), and ``inbox`` (ingests the owner's
+inbound DMs) are OWNER-INTAKE loops: they read and interpret the owner's own
+intent, they do not reach a colleague. ``autonomous_away`` means the human is
+unreachable *right now* — a directive or question must QUEUE for later, not be
+dropped unread. Masking the intake loops means the owner's captured intent is
+never even ingested (20 owner directives sat uninterpreted for ~8 days that way).
+So these loops are structurally exempt from the fleet DISABLED set: interpretation
+proceeds and any ratify question waits in the queue.
+
+The emergency handle is untouched — an operator can still ``t3 loop override
+directive_loop off`` by hand. Only the redeploy-reapplied fleet role policy is
+constrained here.
+"""
+
+from collections.abc import Iterable
+
+#: Owner-intent loops that INGEST / INTERPRET the owner's captured intent. Never
+#: fleet-masked off, so owner intent is always at least ingested even under an
+#: ``autonomous_away`` (unattended) posture.
+OWNER_INTAKE_LOOPS: frozenset[str] = frozenset({"directive_loop", "dispatch", "inbox"})
+
+#: The fleet-role defaults the deploy entrypoint applies (mirrored verbatim in
+#: ``deploy/entrypoint.sh``). The DM-only box runs its own ``inbox`` and forces the
+#: COLLEAGUE-facing ``review`` loop off; ``directive_loop`` is owner-intake and is
+#: no longer in the disabled default (the #3632 fix).
+DEFAULT_FLEET_ENABLED: tuple[str, ...] = ("inbox",)
+DEFAULT_FLEET_DISABLED: tuple[str, ...] = ("review",)
+
+
+def fleet_disable_set(disabled: Iterable[str], *, enabled: Iterable[str]) -> list[str]:
+    """The fleet DISABLED set with owner-intake and enabled-overlap loops removed.
+
+    Order-preserving and deduped. A name is dropped when it is (1) also in the
+    ENABLED set — the enable pass wins, forcing it off would re-mask it every
+    deploy — or (2) an :data:`OWNER_INTAKE_LOOPS` member, which must stay runnable
+    so the owner's intent is always ingested. The result is the set the entrypoint
+    force-OFFs; the pruned intake/overlap loops keep their preset/base verdict.
+    """
+    enabled_set = set(enabled)
+    seen: set[str] = set()
+    kept: list[str] = []
+    for name in disabled:
+        if name in seen or name in enabled_set or name in OWNER_INTAKE_LOOPS:
+            continue
+        seen.add(name)
+        kept.append(name)
+    return kept
+
+
+__all__ = [
+    "DEFAULT_FLEET_DISABLED",
+    "DEFAULT_FLEET_ENABLED",
+    "OWNER_INTAKE_LOOPS",
+    "fleet_disable_set",
+]

--- a/tests/teatree_cli/test_cli_loop.py
+++ b/tests/teatree_cli/test_cli_loop.py
@@ -18,6 +18,7 @@ from typer.testing import CliRunner
 from teatree.agents import permission_modes
 from teatree.cli.loop import _self_improve_cadence_for_loop_slot, loop_app
 from teatree.cli.loop.drain_queue import _drain_cadence_for_loop_slot
+from teatree.cli.loop.intake_loops import intake_loops_command
 from teatree.cli.loop.slack_answer import _slack_answer_cadence_for_loop_slot
 from teatree.loops.fleet_policy import OWNER_INTAKE_LOOPS
 
@@ -692,3 +693,8 @@ class TestIntakeLoopsCommand:
         assert result.exit_code == 0
         assert result.stdout.split() == sorted(OWNER_INTAKE_LOOPS)
         assert "directive_loop" in result.stdout
+
+    def test_command_callable_prints_each_name(self, capsys: pytest.CaptureFixture[str]) -> None:
+        intake_loops_command()
+
+        assert capsys.readouterr().out.split() == sorted(OWNER_INTAKE_LOOPS)

--- a/tests/teatree_cli/test_cli_loop.py
+++ b/tests/teatree_cli/test_cli_loop.py
@@ -19,6 +19,7 @@ from teatree.agents import permission_modes
 from teatree.cli.loop import _self_improve_cadence_for_loop_slot, loop_app
 from teatree.cli.loop.drain_queue import _drain_cadence_for_loop_slot
 from teatree.cli.loop.slack_answer import _slack_answer_cadence_for_loop_slot
+from teatree.loops.fleet_policy import OWNER_INTAKE_LOOPS
 
 runner = CliRunner()
 
@@ -680,3 +681,14 @@ class TestLoopOwnerCli:
 
         assert result.exit_code == 0
         assert json.loads(result.stdout) == {"ok": True, "slot": "t3-master"}
+
+
+class TestIntakeLoopsCommand:
+    """``t3 loop intake-loops`` prints the owner-intake names the fleet policy reads (#3632)."""
+
+    def test_prints_owner_intake_names_sorted(self) -> None:
+        result = runner.invoke(loop_app, ["intake-loops"])
+
+        assert result.exit_code == 0
+        assert result.stdout.split() == sorted(OWNER_INTAKE_LOOPS)
+        assert "directive_loop" in result.stdout

--- a/tests/teatree_loops/test_fleet_policy.py
+++ b/tests/teatree_loops/test_fleet_policy.py
@@ -1,0 +1,78 @@
+"""teatree.loops.fleet_policy — owner-intake loops are never fleet-masked off (#3632).
+
+The deploy entrypoint's fleet-role reseed force-OFFs its DISABLED set on every
+deploy (a durable ``LoopState`` override that beats preset + base config). Owner-
+intake loops — ``directive_loop`` (interprets the owner's captured directives),
+``dispatch`` (posts deferred owner questions), ``inbox`` (ingests inbound DMs) —
+must be pruned from that set, else the owner's intent is never even ingested. The
+unit tests pin :func:`fleet_disable_set`; the integration test proves the end-to-
+end effective verdict through the REAL preset/loop resolution
+(:func:`teatree.loops.preset_status.effective_verdicts`), not a mock of it.
+"""
+
+import django.test
+
+from teatree.core.models import Loop, LoopState, ModeOverride
+from teatree.loops.fleet_policy import (
+    DEFAULT_FLEET_DISABLED,
+    DEFAULT_FLEET_ENABLED,
+    OWNER_INTAKE_LOOPS,
+    fleet_disable_set,
+)
+from teatree.loops.preset_seed import seed_default_presets_and_schedules
+from teatree.loops.preset_status import effective_verdicts
+from teatree.loops.seed import seed_default_loops_and_prompts
+
+
+class TestFleetDisableSet:
+    def test_prunes_owner_intake_loops(self) -> None:
+        assert fleet_disable_set(["review", "directive_loop"], enabled=["inbox"]) == ["review"]
+
+    def test_prunes_every_owner_intake_member(self) -> None:
+        disabled = ["review", *sorted(OWNER_INTAKE_LOOPS)]
+        assert fleet_disable_set(disabled, enabled=[]) == ["review"]
+
+    def test_prunes_enabled_overlap(self) -> None:
+        assert fleet_disable_set(["review", "tickets"], enabled=["tickets"]) == ["review"]
+
+    def test_preserves_order_and_dedups(self) -> None:
+        assert fleet_disable_set(["ship", "review", "ship"], enabled=[]) == ["ship", "review"]
+
+    def test_default_disabled_carries_no_intake_loop(self) -> None:
+        # The shipped default must already be intake-clean — a re-mask can't sneak
+        # back in through the default itself.
+        assert fleet_disable_set(DEFAULT_FLEET_DISABLED, enabled=DEFAULT_FLEET_ENABLED) == list(DEFAULT_FLEET_DISABLED)
+        assert OWNER_INTAKE_LOOPS.isdisjoint(DEFAULT_FLEET_DISABLED)
+
+
+@django.test.override_settings(USE_TZ=True, TIME_ZONE="UTC")
+class TestUnattendedReseedAdmitsIntakeLoops(django.test.TestCase):
+    """After the unattended reseed, intake loops ADMIT while review/followup stay masked."""
+
+    def _apply_fleet_reseed(self, disabled: list[str], *, enabled: list[str]) -> None:
+        """Model the entrypoint reseed: force-OFF the pruned DISABLED set."""
+        for name in fleet_disable_set(disabled, enabled=enabled):
+            LoopState.objects.override(name, on=False)
+
+    def test_directive_and_dispatch_admit_while_review_and_followup_are_masked(self) -> None:
+        seed_default_loops_and_prompts()
+        seed_default_presets_and_schedules()
+        # The operator opted `directive_loop` in (it ships disabled behind its flag);
+        # under the unattended posture it must keep interpreting captured directives.
+        Loop.objects.filter(name="directive_loop").update(enabled=True)
+        ModeOverride.objects.set_override("unattended")
+
+        # A box that lists the intake loops in its DISABLED config — the prune is
+        # what keeps them runnable (anti-vacuous: without it directive_loop/dispatch
+        # would be forced off and masked).
+        self._apply_fleet_reseed(["review", "directive_loop", "dispatch"], enabled=["inbox"])
+
+        verdicts = {v.name: v for v in effective_verdicts()}
+        assert verdicts["directive_loop"].admitted is True
+        assert verdicts["directive_loop"].layer != "forced"
+        assert verdicts["dispatch"].admitted is True
+        # review is forced off by the reseed (colleague-facing, stays masked)…
+        assert verdicts["review"].admitted is False
+        assert verdicts["review"].layer == "forced"
+        # …and followup stays masked by the unattended preset itself.
+        assert verdicts["followup"].admitted is False

--- a/tests/test_deploy_entrypoint_disable_loops.py
+++ b/tests/test_deploy_entrypoint_disable_loops.py
@@ -1,3 +1,4 @@
+# test-path: cross-cutting — exercises the deploy/entrypoint.sh shell script, not a single src package.
 """Integration tests for the deploy entrypoint's fleet-loop policy step.
 
 `deploy/entrypoint.sh` (init role) declares this box's per-loop role through
@@ -10,9 +11,11 @@ or ``t3 loop override`` can revive a loop a prior deploy left in a durable
 It force-enables the ENABLED set (default ``inbox``) with
 ``t3 loop enable <name> --emergency`` — the ONE handle that clears a stale hold, so
 the DM-only box's inbox recovers even from a prior durable disable. It forces the
-DISABLED set (default ``review,directive_loop``) off with
-``t3 loop override <name> off`` — the sanctioned NON-emergency successor to the
-now-refused ``t3 loop disable``.
+DISABLED set (default ``review``) off with ``t3 loop override <name> off`` — the
+sanctioned NON-emergency successor to the now-refused ``t3 loop disable``. The
+OWNER-INTAKE loops (``t3 loop intake-loops`` — ``directive_loop`` / ``dispatch`` /
+``inbox``) are pruned from the DISABLED set before it is applied, so the owner's
+captured intent is always ingested even under ``autonomous_away`` (#3632).
 
 It never calls the deprecated ``t3 loop disable``. Because a typo in either list
 would silently mis-configure the box, the step validates the whole requested set
@@ -39,6 +42,8 @@ from pathlib import Path
 
 import pytest
 
+from teatree.loops.fleet_policy import OWNER_INTAKE_LOOPS
+
 pytestmark = pytest.mark.skipif(
     shutil.which("jq") is None or shutil.which("bash") is None,
     reason="needs bash + jq (both present in the deploy image and CI)",
@@ -55,6 +60,7 @@ _STUB_LOOP_STATUS = {
         {"name": "inbox"},
         {"name": "review"},
         {"name": "directive_loop"},
+        {"name": "dispatch"},
         {"name": "tickets"},
         {"name": "ship"},
     ],
@@ -94,12 +100,20 @@ def _write_t3_stub(bin_dir: Path) -> None:
     missing ``--emergency``, trips the function's loud-failure path.
     """
     bin_dir.mkdir(parents=True, exist_ok=True)
+    # The owner-intake names come from the single Python source, injected so the
+    # stub can never drift from the real `t3 loop intake-loops` contract.
+    intake_echo = "".join(f"  echo {name}\n" for name in sorted(OWNER_INTAKE_LOOPS))
     shim = bin_dir / "t3"
     shim.write_text(
         "#!/usr/bin/env bash\n"
         'if [ "${1:-}" = "loop" ] && [ "${2:-}" = "list" ]; then\n'
         '  [ -n "${T3_LIST_FAIL:-}" ] && exit 3\n'
         '  cat "$T3_LIST_JSON"\n'
+        "  exit 0\n"
+        "fi\n"
+        'if [ "${1:-}" = "loop" ] && [ "${2:-}" = "intake-loops" ]; then\n'
+        '  [ -n "${T3_INTAKE_FAIL:-}" ] && exit 4\n'
+        f"{intake_echo}"
         "  exit 0\n"
         "fi\n"
         'if [ "${1:-}" = "loop" ] && [ "${2:-}" = "enable" ]; then\n'
@@ -196,17 +210,18 @@ def _run(
 
 
 class TestApplyFleetLoopPolicy:
-    def test_defaults_enable_inbox_and_force_colleague_loops_off(self, tmp_path: Path) -> None:
+    def test_defaults_enable_inbox_and_force_colleague_loop_off(self, tmp_path: Path) -> None:
         # The DM-only box: `inbox` is force-enabled (recovering any stale hold),
-        # and the colleague-facing `review` / `directive_loop` are forced off — via
-        # the override plane, never the deprecated `t3 loop disable`.
+        # and the colleague-facing `review` loop is forced off — via the override
+        # plane, never the deprecated `t3 loop disable`. `directive_loop` is
+        # owner-intake and is NOT in the default disabled set (#3632).
         out = _run(tmp_path)
         assert out.result.returncode == 0, out.result.stderr
         assert out.enabled == ["inbox"]
         # `inbox clear` drops any stale forced-off override left by a prior deploy
-        # so the sanctioned-enabled inbox can never stay masked; then the
-        # colleague loops are forced off.
-        assert out.overridden == ["inbox clear", "review off", "directive_loop off"]
+        # so the sanctioned-enabled inbox can never stay masked; then only the
+        # colleague `review` loop is forced off — never `directive_loop`.
+        assert out.overridden == ["inbox clear", "review off"]
         assert out.disabled == [], "the deprecated `t3 loop disable` must never be called"
 
     def test_enable_passes_emergency(self, tmp_path: Path) -> None:
@@ -225,10 +240,34 @@ class TestApplyFleetLoopPolicy:
         assert out.disabled == []
 
     def test_whitespace_and_trailing_comma_tolerated(self, tmp_path: Path) -> None:
+        # `directive_loop` is owner-intake → pruned; only `review` is forced off.
         out = _run(tmp_path, enabled="inbox, ,", disabled="review, directive_loop ,")
         assert out.result.returncode == 0, out.result.stderr
         assert out.enabled == ["inbox"]
-        assert out.overridden == ["inbox clear", "review off", "directive_loop off"]
+        assert out.overridden == ["inbox clear", "review off"]
+        assert "OWNER-INTAKE loop" in out.result.stderr
+
+    def test_owner_intake_loop_is_never_forced_off(self, tmp_path: Path) -> None:
+        """An explicit owner-intake loop in the DISABLED set is pruned, never masked (#3632).
+
+        This is the redeploy re-mask the fix removes: `directive_loop` (interprets
+        the owner's captured directives) forced off on every deploy left owner
+        intent uninterpreted. It stays runnable; the colleague `review` loop still
+        gets forced off, so the exemption is scoped to owner-intake loops only.
+        """
+        out = _run(tmp_path, enabled="inbox", disabled="review,directive_loop,dispatch")
+        assert out.result.returncode == 0, out.result.stderr
+        assert out.enabled == ["inbox"]
+        assert out.overridden == ["inbox clear", "review off"]
+        assert "directive_loop" not in [entry.split()[0] for entry in out.overridden if entry.endswith(" off")]
+        assert "OWNER-INTAKE loop" in out.result.stderr
+
+    def test_intake_read_failure_is_loud(self, tmp_path: Path) -> None:
+        out = _run(tmp_path, enabled="inbox", disabled="review", T3_INTAKE_FAIL="1")
+        assert out.result.returncode != 0
+        assert out.enabled == [], "the intake read precedes every action"
+        assert out.overridden == []
+        assert "could not read the owner-intake loop set" in out.result.stderr
 
     def test_both_empty_is_a_noop_and_succeeds(self, tmp_path: Path) -> None:
         out = _run(tmp_path, enabled="", disabled="")


### PR DESCRIPTION
## Summary

The deploy entrypoint's fleet-role reseed (`apply_fleet_loop_policy` in `deploy/entrypoint.sh`) force-OFFs its `TEATREE_DISABLED_LOOPS` set on **every** deploy via a durable `LoopState` override. Loop admission resolves `hold > forced > preset > base`, so that forced-off beats the preset mask **and** the base config. The default disabled set was `review,directive_loop`, so `directive_loop` — the loop that **interprets the owner's captured directives** — was re-masked on every redeploy. An operator's `t3 loop override directive_loop on` was wiped by the next deploy, so captured owner directives were never even interpreted.

`autonomous_away` (unattended) means the human is unreachable *right now* — owner questions and directives must QUEUE for later, not be dropped unread. Interpreting a directive can proceed and produce a ratify question that waits in the queue; masking the intake loop just means the owner's captured intent is never read.

## Exact source of the redeploy re-mask

`deploy/entrypoint.sh` -> `apply_fleet_loop_policy()` -> default `TEATREE_DISABLED_LOOPS="review,directive_loop"` -> `t3 loop override directive_loop off` (a `LoopState` forced-off; the observed verdict was `masked [forced] override off`). The deploy workflow fallback (`.github/workflows/deploy.yml`) hard-coded the same default, re-written into `teatree.env` on every deploy run.

## The fix — owner-intake loops are structurally exempt

- New pure, DB-free module `teatree.loops.fleet_policy`: canonical `OWNER_INTAKE_LOOPS = {directive_loop, dispatch, inbox}` + `fleet_disable_set()` (order-preserving, drops the enabled-overlap **and** owner-intake loops). Single source of truth shared by the shell reseed and the Python resolution tests.
- New DB-free `t3 loop intake-loops` prints that set; the entrypoint reads it and prunes any owner-intake loop from the DISABLED set (with a warning) before applying the forced-off.
- Default DISABLED set is now `review` only (entrypoint default + `deploy.yml` fallback). `review` (colleague-facing) stays masked; `followup` stays masked by the unattended preset. The emergency `t3 loop override directive_loop off` handle is untouched.

Scope is owner-intake loops only — `followup`/`review` still stay masked under unattended.

## Tests (RED to GREEN)

- `tests/teatree_loops/test_fleet_policy.py`: `fleet_disable_set` unit coverage **plus** an integration test through the REAL resolution (`teatree.loops.preset_status.effective_verdicts`) — after seeding + activating the `unattended` preset and simulating the reseed, `directive_loop`/`dispatch` ADMIT while `review` (forced) and `followup` (preset) stay masked.
- RED verified: with the intake prune removed, that test fails with `directive_loop admitted=False, layer='forced', detail='override off'` — exactly the bug. Restored -> green.
- `tests/test_deploy_entrypoint_disable_loops.py`: runs the real shell function; new cases prove an owner-intake loop in the DISABLED set is pruned (never forced off) while `review` still is.
- `tests/teatree_cli/test_cli_loop.py`: `t3 loop intake-loops` output + callable.

Full affected suite: 30164 passed (one unrelated `test_leak_sentinel_plugin.py` 60s-timeout flake, passes in isolation). Push gate green.

## Architecture pre-check — #3632

**1. BLUEPRINT alignment** — Loop topology / preset masking (5.6). Refines the fleet-role policy so owner-intake loops survive the reseed; no contradiction.
**2. FSM phase boundaries** — n/a (no state transition).
**3. Extension-point contracts** — n/a. Adds one flat CLI leaf (`t3 loop intake-loops`).
**4. Component boundaries** — `teatree.loops.fleet_policy` (pure policy, no Django); CLI leaf in `src/teatree/cli/loop/`; shell reseed in `deploy/`. No straddling.
**5. Dependency direction** — `teatree.cli.loop` -> `teatree.loops` (downward). `tach check`: all modules validated. No backwards edge.
**6. Test surface** — `fleet_disable_set` (unit) + `effective_verdicts` end-to-end admission (integration) + real-shell entrypoint prune + CLI. RED confirmed.
**7. Resilience invariants** — idempotent reseed + pure prune fn; no new external write. Others n/a.
**8. Identity/key normalization** — loop names already canonical; no bare-vs-qualified form.
**9. Behavior preservation** — `review`/`followup` masks preserved; only `directive_loop` erroneous forced-off default removed; emergency override handle untouched; no must-block test inverted.
**10. Removability / harness-vs-data** — removable (reverts to entrypoint default); the owner-intake set is a small constant registry (data-shaped) read by the generic prune (harness).
