### PR TITLE
fix(ci): pin the Claude CLI per tier + close the PR eval lane's capture gap (#3748)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,16 @@ updates:
       # against the metered eval lane (souliane/teatree#3125).
       - dependency-name: "claude-agent-sdk"
 
+  # There is deliberately NO `npm` ecosystem for the pinned `@anthropic-ai/claude-code`
+  # (and `pyright`) installs. Dependabot's npm ecosystem reads a package.json/lockfile,
+  # and its docker ecosystem reads `FROM` lines — neither can see a bare `npm install -g`
+  # in a Dockerfile `RUN` or a workflow `run:` block, so adding the ecosystem would watch
+  # nothing. Manufacturing a package.json just to give the bot a manifest would not update
+  # those strings either, and the eval/test tier is a QUARANTINE tied to the SDK bundle,
+  # for the same reason `claude-agent-sdk` sits in the ignore list above. The pins are
+  # instead held by tests/test_claude_cli_pin.py, which reds when a site drifts or a new
+  # one appears unclassified (souliane/teatree#3748).
+  #
   # SHA-pinned actions are kept current by Dependabot: it reads the `# vN`
   # comment tag and proposes a PR when a new release resolves to a different SHA.
   - package-ecosystem: "github-actions"

--- a/.github/workflows/eval-ci-heal.yml
+++ b/.github/workflows/eval-ci-heal.yml
@@ -151,9 +151,14 @@ jobs:
           command: uv sync
       # Install the Claude CLI the metered api backend shells out to, then ASSERT
       # it — a missing binary must FAIL the job, not skip every scenario green.
+      # Pinned to the CLI generation `claude-agent-sdk` BUNDLES — the binary the eval
+      # runner actually execs (`_find_cli` returns the bundle first; this global install
+      # is only the presence-gate). Matching it stops the two CLIs in one image from
+      # disagreeing. The DEPLOYED runtime pins a newer one on purpose; both tiers are
+      # guarded by tests/test_claude_cli_pin.py (souliane/teatree#3748).
       - name: Install and assert the Claude CLI
         run: |
-          npm install -g @anthropic-ai/claude-code
+          npm install -g @anthropic-ai/claude-code@2.1.169
           claude --version
       - name: Migrate the self-DB (the eval run-history ledger persists into it)
         run: uv run python -m teatree migrate --no-input

--- a/.github/workflows/eval-nightly.yml
+++ b/.github/workflows/eval-nightly.yml
@@ -137,9 +137,14 @@ jobs:
           command: uv sync
       # Install the Claude CLI the api backend shells out to, then ASSERT it — a
       # missing binary must FAIL the job, not skip every scenario green.
+      # Pinned to the CLI generation `claude-agent-sdk` BUNDLES — the binary the eval
+      # runner actually execs (`_find_cli` returns the bundle first; this global install
+      # is only the presence-gate). Matching it stops the two CLIs in one image from
+      # disagreeing. The DEPLOYED runtime pins a newer one on purpose; both tiers are
+      # guarded by tests/test_claude_cli_pin.py (souliane/teatree#3748).
       - name: Install and assert the Claude CLI
         run: |
-          npm install -g @anthropic-ai/claude-code
+          npm install -g @anthropic-ai/claude-code@2.1.169
           claude --version
       - name: Migrate the self-DB (the eval run-history ledger persists into it)
         run: uv run python -m teatree migrate --no-input

--- a/.github/workflows/eval-pr-reusable.yml
+++ b/.github/workflows/eval-pr-reusable.yml
@@ -207,9 +207,14 @@ jobs:
           command: uv sync
       # Install the Claude CLI the metered api backend shells out to, then ASSERT
       # it — a missing binary must FAIL the job, not skip every scenario green.
+      # Pinned to the CLI generation `claude-agent-sdk` BUNDLES — the binary the eval
+      # runner actually execs (`_find_cli` returns the bundle first; this global install
+      # is only the presence-gate). Matching it stops the two CLIs in one image from
+      # disagreeing. The DEPLOYED runtime pins a newer one on purpose; both tiers are
+      # guarded by tests/test_claude_cli_pin.py (souliane/teatree#3748).
       - name: Install and assert the Claude CLI
         run: |
-          npm install -g @anthropic-ai/claude-code
+          npm install -g @anthropic-ai/claude-code@2.1.169
           claude --version
       - name: Migrate the self-DB (the eval run-history ledger persists into it)
         run: uv run python -m teatree migrate --no-input
@@ -251,28 +256,63 @@ jobs:
           timeout_minutes: 80
           max_attempts: 2
           retry_wait_seconds: 60
+          # FAILURE OBSERVABILITY (#3744, #3758) — the same contract `eval.yml` and
+          # `eval-weekly-reusable.yml` carry, on the third lane that spends real credit.
+          # The output was STREAMED but never STORED: nothing wrote the run to a file, so
+          # nothing could be uploaded and anything lost to the 80min SIGTERM kill was gone.
+          # It is now teed to a durable $RUNNER_TEMP log (uploaded below, and the ONLY
+          # artifact that exists before the first scenario finishes rendering), and on a
+          # non-zero exit the tail is re-printed into the job log — the first diagnosis
+          # needs no download. Printing INSIDE the retried command is what makes EACH
+          # attempt visible; `tee -a` keeps both attempts in the one uploaded log.
+          # `set -o pipefail` stops `tee` masking the eval's exit code and the block ends
+          # in `exit "$rc"`: this adds visibility, it never swallows the failure.
+          # `-eu` are dropped so the flag set is byte-identical to the other two lanes':
+          # the loop captures every scenario's code in `rc` and re-raises it, so aborting
+          # on the first non-zero would only discard the remaining scenarios' output
+          # while reporting the same red, and an unset EVAL_NAMES still fails loud
+          # through the ZERO-IS-RED guard below rather than through `-u`.
           command: |
-            set -euo pipefail
-            : > "$RUNNER_TEMP/eval-summary.md"
+            set -o pipefail
+            TAIL_LINES=400
+            LOG="$RUNNER_TEMP/eval-run-pr.log"
+            SUMMARY="$RUNNER_TEMP/eval-summary.md"
+            echo "===== attempt started $(date -u +%Y-%m-%dT%H:%M:%SZ) =====" >> "$LOG"
+            : > "$SUMMARY"
             rc=0
             ran=0
             IFS=',' read -ra NAMES <<< "$EVAL_NAMES"
             for name in "${NAMES[@]}"; do
               name="$(echo "$name" | xargs)"
-              [ -z "$name" ] && continue
+              if [ -z "$name" ]; then
+                continue
+              fi
               ran=$((ran + 1))
               uv run t3 eval run "$name" --backend api \
                 --escalate-on-fail --escalate-trials 3 \
                 --require-executed --docker \
                 --transcript-html "$RUNNER_TEMP/eval-transcripts-$name.html" \
-                --summary-md "$RUNNER_TEMP/eval-summary-$name.md" || rc=$?
-              [ -f "$RUNNER_TEMP/eval-summary-$name.md" ] && cat "$RUNNER_TEMP/eval-summary-$name.md" >> "$RUNNER_TEMP/eval-summary.md"
+                --summary-md "$RUNNER_TEMP/eval-summary-$name.md" 2>&1 | tee -a "$LOG" || rc=$?
+              if [ -f "$RUNNER_TEMP/eval-summary-$name.md" ]; then
+                cat "$RUNNER_TEMP/eval-summary-$name.md" >> "$SUMMARY"
+              fi
             done
             # ZERO-IS-RED: detect reached this job only with run=true (>=1 changed
             # scenario), so executing ZERO here is a vacuous green, never a pass.
             if [ "$ran" -eq 0 ]; then
               echo "::error::detect selected scenarios (run=true) but the eval executed ZERO — vacuous green, failing." >&2
               exit 1
+            fi
+            if [ "$rc" -eq 0 ]; then
+              exit 0
+            fi
+            echo "::group::the PR eval FAILED (exit $rc) — last $TAIL_LINES captured lines"
+            tail -n "$TAIL_LINES" "$LOG" || echo "nothing captured at $LOG"
+            echo "::endgroup::"
+            if [ -s "$SUMMARY" ]; then
+              cat "$SUMMARY"
+            else
+              echo "No summary at $SUMMARY: the run died before rendering one, so the tail above is the whole diagnosis."
             fi
             exit "$rc"
       # Append the sanitized summary to the PR's step summary (the in-container run
@@ -286,13 +326,27 @@ jobs:
           fi
       # Upload the PRIVATE per-trial transcript (reasoning + tool calls) as an
       # artifact a maintainer reads to diagnose a red PR eval. `if: always()` so a
-      # red run still publishes it.
+      # red run still publishes it. The path is a GLOB: the loop renders ONE report
+      # per scenario (`eval-transcripts-<name>.html`), so the un-suffixed filename
+      # this used to publish was never written by anything — `if-no-files-found:
+      # warn` then made every run, red or green, upload nothing at all.
       - name: Upload the per-trial transcript report (private)
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: eval-pr-transcripts
-          path: ${{ runner.temp }}/eval-transcripts.html
+          path: ${{ runner.temp }}/eval-transcripts-*.html
+          if-no-files-found: warn
+      # The RAW teed stdout/stderr of every attempt. Unlike the transcript and the
+      # summary (both rendered as each scenario completes), this exists from the first
+      # byte, so it is the only artifact that survives a run killed mid-scenario. It is
+      # UNSANITIZED, so it is private-only and never collected by a publish job.
+      - name: Upload the raw run log (private)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: eval-run-log-pr
+          path: ${{ runner.temp }}/eval-run-pr.log
           if-no-files-found: warn
 
   # EVAL-GATE: the single always-reporting merge gate an overlay caller pins as a

--- a/.github/workflows/eval-pr.yml
+++ b/.github/workflows/eval-pr.yml
@@ -170,9 +170,14 @@ jobs:
           command: uv sync
       # Install the Claude CLI the metered api backend shells out to, then ASSERT
       # it — a missing binary must FAIL the job, not skip every scenario green.
+      # Pinned to the CLI generation `claude-agent-sdk` BUNDLES — the binary the eval
+      # runner actually execs (`_find_cli` returns the bundle first; this global install
+      # is only the presence-gate). Matching it stops the two CLIs in one image from
+      # disagreeing. The DEPLOYED runtime pins a newer one on purpose; both tiers are
+      # guarded by tests/test_claude_cli_pin.py (souliane/teatree#3748).
       - name: Install and assert the Claude CLI
         run: |
-          npm install -g @anthropic-ai/claude-code
+          npm install -g @anthropic-ai/claude-code@2.1.169
           claude --version
       - name: Migrate the self-DB (the eval run-history ledger persists into it)
         run: uv run python -m teatree migrate --no-input

--- a/.github/workflows/eval-weekly-reusable.yml
+++ b/.github/workflows/eval-weekly-reusable.yml
@@ -270,9 +270,14 @@ jobs:
           command: uv sync
       # Install the Claude CLI the metered api backend shells out to, then ASSERT
       # it — a missing binary must FAIL the job, not skip every scenario green.
+      # Pinned to the CLI generation `claude-agent-sdk` BUNDLES — the binary the eval
+      # runner actually execs (`_find_cli` returns the bundle first; this global install
+      # is only the presence-gate). Matching it stops the two CLIs in one image from
+      # disagreeing. The DEPLOYED runtime pins a newer one on purpose; both tiers are
+      # guarded by tests/test_claude_cli_pin.py (souliane/teatree#3748).
       - name: Install and assert the Claude CLI
         run: |
-          npm install -g @anthropic-ai/claude-code
+          npm install -g @anthropic-ai/claude-code@2.1.169
           claude --version
       - name: Migrate the self-DB (the eval run-history ledger persists into it)
         run: uv run python -m teatree migrate --no-input

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -330,10 +330,15 @@ jobs:
       # for the CLI-free `anthropic_api` backend (#3222), which talks to the
       # Anthropic Messages API directly and spawns no `claude` child — a scheduled
       # run (empty input) keeps the default 'api' backend and still installs it.
+      # Pinned to the CLI generation `claude-agent-sdk` BUNDLES — the binary the eval
+      # runner actually execs (`_find_cli` returns the bundle first; this global install
+      # is only the presence-gate). Matching it stops the two CLIs in one image from
+      # disagreeing. The DEPLOYED runtime pins a newer one on purpose; both tiers are
+      # guarded by tests/test_claude_cli_pin.py (souliane/teatree#3748).
       - name: Install and assert the Claude CLI
         if: ${{ (inputs.backend || 'api') == 'api' }}
         run: |
-          npm install -g @anthropic-ai/claude-code
+          npm install -g @anthropic-ai/claude-code@2.1.169
           claude --version
       - name: Migrate the self-DB (the eval run-history ledger persists into it)
         run: uv run python -m teatree migrate --no-input

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,7 +59,12 @@ variables:
     # every scenario and report a decorative green). `claude --version` is the
     # post-install assertion that turns an install failure into a red job.
     - apt-get update && apt-get install -y --no-install-recommends nodejs npm
-    - npm install -g @anthropic-ai/claude-code
+    # Pinned to the CLI generation `claude-agent-sdk` BUNDLES — the binary the eval
+    # runner actually execs (`_find_cli` returns the bundle first; this global install
+    # is only the presence-gate). Matching it stops the two CLIs in one image from
+    # disagreeing. The DEPLOYED runtime pins a newer one on purpose; both tiers are
+    # guarded by tests/test_claude_cli_pin.py (souliane/teatree#3748).
+    - npm install -g @anthropic-ai/claude-code@2.1.169
     - claude --version
   # Bounded retry on transient infra classes (script_failure = a model/network ReadTimeout); a real miss still fails fast.
   retry:

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -20,6 +20,13 @@ FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebff
 # daemon over the mounted socket. The npm `pyright` package provides the
 # `pyright-langserver` binary the pyright-lsp Claude plugin execs to give factory
 # agents live Python type diagnostics while coding (`t3 setup` enables the plugin).
+#
+# The claude CLI pin here is DELIBERATELY NOT the generation `claude-agent-sdk`
+# bundles (which every eval/test image pins). This image feeds the paths that exec
+# the GLOBAL binary — `t3 loop start`'s os.execv, the agent command, the ttyd web
+# terminal, the tasks command — so it needs a current known-good release; the
+# bundle's 2.1.169 predates `claude-opus-5`, which model_tiering resolves as the
+# `frontier` tier. Both tiers are guarded by tests/test_claude_cli_pin.py.
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends \
         ca-certificates curl direnv git gnupg jq pass sqlite3 ttyd && \
@@ -38,7 +45,7 @@ RUN apt-get update -qq && \
         > /etc/apt/sources.list.d/docker.list && \
     apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends gh docker-ce-cli docker-compose-plugin && \
-    npm install -g @anthropic-ai/claude-code pyright && \
+    npm install -g @anthropic-ai/claude-code@2.1.220 pyright@1.1.411 && \
     npm cache clean --force && \
     rm -rf /var/lib/apt/lists/*
 

--- a/dev/Dockerfile.test
+++ b/dev/Dockerfile.test
@@ -3,12 +3,17 @@
 # layer below — so all 6 CI test shards do the full apt+node+uv rebuild at once
 # (souliane/teatree CI-speedup). Digest = ubuntu:24.04 as of 2026-07-16. Bump it
 # deliberately (dependabot's docker ecosystem can automate this).
+#
+# The claude CLI is likewise pinned, to the generation `claude-agent-sdk` BUNDLES —
+# the binary the eval runner actually execs, so the two CLIs in one image cannot
+# disagree. The DEPLOYED runtime image pins a newer one on purpose; both tiers are
+# guarded by tests/test_claude_cli_pin.py (souliane/teatree#3748).
 FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90 AS base
 RUN apt-get update -qq && \
     apt-get install -y -qq ca-certificates curl direnv git jq sqlite3 >/dev/null 2>&1 && \
     curl -fsSL https://deb.nodesource.com/setup_24.x | bash - >/dev/null 2>&1 && \
     apt-get install -y -qq nodejs >/dev/null 2>&1 && \
-    npm install -g @anthropic-ai/claude-code >/dev/null 2>&1 && \
+    npm install -g @anthropic-ai/claude-code@2.1.169 >/dev/null 2>&1 && \
     rm -rf /var/lib/apt/lists/* && \
     useradd -m testuser
 USER testuser

--- a/tests/test_claude_cli_pin.py
+++ b/tests/test_claude_cli_pin.py
@@ -1,0 +1,195 @@
+"""Guards the npm-installed Claude CLI pin, per tier (souliane/teatree#3748).
+
+``claude-agent-sdk`` is quarantined at an exact pin with a guard test and a
+Dependabot ``ignore`` entry (``tests/test_claude_agent_sdk_pin.py``). The Claude
+CLI installed via ``npm install -g`` had none of that: every image and workflow
+installed it with no version, so each build resolved to whatever ``latest``
+happened to be that day, and Dependabot cannot see a non-manifest-driven install.
+
+The pin is deliberately split into TWO TIERS, because the two consumers need
+opposite things and one global version would break whichever tier lost:
+
+**eval/test images** pin the generation the pinned SDK BUNDLES. The eval runner
+never executes the global binary — ``SubprocessCLITransport._find_cli()`` returns
+``_find_bundled_cli()`` first, and ``shutil.which("claude")`` in
+``teatree.eval.api_runner`` is only a provisioning presence-gate. Matching the
+bundle keeps the two CLIs in one image from disagreeing.
+
+**The deployed runtime image** pins a current known-good version instead. That
+image feeds the paths that DO exec the global binary (``teatree.cli.loop.app``'s
+``os.execv``, ``teatree.cli.agent``, ``teatree.agents.web_terminal``,
+``teatree.core.management.commands.tasks``). Rolling it back to the bundle's
+generation would put the deployed CLI ~50 generations behind, and behind the
+introduction of ``claude-opus-5``, which ``teatree.agents.model_tiering``'s
+``TIER_MODELS`` sets as the ``frontier`` tier.
+
+So these tests assert agreement PER TIER and never one global version across all
+sites — that global equality is precisely the mistake the split exists to avoid.
+"""
+
+import re
+import tomllib
+from collections.abc import Iterator
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SELF = Path(__file__).resolve()
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_RUNTIME_DOCKERFILE = _REPO_ROOT / "deploy" / "Dockerfile"
+
+#: The SDK pin whose bundled CLI the eval/test tier tracks. When the SDK pin moves,
+#: this constant reds and :data:`_SDK_BUNDLED_CLI_VERSION` must be re-derived from
+#: the NEW wheel's ``claude_agent_sdk/_bundled/claude --version`` — never assumed.
+_PINNED_SDK_VERSION = "0.2.94"
+
+#: ``claude_agent_sdk/_bundled/claude --version`` from the wheel of
+#: :data:`_PINNED_SDK_VERSION` → ``2.1.169 (Claude Code)``.
+_SDK_BUNDLED_CLI_VERSION = "2.1.169"
+
+#: The deployed runtime's pin: the version the factory host runs today.
+_RUNTIME_CLI_VERSION = "2.1.220"
+
+#: ``pyright-langserver`` for the pyright-lsp plugin in the runtime image.
+_PYRIGHT_VERSION = "1.1.411"
+
+_EVAL_TEST_SITES = frozenset(
+    {
+        "dev/Dockerfile.test",
+        ".gitlab-ci.yml",
+        ".github/workflows/eval.yml",
+        ".github/workflows/eval-pr.yml",
+        ".github/workflows/eval-pr-reusable.yml",
+        ".github/workflows/eval-nightly.yml",
+        ".github/workflows/eval-weekly-reusable.yml",
+        ".github/workflows/eval-ci-heal.yml",
+    }
+)
+_RUNTIME_SITES = frozenset({"deploy/Dockerfile"})
+
+_SKIP_DIRS = frozenset(
+    {
+        ".git",
+        ".venv",
+        ".ruff_cache",
+        ".pytest_cache",
+        ".mypy_cache",
+        "__pycache__",
+        "node_modules",
+        "dist",
+        "mutants",
+        "staticfiles",
+        "htmlcov",
+    }
+)
+
+_INSTALL_PATTERN = re.compile(r"npm install -g [^\n]*?@anthropic-ai/claude-code(?:@(?P<version>[0-9][^\s\\'\"]*))?")
+_PYRIGHT_PATTERN = re.compile(r"npm install -g [^\n]*?\bpyright(?:@(?P<version>[0-9][^\s\\'\"]*))?")
+
+
+def _repo_text_files() -> Iterator[Path]:
+    stack = [_REPO_ROOT]
+    while stack:
+        for entry in sorted(stack.pop().iterdir()):
+            if entry.is_dir():
+                if entry.name not in _SKIP_DIRS:
+                    stack.append(entry)
+            elif entry.is_file() and entry.resolve() != _SELF:
+                yield entry
+
+
+def _install_sites() -> dict[str, str | None]:
+    """Repo-relative path → the pinned version, or ``None`` when unpinned."""
+    sites: dict[str, str | None] = {}
+    for path in _repo_text_files():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        for match in _INSTALL_PATTERN.finditer(text):
+            sites[path.relative_to(_REPO_ROOT).as_posix()] = match.group("version")
+    return sites
+
+
+def _sdk_pin() -> str:
+    deps = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))["project"]["dependencies"]
+    matches = [d.replace(" ", "") for d in deps if d.replace(" ", "").startswith("claude-agent-sdk")]
+    assert len(matches) == 1, f"expected exactly one claude-agent-sdk dependency, got {matches}"
+    return matches[0].removeprefix("claude-agent-sdk==")
+
+
+def _as_tuple(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.split("."))
+
+
+class TestEveryInstallSiteIsPinned:
+    def test_no_install_resolves_to_whatever_latest_is_today(self) -> None:
+        unpinned = sorted(path for path, version in _install_sites().items() if version is None)
+        assert not unpinned, (
+            "every `npm install -g @anthropic-ai/claude-code` must carry an `@<version>` "
+            "suffix — a bare install resolves to whatever `latest` is on build day, which "
+            "no lockfile, guard, or bot can see. Unpinned: " + ", ".join(unpinned)
+        )
+
+    def test_every_site_is_classified_into_a_tier(self) -> None:
+        # A new workflow that copies an existing install step lands here unclassified,
+        # so it cannot silently inherit the wrong tier's version.
+        discovered = set(_install_sites())
+        known = _EVAL_TEST_SITES | _RUNTIME_SITES
+        assert discovered == known, (
+            "every Claude CLI install site must be classified as eval/test (pins the SDK-bundled "
+            f"generation) or runtime (pins a current known-good version). New: {sorted(discovered - known)}; "
+            f"gone: {sorted(known - discovered)}."
+        )
+
+
+class TestTheEvalTestTierTracksTheSdkBundle:
+    def test_every_eval_test_site_pins_the_bundled_generation(self) -> None:
+        sites = _install_sites()
+        disagreeing = {
+            path: sites.get(path) for path in sorted(_EVAL_TEST_SITES) if sites.get(path) != _SDK_BUNDLED_CLI_VERSION
+        }
+        assert not disagreeing, (
+            f"every eval/test image must install claude-code@{_SDK_BUNDLED_CLI_VERSION} — the generation "
+            f"`claude-agent-sdk=={_PINNED_SDK_VERSION}` bundles and actually executes — so the global binary "
+            f"and the bundle in one image cannot disagree. Got: {disagreeing}"
+        )
+
+    def test_the_sdk_pin_the_tier_tracks_has_not_moved(self) -> None:
+        assert _sdk_pin() == _PINNED_SDK_VERSION, (
+            f"the eval/test tier pins the CLI generation bundled by claude-agent-sdk=={_PINNED_SDK_VERSION}. "
+            f"The SDK pin is now {_sdk_pin()!r}, so its bundled CLI version must be re-derived by running "
+            f"`claude_agent_sdk/_bundled/claude --version` from the NEW wheel, and every eval/test site "
+            "re-pinned to it."
+        )
+
+
+class TestTheRuntimeTierIsPinnedIndependently:
+    def test_every_runtime_site_pins_one_current_known_good_version(self) -> None:
+        sites = _install_sites()
+        disagreeing = {
+            path: sites.get(path) for path in sorted(_RUNTIME_SITES) if sites.get(path) != _RUNTIME_CLI_VERSION
+        }
+        assert not disagreeing, (
+            f"the deployed runtime image must install claude-code@{_RUNTIME_CLI_VERSION}: it execs the GLOBAL "
+            "binary (t3 loop start's os.execv, the agent command, the ttyd web terminal, the tasks command). "
+            f"Got: {disagreeing}"
+        )
+
+    def test_the_runtime_is_never_rolled_back_behind_the_eval_bundle(self) -> None:
+        # The tiers are pinned separately, but only in one direction: the deployed CLI
+        # may lead the bundle, never trail it. Pinning the runtime back to the bundled
+        # generation would take it behind `claude-opus-5`, which model_tiering's
+        # TIER_MODELS resolves as the `frontier` tier, breaking model selection in
+        # production.
+        assert _as_tuple(_RUNTIME_CLI_VERSION) >= _as_tuple(_SDK_BUNDLED_CLI_VERSION), (
+            f"the runtime pin {_RUNTIME_CLI_VERSION} trails the SDK-bundled {_SDK_BUNDLED_CLI_VERSION}."
+        )
+
+    def test_pyright_is_pinned_in_the_runtime_image(self) -> None:
+        # Installed in the same `npm install -g` line, with the same unpinned-drift
+        # exposure: it provides the `pyright-langserver` the pyright-lsp plugin execs.
+        text = _RUNTIME_DOCKERFILE.read_text(encoding="utf-8")
+        versions = {match.group("version") for match in _PYRIGHT_PATTERN.finditer(text)}
+        assert versions == {_PYRIGHT_VERSION}, (
+            f"deploy/Dockerfile must install pyright@{_PYRIGHT_VERSION}; got {versions or 'no install'}."
+        )

--- a/tests/test_eval_failure_observability.py
+++ b/tests/test_eval_failure_observability.py
@@ -4,13 +4,15 @@ Each metered leg costs ~2% of the subscription's weekly usage window (and real
 per-token billing on the benchmark's api-key lane), so a leg that fails while
 emitting only the retry action's ``Child_process exited with error code 1`` makes
 every diagnostic re-run pure waste. These tests pin the observability contract in
-BOTH metered workflows — ``.github/workflows/eval.yml`` (the weekly cron) and
-``.github/workflows/eval-weekly-reusable.yml`` (the manual benchmark): the run's
+all three metered workflows — ``.github/workflows/eval.yml`` (the weekly cron),
+``.github/workflows/eval-weekly-reusable.yml`` (the manual benchmark) and
+``.github/workflows/eval-pr-reusable.yml`` (the per-PR selective lane): the run's
 output is captured to a durable file, every diagnostic artifact uploads
-unconditionally under a per-leg-unique name, and a failing leg re-prints its tail
-into the job log while still propagating the real exit code.
+unconditionally under a name the run actually writes, and a failing leg re-prints
+its tail into the job log while still propagating the real exit code.
 """
 
+import re
 from pathlib import Path
 from typing import Any, cast
 
@@ -20,13 +22,29 @@ import yaml
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _GH_EVAL = _REPO_ROOT / ".github" / "workflows" / "eval.yml"
 _GH_BENCHMARK = _REPO_ROOT / ".github" / "workflows" / "eval-weekly-reusable.yml"
+_GH_PR = _REPO_ROOT / ".github" / "workflows" / "eval-pr-reusable.yml"
 
-# Both spend real credit per leg, so both owe the same post-mortem.
-_METERED_WORKFLOWS = (_GH_EVAL, _GH_BENCHMARK)
+# All three spend real credit per run, so all three owe the same post-mortem.
+_METERED_WORKFLOWS = (_GH_EVAL, _GH_BENCHMARK, _GH_PR)
+
+# Only the fan-out lanes can collide on an artifact name; the PR lane's eval job is
+# a single job with no matrix, so a per-leg suffix would be noise there.
+_MATRIX_WORKFLOWS = (_GH_EVAL, _GH_BENCHMARK)
 
 _SUFFIX_EXPR = "steps.artifact.outputs.suffix"
 _UPLOAD_ACTION = "actions/upload-artifact"
 _RETRY_ACTION = "nick-fields/retry"
+_LOG_ASSIGNMENT = re.compile(r'LOG="\$RUNNER_TEMP/eval-run-[^"]*\.log"')
+_RUNNER_TEMP_REF = re.compile(r"\$RUNNER_TEMP/(?P<name>[A-Za-z0-9_.$-]+)")
+#: A shell variable, a GitHub expression and a glob are all "the varying part" here;
+#: collapsing them to one placeholder compares the SHAPE of the two filenames without
+#: needing to know each variable's runtime value.
+_VARYING_PART = re.compile(r"\$\{\{[^}]*\}\}|\$[A-Za-z_][A-Za-z0-9_]*|\*")
+
+
+def _artifact_shape(path: str) -> str:
+    bare = path.replace("${{ runner.temp }}/", "").replace("$RUNNER_TEMP/", "")
+    return _VARYING_PART.sub("<var>", bare)
 
 
 def _eval_steps(workflow: Path) -> list[dict[str, Any]]:
@@ -67,13 +85,17 @@ class TestDiagnosticArtifactsSurviveAFailingLeg:
                 f"leg still publishes its diagnostics; got {step.get('if')!r}."
             )
 
-    def test_artifact_names_are_unique_per_matrix_leg(self, workflow: Path) -> None:
-        # The fan-out runs many legs in parallel; a shared artifact name collides and
-        # silently keeps only one leg's diagnostics.
+    def test_every_upload_publishes_a_path_the_run_actually_writes(self, workflow: Path) -> None:
+        # An `if: always()` upload of a filename nothing writes is worse than no upload:
+        # `if-no-files-found: warn` makes it fail silently, so the artifact list reads as
+        # complete while the report that would explain the failure was never published.
+        command = _eval_command(workflow)
+        written = {_artifact_shape(match.group("name")) for match in _RUNNER_TEMP_REF.finditer(command)}
         for step in _upload_steps(workflow):
-            assert _SUFFIX_EXPR in step["with"]["name"], (
-                f"{workflow.name}: artifact name {step['with']['name']!r} must carry the per-leg "
-                f"lane/shard/effort suffix so parallel legs cannot collide."
+            published = _artifact_shape(step["with"]["path"])
+            assert published in written, (
+                f"{workflow.name}: upload step {step.get('name')!r} publishes {published!r}, which the eval "
+                f"command never writes (it renders {sorted(written)})."
             )
 
     def test_raw_run_log_is_uploaded(self, workflow: Path) -> None:
@@ -97,9 +119,8 @@ class TestFailureOutputReachesTheJobLog:
         assert "2>&1" in command, (
             f"{workflow.name}: stderr must be merged into the captured stream (tracebacks land on stderr)."
         )
-        assert 'LOG="$RUNNER_TEMP/eval-run-$EVAL_SUFFIX.log"' in command, (
-            f"{workflow.name}: the captured log must live in $RUNNER_TEMP under the per-leg suffix "
-            f"so it can be uploaded."
+        assert _LOG_ASSIGNMENT.search(command), (
+            f"{workflow.name}: the captured log must live at $RUNNER_TEMP/eval-run-*.log so it can be uploaded."
         )
 
     def test_failure_prints_the_captured_tail(self, workflow: Path) -> None:
@@ -126,6 +147,18 @@ class TestFailureOutputReachesTheJobLog:
             f"{workflow.name}: the tail print must follow the eval invocation inside the retried "
             f"command, so every attempt surfaces its own failure output."
         )
+
+
+@pytest.mark.parametrize("workflow", _MATRIX_WORKFLOWS, ids=lambda path: path.name)
+class TestParallelLegsCannotCollideOnAnArtifactName:
+    def test_artifact_names_are_unique_per_matrix_leg(self, workflow: Path) -> None:
+        # The fan-out runs many legs in parallel; a shared artifact name collides and
+        # silently keeps only one leg's diagnostics.
+        for step in _upload_steps(workflow):
+            assert _SUFFIX_EXPR in step["with"]["name"], (
+                f"{workflow.name}: artifact name {step['with']['name']!r} must carry the per-leg "
+                f"lane/shard/effort suffix so parallel legs cannot collide."
+            )
 
 
 class TestTheEndOfRunArtifactIsAccountedForOnFailure:


### PR DESCRIPTION
## What

**Job A — pin the nine unpinned Claude CLI installs ([#3748](https://github.com/souliane/teatree/issues/3748)).** All nine bare `npm install -g @anthropic-ai/claude-code` sites now carry an explicit version, in **two tiers** rather than the issue's single `2.1.169`:

| Tier | Sites | Pin |
|---|---|---|
| eval/test | `dev/Dockerfile.test`, `.gitlab-ci.yml`, `eval.yml`, `eval-pr.yml`, `eval-pr-reusable.yml`, `eval-nightly.yml`, `eval-weekly-reusable.yml`, `eval-ci-heal.yml` | `2.1.169` |
| deployed runtime | `deploy/Dockerfile` (+ `pyright@1.1.411`) | `2.1.220` |

New guard `tests/test_claude_cli_pin.py`: no unpinned install anywhere in the repo, every discovered site classified into a tier, agreement **within** each tier, the SDK pin unmoved, and the runtime never rolled back behind the bundle. It deliberately does **not** assert one global version across the nine.

**Job B — the PR eval lane's capture-less failure shape.** `eval-pr-reusable.yml` was flagged unaudited for the defect [#3744](https://github.com/souliane/teatree/pull/3744) / [#3758](https://github.com/souliane/teatree/pull/3758) fixed on the other two metered lanes. It **has** it, plus a third, independent defect. Fixed to the established shape, and `tests/test_eval_failure_observability.py` now covers all three metered workflows through one parametrized set.

## Why

### The tier split

Both halves were verified, not assumed:

- **The eval runner never executes the global binary.** `SubprocessCLITransport._find_cli()` (`subprocess_cli.py:81-90`) calls `_find_bundled_cli()` **first** and returns it; `shutil.which("claude")` is only the fallback. `teatree.eval.api_runner`'s `which("claude")` is a provisioning presence-gate — present means run, absent means skip or `ClaudeCliMissingError`. So the eval tier pins whatever the SDK bundles, and the two CLIs in one image cannot disagree. `claude-agent-sdk==0.2.94`'s `_bundled/claude --version` reports `2.1.169 (Claude Code)` — derived from the currently pinned SDK, not taken from the issue.
- **The deployed image DOES exec the global binary** — `cli/loop/app.py:241` (`os.execv`), `cli/agent.py:104`, `agents/web_terminal.py:27`, `core/management/commands/tasks.py:565`. Pinning it to `2.1.169` would roll the deployed CLI back ~50 generations from the `2.1.220` the factory host runs. That is not just "older": `strings` on the two binaries shows `claude-opus-5` present in `2.1.220` and **absent** in `2.1.169` (which carries `claude-opus-4`/`-4-0`/`-4-1` as the control), and `agents/model_tiering.py:82` resolves `frontier` to `claude-opus-5`. So the issue's proposal would plausibly have broken model selection in production.

The one-directional invariant is pinned too: the runtime may lead the bundle, never trail it.

### The PR eval lane

Three causes, the third new:

1. **Streamed but never stored.** The retry-wrapped block had no `tee`, no `2>&1`, no log file. `set -euo pipefail` was already present, so that half was right — but nothing wrote the run anywhere, so nothing could be uploaded and anything lost to the 80min `timeout_minutes` SIGTERM was gone.
2. **No captured tail on failure.** `exit "$rc"` re-raised but printed nothing, so attempt 1's output was discarded when attempt 2 started.
3. **The one private artifact was unreachable.** The loop renders `$RUNNER_TEMP/eval-transcripts-$name.html` (one per scenario); the upload's `path:` was `${{ runner.temp }}/eval-transcripts.html` — an exact filename with no `-$name` and no glob. Nothing ever wrote it, so `if-no-files-found: warn` silently uploaded **nothing on every run**, red or green. Confirmed empirically below.

Unlike the benchmark lane there is no matrix here (one job, no parallel legs), so the per-leg artifact suffix is genuinely inapplicable and that assertion stays scoped to the two fan-out workflows.

`set -euo pipefail` → `set -o pipefail`, byte-identical to the other two lanes: the loop already captures each scenario's code in `rc` and re-raises it, so `-e` would only discard the remaining scenarios' output while reporting the same red, and an unset `EVAL_NAMES` still fails loud through the ZERO-IS-RED guard rather than through `-u`. The two `[ … ] && cmd` idioms became explicit `if` blocks.

### Dependabot

**No new ecosystem — and this is a considered "no", recorded in `.github/dependabot.yml`.** Dependabot's `npm` ecosystem reads a `package.json`/lockfile and its `docker` ecosystem reads `FROM` lines; neither can see a bare `npm install -g` in a Dockerfile `RUN` or a workflow `run:` block, so adding one would watch nothing. Manufacturing a `package.json` purely to give the bot a manifest would not update those strings either, and the eval tier is a **quarantine** tied to the SDK bundle — auto-bumping it is precisely how [#3639](https://github.com/souliane/teatree/pull/3639) happened. The guard test is the right mechanism.

## Verification (no eval run fired, no workflow triggered)

**Job A guard proven RED first**, against the unpinned tree: `4 failed, 3 passed`.

```text
FAILED …TestEveryInstallSiteIsPinned::test_no_install_resolves_to_whatever_latest_is_today
FAILED …TestTheEvalTestTierTracksTheSdkBundle::test_every_eval_test_site_pins_the_bundled_generation
FAILED …TestTheRuntimeTierIsPinnedIndependently::test_every_runtime_site_pins_one_current_known_good_version
FAILED …TestTheRuntimeTierIsPinnedIndependently::test_pyright_is_pinned_in_the_runtime_image
```

The 3 that stayed green are the regression guards (all nine sites discovered and classified; the SDK pin unmoved; the runtime not behind the bundle). After the pins: `7 passed`.

**Job B guard proven RED first**, and RED **only** on the unaudited lane — `6 failed, 19 passed`, every failure on `eval-pr-reusable.yml`:

```text
FAILED …test_every_upload_publishes_a_path_the_run_actually_writes[eval-pr-reusable.yml]
FAILED …test_raw_run_log_is_uploaded[eval-pr-reusable.yml]
FAILED …test_run_output_is_captured_to_a_durable_file[eval-pr-reusable.yml]
FAILED …test_failure_prints_the_captured_tail[eval-pr-reusable.yml]
FAILED …test_the_real_exit_code_is_preserved[eval-pr-reusable.yml]
FAILED …test_each_attempt_reports_its_own_failure[eval-pr-reusable.yml]
```

Every `eval.yml` and `eval-weekly-reusable.yml` assertion stayed green throughout — no test was inverted or weakened. After the fix: `32 passed` across both guard modules.

**The command block was extracted from the YAML and executed against a stub, with controls:**

| case | result |
|---|---|
| GREEN run (control) | `exit=0`, **no** `::group::`, no summary cat, no note |
| RED, summary rendered | `exit=1`, tail printed, summary cat'd |
| RED, no summary | `exit=1`, tail printed, honest "died before rendering one" |
| RED across two attempts | `2` `attempt started` markers in the **one** log → `tee -a` accumulates |
| stderr | `stderr: Traceback` present in the teed log → `2>&1` works |
| empty `EVAL_NAMES` | ZERO-IS-RED fires, `exit=1` |

**The artifact-path defect, with a control** — stubbing `uv` to write what the real command writes:

```text
files the run writes: eval-run-pr.log, eval-summary-alpha.md, eval-summary-beta.md,
                      eval-summary.md, eval-transcripts-alpha.html, eval-transcripts-beta.html
OLD upload path 'eval-transcripts.html'   matches: []
NEW upload path 'eval-transcripts-*.html' matches: ['eval-transcripts-alpha.html', 'eval-transcripts-beta.html']
raw-log upload path 'eval-run-pr.log'     matches: ['eval-run-pr.log']
```

**Gates:** `uv run ruff check` → All checks passed; `ruff format --check tests/` → 2036 files already formatted; `ty check` on both test modules → All checks passed; `manage.py makemigrations --check --dry-run` → No changes detected; `t3 tool test-path-mirror` → ledger exact; `tests/quality/test_no_flat_core_regrowth.py` + `tests/quality/test_incompleteness_marker_ratchet.py` + `tests/test_claude_agent_sdk_pin.py` → 17 passed; `dev/push-gate.sh` → exit 0 (FULL lane, `.github/dependabot.yml` is un-modellable). Every test that reads a workflow, Dockerfile, `.gitlab-ci.yml` or `dependabot.yml`, plus `tests/teatree_cli/eval/` → **1442 passed, 5 skipped**. All 14 workflow YAMLs + `.gitlab-ci.yml` + `dependabot.yml` parse under `yaml.safe_load`. No full suite — RAM-constrained box.

## Architecture pre-check

Tactical CI/image change — no `src/teatree` module, FSM transition, `OverlayBase` hook, Protocol surface, or dependency edge is touched, so the ten-check gate does not fire.

- **Test surface:** `tests/test_claude_cli_pin.py` is the new observable contract; `tests/test_eval_failure_observability.py` extends its existing one to the third lane.
- **Identity/key normalization:** the artifact-path check compares the *shape* of two filenames by collapsing shell variables, GitHub expressions and globs to one `<var>` placeholder — canonicalizing both sides to a common form rather than stripping a qualifier off one to make a comparison succeed.
- **Behavior preservation:** additive apart from the deliberate `set -euo pipefail` → `set -o pipefail` (justified above) and the transcript upload path (which matched zero files before). No matcher narrowed, no must-block test inverted; the matrix-suffix assertion moved to its own class, still asserted on both fan-out workflows.
- **Removability:** self-contained. Delete the tee/failure block, the one upload step and the guard module and the tree reverts to today's behavior.
- **Harness vs data:** the tier→version mapping lives in the guard test as two named constants rather than a config table — a table would be machinery with no second consumer, and the pins must be reviewable in the diff.

## Open questions & assumptions

- `2.1.220` is chosen as the runtime pin because it is what the factory host runs **today** (empirically known-good), and it is npm's current `latest`. npm's `stable` dist-tag is `2.1.212`; if you would rather track `stable` than `latest`, that is a one-constant change.
- The eval tier's pin is coupled to the SDK pin by a constant, not by executing the 247 MB bundled binary in CI. `test_the_sdk_pin_the_tier_tracks_has_not_moved` is the tripwire: move the SDK pin and it reds with instructions to re-derive the bundled version from the new wheel.
- The `2.1.169`-lacks-`claude-opus-5` evidence is a `strings` comparison with a `claude-opus-4` control, not a live invocation — no CLI was run against either account (both are exhausted until Jul 30).
