### PR TITLE
fix(ci): detect term-source drift between the DB, the secrets and the registry

### DIFF
--- a/.github/term-source-fingerprint.json
+++ b/.github/term-source-fingerprint.json
@@ -1,0 +1,14 @@
+{
+  "gates": {
+    "overlay": {
+      "count": 51,
+      "digest": "sha256:6ef55a5a6a5c1e943136018507e20663e653a208e2d3c460e0fa7aed8423aa8b"
+    },
+    "tree": {
+      "count": 81,
+      "digest": "sha256:6d69ef0dfa4194032dd16841bf309788dc01d4ced95a056b19cfb940f4af4ebf"
+    }
+  },
+  "note": "Counts and salted digests only \u2014 never term values. Regenerate with `python scripts/term_source_drift.py sync --apply`, which updates the repository secrets and this file together.",
+  "version": 1
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,12 @@
 #                              test (combiner = required `test (3.13)`),
 #                              test-shim
 #   6. Architecture / quality fitness gates — mutation-diff, mutation-full,
-#                              banned-terms-tree, overlay-leak-tree
+#                              banned-terms-tree, overlay-leak-tree,
+#                              term-source-drift
 #                              (the two tree gates run on push, schedule AND PR
-#                              so a leak is caught before merge — #44)
+#                              so a leak is caught before merge — #44;
+#                              term-source-drift proves those two are scanning
+#                              the list the operator actually configured)
 #   7. Security & supply chain — uv-audit, sbom, uv-audit-advisory
 #
 # THE METERED AI EVAL DOES NOT RUN HERE
@@ -1208,6 +1211,42 @@ jobs:
         env:
           TEATREE_OVERLAY_LEAK_TERMS: ${{ secrets.TEATREE_OVERLAY_LEAK_TERMS }}
         run: uv run python scripts/hooks/check_no_overlay_leak.py
+
+  # GATE (push + schedule + PR): the two tree gates above scan whatever list
+  # their secret happens to hold, and a secret is a point-in-time copy — nothing
+  # re-reads the operator's DB, so a term added locally silently never reaches
+  # CI and the backstop keeps running an older, shorter list. This job closes
+  # that: it fingerprints the CI-visible list (count + a domain-separated digest
+  # over the whole sorted list) and compares it to the committed, term-free
+  # `.github/term-source-fingerprint.json`. A stale, shrunk or diverged secret
+  # reds CI with COUNTS ONLY — no term value is ever read, logged or committed.
+  #
+  # No `uv sync`: `check-ci` reads only the env vars and the fingerprint file, so
+  # it runs on the stdlib and stays a seconds-long job.
+  #
+  # push/schedule omit `--allow-unset` so a MISSING secret is a LOUD exit-2 on
+  # main. The PR step passes it: a fork PR cannot read secrets, so it skips
+  # cleanly instead of false-redding, while a same-repo PR gets the full check.
+  term-source-drift:
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v6
+        with:
+          python-version: "3.13"
+      - name: Term-source drift (push/schedule — require the secrets)
+        if: github.event_name != 'pull_request'
+        env:
+          TEATREE_BANNED_BRANDS: ${{ secrets.TEATREE_BANNED_BRANDS }}
+          TEATREE_OVERLAY_LEAK_TERMS: ${{ secrets.TEATREE_OVERLAY_LEAK_TERMS }}
+        run: python scripts/term_source_drift.py check-ci
+      - name: Term-source drift (PR — fork-safe)
+        if: github.event_name == 'pull_request'
+        env:
+          TEATREE_BANNED_BRANDS: ${{ secrets.TEATREE_BANNED_BRANDS }}
+          TEATREE_OVERLAY_LEAK_TERMS: ${{ secrets.TEATREE_OVERLAY_LEAK_TERMS }}
+        run: python scripts/term_source_drift.py check-ci --allow-unset
 
   # GATE (PR-only, NON-required): ground-truth anti-vacuity audit for the
   # incremental push gate (souliane/teatree#122). Runs the WHOLE-TREE ast-grep scan

--- a/scripts/term_source_drift.py
+++ b/scripts/term_source_drift.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Term-source drift detector — keeps every leak gate's list identical to the operator's.
+
+Teatree's leak gates read their term lists from three places, and nothing used to
+notice when they diverged:
+
+* The ``tree`` gate (CI job ``banned-terms-tree``) reads ``$TEATREE_BANNED_BRANDS``,
+    which the operator configures as the ``banned_brands`` row or the registry's
+    ``leak`` class.
+* The ``overlay`` gate (CI job ``overlay-leak-tree``) reads
+    ``$TEATREE_OVERLAY_LEAK_TERMS``, configured as the ``overlay_leak_terms`` row
+    or the registry's ``overlay`` class.
+
+Two independent divergences are possible, and both have happened:
+
+**CI drift.** The secret is a point-in-time copy. Nothing re-reads the DB, so a
+term added locally never reaches CI and the full-tree backstop keeps running an
+older, shorter list. ``check-ci`` closes this by comparing the CI-visible list
+against a committed, term-free fingerprint.
+
+**Registry shadowing.** Every gate resolves registry-FIRST, so a
+``banned_term_registry`` class that lags its legacy row silently SHRINKS the
+gate — a class the registry omits entirely reduces that gate to zero terms while
+the legacy row still looks populated. ``check-shadow`` closes this by requiring
+each registry class to cover its legacy row.
+
+**Nothing here ever emits a term value.** Every report is counts plus a
+domain-separated SHA-256 over the whole sorted list. A whole-list digest is not a
+per-term oracle — it confirms only an exact guess of the entire list — which is
+what makes the fingerprint safe to commit to a public repo.
+
+Exit codes: ``0`` in sync, ``1`` drift detected, ``2`` misconfigured.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+REPO_ROOT: Final = Path(__file__).resolve().parent.parent
+DEFAULT_FINGERPRINT: Final = REPO_ROOT / ".github" / "term-source-fingerprint.json"
+
+#: Domain separation, so the digest is specific to this contract rather than a
+#: bare hash of the list any other tool might also produce.
+_DIGEST_DOMAIN: Final = b"teatree-term-source-fingerprint-v1\n"
+
+_DOCUMENT_NOTE: Final = (
+    "Counts and salted digests only — never term values. Regenerate with "
+    "`python scripts/term_source_drift.py sync --apply`, which updates the "
+    "repository secrets and this file together."
+)
+
+OK: Final = 0
+DRIFT: Final = 1
+MISCONFIGURED: Final = 2
+
+
+def normalise_terms(terms: object) -> tuple[str, ...]:
+    """Sorted, de-duplicated, case- and whitespace-insensitive form of *terms*.
+
+    Reordering a secret or changing a term's case is not drift, so normalisation
+    happens before both the count and the digest.
+    """
+    if not isinstance(terms, list | tuple):
+        return ()
+    cleaned = {str(term).strip().casefold() for term in terms}
+    return tuple(sorted(term for term in cleaned if term))
+
+
+def terms_from_env(env_var: str) -> tuple[str, ...] | None:
+    """The comma-separated list in *env_var*, or ``None`` when it is unset/empty.
+
+    ``None`` is the "CI cannot see this list" signal — a fork PR, which cannot
+    read repository secrets, rather than an empty list the operator chose.
+    """
+    raw = os.environ.get(env_var, "")
+    if not raw.strip():
+        return None
+    return normalise_terms(raw.split(","))
+
+
+@dataclass(frozen=True)
+class Fingerprint:
+    """A term list reduced to what is safe to publish: its size and its digest."""
+
+    count: int
+    digest: str
+
+    @classmethod
+    def of(cls, terms: tuple[str, ...]) -> "Fingerprint":
+        """Fingerprint an already-normalised list."""
+        payload = _DIGEST_DOMAIN + "\n".join(terms).encode("utf-8")
+        return cls(count=len(terms), digest=f"sha256:{hashlib.sha256(payload).hexdigest()}")
+
+    @classmethod
+    def from_stored(cls, raw: object) -> "Fingerprint":
+        """Rebuild a fingerprint from its committed JSON form, failing loud when malformed.
+
+        A malformed entry must raise rather than read as an empty contract that
+        every list would satisfy.
+        """
+        if not isinstance(raw, dict):
+            msg = f"expected a fingerprint table, got {type(raw).__name__}"
+            raise TypeError(msg)
+        fields = {str(key): value for key, value in raw.items()}
+        count = fields.get("count")
+        digest = fields.get("digest")
+        if not isinstance(count, int) or not isinstance(digest, str):
+            msg = "a fingerprint needs an integer count and a string digest"
+            raise TypeError(msg)
+        return cls(count=count, digest=digest)
+
+    def as_stored(self) -> dict[str, int | str]:
+        """The committed JSON form."""
+        return {"count": self.count, "digest": self.digest}
+
+
+@dataclass(frozen=True)
+class GateSource:
+    """Where one gate's term list lives in each of the three stores."""
+
+    gate: str
+    env_var: str
+    registry_class: str
+    legacy_key: str
+
+
+#: Only the gates CI feeds from a secret. The diff/core gates run locally off the
+#: DB, so there is no CI-visible copy of theirs to drift.
+GATES: Final[tuple[GateSource, ...]] = (
+    GateSource("tree", "TEATREE_BANNED_BRANDS", "leak", "banned_brands"),
+    GateSource("overlay", "TEATREE_OVERLAY_LEAK_TERMS", "overlay", "overlay_leak_terms"),
+)
+
+
+class TermStore:
+    """The operator's configured lists, read from the DB-home ``ConfigSetting`` rows."""
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        self.db_path = db_path
+
+    def _setting(self, key: str) -> object:
+        """Read one row through teatree's Django-free cold reader.
+
+        Imported lazily so ``check-ci`` — which touches no store — runs on the
+        stdlib alone, keeping the CI job free of a dependency sync.
+        """
+        from teatree.config import cold_reader
+
+        return cold_reader.read_setting(key, db_path=self.db_path)
+
+    def _registry(self) -> dict[str, tuple[str, ...]] | None:
+        """The consolidated registry as ``{class: terms}``, or ``None`` when unset."""
+        raw = self._setting("banned_term_registry")
+        if not isinstance(raw, dict):
+            return None
+        return {str(key): normalise_terms(value) for key, value in raw.items()}
+
+    def configured(self, source: GateSource) -> tuple[str, ...]:
+        """The WIDEST list configured for *source* — the registry class plus the legacy row.
+
+        Widest, not registry-first: a narrower registry class is a defect
+        (:meth:`shadowed_count` reports it), never a reason to shrink what CI enforces.
+        """
+        legacy = normalise_terms(self._setting(source.legacy_key))
+        registry = self._registry()
+        from_registry = registry.get(source.registry_class, ()) if registry is not None else ()
+        return tuple(sorted(set(legacy) | set(from_registry)))
+
+    def shadowed_count(self, source: GateSource) -> int:
+        """How many of *source*'s legacy-row terms its registry class fails to carry.
+
+        ``0`` when the registry is unset — pre-cutover every gate reads its legacy
+        row, so nothing is shadowed.
+        """
+        registry = self._registry()
+        if registry is None:
+            return 0
+        legacy = set(normalise_terms(self._setting(source.legacy_key)))
+        return len(legacy - set(registry.get(source.registry_class, ())))
+
+    def fingerprints(self) -> dict[str, Fingerprint]:
+        """Fingerprint every CI-fed gate's configured list."""
+        return {source.gate: Fingerprint.of(self.configured(source)) for source in GATES}
+
+
+@dataclass(frozen=True)
+class FingerprintDocument:
+    """The committable contract: one fingerprint per CI-fed gate, and nothing else."""
+
+    version: int
+    gates: dict[str, Fingerprint]
+
+    @classmethod
+    def from_store(cls, store: TermStore) -> "FingerprintDocument":
+        """Build the document from what the operator has configured."""
+        return cls(version=1, gates=store.fingerprints())
+
+    @classmethod
+    def read(cls, path: Path) -> "FingerprintDocument":
+        """Load a committed document."""
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        gates = payload.get("gates") if isinstance(payload, dict) else None
+        if not isinstance(gates, dict):
+            msg = f"{path} carries no gates table"
+            raise TypeError(msg)
+        version = payload.get("version", 1)
+        return cls(
+            version=version if isinstance(version, int) else 1,
+            gates={str(gate): Fingerprint.from_stored(raw) for gate, raw in gates.items()},
+        )
+
+    def write(self, path: Path) -> None:
+        """Persist the document, sorted so a resync produces a minimal diff."""
+        payload = {
+            "version": self.version,
+            "note": _DOCUMENT_NOTE,
+            "gates": {gate: fingerprint.as_stored() for gate, fingerprint in self.gates.items()},
+        }
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+class DriftDetector:
+    """The four operations, each returning a process exit code."""
+
+    def __init__(self, store: TermStore) -> None:
+        self.store = store
+
+    def generate(self, out: Path) -> int:
+        """Write the fingerprint of the operator's configured lists to *out*."""
+        document = FingerprintDocument.from_store(self.store)
+        document.write(out)
+        for gate, fingerprint in sorted(document.gates.items()):
+            print(f"{gate}: {fingerprint.count} term(s)")
+        print(f"wrote {out}")
+        return OK
+
+    def check_shadow(self) -> int:
+        """Fail when a registry class carries fewer terms than the legacy row it replaced."""
+        status = OK
+        for source in GATES:
+            missing = self.store.shadowed_count(source)
+            if missing:
+                print(
+                    f"{source.gate}: SHADOWED — the registry {source.registry_class!r} class omits "
+                    f"{missing} term(s) the {source.legacy_key!r} row carries, so registry-first "
+                    f"resolution shrinks this gate."
+                )
+                status = DRIFT
+            else:
+                print(f"{source.gate}: registry covers {source.legacy_key!r}.")
+        if status == DRIFT:
+            print("\nRebuild the registry from the legacy rows so no class lags its row.")
+        return status
+
+    def sync(self, repo: str, fingerprint_path: Path, *, apply: bool) -> int:
+        """Push each gate's configured list to its secret, then refresh the fingerprint.
+
+        The list is streamed to ``gh secret set`` on stdin, so no term value is ever
+        an argument, an environment variable, or a line of output.
+        """
+        import subprocess
+
+        if self.check_shadow() != OK:
+            print("\nSyncing the WIDEST configured list regardless — a lagging registry never shrinks CI.\n")
+        for source in GATES:
+            terms = self.store.configured(source)
+            if not terms:
+                print(f"{source.gate}: nothing configured — leaving ${source.env_var} untouched.")
+                continue
+            if not apply:
+                print(f"{source.gate}: would set {source.env_var} to {len(terms)} term(s) (dry run).")
+                continue
+            result = subprocess.run(
+                ["gh", "secret", "set", source.env_var, "--repo", repo],
+                input=",".join(terms),
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            if result.returncode != 0:
+                print(f"{source.gate}: FAILED to set ${source.env_var} (gh exit {result.returncode}).")
+                return MISCONFIGURED
+            print(f"{source.gate}: set ${source.env_var} to {len(terms)} term(s).")
+        if not apply:
+            print(f"\nDry run — rerun with --apply to write the secrets and refresh {fingerprint_path}.")
+            return OK
+        self.generate(fingerprint_path)
+        print("\nCommit the refreshed fingerprint so CI can detect the next divergence.")
+        return OK
+
+
+def check_ci(fingerprint_path: Path, *, allow_unset: bool) -> int:
+    """Compare each gate's CI-visible list against the committed fingerprint.
+
+    A free function, not a :class:`DriftDetector` method: it reads only the
+    environment and the committed file, so it must stay runnable where no store
+    exists at all — which is exactly the CI runner.
+    """
+    expected = FingerprintDocument.read(fingerprint_path).gates
+    status = OK
+    for source in GATES:
+        want = expected.get(source.gate)
+        if want is None:
+            print(f"{source.gate}: no committed fingerprint — regenerate {fingerprint_path}")
+            status = max(status, MISCONFIGURED)
+            continue
+        visible = terms_from_env(source.env_var)
+        if visible is None:
+            if allow_unset:
+                print(f"{source.gate}: SKIPPED — ${source.env_var} is unreadable here (fork PR).")
+                continue
+            print(
+                f"{source.gate}: MISCONFIGURED — ${source.env_var} is unset, so the gate "
+                f"cannot scan the {want.count} configured term(s)."
+            )
+            status = max(status, MISCONFIGURED)
+            continue
+        actual = Fingerprint.of(visible)
+        if actual.count != want.count:
+            print(
+                f"{source.gate}: DRIFT — ${source.env_var} holds {actual.count} term(s); "
+                f"the committed fingerprint expects {want.count}."
+            )
+            status = max(status, DRIFT)
+        elif actual.digest != want.digest:
+            print(
+                f"{source.gate}: DRIFT — ${source.env_var} holds {actual.count} term(s) as "
+                f"expected but the digest differs, so the contents diverged."
+            )
+            status = max(status, DRIFT)
+        else:
+            print(f"{source.gate}: in sync ({actual.count} term(s)).")
+    if status == DRIFT:
+        print("\nResync the repository secrets: python scripts/term_source_drift.py sync --apply")
+    return status
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """The detector's command-line surface."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    generate_parser = sub.add_parser("generate", help="write the fingerprint of the configured lists")
+    generate_parser.add_argument("--db", type=Path, default=None, help="ConfigSetting DB to read")
+    generate_parser.add_argument("--out", type=Path, default=DEFAULT_FINGERPRINT)
+
+    ci_parser = sub.add_parser("check-ci", help="compare the CI-visible lists to the committed fingerprint")
+    ci_parser.add_argument("--fingerprint", type=Path, default=DEFAULT_FINGERPRINT)
+    ci_parser.add_argument(
+        "--allow-unset",
+        action="store_true",
+        help="treat an unreadable secret as a clean skip (a fork PR) instead of misconfigured",
+    )
+
+    shadow_parser = sub.add_parser("check-shadow", help="require each registry class to cover its legacy row")
+    shadow_parser.add_argument("--db", type=Path, default=None, help="ConfigSetting DB to read")
+
+    sync_parser = sub.add_parser("sync", help="push the configured lists to their secrets and refresh the fingerprint")
+    sync_parser.add_argument("--db", type=Path, default=None, help="ConfigSetting DB to read")
+    sync_parser.add_argument("--repo", default="souliane/teatree")
+    sync_parser.add_argument("--fingerprint", type=Path, default=DEFAULT_FINGERPRINT)
+    sync_parser.add_argument("--apply", action="store_true", help="actually write the secrets")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Dispatch a subcommand and return its exit code."""
+    args = build_parser().parse_args(argv)
+    if args.command == "check-ci":
+        return check_ci(args.fingerprint, allow_unset=args.allow_unset)
+    detector = DriftDetector(TermStore(args.db))
+    if args.command == "generate":
+        return detector.generate(args.out)
+    if args.command == "check-shadow":
+        return detector.check_shadow()
+    return detector.sync(args.repo, args.fingerprint, apply=args.apply)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_term_source_drift.py
+++ b/tests/test_term_source_drift.py
@@ -1,0 +1,230 @@
+"""Tests for the term-source drift detector (``scripts/term_source_drift.py``).
+
+The detector answers one question for each CI-fed leak gate: *is the term list
+the gate actually scans the list the operator configured?* It compares three
+places a list can live — the consolidated ``banned_term_registry`` class, the
+legacy ``ConfigSetting`` row, and the CI secret CI injects via env — and reports
+only COUNTS and salted digests. A term VALUE must never reach stdout, stderr, a
+committed file, or a CI log, so the privacy assertions below are as load-bearing
+as the drift ones.
+
+The placeholder terms these tests use are invented fixture strings, never real
+configured terms.
+"""
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "term_source_drift.py"
+
+#: Invented placeholder terms. They must not collide with anything real, and the
+#: privacy assertions grep process output for them.
+TREE_TERMS = ["zarquon-corp", "blorbtech", "quuxical"]
+OVERLAY_TERMS = ["frobnitz-overlay", "wibble-tenant"]
+
+
+def _seed_db(tmp_path: Path, settings: dict[str, object]) -> Path:
+    """Build a ``teatree_config_setting`` DB carrying *settings* as JSON values."""
+    db = tmp_path / "config.sqlite3"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "CREATE TABLE teatree_config_setting ("
+        " id INTEGER PRIMARY KEY, scope TEXT NOT NULL DEFAULT '',"
+        " key TEXT NOT NULL, value TEXT NOT NULL)"
+    )
+    for key, value in settings.items():
+        conn.execute(
+            "INSERT INTO teatree_config_setting (scope, key, value) VALUES ('', ?, ?)",
+            (key, json.dumps(value)),
+        )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _run(*args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    """Invoke the detector with a clean environment plus *env*."""
+    child = {k: v for k, v in os.environ.items() if not k.startswith("TEATREE_")}
+    child.update(env or {})
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=child,
+    )
+
+
+def _assert_no_term_leaked(result: subprocess.CompletedProcess[str], terms: list[str]) -> None:
+    """No configured term value may appear in the detector's output."""
+    blob = f"{result.stdout}\n{result.stderr}".lower()
+    for term in terms:
+        assert term.lower() not in blob, f"the detector printed a configured term ({result.stdout}{result.stderr})"
+
+
+@pytest.fixture
+def fingerprint(tmp_path: Path) -> Path:
+    """A fingerprint file generated from a DB whose registry covers both legacy rows."""
+    db = _seed_db(
+        tmp_path,
+        {
+            "banned_brands": TREE_TERMS,
+            "overlay_leak_terms": OVERLAY_TERMS,
+            "banned_term_registry": {"leak": TREE_TERMS, "overlay": OVERLAY_TERMS},
+        },
+    )
+    out = tmp_path / "fingerprint.json"
+    result = _run("generate", "--db", str(db), "--out", str(out))
+    assert result.returncode == 0, result.stderr
+    return out
+
+
+class TestGenerate:
+    def test_writes_counts_and_digests_but_no_terms(self, tmp_path: Path, fingerprint: Path) -> None:
+        payload = json.loads(fingerprint.read_text(encoding="utf-8"))
+        assert payload["gates"]["tree"]["count"] == len(TREE_TERMS)
+        assert payload["gates"]["overlay"]["count"] == len(OVERLAY_TERMS)
+        assert payload["gates"]["tree"]["digest"].startswith("sha256:")
+        raw = fingerprint.read_text(encoding="utf-8").lower()
+        for term in TREE_TERMS + OVERLAY_TERMS:
+            assert term.lower() not in raw, "a term value reached the committed fingerprint file"
+
+    def test_widest_source_wins_so_a_shadowing_registry_cannot_shrink_it(self, tmp_path: Path) -> None:
+        """A registry class narrower than its legacy row must not shrink the fingerprint."""
+        db = _seed_db(
+            tmp_path,
+            {
+                "banned_brands": TREE_TERMS,
+                "overlay_leak_terms": OVERLAY_TERMS,
+                # The live shape this detector exists for: the registry omits the
+                # overlay class entirely and carries only one of the three brands.
+                "banned_term_registry": {"leak": TREE_TERMS[:1]},
+            },
+        )
+        out = tmp_path / "fp.json"
+        assert _run("generate", "--db", str(db), "--out", str(out)).returncode == 0
+        payload = json.loads(out.read_text(encoding="utf-8"))
+        assert payload["gates"]["tree"]["count"] == len(TREE_TERMS)
+        assert payload["gates"]["overlay"]["count"] == len(OVERLAY_TERMS)
+
+
+class TestCheckCi:
+    def test_matching_ci_list_passes(self, fingerprint: Path) -> None:
+        result = _run(
+            "check-ci",
+            "--fingerprint",
+            str(fingerprint),
+            env={
+                "TEATREE_BANNED_BRANDS": ",".join(TREE_TERMS),
+                "TEATREE_OVERLAY_LEAK_TERMS": ",".join(OVERLAY_TERMS),
+            },
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        _assert_no_term_leaked(result, TREE_TERMS + OVERLAY_TERMS)
+
+    def test_stale_smaller_ci_list_fails_with_counts_only(self, fingerprint: Path) -> None:
+        """The exact drift that went unnoticed: the secret holds an older, shorter list."""
+        result = _run(
+            "check-ci",
+            "--fingerprint",
+            str(fingerprint),
+            env={
+                "TEATREE_BANNED_BRANDS": ",".join(TREE_TERMS[:1]),
+                "TEATREE_OVERLAY_LEAK_TERMS": ",".join(OVERLAY_TERMS),
+            },
+        )
+        assert result.returncode == 1
+        assert "tree" in result.stdout
+        assert str(len(TREE_TERMS)) in result.stdout
+        _assert_no_term_leaked(result, TREE_TERMS + OVERLAY_TERMS)
+
+    def test_same_size_different_content_fails_on_the_digest(self, fingerprint: Path) -> None:
+        swapped = [*TREE_TERMS[:-1], "different-term"]
+        result = _run(
+            "check-ci",
+            "--fingerprint",
+            str(fingerprint),
+            env={
+                "TEATREE_BANNED_BRANDS": ",".join(swapped),
+                "TEATREE_OVERLAY_LEAK_TERMS": ",".join(OVERLAY_TERMS),
+            },
+        )
+        assert result.returncode == 1
+        assert "digest" in result.stdout.lower()
+
+    def test_order_and_case_and_whitespace_do_not_count_as_drift(self, fingerprint: Path) -> None:
+        noisy = ", ".join(term.upper() for term in reversed(TREE_TERMS))
+        result = _run(
+            "check-ci",
+            "--fingerprint",
+            str(fingerprint),
+            env={
+                "TEATREE_BANNED_BRANDS": noisy,
+                "TEATREE_OVERLAY_LEAK_TERMS": ",".join(OVERLAY_TERMS),
+            },
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_unset_secret_is_misconfigured_by_default(self, fingerprint: Path) -> None:
+        result = _run("check-ci", "--fingerprint", str(fingerprint))
+        assert result.returncode == 2
+        assert "TEATREE_BANNED_BRANDS" in result.stdout
+
+    def test_allow_unset_skips_for_a_fork_pr(self, fingerprint: Path) -> None:
+        result = _run("check-ci", "--fingerprint", str(fingerprint), "--allow-unset")
+        assert result.returncode == 0
+        assert "skip" in result.stdout.lower()
+
+    def test_malformed_fingerprint_raises_instead_of_passing_vacuously(self, tmp_path: Path) -> None:
+        """An unreadable contract must fail, never read as an empty one every list satisfies."""
+        broken = tmp_path / "broken.json"
+        broken.write_text('{"gates": []}', encoding="utf-8")
+        result = _run(
+            "check-ci",
+            "--fingerprint",
+            str(broken),
+            env={"TEATREE_BANNED_BRANDS": ",".join(TREE_TERMS)},
+        )
+        assert result.returncode != 0
+
+
+class TestCheckShadow:
+    def test_registry_covering_every_legacy_row_passes(self, tmp_path: Path) -> None:
+        db = _seed_db(
+            tmp_path,
+            {
+                "banned_brands": TREE_TERMS,
+                "overlay_leak_terms": OVERLAY_TERMS,
+                "banned_term_registry": {"leak": TREE_TERMS, "overlay": OVERLAY_TERMS},
+            },
+        )
+        result = _run("check-shadow", "--db", str(db))
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_registry_class_narrower_than_its_legacy_row_is_reported(self, tmp_path: Path) -> None:
+        """Registry-first resolution silently shrinks a gate when a class lags its row."""
+        db = _seed_db(
+            tmp_path,
+            {
+                "banned_brands": TREE_TERMS,
+                "overlay_leak_terms": OVERLAY_TERMS,
+                "banned_term_registry": {"leak": TREE_TERMS[:1]},
+            },
+        )
+        result = _run("check-shadow", "--db", str(db))
+        assert result.returncode == 1
+        assert "tree" in result.stdout
+        assert "overlay" in result.stdout
+        _assert_no_term_leaked(result, TREE_TERMS + OVERLAY_TERMS)
+
+    def test_absent_registry_is_not_shadowing(self, tmp_path: Path) -> None:
+        """Pre-cutover the registry is unset and every gate reads its legacy row."""
+        db = _seed_db(tmp_path, {"banned_brands": TREE_TERMS, "overlay_leak_terms": OVERLAY_TERMS})
+        result = _run("check-shadow", "--db", str(db))
+        assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
fix(ci): detect term-source drift between the DB, the secrets and the registry

<!-- t3-reconcile: term-source-drift-detector -->

## What this fixes

The `banned-terms-tree` and `overlay-leak-tree` jobs scan whatever list their
repository secret happens to hold. A secret is a point-in-time copy and nothing
re-reads the operator's store, so a term added locally never reaches CI. The
brand secret had not been refreshed since 2026-07-10 while the store's row grew,
so the push-to-main backstop was enforcing a strictly smaller set than the
operator had configured — 48 terms against 81.

Verifying that turned up a second, independent divergence. Every gate resolves
`banned_term_registry` **first**, so a registry class that lags its legacy row
silently *shrinks* the gate, and a class the registry omits entirely reduces that
gate to zero terms while the legacy row still looks populated. Both CI-fed gates
were affected locally: the tree gate was resolving 48 of 81, and the overlay term
pass was resolving 0 of 51 — fully inert.

Pasting the current list once is what produced the first divergence, so the fix
is a detector rather than another paste.

## What lands

- **`scripts/term_source_drift.py`** — fingerprints each CI-fed gate's list as a
  count plus a domain-separated SHA-256 over the whole sorted list.
  - `check-ci` compares the CI-visible list to the committed fingerprint.
  - `check-shadow` requires each registry class to cover its legacy row.
  - `sync --apply` streams both lists to `gh secret set` on stdin and refreshes
    the fingerprint in the same command, so the secret and its fingerprint
    cannot diverge silently.
- **`.github/term-source-fingerprint.json`** — counts and digests only. A
  whole-list digest confirms only an exact guess of the entire list, never an
  individual entry, which is what makes it safe to commit here. A malformed
  contract raises rather than reading as an empty one every list would satisfy.
- **`term-source-drift` CI job** — push, schedule and PR. No dependency sync
  (`check-ci` reads only env plus the fingerprint), so it is a seconds-long job.
  It omits `--allow-unset` on push/schedule so a missing secret is a loud exit 2,
  and passes it on PRs so a fork skips cleanly instead of false-redding.

Both secrets were resynced from the store as part of this change. The full-tree
and overlay scans were run against the widened lists first and both returned zero
findings, so the wider enforcement does not red main.

No term value is read, printed, logged or committed by any path added here, and a
test asserts the detector's own output stays term-free.

## Architecture pre-check

**1. BLUEPRINT alignment.** BLUEPRINT § 1 (core stays generic, `overlay-leak-tree`)
and § "Full-tree banned-brand backstop" / "Consolidated banned-term registry".
This change adds no new gate semantics; it asserts that the two documented gates
receive the list the operator configured. No BLUEPRINT claim changes.

**2. FSM phase boundaries.** n/a — no `Ticket.State` or `Worktree.State`
transition is touched.

**3. Extension-point contracts.** n/a — no `OverlayBase` hook, scanner
registration or `*Backend` Protocol is touched. The detector reads the same two
`ConfigSetting` keys and the same registry row the existing gates read.

**4. Component boundaries.** `scripts/` — a CI-invoked standalone check, the same
category as `scripts/hooks/check_no_overlay_leak.py` and `scripts/privacy_scan.py`.
It is deliberately not in `src/teatree/`: `check-ci` must run on a CI runner with
no dependency sync and no store, so it stays stdlib-only on that path.

**5. Dependency direction.** One import, lazy and inside `TermStore._setting`:
`teatree.config.cold_reader`. `scripts/` already depends on `teatree.config`
elsewhere, and nothing in `src/` imports this script, so no edge is added to the
package DAG. `tach` passes as part of the commit hooks.

**6. Test surface.** `tests/test_term_source_drift.py`, 12 tests driving the CLI
as a subprocess against a seeded store:

- a stale/smaller CI list fails with counts only;
- a same-size but different list fails on the digest;
- reordering, case and whitespace are not drift;
- an unset secret is misconfigured by default and a clean skip under `--allow-unset`;
- a registry class narrower than its legacy row is reported;
- an absent registry is not shadowing;
- the widest source wins, so a lagging registry cannot shrink the fingerprint;
- a malformed fingerprint raises instead of passing vacuously;
- and the privacy assertion: no configured term appears in stdout, stderr or the
  committed file.

Proven red before the script existed (4 failed, 7 errors), green after.

**7. Resilience invariants.** The only external write is `gh secret set`, on the
operator-invoked `sync --apply` path. *Verify-by-re-read*: the same command
regenerates the fingerprint from the store immediately after writing, and the
next CI run compares the actual secret against it — the write is verified by the
gate itself rather than by a local echo. *Idempotency*: normalisation makes a
repeat sync produce a byte-identical secret and fingerprint. *Fail-loud*: a
non-zero `gh` exit aborts with exit 2 rather than refreshing a fingerprint that
would then certify a secret that was never written. No heartbeat or sub-agent
contract applies — the command is a single short-lived local invocation.

**8. Identity and key normalization.** A gate's identity is the `GateSource`
record (gate name, env var, registry class, legacy key) — one table, consulted
everywhere, so no call site re-derives a gate's env var or legacy key from a
string. Term identity is normalised *up* to one canonical form (stripped,
casefolded, sorted, de-duplicated) at every boundary before either the count or
the digest, so the three stores are compared on the same footing. There is no
strip-a-qualifier-to-make-it-match anywhere.

**9. Behavior preservation / capability deletion.** Purely additive — no existing
gate, matcher or scan root is changed, narrowed or removed, and no existing test
is inverted. The only behavioral change to the running system is that the two
secrets now carry the operator's full configured lists rather than an older
subset, which widens coverage. That widening was verified safe before applying:
the full tree was scanned under the 81-term list and the overlay roots under the
51-term list, both returning zero findings.

**10. Removability / harness-vs-data.** Removable: deleting the script, the
fingerprint file and the CI job returns the repo exactly to today's behaviour;
nothing else imports or reads them. Harness-vs-data: the varying part — which
gates exist and where each one's list lives — is the `GATES` table, and the
per-repo expectation is the committed JSON fingerprint. The script is the generic
mechanism that reads both; no gate name or term is hard-coded in the logic.

## Open questions & assumptions

- **Assumption:** the two `ConfigSetting` rows are the operator's intended source
  of truth and the registry classes are the ones lagging, not the reverse. That
  is why `sync` takes the union rather than the registry: a wider list can only
  over-enforce a gate that is already clean, whereas trusting the narrower side
  would have kept the overlay pass inert.
- **Open question, not addressed here:** `build_registry_from_legacy` resolves
  the brand list through `load_brand_terms`, which is itself registry-first. Once
  a registry exists, rebuilding it from "legacy" therefore re-reads the registry's
  own `leak` class instead of the `banned_brands` row, so the rebuild cannot
  widen a class that has already lagged. That lives in `src/teatree/hooks/`,
  outside this change's surface; `check-shadow` makes the resulting divergence
  visible in the meantime.
- **Assumption:** committing counts and a whole-list digest is acceptable for a
  public repo. The digest is domain-separated and covers the entire sorted list,
  so it can confirm an exact guess of the whole list but cannot test a single
  candidate entry.
- **Not covered:** `TEATREE_BANNED_TERMS` exists as a secret but no workflow
  reads it, so it has no CI-visible copy to drift and is out of the detector's
  scope.
