### PR TITLE
chore(agents): switch frontier tier + cost recognition to claude-opus-5

### DIFF
--- a/src/teatree/agents/harness.py
+++ b/src/teatree/agents/harness.py
@@ -267,7 +267,7 @@ class PydanticAiHarness:
             return resolve_native_anthropic_model(options)
         # Normalise the resolved id to what the configured endpoint actually serves:
         # ``options.model`` is a teatree-abstract-tier default in Claude DASH-form
-        # (``claude-opus-4-8``) an OpenAI-compatible provider does NOT carry, so it maps
+        # (``claude-opus-5``) an OpenAI-compatible provider does NOT carry, so it maps
         # to the configured ``openai_compatible_model``; an explicit provider-native pin
         # passes through.
         model_name = resolve_pydantic_ai_model(options.model, configured_model=self._backend.model)

--- a/src/teatree/agents/model_tiering.py
+++ b/src/teatree/agents/model_tiering.py
@@ -30,9 +30,9 @@ spawns emit no effort and inherit the SDK default.
 
 **Harness-scoped model + effort ([#2885](https://github.com/souliane/teatree/issues/2885)).**
 :data:`TIER_MODELS` is the ``claude_sdk`` catalog — Claude ids in DASH-form
-(``claude-opus-4-8``). The ``pydantic_ai`` harness's OpenAI-compatible provider does
+(``claude-opus-5``). The ``pydantic_ai`` harness's OpenAI-compatible provider does
 NOT carry those dash-form ids (those serve provider-prefixed ids —
-``anthropic/claude-opus-4.8``, the open-source pool, and named router handles), so its
+``anthropic/claude-opus-5``, the open-source pool, and named router handles), so its
 catalog is the SEPARATE :data:`PYDANTIC_AI_TIER_MODELS` (all tiers collapsing to
 one router handle; the router's own bandit does the mundane-vs-hard tiering).
 :func:`resolve_pydantic_ai_model` is the boundary that normalises a resolved
@@ -76,7 +76,7 @@ from teatree.core.cost import FAMILY_TO_TIER, PRICE_TABLE, tier_of_model, tier_r
 # (merged OVER this default), so adopting a new model is one edit here or one
 # DB row — no scenario, test, or dispatch edit.
 TIER_MODELS: dict[str, str] = {
-    "frontier": "claude-opus-4-8",
+    "frontier": "claude-opus-5",
     "balanced": "claude-sonnet-5",
     "cheap": "claude-haiku-4-5",
 }
@@ -84,7 +84,7 @@ TIER_MODELS: dict[str, str] = {
 # The ``pydantic_ai`` parallel of :data:`TIER_MODELS`. The ``claude_sdk`` harness
 # serves the Claude dash-form ids above; the ``pydantic_ai`` harness serves an
 # OpenAI-compatible provider's PROVIDER-PREFIXED catalog, so its tier map is
-# SEPARATE — :data:`TIER_MODELS`'s dash-form ids (``claude-opus-4-8``) do not exist
+# SEPARATE — :data:`TIER_MODELS`'s dash-form ids (``claude-opus-5``) do not exist
 # there, so trusting them here would send an unresolvable id. This shipped default
 # is EMPTY: teatree carries no opinion about a third party's catalog. The operator
 # supplies the id through the generic ``openai_compatible_model`` setting (the
@@ -310,9 +310,9 @@ def resolve_pydantic_ai_model(model_name: str | None, *, configured_model: str |
     """Normalise a resolved model id for the ``pydantic_ai`` (OpenAI-compatible) harness.
 
     THE dash-form id normalisation. teatree's abstract tiers resolve (via
-    :data:`TIER_MODELS`) to Claude ids in DASH-form (``claude-opus-4-8``) that an
+    :data:`TIER_MODELS`) to Claude ids in DASH-form (``claude-opus-5``) that an
     OpenAI-compatible provider's catalog does NOT carry — those serve
-    PROVIDER-PREFIXED ids (``anthropic/claude-opus-4.8``, ``vendor/some-model``). So a
+    PROVIDER-PREFIXED ids (``anthropic/claude-opus-5``, ``vendor/some-model``). So a
     teatree-native id (no provider ``/`` prefix — the :data:`TIER_MODELS` default
     form, or ``None``) is normalised UP to the configured id for its abstract tier
     (:func:`_resolve_pydantic_ai_tier`). An explicit provider-native pin (ANY
@@ -496,7 +496,7 @@ def model_supports_thinking(model: str | None) -> bool:
     """Whether *model* accepts an explicit adaptive-thinking pin — fail-SAFE.
 
     Production spawns set ``thinking={"type": "adaptive"}`` EXPLICITLY so the
-    Opus-4.8 reasoning phases deterministically think — Opus 4.8 runs WITHOUT
+    frontier Opus reasoning phases deterministically think — Opus runs WITHOUT
     thinking when the option is omitted (unlike Sonnet 5, which defaults to
     adaptive). The cheap/Haiku tier rejects the ``thinking`` / ``effort`` levers,
     so this GUARD returns ``False`` for a Haiku model (matched on the tier via

--- a/tests/teatree_agents/test_model_tiering.py
+++ b/tests/teatree_agents/test_model_tiering.py
@@ -71,6 +71,10 @@ class TestTierConstantIsSingleSource:
     def test_three_named_tiers(self) -> None:
         assert set(TIER_MODELS) == {"frontier", "balanced", "cheap"}
 
+    def test_frontier_tier_is_opus_5(self) -> None:
+        assert TIER_MODELS["frontier"] == "claude-opus-5"
+        assert resolve_tier("frontier") == "claude-opus-5"
+
     def test_resolve_tier_reads_the_constant(self) -> None:
         for tier, model in TIER_MODELS.items():
             assert resolve_tier(tier) == model

--- a/tests/teatree_core/test_cost.py
+++ b/tests/teatree_core/test_cost.py
@@ -73,6 +73,16 @@ class TestTierResolution:
         assert price_for_model("claude-sonnet-5").input_per_mtok == pytest.approx(3.0)
         assert price_for_model("claude-sonnet-5").output_per_mtok == pytest.approx(15.0)
 
+    def test_opus_5_maps_to_opus_tier_and_price(self) -> None:
+        # The frontier tier's model is now Opus 5; the substring-keyed lookup
+        # resolves it to the ``opus`` tier (same $5/$25 sticker as the prior Opus
+        # frontier entry) with no new PRICE_TABLE entry, and NOT to the unpriced
+        # bucket.
+        assert tier_of_model("claude-opus-5") == "opus"
+        assert price_for_model("claude-opus-5").input_per_mtok == pytest.approx(5.0)
+        assert price_for_model("claude-opus-5").output_per_mtok == pytest.approx(25.0)
+        assert tier_rank("claude-opus-5") == tier_rank("frontier")
+
     def test_none_falls_back_to_conservative_reasoning_tier(self) -> None:
         # A ``None`` model inherited the user's own (uncaptured) default — priced
         # conservatively at the reasoning tier, NOT the unpriced bucket.
@@ -261,6 +271,17 @@ class TestCostBreakdown:
         assert breakdown.attempts == 3
         assert breakdown.per_tier_usd["opus"] == pytest.approx(3.0)
         assert breakdown.per_tier_usd["sonnet"] == pytest.approx(0.5)
+
+    def test_opus_5_usage_record_costs_to_the_opus_tier(self) -> None:
+        # A dated opus-5 usage record buckets under the ``opus`` tier and prices
+        # from the price table — it never returns None nor crashes on the
+        # frontier-generation id.
+        usage = AttemptUsage("claude-opus-5", None, 1_000_000, 1_000_000, 0, 0)
+        breakdown = CostBreakdown.from_usages([usage])
+        # 1M input @ $5 + 1M output @ $25 = $30 at the opus rate.
+        assert breakdown.total_usd == pytest.approx(30.0)
+        assert breakdown.per_tier_usd == {"opus": pytest.approx(30.0)}
+        assert UNPRICED_TIER not in breakdown.per_tier_usd
 
     def test_empty_is_zero(self) -> None:
         breakdown = CostBreakdown.from_usages([])


### PR DESCRIPTION
## What

Switch teatree's **FRONTIER** model tier and cost recognition from `claude-opus-4-8` to `claude-opus-5`.

- `agents/model_tiering.TIER_MODELS["frontier"]` → `"claude-opus-5"`. Every frontier-pinned FSM phase and eval scenario resolves to Opus 5 through the existing tier seam — `evals/presets/baseline.yaml` pins tier NAMES (`frontier`/`balanced`/`cheap`), so a frontier scenario now resolves to `claude-opus-5` with no pin edit.
- **Cost recognition already flows** for the new id: `core/cost.py` keys `tier_of_model` / `FAMILY_TO_TIER` / `tier_rank` on the `"opus"` substring, so `claude-opus-5` buckets under the `opus` tier and the `frontier` family at the prior Opus `$5/$25` price basis — no new `PRICE_TABLE` entry, never the unpriced bucket, never `None`. `claude-opus-4-8` stays recognized for historical usage records.
- Refreshed the current-state docstrings/comments that used `claude-opus-4-8` as the frontier dash-form example (`model_tiering.py`, `harness.py`). Left the `cost.py` historical usage-record parsing examples (`claude-opus-4-8[1m]`) intact so old records still parse.
- Tests: pin `frontier` → `claude-opus-5`, and assert an opus-5 usage record costs out to the `opus` tier (not `None` / no crash).

## Why

Opus 5 shipped (model id `claude-opus-5`) and is the new default (owner directive, 2026-07-25). The host `~/.claude/settings.json` `model` was switched separately; this is the teatree-internal side.

## Scope

Strictly the frontier tier switch + cost recognition. The eval-lane concrete pins (`eval/transcript.py` `_SHORT_ALIAS_TO_BASE`, the benchmark `--models` help examples) are a separate coordinated generation-bump and are intentionally left untouched.

## Open questions & assumptions

- Opus 5 per-token pricing is assumed equal to the prior Opus frontier basis (`$5` input / `$25` output) — recognition + correct tier/family mapping is the must-have; confirm exact Opus 5 sticker if it differs.

## Architecture pre-check

Tactical model-id switch + cost recognition — no new module, no FSM transition, no extension-point/Protocol change, no dependency edge. Test surface: `tests/teatree_agents/test_model_tiering.py::test_frontier_tier_is_opus_5`, `tests/teatree_core/test_cost.py::test_opus_5_maps_to_opus_tier_and_price` + `::test_opus_5_usage_record_costs_to_the_opus_tier`.
