### PR TITLE
fix(governor,loop): headroom reads the fresh subset; bound the reclaim graces at zero

### DIFF
--- a/docs/generated/cli-reference.md
+++ b/docs/generated/cli-reference.md
@@ -4354,16 +4354,21 @@ Usage: t3 loop reclaim-markers [OPTIONS]
  freeing intake budget.
 
 ╭─ Options ────────────────────────────────────────────────────────────────────╮
-│ --overlay                   TEXT   Restrict to one overlay (default:         │
-│                                    reconcile every overlay's markers).       │
-│ --orphan-grace-hours        FLOAT  How long a ticket-less claim may linger   │
-│                                    before it is abandoned (default: 6). Pass │
-│                                    0 to free a claim stranded moments ago    │
-│                                    rather than waiting out the grace.        │
-│ --stall-grace-hours         FLOAT  How long a claim whose ticket stopped     │
-│                                    moving may hold its slot (default: 24).   │
-│ --json                             Emit the reconcile result as JSON.        │
-│ --help                             Show this message and exit.               │
+│ --overlay                   TEXT                Restrict to one overlay      │
+│                                                 (default: reconcile every    │
+│                                                 overlay's markers).          │
+│ --orphan-grace-hours        FLOAT RANGE [x>=0]  How long a ticket-less claim │
+│                                                 may linger before it is      │
+│                                                 abandoned (default: 6). Pass │
+│                                                 0 to free a claim stranded   │
+│                                                 moments ago rather than      │
+│                                                 waiting out the grace.       │
+│ --stall-grace-hours         FLOAT RANGE [x>=0]  How long a claim whose       │
+│                                                 ticket stopped moving may    │
+│                                                 hold its slot (default: 24). │
+│ --json                                          Emit the reconcile result as │
+│                                                 JSON.                        │
+│ --help                                          Show this message and exit.  │
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 

--- a/src/teatree/cli/loop/reclaim_markers.py
+++ b/src/teatree/cli/loop/reclaim_markers.py
@@ -10,7 +10,9 @@ Both graces the manager takes are exposed as options. Without them the command
 could only ever reproduce the tick's own verdict, so an operator staring at a
 claim stranded minutes ago had to wait out the six-hour grace with no way to say
 "I can see it is dead, release it now" — leaving raw SQL as the only lever, which
-is exactly what this command exists to replace.
+is exactly what this command exists to replace. Zero is their floor: a negative
+grace moves the cutoff into the FUTURE, so it releases claims that are still in
+flight and re-dispatches the very issues this ledger exists to guard.
 
 Split out of ``teatree.cli.loop.app`` (module-health cap, same rationale as the
 sibling ``claim_next`` / ``slack_answer`` splits) and registered flat on
@@ -34,12 +36,14 @@ def reclaim_markers_command(
     orphan_grace_hours: float | None = typer.Option(
         None,
         "--orphan-grace-hours",
+        min=0,
         help="How long a ticket-less claim may linger before it is abandoned (default: 6). "
         "Pass 0 to free a claim stranded moments ago rather than waiting out the grace.",
     ),
     stall_grace_hours: float | None = typer.Option(
         None,
         "--stall-grace-hours",
+        min=0,
         help="How long a claim whose ticket stopped moving may hold its slot (default: 24).",
     ),
     json_output: bool = typer.Option(False, "--json", help="Emit the reconcile result as JSON."),

--- a/src/teatree/core/admission_governor.py
+++ b/src/teatree/core/admission_governor.py
@@ -69,8 +69,8 @@ YIELD_MIN_SAMPLES = 5
 class QuotaSignal:
     """Live model-quota headroom — the PRIMARY admission signal.
 
-    ``fresh`` is False when the cached rate-limit rows are absent or stale; the decision
-    then keeps the operator's static ceiling rather than trusting a guess.
+    ``fresh`` is False when no account's headroom is known; the decision then keeps the
+    operator's static ceiling rather than trusting a guess.
     Utilizations are the BEST (lowest) across usable accounts: the account selector
     already falls through to a non-exhausted account, so the governor asks what the
     healthiest remaining account has left, and ``all_accounts_exhausted`` is the
@@ -252,19 +252,24 @@ def read_quota_signal(now: dt.datetime | None = None) -> QuotaSignal:
     """The cached per-account rate-limit health, folded into one signal.
 
     Reads the ``AnthropicTokenUsage`` cache the routing selector already maintains — no
-    network probe, no model. The aggregate claims knowledge only when EVERY known
-    account's verdict is fresh; a partial sample yields ``fresh=False``, which the
-    decision treats as a fail-safe, not as headroom.
+    network probe, no model. Two questions with two different evidence bars:
 
-    Requiring the WHOLE fleet rather than filtering to the fresh rows is what keeps the
-    aggregate unbiased. ``valid_until`` is the routing cache's "may I skip a re-probe?"
-    rule and is deliberately asymmetric by exhaustion — a healthy verdict lapses after
-    ``HEALTH_TTL`` (minutes), an exhausted one is trusted until its blocking window
-    resets (days). Filtering through it is survivorship bias: outside the minutes right
-    after a healthy probe the only surviving rows are the exhausted ones, so
-    ``all_accounts_exhausted`` reads True and the governor brakes the whole headless
-    lane while a healthy account still has most of its week. A lapsed verdict is
-    UNKNOWN, and no claim about "every account" survives an unknown.
+    HEADROOM (utilization, pace, ceiling) comes from the FRESH, non-exhausted rows. A
+    usable account knows its own week whatever a lapsed peer is doing, so one unknown
+    row must not blank the pace brake and the adaptive ceiling.
+
+    EXHAUSTION (``all_accounts_exhausted``) needs the WHOLE fleet fresh, because it is a
+    claim about EVERY account and no such claim survives an unknown. The asymmetry is
+    forced by ``valid_until``, the routing cache's "may I skip a re-probe?" rule: a
+    healthy verdict lapses after ``HEALTH_TTL`` (minutes), an exhausted one is trusted
+    until its blocking window resets (days). So an exhausted row is fresh by
+    construction, and a STALE row means "not currently known-blocked" — safe to admit
+    against, never evidence that the fallthrough has nowhere left to go.
+
+    When no fresh row is usable and the fleet is not known-exhausted, the healthy
+    accounts' headroom is simply unknown: ``fresh=False``, and the decision keeps the
+    operator's static ceiling. Reporting the surviving exhausted row's 100% instead
+    would brake the lane on a row that proves nothing about the account being used.
     """
     from django.utils import timezone  # noqa: PLC0415 — deferred: Django app-registry read at call time
 
@@ -272,7 +277,10 @@ def read_quota_signal(now: dt.datetime | None = None) -> QuotaSignal:
 
     moment = now or timezone.now()
     rows = list(AnthropicTokenUsage.objects.all())
-    if not rows or not all(row.is_fresh(moment) for row in rows):
+    fresh_rows = [row for row in rows if row.is_fresh(moment)]
+    all_exhausted = bool(rows) and len(fresh_rows) == len(rows) and all(row.is_exhausted for row in rows)
+    sample = [row for row in fresh_rows if not row.is_exhausted] or (rows if all_exhausted else [])
+    if not sample:
         return QuotaSignal(
             fresh=False,
             all_accounts_exhausted=False,
@@ -280,14 +288,13 @@ def read_quota_signal(now: dt.datetime | None = None) -> QuotaSignal:
             short_utilization=0.0,
             seconds_to_weekly_reset=None,
         )
-    usable = [row for row in rows if not row.is_exhausted] or rows
-    best = min(usable, key=lambda row: row.utilization_7d)
+    best = min(sample, key=lambda row: row.utilization_7d)
     reset = best.reset_7d
     return QuotaSignal(
         fresh=True,
-        all_accounts_exhausted=all(row.is_exhausted for row in rows),
+        all_accounts_exhausted=all_exhausted,
         weekly_utilization=best.utilization_7d,
-        short_utilization=min(row.utilization_5h for row in usable),
+        short_utilization=min(row.utilization_5h for row in sample),
         seconds_to_weekly_reset=(reset - moment).total_seconds() if reset is not None else None,
     )
 

--- a/src/teatree/core/models/implemented_issue_marker.py
+++ b/src/teatree/core/models/implemented_issue_marker.py
@@ -199,13 +199,19 @@ class ImplementedIssueMarkerManager(models.Manager["ImplementedIssueMarker"]):
         *cutoff*. Requiring both is what keeps a long-running attempt safe: a
         queued task holds the slot no matter how old the claim is, and a recent
         task holds it no matter how the last one ended.
+
+        The newest task is read with ``Max``, not ``order_by("-created_at")``:
+        ``Task.created_at`` is nullable, and DESC ordering puts NULLs FIRST on
+        PostgreSQL (last on SQLite), so a single null-stamped row would make the
+        ordering read back ``None`` and drop the recency half entirely. ``Max``
+        ignores NULLs on every backend.
         """
         # apps.get_model, not a direct import: task.py imports ticket.py at module scope (real cycle).
         task_model = cast("type[Task]", apps.get_model("core", "Task"))
         tasks = task_model.objects.filter(ticket=ticket)
         if tasks.filter(status__in=task_model.Status.active()).exists():
             return False
-        last_task_at = tasks.order_by("-created_at").values_list("created_at", flat=True).first()
+        last_task_at = tasks.aggregate(latest=models.Max("created_at"))["latest"]
         return max(marker.dispatched_at, last_task_at or marker.dispatched_at) <= cutoff
 
     def reconcile_stale(

--- a/tests/teatree_cli/test_cli_loop_reclaim_markers.py
+++ b/tests/teatree_cli/test_cli_loop_reclaim_markers.py
@@ -84,3 +84,39 @@ class TestReclaimMarkersCommand(TestCase):
         assert result.exit_code == 0, result.stdout
         marker.refresh_from_db()
         assert marker.state == ImplementedIssueMarker.State.ABANDONED
+
+
+class TestNegativeGraceIsRejected(TestCase):
+    """A negative grace inverts the cutoff, so this command would abandon LIVE claims.
+
+    Freeing the double-dispatch guard is this command's entire job, so a cutoff
+    pushed into the FUTURE releases a claim that is still in flight — and the
+    issue is then dispatched a second time, which is exactly what the marker
+    exists to prevent. Both graces are bounded at zero so the mistake is a usage
+    error, not a silent ``Reclaimed 1``.
+    """
+
+    def setUp(self) -> None:
+        patcher = patch("teatree.cli.loop.reclaim_markers.ensure_django")
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_a_negative_stall_grace_is_refused(self) -> None:
+        url = "https://github.com/o/r/issues/6"
+        TicketFactory(overlay="acme", issue_url=url, state=Ticket.State.STARTED)
+        marker = ImplementedIssueMarkerFactory(overlay="acme", issue_url=url, ticket_created=True)
+
+        result = runner.invoke(loop_app, ["reclaim-markers", "--overlay", "acme", "--stall-grace-hours", "-48"])
+
+        assert result.exit_code != 0, result.stdout
+        marker.refresh_from_db()
+        assert marker.state == ImplementedIssueMarker.State.TICKET_CREATED
+
+    def test_a_negative_orphan_grace_is_refused(self) -> None:
+        marker = ImplementedIssueMarkerFactory(overlay="acme", issue_url="https://github.com/o/r/issues/7")
+
+        result = runner.invoke(loop_app, ["reclaim-markers", "--overlay", "acme", "--orphan-grace-hours", "-48"])
+
+        assert result.exit_code != 0, result.stdout
+        marker.refresh_from_db()
+        assert marker.state == ImplementedIssueMarker.State.DISPATCHED

--- a/tests/teatree_core/models/test_implemented_issue_marker.py
+++ b/tests/teatree_core/models/test_implemented_issue_marker.py
@@ -281,7 +281,8 @@ class TestReconcileStalledTicket(TestCase):
     def test_keeps_a_ticket_with_an_active_task(self) -> None:
         url = "https://github.com/o/r/issues/203"
         marker = self._stalled(url)
-        TaskFactory(ticket=marker.ticket, status=Task.Status.PENDING)
+        pending = TaskFactory(ticket=marker.ticket, status=Task.Status.PENDING)
+        Task.objects.filter(pk=pending.pk).update(created_at=timezone.now() - timedelta(hours=72))
 
         result = ImplementedIssueMarker.objects.reconcile_stale("acme")
 

--- a/tests/teatree_core/test_admission_governor.py
+++ b/tests/teatree_core/test_admission_governor.py
@@ -243,6 +243,28 @@ class TestReadMachineSignal:
         assert signal.cores >= 1
 
 
+def _usage_row(path: str, *, utilization_7d: float, status_7d: str, valid_for: dt.timedelta) -> None:
+    now = timezone.now()
+    AnthropicTokenUsage.objects.create(
+        pass_path=path,
+        utilization_5h=0.1,
+        utilization_7d=utilization_7d,
+        status_5h="allowed",
+        status_7d=status_7d,
+        reset_7d=now + dt.timedelta(days=3),
+        checked_at=now,
+        valid_until=now + valid_for,
+    )
+
+
+def _healthy_row(path: str = "healthy", *, valid_for: dt.timedelta = dt.timedelta(minutes=5)) -> None:
+    _usage_row(path, utilization_7d=0.39, status_7d="allowed", valid_for=valid_for)
+
+
+def _exhausted_row(path: str = "exhausted", *, valid_for: dt.timedelta = dt.timedelta(days=2)) -> None:
+    _usage_row(path, utilization_7d=1.0, status_7d="rejected", valid_for=valid_for)
+
+
 class TestReadQuotaSignalFreshnessBias(TestCase):
     """The fleet aggregate must not be computed over a sample biased by exhaustion.
 
@@ -257,36 +279,17 @@ class TestReadQuotaSignalFreshnessBias(TestCase):
     account; a partial sample is ``fresh=False``, which the decision fails OPEN on.
     """
 
-    def _row(self, path: str, *, utilization_7d: float, status_7d: str, valid_for: dt.timedelta) -> None:
-        now = timezone.now()
-        AnthropicTokenUsage.objects.create(
-            pass_path=path,
-            utilization_5h=0.1,
-            utilization_7d=utilization_7d,
-            status_5h="allowed",
-            status_7d=status_7d,
-            reset_7d=now + dt.timedelta(days=3),
-            checked_at=now,
-            valid_until=now + valid_for,
-        )
-
-    def _healthy(self, path: str = "healthy", *, valid_for: dt.timedelta = dt.timedelta(minutes=5)) -> None:
-        self._row(path, utilization_7d=0.39, status_7d="allowed", valid_for=valid_for)
-
-    def _exhausted(self, path: str = "exhausted") -> None:
-        self._row(path, utilization_7d=1.0, status_7d="rejected", valid_for=dt.timedelta(days=2))
-
     def test_a_lapsed_healthy_row_does_not_read_as_every_account_exhausted(self) -> None:
-        self._healthy(valid_for=dt.timedelta(minutes=-1))
-        self._exhausted()
+        _healthy_row(valid_for=dt.timedelta(minutes=-1))
+        _exhausted_row()
 
         signal = admission_governor.read_quota_signal()
 
         assert signal.all_accounts_exhausted is False
 
     def test_a_lapsed_healthy_row_does_not_brake_the_headless_lane(self) -> None:
-        self._healthy(valid_for=dt.timedelta(minutes=-1))
-        self._exhausted()
+        _healthy_row(valid_for=dt.timedelta(minutes=-1))
+        _exhausted_row()
 
         decision = decide_admission(
             quota=admission_governor.read_quota_signal(), machine=_machine(), static_ceiling=None
@@ -295,14 +298,14 @@ class TestReadQuotaSignalFreshnessBias(TestCase):
         assert decision.admit is True
 
     def test_a_partial_sample_claims_no_knowledge(self) -> None:
-        self._healthy(valid_for=dt.timedelta(minutes=-1))
-        self._exhausted()
+        _healthy_row(valid_for=dt.timedelta(minutes=-1))
+        _exhausted_row()
 
         assert admission_governor.read_quota_signal().fresh is False
 
     def test_every_account_fresh_and_exhausted_still_brakes(self) -> None:
-        self._exhausted("a")
-        self._exhausted("b")
+        _exhausted_row("a")
+        _exhausted_row("b")
 
         signal = admission_governor.read_quota_signal()
 
@@ -311,8 +314,8 @@ class TestReadQuotaSignalFreshnessBias(TestCase):
         assert decide_admission(quota=signal, machine=_machine(), static_ceiling=None).admit is False
 
     def test_a_fully_fresh_mixed_fleet_reports_the_healthy_account(self) -> None:
-        self._healthy()
-        self._exhausted()
+        _healthy_row()
+        _exhausted_row()
 
         signal = admission_governor.read_quota_signal()
 
@@ -322,3 +325,49 @@ class TestReadQuotaSignalFreshnessBias(TestCase):
 
     def test_no_rows_at_all_still_reads_unknown(self) -> None:
         assert admission_governor.read_quota_signal().fresh is False
+
+
+class TestReadQuotaSignalUsesTheFreshSubset(TestCase):
+    """A usable account's own numbers must survive a lapsed PEER row.
+
+    Whole-fleet freshness is the right bar for ``all_accounts_exhausted`` — that
+    claim is about every account, so an unknown row defeats it. It is the wrong
+    bar for the utilization the pace brake and the adaptive ceiling read: an
+    exhausted row is fresh BY CONSTRUCTION (``valid_until`` is its blocking-window
+    reset, days out) while a healthy one lapses in minutes, so on a small fleet
+    whole-fleet freshness is a coincidence and both mechanisms sit dark, silently
+    falling back to the static ceiling. A fresh, non-exhausted account knows its
+    own headroom regardless of what a lapsed peer is doing.
+    """
+
+    def test_a_fresh_healthy_account_reports_its_own_headroom(self) -> None:
+        _healthy_row()
+        _exhausted_row("lapsed", valid_for=dt.timedelta(minutes=-1))
+
+        signal = admission_governor.read_quota_signal()
+
+        assert signal.fresh is True
+        assert signal.all_accounts_exhausted is False
+        assert signal.weekly_utilization == pytest.approx(0.39)
+
+    def test_the_adaptive_ceiling_survives_a_lapsed_peer(self) -> None:
+        _healthy_row()
+        _exhausted_row("lapsed", valid_for=dt.timedelta(minutes=-1))
+
+        decision = decide_admission(
+            quota=admission_governor.read_quota_signal(), machine=_machine(cores=8), static_ceiling=8
+        )
+
+        assert decision.admit is True
+        assert decision.ceiling == 2
+
+    def test_the_pacing_brake_survives_a_lapsed_peer(self) -> None:
+        _usage_row("paced", utilization_7d=0.97, status_7d="allowed", valid_for=dt.timedelta(minutes=5))
+        _exhausted_row("lapsed", valid_for=dt.timedelta(minutes=-1))
+
+        decision = decide_admission(
+            quota=admission_governor.read_quota_signal(), machine=_machine(), static_ceiling=None
+        )
+
+        assert decision.admit is False
+        assert "pace" in decision.reason


### PR DESCRIPTION
## What

Three follow-ups to the [#3861](https://github.com/souliane/teatree/pull/3861) review, plus one hardening the reviewer flagged as unverified.

1. **`read_quota_signal` computes headroom from the fresh subset** (`src/teatree/core/admission_governor.py`). Only the `all_accounts_exhausted` claim still requires whole-fleet freshness.
2. **`test_keeps_a_ticket_with_an_active_task` now isolates the guard it names** — its PENDING task is back-dated past the stall grace. Production behaviour is unchanged.
3. **`--stall-grace-hours` / `--orphan-grace-hours` are bounded at `min=0`** (`src/teatree/cli/loop/reclaim_markers.py`), with the regenerated `docs/generated/cli-reference.md`.
4. **`_ticket_stalled` reads the newest task with `Max`**, not `order_by("-created_at")`.

## Why

**1.** #3861 gated `fresh=True` on whole-fleet freshness. But `valid_until` is asymmetric by construction: a healthy verdict lapses after `HEALTH_TTL` (~5 min) while an exhausted one is trusted until its blocking window resets (days). So an exhausted row is fresh almost always and a healthy one rarely — on a small fleet whole-fleet freshness is a coincidence, the weekly-pace brake and the adaptive ceiling sat dark, and the governor silently fell back to `static_ceiling`.

The split is the fix: a fresh, non-exhausted account knows its own week whatever a lapsed peer is doing, so headroom reads that subset. Claiming *every* account is exhausted is different in kind — it is a claim about the whole fleet, and no such claim survives an unknown row, so that one keeps the whole-fleet bar. The property this preserves is that a **stale** row means "not currently known-blocked", never evidence of exhaustion.

One consequence is deliberate: when no fresh row is usable *and* the fleet is not known-exhausted, the signal reports `fresh=False` rather than the surviving exhausted row's 100%. Reporting that 100% would brake the whole lane on a row that proves nothing about the account actually in use — the exact outage #3861 fixed, and `test_a_lapsed_healthy_row_does_not_brake_the_headless_lane` pins it.

**2.** The test created its PENDING task at `now`, so the *recency* half of `_ticket_stalled` passed it whether or not the active-task guard existed. Deleting the guard from production left the test green — it guarded nothing.

**3.** `--stall-grace-hours=-48` pushed the cutoff into the future, abandoned a zero-age marker on a STARTED ticket, and exited 0 with "Reclaimed 1". This is the one command whose entire job is to free the double-dispatch guard, so releasing a live claim causes exactly the double dispatch the marker exists to prevent.

**4.** `Task.created_at` is `auto_now_add` with `null=True`, and DESC ordering puts NULLs **first** on PostgreSQL (last on SQLite). One null-stamped row would read the newest task back as `None`, collapse `last_task_at` to the dispatch time, and drop the recent-task protection. `Max` ignores NULLs on every backend. Harmless on the SQLite prod config today, hence a hardening: **no test ships with it**, because no test could be observed RED on SQLite and a green-either-way test would be exactly the vacuity fixed in item 2.

## Verification

Every regression test was observed RED before its fix.

| Test | Pre-fix |
|---|---|
| `TestReadQuotaSignalUsesTheFreshSubset::test_a_fresh_healthy_account_reports_its_own_headroom` | `assert False is True` |
| `…::test_the_adaptive_ceiling_survives_a_lapsed_peer` | `assert 8 == 2` (fell back to the static ceiling) |
| `…::test_the_pacing_brake_survives_a_lapsed_peer` | `assert True is False` (brake dark) |
| `TestNegativeGraceIsRejected::test_a_negative_stall_grace_is_refused` | exit 0, "Reclaimed 1 stale issue-marker(s)" |
| `…::test_a_negative_orphan_grace_is_refused` | exit 0, "Reclaimed 1 stale issue-marker(s)" |

Item 2 is a vacuity fix, so it was proven by mutation instead — the active-task guard was deleted from `_ticket_stalled` and the test re-run in both shapes:

- guard removed + **as-shipped** test (task at `now`) → **GREEN** (the vacuity)
- guard removed + **back-dated** test → **RED** (`assert 'abandoned' == TICKET_CREATED`)
- guard restored + back-dated test → **GREEN**

Both named controls stay green: `test_every_account_fresh_and_exhausted_still_brakes` (an all-fresh all-exhausted fleet still refuses, same reason string) and `test_a_fully_fresh_mixed_fleet_reports_the_healthy_account`.

`bash dev/ci-parity-fast.sh` — **25269 passed, 62 skipped, 5 xfailed**; scoped prek, `makemigrations --check`, and the incremental push gate all clean.

## Orphaned `AnthropicTokenUsage` rows

Investigated, reporting rather than fixing. No prune path exists — `grep` finds no `.delete()` on the model anywhere. It is not a stuck-state generator, though: routing scopes to the configured candidate list (`PassPathSelector._all_configured_paths`), so an orphan is invisible to account selection and to `AllTokensExhaustedError`; and after this change an orphan can no longer blank `fresh`, only block a false `all_accounts_exhausted`, which is the safe direction. The residual is cosmetic: `teatree.dash.health_bands._account_utilizations` iterates every row, so a decommissioned account would render a permanently frozen band on the health page. A pruner needs a decommission signal and a decision about deleting operator data — bigger than this residue PR.

## Architecture pre-check

1. **BLUEPRINT §** — no contract change; `admission_governor` stays the single admission chokepoint, `reclaim_markers` the sanctioned unjam CLI.
2. **FSM** — none crossed. The marker's `DISPATCHED → ABANDONED` release is unchanged; only the CLI's accepted input range narrows.
3. **Extension points** — none. No `OverlayBase` hook, scanner registration, or Protocol touched.
4. **Component boundaries** — each fix lands in the module that owns the behaviour: the signal in `core/admission_governor.py`, the stall predicate in `core/models/`, the option bound in `cli/loop/`.
5. **Dependency direction** — no import added; `tach` and `import-linter` pass.
6. **Test surface** — five new assertions above, each observed RED; item 4 deliberately ships untested (see Why).
7. **Resilience** — no external write.
8. **Identity/keys** — none.
9. **Behavior preservation** — no matcher narrowed. The only behaviour removed is `read_quota_signal`'s fallback to exhausted rows when none is usable, replaced by an honest `fresh=False`; no must-block test was inverted, and both named controls stay green.
10. **Removability / harness-vs-data** — no new component. `min=0` is a bound on the harness's own input, not policy that belongs in data.
