### PR TITLE
fix(headless): cap SDK append system-context under the argv byte limit

### DIFF
--- a/src/teatree/agents/context_budget.py
+++ b/src/teatree/agents/context_budget.py
@@ -1,0 +1,65 @@
+"""Byte budget for the headless system-context append — the E2BIG spawn guard.
+
+The claude-agent-sdk passes the whole assembled system context as ONE
+``--append-system-prompt`` argv element (its subprocess transport). Linux caps a
+single argv element at ``MAX_ARG_STRLEN`` = 128 KiB, so an oversized append makes
+the ``claude`` child die at spawn with ``OSError: [Errno 7] Argument list too
+long``. :data:`MAX_APPEND_BYTES` bounds the append well under that limit, leaving
+headroom for the rest of argv; :func:`enforce_budget` truncates the largest
+budgetable blocks first and leaves a pointer marker so the agent knows context
+was elided rather than silently dropped.
+"""
+
+from collections.abc import Iterable
+
+# 96 KiB — comfortably below the 128 KiB kernel per-argv-element limit, leaving
+# ~32 KiB of headroom for the preset prefix and the rest of the spawn argv.
+MAX_APPEND_BYTES = 96 * 1024
+
+
+def _marker(dropped_bytes: int, where: str) -> str:
+    return f"\n[…truncated {dropped_bytes} bytes; see {where}]"
+
+
+def _truncate_block(block: str, keep_bytes: int, *, where: str) -> str:
+    """Return *block* shortened to at most *keep_bytes* UTF-8 bytes plus a pointer marker.
+
+    The marker's byte count is sized against the worst case (the whole block
+    dropped) so a shorter actual drop only shrinks the marker — the result never
+    exceeds *keep_bytes*. The kept prefix is decoded with ``errors="ignore"`` so a
+    byte-slice never splits a multibyte codepoint.
+    """
+    encoded = block.encode()
+    if keep_bytes >= len(encoded):
+        return block
+    worst_case_marker = _marker(len(encoded), where)
+    content_budget = max(0, keep_bytes - len(worst_case_marker.encode()))
+    kept = encoded[:content_budget].decode(errors="ignore")
+    dropped = len(encoded) - len(kept.encode())
+    return f"{kept}{_marker(dropped, where)}"
+
+
+def enforce_budget(text: str, blocks: Iterable[tuple[str, str]], *, max_bytes: int = MAX_APPEND_BYTES) -> str:
+    """Bound *text* to *max_bytes*, truncating *blocks* in the given priority order.
+
+    *blocks* is an ordered iterable of ``(block_text, where)`` pairs — each
+    ``block_text`` is an exact substring of *text*, and ``where`` names where the
+    elided content still lives (the pointer the marker cites). Earlier blocks are
+    truncated first, so pass them least-load-bearing first. Returns *text*
+    unchanged (byte-identical) when it already fits, so a normal-sized context is
+    never rewritten.
+    """
+    overage = len(text.encode()) - max_bytes
+    if overage <= 0:
+        return text
+    for block, where in blocks:
+        if overage <= 0 or not block:
+            continue
+        block_bytes = len(block.encode())
+        truncated = _truncate_block(block, block_bytes - overage, where=where)
+        reclaimed = block_bytes - len(truncated.encode())
+        if reclaimed <= 0:
+            continue
+        text = text.replace(block, truncated, 1)
+        overage -= reclaimed
+    return text

--- a/src/teatree/agents/prompt.py
+++ b/src/teatree/agents/prompt.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from typing import cast
 
 from teatree.agents.coding_prompt import _VERIFY_GATES_COMMAND, _coding_phase_directive, _stack_overlay_load_names
+from teatree.agents.context_budget import MAX_APPEND_BYTES, enforce_budget
 from teatree.agents.dispatch_preflight import (
     declared_seams_brief_lines,
     head_state_brief_lines,
@@ -27,6 +28,14 @@ _CODING_PHASE_ALWAYS_FULL = frozenset({"architecture-design"})
 
 
 _MAX_PARENT_SUMMARY_LEN = 2000
+
+# Where the byte-budget markers point the agent when a block is elided. Ordered
+# by truncation priority in ``_enforce_context_budget``: survey first (fully
+# re-derivable), then skills (loadable on demand), then the parent context last
+# (most load-bearing for continuity).
+_SURVEY_POINTER = "the intake landscape survey (re-derive with `t3 <overlay> workspace landscape`)"
+_SKILLS_POINTER = "the full skill body (load it on demand via the Skill tool)"
+_PARENT_POINTER = "the parent task's recorded result"
 
 
 def _parent_result_summary(task: Task) -> str:
@@ -291,18 +300,30 @@ def _intake_landscape_lines(task: Task) -> tuple[str, ...]:
     instead of re-deriving it. Empty when intake recorded none (forge outage),
     so the planner falls back to ``t3 <overlay> workspace landscape``.
     """
-    from teatree.core.models.landscape_artifact import LandscapeArtifact  # noqa: PLC0415 — deferred: ORM/app-registry
-
-    latest = LandscapeArtifact.latest_for(task.ticket)
-    if latest is None:
+    survey_json = _intake_survey_json(task)
+    if not survey_json:
         return ()
     return (
         "",
         "INTAKE LANDSCAPE SURVEY (produced by ticket-intake — CONSUME, do not re-derive):",
         "Plan AGAINST this: an open PR for the issue → finish+merge it, not fresh; a merged",
         "PR → surface for close; an in-flight worktree → build on it, never overwrite.",
-        json.dumps(latest.survey, sort_keys=True),
+        survey_json,
     )
+
+
+def _intake_survey_json(task: Task) -> str:
+    """The latest intake landscape survey as compact JSON, or ``""`` when none persisted.
+
+    Single source of truth for the survey block string, so the byte-budget pass
+    can re-derive the exact substring it needs to truncate.
+    """
+    from teatree.core.models.landscape_artifact import LandscapeArtifact  # noqa: PLC0415 — deferred: ORM/app-registry
+
+    latest = LandscapeArtifact.latest_for(task.ticket)
+    if latest is None:
+        return ""
+    return json.dumps(latest.survey, sort_keys=True)
 
 
 def _planning_phase_lines(task: Task) -> tuple[str, ...]:
@@ -448,6 +469,7 @@ def build_system_context(
     stage_present = stage_skills_present(task, skills, configured=stage_skills)
     stage_exclude = frozenset(_explicit_load_name(s) for s in stage_present)
 
+    skill_content = ""
     if skills:
         if lifecycle_skill:
             # Stage skills embed IN FULL — a no-Skill-tool maker cannot load them
@@ -510,7 +532,28 @@ def build_system_context(
         ),
     )
 
-    return "\n".join(lines)
+    return _enforce_context_budget("\n".join(lines), task, parent_summary=parent_summary, skill_content=skill_content)
+
+
+def _enforce_context_budget(text: str, task: Task, *, parent_summary: str, skill_content: str) -> str:
+    """Bound the assembled append under the argv-element byte limit (E2BIG guard).
+
+    The claude-agent-sdk passes the whole append as ONE ``--append-system-prompt``
+    argv element, and Linux caps a single element at 128 KiB — an oversized
+    survey/skills/parent block makes the ``claude`` spawn die with E2BIG. The
+    largest uncapped blocks are truncated with a pointer marker, survey first
+    (re-derivable), then skills (loadable), then the parent context last. The
+    survey is re-derived only on the over-budget path, so a normal-sized context
+    is one build with no extra query and byte-identical output.
+    """
+    if len(text.encode()) <= MAX_APPEND_BYTES:
+        return text
+    blocks = (
+        (_intake_survey_json(task), _SURVEY_POINTER),
+        (skill_content, _SKILLS_POINTER),
+        (parent_summary, _PARENT_POINTER),
+    )
+    return enforce_budget(text, blocks)
 
 
 type _TicketExtra = dict[str, object]

--- a/tests/teatree_agents/test_context_budget.py
+++ b/tests/teatree_agents/test_context_budget.py
@@ -1,0 +1,52 @@
+"""Tests for teatree.agents.context_budget — the E2BIG append byte budget."""
+
+from teatree.agents.context_budget import MAX_APPEND_BYTES, enforce_budget
+
+
+class TestEnforceBudget:
+    def test_under_budget_is_byte_identical(self) -> None:
+        text = "small context " + "x" * 100
+        assert enforce_budget(text, [("x" * 100, "somewhere")], max_bytes=MAX_APPEND_BYTES) is text
+
+    def test_truncates_first_block_first(self) -> None:
+        big = "B" * 5000
+        second = "S" * 5000
+        text = f"head\n{big}\nmid\n{second}\ntail"
+        out = enforce_budget(text, [(big, "block-one"), (second, "block-two")], max_bytes=6000)
+
+        assert len(out.encode()) <= 6000
+        # The first block absorbs the whole overage; the second stays intact.
+        assert "…truncated" in out
+        assert "see block-one" in out
+        assert second in out
+
+    def test_spills_to_second_block_when_first_insufficient(self) -> None:
+        first = "A" * 2000
+        second = "C" * 20000
+        text = f"{first}\n{second}"
+        out = enforce_budget(text, [(first, "first"), (second, "second")], max_bytes=4000)
+
+        assert len(out.encode()) <= 4000
+        assert "see first" in out
+        assert "see second" in out
+
+    def test_marker_reports_dropped_byte_count(self) -> None:
+        block = "Z" * 10000
+        out = enforce_budget(block, [(block, "the artifact")], max_bytes=1000)
+
+        assert len(out.encode()) <= 1000
+        assert "bytes; see the artifact" in out
+
+    def test_multibyte_block_never_splits_a_codepoint(self) -> None:
+        block = "é" * 10000  # 2 bytes each in UTF-8
+        out = enforce_budget(block, [(block, "unicode")], max_bytes=1000)
+
+        assert len(out.encode()) <= 1000
+        out.encode()  # a split codepoint would already have raised on decode
+
+    def test_empty_block_is_skipped(self) -> None:
+        text = "H" * 5000
+        # A missing (empty) block contributes nothing and must not crash.
+        out = enforce_budget(text, [("", "absent"), (text, "present")], max_bytes=1000)
+        assert len(out.encode()) <= 1000
+        assert "see present" in out

--- a/tests/teatree_agents/test_prompt.py
+++ b/tests/teatree_agents/test_prompt.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
+from teatree.agents.context_budget import MAX_APPEND_BYTES
 from teatree.agents.prompt import (
     _parent_result_summary,
     build_interactive_context,
@@ -13,7 +14,7 @@ from teatree.agents.prompt import (
     build_system_context,
     build_task_prompt,
 )
-from teatree.core.models import Session, Task, TaskAttempt, Ticket
+from teatree.core.models import LandscapeArtifact, Session, Task, TaskAttempt, Ticket
 
 # --- build_task_prompt ---
 
@@ -378,6 +379,55 @@ class TestBuildSystemContext(TestCase):
 
         assert "Context Budget" in ctx
         assert "Truncate file reads" in ctx
+
+
+class TestSystemContextByteBudget(TestCase):
+    """The assembled append never exceeds the argv-element byte budget (E2BIG guard).
+
+    The claude-agent-sdk passes the whole system context as ONE
+    ``--append-system-prompt`` argv element; Linux caps a single element at 128
+    KiB, so an oversized survey/skills/parent block makes the spawn die with
+    ``OSError: [Errno 7] Argument list too long``. The builder must bound the
+    append under :data:`MAX_APPEND_BYTES`, truncating largest-first with a marker.
+    """
+
+    def test_oversized_survey_is_truncated_under_budget(self) -> None:
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket)
+        task = Task.objects.create(ticket=ticket, session=session, phase="planning")
+        # A survey whose JSON alone dwarfs the budget — the live P0 shape.
+        survey = {"blob": "x" * (MAX_APPEND_BYTES * 2), "warnings": [], "recommendations": []}
+        LandscapeArtifact.record(ticket=ticket, survey=survey, recorded_by="t3:intake")
+
+        ctx = build_system_context(task, skills=[])
+
+        assert len(ctx.encode()) <= MAX_APPEND_BYTES
+        assert "…truncated" in ctx
+        assert "landscape survey" in ctx
+
+    def test_oversized_skills_are_truncated_under_budget(self) -> None:
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket)
+        task = Task.objects.create(ticket=ticket, session=session)
+
+        with patch("teatree.agents.prompt._read_skill_contents", return_value="S" * (MAX_APPEND_BYTES * 2)):
+            ctx = build_system_context(task, skills=["huge-skill"])
+
+        assert len(ctx.encode()) <= MAX_APPEND_BYTES
+        assert "…truncated" in ctx
+        assert "Skill tool" in ctx
+
+    def test_normal_context_passes_through_byte_identical(self) -> None:
+        ticket = Ticket.objects.create(issue_url="https://example.com/issues/11")
+        session = Session.objects.create(ticket=ticket)
+        task = Task.objects.create(ticket=ticket, session=session)
+
+        ctx = build_system_context(task, skills=[])
+
+        # A normal-sized context is never rewritten — no truncation marker, and
+        # well under the budget so nothing was elided.
+        assert len(ctx.encode()) < MAX_APPEND_BYTES
+        assert "…truncated" not in ctx
 
 
 # --- build_interactive_context ---


### PR DESCRIPTION
## Problem

A headless agent spawn dies with `OSError: [Errno 7] Argument list too long` (E2BIG) when the assembled system context exceeds Linux's per-argv-element cap (`MAX_ARG_STRLEN` = 128 KiB). `claude-agent-sdk` passes the whole append as a single `--append-system-prompt` argv element, so the ceiling is per-element, not the whole-argv `ARG_MAX`.

`build_system_context` previously truncated only the parent summary; the landscape-survey JSON, skills, and ticket context were uncapped. A large landscape survey therefore blew the limit and permanently wedged its phase — each retry reassembled an identical over-limit context, so the identical-fingerprint repair-halt kept re-dispatching the same doomed spawn.

## Live wedge

Observed on ticket 291 (2026-07-23): a large landscape survey pushed the assembled append past the argv-element cap, and the phase self-wedged via repair-halt with an identical fingerprint on every retry.

## Fix

Enforce a 96 KiB byte budget on the assembled append inside `build_system_context`, truncating the largest uncapped blocks first, in re-derivability order:

1. survey JSON (re-derivable),
2. then skills (loadable on demand),
3. then parent context (last).

Each truncated block leaves a `[...truncated N bytes; see <where>]` pointer, so context is elided with a breadcrumb, never silently lost. A normal-sized context passes through byte-identical and re-derives nothing.

New module `src/teatree/agents/context_budget.py` holds the pure budget/truncation logic; `prompt.py`'s `build_system_context` applies it.

## Test

RED->GREEN regression coverage in `tests/teatree_agents/test_context_budget.py` and `tests/teatree_agents/test_prompt.py`: an over-budget assembled context is capped under the byte limit with the truncation markers present, and a normal-sized context is unchanged byte-for-byte.
