### PR TITLE
fix(agents): teach the result-envelope contract in every headless brief

### DIFF
--- a/src/teatree/agents/envelope_contract.py
+++ b/src/teatree/agents/envelope_contract.py
@@ -1,0 +1,152 @@
+"""The model-agnostic result-envelope contract every headless brief teaches (#3660).
+
+The recorder refuses a run whose final output carries no JSON result envelope
+(``no_result_envelope``), and that refusal is correct — but the brief only ever
+gestured at the envelope in a trailing "if /t3:next is not available" fallback,
+which reads as optional to any model that was not the one the prompts were
+written against. On the metered router lane every headless task failed that way:
+real inference, real reasoning, prose result, zero recorded work.
+
+So the contract is stated here once, in full, and injected into EVERY phase's
+brief: the allowed keys (derived from :data:`RESULT_JSON_SCHEMA`, never a second
+hand-maintained list), the phase's required evidence field (derived from
+:data:`PHASE_REQUIRED_EVIDENCE`), and a literal minimal example the model can
+copy. This is the instruction half of the fix; schema enforcement on the binding
+would be strictly stronger, and the harness reports ``structured_output=False``
+where it is unreachable.
+"""
+
+import json
+from collections.abc import Mapping
+
+from teatree.agents.result_schema import RESULT_JSON_SCHEMA, AgentResult, required_evidence_for_phase
+from teatree.core.modelkit.phases import normalize_phase
+
+CONTRACT_HEADING = "# Result Envelope — REQUIRED OUTPUT CONTRACT"
+
+#: One minimal, schema-valid envelope fragment per evidence field, so the example
+#: the brief shows is the exact shape the recorder accepts rather than a paraphrase
+#: of it. Keyed on every field named in ``PHASE_REQUIRED_EVIDENCE``; a phase whose
+#: field is absent here degrades to a summary-only example (still a valid envelope).
+_EVIDENCE_EXAMPLES: Mapping[str, AgentResult] = {
+    "plan_text": {"plan_text": "1. Add X to module Y. 2. Wire the call site. 3. Test Z."},
+    "files_modified": {"files_modified": [{"path": "src/teatree/agents/prompt.py", "action": "modified"}]},
+    "tests_run": {"tests_run": [{"name": "tests/teatree_agents/test_prompt.py::test_contract", "passed": True}]},
+    "decisions": {"decisions": ["Kept the failure loud rather than synthesising an envelope."]},
+    "review_verdict": {
+        "review_verdict": {
+            "verdict": "merge_safe",
+            "reviewed_sha": "0" * 40,
+            "reviewer_identity": "<your reviewer id>",
+            "gh_verify_result": "green",
+            "blast_class": "logic",
+            "findings": [],
+        }
+    },
+    "critic_verdict": {
+        "critic_verdict": {
+            "grader_identity": "<your grader id>",
+            "items": [{"slug": "<rubric-item>", "status": "pass", "citation": "<file:line or command output>"}],
+        }
+    },
+    "directive_interpretation": {
+        "directive_interpretation": {
+            "interpreter_identity": "<your interpreter id>",
+            "constraint_statement": "<the directive as one enforceable constraint>",
+            "sketch": {"kind": "config_setting", "setting_key": "<setting>", "policy_chokepoint": "<module.function>"},
+        }
+    },
+    "directive_candidate": {
+        "directive_candidate": {
+            "reader_identity": "<your reader id>",
+            "is_directive": True,
+            "normalized_constraint": "<the constraint in one sentence>",
+            "cited_signal": "<the text you read it from>",
+        }
+    },
+    "commands_executed": {"commands_executed": ["git push -u origin HEAD", "gh pr create --base main"]},
+    "article_suggestions": {
+        "article_suggestions": [
+            {"title": "<article title>", "url": "https://example.com/article", "rationale": "<why it matters>"}
+        ]
+    },
+    "triage_recommendations": {
+        "triage_recommendations": [
+            {"issue_url": "https://github.com/<owner>/<repo>/issues/1", "verdict": "keep", "rationale": "<why>"}
+        ]
+    },
+    "answer": {"answer": {"text": "<the drafted reply, in the user's voice>", "thread_ref": "<thread ts, or ''>"}},
+}
+
+
+def allowed_keys() -> tuple[str, ...]:
+    """Every key the envelope schema permits — ``additionalProperties`` is false."""
+    properties = RESULT_JSON_SCHEMA.get("properties")
+    return tuple(str(key) for key in properties) if isinstance(properties, Mapping) else ()
+
+
+def envelope_example(phase: str) -> AgentResult:
+    """A minimal envelope for *phase* that satisfies the phase evidence gate."""
+    example: AgentResult = {"summary": "<one line: what you did and how you proved it>"}
+    for field in required_evidence_for_phase(phase):
+        evidence = _EVIDENCE_EXAMPLES.get(field)
+        if evidence is not None:
+            example.update(evidence)
+            break
+    example["needs_user_input"] = False
+    return example
+
+
+def _evidence_lines(phase: str) -> tuple[str, ...]:
+    """The phase-scoped "this key is also mandatory" clause, or the summary-only note."""
+    required = required_evidence_for_phase(phase)
+    if not required:
+        return (f"- Phase `{normalize_phase(phase) or phase}` requires no extra evidence key beyond `summary`.",)
+    fields = " or ".join(f"`{field}`" for field in required)
+    return (
+        f"- Phase `{normalize_phase(phase)}` ALSO requires a non-empty {fields}.",
+        "  A result without it is refused as missing evidence and the whole run is wasted.",
+    )
+
+
+def final_output_reminder_line(phase: str) -> str:
+    """The one-line restatement of the contract, placed last in the work prompt.
+
+    The full contract sits in the system context; recency is what a non-Claude
+    model actually acts on, so the work prompt closes by naming the phase's own
+    required key again rather than trusting the system prompt to carry it alone.
+    """
+    required = required_evidence_for_phase(phase)
+    keys = "`summary`" + ("" if not required else " and " + " or ".join(f"`{field}`" for field in required))
+    return (
+        f"6. FINAL OUTPUT: end with the JSON result envelope ({keys}) as the last thing you write — "
+        "prose with no envelope is refused and the run is discarded."
+    )
+
+
+def envelope_contract_lines(phase: str) -> tuple[str, ...]:
+    """The full envelope contract taught to a headless brief for *phase*.
+
+    Every phase gets it, verbatim: assuming the model already knows the format is
+    what let prose leak through on a lane whose model never saw these prompts.
+    """
+    return (
+        "",
+        CONTRACT_HEADING,
+        "",
+        "Your work is recorded ONLY if your final output contains the result envelope.",
+        "Prose with no envelope is refused (`no_result_envelope`) and the entire run is",
+        "discarded — there is no partial credit and no envelope is ever synthesised for you.",
+        "",
+        "- Emit exactly ONE JSON object as the very last thing you write. Nothing after it.",
+        "- Plain JSON — no markdown code fence, no trailing commentary, no explanation.",
+        "- `summary` (string) is required on every phase.",
+        "- `needs_user_input` is a boolean; when true, also set `user_input_reason` (string)",
+        "  and stop rather than guessing.",
+        *_evidence_lines(phase),
+        "- Use ONLY these keys — any other key is rejected outright:",
+        f"  {', '.join(allowed_keys())}",
+        "",
+        "Minimal valid envelope for this phase — copy this shape exactly:",
+        json.dumps(envelope_example(phase), indent=2),
+    )

--- a/src/teatree/agents/prompt.py
+++ b/src/teatree/agents/prompt.py
@@ -10,6 +10,7 @@ from teatree.agents.dispatch_preflight import (
     head_state_brief_lines,
     review_diff_brief_lines,
 )
+from teatree.agents.envelope_contract import envelope_contract_lines, final_output_reminder_line
 from teatree.agents.skill_injection import _explicit_load_name, _read_skill_contents, _read_skill_contents_scoped
 from teatree.agents.stage_skill_prompt import stage_precedence_line, stage_skills_present
 from teatree.config.agent_spawn import resolve_agent_config
@@ -176,6 +177,7 @@ def build_task_prompt(task: Task, *, skills: list[str] | None = None, stage_skil
             f"5. Before declaring done, run the FULL CI-equivalent local gate set: `{_VERIFY_GATES_COMMAND}`.",
             "   It runs BOTH commit-stage and push-stage hooks; a bare `prek run --all-files` SKIPS the",
             "   push-stage gates CI re-runs. Report its exit code as the green-proof.",
+            final_output_reminder_line(task.phase),
         ),
     )
 
@@ -491,16 +493,13 @@ def build_system_context(
             "- Comment only the non-obvious *why*; never narrate the *what* the code already shows.",
             "- Be RIGHT but concise: trim words, never a load-bearing fact, decision, or caveat.",
             "",
-            "When done, run /t3:next to wrap up. It will:",
-            "- Run /t3:retro (captures lessons while context is fresh)",
-            "- Emit the structured JSON result the pipeline needs",
-            "- Display a summary of what happened",
-            "",
-            "If /t3:next is not available, output a JSON object on the last line:",
-            '  {"summary": "...", "needs_user_input": false, "files_modified": [...], "next_steps": [...]}',
+            "When done, run /t3:next to wrap up (retro + the result envelope + a summary).",
+            "/t3:next is a convenience, not the contract: the envelope below is required either way,",
+            "so emit it yourself whenever /t3:next is unavailable or does not run.",
+            *envelope_contract_lines(task.phase),
             "",
             "IMPORTANT: If you cannot proceed without human input (design decision, access, clarification),",
-            "STOP immediately. Do not guess or work around it. Output:",
+            "STOP immediately. Do not guess or work around it. Emit the envelope with:",
             '  {"summary": "...", "needs_user_input": true, "user_input_reason": "Why you need input"}',
             "The pipeline will automatically create an interactive session for a human to continue your work.",
         ),

--- a/tests/teatree_agents/test_envelope_contract.py
+++ b/tests/teatree_agents/test_envelope_contract.py
@@ -1,0 +1,78 @@
+"""The headless brief teaches the result-envelope contract on EVERY phase (#3660).
+
+A model that never saw teatree's prompts does not infer the envelope from
+surrounding prose — on the metered router lane every headless task ran real
+inference and then failed ``no_result_envelope``. These assert the brief states
+the contract itself: required keys, allowed values, and a literal example whose
+shape actually satisfies the phase evidence gate.
+"""
+
+import json
+
+from django.test import SimpleTestCase, TestCase
+
+from teatree.agents.envelope_contract import CONTRACT_HEADING, allowed_keys, envelope_contract_lines, envelope_example
+from teatree.agents.prompt import build_system_context
+from teatree.agents.result_schema import RESULT_JSON_SCHEMA, check_evidence, required_evidence_for_phase
+from teatree.core.models import Session, Task, Ticket
+
+_WORK_PHASE = "coding"
+_VERIFICATION_PHASE = "reviewing"
+
+
+def _contract_example(text: str) -> dict[str, object]:
+    """The JSON example embedded in the contract block of *text*."""
+    block = text.split(CONTRACT_HEADING, 1)[1]
+    start = block.index("{")
+    decoded, _ = json.JSONDecoder().raw_decode(block, start)
+    assert isinstance(decoded, dict)
+    return decoded
+
+
+class TestEnvelopeContractText(SimpleTestCase):
+    def test_allowed_keys_come_from_the_schema(self) -> None:
+        properties = RESULT_JSON_SCHEMA["properties"]
+        assert isinstance(properties, dict)
+        assert set(allowed_keys()) == set(properties)
+
+    def test_every_phase_states_the_contract_and_names_its_evidence_key(self) -> None:
+        for phase in ("coding", "reviewing", "testing", "planning", "shipping", "answering", "scanning_news"):
+            text = "\n".join(envelope_contract_lines(phase))
+            assert CONTRACT_HEADING in text, phase
+            assert "no_result_envelope" in text, phase
+            for field in required_evidence_for_phase(phase):
+                assert f"`{field}`" in text, (phase, field)
+
+    def test_example_satisfies_the_phase_evidence_gate(self) -> None:
+        # A brief whose example would itself be refused teaches the wrong shape.
+        for phase in ("coding", "reviewing", "testing", "planning", "shipping", "answering", "scanning_news"):
+            assert check_evidence(envelope_example(phase), phase) == "", phase
+
+    def test_example_uses_only_schema_declared_keys(self) -> None:
+        for phase in ("coding", "reviewing", "shipping"):
+            assert set(envelope_example(phase)) <= set(allowed_keys()), phase
+
+
+class TestSystemContextCarriesTheContract(TestCase):
+    def _context(self, phase: str) -> str:
+        ticket = Ticket.objects.create(issue_url="https://example.com/issues/3660")
+        session = Session.objects.create(ticket=ticket)
+        task = Task.objects.create(ticket=ticket, session=session, phase=phase)
+        return build_system_context(task, skills=[])
+
+    def test_work_phase_brief_teaches_keys_and_example(self) -> None:
+        context = self._context(_WORK_PHASE)
+        assert CONTRACT_HEADING in context
+        assert "files_modified" in context
+        assert check_evidence(_contract_example(context), _WORK_PHASE) == ""
+
+    def test_verification_phase_brief_teaches_keys_and_example(self) -> None:
+        context = self._context(_VERIFICATION_PHASE)
+        assert CONTRACT_HEADING in context
+        assert "review_verdict" in context
+        assert check_evidence(_contract_example(context), _VERIFICATION_PHASE) == ""
+
+    def test_phase_without_required_evidence_still_teaches_the_contract(self) -> None:
+        context = self._context("scoping")
+        assert CONTRACT_HEADING in context
+        assert check_evidence(_contract_example(context), "scoping") == ""

--- a/tests/teatree_agents/test_envelope_contract.py
+++ b/tests/teatree_agents/test_envelope_contract.py
@@ -11,7 +11,13 @@ import json
 
 from django.test import SimpleTestCase, TestCase
 
-from teatree.agents.envelope_contract import CONTRACT_HEADING, allowed_keys, envelope_contract_lines, envelope_example
+from teatree.agents.envelope_contract import (
+    CONTRACT_HEADING,
+    allowed_keys,
+    envelope_contract_lines,
+    envelope_example,
+    final_output_reminder_line,
+)
 from teatree.agents.prompt import build_system_context
 from teatree.agents.result_schema import RESULT_JSON_SCHEMA, check_evidence, required_evidence_for_phase
 from teatree.core.models import Session, Task, Ticket
@@ -42,6 +48,14 @@ class TestEnvelopeContractText(SimpleTestCase):
             assert "no_result_envelope" in text, phase
             for field in required_evidence_for_phase(phase):
                 assert f"`{field}`" in text, (phase, field)
+
+    def test_final_output_reminder_names_the_phase_evidence_key(self) -> None:
+        line = final_output_reminder_line(_WORK_PHASE)
+        assert "`files_modified`" in line
+        assert "refused" in line
+
+    def test_final_output_reminder_on_a_phase_with_no_evidence_key(self) -> None:
+        assert "`summary`" in final_output_reminder_line("scoping")
 
     def test_example_satisfies_the_phase_evidence_gate(self) -> None:
         # A brief whose example would itself be refused teaches the wrong shape.


### PR DESCRIPTION
Fixes #3660.

Headless tasks on the metered router lane executed real inference and then failed
every time with `no_result_envelope`: the agent reasoned normally in prose and
never emitted JSON. The refusal is correct; the defect is that the brief only
mentioned the envelope in a trailing fallback clause, which a model the prompts
were not written against reads as optional context rather than an output contract.

## What changed

New `src/teatree/agents/envelope_contract.py` derives the contract from the two
existing sources of truth, so it cannot drift:

- allowed keys from `RESULT_JSON_SCHEMA` (`additionalProperties: false`)
- the phase's mandatory evidence key from `PHASE_REQUIRED_EVIDENCE`
- a literal minimal example whose shape is asserted to pass `check_evidence`
  for that phase

`build_system_context` injects the block on **every** phase (not just reviewing),
stated as an output requirement with the example to copy. `build_task_prompt`
closes with a one-line restatement naming the phase's own key, because recency is
what the model acts on. The old conditional "output a JSON object if /t3:next is
unavailable" line is gone — it made the envelope optional; it now says the
envelope is required either way.

## Failure stays loud

`no_result_envelope` is untouched: prose with no envelope still records a FAILED
attempt, never a warning, never a synthesised envelope. Existing coverage
(`test_headless_no_envelope_guard.py`) still passes.

## Structured-output enforcement: not achievable on this binding today

Schema enforcement would be strictly stronger than instruction, so I checked it
first. It is not reachable without redesigning the lane's result path:

- The session drains the run with `StreamedRunResult.stream_text(delta=True)`
  (`pydantic_ai_session.py`) and the recorder scrapes the last JSON object out of
  that text. With a structured `output_type`, pydantic_ai's OpenAI-compatible
  binding returns the final output through a `final_result` tool call, so
  `stream_text` yields nothing and the envelope disappears entirely — the whole
  drain/parse/record chain would have to change.
- The envelope is `total=False` with ~20 optional keys and a per-phase evidence
  requirement; strict structured output on the OpenAI-compatible surface requires
  every property to be required, which contradicts the phase-varying shape.

So the capability flag stays honest: both `PYDANTIC_AI_ROUTER_CAPABILITIES` and
`PYDANTIC_AI_NATIVE_CAPABILITIES` report `structured_output=False`, already pinned
by `tests/teatree_agents/test_pydantic_ai_config.py`. Worth a follow-up issue;
instruction-in-the-brief is what unblocks the lane now.

## Tests

`tests/teatree_agents/test_envelope_contract.py` — RED before the change on the
three brief assertions:

- the contract text is present in the brief for a work phase (`coding`) and a
  verification phase (`reviewing`), naming that phase's evidence key
- the embedded example parses and satisfies `check_evidence` for its phase
- allowed keys are derived from the schema, not a second hand-kept list

## Architecture pre-check

1. **BLUEPRINT** — no change: this is prompt content under the existing headless
   dispatch contract.
2. **FSM phase boundaries** — none crossed; the block is keyed on the canonical
   phase token via `normalize_phase`.
3. **Extension-point contracts** — none touched.
4. **Component boundaries** — new module in `teatree/agents/`, alongside
   `result_schema` / `prompt`.
5. **Dependency direction** — `agents.envelope_contract` imports
   `agents.result_schema` + `core.modelkit.phases` only; tach passed.
6. **Test surface** — `tests/teatree_agents/test_envelope_contract.py` (mirrors
   the module path).
7. **Resilience invariants** — n/a, no external write.
8. **Identity/key normalization** — phase tokens go through `normalize_phase`.
9. **Behavior preservation** — the only removal is the conditional framing of the
   envelope, replaced by an unconditional requirement. No gate narrowed;
   `no_result_envelope` untouched.
10. **Removability / harness-vs-data** — one module plus two call sites; deleting
    it reverts to the prior brief. The varying part (per-field examples) is data
    in a typed table, the harness is the generic renderer.
