### PR TITLE
fix(agents): route the no_result_envelope refusal to the corrective retry

### DIFF
--- a/src/teatree/agents/envelope_refusal.py
+++ b/src/teatree/agents/envelope_refusal.py
@@ -1,7 +1,7 @@
 """The refusal half of the result-envelope contract — one vocabulary, one owner.
 
 :mod:`teatree.agents.envelope_contract` states what every headless brief TEACHES;
-this module states what the pipeline REFUSES when the brief was not honoured, and
+this module states what the pipeline REFUSES when an agent ignores that brief, and
 how that refusal is corrected. Both halves of one contract, so a new refusal can
 never be added on the producing side without the consuming side learning it.
 
@@ -52,8 +52,8 @@ _RECORDER_REFUSAL_MARKERS = (
 def is_no_envelope_refusal(error: str) -> bool:
     """Whether *error* is the RUNNER's "no JSON object at all" refusal.
 
-    Keyed on :data:`NO_ENVELOPE_PREFIX` rather than the whole reason so the
-    classification survives a future change to the human-readable tail.
+    Keyed on :data:`NO_ENVELOPE_PREFIX` rather than the whole reason, so rewording
+    the human-readable tail cannot silently drop the classification.
     """
     return NO_ENVELOPE_PREFIX.strip().casefold() in error.casefold()
 

--- a/src/teatree/agents/envelope_refusal.py
+++ b/src/teatree/agents/envelope_refusal.py
@@ -1,0 +1,95 @@
+"""The refusal half of the result-envelope contract — one vocabulary, one owner.
+
+:mod:`teatree.agents.envelope_contract` states what every headless brief TEACHES;
+this module states what the pipeline REFUSES when the brief was not honoured, and
+how that refusal is corrected. Both halves of one contract, so a new refusal can
+never be added on the producing side without the consuming side learning it.
+
+Two seams produce an envelope refusal, and they used to name it in two
+hand-maintained vocabularies that drifted:
+
+* the RUNNER (:func:`teatree.agents.headless._record_success`) refuses a run whose
+    output carried no JSON object at all — :data:`NO_ENVELOPE_ERROR`;
+* the RECORDER (:mod:`teatree.agents.attempt_recorder`, :func:`…result_schema.check_evidence`)
+    refuses an envelope that parsed but is unusable — wrong keys, not an object, or
+    missing the phase's evidence field.
+
+The consumer is :mod:`teatree.loop.transient_requeue`, whose one-shot corrective
+retry reopens such a task with an explicit emit-the-envelope instruction. It
+listed only the RECORDER's four strings, so ``no_result_envelope`` — the most
+literal omitted-envelope failure there is — was the one class that never earned
+the retry: the first prose-only run parked the task and paged a human. The fix is
+this shared module, not a fifth hand-typed literal.
+
+The refusal itself stays: a success you cannot parse is not evidence of success.
+What this module makes possible is a BOUNDED, satisfiable correction of it.
+"""
+
+from teatree.agents.result_schema import required_evidence_for_phase
+
+#: Prefix the headless runner stamps on a run that emitted no JSON object at all.
+NO_ENVELOPE_PREFIX = "no_result_envelope: "
+
+#: The runner's full refusal reason. Deliberately a CONSTANT with no run-specific
+#: detail: ``TaskAttempt.error_fingerprint`` hashes it and the repair loop halts on
+#: two consecutive identical fingerprints, so folding the agent's (always-different)
+#: prose into the reason would make every no-envelope run look like a fresh failure
+#: and defeat the stall check. The prose is preserved on the failed attempt's
+#: ``result`` for diagnosis instead.
+NO_ENVELOPE_ERROR = f"{NO_ENVELOPE_PREFIX}agent produced no JSON result envelope; refusing to record success"
+
+#: Substrings identifying a RECORDER-side envelope refusal — an envelope that
+#: parsed but is unusable, as opposed to a genuine defect (an assertion, a test
+#: failure, a review verdict the reviewer legitimately withheld).
+_RECORDER_REFUSAL_MARKERS = (
+    "missing required evidence",
+    "unexpected keys",
+    "result is not valid json",
+    "result must be a json object",
+)
+
+
+def is_no_envelope_refusal(error: str) -> bool:
+    """Whether *error* is the RUNNER's "no JSON object at all" refusal.
+
+    Keyed on :data:`NO_ENVELOPE_PREFIX` rather than the whole reason so the
+    classification survives a future change to the human-readable tail.
+    """
+    return NO_ENVELOPE_PREFIX.strip().casefold() in error.casefold()
+
+
+def is_recorder_refusal(error: str) -> bool:
+    """Whether *error* is a RECORDER-side refusal of a parsed-but-unusable envelope."""
+    haystack = error.casefold()
+    return any(marker in haystack for marker in _RECORDER_REFUSAL_MARKERS)
+
+
+def is_envelope_refusal(error: str) -> bool:
+    """Whether *error* is an envelope refusal of either kind (never a genuine defect)."""
+    return is_no_envelope_refusal(error) or is_recorder_refusal(error)
+
+
+def required_keys_phrase(phase: str) -> str:
+    """The phase's own required envelope keys, rendered for an instruction line.
+
+    Derived from :data:`~teatree.agents.result_schema.PHASE_REQUIRED_EVIDENCE`, never
+    a second hand-maintained list — an instruction that names a key the phase does
+    not require teaches the re-dispatched agent the wrong contract.
+    """
+    required = required_evidence_for_phase(phase)
+    if not required:
+        return "`summary`"
+    return "`summary` and " + " or ".join(f"`{field}`" for field in required)
+
+
+def corrective_instruction(phase: str) -> str:
+    """The one-shot corrective note appended to a re-dispatched task's prompt.
+
+    Lands in ``Task.execution_reason``, which ``agents/prompt.py`` renders as the
+    brief's ``Reason:`` line — so it is phase-accurate by construction.
+    """
+    return (
+        f"your last run omitted the required trailing JSON result envelope "
+        f"({required_keys_phrase(phase)}) — emit it as the last thing you write, "
+        "plain JSON, nothing after it."
+    )

--- a/src/teatree/agents/headless.py
+++ b/src/teatree/agents/headless.py
@@ -29,6 +29,7 @@ from django.utils import timezone
 
 from teatree.agents._headless_env import _overlay_scope, _provider_child_env, with_test_worker_cap
 from teatree.agents._headless_options import _build_options
+from teatree.agents.envelope_refusal import NO_ENVELOPE_ERROR
 from teatree.agents.harness import Harness, HarnessSession, pydantic_ai_thread, resolve_harness
 from teatree.agents.harness_registry import InvalidHarnessProviderError, UnknownHarnessError
 from teatree.agents.headless_budget import TicketBudget
@@ -83,18 +84,6 @@ _LEASE_SECONDS = 15 * _HEARTBEAT_INTERVAL  # 900s
 
 _STUCK_LOOP_PREFIX = "stuck_loop: "
 _RESULT_ERROR_PREFIX = "result_error: "
-_NO_ENVELOPE_PREFIX = "no_result_envelope: "
-
-#: The refusal recorded when an agent finished cleanly but returned no result
-#: envelope on a phase that requires one (see
-#: :meth:`~teatree.agents.result_schema.ProseSummaryPolicy.allowed`). Deliberately a
-#: CONSTANT: ``TaskAttempt.error_fingerprint`` hashes this reason, and the repair
-#: loop escalates on two consecutive identical fingerprints — folding the agent's
-#: (always-different) prose into the reason would make every no-envelope run look
-#: like a fresh failure and defeat the stall check. The prose itself is preserved
-#: on the failed attempt's ``result`` for diagnosis, the same way every other
-#: envelope refusal keeps its offending blob.
-_NO_ENVELOPE_ERROR = f"{_NO_ENVELOPE_PREFIX}agent produced no JSON result envelope; refusing to record success"
 
 #: Truncation applied to the agent's raw text when it stands in for an envelope.
 _PROSE_SUMMARY_CHARS = 1000
@@ -631,7 +620,7 @@ def _record_success(
         prose: AgentResultBlob = {"summary": outcome.agent_text[:_PROSE_SUMMARY_CHARS]}
         if not ProseSummaryPolicy.allowed(phase or task.phase):
             logger.warning("Task %s produced no result envelope; refusing to record success", task.pk)
-            return _record_failure(task, exit_code=0, error=_NO_ENVELOPE_ERROR, result=prose)
+            return _record_failure(task, exit_code=0, error=NO_ENVELOPE_ERROR, result=prose)
         result = prose
 
     maybe_persist_on_park(task, result, outcome.thread)  # (#2886)

--- a/src/teatree/loop/transient_requeue.py
+++ b/src/teatree/loop/transient_requeue.py
@@ -274,12 +274,14 @@ def _self_repair_reopen(task: Task) -> int | None:
 def _corrective_note(task: Task) -> str | None:
     """The emit-the-envelope instruction *task* earns, or ``None`` if it must escalate.
 
-    The RUNNER-side ``no_result_envelope`` refusal is a pure output-FORMAT failure
-    whose correction is phase-independent, so it is corrective on ANY phase — gating
-    it on :data:`_CORRECTIVE_PHASES` left its whole reachable set paging a human on
-    the very first prose-only run. A RECORDER-side refusal stays gated on that set:
-    on ``reviewing`` a withheld verdict is a judgement to surface, not a format slip.
-    ``None`` for a genuine defect, and for a task whose one retry is already spent.
+    The RUNNER-side ``no_result_envelope`` refusal is a pure output-FORMAT failure, so
+    it is corrective on ANY phase where ``ProseSummaryPolicy.allowed`` is False:
+    ``debugging`` (already in :data:`_CORRECTIVE_PHASES`) plus every no-evidence,
+    non-prose-exempt phase outside it (``architectural_review``, ``bughunt``, ``e2e``,
+    ``codex_*``) — which the old gate left paging a human on the first prose-only run.
+    A RECORDER-side refusal stays gated on the set: a withheld ``reviewing`` verdict is
+    a judgement to surface, not a format slip. ``None`` for a genuine defect, and for a
+    task whose one corrective retry is already spent.
     """
     if _CORRECTIVE_MARKER in task.execution_reason:
         return None

--- a/src/teatree/loop/transient_requeue.py
+++ b/src/teatree/loop/transient_requeue.py
@@ -15,11 +15,11 @@ never forever.
 
 A DETERMINISTIC failure (a test failure, an assertion, a schema/evidence refusal)
 is NOT reopened blindly, but it must never sit silent either. On a non-terminal
-ticket, a coding/debugging failure whose last attempt was an omitted-envelope
-refusal (the coder emitted no trailing ``files_modified`` JSON) gets exactly ONE
-bounded corrective retry — reopened with the emit-the-envelope instruction
-appended to its prompt. Any other deterministic failure, and any envelope refusal
-that already spent its one corrective retry, is escalated via the SAME
+ticket, a failure whose last attempt was an ENVELOPE REFUSAL — classified by the
+shared :mod:`teatree.agents.envelope_refusal` vocabulary, so the producing and
+consuming sides can never drift — gets exactly ONE bounded corrective retry, reopened
+with the phase-accurate emit-the-envelope instruction appended to its prompt. Any
+other deterministic failure, and any refusal that already spent its retry, hits the
 :class:`DeferredQuestion` path. An EMPTY-error FAILED task (no recorded error at
 all — neither transient nor deterministic) would otherwise match no branch and
 freeze silently; it is routed straight to the escalation path. The invariant: a
@@ -91,6 +91,7 @@ from datetime import datetime
 
 from django.utils import timezone
 
+from teatree.agents.envelope_refusal import corrective_instruction, is_no_envelope_refusal, is_recorder_refusal
 from teatree.agents.outage_classifier import is_transient_failure
 from teatree.agents.usage_window import autorecovery_enabled
 from teatree.core.config_self_repair import SELF_REPAIR_STAMP
@@ -132,22 +133,12 @@ _LIVE_SUCCESSOR_STAMP = "[superseded-parked]"
 #: drops out of every active scan instead of re-dispatching indefinitely.
 _DEAD_REVIEW_STAMP = "[dead-review-retired]"
 
-#: Phases whose omitted-envelope refusal earns the one-shot corrective retry.
+#: Phases whose RECORDER-side envelope refusal earns the one-shot corrective retry.
+#: The RUNNER-side ``no_result_envelope`` is NOT gated on it (:func:`_corrective_note`).
 _CORRECTIVE_PHASES = frozenset({"coding", "debugging"})
 #: Idempotency stamp appended to ``execution_reason`` when the corrective retry
 #: fires — its presence means the one retry was already spent (escalate next time).
 _CORRECTIVE_MARKER = "[auto-corrective-retry]"
-_CORRECTIVE_INSTRUCTION = (
-    "your last run omitted the required trailing JSON result envelope with files_modified — emit it."
-)
-#: Error substrings that mark a malformed / missing result envelope (as opposed
-#: to a genuine defect like an assertion or test failure).
-_ENVELOPE_REFUSAL_MARKERS = (
-    "missing required evidence",
-    "unexpected keys",
-    "result is not valid json",
-    "result must be a json object",
-)
 
 
 def requeue_transient_failed() -> int:
@@ -246,8 +237,8 @@ def _handle_deterministic(task: Task) -> int:
     if halt is not None:
         _escalate_once(task, reason=halt)
         return 0
-    if _is_corrective_candidate(task):
-        return _corrective_reopen(task)
+    if (note := _corrective_note(task)) is not None:
+        return _corrective_reopen(task, note)
     _escalate_once(task, reason=_latest_error(task) or "deterministic failure")
     return 0
 
@@ -280,25 +271,34 @@ def _self_repair_reopen(task: Task) -> int | None:
     )
 
 
-def _is_corrective_candidate(task: Task) -> bool:
-    """Whether *task* is an omitted-envelope coding refusal that has not yet been corrective-retried."""
-    if normalize_phase(task.phase) not in _CORRECTIVE_PHASES:
-        return False
+def _corrective_note(task: Task) -> str | None:
+    """The emit-the-envelope instruction *task* earns, or ``None`` if it must escalate.
+
+    The RUNNER-side ``no_result_envelope`` refusal is a pure output-FORMAT failure
+    whose correction is phase-independent, so it is corrective on ANY phase — gating
+    it on :data:`_CORRECTIVE_PHASES` left its whole reachable set paging a human on
+    the very first prose-only run. A RECORDER-side refusal stays gated on that set:
+    on ``reviewing`` a withheld verdict is a judgement to surface, not a format slip.
+    ``None`` for a genuine defect, and for a task whose one retry is already spent.
+    """
     if _CORRECTIVE_MARKER in task.execution_reason:
-        return False
-    error = _latest_error(task).casefold()
-    return any(marker in error for marker in _ENVELOPE_REFUSAL_MARKERS)
+        return None
+    error = _latest_error(task)
+    gated = normalize_phase(task.phase) in _CORRECTIVE_PHASES and is_recorder_refusal(error)
+    if is_no_envelope_refusal(error) or gated:
+        return corrective_instruction(task.phase)
+    return None
 
 
-def _corrective_reopen(task: Task) -> int:
+def _corrective_reopen(task: Task, note: str) -> int:
     """CAS FAILED → PENDING appending the emit-the-envelope instruction to the prompt.
 
     Uses the same conditional ``UPDATE ... WHERE status=FAILED`` compare-and-swap
     as :func:`_reopen` so a concurrent tick that already reopened the row updates 0
     rows and does not re-append the note.
     """
-    note = f"{_CORRECTIVE_MARKER} {_CORRECTIVE_INSTRUCTION}"
-    new_reason = f"{task.execution_reason}\n{note}".strip() if task.execution_reason else note
+    stamped = f"{_CORRECTIVE_MARKER} {note}"
+    new_reason = f"{task.execution_reason}\n{stamped}".strip() if task.execution_reason else stamped
     return Task.objects.filter(pk=task.pk, status=Task.Status.FAILED).update(
         status=Task.Status.PENDING,
         claimed_at=None,

--- a/tests/teatree_agents/test_envelope_refusal.py
+++ b/tests/teatree_agents/test_envelope_refusal.py
@@ -1,0 +1,103 @@
+"""The refusal vocabulary of the result-envelope contract — one owner, both seams.
+
+Two seams produce an envelope refusal and used to name it in two hand-typed
+lists that drifted, leaving ``no_result_envelope`` the one class the corrective
+retry never fired for. These tests pin each classifier separately, so a future
+change that widens one seam cannot silently narrow the other — and each carries
+a negative control, because a classifier that answers ``True`` to everything
+would pass every positive assertion.
+"""
+
+from django.test import SimpleTestCase
+
+from teatree.agents.envelope_refusal import (
+    NO_ENVELOPE_ERROR,
+    NO_ENVELOPE_PREFIX,
+    corrective_instruction,
+    is_envelope_refusal,
+    is_no_envelope_refusal,
+    is_recorder_refusal,
+    required_keys_phrase,
+)
+
+#: A real recorder-side refusal, as ``result_schema.check_evidence`` phrases it.
+_EVIDENCE_REFUSAL = (
+    "missing required evidence for phase 'coding': result must include one of "
+    "[files_modified] with a non-empty value (codex #1282-6)"
+)
+#: A genuine defect — the control every classifier must reject.
+_REAL_DEFECT = "AssertionError: expected 3 got 4"
+
+
+class TestNoEnvelopeRefusal(SimpleTestCase):
+    def test_the_runners_own_constant_is_classified(self) -> None:
+        assert is_no_envelope_refusal(NO_ENVELOPE_ERROR)
+
+    def test_classification_keys_on_the_prefix_not_the_prose_tail(self) -> None:
+        # Keyed on the prefix so a future reword of the human-readable tail does
+        # not silently drop the refusal out of the corrective-retry path.
+        assert is_no_envelope_refusal(f"{NO_ENVELOPE_PREFIX}some entirely different wording")
+
+    def test_a_recorder_refusal_is_not_a_no_envelope_refusal(self) -> None:
+        # The two seams stay distinct: they carry different phase scopes in
+        # ``transient_requeue._corrective_note``, so conflating them would widen
+        # the recorder-side gate by accident.
+        assert not is_no_envelope_refusal(_EVIDENCE_REFUSAL)
+
+    def test_a_genuine_defect_is_rejected(self) -> None:
+        assert not is_no_envelope_refusal(_REAL_DEFECT)
+
+
+class TestRecorderRefusal(SimpleTestCase):
+    def test_each_recorder_marker_is_classified(self) -> None:
+        assert is_recorder_refusal(_EVIDENCE_REFUSAL)
+        assert is_recorder_refusal("Agent result contains unexpected keys: bogus")
+        assert is_recorder_refusal("result is not valid JSON: Expecting value")
+        assert is_recorder_refusal("result must be a JSON object")
+
+    def test_matching_is_case_insensitive(self) -> None:
+        assert is_recorder_refusal("RESULT MUST BE A JSON OBJECT")
+
+    def test_the_runner_refusal_is_not_a_recorder_refusal(self) -> None:
+        assert not is_recorder_refusal(NO_ENVELOPE_ERROR)
+
+    def test_a_genuine_defect_is_rejected(self) -> None:
+        assert not is_recorder_refusal(_REAL_DEFECT)
+        assert not is_recorder_refusal("")
+
+
+class TestEnvelopeRefusalUnion(SimpleTestCase):
+    def test_it_covers_both_seams_and_rejects_a_real_defect(self) -> None:
+        assert is_envelope_refusal(NO_ENVELOPE_ERROR)
+        assert is_envelope_refusal(_EVIDENCE_REFUSAL)
+        assert not is_envelope_refusal(_REAL_DEFECT)
+
+
+class TestRequiredKeysPhrase(SimpleTestCase):
+    def test_a_phase_with_an_evidence_requirement_names_its_own_key(self) -> None:
+        # Derived from PHASE_REQUIRED_EVIDENCE, never a second hand-kept list.
+        assert required_keys_phrase("coding") == "`summary` and `files_modified`"
+
+    def test_a_phase_with_several_accepted_fields_offers_them_all(self) -> None:
+        assert required_keys_phrase("testing") == "`summary` and `tests_run` or `tests_passed`"
+
+    def test_a_phase_with_no_evidence_requirement_names_summary_alone(self) -> None:
+        # ``debugging`` is exactly the phase the no-envelope refusal fires on.
+        assert required_keys_phrase("debugging") == "`summary`"
+
+    def test_an_unknown_phase_degrades_to_summary_rather_than_raising(self) -> None:
+        assert required_keys_phrase("not-a-real-phase") == "`summary`"
+
+
+class TestCorrectiveInstruction(SimpleTestCase):
+    def test_it_demands_the_envelope_last_and_unfenced(self) -> None:
+        # The note lands in the re-dispatched prompt, so it must restate the
+        # placement rule the parser depends on, not merely say "emit it".
+        note = corrective_instruction("debugging")
+        assert "envelope" in note
+        assert "last thing you write" in note
+        assert "plain JSON" in note
+
+    def test_it_never_names_a_key_the_phase_does_not_require(self) -> None:
+        assert "files_modified" not in corrective_instruction("debugging")
+        assert "files_modified" in corrective_instruction("coding")

--- a/tests/teatree_agents/test_headless_no_envelope_guard.py
+++ b/tests/teatree_agents/test_headless_no_envelope_guard.py
@@ -25,6 +25,7 @@ from pydantic_ai.models.test import TestModel
 
 import teatree.agents.harness as harness_mod
 import teatree.agents.headless as headless_mod
+from teatree.agents.envelope_refusal import is_envelope_refusal
 from teatree.agents.harness import PydanticAiHarness
 from teatree.agents.headless import TaskUsage, run_headless
 from teatree.core.models import Session, Task, Ticket
@@ -119,6 +120,25 @@ class TestNoEnvelopeGuardIsLaneAgnostic(TestCase):
             attempt = run_headless(task, phase="debugging", overlay_skill_metadata={})
 
         self._assert_refused(attempt, task, session)
+
+    def test_recorded_refusal_is_classified_by_the_correcting_sweep(self) -> None:
+        # Producer/consumer parity. The refusal this runner WRITES must be the
+        # refusal ``loop.transient_requeue`` READS when it decides whether to spend
+        # the one bounded corrective retry. The two strings were hand-typed in two
+        # modules and drifted, so ``no_result_envelope`` — the most literal
+        # omitted-envelope failure there is — was the single envelope refusal that
+        # never earned the retry, and the first prose-only run paged a human.
+        session = Session.objects.create(ticket=self.ticket, agent_id="agent-1")
+        task = Task.objects.create(ticket=self.ticket, session=session, phase="debugging")
+
+        with _fake_sdk(_PROSE):
+            attempt = run_headless(task, phase="debugging", overlay_skill_metadata={})
+
+        assert is_envelope_refusal(attempt.error), (
+            f"the correcting sweep must classify the runner's own refusal; got: {attempt.error!r}"
+        )
+        # Control: the classifier can say NO — it is not a rubber stamp.
+        assert not is_envelope_refusal("AssertionError: expected 3 got 4")
 
     def test_exempt_phase_keeps_prose_fallback(self) -> None:
         # Behaviour preservation: an exempt phase (``retro``) still records the

--- a/tests/teatree_loop/test_no_envelope_corrective_retry.py
+++ b/tests/teatree_loop/test_no_envelope_corrective_retry.py
@@ -62,11 +62,12 @@ class TestNoEnvelopeCorrectiveRetry(TestCase):
 
     def test_no_envelope_refusal_is_corrective_on_any_phase(self) -> None:
         # The refusal is a pure OUTPUT-FORMAT failure with a phase-independent
-        # correction, and it can only ever fire on a phase OUTSIDE the coding/
-        # debugging pair (every other phase either requires evidence or is
-        # prose-exempt). Gating it on that pair would leave the whole reachable
-        # set — architectural_review, bughunt, e2e, the codex_* variants — paging
-        # a human on the very first prose-only run.
+        # correction. Its reachable set is every phase that neither requires
+        # evidence nor is prose-exempt: `debugging` (covered by the sibling test
+        # above, and already inside _CORRECTIVE_PHASES) AND the phases outside
+        # that pair — architectural_review, bughunt, e2e, the codex_* variants.
+        # Gating it on the pair left this second group paging a human on the
+        # very first prose-only run; `architectural_review` stands for it here.
         task = _failed_task(phase="architectural_review")
         _add_failed_attempt(task, error=NO_ENVELOPE_ERROR)
 

--- a/tests/teatree_loop/test_no_envelope_corrective_retry.py
+++ b/tests/teatree_loop/test_no_envelope_corrective_retry.py
@@ -1,0 +1,120 @@
+"""The ``no_result_envelope`` refusal must earn the one-shot corrective retry.
+
+``_record_success`` refuses to record a headless run that emitted prose and no
+JSON result envelope (``no_result_envelope: …``). That refusal is right — an
+unparsable success is not evidence of success — but the harness already owns
+the machinery that makes the contract SATISFIABLE: ``transient_requeue``'s
+one-shot corrective retry, which reopens the task with an explicit
+"emit the envelope" instruction appended to its prompt.
+
+The runner's refusal string was never listed in the consumer's envelope-refusal
+vocabulary, so the most literal omitted-envelope failure was the one class the
+corrective retry never fired for: the first prose-only run parked the task and
+paged a human. These tests pin the routing (retry once, then escalate) and the
+phase-accuracy of the instruction; the producer/consumer parity that let the two
+strings drift apart is pinned on the runner side, in
+``tests/teatree_agents/test_headless_no_envelope_guard.py``.
+"""
+
+from django.test import TestCase
+from django.utils import timezone
+
+from teatree.agents.envelope_refusal import NO_ENVELOPE_ERROR, corrective_instruction, is_envelope_refusal
+from teatree.core.models import Session, Task, TaskAttempt, Ticket
+from teatree.core.models.deferred_question import DeferredQuestion
+from teatree.loop.transient_requeue import requeue_transient_failed
+
+
+def _failed_task(*, phase: str, state: str = Ticket.State.STARTED) -> Task:
+    ticket = Ticket.objects.create(role=Ticket.Role.AUTHOR, state=state)
+    session = Session.objects.create(ticket=ticket, agent_id=phase)
+    return Task.objects.create(ticket=ticket, session=session, phase=phase, status=Task.Status.FAILED)
+
+
+def _add_failed_attempt(task: Task, *, error: str) -> None:
+    TaskAttempt.objects.create(
+        task=task,
+        execution_target=task.execution_target,
+        ended_at=timezone.now(),
+        exit_code=0,  # an envelope refusal is a clean REFUSAL, not a crash
+        error=error,
+    )
+    Task.objects.filter(pk=task.pk).update(status=Task.Status.FAILED)
+
+
+class TestNoEnvelopeCorrectiveRetry(TestCase):
+    def test_debugging_no_envelope_refusal_gets_one_corrective_retry(self) -> None:
+        # ``debugging`` has no PHASE_REQUIRED_EVIDENCE entry, so a prose-only run
+        # is refused by the RUNNER with ``no_result_envelope`` rather than by the
+        # recorder's evidence gate. It must earn the same one-shot corrective
+        # retry an omitted ``files_modified`` envelope earns — not an immediate page.
+        task = _failed_task(phase="debugging")
+        _add_failed_attempt(task, error=NO_ENVELOPE_ERROR)
+
+        reopened = requeue_transient_failed()
+
+        task.refresh_from_db()
+        assert reopened == 1
+        assert task.status == Task.Status.PENDING
+        assert "[auto-corrective-retry]" in task.execution_reason
+        assert "envelope" in task.execution_reason.lower()
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 0
+
+    def test_no_envelope_refusal_is_corrective_on_any_phase(self) -> None:
+        # The refusal is a pure OUTPUT-FORMAT failure with a phase-independent
+        # correction, and it can only ever fire on a phase OUTSIDE the coding/
+        # debugging pair (every other phase either requires evidence or is
+        # prose-exempt). Gating it on that pair would leave the whole reachable
+        # set — architectural_review, bughunt, e2e, the codex_* variants — paging
+        # a human on the very first prose-only run.
+        task = _failed_task(phase="architectural_review")
+        _add_failed_attempt(task, error=NO_ENVELOPE_ERROR)
+
+        reopened = requeue_transient_failed()
+
+        task.refresh_from_db()
+        assert reopened == 1
+        assert task.status == Task.Status.PENDING
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 0
+
+    def test_second_no_envelope_refusal_escalates_and_never_loops(self) -> None:
+        # The retry is bounded at exactly ONE. A ticket can never retry
+        # indefinitely on the same unsatisfiable condition: the second identical
+        # refusal stops and surfaces.
+        task = _failed_task(phase="debugging")
+        _add_failed_attempt(task, error=NO_ENVELOPE_ERROR)
+        assert requeue_transient_failed() == 1
+
+        _add_failed_attempt(task, error=NO_ENVELOPE_ERROR)
+
+        reopened = requeue_transient_failed()
+
+        task.refresh_from_db()
+        assert reopened == 0
+        assert task.status == Task.Status.FAILED
+        assert "[repair-halt-parked]" in task.execution_reason
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1
+        # Durably parked — a later sweep never resurrects another retry.
+        assert requeue_transient_failed() == 0
+
+    def test_corrective_instruction_names_only_the_phases_own_required_keys(self) -> None:
+        # The note lands in the re-dispatched prompt (``execution_reason`` →
+        # "Reason:"), so naming a key the phase does not require teaches the
+        # agent the wrong contract. ``debugging`` requires only ``summary``.
+        assert "files_modified" in corrective_instruction("coding")
+        assert "summary" in corrective_instruction("coding")
+        assert "files_modified" not in corrective_instruction("debugging")
+        assert "summary" in corrective_instruction("debugging")
+
+    def test_a_genuine_defect_is_still_not_corrective_retried(self) -> None:
+        # Control: the classifier must be able to say NO. A real assertion
+        # failure is not an envelope refusal and still escalates on the first hit.
+        assert not is_envelope_refusal("AssertionError: expected 3 got 4")
+        task = _failed_task(phase="debugging")
+        _add_failed_attempt(task, error="AssertionError: expected 3 got 4")
+
+        assert requeue_transient_failed() == 0
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.FAILED
+        assert DeferredQuestion.objects.filter(answered_at__isnull=True).count() == 1


### PR DESCRIPTION
fix(agents): route the no_result_envelope refusal to the corrective retry

## What

A headless run that emits prose and no JSON result envelope is refused (`no_result_envelope`). The refusal is right; what was broken is that this refusal never reached the harness's own one-shot corrective retry, so the first prose-only run parked the task and paged a human. Routed it there, bounded at exactly one retry.

## Why — the stall

Ticket 266 ([#3502](https://github.com/souliane/teatree/issues/3502)) sat in `planned` with 29,010 task attempts. Two distinct shapes in that history: a `limit_parked` hot-spin (already fixed by [#3827](https://github.com/souliane/teatree/pull/3827) — it explains the count, not the stall), and the two most recent real attempts, both `no_result_envelope`. The agent ran, produced ordinary prose, and the harness refused to record success.

The refusal is correct — a success you cannot parse is not evidence of success. What was broken is the other half: the harness already owns the machinery that makes the contract *satisfiable*, and this refusal never reached it.

## Root cause

`teatree.loop.transient_requeue` gives an envelope refusal exactly ONE bounded corrective retry: it reopens the task with an explicit emit-the-envelope instruction appended to its prompt. It classified those refusals with a hand-typed tuple:

```python
_ENVELOPE_REFUSAL_MARKERS = (
    "missing required evidence",
    "unexpected keys",
    "result is not valid json",
    "result must be a json object",
)
```

Those are the four **recorder-side** strings (`attempt_recorder` / `result_schema.check_evidence`). The **runner-side** refusal — `headless._record_success`'s `no_result_envelope: agent produced no JSON result envelope; refusing to record success` — was spelled in a *second* vocabulary, in `headless.py`, and never added here. So the most literal omitted-envelope failure there is was the one envelope refusal that never earned the retry: the first prose-only run parked the task (`[repair-halt-parked]`) and filed a `DeferredQuestion`, and the ticket sat awaiting a human.

Two seams, two hand-maintained lists, guaranteed drift.

## The fix

New leaf `src/teatree/agents/envelope_refusal.py` owns the whole refusal vocabulary — `NO_ENVELOPE_ERROR` (the runner now imports it instead of spelling it), the recorder markers, the classifiers, and a phase-accurate corrective instruction derived from `PHASE_REQUIRED_EVIDENCE` rather than a second hard-coded list.

Routing, in `_corrective_note`:

- **Runner-side `no_result_envelope`** is corrective on **any** phase — a pure output-format failure whose correction is phase-independent. It fires wherever `ProseSummaryPolicy.allowed` is False: phase not in `PHASE_REQUIRED_EVIDENCE` and not in `{scoping, retro}`. That set **includes `debugging`** (absent from `PHASE_REQUIRED_EVIDENCE`, `result_schema.py:412-424`, and from `PROSE_SUMMARY_ACCEPTED_PHASES`, `:436`) as well as the phases outside the `coding`/`debugging` pair (`architectural_review`, `bughunt`, `e2e`, the `codex_*` variants). So the widening genuinely changes behaviour on `debugging`, which previously escalated — deliberate, covered by `test_debugging_no_envelope_refusal_gets_one_corrective_retry`, and inside the original design intent since `debugging` was already in `_CORRECTIVE_PHASES`. The old gate left everything *but* `debugging` paging a human on the very first prose-only run.
- **Recorder-side** refusals keep their `_CORRECTIVE_PHASES` gate unchanged: on `reviewing`, a withheld verdict is a judgement to surface, not a format slip to re-run.

The retry stays bounded at exactly one, behind the [#2009](https://github.com/souliane/teatree/issues/2009) repair budget — the second identical refusal stops, parks the row, and surfaces a `DeferredQuestion`. Nothing loosens the refusal itself; unparsable output is still never recorded as success.

Also fixed along the way: the corrective note hard-coded `files_modified`, so a `debugging` retry was told to emit a key its phase does not require. It is now derived per phase.

## On the `exit=0`

Intentional, not a second defect. `_record_failure(task, exit_code=0, ...)` is deliberate — `TaskAttempt._classify_outcome` reads exit 0 as `REFUSAL` rather than `CRASH`. The process really did exit cleanly; the refusal is teatree's, on content.

## RED → GREEN

RED, before the fix (`tests/teatree_loop/test_no_envelope_corrective_retry.py`):

```
FAILED ...::test_debugging_no_envelope_refusal_gets_one_corrective_retry - assert 0 == 1
FAILED ...::test_no_envelope_refusal_is_corrective_on_any_phase - assert 0 == 1
FAILED ...::test_second_no_envelope_refusal_escalates_and_never_loops - assert 0 == 1
3 failed, 3 passed
```

`assert 0 == 1` is `requeue_transient_failed()` returning zero reopens — it escalated instead of retrying.

GREEN, after (new file + `test_headless_no_envelope_guard.py` + the untouched `test_transient_requeue.py`):

```
51 passed in 91.13s
```

The pre-existing `test_deterministic_non_coding_failure_is_escalated_not_retried` (a `planning` evidence refusal must NOT be corrective-retried) is unmodified and still green — the recorder-side phase gate is genuinely untouched.

## Drift guard

`test_headless_no_envelope_guard.py::test_recorded_refusal_is_classified_by_the_correcting_sweep` drives a real prose-only run through `run_headless` and asserts the refusal it *writes* is the refusal the correcting sweep *reads*, with a negative control (`AssertionError: expected 3 got 4` must not classify). The two strings can no longer drift apart silently.

## Second commit — the per-diff coverage gate's finding, taken seriously

The §17.6.3 gate flagged `is_no_envelope_refusal`, `is_recorder_refusal` and `required_keys_phrase` as reachable only indirectly (through `is_envelope_refusal` and `corrective_instruction`). It is right: the two seams carry different phase scopes in `_corrective_note`, so a change widening one could silently narrow the other with every existing assertion still green.

`tests/teatree_agents/test_envelope_refusal.py` gives each one a direct pin rather than a cosmetic import — every classifier carries a negative control (one that answered `True` to everything would otherwise satisfy each positive assertion), plus the cross-seam guard that the runner refusal is not a recorder refusal and vice versa. `required_keys_phrase` is pinned on a phase WITH evidence, one with several accepted fields, one WITHOUT (the phase the no-envelope refusal actually fires on), and an unknown phase.

```
15 passed in 2.06s
```

## Gates

`ruff check` / `ruff format` / `ty check` / `tach check` / `check_module_health.py` / `check_test_path_mirror.py` all green; full pre-commit hook chain green on every commit. `transient_requeue.py` goes 492 → 494 on the gate's own measure (non-blank, non-comment lines) against its 500 cap, so it stays under cap and the over-cap shrink-only rule never applies.

## Third commit — the review's two findings

**CI shard 3 was red on this diff**, and `tests/quality` is CI-only (excluded from the local push gate), which is why the green local run missed it. `test_incompleteness_marker_ratchet.py` found two markers in the new module against a peg of 0 — both heuristic false positives on prose describing shipped behaviour: "the brief was not honoured" trips `not-wired` (`not honou?red`), "survives a future change to the human-readable tail" trips `later-phase` (`a future change`). Both reworded. **No peg banked** — a peg here is a suppression under the no-tech-debt bar and would blunt the ratchet for every future file.

```
uv run pytest tests/quality/test_incompleteness_marker_ratchet.py -q
13 passed in 14.89s
```

**The reachability claim above was wrong in three places** — the bullet in this body, `_corrective_note`'s docstring, and a test comment that contradicted its own sibling one method above. All three now say what is true. The behaviour is unchanged and was never in question.

Two `tests/conformance` tests hit the 60s `pytest-timeout` during the push gate under heavy box load (6 concurrent `-n auto` suites, load avg ~46). Both pass in isolation and Tach reports both unaffected by this diff:

```
tests/conformance/test_registry_parity_roster.py::...::test_no_roster_entry_is_a_phantom_registry  1 passed in 64.54s
tests/conformance/test_user_settings_readers.py::...::test_tightening_catches_a_coincidentally_matched_dead_field  1 passed in 45.77s
[Tach] 1 test in 233 files unaffected by changes
```
