### PR TITLE
fix(agents): deliver the reviewer verdict envelope so a PR can merge (#3654)

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -22,8 +22,43 @@ style compliance, architecture issues, and test coverage.
 You cannot edit files — report findings for the coder to fix.
 
 You have NO git-write capability: never commit, push, amend, or make a
-fix-up change. Terminate at your verdict (PASS / HOLD + findings) — the
-verdict is your deliverable; the coder acts on it, not you.
+fix-up change. The coder acts on your findings, not you.
+
+## Your deliverable is the `review_verdict` envelope
+
+Your verdict is only real once it is in your final JSON result. You do not
+record it yourself — you RETURN it, and the orchestrator (a different actor)
+records the `ReviewVerdict` from it. That separation is what keeps the maker
+from being the checker, and the recorded verdict is the sole thing that lets a
+pull request merge. A run that ends without this envelope is a review that
+never happened, and it is refused.
+
+```json
+"review_verdict": {
+  "verdict": "merge_safe",
+  "reviewed_sha": "<full 40-char SHA of the head you reviewed>",
+  "reviewer_identity": "<your reviewer id — never a maker/coder/loop role>",
+  "gh_verify_result": "green",
+  "blast_class": "logic",
+  "findings": [{"severity": "major", "summary": "...", "file": "src/x.py", "line": 42}]
+}
+```
+
+Allowed values, exactly as written — anything else is refused:
+
+- `verdict`: `merge_safe` or `hold`. Not `PASS`, not `LGTM`, not `approve`.
+  Use `hold` with the blocking findings when the change must not merge yet.
+- `gh_verify_result`: `green`, `pending`, or `failed` — the CI state you
+  observed. `merge_safe` can never carry `failed`.
+- `blast_class`: `substrate`, `logic`, or `docs`.
+- `reviewed_sha`: the FULL 40 hex characters of the head you actually
+  reviewed (`git rev-parse HEAD` on the fetched head — never `HEAD~`, never an
+  abbreviated or remembered SHA). The merge gate compares it against the
+  forge's live head, so a short or stale SHA silently vouches for nothing.
+
+If something blocks you from reviewing at all (you cannot fetch the head, the
+diff is unreachable), return `needs_user_input` with the reason instead of
+inventing a verdict.
 
 Follow the loaded skills for review methodology, coding standards,
 platform API recipes, and cross-cutting rules.

--- a/src/teatree/agents/prompt.py
+++ b/src/teatree/agents/prompt.py
@@ -70,8 +70,13 @@ _REVIEW_VERDICT_RETURN_LINES: tuple[str, ...] = (
     '  "review_verdict": {"verdict": "merge_safe"|"hold", "reviewed_sha": "<full 40-char HEAD SHA>",',
     '                     "reviewer_identity": "<your reviewer id, NOT a maker/loop role>",',
     '                     "gh_verify_result": "green"|"pending"|"failed",',
+    '                     "blast_class": "substrate"|"logic"|"docs",',
     '                     "findings": [{"severity": "...", "summary": "...", "file": "...", "line": 0}]}',
     "Use verdict=hold with the blocking findings when the change must not merge yet.",
+    "`verdict` accepts ONLY merge_safe or hold — PASS/LGTM/approve are refused and record nothing.",
+    "`reviewed_sha` MUST be the full 40-char SHA of the head you reviewed (`git rev-parse HEAD`):",
+    "the merge gate compares it against the forge's live head, so a short or stale SHA vouches for nothing.",
+    "A result with no `review_verdict` FAILS the phase — a review that records no verdict never happened.",
 )
 
 # Injected into a headless answering brief: the answering phase is denied the

--- a/src/teatree/agents/result_schema.py
+++ b/src/teatree/agents/result_schema.py
@@ -383,10 +383,14 @@ RESULT_JSON_SCHEMA: JSONSchema = {
 #:
 #: - ``coding``: at least one file change recorded.
 #: - ``testing``: at least one test result OR a positive ``tests_passed``.
-#: - ``reviewing``: at least one design decision recorded, OR a typed
-#:   ``review_verdict`` returned for server-side recording (corr-11) — a
-#:   headless reviewer denied the shell proves the review happened by the
-#:   verdict it hands back, not only by a decision list.
+#: - ``reviewing``: a typed ``review_verdict`` returned for server-side
+#:   recording (corr-11), carrying a verdict the recorder can persist.
+#:   ``decisions`` used to satisfy this too, and that alternative is what let
+#:   138 reviewing tasks complete having recorded no verdict at all while every
+#:   open PR logged ``solo_overlay_no_review`` (#3654): a summary-plus-decisions
+#:   result is indistinguishable from a healthy review, so the absence was
+#:   invisible. The verdict is the only artifact the merge gate consumes, so it
+#:   is the only accepted evidence.
 #: - ``shipping``: at least one command executed (``git push``, ``gh pr``...).
 #: - ``scanning_news``: at least one ``article_suggestion`` returned — the
 #:   shell-denied scanner hands its candidates back through the envelope, so a
@@ -403,7 +407,7 @@ PHASE_REQUIRED_EVIDENCE: dict[str, tuple[str, ...]] = {
     "planning": ("plan_text",),
     "coding": ("files_modified",),
     "testing": ("tests_run", "tests_passed"),
-    "reviewing": ("decisions", "review_verdict"),
+    "reviewing": ("review_verdict",),
     "critic_reviewing": ("critic_verdict",),
     "directive_interpreting": ("directive_interpretation",),
     "directive_reading": ("directive_candidate",),
@@ -519,6 +523,22 @@ def interpretation_carries_payload(envelope: object) -> bool:
     return isinstance(questions, list) and any(str(q).strip() for q in questions)
 
 
+def verdict_carries_payload(envelope: object) -> bool:
+    """Whether a review-verdict envelope names a verdict the recorder can persist (#3654).
+
+    ``ReviewVerdict.record`` only knows ``merge_safe`` / ``hold``; a reviewer that
+    hands back ``PASS`` / ``LGTM`` — or an envelope carrying only findings — writes
+    no row, so the merge gate stays unfed. Matching the recorder's vocabulary here
+    keeps a reviewing task from completing over a verdict that never lands.
+    """
+    from teatree.core.models.review_verdict import ReviewVerdict  # noqa: PLC0415 — deferred: ORM/app-registry
+
+    if not isinstance(envelope, dict):
+        return False
+    verdict = str(cast("ReviewVerdictEnvelope", envelope).get("verdict") or "").strip().lower()
+    return verdict in {choice.value for choice in ReviewVerdict.Verdict}
+
+
 #: Channels whose "evidence present" test is stricter than coarse truthiness:
 #: the field must carry what the recorder actually PERSISTS (a url-bearing
 #: suggestion, a text-bearing answer). Without this a schema-violating-but-
@@ -531,6 +551,7 @@ _FIELD_PERSISTS: dict[str, Callable[[object], bool]] = {
     "answer": lambda v: bool(answer_text(v)),
     "directive_interpretation": interpretation_carries_payload,
     "directive_candidate": candidate_carries_payload,
+    "review_verdict": verdict_carries_payload,
 }
 
 

--- a/tests/integration/review_verdict_chain/test_reviewer_envelope_to_merge_gate.py
+++ b/tests/integration/review_verdict_chain/test_reviewer_envelope_to_merge_gate.py
@@ -1,0 +1,250 @@
+"""The reviewing agent's returned envelope is what unblocks the merge sweep (#3654).
+
+Both ends of this chain had green unit tests while the chain itself was dead: the
+recorder records a verdict when handed one, and the sweep merges when a verdict
+row exists — but nothing told the reviewing agent to RETURN the envelope, so 138
+completed reviewing tasks produced zero verdicts and every open PR logged
+``solo_overlay_no_review`` forever. Only a test spanning agent-brief → recorder →
+``has_independent_cold_review`` → sweep decision catches that class.
+
+The safety floor is asserted, never lowered: the verdict is recorded by the
+orchestrator (a different actor than the reviewer), it binds to the live head SHA,
+and a reviewing run that hands back no envelope FAILS loudly instead of completing
+over a no-op review.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from teatree.agents.attempt_recorder import record_result_envelope
+from teatree.agents.prompt import build_system_context
+from teatree.agents.result_schema import RESULT_JSON_SCHEMA, check_evidence
+from teatree.core.models import AutoReviewDispatch, ReviewVerdict, Task
+from teatree.loop.scanners.pr_sweep import PrSummary, PrSweepScanner
+from teatree.loop.scanners.pr_sweep_adapters import NullMergeNotifier
+from teatree.loop.scanners.pr_sweep_decision import has_independent_cold_review
+
+# ast-grep-ignore: ac-django-no-pytest-django-db
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
+
+_SLUG = "souliane/teatree"
+_PR_ID = 3654
+_HEAD = "9c1e4f0b7a3d25e86f0c41ba9d73e5028cf16a4b"
+_PR_URL = f"https://github.com/{_SLUG}/pull/{_PR_ID}"
+_REVIEWER = "cold-reviewer-agent"
+_REVIEWER_DEFINITION = Path(__file__).resolve().parents[3] / "agents" / "reviewer.md"
+
+
+def _reviewing_task() -> Task:
+    dispatch = AutoReviewDispatch.enqueue(slug=_SLUG, pr_id=_PR_ID, head_sha=_HEAD, pr_url=_PR_URL, overlay="teatree")
+    assert dispatch is not None
+    task = dispatch.task
+    assert task is not None
+    task.claim(claimed_by="headless-reviewer")
+    return task
+
+
+def _returned_envelope(*, reviewed_sha: str = _HEAD) -> dict[str, object]:
+    return {
+        "summary": "Independent cold review of the pull request at its live head.",
+        "review_verdict": {
+            "verdict": "merge_safe",
+            "reviewed_sha": reviewed_sha,
+            "reviewer_identity": _REVIEWER,
+            "gh_verify_result": "green",
+            "blast_class": "logic",
+            "findings": [],
+        },
+    }
+
+
+@dataclass(slots=True)
+class _UnusedKeystone:
+    """The CLEAR keystone the solo-overlay path never reaches — no PR here carries a CLEAR."""
+
+    def merge_clear(self, *, clear_id: int, human_authorized: str = "") -> tuple[bool, str, str, str, str]:
+        msg = "the solo-overlay bypass must never route through the CLEAR keystone"
+        raise AssertionError(msg)
+
+
+@dataclass(slots=True)
+class _FakePrApi:
+    """The sweep's forge seam — enough to drive the solo-overlay decision ladder."""
+
+    pr: PrSummary
+    merge_calls: list[tuple[str, int, str]] = field(default_factory=list)
+
+    def list_open_prs(self, *, slug: str) -> list[PrSummary]:
+        return [self.pr] if slug == _SLUG else []
+
+    def merge_pr_squash_bound(self, *, slug: str, pr_id: int, expected_head_oid: str) -> tuple[bool, str]:
+        self.merge_calls.append((slug, pr_id, expected_head_oid))
+        return True, expected_head_oid
+
+    def main_check_conclusion(self, *, slug: str, check_name: str) -> str:
+        return "SUCCESS"
+
+
+def _green_pr() -> PrSummary:
+    return PrSummary(
+        slug=_SLUG,
+        number=_PR_ID,
+        head_sha=_HEAD,
+        is_draft=False,
+        has_changes_requested=False,
+        rollup=(
+            {
+                "__typename": "CheckRun",
+                "name": "test (3.13)",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "startedAt": "2026-07-23T10:00:00Z",
+                "completedAt": "2026-07-23T10:05:00Z",
+            },
+        ),
+        url=_PR_URL,
+        title=f"PR {_PR_ID}",
+        behind_main=False,
+        author="souliane",
+        same_repo=True,
+    )
+
+
+@pytest.fixture
+def sweep(monkeypatch: pytest.MonkeyPatch) -> _FakePrApi:
+    """A solo-overlay sweep over one green, own, same-repo PR at ``_HEAD``."""
+    monkeypatch.setattr(
+        "teatree.core.merge.ci_rollup.CodeHostQuery.required_context_names",
+        lambda *args, **kwargs: {"test (3.13)"},
+    )
+    monkeypatch.setattr(
+        "teatree.core.merge.ci_rollup.CodeHostQuery.pr_changed_paths",
+        lambda *args, **kwargs: ["src/teatree/agents/attempt_recorder.py"],
+    )
+    monkeypatch.setattr("teatree.core.review.author_trust.repo_is_internal", lambda *args, **kwargs: True)
+    return _FakePrApi(pr=_green_pr())
+
+
+def _run_sweep(api: _FakePrApi) -> str:
+    scanner = PrSweepScanner(
+        repos=(_SLUG,),
+        api=api,
+        keystone=_UnusedKeystone(),
+        notifier=NullMergeNotifier(),
+        overlay="teatree",
+        solo_overlay=True,
+        self_identities=("souliane",),
+    )
+    signals = scanner.scan()
+    assert signals, "the sweep emitted no signal for the PR under test"
+    return signals[0].kind
+
+
+class TestReviewerEnvelopeUnblocksTheMergeSweep:
+    def test_returned_envelope_records_verdict_and_sweep_stops_flagging_no_review(self, sweep: _FakePrApi) -> None:
+        task = _reviewing_task()
+
+        assert _run_sweep(sweep) == "pr_sweep.flag_no_review"
+        assert not has_independent_cold_review(slug=_SLUG, pr_id=_PR_ID, head_sha=_HEAD)
+
+        record_result_envelope(task, _returned_envelope(), phase="reviewing")
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.COMPLETED
+        recorded = ReviewVerdict.objects.get(slug=_SLUG, pr_id=_PR_ID, reviewed_sha=_HEAD)
+        assert recorded.is_merge_safe()
+        # Maker≠checker: the reviewer handed the verdict back; the orchestrator wrote it.
+        assert recorded.reviewer_identity == _REVIEWER
+
+        assert has_independent_cold_review(slug=_SLUG, pr_id=_PR_ID, head_sha=_HEAD)
+        assert _run_sweep(sweep) == "pr_sweep.merged"
+        assert sweep.merge_calls == [(_SLUG, _PR_ID, _HEAD)]
+
+    def test_verdict_at_a_stale_head_leaves_the_sweep_flagging_no_review(self, sweep: _FakePrApi) -> None:
+        task = _reviewing_task()
+        stale = "0" * 39 + "1"
+
+        record_result_envelope(task, _returned_envelope(reviewed_sha=stale), phase="reviewing")
+
+        assert ReviewVerdict.objects.filter(reviewed_sha=stale).exists()
+        assert not has_independent_cold_review(slug=_SLUG, pr_id=_PR_ID, head_sha=_HEAD)
+        assert _run_sweep(sweep) == "pr_sweep.flag_no_review"
+        assert sweep.merge_calls == []
+
+
+class TestMissingEnvelopeFailsLoud:
+    def test_reviewing_run_with_no_verdict_envelope_fails_the_task(self, sweep: _FakePrApi) -> None:
+        task = _reviewing_task()
+
+        attempt = record_result_envelope(
+            task, {"summary": "Reviewed the diff.", "decisions": ["looks good to me"]}, phase="reviewing"
+        )
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+        assert "review_verdict" in attempt.error
+        assert not ReviewVerdict.objects.filter(slug=_SLUG, pr_id=_PR_ID).exists()
+        assert _run_sweep(sweep) == "pr_sweep.flag_no_review"
+
+    def test_envelope_with_an_unpersistable_verdict_fails_the_task(self, sweep: _FakePrApi) -> None:
+        task = _reviewing_task()
+
+        record_result_envelope(
+            task,
+            {"summary": "Reviewed.", "review_verdict": {"verdict": "PASS", "reviewer_identity": _REVIEWER}},
+            phase="reviewing",
+        )
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+        assert not ReviewVerdict.objects.filter(slug=_SLUG, pr_id=_PR_ID).exists()
+
+    def test_blocked_reviewer_still_escalates_instead_of_failing(self) -> None:
+        task = _reviewing_task()
+
+        record_result_envelope(
+            task,
+            {"summary": "No diff access.", "needs_user_input": True, "user_input_reason": "cannot fetch the head"},
+            phase="reviewing",
+        )
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.COMPLETED
+
+
+class TestReviewingBriefTeachesTheEnvelopeVocabulary:
+    def test_reviewer_definition_asks_for_the_envelope_in_the_schema_vocabulary(self) -> None:
+        # The defect itself: the definition told the agent to terminate at a
+        # PASS/HOLD verdict, which is neither the envelope nor the schema's words.
+        definition = _REVIEWER_DEFINITION.read_text(encoding="utf-8")
+
+        assert "review_verdict" in definition
+        assert "merge_safe" in definition
+        assert "hold" in definition
+        assert "reviewed_sha" in definition
+        assert "40" in definition, "the full-length SHA requirement must be spelled out"
+        assert "PASS / HOLD" not in definition
+
+    def test_headless_reviewing_brief_names_the_schema_fields_and_values(self) -> None:
+        prompt = build_system_context(_reviewing_task(), skills=[])
+
+        assert "review_verdict" in prompt
+        assert "merge_safe" in prompt
+        assert "hold" in prompt
+        assert "reviewed_sha" in prompt
+        assert "reviewer_identity" in prompt
+        assert "gh_verify_result" in prompt
+        assert "blast_class" in prompt
+        assert "40-char" in prompt
+
+    def test_reviewing_evidence_gate_accepts_only_the_verdict_channel(self) -> None:
+        assert check_evidence(_returned_envelope(), "reviewing") == ""
+        assert "review_verdict" in check_evidence({"decisions": ["ok"]}, "reviewing")
+
+    def test_schema_allowed_values_match_the_recorder_vocabulary(self) -> None:
+        properties = RESULT_JSON_SCHEMA["properties"]
+        verdict_schema = properties["review_verdict"]["properties"]["verdict"]  # type: ignore[index]
+        assert verdict_schema["enum"] == ["merge_safe", "hold"]
+        assert {choice.value for choice in ReviewVerdict.Verdict} == set(verdict_schema["enum"])

--- a/tests/teatree_agents/test_headless_review_verdict.py
+++ b/tests/teatree_agents/test_headless_review_verdict.py
@@ -96,14 +96,17 @@ class TestHeadlessReviewerRecordsVerdictWithoutBash(TestCase):
         task.refresh_from_db()
         assert task.status == Task.Status.FAILED
 
-    def test_reviewing_task_without_verdict_envelope_is_unchanged(self) -> None:
+    def test_reviewing_task_without_verdict_envelope_fails_loudly(self) -> None:
+        # #3654: this used to COMPLETE, which is how 138 reviewing tasks finished
+        # having recorded nothing while every open PR stayed unmergeable.
         task, _ = _reviewing_task_via_dispatch()
-        record_result_envelope(task, {"summary": "Reviewed.", "decisions": ["looks good"]}, phase="reviewing")
+        attempt = record_result_envelope(task, {"summary": "Reviewed.", "decisions": ["looks good"]}, phase="reviewing")
 
         assert not ReviewVerdict.objects.filter(slug=_SLUG, pr_id=_PR_ID).exists()
         assert MRReviewLock.objects.get(slug=_SLUG, pr_id=_PR_ID).state == MRReviewLock.State.REVIEW_DISPATCHED
         task.refresh_from_db()
-        assert task.status == Task.Status.COMPLETED
+        assert task.status == Task.Status.FAILED
+        assert "review_verdict" in attempt.error
 
 
 class TestOrchestratorRecordingAdvancesReviewLoop(TestCase):
@@ -134,8 +137,17 @@ class TestReviewingEvidenceAcceptsVerdict(TestCase):
         assert check_evidence(envelope, "reviewing") == ""
         assert validate_result_keys(envelope) == ""
 
-    def test_reviewing_without_verdict_or_decisions_still_fails_evidence(self) -> None:
+    def test_reviewing_without_a_verdict_fails_evidence(self) -> None:
         assert "missing required evidence" in check_evidence({"summary": "looked at it"}, "reviewing")
+
+    def test_decisions_alone_no_longer_substitutes_for_the_verdict(self) -> None:
+        # #3654: `decisions` was an accepted alternative, so a reviewer that never
+        # returned a verdict completed indistinguishably from one that did.
+        assert "missing required evidence" in check_evidence({"decisions": ["looks good"]}, "reviewing")
+
+    def test_verdict_outside_the_recorder_vocabulary_fails_evidence(self) -> None:
+        envelope = {"review_verdict": {"verdict": "PASS", "reviewer_identity": "cold-reviewer-agent"}}
+        assert "missing required evidence" in check_evidence(envelope, "reviewing")
 
 
 def _loop_reviewer_task(loop: ReviewLoop) -> Task:


### PR DESCRIPTION
Fixes #3654.

Autonomous merging has never worked: every open PR logs `solo_overlay_no_review`
on every sweep pass, and 159 reviewing tasks (138 completed) produced zero
verdicts. The merge sweep gates on an independent cold-review verdict bound to
the live head, and that verdict arrives through the agent result envelope — but
`agents/reviewer.md` never asked for the envelope. Its whole instruction on the
subject was prose telling the agent to terminate at a PASS/HOLD verdict, which
is not the schema's vocabulary. The agent finished, returned nothing, the
recorder wrote nothing.

Manually dispatched reviewers did produce verdicts, because they were told to
run the record command and had a shell — which is why this stayed hidden.

## What changed

**The reviewer is asked for the envelope, in the schema's own words.**
`agents/reviewer.md` now specifies the `review_verdict` object with its exact
field names and allowed values (`merge_safe` / `hold`, `green` / `pending` /
`failed`, `substrate` / `logic` / `docs`), and spells out that `reviewed_sha`
is the full 40-character SHA of the head actually reviewed — the merge gate
compares it against the forge's live head, so a short or stale SHA vouches for
nothing. The read-only and no-git-write constraints are unchanged. The headless
brief gained `blast_class` and the same explicit vocabulary/SHA wording.

**A missing envelope is now loud.** The `reviewing` evidence gate accepted
`decisions` as an alternative to `review_verdict`, so a review that recorded
nothing completed indistinguishably from one that worked — which is how 138
no-op reviews went unnoticed. It now requires a `review_verdict` carrying a
verdict the recorder can actually persist, so such a run FAILS. Scoped to
`reviewing`; every other phase is untouched. A blocked reviewer still
escalates through `needs_user_input` rather than failing.

## The safety floor is unchanged

The reviewer returns and the orchestrator records, so maker is not checker.
`has_independent_cold_review` and the merge gate are not touched — no verdict
is ever synthesised, and nothing merges without one. The bug was that a real
verdict never arrived; the fix delivers it.

## Tests

A new end-to-end test spans the whole chain — agent definition → headless brief
→ recorder → `has_independent_cold_review` → sweep decision — because a unit
test on either end passes today while the chain is broken.

RED on the pre-fix tree, GREEN after:

- `test_reviewer_definition_asks_for_the_envelope_in_the_schema_vocabulary` —
  RED: `assert 'review_verdict' in definition` fails against the old file.
- `test_reviewing_run_with_no_verdict_envelope_fails_the_task` —
  RED: `assert 'completed' == Task.Status.FAILED`.
- `test_reviewing_evidence_gate_accepts_only_the_verdict_channel`,
  `test_decisions_alone_no_longer_substitutes_for_the_verdict`,
  `test_verdict_outside_the_recorder_vocabulary_fails_evidence` —
  RED: `assert 'missing required evidence' in ''`.
- `test_headless_reviewing_brief_names_the_schema_fields_and_values` —
  RED: `assert 'blast_class' in ...`.

The happy path (envelope returned → verdict row → sweep merges instead of
flagging) and the stale-SHA case (verdict at a different head → still flagged,
no merge) both pass, pinning that the loudness change does not weaken the gate.

## Verification

- `uv run prek run --all-files` — exit 0.
- Scoped suites (`tests/teatree_agents`, the new chain test,
  `tests/teatree_loop/test_pr_sweep_scanner.py`, `test_dispatch.py`,
  `tests/conformance`, `test_merge_verdict_gate.py`,
  `test_review_record_triggers_sweep.py`): 1267 passed, 2 skipped, 3 xfailed.
- `makemigrations --check --dry-run`: no changes.
- The affected-tests selector escalates to FULL on a non-code file, so the
  sharded CI lane is the authority on the whole tree rather than a local
  duplicate on a shared box.

## Architecture pre-check

1. **BLUEPRINT §** — §17.4.2 / the auto-review-dispatch paragraph, which already
   states the reviewer RETURNS a typed `review_verdict` the orchestrator records.
   This brings the agent definition into line with it; no BLUEPRINT change.
2. **FSM phase boundaries** — no transition added or moved. The `reviewing`
   phase's terminal outcome changes from silently-complete to failed when no
   verdict is returned; the bounded auto-requeue sweep handles that as any
   other refusal.
3. **Extension-point contracts** — none. `PHASE_REQUIRED_EVIDENCE` and
   `_FIELD_PERSISTS` are internal data tables, both already the documented
   widen-the-table-not-the-harness seam.
4. **Component boundaries** — `agents/` (definition + brief + result schema)
   only; the loop and merge modules are read, never changed.
5. **Dependency direction** — no new cross-module import. The verdict-vocabulary
   predicate uses the same deferred ORM import the sibling predicates use.
   `tach` passed.
6. **Test surface** — the chain test above, plus the evidence-gate cases in
   `tests/teatree_agents/test_headless_review_verdict.py`.
7. **Resilience invariants** — unchanged. Recording stays idempotent per
   `(slug, pr_id, reviewed_sha)`; the sub-agent return contract is exactly what
   this PR repairs.
8. **Identity/key normalization** — the verdict token is normalized once
   (strip + lower) against the model's own choices, so gate and recorder read
   the same vocabulary.
9. **Behavior preservation** — one capability removed on purpose: `decisions`
   no longer satisfies the `reviewing` gate. That is the fix, not a narrowing
   of a safety matcher; no must-block test was inverted, and the one test that
   pinned the old silent-complete behaviour was strengthened to assert the
   failure.
10. **Removability / harness-vs-data** — the requirement lives in the data
    tables, not in harness logic: reverting is a one-line table edit. The
    per-phase policy stays data, the gate stays the generic mechanism.
