### PR TITLE
ci(eval): add an always-conclusive eval-gate and make selective PR evals a required merge check

### DIFF
--- a/.github/workflows/eval-pr-reusable.yml
+++ b/.github/workflows/eval-pr-reusable.yml
@@ -290,3 +290,42 @@ jobs:
           name: eval-pr-transcripts
           path: ${{ runner.temp }}/eval-transcripts.html
           if-no-files-found: warn
+
+  # EVAL-GATE: the single always-reporting merge gate an overlay caller pins as a
+  # required status check. A conditionally-skipped job (the `eval` job skips when no
+  # scenario changed) is a fragile required check — GitHub leaves a skipped required
+  # context pending, wedging every no-change PR. This job ALWAYS runs (`if:
+  # always()`), so it emits exactly ONE conclusive success/failure check (KEEP THE
+  # JOB KEY `eval-gate` STABLE). It PASSes when detection succeeded AND the eval
+  # passed or was legitimately skipped (no scenario changed); it FAILs when
+  # detection failed, when the eval failed (a real regression OR the vacuous
+  # zero-executed case that `exit 1`s inside the eval job), or when either job was
+  # cancelled.
+  eval-gate:
+    needs: [detect, eval]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Conclude the selective-eval merge gate
+        env:
+          DETECT_RESULT: ${{ needs.detect.result }}
+          EVAL_RESULT: ${{ needs.eval.result }}
+          CHANGED: ${{ needs.detect.outputs.run }}
+        run: |
+          echo "detect=$DETECT_RESULT eval=$EVAL_RESULT changed_scenarios=$CHANGED"
+          if [ "$DETECT_RESULT" != "success" ]; then
+            echo "::error::eval-gate FAIL — scenario detection did not succeed (detect=$DETECT_RESULT); cannot prove the PR's eval coverage."
+            exit 1
+          fi
+          case "$EVAL_RESULT" in
+            success)
+              echo "eval-gate PASS — the PR's changed scenarios ran and passed."
+              ;;
+            skipped)
+              echo "eval-gate PASS — no scenario changed; nothing to eval."
+              ;;
+            *)
+              echo "::error::eval-gate FAIL — the selective eval did not pass (eval=$EVAL_RESULT): a changed scenario failed, the run executed zero scenarios (vacuous), or the job was cancelled."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/eval-pr.yml
+++ b/.github/workflows/eval-pr.yml
@@ -248,3 +248,45 @@ jobs:
           name: eval-pr-transcripts
           path: ${{ runner.temp }}/eval-transcripts.html
           if-no-files-found: warn
+
+  # EVAL-GATE: the single always-reporting merge gate. A conditionally-skipped job
+  # (the `eval` job skips when no scenario changed) is a fragile required check —
+  # GitHub leaves a skipped required context pending, wedging every no-change PR.
+  # This job ALWAYS runs (`if: always()`), so it emits exactly ONE conclusive
+  # success/failure check that branch protection pins as a stable required context
+  # (KEEP THE JOB KEY `eval-gate` STABLE — that is the pinned name). It PASSes when
+  # scenario detection succeeded AND the eval either passed or was legitimately
+  # skipped (no scenario changed — the common case); it FAILs when detection failed
+  # (bad ref / resolver error), when the eval failed (a real scenario regression OR
+  # the vacuous zero-executed case, which `exit 1`s inside the eval job and surfaces
+  # here as eval=failure), or when either job was cancelled. It reads only THIS
+  # workflow's two jobs, never the weekly/nightly metered runs, so a required
+  # eval-gate can never wedge merges on the depleting subscription window.
+  eval-gate:
+    needs: [detect, eval]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Conclude the selective-eval merge gate
+        env:
+          DETECT_RESULT: ${{ needs.detect.result }}
+          EVAL_RESULT: ${{ needs.eval.result }}
+          CHANGED: ${{ needs.detect.outputs.run }}
+        run: |
+          echo "detect=$DETECT_RESULT eval=$EVAL_RESULT changed_scenarios=$CHANGED"
+          if [ "$DETECT_RESULT" != "success" ]; then
+            echo "::error::eval-gate FAIL — scenario detection did not succeed (detect=$DETECT_RESULT); cannot prove the PR's eval coverage."
+            exit 1
+          fi
+          case "$EVAL_RESULT" in
+            success)
+              echo "eval-gate PASS — the PR's changed scenarios ran and passed."
+              ;;
+            skipped)
+              echo "eval-gate PASS — no scenario changed; nothing to eval."
+              ;;
+            *)
+              echo "::error::eval-gate FAIL — the selective eval did not pass (eval=$EVAL_RESULT): a changed scenario failed, the run executed zero scenarios (vacuous), or the job was cancelled."
+              exit 1
+              ;;
+          esac

--- a/tests/test_eval_pr_gate.py
+++ b/tests/test_eval_pr_gate.py
@@ -1,0 +1,128 @@
+"""The always-conclusive `eval-gate` job makes the selective PR eval a requirable check.
+
+The selective-PR eval's `eval` job is conditionally skipped when a PR changes no
+scenario file. A conditionally-skipped job is a fragile required status check —
+GitHub leaves a skipped required context pending and wedges every no-change PR. The
+`eval-gate` job closes that: it `needs: [detect, eval]` with `if: always()`, so it
+ALWAYS runs and produces exactly ONE conclusive success/failure check that branch
+protection can pin as a stable required context.
+
+These tests pin BOTH halves of the gate: the static contract (the job exists in the
+host workflow AND the reusable one, always runs, and depends on both upstream jobs)
+and the behavioral truth table (the gate's own shell, executed under GitHub's
+`bash -eo pipefail` semantics against every `needs.*.result` combination). The
+behavioral test executes the REAL shipped `run:` body, so it goes red if the gate
+logic drifts — not a re-implementation of it.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import yaml
+
+_BASH = shutil.which("bash") or "/bin/bash"
+
+_WORKFLOWS = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+_HOST = _WORKFLOWS / "eval-pr.yml"
+_REUSABLE = _WORKFLOWS / "eval-pr-reusable.yml"
+_GATE_WORKFLOWS = [_HOST, _REUSABLE]
+
+
+def _jobs(path: Path) -> dict[str, Any]:
+    return cast("dict[str, Any]", yaml.safe_load(path.read_text(encoding="utf-8"))["jobs"])
+
+
+def _gate_run_body(path: Path) -> str:
+    for step in cast("list[dict[str, Any]]", _jobs(path)["eval-gate"]["steps"]):
+        if "run" in step:
+            return cast("str", step["run"])
+    msg = f"{path.name}: the eval-gate job has no `run` step."
+    raise AssertionError(msg)
+
+
+def _run_gate(path: Path, *, detect: str, eval_result: str, changed: str) -> subprocess.CompletedProcess[str]:
+    # Execute the gate's real shell body under GitHub's default `run:` shell
+    # semantics (bash -eo pipefail), so the test exercises the shipped logic, not
+    # a copy of it. `needs.*.result` and the detect output are supplied as env.
+    script = "set -eo pipefail\n" + _gate_run_body(path)
+    return subprocess.run(
+        [_BASH, "-c", script],
+        env={"DETECT_RESULT": detect, "EVAL_RESULT": eval_result, "CHANGED": changed, "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class TestGateContract:
+    @pytest.mark.parametrize("path", _GATE_WORKFLOWS, ids=lambda p: p.name)
+    def test_gate_always_runs_and_needs_both_jobs(self, path: Path) -> None:
+        gate = cast("dict[str, Any]", _jobs(path)["eval-gate"])
+        assert gate["if"] == "always()", (
+            f"{path.name}: eval-gate must run with `if: always()` so it produces a conclusive "
+            "check even when the eval job is skipped — a skipped required check wedges merges."
+        )
+        assert gate["needs"] == ["detect", "eval"], (
+            f"{path.name}: eval-gate must depend on both `detect` and `eval` to read their results."
+        )
+
+    @pytest.mark.parametrize("path", _GATE_WORKFLOWS, ids=lambda p: p.name)
+    def test_gate_reads_the_upstream_results_not_the_metered_schedule(self, path: Path) -> None:
+        # The gate must conclude from THIS workflow's two jobs only — never the
+        # weekly/nightly metered runs, whose depleting subscription window would
+        # otherwise wedge every merge.
+        gate = cast("dict[str, Any]", _jobs(path)["eval-gate"])
+        env = cast("dict[str, str]", gate["steps"][0]["env"])
+        assert env["DETECT_RESULT"] == "${{ needs.detect.result }}"
+        assert env["EVAL_RESULT"] == "${{ needs.eval.result }}"
+
+
+class TestGateTruthTable:
+    """The four cases the task defines, executed against the shipped gate shell."""
+
+    @pytest.mark.parametrize("path", _GATE_WORKFLOWS, ids=lambda p: p.name)
+    def test_no_scenario_changed_is_green(self, path: Path) -> None:
+        # detect succeeds, eval is skipped (no scenario changed) → PASS. The common case.
+        result = _run_gate(path, detect="success", eval_result="skipped", changed="false")
+        assert result.returncode == 0, result.stderr
+        assert "PASS — no scenario changed" in result.stdout
+
+    @pytest.mark.parametrize("path", _GATE_WORKFLOWS, ids=lambda p: p.name)
+    def test_changed_and_passing_is_green(self, path: Path) -> None:
+        # detect succeeds, eval succeeds (changed scenarios passed) → PASS.
+        result = _run_gate(path, detect="success", eval_result="success", changed="true")
+        assert result.returncode == 0, result.stderr
+        assert "PASS — the PR's changed scenarios ran and passed" in result.stdout
+
+    @pytest.mark.parametrize("path", _GATE_WORKFLOWS, ids=lambda p: p.name)
+    def test_changed_and_failing_is_red(self, path: Path) -> None:
+        # detect succeeds, eval fails (a changed scenario failed) → FAIL.
+        result = _run_gate(path, detect="success", eval_result="failure", changed="true")
+        assert result.returncode == 1
+        assert "FAIL — the selective eval did not pass" in result.stdout
+
+    @pytest.mark.parametrize("path", _GATE_WORKFLOWS, ids=lambda p: p.name)
+    def test_vacuous_zero_executed_surfaces_as_red(self, path: Path) -> None:
+        # The ZERO-IS-RED guard `exit 1`s INSIDE the eval job, so a supposed-to-run
+        # run that executed zero scenarios reaches the gate as eval=failure — the
+        # same red the gate emits for a real scenario failure. This asserts the
+        # vacuous case flows into the gate rather than being swallowed as green.
+        result = _run_gate(path, detect="success", eval_result="failure", changed="true")
+        assert result.returncode == 1
+
+    @pytest.mark.parametrize("path", _GATE_WORKFLOWS, ids=lambda p: p.name)
+    def test_detection_failure_is_red_even_when_eval_skipped(self, path: Path) -> None:
+        # A bad ref / resolver error fails `detect`, which skips `eval`. The gate
+        # must red on the detect failure rather than green on the skipped eval.
+        result = _run_gate(path, detect="failure", eval_result="skipped", changed="")
+        assert result.returncode == 1
+        assert "FAIL — scenario detection did not succeed" in result.stdout
+
+    @pytest.mark.parametrize("path", _GATE_WORKFLOWS, ids=lambda p: p.name)
+    def test_cancelled_job_is_red(self, path: Path) -> None:
+        # A cancelled eval (timeout / superseded) is not a pass — fail conservatively.
+        result = _run_gate(path, detect="success", eval_result="cancelled", changed="true")
+        assert result.returncode == 1


### PR DESCRIPTION
## What & why

The per-PR behavioral evals (`.github/workflows/eval-pr.yml`, "Selective PR eval")
run only the scenarios a PR changed and are already RED on a real failure or a
vacuous (supposed-to-run-but-ran-zero) run. But **no** eval check is a required
status check on `main`, because the `eval` job is *conditionally skipped* when a
PR touches no scenario file — and a conditionally-skipped job is a fragile
required check (GitHub leaves a skipped required context pending and wedges every
no-change PR).

This PR adds an always-reporting summary gate job — `eval-gate` — that produces
exactly **one conclusive** success/failure check on every PR, so it can be pinned
as a required status check on `main`. Added to both the host workflow
(`eval-pr.yml`) and the reusable one (`eval-pr-reusable.yml`) so overlays get the
same requirable gate.

## The gate job

```yaml
eval-gate:
  needs: [detect, eval]
  if: always()
```

It reads only **this** workflow's two jobs (`needs.detect.result`,
`needs.eval.result`) — never the weekly/nightly metered runs — so a required
`eval-gate` can never wedge merges on the depleting subscription window.

## Truth table

| detect | eval | meaning | gate |
|---|---|---|---|
| success | skipped | no scenario changed (the common case) | **PASS** |
| success | success | changed scenarios ran and passed | **PASS** |
| success | failure | a changed scenario failed | **FAIL** |
| success | failure | supposed-to-run but executed ZERO scenarios (vacuous) — the `ran==0` guard `exit 1`s inside the `eval` job, surfacing here as `eval=failure` | **FAIL** |
| failure | skipped | bad ref / resolver error failed `detect` (which then skips `eval`) | **FAIL** |
| cancelled | — | timeout or superseded run | **FAIL** |

The existing anti-vacuity guard (missing `claude` binary / all-skipped /
`--require-executed` / ZERO-IS-RED) is unchanged; it `exit 1`s inside the `eval`
job and flows into the gate as `eval=failure`, so the vacuous case reddens the
gate.

## Test

`tests/test_eval_pr_gate.py` executes the **shipped** gate shell (extracted from
the YAML) under GitHub's `bash -eo pipefail` semantics against every
`needs.*.result` combination, plus static assertions that the job is
`if: always()` and `needs: [detect, eval]` in both workflows. The parametrized
cases assert both exit-0 and exit-1 outcomes, so a gate that always passed (or
always failed) would turn the suite red — the built-in anti-vacuity control.

## Making it required on `main` (owner, post-merge)

The `eval-gate` context can only be added to branch protection **after** this PR
merges (the context must exist on `main` first). The branch is protected, so this
is handed to the owner. The additive PATCH (current contexts + `eval-gate`):

```bash
gh api -X PATCH repos/souliane/teatree/branches/main/protection/required_status_checks \
  --input - <<'JSON'
{
  "strict": false,
  "contexts": ["lint", "test (3.13)", "docs-drift", "uv-audit", "sbom", "blueprint-cross-pr", "eval-gate"]
}
JSON
```

This is additive — it includes the current required contexts, so nothing is
dropped.

## Architecture pre-check — ci-require-selective-eval-gate

**1. BLUEPRINT § alignment** — CI/eval workflow change; no BLUEPRINT domain-model
or FSM section is touched. n/a.

**2. FSM phase boundaries** — n/a (no `Ticket.State` / `Worktree.State` transition).

**3. Extension-point contracts** — n/a (no `OverlayBase` / scanner / Protocol
change). The reusable workflow's overlay callers gain the `eval-gate` job
transparently (additive job, no input/secret contract change).

**4. Component boundaries** — `.github/workflows/` (CI config) + a mirroring
`tests/` fitness test. No `src/` change.

**5. Dependency direction** — n/a (no Python import added; the test imports only
stdlib + `yaml`). `tach` clean.

**6. Test surface** — `tests/test_eval_pr_gate.py`: the gate's shell executed
against the six `needs.*.result` cases (the 4-case truth table + detect-failure +
cancelled), asserting exit code and one-line reason; plus static `if: always()` /
`needs` contract on both workflows. Regresses red if the gate logic drifts.

**7. Resilience invariants** — no external write. The gate is idempotent (a pure
function of two job results) and always-conclusive by construction (`if:
always()`), which is the fallback/heartbeat property the whole change exists to
provide.

**8. Identity and key normalization** — n/a.

**9. Behavior preservation / capability deletion** — purely additive; no existing
job, guard, or must-block test removed or inverted. The existing ZERO-IS-RED /
`--require-executed` anti-vacuity is preserved and now surfaces through the gate.

**10. Removability / harness-vs-data** — fully removable: deleting the `eval-gate`
job reverts to the prior behavior with no cascade (only branch protection would
need the context removed). It is harness (a CI gate), which is the correct side —
there is no per-item policy to push to data.
