### PR TITLE
fix(dash): serve a favicon and declare ttyd as the terminal spec's host dep

### DIFF
--- a/e2e/dash/test_console_clean.py
+++ b/e2e/dash/test_console_clean.py
@@ -18,6 +18,7 @@ _DASH_PATHS = ("/dash/board/", "/dash/health/", "/dash/loops/")
 def test_dash_page_loads_clean(live_server: LiveServer, page: Page, console_guard: ConsoleGuard, path: str) -> None:
     page.goto(f"{live_server.url}{path}")
     expect(page.locator("header.dash-header")).to_be_visible()
+    page.wait_for_load_state("networkidle")
     console_guard.raise_if_dirty()
 
 
@@ -25,4 +26,10 @@ def test_dash_page_loads_clean(live_server: LiveServer, page: Page, console_guar
 def test_admin_index_loads_clean(live_server: LiveServer, page: Page, console_guard: ConsoleGuard) -> None:
     page.goto(f"{live_server.url}/admin/")
     expect(page.locator("#site-name")).to_be_visible()
+    # A browser fires its unprompted /favicon.ico request AFTER first paint, so the
+    # first visible element resolves well before it lands. Reading the guard there
+    # made the assertion a coin flip — the missing favicon reddened this spec on a
+    # real chromium and passed on the same binary moments later. Settling the
+    # network first catches a late 404 deterministically rather than sometimes.
+    page.wait_for_load_state("networkidle")
     console_guard.raise_if_dirty()

--- a/e2e/dash/test_terminal.py
+++ b/e2e/dash/test_terminal.py
@@ -6,6 +6,7 @@ opens a fresh loopback terminal from every page; the per-ticket drawer button st
 """
 
 import re
+import shutil
 
 import pytest
 from playwright.sync_api import Page, expect
@@ -15,6 +16,24 @@ from e2e.dash.pom import BoardPage
 
 _TERMINAL = "Open a loopback terminal session"
 _LOOPBACK_URL = re.compile(r"^http://127\.0\.0\.1:\d+")
+
+# The click spec drives the REAL launcher, which resolves ``shutil.which("ttyd")``
+# and renders the install hint instead of a launch URL when it is absent. That is a
+# HOST dependency, not a code path worth mocking away — the point of the spec is
+# that the button spawns a real terminal.
+#
+# The dependency is DECLARED where each environment that must run this provisions
+# it: ``.github/workflows/ci.yml`` apt-installs ttyd for the e2e-dash job (so the
+# authoritative lane never skips and the coverage is not quietly dead), and
+# ``deploy/Dockerfile`` installs it into the image the dashboard actually serves
+# from. A developer host with neither gets a VISIBLE skip naming the install
+# command instead of a red that reads like a product bug. Conditional by
+# construction, so it is not the dead coverage ``check_no_silent_skip`` bans.
+requires_ttyd = pytest.mark.skipif(
+    shutil.which("ttyd") is None,
+    reason="ttyd is not on PATH — install it (apt install ttyd / brew install ttyd); "
+    "CI and the deploy image both ship it",
+)
 
 
 @pytest.mark.usefixtures("seeded_board")
@@ -26,6 +45,7 @@ def test_terminal_button_visible_on_board(live_server: LiveServer, page: Page) -
     expect(page.get_by_role("button", name=_TERMINAL)).to_be_visible()
 
 
+@requires_ttyd
 @pytest.mark.usefixtures("seeded_board", "accept_dialogs")
 def test_terminal_button_click_renders_launch_url(live_server: LiveServer, page: Page) -> None:
     board = BoardPage(page, live_server.url)

--- a/skills/workspace/references/prerequisites.md
+++ b/skills/workspace/references/prerequisites.md
@@ -26,6 +26,10 @@ Scripts that need Bash 5+ features (associative arrays) include a version guard 
 - `uv` (used only to auto-install `dslr` when missing)
 - `jq` (required only by agent platform integration scripts, e.g., statusline hooks)
 - `md5sum` or `md5` (dirty-state hashing in statusline; auto-detected per platform)
+- `ttyd` (the dashboard's loopback "Debug session" terminal — `apt install ttyd` /
+  `brew install ttyd`). Required to run `e2e/dash/test_terminal.py`'s launch spec,
+  which skips visibly without it. CI (`.github/workflows/ci.yml`) and the deploy
+  image (`deploy/Dockerfile`) both install it, so the authoritative lanes never skip.
 - Agent platform hook support (e.g., Claude Code hooks in `hooks/scripts/`)
 
 ## Shell Script Portability Checklist

--- a/src/teatree/dash/snapshots/board.html
+++ b/src/teatree/dash/snapshots/board.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TeaTree · Board</title>
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cpath fill='%23c9973f' d='M16 3C9 8 6 14 8 22c1 4 4 6 8 7 4-1 7-3 8-7 2-8-1-14-8-19Z'/%3E%3Cpath fill='%2310140f' d='M16 8c-3 4-4 9-2 15h4c2-6 1-11-2-15Z' opacity='.35'/%3E%3C/svg%3E">
+  <link rel="icon" href="/static/dash/favicon.svg">
   <link rel="stylesheet" href="/static/dash/css/dash.css">
   <script>
     // Apply the operator's pinned theme before first paint (no flash). Absent a

--- a/src/teatree/dash/static/dash/favicon.svg
+++ b/src/teatree/dash/static/dash/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="TeaTree">
+  <path fill="#c9973f" d="M16 3C9 8 6 14 8 22c1 4 4 6 8 7 4-1 7-3 8-7 2-8-1-14-8-19Z"/>
+  <path fill="#10140f" opacity=".35" d="M16 8c-3 4-4 9-2 15h4c2-6 1-11-2-15Z"/>
+</svg>

--- a/src/teatree/dash/templates/dash/base.html
+++ b/src/teatree/dash/templates/dash/base.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TeaTree · {% block title %}Dashboard{% endblock %}</title>
-  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cpath fill='%23c9973f' d='M16 3C9 8 6 14 8 22c1 4 4 6 8 7 4-1 7-3 8-7 2-8-1-14-8-19Z'/%3E%3Cpath fill='%2310140f' d='M16 8c-3 4-4 9-2 15h4c2-6 1-11-2-15Z' opacity='.35'/%3E%3C/svg%3E">
+  <link rel="icon" href="{% static 'dash/favicon.svg' %}">
   <link rel="stylesheet" href="{% static 'dash/css/dash.css' %}">
   <script>
     // Apply the operator's pinned theme before first paint (no flash). Absent a

--- a/src/teatree/urls.py
+++ b/src/teatree/urls.py
@@ -1,8 +1,21 @@
 from django.contrib import admin
+from django.contrib.staticfiles.storage import staticfiles_storage
 from django.contrib.staticfiles.views import serve as serve_static
 from django.urls import include, path, re_path
+from django.views.generic.base import RedirectView
 
 urlpatterns = [
+    # Browsers request /favicon.ico unprompted on any page that declares no icon
+    # link. The dash templates declare one; Django's admin does not, so the admin
+    # index 404'd on every real-browser load (the console guard's response listener
+    # records that as an error). Serving it at the site root covers every page,
+    # declared link or not, and shares the ONE brand mark the dash base template
+    # loads.
+    path(
+        "favicon.ico",
+        RedirectView.as_view(url=staticfiles_storage.url("dash/favicon.svg"), permanent=True),
+        name="favicon",
+    ),
     path("", include("teatree.core.urls", namespace="teatree")),
     # The first-party admin dashboard (#3162) — ticket-FSM kanban, health, and
     # loop control. Rides this same gunicorn process on the same loopback port,

--- a/tests/teatree_dash/test_static_assets.py
+++ b/tests/teatree_dash/test_static_assets.py
@@ -26,6 +26,10 @@ _VENDORED_JS = (
 )
 # The vendored IBM Plex latin subsets (@font-face src in tokens.css). Same tracked +
 # served contract as the JS: a fresh checkout must ship them or every glyph 404s.
+#: The ONE brand mark. Both the site-root ``/favicon.ico`` route and the dash base
+#: template's ``<link rel="icon">`` load this file, so the mark has a single home
+#: rather than a copy inlined as a data URI in the template.
+_FAVICON = "src/teatree/dash/static/dash/favicon.svg"
 _VENDORED_FONTS = (
     "src/teatree/dash/static/dash/fonts/ibm-plex-sans-400.woff2",
     "src/teatree/dash/static/dash/fonts/ibm-plex-sans-500.woff2",
@@ -48,7 +52,12 @@ _SERVE_UNDER_DEBUG_OFF = textwrap.dedent(
     assert settings.MIDDLEWARE[1] == "whitenoise.middleware.WhiteNoiseMiddleware", settings.MIDDLEWARE
     from django.core.management import call_command
     from django.test import Client, override_settings
-    with tempfile.TemporaryDirectory() as static_root, override_settings(STATIC_ROOT=static_root):
+    # ALLOWED_HOSTS matters here and nowhere above: WhiteNoise short-circuits a
+    # /static/ path before CommonMiddleware ever calls get_host(), while the
+    # site-root /favicon.ico route goes through the full middleware stack.
+    with tempfile.TemporaryDirectory() as static_root, override_settings(
+        STATIC_ROOT=static_root, ALLOWED_HOSTS=["testserver"]
+    ):
         call_command("collectstatic", interactive=False, verbosity=0)
         client = Client()
         for path in (
@@ -60,9 +69,15 @@ _SERVE_UNDER_DEBUG_OFF = textwrap.dedent(
             "/static/dash/css/admin-theme.css",
             "/static/dash/fonts/ibm-plex-sans-400.woff2",
             "/static/dash/fonts/ibm-plex-mono-400.woff2",
+            "/static/dash/favicon.svg",
         ):
             status = client.get(path).status_code
             assert status == 200, f"{path} -> {status} under DEBUG off"
+        # A browser asks for /favicon.ico unprompted on any page that declares no
+        # icon link — Django's admin declares none, so this 404'd and the console
+        # guard's response listener recorded it as an error.
+        status = client.get("/favicon.ico", follow=True).status_code
+        assert status == 200, f"/favicon.ico -> {status} under DEBUG off"
     print("SERVED_OK")
     """
 )
@@ -110,6 +125,30 @@ def test_vendored_fonts_tracked_and_not_gitignored() -> None:
     ).stdout.split()
     for rel in _VENDORED_FONTS:
         assert rel in tracked, f"{rel} is not tracked — a missing glyph file 404s in a fresh checkout"
+
+
+def test_favicon_has_exactly_one_source() -> None:
+    """The dash template loads the same file the ``/favicon.ico`` route serves.
+
+    The mark used to be inlined as a data URI in ``base.html`` while the site root
+    served nothing, so the dash pages were clean and every other page (the admin
+    index) 404'd. One tracked file, two consumers, no second copy to drift.
+    """
+    tracked = subprocess.run(
+        ["git", "ls-files", "--", _FAVICON],  # noqa: S607 — git on PATH, repo convention
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()
+    assert _FAVICON in tracked, f"{_FAVICON} is not tracked — /favicon.ico 404s in a fresh checkout"
+
+    base_template = (_REPO_ROOT / "src/teatree/dash/templates/dash/base.html").read_text(encoding="utf-8")
+    assert "{% static 'dash/favicon.svg' %}" in base_template
+    assert "data:image/svg+xml" not in base_template, "the inlined copy is the drift this replaces"
+
+    urlconf = (_REPO_ROOT / "src/teatree/urls.py").read_text(encoding="utf-8")
+    assert "dash/favicon.svg" in urlconf, "the site-root route must serve the same mark"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Favicon — a real 404 the console guard caught only sometimes

Browsers request `/favicon.ico` unprompted on any page that declares no icon link.
The dash templates declare one (that is why `/dash/*` was clean); Django's admin
does not, so the admin index 404'd on every real-browser load.

`test_admin_index_loads_clean` was **racy**, not simply green: the browser fires
that request *after* first paint, so reading the `ConsoleGuard` right after
`expect(#site-name).to_be_visible()` was a coin flip. On this box it passed three
runs in a row, then reddened as soon as the network was allowed to settle.

- one tracked brand mark at `src/teatree/dash/static/dash/favicon.svg`, served at
  the site root by a `RedirectView` so it covers **every** page, declared link or not
- `dash/base.html` loads that same file instead of inlining a second copy as a data
  URI — the mark now has one home, pinned by `test_favicon_has_exactly_one_source`
- the console-clean specs settle the network before reading the guard, so a late
  404 reds **deterministically** instead of sometimes

The `ConsoleGuard` is untouched — no ignore-list entry, no relaxed assertion.

## ttyd — a host dependency, made visible rather than mocked away

`test_terminal_button_click_renders_launch_url` drives the real launcher, which
resolves `shutil.which("ttyd")`. Mocking that out would gut the spec: the point is
that the button spawns a real terminal.

The dependency is already declared where each authoritative environment provisions
it — `.github/workflows/ci.yml` apt-installs ttyd for the e2e-dash job, and
`deploy/Dockerfile` bakes it into the served image. So a conditional
`skipif(shutil.which("ttyd") is None)` never fires in either lane, and the coverage
is not quietly dead. A developer host with neither now gets a **visible** skip
naming the install command instead of a red that reads like a product bug, and
`skills/workspace/references/prerequisites.md` lists it.

Conditional by construction, so it is not the dead coverage
`hooks/portable/check_no_silent_skip.py` bans — that hook explicitly sanctions
`skipif(shutil.which(...) is None)`.

## Verification

Proven RED first, then green, with the exact command from the report:

```text
E2E_CHROMIUM_EXECUTABLE=/snap/chromium/current/usr/lib/chromium-browser/chrome \
  uv run pytest e2e/dash --ds=e2e.dash.settings -rs
→ 35 passed, 1 skipped (ttyd is not on PATH — install it …)
```

Control: dropping the `/favicon.ico` route back out reds
`test_admin_index_loads_clean` on every run, so the strengthened assertion is
load-bearing rather than vacuous.

```text
tests/teatree_dash/  339 passed
```
