### PR TITLE
test(db): refuse a unit run whose collection disabled Django's async guard

### DIFF
--- a/tests/_thread_db_sentinel.py
+++ b/tests/_thread_db_sentinel.py
@@ -25,9 +25,19 @@ Always on, because the failure it catches lands on a random test in a random
 shard: a sentinel that has to be switched on can only ever be switched on after
 the fact. It costs one ``threading.current_thread()`` comparison per connection
 open; the stack capture only runs for the rare non-main-thread open.
+
+The module also holds the guard for the OTHER half of this failure class, which
+produced the strands actually observed in CI: Django decorates
+``BaseDatabaseWrapper.connect`` with ``@async_unsafe``, so a thread that has a
+running event loop is REFUSED a connection with ``SynchronousOnlyOperation``.
+``DJANGO_ALLOW_ASYNC_UNSAFE`` disables that refusal process-wide, and the connect
+then silently succeeds against a fresh EMPTY ``:memory:`` database — the exact
+"no such table" + stranded-handle pair. See
+:func:`assert_async_unsafe_guard_intact`.
 """
 
 import dataclasses
+import os
 import threading
 import traceback
 from typing import TYPE_CHECKING, Any
@@ -36,6 +46,10 @@ import pytest
 
 if TYPE_CHECKING:
     from collections.abc import Generator
+
+#: Django's escape hatch for its own async-unsafe guard. The unit lane must never
+#: run with it set — see :func:`assert_async_unsafe_guard_intact`.
+ASYNC_UNSAFE_ENV = "DJANGO_ALLOW_ASYNC_UNSAFE"
 
 #: Frames of pytest/threading/sentinel plumbing that carry no information about
 #: the site that opened the connection.
@@ -53,6 +67,50 @@ _STACK_FRAMES_SHOWN = 6
 
 class StrandedDbHandleError(AssertionError):
     """A worker thread died holding an open raw DB handle."""
+
+
+class AsyncUnsafeGuardDisabledError(RuntimeError):
+    """The unit lane is running with Django's async-unsafe guard switched off."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            f"{ASYNC_UNSAFE_ENV} is set for the unit test suite. Django's async-unsafe guard "
+            "on BaseDatabaseWrapper.connect is what refuses a connection to a thread that owns "
+            "a running event loop; with it off, that connect silently opens a fresh EMPTY "
+            ":memory: database, every config read logs `no such table`, and the handle is "
+            "stranded for a later GC to red an unrelated test.\n\n"
+            "It is almost always set by a collection-time import side effect — a module under "
+            "tests/ importing the e2e lane's conftest, whose body sets it. Import the helper "
+            "from a plain module instead of the conftest, and leave the variable to the e2e lane."
+        )
+
+
+def assert_async_unsafe_guard_intact(environ: "dict[str, str] | None" = None) -> None:
+    """Refuse to run the unit suite with ``DJANGO_ALLOW_ASYNC_UNSAFE`` set.
+
+    Django's ``@async_unsafe`` decorator on ``BaseDatabaseWrapper.connect`` is what
+    stops a thread that owns a running event loop from opening its own connection.
+    With the guard off, that connect succeeds instead of raising — and under the
+    ``:memory:`` test database it lands on a brand-new EMPTY database, so every
+    config/ORM read logs ``no such table`` and the handle is stranded for a later
+    GC to finalize as ``ResourceWarning: unclosed database``.
+
+    The guard is disabled process-wide by a single ``os.environ`` write, and the
+    write that actually happened was a COLLECTION-TIME side effect: a module under
+    ``tests/`` imported the e2e lane's ``conftest``, whose module body sets the
+    variable. Collection imports every test module in every shard, so one stray
+    import poisons all twelve — even the eleven that then deselect the importing
+    file. That is invisible to the per-test env diff in
+    ``scripts/ci/leak_sentinel_plugin.py`` (the mutation predates every test's
+    baseline), and equally invisible to a session-START check (it predates the
+    import), so this is asserted when collection FINISHES.
+
+    The e2e lane legitimately sets it and does not load ``tests/conftest.py``, so
+    this is scoped to the unit lane only.
+    """
+    env = os.environ if environ is None else environ
+    if env.get(ASYNC_UNSAFE_ENV):
+        raise AsyncUnsafeGuardDisabledError
 
 
 def handle_is_open(raw: Any) -> bool:
@@ -157,6 +215,25 @@ class ThreadDbHandleSentinel:
         """Install the wrapper once Django is configured (after pytest-django's setup)."""
         del session  # hookspec signature; the sentinel is session-independent
         self.install()
+
+    def pytest_collection_finish(self, session: pytest.Session) -> None:
+        """Refuse the run when collection left the async-unsafe guard disabled.
+
+        Asserted HERE, not at session start: the write that disables it is a
+        module-body side effect of importing a test module, so it only exists once
+        every test module has been imported. Failing loud on the cause beats
+        reporting the cascade of stranded handles it produces.
+
+        Re-raised as a :class:`pytest.UsageError` (which is ``@final``, so it
+        cannot simply be the exception's base class) so the session aborts with a
+        plain readable message rather than an INTERNALERROR traceback — the reader
+        needs the cause and the fix, not this hook's own stack.
+        """
+        del session  # hookspec signature; the check is process-global
+        try:
+            assert_async_unsafe_guard_intact()
+        except AsyncUnsafeGuardDisabledError as exc:
+            raise pytest.UsageError(str(exc)) from exc
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_protocol(self, item: pytest.Item) -> "Generator[None, object]":

--- a/tests/test_thread_db_sentinel.py
+++ b/tests/test_thread_db_sentinel.py
@@ -10,16 +10,21 @@ Django connection — so the guard cannot silently become vacuous:
 
 * a thread that does NOT close its handle is detected;
 * the same thread WITH ``close_thread_db_connections`` is not;
-* neutering that helper at a real production call site (``teatree.loop.phases.scan``) goes red.
+* neutering that helper at a real production call site (``teatree.loop.phases.scan``) goes red;
+* Django's async-unsafe guard is what refuses an event-loop thread a connection, and
+``DJANGO_ALLOW_ASYNC_UNSAFE`` turns that refusal into a stranded handle.
 """
 
+import asyncio
 import dataclasses
+import os
 import sqlite3
 import threading
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import pytest
+from django.core.exceptions import SynchronousOnlyOperation
 from django.db import connection
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.test import TestCase
@@ -27,9 +32,12 @@ from django.test import TestCase
 from teatree.loop.phases import scan
 from teatree.utils.thread_db import close_thread_db_connections
 from tests._thread_db_sentinel import (
+    ASYNC_UNSAFE_ENV,
+    AsyncUnsafeGuardDisabledError,
     OpenedConnection,
     StrandedDbHandleError,
     ThreadDbHandleSentinel,
+    assert_async_unsafe_guard_intact,
     describe,
     handle_is_open,
 )
@@ -210,6 +218,88 @@ class TestNeuteringTheHelperGoesRed(TestCase):
         self.monkeypatch.setattr(scan, "close_thread_db_connections", lambda: None)
 
         assert _run_scan_job_on_a_worker(sentinel, self.monkeypatch) == ["sentinel-subject"]
+
+
+def _open_a_connection_inside_an_event_loop() -> None:
+    """Open this thread's connection from inside a running event loop."""
+
+    async def _open() -> None:
+        await asyncio.sleep(0)  # the loop must be running when connect() checks
+        connection.ensure_connection()
+
+    asyncio.run(_open())
+
+
+def _run_on_worker_capturing(target: "Callable[[], object]") -> BaseException | None:
+    """Run *target* on a worker thread; return the exception it raised, if any."""
+    raised: list[BaseException] = []
+
+    def _wrapped() -> None:
+        try:
+            target()
+        except BaseException as exc:  # noqa: BLE001 — the exception IS the assertion subject
+            raised.append(exc)
+
+    thread = threading.Thread(target=_wrapped, name="sentinel-subject")
+    thread.start()
+    thread.join()
+    return raised[0] if raised else None
+
+
+class TestAsyncUnsafeGuardAssertion:
+    """The unit lane refuses to run with Django's async-unsafe guard switched off."""
+
+    def test_silent_when_the_variable_is_absent(self) -> None:
+        assert assert_async_unsafe_guard_intact({}) is None
+
+    def test_silent_when_the_variable_is_empty(self) -> None:
+        assert assert_async_unsafe_guard_intact({ASYNC_UNSAFE_ENV: ""}) is None
+
+    def test_raises_and_explains_the_consequence_when_set(self) -> None:
+        with pytest.raises(AsyncUnsafeGuardDisabledError) as excinfo:
+            assert_async_unsafe_guard_intact({ASYNC_UNSAFE_ENV: "1"})
+
+        message = str(excinfo.value)
+        assert "no such table" in message
+        assert "conftest" in message, "the message must name the collection-time import that sets it"
+
+    def test_the_live_environment_is_clean(self) -> None:
+        """This suite is itself the subject: a stray import would set it for everyone."""
+        assert not os.environ.get(ASYNC_UNSAFE_ENV)
+
+
+class TestAsyncUnsafeGuardIsWhatStopsTheStrand(TestCase):
+    """Anti-vacuity for the guard: flipping the variable produces the real leak.
+
+    Django decorates ``BaseDatabaseWrapper.connect`` with ``@async_unsafe``, so a
+    thread that owns a running event loop is refused a connection. That refusal —
+    not any ``finally`` — is what keeps such a thread from stranding a handle.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _fixtures(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Grouped into a TestCase per souliane/teatree#98; monkeypatch injected."""
+        self.monkeypatch = monkeypatch
+
+    def test_an_event_loop_thread_is_refused_a_connection(self) -> None:
+        monkeypatch = self.monkeypatch
+        sentinel = _recording_sentinel(monkeypatch)
+        monkeypatch.delenv(ASYNC_UNSAFE_ENV, raising=False)
+
+        raised = _run_on_worker_capturing(_open_a_connection_inside_an_event_loop)
+
+        assert isinstance(raised, SynchronousOnlyOperation)
+        assert sentinel.sweep() == [], "a refused connect strands nothing"
+
+    def test_disabling_the_guard_strands_the_handle(self) -> None:
+        monkeypatch = self.monkeypatch
+        sentinel = _recording_sentinel(monkeypatch)
+        monkeypatch.setenv(ASYNC_UNSAFE_ENV, "1")
+
+        raised = _run_on_worker_capturing(_open_a_connection_inside_an_event_loop)
+
+        assert raised is None, "with the guard off the connect succeeds instead of raising"
+        assert [record.thread.name for record in sentinel.sweep()] == ["sentinel-subject"]
 
 
 class TestHandleIsOpen:


### PR DESCRIPTION
## Root cause, found and reproduced

The recurring `PytestUnraisableExceptionWarning` / leaked-sqlite-connection shard flake is **not** a missing
`close_thread_db_connections()` call. Every thread-spawning site is correctly wired; PR #3536 held.

The cause is that Django's own guard was switched off. `BaseDatabaseWrapper.connect` is decorated
`@async_unsafe`, so a thread that owns a running event loop is **refused** a connection with
`SynchronousOnlyOperation`. That refusal — not any `finally` — is what stops such a thread from stranding a
handle. `DJANGO_ALLOW_ASYNC_UNSAFE` disables it process-wide, and the connect then silently succeeds against
a **fresh EMPTY `:memory:` database** — so every config read logs `no such table: teatree_config_setting`
and the handle is stranded for a later GC to finalize as `ResourceWarning: unclosed database`.

The write that set it was a **collection-time import side effect**. On `7e1cac58` (PR #3791's branch head),
`tests/test_e2e_dash_browser_executable.py` opened with:

```python
from e2e.dash.conftest import browser_launch_overrides
```

and `e2e/dash/conftest.py`'s module body runs `os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "1")`.
Collection imports **every** test module in **every** shard, so one stray import poisoned all twelve —
including the eleven that then deselect the importing file. That is exactly the observed pattern: 12/12
shards, on two consecutive runs, on that branch only.

It was fixed before merge by a one-line change (`from e2e.dash.browser_launch import …`), which is why
`main` is clean and why a whole-suite probe at `00a80a88` correctly found zero leaks.

## Evidence

**Reproduced locally at the exact failing SHA.** `7e1cac58`, CI shard 9's exact selection
(`--splits 12 --group 9 --splitting-algorithm least_duration --doctest-modules --cov -n 2`) fails on the
same victim as the CI job:

```
FAILED tests/teatree_agents/test_harness.py::TestRunHeadlessDrivesPydanticAiHarness::test_missing_credential_on_resume_preserves_the_parked_thread
  - pytest.PytestUnraisableExceptionWarning: Exception ignored in: <sqlite3.Con...
```

**Causation isolated by A/B on an unmodified tree.** Same commit, same test selection; the only difference is
the environment variable:

```
DJANGO_ALLOW_ASYNC_UNSAFE=1 uv run pytest tests/teatree_agents tests/test_cli_assess.py
  → E ResourceWarning: unclosed database in <sqlite3.Connection object at ...>   (x12)
uv run pytest tests/teatree_agents tests/test_cli_assess.py
  → 1192 passed
```

**CI record, corrected.** My first scan filtered runs on `conclusion == "failure"`; these runs are
`cancelled`, so the filter dropped them. Rescanning all 415 CI runs since 2026-07-22 (57 `failure` +
58 `cancelled`, 352 failed jobs) finds the sqlite signature in **exactly two runs — `30307086953` and
`30307723058`, both on `feat/e2e-local-browser-executable`, 12 shard jobs each, and nowhere else.**

## Which reds were which

Separating the record, since these were conflated:

| Failure | Runs | Cause |
|---|---|---|
| **sqlite leaked connection** | `30307086953`, `30307723058` (PR #3791 branch, 12/12 shards each) | this PR's root cause — a collection-time env write |
| `tests/quality/test_incompleteness_marker_ratchet.py` | 4 branch PRs + `main` (`30265343082`) | a whole-tree ratchet **red on `main`**; every branch inherited it. Deterministic, on a different arbitrary shard pair each time — a fixed failure wearing the costume of a flake. Cured by rebase, not by retry. |
| `test_signal_route_totality.py` | `feat/memory-skim-loop`, `fix/question-resurface-cadence` | branch-local: a new signal kind with no explicit route |
| `test_intra_core_deferred_import_ratchet.py`, `test_deferred_import_pegs.py` | `ac/agent-runtime-claim-guard` | branch-local ratchets |
| `test_process_cache_reset_roster.py` | `feat/settings-p7-…` | branch-local roster |
| review-nag / lifecycle `replace()` TypeError | `feat/toml-defaults-tier` | real branch breakage |
| `dash-e2e` Playwright | `fix/dash-ux-audit-rest` | e2e lane |

## The guard

`assert_async_unsafe_guard_intact()` in `tests/_thread_db_sentinel.py`, asserted from
`pytest_collection_finish`.

Hook choice is load-bearing and was corrected under test: a session-**start** check cannot see this, because
the write is a module-body side effect that only exists once every test module has been imported. It is
equally invisible to `scripts/ci/leak_sentinel_plugin.py`'s per-test env diff, since the mutation predates
every test's baseline. Collection-finish is the first moment the fact exists.

The e2e lane legitimately sets the variable and does not load `tests/conftest.py`, so this is scoped to the
unit lane. Raised as a `pytest.UsageError` (which is `@final`, hence the translation rather than a subclass)
so the run aborts with the cause and the fix, not an INTERNALERROR traceback.

## Anti-vacuity

- At `7e1cac58`, the guard aborts the unit lane with **exit 4** and the remediation message; the same tree
  without it reproduces the CI red verbatim.
- `TestAsyncUnsafeGuardIsWhatStopsTheStrand` pins the mechanism directly, both directions, at the real seam:
  an event-loop worker thread is refused a connection (`SynchronousOnlyOperation`) with the guard intact, and
  with `DJANGO_ALLOW_ASYNC_UNSAFE` set the same thread opens one and the sentinel reports the strand.
- `TestAsyncUnsafeGuardAssertion::test_the_live_environment_is_clean` makes this suite its own subject.

## Verification

- `tests/test_thread_db_sentinel.py` — 17 passed
- `ruff check` / `ruff format` / `ty check` clean; full `prek` commit hooks green
