### PR TITLE
fix(config): reject inconsistent harness/provider config pair at write time (#3688)

### DIFF
--- a/src/teatree/config/cross_key_consistency.py
+++ b/src/teatree/config/cross_key_consistency.py
@@ -1,0 +1,139 @@
+"""Cross-key config consistency — reject an inconsistent coupled pair at write time (#3688).
+
+Some config settings are COUPLED: the valid value of one depends on the current
+value of another. ``agent_harness`` (Layer 1 transport) and
+``agent_harness_provider`` (Layer 2 credential) are the first such pair — a
+provider is valid only under certain harnesses
+(:meth:`~teatree.config.AgentHarnessProvider.valid_for`). Today a write that lands
+an INCONSISTENT pair (e.g. ``agent_harness_provider=openai_compatible`` under the
+default ``agent_harness=claude_sdk``) is accepted silently, then makes EVERY later
+dispatch fail at :func:`~teatree.agents.harness_registry.assert_provider_valid_for_harness`
+— each failure burning a claim, an attempt, and a repair-halt, fleet-wide, until an
+operator notices.
+
+This module moves that rejection to WRITE time: one loud error at the config seam
+instead of a fleet-wide repair-halt flood. It is the config-layer mirror of the
+dispatch-time constraint — the closed-enum
+:meth:`~teatree.config.AgentHarnessProvider.valid_for` set for the two built-in
+harnesses. The config layer cannot import the agents-layer OPEN harness registry
+(that would be a backwards dependency edge), so an overlay-registered THIRD harness
+carries no closed constraint here and is left UNCONSTRAINED — its own valid-provider
+set is enforced LOUD at dispatch (:class:`~teatree.agents.harness_registry.InvalidHarnessProviderError`),
+exactly as before. This never blocks a valid built-in pair and never falsely blocks
+an overlay backend.
+
+The mechanism is a small extensible registry (:data:`CROSS_KEY_RULES`) keyed on the
+coupled pair, so more coupled pairs (lane/provider, model/tier) route through the
+same seam as they appear — a new pair is one :class:`CrossKeyRule` appended, not new
+inline branching at every write site.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from teatree.config.agent_enums import AgentHarness, AgentHarnessProvider, parse_harness_name
+
+_HARNESS_KEY = "agent_harness"
+_PROVIDER_KEY = "agent_harness_provider"
+
+# The harness a headless run resolves to when ``agent_harness`` is unset — the
+# ``UserSettings.agent_harness`` field default. The pair after a provider-only
+# write is judged against THIS, not against "no harness": the production trigger
+# was exactly a provider pinned while the harness sat at its default.
+_DEFAULT_HARNESS = AgentHarness.CLAUDE_SDK.value
+
+
+def _as_str(value: object) -> str | None:
+    """Normalise a stored value (``StrEnum`` / ``str`` / ``None``) to ``str | None``.
+
+    A blank string collapses to ``None`` so an empty stored row reads as "unset".
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def check_harness_provider_pair(harness: str | None, provider: str | None) -> str | None:
+    """Return a rejection reason when (*harness*, *provider*) is a pair dispatch would refuse.
+
+    The config-layer mirror of :func:`~teatree.agents.harness_registry.assert_provider_valid_for_harness`,
+    resolved through the closed-enum :meth:`~teatree.config.AgentHarnessProvider.valid_for`
+    for the two built-in harnesses:
+
+    * A ``None``/blank *provider* (no explicit Layer-2 pin) always passes.
+    * A *provider* whose value does not parse is left to the registry parser to
+        reject on read — not this check's concern, so it passes here.
+    * An unset/blank *harness* resolves to :data:`_DEFAULT_HARNESS` (the field
+        default a real dispatch would use).
+    * An overlay-registered (non-built-in) *harness* is UNCONSTRAINED here — its
+        valid-provider set lives in the agents-layer open registry the config
+        layer cannot import, and is enforced at dispatch instead.
+
+    Returns ``None`` for a consistent pair.
+    """
+    if provider is None or not str(provider).strip():
+        return None
+    try:
+        resolved_provider = AgentHarnessProvider.parse(str(provider))
+    except ValueError:
+        return None
+    harness_name = parse_harness_name(harness) if harness else _DEFAULT_HARNESS
+    try:
+        built_in = AgentHarness(harness_name)
+    except ValueError:
+        return None
+    valid = AgentHarnessProvider.valid_for(built_in)
+    if resolved_provider in valid:
+        return None
+    allowed = ", ".join(sorted(member.value for member in valid))
+    return (
+        f"agent_harness_provider={resolved_provider.value!r} is not valid under "
+        f"agent_harness={built_in.value!r} (valid providers: {allowed}). "
+        "Set a compatible agent_harness first."
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class CrossKeyRule:
+    """One coupled-key consistency constraint over an ordered set of setting *keys*.
+
+    *check* receives the resulting values in *keys* order (the pending write's value
+    for the changed key, each other key's current effective value) and returns a
+    rejection reason, or ``None`` when the pair is consistent. Adding a new coupled
+    pair is one :class:`CrossKeyRule` appended to :data:`CROSS_KEY_RULES`.
+    """
+
+    keys: tuple[str, ...]
+    check: Callable[..., str | None]
+
+
+def _harness_provider_check(harness: object, provider: object) -> str | None:
+    return check_harness_provider_pair(_as_str(harness), _as_str(provider))
+
+
+CROSS_KEY_RULES: tuple[CrossKeyRule, ...] = (
+    CrossKeyRule(keys=(_HARNESS_KEY, _PROVIDER_KEY), check=_harness_provider_check),
+)
+
+
+def validate_cross_key_write(
+    changed_key: str,
+    changed_value: object,
+    resolve_other: Callable[[str], object],
+) -> str | None:
+    """Return a rejection reason when writing *changed_key*=*changed_value* would land an inconsistent pair.
+
+    *resolve_other* returns the current effective value of another key (the caller
+    reads the paired key's stored value, falling through to its default). The
+    RESULTING pair — the pending value for *changed_key*, the resolved value for
+    each other key in the rule — is judged. A *changed_key* in no coupled pair is a
+    no-op (returns ``None``), so the check never touches an unrelated write.
+    """
+    for rule in CROSS_KEY_RULES:
+        if changed_key not in rule.keys:
+            continue
+        values = [changed_value if key == changed_key else resolve_other(key) for key in rule.keys]
+        if reason := rule.check(*values):
+            return reason
+    return None

--- a/src/teatree/core/factory/operational_health.py
+++ b/src/teatree/core/factory/operational_health.py
@@ -225,10 +225,72 @@ def _failed_task_signals() -> list[HealthSignal]:
     ]
 
 
+def _harness_provider_consistency_signals() -> list[HealthSignal]:
+    """One CRITICAL per scope whose effective (agent_harness, agent_harness_provider) pair is inconsistent (#3688).
+
+    A pair the harness registry would refuse at dispatch — set before the
+    write-time guard existed, or via a path the guard does not cover — otherwise
+    fails EVERY dispatch in that scope, one repair-halt at a time. Surfacing it as
+    a single loud health-red replaces that per-task flood with one visible signal.
+    The effective pair is resolved exactly as dispatch resolves it
+    (:func:`~teatree.config.get_effective_settings`, env → DB → default) for the
+    global/active scope and each registered overlay; an overlay-registered harness
+    is unconstrained here (its constraint lives in the open registry). Per-scope
+    fail-open so one broken resolve never suppresses another scope's signal.
+    """
+    from teatree.config import get_effective_settings  # noqa: PLC0415 — deferred to keep the module cold-import cheap
+    from teatree.config.cross_key_consistency import (  # noqa: PLC0415 — deferred: same cold-import discipline
+        check_harness_provider_pair,
+    )
+
+    signals: list[HealthSignal] = []
+    seen: set[str] = set()
+    scopes: list[str | None] = [None, *sorted(get_all_overlays())]
+    for scope in scopes:
+        try:
+            settings = get_effective_settings(scope)
+            provider = settings.agent_harness_provider
+            reason = check_harness_provider_pair(
+                settings.agent_harness,
+                provider.value if provider is not None else None,
+            )
+        except Exception:  # noqa: BLE001 — fail-open: a broken health read must never crash the tick or blank the chip
+            warn_throttled(
+                logger,
+                f"health-harness-pair:{scope or 'global'}",
+                "harness/provider consistency health read failed for scope %s — skipped",
+                scope or "global",
+                exc_info=True,
+            )
+            continue
+        if reason is None:
+            continue
+        label = scope or "global"
+        fingerprint = f"harness-provider-drift:{label}"
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        signals.append(
+            HealthSignal(
+                fingerprint=fingerprint,
+                severity=KnownIssue.Severity.CRITICAL,
+                kind="config_pair_drift",
+                overlay=scope or "",
+                summary=f"agent_harness/agent_harness_provider mismatch [{label}]: {reason}",
+            ),
+        )
+    return signals
+
+
 # The deterministic signal collectors, run in order. Each is fail-open on its
 # own so one broken read never suppresses the others; adding a new signal family
 # (default-branch CI, stale 404 refs, …) is one entry here plus its collector.
-_COLLECTORS = (_overlay_health_signals, _stale_tick_signals, _failed_task_signals)
+_COLLECTORS = (
+    _overlay_health_signals,
+    _stale_tick_signals,
+    _failed_task_signals,
+    _harness_provider_consistency_signals,
+)
 
 
 def collect_signals() -> list[HealthSignal]:

--- a/src/teatree/core/management/commands/config_setting.py
+++ b/src/teatree/core/management/commands/config_setting.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
+from django.core.exceptions import ValidationError
 from django_typer.management import TyperCommand, command
 
 from teatree.config import ALL_KNOWN_CONFIG_SETTINGS, COLD_HOOK_SETTINGS, FEATURE_FLAGS, get_effective_settings
@@ -129,7 +130,15 @@ class Command(TyperCommand):
         # type — scalar, list, or a ``StrEnum`` (which a ``JSONField`` persists as
         # its string value) — so the parsed value round-trips through the store
         # and the read tier re-coerces it to the same value.
-        ConfigSetting.objects.set_value(key, canonical, scope=overlay)
+        try:
+            ConfigSetting.objects.set_value(key, canonical, scope=overlay)
+        except ValidationError as exc:
+            # A coupled-key inconsistency (#3688) — e.g. an agent_harness_provider
+            # no resulting agent_harness would accept at dispatch. Refuse loudly at
+            # write time, leaving the store untouched, instead of a fleet-wide
+            # repair-halt flood on every later dispatch.
+            self.stderr.write(f"  refusing inconsistent config for {key!r}: {exc.messages[0]}")
+            raise SystemExit(2) from exc
         # Verify-by-re-read: report the stored value the resolver will now see.
         stored = ConfigSetting.objects.get_effective(key, scope=overlay)
         self.stdout.write(f"  set {key} = {stored!r}  [{_scope_label(overlay)}]{_flag_suffix(key)}")

--- a/src/teatree/core/models/config_setting.py
+++ b/src/teatree/core/models/config_setting.py
@@ -102,6 +102,28 @@ class ConfigSettingManager(models.Manager["ConfigSetting"]):
         row = self.filter(scope=scope, key=key).first()
         return row.value if row is not None else None
 
+    def _reject_inconsistent_cross_key(self, key: str, value: ConfigValue, scope: str) -> None:
+        """Raise :class:`ValidationError` when this write would land an inconsistent coupled pair (#3688).
+
+        Delegates to the config-layer :func:`~teatree.config.cross_key_consistency.validate_cross_key_write`,
+        resolving the paired key's current effective value from the DB tier
+        (overlay-scope row, then global-scope row) so the RESULTING pair — not
+        just the value in hand — is judged. A no-op for any key in no coupled
+        pair. Imported lazily to keep the model module's cold-import cheap.
+        """
+        from teatree.config.cross_key_consistency import (  # noqa: PLC0415 — deferred: heavy config import
+            validate_cross_key_write,
+        )
+
+        def resolve_other(other_key: str) -> ConfigValue | None:
+            stored = self.get_effective(other_key, scope=scope)
+            if stored is None and scope != GLOBAL_SCOPE:
+                stored = self.get_effective(other_key, GLOBAL_SCOPE)
+            return stored
+
+        if reason := validate_cross_key_write(key, value, resolve_other):
+            raise ValidationError(reason)
+
     def set_value(self, key: str, value: ConfigValue, scope: str = GLOBAL_SCOPE) -> "ConfigSetting":
         """Upsert the override row for *key* in *scope* to *value* (admin path).
 
@@ -114,7 +136,15 @@ class ConfigSettingManager(models.Manager["ConfigSetting"]):
         seed provenance (``seeded_by`` → ``""``, ``seed_value`` → ``None``): the
         row becomes operator-owned, and no later deploy re-seed or ``t3 doctor
         --repair`` autofix may overwrite or delete it (#3435 / #3434).
+
+        Raises :class:`~django.core.exceptions.ValidationError` when the write
+        would land an INCONSISTENT coupled-key pair (#3688) — e.g. an
+        ``agent_harness_provider`` that no harness the resulting ``agent_harness``
+        names would accept at dispatch. Rejecting at write time turns one bad
+        config into one loud error, not a fleet-wide repair-halt flood on every
+        later dispatch. The store is left untouched on rejection.
         """
+        self._reject_inconsistent_cross_key(key, value, scope)
         row, _ = self.update_or_create(
             scope=scope,
             key=key,

--- a/tests/teatree_config/test_agent_harness_provider_config.py
+++ b/tests/teatree_config/test_agent_harness_provider_config.py
@@ -35,6 +35,10 @@ class TestAgentHarnessProviderResolution(TestCase):
         assert get_effective_settings().agent_harness_provider is AgentHarnessProvider.API_KEY
 
     def test_stored_openai_compatible(self) -> None:
+        # openai_compatible is valid only under agent_harness=pydantic_ai (#3688
+        # cross-key guard), so arrange the consistent pair before checking that the
+        # stored provider resolves.
+        ConfigSetting.objects.set_value("agent_harness", "pydantic_ai")
         ConfigSetting.objects.set_value("agent_harness_provider", "openai_compatible")
         assert get_effective_settings().agent_harness_provider is AgentHarnessProvider.OPENAI_COMPATIBLE
 

--- a/tests/teatree_config/test_cross_key_consistency.py
+++ b/tests/teatree_config/test_cross_key_consistency.py
@@ -1,0 +1,76 @@
+"""Cross-key config consistency validator (souliane/teatree#3688).
+
+Pure-logic unit tests for the write-time (agent_harness, agent_harness_provider)
+consistency check — the config-layer mirror of the dispatch-time
+``harness_registry.assert_provider_valid_for_harness`` constraint. No DB, no env:
+the validator is a pure function over the resulting pair.
+"""
+
+from teatree.config.cross_key_consistency import check_harness_provider_pair, validate_cross_key_write
+
+
+class TestHarnessProviderPair:
+    def test_consistent_claude_sdk_pairs_pass(self) -> None:
+        assert check_harness_provider_pair("claude_sdk", "subscription_oauth") is None
+        assert check_harness_provider_pair("claude_sdk", "api_key") is None
+
+    def test_consistent_pydantic_ai_pairs_pass(self) -> None:
+        assert check_harness_provider_pair("pydantic_ai", "openai_compatible") is None
+        assert check_harness_provider_pair("pydantic_ai", "anthropic_api") is None
+
+    def test_inconsistent_pair_is_rejected_naming_both_sides(self) -> None:
+        reason = check_harness_provider_pair("claude_sdk", "openai_compatible")
+        assert reason is not None
+        assert "openai_compatible" in reason
+        assert "claude_sdk" in reason
+
+    def test_api_key_under_pydantic_ai_is_rejected(self) -> None:
+        assert check_harness_provider_pair("pydantic_ai", "api_key") is not None
+
+    def test_retired_orca_router_byok_alias_under_claude_sdk_is_rejected(self) -> None:
+        # The production trigger: the retired 'orca_router_byok' value aliases
+        # forward to openai_compatible, which is valid only under pydantic_ai.
+        assert check_harness_provider_pair("claude_sdk", "orca_router_byok") is not None
+
+    def test_retired_orca_router_byok_alias_under_pydantic_ai_passes(self) -> None:
+        assert check_harness_provider_pair("pydantic_ai", "orca_router_byok") is None
+
+    def test_absent_or_blank_provider_always_passes(self) -> None:
+        assert check_harness_provider_pair("claude_sdk", None) is None
+        assert check_harness_provider_pair("pydantic_ai", "") is None
+        assert check_harness_provider_pair("claude_sdk", "   ") is None
+
+    def test_unset_harness_resolves_to_the_claude_sdk_default(self) -> None:
+        assert check_harness_provider_pair(None, "openai_compatible") is not None
+        assert check_harness_provider_pair(None, "subscription_oauth") is None
+
+    def test_unparseable_provider_is_left_to_the_registry_parser(self) -> None:
+        assert check_harness_provider_pair("claude_sdk", "not_a_provider") is None
+
+    def test_overlay_registered_harness_is_unconstrained(self) -> None:
+        # A non-built-in (overlay-registered) harness carries no closed-enum
+        # constraint here; the open registry enforces it at dispatch.
+        assert check_harness_provider_pair("vertex_enterprise", "openai_compatible") is None
+
+
+class TestValidateCrossKeyWrite:
+    def test_unrelated_key_is_a_no_op(self) -> None:
+        assert validate_cross_key_write("mode", "auto", lambda _key: None) is None
+
+    def test_setting_provider_reads_the_current_harness(self) -> None:
+        resolve = {"agent_harness": "claude_sdk"}.get
+        assert validate_cross_key_write("agent_harness_provider", "openai_compatible", resolve) is not None
+
+    def test_setting_harness_reads_the_current_provider(self) -> None:
+        resolve = {"agent_harness_provider": "openai_compatible"}.get
+        assert validate_cross_key_write("agent_harness", "claude_sdk", resolve) is not None
+
+    def test_setting_harness_to_a_matching_transport_passes(self) -> None:
+        resolve = {"agent_harness_provider": "openai_compatible"}.get
+        assert validate_cross_key_write("agent_harness", "pydantic_ai", resolve) is None
+
+    def test_provider_with_no_stored_harness_uses_the_default(self) -> None:
+        assert validate_cross_key_write("agent_harness_provider", "openai_compatible", lambda _key: None) is not None
+
+    def test_provider_valid_under_default_harness_passes(self) -> None:
+        assert validate_cross_key_write("agent_harness_provider", "subscription_oauth", lambda _key: None) is None

--- a/tests/teatree_core/management/test_config_setting_command.py
+++ b/tests/teatree_core/management/test_config_setting_command.py
@@ -75,6 +75,20 @@ class TestConfigSettingSet(TestCase):
         # The store is untouched, so config reads still resolve.
         assert get_effective_settings().mode is not None
 
+    def test_set_rejects_inconsistent_harness_provider_pair(self) -> None:
+        # #3688: an agent_harness_provider valid only under pydantic_ai, written
+        # while agent_harness sits at its claude_sdk default, is refused at WRITE
+        # time (exit 2) with the store left untouched — one loud error instead of
+        # a fleet-wide repair-halt flood on every later dispatch.
+        with pytest.raises(SystemExit):
+            call_command("config_setting", "set", "agent_harness_provider", '"openai_compatible"')
+        assert ConfigSetting.objects.filter(key="agent_harness_provider").exists() is False
+
+    def test_set_accepts_consistent_harness_provider_pair(self) -> None:
+        call_command("config_setting", "set", "agent_harness", '"pydantic_ai"')
+        call_command("config_setting", "set", "agent_harness_provider", '"openai_compatible"')
+        assert ConfigSetting.objects.get_effective("agent_harness_provider") == "openai_compatible"
+
     def test_set_rejects_quoted_bool_string(self) -> None:
         # #258 blocker 2: a JSON string ``"false"`` for a bool-typed setting
         # must be rejected, not truthy-coerced via ``bool("false") == True``.

--- a/tests/teatree_core/models/test_config_setting.py
+++ b/tests/teatree_core/models/test_config_setting.py
@@ -203,3 +203,53 @@ class TestConfigSettingValueValidation(TestCase):
         with pytest.raises(ValidationError) as caught:
             row.full_clean()
         assert "value" in caught.value.message_dict
+
+
+class TestConfigSettingCrossKeyConsistency(TestCase):
+    """``set_value`` rejects an inconsistent (agent_harness, agent_harness_provider) pair (#3688).
+
+    A provider valid only under ``pydantic_ai`` written while ``agent_harness``
+    sits at its ``claude_sdk`` default would be accepted silently today, then fail
+    EVERY later dispatch. The guard moves that rejection to write time; the store
+    is left untouched on rejection.
+    """
+
+    def test_provider_inconsistent_with_default_harness_is_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ConfigSetting.objects.set_value("agent_harness_provider", "openai_compatible")
+        assert ConfigSetting.objects.get_effective("agent_harness_provider") is None
+
+    def test_retired_orca_router_byok_under_default_harness_is_rejected(self) -> None:
+        # The exact production trigger from #3688.
+        with pytest.raises(ValidationError):
+            ConfigSetting.objects.set_value("agent_harness_provider", "orca_router_byok")
+
+    def test_provider_valid_under_default_harness_is_accepted(self) -> None:
+        ConfigSetting.objects.set_value("agent_harness_provider", "subscription_oauth")
+        assert ConfigSetting.objects.get_effective("agent_harness_provider") == "subscription_oauth"
+
+    def test_harness_then_matching_provider_is_accepted(self) -> None:
+        ConfigSetting.objects.set_value("agent_harness", "pydantic_ai")
+        ConfigSetting.objects.set_value("agent_harness_provider", "openai_compatible")
+        assert ConfigSetting.objects.get_effective("agent_harness_provider") == "openai_compatible"
+
+    def test_harness_change_conflicting_with_stored_provider_is_rejected(self) -> None:
+        ConfigSetting.objects.set_value("agent_harness", "pydantic_ai")
+        ConfigSetting.objects.set_value("agent_harness_provider", "openai_compatible")
+        with pytest.raises(ValidationError):
+            ConfigSetting.objects.set_value("agent_harness", "claude_sdk")
+        # The harness row is unchanged — the rejected write left the store intact.
+        assert ConfigSetting.objects.get_effective("agent_harness") == "pydantic_ai"
+
+    def test_overlay_scope_pair_is_checked_against_the_default_harness(self) -> None:
+        with pytest.raises(ValidationError):
+            ConfigSetting.objects.set_value("agent_harness_provider", "openai_compatible", scope="acme")
+
+    def test_overlay_scope_provider_matches_overlay_scope_harness(self) -> None:
+        ConfigSetting.objects.set_value("agent_harness", "pydantic_ai", scope="acme")
+        ConfigSetting.objects.set_value("agent_harness_provider", "openai_compatible", scope="acme")
+        assert ConfigSetting.objects.get_effective("agent_harness_provider", scope="acme") == "openai_compatible"
+
+    def test_unrelated_key_write_is_never_touched(self) -> None:
+        ConfigSetting.objects.set_value("issue_implementer_enabled", value=True)
+        assert ConfigSetting.objects.get_effective("issue_implementer_enabled") is True

--- a/tests/teatree_core/test_operational_health.py
+++ b/tests/teatree_core/test_operational_health.py
@@ -17,13 +17,15 @@ from teatree.core.factory.operational_health import (
     HealthSignal,
     HealthStatus,
     _failed_task_signals,
+    _harness_provider_consistency_signals,
     _overlay_health_signals,
     _stale_tick_signals,
     _status_from_issues,
     read_health,
     reconcile_health,
 )
-from teatree.core.models import Session, Task, Ticket
+from teatree.core.models import ConfigSetting, Session, Task, Ticket
+from teatree.core.models.config_setting import GLOBAL_SCOPE
 from teatree.core.models.known_issue import KnownIssue
 from teatree.utils.throttled_log import reset_throttle
 
@@ -213,3 +215,37 @@ class TestOverlaySignalCollector:
         warnings = [r for r in caplog.records if r.name == logger_name and r.levelname == "WARNING"]
         assert warnings, "expected a throttled WARNING for the broken overlay health read"
         assert "broken" in warnings[0].getMessage()
+
+
+class TestHarnessProviderConsistencyCollector:
+    """The loop-admission / health guard for the coupled harness/provider pair (#3688).
+
+    A pair set before the write-time guard existed (or via an uncovered path)
+    surfaces as ONE loud CRITICAL health-red, not a per-task repair-halt flood.
+    Rows are created directly via the ORM to model that pre-existing state — the
+    write-time guard would refuse the inconsistent ``set_value``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("T3_AGENT_HARNESS", raising=False)
+        monkeypatch.delenv("T3_AGENT_HARNESS_PROVIDER", raising=False)
+        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+
+    def test_consistent_effective_pair_yields_nothing(self) -> None:
+        with patch("teatree.core.factory.operational_health.get_all_overlays", return_value={}):
+            assert _harness_provider_consistency_signals() == []
+
+    def test_preexisting_inconsistent_pair_yields_a_critical_signal(self) -> None:
+        ConfigSetting.objects.create(scope=GLOBAL_SCOPE, key="agent_harness_provider", value="openai_compatible")
+        with patch("teatree.core.factory.operational_health.get_all_overlays", return_value={}):
+            signals = _harness_provider_consistency_signals()
+        assert len(signals) == 1
+        assert signals[0].severity == KnownIssue.Severity.CRITICAL
+        assert signals[0].kind == "config_pair_drift"
+
+    def test_inconsistent_pair_reddens_the_chip_via_reconcile(self) -> None:
+        ConfigSetting.objects.create(scope=GLOBAL_SCOPE, key="agent_harness_provider", value="openai_compatible")
+        with patch("teatree.core.factory.operational_health.get_all_overlays", return_value={}):
+            report = reconcile_health()
+        assert report.status is HealthStatus.RED

--- a/tests/teatree_eval/test_eval_credential_selection.py
+++ b/tests/teatree_eval/test_eval_credential_selection.py
@@ -17,7 +17,7 @@ from unittest.mock import patch
 import pytest
 from django.test import TestCase
 
-from teatree.config import AgentHarnessProvider
+from teatree.config import AgentHarness, AgentHarnessProvider
 from teatree.core.models import ConfigSetting
 from teatree.credential_config import resolve_eval_credential
 from teatree.eval.api_runner import ApiInProcessRunner
@@ -54,6 +54,17 @@ class TestProviderToCredentialMapping(TestCase):
             if provider is None:
                 continue
             with self.subTest(provider=str(provider)):
+                # Clear the previous iteration's provider, then pin the harness
+                # this provider is valid under before setting it, so the #3688
+                # cross-key write guard accepts the pair (switching harness while
+                # an incompatible provider is still pinned is itself rejected).
+                harness = (
+                    AgentHarness.PYDANTIC_AI
+                    if provider in AgentHarnessProvider.valid_for(AgentHarness.PYDANTIC_AI)
+                    else AgentHarness.CLAUDE_SDK
+                )
+                ConfigSetting.objects.clear("agent_harness_provider")
+                ConfigSetting.objects.set_value("agent_harness", harness.value)
                 ConfigSetting.objects.set_value("agent_harness_provider", provider.value)
                 assert isinstance(resolve_eval_credential(), expected)
 

--- a/tests/teatree_mcp/test_write_tools.py
+++ b/tests/teatree_mcp/test_write_tools.py
@@ -80,6 +80,14 @@ class TestCliErrorPrimitiveSurfacesStructured(TestCase):
         with pytest.raises(Exception, match="invalid JSON"):
             _call("config_setting_set", {"key": "loop_cadence_seconds", "value": "not-json{"})
 
+    def test_config_setting_inconsistent_harness_provider_pair_is_refused(self) -> None:
+        # #3688: the same write-time cross-key guard fires through the MCP seam
+        # (which wraps the CLI), surfacing the refusal as a structured error with
+        # the store left untouched — not a silent accept that dooms every dispatch.
+        with pytest.raises(Exception, match="inconsistent config"):
+            _call("config_setting_set", {"key": "agent_harness_provider", "value": '"openai_compatible"'})
+        assert not ConfigSetting.objects.filter(key="agent_harness_provider").exists()
+
     def test_question_answer_unknown_id_surfaces_message(self) -> None:
         with pytest.raises(Exception, match="not found or already resolved"):
             _call("question_answer", {"question_id": 999999, "text": "yes"})


### PR DESCRIPTION
## Summary

Fixes #3688 (P0). An inconsistent `(agent_harness, agent_harness_provider)` pair — e.g. a provider valid only under `pydantic_ai` written while `agent_harness` sits at its `claude_sdk` default — was accepted silently at config-write time, then failed **every** later dispatch at the harness registry, each failure burning a claim, an attempt, and a repair-halt fleet-wide until an operator noticed.

This moves the rejection to **write time**: one loud error at the config seam instead of a fleet-wide repair-halt flood.

## What changed

- **New config-layer cross-key consistency registry** (`src/teatree/config/cross_key_consistency.py`): a small, extensible mechanism keyed on the coupled pair, so more coupled pairs (lane/provider, model/tier) route through the same seam as they appear. The harness/provider rule mirrors the dispatch-time `AgentHarnessProvider.valid_for` constraint for the two built-in harnesses. An overlay-registered third harness is **unconstrained here** — its valid-provider set lives in the agents-layer open registry the config layer cannot import (a backwards dependency edge), and stays enforced loud at dispatch.
- **Write-time guard at `ConfigSetting.set_value`**: judges the **resulting** pair (reading the paired key's current effective value, overlay-scope then global) and raises `ValidationError` on an inconsistent write. This single deepest seam covers **both** write paths — the CLI `config_setting set` and the MCP `config_setting_set` tool that wraps it. The CLI surfaces the refusal as a clean exit 2; the store is left untouched on rejection.
- **Loop-admission / health guard**: a new `operational_health` collector surfaces any pre-existing inconsistent pair (set before this guard, or via an uncovered path) as **one** critical health-red per scope, replacing the per-task repair-halt flood.

## Valid-pair source of truth

The consistent combinations are read from the same constraint dispatch enforces (`agents/harness_registry.assert_provider_valid_for_harness`, backed by the closed-enum `config.AgentHarnessProvider.valid_for`):

| `agent_harness` | valid `agent_harness_provider` |
|---|---|
| `claude_sdk` | `subscription_oauth`, `api_key` |
| `pydantic_ai` | `openai_compatible`, `anthropic_api` |

The retired `orca_router_byok` value aliases forward to `openai_compatible` (valid only under `pydantic_ai`) — the exact production trigger.

## Tests (RED→GREEN, controls confirmed)

- `tests/teatree_config/test_cross_key_consistency.py` — the pure validator (consistent pairs pass; inconsistent/alias/default-harness cases reject; overlay harness unconstrained).
- `tests/teatree_core/models/test_config_setting.py::TestConfigSettingCrossKeyConsistency` — `set_value` rejects an inconsistent pair, accepts a consistent one, leaves the store untouched on rejection (RED confirmed with the guard removed).
- `tests/teatree_core/management/test_config_setting_command.py` — the CLI exits 2 on an inconsistent pair, accepts a consistent one (RED confirmed).
- `tests/teatree_mcp/test_write_tools.py` — the MCP `config_setting_set` seam surfaces the refusal as a structured error.
- `tests/teatree_core/test_operational_health.py::TestHarnessProviderConsistencyCollector` — a pre-existing inconsistent pair yields one critical signal and reddens the chip (RED confirmed with the collector unregistered).

One existing resolver test (`test_stored_openai_compatible`) now arranges the consistent pair (`pydantic_ai` first) before checking resolution — its intent is preserved.

## Architecture pre-check — #3688

**1. BLUEPRINT § alignment** — §17.4 DB-home config override tier (`ConfigSetting`, #1775); no new section.

**2. FSM phase boundaries** — n/a (no `Ticket`/`Worktree` state transition).

**3. Extension-point contracts** — none changed. Consumes the existing `AgentHarnessProvider.valid_for` closed enum; the agents-layer open `harness_registry` is untouched and remains the dispatch-time authority for overlay backends.

**4. Component boundaries** — validator in the config (platform) layer so `core.models.ConfigSetting` (domain) can reach it downward; the write guard is a manager method (Django convention); the health signal is a collector in `core.factory.operational_health`.

**5. Dependency direction** — `core.models -> teatree.config` is an existing downward edge (domain -> platform); no new agents import from core. `uv run tach check` passes.

**6. Test surface** — per behaviour above; the write guard test asserts the observable contract (rejection + untouched store), the health test asserts the emitted signal + chip verdict.

**7. Resilience invariants** — idempotency: re-writing the same consistent pair is a no-op upsert. The health collector is per-scope fail-open (one broken resolve never suppresses another scope). No external write introduced.

**8. Identity/key normalization** — the coupled keys are canonical setting names; provider values normalize through `AgentHarnessProvider.parse` (alias-forward for `orca_router_byok`) before comparison — no strip-to-match.

**9. Behavior preservation** — additive; no matcher narrowed, no must-block test inverted. Valid built-in pairs and overlay backends are never falsely blocked.

**10. Removability / harness-vs-data** — the registry is one appendable rule list (`CROSS_KEY_RULES`); the guard and collector are self-contained and revert cleanly. The varying part (which pairs are coupled) is data in the rule list, not inline branching at each write site.
