### PR TITLE
fix(deploy): pin TMPDIR in every compose service so docker exec inherits the disk root (#3641)

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -99,8 +99,15 @@ services:
   # on the shared clone never races.
   teatree-init:
     <<: *teatree-common
+    # TMPDIR pins the disk-backed agent output root at the CONTAINER level so a
+    # `docker exec` into this service inherits it too (#3641). The entrypoint's
+    # export covers only the service MAIN process — an exec'd process bypasses the
+    # entrypoint, so without this pin its scratch/transcripts land under a second,
+    # ephemeral root. The `${TEATREE_DISK_TMPDIR:-/var/tmp}` default matches
+    # deploy/entrypoint.sh's setup_disk_tmpdir.
     environment:
       TEATREE_ROLE: init
+      TMPDIR: ${TEATREE_DISK_TMPDIR:-/var/tmp}
     restart: "no"
 
   # The loop cadence owner. DEBUG off — a long-running DEBUG Django process grows
@@ -110,6 +117,7 @@ services:
     environment:
       TEATREE_ROLE: worker
       T3_DEBUG: "0"
+      TMPDIR: ${TEATREE_DISK_TMPDIR:-/var/tmp}
     depends_on:
       teatree-init:
         condition: service_completed_successfully
@@ -154,6 +162,7 @@ services:
     environment:
       TEATREE_ROLE: admin
       T3_DEBUG: "0"
+      TMPDIR: ${TEATREE_DISK_TMPDIR:-/var/tmp}
     depends_on:
       teatree-init:
         condition: service_completed_successfully
@@ -186,6 +195,7 @@ services:
     environment:
       TEATREE_ROLE: slack-listener
       T3_DEBUG: "0"
+      TMPDIR: ${TEATREE_DISK_TMPDIR:-/var/tmp}
     depends_on:
       teatree-init:
         condition: service_completed_successfully
@@ -219,6 +229,11 @@ services:
     environment:
       TEATREE_ROLE: watchdog
       TEATREE_WATCHDOG_INTERVAL: "300"
+      # The watchdog role execs watchdog.sh before the entrypoint's TMPDIR export
+      # and runs no agents, so it never writes scratch to this root — but #3641's
+      # contract is that EVERY service declares the output root explicitly, so the
+      # pin is uniform and the doctor check (services_missing_output_root) stays green.
+      TMPDIR: ${TEATREE_DISK_TMPDIR:-/var/tmp}
     # root so /var/run/docker.sock is readable regardless of the host docker gid
     # (the socket is root-equivalent anyway; see README § security posture).
     user: "0:0"

--- a/src/teatree/loops/dream/engine.py
+++ b/src/teatree/loops/dream/engine.py
@@ -252,6 +252,10 @@ def default_projects_dir() -> Path:
 
 
 #: Both roots task-output transcripts land under; the split is temporal residue (#3585).
+#: Since #3641 pinned TMPDIR in every compose service's environment, all NEW output
+#: lands under the disk-backed /var/tmp even for `docker exec`-started processes, so
+#: scanning /tmp is now redundant belt-and-braces — retained only to still find any
+#: pre-fix or non-container residual transcripts.
 _TASK_OUTPUT_TMP_BASES: tuple[str, ...] = ("/tmp", "/var/tmp")  # noqa: S108 — fixed agent-controlled paths
 
 

--- a/tests/teatree_docker/test_output_root.py
+++ b/tests/teatree_docker/test_output_root.py
@@ -59,3 +59,13 @@ def test_a_non_mapping_document_reports_nothing(tmp_path: Path) -> None:
 def test_a_non_mapping_services_key_reports_nothing(tmp_path: Path) -> None:
     # `services` present but not a mapping (a list) — no service names to inspect.
     assert services_missing_output_root(_compose(tmp_path, "services:\n  - worker\n")) == []
+
+
+def test_shipped_compose_pins_the_output_root_for_every_service() -> None:
+    # #3641 acceptance: every service declares the output root, so a `docker exec`
+    # into any of them resolves the same disk-backed root as its main process. A
+    # real exec is infeasible under pytest (no daemon, no running stack), so this
+    # pins the container-level guarantee at its source — the shipped compose file.
+    real_compose = Path(__file__).resolve().parents[2] / "deploy" / "docker-compose.yml"
+    assert real_compose.is_file()
+    assert services_missing_output_root(real_compose) == []


### PR DESCRIPTION
Closes #3641.

## Root cause
`deploy/entrypoint.sh`'s `setup_disk_tmpdir` exports `TMPDIR`/`PYTEST_DEBUG_TEMPROOT` only in a service's **main** process. A `docker exec` into a running service does not run the entrypoint, so an exec'd agent falls back to the default temp root and its transcripts + scratch land under a second, ephemeral root. Consumers that scan transcripts (dream/consolidation, retro tooling) then have to scan both roots. None of the compose services declared `TMPDIR` in their `environment:` block, so the exec'd path was unpinned.

## Change
Declare `TMPDIR: ${TEATREE_DISK_TMPDIR:-/var/tmp}` inline in **every** compose service's `environment:` (`teatree-init`, `teatree-worker`, `teatree-admin`, `teatree-slack-listener`, `teatree-watchdog`). An inline `environment` entry is the only form a `docker exec`-started process inherits, so every process in each container — exec'd or not — now resolves the same disk-backed root. The `x-teatree-common` anchor carries no `environment` block, so each service's own key is authoritative and the pin is per-service. The default matches the entrypoint's `setup_disk_tmpdir`.

The watchdog is included too: it runs no agents (it execs `watchdog.sh` before the entrypoint's export), but acceptance #1 is that **every** service declares the root, and the doctor probe `services_missing_output_root` inspects every service — so the pin is uniform and the check stays green.

The dual-root `/tmp` + `/var/tmp` scan in the dream engine is now redundant belt-and-braces (all new output lands under the pinned `/var/tmp`); it is documented as such rather than removed, since pre-fix and non-container residual transcripts may still live under `/tmp` (acceptance #3).

## Doctor check now green
`services_missing_output_root(deploy/docker-compose.yml)` returned all 5 services before, `[]` after — so `_check_compose_output_root_pinned` reports OK. Anti-vacuous control: stripping the pins reports `['teatree-admin', 'teatree-init', 'teatree-slack-listener', 'teatree-watchdog', 'teatree-worker']`.

## Test
`test_shipped_compose_pins_the_output_root_for_every_service` in `tests/teatree_docker/test_output_root.py` (mirrors `src/teatree/docker/output_root.py`) parses the shipped compose and asserts zero services are missing the output root. A real `docker exec` is infeasible under pytest (no daemon, no running stack), so this pins the container-level guarantee at its source.

## Architecture pre-check — #3641
Tactical deploy-config change plus one doc-comment and one regression test — it does not touch `cli/`/`core/`/scanners/`agents`/`OverlayBase`/a Protocol surface, crosses no FSM boundary, and adds no module. The ten-check gate is therefore n/a; the detector `output_root.py` and the doctor check are unchanged (their existing contract is satisfied, not modified).

## Open questions & assumptions
- **`PYTEST_DEBUG_TEMPROOT` not added:** the detector's contract is `TMPDIR` only (`OUTPUT_ROOT_ENV = "TMPDIR"`) and acceptance names "the output root" (singular). pytest honours `TMPDIR` for its base temp dir, so the compose `TMPDIR` pin already routes exec'd pytest scratch to disk — `PYTEST_DEBUG_TEMPROOT` would be belt-and-braces the detector does not require.
- **Dual-root scan kept, not removed:** removing `/tmp` from the dream scan would be a behavior deletion that risks missing pre-fix/non-container residual transcripts; documenting it as redundant is the safe reading of acceptance #3.
