### PR TITLE
fix(privacy-scan): scope per-line diff detectors to added lines only (#3681)

### DIFF
--- a/scripts/privacy_scan.py
+++ b/scripts/privacy_scan.py
@@ -159,9 +159,84 @@ def _run_diff_detectors(text: str) -> list[dict[str, str | int]]:
 
 
 def _scan_text(text: str, terms: tuple[str, ...], allowlist: tuple[str, ...]) -> list[dict[str, str | int]]:
-    """Per-line + whole-text findings for one text blob (no file attribution)."""
+    """Per-line + whole-text findings for one text blob (no file attribution).
+
+    Whole-file mode: every line is scanned. Used for filesystem targets (the
+    directory tree/core scan and a single-file scan), where each line is raw
+    content, never a diff.
+    """
     findings: list[dict[str, str | int]] = []
     for lineno, line in enumerate(text.splitlines(), 1):
+        findings.extend(
+            {"line": lineno, "category": category, "match": match}
+            for category, match in _scan_line(line, terms, allowlist)
+        )
+    findings.extend(_run_diff_detectors(text))
+    return findings
+
+
+#: A unified-diff hunk header — ``@@ … @@`` (2-way) or ``@@@ … @@@`` (combined,
+#: one extra ``@`` per parent). The leading run of ``@`` gives the marker-column
+#: width: ``len(run) - 1`` columns precede each hunk-body line.
+_HUNK_HEADER_RE = re.compile(r"^(@{2,}) ")
+
+
+def _is_hunk_body(raw: str, marker_width: int) -> bool:
+    """True when ``raw`` is a diff hunk-body line for the current marker width.
+
+    A body line begins with ``marker_width`` marker characters, each one of
+    space (context), ``+`` (added) or ``-`` (removed). Anything else (a file
+    header, a commit-message line, plain text) is not a body line and ends the
+    current hunk.
+    """
+    return len(raw) >= marker_width and all(char in " +-" for char in raw[:marker_width])
+
+
+def _diff_scan_lines(text: str) -> Iterator[tuple[int, str]]:
+    """Yield ``(lineno, content)`` for each diff line the per-line scan should inspect.
+
+    Diff-mode scoping for the push-gate path (souliane/teatree#3681). A unified
+    diff's *context* (`` ``) and *removed* (``-``) hunk lines are already-public
+    by definition — they exist unchanged on the parent commit the push builds
+    onto — so a credential/PII finding on them is a false positive that blocks a
+    legitimate push (a refactor pulling synthetic fixtures into the diff as
+    context/removed lines). They are skipped. Every other line is yielded
+    verbatim: *added* (``+``) hunk lines carry the genuinely-new content the
+    gate must still catch, and lines outside any hunk — commit-message bodies
+    (the push-gate scans ``%B`` alongside the patch, the #703 case) or plain
+    text piped with no diff structure — are new content too and are scanned
+    exactly as in whole-file mode.
+
+    Combined diffs (``git show --cc`` on merge commits) carry one marker column
+    per parent; a line counts as added when any column is ``+``, which keeps a
+    merge's conflict resolutions in scope.
+    """
+    in_hunk = False
+    marker_width = 1
+    for lineno, raw in enumerate(text.splitlines(), 1):
+        header = _HUNK_HEADER_RE.match(raw)
+        if header is not None:
+            marker_width = len(header.group(1)) - 1
+            in_hunk = marker_width >= 1
+            continue
+        if in_hunk and _is_hunk_body(raw, marker_width):
+            if "+" in raw[:marker_width]:
+                yield lineno, raw
+            continue
+        in_hunk = False
+        yield lineno, raw
+
+
+def _scan_diff(text: str, terms: tuple[str, ...], allowlist: tuple[str, ...]) -> list[dict[str, str | int]]:
+    """Diff-mode findings: per-line detectors over ADDED lines only, plus whole-text detectors.
+
+    The per-line credential/PII detectors run over :func:`_diff_scan_lines`
+    (added + non-hunk lines), so already-public context/removed lines never
+    trip them. The whole-text diff detectors still see the full text — they are
+    already added-line-scoped internally.
+    """
+    findings: list[dict[str, str | int]] = []
+    for lineno, line in _diff_scan_lines(text):
         findings.extend(
             {"line": lineno, "category": category, "match": match}
             for category, match in _scan_line(line, terms, allowlist)
@@ -265,9 +340,13 @@ def main(
     target = None if input_file == "-" else Path(input_file)
     if target is not None and target.is_dir():
         all_findings = _scan_directory(target, terms, allowlist)
+    elif target is None:
+        # stdin is the push-gate path: a unified diff (or a `%B` message +
+        # patch blob). Scope the per-line detectors to added / non-hunk lines.
+        all_findings = _scan_diff(sys.stdin.read(), terms, allowlist)
     else:
-        text = sys.stdin.read() if target is None else target.read_text(encoding="utf-8")
-        all_findings = _scan_text(text, terms, allowlist)
+        # A filesystem file is raw content, not a diff — scan every line.
+        all_findings = _scan_text(target.read_text(encoding="utf-8"), terms, allowlist)
 
     all_findings.sort(key=lambda f: (str(f.get("file", "")), int(f["line"])))
 

--- a/tests/test_privacy_scan_script.py
+++ b/tests/test_privacy_scan_script.py
@@ -416,3 +416,76 @@ class TestPrivacyScanAllowlistFromRegistry:
         result = _run_env("the acme-product repo\n", {"T3_CONFIG_DB": str(db)})
         assert result.returncode == PRIVACY_FINDINGS_EXIT_CODE, result.stdout + result.stderr
         assert "banned_term" in result.stdout
+
+
+class TestPrivacyScanDiffAddedLineScoping:
+    """The per-line detectors scan ADDED diff lines only, not context/removed (#3681).
+
+    A context (`` ``) or removed (``-``) hunk line is already-public by
+    definition — it exists unchanged on the parent commit the push builds
+    onto — so a credential/PII finding on it is a false positive that blocks
+    a legitimate push (a synthetic-fixture refactor pulling the fixtures into
+    the diff as context/removed lines). Every genuinely-new secret still
+    appears as an added (``+``) line or in a commit-message body, so the
+    gate's teeth are preserved.
+    """
+
+    def test_removed_line_match_is_not_flagged(self) -> None:
+        # RED before fix: the removed line's home-path tripped the scanner.
+        diff = (
+            "diff --git a/x.py b/x.py\n"
+            "--- a/x.py\n"
+            "+++ b/x.py\n"
+            "@@ -1,1 +1,1 @@\n"
+            '-old = "/Users/someone/secret/path"\n'  # privacy-scan:allow self-fixture
+            '+new = "a clean replacement value"\n'
+        )
+        result = _run(diff)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_context_line_match_is_not_flagged(self) -> None:
+        # RED before fix: the unchanged context line's home-path tripped it.
+        diff = (
+            "diff --git a/x.py b/x.py\n"
+            "--- a/x.py\n"
+            "+++ b/x.py\n"
+            "@@ -1,2 +1,2 @@\n"
+            ' ctx = "/home/carol/data/store"\n'  # privacy-scan:allow self-fixture
+            "-removed = 1\n"
+            "+added = 2\n"
+        )
+        result = _run(diff)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_added_line_match_still_flagged(self) -> None:
+        # Anti-vacuity: the SAME match on an added line keeps the gate's teeth.
+        diff = (
+            "diff --git a/x.py b/x.py\n"
+            "--- a/x.py\n"
+            "+++ b/x.py\n"
+            "@@ -1,1 +1,2 @@\n"
+            " ctx = 1\n"
+            '+leak = "/Users/someone/secret/path"\n'  # privacy-scan:allow self-fixture
+        )
+        result = _run(diff)
+        assert result.returncode == PRIVACY_FINDINGS_EXIT_CODE, result.stdout + result.stderr
+        assert "home_path" in result.stdout
+
+    def test_commit_message_body_line_still_flagged(self) -> None:
+        # The push-gate blob is `%B` message + patch; a message-body line is new
+        # content on the pushed range (the #703 Co-authored-by case) and must
+        # still be scanned — the added-only scoping must not silence it.
+        blob = (
+            "Fix the thing\n"
+            "\n"
+            "Co-authored-by: someone@gmail.com\n"  # privacy-scan:allow (dummy example address, test input)
+            "diff --git a/x.py b/x.py\n"
+            "--- a/x.py\n"
+            "+++ b/x.py\n"
+            "@@ -1,1 +1,1 @@\n"
+            "-old = 1\n"
+            "+new = 2\n"
+        )
+        result = _run(blob)
+        assert result.returncode == PRIVACY_FINDINGS_EXIT_CODE, result.stdout + result.stderr
+        assert "email" in result.stdout


### PR DESCRIPTION
Closes #3681.

## Problem

The pre-push public-repo privacy gate ran the per-line credential/PII detectors (`home_path`, `api_key`, `private_ip`, `email`, `opaque_id`, `internal_hostname`, `banned_term`) over **every** line of a diff — including **context** and **removed** (`-`) lines. Those lines are already-public by definition (they exist unchanged on the parent commit the push builds onto), so a finding on them is a false positive that blocks legitimate pushes: a refactor of a file holding synthetic scanner fixtures pulls those unchanged fixtures into the diff as context/removed lines, and the gate blocks even though not one added (`+`) line introduces anything new.

## Fix

Scope the per-line detectors to **added lines only** on the stdin push-gate path, mirroring what the `code_comment_self_reference` diff detector already does:

- A diff **context** (` `) or **removed** (`-`) hunk line is skipped — already-public content.
- An **added** (`+`) hunk line is scanned — genuinely-new content.
- A **non-hunk** line (commit-message body from the `%B` + patch blob, or plain piped text with no diff structure) is scanned exactly as before — new content on the pushed range, so the commit-message teeth stay.
- **Combined** (`--cc`) diffs count a line as added when any marker column is `+`, keeping a merge's conflict resolutions in scope.

Whole-file scans (the directory tree/core scan and single-file scans) are **unchanged** — every line is still scanned; only the diff/per-line push-gate path is scoped.

## Teeth preserved (anti-vacuous)

The fix narrows the scan, it does not weaken it. A genuinely-new secret still appears on a `+` line or in a commit-message body and still blocks. New tests in `TestPrivacyScanDiffAddedLineScoping`:

- `test_removed_line_match_is_not_flagged` / `test_context_line_match_is_not_flagged` — RED before the fix (the removed/context match tripped the scanner), GREEN after.
- `test_added_line_match_still_flagged` — the same match on an added line still blocks.
- `test_commit_message_body_line_still_flagged` — a message-body leak still blocks.

## Architecture pre-check

- **Component boundaries:** change confined to `scripts/privacy_scan.py` (the diff scanner) + its test mirror. No `src/teatree/` module, FSM phase, extension point, or Protocol touched.
- **Behavior preservation:** the change removes a false-positive class on already-public context/removed lines. It does **not** narrow coverage of genuinely-new content (added lines + commit messages remain scanned); no must-block regression test was inverted, and the added-line teeth are pinned by new anti-vacuous tests.
- **Removability:** self-contained — reverting restores whole-line scanning of the diff path with no cascade.
