### PR TITLE
fix(core): close Sessions at their owning task's terminal point

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ records.
 - Tracks visited phases across tasks within a conversation (not FSM-driven)
 - **Fields:** overlay, ticket (FK), visited_phases (JSONField), phase_visits (JSONField), started_at, ended_at, agent_id, repos_modified, repos_tested
 - Quality gates enforce ordering: reviewing requires testing, shipping requires reviewing
+- **Terminal point:** `ended_at` is written by `Session.close()`, driven from the `_close_session_on_terminal_task` `post_save` receiver — a Task reaching COMPLETED/FAILED closes its session once no sibling task on it is still active. `SessionQuerySet.live()` bounds the open-session liveness signal by `session_stale_after_hours` so a crashed agent cannot pin its ticket busy forever
 
 ### TaskAttempt — Execution history (FK → Task)
 

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -64,6 +64,8 @@ graph TD
     teatree.core --> teatree.loop.preset_resolution
     teatree.core.loop_lease_liveness --> teatree.utils
     teatree.core.loop_lease_manager --> teatree.utils
+    teatree.core.managers_session --> teatree.config
+    teatree.core.managers_session --> teatree.core.managers_overlay
     teatree.core.managers --> teatree.config
     teatree.core.managers --> teatree.utils
     teatree.core.managers --> teatree.core.modelkit
@@ -72,6 +74,7 @@ graph TD
     teatree.core.managers --> teatree.core.managers_issue_match
     teatree.core.managers --> teatree.core.managers_overlay
     teatree.core.managers --> teatree.core.managers_phase_cadence
+    teatree.core.managers --> teatree.core.managers_session
     teatree.core.managers --> teatree.core.managers_task_claim
     teatree.core.managers --> teatree.core.repair_loop
     teatree.core.managers --> teatree.core.session_handover_manager

--- a/src/teatree/config/defaults.toml
+++ b/src/teatree/config/defaults.toml
@@ -181,6 +181,7 @@ self_update_cadence_hours = 1
 self_update_disabled = false
 send_proxy_allowlist = []
 send_proxy_mode = "warn"
+session_stale_after_hours = 12
 skill_loading_gate_enabled = true
 slack_voice_classifier_mode = "warn"
 snapshot_baseline_gate_enabled = true

--- a/src/teatree/config/schema.py
+++ b/src/teatree/config/schema.py
@@ -314,6 +314,7 @@ class TeatreeSettingsSchema(BaseSettings):
     self_update_disabled: Annotated[bool, BeforeValidator(_parse_strict_bool), _DEFAULT_OVERLAY]
     send_proxy_allowlist: Annotated[list[str], BeforeValidator(_parse_str_list), _DEFAULT_OVERLAY]
     send_proxy_mode: Annotated[SendProxyMode, BeforeValidator(SendProxyMode.parse), _DEFAULT_OVERLAY]
+    session_stale_after_hours: Annotated[int, BeforeValidator(_parse_strict_int), _DEFAULT_OVERLAY]
     slack_voice_classifier_mode: Annotated[
         SlackVoiceClassifierMode, BeforeValidator(SlackVoiceClassifierMode.parse), _DEFAULT_OVERLAY
     ]

--- a/src/teatree/config/setting_registries.py
+++ b/src/teatree/config/setting_registries.py
@@ -171,6 +171,7 @@ OVERLAY_OVERRIDABLE_SETTINGS: dict[str, Callable[[Any], Any]] = {
     "max_concurrent_local_stacks": _parse_strict_int,
     "task_attempt_retention_days": _parse_strict_int,
     "incoming_event_retention_days": _parse_strict_int,
+    "session_stale_after_hours": _parse_strict_int,
     "provision_step_timeout_seconds": _parse_strict_int,
     "idle_stack_reaper_disabled": _parse_strict_bool,
     "idle_stack_idle_minutes": _parse_strict_int,

--- a/src/teatree/config/settings.py
+++ b/src/teatree/config/settings.py
@@ -857,6 +857,18 @@ class _ResourcePressureSettings:
     # ``0`` disables that table's pruning entirely. Per-overlay overridable.
     task_attempt_retention_days: int = 30
     incoming_event_retention_days: int = 30
+    # Fail-safe staleness bound on the OPEN-Session liveness signal every reaper
+    # consults (``Ticket.has_active_work``). An agent that crashed without closing
+    # its Session would otherwise pin its ticket — and so its worktree, its
+    # ``max_concurrent_local_stacks`` slot, and ``workspace relocate`` — busy
+    # forever. An open Session whose last recorded activity (its own
+    # ``started_at``, its tasks' heartbeats, its attempts' start times) is older
+    # than this many hours is NOT live. 12h is 4x the ``watchdog_max_runtime_seconds``
+    # hard cap on a single agent run, so it cannot mask real in-flight work — and
+    # an active (PENDING/CLAIMED) task keeps a ticket busy with NO time bound at
+    # all, independently of this. ``0`` disables the bound (every open Session is
+    # live). Per-overlay overridable.
+    session_stale_after_hours: int = 12
 
 
 @dataclass

--- a/src/teatree/core/cleanup/cleanup_liveness.py
+++ b/src/teatree/core/cleanup/cleanup_liveness.py
@@ -4,9 +4,11 @@ The reaper's FIRST gate, ahead of done-detection and redundancy analysis: an
 item a human or agent is mid-task in must be SKIPPED-and-reported, never wiped
 and never emitted for the salvage skill to delete. A worktree/branch is LIVE
 when ANY of these hold (fail-safe — uncertainty resolves to LIVE/keep): (a) its
-ticket has a live :class:`Session` (``ended_at`` null) or an active
-:class:`Task` (``PENDING`` / ``CLAIMED``) — the same busy-ticket signal the
-idle-stack reaper uses; (b) the ticket carries a live external-delivery lease, a
+ticket has a live :class:`Session` (open AND active within
+``session_stale_after_hours`` — an abandoned session must not pin a ticket
+forever) or an active :class:`Task` (``PENDING`` / ``CLAIMED``, no time bound)
+— the same busy-ticket signal the idle-stack reaper uses; (b) the ticket
+carries a live external-delivery lease, a
 recent E2E/evidence run touched the worktree, or it is explicitly
 ``reaper_pinned`` — the shared #2227/#2773 active-delivery guards, folded in via
 :func:`teatree.core.gates.idle_stack.active_delivery_keep_reason` so this reaper

--- a/src/teatree/core/gates/idle_stack.py
+++ b/src/teatree/core/gates/idle_stack.py
@@ -9,8 +9,9 @@ reaper stops such a stack (``Worktree.stop_services`` → demote to
 
 A worktree is REAPABLE when ALL hold: (1) its state is ``SERVICES_UP`` or
 ``READY`` — a dormant ``PROVISIONED`` row holds no stack, so it is never a
-candidate; (2) its ticket has NO live :class:`Session` (``ended_at`` is null)
-and NO active/claimed :class:`Task` (``PENDING`` / ``CLAIMED``); (3)
+candidate; (2) its ticket has NO live :class:`Session` (open AND active within
+``session_stale_after_hours``) and NO active/claimed :class:`Task` (``PENDING``
+/ ``CLAIMED``); (3)
 ``last_used_at`` is older than the idle threshold — a null ``last_used_at``
 cannot be confirmed idle, so it is a fail-safe KEEP; (4) it is not the
 currently-active worktree (the process CWD lives inside it); (5) #2227 — its

--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -22,6 +22,7 @@ from teatree.core.managers_overlay import for_overlay as _for_overlay
 from teatree.core.managers_overlay import overlay_scope_q
 from teatree.core.managers_phase_cadence import in_flight_for_phase as _in_flight_for_phase
 from teatree.core.managers_phase_cadence import last_run_at_for_phase as _last_run_at_for_phase
+from teatree.core.managers_session import SessionQuerySet
 from teatree.core.managers_task_claim import ClaimOrder, _claimable_now_q
 from teatree.core.repair_loop import IterationStalled, MaxIterationsExceeded
 from teatree.core.session_handover_manager import SessionHandoverManager, SessionHandoverQuerySet
@@ -148,14 +149,6 @@ class WorktreeQuerySet(models.QuerySet):
             ticket_id=ticket_pk,
             state__in=[worktree_model.State.SERVICES_UP, worktree_model.State.READY],
         ).update(last_e2e_run=now or timezone.now())
-
-
-class SessionQuerySet(models.QuerySet):
-    def for_overlay(self, overlay: str | None = None) -> models.QuerySet:
-        return _for_overlay(self, overlay)
-
-    def for_agent(self, agent_id: str) -> models.QuerySet:
-        return self.filter(agent_id=agent_id).order_by("pk")
 
 
 # The settled/in-flight boundary, defined ONCE (#3693): an event is UNSETTLED until it is

--- a/src/teatree/core/managers_session.py
+++ b/src/teatree/core/managers_session.py
@@ -1,0 +1,52 @@
+"""``SessionQuerySet`` — Session scoping plus the bounded-liveness query.
+
+A leaf split out of ``managers.py`` (module-health cap). ``Session.ended_at``
+marks a session finished, but an agent that crashes never writes it, so "open"
+alone would pin its ticket busy forever — and with it the ticket's worktree, its
+``max_concurrent_local_stacks`` slot, and ``workspace relocate``. A session is
+LIVE only while it is open AND something happened on it within
+``session_stale_after_hours``. The bound cannot mask real in-flight work: an
+active (PENDING/CLAIMED) ``Task`` keeps a ticket busy with no time bound at all
+(``Ticket.has_active_work``), and ``session_stale_after_hours = 0`` restores the
+unbounded reading.
+"""
+
+from datetime import datetime, timedelta
+
+from django.db import models
+from django.db.models import Max
+from django.db.models.functions import Coalesce, Greatest
+from django.utils import timezone
+
+from teatree.config import get_effective_settings
+from teatree.core.managers_overlay import for_overlay as _for_overlay
+
+__all__ = ["SessionQuerySet"]
+
+# The last instant anything happened on a Session: its own creation, the last
+# heartbeat of a task it owns, or the start of that task's most recent attempt.
+# Each aggregate is COALESCEd against ``started_at`` because SQLite's scalar
+# ``MAX()`` returns NULL as soon as one argument is NULL (a session with no
+# tasks, or a task with no attempt), which would read as "no activity ever".
+_LAST_ACTIVITY = Greatest(
+    "started_at",
+    Coalesce(Max("tasks__heartbeat_at"), "started_at"),
+    Coalesce(Max("tasks__attempts__started_at"), "started_at"),
+)
+
+
+class SessionQuerySet(models.QuerySet):
+    def for_overlay(self, overlay: str | None = None) -> models.QuerySet:
+        return _for_overlay(self, overlay)
+
+    def for_agent(self, agent_id: str) -> models.QuerySet:
+        return self.filter(agent_id=agent_id).order_by("pk")
+
+    def live(self, *, now: datetime | None = None) -> models.QuerySet:
+        """Open sessions whose last recorded activity is inside the staleness window."""
+        hours = get_effective_settings().session_stale_after_hours
+        opened = self.filter(ended_at__isnull=True)
+        if hours <= 0:
+            return opened
+        cutoff = (now or timezone.now()) - timedelta(hours=hours)
+        return opened.annotate(last_activity=_LAST_ACTIVITY).filter(last_activity__gte=cutoff)

--- a/src/teatree/core/migrations/0032_close_orphaned_sessions.py
+++ b/src/teatree/core/migrations/0032_close_orphaned_sessions.py
@@ -1,0 +1,51 @@
+from django.db import migrations
+from django.db.models import Max
+from django.db.models.functions import Coalesce, Greatest
+
+# ``Task.Status.active()`` as literals — a historical model carries no methods.
+_ACTIVE_TASK_STATUSES = ("pending", "claimed")
+
+
+def _close_orphaned_sessions(apps, schema_editor):
+    """Close every open Session no longer owning active work, at its last activity.
+
+    ``Session.ended_at`` had no production writer, so every session ever minted
+    is still open and reads as live — which pins its ticket busy and stalls the
+    worktree reaper, the idle-stack reaper and ``workspace relocate``.
+
+    Each row closes at its LAST RECORDED ACTIVITY (its own ``started_at``, the
+    last heartbeat of a task it owns, or that task's most recent attempt start),
+    never at ``now()`` — stamping ``now()`` would leave every row inside the
+    ``session_stale_after_hours`` window and re-pin exactly what this frees.
+
+    A session still owning a PENDING/CLAIMED task is left OPEN: it may be
+    genuinely in flight, and the reapers must fail closed. Idempotent — a re-run
+    matches only rows that are still open.
+    """
+    Session = apps.get_model("core", "Session")
+
+    busy_pks = set(Session.objects.filter(tasks__status__in=_ACTIVE_TASK_STATUSES).values_list("pk", flat=True))
+    rows = list(
+        Session.objects.filter(ended_at__isnull=True)
+        .exclude(pk__in=busy_pks)
+        .annotate(
+            last_activity=Greatest(
+                "started_at",
+                Coalesce(Max("tasks__heartbeat_at"), "started_at"),
+                Coalesce(Max("tasks__attempts__started_at"), "started_at"),
+            ),
+        ),
+    )
+    for session in rows:
+        session.ended_at = session.last_activity
+    Session.objects.bulk_update(rows, ["ended_at"], batch_size=500)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0031_taskattempt_reasoning_effort_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(_close_orphaned_sessions, migrations.RunPython.noop),
+    ]

--- a/src/teatree/core/migrations/max_migration.txt
+++ b/src/teatree/core/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0031_taskattempt_reasoning_effort_and_more
+0032_close_orphaned_sessions

--- a/src/teatree/core/models/session.py
+++ b/src/teatree/core/models/session.py
@@ -1,6 +1,8 @@
 import logging
+from datetime import datetime
 from typing import ClassVar, cast
 
+from django.apps import apps
 from django.db import models, transaction
 from django.utils import timezone
 
@@ -187,9 +189,35 @@ class Session(models.Model):
         tested = set(cast("list[str]", self.repos_tested or []))
         return sorted(modified - tested)
 
+    def close(self, *, at: datetime | None = None) -> bool:
+        """Stamp ``ended_at`` once; ``True`` iff this call was the one that closed it.
+
+        The single writer of ``ended_at`` — the conditional
+        ``UPDATE ... WHERE ended_at IS NULL`` makes it idempotent under
+        concurrency, so a second closer never re-stamps a session that already
+        ended (the first close's timestamp is the truth).
+        """
+        stamped = at or timezone.now()
+        if not type(self).objects.filter(pk=self.pk, ended_at__isnull=True).update(ended_at=stamped):
+            return False
+        self.ended_at = stamped
+        return True
+
+    def close_if_idle(self, *, at: datetime | None = None) -> bool:
+        """Close this session once no task it owns is still PENDING/CLAIMED.
+
+        Every production session-minting site creates one Session per dispatched
+        Task, so a task reaching a terminal status is its session's terminal
+        point. Child tasks and in-session sub-agent tasks share the parent's
+        session, hence the active-sibling check rather than an unconditional close.
+        """
+        task_model = apps.get_model("core", "Task")
+        if self.tasks.filter(status__in=task_model.Status.active()).exists():  # ty: ignore[unresolved-attribute]
+            return False
+        return self.close(at=at)
+
     def begin_manual_handoff(self) -> None:
-        self.ended_at = timezone.now()
-        self.save(update_fields=["ended_at"])
+        self.close()
 
     def _visited_phases(self) -> list[str]:
         return cast("list[str]", self.visited_phases or [])

--- a/src/teatree/core/models/ticket_introspection.py
+++ b/src/teatree/core/models/ticket_introspection.py
@@ -19,12 +19,17 @@ class TicketIntrospectionModel(TicketFacet):
         abstract = True
 
     def has_active_work(self) -> bool:
-        """True iff this ticket has an open session or an active (pending/claimed) task.
+        """True iff this ticket has a LIVE session or an active (pending/claimed) task.
 
         The single owner of the ticket-liveness rule the reapers and the relocate
         command consult — a busy ticket must never be torn down.
+
+        A session counts as live while it is open AND its last recorded activity
+        is inside ``session_stale_after_hours`` (:meth:`SessionQuerySet.live`).
+        The bound is what lets the reapers converge; it cannot mask real in-flight
+        work, because the task half below carries no time bound at all.
         """
-        if self.sessions.filter(ended_at__isnull=True).exists():  # type: ignore[attr-defined]  # Django reverse FK
+        if self.sessions.live().exists():  # type: ignore[attr-defined]  # Django reverse FK
             return True
         # apps.get_model, not a direct import: task.py imports ticket.py at module scope (real cycle).
         task_model = apps.get_model("core", "Task")

--- a/src/teatree/core/signals.py
+++ b/src/teatree/core/signals.py
@@ -280,6 +280,31 @@ def _auto_enqueue_headless_task(
         logger.exception("Failed to auto-enqueue headless task %s", instance.pk)
 
 
+def _close_session_on_terminal_task(
+    sender: type,  # noqa: ARG001 — Django signal receiver signature requires sender even when unused
+    instance: Task,
+    **_kwargs: object,
+) -> None:
+    """End a Session once the work it was minted for terminates.
+
+    The single chokepoint for writing ``Session.ended_at``: every production
+    session-minting site creates one Session per dispatched Task, so a task
+    reaching COMPLETED/FAILED is its session's terminal point. Riding ``post_save``
+    covers ``complete()``, ``fail()``, ``complete_surfacing_advance_failure()`` and
+    ``complete_with_attempt()`` at once, instead of sprinkling a close into each.
+
+    ``close_if_idle`` keeps the session open while a sibling/child task on it is
+    still active. Best-effort: a task write must never fail because its session
+    could not be stamped — the ``session_stale_after_hours`` bound is the backstop.
+    """
+    if instance.status not in Task.Status.terminal():
+        return
+    try:
+        instance.session.close_if_idle()
+    except Exception:
+        logger.exception("Failed to close the session of terminal task %s", instance.pk)
+
+
 def _enqueue_ticket_transition_task(
     sender: type,  # noqa: ARG001 — Django signal receiver signature requires sender even when unused
     instance: Ticket,
@@ -393,4 +418,5 @@ def register_signals() -> None:
         dispatch_uid="ticket_completion_release_issue_markers",
     )
     post_save.connect(_auto_enqueue_headless_task, sender=Task, dispatch_uid="auto_enqueue_headless")
+    post_save.connect(_close_session_on_terminal_task, sender=Task, dispatch_uid="close_session_on_terminal_task")
     post_save.connect(_stamp_issue_title_on_create, sender=Ticket, dispatch_uid="ticket_stamp_issue_title")

--- a/tach.toml
+++ b/tach.toml
@@ -248,6 +248,11 @@ layer = "domain"
 depends_on = []
 
 [[modules]]
+path = "teatree.core.managers_session"
+layer = "domain"
+depends_on = ["teatree.config", "teatree.core.managers_overlay"]
+
+[[modules]]
 path = "teatree.core.managers"
 layer = "domain"
 depends_on = [
@@ -259,6 +264,7 @@ depends_on = [
   "teatree.core.managers_issue_match",
   "teatree.core.managers_overlay",
   "teatree.core.managers_phase_cadence",
+  "teatree.core.managers_session",
   "teatree.core.managers_task_claim",
   "teatree.core.repair_loop",
   "teatree.core.session_handover_manager"

--- a/tests/config/test_settings_field_golden.py
+++ b/tests/config/test_settings_field_golden.py
@@ -175,6 +175,7 @@ GOLDEN_USER_SETTINGS_FIELDS: frozenset[str] = frozenset(
         "self_update_disabled",
         "send_proxy_allowlist",
         "send_proxy_mode",
+        "session_stale_after_hours",
         "slack_voice_classifier_mode",
         "snapshot_baseline_gate_enabled",
         "snapshot_warmer_disabled",

--- a/tests/quality/test_no_flat_core_regrowth.py
+++ b/tests/quality/test_no_flat_core_regrowth.py
@@ -117,7 +117,12 @@ _CORE_DIR = Path(__file__).resolve().parents[2] / "src" / "teatree" / "core"
 # (in_flight_for_phase + last_run_at_for_phase) carved out of managers.py to hold it under the 500-LOC
 # module-health cap. A pure queryset-builder leaf helper of the flat root managers.py hub, mirroring
 # managers_overlay.py / managers_issue_match.py / managers_task_claim.py. Owned by no existing subpackage.
-PINNED_FLAT_CORE_MODULES = 101
+# 102: +managers_session.py — SessionQuerySet (overlay/agent scoping + the bounded-liveness
+# `live()` query) carved out of managers.py to hold it under the 500-LOC module-health cap.
+# A queryset leaf helper of the flat root managers.py hub, mirroring managers_phase_cadence.py /
+# managers_overlay.py / managers_issue_match.py / managers_task_claim.py. Owned by no existing
+# subpackage — models/ may not import config, and this reads `session_stale_after_hours`.
+PINNED_FLAT_CORE_MODULES = 102
 
 
 def _flat_core_modules() -> list[str]:

--- a/tests/teatree_core/migrations/test_close_orphaned_sessions.py
+++ b/tests/teatree_core/migrations/test_close_orphaned_sessions.py
@@ -1,0 +1,120 @@
+"""The ``0032`` backfill closes the never-ended Sessions at their last activity.
+
+``Session.ended_at`` had no production writer, so a deployed database holds one
+open row per session ever minted (497 of 512 on the box this was found on) — each
+pinning its ticket busy. The forward closes them; the tests pin the two properties
+that make the backfill safe: it never stamps ``now()`` (that would re-pin every
+row inside the staleness window) and it never closes a session that still owns
+active work.
+
+Driven through the real migration executor from ``0031``, which is the only run
+that proves the deployed shape.
+"""
+
+import importlib
+from datetime import timedelta
+
+import pytest
+from django.core.management import call_command
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase
+from django.utils import timezone
+
+_BEFORE = ("core", "0031_taskattempt_reasoning_effort_and_more")
+_AFTER = ("core", "0032_close_orphaned_sessions")
+
+
+@pytest.mark.timeout(240)
+class TestOrphanedSessionsAreClosedAtTheirLastActivity(TransactionTestCase):
+    def setUp(self) -> None:
+        self.addCleanup(self._restore_head)
+
+    @staticmethod
+    def _restore_head() -> None:
+        connection.close()
+        call_command("migrate", "core", "--no-input", verbosity=0)
+
+    def _rewind(self) -> MigrationExecutor:
+        executor = MigrationExecutor(connection)
+        executor.migrate([_BEFORE])
+        return executor
+
+    @staticmethod
+    def _models(executor: MigrationExecutor, state: tuple[str, str]) -> tuple[type, type, type]:
+        apps = executor.loader.project_state(state).apps
+        return apps.get_model("core", "Ticket"), apps.get_model("core", "Session"), apps.get_model("core", "Task")
+
+    @staticmethod
+    def _open_session(session_model, ticket_model, *, age_hours: int):
+        session = session_model.objects.create(ticket=ticket_model.objects.create())
+        session_model.objects.filter(pk=session.pk).update(started_at=timezone.now() - timedelta(hours=age_hours))
+        return session_model.objects.get(pk=session.pk)
+
+    def _forward(self) -> MigrationExecutor:
+        executor = MigrationExecutor(connection)
+        executor.migrate([_AFTER])
+        return executor
+
+    def test_a_taskless_session_closes_at_its_own_start(self) -> None:
+        executor = self._rewind()
+        ticket_model, session_model, _task = self._models(executor, _BEFORE)
+        session = self._open_session(session_model, ticket_model, age_hours=200)
+
+        executor = self._forward()
+
+        _t, session_model, _tk = self._models(executor, _AFTER)
+        assert session_model.objects.get(pk=session.pk).ended_at == session.started_at
+
+    def test_the_close_timestamp_is_never_now(self) -> None:
+        executor = self._rewind()
+        ticket_model, session_model, _task = self._models(executor, _BEFORE)
+        session = self._open_session(session_model, ticket_model, age_hours=200)
+
+        executor = self._forward()
+
+        _t, session_model, _tk = self._models(executor, _AFTER)
+        ended = session_model.objects.get(pk=session.pk).ended_at
+        assert ended < timezone.now() - timedelta(hours=100), "closing at now() would re-pin the ticket"
+
+    def test_a_session_owning_an_active_task_stays_open(self) -> None:
+        executor = self._rewind()
+        ticket_model, session_model, task_model = self._models(executor, _BEFORE)
+        session = self._open_session(session_model, ticket_model, age_hours=200)
+        task_model.objects.create(ticket=session.ticket, session=session, status="claimed")
+
+        executor = self._forward()
+
+        _t, session_model, _tk = self._models(executor, _AFTER)
+        assert session_model.objects.get(pk=session.pk).ended_at is None
+
+    def test_a_session_closes_at_its_latest_task_heartbeat(self) -> None:
+        executor = self._rewind()
+        ticket_model, session_model, task_model = self._models(executor, _BEFORE)
+        session = self._open_session(session_model, ticket_model, age_hours=200)
+        heartbeat = timezone.now() - timedelta(hours=50)
+        task_model.objects.create(
+            ticket=session.ticket,
+            session=session,
+            status="completed",
+            heartbeat_at=heartbeat,
+        )
+
+        executor = self._forward()
+
+        _t, session_model, _tk = self._models(executor, _AFTER)
+        assert session_model.objects.get(pk=session.pk).ended_at == heartbeat
+
+    def test_rerunning_the_forward_does_not_re_stamp_a_closed_session(self) -> None:
+        executor = self._rewind()
+        ticket_model, session_model, _task = self._models(executor, _BEFORE)
+        session = self._open_session(session_model, ticket_model, age_hours=200)
+
+        executor = self._forward()
+        _t, session_model, _tk = self._models(executor, _AFTER)
+        first = session_model.objects.get(pk=session.pk).ended_at
+
+        module = importlib.import_module("teatree.core.migrations.0032_close_orphaned_sessions")
+        module._close_orphaned_sessions(executor.loader.project_state(_AFTER).apps, connection.schema_editor())
+
+        assert session_model.objects.get(pk=session.pk).ended_at == first

--- a/tests/teatree_core/models/test_session.py
+++ b/tests/teatree_core/models/test_session.py
@@ -1,9 +1,12 @@
 """Session model tests (souliane/teatree#443 split of test_models.py)."""
 
+from datetime import timedelta
+
 import pytest
 from django.test import TestCase
+from django.utils import timezone
 
-from teatree.core.models import QualityGateError, Session, Ticket
+from teatree.core.models import QualityGateError, Session, Task, Ticket
 
 
 class TestSession(TestCase):
@@ -186,6 +189,37 @@ class TestSession(TestCase):
         from teatree.core.modelkit.phases import CANONICAL_PHASES  # noqa: PLC0415
 
         assert Session._GATE_PHASES <= CANONICAL_PHASES
+
+    def test_close_stamps_ended_at_once(self) -> None:
+        session = Session.objects.create(ticket=Ticket.objects.create())
+        moment = timezone.now() - timedelta(hours=2)
+
+        assert session.close(at=moment) is True
+        assert session.close() is False, "a second close must not re-stamp an already-closed session"
+
+        session.refresh_from_db()
+        assert session.ended_at == moment
+
+    def test_close_if_idle_keeps_a_session_with_an_active_task_open(self) -> None:
+        session = Session.objects.create(ticket=Ticket.objects.create())
+        Task.objects.create(ticket=session.ticket, session=session, status=Task.Status.CLAIMED)
+
+        assert session.close_if_idle() is False
+
+        session.refresh_from_db()
+        assert session.ended_at is None
+
+    def test_close_if_idle_closes_once_every_task_is_terminal(self) -> None:
+        session = Session.objects.create(ticket=Ticket.objects.create())
+        task = Task.objects.create(ticket=session.ticket, session=session)
+        # Bulk update, not ``complete()``: this isolates ``close_if_idle`` from the
+        # post_save receiver that would otherwise have closed the session already.
+        Task.objects.filter(pk=task.pk).update(status=Task.Status.COMPLETED)
+
+        assert session.close_if_idle() is True
+
+        session.refresh_from_db()
+        assert session.ended_at is not None
 
     def test_repo_tracking(self) -> None:
         session = Session.objects.create(ticket=Ticket.objects.create())

--- a/tests/teatree_core/models/test_task_state_partition.py
+++ b/tests/teatree_core/models/test_task_state_partition.py
@@ -7,10 +7,17 @@ the FSM owners — ``Task.Status.active()`` / ``Task.Status.terminal()`` and
 drift guard: a new ``Task.Status`` member that no one classifies fails it.
 """
 
+from datetime import timedelta
+
 from django.test import TestCase
 from django.utils import timezone
 
-from teatree.core.models import Session, Task, Ticket
+from teatree.core.models import ConfigSetting, Session, Task, TaskAttempt, Ticket
+
+
+def _backdate_session(session: Session, *, hours: int) -> None:
+    """Move ``started_at`` (``auto_now_add``) back — the only way to age a Session."""
+    Session.objects.filter(pk=session.pk).update(started_at=timezone.now() - timedelta(hours=hours))
 
 
 class TestActiveTerminalPartition(TestCase):
@@ -43,3 +50,52 @@ class TestTicketHasActiveWork(TestCase):
         Task.objects.create(ticket=ticket, session=session, status=Task.Status.COMPLETED)
         Task.objects.create(ticket=ticket, session=session, status=Task.Status.FAILED)
         assert ticket.has_active_work() is False
+
+
+class TestSessionStalenessBound(TestCase):
+    """An agent that crashed without closing its Session must not pin the ticket forever.
+
+    The bound is on the SESSION signal only. Every test here that expects
+    ``False`` proves the reapers can converge; every test that expects ``True``
+    is a fail-CLOSED control — it must go red if the bound is made aggressive
+    enough to reap genuinely live work.
+    """
+
+    def test_stale_open_session_is_not_active_work(self) -> None:
+        ticket = Ticket.objects.create()
+        _backdate_session(Session.objects.create(ticket=ticket), hours=48)
+
+        assert ticket.has_active_work() is False
+
+    def test_open_session_inside_the_window_is_active_work(self) -> None:
+        ticket = Ticket.objects.create()
+        _backdate_session(Session.objects.create(ticket=ticket), hours=2)
+
+        assert ticket.has_active_work() is True
+
+    def test_stale_session_with_a_recent_attempt_is_active_work(self) -> None:
+        """A long-running agent whose Session row is old but whose attempt just started."""
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket)
+        task = Task.objects.create(ticket=ticket, session=session)
+        TaskAttempt.objects.create(task=task, execution_target=Task.ExecutionTarget.HEADLESS)
+        Task.objects.filter(pk=task.pk).update(status=Task.Status.COMPLETED)
+        _backdate_session(session, hours=48)
+
+        assert ticket.has_active_work() is True
+
+    def test_stale_session_with_an_active_task_is_active_work(self) -> None:
+        """The task signal carries NO time bound, so the staleness window cannot reap live work."""
+        ticket = Ticket.objects.create()
+        session = Session.objects.create(ticket=ticket)
+        Task.objects.create(ticket=ticket, session=session, status=Task.Status.CLAIMED)
+        _backdate_session(session, hours=48)
+
+        assert ticket.has_active_work() is True
+
+    def test_zero_hours_restores_the_unbounded_liveness(self) -> None:
+        ConfigSetting.objects.set_value("session_stale_after_hours", 0)
+        ticket = Ticket.objects.create()
+        _backdate_session(Session.objects.create(ticket=ticket), hours=48)
+
+        assert ticket.has_active_work() is True

--- a/tests/teatree_core/test_cleanup_liveness.py
+++ b/tests/teatree_core/test_cleanup_liveness.py
@@ -117,16 +117,26 @@ class TestFsmTerminalBypass(_LivenessFixture):
         assert worktree_liveness(worktree, wt_path=self.wt_path, fsm_terminal=True).active is False
 
     def test_open_session_ignored_under_fsm_terminal(self) -> None:
-        # A never-ended Session (ended_at NULL) pins a frozen ticket's worktree
-        # ACTIVE forever on the ad-hoc path — the exact stale-session that kept
-        # worktrees from being reaped. The post-terminal teardown passes
-        # fsm_terminal=True so that stale session no longer blocks the purge,
-        # while the ad-hoc sweep (fsm_terminal=False) still keeps it.
+        # A RECENT open Session keeps the ad-hoc sweep off the worktree (an agent
+        # may be mid-task in it); fsm_terminal bypasses it, because the merge
+        # ceremony mints that very session. The staleness bound below is what
+        # stops an ABANDONED open session from pinning the ad-hoc path forever.
         worktree = self._worktree()
         session = Session.objects.create(overlay="test", ticket=worktree.ticket)
         assert session.ended_at is None
         assert worktree_liveness(worktree, wt_path=self.wt_path, fsm_terminal=False).active is True
         assert worktree_liveness(worktree, wt_path=self.wt_path, fsm_terminal=True).active is False
+
+    def test_stale_open_session_no_longer_pins_the_ad_hoc_path(self) -> None:
+        # The session-close defect: ``ended_at`` had no production writer, so
+        # every ticket's session stayed open and the ad-hoc ``clean-all`` sweep
+        # could never converge. The staleness bound retires an abandoned session
+        # WITHOUT weakening the recent-session guard asserted above.
+        worktree = self._worktree()
+        session = Session.objects.create(overlay="test", ticket=worktree.ticket)
+        Session.objects.filter(pk=session.pk).update(started_at=timezone.now() - timedelta(days=7))
+
+        assert worktree_liveness(worktree, wt_path=self.wt_path, fsm_terminal=False).active is False
 
     def test_recent_commit_is_bypassed_on_fsm_terminal(self) -> None:
         worktree = self._worktree()

--- a/tests/teatree_core/test_signals.py
+++ b/tests/teatree_core/test_signals.py
@@ -609,3 +609,72 @@ class TestTerminalTransitionsEnqueueTeardown(TestCase):
         # states minus SHIPPED, so a future terminal state cannot silently skip
         # purge (SHIPPED stays excluded — its PR is still open).
         assert set(Ticket._TERMINAL_STATES) - {Ticket.State.SHIPPED} == signals_mod._TERMINAL_TARGET_STATES
+
+
+class TestSessionClosedOnTerminalTask(TestCase):
+    """A Session ends when the work it was minted for terminates (the reaper's liveness input).
+
+    Every production ``Session.objects.create`` site mints exactly one Session
+    per dispatched Task, so the Task's terminal transition is the Session's
+    terminal point. Without this, ``ended_at`` was never written in production
+    and every ticket read as permanently busy.
+    """
+
+    @staticmethod
+    def _session_with_task() -> tuple[Session, Task]:
+        # CODED + a ``coding`` task: the completion is an idempotent FSM replay, so
+        # the fixture exercises the close path without dragging in a transition.
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.CODED)
+        session = Session.objects.create(ticket=ticket, overlay="test")
+        task = Task.objects.create(
+            ticket=ticket,
+            session=session,
+            phase="coding",
+            execution_target=Task.ExecutionTarget.INTERACTIVE,
+        )
+        return session, task
+
+    def test_completing_the_owning_task_ends_the_session(self) -> None:
+        session, task = self._session_with_task()
+
+        task.complete()
+
+        session.refresh_from_db()
+        assert session.ended_at is not None
+
+    def test_failing_the_owning_task_ends_the_session(self) -> None:
+        session, task = self._session_with_task()
+
+        task.fail()
+
+        session.refresh_from_db()
+        assert session.ended_at is not None
+
+    def test_a_sibling_task_still_in_flight_keeps_the_session_open(self) -> None:
+        session, task = self._session_with_task()
+        Task.objects.create(
+            ticket=session.ticket,
+            session=session,
+            phase="coding",
+            execution_target=Task.ExecutionTarget.INTERACTIVE,
+        )
+
+        task.fail()
+
+        session.refresh_from_db()
+        assert session.ended_at is None
+
+    def test_claiming_a_task_leaves_the_session_open(self) -> None:
+        session, task = self._session_with_task()
+
+        task.claim(claimed_by="worker-1")
+
+        session.refresh_from_db()
+        assert session.ended_at is None
+
+    def test_the_ticket_stops_reading_busy_once_its_task_terminates(self) -> None:
+        session, task = self._session_with_task()
+
+        task.fail()
+
+        assert session.ticket.has_active_work() is False

--- a/tests/teatree_core/test_worktree_done.py
+++ b/tests/teatree_core/test_worktree_done.py
@@ -13,14 +13,16 @@ unpushed work even on a done ticket; and the done-wipe tears the docker volumes 
 """
 
 import subprocess
+from datetime import timedelta
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from django.test import TestCase
+from django.utils import timezone
 
-from teatree.core.cleanup.cleanup_liveness import LivenessVerdict
-from teatree.core.models import Ticket, Worktree
+from teatree.core.cleanup.cleanup_liveness import LivenessVerdict, worktree_liveness
+from teatree.core.models import Session, Ticket, Worktree
 from teatree.core.runners import worktree_start
 from teatree.core.worktree.worktree_done import (
     ChangeAnalysis,
@@ -444,6 +446,55 @@ class TestReaperGatesAndEmit(_ReaperFixture):
         assert "colleague-authored" in outcome.label
         assert self.wt_path.exists(), "a colleague's work must never be wiped"
         assert outcome.emit is not None
+
+
+class TestStaleSessionReachesTheDonePath(_ReaperFixture):
+    """End-to-end: an abandoned open Session must stop returning ACTIVE before done-detection.
+
+    The consequence chain the session-close defect produced — never-written
+    ``ended_at`` → ``has_active_work`` permanently true → ``_ownership_liveness_skip``
+    returning ACTIVE ahead of done-detection → ``clean-all`` never converging.
+    These run the REAL liveness guard (the fixture's stub is restored per test).
+    """
+
+    def _reap_with_real_liveness(self, worktree: Worktree) -> object:
+        with patch("teatree.core.worktree.worktree_done.worktree_liveness", worktree_liveness):
+            return self._reap(worktree)
+
+    def _backdate_head(self) -> None:
+        """Age HEAD past the recent-commit window so the SESSION signal is the decider."""
+        stamp = "2020-01-01T00:00:00 +0000"
+        env = {**_clean_env(), "GIT_COMMITTER_DATE": stamp, "GIT_AUTHOR_DATE": stamp}
+        subprocess.run(
+            [_GIT, "-C", str(self.wt_path), "commit", "-q", "--amend", "--no-edit"],
+            check=True,
+            capture_output=True,
+            env=env,
+        )
+
+    def test_merged_ticket_with_a_stale_session_is_wiped(self) -> None:
+        self._backdate_head()
+        self._push_branch()
+        worktree = self._make_worktree(Ticket.State.MERGED)
+        session = Session.objects.create(overlay="test", ticket=worktree.ticket)
+        Session.objects.filter(pk=session.pk).update(started_at=timezone.now() - timedelta(days=7))
+
+        outcome = self._reap_with_real_liveness(worktree)
+
+        assert outcome.action == "wiped", outcome.label
+        assert not self.wt_path.exists()
+
+    def test_merged_ticket_with_a_recent_session_is_still_skipped(self) -> None:
+        """The fail-CLOSED control: a genuinely live session keeps the worktree."""
+        self._backdate_head()
+        self._push_branch()
+        worktree = self._make_worktree(Ticket.State.MERGED)
+        Session.objects.create(overlay="test", ticket=worktree.ticket)
+
+        outcome = self._reap_with_real_liveness(worktree)
+
+        assert outcome.action == "active", outcome.label
+        assert self.wt_path.exists()
 
 
 class TestPostMergeWorkEmitTag(_ReaperFixture):


### PR DESCRIPTION
## What

`Session.ended_at` is now written when the work a Session was minted for terminates, bounded by a fail-safe staleness window, with a backfill for the rows that were never closed.

1. **Real close path.** `Session.close()` is the single `ended_at` writer (conditional `UPDATE ... WHERE ended_at IS NULL`, so it is idempotent under concurrency). `Session.close_if_idle()` closes once no task on the session is `PENDING`/`CLAIMED`. Both are driven from **one** chokepoint — the `_close_session_on_terminal_task` `post_save` receiver on `Task` — which covers `complete()`, `fail()`, `complete_surfacing_advance_failure()` and `complete_with_attempt()` at once. Every production session-minting site (`ticket_scheduling`, `review_loop`, `task_handoff`, `critic_dispatch`, `directive_dispatch`, `auto_review_dispatch`, `ticket_external_review`, `loop/persistence`, `active_tickets`, `slack_answer/cycle`) creates exactly one Session per dispatched Task, so the Task's terminal status is the Session's terminal point. `begin_manual_handoff()` routes through `close()`.
2. **Fail-safe staleness bound.** `SessionQuerySet.live()` counts a session live only while it is open **and** its last recorded activity (its own `started_at`, its tasks' heartbeats, its attempts' start times) is inside the new `session_stale_after_hours` setting.
3. **Backfill.** Data migration `0032_close_orphaned_sessions` closes every open Session that owns no active task.

## Why

`Session.ended_at` had **no production writer**. `begin_manual_handoff()` was the only one, and it has zero production callers (its definition plus one line in `tests/teatree_core/models/test_session.py`). Every other `ended_at=` write in `src/` is on `TaskAttempt`, a different model. On the deployed box: 512 sessions, 498 with `ended_at IS NULL` (97%), oldest still-open session dated 2026-07-13.

`Ticket.has_active_work()` treats any open session as busy with **no time bound**, so that made every ticket permanently busy, and the whole consequence chain went dead:

- `core/cleanup/cleanup_liveness.py` `_db_liveness_reason` returns the live-session reason, always.
- `core/worktree/worktree_done.py` `_ownership_liveness_skip` returns `ReapOutcome("active")` **before** done-detection, so `reap_done_worktree` never reaches the done path and `workspace clean-all` can never converge (observed live: 10+ worktrees skipped ACTIVE with 10 of their tickets already delivered/ignored).
- `core/gates/idle_stack.py` — the idle-stack reaper never frees a `max_concurrent_local_stacks` slot.
- `core/management/commands/_workspace/relocate.py` — refuses every worktree forever.
- `teams/pane_reaper.py` / `teams/panes.py` — never reap an idle pane.

## The staleness bound, and why it cannot reap live work

`session_stale_after_hours` defaults to **12**, is per-overlay overridable, and `0` restores the pre-change unbounded reading as a kill switch. Three things keep it fail-CLOSED:

- 12h is **4x** `watchdog_max_runtime_seconds` (3h), the hard cap on a single agent run — a legitimate run cannot outlive the window.
- Activity is the **max** of the session's `started_at`, its tasks' `heartbeat_at`, and its attempts' `started_at`, so a long-running agent whose Session row is old but whose attempt just started still reads live.
- The **task** half of `has_active_work()` is untouched and has no time bound at all: a `PENDING`/`CLAIMED` task keeps a ticket busy regardless of the window. The bound only retires the *session* signal.

## The backfill's timestamp

Each row closes at its **last recorded activity**, never `now()`. Closing at `now()` would leave all 498 rows inside the staleness window and re-pin exactly what the migration frees. A session still owning a `PENDING`/`CLAIMED` task is left **open** — it may be genuinely in flight. Idempotent and safe to re-run (it only matches rows that are still open).

## The test that encoded the bug

`tests/teatree_core/test_cleanup_liveness.py::TestFsmTerminalBypass::test_open_session_ignored_under_fsm_terminal` asserted the never-ended-session-pins-forever behaviour as **INTENDED** for the ad-hoc (`fsm_terminal=False`) path. Its comment described a null `ended_at` pinning a frozen ticket's worktree ACTIVE forever on that path as the designed outcome, with the ad-hoc sweep deliberately keeping it. That is the defect written down as the contract, which is why it survived.

It is rewritten to the real contract: a **recent** open session still keeps the worktree on the ad-hoc path (the fail-closed guarantee, unchanged), and a new sibling test pins that a **stale** one no longer does. The FSM-terminal bypass path is untouched.

## Tests (RED before the fix, verified by reverting each half)

- `tests/teatree_core/test_signals.py::TestSessionClosedOnTerminalTask` — completing / failing the owning task ends the session; an in-flight sibling task keeps it open; a claim does not close it; the ticket stops reading busy. **3 of 5 RED** with the receiver unregistered.
- `tests/teatree_core/models/test_task_state_partition.py::TestSessionStalenessBound` — a stale open session is not active work (**RED** before); an in-window one **is** (control); a stale session with a recent attempt **is** (control); a stale session with an active task **is** (the fail-closed control); `0` restores the unbounded reading.
- `tests/teatree_core/test_worktree_done.py::TestStaleSessionReachesTheDonePath` — end-to-end against real git: a MERGED ticket with a stale session is **wiped**; with a recent session it is still **skipped** (fail-closed control).
- `tests/teatree_core/models/test_session.py` — `close()` stamps once, `close_if_idle()` keeps an active-task session open.
- `tests/teatree_core/migrations/test_close_orphaned_sessions.py` — driven through the real migration executor from `0031`: closes at `started_at` / at the latest task heartbeat, never at `now()`, leaves an active-task session open, and a re-run does not re-stamp.

## Refactor note

`SessionQuerySet` moves into its own `src/teatree/core/managers_session.py` leaf so `managers.py` stays under the 500-LOC module-health cap — mirroring the existing `managers_phase_cadence.py` / `managers_overlay.py` / `managers_issue_match.py` / `managers_task_claim.py` splits. The flat-core pin moves 101 to 102 with the justification recorded in the gate.

## Verification

- Scoped suites: `tests/config/`, `tests/teatree_core/models/`, `tests/teatree_core/migrations/`, `tests/teatree_core/cleanup/`, `tests/teatree_core/gates/`, `tests/teatree_core/test_signals.py`, `tests/teatree_core/test_cleanup_liveness.py`, `tests/teatree_core/test_worktree_done.py`, `tests/teatree_core/test_managers.py`, `tests/teatree_core/test_tasks.py`, `tests/teatree_loop/`, `tests/teatree_agents/`, `tests/teatree_teams/`, `tests/teatree_dash/`, `tests/teatree_mcp/`, `tests/conformance/`, `tests/quality/` — all green.
- `ruff check` / `ruff format` / `ty check` clean; `uv run tach check` validated.
- `manage.py makemigrations --check` reports no changes detected; `t3 tool test-path-mirror` ledger exact; `t3 tool comment-density` no findings.
- Full commit-stage and push-stage prek hook sets passed (module health, gate-relaxation, banned-terms, leak gate, incremental push gate).

## Open questions & assumptions

- **Bulk terminal writes are not covered by the receiver.** `Ticket._consume_pending_phase_tasks` and the `transient_requeue` retire paths mark tasks `COMPLETED` via `QuerySet.update()`, which fires no signal. Those sessions close via the `session_stale_after_hours` backstop rather than immediately. Deliberate — keeping the close on one chokepoint rather than sprinkling it, with the bound as the safety net.
- **`resolve_phase_session()` still returns the earliest session regardless of `ended_at`.** Phase attestation reads/writes do not consult `ended_at`, so a closed session still accepts a `visit_phase` — the ledger is unaffected. Left as-is (out of scope for this defect).
- **12h default.** Derived from `watchdog_max_runtime_seconds = 3h`; if any legitimate unattended session is expected to sit idle longer than half a day, raise the setting per-overlay rather than globally.
