### PR TITLE
fix(doctor,deploy): an unprobeable permission is not a missing one

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -203,8 +203,13 @@ assert_gh_token_permissions() {
         exit 1
     fi
 
-    # RECOMMENDED (WARN-tier) probes — never exit 1. workflows:write is never actively probed (see above).
-    warn_missing=("workflows: write")
+    # RECOMMENDED (WARN-tier) probes — never exit 1. workflows:write is never actively
+    # probed for a fine-grained token (see above), so it is NOT seeded here: "no
+    # reliable probe exists" is not evidence the permission is absent. Seeding it made
+    # every deploy tell the operator to recreate a token that may already carry it,
+    # with no action able to clear the warning. It rides along on the recreate line
+    # only when a REAL gap already means a recreate.
+    warn_missing=()
     _gh_probe_denied --method POST "repos/$slug/actions/workflows/0/dispatches" -f ref=teatree-preflight-nonexistent &&
         warn_missing+=("actions: write")
     _gh_probe_denied "repos/$slug/actions/artifacts?per_page=1" && warn_missing+=("actions: read")
@@ -221,7 +226,7 @@ assert_gh_token_permissions() {
     # projects: read needs an overlay's configured Projects-v2 board, which this
     # bash preflight cannot see — `t3 doctor check` probes it when configured.
     if [ ${#warn_missing[@]} -gt 0 ]; then
-        echo "entrypoint: WARN TEATREE_GH_TOKEN is missing recommended permission(s): ${warn_missing[*]} - these degrade optional features (CI trigger/status, auto-merge's required-checks rollup, workflow-file pushes, the CI OAuth-account switch) but do NOT block boot. Fine-grained tokens cannot be widened via the API either - recreate it with these permissions added: $_GH_FINE_GRAINED_TOKENS_URL" >&2
+        echo "entrypoint: WARN TEATREE_GH_TOKEN is missing recommended permission(s): ${warn_missing[*]} - these degrade optional features (CI trigger/status, auto-merge's required-checks rollup, the CI OAuth-account switch) but do NOT block boot. Fine-grained tokens cannot be widened via the API either - recreate it with these permissions added: $_GH_FINE_GRAINED_TOKENS_URL. While recreating, also include 'workflows: write': it cannot be probed on a fine-grained token, so its presence is unknown here - a push touching .github/workflows/* is what proves it either way." >&2
     fi
     echo "teatree-init: GitHub token permissions verified (required issues/pull_requests/contents write present on $slug)"
 }

--- a/src/teatree/core/gates/gh_token_preflight.py
+++ b/src/teatree/core/gates/gh_token_preflight.py
@@ -26,8 +26,12 @@ token) rather than passing preflight then failing mid-run.
 
 ``workflows: write`` is never actively probed on a fine-grained token — the
 #3477 spike could only confirm the permitted (404) path, not whether a denied
-token 403s route-level first, so probing risks a false "missing". Always
-reported as an unprobed WARN gap instead.
+token 403s route-level first, so probing risks a false "missing". It is reported
+in :attr:`GhTokenProbe.unprobed`, NOT in ``missing_recommended``: "no reliable
+probe exists" is not evidence the permission is absent. Folding it into the gap
+list asserted a gap nobody measured, so a token that already HAD the permission
+was told to recreate itself on every deploy and every doctor run, forever, with
+no action able to clear the warning.
 
 ``projects: read`` is probed only when ``github_owner`` + ``github_project_number``
 are supplied (an unconfigured board is never assessed).
@@ -63,6 +67,13 @@ RECOMMENDED_PERMISSION_LABELS: tuple[str, ...] = (
     "secrets: write",
     "variables: write",
 )
+
+#: Permissions a FINE-GRAINED token admits no reliable probe for. The #3477 spike
+#: could confirm only the permitted (404) path for ``workflows: write``, not whether
+#: a denied token 403s route-level first, so probing risks a false "missing". A
+#: classic token IS judged on it (``X-OAuth-Scopes`` is real evidence), so this is
+#: fine-grained-only.
+UNPROBEABLE_FINE_GRAINED_LABELS: tuple[str, ...] = ("workflows: write",)
 
 # One-line "what breaks without this" per permission, both tiers.
 FEATURE_BY_PERMISSION: dict[str, str] = {
@@ -216,17 +227,28 @@ class GhTokenProbe:
 
     ``missing`` is the denied REQUIRED permission labels (empty == the token has
     every required permission); ``missing_recommended`` is the WARN-tier gaps and
-    never affects ``ok``. ``indeterminate_reason`` is set only when the probe
-    could not run to a verdict (``gh`` absent, the metadata read unreachable, or a
-    required write probe that reached no 403/404) — the caller then skips rather
-    than failing on a network fault. A genuine denial always takes precedence over
-    an indeterminate write probe, so a real permission gap is never masked.
+    never affects ``ok``. Both are EVIDENCED — a probe reached a verdict.
+
+    ``unprobed`` is the separate, weaker fact "this token kind admits no reliable
+    probe for X" — never a claim that X is absent. Keeping it out of
+    ``missing_recommended`` is the point: an unprobed permission folded into the
+    gap list asserts a gap nobody measured, so remediation tells the operator to
+    recreate a token that may already carry it, and no action they take can clear
+    the warning. It is unfalsifiable by construction, which is exactly what a
+    permanent, un-actionable WARN is made of.
+
+    ``indeterminate_reason`` is set only when the probe could not run to a verdict
+    (``gh`` absent, the metadata read unreachable, or a required write probe that
+    reached no 403/404) — the caller then skips rather than failing on a network
+    fault. A genuine denial always takes precedence over an indeterminate write
+    probe, so a real permission gap is never masked.
     """
 
     missing: tuple[str, ...]
     missing_recommended: tuple[str, ...] = ()
     token_kind: TokenKind = "unknown"  # noqa: S105 — a classification label, not a credential
     indeterminate_reason: str | None = None
+    unprobed: tuple[str, ...] = ()
 
     @property
     def ok(self) -> bool:
@@ -380,9 +402,6 @@ def _probe_fine_grained(
             token_kind="fine_grained",  # noqa: S106 — a classification label, not a credential
         )
 
-    # Never actively probed (see module docstring) — always surfaced so remediation names it.
-    recommended_missing.add("workflows: write")
-
     if github_owner and github_project_number and _projects_read_denied(run, github_owner, github_project_number):
         recommended_missing.add("projects: read")
 
@@ -392,11 +411,22 @@ def _probe_fine_grained(
         missing=missing,
         missing_recommended=missing_recommended,
         token_kind="fine_grained",  # noqa: S106 — a classification label, not a credential
+        # Never actively probed (see module docstring). Reported as UNPROBED, not as
+        # a gap: it is not evidence the permission is absent, and a token that has it
+        # would otherwise be told to recreate itself on every doctor run forever.
+        unprobed=UNPROBEABLE_FINE_GRAINED_LABELS,
     )
 
 
 def format_remediation(probe: GhTokenProbe, slug: str) -> list[str]:
-    """Remediation lines for every gap ``probe`` reports — always a recreate, never an auto-add. Pure/print-free."""
+    """Remediation lines for every EVIDENCED gap — always a recreate, never an auto-add. Pure/print-free.
+
+    Silent when nothing was measured as missing, even if ``unprobed`` is non-empty:
+    an unprobeable permission is not a gap, and a recreate proposed on the strength
+    of one is advice the operator cannot act on or ever satisfy. The unprobed set
+    rides along only when a real gap already means a recreate — there, naming it is
+    genuinely useful ("while you are recreating it anyway, include this too").
+    """
     missing_all = [*probe.missing, *probe.missing_recommended]
     if not missing_all:
         return []
@@ -415,6 +445,12 @@ def format_remediation(probe: GhTokenProbe, slug: str) -> list[str]:
         "Fine-grained tokens cannot be widened via the API either — recreate it with these "
         f"permissions added: {FINE_GRAINED_TOKENS_URL}"
     )
+    if probe.unprobed:
+        lines.append(
+            f"While recreating, also include {', '.join(probe.unprobed)}: it cannot be probed on a "
+            "fine-grained token, so its presence is unknown here — a push touching .github/workflows/* "
+            "is what proves it either way."
+        )
     return lines
 
 
@@ -424,6 +460,7 @@ __all__ = [
     "FINE_GRAINED_TOKENS_URL",
     "RECOMMENDED_PERMISSION_LABELS",
     "REQUIRED_PERMISSION_LABELS",
+    "UNPROBEABLE_FINE_GRAINED_LABELS",
     "GhRunner",
     "GhTokenProbe",
     "Probe",

--- a/tests/teatree_core/gates/test_gh_token_preflight.py
+++ b/tests/teatree_core/gates/test_gh_token_preflight.py
@@ -144,14 +144,16 @@ class TestRecommendedPermissions:
             "actions/variables/": (1, _NOT_FOUND),
         }
 
-    def test_all_recommended_present_ok_and_no_recommended_gaps_except_workflows(self) -> None:
+    def test_all_recommended_present_reports_no_gap_and_one_unprobed(self) -> None:
         run = _runner(self._base_responses())
         with patch("teatree.core.gates.gh_token_preflight.shutil.which", return_value="/usr/bin/gh"):
             probe = probe_token_permissions(_SLUG, run=run)
         assert probe.ok
-        # workflows:write is never actively probed for a fine-grained token —
-        # always surfaced so remediation tells the operator to verify manually.
-        assert probe.missing_recommended == ("workflows: write",)
+        # workflows:write is never actively probed for a fine-grained token, so it is
+        # reported as UNPROBED — not as a gap. Claiming a gap nobody measured drove a
+        # recreate-your-token warning that no action could ever clear.
+        assert probe.missing_recommended == ()
+        assert probe.unprobed == ("workflows: write",)
 
     def test_missing_actions_write_reported_recommended_never_required(self) -> None:
         responses = self._base_responses()
@@ -524,3 +526,53 @@ class TestFormatRemediation:
         probe = GhTokenProbe(missing=("issues: write",), token_kind="fine_grained")
         lines = format_remediation(probe, _SLUG)
         assert any("issues: write" in line for line in lines)
+
+
+class TestUnprobedIsNotAGap:
+    """An UNPROBEABLE permission is not evidence of a missing one.
+
+    ``workflows: write`` is deliberately never probed on a fine-grained token (the
+    #3477 spike could not distinguish a route-level 403 from the permitted path), so
+    reporting it in ``missing_recommended`` asserts a gap nobody measured. The
+    consequence is worse than noise: ``format_remediation`` then tells the operator
+    to RECREATE a token that may already carry the permission, and no action they
+    take can ever clear the WARN — it is unfalsifiable by construction.
+    """
+
+    def _fine_grained_all_present(self) -> GhTokenProbe:
+        base = TestRecommendedPermissions()._base_responses()
+        run = _runner(base)
+        with patch("teatree.core.gates.gh_token_preflight.shutil.which", return_value="/usr/bin/gh"):
+            return probe_token_permissions(_SLUG, run=run)
+
+    def test_a_clean_fine_grained_token_reports_no_gap(self) -> None:
+        probe = self._fine_grained_all_present()
+        assert probe.missing_recommended == (), "an unprobed permission is not a measured gap"
+        assert probe.unprobed == ("workflows: write",)
+
+    def test_a_clean_fine_grained_token_produces_no_remediation(self) -> None:
+        # The whole point: nothing to act on means nothing printed, run after run.
+        assert format_remediation(self._fine_grained_all_present(), _SLUG) == []
+
+    def test_the_unprobed_note_rides_along_when_a_real_gap_exists(self) -> None:
+        # The operator is already recreating the token, so naming it is actionable.
+        probe = GhTokenProbe(
+            missing=(),
+            missing_recommended=("projects: read",),
+            unprobed=("workflows: write",),
+            token_kind="fine_grained",
+        )
+        lines = format_remediation(probe, _SLUG)
+        body = "\n".join(lines)
+        assert "projects: read" in body
+        assert "workflows: write" in body
+        assert "cannot be probed" in body
+
+    def test_a_classic_token_probes_the_workflow_scope_so_nothing_is_unprobed(self) -> None:
+        # The classic path reads X-OAuth-Scopes, which is real evidence — its
+        # `workflows: write` verdict stays a measured gap, not an unprobed note.
+        run = _runner({_META_KEY: (0, _classic_headers("repo, read:project"))})
+        with patch("teatree.core.gates.gh_token_preflight.shutil.which", return_value="/usr/bin/gh"):
+            probe = probe_token_permissions(_SLUG, run=run)
+        assert probe.missing_recommended == ("workflows: write",)
+        assert probe.unprobed == ()

--- a/tests/test_deploy_entrypoint_token_preflight.py
+++ b/tests/test_deploy_entrypoint_token_preflight.py
@@ -183,13 +183,26 @@ class TestRecommendedPermissionsWarnOnly:
         for label in ("actions: write", "actions: read", "checks: read", "statuses: read"):
             assert label in out.stderr
 
-    def test_workflows_write_always_warned_unprobed_for_fine_grained(self, tmp_path: Path) -> None:
-        # Never actively probed (ambiguous 403-vs-404 ordering) — always listed
-        # so the operator verifies it manually, even when every OTHER probe passes.
+    def test_a_clean_fine_grained_token_warns_about_nothing(self, tmp_path: Path) -> None:
+        """An UNPROBEABLE permission is not evidence of a missing one.
+
+        ``workflows: write`` is never actively probed for a fine-grained token
+        (ambiguous 403-vs-404 ordering), so listing it as a gap asserted something
+        nobody measured — and drove a "recreate your token" line on every single
+        deploy that no action could ever clear. A token that already carries the
+        permission was told to recreate itself, forever.
+        """
         out = _run(tmp_path, GH_DENY="")
         assert out.returncode == 0, out.stderr
+        assert out.stderr == "", "a clean token has nothing to act on, so nothing is printed"
+
+    def test_the_unprobed_note_rides_along_on_a_real_gap(self, tmp_path: Path) -> None:
+        # A recreate is already happening, so naming it there IS actionable.
+        out = _run(tmp_path, GH_DENY="dispatches")
+        assert out.returncode == 0, out.stderr
+        assert "actions: write" in out.stderr
         assert "workflows: write" in out.stderr
-        assert "verify" in out.stderr.lower() or "manually" in out.stderr.lower() or "recreate" in out.stderr.lower()
+        assert "cannot be probed" in out.stderr
 
     def test_required_missing_still_fails_even_with_recommended_gaps(self, tmp_path: Path) -> None:
         out = _run(tmp_path, GH_DENY="issues/0 dispatches")


### PR DESCRIPTION
fix(doctor,deploy): an unprobeable permission is not a missing one

## What

`t3 doctor` and every deploy reported `workflows: write` as a missing recommended
permission on any fine-grained token, and `format_remediation` then told the
operator to recreate the token to add it.

That claim is never measured. The permission is deliberately not probed on a
fine-grained token (#3477: the spike could confirm only the permitted 404 path,
not whether a denied token 403s route-level first, so probing risks a false
"missing") — yet `_probe_fine_grained` seeded it straight into the gap list:

```python
# Never actively probed (see module docstring) - always surfaced so remediation names it.
recommended_missing.add("workflows: write")
```

## Why

The warning is unfalsifiable by construction. A token that ALREADY has the
permission is told to recreate itself on every run, forever, and no action the
operator takes can clear it — the definition of a WARN nobody can act on.

Confirmed empirically on this box: the live `TEATREE_GH_TOKEN` writes to
`.github/workflows/*` successfully, while the doctor reported the permission
missing. The reported gap was a false positive baked into the code.

## Changes

`GhTokenProbe.unprobed` carries "no reliable probe exists for X" separately from
the evidenced gap lists (`missing` / `missing_recommended`), so the two facts are
no longer conflated:

- a clean fine-grained token produces NO remediation at all — silence, run after
  run — instead of an un-actionable recreate;
- when a real gap already means a recreate, the unprobed permission rides along on
  that line, where naming it IS useful, and the line states how to prove it either
  way (a push touching `.github/workflows/*`);
- the classic-PAT path is untouched: `X-OAuth-Scopes` is real evidence, so its
  `workflows: write` verdict stays a measured gap;
- `deploy/entrypoint.sh`'s mirrored shell preflight gets the same treatment, so
  the deploy and the doctor cannot disagree.

## Verification

RED first: 4 new tests failed against the old probe, and the two pre-existing
tests that pinned the false gap were rewritten to pin the corrected contract.

Live output on this box, after the fix — one real gap, honestly attributed:

```text
missing=()  missing_recommended=('projects: read',)  unprobed=('workflows: write',)

TEATREE_GH_TOKEN is missing the following permission(s) on souliane/teatree:
  projects: read - needed for GitHub Projects v2 board sync
Fine-grained tokens cannot be widened via the API either - recreate it with these
permissions added: https://github.com/settings/personal-access-tokens
While recreating, also include workflows: write: it cannot be probed on a
fine-grained token, so its presence is unknown here - a push touching
.github/workflows/* is what proves it either way.
```

`projects: read` is a genuine gap, independently confirmed (the Projects v2
GraphQL read returns `FORBIDDEN`). Granting it clears the whole warning.

```text
tests/teatree_core/gates/  tests/teatree_cli/doctor/  tests/test_deploy_entrypoint_token_preflight.py
991 passed, 4 skipped
```
