### PR TITLE
fix(core): single transactional Ticket.advance_to_delivered() for CLI + loop completion

### DIFF
--- a/src/teatree/backends/loader.py
+++ b/src/teatree/backends/loader.py
@@ -166,6 +166,29 @@ def get_code_host_for_url(overlay: "OverlayBase", issue_url: str) -> CodeHostBac
     return _host_backend(overlay, forge)
 
 
+def issue_is_done(overlay: "OverlayBase", issue_url: str) -> bool:
+    """Whether *issue_url*'s upstream issue is done per *overlay*'s ``is_issue_done``.
+
+    The single completion-detection seam the ``sync-completions`` sweep and the
+    ``TicketCompletionScanner`` both consult before advancing a post-ship ticket.
+    Fail-SKIP: an unresolvable host, a fetch failure, an error payload, or a
+    non-dict response all return ``False`` (never advance on uncertainty) and a
+    fetch failure is logged, never raised — it must not abort the sweep or wedge
+    the scan.
+    """
+    host = get_code_host_for_url(overlay, issue_url)
+    if host is None:
+        return False
+    try:
+        issue_data = host.get_issue(issue_url)
+    except Exception:  # noqa: BLE001 — a fetch failure skips the ticket, never aborts the caller
+        logger.warning("Failed to fetch issue %s — skipping completion check", issue_url)
+        return False
+    if not isinstance(issue_data, dict) or "error" in issue_data:
+        return False
+    return bool(overlay.is_issue_done(issue_data))
+
+
 def pr_is_merged_or_closed(pr_url: str) -> bool:
     """Whether the PR/MR at *pr_url* is provably MERGED or CLOSED (#2081).
 

--- a/src/teatree/core/management/commands/_sweep_commands.py
+++ b/src/teatree/core/management/commands/_sweep_commands.py
@@ -12,18 +12,14 @@ stays out of the (cap-bound) ``ticket.py`` god-module. django-typer collects
 
 import contextlib
 import logging
-from typing import TYPE_CHECKING, Annotated, TypedDict
+from typing import Annotated, TypedDict
 
 import typer
-from django.db import transaction
 from django_typer.management import TyperCommand, command
 
-from teatree.backends.loader import get_code_host_for_url
+from teatree.backends.loader import issue_is_done
 from teatree.core.models import Ticket
 from teatree.core.overlay_loader import get_all_overlays
-
-if TYPE_CHECKING:
-    from teatree.core.overlay import OverlayBase
 
 logger = logging.getLogger(__name__)
 
@@ -67,7 +63,7 @@ class SweepCommands(TyperCommand):
             ).exclude(issue_url="")
 
             for ticket in tickets:
-                if not _issue_is_done(overlay, ticket):
+                if not issue_is_done(overlay, ticket.issue_url):
                     continue
                 result = _complete_one_ticket(ticket, dry_run=dry_run)
                 results.append(result)
@@ -132,31 +128,14 @@ class SweepCommands(TyperCommand):
         return results
 
 
-def _issue_is_done(overlay: "OverlayBase", ticket: Ticket) -> bool:
-    """Whether *ticket*'s upstream issue is done — the eligibility gate for advancement.
-
-    A missing host, an issue-fetch failure, an error payload, or an unfinished issue
-    all skip the ticket. A fetch failure is logged, never fatal — it must not abort the sweep.
-    """
-    host = get_code_host_for_url(overlay, ticket.issue_url)
-    if host is None:
-        return False
-    try:
-        issue_data = host.get_issue(ticket.issue_url)
-    except Exception:  # noqa: BLE001 — an issue-fetch failure skips the ticket, never aborts the sweep
-        logger.warning("Failed to fetch issue for ticket %s (%s)", ticket.pk, ticket.issue_url)
-        return False
-    if not isinstance(issue_data, dict) or "error" in issue_data:
-        return False
-    return bool(overlay.is_issue_done(issue_data))
-
-
 def _complete_one_ticket(ticket: Ticket, *, dry_run: bool) -> CompletionResult:
     """Advance one done ticket toward delivered, returning the recorded outcome.
 
-    A gate-refused (or otherwise failing) FSM advance is caught and recorded as a
-    ``refused`` result so the sweep CONTINUES to the next ticket — the whole-table
-    sweep must never abort on one bad row (CFG-2). ``--dry-run`` records the intent.
+    Delegates the atomic-per-step FSM walk to ``Ticket.advance_to_delivered`` and
+    maps its structured result onto a ``CompletionResult``. A gate-refused advance
+    is reported as ``refused`` (with the persisted partial-progress landing state)
+    rather than aborting; an unexpected non-refusal error is likewise caught so the
+    whole-table sweep never dies on one bad row (CFG-2). ``--dry-run`` records the intent.
     """
     from_state = ticket.state
     if dry_run:
@@ -164,14 +143,10 @@ def _complete_one_ticket(ticket: Ticket, *, dry_run: bool) -> CompletionResult:
             ticket_id=int(ticket.pk), issue_url=ticket.issue_url, from_state=from_state, action="would_complete"
         )
     try:
-        _advance_ticket(ticket)
-    except Exception as exc:  # noqa: BLE001 — a gate-refused / failed FSM advance skips this ticket, never aborts the sweep
+        outcome = ticket.advance_to_delivered()
+    except Exception as exc:  # noqa: BLE001 — an unexpected per-ticket error must never abort the whole-table sweep (CFG-2)
         logger.warning("Failed to advance ticket %s (%s): %s", ticket.pk, ticket.issue_url, exc)
-        # ``_advance_ticket`` commits up to three transitions in separate
-        # ``atomic()`` blocks, so a mid-chain refusal leaves the earlier
-        # transitions persisted. Reload the true landing state to report the
-        # partial progress instead of the (possibly stale) starting state; a
-        # vanished row must not abort the sweep either, so keep the in-memory state.
+        # A vanished row must not abort the sweep either — keep the in-memory state.
         with contextlib.suppress(Exception):
             ticket.refresh_from_db()
         return CompletionResult(
@@ -182,13 +157,17 @@ def _complete_one_ticket(ticket: Ticket, *, dry_run: bool) -> CompletionResult:
             action="refused",
             error=str(exc),
         )
-    return CompletionResult(
+    result = CompletionResult(
         ticket_id=int(ticket.pk),
         issue_url=ticket.issue_url,
-        from_state=from_state,
-        to_state=ticket.state,
-        action="completed",
+        from_state=outcome.from_state,
+        to_state=outcome.to_state,
+        action="refused" if outcome.refused else "completed",
     )
+    if outcome.error is not None:
+        logger.warning("Failed to advance ticket %s (%s): %s", ticket.pk, ticket.issue_url, outcome.error)
+        result["error"] = outcome.error
+    return result
 
 
 def _completion_line(result: CompletionResult) -> str:
@@ -217,19 +196,3 @@ def _completion_summary_lines(results: list[CompletionResult], *, dry_run: bool)
         lines.append(f"{len(refused)} ticket(s) skipped (gate-refused or errored):")
         lines.extend(f"  #{r['ticket_id']} ({r['from_state']}): {r['error']}" for r in refused)
     return lines
-
-
-def _advance_ticket(ticket: Ticket) -> None:
-    """Walk the ticket through remaining FSM transitions toward delivered."""
-    with transaction.atomic():
-        if ticket.state == "shipped":
-            ticket.request_review()
-            ticket.save()
-    with transaction.atomic():
-        if ticket.state == "in_review":
-            ticket.mark_merged()
-            ticket.save()
-    with transaction.atomic():
-        if ticket.state == "merged":
-            ticket.retrospect()
-            ticket.save()

--- a/src/teatree/core/models/ticket_state_sets.py
+++ b/src/teatree/core/models/ticket_state_sets.py
@@ -1,18 +1,88 @@
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, ClassVar
+
+from django.db import transaction
+from django_fsm import TransitionNotAllowed
+
+from teatree.core.models.errors import InvalidTransitionError
 from teatree.core.models.ticket_data import TicketFacet
+
+if TYPE_CHECKING:
+    from teatree.core.models.ticket import Ticket
+
+
+@dataclass(frozen=True, slots=True)
+class AdvanceResult:
+    """Outcome of one :meth:`TicketStateSetsModel.advance_to_delivered` walk.
+
+    ``from_state`` is the pre-walk state; ``to_state`` is where the ticket
+    actually landed. Each step commits in its own ``atomic()``, so a mid-chain
+    refusal leaves the earlier steps persisted — ``to_state`` reflects that
+    partial progress, not the starting state. ``error`` carries the FSM/gate
+    refusal message when the walk stopped short, else ``None``.
+    """
+
+    from_state: str
+    to_state: str
+    error: str | None = None
+
+    @property
+    def refused(self) -> bool:
+        return self.error is not None
+
+    @property
+    def advanced(self) -> bool:
+        return self.to_state != self.from_state
 
 
 class TicketStateSetsModel(TicketFacet):
-    """The canonical ticket state-set classmethods — the SSOT the loop reads.
+    """The completion facet — the canonical post-ship state-sets and the walk over them.
 
     Every scanner, manager, and sweep that needs "which states count as done /
-    in-flight / completable / merged" reads these instead of re-hand-rolling the
-    set (the raw-string drift class behind #798/#799/#808). Each returns an
-    immutable ``frozenset`` of ``State`` values; membership is pinned by
-    ``tests/teatree_core/models/test_ticket.py::TestTicketStateSets``.
+    in-flight / completable / merged" reads the classmethods here instead of
+    re-hand-rolling the set (the raw-string drift class behind #798/#799/#808).
+    Each returns an immutable ``frozenset`` of ``State`` values; membership is
+    pinned by ``tests/teatree_core/models/test_ticket.py::TestTicketStateSets``.
+
+    ``advance_to_delivered`` is the single transactional walk over
+    ``completable_states()`` toward DELIVERED, shared by the ``sync-completions``
+    sweep and the loop's mechanical ``complete_ticket`` so both get identical
+    atomic-per-step + refusal-safe semantics.
     """
 
     class Meta:
         abstract = True
+
+    # The post-ship walk as ``(guard_state, transition_name)`` steps.
+    # request_review: SHIPPED → IN_REVIEW; mark_merged: IN_REVIEW → MERGED;
+    # retrospect: MERGED → RETROSPECTED (the retro worker then drives mark_delivered).
+    _ADVANCE_STEPS: ClassVar[tuple[tuple[str, str], ...]] = (
+        ("shipped", "request_review"),
+        ("in_review", "mark_merged"),
+        ("merged", "retrospect"),
+    )
+
+    def advance_to_delivered(self: "Ticket") -> AdvanceResult:
+        """Walk the ticket through the remaining post-ship FSM transitions.
+
+        Each step runs in its own ``transaction.atomic()``: a successful step
+        commits, a refused step rolls back only itself and stops the walk. A
+        django-fsm ``TransitionNotAllowed`` or a gate's ``InvalidTransitionError``
+        (e.g. the merge-evidence gate on ``mark_merged``) is captured in the
+        returned :class:`AdvanceResult`, never raised — so the whole-table sweep
+        keeps going and the loop tick never wedges on a partial commit.
+        """
+        from_state = self.state
+        for guard_state, transition_name in self._ADVANCE_STEPS:
+            if self.state != guard_state:
+                continue
+            try:
+                with transaction.atomic():
+                    getattr(self, transition_name)()
+                    self.save()
+            except (TransitionNotAllowed, InvalidTransitionError) as exc:
+                return AdvanceResult(from_state=from_state, to_state=self.state, error=str(exc))
+        return AdvanceResult(from_state=from_state, to_state=self.state)
 
     @classmethod
     def marker_release_states(cls) -> frozenset[str]:

--- a/src/teatree/loop/mechanical.py
+++ b/src/teatree/loop/mechanical.py
@@ -70,7 +70,12 @@ def ignore_disposed_ticket(payload: ActionPayload) -> None:
 def complete_ticket(payload: ActionPayload) -> None:
     """Transition a ticket from its current post-ship state toward delivered.
 
-    FSM path: shipped → request_review → mark_merged → retrospect.
+    FSM path: shipped → request_review → mark_merged → retrospect. Delegates to
+    ``Ticket.advance_to_delivered`` so this loop path shares the CLI's
+    atomic-per-step + refusal-safe semantics: a mid-chain gate refusal (e.g. the
+    merge-evidence gate on ``mark_merged``) stops the walk gracefully instead of
+    escaping as an exception after a partial commit — the every-tick error the
+    ungated cascade used to raise.
     """
     from django.apps import apps  # noqa: PLC0415 — deferred: app registry read at call time
 
@@ -80,15 +85,16 @@ def complete_ticket(payload: ActionPayload) -> None:
         return
     ticket = ticket_model.objects.get(pk=ticket_id)
 
-    if ticket.state == "shipped":
-        ticket.request_review()
-        ticket.save()
-    if ticket.state == "in_review":
-        ticket.mark_merged()
-        ticket.save()
-    if ticket.state == "merged":
-        ticket.retrospect()
-        ticket.save()
+    result = ticket.advance_to_delivered()
+    if result.refused:
+        logger.info(
+            "complete_ticket: ticket %s advance stopped at %s (%s → %s): %s",
+            ticket_id,
+            result.to_state,
+            result.from_state,
+            result.to_state,
+            result.error,
+        )
 
 
 def reopen_ticket(payload: ActionPayload) -> None:

--- a/src/teatree/loop/scanners/ticket_completion.py
+++ b/src/teatree/loop/scanners/ticket_completion.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, cast
 
 from django.apps import apps
 
-from teatree.backends.loader import get_code_host_for_url
+from teatree.backends.loader import issue_is_done
 from teatree.core.overlay import OverlayBase
 from teatree.loop.scanners.base import ScanSignal
 
@@ -65,17 +65,7 @@ class TicketCompletionScanner:
                     )
                     continue
 
-                host = get_code_host_for_url(self.overlay, ticket.issue_url)
-                if host is None:
-                    continue
-                try:
-                    issue_data = host.get_issue(ticket.issue_url)
-                except Exception:  # noqa: BLE001 — an issue-fetch failure skips the ticket, never aborts the scan
-                    logger.warning("Failed to fetch issue for ticket %s (%s), skipping", ticket.pk, ticket.issue_url)
-                    continue
-                if not isinstance(issue_data, dict) or "error" in issue_data:
-                    continue
-                if self.overlay.is_issue_done(issue_data):
+                if issue_is_done(self.overlay, ticket.issue_url):
                     signals.append(
                         ScanSignal(
                             kind="ticket.completion_detected",

--- a/tests/teatree_backends/test_loader.py
+++ b/tests/teatree_backends/test_loader.py
@@ -20,6 +20,7 @@ from teatree.backends.loader import (
     get_code_host_for_url,
     get_code_hosts,
     get_messaging,
+    issue_is_done,
     reset_backend_caches,
 )
 from teatree.backends.messaging_noop import NoopMessagingBackend
@@ -555,3 +556,55 @@ class TestGetCodeHostForRepoGithubAmbientAuth:
 
         with pytest.raises(BackendResolutionError, match="github"):
             get_code_host_for_repo(overlay, repo)
+
+
+class _IssueHost:
+    """A code host whose issue fetch is scripted per URL."""
+
+    def __init__(self, payload: object, *, raises: bool = False) -> None:
+        self._payload = payload
+        self._raises = raises
+
+    def get_issue(self, issue_url: str) -> object:
+        _ = issue_url
+        if self._raises:
+            msg = "boom"
+            raise RuntimeError(msg)
+        return self._payload
+
+
+def _done_overlay(*, verdict: bool) -> OverlayBase:
+    overlay = _build_overlay()
+    overlay.is_issue_done = lambda _data: verdict  # type: ignore[method-assign]
+    return overlay
+
+
+class TestIssueIsDone:
+    """The shared completion-detection seam consumed by the sweep and the scanner."""
+
+    def _patch_host(self, monkeypatch: pytest.MonkeyPatch, host: object | None) -> None:
+        monkeypatch.setattr("teatree.backends.loader.get_code_host_for_url", lambda _overlay, _url: host)
+
+    def test_true_when_host_and_overlay_agree(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch_host(monkeypatch, _IssueHost({"state": "closed"}))
+        assert issue_is_done(_done_overlay(verdict=True), "https://x/1") is True
+
+    def test_false_when_overlay_says_not_done(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch_host(monkeypatch, _IssueHost({"state": "closed"}))
+        assert issue_is_done(_done_overlay(verdict=False), "https://x/1") is False
+
+    def test_false_when_no_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch_host(monkeypatch, None)
+        assert issue_is_done(_done_overlay(verdict=True), "https://x/1") is False
+
+    def test_false_on_fetch_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch_host(monkeypatch, _IssueHost(None, raises=True))
+        assert issue_is_done(_done_overlay(verdict=True), "https://x/1") is False
+
+    def test_false_on_error_payload(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch_host(monkeypatch, _IssueHost({"error": "not found"}))
+        assert issue_is_done(_done_overlay(verdict=True), "https://x/1") is False
+
+    def test_false_on_non_dict_payload(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch_host(monkeypatch, _IssueHost("nope"))
+        assert issue_is_done(_done_overlay(verdict=True), "https://x/1") is False

--- a/tests/teatree_core/management/commands/test_sync_completions.py
+++ b/tests/teatree_core/management/commands/test_sync_completions.py
@@ -64,7 +64,7 @@ class TestSyncCompletionsSurvivesGateRefusal(TestCase):
                 return_value={"fake-overlay": _AlwaysDoneOverlay()},
             ),
             patch(
-                "teatree.core.management.commands._sweep_commands.get_code_host_for_url",
+                "teatree.backends.loader.get_code_host_for_url",
                 return_value=_FakeHost(),
             ),
         ):
@@ -99,7 +99,7 @@ class TestSyncCompletionsSurvivesGateRefusal(TestCase):
                 return_value={"fake-overlay": _AlwaysDoneOverlay()},
             ),
             patch(
-                "teatree.core.management.commands._sweep_commands.get_code_host_for_url",
+                "teatree.backends.loader.get_code_host_for_url",
                 return_value=_FakeHost(),
             ),
         ):

--- a/tests/teatree_core/models/test_ticket_state_sets.py
+++ b/tests/teatree_core/models/test_ticket_state_sets.py
@@ -1,0 +1,64 @@
+"""``Ticket.advance_to_delivered`` — the single transactional post-ship walk.
+
+Owns the ``shipped → in_review → merged → retrospected`` FSM walk that both the
+``sync-completions`` sweep and the loop's mechanical ``complete_ticket`` share.
+Each step commits in its own ``atomic()``; a mid-chain gate/FSM refusal stops
+the walk and is reported in the returned ``AdvanceResult`` — never raised.
+"""
+
+from django.test import TestCase
+
+from teatree.core.models import ConfigSetting, Ticket
+from teatree.core.models.ticket_state_sets import AdvanceResult
+
+
+class TestAdvanceToDelivered(TestCase):
+    def test_merged_ticket_walks_to_retrospected(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://x/1", state=Ticket.State.MERGED)
+
+        result = ticket.advance_to_delivered()
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.RETROSPECTED
+        assert result == AdvanceResult(from_state="merged", to_state="retrospected")
+        assert result.advanced
+        assert not result.refused
+
+    def test_shipped_ticket_walks_all_ungated_steps(self) -> None:
+        # With the merge-evidence gate off (the default) the whole chain advances.
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://x/2", state=Ticket.State.SHIPPED)
+
+        result = ticket.advance_to_delivered()
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.RETROSPECTED
+        assert result.from_state == "shipped"
+        assert result.to_state == "retrospected"
+        assert not result.refused
+
+    def test_mid_chain_refusal_reports_persisted_partial_state(self) -> None:
+        # The merge-evidence gate refuses ``mark_merged`` for an evidence-less ticket.
+        ConfigSetting.objects.set_value("require_merge_evidence", value=True)
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://x/3", state=Ticket.State.SHIPPED)
+
+        result = ticket.advance_to_delivered()
+
+        ticket.refresh_from_db()
+        # request_review committed in its own atomic step; mark_merged rolled back.
+        assert ticket.state == Ticket.State.IN_REVIEW
+        assert result.from_state == "shipped"
+        assert result.to_state == "in_review"
+        assert result.refused
+        assert result.error is not None
+        assert "merged-SHA evidence" in result.error
+
+    def test_non_completable_state_is_a_noop(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://x/4", state=Ticket.State.SCOPED)
+
+        result = ticket.advance_to_delivered()
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SCOPED
+        assert result == AdvanceResult(from_state="scoped", to_state="scoped")
+        assert not result.advanced
+        assert not result.refused

--- a/tests/teatree_loop/test_mechanical.py
+++ b/tests/teatree_loop/test_mechanical.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import pytest
 from django.test import TestCase
 
-from teatree.core.models import Session, Task, Ticket
+from teatree.core.models import ConfigSetting, Session, Task, Ticket
 from teatree.loop.dispatch import ActionPayload, DispatchAction
 from teatree.loop.mechanical import (
     HANDLERS,
@@ -92,6 +92,37 @@ class TestCompleteTicket(TestCase):
 
     def test_no_op_when_ticket_id_missing(self) -> None:
         complete_ticket(_payload())
+
+
+class TestCompleteTicketMidChainRefusal(TestCase):
+    """The loop completion path must survive a mid-chain FSM/gate refusal.
+
+    Pre-fix, ``complete_ticket`` cascaded ``request_review`` → ``mark_merged`` →
+    ``retrospect`` with no ``atomic()`` per step and no refusal handling. A
+    ``shipped`` ticket whose issue is done but which lacks merged-SHA evidence
+    committed the ``request_review`` advance, then the merge-evidence gate on
+    ``mark_merged`` raised ``NoMergeEvidenceError``. That escape landed in
+    ``report.errors`` + an ERROR log on EVERY tick, on top of the already-persisted
+    ``in_review`` partial state. Routed through ``Ticket.advance_to_delivered`` the
+    refusal is now caught: the partial progress persists (as the CLI sweep does),
+    but no exception escapes the tick.
+    """
+
+    def setUp(self) -> None:
+        # The merge-evidence gate must bite so ``mark_merged`` genuinely refuses.
+        ConfigSetting.objects.set_value("require_merge_evidence", value=True)
+
+    def test_mid_chain_gate_refusal_does_not_escape_the_tick(self) -> None:
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://x/9", state="shipped")
+
+        with self.assertNoLogs("teatree.loop.tick_recovery", level="ERROR"):
+            report = _run_mechanical("ticket_completion", ticket_id=ticket.pk)
+
+        assert report.errors == {}
+        ticket.refresh_from_db()
+        # request_review committed its own atomic step (partial progress);
+        # mark_merged was gate-refused and rolled back — the walk stopped clean.
+        assert ticket.state == Ticket.State.IN_REVIEW
 
 
 class TestReopenTicket(TestCase):

--- a/tests/teatree_loop/test_per_item_fault_isolation_1597.py
+++ b/tests/teatree_loop/test_per_item_fault_isolation_1597.py
@@ -420,7 +420,10 @@ class TestTicketCompletionIsolation(TestCase):
             return host
 
         scanner = TicketCompletionScanner(overlay=_Overlay(), overlay_name="acme")
-        with patch("teatree.loop.scanners.ticket_completion.get_code_host_for_url", _patched_get_code_host):
+        # The scanner resolves the host through the shared ``issue_is_done`` seam
+        # in ``teatree.backends.loader``; a raising host lookup there propagates
+        # out of ``issue_is_done`` into the scanner's per-ticket ``except`` guard.
+        with patch("teatree.backends.loader.get_code_host_for_url", _patched_get_code_host):
             signals = scanner.scan()
 
         assert len(signals) == 1, "second ticket must still emit completion_detected"

--- a/tests/teatree_loop/test_ticket_completion.py
+++ b/tests/teatree_loop/test_ticket_completion.py
@@ -102,8 +102,10 @@ class TicketCompletionScannerTests(TestCase):
         )
 
     def _patch_host(self, host: _Host):
+        # The scanner resolves the host through the shared ``issue_is_done`` seam
+        # in ``teatree.backends.loader``, so patch the host resolver there.
         return patch(
-            "teatree.loop.scanners.ticket_completion.get_code_host_for_url",
+            "teatree.backends.loader.get_code_host_for_url",
             return_value=host,
         )
 


### PR DESCRIPTION
fix(core): single transactional Ticket.advance_to_delivered() for CLI + loop completion

The post-ship completion walk (shipped -> in_review -> merged -> retrospected)
was implemented twice and had drifted:

- CLI sync-completions wrapped each FSM step in its own transaction.atomic()
  and caught the gate refusal, reporting partial progress.
- The loop's mechanical complete_ticket cascaded the same three transitions
  with no atomic() per step and no refusal handling, so a mid-chain gate
  refusal (merge-evidence gate on mark_merged) escaped as an exception AFTER
  the request_review advance had already committed -- every-tick error noise
  on top of a partial commit.

Fix:
- New Ticket.advance_to_delivered() (on TicketStateSetsModel, alongside the
  completable_states() predicate that selects tickets for it) owns the walk
  once: each step in its own transaction.atomic(), django-fsm
  TransitionNotAllowed and gate InvalidTransitionError caught and returned in a
  structured AdvanceResult (from_state / to_state / error), never raised.
  Partial progress persists, matching the CLI's reporting contract.
- Both callers route through it: the CLI maps AdvanceResult onto its
  CompletionResult (keeping the CFG-2 never-abort belt); the loop's
  complete_ticket now gains the atomic + refusal safety it was missing.
- Shared issue_is_done(overlay, issue_url) detection on the backend loader
  replaces the duplicated host-fetch + is_issue_done check in both the sweep
  and the TicketCompletionScanner.

Regression test proves the loop path no longer escapes a mid-chain refusal:
a shipped, evidence-less ticket lands at in_review with no tick error.