### PR TITLE
fix(hooks): select a Django-capable interpreter for hook subprocesses (https://github.com/souliane/teatree/issues/3819)

### DIFF
--- a/hooks/scripts/run-hook.sh
+++ b/hooks/scripts/run-hook.sh
@@ -1,29 +1,110 @@
 #!/usr/bin/env bash
 
-# Select a Python >= 3.11 interpreter to run a teatree hook script.
+# Select a Python >= 3.11 interpreter to run a teatree hook script — preferring
+# one that can import Django.
 #
 # The hook modules use 3.11+ stdlib (`tomllib`, imported at module level in
 # `teatree_settings.py`) and modern typing; the project baseline is >=3.13.
 # Some hosts resolve a bare `python3` to an older runtime (e.g. macOS system
 # Python 3.9), where `hook_router.py` crashes at import — taking down EVERY
-# hooked session at bootstrap. This shim picks the newest available >= 3.11
-# interpreter and execs it with the forwarded arguments (the hook script path
-# plus its flags), so `hooks.json` never depends on what bare `python3` happens
-# to be on a given host.
+# hooked session at bootstrap. This shim picks an available >= 3.11 interpreter
+# and execs it with the forwarded arguments (the hook script path plus its
+# flags), so `hooks.json` never depends on what bare `python3` happens to be on
+# a given host.
 #
-# Fail open: if no >= 3.11 interpreter is found, exit 0 silently so a hook is a
-# no-op rather than a session-breaking crash — the same crash-proof / silent
-# contract every hook honours (hooks/CLAUDE.md). A broken interpreter shim
-# (e.g. a pyenv shim for an uninstalled version) fails its probe and is skipped.
+# The version floor alone is not enough. `django_bootstrap.bootstrap_teatree_django`
+# puts the sibling `src/` on `sys.path` and calls `django.setup()`, but Django
+# itself must come from the INTERPRETER — and teatree is installed into a uv-tool
+# venv, not into the system python a bare `python3` resolves to. On such a host
+# the bootstrap returns False and EVERY DB-backed handler silently no-ops: the
+# SessionStart hand-off drain, the away-mode `DeferredQuestion` recorder, pending
+# chat injections, the loop-owner/registration readers, and the standing-goal /
+# orchestrator-investigation / unknown-repo-push gates. Nothing errors — the work
+# just never happens, which is how hand-offs accumulated unclaimed for a week.
+#
+# This is the ORM-tier sibling of #3499: that fix taught the Django-free cold
+# reader to bootstrap `src/` so kill-switch flags stopped resolving to their
+# compiled-in defaults. A cold sqlite read can be repaired in-process; an ORM
+# import cannot, because a running interpreter without Django installed can never
+# acquire it. So the choice has to move up here, to interpreter selection.
+#
+# Pass 1 therefore requires `import django` as well as the version floor, and
+# considers the interpreter teatree is installed into first — discovered next to
+# the resolved `t3` entry point (a uv-tool / venv layout puts `python` beside it),
+# so nothing is hard-coded to one host. `T3_HOOK_PYTHON` short-circuits the whole
+# search on the version floor alone — an operator naming an interpreter outranks
+# the Django preference.
+#
+# Fail open: pass 2 repeats the search with the version floor ALONE, so a host
+# with no Django-capable interpreter keeps exactly the pre-existing behaviour —
+# the file-mirror hand-off fallback and every Django-free gate still run. If no
+# >= 3.11 interpreter is found at all, exit 0 silently so a hook is a no-op
+# rather than a session-breaking crash — the same crash-proof / silent contract
+# every hook honours (hooks/CLAUDE.md). A broken interpreter shim (e.g. a pyenv
+# shim for an uninstalled version) fails its probe and is skipped.
 
 set -u
 
-for candidate in python3.13 python3.12 python3.11 python3; do
-    bin="$(command -v "$candidate" 2>/dev/null)" || continue
-    [ -n "$bin" ] || continue
-    if "$bin" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)' >/dev/null 2>&1; then
-        exec "$bin" "$@"
+# Does $1 clear the version floor, and — when $2 is "django" — import Django?
+probe_interpreter() {
+    "$1" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)' >/dev/null 2>&1 || return 1
+    [ "${2:-}" = "django" ] || return 0
+    "$1" -c 'import django' >/dev/null 2>&1
+}
+
+# Interpreter candidates, most-preferred first, one per line. Paths may not
+# exist; the probe filters them.
+interpreter_candidates() {
+    # The venv teatree itself is installed into, found beside the `t3` entry
+    # point. `command -v` is a shell builtin and `${var%/*}` is expansion, so
+    # this needs no external binary — a hook subprocess inherits a restricted
+    # PATH, and shelling out to `dirname` there silently yields no candidate.
+    # `readlink` IS external, so it is strictly best-effort: `~/.local/bin/t3` is
+    # typically a symlink INTO the venv, so try the resolved dir first, but keep
+    # the unresolved dir as a candidate for when `readlink` is unavailable or
+    # non-GNU (BSD/macOS lack `-f`).
+    t3_bin="$(command -v t3 2>/dev/null || true)"
+    if [ -n "$t3_bin" ]; then
+        t3_resolved="$(readlink -f "$t3_bin" 2>/dev/null || true)"
+        for t3_path in "$t3_resolved" "$t3_bin"; do
+            case "$t3_path" in
+                */*) printf '%s\n' "${t3_path%/*}/python" "${t3_path%/*}/python3" ;;
+            esac
+        done
     fi
+
+    # The default uv-tool layout, so the venv is still found when `readlink` is
+    # unavailable and `t3` is a symlink from elsewhere.
+    if [ -n "${HOME:-}" ]; then
+        printf '%s\n' "$HOME/.local/share/uv/tools/teatree/bin/python"
+    fi
+
+    for name in python3.13 python3.12 python3.11 python3; do
+        command -v "$name" 2>/dev/null || true
+    done
+}
+
+# An operator naming an interpreter outranks the search: honour it on the
+# version floor alone, so `T3_HOOK_PYTHON` stays a true override (and a usable
+# escape hatch when the Django-capable pick is the one misbehaving).
+if [ -n "${T3_HOOK_PYTHON:-}" ] && [ -x "${T3_HOOK_PYTHON}" ] && probe_interpreter "$T3_HOOK_PYTHON"; then
+    exec "$T3_HOOK_PYTHON" "$@"
+fi
+
+# Split on newline only, so an interpreter path containing spaces survives.
+old_ifs="$IFS"
+IFS='
+'
+for requirement in django ""; do
+    for bin in $(interpreter_candidates); do
+        [ -n "$bin" ] || continue
+        [ -x "$bin" ] || continue
+        if probe_interpreter "$bin" "$requirement"; then
+            IFS="$old_ifs"
+            exec "$bin" "$@"
+        fi
+    done
 done
+IFS="$old_ifs"
 
 exit 0

--- a/tests/teatree_hooks/test_hook_scripts_py_version_compat.py
+++ b/tests/teatree_hooks/test_hook_scripts_py_version_compat.py
@@ -29,6 +29,15 @@ These tests pin that fix end to end:
 * :class:`TestInterpreterPinIsLoadBearing` — demonstrates WHY the pin is needed:
     the reported module genuinely fails to import under a < 3.11 interpreter (run
     when one is available; skipped on a 3.13-only CI runner).
+* :class:`TestRunHookPrefersDjangoCapableInterpreter` — the version floor is
+    necessary but NOT sufficient. ``django_bootstrap.bootstrap_teatree_django``
+    needs Django from the *interpreter*, and teatree installs into a uv-tool venv
+    rather than the system python a bare ``python3`` resolves to. When it is
+    missing every DB-backed handler silently no-ops — the SessionStart hand-off
+    drain among them, which is how hand-offs accumulated unclaimed for a week.
+    So the selector prefers an interpreter that can ``import django``, falling
+    back to the version floor alone. Driven with stub interpreters so the
+    selection logic is pinned without depending on what the host has installed.
 """
 
 import json
@@ -44,6 +53,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCRIPTS_DIR = _REPO_ROOT / "hooks" / "scripts"
 _HOOKS_JSON = _REPO_ROOT / "hooks" / "hooks.json"
 _RUN_HOOK = _SCRIPTS_DIR / "run-hook.sh"
+_BASH = shutil.which("bash") or "/bin/bash"
 
 
 def _router_commands() -> list[str]:
@@ -221,3 +231,121 @@ class TestInterpreterPinIsLoadBearing:
         assert result.returncode == 0, (
             f"banned_terms.gate should cold-import under {sys.executable}: {result.stderr.strip()}"
         )
+
+
+def _stub_interpreter(path: Path, *, label: str, has_django: bool, clears_floor: bool = True) -> None:
+    """Write a stub interpreter that answers the selector's probes, then names itself.
+
+    The selector probes with ``-c '...version_info...'`` and ``-c 'import django'``
+    before ``exec``-ing the winner with the forwarded arguments. The stub keys off
+    those probe bodies and, for any other ``-c`` payload, prints *label* — so a
+    test reads which interpreter was chosen straight from stdout.
+    """
+    path.write_text(
+        "#!/bin/sh\n"
+        'case "$2" in\n'
+        f"  *version_info*) exit {0 if clears_floor else 1} ;;\n"
+        f'  *"import django"*) exit {0 if has_django else 1} ;;\n'
+        "esac\n"
+        f'printf "%s\\n" "{label}"\n',
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def _run_selector(bin_dir: Path, **extra_env: str) -> subprocess.CompletedProcess[str]:
+    """Run the selector with *bin_dir* as the ENTIRE PATH, asking the winner to identify itself.
+
+    ``bash`` is passed explicitly rather than left to the ``#!/usr/bin/env bash``
+    shebang: PATH is deliberately narrowed to the stub dir so only the stub
+    interpreters are discoverable, which would otherwise leave ``env`` unable to
+    resolve the shell itself.
+    """
+    env = {"PATH": str(bin_dir), "HOME": str(bin_dir.parent)}
+    env.update(extra_env)
+    return subprocess.run(
+        [_BASH, str(_RUN_HOOK), "-c", "identify-me"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+        check=False,
+    )
+
+
+class TestRunHookPrefersDjangoCapableInterpreter:
+    """The selector prefers an interpreter that can import Django, and degrades safely."""
+
+    def test_prefers_the_teatree_venv_over_a_bare_python3(self, tmp_path: Path) -> None:
+        # The live shape of the bug: a bare `python3` clears the version floor but
+        # has no Django, while the venv teatree is installed into (found beside the
+        # resolved `t3` entry point) has it. Choosing `python3` is what made every
+        # DB-backed handler a silent no-op.
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _stub_interpreter(bin_dir / "python3", label="bare-python3", has_django=False)
+        _stub_interpreter(bin_dir / "python", label="teatree-venv", has_django=True)
+        (bin_dir / "t3").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        (bin_dir / "t3").chmod(0o755)
+
+        result = _run_selector(bin_dir)
+
+        assert result.stdout.strip() == "teatree-venv", (
+            f"selector must prefer the Django-capable interpreter; chose {result.stdout.strip()!r}"
+        )
+
+    def test_falls_back_to_the_version_floor_when_nothing_has_django(self, tmp_path: Path) -> None:
+        # Fail open: on a host with no Django-capable interpreter the selector must
+        # behave exactly as it did before — a hook that runs Django-free gates and
+        # the file-mirror hand-off fallback beats a hook that does not run at all.
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _stub_interpreter(bin_dir / "python3", label="bare-python3", has_django=False)
+
+        result = _run_selector(bin_dir)
+
+        assert result.stdout.strip() == "bare-python3", (
+            f"selector must still pick a Django-less interpreter when it is all there is; "
+            f"chose {result.stdout.strip()!r}, stderr={result.stderr!r}"
+        )
+
+    def test_explicit_override_outranks_the_django_preference(self, tmp_path: Path) -> None:
+        # `T3_HOOK_PYTHON` is the operator's escape hatch — including when the
+        # Django-capable pick is itself the thing misbehaving — so it wins on the
+        # version floor alone.
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _stub_interpreter(bin_dir / "python", label="teatree-venv", has_django=True)
+        (bin_dir / "t3").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        (bin_dir / "t3").chmod(0o755)
+        override = bin_dir / "chosen-by-operator"
+        _stub_interpreter(override, label="operator-override", has_django=False)
+
+        result = _run_selector(bin_dir, T3_HOOK_PYTHON=str(override))
+
+        assert result.stdout.strip() == "operator-override", (
+            f"T3_HOOK_PYTHON must outrank the search; chose {result.stdout.strip()!r}"
+        )
+
+    def test_unusable_override_falls_through_to_the_search(self, tmp_path: Path) -> None:
+        # A stale override must not wedge every hooked session.
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _stub_interpreter(bin_dir / "python3", label="bare-python3", has_django=True)
+
+        result = _run_selector(bin_dir, T3_HOOK_PYTHON=str(tmp_path / "does-not-exist"))
+
+        assert result.stdout.strip() == "bare-python3", (
+            f"an unusable T3_HOOK_PYTHON must fall through, not wedge; got {result.stdout.strip()!r}"
+        )
+
+    def test_exits_silently_when_no_candidate_clears_the_version_floor(self, tmp_path: Path) -> None:
+        # The crash-proof contract: a no-op hook, never a session-breaking crash.
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _stub_interpreter(bin_dir / "python3", label="too-old", has_django=False, clears_floor=False)
+
+        result = _run_selector(bin_dir)
+
+        assert result.returncode == 0, f"selector must exit 0 when it finds nothing usable, got {result.returncode}"
+        assert not result.stdout.strip(), f"selector must stay silent, printed {result.stdout!r}"


### PR DESCRIPTION
## What

`hooks/scripts/run-hook.sh` now prefers a hook interpreter that can `import django`, discovered beside the resolved `t3` entry point, and falls back to the existing version-floor-only search when no such interpreter exists.

Closes #3819.

## Why

The selector picked the interpreter on the version floor alone. On a uv-tool install that resolves to a bare system python with no Django, so `django_bootstrap.bootstrap_teatree_django()` raised `ModuleNotFoundError`, swallowed it, and returned `False`.

Every `bootstrap_teatree_django()` call site then took its fail-open branch — 18 of them across 8 modules. The visible symptom was the SessionStart hand-off drain: 13 `SessionHandover` rows sat unclaimed since 2026-07-21 with nothing logged. The away-mode `DeferredQuestion` recorder, pending chat injections, the loop-owner/registration readers and three gates were equally dark.

Measured on this host:

```
/usr/bin/python3                            -> bootstrap_teatree_django() == False
<uv-tool venv>/bin/python                   -> bootstrap_teatree_django() == True   (Django 6.0.7)
```

End-to-end through the real `SessionStart` hook with one unclaimed row present:

| interpreter | payload injected | row after |
|---|---|---|
| `/usr/bin/python3` | no | `claimed_at IS NULL` |
| venv python | yes | `claimed_by` set |

This is the ORM-tier sibling of #3499 / PR #3662. That fix taught the Django-free cold reader to bootstrap `src/`, so kill-switch flags stopped resolving to compiled-in defaults. A cold sqlite read can be repaired in-process; an ORM import cannot, because a running interpreter without Django can never acquire it — so the choice has to move up to interpreter selection.

It composes with #3816 rather than duplicating it. #3816 keeps `if bootstrap_teatree_django():` and logs a WARNING when the queue does not drain, which makes the failure diagnosable; on a host like this one it would log that warning and still drop the hand-off. #3816 makes it loud, this makes it work.

## Design notes

- Candidate discovery uses only shell builtins (`command -v`, `${var%/*}`). A hook subprocess inherits a restricted PATH, and shelling out to `dirname`/`readlink` there silently yields no candidate at all. `readlink` stays best-effort, for the common symlink-into-venv layout.
- `T3_HOOK_PYTHON` short-circuits the whole search on the version floor alone, so the operator escape hatch still works when the Django-capable pick is itself the problem.
- Fail-open is preserved end to end: a host with no Django-capable interpreter behaves exactly as it does today, and a host with no >= 3.11 interpreter at all still exits 0 silently.

## Testing

Five new tests in `TestRunHookPrefersDjangoCapableInterpreter`, driven with stub interpreters so selection is pinned without depending on what the host has installed: prefers the Django-capable interpreter, falls back to the version floor when nothing has Django, override outranks the preference, an unusable override falls through rather than wedging, and no usable candidate exits 0 silently.

Anti-vacuity checked: the two tests pinning new behaviour fail against the previous `run-hook.sh`; the other three pass, since they encode behaviour this change deliberately preserves.

`bash dev/ci-parity-fast.sh` is not runnable for this branch — `dev/test-affected.sh` degrades to FULL on any file outside the modelled roots, and `hooks/` is one of those, so any change here forces a whole-tree run (~30k tests). Run instead:

- `uv run prek run --files` on both changed files — 29 applicable hooks passed
- `uv run python manage.py makemigrations --check --dry-run` — no changes
- `uv run pytest tests/teatree_hooks tests/quality tests/conformance` — 3201 passed, 2 skipped, 3 xfailed
- `uv run ruff check --no-fix hooks/ <test file>` — clean

CI's sharded `test (3.13)` lane owns the whole-tree floor.