### PR TITLE
refactor(loop): CadenceScannerBase for periodic task-queuing scanners

### DIFF
--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -71,6 +71,7 @@ graph TD
     teatree.core.managers --> teatree.core.loop_lease_manager
     teatree.core.managers --> teatree.core.managers_issue_match
     teatree.core.managers --> teatree.core.managers_overlay
+    teatree.core.managers --> teatree.core.managers_phase_cadence
     teatree.core.managers --> teatree.core.managers_task_claim
     teatree.core.managers --> teatree.core.repair_loop
     teatree.core.managers --> teatree.core.session_handover_manager
@@ -384,6 +385,7 @@ graph TD
     teatree.core.managers_overlay
     teatree.core.managers_task_claim
     teatree.core.managers_issue_match
+    teatree.core.managers_phase_cadence
     teatree.backends.errors
     teatree.backends.http_retry
     teatree.backends.types

--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -20,6 +20,8 @@ from teatree.core.loop_lease_manager import (
 from teatree.core.managers_issue_match import matching_issue_q
 from teatree.core.managers_overlay import for_overlay as _for_overlay
 from teatree.core.managers_overlay import overlay_scope_q
+from teatree.core.managers_phase_cadence import in_flight_for_phase as _in_flight_for_phase
+from teatree.core.managers_phase_cadence import last_run_at_for_phase as _last_run_at_for_phase
 from teatree.core.managers_task_claim import ClaimOrder, _claimable_now_q
 from teatree.core.repair_loop import IterationStalled, MaxIterationsExceeded
 from teatree.core.session_handover_manager import SessionHandoverManager, SessionHandoverQuerySet
@@ -258,6 +260,14 @@ class TaskQuerySet(models.QuerySet):
             phase__in=phase_spellings(phase),
             status__in=task_model.Status.active(),
         )
+
+    def in_flight_for_phase(self, overlay: str, phase: str) -> models.QuerySet:
+        """Pending/claimed tasks for one overlay+phase — the periodic scanners' dedupe lock (SSOT)."""
+        return _in_flight_for_phase(self, overlay, phase)
+
+    def last_run_at_for_phase(self, overlay: str, phase: str, *, completed_only: bool = False) -> datetime | None:
+        """Most recent ``Session.started_at`` for an overlay+phase task, or ``None`` — the cadence clock."""
+        return _last_run_at_for_phase(self, overlay, phase, completed_only=completed_only)
 
     def claimable_for_headless(self, overlay: str | None = None) -> models.QuerySet:
         task_model = cast("type[Task]", apps.get_model("core", "Task"))

--- a/src/teatree/core/managers_phase_cadence.py
+++ b/src/teatree/core/managers_phase_cadence.py
@@ -1,0 +1,45 @@
+"""``Task`` queryset helpers for the periodic cadence scanners' dedupe + last-run reads.
+
+Split out of :mod:`teatree.core.managers` (module-health LOC budget), mirroring
+the ``managers_overlay`` / ``managers_issue_match`` concern modules. Referenced by
+:meth:`TaskQuerySet.in_flight_for_phase` / :meth:`TaskQuerySet.last_run_at_for_phase`
+— the single home for the queries the ``PhaseCadence`` scanner helper composes.
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING, cast
+
+from django.apps import apps
+from django.db import models
+from django.db.models import Max
+
+if TYPE_CHECKING:
+    from teatree.core.models.task import Task
+
+
+def in_flight_for_phase(qs: models.QuerySet, overlay: str, phase: str) -> models.QuerySet:
+    """Pending/claimed tasks for one overlay+phase — the scanners' dedupe lock.
+
+    ``Status.active()`` (PENDING|CLAIMED) is the SSOT for "in flight", so no
+    scanner carries a private ``{"pending","claimed"}`` constant.
+    """
+    task_model = cast("type[Task]", apps.get_model("core", "Task"))
+    return qs.filter(ticket__overlay=overlay, phase=phase, status__in=task_model.Status.active())
+
+
+def last_run_at_for_phase(
+    qs: models.QuerySet, overlay: str, phase: str, *, completed_only: bool = False
+) -> datetime | None:
+    """Most recent ``Session.started_at`` for an overlay+phase task, or ``None``.
+
+    A ``Task`` always carries a ``Session`` created at queue time, so the newest
+    ``session__started_at`` is the last-run instant; ``None`` is the bootstrap
+    case. ``completed_only`` narrows to COMPLETED tasks — the
+    ``architectural_review`` variant, whose cadence only advances on a review that
+    actually ran (a FAILED task must not suppress the next dispatch).
+    """
+    task_model = cast("type[Task]", apps.get_model("core", "Task"))
+    scoped = qs.filter(ticket__overlay=overlay, phase=phase)
+    if completed_only:
+        scoped = scoped.filter(status=task_model.Status.COMPLETED)
+    return scoped.aggregate(ts=Max("session__started_at"))["ts"]

--- a/src/teatree/loop/scanners/architectural_review.py
+++ b/src/teatree/loop/scanners/architectural_review.py
@@ -19,10 +19,19 @@ environments that need to tune one overlay differently from the rest:
 * ``architectural_review_disabled: bool`` — escape hatch; when True the
     wiring layer skips scanner instantiation for the affected overlay.
 
+The scanner shares :class:`teatree.loop.scanners.phase_cadence.PhaseCadence`
+with the other periodic task-queuing scanners for its dedupe / last-run /
+bootstrap-cadence machinery, and adds two genuine variants of its own:
+
+* **Completed-only last-run.** The cadence clock advances only on a review
+    that actually ran (``completed_only=True``), so a FAILED review does not
+    suppress the next dispatch for a full week.
+* **Merge-count backstop.** Beyond the time cadence, a high-velocity overlay
+    fires a review after ``after_merge_count`` merges since the last one.
+
 The scanner is a pure observer that creates one :class:`Task` row of
-``phase="architectural_review"`` when either trigger condition holds and
-no review task is currently queued or in-flight. The dispatcher (and any
-overlay-side handler that subscribes) picks up the task through the
+``phase="architectural_review"`` when a trigger holds and no review task is
+currently queued or in-flight. The dispatcher picks up the task through the
 normal pending-task pipeline; the scanner only writes the row.
 
 Design notes
@@ -30,20 +39,11 @@ Design notes
 
 * No new model field for the cadence clock. The "last review" timestamp
     is the existing ``Session.started_at`` (``auto_now_add``) of the most
-    recent ``architectural_review`` task. ``Task`` now has its own
-    ``created_at`` (migration 0004), but this scanner intentionally keys on
-    ``Session.started_at`` as the queue time — a Task always carries a
-    Session created at the moment we queue, so the Session's ``started_at``
-    is the canonical queue timestamp.
-* Dupe suppression. A pending or claimed task for the same overlay/phase
-    acts as the lock — the scanner sees the in-flight row and returns no
-    signal. Completion (or failure) of that task unlocks the next cadence
-    window.
+    recent COMPLETED ``architectural_review`` task.
 * Placeholder ticket. The architectural review is per-overlay, not
-    per-issue, so we ``get_or_create`` a synthetic Ticket carrying a
-    stable ``issue_url`` (``architectural-review://<overlay>``) to anchor
-    the FK chain. Real overlays already do this for tracking-only purposes
-    (e.g. the GitLab approvals scanner). The ticket carries no FSM state.
+    per-issue, so :class:`PhaseCadence` ``get_or_create``s a synthetic Ticket
+    carrying a stable ``issue_url`` (``architectural-review://<overlay>``) to
+    anchor the FK chain. The ticket carries no FSM state.
 """
 
 import datetime as dt
@@ -52,17 +52,14 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
 from django.apps import apps
-from django.db import transaction
-from django.db.models import Count, Max, Q
+from django.db.models import Max
 from django.utils import timezone
 
 from teatree.core.modelkit.phases import ARCHITECTURAL_REVIEW_PHASE
-from teatree.loop.scanners.base import ScanSignal, hours_since
+from teatree.loop.scanners.base import ScanSignal
+from teatree.loop.scanners.phase_cadence import PhaseCadence
 
 if TYPE_CHECKING:
-    from teatree.core.models import Session as _Session
-    from teatree.core.models import Task as _Task
-    from teatree.core.models import Ticket as _Ticket
     from teatree.core.models import TicketTransition as _TicketTransition
 
 logger = logging.getLogger(__name__)
@@ -72,9 +69,6 @@ logger = logging.getLogger(__name__)
 #: PR-just-landed state. ``shipped`` is the pre-merge "PR is up" state, not
 #: a merge.
 _MERGED_STATES: frozenset[str] = frozenset({"merged", "delivered"})
-
-#: States that mean a review task is still in-flight (cannot queue a dupe).
-_IN_FLIGHT_TASK_STATES: frozenset[str] = frozenset({"pending", "claimed"})
 
 
 @dataclass(slots=True)
@@ -100,16 +94,23 @@ class ArchitecturalReviewScanner:
     def scan(self) -> list[ScanSignal]:
         if not self.overlay_name:
             return []
-        if self._in_flight_review_exists():
+        cadence = PhaseCadence(self.overlay_name, phase=ARCHITECTURAL_REVIEW_PHASE, cadence_hours=self.cadence_hours)
+        if cadence.in_flight_exists():
             return []
 
         now = timezone.now()
-        last_review_at = self._last_review_completed_at()
-        trigger = self._evaluate_triggers(now=now, last_review_at=last_review_at)
+        last_review_at = cadence.last_run_at(completed_only=True)
+        trigger = self._evaluate_triggers(cadence, now=now, last_review_at=last_review_at)
         if trigger is None:
             return []
 
-        task = self._queue_task(trigger=trigger)
+        task = cadence.queue_task(
+            placeholder_issue_url=f"architectural-review://{self.overlay_name}",
+            agent_id=f"architectural-review-{self.overlay_name}",
+            execution_reason=f"Periodic architectural review ({trigger}) via skill: {self.skill}",
+            subject=f"Architectural review: {self.overlay_name}",
+            log_label="ArchitecturalReviewScanner",
+        )
         if task is None:
             return []
         return [
@@ -126,35 +127,10 @@ class ArchitecturalReviewScanner:
             ),
         ]
 
-    def _in_flight_review_exists(self) -> bool:
-        """True iff a pending/claimed review task exists for this overlay."""
-        task_model = _task_model()
-        if task_model is None:
-            return False
-        return task_model.objects.filter(
-            ticket__overlay=self.overlay_name,
-            phase=ARCHITECTURAL_REVIEW_PHASE,
-            status__in=_IN_FLIGHT_TASK_STATES,
-        ).exists()
-
-    def _last_review_completed_at(self) -> dt.datetime | None:
-        """Return the most recent review task's Session.started_at, or None.
-
-        Returns ``None`` when no prior review task has been recorded for
-        this overlay (the bootstrap case — cadence is trivially elapsed).
-        """
-        task_model = _task_model()
-        if task_model is None:
-            return None
-        aggregate = task_model.objects.filter(
-            ticket__overlay=self.overlay_name,
-            phase=ARCHITECTURAL_REVIEW_PHASE,
-            status=task_model.Status.COMPLETED,
-        ).aggregate(ts=Max("session__started_at"))
-        return aggregate["ts"]
-
-    def _evaluate_triggers(self, *, now: dt.datetime, last_review_at: dt.datetime | None) -> str | None:
-        """Return the trigger name (``cadence`` / ``after_merge_count``) or None.
+    def _evaluate_triggers(
+        self, cadence: PhaseCadence, *, now: dt.datetime, last_review_at: dt.datetime | None
+    ) -> str | None:
+        """Return the trigger name (``bootstrap`` / ``cadence`` / ``after_merge_count``) or None.
 
         Cadence wins over merge-count when both fire — the cadence is the
         primary contract; merge-count is the "high-velocity backstop" so
@@ -163,10 +139,10 @@ class ArchitecturalReviewScanner:
         """
         if last_review_at is None:
             return "bootstrap"
-        if hours_since(last_review_at, now=now) >= self.cadence_hours:
+        # Non-None ``last_review_at`` can only yield "cadence" or None here.
+        if cadence.evaluate_trigger(now=now, last_run_at=last_review_at) == "cadence":
             return "cadence"
-        merges_since = self._count_merges_since(last_review_at)
-        if merges_since >= self.after_merge_count:
+        if self._count_merges_since(last_review_at) >= self.after_merge_count:
             return "after_merge_count"
         return None
 
@@ -194,78 +170,6 @@ class ArchitecturalReviewScanner:
         )
         return sum(1 for row in latest_per_ticket if row["latest"] is not None and row["latest"] > last_review_at)
 
-    def _queue_task(self, *, trigger: str) -> "_Task | None":
-        """Create a Task + Session row anchored at the per-overlay placeholder ticket.
-
-        Wrapped in ``transaction.atomic()`` so a concurrent scanner on a
-        second loop process can't double-queue: the in-flight check and
-        the insert run under one DB transaction. A DB error is logged
-        but never raised — losing one tick's review queue is acceptable;
-        crashing the tick is not.
-        """
-        ticket_model = _ticket_model()
-        task_model = _task_model()
-        session_model = _session_model()
-        if ticket_model is None or task_model is None or session_model is None:
-            return None
-        try:
-            with transaction.atomic():
-                ticket, _created = ticket_model.objects.get_or_create(
-                    issue_url=_placeholder_issue_url(self.overlay_name),
-                    defaults={"overlay": self.overlay_name, "role": "author"},
-                )
-                # Make sure the overlay tag stays current — overlays renamed
-                # after the placeholder was first created should still queue
-                # under their canonical name.
-                if ticket.overlay != self.overlay_name:
-                    ticket.overlay = self.overlay_name
-                    ticket.save(update_fields=["overlay"])
-                session = session_model.objects.create(
-                    overlay=self.overlay_name,
-                    ticket=ticket,
-                    agent_id=f"architectural-review-{self.overlay_name}",
-                )
-                return task_model.objects.create(
-                    ticket=ticket,
-                    session=session,
-                    phase=ARCHITECTURAL_REVIEW_PHASE,
-                    execution_target=task_model.ExecutionTarget.HEADLESS,
-                    subject=f"Architectural review: {self.overlay_name}",
-                    execution_reason=(f"Periodic architectural review ({trigger}) via skill: {self.skill}"),
-                )
-        except Exception:
-            logger.exception(
-                "ArchitecturalReviewScanner: failed to queue review task for overlay %r",
-                self.overlay_name,
-            )
-            return None
-
-
-def _placeholder_issue_url(overlay_name: str) -> str:
-    """Stable per-overlay synthetic URL for the anchoring placeholder ticket."""
-    return f"architectural-review://{overlay_name}"
-
-
-def _ticket_model() -> "type[_Ticket] | None":
-    try:
-        return cast("type[_Ticket]", apps.get_model("core", "Ticket"))
-    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
-        return None
-
-
-def _task_model() -> "type[_Task] | None":
-    try:
-        return cast("type[_Task]", apps.get_model("core", "Task"))
-    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
-        return None
-
-
-def _session_model() -> "type[_Session] | None":
-    try:
-        return cast("type[_Session]", apps.get_model("core", "Session"))
-    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
-        return None
-
 
 def _transition_model() -> "type[_TicketTransition] | None":
     try:
@@ -274,14 +178,7 @@ def _transition_model() -> "type[_TicketTransition] | None":
         return None
 
 
-# ``Count``/``Q`` are kept on the public surface so future extension
-# (e.g. counting non-merge transitions or PR pushes) can build on the
-# same aggregate primitives without re-importing across the module
-# boundary. Pruning if unused is fine; left here for symmetry with
-# sibling scanners that compose similar queries.
 __all__ = [
     "ARCHITECTURAL_REVIEW_PHASE",
     "ArchitecturalReviewScanner",
-    "Count",
-    "Q",
 ]

--- a/src/teatree/loop/scanners/backlog_sweep.py
+++ b/src/teatree/loop/scanners/backlog_sweep.py
@@ -4,10 +4,10 @@ Companion to the ``sweeping-tickets`` skill: once the sweep's verdicts prove
 trustworthy, the loop fires a low-frequency ``backlog_sweep`` task that
 consolidates the issue tracker (shipped / consolidate-into-epic /
 regressive / still-standalone against current ``main``) without depending
-on an external cron. The scanner mirrors the shape of
-:mod:`teatree.loop.scanners.scanning_news` but bakes in two safety
-properties from day one because the sweep is destructive-capable (it can
-propose closing issues):
+on an external cron. The scanner is one of the periodic task-queuing family
+that share :class:`teatree.loop.scanners.phase_cadence.PhaseCadence`, and bakes
+in two safety properties from day one because the sweep is destructive-capable
+(it can propose closing issues):
 
 * **Default-OFF.** Unlike the always-on news/eval scanners, the kill
     switch (``backlog_sweep_disabled``) defaults *on* at the wiring layer,
@@ -20,7 +20,7 @@ propose closing issues):
     mass-folds unattended. Only the high-confidence shipped-by-merged-PR
     class auto-closes (the skill's own discipline).
 
-Other invariants mirror ``scanning_news``:
+Other invariants mirror the family:
 
 * **Single trigger.** Only a cadence (``backlog_sweep_cadence_hours``,
     default 168h = weekly). A fixed-rate platform behaviour, not coupled
@@ -35,32 +35,13 @@ Other invariants mirror ``scanning_news``:
     ``Session.started_at`` is the "last run" timestamp.
 """
 
-import datetime as dt
-import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
 
-from django.apps import apps
-from django.db import transaction
-from django.db.models import Max
 from django.utils import timezone
 
 from teatree.core.modelkit.phases import BACKLOG_SWEEP_PHASE
-from teatree.loop.scanners.base import ScanSignal, hours_since
-
-if TYPE_CHECKING:
-    from teatree.core.models import Session as _Session
-    from teatree.core.models import Task as _Task
-    from teatree.core.models import Ticket as _Ticket
-
-logger = logging.getLogger(__name__)
-
-#: Canonical phase token written to ``Task.phase`` for backlog-sweep tasks. Owned by the
-#: canonical phase vocabulary and re-exported here, so the phase can never exist without
-#: a declared ``SCANNER_DISPATCHED_PHASES`` producer + tool-least-privilege entry.
-
-#: States that mean a sweep task is still in-flight (cannot queue a dupe).
-_IN_FLIGHT_TASK_STATES: frozenset[str] = frozenset({"pending", "claimed"})
+from teatree.loop.scanners.base import ScanSignal
+from teatree.loop.scanners.phase_cadence import PhaseCadence
 
 
 @dataclass(slots=True)
@@ -97,16 +78,20 @@ class BacklogSweepScanner:
     name: str = "backlog_sweep"
 
     def scan(self) -> list[ScanSignal]:
-        if self._in_flight_task_exists():
+        cadence = PhaseCadence(self.overlay_name, phase=BACKLOG_SWEEP_PHASE, cadence_hours=self.cadence_hours)
+        if cadence.in_flight_exists():
             return []
 
-        now = timezone.now()
-        last_run_at = self._last_run_at()
-        trigger = self._evaluate_trigger(now=now, last_run_at=last_run_at)
+        trigger = cadence.evaluate_trigger(now=timezone.now(), last_run_at=cadence.last_run_at())
         if trigger is None:
             return []
 
-        task = self._queue_task(trigger=trigger)
+        task = cadence.queue_task(
+            placeholder_issue_url=f"backlog-sweep://{self.overlay_name}",
+            agent_id=f"backlog-sweep-{self.overlay_name}",
+            execution_reason=self._execution_reason(trigger),
+            log_label="BacklogSweepScanner",
+        )
         if task is None:
             return []
         return [
@@ -123,79 +108,6 @@ class BacklogSweepScanner:
                 },
             ),
         ]
-
-    def _in_flight_task_exists(self) -> bool:
-        """True iff a pending/claimed backlog-sweep task already exists."""
-        task_model = _task_model()
-        if task_model is None:
-            return False
-        return task_model.objects.filter(
-            ticket__overlay=self.overlay_name,
-            phase=BACKLOG_SWEEP_PHASE,
-            status__in=_IN_FLIGHT_TASK_STATES,
-        ).exists()
-
-    def _last_run_at(self) -> dt.datetime | None:
-        """Return the most recent task's Session.started_at, or None.
-
-        ``None`` when no prior backlog-sweep task has been recorded — the
-        bootstrap case where the cadence is trivially elapsed.
-        """
-        task_model = _task_model()
-        if task_model is None:
-            return None
-        aggregate = task_model.objects.filter(
-            ticket__overlay=self.overlay_name,
-            phase=BACKLOG_SWEEP_PHASE,
-        ).aggregate(ts=Max("session__started_at"))
-        return aggregate["ts"]
-
-    def _evaluate_trigger(self, *, now: dt.datetime, last_run_at: dt.datetime | None) -> str | None:
-        """Return the trigger name (``bootstrap`` / ``cadence``) or None."""
-        if last_run_at is None:
-            return "bootstrap"
-        if hours_since(last_run_at, now=now) >= self.cadence_hours:
-            return "cadence"
-        return None
-
-    def _queue_task(self, *, trigger: str) -> "_Task | None":
-        """Create a Task + Session row anchored at the overlay placeholder ticket.
-
-        Wrapped in ``transaction.atomic()`` so a concurrent scanner on a
-        second loop process can't double-queue: the in-flight check and
-        the insert run under one DB transaction. A DB error is logged but
-        never raised — losing one tick's sweep queue is acceptable;
-        crashing the tick is not.
-        """
-        ticket_model = _ticket_model()
-        task_model = _task_model()
-        session_model = _session_model()
-        if ticket_model is None or task_model is None or session_model is None:
-            return None
-        try:
-            with transaction.atomic():
-                ticket, _created = ticket_model.objects.get_or_create(
-                    issue_url=self._placeholder_issue_url(),
-                    defaults={"overlay": self.overlay_name, "role": "author"},
-                )
-                if ticket.overlay != self.overlay_name:
-                    ticket.overlay = self.overlay_name
-                    ticket.save(update_fields=["overlay"])
-                session = session_model.objects.create(
-                    overlay=self.overlay_name,
-                    ticket=ticket,
-                    agent_id=f"backlog-sweep-{self.overlay_name}",
-                )
-                return task_model.objects.create(
-                    ticket=ticket,
-                    session=session,
-                    phase=BACKLOG_SWEEP_PHASE,
-                    execution_target=task_model.ExecutionTarget.HEADLESS,
-                    execution_reason=self._execution_reason(trigger),
-                )
-        except Exception:
-            logger.exception("BacklogSweepScanner: failed to queue backlog-sweep task")
-            return None
 
     def _execution_reason(self, trigger: str) -> str:
         """Build the dispatcher directive, embedding the ask-gate contract.
@@ -221,31 +133,6 @@ class BacklogSweepScanner:
                 "(#2419, #1931)"
             )
         return base
-
-    def _placeholder_issue_url(self) -> str:
-        """Stable synthetic URL for the overlay-anchored placeholder ticket."""
-        return f"backlog-sweep://{self.overlay_name}"
-
-
-def _ticket_model() -> "type[_Ticket] | None":
-    try:
-        return cast("type[_Ticket]", apps.get_model("core", "Ticket"))
-    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
-        return None
-
-
-def _task_model() -> "type[_Task] | None":
-    try:
-        return cast("type[_Task]", apps.get_model("core", "Task"))
-    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
-        return None
-
-
-def _session_model() -> "type[_Session] | None":
-    try:
-        return cast("type[_Session]", apps.get_model("core", "Session"))
-    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
-        return None
 
 
 __all__ = [

--- a/src/teatree/loop/scanners/eval_local.py
+++ b/src/teatree/loop/scanners/eval_local.py
@@ -7,15 +7,16 @@ first_pr_of_week.py``). This is the local half: the loop fires an
 ``eval_local`` task per cadence window (default 168h = weekly) so the
 SCOPED eval suite runs locally without depending on an external cron.
 
-The scanner mirrors :mod:`teatree.loop.scanners.scanning_news`:
+The scanner is one of the periodic task-queuing family that share
+:class:`teatree.loop.scanners.phase_cadence.PhaseCadence`:
 
 * **Single trigger.** Only a cadence (``eval_local_cadence_hours``,
     default 168h). A fixed-rate platform behaviour, not coupled to
     delivery velocity.
 * **Overlay anchor is injected, not baked.** A core scanner that does
     not know any overlay's name; the wiring layer
-    (``teatree.loop.global_scanner_factories._eval_local_scanner``) resolves the active
-    overlay via :func:`teatree.config.discover_active_overlay`.
+    (``teatree.loop.global_scanner_factories._eval_local_scanner``) resolves the
+    active overlay via :func:`teatree.config.discover_active_overlay`.
 * **Same dedup contract.** A pending or claimed ``eval_local`` task acts
     as the lock — completion (or failure) unlocks the next cadence
     window. No new model fields; the most recent task's
@@ -27,32 +28,13 @@ The scanner mirrors :mod:`teatree.loop.scanners.scanning_news`:
     long-running suite never blocks the tick.
 """
 
-import datetime as dt
-import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
 
-from django.apps import apps
-from django.db import transaction
-from django.db.models import Max
 from django.utils import timezone
 
 from teatree.core.modelkit.phases import EVAL_LOCAL_PHASE
-from teatree.loop.scanners.base import ScanSignal, hours_since
-
-if TYPE_CHECKING:
-    from teatree.core.models import Session as _Session
-    from teatree.core.models import Task as _Task
-    from teatree.core.models import Ticket as _Ticket
-
-logger = logging.getLogger(__name__)
-
-#: Canonical phase token written to ``Task.phase`` for local-eval tasks. Owned by the
-#: canonical phase vocabulary and re-exported here, so the phase can never exist without
-#: a declared ``SCANNER_DISPATCHED_PHASES`` producer + tool-least-privilege entry.
-
-#: States that mean an eval task is still in-flight (cannot queue a dupe).
-_IN_FLIGHT_TASK_STATES: frozenset[str] = frozenset({"pending", "claimed"})
+from teatree.loop.scanners.base import ScanSignal
+from teatree.loop.scanners.phase_cadence import PhaseCadence
 
 
 @dataclass(slots=True)
@@ -74,16 +56,20 @@ class EvalLocalScanner:
     name: str = "eval_local"
 
     def scan(self) -> list[ScanSignal]:
-        if self._in_flight_task_exists():
+        cadence = PhaseCadence(self.overlay_name, phase=EVAL_LOCAL_PHASE, cadence_hours=self.cadence_hours)
+        if cadence.in_flight_exists():
             return []
 
-        now = timezone.now()
-        last_run_at = self._last_run_at()
-        trigger = self._evaluate_trigger(now=now, last_run_at=last_run_at)
+        trigger = cadence.evaluate_trigger(now=timezone.now(), last_run_at=cadence.last_run_at())
         if trigger is None:
             return []
 
-        task = self._queue_task(trigger=trigger)
+        task = cadence.queue_task(
+            placeholder_issue_url=f"eval-local://{self.overlay_name}",
+            agent_id=f"eval-local-{self.overlay_name}",
+            execution_reason=self._execution_reason(trigger),
+            log_label="EvalLocalScanner",
+        )
         if task is None:
             return []
         return [
@@ -100,64 +86,6 @@ class EvalLocalScanner:
             ),
         ]
 
-    def _in_flight_task_exists(self) -> bool:
-        task_model = _task_model()
-        if task_model is None:
-            return False
-        return task_model.objects.filter(
-            ticket__overlay=self.overlay_name,
-            phase=EVAL_LOCAL_PHASE,
-            status__in=_IN_FLIGHT_TASK_STATES,
-        ).exists()
-
-    def _last_run_at(self) -> dt.datetime | None:
-        task_model = _task_model()
-        if task_model is None:
-            return None
-        aggregate = task_model.objects.filter(
-            ticket__overlay=self.overlay_name,
-            phase=EVAL_LOCAL_PHASE,
-        ).aggregate(ts=Max("session__started_at"))
-        return aggregate["ts"]
-
-    def _evaluate_trigger(self, *, now: dt.datetime, last_run_at: dt.datetime | None) -> str | None:
-        if last_run_at is None:
-            return "bootstrap"
-        if hours_since(last_run_at, now=now) >= self.cadence_hours:
-            return "cadence"
-        return None
-
-    def _queue_task(self, *, trigger: str) -> "_Task | None":
-        ticket_model = _ticket_model()
-        task_model = _task_model()
-        session_model = _session_model()
-        if ticket_model is None or task_model is None or session_model is None:
-            return None
-        try:
-            with transaction.atomic():
-                ticket, _created = ticket_model.objects.get_or_create(
-                    issue_url=self._placeholder_issue_url(),
-                    defaults={"overlay": self.overlay_name, "role": "author"},
-                )
-                if ticket.overlay != self.overlay_name:
-                    ticket.overlay = self.overlay_name
-                    ticket.save(update_fields=["overlay"])
-                session = session_model.objects.create(
-                    overlay=self.overlay_name,
-                    ticket=ticket,
-                    agent_id=f"eval-local-{self.overlay_name}",
-                )
-                return task_model.objects.create(
-                    ticket=ticket,
-                    session=session,
-                    phase=EVAL_LOCAL_PHASE,
-                    execution_target=task_model.ExecutionTarget.HEADLESS,
-                    execution_reason=self._execution_reason(trigger),
-                )
-        except Exception:
-            logger.exception("EvalLocalScanner: failed to queue eval_local task")
-            return None
-
     def _execution_reason(self, trigger: str) -> str:
         """Direct the SCOPED local run via the $0-extra transcript runner.
 
@@ -172,30 +100,6 @@ class EvalLocalScanner:
             "`t3 eval pinned-regressions` and `t3 eval run` "
             "(transcript backend, $0 extra)"
         )
-
-    def _placeholder_issue_url(self) -> str:
-        return f"eval-local://{self.overlay_name}"
-
-
-def _ticket_model() -> "type[_Ticket] | None":
-    try:
-        return cast("type[_Ticket]", apps.get_model("core", "Ticket"))
-    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
-        return None
-
-
-def _task_model() -> "type[_Task] | None":
-    try:
-        return cast("type[_Task]", apps.get_model("core", "Task"))
-    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
-        return None
-
-
-def _session_model() -> "type[_Session] | None":
-    try:
-        return cast("type[_Session]", apps.get_model("core", "Session"))
-    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
-        return None
 
 
 __all__ = [

--- a/src/teatree/loop/scanners/phase_cadence.py
+++ b/src/teatree/loop/scanners/phase_cadence.py
@@ -1,0 +1,162 @@
+"""Shared cadence machinery for the periodic task-queuing scanners.
+
+The ``eval_local`` / ``scanning_news`` / ``architectural_review`` /
+``backlog_sweep`` / ``triage_assessor`` / ``provision_smoke`` scanners all queue
+ONE phase ``Task`` per cadence window, guarded by a pending/claimed dedupe lock
+and a ``Session.started_at``-based last-run clock, anchored at a per-overlay
+placeholder ticket. :class:`PhaseCadence` owns that shared machinery — the
+in-flight dedupe check, the last-run lookup, the bootstrap/cadence trigger
+decision, and the placeholder-ticket task write — so each concrete scanner keeps
+only its own signal payload plus any genuine variant (``architectural_review``'s
+merge-count trigger, ``triage_assessor``'s survivors filter) as its own code.
+
+The task QUERIES live on the ``Task`` manager
+(:meth:`TaskQuerySet.in_flight_for_phase` /
+:meth:`TaskQuerySet.last_run_at_for_phase`) — this module is the composition seam
+between a scanner and those queries, never a second home for the SQL.
+
+Every helper degrades to a no-signal default when the ``core`` models are not yet
+registered (a fresh install runs the tick before ``migrate``), preserving the
+per-tick fault isolation the loop relies on (``domain_jobs._run_job``).
+"""
+
+import datetime as dt
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+
+from django.apps import apps
+from django.db import transaction
+
+from teatree.loop.scanners.base import hours_since
+
+if TYPE_CHECKING:
+    from teatree.core.models import Session as _Session
+    from teatree.core.models import Task as _Task
+    from teatree.core.models import Ticket as _Ticket
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class PhaseCadence:
+    """The once-per-N-hours queue-a-phase-task contract, shared across scanners.
+
+    Constructed per scan from a scanner's ``overlay_name`` / phase constant /
+    ``cadence_hours``. Stateless and cheap — a scanner builds one inline rather
+    than carrying it as a field, so the scanners stay plain config dataclasses.
+    """
+
+    overlay_name: str
+    phase: str
+    cadence_hours: int
+
+    def in_flight_exists(self) -> bool:
+        """True iff a pending/claimed task for this overlay+phase already exists."""
+        task_model = _task_model()
+        if task_model is None:
+            return False
+        return task_model.objects.in_flight_for_phase(self.overlay_name, self.phase).exists()
+
+    def last_run_at(self, *, completed_only: bool = False) -> dt.datetime | None:
+        """Most recent task's ``Session.started_at``, or ``None`` (bootstrap).
+
+        ``completed_only`` narrows to COMPLETED tasks — the
+        ``architectural_review`` variant, whose cadence only advances on a review
+        that actually ran (a FAILED task must not suppress the next dispatch).
+        """
+        task_model = _task_model()
+        if task_model is None:
+            return None
+        return task_model.objects.last_run_at_for_phase(self.overlay_name, self.phase, completed_only=completed_only)
+
+    def evaluate_trigger(self, *, now: dt.datetime, last_run_at: dt.datetime | None) -> str | None:
+        """Return the trigger name (``bootstrap`` / ``cadence``) or ``None``.
+
+        The shared bootstrap+cadence decision. Scanners with an extra trigger
+        (``architectural_review``'s merge-count backstop) call this first and add
+        their own branch when it returns ``None``.
+        """
+        if last_run_at is None:
+            return "bootstrap"
+        if hours_since(last_run_at, now=now) >= self.cadence_hours:
+            return "cadence"
+        return None
+
+    def queue_task(
+        self,
+        *,
+        placeholder_issue_url: str,
+        agent_id: str,
+        execution_reason: str,
+        subject: str = "",
+        log_label: str,
+    ) -> "_Task | None":
+        """Create a Task + Session row anchored at the per-overlay placeholder ticket.
+
+        Wrapped in ``transaction.atomic()`` so a concurrent scanner on a second
+        loop process can't double-queue: the caller's in-flight check and this
+        insert run under one DB transaction. A DB error is logged but never
+        raised — losing one tick's queue is acceptable; crashing the tick is not.
+        Returns the created ``Task`` (or ``None`` when a model is unavailable or
+        the write fails).
+        """
+        ticket_model = _ticket_model()
+        task_model = _task_model()
+        session_model = _session_model()
+        if ticket_model is None or task_model is None or session_model is None:
+            return None
+        try:
+            with transaction.atomic():
+                ticket, _created = ticket_model.objects.get_or_create(
+                    issue_url=placeholder_issue_url,
+                    defaults={"overlay": self.overlay_name, "role": "author"},
+                )
+                # Keep the overlay tag current — a placeholder ticket that
+                # pre-dates the current wiring (e.g. a legacy overlay name) is
+                # re-anchored to the canonical name before it queues.
+                if ticket.overlay != self.overlay_name:
+                    ticket.overlay = self.overlay_name
+                    ticket.save(update_fields=["overlay"])
+                session = session_model.objects.create(
+                    overlay=self.overlay_name,
+                    ticket=ticket,
+                    agent_id=agent_id,
+                )
+                return task_model.objects.create(
+                    ticket=ticket,
+                    session=session,
+                    phase=self.phase,
+                    execution_target=task_model.ExecutionTarget.HEADLESS,
+                    subject=subject,
+                    execution_reason=execution_reason,
+                )
+        except Exception:
+            logger.exception("%s: failed to queue %s task", log_label, self.phase)
+            return None
+
+
+def _ticket_model() -> "type[_Ticket] | None":
+    try:
+        return cast("type[_Ticket]", apps.get_model("core", "Ticket"))
+    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
+        return None
+
+
+def _task_model() -> "type[_Task] | None":
+    try:
+        return cast("type[_Task]", apps.get_model("core", "Task"))
+    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
+        return None
+
+
+def _session_model() -> "type[_Session] | None":
+    try:
+        return cast("type[_Session]", apps.get_model("core", "Session"))
+    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
+        return None
+
+
+__all__ = [
+    "PhaseCadence",
+]

--- a/src/teatree/loop/scanners/provision_smoke.py
+++ b/src/teatree/loop/scanners/provision_smoke.py
@@ -4,9 +4,9 @@ Companion to the ``t3 dogfood overlay-provision-smoke`` management
 command: the loop queues a ``dogfood_smoke`` task once per cadence
 window (default 24h — nightly) so latent CLI bugs in the overlay
 provision path surface in the loop, not in the user's next E2E
-session. Mirrors :class:`teatree.loop.scanners.scanning_news.ScanningNewsScanner`
-in shape — a fixed-rate platform behaviour, not coupled to delivery
-velocity.
+session. One of the periodic task-queuing family that share
+:class:`teatree.loop.scanners.phase_cadence.PhaseCadence` — a fixed-rate
+platform behaviour, not coupled to delivery velocity.
 
 The scanner only *schedules*; the dispatcher picks up the queued task
 and shells out to ``t3 dogfood overlay-provision-smoke``. Failures DM
@@ -15,30 +15,17 @@ so the scanner has no responsibility for the verdict pipeline beyond
 keeping its cadence honest.
 """
 
-import datetime as dt
-import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
-from django.apps import apps
-from django.db import transaction
-from django.db.models import Max
 from django.utils import timezone
 
 from teatree.core.modelkit.phases import DOGFOOD_SMOKE_PHASE
-from teatree.loop.scanners.base import ScanSignal, hours_since
+from teatree.loop.scanners.base import ScanSignal
+from teatree.loop.scanners.phase_cadence import PhaseCadence
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-
-    from teatree.core.models import Session as _Session
-    from teatree.core.models import Task as _Task
-    from teatree.core.models import Ticket as _Ticket
-
-logger = logging.getLogger(__name__)
-
-#: States that mean a smoke task is still in-flight (cannot queue a dupe).
-_IN_FLIGHT_TASK_STATES: frozenset[str] = frozenset({"pending", "claimed"})
 
 
 @dataclass(slots=True)
@@ -61,16 +48,21 @@ class ProvisionSmokeScanner:
     def scan(self) -> list[ScanSignal]:
         if not self.overlay_name:
             return []
-        if self._in_flight_task_exists():
+        cadence = PhaseCadence(self.overlay_name, phase=DOGFOOD_SMOKE_PHASE, cadence_hours=self.cadence_hours)
+        if cadence.in_flight_exists():
             return []
 
-        now = timezone.now()
-        last_run_at = self._last_run_at()
-        trigger = self._evaluate_trigger(now=now, last_run_at=last_run_at)
+        trigger = cadence.evaluate_trigger(now=timezone.now(), last_run_at=cadence.last_run_at())
         if trigger is None:
             return []
 
-        task = self._queue_task(trigger=trigger)
+        task = cadence.queue_task(
+            placeholder_issue_url=f"dogfood-smoke://{self.overlay_name}",
+            agent_id=f"dogfood-smoke-{self.overlay_name}",
+            execution_reason=f"Periodic provision smoke ({trigger}) via skill: {self.skill}",
+            subject=f"Provision smoke: {self.overlay_name}",
+            log_label="ProvisionSmokeScanner",
+        )
         if task is None:
             return []
         return [
@@ -86,89 +78,6 @@ class ProvisionSmokeScanner:
                 },
             ),
         ]
-
-    def _in_flight_task_exists(self) -> bool:
-        task_model = _task_model()
-        if task_model is None:
-            return False
-        return task_model.objects.filter(
-            ticket__overlay=self.overlay_name,
-            phase=DOGFOOD_SMOKE_PHASE,
-            status__in=_IN_FLIGHT_TASK_STATES,
-        ).exists()
-
-    def _last_run_at(self) -> dt.datetime | None:
-        task_model = _task_model()
-        if task_model is None:
-            return None
-        aggregate = task_model.objects.filter(
-            ticket__overlay=self.overlay_name,
-            phase=DOGFOOD_SMOKE_PHASE,
-        ).aggregate(ts=Max("session__started_at"))
-        return aggregate["ts"]
-
-    def _evaluate_trigger(self, *, now: dt.datetime, last_run_at: dt.datetime | None) -> str | None:
-        if last_run_at is None:
-            return "bootstrap"
-        if hours_since(last_run_at, now=now) >= self.cadence_hours:
-            return "cadence"
-        return None
-
-    def _queue_task(self, *, trigger: str) -> "_Task | None":
-        ticket_model = _ticket_model()
-        task_model = _task_model()
-        session_model = _session_model()
-        if ticket_model is None or task_model is None or session_model is None:
-            return None
-        try:
-            with transaction.atomic():
-                ticket, _created = ticket_model.objects.get_or_create(
-                    issue_url=self._placeholder_issue_url(),
-                    defaults={"overlay": self.overlay_name, "role": "author"},
-                )
-                if ticket.overlay != self.overlay_name:
-                    ticket.overlay = self.overlay_name
-                    ticket.save(update_fields=["overlay"])
-                session = session_model.objects.create(
-                    overlay=self.overlay_name,
-                    ticket=ticket,
-                    agent_id=f"dogfood-smoke-{self.overlay_name}",
-                )
-                return task_model.objects.create(
-                    ticket=ticket,
-                    session=session,
-                    phase=DOGFOOD_SMOKE_PHASE,
-                    execution_target=task_model.ExecutionTarget.HEADLESS,
-                    subject=f"Provision smoke: {self.overlay_name}",
-                    execution_reason=(f"Periodic provision smoke ({trigger}) via skill: {self.skill}"),
-                )
-        except Exception:
-            logger.exception("ProvisionSmokeScanner: failed to queue smoke task")
-            return None
-
-    def _placeholder_issue_url(self) -> str:
-        return f"dogfood-smoke://{self.overlay_name}"
-
-
-def _ticket_model() -> "type[_Ticket] | None":
-    try:
-        return cast("type[_Ticket]", apps.get_model("core", "Ticket"))
-    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
-        return None
-
-
-def _task_model() -> "type[_Task] | None":
-    try:
-        return cast("type[_Task]", apps.get_model("core", "Task"))
-    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
-        return None
-
-
-def _session_model() -> "type[_Session] | None":
-    try:
-        return cast("type[_Session]", apps.get_model("core", "Session"))
-    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
-        return None
 
 
 def build_provision_smoke_scanner(

--- a/src/teatree/loop/scanners/scanning_news.py
+++ b/src/teatree/loop/scanners/scanning_news.py
@@ -2,9 +2,9 @@
 
 Companion to the ``scanning-news`` skill (#1190): the loop should fire a
 daily ``scanning_news`` task that runs the news-scan / improvement-ideas
-workflow without depending on an external cron. The scanner mirrors the
-shape of :mod:`teatree.loop.scanners.architectural_review` but is
-deliberately simpler:
+workflow without depending on an external cron. The scanner is one of the
+periodic task-queuing family that share
+:class:`teatree.loop.scanners.phase_cadence.PhaseCadence`, deliberately simple:
 
 * **Single trigger.** Only a cadence (``scanning_news_cadence_hours``,
     default 24h). There is no after-merge backstop — news scanning is a
@@ -21,35 +21,19 @@ deliberately simpler:
 * **Same dedup contract.** A pending or claimed ``scanning_news`` task
     acts as the lock — completion (or failure) unlocks the next cadence
     window. No new model fields; the ``Session.started_at`` of the most
-    recent task is the "last run" timestamp (same trick as
-    ``architectural_review``).
+    recent task is the "last run" timestamp.
 """
 
-import datetime as dt
-import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
 
-from django.apps import apps
-from django.db import transaction
-from django.db.models import Max
 from django.utils import timezone
 
 from teatree.core.news_sources import NEWS_SOURCES, render_source_directive
-from teatree.loop.scanners.base import ScanSignal, hours_since
-
-if TYPE_CHECKING:
-    from teatree.core.models import Session as _Session
-    from teatree.core.models import Task as _Task
-    from teatree.core.models import Ticket as _Ticket
-
-logger = logging.getLogger(__name__)
+from teatree.loop.scanners.base import ScanSignal
+from teatree.loop.scanners.phase_cadence import PhaseCadence
 
 #: Canonical phase token written to ``Task.phase`` for scanning-news tasks.
 SCANNING_NEWS_PHASE = "scanning_news"
-
-#: States that mean a news task is still in-flight (cannot queue a dupe).
-_IN_FLIGHT_TASK_STATES: frozenset[str] = frozenset({"pending", "claimed"})
 
 
 @dataclass(slots=True)
@@ -88,16 +72,21 @@ class ScanningNewsScanner:
     name: str = "scanning_news"
 
     def scan(self) -> list[ScanSignal]:
-        if self._in_flight_task_exists():
+        cadence = PhaseCadence(self.overlay_name, phase=SCANNING_NEWS_PHASE, cadence_hours=self.cadence_hours)
+        if cadence.in_flight_exists():
             return []
 
-        now = timezone.now()
-        last_run_at = self._last_run_at()
-        trigger = self._evaluate_trigger(now=now, last_run_at=last_run_at)
+        trigger = cadence.evaluate_trigger(now=timezone.now(), last_run_at=cadence.last_run_at())
         if trigger is None:
             return []
 
-        task = self._queue_task(trigger=trigger)
+        task = cadence.queue_task(
+            placeholder_issue_url=f"scanning-news://{self.overlay_name}",
+            agent_id=f"scanning-news-{self.overlay_name}",
+            execution_reason=self._execution_reason(trigger),
+            subject=f"Scan AI news: {self.overlay_name}",
+            log_label="ScanningNewsScanner",
+        )
         if task is None:
             return []
         return [
@@ -114,83 +103,6 @@ class ScanningNewsScanner:
                 },
             ),
         ]
-
-    def _in_flight_task_exists(self) -> bool:
-        """True iff a pending/claimed scanning-news task already exists."""
-        task_model = _task_model()
-        if task_model is None:
-            return False
-        return task_model.objects.filter(
-            ticket__overlay=self.overlay_name,
-            phase=SCANNING_NEWS_PHASE,
-            status__in=_IN_FLIGHT_TASK_STATES,
-        ).exists()
-
-    def _last_run_at(self) -> dt.datetime | None:
-        """Return the most recent task's Session.started_at, or None.
-
-        ``None`` when no prior scanning-news task has been recorded — the
-        bootstrap case where the cadence is trivially elapsed.
-        """
-        task_model = _task_model()
-        if task_model is None:
-            return None
-        aggregate = task_model.objects.filter(
-            ticket__overlay=self.overlay_name,
-            phase=SCANNING_NEWS_PHASE,
-        ).aggregate(ts=Max("session__started_at"))
-        return aggregate["ts"]
-
-    def _evaluate_trigger(self, *, now: dt.datetime, last_run_at: dt.datetime | None) -> str | None:
-        """Return the trigger name (``bootstrap`` / ``cadence``) or None."""
-        if last_run_at is None:
-            return "bootstrap"
-        if hours_since(last_run_at, now=now) >= self.cadence_hours:
-            return "cadence"
-        return None
-
-    def _queue_task(self, *, trigger: str) -> "_Task | None":
-        """Create a Task + Session row anchored at the overlay placeholder ticket.
-
-        Wrapped in ``transaction.atomic()`` so a concurrent scanner on a
-        second loop process can't double-queue: the in-flight check and
-        the insert run under one DB transaction. A DB error is logged
-        but never raised — losing one tick's news queue is acceptable;
-        crashing the tick is not.
-        """
-        ticket_model = _ticket_model()
-        task_model = _task_model()
-        session_model = _session_model()
-        if ticket_model is None or task_model is None or session_model is None:
-            return None
-        try:
-            with transaction.atomic():
-                ticket, _created = ticket_model.objects.get_or_create(
-                    issue_url=self._placeholder_issue_url(),
-                    defaults={"overlay": self.overlay_name, "role": "author"},
-                )
-                # Keep the overlay tag in sync even if the placeholder
-                # ticket pre-dates the current wiring (e.g. the legacy
-                # ``"teatree"`` row left over before #1267 / migration 0027).
-                if ticket.overlay != self.overlay_name:
-                    ticket.overlay = self.overlay_name
-                    ticket.save(update_fields=["overlay"])
-                session = session_model.objects.create(
-                    overlay=self.overlay_name,
-                    ticket=ticket,
-                    agent_id=f"scanning-news-{self.overlay_name}",
-                )
-                return task_model.objects.create(
-                    ticket=ticket,
-                    session=session,
-                    phase=SCANNING_NEWS_PHASE,
-                    execution_target=task_model.ExecutionTarget.HEADLESS,
-                    subject=f"Scan AI news: {self.overlay_name}",
-                    execution_reason=self._execution_reason(trigger),
-                )
-        except Exception:
-            logger.exception("ScanningNewsScanner: failed to queue scanning-news task")
-            return None
 
     def _execution_reason(self, trigger: str) -> str:
         """Build the dispatcher directive, embedding the ask-gate contract (#1391).
@@ -215,31 +127,6 @@ class ScanningNewsScanner:
                 f"PendingArticleSuggestion and surface the batch for explicit user approval (#1391)"
             )
         return f"{base}\n{render_source_directive(NEWS_SOURCES)}"
-
-    def _placeholder_issue_url(self) -> str:
-        """Stable synthetic URL for the overlay-anchored placeholder ticket."""
-        return f"scanning-news://{self.overlay_name}"
-
-
-def _ticket_model() -> "type[_Ticket] | None":
-    try:
-        return cast("type[_Ticket]", apps.get_model("core", "Ticket"))
-    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
-        return None
-
-
-def _task_model() -> "type[_Task] | None":
-    try:
-        return cast("type[_Task]", apps.get_model("core", "Task"))
-    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
-        return None
-
-
-def _session_model() -> "type[_Session] | None":
-    try:
-        return cast("type[_Session]", apps.get_model("core", "Session"))
-    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
-        return None
 
 
 __all__ = [

--- a/src/teatree/loop/scanners/triage_assessor.py
+++ b/src/teatree/loop/scanners/triage_assessor.py
@@ -18,42 +18,35 @@ Two hard invariants (mirroring the disposition scanner's conservative doctrine):
     that RETURNS a typed ``triage_recommendations`` envelope; the recorder persists
     one PENDING ask-gate row per issue plus one ``DeferredQuestion`` DMing the user.
 
-The dedup contract is the ``scanning_news`` shape: a pending/claimed
-``triage_assessing`` task is the lock, and the most-recent task's
-``Session.started_at`` is the "last run" timestamp (no new model fields). The
-whole scanner is gated default-OFF one layer up
+The dedup / last-run / bootstrap-cadence machinery is shared with the other
+periodic task-queuing scanners via
+:class:`teatree.loop.scanners.phase_cadence.PhaseCadence`; the survivors filter (a
+genuine variant — no other scanner reads the forge) stays local. The whole
+scanner is gated default-OFF one layer up
 (:func:`teatree.loop.scanner_factories._triage_assessor_scanner_for`): with
 ``triage_assessor_enabled = false`` no scanner is built, so this never runs.
 """
 
-import datetime as dt
 import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
 from django.apps import apps
-from django.db import transaction
-from django.db.models import Max
 from django.utils import timezone
 
 from teatree.core.backend_protocols import CodeHostBackend
-from teatree.loop.scanners.base import ScanSignal, hours_since
+from teatree.loop.scanners.base import ScanSignal
 from teatree.loop.scanners.needs_triage_query import _issue_labels, _issue_title, _issue_url, needs_triage_issues
+from teatree.loop.scanners.phase_cadence import PhaseCadence
 from teatree.types import RawAPIDict
 
 if TYPE_CHECKING:
     from teatree.core.models import PendingTriageRecommendation as _PendingTriageRecommendation
-    from teatree.core.models import Session as _Session
-    from teatree.core.models import Task as _Task
-    from teatree.core.models import Ticket as _Ticket
 
 logger = logging.getLogger(__name__)
 
 #: Canonical phase token written to ``Task.phase`` for triage-assessment tasks.
 TRIAGE_ASSESSOR_PHASE = "triage_assessing"
-
-#: States that mean an assessor task is still in-flight (cannot queue a dupe).
-_IN_FLIGHT_TASK_STATES: frozenset[str] = frozenset({"pending", "claimed"})
 
 
 @dataclass(slots=True)
@@ -80,11 +73,11 @@ class TriageAssessorScanner:
         assignees = self._resolve_identities()
         if not assignees:
             return []
-        if self._in_flight_task_exists():
+        cadence = PhaseCadence(self.overlay_name, phase=TRIAGE_ASSESSOR_PHASE, cadence_hours=self.cadence_hours)
+        if cadence.in_flight_exists():
             return []
 
-        now = timezone.now()
-        trigger = self._evaluate_trigger(now=now, last_run_at=self._last_run_at())
+        trigger = cadence.evaluate_trigger(now=timezone.now(), last_run_at=cadence.last_run_at())
         if trigger is None:
             return []
 
@@ -92,7 +85,13 @@ class TriageAssessorScanner:
         if not survivors:
             return []
 
-        task = self._queue_task(survivors=survivors, trigger=trigger)
+        task = cadence.queue_task(
+            placeholder_issue_url=f"triage-assessor://{self.overlay_name}",
+            agent_id=f"triage-assessor-{self.overlay_name}",
+            execution_reason=self._execution_reason(survivors=survivors, trigger=trigger),
+            subject=f"Triage assessment: {self.overlay_name}",
+            log_label="TriageAssessorScanner",
+        )
         if task is None:
             return []
         return [
@@ -139,74 +138,6 @@ class TriageAssessorScanner:
                 break
         return survivors
 
-    def _in_flight_task_exists(self) -> bool:
-        """True iff a pending/claimed triage-assessing task already exists."""
-        task_model = _task_model()
-        if task_model is None:
-            return False
-        return task_model.objects.filter(
-            ticket__overlay=self.overlay_name,
-            phase=TRIAGE_ASSESSOR_PHASE,
-            status__in=_IN_FLIGHT_TASK_STATES,
-        ).exists()
-
-    def _last_run_at(self) -> dt.datetime | None:
-        """The most recent task's ``Session.started_at``, or ``None`` (bootstrap)."""
-        task_model = _task_model()
-        if task_model is None:
-            return None
-        aggregate = task_model.objects.filter(
-            ticket__overlay=self.overlay_name,
-            phase=TRIAGE_ASSESSOR_PHASE,
-        ).aggregate(ts=Max("session__started_at"))
-        return aggregate["ts"]
-
-    def _evaluate_trigger(self, *, now: dt.datetime, last_run_at: dt.datetime | None) -> str | None:
-        """Return the trigger name (``bootstrap`` / ``cadence``) or ``None``."""
-        if last_run_at is None:
-            return "bootstrap"
-        if hours_since(last_run_at, now=now) >= self.cadence_hours:
-            return "cadence"
-        return None
-
-    def _queue_task(self, *, survivors: list[RawAPIDict], trigger: str) -> "_Task | None":
-        """Create a Task + Session row anchored at the overlay placeholder ticket.
-
-        Wrapped in ``transaction.atomic()`` so a concurrent scanner on a second
-        loop process can't double-queue. A DB error is logged but never raised —
-        losing one tick's assessment queue is acceptable; crashing the tick is not.
-        """
-        ticket_model = _ticket_model()
-        task_model = _task_model()
-        session_model = _session_model()
-        if ticket_model is None or task_model is None or session_model is None:
-            return None
-        try:
-            with transaction.atomic():
-                ticket, _created = ticket_model.objects.get_or_create(
-                    issue_url=self._placeholder_issue_url(),
-                    defaults={"overlay": self.overlay_name, "role": "author"},
-                )
-                if ticket.overlay != self.overlay_name:
-                    ticket.overlay = self.overlay_name
-                    ticket.save(update_fields=["overlay"])
-                session = session_model.objects.create(
-                    overlay=self.overlay_name,
-                    ticket=ticket,
-                    agent_id=f"triage-assessor-{self.overlay_name}",
-                )
-                return task_model.objects.create(
-                    ticket=ticket,
-                    session=session,
-                    phase=TRIAGE_ASSESSOR_PHASE,
-                    execution_target=task_model.ExecutionTarget.HEADLESS,
-                    subject=f"Triage assessment: {self.overlay_name}",
-                    execution_reason=self._execution_reason(survivors=survivors, trigger=trigger),
-                )
-        except Exception:
-            logger.exception("TriageAssessorScanner: failed to queue triage-assessing task")
-            return None
-
     @staticmethod
     def _execution_reason(*, survivors: list[RawAPIDict], trigger: str) -> str:
         """Build the dispatcher directive: the ASK-GATE marker + the serialized issue list.
@@ -227,31 +158,6 @@ class TriageAssessorScanner:
             f"The recorder persists each as a PendingTriageRecommendation for user approval; "
             f"nothing is closed/commented without per-item approval.\nISSUES:\n{lines}"
         )
-
-    def _placeholder_issue_url(self) -> str:
-        """Stable synthetic URL for the overlay-anchored placeholder ticket."""
-        return f"triage-assessor://{self.overlay_name}"
-
-
-def _ticket_model() -> "type[_Ticket] | None":
-    try:
-        return cast("type[_Ticket]", apps.get_model("core", "Ticket"))
-    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
-        return None
-
-
-def _task_model() -> "type[_Task] | None":
-    try:
-        return cast("type[_Task]", apps.get_model("core", "Task"))
-    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
-        return None
-
-
-def _session_model() -> "type[_Session] | None":
-    try:
-        return cast("type[_Session]", apps.get_model("core", "Session"))
-    except Exception:  # noqa: BLE001 — a probe failure must never break the tick; degrade to no signal
-        return None
 
 
 def _recommendation_model() -> "type[_PendingTriageRecommendation] | None":

--- a/tach.toml
+++ b/tach.toml
@@ -243,6 +243,11 @@ layer = "domain"
 depends_on = []
 
 [[modules]]
+path = "teatree.core.managers_phase_cadence"
+layer = "domain"
+depends_on = []
+
+[[modules]]
 path = "teatree.core.managers"
 layer = "domain"
 depends_on = [
@@ -253,6 +258,7 @@ depends_on = [
   "teatree.core.loop_lease_manager",
   "teatree.core.managers_issue_match",
   "teatree.core.managers_overlay",
+  "teatree.core.managers_phase_cadence",
   "teatree.core.managers_task_claim",
   "teatree.core.repair_loop",
   "teatree.core.session_handover_manager"

--- a/tests/quality/test_no_flat_core_regrowth.py
+++ b/tests/quality/test_no_flat_core_regrowth.py
@@ -113,7 +113,11 @@ _CORE_DIR = Path(__file__).resolve().parents[2] / "src" / "teatree" / "core"
 # UNKNOWN) that unified the three hand-rolled `gh pr list` / `glab mr list` probes. A genuine shared
 # root leaf bridging two gates/ modules (orphan_guard, open_pr_teardown_gate) and the flat root
 # fast_push.py: gates/ is gate/deny logic, not a forge-transport probe, and no other subpackage owns it.
-PINNED_FLAT_CORE_MODULES = 100
+# 101: +managers_phase_cadence.py — the periodic-scanner dedupe/last-run Task queryset helpers
+# (in_flight_for_phase + last_run_at_for_phase) carved out of managers.py to hold it under the 500-LOC
+# module-health cap. A pure queryset-builder leaf helper of the flat root managers.py hub, mirroring
+# managers_overlay.py / managers_issue_match.py / managers_task_claim.py. Owned by no existing subpackage.
+PINNED_FLAT_CORE_MODULES = 101
 
 
 def _flat_core_modules() -> list[str]:

--- a/tests/teatree_core/test_managers.py
+++ b/tests/teatree_core/test_managers.py
@@ -4,6 +4,7 @@ import pytest
 from django.test import TestCase
 from django.utils import timezone
 
+from teatree.core.managers_phase_cadence import in_flight_for_phase, last_run_at_for_phase
 from teatree.core.models import IncomingEvent, ReplyDispatch, Session, Task, Ticket, Worktree
 
 
@@ -224,6 +225,75 @@ class TestTaskQuerySet(TestCase):
         assert claimed is not None
         assert claimed.claimed_by == "loop-slot"
         assert claimed.claimed_by_session == "sess-A"
+
+
+class TestTaskPhaseCadenceQueries(TestCase):
+    """The periodic-scanner dedupe/last-run queries shared via ``PhaseCadence``."""
+
+    OVERLAY = "t3-teatree"
+    PHASE = "eval_local"
+
+    def _task(self, *, overlay: str, phase: str, status: str, started_hours_ago: int | None = None) -> Task:
+        ticket = Ticket.objects.create(overlay=overlay)
+        session = Session.objects.create(overlay=overlay, ticket=ticket, agent_id="a")
+        if started_hours_ago is not None:
+            Session.objects.filter(pk=session.pk).update(started_at=timezone.now() - timedelta(hours=started_hours_ago))
+        return Task.objects.create(ticket=ticket, session=session, phase=phase, status=status)
+
+    def test_in_flight_for_phase_matches_pending_and_claimed_only(self) -> None:
+        pending = self._task(overlay=self.OVERLAY, phase=self.PHASE, status=Task.Status.PENDING)
+        claimed = self._task(overlay=self.OVERLAY, phase=self.PHASE, status=Task.Status.CLAIMED)
+        self._task(overlay=self.OVERLAY, phase=self.PHASE, status=Task.Status.COMPLETED)
+        self._task(overlay=self.OVERLAY, phase=self.PHASE, status=Task.Status.FAILED)
+
+        in_flight = set(Task.objects.in_flight_for_phase(self.OVERLAY, self.PHASE))
+
+        assert in_flight == {pending, claimed}
+
+    def test_in_flight_for_phase_scopes_to_overlay_and_phase(self) -> None:
+        target = self._task(overlay=self.OVERLAY, phase=self.PHASE, status=Task.Status.PENDING)
+        self._task(overlay="other-overlay", phase=self.PHASE, status=Task.Status.PENDING)
+        self._task(overlay=self.OVERLAY, phase="scanning_news", status=Task.Status.PENDING)
+
+        assert list(Task.objects.in_flight_for_phase(self.OVERLAY, self.PHASE)) == [target]
+
+    def test_last_run_at_for_phase_returns_newest_session_start(self) -> None:
+        self._task(overlay=self.OVERLAY, phase=self.PHASE, status=Task.Status.COMPLETED, started_hours_ago=48)
+        self._task(overlay=self.OVERLAY, phase=self.PHASE, status=Task.Status.PENDING, started_hours_ago=2)
+
+        last_run = Task.objects.last_run_at_for_phase(self.OVERLAY, self.PHASE)
+
+        assert last_run is not None
+        # The newest task started ~2h ago, so the clock reads ~2h, not 48h.
+        assert (timezone.now() - last_run) < timedelta(hours=3)
+
+    def test_last_run_at_for_phase_none_when_no_task(self) -> None:
+        assert Task.objects.last_run_at_for_phase(self.OVERLAY, self.PHASE) is None
+
+    def test_manager_methods_delegate_to_module_helpers(self) -> None:
+        pending = self._task(overlay=self.OVERLAY, phase=self.PHASE, status=Task.Status.PENDING, started_hours_ago=3)
+
+        # The module-level helpers are the concern-split home the manager methods delegate to.
+        assert list(in_flight_for_phase(Task.objects.all(), self.OVERLAY, self.PHASE)) == [pending]
+        direct = last_run_at_for_phase(Task.objects.all(), self.OVERLAY, self.PHASE)
+        via_manager = Task.objects.last_run_at_for_phase(self.OVERLAY, self.PHASE)
+        assert direct == via_manager
+
+    def test_last_run_at_for_phase_completed_only_ignores_failed(self) -> None:
+        completed = self._task(
+            overlay=self.OVERLAY, phase=self.PHASE, status=Task.Status.COMPLETED, started_hours_ago=200
+        )
+        # A newer FAILED task must NOT advance the completed-only clock.
+        self._task(overlay=self.OVERLAY, phase=self.PHASE, status=Task.Status.FAILED, started_hours_ago=1)
+
+        completed_run = Task.objects.last_run_at_for_phase(self.OVERLAY, self.PHASE, completed_only=True)
+        any_run = Task.objects.last_run_at_for_phase(self.OVERLAY, self.PHASE)
+
+        assert completed_run is not None
+        assert (timezone.now() - completed_run) > timedelta(hours=100)  # the old COMPLETED one
+        assert completed_run == Session.objects.get(pk=completed.session_id).started_at
+        assert any_run is not None
+        assert (timezone.now() - any_run) < timedelta(hours=2)  # the recent FAILED one wins without the filter
 
 
 class TestActiveClaimExists(TestCase):

--- a/tests/teatree_loop/scanners/test_phase_cadence.py
+++ b/tests/teatree_loop/scanners/test_phase_cadence.py
@@ -1,0 +1,122 @@
+"""DB-backed tests for the shared ``PhaseCadence`` cadence-scanner helper.
+
+``PhaseCadence`` owns the dedupe / last-run / bootstrap-cadence / queue-task
+machinery the periodic task-queuing scanners (``eval_local``, ``scanning_news``,
+``architectural_review``, ``backlog_sweep``, ``triage_assessor``,
+``provision_smoke``) share. Each scanner's end-to-end behaviour is pinned in its
+own ``tests/teatree_loop/test_*_scanner.py``; this file pins the seam directly,
+including the model-not-migrated degradation branches.
+"""
+
+import datetime as dt
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from teatree.core.models.session import Session
+from teatree.core.models.task import Task
+from teatree.core.models.ticket import Ticket
+from teatree.loop.scanners.phase_cadence import PhaseCadence
+
+OVERLAY = "t3-teatree"
+PHASE = "eval_local"
+
+
+def _cadence(*, overlay: str = OVERLAY, phase: str = PHASE, cadence_hours: int = 168) -> PhaseCadence:
+    return PhaseCadence(overlay, phase, cadence_hours)
+
+
+class InFlightExistsTests(TestCase):
+    def test_true_when_pending_task_present(self) -> None:
+        ticket = Ticket.objects.create(overlay=OVERLAY)
+        session = Session.objects.create(overlay=OVERLAY, ticket=ticket, agent_id="a")
+        Task.objects.create(ticket=ticket, session=session, phase=PHASE, status=Task.Status.PENDING)
+
+        assert _cadence().in_flight_exists() is True
+
+    def test_false_when_only_terminal_tasks(self) -> None:
+        ticket = Ticket.objects.create(overlay=OVERLAY)
+        session = Session.objects.create(overlay=OVERLAY, ticket=ticket, agent_id="a")
+        Task.objects.create(ticket=ticket, session=session, phase=PHASE, status=Task.Status.COMPLETED)
+
+        assert _cadence().in_flight_exists() is False
+
+    def test_false_when_task_model_missing(self) -> None:
+        with patch("teatree.loop.scanners.phase_cadence._task_model", return_value=None):
+            assert _cadence().in_flight_exists() is False
+
+
+class LastRunAtTests(TestCase):
+    def test_none_when_no_task(self) -> None:
+        assert _cadence().last_run_at() is None
+
+    def test_none_when_task_model_missing(self) -> None:
+        with patch("teatree.loop.scanners.phase_cadence._task_model", return_value=None):
+            assert _cadence().last_run_at() is None
+
+    def test_completed_only_ignores_a_newer_failed_task(self) -> None:
+        ticket = Ticket.objects.create(overlay=OVERLAY)
+        completed_session = Session.objects.create(overlay=OVERLAY, ticket=ticket, agent_id="a")
+        Session.objects.filter(pk=completed_session.pk).update(started_at=timezone.now() - timedelta(hours=200))
+        Task.objects.create(ticket=ticket, session=completed_session, phase=PHASE, status=Task.Status.COMPLETED)
+        failed_session = Session.objects.create(overlay=OVERLAY, ticket=ticket, agent_id="a")
+        Task.objects.create(ticket=ticket, session=failed_session, phase=PHASE, status=Task.Status.FAILED)
+
+        completed_run = _cadence().last_run_at(completed_only=True)
+
+        assert completed_run is not None
+        assert (timezone.now() - completed_run) > timedelta(hours=100)
+
+
+class EvaluateTriggerTests(TestCase):
+    NOW = dt.datetime(2026, 6, 16, 12, 0, tzinfo=dt.UTC)
+
+    def test_bootstrap_when_never_run(self) -> None:
+        assert _cadence().evaluate_trigger(now=self.NOW, last_run_at=None) == "bootstrap"
+
+    def test_cadence_when_elapsed(self) -> None:
+        last = self.NOW - timedelta(hours=169)
+        assert _cadence(cadence_hours=168).evaluate_trigger(now=self.NOW, last_run_at=last) == "cadence"
+
+    def test_none_when_within_window(self) -> None:
+        last = self.NOW - timedelta(hours=24)
+        assert _cadence(cadence_hours=168).evaluate_trigger(now=self.NOW, last_run_at=last) is None
+
+
+class QueueTaskTests(TestCase):
+    def _queue(self) -> Task | None:
+        return _cadence().queue_task(
+            placeholder_issue_url=f"eval-local://{OVERLAY}",
+            agent_id=f"eval-local-{OVERLAY}",
+            execution_reason="reason",
+            log_label="Test",
+        )
+
+    def test_creates_task_anchored_at_placeholder_ticket(self) -> None:
+        task = self._queue()
+
+        assert task is not None
+        assert task.phase == PHASE
+        assert task.status == Task.Status.PENDING
+        assert task.execution_target == Task.ExecutionTarget.HEADLESS
+        assert task.ticket.overlay == OVERLAY
+        assert task.ticket.issue_url == f"eval-local://{OVERLAY}"
+
+    def test_reanchors_placeholder_ticket_to_target_overlay(self) -> None:
+        Ticket.objects.create(issue_url=f"eval-local://{OVERLAY}", overlay="stale-overlay", role="author")
+
+        task = self._queue()
+
+        assert task is not None
+        assert Ticket.objects.get(issue_url=f"eval-local://{OVERLAY}").overlay == OVERLAY
+
+    def test_returns_none_when_a_model_is_missing(self) -> None:
+        with patch("teatree.loop.scanners.phase_cadence._ticket_model", return_value=None):
+            assert self._queue() is None
+
+    def test_swallows_write_errors_and_returns_none(self) -> None:
+        with patch.object(Task.objects, "create", side_effect=RuntimeError("db down")):
+            assert self._queue() is None
+        assert not Task.objects.filter(phase=PHASE).exists()

--- a/tests/teatree_loop/test_provision_smoke_scanner.py
+++ b/tests/teatree_loop/test_provision_smoke_scanner.py
@@ -177,23 +177,27 @@ class ScannerProtocolTests(TestCase):
 
 
 class DefensiveModelLookupTests(TestCase):
-    """Cover the model-lookup helpers when Django returns no app (#1308)."""
+    """Cover the shared PhaseCadence model-lookup helpers when Django returns no app (#1308).
+
+    The dedupe / last-run / queue-task machinery now lives on
+    :class:`teatree.loop.scanners.phase_cadence.PhaseCadence`; these tests pin
+    the provision-smoke scanner's behaviour through that seam.
+    """
 
     def test_queue_task_returns_none_when_ticket_model_is_missing(self) -> None:
-        with patch("teatree.loop.scanners.provision_smoke._ticket_model", return_value=None):
+        with patch("teatree.loop.scanners.phase_cadence._ticket_model", return_value=None):
             assert _scanner().scan() == []
 
     def test_queue_task_returns_none_when_session_model_is_missing(self) -> None:
-        with patch("teatree.loop.scanners.provision_smoke._session_model", return_value=None):
+        with patch("teatree.loop.scanners.phase_cadence._session_model", return_value=None):
             assert _scanner().scan() == []
 
-    def test_in_flight_check_returns_false_when_task_model_is_missing(self) -> None:
+    def test_short_circuits_cleanly_when_task_model_is_missing(self) -> None:
         scanner = _scanner()
-        with patch("teatree.loop.scanners.provision_smoke._task_model", return_value=None):
-            assert scanner._in_flight_task_exists() is False
-            assert scanner._last_run_at() is None
+        with patch("teatree.loop.scanners.phase_cadence._task_model", return_value=None):
             # The scanner short-circuits cleanly: no signal, no task queued.
             assert scanner.scan() == []
+        assert _last_smoke_task() is None
 
     def test_queue_task_swallows_exceptions_and_returns_none(self) -> None:
         """If creating the task row raises, the scanner emits no signal."""
@@ -204,10 +208,14 @@ class DefensiveModelLookupTests(TestCase):
         # Nothing was committed by the failing transaction.
         assert _last_smoke_task() is None
 
-    def test_ticket_model_returns_none_on_lookup_error(self) -> None:
+    def test_model_probes_return_none_on_lookup_error(self) -> None:
         from django.apps import apps as django_apps  # noqa: PLC0415
 
-        from teatree.loop.scanners.provision_smoke import _session_model, _task_model, _ticket_model  # noqa: PLC0415
+        from teatree.loop.scanners.phase_cadence import (  # noqa: PLC0415 — test-local
+            _session_model,
+            _task_model,
+            _ticket_model,
+        )
 
         with patch.object(django_apps, "get_model", side_effect=LookupError):
             assert _ticket_model() is None


### PR DESCRIPTION
refactor(loop): CadenceScannerBase for periodic task-queuing scanners

## What

- New `PhaseCadence` composition helper (`src/teatree/loop/scanners/phase_cadence.py`)
  that owns the machinery every periodic task-queuing scanner duplicated:
  in-flight-task dedupe, last-run lookup, bootstrap/cadence trigger evaluation,
  and the placeholder-ticket task-queue write.
- The in-flight / last-run Task queries now live on the Task manager
  (`TaskQuerySet.in_flight_for_phase` / `last_run_at_for_phase`, delegating to a
  `managers_phase_cadence` concern module in the same style as `managers_overlay`).
- The duplicated `_IN_FLIGHT_TASK_STATES = frozenset({"pending","claimed"})`
  constant is gone from every scanner — `Task.Status.active()` is the single source.
- Adopted on all six scanners: `eval_local`, `scanning_news`,
  `architectural_review`, `backlog_sweep`, `triage_assessor`, `provision_smoke`.
- New tests: `tests/teatree_loop/scanners/test_phase_cadence.py` for the helper,
  and manager-method tests in `tests/teatree_core/test_managers.py`.

## Why

- Six scanners carried byte-identical `_in_flight_task_exists`, `_last_run_at`,
  `_evaluate_trigger`, `_queue_task`, three model-probe module functions, and the
  in-flight-states constant — the same cadence machinery copy-pasted per phase.
- Managers, not inline `objects.filter`, are Django's home for QuerySet logic; the
  dedupe/last-run predicates now have one audited definition.
- Net ~230 fewer lines; each scanner keeps only its signal payload and directive.

## Scanners adopted vs. variants kept

- All six adopt `PhaseCadence` for dedupe / last-run / trigger / queue-write.
- Genuine variants stay local to their scanner (not forced into the base):
  - `architectural_review`: merge-count trigger backstop + completed-only last-run
    clock (a FAILED review must not suppress the next dispatch), via `completed_only`.
  - `triage_assessor`: forge-backed survivors filter and per-issue directive.
  - `provision_smoke`: keeps its `build_provision_smoke_scanner` wiring factory.

## Notes

- Fault isolation unchanged: model probes degrade to an empty result before the
  core tables are migrated, and the queue write stays `transaction.atomic` with a
  logged-not-raised failure, so `domain_jobs._run_job` per-scanner isolation holds.
