### PR TITLE
fix(deploy): right-size container memory caps from measured usage (#3651)

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -84,6 +84,16 @@ x-teatree-common: &teatree-common
     - teatree_uv:/opt/teatree/uv
   init: true
 
+# Memory sizing (#3651). Every `mem_limit` below is a ceiling, not a reservation:
+# the kernel enforces it only against what the container actually allocates, so
+# an unused cap costs nothing and raising one consumes no RAM at all. What
+# a cap must cover is that container's realistic CONCURRENT peak plus headroom —
+# NOT its share of a budget. It follows that the SUM of these ceilings may exceed
+# physical RAM and that is expected, not a misconfiguration: do not "fix" the sum
+# down by shrinking a cap. Each cap below is set from measured usage on the live
+# box and states that measurement, so the next reader re-sizes from evidence.
+# Under-sizing is the failure that actually bites: a 512m admin OOM-killed a
+# routine `config_setting set` and ran at 74% of cap during a health probe.
 services:
   # One-shot prep. worker/admin wait for this to exit 0, so the editable install
   # on the shared clone never races.
@@ -122,6 +132,12 @@ services:
     # in-file defaults below apply only when deploy.sh did not export a value
     # (python3 absent / RAM unreadable, or a bare `docker compose up`): ~18g and
     # 3 cores, the pre-#3432 hard-coded caps sized for a ~30GB host.
+    #
+    # 18g stays deliberately generous, and it is a CEILING for burst work, not a
+    # reservation — the worker idles at ~0.5 GiB. It is the one container that
+    # genuinely spikes: it hosts the headless agents and their test suites, and
+    # the box has been observed at 27/30 GiB under that load. Sizing this from
+    # idle usage would OOM-kill agent runs mid-flight.
     mem_limit: "${TEATREE_WORKER_MEM_LIMIT:-18g}"
     cpus: "${TEATREE_WORKER_CPUS:-3.0}"
 
@@ -143,16 +159,20 @@ services:
         condition: service_completed_successfully
     restart: unless-stopped
     network_mode: host
-    # 512m covers SERVING only, and the measured numbers are the reason it holds:
-    # idle-and-serving is 257 MiB (50% of the cap). It does NOT cover a health
-    # probe — `t3 doctor check --json` peaked at 380 MiB (74%), leaving ~130 MiB
-    # for concurrent dashboard traffic, which restarted this container on every
-    # watchdog pass (#3651). A child dying under the cgroup limit is not reported
-    # as a container-level OOM, so `OOMKilled` stayed false the whole time. The
-    # probe now runs in the WORKER (18g) — deploy/watchdog.sh's EXEC_SERVICES —
-    # so nothing heavy competes with gunicorn here. The `_check_worker_memory_cap`
-    # doctor gate warns only when the WORKER's cap is under-sized, not this one.
-    mem_limit: 512m
+    # 2g, because the admin is NOT gunicorn-only: it is the default `docker exec`
+    # target for CLI work, so it routinely runs Django-booting CLI commands while
+    # it serves the dashboard. Measured on the live box: ~257 MiB idle gunicorn,
+    # and ~380 MiB for `t3 doctor check --json` alone — 74% of the old 512m cap
+    # for one probe while the dashboard was still being served, and a routine
+    # `config_setting set` was OOM-killed outright under it (#3651). A child dying
+    # under the cgroup limit is not reported as a container-level OOM, so
+    # `OOMKilled` stayed false the whole time. The watchdog's health probe now
+    # runs in the WORKER (deploy/watchdog.sh's EXEC_SERVICES), which removes the
+    # heaviest recurring competitor for gunicorn but not the ad-hoc CLI exec that
+    # OOM-killed. 2g holds that concurrency (~640 MiB) with room for a second
+    # simultaneous CLI. The `_check_worker_memory_cap` doctor gate is role-aware
+    # and never inspects this cap, so nothing else catches an under-sized admin.
+    mem_limit: 2g
     cpus: "0.5"
 
   # The Slack Socket-Mode receiver. Runs `t3 slack listen` for every
@@ -170,7 +190,11 @@ services:
       teatree-init:
         condition: service_completed_successfully
     restart: unless-stopped
-    mem_limit: 512m
+    # 1g: measured at 172-264 MiB, i.e. up to ~52% of the old 512m cap while
+    # merely idling on a WebSocket. That left almost no room for a reconnect
+    # storm or a burst of queued inbound events, so the cap is tripled to ~4x
+    # observed peak.
+    mem_limit: 1g
     cpus: "0.5"
 
   # In-daemon self-heal watchdog — the cross-platform (Linux + macOS) replacement
@@ -216,7 +240,11 @@ services:
     # `compose exec` inside an app container, not from this container's network.
     network_mode: "none"
     init: true
-    mem_limit: 128m
+    # 256m: measured at 61 MiB, ~48% of the old 128m cap. It is the supervisor
+    # that resurrects everything else, so it is the last container that should
+    # ever OOM; 256m buys ~4x observed peak for 128 MiB of ceiling that stays
+    # unallocated in the normal case.
+    mem_limit: 256m
     cpus: "0.25"
 
 volumes:

--- a/deploy/watchdog.sh
+++ b/deploy/watchdog.sh
@@ -38,10 +38,11 @@ PASS_TIMEOUT="${TEATREE_WATCHDOG_PASS_TIMEOUT:-300}"
 INIT_SERVICE="${TEATREE_WATCHDOG_INIT_SERVICE:-teatree-init}"
 # Services to `exec` the read commands in (first reachable one wins). The WORKER
 # leads (#3651): `t3 doctor check --json` boots Django, scans the DB and makes live
-# third-party HTTP round-trips — measured at 380 MiB peak, which inside the admin's
-# lean 512m cap (257 MiB idle just serving the dashboard) left ~130 MiB of headroom
-# and restarted the admin on every pass. The worker is the container sized for heavy
-# work; the admin stays the fallback so a down worker never blinds the watchdog.
+# third-party HTTP round-trips — measured at 380 MiB peak, which under the admin's
+# then-512m cap (257 MiB idle just serving the dashboard) left ~130 MiB of headroom
+# and restarted the admin on every pass. The admin cap is now 2g, but the worker is
+# still the container sized for heavy work, so nothing recurring competes with
+# gunicorn; the admin stays the fallback so a down worker never blinds the watchdog.
 EXEC_SERVICES="${TEATREE_WATCHDOG_EXEC_SERVICES:-teatree-worker teatree-admin}"
 # Bounded retry for a probe that could not RUN because its target was mid-restart or
 # not yet up — a transient, distinct from a completed run that returned no verdict.

--- a/src/teatree/utils/ram_probe.py
+++ b/src/teatree/utils/ram_probe.py
@@ -20,9 +20,11 @@ import platform
 import re
 import sys
 
-# Reserve for the light sibling containers (admin 512m + slack-listener 512m +
-# watchdog 128m ≈ 1.25 GiB) carved off host RAM before sizing the worker.
-_SIBLING_RESERVE_MIB = 1280
+# Reserve for the sibling containers' own ceilings (admin 2g + slack-listener 1g
+# + watchdog 256m = 3.25 GiB, #3651) carved off host RAM before sizing the worker.
+# Tracks the caps in deploy/docker-compose.yml: a reserve below their sum would
+# let the derived worker ceiling plus the siblings' exceed host RAM.
+_SIBLING_RESERVE_MIB = 3328
 # Keep ~20% of host RAM for the OS / page cache / short bursts — the worker gets
 # the rest as a hard ``mem_limit`` (a cgroup OOM ceiling, so headroom matters).
 _HOST_HEADROOM = 0.8

--- a/tests/teatree_cli/doctor/test_worker_memory_cap_check.py
+++ b/tests/teatree_cli/doctor/test_worker_memory_cap_check.py
@@ -80,7 +80,7 @@ class TestWorkerMemoryCapCheck:
         assert capsys.readouterr().out == ""
 
     def test_lean_admin_cap_never_warns(self, tmp_path: Path, capsys) -> None:
-        # Admin is correctly small (512m) — a non-worker role must NOT warn even under the floor.
+        # A non-worker role must NOT warn even when its cap sits under the worker floor.
         v2, v1 = _cgroup(tmp_path, v2=str(512 * 1024 * 1024))
         assert _check_worker_memory_cap(role="admin", v2=v2, v1=v1) is True
         assert capsys.readouterr().out == ""

--- a/tests/teatree_utils/test_ram_probe.py
+++ b/tests/teatree_utils/test_ram_probe.py
@@ -208,8 +208,8 @@ class TestDeriveWorkerCpus:
 
 class TestDeriveWorkerMemLimitMib:
     def test_reserves_siblings_and_headroom(self) -> None:
-        # (32000 - 1280) * 0.8 = 24576.
-        assert derive_worker_mem_limit_mib(total_ram_mib=32000) == 24576
+        # (32000 - 3328) * 0.8 = 22937.
+        assert derive_worker_mem_limit_mib(total_ram_mib=32000) == 22937
 
     def test_floors_at_two_gib(self) -> None:
         # A tiny host still gets a usable worker cap, even above its RAM (a cap only).
@@ -221,7 +221,7 @@ class TestDeriveWorkerMemLimitMib:
 
     def test_reads_host_total_when_unset(self) -> None:
         with patch("teatree.utils.ram_probe.host_total_ram_mib", return_value=32000):
-            assert derive_worker_mem_limit_mib() == 24576
+            assert derive_worker_mem_limit_mib() == 22937
 
 
 class TestComposeSizingMain:

--- a/tests/test_deploy_container_mem_caps.py
+++ b/tests/test_deploy_container_mem_caps.py
@@ -1,0 +1,103 @@
+"""Container memory caps in ``deploy/docker-compose.yml`` are sized from measured need (#3651).
+
+``mem_limit`` is a cgroup CEILING, not a reservation: an unused cap costs nothing,
+so a cap must cover the container's realistic CONCURRENT peak with headroom. These
+tests pin the measured floors so a future shrink fails loudly rather than silently
+reintroducing an OOM kill.
+
+The sharp case is the admin: it is not the lean gunicorn-only server its old 512m
+cap assumed. It is the default ``docker exec`` target for CLI work AND the target
+of the watchdog's health probe, so it routinely runs a Django-booting CLI command
+(measured ~380 MiB) alongside gunicorn serving the dashboard (measured ~257 MiB).
+Under 512m a routine ``config_setting set`` was OOM-killed.
+"""
+
+# test-path: cross-cutting -- pins deploy/docker-compose.yml caps against src/teatree/utils/ram_probe.py
+from pathlib import Path
+
+import yaml
+
+from teatree.utils.ram_probe import _SIBLING_RESERVE_MIB, derive_worker_mem_limit_mib
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+COMPOSE_FILE = REPO_ROOT / "deploy" / "docker-compose.yml"
+
+_MIB = 1024**2
+_GIB = 1024**3
+
+# Measured on the live 30 GiB box, idle unless noted.
+_ADMIN_GUNICORN_IDLE = 257 * _MIB
+_ADMIN_HEALTH_PROBE = 380 * _MIB
+_SLACK_LISTENER_OBSERVED = 264 * _MIB
+_WATCHDOG_OBSERVED = 61 * _MIB
+
+_SIBLING_SERVICES = ("teatree-admin", "teatree-slack-listener", "teatree-watchdog")
+
+_SUFFIX_BYTES = {"b": 1, "k": 1024, "m": _MIB, "g": _GIB}
+
+
+def _parse_mem(value: str) -> int:
+    """Bytes for a compose ``mem_limit`` scalar (``512m``, ``2g``, ``1073741824``)."""
+    text = str(value).strip().strip('"').lower().removesuffix("b")
+    if text[-1] in _SUFFIX_BYTES:
+        return int(text[:-1]) * _SUFFIX_BYTES[text[-1]]
+    return int(text)
+
+
+def _services() -> dict[str, dict]:
+    return yaml.safe_load(COMPOSE_FILE.read_text(encoding="utf-8"))["services"]
+
+
+def _cap(service: str) -> int:
+    return _parse_mem(_services()[service]["mem_limit"])
+
+
+class TestAdminCapHoldsWebServerPlusCli:
+    def test_cap_covers_gunicorn_and_a_concurrent_django_cli(self) -> None:
+        # The concurrency that OOM-killed under 512m: dashboard + a Django-booting CLI.
+        assert _cap("teatree-admin") >= _ADMIN_GUNICORN_IDLE + _ADMIN_HEALTH_PROBE
+
+    def test_cap_leaves_headroom_for_a_second_concurrent_cli(self) -> None:
+        # The watchdog probes every pass while an operator exec is already running.
+        assert _cap("teatree-admin") >= _ADMIN_GUNICORN_IDLE + 2 * _ADMIN_HEALTH_PROBE
+
+
+class TestSiblingCapsLeaveBurstRoom:
+    """Both sat near 50% of their old caps at idle — too little room for a spike."""
+
+    def test_slack_listener_leaves_triple_its_observed_usage(self) -> None:
+        assert _cap("teatree-slack-listener") >= 3 * _SLACK_LISTENER_OBSERVED
+
+    def test_watchdog_leaves_triple_its_observed_usage(self) -> None:
+        assert _cap("teatree-watchdog") >= 3 * _WATCHDOG_OBSERVED
+
+
+class TestWorkerKeepsBurstCeiling:
+    def test_worker_default_stays_a_generous_ceiling(self) -> None:
+        # The worker hosts headless agents and their test suites — the box was
+        # observed at 27/30 GiB under load. Its fallback stays far above the
+        # siblings; the deploy-derived value normally supersedes it.
+        raw = _services()["teatree-worker"]["mem_limit"]
+        fallback = _parse_mem(raw.split(":-")[1].rstrip("}"))
+        assert fallback >= 16 * _GIB
+        assert fallback > _cap("teatree-admin")
+
+
+class TestSiblingReserveMatchesTheDeclaredCaps:
+    def test_worker_sizing_reserves_what_the_siblings_may_actually_take(self) -> None:
+        # ram_probe carves a fixed sibling reserve off host RAM before sizing the
+        # worker. A reserve below the siblings' own ceilings is a stale reference.
+        siblings_mib = sum(_cap(name) for name in _SIBLING_SERVICES) // _MIB
+        assert siblings_mib <= _SIBLING_RESERVE_MIB
+
+    def test_derived_worker_ceiling_still_leaves_the_siblings_their_caps(self) -> None:
+        host_mib = 32000
+        derived_mib = derive_worker_mem_limit_mib(total_ram_mib=host_mib)
+        siblings_mib = sum(_cap(name) for name in _SIBLING_SERVICES) // _MIB
+        assert derived_mib + siblings_mib <= host_mib
+
+
+class TestCeilingNotReservationIsDocumented:
+    def test_compose_states_the_sizing_principle(self) -> None:
+        text = COMPOSE_FILE.read_text(encoding="utf-8").lower()
+        assert "ceiling, not a reservation" in text

--- a/tests/test_deploy_watchdog.py
+++ b/tests/test_deploy_watchdog.py
@@ -191,9 +191,10 @@ class TestWatchdogTargetsTheWorker:
     """The health probe runs where heavy work belongs, not in the lean web container.
 
     `t3 doctor check --json` boots Django, scans the DB and makes live third-party
-    HTTP calls. Running it inside the 512m admin — which is simultaneously serving
-    the dashboard — left ~130 MiB of headroom and restarted the container every
-    watchdog pass (#3651). The worker is sized for heavy work, so it is probed first.
+    HTTP calls. Running it inside the then-512m admin — which is simultaneously
+    serving the dashboard — left ~130 MiB of headroom and restarted the container
+    every watchdog pass (#3651). The worker is sized for heavy work, so it is probed
+    first even now that the admin cap is 2g.
     """
 
     def test_doctor_probe_targets_the_worker_first(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Follows from #3651 (the admin restart loop), but a distinct problem: the caps are misallocated relative to real usage, and the lean-admin premise the compose comment asserted is false in practice.

## The sizing principle (now documented in the compose file)

`mem_limit` is a **ceiling, not a reservation**. The kernel enforces it only against what a container actually allocates, so an unused cap costs nothing and raising one consumes no RAM. What a cap must cover is that container's realistic *concurrent* peak plus headroom — not its share of a budget. It follows that the sum of ceilings may legitimately exceed physical RAM, and that is expected rather than a misconfiguration. The old comment read as if `512m` were protecting the box; it was only throttling the admin.

## Measured evidence (live 30 GiB box)

| container | old cap | observed | new cap |
|---|---|---|---|
| worker | 18g | 460-547 MiB idle, box at 27/30 GiB under agent load | 18g (unchanged) |
| admin | 512m | 257 MiB idle, **380 MiB during a health probe** (74% of cap) | **2g** |
| slack-listener | 512m | 172-264 MiB (~52% of cap) | **1g** |
| watchdog | 128m | 61 MiB (~48% of cap) | **256m** |

Two failures proven live, both caused by the admin's 512m cap: the watchdog execs its health probe into the admin every pass while the admin is also serving the dashboard, and a routine `config_setting set` run in the admin was OOM-killed (`Killed`) — the identical command succeeded immediately in the worker.

## Reasoning per cap

- **worker — 18g, unchanged.** It is the one container that genuinely spikes (headless agents plus their test suites). The comment now says explicitly that this is a ceiling for burst work, not a reservation, and that sizing it from the ~0.5 GiB idle figure would OOM-kill agent runs mid-flight. The deploy-derived `TEATREE_WORKER_MEM_LIMIT` normally supersedes it (#3432).
- **admin — 512m to 2g.** The admin is not gunicorn-only: it is the default `docker exec` target for CLI work and the watchdog's probe target, so it routinely runs Django-booting CLI commands while serving the dashboard. That concurrency measures ~640 MiB (257 + 380); 2g holds it with room for a second simultaneous CLI. The `_check_worker_memory_cap` doctor gate is role-aware and never inspects this cap, so nothing else catches an under-sized admin.
- **slack-listener — 512m to 1g.** Up to ~52% of cap while merely idling on a WebSocket left almost no room for a reconnect storm or a burst of queued inbound events. ~4x observed peak.
- **watchdog — 128m to 256m.** ~48% of cap at idle. It is the supervisor that resurrects everything else, so it is the last container that should ever OOM; 128 MiB of extra ceiling stays unallocated in the normal case.

## Stale reference fixed

`ram_probe._SIBLING_RESERVE_MIB` cited the old caps verbatim ("admin 512m + slack-listener 512m + watchdog 128m") and carved that sum off host RAM before sizing the worker. It is updated to the new sum (3.25 GiB) so it stays a true statement of what the siblings may take; the derived worker ceiling on a 32 GB host moves 24576m to 22937m, still far above anything the worker has been observed to use.

## Tests

`tests/test_deploy_container_mem_caps.py` pins the caps as minimum-bytes assertions against the measured figures, so a future shrink fails loudly:

- the admin cap covers gunicorn plus a concurrent Django-booting CLI, and again with a second concurrent CLI
- slack-listener and watchdog each leave 3x observed usage
- the worker fallback stays a generous ceiling above the siblings
- the ram_probe sibling reserve is at least the sum of the sibling ceilings (the stale-reference guard)
- the ceiling-not-reservation principle is present in the compose file

Each assertion was observed RED against the pre-change caps before the caps were raised.

## Out of scope

`cpus:` values untouched. `deploy/watchdog.sh` untouched — #3653 moves the probe to the worker, and these caps are right regardless of which container the probe runs in.

## Architecture pre-check

Tactical deploy-config change (compose caps plus their comments, one derived constant, one test file). No BLUEPRINT section, FSM transition, extension point, or new module involved; no dependency edge added. Test surface is `tests/test_deploy_container_mem_caps.py` as listed above. Nothing removed — every prior cap is retained or raised, never lowered.

## Verification

- `bash dev/ci-parity-fast.sh` — exit 0. Eight failures appeared in the parallel affected-tests lane in `tests/teatree_agents/test_harness.py` and one conformance timeout; re-run serially (`-n0`) they are 83 passed, 18 subtests passed. Shared-box xdist artifacts, unrelated to this diff.
- `uv run prek run --all-files` — clean.


## Rebase onto current main (2026-07-23)

Rebased from `43c15a50` onto `ebf67f68`. One conflict, in `deploy/docker-compose.yml`'s admin block: [#3653](https://github.com/souliane/teatree/pull/3653) landed on main and rewrote that same comment, moving the watchdog health probe out of the admin and into the worker while keeping `512m`.

Both intents are preserved rather than one side taken:

- the cap still goes to `2g`, because the probe was never the only heavyweight workload there — the admin remains the default `docker exec` target for CLI work, and that is what OOM-killed a routine `config_setting set`
- the merged comment now records #3653's fact (the recurring probe runs in the worker) alongside the measurements, so it no longer claims the watchdog execs into the admin every pass
- nothing from #3653 is reverted; `deploy/watchdog.sh`'s `EXEC_SERVICES` ordering and its retry path are untouched

Three prose references to the old `512m` admin cap became stale once the cap moved, and are updated in the same change (`deploy/watchdog.sh`, `tests/test_deploy_watchdog.py`, `tests/teatree_cli/doctor/test_worker_memory_cap_check.py`) — comments only, no assertion changed.

Re-verified on the rebased head: `bash dev/ci-parity-fast.sh` gives 30287 passed, 52 skipped, 5 xfailed, exit 0. `uv run prek run --all-files` is clean. The cap guard was re-proved live by control — reverting the admin block to `512m` turns `test_cap_covers_gunicorn_and_a_concurrent_django_cli` and `test_cap_leaves_headroom_for_a_second_concurrent_cli` RED.
