### PR TITLE
refactor(cli): route remaining commands through the emit() machine-output seam

### DIFF
--- a/src/teatree/core/management/commands/handover.py
+++ b/src/teatree/core/management/commands/handover.py
@@ -11,15 +11,15 @@ ORM access is here (a management command, not a plain typer command) per
 the project's "anything touching the ORM is a management command" rule.
 """
 
-import json
 from pathlib import Path
-from typing import Annotated
+from typing import IO, Annotated, cast
 
 import typer
 from django_typer.management import TyperCommand, command, initialize
 
 from teatree.core.handover import claim_handovers, create_handover
 from teatree.core.handover_orchestration import SubagentPush, drive_subagents_to_fast_push
+from teatree.core.machine_output import emit
 from teatree.loop.session_identity import current_session_id
 
 
@@ -59,10 +59,13 @@ class Command(TyperCommand):
         from_session = current_session_id()
         if not from_session:
             msg = "no Claude session id — run inside a Claude Code session to hand off its state"
-            if json_output:
-                self.stdout.write(json.dumps({"ok": False, "error": msg}, indent=2))
-            else:
-                self.stdout.write(f"ERROR  {msg}")
+            emit(
+                {"ok": False, "error": msg},
+                json_output=json_output,
+                out=cast("IO[str]", self.stdout),
+                err=cast("IO[str]", self.stderr),
+                human=f"ERROR  {msg}",
+            )
             raise SystemExit(2)
 
         handover, mirror = create_handover(from_session=from_session, explicit_to=to)
@@ -72,26 +75,24 @@ class Command(TyperCommand):
         # that fails: the operator moves on believing state was carried over, and
         # the receiving session claims a row with nothing in it (#3551).
         empty = not handover.payload.strip()
-        if json_output:
-            self.stdout.write(
-                json.dumps(
-                    {
-                        "ok": not empty,
-                        "empty_payload": empty,
-                        "from_session": handover.from_session,
-                        "to_session": handover.to_session,
-                        "parked_for_next": handover.is_for_next_session,
-                        "mirror_path": str(mirror),
-                        "subagent_pushes": [self._push_json(push) for push in pushes],
-                    },
-                    indent=2,
-                )
-            )
-        else:
-            status = "WARN " if empty else "OK   "
-            self.stdout.write(f"{status} handed off to {recipient}; mirror written to {mirror}.")
-            for push in pushes:
-                self.stdout.write(f"      sub-agent {push.branch}: {self._push_summary(push)}")
+        status = "WARN " if empty else "OK   "
+        human_lines = [f"{status} handed off to {recipient}; mirror written to {mirror}."]
+        human_lines += [f"      sub-agent {push.branch}: {self._push_summary(push)}" for push in pushes]
+        emit(
+            {
+                "ok": not empty,
+                "empty_payload": empty,
+                "from_session": handover.from_session,
+                "to_session": handover.to_session,
+                "parked_for_next": handover.is_for_next_session,
+                "mirror_path": str(mirror),
+                "subagent_pushes": [self._push_json(push) for push in pushes],
+            },
+            json_output=json_output,
+            out=cast("IO[str]", self.stdout),
+            err=cast("IO[str]", self.stderr),
+            human="\n".join(human_lines),
+        )
         if empty:
             self.stderr.write(
                 f"ERROR hand-off {handover.pk} carries NO durable state — no PreCompact snapshot for session "
@@ -145,12 +146,13 @@ class Command(TyperCommand):
     ) -> None:
         """Print this Claude session's own id (the hand-off ``--to`` target)."""
         session_id = current_session_id()
-        if json_output:
-            self.stdout.write(json.dumps({"session_id": session_id}, indent=2))
-        elif session_id:
-            self.stdout.write(session_id)
-        else:
-            self.stdout.write("(no Claude session id — not running inside a Claude Code session)")
+        emit(
+            {"session_id": session_id},
+            json_output=json_output,
+            out=cast("IO[str]", self.stdout),
+            err=cast("IO[str]", self.stderr),
+            human=session_id or "(no Claude session id — not running inside a Claude Code session)",
+        )
 
     @command(name="claim-on-start")
     def claim_on_start(
@@ -167,9 +169,10 @@ class Command(TyperCommand):
         prints the payload. Empty payload when nothing is claimable.
         """
         payload, origin = claim_handovers(session or current_session_id())
-        if json_output:
-            self.stdout.write(
-                json.dumps({"claimed": bool(payload), "from_session": origin, "payload": payload}, indent=2)
-            )
-        elif payload:
-            self.stdout.write(payload)
+        emit(
+            {"claimed": bool(payload), "from_session": origin, "payload": payload},
+            json_output=json_output,
+            out=cast("IO[str]", self.stdout),
+            err=cast("IO[str]", self.stderr),
+            human=payload or None,
+        )

--- a/src/teatree/core/management/commands/loop_dispatch.py
+++ b/src/teatree/core/management/commands/loop_dispatch.py
@@ -8,9 +8,8 @@ each via ``spawn-claim`` so the next tick doesn't see them as pending.
 """
 
 import contextlib
-import json
 import logging
-from typing import Annotated, Any
+from typing import IO, Annotated, Any, cast
 
 import typer
 from django.core.exceptions import ObjectDoesNotExist
@@ -18,6 +17,7 @@ from django.db.models import Q
 from django_typer.management import TyperCommand, command
 
 from teatree.config import cadence_seconds
+from teatree.core.machine_output import emit
 from teatree.core.modelkit.phases import resolve_fanout_directive, subagent_for_phase
 from teatree.core.models import Task
 from teatree.core.models.ticket_worktree_checks import dispatch_worktree_path
@@ -259,17 +259,21 @@ class Command(TyperCommand):
                 .order_by("pk")
             )
             payload = [_task_to_dict(task) for task in pending]
-        if json_output:
-            self.stdout.write(json.dumps(payload, indent=2))
-            return
         if not payload:
-            self.stdout.write("No pending spawn requests.")
-            return
-        for entry in payload:
-            self.stdout.write(
+            human: str | None = "No pending spawn requests."
+        else:
+            human = "\n".join(
                 f"task={entry['task_id']:<5} subagent={entry['subagent']:<18} "
-                f"phase={entry['phase']:<10} url={entry['issue_url']}",
+                f"phase={entry['phase']:<10} url={entry['issue_url']}"
+                for entry in payload
             )
+        emit(
+            payload,
+            json_output=json_output,
+            out=cast("IO[str]", self.stdout),
+            err=cast("IO[str]", self.stderr),
+            human=human,
+        )
 
     @command(name="claim-next")
     def claim_next(
@@ -346,16 +350,20 @@ class Command(TyperCommand):
             )
         payload: list[dict[str, Any]] = [_task_to_dict(task)] if task is not None else []
 
-        if json_output:
-            self.stdout.write(json.dumps(payload, indent=2))
-            return
         if not payload:
-            self.stdout.write("No pending spawn requests.")
-            return
-        entry = payload[0]
-        self.stdout.write(
-            f"Claimed task={entry['task_id']} subagent={entry['subagent']} "
-            f"phase={entry['phase']} url={entry['issue_url']}",
+            human: str | None = "No pending spawn requests."
+        else:
+            entry = payload[0]
+            human = (
+                f"Claimed task={entry['task_id']} subagent={entry['subagent']} "
+                f"phase={entry['phase']} url={entry['issue_url']}"
+            )
+        emit(
+            payload,
+            json_output=json_output,
+            out=cast("IO[str]", self.stdout),
+            err=cast("IO[str]", self.stderr),
+            human=human,
         )
 
     @command(name="spawn-claim")

--- a/src/teatree/core/management/commands/loop_drain_queue.py
+++ b/src/teatree/core/management/commands/loop_drain_queue.py
@@ -16,12 +16,13 @@ live worker for the same rows.
 """
 
 import datetime as dt
-import json
 import os
-from typing import Annotated
+from typing import IO, Annotated, cast
 
 import typer
 from django_typer.management import TyperCommand
+
+from teatree.core.machine_output import emit
 
 
 class Command(TyperCommand):
@@ -35,31 +36,34 @@ class Command(TyperCommand):
         from teatree.core.models import LoopLease  # noqa: PLC0415 — deferred: ORM import needs the app registry
         from teatree.loop.queue_drain import expire_then_drain  # noqa: PLC0415 — deferred: keeps command import light
 
+        out = cast("IO[str]", self.stdout)
+        err = cast("IO[str]", self.stderr)
         owner = f"pid-{os.getpid()}"
         if not LoopLease.objects.acquire("loop-drain-queue", owner=owner):
             now = dt.datetime.now(tz=dt.UTC)
-            if json_output:
-                self.stdout.write(
-                    json.dumps(
-                        {
-                            "skipped": True,
-                            "skipped_reason": "another drain cycle is already running",
-                            "started_at": now.isoformat(),
-                        },
-                        indent=2,
-                    )
-                )
-            else:
-                self.stdout.write("SKIP  loop-drain-queue lease held — another cycle is running.")
+            emit(
+                {
+                    "skipped": True,
+                    "skipped_reason": "another drain cycle is already running",
+                    "started_at": now.isoformat(),
+                },
+                json_output=json_output,
+                out=out,
+                err=err,
+                human="SKIP  loop-drain-queue lease held — another cycle is running.",
+            )
             return
         try:
             result = expire_then_drain()
         finally:
             LoopLease.objects.release("loop-drain-queue", owner=owner)
 
-        if json_output:
-            self.stdout.write(json.dumps(result, indent=2, default=str))
-            return
         retired = result["retired"]
         retired_total = sum(retired.values()) if isinstance(retired, dict) else 0
-        self.stdout.write(f"OK    retired={retired_total} drained={result['drained']}")
+        emit(
+            result,
+            json_output=json_output,
+            out=out,
+            err=err,
+            human=f"OK    retired={retired_total} drained={result['drained']}",
+        )

--- a/src/teatree/core/management/commands/loop_owner.py
+++ b/src/teatree/core/management/commands/loop_owner.py
@@ -20,12 +20,12 @@ durable registry instead of hard-refusing. The refusal still fires only
 when there is genuinely no resolvable session id anywhere.
 """
 
-import json
-from collections.abc import Callable
-from typing import Annotated
+from typing import IO, Annotated, cast
 
 import typer
 from django_typer.management import TyperCommand, command
+
+from teatree.core.machine_output import emit
 
 
 def _refresh_loop_owner_statusline() -> None:
@@ -74,22 +74,17 @@ def _claim(command: TyperCommand, slot: str, *, take_over: bool, driver: str, js
         current_session_pid,
     )
 
-    stdout_write = command.stdout.write
+    out = cast("IO[str]", command.stdout)
+    err = cast("IO[str]", command.stderr)
     stderr_write = command.stderr.write
     if driver and driver not in LoopDriver.values:
         msg = f"invalid --driver {driver!r} — must be one of: {', '.join(LoopDriver.values)}"
-        if json_output:
-            stdout_write(json.dumps({"ok": False, "error": msg}, indent=2))
-        else:
-            stdout_write(f"ERROR  {msg}")
+        emit({"ok": False, "error": msg}, json_output=json_output, out=out, err=err, human=f"ERROR  {msg}")
         raise SystemExit(2)
     session_id = current_session_id()
     if not session_id:
         msg = "refusing to claim loop ownership without a Claude session id — run inside a Claude Code session"
-        if json_output:
-            stdout_write(json.dumps({"ok": False, "error": msg}, indent=2))
-        else:
-            stdout_write(f"ERROR  {msg}")
+        emit({"ok": False, "error": msg}, json_output=json_output, out=out, err=err, human=f"ERROR  {msg}")
         raise SystemExit(2)
     # Record the durable SESSION pid for the ``t3-master`` slot — and for a
     # per-loop ``loop:<name>`` owner (#1834), which is a persistent
@@ -120,24 +115,25 @@ def _claim(command: TyperCommand, slot: str, *, take_over: bool, driver: str, js
         # anchor the rendered statusline still carries from before the claim.
         _refresh_loop_owner_statusline()
     driverless = pid_anchored and not resolved_driver
-    if json_output:
-        stdout_write(
-            json.dumps(
-                {"ok": won, "slot": slot, "owner_session": owner, "driver": resolved_driver, "driverless": driverless},
-                indent=2,
-            )
-        )
-    elif won:
-        stdout_write(f"OK    claimed loop slot {slot!r} for this session ({session_id}).")
-    else:
-        stdout_write(f"SKIP  loop slot {slot!r} held by session {owner} — pass --take-over to seize it.")
+    human = (
+        f"OK    claimed loop slot {slot!r} for this session ({session_id})."
+        if won
+        else f"SKIP  loop slot {slot!r} held by session {owner} — pass --take-over to seize it."
+    )
+    emit(
+        {"ok": won, "slot": slot, "owner_session": owner, "driver": resolved_driver, "driverless": driverless},
+        json_output=json_output,
+        out=out,
+        err=err,
+        human=human,
+    )
     # A successful pid-anchored claim with no driver is a silently-stalled loop —
     # warn loudly (stderr) even though the claim itself succeeded.
     if won and driverless:
         stderr_write(_DRIVERLESS_WARNING.format(slot=slot))
 
 
-def _owner(slot: str, *, json_output: bool, stdout_write: Callable[[str], object]) -> None:
+def _owner(command: TyperCommand, slot: str, *, json_output: bool) -> None:
     from teatree.core.models import LoopLease  # noqa: PLC0415 — deferred: ORM import needs the app registry
     from teatree.loop.session_identity import current_session_id  # noqa: PLC0415 — deferred: keeps command import light
 
@@ -146,61 +142,73 @@ def _owner(slot: str, *, json_output: bool, stdout_write: Callable[[str], object
     you = current_session_id()
     status = LoopLease.objects.ownership_status(slot)
     driverless = status.is_live and not status.driver
-    if json_output:
-        stdout_write(
-            json.dumps(
-                {
-                    "slot": slot,
-                    "you": you,
-                    "owner_session": status.owner_session,
-                    "you_are_owner": bool(you) and status.is_live and you == status.owner_session,
-                    "expires_at": status.expires_at.isoformat() if status.expires_at else "",
-                    "is_live": status.is_live,
-                    "generation": status.generation,
-                    "driver": status.driver,
-                    "driverless": driverless,
-                },
-                indent=2,
+    human_lines = [f"you are: {you or '(no session id)'}"]
+    if status.is_live:
+        human_lines.extend(
+            (
+                f"OWNER {slot}: session {status.owner_session} (live until {status.expires_at.isoformat()}).",
+                f"driver: {status.driver or 'DRIVERLESS'}",
             )
         )
-        return
-    stdout_write(f"you are: {you or '(no session id)'}")
-    if status.is_live:
-        stdout_write(f"OWNER {slot}: session {status.owner_session} (live until {status.expires_at.isoformat()}).")
-        stdout_write(f"driver: {status.driver or 'DRIVERLESS'}")
     else:
-        stdout_write(f"OWNER {slot}: unclaimed (no live owner).")
+        human_lines.append(f"OWNER {slot}: unclaimed (no live owner).")
+    emit(
+        {
+            "slot": slot,
+            "you": you,
+            "owner_session": status.owner_session,
+            "you_are_owner": bool(you) and status.is_live and you == status.owner_session,
+            "expires_at": status.expires_at.isoformat() if status.expires_at else "",
+            "is_live": status.is_live,
+            "generation": status.generation,
+            "driver": status.driver,
+            "driverless": driverless,
+        },
+        json_output=json_output,
+        out=cast("IO[str]", command.stdout),
+        err=cast("IO[str]", command.stderr),
+        human="\n".join(human_lines),
+    )
 
 
-def _whoami(*, json_output: bool, stdout_write: Callable[[str], object]) -> None:
+def _whoami(command: TyperCommand, *, json_output: bool) -> None:
     """Print this Claude session's own id — the hand-off ``--to`` target."""
     from teatree.loop.driver_detection import detect_driver  # noqa: PLC0415 — deferred
     from teatree.loop.session_identity import current_session_id  # noqa: PLC0415 — deferred: keeps command import light
 
     session_id = current_session_id()
     driver = detect_driver(session_id)
-    if json_output:
-        stdout_write(json.dumps({"session_id": session_id, "driver": driver, "driverless": not driver}, indent=2))
-        return
     if session_id:
-        stdout_write(session_id)
-        stdout_write(f"driver: {driver or 'DRIVERLESS'}")
+        human = f"{session_id}\ndriver: {driver or 'DRIVERLESS'}"
     else:
-        stdout_write("(no Claude session id — not running inside a Claude Code session)")
+        human = "(no Claude session id — not running inside a Claude Code session)"
+    emit(
+        {"session_id": session_id, "driver": driver, "driverless": not driver},
+        json_output=json_output,
+        out=cast("IO[str]", command.stdout),
+        err=cast("IO[str]", command.stderr),
+        human=human,
+    )
 
 
-def _release(slot: str, *, json_output: bool, stdout_write: Callable[[str], object]) -> None:
+def _release(command: TyperCommand, slot: str, *, json_output: bool) -> None:
     from teatree.core.models import LoopLease  # noqa: PLC0415 — deferred: ORM import needs the app registry
     from teatree.loop.session_identity import current_session_id  # noqa: PLC0415 — deferred: keeps command import light
 
     session_id = current_session_id()
     released = LoopLease.objects.release_ownership(slot, session_id=session_id)
-    if json_output:
-        stdout_write(json.dumps({"ok": released, "slot": slot}, indent=2))
-    elif released:
-        stdout_write(f"OK    released loop slot {slot!r} (was held by this session).")
-    else:
-        stdout_write(f"NOOP  this session does not hold loop slot {slot!r} — nothing released.")
+    human = (
+        f"OK    released loop slot {slot!r} (was held by this session)."
+        if released
+        else f"NOOP  this session does not hold loop slot {slot!r} — nothing released."
+    )
+    emit(
+        {"ok": released, "slot": slot},
+        json_output=json_output,
+        out=cast("IO[str]", command.stdout),
+        err=cast("IO[str]", command.stderr),
+        human=human,
+    )
 
 
 class Command(TyperCommand):
@@ -239,7 +247,7 @@ class Command(TyperCommand):
         json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
     ) -> None:
         """Show which session owns the t3-master slot."""
-        _owner(slot, json_output=json_output, stdout_write=self.stdout.write)
+        _owner(self, slot, json_output=json_output)
 
     @command(name="whoami")
     def whoami(
@@ -248,7 +256,7 @@ class Command(TyperCommand):
         json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
     ) -> None:
         """Print this Claude session's own id."""
-        _whoami(json_output=json_output, stdout_write=self.stdout.write)
+        _whoami(self, json_output=json_output)
 
     @command(name="release")
     def release(
@@ -258,4 +266,4 @@ class Command(TyperCommand):
         json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
     ) -> None:
         """Release this session's t3-master claim (CAS — non-owner is a no-op)."""
-        _release(slot, json_output=json_output, stdout_write=self.stdout.write)
+        _release(self, slot, json_output=json_output)

--- a/src/teatree/core/management/commands/loop_preset.py
+++ b/src/teatree/core/management/commands/loop_preset.py
@@ -8,14 +8,14 @@ project's "anything touching the ORM is a management command" rule).
 """
 
 import datetime as dt
-import json
 import re
-from typing import Annotated, Any, NoReturn
+from typing import IO, Annotated, Any, NoReturn, cast
 
 import typer
 from django.utils import timezone
 from django_typer.management import TyperCommand, command
 
+from teatree.core.machine_output import emit
 from teatree.core.models import PIN_MODES, Loop, Mode, ModeOverride
 from teatree.loop.preset_resolution import next_boundary
 from teatree.loops.preset_editing import apply_entry_edits
@@ -60,21 +60,20 @@ class Command(TyperCommand):
         active = active_summary()
         active_name = active.name if active is not None else ""
         presets = list(Mode.objects.all())
-        if json_output:
-            payload = [_preset_row(preset, active_name) for preset in presets]
-            self.stdout.write(json.dumps({"active": active_name, "presets": payload}, indent=2))
-            return
+        payload = [_preset_row(preset, active_name) for preset in presets]
         if not presets:
-            self.stdout.write("No presets defined. Run `t3 setup` to seed the defaults.")
-            return
-        self.stdout.write("presets:")
-        for preset in presets:
-            marker = " *ACTIVE*" if preset.name == active_name else ""
-            pin = f" pin={preset.availability_pin}" if preset.availability_pin else ""
-            scope = f" scope={','.join(preset.overlay_scope_names)}" if preset.overlay_scope_names else ""
-            self.stdout.write(f"  {preset.name:<16} {preset.entry_count} entries{pin}{scope}{marker}")
-            if preset.description:
-                self.stdout.write(f"      {preset.description}")
+            human = "No presets defined. Run `t3 setup` to seed the defaults."
+        else:
+            lines = ["presets:"]
+            for preset in presets:
+                marker = " *ACTIVE*" if preset.name == active_name else ""
+                pin = f" pin={preset.availability_pin}" if preset.availability_pin else ""
+                scope = f" scope={','.join(preset.overlay_scope_names)}" if preset.overlay_scope_names else ""
+                lines.append(f"  {preset.name:<16} {preset.entry_count} entries{pin}{scope}{marker}")
+                if preset.description:
+                    lines.append(f"      {preset.description}")
+            human = "\n".join(lines)
+        self._emit({"active": active_name, "presets": payload}, human, json_output=json_output)
 
     @command(name="show")
     def show(
@@ -184,43 +183,38 @@ class Command(TyperCommand):
         if preset is None:
             self._refuse(f"no preset named {name!r}", json_output=json_output)
         unknown = _unknown_entry_loops(preset.entries)
-        if json_output:
-            self.stdout.write(json.dumps(_preset_detail(preset, unknown), indent=2))
-            return
-        self.stdout.write(f"preset {preset.name}: {preset.description}")
-        for loop_name, value in sorted(preset.entries.items()):
-            self.stdout.write(f"  {loop_name:<22} {'on' if value else 'off'}")
+        lines = [f"preset {preset.name}: {preset.description}"]
+        lines += [
+            f"  {loop_name:<22} {'on' if value else 'off'}" for loop_name, value in sorted(preset.entries.items())
+        ]
         if unknown:
-            self.stdout.write(f"  WARN entries name unknown loops: {', '.join(unknown)}")
+            lines.append(f"  WARN entries name unknown loops: {', '.join(unknown)}")
+        self._emit(_preset_detail(preset, unknown), "\n".join(lines), json_output=json_output)
 
     def _show_active(self, *, json_output: bool) -> None:
         now = timezone.now()
         summary = active_summary(now)
         verdicts = effective_verdicts(now)
-        if json_output:
-            self.stdout.write(
-                json.dumps(
-                    {
-                        "active": _summary_payload(summary),
-                        "loops": [
-                            {"name": v.name, "admitted": v.admitted, "layer": v.layer, "detail": v.detail}
-                            for v in verdicts
-                        ],
-                    },
-                    indent=2,
-                )
-            )
-            return
         if summary is None:
-            self.stdout.write("active preset: none (no override, no active schedule) — loops run per base config.")
+            lines = ["active preset: none (no override, no active schedule) — loops run per base config."]
         else:
             pin = f", pins availability {summary.availability_pin}" if summary.availability_pin else ""
             until = "" if summary.until is None else f", until {summary.until.isoformat()}"
-            self.stdout.write(f"active preset: {summary.name}  (why: {summary.reason}{until}{pin})")
-        self.stdout.write("per-loop effective verdict:")
+            lines = [f"active preset: {summary.name}  (why: {summary.reason}{until}{pin})"]
+        lines.append("per-loop effective verdict:")
         for verdict in verdicts:
             state = "run" if verdict.admitted else "masked"
-            self.stdout.write(f"  {verdict.name:<22} {state:<7} [{verdict.layer}] {verdict.detail}")
+            lines.append(f"  {verdict.name:<22} {state:<7} [{verdict.layer}] {verdict.detail}")
+        self._emit(
+            {
+                "active": _summary_payload(summary),
+                "loops": [
+                    {"name": v.name, "admitted": v.admitted, "layer": v.layer, "detail": v.detail} for v in verdicts
+                ],
+            },
+            "\n".join(lines),
+            json_output=json_output,
+        )
 
     def _resolve_until(self, *, expiry: str, hold: bool, json_output: bool) -> dt.datetime | None:
         if hold:
@@ -253,10 +247,22 @@ class Command(TyperCommand):
         self._emit(_preset_detail(preset, unknown), message, json_output=json_output)
 
     def _emit(self, payload: dict[str, Any], message: str, *, json_output: bool) -> None:
-        self.stdout.write(json.dumps(payload, indent=2) if json_output else message)
+        emit(
+            payload,
+            json_output=json_output,
+            out=cast("IO[str]", self.stdout),
+            err=cast("IO[str]", self.stderr),
+            human=message,
+        )
 
     def _refuse(self, message: str, *, json_output: bool) -> NoReturn:
-        self.stdout.write(json.dumps({"error": message}, indent=2) if json_output else f"ERROR  {message}")
+        emit(
+            {"error": message},
+            json_output=json_output,
+            out=cast("IO[str]", self.stdout),
+            err=cast("IO[str]", self.stderr),
+            human=f"ERROR  {message}",
+        )
         raise SystemExit(2)
 
 

--- a/src/teatree/core/management/commands/loop_schedule.py
+++ b/src/teatree/core/management/commands/loop_schedule.py
@@ -7,13 +7,13 @@ lives in a management command (the project's "anything touching the ORM is a
 management command" rule).
 """
 
-import json
 import zoneinfo
-from typing import Annotated, Any, NoReturn
+from typing import IO, Annotated, Any, NoReturn, cast
 
 import typer
 from django_typer.management import TyperCommand, command
 
+from teatree.core.machine_output import emit
 from teatree.core.models import ConfigSetting, ModeSchedule
 from teatree.loop.preset_resolution import ACTIVE_SCHEDULE_SETTING
 
@@ -39,29 +39,34 @@ class Command(TyperCommand):
         """List every schedule with its timezone, slot count, and the ACTIVE marker."""
         active = _active_schedule_name()
         schedules = list(ModeSchedule.objects.all())
-        if json_output:
-            payload = [
-                {
-                    "name": schedule.name,
-                    "timezone": schedule.timezone,
-                    "slots": schedule.slots.count(),
-                    "active": schedule.name == active,
-                }
-                for schedule in schedules
-            ]
-            self.stdout.write(json.dumps({"active": active, "schedules": payload}, indent=2))
-            return
+        payload = [
+            {
+                "name": schedule.name,
+                "timezone": schedule.timezone,
+                "slots": schedule.slots.count(),
+                "active": schedule.name == active,
+            }
+            for schedule in schedules
+        ]
         if not schedules:
-            self.stdout.write("No schedules defined. Run `t3 setup` to seed the defaults.")
-            return
-        self.stdout.write("schedules:")
-        for schedule in schedules:
-            marker = " *ACTIVE*" if schedule.name == active else ""
-            self.stdout.write(
-                f"  {schedule.name:<20} tz={schedule.timezone_label:<18} {schedule.slots.count()} slots{marker}"
-            )
-        if not active:
-            self.stdout.write("  (no active schedule — presets apply only via a manual override)")
+            human = "No schedules defined. Run `t3 setup` to seed the defaults."
+        else:
+            lines = ["schedules:"]
+            for schedule in schedules:
+                marker = " *ACTIVE*" if schedule.name == active else ""
+                lines.append(
+                    f"  {schedule.name:<20} tz={schedule.timezone_label:<18} {schedule.slots.count()} slots{marker}"
+                )
+            if not active:
+                lines.append("  (no active schedule — presets apply only via a manual override)")
+            human = "\n".join(lines)
+        emit(
+            {"active": active, "schedules": payload},
+            json_output=json_output,
+            out=cast("IO[str]", self.stdout),
+            err=cast("IO[str]", self.stderr),
+            human=human,
+        )
 
     @command(name="show")
     def show(
@@ -78,28 +83,28 @@ class Command(TyperCommand):
         if schedule is None:
             self._refuse(f"no schedule named {resolved!r}", json_output=json_output)
         slots = list(schedule.slots.all())
-        if json_output:
-            self.stdout.write(
-                json.dumps(
+        human_lines = [f"schedule {schedule.name} (tz={schedule.timezone_label}): {schedule.description}"]
+        human_lines += [
+            f"  {_slot_days(slot):<28} {slot.start_time.strftime('%H:%M')} -> {slot.preset_name}" for slot in slots
+        ]
+        emit(
+            {
+                "name": schedule.name,
+                "timezone": schedule.timezone,
+                "slots": [
                     {
-                        "name": schedule.name,
-                        "timezone": schedule.timezone,
-                        "slots": [
-                            {
-                                "days": sorted(slot.weekdays),
-                                "start_time": slot.start_time.strftime("%H:%M"),
-                                "preset": slot.preset_name,
-                            }
-                            for slot in slots
-                        ],
-                    },
-                    indent=2,
-                )
-            )
-            return
-        self.stdout.write(f"schedule {schedule.name} (tz={schedule.timezone_label}): {schedule.description}")
-        for slot in slots:
-            self.stdout.write(f"  {_slot_days(slot):<28} {slot.start_time.strftime('%H:%M')} -> {slot.preset_name}")
+                        "days": sorted(slot.weekdays),
+                        "start_time": slot.start_time.strftime("%H:%M"),
+                        "preset": slot.preset_name,
+                    }
+                    for slot in slots
+                ],
+            },
+            json_output=json_output,
+            out=cast("IO[str]", self.stdout),
+            err=cast("IO[str]", self.stderr),
+            human="\n".join(human_lines),
+        )
 
     @command(name="set-active")
     def set_active(
@@ -156,8 +161,20 @@ class Command(TyperCommand):
         self._emit({"cleared": cleared}, message, json_output=json_output)
 
     def _emit(self, payload: dict[str, Any], message: str, *, json_output: bool) -> None:
-        self.stdout.write(json.dumps(payload, indent=2) if json_output else message)
+        emit(
+            payload,
+            json_output=json_output,
+            out=cast("IO[str]", self.stdout),
+            err=cast("IO[str]", self.stderr),
+            human=message,
+        )
 
     def _refuse(self, message: str, *, json_output: bool) -> NoReturn:
-        self.stdout.write(json.dumps({"error": message}, indent=2) if json_output else f"ERROR  {message}")
+        emit(
+            {"error": message},
+            json_output=json_output,
+            out=cast("IO[str]", self.stdout),
+            err=cast("IO[str]", self.stderr),
+            human=f"ERROR  {message}",
+        )
         raise SystemExit(2)

--- a/src/teatree/core/management/commands/loop_self_improve.py
+++ b/src/teatree/core/management/commands/loop_self_improve.py
@@ -11,11 +11,12 @@ import datetime as dt
 import json
 import os
 from dataclasses import asdict
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import IO, TYPE_CHECKING, Annotated, Any, cast
 
 import typer
 from django_typer.management import TyperCommand
 
+from teatree.core.machine_output import emit
 from teatree.core.session_identity import session_id_from_env
 
 if TYPE_CHECKING:
@@ -106,42 +107,35 @@ class Command(TyperCommand):
         from teatree.loop.phases.render import self_improve_rerender  # noqa: PLC0415 — deferred: lazy command import
         from teatree.loop.self_improve.schedule import run_tier  # noqa: PLC0415 — deferred: keeps command import light
 
+        out = cast("IO[str]", self.stdout)
+        err = cast("IO[str]", self.stderr)
         session_id = _non_owner_session_id()
         if not _session_owns_loop(session_id):
             now = dt.datetime.now(tz=dt.UTC)
-            if json_output:
-                self.stdout.write(
-                    json.dumps(
-                        {
-                            "tier": tier,
-                            "skipped": True,
-                            "skipped_reason": "non-owner session",
-                            "started_at": now.isoformat(),
-                        },
-                        indent=2,
-                    )
-                )
-            else:
-                self.stdout.write("SKIP  this session is not the loop owner — skipping self-improve cycle.")
+            emit(
+                {"tier": tier, "skipped": True, "skipped_reason": "non-owner session", "started_at": now.isoformat()},
+                json_output=json_output,
+                out=out,
+                err=err,
+                human="SKIP  this session is not the loop owner — skipping self-improve cycle.",
+            )
             return
 
         owner = f"pid-{os.getpid()}"
         if not LoopLease.objects.acquire("loop-self-improve", owner=owner):
             now = dt.datetime.now(tz=dt.UTC)
-            if json_output:
-                self.stdout.write(
-                    json.dumps(
-                        {
-                            "tier": tier,
-                            "skipped": True,
-                            "skipped_reason": "another self-improve cycle is already running",
-                            "started_at": now.isoformat(),
-                        },
-                        indent=2,
-                    )
-                )
-            else:
-                self.stdout.write("SKIP  loop-self-improve lease held — another cycle is running.")
+            emit(
+                {
+                    "tier": tier,
+                    "skipped": True,
+                    "skipped_reason": "another self-improve cycle is already running",
+                    "started_at": now.isoformat(),
+                },
+                json_output=json_output,
+                out=out,
+                err=err,
+                human="SKIP  loop-self-improve lease held — another cycle is running.",
+            )
             return
         try:
             result = run_tier(tier, auto_fix_callable=self_improve_rerender)
@@ -149,10 +143,8 @@ class Command(TyperCommand):
             LoopLease.objects.release("loop-self-improve", owner=owner)
 
         report = _result_to_dict(result)
-        if json_output:
-            self.stdout.write(json.dumps(report, indent=2, default=str))
-            return
         if result.skipped:
-            self.stdout.write(f"SKIP  budget gate: {result.budget.reason}")
-            return
-        self.stdout.write(f"OK    tier={result.tier} reports={len(result.reports)} actions={len(result.actions)}")
+            human = f"SKIP  budget gate: {result.budget.reason}"
+        else:
+            human = f"OK    tier={result.tier} reports={len(result.reports)} actions={len(result.actions)}"
+        emit(report, json_output=json_output, out=out, err=err, human=human)

--- a/src/teatree/core/management/commands/loop_slack_answer.py
+++ b/src/teatree/core/management/commands/loop_slack_answer.py
@@ -13,14 +13,14 @@ fallback safety net on a 5m default cadence.
 """
 
 import datetime as dt
-import json
 import os
 from dataclasses import asdict
-from typing import Annotated
+from typing import IO, Annotated, cast
 
 import typer
 from django_typer.management import TyperCommand
 
+from teatree.core.machine_output import emit
 from teatree.core.session_identity import session_id_from_env
 
 
@@ -71,50 +71,47 @@ class Command(TyperCommand):
         from teatree.core.models import LoopLease  # noqa: PLC0415 — deferred: ORM import needs the app registry
         from teatree.loop.slack_answer.cycle import run_slack_answer_cycle  # noqa: PLC0415 — lazy command import
 
+        out = cast("IO[str]", self.stdout)
+        err = cast("IO[str]", self.stderr)
         session_id = _non_owner_session_id()
         if not _session_owns_loop(session_id):
             now = dt.datetime.now(tz=dt.UTC)
-            if json_output:
-                self.stdout.write(
-                    json.dumps(
-                        {
-                            "skipped": True,
-                            "skipped_reason": "non-owner session",
-                            "started_at": now.isoformat(),
-                        },
-                        indent=2,
-                    )
-                )
-            else:
-                self.stdout.write("SKIP  this session is not the loop owner — skipping Slack-answer cycle.")
+            emit(
+                {"skipped": True, "skipped_reason": "non-owner session", "started_at": now.isoformat()},
+                json_output=json_output,
+                out=out,
+                err=err,
+                human="SKIP  this session is not the loop owner — skipping Slack-answer cycle.",
+            )
             return
 
         owner = f"pid-{os.getpid()}"
         if not LoopLease.objects.acquire("loop-slack-answer", owner=owner):
             now = dt.datetime.now(tz=dt.UTC)
-            if json_output:
-                self.stdout.write(
-                    json.dumps(
-                        {
-                            "skipped": True,
-                            "skipped_reason": "another Slack-answer cycle is already running",
-                            "started_at": now.isoformat(),
-                        },
-                        indent=2,
-                    )
-                )
-            else:
-                self.stdout.write("SKIP  loop-slack-answer lease held — another cycle is running.")
+            emit(
+                {
+                    "skipped": True,
+                    "skipped_reason": "another Slack-answer cycle is already running",
+                    "started_at": now.isoformat(),
+                },
+                json_output=json_output,
+                out=out,
+                err=err,
+                human="SKIP  loop-slack-answer lease held — another cycle is running.",
+            )
             return
         try:
             report = run_slack_answer_cycle()
         finally:
             LoopLease.objects.release("loop-slack-answer", owner=owner)
 
-        if json_output:
-            self.stdout.write(json.dumps(asdict(report), indent=2, default=str))
-            return
-        self.stdout.write(
-            f"OK    processed={report.processed} acked={report.acked} "
-            f"simple={report.answered_simple} delegated={report.delegated} errors={report.errors}"
+        emit(
+            asdict(report),
+            json_output=json_output,
+            out=out,
+            err=err,
+            human=(
+                f"OK    processed={report.processed} acked={report.acked} "
+                f"simple={report.answered_simple} delegated={report.delegated} errors={report.errors}"
+            ),
         )

--- a/src/teatree/core/management/commands/loop_state.py
+++ b/src/teatree/core/management/commands/loop_state.py
@@ -30,16 +30,15 @@ that does not exist.
 """
 
 import datetime as dt
-import json
 import logging
 import re
-from collections.abc import Callable
-from typing import Annotated
+from typing import IO, Annotated, cast
 
 import typer
 from django.utils import timezone
 from django_typer.management import TyperCommand, command
 
+from teatree.core.machine_output import emit
 from teatree.core.models import Loop, LoopState
 
 logger = logging.getLogger(__name__)
@@ -80,7 +79,11 @@ def _reconcile_timers() -> None:
         )
 
 
-def _require_known_loop(name: str, *, json_output: bool, stdout_write: Callable[[str], object]) -> None:
+def _out_err(command: TyperCommand) -> tuple[IO[str], IO[str]]:
+    return cast("IO[str]", command.stdout), cast("IO[str]", command.stderr)
+
+
+def _require_known_loop(command: TyperCommand, name: str, *, json_output: bool) -> None:
     """Refuse a NAME with no matching ``Loop`` row before any ``LoopState`` read/write (#3117).
 
     Every verb — the mutating ``pause``/``resume``/``disable``/``enable`` and the
@@ -93,23 +96,25 @@ def _require_known_loop(name: str, *, json_output: bool, stdout_write: Callable[
     if Loop.objects.filter(name=name).exists():
         return
     msg = f"no loop named {name!r} — run `t3 loops list` to see the known loops"
-    if json_output:
-        stdout_write(json.dumps({"name": name, "error": msg}, indent=2))
-    else:
-        stdout_write(f"ERROR  {msg}")
+    out, err = _out_err(command)
+    emit({"name": name, "error": msg}, json_output=json_output, out=out, err=err, human=f"ERROR  {msg}")
     raise SystemExit(2)
 
 
-def _report(name: str, *, json_output: bool, stdout_write: Callable[[str], object]) -> None:
+def _report(command: TyperCommand, name: str, *, json_output: bool) -> None:
     """Re-read and report the LANDED status after a mutating transition."""
     status = LoopState.objects.status_of(name)
-    if json_output:
-        stdout_write(json.dumps({"name": name, "status": status.value}, indent=2))
-    else:
-        stdout_write(f"OK    loop {name!r} is now {status.value}.")
+    out, err = _out_err(command)
+    emit(
+        {"name": name, "status": status.value},
+        json_output=json_output,
+        out=out,
+        err=err,
+        human=f"OK    loop {name!r} is now {status.value}.",
+    )
 
 
-def _report_status(name: str, *, json_output: bool, stdout_write: Callable[[str], object]) -> None:
+def _report_status(command: TyperCommand, name: str, *, json_output: bool) -> None:
     """Read-only status report for ``status`` — phrased as a READ, never a mutation.
 
     The mutation verbs print ``is now <status>``; the read prints
@@ -119,20 +124,28 @@ def _report_status(name: str, *, json_output: bool, stdout_write: Callable[[str]
     unaffected.
     """
     status = LoopState.objects.status_of(name)
-    if json_output:
-        stdout_write(json.dumps({"name": name, "status": status.value}, indent=2))
-    else:
-        stdout_write(f"loop {name!r} status: {status.value.upper()}")
+    out, err = _out_err(command)
+    emit(
+        {"name": name, "status": status.value},
+        json_output=json_output,
+        out=out,
+        err=err,
+        human=f"loop {name!r} status: {status.value.upper()}",
+    )
 
 
-def _report_forced(name: str, *, json_output: bool, stdout_write: Callable[[str], object]) -> None:
+def _report_forced(command: TyperCommand, name: str, *, json_output: bool) -> None:
     """Re-read and report the LANDED forced plane after an override."""
     forced = LoopState.objects.forced_of(name)
     word = "neutral" if forced is None else ("on" if forced else "off")
-    if json_output:
-        stdout_write(json.dumps({"name": name, "forced": word}, indent=2))
-    else:
-        stdout_write(f"OK    loop {name!r} override is now {word}.")
+    out, err = _out_err(command)
+    emit(
+        {"name": name, "forced": word},
+        json_output=json_output,
+        out=out,
+        err=err,
+        human=f"OK    loop {name!r} override is now {word}.",
+    )
 
 
 class Command(TyperCommand):
@@ -146,9 +159,9 @@ class Command(TyperCommand):
         json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
     ) -> None:
         """Move *name* into the reversible PAUSED hold."""
-        _require_known_loop(name, json_output=json_output, stdout_write=self.stdout.write)
+        _require_known_loop(self, name, json_output=json_output)
         LoopState.objects.pause(name)
-        _report(name, json_output=json_output, stdout_write=self.stdout.write)
+        _report(self, name, json_output=json_output)
 
     @command(name="resume")
     def resume(
@@ -158,10 +171,10 @@ class Command(TyperCommand):
         json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
     ) -> None:
         """Return *name* to ENABLED, clearing a pause OR a disable — both planes."""
-        _require_known_loop(name, json_output=json_output, stdout_write=self.stdout.write)
+        _require_known_loop(self, name, json_output=json_output)
         Loop.objects.resume(name)
         _reconcile_timers()
-        _report(name, json_output=json_output, stdout_write=self.stdout.write)
+        _report(self, name, json_output=json_output)
 
     @command(name="disable")
     def disable(
@@ -171,10 +184,10 @@ class Command(TyperCommand):
         json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
     ) -> None:
         """Move *name* into the durable DISABLED kill-switch — both planes."""
-        _require_known_loop(name, json_output=json_output, stdout_write=self.stdout.write)
+        _require_known_loop(self, name, json_output=json_output)
         Loop.objects.disable(name)
         _reconcile_timers()
-        _report(name, json_output=json_output, stdout_write=self.stdout.write)
+        _report(self, name, json_output=json_output)
 
     @command(name="enable")
     def enable(
@@ -184,10 +197,10 @@ class Command(TyperCommand):
         json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
     ) -> None:
         """Return *name* to ENABLED (alias of resume) — both planes."""
-        _require_known_loop(name, json_output=json_output, stdout_write=self.stdout.write)
+        _require_known_loop(self, name, json_output=json_output)
         Loop.objects.enable(name)
         _reconcile_timers()
-        _report(name, json_output=json_output, stdout_write=self.stdout.write)
+        _report(self, name, json_output=json_output)
 
     @command(name="override")
     def override(
@@ -200,11 +213,12 @@ class Command(TyperCommand):
         json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
     ) -> None:
         """Set the emergency FORCED plane for *name* — on/off beats a preset, clear returns to neutral."""
-        _require_known_loop(name, json_output=json_output, stdout_write=self.stdout.write)
+        _require_known_loop(self, name, json_output=json_output)
+        out, err = _out_err(self)
         normalized = state.strip().lower()
         if normalized not in _OVERRIDE_STATES:
             msg = f"invalid override state {state!r}; use on, off, or clear"
-            self.stdout.write(json.dumps({"name": name, "error": msg}) if json_output else f"ERROR  {msg}")
+            emit({"name": name, "error": msg}, json_output=json_output, out=out, err=err, human=f"ERROR  {msg}")
             raise SystemExit(2)
         if normalized == "clear":
             LoopState.objects.clear_override(name)
@@ -212,10 +226,16 @@ class Command(TyperCommand):
             try:
                 until = _parse_for(for_ttl)
             except ValueError as exc:
-                self.stdout.write(json.dumps({"name": name, "error": str(exc)}) if json_output else f"ERROR  {exc}")
+                emit(
+                    {"name": name, "error": str(exc)},
+                    json_output=json_output,
+                    out=out,
+                    err=err,
+                    human=f"ERROR  {exc}",
+                )
                 raise SystemExit(2) from exc
             LoopState.objects.override(name, on=normalized == "on", until=until, reason=reason)
-        _report_forced(name, json_output=json_output, stdout_write=self.stdout.write)
+        _report_forced(self, name, json_output=json_output)
 
     @command(name="status")
     def status(
@@ -225,5 +245,5 @@ class Command(TyperCommand):
         json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
     ) -> None:
         """Read *name*'s durable state (ENABLED when no row exists) WITHOUT mutating it."""
-        _require_known_loop(name, json_output=json_output, stdout_write=self.stdout.write)
-        _report_status(name, json_output=json_output, stdout_write=self.stdout.write)
+        _require_known_loop(self, name, json_output=json_output)
+        _report_status(self, name, json_output=json_output)

--- a/src/teatree/core/management/commands/loop_tick.py
+++ b/src/teatree/core/management/commands/loop_tick.py
@@ -9,14 +9,14 @@ scanner set regardless of which loops are enabled. The system never uses it to
 drive itself, and there is no master tick.
 """
 
-import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated
+from typing import IO, TYPE_CHECKING, Annotated, cast
 
 import typer
 from django_typer.management import TyperCommand
 
 from teatree.core.backend_factory import code_host_from_overlay, iter_overlay_backends, messaging_from_overlay
+from teatree.core.machine_output import emit
 from teatree.core.management.commands.loops_tick import _report_to_dict
 
 if TYPE_CHECKING:
@@ -57,8 +57,11 @@ class Command(TyperCommand):
         finally:
             set_mini_loop_schedules_reader(None)
 
-        if json_output:
-            self.stdout.write(json.dumps(_report_to_dict(report), indent=2))
-            return
-        for name, message in report.errors.items():
-            self.stdout.write(f"WARN  {name}: {message}")
+        human = "\n".join(f"WARN  {name}: {message}" for name, message in report.errors.items()) or None
+        emit(
+            _report_to_dict(report),
+            json_output=json_output,
+            out=cast("IO[str]", self.stdout),
+            err=cast("IO[str]", self.stderr),
+            human=human,
+        )

--- a/src/teatree/core/management/commands/loops_list.py
+++ b/src/teatree/core/management/commands/loops_list.py
@@ -15,13 +15,13 @@ row. Distinct from the singular ``t3 loop`` (the legacy fat-loop status view).
 """
 
 import datetime as dt
-import json
-from typing import Annotated, Any
+from typing import IO, Annotated, Any, cast
 
 import typer
 from django.utils import timezone
 from django_typer.management import TyperCommand
 
+from teatree.core.machine_output import emit
 from teatree.core.models import Loop, LoopState, LoopStatus
 from teatree.loops.preset_status import LoopVerdict, effective_verdicts
 
@@ -135,15 +135,19 @@ class Command(TyperCommand):
         held = {row.name: LoopStatus(row.status) for row in LoopState.objects.all()}
         # One read of the preset mask (L3/L2): the per-loop effective verdict + layer.
         verdicts = {verdict.name: verdict for verdict in effective_verdicts(now)}
-        if json_output:
-            payload = [
-                _payload(loop, held.get(loop.name, LoopStatus.ENABLED), now, verdicts.get(loop.name)) for loop in loops
-            ]
-            self.stdout.write(json.dumps({"loops": payload}, indent=2))
-            return
-        self.stdout.write("loops:")
+        payload = [
+            _payload(loop, held.get(loop.name, LoopStatus.ENABLED), now, verdicts.get(loop.name)) for loop in loops
+        ]
+        human_lines = ["loops:"]
         for loop in loops:
-            self.stdout.write(_line(loop, held.get(loop.name, LoopStatus.ENABLED), now, verdicts.get(loop.name)))
+            human_lines.append(_line(loop, held.get(loop.name, LoopStatus.ENABLED), now, verdicts.get(loop.name)))
             description_line = _description_line(loop)
             if description_line is not None:
-                self.stdout.write(description_line)
+                human_lines.append(description_line)
+        emit(
+            {"loops": payload},
+            json_output=json_output,
+            out=cast("IO[str]", self.stdout),
+            err=cast("IO[str]", self.stderr),
+            human="\n".join(human_lines),
+        )

--- a/src/teatree/core/management/commands/loops_tick.py
+++ b/src/teatree/core/management/commands/loops_tick.py
@@ -42,18 +42,18 @@ its own dedicated ``LoopLease``.
 """
 
 import datetime as dt
-import json
 import os
 import uuid
 from dataclasses import asdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import IO, TYPE_CHECKING, Annotated, Any, cast
 
 import typer
 from django_typer.management import TyperCommand
 
 from teatree.core.backend_factory import code_host_from_overlay, iter_overlay_backends, messaging_from_overlay
 from teatree.core.loop_lease_manager import PER_LOOP_TICK_MUTEX_PREFIX, per_loop_owner_slot
+from teatree.core.machine_output import emit
 from teatree.core.mode_resolution import resolve_active_mode
 from teatree.core.models import LoopLease
 from teatree.loop.loop_cadences import loop_owner_ttl_seconds
@@ -185,10 +185,13 @@ class Command(TyperCommand):
 
         now = dt.datetime.now(tz=dt.UTC)
         _write_tick_meta(now, target=statusline_file)
-        if json_output:
-            self.stdout.write(json.dumps(_skipped_report_dict(now, reason), indent=2))
-        else:
-            self.stdout.write(f"SKIP  {reason}")
+        emit(
+            _skipped_report_dict(now, reason),
+            json_output=json_output,
+            out=cast("IO[str]", self.stdout),
+            err=cast("IO[str]", self.stderr),
+            human=f"SKIP  {reason}",
+        )
 
     def _build_request(self, overlay: str) -> "TickRequest":
         from teatree.loop.tick import TickRequest  # noqa: PLC0415 — deferred: keeps command import light
@@ -198,11 +201,14 @@ class Command(TyperCommand):
         return TickRequest(backends=_focus_scoped_backends())
 
     def _emit_report(self, report: "TickReport", *, json_output: bool) -> None:
-        if json_output:
-            self.stdout.write(json.dumps(_report_to_dict(report), indent=2))
-            return
-        for name, message in report.errors.items():
-            self.stdout.write(f"WARN  {name}: {message}")
+        human = "\n".join(f"WARN  {name}: {message}" for name, message in report.errors.items()) or None
+        emit(
+            _report_to_dict(report),
+            json_output=json_output,
+            out=cast("IO[str]", self.stdout),
+            err=cast("IO[str]", self.stderr),
+            human=human,
+        )
 
     def handle(
         self,

--- a/src/teatree/core/management/commands/prompts_list.py
+++ b/src/teatree/core/management/commands/prompts_list.py
@@ -7,12 +7,12 @@ management command (the project's "anything touching the ORM is a management
 command" rule). Strictly read-only — never mutates a row.
 """
 
-import json
-from typing import Annotated, Any
+from typing import IO, Annotated, Any, cast
 
 import typer
 from django_typer.management import TyperCommand
 
+from teatree.core.machine_output import emit
 from teatree.core.models import Prompt
 
 
@@ -41,9 +41,11 @@ class Command(TyperCommand):
         json_output: Annotated[bool, typer.Option("--json", help="Emit the prompts as JSON.")] = False,
     ) -> None:
         prompts = list(Prompt.objects.all())
-        if json_output:
-            self.stdout.write(json.dumps({"prompts": [_payload(p) for p in prompts]}, indent=2))
-            return
-        self.stdout.write("prompts:")
-        for prompt in prompts:
-            self.stdout.write(_line(prompt))
+        human = "\n".join(["prompts:", *(_line(prompt) for prompt in prompts)])
+        emit(
+            {"prompts": [_payload(p) for p in prompts]},
+            json_output=json_output,
+            out=cast("IO[str]", self.stdout),
+            err=cast("IO[str]", self.stderr),
+            human=human,
+        )

--- a/src/teatree/core/management/commands/session.py
+++ b/src/teatree/core/management/commands/session.py
@@ -19,14 +19,14 @@ ORM access is here (a management command, not a plain typer command) per the
 project's "anything touching the ORM is a management command" rule.
 """
 
-import json
 from pathlib import Path
-from typing import Annotated
+from typing import IO, Annotated, cast
 
 import typer
 from django.core.management.base import CommandError
 from django_typer.management import TyperCommand, command, initialize
 
+from teatree.core.machine_output import emit
 from teatree.core.models import Session, SessionTodo
 from teatree.core.session_identity import current_session_id
 from teatree.core.stop_snapshot import prepare_stop
@@ -52,29 +52,28 @@ class Command(TyperCommand):
         overwrites the files and the resume ref in place — no duplicate commits.
         """
         result = prepare_stop(current_session_id(), str(Path.cwd()))
-        if json_output:
-            self.stdout.write(
-                json.dumps(
-                    {
-                        "session_id": result.session_id,
-                        "todos_path": str(result.todos_path) if result.todos_path else None,
-                        "resume_plan_path": str(result.resume_plan_path) if result.resume_plan_path else None,
-                        "at_risk": [
-                            {"path": str(w.path), "branch": w.branch, "recovery_ref": w.recovery_ref}
-                            for w in result.at_risk
-                        ],
-                    },
-                    indent=2,
-                )
-            )
-            return
-        self.stdout.write(f"OK    resume plan: {result.resume_plan_path}")
-        self.stdout.write(f"      TODO mirror: {result.todos_path}")
+        human_lines = [
+            f"OK    resume plan: {result.resume_plan_path}",
+            f"      TODO mirror: {result.todos_path}",
+        ]
         if result.at_risk:
-            for wt in result.at_risk:
-                self.stdout.write(f"      at-risk worktree captured: {wt.path} → {wt.recovery_ref}")
+            human_lines += [f"      at-risk worktree captured: {wt.path} → {wt.recovery_ref}" for wt in result.at_risk]
         else:
-            self.stdout.write("      at-risk worktrees: none")
+            human_lines.append("      at-risk worktrees: none")
+        emit(
+            {
+                "session_id": result.session_id,
+                "todos_path": str(result.todos_path) if result.todos_path else None,
+                "resume_plan_path": str(result.resume_plan_path) if result.resume_plan_path else None,
+                "at_risk": [
+                    {"path": str(w.path), "branch": w.branch, "recovery_ref": w.recovery_ref} for w in result.at_risk
+                ],
+            },
+            json_output=json_output,
+            out=cast("IO[str]", self.stdout),
+            err=cast("IO[str]", self.stderr),
+            human="\n".join(human_lines),
+        )
 
     def _resolve_session(self, session_pk: int | None) -> Session:
         """The session the TODO verbs act on: explicit ``--session``, else the live one.
@@ -116,17 +115,18 @@ class Command(TyperCommand):
     ) -> None:
         """List this session's working items, in working order."""
         session = self._resolve_session(session_pk)
-        rows = SessionTodo.objects.filter(session=session) if all_items else SessionTodo.objects.open_for(session)
-        if json_output:
-            self.stdout.write(
-                json.dumps([{"id": r.pk, "text": r.text, "status": r.status, "order": r.order} for r in rows], indent=2)
-            )
-            return
+        rows = list(SessionTodo.objects.filter(session=session) if all_items else SessionTodo.objects.open_for(session))
         if not rows:
-            self.stdout.write("      (no items)")
-            return
-        for row in rows:
-            self.stdout.write(f"  {row.pk:>4}  [{row.status}] {row.text}")
+            human = "      (no items)"
+        else:
+            human = "\n".join(f"  {row.pk:>4}  [{row.status}] {row.text}" for row in rows)
+        emit(
+            [{"id": r.pk, "text": r.text, "status": r.status, "order": r.order} for r in rows],
+            json_output=json_output,
+            out=cast("IO[str]", self.stdout),
+            err=cast("IO[str]", self.stderr),
+            human=human,
+        )
 
     @command(name="todo-set")
     def todo_set(

--- a/src/teatree/core/management/commands/standing_goal.py
+++ b/src/teatree/core/management/commands/standing_goal.py
@@ -9,62 +9,67 @@ command" rule. Non-zero exits use ``raise SystemExit(N)`` (the ``call_command``
 path); the CLI layer maps that to ``typer.Exit``.
 """
 
-import json
-from collections.abc import Callable
-from typing import Annotated
+from typing import IO, Annotated, cast
 
 import typer
 from django_typer.management import TyperCommand, command
 
-# ``self.stdout.write`` — the command's Django ``OutputWrapper.write``.
-StdoutWrite = Callable[..., object]
+from teatree.core.machine_output import emit
 
 
-def _set(name: str, check: str, *, json_output: bool, stdout_write: StdoutWrite) -> None:
+def _out_err(command: TyperCommand) -> tuple[IO[str], IO[str]]:
+    return cast("IO[str]", command.stdout), cast("IO[str]", command.stderr)
+
+
+def _set(command: TyperCommand, name: str, check: str, *, json_output: bool) -> None:
     from teatree.core.models import (  # noqa: PLC0415 — deferred: touch the ORM only at call time
         StandingGoal,
         StandingGoalError,
     )
 
+    out, err = _out_err(command)
     try:
         goal = StandingGoal.objects.set_goal(name, check)
     except StandingGoalError as exc:
-        if json_output:
-            stdout_write(json.dumps({"ok": False, "error": str(exc)}, indent=2))
-        else:
-            stdout_write(f"ERROR  {exc}")
+        emit({"ok": False, "error": str(exc)}, json_output=json_output, out=out, err=err, human=f"ERROR  {exc}")
         raise SystemExit(2) from exc
-    if json_output:
-        stdout_write(json.dumps({"ok": True, "name": goal.name, "check_command": goal.check_command}, indent=2))
-    else:
-        stdout_write(f"OK    registered standing goal {goal.name!r} — green when `{goal.check_command}` exits 0.")
+    emit(
+        {"ok": True, "name": goal.name, "check_command": goal.check_command},
+        json_output=json_output,
+        out=out,
+        err=err,
+        human=f"OK    registered standing goal {goal.name!r} — green when `{goal.check_command}` exits 0.",
+    )
 
 
-def _clear(name: str | None, *, json_output: bool, stdout_write: StdoutWrite) -> None:
+def _clear(command: TyperCommand, name: str | None, *, json_output: bool) -> None:
     from teatree.core.models import StandingGoal  # noqa: PLC0415 — deferred import
 
     count = StandingGoal.objects.clear(name)
     scope = "all standing goals" if name is None else f"standing goal {name!r}"
-    if json_output:
-        stdout_write(json.dumps({"ok": True, "cleared": count, "scope": scope}, indent=2))
-    else:
-        stdout_write(f"OK    cleared {count} {scope}.")
+    out, err = _out_err(command)
+    emit(
+        {"ok": True, "cleared": count, "scope": scope},
+        json_output=json_output,
+        out=out,
+        err=err,
+        human=f"OK    cleared {count} {scope}.",
+    )
 
 
-def _list(*, json_output: bool, stdout_write: StdoutWrite) -> None:
+def _list(command: TyperCommand, *, json_output: bool) -> None:
     from teatree.core.models import StandingGoal  # noqa: PLC0415 — deferred import
 
     goals = list(StandingGoal.objects.order_by("created_at"))
-    if json_output:
-        rows = [{"name": g.name, "check_command": g.check_command, "active": g.active} for g in goals]
-        stdout_write(json.dumps({"ok": True, "goals": rows}, indent=2))
-        return
+    rows = [{"name": g.name, "check_command": g.check_command, "active": g.active} for g in goals]
     if not goals:
-        stdout_write("NOOP  no standing goals registered.")
-        return
-    for goal in goals:
-        state = "active" if goal.active else "retired"
-        stdout_write(f"{state:8}{goal.name} — `{goal.check_command}`")
+        human: str | None = "NOOP  no standing goals registered."
+    else:
+        human = "\n".join(
+            f"{'active' if goal.active else 'retired':8}{goal.name} — `{goal.check_command}`" for goal in goals
+        )
+    out, err = _out_err(command)
+    emit({"ok": True, "goals": rows}, json_output=json_output, out=out, err=err, human=human)
 
 
 class Command(TyperCommand):
@@ -79,7 +84,7 @@ class Command(TyperCommand):
         json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
     ) -> None:
         """Register (or re-arm) a standing verified-green goal."""
-        _set(name, check, json_output=json_output, stdout_write=self.stdout.write)
+        _set(self, name, check, json_output=json_output)
 
     @command(name="clear")
     def clear(
@@ -89,7 +94,7 @@ class Command(TyperCommand):
         json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
     ) -> None:
         """Delete one named standing goal, or every goal when no name is given."""
-        _clear(name, json_output=json_output, stdout_write=self.stdout.write)
+        _clear(self, name, json_output=json_output)
 
     @command(name="list")
     def list_goals(
@@ -98,4 +103,4 @@ class Command(TyperCommand):
         json_output: Annotated[bool, typer.Option("--json", help="Emit JSON.")] = False,
     ) -> None:
         """List every registered standing goal and its active state."""
-        _list(json_output=json_output, stdout_write=self.stdout.write)
+        _list(self, json_output=json_output)

--- a/tests/teatree_cli/test_cli_loop.py
+++ b/tests/teatree_cli/test_cli_loop.py
@@ -531,7 +531,7 @@ class TestLoopOwnerCli:
         result = runner.invoke(loop_app, ["claim"])
 
         assert result.exit_code == 0, result.stdout
-        assert "claimed loop slot" in result.stdout
+        assert "claimed loop slot" in result.stderr
         assert LoopLease.objects.get(name="t3-master").session_id == "cli-session"
 
     def test_claim_without_session_id_exits_2(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
@@ -541,7 +541,7 @@ class TestLoopOwnerCli:
         result = runner.invoke(loop_app, ["claim"])
 
         assert result.exit_code == 2
-        assert "refusing to claim loop ownership without a Claude session id" in result.stdout
+        assert "refusing to claim loop ownership without a Claude session id" in result.stderr
 
     def test_owner_reports_live_holder(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from teatree.core.models import LoopLease  # noqa: PLC0415
@@ -550,13 +550,13 @@ class TestLoopOwnerCli:
         result = runner.invoke(loop_app, ["owner"])
 
         assert result.exit_code == 0
-        assert "held-by" in result.stdout
+        assert "held-by" in result.stderr
 
     def test_owner_reports_unclaimed(self) -> None:
         result = runner.invoke(loop_app, ["owner"])
 
         assert result.exit_code == 0
-        assert "unclaimed" in result.stdout
+        assert "unclaimed" in result.stderr
 
     def test_release_only_clears_own_claim(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from teatree.core.models import LoopLease  # noqa: PLC0415
@@ -566,7 +566,7 @@ class TestLoopOwnerCli:
         result = runner.invoke(loop_app, ["release"])
 
         assert result.exit_code == 0
-        assert "nothing released" in result.stdout
+        assert "nothing released" in result.stderr
         assert LoopLease.objects.get(name="t3-master").session_id == "other-session"
 
     def test_release_clears_when_holder(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -577,7 +577,7 @@ class TestLoopOwnerCli:
         result = runner.invoke(loop_app, ["release"])
 
         assert result.exit_code == 0
-        assert "released loop slot" in result.stdout
+        assert "released loop slot" in result.stderr
         assert LoopLease.objects.get(name="t3-master").session_id == ""
 
     def test_take_over_seizes_live_claim(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -588,7 +588,7 @@ class TestLoopOwnerCli:
         result = runner.invoke(loop_app, ["claim", "--take-over"])
 
         assert result.exit_code == 0
-        assert "claimed loop slot" in result.stdout
+        assert "claimed loop slot" in result.stderr
         assert LoopLease.objects.get(name="t3-master").session_id == "main"
 
     def test_claim_without_take_over_is_blocked(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -599,7 +599,7 @@ class TestLoopOwnerCli:
         result = runner.invoke(loop_app, ["claim"])
 
         assert result.exit_code == 0
-        assert "held by session hijacker" in result.stdout
+        assert "held by session hijacker" in result.stderr
         assert LoopLease.objects.get(name="t3-master").session_id == "hijacker"
 
     def test_owner_json_shape(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -639,7 +639,7 @@ class TestLoopOwnerCli:
         result = runner.invoke(loop_app, ["claim", "--driver", "bogus"])
 
         assert result.exit_code == 2
-        assert "invalid --driver" in result.stdout
+        assert "invalid --driver" in result.stderr
 
     def test_claim_json_success_shape(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import json  # noqa: PLC0415

--- a/tests/teatree_cli/test_cli_loop_state.py
+++ b/tests/teatree_cli/test_cli_loop_state.py
@@ -107,8 +107,9 @@ class TestLoopStateCommandIsReadOnly(TestCase):
 
     def test_loop_state_output_reads_as_a_status(self) -> None:
         result = runner.invoke(loop_app, ["loop-state", "review"])
-        assert "is now" not in result.stdout
-        assert "ENABLED" in result.stdout
+        # The human view routes through the emit() seam to stderr; stdout stays a clean JSON channel.
+        assert "is now" not in result.stderr
+        assert "ENABLED" in result.stderr
 
 
 class TestUnknownLoopNameRefused(TestCase):
@@ -134,5 +135,5 @@ class TestUnknownLoopNameRefused(TestCase):
 
     def test_refusal_names_the_loop_and_suggests_loops_list(self) -> None:
         result = runner.invoke(loop_app, ["pause", self._BOGUS, "--emergency"])
-        assert self._BOGUS in result.stdout
-        assert "t3 loops list" in result.stdout
+        assert self._BOGUS in result.stderr
+        assert "t3 loops list" in result.stderr

--- a/tests/teatree_core/management/test_loop_owner_driver.py
+++ b/tests/teatree_core/management/test_loop_owner_driver.py
@@ -46,9 +46,9 @@ class TestClaimWithSelfPumpRegisters(TestCase):
 
 class TestClaimWithNothingWarnsLoud(TestCase):
     def test_claim_succeeds_but_warns_with_remediation_verbatim(self) -> None:
-        out, err = _claim(slot="loop:dispatch", detected="")
-        # The claim itself SUCCEEDS (exit 0, OK on stdout) — driverless is a warning, not a refusal.
-        assert "OK    claimed" in out
+        _out, err = _claim(slot="loop:dispatch", detected="")
+        # The claim itself SUCCEEDS (exit 0, OK on the human/stderr channel) — driverless is a warning, not a refusal.
+        assert "OK    claimed" in err
         assert LoopLease.objects.get(name="loop:dispatch").driver == ""
         # The three remedies are named verbatim.
         assert "t3 worker" in err
@@ -81,6 +81,7 @@ class TestOwnerSurfacesDriver(TestCase):
     def test_owner_text_reports_driverless(self) -> None:
         _claim(slot="loop:dispatch", detected="")
         out = io.StringIO()
+        err = io.StringIO()
         with mock.patch("teatree.loop.session_identity.current_session_id", return_value="sess-x"):
-            call_command("loop_owner", "owner", slot="loop:dispatch", stdout=out)
-        assert "driver: DRIVERLESS" in out.getvalue()
+            call_command("loop_owner", "owner", slot="loop:dispatch", stdout=out, stderr=err)
+        assert "driver: DRIVERLESS" in err.getvalue()

--- a/tests/teatree_core/management/test_loop_preset_command.py
+++ b/tests/teatree_core/management/test_loop_preset_command.py
@@ -15,9 +15,12 @@ from teatree.core.models import PIN_MODES, Loop, Mode, ModeOverride
 
 
 def _run(*args: str, **kwargs: object) -> str:
+    # emit() sends JSON to stdout and the human view to stderr — one channel per
+    # call — so their concatenation is the single populated output stream.
     out = io.StringIO()
-    call_command("loop_preset", *args, stdout=out, **kwargs)
-    return out.getvalue()
+    err = io.StringIO()
+    call_command("loop_preset", *args, stdout=out, stderr=err, **kwargs)
+    return out.getvalue() + err.getvalue()
 
 
 @django.test.override_settings(USE_TZ=True, TIME_ZONE="UTC")

--- a/tests/teatree_core/management/test_loop_schedule_command.py
+++ b/tests/teatree_core/management/test_loop_schedule_command.py
@@ -13,9 +13,12 @@ from teatree.loop.preset_resolution import ACTIVE_SCHEDULE_SETTING
 
 
 def _run(*args: str, **kwargs: object) -> str:
+    # emit() sends JSON to stdout and the human view to stderr — one channel per
+    # call — so their concatenation is the single populated output stream.
     out = io.StringIO()
-    call_command("loop_schedule", *args, stdout=out, **kwargs)
-    return out.getvalue()
+    err = io.StringIO()
+    call_command("loop_schedule", *args, stdout=out, stderr=err, **kwargs)
+    return out.getvalue() + err.getvalue()
 
 
 @django.test.override_settings(USE_TZ=True, TIME_ZONE="UTC")

--- a/tests/teatree_core/management/test_loop_state_command.py
+++ b/tests/teatree_core/management/test_loop_state_command.py
@@ -19,9 +19,12 @@ from teatree.core.models import Loop, LoopState, LoopStatus, Prompt
 
 
 def _run(*args: str) -> str:
+    # emit() sends JSON to stdout and the human view to stderr — one channel per
+    # call — so their concatenation is the single populated output stream.
     out = StringIO()
-    call_command("loop_state", *args, stdout=out)
-    return out.getvalue()
+    err = StringIO()
+    call_command("loop_state", *args, stdout=out, stderr=err)
+    return out.getvalue() + err.getvalue()
 
 
 def _loop(name: str, *, enabled: bool) -> Loop:
@@ -166,10 +169,11 @@ class TestUnknownLoopNameRefused(TestCase):
 
     def _refuse(self, *args: str) -> str:
         out = StringIO()
+        err = StringIO()
         with pytest.raises(SystemExit) as caught:
-            call_command("loop_state", *args, self._BOGUS, stdout=out)
+            call_command("loop_state", *args, self._BOGUS, stdout=out, stderr=err)
         assert caught.value.code == 2
-        return out.getvalue()
+        return out.getvalue() + err.getvalue()
 
     def test_pause_unknown_name_refused_no_row(self) -> None:
         out = self._refuse("pause")

--- a/tests/teatree_core/management_commands/test_handover.py
+++ b/tests/teatree_core/management_commands/test_handover.py
@@ -18,8 +18,15 @@ from teatree.core.models import LoopLease, SessionHandover
 
 def _call(*args: str, **kwargs) -> str:
     buf = StringIO()
-    call_command(*args, stdout=buf, **kwargs)
+    call_command(*args, stdout=buf, stderr=StringIO(), **kwargs)
     return buf.getvalue()
+
+
+def _call_human(*args: str, **kwargs) -> str:
+    """Capture the human view — the emit() seam routes it to stderr, stdout stays JSON-only."""
+    err = StringIO()
+    call_command(*args, stdout=StringIO(), stderr=err, **kwargs)
+    return err.getvalue()
 
 
 class _PinnedSessionTestCase(TestCase):
@@ -91,8 +98,9 @@ class TestHandoverCreate(_PinnedSessionTestCase):
         assert json.loads(out)["to_session"] == "target-Z"
 
     def test_human_output_reports_ok_and_the_mirror(self) -> None:
-        # The non-JSON path: durable state present → "OK" status and the mirror path.
-        out = _call("handover", "create", to="target-Z")
+        # The non-JSON path: durable state present → "OK" status and the mirror path,
+        # now routed to stderr so stdout stays a pure JSON channel (emit seam).
+        out = _call_human("handover", "create", to="target-Z")
         assert "OK" in out
         assert "handed off to target-Z" in out
         assert "mirror written to" in out
@@ -164,7 +172,7 @@ class TestHandoverDrivesSubagents(_PinnedSessionTestCase):
 
 class TestHandoverWhoami(_PinnedSessionTestCase):
     def test_whoami_prints_session_id(self) -> None:
-        assert _call("handover", "whoami").strip() == "this-session"
+        assert _call_human("handover", "whoami").strip() == "this-session"
 
     def test_whoami_json(self) -> None:
         assert json.loads(_call("handover", "whoami", json_output=True))["session_id"] == "this-session"
@@ -191,10 +199,10 @@ class TestHandoverClaimOnStart(_PinnedSessionTestCase):
 
 class TestLoopWhoamiAndOwnerDisplay(_PinnedSessionTestCase):
     def test_loop_owner_whoami_prints_session_id(self) -> None:
-        assert _call("loop_owner", "whoami").splitlines()[0].strip() == "this-session"
+        assert _call_human("loop_owner", "whoami").splitlines()[0].strip() == "this-session"
 
     def test_loop_owner_shows_you_are(self) -> None:
-        out = _call("loop_owner", "owner")
+        out = _call_human("loop_owner", "owner")
         assert "you are: this-session" in out
 
     def test_loop_owner_json_includes_you_and_owner_flag(self) -> None:

--- a/tests/teatree_core/models/test_session_todo.py
+++ b/tests/teatree_core/models/test_session_todo.py
@@ -85,7 +85,7 @@ class SessionTodoCommandTest(TestCase):
         call_command("session", "todo-add", "first thread", session_pk=session.pk)
         call_command("session", "todo-add", "second thread", session_pk=session.pk)
         out = StringIO()
-        call_command("session", "todo-list", session_pk=session.pk, stdout=out)
+        call_command("session", "todo-list", session_pk=session.pk, stdout=out, stderr=out)
         text = out.getvalue()
         assert "first thread" in text
         assert "second thread" in text
@@ -103,7 +103,7 @@ class SessionTodoCommandTest(TestCase):
     def test_todo_list_reports_no_items_when_empty(self) -> None:
         session = self._session()
         out = StringIO()
-        call_command("session", "todo-list", session_pk=session.pk, stdout=out)
+        call_command("session", "todo-list", session_pk=session.pk, stdout=out, stderr=out)
         assert "(no items)" in out.getvalue()
 
     def test_the_live_session_is_resolved_from_the_agent_id(self) -> None:
@@ -115,7 +115,7 @@ class SessionTodoCommandTest(TestCase):
             return_value="entrypoint-abc",
         ):
             out = StringIO()
-            call_command("session", "todo-list", stdout=out)
+            call_command("session", "todo-list", stdout=out, stderr=out)
         assert "resume the drain" in out.getvalue()
 
     def test_no_session_recorded_for_the_agent_id_names_the_escape(self) -> None:

--- a/tests/teatree_core/test_loop_dispatch_command.py
+++ b/tests/teatree_core/test_loop_dispatch_command.py
@@ -108,9 +108,9 @@ class TestPendingSpawn(_LoopDispatchTest):
         assert json.loads(stdout.getvalue()) == []
 
     def test_text_output_when_empty(self) -> None:
-        stdout = StringIO()
-        call_command("loop_dispatch", "pending-spawn", stdout=stdout)
-        assert "No pending spawn requests." in stdout.getvalue()
+        stderr = StringIO()
+        call_command("loop_dispatch", "pending-spawn", stdout=StringIO(), stderr=stderr)
+        assert "No pending spawn requests." in stderr.getvalue()
 
     def test_payload_carries_model_and_skill_bundle(self) -> None:
         # The model tier + skill bundle are resolved in LOOP scope and threaded
@@ -290,10 +290,10 @@ class TestClaimNextAtomicDispatch(_LoopDispatchTest):
     def test_claim_next_text_output_when_claimed(self) -> None:
         """N3: the non-JSON branch — emits a human line for the claimed task."""
         task = self._reviewer_task()
-        stdout = StringIO()
-        call_command("loop_dispatch", "claim-next", stdout=stdout)
+        stderr = StringIO()
+        call_command("loop_dispatch", "claim-next", stdout=StringIO(), stderr=stderr)
 
-        out = stdout.getvalue()
+        out = stderr.getvalue()
         assert f"Claimed task={task.pk}" in out
         assert "subagent=t3:reviewer" in out
         assert "phase=reviewing" in out
@@ -302,9 +302,9 @@ class TestClaimNextAtomicDispatch(_LoopDispatchTest):
 
     def test_claim_next_text_output_when_empty(self) -> None:
         """N3: the non-JSON empty branch."""
-        stdout = StringIO()
-        call_command("loop_dispatch", "claim-next", stdout=stdout)
-        assert "No pending spawn requests." in stdout.getvalue()
+        stderr = StringIO()
+        call_command("loop_dispatch", "claim-next", stdout=StringIO(), stderr=stderr)
+        assert "No pending spawn requests." in stderr.getvalue()
 
     def test_claim_next_session_defaults_to_current_session_id(self) -> None:
         """#1917: an unset ``--claimed-by-session`` resolves to the active session id."""

--- a/tests/teatree_core/test_loops_list_command.py
+++ b/tests/teatree_core/test_loops_list_command.py
@@ -23,9 +23,12 @@ def _prompt(name: str = "demo-prompt") -> Prompt:
 
 
 def _run(*args: str) -> str:
+    # The emit() seam sends JSON to stdout and the human view to stderr; exactly
+    # one channel is populated per invocation, so their concatenation is the output.
     out = io.StringIO()
-    call_command("loops_list", *args, stdout=out)
-    return out.getvalue()
+    err = io.StringIO()
+    call_command("loops_list", *args, stdout=out, stderr=err)
+    return out.getvalue() + err.getvalue()
 
 
 @django.test.override_settings(USE_TZ=True)

--- a/tests/teatree_core/test_loops_tick_command.py
+++ b/tests/teatree_core/test_loops_tick_command.py
@@ -65,9 +65,12 @@ class TestHardExitGuard:
 
 
 def _run(**kwargs: object) -> str:
+    # emit() sends JSON to stdout and the human view to stderr — one channel per
+    # call — so their concatenation is the single populated output stream.
     out = io.StringIO()
-    call_command("loops_tick", stdout=out, **kwargs)
-    return out.getvalue()
+    err = io.StringIO()
+    call_command("loops_tick", stdout=out, stderr=err, **kwargs)
+    return out.getvalue() + err.getvalue()
 
 
 class _CleanOverlay(OverlayBase):

--- a/tests/teatree_core/test_prompts_command.py
+++ b/tests/teatree_core/test_prompts_command.py
@@ -16,9 +16,12 @@ from teatree.core.models import Prompt
 
 
 def _list(*args: str) -> str:
+    # emit() routes the human view to stderr and JSON to stdout — one channel per
+    # call — so their concatenation is the single populated output stream.
     out = io.StringIO()
-    call_command("prompts_list", *args, stdout=out)
-    return out.getvalue()
+    err = io.StringIO()
+    call_command("prompts_list", *args, stdout=out, stderr=err)
+    return out.getvalue() + err.getvalue()
 
 
 def _render(*args: str) -> str:

--- a/tests/teatree_core/test_session_command.py
+++ b/tests/teatree_core/test_session_command.py
@@ -55,9 +55,9 @@ class TestPrepareStopCommand(TestCase):
         work = self.tmp / "work2"
         work.mkdir()
         os.chdir(work)
-        out = StringIO()
-        call_command("session", "prepare-stop", stdout=out)
-        text = out.getvalue()
+        err = StringIO()
+        call_command("session", "prepare-stop", stdout=StringIO(), stderr=err)
+        text = err.getvalue()
         assert "resume plan:" in text
         assert "at-risk worktrees: none" in text
 

--- a/tests/teatree_core/test_session_identity.py
+++ b/tests/teatree_core/test_session_identity.py
@@ -252,7 +252,8 @@ class TestLoopClaimSucceedsViaRegistrySessionId:
         )
         out = io.StringIO()
         with patch.dict("os.environ", {**_no_session_env(), "T3_LOOP_REGISTRY_DIR": str(tmp_path)}, clear=True):
-            call_command("loop_owner", "claim", "--take-over", stdout=out)
+            # emit() routes the human view to stderr; capture it in the same buffer for the assertion.
+            call_command("loop_owner", "claim", "--take-over", stdout=out, stderr=out)
 
         assert "OK    claimed" in out.getvalue()
         status = LoopLease.objects.ownership_status("t3-master")

--- a/tests/teatree_loop/self_improve/test_loop_self_improve_command.py
+++ b/tests/teatree_loop/self_improve/test_loop_self_improve_command.py
@@ -54,7 +54,7 @@ class LoopSelfImproveCommandTests(TestCase):
         MergeClear.objects.filter(pk=clear.pk).update(issued_at=old)
 
         out = io.StringIO()
-        call_command("loop_self_improve", tier="cheap", stdout=out)
+        call_command("loop_self_improve", tier="cheap", stdout=out, stderr=out)
 
         # The forgotten_merge detector must have written a firing.
         assert SelfImproveFiring.objects.filter(detector="forgotten_merge").count() == 1
@@ -110,7 +110,7 @@ class LoopSelfImproveCommandTests(TestCase):
                 patch.dict(os.environ, {"XDG_DATA_HOME": data_home}),
                 patch("teatree.loop.phases.render.self_improve_rerender") as seam,
             ):
-                call_command("loop_self_improve", tier="cheap", stdout=out)
+                call_command("loop_self_improve", tier="cheap", stdout=out, stderr=out)
 
         seam.assert_called_once()
         assert SelfImproveFiring.objects.filter(detector="stale_statusline_entry").count() == 1

--- a/tests/teatree_loop/slack_answer/test_loop_slack_answer_command.py
+++ b/tests/teatree_loop/slack_answer/test_loop_slack_answer_command.py
@@ -73,7 +73,7 @@ class TestLoopSlackAnswerCommand:
             "teatree.core.backend_factory.messaging_from_overlay",
             return_value=backend,
         ):
-            call_command("loop_slack_answer", stdout=out)
+            call_command("loop_slack_answer", stdout=out, stderr=out)
 
         assert "OK" in out.getvalue()
         assert any(e[2] for e in backend.reactions)
@@ -97,7 +97,7 @@ class TestLoopSlackAnswerCommand:
         PendingChatInjection.record(channel="C1", slack_ts="1.0", text="thanks!")
         LoopLease.objects.acquire("loop-slack-answer", owner="other-pid")
         out = io.StringIO()
-        call_command("loop_slack_answer", stdout=out)
+        call_command("loop_slack_answer", stdout=out, stderr=out)
 
         assert "SKIP" in out.getvalue()
 
@@ -111,7 +111,7 @@ class TestLoopSlackAnswerCommand:
                 return_value=False,
             ),
         ):
-            call_command("loop_slack_answer", stdout=out)
+            call_command("loop_slack_answer", stdout=out, stderr=out)
 
         assert "SKIP" in out.getvalue()
         assert PendingChatInjection.loop_unreplied().count() == 1


### PR DESCRIPTION
## What

Finishes the emit() machine-output migration for the imperative human-view-to-stdout cluster of management commands. Each hand-rolled json.dumps branch that also wrote its human view to self.stdout now routes through core.machine_output.emit — JSON to stdout, human diagnostics to stderr — following the retention.py reference model.

Under the json flag, stdout is a pure JSON channel; otherwise stdout stays empty and the human view goes to stderr. The json contract (keys and shape) is preserved for every command; the only observable changes are the human view moving from stdout to stderr, and compact JSON instead of indent 2 (the seam canonical form: byte-equivalent where the payload was already compact, parse-equivalent otherwise).

## Migrated (15)

- handover.py — the worst verified offender: create, whoami and claim-on-start all wrote the human view to stdout (create around lines 92 to 96). Fixed.
- loop_owner.py, loop_state.py, standing_goal.py — the stdout-write closure helpers refactored to take the command instance and emit through it.
- loop_schedule.py, loop_preset.py — central emit and refuse helpers plus the list and show direct writes.
- loop_slack_answer.py, loop_self_improve.py, loop_drain_queue.py, loop_dispatch.py, loop_tick.py, loops_tick.py, loops_list.py, prompts_list.py, session.py.

## Deliberately left alone (with rationale)

- _sweep_commands.py — owned by a separate refactor (cluster 2); untouched to avoid a merge conflict.
- env.py show — uses a shell-or-json format selector; the shell output is machine-sourced by a shell eval, not a human view, so it must remain on stdout. Not an emit-seam case.
- db.py query and review_request_post.py emit — always-JSON with no human branch: already a pure JSON channel, no stdout pollution to fix. Migrating would also risk changing their intentional str-serialization of datetimes.
- The return-based commands (signals, cost, checking, questions, waiting, recover, availability, health, tokens, info, recipe, retro) — these emit via django-typer's return path; their json output is already pure with no in-invocation interleave. Converting the return seam (flip primary human UX to stderr plus print_result plumbing) is a distinct, larger follow-up slice, deferred to keep this PR coherent.
- _e2e_lanes.py, _test_plan/render.py, _test_plan/tracked.py, _workspace/salvage.py, recipe.py options-json — json used for data strings, HTML markers or DB field values, not stdout result emission.

## Tests

Tests updated to read the human view from stderr (JSON assertions unchanged). Capture helpers concatenate stdout and stderr (exactly one channel is populated per invocation); Typer CLI tests assert on result.stderr for the human path. No new suppressions.

Verified locally: scoped tests for all touched commands and their CLI wrappers, ruff check, ruff format and ty check on changed files, plus the tree-wide gates test_no_flat_core_regrowth, test_teatree_skill_cli_reference, and t3 tool test-path-mirror (ledger exact).