### PR TITLE
fix(admin): mask config secrets and route every admin write through set_value

### DIFF
--- a/docs/blueprint/configuration.md
+++ b/docs/blueprint/configuration.md
@@ -747,6 +747,20 @@ answers the edited `<tr>` alone to an htmx request (`dash/partials/_settings_row
 never moves; a refused write answers 400 carrying that same row plus its reason. Both forms
 keep `method`/`action`, so with JavaScript off the pre-htmx redirect path still works.
 
+**Django admin (`ConfigSettingAdmin`).** The fourth config write surface, held to the same
+two boundaries as the other three. A secret's value is MASKED wherever the admin would
+render it — the changelist column, the change form's textarea (a write-only widget, so
+submitting nothing keeps the stored value), the `seed_value` provenance copy, and
+`ConfigSetting.__str__` itself, which reaches log lines and the admin's object labels and
+therefore carries the coordinate alone. Every write runs `ConfigSetting.objects.set_value`,
+so the cross-key check and the seed-provenance clear fire exactly as they do for
+`config_setting set`; `ConfigSetting.clean` runs that same cross-key check, so an
+inconsistent coupled pair is a form error rather than a silent save. The masking taxonomy is
+ONE function (`teatree.core.config_display.is_secret`) shared by all three rendering
+surfaces — it lives in `core` because the admin sits below `dash` in the layer graph. There
+is no `list_editable`: an inline widget must round-trip the raw value (so it cannot mask)
+and the changelist formset writes through `Model.save()` (so it cannot use the seam).
+
 ### 10.4 Data Storage
 
 `~/.local/share/teatree/<namespace>/` — namespaced data directories created by `get_data_dir()`.

--- a/src/teatree/core/admin.py
+++ b/src/teatree/core/admin.py
@@ -1,5 +1,11 @@
-from django.contrib import admin
+from typing import TYPE_CHECKING, Any, ClassVar, override
 
+from django import forms
+from django.contrib import admin
+from django.forms.renderers import BaseRenderer
+from django.utils.safestring import SafeString
+
+from teatree.core.config_display import is_secret, masked_display
 from teatree.core.models import (
     ConfigSetting,
     Loop,
@@ -16,6 +22,10 @@ from teatree.core.models import (
     Ticket,
     Worktree,
 )
+from teatree.core.models.config_setting import ConfigValue
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest
 
 
 @admin.register(Ticket)
@@ -102,13 +112,99 @@ class PromptAdmin(admin.ModelAdmin):
         return obj.current_version
 
 
+_WRITE_ONLY_ATTRS = {"rows": 4, "cols": 40, "placeholder": "write-only — leave blank to keep the stored value"}
+
+
+class WriteOnlyJSONWidget(forms.Textarea):
+    """A textarea that never renders the value it holds — a secret leaves no HTML trace.
+
+    The admin's counterpart to the settings editor's write-only password input: the
+    operator can SET a secret from the change form, and submitting nothing keeps what
+    is stored (``ConfigSettingAdminForm.clean_value``).
+    """
+
+    @override
+    def render(
+        self,
+        name: str,
+        value: object,
+        attrs: dict[str, Any] | None = None,
+        renderer: BaseRenderer | None = None,
+    ) -> SafeString:
+        return super().render(name, "", attrs, renderer)
+
+
+class ConfigSettingAdminForm(forms.ModelForm):
+    """Edits a setting the way every other write surface does — masked, and through the seam.
+
+    ``value`` is write-only for a secret key, so the change form is not a second place
+    a stored secret renders in cleartext. Cross-key consistency (#3688) is enforced by
+    ``ConfigSetting.clean``, which every ``ModelForm`` runs, so an inconsistent coupled
+    pair surfaces as a field error rather than landing silently.
+    """
+
+    class Meta:
+        model = ConfigSetting
+        fields: ClassVar = ["scope", "key", "value"]
+
+    def _edits_a_secret(self) -> bool:
+        return bool(self.instance.pk) and is_secret(self.instance.key)
+
+    def clean_value(self) -> ConfigValue | None:
+        """A blank write-only submission means "leave the stored secret alone"."""
+        value = self.cleaned_data.get("value")
+        if value is None and self._edits_a_secret():
+            return self.instance.value
+        return value
+
+
 @admin.register(ConfigSetting)
 class ConfigSettingAdmin(admin.ModelAdmin):
-    list_display = ("key", "scope", "value", "updated_at")
-    list_editable = ("value",)
+    """The admin config surface, held to the same bar as ``/dash/settings`` (#3760 follow-up).
+
+    Two properties the dash editor has always had and this surface lacked. A secret's
+    value is MASKED wherever it would render, and every write runs
+    ``ConfigSetting.objects.set_value`` — the seam carrying the #3688 cross-key check
+    and the #3435 seed-provenance clear. ``list_editable`` is deliberately absent: an
+    inline widget must round-trip the raw value (so it cannot mask) and the changelist
+    formset writes through ``Model.save()`` (so it cannot use the seam).
+    """
+
+    form = ConfigSettingAdminForm
+    list_display = ("key", "scope", "masked_value", "updated_at")
     list_filter = ("scope",)
     search_fields = ("key", "scope")
-    readonly_fields = ("created_at", "updated_at")
+    fields = ("scope", "key", "value", "seeded_by", "masked_seed_value", "created_at", "updated_at")
+    readonly_fields = ("seeded_by", "masked_seed_value", "created_at", "updated_at")
+
+    @override
+    def get_form(
+        self, request: "HttpRequest", obj: ConfigSetting | None = None, change: bool = False, **kwargs: object
+    ) -> type[forms.ModelForm]:
+        """Give a secret key a write-only ``value`` widget so its stored value never renders."""
+        if obj is not None and is_secret(obj.key):
+            kwargs["widgets"] = {"value": WriteOnlyJSONWidget(attrs=_WRITE_ONLY_ATTRS)}
+        return super().get_form(request, obj, change, **kwargs)
+
+    @admin.display(description="value")
+    @staticmethod
+    def masked_value(obj: ConfigSetting) -> str:
+        return masked_display(obj.key, obj.value)
+
+    @admin.display(description="seed value")
+    @staticmethod
+    def masked_seed_value(obj: ConfigSetting) -> str:
+        """Seed provenance carries a second copy of the same value — mask it identically."""
+        return masked_display(obj.key, obj.seed_value)
+
+    @override
+    def save_model(self, request: "HttpRequest", obj: ConfigSetting, form: forms.ModelForm, change: bool) -> None:
+        """Write through ``set_value``, and drop the row the edit moved off its old key."""
+        if change:
+            previous = ConfigSetting.objects.filter(pk=obj.pk).first()
+            if previous is not None and (previous.scope, previous.key) != (obj.scope, obj.key):
+                ConfigSetting.objects.clear(previous.key, scope=previous.scope)
+        ConfigSetting.objects.set_value(obj.key, obj.value, scope=obj.scope)
 
 
 @admin.register(Mode)

--- a/src/teatree/core/config_display.py
+++ b/src/teatree/core/config_display.py
@@ -1,16 +1,19 @@
-"""Shared config-display helpers for the dashboard's two config surfaces (#3664, D7).
+"""Shared config-display helpers for every surface that renders a setting (#3664, D7).
 
-Both the settings editor (:mod:`teatree.dash.settings_editor`) and the read-only
-config surface (:mod:`teatree.dash.config_surface`) turn a setting's value into display
-text and decide which values must never reach the response. This is the ONE source of
-truth for both, so the two pages can never drift into divergent render or masking:
+The settings editor (:mod:`teatree.dash.settings_editor`), the read-only config surface
+(:mod:`teatree.dash.config_surface`) and the Django admin's ``ConfigSettingAdmin`` all
+turn a setting's value into display text and decide which values must never reach the
+response. This is the ONE source of truth for all three, so no surface can drift into
+divergent render or masking. It sits in ``core`` rather than ``dash`` because the admin
+is a layer BELOW the dashboard and may not import it:
 
 - :func:`render_value` — one value-to-display rule (booleans as on/off, empties as a dash).
 - :func:`is_secret` — the value-masking taxonomy: the full four-class union a secret
     VALUE is withheld by (``Category.SECRET`` field / ``SECRET_SETTINGS`` denylist /
     credential coordinate / personal identifier). A key that is a personal identifier or
-    ``Category.SECRET`` but not on the denylist is masked here too, so neither surface can
+    ``Category.SECRET`` but not on the denylist is masked here too, so no surface can
     regress toward exposure.
+- :func:`masked_display` — the two composed: the mask for a secret key, else the text.
 
 Masking a credential ENTRY NAME (the ``pass`` coordinate the config surface's credential
 band shows) is a DIFFERENT question — "does this coordinate NAME carry an internal
@@ -51,4 +54,9 @@ def is_secret(setting: str) -> bool:
     return setting_meta(setting).category is Category.SECRET
 
 
-__all__ = ["MASKED", "is_secret", "render_value"]
+def masked_display(setting: str, value: object) -> str:
+    """*value* as display text, replaced by :data:`MASKED` when *setting* is secret."""
+    return MASKED if is_secret(setting) else render_value(value)
+
+
+__all__ = ["MASKED", "is_secret", "masked_display", "render_value"]

--- a/src/teatree/core/models/config_setting.py
+++ b/src/teatree/core/models/config_setting.py
@@ -107,7 +107,7 @@ class ConfigSettingManager(models.Manager["ConfigSetting"]):
         row = self.filter(scope=scope, key=key).first()
         return row.value if row is not None else None
 
-    def _reject_inconsistent_cross_key(self, key: str, value: ConfigValue, scope: str) -> None:
+    def reject_inconsistent_cross_key(self, key: str, value: ConfigValue, scope: str) -> None:
         """Raise :class:`ValidationError` when this write would land an inconsistent coupled pair (#3688).
 
         Delegates to the config-layer :func:`~teatree.config.cross_key_consistency.validate_cross_key_write`,
@@ -115,6 +115,10 @@ class ConfigSettingManager(models.Manager["ConfigSetting"]):
         (overlay-scope row, then global-scope row) so the RESULTING pair — not
         just the value in hand — is judged. A no-op for any key in no coupled
         pair. Imported lazily to keep the model module's cold-import cheap.
+
+        Called by :meth:`set_value` (every programmatic write) and by
+        :meth:`ConfigSetting.clean` (every ``ModelForm`` write, so the Django
+        admin shows a field error instead of landing the bad pair).
         """
         from teatree.config.cross_key_consistency import (  # noqa: PLC0415 — deferred: heavy config import
             validate_cross_key_write,
@@ -149,7 +153,7 @@ class ConfigSettingManager(models.Manager["ConfigSetting"]):
         config into one loud error, not a fleet-wide repair-halt flood on every
         later dispatch. The store is left untouched on rejection.
         """
-        self._reject_inconsistent_cross_key(key, value, scope)
+        self.reject_inconsistent_cross_key(key, value, scope)
         row, _ = self.update_or_create(
             scope=scope,
             key=key,
@@ -267,11 +271,21 @@ class ConfigSetting(models.Model):
         ]
 
     def __str__(self) -> str:
+        """Identify the row by coordinate ONLY — a value here would leak a stored secret.
+
+        ``__str__`` reaches log lines, tracebacks, and the Django admin's object
+        labels (the changelist action checkbox, the change-form breadcrumb), none of
+        which consult the secret taxonomy. The coordinate is what identifies a row;
+        reading its value is the settings surfaces' job, and they mask it.
+        """
         where = "global" if self.scope == GLOBAL_SCOPE else f"overlay:{self.scope}"
-        return f"config-setting<{where} {self.key}={self.value!r}>"
+        return f"config-setting<{where} {self.key}>"
 
     def clean(self) -> None:
-        """Refuse a JSON ``null`` value, which ``blank=True`` would otherwise wave through.
+        """Refuse a JSON ``null`` value and any inconsistent coupled pair (#3688).
+
+        ``ModelForm`` validation runs this, so the Django admin refuses the same
+        writes ``set_value`` refuses instead of landing them via ``Model.save()``.
 
         ``value`` is ``blank=True`` because ``[]`` / ``{}`` / ``""`` are all
         legitimate overrides (``statusline_chain = []`` means "override the
@@ -289,3 +303,4 @@ class ConfigSetting(models.Model):
         """
         if self.value is None:
             raise ValidationError({"value": "Enter a JSON value — use [] or {} for an empty list or object."})
+        ConfigSetting.objects.reject_inconsistent_cross_key(self.key, self.value, self.scope)

--- a/src/teatree/dash/config_surface.py
+++ b/src/teatree/dash/config_surface.py
@@ -9,7 +9,7 @@ than introducing a second source of truth: the effective values come from
 :func:`~teatree.config.agent_spawn.resolve_agent_config`.
 
 **A secret value is never rendered.** A band row's value is masked whenever the setting
-is secret under the shared :func:`~teatree.dash.config_display.is_secret` taxonomy — the
+is secret under the shared :func:`~teatree.core.config_display.is_secret` taxonomy — the
 SAME policy the settings editor applies, so the two pages never diverge. A credential row
 carries the ``pass`` entry NAME and whether it resolves — never the token; an entry name
 that is itself private (a key in :data:`~teatree.config.secret_settings.SECRET_SETTINGS`,
@@ -25,15 +25,17 @@ from dataclasses import dataclass, field
 from teatree.config import get_effective_settings
 from teatree.config.agent_spawn import resolve_agent_config
 from teatree.config.secret_settings import SECRET_SETTINGS, is_credential_reference
+from teatree.core.config_display import masked_display, render_value
 from teatree.core.config_self_repair import SELF_REPAIR_STAMP
 from teatree.core.models import Task
-from teatree.dash.config_display import is_secret, render_value
 from teatree.utils.secrets import read_pass
 
 logger = logging.getLogger(__name__)
 
-#: Redaction shown in place of a private entry name OR a secret setting's value.
-MASKED = "<private>"
+#: Redaction shown in place of a private ``pass`` entry NAME. A secret VALUE is redacted
+#: by the shared :data:`~teatree.core.config_display.MASKED` token instead — two different
+#: questions, and only the value one is a policy the settings editor also answers.
+MASKED_ENTRY_NAME = "<private>"
 
 #: How many self-repairs the band lists, newest first.
 _SELF_REPAIR_LIMIT = 20
@@ -91,7 +93,7 @@ class CredentialEntry:
         would be true for all of them and hide every account name, defeating the band. This
         narrower rule masks only names that can carry an internal namespace.
         """
-        shown = MASKED if setting in SECRET_SETTINGS else entry_name
+        shown = MASKED_ENTRY_NAME if setting in SECRET_SETTINGS else entry_name
         return cls(setting=setting, entry_name=shown, resolves=_pass_entry_resolves(entry_name))
 
 
@@ -162,8 +164,8 @@ def _settings_bands() -> _Bands:
 
 
 def _band_row(name: str, value: object) -> SettingRow:
-    """A band row — the value MASKED when the setting is secret (same policy as the editor)."""
-    return SettingRow(name=name, value=MASKED if is_secret(name) else render_value(value))
+    """A band row — masked when the setting is secret, through the editor's own helper."""
+    return SettingRow(name=name, value=masked_display(name, value))
 
 
 def _credential_entries(setting: str, value: object) -> list[CredentialEntry]:

--- a/src/teatree/dash/settings_editor.py
+++ b/src/teatree/dash/settings_editor.py
@@ -5,7 +5,7 @@ and editable with NO hand-kept list — a newly-added setting appears here for f
 edit path writes through ``ConfigSetting.set_value`` (the same seam ``config_setting set``
 uses), so the #258 strict coercion and the #3688 cross-key checks fire identically.
 
-**A secret value never reaches the response.** :func:`~teatree.dash.config_display.is_secret`
+**A secret value never reaches the response.** :func:`~teatree.core.config_display.is_secret`
 (the shared value-masking taxonomy — ``Category.SECRET`` / ``SECRET_SETTINGS`` / credential
 coordinate / personal identifier) drives masking here AND on the read-only config surface,
 so the two pages apply ONE policy. A secret row's value AND its shipped default are replaced
@@ -20,10 +20,10 @@ from dataclasses import dataclass
 
 from teatree.config.schema import TeatreeSettingsSchema, setting_meta, shipped_defaults
 from teatree.config.setting_registries import SAFETY_POSTURE_KEYS
+from teatree.core.config_display import MASKED, is_secret, render_value
 from teatree.core.config_migration import ConfigImport, export_db_to_toml, import_toml_to_db
 from teatree.core.models import ConfigSetting
 from teatree.core.models.config_setting import ConfigValue
-from teatree.dash.config_display import MASKED, is_secret, render_value
 
 logger = logging.getLogger(__name__)
 

--- a/src/teatree/dash/views/settings.py
+++ b/src/teatree/dash/views/settings.py
@@ -22,10 +22,10 @@ from django.views.decorators.http import require_GET, require_POST
 from teatree.config import ALL_KNOWN_CONFIG_SETTINGS
 from teatree.config.setting_registries import SAFETY_POSTURE_KEYS
 from teatree.config.write_validation import ConfigWriteError, validate_config_write
+from teatree.core.config_display import is_secret
 from teatree.core.config_migration import import_toml_to_db
 from teatree.core.models import ConfigSetting
 from teatree.dash import audit
-from teatree.dash.config_display import is_secret
 from teatree.dash.settings_editor import build_setting_row, build_settings_editor, export_text, import_preview
 from teatree.dash.views.access import require_loopback_or_staff
 from teatree.dash.views.base import actor, nav_context

--- a/tests/quality/test_no_flat_core_regrowth.py
+++ b/tests/quality/test_no_flat_core_regrowth.py
@@ -122,7 +122,13 @@ _CORE_DIR = Path(__file__).resolve().parents[2] / "src" / "teatree" / "core"
 # A queryset leaf helper of the flat root managers.py hub, mirroring managers_phase_cadence.py /
 # managers_overlay.py / managers_issue_match.py / managers_task_claim.py. Owned by no existing
 # subpackage — models/ may not import config, and this reads `session_stale_after_hours`.
-PINNED_FLAT_CORE_MODULES = 102
+# 103: +config_display.py — the setting-name secrecy taxonomy (is_secret) and the one
+# value-to-display rule, relocated out of teatree.dash. Three surfaces now consume it —
+# the two dash config pages and ConfigSettingAdmin — and the admin sits in the domain
+# layer, which may not import the interface-layer dash. It must also stay OUT of
+# core/models/ (which may not import teatree.config, and this reads the settings schema),
+# so no existing subpackage owns it.
+PINNED_FLAT_CORE_MODULES = 103
 
 
 def _flat_core_modules() -> list[str]:

--- a/tests/teatree_core/test_admin.py
+++ b/tests/teatree_core/test_admin.py
@@ -26,11 +26,122 @@ class TestConfigSettingAdmin:
     def test_config_setting_registered_in_admin(self) -> None:
         assert ConfigSetting in admin.site._registry
 
-    def test_config_setting_admin_lists_and_edits_value(self) -> None:
+    def test_config_setting_admin_lists_key_scope_and_a_masked_value(self) -> None:
         model_admin = admin.site._registry[ConfigSetting]
         assert "key" in model_admin.list_display
         assert "scope" in model_admin.list_display
-        assert "value" in model_admin.list_editable
+        assert "masked_value" in model_admin.list_display
+
+    def test_the_value_column_is_not_inline_editable(self) -> None:
+        """``list_editable`` renders the raw value in a textarea AND writes via ``Model.save()``.
+
+        Both halves of the finding ride on it: the changelist cannot mask a value it
+        must round-trip through an input, and the changelist formset bypasses the
+        ``set_value`` seam. The change form is the one write surface.
+        """
+        model_admin = admin.site._registry[ConfigSetting]
+        assert "value" not in model_admin.list_editable
+
+
+class TestConfigSettingAdminSecrecy(django.test.TestCase):
+    """A stored secret must not reach the admin's HTML — the same bar the dash holds.
+
+    ``/dash/settings`` masks a secret's value in its table and edits it through a
+    write-only input, so the value never enters a response. The admin is the fourth
+    config write surface (dash editor, dash import, MCP, admin) and rendered every
+    value verbatim.
+    """
+
+    #: A recognisable stand-in for a stored secret — its literal absence from the
+    #: rendered HTML is the assertion, so it must not collide with any markup.
+    SECRET_VALUE = "zzz-stored-secret-marker-zzz"
+
+    def setUp(self) -> None:
+        user = get_user_model().objects.create_superuser("admin-secrecy", "sec@example.com", "pw")
+        self.client.force_login(user)
+
+    def _changelist(self) -> django.http.HttpResponse:
+        return self.client.get(reverse("admin:core_configsetting_changelist"))
+
+    def _change_form(self, row: ConfigSetting) -> django.http.HttpResponse:
+        return self.client.get(reverse("admin:core_configsetting_change", args=[row.pk]))
+
+    def test_a_secret_value_is_masked_in_the_changelist(self) -> None:
+        ConfigSetting.objects.set_value("banned_terms", [self.SECRET_VALUE])
+        response = self._changelist()
+        assert response.status_code == 200
+        assert self.SECRET_VALUE.encode() not in response.content
+        assert b"***" in response.content
+
+    def test_a_secret_value_is_not_rendered_on_the_change_form(self) -> None:
+        row = ConfigSetting.objects.set_value("banned_terms", [self.SECRET_VALUE])
+        response = self._change_form(row)
+        assert response.status_code == 200
+        assert self.SECRET_VALUE.encode() not in response.content
+
+    def test_a_secret_seed_value_is_not_rendered_on_the_change_form(self) -> None:
+        """``seed_value`` is a second copy of the same secret — provenance, not a payload."""
+        ConfigSetting.objects.seed("banned_terms", [self.SECRET_VALUE], code_default=[])
+        row = ConfigSetting.objects.get(key="banned_terms")
+        assert row.seed_value == [self.SECRET_VALUE]
+        response = self._change_form(row)
+        assert response.status_code == 200
+        assert self.SECRET_VALUE.encode() not in response.content
+
+    def test_an_ordinary_value_still_renders_in_the_changelist(self) -> None:
+        """Masking is the secret taxonomy, not a blanket blindfold on the changelist."""
+        ConfigSetting.objects.set_value("issue_implementer_label", "t3-auto")
+        response = self._changelist()
+        assert b"t3-auto" in response.content
+
+    def test_a_blank_value_leaves_a_stored_secret_untouched(self) -> None:
+        """The write-only input's contract: submitting nothing keeps what is stored."""
+        row = ConfigSetting.objects.set_value("banned_terms", [self.SECRET_VALUE])
+        url = reverse("admin:core_configsetting_change", args=[row.pk])
+        response = self.client.post(url, {"scope": row.scope, "key": row.key, "value": ""})
+        assert response.status_code == 302, dict(response.context["adminform"].form.errors)
+        row.refresh_from_db()
+        assert row.value == [self.SECRET_VALUE]
+
+
+class TestConfigSettingAdminWritesThroughSetValue(django.test.TestCase):
+    """An admin write is an operator write — it runs the ``set_value`` seam, not ``Model.save()``.
+
+    ``ConfigSetting.objects.set_value`` is where the #3688 cross-key consistency
+    check and the #3435 seed-provenance clear live. An admin form that called
+    ``Model.save()`` could land a coupled pair every other write surface refuses.
+    """
+
+    def setUp(self) -> None:
+        user = get_user_model().objects.create_superuser("admin-seam", "seam@example.com", "pw")
+        self.client.force_login(user)
+
+    def _post_change(self, row: ConfigSetting, value: str) -> django.http.HttpResponse:
+        url = reverse("admin:core_configsetting_change", args=[row.pk])
+        return self.client.post(url, {"scope": row.scope, "key": row.key, "value": value})
+
+    def test_an_inconsistent_cross_key_pair_is_refused_with_a_form_error(self) -> None:
+        """``openai_compatible`` is invalid under the default ``claude_sdk`` harness."""
+        row = ConfigSetting.objects.set_value("agent_harness_provider", "subscription_oauth")
+        response = self._post_change(row, '"openai_compatible"')
+        assert response.status_code == 200
+        assert response.context["adminform"].form.errors
+        row.refresh_from_db()
+        assert row.value == "subscription_oauth"
+
+    def test_an_admin_edit_clears_the_seed_provenance(self) -> None:
+        """``set_value`` makes the row operator-owned so no redeploy re-seed clobbers it."""
+        ConfigSetting.objects.seed("issue_implementer_label", "seeded", code_default="")
+        row = ConfigSetting.objects.get(key="issue_implementer_label")
+        assert row.seeded_by
+
+        response = self._post_change(row, '"operator-chosen"')
+
+        assert response.status_code == 302
+        row.refresh_from_db()
+        assert row.value == "operator-chosen"
+        assert row.seeded_by == ""
+        assert row.seed_value is None
 
 
 class TestConfigSettingAdminSaves(django.test.TestCase):
@@ -59,26 +170,9 @@ class TestConfigSettingAdminSaves(django.test.TestCase):
         url = reverse("admin:core_configsetting_change", args=[row.pk])
         return self.client.post(url, self._change_form_post(row, value))
 
-    def _post_changelist(self, submitted: list[tuple[ConfigSetting, str]]) -> django.http.HttpResponse:
-        data = {
-            "form-TOTAL_FORMS": str(len(submitted)),
-            "form-INITIAL_FORMS": str(len(submitted)),
-            "form-MIN_NUM_FORMS": "0",
-            "form-MAX_NUM_FORMS": "1000",
-            "_save": "Save",
-        }
-        for index, (row, rendered) in enumerate(submitted):
-            data[f"form-{index}-id"] = str(row.pk)
-            data[f"form-{index}-value"] = rendered
-        return self.client.post(reverse("admin:core_configsetting_changelist"), data)
-
     @staticmethod
     def _change_form_errors(response: django.http.HttpResponse) -> dict[str, list[str]]:
         return dict(response.context["adminform"].form.errors) if response.status_code == 200 else {}
-
-    @staticmethod
-    def _changelist_errors(response: django.http.HttpResponse) -> list[dict[str, list[str]]]:
-        return response.context["cl"].formset.errors if response.status_code == 200 else []
 
     def test_change_form_saves_an_empty_list_value(self) -> None:
         row = ConfigSetting.objects.set_value("statusline_chain", ["branch", "model"])
@@ -94,41 +188,24 @@ class TestConfigSettingAdminSaves(django.test.TestCase):
         row.refresh_from_db()
         assert row.value == {}
 
-    def test_changelist_empties_every_affected_row_in_one_save(self) -> None:
-        """The real-world failure: ``list_editable`` makes the whole page ONE formset.
+    def test_change_form_empties_each_row_the_reported_outage_hit(self) -> None:
+        """The three live rows of the reported outage, emptied one change form at a time.
 
-        A single rejected empty row fails ``formset.is_valid()`` and NOTHING on
-        the page saves. These are the three live rows the reported outage hit.
+        The outage was a blanket non-empty requirement on the storage field, which
+        rejected ``[]`` / ``{}`` for every key. That requirement is per-row, so each
+        row proves it independently; the one-formset-for-the-whole-page coupling that
+        made it page-wide belonged to ``list_editable``, which no longer exists.
         """
-        statusline = ConfigSetting.objects.set_value("statusline_chain", ["branch"])
-        allowlist = ConfigSetting.objects.set_value("banned_terms_allowlist", ["acme"])
-        skill_models = ConfigSetting.objects.set_value("agent_skill_models", {"coder": "opus"})
-
-        response = self._post_changelist([(statusline, "[]"), (allowlist, "[]"), (skill_models, "{}")])
-
-        assert response.status_code == 302, self._changelist_errors(response)
-        for row in (statusline, allowlist, skill_models):
+        rows = [
+            (ConfigSetting.objects.set_value("statusline_chain", ["branch"]), "[]", []),
+            (ConfigSetting.objects.set_value("banned_terms_allowlist", ["acme"]), "[]", []),
+            (ConfigSetting.objects.set_value("agent_skill_models", {"coder": "opus"}), "{}", {}),
+        ]
+        for row, submitted, expected in rows:
+            response = self._post_change_form(row, submitted)
+            assert response.status_code == 302, self._change_form_errors(response)
             row.refresh_from_db()
-        assert statusline.value == []
-        assert allowlist.value == []
-        assert skill_models.value == {}
-
-    def test_one_empty_row_does_not_block_the_rest_of_the_changelist(self) -> None:
-        """The reported symptom: one legitimately-empty row broke saving ANY setting.
-
-        The sibling row changes value, so its persistence is observable
-        independently of the response status.
-        """
-        emptied = ConfigSetting.objects.set_value("banned_terms_allowlist", ["acme"])
-        unrelated = ConfigSetting.objects.set_value("issue_implementer_label", "before")
-
-        response = self._post_changelist([(emptied, "[]"), (unrelated, '"after"')])
-
-        assert response.status_code == 302, self._changelist_errors(response)
-        emptied.refresh_from_db()
-        unrelated.refresh_from_db()
-        assert emptied.value == []
-        assert unrelated.value == "after"
+            assert row.value == expected
 
     def test_change_form_rejects_an_empty_value_with_a_field_error(self) -> None:
         """An empty textarea is a form error, never a NOT NULL ``IntegrityError``.

--- a/tests/teatree_core/test_config_display.py
+++ b/tests/teatree_core/test_config_display.py
@@ -1,6 +1,6 @@
 """The shared config-display helpers both dash config surfaces consume (cluster 9)."""
 
-from teatree.dash.config_display import MASKED, is_secret, render_value
+from teatree.core.config_display import MASKED, is_secret, render_value
 
 
 class TestIsSecret:

--- a/tests/teatree_dash/test_config_surface.py
+++ b/tests/teatree_dash/test_config_surface.py
@@ -6,10 +6,11 @@ import pytest
 from django.test import TestCase
 
 from teatree.config.agent_spawn import AgentConfig
+from teatree.core.config_display import MASKED
 from teatree.core.config_self_repair import ConfigRepair
 from teatree.core.models import ConfigSetting, Session, Task, Ticket
 from teatree.dash.config_surface import (
-    MASKED,
+    MASKED_ENTRY_NAME,
     CredentialEntry,
     _band_row,
     _pass_entry_resolves,
@@ -55,7 +56,8 @@ class TestCredentialEntry:
         assert not hasattr(entry, "value")
 
     def test_a_private_setting_masks_even_its_entry_name(self) -> None:
-        assert CredentialEntry.mask_if_private("github_token_pass_key", "team/internal/token").entry_name == "<private>"
+        masked = CredentialEntry.mask_if_private("github_token_pass_key", "team/internal/token")
+        assert masked.entry_name == MASKED_ENTRY_NAME == "<private>"
 
     def test_a_public_setting_keeps_its_entry_name(self) -> None:
         entry = CredentialEntry.mask_if_private("openai_compatible_credential_entry", "router/key")
@@ -72,6 +74,10 @@ class TestBandRowMasksSecretValues:
         row = _band_row("slack_user_id", "U-OWNER-SECRET")
         assert row.value == MASKED
         assert "U-OWNER-SECRET" not in row.value
+
+    def test_the_value_mask_is_the_one_shared_token(self) -> None:
+        """One policy, one token. This surface used to redact a VALUE with the ENTRY-NAME mask."""
+        assert _band_row("slack_user_id", "U-OWNER-SECRET").value != MASKED_ENTRY_NAME
 
     def test_an_ordinary_dial_value_renders(self) -> None:
         assert _band_row("boost_concurrency", 4).value == "4"

--- a/tests/teatree_dash/test_settings_editor.py
+++ b/tests/teatree_dash/test_settings_editor.py
@@ -5,8 +5,8 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from teatree.config.schema import TeatreeSettingsSchema
+from teatree.core.config_display import MASKED
 from teatree.core.models import ConfigSetting
-from teatree.dash.config_display import MASKED
 from teatree.dash.settings_editor import build_setting_row, build_settings_editor, export_text, import_preview
 
 


### PR DESCRIPTION
## What

`ConfigSettingAdmin` was the fourth config write surface and the only one held to
neither of the two boundaries the other three enforce. Reported as finding 1 of the
`/dash` UX audit that shipped with #3760, deliberately left out of scope there.

**Cleartext.** `list_display` carried `value` verbatim, so a stored secret appeared in
the changelist HTML that `/dash/settings` masks. Three more copies of the same value
came out with it: the change form's textarea, the `seed_value` provenance field, and
`ConfigSetting.__str__`, which interpolated the value into the object labels Django
puts on the changelist action checkbox and the change-form breadcrumb — and into every
log line and traceback besides.

**Bypass.** `list_editable = ("value",)` writes through `Model.save()`, so an admin edit
skipped `ConfigSetting.objects.set_value` and with it the #3688 cross-key consistency
check and the #3435 seed-provenance clear.

The two halves are one knot. An inline widget must round-trip the raw value, so a
changelist that masks cannot also inline-edit; and the changelist formset writes via
`Model.save()`, so it cannot use the seam. So `list_editable` goes and the change form
becomes the one write surface:

- `list_display` renders `masked_value`; `seed_value` renders `masked_seed_value`.
- A secret key's `value` gets a write-only widget (`get_form` swaps it in). Submitting
  nothing keeps what is stored — the same contract as the dash editor's password input.
- `save_model` writes through `ConfigSetting.objects.set_value`, and drops the old row
  when an edit moves a setting off its `(scope, key)` coordinate.
- `ConfigSetting.clean` runs the cross-key check, so an inconsistent coupled pair is a
  form error rather than a 500 or a silent save.
- `ConfigSetting.__str__` carries the coordinate alone.

`is_secret` / `render_value` move from `teatree.dash.config_display` to
`teatree.core.config_display`. Three surfaces consume the taxonomy now, and the admin
sits in the domain layer, which may not import the interface-layer `dash` — one shared
function, no second copy to drift.

**Bundled** (small, self-contained, same policy): the two mask tokens for one policy are
unified. A secret VALUE is `***` on both dash surfaces; `<private>` is left to the
genuinely different question of a private `pass` entry NAME, and renamed
`MASKED_ENTRY_NAME` to say so.

## Why

The safety and secrecy boundaries are absolute on every other surface — MCP refuses all
ten safety-posture keys behind a fail-closed conformance test, the dashboard editor
demands a typed confirm phrase, and #3760 closed the same hole on the import path. A
boundary that holds on three surfaces and not the fourth is not a boundary.

## Tests — proven RED first

Every new test was observed failing against the pre-fix admin, not assumed to:

- `test_an_inconsistent_cross_key_pair_is_refused_with_a_form_error` — `assert 302 == 200`.
  The admin really did land `agent_harness_provider = "openai_compatible"` under the
  default `claude_sdk` harness, the exact pair the dashboard, the CLI and the MCP write
  tools all refuse.
- `test_a_secret_value_is_masked_in_the_changelist`,
  `test_a_secret_value_is_not_rendered_on_the_change_form`,
  `test_a_secret_seed_value_is_not_rendered_on_the_change_form` — all failed on the
  marker string being present in the response bytes.
- `test_an_admin_edit_clears_the_seed_provenance` — `assert 'entrypoint' == ''`.
- `test_config_setting_admin_lists_key_scope_and_a_masked_value`,
  `test_the_value_column_is_not_inline_editable`,
  `test_a_blank_value_leaves_a_stored_secret_untouched`.
- `test_the_value_mask_is_the_one_shared_token` — `assert '<private>' == '***'`.

Two existing changelist-formset tests are rewritten as change-form tests. What they
pinned — an empty `[]` / `{}` is a legitimate override and must save — is a per-row
property that survives intact; the page-wide coupling they also exercised was a property
OF `list_editable`, which no longer exists.

Gates green: `ruff check`, `ruff format`, `ty check`, `tach check`,
`makemigrations --check --dry-run`, `t3 tool test-path-mirror`,
`check_module_health.py --from-ref origin/main`, `tests/quality` (713),
`tests/teatree_core/test_admin.py` + `tests/teatree_dash` (329), and the whole
`-k "config_setting or config_migration or admin or config_display or config_surface or settings_editor or cross_key"`
selection (302). `docs/generated/dashboard/admin-index.html` regenerates byte-identical
and `git diff --exit-code docs/generated` is clean — the snapshot renders the admin
index, not a changelist.

## Architecture pre-check

1. **BLUEPRINT §** — `docs/blueprint/configuration.md` §10.3, which documents the config
   write surfaces; the admin now has its paragraph there, updated in this commit.
2. **FSM phase boundaries** — n/a, no `Ticket` / `Worktree` transition.
3. **Extension-point contracts** — n/a; no `OverlayBase`, scanner or Protocol surface.
   `_reject_inconsistent_cross_key` is renamed to a public
   `ConfigSettingManager.reject_inconsistent_cross_key` because `Model.clean` is now a
   second caller; it had no external callers.
4. **Component boundaries** — the taxonomy in `core` (shared by admin and dash), the
   admin presentation in `core/admin.py`, the validation on the model where the write
   already lives.
5. **Dependency direction** — no new edge and no backwards edge. `core -> config` already
   exists; the move REMOVES the need for a `core -> dash` edge, which the layer graph
   forbids. `uv run tach check` passes.
6. **Test surface** — `tests/teatree_core/test_admin.py`
   (`TestConfigSettingAdminSecrecy`, `TestConfigSettingAdminWritesThroughSetValue`),
   `tests/teatree_core/test_config_display.py` (moved with its module),
   `tests/teatree_dash/test_config_surface.py` (the unified mask token).
7. **Resilience invariants** — no new external write. The write path is the existing
   idempotent `set_value` upsert.
8. **Identity and key normalization** — a row's identity is `(scope, key)`, and
   `save_model` handles the one case that moves it: an edit that changes either half now
   clears the old coordinate instead of leaving a duplicate behind. No stripping or
   splitting anywhere.
9. **Behavior preservation / capability deletion** — two capabilities are deliberately
   removed and neither is a narrowing of a privacy/security matcher (both are widenings
   of one). (a) Inline changelist editing of `value` — it is unmaskable and bypasses the
   seam; the change form does the same job, and `t3 config_setting set` and
   `/dash/settings` remain. (b) Hand-editing `seeded_by` / `seed_value` — now readonly,
   which is honest rather than restrictive: `set_value` clears provenance on every
   operator write, so a submitted value was always going to be overwritten. No must-block
   test was inverted to must-not-block.
10. **Removability / harness-vs-data** — the admin form, widget and two display methods
    delete cleanly back to a plain `ModelAdmin`. Correctly harness, not data: which keys
    are secret is already data (`SECRET_SETTINGS` + the schema `Category`), and this is
    only the rendering rule that reads it.
