### PR TITLE
fix(loop): draft-PR reopen guard read the stale 'mrs' key, never fired

### DIFF
--- a/src/teatree/loop/scanners/ticket_completion.py
+++ b/src/teatree/loop/scanners/ticket_completion.py
@@ -30,13 +30,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _has_draft_mrs(ticket: "Ticket") -> bool:
-    """Return True if any MR in the ticket's extra is still a draft."""
+def _has_draft_prs(ticket: "Ticket") -> bool:
+    """Return True if any PR in the ticket's extra is still a draft."""
     extra = ticket.extra if isinstance(ticket.extra, dict) else {}
-    mrs = extra.get("mrs", {})
-    if not isinstance(mrs, dict):
+    prs = extra.get("prs", {})
+    if not isinstance(prs, dict):
         return False
-    return any(isinstance(mr, dict) and mr.get("draft") for mr in mrs.values())
+    return any(isinstance(pr, dict) and pr.get("draft") for pr in prs.values())
 
 
 @dataclass(slots=True)
@@ -51,11 +51,11 @@ class TicketCompletionScanner:
         signals: list[ScanSignal] = []
         for ticket in self._candidate_tickets():
             try:
-                if _has_draft_mrs(ticket):
+                if _has_draft_prs(ticket):
                     signals.append(
                         ScanSignal(
                             kind="ticket.reopen_needed",
-                            summary=f"Ticket {ticket.ticket_number} — draft MRs exist, reopening",
+                            summary=f"Ticket {ticket.ticket_number} — draft PRs exist, reopening",
                             payload={
                                 "ticket_id": ticket.pk,
                                 "ticket_state": ticket.state,

--- a/tests/teatree_loop/test_ticket_completion.py
+++ b/tests/teatree_loop/test_ticket_completion.py
@@ -220,6 +220,31 @@ class TicketCompletionScannerTests(TestCase):
         assert signals[0].payload["ticket_state"] == "merged"
         assert signals[0].payload["issue_url"] == self.URL
 
+    def test_draft_pr_reopens_instead_of_completing(self) -> None:
+        # A completable ticket whose recorded PR is still a DRAFT must reopen,
+        # not walk to terminal DELIVERED — even when the upstream issue is done.
+        ticket = self._ticket(state=Ticket.State.SHIPPED)
+        ticket.extra = {"prs": {"https://example.com/prs/1": {"draft": True}}}
+        ticket.save(update_fields=["extra"])
+        host = _Host(issues_by_url={self.URL: {"state": "closed"}})
+        with self._patch_host(host):
+            signals = self._scanner(host).scan()
+        assert len(signals) == 1
+        assert signals[0].kind == "ticket.reopen_needed"
+        assert signals[0].payload["ticket_id"] == ticket.pk
+
+    def test_non_draft_pr_completes(self) -> None:
+        # A recorded PR that is NOT a draft leaves the completion path intact.
+        self._ticket(state=Ticket.State.SHIPPED)
+        ticket = Ticket.objects.get(issue_url=self.URL)
+        ticket.extra = {"prs": {"https://example.com/prs/1": {"draft": False}}}
+        ticket.save(update_fields=["extra"])
+        host = _Host(issues_by_url={self.URL: {"state": "closed"}})
+        with self._patch_host(host):
+            signals = self._scanner(host).scan()
+        assert len(signals) == 1
+        assert signals[0].kind == "ticket.completion_detected"
+
 
 class DispatchCompletionTests(TestCase):
     def test_completion_signal_dispatches_to_mechanical(self) -> None:


### PR DESCRIPTION
What:
- The ticket-completion scanner`s draft-PR reopen guard read `extra["mrs"]`, but the canonical key in `Ticket.extra` is `"prs"`. Nothing writes `extra["mrs"]` (the PR list is written as `extra={"prs": {...}}` in `backends/gitlab/sync_prs.py` and read as `extra.get("prs")` everywhere else), so `_has_draft_mrs` always returned False — the guard was dead code (leftover from the historical MR->PR rename).
- Renamed `_has_draft_mrs` -> `_has_draft_prs`, read `extra["prs"]`, and added a regression test.

Why:
- A completable ticket (SHIPPED/IN_REVIEW/MERGED) whose PR is still a DRAFT should emit `ticket.reopen_needed` (-> `mechanical.reopen_ticket`) when its upstream issue reads done. With the dead guard it instead emitted `ticket.completion_detected` -> `complete_ticket` -> `advance_to_delivered`, walking an unmerged-draft ticket to terminal DELIVERED.
- On the teatree overlay the `require_merge_evidence` gate catches it (sticks at IN_REVIEW), but that gate defaults OFF for non-teatree overlays — there the draft ticket walks straight through, exactly the "believe work is done when it isn`t" failure the reopen guard exists to prevent.

Test:
- New `test_draft_pr_reopens_instead_of_completing`: a SHIPPED ticket with `extra={"prs": {<url>: {"draft": True}}}` + a done issue now emits `ticket.reopen_needed`, not `completion_detected`. Verified anti-vacuous — it fails RED if the key is reverted to `"mrs"`.
- Reopen wiring confirmed intact end-to-end (scanner -> `MECHANICAL_BY_KIND["ticket.reopen_needed"]` -> `mechanical.reopen_ticket`); no wiring changed.

blast=logic