### PR TITLE
docs(runners): describe the retro runner as the marker it is; rename it

### DIFF
--- a/src/teatree/core/runners/__init__.py
+++ b/src/teatree/core/runners/__init__.py
@@ -1,15 +1,16 @@
 """Transition runners — composed work executed by ``@task`` workers.
 
-Each runner performs the long I/O for a specific lifecycle transition.
-Workers enqueue at transition time, claim via ``select_for_update()``, and
-on success call the next transition to advance the ticket or worktree.
+Each runner performs the out-of-transaction work for a specific lifecycle
+transition. Workers enqueue at transition time, claim via
+``select_for_update()``, and on success call the next transition to advance
+the ticket or worktree.
 
 See BLUEPRINT.md §4 for the invariant and §4.1 for the per-transition map.
 """
 
 from teatree.core.runners.base import RunnerBase, RunnerResult
 from teatree.core.runners.provision import WorktreeProvisioner
-from teatree.core.runners.retro import RetroExecutor
+from teatree.core.runners.retro import RetroPhaseMarker
 from teatree.core.runners.ship import ShipExecutor
 from teatree.core.runners.teardown import WorktreeTeardown
 from teatree.core.runners.worktree_provision import WorktreeProvisionRunner, heal_missing_provisioned_db
@@ -18,7 +19,7 @@ from teatree.core.runners.worktree_teardown import WorktreeTeardownRunner
 from teatree.core.runners.worktree_verify import WorktreeVerifyRunner
 
 __all__ = [
-    "RetroExecutor",
+    "RetroPhaseMarker",
     "RunnerBase",
     "RunnerResult",
     "ShipExecutor",

--- a/src/teatree/core/runners/retro.py
+++ b/src/teatree/core/runners/retro.py
@@ -6,12 +6,13 @@ from teatree.core.runners.base import RunnerBase, RunnerResult
 logger = logging.getLogger(__name__)
 
 
-class RetroExecutor(RunnerBase):
-    """Write retrospection artifacts for a merged ticket.
+class RetroPhaseMarker(RunnerBase):
+    """Stamp ``extra["retro_scheduled"]`` when a ticket reaches the retro phase.
 
-    Scaffold implementation: records that retro ran and leaves a short marker
-    on ``ticket.extra``. The agent-driven retro (skill bundle, prompt build,
-    artifact generation) lands in a follow-up PR.
+    Bookkeeping only — it runs no retrospective. The agent-driven retro is the
+    interactive ``/t3:retro`` skill, attested via ``t3 <overlay> lifecycle
+    visit-phase <ticket_id> retro`` (the shipping-phase gate block in
+    ``teatree.agents.prompt``); no sub-agent phase runs it.
     """
 
     def __init__(self, ticket: Ticket) -> None:
@@ -21,5 +22,5 @@ class RetroExecutor(RunnerBase):
         ticket = self.ticket
         # #800 N3: canonical locked RMW (was an unlocked extra save).
         ticket.merge_extra(set_keys={"retro_scheduled": True})
-        logger.info("Retro scheduled for ticket %s", ticket.pk)
+        logger.info("Retro phase marked for ticket %s", ticket.pk)
         return RunnerResult(ok=True, detail="retro-scheduled")

--- a/src/teatree/core/tasks.py
+++ b/src/teatree/core/tasks.py
@@ -14,7 +14,7 @@ from teatree.core.models import LandscapeArtifact, Task, Ticket
 from teatree.core.models.errors import CriticGateError, InvalidTransitionError
 from teatree.core.models.external_delivery import under_external_delivery
 from teatree.core.models.trivial_plan_skip import is_trivial_plan_skip
-from teatree.core.runners import RetroExecutor, ShipExecutor, WorktreeProvisioner, WorktreeTeardown
+from teatree.core.runners import RetroPhaseMarker, ShipExecutor, WorktreeProvisioner, WorktreeTeardown
 from teatree.core.worktree.worktree_done import _DONE_TICKET_STATES
 
 logger = logging.getLogger(__name__)
@@ -286,7 +286,7 @@ def refresh_followup_snapshot() -> dict[str, int]:
 
 @task()
 def execute_retrospect(ticket_id: int) -> TransitionResult:
-    """Run retrospection I/O for a ticket in the RETROSPECTED state.
+    """Stamp the retro-phase marker for a ticket in the RETROSPECTED state.
 
     Idempotency: the worker takes a row lock and re-checks state before running.
     At-least-once delivery from django-tasks means this can fire more than once
@@ -294,13 +294,13 @@ def execute_retrospect(ticket_id: int) -> TransitionResult:
 
     On success, advances ``RETROSPECTED → DELIVERED`` via ``mark_delivered()``.
 
-    ``RetroExecutor.run()`` (retrospection I/O — potentially minutes) runs
-    OUTSIDE the FSM-advance transaction (#1522 shape, mirroring ``execute_ship``):
-    a short atomic state-check, the executor as a top-level operation, then a
-    short atomic re-check + ``mark_delivered``. Running the executor inside the
-    ``select_for_update`` atomic held the SQLite global write lock (``BEGIN
-    IMMEDIATE``) for the whole run, stalling every other writer and expiring
-    live leases.
+    ``RetroPhaseMarker.run()`` runs OUTSIDE the FSM-advance transaction (#1522
+    shape, mirroring ``execute_ship``): a short atomic state-check, the runner as
+    a top-level operation, then a short atomic re-check + ``mark_delivered``. The
+    marker is durable evidence that the retro phase was reached, so it must
+    outlive a refused delivery — inside the advance atomic its ``merge_extra``
+    would be a savepoint the ``CriticGateError`` below unwinds, losing the
+    evidence the same way the rolled-back ``CriticFinding`` rows are lost.
 
     When the SELFCATCH-5 critic gate blocks (enforcing mode), it raises
     ``CriticGateError`` from inside the advance atomic, rolling back the
@@ -319,7 +319,7 @@ def execute_retrospect(ticket_id: int) -> TransitionResult:
             )
             return {"ticket_id": ticket_id, "skipped": True, "state": str(ticket.state)}
 
-    result = RetroExecutor(ticket).run()
+    result = RetroPhaseMarker(ticket).run()
     if not result.ok:
         logger.warning("Retro failed for ticket %s: %s", ticket_id, result.detail)
         return {"ticket_id": ticket_id, "ok": False, "detail": result.detail}

--- a/tests/teatree_core/gates/test_critic_gate.py
+++ b/tests/teatree_core/gates/test_critic_gate.py
@@ -337,13 +337,29 @@ class TestEnforcingBlockFindingsSurviveRollback(TestCase):
     def test_findings_persist_after_the_enforcing_block(self) -> None:
         ticket = _clean_delivered_ticket()
         _strip_merge_evidence(ticket)
-        with _mode(CriticGateMode.BLOCKING), patch.object(core_tasks, "RetroExecutor") as retro:
+        with _mode(CriticGateMode.BLOCKING), patch.object(core_tasks, "RetroPhaseMarker") as retro:
             retro.return_value.run.return_value = RunnerResult(ok=True, detail="retro ok")
             result = core_tasks.execute_retrospect.func(ticket.pk)
         ticket.refresh_from_db()
         assert result["ok"] is False
         assert ticket.state == Ticket.State.RETROSPECTED  # the delivery was refused
         assert CriticFinding.objects.filter(ticket=ticket, rubric_item="done_not_done").exists()  # survived rollback
+
+    def test_retro_phase_marker_survives_the_enforcing_block(self) -> None:
+        """The REAL marker: hoisting it out of the advance atomic is what keeps it durable.
+
+        Moving ``RetroPhaseMarker(ticket).run()`` inside that atomic turns its
+        ``merge_extra`` into a savepoint the ``CriticGateError`` unwinds, and the
+        evidence that the retro phase was reached disappears with the refusal.
+        """
+        ticket = _clean_delivered_ticket()
+        _strip_merge_evidence(ticket)
+        with _mode(CriticGateMode.BLOCKING):
+            result = core_tasks.execute_retrospect.func(ticket.pk)
+        ticket.refresh_from_db()
+        assert result["ok"] is False
+        assert ticket.state == Ticket.State.RETROSPECTED
+        assert ticket.extra.get("retro_scheduled") is True
 
 
 class TestProductionRecordingPath(TestCase):

--- a/tests/teatree_core/test_tasks.py
+++ b/tests/teatree_core/test_tasks.py
@@ -10,6 +10,7 @@ from django.test import TestCase, override_settings
 import teatree.core.overlay_loader as overlay_loader_mod
 from teatree.core.intake.attachment_manifest import AttachmentKind, AttachmentRef, local_path_for
 from teatree.core.models import AttachmentManifest, Session, Task, TaskAttempt, Ticket
+from teatree.core.runners import RetroPhaseMarker
 from teatree.core.runners.base import RunnerResult
 from teatree.core.tasks import (
     drain_headless_queue,
@@ -403,6 +404,15 @@ class TestExecuteRetrospect(TestCase):
         ticket.state = Ticket.State.MERGED
         ticket.save(update_fields=["state"])
         return ticket
+
+    def test_the_runner_only_stamps_the_phase_marker(self) -> None:
+        """Bookkeeping only — the agent-driven retro lives in `/t3:retro` + `lifecycle visit-phase`."""
+        ticket = self._ticket_in_merged()
+
+        assert RetroPhaseMarker(ticket).run() == RunnerResult(ok=True, detail="retro-scheduled")
+
+        ticket.refresh_from_db()
+        assert ticket.extra == {"retro_scheduled": True}
 
     @override_settings(**IMMEDIATE_BACKEND)
     def test_advances_merged_ticket_to_delivered(self) -> None:


### PR DESCRIPTION
docs(runners): describe the retro runner as the marker it is; rename it

## What

- Rename `RetroExecutor` -> `RetroPhaseMarker` and rewrite its docstring to
  describe what it does: stamp `extra["retro_scheduled"]`. It names the real
  retro path (`/t3:retro` + `t3 <overlay> lifecycle visit-phase <id> retro`) so
  a reader knows where the actual work happens.
- Rewrite the `execute_retrospect` transaction-hoist rationale with the reason
  that actually holds: the marker is durable evidence the retro phase was
  reached, so it must outlive a `CriticGateError`-refused delivery. Inside the
  advance atomic its `merge_extra` would be a savepoint the refusal unwinds.
  The structure is unchanged.
- Widen the `runners/__init__` package docstring from long-I/O-only to the
  out-of-transaction work, so it covers a runner that is not long I/O.
- New test in `TestEnforcingBlockFindingsSurviveRollback`: the marker survives
  the enforcing critic block, driving the REAL runner (the sibling test patches
  it out). Verified RED with the call moved inside the advance atomic.
- New test in `TestExecuteRetrospect`: the runner stamps the phase marker and
  nothing else, pinning the bookkeeping-only claim the docstring now makes.

## Why

- The docstring described itself as a scaffold whose agent-driven retro (skill
  bundle, prompt build, artifact generation) was still to arrive in a follow-up
  PR. That retro shipped by another route -- the `/t3:retro` skill plus the
  lifecycle phase-visit gate emitted in `agents/prompt.py` -- so the class read
  as unfinished work awaiting completion. It is live code, not dead:
  `execute_retrospect` advances RETROSPECTED -> DELIVERED on its `ok=True`.
- The hoist comment justified a real structural decision with a cost estimate
  off by six orders of magnitude (potentially minutes, for a single
  `merge_extra`). Keeping the call outside the transaction is still correct on
  its own merits -- the rollback-durability reason above, plus symmetry with
  the #1522 shape of `execute_ship` -- so behaviour is unchanged and the comment
  now states the reason a test can hold it to.

## Verification

- `uv run pytest tests/teatree_core/gates/test_critic_gate.py tests/teatree_core/test_tasks.py tests/quality/test_no_flat_core_regrowth.py tests/quality/test_patch_targets_resolve.py` -- 101 passed (102 with the added direct test).
- Anti-vacuity control: moved `RetroPhaseMarker(ticket).run()` inside the advance
  atomic, the rollback test went RED (`assert None is True` on `retro_scheduled`); reverted, GREEN.
- `uv run ruff check` / `ruff format --check` / `uv run ty check` on the changed files -- clean.
- `t3 tool test-path-mirror` -- ledger exact. `manage.py makemigrations --check` -- no changes.
- `rg RetroExecutor` across the tree -- zero hits.

## Architecture pre-check

Tactical documentation/naming fix -- no new module, no FSM transition, no
Protocol or extension-point change, no import added to `src/`. Checks 1-5 and
7-10 are n/a. Check 6 (test surface): the added tests assert the runner stamps
only the marker, and that `extra["retro_scheduled"]` survives an enforcing
`CriticGateError` refusal -- the observable contract the transaction hoist buys.

## Open questions & assumptions

- `RetroPhaseMarker` renamed rather than kept (assumed): 8 in-repo references,
  no overlay or BLUEPRINT consumer, and the name was the crux of the finding --
  its sibling `ShipExecutor` genuinely ships, so the `*Executor` suffix read as
  a promise the body does not keep. Small enough not to be churn.
- `extra["retro_scheduled"]` key left as-is (decided): renaming it is a data
  migration and a behaviour change, out of scope for an honesty fix.
- Zero behaviour change (assumed): only names, docstrings, and two added tests.
