### PR TITLE
test(conformance): ratchet the two recurring regression classes shut (https://github.com/souliane/teatree/issues/3828)

### DIFF
--- a/tests/conformance/test_cross_tier_artifact_parity.py
+++ b/tests/conformance/test_cross_tier_artifact_parity.py
@@ -1,0 +1,376 @@
+"""Cross-tier artifact parity ratchet — a Django-free reader and its Django writer must be pinned together.
+
+The single most-repeated regression class in this repo: a concept is resolved by
+BOTH a Django path and a Django-free "cold" path, the two read different sources,
+they disagree silently, and every test that exists sits on one side of the divide.
+
+Three shipped instances, all the same shape:
+
+* **#3499** — ``teatree_settings.py`` cold reads resolved to compiled-in defaults
+    for months; 14 kill-switches silently ignored their stored values, because the
+    value alone cannot distinguish "never opted in" from "cannot read the store".
+* **#3819** — ``run-hook.sh`` picked an interpreter with no Django, so
+    ``bootstrap_teatree_django()`` returned False and 18 DB-backed call sites
+    silently no-opped.
+* **#3826** — ``availability_override.json`` held a week-old ``autonomous_away``
+    while the ``ModeOverride`` table was empty. The hooks obey the FILE; the guard
+    built for exactly this failure (``_check_availability_override_staleness``)
+    reads the TABLE, so it could never observe it.
+
+The repo already invented the countermeasure — ``tests/test_speak_hook_config_parity.py``
+pins the hook-side ``speak`` duplicate against the config-side source of truth,
+and ``tests/config/test_cold_hook_settings.py`` does it for the cold kill-switch
+registry. What was missing is TOTALITY: nothing forced a NEW cross-tier artifact
+to acquire such a pin, so coverage accreted one concept at a time and the gaps
+were invisible.
+
+This lane is that totality ratchet. Discovery is mechanical and tree-wide, never
+a hand-list: an artifact-shaped filename literal that appears BOTH under
+``src/teatree`` (the Django tier) AND under a Django-free consumer root
+(``hooks/``, ``scripts/lib/``, including ``*.sh``) IS a cross-tier artifact, by
+construction. Each one must then be enrolled either as covered — naming a test
+that provably exercises BOTH tiers — or as an explicitly-pegged gap carrying its
+tracking issue.
+
+Crucially the coverage criterion is NOT "some test mentions the filename". Every
+one of the six live mirrors has such a test, including ``availability_override.json``,
+whose divergence shipped anyway. Substring presence is the same measurement-by-proxy
+that let "237/237 keys in the DOM" pass while no row was usable. A covering test
+must IMPORT a ``teatree.*`` module and a ``hooks.*``/``scripts.*`` module in the
+same file — it must be able to observe both sides of the seam it claims to pin.
+
+The peg ledger is a ratchet in both directions: a new unpinned artifact fails
+(:class:`TestCrossTierRosterIsComplete`), and a pegged artifact that has silently
+GAINED a both-tier test must be promoted out of the ledger
+(:class:`TestCrossTierPegLedgerRatchets`) — freed budget can never be respent on
+the next gap.
+"""
+
+import ast
+import re
+from functools import cache
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: The Django tier — the whole package, never a hardcoded subset.
+_DJANGO_ROOT = _REPO_ROOT / "src" / "teatree"
+#: The Django-free tiers: the hook leaves and the stdlib-only script helpers.
+#: These run before (or entirely without) a Django bootstrap, which is precisely
+#: why they carry their own readers and can drift.
+_COLD_ROOTS = (_REPO_ROOT / "hooks", _REPO_ROOT / "scripts" / "lib")
+
+_TESTS_ROOT = _REPO_ROOT / "tests"
+
+#: A string literal shaped like an on-disk artifact. Deliberately narrow — a bare
+#: word or a path fragment is not an artifact; a concrete ``<name>.<ext>`` is.
+_ARTIFACT_SHAPE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*\.(json|txt|md|sqlite3|toml|yaml|yml|log|html)$")
+
+#: Artifacts that are NOT a Django-state mirror, with the reason each is exempt.
+#: Reviewable by construction: an entry here is a claim that no state flows from
+#: the ORM into the file, so the two tiers have nothing to disagree ABOUT.
+NOT_A_CROSS_TIER_MIRROR: dict[str, str] = {
+    "CLAUDE.md": "repo/agent instruction prose — authored, never derived from ORM state",
+    "SKILL.md": "skill frontmatter authored in-repo; schema-validated by the validate-skill-md prek hook",
+    "pyproject.toml": "build metadata — authored, never written from the ORM",
+    "settings.json": "the Claude Code harness's own config file, not a teatree-written mirror",
+    "db.sqlite3": (
+        "the canonical store ITSELF, not a mirror of it. Its cross-tier reads are the "
+        "COLD_HOOK_SETTINGS registry, already pinned key-by-key by "
+        "tests/config/test_cold_hook_settings.py plus the t3 doctor cold-hook probe"
+    ),
+}
+
+#: Cross-tier artifact -> a test that provably exercises BOTH tiers.
+#: An entry here is a claim of real coverage, and
+#: ``test_every_covered_artifact_has_a_both_tier_test`` verifies the claim.
+PARITY_LANE_ROSTER: dict[str, str] = {
+    "loop-registry.json": "tests/test_session_start_bootstrap_hook.py",
+    "tick-meta.json": "tests/test_hook_router_cadence_hook.py",
+}
+
+#: Cross-tier artifacts with NO both-tier pin yet — the ratchet ledger.
+#: Every row carries its tracking issue. Rows may only be REMOVED (by adding a
+#: real both-tier test and promoting the artifact into PARITY_LANE_ROSTER); a new
+#: row is a new instance of the #3826 class and must be justified in review.
+UNPINNED_CROSS_TIER_MIRRORS: dict[str, str] = {
+    # The #3826 divergence itself: written by mode_resolution, obeyed by the
+    # availability hook probe, and reconciled by nothing.
+    "availability_override.json": "https://github.com/souliane/teatree/issues/3826",
+    "consolidation-registry.json": "https://github.com/souliane/teatree/issues/3828",
+    "skill-metadata.json": "https://github.com/souliane/teatree/issues/3829",
+    "statusline.txt": "https://github.com/souliane/teatree/issues/3830",
+}
+
+_ISSUE_URL_SHAPE = re.compile(r"^https://github\.com/[\w.-]+/[\w.-]+/issues/\d+$")
+
+#: Anti-vacuity floors — a discovery that silently stopped finding things must not pass green.
+_MIN_DJANGO_LITERALS = 40
+_MIN_COLD_LITERALS = 10
+_MIN_CROSS_TIER = 8
+#: Artifacts known to live in DISTINCT cold roots / file types, so a re-narrowed
+#: scan (dropping ``*.sh``, or dropping ``scripts/lib``) is caught.
+_CROSS_ROOT_ANCHORS: frozenset[str] = frozenset(
+    {
+        "availability_override.json",  # hooks/scripts/*.py
+        "statusline.txt",  # hooks/scripts/*.sh only
+        "skill-metadata.json",  # scripts/lib/*.py only
+    }
+)
+
+
+@cache
+def _literals_in_python(root: Path) -> dict[str, set[str]]:
+    """Artifact-shaped string constants under *root*, keyed by literal -> owning modules.
+
+    Migrations are FROZEN ORM state, never a live reader or writer, so they are
+    excluded for the same reason ``test_user_settings_readers`` excludes them.
+
+    Cached: the tree does not change within a run, and every assertion below needs
+    the same walk. Uncached, this lane cost ~12s of the push gate's conformance
+    budget for six repeats of identical work.
+    """
+    found: dict[str, set[str]] = {}
+    for path in root.rglob("*.py"):
+        if "migrations" in path.parts:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"), filename=str(path))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str) and _ARTIFACT_SHAPE.match(node.value):
+                found.setdefault(node.value, set()).add(path.relative_to(_REPO_ROOT).as_posix())
+    return found
+
+
+@cache
+def _literals_in_shell(root: Path) -> dict[str, set[str]]:
+    """Artifact-shaped tokens in ``*.sh`` under *root*.
+
+    A shell hook reading the store with a raw ``sqlite3`` call is a real cold
+    reader that a Python-only walk cannot see — the same blind spot
+    ``test_user_settings_readers`` closes with its own ``_shell_readers`` pass.
+    """
+    token = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\.(?:json|txt|md|sqlite3|toml|yaml|yml|log|html)")
+    found: dict[str, set[str]] = {}
+    for path in root.rglob("*.sh"):
+        for match in token.findall(path.read_text(encoding="utf-8", errors="ignore")):
+            found.setdefault(match, set()).add(path.relative_to(_REPO_ROOT).as_posix())
+    return found
+
+
+def django_tier_literals() -> dict[str, set[str]]:
+    return _literals_in_python(_DJANGO_ROOT)
+
+
+def cold_tier_literals() -> dict[str, set[str]]:
+    merged: dict[str, set[str]] = {}
+    for root in _COLD_ROOTS:
+        if not root.is_dir():
+            continue
+        for source in (_literals_in_python(root), _literals_in_shell(root)):
+            for name, owners in source.items():
+                merged.setdefault(name, set()).update(owners)
+    return merged
+
+
+def cross_tier_artifacts() -> set[str]:
+    """Artifacts named by BOTH tiers — the unit of coverage, discovered not declared."""
+    return set(django_tier_literals()) & set(cold_tier_literals())
+
+
+@cache
+def _imported_modules(path: Path) -> set[str]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"), filename=str(path))
+    except SyntaxError:
+        return set()
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def _reaches_both_tiers(path: Path) -> bool:
+    """*path* imports a Django-tier module AND a Django-free-tier module.
+
+    The discriminator that makes this lane more than a substring check: a test
+    that cannot even import both sides cannot have compared them.
+    """
+    modules = _imported_modules(path)
+    return any(m.startswith("teatree.") for m in modules) and any(m.startswith(("hooks.", "scripts.")) for m in modules)
+
+
+@cache
+def _both_tier_test_files() -> tuple[Path, ...]:
+    """Every test file that imports both tiers — the only candidates for a real pin.
+
+    Computed once: the both-tier set is small, so the per-artifact search below is a
+    substring check over a handful of files rather than a walk of the whole suite.
+    """
+    return tuple(path for path in sorted(_TESTS_ROOT.rglob("test_*.py")) if _reaches_both_tiers(path))
+
+
+def both_tier_tests_for(artifact: str) -> list[str]:
+    """Test files that name *artifact* AND import both tiers."""
+    return [
+        path.relative_to(_REPO_ROOT).as_posix()
+        for path in _both_tier_test_files()
+        if artifact in path.read_text(encoding="utf-8", errors="ignore")
+    ]
+
+
+class TestCrossTierRosterIsComplete:
+    """Every discovered cross-tier artifact is accounted for — no silent-coverage gap."""
+
+    def test_every_cross_tier_artifact_is_enrolled(self) -> None:
+        enrolled = set(PARITY_LANE_ROSTER) | set(UNPINNED_CROSS_TIER_MIRRORS) | set(NOT_A_CROSS_TIER_MIRROR)
+        unenrolled = sorted(cross_tier_artifacts() - enrolled)
+        assert not unenrolled, (
+            "artifact(s) read by BOTH the Django tier and a Django-free tier with no parity enrolment — "
+            "this is the #3499 / #3819 / #3826 class. Add a test that imports both tiers and enrol it in "
+            "PARITY_LANE_ROSTER; or, if the two tiers genuinely cannot disagree, add a rationale row to "
+            "NOT_A_CROSS_TIER_MIRROR: " + str(unenrolled)
+        )
+
+    def test_no_roster_entry_is_a_phantom_artifact(self) -> None:
+        live = cross_tier_artifacts()
+        phantom = sorted(name for name in PARITY_LANE_ROSTER if name not in live)
+        assert not phantom, f"PARITY_LANE_ROSTER rows naming no live cross-tier artifact (renamed/removed): {phantom}"
+
+    def test_no_peg_ledger_entry_is_a_phantom_artifact(self) -> None:
+        live = cross_tier_artifacts()
+        phantom = sorted(name for name in UNPINNED_CROSS_TIER_MIRRORS if name not in live)
+        assert not phantom, (
+            "UNPINNED_CROSS_TIER_MIRRORS rows naming no live cross-tier artifact — the artifact was "
+            f"renamed or removed, so drop the row: {phantom}"
+        )
+
+    def test_every_covered_artifact_has_a_both_tier_test(self) -> None:
+        for artifact, test_rel in PARITY_LANE_ROSTER.items():
+            path = _REPO_ROOT / test_rel
+            assert path.is_file(), f"{artifact}: covering lane file {test_rel} is missing"
+            text = path.read_text(encoding="utf-8")
+            assert artifact in text, f"{artifact}: covering lane {test_rel} no longer references it"
+            assert _reaches_both_tiers(path), (
+                f"{artifact}: covering lane {test_rel} imports only ONE tier, so it cannot have compared "
+                "them — a claim of coverage that mentions the filename without observing the seam"
+            )
+
+
+class TestCrossTierPegLedgerRatchets:
+    """The ledger may only shrink — freed budget can never be respent silently."""
+
+    def test_every_pegged_artifact_names_a_tracking_issue(self) -> None:
+        malformed = sorted(
+            f"{artifact} -> {issue!r}"
+            for artifact, issue in UNPINNED_CROSS_TIER_MIRRORS.items()
+            if not _ISSUE_URL_SHAPE.match(issue)
+        )
+        assert not malformed, f"peg rows must carry a tracking issue URL: {malformed}"
+
+    def test_no_pegged_artifact_has_silently_gained_coverage(self) -> None:
+        # Under-peg, the mandatory half of a ratchet: once a real both-tier test
+        # lands, the row MUST move to PARITY_LANE_ROSTER. Leaving it pegged would
+        # let the next gap hide behind a stale allowance.
+        promotable = {
+            artifact: covering
+            for artifact in UNPINNED_CROSS_TIER_MIRRORS
+            if (covering := both_tier_tests_for(artifact))
+        }
+        assert not promotable, (
+            "pegged artifact(s) now HAVE a both-tier test — promote each into PARITY_LANE_ROSTER and "
+            f"delete its UNPINNED_CROSS_TIER_MIRRORS row: {promotable}"
+        )
+
+    def test_the_two_ledgers_are_disjoint(self) -> None:
+        both = sorted(set(PARITY_LANE_ROSTER) & set(UNPINNED_CROSS_TIER_MIRRORS))
+        assert not both, f"artifact(s) claimed as both covered and unpinned: {both}"
+
+    def test_no_exempt_artifact_is_also_enrolled(self) -> None:
+        clashing = sorted(set(NOT_A_CROSS_TIER_MIRROR) & (set(PARITY_LANE_ROSTER) | set(UNPINNED_CROSS_TIER_MIRRORS)))
+        assert not clashing, f"artifact(s) declared exempt AND enrolled: {clashing}"
+
+
+class TestCrossTierScanIsTreeWide:
+    """Self-completeness — the scan cannot silently re-narrow to a subset."""
+
+    def test_django_scan_root_is_the_whole_package(self) -> None:
+        assert _DJANGO_ROOT.name == "teatree"
+        assert (_DJANGO_ROOT / "__init__.py").is_file()
+
+    def test_cold_roots_all_exist(self) -> None:
+        missing = [str(root) for root in _COLD_ROOTS if not root.is_dir()]
+        assert not missing, f"cold-tier scan root(s) missing — scope narrowed?: {missing}"
+
+    def test_scan_reaches_every_cold_root_and_file_type(self) -> None:
+        # The anchors are reachable ONLY via distinct roots/extensions: dropping the
+        # shell pass loses statusline.txt, dropping scripts/lib loses skill-metadata.json.
+        missing = sorted(_CROSS_ROOT_ANCHORS - cross_tier_artifacts())
+        assert not missing, f"scan missed cross-root anchor(s) — a tier or file type was dropped: {missing}"
+
+
+class TestCrossTierCardinalityFloors:
+    """Anti-vacuity — a discovery that finds nothing must not pass green."""
+
+    def test_discovery_floors(self) -> None:
+        django = django_tier_literals()
+        cold = cold_tier_literals()
+        assert len(django) >= _MIN_DJANGO_LITERALS, sorted(django)
+        assert len(cold) >= _MIN_COLD_LITERALS, sorted(cold)
+        assert len(cross_tier_artifacts()) >= _MIN_CROSS_TIER, sorted(cross_tier_artifacts())
+
+    def test_enrolment_ledgers_are_non_empty(self) -> None:
+        assert PARITY_LANE_ROSTER
+        assert NOT_A_CROSS_TIER_MIRROR
+
+
+class TestCrossTierFiresRed:
+    """Anti-vacuity — the ratchet must actually catch the shapes it exists to catch."""
+
+    def test_a_synthetic_unenrolled_artifact_is_reported(self) -> None:
+        synthetic = "synthetic-mirror.json"
+        assert _ARTIFACT_SHAPE.match(synthetic)
+        enrolled = set(PARITY_LANE_ROSTER) | set(UNPINNED_CROSS_TIER_MIRRORS) | set(NOT_A_CROSS_TIER_MIRROR)
+        assert synthetic not in enrolled
+
+    def test_the_historical_3826_artifact_is_discovered(self) -> None:
+        # The concrete instance that motivated the lane: the availability mirror IS
+        # discovered as cross-tier by the mechanical walk, so the lane is anchored on
+        # the real failure and not only on a synthetic one. Deliberately asserts
+        # DISCOVERY + enrolment, never "still uncovered" — pinning the gap open would
+        # make the eventual fix red a second, unrelated test.
+        assert "availability_override.json" in cross_tier_artifacts()
+        assert "availability_override.json" in set(PARITY_LANE_ROSTER) | set(UNPINNED_CROSS_TIER_MIRRORS)
+
+    def test_mentioning_the_filename_is_not_coverage(self, tmp_path: Path) -> None:
+        # The measurement-by-proxy guard: a test that names the artifact but imports
+        # one tier must NOT read as covering. Four such files exist for the #3826
+        # mirror, which is exactly why it shipped divergent.
+        one_tier = tmp_path / "test_one_tier.py"
+        one_tier.write_text(
+            "from teatree.core import availability\n\ndef test_x():\n    assert 'availability_override.json'\n",
+            encoding="utf-8",
+        )
+        assert not _reaches_both_tiers(one_tier)
+
+        two_tier = tmp_path / "test_two_tier.py"
+        two_tier.write_text(
+            "from teatree.core import availability\n"
+            "from hooks.scripts import availability_away_probe\n\n"
+            "def test_x():\n    assert availability and availability_away_probe\n",
+            encoding="utf-8",
+        )
+        assert _reaches_both_tiers(two_tier)
+
+    def test_the_artifact_shape_is_selective(self) -> None:
+        # The heuristic must not sweep in unrelated literals (a false ratchet trip).
+        assert not _ARTIFACT_SHAPE.match("some plain sentence")
+        assert not _ARTIFACT_SHAPE.match("teatree.core.models")
+        assert not _ARTIFACT_SHAPE.match("/abs/path/to/dir")
+        assert _ARTIFACT_SHAPE.match("availability_override.json")
+        assert _ARTIFACT_SHAPE.match("statusline.txt")

--- a/tests/conformance/test_golden_artifact_invariants.py
+++ b/tests/conformance/test_golden_artifact_invariants.py
@@ -1,0 +1,268 @@
+"""Golden-artifact invariants — a byte comparison is not an assertion about correctness.
+
+``tests/teatree_dash/test_snapshot.py`` re-renders ``/dash/board`` and asserts the
+result byte-matches the committed ``src/teatree/dash/snapshots/board.html``. That
+comparison is total and it is also entirely self-referential: its expected value
+comes from the very renderer under test. When the renderer started emitting a
+Django template comment as literal page text — ``{# … #}`` is single-line only,
+so a comment wrapped across three lines renders — the fix for the drift test was
+to regenerate the golden, and the suite then asserted the bug was the correct
+output. It stayed asserted-correct until a human looked at the page (#3823).
+
+The lesson generalises past that one file: **a golden compared only against its
+own renderer has no invariant the renderer can violate.** It needs at least one
+assertion whose truth does not depend on the renderer being right.
+
+This lane supplies that floor for every golden in the tree, and pins the second
+half of the same story — WHO maintains the golden:
+
+* ``docs/generated/**`` is machine-maintained. CI's ``docs-drift`` job re-runs
+    every generator and then ``git diff --exit-code docs/generated``, so a stale or
+    hand-edited file fails. Fifteen artifacts live there; none has ever leaked.
+* ``src/teatree/dash/snapshots/board.html`` is maintained BY HAND — its own test
+    docstring tells a human to run a ``python -c`` one-liner and eyeball the diff.
+    It is the single golden outside the drift gate, and it is the single golden
+    carrying a renderer leak. That correlation is the finding, not a coincidence.
+
+Both ledgers ratchet in both directions: a new golden that violates an invariant
+or sits outside the drift gate fails, and a pegged golden that has since been
+cleaned must be un-pegged (:class:`TestGoldenPegLedgersRatchet`), so a freed
+allowance can never be silently respent on the next one.
+"""
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Roots holding committed golden artifacts — files whose content is a recorded
+#: render rather than authored source.
+_GOLDEN_ROOTS = (_REPO_ROOT / "docs" / "generated",)
+#: Snapshot directories anywhere under the package (the ``snapshots/`` convention).
+_PACKAGE_ROOT = _REPO_ROOT / "src"
+
+_CI_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+#: The CI step shape that makes a root machine-maintained: regenerate, then refuse
+#: any diff. Parsed from the workflow so deleting the step is itself caught.
+_DRIFT_GATE_STEP = re.compile(r"git diff --exit-code (\S+)")
+
+#: Unrendered Django template syntax surviving into rendered HTML. Every one of
+#: these means the template engine emitted markup it was supposed to consume.
+_TEMPLATE_LEAK = re.compile(r"\{#|#\}|\{%|%\}|\{\{|\}\}")
+#: Python internals that must never reach a rendered artifact — a repr in place of
+#: a value, or a traceback in place of a page.
+_INTERNALS_LEAK = re.compile(r"<[A-Za-z_][\w.]* object at 0x[0-9a-fA-F]+|Traceback \(most recent call last\)")
+
+#: A golden below this many bytes is very likely a render that returned nothing and
+#: was then committed as the expected output.
+_MIN_GOLDEN_BYTES = 100
+
+#: Goldens with a KNOWN renderer leak, each pegged to its tracking issue. Rows may
+#: only be removed. A NEW row is a new instance of the #3823 class.
+GOLDENS_WITH_PEGGED_LEAKS: dict[str, str] = {
+    # Three lines of `{# … #}` in dash/base.html render as page text; the golden
+    # records them, so the drift test asserts the bug. Fix in flight.
+    "src/teatree/dash/snapshots/board.html": "https://github.com/souliane/teatree/issues/3823",
+}
+
+#: Goldens NOT covered by a regenerate-and-diff CI gate, pegged to their issue.
+#: Hand-maintenance is how a renderer bug becomes an expected value.
+GOLDENS_OUTSIDE_THE_DRIFT_GATE: dict[str, str] = {
+    "src/teatree/dash/snapshots/board.html": "https://github.com/souliane/teatree/issues/3832",
+}
+
+_ISSUE_URL_SHAPE = re.compile(r"^https://github\.com/[\w.-]+/[\w.-]+/issues/\d+$")
+
+#: Anti-vacuity floors.
+_MIN_GOLDENS = 12
+_MIN_HTML_GOLDENS = 2
+#: Goldens reachable only via distinct discovery arms — a re-narrowed walk drops one.
+_DISCOVERY_ANCHORS: frozenset[str] = frozenset(
+    {
+        "docs/generated/cli-reference.md",  # _GOLDEN_ROOTS arm
+        "docs/generated/dashboard/admin-index.html",  # nested under _GOLDEN_ROOTS
+        "src/teatree/dash/snapshots/board.html",  # package snapshots/ arm
+    }
+)
+
+
+def golden_paths() -> list[Path]:
+    """Every committed golden artifact, discovered by convention rather than listed."""
+    found: set[Path] = set()
+    for root in _GOLDEN_ROOTS:
+        found.update(path for path in root.rglob("*") if path.is_file())
+    for snapshot_dir in _PACKAGE_ROOT.rglob("snapshots"):
+        if snapshot_dir.is_dir():
+            found.update(path for path in snapshot_dir.rglob("*") if path.is_file())
+    return sorted(found)
+
+
+def _rel(path: Path) -> str:
+    return path.relative_to(_REPO_ROOT).as_posix()
+
+
+def drift_gated_roots() -> set[str]:
+    """Repo roots CI regenerates and then refuses to see a diff in.
+
+    Read out of the workflow rather than hardcoded: if the ``git diff --exit-code``
+    step is ever dropped, this set shrinks and the totality assertion below fails
+    instead of silently passing on an ungated tree.
+    """
+    return set(_DRIFT_GATE_STEP.findall(_CI_WORKFLOW.read_text(encoding="utf-8")))
+
+
+def _is_drift_gated(rel_path: str) -> bool:
+    return any(rel_path == root or rel_path.startswith(f"{root.rstrip('/')}/") for root in drift_gated_roots())
+
+
+class TestGoldenContentInvariants:
+    """Renderer-independent floors — assertions the renderer cannot make true by being wrong."""
+
+    def test_no_golden_is_empty(self) -> None:
+        tiny = sorted(
+            f"{_rel(path)} ({path.stat().st_size}B)"
+            for path in golden_paths()
+            if path.stat().st_size < _MIN_GOLDEN_BYTES
+        )
+        assert not tiny, (
+            "golden artifact(s) below the size floor — a render that produced (almost) nothing and was "
+            f"committed as the expected output: {tiny}"
+        )
+
+    def test_no_html_golden_leaks_unrendered_template_syntax(self) -> None:
+        offenders = {}
+        for path in golden_paths():
+            if path.suffix != ".html" or _rel(path) in GOLDENS_WITH_PEGGED_LEAKS:
+                continue
+            leaks = _TEMPLATE_LEAK.findall(path.read_text(encoding="utf-8", errors="ignore"))
+            if leaks:
+                offenders[_rel(path)] = sorted(set(leaks))
+        assert not offenders, (
+            "rendered HTML golden(s) containing unrendered template syntax — the template engine emitted "
+            "markup it should have consumed, and the byte comparison recorded it as correct. Note Django's "
+            "`{# #}` comment is SINGLE-LINE only; use `{% comment %}` to span lines (#3823): " + str(offenders)
+        )
+
+    def test_no_golden_leaks_python_internals(self) -> None:
+        offenders = {}
+        for path in golden_paths():
+            leaks = _INTERNALS_LEAK.findall(path.read_text(encoding="utf-8", errors="ignore"))
+            if leaks:
+                offenders[_rel(path)] = sorted(set(leaks))[:3]
+        assert not offenders, (
+            "golden artifact(s) containing a Python object repr or a traceback — an internal reached the "
+            f"rendered output and the byte comparison froze it as expected: {offenders}"
+        )
+
+
+class TestGoldenMaintenanceIsMechanical:
+    """Every golden is regenerated by a machine and diff-gated — never hand-edited."""
+
+    def test_every_golden_is_under_a_drift_gated_root(self) -> None:
+        ungated = sorted(
+            _rel(path)
+            for path in golden_paths()
+            if not _is_drift_gated(_rel(path)) and _rel(path) not in GOLDENS_OUTSIDE_THE_DRIFT_GATE
+        )
+        assert not ungated, (
+            "golden artifact(s) outside every regenerate-and-diff CI gate. A hand-maintained golden is how "
+            "a renderer bug becomes an expected value (#3823): give it a generator and a "
+            "`git diff --exit-code <root>` step in the docs-drift job: " + str(ungated)
+        )
+
+    def test_the_drift_gate_still_exists_in_ci(self) -> None:
+        # Self-completeness: the assertion above is only meaningful while CI really
+        # runs the step it reads. An empty set would make it vacuously strict, and a
+        # DELETED step would make the whole lane meaningless.
+        roots = drift_gated_roots()
+        assert "docs/generated" in roots, (
+            f"CI no longer runs `git diff --exit-code docs/generated` — the generated docs are unguarded: {roots}"
+        )
+
+
+class TestGoldenPegLedgersRatchet:
+    """Both ledgers may only shrink — a cleaned golden must be un-pegged."""
+
+    def test_every_peg_names_a_tracking_issue(self) -> None:
+        malformed = sorted(
+            f"{name} -> {issue!r}"
+            for ledger in (GOLDENS_WITH_PEGGED_LEAKS, GOLDENS_OUTSIDE_THE_DRIFT_GATE)
+            for name, issue in ledger.items()
+            if not _ISSUE_URL_SHAPE.match(issue)
+        )
+        assert not malformed, f"peg rows must carry a tracking issue URL: {malformed}"
+
+    def test_every_pegged_golden_still_exists(self) -> None:
+        live = {_rel(path) for path in golden_paths()}
+        phantom = sorted(
+            name
+            for ledger in (GOLDENS_WITH_PEGGED_LEAKS, GOLDENS_OUTSIDE_THE_DRIFT_GATE)
+            for name in ledger
+            if name not in live
+        )
+        assert not phantom, f"peg rows naming no live golden (renamed/removed) — drop the row: {phantom}"
+
+    def test_no_pegged_leak_has_silently_been_fixed(self) -> None:
+        # Under-peg, the mandatory half: once the renderer stops leaking, the row must
+        # go, or the allowance shields the next leak in the same file.
+        clean = sorted(
+            name
+            for name in GOLDENS_WITH_PEGGED_LEAKS
+            if not _TEMPLATE_LEAK.search((_REPO_ROOT / name).read_text(encoding="utf-8", errors="ignore"))
+        )
+        assert not clean, (
+            "pegged golden(s) no longer leak template syntax — delete the row from "
+            f"GOLDENS_WITH_PEGGED_LEAKS so the file is guarded again: {clean}"
+        )
+
+    def test_no_ungated_peg_has_silently_become_gated(self) -> None:
+        gated = sorted(name for name in GOLDENS_OUTSIDE_THE_DRIFT_GATE if _is_drift_gated(name))
+        assert not gated, (
+            "pegged golden(s) are now under a drift-gated root — delete the row from "
+            f"GOLDENS_OUTSIDE_THE_DRIFT_GATE: {gated}"
+        )
+
+
+class TestGoldenDiscoveryFloors:
+    """Anti-vacuity — a discovery that finds nothing must not pass green."""
+
+    def test_discovery_floors(self) -> None:
+        goldens = golden_paths()
+        assert len(goldens) >= _MIN_GOLDENS, [_rel(p) for p in goldens]
+        html = [p for p in goldens if p.suffix == ".html"]
+        assert len(html) >= _MIN_HTML_GOLDENS, [_rel(p) for p in html]
+
+    def test_discovery_reaches_every_arm(self) -> None:
+        # The anchors are reachable only via distinct arms: dropping the package
+        # `snapshots/` walk loses board.html, which is the one the lane exists for.
+        missing = sorted(_DISCOVERY_ANCHORS - {_rel(path) for path in golden_paths()})
+        assert not missing, f"golden discovery missed anchor(s) — an arm was dropped: {missing}"
+
+
+class TestGoldenInvariantsFireRed:
+    """Anti-vacuity — the detectors must actually catch the shapes they exist to catch."""
+
+    def test_the_historical_3823_leak_is_detected(self) -> None:
+        # The concrete render that shipped: the board golden really does contain the
+        # unrendered comment, so the detector is proven on the real artifact and not
+        # only on a synthetic one.
+        board = _REPO_ROOT / "src" / "teatree" / "dash" / "snapshots" / "board.html"
+        assert _TEMPLATE_LEAK.search(board.read_text(encoding="utf-8")), (
+            "the #3823 leak is gone — delete its GOLDENS_WITH_PEGGED_LEAKS row and this anchor"
+        )
+
+    def test_detectors_fire_on_synthetic_offenders(self, tmp_path: Path) -> None:
+        assert _TEMPLATE_LEAK.search("<div>{# stray comment #}</div>")
+        assert _TEMPLATE_LEAK.search("<div>{% if x %}</div>")
+        assert _INTERNALS_LEAK.search("<Ticket object at 0x7f0011aa>")
+        assert _INTERNALS_LEAK.search("Traceback (most recent call last):")
+
+    def test_detectors_are_selective(self) -> None:
+        # A false trip would make the lane noise, and noise gets bypassed.
+        assert not _TEMPLATE_LEAK.search('<div class="dash-actions"><button>Terminal</button></div>')
+        assert not _INTERNALS_LEAK.search("the object at the top of the page")
+        assert not _INTERNALS_LEAK.search("<span>0x1F</span>")
+
+    def test_an_ungated_golden_root_is_reported(self) -> None:
+        assert not _is_drift_gated("src/teatree/dash/snapshots/board.html")
+        assert _is_drift_gated("docs/generated/cli-reference.md")


### PR DESCRIPTION
## What

Two conformance test files that stop two recurring failure classes from growing silently. They live in `tests/conformance/`, which `dev/push-gate.sh` lane 2 runs unconditionally on every push, so no wiring is needed. 32 tests, 5.9s. They are tests rather than deny hooks, so they cannot wedge the box.

## Why

Seven failure leads were collected from one session's incidents. On verification they collapse into three classes, two of which are mechanically gatable.

**Class 1 — cross-tier resolver divergence.** A concept resolved by both a Django path and a Django-free cold path, reading different sources, disagreeing silently. Four of the seven leads are this one defect:

- #3499 — cold settings fell back to compiled-in defaults; 14 kill-switches silently ignored their DB values
- #3819 — the hook interpreter had no Django, so 18 DB-backed call sites no-opped
- #3826 — `availability_override.json` held a week-old posture while `ModeOverride` was empty, and `_check_availability_override_staleness` reads the *table* while the hooks obey the *file*, so the guard built for that failure could never observe it

The repo had already invented both countermeasures — a parity pin (`test_speak_hook_config_parity.py`) and a cross-tier doctor probe. Each existed for exactly one concept, and nothing forced coverage, so protection accreted one concept at a time while the class kept recurring.

**Class 2 — self-referential assertion.** `src/teatree/dash/snapshots/board.html` is byte-compared against the renderer that produces it, so a renderer defect becomes the expected output. Still live on main: the golden carries unrendered template syntax at lines 45-47 (the leak fixed in #3824). It is also the only one of 16 goldens with no generator and no drift gate — the other 15 live under `docs/generated/**`, which CI regenerates and guards with `git diff --exit-code`. That correlation is the finding, not a coincidence.

**Class 3 — claim without observation.** Verified: 272 of 328 tickets (82.9%) still have an empty `short_description`, the outcome #3570 was closed for. Not gatable by a test; filed as #3833.

## Leads that did NOT survive verification

- **PR #3816 regressing `CLAUDE_CODE_SESSION_ID`** is real but already repaired *and* pinned — `session_identity.py` carries a canonical precedence list, `test_session_identity.py` names #3554, and the hook-side redeclaration is held in sync by a test. Not an open gap. What it exposes is that the pinning was voluntary (#3834).
- **Invisible tick output** was initially not reproducible, then found to be real and worse than described: `_emit_report` sets `human=None` on a clean tick and `emit` returns silently, so a *successful* `loops tick` prints nothing at all in non-JSON mode. Filed as #3835.

## The gates

**`test_cross_tier_artifact_parity.py`** — discovery is mechanical and tree-wide: a filename literal named by both `src/teatree` and a Django-free root (`hooks/`, `scripts/lib/`, including `*.sh`) is cross-tier by construction. Six found.

Coverage deliberately rejects the weaker test of a filename merely being mentioned — all six already satisfied that, including the #3826 mirror that shipped divergent. That is exactly the proxy-measurement failure this is meant to end. A covering test must import **both** tiers. Two pass; four are pegged.

**`test_golden_artifact_invariants.py`** — renderer-independent floors (no unrendered template syntax, no object reprs or tracebacks, a size floor) plus a totality assertion that every golden sits under a root CI regenerates and diffs, parsed out of `ci.yml` so deleting that step is itself caught.

Both ledgers block in **both** directions: a fixed entry must be un-pegged, so a freed allowance cannot be silently respent.

## Testing

RED-then-GREEN on the real artifacts, not only synthetics: dropping the #3826 peg reds enrolment; adding a both-tier test for a pegged artifact reds the under-peg assertion; dropping either `board.html` peg reds the leak and drift-gate lanes.

No gate weakened — no suppression, no threshold change, no skipped or deleted test. Both files are pure additions; the anti-relaxation, module-health and regression-rule hooks all passed. Full pre-push gate green.

## Scope limits, stated plainly

So this is not mistaken for broader assurance than it provides:

- **It ratchets two classes, not all defects.** A wrong algorithm, a bad query, a misread requirement — none are touched.
- **Four known cross-tier gaps are pegged, not repaired.** The gate stops new ones today; the existing four close via #3826 / #3828 / #3829 / #3830. They were pegged rather than repaired because availability and the board template are live on other branches right now.
- **#3819's class is only half-gatable.** That failure was environmental — correct code, wrong host. No pre-merge check can observe it; it needs the runtime probe in #3831.
- **Discovery is heuristic.** A cross-tier artifact whose filename is constructed rather than written as a literal is invisible to the walk. The anchors guard against the scan silently narrowing, not against an unanticipated shape.
- **The largest lever is filed, not built.** #3834 — requiring every repair to land its own detector — is the only mechanism that generalises across all classes. The repo already has two strong ratchets for it (`regression_rules.yaml`, the pinned-regression corpus) carrying 8 rules against a far larger defect history, precisely because both are opt-in.

What this does support: two recurring classes can no longer grow unnoticed, and every gap in them is named, pegged, and blocked from being re-hidden. A real ratchet on a bounded slice.

Related: #3828, #3829, #3830, #3831, #3832, #3833, #3834, #3835.
