### PR TITLE
chore(ci): trigger-categorized names across all GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,10 @@
 #   prek and the regression corpus is asserted every PR via pytest.
 # ============================================================
 
-name: CI
+# TRIGGER: primarily pull_request (the PR merge pipeline — hence the `CI ·`
+# name). ALSO runs on push to main and a daily schedule as full-tree backstops
+# (see the CONCURRENCY note above); those secondary triggers are declared below.
+name: CI · Lint, test & quality gates
 
 on:
   push:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@
 # Hetzner Cloud. No box-identifying info lives here — the host/IP, SSH
 # user/port, host key, and private key all come from secrets, and the host/IP
 # is masked out of the logs. Uses no third-party actions (nothing to SHA-pin).
-name: Deploy teatree
+name: Push · Deploy to box
 
 on:
   workflow_dispatch:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,6 @@
-name: Docs
+# TRIGGER: push to main only — regenerate the docs and deploy them to GitHub Pages
+# on every merge.
+name: Push · Publish docs (Pages)
 
 on:
   push:

--- a/.github/workflows/eval-benchmark.yml
+++ b/.github/workflows/eval-benchmark.yml
@@ -26,7 +26,7 @@
 # `api_key` stays selectable wherever the metered secret does exist.
 # ============================================================
 
-name: Behavioral benchmark
+name: Manual · Full benchmark eval
 
 on:
   workflow_dispatch:

--- a/.github/workflows/eval-ci-heal.yml
+++ b/.github/workflows/eval-ci-heal.yml
@@ -58,7 +58,7 @@
 #   downloads it to the box for the fix agent to read; it is NEVER published.
 # ============================================================
 
-name: Eval CI heal
+name: Manual · Eval CI heal
 
 on:
   workflow_dispatch:

--- a/.github/workflows/eval-nightly.yml
+++ b/.github/workflows/eval-nightly.yml
@@ -43,7 +43,7 @@
 #   rather than passing green with zero coverage (mirrors eval.yml / eval-pr.yml).
 # ============================================================
 
-name: Nightly smoke eval
+name: Scheduled · Nightly smoke eval
 
 on:
   schedule:

--- a/.github/workflows/eval-pr-reusable.yml
+++ b/.github/workflows/eval-pr-reusable.yml
@@ -56,6 +56,10 @@
 #   PR pays nothing extra (only failures are re-run).
 # ============================================================
 
+# TRIGGER: workflow_call only — invoked by the host's `eval-pr.yml` and by an
+# overlay's thin caller; it is never triggered on its own.
+name: Reusable · Selective PR eval
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/eval-pr.yml
+++ b/.github/workflows/eval-pr.yml
@@ -65,7 +65,7 @@
 #   step appends that file to `$GITHUB_STEP_SUMMARY`.
 # ============================================================
 
-name: Selective PR eval
+name: CI · Selective PR eval
 
 on:
   pull_request:

--- a/.github/workflows/eval-weekly-reusable.yml
+++ b/.github/workflows/eval-weekly-reusable.yml
@@ -42,6 +42,10 @@
 #   failed-run email (no extra secret, no bot).
 # ============================================================
 
+# TRIGGER: workflow_call only — invoked by `eval-benchmark.yml` (manual dispatch)
+# and by an overlay's thin weekly caller; it is never triggered on its own.
+name: Reusable · Weekly benchmark eval
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -106,7 +106,7 @@
 # `shutil.which("claude")` is still the provisioning gate) lives here.
 # ============================================================
 
-name: Behavioral eval
+name: Scheduled · Weekly behavioral eval
 
 on:
   schedule:

--- a/.github/workflows/needs-triage.yml
+++ b/.github/workflows/needs-triage.yml
@@ -1,4 +1,6 @@
-name: Needs triage
+# TRIGGER: issue opened — auto-apply the `needs-triage` label to any issue a
+# non-owner files, gating the factory's issue-implementer claim path.
+name: Issues · Auto-label needs-triage
 
 on:
   issues:

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -17,7 +17,7 @@
 # OWNER-INFRA NOTE: this workflow's PUSH step cannot be validated without the
 # target registry. On a fork PR or when registry credentials do not resolve it
 # runs in BUILD-ONLY mode (proves the image builds, pushes nothing).
-name: Publish teatree image
+name: Push · Publish deploy image
 
 on:
   workflow_dispatch:

--- a/.github/workflows/uv-lock-upgrade.yml
+++ b/.github/workflows/uv-lock-upgrade.yml
@@ -16,7 +16,7 @@
 # Also triggerable on-demand via workflow_dispatch.
 # ============================================================
 
-name: Weekly uv.lock refresh
+name: Scheduled · Weekly uv.lock refresh
 
 on:
   schedule:


### PR DESCRIPTION
## Summary

Every `.github/workflows/*.yml` now has a `name:` that states its **trigger category** and purpose at a glance. A reader can tell whether a workflow runs on a PR, a schedule, a manual dispatch, a push to main, an issue event, or is a reusable callee — without opening the file.

## Naming convention

Prefix by the **primary** trigger; keep the domain word (eval / deploy / docs / image); note any secondary triggers in a top-of-file comment.

| Prefix | Trigger |
|---|---|
| `CI ·` | `pull_request` (PR pipeline) |
| `Scheduled ·` | `schedule` (cron) primary |
| `Manual ·` | `workflow_dispatch`-only |
| `Push ·` | `push` to main (runs on merge) |
| `Reusable ·` | `workflow_call` |
| `Issues ·` | issue events |

## Inventory (file → old name → new name → trigger → purpose)

| File | Old `name:` | New `name:` | Trigger(s) | Purpose |
|---|---|---|---|---|
| `ci.yml` | `CI` | `CI · Lint, test & quality gates` | pull_request *(+ push main, daily schedule)* | Main PR pipeline: lint, 12-way sharded tests, docs/security/quality gates |
| `eval-pr.yml` | `Selective PR eval` | `CI · Selective PR eval` | pull_request | Runs only the eval scenarios a PR's diff changed; emits the `eval-gate` check |
| `eval.yml` | `Behavioral eval` | `Scheduled · Weekly behavioral eval` | schedule (Mon) *(+ dispatch)* | Full metered behavioral-eval catalog, sharded |
| `eval-nightly.yml` | `Nightly smoke eval` | `Scheduled · Nightly smoke eval` | schedule (daily) *(+ dispatch)* | Small nightly smoke slice on days something merged |
| `uv-lock-upgrade.yml` | `Weekly uv.lock refresh` | `Scheduled · Weekly uv.lock refresh` | schedule (Sun) *(+ dispatch)* | Regenerate `uv.lock`, open/update a PR |
| `eval-benchmark.yml` | `Behavioral benchmark` | `Manual · Full benchmark eval` | workflow_dispatch | Dispatchable caller for the weekly reusable benchmark |
| `eval-ci-heal.yml` | `Eval CI heal` | `Manual · Eval CI heal` | workflow_dispatch | Eval against a PR branch under repair; emits triage JSON |
| `publish-image.yml` | `Publish teatree image` | `Push · Publish deploy image` | push main (paths) *(+ dispatch, PR build-only)* | Build + publish the deploy image when baked inputs change |
| `deploy.yml` | `Deploy teatree` | `Push · Deploy to box` | push main *(+ dispatch)* | Headless deploy over SSH on merge |
| `docs.yml` | `Docs` | `Push · Publish docs (Pages)` | push main | Regenerate docs + deploy to GitHub Pages |
| `eval-pr-reusable.yml` | *(none)* | `Reusable · Selective PR eval` | workflow_call | Reusable selective-PR eval logic (host + overlays) |
| `eval-weekly-reusable.yml` | *(none)* | `Reusable · Weekly benchmark eval` | workflow_call | Reusable weekly metered benchmark logic (host + overlays) |
| `needs-triage.yml` | `Needs triage` | `Issues · Auto-label needs-triage` | issues (opened) | Auto-apply `needs-triage` to a non-owner's new issue |

## Required-context safety — every producing job name is UNCHANGED

Only workflow-level `name:` and comment lines changed. No `jobs.<id>` or `jobs.<id>.name` was touched. Check contexts are bare job names (verified via `gh pr checks 3687`: `lint`, `test (3.13)`, `eval-gate`… — not `<workflow> / <job>` formed), so a workflow `name:` change cannot move a context.

| Required context | Producing workflow / job | Unchanged? |
|---|---|---|
| `lint` | `ci.yml` job `lint` | ✅ |
| `test (3.13)` | `ci.yml` job `test` (matrix `3.13`) | ✅ |
| `docs-drift` | `ci.yml` job `docs-drift` | ✅ |
| `uv-audit` | `ci.yml` job `uv-audit` | ✅ |
| `sbom` | `ci.yml` job `sbom` | ✅ |
| `blueprint-cross-pr` | `ci.yml` job `blueprint-cross-pr` | ✅ |
| `eval-gate` (pending) | `eval-pr.yml` job `eval-gate` | ✅ |

## Files NOT renamed (deliberate)

Workflow **filenames** are dispatched by exact string from Python (e.g. `eval.yml` ×25, `eval-ci-heal.yml` ×14, `eval-pr.yml`, the reusables) and asserted in tests — a rename risks a dangling reference whose blast radius is a broken autonomous loop. Per the task's fallback guidance, filenames are kept and only `name:`/comments changed. The single `uses:` reference (`eval-benchmark.yml` → `eval-weekly-reusable.yml`) is unaffected.

## Coordination

`eval.yml` only had its `name:` line changed — no TIER/effort logic touched, so it won't collide with the in-flight `fix-eval-scenario-regressions` PR.

## Verification

- All 13 workflows parse (yaml.safe_load + `check-yaml` hook green).
- Full prek hook set scoped to the changed files: green (check-yaml, banned-terms, editorconfig, codespell, ty-check, …).
- Commit- and push-stage hooks: green.
