### PR TITLE
feat(slack): read channel history with the user token, interact with the bot token

### DIFF
--- a/src/teatree/backends/slack/bot.py
+++ b/src/teatree/backends/slack/bot.py
@@ -260,24 +260,23 @@ class SlackBotBackend:  # noqa: PLR0904 — method count reflects the MessagingB
 
         The single, deterministic token-selection policy consulted by
         every outbound surface — ``post_message`` / ``post_reply`` /
-        ``react`` / ``get_reactions`` (all ``SlackOp.WRITE``) — and, via
-        the shared
+        ``react`` / ``get_reactions`` (all ``SlackOp.WRITE``) and the
+        genuine-viewing ``fetch_channel_history_or_refuse``
+        (``SlackOp.READ``) — and, via the shared
         :func:`teatree.backends.slack.token_policy.channel_token` helper,
         by the review-request dedup guard's read-as-the-post
-        (``resolve_channel_token`` → ``SlackOp.WRITE``, so read-token ==
-        post-token #1084). Connect membership is only probed when both
-        credentials exist (the helper short-circuits the single-token /
-        DM cases first), preserving the legacy no-probe behaviour. When
-        the probe cannot confirm membership the policy falls back by
-        ``op``: a ``READ`` fails safe to the bot token (a bot-token read
-        of an unreachable Connect channel is empty at worst), a ``WRITE``
-        fails toward the user ``xoxp`` token (the bot token is rejected
-        on a Connect channel and the partner write is silently dropped).
+        (``resolve_channel_token`` → ``SlackOp.WRITE``, read-token ==
+        post-token #1084). Connect membership is probed only for a WRITE
+        with both credentials (single-token / DM short-circuit first). A
+        ``READ`` routes to the user token on any non-DM channel without
+        probing — the bot ``conversations.info`` call would be wasted, and
+        a transport failure on it would spuriously abort a read the user
+        token could serve.
         """
         assert_owner_dm(
             channel, owner_dm_only=self._owner_dm_only, dm_channel_id=self._dm_channel_id, user_id=self._user_id
         )
-        if not self._user_token or not self._bot_token or channel.startswith("D"):
+        if not self._user_token or not self._bot_token or channel.startswith("D") or op is SlackOp.READ:
             return channel_token(
                 channel,
                 bot_token=self._bot_token,
@@ -412,14 +411,15 @@ class SlackBotBackend:  # noqa: PLR0904 — method count reflects the MessagingB
     def fetch_channel_history_or_refuse(self, *, channel: str, limit: int = 50) -> list[RawAPIDict]:
         """Like :meth:`fetch_channel_history` but raises :class:`ChannelReadRefusedError`.
 
-        The seam for a caller asking about ONE channel interactively, where an empty
-        list is a misleading answer: a bot token reads only channels the bot was
-        invited to, and Slack reports that as ``not_in_channel`` /
-        ``channel_not_found`` — a fact the caller must hear, not a silent ``[]``.
+        The MCP ``slack_channel_history`` seam — a GENUINE viewing read, not a
+        read-as-post — so it routes under :attr:`SlackOp.READ` through the user
+        ``xoxp`` token: the agent sees the same channels and history the user sees,
+        not the bot's view of only the channels it was invited to. A channel neither
+        can read still refuses loudly, never a misleading ``[]``.
         """
         if not channel:
             raise ChannelReadRefusedError(channel, "empty_channel_argument")
-        token = self._channel_token(channel, op=SlackOp.WRITE)
+        token = self._channel_token(channel, op=SlackOp.READ)
         messages = read_channel_history_or_refuse(get=self._get, channel=channel, token=token, limit=limit)
         return self._strip_own_tts_audio(messages)
 

--- a/src/teatree/backends/slack/token_policy.py
+++ b/src/teatree/backends/slack/token_policy.py
@@ -1,38 +1,49 @@
 """The single deterministic Slack token-selection policy (#1084, #1110).
 
-Extracted verbatim from ``SlackBotBackend._channel_token`` so the
-review-request dedup guard reads channel history with the **same** token
-the post will go out under. A Slack-Connect externally-shared channel
-rejects the bot token (``xoxb-…``) with
-``mcp_externally_shared_channel_restricted`` for *both* posting and
-reading history — so the guard's live read MUST use the user OAuth token
-(``xoxp-…``) exactly when the post would. Read-token == post-token is a
-load-bearing correctness invariant: a dedup that reads with a token the
-channel rejects would always see an empty history and never suppress a
-duplicate.
+Extracted verbatim from ``SlackBotBackend._channel_token``. The policy
+is consulted for two operation classes, distinguished by the required
+keyword-only ``op``, and it routes reads and writes to *different*
+tokens by design.
 
-The reads-fail-safe-to-bot invariant (#1110). The policy is consulted
-for two operation classes, distinguished by the required keyword-only
-``op``. A ``SlackOp.READ`` is a history/metadata read: the bot token
-can always read its own metadata, and on an *unreachable* Connect
-channel a bot-token history read returns an empty list at worst (the
-#1084 dedup tolerates that), so a READ on an *ambiguous* channel
-(Connect membership could not be confirmed) stays conservative on the
-bot token — reads fail safe to the bot. A ``SlackOp.WRITE`` is a
-``chat.postMessage`` / reaction / a read taken *as the post* (the
-#1084 guard): a Connect channel rejects the bot token outright, so a
-silent bot-token write would post under the wrong identity or drop the
-partner write entirely, hence a WRITE on an *ambiguous* channel fails
-*toward* the user ``xoxp`` token (the only token that can reach a
-Connect channel), never silently toward the bot. Writes / reactions in
-a shared or ambiguous context fail toward the user xoxp.
+Reads go out under the USER token. A ``SlackOp.READ`` is a genuine
+history/metadata read taken to *view* a channel — the MCP
+``slack_channel_history`` tool, an interactive "what's in this channel"
+read. The bot token (``xoxb-…``) reads only channels the bot was
+invited to, so a bot-token read reports ``[]`` for every channel the
+user is in but the bot is not — the agent silently misses the user's
+own channels. Routing a general read through the user OAuth token
+(``xoxp-…``) makes the agent see exactly the channels and history the
+user sees. The only read kept on the bot is a DM read (see below).
+
+Writes go out under the interaction token. A ``SlackOp.WRITE`` is a
+``chat.postMessage`` / reaction, OR a read taken *as the post* — the
+#1084 review-request dedup guard reads channel history and must read
+with the SAME token its subsequent post/reaction will go out under
+(read-token == post-token). That guard passes ``SlackOp.WRITE``, so it
+flows the WRITE branch and is unchanged by the read-as-user rule above:
+a Connect channel rejects the bot token (``xoxb-…``) with
+``mcp_externally_shared_channel_restricted`` for *both* posting and
+reading, so a dedup that read under the bot would see an empty history
+and never suppress a duplicate. Read-token == post-token stays a
+load-bearing correctness invariant on the WRITE path.
+
+The write-side fail-toward-user invariant (#1110). On the WRITE path a
+confirmed Connect channel routes to the user ``xoxp`` (the bot is
+rejected outright), a confirmed internal channel interacts as the bot
+``xoxb``, and an *ambiguous* channel (Connect membership could not be
+confirmed) fails *toward* the user ``xoxp`` — the only token that can
+reach a Connect channel — never silently toward a bot the channel may
+reject.
 
 ``is_ext_shared`` is tri-state: ``True`` (confirmed externally-shared),
 ``False`` (confirmed internal), or ``None`` (membership could not be
-confirmed — ``conversations.info`` failed). Only the ``None`` case
-consults ``op``; confirmed ``True`` / ``False`` and the
-single-credential / DM short-circuits are bit-for-bit unchanged from
-#1084.
+confirmed — ``conversations.info`` failed). Only the WRITE path
+consults ``is_ext_shared``; a READ routes to the user token on any
+non-DM channel without probing membership. The single-credential and
+DM short-circuits are bit-for-bit unchanged from #1084, and the whole
+policy activates only when a user token is configured (the
+``if not user_token`` short-circuit) — a bot-token-only deployment is
+unchanged.
 """
 
 from enum import Enum
@@ -41,9 +52,10 @@ from enum import Enum
 class SlackOp(Enum):
     """The operation class an outbound token request is for (#1110).
 
-    ``READ`` is a history / metadata read; ``WRITE`` is a post,
-    reaction, or a read taken *as the post* (the #1084 dedup guard).
-    Only the ambiguous (``is_ext_shared is None``) branch consults it.
+    ``READ`` is a genuine history / metadata read taken to *view* a
+    channel (routed to the user token so the agent sees what the user
+    sees); ``WRITE`` is a post, reaction, or a read taken *as the post*
+    (the #1084 dedup guard — routed to the interaction token).
     """
 
     READ = "read"
@@ -61,15 +73,25 @@ def channel_token(
     """The token authorising an outbound call to (or a history read of) *channel*.
 
     No user (``xoxp``) token configured -> bot token (the legacy
-    single-credential case; nothing to route to).
+    single-credential case; nothing to route to — the whole read-as-user
+    policy activates only once a user token exists).
 
     No bot token configured -> user token. There is no second credential
     to probe Connect membership with, and the user-token-only deployment
     intends every call to go out under the user's identity anyway.
 
     A DM channel (id starts with ``D``) -> bot token. DMs are scoped to
-    the bot's own IM channels; routing them through the user token would
+    the bot's own IM channels; a user-token read of the bot's DM history
+    would be wrong, and routing a DM post through the user token would
     impersonate the user against their own DM history.
+
+    A ``SlackOp.READ`` on any non-DM channel -> user token. A general
+    history/metadata read routes through the user's identity so the
+    agent sees exactly the channels and history the user sees — the bot
+    token reads only the channels the bot was invited to.
+
+    The remaining cases are all WRITE (a post, a reaction, or a read
+    taken *as the post* — the #1084 dedup guard):
 
     A *confirmed* Slack-Connect externally-shared channel
     (``is_ext_shared is True``) -> user token. The bot token is rejected
@@ -77,17 +99,13 @@ def channel_token(
     ``xoxp`` is a partner-channel member and can post and read.
 
     A *confirmed* ordinary internal channel (``is_ext_shared is False``)
-    -> bot token.
+    -> bot token — interact as the bot.
 
     An *ambiguous* channel (``is_ext_shared is None`` — Connect
-    membership could not be confirmed): ``op`` decides. A
-    ``SlackOp.READ`` falls safe to the bot token (reads fail safe to the
-    bot — a bot-token read of an unreachable Connect channel is empty at
-    worst, which the #1084 dedup tolerates). A ``SlackOp.WRITE`` fails
-    *toward* the user ``xoxp`` token (writes / reactions in a shared or
-    ambiguous context fail toward the user xoxp — a silent bot-token
+    membership could not be confirmed) -> user token. A silent bot-token
     write to a Connect channel is rejected and the partner write is
-    dropped).
+    dropped, so an ambiguous write fails *toward* the user ``xoxp`` — the
+    only token that can reach a Connect channel.
     """
     if not user_token:
         return bot_token
@@ -95,8 +113,9 @@ def channel_token(
         return user_token
     if channel.startswith("D"):
         return bot_token
-    if is_ext_shared is True:
+    if op is SlackOp.READ:
         return user_token
-    if is_ext_shared is False:
-        return bot_token
-    return bot_token if op is SlackOp.READ else user_token
+    # WRITE: only a confirmed-internal channel interacts as the bot; a confirmed
+    # Connect (True) or an unconfirmed (None) channel fails toward the user xoxp —
+    # the only token that can reach a Connect channel the bot would be rejected on.
+    return bot_token if is_ext_shared is False else user_token

--- a/src/teatree/cli/doctor/app.py
+++ b/src/teatree/cli/doctor/app.py
@@ -63,6 +63,7 @@ from teatree.cli.doctor.checks_session import (
     _check_interactive_permission_mode,
     _check_slack_socket_mode,
 )
+from teatree.cli.doctor.checks_slack_engagement import check_slack_engagement
 from teatree.cli.doctor.checks_slack_roundtrip import check_slack_roundtrip
 from teatree.cli.doctor.checks_worktree_health import check_worktree_health
 from teatree.cli.doctor.dev_sources import (
@@ -154,6 +155,7 @@ __all__ = (
     "_write_dev_sources_marker",
     "agent_skill_dirs",
     "check",
+    "check_slack_engagement",
     "check_slack_roundtrip",
     "check_statusline",
     "check_statusline_freshness",
@@ -464,6 +466,12 @@ def run_doctor_checks(*, repair: bool = False, slack_roundtrip: bool = False) ->
     # must be a doctor FAILURE, not a surprise. `--slack-roundtrip` adds a live
     # auth.test. A silent no-op with no Slack-backed overlay (Slack stays optional).
     ok = check_slack_roundtrip(deep=slack_roundtrip) and ok
+
+    # Slack engagement (#256): WARN when `autoload` is OFF yet a Slack posting token
+    # is configured — with engagement default-off a session never engages teatree, so
+    # a configured bot never routes Slack through the MCP tools. Surfacing-only (never
+    # gates the exit code): `autoload` off is a legitimate colleague/opted-out posture.
+    check_slack_engagement()
 
     ok = _check_claude_session_posture() and ok
 

--- a/src/teatree/cli/doctor/checks_slack_engagement.py
+++ b/src/teatree/cli/doctor/checks_slack_engagement.py
@@ -1,0 +1,73 @@
+"""``t3 doctor`` — WARN when ``autoload`` is off yet Slack posting is configured (#256).
+
+With engagement default-OFF (``autoload`` off, #256) a session never engages
+teatree, so it never routes Slack through the MCP tools — a bot configured with a
+``slack_token_ref`` then reacts/posts nothing through the agent surface even though
+the credentials are present. This surfacing-only check WARNs the moment those two
+facts coexist and names the one-line fix. Slack stays optional: with no
+Slack-configured overlay it is a silent no-op.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import typer
+
+from teatree.cli.slack.socket_doctor import Level
+
+
+@dataclass(frozen=True, slots=True)
+class EngagementFinding:
+    """One Slack-engagement observation the doctor renders on its own line."""
+
+    level: Level
+    message: str
+
+
+def evaluate_slack_engagement(*, autoload: bool, slack_overlays: list[str]) -> EngagementFinding | None:
+    """WARN when ``autoload`` is off yet Slack posting is configured; ``None`` otherwise.
+
+    Pure decision so the two facts — engagement off, Slack configured — can be
+    asserted directly. ``autoload`` on, or no Slack-configured overlay, is a clean
+    no-op.
+    """
+    if autoload or not slack_overlays:
+        return None
+    names = ", ".join(sorted(slack_overlays))
+    return EngagementFinding(
+        Level.WARN,
+        f"`autoload` is OFF but Slack posting is configured ({names}) — with engagement default-off "
+        "(#256) sessions never engage teatree, so Slack never routes through the MCP tools and the "
+        "bot reacts/posts nothing through the agent. Enable engagement: `config_setting set autoload true`.",
+    )
+
+
+def _slack_configured_overlays() -> list[str]:
+    """Overlays declaring the Slack backend WITH a ``slack_token_ref`` posting entry."""
+    from teatree.cli.slack.app_resolve import read_overlay_field  # noqa: PLC0415 — deferred: ORM-backed registry read
+    from teatree.cli.slack.provision import _slack_overlays  # noqa: PLC0415 — deferred: ORM-backed registry read
+
+    return [overlay for overlay in _slack_overlays() if read_overlay_field(overlay, "slack_token_ref")]
+
+
+def check_slack_engagement(*, echo: Callable[[str], object] = typer.echo) -> bool:
+    """Render the engagement WARN if it applies; always returns ``True`` (surfacing-only).
+
+    Never gates the doctor exit code — Slack is optional and ``autoload`` off is a
+    legitimate colleague/opted-out posture; the WARN only flags the *combination*
+    where a configured bot is silently inert.
+    """
+    from teatree.config import get_effective_settings  # noqa: PLC0415 — deferred: keeps CLI startup light
+
+    try:
+        autoload = bool(get_effective_settings().autoload)
+        overlays = _slack_configured_overlays()
+    except Exception:  # noqa: BLE001 — a doctor check must never crash the run
+        return True
+    finding = evaluate_slack_engagement(autoload=autoload, slack_overlays=overlays)
+    if finding is not None:
+        echo(f"{finding.level.value:<5} Slack engagement: {finding.message}")
+    return True
+
+
+__all__ = ["EngagementFinding", "check_slack_engagement", "evaluate_slack_engagement"]

--- a/tests/teatree_backends/test_slack_connect_channel_routing.py
+++ b/tests/teatree_backends/test_slack_connect_channel_routing.py
@@ -300,16 +300,18 @@ class TestChannelTokenIsTheSingleSelectionPoint:
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
         assert backend._channel_token(_EXT_SHARED, op=slack_bot.SlackOp.WRITE) == "xoxp-user"
 
-    def test_channel_token_read_still_uses_bot_on_info_failure(
+    def test_channel_token_read_uses_user_token_and_skips_the_probe(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A READ in an ambiguous channel stays on the bot token.
+        """A genuine READ routes to the user token and never probes membership.
 
-        The bot can always read its own metadata; on an unreachable
-        Connect channel a bot-token history read returns an empty list
-        at worst — which the #1084 dedup tolerates. READ stays
-        conservative on the bot token; only WRITE fails toward xoxp.
+        The pre-flip policy routed an ambiguous READ to the bot token
+        (asserted ``== "xoxb-bot"`` here). The new intent: a general
+        viewing read goes out under the user ``xoxp`` on any non-DM
+        channel so the agent sees what the user sees — and because a READ
+        never consults ``is_ext_shared``, the bot ``conversations.info``
+        probe is skipped entirely (no GET is issued).
         """
         captured: list[dict[str, object]] = []
 
@@ -328,7 +330,8 @@ class TestChannelTokenIsTheSingleSelectionPoint:
         monkeypatch.setattr(slack_http.httpx, "post", fake_post)
 
         backend = SlackBotBackend(bot_token="xoxb-bot", user_token="xoxp-user")
-        assert backend._channel_token(_EXT_SHARED, op=slack_bot.SlackOp.READ) == "xoxb-bot"
+        assert backend._channel_token(_EXT_SHARED, op=slack_bot.SlackOp.READ) == "xoxp-user"
+        assert captured == []  # no conversations.info probe for a READ
 
     def test_react_on_info_failed_channel_uses_user_token(
         self,

--- a/tests/teatree_backends/test_slack_token_policy.py
+++ b/tests/teatree_backends/test_slack_token_policy.py
@@ -1,20 +1,16 @@
 """The single Slack token-selection policy (#1084, #1110).
 
-Extracted verbatim from ``SlackBotBackend._channel_token`` so the
-review-request dedup guard reads channel history with the same token the
-post will use (read-token == post-token). These assert each branch of
-the policy directly; ``test_slack_connect_channel_routing.py`` proves the
-``SlackBotBackend`` refactor stays behaviour-preserving.
-
-#1110 adds a required keyword-only ``op`` (``SlackOp.READ`` /
-``SlackOp.WRITE``) and an ``is_ext_shared`` tri-state. When Connect
-membership is *unknown* (``conversations.info`` failed → ``None``) the
-operation decides: a READ falls safe to the bot token (the bot can
-always read its own metadata; the worst case is an empty history a
-dedup tolerates), but a WRITE / reaction falls toward the user ``xoxp``
-token, because a Connect channel rejects the bot token outright and a
-silent bot-token write would post under the wrong identity or drop the
-partner write entirely.
+Reads and writes route to *different* tokens by design. A genuine
+``SlackOp.READ`` (a history/metadata read taken to VIEW a channel — the
+MCP ``slack_channel_history`` tool) goes out under the USER ``xoxp``
+token on any non-DM channel, so the agent sees the same channels and
+history the user sees rather than the bot's view of only the channels
+it was invited to. A ``SlackOp.WRITE`` (a post, a reaction, or the
+#1084 dedup guard's read-taken-as-the-post) keeps the interaction
+doctrine: confirmed Connect -> user, confirmed internal -> bot,
+ambiguous -> user (a bot-token write to a Connect channel is rejected
+and the partner write is dropped). DMs and the single-credential
+short-circuits are bit-for-bit unchanged from #1084.
 """
 
 from teatree.backends.slack.token_policy import SlackOp, channel_token
@@ -28,8 +24,39 @@ def test_no_bot_token_returns_user_token() -> None:
     assert channel_token("C1", bot_token="", user_token="xoxp", is_ext_shared=False, op=SlackOp.READ) == "xoxp"
 
 
-def test_dm_still_bot() -> None:
+def test_dm_read_still_bot() -> None:
+    """A DM read stays on the bot — a user-token read of the bot's own DM history would be wrong."""
+    assert channel_token("D123", bot_token="xoxb", user_token="xoxp", is_ext_shared=None, op=SlackOp.READ) == "xoxb"
+
+
+def test_dm_write_still_bot() -> None:
     assert channel_token("D123", bot_token="xoxb", user_token="xoxp", is_ext_shared=True, op=SlackOp.WRITE) == "xoxb"
+
+
+def test_read_on_confirmed_internal_returns_user_token() -> None:
+    """A general READ sees what the USER sees — the intent flip.
+
+    The pre-flip policy routed a confirmed-internal READ to the bot
+    token (the bot's view of only channels it was invited to). The new
+    intent: a genuine viewing read routes through the user ``xoxp`` so
+    the agent sees the same channels the user does.
+    """
+    assert channel_token("C9", bot_token="xoxb", user_token="xoxp", is_ext_shared=False, op=SlackOp.READ) == "xoxp"
+
+
+def test_read_on_ambiguous_returns_user_token() -> None:
+    """Unknown Connect membership + READ -> user token (was bot pre-flip).
+
+    A READ never consults ``is_ext_shared`` under the new policy — it
+    routes to the user token on any non-DM channel. This replaces the
+    old #1110 "ambiguous READ falls safe to the bot" behaviour, which
+    was deliberately narrowed to the WRITE path.
+    """
+    assert channel_token("C9", bot_token="xoxb", user_token="xoxp", is_ext_shared=None, op=SlackOp.READ) == "xoxp"
+
+
+def test_read_on_confirmed_ext_shared_returns_user_token() -> None:
+    assert channel_token("C9", bot_token="xoxb", user_token="xoxp", is_ext_shared=True, op=SlackOp.READ) == "xoxp"
 
 
 def test_confirmed_ext_shared_write_still_user() -> None:
@@ -37,30 +64,30 @@ def test_confirmed_ext_shared_write_still_user() -> None:
 
 
 def test_confirmed_internal_write_still_bot() -> None:
+    """A WRITE to a confirmed-internal channel interacts as the bot — unchanged by the read flip."""
     assert channel_token("C9", bot_token="xoxb", user_token="xoxp", is_ext_shared=False, op=SlackOp.WRITE) == "xoxb"
 
 
 def test_ambiguous_channel_write_returns_user_token() -> None:
-    """Unknown Connect membership + WRITE -> user xoxp (the #1110 fix).
+    """Unknown Connect membership + WRITE -> user xoxp (the #1110 fix, preserved).
 
-    The pre-#1110 policy had no ``op`` and routed an unknown channel
-    (``is_ext_shared`` was hard ``False``) to the bot — Slack then
-    rejects a Connect write with
-    ``mcp_externally_shared_channel_restricted`` and the post is
-    silently dropped. A write must fail toward the user token.
+    An unconfirmed channel could be a Connect channel that rejects the
+    bot token with ``mcp_externally_shared_channel_restricted`` and
+    silently drops the post — so a write must fail toward the user token.
     """
     assert channel_token("C9", bot_token="xoxb", user_token="xoxp", is_ext_shared=None, op=SlackOp.WRITE) == "xoxp"
 
 
-def test_ambiguous_channel_read_returns_bot_token() -> None:
-    """Unknown Connect membership + READ -> bot token.
+def test_dedup_read_as_post_uses_the_posts_token() -> None:
+    """The #1084 dedup guard reads history AS the post, so it passes WRITE.
 
-    A read with the bot token on an unreachable Connect channel returns
-    an empty history at worst — which the #1084 dedup tolerates. The bot
-    can always read its own metadata, so READ stays conservative on the
-    bot token.
+    Read-token == post-token stays load-bearing: the dedup read of a
+    confirmed-internal channel must use the bot token the reaction will
+    go out under (not the user token a genuine viewing READ would use),
+    so the read sees the same history the post's identity does.
     """
-    assert channel_token("C9", bot_token="xoxb", user_token="xoxp", is_ext_shared=None, op=SlackOp.READ) == "xoxb"
+    assert channel_token("C9", bot_token="xoxb", user_token="xoxp", is_ext_shared=False, op=SlackOp.WRITE) == "xoxb"
+    assert channel_token("C9", bot_token="xoxb", user_token="xoxp", is_ext_shared=True, op=SlackOp.WRITE) == "xoxp"
 
 
 def test_single_credential_unchanged() -> None:
@@ -70,4 +97,6 @@ def test_single_credential_unchanged() -> None:
     user regardless of op / membership.
     """
     assert channel_token("C9", bot_token="xoxb", user_token="", is_ext_shared=None, op=SlackOp.WRITE) == "xoxb"
+    assert channel_token("C9", bot_token="xoxb", user_token="", is_ext_shared=None, op=SlackOp.READ) == "xoxb"
     assert channel_token("C9", bot_token="", user_token="xoxp", is_ext_shared=None, op=SlackOp.READ) == "xoxp"
+    assert channel_token("C9", bot_token="", user_token="xoxp", is_ext_shared=None, op=SlackOp.WRITE) == "xoxp"

--- a/tests/teatree_cli/doctor/test_checks_slack_engagement.py
+++ b/tests/teatree_cli/doctor/test_checks_slack_engagement.py
@@ -1,0 +1,71 @@
+"""``t3 doctor`` WARNs when ``autoload`` is off yet Slack posting is configured (#256).
+
+With engagement default-off a session never engages teatree, so a bot configured
+with a ``slack_token_ref`` never routes Slack through the MCP tools. The check
+fires ONLY on that combination — ``autoload`` on, or no Slack-configured overlay,
+is a clean no-op (anti-vacuous: the WARN must not fire when either fact is absent).
+"""
+
+from dataclasses import dataclass
+
+import pytest
+
+from teatree.cli.doctor.checks_slack_engagement import check_slack_engagement, evaluate_slack_engagement
+from teatree.cli.slack.socket_doctor import Level
+
+_SETTINGS = "teatree.config.get_effective_settings"
+_OVERLAYS = "teatree.cli.doctor.checks_slack_engagement._slack_configured_overlays"
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeSettings:
+    autoload: bool
+
+
+def test_warns_when_autoload_off_and_slack_configured() -> None:
+    finding = evaluate_slack_engagement(autoload=False, slack_overlays=["acme"])
+    assert finding is not None
+    assert finding.level is Level.WARN
+    assert "config_setting set autoload true" in finding.message
+    assert "acme" in finding.message
+
+
+def test_no_finding_when_autoload_on() -> None:
+    assert evaluate_slack_engagement(autoload=True, slack_overlays=["acme"]) is None
+
+
+def test_no_finding_when_no_slack_overlay_configured() -> None:
+    assert evaluate_slack_engagement(autoload=False, slack_overlays=[]) is None
+
+
+def test_multiple_overlays_are_named_sorted() -> None:
+    finding = evaluate_slack_engagement(autoload=False, slack_overlays=["zeta", "acme"])
+    assert finding is not None
+    assert "acme, zeta" in finding.message
+
+
+def test_check_renders_the_warn_line(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_SETTINGS, lambda: _FakeSettings(autoload=False))
+    monkeypatch.setattr(_OVERLAYS, lambda: ["acme"])
+    lines: list[str] = []
+
+    # Surfacing-only: the WARN is rendered but the return value never gates the exit code.
+    assert check_slack_engagement(echo=lines.append) is True
+    assert any("WARN" in line and "autoload" in line for line in lines)
+
+
+def test_check_is_silent_when_autoload_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_SETTINGS, lambda: _FakeSettings(autoload=True))
+    monkeypatch.setattr(_OVERLAYS, lambda: ["acme"])
+    lines: list[str] = []
+
+    assert check_slack_engagement(echo=lines.append) is True
+    assert lines == []
+
+
+def test_check_never_crashes_on_a_config_read_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom() -> _FakeSettings:
+        raise RuntimeError
+
+    monkeypatch.setattr(_SETTINGS, _boom)
+    assert check_slack_engagement(echo=lambda _line: None) is True


### PR DESCRIPTION
The Slack token policy now reads with the user (`xoxp`) token and writes/reacts with the bot (`xoxb`) token, so the agent sees the same channels and history the user does while posts still go out under the bot identity.

- `channel_token`: a general `SlackOp.READ` (non-DM) resolves to the user token; writes/reactions resolve to the bot token for confirmed-internal channels and the user token only where the bot is structurally rejected (Slack-Connect / ambiguous). DMs stay on the bot token.
- The MCP `slack_channel_history` read is reclassified READ→user (genuine viewing); the #1084 review-dedup 'read-as-post' and all writes remain `SlackOp.WRITE`, so read-token == post-token is preserved.
- Only overlays configured with a `user_token_ref` are affected; bot-token-only and DM-only deployments are unchanged.
- Adds a `t3 doctor` check that warns when `autoload` is off while Slack posting is configured (sessions won't engage teatree / route Slack through the MCP), naming the `config_setting set autoload true` fix.