### PR TITLE
refactor(eval): EvalRun.skipped()/terminal() classmethods + resolve_spec_model()

### DIFF
--- a/src/teatree/eval/anthropic_api_runner.py
+++ b/src/teatree/eval/anthropic_api_runner.py
@@ -31,13 +31,11 @@ the all-skipped enforcement gate — then it raises
 point.
 """
 
-import dataclasses
-
 from claude_agent_sdk.types import EffortLevel
 from pydantic_ai.models import Model
 
 from teatree.config import get_effective_settings
-from teatree.eval.model_resolution import resolve_eval_model
+from teatree.eval.model_resolution import resolve_spec_model
 from teatree.eval.model_variant import parse_model_variant
 from teatree.eval.models import EvalRun, EvalSpec
 from teatree.eval.pydantic_ai_runner import PydanticAiRunner
@@ -89,10 +87,10 @@ class AnthropicApiRunner:
         # Resolve the abstract tier/phase to a concrete model id (a no-op when the
         # spec already carries a concrete ``model``); the resolved id names the
         # Anthropic API model and flows into the ledger label + report.
-        spec = dataclasses.replace(spec, model=resolve_eval_model(spec))
+        spec = resolve_spec_model(spec)
         model = self._resolve_model_or_skip(spec)
         if model is None:
-            return _skip_run(spec, "ANTHROPIC_API_KEY not resolvable")
+            return EvalRun.skipped(spec.name, "ANTHROPIC_API_KEY not resolvable")
         # Delegate the request loop + vocabulary mapping + watchdog to the pydantic_ai
         # lane, injecting the Anthropic model so its own model-resolution is
         # never reached; the turn cap bounds that loop.
@@ -135,19 +133,6 @@ def _build_anthropic_model(spec: EvalSpec, api_key: str) -> Model:
 
     model_name = parse_model_variant(spec.model).model
     return AnthropicModel(model_name, provider=AnthropicProvider(api_key=api_key))
-
-
-def _skip_run(spec: EvalSpec, reason: str) -> EvalRun:
-    """A skip-shaped run for an un-provisioned lane (no key), mirroring the ``api`` runner's skip."""
-    return EvalRun(
-        spec_name=spec.name,
-        tool_calls=(),
-        text_blocks=(),
-        terminal_reason=f"skipped: {reason}",
-        is_error=False,
-        raw_stdout="",
-        raw_stderr="",
-    )
 
 
 def build_anthropic_api_eval_runner(

--- a/src/teatree/eval/api_runner.py
+++ b/src/teatree/eval/api_runner.py
@@ -63,7 +63,7 @@ from teatree.eval.ephemeral_checkout import ephemeral_checkout_env, provision_ep
 from teatree.eval.git_fixture import provision_fixture
 from teatree.eval.isolation import isolated_claude_env
 from teatree.eval.message_mapping import eval_run_from_messages
-from teatree.eval.model_resolution import resolve_eval_model
+from teatree.eval.model_resolution import resolve_spec_model
 from teatree.eval.model_variant import parse_model_variant
 from teatree.eval.models import CLEAN_ROOM_LANE, CLEAN_ROOM_MIN_TURNS, EvalRun, EvalSpec
 from teatree.eval.production_hooks import has_hook_events, hooked_env, t3_plugin, teatree_root
@@ -414,7 +414,7 @@ class ApiInProcessRunner:
         # spec already carries a concrete ``model``, e.g. the matrix/--model lanes
         # set it upstream). The resolved id flows into _drive's variant parse, the
         # model-presence check, the ledger label, and the report.
-        spec = dataclasses.replace(spec, model=resolve_eval_model(spec))
+        spec = resolve_spec_model(spec)
         if resolve_claude_path() is None:
             if self._require_executed:
                 msg = (
@@ -425,7 +425,7 @@ class ApiInProcessRunner:
                     "decoratively skip."
                 )
                 raise ClaudeCliMissingError(msg)
-            return self._skip_run(spec, "claude binary not on PATH")
+            return EvalRun.skipped(spec.name, "claude binary not on PATH")
 
         clean_room_prompt = load_agent_definition(spec.agent_path, spec.agent_sections) + LIVE_ENV_FRAMING
         system_prompt = build_system_prompt(spec, clean_room_prompt=clean_room_prompt)
@@ -441,18 +441,19 @@ class ApiInProcessRunner:
             # A throttle that outlasted its retry budget surfaces loud as an errored
             # run stamped with the retry count (visible to the AIMD governor).
             surface_throttled=lambda reason, retries: dataclasses.replace(
-                self._terminal_run(spec, terminal_reason=reason), throttle_retries=retries
+                EvalRun.terminal(spec.name, terminal_reason=reason), throttle_retries=retries
             ),
         )
         return self._retry.run(_drive_once, handlers)
 
-    def _grade_success(self, spec: EvalSpec, messages: list[Message], retries: int) -> EvalRun:
+    @staticmethod
+    def _grade_success(spec: EvalSpec, messages: list[Message], retries: int) -> EvalRun:
         # A hooked run that captured ZERO hook events means the shipped plugin did
         # NOT register (the lane silently degraded to raw-model measurement) — fail
         # loud rather than report a spurious pass. Otherwise grade the trajectory and
         # carry the retry count for the AIMD governor.
         if spec.production_hooks and not has_hook_events(messages):
-            return self._terminal_run(spec, terminal_reason="hooks_not_registered")
+            return EvalRun.terminal(spec.name, terminal_reason="hooks_not_registered")
         run = eval_run_from_messages(spec, messages)
         return dataclasses.replace(run, throttle_retries=retries) if retries else run
 
@@ -464,7 +465,7 @@ class ApiInProcessRunner:
         ``is_error`` (the cap is surfaced via ``terminal_reason``, not the error flag).
         Cost comes from the message's ``($X)``, else a captured ``ResultMessage``, else
         ``0.0``; a run that captured NOTHING falls back to the empty
-        :meth:`_terminal_run` (whose budget cost floors to the cap).
+        :meth:`EvalRun.terminal` (whose budget cost floors to the cap).
         """
         message_amount = budget_amount_from_message(str(terminal.cause))
         if not terminal.messages:
@@ -474,7 +475,7 @@ class ApiInProcessRunner:
             effective_cap = spec.max_budget_usd if spec.max_budget_usd is not None else self._max_budget_usd
             cost = budget_floor_from_message(str(terminal.cause), cap=effective_cap)
             empty_cost = cost if terminal.terminal_reason == BUDGET_EXCEEDED_REASON else 0.0
-            return self._terminal_run(spec, terminal_reason=terminal.terminal_reason, cost_usd=empty_cost)
+            return EvalRun.terminal(spec.name, terminal_reason=terminal.terminal_reason, cost_usd=empty_cost)
         graded = eval_run_from_messages(spec, terminal.messages)
         cost = message_amount if message_amount is not None else graded.cost_usd
         return dataclasses.replace(
@@ -568,38 +569,6 @@ class ApiInProcessRunner:
             checkout = stack.enter_context(provision_ephemeral_checkout())
             isolated_env = ephemeral_checkout_env(env, checkout)
             yield checkout, str(checkout), isolated_env
-
-    @staticmethod
-    def _terminal_run(spec: EvalSpec, *, terminal_reason: str, cost_usd: float = 0.0) -> EvalRun:
-        """Build an error-shaped :class:`EvalRun` for a run that never produced a transcript.
-
-        The timeout and budget-exceeded paths share this shape: no captured tool
-        calls/text, ``is_error=True``, and a terminal reason that grades the cell
-        to a FAIL signal rather than crashing the run. Mirrors how the timeout
-        path built its EvalRun before being extracted here.
-        """
-        return EvalRun(
-            spec_name=spec.name,
-            tool_calls=(),
-            text_blocks=(),
-            terminal_reason=terminal_reason,
-            is_error=True,
-            raw_stdout="",
-            raw_stderr="",
-            cost_usd=cost_usd,
-        )
-
-    @staticmethod
-    def _skip_run(spec: EvalSpec, reason: str) -> EvalRun:
-        return EvalRun(
-            spec_name=spec.name,
-            tool_calls=(),
-            text_blocks=(),
-            terminal_reason=f"skipped: {reason}",
-            is_error=False,
-            raw_stdout="",
-            raw_stderr="",
-        )
 
 
 async def _collect(prompt: str, options: ClaudeAgentOptions) -> list[Message]:

--- a/src/teatree/eval/model_resolution.py
+++ b/src/teatree/eval/model_resolution.py
@@ -18,6 +18,8 @@ Precedence, highest first:
 4.  ``DEFAULT_TIER`` — the conservative default, resolved through ``resolve_tier``.
 """
 
+import dataclasses
+
 from teatree.agents.model_tiering import DEFAULT_PHASE_MODELS, DEFAULT_TIER, resolve_tier
 from teatree.eval.models import EvalSpec
 
@@ -38,3 +40,15 @@ def resolve_eval_model(spec: EvalSpec) -> str:
         tier = DEFAULT_PHASE_MODELS.get(spec.phase.strip(), DEFAULT_TIER)
         return resolve_tier(tier)
     return resolve_tier(DEFAULT_TIER)
+
+
+def resolve_spec_model(spec: EvalSpec) -> EvalSpec:
+    """Return *spec* with its concrete resolved ``model`` — the fresh-run opener.
+
+    Every fresh-run backend opens ``run`` by resolving the abstract tier/phase to a
+    concrete model id and folding it back onto the spec (a no-op when the spec
+    already carries a concrete ``model``, e.g. the matrix/``--model`` lanes set it
+    upstream). The resolved id then flows into the variant parse, the
+    model-presence check, the ledger label, and the report.
+    """
+    return dataclasses.replace(spec, model=resolve_eval_model(spec))

--- a/src/teatree/eval/models.py
+++ b/src/teatree/eval/models.py
@@ -440,3 +440,42 @@ class EvalRun:
     #: shrinks the shared permit count, ``0``-and-clean grows it back — so a
     #: throttled suite backs its parallel load off the single shared OAuth token.
     throttle_retries: int = 0
+
+    @classmethod
+    def skipped(cls, spec_name: str, reason: str) -> "EvalRun":
+        """A skip-shaped run for an un-provisioned lane — no transcript, not an error.
+
+        Every fresh-run backend shares this shape when its provisioning gate is
+        unmet (no ``claude`` binary, no ``ANTHROPIC_API_KEY``, …): the terminal
+        reason is stamped ``skipped: <reason>`` so the report renders a clean SKIP,
+        and ``is_error`` stays False — a skip is not a failure.
+        """
+        return cls(
+            spec_name=spec_name,
+            tool_calls=(),
+            text_blocks=(),
+            terminal_reason=f"skipped: {reason}",
+            is_error=False,
+            raw_stdout="",
+            raw_stderr="",
+        )
+
+    @classmethod
+    def terminal(cls, spec_name: str, *, terminal_reason: str, cost_usd: float = 0.0) -> "EvalRun":
+        """An error-shaped run that never produced a transcript (timeout / budget cap).
+
+        No captured tool calls or text, ``is_error=True``, and a ``terminal_reason``
+        that grades the cell to a FAIL signal rather than crashing the run. The
+        optional ``cost_usd`` carries a budget-exceeded cap's floored cost (``0.0``
+        for a timeout, which paid nothing).
+        """
+        return cls(
+            spec_name=spec_name,
+            tool_calls=(),
+            text_blocks=(),
+            terminal_reason=terminal_reason,
+            is_error=True,
+            raw_stdout="",
+            raw_stderr="",
+            cost_usd=cost_usd,
+        )

--- a/src/teatree/eval/pydantic_ai_runner.py
+++ b/src/teatree/eval/pydantic_ai_runner.py
@@ -23,7 +23,6 @@ side effect.
 """
 
 import asyncio
-import dataclasses
 from typing import cast
 
 from claude_agent_sdk import Message
@@ -45,7 +44,7 @@ from teatree.agents.regulated_path import assert_model_allowed_on_regulated_path
 from teatree.config import get_effective_settings
 from teatree.eval.api_runner import load_agent_definition
 from teatree.eval.message_mapping import eval_run_from_messages
-from teatree.eval.model_resolution import resolve_eval_model
+from teatree.eval.model_resolution import resolve_spec_model
 from teatree.eval.model_variant import parse_model_variant
 from teatree.eval.models import EvalRun, EvalSpec
 from teatree.eval.prompt_framing import LIVE_ENV_FRAMING
@@ -130,12 +129,12 @@ class PydanticAiRunner:
         # Resolve the abstract tier/phase to a concrete model id (a no-op when the
         # spec already carries a concrete ``model``); the resolved id flows into the
         # variant parse, the model-presence check, the ledger label, and the report.
-        spec = dataclasses.replace(spec, model=resolve_eval_model(spec))
+        spec = resolve_spec_model(spec)
         model = self._resolve_model(spec)
         try:
             messages = asyncio.run(self._drive_with_watchdog(spec, model))
         except TimeoutError:
-            return _terminal_eval_run(spec, terminal_reason="timeout")
+            return EvalRun.terminal(spec.name, terminal_reason="timeout")
         return eval_run_from_messages(spec, messages)
 
     def _resolve_model(self, spec: EvalSpec) -> Model:
@@ -183,19 +182,6 @@ class PydanticAiRunner:
             session = PydanticAiHarnessSession(agent, model_name=model.model_name, request_limit=request_limit)
             await session.query(build_user_prompt(spec))
             return [cast("Message", message) async for message in session.receive_response()]
-
-
-def _terminal_eval_run(spec: EvalSpec, *, terminal_reason: str) -> EvalRun:
-    """An error-shaped run for a lane that produced no transcript (the watchdog fired)."""
-    return EvalRun(
-        spec_name=spec.name,
-        tool_calls=(),
-        text_blocks=(),
-        terminal_reason=terminal_reason,
-        is_error=True,
-        raw_stdout="",
-        raw_stderr="",
-    )
 
 
 def build_pydantic_ai_eval_runner(

--- a/tests/teatree_eval/test_model_resolution.py
+++ b/tests/teatree_eval/test_model_resolution.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 
 from teatree.agents.model_tiering import DEFAULT_TIER, TIER_MODELS
-from teatree.eval.model_resolution import resolve_eval_model
+from teatree.eval.model_resolution import resolve_eval_model, resolve_spec_model
 from teatree.eval.models import EvalSpec
 
 
@@ -85,3 +85,17 @@ class TestResolveEvalModel:
         monkeypatch.setenv("T3_CONFIG_DB", str(db))
         _seed_tier_models(db, {"frontier": "sentinel-x"})
         assert resolve_eval_model(_spec(phase="planning")) == "sentinel-x"
+
+
+class TestResolveSpecModel:
+    def test_folds_the_resolved_id_onto_the_spec(self) -> None:
+        # The shared fresh-run opener returns a spec whose ``model`` is the concrete
+        # resolved id, leaving every other field untouched.
+        resolved = resolve_spec_model(_spec(tier="cheap"))
+        assert resolved.model == TIER_MODELS["cheap"]
+        assert resolved.tier == "cheap"
+
+    def test_is_a_noop_when_model_already_concrete(self) -> None:
+        # A spec that already pins a concrete ``model`` (matrix/--model lanes) is
+        # returned with that pin unchanged.
+        assert resolve_spec_model(_spec(model="claude-pinned-id@xhigh")).model == "claude-pinned-id@xhigh"

--- a/tests/teatree_eval/test_models.py
+++ b/tests/teatree_eval/test_models.py
@@ -2,7 +2,49 @@
 
 from typing import get_args
 
-from teatree.eval.models import Matcher
+import pytest
+
+from teatree.eval.models import EvalRun, Matcher
+
+
+def test_skipped_matches_the_old_skip_run_shape() -> None:
+    """``EvalRun.skipped`` reproduces the byte-identical shape the per-runner ``_skip_run`` built.
+
+    The three fresh-run backends each carried a private ``_skip_run`` that stamped a
+    ``skipped: <reason>`` terminal reason on an empty, non-error run. The classmethod
+    that collapses them must produce exactly that record.
+    """
+    run = EvalRun.skipped("alpha", "ANTHROPIC_API_KEY not resolvable")
+    assert run == EvalRun(
+        spec_name="alpha",
+        tool_calls=(),
+        text_blocks=(),
+        terminal_reason="skipped: ANTHROPIC_API_KEY not resolvable",
+        is_error=False,
+        raw_stdout="",
+        raw_stderr="",
+    )
+
+
+def test_terminal_matches_the_old_terminal_run_shape() -> None:
+    """``EvalRun.terminal`` reproduces the byte-identical shape the old ``_terminal_run`` built.
+
+    A run that never produced a transcript (timeout / budget cap) is empty,
+    ``is_error=True``, and carries the classified terminal reason; the optional
+    ``cost_usd`` floors a budget-exceeded cap (``0.0`` for a timeout).
+    """
+    assert EvalRun.terminal("beta", terminal_reason="timeout") == EvalRun(
+        spec_name="beta",
+        tool_calls=(),
+        text_blocks=(),
+        terminal_reason="timeout",
+        is_error=True,
+        raw_stdout="",
+        raw_stderr="",
+    )
+    capped = EvalRun.terminal("beta", terminal_reason="budget_exceeded", cost_usd=0.1)
+    assert capped.cost_usd == pytest.approx(0.1)
+    assert capped.is_error is True
 
 
 def test_matcher_kind_is_narrowed_to_positive_or_negative() -> None:


### PR DESCRIPTION
refactor(eval): EvalRun.skipped()/terminal() classmethods + resolve_spec_model()

What:
- Add EvalRun.skipped() and EvalRun.terminal() classmethods on the eval model.
- Add resolve_spec_model(spec) beside resolve_eval_model — the shared fresh-run opener.
- Route api / anthropic_api / pydantic_ai runners through them; delete the triplicated private _skip_run / _terminal_run / _terminal_eval_run factories.

Why:
- The skip/terminal EvalRun factories were triplicated (byte-identical) across the three fresh-run backends, as was the dataclasses.replace(spec, model=resolve_eval_model(spec)) opener. One home each collapses the drift; shape is preserved exactly (runners are eval-critical).