### PR TITLE
fix(core): a usage-window park must not re-arm the dispatch it just refused

### DIFF
--- a/src/teatree/core/models/task.py
+++ b/src/teatree/core/models/task.py
@@ -15,6 +15,7 @@ from teatree.core.models.external_delivery import not_under_external_delivery_q
 from teatree.core.models.session import Session
 from teatree.core.models.task_claim import claim as _claim_task
 from teatree.core.models.task_claim import renew_lease as _renew_task_lease
+from teatree.core.models.task_claim import window_parked as _window_parked
 from teatree.core.models.task_phase_disposition import (
     dispose_unshippable_review,
     escalate_unmatched_phase_transition,
@@ -195,6 +196,9 @@ class Task(models.Model):
 
     def renew_lease(self, *, lease_seconds: int = 300) -> None:
         _renew_task_lease(self, lease_seconds=lease_seconds)
+
+    def is_window_parked(self, now: datetime | None = None) -> bool:
+        return _window_parked(self, now)
 
     def route_to_headless(self, *, reason: str = "") -> None:
         self._route(self.ExecutionTarget.HEADLESS, reason)

--- a/src/teatree/core/models/task_claim.py
+++ b/src/teatree/core/models/task_claim.py
@@ -11,7 +11,7 @@ class through the instance, so this module needs no runtime import of ``Task`` a
 stays cycle-free (task.py imports it at module level).
 """
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from django.db.models import Q
@@ -21,6 +21,17 @@ from teatree.core.models.errors import InvalidTransitionError, LeaseLostError
 
 if TYPE_CHECKING:
     from teatree.core.models.task import Task
+
+
+def window_parked(task: "Task", now: datetime | None = None) -> bool:
+    """Whether *task* sits behind an unelapsed usage-window park gate (Directive #3).
+
+    The single-row twin of :func:`~teatree.core.managers_task_claim._claimable_now_q`, for
+    the seams that hold ONE instance rather than a queryset (the ``post_save`` headless
+    auto-enqueue, the lost-claim diagnosis below). Kept as one expression both spellings
+    share so "is there work" and "may this be re-dispatched" can never disagree.
+    """
+    return task.not_before is not None and task.not_before > (now or timezone.now())
 
 
 def claim(task: "Task", *, claimed_by: str, claimed_by_session: str = "", lease_seconds: int = 300) -> None:
@@ -88,7 +99,7 @@ def claim(task: "Task", *, claimed_by: str, claimed_by_session: str = "", lease_
         if task.status in status.terminal():
             msg = "Task already finished"
             raise InvalidTransitionError(msg)
-        if task.status == status.PENDING and task.not_before is not None and task.not_before > now:
+        if task.status == status.PENDING and window_parked(task, now):
             msg = f"Task parked until {task.not_before.isoformat()}"
             raise InvalidTransitionError(msg)
         msg = "Task already claimed"

--- a/src/teatree/core/signals.py
+++ b/src/teatree/core/signals.py
@@ -252,10 +252,20 @@ def _auto_enqueue_headless_task(
     (souliane/teatree#1959): dispatching it would crash ``execute_headless_task``
     — the drain safety-net fails such rows permanently instead. A blank overlay
     is the ambient single-overlay default and stays dispatchable.
+
+    A usage-window-parked task (PENDING with a future ``not_before``, Directive #3) is
+    never enqueued either. ``Task.park`` leaves the task PENDING, so this receiver fired
+    on the park's own save and re-armed the dispatch the park had just refused — the
+    self-feeding edge behind the measured 47,172 park rows on a single task in eight
+    hours. The drain and the claim CAS honour the same gate; the lane now stays quiesced
+    until ``usage_window_recovery`` releases the task at the window's re-arm instant.
     """
     if instance.execution_target != Task.ExecutionTarget.HEADLESS:
         return
     if instance.status != Task.Status.PENDING:
+        return
+    if instance.is_window_parked():
+        logger.debug("Task %s is window-parked until %s — not re-enqueuing", instance.pk, instance.not_before)
         return
     if _runs_in_session(instance):
         return

--- a/tests/teatree_core/test_park_no_reenqueue.py
+++ b/tests/teatree_core/test_park_no_reenqueue.py
@@ -1,0 +1,122 @@
+"""A usage-window park quiesces the lane — it never re-arms the dispatch it just refused.
+
+``Task.park`` returns the task to the queue PENDING with a future ``not_before``, and that
+save fires the ``post_save`` auto-enqueue. Before the fix the signal read only
+``status == PENDING`` and immediately enqueued a fresh ``execute_headless_task`` for a task
+its own claim CAS refuses — a self-feeding edge that, before the claim gained the same
+``not_before`` predicate, spun at the worker round-trip (a measured 47,172 park rows on one
+task in eight hours). The drain (``_claimable_now_q``) and the claim CAS both honour the
+park gate; this pins the third seam.
+"""
+
+import datetime as dt
+from unittest import mock
+
+from django.test import TestCase
+from django.utils import timezone
+
+from teatree.agents.usage_window import maybe_park_for_active_window
+from teatree.core.managers_task_claim import _claimable_now_q
+from teatree.core.models import LIMIT_PARKED_PREFIX, Session, Task, TaskAttempt, Ticket, UsageWindowState
+from teatree.core.models.config_setting import ConfigSetting
+
+#: A phase with no registered agent, so the headless auto-enqueue seam stays live under the
+#: default interactive runtime (a loop-dispatched phase would short-circuit the signal).
+_FREE_FORM_PHASE = "architectural_review"
+_LANE = TaskAttempt.Lane.SUBSCRIPTION
+
+
+class TestParkDoesNotReEnqueue(TestCase):
+    def setUp(self) -> None:
+        ConfigSetting.objects.set_value("limit_autorecovery_enabled", value=True)
+        self.admit = mock.patch(
+            "teatree.core.headless_admission.headless_admission_denied_reason",
+            return_value=None,
+        )
+        self.admit.start()
+        self.addCleanup(self.admit.stop)
+        self.ticket = Ticket.objects.create(issue_url="https://example.com/i/1", role=Ticket.Role.AUTHOR)
+        self.session = Session.objects.create(ticket=self.ticket)
+        self.resets_at = timezone.now() + dt.timedelta(hours=5)
+
+    def _dispatching_task(self) -> Task:
+        """A headless task mid-dispatch — CLAIMED, exactly as the admission guard finds it."""
+        task = Task.objects.create(
+            ticket=self.ticket,
+            session=self.session,
+            phase=_FREE_FORM_PHASE,
+            execution_target=Task.ExecutionTarget.HEADLESS,
+        )
+        Task.objects.filter(pk=task.pk).update(status=Task.Status.CLAIMED)
+        task.refresh_from_db()
+        return task
+
+    def _exhausted_lane(self) -> UsageWindowState:
+        return UsageWindowState.record_limit(
+            lane=_LANE,
+            cause="all_accounts_exhausted",
+            resets_at=self.resets_at,
+        )
+
+    def test_park_does_not_re_arm_the_headless_dispatch(self) -> None:
+        window = self._exhausted_lane()
+        task = self._dispatching_task()
+        with mock.patch("teatree.core.tasks.execute_headless_task") as job:
+            attempt = maybe_park_for_active_window(task, lane=_LANE)
+        assert job.enqueue.call_count == 0
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING
+        assert task.not_before == window.resets_at
+        # The park stays visible: one attempt row naming the lane and the reason.
+        assert attempt is not None
+        assert attempt.error.startswith(LIMIT_PARKED_PREFIX)
+        assert TaskAttempt.objects.filter(task=task).count() == 1
+
+    def test_repeated_park_stays_one_visible_row(self) -> None:
+        self._exhausted_lane()
+        task = self._dispatching_task()
+        with mock.patch("teatree.core.tasks.execute_headless_task"):
+            maybe_park_for_active_window(task, lane=_LANE)
+            maybe_park_for_active_window(task, lane=_LANE)
+        rows = TaskAttempt.objects.filter(task=task)
+        assert rows.count() == 1
+        assert rows.get().park_repeats == 1
+
+    def test_unparked_headless_task_is_still_enqueued(self) -> None:
+        # Control: the guard is scoped to the park gate, not a blanket disable of the lane.
+        with mock.patch("teatree.core.tasks.execute_headless_task") as job:
+            task = Task.objects.create(
+                ticket=self.ticket,
+                session=self.session,
+                phase=_FREE_FORM_PHASE,
+                execution_target=Task.ExecutionTarget.HEADLESS,
+            )
+        job.enqueue.assert_called_once_with(task.pk, task.phase)
+
+    def test_elapsed_park_gate_re_enqueues(self) -> None:
+        # Control: once the window re-arms, an ordinary PENDING save enqueues again, so the
+        # suppression is keyed on the FUTURE instant rather than on the field being set.
+        task = self._dispatching_task()
+        task.park(not_before=timezone.now() - dt.timedelta(minutes=1))
+        with mock.patch("teatree.core.tasks.execute_headless_task") as job:
+            task.save(update_fields=["status", "not_before"])
+        job.enqueue.assert_called_once_with(task.pk, task.phase)
+
+
+class TestWindowParkedPredicateParity(TestCase):
+    """The per-row park predicate and the queryset one answer identically (no drift)."""
+
+    def setUp(self) -> None:
+        self.ticket = Ticket.objects.create(issue_url="https://example.com/i/2", role=Ticket.Role.AUTHOR)
+        self.session = Session.objects.create(ticket=self.ticket)
+
+    def test_instance_predicate_matches_the_claim_filter(self) -> None:
+        now = timezone.now()
+        gates = [None, now - dt.timedelta(minutes=1), now + dt.timedelta(minutes=1)]
+        tasks = [
+            Task.objects.create(ticket=self.ticket, session=self.session, phase=_FREE_FORM_PHASE, not_before=gate)
+            for gate in gates
+        ]
+        claimable = set(Task.objects.filter(_claimable_now_q(now)).values_list("pk", flat=True))
+        for task in tasks:
+            assert task.is_window_parked(now) is (task.pk not in claimable)

--- a/tests/teatree_core/test_park_no_reenqueue.py
+++ b/tests/teatree_core/test_park_no_reenqueue.py
@@ -19,6 +19,7 @@ from teatree.agents.usage_window import maybe_park_for_active_window
 from teatree.core.managers_task_claim import _claimable_now_q
 from teatree.core.models import LIMIT_PARKED_PREFIX, Session, Task, TaskAttempt, Ticket, UsageWindowState
 from teatree.core.models.config_setting import ConfigSetting
+from teatree.core.models.task_claim import window_parked
 
 #: A phase with no registered agent, so the headless auto-enqueue seam stays live under the
 #: default interactive runtime (a loop-dispatched phase would short-circuit the signal).
@@ -104,13 +105,18 @@ class TestParkDoesNotReEnqueue(TestCase):
 
 
 class TestWindowParkedPredicateParity(TestCase):
-    """The per-row park predicate and the queryset one answer identically (no drift)."""
+    """All THREE spellings of the park gate answer identically (no drift).
+
+    ``window_parked`` is the shared predicate; ``Task.is_window_parked`` delegates to it and
+    ``_claimable_now_q`` is its queryset form. A row every spelling does not agree on is a
+    seam where "is there work" and "may this be re-dispatched" could diverge.
+    """
 
     def setUp(self) -> None:
         self.ticket = Ticket.objects.create(issue_url="https://example.com/i/2", role=Ticket.Role.AUTHOR)
         self.session = Session.objects.create(ticket=self.ticket)
 
-    def test_instance_predicate_matches_the_claim_filter(self) -> None:
+    def test_every_spelling_of_the_park_gate_agrees(self) -> None:
         now = timezone.now()
         gates = [None, now - dt.timedelta(minutes=1), now + dt.timedelta(minutes=1)]
         tasks = [
@@ -119,4 +125,6 @@ class TestWindowParkedPredicateParity(TestCase):
         ]
         claimable = set(Task.objects.filter(_claimable_now_q(now)).values_list("pk", flat=True))
         for task in tasks:
-            assert task.is_window_parked(now) is (task.pk not in claimable)
+            parked = task.pk not in claimable
+            assert window_parked(task, now) is parked
+            assert task.is_window_parked(now) is parked


### PR DESCRIPTION
fix(core): a usage-window park must not re-arm the dispatch it just refused

## What
`Task.park` returns the task to the queue PENDING with a future `not_before`,
and that save fires the `post_save` headless auto-enqueue. The receiver read
only `status == PENDING`, so every park immediately enqueued a fresh
`execute_headless_task` for a task its own claim CAS refuses — a self-feeding
edge between the park and the dispatcher.

Measured on the control DB: 133,216 headless attempts on 2026-07-20, of which
133,191 were `limit_parked:` rows; one task logged 47,172 of them in eight
hours, at 0.37s intervals — the worker round-trip, not any poll cadence. The
window backing them was correctly keyed hours ahead, so the reset time was
known and honoured by the park; the re-attempt came from this signal.

#3680 later ANDed `_claimable_now_q` into the claim CAS and the drain, which
absorbs the spin at the claim rather than removing it, and the governor cannot
be relied on to brake it — `read_quota_signal` drops stale rows, so a deep
outage yields `fresh=False` and `all_accounts_exhausted=False`, and admission
fails open exactly when the lane is dead. This closes the third seam at its
source: the park gate is now honoured by the enqueue too, so the lane stays
quiesced until `usage_window_recovery` releases the task at the reset instant.

Observability is unchanged: the park still records its `UsageWindowState`, one
coalesced `limit_parked:` `TaskAttempt` naming the lane and cause, and a
WARNING log line. Only the redundant re-enqueue is suppressed.

The single-row park predicate lands next to `_claimable_now_q`'s queryset
spelling as `task_claim.window_parked`, replacing the inline copy in the
lost-claim diagnosis, with a parity test pinning the two spellings together.

## Why
TODO — opened automatically by the no-orphan pre-push hook, which sees only the commit. Replace this line with the rationale before requesting review.