### PR TITLE
fix(privacy): require four octets so a version or doc section is not a private IP

### DIFF
--- a/scripts/privacy_scan.py
+++ b/scripts/privacy_scan.py
@@ -54,7 +54,11 @@ _EMAIL_RE = re.compile(
     re.ASCII,
 )
 _HOME_PATH_RE = re.compile(r"(?:/Users/|/home/)[a-zA-Z0-9_.-]+")
-_IP_RE = re.compile(r"\b(?:10|172\.(?:1[6-9]|2\d|3[01])|192\.168)\.\d{1,3}\.\d{1,3}\b")
+# Every branch must yield a FOUR-octet address. The ``10`` branch carries its own
+# second octet because ``10`` alone left it three-wide, so a three-component string
+# like a doc section reference or a three-part version string matched as a private
+# IP — and a real four-octet address matched only its first three octets.
+_IP_RE = re.compile(r"\b(?:10\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])|192\.168)\.\d{1,3}\.\d{1,3}\b")
 _API_KEY_RE = re.compile(r"\b(?:glpat-|sk-|ghp_|gho_|github_pat_|xoxb-|xoxp-)[a-zA-Z0-9_-]{10,}")
 _HOSTNAME_RE = re.compile(r"\b[a-z0-9-]+\.internal\.[a-z]+\b|\b[a-z0-9-]+\.corp\.[a-z]+\b")
 _FALSE_POSITIVE_RE = re.compile(r"example\.com|user@example|jane|bob|placeholder")

--- a/tests/test_privacy_scan_script.py
+++ b/tests/test_privacy_scan_script.py
@@ -489,3 +489,38 @@ class TestPrivacyScanDiffAddedLineScoping:
         result = _run(blob)
         assert result.returncode == PRIVACY_FINDINGS_EXIT_CODE, result.stdout + result.stderr
         assert "email" in result.stdout
+
+    def test_three_component_version_or_section_is_not_a_private_ip(self) -> None:
+        # A private IP has FOUR octets. The `10` branch of the matcher used to
+        # carry only three, so a doc section reference or a version string of
+        # the same shape was reported as a leaked address — and a real
+        # a real four-octet address matched only its first three octets. This
+        # blocked a real push over an unchanged doc section reference.
+        diff = (
+            "diff --git a/BLUEPRINT.md b/BLUEPRINT.md\n"
+            "--- a/BLUEPRINT.md\n"
+            "+++ b/BLUEPRINT.md\n"
+            "@@ -1,1 +1,2 @@\n"
+            " ctx = 1\n"
+            "+Config lives in appendix \u00a710.1.1, shipped since version 10.2.3.\n"  # privacy-scan:allow self-fixture
+        )
+        result = _run(diff)
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "private_ip" not in result.stdout
+
+    def test_a_real_private_ip_is_still_flagged_whole(self) -> None:
+        # The counterpart to the test above: narrowing the matcher must not
+        # stop it catching an actual address, and it must report all four
+        # octets rather than a truncated prefix.
+        diff = (
+            "diff --git a/x.py b/x.py\n"
+            "--- a/x.py\n"
+            "+++ b/x.py\n"
+            "@@ -1,1 +1,2 @@\n"
+            " ctx = 1\n"
+            '+HOST = "10.1.1.5"\n'  # privacy-scan:allow self-fixture
+        )
+        result = _run(diff)
+        assert result.returncode == PRIVACY_FINDINGS_EXIT_CODE, result.stdout + result.stderr
+        assert "private_ip" in result.stdout
+        assert "10.1.1.5" in result.stdout  # privacy-scan:allow self-fixture


### PR DESCRIPTION
## What

Narrows the private-IP matcher in `scripts/privacy_scan.py` so every branch requires a four-octet address, and adds two regression tests.

## Why

The matcher's first branch carried only three octets where the other two carried four:

```
(?:10|172\.(?:1[6-9]|2\d|3[01])|192\.168)\.\d{1,3}\.\d{1,3}
```

`172.16-31` and `192.168` each contribute two components and pick up two more, giving four. The bare first branch contributes one and picks up two, giving three. So it matched any three-part string of that shape — a document section reference, a three-part version number — and a genuine four-octet address in that range matched only its first three components, so findings were reported truncated.

## How it surfaced

It blocked a real push. A `BLUEPRINT.md` line was edited for an unrelated word; a pre-existing section reference elsewhere on that same line came along in the diff and tripped the gate. The diff did not introduce the text and did not change it — the line was simply touched.

The prescribed remedy on the failure message is to scrub the diff. Here that would mean mangling a correct section reference to satisfy a broken matcher.

## The fix

The first branch now carries its own second octet, so all three branches yield four components.

## Testing

Two regression tests in `tests/test_privacy_scan_script.py`, both observed RED against the old pattern:

```
FAILED …::test_three_component_version_or_section_is_not_a_private_ip
  - AssertionError: Privacy scan: 2 finding(s)
FAILED …::test_a_real_private_ip_is_still_flagged_whole
  - AssertionError: assert '10.1.1.5' in 'Privacy scan: 1 finding(s)…'
2 failed, 50 passed
```

The second is the important one: it fails on the OLD pattern not because nothing was detected, but because the finding was truncated to three octets. Narrowing the matcher had to keep genuine addresses caught, and caught whole.

GREEN after: `52 passed` in `tests/test_privacy_scan_script.py`, `88 passed` across that file plus `tests/test_refuse_public_push_with_leak.py`. `ruff check` clean.

## Self-fixture markers

Both new fixtures carry the existing `privacy-scan:allow` marker. That marker's own docstring states this is its purpose:

> used so a repo's own privacy-scanner test fixtures and the gate's own documentation examples do not self-block the public-repo privacy gate

The surrounding tests already use it the same way for a planted `/Users/...` path and a planted address.

## Note on the bootstrap

This fix could not validate itself at push time. The pre-push gate runs the **installed** scanner, not the branch's, so a change to a leak-gate matcher must satisfy the version it is replacing. Both the diff and the commit message had to avoid the literal shapes the old pattern over-matches.

That is worth recording as a property of the gate rather than of this change: a guard that reads from somewhere other than the change being gated cannot be fixed by the change it blocks. Same shape as a hook running under a different interpreter than the code it guards, and as a drift ledger pegging a bug that a sibling PR had already fixed.
