### PR TITLE
refactor(skills): split the classifier-denial mechanics; scope review findings by lane

### DIFF
--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -229,6 +229,15 @@ Run gates → Any failure? → Fix → Re-run gates → Repeat until clean
 
 ### Giving Code Review
 
+#### Two Lanes — a Colleague-Facing Post, and the Verdict Envelope (decide this first)
+
+This chapter's deliverable is one of two things, and the reporting rules are **opposite** between them. Decide which before drafting anything.
+
+- **Colleague-facing post** — a comment, discussion, or approval published on someone else's MR/PR **under the owner's identity**. Noise costs real credibility here, so the suppression rules below are binding on this lane: scale severity to confidence, say nothing on a check that came back clean, don't police formatting, don't block on style.
+- **Verdict envelope** — the headless cold reviewer's `review_verdict` result (`teatree.agents.result_schema.ReviewVerdictEnvelope`), recorded server-side as the durable `ReviewVerdict` the merge gate reads. Nothing is published and `findings` is schema-optional, so suppression here buys nothing and costs only recall.
+
+**In the envelope, record what you actually observed** — every finding, including the uncertain and the low-severity ones, each carrying its severity and your confidence. Coverage is your job; filtering is the merge gate's, downstream. Silence on a check you performed is a **missing record**, not a clean bill of health. `verdict: merge_safe` with an empty `findings` array asserts you looked and found nothing worth saying — emit it only when that is true, and record anything you could not check as a finding rather than leaving the array empty.
+
 #### Fetch-Only vs Comprehensive Review — Pick the Right Entry Command (do X — never Y)
 
 A colleague-authored MR on a **shared product repo** (a repo you do NOT solely own — shared with colleagues, gated on their review) is **review work, not merge work**. The action when you are handed one is to **fetch its diff and review it** — never to land it yourself. Do X (fetch + review); never Y (merge a teammate's product-repo MR):
@@ -342,9 +351,9 @@ Investigate first by exhausting the sources you **can** reach:
 
 Only after all reachable sources are exhausted can you post a question-style comment — and only when the answer truly requires access you do not have (partner portal behind SSO, vendor-only documentation, product owner's desk knowledge). State what you checked and why the answer isn't reachable, so the author sees you did the work.
 
-**Scale severity to confidence.** A speculative "maybe wrong?" is a nit at best; drop it. A verified finding ("grepped `foo-producer`, canonical spelling is `X`, branch has `Y` — will fail at runtime") is a blocker and belongs in the review.
+**Scale severity to confidence — on a colleague-facing post, drop what stays speculative.** A speculative "maybe wrong?" is a nit at best; do not post it under the owner's name. A verified finding ("grepped `foo-producer`, canonical spelling is `X`, branch has `Y` — will fail at runtime") is a blocker and belongs in the review. In the **verdict envelope** the disposal is the opposite: record the uncertain observation with its confidence rather than dropping it.
 
-**When the investigation confirms the code is correct, say nothing.** Silence on a check you performed is the correct outcome — not a "looks good, but…" comment. Positive comments belong in the summary to the user, not in the PR.
+**When the investigation confirms the code is correct, post nothing — on a colleague-facing post.** Silence on a check you performed is the correct outcome there, not a "looks good, but…" comment. Positive comments belong in the summary to the user, not in the PR. In the **verdict envelope** that same clean check is *recorded*, not silenced: name what you checked and that it came back clean.
 
 **Step 0e — Don't Police Other Authors' Title/Description Format (Non-Negotiable):**
 
@@ -420,7 +429,7 @@ When posting on the PR, prefer **inline** (line-anchored) discussions over **gen
 
 **Step 2 — Review Tone & Formatting:**
 
-Follow the [Google Engineering Practices — Code Review Standard](https://google.github.io/eng-practices/review/reviewer/standard.html): approve if the CL improves overall code health, even if it isn't perfect. Don't block on style preferences or theoretical improvements. The bar is "does this improve the codebase?" — not "is this how I would have written it?"
+Follow the [Google Engineering Practices — Code Review Standard](https://google.github.io/eng-practices/review/reviewer/standard.html): approve if the CL improves overall code health, even if it isn't perfect. Don't block on style preferences or theoretical improvements. The bar is "does this improve the codebase?" — not "is this how I would have written it?" That governs the **verdict**, not the record: a style preference is not a reason to `hold`, and it is still worth recording as a low-severity finding in the verdict envelope.
 
 Comments are posted under the user's name. They must sound like a **real human colleague** wrote them — not an AI, not a linter, not a manager.
 
@@ -474,7 +483,7 @@ This step is the **`autonomy = "babysit"`** flow (the conservative default). Und
 
 This prevents noise from multiple review passes or multiple reviewers covering the same ground.
 
-**Post all *new* findings.** Don't self-censor or hold back comments because they seem minor. The user will review every draft note in the platform's UI, edit wording, and delete anything they don't want before submitting. Your job is to surface everything you noticed — the user curates. But "everything" means everything *not already said* — duplicating an existing comment wastes the author's time.
+**Post all *new* findings.** Don't self-censor or hold back comments because they seem minor. A draft note is colleague-invisible until the user submits it, so the user is the filter here exactly as the merge gate is on the verdict envelope — the suppression rules bind on what reaches a colleague, never on what reaches a curator. The user will review every draft note in the platform's UI, edit wording, and delete anything they don't want before submitting. Your job is to surface everything you noticed — the user curates. But "everything" means everything *not already said* — duplicating an existing comment wastes the author's time.
 
 When reviewing an external MR/PR, **always post comments inline on the correct file and line** in the diff view. For comments that aren't tied to a specific line (e.g., description feedback), post a general note without position data.
 

--- a/skills/rules/SKILL.md
+++ b/skills/rules/SKILL.md
@@ -199,16 +199,14 @@ This composes with § "User Instructions Are Priority 1" (an EXPLICIT destructiv
 
 When the auto-mode classifier denies a tool call (Bash command rejected, MCP call refused, "permission denied" from the harness, etc.), **stop immediately**. Do not retry, do not work around it with a different command, do not "find another way". A classifier denial is an **immediate session blocker** — handle it before doing anything else.
 
-**Step 0 — read the denial reason and check existing allow-rules before escalating.** The denial message states _why_ it was blocked, and that reason frequently names the in-scope form the action must take (e.g. "database outside the authorized `development-<tenant>` scope" → the authorized DB name is `development-<tenant>`, not the one you used). Before treating this as "needs relaxation": (a) parse the stated reason for the corrective scope, and (b) read the user's `~/.claude/settings.json` `autoMode.allow` and `permissions.allow` entries for a rule that already authorizes this action under the correct form. If either resolves it, the action was never out of policy — re-issue it in the **authorized form** (this is not a relaxation and needs no user prompt). Only if neither the reason nor an existing rule resolves it do you run the escalation below. Skipping Step 0 and escalating a mere wrong-form mistake wastes the user's time on a decision they should never have been asked.
+**Step 0 — the denial reason usually names the in-scope form; re-issue in it rather than escalating.** Parse the stated reason for the corrective scope, and check the user's `~/.claude/settings.json` `autoMode.allow` / `permissions.allow` for a rule that already authorizes the action under the correct form. If either resolves it, the action was never out of policy — re-issue it in the **authorized form**; that is not a relaxation and needs no user prompt. Escalate only when neither resolves it: escalating a wrong-form mistake wastes the user's time on a decision they should never have been asked.
 
 **Required response when Step 0 does not resolve it:**
 
 1. **Stop.** Drop whatever you were doing. Do not start an alternative approach in the same response.
 2. **Inform the user** in plain text: which command was denied, what you were trying to accomplish, and the smallest static permission rule that would have allowed it (e.g. `Bash(gh issue create *)`, `Bash(docker buildx prune *)`). The rule must be the smallest rule that covers the use case — never a blanket `Bash` or `Bash(* *)`.
-3. **Ask via `AskUserQuestion`** with two options:
-   - **"Allow it (relax classifier)"** — preferred. You then attempt the edit yourself (see step 4); only if the harness blocks the write do you fall back to a paste-ready snippet for the user to apply.
-   - **"Keep the denial (do it differently)"** — you propose a concrete alternative path (different tool, manual step, API call) and proceed only after the user picks one.
-4. **If the user picked "Allow it":** attempt to add the rule to the user's `~/.claude/settings.json` (`permissions.allow` array) yourself, via the `Edit` tool. Read the file first, merge the new entry into the existing array, write it back. **If the write succeeds**, retry the original command. **If the write is denied** by the harness self-modification guardrail, only then fall back: hand over a paste-ready snippet, wait for the user to apply it, then retry. Do not preemptively skip the edit attempt — the goal is zero manual operations for the user when the harness allows it.
+3. **Ask via `AskUserQuestion`** with exactly two options: **"Allow it (relax classifier)"** — the preferred one — or **"Keep the denial (do it differently)"**, for which you propose a concrete alternative path and proceed only after the user picks one.
+4. **If the user picked "Allow it":** attempt the `~/.claude/settings.json` edit yourself via `Edit`, then retry the original command. A paste-ready snippet for the user to apply is the fallback **after** the harness blocks that write, never the default path.
 5. **Wait for the answer.** Do not retry the denied command, do not invent workarounds, do not file tickets, do not start unrelated work, until the user has chosen and (if relaxing) the new rule is in place.
 
 **Banned reactions to a classifier denial:**
@@ -216,18 +214,10 @@ When the auto-mode classifier denies a tool call (Bash command rejected, MCP cal
 - Silently retrying with a different argument shape hoping the classifier passes (`gh issue create` → `gh api repos/.../issues`).
 - Switching tools (Bash → MCP, MCP → Python subprocess) to bypass the rule.
 - Decomposing the command into pieces that each pass individually.
-- Editing teatree's plugin `settings.json`, `CLAUDE.md`, or any plugin-distributed permissions file to add an allow rule.
+- Editing teatree's plugin `settings.json`, `CLAUDE.md`, or any plugin-distributed permissions file to add an allow rule — the user-scope `settings.json` is the only right knob, and teatree never relaxes permissions on the user's behalf.
 - Continuing the surrounding work and "leaving the denial for later".
 
-**Why this rule exists.** The classifier exists to give the user a final say on standing-permission expansions. Auto-mode aggressiveness combined with classifier strictness is a recurring source of teatree workflow breakage — agents that retry, decompose, or sidestep silently accumulate scope, lose user trust, and ship work the user never authorized. The right escalation is to **ask once, fix permission at the user-scope settings file, retry**.
-
-**Standing recommended set (proactive, not reactive).** This protocol governs _reacting_ to a mid-session denial. The _standing_ generic set of authorizations that prevents most denials in the first place — and the read-only `t3 doctor authorizations` check that suggests (never applies) the absent ones — is documented in `skills/setup/references/recommended-automode-authorizations.md`. That doc and this section do not duplicate: one is the standing recommendation, the other the in-session escalation.
-
-**Boundary: who edits permissions where.**
-
-- Teatree (this skill, BLUEPRINT, plugin `settings.json`) defines the _protocol_. Teatree never relaxes permissions on the user's behalf.
-- The agent **attempts** the edit to `~/.claude/settings.json` (user scope) directly — that's the path with zero manual steps for the user. Many users have a standing authorization for this in their `autoMode.allow`. The agent only falls back to handing over a paste-ready snippet **after** the harness self-modification guardrail blocks the write — never as the default path. The snippet is the manual fallback, not the primary mechanism.
-- Plugin-distributed permissions (`plugins/t3/settings.json`, `CLAUDE.md` standing clauses) are **never** the right place to relax for a single workflow — that would grant the standing right to every user of the plugin. Refuse if asked to do this; explain that user-scope `settings.json` is the right knob.
+The Step 0 worked example, the settings-file edit procedure, the rationale, the standing recommended authorization set (and the read-only `t3 doctor authorizations` check that suggests it), and the full permissions boundary are in [`skills/rules/references/classifier-denial-escalation.md`](references/classifier-denial-escalation.md).
 
 ## Anticipate a Predictable Gate: Offer Enable-Setting or Approve-Once, Never Bypass-or-DIY (Non-Negotiable)
 

--- a/skills/rules/references/classifier-denial-escalation.md
+++ b/skills/rules/references/classifier-denial-escalation.md
@@ -1,0 +1,30 @@
+# Classifier denial — escalation mechanics and the permissions boundary
+
+The mechanics behind `/t3:rules` § "Classifier Denial Protocol (Non-Negotiable)". That section carries the decision — stop on a denial, re-issue only in an authorized form, escalate once through `AskUserQuestion`, and the banned reactions that are never taken. This file carries the Step 0 worked example, the settings-file edit procedure, the rationale, and the boundary of who relaxes permissions where.
+
+## Step 0 in full — the denial reason names the in-scope form
+
+**Step 0 — read the denial reason and check existing allow-rules before escalating.** The denial message states _why_ it was blocked, and that reason frequently names the in-scope form the action must take (e.g. "database outside the authorized `development-<tenant>` scope" → the authorized DB name is `development-<tenant>`, not the one you used). Before treating this as "needs relaxation": (a) parse the stated reason for the corrective scope, and (b) read the user's `~/.claude/settings.json` `autoMode.allow` and `permissions.allow` entries for a rule that already authorizes this action under the correct form. If either resolves it, the action was never out of policy — re-issue it in the **authorized form** (this is not a relaxation and needs no user prompt). Only if neither the reason nor an existing rule resolves it do you run the escalation. Skipping Step 0 and escalating a mere wrong-form mistake wastes the user's time on a decision they should never have been asked.
+
+## The two options, and the settings-file edit
+
+**Ask via `AskUserQuestion`** with two options:
+
+- **"Allow it (relax classifier)"** — preferred. You then attempt the edit yourself (see below); only if the harness blocks the write do you fall back to a paste-ready snippet for the user to apply.
+- **"Keep the denial (do it differently)"** — you propose a concrete alternative path (different tool, manual step, API call) and proceed only after the user picks one.
+
+**If the user picked "Allow it":** attempt to add the rule to the user's `~/.claude/settings.json` (`permissions.allow` array) yourself, via the `Edit` tool. Read the file first, merge the new entry into the existing array, write it back. **If the write succeeds**, retry the original command. **If the write is denied** by the harness self-modification guardrail, only then fall back: hand over a paste-ready snippet, wait for the user to apply it, then retry. Do not preemptively skip the edit attempt — the goal is zero manual operations for the user when the harness allows it.
+
+## Why this rule exists
+
+The classifier exists to give the user a final say on standing-permission expansions. Auto-mode aggressiveness combined with classifier strictness is a recurring source of teatree workflow breakage — agents that retry, decompose, or sidestep silently accumulate scope, lose user trust, and ship work the user never authorized. The right escalation is to **ask once, fix permission at the user-scope settings file, retry**.
+
+## Standing recommended set (proactive, not reactive)
+
+This protocol governs _reacting_ to a mid-session denial. The _standing_ generic set of authorizations that prevents most denials in the first place — and the read-only `t3 doctor authorizations` check that suggests (never applies) the absent ones — is documented in [`skills/setup/references/recommended-automode-authorizations.md`](../../setup/references/recommended-automode-authorizations.md). That doc and the protocol do not duplicate: one is the standing recommendation, the other the in-session escalation.
+
+## Boundary: who edits permissions where
+
+- Teatree (the rules skill, BLUEPRINT, plugin `settings.json`) defines the _protocol_. Teatree never relaxes permissions on the user's behalf.
+- The agent **attempts** the edit to `~/.claude/settings.json` (user scope) directly — that's the path with zero manual steps for the user. Many users have a standing authorization for this in their `autoMode.allow`. The agent only falls back to handing over a paste-ready snippet **after** the harness self-modification guardrail blocks the write — never as the default path. The snippet is the manual fallback, not the primary mechanism.
+- Plugin-distributed permissions (`plugins/t3/settings.json`, `CLAUDE.md` standing clauses) are **never** the right place to relax for a single workflow — that would grant the standing right to every user of the plugin. Refuse if asked to do this; explain that user-scope `settings.json` is the right knob.


### PR DESCRIPTION
refactor(skills): split the classifier-denial mechanics; scope review findings by lane

Plan Item 2 tranche 2 (`plans/opus5-context-engineering-plan.md` § Item 2) plus review recommendation 2 (`plans/ai-review-and-design-plan.md` § Item 2). Tranche 1 was [#3770](https://github.com/souliane/teatree/pull/3770). Both parts land in one pass on the same files: opening a 72 KB skill twice for two reasons is how eval section anchors break.

## Part A — split one more unanchored section out of the rules spine

`## Classifier Denial Protocol (Non-Negotiable)` was the largest level-2 section in `skills/rules/SKILL.md` that no eval scenario anchors, after the one tranche 1 took. Its mechanics move to `skills/rules/references/classifier-denial-escalation.md`; the spine keeps the decision.

**Stays in the spine — what changes behaviour:**

- Stop immediately on a denial. Do not retry, do not switch tools, do not decompose the command.
- Step 0's decision: the denial reason usually names the in-scope form, so re-issue in the authorized form rather than escalating a wrong-form mistake.
- The five-step escalation, including the "smallest static permission rule, never a blanket `Bash`" constraint.
- The whole banned-reactions list, verbatim. It is the negative form of the same safety property, and it now carries the plugin-permissions ban that used to live only in the moved boundary block — so nothing that must hold is behind a second file read.

**Moves to the reference — lookup material consulted after the decision is made:**

- Step 0's worked example (the wrong-scope database name).
- The `~/.claude/settings.json` edit procedure and its harness-blocked fallback, consulted only once the user has answered "Allow it".
- "Why this rule exists", the standing recommended authorization set, and the three-bullet permissions boundary.

The spine names the reference by repo-relative path, as tranche 1 did: the headless dispatch keeps `Read`, so a path is reachable there without the `Skill` tool.

Both reverse cross-references — `skills/setup/references/agent-mode-and-mcp-config.md` and `skills/setup/references/recommended-automode-authorizations.md` — cite the section by heading, and the heading is unchanged, so neither goes stale.

## Part B — scope the findings-suppression rules by lane

`skills/review/SKILL.md` carried two opposite rules with no lane on either. At `:345` and `:347` (pre-change line numbers): a speculative finding is "a nit at best; drop it", and a check that came back clean means "say nothing". At `:477`: "Post all *new* findings. Don't self-censor."

Both are correct, for different deliverables, and the file never said which. The suppression rules are right for a comment posted on a colleague's MR under the owner's name, where noise costs real credibility. They are recall loss on the headless cold reviewer's `review_verdict` envelope, where nothing is published, the record is internal and durable, and `findings` is optional in the schema (`result_schema.py` — only `verdict` is required).

The measured shape of that recall loss, from the live DB over the 14 days to 2026-07-27: on a green PR the reviewer's own judgement held **5 times in 516 (0.97%)**, and **416 of 511 passing verdicts (81.4%)** carry an empty findings array — against a median merged diff of 287 lines.

**The edits:**

- New `#### Two Lanes` opening the "Giving Code Review" chapter. It names both deliverables, states that the suppression rules bind on the colleague-facing one, and states the envelope rule: record what you observed, every finding with its severity and your confidence; coverage is the reviewer's job and filtering is the merge gate's, downstream. An empty `findings` array on a `merge_safe` asserts you looked and found nothing — emit it only when true, and record what you could not check rather than leaving it empty.
- The two suppression rules are scoped in place: each keeps its original wording for the colleague-facing post and gains the envelope's opposite disposal.
- The Google code-review-standard line gains one clause: it governs the *verdict*, not the *record* — a style preference is not a reason to hold, and is still worth recording.
- "Post all *new* findings" gains the reason it does not contradict the two above: a draft note is colleague-invisible, so the user is the filter there exactly as the merge gate is on the envelope.

Nothing correct was deleted. This is a scoping change, not a loosening: the three deterministic post gates (shape, bloat, todo) still refuse a mis-shaped colleague comment before any API call, so extra recall on the envelope lane cannot leak onto a colleague's MR.

## Measurement

Per-phase skill bundles, measured with the real `_read_skill_contents_scoped` over the `requires` chain, against `MAX_APPEND_BYTES` = 98,304.

| bundle | before | after | delta | after / budget |
|---|---:|---:|---:|---:|
| coding | 191,522 | 189,189 | −2,333 | 1.92× |
| reviewing | 227,816 | 227,747 | −69 | 2.32× |
| shipping | 218,220 | 215,887 | −2,333 | 2.20× |
| testing | 167,671 | 165,338 | −2,333 | 1.68× |

`skills/rules/SKILL.md`: 154,873 → 152,540 B (−2,333). `skills/review/SKILL.md`: 72,623 → 74,887 B (+2,264). The reviewing bundle carries both, so it moves only −69 B; the other three take the full rules saving. Every bundle still exceeds the budget, so every headless dispatch still truncates. One tranche does not fix that.

Section: **5,529 → 3,196 B. Move ratio 42.2%** of the section — the same as tranche 1's. Tranche 1 predicted better here, and that prediction did not hold: the five-step protocol and the banned-reactions list are both decision-relevant and both stayed; only the ~2.3 KB named above was lookup.

Section sizes throughout are real UTF-8 bytes of the level-2 span. Tranche 1's table reported Python string lengths, which undercount every em dash by two bytes, so its figures run ~0.5% low against these.

## The section map — every `## ` section, by size, with its eval anchors

Regenerated on `origin/main` (`a704262c`), before this change. 73 level-2 sections, 154,518 B; **15 anchored, 58 unanchored**. Re-measured rather than reused: [#3770](https://github.com/souliane/teatree/pull/3770) changed the file and [#3771](https://github.com/souliane/teatree/pull/3771) fixed `_section_spans`, so anchored sections now extract more than they used to.

| bytes | `## ` section | anchored by |
|---:|---|---|
| 15,036 | Always Use AskUserQuestion for Questions | `communication_ux.yaml:5`, `do_the_best_no_tech_debt.yaml:27`, `do_the_best_no_tech_debt.yaml:96`, `harness_canary.yaml:25`, `rules.yaml:26`, `rules.yaml:44` |
| 11,754 | Background Long Operations (Non-Negotiable) | `background_long_operations.yaml:1`, `background_long_operations.yaml:28`, `background_long_operations_extra.yaml:5`, `background_long_operations_extra.yaml:22`, `background_long_operations_extra.yaml:39`, `background_long_operations_extra.yaml:56`, `orchestration_boundary_extra.yaml:5`, `orchestration_boundary_extra.yaml:20`, `orchestration_boundary_extra.yaml:34`, `orchestration_boundary_extra.yaml:49`, `orchestrator_boundary.yaml:1`, `orchestrator_boundary.yaml:19` |
| 8,256 | Do Work Now, Don't Defer to "Later" Tickets (Non-Negotiable) | `rules.yaml:5` |
| 8,003 | Sub-Agent Limitations | `blocked_subagent_escalation.yaml:5`, `blocked_subagent_escalation.yaml:22`, `blocked_subagent_escalation.yaml:36`, `orchestration_boundary_extra.yaml:5`, `orchestration_boundary_extra.yaml:20`, `orchestration_boundary_extra.yaml:34`, `orchestration_boundary_extra.yaml:49`, `orchestrator_boundary.yaml:1`, `orchestrator_boundary.yaml:19`, `orchestrator_embeds_skills_in_subagent_brief.yaml:6`, `subagent_prompt_drift.yaml:1`, `subagent_prompt_drift.yaml:21` |
| 6,434 | Index | — |
| 6,383 | Ask Before Posting on the User's Behalf (Non-Negotiable) | `never_post_on_behalf_via_bot_token.yaml:5`, `never_post_on_behalf_via_bot_token.yaml:22`, `never_post_on_behalf_via_bot_token.yaml:37`, `never_post_on_behalf_via_bot_token.yaml:50`, `on_behalf_egress_colleague_slack.yaml:5`, `on_behalf_egress_colleague_slack.yaml:23`, `on_behalf_egress_colleague_slack.yaml:35` |
| **5,529** | **Classifier Denial Protocol (Non-Negotiable)** ← this tranche | — |
| 4,443 | Verification Before Completion (Non-Negotiable) | `completion_claim_gate.yaml:20`, `false_completion.yaml:17`, `false_completion.yaml:57` |
| 3,646 | Worktree-First Work (Non-Negotiable) | — |
| 3,637 | Three Orthogonal Repo Axes — Visibility, Ownership, Collaboration (Non-Negotiable) | — |
| 3,273 | Read the Canonical Source Before a Structural Action (Non-Negotiable) | — |
| 3,141 | Never Introduce Tech Debt; Reduce It (Non-Negotiable) | `do_the_best_no_tech_debt.yaml:129`, `rules.yaml:1404` |
| 2,927 | Public-Repo Commit Author Identity (Non-Negotiable) | `banned_term_public_only.yaml:5`, `banned_term_public_only.yaml:19` |
| 2,804 | Re-Validate a Reused Guard in a New Destructive Context | — |
| 2,786 | Lead a Completion Report With the Assigned-Work Status | `completion_report_leads_with_status.yaml:1`, `rules.yaml:1286`, `rules.yaml:1346` |
| 2,715 | Evidence Comes From the Deployed Environment (Non-Negotiable) | — |
| 2,703 | Publishing Actions Are Mode-Conditional (Non-Negotiable) | — (tranche 1) |
| 2,545 | No AI Signature on Posts Made on the User's Behalf (Non-Negotiable) | `never_post_on_behalf_via_bot_token.yaml:5`, `terse_writing_on_user_behalf.yaml:1` |
| 2,540 | ID Namespace Disambiguation (Non-Negotiable) | `id_namespace_disambiguation.yaml:18` |
| 2,466 | Shell Probes Run Under zsh — a Probe Without a Control Is Unfalsifiable | — |
| 2,372 | Anticipate a Predictable Gate: Offer Enable-Setting or Approve-Once, Never Bypass-or-DIY (Non-Negotiable) | — |
| 2,203 | External Read Failure Must Fail Loud, Never Silent-Empty (Non-Negotiable) | — |
| 2,181 | Escalate Honesty-Critical Verification to the Most-Honest Model | — |
| 2,122 | Read Before Overwriting a Tracked Config/Dotfile (Non-Negotiable) | — |
| 2,063 | Grep Before Claiming Cross-Reference Coverage (Non-Negotiable) | — |
| 1,974 | Autonomous Directive Adoption | — |
| 1,918 | Teatree Extension Point Changes Must Update All Registered Overlays (Non-Negotiable) | — |
| 1,848 | Fewest PRs for Related Work — Splitting Requires Approval (Non-Negotiable) | — |
| 1,736 | Keep Turn Output Terse and TTS-Ready | `terse_claude_code_output_no_narration.yaml:1`, `terse_status_report_not_essay.yaml:13` |
| 1,648 | Never Modify a Remote Database Without Explicit User Approval (Non-Negotiable) | — |
| 1,600 | Never Post PR Comments from Parallel Agents (Non-Negotiable) | — |
| 1,581 | An Acceptance Criterion That Cannot Fail Is Not a Criterion (Non-Negotiable) | — |
| 1,572 | Self-Apply `needs-triage` on Agent-Filed Issues (Non-Negotiable) | — |
| 1,428 | On an Ambiguous Directive, Take the Non-Destructive Reading (Non-Negotiable) | — |
| 1,389 | Ask About Auth Before External Service Integrations | — |
| 1,373 | Commit Before Declaring Done (Non-Negotiable) | — |
| 1,318 | Read the Canonical Source Before Fixing a Conformance Bug | — |
| 1,314 | Verify Repo Visibility Before Filing External Issues (Non-Negotiable) | `banned_term_public_only.yaml:5`, `banned_term_public_only.yaml:19` |
| 1,235 | Split Long Skills With Progressive Disclosure | — |
| 1,221 | Read Secrets From the Secret Store (Non-Negotiable) | — |
| 1,190 | Render the Title Inline, Never a Bare/Link-Only Id (Non-Negotiable) | — |
| 1,176 | Overlay Skills Are Scoped to Overlay Repos (Non-Negotiable) | — |
| 1,175 | Contribute Mode: Promote Findings to Skills, Not Personal Memory (Non-Negotiable) | `instruction_compliance_accountant.yaml:19` |
| 1,127 | Never Pipe, Redirect, or Chain a gh/glab Publish Command | — |
| 1,092 | Invoke Skills Before ANY Response | — |
| 1,063 | Mid-Task Interrupts (Non-Negotiable) | — |
| 947 | Re-Derive the Minimal Blocker | — |
| 859 | Temp File Safety | — |
| 848 | Context Longevity | — |
| 818 | Re-Verify Cross-Agent State Before Reporting a Dependent Request | — |
| 723 | Clickable References | `clickable_references.yaml:1`, `clickable_references.yaml:24`, `clickable_references.yaml:46`, `clickable_references.yaml:63` |
| 643 | Never Change PR Base Branch or Dependencies (Non-Negotiable) | — |
| 607 | Context Transparency | — |
| 575 | Always Create Tasks | — |
| 564 | Leak Remediation — Silent Scrubs (Non-Negotiable) | — |
| 489 | Skill Auto-Loading Must Work | — |
| 461 | Pre-Commit Hook Failures on Unrelated Tests | — |
| 449 | Complex API Payloads: Use curl or Python | — |
| 436 | Prefer Standard Over Clever | — |
| 435 | Run Retro Before Ending Non-Trivial Sessions | — |
| 414 | Verify Imports Before Applying External Code | — |
| 393 | User Instructions Are Priority 1 | — |
| 362 | Token Extraction | — |
| 337 | Deprecated Code | — |
| 320 | Preserve Existing UX Patterns | — |
| 315 | Session Scope Management | — |
| 298 | Concurrent Agent Safety (Non-Negotiable) | — |
| 278 | Shell Alias Safety | — |
| 248 | Prefer Native Tool APIs Over Filesystem Heuristics | — |
| 245 | Fix TeaTree/Skill Bugs Immediately | — |
| 213 | Skill File Writes Require a Git Repo | — |
| 176 | Symlink Safety | — |
| 125 | GitLab Inline Comments | — |

Line numbers are the spec's `- name:` line. Tranche 1's table cited a different line within each spec, so its numbers run a few lines higher.

## Verification

- **No anchor breaks.** All 54 anchor-declaring specs resolve through the real `extract_sections`: `specs with anchors checked=54 broken=0`. `skills/review/SKILL.md` has **zero** `agent_sections` anchors across the whole catalog, so Part B could not break one. No `evals/scenarios/*.yaml` needed to change.
- **Offline replay lane green.** `uv run pytest tests/eval_replay/ -q -p no:randomly -n 0` → **2276 passed, 28 skipped**. `test_scenarios_anti_vacuous.py` alone → **657 passed**.
- **Skill lanes green.** Skill-prose, t3-invocation, deps, catalogue-version, ship-validator-references and `tests/teatree_eval` → **920 passed, 13 subtests passed**.
- **Gates.** `t3 tool verify-gates` → `all gate stages green (commit + push)`, exit 0. `uv run ruff check` clean. `t3 tool test-path-mirror` ratchet holds. `python -m teatree generate_all_docs` then `git diff --exit-code docs/generated` → clean, no drift.
- **Privacy.** `t3 tool privacy-scan` on the diff and on the commit message: clean, 0 findings.

### What this verification does not prove

Nothing offline shows that a slimmed prompt still **elicits** the behaviour, or that a lane-scoped reviewer actually records more findings. The replay lane proves the scenarios still discriminate and the anchors still resolve; its `transcript` backend replays pre-recorded transcripts, so the system prompt is **not part of replay grading at all**. Only a metered pass can show either, and that is deferred. Treat this tranche as structurally verified and behaviourally unverified.

## Scope held

- No anchored section was touched.
- No rule text was deleted. Moved content is verbatim; the spine's shortened Step 0 and steps 3–4 are decision statements over material the reference carries in full.
- No eval run was fired, no headless agent dispatched, no tick run.
- No `src/` module, no FSM transition, no extension point, no dependency edge — a prose-only change, so the architecture pre-check gate does not fire.

## Open questions and assumptions

- **The measurement harness is a reconstruction, not the production call path.** It calls the real `_read_skill_contents_scoped` over the requires chain but omits the host-specific framework and overlay skills a live dispatch adds. The deltas are exact; the absolute numbers run low.
- **`build_review_contract` disagrees with the skill now.** `src/teatree/core/models/auto_review_dispatch.py` tells every auto-dispatched reviewer to use a findings array *"when blocking"*, which reads as licence for the empty array on a pass — the same suppression Part B is removing, stamped into the task brief. That module is outside this change's stated surface, so it is flagged rather than edited.
- **The Part B calibration numbers are a re-statement of the plan's live-DB reading, not a fresh query.** Re-running the two SQL lines a few weeks after this lands is a free before/after with no token cost.
