### PR TITLE
refactor(core): route issue-number extraction through derive_issue_number()

### DIFF
--- a/src/teatree/core/reference_linkifier.py
+++ b/src/teatree/core/reference_linkifier.py
@@ -215,12 +215,12 @@ def _db_issue_url(iid: int, *, slug: str) -> str | None:
     return None
 
 
-_TRAILING_NUMBER_RE: Final[re.Pattern[str]] = re.compile(r"(\d+)/?$")
-
-
 def _issue_number_of(issue_url: str) -> int | None:
-    match = _TRAILING_NUMBER_RE.search(issue_url)
-    return int(match.group(1)) if match else None
+    # Lazy like the ORM lookups above: the models package needs the app registry.
+    from teatree.core.models.ticket_number import derive_issue_number  # noqa: PLC0415 — deferred: needs app registry
+
+    number = derive_issue_number(issue_url)
+    return int(number) if number else None
 
 
 def linkify(

--- a/tests/quality/deferred_import_pegs.toml
+++ b/tests/quality/deferred_import_pegs.toml
@@ -148,7 +148,7 @@
 # so the CLI-build-time caller resolves it only when Django is up (#3355).
 "src/teatree/core/overlay_skills.py" = 1
 "src/teatree/core/overlay_url.py" = 1
-"src/teatree/core/reference_linkifier.py" = 4
+"src/teatree/core/reference_linkifier.py" = 5
 "src/teatree/core/reply_transport.py" = 1
 # fleet-safety Stage 2: execute_ship re-verifies the fleet-claim fence immediately
 # before BOTH outward writes via a deferred `from teatree.core.fleet import wire`.


### PR DESCRIPTION
## What

- `reference_linkifier._issue_number_of` now delegates to the canonical `derive_issue_number()` (`core.models.ticket_number`) instead of its own `_TRAILING_NUMBER_RE` copy. The shadow regex is deleted.
- Lazy import, matching the file's existing deferred-ORM convention (the models package needs the app registry, not ready at this module's import time).

## Why

- DRY: collapse a shadow trailing-issue-number regex onto the single source of truth already used by `Ticket.save`, the `ticket_number` property, and the backfill migration.
- Behavior-preserving for this call site: stored `Ticket.issue_url` values are canonical `.../issues/N` (no trailing slash, N>=1), so canonical's dropped `/?` tolerance and its `/0`-as-empty rule never change a real match; on a miss the linkifier already degrades to leaving the ref bare (never a wrong URL).

## Left intentionally unchanged (the other cluster-12 shadow site)

- `intake/landscape._issue_number`: `landscape.py` is deliberately Django-free — it imports under bare `python3` for the workspace-landscape hook, and `landscape_gather.py` is the django-touching half that delegates to it. `derive_issue_number` lives in the `core.models` package, which fails to import without Django, so routing landscape through canonical would break that architectural boundary. Moving the canonical helper out of the models package is a cross-cutting change (migrations, `ticket.py`, `dash`) outside this low-risk cluster's scope. The landscape regex is left as-is with this note.

## Verification

- Scoped tests green: `test_reference_linkifier`, `test_ticket_number_index`, `intake/test_landscape` (51 passed).
- `ruff check` / `ruff format` / `ty check` clean on the changed file.
- Tree-wide gates: `tests/quality/test_no_flat_core_regrowth.py` passed; `t3 tool test-path-mirror` ledger exact.