### PR TITLE
fix(eval): make a failing eval leg diagnosable from the run it already spent

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -105,6 +105,21 @@
 #   failed-workflow-run email goes to the maintainer (Actions → Notifications) with
 #   no extra secret and no bot — that is the failure-notification mechanism here.
 #
+# RED-LEG DIAGNOSIS (souliane/teatree#3745)
+#   A metered leg is expensive to re-run (~2% of the subscription's weekly window per
+#   attempt), so a red leg MUST be diagnosable from the run it already spent — never
+#   by firing another one. Three artifacts back that, all uploaded `if: always()` and
+#   all named per matrix leg (`<lane>-<shard>-<effort>`, so the fan-out's legs cannot
+#   collide or overwrite each other):
+#     * `eval-run-log-*`   — the raw teed stdout/stderr of EVERY attempt. Exists from
+#       the first byte, so it is the only one that survives a leg that dies mid-run.
+#     * `eval-report-*`    — the per-trial transcripts (rendered at end of run).
+#     * `eval-summary-*`   — the sanitized publish-safe summary (ditto).
+#   And the first diagnosis needs NO download at all: on a non-zero exit the eval step
+#   re-prints the captured tail plus the summary into the job log, then re-raises the
+#   real exit code. See the block above the eval step's `command:` for the two gaps
+#   that made a red leg emit only `Child_process exited with error code 1`.
+#
 # The FREE deterministic TESTS (eval-pinned-regressions push-stage) are
 # unaffected — they gate every push via
 # prek and the regression corpus is asserted every PR via pytest. Only the
@@ -427,6 +442,9 @@ jobs:
           # a pure no-op: MODEL_FLAG stays "" below and the emitted command is
           # byte-identical to a run with no `model` input at all.
           EVAL_MODEL: ${{ inputs.model || '' }}
+          # The per-leg (lane-shard-effort) filename token, so the command block names
+          # its summary + captured-log files without re-inlining the expression.
+          EVAL_SUFFIX: ${{ steps.artifact.outputs.suffix }}
         with:
           # A single shard is ≤ its lane's ceiling (clean_room ≤14, under_load ≤4 —
           # #2683) x 3 trials, each a real metered `claude` SDK call. Each retry
@@ -455,19 +473,63 @@ jobs:
           # private transcript — both land in $RUNNER_TEMP (the writable artifacts
           # mount). The `publish` job merges every shard's summary into the public
           # dashboard; the transcript stays in the private `eval-report-*` artifact.
+          #
+          # FAILURE OBSERVABILITY (#3745). A red leg used to emit ONLY the retry
+          # action's `Child_process exited with error code 1` — no scenario name, no
+          # pass@k line, no traceback — so every diagnostic re-run re-spent ~2% of the
+          # subscription's weekly window for zero information. Two gaps caused that,
+          # and `tee` closes both:
+          #   * The container's output was STREAMED but never STORED. `t3 eval run
+          #     --docker` does inherit the container's stdio (`run_streamed`) and
+          #     nick-fields/retry does forward the child's stdout, so the bytes reach
+          #     the live log — but nothing wrote them to a file, so nothing could be
+          #     uploaded, and anything lost to the 80min SIGTERM kill (or the action's
+          #     exit-vs-close drain race) was gone for good.
+          #   * `--summary-md` is rendered at the END of a run, so a leg that dies
+          #     mid-run NEVER writes it. The upload step's `if: always()` was already
+          #     correct; the file simply did not exist, which is why the summary
+          #     artifact looked un-uploaded on exactly the failures that needed it.
+          # So the run is teed to a durable $RUNNER_TEMP log (uploaded as its own
+          # per-leg artifact below, and the ONLY artifact that survives a pre-summary
+          # death), and on non-zero exit the tail + the summary are re-printed from
+          # that file into the job log — the first diagnosis needs no download.
+          # `set -o pipefail` keeps `tee` from masking the eval's exit code, and the
+          # block ends in `exit "$rc"`: this adds visibility, it never swallows the
+          # failure. Printing INSIDE the command block is what makes EACH attempt
+          # visible — attempt 1's tail lands before the retry's "Attempt 1 failed"
+          # line, instead of being discarded when attempt 2 starts. `tee -a` keeps
+          # both attempts in the one uploaded log.
           command: |
+            set -o pipefail
             EFFORT_FLAG=""
             [ -n "$EVAL_EFFORT" ] && EFFORT_FLAG="--effort $EVAL_EFFORT"
             MODEL_FLAG=""
             [ -n "$EVAL_MODEL" ] && MODEL_FLAG="--model $EVAL_MODEL"
             PRESET_FLAG=""
             [ -n "$EVAL_PRESET" ] && PRESET_FLAG="--preset $EVAL_PRESET"
+            TAIL_LINES=400
+            SUMMARY="$RUNNER_TEMP/eval-summary-$EVAL_SUFFIX.md"
+            LOG="$RUNNER_TEMP/eval-run-$EVAL_SUFFIX.log"
+            echo "===== attempt started $(date -u +%Y-%m-%dT%H:%M:%SZ) · leg $EVAL_SUFFIX =====" >> "$LOG"
             uv run t3 eval run --trials "$EVAL_TRIALS" --require any --backend "$EVAL_BACKEND" \
               --lane "$EVAL_LANE" --shard "$EVAL_SHARD" $EFFORT_FLAG $PRESET_FLAG \
               --require-executed --docker \
               --transcript-html "$RUNNER_TEMP/eval-transcripts.html" \
-              --summary-md "$RUNNER_TEMP/eval-summary-${{ steps.artifact.outputs.suffix }}.md" \
-              $MODEL_FLAG
+              --summary-md "$SUMMARY" \
+              $MODEL_FLAG 2>&1 | tee -a "$LOG"
+            rc=$?
+            [ "$rc" -eq 0 ] && exit 0
+            echo "::group::leg $EVAL_SUFFIX FAILED (exit $rc) — last $TAIL_LINES captured lines"
+            tail -n "$TAIL_LINES" "$LOG" || echo "nothing captured at $LOG"
+            echo "::endgroup::"
+            if [ -s "$SUMMARY" ]; then
+              echo "::group::leg $EVAL_SUFFIX FAILED — eval summary"
+              cat "$SUMMARY"
+              echo "::endgroup::"
+            else
+              echo "No summary at $SUMMARY: the run died before rendering one, so the tail above is the whole diagnosis."
+            fi
+            exit "$rc"
       # Publish the per-trial transcript report THIS leg emitted as a job artifact.
       # `if: always()` so a red leg still publishes it (the report is exactly what a
       # maintainer reads to triage the failure; the eval step above already decided
@@ -492,6 +554,21 @@ jobs:
         with:
           name: eval-summary-${{ steps.artifact.outputs.suffix }}
           path: ${{ runner.temp }}/eval-summary-${{ steps.artifact.outputs.suffix }}.md
+          if-no-files-found: warn
+      # The RAW captured stdout/stderr of every attempt (the `tee -a` target in the
+      # eval command). Unlike the transcript and the summary — both rendered only if
+      # the run reaches its end — this file exists from the first byte, so it is the
+      # one artifact that survives a leg that died mid-run, which is precisely the
+      # failure class that used to leave a maintainer with nothing but "exit code 1".
+      # `if: always()` because a GREEN leg needs none of this; a red one needs all of
+      # it. NOT downloaded by the `publish` job — it is unsanitized, so it stays out
+      # of the public dashboard alongside the private transcript.
+      - name: Upload the raw eval run log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: eval-run-log-${{ steps.artifact.outputs.suffix }}
+          path: ${{ runner.temp }}/eval-run-${{ steps.artifact.outputs.suffix }}.log
           if-no-files-found: warn
 
   # PUBLISH: merge every shard's sanitized summary into ONE public dashboard and

--- a/tests/test_eval_failure_observability.py
+++ b/tests/test_eval_failure_observability.py
@@ -1,0 +1,112 @@
+"""A red behavioral-eval leg must be diagnosable from the run that already spent.
+
+Each metered leg costs ~2% of the subscription's weekly usage window, so a leg that
+fails while emitting only the retry action's ``Child_process exited with error code
+1`` makes every diagnostic re-run pure waste. These tests pin the observability
+contract in ``.github/workflows/eval.yml``: the run's output is captured to a durable
+file, every diagnostic artifact uploads unconditionally under a per-leg-unique name,
+and a failing leg re-prints its tail + summary into the job log while still
+propagating the real exit code.
+"""
+
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_GH_EVAL = _REPO_ROOT / ".github" / "workflows" / "eval.yml"
+
+_SUFFIX_EXPR = "steps.artifact.outputs.suffix"
+_UPLOAD_ACTION = "actions/upload-artifact"
+_RETRY_ACTION = "nick-fields/retry"
+
+
+def _eval_steps() -> list[dict[str, Any]]:
+    jobs = cast("dict[str, Any]", yaml.safe_load(_GH_EVAL.read_text(encoding="utf-8"))["jobs"])
+    return cast("list[dict[str, Any]]", jobs["eval"]["steps"])
+
+
+def _upload_steps() -> list[dict[str, Any]]:
+    steps = [step for step in _eval_steps() if step.get("uses", "").startswith(_UPLOAD_ACTION)]
+    assert steps, "the eval job must upload diagnostic artifacts."
+    return steps
+
+
+def _eval_command() -> str:
+    for step in _eval_steps():
+        if step.get("uses", "").startswith(_RETRY_ACTION) and "t3 eval run" in step.get("with", {}).get("command", ""):
+            return cast("str", step["with"]["command"])
+    msg = "No retry-wrapped `t3 eval run` step in the eval job."
+    raise AssertionError(msg)
+
+
+def _upload_step_named(name_fragment: str) -> dict[str, Any]:
+    for step in _upload_steps():
+        if name_fragment in step["with"]["name"]:
+            return step
+    msg = f"No upload-artifact step publishing a {name_fragment!r} artifact."
+    raise AssertionError(msg)
+
+
+class TestDiagnosticArtifactsSurviveAFailingLeg:
+    def test_every_artifact_upload_is_unconditional(self) -> None:
+        # A success-only (or absent) `if:` drops the artifact on exactly the runs that
+        # need it — the whole point of uploading a summary is to explain a failure.
+        for step in _upload_steps():
+            assert step.get("if") == "always()", (
+                f"Upload step {step.get('name')!r} must be `if: always()` so a RED leg still "
+                f"publishes its diagnostics; got {step.get('if')!r}."
+            )
+
+    def test_artifact_names_are_unique_per_matrix_leg(self) -> None:
+        # The fan-out runs many legs in parallel; a shared artifact name collides and
+        # silently keeps only one leg's diagnostics.
+        for step in _upload_steps():
+            assert _SUFFIX_EXPR in step["with"]["name"], (
+                f"Artifact name {step['with']['name']!r} must carry the per-leg "
+                f"lane/shard/effort suffix so parallel legs cannot collide."
+            )
+
+    def test_raw_run_log_is_uploaded(self) -> None:
+        # The transcript and the summary are rendered at END of run, so a leg that
+        # dies mid-run writes neither. The teed log exists from the first byte.
+        step = _upload_step_named("eval-run-log")
+        assert "eval-run-" in step["with"]["path"], "the raw-log artifact must publish the teed run log."
+
+
+class TestFailureOutputReachesTheJobLog:
+    def test_run_output_is_captured_to_a_durable_file(self) -> None:
+        command = _eval_command()
+        assert "tee -a" in command, (
+            "The eval run's combined output must be teed to a file: streaming alone leaves "
+            "nothing to upload and loses everything killed by the step timeout."
+        )
+        assert "2>&1" in command, "stderr must be merged into the captured stream (tracebacks land on stderr)."
+        assert 'LOG="$RUNNER_TEMP/eval-run-$EVAL_SUFFIX.log"' in command, (
+            "the captured log must live in $RUNNER_TEMP under the per-leg suffix so it can be uploaded."
+        )
+
+    def test_failure_prints_the_captured_tail_and_the_summary(self) -> None:
+        command = _eval_command()
+        assert "tail -n" in command, "a failing leg must print the tail of the captured output into the job log."
+        assert 'cat "$SUMMARY"' in command, "a failing leg must print the summary markdown when one was rendered."
+
+    def test_the_real_exit_code_is_preserved(self) -> None:
+        command = _eval_command()
+        assert "set -o pipefail" in command, (
+            "`tee` would otherwise mask a non-zero eval exit code and turn a red leg green."
+        )
+        assert 'exit "$rc"' in command, (
+            "The failure handler adds visibility, never swallows the error — the leg must still fail."
+        )
+
+    def test_each_attempt_reports_its_own_failure(self) -> None:
+        # Printing INSIDE the retried command is what makes attempt 1 visible; a
+        # post-step handler would only ever see the final attempt.
+        command = _eval_command()
+        marker = command.index("tail -n")
+        assert command.index("t3 eval run") < marker, (
+            "the tail print must follow the eval invocation inside the retried command, "
+            "so every attempt surfaces its own failure output."
+        )


### PR DESCRIPTION
fix(eval): make a failing eval leg diagnosable from the run it already spent

## What

- **Tee the eval run's combined stdout/stderr** to a durable
  `$RUNNER_TEMP/eval-run-<lane>-<shard>-<effort>.log`, and upload it as a new
  per-leg **`eval-run-log-*`** artifact (`if: always()`).
- **On non-zero exit, print into the job log** — the captured tail (400 lines)
  plus the summary markdown, in collapsible `::group::` blocks — then re-raise
  the real exit code. `set -o pipefail` keeps `tee` from masking that code and
  the block ends in `exit "$rc"`: this adds visibility, it never swallows the
  failure. **The leg still fails.**
- **Each attempt is now visible.** The print happens *inside* the retried
  command, so attempt 1's tail lands in the log before the retry action's
  `Attempt 1 failed` line instead of being discarded when attempt 2 starts.
  `tee -a` keeps both attempts in the one uploaded log.
- **Pinned** by `tests/test_eval_failure_observability.py`: unconditional
  uploads, per-leg-unique artifact names, the tee, the tail+summary print, and
  the preserved exit code.

## Why

A red leg emitted only `Child_process exited with error code 1` — no scenario
name, no pass@k line, no verdict, no traceback. So a failing eval was
unactionable, and each diagnostic re-run re-spent **~2% of the subscription's
finite weekly window for zero information**. Measured: run `30150632748` failed
8/21 legs; run `30156207943` failed 13/13, with headroom going 7%→5% across the
second while the 5h window stayed 93% free (so quota was not the trigger).

Two separate gaps caused the blindness:

1. **The container's output was STREAMED but never STORED.** `t3 eval run
   --docker` *does* inherit the container's stdio (`run_streamed` uses
   `Popen` with stdout inherited and stderr teed), and `nick-fields/retry`
   *does* forward the child's stdout (`spawn(command, {shell:'bash'})` +
   `child.stdout.on('data', … process.stdout.write)`). So the bytes do reach the
   live log — but nothing wrote them to a file, so nothing could be uploaded,
   and anything lost to the 80min `SIGTERM` kill or the action's
   `exit`-vs-`close` drain race was gone for good.
2. **`--summary-md` is rendered at the END of a run**, so a leg that dies
   mid-run never writes it. The upload step's `if: always()` was *already*
   correct and the artifact names were *already* per-leg unique — the file
   simply did not exist, which is exactly why the summary looked un-uploaded on
   the failures that needed it. The teed log exists from the first byte, so it
   is the one artifact that survives a pre-summary death.

## Verification (no eval run fired — the weekly window is nearly spent)

- YAML parses: `python -c "import yaml; yaml.safe_load(open('.github/workflows/eval.yml'))"`.
- The command block was **extracted from the YAML and executed against a stub**,
  with controls: fails-without-summary → tail + honest "no summary" note, `rc=1`;
  fails-with-summary → also cats the summary, `rc=1`; **green run → zero failure
  output, `rc=0`**. Durable log present on disk; `tee -a` accumulated both
  attempts.
- The new test was confirmed **RED against the pre-fix workflow** (5 of 7
  assertions) before being made green. The 2 that stayed green are the two
  properties already correct on `main` — they are regression guards.
- `ruff check` / `ruff format --check` / `ty check` clean on the new test;
  `tests/quality/test_no_flat_core_regrowth.py` passed; `t3 tool
  test-path-mirror` ledger exact. The 4 pre-existing
  `test_eval_ci_retries_transient_failures` assertions still pass — no test was
  inverted or weakened. No full suite (RAM-constrained box).

## Architecture pre-check

Tactical CI-observability change — no `src/teatree` module, FSM transition,
`OverlayBase` hook, Protocol surface, or dependency edge is touched, so the
ten-check gate does not fire. **Test surface:** the new
`tests/test_eval_failure_observability.py` is the observable contract.
**Behavior preservation:** purely additive — no matcher narrowed, no capability
removed, no must-block test inverted. **Removability:** self-contained (delete
the tee/failure block and the one upload step and the workflow reverts to
today's behavior). **Harness vs data:** the tail depth is a literal in the one
command block that consumes it, not a new setting — a per-leg policy table would
be machinery with no second consumer.

## Open questions & assumptions

- **The retry is KEPT at 2 attempts, not disabled.** Its cost only lands on an
  already-failed leg; a transient flake retried in-run is cheaper than the
  manual re-run it replaces (the same window either way); and removing it would
  delete a capability *and* force inverting the existing must-pass
  `test_eval_ci_retries_transient_failures` assertions. What made the retry
  actively harmful was that it **discarded attempt 1's output** — that is the
  part this change fixes. Say the word if you'd rather drop it to 1 attempt.
- `eval.yml` writes **no JSON result file** to `$RUNNER_TEMP` (the only `.json`
  is the `prepare` job's unrelated `prs.json`), so there was no JSON upload to
  make unconditional.
- The new raw log is **unsanitized**, so it is deliberately *not* downloaded by
  the `publish` job — it stays out of the public dashboard alongside the private
  transcript.
- `eval-weekly-reusable.yml`'s benchmark leg has the same capture-less shape.
  Left untouched to keep this scoped to the measured failure path — worth the
  same treatment as a follow-up if you want it.
