### PR TITLE
fix(config): log loud when a runtime DB fault drops the override tier (not just bootstrap-silent)

### DIFF
--- a/src/teatree/config/resolution.py
+++ b/src/teatree/config/resolution.py
@@ -380,16 +380,24 @@ def _coerce_db_rows(rows: dict[str, Any]) -> dict[str, Any]:
     return overrides
 
 
-def _bootstrap_read_exceptions() -> tuple[type[Exception], ...]:
-    """The GENUINE not-ready exceptions the DB override read fails SILENTLY-safe on (returns ``{}``).
+def _app_registry_ready() -> bool:
+    """True when Django is configured AND its app registry is fully populated (post-``django.setup()``)."""
+    from django.apps import apps  # noqa: PLC0415 — deferred: app registry read at call time
+    from django.conf import settings as django_settings  # noqa: PLC0415 — deferred: settings read at call time
 
-    Django unconfigured / a settings access failing (``ImproperlyConfigured``), the app
-    registry not yet populated (``AppRegistryNotReady``), a pre-migration/missing table
-    or an unreachable DB (``OperationalError`` / ``ProgrammingError``) — the legitimate
-    bootstrap states a cold or fresh install hits before the DB exists. These are the
-    only states the reader may empty the override tier for WITHOUT a signal, because
-    they are expected. Any OTHER exception is a real read bug and is LOGGED loud (see
-    :func:`_read_override_rows`) rather than silently swallowed.
+    return django_settings.configured and apps.ready
+
+
+def _override_read_degrades_silently(exc: BaseException) -> bool:
+    """Whether a caught override-read exception is a genuine BOOTSTRAP no-op (silent ``{}``).
+
+    ``ImproperlyConfigured`` / ``AppRegistryNotReady`` are unambiguous bootstrap states —
+    always silent. ``OperationalError`` / ``ProgrammingError`` are AMBIGUOUS: a bootstrap
+    signal (missing table, DB not ready) before ``django.setup()``, but ALSO a real RUNTIME
+    fault (a locked SQLite DB, a lock timeout, a mid-session drop) once the registry is
+    ready — the TYPE alone can't tell them apart, so they are silent ONLY while the registry
+    is not ready (:func:`_app_registry_ready`); a runtime one logs loud. Any OTHER exception
+    is a real read bug — always loud.
     """
     from django.core.exceptions import (  # noqa: PLC0415 — deferred: Django import at call time
         AppRegistryNotReady,
@@ -400,7 +408,11 @@ def _bootstrap_read_exceptions() -> tuple[type[Exception], ...]:
         ProgrammingError,
     )
 
-    return (ImproperlyConfigured, AppRegistryNotReady, OperationalError, ProgrammingError)
+    if isinstance(exc, ImproperlyConfigured | AppRegistryNotReady):
+        return True
+    if isinstance(exc, OperationalError | ProgrammingError):
+        return not _app_registry_ready()
+    return False
 
 
 # The loud SIGNAL for a non-bootstrap ``ConfigSetting`` read fault. Such a failure is a
@@ -419,19 +431,19 @@ def _load_global_rows() -> dict[str, Any]:
     """Read the GLOBAL-scope (``scope=""``) ``{key: value}`` rows, or ``{}`` on failure.
 
     Reaches the model via Django's app registry (no static ``teatree.core`` import — that
-    would be a backwards ``platform -> domain`` tach edge). A bootstrap state degrades
-    SILENTLY (:func:`_bootstrap_read_exceptions`); any other read fault is logged loud
-    (:data:`_OVERRIDE_READ_FAILURE_MSG`), never silently emptying the override tier.
+    would be a backwards ``platform -> domain`` tach edge). A genuine bootstrap state
+    degrades SILENTLY (:func:`_override_read_degrades_silently`); a RUNTIME fault — incl.
+    an ``OperationalError`` / ``ProgrammingError`` raised while the app registry is ready —
+    is logged loud (:data:`_OVERRIDE_READ_FAILURE_MSG`), never silently emptying the tier.
     """
     from django.apps import apps  # noqa: PLC0415 — deferred: app registry read at call time
 
     try:
         model = apps.get_model("core", "ConfigSetting")
         return dict(model.objects.overrides_for_scope(""))
-    except _bootstrap_read_exceptions():
-        return {}
-    except Exception:
-        _logger.exception(_OVERRIDE_READ_FAILURE_MSG, "global")
+    except Exception as exc:
+        if not _override_read_degrades_silently(exc):
+            _logger.exception(_OVERRIDE_READ_FAILURE_MSG, "global")
         return {}
 
 
@@ -444,7 +456,8 @@ def _load_overlay_rows(overlay_name: str = "") -> dict[str, Any]:
     a row scoped ``myovl`` and one scoped ``t3-myovl`` both apply. Alias groups
     apply in sorted-scope order, then the exact-name group last, so on a key
     collision the exact-name row wins. Same signal-on-real-failure posture as
-    :func:`_load_global_rows`.
+    :func:`_load_global_rows`: a genuine bootstrap state is silent, a runtime fault
+    (incl. a ready-registry ``OperationalError`` / ``ProgrammingError``) logs loud.
     """
     if not overlay_name:
         return {}
@@ -462,10 +475,9 @@ def _load_overlay_rows(overlay_name: str = "") -> dict[str, Any]:
             if scope != overlay_name:
                 merged.update(scope_values[scope])
         merged.update(scope_values.get(overlay_name, {}))
-    except _bootstrap_read_exceptions():
-        return {}
-    except Exception:
-        _logger.exception(_OVERRIDE_READ_FAILURE_MSG, f"overlay {overlay_name!r}")
+    except Exception as exc:
+        if not _override_read_degrades_silently(exc):
+            _logger.exception(_OVERRIDE_READ_FAILURE_MSG, f"overlay {overlay_name!r}")
         return {}
     return merged
 

--- a/tests/config/test_db_config_tier.py
+++ b/tests/config/test_db_config_tier.py
@@ -17,7 +17,8 @@ overlay set via ``T3_OVERLAY_NAME``.
 from unittest import mock
 
 import pytest
-from django.db.utils import OperationalError
+from django.core.exceptions import AppRegistryNotReady
+from django.db.utils import OperationalError, ProgrammingError
 from django.test import TestCase
 
 from teatree.config import get_effective_settings
@@ -172,14 +173,65 @@ class TestOverrideReadSignalsOnRealFailure(TestCase):
         monkeypatch.delenv("T3_OVERLAY_NAME", raising=False)
 
     def test_bootstrap_missing_table_error_is_a_silent_no_op(self) -> None:
-        # A pre-migration / missing-table read is the legitimate no-op: {} and NO error log.
+        # A pre-migration / missing-table read while the app registry is NOT ready is the
+        # legitimate bootstrap no-op: {} and NO error log. `_app_registry_ready` is patched
+        # False to model the genuine bootstrap state (this TestCase has Django set up).
         with (
+            mock.patch("teatree.config.resolution._app_registry_ready", return_value=False),
             mock.patch.object(
                 ConfigSetting.objects, "overrides_for_scope", side_effect=OperationalError("no such table")
             ),
             self.assertNoLogs("teatree.config", level="ERROR"),
         ):
             assert _load_global_rows() == {}
+
+    def test_app_registry_not_ready_error_is_always_silent(self) -> None:
+        # AppRegistryNotReady is an unambiguous bootstrap state — silent regardless of the
+        # readiness predicate (it is the very signal the predicate reads as not-ready).
+        with (
+            mock.patch.object(
+                ConfigSetting.objects, "overrides_for_scope", side_effect=AppRegistryNotReady("apps not ready")
+            ),
+            self.assertNoLogs("teatree.config", level="ERROR"),
+        ):
+            assert _load_global_rows() == {}
+
+    def test_runtime_operational_error_is_logged_loud_not_silent(self) -> None:
+        # THE fix: an OperationalError raised while the app registry IS ready (a locked DB,
+        # a lock timeout, a mid-session drop) is a RUNTIME fault, not a bootstrap no-op — it
+        # still degrades to {} but MUST be signalled loud, else the operator's DB-override
+        # tier (autonomy, per-overlay mode, worker_quiescing) silently reverts to defaults.
+        with (
+            mock.patch("teatree.config.resolution._app_registry_ready", return_value=True),
+            mock.patch.object(
+                ConfigSetting.objects, "overrides_for_scope", side_effect=OperationalError("database is locked")
+            ),
+            self.assertLogs("teatree.config", level="ERROR") as captured,
+        ):
+            assert _load_global_rows() == {}
+        assert any("FAILED unexpectedly" in r.getMessage() for r in captured.records)
+
+    def test_runtime_programming_error_is_logged_loud_not_silent(self) -> None:
+        # ProgrammingError shares the runtime-vs-bootstrap distinction with OperationalError.
+        with (
+            mock.patch("teatree.config.resolution._app_registry_ready", return_value=True),
+            mock.patch.object(
+                ConfigSetting.objects, "overrides_for_scope", side_effect=ProgrammingError("relation gone")
+            ),
+            self.assertLogs("teatree.config", level="ERROR") as captured,
+        ):
+            assert _load_global_rows() == {}
+        assert any("FAILED unexpectedly" in r.getMessage() for r in captured.records)
+
+    def test_runtime_operational_error_on_overlay_read_is_logged_loud(self) -> None:
+        # The per-overlay reader shares the runtime-vs-bootstrap distinction.
+        with (
+            mock.patch("teatree.config.resolution._app_registry_ready", return_value=True),
+            mock.patch.object(ConfigSetting.objects, "exclude", side_effect=OperationalError("database is locked")),
+            self.assertLogs("teatree.config", level="ERROR") as captured,
+        ):
+            assert _load_overlay_rows("my-overlay") == {}
+        assert any("FAILED unexpectedly" in r.getMessage() for r in captured.records)
 
     def test_real_read_error_is_logged_loud_not_silent(self) -> None:
         # A genuine read bug (not a bootstrap state) degrades to {} but is SIGNALLED loud —


### PR DESCRIPTION
What:
- The DB override-read (`_load_global_rows` / `_load_overlay_rows`) now distinguishes a genuine BOOTSTRAP `OperationalError`/`ProgrammingError` from a RUNTIME one via app-registry readiness (`_app_registry_ready()` = `settings.configured and apps.ready`). A caught `OperationalError`/`ProgrammingError` is silent-`{}` only while the registry is NOT ready; once ready it falls through to the loud `_OVERRIDE_READ_FAILURE_MSG` ERROR log before degrading. `ImproperlyConfigured`/`AppRegistryNotReady` stay always-silent (unambiguous bootstrap).
- Regression tests: a runtime `OperationalError`/`ProgrammingError` (registry ready) logs loud while still returning `{}`; a bootstrap one (registry not ready) stays silent.

Why:
- The #3720 fail-open fix scoped the silent-`{}` degrade to an allowlist that includes `OperationalError`/`ProgrammingError`. Those are genuine bootstrap signals (missing table, DB not ready) but ALSO real RUNTIME faults — a locked SQLite DB, a lock timeout, a mid-session connection drop. In the runtime case the entire operator DB-override tier silently reverted to dataclass defaults (`autonomy`, per-overlay `mode`, `worker_quiescing` all vanish) with zero signal — very hard to debug. The exception TYPE alone cannot distinguish the two states, so the fix keys on app-registry readiness.
- Fail direction is unchanged (still degrade to `{}` after logging — the tier is unreadable either way); this only adds the loud log on the runtime case so the silent-revert is observable. Safety gates still fail closed (autonomy→babysit, require_human_approval_to_merge→True), so this is an observability + override-durability fix, not a safety fix.

## Architecture pre-check
Tactical, narrow correctness/observability fix scoped to `src/teatree/config/resolution.py` — no new module, no FSM/phase change, no `OverlayBase`/scanner/Protocol contract change, no dependency-direction change. Behavior preservation: bootstrap-silence path unchanged (full config suite + the ~52 non-django_db bootstrap-silence tests stay green); the only behavior change is adding the loud log on a ready-registry runtime DB fault. Test surface: `tests/config/test_db_config_tier.py::TestOverrideReadSignalsOnRealFailure` — runtime-loud asserted via `assertLogs(ERROR)`, verified anti-vacuous (an unconditional-silent mutant turns the runtime-loud assertions RED).