### PR TITLE
fix(quality): re-bank the resolution.py incompleteness peg after the tier landed

### DIFF
--- a/tests/quality/incompleteness_marker_pegs.toml
+++ b/tests/quality/incompleteness_marker_pegs.toml
@@ -56,7 +56,6 @@
 # documented as absent from its resolver, beside a carve-out documented as kept
 # and empty, each said twice. A sibling change resolves the prose; this entry
 # drops to 0 with it.
-"src/teatree/config/resolution.py" = 4
 "src/teatree/config/schema.py" = 1
 "src/teatree/config/settings_loop_flags.py" = 2
 "src/teatree/core/cleanup/cleanup.py" = 1

--- a/tests/quality/test_incompleteness_marker_ratchet.py
+++ b/tests/quality/test_incompleteness_marker_ratchet.py
@@ -112,12 +112,13 @@ class TestHistoricalCase:
         _write_module(tmp_path, FINISHED_DOCSTRING)
         assert scan_tree(tmp_path) == []
 
-    def test_still_present_in_this_tree_under_its_peg(self, tree_markers: list[Marker]) -> None:
-        # Anti-vacuous against the live tree, not only a fixture: the historical
-        # statements are still shipped, so the gate has a real subject, and the
-        # peg has to be paid down by whichever change resolves the prose.
+    def test_the_historical_statements_stay_resolved_in_this_tree(self, tree_markers: list[Marker]) -> None:
+        # The change that motivated this gate wired the TOML tier in and deleted the
+        # prose, so the live tree carries none of those statements and the peg is gone.
+        # Pinned here rather than dropped: the fixture cases above prove the detector
+        # discriminates, and this proves the real file it was built for stays clean.
         live = [marker for marker in tree_markers if marker.path == "src/teatree/config/resolution.py"]
-        assert {marker.pattern_id for marker in live} == {"retained-but-empty", "not-wired", "later-phase"}
+        assert live == [], [marker.describe() for marker in live]
 
 
 class TestMarkerRatchet:


### PR DESCRIPTION
## What

`origin/main` is red on `tests/quality/test_incompleteness_marker_ratchet.py`. #3757 removed the two statements in `src/teatree/config/resolution.py` that declared the TOML tier unwired, without lowering the file's peg.

## Why it slipped

#3757's CI ran against `82d2faa7`, before the ratchet merged at `e7799fe0`, so its checks never saw the gate. It was merged on a status that predated the thing it would break.

## Changes

- Remove the `resolution.py = 4` entry from `incompleteness_marker_pegs.toml`.
- Replace the live-tree assertion with a regression guard that the file stays clean. Kept rather than deleted: the fixture cases prove the detector discriminates; this proves the real file it was built for is fixed and cannot silently regress.

## Verification

`tests/quality/test_incompleteness_marker_ratchet.py` — 13 passed (2 failed before). `ruff check` clean.