### PR TITLE
refactor(config): unify write-path validation; fix default-authority divergence + fail-open override drop

### DIFF
--- a/src/teatree/config/__init__.py
+++ b/src/teatree/config/__init__.py
@@ -52,6 +52,7 @@ from teatree.config.resolution import (
     _apply_autonomy,
     _overlay_overrides_by_name,
     cadence_seconds,
+    effective_default,
     get_effective_settings,
     worker_is_quiescing,
 )
@@ -130,6 +131,7 @@ __all__ = [
     "default_logging",
     "discover_active_overlay",
     "discover_overlays",
+    "effective_default",
     "effective_trusted_issue_authors",
     "get_data_dir",
     "get_effective_settings",

--- a/src/teatree/config/resolution.py
+++ b/src/teatree/config/resolution.py
@@ -43,6 +43,44 @@ _logger = logging.getLogger("teatree.config")
 # overlay-then-global, ``speak`` as a per-overlay MERGE onto the global base.
 _BESPOKE_STRUCTURED_FIELDS: frozenset[str] = frozenset({"speak", "mr_reminder"})
 
+# Sentinel for "no shipped default at all" — never equals a real value, so a
+# seed/import of such a key is always written.
+_NO_EFFECTIVE_DEFAULT: object = object()
+
+
+def effective_default(key: str) -> object:
+    """The value *key* resolves to with NO DB row / env override — the ONE default authority.
+
+    The single source the seed-skip (``config_setting seed``), the import-skip
+    (``config_migration``), and the resolver all agree on, so a row equal to it is
+    provably redundant: writing it and clearing it resolve to the SAME value.
+
+    A ``UserSettings`` scalar field resolves to its DATACLASS default: the resolver
+    base (``load_config().user`` is always a bare ``UserSettings()``), NOT the
+    ``defaults.toml``/pydantic value. The TOML-default tier is NOT wired into the
+    resolver (a later phase — ``config/schema.py``), so ``defaults.toml`` adopting a
+    live value (e.g. ``provision_ram_ceiling_percent = 75``) that differs from the
+    conservative code default (``85``) MUST write a row on import/seed — else the
+    value would be skipped-as-default and then silently resolve to ``85``.
+
+    A structured field (``speak`` / ``mr_reminder``) is stored as a dict the resolver
+    rebuilds bespoke; its stored-form default is the ``shipped_defaults`` dict (equal
+    in meaning to the dataclass default), so it is compared in that stored form rather
+    than against the dataclass instance. A non-``UserSettings`` key (cold / cold-hook
+    / registry) resolves to its ``shipped_defaults`` value, which IS its resolver
+    default (the cold reader / registry default sourced from ``defaults.toml``).
+
+    Returns a never-equal sentinel for a key with no shipped default, so its
+    seed/import is always written.
+    """
+    if key not in _BESPOKE_STRUCTURED_FIELDS:
+        dataclass_default = getattr(UserSettings(), key, _NO_EFFECTIVE_DEFAULT)
+        if dataclass_default is not _NO_EFFECTIVE_DEFAULT:
+            return dataclass_default
+    from teatree.config.schema import shipped_defaults  # noqa: PLC0415 — deferred: heavy pydantic import
+
+    return getattr(shipped_defaults(), key, _NO_EFFECTIVE_DEFAULT)
+
 
 def get_effective_settings(overlay_name: str | None = None) -> UserSettings:
     """Return the user settings under the #1775 DB-home partition + env.
@@ -342,21 +380,58 @@ def _coerce_db_rows(rows: dict[str, Any]) -> dict[str, Any]:
     return overrides
 
 
-def _load_global_rows() -> dict[str, Any]:
-    """Read the GLOBAL-scope (``scope=""``) ``{key: value}`` rows, or ``{}``.
+def _bootstrap_read_exceptions() -> tuple[type[Exception], ...]:
+    """The GENUINE not-ready exceptions the DB override read fails SILENTLY-safe on (returns ``{}``).
 
-    Reaches the model via Django's app registry (no static ``teatree.core``
-    import — that would be a backwards ``platform -> domain`` tach edge). Fails
-    safe to ``{}`` for any early/unconfigured read (apps not ready, no settings,
-    pre-migration table, DB unreachable) so the DB tier is a strict no-op rather
-    than an exception in the hot config path.
+    Django unconfigured / a settings access failing (``ImproperlyConfigured``), the app
+    registry not yet populated (``AppRegistryNotReady``), a pre-migration/missing table
+    or an unreachable DB (``OperationalError`` / ``ProgrammingError``) — the legitimate
+    bootstrap states a cold or fresh install hits before the DB exists. These are the
+    only states the reader may empty the override tier for WITHOUT a signal, because
+    they are expected. Any OTHER exception is a real read bug and is LOGGED loud (see
+    :func:`_read_override_rows`) rather than silently swallowed.
     """
-    try:
-        from django.apps import apps  # noqa: PLC0415 — deferred: app registry read at call time
+    from django.core.exceptions import (  # noqa: PLC0415 — deferred: Django import at call time
+        AppRegistryNotReady,
+        ImproperlyConfigured,
+    )
+    from django.db.utils import (  # noqa: PLC0415 — deferred: Django import at call time
+        OperationalError,
+        ProgrammingError,
+    )
 
+    return (ImproperlyConfigured, AppRegistryNotReady, OperationalError, ProgrammingError)
+
+
+# The loud SIGNAL for a non-bootstrap ``ConfigSetting`` read fault. Such a failure is a
+# fail-OPEN of the ENTIRE DB override tier — it drops the ``autonomy`` /
+# ``require_human_approval_to_merge`` safety gates back to the dataclass defaults — so it
+# is logged ``ERROR`` + traceback (the "raise or log-and-signal, not SILENTLY fail-open"
+# contract) rather than swallowed: operator error-monitoring surfaces the real fault.
+_OVERRIDE_READ_FAILURE_MSG = (
+    "ConfigSetting %s-scope override read FAILED unexpectedly — resolving with NO DB override tier for this "
+    "read (safety gates fall back to dataclass defaults). This is a real read fault, not a bootstrap no-op; "
+    "fix the DB/read error."
+)
+
+
+def _load_global_rows() -> dict[str, Any]:
+    """Read the GLOBAL-scope (``scope=""``) ``{key: value}`` rows, or ``{}`` on failure.
+
+    Reaches the model via Django's app registry (no static ``teatree.core`` import — that
+    would be a backwards ``platform -> domain`` tach edge). A bootstrap state degrades
+    SILENTLY (:func:`_bootstrap_read_exceptions`); any other read fault is logged loud
+    (:data:`_OVERRIDE_READ_FAILURE_MSG`), never silently emptying the override tier.
+    """
+    from django.apps import apps  # noqa: PLC0415 — deferred: app registry read at call time
+
+    try:
         model = apps.get_model("core", "ConfigSetting")
         return dict(model.objects.overrides_for_scope(""))
-    except Exception:  # noqa: BLE001 — fail safe: any read failure => no DB override tier.
+    except _bootstrap_read_exceptions():
+        return {}
+    except Exception:
+        _logger.exception(_OVERRIDE_READ_FAILURE_MSG, "global")
         return {}
 
 
@@ -368,14 +443,14 @@ def _load_overlay_rows(overlay_name: str = "") -> dict[str, Any]:
     for the active overlay) and MERGES every canonically-equivalent scope group —
     a row scoped ``myovl`` and one scoped ``t3-myovl`` both apply. Alias groups
     apply in sorted-scope order, then the exact-name group last, so on a key
-    collision the exact-name row wins. Same fail-safe-to-``{}`` posture as
+    collision the exact-name row wins. Same signal-on-real-failure posture as
     :func:`_load_global_rows`.
     """
     if not overlay_name:
         return {}
-    try:
-        from django.apps import apps  # noqa: PLC0415 — deferred: app registry read at call time
+    from django.apps import apps  # noqa: PLC0415 — deferred: app registry read at call time
 
+    try:
         model = apps.get_model("core", "ConfigSetting")
         canonical = OverlayEntry.canonical_overlay_name(overlay_name)
         scope_values: dict[str, dict[str, Any]] = {}
@@ -387,7 +462,10 @@ def _load_overlay_rows(overlay_name: str = "") -> dict[str, Any]:
             if scope != overlay_name:
                 merged.update(scope_values[scope])
         merged.update(scope_values.get(overlay_name, {}))
-    except Exception:  # noqa: BLE001 — fail safe: any read failure => no DB override tier.
+    except _bootstrap_read_exceptions():
+        return {}
+    except Exception:
+        _logger.exception(_OVERRIDE_READ_FAILURE_MSG, f"overlay {overlay_name!r}")
         return {}
     return merged
 

--- a/src/teatree/config/write_validation.py
+++ b/src/teatree/config/write_validation.py
@@ -1,0 +1,47 @@
+"""The one parse→coerce→canonicalize core every config WRITE surface shares.
+
+Four surfaces persist a ``ConfigSetting`` row — ``config_setting set`` / ``seed``
+(the CLI), the dashboard settings editor POST, and the ``config_migration`` TOML
+import. Each ran the SAME copy: look up the key's registry parser, coerce the raw
+value, and catch the same ``(ValueError, TypeError, AttributeError)`` tuple a bad
+value raises. This module owns that core once so the surfaces can never drift on
+how a value is coerced or which errors a bad value raises.
+
+Each surface keeps its OWN gating (known-key refusal, the dashboard safety-posture
+confirm, the import removed-key + secret scan) and its OWN persistence call and
+error presentation (``SystemExit`` vs ``HttpResponseBadRequest`` vs a reject row);
+this helper covers only the shared coercion, raising a single
+:class:`ConfigWriteError` the caller formats for its surface.
+"""
+
+from teatree.config.known_settings import ALL_KNOWN_CONFIG_SETTINGS
+
+# A canonical, JSON/TOML-storable config value — the shape every registry parser
+# returns (a ``StrEnum`` is a ``str``; the structured ``speak`` / ``mr_reminder``
+# parsers return plain dicts). Mirrors ``ConfigSetting.ConfigValue``, which lives in
+# the ``core.models`` layer this platform module cannot import.
+type ConfigWriteValue = bool | int | float | str | list[object] | dict[str, object]
+
+
+class ConfigWriteError(ValueError):
+    """A raw config value that a setting's registry parser rejected (#258)."""
+
+
+def validate_config_write(key: str, raw: object) -> ConfigWriteValue:
+    """Coerce an already-decoded *raw* value through *key*'s registry parser.
+
+    Returns the CANONICAL value to persist (a numeric string ``"5"`` → ``5``, an
+    upper-case enum ``"AUTO"`` → ``"auto"``) so the stored row and the read-time
+    coercion agree. Raises :class:`ConfigWriteError` — wrapping the parser's
+    ``ValueError`` / ``TypeError`` / ``AttributeError`` — so every write surface
+    reports an invalid value identically and leaves its store untouched.
+
+    The caller MUST have already gated *key* into
+    :data:`~teatree.config.known_settings.ALL_KNOWN_CONFIG_SETTINGS`; this coerces
+    a known key's value, it does not decide key-ness or any surface-specific gate.
+    """
+    parser = ALL_KNOWN_CONFIG_SETTINGS[key]
+    try:
+        return parser(raw)
+    except (ValueError, TypeError, AttributeError) as exc:
+        raise ConfigWriteError(str(exc)) from exc

--- a/src/teatree/core/config_migration.py
+++ b/src/teatree/core/config_migration.py
@@ -16,11 +16,13 @@ from typing import Any
 import tomlkit
 from tomlkit import items as tomlkit_items
 
+from teatree.config import effective_default
 from teatree.config.known_settings import ALL_KNOWN_CONFIG_SETTINGS
 from teatree.config.registries import REGISTRY_KEYS
 from teatree.config.retired_settings import REMOVED_SETTING_KEYS, RENAMED_SETTING_KEYS, removed_setting
 from teatree.config.secret_settings import PERSONAL_IDENTIFIERS, SECRET_SETTINGS, is_credential_reference
 from teatree.config.setting_registries import OVERLAY_OVERRIDABLE_SETTINGS
+from teatree.config.write_validation import ConfigWriteError, validate_config_write
 from teatree.core.models import ConfigSetting
 from teatree.core.models.config_setting import ConfigValue
 from teatree.hooks.term_match import matched_term
@@ -29,11 +31,6 @@ GLOBAL_SCOPE = ""
 _TEATREE_TABLE = "teatree"
 _OVERLAYS_TABLE = "overlays"
 _E2E_REPOS_TABLE = "e2e_repos"
-
-
-def _scope_label(scope: str) -> str:
-    """Human label for a scope: ``global`` for the empty scope else ``overlay '<name>'``."""
-    return "global" if not scope else f"overlay {scope!r}"
 
 
 @dataclass(frozen=True)
@@ -279,18 +276,6 @@ class ConfigImport:
     dry_run: bool
 
 
-_NO_DEFAULT: object = object()
-
-
-def _shipped_default(key: str) -> object:
-    """The model's shipped default for *key* — the value a row equal to it is redundant against."""
-    # Deferred (PLC0415): the pydantic model import costs ~110ms; only the Django/import
-    # path pays it, never a cold reader.
-    from teatree.config.schema import shipped_defaults  # noqa: PLC0415 — deferred: heavy pydantic import
-
-    return getattr(shipped_defaults(), key, _NO_DEFAULT)
-
-
 def _import_candidates(doc: dict[str, Any]) -> list[tuple[str, str, ConfigValue]]:
     """Flatten a parsed export document into ``(scope, key, value)`` candidate rows.
 
@@ -325,8 +310,12 @@ def _classify_import_row(key: str, value: ConfigValue, terms: tuple[str, ...]) -
 
     Reject a removed key (loud, no home), an unknown key, and a secret/personal-identifier
     row (reusing the export withhold rule so a shared TOML never smuggles customer data back
-    in). Otherwise coerce through the same registry parser the resolver uses; a value equal to
-    the shipped default is redundant (``skip``), leaving ``restore = delete row`` intact.
+    in). Otherwise coerce through the shared write-path validator; a value equal to the key's
+    EFFECTIVE default (:func:`~teatree.config.effective_default` — the resolver's own default,
+    the same authority the seed-skip consults) is redundant (``skip``), leaving
+    ``restore = delete row`` intact. An adopted-live ``defaults.toml`` value that diverges
+    from the code default is NOT redundant, so it is written rather than skipped-then-silently
+    resolving back to the code default (P1-A).
     """
     if key in REMOVED_SETTING_KEYS:
         entry = removed_setting(key)
@@ -336,10 +325,10 @@ def _classify_import_row(key: str, value: ConfigValue, terms: tuple[str, ...]) -
     if (secret := _redaction_reason(key, value, terms)) is not None:
         return ("reject", f"secret ({secret})")
     try:
-        canonical = ALL_KNOWN_CONFIG_SETTINGS[key](value)
-    except (ValueError, TypeError, AttributeError) as exc:
+        canonical = validate_config_write(key, value)
+    except ConfigWriteError as exc:
         return ("reject", f"invalid: {exc}")
-    return ("skip", canonical) if canonical == _shipped_default(key) else ("write", canonical)
+    return ("skip", canonical) if canonical == effective_default(key) else ("write", canonical)
 
 
 def import_toml_to_db(

--- a/src/teatree/core/management/commands/config_setting.py
+++ b/src/teatree/core/management/commands/config_setting.py
@@ -33,11 +33,18 @@ import typer
 from django.core.exceptions import ValidationError
 from django_typer.management import TyperCommand, command
 
-from teatree.config import ALL_KNOWN_CONFIG_SETTINGS, COLD_HOOK_SETTINGS, FEATURE_FLAGS, get_effective_settings
+from teatree.config import (
+    ALL_KNOWN_CONFIG_SETTINGS,
+    COLD_HOOK_SETTINGS,
+    FEATURE_FLAGS,
+    effective_default,
+    get_effective_settings,
+)
 from teatree.config.feature_flags import flag_trailer, render_flags_audit
+from teatree.config.write_validation import ConfigWriteError, validate_config_write
 from teatree.core.config_migration import export_db_to_toml, import_toml_to_db
 from teatree.core.models import ConfigSetting
-from teatree.core.models.config_setting import ENTRYPOINT_SEEDER
+from teatree.core.models.config_setting import ENTRYPOINT_SEEDER, scope_label
 
 # Every key ``config_setting`` knows — the SINGLE known-key set shared by
 # get/list/set/clear AND the MCP ``config_setting_get`` read tool
@@ -46,20 +53,10 @@ from teatree.core.models.config_setting import ENTRYPOINT_SEEDER
 # a row no reader would consult.
 _ALLOWED_SETTINGS = ALL_KNOWN_CONFIG_SETTINGS
 
-# Sentinel for "no known code default" — a registry/cold key that is not a
-# ``UserSettings`` field. It never equals a real seed value, so a seed of such a
-# key is always written rather than mistaken for a redundant code-default seed.
-_NO_CODE_DEFAULT: object = object()
-
 _OverlayOption = Annotated[
     str,
     typer.Option("--overlay", help="Overlay name to scope the row to; omit for the global scope (every overlay)."),
 ]
-
-
-def _scope_label(scope: str) -> str:
-    """Human label for a row's scope: ``global`` for the empty scope else ``overlay '<name>'``."""
-    return "global" if not scope else f"overlay {scope!r}"
 
 
 def _flag_suffix(key: str) -> str:
@@ -70,20 +67,6 @@ def _flag_suffix(key: str) -> str:
     """
     trailer = flag_trailer(key)
     return f"  {trailer}" if trailer else ""
-
-
-def _code_default(key: str) -> object:
-    """The pure CODE default for *key* — the ``UserSettings`` field default.
-
-    A bare ``UserSettings()`` carries the dataclass field defaults with NO env or
-    DB layer applied, so this is the value a setting resolves to when nothing
-    overrides it. Returns :data:`_NO_CODE_DEFAULT` when *key* is not a
-    ``UserSettings`` field (a registry/cold key), so the seeder never mistakes a
-    non-``UserSettings`` seed for a redundant code-default write.
-    """
-    from teatree.config.settings import UserSettings  # noqa: PLC0415 — deferred: heavy config import
-
-    return getattr(UserSettings(), key, _NO_CODE_DEFAULT)
 
 
 class Command(TyperCommand):
@@ -119,10 +102,9 @@ class Command(TyperCommand):
         except json.JSONDecodeError as exc:
             self.stderr.write(f"  invalid JSON value for {key!r}: {exc}")
             raise SystemExit(2) from exc
-        parser = _ALLOWED_SETTINGS[key]
         try:
-            canonical = parser(parsed)
-        except (ValueError, TypeError, AttributeError) as exc:
+            canonical = validate_config_write(key, parsed)
+        except ConfigWriteError as exc:
             self.stderr.write(f"  invalid value for {key!r}: {exc}")
             raise SystemExit(2) from exc
         # Persist the CANONICAL parsed value, not the raw user value, so the DB
@@ -143,7 +125,7 @@ class Command(TyperCommand):
             raise SystemExit(2) from exc
         # Verify-by-re-read: report the stored value the resolver will now see.
         stored = ConfigSetting.objects.get_effective(key, scope=overlay)
-        self.stdout.write(f"  set {key} = {stored!r}  [{_scope_label(overlay)}]{_flag_suffix(key)}")
+        self.stdout.write(f"  set {key} = {stored!r}  [{scope_label(overlay)}]{_flag_suffix(key)}")
 
     @command()
     def seed(
@@ -174,22 +156,21 @@ class Command(TyperCommand):
         except json.JSONDecodeError as exc:
             self.stderr.write(f"  invalid JSON value for {key!r}: {exc}")
             raise SystemExit(2) from exc
-        parser = _ALLOWED_SETTINGS[key]
         try:
-            canonical = parser(parsed)
-        except (ValueError, TypeError, AttributeError) as exc:
+            canonical = validate_config_write(key, parsed)
+        except ConfigWriteError as exc:
             self.stderr.write(f"  invalid value for {key!r}: {exc}")
             raise SystemExit(2) from exc
         outcome = ConfigSetting.objects.seed(
             key,
             canonical,
-            code_default=_code_default(key),
+            code_default=effective_default(key),
             seeded_by=seeded_by,
             scope=overlay,
         )
         stored = ConfigSetting.objects.get_effective(key, scope=overlay)
         self.stdout.write(
-            f"  seed {key}: {outcome.value}  (effective={stored!r})  [{_scope_label(overlay)}]{_flag_suffix(key)}"
+            f"  seed {key}: {outcome.value}  (effective={stored!r})  [{scope_label(overlay)}]{_flag_suffix(key)}"
         )
 
     @command()
@@ -206,9 +187,9 @@ class Command(TyperCommand):
         silent.
         """
         if ConfigSetting.objects.clear(key, scope=overlay):
-            self.stdout.write(f"  cleared DB override for {key}  [{_scope_label(overlay)}]")
+            self.stdout.write(f"  cleared DB override for {key}  [{scope_label(overlay)}]")
             return
-        self.stderr.write(f"  no DB override row for {key}  [{_scope_label(overlay)}]")
+        self.stderr.write(f"  no DB override row for {key}  [{scope_label(overlay)}]")
         raise SystemExit(1)
 
     @command(name="list")
@@ -219,7 +200,7 @@ class Command(TyperCommand):
             self.stdout.write("  (no DB config overrides)")
             return
         for row in rows:
-            self.stdout.write(f"  {row.key} = {row.value!r}  [{_scope_label(row.scope)}]")
+            self.stdout.write(f"  {row.key} = {row.value!r}  [{scope_label(row.scope)}]")
 
     @command()
     def flags(self) -> None:
@@ -253,7 +234,7 @@ class Command(TyperCommand):
             raise SystemExit(2)
         stored = ConfigSetting.objects.get_effective(key, scope=overlay)
         if stored is not None:
-            self.stdout.write(f"  {key} = {stored!r}  [source: db, {_scope_label(overlay)}]{_flag_suffix(key)}")
+            self.stdout.write(f"  {key} = {stored!r}  [source: db, {scope_label(overlay)}]{_flag_suffix(key)}")
             return
         cold_hook = COLD_HOOK_SETTINGS.get(key)
         if cold_hook is not None:
@@ -297,7 +278,7 @@ class Command(TyperCommand):
         """
         result = export_db_to_toml(overlay or None, include_private=include_private)
         for row in result.redacted:
-            self.stderr.write(f"  withheld {row.key}  [{_scope_label(row.scope)}]  ({row.reason})")
+            self.stderr.write(f"  withheld {row.key}  [{scope_label(row.scope)}]  ({row.reason})")
         if result.redacted:
             self.stderr.write(
                 f"  {len(result.redacted)} private/tainted row(s) withheld; pass --include-private to include them."
@@ -340,13 +321,13 @@ class Command(TyperCommand):
         for old, new in result.folded:
             self.stdout.write(f"  folded retired alias {old} -> {new}")
         for row in result.rejected:
-            self.stderr.write(f"  rejected {row.key}  [{_scope_label(row.scope)}]  ({row.reason})")
+            self.stderr.write(f"  rejected {row.key}  [{scope_label(row.scope)}]  ({row.reason})")
         if result.rejected:
             self.stderr.write(f"  {len(result.rejected)} row(s) rejected; nothing was imported.")
             raise SystemExit(2)
         verb = "would import" if dry_run else "imported"
         for row in result.written:
-            self.stdout.write(f"  {verb} {row.key} = {row.value!r}  [{_scope_label(row.scope)}]")
+            self.stdout.write(f"  {verb} {row.key} = {row.value!r}  [{scope_label(row.scope)}]")
         self.stdout.write(
             f"  {verb} {len(result.written)} row(s); "
             f"{len(result.skipped_default)} equal to the shipped default (no row)."

--- a/src/teatree/core/models/config_setting.py
+++ b/src/teatree/core/models/config_setting.py
@@ -68,6 +68,11 @@ GLOBAL_SCOPE = ""
 ENTRYPOINT_SEEDER = "entrypoint"
 
 
+def scope_label(scope: str) -> str:
+    """Human label for a row's scope: ``global`` for the empty scope else ``overlay '<name>'``."""
+    return "global" if not scope else f"overlay {scope!r}"
+
+
 class SeedOutcome(StrEnum):
     """What :meth:`ConfigSettingManager.seed` did to the row (for operator logs)."""
 

--- a/src/teatree/dash/views/settings.py
+++ b/src/teatree/dash/views/settings.py
@@ -17,6 +17,7 @@ from django.views.decorators.http import require_GET, require_POST
 
 from teatree.config import ALL_KNOWN_CONFIG_SETTINGS
 from teatree.config.setting_registries import SAFETY_POSTURE_KEYS
+from teatree.config.write_validation import ConfigWriteError, validate_config_write
 from teatree.core.config_migration import import_toml_to_db
 from teatree.core.models import ConfigSetting
 from teatree.dash import audit
@@ -61,8 +62,8 @@ def settings_set(request: "HttpRequest") -> "HttpResponse":
     except json.JSONDecodeError as exc:
         return HttpResponseBadRequest(f"invalid JSON value: {exc}")
     try:
-        canonical = ALL_KNOWN_CONFIG_SETTINGS[key](parsed)
-    except (ValueError, TypeError, AttributeError) as exc:
+        canonical = validate_config_write(key, parsed)
+    except ConfigWriteError as exc:
         return HttpResponseBadRequest(f"invalid value for {key}: {exc}")
     try:
         ConfigSetting.objects.set_value(key, canonical, scope=scope)

--- a/tests/config/test_db_config_tier.py
+++ b/tests/config/test_db_config_tier.py
@@ -14,10 +14,14 @@ Integration-first: real ``ConfigSetting`` rows against the real DB, the active
 overlay set via ``T3_OVERLAY_NAME``.
 """
 
+from unittest import mock
+
 import pytest
+from django.db.utils import OperationalError
 from django.test import TestCase
 
 from teatree.config import get_effective_settings
+from teatree.config.resolution import _load_global_rows, _load_overlay_rows
 from teatree.core.models import ConfigSetting
 
 
@@ -151,3 +155,57 @@ class TestPerOverlayDbScope(TestCase):
         self.monkeypatch.setenv("T3_OVERLAY_NAME", "my-overlay")
         assert ConfigSetting.objects.count() == 0
         assert get_effective_settings().issue_implementer_enabled is False
+
+
+class TestOverrideReadSignalsOnRealFailure(TestCase):
+    """The DB override read never SILENTLY empties the tier on a REAL error (P1-B).
+
+    ``_load_global_rows`` / ``_load_overlay_rows`` degrade to ``{}`` SILENTLY only for
+    genuine bootstrap states (missing table, DB not ready). A real read bug drops the
+    whole override tier — including the ``autonomy`` / ``require_human_approval_to_merge``
+    safety gates — back to the dataclass defaults; that fail-open must be SIGNALLED loud
+    (ERROR log + traceback), not silently swallowed, so operator monitoring surfaces it.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
+
+    def test_bootstrap_missing_table_error_is_a_silent_no_op(self) -> None:
+        # A pre-migration / missing-table read is the legitimate no-op: {} and NO error log.
+        with (
+            mock.patch.object(
+                ConfigSetting.objects, "overrides_for_scope", side_effect=OperationalError("no such table")
+            ),
+            self.assertNoLogs("teatree.config", level="ERROR"),
+        ):
+            assert _load_global_rows() == {}
+
+    def test_real_read_error_is_logged_loud_not_silent(self) -> None:
+        # A genuine read bug (not a bootstrap state) degrades to {} but is SIGNALLED loud —
+        # never a silent empty override tier that fails OPEN on the safety gates.
+        with (
+            mock.patch.object(ConfigSetting.objects, "overrides_for_scope", side_effect=RuntimeError("corrupt read")),
+            self.assertLogs("teatree.config", level="ERROR") as captured,
+        ):
+            assert _load_global_rows() == {}
+        assert any("FAILED unexpectedly" in r.getMessage() for r in captured.records)
+
+    def test_real_read_error_signals_through_effective_settings(self) -> None:
+        # End to end: a real read failure surfaces loud (ERROR) rather than silently
+        # resolving the safety gates to their fail-open defaults with no trace.
+        with (
+            mock.patch.object(ConfigSetting.objects, "overrides_for_scope", side_effect=RuntimeError("corrupt read")),
+            self.assertLogs("teatree.config", level="ERROR") as captured,
+        ):
+            get_effective_settings()
+        assert any("FAILED unexpectedly" in r.getMessage() for r in captured.records)
+
+    def test_overlay_read_real_error_is_logged_loud(self) -> None:
+        # The per-overlay reader shares the same signal-on-real-failure contract.
+        with (
+            mock.patch.object(ConfigSetting.objects, "exclude", side_effect=RuntimeError("corrupt read")),
+            self.assertLogs("teatree.config", level="ERROR") as captured,
+        ):
+            assert _load_overlay_rows("my-overlay") == {}
+        assert any("FAILED unexpectedly" in r.getMessage() for r in captured.records)

--- a/tests/teatree_config/test_write_validation.py
+++ b/tests/teatree_config/test_write_validation.py
@@ -1,0 +1,31 @@
+"""The shared write-path validator every config write surface routes through."""
+
+import pytest
+
+from teatree.config.write_validation import ConfigWriteError, validate_config_write
+
+
+class TestValidateConfigWrite:
+    def test_returns_the_canonical_coerced_value(self) -> None:
+        # An upper-case enum canonicalises, a numeric string coerces to int (#258).
+        assert validate_config_write("mode", "AUTO") == "auto"
+        assert validate_config_write("issue_implementer_max_concurrent", "5") == 5
+
+    def test_real_bool_round_trips(self) -> None:
+        assert validate_config_write("issue_implementer_enabled", raw=True) is True
+
+    def test_quoted_bool_string_is_rejected(self) -> None:
+        # bool("false") == True would silently enable an opt-in setting — must raise.
+        with pytest.raises(ConfigWriteError):
+            validate_config_write("issue_implementer_enabled", "false")
+
+    def test_scalar_for_a_list_setting_is_rejected(self) -> None:
+        with pytest.raises(ConfigWriteError):
+            validate_config_write("excluded_skills", raw=True)
+
+    def test_error_message_carries_the_parser_reason(self) -> None:
+        with pytest.raises(ConfigWriteError, match="bool"):
+            validate_config_write("issue_implementer_enabled", 1)
+
+    def test_config_write_error_is_a_value_error(self) -> None:
+        assert issubclass(ConfigWriteError, ValueError)

--- a/tests/teatree_core/models/test_config_setting.py
+++ b/tests/teatree_core/models/test_config_setting.py
@@ -12,7 +12,17 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from teatree.core.models import ConfigSetting
-from teatree.core.models.config_setting import ENTRYPOINT_SEEDER, GLOBAL_SCOPE, SeedOutcome
+from teatree.core.models.config_setting import ENTRYPOINT_SEEDER, GLOBAL_SCOPE, SeedOutcome, scope_label
+
+
+class TestScopeLabel:
+    """The one ``scope_label`` home shared by the config CLI and the TOML export."""
+
+    def test_empty_scope_is_global(self) -> None:
+        assert scope_label("") == "global"
+
+    def test_named_scope_is_overlay_quoted(self) -> None:
+        assert scope_label("myproj") == "overlay 'myproj'"
 
 
 class TestConfigSettingStore(TestCase):

--- a/tests/teatree_core/test_config_migration.py
+++ b/tests/teatree_core/test_config_migration.py
@@ -17,8 +17,9 @@ from unittest import mock
 import pytest
 from django.test import TestCase
 
-from teatree.config import COLD_HOOK_SETTINGS, OVERLAY_OVERRIDABLE_SETTINGS
-from teatree.config.schema import _DEFAULTS_TOML
+from teatree.config import COLD_HOOK_SETTINGS, OVERLAY_OVERRIDABLE_SETTINGS, effective_default, get_effective_settings
+from teatree.config.schema import _DEFAULTS_TOML, shipped_defaults
+from teatree.config.settings import UserSettings
 from teatree.core.config_migration import _resolve_export_scan_terms, export_db_to_toml, import_toml_to_db
 from teatree.core.models import ConfigSetting
 
@@ -260,22 +261,44 @@ class TestImportTomlToDb(TestCase):
         assert result.rejected[0].reason.startswith("invalid")
         assert ConfigSetting.objects.count() == 0
 
-    def test_value_equal_to_shipped_default_writes_no_row(self) -> None:
-        # issue_implementer_enabled's shipped default is False.
+    def test_value_equal_to_effective_default_writes_no_row(self) -> None:
+        # issue_implementer_enabled's effective (code) default is False, so a row
+        # equal to it is redundant and skipped.
         result = import_toml_to_db("[teatree]\nissue_implementer_enabled = false\n", scan_terms=())
         assert result.rejected == ()
         assert result.written == ()
         assert [(r.scope, r.key) for r in result.skipped_default] == [("", "issue_implementer_enabled")]
         assert ConfigSetting.objects.count() == 0
 
-    def test_defaults_toml_imports_to_zero_rows(self) -> None:
-        # Every key in the shipped defaults equals its own default, so a clean import
-        # of defaults.toml stores nothing — preserving the #3676 zero-seed property.
+    def test_import_of_adopted_default_diverging_from_code_default_writes_a_row(self) -> None:
+        # P1-A regression: defaults.toml ADOPTS a live value (provision_ram_ceiling_percent
+        # = 75) that diverges from the conservative dataclass code default (85). The old
+        # import-skip authority (shipped_defaults) SKIPPED it as "equal to the shipped
+        # default" — but the resolver has no toml tier, so it then silently resolved to 85.
+        # The unified effective-default authority is the resolver's own default (85), so 75
+        # is NOT redundant: it must be written and then resolve to 75, not 85.
+        toml_default = shipped_defaults().provision_ram_ceiling_percent
+        code_default = UserSettings().provision_ram_ceiling_percent
+        assert toml_default != code_default  # the divergence this test guards
+        assert effective_default("provision_ram_ceiling_percent") == code_default
+        result = import_toml_to_db(f"[teatree]\nprovision_ram_ceiling_percent = {toml_default}\n", scan_terms=())
+        assert result.rejected == ()
+        assert [(r.scope, r.key) for r in result.written] == [("", "provision_ram_ceiling_percent")]
+        assert result.skipped_default == ()
+        # No silent divergence: the imported value is what the resolver now returns.
+        assert get_effective_settings().provision_ram_ceiling_percent == toml_default
+
+    def test_defaults_toml_import_leaves_no_silent_divergence(self) -> None:
+        # A clean import of defaults.toml writes ONLY the adopted-live keys that diverge
+        # from their code default (e.g. provision_ram_ceiling_percent); every other key is
+        # skipped as redundant. The invariant: after import, every resolved value equals
+        # what defaults.toml declares — the import never silently drops an adopted value.
         result = import_toml_to_db(_DEFAULTS_TOML.read_text(encoding="utf-8"), scan_terms=())
         assert result.rejected == ()
-        assert result.written == ()
         assert len(result.skipped_default) > 0
-        assert ConfigSetting.objects.count() == 0
+        assert "provision_ram_ceiling_percent" in {r.key for r in result.written}
+        resolved = get_effective_settings().provision_ram_ceiling_percent
+        assert resolved == shipped_defaults().provision_ram_ceiling_percent
 
     def test_dry_run_classifies_without_writing(self) -> None:
         result = import_toml_to_db('[teatree]\nmode = "auto"\n', scan_terms=(), dry_run=True)


### PR DESCRIPTION
refactor(config): unify write-path validation; fix default-authority divergence + fail-open override drop

Cluster 2 (DRY): extract the shared json-parse->coerce->canonicalize core the
four config write surfaces copy-pasted (CLI set/seed, dashboard editor POST, TOML
import) into teatree.config.write_validation.validate_config_write, raising one
ConfigWriteError each caller formats for its own surface. Each surface keeps its
own gating (known-key refusal, safety-posture confirm, import removed-key + secret
scan) and persistence call. Fold the byte-identical _scope_label duplicate into a
single scope_label home on the ConfigSetting model module.

P1-A (correctness): the seed-skip compared candidate rows against the UserSettings
dataclass default while the import-skip compared against the toml shipped_defaults.
Because generate_settings_defaults adopts live values into defaults.toml, those
two authorities diverge (e.g. provision_ram_ceiling_percent: toml 75 vs code 85),
and the resolver has no toml tier yet, so an imported row equal to the toml value
was skipped-as-default and then silently resolved to the code default. Establish
one effective_default authority (the resolver's own default, structured-field and
registry aware) consulted by both the seed-skip and import-skip; add a regression
reproducing the skip-then-resolves-differently divergence.

P1-B (safety): the DB override reads swallowed every exception into {}, so a real
read bug dropped the entire override tier -- including the autonomy and
require_human_approval_to_merge safety gates -- back to fail-open dataclass
defaults with no signal. Keep the silent {} degrade only for genuine bootstrap
states (Django unconfigured, app registry not ready, missing table, DB
unreachable); any other read fault is logged loud (ERROR + traceback) before
degrading, so operator monitoring surfaces the real fault instead of an invisible
safety-gate drop.