### PR TITLE
fix(loop): give the open-question backlog a resurface cadence

### DIFF
--- a/src/teatree/core/notify_question_drains.py
+++ b/src/teatree/core/notify_question_drains.py
@@ -10,17 +10,27 @@ of ``teatree.core.notify`` (at its module-health LOC cap). Both post pending
     transition);
 * :func:`drain_unmirrored_deferred_questions` — the headless ask-loop poster:
     posts rows with no Slack mirror yet and stamps the mirror coordinates so a
-    reply can later bind.
+    reply can later bind;
+* :func:`resurface_question_backlog` — the RECURRING nag (directive #36). The
+    two drains above are single-shot per question (each keys its idempotency on
+    the row's ``stable_notify_ref``), so a question the owner never answers is
+    never raised again. This one re-raises the whole backlog as ONE digest per
+    :data:`RESURFACE_INTERVAL_HOURS` bucket in the same DM thread — the lowest
+    message count that still keeps an unanswered question visible.
 
 The INFO-redelivery peer (``drain_undelivered_notifies``) stays in
 ``teatree.core.notify`` — a different durability concern (no-backend at post
 time vs. no-mirror / away at ask time).
 """
 
+import datetime as dt
 import json
 import logging
 import os
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
+
+from django.utils import timezone
 
 from teatree.core.modelkit.notify_policy import NotifyAudience
 from teatree.core.models import BotPing, DeferredQuestion
@@ -30,6 +40,16 @@ if TYPE_CHECKING:
     from teatree.core.backend_protocols import MessagingBackend
 
 logger = logging.getLogger(__name__)
+
+#: How long one backlog-digest bucket lasts. The digest's idempotency key is the
+#: bucket index, so the ``BotPing`` ledger collapses every tick inside a bucket to
+#: a single delivered message and a new bucket is the next nag.
+RESURFACE_INTERVAL_HOURS = 24
+
+#: How many questions the digest names before it degrades to a "+N more" count —
+#: a nag the owner can read on a phone, not a wall of 42 lines.
+_DIGEST_LIST_CAP = 10
+_DIGEST_QUESTION_CHARS = 90
 
 
 def _resurface_text(row: DeferredQuestion) -> str:
@@ -44,8 +64,69 @@ def _resurface_text(row: DeferredQuestion) -> str:
         label = opt.get("label", "")
         desc = opt.get("description", "")
         lines.append(f"  {i}. {label}" + (f" — {desc}" if desc else ""))
-    lines.append("\n_Just reply in this thread to answer._")
+    lines.append("\n_Reply in this thread — a typed reply is what gets recorded as your answer._")
     return "\n".join(lines)
+
+
+def _digest_line(row: DeferredQuestion) -> str:
+    first_line = row.question.strip().splitlines()[0] if row.question.strip() else ""
+    if len(first_line) > _DIGEST_QUESTION_CHARS:
+        first_line = first_line[: _DIGEST_QUESTION_CHARS - 1].rstrip() + "…"
+    return f"  • #{row.pk} — {first_line}"
+
+
+def format_backlog_digest(rows: Sequence[DeferredQuestion]) -> str:
+    """The single recurring nag message covering *rows*.
+
+    One header, up to :data:`_DIGEST_LIST_CAP` question lines, and a remainder
+    count — so a 42-deep backlog is one readable message rather than 42 DMs. The
+    ``#<id>`` prefix is what the owner echoes back, since a bare reply in a shared
+    DM thread cannot say WHICH question it answers.
+    """
+    header = f"*{len(rows)} open question{'s' if len(rows) != 1 else ''} waiting on you.*"
+    lines = [header, "Reply in this thread as `#<id> <your answer>`."]
+    lines.extend(_digest_line(row) for row in rows[:_DIGEST_LIST_CAP])
+    remainder = len(rows) - _DIGEST_LIST_CAP
+    if remainder > 0:
+        lines.append(f"  +{remainder} more.")
+    return "\n".join(lines)
+
+
+def resurface_question_backlog(
+    *,
+    user_id: str = "",
+    overlay: str = "",
+    backend: "MessagingBackend | None" = None,
+    now: dt.datetime | None = None,
+) -> tuple[bool, int]:
+    """Post at most one backlog digest per interval; return ``(posted, pending)``.
+
+    Directive #36's recurring half: an unanswered question is re-raised until the
+    owner reacts, in the same DM thread (:func:`notify_user` threads into the
+    active DM thread) and never as a per-question burst. The interval bucket IS
+    the idempotency key, so every tick inside one bucket collapses onto the single
+    delivered ``BotPing`` row and only a new bucket posts again. INTERNAL-audience
+    rows (an agent's own tool-lack self-report) are excluded, as in the two
+    first-post drains.
+    """
+    rows = [r for r in DeferredQuestion.pending() if r.audience != DeferredQuestion.Audience.INTERNAL]
+    if not rows:
+        return False, 0
+
+    bucket = int((now or timezone.now()).timestamp()) // (RESURFACE_INTERVAL_HOURS * 3600)
+    previous_overlay = _scoped_overlay_env(overlay)
+    try:
+        posted = notify_user(
+            format_backlog_digest(rows),
+            kind=NotifyKind.QUESTION,
+            idempotency_key=f"question-backlog-digest:{bucket}",
+            audience=NotifyAudience.OWNER_QUESTION,
+            backend=backend,
+            user_id=user_id or None,
+        )
+    finally:
+        _restore_overlay_env(overlay, previous_overlay)
+    return posted, len(rows)
 
 
 def _scoped_overlay_env(overlay: str) -> str | None:

--- a/src/teatree/loop/dispatch_tables.py
+++ b/src/teatree/loop/dispatch_tables.py
@@ -104,6 +104,10 @@ STATUSLINE_ZONE_BY_KIND: dict[str, str] = {
     # to promote and which to drop, so the signal IS a pending owner decision — the
     # generic in_flight fallback would file it under work-in-progress instead.
     "memory.skim_promotable": "action_needed",
+    # The recurring question digest exists BECAUSE the first posts (the in_flight
+    # ``deferred_question.mirrored`` above) did not get an answer, so the nag is the
+    # escalation and belongs where the owner looks for what they owe.
+    "deferred_question.resurfaced": "action_needed",
     # Only the CI-green-gate skips reach here (see is_self_update_ci_skip); a
     # clone wedged behind a red default branch must surface, not stay silent.
     "self_update.skipped": "action_needed",

--- a/src/teatree/loop/domain_jobs.py
+++ b/src/teatree/loop/domain_jobs.py
@@ -47,6 +47,7 @@ from teatree.loop.scanners import (
     OutboundAuditScanner,
     PendingTasksScanner,
     PrApprovalScanner,
+    QuestionBacklogNagScanner,
     RedCardScanner,
     ReviewDoneAckScanner,
     ReviewedPrHeadScanner,
@@ -90,8 +91,9 @@ def default_drift_notifier(alert_text: str, idempotency_key: str) -> None:
 def _global_dispatch_jobs() -> list[_ScannerJob]:
     """The always-on global set ``build_default_jobs`` fans out once per tick.
 
-    The two owner-DM delivery scanners (``UndeliveredNotifyScanner`` and
-    ``DeferredQuestionPosterScanner``) are handed an explicit messaging backend +
+    The three owner-DM delivery scanners (``UndeliveredNotifyScanner``,
+    ``DeferredQuestionPosterScanner`` and ``QuestionBacklogNagScanner``) are
+    handed an explicit messaging backend +
     user id resolved from the active overlay — the same source
     ``_pr_sweep_scanner_for`` uses — so a global tick with no ``T3_OVERLAY_NAME``
     can still DELIVER the allowed owner-audience DMs instead of no-opping on an
@@ -106,6 +108,7 @@ def _global_dispatch_jobs() -> list[_ScannerJob]:
         _ScannerJob(scanner=OutboundAuditScanner(notifier=default_drift_notifier), overlay=""),
         _ScannerJob(scanner=UndeliveredNotifyScanner(backend=backend, user_id=user_id), overlay=""),
         _ScannerJob(scanner=DeferredQuestionPosterScanner(backend=backend, user_id=user_id), overlay=""),
+        _ScannerJob(scanner=QuestionBacklogNagScanner(backend=backend, user_id=user_id), overlay=""),
         _ScannerJob(scanner=WaitingDigestScanner(), overlay=""),
         # SELFCATCH-1: global (walks every ticket across overlays via
         # ``reconcile_work_state_all``), so it runs once per tick here rather

--- a/src/teatree/loop/scanners/__init__.py
+++ b/src/teatree/loop/scanners/__init__.py
@@ -40,6 +40,7 @@ from teatree.loop.scanners.pr_sweep_adapters import (
 )
 from teatree.loop.scanners.provision_smoke import ProvisionSmokeScanner
 from teatree.loop.scanners.pull_main_clone import PullMainCloneScanner
+from teatree.loop.scanners.question_backlog_nag import QuestionBacklogNagScanner
 from teatree.loop.scanners.red_card import RedCardScanner
 from teatree.loop.scanners.resource_pressure import ResourcePressureScanner
 from teatree.loop.scanners.review_done_ack import ReviewDoneAckScanner
@@ -97,6 +98,7 @@ __all__ = [
     "PrSweepScanner",
     "ProvisionSmokeScanner",
     "PullMainCloneScanner",
+    "QuestionBacklogNagScanner",
     "RedCardScanner",
     "ResourcePressureScanner",
     "ReviewDoneAckScanner",

--- a/src/teatree/loop/scanners/question_backlog_nag.py
+++ b/src/teatree/loop/scanners/question_backlog_nag.py
@@ -1,0 +1,66 @@
+"""Scanner that re-raises the unanswered ``DeferredQuestion`` backlog on a cadence.
+
+The mechanism to resurface a question backlog existed (``t3 teatree questions
+resurface`` → :func:`teatree.core.notify_question_drains.drain_deferred_questions`)
+but nothing called it, and its per-question idempotency key made it single-shot
+anyway — so a question the owner never answered was posted once and then sat.
+This scanner is the caller: it runs in the global dispatch set (once per tick in
+the orchestrator loop, which has a working backend) and drives
+:func:`teatree.core.notify_question_drains.resurface_question_backlog`, whose
+interval bucket keeps the message count to one digest per day.
+
+It is the recurring peer of :class:`DeferredQuestionPosterScanner`: that one is
+the FIRST post of a never-mirrored row, this one is the nag for a row already
+posted and still unanswered. Directive #36 asks for the nag in the same Slack
+thread rather than a new post, which is what the digest-into-the-active-DM-thread
+shape gives.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from django.db import OperationalError, ProgrammingError
+
+from teatree.loop.scanners.base import ScanSignal
+
+if TYPE_CHECKING:
+    from teatree.core.backend_protocols import MessagingBackend
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class QuestionBacklogNagScanner:
+    overlay: str = ""
+    # Explicit backend + user id for the same reason the poster takes them: the
+    # GLOBAL dispatch tick runs with no ``T3_OVERLAY_NAME`` and would otherwise
+    # no-op on an unresolved overlay backend.
+    backend: "MessagingBackend | None" = None
+    user_id: str = ""
+    name: str = "question_backlog_nag"
+
+    def scan(self) -> list[ScanSignal]:
+        from teatree.core.notify_question_drains import (  # noqa: PLC0415 — deferred: loaded at tick time, not import
+            resurface_question_backlog,
+        )
+
+        try:
+            posted, pending = resurface_question_backlog(
+                overlay=self.overlay, backend=self.backend, user_id=self.user_id
+            )
+        except (OperationalError, ProgrammingError):
+            logger.info("QuestionBacklogNagScanner: DeferredQuestion unavailable (DB not migrated yet) — skipping")
+            return []
+        except Exception:
+            logger.exception("QuestionBacklogNagScanner resurface failed")
+            return []
+        if not posted:
+            return []
+        return [
+            ScanSignal(
+                kind="deferred_question.resurfaced",
+                summary=f"resurfaced {pending} unanswered question(s) as one digest",
+                payload={"pending": pending},
+            ),
+        ]

--- a/tests/conformance/test_signal_route_totality.py
+++ b/tests/conformance/test_signal_route_totality.py
@@ -42,6 +42,12 @@ _LOOP_DIR = Path(__file__).resolve().parents[2] / "src" / "teatree" / "loop"
 INTENTIONAL_FALLBACK_KINDS: frozenset[str] = frozenset(
     {
         "deferred_question.mirrored",
+        # The nag's digest is the recurring peer of ``mirrored`` above and takes the
+        # same decision: the side effect (an owner DM) is already done when the signal
+        # is emitted, so there is no work to route — the statusline row IS the outcome.
+        # Bounded to one per interval bucket, so it cannot flood the way a per-item
+        # kind would.
+        "deferred_question.resurfaced",
         "eval_local.queued",
         "incoming_event.dead_letter",
         "notify.redelivered",

--- a/tests/conformance/test_signal_route_totality.py
+++ b/tests/conformance/test_signal_route_totality.py
@@ -42,12 +42,6 @@ _LOOP_DIR = Path(__file__).resolve().parents[2] / "src" / "teatree" / "loop"
 INTENTIONAL_FALLBACK_KINDS: frozenset[str] = frozenset(
     {
         "deferred_question.mirrored",
-        # The nag's digest is the recurring peer of ``mirrored`` above and takes the
-        # same decision: the side effect (an owner DM) is already done when the signal
-        # is emitted, so there is no work to route — the statusline row IS the outcome.
-        # Bounded to one per interval bucket, so it cannot flood the way a per-item
-        # kind would.
-        "deferred_question.resurfaced",
         "eval_local.queued",
         "incoming_event.dead_letter",
         "notify.redelivered",

--- a/tests/teatree_core/management_commands/test_questions_resurface.py
+++ b/tests/teatree_core/management_commands/test_questions_resurface.py
@@ -139,7 +139,10 @@ class TestResurfaceText:
         assert "Ship?" in text
         assert "Yes — go" in text
         assert "No" in text
-        assert "reply in this thread to answer" in text
+        # Still guarantees the message says HOW to answer, and now also that a TYPED
+        # reply is the recorded one — an emoji reaction on the question reaches no consumer.
+        assert "Reply in this thread" in text
+        assert "typed reply" in text
 
     def test_malformed_options_json_is_tolerated(self) -> None:
         row = DeferredQuestion.record("Broken?", options_json="{not json", session_id="s-1")

--- a/tests/teatree_core/test_question_backlog_digest.py
+++ b/tests/teatree_core/test_question_backlog_digest.py
@@ -1,0 +1,103 @@
+"""The recurring open-question digest — one message per interval, same DM thread.
+
+Directive #36: resurface the open questions as often as necessary until the
+owner answers, in the SAME Slack thread and with the message count as low as
+possible. The per-question first-post drains are single-shot (their idempotency
+key is per question), so nothing recurred; this digest is the recurring half and
+it collapses the whole backlog into ONE message per interval.
+"""
+
+import datetime as dt
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from teatree.core.models import DeferredQuestion
+from teatree.core.notify_question_drains import (
+    RESURFACE_INTERVAL_HOURS,
+    format_backlog_digest,
+    resurface_question_backlog,
+)
+
+
+class TestBacklogDigestText(TestCase):
+    def test_digest_lists_every_pending_question_id_in_one_message(self) -> None:
+        first = DeferredQuestion.record("Unify the worktree output root?")
+        second = DeferredQuestion.record("Which merge target for the coding phase?")
+
+        text = format_backlog_digest([first, second])
+
+        assert f"#{first.pk}" in text
+        assert f"#{second.pk}" in text
+        assert "Unify the worktree output root?" in text
+        assert "2 open question" in text
+
+    def test_digest_caps_the_list_and_names_the_remainder(self) -> None:
+        rows = [DeferredQuestion.record(f"Question {i}") for i in range(14)]
+
+        text = format_backlog_digest(rows)
+
+        assert "+4 more" in text
+        assert f"#{rows[-1].pk}" not in text
+
+    def test_digest_tells_the_owner_to_reply_with_the_question_id(self) -> None:
+        row = DeferredQuestion.record("Merge it?")
+
+        text = format_backlog_digest([row])
+
+        assert "reply" in text.lower()
+        assert "t3 " not in text
+
+
+class TestResurfaceQuestionBacklog(TestCase):
+    def test_empty_backlog_posts_nothing(self) -> None:
+        with patch("teatree.core.notify_question_drains.notify_user") as notify:
+            posted, pending = resurface_question_backlog()
+
+        notify.assert_not_called()
+        assert (posted, pending) == (False, 0)
+
+    def test_internal_rows_never_reach_the_owner_digest(self) -> None:
+        DeferredQuestion.record("I lack the shell tool to proceed.", audience=DeferredQuestion.Audience.INTERNAL)
+
+        with patch("teatree.core.notify_question_drains.notify_user") as notify:
+            posted, pending = resurface_question_backlog()
+
+        notify.assert_not_called()
+        assert (posted, pending) == (False, 0)
+
+    def test_one_digest_covers_the_whole_backlog(self) -> None:
+        DeferredQuestion.record("First?")
+        DeferredQuestion.record("Second?")
+        DeferredQuestion.record("Third?")
+
+        with patch("teatree.core.notify_question_drains.notify_user", return_value=True) as notify:
+            posted, pending = resurface_question_backlog()
+
+        assert notify.call_count == 1
+        assert (posted, pending) == (True, 3)
+
+    def test_the_interval_bucket_is_the_idempotency_key(self) -> None:
+        DeferredQuestion.record("Merge it?")
+        now = timezone.now()
+
+        with patch("teatree.core.notify_question_drains.notify_user", return_value=True) as notify:
+            resurface_question_backlog(now=now)
+            key_first = notify.call_args.kwargs["idempotency_key"]
+            resurface_question_backlog(now=now + dt.timedelta(minutes=5))
+            key_same_bucket = notify.call_args.kwargs["idempotency_key"]
+            resurface_question_backlog(now=now + dt.timedelta(hours=RESURFACE_INTERVAL_HOURS))
+            key_next_bucket = notify.call_args.kwargs["idempotency_key"]
+
+        # Same bucket → the BotPing ledger collapses the repeat; a new bucket is a new nag.
+        assert key_first == key_same_bucket
+        assert key_next_bucket != key_first
+
+    def test_a_failed_delivery_reports_not_posted(self) -> None:
+        DeferredQuestion.record("Merge it?")
+
+        with patch("teatree.core.notify_question_drains.notify_user", return_value=False):
+            posted, pending = resurface_question_backlog()
+
+        assert (posted, pending) == (False, 1)

--- a/tests/teatree_loop/scanners/test_question_backlog_nag_scanner.py
+++ b/tests/teatree_loop/scanners/test_question_backlog_nag_scanner.py
@@ -1,0 +1,51 @@
+"""Behaviour tests for :class:`QuestionBacklogNagScanner`.
+
+The recurring caller the resurface mechanism never had: it drives
+:func:`teatree.core.notify_question_drains.resurface_question_backlog` once per
+tick, and that function's interval bucket decides whether a message actually
+goes out. Side-effecting; emits a signal only when a digest was delivered.
+"""
+
+from unittest.mock import patch
+
+from django.db import OperationalError
+from django.test import TestCase
+
+from teatree.loop.domain_jobs import _global_dispatch_jobs
+from teatree.loop.scanners.question_backlog_nag import QuestionBacklogNagScanner
+
+
+class TestQuestionBacklogNagScanner(TestCase):
+    def test_no_signal_when_the_interval_suppressed_the_digest(self) -> None:
+        with patch("teatree.core.notify_question_drains.resurface_question_backlog", return_value=(False, 7)):
+            assert QuestionBacklogNagScanner().scan() == []
+
+    def test_emits_signal_when_the_digest_was_delivered(self) -> None:
+        with patch("teatree.core.notify_question_drains.resurface_question_backlog", return_value=(True, 42)):
+            signals = QuestionBacklogNagScanner().scan()
+        assert len(signals) == 1
+        assert signals[0].kind == "deferred_question.resurfaced"
+        assert signals[0].payload == {"pending": 42}
+
+    def test_db_unavailable_is_silent_noop(self) -> None:
+        with patch(
+            "teatree.core.notify_question_drains.resurface_question_backlog",
+            side_effect=OperationalError("no such table: teatree_deferred_question"),
+        ):
+            assert QuestionBacklogNagScanner().scan() == []
+
+    def test_unexpected_error_never_raises(self) -> None:
+        with patch(
+            "teatree.core.notify_question_drains.resurface_question_backlog",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert QuestionBacklogNagScanner().scan() == []
+
+
+class TestNagRunsOnEveryTick(TestCase):
+    """The whole point: something calls the resurface. Without this it is dead code."""
+
+    def test_the_global_dispatch_set_carries_the_nag_scanner(self) -> None:
+        names = [job.scanner.name for job in _global_dispatch_jobs()]
+
+        assert "question_backlog_nag" in names

--- a/tests/teatree_loop/test_jobs_for_domain.py
+++ b/tests/teatree_loop/test_jobs_for_domain.py
@@ -107,6 +107,7 @@ class JobsForDomainPartitionTestCase(TestCase):
             "outbound_audit",
             "undelivered_notify",
             "deferred_question_poster",
+            "question_backlog_nag",
             "waiting_digest",
             "work_state",
         }

--- a/tests/teatree_loops/test_mini_loop_jobs.py
+++ b/tests/teatree_loops/test_mini_loop_jobs.py
@@ -63,6 +63,7 @@ class TestDispatchLoopBuildJobs:
             "outbound_audit",
             "undelivered_notify",
             "deferred_question_poster",
+            "question_backlog_nag",
             "waiting_digest",
             "work_state",
         }


### PR DESCRIPTION
fix(loop): give the open-question backlog a resurface cadence

Reconcilable: `/home/teatree/plans/dropped-items-audit.md` — finding 2 ("The open-question backlog is never resurfaced"), directive #36.

Rebased onto and verified against `origin/main` at `1a068515ea17fa4368e7240634767fd5c66f654a`.

## Why

The audit says no resurface mechanism exists. It does — `t3 teatree questions resurface` works. But the correction is itself incomplete, and the second half is what makes a caller-only fix useless:

1. **Nothing called it.** No scanner, no loop, no cadence — so the backlog sat from Jul 21.
2. **Even when called it cannot recur.** Both existing drains key idempotency on the rows `stable_notify_ref`, so each question posts exactly once ever. A question the owner never answers is never raised again.

So the fix needs a caller AND a recurring shape.

## What

`QuestionBacklogNagScanner` joins the always-on global dispatch set (next to `DeferredQuestionPosterScanner`, its first-post peer) and drives a new `resurface_question_backlog()`:

- **One message per interval, not one per question.** Up to 10 questions named by id, then a `+N more` count — a 42-deep backlog is one readable DM, not 42.
- **Same thread, not a new post** (directive #36). `notify_user` already threads into the active DM thread.
- **The interval bucket IS the idempotency key** (`question-backlog-digest:<bucket>`, 24h), so every tick inside a bucket collapses onto the single delivered `BotPing` row. No re-spam by construction.
- INTERNAL-audience rows are excluded, as in both first-post drains.

Deliberately NOT merged with the #3783 findings notifier: findings dedupe unchanged items, questions are the inverse obligation.

## The reaction question — verdict: no, a reaction cannot answer a two-option question

The owner answered two questions with 👍 and nothing read it. The substrate exists (`reaction_added` is subscribed, received, and already consumed by `SlackReviewIntentScanner` / `slack_self_ack`), so binding reactions is buildable. But 👍 is a sentiment, not an option index: on "canary or full rollout?" it names neither, and most `AskUserQuestion` payloads are not yes/no. A guessed mapping writes a wrong answer into a durable, single-use `DeferredQuestion` that then drives real work.

Proposed instead, not built: seed `:one:`/`:two:`/… on the mirror post so a reaction names the option by index; seed ✅/❌ only for a genuinely binary question; accept 👍 as its own distinct semantic ("no preference, use your recommendation"), never silently as option 1. That needs an option-index scanner plus a seeding step, and wants the owners nod on the emoji vocabulary first.

Meanwhile the per-question text now says a typed reply is what gets recorded, so the silent loss does not repeat.

## Post-review correction — the signal had no route

CIs signal-route totality gate caught a real defect: the new `deferred_question.resurfaced` kind fell through to the generic fallback. Reading `_dispatch_one` settled what that means — the fallback does return a statusline action rather than dropping, but `in_flight` files a pending owner decision under work-in-progress. Fixed with an explicit `STATUSLINE_ZONE_BY_KIND` route to **`action_needed`**: the digest exists BECAUSE the per-question first posts (`deferred_question.mirrored`, in_flight) went unanswered, so the nag is the escalation and belongs where the owner looks for what they owe. The conformance allowlist is left exactly as on main.

## Architecture pre-check

1. **BLUEPRINT § alignment** — §17.1 invariant 9 (no user-directed question is silently dropped) and §5.6 loop topology. No contract change, so no BLUEPRINT edit.
2. **FSM phase boundaries** — n/a. No `Ticket.State` / `Worktree.State` transition; `DeferredQuestion` rows are read, never resolved, by the nag.
3. **Extension-point contracts** — none. No `OverlayBase` hook, no `*Backend` Protocol; the scanner joins the existing global job list and registers one statusline route.
4. **Component boundaries** — egress in `core/notify_question_drains.py` (whose docstring already scopes it to these drains), cadence in `loop/scanners/`, routing in `loop/dispatch_tables.py`. Same seam as the poster.
5. **Dependency direction** — `loop.scanners` → `core.notify_question_drains` via a tick-time deferred import, identical to the poster. `uv run tach check` → `All modules validated!`.
6. **Test surface** — `tests/teatree_core/test_question_backlog_digest.py` (digest text, INTERNAL exclusion, one-message-per-backlog, bucket-is-the-key, failed-delivery reporting); `tests/teatree_loop/scanners/test_question_backlog_nag_scanner.py` (signal shape, DB-unavailable no-op, never-raises, and the wiring assertion — proven RED by removing the wiring line); the routing is pinned by the totality gate itself.
7. **Resilience invariants** — verify-by-re-read: the `BotPing` ledger is the delivery record and `notify_user` returns the confirmed-send boolean. Fallback-transport: the durable rows ARE the fallback; a non-delivery leaves them pending for the next bucket. Idempotency: the bucket key under `BotPing`s unique constraint. Heartbeat: a `ScanSignal` only on an actual delivery, so a tick never falsely reports a nag. Sub-agent contract: n/a.
8. **Identity and key normalization** — the digest key is the interval bucket (a global scalar), not a per-row id. The per-question keys keep their `stable_notify_ref` qualification untouched.
9. **Behavior preservation** — additive apart from one message string. No matcher narrowed, no test inverted, no drain removed; both existing drains keep their exact single-shot semantics. The one stale assertion pinning the retired sentence was updated to assert the new instruction, preserving its behavioural guarantee (the message says HOW to answer) and adding the new claim (a TYPED reply is the recorded one).
10. **Removability / harness-vs-data** — removable: delete the scanner file, its export, one line in `_global_dispatch_jobs` and one route entry, and the behaviour reverts. Harness-vs-data: the interval is a module constant rather than a `ConfigSetting` because `src/teatree/config/` is under active rewrite; promoting it later is a one-line change.

## Gates

`ruff check` (All checks passed), `ruff format` (clean), `tach check` (validated), `t3 tool test-path-mirror` (ledger exact), flat-core pin + incompleteness ratchet (14 passed), and the FULL shuffle-lane curated set run locally at seed 7 — **8399 passed** — which is the lane the original scoped run skipped. Nothing armed, no loop enabled or unmasked, no Slack message sent: every test asserts on what would be posted through a patched `notify_user`.