### PR TITLE
fix(backends): hold the sync watermark on failure; make board-status writes monotonic

### DIFF
--- a/src/teatree/backends/github/sync.py
+++ b/src/teatree/backends/github/sync.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import shutil
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast, override
 
 from django.core.cache import cache
@@ -13,10 +14,60 @@ from teatree.types import PENDING_REVIEWS_CACHE_KEY, RawAPIDict, SyncBackend, Sy
 from teatree.utils.run import run_allowed_to_fail
 
 if TYPE_CHECKING:
+    from teatree.backends.github import ProjectItem
     from teatree.core.models import Ticket
-    from teatree.core.models.types import TicketExtra
+    from teatree.core.models.types import TicketExtra, TicketSiblingFields
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class _BoardItem:
+    """One project-board item resolved against teatree's model.
+
+    ``state`` is ``None`` when the column is not one of the three teatree maps.
+    A board carries columns beyond Todo / In Progress / Done (Backlog, In
+    Review, Blocked, a renamed column); defaulting those to NOT_STARTED would
+    overwrite the ticket's real FSM state on every sync.
+    """
+
+    item: "ProjectItem"
+    state: str | None
+    repo_short: str
+    extra: RawAPIDict
+
+    @classmethod
+    def resolve(cls, item: "ProjectItem", *, owner: str) -> "_BoardItem":
+        from teatree.backends.github import issue_repo_short  # noqa: PLC0415 — import cycle
+        from teatree.core.models import Ticket  # noqa: PLC0415 — deferred: ORM import needs the app registry
+
+        status_map = {
+            "Todo": Ticket.State.NOT_STARTED,
+            "In Progress": Ticket.State.STARTED,
+            "Done": Ticket.State.DELIVERED,
+        }
+        state = status_map.get(item.status)
+        if state is None:
+            logger.warning(
+                "Unmapped board status %r on %s — leaving the ticket's own state untouched.",
+                item.status,
+                item.url,
+            )
+        return cls(
+            item=item,
+            state=state,
+            # The board item's URL is the authoritative repo source; the project
+            # owner is not (a board spans repos), and scoping by owner
+            # mis-classifies UI-visibility for the DoD gate (#1426).
+            repo_short=issue_repo_short(item.url) or owner.rsplit("/", maxsplit=1)[-1],
+            extra={
+                "issue_title": item.title,
+                "board_position": item.position,
+                "board_status": item.status,
+                "labels": item.labels,
+                "updated_at": item.updated_at,
+            },
+        )
 
 
 class GitHubSyncBackend(SyncBackend):
@@ -37,8 +88,7 @@ class GitHubSyncBackend(SyncBackend):
 
     @override
     def sync(self, overlay: object) -> SyncResult:
-        from teatree.backends.github import fetch_project_items, issue_repo_short  # noqa: PLC0415 — import cycle
-        from teatree.core.intake.ticket_kind_classification import classify_ticket_kind  # noqa: PLC0415 — lazy: cycle
+        from teatree.backends.github import fetch_project_items  # noqa: PLC0415 — import cycle
         from teatree.core.models import Ticket  # noqa: PLC0415 — deferred: ORM import needs the app registry
         from teatree.core.overlay import OverlayBase  # noqa: PLC0415 — deferred: avoids a backends ↔ core cycle
 
@@ -59,69 +109,67 @@ class GitHubSyncBackend(SyncBackend):
         except Exception as exc:  # noqa: BLE001 — a project-fetch failure is recorded as a sync error, never crashes the sync
             return SyncResult(errors=[f"GitHub project fetch failed: {exc}"])
 
-        status_map = {
-            "Todo": Ticket.State.NOT_STARTED,
-            "In Progress": Ticket.State.STARTED,
-            "Done": Ticket.State.DELIVERED,
-        }
-
         for item in items:
             result.prs_found += 1
-            state = status_map.get(item.status, Ticket.State.NOT_STARTED)
-            # The board item's URL is the authoritative repo source; the
-            # project owner is not (a board spans repos), and scoping by owner
-            # mis-classifies UI-visibility for the DoD gate (#1426).
-            repo_short = issue_repo_short(item.url) or owner.split("/")[-1]
-            extra: RawAPIDict = {
-                "issue_title": item.title,
-                "board_position": item.position,
-                "board_status": item.status,
-                "labels": item.labels,
-                "updated_at": item.updated_at,
-            }
-
+            board = _BoardItem.resolve(item, owner=owner)
             tickets = list(Ticket.objects.matching_issue(item.url).order_by("pk"))
-            if not tickets:
-                created = Ticket.objects.create(
-                    issue_url=item.url,
-                    repos=[repo_short],
-                    state=state,
-                    extra=extra,
-                    overlay=self._overlay_name(overlay),
-                    kind=classify_ticket_kind(labels=item.labels, title=item.title),
-                )
-                result.tickets_created += 1
-                if state == Ticket.State.DELIVERED:
-                    self._record_delivered_dod_violation(created)
+            if tickets:
+                self._update_ticket_from_board(tickets[0], board, result)
             else:
-                ticket = tickets[0]
-                prior_state = ticket.state
-                # Repair the repo scope from the authoritative URL before the
-                # DoD check so the gate sees the real repo set (#1426).
-                repos = ticket.repos if isinstance(ticket.repos, list) else []
-                if repo_short and repo_short not in repos:
-                    repos = [*repos, repo_short]
-                ticket.repos = repos
-                # #800 N3: canonical locked RMW; extra + repos + state stay one
-                # atomic write via also_set (no split).
-                ticket.merge_extra(
-                    set_keys=cast("TicketExtra", dict(extra)),
-                    also_set={"state": state, "repos": repos},
-                )
-                result.tickets_updated += 1
-                if state == Ticket.State.DELIVERED:
-                    # Audit runs on EVERY Done sync (idempotent — dedups on the
-                    # existing marker), so a ticket the old owner-scoping bug
-                    # already left at DELIVERED still gets the marker once its
-                    # repo scope is repaired. Worktree cleanup, by contrast,
-                    # stays gated on the transition so it never re-runs (#1426).
-                    self._record_delivered_dod_violation(ticket)
-                    if prior_state != Ticket.State.DELIVERED:
-                        self._cleanup_ticket_worktrees(ticket, result)
+                self._create_ticket_from_board(board, self._overlay_name(overlay), result)
 
         self._sync_reviewer_prs(token, result)
 
         return result
+
+    @classmethod
+    def _create_ticket_from_board(cls, board: _BoardItem, overlay_name: str, result: SyncResult) -> None:
+        from teatree.core.intake.ticket_kind_classification import classify_ticket_kind  # noqa: PLC0415 — lazy: cycle
+        from teatree.core.models import Ticket  # noqa: PLC0415 — deferred: ORM import needs the app registry
+
+        created = Ticket.objects.create(
+            issue_url=board.item.url,
+            repos=[board.repo_short],
+            # A brand-new ticket has no local state to preserve, so an unmapped
+            # column starts it at the bottom of the ladder.
+            state=board.state or Ticket.State.NOT_STARTED,
+            extra=board.extra,
+            overlay=overlay_name,
+            kind=classify_ticket_kind(labels=board.item.labels, title=board.item.title),
+        )
+        result.tickets_created += 1
+        if board.state == Ticket.State.DELIVERED:
+            cls._record_delivered_dod_violation(created)
+
+    @classmethod
+    def _update_ticket_from_board(cls, ticket: "Ticket", board: _BoardItem, result: SyncResult) -> None:
+        from teatree.core.models import Ticket  # noqa: PLC0415 — deferred: ORM import needs the app registry
+
+        prior_state = ticket.state
+        # Repair the repo scope from the authoritative URL before the DoD check
+        # so the gate sees the real repo set (#1426).
+        repos = ticket.repos if isinstance(ticket.repos, list) else []
+        if board.repo_short and board.repo_short not in repos:
+            repos = [*repos, board.repo_short]
+        ticket.repos = repos
+        # The board is an advance-only signal: its column lags the ticket's own
+        # FSM, so a backward state would reset live work (Ticket.state_advances).
+        also_set: TicketSiblingFields = {"repos": repos}
+        if board.state is not None and Ticket.state_advances(ticket.state, board.state):
+            also_set["state"] = board.state
+        # #800 N3: canonical locked RMW; extra + repos + state stay one atomic
+        # write via also_set (no split).
+        ticket.merge_extra(set_keys=cast("TicketExtra", dict(board.extra)), also_set=also_set)
+        result.tickets_updated += 1
+        if board.state == Ticket.State.DELIVERED:
+            # Audit runs on EVERY Done sync (idempotent — dedups on the existing
+            # marker), so a ticket the old owner-scoping bug already left at
+            # DELIVERED still gets the marker once its repo scope is repaired.
+            # Worktree cleanup, by contrast, stays gated on the transition so it
+            # never re-runs (#1426).
+            cls._record_delivered_dod_violation(ticket)
+            if prior_state != Ticket.State.DELIVERED:
+                cls._cleanup_ticket_worktrees(ticket, result)
 
     @staticmethod
     def _record_delivered_dod_violation(ticket: "Ticket") -> None:

--- a/src/teatree/backends/gitlab/sync.py
+++ b/src/teatree/backends/gitlab/sync.py
@@ -10,7 +10,7 @@ literal endpoint being called.
 """
 
 import logging
-from typing import override
+from typing import TYPE_CHECKING, override
 
 from django.core.cache import cache
 from django.utils import timezone
@@ -25,6 +25,11 @@ from teatree.core.intake.label_admission import LabelPolicy
 from teatree.core.models import Ticket
 from teatree.core.sync import _overlay_name
 from teatree.types import LAST_SYNC_CACHE_KEY, PENDING_REVIEWS_CACHE_KEY, SyncBackend, SyncResult
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from teatree.backends.gitlab.api import GitLabAPI
 
 logger = logging.getLogger(__name__)
 
@@ -89,15 +94,38 @@ class GitLabSyncBackend(SyncBackend):
             Ticket.objects.in_flight().filter(overlay="").update(overlay=overlay_name)
 
         fetch_issue_labels(client, result)
-        detect_merged_prs(client, username, result, last_sync)
-        detect_closed_prs(client, username, result, last_sync)
+        self._sync_terminal_prs(client, username, result, last_sync=last_sync, sync_started_at=sync_started_at)
         fetch_review_permalinks(result)
         self._sync_reviewer_prs(host, username, result)
         self._detect_conflicted_prs(host, username, result)
 
-        cache.set(LAST_SYNC_CACHE_KEY, sync_started_at.isoformat(), timeout=None)
-
         return result
+
+    @classmethod
+    def _sync_terminal_prs(
+        cls,
+        client: "GitLabAPI",
+        username: str,
+        result: SyncResult,
+        *,
+        last_sync: str | None,
+        sync_started_at: "datetime",
+    ) -> None:
+        """Apply terminal PR status, then advance the watermark iff both windows were read.
+
+        The watermark is monotonic: advancing it past a window a fetch failed to
+        read retires that window forever, so an MR that merged inside it is never
+        seen again — its ticket never reaches MERGED and its worktrees are never
+        cleaned. Holding the previous watermark costs one overlapping re-fetch,
+        and both appliers are idempotent. The only other ``last_sync``-bounded
+        fetch is the open-PR one, which aborts the whole sync on failure.
+        """
+        merged_window_read = detect_merged_prs(client, username, result, last_sync)
+        closed_window_read = detect_closed_prs(client, username, result, last_sync)
+        if merged_window_read and closed_window_read:
+            cache.set(LAST_SYNC_CACHE_KEY, sync_started_at.isoformat(), timeout=None)
+        else:
+            logger.warning("Holding the GitLab sync watermark at %s — a terminal PR fetch failed.", last_sync)
 
     @classmethod
     def _detect_conflicted_prs(cls, host: GitLabCodeHost, username: str, result: SyncResult) -> None:

--- a/src/teatree/backends/gitlab/sync_prs.py
+++ b/src/teatree/backends/gitlab/sync_prs.py
@@ -27,7 +27,6 @@ _E2E_TEST_PLAN_RE = re.compile(
     re.IGNORECASE,
 )
 _SKILL_WRITTEN_FIELDS = ("review_channel", "review_permalink", "e2e_test_plan_url", "notion_status", "notion_url")
-_STATE_ORDER = [s.value for s in Ticket.State]
 
 
 @dataclass(frozen=True, slots=True)
@@ -245,7 +244,7 @@ def update_ticket(
     # same atomic write (no split).
     also_set: TicketSiblingFields = {"repos": repos}
     capped_state = workflow_capped_state(ticket, inferred_state) if inferred_state else inferred_state
-    if capped_state and _STATE_ORDER.index(capped_state) > _STATE_ORDER.index(ticket.state):
+    if capped_state and Ticket.state_advances(ticket.state, capped_state):
         also_set["state"] = capped_state
 
     set_keys = cast("TicketExtra", {"prs": prs})
@@ -265,7 +264,7 @@ def infer_state_from_prs(prs_data: dict[str, PREntryDict]) -> str:
             has_approvals = isinstance(approvals, dict) and int(approvals.get("count", 0)) > 0  # ty: ignore[no-matching-overload]
             review_requested = bool(pr.get("review_requested"))
             candidate = Ticket.State.IN_REVIEW if (has_approvals or review_requested) else Ticket.State.SHIPPED
-        if _STATE_ORDER.index(candidate) > _STATE_ORDER.index(best):
+        if Ticket.state_advances(best, candidate):
             best = candidate
     return best
 

--- a/src/teatree/backends/gitlab/sync_terminal.py
+++ b/src/teatree/backends/gitlab/sync_terminal.py
@@ -29,10 +29,13 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_STATE_ORDER = [s.value for s in Ticket.State]
 
+def detect_merged_prs(client: "GitLabAPI", username: str, result: SyncResult, last_sync: str | None) -> bool:
+    """Apply merged status to every in-flight ticket; return whether the fetch succeeded.
 
-def detect_merged_prs(client: "GitLabAPI", username: str, result: SyncResult, last_sync: str | None) -> None:
+    The caller advances the incremental sync watermark only on ``True`` — see
+    :func:`_fetch_terminal_pr_urls`.
+    """
     merged_urls = _fetch_terminal_pr_urls(
         client.list_recently_merged_mrs,
         username,
@@ -41,12 +44,14 @@ def detect_merged_prs(client: "GitLabAPI", username: str, result: SyncResult, la
         label="Merged",
     )
     if merged_urls is None:
-        return
+        return False
     for ticket in Ticket.objects.in_flight():
         apply_merged_status(ticket, merged_urls, result)
+    return True
 
 
-def detect_closed_prs(client: "GitLabAPI", username: str, result: SyncResult, last_sync: str | None) -> None:
+def detect_closed_prs(client: "GitLabAPI", username: str, result: SyncResult, last_sync: str | None) -> bool:
+    """Apply closed status to every in-flight ticket; return whether the fetch succeeded."""
     closed_urls = _fetch_terminal_pr_urls(
         client.list_recently_closed_mrs,
         username,
@@ -55,9 +60,10 @@ def detect_closed_prs(client: "GitLabAPI", username: str, result: SyncResult, la
         label="Closed",
     )
     if closed_urls is None:
-        return
+        return False
     for ticket in Ticket.objects.in_flight():
         apply_closed_status(ticket, closed_urls, result)
+    return True
 
 
 def apply_merged_status(ticket: Ticket, merged_urls: set[str], result: SyncResult) -> None:
@@ -73,7 +79,7 @@ def apply_merged_status(ticket: Ticket, merged_urls: set[str], result: SyncResul
 
     set_keys = cast("TicketExtra", {"prs": prs}) if changed else None
     also_set: TicketSiblingFields = {}
-    advancing_to_merged = all_merged and _STATE_ORDER.index(Ticket.State.MERGED) > _STATE_ORDER.index(ticket.state)
+    advancing_to_merged = all_merged and Ticket.state_advances(ticket.state, Ticket.State.MERGED)
     if advancing_to_merged:
         also_set["state"] = Ticket.State.MERGED
     if set_keys or also_set:
@@ -158,11 +164,16 @@ def _fetch_terminal_pr_urls(
     *,
     label: str,
 ) -> set[str] | None:
+    """The terminal PR URLs in the ``last_sync`` window, or ``None`` on a FAILED read.
+
+    An empty set means the window genuinely held no terminal PR; ``None`` means
+    the window was never read. Collapsing the two is what let a 502 look like
+    "nothing merged" to the caller, which then ratcheted the monotonic watermark
+    past the unread window — permanently skipping every MR that merged inside it.
+    """
     try:
         raw_prs = fetcher(username, updated_after=last_sync)
     except httpx.HTTPError as exc:
         result.errors.append(f"{label} PR fetch failed: {exc}")
-        return None
-    if not raw_prs:
         return None
     return {str(raw.get("web_url", "")) for raw in raw_prs}

--- a/src/teatree/core/gates/dod_gate.py
+++ b/src/teatree/core/gates/dod_gate.py
@@ -197,12 +197,6 @@ def check_local_e2e_dod(ticket: "Ticket") -> None:
 _DOD_VIOLATION_KEY = "dod_e2e_violation"
 
 
-def _state_index(state: str) -> int:
-    from teatree.core.models.ticket import Ticket  # noqa: PLC0415 — deferred: ORM import needs the app registry
-
-    return [s.value for s in Ticket.State].index(state)
-
-
 def _is_post_ship_state(state: str) -> bool:
     """True iff *state* is at or past SHIPPED on the lifecycle.
 
@@ -213,7 +207,7 @@ def _is_post_ship_state(state: str) -> bool:
     """
     from teatree.core.models.ticket import Ticket  # noqa: PLC0415 — deferred: ORM import needs the app registry
 
-    return _state_index(state) >= _state_index(Ticket.State.SHIPPED)
+    return Ticket.state_index(state) >= Ticket.state_index(Ticket.State.SHIPPED)
 
 
 def sync_gate_allows(ticket: "Ticket", inferred_state: str) -> bool:

--- a/src/teatree/core/models/ticket_state_sets.py
+++ b/src/teatree/core/models/ticket_state_sets.py
@@ -85,6 +85,24 @@ class TicketStateSetsModel(TicketFacet):
         return AdvanceResult(from_state=from_state, to_state=self.state)
 
     @classmethod
+    def state_index(cls, state: str) -> int:
+        """Position of *state* in the ``State`` declaration order."""
+        return [s.value for s in cls.State].index(state)
+
+    @classmethod
+    def state_advances(cls, current: str, candidate: str) -> bool:
+        """True iff writing *candidate* over *current* moves the ticket forward.
+
+        The single ordering every external-sync writer compares against. A
+        tracker/board tells us where IT thinks the ticket is; that is an
+        advance-only signal, never a rewind — a board column or an inferred PR
+        state that reads behind the ticket's own FSM would otherwise reset live
+        work (an in-review ticket back to not-started) and re-arm the loop's
+        scanners against already-delivered work.
+        """
+        return cls.state_index(candidate) > cls.state_index(current)
+
+    @classmethod
     def marker_release_states(cls) -> frozenset[str]:
         """Terminal-done states that free markers and trigger worktree teardown.
 

--- a/tests/quality/deferred_import_pegs.toml
+++ b/tests/quality/deferred_import_pegs.toml
@@ -32,7 +32,7 @@
 # app-load cycle). Nesting the two modules under core/fleet/ does not change these
 # runtime edges, so the deferrals stay and are pegged here.
 "src/teatree/core/fleet/wire.py" = 3
-"src/teatree/core/gates/dod_gate.py" = 3
+"src/teatree/core/gates/dod_gate.py" = 2
 "src/teatree/core/gates/e2e_mandatory_gate.py" = 3
 "src/teatree/core/gates/fix_dod_gate.py" = 1
 "src/teatree/core/gates/live_post_gate.py" = 1

--- a/tests/teatree_core/sync/test_state_monotonicity.py
+++ b/tests/teatree_core/sync/test_state_monotonicity.py
@@ -1,0 +1,129 @@
+"""External trackers are advance-only signals — a sync never rewinds a ticket.
+
+A board column and a PR-inferred state both describe where an EXTERNAL system
+thinks a ticket sits, which routinely lags the ticket's own FSM. Writing such a
+value unconditionally resets live work: a shipped ticket with an open PR drops
+back to not-started and the loop's scanners re-arm against delivered work.
+
+Both code hosts share the one ordering (``Ticket.state_advances``); the last
+class pins that shared contract so a third backend cannot reintroduce the
+asymmetry.
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from teatree.backends.github import ProjectItem
+from teatree.backends.github.sync import GitHubSyncBackend
+from teatree.backends.gitlab.sync_prs import update_ticket
+from teatree.core.models import Ticket
+from teatree.core.sync import sync_followup  # noqa: F401 — pins this suite to the sync package
+from tests.teatree_core.sync._overlays import SyncOverlay, _patch_overlay
+
+_ISSUE_URL = "https://github.com/souliane/teatree/issues/60"
+
+
+def _board_item(status: str, *, url: str = _ISSUE_URL) -> ProjectItem:
+    return ProjectItem(
+        issue_number=60,
+        title="Board item",
+        url=url,
+        status=status,
+        position=1,
+        labels=[],
+        updated_at="2026-05-01T00:00:00Z",
+    )
+
+
+class _GitHubBoardSync(TestCase):
+    """Runs one GitHub board sync against a single project item."""
+
+    def _sync(self, item: ProjectItem) -> None:
+        overlay = SyncOverlay(
+            gitlab_token="",
+            gitlab_username="",
+            github_token="gh-test-token",
+            github_owner="souliane",
+            github_project_number=1,
+        )
+        with (
+            _patch_overlay(overlay),
+            patch("teatree.backends.github.fetch_project_items", return_value=[item]),
+            patch.object(GitHubSyncBackend, "_sync_reviewer_prs"),
+            patch("teatree.backends.github.sync.cleanup_worktree"),
+        ):
+            GitHubSyncBackend().sync(overlay)
+
+
+class TestGitHubBoardStatusIsMonotonic(_GitHubBoardSync):
+    def test_unmapped_column_leaves_the_ticket_state_untouched(self) -> None:
+        ticket = Ticket.objects.create(issue_url=_ISSUE_URL, state=Ticket.State.SHIPPED)
+
+        with self.assertLogs("teatree.backends.github.sync", level="WARNING") as logs:
+            self._sync(_board_item("In Review"))
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SHIPPED
+        assert "In Review" in "\n".join(logs.output)
+        # The rest of the board payload still lands — only ``state`` is withheld.
+        assert ticket.extra["board_status"] == "In Review"
+
+    def test_unmapped_column_on_a_new_ticket_starts_at_not_started(self) -> None:
+        self._sync(_board_item("Backlog"))
+
+        ticket = Ticket.objects.get(issue_url=_ISSUE_URL)
+        assert ticket.state == Ticket.State.NOT_STARTED
+
+    def test_mapped_column_that_advances_is_applied(self) -> None:
+        ticket = Ticket.objects.create(issue_url=_ISSUE_URL, state=Ticket.State.NOT_STARTED)
+
+        self._sync(_board_item("In Progress"))
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.STARTED
+
+    def test_mapped_column_that_would_regress_is_withheld(self) -> None:
+        ticket = Ticket.objects.create(issue_url=_ISSUE_URL, state=Ticket.State.DELIVERED)
+
+        self._sync(_board_item("Todo"))
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.DELIVERED
+
+
+class TestBothBackendsShareOneMonotonicContract(_GitHubBoardSync):
+    """Same lagging signal, same verdict — whichever code host reports it."""
+
+    def test_github_board_does_not_rewind_a_shipped_ticket(self) -> None:
+        ticket = Ticket.objects.create(issue_url=_ISSUE_URL, state=Ticket.State.SHIPPED)
+
+        self._sync(_board_item("Todo"))
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SHIPPED
+
+    def test_gitlab_pr_inference_does_not_rewind_a_shipped_ticket(self) -> None:
+        pr_url = "https://gitlab.com/org/repo/-/merge_requests/60"
+        ticket = Ticket.objects.create(
+            issue_url="https://gitlab.com/org/repo/-/issues/60",
+            state=Ticket.State.SHIPPED,
+            repos=["repo"],
+        )
+
+        update_ticket(
+            ticket,
+            {"title": "MR60"},
+            pr_url,
+            "repo",
+            inferred_state=Ticket.State.NOT_STARTED,
+        )
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.SHIPPED
+        assert pr_url in ticket.extra["prs"]
+
+    def test_state_advances_orders_the_lifecycle(self) -> None:
+        assert Ticket.state_advances(Ticket.State.NOT_STARTED, Ticket.State.SHIPPED)
+        assert not Ticket.state_advances(Ticket.State.SHIPPED, Ticket.State.NOT_STARTED)
+        assert not Ticket.state_advances(Ticket.State.SHIPPED, Ticket.State.SHIPPED)

--- a/tests/teatree_core/sync/test_watermark_hold.py
+++ b/tests/teatree_core/sync/test_watermark_hold.py
@@ -1,0 +1,120 @@
+"""The incremental sync watermark must never ratchet past an unread window.
+
+``LAST_SYNC_CACHE_KEY`` is monotonic: once it advances to T, no later sync ever
+asks the forge about anything before T. Advancing it after a failed
+``last_sync``-bounded fetch therefore retires that window permanently — an MR
+that merged inside it is never seen again, so its ticket never reaches MERGED
+and its worktrees are never cleaned.
+"""
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from django.core.cache import cache
+from django.test import TestCase
+
+from teatree.core.models import Ticket
+from teatree.core.sync import sync_followup
+from teatree.types import LAST_SYNC_CACHE_KEY
+from tests.teatree_core.sync._overlays import SyncOverlay, _make_mock_client, _patch_overlay
+
+_WATERMARK = "2020-01-01T00:00:00+00:00"
+_MERGED_INSIDE_WINDOW = "2020-01-01T01:00:00+00:00"
+_MR_URL = "https://gitlab.com/org/repo/-/merge_requests/42"
+_MERGED_MR = {"web_url": _MR_URL, "iid": 42, "project_id": 123}
+
+
+class _WindowedMergedFetcher:
+    """A server-side ``updated_after`` window, plus a scripted outage.
+
+    Mirrors what GitLab does: an MR merged at ``_MERGED_INSIDE_WINDOW`` is
+    returned only while the caller's cutoff is at or before that instant. A
+    watermark that advanced past the outage puts the cutoff beyond it, and the
+    merge becomes unreachable.
+    """
+
+    def __init__(self, *, fail_first: bool) -> None:
+        self.fail_first = fail_first
+        self.cutoffs: list[str | None] = []
+
+    def __call__(self, _username: str, *, updated_after: str | None = None) -> list[dict[str, object]]:
+        self.cutoffs.append(updated_after)
+        if self.fail_first and len(self.cutoffs) == 1:
+            msg = "502 Bad Gateway"
+            raise httpx.HTTPError(msg)
+        if updated_after is not None and updated_after > _MERGED_INSIDE_WINDOW:
+            return []
+        return [_MERGED_MR]
+
+
+class TestWatermarkHeldOnFailedIncrementalFetch(TestCase):
+    _OVERLAY = SyncOverlay()
+
+    @pytest.fixture(autouse=True)
+    def _with_overlay(self, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+        self._monkeypatch = monkeypatch
+        cache.delete(LAST_SYNC_CACHE_KEY)
+        with _patch_overlay(self._OVERLAY):
+            yield
+        cache.delete(LAST_SYNC_CACHE_KEY)
+
+    def _install(self, mock_client: MagicMock) -> None:
+        self._monkeypatch.setattr("teatree.backends.gitlab.api.GitLabAPI", lambda **_kw: mock_client)
+
+    def test_merged_fetch_failure_holds_the_watermark(self) -> None:
+        cache.set(LAST_SYNC_CACHE_KEY, _WATERMARK, timeout=None)
+        mock_client = _make_mock_client([])
+        mock_client.list_recently_merged_mrs.side_effect = httpx.HTTPError("502 Bad Gateway")
+        self._install(mock_client)
+
+        result = sync_followup()
+
+        assert any("Merged PR fetch failed" in e for e in result.errors)
+        assert cache.get(LAST_SYNC_CACHE_KEY) == _WATERMARK
+
+    def test_closed_fetch_failure_holds_the_watermark(self) -> None:
+        cache.set(LAST_SYNC_CACHE_KEY, _WATERMARK, timeout=None)
+        mock_client = _make_mock_client([])
+        mock_client.list_recently_closed_mrs.side_effect = httpx.HTTPError("502 Bad Gateway")
+        self._install(mock_client)
+
+        result = sync_followup()
+
+        assert any("Closed PR fetch failed" in e for e in result.errors)
+        assert cache.get(LAST_SYNC_CACHE_KEY) == _WATERMARK
+
+    def test_fully_successful_sync_advances_the_watermark(self) -> None:
+        cache.set(LAST_SYNC_CACHE_KEY, _WATERMARK, timeout=None)
+        self._install(_make_mock_client([]))
+
+        result = sync_followup()
+
+        assert result.errors == []
+        assert cache.get(LAST_SYNC_CACHE_KEY) != _WATERMARK
+
+    def test_merge_inside_the_failed_window_is_still_applied_on_the_next_sync(self) -> None:
+        """The end-to-end property: a skipped window loses the merge forever."""
+        cache.set(LAST_SYNC_CACHE_KEY, _WATERMARK, timeout=None)
+        ticket = Ticket.objects.create(
+            overlay="test",
+            issue_url="https://gitlab.com/org/repo/-/issues/100",
+            repos=["repo"],
+            state=Ticket.State.IN_REVIEW,
+            extra={"prs": {_MR_URL: {"title": "MR42"}}},
+        )
+        fetcher = _WindowedMergedFetcher(fail_first=True)
+        mock_client = _make_mock_client([])
+        mock_client.list_recently_merged_mrs.side_effect = fetcher
+        self._install(mock_client)
+
+        sync_followup()
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.IN_REVIEW
+
+        sync_followup()
+
+        ticket.refresh_from_db()
+        assert ticket.state == Ticket.State.MERGED
+        assert fetcher.cutoffs == [_WATERMARK, _WATERMARK]

--- a/tests/teatree_core/sync/test_watermark_hold.py
+++ b/tests/teatree_core/sync/test_watermark_hold.py
@@ -15,9 +15,10 @@ import pytest
 from django.core.cache import cache
 from django.test import TestCase
 
+from teatree.backends.gitlab.sync_terminal import detect_closed_prs, detect_merged_prs
 from teatree.core.models import Ticket
 from teatree.core.sync import sync_followup
-from teatree.types import LAST_SYNC_CACHE_KEY
+from teatree.types import LAST_SYNC_CACHE_KEY, SyncResult
 from tests.teatree_core.sync._overlays import SyncOverlay, _make_mock_client, _patch_overlay
 
 _WATERMARK = "2020-01-01T00:00:00+00:00"
@@ -47,6 +48,40 @@ class _WindowedMergedFetcher:
         if updated_after is not None and updated_after > _MERGED_INSIDE_WINDOW:
             return []
         return [_MERGED_MR]
+
+
+class TestTerminalDetectionReportsWhetherItReadTheWindow(TestCase):
+    """An empty window and a failed read are different outcomes, reported apart."""
+
+    def test_merged_detection_reports_read_on_an_empty_window(self) -> None:
+        client = MagicMock()
+        client.list_recently_merged_mrs.return_value = []
+        result = SyncResult()
+
+        assert detect_merged_prs(client, "testuser", result, None) is True
+        assert result.errors == []
+
+    def test_merged_detection_reports_unread_on_a_failed_fetch(self) -> None:
+        client = MagicMock()
+        client.list_recently_merged_mrs.side_effect = httpx.HTTPError("502 Bad Gateway")
+        result = SyncResult()
+
+        assert detect_merged_prs(client, "testuser", result, None) is False
+        assert result.errors == ["Merged PR fetch failed: 502 Bad Gateway"]
+
+    def test_closed_detection_reports_read_on_an_empty_window(self) -> None:
+        client = MagicMock()
+        client.list_recently_closed_mrs.return_value = []
+
+        assert detect_closed_prs(client, "testuser", SyncResult(), None) is True
+
+    def test_closed_detection_reports_unread_on_a_failed_fetch(self) -> None:
+        client = MagicMock()
+        client.list_recently_closed_mrs.side_effect = httpx.HTTPError("502 Bad Gateway")
+        result = SyncResult()
+
+        assert detect_closed_prs(client, "testuser", result, None) is False
+        assert result.errors == ["Closed PR fetch failed: 502 Bad Gateway"]
 
 
 class TestWatermarkHeldOnFailedIncrementalFetch(TestCase):


### PR DESCRIPTION
fix(backends): hold the sync watermark on failure; make board-status writes monotonic

## What

Two independent sync-correctness bugs, fixed together because they are the same
class of defect: an external signal being written into local state without
asking whether it can be trusted.

**Bug 1 — GitLab sync advanced its incremental watermark past a FAILED fetch (permanent data loss).**

`_fetch_terminal_pr_urls` returned `None` for both *"the fetch raised"* and
*"the window was genuinely empty"*, and `GitLabSyncBackend.sync()` then set
`LAST_SYNC_CACHE_KEY` unconditionally at the end of the run.

So: a sync at T calls `detect_merged_prs(..., last_sync=T-1h)`; GitLab 502s on
`list_recently_merged_mrs`. The error is appended to `result.errors`, the sync
continues, and the watermark ratchets to T. The watermark is monotonic, so the
next sync only asks for MRs merged **after T** — an MR that merged inside the
`T-1h .. T` window is never seen again. `apply_merged_status` never fires, the
ticket never reaches MERGED, and `_cleanup_merged_worktrees` never runs. Silent
and permanent, because the failure window is skipped rather than retried.

The fix is the reader-fails-loud / caller-decides split:

- `_fetch_terminal_pr_urls` no longer collapses failure into empty — `None`
  means the window was *not read*, an empty set means it was read and held
  nothing.
- `detect_merged_prs` / `detect_closed_prs` report whether they read their window.
- `_sync_terminal_prs` advances the watermark only when **both** did, otherwise
  it holds the previous value and logs. Holding costs one overlapping re-fetch;
  both appliers are idempotent.

Every other `last_sync`-bounded fetch in the sync was audited: the open-PR
fetch (`list_my_prs(updated_after=last_sync)`) already aborts the whole sync on
failure, so it cannot reach the watermark write. The conflict-check and
reviewer-PR fetches are deliberately non-incremental, so their failures
correctly do **not** hold the watermark.

**Bug 2 — GitHub board sync clobbered local ticket state with an unmapped-column default.**

`status_map.get(item.status, Ticket.State.NOT_STARTED)` written through
`merge_extra(also_set={"state": state, ...})` — unconditional and
non-monotonic. Any board column not spelled exactly `Todo` / `In Progress` /
`Done` (Backlog, In Review, Blocked, Ready, or a renamed column) mapped to
NOT_STARTED and overwrote the ticket's real FSM state on every sync, so a
ticket at shipped/in_review with an open PR was reset to not_started and the
loop's scanners re-armed against already-delivered work.

Now an unmapped column is logged and **skipped** (the ticket's own state is left
alone; the rest of the board payload still lands), and a mapped column is
applied only when it *advances* the ticket — the guard the GitLab PR sync
already had at `sync_prs.py`.

**Honest impact note:** bug 2 is latent on this deployment. No
`github_project_number` is configured, so `GitHubSyncBackend.sync()`
short-circuits early and the code path never runs here. It bites the first
operator who wires a GitHub project board with any column beyond the three.
Fixed anyway — it is a data-loss-shaped bug waiting on a config change.

## Why

Both backends were making the same category error in opposite directions: one
trusted a failed read as an empty result, the other trusted a lagging external
signal as authoritative local state.

The asymmetry between the two backends was unpinned anywhere — GitLab had the
monotonic guard, GitHub did not, and nothing said they should agree. This PR
gives both one shared ordering, `Ticket.state_advances`, on the existing
`TicketStateSetsModel` facet, and pins the shared contract with a test class
that exercises the same lagging signal through both code hosts. That helper
also replaces the three hand-rolled copies of `[s.value for s in Ticket.State]`
that had accumulated in `dod_gate`, `gitlab/sync_prs` and
`gitlab/sync_terminal`, so a fourth backend cannot re-derive its own.

## Tests

Every new regression test was verified anti-vacuous by reverting the fix and
confirming it goes RED (6 RED / 5 GREEN with both fixes reverted; 11 GREEN with
them restored).

- `tests/teatree_core/sync/test_watermark_hold.py`
  - a merged-fetch `HTTPError` holds the watermark
  - a closed-fetch `HTTPError` holds the watermark
  - a fully-successful sync **advances** it (the control — this fails if the
    watermark is simply never written)
  - end-to-end: a `_WindowedMergedFetcher` models GitLab's server-side
    `updated_after` bound; the MR that merged inside the failed window is still
    applied on the *next* sync, and both syncs are proven to have asked with the
    same cutoff
- `tests/teatree_core/sync/test_state_monotonicity.py`
  - an unmapped column leaves `ticket.state` untouched and logs a warning
  - an unmapped column on a *new* ticket starts at NOT_STARTED (no local state
    to preserve)
  - a mapped column that advances is applied
  - a mapped column that would regress (Done → Todo on a delivered ticket) is withheld
  - the shared contract: the same lagging signal is withheld by **both** the
    GitHub board sync and the GitLab PR-state inference

## Verification

- `uv run pytest tests/teatree_core/sync/ tests/teatree_backends/ tests/teatree_core/gates/ tests/teatree_core/models/` — 2790 passed, 5 skipped
- `uv run ruff check` / `ruff format` / `uv run ty check` on all changed files — clean
- `uv run tach check` — all modules validated
- `t3 tool test-path-mirror` — ledger exact, ratchet holds
- `uv run pytest tests/quality/test_no_flat_core_regrowth.py` — passed
- `scripts/hooks/check_module_health.py` + `t3 tool comment-density` — no findings
- Full pre-commit and pre-push gate suites green (including the privacy, leak
  and near-zero-comments gates)

Two lint errors surfaced from the added branches (`sync` complexity on the
GitHub side, too many locals on the GitLab side) and were fixed structurally —
a `_BoardItem` value object plus create/update split on GitHub, and a
`_sync_terminal_prs` method on GitLab. No suppressions were added.

## Architecture pre-check

1. **BLUEPRINT § alignment** — no BLUEPRINT change: this is a behaviour fix
   inside two existing `SyncBackend` implementations, not a topology change.
2. **FSM phase boundaries** — no new transitions. The change *narrows* when
   `state` is written by a sync writer (advance-only), and preserves the
   existing terminal-DoD audit behaviour on a board `Done`.
3. **Extension-point contracts** — `SyncBackend.sync()` signature unchanged.
   `detect_merged_prs` / `detect_closed_prs` change `None` → `bool`; both are
   internal to `teatree.backends.gitlab` and their only callers are updated here.
4. **Component boundaries** — the shared ordering belongs on the model that owns
   `State`, so it went on the existing `TicketStateSetsModel` facet rather than
   a new module.
5. **Dependency direction** — no new cross-module imports; `uv run tach check`
   clean. `dod_gate` keeps its existing deferred `Ticket` import.
6. **Test surface** — two new test modules, listed above, each verified RED
   before GREEN.
7. **Resilience invariants** — this PR *restores* two of them. Idempotency: the
   held watermark relies on the terminal appliers being idempotent (they are —
   re-applying a merged URL is a no-op once the entry reads `merged`).
   Fail-loud: the terminal read no longer laundders an error into an empty result.
8. **Identity / key normalization** — n/a.
9. **Behavior preservation** — the only intentional behaviour removals are the
   two bugs. One incidental change: with an empty (but successfully read)
   terminal window, the in-flight ticket loop now runs and no-ops, where it
   previously short-circuited — the cost of distinguishing empty from failed.
   No test was inverted or weakened.
10. **Removability / harness-vs-data** — `_BoardItem` is a local value object,
    removable without a cascade. `Ticket.state_advances` is harness (a pure
    ordering predicate over an enum the model already declares), not data.
