### PR TITLE
test(db): red the thread that strands a DB handle, not its bystander

### DIFF
--- a/tests/_thread_db_sentinel.py
+++ b/tests/_thread_db_sentinel.py
@@ -1,0 +1,201 @@
+"""Fail the thread that STRANDS a DB handle, not the bystander test that GCs it.
+
+A worker thread that touches the ORM gets its own thread-local Django connection
+(``django.db.connections`` is an ``asgiref.local.Local``). If it exits without
+closing the raw DB-API handle, CPython finalizes that handle at an arbitrary
+later garbage collection and emits ``ResourceWarning: unclosed database``. Under
+this repo's ``filterwarnings = ["error", ...]`` the warning becomes a hard
+``PytestUnraisableExceptionWarning`` attributed to whatever unrelated test
+happened to be running in that xdist worker — a rotating cast of innocent
+victims, one per shard, with nothing in the traceback pointing at the culprit.
+
+Under the ``:memory:`` test database the same leak also produces a loud
+``no such table: <table>`` from any config/ORM read on that thread: a fresh
+in-memory connection is a fresh EMPTY database, not the migrated one the main
+thread restored from the template.
+
+:func:`teatree.utils.thread_db.close_thread_db_connections` is the fix a
+thread-spawning site must call in a ``finally``. This sentinel is the mechanical
+check that every such site actually does: it wraps ``BaseDatabaseWrapper.connect``,
+records each non-main-thread open with the test that caused it, and at every test
+teardown fails the run for any handle whose owning thread has DIED while the
+handle is still open — naming the opening test and the stack that opened it.
+
+Always on, because the failure it catches lands on a random test in a random
+shard: a sentinel that has to be switched on can only ever be switched on after
+the fact. It costs one ``threading.current_thread()`` comparison per connection
+open; the stack capture only runs for the rare non-main-thread open.
+"""
+
+import dataclasses
+import threading
+import traceback
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+#: Frames of pytest/threading/sentinel plumbing that carry no information about
+#: the site that opened the connection.
+_UNINTERESTING_FRAME_MARKERS = (
+    "/_pytest/",
+    "/site-packages/pluggy/",
+    "lib/python3",
+    "/threading.py",
+    "_thread_db_sentinel.py",
+)
+
+#: How many surviving frames of the opening stack to show in the failure.
+_STACK_FRAMES_SHOWN = 6
+
+
+class StrandedDbHandleError(AssertionError):
+    """A worker thread died holding an open raw DB handle."""
+
+
+def handle_is_open(raw: Any) -> bool:
+    """Whether *raw* (a DB-API connection) still holds an open handle.
+
+    Deliberately does NOT execute SQL: the owning thread is gone, and a probe
+    query would be I/O on a connection nobody owns. ``sqlite3`` raises
+    ``ProgrammingError`` on any attribute touch after ``close()``; psycopg
+    exposes a ``closed`` flag. An unrecognised backend is assumed open, so a
+    future backend fails loud rather than silently green.
+    """
+    closed = getattr(raw, "closed", None)
+    if closed is not None:
+        return not closed
+    try:
+        raw.in_transaction  # noqa: B018 — sqlite3 raises ProgrammingError once closed
+    except AttributeError:
+        return True
+    except Exception:  # noqa: BLE001 — any refusal to answer means the handle is gone
+        return False
+    return True
+
+
+@dataclasses.dataclass(slots=True)
+class OpenedConnection:
+    """One non-main-thread connection open, kept until its thread is proven clean."""
+
+    wrapper: Any
+    thread: threading.Thread
+    nodeid: str
+    stack: str
+
+
+def _opening_stack() -> str:
+    """The call stack at the open, minus pytest/threading/sentinel plumbing."""
+    raw_frames = traceback.format_stack()[:-2]
+    frames = [line for line in raw_frames if not any(m in line for m in _UNINTERESTING_FRAME_MARKERS)]
+    return "".join((frames or raw_frames)[-_STACK_FRAMES_SHOWN:])
+
+
+class ThreadDbHandleSentinel:
+    """Pytest plugin: red the run when a worker thread strands a raw DB handle."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._opened: list[OpenedConnection] = []
+        self._nodeid = "<session>"
+        self._installed = False
+
+    def install(self) -> None:
+        """Wrap ``BaseDatabaseWrapper.connect`` so every open is recorded."""
+        from django.db.backends.base.base import BaseDatabaseWrapper  # noqa: PLC0415 — Django import at call time
+
+        if self._installed:
+            return
+        original = BaseDatabaseWrapper.connect
+        sentinel = self
+
+        def connect(wrapper: Any) -> Any:
+            result = original(wrapper)
+            sentinel.record_open(wrapper)
+            return result
+
+        BaseDatabaseWrapper.connect = connect  # ty: ignore[invalid-assignment]
+        self._installed = True
+
+    def record_open(self, wrapper: Any) -> None:
+        """Register *wrapper* when the opening thread is not the main thread."""
+        thread = threading.current_thread()
+        if thread is threading.main_thread():
+            return
+        with self._lock:
+            self._opened.append(OpenedConnection(wrapper, thread, self._nodeid, _opening_stack()))
+
+    def sweep(self) -> list[OpenedConnection]:
+        """Release and return every recorded open whose thread died holding the handle.
+
+        A record whose thread is still alive stays under watch — a live worker's
+        connection is in use, not stranded. A record whose owner closed properly
+        is simply dropped.
+        """
+        stranded: list[OpenedConnection] = []
+        with self._lock:
+            pending, self._opened = self._opened, []
+            for record in pending:
+                if record.thread.is_alive():
+                    self._opened.append(record)
+                    continue
+                raw = record.wrapper.connection
+                if raw is None or not handle_is_open(raw):
+                    continue
+                stranded.append(record)
+                # Release it here so ONE leak reds its own opener rather than
+                # cascading into an unraisable warning on a later bystander.
+                try:
+                    raw.close()
+                finally:
+                    record.wrapper.connection = None
+        return stranded
+
+    def pytest_sessionstart(self, session: pytest.Session) -> None:
+        """Install the wrapper once Django is configured (after pytest-django's setup)."""
+        del session  # hookspec signature; the sentinel is session-independent
+        self.install()
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_protocol(self, item: pytest.Item) -> "Generator[None, object]":
+        self._nodeid = item.nodeid
+        yield
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_teardown(self, item: pytest.Item) -> "Generator[None, object]":
+        yield  # let the real teardown join any threads the test started
+        stranded = self.sweep()
+        if not stranded:
+            return
+        raise StrandedDbHandleError(describe(stranded, detected_in=item.nodeid))
+
+
+def describe(stranded: "list[OpenedConnection]", *, detected_in: str) -> str:
+    """The failure message naming each stranding site and how to fix it."""
+    lines = [
+        (
+            f"{len(stranded)} worker thread(s) exited holding an open Django DB handle "
+            f"(detected at the teardown of {detected_in})."
+        ),
+        "",
+        (
+            "A stranded handle is finalized by a later garbage collection, which under "
+            "this suite's `filterwarnings = error` reds an unrelated bystander test in "
+            "whatever xdist worker happens to be running — the flake this sentinel exists "
+            "to prevent."
+        ),
+        "",
+        (
+            "Fix: call `teatree.utils.thread_db.close_thread_db_connections()` in a "
+            "`finally` on the thread target below."
+        ),
+    ]
+    for record in stranded:
+        lines += [
+            "",
+            f"  thread {record.thread.name!r} opened during {record.nodeid}:",
+            record.stack.rstrip(),
+        ]
+    return "\n".join(lines)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from tests._db_template import build_or_reuse_template, restore_from_template
+from tests._thread_db_sentinel import ThreadDbHandleSentinel
 
 # Ensure unit tests use the settings declared in pyproject.toml, not a stale
 # DJANGO_SETTINGS_MODULE from the shell. pytest-django falls back to
@@ -298,6 +299,17 @@ def _clean_registry() -> Iterator[None]:
     clear()
     yield
     clear()
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Arm the worker-thread DB-handle sentinel for the whole suite.
+
+    Always on: a stranded handle reds a random bystander test in a random shard,
+    so the sentinel that names the culprit has to already be running when it
+    happens — an opt-in flag would only ever be switched on after the fact. See
+    ``tests/_thread_db_sentinel.py``.
+    """
+    config.pluginmanager.register(ThreadDbHandleSentinel(), "thread-db-handle-sentinel")
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:

--- a/tests/test_thread_db_sentinel.py
+++ b/tests/test_thread_db_sentinel.py
@@ -1,3 +1,5 @@
+# test-path: cross-cutting — tests tests/_thread_db_sentinel.py (test infra); the src imports are the
+# anti-vacuity subject, not the unit under test.
 """Tests for ``tests/_thread_db_sentinel.py`` — the stranded-DB-handle sentinel.
 
 The sentinel converts a non-deterministic bystander red (a

--- a/tests/test_thread_db_sentinel.py
+++ b/tests/test_thread_db_sentinel.py
@@ -1,0 +1,245 @@
+"""Tests for ``tests/_thread_db_sentinel.py`` — the stranded-DB-handle sentinel.
+
+The sentinel converts a non-deterministic bystander red (a
+``PytestUnraisableExceptionWarning`` on whatever test the GC happened to
+interrupt) into a named failure on the thread that stranded the handle. These
+tests pin BOTH directions at the real seam — a real worker thread, a real
+Django connection — so the guard cannot silently become vacuous:
+
+* a thread that does NOT close its handle is detected;
+* the same thread WITH ``close_thread_db_connections`` is not;
+* neutering that helper at a real production call site (``teatree.loop.phases.scan``) goes red.
+"""
+
+import dataclasses
+import sqlite3
+import threading
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from django.db import connection
+from django.db.backends.base.base import BaseDatabaseWrapper
+from django.test import TestCase
+
+from teatree.loop.phases import scan
+from teatree.utils.thread_db import close_thread_db_connections
+from tests._thread_db_sentinel import (
+    OpenedConnection,
+    StrandedDbHandleError,
+    ThreadDbHandleSentinel,
+    describe,
+    handle_is_open,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _recording_sentinel(monkeypatch: pytest.MonkeyPatch) -> ThreadDbHandleSentinel:
+    """A sentinel wired to record opens for the duration of one test.
+
+    Wraps ``connect`` through ``monkeypatch`` rather than the plugin's own
+    ``install()`` so the class is restored afterwards and the always-on suite
+    sentinel is left untouched.
+    """
+    sentinel = ThreadDbHandleSentinel()
+    original = BaseDatabaseWrapper.connect
+
+    def connect(wrapper: Any) -> Any:
+        result = original(wrapper)
+        sentinel.record_open(wrapper)
+        return result
+
+    monkeypatch.setattr(BaseDatabaseWrapper, "connect", connect)
+    return sentinel
+
+
+def _open_this_threads_connection() -> None:
+    """Open the CALLING thread's connection.
+
+    ``django.db.connection`` is a thread-local proxy, so this must be resolved on
+    the worker thread — passing ``connection.ensure_connection`` in from the main
+    thread would bind (and reuse) the main thread's already-open wrapper.
+    """
+    connection.ensure_connection()
+
+
+def _run_on_worker(target: "Callable[[], object]") -> None:
+    thread = threading.Thread(target=target, name="sentinel-subject")
+    thread.start()
+    thread.join()
+
+
+def _run_scan_job_on_a_worker(sentinel: ThreadDbHandleSentinel, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Drive the real ``scan_phase`` pool-worker wrapper with an ORM-touching job."""
+
+    def _job_that_touches_the_orm(job: object) -> tuple[object, list[object], str]:
+        _open_this_threads_connection()
+        return (job, [], "")
+
+    monkeypatch.setattr(scan, "_run_job", _job_that_touches_the_orm)
+    _run_on_worker(lambda: scan._run_job_closing_connections("job"))
+    return [record.thread.name for record in sentinel.sweep()]
+
+
+@dataclasses.dataclass(slots=True)
+class _Item:
+    """The minimal ``pytest.Item`` surface the teardown hook reads."""
+
+    nodeid: str
+
+
+class TestSentinelDetectsAStrandedHandle(TestCase):
+    """A worker thread that exits holding an open handle is named, not tolerated."""
+
+    @pytest.fixture(autouse=True)
+    def _fixtures(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Grouped into a TestCase per souliane/teatree#98; monkeypatch injected."""
+        self.monkeypatch = monkeypatch
+
+    def test_a_thread_that_never_closes_is_reported(self) -> None:
+        sentinel = _recording_sentinel(self.monkeypatch)
+
+        _run_on_worker(_open_this_threads_connection)
+
+        assert [record.thread.name for record in sentinel.sweep()] == ["sentinel-subject"]
+
+    def test_a_thread_that_closes_is_not_reported(self) -> None:
+        sentinel = _recording_sentinel(self.monkeypatch)
+
+        def _clean() -> None:
+            try:
+                _open_this_threads_connection()
+            finally:
+                close_thread_db_connections()
+
+        _run_on_worker(_clean)
+
+        assert sentinel.sweep() == []
+
+    def test_a_live_thread_is_left_under_watch_not_flagged(self) -> None:
+        """A running worker's connection is in use, not stranded."""
+        sentinel = _recording_sentinel(self.monkeypatch)
+        release = threading.Event()
+        opened = threading.Event()
+
+        def _hold() -> None:
+            try:
+                _open_this_threads_connection()
+                opened.set()
+                release.wait(timeout=10)
+            finally:
+                close_thread_db_connections()
+
+        thread = threading.Thread(target=_hold, name="sentinel-live", daemon=True)
+        thread.start()
+        assert opened.wait(timeout=10), "the worker never opened its connection"
+        try:
+            assert sentinel.sweep() == []
+        finally:
+            release.set()
+            thread.join(timeout=10)
+
+    def test_sweep_releases_the_handle_so_no_bystander_inherits_it(self) -> None:
+        """The whole point: the leak dies here instead of GC-ing into another test."""
+        sentinel = _recording_sentinel(self.monkeypatch)
+
+        _run_on_worker(_open_this_threads_connection)
+        stranded = sentinel.sweep()
+
+        assert stranded, "precondition: the sweep must have found the stranded handle"
+        assert all(record.wrapper.connection is None for record in stranded)
+        assert sentinel.sweep() == [], "a released handle must not be reported twice"
+
+
+class TestSentinelFailsTheRun(TestCase):
+    """The teardown hook turns a detected strand into a real, named failure."""
+
+    @pytest.fixture(autouse=True)
+    def _fixtures(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Grouped into a TestCase per souliane/teatree#98; monkeypatch injected."""
+        self.monkeypatch = monkeypatch
+
+    def test_teardown_raises_and_names_the_opening_test(self) -> None:
+        sentinel = _recording_sentinel(self.monkeypatch)
+
+        _run_on_worker(_open_this_threads_connection)
+
+        hook = sentinel.pytest_runtest_teardown(_Item("tests/some_module.py::test_victim"))
+        next(hook)
+        with pytest.raises(StrandedDbHandleError) as excinfo:
+            hook.send(None)
+
+        message = str(excinfo.value)
+        assert "close_thread_db_connections" in message
+        assert "sentinel-subject" in message
+        assert "tests/some_module.py::test_victim" in message
+
+    def test_teardown_is_silent_when_nothing_leaked(self) -> None:
+        sentinel = _recording_sentinel(self.monkeypatch)
+
+        hook = sentinel.pytest_runtest_teardown(_Item("tests/some_module.py::test_clean"))
+        next(hook)
+        with pytest.raises(StopIteration):
+            hook.send(None)
+
+
+class TestNeuteringTheHelperGoesRed(TestCase):
+    """Anti-vacuity: a real production call site reds the sentinel once un-wired.
+
+    ``teatree.loop.phases.scan._run_job_closing_connections`` is one of the pool
+    workers PR #3536 wired. Removing its ``close_thread_db_connections`` call —
+    exactly the regression this sentinel exists to catch — must be detected.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _fixtures(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Grouped into a TestCase per souliane/teatree#98; monkeypatch injected."""
+        self.monkeypatch = monkeypatch
+
+    def test_the_wired_site_is_clean(self) -> None:
+        sentinel = _recording_sentinel(self.monkeypatch)
+
+        assert _run_scan_job_on_a_worker(sentinel, self.monkeypatch) == []
+
+    def test_the_same_site_with_the_helper_neutered_is_caught(self) -> None:
+        sentinel = _recording_sentinel(self.monkeypatch)
+        self.monkeypatch.setattr(scan, "close_thread_db_connections", lambda: None)
+
+        assert _run_scan_job_on_a_worker(sentinel, self.monkeypatch) == ["sentinel-subject"]
+
+
+class TestHandleIsOpen:
+    """The open/closed probe answers without executing SQL on an ownerless handle."""
+
+    def test_tracks_a_real_sqlite_handle_through_close(self) -> None:
+        raw = sqlite3.connect(":memory:")
+
+        assert handle_is_open(raw)
+
+        raw.close()
+
+        assert not handle_is_open(raw)
+
+    def test_reads_the_closed_flag_when_the_backend_exposes_one(self) -> None:
+        assert handle_is_open(SimpleNamespace(closed=False))
+        assert not handle_is_open(SimpleNamespace(closed=True))
+
+
+class TestDescribe:
+    """The failure message has to be actionable without re-running anything."""
+
+    def test_names_the_fix_and_both_endpoints(self) -> None:
+        record = OpenedConnection(
+            wrapper=None,
+            thread=threading.current_thread(),
+            nodeid="tests/a.py::test_a",
+            stack="  frame\n",
+        )
+
+        message = describe([record], detected_in="tests/b.py::test_b")
+
+        assert "close_thread_db_connections" in message
+        assert "tests/a.py::test_a" in message
+        assert "tests/b.py::test_b" in message


### PR DESCRIPTION
## What this is

A durable, always-on guard against the class of failure PR #3536 fixed: a worker
thread that touches the ORM, exits without closing its raw DB-API handle, and
leaves it for a later GC — which under `filterwarnings = ["error", ...]` reds a
random bystander test in a random xdist shard.

## What the investigation actually found

The recurrence this was opened to chase **does not exist on `main`**. Empirically:

- **Probe run, whole suite** (33,083 tests, a plugin wrapping
  `BaseDatabaseWrapper.connect` recording every non-main-thread open and every
  handle still open once its thread died): **66 non-main-thread opens, 0
  production leaks**. Same result on a second run with `--doctest-modules` and
  `tests/quality` included (33,795 tests). The only strands were a deliberately
  planted control and `tests/teatree_utils/test_thread_db.py`'s own
  reproduce-then-clean-up case.
- **CI history:** across every failed job in `ci.yml` since 2026-07-23, there is
  exactly one `PytestUnraisableExceptionWarning`, and it is a **socket**, not a
  sqlite connection. The last sqlite one is run `29831394859` at
  **2026-07-21T12:44:50Z** — 55 seconds before #3536 merged (2026-07-21T12:45:46Z).
  Before that merge the flake was firing many times a day.

So the fix held. What was missing was any mechanical check that a *future*
thread-spawning site keeps holding the line — which is what this PR adds.

## The guard

`tests/_thread_db_sentinel.py`, registered from `tests/conftest.py`:

- wraps `BaseDatabaseWrapper.connect` and records every non-main-thread open with
  the test that caused it and the stack that opened it;
- at each test teardown, fails the run for any handle whose owning thread has
  **died** while the handle is still open — naming the opening test and the site;
- **releases** that handle, so one leak reds its own opener instead of cascading
  into an unraisable warning on an innocent bystander.

Always on rather than flag-gated: the failure it catches lands on a random test in
a random shard, so a sentinel that has to be switched on can only ever be switched
on after the fact. Cost is one `threading.current_thread()` comparison per
connection open.

A live thread's connection is left under watch, not flagged — a running worker's
connection is in use, not stranded.

## Anti-vacuity proof

Neutering `close_thread_db_connections` (early `return`) and running
`tests/teatree_loop/phases tests/teatree_core/provision`:

```
E  tests._thread_db_sentinel.StrandedDbHandleError: 1 worker thread(s) exited holding
   an open Django DB handle (detected at the teardown of
   tests/teatree_loop/phases/test_scan.py::TestScanPhaseConnectionHygiene::test_scan_phase_closes_a_worker_threads_db_connection).
E    thread 'ThreadPoolExecutor-1_0' opened during ...
1 failed, 145 passed, 1 error
```

Restoring the helper: green. The same A/B is pinned permanently in
`tests/test_thread_db_sentinel.py::TestNeuteringTheHelperGoesRed`, driving the real
`teatree.loop.phases.scan._run_job_closing_connections` wrapper both ways.

## Verification

- `tests/test_thread_db_sentinel.py` — 11 passed
- whole suite with the sentinel armed — **33,803 passed, 0 sentinel findings**
  (two unrelated reds: `test_deploy_worker_sizing.py`, which reproduces identically
  on plain `main` with no sentinel, and `test_leak_sentinel_plugin.py` timing out
  under a doubly-loaded box — both pass in isolation)
- `ruff check` / `ruff format` / `ty check` clean; `t3 tool test-path-mirror` ratchet
  holds; `makemigrations --check` clean; full `prek` commit hooks green
