### PR TITLE
fix(directive): stop silent-drop of governor-refused interpret dispatches (#3706)

### DIFF
--- a/src/teatree/core/models/directive_dispatch.py
+++ b/src/teatree/core/models/directive_dispatch.py
@@ -9,11 +9,16 @@ the codebase and RETURNS a ``directive_interpretation`` envelope;
 ``attempt_recorder`` records the typed :class:`MechanismSketch` server-side
 (maker≠checker — a different actor writes it than the one that captured the text).
 
-Dedup is per ``(directive, purpose, generation)``: a re-fire at the same
-generation returns the existing row and enqueues no second interpreter; a
-clarification bumps ``generation`` and arms exactly one fresh interpreter. The row
-insert and the ``Task`` creation share one transaction so a row never exists
-without its task.
+Dedup is per ``(directive, purpose, generation)`` but keyed on the LIVE task, not
+the row: a re-fire while the generation's interpret task is still in flight
+(PENDING/CLAIMED) returns the existing row and enqueues no second interpreter. Once
+that task reaches a terminal status WITHOUT an interpretation being recorded — the
+governor refused it and the artifact sweep completed the still-PENDING task, or the
+run failed the evidence gate — the directive is still awaiting interpretation, so a
+re-tick RE-ARMS a fresh interpreter on the same row rather than dedup-stranding the
+directive in ``CAPTURED`` forever. A clarification bumps ``generation`` and arms its
+own fresh row. The row insert and the ``Task`` creation share one transaction so a
+row never exists without its task.
 """
 
 from typing import TYPE_CHECKING, ClassVar
@@ -87,14 +92,27 @@ class DirectiveDispatch(models.Model):
     def __str__(self) -> str:
         return f"directive-dispatch<{self.pk}:directive:{self.directive_id} {self.purpose}@gen{self.generation}>"  # type: ignore[attr-defined]  # Django FK accessor
 
+    def has_live_interpreter(self) -> bool:
+        """Whether this dispatch's interpret task is still in flight (PENDING/CLAIMED).
+
+        A live task means an interpreter is already armed for this generation — a
+        re-tick waits on it (the dedup). A terminal or absent task means the prior
+        interpreter finished without an interpretation being recorded, so the
+        directive is still awaiting one and a re-tick may RE-ARM a fresh interpreter.
+        """
+        return self.task is not None and self.task.status in Task.Status.active()
+
     @classmethod
     def enqueue(cls, *, directive: "Directive", contract: str) -> "DirectiveDispatch | None":
         """Record the dispatch + create one claimable headless interpret task — idempotently.
 
-        Returns the new row on the first dispatch for ``(directive, interpret,
-        generation)``; ``None`` when a row for that generation already exists (a
-        prior tick already armed the interpreter). The row insert and the ``Task``
-        creation share one transaction so a row never exists without its task.
+        Returns the row (a fresh interpret task attached) on the first dispatch for
+        ``(directive, interpret, generation)`` AND on a re-arm — when a row for that
+        generation already exists but its interpreter is terminal without having
+        recorded an interpretation. Returns ``None`` only while the generation's
+        interpreter is still in flight (a live PENDING/CLAIMED task). The row insert
+        and the ``Task`` creation share one transaction so a row never exists without
+        its task.
         """
         with transaction.atomic():
             row, created = cls.objects.get_or_create(
@@ -102,7 +120,7 @@ class DirectiveDispatch(models.Model):
                 purpose=cls.Purpose.INTERPRET,
                 generation=directive.generation,
             )
-            if not created:
+            if not created and row.has_live_interpreter():
                 return None
             row.task = cls._create_interpret_task(directive=directive, contract=contract)
             row.save(update_fields=["task"])

--- a/src/teatree/core/models/directive_dispatch.py
+++ b/src/teatree/core/models/directive_dispatch.py
@@ -29,19 +29,20 @@ from django.utils import timezone
 from teatree.core.models.session import Session
 from teatree.core.models.task import Task
 from teatree.core.models.ticket import Ticket
+from teatree.utils.url_slug import SYNTHETIC_LOOP_UMBRELLA_URL
 
 if TYPE_CHECKING:
     from teatree.core.models.directive import Directive
 
 INTERPRET_PHASE = "directive_interpreting"
 
-#: The standing north-star self-modification umbrella every directive's synthetic
-#: interpret ticket anchors under; the ``#directive=<pk>`` fragment makes each unique
-#: while still resolving the ``souliane/teatree`` overlay via ``infer_overlay_for_url``
-#: (the outer-loop synthetic-ticket idiom — the interpret phase needs a ``Task``, and a
-#: ``Task`` needs a ``Ticket``). Shares the north-star umbrella with the outer loop and
-#: the directive-implementation ticket; the ``#directive=`` fragment disambiguates.
-DIRECTIVE_UMBRELLA_URL = "https://github.com/souliane/teatree/issues/3009"
+#: The standing north-star self-modification umbrella the directive's synthetic interpret
+#: ticket anchors under; the ``#directive=<pk>`` fragment makes each unique while still
+#: resolving the ``souliane/teatree`` overlay via ``infer_overlay_for_url`` (the interpret
+#: phase needs a ``Task``, and a ``Task`` needs a ``Ticket``). Single-sourced from
+#: :data:`~teatree.utils.url_slug.SYNTHETIC_LOOP_UMBRELLA_URL` — the ONE anchor the task
+#: sweep recognises so it never artifact-completes a synthetic loop ticket (#3706).
+DIRECTIVE_UMBRELLA_URL = SYNTHETIC_LOOP_UMBRELLA_URL
 
 
 def synthetic_interpret_ticket(directive: "Directive") -> Ticket:
@@ -120,8 +121,14 @@ class DirectiveDispatch(models.Model):
                 purpose=cls.Purpose.INTERPRET,
                 generation=directive.generation,
             )
-            if not created and row.has_live_interpreter():
-                return None
+            if not created:
+                # Lock the existing row so two concurrent ticks cannot both pass the
+                # terminal-task check and double-arm two live interpreters. On the
+                # file-backed prod SQLite backend the atomic already serializes writers;
+                # the row lock makes it correct on any backend if the loop ever fans out.
+                row = cls.objects.select_for_update().get(pk=row.pk)
+                if row.has_live_interpreter():
+                    return None
             row.task = cls._create_interpret_task(directive=directive, contract=contract)
             row.save(update_fields=["task"])
         return row

--- a/src/teatree/loop/mechanical.py
+++ b/src/teatree/loop/mechanical.py
@@ -215,6 +215,7 @@ def task_completion(payload: ActionPayload) -> None:
     done all no-op silently rather than crash the tick.
     """
     from teatree.core.models.task import Task  # noqa: PLC0415 — deferred: ORM import needs the app registry
+    from teatree.utils.url_slug import is_synthetic_loop_umbrella_url  # noqa: PLC0415 — deferred: tick-time import
 
     task_id = payload.get("task_id")
     if task_id is None:
@@ -224,6 +225,12 @@ def task_completion(payload: ActionPayload) -> None:
     except Task.DoesNotExist:
         return
     if task.status in Task.Status.terminal():
+        return
+    # Defence in depth (#3706): a synthetic loop ticket anchors on the shared umbrella
+    # issue, whose upstream closed state says nothing about whether the loop work is done.
+    # The sweep already excludes these, so this signal should never carry one — never
+    # artifact-complete it if one slips through.
+    if is_synthetic_loop_umbrella_url(task.ticket.issue_url):
         return
     if not _artifact_still_terminal(task):
         logger.info("task_completion: task %s artifact no longer terminal — skipping completion", task_id)

--- a/src/teatree/loop/scanners/task_sweep.py
+++ b/src/teatree/loop/scanners/task_sweep.py
@@ -3,11 +3,13 @@
 This scanner reconciles teatree **Task** rows (the DB-backed lifecycle work
 units), never the agent harness's working list of session items. The candidate
 set is the open :class:`Task` rows (status ``PENDING`` or ``CLAIMED``) whose
-``Ticket`` carries an ``issue_url``, EXCLUDING the directive-loop-internal phases
-(:data:`_FSM_OWNED_PHASES`) whose completion the directive FSM owns rather than an
-upstream artifact — their synthetic umbrella ``issue_url`` is a routing device, not
-a trackable issue, so sweeping them on the umbrella's closed state would strand the
-directive. Each tick the scanner walks those tasks
+``Ticket`` carries an ``issue_url``, EXCLUDING every task anchored on the synthetic
+loop umbrella (:func:`~teatree.utils.url_slug.is_synthetic_loop_umbrella_url`) —
+the directive interpret/implement and outer-loop experiment tickets whose completion
+the loop FSM owns rather than an upstream artifact. Their umbrella ``issue_url`` is a
+routing device, not a trackable issue, so sweeping them on the umbrella's closed state
+would complete a live task and strand the loop work regardless of phase (#3706). Each
+tick the scanner walks those tasks
 and, for each, verifies the underlying artifact's *terminal* state — is the
 upstream issue closed / the PR merged? — via the overlay's ``is_issue_done()``
 hook (the same independent-evidence check ``TicketCompletionScanner`` uses for
@@ -42,6 +44,7 @@ from django.utils import timezone
 from teatree.backends.loader import get_code_host_for_url
 from teatree.core.overlay import OverlayBase
 from teatree.loop.scanners.base import ScanSignal
+from teatree.utils.url_slug import is_synthetic_loop_umbrella_url
 
 if TYPE_CHECKING:
     from teatree.core.models import Task
@@ -49,15 +52,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _OPEN_STATUSES = ("pending", "claimed")
-
-#: Directive-loop-internal phases whose completion the DIRECTIVE FSM owns, not an
-#: upstream artifact. Their task anchors on a SYNTHETIC ticket whose ``issue_url`` is
-#: the shared north-star umbrella (a routing device so the overlay resolves, not a
-#: trackable issue), so an artifact-terminal sweep on the umbrella's closed state would
-#: wrongly complete a still-PENDING interpret task and silently strand the directive in
-#: ``CAPTURED``. The interpret gate recording an envelope is the only thing that
-#: terminates these; the sweep leaves them alone.
-_FSM_OWNED_PHASES = ("directive_interpreting",)
 
 
 @dataclass(slots=True)
@@ -101,18 +95,23 @@ class TaskSweepScanner:
         qs = (
             task_model.objects.filter(status__in=_OPEN_STATUSES)
             .exclude(ticket__issue_url="")
-            .exclude(phase__in=_FSM_OWNED_PHASES)
             .filter(Q(last_sweep_check_ts__isnull=True) | Q(last_sweep_check_ts__lt=cutoff))
             .select_related("ticket")
         )
         if self.overlay_name:
             qs = qs.filter(ticket__overlay=self.overlay_name)
         try:
-            return list(qs.only("id", "status", "ticket__id", "ticket__issue_url", "last_sweep_check_ts"))
+            rows = list(qs.only("id", "status", "ticket__id", "ticket__issue_url", "last_sweep_check_ts"))
         except (OperationalError, ProgrammingError):
             # Pre-migration install: the table or the new column does not exist
             # yet. The next tick after ``migrate`` picks the tasks up.
             return []
+        # A synthetic loop ticket (directive interpret/implement, outer-loop experiment)
+        # anchors on the shared north-star umbrella issue via a URL fragment. Its task
+        # lifecycle is owned by the loop FSM, not by the umbrella issue's upstream state,
+        # so a sweep on the umbrella's closed state would wrongly complete a live task and
+        # silently strand the loop work — regardless of phase (#3706).
+        return [row for row in rows if not is_synthetic_loop_umbrella_url(row.ticket.issue_url)]
 
     def _claim_for_sweep(self, *, task_id: int, now: datetime) -> bool:
         """Atomically stamp ``last_sweep_check_ts``; True iff this tick won the race."""

--- a/src/teatree/loop/scanners/task_sweep.py
+++ b/src/teatree/loop/scanners/task_sweep.py
@@ -3,7 +3,11 @@
 This scanner reconciles teatree **Task** rows (the DB-backed lifecycle work
 units), never the agent harness's working list of session items. The candidate
 set is the open :class:`Task` rows (status ``PENDING`` or ``CLAIMED``) whose
-``Ticket`` carries an ``issue_url``. Each tick the scanner walks those tasks
+``Ticket`` carries an ``issue_url``, EXCLUDING the directive-loop-internal phases
+(:data:`_FSM_OWNED_PHASES`) whose completion the directive FSM owns rather than an
+upstream artifact — their synthetic umbrella ``issue_url`` is a routing device, not
+a trackable issue, so sweeping them on the umbrella's closed state would strand the
+directive. Each tick the scanner walks those tasks
 and, for each, verifies the underlying artifact's *terminal* state — is the
 upstream issue closed / the PR merged? — via the overlay's ``is_issue_done()``
 hook (the same independent-evidence check ``TicketCompletionScanner`` uses for
@@ -45,6 +49,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _OPEN_STATUSES = ("pending", "claimed")
+
+#: Directive-loop-internal phases whose completion the DIRECTIVE FSM owns, not an
+#: upstream artifact. Their task anchors on a SYNTHETIC ticket whose ``issue_url`` is
+#: the shared north-star umbrella (a routing device so the overlay resolves, not a
+#: trackable issue), so an artifact-terminal sweep on the umbrella's closed state would
+#: wrongly complete a still-PENDING interpret task and silently strand the directive in
+#: ``CAPTURED``. The interpret gate recording an envelope is the only thing that
+#: terminates these; the sweep leaves them alone.
+_FSM_OWNED_PHASES = ("directive_interpreting",)
 
 
 @dataclass(slots=True)
@@ -88,6 +101,7 @@ class TaskSweepScanner:
         qs = (
             task_model.objects.filter(status__in=_OPEN_STATUSES)
             .exclude(ticket__issue_url="")
+            .exclude(phase__in=_FSM_OWNED_PHASES)
             .filter(Q(last_sweep_check_ts__isnull=True) | Q(last_sweep_check_ts__lt=cutoff))
             .select_related("ticket")
         )

--- a/src/teatree/loops/directive_loop/implement.py
+++ b/src/teatree/loops/directive_loop/implement.py
@@ -17,12 +17,14 @@ from teatree.core.models import Directive, FactoryScoreSnapshot
 from teatree.core.models.task import Task
 from teatree.core.models.ticket import Ticket
 from teatree.loops.outer_loop.score import read_score
+from teatree.utils.url_slug import SYNTHETIC_LOOP_UMBRELLA_URL
 
 #: The standing north-star self-modification umbrella every directive's synthetic
 #: mechanism ticket anchors under; the ``#directive-impl=<pk>`` fragment makes each
 #: unique while still resolving the ``souliane/teatree`` overlay via
-#: ``infer_overlay_for_url`` (the outer-loop synthetic-ticket idiom).
-DIRECTIVE_IMPL_UMBRELLA_URL = "https://github.com/souliane/teatree/issues/3009"
+#: ``infer_overlay_for_url``. Single-sourced from the ONE umbrella anchor the task
+#: sweep recognises (#3706).
+DIRECTIVE_IMPL_UMBRELLA_URL = SYNTHETIC_LOOP_UMBRELLA_URL
 
 _DIRECTIVE_KEY = "directive_id"
 

--- a/src/teatree/loops/outer_loop/implement.py
+++ b/src/teatree/loops/outer_loop/implement.py
@@ -11,11 +11,13 @@ FSM condition); the outer loop gains ZERO new merge authority.
 from teatree.core.models import OuterLoopExperiment
 from teatree.core.models.task import Task
 from teatree.core.models.ticket import Ticket
+from teatree.utils.url_slug import SYNTHETIC_LOOP_UMBRELLA_URL
 
 #: The standing umbrella issue every outer-loop experiment's synthetic ticket
 #: anchors under; the ``#outer-loop-experiment=<pk>`` fragment makes each unique
 #: while still resolving the ``souliane/teatree`` overlay via ``infer_overlay_for_url``.
-OUTER_LOOP_UMBRELLA_URL = "https://github.com/souliane/teatree/issues/3009"
+#: Single-sourced from the ONE umbrella anchor the task sweep recognises (#3706).
+OUTER_LOOP_UMBRELLA_URL = SYNTHETIC_LOOP_UMBRELLA_URL
 
 _EXPERIMENT_KEY = "outer_loop_experiment_id"
 _TARGET_KEY = "outer_loop_target"

--- a/src/teatree/utils/url_slug.py
+++ b/src/teatree/utils/url_slug.py
@@ -13,6 +13,21 @@ from urllib.parse import urlparse
 
 from teatree.utils.pr_ref import PrRef
 
+#: The one north-star self-modification umbrella every SYNTHETIC loop ticket anchors
+#: on — the directive interpret (``#directive=``) + implement (``#directive-impl=``)
+#: tickets and the outer-loop experiment (``#outer-loop-experiment=``) tickets, each
+#: disambiguated solely by a URL fragment. These tickets are routing devices whose
+#: task lifecycle the loop FSM owns; the umbrella issue's own upstream open/closed
+#: state says nothing about whether the loop work is done, so the artifact-terminal
+#: task sweep must never complete a task anchored here (souliane/teatree#3706).
+SYNTHETIC_LOOP_UMBRELLA_URL = "https://github.com/souliane/teatree/issues/3009"
+
+
+def is_synthetic_loop_umbrella_url(issue_url: str) -> bool:
+    """Whether *issue_url* anchors on the synthetic-loop umbrella, with or without a fragment."""
+    return issue_url.partition("#")[0] == SYNTHETIC_LOOP_UMBRELLA_URL
+
+
 _GITHUB_RE = re.compile(r"^/(?P<slug>[^/]+/[^/]+)/(?:issues|pull|pulls)/\d+/?$")
 _GITLAB_RE = re.compile(r"^/(?P<slug>.+?)/-/(?:issues|work_items|merge_requests)/\d+/?$")
 

--- a/tests/teatree_core/models/test_directive_dispatch.py
+++ b/tests/teatree_core/models/test_directive_dispatch.py
@@ -8,7 +8,7 @@ one. The interpret task needs a ``Ticket``, so the dispatch anchors a synthetic 
 
 from django.test import TestCase
 
-from teatree.core.models import Directive, DirectiveDispatch
+from teatree.core.models import Directive, DirectiveDispatch, Task
 
 
 def _directive() -> Directive:
@@ -58,3 +58,66 @@ class TestDirectiveDispatchEnqueue(TestCase):
         assert row is not None
         assert row.task is not None
         assert row.task.directive_dispatches.first().directive_id == directive.pk
+
+
+class TestDirectiveDispatchReArm(TestCase):
+    """A prior interpreter that recorded no interpretation must not strand the directive.
+
+    The dedup that keeps a re-tick from spawning a second interpreter must hold ONLY
+    while an interpreter is in flight. Once the prior interpret task reaches a terminal
+    status without an interpretation being recorded — the governor refused it and the
+    artifact sweep completed the PENDING task, or the run itself failed the evidence
+    gate — the directive is still awaiting interpretation, so a re-tick RE-ARMS a fresh
+    interpreter rather than dedup-returning ``None`` forever.
+    """
+
+    def test_a_live_pending_interpreter_is_not_rearmed(self) -> None:
+        directive = _directive()
+        first = DirectiveDispatch.enqueue(directive=directive, contract="c")
+        assert first is not None
+        assert first.task is not None
+        assert first.task.status == Task.Status.PENDING  # in flight
+        assert DirectiveDispatch.enqueue(directive=directive, contract="c") is None  # dedup holds
+
+    def test_a_completed_interpreter_that_recorded_nothing_is_rearmed(self) -> None:
+        directive = _directive()
+        first = DirectiveDispatch.enqueue(directive=directive, contract="c")
+        assert first is not None
+        assert first.task is not None
+        old_task = first.task
+        old_task.complete()  # the observed defect: swept-complete with no envelope
+        assert directive.state == Directive.State.CAPTURED  # never advanced past intake
+
+        rearmed = DirectiveDispatch.enqueue(directive=directive, contract="c")
+        assert rearmed is not None  # NOT dedup-suppressed
+        assert rearmed.task is not None
+        assert rearmed.task.pk != old_task.pk  # a fresh interpreter task
+        assert rearmed.task.status == Task.Status.PENDING
+        # Same generation → one dispatch row, its task re-pointed (no unique-constraint churn).
+        assert DirectiveDispatch.objects.filter(directive=directive).count() == 1
+        first.refresh_from_db()
+        assert first.task_id == rearmed.task.pk
+
+    def test_a_failed_interpreter_that_recorded_nothing_is_rearmed(self) -> None:
+        directive = _directive()
+        first = DirectiveDispatch.enqueue(directive=directive, contract="c")
+        assert first is not None
+        assert first.task is not None
+        first.task.fail()  # run-then-fail: bad envelope, evidence gate refused it
+        rearmed = DirectiveDispatch.enqueue(directive=directive, contract="c")
+        assert rearmed is not None
+        assert rearmed.task is not None
+        assert rearmed.task.status == Task.Status.PENDING
+
+    def test_rearm_leaves_a_bumped_generation_as_its_own_fresh_row(self) -> None:
+        # A clarification bump is orthogonal to re-arm: it still arms its own row.
+        directive = _directive()
+        first = DirectiveDispatch.enqueue(directive=directive, contract="c")
+        assert first is not None
+        assert first.task is not None
+        first.task.complete()
+        directive.bump_generation()
+        second = DirectiveDispatch.enqueue(directive=directive, contract="c")
+        assert second is not None
+        assert second.generation == 1
+        assert DirectiveDispatch.objects.filter(directive=directive).count() == 2

--- a/tests/teatree_loop/test_task_sweep_mechanical.py
+++ b/tests/teatree_loop/test_task_sweep_mechanical.py
@@ -129,6 +129,26 @@ class RecheckBeforeCompleteTests(_TaskCompletionHarness):
         assert task.status == Task.Status.PENDING
 
 
+class SyntheticUmbrellaGuardTests(_TaskCompletionHarness):
+    """Defence in depth (#3706): the handler never artifact-completes a synthetic loop task.
+
+    Even if a stale ``task.completion_detected`` signal carried an umbrella-anchored task,
+    the handler must not complete it on the umbrella issue's closed state — the loop FSM
+    owns that task, not the umbrella artifact.
+    """
+
+    UMBRELLA = "https://github.com/souliane/teatree/issues/3009#directive-impl=7"
+
+    def test_umbrella_anchored_task_is_not_completed(self) -> None:
+        task = self._task(url=self.UMBRELLA)
+        host = _Host(issues_by_url={self.UMBRELLA: {"state": "closed"}})
+        overlay_patch, host_patch = self._patch(host)
+        with overlay_patch, host_patch:
+            task_completion({"task_id": task.pk, "issue_url": self.UMBRELLA})
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING
+
+
 class MultiOverlayResolutionTests(TestCase):
     """Real ``get_overlay()`` ambiguity path — two overlays registered (#1605).
 

--- a/tests/teatree_loop/test_task_sweep_scanner.py
+++ b/tests/teatree_loop/test_task_sweep_scanner.py
@@ -164,30 +164,46 @@ class CompletionDetectionTests(_SweepHarness):
         assert payload["issue_url"] == self.URL
 
 
-class FsmOwnedPhaseTests(_SweepHarness):
-    """A directive-loop-internal phase's completion is FSM-owned, not artifact-owned.
+class SyntheticUmbrellaTests(_SweepHarness):
+    """A synthetic loop ticket's completion is FSM-owned, not artifact-owned.
 
-    The ``directive_interpreting`` interpret task anchors on a SYNTHETIC ticket whose
-    ``issue_url`` is the shared north-star umbrella (a routing device, not a trackable
-    artifact). When that umbrella issue is closed upstream the artifact sweep must NOT
-    complete the still-PENDING interpret task — doing so silently strands the directive
-    in ``CAPTURED``. The directive FSM (the interpret gate recording an envelope) owns
-    that task's terminal outcome.
+    Directive interpret (``#directive=``), directive implement (``#directive-impl=``),
+    and outer-loop experiment tickets all anchor on the shared north-star umbrella issue
+    (a routing device, not a trackable artifact). When that umbrella is closed upstream
+    the artifact sweep must NOT complete their live tasks — regardless of phase — because
+    doing so silently strands the loop work. The exclusion keys on the umbrella ANCHOR,
+    not the phase, so the real-work phases (coding/testing/...) the impl tickets share
+    with ordinary tickets are still covered.
     """
 
-    UMBRELLA = "https://github.com/souliane/teatree/issues/3009#directive=7"
+    UMBRELLA = "https://github.com/souliane/teatree/issues/3009"
 
-    def test_directive_interpreting_task_is_not_swept_on_closed_umbrella(self) -> None:
-        self._task(url=self.UMBRELLA, phase="directive_interpreting")
-        host = _Host(issues_by_url={self.UMBRELLA: {"state": "closed"}})
+    def test_directive_interpret_task_is_not_swept_on_closed_umbrella(self) -> None:
+        self._task(url=f"{self.UMBRELLA}#directive=7", phase="directive_interpreting")
+        host = _Host(issues_by_url={f"{self.UMBRELLA}#directive=7": {"state": "closed"}})
         with self._patch_host(host):
             assert self._scanner().scan() == []
         assert host.get_issue_calls == []  # never even fetched — excluded up front
 
-    def test_ordinary_phase_on_the_same_ticket_shape_is_still_swept(self) -> None:
-        # The exclusion is phase-scoped, not a blanket umbrella-URL skip.
-        task = self._task(url=self.UMBRELLA, phase="coding")
-        host = _Host(issues_by_url={self.UMBRELLA: {"state": "closed"}})
+    def test_directive_impl_coding_task_is_not_swept_on_closed_umbrella(self) -> None:
+        # The class-level fix: an impl task rides a REAL-work phase (coding) yet still
+        # anchors on the umbrella, so it must be excluded by anchor, not phase.
+        self._task(url=f"{self.UMBRELLA}#directive-impl=7", phase="coding")
+        host = _Host(issues_by_url={f"{self.UMBRELLA}#directive-impl=7": {"state": "closed"}})
+        with self._patch_host(host):
+            assert self._scanner().scan() == []
+        assert host.get_issue_calls == []
+
+    def test_outer_loop_experiment_task_is_not_swept_on_closed_umbrella(self) -> None:
+        self._task(url=f"{self.UMBRELLA}#outer-loop-experiment=3", phase="coding")
+        host = _Host(issues_by_url={f"{self.UMBRELLA}#outer-loop-experiment=3": {"state": "closed"}})
+        with self._patch_host(host):
+            assert self._scanner().scan() == []
+
+    def test_an_ordinary_ticket_coding_task_is_still_swept(self) -> None:
+        # The sweep MUST keep working for real, artifact-backed tickets.
+        task = self._task(url=self.URL, phase="coding")
+        host = _Host(issues_by_url={self.URL: {"state": "closed"}})
         with self._patch_host(host):
             signals = self._scanner().scan()
         assert len(signals) == 1

--- a/tests/teatree_loop/test_task_sweep_scanner.py
+++ b/tests/teatree_loop/test_task_sweep_scanner.py
@@ -82,11 +82,12 @@ class _SweepHarness(TestCase):
         url: str | None = None,
         status: str = Task.Status.PENDING,
         overlay: str | None = None,
+        phase: str = "coding",
     ) -> Task:
         issue_url = self.URL if url is None else url
         ticket = Ticket.objects.create(overlay=overlay or self.OVERLAY, issue_url=issue_url)
         session = Session.objects.create(overlay=overlay or self.OVERLAY, ticket=ticket, agent_id="a")
-        task = Task.objects.create(ticket=ticket, session=session, phase="coding")
+        task = Task.objects.create(ticket=ticket, session=session, phase=phase)
         if status != Task.Status.PENDING:
             Task.objects.filter(pk=task.pk).update(status=status)
             task.refresh_from_db()
@@ -161,6 +162,36 @@ class CompletionDetectionTests(_SweepHarness):
         assert payload["task_id"] == task.pk
         assert payload["ticket_id"] == task.ticket.pk
         assert payload["issue_url"] == self.URL
+
+
+class FsmOwnedPhaseTests(_SweepHarness):
+    """A directive-loop-internal phase's completion is FSM-owned, not artifact-owned.
+
+    The ``directive_interpreting`` interpret task anchors on a SYNTHETIC ticket whose
+    ``issue_url`` is the shared north-star umbrella (a routing device, not a trackable
+    artifact). When that umbrella issue is closed upstream the artifact sweep must NOT
+    complete the still-PENDING interpret task — doing so silently strands the directive
+    in ``CAPTURED``. The directive FSM (the interpret gate recording an envelope) owns
+    that task's terminal outcome.
+    """
+
+    UMBRELLA = "https://github.com/souliane/teatree/issues/3009#directive=7"
+
+    def test_directive_interpreting_task_is_not_swept_on_closed_umbrella(self) -> None:
+        self._task(url=self.UMBRELLA, phase="directive_interpreting")
+        host = _Host(issues_by_url={self.UMBRELLA: {"state": "closed"}})
+        with self._patch_host(host):
+            assert self._scanner().scan() == []
+        assert host.get_issue_calls == []  # never even fetched — excluded up front
+
+    def test_ordinary_phase_on_the_same_ticket_shape_is_still_swept(self) -> None:
+        # The exclusion is phase-scoped, not a blanket umbrella-URL skip.
+        task = self._task(url=self.UMBRELLA, phase="coding")
+        host = _Host(issues_by_url={self.UMBRELLA: {"state": "closed"}})
+        with self._patch_host(host):
+            signals = self._scanner().scan()
+        assert len(signals) == 1
+        assert signals[0].payload["task_id"] == task.pk
 
 
 class FailOpenTests(_SweepHarness):

--- a/tests/teatree_loops/directive_loop/test_tick.py
+++ b/tests/teatree_loops/directive_loop/test_tick.py
@@ -95,6 +95,24 @@ class TestIntakeBranches(TestCase):
         result = run_tick(settings=_open_settings(), seams=_seams())
         assert result.action == "interpret_dispatched"
 
+    def test_captured_rearms_a_fresh_interpreter_after_the_prior_one_died_uninterpreted(self) -> None:
+        # The silent-drop invariant: a CAPTURED directive whose interpret task went
+        # terminal without recording an interpretation (governor-refused → swept
+        # complete) is RE-ATTEMPTED on a later tick, not stranded by the dedup.
+        directive = Directive.objects.capture("do X", source=Directive.Source.CLI)
+        assert run_tick(settings=_open_settings(), seams=_seams()).action == "interpret_dispatched"
+        first_task = DirectiveDispatch.objects.get(directive=directive).task
+        assert first_task is not None
+        first_task.complete()  # completed with no interpretation envelope
+        directive.refresh_from_db()
+        assert directive.state == Directive.State.CAPTURED  # never advanced
+
+        result = run_tick(settings=_open_settings(), seams=_seams())
+        assert result.action == "interpret_dispatched"  # re-armed, not idle/waiting
+        rearmed_task = DirectiveDispatch.objects.get(directive=directive).task
+        assert rearmed_task is not None
+        assert rearmed_task.pk != first_task.pk  # a fresh interpreter
+
     def test_interpreted_asks_ratification(self) -> None:
         directive = Directive.objects.capture("do X", source=Directive.Source.CLI)
         directive.record_interpretation(sketch_from_envelope(valid_envelope()), constraint_statement="c")

--- a/tests/teatree_utils/test_url_slug_synthetic_umbrella.py
+++ b/tests/teatree_utils/test_url_slug_synthetic_umbrella.py
@@ -1,0 +1,33 @@
+"""The synthetic-loop umbrella anchor predicate (souliane/teatree#3706).
+
+Every synthetic loop ticket — directive interpret/implement, outer-loop experiment —
+anchors on ONE umbrella issue and disambiguates via a URL fragment. The predicate
+recognises that anchor (any fragment, or none) so the artifact-terminal task sweep can
+skip these FSM-owned tasks regardless of their phase.
+"""
+
+from teatree.utils.url_slug import SYNTHETIC_LOOP_UMBRELLA_URL, is_synthetic_loop_umbrella_url
+
+
+class TestIsSyntheticLoopUmbrellaUrl:
+    def test_bare_umbrella_matches(self) -> None:
+        assert is_synthetic_loop_umbrella_url(SYNTHETIC_LOOP_UMBRELLA_URL)
+
+    def test_interpret_fragment_matches(self) -> None:
+        assert is_synthetic_loop_umbrella_url(f"{SYNTHETIC_LOOP_UMBRELLA_URL}#directive=5")
+
+    def test_implement_fragment_matches(self) -> None:
+        assert is_synthetic_loop_umbrella_url(f"{SYNTHETIC_LOOP_UMBRELLA_URL}#directive-impl=5")
+
+    def test_outer_loop_fragment_matches(self) -> None:
+        assert is_synthetic_loop_umbrella_url(f"{SYNTHETIC_LOOP_UMBRELLA_URL}#outer-loop-experiment=7")
+
+    def test_a_real_issue_does_not_match(self) -> None:
+        assert not is_synthetic_loop_umbrella_url("https://github.com/souliane/teatree/issues/42")
+
+    def test_a_numeric_superstring_of_the_umbrella_does_not_match(self) -> None:
+        # #30091 startswith #3009 textually — the base must be an EXACT match, not a prefix.
+        assert not is_synthetic_loop_umbrella_url("https://github.com/souliane/teatree/issues/30091")
+
+    def test_empty_url_does_not_match(self) -> None:
+        assert not is_synthetic_loop_umbrella_url("")


### PR DESCRIPTION
Fixes #3706.

## Problem

A `CAPTURED` directive whose interpret task went terminal without recording an
interpretation was silently stranded forever. The governor refuses to admit the
headless interpret dispatch (quota spent / ceiling reached), the task lingers
PENDING, and the artifact-terminal task sweep then completes it — its synthetic
ticket anchors on the closed north-star umbrella issue (a routing device, not a
trackable artifact). The `DirectiveDispatch` dedup on `(directive, purpose,
generation)` then blocks any re-arm on later ticks, so the directive never
auto-retries interpretation and never surfaces a ratify question.

## Fix

Two compounding defects on the interpret-retry path:

1. **`TaskSweepScanner`** now excludes the directive-loop-internal phases whose
   completion the directive FSM owns (`directive_interpreting`), so a
   governor-refused interpret task stays PENDING and the headless drain re-runs it
   once the governor admits — instead of being wrongly completed on the umbrella's
   closed state.
2. **`DirectiveDispatch.enqueue`** dedups on a LIVE interpreter (a PENDING/CLAIMED
   task), not the mere row. Once the generation's interpreter is terminal without an
   interpretation recorded, a re-tick re-arms a fresh interpreter on the same row.
   This restores retry for both the governor-refused-then-swept path and the
   run-then-fail path (matching the interpret gate's documented "the loop
   redispatches rather than record garbage").

The human-ratify gate is untouched — `Directive.admit` still requires a consumed,
answered ratify question (maker≠checker). This change is only about retry-ability of
INTERPRETATION.

## Tests (RED → GREEN)

- `TestDirectiveDispatchReArm` — a live PENDING interpreter is not re-armed (dedup
  holds); a terminal (completed or failed) interpreter that recorded nothing IS
  re-armed on the same generation row; a generation bump still arms its own row.
- `FsmOwnedPhaseTests` — a `directive_interpreting` task is not swept on a closed
  umbrella (never even fetched); an ordinary-phase task on the same ticket shape is
  still swept (the exclusion is phase-scoped, not a blanket URL skip).
- `test_captured_rearms_a_fresh_interpreter_after_the_prior_one_died_uninterpreted`
  — end-to-end tick proof: a later `run_tick` re-arms a fresh interpreter.

Each was observed RED before the fix. `ci-parity-fast` green (23899 passed).

## Architecture pre-check — #3706

## 1. BLUEPRINT § alignment
§5.6 Loop Topology (directive mini-loop) + §17.4 orchestrator-decides/loop-executes.
No BLUEPRINT change: this restores an already-documented invariant (the interpret
gate's "loop redispatches rather than record garbage").

## 2. FSM phase boundaries
No new `Directive.State`/`Ticket.State` transition. The change makes the
`CAPTURED → INTERPRETED`/`CLARIFYING` retry reachable again after a terminal-but-
uninterpreted dispatch; the ratify/admit gate is unchanged.

## 3. Extension-point contracts
No `OverlayBase`/scanner-registration/Protocol change. `TaskSweepScanner`'s candidate
query narrows; its `ScanSignal` contract is unchanged.

## 4. Component boundaries
`core/models/directive_dispatch.py` (dedup is model behaviour) and
`loop/scanners/task_sweep.py` (candidate selection is scanner behaviour). No straddle.

## 5. Dependency direction
No new cross-module import. `_FSM_OWNED_PHASES` is a local constant in the scanner
(no `teatree.loops` import from `teatree.loop`).

## 6. Test surface
Model-level (`test_directive_dispatch.py`), scanner-level (`test_task_sweep_scanner.py`),
and tick-level (`test_tick.py`) — each asserts the observable contract the bug violated.

## 7. Resilience invariants
Idempotency preserved: re-arm is keyed on the task's terminal status, so a re-tick
while an interpreter is live is a no-op. No new external write.

## 8. Identity and key normalization
n/a — no bare/qualified identity split introduced.

## 9. Behavior preservation / capability deletion
Additive/narrowing only. The sweep still completes every real artifact-backed task;
only FSM-owned synthetic interpret tasks are excluded. No must-block test inverted.

## 10. Removability / harness-vs-data
Both changes are self-contained and revert cleanly. `_FSM_OWNED_PHASES` is a small
data table (widen it to cover a new FSM-owned phase — never the runner).
