### PR TITLE
refactor(eval): say model-free, not free — rename --free-only to --model-free

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,7 +631,7 @@ graph LR
 | `review` | Code review — self-review before finalization, giving review, receiving review feedback |
 | `review-request` | Batch review requests — discover open PRs, validate metadata, check for duplicates, post to review channels |
 | `rules` | Cross-cutting agent safety rules — clickable refs, temp files, sub-agent limits, UX preservation. Auto-loaded as a dependency by other skills. |
-| `running-evals` | Single in-session entrypoint that auto-orchestrates the whole eval picture — free deterministic lanes (the eval-coverage gate `t3 eval coverage`, pinned-regressions) plus the transcript AI/trajectory lane (prepare → produce transcripts in-session → grade) — and prints one unified results table |
+| `running-evals` | Single in-session entrypoint that auto-orchestrates the whole eval picture — model-free deterministic lanes (the eval-coverage gate `t3 eval coverage`, pinned-regressions) plus the transcript AI/trajectory lane (prepare → produce transcripts in-session → grade) — and prints one unified results table |
 | `scanning-news` | Scans today's TLDR AI and The Rundown AI editions for ideas that could improve teatree, fetches the full article for promising items, and hands each concrete t3-improvement candidate back through the result envelope's article_suggestions field. The loop queues each behind the ask-gate (PendingArticleSuggestion) for per-article user approval before any souliane/teatree issue is filed, and DMs the batch to the user |
 | `setup` | Bootstrap and validate teatree for local use — prerequisites, config, skill symlinks, optional agent hooks, and Django project scaffolding |
 | `ship` | Delivery — committing, pushing, creating MR/PR, pipeline monitoring, review requests |

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -1531,8 +1531,9 @@ Usage: t3 eval [OPTIONS] COMMAND [ARGS]...
 │                                  [default: transcript]                       │
 │ --transcript-dir        PATH     Directory of <scenario>.jsonl transcripts   │
 │                                  for the AI lane (default: cwd).             │
-│ --free-only                      Run only the free deterministic lanes (drop │
-│                                  the AI lane) — the fast pre-push gate.      │
+│ --model-free                     Run only the model-free deterministic lanes │
+│                                  (drop the AI lane) — the fast pre-push      │
+│                                  gate.                                       │
 │ --strict                         Exit non-zero when a lane was SKIPPED for   │
 │                                  setup reasons (the AI behavioural lane with │
 │                                  no transcripts / no key) — for CI, where    │
@@ -1773,7 +1774,7 @@ Usage: t3 eval coverage [OPTIONS]
  via ``agent_path`` (from the ``evals/scenarios/`` catalog or an overlay's
  own dir), or EXEMPT when its frontmatter carries a non-empty ``eval_exempt``
  reason. A skill that is
- neither is a GAP. Deterministic and free — no ``claude -p`` invocation.
+ neither is a GAP. Deterministic and model-free — no ``claude -p`` invocation.
  Warn-first by default (a gap is reported, exit 0); ``--fail-on-gap`` is the
  Phase-B enforcement that exits non-zero on any gap.
 
@@ -1792,7 +1793,8 @@ Usage: t3 eval pinned-regressions [OPTIONS]
 
  Run the deterministic regression corpus over the real gate/checker code paths.
 
- Layer-1 (deterministic, free, no ``claude`` run): each check calls the real
+ Layer-1 (deterministic, model-free, no ``claude`` run): each check calls the
+ real
  function for a recurring failure class (branch-currency §940, the
  bare-reference gate, the substrate-merge and maker≠checker floors, the
  pid-anchored loop lease, the migration-graph leaf count) on a must-block and
@@ -1812,7 +1814,7 @@ Usage: t3 eval skill-command-validity [OPTIONS]
  Validate every backticked ``t3 …`` in the repo docs against the live CLI
  registry.
 
- Tier-1 (deterministic, free, no ``claude`` run): the backticked ``t3 …``
+ Tier-1 (deterministic, model-free, no ``claude`` run): the backticked ``t3 …``
  commands in the skills tree, the ``agents/*.md`` role briefs, ``BLUEPRINT.md``
  and ``docs/`` are token-walked against the live typer command tree. A leading
  ``t3 <overlay>`` is resolved to a representative overlay so an overlay-scoped
@@ -1834,7 +1836,8 @@ Usage: t3 eval reachability [OPTIONS]
 
  Report scenario/fixture ``t3 …`` invocations that name no live CLI command.
 
- Tier-1 (deterministic, free, no ``claude`` run): each scenario YAML and each
+ Tier-1 (deterministic, model-free, no ``claude`` run): each scenario YAML and
+ each
  ``_pass``/``_fail`` transcript fixture is scanned for ``t3 …`` runs, which are
  token-walked against the live typer command tree. A reference that resolves to
  nothing grades a path the product cannot take. ADVISORY by default (the
@@ -2405,9 +2408,9 @@ Usage: t3 eval run [OPTIONS] [NAME]
 │                                                     exits non-zero. Distinct │
 │                                                     from an absolute         │
 │                                                     ceiling: a zero-cost     │
-│                                                     (subscription/free)      │
-│                                                     baseline is skipped,     │
-│                                                     never divided by.        │
+│                                                     (subscription) baseline  │
+│                                                     is skipped, never        │
+│                                                     divided by.              │
 │ --cost-regression-tole…                    FLOAT    Relative per-scenario    │
 │                                                     cost rise                │
 │                                                     --gate-cost-regression   │
@@ -2808,9 +2811,9 @@ Usage: t3 eval ci-account switch [OPTIONS]
 │                               [default: souliane/teatree]                    │
 │ --json                        Emit the report as JSON.                       │
 │ --starting-in        INTEGER  Minutes until the run starts. A 5h window that │
-│                               resets before then counts as fully free, so an │
-│                               account can be scored for a run scheduled      │
-│                               after its reset.                               │
+│                               resets before then counts as fully available,  │
+│                               so an account can be scored for a run          │
+│                               scheduled after its reset.                     │
 │                               [default: 0]                                   │
 │ --dry-run                     Report the switch without writing anything.    │
 │ --help                        Show this message and exit.                    │
@@ -2889,10 +2892,10 @@ Usage: t3 eval corpus grade [OPTIONS] [ENTRY_ID]
 │                                          shipped corpus).                    │
 │ --judge           --no-judge             Grade judge-oracle entries with the │
 │                                          LLM judge (metered). The --no-judge │
-│                                          default is free and deterministic:  │
-│                                          judge entries SKIP with a note;     │
-│                                          `both` entries grade their matcher  │
-│                                          part.                               │
+│                                          default is model-free and           │
+│                                          deterministic: judge entries SKIP   │
+│                                          with a note; `both` entries grade   │
+│                                          their matcher part.                 │
 │                                          [default: no-judge]                 │
 │ --judge-budget                  INTEGER  Max LLM-judge calls per run (cost   │
 │                                          cap).                               │

--- a/docs/generated/skills-catalogue.json
+++ b/docs/generated/skills-catalogue.json
@@ -90,7 +90,7 @@
     },
     {
       "name": "running-evals",
-      "summary": "Single in-session entrypoint that auto-orchestrates the whole eval picture \u2014 free deterministic lanes (the eval-coverage gate `t3 eval coverage`, pinned-regressions) plus the transcript AI/trajectory lane (prepare \u2192 produce transcripts in-session \u2192 grade) \u2014 and prints one unified results table"
+      "summary": "Single in-session entrypoint that auto-orchestrates the whole eval picture \u2014 model-free deterministic lanes (the eval-coverage gate `t3 eval coverage`, pinned-regressions) plus the transcript AI/trajectory lane (prepare \u2192 produce transcripts in-session \u2192 grade) \u2014 and prints one unified results table"
     },
     {
       "name": "scanning-news",

--- a/docs/generated/skills-catalogue.md
+++ b/docs/generated/skills-catalogue.md
@@ -26,7 +26,7 @@ Source: `skills/*/SKILL.md` frontmatter
 | `review` | Code review — self-review before finalization, giving review, receiving review feedback |
 | `review-request` | Batch review requests — discover open PRs, validate metadata, check for duplicates, post to review channels |
 | `rules` | Cross-cutting agent safety rules — clickable refs, temp files, sub-agent limits, UX preservation. Auto-loaded as a dependency by other skills |
-| `running-evals` | Single in-session entrypoint that auto-orchestrates the whole eval picture — free deterministic lanes (the eval-coverage gate `t3 eval coverage`, pinned-regressions) plus the transcript AI/trajectory lane (prepare → produce transcripts in-session → grade) — and prints one unified results table |
+| `running-evals` | Single in-session entrypoint that auto-orchestrates the whole eval picture — model-free deterministic lanes (the eval-coverage gate `t3 eval coverage`, pinned-regressions) plus the transcript AI/trajectory lane (prepare → produce transcripts in-session → grade) — and prints one unified results table |
 | `scanning-news` | Scans today's TLDR AI and The Rundown AI editions for ideas that could improve teatree, fetches the full article for promising items, and hands each concrete t3-improvement candidate back through the result envelope's article_suggestions field. The loop queues each behind the ask-gate (PendingArticleSuggestion) for per-article user approval before any souliane/teatree issue is filed, and DMs the batch to the user |
 | `setup` | Bootstrap and validate teatree for local use — prerequisites, config, skill symlinks, optional agent hooks, and Django project scaffolding |
 | `ship` | Delivery — committing, pushing, creating MR/PR, pipeline monitoring, review requests |

--- a/docs/testing-skill-evals.md
+++ b/docs/testing-skill-evals.md
@@ -1,6 +1,6 @@
 # Testing skill evals
 
-A **test** checks what a function *returns* (deterministic, free, runs every
+A **test** checks what a function *returns* (deterministic, model-free, runs every
 commit). An **eval** checks what an *agent does* when it loads a skill — given a
 prompt, does it call the right tools, in the right order, and say the right
 thing? Skills carry behavior, so they need behavioral tests. That is an eval.
@@ -27,7 +27,7 @@ Overlays ship their own scenarios from the directory returned by
 ## A scenario, end to end
 
 A scenario is two *separate* AI steps — keeping them apart is what makes
-re-grading free and lets cheap checks gate every PR.
+re-grading model-free and lets cheap checks gate every PR.
 
 1. **RUN** — a fresh agent is given only the scenario `prompt`, run once **with
    the skill** loaded as its system prompt and once at a neutral **baseline** (no
@@ -39,7 +39,7 @@ re-grading free and lets cheap checks gate every PR.
 
 2. **GRADE** — a separate step reads the recorded transcript and decides
    PASS/FAIL. It never re-runs the task. Two mechanisms:
-   - **Matchers** (no model, free, instant) for crisp criteria: `tool_call`
+   - **Matchers** (no model, instant) for crisp criteria: `tool_call`
      present, `no_tool_call_matching` absent, `any_of`, `final_state`.
    - **LLM judge** (a second model call) only for fuzzy criteria a matcher can't
      express (tone, faithfulness). Prefer matchers; reach for a judge last.
@@ -98,7 +98,7 @@ negative; only `_pass` is GREEN.
 
 | Lane | What it does | Cost | When |
 |------|-------------|------|------|
-| **matchers** | GRADE a transcript, no model | free | every PR |
+| **matchers** | GRADE a transcript, no model | model-free | every PR |
 | **transcript** (default) | REUSE an already-recorded RUN, then GRADE | $0 extra | in-session via `/t3:running-evals` |
 | **api** | RUN the model fresh, then GRADE | on the `agent_harness_provider` credential (default subscription OAuth) | weekly CI + explicit `t3 eval run` |
 
@@ -123,8 +123,8 @@ nothing. The `api` lane never runs silently; it runs only when passed explicitly
 ## How to run
 
 ```bash
-t3 eval --free-only    # fast pre-push gate: free deterministic lanes only
-t3 eval                # whole suite: free lanes + grade recorded transcripts
+t3 eval --model-free   # fast pre-push gate: model-free deterministic lanes only
+t3 eval                # whole suite: model-free lanes + grade recorded transcripts
 t3 eval list           # discovered scenarios
 t3 eval coverage       # per-skill covered / exempt / gap (--fail-on-gap to enforce)
 ```
@@ -145,7 +145,7 @@ green with zero coverage.
 
 ## What CI does
 
-- **Free lanes — every PR.** `pinned-regressions` (prek hook)
+- **Model-free lanes — every PR.** `pinned-regressions` (prek hook)
   - `skill-coverage` (pytest). `t3 tool verify-gates` runs the same set locally.
 - **Fresh-run lane — weekly + on demand.** A standalone workflow
   ([`eval.yml`](https://github.com/souliane/teatree/blob/main/.github/workflows/eval.yml)), off the PR path: weekly cron +

--- a/evals/README.md
+++ b/evals/README.md
@@ -15,7 +15,7 @@ one umbrella CLI (`t3 eval …`):
   **cadence** (weekly cron + manual dispatch), fail-loud via `--require-executed`
   / judge-metered / count-floor. This is the `--backend api` AI lane, the
   `--judge` / `judge:` oracles, `benchmark`, and the advisory `skill-prose-judge`.
-- **tests** — deterministic, no live model, free, run **every commit** (pytest +
+- **tests** — deterministic, no live model, run **every commit** (pytest +
   prek): pinned-regressions, skill-command-validity, coverage,
   negative-control, transcript-replay, corpus-grade, plus the **replay** of the
   committed `evals/scenarios/*.yaml` against their `_{pass,fail,noop}` fixtures.
@@ -88,9 +88,9 @@ installed editable from a clone; the eval harness ships inside it.
 
 ### How it runs
 
-- **Free / deterministic lanes — host (the default).** `t3 eval` / `t3 eval
-  --free-only` run directly on the host — no container, no setup. The free
-  lanes spawn no agent, so they are host-default for every local invocation.
+- **Model-free / deterministic lanes — host (the default).** `t3 eval` / `t3 eval
+  --model-free` run directly on the host — no container, no setup. The
+  model-free lanes spawn no agent, so they are host-default for every local invocation.
 - **Fresh-run lane + benchmark — DOCKER is the default.** `t3 eval run --backend
   api` and `t3 eval benchmark` run IN the CI image (`dev/Dockerfile.test`, the
   exact image the CI test job builds, which ships the `claude` CLI) **by
@@ -161,7 +161,7 @@ installed editable from a clone; the eval harness ships inside it.
 ```bash
 t3 eval                                      # THE DEFAULT: run the WHOLE suite (all lanes) in one summary table — no subcommand, no args
 t3 eval list                                # show available scenarios as a rich table
-t3 eval --free-only                           # the free deterministic lanes only (no AI lane)
+t3 eval --model-free                           # the model-free deterministic lanes only (no AI lane)
 t3 eval --docker                              # run the gate inside the CI image (dev/Dockerfile.test) for parity
 t3 eval run --backend api                       # fresh-run Agent-SDK lane — DEFAULTS to the container (dev/Dockerfile.test), authed on the agent_harness_provider credential (DEFAULT subscription OAuth; --credential api_key for a metered run)
 t3 eval benchmark --models opus@xhigh,sonnet@medium  # cost/pass-rate compare — DEFAULTS to the container; --local for a host check
@@ -198,7 +198,7 @@ t3 eval negative-control                      # harness self-test: plant a viola
 t3 eval negative-control --format json        # JSON: caught / violated_rule / offending_tool_call
 t3 eval corpus list                           # ground-truth corpus entries (id, oracle, confidence, axis, expected, labeller)
 t3 eval corpus show <entry_id>                # one label in full + a privacy-safe session summary (counts only)
-t3 eval corpus grade                          # grade every entry (--no-judge default: free; judge-oracle entries skip); FAIL exits non-zero
+t3 eval corpus grade                          # grade every entry (--no-judge default: model-free; judge-oracle entries skip); FAIL exits non-zero
 t3 eval corpus grade <entry_id> --judge       # grade one entry incl. its LLM-judge oracle (metered)
 t3 eval audit                                 # conversation-audit the recent sessions into the ledger (--limit N, --session <id>)
 t3 eval audit --confusion <axis>              # …then render the confusion matrix for one outcome axis (--json for machine form)
@@ -241,7 +241,7 @@ JSON `ci-status` downloads — so the shard fan-out is invisible to the heal loo
 The deterministic regression lane is wired into prek under its explicit name:
 `eval-pinned-regressions` runs at the **pre-push** stage (real git/FSM work) —
 token-free, no model, no spec discovery. It fails the push on a real
-deterministic violation. The full free-lane summary (`t3 eval --free-only`) —
+deterministic violation. The full model-free-lane summary (`t3 eval --model-free`) —
 which also folds in the warn-first skill-coverage lane, negative-control, and the
 SKIP-when-out-of-scope transcript-replay lane — stays runnable on demand. Run the
 prek lane on demand with:
@@ -263,7 +263,7 @@ metered `ANTHROPIC_API_KEY` selectable per run via `--credential api_key`.
 | `transcript` (default) | $0 extra (reuses a recorded run) | local / manual | grades an already-recorded `<scenario>.jsonl` transcript off disk — runs no model |
 | `sdk` | subscription-covered by default (NOT API-billed; the metered `api_key` selectable) | CI (standalone `eval.yml`) + local `--backend api` (DEFAULTS to the container) | RUNS the model fresh in-process via the Agent SDK + grades the run, in a container by default (`--local` for durable-history gates / host checks) |
 
-The free, no-model commands — `pinned-regressions` and
+The model-free commands — `pinned-regressions` and
 `transcript-replay` — never invoke any model and are unaffected by the backend.
 
 ### Token cost — the per-scenario system prompt (`agent_sections`)
@@ -476,13 +476,13 @@ wall-clock lever only — it does not change token cost.
 prints a single aggregated summary table — the command to reach for by default.
 Arguments and subcommands are the *targeted/special* path: `run` (a single AI
 scenario, the fresh-run `--backend api` path — Docker-default), `pinned-regressions` /
-`negative-control` / `coverage` (one free lane in isolation),
+`negative-control` / `coverage` (one model-free lane in isolation),
 `history` / `list` / `prepare-transcript` (introspection). The bare default
-accepts `--free-only`, `--backend`, `--transcript-dir`, `--docker`, `--strict`,
+accepts `--model-free`, `--backend`, `--transcript-dir`, `--docker`, `--strict`,
 `--parallel`. The process exits non-zero if ANY lane fails (fail-loud); a SKIP
 never counts as a green pass.
 
-It runs every lane in one summary table: the six free deterministic lanes
+It runs every lane in one summary table: the six model-free deterministic lanes
 (`skill-coverage`, `pinned-regressions`, `negative-control`,
 `transcript-replay`, `corpus-grade`, `skill-command-validity`) plus the AI lane.
 `skill-coverage` is warn-first (reports a gap, exit 0). The AI lane never runs a
@@ -494,7 +494,7 @@ transcript SKIPs (never FAILs) the transcript-replay lane. Driver:
 
 A fresh-run suite (`--backend api`, the AI lane + the live prose-judge) runs a
 model, so it DEFAULTS to running inside the CI container (`dev/Dockerfile.test`) —
-exactly like `t3 eval run` / `t3 eval benchmark`. `--free-only` runs only the
+exactly like `t3 eval run` / `t3 eval benchmark`. `--model-free` runs only the
 host-safe deterministic lanes (no model) and stays on the host.
 
 `--trials`/`--models` require the fresh-run `sdk` runner (a multi-trial / matrix
@@ -679,7 +679,7 @@ whose cost rose by more than `--cost-regression-tolerance` (relative drift,
 default `0.20` = +20%) prints a `COST REGRESSED` line and exits non-zero. This
 is *relative drift*, distinct from the absolute `--max-budget-usd` ceiling: a
 scenario can stay under the absolute cap while still doubling its cost vs the
-baseline. A `$0` baseline scenario (subscription/free — no metered reference)
+baseline. A `$0` baseline scenario (subscription — no metered reference)
 has undefined relative drift, so the gate no-ops it (never divides by zero) and
 reports "no cost baseline" when no metered baseline exists at all. The gate runs
 in every run shape — single-trial, `--trials` (pass@k, cost summed across
@@ -896,7 +896,7 @@ no `expect:` (judge-only) or alongside matchers (both must pass).
 
 ### Pinned-regressions corpus (real gate/checker code paths)
 
-`t3 eval pinned-regressions` is a Layer-1 (deterministic, free, no `claude` run)
+`t3 eval pinned-regressions` is a Layer-1 (deterministic, model-free, no `claude` run)
 **test**. Where a scenario grades what an agent *says* it
 would do, the pinned-regressions corpus (`regression_corpus.py`) grades what the gate/checker
 code *does*: each `RegressionCheck` calls the **real** function for a recurring
@@ -917,7 +917,7 @@ code path still honors the invariant — then add the matching anti-vacuous test
 
 ### Skill-command-validity (#550 Tier-1 — stale `t3 …` references)
 
-`t3 eval skill-command-validity` is a Layer-1 (deterministic, free, no `claude`
+`t3 eval skill-command-validity` is a Layer-1 (deterministic, model-free, no `claude`
 run) **test** — a sibling of pinned-regressions. It
 grades the repo's prose *docs* themselves: every backticked `t3 …` command a
 doc in `DOC_GLOBS` cites — `skills/<name>/SKILL.md` and its nested `*.md`
@@ -943,7 +943,7 @@ resolve) and injects it. The parse + token-walk logic is the single chokepoint
 the doc-prose static-invocation pytest gate (`tests/test_skill_t3_invocations.py`)
 also consumes, so the regex and placeholder rules live in exactly one place. A
 generic placeholder mention (`t3 …` / `t3 <overlay> …`) names no concrete
-command and is skipped — never drift. It runs as a free lane in every `t3 eval
+command and is skipped — never drift. It runs as a model-free lane in every `t3 eval
 all` run.
 
 ### Skill-prose-judge (#550 Tier-3 — model-judged, ADVISORY)
@@ -977,7 +977,7 @@ path drives it for real.
   `tests/eval_replay/test_regression_corpus.py` in the normal pytest gate on every
   PR, and the scenario anti-vacuous matchers are pinned by
   `tests/eval_replay/test_scenarios_anti_vacuous.py` / `tests/teatree_cli/
-  test_eval.py`. The deterministic, free layers therefore guard every PR
+  test_eval.py`. The deterministic, model-free layers therefore guard every PR
   through pytest — only the paid Agent-SDK scenario *run* is weekly.
 - **Weekly, in a standalone workflow (decoupled from PRs).** CI runs the paid
   scenario suite once a week on a cron — not on every push, not on every PR, and
@@ -997,16 +997,16 @@ path drives it for real.
 
 This table is the single source of truth for which lanes exist, how they run, and when. Other docs point here rather than repeating it.
 
-**Kind** is the binding split: a **test** is deterministic and model-free — it runs every commit, for free; an **eval** drives a live model + grader — it is metered, runs on a cadence, and fails loud. The `t3 eval …` command surface is the shared umbrella across both.
+**Kind** is the binding split: a **test** is deterministic and model-free — it runs every commit; an **eval** drives a live model + grader — it is metered, runs on a cadence, and fails loud. The `t3 eval …` command surface is the shared umbrella across both.
 
 | Lane | Kind | Cost | Host / Docker | Local invocation | CI | Cadence |
 |---|---|---|---|---|---|---|
-| pinned-regressions | **test** | free | host | `t3 eval pinned-regressions` | pytest (`test_regression_corpus.py`) | push (prek `eval-pinned-regressions`) + every PR |
-| skill-coverage | **test** | free | host | `t3 eval coverage` | — (warn-first, not in CI standalone) | on demand |
-| negative-control | **test** | free | host | `t3 eval negative-control` | — | on demand |
-| transcript-replay | **test** | free | host | `t3 eval transcript-replay` | — (SKIPs when no session transcript in scope) | on demand |
-| corpus-grade | **test** | free | host | `t3 eval corpus grade` (`--no-judge` default; judge-oracle entries skip) | pytest (`tests/teatree_cli/eval/test_corpus.py`) | every bare-`t3 eval` run + on demand |
-| skill-command-validity | **test** | free | host | `t3 eval skill-command-validity` | pytest (`tests/teatree_cli/eval/test_skill_command_lane.py`, `tests/test_skill_t3_invocations.py`) | every bare-`t3 eval` run + on demand |
+| pinned-regressions | **test** | model-free | host | `t3 eval pinned-regressions` | pytest (`test_regression_corpus.py`) | push (prek `eval-pinned-regressions`) + every PR |
+| skill-coverage | **test** | model-free | host | `t3 eval coverage` | — (warn-first, not in CI standalone) | on demand |
+| negative-control | **test** | model-free | host | `t3 eval negative-control` | — | on demand |
+| transcript-replay | **test** | model-free | host | `t3 eval transcript-replay` | — (SKIPs when no session transcript in scope) | on demand |
+| corpus-grade | **test** | model-free | host | `t3 eval corpus grade` (`--no-judge` default; judge-oracle entries skip) | pytest (`tests/teatree_cli/eval/test_corpus.py`) | every bare-`t3 eval` run + on demand |
+| skill-command-validity | **test** | model-free | host | `t3 eval skill-command-validity` | pytest (`tests/teatree_cli/eval/test_skill_command_lane.py`, `tests/test_skill_t3_invocations.py`) | every bare-`t3 eval` run + on demand |
 | ai-eval transcript | **test** (replay) | $0 extra (reuses a recorded run) | host | `t3 eval run` (default backend) | — (grades a saved transcript off disk; the in-session capture that produces it is the live step) | manual / on demand |
 | ai-eval sdk | **eval** | `agent_harness_provider`-selected — DEFAULT subscription OAuth (no per-token bill); the metered `api_key` selectable | **docker** (the DEFAULT locally; CI image in `eval.yml`) | `t3 eval run --backend api` | `.github/workflows/eval.yml` (`CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` secrets, `--docker`) | weekly cron (Mon 06:00 UTC, skips when no PRs merged) + manual `workflow_dispatch` |
 | `--judge` / `judge:` oracle | **eval** | subscription-covered (judge) | host/docker (with the api lane) | `t3 eval run --judge` / `corpus grade --judge` | metered path only (fail-loud: judge-metered guard) | metered path + on demand |
@@ -1089,7 +1089,7 @@ The per-skill coverage map is **generated, not hand-maintained** — run
 (from the core catalog or an overlay dir), or **exempt** when its frontmatter
 carries a non-empty `eval_exempt: <reason>` (pure-doc / methodology skills). A skill that is neither
 is a **gap**. `coverage.py` (`skill_eval_coverage`) is a pure function over
-`discover_specs()` + frontmatter — deterministic, free, no model.
+`discover_specs()` + frontmatter — deterministic, model-free, no model.
 
 The gate is general and declarative: a new `skills/<name>/` with no eval and no
 `eval_exempt` trips it by default, and a new skill is covered-or-exempt with a
@@ -1230,9 +1230,9 @@ readers/writers over the committed engine modules (`corpus_loader`,
 - `t3 eval corpus grade [<entry_id>]` — grade captured sessions against their
   labels through `corpus_grade.grade`, with `assert_independent_oracle`
   enforced (a circular matcher oracle is a FAIL row). The `--no-judge` default
-  is free and deterministic: judge-oracle entries SKIP with a note; `both`
+  is model-free and deterministic: judge-oracle entries SKIP with a note; `both`
   entries grade their matcher part. Any FAIL exits non-zero. This deterministic
-  form also runs as the free `corpus-grade` lane inside bare `t3 eval`.
+  form also runs as the model-free `corpus-grade` lane inside bare `t3 eval`.
 - `t3 eval audit` — run the #1861 conversation-audit engine over recent on-disk
   sessions (`--limit N`, `--session <id>`), persist one `SessionAuditRecord`
   per session, and print the per-session verdict table + nominated count.
@@ -1554,8 +1554,8 @@ Behavioral rules fall into two layers:
   "stakeholder messages avoid code jargon"), a YAML+JSONL scenario
   captures the captured tool-call shape and applies matchers.
 
-Prefer Layer 1 every time it applies — code-level tests run in CI for
-free; eval scenarios require a paid Claude run. Layer 2 is for what
+Prefer Layer 1 every time it applies — code-level tests run in CI with no
+model call; eval scenarios require a paid Claude run. Layer 2 is for what
 Layer 1 cannot reach.
 
 ## Transcript-replay conformance (the other half)
@@ -1687,7 +1687,7 @@ agent editing the canonical clone without `git worktree add` first), drives it
 through the *public* report path, and exits 0 only when the harness reports the
 violation — naming the violated rule and the offending tool call. It is
 token-free and deterministic (it never drives the Agent SDK), so it runs as one of
-the free lanes `t3 eval --free-only` gates on. A non-zero
+the model-free lanes `t3 eval --model-free` gates on. A non-zero
 exit means the harness went green on a genuine violation, i.e. the harness
 itself is broken.
 

--- a/skills/running-evals/SKILL.md
+++ b/skills/running-evals/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: running-evals
-description: Single in-session entrypoint that auto-orchestrates the whole eval picture — free deterministic lanes (the eval-coverage gate `t3 eval coverage`, pinned-regressions) plus the transcript AI/trajectory lane (prepare → produce transcripts in-session → grade) — and prints one unified results table. Use when running the full eval suite, producing recorded transcripts, or deciding between `t3 eval run` (AI evals) and `t3 teatree run tests` (deterministic tests).
+description: Single in-session entrypoint that auto-orchestrates the whole eval picture — model-free deterministic lanes (the eval-coverage gate `t3 eval coverage`, pinned-regressions) plus the transcript AI/trajectory lane (prepare → produce transcripts in-session → grade) — and prints one unified results table. Use when running the full eval suite, producing recorded transcripts, or deciding between `t3 eval run` (AI evals) and `t3 teatree run tests` (deterministic tests).
 eval_exempt: in-session driver for the eval harness itself; its commands are covered by the eval CLI tests, not by a self-referential behavioural eval
 compatibility: any
 metadata:
@@ -18,18 +18,18 @@ Running the full eval picture by hand takes several easy-to-forget commands, and
 
 | term | what it is | command | determinism |
 |------|-----------|---------|-------------|
-| **test** | unit / integration code test | `t3 teatree run tests` | deterministic, free |
+| **test** | unit / integration code test | `t3 teatree run tests` | deterministic, model-free |
 | **eval** | AI / trajectory eval (agent behaviour) | `t3 eval run` | non-deterministic (model) |
 
 The CLI mirror is **noun-first**: deterministic tests run under the overlay's `t3 teatree run tests` (a future top-level "t3 test run" form is owned by the separate CLI-simplification audit), AI evals are `t3 eval run`. There is intentionally no "t3 run evals" group — `t3 eval run` is canonical. When in doubt: "eval" grades what the agent *did* on a prompt; "test" asserts what a function *returns*.
 
 ## Cost split (never silently meter)
 
-Two buckets under one umbrella. The free deterministic lanes are **tests** — they assert code/config behaviour with fixed I/O, no live model, every commit. The metered lanes are genuine **evals** — they judge a live model's behaviour on a cadence. The `t3 eval …` command surface is shared; the split is about what each lane *is*.
+Two buckets under one umbrella. The model-free deterministic lanes are **tests** — they assert code/config behaviour with fixed I/O, no live model, every commit. The metered lanes are genuine **evals** — they judge a live model's behaviour on a cadence. The `t3 eval …` command surface is shared; the split is about what each lane *is*.
 
 | kind | lane | command surface | cost |
 |------|------|-----------------|------|
-| **test** (deterministic, no model) | pinned-regressions (regression corpus) | `t3 eval pinned-regressions` | free |
+| **test** (deterministic, no model) | pinned-regressions (regression corpus) | `t3 eval pinned-regressions` | model-free |
 | **eval** (fresh model run) | AI/trajectory (api, CI cadence) | `t3 eval run --backend api` | on the `agent_harness_provider` credential — default subscription OAuth (right-sized CI lane), metered `ANTHROPIC_API_KEY` selectable via `--credential api_key` |
 
 The default backend is `transcript` — it REUSES an already-recorded run by grading its on-disk transcript ($0 extra, no model run); the in-session step this skill drives produces that transcript (`prepare-transcript` → dispatch sub-agent → `capture-subagent` → `run --backend transcript`). The `--backend api` path RUNS the model fresh on the credential `agent_harness_provider` selects — DEFAULT the subscription OAuth token (no per-token bill, so the CI lane is right-sized — single effort tier, smaller trial count, per-account OAuth routing — to stay inside the plan's usage window), with the metered `ANTHROPIC_API_KEY` selectable per run via `--credential api_key`. It is **never** a silent fallback — the `api` backend runs only when passed explicitly (CI's cadence). The `transcript` backend runs no model, so it authenticates nothing.
@@ -44,7 +44,7 @@ In ONE invocation, without the human running `prepare-transcript` or `capture-su
 4. `t3 eval run --backend transcript` to grade the captured transcripts.
 5. Print ONE unified results table.
 
-The free deterministic lane (`t3 eval pinned-regressions`) — deterministic tests, no model — runs alongside. Only steps 2–3 — producing and capturing the recorded transcripts — need this in-session skill; bare `t3 eval` (below) folds in everything else.
+The model-free deterministic lane (`t3 eval pinned-regressions`) — deterministic tests, no model — runs alongside. Only steps 2–3 — producing and capturing the recorded transcripts — need this in-session skill; bare `t3 eval` (below) folds in everything else.
 
 The captured transcript is the on-disk session schema (`isSidechain`/`agentId`, no `result` event, terminus via the final assistant `stop_reason`). The `transcript` backend auto-detects it and grades on matchers identically to a stream-json transcript — capture and grade read on-disk files only, so the lane runs no model.
 
@@ -52,7 +52,7 @@ The captured transcript is the on-disk session schema (`isSidechain`/`agentId`, 
 
 ```bash
 # THE DEFAULT: bare `t3 eval` (no subcommand, no args) runs the WHOLE suite —
-# free deterministic lanes + AI lane — in one unified summary table.
+# model-free deterministic lanes + AI lane — in one unified summary table.
 # Grades recorded transcripts when present in the transcript dir;
 # with none, emits the manifest + this skill's recipe — never runs a model.
 t3 eval
@@ -62,12 +62,12 @@ t3 eval --transcript-dir ./transcripts
 t3 eval --backend api
 ```
 
-Bare `t3 eval` runs the FREE lanes, then for the AI lane grades recorded transcripts when they exist ($0 extra), otherwise emits the transcript manifest plus the "produce transcripts in-session — see /t3:running-evals" guidance. It NEVER silently falls back to running a model. This skill is the in-session entrypoint that produces the transcripts the suite then grades; subcommands (`run`, a single lane, `history`, `list`) stay the targeted path and are unchanged.
+Bare `t3 eval` runs the MODEL-FREE lanes, then for the AI lane grades recorded transcripts when they exist ($0 extra), otherwise emits the transcript manifest plus the "produce transcripts in-session — see /t3:running-evals" guidance. It NEVER silently falls back to running a model. This skill is the in-session entrypoint that produces the transcripts the suite then grades; subcommands (`run`, a single lane, `history`, `list`) stay the targeted path and are unchanged.
 
 ## CLI surface
 
 ```bash
-# Free deterministic lanes (no model spend).
+# Model-free deterministic lanes (no model spend).
 t3 eval coverage          # per-skill eval coverage: covered / eval_exempt / gap (warn-first)
 t3 eval pinned-regressions
 

--- a/src/teatree/cli/eval/all.py
+++ b/src/teatree/cli/eval/all.py
@@ -1,6 +1,6 @@
 """``t3 eval list`` table render + bare-``t3 eval`` full-suite lane orchestration.
 
-The six free deterministic lanes (skill-coverage, pinned-regressions,
+The six model-free deterministic lanes (skill-coverage, pinned-regressions,
 negative-control, transcript-replay, corpus-grade, skill-command-validity) always run;
 skill-coverage is warn-first (reports a gap, never FAILs in Phase A), transcript-replay
 surfaces as a SKIP when no real session transcript is in scope (never a FAIL), corpus-grade
@@ -96,7 +96,7 @@ def regression_lane(report: RegressionReport) -> LaneResult:
     detail = f"{len(report.results)} checks, {len(report.failures)} failed, {skipped} skipped"
     return LaneResult(
         name="pinned-regressions",
-        cost="free",
+        cost="model-free",
         passed=report.ok,
         skipped=False,
         detail=detail,
@@ -111,14 +111,14 @@ def coverage_lane(report: CoverageReport) -> LaneResult:
         if report.gaps
         else f"{len(report.rows)} skills, all covered or eval_exempt"
     )
-    return LaneResult(name="skill-coverage", cost="free", passed=True, skipped=False, detail=detail)
+    return LaneResult(name="skill-coverage", cost="model-free", passed=True, skipped=False, detail=detail)
 
 
 def negative_control_lane(outcome: NegativeControlOutcome) -> LaneResult:
     detail = "harness caught the planted violation" if outcome.caught else "harness MISSED the planted violation"
     return LaneResult(
         name="negative-control",
-        cost="free",
+        cost="model-free",
         passed=outcome.caught,
         skipped=False,
         detail=detail,
@@ -129,7 +129,7 @@ def transcript_replay_lane(results: list[InvariantResult] | None) -> LaneResult:
     if results is None:
         return LaneResult(
             name="transcript-replay",
-            cost="free",
+            cost="model-free",
             passed=True,
             skipped=True,
             detail="no session transcript in scope",
@@ -137,7 +137,7 @@ def transcript_replay_lane(results: list[InvariantResult] | None) -> LaneResult:
     failed = sum(1 for result in results if not result.ok)
     return LaneResult(
         name="transcript-replay",
-        cost="free",
+        cost="model-free",
         passed=failed == 0,
         skipped=False,
         detail=f"{len(results)} invariants, {failed} violated",
@@ -266,13 +266,13 @@ def build_summary_table(lanes: Iterable[LaneResult]) -> Table:
 
 
 def _full_suite_docker_passthrough(
-    *, backend: str, free_only: bool, strict: bool, parallel: int = DEFAULT_PARALLEL
+    *, backend: str, model_free: bool, strict: bool, parallel: int = DEFAULT_PARALLEL
 ) -> list[str]:
     # The bare `t3 eval` callback IS the full suite (no subcommand), so the
     # in-container re-invocation passes only the flags — `all` was removed.
     passthrough: list[str] = []
-    if free_only:
-        passthrough.append("--free-only")
+    if model_free:
+        passthrough.append("--model-free")
     if backend != TRANSCRIPT_BACKEND:
         passthrough += ["--backend", backend]
     if strict:
@@ -303,14 +303,14 @@ def run_full_suite(  # noqa: PLR0913 — the single eval-suite chokepoint: each 
     *,
     backend: str,
     transcript_dir: Path | None,
-    free_only: bool,
+    model_free: bool,
     docker: bool,
     strict: bool,
     parallel: int = DEFAULT_PARALLEL,
 ) -> None:
     """The single eval-suite chokepoint: run every lane and render one summary.
 
-    The bare ``t3 eval`` default calls this. The six free deterministic lanes
+    The bare ``t3 eval`` default calls this. The six model-free deterministic lanes
     (skill-coverage, pinned-regressions, negative-control,
     transcript-replay, corpus-grade, skill-command-validity) always run;
     skill-coverage is warn-first, transcript-replay SKIPs when no real session
@@ -333,13 +333,13 @@ def run_full_suite(  # noqa: PLR0913 — the single eval-suite chokepoint: each 
     """
     # The fresh-run SDK AI lane + the live prose-judge run a model, so the whole
     # suite defaults to the CI container when they are in scope (`--backend api`,
-    # not `--free-only`) — exactly like `eval run` / `eval benchmark`. `--docker`
-    # forces the container for any backend; `--free-only` runs only the host-safe
+    # not `--model-free`) — exactly like `eval run` / `eval benchmark`. `--docker`
+    # forces the container for any backend; `--model-free` runs only the host-safe
     # deterministic lanes, so it never runs a model.
-    metered = backend != TRANSCRIPT_BACKEND and not free_only
+    metered = backend != TRANSCRIPT_BACKEND and not model_free
     if docker or should_route_to_docker(metered=metered, local=False):
         passthrough = _full_suite_docker_passthrough(
-            backend=backend, free_only=free_only, strict=strict, parallel=parallel
+            backend=backend, model_free=model_free, strict=strict, parallel=parallel
         )
         try:
             raise typer.Exit(code=run_eval_in_docker(passthrough))
@@ -357,7 +357,7 @@ def run_full_suite(  # noqa: PLR0913 — the single eval-suite chokepoint: each 
         _timed(lambda: skill_command_validity_lane(validate_shipped_skill_commands())),
     ]
     ai_results: list[ScenarioResult] = []
-    if not free_only:
+    if not model_free:
         # The AI lane runs first. It is itself backend-gated: the default
         # transcript backend grades on-disk transcripts ($0 extra) and never runs
         # a model, so it is safe on the bare-`t3 eval` path.
@@ -368,8 +368,8 @@ def run_full_suite(  # noqa: PLR0913 — the single eval-suite chokepoint: each 
     if metered:
         # The ADVISORY Tier-3 prose-judge fires the LIVE ClaudeJudge, so it is gated
         # on the explicit fresh-run opt-in (`--backend api`), NOT merely on
-        # `not --free-only` — bare `t3 eval` (default transcript, $0 extra) must
-        # never silently run a model, and `--free-only` drops it.
+        # `not --model-free` — bare `t3 eval` (default transcript, $0 extra) must
+        # never silently run a model, and `--model-free` drops it.
         # skill_prose_judge_lane always returns passed=True, so a low prose score
         # never fails the suite.
         lanes.append(_timed(lambda: skill_prose_judge_lane(run_prose_judge())))

--- a/src/teatree/cli/eval/app.py
+++ b/src/teatree/cli/eval/app.py
@@ -155,7 +155,7 @@ def run(  # noqa: PLR0913, PLR0917 — typer command: each param maps 1:1 to a p
         help=(
             "Diff this run's per-scenario cost against each model's baseline cost; a relative "
             "rise beyond --cost-regression-tolerance exits non-zero. Distinct from an absolute "
-            "ceiling: a zero-cost (subscription/free) baseline is skipped, never divided by."
+            "ceiling: a zero-cost (subscription) baseline is skipped, never divided by."
         ),
     ),
     cost_regression_tolerance: float = typer.Option(

--- a/src/teatree/cli/eval/audit.py
+++ b/src/teatree/cli/eval/audit.py
@@ -7,7 +7,7 @@ ground-truth label when a corpus entry's ``source_session_id`` matches, and
 audited + persisted by
 :func:`teatree.eval.conversation_audit.run_conversation_audit`. ``--confusion
 <axis>`` then renders the categorical grid from the persisted ledger
-(``--json`` for the machine form). Free and deterministic — no judge, no model
+(``--json`` for the machine form). Model-free and deterministic — no judge, no model
 call — and privacy-safe: the table carries ONLY ids, slugs, and categorical
 labels, never a payload.
 """

--- a/src/teatree/cli/eval/ci_account.py
+++ b/src/teatree/cli/eval/ci_account.py
@@ -28,7 +28,7 @@ _STARTING_IN_OPTION = typer.Option(
     "--starting-in",
     help=(
         "Minutes until the run starts. A 5h window that resets before then counts as fully "
-        "free, so an account can be scored for a run scheduled after its reset."
+        "available, so an account can be scored for a run scheduled after its reset."
     ),
 )
 
@@ -83,7 +83,7 @@ def show(*, repo: str = _REPO_OPTION, json_output: bool = _JSON_OPTION) -> None:
     typer.echo(f"active: {active or '(unrecorded — the secret predates account tracking)'}")
     for entry in selection.ranked:
         typer.echo(
-            f"  {entry.account}  5h free {entry.headroom_5h:.0%}  weekly free {entry.headroom_7d:.0%}  "
+            f"  {entry.account}  5h headroom {entry.headroom_5h:.0%}  weekly headroom {entry.headroom_7d:.0%}  "
             f"binding {entry.binding_headroom:.0%}"
         )
     for rejection in selection.rejected:

--- a/src/teatree/cli/eval/corpus.py
+++ b/src/teatree/cli/eval/corpus.py
@@ -4,13 +4,13 @@ Thin readers over the committed corpus engine — the modules own the behaviour
 (:mod:`teatree.eval.corpus_loader` discovers and validates labels,
 :mod:`teatree.eval.corpus_grade` grades a captured session through the same
 ``report.evaluate`` path a scenario uses); the commands here only coordinate.
-``grade`` is free and deterministic under the ``--no-judge`` default: a
+``grade`` is model-free and deterministic under the ``--no-judge`` default: a
 judge-oracle entry SKIPs with a visible note (never a silent vacuous pass) and
 a ``both`` entry grades its matcher part. The anti-circular guard
 (:func:`~teatree.eval.corpus_grade.assert_independent_oracle`) is enforced on
 every graded entry — a circular oracle is a FAIL row, so the grade exit code
 catches it. :func:`grade_shipped_corpus` is the same deterministic body the
-free ``corpus-grade`` lane in ``t3 eval`` runs.
+model-free ``corpus-grade`` lane in ``t3 eval`` runs.
 
 ``show`` is privacy-safe by construction: it prints the label's own committed
 fields plus DERIVED session counts — never a tool input, prompt text, or any
@@ -59,13 +59,13 @@ def grade_corpus_rows(labels: list[CorpusLabel], *, directory: Path, judge: Judg
 
     The anti-circular oracle guard runs first (a circular entry is a FAIL row);
     with no ``judge`` a judge-oracle entry SKIPs and a ``both`` entry grades its
-    matcher part — free and deterministic.
+    matcher part — model-free and deterministic.
     """
     return [_grade_row(label, directory=directory, judge=judge) for label in labels]
 
 
 def grade_shipped_corpus() -> list[CorpusGradeRow]:
-    """Grade the shipped corpus deterministically (no judge) — the free-lane body for ``t3 eval``."""
+    """Grade the shipped corpus deterministically (no judge) — the model-free-lane body for ``t3 eval``."""
     return grade_corpus_rows(discover_corpus(), directory=CORPUS_DIR, judge=None)
 
 
@@ -79,7 +79,7 @@ CORPUS_NO_GRADED_HINT = (
 
 
 def corpus_grade_lane(rows: list[CorpusGradeRow]) -> LaneResult:
-    """Fold graded rows into the free ``corpus-grade`` lane for ``t3 eval``.
+    """Fold graded rows into the model-free ``corpus-grade`` lane for ``t3 eval``.
 
     ``graded == 0`` (every entry judge-skipped, or an empty corpus) is NOT a
     green pass — there is nothing deterministically validated, so a green row
@@ -94,7 +94,7 @@ def corpus_grade_lane(rows: list[CorpusGradeRow]) -> LaneResult:
     if graded == 0:
         return LaneResult(
             name="corpus-grade",
-            cost="free",
+            cost="model-free",
             passed=True,
             skipped=True,
             detail=detail,
@@ -102,7 +102,7 @@ def corpus_grade_lane(rows: list[CorpusGradeRow]) -> LaneResult:
         )
     return LaneResult(
         name="corpus-grade",
-        cost="free",
+        cost="model-free",
         passed=failed == 0,
         skipped=False,
         detail=detail,
@@ -141,7 +141,7 @@ def grade_entries(
         False,
         "--judge/--no-judge",
         help=(
-            "Grade judge-oracle entries with the LLM judge (metered). The --no-judge default is free "
+            "Grade judge-oracle entries with the LLM judge (metered). The --no-judge default is model-free "
             "and deterministic: judge entries SKIP with a note; `both` entries grade their matcher part."
         ),
     ),

--- a/src/teatree/cli/eval/docker.py
+++ b/src/teatree/cli/eval/docker.py
@@ -3,7 +3,7 @@
 Reuses ``dev/Dockerfile.test`` (the image the CI test job builds) so a containerized
 run reproduces CI's environment exactly. The fresh-run AI lane (``t3 eval run
 --backend api``) and ``t3 eval benchmark`` default to running IN the container —
-the reproducible gate must never accidentally run a model on the host. The free /
+the reproducible gate must never accidentally run a model on the host. The model-free /
 deterministic lanes stay host-default; ``--local`` is the explicit host escape
 hatch for durable-history gates or quick checks. No PyPI — the image installs
 the working tree via the mounted repo and ``uv``. The fresh-run lane authenticates
@@ -179,7 +179,7 @@ def run_eval_in_docker(eval_args: list[str], *, artifacts_dir: Path | None = Non
     in-process Agent SDK's ``claude`` child authenticates in-container on the
     selected credential — the run just works without a manual ``export``. That one
     forwarded var is also what the in-container ``make_runner`` reads back to resolve
-    the same kind. The free / transcript lanes never authenticate ``claude``, so the
+    the same kind. The model-free / transcript lanes never authenticate ``claude``, so the
     secret store is not touched for them (empty ``auth_env_vars``).
 
     ``artifacts_dir`` (when set) is bind-mounted WRITABLE at

--- a/src/teatree/cli/eval/full_suite_command.py
+++ b/src/teatree/cli/eval/full_suite_command.py
@@ -35,10 +35,10 @@ def register_full_suite_callback(eval_app: typer.Typer) -> None:
             "--transcript-dir",
             help="Directory of <scenario>.jsonl transcripts for the AI lane (default: cwd).",
         ),
-        free_only: bool = typer.Option(  # noqa: FBT001 — typer boolean flag, not a positional bool foot-gun.
+        model_free: bool = typer.Option(  # noqa: FBT001 — typer boolean flag, not a positional bool foot-gun.
             False,
-            "--free-only",
-            help="Run only the free deterministic lanes (drop the AI lane) — the fast pre-push gate.",
+            "--model-free",
+            help="Run only the model-free deterministic lanes (drop the AI lane) — the fast pre-push gate.",
         ),
         strict: bool = typer.Option(  # noqa: FBT001 — typer boolean flag, not a positional bool foot-gun.
             False,
@@ -71,7 +71,7 @@ def register_full_suite_callback(eval_app: typer.Typer) -> None:
         run_full_suite(
             backend=backend,
             transcript_dir=transcript_dir,
-            free_only=free_only,
+            model_free=model_free,
             docker=docker,
             strict=strict,
             parallel=parallel,

--- a/src/teatree/cli/eval/lanes.py
+++ b/src/teatree/cli/eval/lanes.py
@@ -1,7 +1,7 @@
-"""Deterministic single-lane ``t3 eval`` subcommands (free — no ``claude`` run).
+"""Deterministic single-lane ``t3 eval`` subcommands (model-free — no ``claude`` run).
 
 Held apart from the ``run`` body and the bare-suite callback in
-:mod:`teatree.cli.eval.app`: each is a self-contained free lane that renders one
+:mod:`teatree.cli.eval.app`: each is a self-contained model-free lane that renders one
 report and exits non-zero on a violation, sharing none of the runner/persist/gate
 machinery. Registered onto ``eval_app`` from ``app`` via the same
 ``command(name)(func)`` indirection the other split-out lanes use.
@@ -35,7 +35,7 @@ def coverage(
     via ``agent_path`` (from the ``evals/scenarios/`` catalog or an overlay's
     own dir), or EXEMPT when its frontmatter carries a non-empty ``eval_exempt``
     reason. A skill that is
-    neither is a GAP. Deterministic and free — no ``claude -p`` invocation.
+    neither is a GAP. Deterministic and model-free — no ``claude -p`` invocation.
     Warn-first by default (a gap is reported, exit 0); ``--fail-on-gap`` is the
     Phase-B enforcement that exits non-zero on any gap.
     """
@@ -52,7 +52,7 @@ def pinned_regressions(
 ) -> None:
     """Run the deterministic regression corpus over the real gate/checker code paths.
 
-    Layer-1 (deterministic, free, no ``claude`` run): each check calls the real
+    Layer-1 (deterministic, model-free, no ``claude`` run): each check calls the real
     function for a recurring failure class (branch-currency §940, the
     bare-reference gate, the substrate-merge and maker≠checker floors, the
     pid-anchored loop lease, the migration-graph leaf count) on a must-block and

--- a/src/teatree/cli/eval/metered_routing.py
+++ b/src/teatree/cli/eval/metered_routing.py
@@ -2,7 +2,7 @@
 
 The metered ``api`` lane and ``t3 eval benchmark`` default to running IN the CI
 container (``dev/Dockerfile.test``): a metered run bills the API, so it must
-never accidentally run on the host. The free / deterministic / subscription
+never accidentally run on the host. The model-free / deterministic / subscription
 lanes spawn no agent and stay host-default.
 
 Two predicates break the re-route loop and gate the host escape:
@@ -30,7 +30,7 @@ def should_route_to_docker(*, metered: bool, local: bool) -> bool:
 
     Routes to docker only for a *metered* lane that is NOT already in the
     container and was NOT given the explicit ``--local`` host escape. A
-    non-metered lane (free / deterministic / subscription) is never routed.
+    non-metered lane (model-free / deterministic / subscription) is never routed.
     """
     if not metered:
         return False

--- a/src/teatree/cli/eval/reachability_lane.py
+++ b/src/teatree/cli/eval/reachability_lane.py
@@ -51,7 +51,7 @@ def reachability(
 ) -> None:
     """Report scenario/fixture ``t3 …`` invocations that name no live CLI command.
 
-    Tier-1 (deterministic, free, no ``claude`` run): each scenario YAML and each
+    Tier-1 (deterministic, model-free, no ``claude`` run): each scenario YAML and each
     ``_pass``/``_fail`` transcript fixture is scanned for ``t3 …`` runs, which are
     token-walked against the live typer command tree. A reference that resolves to
     nothing grades a path the product cannot take. ADVISORY by default (the shipped

--- a/src/teatree/cli/eval/run_modes.py
+++ b/src/teatree/cli/eval/run_modes.py
@@ -248,7 +248,7 @@ class RegressionGates:
 
         Returns ``True`` (caller exits non-zero) when any scenario's cost rose by
         more than *tolerance* (relative drift) versus the baseline run. A scenario
-        whose baseline cost is ``0.0`` (subscription/free baseline — no metered
+        whose baseline cost is ``0.0`` (subscription baseline — no metered
         reference) has an undefined relative drift, so it is skipped, never flagged
         and never a divide-by-zero. When no model has a baseline at all, the gate
         reports "no cost baseline" and passes.

--- a/src/teatree/cli/eval/skill_command_lane.py
+++ b/src/teatree/cli/eval/skill_command_lane.py
@@ -1,4 +1,4 @@
-"""``t3 eval skill-command-validity`` — Tier-1 command-validity lane (#550, free).
+"""``t3 eval skill-command-validity`` — Tier-1 command-validity lane (#550, model-free).
 
 The thin CLI surface over the pure :mod:`teatree.eval.skill_command_validity`
 engine. The engine validates SKILL.md ``t3 …`` invocations against an injected
@@ -17,8 +17,8 @@ that builds the registry from its own app. The default provider raises a clear
 error, so a caller that never registered one fails loud rather than silently
 validating against an empty registry.
 
-Free and deterministic — no model, no spend. Wired into ``t3 eval`` (the
-free-lane summary) and exposed as the standalone ``t3 eval skill-command-validity``.
+Model-free and deterministic — no model, no spend. Wired into ``t3 eval`` (the
+model-free-lane summary) and exposed as the standalone ``t3 eval skill-command-validity``.
 """
 
 import sys
@@ -67,7 +67,7 @@ def validate_shipped_skill_commands(repo_root: Path = DEFAULT_REPO_ROOT) -> Comm
 
 
 def skill_command_validity_lane(report: CommandValidityReport) -> LaneResult:
-    """Fold a validity report into the free ``skill-command-validity`` lane for ``t3 eval``."""
+    """Fold a validity report into the model-free ``skill-command-validity`` lane for ``t3 eval``."""
     detail = (
         f"{report.checked} `t3 …` invocation(s) all resolve"
         if report.ok
@@ -75,7 +75,7 @@ def skill_command_validity_lane(report: CommandValidityReport) -> LaneResult:
     )
     return LaneResult(
         name="skill-command-validity",
-        cost="free",
+        cost="model-free",
         passed=report.ok,
         skipped=False,
         detail=detail,
@@ -87,7 +87,7 @@ def skill_command_validity(
 ) -> None:
     """Validate every backticked ``t3 …`` in the repo docs against the live CLI registry.
 
-    Tier-1 (deterministic, free, no ``claude`` run): the backticked ``t3 …``
+    Tier-1 (deterministic, model-free, no ``claude`` run): the backticked ``t3 …``
     commands in the skills tree, the ``agents/*.md`` role briefs, ``BLUEPRINT.md``
     and ``docs/`` are token-walked against the live typer command tree. A leading
     ``t3 <overlay>`` is resolved to a representative overlay so an overlay-scoped

--- a/src/teatree/quality/eval_lane_vocabulary.py
+++ b/src/teatree/quality/eval_lane_vocabulary.py
@@ -1,0 +1,83 @@
+"""Scan the eval-harness surfaces for the bare cost claim "free".
+
+A deterministic eval lane spends no model tokens, but it still spends CPU,
+wall-clock and maintenance — so "free" is a false cost claim, and it was the
+headline of a shipped skill. The accurate distinction the eval docs draw is
+whether a lane calls a live model, which the repo already spells ``model-free``
+(the ``X-free`` compound reads "without X", never "costs nothing").
+
+The scan is deliberately narrow: only the eval-harness surfaces, and only the
+STANDALONE token. A hyphenated compound (``model-free``, ``Django-free``,
+``gap-free``, ``free-form``) is never a cost claim, so it is not a violation.
+"""
+
+import dataclasses
+import re
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Final
+
+#: A bare ``free`` token in any casing — not one half of a hyphenated compound.
+_BARE_FREE: Final[re.Pattern[str]] = re.compile(r"(?<![\w-])free(?![\w-])", re.IGNORECASE)
+
+#: Eval-harness surfaces, relative to the repo root.
+_SCANNED_FILES: Final[tuple[str, ...]] = (
+    "skills/running-evals/SKILL.md",
+    "docs/testing-skill-evals.md",
+    "evals/README.md",
+)
+_SCANNED_DIRS: Final[tuple[str, ...]] = ("src/teatree/cli/eval",)
+
+
+@dataclasses.dataclass(frozen=True)
+class Violation:
+    path: str
+    line_number: int
+    line: str
+
+    def render(self) -> str:
+        return f"{self.path}:{self.line_number}: {self.line.strip()}"
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def scanned_paths(root: Path | None = None) -> list[Path]:
+    base = root or repo_root()
+    paths = [base / name for name in _SCANNED_FILES]
+    for directory in _SCANNED_DIRS:
+        paths.extend(sorted((base / directory).rglob("*.py")))
+    return [path for path in paths if path.is_file()]
+
+
+def scan_text(text: str, *, path: str) -> Iterator[Violation]:
+    previous = ""
+    for number, line in enumerate(text.splitlines(), start=1):
+        match = _BARE_FREE.search(line)
+        if match and not _is_wrapped_compound(previous, line, match) and not _is_absence_sense(line, match):
+            yield Violation(path=path, line_number=number, line=line)
+        previous = line
+
+
+def _is_wrapped_compound(previous: str, line: str, match: re.Match[str]) -> bool:
+    """True when the token is the tail of a compound wrapped across two lines.
+
+    ``price-table-`` / ``free:`` is one hyphenated compound the line break split,
+    not a bare cost claim.
+    """
+    return previous.rstrip().endswith("-") and not line[: match.start()].strip()
+
+
+def _is_absence_sense(line: str, match: re.Match[str]) -> bool:
+    """True for ``free of X`` — the spelled-out form of the ``X-free`` absence sense."""
+    return line[match.end() :].startswith(" of ")
+
+
+def scan(root: Path | None = None) -> list[Violation]:
+    base = root or repo_root()
+    violations: list[Violation] = []
+    for path in scanned_paths(base):
+        relative = path.relative_to(base).as_posix()
+        violations.extend(scan_text(path.read_text(encoding="utf-8"), path=relative))
+    return violations

--- a/tests/eval_replay/test_readme_sync.py
+++ b/tests/eval_replay/test_readme_sync.py
@@ -23,7 +23,7 @@ _README = _REPO_ROOT / "evals" / "README.md"
 _PARTS_TABLE_ROW = "| CLI surface"
 
 _CLI_EVAL_FILE_RE = re.compile(r"`(?:src/teatree/cli/eval/)?([a-z_]+\.py)`")
-# A subcommand starts with a letter; a `--flag` (e.g. `t3 eval --free-only`,
+# A subcommand starts with a letter; a `--flag` (e.g. `t3 eval --model-free`,
 # now valid on the bare-`t3 eval` default) is NOT a subcommand and must not be
 # captured as one.
 _EVAL_COMMAND_RE = re.compile(r"\bt3 eval ([a-z][a-z-]*)\b")

--- a/tests/teatree_cli/eval/test_corpus.py
+++ b/tests/teatree_cli/eval/test_corpus.py
@@ -230,7 +230,7 @@ class TestShippedCorpusLaneBody:
         assert rows, "shipped corpus is empty — the corpus-grade lane would be vacuous"
         assert all(row.verdict != "fail" for row in rows), rows
 
-    def test_judge_oracle_entries_skip_in_the_free_lane(self) -> None:
+    def test_judge_oracle_entries_skip_in_the_model_free_lane(self) -> None:
         rows = {row.entry_id: row for row in grade_shipped_corpus()}
         assert rows["faithful_explanation"].verdict == "skip"
         assert rows["structured_question"].verdict == "pass"
@@ -252,7 +252,7 @@ class TestShippedCorpusLaneBody:
             "ZERO entries under --no-judge and read as a vacuous green. Add a deterministically-"
             "gradable entry."
         )
-        # And it actually grades (not skips) in the free lane.
+        # And it actually grades (not skips) in the model-free lane.
         graded_ids = {label.entry_id for label in deterministic}
         rows = {row.entry_id: row for row in grade_shipped_corpus()}
         assert any(rows[entry_id].verdict in {"pass", "fail"} for entry_id in graded_ids)

--- a/tests/teatree_cli/eval/test_skill_command_lane.py
+++ b/tests/teatree_cli/eval/test_skill_command_lane.py
@@ -46,10 +46,10 @@ class TestShippedCorpus:
 
 
 class TestLaneResult:
-    def test_clean_corpus_is_a_passing_free_lane(self) -> None:
+    def test_clean_corpus_is_a_passing_model_free_lane(self) -> None:
         lane = skill_command_validity_lane(validate_shipped_skill_commands())
         assert lane.name == "skill-command-validity"
-        assert lane.cost == "free"
+        assert lane.cost == "model-free"
         assert lane.passed is True
         assert lane.skipped is False
 

--- a/tests/teatree_cli/test_eval.py
+++ b/tests/teatree_cli/test_eval.py
@@ -947,7 +947,7 @@ def _per_scenario_cost_runner(costs: dict[str, float]) -> type:
 @pytest.mark.django_db
 class TestEvalCostRegressionGate:
     def _record_baseline(self, specs: list[EvalSpec], *, cost_usd: float) -> None:
-        # A zero-cost baseline is a subscription/free run (no metered cost) — persist it
+        # A zero-cost baseline is a subscription run (no metered cost) — persist it
         # through the ledger directly, the way such a baseline really lands, rather than
         # the metered api path (whose $0-fail guard would correctly reject it). The
         # specs carry their RESOLVED model (the candidate run resolves per-scenario at
@@ -995,7 +995,7 @@ class TestEvalCostRegressionGate:
         assert "COST REGRESSED" not in result.output
 
     def test_zero_baseline_cost_passes_without_div_by_zero(self) -> None:
-        # The baseline run EXISTS but its per-scenario cost is $0 (a subscription/free
+        # The baseline run EXISTS but its per-scenario cost is $0 (a subscription
         # baseline). The relative drift is undefined, so the gate skips the scenario:
         # exit 0, never a COST REGRESSED, never a divide-by-zero — and NOT the
         # "no cost baseline" path (a baseline run is present, just zero-cost).
@@ -1813,7 +1813,7 @@ def _prose_report(*, weakest: str = "beta") -> ProseJudgeReport:
 
 @contextmanager
 # ast-grep-ignore: ac-django-no-complexity-suppressions
-def _patch_all_lanes(  # noqa: PLR0913 — one keyword per free lane the bare-`t3 eval` run patches; the list IS the lane set.
+def _patch_all_lanes(  # noqa: PLR0913 — one keyword per model-free lane the bare-`t3 eval` run patches; the list IS the lane set.
     specs: list[EvalSpec],
     *,
     regression_ok: bool = True,
@@ -1822,7 +1822,7 @@ def _patch_all_lanes(  # noqa: PLR0913 — one keyword per free lane the bare-`t
     coverage_gaps: tuple[str, ...] = (),
     command_validity_ok: bool = True,
 ) -> "Iterator[None]":
-    """Patch every free-lane input `run_full_suite` (in cli.eval.all) resolves."""
+    """Patch every model-free-lane input `run_full_suite` (in cli.eval.all) resolves."""
     with (
         patch("teatree.cli.eval.all.discover_specs", return_value=specs),
         patch("teatree.cli.eval.all.skill_eval_coverage", return_value=_coverage(gaps=coverage_gaps)),
@@ -1891,10 +1891,10 @@ class TestEvalDefault:
                 side_effect=AssertionError("docker must not run host lanes"),
             ),
         ):
-            result = CliRunner().invoke(app, ["eval", "--docker", "--free-only"])
+            result = CliRunner().invoke(app, ["eval", "--docker", "--model-free"])
         assert result.exit_code == 0, result.output
         run_docker.assert_called_once()
-        assert run_docker.call_args.args[0] == ["--free-only"]
+        assert run_docker.call_args.args[0] == ["--model-free"]
 
     def test_bare_eval_docker_propagates_container_exit_code(self) -> None:
         with patch("teatree.cli.eval.all.run_eval_in_docker", return_value=1):
@@ -2004,7 +2004,7 @@ class TestEvalSubcommandsStillWork:
 
 
 class TestEvalAll:
-    def test_runs_free_lanes_and_renders_unified_table(self, tmp_path: Path) -> None:
+    def test_runs_model_free_lanes_and_renders_unified_table(self, tmp_path: Path) -> None:
         with _patch_all_lanes([_spec("worktree_first")]):
             result = CliRunner().invoke(app, ["eval", "--transcript-dir", str(tmp_path)])
         assert result.exit_code == 0, result.output
@@ -2013,7 +2013,7 @@ class TestEvalAll:
         assert "pinned-regressions" in result.output
 
     def test_table_lists_all_lanes_including_coverage(self, tmp_path: Path) -> None:
-        # The default subscription path lists every free lane plus the
+        # The default subscription path lists every model-free lane plus the
         # transcript-graded ai-eval lane; the metered prose-judge is gated off the
         # default path (it bills the API — see TestEvalAllSkillProseJudgeLaneAdvisory).
         with _patch_all_lanes([_spec("worktree_first")]):
@@ -2034,13 +2034,13 @@ class TestEvalAll:
 
     def test_coverage_gap_is_warn_first_exit_zero(self, tmp_path: Path) -> None:
         with _patch_all_lanes([_spec("worktree_first")], coverage_gaps=("loops",)):
-            result = CliRunner().invoke(app, ["eval", "--free-only", "--transcript-dir", str(tmp_path)])
+            result = CliRunner().invoke(app, ["eval", "--model-free", "--transcript-dir", str(tmp_path)])
         assert result.exit_code == 0, result.output
         assert "skill-coverage" in result.output
 
-    def test_free_only_drops_the_ai_lane(self, tmp_path: Path) -> None:
+    def test_model_free_drops_the_ai_lane(self, tmp_path: Path) -> None:
         with _patch_all_lanes([_spec("worktree_first")]):
-            result = CliRunner().invoke(app, ["eval", "--free-only", "--transcript-dir", str(tmp_path)])
+            result = CliRunner().invoke(app, ["eval", "--model-free", "--transcript-dir", str(tmp_path)])
         assert result.exit_code == 0, result.output
         for lane in (
             "skill-coverage",
@@ -2050,21 +2050,23 @@ class TestEvalAll:
             "corpus-grade",
             "skill-command-validity",
         ):
-            assert lane in result.output, f"missing free lane {lane!r}: {result.output}"
+            assert lane in result.output, f"missing model-free lane {lane!r}: {result.output}"
         assert "ai-eval" not in result.output, result.output
-        assert "skill-prose-judge" not in result.output, result.output  # Tier-3 is metered, dropped by --free-only
+        assert "skill-prose-judge" not in result.output, result.output  # Tier-3 is metered, dropped by --model-free
 
-    def test_free_only_never_discovers_specs_or_meters(self, tmp_path: Path) -> None:
+    def test_model_free_never_discovers_specs_or_meters(self, tmp_path: Path) -> None:
         with (
             _patch_all_lanes([_spec("worktree_first")]),
-            patch("teatree.cli.eval.all.run_ai_lane", side_effect=AssertionError("free-only must not run the AI lane")),
+            patch(
+                "teatree.cli.eval.all.run_ai_lane", side_effect=AssertionError("--model-free must not run the AI lane")
+            ),
         ):
-            result = CliRunner().invoke(app, ["eval", "--free-only", "--transcript-dir", str(tmp_path)])
+            result = CliRunner().invoke(app, ["eval", "--model-free", "--transcript-dir", str(tmp_path)])
         assert result.exit_code == 0, result.output
 
-    def test_free_only_still_fails_on_a_deterministic_violation(self, tmp_path: Path) -> None:
+    def test_model_free_still_fails_on_a_deterministic_violation(self, tmp_path: Path) -> None:
         with _patch_all_lanes([_spec("worktree_first")], negative_caught=False):
-            result = CliRunner().invoke(app, ["eval", "--free-only", "--transcript-dir", str(tmp_path)])
+            result = CliRunner().invoke(app, ["eval", "--model-free", "--transcript-dir", str(tmp_path)])
         assert result.exit_code == 1, result.output
 
     def test_docker_delegates_to_the_container_and_skips_host_lanes(self) -> None:
@@ -2075,10 +2077,10 @@ class TestEvalAll:
                 side_effect=AssertionError("docker must not run host lanes"),
             ),
         ):
-            result = CliRunner().invoke(app, ["eval", "--docker", "--free-only"])
+            result = CliRunner().invoke(app, ["eval", "--docker", "--model-free"])
         assert result.exit_code == 0, result.output
         run_docker.assert_called_once()
-        assert run_docker.call_args.args[0] == ["--free-only"]
+        assert run_docker.call_args.args[0] == ["--model-free"]
 
     def test_docker_propagates_container_exit_code(self) -> None:
         with patch("teatree.cli.eval.all.run_eval_in_docker", return_value=1):
@@ -2110,14 +2112,14 @@ class TestEvalFinalVerdict:
     def test_all_pass_renders_all_good_verdict(self, tmp_path: Path) -> None:
         # Free-only so every lane truly passes (no AI lane to caveat).
         with _patch_all_lanes([_spec("worktree_first")]):
-            result = CliRunner().invoke(app, ["eval", "--free-only", "--transcript-dir", str(tmp_path)])
+            result = CliRunner().invoke(app, ["eval", "--model-free", "--transcript-dir", str(tmp_path)])
         assert result.exit_code == 0, result.output
         assert "✅ ALL GOOD" in result.output, result.output
         assert "every check passed" in result.output, result.output
 
     def test_real_failure_renders_problems_and_names_the_lane(self, tmp_path: Path) -> None:
         with _patch_all_lanes([_spec("worktree_first")], negative_caught=False):
-            result = CliRunner().invoke(app, ["eval", "--free-only", "--transcript-dir", str(tmp_path)])
+            result = CliRunner().invoke(app, ["eval", "--model-free", "--transcript-dir", str(tmp_path)])
         assert result.exit_code == 1, result.output
         assert "❌ PROBLEMS FOUND" in result.output, result.output
         assert "negative-control" in result.output, result.output
@@ -2158,7 +2160,7 @@ class TestEvalFinalVerdict:
 
     def test_strict_stays_green_when_everything_actually_passes(self, tmp_path: Path) -> None:
         with _patch_all_lanes([_spec("worktree_first")]):
-            result = CliRunner().invoke(app, ["eval", "--strict", "--free-only", "--transcript-dir", str(tmp_path)])
+            result = CliRunner().invoke(app, ["eval", "--strict", "--model-free", "--transcript-dir", str(tmp_path)])
         assert result.exit_code == 0, result.output
         assert "✅ ALL GOOD" in result.output, result.output
 
@@ -2340,7 +2342,7 @@ class TestEvalRunMeteredDockerByDefault:
         assert result.exit_code == 0, result.output
         assert "ai-eval" in result.output
 
-    def test_failing_free_lane_exits_nonzero(self, tmp_path: Path) -> None:
+    def test_failing_model_free_lane_exits_nonzero(self, tmp_path: Path) -> None:
         with _patch_all_lanes([_spec("worktree_first")], regression_ok=False):
             result = CliRunner().invoke(app, ["eval", "--transcript-dir", str(tmp_path)])
         assert result.exit_code == 1, result.output
@@ -2490,11 +2492,11 @@ class TestEvalCoverage:
 
 
 class TestEvalAllCorpusGradeLane:
-    """The deterministic corpus part runs as a free lane in the full suite."""
+    """The deterministic corpus part runs as a model-free lane in the full suite."""
 
-    def test_corpus_grade_lane_runs_in_the_free_suite(self, tmp_path: Path) -> None:
+    def test_corpus_grade_lane_runs_in_the_model_free_suite(self, tmp_path: Path) -> None:
         with _patch_all_lanes([_spec("worktree_first")]):
-            result = CliRunner().invoke(app, ["eval", "--free-only", "--transcript-dir", str(tmp_path)])
+            result = CliRunner().invoke(app, ["eval", "--model-free", "--transcript-dir", str(tmp_path)])
         assert result.exit_code == 0, result.output
         assert "corpus-grade" in result.output
         assert "judge-skipped" in result.output
@@ -2505,7 +2507,7 @@ class TestEvalAllCorpusGradeLane:
             _patch_all_lanes([_spec("worktree_first")]),
             patch("teatree.cli.eval.all.grade_shipped_corpus", return_value=failing),
         ):
-            result = CliRunner().invoke(app, ["eval", "--free-only", "--transcript-dir", str(tmp_path)])
+            result = CliRunner().invoke(app, ["eval", "--model-free", "--transcript-dir", str(tmp_path)])
         assert result.exit_code == 1, result.output
         assert "corpus-grade" in result.output
 
@@ -2518,7 +2520,7 @@ class TestEvalAllCorpusGradeLane:
             _patch_all_lanes([_spec("worktree_first")]),
             patch("teatree.cli.eval.all.grade_shipped_corpus", return_value=all_skip),
         ):
-            default_run = CliRunner().invoke(app, ["eval", "--free-only", "--transcript-dir", str(tmp_path)])
+            default_run = CliRunner().invoke(app, ["eval", "--model-free", "--transcript-dir", str(tmp_path)])
         assert default_run.exit_code == 0, default_run.output
         assert "needs setup" in default_run.output.lower(), default_run.output
 
@@ -2526,22 +2528,24 @@ class TestEvalAllCorpusGradeLane:
             _patch_all_lanes([_spec("worktree_first")]),
             patch("teatree.cli.eval.all.grade_shipped_corpus", return_value=all_skip),
         ):
-            strict_run = CliRunner().invoke(app, ["eval", "--free-only", "--strict", "--transcript-dir", str(tmp_path)])
+            strict_run = CliRunner().invoke(
+                app, ["eval", "--model-free", "--strict", "--transcript-dir", str(tmp_path)]
+            )
         assert strict_run.exit_code == 1, strict_run.output
 
 
 class TestEvalAllSkillCommandValidityLane:
-    """Tier-1 (#550) runs as a free lane and FAILs on a stale `t3 …` reference."""
+    """Tier-1 (#550) runs as a model-free lane and FAILs on a stale `t3 …` reference."""
 
-    def test_command_validity_lane_runs_in_the_free_suite(self, tmp_path: Path) -> None:
+    def test_command_validity_lane_runs_in_the_model_free_suite(self, tmp_path: Path) -> None:
         with _patch_all_lanes([_spec("worktree_first")]):
-            result = CliRunner().invoke(app, ["eval", "--free-only", "--transcript-dir", str(tmp_path)])
+            result = CliRunner().invoke(app, ["eval", "--model-free", "--transcript-dir", str(tmp_path)])
         assert result.exit_code == 0, result.output
         assert "skill-command-validity" in result.output
 
     def test_stale_command_reference_fails_the_suite(self, tmp_path: Path) -> None:
         with _patch_all_lanes([_spec("worktree_first")], command_validity_ok=False):
-            result = CliRunner().invoke(app, ["eval", "--free-only", "--transcript-dir", str(tmp_path)])
+            result = CliRunner().invoke(app, ["eval", "--model-free", "--transcript-dir", str(tmp_path)])
         assert result.exit_code == 1, result.output
         assert "skill-command-validity" in result.output
 
@@ -2566,7 +2570,7 @@ class TestEvalAllSkillProseJudgeLaneAdvisory:
     def test_bare_eval_does_not_invoke_the_live_judge(self, tmp_path: Path) -> None:
         # Bare `t3 eval` (default subscription backend, advertised "no API spend")
         # must NOT fire the live metered prose-judge — gate it on the metered
-        # opt-in, not merely on `not --free-only`.
+        # opt-in, not merely on `not --model-free`.
         with (
             _patch_all_lanes([_spec("worktree_first")]),
             patch("teatree.cli.eval.all.run_prose_judge") as prose,
@@ -2576,15 +2580,15 @@ class TestEvalAllSkillProseJudgeLaneAdvisory:
         prose.assert_not_called()
         assert "skill-prose-judge" not in result.output, result.output
 
-    def test_free_only_drops_the_prose_judge_even_with_sdk_backend(self, tmp_path: Path) -> None:
-        # `--free-only` runs only the host-safe deterministic lanes — it is never
+    def test_model_free_drops_the_prose_judge_even_with_sdk_backend(self, tmp_path: Path) -> None:
+        # `--model-free` runs only the host-safe deterministic lanes — it is never
         # metered, so the prose-judge is dropped even when `--backend api` is given.
         with (
             _patch_all_lanes([_spec("worktree_first")]),
             patch("teatree.cli.eval.all.run_prose_judge") as prose,
         ):
             result = CliRunner().invoke(
-                app, ["eval", "--free-only", "--backend", "api", "--transcript-dir", str(tmp_path)]
+                app, ["eval", "--model-free", "--backend", "api", "--transcript-dir", str(tmp_path)]
             )
         assert result.exit_code == 0, result.output
         prose.assert_not_called()
@@ -2661,7 +2665,7 @@ class TestSuiteMeteredImpliesStrict:
 
     def _lanes(self) -> list[LaneResult]:
         return [
-            LaneResult(name="pinned-regressions", cost="free", passed=True, skipped=False, detail="ok"),
+            LaneResult(name="pinned-regressions", cost="model-free", passed=True, skipped=False, detail="ok"),
             LaneResult(
                 name="ai-eval",
                 cost="metered",
@@ -2682,7 +2686,7 @@ class TestSuiteMeteredImpliesStrict:
         assert _suite_should_fail(self._lanes(), strict=True, metered=False) is True
 
     def test_all_green_never_fails(self) -> None:
-        green = [LaneResult(name="x", cost="free", passed=True, skipped=False, detail="ok")]
+        green = [LaneResult(name="x", cost="model-free", passed=True, skipped=False, detail="ok")]
         assert _suite_should_fail(green, strict=True, metered=True) is False
 
 

--- a/tests/teatree_cli/test_eval_docker.py
+++ b/tests/teatree_cli/test_eval_docker.py
@@ -62,7 +62,7 @@ class TestRunEvalInDocker(TestCase):
             patch(f"{_MODULE}._image_present", return_value=False),
             patch(f"{_MODULE}.run_streamed", return_value=0) as streamed,
         ):
-            code = run_eval_in_docker(["all", "--free-only"])
+            code = run_eval_in_docker(["all", "--model-free"])
         assert code == 0
         build, exec_ = streamed.call_args_list
         assert "build" in build.args[0]
@@ -76,7 +76,7 @@ class TestRunEvalInDocker(TestCase):
             patch(f"{_MODULE}._image_present", return_value=True),
             patch(f"{_MODULE}.run_streamed", return_value=0) as streamed,
         ):
-            run_eval_in_docker(["all", "--free-only"])
+            run_eval_in_docker(["all", "--model-free"])
         assert streamed.call_count == 1
         assert streamed.call_args.args[0][:2] == ["docker", "run"]
 
@@ -86,10 +86,10 @@ class TestRunEvalInDocker(TestCase):
             patch(f"{_MODULE}._image_present", return_value=True),
             patch(f"{_MODULE}.run_streamed", return_value=0) as streamed,
         ):
-            run_eval_in_docker(["all", "--free-only"])
+            run_eval_in_docker(["all", "--model-free"])
         container_cmd = streamed.call_args.args[0]
         start = container_cmd.index("uv")
-        assert container_cmd[start:] == ["uv", "run", "t3", "eval", "all", "--free-only"]
+        assert container_cmd[start:] == ["uv", "run", "t3", "eval", "all", "--model-free"]
 
     def test_propagates_nonzero_exit_from_container(self) -> None:
         with (
@@ -97,7 +97,7 @@ class TestRunEvalInDocker(TestCase):
             patch(f"{_MODULE}._image_present", return_value=True),
             patch(f"{_MODULE}.run_streamed", return_value=1),
         ):
-            assert run_eval_in_docker(["all", "--free-only"]) == 1
+            assert run_eval_in_docker(["all", "--model-free"]) == 1
 
     def test_uses_the_ci_image_tag(self) -> None:
         with (
@@ -133,7 +133,7 @@ class TestRunEvalInDocker(TestCase):
             patch(f"{_MODULE}._image_present", return_value=False),
             patch(f"{_MODULE}.run_streamed", return_value=0) as streamed,
         ):
-            run_eval_in_docker(["all", "--free-only"])
+            run_eval_in_docker(["all", "--model-free"])
         build = streamed.call_args_list[0].args[0]
         assert "-q" not in build
 
@@ -145,7 +145,7 @@ class TestRunEvalInDocker(TestCase):
             patch(f"{_MODULE}._image_present", return_value=True),
             patch(f"{_MODULE}.run_streamed", return_value=0) as streamed,
         ):
-            run_eval_in_docker(["all", "--free-only"])
+            run_eval_in_docker(["all", "--model-free"])
         command = streamed.call_args.args[0]
         index = command.index("PYTHONUNBUFFERED=1")
         assert command[index - 1 : index + 1] == ["-e", "PYTHONUNBUFFERED=1"]
@@ -361,7 +361,7 @@ class TestDockerResolvesCredentialFromPassForSdkLane(TestCase):
     resolves it from the ``pass`` store and exports it into the parent env BEFORE
     ``_auth_passthrough_flags()`` is computed, so the ``-e`` flag is emitted and the
     credential reaches the container — ``--backend api --docker`` just works. The
-    free / transcript lane must not read the secret store.
+    model-free / transcript lane must not read the secret store.
     """
 
     def _run(self, args: list[str], env: dict[str, str], pass_value: str) -> list[str]:
@@ -382,8 +382,8 @@ class TestDockerResolvesCredentialFromPassForSdkLane(TestCase):
         index = command.index(_OAUTH_ENV)
         assert command[index - 1 : index + 1] == ["-e", _OAUTH_ENV]
 
-    def test_free_only_lane_does_not_read_pass(self) -> None:
-        self._run(["all", "--free-only"], env={}, pass_value="oauth-pass-token")
+    def test_model_free_lane_does_not_read_pass(self) -> None:
+        self._run(["all", "--model-free"], env={}, pass_value="oauth-pass-token")
         self.read_pass.assert_not_called()
 
 

--- a/tests/teatree_quality/test_eval_lane_vocabulary.py
+++ b/tests/teatree_quality/test_eval_lane_vocabulary.py
@@ -1,0 +1,38 @@
+"""The eval surfaces never call a lane "free" — it is a false cost claim."""
+
+from teatree.quality.eval_lane_vocabulary import repo_root, scan, scan_text, scanned_paths
+
+
+class TestShippedSurfacesAreClean:
+    def test_the_scan_set_resolves_inside_the_repo(self) -> None:
+        assert (repo_root() / "pyproject.toml").is_file()
+        assert all(path.is_relative_to(repo_root()) for path in scanned_paths())
+
+    def test_no_eval_surface_calls_a_lane_free(self) -> None:
+        violations = scan()
+        assert not violations, (
+            "the eval surfaces claim a lane is 'free' — a deterministic lane still spends CPU, "
+            "wall-clock and maintenance. Say 'model-free' (the lane calls no live model):\n"
+            + "\n".join(violation.render() for violation in sorted(violations, key=lambda v: (v.path, v.line_number)))
+        )
+
+    def test_the_scan_set_is_not_empty(self) -> None:
+        assert scanned_paths(), "the eval-surface scan set resolved to nothing — the gate would be vacuous"
+
+
+class TestScannerIsAntiVacuous:
+    def test_a_bare_free_cost_claim_is_flagged(self) -> None:
+        assert [v.line_number for v in scan_text("the free deterministic lanes\n", path="x.md")] == [1]
+
+    def test_an_uppercase_cost_claim_is_flagged(self) -> None:
+        assert [v.line_number for v in scan_text("runs the FREE lanes\n", path="x.md")] == [1]
+
+    def test_a_hyphenated_compound_is_not_a_cost_claim(self) -> None:
+        clean = "model-free lanes, a Django-free reader, a gap-free corpus, free-form work\n"
+        assert list(scan_text(clean, path="x.md")) == []
+
+    def test_a_compound_wrapped_across_two_lines_is_not_a_cost_claim(self) -> None:
+        assert list(scan_text("it is price-table-\n  free: per variant\n", path="x.md")) == []
+
+    def test_the_absence_sense_is_not_a_cost_claim(self) -> None:
+        assert list(scan_text("transcripts must stay free of personal content\n", path="x.md")) == []


### PR DESCRIPTION
refactor(eval): say model-free, not free — rename --free-only to --model-free

Reconcilable: eval-lane-vocabulary-model-free

## Why now

A deterministic eval lane spends no model tokens, but it still spends CPU, wall-clock and maintenance. Calling it *free* is a false cost claim, and it was the **headline** of a shipped skill — `skills/running-evals/SKILL.md` line 3 is the `description:` frontmatter, so the claim appeared in every skill listing, the generated skills catalogue, and the README table.

## The word, and why not the others

The distinction the eval docs actually draw is **does this lane call a live model**. Four candidates were on the table:

- **`cheap`** — honest about magnitude but silent about mechanism. It replaces one cost claim with a weaker cost claim, and a reader still cannot tell *why* it is cheap. It also re-opens the same argument the next time someone measures the CPU.
- **`deterministic`** — a real property, but an orthogonal one, and the docs already use it *alongside* "free" (`the free deterministic lanes`). It says nothing about model calls; a graded model run can be deterministic in its scoring.
- **`unmetered`** — the tempting one, and wrong **in this codebase specifically**. `metered` here is a BILLING axis with an existing, load-bearing meaning: `metered_routing.should_route_to_docker(metered=…)` routes a lane to the CI container because it *bills the API*. A subscription-OAuth lane is explicitly **non-metered while still running a model** (`metered_routing.py`: "A non-metered lane (free / deterministic / subscription) is never routed"). Using `unmetered` for "calls no model" would collide with that axis at exactly the point precision is needed.
- **`model-free`** — chosen. It states the mechanism directly, and it inherits the repo's established `X-free` compound idiom (`Django-free`, `CLI-free`, `token-free`, `network-free`, `gap-free`), where `-free` reads *"without X"* and carries **no cost claim at all**. `evals/README.md` was already using it in one place before this PR ("a **test** is deterministic and model-free"); this makes it the consistent word.

## The flag rename — `--free-only` to `--model-free`, no alias

Renaming a public CLI flag is a breaking change, so the external-consumer question was answered before the rename, not after:

```
grep -rn "free-only|free_only" .github/ deploy/ scripts/ skills/ dev/ .gitlab-ci.yml .pre-commit-config.yaml
  -> no matches
```

Every `t3 eval …` invocation in CI (`eval.yml`, `eval-nightly.yml`, `eval-pr-reusable.yml`, `eval-weekly-reusable.yml`, `.gitlab-ci.yml`) uses `run` / `list` / `changed-scenarios` / `merged-prs-since` / `reachability` / `verify-benchmark-publish` — never the full-suite flag. No prek hook and no `dev/*.sh` references it either.

The only cross-process use is internal and version-locked: `all._full_suite_docker_passthrough` re-appends the flag when the full suite re-invokes itself **inside the CI container**, which is built from this same source tree. Parent and child move together, so there is no skew window.

That makes it internal-only, and `CLAUDE.md` § "Deprecated Code" is explicit — delete cleanly, no aliases, no compat shims. Renamed with no alias.

The only other artifact carrying the old string is `dev/.test_durations`, an auto-regenerated timing cache keyed on test node ids; a stale key costs a marginally worse shard balance for one run and self-heals.

## The gate that keeps it fixed

The owner has corrected this wording repeatedly, which makes it a recurrence class rather than a one-off typo — so the fix ships with its enforcement. `teatree.quality.eval_lane_vocabulary` scans the eval surfaces (`skills/running-evals/SKILL.md`, `docs/testing-skill-evals.md`, `evals/README.md`, `src/teatree/cli/eval/**/*.py`) for a **standalone** `free` token in any casing.

Three cases are deliberately not violations, each with its own anti-vacuity test:

- a hyphenated compound (`model-free`, `Django-free`, `gap-free`, `free-form`) — the absence sense, never a cost claim;
- a compound the line-wrap split across two lines (`price-table-` / `free:`);
- the spelled-out absence sense `free of X` ("must stay free of personal content").

The scanner was proven RED first: it reported 60+ violations across the shipped tree, including the skill frontmatter, before any wording changed.

## Also reworded

`ci_account.py` printed OAuth quota headroom as `5h free 82%` — genuinely free *capacity*, not a lane cost, but the same word. Reworded to `5h headroom` / `weekly headroom`, which reads better anyway and needs no gate allowlist. `app.py` / `run_modes.py` `(subscription/free)` becomes `(subscription)`, since the `$0` is already stated beside it.

## Architecture pre-check

1. **BLUEPRINT §** — n/a. No architectural surface changes; the eval-lane taxonomy prose lives in `evals/README.md` and `docs/testing-skill-evals.md`, both updated here.
2. **FSM phase boundaries** — n/a. No `Ticket.State` / `Worktree.State` transition.
3. **Extension-point contracts** — n/a. No `OverlayBase` hook, scanner registration, or `*Backend` Protocol touched. `LaneResult.cost` is a display string, not a contract; no consumer branches on its value.
4. **Component boundaries** — the scanner lives in `src/teatree/quality/`, the package that already owns every repo-invariant checker (`prose.py`, `incompleteness_markers.py`, `skill_cli_ratchet.py`). Its test mirrors it at `tests/teatree_quality/`, per `t3 tool test-path-mirror`.
5. **Dependency direction** — the new module imports only stdlib (`dataclasses`, `re`, `pathlib`). No new cross-module edge. `uv run tach check` -> `All modules validated!`
6. **Test surface** — `tests/teatree_quality/test_eval_lane_vocabulary.py`: the shipped tree is clean; the scan set is non-empty and inside the repo (so the gate can never pass vacuously); and five scanner-behaviour cases (bare token flagged, uppercase flagged, compound not flagged, wrapped compound and `free of` not flagged). The flag rename is covered by the existing `tests/teatree_cli/test_eval.py` / `test_eval_docker.py` suites, updated in place.
7. **Resilience invariants** — n/a. No external write, no network read, no sub-agent dispatch. The scanner reads files off disk and fails loud on an empty scan set rather than returning a green empty.
8. **Identity and key normalization** — n/a. No identity with bare/qualified forms; no `split()[-1]`-style narrowing introduced.
9. **Behavior preservation / capability deletion** — the flag behaviour is preserved exactly; only its spelling changed. No test was inverted, no matcher narrowed, no privacy/leak/security gate touched. The removed capability is the `--free-only` **spelling**, justified above by the external-consumer grep.
10. **Removability / harness-vs-data** — the gate is one module plus one test file; deleting both reverts to the pre-PR state with no cascade. It belongs in the **harness** rather than a data table: the rule is a single fixed vocabulary constraint over a fixed surface, not a per-item policy that varies, so a config row would add indirection without adding expressiveness.

## Test plan

```
uv run pytest tests/teatree_quality/test_eval_lane_vocabulary.py                     -> 8 passed
uv run pytest tests/teatree_cli/test_eval.py tests/teatree_cli/test_eval_docker.py   -> 221 passed
uv run pytest tests/teatree_cli/eval/                                                -> 340 passed, 2 skipped
uv run pytest tests/eval_replay/ tests/test_skill_t3_invocations.py                  -> in the 2654-passed adjacent run
uv run pytest tests/quality/test_no_flat_core_regrowth.py
              tests/quality/test_incompleteness_marker_ratchet.py                    -> 14 passed
uv run ruff check src/ tests/                                                        -> All checks passed!
uv run ruff format --check                                                           -> 43 files already formatted
uv run tach check                                                                    -> All modules validated!
uv run python manage.py makemigrations --check --dry-run                             -> No changes detected
t3 tool test-path-mirror                                                             -> ratchet holds (186 grandfathered)
t3 tool verify-gates                                                                 -> all gate stages green (commit + push)
uv run python manage.py generate_all_docs && git diff --exit-code docs/generated      -> clean (regenerated in this commit)
```

The gate was proved anti-vacuous the required way: run RED against the pre-fix tree (60+ violations reported, listing the skill frontmatter first), then GREEN after the rewrite. The three exemption branches each have a positive test that would fail if the exemption were dropped, and the flag/uppercase cases each have a must-flag test.

## Open questions & assumptions

- Assumed the `Cost` column in the `t3 eval` summary table should read `model-free` rather than a dollar figure, to stay parallel with its existing `transcript ($0)` and `advisory (judge)` values.
- The gate scans four surfaces, not the whole tree. `free disk`, `free flock`, `Django-free`, `free text` and the OAuth quota sense all live outside `src/teatree/cli/eval/` and are legitimate; widening the scan would need an allowlist, which is the maintenance cost the narrow scope avoids.
- No eval run was fired and no tick was run — both OAuth accounts are exhausted until Jul 30. The eval-lane changes are verified through the CLI unit suites only.