### PR TITLE
test(e2e): run the dash lane against an installed chromium when Playwright has no build

### DIFF
--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -6,3 +6,11 @@ See the root [`CLAUDE.md`](../CLAUDE.md) for the code-quality bar. This file add
 - **Full worktree per PR (non-negotiable).** Each PR under test gets its own backend + frontend via `t3 <overlay> worktree provision` + `t3 <overlay> worktree start`. Never mix one worktree's backend with another's frontend; never hand-patch an incomplete worktree — delete and recreate.
 - **Evidence comes from the deployed environment**, never from local builds or `localhost` screenshots (`/t3:rules` § "Evidence Comes From the Deployed Environment").
 - **Never blindly accept snapshot baselines** — verify the captured PNG shows the asserted state before updating (`/t3:e2e` visual QA gate).
+- **On a host Playwright has no browser build for, name an installed chromium** via `E2E_CHROMIUM_EXECUTABLE`. `playwright install` refuses on an unrecognised platform — and *exits 0 while printing `Failed to install browsers`*, so never gate provisioning on its exit code. CI leaves the variable unset and launches Playwright's own browser:
+
+  ```bash
+  E2E_CHROMIUM_EXECUTABLE=/snap/chromium/current/usr/lib/chromium-browser/chrome \
+    uv run pytest e2e/dash --ds=e2e.dash.settings
+  ```
+
+  Two specs depend on the host rather than the browser: `test_terminal_button_click_renders_launch_url` needs `ttyd` on `PATH`, and `test_admin_index_loads_clean` fails against a full chromium because it requests `/favicon.ico` (404) while CI's `chrome-headless-shell` never does.

--- a/e2e/dash/browser_launch.py
+++ b/e2e/dash/browser_launch.py
@@ -1,0 +1,29 @@
+"""Launch arguments for the /dash/ e2e lane's browser.
+
+Kept out of ``conftest.py`` so tests can import it without executing conftest's
+import-time side effects (it sets ``DJANGO_ALLOW_ASYNC_UNSAFE`` for the sync
+Playwright + sync Django combination, which must not leak into other lanes).
+"""
+
+BROWSER_EXECUTABLE_ENV = "E2E_CHROMIUM_EXECUTABLE"
+
+
+def browser_launch_overrides(executable: str | None) -> dict[str, object]:
+    """Launch-arg overrides for an externally-provided chromium, or none when unset.
+
+    Playwright ships browser builds per distro and has none for every host it can
+    otherwise run on — ``playwright install`` refuses outright on an unrecognised
+    platform, so the lane is unrunnable there even though a perfectly good chromium
+    is installed. Pointing Playwright at that binary is the supported escape.
+
+    ``--no-sandbox`` is required because a distro chromium's SUID sandbox helper is
+    not installed at the path Playwright's own build uses; the other two flags avoid
+    a GPU probe and a shared-memory sizing assumption that headless containers and
+    confined desktop packages both break on.
+    """
+    if not executable:
+        return {}
+    return {
+        "executable_path": executable,
+        "args": ["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"],
+    }

--- a/e2e/dash/conftest.py
+++ b/e2e/dash/conftest.py
@@ -26,6 +26,39 @@ from tests.factories import PullRequestFactory, TicketFactory, TicketTransitionF
 
 State = Ticket.State
 
+BROWSER_EXECUTABLE_ENV = "E2E_CHROMIUM_EXECUTABLE"
+
+
+def browser_launch_overrides(executable: str | None) -> dict[str, object]:
+    """Launch-arg overrides for an externally-provided chromium, or none when unset.
+
+    Playwright ships browser builds per distro and has none for every host it can
+    otherwise run on — ``playwright install`` refuses outright on an unrecognised
+    platform, so the lane is unrunnable there even though a perfectly good chromium
+    is installed. Pointing Playwright at that binary is the supported escape.
+
+    ``--no-sandbox`` is required because a distro chromium's SUID sandbox helper is
+    not installed at the path Playwright's own build uses; the other two flags avoid
+    a GPU probe and a shared-memory sizing assumption that headless containers and
+    confined desktop packages both break on.
+    """
+    if not executable:
+        return {}
+    return {
+        "executable_path": executable,
+        "args": ["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"],
+    }
+
+
+@pytest.fixture(scope="session")
+def browser_type_launch_args(browser_type_launch_args: dict[str, object]) -> dict[str, object]:
+    """Honor ``E2E_CHROMIUM_EXECUTABLE`` so a host without a Playwright build can run the lane.
+
+    Unset (CI, where the job installs Playwright's own chromium) this returns the
+    plugin's arguments untouched, so the lane runs byte-identically to before.
+    """
+    return {**browser_type_launch_args, **browser_launch_overrides(os.environ.get(BROWSER_EXECUTABLE_ENV))}
+
 
 @pytest.fixture
 def seeded_board(request: pytest.FixtureRequest) -> SeededBoard:

--- a/e2e/dash/conftest.py
+++ b/e2e/dash/conftest.py
@@ -19,35 +19,13 @@ os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "1")
 import pytest
 from playwright.sync_api import Page
 
+from e2e.dash.browser_launch import BROWSER_EXECUTABLE_ENV, browser_launch_overrides
 from e2e.dash.pom import ConsoleGuard, SeededBoard
 from teatree.core.models.loop import Loop
 from teatree.core.models.ticket import Ticket
 from tests.factories import PullRequestFactory, TicketFactory, TicketTransitionFactory
 
 State = Ticket.State
-
-BROWSER_EXECUTABLE_ENV = "E2E_CHROMIUM_EXECUTABLE"
-
-
-def browser_launch_overrides(executable: str | None) -> dict[str, object]:
-    """Launch-arg overrides for an externally-provided chromium, or none when unset.
-
-    Playwright ships browser builds per distro and has none for every host it can
-    otherwise run on — ``playwright install`` refuses outright on an unrecognised
-    platform, so the lane is unrunnable there even though a perfectly good chromium
-    is installed. Pointing Playwright at that binary is the supported escape.
-
-    ``--no-sandbox`` is required because a distro chromium's SUID sandbox helper is
-    not installed at the path Playwright's own build uses; the other two flags avoid
-    a GPU probe and a shared-memory sizing assumption that headless containers and
-    confined desktop packages both break on.
-    """
-    if not executable:
-        return {}
-    return {
-        "executable_path": executable,
-        "args": ["--no-sandbox", "--disable-gpu", "--disable-dev-shm-usage"],
-    }
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_e2e_dash_browser_executable.py
+++ b/tests/test_e2e_dash_browser_executable.py
@@ -6,7 +6,7 @@ chromium is installed. `E2E_CHROMIUM_EXECUTABLE` points the lane at that binary.
 leaves it unset and must keep launching exactly as before.
 """
 
-from e2e.dash.conftest import browser_launch_overrides
+from e2e.dash.browser_launch import browser_launch_overrides
 
 
 class TestBrowserLaunchOverrides:

--- a/tests/test_e2e_dash_browser_executable.py
+++ b/tests/test_e2e_dash_browser_executable.py
@@ -1,0 +1,28 @@
+"""The /dash/ e2e lane runs against an externally-provided chromium when one is named.
+
+Playwright ships browser builds per distro and refuses to install on a platform it has
+no build for, which makes the lane unrunnable on such a host even when a working
+chromium is installed. `E2E_CHROMIUM_EXECUTABLE` points the lane at that binary. CI
+leaves it unset and must keep launching exactly as before.
+"""
+
+from e2e.dash.conftest import browser_launch_overrides
+
+
+class TestBrowserLaunchOverrides:
+    def test_no_overrides_when_no_executable_is_named(self) -> None:
+        assert browser_launch_overrides(None) == {}
+
+    def test_an_empty_value_is_treated_as_unset(self) -> None:
+        assert browser_launch_overrides("") == {}
+
+    def test_a_named_executable_is_launched_instead_of_playwrights_own(self) -> None:
+        overrides = browser_launch_overrides("/usr/bin/chromium")
+
+        assert overrides["executable_path"] == "/usr/bin/chromium"
+
+    def test_a_named_executable_disables_the_sandbox_it_cannot_provide(self) -> None:
+        """A distro chromium has no SUID helper at the path Playwright's build uses."""
+        overrides = browser_launch_overrides("/usr/bin/chromium")
+
+        assert "--no-sandbox" in overrides["args"]


### PR DESCRIPTION
test(e2e): run the dash lane against an installed chromium when Playwright has no build

## What

Adds `E2E_CHROMIUM_EXECUTABLE`. When set, the `/dash/` e2e lane launches that binary instead of Playwright's own. When unset — every CI job, since those install Playwright's browser — the launch arguments pass through untouched and CI behaviour is unchanged.

## Why

Playwright ships browser builds per distro and refuses to install on a platform it has no build for. On this host `playwright install <any browser>` fails for all of them, so the lane could not run locally at all and the specs were effectively CI-only.

That mattered concretely: those specs caught a production fix that was wrong in a way the Django test client **structurally cannot see** (htmx drops a submit button's `name`/`value`), plus a pre-existing bug where `/dash/health`'s "Run doctor" never worked with JS enabled. Every such finding had to round-trip through CI.

Two traps worth recording, both now in `e2e/CLAUDE.md`:

- **`playwright install` exits 0 while printing `Failed to install browsers`.** Any provisioning script checking its exit code reads success.
- **`--dry-run` is not a support check** — it prints install locations for browsers the platform cannot run.

## Evidence

Against the distro chromium on Ubuntu 26.04, where `playwright install` supports nothing: **30 of 32 specs pass**.

The 2 failures depend on the host rather than the browser, and neither is masked:

- `test_terminal_button_click_renders_launch_url` — needs `ttyd` on `PATH`.
- `test_admin_index_loads_clean` — a full chromium requests `/favicon.ico` and gets a 404; CI's `chrome-headless-shell` never requests it. **The console guard was deliberately not relaxed to hide this** — it is a real browser-behaviour delta, and weakening the guard to get a green local run would cost the assertion its value in CI.

`tests/test_e2e_dash_browser_executable.py` pins the override logic and was **proven RED first**: sabotaging the helper (returning an executable when none is named, dropping `--no-sandbox`) fails 3 of its 4 tests; restored, 4 pass.

## Gates

ruff check + format clean · test-path-mirror ledger exact · module-health clean vs `origin/main` · 38 passed across the e2e-adjacent test lane · all pre-commit hooks passed including tach, import-linter, ty-check, banned-terms and the anti-relaxation gate.
