### PR TITLE
fix(review): findings record what was observed, not only what blocks

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -47,7 +47,13 @@ never happened, and it is refused.
 Allowed values, exactly as written — anything else is refused:
 
 - `verdict`: `merge_safe` or `hold`. Not `PASS`, not `LGTM`, not `approve`.
-  Use `hold` with the blocking findings when the change must not merge yet.
+- `findings`: Record in "findings" what you actually observed — the low-severity
+  and the uncertain ones too, and anything you could not check — whatever verdict
+  you reach. Nothing here is published, so an omitted observation is a lost record
+  rather than spared noise: "findings" is what you looked at, "verdict" is the
+  separate judgement. A "hold" carries the observations that block. A "merge_safe"
+  with an empty "findings" asserts you looked and found nothing worth recording,
+  so emit that only when it is true.
 - `gh_verify_result`: `green`, `pending`, or `failed` — the CI state you
   observed. `merge_safe` can never carry `failed`.
 - `blast_class`: `substrate`, `logic`, or `docs`.

--- a/src/teatree/agents/envelope_contract.py
+++ b/src/teatree/agents/envelope_contract.py
@@ -40,7 +40,9 @@ _EVIDENCE_EXAMPLES: Mapping[str, AgentResult] = {
             "reviewer_identity": "<your reviewer id>",
             "gh_verify_result": "green",
             "blast_class": "logic",
-            "findings": [],
+            # Non-empty on a PASS: the example a reviewer copies outranks the prose
+            # beside it (``modelkit.review_contract.ENVELOPE_FINDINGS_RULE``).
+            "findings": [{"severity": "low", "summary": "<what you observed>", "file": "src/x.py", "line": 42}],
         }
     },
     "critic_verdict": {

--- a/src/teatree/agents/phase_blocks.py
+++ b/src/teatree/agents/phase_blocks.py
@@ -1,11 +1,12 @@
 """The per-phase trailing blocks of the headless system context.
 
 ``prompt.build_system_context`` assembles the append; this module owns the block
-it appends LAST — the directive set for the dispatched phase. Each shell-denied
-phase (reviewing / answering / planning / scanning_news) must RETURN its evidence
-in the result envelope rather than write it through a CLI, and the phase evidence
-gate refuses a run whose envelope omits it, so each block carries the envelope
-directive that keeps the run from being wasted.
+it appends LAST — the directive set for the dispatched phase. Reviewing, answering,
+planning and scanning_news must each RETURN their evidence in the result envelope
+rather than write it through a CLI — some because the phase has no shell, reviewing
+because maker≠checker reserves the write for a different actor — and the phase
+evidence gate refuses a run whose envelope omits it, so each block carries the
+envelope directive that keeps the run from being wasted.
 """
 
 import json
@@ -20,6 +21,7 @@ from teatree.agents.dispatch_preflight import (
 from teatree.agents.skill_injection import _explicit_load_name
 from teatree.config.agent_spawn import resolve_agent_config
 from teatree.core.modelkit.phases import normalize_phase, resolve_fanout_directive
+from teatree.core.modelkit.review_contract import ENVELOPE_FINDINGS_RULE
 from teatree.core.models import Task
 
 # The anti-rubber-stamp contract for a verification brief — prove the change out
@@ -33,20 +35,20 @@ _VERIFICATION_BRIEF_LINES: tuple[str, ...] = (
     "   correctness | robustness (failure modes) | maintainability | coherence | reliability | proactivity.",
 )
 
-# The reviewing phase is denied the shell, so it CANNOT run `t3 <overlay> review
-# record`. It returns the verdict in the result envelope instead; the orchestrator
-# records it server-side (maker≠checker: a different actor writes the row).
+# The reviewer returns its verdict in the result envelope rather than writing the
+# row itself: maker≠checker requires a different actor, so the orchestrator records
+# it server-side. The phase carries the shell (``phase_tools.VERDICT_REVIEW_PHASES``).
 _REVIEW_VERDICT_RETURN_LINES: tuple[str, ...] = (
     "",
-    "RECORD YOUR VERDICT BY RETURNING IT (this phase has no shell — do NOT try `t3 <overlay> review record`):",
-    "add a `review_verdict` object to your final JSON result. The orchestrator records the",
-    "ReviewVerdict server-side and releases the review lock:",
+    "RECORD YOUR VERDICT BY RETURNING IT (do NOT try `t3 <overlay> review record` — maker≠checker",
+    "requires a different actor to write the row): add a `review_verdict` object to your final JSON",
+    "result. The orchestrator records the ReviewVerdict server-side and releases the review lock:",
     '  "review_verdict": {"verdict": "merge_safe"|"hold", "reviewed_sha": "<full 40-char HEAD SHA>",',
     '                     "reviewer_identity": "<your reviewer id, NOT a maker/loop role>",',
     '                     "gh_verify_result": "green"|"pending"|"failed",',
     '                     "blast_class": "substrate"|"logic"|"docs",',
     '                     "findings": [{"severity": "...", "summary": "...", "file": "...", "line": 0}]}',
-    "Use verdict=hold with the blocking findings when the change must not merge yet.",
+    ENVELOPE_FINDINGS_RULE,
     "`verdict` accepts ONLY merge_safe or hold — PASS/LGTM/approve are refused and record nothing.",
     "`reviewed_sha` MUST be the full 40-char SHA of the head you reviewed (`git rev-parse HEAD`):",
     "the merge gate compares it against the forge's live head, so a short or stale SHA vouches for nothing.",

--- a/src/teatree/agents/result_schema.py
+++ b/src/teatree/agents/result_schema.py
@@ -17,6 +17,7 @@ from collections.abc import Callable
 from typing import TypedDict, cast
 
 from teatree.core.modelkit.phases import normalize_phase
+from teatree.core.modelkit.review_contract import ENVELOPE_FINDINGS_RULE
 from teatree.core.models.mechanism_sketch import MechanismSketchDict
 
 
@@ -98,7 +99,9 @@ class ReviewVerdictEnvelope(TypedDict, total=False):
     maker≠checker reserves that write for another actor. It RETURNS this instead: the orchestrator
     (a different actor) records the ``ReviewVerdict`` from it, so maker≠checker
     holds by construction. ``reviewed_sha`` is the full 40-char SHA the review
-    bound to; ``verdict`` is ``merge_safe`` / ``hold``.
+    bound to; ``verdict`` is ``merge_safe`` / ``hold``; ``findings`` is the record of
+    what the reviewer observed, independent of the verdict it reached
+    (:data:`~teatree.core.modelkit.review_contract.ENVELOPE_FINDINGS_RULE`).
     """
 
     verdict: str
@@ -248,6 +251,7 @@ RESULT_JSON_SCHEMA: JSONSchema = {
                 "blast_class": {"type": "string", "enum": ["substrate", "logic", "docs"]},
                 "findings": {
                     "type": "array",
+                    "description": ENVELOPE_FINDINGS_RULE,
                     "items": {
                         "type": "object",
                         "properties": {

--- a/src/teatree/core/modelkit/review_contract.py
+++ b/src/teatree/core/modelkit/review_contract.py
@@ -1,0 +1,29 @@
+"""The reviewer-brief doctrine both ``core.models`` and ``agents`` render — a pure leaf.
+
+``modelkit`` (``depends_on = []``) is the only stratum
+:mod:`teatree.core.models.auto_review_dispatch` and :mod:`teatree.agents.phase_blocks`
+can both import, so the sentence they each stamp into a reviewer's brief lives here
+once instead of being reworded independently in each.
+
+The rule below exists because the brief and the review skill had drifted into saying
+opposite things about the same array, and the brief wins on ordering: it is stamped
+into ``Task.execution_reason`` and read before any skill loads. ``/t3:review``
+suppresses a clean-check finding on the colleague-facing lane, where noise under the
+owner's identity costs credibility; the ``review_verdict`` envelope is a durable
+internal record nothing publishes, so the same suppression there buys nothing and
+costs recall. 81.4% of passing verdicts (416/511) arrived with an empty ``findings``
+array against a median merged diff of 287 lines.
+"""
+
+from typing import Final
+
+#: Stamped verbatim into every reviewer-facing brief teatree renders, and mirrored
+#: in the ``findings`` JSON-schema description a structured-output model reads.
+ENVELOPE_FINDINGS_RULE: Final[str] = (
+    'Record in "findings" what you actually observed — the low-severity and the uncertain ones too, '
+    "and anything you could not check — whatever verdict you reach. Nothing here is published, so an "
+    'omitted observation is a lost record rather than spared noise: "findings" is what you looked at, '
+    '"verdict" is the separate judgement. A "hold" carries the observations that block. A "merge_safe" '
+    'with an empty "findings" asserts you looked and found nothing worth recording, so emit that only '
+    "when it is true."
+)

--- a/src/teatree/core/models/auto_review_dispatch.py
+++ b/src/teatree/core/models/auto_review_dispatch.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, ClassVar
 from django.db import models, transaction
 from django.utils import timezone
 
+from teatree.core.modelkit.review_contract import ENVELOPE_FINDINGS_RULE
 from teatree.core.models.mr_review_lock import MRReviewLock
 
 if TYPE_CHECKING:
@@ -62,8 +63,9 @@ def build_review_contract(*, slug: str, pr_id: int, head_sha: str, pr_url: str) 
         f"affected tests in that checkout before voting merge_safe. Then RETURN your verdict in the "
         f'result envelope: `"review_verdict": '
         f'{{"verdict": "merge_safe", "reviewed_sha": "{head_sha}", "reviewer_identity": '
-        f'"<your-reviewer-id>", "gh_verify_result": "green"}}`. Use "verdict": "hold" with a "findings" '
-        f"array when blocking. Do NOT run `t3 <overlay> review record` — maker≠checker requires a different "
+        f'"<your-reviewer-id>", "gh_verify_result": "green", "findings": [{{"severity": "low", '
+        f'"summary": "<what you observed>", "file": "<path>", "line": 0}}]}}`. {ENVELOPE_FINDINGS_RULE} '
+        f"Do NOT run `t3 <overlay> review record` — maker≠checker requires a different "
         f"actor to write the row: the orchestrator records the ReviewVerdict at head {head_sha[:8]} from "
         f"your envelope, and pr_sweep consumes it to auto-merge this own PR (#68)."
     )

--- a/tests/teatree_core/models/test_auto_review_dispatch.py
+++ b/tests/teatree_core/models/test_auto_review_dispatch.py
@@ -1,9 +1,16 @@
 """Tests for :class:`AutoReviewDispatch` — the auto-review-dispatch ledger + task factory (#68)."""
 
+import json
+from pathlib import Path
+from typing import cast
+
 import pytest
 
-from teatree.agents.result_schema import ReviewVerdictEnvelope
+from teatree.agents.envelope_contract import envelope_example
+from teatree.agents.phase_blocks import _REVIEW_VERDICT_RETURN_LINES
+from teatree.agents.result_schema import RESULT_JSON_SCHEMA, JSONSchema, ReviewVerdictEnvelope
 from teatree.core.modelkit.phase_tools import tools_for_phase
+from teatree.core.modelkit.review_contract import ENVELOPE_FINDINGS_RULE
 from teatree.core.models import AutoReviewDispatch, MRReviewLock, Task, Ticket
 from teatree.core.models.auto_review_dispatch import build_review_contract
 
@@ -139,6 +146,9 @@ def _reviewing_capability_claims() -> dict[str, str]:
         "stamped execution_reason contract": build_review_contract(slug=SLUG, pr_id=1, head_sha=HEAD, pr_url=URL),
         "build_review_contract docstring": build_review_contract.__doc__ or "",
         "ReviewVerdictEnvelope docstring": ReviewVerdictEnvelope.__doc__ or "",
+        # The block the headless brief actually appends. Absent from this set it
+        # kept telling reviewers "this phase has no shell" for the whole of #3775.
+        "headless reviewing brief lines": "\n".join(_REVIEW_VERDICT_RETURN_LINES),
     }
 
 
@@ -175,6 +185,106 @@ class TestContractMatchesPhaseToolGrant:
     def test_contract_states_maker_checker_as_the_reason_for_the_record_ban(self) -> None:
         contract = build_review_contract(slug=SLUG, pr_id=1, head_sha=HEAD, pr_url=URL)
         assert "maker" in contract.lower()
+
+
+#: Phrasings that tie ``findings`` exclusively to a blocking verdict. Read as an
+#: instruction, each licenses an empty array on a pass — the disposal the review
+#: skill reserves for the colleague-facing lane, where noise costs credibility,
+#: and forbids in the envelope, where nothing is published and an omission is a
+#: lost record.
+FINDINGS_ONLY_WHEN_BLOCKING_PHRASINGS = (
+    'with a "findings" array when blocking',
+    "with a `findings` array when blocking",
+    "with the blocking findings",
+    "findings array when blocking",
+    "findings only when blocking",
+    "findings when you block",
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REVIEWER_AGENT_MD = REPO_ROOT / "agents" / "reviewer.md"
+REVIEW_SKILL_MD = REPO_ROOT / "skills" / "review" / "SKILL.md"
+
+
+def _normalized(text: str) -> str:
+    """Collapse every whitespace run so a line-wrapped rendering still matches."""
+    return " ".join(text.split())
+
+
+def _schema_node(*path: str) -> JSONSchema:
+    """Walk :data:`RESULT_JSON_SCHEMA` down *path*, keeping the untyped blob navigable."""
+    node = RESULT_JSON_SCHEMA
+    for key in path:
+        node = cast("JSONSchema", node[key])
+    return node
+
+
+def _code_owned_reviewer_briefs() -> dict[str, str]:
+    """The reviewer-facing briefs this repo renders, each of which must carry the rule."""
+    return {
+        "stamped execution_reason contract": build_review_contract(slug=SLUG, pr_id=1, head_sha=HEAD, pr_url=URL),
+        "headless reviewing brief lines": "\n".join(_REVIEW_VERDICT_RETURN_LINES),
+        "reviewer agent definition": REVIEWER_AGENT_MD.read_text(encoding="utf-8"),
+    }
+
+
+def _findings_prose_surfaces() -> dict[str, str]:
+    """Every surface that tells a reviewer what belongs in ``findings`` — briefs and doctrine alike."""
+    return {
+        **_code_owned_reviewer_briefs(),
+        "review skill": REVIEW_SKILL_MD.read_text(encoding="utf-8"),
+        "ReviewVerdictEnvelope docstring": ReviewVerdictEnvelope.__doc__ or "",
+        "review_verdict JSON schema": json.dumps(_schema_node("properties", "review_verdict")),
+    }
+
+
+class TestFindingsAreARecordNotABlockingArtifact:
+    """Every reviewer-facing brief renders one shared findings rule, and none contradicts it.
+
+    The brief reaches the reviewer before the skill does — it is stamped into
+    ``execution_reason`` and read first — so a brief that says the opposite of
+    the skill wins on ordering. Pinning the briefs to :data:`ENVELOPE_FINDINGS_RULE`
+    binds them to one another and to the skill's envelope-lane doctrine, rather
+    than to a sentence each surface is free to reword on its own.
+    """
+
+    def test_no_surface_ties_findings_exclusively_to_blocking(self) -> None:
+        offenders = [
+            (surface, phrasing)
+            for surface, text in _findings_prose_surfaces().items()
+            for phrasing in FINDINGS_ONLY_WHEN_BLOCKING_PHRASINGS
+            if phrasing in text.lower()
+        ]
+        assert not offenders, (
+            f"findings record what was observed, whatever the verdict, but these surfaces "
+            f"tie them to a block: {offenders}"
+        )
+
+    def test_every_code_owned_brief_renders_the_shared_rule(self) -> None:
+        rule = _normalized(ENVELOPE_FINDINGS_RULE)
+        missing = [surface for surface, text in _code_owned_reviewer_briefs().items() if rule not in _normalized(text)]
+        assert not missing, f"these reviewer briefs do not render ENVELOPE_FINDINGS_RULE: {missing}"
+
+    def test_the_shared_rule_still_requires_findings_on_a_block(self) -> None:
+        lowered = ENVELOPE_FINDINGS_RULE.lower()
+        assert "hold" in lowered
+        assert "block" in lowered
+
+    def test_the_shared_rule_reaches_the_reviewer_through_the_stamped_task(self) -> None:
+        row = AutoReviewDispatch.enqueue(slug=SLUG, pr_id=6230, head_sha=HEAD, pr_url=URL, overlay="teatree")
+
+        assert row is not None
+        assert row.task is not None
+        assert _normalized(ENVELOPE_FINDINGS_RULE) in _normalized(row.task.execution_reason)
+
+    def test_the_json_schema_teaches_the_rule_to_a_structured_output_model(self) -> None:
+        findings = _schema_node("properties", "review_verdict", "properties", "findings")
+        assert _normalized(ENVELOPE_FINDINGS_RULE) in _normalized(str(findings["description"]))
+
+    def test_the_worked_envelope_example_does_not_model_an_empty_findings_pass(self) -> None:
+        example = envelope_example(REVIEWING_PHASE)["review_verdict"]
+        assert example["verdict"] == "merge_safe"
+        assert example["findings"], "the example a reviewer copies must not model a pass with nothing recorded"
 
 
 class TestDispatchedTaskReachesTerminalState:


### PR DESCRIPTION
fix(review): findings record what was observed, not only what blocks

Reconcilable marker: **review-path plan — the reviewer's findings array**, the envelope-lane half of the split [#3779](https://github.com/souliane/teatree/pull/3779) writes on the skill side.

## The defect, verified

`build_review_contract` in `src/teatree/core/models/auto_review_dispatch.py` stamped this into every auto-review task's `execution_reason`, verbatim on `origin/main`:

> Use `"verdict": "hold"` with a `"findings"` array when blocking.

The quote in the brief was accurate. The brief does reach the reviewer: `execution_reason` → `agents/prompt._task_header_lines` → `Reason: …` in the headless work prompt, before any skill loads. So on ordering it beats the skill.

Read as an instruction it says findings accompany a hold, which makes an empty array the correct shape for a pass. Measured: **81.4% of passing verdicts (416/511) carry an empty `findings` array**, against a median merged diff of 287 lines.

## What changed

One rule, one source: `teatree.core.modelkit.review_contract.ENVELOPE_FINDINGS_RULE`. `modelkit` is `depends_on = []` and the only stratum both `core.models` and `agents` may import, so the sentence is rendered verbatim into every reviewer-facing brief rather than reworded per surface.

> Record in "findings" what you actually observed — the low-severity and the uncertain ones too, and anything you could not check — whatever verdict you reach. Nothing here is published, so an omitted observation is a lost record rather than spared noise: "findings" is what you looked at, "verdict" is the separate judgement. A "hold" carries the observations that block. A "merge_safe" with an empty "findings" asserts you looked and found nothing worth recording, so emit that only when it is true.

The blocking requirement is kept, not deleted — the sentence is replaced, never dropped.

## Siblings

| surface | what it said |
|---|---|
| `agents/phase_blocks._REVIEW_VERDICT_RETURN_LINES` | same sentence, **and** still `this phase has no shell` — the stale claim [#3775](https://github.com/souliane/teatree/pull/3775) corrected on three other surfaces. That block was absent from #3775's `_reviewing_capability_claims()` set, so nothing caught it. Added to the set. |
| `agents/reviewer.md` | same sentence |
| `agents/envelope_contract._EVIDENCE_EXAMPLES["review_verdict"]` | `merge_safe` paired with `"findings": []` — the defect as a worked example, on every reviewing brief |
| `build_review_contract`'s own inline example | omitted the `findings` key entirely |
| `result_schema.RESULT_JSON_SCHEMA` `findings` | no `description` at all; carries the rule now, where a structured-output model reads it |

Nothing was deliberately left. `skills/review/SKILL.md` is fenced and is #3779's surface; it carries no contradicting phrasing today, so it needs no edit here.

## The drift test, RED first

`TestFindingsAreARecordNotABlockingArtifact` in `tests/teatree_core/models/test_auto_review_dispatch.py`.

**Observed RED** on the pre-fix tree, naming all three prose offenders:

```
AssertionError: findings record what was observed, whatever the verdict, but these
surfaces tie them to a block: [('stamped execution_reason contract', 'with a
"findings" array when blocking'), ('headless reviewing brief lines', 'with the
blocking findings'), ('reviewer agent definition', 'with the blocking findings')]
```

`skills/review/SKILL.md` was in that same scanned set and came back clean — the control that the scan discriminates rather than matching everything. A second control perturbed one sentence in `agents/reviewer.md`; `test_every_code_owned_brief_renders_the_shared_rule` went red naming that surface, so the verbatim binding is not vacuous.

**Merge-order independence.** The test asserts a negative on the skill (it may not tie findings to a block) and a positive only on the code-owned briefs. That holds whether #3779 lands before or after this, and goes red if anyone later writes the licensing phrasing into the skill.

## Architecture pre-check

**1. BLUEPRINT § alignment** — no section changes. This corrects prose describing an existing contract; the `review_verdict` envelope and the merge gate that consumes it are untouched.

**2. FSM phase boundaries** — n/a. No `Ticket.State` / `Worktree.State` transition changes.

**3. Extension-point contracts** — none. `ENVELOPE_FINDINGS_RULE` is a module constant, not a hook; no `OverlayBase` surface, no scanner registration, no Protocol.

**4. Component boundaries** — `core/modelkit/review_contract.py` is a new leaf beside `phase_tools.py` (the authority #3775's drift test binds to) and `review_state.py`. Naming it `review_contract` rather than folding it into either keeps the file name the documentation: tool grants, reviewer state vocabulary, brief doctrine.

**5. Dependency direction** — `uv run tach check` → All modules validated. `core.models` → `agents.result_schema` would have been a backwards edge (`core.models` does not depend on `agents`); routing through `modelkit` (`depends_on = []`, already a dependency of both) avoids it. import-linter passed.

**6. Test surface** — the five tests above, each red on a real perturbation: the phrasing scan (offenders named), the verbatim render (perturbed markdown), the stamped-task path (the rule reaching `Task.execution_reason`), the JSON-schema description, and the worked example's non-empty findings.

**7. Resilience invariants** — n/a. No external write, no sub-agent dispatch, no long-running work. The change is prose rendered into a string.

**8. Identity and key normalization** — n/a. No identity with a bare/qualified form; no `split`/`strip` introduced.

**9. Behavior preservation / capability deletion** — one sentence replaced on three surfaces, none dropped: each replacement still states that a hold carries its blocking findings, pinned by `test_the_shared_rule_still_requires_findings_on_a_block` so a later "fix by deletion" goes red. `envelope_contract`'s example gains a finding rather than losing a key. No test was inverted; no privacy/leak/security matcher touched. The `phase_blocks` no-shell correction restores a claim `phase_tools.VERDICT_REVIEW_PHASES` already grants — it removes a false denial, not a capability.

**10. Removability / harness-vs-data** — `review_contract.py` is removable: deleting it reverts three import lines and three inlined sentences. Data, not harness — the rule is a string a table holds, and every consumer reads it rather than branching on it.

## Verification

Branch off `origin/main` at `d2d948b0`.

| gate | result |
|---|---|
| `ruff check` / `ruff format` (src + tests) | pass |
| `ty check` (touched modules + test) | All checks passed |
| `tach check` | All modules validated |
| `t3 tool test-path-mirror` | 186 grandfathered, ledger exact |
| `makemigrations --check --dry-run` | No changes detected |
| `tests/quality/test_no_flat_core_regrowth.py` + incompleteness ratchet | 14 passed, no peg moved |
| `check_module_health.py --from-ref origin/main` | pass |
| `t3 tool comment-density` | no findings |
| `check_antipatterns.py` (staged) | no greppable anti-patterns |
| `tests/teatree_agents` | 1149 passed, 9 skipped |
| `tests/teatree_core/models` | 1030 passed |
| `tests/conformance` | 225 passed, 3 xfailed |

The full pre-commit and pre-push hook chains ran green, including the banned-terms, privacy-diff and near-zero-comments gates.

## Open questions & assumptions

- **Assumption:** the 81.4% figure is relayed from the task brief, not re-measured here — no DB read was performed. It motivates the fix; the defect itself is verified independently from the source.
- **Left to #3779:** `skills/review/SKILL.md` is fenced. The wording here was written against that PR's diff so the two agree whichever lands first.
