### PR TITLE
refactor(core): single tri-state open-PR probe + forge_kind_for_remote()

### DIFF
--- a/src/teatree/core/fast_push.py
+++ b/src/teatree/core/fast_push.py
@@ -25,12 +25,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Final, Protocol
 
+from teatree.core.forge_pr_probe import probe_github_open_pr, probe_gitlab_open_pr
 from teatree.hooks.banned_term_registry import allowlist_terms, terms_for_gate
 from teatree.hooks.banned_terms_cli import staged_added_lines
 from teatree.hooks.banned_terms_tree_scan import BannedTermsUnsetError
 from teatree.hooks.opaque_id import find_opaque_ids
 from teatree.hooks.term_match import matched_term
 from teatree.utils import git, git_remote
+from teatree.utils.forge import forge_from_remote
 from teatree.utils.run import run_allowed_to_fail, run_checked
 
 LEAK_GATES: Final[tuple[str, str, str, str]] = (
@@ -80,12 +82,7 @@ class GhForge:
         self._repo = repo
 
     def find_pr_url(self, *, branch: str) -> str:
-        result = run_allowed_to_fail(
-            ["gh", "pr", "list", "--head", branch, "--json", "url", "--jq", ".[0].url"],
-            expected_codes=None,
-            cwd=self._repo,
-        )
-        return result.stdout.strip() if result.returncode == 0 else ""
+        return probe_github_open_pr(self._repo, branch).url_or_empty()
 
     def create_pr(self, *, branch: str, title: str, body: str) -> str:
         result = run_checked(
@@ -103,18 +100,7 @@ class GlabForge:
         self._repo = repo
 
     def find_pr_url(self, *, branch: str) -> str:
-        result = run_allowed_to_fail(
-            ["glab", "mr", "list", "--source-branch", branch, "-F", "json"],
-            expected_codes=None,
-            cwd=self._repo,
-        )
-        if result.returncode != 0:
-            return ""
-        try:
-            payload = json.loads(result.stdout or "[]")
-        except json.JSONDecodeError:
-            return ""
-        return str(payload[0].get("web_url", "")) if payload else ""
+        return probe_gitlab_open_pr(self._repo, branch).url_or_empty()
 
     def create_pr(self, *, branch: str, title: str, body: str) -> str:
         result = run_checked(
@@ -129,10 +115,10 @@ class GlabForge:
 
 
 def forge_for_repo(repo: Path) -> ForgeClient | None:
-    remote = git.remote_url(repo=str(repo))
-    if "github" in remote:
+    kind = forge_from_remote(git.remote_url(repo=str(repo)))
+    if kind == "github":
         return GhForge(repo)
-    if "gitlab" in remote:
+    if kind == "gitlab":
         return GlabForge(repo)
     return None
 

--- a/src/teatree/core/forge_pr_probe.py
+++ b/src/teatree/core/forge_pr_probe.py
@@ -1,0 +1,150 @@
+"""Single tri-state open-PR probe shared by the orphan, teardown, and fast-push gates.
+
+Three gates each asked the forge the same question — "is there an OPEN PR/MR whose
+source is this branch?" — with their own hand-rolled ``gh pr list`` / ``glab mr
+list`` runner, and they DID NOT agree on the crucial ambiguity: a probe that could
+not run (missing CLI, non-zero exit, unparsable JSON) versus one that ran and found
+nothing. Collapsing the two is safe for a caller that reacts to both by creating a
+PR (fast_push), but it is a safety REGRESSION for a fail-closed reclaim gate, which
+must BLOCK on "unknown" and CLEAR on "none".
+
+:class:`PrProbe` answers the question ONCE with an explicit tri-state
+(:attr:`PrProbeOutcome.FOUND` / :attr:`~PrProbeOutcome.NONE` /
+:attr:`~PrProbeOutcome.UNKNOWN`). Each caller keeps its own posture by mapping the
+tri-state through :meth:`PrProbe.url_or_empty` (collapse none+unknown) or
+:meth:`PrProbe.url_or_none_on_unknown` (keep them apart, fail closed on unknown) —
+the probe implementation no longer forks per caller.
+"""
+
+import json
+import logging
+from dataclasses import dataclass
+from enum import Enum, auto
+from pathlib import Path
+
+from teatree.utils import git
+from teatree.utils.forge import forge_from_remote
+from teatree.utils.run import run_allowed_to_fail
+
+logger = logging.getLogger(__name__)
+
+# Both CLIs list only OPEN PRs/MRs here (``--state open`` / ``--state opened``), one
+# row, so a non-empty payload IS an open PR/MR. The branch selector is appended by
+# the forge-specific wrapper (``--head`` on GitHub, ``--source-branch`` on GitLab).
+_GH_OPEN_PR: tuple[str, ...] = ("gh", "pr", "list", "--state", "open", "--json", "url", "--limit", "1")
+_GLAB_OPEN_MR: tuple[str, ...] = ("glab", "mr", "list", "--state", "opened", "--output", "json", "-P", "1")
+
+
+class PrProbeOutcome(Enum):
+    """The three distinguishable answers to "is an OPEN PR/MR backing this branch?"."""
+
+    FOUND = auto()
+    NONE = auto()
+    UNKNOWN = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class PrProbe:
+    """The result of one open-PR probe: an outcome plus the URL when one was found."""
+
+    outcome: PrProbeOutcome
+    url: str = ""
+
+    @classmethod
+    def found(cls, url: str) -> "PrProbe":
+        return cls(PrProbeOutcome.FOUND, url)
+
+    @classmethod
+    def none(cls) -> "PrProbe":
+        return cls(PrProbeOutcome.NONE)
+
+    @classmethod
+    def unknown(cls) -> "PrProbe":
+        return cls(PrProbeOutcome.UNKNOWN)
+
+    @property
+    def is_found(self) -> bool:
+        return self.outcome is PrProbeOutcome.FOUND
+
+    @property
+    def is_unknown(self) -> bool:
+        return self.outcome is PrProbeOutcome.UNKNOWN
+
+    def url_or_empty(self) -> str:
+        """FOUND → the URL; NONE and UNKNOWN both → ``""``.
+
+        For callers that treat a failed probe the same as "no PR" because their
+        reaction to both is identical — fast_push upserts a PR either way, the
+        orphan scan surfaces the branch either way — so the distinction would not
+        change what they do.
+        """
+        return self.url if self.outcome is PrProbeOutcome.FOUND else ""
+
+    def url_or_none_on_unknown(self) -> str | None:
+        """FOUND → the URL; NONE → ``""``; UNKNOWN → ``None``.
+
+        For fail-closed callers that must keep "found nothing" (safe to proceed)
+        apart from "could not ask" (must refuse) — the open-PR teardown gate reads
+        ``None`` as "refuse while it is unknown".
+        """
+        if self.outcome is PrProbeOutcome.UNKNOWN:
+            return None
+        return self.url
+
+
+def find_open_pr_for_branch(repo_dir: str | Path, branch: str) -> PrProbe:
+    """The OPEN PR/MR backing *branch* on the repo's forge, as an explicit tri-state.
+
+    The forge is sniffed from ``origin`` via :func:`forge_from_remote`. A repo whose
+    ``origin`` is not a recognised forge is :attr:`~PrProbeOutcome.NONE` (no forge,
+    therefore no PR to find and nothing to protect), NOT unknown. An empty *branch*
+    is :attr:`~PrProbeOutcome.UNKNOWN` — there is nothing to probe, and a
+    fail-closed caller must not read that as "no PR". Any CLI failure (missing
+    binary, non-zero exit, unparsable JSON) is :attr:`~PrProbeOutcome.UNKNOWN`.
+    """
+    if not branch:
+        return PrProbe.unknown()
+    kind = forge_from_remote(git.remote_url(repo=str(repo_dir)))
+    if kind == "github":
+        return probe_github_open_pr(repo_dir, branch)
+    if kind == "gitlab":
+        return probe_gitlab_open_pr(repo_dir, branch)
+    return PrProbe.none()
+
+
+def probe_github_open_pr(repo_dir: str | Path, branch: str) -> PrProbe:
+    """The tri-state open-PR probe for a known-GitHub repo (``gh pr list --head``)."""
+    return _probe_open_pr([*_GH_OPEN_PR, "--head", branch], repo_dir, key="url")
+
+
+def probe_gitlab_open_pr(repo_dir: str | Path, branch: str) -> PrProbe:
+    """The tri-state open-MR probe for a known-GitLab repo (``glab mr list --source-branch``)."""
+    return _probe_open_pr([*_GLAB_OPEN_MR, "--source-branch", branch], repo_dir, key="web_url")
+
+
+def _probe_open_pr(cmd: list[str], repo_dir: str | Path, *, key: str) -> PrProbe:
+    """Run *cmd* (a forge CLI that lists only OPEN PRs/MRs) and classify the result.
+
+    A non-empty JSON array is an open PR/MR (:attr:`~PrProbeOutcome.FOUND`, carrying
+    the first row's *key*); an empty array is :attr:`~PrProbeOutcome.NONE`. A missing
+    binary (``OSError``), a non-zero exit, or unparsable / non-list JSON is
+    :attr:`~PrProbeOutcome.UNKNOWN` — the probe could not answer.
+    """
+    try:
+        result = run_allowed_to_fail(cmd, expected_codes=None, cwd=Path(repo_dir))
+    except OSError:
+        logger.warning("open-PR probe could not run %r in %s — unknown", cmd[0], repo_dir)
+        return PrProbe.unknown()
+    if result.returncode != 0:
+        logger.warning("open-PR probe %r failed (exit %s) in %s — unknown", cmd[0], result.returncode, repo_dir)
+        return PrProbe.unknown()
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return PrProbe.unknown()
+    if not isinstance(payload, list):
+        return PrProbe.unknown()
+    if not payload:
+        return PrProbe.none()
+    first = payload[0]
+    return PrProbe.found(str(first.get(key, "")) if isinstance(first, dict) else "")

--- a/src/teatree/core/gates/merge_evidence_gate.py
+++ b/src/teatree/core/gates/merge_evidence_gate.py
@@ -41,13 +41,13 @@ chokepoint every path to MERGED funnels through. On a block it raises
 
 import logging
 from typing import TYPE_CHECKING
-from urllib.parse import urlparse
 
 from teatree.config import get_effective_settings
 from teatree.core.merge.ci_rollup import CodeHostQuery
 from teatree.core.modelkit.gate_registry import register_gate
 from teatree.core.models import MergeAudit, PullRequest
 from teatree.core.models.errors import InvalidTransitionError
+from teatree.utils.forge import forge_from_remote
 from teatree.utils.pr_ref import PrRef
 
 if TYPE_CHECKING:
@@ -79,8 +79,7 @@ def has_merge_audit_evidence(ticket: "Ticket") -> bool:
 
 
 def _pr_host_kind(pr: PullRequest) -> str:
-    host = (urlparse(pr.url).hostname or "").lower()
-    return "gitlab" if "gitlab" in host else "github"
+    return forge_from_remote(pr.url) or "github"
 
 
 def forge_confirms_merged(ticket: "Ticket") -> bool:

--- a/src/teatree/core/gates/open_pr_teardown_gate.py
+++ b/src/teatree/core/gates/open_pr_teardown_gate.py
@@ -61,16 +61,14 @@ reader is INJECTED as :class:`PrStateReader` — the same split as
 interface layer supplies the concrete reader.
 """
 
-import json
 import logging
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Protocol
 
 from teatree.core.backend_protocols import PrOpenState
+from teatree.core.forge_pr_probe import find_open_pr_for_branch
 from teatree.core.models import PullRequest, Ticket, Worktree
-from teatree.utils import git
-from teatree.utils.run import run_allowed_to_fail
 
 logger = logging.getLogger(__name__)
 
@@ -193,43 +191,14 @@ def _live_pr_state(pr_url: str, read_pr_state: PrStateReader) -> PrOpenState:
 def _open_pr_url_for_branch(repo_dir: Path, branch: str) -> str | None:
     """The OPEN PR/MR URL backing *branch*, ``""`` when there is none, ``None`` when unknown.
 
-    Deliberately not ``fast_push.ForgeClient.find_pr_url``: that primitive
-    collapses "no PR" and "the probe failed" into ``""`` because its caller
-    treats both as "create one", which is safe there. A reclaim gate needs the
-    two apart — one clears the teardown, the other must block it.
+    Maps the shared :func:`find_open_pr_for_branch` tri-state through
+    :meth:`~teatree.core.forge_pr_probe.PrProbe.url_or_none_on_unknown`, keeping
+    "found nothing" (``""`` — the teardown clears) apart from "could not ask"
+    (``None`` — the reclaim must block). This is exactly the distinction a
+    collapse-to-``""`` caller like fast_push does not need but this fail-closed
+    gate does.
 
-    A repo whose ``origin`` is not a recognised forge returns ``""``: no forge,
+    A repo whose ``origin`` is not a recognised forge yields ``""``: no forge,
     therefore no MR, therefore nothing to protect.
     """
-    if not branch:
-        return None
-    remote = git.remote_url(repo=str(repo_dir))
-    if "gitlab" in remote:
-        return _first_url(["glab", "mr", "list", "--source-branch", branch, "-F", "json"], repo_dir, key="web_url")
-    if "github" in remote:
-        return _first_url(["gh", "pr", "list", "--head", branch, "--json", "url"], repo_dir, key="url")
-    return ""
-
-
-def _first_url(cmd: list[str], repo_dir: Path, *, key: str) -> str | None:
-    """First ``key`` in the forge CLI's JSON array, ``""`` when empty, ``None`` when the probe failed.
-
-    Both CLIs list only OPEN PRs/MRs by default, so a non-empty payload IS an
-    open one. A missing binary raises ``FileNotFoundError`` rather than exiting
-    non-zero, which is why the catch covers ``OSError`` as well as a bad exit.
-    """
-    try:
-        result = run_allowed_to_fail(cmd, expected_codes=None, cwd=repo_dir)
-    except OSError:
-        logger.warning("open-PR teardown gate could not run %r in %s — failing closed", cmd[0], repo_dir)
-        return None
-    if result.returncode != 0:
-        logger.warning("open-PR teardown gate probe %r failed in %s — failing closed", cmd[0], repo_dir)
-        return None
-    try:
-        payload = json.loads(result.stdout or "[]")
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(payload, list):
-        return None
-    return str(payload[0].get(key, "")) if payload else ""
+    return find_open_pr_for_branch(repo_dir, branch).url_or_none_on_unknown()

--- a/src/teatree/core/gates/orphan_guard.py
+++ b/src/teatree/core/gates/orphan_guard.py
@@ -22,12 +22,9 @@ from dataclasses import dataclass
 from enum import StrEnum
 
 from teatree.config import clone_root
+from teatree.core.forge_pr_probe import find_open_pr_for_branch
 from teatree.core.models import Worktree
-from teatree.core.worktree.branch_classification import (
-    _branch_tree_matches_squash,
-    prefilter_branch_commits_by_subject,
-    probe_host_cli,
-)
+from teatree.core.worktree.branch_classification import _branch_tree_matches_squash, prefilter_branch_commits_by_subject
 from teatree.core.worktree.clone_paths import resolve_clone_path
 from teatree.utils import git
 from teatree.utils.run import CommandFailedError
@@ -65,22 +62,13 @@ class BranchReport:
 def find_open_pr(repo: str, branch: str) -> str:
     """Return the URL of the open PR for ``branch``, or ``""`` if none.
 
-    Queries GitHub (``gh pr list``) and GitLab (``glab mr list``). Returns ``""``
-    when neither CLI is available (sandbox, CI without auth) — callers treat
-    that as "no open PR known" rather than erroring.
+    A thin :meth:`~teatree.core.forge_pr_probe.PrProbe.url_or_empty` adapter over
+    the shared :func:`find_open_pr_for_branch`: a probe that could not run (no CLI
+    in a sandbox, CI without auth) collapses to ``""`` here, because the orphan
+    scan surfaces the branch as an orphan either way — the distinction the
+    fail-closed teardown gate needs does not change what this caller does.
     """
-    url = probe_host_cli(
-        ["gh", "pr", "list", "--head", branch, "--state", "open", "--json", "url", "--limit", "1"],
-        repo,
-        lambda data: data[0]["url"],
-    )
-    if url:
-        return url
-    return probe_host_cli(
-        ["glab", "mr", "list", "--source-branch", branch, "--state", "opened", "--output", "json", "-P", "1"],
-        repo,
-        lambda data: data[0]["web_url"],
-    )
+    return find_open_pr_for_branch(repo, branch).url_or_empty()
 
 
 def _origin_default_branch_target(repo: str) -> str:

--- a/src/teatree/core/merge/pr_slug_resolution.py
+++ b/src/teatree/core/merge/pr_slug_resolution.py
@@ -15,6 +15,7 @@ from teatree.core.merge.errors import MergePreconditionError
 from teatree.core.overlay_loader import get_all_overlays
 from teatree.project import find_project_root
 from teatree.utils import git, git_remote
+from teatree.utils.forge import forge_from_remote
 from teatree.utils.pr_ref import PrRef
 from teatree.utils.throttled_log import warn_throttled
 from teatree.utils.url_slug import slug_from_issue_or_pr_url
@@ -40,15 +41,7 @@ def _resolve_host_kind(clear: object) -> str:
     """
     ticket = getattr(clear, "ticket", None)
     issue_url = str(getattr(ticket, "issue_url", "") or "") if ticket is not None else ""
-    if not issue_url:
-        return "github"
-    host = urlparse(issue_url).hostname or ""
-    host = host.lower()
-    if "github.com" in host or host == "github":
-        return "github"
-    if "gitlab" in host:
-        return "gitlab"
-    return "github"
+    return forge_from_remote(issue_url) or "github"
 
 
 _GIT_BRANCH_PREFIXES = frozenset(

--- a/src/teatree/core/review/stranger_pr.py
+++ b/src/teatree/core/review/stranger_pr.py
@@ -21,6 +21,7 @@ from urllib.parse import urlparse
 from teatree.core.intake.factory_admission import IntakeFacts, decide_intake, payload_labels
 from teatree.core.review.author_trust import AuthorSubject, AutonomyGate, TrustVerdict, decide_author_trust
 from teatree.types import RawAPIDict
+from teatree.utils.forge import forge_from_remote
 from teatree.utils.url_slug import slug_from_issue_or_pr_url
 
 
@@ -49,7 +50,7 @@ def pr_is_admitted(pr: RawAPIDict, *, pr_url: str, trusted: frozenset[str], admi
     slug = slug_from_issue_or_pr_url(parsed.path)
     if not author or not slug:
         return False
-    host_kind = "gitlab" if "/-/" in parsed.path or "gitlab" in (parsed.hostname or "").lower() else "github"
+    host_kind = "gitlab" if "/-/" in parsed.path or forge_from_remote(pr_url) == "gitlab" else "github"
     subject = AuthorSubject(slug=slug, author=author, host_kind=host_kind)
     trust = decide_author_trust(subject, gate=AutonomyGate.INTAKE, extra_trusted=trusted)
     author_trusted = trust is TrustVerdict.AUTONOMOUS

--- a/tests/quality/test_no_flat_core_regrowth.py
+++ b/tests/quality/test_no_flat_core_regrowth.py
@@ -109,7 +109,11 @@ _CORE_DIR = Path(__file__).resolve().parents[2] / "src" / "teatree" / "core"
 # 99: +retention.py (#3693) — the age-based prune of the high-churn control-DB tables. A genuine new
 # root data-lifecycle concern: it spans TaskAttempt + IncomingEvent + Ticket and fits no existing
 # subpackage (cleanup/ is worktree/branch/stash reaping, not DB-row retention).
-PINNED_FLAT_CORE_MODULES = 99
+# 100: +forge_pr_probe.py — the single tri-state open-PR probe (find_open_pr_for_branch → FOUND/NONE/
+# UNKNOWN) that unified the three hand-rolled `gh pr list` / `glab mr list` probes. A genuine shared
+# root leaf bridging two gates/ modules (orphan_guard, open_pr_teardown_gate) and the flat root
+# fast_push.py: gates/ is gate/deny logic, not a forge-transport probe, and no other subpackage owns it.
+PINNED_FLAT_CORE_MODULES = 100
 
 
 def _flat_core_modules() -> list[str]:

--- a/tests/teatree_core/gates/test_open_pr_teardown_gate.py
+++ b/tests/teatree_core/gates/test_open_pr_teardown_gate.py
@@ -36,6 +36,7 @@ import pytest
 from django.core.management import call_command
 from django.test import TestCase
 
+import teatree.core.forge_pr_probe as probe_mod
 import teatree.core.gates.open_pr_teardown_gate as gate_mod
 import teatree.core.management.commands._workspace.forge_pr_state as forge_state_mod
 import teatree.core.management.commands.workspace as workspace_mod
@@ -119,7 +120,7 @@ class _TeardownHarness(TestCase):
             payload = [{"web_url": _MR_URL}] if branch in opened else []
             return subprocess.CompletedProcess(cmd, returncode, json.dumps(payload), "")
 
-        return patch.object(gate_mod, "run_allowed_to_fail", side_effect=_run)
+        return patch.object(probe_mod, "run_allowed_to_fail", side_effect=_run)
 
     def _forge_api(self, state: PrOpenState):
         """Fake the code host behind the injected reader, for the recorded-row leg."""
@@ -206,7 +207,7 @@ class TestFailsClosed(_TeardownHarness):
 
     def test_refuses_when_the_forge_cli_is_missing(self) -> None:
         with (
-            patch.object(gate_mod, "run_allowed_to_fail", side_effect=FileNotFoundError("glab")),
+            patch.object(probe_mod, "run_allowed_to_fail", side_effect=FileNotFoundError("glab")),
             pytest.raises(OpenPullRequestTeardownError),
         ):
             self._teardown()
@@ -236,7 +237,7 @@ class TestNoForgeRemote(_TeardownHarness):
     remote = ""
 
     def test_a_repo_with_no_forge_origin_is_clear(self) -> None:
-        with patch.object(gate_mod, "run_allowed_to_fail", side_effect=AssertionError("must not probe")):
+        with patch.object(probe_mod, "run_allowed_to_fail", side_effect=AssertionError("must not probe")):
             self._teardown()
         self.assert_all_reclaimed()
 
@@ -297,18 +298,8 @@ class TestGateHelpersDirect(_TeardownHarness):
 
     def test_open_pr_url_for_branch_uses_the_github_probe_on_a_github_remote(self) -> None:
         with (
-            patch.object(gate_mod.git, "remote_url", return_value="https://github.com/acme/backend"),
-            patch.object(gate_mod, "_first_url", return_value="") as first_url,
+            patch.object(probe_mod.git, "remote_url", return_value="https://github.com/acme/backend"),
+            patch.object(probe_mod, "_probe_open_pr", return_value=probe_mod.PrProbe.none()) as probe,
         ):
             assert gate_mod._open_pr_url_for_branch(self.clone, "feature") == ""
-        assert first_url.call_args.args[0][0] == "gh"
-
-    def test_first_url_is_none_on_unparseable_json(self) -> None:
-        result = subprocess.CompletedProcess(["glab"], 0, "not json at all", "")
-        with patch.object(gate_mod, "run_allowed_to_fail", return_value=result):
-            assert gate_mod._first_url(["glab"], self.clone, key="web_url") is None
-
-    def test_first_url_is_none_when_payload_is_not_a_list(self) -> None:
-        result = subprocess.CompletedProcess(["glab"], 0, '{"web_url": "x"}', "")
-        with patch.object(gate_mod, "run_allowed_to_fail", return_value=result):
-            assert gate_mod._first_url(["glab"], self.clone, key="web_url") is None
+        assert probe.call_args.args[0][0] == "gh"

--- a/tests/teatree_core/test_fast_push.py
+++ b/tests/teatree_core/test_fast_push.py
@@ -284,9 +284,10 @@ class TestForgeCliCommands:
 
     def test_gh_find_create_update(self, tmp_path: Path) -> None:
         forge = GhForge(tmp_path)
-        with patch("teatree.core.fast_push.run_allowed_to_fail", return_value=self._completed("https://x/pr/4\n")):
+        listing = json.dumps([{"url": "https://x/pr/4"}])
+        with patch("teatree.core.forge_pr_probe.run_allowed_to_fail", return_value=self._completed(listing)):
             assert forge.find_pr_url(branch="b") == "https://x/pr/4"
-        with patch("teatree.core.fast_push.run_allowed_to_fail", return_value=self._completed("", returncode=1)):
+        with patch("teatree.core.forge_pr_probe.run_allowed_to_fail", return_value=self._completed("", returncode=1)):
             assert forge.find_pr_url(branch="b") == ""
         with patch("teatree.core.fast_push.run_checked", return_value=self._completed("https://x/pr/5\n")) as run:
             assert forge.create_pr(branch="b", title="t", body="d") == "https://x/pr/5"
@@ -299,9 +300,9 @@ class TestForgeCliCommands:
     def test_glab_find_create_update(self, tmp_path: Path) -> None:
         forge = GlabForge(tmp_path)
         listing = json.dumps([{"web_url": "https://gl/mr/7"}])
-        with patch("teatree.core.fast_push.run_allowed_to_fail", return_value=self._completed(listing)):
+        with patch("teatree.core.forge_pr_probe.run_allowed_to_fail", return_value=self._completed(listing)):
             assert forge.find_pr_url(branch="b") == "https://gl/mr/7"
-        with patch("teatree.core.fast_push.run_allowed_to_fail", return_value=self._completed("not-json")):
+        with patch("teatree.core.forge_pr_probe.run_allowed_to_fail", return_value=self._completed("not-json")):
             assert forge.find_pr_url(branch="b") == ""
         with patch(
             "teatree.core.fast_push.run_checked", return_value=self._completed("created https://gl/mr/8\n")

--- a/tests/teatree_core/test_forge_pr_probe.py
+++ b/tests/teatree_core/test_forge_pr_probe.py
@@ -1,0 +1,154 @@
+"""The single tri-state open-PR probe the orphan, teardown, and fast-push gates share.
+
+The whole point of unifying the three hand-rolled probes is that FOUND / NONE /
+UNKNOWN survive the merge exactly — a fail-closed gate must still see "probe failed"
+apart from "no PR". These tests pin all three outcomes at the probe seam and pin
+both collapse mappers, so a future edit that quietly folds UNKNOWN into NONE (the
+safety regression the fork was guarding against) turns them red.
+
+Real git repos under ``tmp_path`` carry the forge ``origin`` so the remote sniff is
+exercised for real; only the ``gh`` / ``glab`` subprocess (the unstoppable network
+external) is faked.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from teatree.core import forge_pr_probe
+from teatree.core.forge_pr_probe import (
+    PrProbe,
+    PrProbeOutcome,
+    find_open_pr_for_branch,
+    probe_github_open_pr,
+    probe_gitlab_open_pr,
+)
+
+_GH_URL = "https://github.com/acme/widgets/pull/7"
+_MR_URL = "https://gitlab.com/acme/widgets/-/merge_requests/7"
+_GIT = shutil.which("git") or "git"
+
+
+def _repo(tmp_path: Path, *, remote: str) -> Path:
+    repo = tmp_path / "clone"
+    repo.mkdir()
+    subprocess.run([_GIT, "-C", str(repo), "init", "-q"], check=True)
+    if remote:
+        subprocess.run([_GIT, "-C", str(repo), "remote", "add", "origin", remote], check=True)
+    return repo
+
+
+def _completed(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=["stub"], returncode=returncode, stdout=stdout, stderr="")
+
+
+def _fake_cli(monkeypatch: pytest.MonkeyPatch, result: object) -> list[list[str]]:
+    """Fake the forge subprocess. ``result`` is a CompletedProcess or an exception to raise."""
+    seen: list[list[str]] = []
+
+    def _run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        seen.append(cmd)
+        if isinstance(result, BaseException):
+            raise result
+        return result  # type: ignore[return-value]
+
+    monkeypatch.setattr(forge_pr_probe, "run_allowed_to_fail", _run)
+    return seen
+
+
+class TestPrProbeMappers:
+    """The two collapse mappers each caller uses to keep its own posture."""
+
+    def test_url_or_empty_collapses_none_and_unknown(self) -> None:
+        assert PrProbe.found(_GH_URL).url_or_empty() == _GH_URL
+        assert PrProbe.none().url_or_empty() == ""
+        assert PrProbe.unknown().url_or_empty() == ""
+
+    def test_url_or_none_on_unknown_keeps_them_apart(self) -> None:
+        assert PrProbe.found(_GH_URL).url_or_none_on_unknown() == _GH_URL
+        assert PrProbe.none().url_or_none_on_unknown() == ""
+        assert PrProbe.unknown().url_or_none_on_unknown() is None
+
+    def test_outcome_predicates(self) -> None:
+        assert PrProbe.found(_GH_URL).is_found
+        assert not PrProbe.none().is_found
+        assert PrProbe.unknown().is_unknown
+        assert not PrProbe.found(_GH_URL).is_unknown
+
+
+class TestFindOpenPrForBranch:
+    """The sniffing entry: found / none / unknown across both forges and both fail modes."""
+
+    def test_github_found(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        repo = _repo(tmp_path, remote="git@github.com:acme/widgets.git")
+        seen = _fake_cli(monkeypatch, _completed(json.dumps([{"url": _GH_URL}])))
+        probe = find_open_pr_for_branch(repo, "feature")
+        assert probe.outcome is PrProbeOutcome.FOUND
+        assert probe.url == _GH_URL
+        assert seen[0][0] == "gh"
+        assert "--head" in seen[0]
+
+    def test_gitlab_found(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        repo = _repo(tmp_path, remote="https://gitlab.com/acme/widgets.git")
+        seen = _fake_cli(monkeypatch, _completed(json.dumps([{"web_url": _MR_URL}])))
+        probe = find_open_pr_for_branch(repo, "feature")
+        assert probe.outcome is PrProbeOutcome.FOUND
+        assert probe.url == _MR_URL
+        assert seen[0][0] == "glab"
+        assert "--source-branch" in seen[0]
+
+    def test_empty_array_is_none(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        repo = _repo(tmp_path, remote="git@github.com:acme/widgets.git")
+        _fake_cli(monkeypatch, _completed("[]"))
+        assert find_open_pr_for_branch(repo, "feature").outcome is PrProbeOutcome.NONE
+
+    def test_nonzero_exit_is_unknown(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        repo = _repo(tmp_path, remote="git@github.com:acme/widgets.git")
+        _fake_cli(monkeypatch, _completed("", returncode=1))
+        assert find_open_pr_for_branch(repo, "feature").outcome is PrProbeOutcome.UNKNOWN
+
+    def test_missing_binary_is_unknown(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        repo = _repo(tmp_path, remote="git@github.com:acme/widgets.git")
+        _fake_cli(monkeypatch, FileNotFoundError("gh"))
+        assert find_open_pr_for_branch(repo, "feature").outcome is PrProbeOutcome.UNKNOWN
+
+    def test_unparsable_json_is_unknown(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        repo = _repo(tmp_path, remote="git@github.com:acme/widgets.git")
+        _fake_cli(monkeypatch, _completed("not json at all"))
+        assert find_open_pr_for_branch(repo, "feature").outcome is PrProbeOutcome.UNKNOWN
+
+    def test_non_list_json_is_unknown(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        repo = _repo(tmp_path, remote="git@github.com:acme/widgets.git")
+        _fake_cli(monkeypatch, _completed('{"url": "x"}'))
+        assert find_open_pr_for_branch(repo, "feature").outcome is PrProbeOutcome.UNKNOWN
+
+    def test_no_forge_remote_is_none_without_probing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        repo = _repo(tmp_path, remote="git@git.example.org:acme/widgets.git")
+        seen = _fake_cli(monkeypatch, AssertionError("a non-forge remote must not probe"))
+        assert find_open_pr_for_branch(repo, "feature").outcome is PrProbeOutcome.NONE
+        assert seen == []
+
+    def test_empty_branch_is_unknown_without_probing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        repo = _repo(tmp_path, remote="git@github.com:acme/widgets.git")
+        seen = _fake_cli(monkeypatch, AssertionError("an empty branch must not probe"))
+        assert find_open_pr_for_branch(repo, "").outcome is PrProbeOutcome.UNKNOWN
+        assert seen == []
+
+
+class TestForgeSpecificProbes:
+    """The forge-explicit wrappers fast_push uses — no re-sniff, right CLI each."""
+
+    def test_probe_github_uses_gh_head(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen = _fake_cli(monkeypatch, _completed(json.dumps([{"url": _GH_URL}])))
+        assert probe_github_open_pr(tmp_path, "feature").url == _GH_URL
+        assert seen[0][0] == "gh"
+        assert seen[0][seen[0].index("--head") + 1] == "feature"
+
+    def test_probe_gitlab_uses_glab_source_branch(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen = _fake_cli(monkeypatch, _completed(json.dumps([{"web_url": _MR_URL}])))
+        assert probe_gitlab_open_pr(tmp_path, "feature").url == _MR_URL
+        assert seen[0][0] == "glab"
+        assert seen[0][seen[0].index("--source-branch") + 1] == "feature"

--- a/tests/teatree_core/test_forge_pr_probe.py
+++ b/tests/teatree_core/test_forge_pr_probe.py
@@ -12,7 +12,6 @@ external) is faked.
 """
 
 import json
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -26,18 +25,22 @@ from teatree.core.forge_pr_probe import (
     probe_github_open_pr,
     probe_gitlab_open_pr,
 )
+from tests._git_repo import make_git_repo, run_git
 
 _GH_URL = "https://github.com/acme/widgets/pull/7"
 _MR_URL = "https://gitlab.com/acme/widgets/-/merge_requests/7"
-_GIT = shutil.which("git") or "git"
 
 
 def _repo(tmp_path: Path, *, remote: str) -> Path:
-    repo = tmp_path / "clone"
-    repo.mkdir()
-    subprocess.run([_GIT, "-C", str(repo), "init", "-q"], check=True)
+    """A real git repo (born on ``main``) carrying the forge *remote* as ``origin``.
+
+    A real checkout is needed because :func:`find_open_pr_for_branch` sniffs the
+    forge from ``git remote get-url origin``; the ``gh`` / ``glab`` subprocess it
+    then runs is the only external the tests fake.
+    """
+    repo = make_git_repo(tmp_path / "clone")
     if remote:
-        subprocess.run([_GIT, "-C", str(repo), "remote", "add", "origin", remote], check=True)
+        run_git(repo, "remote", "add", "origin", remote)
     return repo
 
 


### PR DESCRIPTION
## What

- New `core/forge_pr_probe.py` with one `find_open_pr_for_branch(...) -> PrProbe`. The result is a typed dataclass tagged by a three-value enum: FOUND (with the URL), NONE, and UNKNOWN — a real type rather than a `str | None` that would blur the last two together. Two small mappers let callers pick how to read UNKNOWN: `url_or_empty()` treats it like NONE, `url_or_none_on_unknown()` returns `None` for it.
- The three previous open-PR probes now call the shared one and keep their existing behaviour:
  - `fast_push` (Gh/GlabForge.find_pr_url) treats a failed probe the same as no PR — it will upsert a PR in both cases.
  - `orphan_guard.find_open_pr` also treats both the same — it reports the branch as an orphan either way.
  - `open_pr_teardown_gate._open_pr_url_for_branch` keeps them separate: an UNKNOWN result returns `None`, and the gate then refuses to reclaim.
- Forge detection now goes through the existing three-value `utils.forge.forge_from_remote` rather than repeated `"gitlab" in remote` string checks: `fast_push.forge_for_repo`, the teardown gate (via the shared probe), `merge_evidence_gate._pr_host_kind`, `pr_slug_resolution._resolve_host_kind`, and `stranger_pr` (host check only — its `/-/` merge-request path check stays).
- Bumped the flat-core module ratchet to 100 for the new shared root module, with a ledger note.

## Why

Each probe used to answer the same question with its own runner, and they disagreed on what a probe that could not run should mean. The teardown gate had grown its own copy because the fast-push version returns `""` both when there is no PR and when the query failed. That is fine for fast-push but wrong for a reclaim gate, which needs to hold when it cannot get an answer. Sharing one implementation while exposing the three-value result lets every caller keep the reading it needs. The new tests exercise all three results directly and lock in each gate's response to each — including that the teardown gate still holds on UNKNOWN.

Note: `branch_classification._pr_merge_commit_sha` appeared in the original list but it probes for MERGED PRs through the gh-then-glab `probe_host_cli` and has no inline remote string check, so it is unchanged.

Verification: scoped tests across the three gates, fast_push, the forge-detection callers, and the new module (133 passed); `ruff check` / `ruff format` / `ty check` clean on the changed files; plus `test_no_flat_core_regrowth` and `t3 tool test-path-mirror`.