### PR TITLE
fix(hooks): bootstrap src/ before the cold DB read so gate flags resolve (https://github.com/souliane/teatree/issues/3499)

### DIFF
--- a/hooks/scripts/teatree_settings.py
+++ b/hooks/scripts/teatree_settings.py
@@ -18,8 +18,10 @@ resolves to the per-setting default, so a gate never silently flips its verdict
 (never-lockout).
 """
 
+import contextlib
 import os
 import sys
+from pathlib import Path
 
 # Alias both identities so a bare ``from teatree_settings import ...`` (the live
 # hook, whose dir is on sys.path) and ``hooks.scripts.teatree_settings`` (a
@@ -30,20 +32,61 @@ sys.modules.setdefault("hooks.scripts.teatree_settings", sys.modules[__name__])
 _GLOBAL_SCOPE = ""
 
 
-def _cold_db_bool(name: str) -> bool | None:
-    """The stored GLOBAL-scope DB bool for ``[teatree] <name>``; ``None`` on absence/failure.
+def _read_cold_setting(name: str) -> object | None:
+    """The stored GLOBAL-scope DB value for ``[teatree] <name>``, un-coerced; ``None`` on absence/failure.
 
-    Delegates to the Django-free ``teatree.config.cold_reader``, lazily imported so
-    this leaf stays import-light at load. Fails open to ``None`` on ANY error —
-    ``teatree`` not importable, an unreadable/locked DB, a missing row, a non-bool
-    value — so the caller's per-setting default still stands (never-lockout).
+    THE single seam through which every reader below reaches the canonical
+    ``ConfigSetting`` store, so the ``sys.path`` bootstrap can never be applied to
+    one reader and forgotten on its siblings.
+
+    It puts the sibling ``src/`` on ``sys.path`` for the duration of the import
+    (#3499). ``run-hook.sh`` execs the first ``python3.13|3.12|3.11|python3`` on
+    PATH — on a host where that is a bare system interpreter, ``teatree`` is not
+    installed in it, so an unbootstrapped ``from teatree.config.cold_reader import
+    read_setting`` raises ``ModuleNotFoundError``. The blanket ``except`` below then
+    swallows it and EVERY DB-home flag in this module silently resolves to its
+    compiled-in default — a total DB-read outage indistinguishable from "the
+    operator never opted in". ``hook_router`` puts only the PLUGIN ROOT on
+    ``sys.path``; ``src/`` is a separate entry every other leaf that imports
+    ``teatree`` bootstraps for itself.
+
+    The bootstrap is inlined rather than reusing ``managed_repo.teatree_src_on_path``
+    on purpose: this module is reachable with only the *scripts* dir on ``sys.path``
+    (``memory_recall`` inserts exactly that before importing us), where the
+    ``hooks.scripts.managed_repo`` import would not resolve — and the module contract
+    is to import nothing first-party at load.
+
+    Fails open to ``None`` on ANY error — ``teatree`` still not importable, an
+    unreadable/locked DB, a missing row — so each caller's per-setting default still
+    stands (never-lockout). The path entry is always removed again, so a hook process
+    that imports us never leaks a mutated ``sys.path`` into later handlers.
     """
+    src_dir = str(Path(__file__).resolve().parents[2] / "src")
+    added = src_dir not in sys.path
+    if added:
+        sys.path.insert(0, src_dir)
     try:
         from teatree.config.cold_reader import read_setting  # noqa: PLC0415 — deferred: cold-hook import
 
-        value = read_setting(name, scope=_GLOBAL_SCOPE)
+        return read_setting(name, scope=_GLOBAL_SCOPE)
     except Exception:  # noqa: BLE001 — crash-proof hook: any failure degrades silently, never breaks the tool call
         return None
+    finally:
+        if added:
+            with contextlib.suppress(ValueError):
+                sys.path.remove(src_dir)
+
+
+def _cold_db_bool(name: str) -> bool | None:
+    """The stored GLOBAL-scope DB bool for ``[teatree] <name>``; ``None`` on absence/failure.
+
+    Delegates to the Django-free ``teatree.config.cold_reader`` via
+    :func:`_read_cold_setting`, lazily imported so this leaf stays import-light at
+    load. Fails open to ``None`` on ANY error — ``teatree`` not importable, an
+    unreadable/locked DB, a missing row, a non-bool value — so the caller's
+    per-setting default still stands (never-lockout).
+    """
+    value = _read_cold_setting(name)
     return value if isinstance(value, bool) else None
 
 
@@ -78,12 +121,7 @@ def _cold_db_raw(name: str) -> object | None:
     ABSENT setting apart from one whose stored value is not a clean boolean. Fails
     open to ``None`` on any error.
     """
-    try:
-        from teatree.config.cold_reader import read_setting  # noqa: PLC0415 — deferred: cold-hook import
-
-        return read_setting(name, scope=_GLOBAL_SCOPE)
-    except Exception:  # noqa: BLE001 — crash-proof hook: any failure degrades silently, never breaks the tool call
-        return None
+    return _read_cold_setting(name)
 
 
 def teatree_bool_setting_loud(name: str, *, default: bool) -> bool:
@@ -122,12 +160,7 @@ def _cold_db_int(name: str) -> int | None:
     as a budget, so it returns ``None`` and the caller's default fires instead
     (never-lockout).
     """
-    try:
-        from teatree.config.cold_reader import read_setting  # noqa: PLC0415 — deferred: cold-hook import
-
-        value = read_setting(name, scope=_GLOBAL_SCOPE)
-    except Exception:  # noqa: BLE001 — crash-proof hook: any failure degrades silently, never breaks the tool call
-        return None
+    value = _read_cold_setting(name)
     if isinstance(value, bool) or not isinstance(value, int):
         return None
     return value

--- a/tests/config/test_autoload_db.py
+++ b/tests/config/test_autoload_db.py
@@ -16,6 +16,8 @@ import json
 import os
 import shutil
 import sqlite3
+import subprocess
+import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -23,6 +25,7 @@ from unittest.mock import patch
 import pytest
 from django.test import TestCase
 
+from hooks.scripts import teatree_settings
 from hooks.scripts.teatree_settings import autoload_enabled
 from teatree.config import get_effective_settings
 from teatree.core.models import ConfigSetting
@@ -123,3 +126,89 @@ class TestColdAutoloadEnabled:
     def test_env_truthy_wins_over_absent_db(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("T3_AUTOLOAD", "1")
         assert autoload_enabled() is True
+
+
+# Runs in a REAL subprocess whose ``sys.path`` is stripped of every entry that could
+# satisfy ``import teatree``, then imports the leaf under its BARE identity with only
+# the scripts dir on the path -- exactly how the live hook reaches it. Reports the
+# resolved value as JSON so the parent can assert on it.
+_NO_TEATREE_PROBE = """
+import json, sys
+from pathlib import Path
+
+sys.path[:] = [p for p in sys.path if p and not (Path(p) / "teatree" / "__init__.py").is_file()]
+try:
+    import teatree
+except ModuleNotFoundError:
+    pass
+else:
+    print(json.dumps({{"error": "probe is void: teatree still importable from {{}}".format(teatree.__file__)}}))
+    raise SystemExit(0)
+
+sys.path.insert(0, {scripts_dir!r})
+from teatree_settings import autoload_enabled, teatree_int_setting
+
+print(json.dumps({{"autoload": autoload_enabled(), "budget": teatree_int_setting("probe_budget", default=7)}}))
+"""
+
+
+class TestColdReadersBootstrapSrc:
+    """#3499: the cold readers must reach the DB when ``teatree`` is NOT already importable.
+
+    ``run-hook.sh`` execs the first ``python3.13|3.12|3.11|python3`` on PATH. Where that
+    resolves to a bare system interpreter, ``teatree`` is not installed in it, and
+    ``hook_router`` puts only the PLUGIN ROOT -- never the sibling ``src/`` -- on
+    ``sys.path``. So the lazy ``from teatree.config.cold_reader import read_setting``
+    raised ``ModuleNotFoundError``, the blanket ``except`` swallowed it, and EVERY
+    DB-home flag in the module silently resolved to its compiled-in default: a total
+    DB-read outage indistinguishable from "the operator never opted in". The observed
+    damage was ``autoload`` reading OFF while the store said ``True``, so no session
+    ever auto-engaged and every ``gate <name> disable/enable`` write was inert.
+
+    In-process tests cannot catch this -- pytest always has ``teatree`` importable --
+    hence the subprocess.
+    """
+
+    @staticmethod
+    def _run_probe(db: Path, tmp_path: Path) -> dict[str, object]:
+        scripts_dir = Path(teatree_settings.__file__).resolve().parent
+        env = {
+            "PATH": os.environ.get("PATH", ""),
+            "HOME": str(tmp_path),
+            "T3_CONFIG_DB": str(db),
+        }
+        proc = subprocess.run(
+            [sys.executable, "-c", _NO_TEATREE_PROBE.format(scripts_dir=str(scripts_dir))],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+            check=True,
+        )
+        payload = json.loads(proc.stdout.strip().splitlines()[-1])
+        assert "error" not in payload, payload["error"]
+        return payload
+
+    def test_db_true_enables_without_teatree_on_syspath(self, tmp_path: Path) -> None:
+        db = tmp_path / "db.sqlite3"
+        _make_config_db(db, autoload=True)
+        assert self._run_probe(db, tmp_path)["autoload"] is True
+
+    def test_int_budget_reads_db_without_teatree_on_syspath(self, tmp_path: Path) -> None:
+        """The bootstrap lives at the SHARED seam, so the int reader is fixed too.
+
+        ``7`` is the caller's default and ``11`` the stored row, so a value of ``11``
+        can only come from a DB read that actually succeeded.
+        """
+        db = tmp_path / "db.sqlite3"
+        _make_config_db(db, autoload=True)
+        conn = sqlite3.connect(db)
+        try:
+            conn.execute(
+                "INSERT INTO teatree_config_setting (scope, key, value) VALUES ('', 'probe_budget', ?)",
+                (json.dumps(11),),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        assert self._run_probe(db, tmp_path)["budget"] == 11


### PR DESCRIPTION
## What

`hooks/scripts/teatree_settings.py` was the only hook leaf doing the lazy
`from teatree.config.cold_reader import read_setting` without first putting the
sibling `src/` on `sys.path`.

All three cold readers (`_cold_db_bool`, `_cold_db_raw`, `_cold_db_int`) now go
through one `_read_cold_setting` seam that does the bootstrap and restores
`sys.path` in a `finally`, so it cannot be applied to one reader and forgotten on
its siblings.

## Why

`run-hook.sh` execs the first `python3.13|3.12|3.11|python3` on PATH. Where that
resolves to a bare system interpreter with no teatree installed, the import raised
`ModuleNotFoundError`, the blanket `except` swallowed it, `_cold_db_bool` returned
`None`, and every DB-home flag in the module silently resolved to its compiled-in
default. `hook_router` puts only the plugin root on `sys.path`; `src/` is a
separate entry every other leaf bootstraps for itself.

This is a total DB-read outage, not only an autoload bug. 14 cold-hook gates read
their kill-switches through this module, so `gate <name> disable/enable` wrote the
DB and had no effect on the hooks.

Reported symptom (#3499): `autoload` read OFF while the store said `True`, so no
session auto-engaged and the advisory told the operator to set a setting they had
already set.

## Verification

- New `TestColdReadersBootstrapSrc` drives a real subprocess whose `sys.path` is
  stripped of every entry that could satisfy `import teatree`, then imports the
  leaf under its bare identity. Observed **RED before the fix**
  (`assert False is True`, `assert 7 == 11`) and green after. In-process tests
  cannot catch this: pytest always has teatree importable.
- 258 green across the cold-hook, opt-in, session-start and lockout-regression
  lanes; `dev/ci-parity-fast.sh` clean.
- Live check on the real host, bare `/usr/bin/python3` from a neutral cwd:
  `autoload_enabled()` now returns `True`, matching the store, with `sys.path`
  restored afterwards.

## Cost

The readers now perform the sqlite read they were silently skipping: ~335 ms for
the first call in a hook process (importing teatree) and ~3.2 ms per read after.
`hook_router` already imports teatree for other paths in the same process, so the
one-time cost is usually already paid. No caching added — it would pin kill-switch
values mid-process for no measured benefit.

## Deferred

The issue also floats two follow-ups, neither included here: distinguishing
"import/DB broken" from "not opted in" in the advisory text, and a `t3 doctor`
probe that runs `autoload_enabled()` through the hook's interpreter to flag a
CLI/hook disagreement. The first largely dissolves now the outage is fixed; the
second is a separate mechanism worth its own change.
