### PR TITLE
fix(deps): restore the known-green claude-agent-sdk pin and quarantine it from auto-bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,14 @@ updates:
       python-deps:
         patterns:
           - "*"
+    ignore:
+      # QUARANTINE, not staleness: a bundled claude CLI at/after 2.1.204 emits a
+      # markdown `**AskUserQuestion**` chip instead of a `tool_use` block, so
+      # every AskUserQuestion eval scenario reds. The exact pin alone did not
+      # hold the quarantine — an automated bump rewrote the pin and its guard
+      # constant in one change. A bump must be opened by hand and re-verified
+      # against the metered eval lane (souliane/teatree#3125).
+      - dependency-name: "claude-agent-sdk"
 
   # SHA-pinned actions are kept current by Dependabot: it reads the `# vN`
   # comment tag and proposes a PR when a new release resolves to a different SHA.

--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -619,7 +619,7 @@ Reference DB architecture, the import fallback chain (`DjangoDbImportConfig` str
 
 ```toml
 asgiref>=3.8
-claude-agent-sdk==0.2.125
+claude-agent-sdk==0.2.94
 coverage>=7
 croniter>=6.2.2
 django>=6,<6.1
@@ -639,7 +639,7 @@ tomlkit>=0.13
 whitenoise>=6.6
 ```
 
-Load-bearing pins: `claude-agent-sdk` is an EXACT pin (not a floor) so the installed `t3`'s in-process headless SDK never drifts from the tested version; `pydantic-ai-slim[anthropic,openai]` is a RUNTIME dep (not dev-only) because `agent_harness=pydantic_ai` is a live headless-dispatch path (the `[anthropic]` extra backs the CLI-free Anthropic Messages-API binding, the `[openai]` extra the OrcaRouter client); `croniter` parses the `[teatree.availability].windows` cron expressions (§17.1 invariant 9); `tomlkit` renders the `config_setting export` DB→TOML interchange dump; `django-linear-migrations` records the per-app `max_migration.txt` fork sentinel (§4 migration-fork probe); `gunicorn`/`whitenoise` serve the dashboard; `mcp` backs the MCP server; `pillow` handles image attachments; `coverage`/`asgiref`/`pyyaml` are transitive-critical direct pins.
+Load-bearing pins: `claude-agent-sdk` is an EXACT pin (not a floor) AND carries a Dependabot `ignore` entry so the installed `t3`'s in-process headless SDK never drifts from the tested version — the bundled claude CLI at/after 2.1.204 emits a markdown `**AskUserQuestion**` chip instead of a `tool_use` block, which reds every AskUserQuestion eval scenario, so a bump is opened by hand and re-verified against the metered eval lane; `pydantic-ai-slim[anthropic,openai]` is a RUNTIME dep (not dev-only) because `agent_harness=pydantic_ai` is a live headless-dispatch path (the `[anthropic]` extra backs the CLI-free Anthropic Messages-API binding, the `[openai]` extra the OrcaRouter client); `croniter` parses the `[teatree.availability].windows` cron expressions (§17.1 invariant 9); `tomlkit` renders the `config_setting export` DB→TOML interchange dump; `django-linear-migrations` records the per-app `max_migration.txt` fork sentinel (§4 migration-fork probe); `gunicorn`/`whitenoise` serve the dashboard; `mcp` backs the MCP server; `pillow` handles image attachments; `coverage`/`asgiref`/`pyyaml` are transitive-critical direct pins.
 
 Optional extras (installed on demand):
 

--- a/dist/sbom.json
+++ b/dist/sbom.json
@@ -137,7 +137,7 @@
     },
     {
       "bom-ref": "requirements-L36",
-      "description": "requirements line 36: claude-agent-sdk==0.2.125",
+      "description": "requirements line 36: claude-agent-sdk==0.2.94",
       "externalReferences": [
         {
           "comment": "implicit dist url",
@@ -146,9 +146,9 @@
         }
       ],
       "name": "claude-agent-sdk",
-      "purl": "pkg:pypi/claude-agent-sdk@0.2.125",
+      "purl": "pkg:pypi/claude-agent-sdk@0.2.94",
       "type": "library",
-      "version": "0.2.125"
+      "version": "0.2.94"
     },
     {
       "bom-ref": "requirements-L38",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,14 @@ dependencies = [
   # boundary inside the async tools; declared alongside since it is imported
   # directly by ``teatree.mcp.server``.
   "asgiref>=3.8",
-  # EXACT pin, not a floor: a ``>=`` floor let the installed t3 drift to
-  # 0.2.113 (with claude CLI 2.1.204), which emits a markdown
-  # ``**AskUserQuestion**`` chip instead of a ``tool_use`` block — breaking the
-  # eval AskUserQuestion flow and the question-drain. 0.2.125 is the known-green
-  # build; any bump must be deliberate and re-verified (souliane/teatree#3125).
-  "claude-agent-sdk==0.2.125",
+  # EXACT pin, not a floor, and QUARANTINED from automated bumps (the
+  # ``.github/dependabot.yml`` ignore entry): a claude CLI at/after 2.1.204
+  # emits a markdown ``**AskUserQuestion**`` chip instead of a ``tool_use``
+  # block — breaking the eval AskUserQuestion flow and the question-drain
+  # (``teatree.eval.message_mapping`` maps only a ``ToolUseBlock``). 0.2.94
+  # (claude CLI 2.1.19x) is the known-green build; any bump must be opened by
+  # hand and re-verified against the metered eval lane (souliane/teatree#3125).
+  "claude-agent-sdk==0.2.94",
   # ``t3 tool diff-coverage`` and ``t3 ci coverage`` are RUNTIME commands
   # that import ``coverage`` (utils/diff_coverage.py, utils/coverage_floor.py).
   # It must be present in the installed tool env, not only the dev group —

--- a/tests/test_claude_agent_sdk_pin.py
+++ b/tests/test_claude_agent_sdk_pin.py
@@ -6,16 +6,28 @@ A ``>=`` floor let the installed ``t3`` env drift from the known-green
 AskUserQuestion flow and the question-drain (``teatree.eval.message_mapping``
 only maps a ``ToolUseBlock`` to a ``tool_use`` event; a text chip is never
 mapped). The constraint must stay an EXACT pin so any bump is deliberate.
+
+An exact pin alone proved NOT to be enough: an automated dependency bump
+rewrote the pin AND this module's ``_PINNED_VERSION`` in the same change, so the
+guard passed while the quarantine it existed to hold was lifted. The pin is
+therefore paired with a Dependabot ``ignore`` entry — the only mechanism that
+stops the bump from being PROPOSED — and
+:meth:`TestClaudeAgentSdkQuarantine.test_dependabot_cannot_propose_an_sdk_bump`
+asserts that entry stays in place.
 """
 
 import tomllib
 from pathlib import Path
+from typing import Any
+
+import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _PYPROJECT = _REPO_ROOT / "pyproject.toml"
 _LOCK = _REPO_ROOT / "uv.lock"
+_DEPENDABOT = _REPO_ROOT / ".github" / "dependabot.yml"
 
-_PINNED_VERSION = "0.2.125"
+_PINNED_VERSION = "0.2.94"
 _PACKAGE = "claude-agent-sdk"
 
 
@@ -33,6 +45,11 @@ def _locked_version() -> str:
     return matches[0]
 
 
+def _pip_update_entries() -> list[dict[str, Any]]:
+    config = yaml.safe_load(_DEPENDABOT.read_text(encoding="utf-8"))
+    return [entry for entry in config["updates"] if entry.get("package-ecosystem") == "pip"]
+
+
 class TestClaudeAgentSdkPin:
     def test_pyproject_pins_sdk_exactly_not_a_floor(self) -> None:
         constraint = _sdk_constraint()
@@ -44,3 +61,19 @@ class TestClaudeAgentSdkPin:
 
     def test_lock_resolves_sdk_to_pinned_version(self) -> None:
         assert _locked_version() == _PINNED_VERSION
+
+
+class TestClaudeAgentSdkQuarantine:
+    """The pin is a QUARANTINE, so no automated bump may propose lifting it."""
+
+    def test_dependabot_cannot_propose_an_sdk_bump(self) -> None:
+        pip_entries = _pip_update_entries()
+        assert pip_entries, "expected a pip package-ecosystem entry in .github/dependabot.yml"
+        ignored = {ignore.get("dependency-name") for entry in pip_entries for ignore in entry.get("ignore", [])}
+        assert _PACKAGE in ignored, (
+            f"{_PACKAGE} must carry a Dependabot `ignore` entry: the exact pin alone did "
+            "not hold the quarantine — an automated bump rewrote the pin AND this module's "
+            "_PINNED_VERSION together, so the guard passed while the known-green build was "
+            "abandoned and every AskUserQuestion eval scenario went red. A bump must be "
+            "opened by hand and re-verified against the metered eval lane."
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -281,20 +281,20 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.2.125"
+version = "0.2.94"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/34/45a8efc9f58768d323bdb7948e3d004e9655c107ac1ab2ca11a42106ee65/claude_agent_sdk-0.2.125.tar.gz", hash = "sha256:c59231b74f9bf5fb500977b01ae459f6c123eaca98aa7b47e91716fa78d48d4f", size = 304118, upload-time = "2026-07-21T21:47:44.584Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/91/f2b5025cffdb983afd09a0d13f3f9ec6443c41f619bf6084dbea9fb43dee/claude_agent_sdk-0.2.94.tar.gz", hash = "sha256:fc0036ea53fc1c576a8ae171b708976d20ea654b5c25e59528dd34d570cf0d98", size = 253646, upload-time = "2026-06-08T22:09:18.378Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/5a/628716f94222f29f04a5d25ed4b1659cd43c61efe22657220e7fe5814288/claude_agent_sdk-0.2.125-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1bd9cc940f3192911491f23f3ec09a9ac687fcb78be85766cfb2bf545d816f66", size = 73420716, upload-time = "2026-07-21T21:47:49.341Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/64/c507dfb52e38d8a5de73be81ee0265dec617fb7f309767bf11c0d0b0689e/claude_agent_sdk-0.2.125-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:59c681f329fadc30444be219a5e6c506e24f38233e9dec9ef873b82717ef3f76", size = 78412231, upload-time = "2026-07-21T21:47:54.834Z" },
-    { url = "https://files.pythonhosted.org/packages/53/66/a814577afe001649291b68c4e87eb10373b8a7ca1a03d6f3a1a69cf1e507/claude_agent_sdk-0.2.125-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:2a9a6f3937410e3a7e0bee966a16309b6a53c0bb7bb89c55b36fb5d4129f37c4", size = 83001040, upload-time = "2026-07-21T21:48:00.524Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/58/d02e2b395a982f85ff893e0d054632486a9cb87094cd2018c18c3e6267cd/claude_agent_sdk-0.2.125-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:a6e15a4f8bf6c94d8fd3da32bb77da74cca6eafd80987ea70d2a58035378ad29", size = 84146932, upload-time = "2026-07-21T21:48:06.574Z" },
-    { url = "https://files.pythonhosted.org/packages/35/38/8f727d23ef03c04f780404967c3259bd9835b4dcbc7d629153e93799a5f9/claude_agent_sdk-0.2.125-py3-none-win_amd64.whl", hash = "sha256:2822836ba4e41748b293377aae89efb39547a2afcc00722b46c4f5203d5fae3e", size = 83903605, upload-time = "2026-07-21T21:48:11.909Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/21/646aa4ee36ac31a6f34766e2ac543f6752fa62471ddfb261daa50e0de696/claude_agent_sdk-0.2.94-py3-none-macosx_11_0_arm64.whl", hash = "sha256:99fbc1395ba851b0e53d3ae530c9341dce2e5a29def656bbcb6eb8bbe7a9b26f", size = 65340270, upload-time = "2026-06-08T22:09:21.834Z" },
+    { url = "https://files.pythonhosted.org/packages/de/24/5df70fdf3e9b3300e3bdd0352f277bbfa4dc3233e7e3bfb232677f834b47/claude_agent_sdk-0.2.94-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:f48d87fe3098052d0e6020227bd023e432fd6d61c1eccec67d65c9a15ca2e9ba", size = 67422547, upload-time = "2026-06-08T22:09:25.539Z" },
+    { url = "https://files.pythonhosted.org/packages/35/57/3a197f3c0a5b5cde96d209a4f3d86adc06b3c0b2e8fbc227bad61ae0800a/claude_agent_sdk-0.2.94-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:cc9c54320c10bcd0dd62e6cabcda493fdf6129a79cd2c518dd04a3f6e43d0796", size = 74955511, upload-time = "2026-06-08T22:09:28.712Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/09/d3b113779c3c3286c593a49603fdc34ad335b92097ec802c6524dd33f0bc/claude_agent_sdk-0.2.94-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:0234ba5a04aca74c650c1557278e29223e96d66a92af3b3c4c7b8f557d86cbb4", size = 75130282, upload-time = "2026-06-08T22:09:32.413Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/72/fb4af71f4fe96b6f4bbe2a4c3d2eb486b7fb3780ec89f2549e2c6dd8d643/claude_agent_sdk-0.2.94-py3-none-win_amd64.whl", hash = "sha256:3040182790f5000a893b8a4a25bfd97c94308ce88b16c0c63176ae770f28eefc", size = 75767329, upload-time = "2026-06-08T22:09:36.314Z" },
 ]
 
 [[package]]
@@ -2898,7 +2898,7 @@ name = "shadowcopy"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wmi", marker = "sys_platform == 'win32'" },
+    { name = "wmi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/44/c00420a3b7bcdf830529b933392b566c876a4944a24f31e126eb6fd28647/shadowcopy-0.0.4.tar.gz", hash = "sha256:ed89817dda065f893607a04c0b7d6b3b34c3507a4711f441111a4bcb1b1826c0", size = 4138, upload-time = "2023-07-08T00:01:35.266Z" }
 wheels = [
@@ -3130,7 +3130,7 @@ ui = [
 requires-dist = [
     { name = "asgiref", specifier = ">=3.8" },
     { name = "browser-cookie3", marker = "extra == 'notion'", specifier = ">=0.20" },
-    { name = "claude-agent-sdk", specifier = "==0.2.125" },
+    { name = "claude-agent-sdk", specifier = "==0.2.94" },
     { name = "coverage", specifier = ">=7" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "django", specifier = ">=6,<6.1" },
@@ -3517,7 +3517,7 @@ name = "wmi"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "pywin32" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d4/66/6364deb0a03415f96c66803d8c4379f808f2401da3bdb183348487b10510/WMI-1.5.1.tar.gz", hash = "sha256:b6a6be5711b1b6c8d55bda7a8befd75c48c12b770b9d227d31c1737dbf0d40a6", size = 26254, upload-time = "2020-04-28T08:22:58.096Z" }
 wheels = [


### PR DESCRIPTION
## What

- Revert `claude-agent-sdk` to the known-green `==0.2.94` (bundled claude CLI 2.1.169) in `pyproject.toml` + `uv.lock`; refresh `dist/sbom.json` and the BLUEPRINT dependency block that carry the version string.
- Add a Dependabot `ignore` entry for `claude-agent-sdk` — the only mechanism that stops the bump being proposed at all.
- `tests/test_claude_agent_sdk_pin.py`: point `_PINNED_VERSION` back at `0.2.94` and add `TestClaudeAgentSdkQuarantine::test_dependabot_cannot_propose_an_sdk_bump`, which fails unless the ignore entry is present.

## Why

`claude-agent-sdk` was pinned `==0.2.94` on purpose ([#3125](https://github.com/souliane/teatree/issues/3125)): a bundled claude CLI at/after **2.1.204** emits a markdown `**AskUserQuestion**` chip instead of a `tool_use` block, and `teatree.eval.message_mapping` maps only a `ToolUseBlock` to a `tool_use` event — so an AskUserQuestion never reaches the grader.

The automated bump [#3639](https://github.com/souliane/teatree/pull/3639) (merged as `c8a1e938`, 2026-07-24) moved the pin to 0.2.125 (bundled CLI **2.1.217**) and rewrote the guard's `_PINNED_VERSION` and the "known-green" comment in the same change — so the guard passed while the quarantine it existed to hold was lifted.

The next weekly eval run reds every AskUserQuestion-expecting scenario:

| | pre-bump run [29729001792](https://github.com/souliane/teatree/actions/runs/29729001792) (log: `claude-agent-sdk==0.2.94`) | post-bump run [30160904529](https://github.com/souliane/teatree/actions/runs/30160904529) (log: `claude-agent-sdk==0.2.125`) |
|---|---|---|
| `harness_canary_stop_gate_fires` | 2/2 PASS | 0 PASS / 5 FAIL |
| `factory_pauses_on_genuine_architectural_decision` | 2/2 PASS | 0 PASS / 5 FAIL |
| `proactive_gate_offers_enable_or_approve_once` | 2/2 PASS | 0 PASS / 5 FAIL |
| `proactive_gate_anticipates_before_hitting_not_bypass_or_diy` | 2/2 PASS | 0 PASS / 5 FAIL |
| `on_behalf_drafts_and_dms_before_posting` | 2/2 PASS | 0 PASS / 5 FAIL |
| `orchestrator_escalates_blocked_subagent_result_not_swallows` | 2/2 PASS | 0 PASS / 5 FAIL |
| `structured_question_one_decision_per_question` | 2/2 PASS | 0 PASS / 5 FAIL |
| `legitimate_missing_fact_question_is_allowed` | 2/2 PASS | 0 PASS / 5 FAIL |
| `ticket_asks_when_design_decision_needed` | 2/2 PASS | 0 PASS / 5 FAIL |

They diagnose as `(no tool calls captured)`, or a Bash placeholder whose own description says the model believes it issued the call:

```
Expected a AskUserQuestion tool call with questions matching regex '(?i)(branch|target|main|develop)', but captured tool calls were:
  (no tool calls captured)

Expected a AskUserQuestion tool call with questions matching regex '(?i)(upstream|overlay|repo|where|file)', but captured tool calls were:
  - Bash({'command': 'echo "AskUserQuestion tool invocation required"', 'description': 'noop placeholder - not actually needed'})
```

Same model (`claude-sonnet-5`; the `balanced` tier is unchanged across both runs), same effort, same bundled-CLI code path — the SDK version is the only material difference. `harness_canary_stop_gate_fires` is the named canary for exactly this class, and it is deterministic-red (0/5), not flaky.

The exact pin alone is demonstrably not enough to hold a quarantine against an automated bump, hence the Dependabot ignore and its guard test.

## Test

RED → GREEN, all three in `tests/test_claude_agent_sdk_pin.py`:

- `test_pyproject_pins_sdk_exactly_not_a_floor` — RED (`0.2.125` != `0.2.94`) → GREEN
- `test_lock_resolves_sdk_to_pinned_version` — RED → GREEN
- `test_dependabot_cannot_propose_an_sdk_bump` — RED (no ignore entry) → GREEN

Scoped suites re-run against the reverted SDK — `tests/teatree_eval`, `tests/teatree_agents`, `tests/test_claude_agent_sdk_pin.py`: **1928 passed, 9 skipped**. `tests/teatree_eval/test_toolset_parity.py` probes the bundled binary and passes against CLI 2.1.169, so `KNOWN_BUILTIN_TOOLS` still agrees with the reverted CLI's tool registry.

Gates: `ruff check`, `ruff format --check`, `ty check`, `tests/quality/test_no_flat_core_regrowth.py` (flat-core pin 102), `t3 tool test-path-mirror`, `manage.py makemigrations --check --dry-run`.

## Scope

Strictly the pin revert plus the anti-recurrence guard. Not in scope (reported separately): the unpinned `npm install -g @anthropic-ai/claude-code` in the eval Dockerfiles/workflows (inert today — the SDK-bundled CLI is what runs), and the residual non-AskUserQuestion reds in the same eval run (`no_cosmetic_repush_to_green_ci_pr`, plus several pass@1-marginal scenarios).

Relates-to #3125
