### PR TITLE
refactor(backends): extract shared BoundedRetryTransport; add retry to sentry/notion/figma

### DIFF
--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -102,6 +102,7 @@ graph TD
     teatree.backends --> teatree.llm
     teatree.backends --> teatree.backends.errors
     teatree.backends --> teatree.backends.types
+    teatree.backends --> teatree.backends.http_retry
     teatree.backends --> teatree.backends.forge_merge_rpc
     teatree.backends --> teatree.backends.github
     teatree.backends --> teatree.backends.gitlab
@@ -115,6 +116,7 @@ graph TD
     teatree.backends.slack --> teatree.core.models
     teatree.backends.slack --> teatree.identity
     teatree.backends.slack --> teatree.url_classify
+    teatree.backends.slack --> teatree.backends.http_retry
     teatree.backends.gitlab --> teatree.types
     teatree.backends.gitlab --> teatree.utils
     teatree.backends.gitlab --> teatree.core
@@ -122,6 +124,7 @@ graph TD
     teatree.backends.gitlab --> teatree.llm
     teatree.backends.gitlab --> teatree.backends.errors
     teatree.backends.gitlab --> teatree.backends.types
+    teatree.backends.gitlab --> teatree.backends.http_retry
     teatree.backends.gitlab --> teatree.backends.forge_merge_rpc
     teatree.backends.gitlab --> teatree.backends.slack
     teatree.backends.github --> teatree.types
@@ -382,6 +385,7 @@ graph TD
     teatree.core.managers_task_claim
     teatree.core.managers_issue_match
     teatree.backends.errors
+    teatree.backends.http_retry
     teatree.backends.types
     teatree.cli._format_opts
     teatree.loop.statusline_palette

--- a/src/teatree/backends/figma.py
+++ b/src/teatree/backends/figma.py
@@ -17,6 +17,7 @@ from typing import TypedDict, cast
 import httpx
 from PIL import Image
 
+from teatree.backends.http_retry import SimpleRetryTransport
 from teatree.llm.credentials import Credential, CredentialSpec
 
 
@@ -146,21 +147,30 @@ class FigmaComponentMetadata:
 
 
 class FigmaClient:
-    """Figma REST API client — one HTTP call per method, no local state."""
+    """Figma REST API client — one HTTP call per method, no local state.
+
+    Every method is an idempotent GET, so all run under the shared bounded-retry
+    transport (:class:`~teatree.backends.http_retry.SimpleRetryTransport`): a
+    transient ``5xx`` / ``429`` / connect timeout is retried instead of breaking
+    the design-to-code workflow. Knobs default from ``T3_FIGMA_HTTP_*``.
+    """
 
     def __init__(self, *, token: str, base_url: str = "https://api.figma.com") -> None:
         self.token = token
         self.base_url = base_url.rstrip("/")
+        self._transport = SimpleRetryTransport(env_prefix="T3_FIGMA_HTTP")
 
     def get_file(self, file_key: str) -> _FigmaFileResponse:
         with self._client() as client:
-            response = client.get(f"/v1/files/{file_key}")
+            response = self._transport.run(lambda: client.get(f"/v1/files/{file_key}"), idempotent=True)
             response.raise_for_status()
             return cast("_FigmaFileResponse", response.json())
 
     def get_node(self, file_key: str, node_id: str) -> FigmaNode:
         with self._client() as client:
-            response = client.get(f"/v1/files/{file_key}/nodes", params={"ids": node_id})
+            response = self._transport.run(
+                lambda: client.get(f"/v1/files/{file_key}/nodes", params={"ids": node_id}), idempotent=True
+            )
             response.raise_for_status()
             body = cast("_FigmaNodesResponse", response.json())
         entry = body.get("nodes", {}).get(node_id)
@@ -180,9 +190,12 @@ class FigmaClient:
         self, file_key: str, node_ids: list[str], *, scale: float = 1.0, image_format: str = "png"
     ) -> dict[str, str]:
         with self._client() as client:
-            response = client.get(
-                f"/v1/images/{file_key}",
-                params={"ids": ",".join(node_ids), "scale": scale, "format": image_format},
+            response = self._transport.run(
+                lambda: client.get(
+                    f"/v1/images/{file_key}",
+                    params={"ids": ",".join(node_ids), "scale": scale, "format": image_format},
+                ),
+                idempotent=True,
             )
             response.raise_for_status()
             body = cast("_FigmaImagesResponse", response.json())
@@ -203,7 +216,7 @@ class FigmaClient:
 
     def get_comments(self, file_key: str) -> list[FigmaComment]:
         with self._client() as client:
-            response = client.get(f"/v1/files/{file_key}/comments")
+            response = self._transport.run(lambda: client.get(f"/v1/files/{file_key}/comments"), idempotent=True)
             response.raise_for_status()
             body = cast("_FigmaCommentsResponse", response.json())
         return body.get("comments") or []

--- a/src/teatree/backends/gitlab/http_client.py
+++ b/src/teatree/backends/gitlab/http_client.py
@@ -22,15 +22,15 @@ Two reliability invariants govern every request:
 """
 
 import logging
-import os
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
 import httpx
 
+from teatree.backends.http_retry import BoundedRetryTransport, SleepFn, env_float
 from teatree.core.backend_protocols import BackendResolutionError
 from teatree.llm.credentials import Credential, CredentialError, CredentialSpec
 
@@ -44,9 +44,6 @@ alias IS the typed contract here: "an untyped JSON object straight off the wire"
 Callers narrow it at the domain layer (``api.GitLabAPI``) or at the host boundary.
 """
 
-type AttemptFn = Callable[[], httpx.Response]
-type SleepFn = Callable[[float], None]
-
 # Upper bound on pages walked for an offset-paginated list endpoint. GitLab
 # serves at most 100 items per page; this cap stops a runaway loop if the API
 # ever returns a malformed ``x-next-page`` that never empties.
@@ -54,13 +51,9 @@ _MAX_PAGES = 100
 
 _DEFAULT_TIMEOUT_SECONDS = 10.0
 _UPLOAD_TIMEOUT_SECONDS = 30.0
-_DEFAULT_MAX_RETRIES = 3
-_DEFAULT_BACKOFF_BASE_SECONDS = 0.5
-_MAX_BACKOFF_SECONDS = 30.0
 # Statuses at or above which a write is a failure the caller may drop on the floor;
 # the transport logs it so a failed MR update / note post never vanishes silently.
 _HTTP_ERROR_FLOOR = 400
-_CONNECT_ERRORS = (httpx.ConnectTimeout, httpx.ConnectError, httpx.PoolTimeout)
 
 
 @dataclass(frozen=True, slots=True)
@@ -105,29 +98,17 @@ def _resolve_token() -> str:
         return ""
 
 
-def _env_float(name: str, default: float) -> float:
-    raw = os.environ.get(name, "").strip()
-    if not raw:
-        return default
-    try:
-        value = float(raw)
-    except ValueError:
-        return default
-    return value if value > 0 else default
+class GitLabHTTPClient(BoundedRetryTransport):
+    """GitLab REST/GraphQL transport on the shared bounded-retry machine.
 
+    Inherits :class:`~teatree.backends.http_retry.BoundedRetryTransport`'s retry
+    loop unchanged (``_RAISE_FOR_STATUS_ON_RETURN`` stays ``False`` — a response
+    is handed back raw so status-inspecting callers like ``post_status`` keep
+    working; body-returning callers apply ``raise_for_status`` themselves) and
+    layers on GitLab's own concerns: token resolution, the TTL response cache,
+    offset pagination, uploads, and GraphQL.
+    """
 
-def _env_int(name: str, default: int) -> int:
-    raw = os.environ.get(name, "").strip()
-    if not raw:
-        return default
-    try:
-        value = int(raw)
-    except ValueError:
-        return default
-    return value if value >= 0 else default
-
-
-class GitLabHTTPClient:
     def __init__(
         self,
         *,
@@ -141,16 +122,10 @@ class GitLabHTTPClient:
         self.base_url = base_url.rstrip("/")
         self._project_cache: dict[str, ProjectInfo] = {}
         self._response_cache: dict[str, tuple[float, object]] = {}
-        self._timeout = _env_float("T3_GITLAB_HTTP_TIMEOUT", _DEFAULT_TIMEOUT_SECONDS)
-        self._max_retries = (
-            max_retries if max_retries is not None else _env_int("T3_GITLAB_HTTP_MAX_RETRIES", _DEFAULT_MAX_RETRIES)
+        self._timeout = env_float("T3_GITLAB_HTTP_TIMEOUT", _DEFAULT_TIMEOUT_SECONDS)
+        self._configure_retry(
+            env_prefix="T3_GITLAB_HTTP", max_retries=max_retries, backoff_base=backoff_base, sleep=sleep
         )
-        self._backoff_base = (
-            backoff_base
-            if backoff_base is not None
-            else _env_float("T3_GITLAB_HTTP_BACKOFF", _DEFAULT_BACKOFF_BASE_SECONDS)
-        )
-        self._sleep = sleep
 
     def _get_cached[T](self, cache_key: str, ttl: int) -> T | None:
         """Return the fresh cached value for *cache_key*, or ``None`` when missing/stale.
@@ -191,44 +166,6 @@ class GitLabHTTPClient:
     def clear_response_cache(self) -> None:
         self._response_cache.clear()
 
-    def _run(self, attempt: AttemptFn, *, idempotent: bool) -> httpx.Response:
-        """Execute *attempt* under a bounded retry, returning the ``httpx.Response``.
-
-        Retries are gated by BOTH the failure class and the call's idempotency,
-        mirroring :class:`teatree.backends.slack.http.SlackHttpClient`:
-
-        *   a CONNECT-phase failure (the request never reached GitLab) is safe to
-            retry for any call, idempotent or not — nothing was sent;
-        *   a RESPONSE-phase failure (a read timeout, a ``5xx``, a ``429``) is
-            retried only for an idempotent call, so a non-idempotent ``POST``
-            (creating a note / pipeline) is never blindly replayed.
-
-        A ``429`` / ``5xx`` honours the ``Retry-After`` header when present, else
-        the standard exponential backoff. The response is returned WITHOUT
-        ``raise_for_status`` so status-inspecting callers (``post_status`` et al.)
-        keep working; body-returning callers apply ``raise_for_status`` themselves.
-        """
-        for retries_left in range(self._max_retries, -1, -1):
-            last = retries_left == 0
-            try:
-                response = attempt()
-            except _CONNECT_ERRORS:
-                if last:
-                    raise
-                self._backoff(self._max_retries - retries_left)
-                continue
-            except httpx.TimeoutException:
-                if last or not idempotent:
-                    raise
-                self._backoff(self._max_retries - retries_left)
-                continue
-            retry_after = self._transient_response_wait(response, idempotent=idempotent)
-            if retry_after is None or last:
-                return response
-            self._sleep_for(retry_after if retry_after > 0 else self._backoff_seconds(self._max_retries - retries_left))
-        unreachable = "retry loop is exhaustive: the final iteration always returns or raises"
-        raise AssertionError(unreachable)  # pragma: no cover
-
     def _url(self, endpoint: str) -> str:
         return f"{self.base_url}/{endpoint.lstrip('/')}"
 
@@ -265,49 +202,6 @@ class GitLabHTTPClient:
             return httpx.delete(url, headers=self._headers(), timeout=self._timeout)
 
         return self._run(attempt, idempotent=True)
-
-    def _transient_response_wait(self, response: httpx.Response, *, idempotent: bool) -> float | None:
-        """Seconds to wait before a response-phase retry, or ``None`` when not retryable.
-
-        ``0.0`` means "retry on the standard backoff"; a positive value is an
-        explicit ``Retry-After`` to honour. ``None`` means surface the response to
-        the caller (success, a non-transient status, or a non-idempotent write
-        that must not be replayed on a response-phase failure).
-        """
-        if not self._is_transient_response(response):
-            return None
-        if not idempotent:
-            return None
-        return self._retry_after_seconds(response)
-
-    @staticmethod
-    def _is_transient_response(response: httpx.Response) -> bool:
-        # A real httpx.Response always carries an int status; a response object that
-        # reports no integer status is not classifiable as transient (surfaced as-is).
-        status = getattr(response, "status_code", None)
-        if not isinstance(status, int):
-            return False
-        return status >= httpx.codes.INTERNAL_SERVER_ERROR or status == httpx.codes.TOO_MANY_REQUESTS
-
-    @staticmethod
-    def _retry_after_seconds(response: httpx.Response) -> float:
-        header = response.headers.get("Retry-After", "").strip()
-        if not header:
-            return 0.0
-        try:
-            return max(0.0, float(header))
-        except ValueError:
-            return 0.0
-
-    def _backoff(self, attempt_index: int) -> None:
-        self._sleep_for(self._backoff_seconds(attempt_index))
-
-    def _backoff_seconds(self, attempt_index: int) -> float:
-        return min(_MAX_BACKOFF_SECONDS, self._backoff_base * (2**attempt_index))
-
-    def _sleep_for(self, seconds: float) -> None:
-        if seconds > 0:
-            self._sleep(min(_MAX_BACKOFF_SECONDS, seconds))
 
     @staticmethod
     def _log_write_failure(method: str, endpoint: str, status: int) -> int:

--- a/src/teatree/backends/http_retry.py
+++ b/src/teatree/backends/http_retry.py
@@ -1,0 +1,224 @@
+"""Shared bounded-retry HTTP transport for every ``httpx`` backend.
+
+Naked ``httpx`` calls broke a whole loop tick on a single transient ``502`` /
+``429`` / connect timeout — the failure both :class:`SlackHttpClient` and
+:class:`GitLabHTTPClient` were built to survive. :class:`BoundedRetryTransport`
+is the one machine those two (and the lighter Sentry / Notion / Figma clients)
+share: a bounded exponential backoff that honours ``Retry-After`` and is gated
+by BOTH the failure class and the call's idempotency.
+
+Idempotency is the load-bearing safety constraint. A non-idempotent write
+(``chat.postMessage``, a GitLab note ``POST``) that read-times-out may have
+reached the host and only lost the response — a blind replay would double-post.
+So retries split by :class:`RetryClass`:
+
+*   :class:`RetryClass.CONNECT` — the request never reached the host
+    (``ConnectTimeout`` / ``ConnectError`` / ``PoolTimeout``). Safe to retry for
+    *every* call, idempotent or not, because nothing was sent.
+*   :class:`RetryClass.RESPONSE` — the request reached the host but the response
+    failed or signalled "try again" (a read timeout, ``5xx``, ``429``, or a
+    host-specific ratelimit body). Retried only for an *idempotent* call.
+
+Subclasses parameterize three seams:
+
+*   :attr:`BoundedRetryTransport._RAISE_FOR_STATUS_ON_RETURN` — whether the
+    returned response is ``raise_for_status``-ed before it surfaces (Slack raises
+    so a ``5xx`` becomes an exception; GitLab returns the raw response so
+    status-inspecting callers keep working).
+*   :meth:`BoundedRetryTransport._is_transient_response` — the transient-status
+    classification, which a subclass overrides to union a host-specific transient
+    body onto the standard ``5xx`` / ``429`` check (Slack's ``ratelimited`` JSON).
+*   The env-var prefix + retry knobs, resolved once via
+    :meth:`BoundedRetryTransport._configure_retry`.
+"""
+
+import os
+import time
+from collections.abc import Callable
+from enum import Enum
+
+import httpx
+
+type SleepFn = Callable[[float], None]
+type AttemptFn = Callable[[], httpx.Response]
+
+DEFAULT_TIMEOUT_SECONDS = 10.0
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_BACKOFF_BASE_SECONDS = 0.5
+MAX_BACKOFF_SECONDS = 30.0
+CONNECT_ERRORS = (httpx.ConnectTimeout, httpx.ConnectError, httpx.PoolTimeout)
+
+
+class RetryClass(Enum):
+    """How a transient failure may be retried.
+
+    ``CONNECT`` — the request never reached the host, so a retry cannot
+    duplicate a side effect; safe even for a non-idempotent write.
+    ``RESPONSE`` — the request reached the host; retry only when the call
+    itself is idempotent (a read, or an ``add``-the-same-thing no-op).
+    """
+
+    CONNECT = "connect"
+    RESPONSE = "response"
+
+
+def env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value >= 0 else default
+
+
+class BoundedRetryTransport:
+    """Bounded exponential-backoff retry around an ``httpx`` request attempt.
+
+    ``max_retries`` is the number of *additional* attempts after the first, so
+    the default ``3`` means up to four total tries. ``sleep`` is injectable
+    purely so tests assert the backoff schedule without real delay — production
+    uses ``time.sleep``.
+    """
+
+    _RAISE_FOR_STATUS_ON_RETURN: bool = False
+
+    def _configure_retry(
+        self,
+        *,
+        env_prefix: str,
+        max_retries: int | None,
+        backoff_base: float | None,
+        sleep: SleepFn,
+    ) -> None:
+        self._max_retries = (
+            max_retries if max_retries is not None else env_int(f"{env_prefix}_MAX_RETRIES", DEFAULT_MAX_RETRIES)
+        )
+        self._backoff_base = (
+            backoff_base
+            if backoff_base is not None
+            else env_float(f"{env_prefix}_BACKOFF", DEFAULT_BACKOFF_BASE_SECONDS)
+        )
+        self._sleep = sleep
+
+    def _run(self, attempt: AttemptFn, *, idempotent: bool) -> httpx.Response:
+        """Execute *attempt* under a bounded retry, returning the ``httpx.Response``.
+
+        A CONNECT-phase failure is safe to retry for any call (nothing was sent);
+        a RESPONSE-phase failure (read timeout, ``5xx``, ``429``, ratelimited) is
+        retried only for an idempotent call. A ``429`` / ``5xx`` honours a
+        ``Retry-After`` header when present, else the standard exponential
+        backoff. The final iteration always returns or raises, so the loop is
+        exhaustive — no unreachable fall-through.
+        """
+        for retries_left in range(self._max_retries, -1, -1):
+            last = retries_left == 0
+            try:
+                response = attempt()
+            except CONNECT_ERRORS:
+                if last:
+                    raise
+                self._backoff(self._max_retries - retries_left)
+                continue
+            except httpx.TimeoutException:
+                if last or not self._may_retry(RetryClass.RESPONSE, idempotent=idempotent):
+                    raise
+                self._backoff(self._max_retries - retries_left)
+                continue
+            retry_after = self._transient_response_wait(response, idempotent=idempotent)
+            if retry_after is None or last:
+                if self._RAISE_FOR_STATUS_ON_RETURN:
+                    response.raise_for_status()
+                return response
+            self._sleep_for(retry_after if retry_after > 0 else self._backoff_seconds(self._max_retries - retries_left))
+        unreachable = "retry loop is exhaustive: the final iteration always returns or raises"
+        raise AssertionError(unreachable)  # pragma: no cover
+
+    def _transient_response_wait(self, response: httpx.Response, *, idempotent: bool) -> float | None:
+        """Seconds to wait before a response-phase retry, or ``None`` when not retryable.
+
+        ``0.0`` means "retry on the standard backoff"; a positive value is an
+        explicit ``Retry-After`` to honour. ``None`` means surface the response to
+        the caller (success, a non-transient status, or a non-idempotent write
+        that must not be replayed on a response-phase failure).
+        """
+        if not self._is_transient_response(response):
+            return None
+        if not self._may_retry(RetryClass.RESPONSE, idempotent=idempotent):
+            return None
+        return self._retry_after_seconds(response)
+
+    @staticmethod
+    def _is_transient_response(response: httpx.Response) -> bool:
+        # A real httpx.Response always carries an int status; a response object
+        # that reports no integer status is not classifiable as transient
+        # (surfaced as-is). Keeps the transport tolerant of the lightweight
+        # stub responses some backend tests hand back. Subclasses that add a
+        # host-specific transient body (Slack's ``ratelimited``) OVERRIDE this
+        # and union their check onto ``super()._is_transient_response(...)``.
+        status = getattr(response, "status_code", None)
+        if not isinstance(status, int):
+            return False
+        return status >= httpx.codes.INTERNAL_SERVER_ERROR or status == httpx.codes.TOO_MANY_REQUESTS
+
+    @staticmethod
+    def _may_retry(failure: RetryClass, *, idempotent: bool) -> bool:
+        return failure is RetryClass.CONNECT or idempotent
+
+    @staticmethod
+    def _retry_after_seconds(response: httpx.Response) -> float:
+        header = response.headers.get("Retry-After", "").strip()
+        if not header:
+            return 0.0
+        try:
+            return max(0.0, float(header))
+        except ValueError:
+            return 0.0
+
+    def _backoff(self, attempt_index: int) -> None:
+        self._sleep_for(self._backoff_seconds(attempt_index))
+
+    def _backoff_seconds(self, attempt_index: int) -> float:
+        return min(MAX_BACKOFF_SECONDS, self._backoff_base * (2**attempt_index))
+
+    def _sleep_for(self, seconds: float) -> None:
+        if seconds > 0:
+            self._sleep(min(MAX_BACKOFF_SECONDS, seconds))
+
+
+class SimpleRetryTransport(BoundedRetryTransport):
+    """Composable bounded-retry wrapper for a backend that owns its ``httpx.Client``.
+
+    The Sentry / Notion / Figma clients build a fresh ``httpx.Client`` per call
+    (their own base URL, auth header, and timeout) and then ``raise_for_status``
+    themselves, so they COMPOSE this transport rather than subclass the base:
+    each request is a closure passed to :meth:`run`, which adds the shared
+    bounded retry without touching the client's own timeout or exception
+    handling. ``_RAISE_FOR_STATUS_ON_RETURN`` stays ``False`` — the caller keeps
+    its existing ``raise_for_status`` so a persistent error surfaces unchanged.
+    """
+
+    def __init__(
+        self,
+        *,
+        env_prefix: str,
+        max_retries: int | None = None,
+        backoff_base: float | None = None,
+        sleep: SleepFn = time.sleep,
+    ) -> None:
+        self._configure_retry(env_prefix=env_prefix, max_retries=max_retries, backoff_base=backoff_base, sleep=sleep)
+
+    def run(self, attempt: AttemptFn, *, idempotent: bool) -> httpx.Response:
+        return self._run(attempt, idempotent=idempotent)

--- a/src/teatree/backends/notion.py
+++ b/src/teatree/backends/notion.py
@@ -6,6 +6,7 @@ from urllib.parse import unquote
 
 import httpx
 
+from teatree.backends.http_retry import SimpleRetryTransport
 from teatree.types import RawAPIDict
 
 _UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
@@ -152,11 +153,22 @@ def _property_name_value(prop: object) -> str | None:
 
 
 class NotionClient:
+    """Notion API client — page reads, database queries, status writes.
+
+    Reads (``get_page`` and each ``query_database`` page — a POST, but a read
+    with no side effect) run under the shared bounded-retry transport
+    (:class:`~teatree.backends.http_retry.SimpleRetryTransport`); the
+    ``update_page_status`` PATCH is a non-idempotent write, so it is retried only
+    on a CONNECT-phase failure (never replayed after the request reached Notion).
+    Knobs default from ``T3_NOTION_HTTP_*``.
+    """
+
     _BASE = "https://api.notion.com/v1"
 
     def __init__(self, *, token: str, version: str = "2022-06-28") -> None:
         self.token = token
         self.version = version
+        self._transport = SimpleRetryTransport(env_prefix="T3_NOTION_HTTP")
 
     def _client(self) -> httpx.Client:
         return httpx.Client(
@@ -169,7 +181,7 @@ class NotionClient:
 
     def get_page(self, page_id: str) -> RawAPIDict:
         with self._client() as client:
-            response = client.get(f"{self._BASE}/pages/{page_id}")
+            response = self._transport.run(lambda: client.get(f"{self._BASE}/pages/{page_id}"), idempotent=True)
             response.raise_for_status()
             return cast("RawAPIDict", response.json())
 
@@ -191,7 +203,10 @@ class NotionClient:
                     payload["filter"] = db_filter
                 if cursor:
                     payload["start_cursor"] = cursor
-                response = client.post(f"{self._BASE}/databases/{database_id}/query", json=payload)
+                response = self._transport.run(
+                    lambda p=payload: client.post(f"{self._BASE}/databases/{database_id}/query", json=p),
+                    idempotent=True,
+                )
                 response.raise_for_status()
                 body = response.json()
                 results.extend(body.get("results", []))
@@ -201,9 +216,12 @@ class NotionClient:
 
     def update_page_status(self, page_id: str, *, property_name: str, value: str) -> RawAPIDict:
         with self._client() as client:
-            response = client.patch(
-                f"{self._BASE}/pages/{page_id}",
-                json={"properties": {property_name: {"status": {"name": value}}}},
+            response = self._transport.run(
+                lambda: client.patch(
+                    f"{self._BASE}/pages/{page_id}",
+                    json={"properties": {property_name: {"status": {"name": value}}}},
+                ),
+                idempotent=False,
             )
             response.raise_for_status()
             return cast("RawAPIDict", response.json())

--- a/src/teatree/backends/sentry.py
+++ b/src/teatree/backends/sentry.py
@@ -4,42 +4,56 @@ from typing import cast
 
 import httpx
 
+from teatree.backends.http_retry import SimpleRetryTransport
+
 
 class SentryClient:
-    """Sentry API client — fetches issue summaries for retro/triage skills."""
+    """Sentry API client — fetches issue summaries for retro/triage skills.
+
+    Every read runs under the shared bounded-retry transport
+    (:class:`~teatree.backends.http_retry.SimpleRetryTransport`) so a transient
+    ``5xx`` / ``429`` / connect timeout is retried instead of breaking the caller;
+    all four calls are idempotent GETs. Knobs default from ``T3_SENTRY_HTTP_*``.
+    """
 
     def __init__(self, *, token: str, org: str, base_url: str = "https://sentry.io") -> None:
         self.token = token
         self.org = org
         self.base_url = base_url.rstrip("/")
+        self._transport = SimpleRetryTransport(env_prefix="T3_SENTRY_HTTP")
 
     def get_top_issues(self, *, project: str, limit: int = 10) -> list[dict[str, object]]:
         with self._client() as client:
-            response = client.get(
-                f"/api/0/projects/{self.org}/{project}/issues/",
-                params={"query": "is:unresolved", "sort": "freq", "limit": limit},
+            response = self._transport.run(
+                lambda: client.get(
+                    f"/api/0/projects/{self.org}/{project}/issues/",
+                    params={"query": "is:unresolved", "sort": "freq", "limit": limit},
+                ),
+                idempotent=True,
             )
             response.raise_for_status()
             return cast("list[dict[str, object]]", response.json())
 
     def get_issue(self, issue_id: str) -> dict[str, object]:
         with self._client() as client:
-            response = client.get(f"/api/0/issues/{issue_id}/")
+            response = self._transport.run(lambda: client.get(f"/api/0/issues/{issue_id}/"), idempotent=True)
             response.raise_for_status()
             return cast("dict[str, object]", response.json())
 
     def get_issue_events(self, issue_id: str, *, limit: int = 10) -> list[dict[str, object]]:
         with self._client() as client:
-            response = client.get(
-                f"/api/0/issues/{issue_id}/events/",
-                params={"limit": limit},
+            response = self._transport.run(
+                lambda: client.get(f"/api/0/issues/{issue_id}/events/", params={"limit": limit}),
+                idempotent=True,
             )
             response.raise_for_status()
             return cast("list[dict[str, object]]", response.json())
 
     def list_projects(self) -> list[dict[str, object]]:
         with self._client() as client:
-            response = client.get(f"/api/0/organizations/{self.org}/projects/")
+            response = self._transport.run(
+                lambda: client.get(f"/api/0/organizations/{self.org}/projects/"), idempotent=True
+            )
             response.raise_for_status()
             return cast("list[dict[str, object]]", response.json())
 

--- a/src/teatree/backends/slack/http.py
+++ b/src/teatree/backends/slack/http.py
@@ -9,6 +9,15 @@ very next attempt would have succeeded. :class:`SlackHttpClient`
 centralises the transport so every call gets a configurable timeout and
 a bounded exponential backoff on *transient* failures only.
 
+The retry machine itself lives in
+:class:`teatree.backends.http_retry.BoundedRetryTransport` — the shared
+bounded-retry transport GitLab's client is built on too. This subclass
+adds the two Slack-specific seams: the ``ratelimited`` classification
+(:meth:`SlackHttpClient._extra_transient`) and the scope-cache guard
+(:func:`_scope_guarded`). It also flips
+``_RAISE_FOR_STATUS_ON_RETURN`` on so a persistent ``5xx`` surfaces as an
+exception (GitLab, by contrast, hands the raw response back).
+
 Idempotency is the load-bearing safety constraint. A
 ``chat.postMessage`` is **not** idempotent: a ``ReadTimeout`` after the
 request reached Slack may mean the message *was* posted and only the
@@ -33,20 +42,24 @@ backoff and timeout are read once from the environment so a slow link
 can widen them without a code change.
 """
 
-import os
 import time
 from collections.abc import Callable
-from enum import Enum
-from typing import cast
+from typing import cast, override
 
 import httpx
 
+from teatree.backends.http_retry import (
+    DEFAULT_BACKOFF_BASE_SECONDS,
+    DEFAULT_MAX_RETRIES,
+    DEFAULT_TIMEOUT_SECONDS,
+    BoundedRetryTransport,
+    RetryClass,
+    SleepFn,
+    env_float,
+)
 from teatree.backends.slack.scopes import SLACK_METHOD_SCOPES, slack_scope_failure
 from teatree.core.intake.scope_cache import ScopeMissingError, guarded_scope_call, token_scope_id
 from teatree.types import RawAPIDict
-
-type SleepFn = Callable[[float], None]
-type AttemptFn = Callable[[], httpx.Response]
 
 __all__ = [
     "DEFAULT_BACKOFF_BASE_SECONDS",
@@ -56,12 +69,7 @@ __all__ = [
     "SlackHttpClient",
 ]
 
-DEFAULT_TIMEOUT_SECONDS = 10.0
-DEFAULT_MAX_RETRIES = 3
-DEFAULT_BACKOFF_BASE_SECONDS = 0.5
-_MAX_BACKOFF_SECONDS = 30.0
 _RATELIMITED = "ratelimited"
-_CONNECT_ERRORS = (httpx.ConnectTimeout, httpx.ConnectError, httpx.PoolTimeout)
 
 
 def _scope_guarded(method: str, token: str, call: Callable[[], RawAPIDict]) -> RawAPIDict:
@@ -85,42 +93,7 @@ def _scope_guarded(method: str, token: str, call: Callable[[], RawAPIDict]) -> R
         return {"ok": False, "error": "missing_scope", "needed": exc.scope}
 
 
-class RetryClass(Enum):
-    """How a transient failure may be retried.
-
-    ``CONNECT`` — the request never reached Slack, so a retry cannot
-    duplicate a side effect; safe even for a non-idempotent post.
-    ``RESPONSE`` — the request reached Slack; retry only when the call
-    itself is idempotent (a read, or ``reactions.add``).
-    """
-
-    CONNECT = "connect"
-    RESPONSE = "response"
-
-
-def _env_float(name: str, default: float) -> float:
-    raw = os.environ.get(name, "").strip()
-    if not raw:
-        return default
-    try:
-        value = float(raw)
-    except ValueError:
-        return default
-    return value if value > 0 else default
-
-
-def _env_int(name: str, default: int) -> int:
-    raw = os.environ.get(name, "").strip()
-    if not raw:
-        return default
-    try:
-        value = int(raw)
-    except ValueError:
-        return default
-    return value if value >= 0 else default
-
-
-class SlackHttpClient:
+class SlackHttpClient(BoundedRetryTransport):
     """Transport for the Slack Web API with a bounded retry on transient errors.
 
     ``timeout`` and ``max_retries`` default from
@@ -133,6 +106,7 @@ class SlackHttpClient:
     """
 
     _BASE_URL = "https://slack.com/api"
+    _RAISE_FOR_STATUS_ON_RETURN = True
 
     def __init__(
         self,
@@ -142,16 +116,10 @@ class SlackHttpClient:
         backoff_base: float | None = None,
         sleep: SleepFn = time.sleep,
     ) -> None:
-        self._timeout = timeout if timeout is not None else _env_float("T3_SLACK_HTTP_TIMEOUT", DEFAULT_TIMEOUT_SECONDS)
-        self._max_retries = (
-            max_retries if max_retries is not None else _env_int("T3_SLACK_HTTP_MAX_RETRIES", DEFAULT_MAX_RETRIES)
+        self._timeout = timeout if timeout is not None else env_float("T3_SLACK_HTTP_TIMEOUT", DEFAULT_TIMEOUT_SECONDS)
+        self._configure_retry(
+            env_prefix="T3_SLACK_HTTP", max_retries=max_retries, backoff_base=backoff_base, sleep=sleep
         )
-        self._backoff_base = (
-            backoff_base
-            if backoff_base is not None
-            else _env_float("T3_SLACK_HTTP_BACKOFF", DEFAULT_BACKOFF_BASE_SECONDS)
-        )
-        self._sleep = sleep
 
     def post(
         self,
@@ -229,52 +197,9 @@ class SlackHttpClient:
 
         return self._run(attempt, idempotent=True).status_code
 
-    def _run(self, attempt: AttemptFn, *, idempotent: bool) -> httpx.Response:
-        # The final iteration (retries_left == 0) always returns or re-raises,
-        # so the loop is exhaustive — no unreachable fall-through.
-        for retries_left in range(self._max_retries, -1, -1):
-            last = retries_left == 0
-            try:
-                response = attempt()
-            except _CONNECT_ERRORS:
-                if last:
-                    raise
-                self._backoff(self._max_retries - retries_left)
-                continue
-            except httpx.TimeoutException:
-                if last or not self._may_retry(RetryClass.RESPONSE, idempotent=idempotent):
-                    raise
-                self._backoff(self._max_retries - retries_left)
-                continue
-            retry_after = self._transient_response_wait(response, idempotent=idempotent)
-            if retry_after is None or last:
-                response.raise_for_status()
-                return response
-            self._sleep_for(retry_after if retry_after > 0 else self._backoff_seconds(self._max_retries - retries_left))
-        unreachable = "retry loop is exhaustive: the final iteration always returns or raises"
-        raise AssertionError(unreachable)  # pragma: no cover
-
-    def _transient_response_wait(self, response: httpx.Response, *, idempotent: bool) -> float | None:
-        """Seconds to wait before a response-phase retry, or ``None`` when not retryable.
-
-        ``0.0`` means "retry on the standard backoff"; a positive value is
-        an explicit ``Retry-After`` to honour. ``None`` means surface the
-        response to the caller (success, a non-transient ``ok:false``, or a
-        non-idempotent post that must not be replayed on a response-phase
-        failure).
-        """
-        if not self._is_transient_response(response):
-            return None
-        if not self._may_retry(RetryClass.RESPONSE, idempotent=idempotent):
-            return None
-        return self._retry_after_seconds(response)
-
+    @override
     def _is_transient_response(self, response: httpx.Response) -> bool:
-        if response.status_code >= httpx.codes.INTERNAL_SERVER_ERROR:
-            return True
-        if response.status_code == httpx.codes.TOO_MANY_REQUESTS:
-            return True
-        return self._is_slack_ratelimited(response)
+        return super()._is_transient_response(response) or self._is_slack_ratelimited(response)
 
     @staticmethod
     def _is_slack_ratelimited(response: httpx.Response) -> bool:
@@ -285,27 +210,3 @@ class SlackHttpClient:
         except ValueError:
             return False
         return isinstance(body, dict) and body.get("error") == _RATELIMITED
-
-    @staticmethod
-    def _retry_after_seconds(response: httpx.Response) -> float:
-        header = response.headers.get("Retry-After", "").strip()
-        if not header:
-            return 0.0
-        try:
-            return max(0.0, float(header))
-        except ValueError:
-            return 0.0
-
-    @staticmethod
-    def _may_retry(failure: RetryClass, *, idempotent: bool) -> bool:
-        return failure is RetryClass.CONNECT or idempotent
-
-    def _backoff(self, attempt_index: int) -> None:
-        self._sleep_for(self._backoff_seconds(attempt_index))
-
-    def _backoff_seconds(self, attempt_index: int) -> float:
-        return min(_MAX_BACKOFF_SECONDS, self._backoff_base * (2**attempt_index))
-
-    def _sleep_for(self, seconds: float) -> None:
-        if seconds > 0:
-            self._sleep(min(_MAX_BACKOFF_SECONDS, seconds))

--- a/tach.toml
+++ b/tach.toml
@@ -317,6 +317,7 @@ depends_on = [
   "teatree.llm",
   "teatree.backends.errors",
   "teatree.backends.types",
+  "teatree.backends.http_retry",
   "teatree.backends.forge_merge_rpc",
   "teatree.backends.github",
   "teatree.backends.gitlab",
@@ -325,6 +326,11 @@ depends_on = [
 
 [[modules]]
 path = "teatree.backends.errors"
+layer = "domain"
+depends_on = []
+
+[[modules]]
+path = "teatree.backends.http_retry"
 layer = "domain"
 depends_on = []
 
@@ -347,7 +353,8 @@ depends_on = [
   "teatree.core",
   "teatree.core.models",
   "teatree.identity",
-  "teatree.url_classify"
+  "teatree.url_classify",
+  "teatree.backends.http_retry"
 ]
 
 [[modules]]
@@ -361,6 +368,7 @@ depends_on = [
   "teatree.llm",
   "teatree.backends.errors",
   "teatree.backends.types",
+  "teatree.backends.http_retry",
   "teatree.backends.forge_merge_rpc",
   "teatree.backends.slack"
 ]

--- a/tests/teatree_backends/test_http_retry.py
+++ b/tests/teatree_backends/test_http_retry.py
@@ -1,0 +1,212 @@
+"""Tests for the shared bounded-retry transport and the backends now built on it.
+
+The retry contract is exercised end-to-end through :class:`SimpleRetryTransport`
+(a transient connect/response failure is retried with backoff; a non-idempotent
+write is NOT replayed on a response-phase failure; a ``Retry-After`` is
+honoured), and the Sentry / Notion / Figma clients are shown to actually gain
+that retry — the failure their docstrings say broke a loop tick.
+"""
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from teatree.backends.figma import FigmaClient
+from teatree.backends.gitlab.http_client import GitLabHTTPClient
+from teatree.backends.http_retry import (
+    DEFAULT_BACKOFF_BASE_SECONDS,
+    DEFAULT_MAX_RETRIES,
+    DEFAULT_TIMEOUT_SECONDS,
+    BoundedRetryTransport,
+    RetryClass,
+    SimpleRetryTransport,
+    env_float,
+    env_int,
+)
+from teatree.backends.notion import NotionClient
+from teatree.backends.sentry import SentryClient
+from teatree.backends.slack.http import SlackHttpClient
+
+
+def _ok(body: object = None) -> httpx.Response:
+    return httpx.Response(200, json=body if body is not None else {"ok": True}, request=_req())
+
+
+def _status(code: int) -> httpx.Response:
+    return httpx.Response(code, request=_req())
+
+
+def _req() -> httpx.Request:
+    return httpx.Request("GET", "https://example.test/x")
+
+
+def _raise_or_return(calls: Iterator[httpx.Response | BaseException]) -> httpx.Response:
+    item = next(calls)
+    if isinstance(item, BaseException):
+        raise item
+    return item
+
+
+def _transport(sleeps: list[float]) -> SimpleRetryTransport:
+    return SimpleRetryTransport(env_prefix="T3_TEST_HTTP", max_retries=3, backoff_base=0.5, sleep=sleeps.append)
+
+
+class TestEnvHelpers:
+    @pytest.mark.parametrize(("raw", "expected"), [("", 10.0), ("bad", 10.0), ("-1", 10.0), ("0", 10.0), ("2.5", 2.5)])
+    def test_env_float_falls_back_unless_positive(
+        self, raw: str, expected: float, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("T3_TEST_HTTP_X", raw)
+        assert env_float("T3_TEST_HTTP_X", 10.0) == pytest.approx(expected)
+
+    @pytest.mark.parametrize(("raw", "expected"), [("", 3), ("bad", 3), ("-1", 3), ("0", 0), ("5", 5)])
+    def test_env_int_falls_back_unless_non_negative(
+        self, raw: str, expected: int, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("T3_TEST_HTTP_N", raw)
+        assert env_int("T3_TEST_HTTP_N", 3) == expected
+
+    def test_defaults_resolve_from_prefix_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for suffix in ("MAX_RETRIES", "BACKOFF"):
+            monkeypatch.delenv(f"T3_TEST_HTTP_{suffix}", raising=False)
+        transport = SimpleRetryTransport(env_prefix="T3_TEST_HTTP")
+        assert transport._max_retries == DEFAULT_MAX_RETRIES
+        assert transport._backoff_base == pytest.approx(DEFAULT_BACKOFF_BASE_SECONDS)
+        assert pytest.approx(10.0) == DEFAULT_TIMEOUT_SECONDS
+
+
+class TestConcreteTransportsShareTheBase:
+    """The refactor invariant: both reliability-critical clients ARE the shared machine."""
+
+    def test_gitlab_and_slack_build_on_bounded_retry_transport(self) -> None:
+        assert issubclass(GitLabHTTPClient, BoundedRetryTransport)
+        assert issubclass(SlackHttpClient, BoundedRetryTransport)
+
+    def test_raise_for_status_seam_differs(self) -> None:
+        # Slack raises on a persistent 5xx; GitLab hands the raw response back.
+        assert SlackHttpClient._RAISE_FOR_STATUS_ON_RETURN is True
+        assert GitLabHTTPClient._RAISE_FOR_STATUS_ON_RETURN is False
+
+    def test_retry_class_gating(self) -> None:
+        # CONNECT is always retryable; RESPONSE only for an idempotent call.
+        may = BoundedRetryTransport._may_retry
+        assert may(RetryClass.CONNECT, idempotent=False) is True
+        assert may(RetryClass.CONNECT, idempotent=True) is True
+        assert may(RetryClass.RESPONSE, idempotent=False) is False
+        assert may(RetryClass.RESPONSE, idempotent=True) is True
+
+
+class TestSimpleRetryTransport:
+    def test_server_error_then_success_retries_idempotent(self) -> None:
+        sleeps: list[float] = []
+        calls = iter([_status(503), _ok({"n": 1})])
+        body = _transport(sleeps).run(lambda: _raise_or_return(calls), idempotent=True)
+        assert body.json() == {"n": 1}
+        assert sleeps == [0.5]
+
+    def test_connect_error_retried_even_for_non_idempotent(self) -> None:
+        sleeps: list[float] = []
+        calls = iter([httpx.ConnectError("down"), _ok({"n": 2})])
+        body = _transport(sleeps).run(lambda: _raise_or_return(calls), idempotent=False)
+        assert body.json() == {"n": 2}
+        assert sleeps == [0.5]
+
+    def test_non_idempotent_response_failure_is_not_replayed(self) -> None:
+        sleeps: list[float] = []
+        attempts: list[int] = []
+
+        def attempt() -> httpx.Response:
+            attempts.append(1)
+            return _status(503)
+
+        # SimpleRetryTransport does not raise_for_status; the 503 surfaces so the
+        # caller's own raise_for_status decides — but it must NOT have been retried.
+        response = _transport(sleeps).run(attempt, idempotent=False)
+        assert response.status_code == 503
+        assert attempts == [1]
+        assert sleeps == []
+
+    def test_retry_after_header_is_honoured(self) -> None:
+        sleeps: list[float] = []
+        limited = httpx.Response(429, headers={"Retry-After": "7"}, request=_req())
+        calls = iter([limited, _ok()])
+        _transport(sleeps).run(lambda: _raise_or_return(calls), idempotent=True)
+        assert sleeps == [7.0]
+
+    def test_exhaustion_raises_last_connect_error(self) -> None:
+        sleeps: list[float] = []
+        down = httpx.ConnectError("always")
+
+        def attempt() -> httpx.Response:
+            raise down
+
+        with pytest.raises(httpx.ConnectError):
+            _transport(sleeps).run(attempt, idempotent=True)
+        assert sleeps == [0.5, 1.0, 2.0]
+
+
+def _fake_client(responses: list[httpx.Response | BaseException]) -> MagicMock:
+    calls = iter(responses)
+    client = MagicMock()
+    client.__enter__ = MagicMock(return_value=client)
+    client.__exit__ = MagicMock(return_value=False)
+    for verb in ("get", "post", "patch"):
+        getattr(client, verb).side_effect = lambda *_a, _c=calls, **_k: _raise_or_return(_c)
+    return client
+
+
+class TestBackendsNowRetry:
+    def test_sentry_retries_transient_5xx(self) -> None:
+        client = SentryClient(token="t", org="o")
+        sleeps: list[float] = []
+        client._transport._sleep = sleeps.append
+        fake = _fake_client([_status(503), _ok([{"id": "1"}])])
+
+        with patch.object(client, "_client", return_value=fake):
+            issues = client.get_top_issues(project="p")
+
+        assert issues == [{"id": "1"}]
+        assert fake.get.call_count == 2
+        assert sleeps == [0.5]
+
+    def test_figma_retries_transient_5xx(self) -> None:
+        client = FigmaClient(token="t")
+        sleeps: list[float] = []
+        client._transport._sleep = sleeps.append
+        fake = _fake_client([_status(503), _ok({"document": {}, "components": {}})])
+
+        with patch.object(client, "_client", return_value=fake):
+            file_data = client.get_file("fk")
+
+        assert file_data == {"document": {}, "components": {}}
+        assert fake.get.call_count == 2
+        assert sleeps == [0.5]
+
+    def test_notion_query_retries_transient_5xx(self) -> None:
+        client = NotionClient(token="t")
+        sleeps: list[float] = []
+        client._transport._sleep = sleeps.append
+        fake = _fake_client([_status(503), _ok({"results": [{"id": "r1"}], "has_more": False})])
+
+        with patch.object(client, "_client", return_value=fake):
+            rows = client.query_database("db")
+
+        assert [r["id"] for r in rows] == ["r1"]
+        assert fake.post.call_count == 2
+        assert sleeps == [0.5]
+
+    def test_notion_update_is_non_idempotent_no_response_replay(self) -> None:
+        client = NotionClient(token="t")
+        sleeps: list[float] = []
+        client._transport._sleep = sleeps.append
+        # A 503 on the PATCH must NOT be replayed (a write may have landed); the
+        # caller's raise_for_status then surfaces it.
+        fake = _fake_client([_status(503)])
+
+        with patch.object(client, "_client", return_value=fake), pytest.raises(httpx.HTTPStatusError):
+            client.update_page_status("pg", property_name="Status", value="Done")
+
+        assert fake.patch.call_count == 1
+        assert sleeps == []


### PR DESCRIPTION
refactor(backends): extract shared BoundedRetryTransport; add retry to sentry/notion/figma

The GitLab (http_client.py) and Slack (http.py) transports were
method-for-method the same bounded-retry machine. Extract it into
teatree.backends.http_retry.BoundedRetryTransport — one retry loop,
Retry-After handling, CONNECT/RESPONSE idempotency gating, and the
env-tunable knobs — parameterized on the two genuine deltas:

- _RAISE_FOR_STATUS_ON_RETURN: Slack raises on the returned response so a
  persistent 5xx surfaces as an exception; GitLab hands the raw response
  back for its status-inspecting callers.
- _is_transient_response override: Slack unions its ratelimited-body
  check onto the standard 5xx/429 classification via super().

Preserved deltas: GitLab's TTL response cache, Slack's ratelimit hook +
scope-cache guard. Behavior unchanged for both (~245 duplicated lines
collapsed) — full existing retry test suites stay green.

sentry.py, notion.py, figma.py used naked httpx.Client with ZERO retry —
the exact failure both transports' docstrings say broke a loop tick.
They now compose SimpleRetryTransport (env prefixes T3_SENTRY_HTTP /
T3_NOTION_HTTP / T3_FIGMA_HTTP): idempotent reads retry on transient
5xx/429/connect failures; Notion's status PATCH stays non-idempotent
(connect-only retry, never replayed after reaching Notion).