### PR TITLE
fix(loop): task-sweep synthetic-URL orphan noise on cadence placeholders

### DIFF
--- a/src/teatree/loop/scanners/task_sweep.py
+++ b/src/teatree/loop/scanners/task_sweep.py
@@ -3,13 +3,14 @@
 This scanner reconciles teatree **Task** rows (the DB-backed lifecycle work
 units), never the agent harness's working list of session items. The candidate
 set is the open :class:`Task` rows (status ``PENDING`` or ``CLAIMED``) whose
-``Ticket`` carries an ``issue_url``, EXCLUDING every task anchored on the synthetic
-loop umbrella (:func:`~teatree.utils.url_slug.is_synthetic_loop_umbrella_url`) —
-the directive interpret/implement and outer-loop experiment tickets whose completion
-the loop FSM owns rather than an upstream artifact. Their umbrella ``issue_url`` is a
-routing device, not a trackable issue, so sweeping them on the umbrella's closed state
-would complete a live task and strand the loop work regardless of phase (#3706). Each
-tick the scanner walks those tasks
+``Ticket`` carries an ``issue_url``, EXCLUDING every task anchored on a synthetic
+teatree-internal URL (:func:`_is_synthetic_issue_url`) — the loop-umbrella routing
+device (directive interpret/implement + outer-loop experiment, #3706) and the cadence
+scanners' hostless placeholder schemes (``eval-local://``, ``scanning-news://``,
+``architectural-review://``, ``backlog-sweep://``, ``dogfood-smoke://``). Neither
+resolves to a real per-URL code host, so sweeping them would either complete a live
+FSM-owned task or run ``get_issue`` against the wrong default forge and manufacture a
+spurious ``task.orphaned`` signal. Each tick the scanner walks the remaining tasks
 and, for each, verifies the underlying artifact's *terminal* state — is the
 upstream issue closed / the PR merged? — via the overlay's ``is_issue_done()``
 hook (the same independent-evidence check ``TicketCompletionScanner`` uses for
@@ -44,6 +45,7 @@ from django.utils import timezone
 from teatree.backends.loader import get_code_host_for_url
 from teatree.core.overlay import OverlayBase
 from teatree.loop.scanners.base import ScanSignal
+from teatree.utils.git_remote import web_base_from_remote
 from teatree.utils.url_slug import is_synthetic_loop_umbrella_url
 
 if TYPE_CHECKING:
@@ -106,12 +108,7 @@ class TaskSweepScanner:
             # Pre-migration install: the table or the new column does not exist
             # yet. The next tick after ``migrate`` picks the tasks up.
             return []
-        # A synthetic loop ticket (directive interpret/implement, outer-loop experiment)
-        # anchors on the shared north-star umbrella issue via a URL fragment. Its task
-        # lifecycle is owned by the loop FSM, not by the umbrella issue's upstream state,
-        # so a sweep on the umbrella's closed state would wrongly complete a live task and
-        # silently strand the loop work — regardless of phase (#3706).
-        return [row for row in rows if not is_synthetic_loop_umbrella_url(row.ticket.issue_url)]
+        return [row for row in rows if not _is_synthetic_issue_url(row.ticket.issue_url)]
 
     def _claim_for_sweep(self, *, task_id: int, now: datetime) -> bool:
         """Atomically stamp ``last_sweep_check_ts``; True iff this tick won the race."""
@@ -164,6 +161,20 @@ class TaskSweepScanner:
                 "overlay": self.overlay_name,
             },
         )
+
+
+def _is_synthetic_issue_url(issue_url: str) -> bool:
+    """Whether *issue_url* is a teatree-internal anchor no per-URL host can resolve.
+
+    Covers the shared loop umbrella (github-hosted, FSM-owned task lifecycle,
+    #3706) and the cadence scanners' hostless ``<scheme>://<overlay>`` placeholders
+    (``eval-local://``, ``scanning-news://`` …). For the latter ``web_base_from_remote``
+    returns ``""``, so ``get_code_host_for_url`` falls back to the overlay DEFAULT host
+    and ``get_issue`` runs against the wrong forge — manufacturing a spurious
+    ``task.orphaned`` signal. A URL with a real host but an unrecognised forge is NOT
+    synthetic, keeping the fail-open orphan-for-operator-review behaviour.
+    """
+    return is_synthetic_loop_umbrella_url(issue_url) or not web_base_from_remote(issue_url)
 
 
 __all__ = ["TaskSweepScanner"]

--- a/tests/teatree_loop/test_task_sweep_scanner.py
+++ b/tests/teatree_loop/test_task_sweep_scanner.py
@@ -210,6 +210,40 @@ class SyntheticUmbrellaTests(_SweepHarness):
         assert signals[0].payload["task_id"] == task.pk
 
 
+class SyntheticSchemeTicketTests(_SweepHarness):
+    """Cadence-scanner placeholder tickets anchor on hostless synthetic schemes.
+
+    ``eval-local://``, ``scanning-news://``, ``architectural-review://``,
+    ``backlog-sweep://``, ``dogfood-smoke://`` carry no forge host, so
+    ``get_code_host_for_url`` would fall back to the overlay DEFAULT host and run
+    ``get_issue`` against the wrong forge — manufacturing a spurious
+    ``task.orphaned`` signal and wasting an API call. The sweep must exclude them
+    up front, exactly like the loop umbrella.
+    """
+
+    def test_synthetic_scheme_task_is_not_swept(self) -> None:
+        self._task(url="eval-local://t3-acme", phase="eval_local")
+        host = _Host()
+        with self._patch_host(host):
+            assert self._scanner().scan() == []
+        assert host.get_issue_calls == []  # never even fetched — excluded up front
+
+    def test_every_named_synthetic_scheme_is_excluded(self) -> None:
+        schemes = (
+            "eval-local://t3-acme",
+            "scanning-news://t3-acme",
+            "architectural-review://t3-acme",
+            "backlog-sweep://t3-acme",
+            "dogfood-smoke://t3-acme",
+        )
+        for url in schemes:
+            self._task(url=url, phase="coding")
+        host = _Host()
+        with self._patch_host(host):
+            assert self._scanner().scan() == []
+        assert host.get_issue_calls == []
+
+
 class FailOpenTests(_SweepHarness):
     """Uncertainty never auto-completes — it emits ``task.orphaned``."""
 


### PR DESCRIPTION
## What

`TaskSweepScanner._candidate_tasks` previously excluded only the single synthetic
loop-umbrella issue (`.../issues/3009`). It now excludes any task whose `issue_url`
resolves to no forge host, via a combined `_is_synthetic_issue_url` predicate that
keeps the umbrella exclusion **and** adds the cadence scanners' hostless placeholder
schemes: `eval-local://`, `scanning-news://`, `architectural-review://`,
`backlog-sweep://`, `dogfood-smoke://`.

## Why

For a synthetic-scheme placeholder ticket, `utils/forge.forge_from_remote()` returns
`""` (no forge host), so `backends/loader.get_code_host_for_url` does **not** return
`None` — it falls through to the overlay DEFAULT host, and `_verify` then calls
`host.get_issue("eval-local://<overlay>")` against the real forge. That errors →
spurious `task.orphaned` signal (false "needs operator review" noise) + a wasted API
call every recheck window.

Keying the exclusion on `web_base_from_remote(issue_url) == ""` covers all synthetic
schemes generically (they are all hostless `<scheme>://<overlay>` anchors) while
**preserving** the fail-open orphan-for-operator-review behaviour for a URL that has a
real host but an unrecognised forge. The fail-closed re-check in the `task_completion`
mechanical handler is untouched.

## Tests

Added `SyntheticSchemeTicketTests` to `tests/teatree_loop/test_task_sweep_scanner.py`:
an in-flight task on `eval-local://<overlay>` (and each of the five named schemes) is
**not** emitted as `task.orphaned` and triggers **no** default-host `get_issue` call.
Verified anti-vacuous: reverting the predicate to umbrella-only turns both new tests
RED (the pre-fix `task.orphaned` on `eval-local://…`).

## Note — the arch-review "failure-storm" (originally bug 1 of this pair) is NOT in this PR

This PR was scoped to fix two bugs. The second — `ArchitecturalReviewScanner`
re-dispatching an expensive review every tick after a FAILED task — was **held back**
because the proposed fix (dropping the `status=COMPLETED` filter in the cadence clock)
**directly reverses a deliberate, test-pinned decision** from
[#1617](https://github.com/souliane/teatree/pull/1617): bullet **L1** added that exact
filter "so FAILED tasks don't advance the cadence clock", backed by a RED→GREEN
regression test (`tests/teatree_loop/test_bug_fixes.py::TestL1FailedTaskDoesNotAdvanceCadence`)
that asserts the **opposite** of the proposed fix. Both concerns are real — #1617
prevents a week-long gap after a transient failure; dropping the filter prevents a
storm after a persistent failure — so the principled resolution is an explicit
**bounded** post-failure backoff, which changes L1's contract and needs sign-off. Held
for a design decision rather than silently inverting a must-block regression test.
