### PR TITLE
fix(fleet,retro): forge host is part of a repo's identity; recurrence counts intra-session repeats

### DIFF
--- a/src/teatree/core/fleet/wire.py
+++ b/src/teatree/core/fleet/wire.py
@@ -25,7 +25,8 @@ from teatree.config.loader import clone_root
 from teatree.core.fleet import claim
 from teatree.core.worktree.clone_paths import find_clone_path
 from teatree.instance_id import instance_id
-from teatree.utils import git
+from teatree.utils import git, git_remote
+from teatree.utils.run import run_allowed_to_fail
 
 if TYPE_CHECKING:
     from teatree.core.models import ImplementedIssueMarker, Ticket
@@ -33,6 +34,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _ISSUE_URL_MARKERS = ("/-/issues/", "/-/merge_requests/", "/issues/", "/pull/", "/merge_requests/")
+#: An ssh-alias expansion is a local config read; it must never stall a claim.
+_SSH_PROBE_TIMEOUT = 5.0
 
 
 def fleet_claim_enabled(overlay: str) -> bool:
@@ -77,6 +80,59 @@ def _origin_hosts_issue(repo: str, expected_slug: str) -> bool:
     return False
 
 
+def host_from_issue_url(issue_url: str) -> str:
+    """The forge host an issue/PR URL lives on (``github.com``), or ``""``."""
+    remainder = issue_url.split("://", 1)[-1]
+    return git_remote.host_from_remote(f"https://{remainder}") if remainder else ""
+
+
+def _ssh_resolved_hostname(host: str) -> str:
+    """The real ``HostName`` an ssh ``Host`` alias expands to, or ``""`` when unresolvable.
+
+    ``git@github-work:owner/repo`` is a perfectly ordinary work-account setup where
+    ``github-work`` is a ``Host`` block in ``~/.ssh/config``. Comparing the raw token
+    against ``github.com`` would call that a different forge, so the alias is expanded
+    through the same resolver the git transport itself uses. No ssh on PATH, a
+    non-zero exit, or an alias ssh cannot expand all yield ``""`` — UNKNOWN, which the
+    caller must not read as "different".
+    """
+    with contextlib.suppress(Exception):
+        result = run_allowed_to_fail(["ssh", "-G", host], expected_codes=None, timeout=_SSH_PROBE_TIMEOUT)
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                key, _, value = line.strip().partition(" ")
+                if key == "hostname" and value:
+                    return git_remote.host_from_remote(f"https://{value}/x")
+    return ""
+
+
+def _resolved_origin_host(repo: str) -> str:
+    """*repo*'s ``origin`` host with any ssh alias expanded, or ``""`` when unknown."""
+    with contextlib.suppress(Exception):
+        host = git_remote.host_from_remote(git.remote_url(repo=repo))
+        if not host:
+            return ""
+        # A dotless token cannot be a public forge FQDN, so it is an ssh alias (or a
+        # LAN short name) — ask ssh what it expands to before judging it different.
+        return host if "." in host else _ssh_resolved_hostname(host)
+    return ""
+
+
+def _forge_host_conflict(repo: str, issue_url: str) -> bool:
+    """``True`` only when BOTH forge hosts are known AND they differ.
+
+    An unknown host on either side (a ``file://`` or filesystem-path origin, an ssh
+    alias ssh could not expand, an unparsable issue URL) is non-discriminating: the
+    slug verdict stands, exactly as before. Only two confidently-read, different
+    hosts are a conflict.
+    """
+    issue_host = host_from_issue_url(issue_url)
+    if not issue_host:
+        return False
+    origin_host = _resolved_origin_host(repo)
+    return bool(origin_host) and origin_host != issue_host
+
+
 def resolve_claim_repo(issue_url: str) -> str:
     """The local clone to push claim refs from — one whose ``origin`` HOSTS the issue.
 
@@ -87,6 +143,23 @@ def resolve_claim_repo(issue_url: str) -> str:
     issue URL's ``owner/repo`` — on a mismatch, an unparsable slug, or an absent
     origin, return ``""`` and fail SAFE (do not claim) rather than push to the wrong
     remote.
+
+    The slug alone is not the repo's identity. ``owner/repo`` is unique per FORGE, not
+    globally, and the claim ref is a compare-and-swap on ONE server's receive-pack: an
+    instance pushing to ``gitlab.com/owner/repo`` and one pushing to
+    ``github.com/owner/repo`` each create their own ref and each believe they won, so
+    the mutex stops excluding anything precisely when it matters. The host is
+    therefore part of the identity — but only when it can be read CONFIDENTLY:
+
+    *   an **ssh alias** (``git@github-work:owner/repo``) is expanded via ``ssh -G``,
+        so a work-account remote matches the forge it actually reaches;
+    *   a **``file://`` or filesystem-path** origin names no forge, so it is unknown
+        rather than different and the slug verdict stands unchanged;
+    *   a **mirror on another host** IS rejected, deliberately. A mirror has its own
+        receive-pack, so a claim pushed there excludes nobody on the forge that owns
+        the issue — accepting it would manufacture a mutex that does not exist.
+        Refusing degrades to local-only behaviour (the same as no clone resolving)
+        and logs why; point ``origin`` at the arbitrating forge to opt back in.
     """
     candidate = _resolve_clone(issue_url)
     if not candidate:
@@ -97,6 +170,17 @@ def resolve_claim_repo(issue_url: str) -> str:
             "fleet_claim: resolved clone %s does not host %s (origin mismatch) — failing safe (not claiming)",
             candidate,
             expected or issue_url,
+        )
+        return ""
+    if _forge_host_conflict(candidate, issue_url):
+        logger.warning(
+            "fleet_claim: resolved clone %s carries slug %s but its origin is on %s, not %s — "
+            "a claim pushed there would not exclude an instance claiming on the issue's own forge; "
+            "failing safe (not claiming)",
+            candidate,
+            expected,
+            _resolved_origin_host(candidate),
+            host_from_issue_url(issue_url),
         )
         return ""
     return candidate

--- a/src/teatree/core/management/commands/retro.py
+++ b/src/teatree/core/management/commands/retro.py
@@ -44,6 +44,7 @@ from teatree.eval.gate_failures import (
     escalate_gate_failures,
     extract_gate_failures,
     record_gate_failures,
+    recurring_fingerprints,
 )
 from teatree.eval.session_transcript import parse_session_jsonl
 from teatree.eval.transcript_resolver import resolve_transcript
@@ -140,7 +141,7 @@ class Command(TyperCommand):
         store = FindingsStore()
         record_gate_failures(store, failures)
 
-        recurring = store.recurring_fingerprints(min_occurrences=2)
+        recurring = recurring_fingerprints(failures, store=store)
         views = self._gate_failure_views(failures, recurring=recurring)
         self._print_gate_failure_summary(views)
 

--- a/src/teatree/eval/gate_failures.py
+++ b/src/teatree/eval/gate_failures.py
@@ -49,6 +49,7 @@ edge; the ``retro gate-failures`` CLI command lives in ``teatree.core.management
 """
 
 import re
+from collections import Counter
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING, cast
@@ -78,6 +79,10 @@ _SENTENCE_SPLIT_RE = re.compile(r"[.;:\n]")
 _NON_SLUG_RE = re.compile(r"[^a-z0-9]+")
 _SLUG_WORD_CAP = 6
 _SLUG_CHAR_CAP = 80
+#: Two firings is recurrence in BOTH dimensions — a gate hit twice in one session
+#: means the corrective did not take; hit once in each of two sessions means it did
+#: not stick. Same threshold, so neither dimension is privileged.
+_RECURRENCE_THRESHOLD = 2
 
 
 class GateVerdict(StrEnum):
@@ -284,6 +289,34 @@ def record_gate_failures(store: FindingsStore, failures: list[GateFailure]) -> N
         store.record(_session_key(failure.session_id), [classified])
 
 
+def recurring_fingerprints(
+    failures: list[GateFailure],
+    *,
+    store: FindingsStore,
+    min_occurrences: int = _RECURRENCE_THRESHOLD,
+) -> set[str]:
+    """Fingerprints that recur — WITHIN this session's *failures* or ACROSS sessions.
+
+    :meth:`FindingsStore.recurring_fingerprints` counts the number of per-session
+    FILES holding a fingerprint, and each file's findings are a
+    ``fingerprint -> classification`` map, so every firing of one gate inside a
+    single session collapses to one entry and that count stays 1. Cross-session
+    recurrence is therefore the only kind the store can see on its own.
+
+    Repetition inside one session is the stronger signal, not a weaker one: the
+    agent hit the gate, was told, and hit it again — the corrective visibly failed
+    to take. Counting only the cross-session dimension reported both gates of a
+    102-block transcript as ``recurring: false``, silently disabling the escalation
+    from "write a memory" to "build a gate" in exactly the case it exists for.
+
+    The two dimensions are unioned rather than summed: either one reaching
+    *min_occurrences* is recurrence, and neither can mask the other.
+    """
+    within = Counter(failure.fingerprint for failure in failures)
+    across = store.recurring_fingerprints(min_occurrences=min_occurrences)
+    return {fingerprint for fingerprint, seen in within.items() if seen >= min_occurrences} | across
+
+
 def escalate_gate_failures(
     host: "CodeHostBackend",
     *,
@@ -294,13 +327,14 @@ def escalate_gate_failures(
     """File one deduped enforcement issue per recurring preventable failure.
 
     A failure is escalated only when it is both *preventable* (classifier) and
-    *recurring* (its fingerprint recorded across >= 2 sessions). The filing
-    reuses :func:`~teatree.core.review.review_findings.file_class_c_issue`, so it is
+    *recurring* (:func:`recurring_fingerprints` — repeated within this session, or
+    recorded across >= 2 sessions). The filing reuses
+    :func:`~teatree.core.review.review_findings.file_class_c_issue`, so it is
     deduped by fingerprint marker (a re-run never refiles), banned-terms-safe
     (a hit withholds rather than leaks), and clickable-link safe. Environmental
     or non-recurring failures file nothing.
     """
-    recurring = store.recurring_fingerprints(min_occurrences=2)
+    recurring = recurring_fingerprints(failures, store=store)
     filed: list[FiledIssue] = []
     seen: set[str] = set()
     for failure in failures:

--- a/src/teatree/utils/git_remote.py
+++ b/src/teatree/utils/git_remote.py
@@ -15,6 +15,8 @@ import re
 _REMOTE_HOST_RE = re.compile(r"^(?:git@[^:]+:|https?://[^/]+/|ssh://[^/]+/|git://[^/]+/)")
 _SSH_HOST_RE = re.compile(r"^(?:ssh://)?git@([^:/]+)[:/]")
 _HTTP_HOST_RE = re.compile(r"^(https?)://([^/]+)/")
+#: Any ``<scheme>://[user@]host[:port]/`` form — the host half of every non-ssh URL.
+_SCHEME_HOST_RE = re.compile(r"^[a-z][a-z0-9+.-]*://(?:[^@/]+@)?([^/]+)/", re.IGNORECASE)
 
 
 def slug_from_remote(remote_url: str) -> str:
@@ -27,6 +29,43 @@ def slug_from_remote(remote_url: str) -> str:
     if not remote_url:
         return ""
     return _REMOTE_HOST_RE.sub("", remote_url.strip()).removesuffix(".git")
+
+
+def host_from_remote(remote_url: str) -> str:
+    """The network host a git remote URL points at, or ``""`` when it names none.
+
+    Pure string helper, the host counterpart of :func:`slug_from_remote` (which
+    deliberately strips the host). Handles ``git@host:slug``, ``ssh://git@host/slug``,
+    ``https://host/slug`` and ``git://host/slug``, lower-cased with any ``:port``
+    stripped so ``ssh://git@GitHub.com:22/…`` and ``https://github.com/…`` compare
+    equal.
+
+    Returns ``""`` for a URL with no network host — a bare filesystem path, a
+    relative path, or a ``file://`` URL. That is *unknown*, NOT "a different host":
+    a caller comparing hosts must treat the empty answer as non-discriminating
+    rather than as a mismatch.
+    """
+    if not remote_url:
+        return ""
+    text = remote_url.strip()
+    if text.startswith("file://"):
+        return ""
+    ssh_match = _SSH_HOST_RE.match(text)
+    if ssh_match:
+        return _normalize_host(ssh_match.group(1))
+    scheme_match = _SCHEME_HOST_RE.match(text)
+    if scheme_match:
+        return _normalize_host(scheme_match.group(1))
+    return ""
+
+
+def _normalize_host(host: str) -> str:
+    """Lower-case, drop a trailing numeric ``:port``, and drop a leading ``www.``."""
+    bare = host.strip()
+    head, separator, tail = bare.rpartition(":")
+    if separator and tail.isdigit():
+        bare = head
+    return bare.lower().removeprefix("www.")
 
 
 def web_base_from_remote(remote_url: str) -> str:

--- a/tests/eval_replay/test_gate_failures.py
+++ b/tests/eval_replay/test_gate_failures.py
@@ -26,6 +26,7 @@ from teatree.eval.gate_failures import (
     extract_gate_failures,
     gate_identity_slug,
     record_gate_failures,
+    recurring_fingerprints,
 )
 from teatree.eval.session_transcript import SessionEvent, parse_session_jsonl
 
@@ -279,3 +280,47 @@ class TestEscalate:
 @pytest.fixture
 def banned_config(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("T3_BANNED_TERMS", "acmecorp")
+
+
+class TestRecurrenceCountsRepeatsWithinOneSession:
+    """A gate the agent tripped 67 times in ONE session is recurring by any reading.
+
+    ``FindingsStore`` keys each session on its own file whose findings are a
+    ``fingerprint -> classification`` MAP, so N firings of one gate collapse to a
+    single entry and the cross-session file count stays 1. An observed transcript
+    held 102 blocks of exactly 2 gate identities and reported both
+    ``recurring: false``. Recurrence is what escalates a finding from "write a
+    memory" to "build a gate", so that false negative disables the escalation path
+    in precisely the case it exists for — a corrective visibly failing to take,
+    over and over, inside one run.
+    """
+
+    def test_a_gate_repeated_within_one_session_is_recurring(self, tmp_path: Path) -> None:
+        store = FindingsStore(data_dir=tmp_path)
+        repeated = [_preventable("only-session") for _ in range(3)]
+        record_gate_failures(store, repeated)
+        assert repeated[0].fingerprint in recurring_fingerprints(repeated, store=store)
+
+    def test_a_single_firing_in_a_single_session_is_not_recurring(self, tmp_path: Path) -> None:
+        store = FindingsStore(data_dir=tmp_path)
+        once = _preventable("only-session")
+        record_gate_failures(store, [once])
+        assert once.fingerprint not in recurring_fingerprints([once], store=store)
+
+    def test_the_cross_session_signal_still_counts(self, tmp_path: Path) -> None:
+        # One firing each in two sessions: no intra-session repeat, still recurring.
+        store = FindingsStore(data_dir=tmp_path)
+        first, second = _preventable("s1"), _preventable("s2")
+        record_gate_failures(store, [first])
+        record_gate_failures(store, [second])
+        assert second.fingerprint in recurring_fingerprints([second], store=store)
+
+    def test_a_repeated_gate_within_one_session_escalates(self, tmp_path: Path) -> None:
+        # The end-to-end consequence — the filer, not just the reported flag.
+        store = FindingsStore(data_dir=tmp_path)
+        repeated = [_preventable("only-session") for _ in range(4)]
+        record_gate_failures(store, repeated)
+        host = _FakeHost()
+        filed = escalate_gate_failures(host, failures=repeated, store=store, context=_CONTEXT)
+        assert len(filed) == 1, "one issue for the repeated gate, deduped by fingerprint"
+        assert len(host.created) == 1

--- a/tests/teatree_core/fleet/test_claim_unit.py
+++ b/tests/teatree_core/fleet/test_claim_unit.py
@@ -13,6 +13,7 @@ from django.test import TestCase
 
 from teatree.core.fleet import claim as fleet_claim
 from teatree.core.fleet import wire as fleet_claim_wire
+from teatree.core.fleet.wire import host_from_issue_url
 
 from ._git_origin import init_bare, init_client, init_with_origin
 
@@ -284,6 +285,11 @@ class TestForgeHostIsPartOfTheIdentity:
         for url in (f"file://{tmp_path}/souliane/teatree.git", f"{tmp_path}/souliane/teatree.git"):
             clone = init_with_origin(tmp_path / f"c{abs(hash(url))}", url)
             assert fleet_claim_wire._forge_host_conflict(str(clone), _KEY) is False, url
+
+    def test_the_issue_url_host_is_read_from_the_url_itself(self) -> None:
+        assert host_from_issue_url(_KEY) == "github.com"
+        assert host_from_issue_url("https://gitlab.example.org/g/s/p/-/issues/7") == "gitlab.example.org"
+        assert host_from_issue_url("") == ""
 
     def test_an_unparsable_issue_url_is_never_a_conflict(self, tmp_path) -> None:
         clone = init_with_origin(tmp_path / "found", "https://gitlab.com/souliane/teatree.git")

--- a/tests/teatree_core/fleet/test_claim_unit.py
+++ b/tests/teatree_core/fleet/test_claim_unit.py
@@ -235,6 +235,70 @@ class TestWireResolvers:
         assert fleet_claim_wire.resolve_claim_repo(_KEY) == ""
 
 
+class TestForgeHostIsPartOfTheIdentity:
+    """The slug alone is not the repo — the same ``owner/repo`` exists on many forges.
+
+    The claim ref is a server-side CAS on ONE receive-pack. Two instances pushing
+    ``souliane/teatree`` claims to two different forges each win their own ref, so
+    the mutex silently stops excluding anything and both implement the work item.
+    """
+
+    def test_same_slug_on_a_different_forge_is_rejected(self, tmp_path, monkeypatch) -> None:
+        clone = init_with_origin(tmp_path / "found", "https://gitlab.com/souliane/teatree.git")
+        monkeypatch.setattr(fleet_claim_wire, "find_clone_path", lambda *_: clone)
+        assert fleet_claim_wire.resolve_claim_repo(_KEY) == ""
+
+    def test_the_matching_forge_is_still_accepted_over_ssh(self, tmp_path, monkeypatch) -> None:
+        clone = init_with_origin(tmp_path / "found", "git@github.com:souliane/teatree.git")
+        monkeypatch.setattr(fleet_claim_wire, "find_clone_path", lambda *_: clone)
+        assert fleet_claim_wire.resolve_claim_repo(_KEY) == str(clone)
+
+    def test_a_port_and_case_difference_is_not_a_different_forge(self, tmp_path, monkeypatch) -> None:
+        clone = init_with_origin(tmp_path / "found", "ssh://git@GitHub.com:22/souliane/teatree.git")
+        monkeypatch.setattr(fleet_claim_wire, "find_clone_path", lambda *_: clone)
+        assert fleet_claim_wire.resolve_claim_repo(_KEY) == str(clone)
+
+    def test_an_ssh_config_alias_resolves_to_its_real_hostname(self, tmp_path, monkeypatch) -> None:
+        # `git@github-work:…` is one Host alias away from github.com. Comparing the
+        # raw token would reject a perfectly valid work-account setup, so the alias
+        # is resolved through the same `ssh -G` the transport itself would use.
+        clone = init_with_origin(tmp_path / "found", "git@github-work:souliane/teatree.git")
+        monkeypatch.setattr(fleet_claim_wire, "find_clone_path", lambda *_: clone)
+        monkeypatch.setattr(fleet_claim_wire, "_ssh_resolved_hostname", lambda host: "github.com")
+        assert fleet_claim_wire.resolve_claim_repo(_KEY) == str(clone)
+
+    def test_an_unresolvable_alias_is_not_treated_as_a_conflict(self, tmp_path, monkeypatch) -> None:
+        # No ssh on PATH, or an alias ssh cannot resolve: the host is UNKNOWN, not
+        # different. Fall back to the slug-only verdict rather than refusing to
+        # claim on a host we simply could not read.
+        clone = init_with_origin(tmp_path / "found", "git@github-work:souliane/teatree.git")
+        monkeypatch.setattr(fleet_claim_wire, "find_clone_path", lambda *_: clone)
+        monkeypatch.setattr(fleet_claim_wire, "_ssh_resolved_hostname", lambda host: "")
+        assert fleet_claim_wire.resolve_claim_repo(_KEY) == str(clone)
+
+    def test_a_local_or_file_origin_is_unknown_not_different(self, tmp_path) -> None:
+        # A clone-of-a-clone (and every local fixture) names no forge. Unknown must
+        # not read as "different", or the host check would newly reject clones the
+        # slug check accepts. Asserted on the predicate: a local origin never even
+        # reaches it in practice, because `remote_slug` yields no owner/repo for one.
+        for url in (f"file://{tmp_path}/souliane/teatree.git", f"{tmp_path}/souliane/teatree.git"):
+            clone = init_with_origin(tmp_path / f"c{abs(hash(url))}", url)
+            assert fleet_claim_wire._forge_host_conflict(str(clone), _KEY) is False, url
+
+    def test_an_unparsable_issue_url_is_never_a_conflict(self, tmp_path) -> None:
+        clone = init_with_origin(tmp_path / "found", "https://gitlab.com/souliane/teatree.git")
+        assert fleet_claim_wire._forge_host_conflict(str(clone), "not-a-url") is False
+
+    def test_a_mirror_on_another_host_fails_safe_rather_than_splitting_the_mutex(self, tmp_path, monkeypatch) -> None:
+        # A mirror carries the same content but a DIFFERENT receive-pack, so a claim
+        # pushed there excludes nobody on the forge that owns the issue. Refusing to
+        # claim degrades to local-only behaviour; accepting would manufacture a mutex
+        # that does not exist.
+        clone = init_with_origin(tmp_path / "found", "https://mirror.example.com/souliane/teatree.git")
+        monkeypatch.setattr(fleet_claim_wire, "find_clone_path", lambda *_: clone)
+        assert fleet_claim_wire.resolve_claim_repo(_KEY) == ""
+
+
 class TestWireFailSafe:
     def test_acquire_issue_claim_no_repo_fails_safe(self, monkeypatch) -> None:
         monkeypatch.setattr(fleet_claim_wire, "resolve_claim_repo", lambda _: "")

--- a/tests/teatree_core/management_commands/test_retro_gate_failures.py
+++ b/tests/teatree_core/management_commands/test_retro_gate_failures.py
@@ -115,6 +115,32 @@ class RetroGateFailuresTest(TestCase):
         assert any("plugin-directory-does-not-exist" in g for g in environmental)
         assert not any("pretooluse" in g for g in verdicts)
 
+    def test_a_gate_repeated_within_one_session_reports_recurring(self) -> None:
+        """The reported flag, not just the filer.
+
+        A session in which the SAME gate blocked repeatedly used to report
+        ``recurring: false`` on every row, because recurrence counted distinct
+        session FILES and one session is one file. Recurrence is what escalates a
+        finding from "write a memory" to "build a gate", so the flag being wrong
+        here is the whole signal being wrong.
+        """
+        store_dir = Path(self._tmp())
+        session = _session_file(
+            store_dir,
+            *[_gate_block_line(message=_QUESTION_GATE)] * 3,
+        )
+        result = self._run(file=str(session), store_dir=store_dir)
+        failures = cast("list[dict[str, object]]", result["failures"])
+        assert len(failures) == 3
+        assert all(f["recurring"] is True for f in failures)
+
+    def test_a_gate_blocking_once_in_one_session_is_not_recurring(self) -> None:
+        store_dir = Path(self._tmp())
+        session = _session_file(store_dir, _gate_block_line(message=_QUESTION_GATE))
+        result = self._run(file=str(session), store_dir=store_dir)
+        failures = cast("list[dict[str, object]]", result["failures"])
+        assert [f["recurring"] for f in failures] == [False]
+
     def test_serialized_output_never_carries_message_stderr_or_command(self) -> None:
         store_dir = Path(self._tmp())
         session = _session_file(

--- a/tests/teatree_utils/test_git_remote.py
+++ b/tests/teatree_utils/test_git_remote.py
@@ -36,3 +36,44 @@ class TestWebBaseFromRemote:
 
     def test_unparsable_host_returns_empty(self) -> None:
         assert git_remote.web_base_from_remote("not-a-remote-url") == ""
+
+
+class TestHostFromRemote:
+    """The host half of a remote URL — the identity bit ``slug_from_remote`` drops.
+
+    ``owner/repo`` is unique per FORGE, not globally, so any caller deciding "is this
+    clone the one the issue lives on" needs both halves.
+    """
+
+    def test_ssh_scp_form(self) -> None:
+        assert git_remote.host_from_remote("git@github.com:acme/widgets.git") == "github.com"
+
+    def test_ssh_url_form_with_port(self) -> None:
+        assert git_remote.host_from_remote("ssh://git@gitlab.com:22/acme/widgets.git") == "gitlab.com"
+
+    def test_https_form_is_case_insensitive(self) -> None:
+        assert git_remote.host_from_remote("https://GitHub.COM/acme/widgets") == "github.com"
+
+    def test_https_form_with_port(self) -> None:
+        assert git_remote.host_from_remote("https://git.example.org:8443/acme/widgets.git") == "git.example.org"
+
+    def test_www_prefix_is_not_a_different_host(self) -> None:
+        assert git_remote.host_from_remote("https://www.github.com/acme/widgets") == "github.com"
+
+    def test_git_protocol_form(self) -> None:
+        assert git_remote.host_from_remote("git://github.com/acme/widgets.git") == "github.com"
+
+    def test_file_url_names_no_host(self) -> None:
+        assert git_remote.host_from_remote("file:///srv/mirrors/widgets.git") == ""
+
+    def test_filesystem_path_names_no_host(self) -> None:
+        assert git_remote.host_from_remote("/srv/mirrors/widgets.git") == ""
+        assert git_remote.host_from_remote("../sibling/widgets.git") == ""
+
+    def test_empty_returns_empty(self) -> None:
+        assert git_remote.host_from_remote("") == ""
+
+    def test_an_ssh_alias_token_is_returned_verbatim_for_the_caller_to_resolve(self) -> None:
+        # `github-work` is a ~/.ssh/config Host alias. This module is pure, so it
+        # reports the token; expanding it needs `ssh -G`, which the caller owns.
+        assert git_remote.host_from_remote("git@github-work:acme/widgets.git") == "github-work"

--- a/tests/teatree_utils/test_git_remote.py
+++ b/tests/teatree_utils/test_git_remote.py
@@ -1,4 +1,5 @@
 from teatree.utils import git_remote
+from teatree.utils.git_remote import host_from_remote
 
 
 class TestSlugFromRemote:
@@ -46,7 +47,7 @@ class TestHostFromRemote:
     """
 
     def test_ssh_scp_form(self) -> None:
-        assert git_remote.host_from_remote("git@github.com:acme/widgets.git") == "github.com"
+        assert host_from_remote("git@github.com:acme/widgets.git") == "github.com"
 
     def test_ssh_url_form_with_port(self) -> None:
         assert git_remote.host_from_remote("ssh://git@gitlab.com:22/acme/widgets.git") == "gitlab.com"


### PR DESCRIPTION
fix(fleet,retro): forge host is part of a repo's identity; recurrence counts intra-session repeats

## What

Two findings surfaced earlier and never actioned. Independent subsystems, bundled because they are one reported cluster; each is a self-contained commit with its own tests.

### 1. resolve_claim_repo was forge-host-blind

`owner/repo` is unique per FORGE, not globally, and `git.remote_slug` drops the host by design. So a clone of `gitlab.com/o/r` satisfied the origin check for an issue on `github.com/o/r`.

That matters because the claim ref is a compare-and-swap on ONE server's receive-pack. Two instances pushing to two different forges each create their own ref and each conclude they won, so the mutex stops excluding anything at precisely the moment it is supposed to.

A strict host match is not a drop-in fix, so the check is confidence-gated — it fires only when both hosts are read confidently and differ:

- `git@github-work:o/r` (ssh alias) - accept, expanded via `ssh -G` to the host it actually reaches
- `file://...` or a filesystem path (no host) - accept; unknown is not different, so the slug verdict stands unchanged and no existing setup newly fails
- an alias `ssh -G` cannot expand - accept, same reason
- `gitlab.com` vs `github.com` - reject, genuinely a different forge
- a mirror on another host - reject, deliberately

The mirror case is a considered reject, not an oversight. A mirror has its own receive-pack, so a claim pushed there excludes nobody on the forge that owns the issue. Refusing degrades to today's local-only behaviour (identical to no clone resolving) and logs the reason; accepting would manufacture a mutex that does not exist, which is strictly worse than having none. Pointing `origin` at the arbitrating forge opts back in.

Case, port and `www.` differences normalise away, so `ssh://git@GitHub.com:22/...` and `https://github.com/...` still compare equal.

### 2. retro gate-failures recurrence was cross-session only

`FindingsStore.recurring_fingerprints` counts the number of per-session FILES holding a fingerprint, and each file's findings are a `fingerprint -> classification` MAP. So every firing of one gate inside a single session collapses to one entry and that count stays 1.

Verified against a real transcript: 102 blocking events, 2 distinct gate identities (67 of one, 35 of the other), all reported `recurring: false`.

## Why

Recurrence is what escalates a finding from "write a memory" to "build a gate", so the false negative disabled the escalation path in exactly the case it exists for - a corrective visibly failing to take, over and over, inside one run. Repetition within a session is the STRONGER signal, not a weaker one.

`recurring_fingerprints(failures, store=...)` unions the two dimensions at the same threshold, so neither can mask the other. Both the reported flag and the escalation filer read it; the PR-review findings path (recurrence across PRs) is untouched.

## Verification

Every test proven RED first.

- `TestForgeHostIsPartOfTheIdentity` - 5 failed against the old resolver, now green
- `TestRecurrenceCountsRepeatsWithinOneSession` - import error, then green
- CLI control: reverting `retro.py` to `store.recurring_fingerprints()` reds `test_a_gate_repeated_within_one_session_reports_recurring`, so the assertion is load-bearing rather than vacuous

```text
tests/teatree_core/fleet/  tests/eval_replay/  tests/teatree_utils/test_git_remote.py
tests/teatree_core/management_commands/test_retro_gate_failures.py
2387 passed, 28 skipped
```
