### PR TITLE
refactor(core): WorktreeQuerySet.for_ticket + retention predicates onto managers

### DIFF
--- a/src/teatree/agents/_headless_options.py
+++ b/src/teatree/agents/_headless_options.py
@@ -249,7 +249,7 @@ def _resolve_task_cwd(task: Task) -> str | None:
     Every other phase keeps the historical ``None`` (cwd unset) when no ticket
     worktree exists.
     """
-    worktree = Worktree.objects.filter(ticket=task.ticket).order_by("pk").first()
+    worktree = Worktree.objects.for_ticket(task.ticket).order_by("pk").first()
     if worktree and Path(worktree.repo_path).is_dir():
         return str(worktree.repo_path)
     return _main_clone_cwd(task)

--- a/src/teatree/agents/attempt_recorder.py
+++ b/src/teatree/agents/attempt_recorder.py
@@ -384,7 +384,7 @@ def _salvage_coding_result(task: Task, result: AgentResultBlob, *, phase: str) -
 
 def _committed_file_changes(task: Task) -> list[dict[str, str]]:
     """``files_modified`` entries for the first ticket worktree with a commit ahead, else ``[]``."""
-    for worktree in Worktree.objects.filter(ticket=task.ticket):
+    for worktree in Worktree.objects.for_ticket(task.ticket):
         if not worktree_has_commits_ahead(worktree):
             continue
         paths = _committed_paths(worktree)

--- a/src/teatree/agents/landing_verification.py
+++ b/src/teatree/agents/landing_verification.py
@@ -39,7 +39,7 @@ def landing_verification_error(task: "Task", *, phase: str = "") -> str:
     """
     if normalize_phase(phase or task.phase) not in _LANDING_VERIFIED_PHASES:
         return ""
-    checkable = [wt for wt in Worktree.objects.filter(ticket=task.ticket) if _on_disk_repo(wt)]
+    checkable = [wt for wt in Worktree.objects.for_ticket(task.ticket) if _on_disk_repo(wt)]
     if not checkable:
         return ""
     for wt in checkable:

--- a/src/teatree/backends/github/sync.py
+++ b/src/teatree/backends/github/sync.py
@@ -147,7 +147,7 @@ class GitHubSyncBackend(SyncBackend):
         """
         from teatree.core.models import Worktree  # noqa: PLC0415 — deferred: ORM import needs the app registry
 
-        for worktree in Worktree.objects.filter(ticket=ticket):
+        for worktree in Worktree.objects.for_ticket(ticket):
             try:
                 cleanup_result = cleanup_worktree(worktree)
                 result.worktrees_cleaned += 1

--- a/src/teatree/backends/gitlab/sync_terminal.py
+++ b/src/teatree/backends/gitlab/sync_terminal.py
@@ -138,7 +138,7 @@ def _scan_merged_prs(prs: RawAPIDict, merged_urls: set[str], result: SyncResult)
 
 
 def _cleanup_merged_worktrees(ticket: Ticket, result: SyncResult) -> None:
-    for worktree in Worktree.objects.filter(ticket=ticket):
+    for worktree in Worktree.objects.for_ticket(ticket):
         try:
             cleanup_result = cleanup_worktree(worktree)
             result.worktrees_cleaned += 1

--- a/src/teatree/core/intake/e2e_workitem.py
+++ b/src/teatree/core/intake/e2e_workitem.py
@@ -128,7 +128,7 @@ def _workspace_repo_dirs(ticket: Ticket) -> dict[str, str]:
     is dropped here — the ladder must never adopt a path that disappeared.
     """
     dirs: dict[str, str] = {}
-    for wt in Worktree.objects.filter(ticket=ticket):
+    for wt in Worktree.objects.for_ticket(ticket):
         path = wt.worktree_path
         if path and Path(path).exists():
             dirs[str(wt.repo_path)] = path
@@ -149,7 +149,7 @@ def _recipe_repo_names(ticket: Ticket, recipe: E2ERecipe) -> list[str]:
     if names:
         return names
     seen: dict[str, None] = {}
-    for wt in Worktree.objects.filter(ticket=ticket).order_by("pk"):
+    for wt in Worktree.objects.for_ticket(ticket).order_by("pk"):
         seen.setdefault(str(wt.repo_path), None)
     return list(seen)
 

--- a/src/teatree/core/management/commands/_e2e_discovery.py
+++ b/src/teatree/core/management/commands/_e2e_discovery.py
@@ -79,12 +79,12 @@ def ticket_frontend_projects(worktree: Worktree, *, linked_ticket: Ticket | None
     ticket's siblings.
     """
     if linked_ticket is not None:
-        candidates: list[Worktree] = [worktree, *Worktree.objects.filter(ticket=linked_ticket).order_by("pk")]
+        candidates: list[Worktree] = [worktree, *Worktree.objects.for_ticket(linked_ticket).order_by("pk")]
     else:
         ticket = worktree.ticket
         candidates = [worktree]
         if ticket is not None:
-            candidates += [wt for wt in Worktree.objects.filter(ticket=ticket) if wt.pk != worktree.pk]
+            candidates += [wt for wt in Worktree.objects.for_ticket(ticket) if wt.pk != worktree.pk]
     seen: set[str] = set()
     projects: list[str] = []
     for wt in candidates:
@@ -147,7 +147,7 @@ def resolve_linked_worktree(linked_ticket: Ticket) -> Worktree | None:
     first stored-path worktree, then any sibling so a freshly-provisioned
     ticket with no recorded ``worktree_path`` still routes.
     """
-    siblings = list(Worktree.objects.filter(ticket=linked_ticket).order_by("pk"))
+    siblings = list(Worktree.objects.for_ticket(linked_ticket).order_by("pk"))
     stored = [wt for wt in siblings if (wt.extra or {}).get("worktree_path")]
     for wt in stored:
         if _runs_backend_stack(wt):

--- a/src/teatree/core/management/commands/_workspace/finalize.py
+++ b/src/teatree/core/management/commands/_workspace/finalize.py
@@ -54,7 +54,7 @@ def run_finalize(ticket: Ticket, *, message: str, write: Callable[[str], None]) 
     worktrees. Returns the joined per-worktree result lines.
     """
     results: list[str] = []
-    for worktree in Worktree.objects.filter(ticket=ticket):
+    for worktree in Worktree.objects.for_ticket(ticket):
         repo = worktree.repo_path
         repo_dir = (worktree.extra or {}).get("worktree_path") or repo
         default_br = git.default_branch(repo)

--- a/src/teatree/core/management/commands/workspace.py
+++ b/src/teatree/core/management/commands/workspace.py
@@ -219,7 +219,7 @@ class Command(TyperCommand):
         # provisioning work competes with them for host CPU/RAM.
         reap_stale_local_stacks(self.stdout.write)
 
-        worktrees = list(Worktree.objects.filter(ticket=ticket))
+        worktrees = list(Worktree.objects.for_ticket(ticket))
         to_provision = [wt for wt in worktrees if wt.state in {Worktree.State.CREATED, Worktree.State.PROVISIONED}]
         results = run_worktree_provisions_in_parallel(
             to_provision,
@@ -255,7 +255,7 @@ class Command(TyperCommand):
         # #1310: disambiguate from ``ticket.overlay`` (see ``provision``).
         overlay = get_overlay(ticket.overlay or None)
 
-        worktrees = list(Worktree.objects.filter(ticket=ticket))
+        worktrees = list(Worktree.objects.for_ticket(ticket))
         started: list[Worktree] = []
         failures: list[str] = []
         # #2207: abandoned unowned stacks (age-guarded) are reaped first so
@@ -316,7 +316,7 @@ class Command(TyperCommand):
         # #1310: disambiguate from ``ticket.overlay`` (see ``provision``).
         overlay = get_overlay(ticket.overlay or None)
 
-        worktrees = list(Worktree.objects.filter(ticket=ticket))
+        worktrees = list(Worktree.objects.for_ticket(ticket))
         total, total_failures = _wh.report_worktree_probes(worktrees, overlay, self.stdout.write, note_empty=True)
         if total_failures:
             _die(self.stderr.write, f"  {total_failures} of {total} probe(s) failed")
@@ -353,7 +353,7 @@ class Command(TyperCommand):
         """
         ticket = _resolve_workspace_ticket(path)
 
-        worktrees = list(Worktree.objects.filter(ticket=ticket))
+        worktrees = list(Worktree.objects.for_ticket(ticket))
         check_no_open_prs(ticket, worktrees, read_pr_state=read_live_pr_state, allow_open_prs=allow_open_prs)
         labels: list[str] = []
         failures: list[str] = []

--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -119,6 +119,9 @@ class WorktreeQuerySet(models.QuerySet):
     def for_overlay(self, overlay: str | None = None) -> models.QuerySet:
         return _for_overlay(self, overlay)
 
+    def for_ticket(self, ticket: "Ticket") -> models.QuerySet:
+        return self.filter(ticket=ticket)
+
     def active(self, overlay: str | None = None) -> models.QuerySet:
         """Worktrees whose ticket is still in flight (not delivered, review-posted, or ignored).
 
@@ -155,6 +158,13 @@ class SessionQuerySet(models.QuerySet):
         return self.filter(agent_id=agent_id).order_by("pk")
 
 
+# The settled/in-flight boundary, defined ONCE (#3693): an event is UNSETTLED until it is
+# drained (``processed_at``) or dead-lettered. ``unprocessed()`` filters this in (plus a
+# due clause); ``prunable()`` excludes it (the exact settled complement). Deriving both
+# from this one Q keeps the boundary from drifting between the two call sites.
+_UNSETTLED = Q(processed_at__isnull=True, dead_lettered_at__isnull=True)
+
+
 class IncomingEventQuerySet(models.QuerySet):
     def unprocessed(self, now: datetime | None = None) -> models.QuerySet:
         """Events still awaiting a drain: un-processed, not dead-lettered, and due (#673).
@@ -166,9 +176,13 @@ class IncomingEventQuerySet(models.QuerySet):
         dead-lettered poison out of the queue rather than block behind it.
         """
         moment = now or timezone.now()
-        return self.filter(processed_at__isnull=True, dead_lettered_at__isnull=True).filter(
-            Q(next_retry_at__isnull=True) | Q(next_retry_at__lte=moment)
-        )
+        return self.filter(_UNSETTLED).filter(Q(next_retry_at__isnull=True) | Q(next_retry_at__lte=moment))
+
+    def prunable(self, cutoff: datetime) -> models.QuerySet:
+        # Settled events before *cutoff*, safe to delete (#3693). Excludes the _UNSETTLED
+        # boundary itself (drained/dead-lettered) — NOT unprocessed(): a not-yet-due backoff
+        # row is still in-flight and must never be pruned however old.
+        return self.exclude(_UNSETTLED).filter(received_at__lt=cutoff)
 
     def dead_lettered(self) -> models.QuerySet:
         """Poisoned events that exhausted their retries — the dead-letter view (#673)."""

--- a/src/teatree/core/models/task_attempt.py
+++ b/src/teatree/core/models/task_attempt.py
@@ -1,9 +1,11 @@
+from datetime import datetime
 from typing import TYPE_CHECKING, cast
 
 from django.db import models
 
 from teatree.core.modelkit.gate_registry import get
 from teatree.core.models.task import Task
+from teatree.core.models.ticket import Ticket
 from teatree.core.models.usage_window_state import LIMIT_PARKED_PREFIX
 from teatree.core.repair_loop import terminal_reason_fingerprint
 
@@ -12,6 +14,23 @@ if TYPE_CHECKING:
 
 
 class TaskAttemptQuerySet(models.QuerySet):
+    def prunable(self, cutoff: datetime) -> "TaskAttemptQuerySet":
+        """Attempts safe to delete (#3693): the conservative double guard.
+
+        An attempt is prunable ONLY when it started before *cutoff* AND its owning task
+        is terminal AND that task's ticket is definitively finished. SHIPPED is NOT
+        finished (its PR is still open, so the ticket may take review comments and
+        re-work), so ``marker_release_states()`` plus RETROSPECTED is the terminal set.
+        An attempt of an active task, or of a live ticket, is NEVER prunable — deleting
+        a referenced/in-flight row is far worse than a bloated DB.
+        """
+        finished = Ticket.marker_release_states() | {Ticket.State.RETROSPECTED}
+        return self.filter(
+            started_at__lt=cutoff,
+            task__status__in=Task.Status.terminal(),
+            task__ticket__state__in=finished,
+        )
+
     def headless(self) -> "TaskAttemptQuerySet":
         """Only the attempts that ran a billed detached headless-SDK run.
 

--- a/src/teatree/core/retention.py
+++ b/src/teatree/core/retention.py
@@ -9,22 +9,20 @@ is TERMINAL, never a live or in-flight row.
 Destructive, so the default is planning, not deleting: :func:`plan_retention`
 reports what WOULD be pruned (read-only); :func:`apply_retention` is the only path
 that deletes, and it does so inside one transaction. The two safety predicates
-(:func:`task_attempts_prunable` / :func:`incoming_events_prunable`) are the SINGLE
-audit point for "safe to delete" — both the plan and the apply resolve the row set
-through them, so the guard is defined in exactly one place.
+(:meth:`TaskAttemptQuerySet.prunable` / :meth:`IncomingEventQuerySet.prunable`) are
+the SINGLE audit point for "safe to delete" — both the plan and the apply resolve the
+row set through them, so the guard is defined in exactly one place.
 """
 
 import dataclasses
 import datetime as dt
 
 from django.db import models, transaction
-from django.db.models import Q
 from django.utils import timezone
 
 from teatree.config import get_effective_settings
 from teatree.config.settings import UserSettings
-from teatree.core.models import IncomingEvent, TaskAttempt, Ticket
-from teatree.core.models.task import Task
+from teatree.core.models import IncomingEvent, TaskAttempt
 from teatree.core.models.usage_window_state import LIMIT_PARKED_PREFIX
 
 
@@ -61,36 +59,6 @@ def _cutoff(now: dt.datetime, days: int) -> dt.datetime:
     return now - dt.timedelta(days=days)
 
 
-def task_attempts_prunable(cutoff: dt.datetime) -> models.QuerySet:
-    """Attempts safe to delete (#3693): the conservative double guard.
-
-    An attempt is prunable ONLY when it started before *cutoff* AND its owning task
-    is terminal AND that task's ticket is definitively finished. SHIPPED is NOT
-    finished (its PR is still open, so the ticket may take review comments and
-    re-work), so ``marker_release_states()`` plus RETROSPECTED is the terminal set.
-    An attempt of an active task, or of a live ticket, is NEVER prunable — deleting
-    a referenced/in-flight row is far worse than a bloated DB.
-    """
-    finished = Ticket.marker_release_states() | {Ticket.State.RETROSPECTED}
-    return TaskAttempt.objects.filter(
-        started_at__lt=cutoff,
-        task__status__in=Task.Status.terminal(),
-        task__ticket__state__in=finished,
-    )
-
-
-def incoming_events_prunable(cutoff: dt.datetime) -> models.QuerySet:
-    """Events safe to delete (#3693): only a FINISHED event received before *cutoff*.
-
-    Finished = already drained (``processed_at`` set) or dead-lettered. An
-    un-processed, non-dead-lettered event is still in-flight (awaiting its first
-    drain or a backoff retry), so it is NEVER prunable however old it is.
-    """
-    return IncomingEvent.objects.filter(received_at__lt=cutoff).filter(
-        Q(processed_at__isnull=False) | Q(dead_lettered_at__isnull=False)
-    )
-
-
 def _junk_count(task_attempt_qs: models.QuerySet) -> int:
     return task_attempt_qs.filter(error__startswith=LIMIT_PARKED_PREFIX).count()
 
@@ -104,14 +72,14 @@ def plan_retention(now: dt.datetime | None = None, *, settings: UserSettings | N
 
     ta_days = int(cfg.task_attempt_retention_days)
     if ta_days > 0:
-        qs = task_attempts_prunable(_cutoff(moment, ta_days))
+        qs = TaskAttempt.objects.prunable(_cutoff(moment, ta_days))
         tables.append(TableRetention("TaskAttempt", ta_days, qs.count(), junk=_junk_count(qs)))
     else:
         tables.append(TableRetention("TaskAttempt", ta_days, 0, disabled=True))
 
     ie_days = int(cfg.incoming_event_retention_days)
     if ie_days > 0:
-        qs = incoming_events_prunable(_cutoff(moment, ie_days))
+        qs = IncomingEvent.objects.prunable(_cutoff(moment, ie_days))
         tables.append(TableRetention("IncomingEvent", ie_days, qs.count()))
     else:
         tables.append(TableRetention("IncomingEvent", ie_days, 0, disabled=True))
@@ -128,7 +96,7 @@ def apply_retention(now: dt.datetime | None = None, *, settings: UserSettings | 
     with transaction.atomic():
         ta_days = int(cfg.task_attempt_retention_days)
         if ta_days > 0:
-            qs = task_attempts_prunable(_cutoff(moment, ta_days))
+            qs = TaskAttempt.objects.prunable(_cutoff(moment, ta_days))
             junk = _junk_count(qs)
             # Count inside the transaction, before the delete: nothing else mutates
             # the row set here, so the count is exactly what delete() removes — and it
@@ -141,7 +109,7 @@ def apply_retention(now: dt.datetime | None = None, *, settings: UserSettings | 
 
         ie_days = int(cfg.incoming_event_retention_days)
         if ie_days > 0:
-            qs = incoming_events_prunable(_cutoff(moment, ie_days))
+            qs = IncomingEvent.objects.prunable(_cutoff(moment, ie_days))
             rows = qs.count()
             qs.delete()
             tables.append(TableRetention("IncomingEvent", ie_days, rows))

--- a/src/teatree/core/runners/provision.py
+++ b/src/teatree/core/runners/provision.py
@@ -337,7 +337,7 @@ class WorktreeProvisioner(RunnerBase):
         """
         parents = {
             Path(path).parent
-            for wt in Worktree.objects.filter(ticket=ticket)
+            for wt in Worktree.objects.for_ticket(ticket)
             if (path := (wt.extra or {}).get("worktree_path")) and Path(path).is_dir()
         }
         return parents.pop() if len(parents) == 1 else None

--- a/src/teatree/core/worktree/reconcile.py
+++ b/src/teatree/core/worktree/reconcile.py
@@ -471,7 +471,7 @@ def reconcile_ticket(ticket: Ticket) -> Drift:
     """Walk every state store and return a typed ``Drift`` for *ticket*."""
     drift = Drift(ticket_pk=ticket.pk)
     clone_workspace = clone_root()
-    worktrees = list(Worktree.objects.filter(ticket=ticket))
+    worktrees = list(Worktree.objects.for_ticket(ticket))
 
     for wt in worktrees:
         _reconcile_worktree_row(drift, wt)
@@ -546,7 +546,7 @@ def reconcile_work_state_ticket(ticket: Ticket) -> Drift:
     :func:`reconcile_ticket` runs for ``workspace doctor``.
     """
     drift = Drift(ticket_pk=ticket.pk)
-    worktrees = list(Worktree.objects.filter(ticket=ticket))
+    worktrees = list(Worktree.objects.for_ticket(ticket))
     _collect_work_state_drift(drift, ticket, worktrees, clone_root())
     return drift
 

--- a/src/teatree/mcp/search.py
+++ b/src/teatree/mcp/search.py
@@ -172,7 +172,7 @@ def worktree_status(
             resolved = Ticket.objects.resolve(ticket)
         except Ticket.DoesNotExist:
             return []
-        queryset = Worktree.objects.filter(ticket=resolved)
+        queryset = Worktree.objects.for_ticket(resolved)
     elif active_only:
         queryset = Worktree.objects.active(overlay)
     else:

--- a/tests/teatree_core/models/test_task_attempt.py
+++ b/tests/teatree_core/models/test_task_attempt.py
@@ -1,7 +1,10 @@
 """``TaskAttempt.Lane`` attribution and the per-row ``effective_tokens`` metric."""
 
+import datetime as dt
+
 import pytest
 from django.test import TestCase
+from django.utils import timezone
 
 from teatree.core.models import Session, Task, TaskAttempt, Ticket
 
@@ -59,6 +62,33 @@ class TestTaskAttemptLane(TestCase):
         metered.refresh_from_db()
         assert subscription.lane == "subscription"
         assert metered.lane == "metered"
+
+
+class TestTaskAttemptPrunable(TestCase):
+    """``TaskAttemptQuerySet.prunable`` — the conservative double-guard prune set (#3693)."""
+
+    def _attempt(self, *, ticket_state: str, task_status: str, started_at: dt.datetime) -> TaskAttempt:
+        ticket = Ticket.objects.create(overlay="acme", state=ticket_state)
+        session = Session.objects.create(ticket=ticket)
+        task = Task.objects.create(ticket=ticket, session=session, status=task_status)
+        attempt = TaskAttempt.objects.create(task=task)
+        TaskAttempt.objects.filter(pk=attempt.pk).update(started_at=started_at)
+        return TaskAttempt.objects.get(pk=attempt.pk)
+
+    def test_old_terminal_owned_attempt_is_prunable(self) -> None:
+        old = timezone.now() - dt.timedelta(days=60)
+        attempt = self._attempt(ticket_state=Ticket.State.MERGED, task_status=Task.Status.COMPLETED, started_at=old)
+        cutoff = timezone.now() - dt.timedelta(days=30)
+        assert list(TaskAttempt.objects.prunable(cutoff).values_list("pk", flat=True)) == [attempt.pk]
+
+    def test_never_prunes_live_ticket_or_active_task_or_recent_attempt(self) -> None:
+        old = timezone.now() - dt.timedelta(days=60)
+        recent = timezone.now() - dt.timedelta(days=2)
+        self._attempt(ticket_state=Ticket.State.STARTED, task_status=Task.Status.COMPLETED, started_at=old)
+        self._attempt(ticket_state=Ticket.State.MERGED, task_status=Task.Status.PENDING, started_at=old)
+        self._attempt(ticket_state=Ticket.State.SHIPPED, task_status=Task.Status.COMPLETED, started_at=old)
+        self._attempt(ticket_state=Ticket.State.MERGED, task_status=Task.Status.COMPLETED, started_at=recent)
+        assert TaskAttempt.objects.prunable(timezone.now() - dt.timedelta(days=30)).count() == 0
 
 
 class TestTaskAttemptOutcome(TestCase):

--- a/tests/teatree_core/test_managers.py
+++ b/tests/teatree_core/test_managers.py
@@ -52,6 +52,15 @@ class TestWorktreeQuerySet(TestCase):
 
         assert list(Worktree.objects.active()) == [active, also_active]
 
+    def test_for_ticket_scopes_to_the_given_ticket(self) -> None:
+        wanted_ticket = Ticket.objects.create(state=Ticket.State.STARTED)
+        other_ticket = Ticket.objects.create(state=Ticket.State.STARTED)
+        mine = Worktree.objects.create(ticket=wanted_ticket, repo_path="/tmp/be", branch="mine")
+        also_mine = Worktree.objects.create(ticket=wanted_ticket, repo_path="/tmp/fe", branch="also")
+        Worktree.objects.create(ticket=other_ticket, repo_path="/tmp/other", branch="other")
+
+        assert list(Worktree.objects.for_ticket(wanted_ticket).order_by("pk")) == [mine, also_mine]
+
 
 class TestIncomingEventQuerySet(TestCase):
     def _slack(self, *, channel: str, thread_ref: str, key: str) -> IncomingEvent:
@@ -93,6 +102,37 @@ class TestIncomingEventQuerySet(TestCase):
         self._slack(channel="D1", thread_ref="1700000000.0001", key="slack:a")
 
         assert IncomingEvent.objects.active_dm_thread(channel="") == ""
+
+    def _event(
+        self, *, key: str, processed: bool = False, dead: bool = False, retry_ahead: bool = False
+    ) -> IncomingEvent:
+        now = timezone.now()
+        return IncomingEvent.objects.create(
+            source=IncomingEvent.Source.SLACK,
+            idempotency_key=key,
+            received_at=now - timedelta(days=60),
+            processed_at=now if processed else None,
+            dead_lettered_at=now if dead else None,
+            next_retry_at=(now + timedelta(hours=1)) if retry_ahead else None,
+        )
+
+    def test_prunable_is_the_settled_set_processed_or_dead_lettered(self) -> None:
+        processed = self._event(key="k-proc", processed=True)
+        dead = self._event(key="k-dead", dead=True)
+        self._event(key="k-inflight")
+
+        prunable = IncomingEvent.objects.prunable(timezone.now() - timedelta(days=30))
+
+        assert set(prunable.values_list("pk", flat=True)) == {processed.pk, dead.pk}
+
+    def test_prunable_derives_from_the_unprocessed_boundary_not_its_due_clause(self) -> None:
+        # A backoff-retry event is unsettled but NOT due, so it is absent from BOTH
+        # unprocessed(now) and prunable(). Were prunable defined as the naive complement
+        # of unprocessed(now) it would wrongly prune this in-flight, backing-off row.
+        backoff = self._event(key="k-backoff", retry_ahead=True)
+
+        assert backoff not in IncomingEvent.objects.unprocessed()
+        assert backoff not in IncomingEvent.objects.prunable(timezone.now() - timedelta(days=30))
 
 
 class TestSessionQuerySet(TestCase):

--- a/tests/teatree_core/test_retention.py
+++ b/tests/teatree_core/test_retention.py
@@ -15,7 +15,7 @@ from django.utils import timezone
 from teatree.config.settings import UserSettings
 from teatree.core.models import IncomingEvent, Session, Task, TaskAttempt, Ticket
 from teatree.core.models.usage_window_state import LIMIT_PARKED_PREFIX
-from teatree.core.retention import apply_retention, incoming_events_prunable, plan_retention, task_attempts_prunable
+from teatree.core.retention import apply_retention, plan_retention
 
 _OLD = timezone.now() - dt.timedelta(days=60)
 _RECENT = timezone.now() - dt.timedelta(days=2)
@@ -56,51 +56,51 @@ def _event(
 class TaskAttemptPrunableGuardTestCase(TestCase):
     def test_old_terminal_owned_attempt_is_prunable(self) -> None:
         attempt = _attempt()
-        prunable = task_attempts_prunable(timezone.now() - dt.timedelta(days=30))
+        prunable = TaskAttempt.objects.prunable(timezone.now() - dt.timedelta(days=30))
         assert list(prunable.values_list("pk", flat=True)) == [attempt.pk]
 
     def test_never_prunes_attempt_of_non_terminal_ticket(self) -> None:
         # The critical guard: a live ticket's attempt must survive even when old
         # and its task is terminal — deleting it drops history a live ticket needs.
         _attempt(ticket_state=Ticket.State.STARTED, task_status=Task.Status.COMPLETED)
-        prunable = task_attempts_prunable(timezone.now() - dt.timedelta(days=30))
+        prunable = TaskAttempt.objects.prunable(timezone.now() - dt.timedelta(days=30))
         assert prunable.count() == 0
 
     def test_never_prunes_attempt_of_non_terminal_task(self) -> None:
         _attempt(ticket_state=Ticket.State.MERGED, task_status=Task.Status.PENDING)
-        prunable = task_attempts_prunable(timezone.now() - dt.timedelta(days=30))
+        prunable = TaskAttempt.objects.prunable(timezone.now() - dt.timedelta(days=30))
         assert prunable.count() == 0
 
     def test_never_prunes_attempt_within_window(self) -> None:
         _attempt(started_at=_RECENT)
-        prunable = task_attempts_prunable(timezone.now() - dt.timedelta(days=30))
+        prunable = TaskAttempt.objects.prunable(timezone.now() - dt.timedelta(days=30))
         assert prunable.count() == 0
 
     def test_shipped_ticket_is_not_prunable(self) -> None:
         # SHIPPED is excluded on purpose — its PR is still open and may re-work.
         _attempt(ticket_state=Ticket.State.SHIPPED)
-        assert task_attempts_prunable(timezone.now() - dt.timedelta(days=30)).count() == 0
+        assert TaskAttempt.objects.prunable(timezone.now() - dt.timedelta(days=30)).count() == 0
 
 
 class IncomingEventPrunableGuardTestCase(TestCase):
     def test_old_processed_event_is_prunable(self) -> None:
         event = _event(idempotency_key="k-processed")
-        prunable = incoming_events_prunable(timezone.now() - dt.timedelta(days=30))
+        prunable = IncomingEvent.objects.prunable(timezone.now() - dt.timedelta(days=30))
         assert list(prunable.values_list("pk", flat=True)) == [event.pk]
 
     def test_old_dead_lettered_event_is_prunable(self) -> None:
         event = _event(idempotency_key="k-dead", processed=False, dead_lettered=True)
-        prunable = incoming_events_prunable(timezone.now() - dt.timedelta(days=30))
+        prunable = IncomingEvent.objects.prunable(timezone.now() - dt.timedelta(days=30))
         assert list(prunable.values_list("pk", flat=True)) == [event.pk]
 
     def test_never_prunes_old_unprocessed_event(self) -> None:
         # An un-processed, non-dead-lettered event is still in-flight — never pruned.
         _event(idempotency_key="k-inflight", processed=False, dead_lettered=False)
-        assert incoming_events_prunable(timezone.now() - dt.timedelta(days=30)).count() == 0
+        assert IncomingEvent.objects.prunable(timezone.now() - dt.timedelta(days=30)).count() == 0
 
     def test_never_prunes_processed_event_within_window(self) -> None:
         _event(idempotency_key="k-recent", received_at=_RECENT)
-        assert incoming_events_prunable(timezone.now() - dt.timedelta(days=30)).count() == 0
+        assert IncomingEvent.objects.prunable(timezone.now() - dt.timedelta(days=30)).count() == 0
 
 
 class PlanRetentionTestCase(TestCase):


### PR DESCRIPTION
## What

- Add `WorktreeQuerySet.for_ticket(ticket)` and route the 19 clear
  ticket-scoped `Worktree.objects.filter(ticket=...)` call sites through it
  (workspace/e2e/reconcile/provision/sync/agents/mcp). Multi-field filters
  (`repo_path`/`branch`) are left inline.
- Move the retention safety predicates off `retention.py` module functions
  onto their querysets: `task_attempts_prunable` → `TaskAttemptQuerySet.prunable`,
  `incoming_events_prunable` → `IncomingEventQuerySet.prunable`. `plan_retention`
  / `apply_retention` and the `retention prune` command now resolve the row set
  through the manager methods.
- Define the settled/in-flight boundary **once** as `_UNSETTLED` in
  `managers.py`: `unprocessed()` filters it in (plus the due clause), `prunable()`
  excludes it (the exact settled complement).

## Why

- Django convention: queryset logic belongs on the manager, not inlined at call
  sites or in a module function beside a model that already has a manager.
- The settled boundary was defined independently in two places — `unprocessed()`'s
  filter and `incoming_events_prunable`'s hand-written logical complement — so an
  edit to one could silently drift from the other. Deriving both from one `Q`
  gives the boundary a single home. `prunable()` **excludes** the boundary rather
  than negating `unprocessed()`, which preserves the exact #3693/#3713 semantics:
  a not-yet-due backoff row is still in-flight and is never pruned.

Pure refactor, no semantics change. The retention prune tests from #3693/#3713
stay green; a new derived-complement test proves the backoff row is excluded from
both `unprocessed()` and `prunable()` (and goes RED under a naive-complement
implementation, while the pre-existing retention tests do not — confirming the new
test adds real coverage). Flat-core pin stays 101 (methods added to existing
`managers.py` / `task_attempt.py`, no new root leaf).

## Architecture pre-check

1. **BLUEPRINT § alignment** — §4 Domain Models (manager/queryset conventions);
   no contract change.
2. **FSM phase boundaries** — n/a, no `Ticket`/`Worktree` transition touched.
3. **Extension-point contracts** — n/a, no `OverlayBase`/scanner/Protocol surface.
4. **Component boundaries** — queryset logic on `core/managers.py` +
   `core/models/task_attempt.py`; retention module stays coordination-only.
5. **Dependency direction** — `task_attempt.py` gains a top-level `Ticket` import
   (models→models, no cycle: `ticket` imports `task` only under `TYPE_CHECKING`);
   `retention.py` drops its `Q`/`Ticket`/`Task` imports. `tach` passed.
6. **Test surface** — `for_ticket` manager test; derived-complement retention test
   (backoff row excluded from both querysets); TaskAttempt.prunable double-guard
   test; the #3693/#3713 retention suite retargeted onto the manager methods.
7. **Resilience invariants** — n/a, no external write; read-only queryset builders.
8. **Identity/key normalization** — n/a.
9. **Behavior preservation** — the two removed module functions are replaced by
   byte-equivalent queryset methods; `prunable` excludes `_UNSETTLED` == the old
   `Q(processed__isnull=False) | Q(dead_lettered__isnull=False)`. No must-block
   test inverted.
10. **Removability / harness-vs-data** — methods are self-contained; reverting is
    a local change. Logic (not data) — correct home is the manager.
