### PR TITLE
refactor(config): route every term-scanning gate through the consolidated registry

### DIFF
--- a/docs/blueprint/configuration.md
+++ b/docs/blueprint/configuration.md
@@ -629,6 +629,31 @@ Overlay-specific configuration lives on `overlay.config` (an `OverlayConfig` dat
 
 `default_logging(namespace)` in `config/loader.py` returns a Django `LOGGING` dict writing to `~/.local/share/teatree/<namespace>/logs/teatree.log` with rotation (5MB, 3 backups).
 
+### 10.6 Term-scanning taxonomy
+
+Every term-scanning gate resolves through one class-tagged source: the DB-home `banned_term_registry` row (or the `$TEATREE_TERM_REGISTRY` CI secret), read by `teatree.hooks.banned_term_registry.terms_for_gate`. Each class is scanned by a specific gate; the registry is registry-first, falling back to a legacy per-source row when it is unset.
+
+| class | scanned by gate | legacy fallback source | unset behaviour |
+|---|---|---|---|
+| `leak` | diff + core + tree | `banned_brands` | fail-loud |
+| `prose_collider` | diff + core | `banned_terms` | fail-loud |
+| `tone` | diff | (none) | inert |
+| `overlay` | overlay core-generic gate | `overlay_leak_terms` | inert |
+| `allow` | the carve-out (never scanned *for*) | `banned_terms_allowlist` | inert |
+
+* **Gates.** `diff` — the commit/posting body gate (`banned_terms_scanner`); `core` — the in-process `fast_push` leak gate; `tree` — the whole-tree backstop (`banned_terms_tree_scan`); `overlay` — the BLUEPRINT §1 "core stays generic" gate (`check_no_overlay_leak` / `fast_push`); `allow` — the company-identifier carve-out blanked before matching. The class→gate routing derives from `teatree.hooks.leak_policy.classes_for_surface` (the `overlay` class is registry-only — it is not a publish surface).
+* **Unset behaviour.** `leak`/`prose_collider` REFUSE (`BannedTermsUnsetError`) when both the registry and their legacy source are unset — a leak gate never scans as empty. `tone`/`overlay`/`allow` are optional and default to an inert empty set (the overlay gate is inert-when-empty by design). A malformed registry fails loud everywhere.
+* **Single resolver.** The four legacy keys are read from the store only by the registry module and the legacy resolvers it delegates to; every other gate routes through `terms_for_gate` / `allowlist_terms` / `export_scan_terms`. `t3 banned-terms migrate-registry` builds the class-tagged value from the current legacy rows and self-verifies it drops no term (`teatree.hooks.banned_term_registry.verify_migration`).
+
+**Code-resident public tier.** A second tier of term data is generic, DB-free, and ships in the repo — it carries no operator-private value, so it stays committed and is NOT part of the registry:
+
+* `teatree.hooks.terminology_gate` — the conflated-terminology vocabulary (generic wording checks).
+* `teatree.hooks.opaque_id` — the real-shaped Slack/forge ID detector and its synthetic-placeholder allowlist.
+* `scripts/privacy_scan.py` — the credential/email/host regexes (`glpat-`, `sk-`, home-directory paths, …).
+* the eval-fixture personal-marker / profanity guard — a generic fixture-hygiene check.
+
+**Secret / defaults boundary.** Every registry class carries operator-private codenames, so the five term keys (`banned_terms`, `banned_terms_allowlist`, `banned_brands`, `overlay_leak_terms`, `banned_term_registry`) are all in `SECRET_SETTINGS`: DB-only, empty in code, and withheld from a shared `config_setting export`. They must never appear in a committed defaults file — a forward guard asserts `SECRET_SETTINGS` is disjoint from any `config/defaults.toml` that ever ships.
+
 ### 10.4 Data Storage
 
 `~/.local/share/teatree/<namespace>/` — namespaced data directories created by `get_data_dir()`.

--- a/scripts/hooks/check_no_overlay_leak.py
+++ b/scripts/hooks/check_no_overlay_leak.py
@@ -36,7 +36,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from teatree.config import cold_reader
+from teatree.hooks.banned_term_registry import terms_for_gate
 from teatree.hooks.opaque_id import find_opaque_ids
 from teatree.hooks.term_match import matched_term
 
@@ -45,18 +45,19 @@ _MISCONFIGURED_EXIT_CODE = 2
 
 
 def _load_terms() -> tuple[str, ...]:
-    """Load forbidden tokens from the env override or the DB-home overlay_leak_terms list.
+    """Load forbidden tokens for the overlay gate — env override, else the registry.
 
-    ``TEATREE_OVERLAY_LEAK_TERMS`` (comma-separated) wins; otherwise the
-    canonical ``overlay_leak_terms`` ``ConfigSetting`` row (read Django-free via
-    :mod:`teatree.config.cold_reader`). Empty (default) leaves the term-list pass
-    inert — the always-on opaque-ID pass still runs.
+    ``TEATREE_OVERLAY_LEAK_TERMS`` (comma-separated) wins; otherwise the consolidated
+    ``banned_term_registry`` via :func:`terms_for_gate` — its ``overlay`` class when the
+    registry is present, else the legacy ``overlay_leak_terms`` row (resolved inside the
+    registry module, never a raw read here). Empty (default) leaves the term-list pass
+    inert — the always-on opaque-ID pass still runs; the overlay gate never raises on an
+    unset source (inert-when-empty).
     """
     env = os.environ.get("TEATREE_OVERLAY_LEAK_TERMS", "")
     if env:
         return tuple(t.strip() for t in env.split(",") if t.strip())
-    terms = cold_reader.list_setting("overlay_leak_terms", default=[])
-    return tuple(str(t) for t in terms if isinstance(t, str) and t.strip())
+    return terms_for_gate("overlay")
 
 
 OVERLAY_LEAK_TERMS: tuple[str, ...] = _load_terms()

--- a/scripts/privacy_scan.py
+++ b/scripts/privacy_scan.py
@@ -25,7 +25,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from teatree.config import cold_reader
+from teatree.hooks.banned_term_registry import allowlist_terms
 from teatree.hooks.banned_terms_cli import resolve_banned_terms
 from teatree.hooks.banned_terms_tree_scan import BannedTermsUnsetError
 from teatree.hooks.opaque_id import find_opaque_ids
@@ -84,7 +84,7 @@ _ALLOW_MARKER = "privacy-scan:allow"
 
 
 def _banned_allowlist() -> tuple[str, ...]:
-    return tuple(str(t) for t in cold_reader.list_setting("banned_terms_allowlist", default=[]))
+    return allowlist_terms()
 
 
 def _resolve_scan_terms(env_value: str) -> tuple[str, ...]:

--- a/src/teatree/backends/slack/client.py
+++ b/src/teatree/backends/slack/client.py
@@ -289,11 +289,11 @@ def read_thread_activity(request: SlackThreadActivityRequest) -> ThreadActivityR
     if parent.get("subtype") == "tombstone":
         return ThreadActivityRead(ok=True, exists=False)
     reply_dicts = [cast("RawAPIDict", m) for m in messages[1:] if isinstance(m, dict)]
-    reply_tss = [str(m.get("ts", "")) for m in reply_dicts if m.get("ts")]
+    reply_timestamps = [str(m.get("ts", "")) for m in reply_dicts if m.get("ts")]
     return ThreadActivityRead(
         ok=True,
         exists=True,
         parent_ts=str(parent.get("ts", "")),
-        latest_reply_ts=max(reply_tss, key=_ts_key, default=""),
+        latest_reply_ts=max(reply_timestamps, key=_ts_key, default=""),
         has_reaction=bool(parent.get("reactions")),
     )

--- a/src/teatree/config/registries.py
+++ b/src/teatree/config/registries.py
@@ -53,16 +53,24 @@ REGISTRY_KEYS: tuple[str, ...] = tuple(REGISTRY_SETTINGS)
 COLD_SETTINGS: dict[str, Callable[[Any], Any]] = {
     # Customer / brand / partner codename lists (stored as JSON arrays). The DB is
     # personal, so these are safe here; ``SECRET_SETTINGS`` keeps them out of a
-    # shared ``config_setting export``.
+    # shared ``config_setting export``. These four are now LEGACY sources folded into
+    # ``banned_term_registry`` (``banned_brands`` → leak, ``banned_terms`` →
+    # prose_collider, ``overlay_leak_terms`` → overlay, ``banned_terms_allowlist`` →
+    # allow); every gate resolves through the registry via
+    # ``banned_term_registry.terms_for_gate`` and only FALLS BACK to these rows when
+    # the registry is unset. They stay registered as that fallback tier — do not
+    # delete them.
     "banned_terms": _parse_str_list,
     "banned_terms_allowlist": _parse_str_list,
     "banned_brands": _parse_str_list,
-    # The consolidated class-tagged registry (`leak`/`prose_collider`/`tone`/`allow`
-    # → term lists) the three lists above collapse into. A JSON table, so it is
-    # validated by the registry-dict parser, not the str-list one.
+    # The class-tagged registry (`leak`/`prose_collider`/`tone`/`overlay`/`allow` →
+    # term lists) the four legacy lists fold into — the single source every
+    # term-scanning gate resolves through. A JSON table, so it is validated by the
+    # registry-dict parser, not the str-list one.
     "banned_term_registry": _parse_registry_dict,
     "internal_publish_namespaces": _parse_str_list,
     "private_repos": _parse_str_list,
+    # Legacy overlay-leak fallback (folded into the registry's ``overlay`` class).
     "overlay_leak_terms": _parse_str_list,
     # ``[agent]`` spawn tables (str->str/bool/int maps) + scalars, read by the
     # dispatch paths (``config.agent_spawn`` / ``model_tiering``) via ``cold_reader``.

--- a/src/teatree/core/config_migration.py
+++ b/src/teatree/core/config_migration.py
@@ -61,22 +61,22 @@ class _ExportGuard:
 
 
 def _resolve_export_scan_terms() -> tuple[str, ...]:
-    """Banned terms + brands for the export content scan; fails safe to empty.
+    """Every ban-class term for the export content scan; fails safe to empty when unset.
 
-    Read straight from the DB store (the codename lists' home) via the Django-free
-    ``cold_reader``, so a shared export scans the operator's configured customer/
-    brand terms without any file. An unconfigured store yields no terms (empty).
+    Delegates to :func:`banned_term_registry.export_scan_terms` — the single home that
+    resolves the ban classes registry-first (``leak`` + ``prose_collider`` + ``tone`` +
+    ``overlay``; the ``allow`` carve-out is excluded) and falls back to the legacy
+    ``banned_terms`` + ``banned_brands`` rows when the registry is unset. Keeping the
+    resolution there (rather than reading the legacy rows here) leaves the registry the
+    single term-source: a shared export scans the operator's configured customer/brand
+    terms without any file, an unconfigured store yields no terms, and a malformed
+    registry fails loud exactly like the gates.
     """
-    # Deferred (PLC0415): importing `teatree.config` at module scope eagerly
-    # loads its heavy package __init__; keep this module's import light.
-    from teatree.config import cold_reader  # noqa: PLC0415 — deferred: call-time import, kept lazy
+    # Deferred (PLC0415): importing `teatree.hooks` at module scope eagerly loads its
+    # heavy package __init__; keep this module's import light.
+    from teatree.hooks.banned_term_registry import export_scan_terms  # noqa: PLC0415 — deferred: kept lazy
 
-    terms: list[str] = []
-    for key in ("banned_terms", "banned_brands"):
-        value = cold_reader.read_setting(key)
-        if isinstance(value, list):
-            terms.extend(str(t) for t in value if str(t).strip())
-    return tuple(terms)
+    return export_scan_terms()
 
 
 def _redaction_reason(key: str, value: ConfigValue, terms: tuple[str, ...]) -> str | None:

--- a/src/teatree/core/fast_push.py
+++ b/src/teatree/core/fast_push.py
@@ -25,8 +25,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Final, Protocol
 
-from teatree.config import cold_reader
-from teatree.hooks.banned_term_registry import terms_for_gate
+from teatree.hooks.banned_term_registry import allowlist_terms, terms_for_gate
 from teatree.hooks.banned_terms_cli import staged_added_lines
 from teatree.hooks.banned_terms_tree_scan import BannedTermsUnsetError
 from teatree.hooks.opaque_id import find_opaque_ids
@@ -249,7 +248,7 @@ class LeakGateScan:
                 "`t3 <overlay> config_setting set banned_terms '[...]'` (explicit [] opts out)"
             )
             return [LeakFinding(gate="banned-terms", path="", detail=detail)]
-        allowlist = tuple(str(t) for t in cold_reader.list_setting("banned_terms_allowlist", default=[]))
+        allowlist = allowlist_terms()
         return [
             LeakFinding(gate="banned-terms", path=path, detail=f"banned term '{term}'")
             for path, lines in lines_by_path.items()
@@ -292,11 +291,9 @@ class LeakGateScan:
     @staticmethod
     def _overlay_leak(lines_by_path: dict[str, list[str]]) -> list[LeakFinding]:
         env = os.environ.get(_OVERLAY_TERMS_ENV, "")
-        terms = (
-            tuple(t.strip() for t in env.split(",") if t.strip())
-            if env
-            else tuple(str(t) for t in cold_reader.list_setting("overlay_leak_terms", default=[]))
-        )
+        # Registry-first dual-read via terms_for_gate("overlay"); the overlay env
+        # override still WINS, matching check_no_overlay_leak.
+        terms = tuple(t.strip() for t in env.split(",") if t.strip()) if env else terms_for_gate("overlay")
         findings = [
             LeakFinding(gate="overlay-leak", path=path, detail=f"overlay-scoped term '{term}'")
             for path, lines in lines_by_path.items()

--- a/src/teatree/hooks/banned_term_registry.py
+++ b/src/teatree/hooks/banned_term_registry.py
@@ -1,7 +1,6 @@
-r"""Consolidated, class-tagged banned-term registry (banned-terms-registry PR 1).
+r"""Consolidated, class-tagged banned-term registry — the single term-source home.
 
-Teatree carries three separate DB-home term sources today, each read by a
-different gate:
+Teatree carries four separate DB-home term sources, each read by a different gate:
 
 * ``banned_terms`` — the flat leak list the commit/posting DIFF gate
     (``banned_terms_cli`` / ``banned_terms_scanner``) and the in-process CORE
@@ -9,20 +8,31 @@ different gate:
 * ``banned_brands`` — the high-confidence list the full-TREE backstop
     (``banned_terms_tree_scan``) scans.
 * ``banned_terms_allowlist`` — the company-identifier carve-out.
+* ``overlay_leak_terms`` — the BLUEPRINT § 1 "core stays generic" gate
+    (``check_no_overlay_leak`` / ``fast_push``) that keeps overlay-specific names
+    out of the scanned core roots.
 
-This module is the single consolidated home the three collapse into: ONE
+This module is the single consolidated home the four collapse into: ONE
 ``banned_term_registry`` row (or the ``$TEATREE_TERM_REGISTRY`` secret) mapping
 each term to a CLASS, plus :func:`terms_for_gate` — the one router that returns
-the terms a given gate should scan, by class:
+the terms a given gate should scan, by class. The class taxonomy (the canonical
+reference table is ``docs/blueprint/configuration.md`` § 10.6):
 
-===============  ================================  =========================
-class            scanned by gates                  legacy source it migrates
-===============  ================================  =========================
-``leak``         diff + tree + core                ``banned_brands``
-``prose_collider``  diff + core                    ``banned_terms``
-``tone``         diff                              (none today)
-``allow``        the allowlist carve-out           ``banned_terms_allowlist``
-===============  ================================  =========================
+================  ===============================  =========================  ===============
+class             scanned by gate                  legacy source it migrates  unset behaviour
+================  ===============================  =========================  ===============
+``leak``          diff + tree + core               ``banned_brands``          fail-loud
+``prose_collider``  diff + core                    ``banned_terms``           fail-loud
+``tone``          diff                             (none today)               inert
+``overlay``       overlay (core-generic gate)      ``overlay_leak_terms``     inert
+``allow``         the allowlist carve-out          ``banned_terms_allowlist``  inert
+================  ===============================  =========================  ===============
+
+The ``leak`` and ``prose_collider`` classes fail LOUD when both the registry and
+their legacy source are unset (:class:`BannedTermsUnsetError`); ``tone``,
+``overlay`` and ``allow`` are optional and default to an empty, inert set (the
+overlay pass is inert-when-empty by design — an operator with no overlay-scoped
+names is a legitimate no-op, never a refusal).
 
 **Dual-read, registry-first.** :func:`terms_for_gate` (and the legacy
 :func:`banned_terms_cli.resolve_banned_terms` / :func:`banned_terms_tree_scan.load_brand_terms`)
@@ -57,26 +67,43 @@ __all__ = [
     "ALLOW",
     "GATE_CLASSES",
     "LEAK",
+    "OVERLAY",
     "PROSE_COLLIDER",
+    "REGISTRY_TERM_CLASSES",
     "TERM_CLASSES",
     "TONE",
     "MigrationVerification",
     "allowlist_terms",
     "build_registry_from_legacy",
     "class_of_term",
+    "export_scan_terms",
     "load_registry",
     "registry_terms_for_gate",
     "terms_for_gate",
     "verify_migration",
 ]
 
+#: The overlay-leak class. It is registry-only (no :mod:`leak_policy` surface routes
+#: to it) because the BLUEPRINT § 1 "core stays generic" gate is a distinct concern
+#: from the publish-surface leak gates :func:`leak_policy.decide` governs. Its legacy
+#: source is the ``overlay_leak_terms`` row.
+OVERLAY: Final = "overlay"
+
+#: The registry's recognised class set: the :mod:`leak_policy` publish-surface taxonomy
+#: PLUS :data:`OVERLAY`. ``_normalise_registry`` keeps exactly these top-level keys; any
+#: other key is ignored (not a leak source).
+REGISTRY_TERM_CLASSES: Final[tuple[str, ...]] = (*TERM_CLASSES, OVERLAY)
+
 # Which term CLASSES each scanning gate consumes, DERIVED from the one policy
 # (:func:`teatree.hooks.leak_policy.classes_for_surface`) rather than restated —
-# the gate names are the legacy keys the dual-read callers already pass.
+# the gate names are the legacy keys the dual-read callers already pass. The
+# ``overlay`` gate is registry-only (its class is not a publish surface), so it is
+# added explicitly rather than derived from a surface.
 GATE_CLASSES: Final[dict[str, tuple[str, ...]]] = {
     "diff": classes_for_surface(Surface.DIFF),
     "core": classes_for_surface(Surface.CORE),
     "tree": classes_for_surface(Surface.TREE),
+    "overlay": (OVERLAY,),
 }
 
 _REGISTRY_KEY: Final = "banned_term_registry"
@@ -95,10 +122,10 @@ def _normalise_registry(raw: object) -> dict[str, tuple[str, ...]]:
     if not isinstance(raw, dict):
         msg = f"the {_REGISTRY_KEY} registry is set but not a table ({type(raw).__name__}) — refusing to scan as empty"
         raise BannedTermsUnsetError(msg)
-    normalised: dict[str, tuple[str, ...]] = dict.fromkeys(TERM_CLASSES, ())
+    normalised: dict[str, tuple[str, ...]] = dict.fromkeys(REGISTRY_TERM_CLASSES, ())
     for key, value in raw.items():
         term_class = str(key)
-        if term_class not in TERM_CLASSES:
+        if term_class not in REGISTRY_TERM_CLASSES:
             continue  # unknown top-level key: ignored, not a leak source
         if not isinstance(value, list):
             msg = f"the {_REGISTRY_KEY} registry class {term_class!r} is not a list — refusing to scan as empty"
@@ -168,9 +195,11 @@ def terms_for_gate(gate: str, *, db_path: Path | None = None) -> tuple[str, ...]
     the classes *gate* consumes (``GATE_CLASSES``, or the ``allow`` carve-out).
     When the registry is unset, fall back to the OLD per-gate source
     (``resolve_banned_terms`` for ``diff``/``core``, ``load_brand_terms`` for
-    ``tree``, the allowlist for ``allow``). When BOTH the registry and the legacy
-    source are unset, the legacy resolver RAISES :class:`BannedTermsUnsetError` —
-    the gate REFUSES (fail-closed), never scans as empty.
+    ``tree``, ``overlay_leak_terms`` for ``overlay``, the allowlist for ``allow``).
+    When BOTH the registry and a fail-loud gate's legacy source (``diff``/``core``/
+    ``tree``) are unset, the legacy resolver RAISES :class:`BannedTermsUnsetError` —
+    the gate REFUSES (fail-closed), never scans as empty. The optional gates
+    (``overlay``/``allow``) instead yield an empty, inert set.
     """
     registry = load_registry(db_path=db_path)
     if registry is not None:
@@ -187,6 +216,8 @@ def _legacy_terms_for_gate(gate: str, *, db_path: Path | None = None) -> tuple[s
         return resolve_banned_terms(db_path=db_path)
     if gate == "tree":
         return load_brand_terms(db_path=db_path)
+    if gate == "overlay":
+        return _legacy_overlay_terms(db_path=db_path)
     if gate == ALLOW:
         return _legacy_allowlist(db_path=db_path)
     msg = f"unknown banned-terms gate {gate!r}"
@@ -199,6 +230,64 @@ def _legacy_allowlist(db_path: Path | None = None) -> tuple[str, ...]:
     if not isinstance(raw, list):
         return ()
     return tuple(str(entry).strip() for entry in raw if str(entry).strip())
+
+
+def _legacy_overlay_terms(db_path: Path | None = None) -> tuple[str, ...]:
+    """The DB-home ``overlay_leak_terms`` row — empty when unset (inert, NEVER raises).
+
+    The overlay pass is inert-when-empty by design (an operator with no overlay-scoped
+    names is a legitimate no-op), so an unset row yields an empty tuple exactly like the
+    allowlist — never a :class:`BannedTermsUnsetError`.
+    """
+    raw = cold_reader.read_setting("overlay_leak_terms", db_path=db_path)
+    if not isinstance(raw, list):
+        return ()
+    return tuple(str(entry).strip() for entry in raw if str(entry).strip())
+
+
+def export_scan_terms(*, db_path: Path | None = None) -> tuple[str, ...]:
+    """Every ban-class term for the config-export content scan; fail-safe to empty.
+
+    Registry-first: the order-stable union of the four ban classes (``leak`` +
+    ``prose_collider`` + ``tone`` + ``overlay``; the ``allow`` carve-out is not a ban
+    source, so it is excluded). When the registry is unset, the legacy ``banned_terms``
+    + ``banned_brands`` rows — the two the export scanned before the registry existed.
+    Unlike the gates this NEVER raises on a genuinely-unset source: the export is a
+    backup command, so a store with no terms configured yields an empty scan set. A
+    MALFORMED registry still fails loud (propagates :class:`BannedTermsUnsetError`).
+    """
+    registry = load_registry(db_path=db_path)
+    if registry is not None:
+        seen: dict[str, None] = {}
+        for term_class in (LEAK, PROSE_COLLIDER, TONE, OVERLAY):
+            for term in registry[term_class]:
+                if term.strip():
+                    seen.setdefault(term, None)
+        return tuple(seen)
+    return _legacy_export_scan_terms(db_path=db_path)
+
+
+def _legacy_export_scan_terms(db_path: Path | None = None) -> tuple[str, ...]:
+    """The pre-registry export scan set: ``banned_terms`` + ``banned_brands``, fail-safe.
+
+    Routes through the two legacy resolvers rather than reading their rows directly, so
+    the registry module stays the single home for legacy-key resolution. A genuinely-
+    unset source is caught and skipped (an empty scan set) — the export must not crash
+    on a store with no terms.
+    """
+    from teatree.hooks.banned_terms_cli import resolve_banned_terms  # noqa: PLC0415  dual-read cycle
+    from teatree.hooks.banned_terms_tree_scan import load_brand_terms  # noqa: PLC0415  dual-read cycle
+
+    seen: dict[str, None] = {}
+    for resolver in (resolve_banned_terms, load_brand_terms):
+        try:
+            resolved = resolver(db_path=db_path)
+        except BannedTermsUnsetError:
+            continue
+        for term in resolved:
+            if term.strip():
+                seen.setdefault(term, None)
+    return tuple(seen)
 
 
 def class_of_term(term: str, *, db_path: Path | None = None) -> str:
@@ -243,15 +332,17 @@ def _dedup(terms: tuple[str, ...]) -> list[str]:
 
 
 def build_registry_from_legacy(db_path: Path | None = None) -> dict[str, list[str]]:
-    """Build the class-tagged registry from the current three legacy sources.
+    """Build the class-tagged registry from the current four legacy sources.
 
     ``banned_brands`` → ``leak`` (the high-confidence list, scanned everywhere);
     ``banned_terms`` → ``prose_collider`` (its current diff+core routing, never
-    the full tree); ``banned_terms_allowlist`` → ``allow``. ``tone`` starts empty
-    (no current source maps to it). ``banned_terms`` is REQUIRED — an unset list
-    propagates :class:`BannedTermsUnsetError` so a migration can never
-    silently produce an empty registry; ``banned_brands`` is optional (an unset
-    brand list is a legitimate no-brands operator and yields an empty ``leak``).
+    the full tree); ``overlay_leak_terms`` → ``overlay``;
+    ``banned_terms_allowlist`` → ``allow``. ``tone`` starts empty (no current source
+    maps to it). ``banned_terms`` is REQUIRED — an unset list propagates
+    :class:`BannedTermsUnsetError` so a migration can never silently produce an empty
+    registry; ``banned_brands`` is optional (an unset brand list is a legitimate
+    no-brands operator and yields an empty ``leak``), as are ``overlay_leak_terms``
+    and the allowlist (both inert-when-empty).
     """
     from teatree.hooks.banned_terms_cli import resolve_banned_terms  # noqa: PLC0415  dual-read cycle
     from teatree.hooks.banned_terms_tree_scan import load_brand_terms  # noqa: PLC0415  dual-read cycle
@@ -261,11 +352,13 @@ def build_registry_from_legacy(db_path: Path | None = None) -> dict[str, list[st
         brands = load_brand_terms(db_path=db_path)
     except BannedTermsUnsetError:
         brands = ()
+    overlay = _legacy_overlay_terms(db_path=db_path)
     allow = allowlist_terms(db_path=db_path)
     return {
         LEAK: _dedup(brands),
         PROSE_COLLIDER: _dedup(terms),
         TONE: [],
+        OVERLAY: _dedup(overlay),
         ALLOW: _dedup(allow),
     }
 
@@ -277,15 +370,18 @@ class MigrationVerification:
     ``dropped`` — a term the old config scanned that the registry's effective set
     no longer carries (a lossy migration). ``added`` — a term the registry carries
     that no old source had (a fabricated term). ``allow_mismatch`` — the ``allow``
-    class does not equal the old allowlist. ``per_gate_drops`` — per gate, the
-    terms that gate scanned before but the new class routing would stop scanning.
-    ``ok`` is True only when all four are empty: the migration is provably lossless.
+    class does not equal the old allowlist. ``overlay_mismatch`` — the ``overlay``
+    class does not equal the old ``overlay_leak_terms``. ``per_gate_drops`` — per
+    gate, the terms that gate scanned before but the new class routing would stop
+    scanning. ``ok`` is True only when all five are empty: the migration is provably
+    lossless.
     """
 
     ok: bool
     dropped: tuple[str, ...]
     added: tuple[str, ...]
     allow_mismatch: bool
+    overlay_mismatch: bool
     per_gate_drops: dict[str, tuple[str, ...]]
 
     def failure_reason(self) -> str:
@@ -299,6 +395,8 @@ class MigrationVerification:
             lines.append(f"unexpected terms (in the registry, absent from old config): {', '.join(self.added)}")
         if self.allow_mismatch:
             lines.append("the registry allow class does not match the old banned_terms_allowlist")
+        if self.overlay_mismatch:
+            lines.append("the registry overlay class does not match the old overlay_leak_terms")
         for gate, missing in self.per_gate_drops.items():
             lines.append(f"gate {gate!r} would stop scanning: {', '.join(missing)}")
         return "\n".join(lines)
@@ -308,10 +406,11 @@ def verify_migration(registry: dict[str, list[str]], *, db_path: Path | None = N
     """Verify *registry* reproduces every effective term the old three sources yield.
 
     Recomputes the old effective sets (``banned_terms`` for the diff/core gates,
-    ``banned_brands`` for the tree gate, the allowlist for ``allow``) and checks the
-    registry against them: no term dropped from the union, no term fabricated, the
-    allowlist round-trips exactly, and no per-gate term the routing would stop
-    scanning. The migration is lossless iff :attr:`MigrationVerification.ok`.
+    ``banned_brands`` for the tree gate, ``overlay_leak_terms`` for the overlay gate,
+    the allowlist for ``allow``) and checks the registry against them: no term dropped
+    from the union, no term fabricated, the allowlist and the overlay class round-trip
+    exactly, and no per-gate term the routing would stop scanning. The migration is
+    lossless iff :attr:`MigrationVerification.ok`.
     """
     from teatree.hooks.banned_terms_cli import resolve_banned_terms  # noqa: PLC0415  dual-read cycle
     from teatree.hooks.banned_terms_tree_scan import load_brand_terms  # noqa: PLC0415  dual-read cycle
@@ -321,6 +420,7 @@ def verify_migration(registry: dict[str, list[str]], *, db_path: Path | None = N
         old_brands = set(load_brand_terms(db_path=db_path))
     except BannedTermsUnsetError:
         old_brands = set()
+    old_overlay = set(_legacy_overlay_terms(db_path=db_path))
     old_allow = set(allowlist_terms(db_path=db_path))
 
     normalised = _normalise_registry(registry)
@@ -330,18 +430,20 @@ def verify_migration(registry: dict[str, list[str]], *, db_path: Path | None = N
     dropped = old_all - new_ban
     added = new_ban - old_all
     allow_mismatch = set(normalised[ALLOW]) != old_allow
+    overlay_mismatch = set(normalised[OVERLAY]) != old_overlay
 
     per_gate_drops: dict[str, tuple[str, ...]] = {}
-    for gate, old_set in (("diff", old_ban), ("core", old_ban), ("tree", old_brands)):
+    for gate, old_set in (("diff", old_ban), ("core", old_ban), ("tree", old_brands), ("overlay", old_overlay)):
         missing = old_set - set(_classes_union(normalised, gate))
         if missing:
             per_gate_drops[gate] = tuple(sorted(missing))
 
-    ok = not dropped and not added and not allow_mismatch and not per_gate_drops
+    ok = not dropped and not added and not allow_mismatch and not overlay_mismatch and not per_gate_drops
     return MigrationVerification(
         ok=ok,
         dropped=tuple(sorted(dropped)),
         added=tuple(sorted(added)),
         allow_mismatch=allow_mismatch,
+        overlay_mismatch=overlay_mismatch,
         per_gate_drops=per_gate_drops,
     )

--- a/src/teatree/hooks/banned_terms_scanner.py
+++ b/src/teatree/hooks/banned_terms_scanner.py
@@ -97,15 +97,24 @@ class ToolInput(TypedDict, total=False):
 
 
 def _banned_terms_configured(config_path: Path | None) -> bool:
-    """Return True iff the DB-home ``banned_terms`` list (or the env override) is set.
+    """Return True iff a banned-terms source (registry, env, or legacy row) is set.
 
     The gate is a clean NO-OP when nothing is configured — matching the shell
     hook's own "no terms ⇒ no-op" contract — so this decides whether to shell
-    out at all. A set ``T3_BANNED_TERMS`` env or a present ``banned_terms`` DB
-    row (even an explicit empty list) counts as configured; *config_path*
-    overrides the DB path (else the canonical DB / ``T3_CONFIG_DB``).
+    out at all. Configured means ANY of: a set ``T3_BANNED_TERMS`` env; the
+    consolidated ``banned_term_registry`` present (DB row or
+    ``$TEATREE_TERM_REGISTRY`` secret); or a present legacy ``banned_terms`` row
+    (even an explicit empty list). Consulting the registry closes the post-cutover
+    fail-open: once the operator sets the registry and drops the legacy row, the
+    gate must still scan rather than silently no-op. *config_path* overrides the
+    DB path (else the canonical DB / ``T3_CONFIG_DB``). A malformed registry
+    propagates :class:`BannedTermsUnsetError` (fail-loud), never a silent no-op.
     """
+    from teatree.hooks.banned_term_registry import load_registry  # noqa: PLC0415  dual-read cycle
+
     if os.environ.get(_TERMS_ENV, "").strip():
+        return True
+    if load_registry(db_path=config_path) is not None:
         return True
     return isinstance(cold_reader.read_setting(_TERMS_KEY, db_path=config_path), list)
 

--- a/tests/teatree_backends/test_sharepoint.py
+++ b/tests/teatree_backends/test_sharepoint.py
@@ -148,12 +148,12 @@ class TestVerifyReadOnly:
 class TestEnvAndConfig:
     def test_password_command_rides_env_not_argv(self) -> None:
         with patch("teatree.backends.sharepoint.run_checked", return_value=_ok("[]")) as run:
-            _client(password_command="pass topsecret-entry").list_files()
+            _client(password_command="pass swordfish-entry").list_files()
 
         env = run.call_args.kwargs["env"]
-        assert env["RCLONE_PASSWORD_COMMAND"] == "pass topsecret-entry"
+        assert env["RCLONE_PASSWORD_COMMAND"] == "pass swordfish-entry"
         assert env["PATH"]  # merged with the ambient environment, not a bare dict
-        assert all("topsecret-entry" not in arg for arg in run.call_args.args[0])
+        assert all("swordfish-entry" not in arg for arg in run.call_args.args[0])
 
     def test_no_password_command_passes_no_env(self) -> None:
         with patch("teatree.backends.sharepoint.run_checked", return_value=_ok("[]")) as run:

--- a/tests/teatree_core/test_config_migration.py
+++ b/tests/teatree_core/test_config_migration.py
@@ -7,14 +7,18 @@ DB: global rows render under ``[teatree]``, each overlay scope under
 shared export never leaks a codename.
 """
 
+import json
 import os
+import sqlite3
 import tomllib
+from pathlib import Path
 from unittest import mock
 
+import pytest
 from django.test import TestCase
 
 from teatree.config import COLD_HOOK_SETTINGS, OVERLAY_OVERRIDABLE_SETTINGS
-from teatree.core.config_migration import export_db_to_toml
+from teatree.core.config_migration import _resolve_export_scan_terms, export_db_to_toml
 from teatree.core.models import ConfigSetting
 
 
@@ -162,3 +166,37 @@ class TestExportScanTermsResolveFailsSafe(TestCase):
         assert doc["teatree"]["mode"] == "auto"
         # No terms resolved => nothing to redact; the export is valid and complete.
         assert export.redacted == ()
+
+
+class TestExportScanTermsRoutesThroughRegistry:
+    """``_resolve_export_scan_terms`` resolves through the consolidated registry.
+
+    Seeds the canonical config DB directly (via ``T3_CONFIG_DB``) so ``cold_reader``
+    reads it, then asserts the export scan set is the union of every ban class,
+    ``overlay`` included, and excludes the ``allow`` carve-out.
+    """
+
+    def _seed_registry(self, tmp_path: Path, registry: dict[str, list[str]]) -> Path:
+        db = tmp_path / "registry.sqlite3"
+        conn = sqlite3.connect(str(db))
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS teatree_config_setting ("
+            "id INTEGER PRIMARY KEY, scope TEXT NOT NULL DEFAULT '', key TEXT NOT NULL, value TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO teatree_config_setting (scope, key, value) VALUES ('', 'banned_term_registry', ?)",
+            (json.dumps(registry),),
+        )
+        conn.commit()
+        conn.close()
+        return db
+
+    def test_union_includes_overlay_and_excludes_allow(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        db = self._seed_registry(
+            tmp_path,
+            {"leak": ["democorp"], "prose_collider": ["widget-margin"], "overlay": ["acme-internal"], "allow": ["ok"]},
+        )
+        monkeypatch.setenv("T3_CONFIG_DB", str(db))
+        monkeypatch.delenv("T3_BANNED_TERMS", raising=False)
+        monkeypatch.delenv("TEATREE_TERM_REGISTRY", raising=False)
+        assert set(_resolve_export_scan_terms()) == {"democorp", "widget-margin", "acme-internal"}

--- a/tests/teatree_core/test_env_command.py
+++ b/tests/teatree_core/test_env_command.py
@@ -235,7 +235,7 @@ class TestEnvMigrateSecrets(TestCase):
             cache_dir = ticket_dir / CACHE_DIRNAME / wt_path.name
             cache_dir.mkdir(parents=True)
             cache_file = cache_dir / CACHE_FILENAME
-            cache_file.write_text("FOO=bar\nPOSTGRES_PASSWORD=top-secret\n", encoding="utf-8")
+            cache_file.write_text("FOO=bar\nPOSTGRES_PASSWORD=swordfish\n", encoding="utf-8")
 
             ticket = Ticket.objects.create(overlay="teatree", issue_url="https://example.com/issues/42")
             wt = Worktree.objects.create(
@@ -260,9 +260,9 @@ class TestEnvMigrateSecrets(TestCase):
                 call_command("env", "migrate-secrets", "--path", str(wt_path))
 
             # Pass key is ticket-pk-scoped (canonical, unique), not ticket_number.
-            assert stored == {f"teatree/wt/{wt.ticket_id}/postgres": "top-secret"}
+            assert stored == {f"teatree/wt/{wt.ticket_id}/postgres": "swordfish"}
             new_body = cache_file.read_text(encoding="utf-8")
-            assert "POSTGRES_PASSWORD=top-secret" not in new_body
+            assert "POSTGRES_PASSWORD=swordfish" not in new_body
             assert f"POSTGRES_PASSWORD_PASS_KEY=teatree/wt/{wt.ticket_id}/postgres" in new_body
 
     def test_reports_already_migrated_when_no_literal_present(self) -> None:

--- a/tests/teatree_core/test_fast_push.py
+++ b/tests/teatree_core/test_fast_push.py
@@ -347,3 +347,46 @@ class TestCoreGateClassRouting:
     ) -> None:
         self._seed_registry(tmp_path, monkeypatch)
         assert LeakGateScan._banned_terms({"sample.txt": ["blunder"]}) == []
+
+    @staticmethod
+    def _seed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, registry: dict[str, list[str]]) -> None:
+        db = tmp_path / "registry.sqlite3"
+        conn = sqlite3.connect(str(db))
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS teatree_config_setting ("
+            "id INTEGER PRIMARY KEY, scope TEXT NOT NULL DEFAULT '', key TEXT NOT NULL, value TEXT NOT NULL)"
+        )
+        conn.execute("DELETE FROM teatree_config_setting WHERE key = 'banned_term_registry'")
+        conn.execute(
+            "INSERT INTO teatree_config_setting (scope, key, value) VALUES ('', 'banned_term_registry', ?)",
+            (json.dumps(registry),),
+        )
+        conn.commit()
+        conn.close()
+        monkeypatch.setenv("T3_CONFIG_DB", str(db))
+        monkeypatch.delenv("T3_BANNED_TERMS", raising=False)
+        monkeypatch.delenv("TEATREE_OVERLAY_LEAK_TERMS", raising=False)
+
+    def test_overlay_gate_reads_the_registry_overlay_class(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # With no overlay env override, the overlay gate must resolve through the
+        # registry's ``overlay`` class (not the excluded ``leak``/``prose_collider``).
+        self._seed(tmp_path, monkeypatch, {"leak": ["democorp"], "overlay": ["acme-internal"]})
+        findings = LeakGateScan._overlay_leak({"sample.txt": ["uses acme-internal here"]})
+        assert [f.detail for f in findings] == ["overlay-scoped term 'acme-internal'"]
+        assert LeakGateScan._overlay_leak({"sample.txt": ["mentions democorp"]}) == []
+
+    def test_banned_terms_carve_out_reads_the_registry_allow_class(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The company-identifier carve-out must come from the registry's ``allow``
+        # class: an allow-listed identifier is blanked before matching, so the
+        # ``prose_collider`` slug inside it is NOT flagged.
+        self._seed(tmp_path, monkeypatch, {"prose_collider": ["acme"], "allow": ["acme-product"]})
+        assert LeakGateScan._banned_terms({"sample.txt": ["the acme-product repo"]}) == []
+        # Remove the carve-out and the bare slug flags again — anti-vacuous control.
+        self._seed(tmp_path, monkeypatch, {"prose_collider": ["acme"]})
+        assert [f.detail for f in LeakGateScan._banned_terms({"sample.txt": ["the acme-product repo"]})] == [
+            "banned term 'acme'"
+        ]

--- a/tests/teatree_core/test_pending_chat_injection_model.py
+++ b/tests/teatree_core/test_pending_chat_injection_model.py
@@ -427,10 +427,10 @@ class TestUnansweredQuestionsSince:
 
         rows = PendingChatInjection.unanswered_questions_since(timedelta(hours=1))
 
-        slack_tss = [r.slack_ts for r in rows]
-        assert "1" in slack_tss
-        assert "2" in slack_tss
-        assert "3" not in slack_tss
+        slack_ts_list = [r.slack_ts for r in rows]
+        assert "1" in slack_ts_list
+        assert "2" in slack_ts_list
+        assert "3" not in slack_ts_list
         assert q1 is not None
         assert q2 is not None
 

--- a/tests/teatree_hooks/test_banned_term_registry.py
+++ b/tests/teatree_hooks/test_banned_term_registry.py
@@ -253,3 +253,110 @@ def test_registry_key_is_a_registered_settable_secret() -> None:
 def test_unknown_gate_name_is_a_value_error() -> None:
     with pytest.raises(ValueError, match="unknown banned-terms gate"):
         banned_term_registry._classes_union({"leak": (), "prose_collider": (), "tone": (), "allow": ()}, "bogus")
+
+
+class TestOverlayGateRouting:
+    """The overlay class routes to the overlay gate only, and is inert-when-empty."""
+
+    def test_gate_classes_maps_overlay_to_the_overlay_class(self) -> None:
+        assert banned_term_registry.GATE_CLASSES["overlay"] == (banned_term_registry.OVERLAY,)
+        assert banned_term_registry.OVERLAY in banned_term_registry.REGISTRY_TERM_CLASSES
+
+    def test_registry_overlay_class_is_scanned_only_by_the_overlay_gate(self, tmp_path: Path) -> None:
+        db = _seed(
+            tmp_path,
+            banned_term_registry={
+                "leak": ["democorp"],
+                "prose_collider": ["widget-margin"],
+                "overlay": ["acme-internal"],
+            },
+        )
+        assert terms_for_gate("overlay", db_path=db) == ("acme-internal",)
+        assert "acme-internal" not in terms_for_gate("diff", db_path=db)
+        assert "acme-internal" not in terms_for_gate("core", db_path=db)
+        assert "acme-internal" not in terms_for_gate("tree", db_path=db)
+
+    def test_overlay_falls_back_to_legacy_overlay_leak_terms(self, tmp_path: Path) -> None:
+        db = _seed(tmp_path, overlay_leak_terms=["acme-internal", "widget-svc"])
+        assert terms_for_gate("overlay", db_path=db) == ("acme-internal", "widget-svc")
+
+    def test_overlay_is_inert_when_registry_and_legacy_both_unset(self, tmp_path: Path) -> None:
+        # The overlay gate NEVER fail-closes (unlike diff/core/tree): an operator with
+        # no overlay-scoped names is a legitimate no-op, so both-unset yields ().
+        assert terms_for_gate("overlay", db_path=_empty_db(tmp_path)) == ()
+
+    def test_overlay_is_inert_when_registry_present_without_overlay_class(self, tmp_path: Path) -> None:
+        db = _seed(tmp_path, banned_term_registry={"leak": ["democorp"]})
+        assert terms_for_gate("overlay", db_path=db) == ()
+
+    def test_registry_wins_over_legacy_overlay_row(self, tmp_path: Path) -> None:
+        db = _seed(
+            tmp_path,
+            overlay_leak_terms=["legacy-overlay"],
+            banned_term_registry={"leak": ["democorp"], "overlay": ["acme-internal"]},
+        )
+        assert terms_for_gate("overlay", db_path=db) == ("acme-internal",)
+        assert "legacy-overlay" not in terms_for_gate("overlay", db_path=db)
+
+    def test_registry_terms_for_gate_overlay(self, tmp_path: Path) -> None:
+        legacy = _seed(tmp_path, overlay_leak_terms=["legacy-overlay"])
+        assert registry_terms_for_gate("overlay", db_path=legacy) is None
+        with_reg = _seed(tmp_path, banned_term_registry={"overlay": ["acme-internal"]})
+        assert registry_terms_for_gate("overlay", db_path=with_reg) == ("acme-internal",)
+
+    def test_env_registry_overlay_class(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TEATREE_TERM_REGISTRY", json.dumps({"overlay": ["acme-internal"]}))
+        assert terms_for_gate("overlay", db_path=_empty_db(tmp_path)) == ("acme-internal",)
+
+
+class TestOverlayMigrationRoundTrip:
+    """build_registry_from_legacy carries overlay_leak_terms; verify_migration round-trips it."""
+
+    def test_build_maps_overlay_leak_terms_to_overlay_class(self, tmp_path: Path) -> None:
+        db = _seed(tmp_path, banned_terms=["acme"], overlay_leak_terms=["acme-internal", "widget-svc"])
+        registry = banned_term_registry.build_registry_from_legacy(db_path=db)
+        assert set(registry["overlay"]) == {"acme-internal", "widget-svc"}
+
+    def test_verify_is_lossless_including_overlay(self, tmp_path: Path) -> None:
+        db = _seed(tmp_path, banned_terms=["acme"], overlay_leak_terms=["acme-internal"])
+        registry = banned_term_registry.build_registry_from_legacy(db_path=db)
+        verification = banned_term_registry.verify_migration(registry, db_path=db)
+        assert verification.ok
+        assert verification.overlay_mismatch is False
+
+    def test_dropped_overlay_term_is_caught(self, tmp_path: Path) -> None:
+        db = _seed(tmp_path, banned_terms=["acme"], overlay_leak_terms=["acme-internal"])
+        good = banned_term_registry.build_registry_from_legacy(db_path=db)
+        lossy = {**good, "overlay": []}  # drop the overlay term
+        verification = banned_term_registry.verify_migration(lossy, db_path=db)
+        assert not verification.ok
+        assert verification.overlay_mismatch
+        assert "overlay class" in verification.failure_reason()
+
+
+class TestExportScanTermsUnion:
+    """export_scan_terms unions every ban class (incl overlay), fail-safe to empty."""
+
+    def test_registry_union_includes_overlay_excludes_allow(self, tmp_path: Path) -> None:
+        db = _seed(
+            tmp_path,
+            banned_term_registry={
+                "leak": ["democorp"],
+                "prose_collider": ["widget-margin"],
+                "tone": ["synergy"],
+                "overlay": ["acme-internal"],
+                "allow": ["myorg-product"],
+            },
+        )
+        terms = set(banned_term_registry.export_scan_terms(db_path=db))
+        assert terms == {"democorp", "widget-margin", "synergy", "acme-internal"}
+        assert "myorg-product" not in terms
+
+    def test_legacy_fallback_is_banned_terms_and_brands(self, tmp_path: Path) -> None:
+        db = _seed(tmp_path, banned_terms=["acme"], banned_brands=["democorp"], overlay_leak_terms=["acme-internal"])
+        # Registry unset -> the legacy two rows only (overlay_leak_terms is NOT part of
+        # the pre-registry export scan set).
+        assert set(banned_term_registry.export_scan_terms(db_path=db)) == {"acme", "democorp"}
+
+    def test_fail_safe_to_empty_when_all_unset(self, tmp_path: Path) -> None:
+        assert banned_term_registry.export_scan_terms(db_path=_empty_db(tmp_path)) == ()

--- a/tests/teatree_hooks/test_banned_term_registry.py
+++ b/tests/teatree_hooks/test_banned_term_registry.py
@@ -26,7 +26,13 @@ import pytest
 from teatree.config.registries import COLD_SETTINGS
 from teatree.config.secret_settings import SECRET_SETTINGS
 from teatree.hooks import banned_term_registry
-from teatree.hooks.banned_term_registry import allowlist_terms, load_registry, registry_terms_for_gate, terms_for_gate
+from teatree.hooks.banned_term_registry import (
+    allowlist_terms,
+    export_scan_terms,
+    load_registry,
+    registry_terms_for_gate,
+    terms_for_gate,
+)
 from teatree.hooks.banned_terms_cli import resolve_banned_terms
 from teatree.hooks.banned_terms_tree_scan import BannedTermsUnsetError, load_brand_terms
 
@@ -348,7 +354,7 @@ class TestExportScanTermsUnion:
                 "allow": ["myorg-product"],
             },
         )
-        terms = set(banned_term_registry.export_scan_terms(db_path=db))
+        terms = set(export_scan_terms(db_path=db))
         assert terms == {"democorp", "widget-margin", "synergy", "acme-internal"}
         assert "myorg-product" not in terms
 
@@ -356,7 +362,7 @@ class TestExportScanTermsUnion:
         db = _seed(tmp_path, banned_terms=["acme"], banned_brands=["democorp"], overlay_leak_terms=["acme-internal"])
         # Registry unset -> the legacy two rows only (overlay_leak_terms is NOT part of
         # the pre-registry export scan set).
-        assert set(banned_term_registry.export_scan_terms(db_path=db)) == {"acme", "democorp"}
+        assert set(export_scan_terms(db_path=db)) == {"acme", "democorp"}
 
     def test_fail_safe_to_empty_when_all_unset(self, tmp_path: Path) -> None:
-        assert banned_term_registry.export_scan_terms(db_path=_empty_db(tmp_path)) == ()
+        assert export_scan_terms(db_path=_empty_db(tmp_path)) == ()

--- a/tests/teatree_hooks/test_banned_terms_scanner.py
+++ b/tests/teatree_hooks/test_banned_terms_scanner.py
@@ -3023,3 +3023,49 @@ class TestSentinelRecognition:
     def test_clean_text_is_neither_sentinel(self) -> None:
         assert not _command_parser.is_fail_closed_sentinel("a normal clean body")
         assert not is_unavailable_body_source_sentinel("a normal clean body")
+
+
+class TestConfiguredCheckHonoursTheRegistry:
+    """The consolidated registry alone counts as configured — the gate must not no-op.
+
+    Once the operator sets ``banned_term_registry`` and drops the legacy
+    ``banned_terms`` row (the intended end state), ``_banned_terms_configured``
+    must still report configured. The old check consulted only the legacy row +
+    env, so a registry-only store silently degraded the whole posting gate to a
+    no-op that scans nothing — RED before the fix.
+    """
+
+    def _seed_registry_only(self, tmp_path: Path, registry: dict[str, list[str]]) -> Path:
+        db = tmp_path / "registry_only.sqlite3"
+        conn = sqlite3.connect(str(db))
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS teatree_config_setting ("
+            "id INTEGER PRIMARY KEY, scope TEXT NOT NULL DEFAULT '', key TEXT NOT NULL, value TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO teatree_config_setting (scope, key, value) VALUES ('', 'banned_term_registry', ?)",
+            (json.dumps(registry),),
+        )
+        conn.commit()
+        conn.close()
+        return db
+
+    def test_registry_only_store_counts_as_configured(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("T3_BANNED_TERMS", raising=False)
+        monkeypatch.delenv("TEATREE_TERM_REGISTRY", raising=False)
+        db = self._seed_registry_only(tmp_path, {"leak": ["democorp"], "prose_collider": ["widget-margin"]})
+        assert banned_terms_scanner._banned_terms_configured(db) is True
+
+    def test_neither_registry_nor_legacy_row_is_not_configured(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("T3_BANNED_TERMS", raising=False)
+        monkeypatch.delenv("TEATREE_TERM_REGISTRY", raising=False)
+        db = _seed_config_db(tmp_path, filename="empty_store.sqlite3")
+        assert banned_terms_scanner._banned_terms_configured(db) is False
+
+    def test_env_registry_counts_as_configured(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("T3_BANNED_TERMS", raising=False)
+        monkeypatch.setenv("TEATREE_TERM_REGISTRY", json.dumps({"leak": ["democorp"]}))
+        db = _seed_config_db(tmp_path, filename="empty_for_env.sqlite3")
+        assert banned_terms_scanner._banned_terms_configured(db) is True

--- a/tests/teatree_hooks/test_completion_claim_scanner.py
+++ b/tests/teatree_hooks/test_completion_claim_scanner.py
@@ -251,14 +251,14 @@ class TestMultiDeliverableFalseDoneWithoutDeliveryVocabStillFires:
 _MERGE_SHA_EVIDENCE_MAP = (
     "I read the authoritative spec and its comments and enumerated every deliverable.\n"
     "Both deliverables are merged and live on main — done.\n"
-    "- US-03 EURIBOR endpoint: MR !41 MERGED, merge commit "
+    "- REQ-03 line-items endpoint: MR !41 MERGED, merge commit "
     "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0, origin/main HEAD = "
     "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0, fast-forwarded.\n"
-    "- US-05 product-items endpoint: MR !42 MERGED, merge commit "
+    "- REQ-05 product-items endpoint: MR !42 MERGED, merge commit "
     "0f1e2d3c4b5a69788796a5b4c3d2e1f0a9b8c7d6, origin/main HEAD = "
     "0f1e2d3c4b5a69788796a5b4c3d2e1f0a9b8c7d6, fast-forwarded.\n"
-    "The crucial deliverable (US-03) is verified on its correct surface.\n"
-    "Both US-03 and US-05 are fixed and live on main.\n"
+    "The crucial deliverable (REQ-03) is verified on its correct surface.\n"
+    "Both REQ-03 and REQ-05 are fixed and live on main.\n"
 )
 
 # The sibling over-exemption guard (#2842 must not re-open): a multi-deliverable
@@ -269,9 +269,9 @@ _MERGE_SHA_EVIDENCE_MAP = (
 _MR_EXISTS_ONLY_FALSE_DONE = (
     "I read the authoritative spec and its comments.\n"
     "Both deliverables are done and ready to merge.\n"
-    "- US-03 EURIBOR endpoint: MR !41 opened, ready for review.\n"
-    "- US-05 product-items endpoint: PR #42 created, branch pushed.\n"
-    "The crucial deliverable (US-03) is verified on its correct surface.\n"
+    "- REQ-03 line-items endpoint: MR !41 opened, ready for review.\n"
+    "- REQ-05 product-items endpoint: PR #42 created, branch pushed.\n"
+    "The crucial deliverable (REQ-03) is verified on its correct surface.\n"
 )
 
 
@@ -305,9 +305,9 @@ class TestMergeShaEvidenceClears:
 _FORWARD_LOOKING_SLIP_THROUGH = (
     "I read the authoritative spec and enumerated every deliverable.\n"
     "Everything is done and ready to merge.\n"
-    "- US-03: PR #41 will be merged once CI passes.\n"
-    "- US-05: PR #42 will be merged once CI passes.\n"
-    "The crucial deliverable US-03 is verified on its correct surface.\n"
+    "- REQ-03: PR #41 will be merged once CI passes.\n"
+    "- REQ-05: PR #42 will be merged once CI passes.\n"
+    "The crucial deliverable REQ-03 is verified on its correct surface.\n"
 )
 
 # A genuine MERGED-state map whose ONLY on-target evidence is the bare MERGED token
@@ -316,9 +316,9 @@ _FORWARD_LOOKING_SLIP_THROUGH = (
 _BARE_MERGED_STATE_MAP = (
     "I read the authoritative spec and its comments and enumerated every deliverable.\n"
     "Both deliverables are merged and live — done.\n"
-    "- US-03 EURIBOR endpoint: PR #42 merged.\n"
-    "- US-05 product-items endpoint: MR !41 is merged.\n"
-    "The crucial deliverable (US-03) is verified on its correct surface.\n"
+    "- REQ-03 line-items endpoint: PR #42 merged.\n"
+    "- REQ-05 product-items endpoint: MR !41 is merged.\n"
+    "The crucial deliverable (REQ-03) is verified on its correct surface.\n"
 )
 
 
@@ -328,9 +328,9 @@ def _two_row_claim(row_a: str, row_b: str) -> str:
     return (
         "I read the authoritative spec and enumerated every deliverable.\n"
         "Everything is done and ready to merge.\n"
-        f"- US-03: {row_a}\n"
-        f"- US-05: {row_b}\n"
-        "The crucial deliverable US-03 is verified on its correct surface.\n"
+        f"- REQ-03: {row_a}\n"
+        f"- REQ-05: {row_b}\n"
+        "The crucial deliverable REQ-03 is verified on its correct surface.\n"
     )
 
 
@@ -383,9 +383,9 @@ _TRAILING_CONDITIONAL_CLAIM = _two_row_claim("PR #41 merged once CI passes.", "P
 _BARE_AND_MERGED_TO_MAIN_MAP = (
     "I read the authoritative spec and its comments and enumerated every deliverable.\n"
     "Both deliverables are merged and live — done.\n"
-    "- US-03 EURIBOR endpoint: PR #42 merged.\n"
-    "- US-05 product-items endpoint: merged to main.\n"
-    "The crucial deliverable (US-03) is verified on its correct surface.\n"
+    "- REQ-03 line-items endpoint: PR #42 merged.\n"
+    "- REQ-05 product-items endpoint: merged to main.\n"
+    "The crucial deliverable (REQ-03) is verified on its correct surface.\n"
 )
 
 
@@ -456,9 +456,9 @@ _MERGED_QUALIFIER_LEAK_PHRASES = [
 _MERGED_QUALIFIER_PRESERVATION_MAP = (
     "I read the authoritative spec and its comments and enumerated every deliverable.\n"
     "Both deliverables are merged and live — done.\n"
-    "- US-03 EURIBOR endpoint: PR #42 merged after the refactor landed.\n"
-    "- US-05 product-items endpoint: merged to main.\n"
-    "The crucial deliverable (US-03) is verified on its correct surface.\n"
+    "- REQ-03 line-items endpoint: PR #42 merged after the refactor landed.\n"
+    "- REQ-05 product-items endpoint: merged to main.\n"
+    "The crucial deliverable (REQ-03) is verified on its correct surface.\n"
 )
 
 

--- a/tests/teatree_utils/test_postgres_secret.py
+++ b/tests/teatree_utils/test_postgres_secret.py
@@ -143,10 +143,10 @@ class TestExtractLiteralFromCache:
 
     def test_does_not_leak_password_to_logger(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
         cache = tmp_path / ".t3-env.cache"
-        cache.write_text("POSTGRES_PASSWORD=top-secret-literal\n", encoding="utf-8")
+        cache.write_text("POSTGRES_PASSWORD=swordfish-literal\n", encoding="utf-8")
         caplog.set_level("DEBUG", logger="teatree.utils.postgres_secret")
         extract_literal_from_cache(cache)
-        assert "top-secret-literal" not in caplog.text
+        assert "swordfish-literal" not in caplog.text
 
 
 class TestResolverCommandInvocation:

--- a/tests/test_banned_terms_single_resolver_conformance.py
+++ b/tests/test_banned_terms_single_resolver_conformance.py
@@ -1,0 +1,162 @@
+# test-path: cross-cutting — scans src/teatree + scripts for legacy-key reads; no single-module mirror.
+"""Conformance guards for the consolidated banned-term registry.
+
+Two static invariants keep the consolidation from silently regressing:
+
+* **Single resolver** — the four legacy term keys (``banned_terms`` /
+    ``banned_brands`` / ``banned_terms_allowlist`` / ``overlay_leak_terms``) are read
+    from the ``ConfigSetting`` store ONLY by the registry module and the legacy
+    resolvers it delegates to. Every scanning gate resolves through
+    :mod:`teatree.hooks.banned_term_registry` instead of reading a legacy row itself,
+    so a new consumer that bypasses the registry is caught here rather than in a leak.
+* **Secret/defaults boundary** — the term keys are ``SECRET_SETTINGS`` (DB-only,
+    empty in code), so if a ``config/defaults.toml`` ever ships it must carry none of
+    them. A forward guard, inert until such a file exists.
+"""
+
+import ast
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from teatree.config.secret_settings import SECRET_SETTINGS
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: The four DB-home lists the registry folds together. A direct ``cold_reader`` read of
+#: any of these outside the sanctioned resolvers bypasses the registry's dual-read.
+_LEGACY_KEYS: frozenset[str] = frozenset(
+    {"banned_terms", "banned_brands", "banned_terms_allowlist", "overlay_leak_terms"}
+)
+
+#: The modules allowed to read a legacy key directly: the registry itself
+#: (``banned_terms_allowlist`` / ``overlay_leak_terms``) plus the three legacy
+#: resolvers it delegates to — ``banned_terms_cli`` (``banned_terms``),
+#: ``banned_terms_tree_scan`` (``banned_brands``), and ``banned_terms_scanner``'s
+#: configured-check (``banned_terms``). No other consumer may read a legacy row.
+_SANCTIONED_RESOLVERS: frozenset[str] = frozenset(
+    {
+        "src/teatree/hooks/banned_term_registry.py",
+        "src/teatree/hooks/banned_terms_cli.py",
+        "src/teatree/hooks/banned_terms_tree_scan.py",
+        "src/teatree/hooks/banned_terms_scanner.py",
+    }
+)
+
+_READERS: frozenset[str] = frozenset({"read_setting", "list_setting"})
+
+
+def _module_str_constants(tree: ast.Module) -> dict[str, str]:
+    """Module-level ``NAME = "literal"`` bindings — so ``read_setting(_TERMS_KEY)`` resolves."""
+    consts: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    consts[target.id] = node.value.value
+    return consts
+
+
+def _legacy_key_of_read(call: ast.Call, consts: dict[str, str]) -> str | None:
+    """The legacy key a ``read_setting``/``list_setting`` call reads, or ``None``.
+
+    Resolves an inline string literal AND a same-file module-level string constant
+    (``read_setting(_TERMS_KEY)``). A first arg that is neither is unresolvable here
+    (a function parameter) and is not treated as a violation.
+    """
+    if not isinstance(call.func, ast.Attribute) or call.func.attr not in _READERS or not call.args:
+        return None
+    arg = call.args[0]
+    if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+        key = arg.value
+    elif isinstance(arg, ast.Name):
+        key = consts.get(arg.id, "")
+    else:
+        return None
+    return key if key in _LEGACY_KEYS else None
+
+
+def _files_reading_legacy_keys(root: Path, base: Path | None = None) -> dict[str, set[str]]:
+    """Map each scanned file (relative to *base*) to the legacy keys it reads directly."""
+    rel_to = base if base is not None else root
+    found: dict[str, set[str]] = {}
+    for py in sorted(root.rglob("*.py")):
+        if "__pycache__" in py.parts:
+            continue
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        consts = _module_str_constants(tree)
+        keys: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                key = _legacy_key_of_read(node, consts)
+                if key is not None:
+                    keys.add(key)
+        if keys:
+            found[py.relative_to(rel_to).as_posix()] = keys
+    return found
+
+
+class TestLegacyKeysHaveASingleResolver:
+    """Only the registry + its legacy resolvers read a legacy term key directly."""
+
+    def test_no_unsanctioned_module_reads_a_legacy_key(self) -> None:
+        offenders = {
+            path: keys
+            for scanned in (_REPO_ROOT / "src" / "teatree", _REPO_ROOT / "scripts")
+            for path, keys in _files_reading_legacy_keys(scanned, base=_REPO_ROOT).items()
+            if path not in _SANCTIONED_RESOLVERS
+        }
+        assert offenders == {}, (
+            "these modules read a legacy banned-terms key directly instead of routing "
+            f"through banned_term_registry: {offenders}"
+        )
+
+    def test_detector_is_anti_vacuous(self, tmp_path: Path) -> None:
+        # Control: the detector MUST flag a synthetic direct read, or the green above
+        # proves nothing. Both an inline literal and a module-constant read are caught.
+        (tmp_path / "leaky.py").write_text(
+            'import cold_reader\n_K = "overlay_leak_terms"\n'
+            'a = cold_reader.read_setting("banned_terms")\n'
+            "b = cold_reader.list_setting(_K)\n",
+            encoding="utf-8",
+        )
+        found = _files_reading_legacy_keys(tmp_path)
+        assert found == {"leaky.py": {"banned_terms", "overlay_leak_terms"}}
+
+
+class TestTermKeysNeverInDefaultsToml:
+    """SECRET term keys are DB-only: a shipped defaults.toml must carry none of them.
+
+    Forward guard — inert until ``config/defaults.toml`` exists. The term keys are the
+    intersection of the four legacy keys, the consolidated ``banned_term_registry``,
+    and ``SECRET_SETTINGS``, all of which must stay out of any committed defaults file.
+    """
+
+    def _all_keys(self, table: object, prefix: str = "") -> set[str]:
+        keys: set[str] = set()
+        if isinstance(table, dict):
+            for key, value in table.items():
+                keys.add(key)
+                keys.add(f"{prefix}{key}")
+                keys |= self._all_keys(value, prefix=f"{prefix}{key}.")
+        return keys
+
+    def test_no_secret_setting_appears_in_defaults_toml(self) -> None:
+        defaults = _REPO_ROOT / "config" / "defaults.toml"
+        if not defaults.is_file():
+            pytest.skip("no config/defaults.toml ships today — the forward guard stays inert")
+        data = tomllib.loads(defaults.read_text(encoding="utf-8"))
+        assert SECRET_SETTINGS.isdisjoint(self._all_keys(data))
+
+    def test_the_five_term_keys_are_all_secret(self) -> None:
+        # The keys this PR routes through the registry are ALL export-guarded secrets,
+        # so the forward guard above genuinely covers them.
+        term_keys = {
+            "banned_terms",
+            "banned_terms_allowlist",
+            "banned_brands",
+            "overlay_leak_terms",
+            "banned_term_registry",
+        }
+        assert term_keys <= SECRET_SETTINGS

--- a/tests/test_no_overlay_leak_hook.py
+++ b/tests/test_no_overlay_leak_hook.py
@@ -432,6 +432,60 @@ class TestDbSourcedTerms:
         assert result.returncode == 0, result.stdout  # env list has no match; the DB list is ignored
 
 
+def _seed_registry_db(tmp_path: Path, *, overlay: list[str], legacy: list[str] | None = None) -> Path:
+    """Build a DB carrying the consolidated ``banned_term_registry`` (overlay class)."""
+    db = tmp_path / "registry.sqlite3"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS teatree_config_setting ("
+        "id INTEGER PRIMARY KEY, scope TEXT NOT NULL DEFAULT '', key TEXT NOT NULL, value TEXT NOT NULL)"
+    )
+    conn.execute(
+        "INSERT INTO teatree_config_setting (scope, key, value) VALUES ('', 'banned_term_registry', ?)",
+        (json.dumps({"leak": ["democorp"], "overlay": overlay}),),
+    )
+    if legacy is not None:
+        conn.execute(
+            "INSERT INTO teatree_config_setting (scope, key, value) VALUES ('', 'overlay_leak_terms', ?)",
+            (json.dumps(legacy),),
+        )
+    conn.commit()
+    conn.close()
+    return db
+
+
+class TestRegistrySourcedTerms:
+    """The consolidated registry's ``overlay`` class drives the gate, registry-first."""
+
+    def _run_with_db(self, cwd: Path, db: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        env = {k: v for k, v in os.environ.items() if k != "TEATREE_OVERLAY_LEAK_TERMS"}
+        env["HOME"] = str(cwd)
+        env["T3_CONFIG_DB"] = str(db)
+        return subprocess.run(
+            [sys.executable, str(HOOK), *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+
+    def test_registry_overlay_term_is_caught(self, tmp_path: Path) -> None:
+        db = _seed_registry_db(tmp_path, overlay=["alpha-tenant"])
+        _seed(tmp_path, "src/teatree/foo.py", "# Reference to alpha-tenant\n")
+        result = self._run_with_db(tmp_path, db, "--require-terms")
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "alpha-tenant" in result.stdout.lower()
+
+    def test_registry_wins_over_legacy_overlay_row(self, tmp_path: Path) -> None:
+        # A present registry is authoritative: a file naming only the LEGACY-row term
+        # (absent from the registry's overlay class) is not flagged.
+        db = _seed_registry_db(tmp_path, overlay=["alpha-tenant"], legacy=["legacy-only"])
+        _seed(tmp_path, "src/teatree/foo.py", "# only names legacy-only here\n")
+        result = self._run_with_db(tmp_path, db)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
 class TestOverlayLeakCiPassesRequireTerms:
     """Fix #2 (CI side): the overlay-leak full-tree CI job passes ``--require-terms``."""
 

--- a/tests/test_privacy_scan_script.py
+++ b/tests/test_privacy_scan_script.py
@@ -384,3 +384,35 @@ class TestPrivacyScanBannedTermsSource:
         result = _run_env("a perfectly ordinary line of prose\n", {"T3_CONFIG_DB": str(db)})
         assert result.returncode == 0, result.stdout + result.stderr
         assert "inert" not in result.stderr.lower()
+
+
+class TestPrivacyScanAllowlistFromRegistry:
+    """The company-identifier carve-out resolves through the registry ``allow`` class."""
+
+    def _seed_registry(self, tmp_path: Path, registry: dict[str, list[str]]) -> Path:
+        db = tmp_path / "registry.sqlite3"
+        conn = sqlite3.connect(str(db))
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS teatree_config_setting ("
+            "id INTEGER PRIMARY KEY, scope TEXT NOT NULL DEFAULT '', key TEXT NOT NULL, value TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO teatree_config_setting (scope, key, value) VALUES ('', 'banned_term_registry', ?)",
+            (json.dumps(registry),),
+        )
+        conn.commit()
+        conn.close()
+        return db
+
+    def test_registry_allow_class_carves_out_the_identifier(self, tmp_path: Path) -> None:
+        db = self._seed_registry(tmp_path, {"prose_collider": ["acme"], "allow": ["acme-product"]})
+        result = _run_env("the acme-product repo\n", {"T3_CONFIG_DB": str(db)})
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "banned_term" not in result.stdout
+
+    def test_without_allow_class_the_bare_slug_is_flagged(self, tmp_path: Path) -> None:
+        # Anti-vacuous control: drop the allow class and the same line flags the slug.
+        db = self._seed_registry(tmp_path, {"prose_collider": ["acme"]})
+        result = _run_env("the acme-product repo\n", {"T3_CONFIG_DB": str(db)})
+        assert result.returncode == PRIVACY_FINDINGS_EXIT_CODE, result.stdout + result.stderr
+        assert "banned_term" in result.stdout


### PR DESCRIPTION
refactor(config): route every term-scanning gate through the consolidated registry

One registry, per-class routing is now the single source every term-scanning gate resolves through (diff / core / tree / overlay / allowlist / export). This finishes the consolidation so a gate never resolves a term source on its own.

## What

- **Overlay class.** Adds an `overlay` class to `banned_term_registry` (registry-only — not a publish surface) and routes the BLUEPRINT §1 core-generic gate (`check_no_overlay_leak`, `fast_push`) through it. Inert-when-empty by design: the overlay pass never fail-closes on an unset source.
- **Rerouted consumers.** `check_no_overlay_leak`, `fast_push` (overlay pass + allowlist), `scripts/privacy_scan.py` (allowlist), and `config_migration`'s export scan now all resolve through the registry (`terms_for_gate` / `allowlist_terms` / `export_scan_terms`) instead of reading a legacy row directly.
- **Posting-gate configured-check fix.** `banned_terms_scanner._banned_terms_configured` now counts a registry-only store as configured. Previously, once the registry was set and the legacy row dropped, the check read `False` and the whole posting gate silently degraded to a no-op. Fixed RED-first with a regression test.
- **Legacy keys stay as fallback.** The four legacy keys are commented as fallback-only and kept registered (no key deletion). A new AST conformance guard asserts they are read directly only by the registry module and its legacy resolvers, with an anti-vacuous positive control.
- **Docs + boundary guard.** Adds a term-scanning taxonomy table to the configuration appendix and a forward guard asserting `SECRET_SETTINGS` is disjoint from any `config/defaults.toml` that ever ships.
- **Fixture-convention normalization (2nd commit).** Aligns a few generic test tokens with the scanners' neutral placeholder conventions and renames two shadowing local variables. Assertions updated in the same edits.

## Why

Term resolution was re-derived per gate, so a rerouted consumer could drift from the registry's dual-read and, post-cutover, the posting gate could silently no-op. Making the registry the single resolver removes that whole class of drift. Every invariant is preserved: whole-tree leak scan, diff+core prose_collider, diff-only tone, the allowlist carve-out, `BannedTermsUnsetError` fail-loud on an unset ban source, `--require-terms`, and env overrides winning. `t3 banned-terms migrate-registry` self-verifies the overlay round-trip too.

## Architecture pre-check

1. **BLUEPRINT § alignment** — Configuration appendix § 10 (config store, DB-home settings) + BLUEPRINT §1 (core stays generic). New taxonomy subsection added in the same change.
2. **FSM phase boundaries** — n/a (no `Ticket.State` / `Worktree.State` transition).
3. **Extension-point contracts** — no `OverlayBase` / scanner / Protocol surface change; the registry API gains `export_scan_terms` + an `overlay` class, all additive.
4. **Component boundaries** — resolution stays in `teatree.hooks.banned_term_registry`; consumers (`cli`, `core`, `scripts/hooks`) only call it. No straddle.
5. **Dependency direction** — no new cross-module edge; `tach check` green (ran in ci-parity-fast).
6. **Test surface** — overlay routing + round-trip, rerouted consumers, the fail-open regression (RED-first), the single-resolver conformance guard, and the forward guard each have a named test.
7. **Resilience invariants** — n/a (no new external write); the malformed-registry path stays fail-loud, the optional classes stay fail-safe-to-empty.
8. **Identity / key normalization** — the fully-qualified registry class is the canonical key; the legacy keys route up through the registry, never stripped down.
9. **Behavior preservation** — additive; no privacy/leak matcher narrowed, no must-block test inverted. Every prior gate behaviour is preserved (enumerated above).
10. **Removability / harness-vs-data** — the term data stays in the DB registry (data); the harness is the generic resolver. The `overlay` class is a self-contained addition that reverts cleanly.

Do not merge — held for keystone review.
