### PR TITLE
refactor(core): consolidate ticket state-sets onto Ticket classmethods (SSOT)

### DIFF
--- a/src/teatree/core/management/commands/_sweep_commands.py
+++ b/src/teatree/core/management/commands/_sweep_commands.py
@@ -58,12 +58,11 @@ class SweepCommands(TyperCommand):
         ``is_issue_done()`` for each, and transitions completed tickets toward
         delivered. Use ``--dry-run`` to preview without touching state.
         """
-        completable_states = frozenset({"shipped", "in_review", "merged"})
         results: list[CompletionResult] = []
 
         for overlay_name, overlay in get_all_overlays().items():
             tickets = Ticket.objects.filter(
-                state__in=completable_states,
+                state__in=Ticket.completable_states(),
                 overlay=overlay_name,
             ).exclude(issue_url="")
 

--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -107,13 +107,7 @@ class TicketQuerySet(models.QuerySet):
 
         return (
             self.for_overlay(overlay)
-            .exclude(
-                state__in=[
-                    ticket_model.State.DELIVERED,
-                    ticket_model.State.REVIEW_POSTED,
-                    ticket_model.State.IGNORED,
-                ],
-            )
+            .exclude(state__in=ticket_model.in_flight_excluded_states())
             .filter(Q(extra__tracker_status__isnull=True) | ~Q(extra__tracker_status="Done"))
             .order_by("pk")
         )
@@ -131,15 +125,7 @@ class WorktreeQuerySet(models.QuerySet):
         ticket_model = cast("type[Ticket]", apps.get_model("core", "Ticket"))
 
         return (
-            self.for_overlay(overlay)
-            .exclude(
-                ticket__state__in=[
-                    ticket_model.State.DELIVERED,
-                    ticket_model.State.REVIEW_POSTED,
-                    ticket_model.State.IGNORED,
-                ],
-            )
-            .order_by("pk")
+            self.for_overlay(overlay).exclude(ticket__state__in=ticket_model.in_flight_excluded_states()).order_by("pk")
         )
 
     def stamp_e2e_run(self, ticket_pk: int, *, now: datetime | None = None) -> int:

--- a/src/teatree/core/models/ticket.py
+++ b/src/teatree/core/models/ticket.py
@@ -15,6 +15,7 @@ from teatree.core.models.ticket_number import derive_issue_number
 from teatree.core.models.ticket_overlay import TicketOverlayModel
 from teatree.core.models.ticket_phase_sessions import TicketPhaseSessionModel
 from teatree.core.models.ticket_scheduling import TicketSchedulingModel
+from teatree.core.models.ticket_state_sets import TicketStateSetsModel
 from teatree.core.models.ticket_status import TicketStatusModel
 from teatree.utils.url_slug import repo_namespaced_key as compute_repo_namespaced_key
 
@@ -43,6 +44,7 @@ class Ticket(
     TicketSchedulingModel,
     TicketEvidenceModel,
     TicketStatusModel,
+    TicketStateSetsModel,
     TicketIntrospectionModel,
 ):
     class State(models.TextChoices):
@@ -191,16 +193,6 @@ class Ticket(
                 condition=~models.Q(repo_namespaced_key=""),
             ),
         ]
-
-    @classmethod
-    def marker_release_states(cls) -> frozenset[str]:
-        """Terminal-done states that free markers and trigger worktree teardown.
-
-        ``_TERMINAL_STATES`` minus SHIPPED (its PR is still open). Shared by the
-        teardown/marker signal and the #3275 reconciler; REVIEW_POSTED is the
-        reviewer terminal (marker release is a no-op for reviewer tickets).
-        """
-        return frozenset({cls.State.MERGED, cls.State.DELIVERED, cls.State.REVIEW_POSTED, cls.State.IGNORED})
 
     def __str__(self) -> str:
         return str(self.issue_url or f"ticket-{self.pk}")

--- a/src/teatree/core/models/ticket_state_sets.py
+++ b/src/teatree/core/models/ticket_state_sets.py
@@ -1,0 +1,59 @@
+from teatree.core.models.ticket_data import TicketFacet
+
+
+class TicketStateSetsModel(TicketFacet):
+    """The canonical ticket state-set classmethods — the SSOT the loop reads.
+
+    Every scanner, manager, and sweep that needs "which states count as done /
+    in-flight / completable / merged" reads these instead of re-hand-rolling the
+    set (the raw-string drift class behind #798/#799/#808). Each returns an
+    immutable ``frozenset`` of ``State`` values; membership is pinned by
+    ``tests/teatree_core/models/test_ticket.py::TestTicketStateSets``.
+    """
+
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def marker_release_states(cls) -> frozenset[str]:
+        """Terminal-done states that free markers and trigger worktree teardown.
+
+        ``_TERMINAL_STATES`` minus SHIPPED (its PR is still open). Shared by the
+        teardown/marker signal and the #3275 reconciler; REVIEW_POSTED is the
+        reviewer terminal (marker release is a no-op for reviewer tickets).
+        """
+        return frozenset({cls.State.MERGED, cls.State.DELIVERED, cls.State.REVIEW_POSTED, cls.State.IGNORED})
+
+    @classmethod
+    def in_flight_excluded_states(cls) -> frozenset[str]:
+        """States that drop a ticket OUT of the in-flight working set.
+
+        ``marker_release_states()`` minus MERGED: a merged-but-not-yet-delivered
+        ticket's PR has landed, but the ticket is still in flight (retro/delivery
+        pending) so it stays on the board. The in-flight queryset, the dashboard
+        worktrees panel, and both active-ticket scanners (primary ORM + external
+        SQLite) ``exclude(state__in=...)`` on exactly this set.
+        """
+        return frozenset({cls.State.DELIVERED, cls.State.REVIEW_POSTED, cls.State.IGNORED})
+
+    @classmethod
+    def completable_states(cls) -> frozenset[str]:
+        """Post-ship states a completion sweep may advance toward DELIVERED.
+
+        SHIPPED (PR open), IN_REVIEW (review requested), MERGED (PR landed) — the
+        states worth polling ``is_issue_done()`` on before driving the ticket to
+        delivered. Read by the completion scanner and the ``sync-completions`` sweep.
+        """
+        return frozenset({cls.State.SHIPPED, cls.State.IN_REVIEW, cls.State.MERGED})
+
+    @classmethod
+    def merged_states(cls) -> frozenset[str]:
+        """States that mean the ticket's PR has landed (merged-or-past).
+
+        MERGED (just landed) plus the RETROSPECTED/DELIVERED post-merge lifecycle.
+        The outer- and directive-loop liveness guards and the issue-disposition
+        dedup read this to tell a landed ticket from one whose PR is still open.
+        Narrower than an "after-merge trigger" set that excludes RETROSPECTED —
+        that lives at its own call site on purpose.
+        """
+        return frozenset({cls.State.MERGED, cls.State.RETROSPECTED, cls.State.DELIVERED})

--- a/src/teatree/core/worktree/worktree_done.py
+++ b/src/teatree/core/worktree/worktree_done.py
@@ -61,9 +61,9 @@ logger = logging.getLogger(__name__)
 # Terminal ticket states that authorise teardown. SHIPPED is excluded on purpose
 # — a shipped ticket still has an OPEN PR, so the work is not finished.
 # REVIEW_POSTED (reviewer terminal) is included so a reviewer worktree is reaped.
-_DONE_TICKET_STATES = frozenset(
-    {Ticket.State.MERGED, Ticket.State.DELIVERED, Ticket.State.REVIEW_POSTED, Ticket.State.IGNORED},
-)
+# The canonical set lives on the model so the teardown signal (``core.signals``)
+# and this reaper can never diverge on which states are terminal.
+_DONE_TICKET_STATES = Ticket.marker_release_states()
 
 _PREVIEW_LIMIT = 3
 _FALLBACK_DEFAULT_TARGET = "origin/main"

--- a/src/teatree/loop/scanners/active_tickets.py
+++ b/src/teatree/loop/scanners/active_tickets.py
@@ -38,8 +38,6 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from teatree.core.models import Ticket
 
-_TERMINAL_STATES: frozenset[str] = frozenset({"delivered", "review_posted", "ignored"})
-
 #: How many ``short_describe`` tasks this scanner may enqueue for one ticket before
 #: giving up on it permanently. Three covers a transient failure of the one-shot turn
 #: (timeout, backend blip); past that the write path is broken rather than unlucky,
@@ -59,7 +57,7 @@ class ActiveTicketsScanner:
 
     def scan(self) -> list[ScanSignal]:
         ticket_model = cast("type[Ticket]", apps.get_model("core", "Ticket"))
-        qs = ticket_model.objects.exclude(state__in=_TERMINAL_STATES).order_by("id")
+        qs = ticket_model.objects.exclude(state__in=ticket_model.in_flight_excluded_states()).order_by("id")
         if self.overlay_name:
             qs = qs.filter(overlay=self.overlay_name)
         signals: list[ScanSignal] = []

--- a/src/teatree/loop/scanners/external_tickets.py
+++ b/src/teatree/loop/scanners/external_tickets.py
@@ -9,14 +9,21 @@ import logging
 import sqlite3
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+from django.apps import apps
 
 from teatree.loop.scanners.base import ScanSignal
 
+if TYPE_CHECKING:
+    from teatree.core.models.ticket import Ticket
+
 logger = logging.getLogger(__name__)
 
-_TERMINAL_STATES = ("delivered", "review_posted", "ignored")
-_PLACEHOLDERS = ", ".join("?" for _ in _TERMINAL_STATES)
-_QUERY = f"SELECT id, state, issue_url, overlay FROM teatree_ticket WHERE state NOT IN ({_PLACEHOLDERS}) ORDER BY id"  # noqa: S608 — literal placeholder count, no user input
+# Placeholder count is filled per-scan from the enum-sourced excluded set.
+_QUERY_TEMPLATE = (
+    "SELECT id, state, issue_url, overlay FROM teatree_ticket WHERE state NOT IN ({placeholders}) ORDER BY id"
+)
 
 
 @dataclass(slots=True)
@@ -31,10 +38,18 @@ class ExternalTicketsScanner:
     def scan(self) -> list[ScanSignal]:
         if not self.db_path.is_file():
             return []
+        # Enum-sourced (not raw strings) so this raw-SQLite reader excludes exactly
+        # the states the ORM in-flight queryset does. ``apps.get_model`` yields the
+        # values only — no ORM query/connection — so the "reads external DBs
+        # directly" contract holds; sorted for a stable placeholder order.
+        ticket_model = cast("type[Ticket]", apps.get_model("core", "Ticket"))
+        excluded = tuple(sorted(ticket_model.in_flight_excluded_states()))
+        placeholders = ", ".join("?" for _ in excluded)
+        query = _QUERY_TEMPLATE.format(placeholders=placeholders)
         try:
             conn = sqlite3.connect(f"file:{self.db_path}?mode=ro", uri=True)
             try:
-                rows = conn.execute(_QUERY, _TERMINAL_STATES).fetchall()
+                rows = conn.execute(query, excluded).fetchall()
             finally:
                 conn.close()
         except (sqlite3.OperationalError, sqlite3.DatabaseError) as exc:

--- a/src/teatree/loop/scanners/issue_disposition.py
+++ b/src/teatree/loop/scanners/issue_disposition.py
@@ -44,7 +44,6 @@ logger = logging.getLogger(__name__)
 
 CLOSE_CANDIDATE_KIND = "issue_disposition.close_candidate"
 
-_DELIVERED_TICKET_STATES: frozenset[str] = frozenset({"merged", "delivered", "retrospected"})
 _LIVE_TICKET_STATES: frozenset[str] = frozenset(
     {"not_started", "scoped", "started", "planned", "coded", "tested", "reviewed", "in_review", "shipped"}
 )
@@ -148,7 +147,7 @@ class IssueDispositionScanner:
         states = set(ticket_model.objects.filter(issue_url=url).values_list("state", flat=True))
         if states & _LIVE_TICKET_STATES:
             return ""
-        return "already_shipped" if states & _DELIVERED_TICKET_STATES else ""
+        return "already_shipped" if states & ticket_model.merged_states() else ""
 
     def _exact_duplicate_reason(self, url: str, title: str) -> str:
         fingerprint = title_fingerprint(title)

--- a/src/teatree/loop/scanners/ticket_completion.py
+++ b/src/teatree/loop/scanners/ticket_completion.py
@@ -39,9 +39,6 @@ def _has_draft_mrs(ticket: "Ticket") -> bool:
     return any(isinstance(mr, dict) and mr.get("draft") for mr in mrs.values())
 
 
-_COMPLETABLE_STATES: frozenset[str] = frozenset({"shipped", "in_review", "merged"})
-
-
 @dataclass(slots=True)
 class TicketCompletionScanner:
     """Yield ``ticket.completion_detected`` for post-ship tickets whose issue is done."""
@@ -97,7 +94,7 @@ class TicketCompletionScanner:
 
     def _candidate_tickets(self) -> Iterable["Ticket"]:
         ticket_model = cast("type[Ticket]", apps.get_model("core", "Ticket"))
-        qs = ticket_model.objects.filter(state__in=_COMPLETABLE_STATES).exclude(issue_url="")
+        qs = ticket_model.objects.filter(state__in=ticket_model.completable_states()).exclude(issue_url="")
         if self.overlay_name:
             qs = qs.filter(overlay=self.overlay_name)
         return qs.only("id", "issue_url", "state", "overlay")

--- a/src/teatree/loop/self_improve/detectors/stale_statusline.py
+++ b/src/teatree/loop/self_improve/detectors/stale_statusline.py
@@ -32,9 +32,7 @@ from teatree.loop.statusline_render import default_path
 # plain form between the escape sequences).
 _URL_RE = re.compile(r"https?://[^\s\x1b\\]+")
 
-_TERMINAL_TICKET_STATES = frozenset(
-    {Ticket.State.MERGED, Ticket.State.DELIVERED, Ticket.State.REVIEW_POSTED, Ticket.State.IGNORED},
-)
+_TERMINAL_TICKET_STATES = Ticket.marker_release_states()
 
 
 def _default_statusline_reader() -> str:

--- a/src/teatree/loops/directive_loop/tick.py
+++ b/src/teatree/loops/directive_loop/tick.py
@@ -102,9 +102,8 @@ class DirectiveTickResult:
 
 def _ticket_merged(directive: Directive) -> bool:
     """Whether the directive's mechanism ticket has reached a merged-or-past state."""
-    merged_states = {Ticket.State.MERGED, Ticket.State.RETROSPECTED, Ticket.State.DELIVERED}
     ticket = directive.ticket
-    return ticket is not None and ticket.state in merged_states
+    return ticket is not None and ticket.state in Ticket.merged_states()
 
 
 def _is_activation_only(directive: Directive) -> bool:

--- a/src/teatree/loops/outer_loop/tick.py
+++ b/src/teatree/loops/outer_loop/tick.py
@@ -55,9 +55,8 @@ class OuterLoopTickResult:
 
 def _ticket_merged(experiment: OuterLoopExperiment) -> bool:
     """Whether the experiment's synthetic ticket has reached a merged-or-past state."""
-    merged_states = {Ticket.State.MERGED, Ticket.State.RETROSPECTED, Ticket.State.DELIVERED}
     ticket = experiment.ticket
-    return ticket is not None and ticket.state in merged_states
+    return ticket is not None and ticket.state in Ticket.merged_states()
 
 
 def run_tick(

--- a/tests/teatree_core/models/test_ticket.py
+++ b/tests/teatree_core/models/test_ticket.py
@@ -11,6 +11,7 @@ import pytest
 from django.test import TestCase
 
 from teatree.core.models import E2eMandatoryRun, PlanArtifact, Session, Task, TaskAttempt, Ticket, Worktree
+from teatree.core.models.ticket_state_sets import TicketStateSetsModel
 from teatree.core.models.ticket_worktree_checks import WorktreeProbeUnverifiableError
 from tests.teatree_core.models._shared import (
     _advance_started_to_planned,
@@ -611,3 +612,56 @@ class TestHasCompletedPhase(TestCase):
         # the safe answer that escalates rather than silently retiring a live task.
         assert Ticket.objects.create(state=Ticket.State.TESTED).has_completed_phase("bughunt") is False
         assert Ticket.objects.create(state=Ticket.State.IN_REVIEW).has_completed_phase("coding") is False
+
+
+class TestTicketStateSets(TestCase):
+    """The canonical ticket state-set classmethods — the SSOT the scanners/managers read.
+
+    ~10 sites used to re-hand-roll these sets (some as raw strings that bypass the
+    enum), the drift class behind #798/#799/#808. Each classmethod is pinned to its
+    exact intended membership so any future edit that changes a set breaks HERE, and
+    every member is asserted to be a real ``State`` so a rename can't silently rot.
+    """
+
+    def test_sets_live_on_the_composed_facet(self) -> None:
+        # The SSOT is the field-less TicketStateSetsModel facet, reachable as a
+        # Ticket classmethod via composition — not re-defined on the concrete model.
+        assert issubclass(Ticket, TicketStateSetsModel)
+        assert Ticket.merged_states.__func__ is TicketStateSetsModel.merged_states.__func__
+
+    def test_marker_release_states_membership(self) -> None:
+        assert Ticket.marker_release_states() == frozenset(
+            {Ticket.State.MERGED, Ticket.State.DELIVERED, Ticket.State.REVIEW_POSTED, Ticket.State.IGNORED},
+        )
+
+    def test_in_flight_excluded_states_membership(self) -> None:
+        assert Ticket.in_flight_excluded_states() == frozenset(
+            {Ticket.State.DELIVERED, Ticket.State.REVIEW_POSTED, Ticket.State.IGNORED},
+        )
+
+    def test_in_flight_excluded_is_marker_release_minus_merged(self) -> None:
+        # The invariant the docstring names: a MERGED ticket's PR has landed but the
+        # ticket is still in flight (retro/delivery pending), so it stays on the board.
+        assert Ticket.in_flight_excluded_states() == Ticket.marker_release_states() - {Ticket.State.MERGED}
+
+    def test_completable_states_membership(self) -> None:
+        assert Ticket.completable_states() == frozenset(
+            {Ticket.State.SHIPPED, Ticket.State.IN_REVIEW, Ticket.State.MERGED},
+        )
+
+    def test_merged_states_membership(self) -> None:
+        assert Ticket.merged_states() == frozenset(
+            {Ticket.State.MERGED, Ticket.State.RETROSPECTED, Ticket.State.DELIVERED},
+        )
+
+    def test_every_set_member_is_a_real_state(self) -> None:
+        valid = set(Ticket.State.values)
+        for name in (
+            "marker_release_states",
+            "in_flight_excluded_states",
+            "completable_states",
+            "merged_states",
+        ):
+            states = getattr(Ticket, name)()
+            assert isinstance(states, frozenset), f"{name} must return an immutable frozenset"
+            assert states <= valid, f"{name} has non-State members: {states - valid}"


### PR DESCRIPTION
refactor(core): consolidate ticket state-sets onto Ticket classmethods (SSOT)

~10 sites re-hand-rolled ticket-state sets (some as raw strings that bypass
the State enum) — the drift class behind #798/#799/#808. Move the canonical
sets onto a cohesive TicketStateSetsModel facet and route every consumer
through the classmethods.

Classmethods (on new src/teatree/core/models/ticket_state_sets.py facet):
- marker_release_states()      {MERGED, DELIVERED, REVIEW_POSTED, IGNORED}  (moved off Ticket)
- in_flight_excluded_states()  {DELIVERED, REVIEW_POSTED, IGNORED}          (= marker_release - MERGED)
- completable_states()         {SHIPPED, IN_REVIEW, MERGED}
- merged_states()              {MERGED, RETROSPECTED, DELIVERED}

Collapsed consumers:
- marker_release_states(): worktree_done._DONE_TICKET_STATES, stale_statusline._TERMINAL_TICKET_STATES
- in_flight_excluded_states(): managers in_flight/active, active_tickets + external_tickets scanners (raw strings -> enum)
- completable_states(): ticket_completion scanner, sync-completions sweep
- merged_states(): outer_loop/directive_loop liveness guards, issue_disposition dedup (raw strings -> enum)

Housing the four classmethods on a field-less abstract facet (not the concrete
Ticket) keeps Ticket under the 25-public-method composition cap and puts all
state-set SSOT in one self-documenting module.

Deliberately NOT collapsed (distinct membership — behavior preserved):
- dash/selectors.HIDDEN_STATES {IGNORED, REVIEW_POSTED} (kanban-conformance-pinned)
- architectural_review._MERGED_STATES {merged, delivered} (after-merge trigger, excludes RETROSPECTED)
- review_candidate._MERGED_STATES ('merged',) (MR forge state, not a Ticket FSM state)

Parity/completeness test pins each set's exact membership + the
in_flight = marker_release - MERGED invariant.