### PR TITLE
fix(dash): close the template comments Django was rendering as page text (https://github.com/souliane/teatree/issues/3823)

### DIFF
--- a/src/teatree/dash/snapshots/board.html
+++ b/src/teatree/dash/snapshots/board.html
@@ -42,9 +42,7 @@
 
     </nav>
     <div class="dash-actions">
-      {# Always-visible loopback terminal: POSTs to the same debug_session endpoint
-      the drawer uses (a fresh generic session, no ticket id); body hx-headers
-      carries the CSRF token. #}
+
       <button type="button" class="dash-btn" data-terminal
         hx-post="/dash/debug/session/" hx-target="#terminal-result" hx-swap="innerHTML"
         hx-confirm="Start a loopback debug session?"

--- a/src/teatree/dash/templates/dash/base.html
+++ b/src/teatree/dash/templates/dash/base.html
@@ -34,9 +34,9 @@
       {% endfor %}
     </nav>
     <div class="dash-actions">
-      {# Always-visible loopback terminal: POSTs to the same debug_session endpoint
-      the drawer uses (a fresh generic session, no ticket id); body hx-headers
-      carries the CSRF token. #}
+      {% comment %} Always-visible loopback terminal: POSTs to the same debug_session
+      endpoint the drawer uses (a fresh generic session, no ticket id); body hx-headers
+      carries the CSRF token. {% endcomment %}
       <button type="button" class="dash-btn" data-terminal
         hx-post="{% url 'dash:debug_session' %}" hx-target="#terminal-result" hx-swap="innerHTML"
         hx-confirm="Start a loopback debug session?"

--- a/src/teatree/dash/templates/dash/health.html
+++ b/src/teatree/dash/templates/dash/health.html
@@ -11,8 +11,8 @@
 
   <section class="band">
     <h2>Debug commands</h2>
-    {# One form per command: the vendored htmx drops the clicked submitter, so a shared
-    form posted an empty `command` and every button was refused. #}
+    {% comment %} One form per command: the vendored htmx drops the clicked submitter, so a
+    shared form posted an empty `command` and every button was refused. {% endcomment %}
     <div class="toolbar">
       {% for spec in command_buttons %}
         <form method="post" action="{% url 'dash:command_run' %}" hx-post="{% url 'dash:command_run' %}" hx-target="#command-result" hx-swap="innerHTML">

--- a/src/teatree/dash/templates/dash/partials/_loops_body.html
+++ b/src/teatree/dash/templates/dash/partials/_loops_body.html
@@ -2,8 +2,8 @@
   <section class="band">
     <h2>Availability</h2>
     <p>Current — <strong>{{ control.availability_mode }}</strong> (decided by {{ control.availability_source }})</p>
-    {# One form per mode: the vendored htmx drops the clicked submitter, so the value
-    rides in a hidden input rather than on the button. #}
+    {% comment %} One form per mode: the vendored htmx drops the clicked submitter, so the
+    value rides in a hidden input rather than on the button. {% endcomment %}
     <div class="toolbar">
       <form method="post" action="{% url 'dash:availability' %}" hx-post="{% url 'dash:availability' %}" hx-target="#loops-body" hx-swap="morph:innerHTML">
         {% csrf_token %}

--- a/tests/teatree_dash/test_template_conformance.py
+++ b/tests/teatree_dash/test_template_conformance.py
@@ -1,0 +1,43 @@
+"""Django's ``{# … #}`` comment is single-line ONLY — a multi-line one renders as page text.
+
+The lexer matches an opening and a closing tag on the SAME line, so a ``{#`` whose
+``#}`` sits on a later line is not a comment at all: every line of it is emitted
+verbatim into the page. Three of these had shipped, and the ``base.html`` one sat in
+the header block, so the explanatory prose appeared centred in the header of every
+dashboard page. ``{% comment %} … {% endcomment %}`` is the multi-line construct.
+
+Whole-tree rather than three pinned assertions: the fourth one someone writes next
+month must turn this RED too.
+"""
+
+from pathlib import Path
+
+from django.test import TestCase
+
+from teatree.dash.dashboard_snapshot import render_board_snapshot
+
+_TEMPLATES = Path(__file__).resolve().parents[2] / "src/teatree/dash/templates"
+
+
+def _unterminated_comment_openings() -> list[str]:
+    return [
+        f"{path.relative_to(_TEMPLATES)}:{number}: {line.strip()}"
+        for path in sorted(_TEMPLATES.rglob("*.html"))
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
+        for index in range(len(line))
+        if line.startswith("{#", index) and "#}" not in line[index:]
+    ]
+
+
+def test_no_dash_template_opens_a_comment_it_does_not_close_on_the_same_line() -> None:
+    offenders = _unterminated_comment_openings()
+    assert not offenders, (
+        "these `{#` openings have no `#}` on the same line, so Django renders them as "
+        "visible page text — use `{% comment %} … {% endcomment %}`:\n" + "\n".join(offenders)
+    )
+
+
+class RenderedBoardCarriesNoCommentMarkupTestCase(TestCase):
+    def test_board_render_contains_no_comment_delimiters(self) -> None:
+        html = render_board_snapshot()
+        assert "{#" not in html, "a template comment leaked into the rendered page"


### PR DESCRIPTION
## What

Converts three multi-line `{# ... #}` template comments to `{% comment %} … {% endcomment %}`, and adds a whole-tree regression assertion over the dash templates.

Addresses item 1 of #3823.

## Why

Django's `{#…#}` comment syntax is single-line only — the lexer matches an opening and closing tag on the same line. A multi-line one is not a comment at all: it is emitted as literal page text.

Three of them were live:

```
src/teatree/dash/templates/dash/base.html:37
src/teatree/dash/templates/dash/health.html:14
src/teatree/dash/templates/dash/partials/_loops_body.html:5
```

`base.html:37` sits in the header `dash-actions` block, so this rendered in the header of **every** dashboard page:

```
{# Always-visible loopback terminal: POSTs to the same debug_session endpoint the drawer
uses (a fresh generic session, no ticket id); body hx-headers carries the CSRF token. #}
```

Confirmed in a real browser against the running deploy, and by `grep -c` returning 1 on `/dash/board/`, `/dash/settings/` and `/dash/loops/`.

The comment wording is preserved in all three — it carries real reasoning about the vendored htmx dropping the clicked submitter, and about where the CSRF token rides.

## The snapshot was encoding the bug

`src/teatree/dash/snapshots/board.html` is compared byte-for-byte against `dashboard_snapshot.render_board_snapshot()`, so it contained the leaked text as *expected* output. It was regenerated through that renderer rather than hand-edited; the whole diff is the three removed lines, which is itself evidence the regeneration is faithful.

## Testing

`tests/teatree_dash/test_template_conformance.py`, placed alongside the existing dash conformance tests (`test_kanban_conformance.py`, `test_static_assets.py`) — `tests/conformance/` holds registry and capability walks, not template checks.

Two assertions:

1. a whole-tree walk over `src/teatree/dash/templates/**/*.html` flagging any `{#` with no `#}` on the same line — so a fourth occurrence cannot slip in later;
2. a render-level check that `{#` is absent from the rendered board HTML.

Observed RED before the fix:

```
AssertionError: these `{#` openings have no `#}` on the same line, so Django renders them
as visible page text — use `{% comment %} … {% endcomment %}`:
  dash/base.html:37: {# Always-visible loopback terminal: POSTs to the same debug_session endpoint
  dash/health.html:14: {# One form per command: the vendored htmx drops the clicked submitter, so a shared
  dash/partials/_loops_body.html:5: {# One form per mode: the vendored htmx drops the clicked submitter, so the value
2 failed in 5.96s
```

GREEN after, scoped run of the whole dash suite: `341 passed in 24.68s`.

Nothing was redeployed or restarted, so the render assertion rather than a live curl is the durable proof.