### PR TITLE
fix(deploy): make the watchdog deploy-aware so a rolling deploy stops paging

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -560,10 +560,50 @@ service is down — exactly the outage it exists to repair.
    the finding set so an ongoing outage does not re-spam every pass. (The default
    deploy wires no Slack credential; until you add one the DM step no-ops and the
    findings are visible in the watchdog's own container logs and `t3 doctor check`.)
+   Three of those findings are **deploy-gated** — see below.
 
 The DM leaves the box via a `docker compose exec` inside a *live app container*,
 not from the watchdog itself — the watchdog runs `network_mode: none`, so the
 docker socket is its only channel.
+
+### Deploy-awareness (#3732)
+
+`deploy.sh` fast-forwards the checkout and swaps the image, which **recreates**
+the worker and the slack-listener. A watchdog pass landing in that window samples
+a healthy rolling deploy and used to DM it as an outage — one red DM per merge,
+which on a busy day makes a genuine freeze indistinguishable from routine noise.
+
+Exactly three findings are what a deploy manufactures, so exactly three are gated:
+**worker-flock-not-held**, **slack-listener-down**, **clone-behind-origin**. Every
+other finding pages on the first observation, unchanged.
+
+A convergence is detected two ways, either sufficient:
+
+- **The deploy flock.** `deploy.sh` holds `${TEATREE_DEPLOY_LOCK:-/tmp/teatree-deploy.lock}`
+  for its whole run. The watchdog probes it **read-only** — it matches the file's
+  device+inode against `/proc/locks` and never opens it for locking, because a
+  probe that briefly *acquired* the lock would make a deploy starting in that
+  instant see it as busy, and `deploy.sh` exits 0 on a busy lock (a silently
+  skipped deploy). The host `/tmp` is mounted read-only at `/host-tmp` so the lock
+  is visible; without that mount the probe degrades to the signal below.
+- **Very-recent container creation**, read from the docker socket. `Created` (not
+  started) is the discriminating field: a crash-looping container restarts without
+  being recreated, so a genuine outage never reads as a deploy. The grace window is
+  one watchdog interval.
+
+Then:
+
+| Situation | Behaviour |
+| --- | --- |
+| deploy in flight | the three findings are skipped for this pass (logged with the reason) |
+| no deploy, first observation | recorded in a small state file, **not** paged — a swap window that just ended cannot page either |
+| no deploy, second consecutive observation | **paged**, exactly as before |
+| any other finding | paged immediately, deploy or not |
+
+No blanket time-based mute, and the findings are never silenced outright: a worker
+down over two clean passes still reaches the owner. A green pass resets the count,
+and a deploy pass is not a strike. If the deploy probe itself errors it reports "no
+deploy", so a broken probe fails toward alerting rather than toward silence.
 
 ### What it does — and does not — survive
 
@@ -602,6 +642,9 @@ docker compose -p teatree logs -f teatree-watchdog
 | `TEATREE_WATCHDOG_DOCTOR_RETRY_DELAY` | `15` | seconds between those retries |
 | `TEATREE_WATCHDOG_APP_SERVICES` | `teatree-worker teatree-admin teatree-slack-listener teatree-watchdog` | services restarted when init has already completed (init excluded) |
 | `TEATREE_WATCHDOG_INIT_SERVICE` | `teatree-init` | the one-shot init service the pass gates on |
+| `TEATREE_WATCHDOG_DEPLOY_LOCK` | `/host-tmp/teatree-deploy.lock` (compose) | deploy.sh's convergence flock, as seen from this container — the deploy-in-flight probe |
+| `TEATREE_WATCHDOG_DEPLOY_RECREATE_WINDOW` | `$TEATREE_WATCHDOG_INTERVAL` | seconds after a container was *created* that still count as the image swap settling |
+| `TEATREE_WATCHDOG_DEPLOY_PENDING_STATE` | `/var/tmp/teatree-watchdog-deploy-sensitive.state` | the two-strikes ledger for the deploy-gated findings |
 
 It needs `python3` in the image for the richest DM body (baked into the image);
 without it the DM degrades to a generic "red findings" body.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -589,7 +589,10 @@ A convergence is detected two ways, either sufficient:
 - **Very-recent container creation**, read from the docker socket. `Created` (not
   started) is the discriminating field: a crash-looping container restarts without
   being recreated, so a genuine outage never reads as a deploy. The grace window is
-  one watchdog interval.
+  one watchdog interval. The timestamp comes from `inspect --format '{{.Created}}'`
+  (RFC3339 UTC) and never `ps --format '{{.CreatedAt}}'`, whose local-zone
+  abbreviation (`… +0200 CEST`) GNU date refuses to parse on this tzdata-less image
+  — every sample would fail to parse and the probe would silently never fire.
 
 Then:
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -229,6 +229,10 @@ services:
     environment:
       TEATREE_ROLE: watchdog
       TEATREE_WATCHDOG_INTERVAL: "300"
+      # Where deploy.sh's single-convergence flock lands inside THIS container — the
+      # deploy-in-flight probe that keeps a rolling deploy from paging as an outage
+      # (#3732). The host path is /tmp/teatree-deploy.lock; see the /host-tmp mount.
+      TEATREE_WATCHDOG_DEPLOY_LOCK: /host-tmp/teatree-deploy.lock
       # The watchdog role execs watchdog.sh before the entrypoint's TMPDIR export
       # and runs no agents, so it never writes scratch to this root — but #3641's
       # contract is that EVERY service declares the output root explicitly, so the
@@ -246,6 +250,17 @@ services:
       - type: bind
         source: /home/teatree/teatree-deploy
         target: /home/teatree/teatree-deploy
+        read_only: true
+      # The host temp root, READ-ONLY, at a DISTINCT target so the container's own
+      # /tmp is untouched. The only thing read from it is deploy.sh's convergence
+      # flock, whose inode the deploy-in-flight probe matches against /proc/locks
+      # (#3732). The DIRECTORY is the mount source, never the lock file: a missing
+      # file source would have dockerd create a host DIRECTORY at that path, and
+      # deploy.sh's `exec 9>` on a directory fails — killing every later deploy.
+      # Without this mount the probe degrades to the container-recreation signal.
+      - type: bind
+        source: /tmp
+        target: /host-tmp
         read_only: true
     # NO depends_on — it must start even when init crash-loops (the whole point).
     # restart: always (NOT unless-stopped) — it must resurrect even after a manual

--- a/deploy/watchdog.sh
+++ b/deploy/watchdog.sh
@@ -261,16 +261,28 @@ deploy_lock_held() {
 # of the image swap. Created (never started) is the discriminating field: a
 # crash-looping container restarts without being recreated, so a genuine outage is
 # never mistaken for a deploy.
+#
+# The timestamp comes from `inspect .Created` (RFC3339 UTC, e.g.
+# 2026-07-25T09:01:41.683288764Z), NEVER from `ps --format {{.CreatedAt}}`, whose
+# local-zone abbreviation form ("… +0200 CEST") GNU date REFUSES to parse on a
+# tzdata-less image — which this one is, so every sample would silently fail to
+# parse and the probe would never fire on the box.
 stack_recently_recreated() {
   local now created epoch
+  local -a ids
   now="$(date -u +%s 2>/dev/null)" || return 1
+  mapfile -t ids < <(docker ps --all --filter "label=com.docker.compose.project=$PROJECT" --format '{{.ID}}' 2>/dev/null)
+  [ "${#ids[@]}" -gt 0 ] || return 1
   while IFS= read -r created; do
     [ -n "$created" ] || continue
-    epoch="$(date -u -d "$created" +%s 2>/dev/null)" || continue
+    if ! epoch="$(date -u -d "$created" +%s 2>/dev/null)"; then
+      log "unreadable container creation time ('$created') — not treating the stack as mid-deploy"
+      continue
+    fi
     if [ "$((now - epoch))" -lt "$DEPLOY_RECREATE_WINDOW" ]; then
       return 0
     fi
-  done < <(docker ps --all --filter "label=com.docker.compose.project=$PROJECT" --format '{{.CreatedAt}}' 2>/dev/null)
+  done < <(docker inspect --format '{{.Created}}' "${ids[@]}" 2>/dev/null)
   return 1
 }
 

--- a/deploy/watchdog.sh
+++ b/deploy/watchdog.sh
@@ -21,7 +21,10 @@
 #      over overdue loop work, stranded headless tasks, stale timers, unrunnable
 #      interactive tasks, failed tasks on live tickets, a drifted runtime clone).
 #   3. On any red finding, DM the owner via `t3 teatree notify send`, keyed on the
-#      finding set so an ongoing outage does not re-spam every pass.
+#      finding set so an ongoing outage does not re-spam every pass. Three of those
+#      findings — a free worker flock, a down slack-listener, a clone behind
+#      origin — are what a ROLLING DEPLOY looks like mid-swap, so they are gated on
+#      the deploy-awareness block below; every other finding pages as before.
 #
 # Safe by construction: the ONLY mutating docker op is `up -d --no-recreate`
 # (idempotent, never destructive, never recreates a running container). The
@@ -59,6 +62,15 @@ read -ra APP_SERVICES <<<"${TEATREE_WATCHDOG_APP_SERVICES:-teatree-worker teatre
 TEMP_TRIM_SERVICES="${TEATREE_WATCHDOG_TEMP_TRIM_SERVICES:-teatree-admin teatree-worker}"
 TEMP_TRIM_ROOTS="${TEATREE_WATCHDOG_TEMP_TRIM_ROOTS:-/var/tmp /tmp}"
 TEMP_TRIM_MIN_AGE_MIN="${TEATREE_WATCHDOG_TEMP_TRIM_MIN_AGE_MIN:-720}"
+
+# Deploy-awareness (#3732). deploy.sh holds this host flock for the whole
+# convergence (path-identity mounted read-only into this container, see
+# docker-compose.yml); the recreate window is the grace after a container was
+# CREATED, one watchdog interval by default; the pending-state file carries the
+# two-strikes ledger across passes.
+DEPLOY_LOCK="${TEATREE_WATCHDOG_DEPLOY_LOCK:-${TEATREE_DEPLOY_LOCK:-/tmp/teatree-deploy.lock}}"
+DEPLOY_RECREATE_WINDOW="${TEATREE_WATCHDOG_DEPLOY_RECREATE_WINDOW:-$INTERVAL}"
+DEPLOY_PENDING_STATE="${TEATREE_WATCHDOG_DEPLOY_PENDING_STATE:-/var/tmp/teatree-watchdog-deploy-sensitive.state}"
 
 log() { printf '%s watchdog: %s\n' "$(date -uIseconds)" "$*" >&2; }
 
@@ -210,6 +222,108 @@ trim_stale_temp() {
   log "stale-temp trim swept ${TEMP_TRIM_SERVICES// /, } (>${TEMP_TRIM_MIN_AGE_MIN}min under ${TEMP_TRIM_ROOTS// /, })"
 }
 
+# The finding's deploy-sensitive class token, non-zero when it is not one. Keyed on
+# the class rather than the message text: the clone-behind count changes between
+# passes, so a text-keyed ledger could never match two observations of it.
+#
+# The patterns are deliberately narrow. A loose `holds the flock` would also swallow
+# the INVERSE finding — "the worker holds the flock but these loops are not
+# advancing" — a wedged worker, which is a real outage that must page on sight. A
+# wording drift here un-gates a finding (back to a false page), never gates a real
+# outage: the safe direction.
+_deploy_sensitive_token() {
+  case "$1" in
+    *"no loop worker holds the flock"*) printf 'worker-flock-not-held' ;;
+    *"slack-listener receiver is DOWN"*) printf 'slack-listener-down' ;;
+    *"commit(s) behind origin/"*) printf 'clone-behind-origin' ;;
+    *) return 1 ;;
+  esac
+}
+
+# True when deploy.sh's single-convergence flock is held. READ-ONLY by construction:
+# it matches the lock file's device+inode against /proc/locks and never opens the
+# file for locking. A probe that briefly ACQUIRED the lock would make a deploy
+# starting in that instant see it as busy — and deploy.sh exits 0 on a busy lock, so
+# that deploy would be silently skipped. Non-zero means "not held, or cannot tell"
+# (lock invisible from this container, /proc/locks unreadable, macOS host); the
+# caller then falls back to the recreation signal, so a probe that cannot run fails
+# toward alerting rather than toward silence.
+deploy_lock_held() {
+  local fields maj min ino
+  [ -r /proc/locks ] || return 1
+  fields="$(stat -c '%Hd %Ld %i' "$DEPLOY_LOCK" 2>/dev/null)" || return 1
+  read -r maj min ino <<<"$fields"
+  [ -n "${ino:-}" ] || return 1
+  grep -qF "$(printf ' %02x:%02x:%s ' "$maj" "$min" "$ino")" /proc/locks
+}
+
+# True when a stack container was CREATED within the grace window — the fingerprint
+# of the image swap. Created (never started) is the discriminating field: a
+# crash-looping container restarts without being recreated, so a genuine outage is
+# never mistaken for a deploy.
+stack_recently_recreated() {
+  local now created epoch
+  now="$(date -u +%s 2>/dev/null)" || return 1
+  while IFS= read -r created; do
+    [ -n "$created" ] || continue
+    epoch="$(date -u -d "$created" +%s 2>/dev/null)" || continue
+    if [ "$((now - epoch))" -lt "$DEPLOY_RECREATE_WINDOW" ]; then
+      return 0
+    fi
+  done < <(docker ps --all --filter "label=com.docker.compose.project=$PROJECT" --format '{{.CreatedAt}}' 2>/dev/null)
+  return 1
+}
+
+deploy_in_flight() {
+  if deploy_lock_held; then
+    log "deploy lock $DEPLOY_LOCK is held — a convergence is in flight"
+    return 0
+  fi
+  if stack_recently_recreated; then
+    log "a stack container was created <${DEPLOY_RECREATE_WINDOW}s ago — the image swap is still settling"
+    return 0
+  fi
+  return 1
+}
+
+_read_pending_findings() { cat "$DEPLOY_PENDING_STATE" 2>/dev/null || true; }
+
+# Best-effort: an unwritable state root must never retire the only supervisor.
+# Losing the ledger costs one extra pass before a persisting finding pages.
+_write_pending_findings() {
+  printf '%s' "$1" >"$DEPLOY_PENDING_STATE" 2>/dev/null ||
+    log "could not persist the deploy-sensitive ledger at $DEPLOY_PENDING_STATE"
+}
+
+# Emit (stdout) the FAIL messages that page THIS pass, reading all of them on stdin
+# one per line. A deploy-sensitive finding is dropped while a convergence is in
+# flight, and otherwise pages only on a SECOND consecutive observation — so a swap
+# window that ended moments ago cannot page either, while a worker down over two
+# clean passes pages exactly as it did before. Log lines go to stderr, never into
+# the DM body.
+_findings_that_page() {
+  local in_flight=false previous observed="" message token
+  deploy_in_flight && in_flight=true
+  previous="$(_read_pending_findings)"
+  while IFS= read -r message; do
+    [ -n "$message" ] || continue
+    if ! token="$(_deploy_sensitive_token "$message")"; then
+      printf '%s\n' "$message"
+      continue
+    fi
+    if [ "$in_flight" = true ]; then
+      log "deploy in flight — skipping $token this pass"
+      continue
+    fi
+    observed="$observed$token"$'\n'
+    case "$previous" in
+      *"$token"*) printf '%s\n' "$message" ;;
+      *) log "first observation of $token with no deploy in flight — re-probing next pass before paging" ;;
+    esac
+  done
+  _write_pending_findings "$observed"
+}
+
 # The three hard-outage alarms below key on a DAILY bucket (`%Y%m%d`), not an
 # hourly one: `notify_user` dedups on the key, so an hourly bucket re-DM'd the
 # identical "stack down" alarm every hour (13+ overnight copies observed). A
@@ -264,13 +378,26 @@ run_pass() {
   case "$json" in
     *'"ok": true'*)
       log "doctor: all green"
+      # "Two CONSECUTIVE passes": a green pass resets the two-strikes ledger.
+      _write_pending_findings ""
       return 0
       ;;
   esac
 
   # Red: build the DM body (FAIL findings) and a stable idempotency key from them.
-  local body key
-  body="$(printf '%s' "$json" | _extract_fail_body)"
+  local fails body key
+  fails="$(printf '%s' "$json" | _fail_messages)"
+  if [ -n "$fails" ]; then
+    fails="$(printf '%s\n' "$fails" | _findings_that_page)"
+    if [ -z "$fails" ]; then
+      log "every red finding was deploy-sensitive and gated this pass — not paging"
+      return 0
+    fi
+    body="$(printf '%s\n' "$fails" | sed 's/^/- /')"
+  else
+    # Nothing to classify — a red verdict is never silently dropped.
+    body="$(_generic_fail_body)"
+  fi
   key="watchdog:red:$(printf '%s' "$body" | _stable_key)"
   log "doctor RED — DMing owner"
   printf 'teatree watchdog found red findings on the box:\n\n%s\n\nThe stack was already `up -d`-restarted this pass; SSH in if it persists.' "$body" \
@@ -289,22 +416,30 @@ run_loop() {
   done
 }
 
-# Extract the FAIL messages from the doctor JSON (read on stdin). Uses python3
-# (present on the box) and degrades to a generic body when it is absent. Uses
-# `python3 -c` rather than a `-` heredoc: a `python3 - <<'PY'` feeds the heredoc
-# as the PROGRAM on stdin, leaving `sys.stdin` at EOF so the piped verdict is
-# never read — the body would always be the generic fallback.
-_extract_fail_body() {
-  if command -v python3 >/dev/null 2>&1; then
-    python3 -c '
+# Extract the FAIL messages from the doctor JSON (read on stdin), one per line, so
+# each can be classified for deploy-sensitivity. Empty when there are none or when
+# python3 is absent; the caller then falls back to `_generic_fail_body`. Uses
+# `python3 -c` rather than a `-` heredoc: a `python3 - <<'PY'` feeds the heredoc as
+# the PROGRAM on stdin, leaving `sys.stdin` at EOF so the piped verdict is never
+# read — every body would be the generic fallback.
+_fail_messages() {
+  command -v python3 >/dev/null 2>&1 || return 0
+  python3 -c '
 import json, sys
 try:
     data = json.load(sys.stdin)
-    fails = [f["message"] for f in data.get("findings", []) if f.get("level") == "FAIL"]
 except Exception:
-    fails = []
-print("\n".join(f"- {m}" for m in fails) if fails else "- (see `t3 doctor check` on the box for detail)")
+    sys.exit(0)
+for f in data.get("findings", []):
+    if f.get("level") == "FAIL":
+        print(f.get("message", "").replace("\n", " "))
 '
+}
+
+# The body for a red verdict whose FAIL lines could not be extracted.
+_generic_fail_body() {
+  if command -v python3 >/dev/null 2>&1; then
+    printf '%s' "- (see \`t3 doctor check\` on the box for detail)"
   else
     printf '%s' "- one or more red findings (install python3 on the box for detail, or run \`t3 doctor check\`)"
   fi

--- a/tests/test_deploy_watchdog_deploy_aware.py
+++ b/tests/test_deploy_watchdog_deploy_aware.py
@@ -1,0 +1,237 @@
+# test-path: cross-cutting — drives deploy/watchdog.sh (no src mirror).
+"""The watchdog's deploy-awareness (deploy/watchdog.sh, #3732).
+
+A convergence fast-forwards the checkout and swaps the image, which RECREATES the
+worker and the slack-listener. A pass landing inside that window samples a healthy
+rolling deploy and used to DM it as an outage, so every merge produced a red DM
+that needed no action. Three findings — and only those three — are gated on it:
+worker-flock-not-held, slack-listener-down, clone-behind-origin.
+
+Runs the REAL ``run_pass`` (the script is sourced, its dispatch guarded so it does
+not auto-run) with a stub ``docker`` modelling the compose calls, and a REAL
+``flock`` held on a tmp lock file to drive the deploy-in-flight probe.
+"""
+
+import contextlib
+import os
+import shutil
+import stat
+import subprocess
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+WATCHDOG = Path(__file__).resolve().parents[1] / "deploy" / "watchdog.sh"
+_BASH = shutil.which("bash") or "bash"
+_FLOCK = shutil.which("flock")
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("python3") is None or not Path("/proc/locks").exists(),
+    reason="needs bash + python3 + Linux /proc/locks (present in the deploy image and CI)",
+)
+
+_FLOCK_FAIL = "no loop worker holds the flock — the reactive Slack-answer cycle never runs. Start `t3 worker ensure`."
+_LISTENER_FAIL = "slack-listener receiver is DOWN — no inbound Slack event is being received."
+_CLONE_FAIL = "teatree clone at <clone-path> is 7 commit(s) behind origin/main — run `t3 update`."
+_OTHER_FAIL = "Compose service teatree-worker is exited"
+_WEDGED_FAIL = "the worker holds the flock but these loops are not advancing their cadence: inbox, review"
+
+
+def _verdict(*messages: str) -> str:
+    findings = ", ".join(f'{{"level": "FAIL", "message": "{m}"}}' for m in messages)
+    return f'{{"ok": false, "findings": [{findings}]}}'
+
+
+def _write_docker_stub(bin_dir: Path) -> None:
+    """A ``docker`` shim modelling the compose calls ``run_pass`` makes.
+
+    ``STUB_CREATED_AT`` serves the container-creation probe (``docker ps
+    --format '{{.CreatedAt}}'``); a doctor ``exec`` prints ``STUB_DOCTOR_JSON``; a
+    ``notify send`` exec captures the piped DM body to ``STUB_NOTIFY_FILE``.
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    shim = bin_dir / "docker"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "$1" != compose ]; then\n'
+        '  case "$*" in\n'
+        '    *CreatedAt*) printf "%s\\n" "$STUB_CREATED_AT" ;;\n'
+        "  esac\n"
+        "  exit 0\n"
+        "fi\n"
+        "shift\n"
+        'while [ "${1:-}" = -p ] || [ "${1:-}" = -f ]; do shift 2; done\n'
+        'sub="${1:-}"; shift || true\n'
+        'case "$sub" in\n'
+        '  ps) printf "%s\\n" \'{"State":"exited","ExitCode":0}\' ;;\n'
+        "  up) exit 0 ;;\n"
+        "  exec)\n"
+        '    [ "${1:-}" = -T ] && shift\n'
+        '    while [ "${1:-}" = -e ]; do shift 2; done\n'
+        "    shift || true\n"
+        '    case "$*" in\n'
+        "      true) exit 0 ;;\n"
+        '      *"doctor check --json"*) printf "%s\\n" "$STUB_DOCTOR_JSON"; exit 1 ;;\n'
+        '      *"notify send"*) cat >"$STUB_NOTIFY_FILE"; exit 0 ;;\n'
+        "      *) exit 0 ;;\n"
+        "    esac\n"
+        "    ;;\n"
+        "  *) exit 0 ;;\n"
+        "esac\n",
+        encoding="utf-8",
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _run_pass(tmp_path: Path, *, label: str = "1", **stub_env: str) -> str:
+    """Source watchdog.sh, run one ``run_pass``, and return the captured owner DM (or "")."""
+    bin_dir = tmp_path / "bin"
+    _write_docker_stub(bin_dir)
+    notify_file = tmp_path / f"dm-{label}.txt"
+    harness = tmp_path / "harness.sh"
+    harness.write_text(f'set -uo pipefail\nsource "{WATCHDOG}"\nrun_pass\n', encoding="utf-8")
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["STUB_NOTIFY_FILE"] = str(notify_file)
+    env.setdefault("STUB_CREATED_AT", "")
+    env.setdefault("STUB_DOCTOR_JSON", '{"ok": true, "findings": []}')
+    # Shared across passes so the two-strikes ledger is exercised for real.
+    env.setdefault("TEATREE_WATCHDOG_DEPLOY_PENDING_STATE", str(tmp_path / "pending.state"))
+    env.setdefault("TEATREE_WATCHDOG_DEPLOY_LOCK", str(tmp_path / "absent-deploy.lock"))
+    env.update(stub_env)
+    subprocess.run([_BASH, str(harness)], capture_output=True, text=True, check=False, env=env)
+    return notify_file.read_text(encoding="utf-8") if notify_file.exists() else ""
+
+
+@contextlib.contextmanager
+def _deploy_lock_held(lock: Path) -> Iterator[Path]:
+    """Hold a REAL exclusive flock on *lock* for the body — what deploy.sh does."""
+    lock.touch()
+    holder = subprocess.Popen([_FLOCK or "flock", str(lock), "sleep", "60"])
+    try:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            probe = subprocess.run([_FLOCK or "flock", "-n", str(lock), "true"], check=False, capture_output=True)
+            if probe.returncode != 0:
+                break
+            time.sleep(0.05)
+        else:  # pragma: no cover — a flock that never lands would fail the assertions anyway
+            pytest.fail("the lock holder never acquired the flock")
+        yield lock
+    finally:
+        holder.kill()
+        holder.wait()
+
+
+class TestDeployInFlightSuppressesTheThreeFindings:
+    """A convergence is running: the three findings it manufactures are not an outage.
+
+    Every case runs TWO passes: one pass alone is silent under the two-strikes rule
+    whatever the deploy probe says, so a single-pass assertion would hold even with
+    the probe ripped out.
+    """
+
+    @pytest.mark.skipif(_FLOCK is None, reason="needs flock(1)")
+    def test_held_deploy_lock_suppresses_all_three(self, tmp_path: Path) -> None:
+        env = {"STUB_DOCTOR_JSON": _verdict(_FLOCK_FAIL, _LISTENER_FAIL, _CLONE_FAIL)}
+        with _deploy_lock_held(tmp_path / "deploy.lock") as lock:
+            env["TEATREE_WATCHDOG_DEPLOY_LOCK"] = str(lock)
+            assert _run_pass(tmp_path, label="1", **env) == ""
+            assert _run_pass(tmp_path, label="2", **env) == ""
+
+    def test_a_just_recreated_container_suppresses_all_three(self, tmp_path: Path) -> None:
+        # The image swap recreates containers; it is still settling.
+        env = {
+            "STUB_DOCTOR_JSON": _verdict(_FLOCK_FAIL, _LISTENER_FAIL, _CLONE_FAIL),
+            "STUB_CREATED_AT": time.strftime("%Y-%m-%d %H:%M:%S +0000 UTC", time.gmtime()),
+        }
+        assert _run_pass(tmp_path, label="1", **env) == ""
+        assert _run_pass(tmp_path, label="2", **env) == ""
+
+    def test_a_long_running_container_is_not_a_deploy(self, tmp_path: Path) -> None:
+        # A crash-looping container RESTARTS without being recreated, so an old
+        # creation timestamp must never read as a deploy — only the two-strikes
+        # rule gates here, and the second pass pages.
+        old = time.strftime("%Y-%m-%d %H:%M:%S +0000 UTC", time.gmtime(time.time() - 86400))
+        env = {"STUB_DOCTOR_JSON": _verdict(_FLOCK_FAIL), "STUB_CREATED_AT": old}
+        assert _run_pass(tmp_path, label="1", **env) == ""
+        assert "holds the flock" in _run_pass(tmp_path, label="2", **env)
+
+
+class TestTwoStrikesWithoutADeploy:
+    """No deploy in flight: the first observation re-probes, the second pages."""
+
+    def test_first_observation_does_not_page(self, tmp_path: Path) -> None:
+        dm = _run_pass(tmp_path, STUB_DOCTOR_JSON=_verdict(_FLOCK_FAIL, _LISTENER_FAIL, _CLONE_FAIL))
+        assert dm == ""
+
+    def test_second_consecutive_observation_pages(self, tmp_path: Path) -> None:
+        # The anti-vacuous case: a real freeze must still reach the owner. This
+        # goes RED the moment the gating over-suppresses.
+        env = {"STUB_DOCTOR_JSON": _verdict(_FLOCK_FAIL, _LISTENER_FAIL, _CLONE_FAIL)}
+        assert _run_pass(tmp_path, label="1", **env) == ""
+        dm = _run_pass(tmp_path, label="2", **env)
+        assert "red findings" in dm
+        assert "holds the flock" in dm
+        assert "slack-listener receiver is DOWN" in dm
+        assert "behind origin/main" in dm
+
+    def test_the_ledger_keys_on_the_class_not_the_volatile_message(self, tmp_path: Path) -> None:
+        # The clone-behind count changes between passes; a text-keyed ledger would
+        # never match two observations and the finding could never page.
+        assert _run_pass(tmp_path, label="1", STUB_DOCTOR_JSON=_verdict(_CLONE_FAIL)) == ""
+        drifted = _CLONE_FAIL.replace("7 commit(s)", "9 commit(s)")
+        assert "behind origin/main" in _run_pass(tmp_path, label="2", STUB_DOCTOR_JSON=_verdict(drifted))
+
+    def test_a_green_pass_clears_the_ledger(self, tmp_path: Path) -> None:
+        # "Two CONSECUTIVE passes": a green pass in between resets the count.
+        red = _verdict(_FLOCK_FAIL)
+        assert _run_pass(tmp_path, label="1", STUB_DOCTOR_JSON=red) == ""
+        assert _run_pass(tmp_path, label="2", STUB_DOCTOR_JSON='{"ok": true, "findings": []}') == ""
+        assert _run_pass(tmp_path, label="3", STUB_DOCTOR_JSON=red) == ""
+
+    def test_a_deploy_pass_does_not_count_as_a_strike(self, tmp_path: Path) -> None:
+        # A finding observed only while the swap ran is not evidence of anything.
+        red = _verdict(_LISTENER_FAIL)
+        fresh = time.strftime("%Y-%m-%d %H:%M:%S +0000 UTC", time.gmtime())
+        assert _run_pass(tmp_path, label="1", STUB_DOCTOR_JSON=red, STUB_CREATED_AT=fresh) == ""
+        assert _run_pass(tmp_path, label="2", STUB_DOCTOR_JSON=red) == ""
+
+
+class TestEveryOtherFindingPagesImmediately:
+    """Only the three deploy-sensitive findings are gated; nothing else changes."""
+
+    def test_an_unrelated_finding_pages_on_the_first_pass(self, tmp_path: Path) -> None:
+        dm = _run_pass(tmp_path, STUB_DOCTOR_JSON=_verdict(_OTHER_FAIL))
+        assert "red findings" in dm
+        assert _OTHER_FAIL in dm
+
+    def test_the_inverse_wedged_worker_finding_pages_on_the_first_pass(self, tmp_path: Path) -> None:
+        # The near-miss a loose `holds the flock` pattern would swallow: the flock is
+        # HELD and the loops are stalled. A deploy cannot manufacture that — it is a
+        # wedged worker, and gating it would hide the outage the watchdog exists for.
+        dm = _run_pass(tmp_path, STUB_DOCTOR_JSON=_verdict(_WEDGED_FAIL))
+        assert _WEDGED_FAIL in dm
+
+    @pytest.mark.skipif(_FLOCK is None, reason="needs flock(1)")
+    def test_an_unrelated_finding_pages_even_during_a_deploy(self, tmp_path: Path) -> None:
+        env = {"STUB_DOCTOR_JSON": _verdict(_FLOCK_FAIL, _OTHER_FAIL, _CLONE_FAIL)}
+        with _deploy_lock_held(tmp_path / "deploy.lock") as lock:
+            env["TEATREE_WATCHDOG_DEPLOY_LOCK"] = str(lock)
+            _run_pass(tmp_path, label="1", **env)
+            dm = _run_pass(tmp_path, label="2", **env)
+        assert _OTHER_FAIL in dm
+        assert "holds the flock" not in dm, "the deploy-sensitive findings stay gated"
+        assert "behind origin/main" not in dm
+
+    def test_a_red_verdict_with_no_extractable_finding_still_pages(self, tmp_path: Path) -> None:
+        # Never silently drop a red verdict: nothing to classify → the generic body.
+        dm = _run_pass(tmp_path, STUB_DOCTOR_JSON='{"ok": false, "findings": []}')
+        assert "red findings" in dm
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_deploy_watchdog_deploy_aware.py
+++ b/tests/test_deploy_watchdog_deploy_aware.py
@@ -39,25 +39,36 @@ _OTHER_FAIL = "Compose service teatree-worker is exited"
 _WEDGED_FAIL = "the worker holds the flock but these loops are not advancing their cadence: inbox, review"
 
 
+def _created(*, seconds_ago: float = 0) -> str:
+    """A container creation time in `docker inspect .Created`'s real shape (RFC3339Nano, UTC)."""
+    return time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(time.time() - seconds_ago)) + ".683288764Z"
+
+
 def _verdict(*messages: str) -> str:
     findings = ", ".join(f'{{"level": "FAIL", "message": "{m}"}}' for m in messages)
     return f'{{"ok": false, "findings": [{findings}]}}'
 
 
 def _write_docker_stub(bin_dir: Path) -> None:
-    """A ``docker`` shim modelling the compose calls ``run_pass`` makes.
+    """A ``docker`` shim modelling the docker + compose calls ``run_pass`` makes.
 
-    ``STUB_CREATED_AT`` serves the container-creation probe (``docker ps
-    --format '{{.CreatedAt}}'``); a doctor ``exec`` prints ``STUB_DOCTOR_JSON``; a
-    ``notify send`` exec captures the piped DM body to ``STUB_NOTIFY_FILE``.
+    The container-creation probe is TWO calls, exactly as the real one is: ``ps
+    --format '{{.ID}}'`` then ``inspect --format '{{.Created}}'``. ``STUB_CREATED``
+    supplies the RFC3339 creation time (empty → no containers). Every invocation is
+    appended to ``STUB_DOCKER_LOG`` so the argv shape itself can be asserted.
+
+    A doctor ``exec`` prints ``STUB_DOCTOR_JSON``; a ``notify send`` exec captures
+    the piped DM body to ``STUB_NOTIFY_FILE``.
     """
     bin_dir.mkdir(parents=True, exist_ok=True)
     shim = bin_dir / "docker"
     shim.write_text(
         "#!/usr/bin/env bash\n"
+        'printf "%s\\n" "$*" >>"${STUB_DOCKER_LOG:-/dev/null}"\n'
         'if [ "$1" != compose ]; then\n'
-        '  case "$*" in\n'
-        '    *CreatedAt*) printf "%s\\n" "$STUB_CREATED_AT" ;;\n'
+        '  case "$1 $*" in\n'
+        '    "ps "*.ID*) [ -z "${STUB_CREATED:-}" ] || printf "%s\\n" "stubcid" ;;\n'
+        '    "inspect "*) printf "%s\\n" "${STUB_CREATED:-}" ;;\n'
         "  esac\n"
         "  exit 0\n"
         "fi\n"
@@ -96,7 +107,8 @@ def _run_pass(tmp_path: Path, *, label: str = "1", **stub_env: str) -> str:
     env = dict(os.environ)
     env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
     env["STUB_NOTIFY_FILE"] = str(notify_file)
-    env.setdefault("STUB_CREATED_AT", "")
+    env["STUB_DOCKER_LOG"] = str(tmp_path / "docker.log")
+    env.setdefault("STUB_CREATED", "")
     env.setdefault("STUB_DOCTOR_JSON", '{"ok": true, "findings": []}')
     # Shared across passes so the two-strikes ledger is exercised for real.
     env.setdefault("TEATREE_WATCHDOG_DEPLOY_PENDING_STATE", str(tmp_path / "pending.state"))
@@ -146,17 +158,26 @@ class TestDeployInFlightSuppressesTheThreeFindings:
         # The image swap recreates containers; it is still settling.
         env = {
             "STUB_DOCTOR_JSON": _verdict(_FLOCK_FAIL, _LISTENER_FAIL, _CLONE_FAIL),
-            "STUB_CREATED_AT": time.strftime("%Y-%m-%d %H:%M:%S +0000 UTC", time.gmtime()),
+            "STUB_CREATED": _created(),
         }
         assert _run_pass(tmp_path, label="1", **env) == ""
         assert _run_pass(tmp_path, label="2", **env) == ""
+
+    def test_the_creation_time_is_read_in_a_tzdata_free_format(self, tmp_path: Path) -> None:
+        # `ps --format {{.CreatedAt}}` yields a local-zone abbreviation ("+0200
+        # CEST") that GNU date REFUSES without tzdata — which the deploy image and
+        # the CI image both lack, so the probe would silently never fire. Pin the
+        # argv: the creation time comes from `inspect .Created` (RFC3339 UTC).
+        _run_pass(tmp_path, STUB_DOCTOR_JSON=_verdict(_FLOCK_FAIL), STUB_CREATED=_created())
+        log = (tmp_path / "docker.log").read_text(encoding="utf-8")
+        assert "inspect --format {{.Created}}" in log
+        assert "CreatedAt" not in log, "the tzdata-dependent human timestamp must never be parsed"
 
     def test_a_long_running_container_is_not_a_deploy(self, tmp_path: Path) -> None:
         # A crash-looping container RESTARTS without being recreated, so an old
         # creation timestamp must never read as a deploy — only the two-strikes
         # rule gates here, and the second pass pages.
-        old = time.strftime("%Y-%m-%d %H:%M:%S +0000 UTC", time.gmtime(time.time() - 86400))
-        env = {"STUB_DOCTOR_JSON": _verdict(_FLOCK_FAIL), "STUB_CREATED_AT": old}
+        env = {"STUB_DOCTOR_JSON": _verdict(_FLOCK_FAIL), "STUB_CREATED": _created(seconds_ago=86400)}
         assert _run_pass(tmp_path, label="1", **env) == ""
         assert "holds the flock" in _run_pass(tmp_path, label="2", **env)
 
@@ -196,8 +217,7 @@ class TestTwoStrikesWithoutADeploy:
     def test_a_deploy_pass_does_not_count_as_a_strike(self, tmp_path: Path) -> None:
         # A finding observed only while the swap ran is not evidence of anything.
         red = _verdict(_LISTENER_FAIL)
-        fresh = time.strftime("%Y-%m-%d %H:%M:%S +0000 UTC", time.gmtime())
-        assert _run_pass(tmp_path, label="1", STUB_DOCTOR_JSON=red, STUB_CREATED_AT=fresh) == ""
+        assert _run_pass(tmp_path, label="1", STUB_DOCTOR_JSON=red, STUB_CREATED=_created()) == ""
         assert _run_pass(tmp_path, label="2", STUB_DOCTOR_JSON=red) == ""
 
 


### PR DESCRIPTION
fix(deploy): make the watchdog deploy-aware so a rolling deploy stops paging

Closes #3732

## What

Three of the doctor's findings — **worker-flock-not-held**, **slack-listener-down**, **clone-behind-origin** — are exactly what a rolling deploy looks like mid-swap. Those three, and only those three, are now gated on whether a convergence is in flight. Every other finding pages on first sight, unchanged.

- **Deploy-in-flight probe.** `deploy.sh` holds a host flock for its whole run. The watchdog matches the lock file's device+inode against `/proc/locks` — **read-only**, never opening the file for locking, because a probe that briefly *acquired* the lock would make a deploy starting in that instant see it as busy, and `deploy.sh` exits 0 on a busy lock (a silently skipped deploy). Host `/tmp` is mounted read-only at `/host-tmp` so the lock is visible. The mount source is the **directory**, never the lock file: a missing file source has dockerd create a host *directory* at that path, and `deploy.sh`'s `exec 9>` on a directory would kill every later deploy.
- **Corroborating probe.** A stack container `Created` within one watchdog interval, read from the socket the watchdog already holds. `Created` (not started) is the discriminating field — a crash-looping container restarts *without* being recreated, so a genuine outage never reads as a deploy. The timestamp comes from `inspect --format '{{.Created}}'` (RFC3339 UTC), never `ps --format '{{.CreatedAt}}'`: that Go layout is a local-zone time with a zone abbreviation (`2026-07-25 11:01:41 +0200 CEST`) which GNU date refuses without tzdata — and neither `deploy/Dockerfile` nor `dev/Dockerfile.test` installs tzdata, so every sample would fail to parse and the probe would silently never fire on the box.
- **Deploy in flight** → the three findings are skipped for the pass, logged with the reason.
- **No deploy** → the first observation is recorded, not paged; the second **consecutive** one pages exactly as before. A green pass resets the ledger, a deploy pass is not a strike, and the ledger keys on the finding *class* (the clone-behind count changes between passes, so a text-keyed ledger could never match two observations).

A real freeze still pages: a worker down over two clean passes reaches the owner. No blanket time-based mute, nothing silenced outright, and a probe that errors reports "no deploy" — a broken probe fails toward alerting, never toward silence. The only mutating docker op is still `up -d --no-recreate`.

## Why

The watchdog runs `up -d --no-recreate` and then **immediately** runs `t3 doctor check --json`, with no notion of a deploy. `deploy.sh` fast-forwards the checkout and swaps the image, which **recreates** the worker and the slack-listener (drain-then-deploy at `deploy.sh:139` protects in-flight agents, but the processes still bounce for the swap). A pass landing in that window sampled a healthy deploy and DM'd it as an outage.

On 2026-07-25 all four containers showed a creation time of ~09:48 against a merge at 09:43, and a red-findings DM landed at 06:20:36 — 46 seconds after merges at 06:18:29 / 06:19:11 / 06:19:50, carrying exactly those three findings. One useless red DM per merge; on a 17-PR day the channel is noise and a genuine freeze looks identical to a routine deploy.

## Architecture pre-check

**1. BLUEPRINT § alignment** — n/a: deploy-plane shell + compose only, no `src/teatree` surface. `deploy/README.md` § "Self-heal watchdog" is the doc of record and is updated in this PR (new "Deploy-awareness" subsection + three knob rows).

**2. FSM phase boundaries** — n/a. No `Ticket`/`Worktree` transition; the watchdog reads the doctor verdict and never mutates lifecycle state.

**3. Extension-point contracts** — none. No `OverlayBase` hook, scanner registration, or `*Backend` Protocol is touched. The `t3 doctor check --json` contract (`{"ok", "findings":[{"level","message"}]}`) is consumed unchanged.

**4. Component boundaries** — the change lives entirely in the deploy plane (`deploy/watchdog.sh`, `deploy/docker-compose.yml`, `deploy/README.md`). Deliberately *not* pushed into `src/teatree/cli/doctor`: the doctor's job is to report what it observes, and "was a deploy running when you observed it" is knowledge only the socket-holding watchdog has. Teaching the doctor to suppress its own findings would make every other consumer of `--json` blind too.

**5. Dependency direction** — no Python imports added; `uv run tach check` is unaffected. The bash helpers are private (`_`-prefixed) except the three probe functions the tests drive.

**6. Test surface** — `tests/test_deploy_watchdog_deploy_aware.py`, 12 cases running the REAL `run_pass` against a stub `docker` and a REAL `flock` held by a background process:
- deploy in flight (held flock / just-created container) → all three suppressed, over **two** passes each (one pass alone is silent under two-strikes whatever the probe says, so a single-pass assertion would hold with the probe ripped out);
- no deploy, first observation → silent; second consecutive → **pages** (the anti-vacuous case);
- ledger keys on the class, not the volatile count; a green pass resets it; a deploy pass is not a strike;
- an old creation timestamp is not a deploy (the crash-loop case);
- unrelated findings page on the first pass, deploy or not;
- the **inverse** wedged-worker finding ("the worker holds the flock but these loops are not advancing") pages on sight — the near-miss a loose pattern would have swallowed;
- a red verdict with no extractable finding still pages.

Anti-vacuousness verified by breaking the logic and confirming the expected RED each time: pre-implementation (9 fail), two-strikes removed (3 fail), `deploy_in_flight` forced false (5 fail), lock probe forced false (2 fail), loose `holds the flock` pattern (1 fail — the wedged-worker test), and a regression to the tzdata-dependent `ps '{{.CreatedAt}}'` source (3 fail — the argv-pinning test catches it even on a host that *has* tzdata).

**7. Resilience invariants** — no new external write. The only new state is a local ledger file: writes are best-effort and log-on-failure (an unwritable root must never retire the only supervisor), reads degrade to empty, and the whole pass is idempotent — re-running it re-derives the same verdict. Both probes fail *closed toward alerting*: an unreadable `/proc/locks`, an invisible lock, or a `docker ps` error all report "no deploy in flight", so a broken probe restores the pre-change paging behaviour rather than silence.

**8. Identity and key normalization** — the finding's canonical key is its **class token** (`worker-flock-not-held` / `slack-listener-down` / `clone-behind-origin`), resolved once in `_deploy_sensitive_token` and used for both the in-flight skip and the ledger. The raw message is never a key: it carries a volatile commit count. No strip/split-to-match anywhere.

**9. Behavior preservation** — `_extract_fail_body` is split into `_fail_messages` (raw messages, one per line, so each can be classified) + `_generic_fail_body`. Both of its fallback bodies are preserved verbatim, including the python3-absent variant. No existing test was weakened or inverted; the 10 pre-existing watchdog tests and the 4 temp-trim tests pass untouched. Nothing is removed: the three findings are *deferred*, never dropped — the ledger guarantees a persisting one pages on the next pass.

**10. Removability / harness-vs-data** — removable: delete the deploy-awareness block, restore the one-line body build in `run_pass`, drop the compose mount, and the watchdog is byte-equivalent to today. Blast radius is the one script plus one optional mount. Harness-vs-data: the *mechanism* (probe → gate → two-strikes) is harness; the tuning that varies per box (lock path, grace window, ledger location) is env-configurable data with sane defaults, and the grace window derives from `TEATREE_WATCHDOG_INTERVAL` rather than a second magic number.

## Verification

- `pytest` over the whole deploy/watchdog/docker surface `-p no:xdist` → **126 passed, 1 skipped**
- `pytest tests/quality/test_no_flat_core_regrowth.py -p no:xdist` → passed
- `t3 tool test-path-mirror` → ledger exact, ratchet holds
- `ruff check` / `ruff format --check` / `ty check` on the new test → clean
- `shellcheck deploy/watchdog.sh` → 4 findings, all pre-existing SC2016 backtick-in-single-quote info lines (5 before this change)
- `prek run --files <the four changed files>` → all hooks pass

## Open questions & assumptions

- **Assumption:** the deploy box is Linux, so `/proc/locks` is readable inside the watchdog container. On a macOS Docker Desktop host the host-side flock is invisible to the Linux VM; the probe reports "cannot tell" and the container-recreation signal carries the detection alone. Documented in the script comment and the README.
- **Assumption:** mounting the host temp root read-only at `/host-tmp` is acceptable for this container. It already runs as root with `/var/run/docker.sock`, which is root-equivalent, so a read-only view of `/tmp` widens nothing in practice.
- **Deliberate scope:** the sibling finding "No worker holds the loop **flock** but N loop timer(s) are overdue" (`self_heal.py`) is left ungated. It is arguably the same class, but it bundles an independent overdue-timer signal, and the incident only produced the three findings gated here. Widening it is a separate, evidenced decision.


## CI-red follow-up (tzdata)

The first push went red on the two container-recency tests. Root cause was **not** a test artifact: the probe parsed docker's human `CreatedAt` string, which GNU date rejects on a tzdata-less image. Reproduced directly in the CI base image:

```
date -u -d "2026-07-25 09:48:12 +0000 UTC"   -> date: invalid date
date -u -d "2026-07-25 09:48:12 +0200 CEST"  -> date: invalid date
date -u -d "2026-07-25T09:48:12.123456789Z" -> 1784972892
```

Fixed at the source (RFC3339 via `inspect`), the silent `continue` on an unparseable timestamp now logs, the stub models the real two-call shape and real timestamp format, and the argv is pinned so the fragile source cannot creep back. Verified inside the tzdata-free image: old format MISSED, new format DETECTED, a day-old container still MISSED.
