### PR TITLE
refactor(dash): unify config-surface render + secret-masking taxonomy

### DIFF
--- a/src/teatree/dash/config_display.py
+++ b/src/teatree/dash/config_display.py
@@ -1,0 +1,54 @@
+"""Shared config-display helpers for the dashboard's two config surfaces (#3664, D7).
+
+Both the settings editor (:mod:`teatree.dash.settings_editor`) and the read-only
+config surface (:mod:`teatree.dash.config_surface`) turn a setting's value into display
+text and decide which values must never reach the response. This is the ONE source of
+truth for both, so the two pages can never drift into divergent render or masking:
+
+- :func:`render_value` — one value-to-display rule (booleans as on/off, empties as a dash).
+- :func:`is_secret` — the value-masking taxonomy: the full four-class union a secret
+    VALUE is withheld by (``Category.SECRET`` field / ``SECRET_SETTINGS`` denylist /
+    credential coordinate / personal identifier). A key that is a personal identifier or
+    ``Category.SECRET`` but not on the denylist is masked here too, so neither surface can
+    regress toward exposure.
+
+Masking a credential ENTRY NAME (the ``pass`` coordinate the config surface's credential
+band shows) is a DIFFERENT question — "does this coordinate NAME carry an internal
+namespace" — answered by ``SECRET_SETTINGS`` membership alone, not by this taxonomy:
+broadening it to :func:`is_secret` would hide every credential name (they are all
+credential coordinates) and defeat the band. See ``CredentialEntry.mask_if_private``.
+"""
+
+from teatree.config.schema import Category, TeatreeSettingsSchema, setting_meta
+from teatree.config.secret_settings import PERSONAL_IDENTIFIERS, SECRET_SETTINGS, is_credential_reference
+
+#: Rendered in place of a secret VALUE — never the real value.
+MASKED = "***"
+
+
+def render_value(value: object) -> str:
+    """A value as display text — booleans as on/off, empties (None/``""``/``[]``/``{}``) as a dash."""
+    if isinstance(value, bool):
+        return "on" if value else "off"
+    if value is None or (isinstance(value, str) and not value) or value in ([], {}):
+        return "—"
+    return str(value)
+
+
+def is_secret(setting: str) -> bool:
+    """Whether *setting*'s VALUE must never be rendered — the four-class withhold union.
+
+    A ``Category.SECRET`` field, an explicit ``SECRET_SETTINGS`` denylist key, a credential
+    coordinate (``*_pass_path`` / ``*_token_ref`` / …), or a personal identifier
+    (``slack_user_id`` / …). Total over any string — the key-based classes are checked
+    before the model, so a denylist key that is not a schema field (a legacy token ref) is
+    still classified without a lookup that raises.
+    """
+    if setting in SECRET_SETTINGS or setting in PERSONAL_IDENTIFIERS or is_credential_reference(setting):
+        return True
+    if setting not in TeatreeSettingsSchema.model_fields:
+        return False
+    return setting_meta(setting).category is Category.SECRET
+
+
+__all__ = ["MASKED", "is_secret", "render_value"]

--- a/src/teatree/dash/config_surface.py
+++ b/src/teatree/dash/config_surface.py
@@ -8,10 +8,12 @@ than introducing a second source of truth: the effective values come from
 :func:`~teatree.config.get_effective_settings` and
 :func:`~teatree.config.agent_spawn.resolve_agent_config`.
 
-**A secret value is never rendered.** A credential row carries the ``pass`` entry
-NAME and whether it resolves — never the token. An entry name that is itself
-private (a key in :data:`~teatree.config.secret_settings.SECRET_SETTINGS`, whose
-value can carry an internal namespace) is masked too, so the page answers "which
+**A secret value is never rendered.** A band row's value is masked whenever the setting
+is secret under the shared :func:`~teatree.dash.config_display.is_secret` taxonomy — the
+SAME policy the settings editor applies, so the two pages never diverge. A credential row
+carries the ``pass`` entry NAME and whether it resolves — never the token; an entry name
+that is itself private (a key in :data:`~teatree.config.secret_settings.SECRET_SETTINGS`,
+whose value can carry an internal namespace) is masked too, so the page answers "which
 account, and does it work" without becoming a secret surface.
 """
 
@@ -25,11 +27,12 @@ from teatree.config.agent_spawn import resolve_agent_config
 from teatree.config.secret_settings import SECRET_SETTINGS, is_credential_reference
 from teatree.core.config_self_repair import SELF_REPAIR_STAMP
 from teatree.core.models import Task
+from teatree.dash.config_display import is_secret, render_value
 from teatree.utils.secrets import read_pass
 
 logger = logging.getLogger(__name__)
 
-#: Redaction shown in place of a private entry name.
+#: Redaction shown in place of a private entry name OR a secret setting's value.
 MASKED = "<private>"
 
 #: How many self-repairs the band lists, newest first.
@@ -81,7 +84,13 @@ class CredentialEntry:
 
     @classmethod
     def mask_if_private(cls, setting: str, entry_name: str) -> "CredentialEntry":
-        """Build the row, masking the entry name when the SETTING is itself private."""
+        """Build the row, masking the entry NAME when the SETTING is itself private.
+
+        Keyed on ``SECRET_SETTINGS`` membership — NOT the shared ``is_secret`` value-masking
+        taxonomy. Every setting reaching here is a credential coordinate, so ``is_secret``
+        would be true for all of them and hide every account name, defeating the band. This
+        narrower rule masks only names that can carry an internal namespace.
+        """
         shown = MASKED if setting in SECRET_SETTINGS else entry_name
         return cls(setting=setting, entry_name=shown, resolves=_pass_entry_resolves(entry_name))
 
@@ -148,8 +157,13 @@ def _settings_bands() -> _Bands:
         if band == "credentials":
             bands.credentials.extend(_credential_entries(spec.name, value))
             continue
-        getattr(bands, band).append(SettingRow(name=spec.name, value=_render(value)))
+        getattr(bands, band).append(_band_row(spec.name, value))
     return bands
+
+
+def _band_row(name: str, value: object) -> SettingRow:
+    """A band row — the value MASKED when the setting is secret (same policy as the editor)."""
+    return SettingRow(name=name, value=MASKED if is_secret(name) else render_value(value))
 
 
 def _credential_entries(setting: str, value: object) -> list[CredentialEntry]:
@@ -166,9 +180,9 @@ def _model_rows() -> list[SettingRow]:
     """The agent lane's model / reasoning-effort pins."""
     agent = resolve_agent_config()
     rows = [
-        SettingRow(name="session_model", value=_render(agent.session_model)),
-        SettingRow(name="session_effort", value=_render(agent.session_effort)),
-        SettingRow(name="honesty_model", value=_render(agent.honesty_model)),
+        SettingRow(name="session_model", value=render_value(agent.session_model)),
+        SettingRow(name="session_effort", value=render_value(agent.session_effort)),
+        SettingRow(name="honesty_model", value=render_value(agent.honesty_model)),
     ]
     rows.extend(
         SettingRow(name=f"tier_model[{tier}]", value=model) for tier, model in sorted(agent.tier_models.items())
@@ -210,15 +224,6 @@ def _pass_entry_resolves(entry_name: str) -> bool:
     except Exception:
         logger.warning("pass probe for a configured credential entry failed", exc_info=True)
         return False
-
-
-def _render(value: object) -> str:
-    """A setting's effective value as display text — booleans as on/off, absence as a dash."""
-    if isinstance(value, bool):
-        return "on" if value else "off"
-    if value is None or (isinstance(value, str) and not value):
-        return "—"
-    return str(value)
 
 
 __all__ = ["ConfigView", "CredentialEntry", "SelfRepairRow", "SettingRow", "build_config_view", "classify_setting_band"]

--- a/src/teatree/dash/settings_editor.py
+++ b/src/teatree/dash/settings_editor.py
@@ -5,10 +5,11 @@ and editable with NO hand-kept list — a newly-added setting appears here for f
 edit path writes through ``ConfigSetting.set_value`` (the same seam ``config_setting set``
 uses), so the #258 strict coercion and the #3688 cross-key checks fire identically.
 
-**A secret value never reaches the response.** ``is_secret_setting`` reuses the export
-withhold taxonomy (``Category.SECRET`` / ``SECRET_SETTINGS`` / credential coordinate /
-personal identifier); a secret row's value AND its shipped default are replaced with
-``***`` HERE, before the row enters the view context — so the stored value is never read
+**A secret value never reaches the response.** :func:`~teatree.dash.config_display.is_secret`
+(the shared value-masking taxonomy — ``Category.SECRET`` / ``SECRET_SETTINGS`` / credential
+coordinate / personal identifier) drives masking here AND on the read-only config surface,
+so the two pages apply ONE policy. A secret row's value AND its shipped default are replaced
+with ``***`` HERE, before the row enters the view context — so the stored value is never read
 into a rendered string. Restore-to-default deletes the DB row (the Phase-4 zero-row /
 ``restore = delete row`` semantics). Export withholds secrets and keeps personal; import
 previews via ``import_toml_to_db(dry_run=True)``.
@@ -17,33 +18,14 @@ previews via ``import_toml_to_db(dry_run=True)``.
 import logging
 from dataclasses import dataclass
 
-from teatree.config.schema import Category, TeatreeSettingsSchema, setting_meta, shipped_defaults
-from teatree.config.secret_settings import PERSONAL_IDENTIFIERS, SECRET_SETTINGS, is_credential_reference
+from teatree.config.schema import TeatreeSettingsSchema, setting_meta, shipped_defaults
 from teatree.config.setting_registries import SAFETY_POSTURE_KEYS
 from teatree.core.config_migration import ConfigImport, export_db_to_toml, import_toml_to_db
 from teatree.core.models import ConfigSetting
 from teatree.core.models.config_setting import ConfigValue
+from teatree.dash.config_display import MASKED, is_secret, render_value
 
 logger = logging.getLogger(__name__)
-
-#: Rendered in place of a secret value AND its default — never the real value.
-MASKED = "***"
-
-
-def is_secret_setting(key: str) -> bool:
-    """Whether *key*'s value must never be rendered — the export withhold taxonomy.
-
-    The union the export secret guard withholds by key: a ``Category.SECRET`` field, an
-    explicit ``SECRET_SETTINGS`` denylist key, a credential coordinate (``*_pass_path`` /
-    ``*_token_ref`` / …), or a personal identifier (``slack_user_id`` / …). Total over any
-    string — the key-based classes are checked before the model, so a denylist key that is
-    not a schema field (a legacy token ref) is still classified without a lookup that raises.
-    """
-    if key in SECRET_SETTINGS or key in PERSONAL_IDENTIFIERS or is_credential_reference(key):
-        return True
-    if key not in TeatreeSettingsSchema.model_fields:
-        return False
-    return setting_meta(key).category is Category.SECRET
 
 
 @dataclass(frozen=True, slots=True)
@@ -67,25 +49,16 @@ class SettingsEditorView:
     error: str = ""
 
 
-def _render(value: object) -> str:
-    """A value as display text — booleans as on/off, empties as a dash."""
-    if isinstance(value, bool):
-        return "on" if value else "off"
-    if value is None or (isinstance(value, str) and not value) or value in ([], {}):
-        return "—"
-    return str(value)
-
-
 def _display_value(key: str, *, overridden: bool, db_value: ConfigValue | None) -> str:
     """The row's shown value — ``***`` for a secret (its default too), else DB-or-default.
 
     A secret returns ``MASKED`` WITHOUT reading the stored value or the shipped default, so
     neither can ever be serialised into the page.
     """
-    if is_secret_setting(key):
+    if is_secret(key):
         return MASKED
     value = db_value if overridden else getattr(shipped_defaults(), key)
-    return _render(value)
+    return render_value(value)
 
 
 def build_settings_editor(scope: str = "") -> SettingsEditorView:
@@ -97,7 +70,7 @@ def build_settings_editor(scope: str = "") -> SettingsEditorView:
                 name=key,
                 category=setting_meta(key).category.value,
                 value=_display_value(key, overridden=key in overrides, db_value=overrides.get(key)),
-                is_secret=is_secret_setting(key),
+                is_secret=is_secret(key),
                 is_safety_posture=key in SAFETY_POSTURE_KEYS,
                 is_overridden=key in overrides,
             )
@@ -126,5 +99,4 @@ __all__ = [
     "build_settings_editor",
     "export_text",
     "import_preview",
-    "is_secret_setting",
 ]

--- a/src/teatree/dash/views/settings.py
+++ b/src/teatree/dash/views/settings.py
@@ -21,7 +21,8 @@ from teatree.config.write_validation import ConfigWriteError, validate_config_wr
 from teatree.core.config_migration import import_toml_to_db
 from teatree.core.models import ConfigSetting
 from teatree.dash import audit
-from teatree.dash.settings_editor import build_settings_editor, export_text, import_preview, is_secret_setting
+from teatree.dash.config_display import is_secret
+from teatree.dash.settings_editor import build_settings_editor, export_text, import_preview
 from teatree.dash.views.access import require_loopback_or_staff
 from teatree.dash.views.base import actor, nav_context
 
@@ -34,7 +35,7 @@ SAFETY_CONFIRM_PHRASE = "change-safety-posture"
 
 def _audit_after(key: str, canonical: object) -> str:
     """The audit ``after`` value — never the real value of a secret key."""
-    return "***" if is_secret_setting(key) else str(canonical)
+    return "***" if is_secret(key) else str(canonical)
 
 
 @require_loopback_or_staff

--- a/tests/teatree_dash/test_config_display.py
+++ b/tests/teatree_dash/test_config_display.py
@@ -1,0 +1,46 @@
+"""The shared config-display helpers both dash config surfaces consume (cluster 9)."""
+
+from teatree.dash.config_display import MASKED, is_secret, render_value
+
+
+class TestIsSecret:
+    """One taxonomy — the full four-class union of what must never render."""
+
+    def test_secret_category_and_denylist_keys_are_secret(self) -> None:
+        assert is_secret("banned_terms") is True  # Category.SECRET + SECRET_SETTINGS
+        assert is_secret("github_token_pass_key") is True  # credential coordinate
+
+    def test_a_personal_identifier_not_on_the_denylist_is_secret(self) -> None:
+        # slack_user_id is a personal identifier only — NOT in SECRET_SETTINGS. This is the
+        # drift the two surfaces diverged on: the config surface used to leave it unmasked.
+        assert is_secret("slack_user_id") is True
+
+    def test_an_ordinary_dial_is_not_secret(self) -> None:
+        assert is_secret("mode") is False
+        assert is_secret("issue_implementer_enabled") is False
+
+    def test_an_unknown_non_schema_key_is_not_secret(self) -> None:
+        # A key that is neither a secret/personal/credential coordinate NOR a model field
+        # (a stale or bogus key) is safely reported non-secret, never a KeyError.
+        assert is_secret("a_removed_or_unknown_key") is False
+
+
+class TestRenderValue:
+    """Booleans as on/off, every empty as a single dash, else the value's text."""
+
+    def test_booleans_render_on_off(self) -> None:
+        assert render_value(value=True) == "on"
+        assert render_value(value=False) == "off"
+
+    def test_every_empty_renders_a_dash(self) -> None:
+        assert render_value(None) == "—"
+        assert render_value("") == "—"
+        assert render_value([]) == "—"
+        assert render_value({}) == "—"
+
+    def test_a_present_value_renders_its_text(self) -> None:
+        assert render_value("auto") == "auto"
+        assert render_value(4) == "4"
+
+    def test_masked_is_the_value_redaction(self) -> None:
+        assert MASKED == "***"

--- a/tests/teatree_dash/test_config_surface.py
+++ b/tests/teatree_dash/test_config_surface.py
@@ -9,7 +9,9 @@ from teatree.config.agent_spawn import AgentConfig
 from teatree.core.config_self_repair import ConfigRepair
 from teatree.core.models import ConfigSetting, Session, Task, Ticket
 from teatree.dash.config_surface import (
+    MASKED,
     CredentialEntry,
+    _band_row,
     _pass_entry_resolves,
     _self_repair_rows,
     build_config_view,
@@ -58,6 +60,21 @@ class TestCredentialEntry:
     def test_a_public_setting_keeps_its_entry_name(self) -> None:
         entry = CredentialEntry.mask_if_private("openai_compatible_credential_entry", "router/key")
         assert entry.entry_name == "router/key"
+
+
+class TestBandRowMasksSecretValues:
+    """A band value obeys the shared secret taxonomy — never leaks a secret's value."""
+
+    def test_a_personal_identifier_value_is_masked(self) -> None:
+        # slack_user_id is a personal identifier (NOT in SECRET_SETTINGS). Were it ever to
+        # land in a value band, its value must be masked — the same policy the settings
+        # editor applies. This is the cluster-9 drift: the config surface used to render it.
+        row = _band_row("slack_user_id", "U-OWNER-SECRET")
+        assert row.value == MASKED
+        assert "U-OWNER-SECRET" not in row.value
+
+    def test_an_ordinary_dial_value_renders(self) -> None:
+        assert _band_row("boost_concurrency", 4).value == "4"
 
 
 class TestBuildConfigView(TestCase):

--- a/tests/teatree_dash/test_settings_editor.py
+++ b/tests/teatree_dash/test_settings_editor.py
@@ -6,23 +6,8 @@ from django.test import TestCase
 
 from teatree.config.schema import TeatreeSettingsSchema
 from teatree.core.models import ConfigSetting
-from teatree.dash.settings_editor import MASKED, build_settings_editor, export_text, import_preview, is_secret_setting
-
-
-class TestIsSecretSetting:
-    def test_secret_category_and_denylist_keys_are_secret(self) -> None:
-        assert is_secret_setting("banned_terms") is True  # Category.SECRET + SECRET_SETTINGS
-        assert is_secret_setting("github_token_pass_key") is True  # credential coordinate
-        assert is_secret_setting("slack_user_id") is True  # personal identifier
-
-    def test_an_ordinary_dial_is_not_secret(self) -> None:
-        assert is_secret_setting("mode") is False
-        assert is_secret_setting("issue_implementer_enabled") is False
-
-    def test_an_unknown_non_schema_key_is_not_secret(self) -> None:
-        # A key that is neither a secret/personal/credential coordinate NOR a model field
-        # (a stale or bogus key) is safely reported non-secret, never a KeyError.
-        assert is_secret_setting("a_removed_or_unknown_key") is False
+from teatree.dash.config_display import MASKED
+from teatree.dash.settings_editor import build_settings_editor, export_text, import_preview
 
 
 class TestBuildSettingsEditor(TestCase):
@@ -43,6 +28,15 @@ class TestBuildSettingsEditor(TestCase):
     def test_a_secret_default_is_also_masked(self) -> None:
         # No override — the secret still renders MASKED, never its (empty) default.
         assert self._row("banned_terms").value == MASKED
+
+    def test_a_personal_identifier_not_on_the_denylist_is_masked(self) -> None:
+        # slack_user_id is a personal identifier (NOT in SECRET_SETTINGS) — the exact
+        # drift class: masked here, and now masked on the config surface too (cluster 9).
+        ConfigSetting.objects.set_value("slack_user_id", "U-OWNER-SECRET")
+        row = self._row("slack_user_id")
+        assert row.is_secret is True
+        assert row.value == MASKED
+        assert "U-OWNER-SECRET" not in row.value
 
     def test_a_non_secret_override_shows_its_value(self) -> None:
         ConfigSetting.objects.set_value("mode", "auto")


### PR DESCRIPTION
## What

- New `teatree.dash.config_display` is the single source of truth both dash config surfaces consume:
  - `render_value` — one value-to-display rule (booleans as on/off, empties incl. `[]`/`{}` as a dash).
  - `is_secret` — one value-masking taxonomy = the full four-class union (`Category.SECRET` field / `SECRET_SETTINGS` denylist / credential coordinate / personal identifier).
- `settings_editor` and `config_surface` both import from it. The two duplicated `_render` copies and the divergent `is_secret_setting` are removed.
- `config_surface` value bands now mask a secret setting's value via the shared `is_secret`, matching the settings editor: a personal-identifier or `Category.SECRET` key that is not on the denylist no longer renders unmasked on the config page.
- The credential entry-NAME redaction (`CredentialEntry.mask_if_private`) intentionally stays keyed on `SECRET_SETTINGS`. It answers a different question — does the `pass` coordinate NAME carry an internal namespace — and every setting reaching it is already a credential coordinate, so routing it through `is_secret` would hide every account name and defeat the band.

## Why

- The two `_render` copies had already drifted: the editor rendered `[]`/`{}` as a dash, the config surface did not.
- The two surfaces embodied divergent secret-masking POLICY. A key that is a personal identifier or `Category.SECRET` but not on the denylist was masked by the editor yet could render unmasked on the config page.
- One taxonomy removes the drift and closes the exposure path in a leak-sensitive factory. The unification only ever masks more, never less — no page regresses toward exposure.

## Tests

- New `tests/teatree_dash/test_config_display.py` covers the shared `is_secret` taxonomy (incl. a personal-identifier key not on the denylist) and `render_value`.
- Added assertions that a `Category.SECRET`/personal-identifier key not in `SECRET_SETTINGS` is masked on BOTH surfaces (settings editor row + config-surface band row) — the exact drift being fixed.
- The #3710 response-bytes masking tests stay green.