### PR TITLE
fix(deploy): unwedge box convergence — lossless fast-forward + attributable image fetches

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -27,10 +27,33 @@ FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebff
 # terminal, the tasks command — so it needs a current known-good release; the
 # bundle's 2.1.169 predates `claude-opus-5`, which model_tiering resolves as the
 # `frontier` tier. Both tiers are guarded by tests/test_claude_cli_pin.py.
+# bash with `pipefail`, not the default dash `/bin/sh`. dash has no `pipefail`, so
+# a `curl ... | bash` whose FETCH fails still reports only the shell's exit status
+# and the `&&` chain sails on. That silently broke the box: NodeSource answered the
+# setup script with HTTP 403 on one build, the repo was therefore never added,
+# `apt-get install nodejs` happily installed Ubuntu's nodejs 18 — which packages
+# npm SEPARATELY, so npm was absent — and the layer died 6 seconds later at
+# `npm install -g` with a bare `/bin/sh: 1: npm: not found` and exit 127, naming
+# neither the 403 nor the wrong node. Every fetch below is now attributable.
+SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
+
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends \
         ca-certificates curl direnv git gnupg jq pass sqlite3 ttyd && \
-    curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
+    # Fetch the NodeSource setup script to a FILE, never straight into a shell, so
+    # a truncated or error body cannot be executed as a script; and retry, so a
+    # transient CDN 403/5xx costs seconds instead of the whole deploy.
+    for attempt in 1 2 3 4 5; do \
+        if curl -fsSL https://deb.nodesource.com/setup_24.x -o /tmp/nodesource_setup.sh; then break; fi; \
+        echo "deploy image: NodeSource setup_24.x fetch failed (attempt ${attempt}/5) - retrying" >&2; \
+        if [ "$attempt" -lt 5 ]; then sleep 15; fi; \
+    done && \
+    if [ ! -s /tmp/nodesource_setup.sh ]; then \
+        echo "deploy image: FATAL - could not fetch https://deb.nodesource.com/setup_24.x after 5 attempts. Without that repo apt installs Ubuntu's nodejs 18, which ships no npm, and this build would die later with an unattributable 'npm: not found'." >&2; \
+        exit 1; \
+    fi && \
+    bash /tmp/nodesource_setup.sh && \
+    rm -f /tmp/nodesource_setup.sh && \
     apt-get install -y -qq --no-install-recommends nodejs && \
     install -m 0755 -d /etc/apt/keyrings && \
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -45,6 +68,13 @@ RUN apt-get update -qq && \
         > /etc/apt/sources.list.d/docker.list && \
     apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends gh docker-ce-cli docker-compose-plugin && \
+    # Assert the node that landed is the NodeSource one before leaning on npm.
+    # `npm: not found` from the line below is the symptom that cost a week of
+    # deploys; say what it MEANS at the moment it is provable.
+    if ! command -v npm >/dev/null 2>&1; then \
+        echo "deploy image: FATAL - npm is absent after installing nodejs ($(node --version 2>/dev/null || echo 'node missing')). The NodeSource repo did not take effect, so this is Ubuntu's nodejs, which packages npm separately." >&2; \
+        exit 1; \
+    fi && \
     npm install -g @anthropic-ai/claude-code@2.1.220 pyright@1.1.411 && \
     npm cache clean --force && \
     rm -rf /var/lib/apt/lists/*
@@ -113,7 +143,21 @@ WORKDIR /home/teatree
 
 # uv (the only baked python toolchain) — the teatree editable install and its
 # managed Python land on the shared /opt/teatree/uv volume at runtime.
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+# Fetched to a file, retried, and size-checked for the same reason as the
+# NodeSource script above: this is the second `curl | shell` in the image, and a
+# CDN blip here would otherwise pipe an error page into a shell and surface as
+# some later "uv: not found" that names nothing.
+RUN for attempt in 1 2 3 4 5; do \
+        if curl -LsSf https://astral.sh/uv/install.sh -o /tmp/uv-install.sh; then break; fi; \
+        echo "deploy image: uv install.sh fetch failed (attempt ${attempt}/5) - retrying" >&2; \
+        if [ "$attempt" -lt 5 ]; then sleep 15; fi; \
+    done && \
+    if [ ! -s /tmp/uv-install.sh ]; then \
+        echo "deploy image: FATAL - could not fetch https://astral.sh/uv/install.sh after 5 attempts." >&2; \
+        exit 1; \
+    fi && \
+    sh /tmp/uv-install.sh && \
+    rm -f /tmp/uv-install.sh
 
 # No XDG_DATA_HOME: with HOME=/home/teatree the default already resolves DATA_DIR
 # to ~/.local/share/teatree (the canonical DB on the teatree_data volume). Setting

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -38,7 +38,11 @@ _DRAINED=false
 _SWAP_DONE=false
 _clear_quiescing_if_stranded() {
     if [ "$_DRAINED" = true ] && [ "$_SWAP_DONE" = false ]; then
-        echo "deploy: exiting after a drain but before the swap — clearing worker_quiescing so admission resumes." >&2
+        # Say "cleanup", loudly. This runs LAST, so it is the final line in the
+        # Action log and reads as the cause to anyone triaging the failure — it is
+        # not; the real error is further up. One triage of this run was nearly
+        # anchored on this very line.
+        echo "deploy: [cleanup, NOT the failure cause — see the error above] exiting after a drain but before the swap; clearing worker_quiescing so admission resumes." >&2
         docker compose -f "$COMPOSE_FILE" exec -T teatree-worker \
             t3 teatree config_setting set worker_quiescing false >/dev/null 2>&1 || true
     fi
@@ -81,8 +85,13 @@ if [ ! -f "$ENV_FILE" ]; then
 fi
 
 # Bring the build context current (fast-forward only — never clobber local work).
-git -C "$REPO_ROOT" fetch --prune origin
-git -C "$REPO_ROOT" pull --ff-only
+# The helper runs `fetch --prune origin` then `pull --ff-only`, and between them
+# reconciles the one class of local dirt a fast-forward provably cannot lose: a
+# path whose working-tree bytes already equal the target's. Everything else is
+# retained and, if it blocks the merge, named in a fatal diagnostic. See its
+# header for the wedge this closes — a `uv.lock` silently re-locked by `uv run`
+# aborted every deploy and left the box 42 commits behind, unreported, for days.
+bash "$SCRIPT_DIR/fast-forward-checkout.sh" "$REPO_ROOT"
 echo "deploy: deploying $(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD) @ $(git -C "$REPO_ROOT" rev-parse --short HEAD)"
 
 # EVERY host bind-mount SOURCE dir (compose x-teatree-common `volumes:`) must
@@ -154,8 +163,12 @@ if worker_running; then
 fi
 
 # Surface the WHY on a build/up failure — `set -e` would otherwise exit before
-# the Action log sees anything but "exited (1)".
+# the Action log sees anything but "exited (1)". The banner is load-bearing: the
+# 200 stale container lines below push the real buildkit error hundreds of lines
+# up the Action log, where it reads as unrelated noise. Name the failing step at
+# the top of the dump so triage starts in the right place.
 docker compose -f "$COMPOSE_FILE" up -d --build || {
+    echo "deploy: FATAL — 'docker compose up -d --build' failed. The cause is the buildkit/compose error ABOVE this line; what follows is stack state for context, not the failure."
     docker compose -f "$COMPOSE_FILE" ps
     docker compose -f "$COMPOSE_FILE" logs --tail 200 teatree-init teatree-worker teatree-admin
     exit 1

--- a/deploy/fast-forward-checkout.sh
+++ b/deploy/fast-forward-checkout.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Fast-forward the deploy build-context checkout to its upstream, surviving the
+# one kind of local dirt that can never be lost by doing so.
+#
+# WHY THIS EXISTS. The checkout is the deploy build context AND the host's main
+# clone that agents branch worktrees from, so host-side tooling writes into its
+# working tree. The recorded wedge: a dependabot PR bumps a pin in
+# `pyproject.toml` WITHOUT regenerating `uv.lock` (the pip ecosystem does not
+# know about uv — that gap is why `.github/workflows/uv-lock-upgrade.yml`
+# exists), and the next `uv run` in this clone silently re-locks `uv.lock` to
+# match. That leaves ONE modified tracked file, and from then on
+# `git pull --ff-only` aborts with
+#
+#     error: Your local changes to the following files would be overwritten by merge
+#
+# on EVERY subsequent deploy. Nothing retries, nothing reports it, and the box
+# silently stops tracking main while merges keep landing — it sat 42 commits
+# behind before anyone noticed that "the deploy is red" meant "production is a
+# different codebase".
+#
+# THE SAFETY STANDARD IS CONTENT-EQUIVALENCE, NOT "LOOKS REGENERABLE". A blanket
+# `git reset --hard` / `git clean -fd` would unwedge every case and destroy
+# uncommitted work in a clone that other agents share. So dirt is discarded ONLY
+# when the working-tree blob already equals the blob at the fast-forward target:
+# the fast-forward then recreates that exact content, so nothing unique can be
+# lost. Every other modified, deleted, or untracked path is RETAINED untouched —
+# and if it blocks the merge the deploy fails loud NAMING each file and the
+# recovery command, instead of a raw git error that identifies neither.
+set -euo pipefail
+
+REPO_ROOT="${1:?usage: fast-forward-checkout.sh <repo-root>}"
+
+git -C "$REPO_ROOT" fetch --prune origin
+
+# The exact ref `git pull --ff-only` would merge. Without an upstream there is
+# nothing to compare against, so no dirt is provably lossless and none is touched.
+FF_TARGET="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+
+retained=()
+
+# Blob sha of <rev>:<path>, or empty when that rev does not carry the path.
+blob_at() {
+    git -C "$REPO_ROOT" rev-parse --quiet --verify "$1:$2" 2>/dev/null || true
+}
+
+# True when discarding the local state of <path> destroys nothing: either the
+# working tree already holds the target's exact bytes, or the path is absent from
+# the working tree (a deletion has no content to lose) and the target restores it.
+lossless_to_discard() {
+    local path="$1" target_blob="$2"
+    [ -n "$target_blob" ] || return 1
+    if [ ! -e "$REPO_ROOT/$path" ]; then
+        return 0
+    fi
+    [ "$(git -C "$REPO_ROOT" hash-object -- "$path" 2>/dev/null || true)" = "$target_blob" ]
+}
+
+if [ -n "$FF_TARGET" ]; then
+    # Tracked paths that differ from HEAD, staged or unstaged, deletions included.
+    # `< <(...)` (process substitution, never a pipe) keeps the loop in this shell
+    # so `retained` survives it.
+    while IFS= read -r -d '' path; do
+        if [ -n "$(blob_at HEAD "$path")" ] && lossless_to_discard "$path" "$(blob_at "$FF_TARGET" "$path")"; then
+            echo "deploy: discarding the local change to '$path' — its content already equals ${FF_TARGET}'s, so the fast-forward restores it byte-for-byte."
+            git -C "$REPO_ROOT" checkout HEAD -- "$path"
+        else
+            retained+=("$path")
+        fi
+    done < <(git -C "$REPO_ROOT" diff --name-only -z HEAD)
+
+    # Untracked paths the incoming commits would create. git refuses the merge for
+    # these too, and removing one whose bytes the target already carries is equally
+    # lossless.
+    while IFS= read -r -d '' path; do
+        if lossless_to_discard "$path" "$(blob_at "$FF_TARGET" "$path")"; then
+            echo "deploy: removing the untracked '$path' — ${FF_TARGET} carries that exact content."
+            rm -f "$REPO_ROOT/$path"
+        else
+            retained+=("$path")
+        fi
+    done < <(git -C "$REPO_ROOT" ls-files --others --exclude-standard -z)
+fi
+
+if git -C "$REPO_ROOT" pull --ff-only; then
+    exit 0
+fi
+
+echo "deploy: FATAL — could not fast-forward $REPO_ROOT to ${FF_TARGET:-its upstream}." >&2
+if [ "${#retained[@]}" -gt 0 ]; then
+    echo "deploy: these paths hold content that is NOT in ${FF_TARGET:-the upstream}, so they were kept, never discarded:" >&2
+    printf 'deploy:   %s\n' "${retained[@]}" >&2
+    echo "deploy: inspect each with 'git -C $REPO_ROOT diff -- <path>', then either move it to a branch or discard it with 'git -C $REPO_ROOT checkout HEAD -- <path>', and re-run the deploy." >&2
+else
+    echo "deploy: no local changes were retained, so the dirt is not the cause — read the git error above (diverged history, or an index lock / permission problem)." >&2
+fi
+exit 1

--- a/tests/test_deploy_fast_forward_checkout.py
+++ b/tests/test_deploy_fast_forward_checkout.py
@@ -1,0 +1,196 @@
+# test-path: cross-cutting
+"""The deploy build context fast-forwards past lossless dirt, and never past unique work.
+
+`deploy/fast-forward-checkout.sh` replaces the bare `git pull --ff-only` that
+wedged the box for 42 commits: a dependabot PR bumped a pin in `pyproject.toml`
+without regenerating `uv.lock`, the next `uv run` in the clone re-locked it, and
+every deploy from then on aborted with "Your local changes to the following files
+would be overwritten by merge" — unreported, so merged code silently stopped
+reaching production.
+
+These exercise the real script against real git repos under `tmp_path`. The
+safety property under test is content-equivalence: dirt is discarded ONLY when the
+working tree already holds the target's exact bytes, so the fast-forward restores
+it byte-for-byte. Unique local work is retained and reported, never destroyed.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests._git_repo import git_identity_env, make_git_repo, run_git
+
+_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _ROOT / "deploy" / "fast-forward-checkout.sh"
+_GIT = shutil.which("git") or "/usr/bin/git"
+_BASH = shutil.which("bash") or "/bin/bash"
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return run_git(cwd, *args)
+
+
+def _run_script(clone: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [_BASH, str(_SCRIPT), str(clone)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=git_identity_env(),
+    )
+
+
+def _clone(origin: Path, dest: Path) -> None:
+    subprocess.run(
+        [_GIT, "clone", "-q", str(origin), str(dest)],
+        check=True,
+        capture_output=True,
+        env=git_identity_env(),
+    )
+
+
+@pytest.fixture
+def repos(tmp_path: Path) -> tuple[Path, Path]:
+    """An origin one commit ahead of a clone, mirroring the box's build context."""
+    origin = tmp_path / "origin"
+    work = tmp_path / "origin-work"
+    clone = tmp_path / "clone"
+
+    make_git_repo(origin, bare=True)
+    _clone(origin, work)
+    (work / "uv.lock").write_text('version = "0.4.10"\n', encoding="utf-8")
+    (work / "keep.txt").write_text("base\n", encoding="utf-8")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-m", "base")
+    _git(work, "push", "-u", "origin", "main")
+
+    _clone(origin, clone)
+
+    # The commit the box is behind by — it bumps the very file that goes dirty.
+    (work / "uv.lock").write_text('version = "0.4.11"\n', encoding="utf-8")
+    (work / "added-upstream.txt").write_text("upstream\n", encoding="utf-8")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-m", "bump")
+    _git(work, "push")
+
+    return clone, work
+
+
+class TestLosslessDirtIsDiscarded:
+    def test_fast_forwards_past_a_locally_regenerated_file(self, repos: tuple[Path, Path]) -> None:
+        clone, _ = repos
+        # The recorded wedge: `uv run` re-locked uv.lock to exactly what upstream
+        # already carries. A bare `pull --ff-only` aborts here.
+        (clone / "uv.lock").write_text('version = "0.4.11"\n', encoding="utf-8")
+
+        result = _run_script(clone)
+
+        assert result.returncode == 0, result.stderr
+        assert "uv.lock" in result.stdout
+        assert _git(clone, "status", "--porcelain") == ""
+        assert (clone / "uv.lock").read_text(encoding="utf-8") == 'version = "0.4.11"\n'
+        assert (clone / "added-upstream.txt").exists()
+
+    def test_fast_forwards_past_an_untracked_file_the_merge_would_create(self, repos: tuple[Path, Path]) -> None:
+        clone, _ = repos
+        # git refuses the merge for untracked collisions too, with a different message.
+        (clone / "added-upstream.txt").write_text("upstream\n", encoding="utf-8")
+
+        result = _run_script(clone)
+
+        assert result.returncode == 0, result.stderr
+        assert _git(clone, "status", "--porcelain") == ""
+
+    def test_fast_forwards_past_a_locally_deleted_file(self, repos: tuple[Path, Path]) -> None:
+        clone, _ = repos
+        # A deletion holds no content, so restoring it can lose nothing.
+        (clone / "uv.lock").unlink()
+
+        result = _run_script(clone)
+
+        assert result.returncode == 0, result.stderr
+        assert (clone / "uv.lock").read_text(encoding="utf-8") == 'version = "0.4.11"\n'
+
+
+class TestUniqueWorkIsNeverDestroyed:
+    def test_unique_edit_to_an_incoming_file_fails_loud_and_is_kept(self, repos: tuple[Path, Path]) -> None:
+        clone, _ = repos
+        (clone / "uv.lock").write_text("hand-written local work\n", encoding="utf-8")
+
+        result = _run_script(clone)
+
+        assert result.returncode == 1
+        assert "FATAL" in result.stderr
+        assert "uv.lock" in result.stderr, "the diagnostic must NAME the blocking file"
+        assert "checkout HEAD --" in result.stderr, "and give the recovery command"
+        assert (clone / "uv.lock").read_text(encoding="utf-8") == "hand-written local work\n"
+
+    def test_unique_untracked_file_colliding_with_the_merge_is_kept(self, repos: tuple[Path, Path]) -> None:
+        clone, _ = repos
+        (clone / "added-upstream.txt").write_text("different local content\n", encoding="utf-8")
+
+        result = _run_script(clone)
+
+        assert result.returncode == 1
+        assert "added-upstream.txt" in result.stderr
+        assert (clone / "added-upstream.txt").read_text(encoding="utf-8") == "different local content\n"
+
+    def test_unrelated_local_edit_survives_the_fast_forward(self, repos: tuple[Path, Path]) -> None:
+        clone, _ = repos
+        # Dirt the merge does not touch never blocked the pull, and must not be
+        # collected as collateral by the reconciliation either.
+        (clone / "keep.txt").write_text("local work in progress\n", encoding="utf-8")
+
+        result = _run_script(clone)
+
+        assert result.returncode == 0, result.stderr
+        assert (clone / "keep.txt").read_text(encoding="utf-8") == "local work in progress\n"
+        assert (clone / "uv.lock").read_text(encoding="utf-8") == 'version = "0.4.11"\n'
+
+
+class TestControl:
+    def test_a_bare_ff_pull_really_does_abort_on_the_regenerated_file(self, repos: tuple[Path, Path]) -> None:
+        # Control for the whole suite: prove the wedge exists, so a green above is
+        # the guard working rather than a merge that never needed guarding.
+        clone, _ = repos
+        (clone / "uv.lock").write_text('version = "0.4.11"\n', encoding="utf-8")
+
+        pull = subprocess.run(
+            [_GIT, "-C", str(clone), "pull", "--ff-only"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=git_identity_env(),
+        )
+
+        assert pull.returncode != 0
+        assert "would be overwritten by merge" in pull.stderr
+
+    def test_clean_checkout_fast_forwards_unchanged(self, repos: tuple[Path, Path]) -> None:
+        clone, _ = repos
+
+        result = _run_script(clone)
+
+        assert result.returncode == 0, result.stderr
+        assert (clone / "uv.lock").read_text(encoding="utf-8") == 'version = "0.4.11"\n'
+
+
+class TestDeployScriptUsesTheGuard:
+    def test_deploy_sh_delegates_the_fast_forward_to_the_helper(self) -> None:
+        body = (_ROOT / "deploy" / "deploy.sh").read_text(encoding="utf-8")
+        assert "fast-forward-checkout.sh" in body, (
+            "deploy.sh must fast-forward through the guard, not a bare `git pull --ff-only` "
+            "that aborts on any stray lockfile write and reports nothing."
+        )
+
+    def test_the_helper_never_hard_resets_or_cleans(self) -> None:
+        # The unwedge must stay content-equivalence-scoped: a blanket reset/clean
+        # would also unwedge every case, and destroy uncommitted work in a clone
+        # that host agents share.
+        code = "\n".join(
+            line for line in _SCRIPT.read_text(encoding="utf-8").splitlines() if not line.lstrip().startswith("#")
+        )
+        assert "reset --hard" not in code
+        assert "git clean" not in code

--- a/tests/test_deploy_image_fetch_hardening.py
+++ b/tests/test_deploy_image_fetch_hardening.py
@@ -1,0 +1,73 @@
+# test-path: cross-cutting
+"""Every remote fetch in the deploy image is attributable and retried.
+
+The box's convergence failed on `docker compose up -d --build` with a bare
+`/bin/sh: 1: npm: not found` (exit 127). The cause was 15 seconds and one masked
+error earlier: `curl -fsSL https://deb.nodesource.com/setup_24.x | bash -` got
+HTTP 403, and because Docker's default shell is dash — which has no `pipefail` —
+the pipeline reported the shell's success, the `&&` chain continued, the
+NodeSource repo was never added, and `apt-get install nodejs` installed Ubuntu's
+nodejs 18, which packages npm separately.
+
+Three properties keep that from recurring silently: the build shell has
+`pipefail`, no fetch is piped straight into a shell, and a transient CDN error is
+retried before it can fail a deploy.
+"""
+
+import re
+from pathlib import Path
+
+DOCKERFILE = Path(__file__).resolve().parents[1] / "deploy" / "Dockerfile"
+
+
+def _content() -> str:
+    return DOCKERFILE.read_text(encoding="utf-8")
+
+
+def _code_lines() -> list[str]:
+    return [line for line in _content().splitlines() if not line.lstrip().startswith("#")]
+
+
+def test_build_shell_enables_pipefail() -> None:
+    shell_lines = [line for line in _code_lines() if line.startswith("SHELL ")]
+    assert shell_lines, (
+        "deploy/Dockerfile must declare a SHELL — the default dash has no `pipefail`, so a "
+        "failed fetch inside a pipeline is invisible to the `&&` chain."
+    )
+    assert any("pipefail" in line and "bash" in line for line in shell_lines), (
+        f"the SHELL directive must be bash with -o pipefail; got {shell_lines!r}"
+    )
+
+
+def test_no_remote_fetch_is_piped_into_a_shell() -> None:
+    # `curl ... | bash` also feeds a truncated or error body to a shell even when
+    # pipefail catches the exit status, so the pattern is banned outright.
+    piped = [line for line in _code_lines() if "curl" in line and re.search(r"\|\s*(ba)?sh\b", line)]
+    assert not piped, f"fetch to a file and run it, never pipe into a shell: {piped!r}"
+
+
+def test_the_nodesource_fetch_is_retried_and_fails_loud_when_empty() -> None:
+    content = _content()
+    assert "deb.nodesource.com/setup_24.x -o " in content, "the NodeSource setup script must be downloaded to a file"
+    assert "-s /tmp/nodesource_setup.sh" in content, (
+        "an empty/failed NodeSource download must fail the build immediately, at the point "
+        "where the cause is still nameable — not 15 seconds later as `npm: not found`."
+    )
+    assert re.search(r"for attempt in .*?; do.*?nodesource", content, re.DOTALL), (
+        "a transient CDN 403/5xx must be retried, not fail the whole deploy"
+    )
+
+
+def test_npm_absence_is_asserted_before_it_is_used() -> None:
+    code = "\n".join(_code_lines())
+    npm_guard = code.find("command -v npm")
+    npm_install = code.find("npm install -g")
+    assert npm_guard != -1, "the image must assert npm exists before installing global packages"
+    assert npm_guard < npm_install, "the assertion must precede the use it protects"
+
+
+def test_the_uv_installer_fetch_is_hardened_too() -> None:
+    # Same class, second call site: this was the image's other `curl | shell`.
+    content = _content()
+    assert "astral.sh/uv/install.sh -o " in content
+    assert "-s /tmp/uv-install.sh" in content

--- a/tests/test_deploy_rolling_drain.py
+++ b/tests/test_deploy_rolling_drain.py
@@ -20,6 +20,7 @@ import yaml
 _ROOT = Path(__file__).resolve().parents[1]
 _DEPLOY_YML = _ROOT / ".github" / "workflows" / "deploy.yml"
 _DEPLOY_SH = _ROOT / "deploy" / "deploy.sh"
+_FF_CHECKOUT_SH = _ROOT / "deploy" / "fast-forward-checkout.sh"
 _ENTRYPOINT_SH = _ROOT / "deploy" / "entrypoint.sh"
 _COMPOSE_YML = _ROOT / "deploy" / "docker-compose.yml"
 
@@ -43,9 +44,19 @@ class TestDeployDebounce:
         )
 
     def test_deploy_script_fast_forwards_to_latest_main(self) -> None:
-        body = _DEPLOY_SH.read_text(encoding="utf-8")
-        assert "fetch --prune origin" in body
-        assert "pull --ff-only" in body
+        # The fetch/pull pair now lives in deploy/fast-forward-checkout.sh, which
+        # wraps it in the lossless-dirt reconciliation (a stray `uv.lock` write
+        # aborted the bare `pull --ff-only` on every deploy for 42 commits).
+        # Assert on the helper's CODE, not on prose: matching the strings anywhere
+        # in deploy.sh would now be satisfied by the comment that points here.
+        assert "fast-forward-checkout.sh" in _DEPLOY_SH.read_text(encoding="utf-8")
+        code = "\n".join(
+            line
+            for line in _FF_CHECKOUT_SH.read_text(encoding="utf-8").splitlines()
+            if not line.lstrip().startswith("#")
+        )
+        assert "fetch --prune origin" in code
+        assert "pull --ff-only" in code
 
     def test_deploy_script_serializes_on_a_host_flock(self) -> None:
         # A remote deploy.sh can outlive its GitHub job, defeating the workflow

--- a/tests/test_deploy_worker_sizing.py
+++ b/tests/test_deploy_worker_sizing.py
@@ -25,6 +25,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DEPLOY = REPO_ROOT / "deploy"
 COMPOSE_FILE = DEPLOY / "docker-compose.yml"
 DEPLOY_SH = DEPLOY / "deploy.sh"
+FF_CHECKOUT_SH = DEPLOY / "fast-forward-checkout.sh"
 RAM_PROBE = REPO_ROOT / "src" / "teatree" / "utils" / "ram_probe.py"
 
 
@@ -63,6 +64,10 @@ class TestDeployShRunDerivesWorkerCaps:
         (repo / "deploy").mkdir(parents=True)
         (repo / "src" / "teatree" / "utils").mkdir(parents=True)
         shutil.copy(DEPLOY_SH, repo / "deploy" / "deploy.sh")
+        # deploy.sh delegates the fast-forward to this sibling; staging deploy.sh
+        # alone makes the run die at `No such file or directory` before it reaches
+        # the compose invocation under test.
+        shutil.copy(FF_CHECKOUT_SH, repo / "deploy" / "fast-forward-checkout.sh")
         shutil.copy(RAM_PROBE, repo / "src" / "teatree" / "utils" / "ram_probe.py")
         (repo / "deploy" / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
         (repo / "deploy" / "teatree.env").write_text("", encoding="utf-8")


### PR DESCRIPTION
fix(deploy): unwedge box convergence — lossless fast-forward + attributable image fetches

`Push · Deploy to box` had failed on **every** push to main, so merged code stopped reaching the box while main moved 42 commits ahead. Two independent defects, each of which turned a recoverable condition into a permanent, unreported one.

## Blocker 1 — the fast-forward aborted on a lockfile nobody wrote by hand

Sampled runs [30310599152](https://github.com/souliane/teatree/actions/runs/30310599152), [30302915447](https://github.com/souliane/teatree/actions/runs/30302915447), [30298909978](https://github.com/souliane/teatree/actions/runs/30298909978) and [30292609345](https://github.com/souliane/teatree/actions/runs/30292609345) all died the same way:

```
error: Your local changes to the following files would be overwritten by merge: uv.lock
Please commit your changes or stash them before you merge.
Aborting
```

The mechanism, traced end to end:

- [`64a234a6`](https://github.com/souliane/teatree/commit/64a234a6) (dependabot, merged) changed **only `pyproject.toml`** — `prek==0.4.10` → `0.4.11`. It did not touch `uv.lock`; the pip ecosystem does not know about uv, which is exactly the gap `.github/workflows/uv-lock-upgrade.yml` exists to close.
- `uv run` silently re-locks when `pyproject.toml` has moved. Verified with a control: on an unchanged `pyproject.toml`, `uv run` leaves `uv.lock` byte-identical; after a pyproject-only `0.4.10` → `0.4.11` bump, `uv run` rewrote `uv.lock` to `0.4.11` without being asked.
- The regeneration landed upstream days later, inside the unrelated [`032b601a`](https://github.com/souliane/teatree/commit/032b601a) — which is why the box's dirty `uv.lock` was byte-identical to `origin/main`'s.

So one modified tracked file, produced by routine tooling and byte-identical to what upstream already carried, aborted the fast-forward on every deploy from then on. Nothing retried, nothing reported it, and the box silently stopped tracking main.

**The fix — `deploy/fast-forward-checkout.sh`.** It reconciles only the dirt whose discard is *provably* lossless: the working-tree blob already equals the blob at the fast-forward target, so the merge restores it byte-for-byte. Everything else is unique local work — retained untouched, and if it blocks the merge the deploy fails loud, **naming each blocking path and its recovery command** instead of emitting a raw git error that identifies neither.

Deliberately **not** `git reset --hard` / `git clean -fd`. That would unwedge every case and destroy uncommitted work: host agents branch their worktrees from this same clone (`.git/worktrees/*` entries for it appear in the deploy logs). Content-equivalence is the safety standard, not "looks regenerable".

## Blocker 2 — the image build laundered a transient CDN error into an unattributable one

Run [30312507222](https://github.com/souliane/teatree/actions/runs/30312507222) is the first to get *past* blocker 1, and it failed differently. The reported last line — `exiting after a drain but before the swap` — is the EXIT trap's cleanup message, not the cause. The cause is 15 seconds and one masked error earlier, at `docker compose up -d --build`:

```
#7  9.966 curl: (22) The requested URL returned error: 403     <- NodeSource setup_24.x
#7 11.67  Unpacking nodejs (18.19.1+dfsg-6ubuntu5)             <- Ubuntu's node, not NodeSource's
#7 15.99  /bin/sh: 1: npm: not found
#7 ERROR: ... did not complete successfully: exit code: 127
```

Docker's default shell is dash, which has no `pipefail`. So `curl -fsSL https://deb.nodesource.com/setup_24.x | bash -` reported the *shell's* exit status after the fetch 403'd, the `&&` chain sailed on, the NodeSource repo was never added, `apt-get install nodejs` happily took Ubuntu's nodejs 18 — which packages npm separately — and the layer died at `npm install -g` naming neither the 403 nor the wrong node.

Verified as a control pair on this box:

- Old shape, under dash, with a deliberately failing URL: `curl` fails, **the pipeline returns rc 0 and the chain continues**.
- New shape, same failing URL: retries, then exits 1 with `FATAL - could not fetch ...`, before installing anything.

**The fix.** The build shell is now `bash -eo pipefail`; neither remote fetch is piped into a shell (both download to a file, are retried, and are size-checked — so a truncated or error body can never be executed as a script); and npm's presence is asserted at the point where "the NodeSource repo did not take effect" is still provable. The uv installer was the image's second `curl | shell` and got the same treatment — same class, not just the one call site.

## Also

- The drain fail-safe's EXIT-trap message is the last line of a failed run and reads as the cause to anyone triaging. It now labels itself as cleanup.
- The compose build/up failure path prints a banner naming the failing step: the 200 stale container lines it dumps push the real buildkit error hundreds of lines up the Action log.

## Verification

- `tests/test_deploy_fast_forward_checkout.py` — 10 tests driving the real script against real git repos under `tmp_path`. Covers the regenerated lockfile, an untracked collision, a local deletion, and three cases where unique work must survive; plus a **control** that proves a bare `pull --ff-only` really does abort on the wedge, so a green is the guard working rather than a merge that never needed guarding.
- `tests/test_deploy_image_fetch_hardening.py` — 5 tests pinning `pipefail`, the no-`curl | shell` rule, the retry + size check, and the npm assertion ordering.
- `tests/test_deploy_rolling_drain.py`'s fast-forward pin now asserts against the helper's **code** (comment lines stripped). Left as-is it would have passed on the prose of the comment pointing at the helper — a false green.
- `tests/test_deploy_worker_sizing.py` stages the new sibling; without it that fixture's `deploy.sh` run dies before reaching the compose call under test.
- Full deploy lane: **253 passed, 2 skipped**.
- Blocker 2's happy path built for real on the box from the amended Dockerfile: `PROBE-OK node=v24.18.0 npm=11.16.0`.

## What remains unproven

Only a live deploy can prove end-to-end convergence. The failing build died at the *first* toolchain layer, so every later step (the remaining image layers, `up -d`, init, the admin health wait) is untested since the box last converged — a further failure past this point cannot be ruled out.

Whether the 403 was transient is also unproven: `deb.nodesource.com/setup_24.x` returns 200 from this box now, and the retry makes the distinction moot for the deploy, but an intermittent block on the box's egress rather than a one-off CDN blip cannot be excluded from the log alone.

This is **not** environmental in the credential sense: all five required `DEPLOY_SSH_*` secrets are present, and job steps 1–4 (validate, mask, SSH config, remote clone) passed.

Unrelated, for the owner: the repo variables set `TEATREE_DISABLED_LOOPS=inbox,directive_loop` while `TEATREE_ENABLED_LOOPS` is unset (defaulting to `inbox`). The entrypoint resolves this correctly but warns twice on every deploy. Worth reconciling the variable, not a blocker.
