### PR TITLE
refactor(config): derive hot-path setting registries from the schema (partial)

### DIFF
--- a/src/teatree/config/schema.py
+++ b/src/teatree/config/schema.py
@@ -9,14 +9,18 @@ callable the four config registries already use (``setting_parsers`` /
 model HOSTS teatree's strictness rather than substituting pydantic's own lax/strict
 rules.
 
-Phase 1 is foundation only: NOTHING in the runtime imports this module — the
-resolver, registries and cold readers are untouched. The only consumers are the
-conformance tests. The rewire (registries derived from the model, resolver
-re-sourcing the TOML-default tier) is a later phase.
+No runtime module imports this one: the four config registries stay
+hand-maintained (``setting_registries`` / ``registries`` / ``cold_hook_settings``)
+and the ``derive_*`` helpers below are consumed ONLY by the conformance suite
+(``tests/config/test_registry_derivation.py``), which pins each hand registry equal
+to what the model derives, key-for-key and coercer-for-coercer. That parity-pin is a
+deliberate steady state, not a half-finished cutover — see the ``derive_*`` block for
+why the runtime must never call these at import scope.
 
-The ONE cost this module carries — importing ``pydantic_settings`` — is paid only
-by a caller that imports ``schema``; thin CLI / cold-hook paths never do (they use
-the stdlib cold readers), so they never pay the ~110ms. ``shipped_defaults()`` is
+The ONE cost this module carries — importing ``pydantic_settings`` (~110ms) — is paid
+only by a caller that imports ``schema``; the cold path (``cold_reader`` /
+``cold_defaults`` / ``cold_hook_settings``, all reached through ``teatree.config``'s
+package init) never imports ``schema``, so it never pays it. ``shipped_defaults()`` is
 the ``@lru_cache`` singleton entry point.
 """
 
@@ -454,6 +458,19 @@ def _keys_in(registry: Registry) -> list[str]:
     return [k for k in TeatreeSettingsSchema.model_fields if setting_meta(k).registry is registry]
 
 
+# COLD-PATH PARITY PIN — deliberate; do NOT wire these into the registry modules.
+# The four ``derive_*`` helpers reconstruct each hand registry from the model taxonomy,
+# and the conformance suite asserts they match the hand copies exactly. They are
+# call-time helpers ONLY: none may be assigned at the import scope of
+# ``setting_registries`` / ``registries`` / ``cold_hook_settings``. ``teatree.config``'s
+# package ``__init__`` eagerly imports all three of those modules, and the cold path
+# loads that package init (``cold_reader`` does ``from teatree.config import
+# value_coercion``), so a module-scope ``derive_*()`` call would drag ``schema`` ->
+# pydantic (~110ms) onto every cold-hook invocation. The registries therefore stay
+# hand-maintained; these helpers exist to keep the hand copies honest via the parity
+# suite, not to replace them at runtime. The leak guard is
+# ``test_registry_derivation.test_registry_modules_stay_pydantic_free`` (with
+# ``test_cold_defaults``'s cold-import control).
 def derive_overlay_overridable_settings() -> dict[str, Callable[[Any], Any]]:
     """The ``OVERLAY_OVERRIDABLE_SETTINGS`` registry, derived from the model taxonomy."""
     return {k: _registry_coercer(k) for k in _keys_in(Registry.OVERLAY)}

--- a/tests/config/test_registry_derivation.py
+++ b/tests/config/test_registry_derivation.py
@@ -13,9 +13,18 @@ Parser equality is BEHAVIORAL, not object-identity: a bound ``.parse`` classmeth
 would spuriously diverge. The two keys whose resolve-tier coercer intentionally differs from
 the model's storage-tier validator (``handover_mirror_path``, ``agent_harness_provider``) are
 re-sourced by the derivation and so match here too.
+
+WHY the runtime dicts stay hand-maintained instead of calling ``derive_*()``:
+``teatree.config``'s package init eagerly imports all three registry-defining modules,
+and the cold path (``cold_reader``) loads that package init — so a module-scope
+``derive_*()`` call would drag ``schema`` -> pydantic (~110ms) onto every cold-hook
+invocation. ``test_registry_modules_stay_pydantic_free`` pins that invariant.
 """
 
 import math
+import subprocess
+import sys
+import textwrap
 from typing import Any
 
 import pytest
@@ -114,6 +123,30 @@ def test_cold_hook_registry_derives_from_model(key: str) -> None:
     assert type(derived[key].default) is type(hand.default)
     assert derived[key].scope == hand.scope
     _assert_parser_parity(hand.parse, derived[key].parse, key)
+
+
+def test_registry_modules_stay_pydantic_free() -> None:
+    # The reason the four registries above stay hand-maintained rather than deriving from
+    # the model at import: ``teatree.config``'s package init eagerly imports the three
+    # registry-defining modules, and the cold path loads that package init, so a
+    # module-scope ``derive_*()`` call would import ``schema`` -> pydantic (~110ms) onto
+    # every cold-hook invocation. A fresh subprocess is the only honest probe — the test
+    # process already has pydantic/schema loaded. This pins the invariant the parity
+    # matrix above depends on: the ``derive_*`` helpers stay call-time only.
+    probe = textwrap.dedent(
+        """
+        import sys
+        import teatree.config.setting_registries
+        import teatree.config.registries
+        import teatree.config.cold_hook_settings
+        assert "pydantic" not in sys.modules, "pydantic leaked onto the cold path via a registry module"
+        assert "teatree.config.schema" not in sys.modules, "schema leaked onto the cold path via a registry module"
+        print("clean")
+        """
+    )
+    result = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "clean"
 
 
 class TestDerivedKeysetsMatchTheHandRegistries:


### PR DESCRIPTION
## What

- Document in `schema.py` that the four config registries stay hand-maintained on purpose: the `derive_*` helpers are call-time-only conformance helpers, never wired at any registry module's import scope.
- Add `test_registry_modules_stay_pydantic_free` to the parity suite (`tests/config/test_registry_derivation.py`): a fresh subprocess checks that importing `setting_registries` / `registries` / `cold_hook_settings` loads neither pydantic nor `schema` — the exact leak a module-scope `derive_*()` would introduce.

## Why

The abstraction (`derive_overlay_overridable_settings` / `derive_cold_settings` / `derive_registry_settings` / `derive_cold_hook_settings`) already reconstructs each registry from the model, and `test_registry_derivation` pins them equal key-for-key and coercer-for-coercer. It reads like a half-finished cutover, tempting a "just call `derive_*()` in the runtime" change.

That change is unsafe for every registry, not only the cold ones:

- `teatree.config`'s package `__init__` eagerly imports all three registry-defining modules (`setting_registries`, `registries`, `cold_hook_settings`).
- The cold path loads that package init — `cold_reader` does `from teatree.config import value_coercion`, which runs `config/__init__.py`.
- Verified empirically: importing `cold_reader` today pulls in `config/__init__` and all three registry modules, but not pydantic or schema. A module-scope `derive_*()` call would drag `schema` into pydantic (about 110ms) onto every cold-hook invocation.

So no registry — hot-path `OVERLAY_OVERRIDABLE_SETTINGS` included — can be derived at import scope without paying the cold-path pydantic cost, because the registry definition sites are all cold-reachable through the shared config package facade even when a given consumer (for example `resolution.py`) is hot. A lazy per-consumer rewire would leave the hand dicts in place (no surface shrink) while adding fragility, so the safe outcome is to pin the current steady state precisely rather than force a risky rewire.

## How the cold-path import guard stays green

No production import edges change — only a docstring and comment in `schema.py`, plus a test. The cold path never imports `schema`, so `test_cold_defaults::test_import_does_not_load_pydantic_or_django` (the existing cold-import control) is untouched, and the new `test_registry_modules_stay_pydantic_free` adds a focused, parity-suite-local guard so any future rewire attempt is caught with a clear reason instead of silently regressing cold-start latency. The intra-package deferred-import ratchet (`tests/quality/deferred_import_pegs.toml`) is unchanged — no new function-scoped intra-core or intra-loop imports were added.
