### PR TITLE
docs(teams): stop asserting the pane layer has a live consumer (#3734)

### DIFF
--- a/src/teatree/cli/teams.py
+++ b/src/teatree/cli/teams.py
@@ -13,6 +13,10 @@ in the ``[teams]`` TOML table is ignored on read). ``status`` reports the
 :func:`teatree.config.get_effective_settings`). The writes go through the ORM, so
 they ensure Django is configured first. Kept top-level (like ``t3 loop``) because
 the switch is overlay-agnostic.
+
+Flipping the row on does not currently produce a teammate pane: the pane-spawn
+half of ``teatree.teams`` has no production caller (#3734), so ``on`` and a
+``status`` that reads on both disclose that rather than implying a live pane.
 """
 
 import typer
@@ -20,6 +24,12 @@ import typer
 ENABLED_KEY = "teams_enabled"
 
 CLASSIC_NOTE = "classic in-session sub-agent mode"
+
+NO_CONSUMER_NOTE = (
+    "note: no teammate pane is spawned — the pane-spawn half has no production "
+    "caller yet; wire-vs-retire is open at "
+    "https://github.com/souliane/teatree/issues/3734"
+)
 
 teams_app = typer.Typer(
     name="teams",
@@ -47,6 +57,7 @@ def on() -> None:
     """Enable agent teams — write the global teams_enabled = true config row."""
     _set_enabled(value=True)
     typer.echo(f"agent teams = on — wrote the {ENABLED_KEY} row to the global config store")
+    typer.echo(NO_CONSUMER_NOTE)
 
 
 @teams_app.command()
@@ -63,5 +74,6 @@ def status() -> None:
 
     if get_effective_settings().teams_enabled:
         typer.echo("agent teams = on")
+        typer.echo(NO_CONSUMER_NOTE)
         return
     typer.echo(f"agent teams = off — {CLASSIC_NOTE}")

--- a/src/teatree/config/settings.py
+++ b/src/teatree/config/settings.py
@@ -281,9 +281,10 @@ class _LoopAndTeamsSettings:
     # #1838 Track-B PR#6 — the inert agent-teams WORK layer. When false (the
     # default, fail-OFF), the team-role registry (`teatree.teams.roles`) is
     # PURE DATA referenced by nothing in the loop/dispatch/claim path: the
-    # WORK-team ships DARK. When flipped on, a LATER PR wires the
-    # `team:<role>` claim namespace + the overlay-seam claim filters into a
-    # pane-backed teammate; this PR adds only the config surface. DB-home
+    # WORK-team ships DARK. Flipping it TRUE spawns no teammate pane either —
+    # the `team:<role>` claim namespace + the overlay-seam claim filters are
+    # built and tested but have no production caller, so this key gates only
+    # the reaper scanner. Wire-vs-retire is open (#3734). DB-home
     # (#1775): resolved from the `ConfigSetting` store (global + overlay rows) +
     # `T3_TEAMS_ENABLED` env; a `[teams]`/`[overlays.<name>]` TOML value is ignored
     # on read. Set via `t3 teams on|off` (the DB-row write path).

--- a/src/teatree/loops/pane_reaper/loop.py
+++ b/src/teatree/loops/pane_reaper/loop.py
@@ -1,9 +1,10 @@
 """Pane-reaper mini-loop — demote idle maker panes past the idle threshold (#1838 PR#7b).
 
-A sibling of :mod:`teatree.loops.idle_stack_reaper`. PR#7a deferred this
-registration to avoid the inertness gate; now that the maker consumer wires
-teams into the live path, the pane reaper registers as a mini-loop. It is ONLY
-active when ``teams_enabled``: :func:`_pane_reaper_scanner` returns ``None`` (so
+A sibling of :mod:`teatree.loops.idle_stack_reaper`. The pane reaper is the ONE
+registered consumer of ``teatree.teams``; the pane-SPAWN half it reaps for has no
+production caller, so nothing ever claims a ``team:*`` slot and this loop reaps
+nothing. Wire-vs-retire is an open owner decision (#3734). It is ONLY active when
+``teams_enabled``: :func:`_pane_reaper_scanner` returns ``None`` (so
 ``build_jobs`` returns ``[]``) while the feature is off, and the scanner itself
 no-ops on a disabled flag — DEFAULT-OFF, byte-identical to today.
 """

--- a/src/teatree/teams/__init__.py
+++ b/src/teatree/teams/__init__.py
@@ -8,12 +8,18 @@ key in the ``team:<role>`` namespace (disjoint from the t3-master / per-loop /
 infra slots), and each maker role a declarative overlay-seam claim filter that
 partitions the backlog (CORE → ``overlay == ""``, OVERLAY → ``overlay != ""``).
 
-This PR ships the registry DARK behind the default-OFF ``[teams] enabled``
-toggle: the module is PURE DATA, imports nothing from ``teatree`` (a foundation
-leaf), and is referenced by NOTHING in the loop / dispatch / claim execution
-path. The pane-spawn helper and the live REVIEWER/maker teammates are deferred
-to later PRs. Nothing here runs when the flag is off; nothing runs when it is
-on either, until a future PR wires a consumer in.
+The registry ships DARK behind the default-OFF ``teams_enabled`` toggle: the
+module is PURE DATA, imports nothing from ``teatree`` (a foundation leaf), and is
+referenced by NOTHING in the loop / dispatch / claim execution path.
+
+**No production caller spawns a teammate pane (#3734).** The whole package is
+built and tested, but the only live-path importer is the idle-pane reaper
+scanner, which consumes four reaper-side symbols. ``claim_maker_pane``,
+``TeammatePane.spawn``, ``build_pane_options``, ``spawn_pane``, the guardrails
+and the role claim filters have zero references outside this package and its
+tests — so ``t3 teams on`` produces no pane, and the reaper reaps nothing because
+nothing claims a ``team:*`` slot. Whether to wire the spawn half in or retire it
+is an open owner decision.
 """
 
 from teatree.teams.roles import TEAM_CLAIM_PREFIX, TeamRole, is_team_claim_slot, team_claim_slot

--- a/tests/teatree_teams/test_inert.py
+++ b/tests/teatree_teams/test_inert.py
@@ -1,14 +1,15 @@
 """Pane-layer wiring fitness — only the sanctioned consumer reaches teams (#1838 PR#7b).
 
-PR#6/#7a shipped the team-role registry + pane machinery DARK. PR#7b is the
-named consumer the Track-B section staged for: it wires teams into the live path
-through exactly ONE module-level seam — ``teatree.loop.scanners.pane_reaper`` (the
-idle-pane reaper scanner the pane-reaper mini-loop dispatches). This AST-level
-import scan pins that the ONLY live-path module reaching ``teatree.teams`` is that
-sanctioned consumer; any OTHER live-path module wiring the registry in turns it
-RED. The maker claim path (``teatree.teams.pane_spawn``) lives INSIDE the teams
-package and is reached via a lazy import from the claim command, so it never adds
-a module-level live-path → teams edge either.
+Exactly ONE live-path module reaches ``teatree.teams``:
+``teatree.loop.scanners.pane_reaper`` (the idle-pane reaper scanner the
+pane-reaper mini-loop dispatches). This AST-level import scan pins that; any
+OTHER live-path module wiring the registry in turns it RED.
+
+The maker claim path (``teatree.teams.pane_spawn``) has NO production caller at
+all — no module-level import, no lazy one. So this scan currently ENFORCES the
+pane-spawn half's dead state: wiring a maker consumer in would turn it red by
+design, and re-specifying ``_SANCTIONED_TEAMS_CONSUMERS`` is part of that work.
+Wire-vs-retire is an open owner decision (#3734).
 """
 
 import ast

--- a/tests/test_cli_teams.py
+++ b/tests/test_cli_teams.py
@@ -75,6 +75,34 @@ class TestTeamsStatus(TestCase):
         assert ConfigSetting.objects.get_effective("teams_enabled") is True
 
 
+class TestOnAndStatusDiscloseTheMissingConsumer(TestCase):
+    # `on` writing the row must not read as "a teammate pane now exists" while the
+    # pane-spawn half has no production caller (#3734).
+    def test_on_states_no_pane_is_spawned_and_points_at_the_issue(self) -> None:
+        result = runner.invoke(teams_app, ["on"])
+        assert result.exit_code == 0
+        assert "no teammate pane is spawned" in result.stdout
+        assert "3734" in result.stdout
+
+    def test_status_on_states_no_pane_is_spawned_and_points_at_the_issue(self) -> None:
+        ConfigSetting.objects.set_value("teams_enabled", value=True)
+        result = runner.invoke(teams_app, ["status"])
+        assert result.exit_code == 0
+        assert "no teammate pane is spawned" in result.stdout
+        assert "3734" in result.stdout
+
+    def test_off_does_not_carry_the_note(self) -> None:
+        result = runner.invoke(teams_app, ["off"])
+        assert result.exit_code == 0
+        assert "no teammate pane is spawned" not in result.stdout
+
+    def test_status_off_does_not_carry_the_note(self) -> None:
+        ConfigSetting.objects.set_value("teams_enabled", value=False)
+        result = runner.invoke(teams_app, ["status"])
+        assert result.exit_code == 0
+        assert "no teammate pane is spawned" not in result.stdout
+
+
 class TestStatusReflectsRoundTrip(TestCase):
     def test_off_then_status_reports_off(self) -> None:
         ConfigSetting.objects.set_value("teams_enabled", value=True)


### PR DESCRIPTION
docs(teams): stop asserting the pane layer has a live consumer (#3734)

## What

Comments only, plus one CLI output/wording change. No feature is deleted, none is wired — that decision is open at [#3734](https://github.com/souliane/teatree/issues/3734).

- `src/teatree/loops/pane_reaper/loop.py` — dropped the claim that a maker consumer wires teams into the live path. It now says the pane reaper is the one registered consumer and that it reaps nothing, because the spawn half has no caller.
- `src/teatree/config/settings.py` — dropped the promise that a later PR wires the `team:<role>` namespace and the claim filters into a pane-backed teammate. It now says flipping the key true spawns no pane and gates only the reaper.
- `tests/teatree_teams/test_inert.py` — dropped the claim that the maker claim path is reached via a lazy import from the claim command. It now records that the AST scan currently *enforces* the dead state, so wiring a consumer in turns it red by design.
- `src/teatree/teams/__init__.py` — a package-seam note recording the same fact.
- `src/teatree/cli/teams.py` — `t3 teams on` and an on-reading `t3 teams status` now print a second line stating that no teammate pane is spawned, with the issue link. `off` and its status branch are untouched.

## Why

The pane layer is fully built (~1.2k lines of `src/`, ~1.5k lines of tests, a CLI group, four settings, a dedicated mini-loop) but nothing in production calls its spawn half. Grepping `src/ hooks/ scripts/ plugins/`, the only importer of `teatree.teams` is `src/teatree/loop/scanners/pane_reaper.py:40-42`, taking four reaper-side symbols. `claim_maker_pane`, `TeammatePane.spawn`, `build_pane_options`, `build_pane_prompt`, `spawn_pane`, `teardown_pane`, `detect_multiplexer`, `assert_pane_claim_allowed`, `live_owner_blocks_pane`, `TeamRole.claim_filter`, `TeamRole.task_claim_filter`, `team_claim_slot` and `is_team_claim_slot` have zero references outside the package and its tests.

So `t3 teams on` produces no teammate pane and the reaper reaps nothing. Three comments said the opposite, and the CLI reported a success an operator would reasonably read as "the feature is now live". `BLUEPRINT.md:260` was already accurate; these edits keep its inert framing.

## Verification

- `uv run pytest tests/teatree_teams/ tests/test_cli_teams.py tests/config/test_teams_display.py -n0` — 132 passed. `test_inert.py` stays green (no live-path import added).
- New CLI-output tests observed RED before the change (2 failed on the missing note, the two off-path guards already green), GREEN after.
- `ruff format` / `ruff check` / `ty check` on the changed files — clean.
- `uv run pytest tests/quality/test_no_flat_core_regrowth.py -n0` — passed. `t3 tool test-path-mirror` — ledger exact.
- CLI-reference and CLI-output-snapshot generators re-run: no diff (the command docstrings are unchanged; the note is runtime output).
- `t3 tool comment-density` — no findings.

## Architecture pre-check

Tactical documentation-honesty change; the ten-check gate does not fire. No module added, no import added, no FSM transition, no Protocol or extension-point touched, no dependency edge. The one behavioural delta is two extra `typer.echo` lines, covered by `tests/test_cli_teams.py::TestOnAndStatusDiscloseTheMissingConsumer`.

## Open questions & assumptions

- Wire vs retire is deliberately left open — that is [#3734](https://github.com/souliane/teatree/issues/3734), hence `Refs`, not `Closes`.
- I left `teams_max_panes` / `teams_idle_minutes`'s comment alone: it already says "referenced by nothing until `teams_enabled` flips on and a consumer lands", which is accurate today.
- I kept the note wording short enough to sit on one output line and pointed it at the issue rather than restating the inventory in the CLI.

Refs #3734
