### PR TITLE
fix(intake): release a stalled marker and judge quota over every account

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -4354,10 +4354,16 @@ Usage: t3 loop reclaim-markers [OPTIONS]
  freeing intake budget.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --overlay        TEXT  Restrict to one overlay (default: reconcile every     │
-│                        overlay's markers).                                   │
-│ --json                 Emit the reconcile result as JSON.                    │
-│ --help                 Show this message and exit.                           │
+│ --overlay                   TEXT   Restrict to one overlay (default:         │
+│                                    reconcile every overlay's markers).       │
+│ --orphan-grace-hours        FLOAT  How long a ticket-less claim may linger   │
+│                                    before it is abandoned (default: 6). Pass │
+│                                    0 to free a claim stranded moments ago    │
+│                                    rather than waiting out the grace.        │
+│ --stall-grace-hours         FLOAT  How long a claim whose ticket stopped     │
+│                                    moving may hold its slot (default: 24).   │
+│ --json                             Emit the reconcile result as JSON.        │
+│ --help                             Show this message and exit.               │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -4053,8 +4053,8 @@ Usage: t3 loop [OPTIONS] COMMAND [ARGS]...
 │                  last fire, and next tick.                                   │
 │ intake-loops     Print each owner-intake loop name (never fleet-masked off), │
 │                  one per line, sorted.                                       │
-│ reclaim-markers  Release orphaned non-terminal markers whose ticket is       │
-│                  terminal/gone, freeing intake budget.                       │
+│ reclaim-markers  Release non-terminal markers whose ticket is terminal,      │
+│                  gone, or stalled, freeing intake budget.                    │
 │ pause            Pause a mini-loop durably (#1913) — EMERGENCY-only; prefer  │
 │                  presets/schedules or `loop override`.                       │
 │ resume           Resume a paused OR disabled mini-loop — EMERGENCY-only;     │
@@ -4350,8 +4350,8 @@ Usage: t3 loop intake-loops [OPTIONS]
 ```
 Usage: t3 loop reclaim-markers [OPTIONS]
 
- Release orphaned non-terminal markers whose ticket is terminal/gone, freeing
- intake budget.
+ Release non-terminal markers whose ticket is terminal, gone, or stalled,
+ freeing intake budget.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
 │ --overlay        TEXT  Restrict to one overlay (default: reconcile every     │

--- a/docs/generated/cli/representative-output.md
+++ b/docs/generated/cli/representative-output.md
@@ -156,8 +156,8 @@ Usage: t3 loop [OPTIONS] COMMAND [ARGS]...
 │                  last fire, and next tick.                                   │
 │ intake-loops     Print each owner-intake loop name (never fleet-masked off), │
 │                  one per line, sorted.                                       │
-│ reclaim-markers  Release orphaned non-terminal markers whose ticket is       │
-│                  terminal/gone, freeing intake budget.                       │
+│ reclaim-markers  Release non-terminal markers whose ticket is terminal,      │
+│                  gone, or stalled, freeing intake budget.                    │
 │ pause            Pause a mini-loop durably (#1913) — EMERGENCY-only; prefer  │
 │                  presets/schedules or `loop override`.                       │
 │ resume           Resume a paused OR disabled mini-loop — EMERGENCY-only;     │

--- a/src/teatree/cli/doctor/checks_loop.py
+++ b/src/teatree/cli/doctor/checks_loop.py
@@ -34,10 +34,11 @@ def _check_marker_jam() -> bool:
     """Warn when orphaned issue-markers strand the intake budget (#3275).
 
     The jam signature: non-terminal ``ImplementedIssueMarker`` rows whose ticket
-    is already terminal/gone — they never left ``dispatched`` (release-on-
-    completion only fires on the live transition), so they permanently consume
-    the ``issue_implementer_max_concurrent`` budget and no new issue is ever
-    claimed. Reads the non-mutating :meth:`find_stale` preview across every
+    is already terminal, gone, or stalled — they never left ``dispatched`` /
+    ``ticket_created`` (release-on-completion only fires on the live transition),
+    so they permanently consume the ``issue_implementer_max_concurrent`` budget
+    and no new issue is ever claimed. Reads the non-mutating :meth:`find_stale`
+    preview across every
     overlay. A WARN (never a hard FAIL): the loop self-heals each tick, and the
     operator can force it now with ``t3 loop reclaim-markers``. Crash-proof: any
     error degrades to OK so a doctor run never aborts on this check.
@@ -53,7 +54,7 @@ def _check_marker_jam() -> bool:
         return True
     typer.echo(
         f"WARN  {stale.released} orphaned issue-marker(s) hold intake budget but their tickets are "
-        f"terminal/gone ({len(stale.completed)} completed, {len(stale.abandoned)} abandoned) — "
+        f"terminal, gone, or stalled ({len(stale.completed)} completed, {len(stale.abandoned)} abandoned) — "
         "run `t3 loop reclaim-markers` to free the issue_implementer budget (#3275)."
     )
     return False

--- a/src/teatree/cli/loop/reclaim_markers.py
+++ b/src/teatree/cli/loop/reclaim_markers.py
@@ -25,7 +25,7 @@ def reclaim_markers_command(
     ),
     json_output: bool = typer.Option(False, "--json", help="Emit the reconcile result as JSON."),
 ) -> None:
-    """Release orphaned non-terminal markers whose ticket is terminal/gone, freeing intake budget."""
+    """Release non-terminal markers whose ticket is terminal, gone, or stalled, freeing intake budget."""
     ensure_django()
 
     from teatree.core.models import ImplementedIssueMarker  # noqa: PLC0415 — ORM import needs the app registry
@@ -48,5 +48,6 @@ def reclaim_markers_command(
     scope = f"overlay {overlay!r}" if overlay else "all overlays"
     typer.echo(
         f"Reclaimed {result.released} stale issue-marker(s) for {scope}: "
-        f"{len(result.completed)} completed (terminal ticket), {len(result.abandoned)} abandoned (gone ticket)."
+        f"{len(result.completed)} completed (terminal ticket), "
+        f"{len(result.abandoned)} abandoned (gone or stalled ticket)."
     )

--- a/src/teatree/cli/loop/reclaim_markers.py
+++ b/src/teatree/cli/loop/reclaim_markers.py
@@ -6,10 +6,18 @@ budget is stranded by orphaned ``dispatched`` markers had no CLI to free it. Thi
 wraps :meth:`ImplementedIssueMarker.objects.reconcile_stale` — the same
 retroactive path the loop runs each tick — so the budget can be freed by hand.
 
+Both graces the manager takes are exposed as options. Without them the command
+could only ever reproduce the tick's own verdict, so an operator staring at a
+claim stranded minutes ago had to wait out the six-hour grace with no way to say
+"I can see it is dead, release it now" — leaving raw SQL as the only lever, which
+is exactly what this command exists to replace.
+
 Split out of ``teatree.cli.loop.app`` (module-health cap, same rationale as the
 sibling ``claim_next`` / ``slack_answer`` splits) and registered flat on
 ``loop_app`` by that module.
 """
+
+import datetime as dt
 
 import typer
 
@@ -23,6 +31,17 @@ def reclaim_markers_command(
         "--overlay",
         help="Restrict to one overlay (default: reconcile every overlay's markers).",
     ),
+    orphan_grace_hours: float | None = typer.Option(
+        None,
+        "--orphan-grace-hours",
+        help="How long a ticket-less claim may linger before it is abandoned (default: 6). "
+        "Pass 0 to free a claim stranded moments ago rather than waiting out the grace.",
+    ),
+    stall_grace_hours: float | None = typer.Option(
+        None,
+        "--stall-grace-hours",
+        help="How long a claim whose ticket stopped moving may hold its slot (default: 24).",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit the reconcile result as JSON."),
 ) -> None:
     """Release non-terminal markers whose ticket is terminal, gone, or stalled, freeing intake budget."""
@@ -30,7 +49,11 @@ def reclaim_markers_command(
 
     from teatree.core.models import ImplementedIssueMarker  # noqa: PLC0415 — ORM import needs the app registry
 
-    result = ImplementedIssueMarker.objects.reconcile_stale(overlay)
+    result = ImplementedIssueMarker.objects.reconcile_stale(
+        overlay,
+        orphan_grace=None if orphan_grace_hours is None else dt.timedelta(hours=orphan_grace_hours),
+        stall_grace=None if stall_grace_hours is None else dt.timedelta(hours=stall_grace_hours),
+    )
     if json_output:
         import json  # noqa: PLC0415 — deferred: only the JSON path needs it
 

--- a/src/teatree/core/admission_governor.py
+++ b/src/teatree/core/admission_governor.py
@@ -252,16 +252,27 @@ def read_quota_signal(now: dt.datetime | None = None) -> QuotaSignal:
     """The cached per-account rate-limit health, folded into one signal.
 
     Reads the ``AnthropicTokenUsage`` cache the routing selector already maintains — no
-    network probe, no model. Only FRESH rows count: a stale cache yields
-    ``fresh=False``, which the decision treats as a fail-safe, not as headroom.
+    network probe, no model. The aggregate claims knowledge only when EVERY known
+    account's verdict is fresh; a partial sample yields ``fresh=False``, which the
+    decision treats as a fail-safe, not as headroom.
+
+    Requiring the WHOLE fleet rather than filtering to the fresh rows is what keeps the
+    aggregate unbiased. ``valid_until`` is the routing cache's "may I skip a re-probe?"
+    rule and is deliberately asymmetric by exhaustion — a healthy verdict lapses after
+    ``HEALTH_TTL`` (minutes), an exhausted one is trusted until its blocking window
+    resets (days). Filtering through it is survivorship bias: outside the minutes right
+    after a healthy probe the only surviving rows are the exhausted ones, so
+    ``all_accounts_exhausted`` reads True and the governor brakes the whole headless
+    lane while a healthy account still has most of its week. A lapsed verdict is
+    UNKNOWN, and no claim about "every account" survives an unknown.
     """
     from django.utils import timezone  # noqa: PLC0415 — deferred: Django app-registry read at call time
 
     from teatree.core.models.anthropic_token_usage import AnthropicTokenUsage  # noqa: PLC0415 — deferred: same
 
     moment = now or timezone.now()
-    rows = [row for row in AnthropicTokenUsage.objects.all() if row.is_fresh(moment)]
-    if not rows:
+    rows = list(AnthropicTokenUsage.objects.all())
+    if not rows or not all(row.is_fresh(moment) for row in rows):
         return QuotaSignal(
             fresh=False,
             all_accounts_exhausted=False,

--- a/src/teatree/core/models/implemented_issue_marker.py
+++ b/src/teatree/core/models/implemented_issue_marker.py
@@ -14,12 +14,14 @@ Mirrors :class:`teatree.core.models.red_mr_fix_attempt.RedMrFixAttempt`
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, ClassVar, TypedDict, Unpack
+from typing import TYPE_CHECKING, ClassVar, TypedDict, Unpack, cast
 
+from django.apps import apps
 from django.db import models
 from django.utils import timezone
 
 if TYPE_CHECKING:
+    from teatree.core.models.task import Task
     from teatree.core.models.ticket import Ticket
 
 #: A maintainer applies this label to withhold an issue from the autonomous
@@ -198,10 +200,10 @@ class ImplementedIssueMarkerManager(models.Manager["ImplementedIssueMarker"]):
         queued task holds the slot no matter how old the claim is, and a recent
         task holds it no matter how the last one ended.
         """
-        from teatree.core.models.task import Task  # noqa: PLC0415 — peer model, deferred to avoid load-time cycle
-
-        tasks = Task.objects.filter(ticket=ticket)
-        if tasks.filter(status__in=Task.Status.active()).exists():
+        # apps.get_model, not a direct import: task.py imports ticket.py at module scope (real cycle).
+        task_model = cast("type[Task]", apps.get_model("core", "Task"))
+        tasks = task_model.objects.filter(ticket=ticket)
+        if tasks.filter(status__in=task_model.Status.active()).exists():
             return False
         last_task_at = tasks.order_by("-created_at").values_list("created_at", flat=True).first()
         return max(marker.dispatched_at, last_task_at or marker.dispatched_at) <= cutoff

--- a/src/teatree/core/models/implemented_issue_marker.py
+++ b/src/teatree/core/models/implemented_issue_marker.py
@@ -14,10 +14,13 @@ Mirrors :class:`teatree.core.models.red_mr_fix_attempt.RedMrFixAttempt`
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import ClassVar, TypedDict, Unpack
+from typing import TYPE_CHECKING, ClassVar, TypedDict, Unpack
 
 from django.db import models
 from django.utils import timezone
+
+if TYPE_CHECKING:
+    from teatree.core.models.ticket import Ticket
 
 #: A maintainer applies this label to withhold an issue from the autonomous
 #: factory until they have reviewed it. The issue-implementer claim path
@@ -32,6 +35,16 @@ NEEDS_TRIAGE_LABEL = "needs-triage"
 #: legitimately in-flight one. Terminal-ticket markers are released regardless
 #: of age — this grace guards only the ticket-gone branch.
 _DEFAULT_ORPHAN_GRACE = timedelta(hours=6)
+
+#: How long a non-terminal marker whose ticket EXISTS but has stopped moving may
+#: hold its in-flight slot. The ticket-gone grace above cannot see this class:
+#: the ticket was created, then every task failed and none was re-queued, so the
+#: state freezes short of terminal and the marker is non-terminal forever. Enough
+#: of those and ``issue_implementer_max_concurrent`` is permanently exhausted, the
+#: intake scanner is never built, and the factory reads enabled while implementing
+#: nothing. A live ticket queues or claims a task far more often than daily, so a
+#: whole day of no task activity AND no active task is a dead attempt, not a slow one.
+_DEFAULT_STALL_GRACE = timedelta(hours=24)
 
 
 @dataclass(frozen=True, slots=True)
@@ -130,22 +143,31 @@ class ImplementedIssueMarkerManager(models.Manager["ImplementedIssueMarker"]):
         overlay: str = "",
         *,
         orphan_grace: timedelta | None = None,
+        stall_grace: timedelta | None = None,
     ) -> MarkerReconcileResult:
         """Classify — WITHOUT mutating — which non-terminal markers are reconcilable (#3275).
 
-        A marker is stale when its linked ticket (matched by ``issue_url``, the
-        canonical unique key the release signal also keys on) has reached a
-        terminal state (``Ticket.marker_release_states()`` → COMPLETED), or when
-        no ticket exists for its issue at all and it has outlived
-        ``orphan_grace`` (a stranded claim → ABANDONED). ``overlay=""`` spans
-        every overlay. The doctor jam-signature check reads this preview; the
-        loop and CLI mutate via :meth:`reconcile_stale`.
+        Three ways a marker stops being legitimately in flight, and each frees its
+        budget slot:
+
+        TERMINAL — its ticket reached a ``Ticket.marker_release_states()`` state → COMPLETED.
+        GONE — no ticket exists for its issue and it outlived ``orphan_grace`` → ABANDONED.
+        STALLED — its ticket exists but died past ``stall_grace`` (:meth:`_ticket_stalled`) → ABANDONED.
+
+        The third is the gap between the first two: a dispatch that got as far as
+        creating a ticket and then died leaves a non-terminal ticket forever, so
+        neither of the original branches can ever fire and the slot is held for
+        good. Tickets are matched by ``issue_url``, the canonical unique key the
+        release signal also keys on. ``overlay=""`` spans every overlay. The doctor
+        jam-signature check reads this preview; the loop and CLI mutate via
+        :meth:`reconcile_stale`.
         """
         from teatree.core.models.ticket import Ticket  # noqa: PLC0415 — peer model, deferred to avoid load-time cycle
 
-        grace = _DEFAULT_ORPHAN_GRACE if orphan_grace is None else orphan_grace
         terminal_states = Ticket.marker_release_states()
-        cutoff = timezone.now() - grace
+        now = timezone.now()
+        orphan_cutoff = now - (_DEFAULT_ORPHAN_GRACE if orphan_grace is None else orphan_grace)
+        stall_cutoff = now - (_DEFAULT_STALL_GRACE if stall_grace is None else stall_grace)
         non_terminal = self.exclude(state__in=ImplementedIssueMarker.State.terminal())
         if overlay:
             non_terminal = non_terminal.filter(overlay=overlay)
@@ -155,29 +177,52 @@ class ImplementedIssueMarkerManager(models.Manager["ImplementedIssueMarker"]):
         for marker in non_terminal.iterator():
             if not marker.issue_url:
                 continue
-            ticket_state = Ticket.objects.filter(issue_url=marker.issue_url).values_list("state", flat=True).first()
-            if ticket_state is not None:
-                if ticket_state in terminal_states:
-                    completed.append(marker.pk)
-            elif marker.dispatched_at <= cutoff:
+            ticket = Ticket.objects.filter(issue_url=marker.issue_url).only("pk", "state").first()
+            if ticket is None:
+                if marker.dispatched_at <= orphan_cutoff:
+                    abandoned.append(marker.pk)
+            elif ticket.state in terminal_states:
+                completed.append(marker.pk)
+            elif self._ticket_stalled(ticket, marker, cutoff=stall_cutoff):
                 abandoned.append(marker.pk)
         return MarkerReconcileResult(completed=tuple(completed), abandoned=tuple(abandoned))
+
+    @staticmethod
+    def _ticket_stalled(ticket: "Ticket", marker: "ImplementedIssueMarker", *, cutoff: datetime) -> bool:
+        """True when *ticket*'s attempt is DEAD rather than merely slow.
+
+        Dead means both halves: no task is still being worked (nothing PENDING or
+        CLAIMED will ever move it again), and the newest thing that happened to it
+        — its last task, or the claim itself when it never got one — predates
+        *cutoff*. Requiring both is what keeps a long-running attempt safe: a
+        queued task holds the slot no matter how old the claim is, and a recent
+        task holds it no matter how the last one ended.
+        """
+        from teatree.core.models.task import Task  # noqa: PLC0415 — peer model, deferred to avoid load-time cycle
+
+        tasks = Task.objects.filter(ticket=ticket)
+        if tasks.filter(status__in=Task.Status.active()).exists():
+            return False
+        last_task_at = tasks.order_by("-created_at").values_list("created_at", flat=True).first()
+        return max(marker.dispatched_at, last_task_at or marker.dispatched_at) <= cutoff
 
     def reconcile_stale(
         self,
         overlay: str = "",
         *,
         orphan_grace: timedelta | None = None,
+        stall_grace: timedelta | None = None,
     ) -> MarkerReconcileResult:
         """Release stale markers so the in-flight budget self-heals (#3275).
 
-        Terminal-ticket markers → COMPLETED, gone-ticket orphans past the grace
-        → ABANDONED (mirroring the give-up semantics ABANDONED already carries).
-        Idempotent: a second pass finds the just-released rows terminal and is a
-        no-op. Returns the same :class:`MarkerReconcileResult`
-        :meth:`find_stale` computes.
+        Terminal-ticket markers → COMPLETED; gone-ticket orphans past the grace and
+        stalled-ticket attempts past ``stall_grace`` → ABANDONED (mirroring the
+        give-up semantics ABANDONED already carries, so the issue becomes claimable
+        again through :meth:`claim`'s re-claim path). Idempotent: a second pass
+        finds the just-released rows terminal and is a no-op. Returns the same
+        :class:`MarkerReconcileResult` :meth:`find_stale` computes.
         """
-        result = self.find_stale(overlay, orphan_grace=orphan_grace)
+        result = self.find_stale(overlay, orphan_grace=orphan_grace, stall_grace=stall_grace)
         if result.completed:
             self.filter(pk__in=result.completed).update(state=ImplementedIssueMarker.State.COMPLETED)
         if result.abandoned:

--- a/tests/teatree_cli/test_cli_loop_reclaim_markers.py
+++ b/tests/teatree_cli/test_cli_loop_reclaim_markers.py
@@ -55,3 +55,32 @@ class TestReclaimMarkersCommand(TestCase):
 
         assert result.exit_code == 0, result.stdout
         assert "Reclaimed 0 stale issue-marker(s)" in result.stdout
+
+    def test_a_fresh_ticketless_claim_is_held_by_the_default_grace(self) -> None:
+        marker = ImplementedIssueMarkerFactory(overlay="acme", issue_url="https://github.com/o/r/issues/3")
+
+        result = runner.invoke(loop_app, ["reclaim-markers", "--overlay", "acme"])
+
+        assert result.exit_code == 0, result.stdout
+        marker.refresh_from_db()
+        assert marker.state == ImplementedIssueMarker.State.DISPATCHED
+
+    def test_a_zero_orphan_grace_frees_a_claim_stranded_moments_ago(self) -> None:
+        marker = ImplementedIssueMarkerFactory(overlay="acme", issue_url="https://github.com/o/r/issues/4")
+
+        result = runner.invoke(loop_app, ["reclaim-markers", "--overlay", "acme", "--orphan-grace-hours", "0"])
+
+        assert result.exit_code == 0, result.stdout
+        marker.refresh_from_db()
+        assert marker.state == ImplementedIssueMarker.State.ABANDONED
+
+    def test_an_explicit_stall_grace_frees_a_ticket_that_stopped_moving(self) -> None:
+        url = "https://github.com/o/r/issues/5"
+        TicketFactory(overlay="acme", issue_url=url, state=Ticket.State.PLANNED)
+        marker = ImplementedIssueMarkerFactory(overlay="acme", issue_url=url, ticket_created=True)
+
+        result = runner.invoke(loop_app, ["reclaim-markers", "--overlay", "acme", "--stall-grace-hours", "0"])
+
+        assert result.exit_code == 0, result.stdout
+        marker.refresh_from_db()
+        assert marker.state == ImplementedIssueMarker.State.ABANDONED

--- a/tests/teatree_core/models/test_implemented_issue_marker.py
+++ b/tests/teatree_core/models/test_implemented_issue_marker.py
@@ -12,9 +12,9 @@ from datetime import timedelta
 from django.test import TestCase
 from django.utils import timezone
 
-from teatree.core.models import ImplementedIssueMarker, Ticket
+from teatree.core.models import ImplementedIssueMarker, Task, Ticket
 from teatree.instance_id import instance_id
-from tests.factories import ImplementedIssueMarkerFactory, TicketFactory
+from tests.factories import ImplementedIssueMarkerFactory, TaskFactory, TicketFactory
 
 
 class TestClaim(TestCase):
@@ -228,3 +228,92 @@ class TestReconcileStale(TestCase):
         marker.refresh_from_db()
         assert marker.state == ImplementedIssueMarker.State.DISPATCHED
         assert result.completed == (marker.pk,)
+
+
+class TestReconcileStalledTicket(TestCase):
+    """A marker whose ticket EXISTS but died mid-pipeline must still release.
+
+    The #3275 reconciler covered only the two ends of the range — a ticket that
+    reached a terminal state, and a ticket that never existed. The gap between
+    them is a ticket that WAS created and then stopped: every task FAILED, none
+    pending, the state frozen short of terminal. Such a marker is non-terminal
+    forever, so it holds an in-flight slot for good; enough of them and
+    ``issue_implementer_max_concurrent`` is permanently exhausted and the intake
+    scanner is never even built — the factory reads enabled and implements
+    nothing.
+    """
+
+    def _stalled(self, url: str, *, state: str = Ticket.State.PLANNED, age_hours: int = 72) -> ImplementedIssueMarker:
+        ticket = TicketFactory(overlay="acme", issue_url=url, state=state)
+        task = TaskFactory(ticket=ticket, status=Task.Status.FAILED)
+        Task.objects.filter(pk=task.pk).update(created_at=timezone.now() - timedelta(hours=age_hours))
+        marker = ImplementedIssueMarkerFactory(overlay="acme", issue_url=url, ticket_created=True, ticket=ticket)
+        ImplementedIssueMarker.objects.filter(pk=marker.pk).update(
+            dispatched_at=timezone.now() - timedelta(hours=age_hours)
+        )
+        return ImplementedIssueMarker.objects.get(pk=marker.pk)
+
+    def test_abandons_marker_whose_ticket_stalled_past_grace(self) -> None:
+        marker = self._stalled("https://github.com/o/r/issues/200")
+
+        result = ImplementedIssueMarker.objects.reconcile_stale("acme")
+
+        marker.refresh_from_db()
+        assert marker.state == ImplementedIssueMarker.State.ABANDONED
+        assert result.abandoned == (marker.pk,)
+
+    def test_frees_the_in_flight_budget(self) -> None:
+        self._stalled("https://github.com/o/r/issues/201")
+        assert ImplementedIssueMarker.objects.in_flight_count("acme") == 1
+
+        ImplementedIssueMarker.objects.reconcile_stale("acme")
+
+        assert ImplementedIssueMarker.objects.in_flight_count("acme") == 0
+
+    def test_released_issue_is_claimable_again(self) -> None:
+        url = "https://github.com/o/r/issues/202"
+        self._stalled(url)
+
+        ImplementedIssueMarker.objects.reconcile_stale("acme")
+
+        assert ImplementedIssueMarker.objects.claim(url, "acme") is not None
+
+    def test_keeps_a_ticket_with_an_active_task(self) -> None:
+        url = "https://github.com/o/r/issues/203"
+        marker = self._stalled(url)
+        TaskFactory(ticket=marker.ticket, status=Task.Status.PENDING)
+
+        result = ImplementedIssueMarker.objects.reconcile_stale("acme")
+
+        marker.refresh_from_db()
+        assert marker.state == ImplementedIssueMarker.State.TICKET_CREATED
+        assert result.released == 0
+
+    def test_keeps_a_ticket_whose_work_is_recent(self) -> None:
+        marker = self._stalled("https://github.com/o/r/issues/204", age_hours=1)
+
+        result = ImplementedIssueMarker.objects.reconcile_stale("acme")
+
+        marker.refresh_from_db()
+        assert marker.state == ImplementedIssueMarker.State.TICKET_CREATED
+        assert result.released == 0
+
+    def test_keeps_a_taskless_ticket_within_the_dispatch_grace(self) -> None:
+        url = "https://github.com/o/r/issues/205"
+        TicketFactory(overlay="acme", issue_url=url, state=Ticket.State.STARTED)
+        marker = ImplementedIssueMarkerFactory(overlay="acme", issue_url=url)
+
+        result = ImplementedIssueMarker.objects.reconcile_stale("acme")
+
+        marker.refresh_from_db()
+        assert marker.state == ImplementedIssueMarker.State.DISPATCHED
+        assert result.released == 0
+
+    def test_find_stale_previews_the_stall_without_mutating(self) -> None:
+        marker = self._stalled("https://github.com/o/r/issues/206")
+
+        result = ImplementedIssueMarker.objects.find_stale("acme")
+
+        marker.refresh_from_db()
+        assert marker.state == ImplementedIssueMarker.State.TICKET_CREATED
+        assert result.abandoned == (marker.pk,)

--- a/tests/teatree_core/test_admission_governor.py
+++ b/tests/teatree_core/test_admission_governor.py
@@ -7,7 +7,11 @@ reason — a governor that denies silently recreates the class of bug that hid a
 merge loop for weeks.
 """
 
+import datetime as dt
+
 import pytest
+from django.test import TestCase
+from django.utils import timezone
 
 from teatree.agents import _headless_env
 from teatree.agents._headless_env import XDIST_WORKERS_VAR, with_test_worker_cap
@@ -21,6 +25,7 @@ from teatree.core.admission_governor import (
     read_machine_signal,
     weekly_pace,
 )
+from teatree.core.models.anthropic_token_usage import AnthropicTokenUsage
 
 _WEEK = 7 * 24 * 3600
 
@@ -236,3 +241,84 @@ class TestReadMachineSignal:
         signal = read_machine_signal()
         assert signal.load1 == pytest.approx(0.0)
         assert signal.cores >= 1
+
+
+class TestReadQuotaSignalFreshnessBias(TestCase):
+    """The fleet aggregate must not be computed over a sample biased by exhaustion.
+
+    ``AnthropicTokenUsage.valid_until`` is the ROUTING cache's "may I skip a
+    re-probe?" rule, and it is deliberately asymmetric: a healthy verdict lapses
+    after ``HEALTH_TTL`` (5 minutes) while an exhausted one is trusted until its
+    blocking window resets (days). Filtering the fleet aggregate through that same
+    rule is survivorship bias — outside the minutes right after a healthy probe the
+    ONLY surviving rows are the exhausted ones, so ``all_accounts_exhausted`` reads
+    True and the governor brakes the whole headless lane while a healthy account
+    sits at 39% weekly. The aggregate must claim knowledge only when it knows every
+    account; a partial sample is ``fresh=False``, which the decision fails OPEN on.
+    """
+
+    def _row(self, path: str, *, utilization_7d: float, status_7d: str, valid_for: dt.timedelta) -> None:
+        now = timezone.now()
+        AnthropicTokenUsage.objects.create(
+            pass_path=path,
+            utilization_5h=0.1,
+            utilization_7d=utilization_7d,
+            status_5h="allowed",
+            status_7d=status_7d,
+            reset_7d=now + dt.timedelta(days=3),
+            checked_at=now,
+            valid_until=now + valid_for,
+        )
+
+    def _healthy(self, path: str = "healthy", *, valid_for: dt.timedelta = dt.timedelta(minutes=5)) -> None:
+        self._row(path, utilization_7d=0.39, status_7d="allowed", valid_for=valid_for)
+
+    def _exhausted(self, path: str = "exhausted") -> None:
+        self._row(path, utilization_7d=1.0, status_7d="rejected", valid_for=dt.timedelta(days=2))
+
+    def test_a_lapsed_healthy_row_does_not_read_as_every_account_exhausted(self) -> None:
+        self._healthy(valid_for=dt.timedelta(minutes=-1))
+        self._exhausted()
+
+        signal = admission_governor.read_quota_signal()
+
+        assert signal.all_accounts_exhausted is False
+
+    def test_a_lapsed_healthy_row_does_not_brake_the_headless_lane(self) -> None:
+        self._healthy(valid_for=dt.timedelta(minutes=-1))
+        self._exhausted()
+
+        decision = decide_admission(
+            quota=admission_governor.read_quota_signal(), machine=_machine(), static_ceiling=None
+        )
+
+        assert decision.admit is True
+
+    def test_a_partial_sample_claims_no_knowledge(self) -> None:
+        self._healthy(valid_for=dt.timedelta(minutes=-1))
+        self._exhausted()
+
+        assert admission_governor.read_quota_signal().fresh is False
+
+    def test_every_account_fresh_and_exhausted_still_brakes(self) -> None:
+        self._exhausted("a")
+        self._exhausted("b")
+
+        signal = admission_governor.read_quota_signal()
+
+        assert signal.fresh is True
+        assert signal.all_accounts_exhausted is True
+        assert decide_admission(quota=signal, machine=_machine(), static_ceiling=None).admit is False
+
+    def test_a_fully_fresh_mixed_fleet_reports_the_healthy_account(self) -> None:
+        self._healthy()
+        self._exhausted()
+
+        signal = admission_governor.read_quota_signal()
+
+        assert signal.fresh is True
+        assert signal.all_accounts_exhausted is False
+        assert signal.weekly_utilization == pytest.approx(0.39)
+
+    def test_no_rows_at_all_still_reads_unknown(self) -> None:
+        assert admission_governor.read_quota_signal().fresh is False


### PR DESCRIPTION
## What

Two independent faults kept the autonomous factory from intaking any work. Both are fixed with regression tests.

1. `ImplementedIssueMarker.reconcile_stale` now releases a marker whose ticket **stalled**, not only one whose ticket is terminal or gone.
2. `AdmissionGovernor` judges fleet quota over **every** account rather than a sample biased toward exhausted ones.
3. `t3 loop reclaim-markers` can name its own grace periods, so a stranded claim can be freed immediately instead of waiting out a fixed window.

## Why

The factory looked healthy and did nothing. `issue_implementer` is enabled, leased, and ticks every 30 minutes; every tick logged `0 signal(s), 0 action(s)` with no stated reason.

### Fault 1 — the in-flight budget deadlocked

`_issue_intake_scanner_for` returned `None`, so discovery never ran at all. That is why there was no reason in the log: the scanner did not exist to log one.

```
gate1 issue_implementer_enabled : True
gate2 code_host                 : <GitHubCodeHost ...>
in_flight_count                 : 2
issue_implementer_max_concurrent: 2
can_claim                       : False   <- scanner is None, no job emitted
```

Two markers had sat in `ticket_created` since 2026-07-21/22. Their tickets **existed** but were frozen at `planned` with every coding task `failed` and none pending. `reconcile_stale` released only when a ticket was *terminal* or *gone* — a ticket that exists but has died matches neither branch, so those two slots were held permanently.

The budget is per-overlay and small (2), so two dead claims were enough to stop all intake indefinitely.

### Fault 2 — the governor braked on a biased sample

With the budget freed, the scanner built and found 42 candidates (25 admissible) — and every tick still refused. `read_quota_signal` filtered `AnthropicTokenUsage` rows through `row.is_fresh()`, but `valid_until` is the *routing* cache's "may I skip a re-probe?" rule, and it is asymmetric: a healthy reading lapses in 5 minutes, while an exhausted one is trusted until its window resets, which can be days.

So healthy accounts age out of the sample while exhausted ones persist, and the surviving sample says everything is exhausted. Same DB rows, four minutes apart:

```
17:32 (healthy row still fresh):   all_accounts_exhausted=False  admit=True
17:36 (healthy row's TTL expired): all_accounts_exhausted=True   admit=False
                                   "every account is quota-exhausted"
```

At that moment one account was rejected on its weekly window and the other sat at 39% weekly / 66% 5h. The fleet was fine; the sample was not.

This is self-resolving in the narrow sense — the bias only bites while one account is exhausted *and* another is healthy — but it silently converts a partial outage into a total one, which is the opposite of what a load brake is for.

## Verification

Regression tests added for all three changes (`test_implemented_issue_marker.py`, `test_admission_governor.py`, `test_cli_loop_reclaim_markers.py`).

Proven end to end on the live box after the fix:

```
ran loop 'issue_implementer' — 1 signal(s), 2 action(s)
INFO teatree.core.signals Auto-enqueued headless task 584 (phase=coding)
```

with the corresponding rows present in the live control DB — marker 54 (`issues/3855` → `ticket_created`), ticket 411 (`not_started`, feature), task 584 (phase `coding`, claimed by `headless-worker`).

## Claim budget is bounded

`issue_implementer_max_concurrent` is re-read per candidate inside `scan()`, so a tick cannot claim past the ceiling. Measured: with 2 slots free it claimed exactly 2; with 1 free, exactly 1. This matters because the box has been disk-constrained — an unbounded intake would be worse than an idle one.

## Live changes made during diagnosis

Recorded here so they are not invisible:

- Tickets 242 and 266 → `IGNORED`. Both issues are CLOSED on GitHub and already shipped, so these were dead attempts holding budget. Reversible via `unignore`.
- Two markers stranded by a read-probe were released through the same `reconcile_stale` seam the CLI wraps.
- `issue_implementer_max_concurrent` for `t3-teatree` was temporarily raised 2 → 3 to free a slot for the proof, then set back to 2.

## Follow-ups, not in this PR

- `issue_implementer_require_label` is set to `true` in the DB but is consumed nowhere in `src/`. Dead config that reads as a live gate.
- The MCP/ORM overlay filter returns an empty result set for an unknown overlay rather than erroring: `Ticket.objects.filter(overlay="teatree").count()` → 0, silently, versus 332 for `t3-teatree`. A typo becomes a confident wrong answer.
