### PR TITLE
refactor(hooks): shared diff added-line parser for the privacy hooks

### DIFF
--- a/src/teatree/hooks/_diff_lines.py
+++ b/src/teatree/hooks/_diff_lines.py
@@ -1,0 +1,90 @@
+r"""Shared unified-diff added-line parsing for the two privacy diff hooks.
+
+Both privacy diff hooks walk a unified diff's ADDED lines scoped by file path
+and language: the ``code_comment_self_reference`` leak scan
+(:mod:`privacy_diff_comments`) and the advisory ``code_comment_density`` pass
+(:mod:`privacy_diff_comment_density`). This module holds the parsing primitives
+they share — the ``+++`` file-header regex, the added-line predicate, the
+added-line generator, and the doc-exempt / slash-comment suffix tables — so the
+two hooks keep one copy of the diff plumbing and diverge only in their detection
+logic.
+
+Not routed through :func:`teatree.quality.gate_relaxation.parse_diff`: that
+parser groups per-file added/removed bodies but drops each added line's 1-based
+position within the diff text (the leak scan needs it to line up with
+``privacy_scan.py``'s per-line findings) and requires a ``b/`` header prefix,
+whereas these hooks accept a bare ``+++ <path>`` header and strip trailing tab
+metadata (``+++ b/<path>\t<timestamp>``). The density hook additionally consumes
+context lines and hunk headers, which an added-only iterator cannot carry — so
+it reuses the primitives below rather than the generator.
+"""
+
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+# A unified-diff ``+++ b/<path>`` new-file header. The ``b/`` prefix is optional
+# and any trailing tab metadata (``\t<timestamp>``) is stripped, so ``path`` is
+# the repo-relative file path.
+FILE_HEADER_RE = re.compile(r"^\+\+\+ (?:b/)?(.+?)(?:\t.*)?$")
+
+# File suffixes whose languages use ``//`` line comments and ``/* */`` blocks.
+SLASH_COMMENT_SUFFIXES = (".ts", ".tsx", ".js", ".jsx", ".java", ".go", ".c", ".cpp", ".cs", ".scss", ".css")
+
+# Docs / markdown files legitimately cite MRs / tickets and carry prose — both
+# hooks exempt them (density additionally exempts config + tests; see its
+# ``_is_exempt_file``).
+DOC_SUFFIXES = (".md", ".rst", ".txt", ".adoc")
+DOC_PATH_PREFIXES = ("docs/",)
+DOC_BASENAME_PREFIXES = ("CHANGELOG",)
+
+
+def is_added_line(raw: str) -> bool:
+    """True for a unified-diff added body line (``+…`` but not the ``+++`` header)."""
+    return raw.startswith("+") and not raw.startswith("+++")
+
+
+def is_doc_path(path: str) -> bool:
+    """True when ``path`` is markdown/docs (suffix, a ``docs/`` segment, or ``CHANGELOG*``)."""
+    lowered = path.lower()
+    if lowered.endswith(DOC_SUFFIXES):
+        return True
+    if any(lowered.startswith(prefix) or f"/{prefix}" in lowered for prefix in DOC_PATH_PREFIXES):
+        return True
+    basename = path.rsplit("/", 1)[-1]
+    return any(basename.startswith(prefix) for prefix in DOC_BASENAME_PREFIXES)
+
+
+@dataclass(frozen=True)
+class AddedLine:
+    """One added line in a unified diff, with its enclosing-file context.
+
+    ``lineno`` is the 1-based position within the whole diff text (so it lines
+    up with ``privacy_scan.py``'s per-line findings), ``path`` is the enclosing
+    file's repo-relative path, and ``body`` is the line with its leading ``+``
+    stripped.
+    """
+
+    lineno: int
+    path: str
+    body: str
+
+
+def iter_added_lines(text: str) -> Iterator[AddedLine]:
+    """Yield each added line in a unified diff with its file context.
+
+    Walks ``text`` line by line, tracking the current ``+++`` file header. An
+    added body line that appears before any file header — a malformed diff — is
+    skipped, since it has no path context.
+    """
+    current_path: str | None = None
+    for lineno, raw in enumerate(text.splitlines(), 1):
+        header = FILE_HEADER_RE.match(raw)
+        if header is not None:
+            current_path = header.group(1)
+            continue
+        if not is_added_line(raw):
+            continue
+        if current_path is None:
+            continue
+        yield AddedLine(lineno=lineno, path=current_path, body=raw[1:])

--- a/src/teatree/hooks/privacy_diff_comment_density.py
+++ b/src/teatree/hooks/privacy_diff_comment_density.py
@@ -36,6 +36,15 @@ down; markdown/docs, declarative config, and ``tests/``.
 import re
 from dataclasses import dataclass
 
+from teatree.hooks._diff_lines import (
+    DOC_BASENAME_PREFIXES,
+    DOC_PATH_PREFIXES,
+    DOC_SUFFIXES,
+    FILE_HEADER_RE,
+    SLASH_COMMENT_SUFFIXES,
+    is_added_line,
+)
+
 _ALLOW_MARKER = "privacy-scan:allow"
 _SECURITY_RATIONALE_MARKER = "security:"
 
@@ -67,16 +76,14 @@ _MIN_ADDED_CODE_LINES = 3
 _MIN_ADDED_COMMENT_LINES = 3
 _CONSECUTIVE_COMMENT_WARN_THRESHOLD = 2
 
+# Unlike the self-reference leak scan, YAML/TOML/INI are config surfaces
+# exempt from the density pass entirely (``_is_exempt_file``), so the
+# hash-comment set here stays code-only.
 _HASH_COMMENT_SUFFIXES = (".py", ".sh", ".bash", ".rb")
-_SLASH_COMMENT_SUFFIXES = (".ts", ".tsx", ".js", ".jsx", ".java", ".go", ".c", ".cpp", ".cs", ".scss", ".css")
 
-_DOC_SUFFIXES = (".md", ".rst", ".txt", ".adoc")
 _CONFIG_SUFFIXES = (".yml", ".yaml", ".toml", ".cfg", ".ini")
-_DOC_PATH_PREFIXES = ("docs/",)
-_DOC_BASENAME_PREFIXES = ("CHANGELOG",)
 _TEST_PATH_PREFIXES = ("tests/", "test/")
 
-_FILE_HEADER_RE = re.compile(r"^\+\+\+ (?:b/)?(.+?)(?:\t.*)?$")
 _HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
 _HASH_COMMENT_RE = re.compile(r"^\s*#")
 _SLASH_COMMENT_RE = re.compile(r"^\s*(?://|/\*|\*)")
@@ -231,19 +238,19 @@ def _echoes_signature(words: list[str], name_words: set[str]) -> bool:
 
 def _is_exempt_file(path: str) -> bool:
     lowered = path.lower()
-    if lowered.endswith((*_DOC_SUFFIXES, *_CONFIG_SUFFIXES)):
+    if lowered.endswith((*DOC_SUFFIXES, *_CONFIG_SUFFIXES)):
         return True
-    if any(lowered.startswith(p) or f"/{p}" in lowered for p in (*_DOC_PATH_PREFIXES, *_TEST_PATH_PREFIXES)):
+    if any(lowered.startswith(p) or f"/{p}" in lowered for p in (*DOC_PATH_PREFIXES, *_TEST_PATH_PREFIXES)):
         return True
     basename = path.rsplit("/", 1)[-1]
-    return any(basename.startswith(p) for p in _DOC_BASENAME_PREFIXES)
+    return any(basename.startswith(p) for p in DOC_BASENAME_PREFIXES)
 
 
 def _comment_re(path: str) -> re.Pattern[str] | None:
     lowered = path.lower()
     if lowered.endswith(_HASH_COMMENT_SUFFIXES):
         return _HASH_COMMENT_RE
-    if lowered.endswith(_SLASH_COMMENT_SUFFIXES):
+    if lowered.endswith(SLASH_COMMENT_SUFFIXES):
         return _SLASH_COMMENT_RE
     return None
 
@@ -288,7 +295,7 @@ class _FileScan:
         if raw.startswith(" "):
             self._feed_context_line(raw[1:])
             return
-        if not raw.startswith("+") or raw.startswith("+++"):
+        if not is_added_line(raw):
             return
         self._feed_added_line(raw[1:], comment_re)
 
@@ -429,7 +436,7 @@ def _iter_file_scans(text: str) -> "list[tuple[int, str, _FileScan]]":
             results.append((header_lineno, current_path, scan))
 
     for lineno, raw in enumerate(text.splitlines(), 1):
-        header = _FILE_HEADER_RE.match(raw)
+        header = FILE_HEADER_RE.match(raw)
         if header is not None:
             flush()
             current_path = header.group(1)

--- a/src/teatree/hooks/privacy_diff_comments.py
+++ b/src/teatree/hooks/privacy_diff_comments.py
@@ -27,6 +27,8 @@ target.
 
 import re
 
+from teatree.hooks._diff_lines import SLASH_COMMENT_SUFFIXES, is_doc_path, iter_added_lines
+
 # Inline allow-annotation, shared with ``privacy_scan.py``. A comment line
 # carrying this literal marker is exempt (used by the scanner's own
 # fixtures and doc examples).
@@ -66,28 +68,10 @@ _SELF_REF_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\bpentest\b", re.IGNORECASE),
 )
 
-# File suffixes whose languages use ``#`` line comments.
+# File suffixes whose languages use ``#`` line comments. Unlike the density
+# pass, YAML/TOML count here: a ``#`` comment in config CAN carry a bookkeeping
+# self-reference worth flagging.
 _HASH_COMMENT_SUFFIXES = (".py", ".sh", ".bash", ".rb", ".yml", ".yaml", ".toml")
-# File suffixes whose languages use ``//`` line comments and ``/* */`` blocks.
-_SLASH_COMMENT_SUFFIXES = (".ts", ".tsx", ".js", ".jsx", ".java", ".go", ".c", ".cpp", ".cs", ".scss", ".css")
-
-# Docs / markdown files legitimately cite MRs / tickets — fully exempt.
-_DOC_SUFFIXES = (".md", ".rst", ".txt", ".adoc")
-_DOC_PATH_PREFIXES = ("docs/",)
-_DOC_BASENAME_PREFIXES = ("CHANGELOG",)
-
-_FILE_HEADER_RE = re.compile(r"^\+\+\+ (?:b/)?(.+?)(?:\t.*)?$")
-
-
-def _is_doc_file(path: str) -> bool:
-    """True when ``path`` is markdown/docs and therefore exempt."""
-    lowered = path.lower()
-    if lowered.endswith(_DOC_SUFFIXES):
-        return True
-    if any(lowered.startswith(prefix) or f"/{prefix}" in lowered for prefix in _DOC_PATH_PREFIXES):
-        return True
-    basename = path.rsplit("/", 1)[-1]
-    return any(basename.startswith(prefix) for prefix in _DOC_BASENAME_PREFIXES)
 
 
 def _comment_text(path: str, code: str) -> str | None:
@@ -106,7 +90,7 @@ def _comment_text(path: str, code: str) -> str | None:
     if lowered.endswith(_HASH_COMMENT_SUFFIXES):
         marker = code.find("#")
         return code[marker:] if marker != -1 else None
-    if lowered.endswith(_SLASH_COMMENT_SUFFIXES):
+    if lowered.endswith(SLASH_COMMENT_SUFFIXES):
         line_marker = code.find("//")
         block_open = code.find("/*")
         markers = [m for m in (line_marker, block_open) if m != -1]
@@ -149,23 +133,15 @@ def scan_diff(text: str) -> list[tuple[int, str, str]]:
     files** are scanned, and only the **comment** portion of each.
     """
     findings: list[tuple[int, str, str]] = []
-    current_path: str | None = None
-    for lineno, raw in enumerate(text.splitlines(), 1):
-        header = _FILE_HEADER_RE.match(raw)
-        if header is not None:
-            current_path = header.group(1)
+    for line in iter_added_lines(text):
+        if is_doc_path(line.path):
             continue
-        if not raw.startswith("+") or raw.startswith("+++"):
+        if _ALLOW_MARKER in line.body:
             continue
-        if current_path is None or _is_doc_file(current_path):
-            continue
-        added = raw[1:]
-        if _ALLOW_MARKER in added:
-            continue
-        comment = _comment_text(current_path, added)
+        comment = _comment_text(line.path, line.body)
         if comment is None:
             continue
         match = _matches_self_ref(comment)
         if match is not None:
-            findings.append((lineno, CATEGORY, match))
+            findings.append((line.lineno, CATEGORY, match))
     return findings

--- a/tests/teatree_hooks/test_diff_lines.py
+++ b/tests/teatree_hooks/test_diff_lines.py
@@ -1,0 +1,78 @@
+"""Tests for the shared unified-diff added-line parser (``hooks/_diff_lines``).
+
+The two privacy diff hooks route their added-line iteration through this
+module. These cover the parsing primitives directly: the ``+`` vs ``+++`` edge
+(a file header is never mistaken for an added line), multi-file hunks (each
+added line carries its own file's path), the 1-based line-number contract, and
+the header-regex tolerances (optional ``b/`` prefix, stripped tab metadata).
+"""
+
+from teatree.hooks._diff_lines import is_added_line, is_doc_path, iter_added_lines
+
+
+def _diff(path: str, *added_lines: str) -> str:
+    body = "".join(f"+{line}\n" for line in added_lines)
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"index 0000000..1111111 100644\n"
+        f"--- a/{path}\n"
+        f"+++ b/{path}\n"
+        f"@@ -0,0 +1,{len(added_lines)} @@\n"
+        f"{body}"
+    )
+
+
+class TestIsAddedLine:
+    def test_added_body_line_is_added(self) -> None:
+        assert is_added_line("+    x = 1")
+
+    def test_file_header_is_not_added(self) -> None:
+        # The `+++ b/<path>` header shares the `+` prefix but is not a body line.
+        assert not is_added_line("+++ b/src/x.py")
+
+    def test_context_and_removed_lines_are_not_added(self) -> None:
+        assert not is_added_line("     context")
+        assert not is_added_line("-    removed")
+
+
+class TestIterAddedLines:
+    def test_yields_only_added_bodies_not_the_header(self) -> None:
+        diff = _diff("src/x.py", "a = 1", "b = 2")
+        lines = list(iter_added_lines(diff))
+        assert [ln.body for ln in lines] == ["a = 1", "b = 2"]
+        # The `+++ b/src/x.py` header must never leak in as an added line.
+        assert all(ln.body not in {"+ b/src/x.py", "src/x.py"} for ln in lines)
+
+    def test_line_numbers_are_1_based_positions_in_the_text(self) -> None:
+        diff = _diff("src/x.py", "a = 1", "b = 2")
+        linenos = [ln.lineno for ln in iter_added_lines(diff)]
+        # Header block is 5 lines; the two added lines are text lines 6 and 7.
+        assert linenos == [6, 7]
+        splat = diff.splitlines()
+        for ln in iter_added_lines(diff):
+            assert splat[ln.lineno - 1] == f"+{ln.body}"
+
+    def test_multi_file_hunks_carry_per_file_paths(self) -> None:
+        diff = _diff("src/a.py", "first") + _diff("src/b.ts", "second")
+        by_body = {ln.body: ln.path for ln in iter_added_lines(diff)}
+        assert by_body == {"first": "src/a.py", "second": "src/b.ts"}
+
+    def test_added_line_before_any_header_is_skipped(self) -> None:
+        # No `+++` header yet — a bare `+` line has no path context.
+        assert list(iter_added_lines("+orphan added line\n")) == []
+
+    def test_header_accepts_bare_path_and_strips_tab_metadata(self) -> None:
+        text = "+++ src/plain.py\n+x = 1\n+++ b/tabbed.py\t2026-01-01 12:00:00\n+y = 2\n"
+        paths = {ln.body: ln.path for ln in iter_added_lines(text)}
+        assert paths == {"x = 1": "src/plain.py", "y = 2": "tabbed.py"}
+
+
+class TestIsDocPath:
+    def test_markdown_and_docs_dir_and_changelog_are_docs(self) -> None:
+        assert is_doc_path("BLUEPRINT.md")
+        assert is_doc_path("docs/x.py")
+        assert is_doc_path("packages/docs/snippet.py")
+        assert is_doc_path("CHANGELOG.rst")
+
+    def test_source_file_is_not_docs(self) -> None:
+        assert not is_doc_path("src/teatree/x.py")


### PR DESCRIPTION
refactor(hooks): shared diff added-line parser for the privacy hooks

- New src/teatree/hooks/_diff_lines.py holds the diff plumbing both privacy
  hooks duplicated: the `+++` FILE_HEADER_RE, the `is_added_line` predicate
  (the `+` vs `+++` filter that was verbatim in both), an `iter_added_lines`
  generator yielding added lines with file + 1-based-lineno context, and the
  identical slash-comment / doc-exempt suffix tables.
- privacy_diff_comments routes scan_diff through iter_added_lines + is_doc_path.
- privacy_diff_comment_density reuses FILE_HEADER_RE, is_added_line, and the
  doc-exempt tables; its stateful scan still walks context + hunk lines itself,
  which an added-only generator cannot carry.
- Detection logic (leak scan vs comment-density) unchanged; only shareable
  plumbing collapsed. The hash-comment tables stay per-hook: the leak scan
  flags `#` self-references in YAML/TOML, the density pass exempts config.
- Not folded onto quality.gate_relaxation.parse_diff: it drops per-line
  positions the leak scan needs and requires a `b/` header prefix the hooks
  tolerate as optional.