### PR TITLE
fix(factory): real red floors for the three red_when=None signals + stop park rows corrupting iteration telemetry (#3690, #3689)

### DIFF
--- a/src/teatree/core/factory/factory_signal_queries.py
+++ b/src/teatree/core/factory/factory_signal_queries.py
@@ -26,12 +26,22 @@ from teatree.core.models.review_verdict import ReviewVerdict, Severity
 from teatree.core.models.task_attempt import TaskAttempt
 from teatree.core.models.ticket import Ticket
 from teatree.core.models.transition import TicketTransition
+from teatree.core.models.usage_window_state import LIMIT_PARKED_PREFIX
+from teatree.llm.anthropic_limits import recoverable_exhaustion_cause
 from teatree.utils.url_slug import pr_ref_from_url
 
 # A five-observation floor keeps the thresholds stable at solo-factory volume;
 # a stale actionable CLEAR older than STALE_CLEAR_HOURS is a stalled merge loop.
 MIN_SAMPLE = 5
 STALE_CLEAR_HOURS = 48.0
+# S5 companion volume detector (#3690): a window where most work attempts crash or
+# refuse is broken regardless of how few successes remain to measure — the
+# mean-terminal-iteration scalar reads low (or insufficient) precisely when the loop
+# thrashes hardest and produces almost no success groups. Trip a hard-red when the
+# failure fraction is this high AND the window carries at least MIN_SAMPLE work attempts,
+# so a small sample is treated as noise, not a fleet-scale collapse.
+HIGH_FAILURE_FRACTION = 0.5
+
 
 _CATCH_SEVERITIES = frozenset({Severity.BLOCKER, Severity.MAJOR})
 
@@ -487,14 +497,26 @@ def compute_s4(window: Window, overlay: str, now: datetime) -> Computation:
 
 
 def compute_s5(window: Window, overlay: str, now: datetime) -> Computation:  # noqa: ARG001 — uniform compute signature
-    """S5 repair_iteration_burn: mean terminal iteration per succeeded (ticket, phase)."""
-    attempts = TaskAttempt.objects.filter(
-        started_at__gte=window.start,
-        started_at__lt=window.end,
-    ).select_related("task")
+    """S5 repair_iteration_burn: mean terminal iteration per succeeded (ticket, phase).
+
+    Scheduling-event attempts (limit-parks, recoverable-exhaustion dips) are excluded,
+    the same rows ``task_repair.phase_attempts`` drops from the budget query and by the
+    same idiom (a DB-level park exclude for the perf win over the 340k-row park backlog,
+    then a Python recoverable-exhaustion filter) — they are capacity events, not work
+    iterations, so they neither inflate the burn mean nor the failure fraction
+    (#3689/#3690). A high failure fraction over a meaningful sample trips a companion
+    hard-red the scalar mean alone cannot see: a window where nearly every attempt fails
+    leaves too few success groups to measure, so the mean reads low (or insufficient)
+    while the loop is on fire.
+    """
+    attempts = (
+        TaskAttempt.objects.filter(started_at__gte=window.start, started_at__lt=window.end)
+        .exclude(error__startswith=LIMIT_PARKED_PREFIX)
+        .select_related("task")
+    )
     if overlay:
         attempts = attempts.filter(task__ticket__overlay=overlay)
-    rows = list(attempts)
+    rows = [attempt for attempt in attempts if recoverable_exhaustion_cause(attempt.error) is None]
     total = len(rows)
     groups: dict[tuple[int, str], list[int]] = defaultdict(list)
     failed = 0
@@ -511,11 +533,24 @@ def compute_s5(window: Window, overlay: str, now: datetime) -> Computation:  # n
             failed += 1
     terminal_iters = [max(iters) for iters in groups.values()]
     sample = len(terminal_iters)
+    failed_fraction = failed / total if total else 0.0
+    hard_red = total >= MIN_SAMPLE and failed_fraction >= HIGH_FAILURE_FRACTION
+    reason = f"{round(failed_fraction, 3)} of {total} work attempts failed" if hard_red else ""
     evidence: S5Evidence = {
         "attempts": total,
         "success_groups": sample,
-        "failed_fraction": round(failed / total, 3) if total else 0.0,
+        "failed_fraction": round(failed_fraction, 3),
     }
     if sample < MIN_SAMPLE:
-        return Computation(SignalReading(0.0, sample, window.days, SignalStatus.INSUFFICIENT_DATA), evidence)
-    return Computation(SignalReading(round(mean(terminal_iters), 3), sample, window.days, SignalStatus.OK), evidence)
+        return Computation(
+            SignalReading(0.0, sample, window.days, SignalStatus.INSUFFICIENT_DATA),
+            evidence,
+            hard_red=hard_red,
+            hard_red_reason=reason,
+        )
+    return Computation(
+        SignalReading(round(mean(terminal_iters), 3), sample, window.days, SignalStatus.OK),
+        evidence,
+        hard_red=hard_red,
+        hard_red_reason=reason,
+    )

--- a/src/teatree/core/factory/factory_signals.py
+++ b/src/teatree/core/factory/factory_signals.py
@@ -93,6 +93,26 @@ __all__ = [
 
 DEFAULT_WINDOW_DAYS = 28
 
+# Hard red floors for the three signals that shipped with ``red_when=None`` and so
+# could never trip, letting the exact pathology that hit the factory pass silently
+# (#3690). Each sits at a "the factory is broken" level, not a nudge — a RED verdict
+# is the operator's primary alarm, so the floor is set well above the regress band to
+# stay quiet on ordinary drift and fire only on a genuine collapse.
+#
+# defect_escape (corrections per preceding merge, LOWER_IS_BETTER): at 1.0 the factory
+# mints as many fix tickets + red cards as it merges — breakage outpaces throughput.
+DEFECT_ESCAPE_RED = 1.0
+# merge_latency (median CLEAR→merge hours, LOWER_IS_BETTER): half the 48h stale-CLEAR
+# companion floor — a median clear-to-merge past a full day is a merge loop that is
+# draining, but far too slowly.
+MERGE_LATENCY_RED_HOURS = 24.0
+# repair_burn (mean terminal iteration per succeeded phase, LOWER_IS_BETTER): the phase
+# cap is MAX_PHASE_ITERATIONS = 5, so a mean of 4 means the phases that DO land are
+# almost exhausting their repair budget every time. The high-failure companion detector
+# in factory_signal_queries.compute_s5 catches the orthogonal collapse the scalar mean
+# misses — a window where nearly every attempt fails and the few successes read low.
+REPAIR_BURN_RED_ITERS = 4.0
+
 
 class SignalVerdict(enum.StrEnum):
     """A per-signal-row (and top-level report) verdict.
@@ -222,10 +242,18 @@ class SignalSpec:
 
 SIGNALS: tuple[SignalSpec, ...] = (
     SignalSpec("first_try_green", "quant", Direction.HIGHER_IS_BETTER, compute_s1, 0.5, 0.1),
-    SignalSpec("defect_escape", "quant", Direction.LOWER_IS_BETTER, compute_s2, None, 0.1),
+    SignalSpec("defect_escape", "quant", Direction.LOWER_IS_BETTER, compute_s2, DEFECT_ESCAPE_RED, 0.1),
     SignalSpec("review_catch", "quant", Direction.HIGHER_IS_BETTER, compute_s3, 0.0, 0.1),
-    SignalSpec("merge_latency", "quant", Direction.LOWER_IS_BETTER, compute_s4, None, 2.0, regress_multiplicative=True),
-    SignalSpec("repair_burn", "quant", Direction.LOWER_IS_BETTER, compute_s5, None, 0.5),
+    SignalSpec(
+        "merge_latency",
+        "quant",
+        Direction.LOWER_IS_BETTER,
+        compute_s4,
+        MERGE_LATENCY_RED_HOURS,
+        2.0,
+        regress_multiplicative=True,
+    ),
+    SignalSpec("repair_burn", "quant", Direction.LOWER_IS_BETTER, compute_s5, REPAIR_BURN_RED_ITERS, 0.5),
 )
 
 

--- a/src/teatree/core/management/commands/_ticket_show.py
+++ b/src/teatree/core/management/commands/_ticket_show.py
@@ -13,7 +13,9 @@ from django_typer.management import TyperCommand, command
 
 from teatree.core.modelkit.phases import normalize_phase
 from teatree.core.models import TaskAttempt, Ticket
+from teatree.core.models.usage_window_state import LIMIT_PARKED_PREFIX
 from teatree.core.repair_loop import max_phase_iterations
+from teatree.llm.anthropic_limits import recoverable_exhaustion_cause
 
 
 class PhaseBudgetRow(TypedDict):
@@ -41,12 +43,23 @@ def phase_budget_rows(ticket: Ticket) -> list[PhaseBudgetRow]:
 
     Attempts are grouped by the canonical phase token so a short-verb ``review``
     and gerund ``reviewing`` collapse into one row, matching how the repair-loop
-    counts a ticket-phase. ``max`` is the configured iteration cap.
+    counts a ticket-phase. ``max`` is the configured iteration cap. Scheduling-event
+    attempts (limit-parks, recoverable-exhaustion dips) are EXCLUDED so the displayed
+    count matches the budget query ``task_repair.phase_attempts`` — a usage-window park
+    is not a work iteration, so counting it inflated ``attempt N/max`` past the cap (#3689).
     """
     cap = max_phase_iterations()
     counts: dict[str, int] = {}
     first_pk: dict[str, int] = {}
-    for attempt in TaskAttempt.objects.filter(task__ticket_id=ticket.pk).select_related("task").order_by("pk"):
+    attempts = (
+        TaskAttempt.objects.filter(task__ticket_id=ticket.pk)
+        .exclude(error__startswith=LIMIT_PARKED_PREFIX)
+        .select_related("task")
+        .order_by("pk")
+    )
+    for attempt in attempts:
+        if recoverable_exhaustion_cause(attempt.error) is not None:
+            continue
         phase = normalize_phase(attempt.task.phase) or "(none)"
         counts[phase] = counts.get(phase, 0) + 1
         first_pk.setdefault(phase, attempt.pk)

--- a/src/teatree/core/models/task_attempt.py
+++ b/src/teatree/core/models/task_attempt.py
@@ -4,6 +4,7 @@ from django.db import models
 
 from teatree.core.modelkit.gate_registry import get
 from teatree.core.models.task import Task
+from teatree.core.models.usage_window_state import LIMIT_PARKED_PREFIX
 from teatree.core.repair_loop import terminal_reason_fingerprint
 
 if TYPE_CHECKING:
@@ -196,5 +197,10 @@ class TaskAttempt(models.Model):
         """
         if not self.error_fingerprint:
             self.error_fingerprint = terminal_reason_fingerprint(self.error)
-        if not self.iteration and self.task_id:  # ty: ignore[unresolved-attribute]
+        # A limit-park records a scheduling event, not a work iteration (#3689): the
+        # budget query (task_repair.phase_attempts) already EXCLUDES park rows, so
+        # stamping one here disagrees with that query and leaves the park row carrying a
+        # bogus work-iteration number that corrupts the "attempt N/max" display and the
+        # S5 signal. Leave it at the 0 sentinel so the stamp and the budget query agree.
+        if not self.iteration and self.task_id and not self.error.startswith(LIMIT_PARKED_PREFIX):  # ty: ignore[unresolved-attribute]
             self.iteration = self.task.phase_iteration_count() + 1

--- a/tests/teatree_core/factory/test_factory_signals.py
+++ b/tests/teatree_core/factory/test_factory_signals.py
@@ -33,6 +33,7 @@ from teatree.core.merge.pr_slug_resolution import resolve_pr_repo_slug
 from teatree.core.models.task_attempt import TaskAttempt
 from teatree.core.models.ticket import Ticket
 from teatree.core.models.transition import TicketTransition
+from teatree.core.models.usage_window_state import LIMIT_PARKED_PREFIX
 from tests.factories import (
     MergeAuditFactory,
     MergeClearFactory,
@@ -323,6 +324,22 @@ class S2DefectEscapeTests(FactorySignalsTestBase):
         assert reading.status == SignalStatus.OK
         assert reading.value == pytest.approx(0.0)
 
+    def test_escape_at_or_above_red_floor_trips_red(self) -> None:
+        # #3690 RED-first: 5 preceding merges and 6 escaped corrections (fix tickets)
+        # in-window is a defect-escape rate of 1.2 — corrections outpace merges. With
+        # red_when=None this reported OK regardless of value; it must now trip RED.
+        for i in range(5):
+            self._merge(pr_id=700 + i, days_ago=40)
+        for _ in range(6):
+            self._fix_ticket(days_ago=5)
+        report = compute_factory_signals(now=self.now)
+        row = _row(report, "defect_escape")
+        assert row.reading.value == pytest.approx(1.2)
+        assert row.reading.status == SignalStatus.OK
+        assert row.tripped is True
+        assert row.verdict == SignalVerdict.RED
+        assert report.verdict == SignalVerdict.RED
+
 
 class S3ReviewCatchTests(FactorySignalsTestBase):
     def test_rubber_stamp_window_is_hard_red(self) -> None:
@@ -513,6 +530,22 @@ class S4MergeLatencyTests(FactorySignalsTestBase):
         assert row.tripped is True
         assert row.verdict == SignalVerdict.RED
 
+    def test_median_latency_at_or_above_red_floor_trips_red(self) -> None:
+        # #3690 RED-first: 5 merges whose CLEARs are all CONSUMED (so the stale-CLEAR
+        # companion never fires — stale_clear_hours stays 0) but each sat 30h between
+        # CLEAR and merge. The median latency of 30h crosses the 24h scalar red floor.
+        # With red_when=None this reported OK at any latency; it must now trip RED on
+        # the scalar alone, independent of the staleness companion.
+        for i in range(5):
+            self._merge(pr_id=901 + i, days_ago=5, latency_hours=30.0)
+        report = compute_factory_signals(now=self.now)
+        row = _row(report, "merge_latency")
+        assert row.reading.value == pytest.approx(30.0)
+        assert row.reading.status == SignalStatus.OK
+        assert row.evidence["stale_clear_hours"] == pytest.approx(0.0)
+        assert row.tripped is True
+        assert row.verdict == SignalVerdict.RED
+
 
 class S5RepairBurnTests(FactorySignalsTestBase):
     def test_low_burn_is_ok(self) -> None:
@@ -566,6 +599,53 @@ class S5RepairBurnTests(FactorySignalsTestBase):
         assert row.reading.value == pytest.approx(3.0)
         assert row.baseline_value == pytest.approx(1.0)
         assert row.verdict == SignalVerdict.REGRESSING
+
+    def test_mean_terminal_iteration_at_or_above_red_floor_trips_red(self) -> None:
+        # #3690 RED-first: 5 succeeded phases each landing at terminal iteration 5 —
+        # the phases that DO complete nearly exhaust the 5-iteration budget every time.
+        # The mean of 5.0 crosses the 4.0 scalar red floor. With red_when=None this
+        # reported OK at any burn (the observed 11.756 stayed "ok"); it must now RED.
+        for _ in range(5):
+            self._attempt(days_ago=5, iteration=5)
+        report = compute_factory_signals(now=self.now)
+        row = _row(report, "repair_burn")
+        assert row.reading.value == pytest.approx(5.0)
+        assert row.reading.status == SignalStatus.OK
+        assert row.tripped is True
+        assert row.verdict == SignalVerdict.RED
+
+    def test_high_failure_fraction_trips_hard_red_even_below_success_sample(self) -> None:
+        # #3690 companion volume detector: a window where almost every work attempt
+        # crashes leaves too few success groups to measure, so the scalar mean reads
+        # INSUFFICIENT_DATA and the pathology (observed failed_fraction 0.996) was
+        # invisible. 8 crashes + 1 success is failed_fraction 0.889 over 9 attempts —
+        # the companion must trip a hard RED despite the thin success sample.
+        for _ in range(8):
+            self._attempt(days_ago=5, iteration=1, exit_code=1, error="boom")
+        self._attempt(days_ago=5, iteration=1)
+        report = compute_factory_signals(now=self.now)
+        row = _row(report, "repair_burn")
+        assert row.evidence["failed_fraction"] == pytest.approx(0.889, abs=0.001)
+        assert row.reading.status == SignalStatus.INSUFFICIENT_DATA
+        assert row.tripped is True
+        assert row.verdict == SignalVerdict.RED
+        assert report.verdict == SignalVerdict.RED
+
+    def test_limit_park_rows_do_not_inflate_failure_fraction(self) -> None:
+        # #3689/#3690: a usage-window outage records many limit_parked TaskAttempts.
+        # They are scheduling events, not work failures, so they must be excluded from
+        # the failure fraction — otherwise the companion detector false-REDs a healthy
+        # factory that merely hit its window. 5 clean successes + 10 parks reads 0.0.
+        for _ in range(5):
+            self._attempt(days_ago=5, iteration=1)
+        for _ in range(10):
+            self._attempt(days_ago=5, iteration=0, exit_code=1, error=f"{LIMIT_PARKED_PREFIX}session window active")
+        report = compute_factory_signals(now=self.now)
+        row = _row(report, "repair_burn")
+        assert row.evidence["attempts"] == 5
+        assert row.evidence["failed_fraction"] == pytest.approx(0.0)
+        assert row.tripped is False
+        assert row.verdict == SignalVerdict.OK
 
 
 class ReportShapeTests(FactorySignalsTestBase):

--- a/tests/teatree_core/test_repair_loop.py
+++ b/tests/teatree_core/test_repair_loop.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 
 from teatree.core.models import Session, Task, TaskAttempt, Ticket
 from teatree.core.models.deferred_question import DeferredQuestion
+from teatree.core.models.usage_window_state import LIMIT_PARKED_PREFIX
 from teatree.core.repair_loop import (
     IterationStalled,
     MaxIterationsExceeded,
@@ -28,6 +29,16 @@ def _failed_attempt(task: Task, *, error: str) -> TaskAttempt:
         ended_at=timezone.now(),
         exit_code=1,
         error=error,
+    )
+
+
+def _park_attempt(task: Task) -> TaskAttempt:
+    return TaskAttempt.objects.create(
+        task=task,
+        execution_target=task.execution_target,
+        ended_at=timezone.now(),
+        exit_code=1,
+        error=f"{LIMIT_PARKED_PREFIX}session window active",
     )
 
 
@@ -71,6 +82,23 @@ class TestIterationCounter(TestCase):
         _failed_attempt(review, error="r1")
         second = _failed_attempt(reviewing, error="r2")
         assert second.iteration == 2
+
+    def test_park_rows_are_not_stamped_and_do_not_advance_real_iteration(self) -> None:
+        # #3689: a limit_parked attempt is a scheduling event, not a work iteration.
+        # The budget query (task_repair.phase_attempts) already EXCLUDES park rows, so
+        # the stamp must too — otherwise park rows carry bogus work-iteration numbers
+        # (observed max 281 vs a cap of 5) that corrupt "attempt N/max" and the S5
+        # signal. Real attempts count only real attempts; parks stay at the 0 sentinel.
+        ticket = Ticket.objects.create()
+        task = self._phase_task(ticket, phase="coding")
+        first = _failed_attempt(task, error="boom-1")
+        park1 = _park_attempt(task)
+        second = _failed_attempt(task, error="boom-2")
+        park2 = _park_attempt(task)
+        third = _failed_attempt(task, error="boom-3")
+        assert [first.iteration, second.iteration, third.iteration] == [1, 2, 3]
+        assert park1.iteration == 0
+        assert park2.iteration == 0
 
 
 class TestTerminalReasonFingerprint(TestCase):

--- a/tests/teatree_core/test_ticket_show_command.py
+++ b/tests/teatree_core/test_ticket_show_command.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 
 from teatree.core.management.commands._ticket_show import TicketShowResult, render_ticket_show
 from teatree.core.models import Session, Task, TaskAttempt, Ticket
+from teatree.core.models.usage_window_state import LIMIT_PARKED_PREFIX
 
 
 def _failed_attempt(task: Task, *, error: str) -> TaskAttempt:
@@ -22,6 +23,16 @@ def _failed_attempt(task: Task, *, error: str) -> TaskAttempt:
         ended_at=timezone.now(),
         exit_code=1,
         error=error,
+    )
+
+
+def _park_attempt(task: Task) -> TaskAttempt:
+    return TaskAttempt.objects.create(
+        task=task,
+        execution_target=task.execution_target,
+        ended_at=timezone.now(),
+        exit_code=1,
+        error=f"{LIMIT_PARKED_PREFIX}session window active",
     )
 
 
@@ -44,6 +55,24 @@ class TicketShowTest(TestCase):
         coding_row = next(row for row in phases if row["phase"] == "coding")
         assert coding_row["attempts"] == 2
         assert coding_row["max"] == 5
+
+    def test_park_attempts_do_not_inflate_the_displayed_count(self) -> None:
+        # #3689: limit-park attempts are scheduling events, not work iterations. The
+        # budget query excludes them, so the displayed count must too — otherwise a
+        # multi-hour usage-window outage that parked 200+ times showed "attempt 281/5".
+        ticket = Ticket.objects.create(issue_url="https://example.com/issues/park")
+        coding = self._phase_task(ticket, phase="coding")
+        _failed_attempt(coding, error="c1")
+        for _ in range(200):
+            _park_attempt(coding)
+        _failed_attempt(coding, error="c2")
+        result = cast(
+            "dict[str, object]",
+            call_command("ticket", "show", str(ticket.pk)),
+        )
+        phases = cast("list[dict[str, object]]", result["phases"])
+        coding_row = next(row for row in phases if row["phase"] == "coding")
+        assert coding_row["attempts"] == 2
 
     def test_show_renders_attempt_n_max_string(self) -> None:
         ticket = Ticket.objects.create(issue_url="https://example.com/issues/2")


### PR DESCRIPTION
Fixes two Fable-found P0 factory-signal integrity bugs together — both touch the same telemetry surface, so one PR avoids a file collision.

## #3690 — three factory signals could never trip (`red_when=None`)
`defect_escape`, `merge_latency`, and `repair_burn` shipped with `red_when=None`, so they reported status `ok` at any value. The exact pathology that hit the factory (`repair_burn` mean terminal iteration 11.756, `failed_fraction` 0.996, still `ok`) was invisible.

Each now carries a concrete hard red floor, set well above its regress band so ordinary drift stays quiet and only a genuine collapse trips:

| Signal | Direction | `red_when` | Rationale |
|---|---|---|---|
| `defect_escape` | lower-is-better | `1.0` | corrections (fix tickets + red cards) per preceding merge reach parity — breakage outpaces throughput |
| `merge_latency` | lower-is-better | `24.0` h | median CLEAR→merge past a full day; half the existing 48h stale-CLEAR companion floor |
| `repair_burn` | lower-is-better | `4.0` | mean terminal iteration nears the `MAX_PHASE_ITERATIONS = 5` cap — landing phases almost exhaust their repair budget every time |

`repair_burn` also gets a **companion volume detector** the scalar mean cannot see: a window where nearly every attempt fails leaves too few success groups to measure, so the mean reads low (or insufficient) while the loop is on fire. A failure fraction ≥ `0.5` over ≥ `MIN_SAMPLE` work attempts trips a hard-red independent of the success-sample size (the same shape as S4's stale-CLEAR companion).

## #3689 — park-spin telemetry residue (iteration stamp)
`TaskAttempt.iteration` numbering INCLUDED `limit_parked:` park rows (observed 281 vs `MAX_PHASE_ITERATIONS = 5`). A limit-park is a scheduling event, not a work iteration. The budget query (`core/models/task_repair.py:phase_attempts`) already excludes park rows, but the `iteration` stamp at the `TaskAttempt.save` chokepoint and the `ticket show` "attempt N/max" display did not — so the stamp, the display, and the S5 signal read garbage while the budget query stayed correct.

Excludes park (and recoverable-exhaustion) rows at all three surfaces — the `save` stamp, the `ticket show` count, and the S5 computation — by the same idiom `phase_attempts` uses (DB-level park exclude for the perf win over the large park backlog, then a Python recoverable-exhaustion filter), so every surface now agrees with the budget query.

### Follow-up (operator action — NOT this PR)
The accumulated junk park rows (~340k) are a one-time operator purge/archive, performed after this stamp fix lands. No DB rows are deleted here — this change fixes the stamp/display/signal going forward.

## Tests (RED-first, each verified to fail against pre-fix code)
- `S2DefectEscapeTests::test_escape_at_or_above_red_floor_trips_red`
- `S4MergeLatencyTests::test_median_latency_at_or_above_red_floor_trips_red`
- `S5RepairBurnTests::test_mean_terminal_iteration_at_or_above_red_floor_trips_red`
- `S5RepairBurnTests::test_high_failure_fraction_trips_hard_red_even_below_success_sample`
- `S5RepairBurnTests::test_limit_park_rows_do_not_inflate_failure_fraction`
- `TestIterationCounter::test_park_rows_are_not_stamped_and_do_not_advance_real_iteration`
- `TicketShowTest::test_park_attempts_do_not_inflate_the_displayed_count` (showed "attempt 202/5" pre-fix)

`bash dev/ci-parity-fast.sh`: 31804 passed, 69 skipped, 5 xfailed; push-gate scoped clean.

## Architecture pre-check — #3690 / #3689

**1. BLUEPRINT § alignment** — factory quality/velocity signals (§17.4-adjacent merge/review ledger reads); no BLUEPRINT change (behavior of existing signals + telemetry, no new section).

**2. FSM phase boundaries** — n/a. No `Ticket.State` / `Worktree.State` transition touched; the `iteration` stamp is on `TaskAttempt.save`, not an FSM transition.

**3. Extension-point contracts** — n/a. No `OverlayBase` / scanner / hook / Protocol surface changed. `SignalSpec.red_when` is an existing field; only three registry values change.

**4. Component boundaries** — `core/factory` (signal thresholds + queries), `core/models/task_attempt` (stamp chokepoint), `core/management/commands/_ticket_show` (display). Each edit stays in its own layer.

**5. Dependency direction** — added imports: `core/factory` and `core/management` → `core/models/usage_window_state` (`LIMIT_PARKED_PREFIX`) and `teatree/llm/anthropic_limits` (`recoverable_exhaustion_cause`); `core/models/task_attempt` → `core/models/usage_window_state`. `uv run tach check` ✅ no backwards edge.

**6. Test surface** — every new floor/exclusion has a RED-first test named above; each was reverted-and-confirmed-red against pre-fix code.

**7. Resilience invariants** — n/a. Pure read-path signal computation + an insert-time stamp; no external write, so verify-by-re-read / fallback-transport / idempotency / heartbeat / sub-agent-return do not apply.

**8. Identity/key normalization** — the "is this a scheduling event?" exclusion (park OR recoverable-exhaustion) is applied by the single canonical idiom `task_repair.phase_attempts` established, replicated verbatim at the two new read sites and the stamp, so no surface can silently disagree on whether a park row counts.

**9. Behavior preservation** — additive: `red_when` moves from `None` (never trips) to a concrete floor; the S5 companion is a new detector; the park exclusions tighten counts to match the already-correct budget query. No matcher narrowed, no must-block test inverted. Existing `regressing`-band tests (S2 at 0.6, S5 at 3.0) stay below the new floors and keep their verdicts.

**10. Removability / harness-vs-data** — the thresholds are named module constants (data-shaped, one-line revert each); the park-exclusion is a self-contained filter at each site. Blast radius of reverting any one: local to its function.
