### PR TITLE
docs(mutation): state the inert mode knob's real behaviour instead of a gate-promotion promise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1038,10 +1038,10 @@ jobs:
     # ``[tool.teatree.mutation].high_value_modules``, and mutates ONLY the
     # touched safety modules — a no-op (fast pass) when the PR touches none, so
     # most PRs pay nothing. Programmatic ratchet: the command fails when the
-    # surviving-mutant count exceeds the recorded ``baseline_surviving`` total,
-    # in BOTH ``warn`` and ``block`` mode (the count may only ever shrink) —
-    # survivors at-or-below baseline still pass. Flipping ``mode`` to "block" is
-    # a later follow-up (gate on survivors existing at all), no workflow change.
+    # surviving-mutant count exceeds the recorded ``baseline_surviving`` total
+    # (the count may only ever shrink) — survivors at-or-below baseline still
+    # pass. ``mode`` is validated but inert: "warn" and "block" resolve to that
+    # same verdict, so this job's behaviour does not depend on it.
     # ``t3 mutation run --all --update-baseline`` tightens the recorded counts.
     # The 10-min cap bounds a pathological run.
     #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -509,13 +509,18 @@ baseline_file = "tests/skill_cli_ratchet_grandfathered.txt"
 # worst: a fail-closed gate that stops failing closed, a lost-update in a
 # claim/CAS path, a merge-clear/keystone that stops gating. ``t3 mutation
 # run`` mutates ONLY the registry entries a PR's diff touches and no-ops when
-# none are touched, so most PRs pay nothing. ``mode`` defaults to "warn"
-# (the CI ``mutation-diff`` job never fails the pipeline); flip to "block" to
-# promote it to a gate without a workflow change. ``baseline_surviving`` is the
-# ratchet floor (only shrinks): a per-module count of mutants knowingly left
-# alive, so "block" mode fails only on a NEW survivor, never on the documented
-# backlog. NARROW BY DESIGN — do NOT add the whole codebase; the conformance
-# test ``tests/quality/test_mutation.py`` caps the registry size.
+# none are touched, so most PRs pay nothing. The verdict is the
+# ``baseline_surviving`` ratchet floor (only shrinks): a per-module count of
+# mutants knowingly left alive, so a run FAILS only on a NEW survivor above the
+# recorded total, never on the documented backlog — and it fails that way in
+# BOTH modes. ``mode`` is validated against {"warn", "block"} and does nothing
+# else: the two values resolve to the identical ratchet verdict, so setting
+# "block" changes no behaviour (pinned by ``TestModeIsInertToday`` in
+# ``tests/quality/test_mutation_run.py``). It is reserved for the follow-up that
+# gates on survivors existing at all, which needs the recorded survivor backlog
+# paid down first — that paydown has no tracking issue. NARROW BY DESIGN — do
+# NOT add the whole codebase; the conformance test
+# ``tests/quality/test_mutation.py`` caps the registry size.
 
 [tool.teatree.mutation]
 mode = "warn"

--- a/src/teatree/cli/mutation.py
+++ b/src/teatree/cli/mutation.py
@@ -7,9 +7,10 @@ PR that touches no safety module pays nothing.
 
 The exit code is the programmatic ratchet in
 :meth:`teatree.quality.mutation_run.BaselineRatchet.verdict`: a run that surfaces
-MORE surviving mutants than the recorded ``baseline_surviving`` total FAILS — in
-both ``warn`` and ``block`` mode — because the surviving count may only ever
-shrink. This is the prerequisite to flipping ``mode`` to ``"block"`` later.
+MORE surviving mutants than the recorded ``baseline_surviving`` total FAILS —
+because the surviving count may only ever shrink. ``[tool.teatree.mutation].mode``
+is validated but does not change that verdict; ``"warn"`` and ``"block"`` are
+equivalent today.
 
 ``t3 mutation run --update-baseline`` rewrites the per-module
 ``baseline_surviving`` counts to the current measurement. The ratchet only moves

--- a/src/teatree/quality/mutation_run.py
+++ b/src/teatree/quality/mutation_run.py
@@ -3,7 +3,7 @@
 The cheap gate (diff ∩ registry) lives in :mod:`teatree.quality.mutation`. This
 module is the runner that, when the intersection is non-empty, writes a scoped
 mutmut config and executes mutmut over ONLY the touched safety modules, then
-classifies the result and applies the warn/block ratchet.
+classifies the result and applies the surviving-count ratchet.
 
 Two design choices keep it robust and narrow. Serial (debug) execution:
 mutmut's default forks a child per mutant; on macOS a forked child that has
@@ -286,9 +286,11 @@ class BaselineRatchet:
         A run above the recorded baseline fails (exit 1) in BOTH ``warn`` and
         ``block`` mode: the surviving count may only ever shrink, so a PR that
         surfaces more survivors than the baseline is a regression CI must catch.
-        This is the prerequisite that makes flipping ``mode`` to ``"block"`` safe
-        — ``mode`` stays as the lever for that follow-up (where it will gate on
-        survivors existing at all); today both modes coincide on the ratchet.
+        ``mode`` is validated here and does nothing else — the two values resolve
+        to the identical verdict, pinned by ``TestModeIsInertToday``. It is
+        reserved for the follow-up that gates on survivors existing at all, which
+        needs the recorded survivor backlog paid down first; that paydown has no
+        tracking issue.
         """
         if mode not in _MODES:
             detail = f"mode must be one of {sorted(_MODES)}, got {mode!r}"

--- a/tests/quality/test_mutation_run.py
+++ b/tests/quality/test_mutation_run.py
@@ -118,6 +118,43 @@ class TestBaselineRatchetVerdict:
             BaselineRatchet.verdict(self._outcome(survivors=1), mode="explode", baseline=0)
 
 
+class TestModeIsInertToday:
+    """``mode`` is validated but changes no verdict — the documented current contract.
+
+    ``[tool.teatree.mutation].mode`` is reserved for the follow-up that gates on
+    survivors existing at all, which needs the recorded survivor backlog paid
+    down first. Until then "warn" and "block" are equivalent, and this pins that
+    equivalence so an implementer wiring real blocking sees it fail here.
+    """
+
+    @pytest.mark.parametrize(("survivors", "baseline"), [(0, 0), (1, 0), (2, 2), (3, 2), (0, 5)])
+    def test_warn_and_block_agree(self, survivors: int, baseline: int) -> None:
+        outcome = MutationOutcome(
+            scoped_modules=("src/teatree/x.py",),
+            survived=tuple(f"m{i}" for i in range(survivors)),
+            killed=(),
+            inconclusive=(),
+        )
+        warn = BaselineRatchet.verdict(outcome, mode="warn", baseline=baseline)
+        block = BaselineRatchet.verdict(outcome, mode="block", baseline=baseline)
+        assert warn == block
+
+    def test_a_survivor_at_baseline_passes_in_block_mode(self) -> None:
+        outcome = MutationOutcome(
+            scoped_modules=("src/teatree/x.py",),
+            survived=("m0",),
+            killed=(),
+            inconclusive=(),
+        )
+        assert BaselineRatchet.verdict(outcome, mode="block", baseline=1) == 0
+
+    @pytest.mark.parametrize("mode", ["", "warn ", "BLOCK", "gate", "explode"])
+    def test_only_the_two_declared_values_are_accepted(self, mode: str) -> None:
+        outcome = MutationOutcome(scoped_modules=(), survived=(), killed=(), inconclusive=())
+        with pytest.raises(MutationConfigError, match="mode"):
+            BaselineRatchet.verdict(outcome, mode=mode, baseline=0)
+
+
 class TestSurvivingExceedsBaseline:
     """The mode-independent ratchet: more survivors than recorded baseline fails."""
 


### PR DESCRIPTION
docs(mutation): state the inert mode knob's real behaviour instead of a gate-promotion promise

## What

- `pyproject.toml`'s `[tool.teatree.mutation]` comment now states the current contract: the verdict is the `baseline_surviving` ratchet, and `mode` is validated against the two declared values but resolves to the identical verdict either way. It is reserved for the follow-up that gates on survivors existing at all, which needs the recorded survivor backlog paid down first — that paydown has no tracking issue (verified: no open issue matches).
- `BaselineRatchet.verdict`'s docstring drops its future-tense aside for the same statement plus a pointer to the pin; the module docstring says "surviving-count ratchet" rather than "warn/block ratchet".
- `t3 mutation run`'s CLI docstring and the `mutation-diff` CI job comment carry the same statement.
- New `TestModeIsInertToday` in `tests/quality/test_mutation_run.py` pins the equivalence across the baseline boundary (including the at-baseline case a real block implementation would fail) and pins that any other value still raises `MutationConfigError`.

## Why

- The pyproject comment promised an operator a capability the code does not implement: that setting `mode = "block"` promotes the lane to a gate with no workflow change. `BaselineRatchet.verdict` uses `mode` only to reject an invalid value, then returns `1 if exceeds_baseline(...) else 0` — identical in both modes. The same comment also claimed the warn lane never fails the pipeline, which is false: it exits 1 whenever survivors exceed the recorded floor.
- Real blocking is not a drive-by fix. The recorded floor is 622 survivors across the eight safety modules; failing on any surviving mutant would go red immediately and block every PR. The survivor paydown comes first — which is why the ratchet exists and the knob was deferred.
- The equivalence was previously only a buried docstring aside. The new test converts it into an asserted fact, so a future implementer wiring real blocking sees it fail exactly when they should.

## Knob decision — kept, documented as reserved (option i)

Kept rather than removed. Removal is not clean: it would drop the validated `{"warn", "block"}` domain (the only rejection path for a malformed value), change `verdict`'s signature and its call sites in the CLI and in `tests/teatree_quality/test_mutation_baseline_covers_registry.py`, churn ~8 existing tests plus this repo's own `mode = "warn"` line and the two test fixtures that set it, and all of it would have to be reintroduced when the paydown lands. Keeping costs one dataclass field, one validated config line, and one honest comment.

## Verification

- `uv run pytest tests/quality/test_mutation_run.py -n0` — 53 passed.
- `uv run pytest tests/quality/test_mutation.py tests/teatree_cli/test_mutation_cli.py tests/teatree_quality/test_mutation_baseline_covers_registry.py tests/quality/test_no_flat_core_regrowth.py -n0` — 34 passed.
- Anti-vacuity control: temporarily making `verdict` return 1 in block mode on any survivor turned `TestModeIsInertToday` RED (2 failures — `test_warn_and_block_agree[2-2]` and `test_a_survivor_at_baseline_passes_in_block_mode`); reverted, green again.
- `uv run ruff check` / `ruff format --check` / `uv run ty check` on the changed files — clean.
- `t3 tool test-path-mirror` — ledger exact.
- `mode` is still `warn` and the baseline still sums to 622 (re-read from the parsed TOML after the edit). No behaviour change to the ratchet.

## Architecture pre-check

Tactical documentation-honesty fix plus one test; touches no module boundary, no FSM transition, no extension point, and no external write. The ten-check gate does not fire.
