### PR TITLE
fix(loop): auto-drain stale repair-loop questions when the subject reconciles (#3692)

### DIFF
--- a/src/teatree/loop/repair_halt_reconcile.py
+++ b/src/teatree/loop/repair_halt_reconcile.py
@@ -1,0 +1,117 @@
+"""Auto-drain stale repair-loop escalation questions when their subject reconciles (#3692).
+
+A repair-loop escalation records a durable ``DeferredQuestion`` when an auto-retry
+is halted (``repair-halt:``), a phase stalls on two identical failures
+(``repair-stall:``), or a phase exhausts its iteration budget (``repair-cap:``).
+Each asks the owner "how should it proceed — investigate, rework, or ignore?".
+
+When the escalation's SUBJECT — the ticket(s) whose stall raised it — subsequently
+reaches a terminal state (its PR merged, the ticket delivered, or it was ignored),
+the question is MOOT: the loop will never retry that phase again
+(:func:`~teatree.loop.transient_requeue._non_terminal_failed_tasks` excludes
+terminal tickets), so the only possible answer is "ignore". Left pending, these
+moot rows pile up in the away-mode queue and bury the one live question the owner
+actually needs to answer.
+
+This tick reconcile dismisses exactly the provably-moot rows and no others. The
+conservatism guard is per-subject: a row is drained ONLY when EVERY ticket that
+raised it is terminal. A ticket-keyed marker (``repair-stall``/``repair-cap``)
+carries its subject ticket pk directly; a fingerprint-keyed ``repair-halt`` marker
+collapses several tickets onto one row, so its subjects are re-derived from the
+parked (:data:`~teatree.loop.transient_requeue.HALT_STAMP`) tasks that share the
+marker. If even one such ticket is still live — or the subject cannot be
+determined at all — the row is KEPT. Dropping a question whose subject is still
+live is the failure mode this must never commit.
+
+Lives in ``teatree.loop`` (orchestration): it composes the ``DeferredQuestion``
+and ``Task``/``Ticket`` domain models with the ``transient_requeue`` escalation
+marker, so only an orchestration-layer module may own it.
+"""
+
+from collections import defaultdict
+
+from teatree.core.models import Task, Ticket
+from teatree.core.models.deferred_question import DeferredQuestion
+from teatree.loop.transient_requeue import HALT_STAMP, escalation_marker
+
+_HALT_PREFIX = "repair-halt:"
+_TICKET_KEYED_PREFIXES = ("repair-stall:", "repair-cap:")
+#: A ticket-keyed marker is ``<kind>:<ticket-pk>:<phase>`` — three colon-separated fields.
+_TICKET_KEYED_FIELDS = 3
+
+
+def resolve_reconciled_repair_halts() -> int:
+    """Dismiss pending repair-loop questions whose every subject ticket is terminal.
+
+    Returns the number of questions drained. A question is dismissed as STALE only
+    when its subjects are determinable AND every one is in a terminal state; any
+    live or undeterminable subject leaves the row pending untouched.
+    """
+    pending = list(
+        DeferredQuestion.objects.filter(
+            answered_at__isnull=True,
+            dismissed_at__isnull=True,
+            dedupe_marker__startswith="repair-",
+        )
+    )
+    if not pending:
+        return 0
+    halt_subjects = _halt_marker_subject_states(
+        {q.dedupe_marker for q in pending if q.dedupe_marker.startswith(_HALT_PREFIX)}
+    )
+    resolved = 0
+    for question in pending:
+        states = _subject_states(question.dedupe_marker, halt_subjects)
+        if states and all(state in Ticket._TERMINAL_STATES for state in states):  # noqa: SLF001 — model SSOT terminal set
+            reason = f"repair-loop escalation moot: every subject ticket is terminal [{question.dedupe_marker}]"
+            question.mark_stale(reason)
+            resolved += 1
+    return resolved
+
+
+def _subject_states(marker: str, halt_subject_states: dict[str, list[str]]) -> list[str] | None:
+    """The FSM state of every ticket that raised *marker*, or ``None`` if undeterminable.
+
+    A ticket-keyed ``repair-stall``/``repair-cap`` marker carries its subject pk; a
+    fingerprint-keyed ``repair-halt`` marker's subjects come from the pre-computed
+    parked-task map. ``None`` (undeterminable) is treated as "keep" by the caller —
+    the conservative default that never drops a question on a guess.
+    """
+    if marker.startswith(_TICKET_KEYED_PREFIXES):
+        return _ticket_keyed_states(marker)
+    if marker.startswith(_HALT_PREFIX):
+        return halt_subject_states.get(marker)
+    return None
+
+
+def _ticket_keyed_states(marker: str) -> list[str] | None:
+    """The single subject ticket's state for a ``repair-stall:<pk>:<phase>`` marker, else ``None``."""
+    parts = marker.split(":", _TICKET_KEYED_FIELDS - 1)
+    if len(parts) < _TICKET_KEYED_FIELDS or not parts[1].isdigit():
+        return None
+    state = Ticket.objects.filter(pk=int(parts[1])).values_list("state", flat=True).first()
+    return [state] if state is not None else None
+
+
+def _halt_marker_subject_states(markers: set[str]) -> dict[str, list[str]]:
+    """Map each ``repair-halt`` marker in *markers* to the states of the tickets that raised it.
+
+    One pass over the parked (:data:`HALT_STAMP`) FAILED tasks — the durable record
+    of which tickets a fingerprint-keyed marker collapsed — re-deriving each task's
+    :func:`escalation_marker` and grouping ticket states by it. A marker with no
+    surviving parked task is absent from the map, so the caller keeps its question
+    (the subject cannot be proven terminal).
+    """
+    if not markers:
+        return {}
+    by_marker: dict[str, list[str]] = defaultdict(list)
+    parked = (
+        Task.objects.filter(status=Task.Status.FAILED, execution_reason__contains=HALT_STAMP)
+        .select_related("ticket")
+        .prefetch_related("attempts")
+    )
+    for task in parked:
+        marker = escalation_marker(task)
+        if marker in markers:
+            by_marker[marker].append(task.ticket.state)
+    return dict(by_marker)

--- a/src/teatree/loop/tick_recovery.py
+++ b/src/teatree/loop/tick_recovery.py
@@ -41,12 +41,17 @@ def _reap_stale_task_claims(errors: dict[str, str] | None = None) -> None:
     failure surfaces loudly instead of freezing the factory in silence.
     """
     from teatree.core.worktree.recovery_sweeps import run_boot_sweeps  # noqa: PLC0415 — deferred: loaded at tick time
-    from teatree.loop import stuck_ticket_redispatch, transient_requeue  # noqa: PLC0415 — deferred: loaded at tick time
+    from teatree.loop import (  # noqa: PLC0415 — deferred: loaded at tick time
+        repair_halt_reconcile,
+        stuck_ticket_redispatch,
+        transient_requeue,
+    )
 
     sweeps: tuple[tuple[str, Callable[[], object]], ...] = (
         ("recovery:boot_sweeps", run_boot_sweeps),
         ("recovery:transient_requeue", transient_requeue.requeue_transient_failed),
         ("recovery:stuck_redispatch", stuck_ticket_redispatch.redispatch_stuck_tickets),
+        ("recovery:repair_halt_reconcile", repair_halt_reconcile.resolve_reconciled_repair_halts),
     )
     for label, sweep in sweeps:
         try:

--- a/src/teatree/loop/transient_requeue.py
+++ b/src/teatree/loop/transient_requeue.py
@@ -73,7 +73,7 @@ ticket IGNORED), never reopened: a verdict can never land on a dead PR, so
 re-dispatching only burns a session that re-confirms the close (3556). Fail-OPEN on an
 UNKNOWN PR state so a transient forge hiccup never retires a live review.
 
-A once-escalated task is stamped (:data:`_HALT_STAMP` in ``execution_reason``) and
+A once-escalated task is stamped (:data:`HALT_STAMP` in ``execution_reason``) and
 excluded from every subsequent scan, so the dead-letter set never grows the per-tick
 work unboundedly. The ``DeferredQuestion`` itself is deduped by a STABLE key —
 ``(ticket, phase, failure-fingerprint)``, NOT the task pk — so the fresh ``Task`` rows
@@ -113,7 +113,7 @@ logger = logging.getLogger(__name__)
 #: Stamped onto ``execution_reason`` when a task is escalated (dead-lettered), so it
 #: is excluded from every future scan — bounds per-tick work and makes the escalation
 #: durably once-per-task regardless of whether the question is later answered.
-_HALT_STAMP = "[repair-halt-parked]"
+HALT_STAMP = "[repair-halt-parked]"
 #: Stamped onto ``execution_reason`` when a SUPERSEDED FAILED task is retired (its
 #: phase output the ticket's FSM already reached). It is marked COMPLETED and drops
 #: out of the scan — the away-mode queue is never asked about a phase the ticket
@@ -325,7 +325,7 @@ def _latest_error(task: Task) -> str:
 def _non_terminal_failed_tasks() -> list[Task]:
     """FAILED tasks on a non-terminal ticket, minus already-parked rows, attempts prefetched.
 
-    Excluding the parked rows — :data:`_HALT_STAMP` (escalated) and
+    Excluding the parked rows — :data:`HALT_STAMP` (escalated) and
     :data:`_LIVE_SUCCESSOR_STAMP` (a live successor holds the phase) — keeps the
     per-tick scan bounded as dead letters pile up (a monotonically growing FAILED set
     would otherwise degrade tick latency linearly); prefetching ``attempts`` removes the
@@ -334,7 +334,7 @@ def _non_terminal_failed_tasks() -> list[Task]:
     return list(
         Task.objects.filter(status=Task.Status.FAILED)
         .exclude(ticket__state__in=Ticket._TERMINAL_STATES)  # noqa: SLF001 — the model's SSOT terminal set
-        .exclude(execution_reason__contains=_HALT_STAMP)
+        .exclude(execution_reason__contains=HALT_STAMP)
         .exclude(execution_reason__contains=_LIVE_SUCCESSOR_STAMP)
         .select_related("ticket")
         .prefetch_related("attempts"),
@@ -383,17 +383,17 @@ def _reopen(task: Task) -> int:
 
 
 def _stamp_halt(task: Task) -> None:
-    """Park *task* out of future scans by stamping :data:`_HALT_STAMP` onto ``execution_reason``.
+    """Park *task* out of future scans by stamping :data:`HALT_STAMP` onto ``execution_reason``.
 
     Idempotent — a no-op once the stamp is present. The per-task park: an escalated
     row is excluded from :func:`_non_terminal_failed_tasks`, so answering or dismissing
     the question can never resurrect a fresh escalation for THIS row. Cross-row
     collapse of the fresh ``Task`` rows a stuck phase mints each cycle is the separate
-    job of the stable ``dedupe_marker`` (:func:`_escalation_marker`).
+    job of the stable ``dedupe_marker`` (:func:`escalation_marker`).
     """
-    if _HALT_STAMP in task.execution_reason:
+    if HALT_STAMP in task.execution_reason:
         return
-    reason = f"{task.execution_reason}\n{_HALT_STAMP}".strip() if task.execution_reason else _HALT_STAMP
+    reason = f"{task.execution_reason}\n{HALT_STAMP}".strip() if task.execution_reason else HALT_STAMP
     Task.objects.filter(pk=task.pk).update(execution_reason=reason)
 
 
@@ -560,7 +560,7 @@ def _retire_superseded(task: Task) -> None:
     )
 
 
-def _escalation_marker(task: Task) -> str:
+def escalation_marker(task: Task) -> str:
     """Stable dedupe key for a halted task's escalation — ``(phase, failure)``, ticket-agnostic.
 
     Keyed on the canonical phase + the NORMALIZED failure fingerprint — NOT the task pk
@@ -585,8 +585,8 @@ def _escalation_marker(task: Task) -> str:
 def _escalate_once(task: Task, *, reason: str) -> None:
     """Record a durable escalation for a halted task, then park the row. Deduped by condition.
 
-    The row is stamped (:data:`_HALT_STAMP`) so it drops out of every future scan; the
-    ``DeferredQuestion`` is deduped by the STABLE :func:`_escalation_marker` (ticket +
+    The row is stamped (:data:`HALT_STAMP`) so it drops out of every future scan; the
+    ``DeferredQuestion`` is deduped by the STABLE :func:`escalation_marker` (ticket +
     phase + failure fingerprint) through the model's indexed ``dedupe_marker`` — so the
     fresh ``Task`` rows a stuck phase mints each redispatch cycle collapse to a SINGLE
     open question instead of one per cycle. Reuses the §17.1 invariant 9 surface
@@ -603,5 +603,5 @@ def _escalate_once(task: Task, *, reason: str) -> None:
     DeferredQuestion.record(
         question,
         session_id=str(task.session_id or ""),  # ty: ignore[unresolved-attribute]
-        dedupe_marker=_escalation_marker(task),
+        dedupe_marker=escalation_marker(task),
     )

--- a/tests/teatree_loop/test_repair_halt_reconcile.py
+++ b/tests/teatree_loop/test_repair_halt_reconcile.py
@@ -1,0 +1,176 @@
+"""Auto-drain stale repair-loop escalation questions when their subject reconciles (#3692).
+
+A repair-loop escalation (``repair-halt`` / ``repair-stall`` / ``repair-cap``)
+records a durable ``DeferredQuestion`` asking the owner how a halted phase should
+proceed. When the subject ticket subsequently reaches a terminal state (its PR
+merged, delivered, or ignored) the question is MOOT — the loop will never retry
+that phase again, so the only possible answer is "ignore". Left pending, these
+moot rows bury the one live question the owner needs to answer.
+
+The reconcile dismisses exactly the provably-moot rows: a row is drained ONLY when
+EVERY ticket that raised it is terminal. A row with even one still-live subject —
+or whose subject cannot be determined — is KEPT. Dropping a question whose subject
+is still live is the failure mode these tests pin against.
+"""
+
+from django.test import TestCase
+from django.utils import timezone
+
+from teatree.core.models import Session, Task, TaskAttempt, Ticket
+from teatree.core.models.deferred_question import DeferredQuestion
+from teatree.loop.repair_halt_reconcile import resolve_reconciled_repair_halts
+from teatree.loop.tick_recovery import _reap_stale_task_claims
+from teatree.loop.transient_requeue import HALT_STAMP, requeue_transient_failed
+
+
+def _failed_task(*, phase: str = "coding", state: str = Ticket.State.STARTED) -> Task:
+    ticket = Ticket.objects.create(role=Ticket.Role.AUTHOR, state=state)
+    session = Session.objects.create(ticket=ticket, agent_id=phase)
+    return Task.objects.create(ticket=ticket, session=session, phase=phase, status=Task.Status.FAILED)
+
+
+def _add_failed_attempt(task: Task, *, error: str) -> None:
+    TaskAttempt.objects.create(
+        task=task,
+        execution_target=task.execution_target,
+        ended_at=timezone.now(),
+        exit_code=1,
+        error=error,
+    )
+    Task.objects.filter(pk=task.pk).update(status=Task.Status.FAILED)
+
+
+def _escalated_halt_task() -> Task:
+    """Drive a real ``repair-halt`` escalation: two identical failures halt + queue a question."""
+    task = _failed_task()
+    _add_failed_attempt(task, error="result_error: no terminal ResultMessage")
+    _add_failed_attempt(task, error="result_error: no terminal ResultMessage")
+    assert requeue_transient_failed() == 0
+    task.refresh_from_db()
+    assert HALT_STAMP in task.execution_reason
+    assert DeferredQuestion.objects.filter(dedupe_marker__startswith="repair-halt:").count() == 1
+    return task
+
+
+class TestRepairHaltReconcile(TestCase):
+    def test_merged_subject_drains_the_halt_question(self) -> None:
+        task = _escalated_halt_task()
+        Ticket.objects.filter(pk=task.ticket_id).update(state=Ticket.State.MERGED)
+
+        resolved = resolve_reconciled_repair_halts()
+
+        assert resolved == 1
+        question = DeferredQuestion.objects.get(dedupe_marker__startswith="repair-halt:")
+        assert question.status == DeferredQuestion.STATUS_DISMISSED
+        assert question.resolved_via == DeferredQuestion.ResolvedVia.STALE
+        assert question.dismissed_reason
+
+    def test_live_subject_question_is_never_touched(self) -> None:
+        # The over-resolve guard: the subject ticket is still STARTED — the halt is a
+        # genuine live question, so the reconcile must leave it pending untouched.
+        _escalated_halt_task()
+
+        resolved = resolve_reconciled_repair_halts()
+
+        assert resolved == 0
+        question = DeferredQuestion.objects.get(dedupe_marker__startswith="repair-halt:")
+        assert question.status == DeferredQuestion.STATUS_PENDING
+
+    def test_one_live_subject_among_merged_keeps_the_shared_question(self) -> None:
+        # A fingerprint-keyed ``repair-halt`` marker collapses several tickets onto ONE
+        # question. When one subject merged but another is still live, the shared row must
+        # stay pending — the live ticket still needs the answer.
+        live = _escalated_halt_task()
+        merged = _failed_task()
+        _add_failed_attempt(merged, error="result_error: no terminal ResultMessage")
+        _add_failed_attempt(merged, error="result_error: no terminal ResultMessage")
+        assert requeue_transient_failed() == 0  # same fingerprint ⇒ same marker, no 2nd question
+        assert DeferredQuestion.objects.filter(dedupe_marker__startswith="repair-halt:").count() == 1
+        Ticket.objects.filter(pk=merged.ticket_id).update(state=Ticket.State.MERGED)
+
+        resolved = resolve_reconciled_repair_halts()
+
+        assert resolved == 0  # `live`'s ticket is still STARTED
+        question = DeferredQuestion.objects.get(dedupe_marker__startswith="repair-halt:")
+        assert question.status == DeferredQuestion.STATUS_PENDING
+        assert live.ticket.state == Ticket.State.STARTED
+
+    def test_all_subjects_merged_drains_the_shared_question(self) -> None:
+        first = _escalated_halt_task()
+        second = _failed_task()
+        _add_failed_attempt(second, error="result_error: no terminal ResultMessage")
+        _add_failed_attempt(second, error="result_error: no terminal ResultMessage")
+        assert requeue_transient_failed() == 0
+        Ticket.objects.filter(pk__in=[first.ticket_id, second.ticket_id]).update(state=Ticket.State.MERGED)
+
+        resolved = resolve_reconciled_repair_halts()
+
+        assert resolved == 1
+        question = DeferredQuestion.objects.get(dedupe_marker__startswith="repair-halt:")
+        assert question.status == DeferredQuestion.STATUS_DISMISSED
+
+    def test_ticket_keyed_stall_marker_drains_on_terminal_subject(self) -> None:
+        ticket = Ticket.objects.create(role=Ticket.Role.AUTHOR, state=Ticket.State.MERGED)
+        DeferredQuestion.record(
+            "Repair-loop stall on ticket (phase 'coding'): identical failures.",
+            dedupe_marker=f"repair-stall:{ticket.pk}:coding",
+            audience=DeferredQuestion.Audience.INTERNAL,
+        )
+
+        resolved = resolve_reconciled_repair_halts()
+
+        assert resolved == 1
+        assert DeferredQuestion.objects.get(dedupe_marker__startswith="repair-stall:").status == (
+            DeferredQuestion.STATUS_DISMISSED
+        )
+
+    def test_ticket_keyed_cap_marker_kept_on_live_subject(self) -> None:
+        ticket = Ticket.objects.create(role=Ticket.Role.AUTHOR, state=Ticket.State.STARTED)
+        DeferredQuestion.record(
+            "Repair-loop cap on ticket (phase 'coding'): iteration cap hit.",
+            dedupe_marker=f"repair-cap:{ticket.pk}:coding",
+            audience=DeferredQuestion.Audience.INTERNAL,
+        )
+
+        resolved = resolve_reconciled_repair_halts()
+
+        assert resolved == 0
+        assert DeferredQuestion.objects.get(dedupe_marker__startswith="repair-cap:").status == (
+            DeferredQuestion.STATUS_PENDING
+        )
+
+    def test_ticket_keyed_marker_missing_ticket_is_kept(self) -> None:
+        # A marker whose subject ticket no longer exists cannot be proven moot → kept.
+        DeferredQuestion.record(
+            "Repair-loop stall on a vanished ticket.",
+            dedupe_marker="repair-stall:999999:coding",
+            audience=DeferredQuestion.Audience.INTERNAL,
+        )
+
+        assert resolve_reconciled_repair_halts() == 0
+        assert DeferredQuestion.objects.filter(dismissed_at__isnull=True).count() == 1
+
+    def test_non_repair_question_is_never_touched(self) -> None:
+        DeferredQuestion.record("A real owner decision", dedupe_marker="attachment-hold:5")
+
+        assert resolve_reconciled_repair_halts() == 0
+        assert DeferredQuestion.objects.get(dedupe_marker="attachment-hold:5").status == (
+            DeferredQuestion.STATUS_PENDING
+        )
+
+    def test_already_resolved_question_is_not_re_counted(self) -> None:
+        task = _escalated_halt_task()
+        Ticket.objects.filter(pk=task.ticket_id).update(state=Ticket.State.MERGED)
+
+        assert resolve_reconciled_repair_halts() == 1
+        # Idempotent: a second pass finds it already dismissed and drains nothing.
+        assert resolve_reconciled_repair_halts() == 0
+
+    def test_reconcile_is_wired_into_tick_recovery(self) -> None:
+        task = _escalated_halt_task()
+        Ticket.objects.filter(pk=task.ticket_id).update(state=Ticket.State.MERGED)
+
+        _reap_stale_task_claims()
+
+        question = DeferredQuestion.objects.get(dedupe_marker__startswith="repair-halt:")
+        assert question.status == DeferredQuestion.STATUS_DISMISSED

--- a/tests/teatree_loop/test_repair_halt_reconcile.py
+++ b/tests/teatree_loop/test_repair_halt_reconcile.py
@@ -20,7 +20,7 @@ from teatree.core.models import Session, Task, TaskAttempt, Ticket
 from teatree.core.models.deferred_question import DeferredQuestion
 from teatree.loop.repair_halt_reconcile import resolve_reconciled_repair_halts
 from teatree.loop.tick_recovery import _reap_stale_task_claims
-from teatree.loop.transient_requeue import HALT_STAMP, requeue_transient_failed
+from teatree.loop.transient_requeue import HALT_STAMP, escalation_marker, requeue_transient_failed
 
 
 def _failed_task(*, phase: str = "coding", state: str = Ticket.State.STARTED) -> Task:
@@ -165,6 +165,13 @@ class TestRepairHaltReconcile(TestCase):
         assert resolve_reconciled_repair_halts() == 1
         # Idempotent: a second pass finds it already dismissed and drains nothing.
         assert resolve_reconciled_repair_halts() == 0
+
+    def test_reconcile_keys_on_the_same_marker_the_escalation_writes(self) -> None:
+        # The reconcile re-derives a parked task's marker to map it back to its question,
+        # so the derivation MUST equal the dedupe_marker the escalation recorded.
+        task = _escalated_halt_task()
+        question = DeferredQuestion.objects.get(dedupe_marker__startswith="repair-halt:")
+        assert escalation_marker(task) == question.dedupe_marker
 
     def test_reconcile_is_wired_into_tick_recovery(self) -> None:
         task = _escalated_halt_task()


### PR DESCRIPTION
fix(loop): auto-drain stale repair-loop questions when the subject reconciles (#3692)

## Why
Fixes [#3692](https://github.com/souliane/teatree/issues/3692) (P1). Repair-loop escalations (`repair-halt` / `repair-stall` / `repair-cap`) record a durable `DeferredQuestion` asking the owner how a halted phase should proceed. When the subject ticket later reaches a terminal state (PR merged, delivered, ignored) the loop never retries that phase again, so the question is moot — the only possible answer is "ignore". Left pending, these moot rows pile up in the away-mode queue and bury the one live question the owner actually needs to answer. There was no auto-resolution and no drain path.

## What
A per-tick reconcile `resolve_reconciled_repair_halts()` (new module `teatree.loop.repair_halt_reconcile`, wired into the tick recovery sweeps in `tick_recovery._reap_stale_task_claims` alongside `transient_requeue`) dismisses exactly the provably-moot rows as `STALE` (via the existing `DeferredQuestion.mark_stale`, which stamps `dismissed_at` + `resolved_via=stale` + an audit row).

### Conservatism guard (the over-resolve failure mode this never commits)
A row is drained **only** when its subjects are determinable **and every one is terminal**:

- **Ticket-keyed markers** (`repair-stall:<pk>:<phase>`, `repair-cap:<pk>:<phase>`) carry the subject ticket pk directly — parse it, load the ticket, check terminal.
- **Fingerprint-keyed `repair-halt:<phase>:<fingerprint>`** collapses several tickets onto one row, so its subjects are re-derived from the parked (`HALT_STAMP`) FAILED tasks that share the marker (re-computing each task's `escalation_marker`). If even one such ticket is still live, or the subject cannot be determined at all, the row is **kept**.

"Terminal" is `Ticket._TERMINAL_STATES` — the same SSOT set `transient_requeue` already uses to stop retrying a phase, so the drain and the retry-stop agree on the signal. No network call: the DB ticket state is the demonstrable proof.

`HALT_STAMP` and `escalation_marker` are promoted from private to public in `transient_requeue` so the reconcile reuses the exact escalation-marker derivation.

## Tests (RED to GREEN)
New `tests/teatree_loop/test_repair_halt_reconcile.py` (11 tests). Drives real escalations via `requeue_transient_failed()`, then reconciles:

- `test_merged_subject_drains_the_halt_question`
- `test_live_subject_question_is_never_touched` (over-resolve guard)
- `test_one_live_subject_among_merged_keeps_the_shared_question` (multi-ticket guard)
- `test_all_subjects_merged_drains_the_shared_question`
- `test_ticket_keyed_stall_marker_drains_on_terminal_subject`
- `test_ticket_keyed_cap_marker_kept_on_live_subject`
- `test_ticket_keyed_marker_missing_ticket_is_kept`
- `test_non_repair_question_is_never_touched`
- `test_already_resolved_question_is_not_re_counted` (idempotent)
- `test_reconcile_keys_on_the_same_marker_the_escalation_writes`
- `test_reconcile_is_wired_into_tick_recovery`

The `merged-drains` / `live-untouched` pair is mutually controlling. A mutation control (dropping the terminal guard) turns the 3 over-resolve guard tests RED, proving they are non-vacuous. ci-parity-fast: 31818 passed, push-gate SCOPED green.

## Scope note
The auto-resolution is the durable fix and runs every tick, so stale rows drain without operator action — this makes the optional `t3 checking` batch-resolve affordance from the issue redundant; it is intentionally not added.

## Architecture pre-check — #3692

**1. BLUEPRINT § alignment** — §17.1 invariant 9 (away-mode questions are captured, never silently dropped). This retires MOOT questions whose subject reconciled — not a silent drop of a live one; the guard preserves the invariant.

**2. FSM phase boundaries** — n/a — reads `Ticket.state` (terminal check); no Ticket/Worktree transition.

**3. Extension-point contracts** — n/a — no `OverlayBase` / scanner / hook / Protocol surface touched.

**4. Component boundaries** — `teatree.loop` (orchestration): composes `DeferredQuestion` + `Task`/`Ticket` domain models with the `transient_requeue` escalation marker; mirrors the sibling `transient_requeue`'s placement in the tick recovery sweeps.

**5. Dependency direction** — new module imports `teatree.core.models` and `teatree.loop.transient_requeue` (same layer) — no backwards edge. `tach` + `import-linter` pre-commit hooks passed.

**6. Test surface** — each behaviour has a named assertion above; the reconcile emits a dismissed `DeferredQuestion` (status `dismissed`, `resolved_via=stale`) which the tests read.

**7. Resilience invariants** — idempotency: `mark_stale` is a single-use CAS (`WHERE answered_at IS NULL AND dismissed_at IS NULL`) — a second pass drains nothing (pinned). Per-tick sweep runs in its own `try` in `_reap_stale_task_claims`, so a failure is recorded, not fatal. No external write.

**8. Identity and key normalization** — subject identity is the fully-qualified `dedupe_marker`; matched by exact marker equality (no strip-to-match). `repair-halt` markers are re-canonicalized UP via `escalation_marker(task)` rather than parsed down.

**9. Behavior preservation / capability deletion** — purely additive — no existing behavior removed; the symbol rename (`_HALT_STAMP`/`_escalation_marker` to public) preserves values and all call sites.

**10. Removability / harness-vs-data** — fully removable — deleting the module + its sweep tuple entry reverts to prior behavior (rows stay pending), no cascade. The varying part (which states are terminal) reads `Ticket._TERMINAL_STATES` data, not a hard-coded list.
