### PR TITLE
docs(hooks): consolidate escape-marker & kill-switch reference; verify heavy-Bash read-only gate is moot (#3562)

### DIFF
--- a/docs/blueprint/configuration.md
+++ b/docs/blueprint/configuration.md
@@ -329,6 +329,12 @@ The code registries are the single source of truth — the curated table below
 explains why representative keys are per-overlay-overridable; consult the
 registries for the full set, type signatures, and defaults.
 
+The `*_gate_enabled` kill-switch keys below each disable one over-deny gate. For
+the flat catalog of EVERY gate's never-lockout paths — the per-call escape marker
+tokens (`[fg-ok: …]`, `[skip-plan-gate: …]`, …), the `t3 <overlay> gate …
+disable` self-rescue CLIs, and the master `danger_gate_fail_open` switch — see
+`hooks/CLAUDE.md` § "Escape markers & kill-switches".
+
 | Key | Why overridable |
 |-----|------------------|
 | `mode` | `auto` for a personal dogfooding overlay, `interactive` for a client overlay |

--- a/hooks/CLAUDE.md
+++ b/hooks/CLAUDE.md
@@ -39,3 +39,43 @@ See the root [`CLAUDE.md`](../CLAUDE.md) for the code-quality bar. This file add
 - **The out-of-band raw-merge gate has a `gate raw-merge` kill-switch and fail-open-routes (FIX-EXPEDITE PART B).** `handle_block_out_of_band_merge` (in the router — it shares the effective-HTTP-method regexes with the sibling gates) denies raw `gh pr merge` / `glab mr merge` / a REST-API `.../pulls|merge_requests/<n>/merge` WRITE / a graphql merge-mutation on a teatree-managed repo, forcing the keystone `t3 <overlay> ticket merge <clear_id>` (BLUEPRINT §17.4). It was the ONLY merge-adjacent gate denying via a bare `emit_pretooluse_deny` — honouring neither the self-rescue allowlist, the master `danger_gate_fail_open`, nor a per-gate kill-switch. It now reads `out_of_band_merge_gate_enabled` (default True, registered in `COLD_HOOK_SETTINGS`) and early-returns allow when disabled; both deny sites route through `_fail_open_or_deny` so the self-rescue allowlist + master fail-open apply. Never-lockout: `t3 <overlay> gate raw-merge disable` (the kill-switch CLI, in `SELF_RESCUE_ALLOWLIST` so it is never itself denied) and the `= false` config flip. The never-lockout contract (`tests/test_gate_never_lockout_contract.py`) now verifies the route structurally rather than via a narrow-exemption allowlist entry.
 - **Hooks must be crash-proof and fast.** `hooks.json` sets a 30s timeout ceiling; a hook that raises or hangs blocks the user, so stay fast regardless of the ceiling. Fail open and stay silent on the happy path.
 - **Statusline state** is regenerated, not authored: `/tmp/claude-statusline/<session>.<suffix>` (override dir via `TEATREE_CLAUDE_STATUSLINE_STATE_DIR`). Never read it as a source of truth.
+
+## Escape markers & kill-switches (canonical reference)
+
+Every over-deny gate ships a never-lockout path. This is the ONE catalog of them — the per-gate bullets above carry the gate-specific detail; this table is the flat index. `docs/blueprint/configuration.md` (the kill-switch config settings) and `hooks/scripts/deny_circuit_breaker.py` (the signature-strip set) cross-link here.
+
+**Per-call escape marker tokens** — a `[<token>: <reason>]` in the current tool call ALLOWs that single call only. An **empty reason is rejected** (a bare `[fg-ok:]` / `[fg-ok: ]` does not unblock — the reason must be non-empty).
+
+| Marker | Gate it relaxes | Where the hook reads it |
+|---|---|---|
+| `[fg-ok: <reason>]` | orchestrator heavy-Bash gate + foreground-`Agent`-dispatch gate | Bash `command` text / `Agent` `prompt` (first 512 chars) |
+| `[skip-plan-gate: <reason>]` | plan-before-code edit-block gate | Edit `new_string` / Write `content` / `file_path` (first 512) |
+| `[skill-load-ok: <reason>]` | skill-loading `PreToolUse` gate | Bash `command` / Edit-Write args (first 512) |
+| `[skip-skill-gate: <reason>]` | skill-loading-on-`TaskCreated` gate | task subject / description |
+| `[quote-ok: <reason>]` | dispatch-prompt quote scanner (`PreToolUse` + `TaskCreated` arms) | `Agent`/`Task` prompt / task fields |
+| `[config-overwrite-ok: <reason>]` | read-before-overwrite config/dotfile gate | Edit / Write args |
+| `[scope-push-ok: <reason>]` | unknown-owned-repo push/merge gate | Bash `command` |
+| `[reviewer-ok: <reason>]` | no-self-reviewer-assign gate | Bash `command` |
+| `[standing-goal-hold: <token> <reason>]` | standing verified-green `Stop` gate (single-use minted token; holds ONE stop) | turn text |
+| `[fp-confirmed: <reason>]` | repeated-denial circuit breaker (session-scoped confirmed-FP grant; NEVER the public-egress leak gate — that is fail-CLOSED always) | Bash `command` / Edit-Write args |
+| `--allow-banned-term` / `ALLOW_BANNED_TERM=1` | banned-terms gate on a LOCAL surface (never a public-egress post) | CLI flag / env var |
+| `ALLOW_GATE_RELAX='<reason>'` | anti-relaxation + tach-soundness prek gate | env var |
+
+**Config kill-switches (self-rescue CLI)** — each flips a DB-home `ConfigSetting` flag (out-of-repo, survives `t3 update`); the equivalent `t3 <overlay> config_setting set <key> false` also works.
+
+| Command | Gate disabled |
+|---|---|
+| `t3 <overlay> gate disable` | orchestrator heavy-Bash gate — the PRIMARY self-rescue, always reachable (`t3 …` never matches the heavy denylist) |
+| `t3 <overlay> gate skill-loading disable` | skill-loading gate |
+| `t3 <overlay> gate plan disable` | plan-before-code edit-block gate |
+| `t3 <overlay> gate config-overwrite disable` | read-before-overwrite config/dotfile gate |
+| `t3 <overlay> gate completion-claim disable` | completion-claim `Stop` gate |
+| `t3 <overlay> gate main-clone disable` | main-clone working-tree mutation gate |
+| `t3 <overlay> gate memory-recall disable` | cold-tier memory-recall injector |
+| `t3 <overlay> gate snapshot-baseline disable` | snapshot-baseline attestation gate |
+| `t3 <overlay> gate gate-relaxation disable` | anti-relaxation + tach-soundness gate |
+| `t3 <overlay> gate raw-merge disable` | out-of-band raw-merge gate |
+| `t3 <overlay> gate standing-goal disable` | standing verified-green `Stop` gate |
+| `t3 review gate fail-open enable` | master `danger_gate_fail_open` — flips EVERY over-deny gate to fail-open (PUBLIC-egress gate excluded) |
+
+Every gate's deny routes through `_fail_open_or_deny`, so the `SELF_RESCUE_ALLOWLIST` (`src/teatree/hooks/self_rescue.py`) — the fixed set of `t3 … gate … disable` self-rescue commands — is never itself denied, and the master `danger_gate_fail_open` switch relaxes them all at once.

--- a/hooks/scripts/deny_circuit_breaker.py
+++ b/hooks/scripts/deny_circuit_breaker.py
@@ -77,6 +77,8 @@ _FP_CONFIRMED_RE = re.compile(r"\[fp-confirmed:\s*\S[^\]]*?\s*\]")
 # The confirm-once-then-reuse contract (#3252) needs the tokened confirming call
 # and the later tokenless call to share a fingerprint; the other tokens are
 # folded in so an escape marker never splits a genuine retry loop into two.
+# Canonical catalog of every escape marker + kill-switch: hooks/CLAUDE.md
+# § "Escape markers & kill-switches".
 _SIGNATURE_STRIP_RE = re.compile(
     r"\[(?:fp-confirmed|fg-ok|skip-skill-gate|skill-load-ok|skip-plan-gate|quote-ok|reviewer-ok|config-overwrite-ok):[^\]]*\]"
     r"|\b(?:ALLOW_BANNED_TERM|QUOTE_OK|T3_MR_VALIDATE_ALLOW_BROKEN_ENV)=\S+"

--- a/tests/teatree_quality/test_tach_impact.py
+++ b/tests/teatree_quality/test_tach_impact.py
@@ -52,8 +52,14 @@ class TestLiveRepoProbe:
         skipped = would_skip_tests(root, candidates=candidates)
         if skipped is None:
             pytest.skip("tach impact probe unavailable in this environment")
-        assert 0 < len(skipped) < len(candidates)
         assert set(skipped) <= set(candidates)
+        if len(skipped) in {0, len(candidates)}:
+            # A diff touching NONE (a docs/hooks/skills-only PR) or ALL of the modules
+            # these candidates import yields a UNIFORM verdict — a legitimate outcome,
+            # not a broken probe: a src-touching diff still splits the set (skipping a
+            # strict subset). There is simply no discrimination to observe on this diff.
+            pytest.skip("live diff yields a uniform verdict over the candidate set — no split to observe")
+        assert 0 < len(skipped) < len(candidates)
 
     def test_the_default_base_is_the_merge_base_ref_our_selector_uses(self) -> None:
         # A divergent base would make every comparison meaningless.

--- a/tests/test_escape_marker_reference_complete.py
+++ b/tests/test_escape_marker_reference_complete.py
@@ -1,0 +1,75 @@
+"""hooks/CLAUDE.md § "Escape markers & kill-switches" is the canonical catalog.
+
+Doc-invariant guards that keep the catalog from going stale: they derive the live
+token set from the circuit breaker's `_SIGNATURE_STRIP_RE` and the live gate names
+from the `t3 <overlay> gate` CLI registration, and assert each is documented in
+that section. An undocumented new escape token or gate CLI turns CI red.
+"""
+
+import re
+from pathlib import Path
+
+import hooks.scripts.deny_circuit_breaker as dcb
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_HOOKS_CLAUDE_MD = _REPO_ROOT / "hooks" / "CLAUDE.md"
+_GATE_CLI = _REPO_ROOT / "src" / "teatree" / "cli" / "teatree_gate.py"
+
+_SECTION_HEADING = "## Escape markers & kill-switches"
+
+
+def _canonical_section() -> str:
+    """The body of the canonical reference section (heading → next `##` or EOF)."""
+    text = _HOOKS_CLAUDE_MD.read_text(encoding="utf-8")
+    start = text.index(_SECTION_HEADING)
+    rest = text[start + len(_SECTION_HEADING) :]
+    end = rest.find("\n## ")
+    return rest if end == -1 else rest[:end]
+
+
+def _bracket_tokens() -> set[str]:
+    """The `[<token>: …]` names the circuit breaker strips — the live token set."""
+    alternation = re.search(r"\\\[\(\?:([^)]+)\)", dcb._SIGNATURE_STRIP_RE.pattern)
+    assert alternation is not None, "could not parse _SIGNATURE_STRIP_RE bracket alternation"
+    return set(alternation.group(1).split("|"))
+
+
+def _registered_gate_names() -> set[str]:
+    """The named `_register_keyed_gate` subcommands attached under `gate`.
+
+    Excludes the bare orchestrator gate (attached directly with no `name=`,
+    documented separately as `gate disable`) and the `name="gate"` parent group.
+    """
+    source = _GATE_CLI.read_text(encoding="utf-8")
+    body = source[source.index("def register_gate_commands(") :]
+    body = body[: body.index("\ndef ")]
+    return set(re.findall(r'_register_keyed_gate\(\s*gate_group,\s*name="([a-z-]+)"', body))
+
+
+class TestEscapeMarkerReferenceComplete:
+    def test_section_exists(self) -> None:
+        assert _SECTION_HEADING in _HOOKS_CLAUDE_MD.read_text(encoding="utf-8"), (
+            f'hooks/CLAUDE.md must carry the canonical "{_SECTION_HEADING}" reference section.'
+        )
+
+    def test_every_active_bracket_token_is_documented(self) -> None:
+        section = _canonical_section()
+        tokens = _bracket_tokens()
+        assert tokens, "expected a non-empty live token set from _SIGNATURE_STRIP_RE"
+        missing = sorted(t for t in tokens if f"[{t}:" not in section)
+        assert not missing, (
+            "The canonical escape-marker reference in hooks/CLAUDE.md is missing "
+            f"tokens the circuit breaker actively strips: {missing}. Document each "
+            "as `[<token>: <reason>]` in the § 'Escape markers & kill-switches' table."
+        )
+
+    def test_every_registered_gate_cli_is_documented(self) -> None:
+        section = _canonical_section()
+        names = _registered_gate_names()
+        assert names, "expected a non-empty gate-name set from register_gate_commands"
+        missing = sorted(n for n in names if f"gate {n} disable" not in section)
+        assert not missing, (
+            "The canonical kill-switch reference in hooks/CLAUDE.md is missing "
+            f"self-rescue CLIs for gates registered in teatree_gate.py: {missing}. "
+            "Document each as `t3 <overlay> gate <name> disable`."
+        )


### PR DESCRIPTION
Resolves the thin residual of #3562 (classifier rule pack). Items 1/2/4 shipped via #3679/#3586; this closes items 3 (verify) and 5 (consolidate).

## Item 3 — verified MOOT (no code change)
The suspected `_READ_ONLY_BASH_RE` short-circuit in the heavy-Bash gate is unnecessary. Falsifiable probes (heavy-command controls all matched, proving the probe works) show that **none** of the read-only commands match `_ORCHESTRATOR_HEAVY_BASH_RE` (`hook_router.py`) **or** the direct-command guard's denylist (`direct_command_guard.py`):

- `ps` / `lsof` / `docker compose ps|logs|exec` / `git status|log|diff|show` / pipes to `grep`/`jq`, plus `pgrep` / `free` / `git ls-remote` — all pass both gates today.

The heavy-Bash gate is a denylist that simply does not name these commands, so a read-only short-circuit there would be dead code. (The harness auto-mode classifier — a separate layer teatree cannot fix in code — is addressed by the already-shipped `autoMode.allow` grant pack, item 1.)

## Item 5 — consolidate the escape-marker & kill-switch reference
The per-call escape marker tokens and the gate self-rescue CLIs were spread across three places. Consolidated into ONE canonical section, `hooks/CLAUDE.md` "Escape markers & kill-switches":

- a flat table of every per-call token (`[fg-ok: ...]`, `[skip-plan-gate: ...]`, `[skill-load-ok: ...]`, `[skip-skill-gate: ...]`, `[quote-ok: ...]`, `[config-overwrite-ok: ...]`, `[scope-push-ok: ...]`, `[reviewer-ok: ...]`, `[standing-goal-hold: ...]`, `[fp-confirmed: ...]`, `--allow-banned-term`/`ALLOW_BANNED_TERM=1`, `ALLOW_GATE_RELAX=...`) with the gate it relaxes and where the hook reads it, plus the empty-reason-rejected note;
- a table of the `t3 <overlay> gate ... disable` self-rescue CLIs and `t3 review gate fail-open enable` (the master `danger_gate_fail_open`), plus the `SELF_RESCUE_ALLOWLIST`.

`hooks/scripts/deny_circuit_breaker.py` and `docs/blueprint/configuration.md` now cross-link to it.

A doc-invariant test (`tests/test_escape_marker_reference_complete.py`) derives the live token set from the circuit breaker's `_SIGNATURE_STRIP_RE` and the live gate names from `register_gate_commands`, and asserts each is documented — a new escape token or gate CLI turns CI red until the catalog is updated. Verified anti-vacuous (dropping a token row and a gate row both go RED).

## Bundled fix — test_tach_impact brittleness (blocked this PR)
`TestLiveRepoProbe.test_the_verdict_splits_the_candidate_set` asserted the live diff always splits the `teatree_quality` candidate set. That holds only when the diff touches a `teatree.*` module — a docs/hooks-only PR affects none, so the probe legitimately skips ALL candidates and the assertion failed (`assert 14 < 14`) on the whole-tree CI shard for every such PR. Fixed by skipping the split assertion on a uniform verdict (all-skipped or all-kept), matching the existing probe-unavailable skip; the discrimination check still fires for src-touching PRs. Control-verified: touching `teatree.quality.tach_impact` still yields a strict subset (13 kept, 1 skipped).

## Architecture pre-check
- **BLUEPRINT alignment**: docs-only consolidation of the never-lockout catalog (BLUEPRINT §17 invariant 10 / §17.6.4); `docs/blueprint/configuration.md` cross-links, no drift.
- **FSM / extension-point / dependency direction**: n/a — no `src/teatree` behavior, Protocol, or import change.
- **Test surface**: the new doc-invariant test derives from live code (`_SIGNATURE_STRIP_RE`, `register_gate_commands`), anti-vacuous.
- **Behavior preservation**: no gate behavior changed; item 3 is verify-only; the tach test change only relaxes an over-strict assertion for a legitimate diff shape, preserving the discrimination check.
- **Removability / harness-vs-data**: the canonical reference is one doc section; deleting it only removes the cross-links.
