### PR TITLE
fix(eval): make a failing benchmark leg diagnosable from the run it already spent

### DIFF
--- a/.github/workflows/eval-weekly-reusable.yml
+++ b/.github/workflows/eval-weekly-reusable.yml
@@ -41,7 +41,7 @@
 #   publish-safe artifact. A red weekly run is surfaced by GitHub's NATIVE
 #   failed-run email (no extra secret, no bot).
 #
-# RED-LEG DIAGNOSIS (souliane/teatree#3745, mirroring `eval.yml`)
+# RED-LEG DIAGNOSIS (souliane/teatree#3744, mirroring `eval.yml`)
 #   A metered leg is expensive to re-run, so a red leg MUST be diagnosable from the
 #   run it already spent — never by firing another one. Two artifacts back that, both
 #   uploaded `if: always()` and both named per matrix leg (`<lane>-<shard>-<effort>`,
@@ -366,7 +366,7 @@ jobs:
           timeout_minutes: 80
           max_attempts: 2
           retry_wait_seconds: 60
-          # FAILURE OBSERVABILITY (#3745) — the same contract `eval.yml` carries, on the
+          # FAILURE OBSERVABILITY (#3744) — the same contract `eval.yml` carries, on the
           # leg that spends per-token credit. A red leg used to emit ONLY the retry
           # action's `Child_process exited with error code 1`: no scenario name, no
           # verdict, no traceback. Two gaps caused that, and `tee` closes both:

--- a/.github/workflows/eval-weekly-reusable.yml
+++ b/.github/workflows/eval-weekly-reusable.yml
@@ -40,6 +40,17 @@
 #   caller's default branch when it changed. The benchmark HTML is itself the
 #   publish-safe artifact. A red weekly run is surfaced by GitHub's NATIVE
 #   failed-run email (no extra secret, no bot).
+#
+# RED-LEG DIAGNOSIS (souliane/teatree#3745, mirroring `eval.yml`)
+#   A metered leg is expensive to re-run, so a red leg MUST be diagnosable from the
+#   run it already spent — never by firing another one. Two artifacts back that, both
+#   uploaded `if: always()` and both named per matrix leg (`<lane>-<shard>-<effort>`,
+#   so parallel legs cannot collide):
+#     * `eval-run-log-*`   — the raw teed stdout/stderr of EVERY attempt. Exists from
+#       the first byte, so it is the only one that survives a leg that dies mid-run.
+#     * `eval-benchmark-*` — the sanitized matrix dashboard (rendered at end of run).
+#   And the first diagnosis needs NO download: on a non-zero exit the eval step
+#   re-prints the captured tail into the job log, then re-raises the real exit code.
 # ============================================================
 
 # TRIGGER: workflow_call only — invoked by `eval-benchmark.yml` (manual dispatch)
@@ -350,18 +361,60 @@ jobs:
           EVAL_LANE: ${{ matrix.lane }}
           EVAL_SHARD: ${{ matrix.shard }}
           EVAL_EFFORT: ${{ matrix.effort }}
-          SUMMARY_SUFFIX: ${{ steps.artifact.outputs.suffix }}
+          EVAL_SUFFIX: ${{ steps.artifact.outputs.suffix }}
         with:
           timeout_minutes: 80
           max_attempts: 2
           retry_wait_seconds: 60
+          # FAILURE OBSERVABILITY (#3745) — the same contract `eval.yml` carries, on the
+          # leg that spends per-token credit. A red leg used to emit ONLY the retry
+          # action's `Child_process exited with error code 1`: no scenario name, no
+          # verdict, no traceback. Two gaps caused that, and `tee` closes both:
+          #   * The container's output was STREAMED but never STORED. `t3 eval run
+          #     --docker` does inherit the container's stdio and nick-fields/retry does
+          #     forward the child's stdout, so the bytes reach the live log — but nothing
+          #     wrote them to a file, so nothing could be uploaded, and anything lost to
+          #     the 80min SIGTERM kill was gone for good.
+          #   * The matrix dashboard is rendered from the COMPLETED rows (after
+          #     `collect_matrix_rows`), so a leg that dies mid-matrix NEVER writes it.
+          #     The upload step's `if: always()` was already correct; the file simply did
+          #     not exist, which is why the artifact looked un-uploaded on exactly the
+          #     failures that needed it.
+          # So the run is teed to a durable $RUNNER_TEMP log (uploaded as its own per-leg
+          # artifact below, and the ONLY artifact that survives a pre-dashboard death),
+          # and on non-zero exit the tail is re-printed from that file into the job log —
+          # the first diagnosis needs no download. The dashboard is an HTML file, useless
+          # catted into a log, so the block points at the uploaded artifact instead; its
+          # text twin (the matrix table `t3 eval run` echoes before writing the HTML) is
+          # already inside the tail. `set -o pipefail` keeps `tee` from masking the eval's
+          # exit code, and the block ends in `exit "$rc"`: this adds visibility, it never
+          # swallows the failure. Printing INSIDE the command block is what makes EACH
+          # attempt visible — attempt 1's tail lands before the retry's "Attempt 1 failed"
+          # line instead of being discarded when attempt 2 starts. `tee -a` keeps both
+          # attempts in the one uploaded log.
           command: |
+            set -o pipefail
             EFFORT_FLAG=""
             [ -n "$EVAL_EFFORT" ] && EFFORT_FLAG="--effort $EVAL_EFFORT"
+            TAIL_LINES=400
+            MATRIX_HTML="$RUNNER_TEMP/eval-benchmark-$EVAL_SUFFIX.html"
+            LOG="$RUNNER_TEMP/eval-run-$EVAL_SUFFIX.log"
+            echo "===== attempt started $(date -u +%Y-%m-%dT%H:%M:%SZ) · leg $EVAL_SUFFIX =====" >> "$LOG"
             uv run t3 eval run --benchmark --backend api \
               --lane "$EVAL_LANE" --shard "$EVAL_SHARD" $EFFORT_FLAG \
               --require-executed --docker \
-              --transcript-html "$RUNNER_TEMP/eval-benchmark-$SUMMARY_SUFFIX.html"
+              --transcript-html "$MATRIX_HTML" 2>&1 | tee -a "$LOG"
+            rc=$?
+            [ "$rc" -eq 0 ] && exit 0
+            echo "::group::leg $EVAL_SUFFIX FAILED (exit $rc) — last $TAIL_LINES captured lines"
+            tail -n "$TAIL_LINES" "$LOG" || echo "nothing captured at $LOG"
+            echo "::endgroup::"
+            if [ -s "$MATRIX_HTML" ]; then
+              echo "The matrix dashboard rendered: download artifact eval-benchmark-$EVAL_SUFFIX."
+            else
+              echo "No dashboard at $MATRIX_HTML: the run died before rendering one, so the tail above is the whole diagnosis."
+            fi
+            exit "$rc"
       # Publish the benchmark matrix HTML dashboard THIS leg emitted. The name is
       # per-lane-and-shard (and effort) so parallel matrix legs never collide. The
       # matrix HTML is itself sanitized (no reasoning/tool-call transcript — only
@@ -373,6 +426,21 @@ jobs:
         with:
           name: eval-benchmark-${{ steps.artifact.outputs.suffix }}
           path: ${{ runner.temp }}/eval-benchmark-${{ steps.artifact.outputs.suffix }}.html
+          if-no-files-found: warn
+      # The RAW captured stdout/stderr of every attempt (the `tee -a` target in the
+      # eval command). Unlike the matrix dashboard — rendered only if the run reaches
+      # its end — this file exists from the first byte, so it is the one artifact that
+      # survives a leg that died mid-run, which is precisely the failure class that
+      # used to leave a maintainer with nothing but "exit code 1". `if: always()`
+      # because a GREEN leg needs none of this; a red one needs all of it. NOT
+      # collected by the `publish` job (which globs `eval-benchmark-*` only) — it is
+      # unsanitized, so it stays out of the public dashboard.
+      - name: Upload the raw eval run log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: eval-run-log-${{ steps.artifact.outputs.suffix }}
+          path: ${{ runner.temp }}/eval-run-${{ steps.artifact.outputs.suffix }}.log
           if-no-files-found: warn
 
   # PUBLISH: collect every shard's benchmark matrix HTML into the public

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -105,7 +105,7 @@
 #   failed-workflow-run email goes to the maintainer (Actions → Notifications) with
 #   no extra secret and no bot — that is the failure-notification mechanism here.
 #
-# RED-LEG DIAGNOSIS (souliane/teatree#3745)
+# RED-LEG DIAGNOSIS (souliane/teatree#3744)
 #   A metered leg is expensive to re-run (~2% of the subscription's weekly window per
 #   attempt), so a red leg MUST be diagnosable from the run it already spent — never
 #   by firing another one. Three artifacts back that, all uploaded `if: always()` and
@@ -474,7 +474,7 @@ jobs:
           # mount). The `publish` job merges every shard's summary into the public
           # dashboard; the transcript stays in the private `eval-report-*` artifact.
           #
-          # FAILURE OBSERVABILITY (#3745). A red leg used to emit ONLY the retry
+          # FAILURE OBSERVABILITY (#3744). A red leg used to emit ONLY the retry
           # action's `Child_process exited with error code 1` — no scenario name, no
           # pass@k line, no traceback — so every diagnostic re-run re-spent ~2% of the
           # subscription's weekly window for zero information. Two gaps caused that,

--- a/tests/test_eval_failure_observability.py
+++ b/tests/test_eval_failure_observability.py
@@ -1,112 +1,151 @@
 """A red behavioral-eval leg must be diagnosable from the run that already spent.
 
-Each metered leg costs ~2% of the subscription's weekly usage window, so a leg that
-fails while emitting only the retry action's ``Child_process exited with error code
-1`` makes every diagnostic re-run pure waste. These tests pin the observability
-contract in ``.github/workflows/eval.yml``: the run's output is captured to a durable
-file, every diagnostic artifact uploads unconditionally under a per-leg-unique name,
-and a failing leg re-prints its tail + summary into the job log while still
-propagating the real exit code.
+Each metered leg costs ~2% of the subscription's weekly usage window (and real
+per-token billing on the benchmark's api-key lane), so a leg that fails while
+emitting only the retry action's ``Child_process exited with error code 1`` makes
+every diagnostic re-run pure waste. These tests pin the observability contract in
+BOTH metered workflows — ``.github/workflows/eval.yml`` (the weekly cron) and
+``.github/workflows/eval-weekly-reusable.yml`` (the manual benchmark): the run's
+output is captured to a durable file, every diagnostic artifact uploads
+unconditionally under a per-leg-unique name, and a failing leg re-prints its tail
+into the job log while still propagating the real exit code.
 """
 
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
 import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _GH_EVAL = _REPO_ROOT / ".github" / "workflows" / "eval.yml"
+_GH_BENCHMARK = _REPO_ROOT / ".github" / "workflows" / "eval-weekly-reusable.yml"
+
+# Both spend real credit per leg, so both owe the same post-mortem.
+_METERED_WORKFLOWS = (_GH_EVAL, _GH_BENCHMARK)
 
 _SUFFIX_EXPR = "steps.artifact.outputs.suffix"
 _UPLOAD_ACTION = "actions/upload-artifact"
 _RETRY_ACTION = "nick-fields/retry"
 
 
-def _eval_steps() -> list[dict[str, Any]]:
-    jobs = cast("dict[str, Any]", yaml.safe_load(_GH_EVAL.read_text(encoding="utf-8"))["jobs"])
+def _eval_steps(workflow: Path) -> list[dict[str, Any]]:
+    jobs = cast("dict[str, Any]", yaml.safe_load(workflow.read_text(encoding="utf-8"))["jobs"])
     return cast("list[dict[str, Any]]", jobs["eval"]["steps"])
 
 
-def _upload_steps() -> list[dict[str, Any]]:
-    steps = [step for step in _eval_steps() if step.get("uses", "").startswith(_UPLOAD_ACTION)]
-    assert steps, "the eval job must upload diagnostic artifacts."
+def _upload_steps(workflow: Path) -> list[dict[str, Any]]:
+    steps = [step for step in _eval_steps(workflow) if step.get("uses", "").startswith(_UPLOAD_ACTION)]
+    assert steps, f"{workflow.name}: the eval job must upload diagnostic artifacts."
     return steps
 
 
-def _eval_command() -> str:
-    for step in _eval_steps():
+def _eval_command(workflow: Path) -> str:
+    for step in _eval_steps(workflow):
         if step.get("uses", "").startswith(_RETRY_ACTION) and "t3 eval run" in step.get("with", {}).get("command", ""):
             return cast("str", step["with"]["command"])
-    msg = "No retry-wrapped `t3 eval run` step in the eval job."
+    msg = f"{workflow.name}: no retry-wrapped `t3 eval run` step in the eval job."
     raise AssertionError(msg)
 
 
-def _upload_step_named(name_fragment: str) -> dict[str, Any]:
-    for step in _upload_steps():
+def _upload_step_named(workflow: Path, name_fragment: str) -> dict[str, Any]:
+    for step in _upload_steps(workflow):
         if name_fragment in step["with"]["name"]:
             return step
-    msg = f"No upload-artifact step publishing a {name_fragment!r} artifact."
+    msg = f"{workflow.name}: no upload-artifact step publishing a {name_fragment!r} artifact."
     raise AssertionError(msg)
 
 
+@pytest.mark.parametrize("workflow", _METERED_WORKFLOWS, ids=lambda path: path.name)
 class TestDiagnosticArtifactsSurviveAFailingLeg:
-    def test_every_artifact_upload_is_unconditional(self) -> None:
+    def test_every_artifact_upload_is_unconditional(self, workflow: Path) -> None:
         # A success-only (or absent) `if:` drops the artifact on exactly the runs that
         # need it — the whole point of uploading a summary is to explain a failure.
-        for step in _upload_steps():
+        for step in _upload_steps(workflow):
             assert step.get("if") == "always()", (
-                f"Upload step {step.get('name')!r} must be `if: always()` so a RED leg still "
-                f"publishes its diagnostics; got {step.get('if')!r}."
+                f"{workflow.name}: upload step {step.get('name')!r} must be `if: always()` so a RED "
+                f"leg still publishes its diagnostics; got {step.get('if')!r}."
             )
 
-    def test_artifact_names_are_unique_per_matrix_leg(self) -> None:
+    def test_artifact_names_are_unique_per_matrix_leg(self, workflow: Path) -> None:
         # The fan-out runs many legs in parallel; a shared artifact name collides and
         # silently keeps only one leg's diagnostics.
-        for step in _upload_steps():
+        for step in _upload_steps(workflow):
             assert _SUFFIX_EXPR in step["with"]["name"], (
-                f"Artifact name {step['with']['name']!r} must carry the per-leg "
+                f"{workflow.name}: artifact name {step['with']['name']!r} must carry the per-leg "
                 f"lane/shard/effort suffix so parallel legs cannot collide."
             )
 
-    def test_raw_run_log_is_uploaded(self) -> None:
-        # The transcript and the summary are rendered at END of run, so a leg that
-        # dies mid-run writes neither. The teed log exists from the first byte.
-        step = _upload_step_named("eval-run-log")
-        assert "eval-run-" in step["with"]["path"], "the raw-log artifact must publish the teed run log."
+    def test_raw_run_log_is_uploaded(self, workflow: Path) -> None:
+        # Every other artifact (transcript, summary, benchmark matrix) is rendered at
+        # END of run, so a leg that dies mid-run writes none of them. The teed log
+        # exists from the first byte.
+        step = _upload_step_named(workflow, "eval-run-log")
+        assert "eval-run-" in step["with"]["path"], (
+            f"{workflow.name}: the raw-log artifact must publish the teed run log."
+        )
 
 
+@pytest.mark.parametrize("workflow", _METERED_WORKFLOWS, ids=lambda path: path.name)
 class TestFailureOutputReachesTheJobLog:
-    def test_run_output_is_captured_to_a_durable_file(self) -> None:
-        command = _eval_command()
+    def test_run_output_is_captured_to_a_durable_file(self, workflow: Path) -> None:
+        command = _eval_command(workflow)
         assert "tee -a" in command, (
-            "The eval run's combined output must be teed to a file: streaming alone leaves "
-            "nothing to upload and loses everything killed by the step timeout."
+            f"{workflow.name}: the eval run's combined output must be teed to a file — streaming "
+            f"alone leaves nothing to upload and loses everything killed by the step timeout."
         )
-        assert "2>&1" in command, "stderr must be merged into the captured stream (tracebacks land on stderr)."
+        assert "2>&1" in command, (
+            f"{workflow.name}: stderr must be merged into the captured stream (tracebacks land on stderr)."
+        )
         assert 'LOG="$RUNNER_TEMP/eval-run-$EVAL_SUFFIX.log"' in command, (
-            "the captured log must live in $RUNNER_TEMP under the per-leg suffix so it can be uploaded."
+            f"{workflow.name}: the captured log must live in $RUNNER_TEMP under the per-leg suffix "
+            f"so it can be uploaded."
         )
 
-    def test_failure_prints_the_captured_tail_and_the_summary(self) -> None:
-        command = _eval_command()
-        assert "tail -n" in command, "a failing leg must print the tail of the captured output into the job log."
-        assert 'cat "$SUMMARY"' in command, "a failing leg must print the summary markdown when one was rendered."
+    def test_failure_prints_the_captured_tail(self, workflow: Path) -> None:
+        command = _eval_command(workflow)
+        assert "tail -n" in command, (
+            f"{workflow.name}: a failing leg must print the tail of the captured output into the job log."
+        )
 
-    def test_the_real_exit_code_is_preserved(self) -> None:
-        command = _eval_command()
+    def test_the_real_exit_code_is_preserved(self, workflow: Path) -> None:
+        command = _eval_command(workflow)
         assert "set -o pipefail" in command, (
-            "`tee` would otherwise mask a non-zero eval exit code and turn a red leg green."
+            f"{workflow.name}: `tee` would otherwise mask a non-zero eval exit code and turn a red leg green."
         )
         assert 'exit "$rc"' in command, (
-            "The failure handler adds visibility, never swallows the error — the leg must still fail."
+            f"{workflow.name}: the failure handler adds visibility, never swallows the error — the leg must still fail."
         )
 
-    def test_each_attempt_reports_its_own_failure(self) -> None:
+    def test_each_attempt_reports_its_own_failure(self, workflow: Path) -> None:
         # Printing INSIDE the retried command is what makes attempt 1 visible; a
         # post-step handler would only ever see the final attempt.
-        command = _eval_command()
+        command = _eval_command(workflow)
         marker = command.index("tail -n")
         assert command.index("t3 eval run") < marker, (
-            "the tail print must follow the eval invocation inside the retried command, "
-            "so every attempt surfaces its own failure output."
+            f"{workflow.name}: the tail print must follow the eval invocation inside the retried "
+            f"command, so every attempt surfaces its own failure output."
+        )
+
+
+class TestTheEndOfRunArtifactIsAccountedForOnFailure:
+    """Each lane's end-of-run artifact is either shown or its absence stated.
+
+    A maintainer must never be left guessing whether the artifact is missing from
+    the run or merely missing from the log, so each failure block branches on the
+    file rather than staying silent about it.
+    """
+
+    def test_weekly_cron_prints_the_summary_markdown(self) -> None:
+        command = _eval_command(_GH_EVAL)
+        assert 'cat "$SUMMARY"' in command, "a failing leg must print the summary markdown when one was rendered."
+
+    def test_benchmark_reports_whether_the_matrix_dashboard_rendered(self) -> None:
+        # The benchmark's end-of-run artifact is an HTML dashboard — useless catted
+        # into a job log, so the block points at the uploaded artifact instead. Its
+        # text twin (the matrix table) is already inside the teed tail.
+        command = _eval_command(_GH_BENCHMARK)
+        assert '[ -s "$MATRIX_HTML" ]' in command, (
+            "a failing benchmark leg must say whether the matrix dashboard rendered — "
+            "its absence is what tells a maintainer the run died mid-matrix."
         )


### PR DESCRIPTION
## What

The manual benchmark leg (`.github/workflows/eval-weekly-reusable.yml`) gets the
observability contract [#3744](https://github.com/souliane/teatree/pull/3744) gave
the weekly cron:

- **Tee the run's combined stdout/stderr** to a durable
  `$RUNNER_TEMP/eval-run-<lane>-<shard>-<effort>.log`, uploaded as a new per-leg
  **`eval-run-log-*`** artifact (`if: always()`).
- **On non-zero exit, print into the job log** — the captured tail (400 lines) in a
  collapsible `::group::` block, plus a line saying whether the matrix dashboard
  rendered — then re-raise the real exit code. `set -o pipefail` keeps `tee` from
  masking that code and the block ends in `exit "$rc"`: this adds visibility, it
  never swallows the failure. **The leg still fails.**
- **Each attempt is visible.** The print happens *inside* the retried command, so
  attempt 1's tail lands before the retry action's `Attempt 1 failed` line instead
  of being discarded when attempt 2 starts. `tee -a` keeps both attempts in the one
  uploaded log.
- The dashboard is **HTML** — useless catted into a job log — so the block points at
  the uploaded `eval-benchmark-*` artifact instead of dumping it. Its text twin (the
  matrix table `t3 eval run` echoes before writing the HTML) is already in the tail,
  so nothing is lost by not printing it.
- `SUMMARY_SUFFIX` → **`EVAL_SUFFIX`** (its only two references), so the capture
  contract is byte-identical to `eval.yml`'s rather than a parallel one.
- **Pinned** by `tests/test_eval_failure_observability.py`, now parametrized over
  both metered workflows; the two genuinely per-workflow expectations (summary
  markdown vs matrix dashboard) are split into their own class.

Second commit: the four `RED-LEG DIAGNOSIS` / `FAILURE OBSERVABILITY` comments cited
`#3745`, which is an unrelated merged docs PR — the contract they describe landed in
`#3744`. Corrected in both workflows.

## Why

The gap is real, not assumed — verified against `origin/main`, and it is the same
two causes #3744 found (**not** a missing `if: always()`, which was already correct
here, on an already per-leg-unique artifact name):

1. **The output was STREAMED but never STORED.** The `command:` block had no `tee`,
   so nothing wrote the run to a file: nothing could be uploaded, and anything lost
   to the 80min `SIGTERM` kill was gone for good.
2. **The only artifact is rendered at END of run.** `multi_trial.py:291` writes
   `html_out` *after* `collect_matrix_rows` returns, so a leg that dies mid-matrix
   never writes it. The upload's `if: always()` was already correct — the file simply
   did not exist, which is exactly why the artifact looks un-uploaded on the failures
   that need it.

Net effect on `main`: a red benchmark leg emits only the retry action's
`Child_process exited with error code 1` — no scenario name, no verdict, no
traceback — while having spent real per-token credit. The teed log exists from the
first byte, so it is the one artifact that survives a pre-dashboard death.

The raw log is **unsanitized**, so it is deliberately not collected by the `publish`
job (which globs `eval-benchmark-*` only) — it stays out of the public dashboard.

## Verification (no eval run was fired, no workflow triggered)

- The new assertions were confirmed **RED against the unfixed workflow first**: 6 of
  the 8 benchmark-parametrized assertions failed (missing `eval-run-log` upload, no
  `tee -a`, no `2>&1`, no `LOG=` path, no `tail -n`, no `set -o pipefail`/`exit
  "$rc"`, no `[ -s "$MATRIX_HTML" ]`). The 2 that stayed green are the properties
  already correct on `main` — they are regression guards. All 10 `eval.yml`
  assertions stayed green throughout: no test was inverted or weakened.
- **The command block was extracted from the YAML and executed against a stub**, with
  controls, two attempts each: fails-without-dashboard → tail + honest "the run died
  before rendering one" note, `rc=1`; fails-with-dashboard → tail + the artifact
  pointer, `rc=1`; **green run → zero failure output, `rc=0`**. The stub's stderr
  line appears in the teed tail (so `2>&1` works), and `tee -a` accumulated both
  attempts in the one log.
- Both workflows parse: `yaml.safe_load`.
- `uv run ruff check` clean tree-wide; `ruff format --check` and `ty check` clean on
  the test; `uv run python manage.py makemigrations --check --dry-run` → "No changes
  detected"; `t3 tool test-path-mirror` → ledger exact;
  `tests/quality/test_no_flat_core_regrowth.py` → 1 passed.
- Every test that reads these workflows run together and green: 384 passed, 2 skipped
  (`test_eval_failure_observability`, `test_eval_ci_retries_transient_failures`,
  `test_eval_ci_require_executed_gate`, `tests/teatree_cli/eval/`). No full suite —
  RAM-constrained box.

## Architecture pre-check

Tactical CI-observability change — no `src/teatree` module, FSM transition,
`OverlayBase` hook, Protocol surface, or dependency edge is touched, so the ten-check
gate does not fire. **Test surface:** `tests/test_eval_failure_observability.py` is
the observable contract, now covering both metered workflows through one parametrized
set. **Behavior preservation:** additive — no matcher narrowed, no capability removed,
no must-block test inverted; the `SUMMARY_SUFFIX` rename updates both of its
references in the same change. **Removability:** self-contained (delete the tee/failure
block and the one upload step and the workflow reverts to today's behavior).
**Harness vs data:** the tail depth stays a literal in the one command block that
consumes it — a per-leg policy table would be machinery with no second consumer.

## Open questions & assumptions

- The retry is **kept** at 2 attempts, for the same reason as #3744: what made it
  harmful was discarding attempt 1's output, which is the part this fixes.
- `eval-pr-reusable.yml` was **not** touched. It is out of scope for this task and I
  have not audited it — worth the same check, but it should be a deliberate look
  rather than a bundled assumption.
- No issue was filed for either follow-up (per instruction); they are recorded here.
