### PR TITLE
fix(deploy): run the health probe in the worker, retry a restarting target (#3651)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -575,6 +575,7 @@ same-daemon supervisor can cover, and is honest about the two it cannot:
 | `teatree-init` crash-loop (the recorded 7h freeze) | ✅ | next pass's gated `up -d --no-recreate` re-runs the failed init; while the root cause persists the doctor step reddens and DMs the owner |
 | an app service crashed / exited | ✅ | `up -d --no-recreate` restarts it |
 | the **watchdog itself** crashed | ✅ | `restart: always` — the daemon relaunches it in seconds |
+| the probe's target is mid-restart when the pass runs | ✅ | the daemon's "container is restarting" refusal is classified as transient and retried (`TEATREE_WATCHDOG_DOCTOR_RETRIES`); it never pages the owner. A run that COMPLETED but emitted no verdict is still RED and still DMs |
 | the daemon restarted (e.g. host reboot with Docker enabled on boot) | ✅ | `restart: always` brings it back with the stack |
 | `docker compose down` (deliberate teardown) | ❌ (intentional) | the operator took the stack down on purpose; nothing should fight that |
 | the Docker **daemon** is dead | ❌ | its supervisor is gone; an external uptime check is the backstop |
@@ -596,7 +597,9 @@ docker compose -p teatree logs -f teatree-watchdog
 | `TEATREE_WATCHDOG_PASS_TIMEOUT` | `300` | hard cap on a single pass; a wedged pass is killed and the loop continues |
 | `TEATREE_WATCHDOG_PROJECT` | `teatree` | the compose project the watchdog drives |
 | `TEATREE_WATCHDOG_OVERLAY` | `teatree` | the overlay used for the owner DM |
-| `TEATREE_WATCHDOG_EXEC_SERVICES` | `teatree-admin teatree-worker` | services (first reachable wins) to run the doctor/DM commands in |
+| `TEATREE_WATCHDOG_EXEC_SERVICES` | `teatree-worker teatree-admin` | services (first reachable wins) to run the doctor/DM commands in — the worker leads because the health probe is heavy (#3651) |
+| `TEATREE_WATCHDOG_DOCTOR_RETRIES` | `3` | attempts when the probe cannot run because its target is restarting / not running |
+| `TEATREE_WATCHDOG_DOCTOR_RETRY_DELAY` | `15` | seconds between those retries |
 | `TEATREE_WATCHDOG_APP_SERVICES` | `teatree-worker teatree-admin teatree-slack-listener teatree-watchdog` | services restarted when init has already completed (init excluded) |
 | `TEATREE_WATCHDOG_INIT_SERVICE` | `teatree-init` | the one-shot init service the pass gates on |
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -143,9 +143,14 @@ services:
         condition: service_completed_successfully
     restart: unless-stopped
     network_mode: host
-    # 512m is correct: the admin is a lean Django web-UI server (gunicorn) — the
-    # heavy CLI/commit/agent work (headless agents + their ty-check/lint hooks)
-    # belongs in the WORKER (18g), never here. The `_check_worker_memory_cap`
+    # 512m covers SERVING only, and the measured numbers are the reason it holds:
+    # idle-and-serving is 257 MiB (50% of the cap). It does NOT cover a health
+    # probe — `t3 doctor check --json` peaked at 380 MiB (74%), leaving ~130 MiB
+    # for concurrent dashboard traffic, which restarted this container on every
+    # watchdog pass (#3651). A child dying under the cgroup limit is not reported
+    # as a container-level OOM, so `OOMKilled` stayed false the whole time. The
+    # probe now runs in the WORKER (18g) — deploy/watchdog.sh's EXEC_SERVICES —
+    # so nothing heavy competes with gunicorn here. The `_check_worker_memory_cap`
     # doctor gate warns only when the WORKER's cap is under-sized, not this one.
     mem_limit: 512m
     cpus: "0.5"

--- a/deploy/watchdog.sh
+++ b/deploy/watchdog.sh
@@ -15,7 +15,8 @@
 #      EXCLUDED (an empirical fact — `up -d --no-recreate` re-runs a completed
 #      init every pass, which would replay the heavy ~minute init on every tick),
 #      while a missing/failed init IS included so the init-failure outage recovers.
-#   2. `t3 doctor check --json` inside a live container — read the factory health,
+#   2. `t3 doctor check --json` inside the WORKER (the container sized for heavy
+#      work; see EXEC_SERVICES) — read the factory health,
 #      including the H24 self-heal detectors (dead containers, a free worker flock
 #      over overdue loop work, stranded headless tasks, stale timers, unrunnable
 #      interactive tasks, failed tasks on live tickets, a drifted runtime clone).
@@ -35,8 +36,17 @@ OVERLAY="${TEATREE_WATCHDOG_OVERLAY:-teatree}"
 INTERVAL="${TEATREE_WATCHDOG_INTERVAL:-300}"
 PASS_TIMEOUT="${TEATREE_WATCHDOG_PASS_TIMEOUT:-300}"
 INIT_SERVICE="${TEATREE_WATCHDOG_INIT_SERVICE:-teatree-init}"
-# Services to `exec` the read commands in (first reachable one wins).
-EXEC_SERVICES="${TEATREE_WATCHDOG_EXEC_SERVICES:-teatree-admin teatree-worker}"
+# Services to `exec` the read commands in (first reachable one wins). The WORKER
+# leads (#3651): `t3 doctor check --json` boots Django, scans the DB and makes live
+# third-party HTTP round-trips — measured at 380 MiB peak, which inside the admin's
+# lean 512m cap (257 MiB idle just serving the dashboard) left ~130 MiB of headroom
+# and restarted the admin on every pass. The worker is the container sized for heavy
+# work; the admin stays the fallback so a down worker never blinds the watchdog.
+EXEC_SERVICES="${TEATREE_WATCHDOG_EXEC_SERVICES:-teatree-worker teatree-admin}"
+# Bounded retry for a probe that could not RUN because its target was mid-restart or
+# not yet up — a transient, distinct from a completed run that returned no verdict.
+DOCTOR_RETRIES="${TEATREE_WATCHDOG_DOCTOR_RETRIES:-3}"
+DOCTOR_RETRY_DELAY="${TEATREE_WATCHDOG_DOCTOR_RETRY_DELAY:-15}"
 # Services restarted when init has already completed (init excluded — see header).
 read -ra APP_SERVICES <<<"${TEATREE_WATCHDOG_APP_SERVICES:-teatree-worker teatree-admin teatree-slack-listener teatree-watchdog}"
 
@@ -45,7 +55,7 @@ read -ra APP_SERVICES <<<"${TEATREE_WATCHDOG_APP_SERVICES:-teatree-worker teatre
 # temp is routed to disk (/var/tmp) by the entrypoint + settings template, but a
 # crashed/abandoned run can still leave pytest/uv/claude scratch behind that grows
 # unbounded over weeks — the periodic half of the tmpfs-fill guard.
-TEMP_TRIM_SERVICES="${TEATREE_WATCHDOG_TEMP_TRIM_SERVICES:-teatree-worker teatree-admin}"
+TEMP_TRIM_SERVICES="${TEATREE_WATCHDOG_TEMP_TRIM_SERVICES:-teatree-admin teatree-worker}"
 TEMP_TRIM_ROOTS="${TEATREE_WATCHDOG_TEMP_TRIM_ROOTS:-/var/tmp /tmp}"
 TEMP_TRIM_MIN_AGE_MIN="${TEATREE_WATCHDOG_TEMP_TRIM_MIN_AGE_MIN:-720}"
 
@@ -122,22 +132,62 @@ compose_states_b64() {
 # made the red-findings DM path below dead code). Reachability is probed
 # separately (a trivial `exec ... true`); only a genuinely unreachable service
 # falls through to the next one. Returns 0 when a service was reached (DOCTOR_RAW
-# set, possibly empty), 125 when NO exec service could be reached at all.
-run_doctor() {
-  local svc states_b64
+# set, possibly empty), 125 when NO exec service could be reached at all. Either
+# way DOCTOR_ERR carries the daemon's stderr, which run_doctor classifies.
+_doctor_attempt() {
+  local svc states_b64 err_file probe_err
   DOCTOR_RAW=""
+  DOCTOR_ERR=""
   states_b64="$(compose_states_b64)"
+  err_file="$(mktemp)"
   for svc in $EXEC_SERVICES; do
-    if compose exec -T "$svc" true >/dev/null 2>&1; then
+    probe_err="$(compose exec -T "$svc" true 2>&1 >/dev/null)" && {
       # `|| true`: doctor exits non-zero on red findings; keep its stdout, drop
       # the exit code (set -e must not abort, and the code is NOT the signal).
       # `-e TEATREE_DOCTOR_COMPOSE_PS`: hand the socket-only container states to the
       # doctor's compose-stack detector, which cannot reach the daemon itself.
-      DOCTOR_RAW="$(compose exec -T -e "TEATREE_DOCTOR_COMPOSE_PS=$states_b64" "$svc" t3 doctor check --json 2>/dev/null || true)"
+      DOCTOR_RAW="$(compose exec -T -e "TEATREE_DOCTOR_COMPOSE_PS=$states_b64" "$svc" t3 doctor check --json 2>"$err_file" || true)"
+      DOCTOR_ERR="$(cat "$err_file")"
+      rm -f "$err_file"
+      return 0
+    }
+    DOCTOR_ERR="$DOCTOR_ERR$probe_err"$'\n'
+  done
+  rm -f "$err_file"
+  return 125
+}
+
+# A daemon refusal to exec into a container that is restarting / not (yet) running.
+# This is the target being momentarily UNAVAILABLE, never a statement about doctor.
+_is_transient_exec_error() {
+  case "$1" in
+    *"is restarting"* | *"is not running"* | *"is paused"* | *"No such container"* | *"not running"*) return 0 ;;
+  esac
+  return 1
+}
+
+# Run the doctor probe, retrying a bounded number of times while the only failure is
+# a transient target unavailability. Returns 0 when a run COMPLETED (DOCTOR_RAW set,
+# possibly empty — an empty completed run is RED), 125 when no exec service could be
+# reached for a non-transient reason, and 126 when the target stayed unavailable for
+# every attempt (a transient the caller must NOT page on).
+run_doctor() {
+  local attempt=1 rc
+  while :; do
+    _doctor_attempt && rc=0 || rc=$?
+    if [ "$rc" -eq 0 ] && { [ -n "$DOCTOR_RAW" ] || ! _is_transient_exec_error "$DOCTOR_ERR"; }; then
       return 0
     fi
+    if [ "$rc" -ne 0 ] && ! _is_transient_exec_error "$DOCTOR_ERR"; then
+      return "$rc"
+    fi
+    if [ "$attempt" -ge "$DOCTOR_RETRIES" ]; then
+      return 126
+    fi
+    log "doctor probe target unavailable (attempt $attempt/$DOCTOR_RETRIES) — retrying in ${DOCTOR_RETRY_DELAY}s"
+    attempt=$((attempt + 1))
+    sleep "$DOCTOR_RETRY_DELAY"
   done
-  return 125
 }
 
 # Trim ONLY well-known stale scratch (pytest / uv / claude) older than the age
@@ -176,7 +226,16 @@ run_pass() {
   # Guard against a temp-scratch leak filling the disk (never fatal — see fn).
   trim_stale_temp
 
-  if ! run_doctor; then
+  local doctor_rc
+  run_doctor && doctor_rc=0 || doctor_rc=$?
+  if [ "$doctor_rc" -eq 126 ]; then
+    # The probe could not RUN: its target was restarting / not running for every
+    # attempt. That is a transient (#3651) — a retry is the whole remedy, and it
+    # must never page the owner the way a completed-but-silent doctor does.
+    log "doctor probe target unavailable after $DOCTOR_RETRIES attempts — transient, not paging"
+    return 0
+  fi
+  if [ "$doctor_rc" -ne 0 ]; then
     # No exec service could be reached at all — a genuine transport failure, the
     # ONLY case that is truly "unreachable" (distinct from doctor running and
     # returning a red verdict, which is handled below).
@@ -196,7 +255,7 @@ run_pass() {
     # is itself a RED condition, not a healthy pass (the old code treated it as
     # healthy and stayed silent). DM at most once per day so a persistent breakage is seen.
     log "doctor reachable but produced no JSON verdict — treating as RED"
-    printf 'teatree watchdog: `t3 doctor check --json` ran but produced NO parseable verdict — doctor may be crashing on the box. SSH in and run `t3 doctor check` in `docker compose -p %s exec teatree-admin`.' "$PROJECT" \
+    printf 'teatree watchdog: `t3 doctor check --json` ran but produced NO parseable verdict — doctor may be crashing on the box. SSH in and run `t3 doctor check` in `docker compose -p %s exec teatree-worker`.' "$PROJECT" \
       | notify_owner "watchdog:doctor-no-verdict:$(date -u +%Y%m%d)"
     return 0
   fi

--- a/src/teatree/cli/doctor/self_heal.py
+++ b/src/teatree/cli/doctor/self_heal.py
@@ -105,7 +105,7 @@ def _parse_compose_state_rows(text: str) -> list[tuple[str, str, str]]:
 def _compose_states_from_handoff() -> list[tuple[str, str, str]] | None:
     """Compose states handed off by the socket-holding watchdog, or ``None`` when absent.
 
-    ``t3 doctor`` runs inside ``teatree-admin`` (docker CLI but no
+    ``t3 doctor`` runs inside an app container (docker CLI but no
     ``/var/run/docker.sock``), so only the socket-holding watchdog can gather the
     states; it passes them in via :data:`_COMPOSE_STATES_ENV` (base64 of the
     tab-separated ``docker ps`` output). ``None`` when the env var is unset/empty

--- a/tests/test_claude_statusline.py
+++ b/tests/test_claude_statusline.py
@@ -602,7 +602,9 @@ class TestHarnessTodoSummary:
         plain = _strip_ansi(result.stdout)
         # The harness store's counts win (1/2), never the stale mirror's (0/3).
         assert "TODO 1/2 ✓" in plain, plain
-        assert "0/3" not in plain, plain
+        # Scoped to the TODO chip: a bare "0/3" also matches the RAM chip on a host
+        # whose reading renders as e.g. "26.0/30G".
+        assert "TODO 0/3" not in plain, plain
 
     def test_renders_compact_done_over_total(self, tmp_path: Path) -> None:
         state_dir = tmp_path / "state"

--- a/tests/test_deploy_watchdog.py
+++ b/tests/test_deploy_watchdog.py
@@ -37,9 +37,16 @@ def _write_docker_stub(bin_dir: Path) -> None:
     """A `docker` shim modelling the `docker compose` calls run_pass makes.
 
     ``STUB_INIT_PS`` is the init service's `ps --format json` row; ``STUB_TRUE_RC``
-    is the reachability probe's exit code (non-zero → unreachable); a doctor `exec`
-    prints ``STUB_DOCTOR_JSON`` and exits ``STUB_DOCTOR_RC``; a `notify send` exec
-    captures the piped DM body to ``STUB_NOTIFY_FILE``.
+    is the reachability probe's exit code (non-zero → unreachable, with
+    ``STUB_TRUE_STDERR`` on stderr); a doctor `exec` prints ``STUB_DOCTOR_JSON`` and
+    exits ``STUB_DOCTOR_RC``; a `notify send` exec captures the piped DM body to
+    ``STUB_NOTIFY_FILE``.
+
+    ``STUB_UNREACHABLE_SVC`` makes the reachability probe fail for exactly that one
+    service, so the fallback ordering can be driven. ``STUB_DOCTOR_TRANSIENT_UNTIL``
+    makes the first N doctor attempts fail the way a restarting target does — nothing
+    on stdout, ``STUB_DOCTOR_STDERR`` on stderr — so a bounded retry can be driven;
+    attempts are counted into ``STUB_DOCTOR_ATTEMPTS``.
     """
     bin_dir.mkdir(parents=True, exist_ok=True)
     shim = bin_dir / "docker"
@@ -60,11 +67,28 @@ def _write_docker_stub(bin_dir: Path) -> None:
         "  exec)\n"
         '    printf "%s\\n" "$*" >>"${STUB_EXEC_LOG:-/dev/null}"\n'
         '    [ "${1:-}" = -T ] && shift\n'
+        '    while [ "${1:-}" = -e ]; do shift 2; done\n'
+        '    svc="${1:-}"\n'
         "    shift || true\n"
         '    rest="$*"\n'
         '    case "$rest" in\n'
-        '      true) exit "${STUB_TRUE_RC:-0}" ;;\n'
-        '      *"doctor check --json"*) printf "%s\\n" "$STUB_DOCTOR_JSON"; exit "${STUB_DOCTOR_RC:-1}" ;;\n'
+        "      true)\n"
+        '        rc="${STUB_TRUE_RC:-0}"\n'
+        '        [ -z "${STUB_UNREACHABLE_SVC:-}" ] || { rc=0; [ "$svc" != "$STUB_UNREACHABLE_SVC" ] || rc=1; }\n'
+        '        [ "$rc" = 0 ] || printf "%s\\n" "${STUB_TRUE_STDERR:-}" >&2\n'
+        '        exit "$rc" ;;\n'
+        '      *"doctor check --json"*)\n'
+        "        n=0\n"
+        '        if [ -n "${STUB_DOCTOR_ATTEMPTS:-}" ]; then\n'
+        '          n=$(cat "$STUB_DOCTOR_ATTEMPTS" 2>/dev/null || printf 0)\n'
+        "          n=$((n + 1))\n"
+        '          printf "%s" "$n" >"$STUB_DOCTOR_ATTEMPTS"\n'
+        "        fi\n"
+        '        if [ "$n" -le "${STUB_DOCTOR_TRANSIENT_UNTIL:-0}" ]; then\n'
+        '          printf "%s\\n" "${STUB_DOCTOR_STDERR:-}" >&2\n'
+        "          exit 1\n"
+        "        fi\n"
+        '        printf "%s\\n" "$STUB_DOCTOR_JSON"; exit "${STUB_DOCTOR_RC:-1}" ;;\n'
         '      *"notify send"*) cat >"$STUB_NOTIFY_FILE"; exit 0 ;;\n'
         "      *) exit 0 ;;\n"
         "    esac\n"
@@ -88,6 +112,8 @@ def _run_pass(tmp_path: Path, **stub_env: str) -> str:
     env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
     env["STUB_NOTIFY_FILE"] = str(notify_file)
     env["STUB_EXEC_LOG"] = str(tmp_path / "exec.log")
+    env["STUB_DOCTOR_ATTEMPTS"] = str(tmp_path / "attempts.txt")
+    env["TEATREE_WATCHDOG_DOCTOR_RETRY_DELAY"] = "0"
     env.setdefault("STUB_INIT_PS", '{"State":"exited","ExitCode":0}')
     env.setdefault("STUB_DOCTOR_JSON", _GREEN_VERDICT)
     env.update(stub_env)
@@ -98,6 +124,18 @@ def _run_pass(tmp_path: Path, **stub_env: str) -> str:
 def _exec_log(tmp_path: Path) -> str:
     log = tmp_path / "exec.log"
     return log.read_text(encoding="utf-8") if log.exists() else ""
+
+
+def _doctor_exec_lines(tmp_path: Path) -> list[str]:
+    return [line for line in _exec_log(tmp_path).splitlines() if "doctor check --json" in line]
+
+
+def _doctor_attempts(tmp_path: Path) -> int:
+    counter = tmp_path / "attempts.txt"
+    return int(counter.read_text(encoding="utf-8")) if counter.exists() else 0
+
+
+_RESTARTING_ERR = "Error response from daemon: Container 9f2c is restarting, wait until the container is running"
 
 
 class TestWatchdogRunPass:
@@ -147,6 +185,80 @@ class TestWatchdogComposeStateHandoff:
         # flag — so the exec shape is stable and the doctor falls back cleanly.
         _run_pass(tmp_path, STUB_DOCKER_PS="", STUB_DOCTOR_JSON=_GREEN_VERDICT, STUB_DOCTOR_RC="0")
         assert "TEATREE_DOCTOR_COMPOSE_PS=" in _exec_log(tmp_path)
+
+
+class TestWatchdogTargetsTheWorker:
+    """The health probe runs where heavy work belongs, not in the lean web container.
+
+    `t3 doctor check --json` boots Django, scans the DB and makes live third-party
+    HTTP calls. Running it inside the 512m admin — which is simultaneously serving
+    the dashboard — left ~130 MiB of headroom and restarted the container every
+    watchdog pass (#3651). The worker is sized for heavy work, so it is probed first.
+    """
+
+    def test_doctor_probe_targets_the_worker_first(self, tmp_path: Path) -> None:
+        _run_pass(tmp_path, STUB_DOCTOR_JSON=_GREEN_VERDICT, STUB_DOCTOR_RC="0")
+        assert "teatree-worker" in _doctor_exec_lines(tmp_path)[0]
+
+    def test_admin_is_the_fallback_when_the_worker_is_unreachable(self, tmp_path: Path) -> None:
+        # A down worker must not blind the watchdog — the admin stays in the list.
+        dm = _run_pass(
+            tmp_path,
+            STUB_UNREACHABLE_SVC="teatree-worker",
+            STUB_DOCTOR_JSON=_GREEN_VERDICT,
+            STUB_DOCTOR_RC="0",
+        )
+        assert dm == ""
+        assert "teatree-admin" in _doctor_exec_lines(tmp_path)[0]
+
+
+class TestWatchdogTransientTargetUnavailability:
+    """A target that was restarting is a transient to retry, not a red to page on.
+
+    A completed doctor run that emits nothing is still RED (a half-crashed doctor).
+    A probe that could not run at all — the daemon refusing the exec because the
+    container is restarting/not running — is a transient: retried, never paged.
+    """
+
+    def test_restarting_target_is_retried_and_does_not_page(self, tmp_path: Path) -> None:
+        dm = _run_pass(
+            tmp_path,
+            STUB_DOCTOR_TRANSIENT_UNTIL="99",
+            STUB_DOCTOR_STDERR=_RESTARTING_ERR,
+            TEATREE_WATCHDOG_DOCTOR_RETRIES="3",
+        )
+        assert dm == ""
+        assert _doctor_attempts(tmp_path) == 3
+
+    def test_transient_that_clears_on_retry_reads_the_recovered_verdict(self, tmp_path: Path) -> None:
+        dm = _run_pass(
+            tmp_path,
+            STUB_DOCTOR_TRANSIENT_UNTIL="1",
+            STUB_DOCTOR_STDERR=_RESTARTING_ERR,
+            STUB_DOCTOR_JSON=_RED_VERDICT,
+            STUB_DOCTOR_RC="1",
+            TEATREE_WATCHDOG_DOCTOR_RETRIES="3",
+        )
+        assert "red findings" in dm
+        assert _doctor_attempts(tmp_path) == 2
+
+    def test_unreachable_service_with_a_restarting_error_does_not_page(self, tmp_path: Path) -> None:
+        # The exec never lands because every target is mid-restart — transient, not
+        # the genuine "stack unreachable" outage.
+        dm = _run_pass(
+            tmp_path,
+            STUB_TRUE_RC="1",
+            STUB_TRUE_STDERR=_RESTARTING_ERR,
+            TEATREE_WATCHDOG_DOCTOR_RETRIES="2",
+        )
+        assert dm == ""
+
+    def test_completed_run_with_no_verdict_still_pages_as_red(self, tmp_path: Path) -> None:
+        # The deliberate #3440 behaviour must survive the transient carve-out: doctor
+        # RAN (no daemon error) and produced nothing → still RED.
+        dm = _run_pass(tmp_path, STUB_DOCTOR_JSON="garbage with no verdict line", STUB_DOCTOR_RC="1")
+        assert "no parseable verdict" in dm.lower()
+        assert _doctor_attempts(tmp_path) == 1, "a completed run must not be retried"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #3651. Release blocker for the self-contained-deployment epic #3445, item 4 ("it stays up and tells you when it can't, without a human watching").

## The defect

The watchdog ran the health probe **inside the lean web container**:
`compose exec -T teatree-admin t3 doctor check --json`. The admin's `mem_limit`
is `512m`, sized for serving the dashboard. The probe is not lean — it boots
Django, scans the DB, and makes live third-party HTTP round-trips.

Measured on a live box:

| state | memory |
| --- | --- |
| admin idle, serving the dashboard | 257 MiB / 512 MiB (50%) |
| during `t3 doctor check --json` | 380 MiB / 512 MiB (74%) |

That leaves ~130 MiB for concurrent dashboard traffic. A child dying under the
cgroup limit is not reported as a container-level OOM, which is why the
container showed `ExitCode=0` / `OOMKilled=false` while `RestartCount` climbed
(9 to 10 within ~2 minutes). Each failed pass then read as RED and DMed the
owner (`watchdog:doctor-no-verdict`), immediately followed by
`Error response from daemon: Container ... is restarting`.

## Fix — direction 1 (the probe leaves the lean container) plus direction 3

**1. The probe runs in the worker.** `EXEC_SERVICES` now leads with
`teatree-worker` (18g, the container sized for heavy work) and keeps
`teatree-admin` as the fallback, so a down worker never blinds the watchdog.
This was preferred over raising the admin cap because the cap is not the real
constraint — the web server competing with a heavyweight probe is. Raising 512m
would buy headroom while leaving the probe contending with gunicorn on every
pass; moving it removes the contention outright and makes the existing
"heavy work belongs in the worker" invariant actually true.

The watchdog's contract with its target is unchanged and explicit: it needs a
container that can `exec` `t3` and reach the DB/credentials — both app
containers qualify (both use the same compose anchor, so the same data mount
and env). The socket-only compose-state handoff
(`TEATREE_DOCTOR_COMPOSE_PS`) is passed to whichever service is reached,
exactly as before.

**2. The compose comment now carries the real reasoning.** The old comment
asserted "512m is correct: the admin is a lean Django web-UI server ... heavy
work belongs in the WORKER" — true as a principle, false as a description of
what was actually running there. It now records the measured numbers, the
cgroup-OOM invisibility, and the fact that the probe runs elsewhere.

**3. The watchdog distinguishes "could not run" from "ran and returned
nothing"** (required regardless of 1/2). A daemon refusal to exec into a
restarting / not-running container is classified as transient: bounded retry
(`TEATREE_WATCHDOG_DOCTOR_RETRIES`, default 3, `..._RETRY_DELAY` 15s), logged,
and it never pages the owner. The deliberate #3440 behaviour is preserved
intact: doctor exiting non-zero on red findings is still a healthy RUN, and a
run that COMPLETED but emitted no parseable verdict is still RED and still DMs.

## RED to GREEN evidence

Every new test was observed failing on the pre-fix code:

- `test_restarting_target_is_retried_and_does_not_page` — RED
  (`AssertionError: assert 'teatree watc...atree-admin`.' == ''` — it paged)
- `test_unreachable_service_with_a_restarting_error_does_not_page` — RED
- `test_transient_that_clears_on_retry_reads_the_recovered_verdict` — RED
  (`assert 'red findings' in '... produced NO parseable verdict ...'`)
- `test_doctor_probe_targets_the_worker_first` — control run with the service
  order reverted:
  `AssertionError: assert 'teatree-worker' in '-T -e TEATREE_DOCTOR_COMPOSE_PS= teatree-admin t3 doctor check --json'`

The first version of the ordering test passed vacuously (the stale-temp trim
execs the worker before the probe runs), so it was rewritten to assert on the
`doctor check --json` exec line specifically and re-proved RED by control.

GREEN after the fix: `tests/test_deploy_watchdog.py` +
`tests/test_deploy_watchdog_temp_trim.py` gives 14 passed.
`bash dev/ci-parity-fast.sh` gives 30197 passed (its single failure was an
unrelated host-dependent flake, fixed in this PR — see below).
`uv run prek run --all-files` is clean. `shellcheck deploy/watchdog.sh` is at
parity with `main` (the same 5 pre-existing `SC2016` infos, no new findings).

## Why the restart loop is gone

I cannot redeploy the live box, so the argument is mechanical rather than
observational:

- The restarts were the admin container's, and the only heavyweight workload
  reaching it was the watchdog's `exec`. With `EXEC_SERVICES` leading with the
  worker, no watchdog pass execs `t3 doctor` into the admin while the worker is
  up — the exec-log assertion in `test_doctor_probe_targets_the_worker_first`
  pins that. The admin is then left at its measured 257 MiB idle-and-serving
  against a 512m cap (2x headroom), with no 380 MiB peak landing on top of it,
  so the cgroup pressure that killed it every pass is simply not applied.
- The probe's peak now lands in the 18g worker, where 380 MiB is 2% of the cap.
- The residual case — the admin being unavailable for some other reason when the
  fallback path uses it — no longer produces a page: it is classified transient
  and retried, so a fresh deployment cannot DM its owner about a probe that is
  actually fine.

Acceptance criteria mapping: `RestartCount` stays flat (no heavy exec into the
admin), the probe returns a parseable verdict each pass (it runs with 18g of
room), and a transient probe failure is retried without paging.

## Bundled unrelated fix

`tests/test_claude_statusline.py::test_chip_sourced_from_harness_store_not_teatree_mirror`
asserted `"0/3" not in plain` against the whole rendered statusline, so it also
matched the RAM chip on a host rendering `26.0/30G` — a host-dependent red with
nothing to do with the TODO source under test. Scoped to `"TODO 0/3"`.

## Architecture pre-check

1. **BLUEPRINT section alignment** — no BLUEPRINT change; this is deploy
   substrate (`deploy/`), documented by `deploy/README.md`, which is updated
   (knob table plus an outage-matrix row for a mid-restart probe target).
2. **FSM phase boundaries** — n/a, no `Ticket.State` / `Worktree.State`
   transition is touched.
3. **Extension-point contracts** — none. No `OverlayBase` hook, scanner
   registration, or `*Backend` Protocol is involved.
4. **Component boundaries** — `deploy/watchdog.sh` (deploy substrate) plus a
   one-line stale docstring in `src/teatree/cli/doctor/self_heal.py` that named
   `teatree-admin` as the doctor's host container.
5. **Dependency direction** — no imports added; the Python change is a
   docstring.
6. **Test surface** — `tests/test_deploy_watchdog.py`:
   `TestWatchdogTargetsTheWorker` (exec-target ordering plus admin fallback) and
   `TestWatchdogTransientTargetUnavailability` (transient retried and silent;
   completed-but-silent run still RED and still paged, with an assertion that it
   is NOT retried).
7. **Resilience invariants** — idempotency: a pass is unchanged in shape and
   remains safe to repeat; the only mutating docker op is still
   `up -d --no-recreate`. Fallback transport: the admin remains the fallback
   exec target. Heartbeat: each retry logs its attempt number, so a persistently
   unavailable target is visible in the watchdog's container logs rather than
   silent. Verify-by-re-read: the retry loop re-probes rather than trusting a
   single reading. No new external write is introduced.
8. **Identity and key normalization** — n/a; no bare/qualified identity pair.
   The DM idempotency keys are unchanged.
9. **Behavior preservation** — the `run_doctor` rewrite preserves every prior
   behaviour: first-reachable-service selection, stdout captured regardless of
   doctor's exit code, the compose-state handoff flag always present, 125 for a
   genuinely unreachable stack, and the #3440 "no parseable verdict is RED"
   path. The only deliberate change is that a *transient target unavailability*
   stops being folded into those two. No must-block test was inverted —
   `test_completed_run_with_no_verdict_still_pages_as_red` pins the preserved
   RED path explicitly.
10. **Removability / harness-vs-data** — both halves are removable by reverting
    two variables: the exec order and the retry counts are env-overridable data
    (`TEATREE_WATCHDOG_EXEC_SERVICES`, `..._DOCTOR_RETRIES`,
    `..._DOCTOR_RETRY_DELAY`), so an operator can restore the old behaviour with
    no code change. The transient classifier is a single predicate function with
    one call site.

## Open questions and assumptions

- Assumption: the worker container runs `t3 doctor check --json` with the same
  result as the admin. Both use the `x-teatree-common` anchor, so they share the
  data mount, credentials, and env; the doctor's only container-shape dependency
  is the compose-state handoff, which the watchdog supplies to whichever service
  it reached.
- Assumption: probing a busy worker is acceptable. At 380 MiB peak against an
  18g cap this is 2%, versus 74% of the admin's cap.
- Not changed: the admin's `512m`. The measured idle-and-serving figure is
  257 MiB, so the cap keeps ~2x headroom once the probe is not competing with
  it. Raising it was left out deliberately — with the probe moved, a larger cap
  would mask rather than fix a future regression of this same shape.
- The transient path deliberately never pages, per the issue. A persistently
  unavailable target is therefore visible only in the watchdog's logs; if that
  proves too quiet in practice, a distinct low-frequency key would be the
  follow-up, but adding it now would re-introduce the paging the issue asks to
  remove.
