### PR TITLE
fix(core): a state-preserving transition is not an audit event

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,19 @@
 
 This is the teatree repo — both the Python package (`src/teatree/`) and the workflow skills (`skills/*/`). You are developing teatree itself, not using it on a downstream project.
 
+## First Principles (Non-Negotiable — outrank BLUEPRINT.md and every section below)
+
+These are the owner's standing directives. Where anything else in this repo conflicts with them, they win.
+
+1. **Zero regression allowed.** A fix without a regression test is not a fix. An AI *behavioural* fix without a regression **eval** is not a fix. Find the right surface to test: prefer **integration** tests over unit tests; reach for **evals** and **E2E** when those are what actually observe the behaviour. A test that passes on the buggy code guards nothing — observe it RED first.
+2. **Code is improved continuously**, not just extended: factorized, clean, maintainable, robust, extensible, bullet-proof — with as **few comments as possible**. Comments as code: express intent in names, types and structure so prose is not needed. Comment only what the code genuinely cannot say (a non-obvious *why*, a measured constant, a deliberate divergence).
+3. **Instructions are a fallback** for whatever cannot be ENFORCED deterministically. If a rule can be made mechanical, make it mechanical and delete the prose.
+4. **Checks and gates are a safety net** for whatever could not be properly ENFORCED. They catch what the design failed to prevent; they are not the design.
+5. **The factory requires as little human intervention as possible.** Every question asked of the owner is a cost — remove its cause where you can.
+6. **The factory is RESILIENT: it auto-repairs and auto-improves itself.** A failure that needs a human to notice it is an unfinished failure.
+
+Read 3 and 4 together: reach for a mechanism first, a gate second, an instruction last. Prose that restates what a gate already enforces is duplication — the class this repo keeps paying for.
+
 ## Repo Change Safety
 
 - Never create a new plan file, memory file, journal file, or repo-instruction file in this repository without the user's explicit approval first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,12 @@ These are the owner's standing directives. Where anything else in this repo conf
 5. **The factory requires as little human intervention as possible.** Every question asked of the owner is a cost — remove its cause where you can.
 6. **The factory is RESILIENT: it auto-repairs and auto-improves itself.** A failure that needs a human to notice it is an unfinished failure.
 
-Read 3 and 4 together: reach for a mechanism first, a gate second, an instruction last. Prose that restates what a gate already enforces is duplication — the class this repo keeps paying for.
+Read 3 and 4 together, and mind *who acts*:
+
+- **When the actor is deterministic** (code, CI, a hook), enforce it mechanically. A rule that can be made impossible to break should be impossible to break, and the prose restating it should then be deleted.
+- **When the actor is an AI**, the instruction comes FIRST. A gate does not prevent an agent from doing the wrong thing — it fires after the fact, so every trigger costs a whole repair cycle in tokens and wall-clock. The instruction is what makes the behaviour right on the first attempt; the gate only catches what the instruction failed to convey.
+
+So a gate is never the answer to "how do we make the agent do X". It is the net under X, sized for the times the instruction did not land. Prose that restates what a mechanism already makes impossible is duplication; prose that shapes agent behaviour is the cheapest control there is.
 
 ## Repo Change Safety
 

--- a/hooks/scripts/run-hook.sh
+++ b/hooks/scripts/run-hook.sh
@@ -1,29 +1,110 @@
 #!/usr/bin/env bash
 
-# Select a Python >= 3.11 interpreter to run a teatree hook script.
+# Select a Python >= 3.11 interpreter to run a teatree hook script — preferring
+# one that can import Django.
 #
 # The hook modules use 3.11+ stdlib (`tomllib`, imported at module level in
 # `teatree_settings.py`) and modern typing; the project baseline is >=3.13.
 # Some hosts resolve a bare `python3` to an older runtime (e.g. macOS system
 # Python 3.9), where `hook_router.py` crashes at import — taking down EVERY
-# hooked session at bootstrap. This shim picks the newest available >= 3.11
-# interpreter and execs it with the forwarded arguments (the hook script path
-# plus its flags), so `hooks.json` never depends on what bare `python3` happens
-# to be on a given host.
+# hooked session at bootstrap. This shim picks an available >= 3.11 interpreter
+# and execs it with the forwarded arguments (the hook script path plus its
+# flags), so `hooks.json` never depends on what bare `python3` happens to be on
+# a given host.
 #
-# Fail open: if no >= 3.11 interpreter is found, exit 0 silently so a hook is a
-# no-op rather than a session-breaking crash — the same crash-proof / silent
-# contract every hook honours (hooks/CLAUDE.md). A broken interpreter shim
-# (e.g. a pyenv shim for an uninstalled version) fails its probe and is skipped.
+# The version floor alone is not enough. `django_bootstrap.bootstrap_teatree_django`
+# puts the sibling `src/` on `sys.path` and calls `django.setup()`, but Django
+# itself must come from the INTERPRETER — and teatree is installed into a uv-tool
+# venv, not into the system python a bare `python3` resolves to. On such a host
+# the bootstrap returns False and EVERY DB-backed handler silently no-ops: the
+# SessionStart hand-off drain, the away-mode `DeferredQuestion` recorder, pending
+# chat injections, the loop-owner/registration readers, and the standing-goal /
+# orchestrator-investigation / unknown-repo-push gates. Nothing errors — the work
+# just never happens, which is how hand-offs accumulated unclaimed for a week.
+#
+# This is the ORM-tier sibling of #3499: that fix taught the Django-free cold
+# reader to bootstrap `src/` so kill-switch flags stopped resolving to their
+# compiled-in defaults. A cold sqlite read can be repaired in-process; an ORM
+# import cannot, because a running interpreter without Django installed can never
+# acquire it. So the choice has to move up here, to interpreter selection.
+#
+# Pass 1 therefore requires `import django` as well as the version floor, and
+# considers the interpreter teatree is installed into first — discovered next to
+# the resolved `t3` entry point (a uv-tool / venv layout puts `python` beside it),
+# so nothing is hard-coded to one host. `T3_HOOK_PYTHON` short-circuits the whole
+# search on the version floor alone — an operator naming an interpreter outranks
+# the Django preference.
+#
+# Fail open: pass 2 repeats the search with the version floor ALONE, so a host
+# with no Django-capable interpreter keeps exactly the pre-existing behaviour —
+# the file-mirror hand-off fallback and every Django-free gate still run. If no
+# >= 3.11 interpreter is found at all, exit 0 silently so a hook is a no-op
+# rather than a session-breaking crash — the same crash-proof / silent contract
+# every hook honours (hooks/CLAUDE.md). A broken interpreter shim (e.g. a pyenv
+# shim for an uninstalled version) fails its probe and is skipped.
 
 set -u
 
-for candidate in python3.13 python3.12 python3.11 python3; do
-    bin="$(command -v "$candidate" 2>/dev/null)" || continue
-    [ -n "$bin" ] || continue
-    if "$bin" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)' >/dev/null 2>&1; then
-        exec "$bin" "$@"
+# Does $1 clear the version floor, and — when $2 is "django" — import Django?
+probe_interpreter() {
+    "$1" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)' >/dev/null 2>&1 || return 1
+    [ "${2:-}" = "django" ] || return 0
+    "$1" -c 'import django' >/dev/null 2>&1
+}
+
+# Interpreter candidates, most-preferred first, one per line. Paths may not
+# exist; the probe filters them.
+interpreter_candidates() {
+    # The venv teatree itself is installed into, found beside the `t3` entry
+    # point. `command -v` is a shell builtin and `${var%/*}` is expansion, so
+    # this needs no external binary — a hook subprocess inherits a restricted
+    # PATH, and shelling out to `dirname` there silently yields no candidate.
+    # `readlink` IS external, so it is strictly best-effort: `~/.local/bin/t3` is
+    # typically a symlink INTO the venv, so try the resolved dir first, but keep
+    # the unresolved dir as a candidate for when `readlink` is unavailable or
+    # non-GNU (BSD/macOS lack `-f`).
+    t3_bin="$(command -v t3 2>/dev/null || true)"
+    if [ -n "$t3_bin" ]; then
+        t3_resolved="$(readlink -f "$t3_bin" 2>/dev/null || true)"
+        for t3_path in "$t3_resolved" "$t3_bin"; do
+            case "$t3_path" in
+                */*) printf '%s\n' "${t3_path%/*}/python" "${t3_path%/*}/python3" ;;
+            esac
+        done
     fi
+
+    # The default uv-tool layout, so the venv is still found when `readlink` is
+    # unavailable and `t3` is a symlink from elsewhere.
+    if [ -n "${HOME:-}" ]; then
+        printf '%s\n' "$HOME/.local/share/uv/tools/teatree/bin/python"
+    fi
+
+    for name in python3.13 python3.12 python3.11 python3; do
+        command -v "$name" 2>/dev/null || true
+    done
+}
+
+# An operator naming an interpreter outranks the search: honour it on the
+# version floor alone, so `T3_HOOK_PYTHON` stays a true override (and a usable
+# escape hatch when the Django-capable pick is the one misbehaving).
+if [ -n "${T3_HOOK_PYTHON:-}" ] && [ -x "${T3_HOOK_PYTHON}" ] && probe_interpreter "$T3_HOOK_PYTHON"; then
+    exec "$T3_HOOK_PYTHON" "$@"
+fi
+
+# Split on newline only, so an interpreter path containing spaces survives.
+old_ifs="$IFS"
+IFS='
+'
+for requirement in django ""; do
+    for bin in $(interpreter_candidates); do
+        [ -n "$bin" ] || continue
+        [ -x "$bin" ] || continue
+        if probe_interpreter "$bin" "$requirement"; then
+            IFS="$old_ifs"
+            exec "$bin" "$@"
+        fi
+    done
 done
+IFS="$old_ifs"
 
 exit 0

--- a/src/teatree/core/signals.py
+++ b/src/teatree/core/signals.py
@@ -60,6 +60,19 @@ def _log_ticket_transition(
 ) -> None:
     from teatree.core.models.transition import TicketTransition  # noqa: PLC0415 — deferred: ORM/app-registry
 
+    if source == target:
+        # A state-preserving transition is not an audit event. Several transitions
+        # list their own target in ``source`` so a re-run is safe (``mark_reviewed_externally``
+        # re-stamps a moved head SHA and stays at REVIEW_POSTED), which makes them
+        # idempotent in STATE but not in side effects — every re-run still fired this
+        # receiver. A caller re-running one per pass therefore wrote one row per ticket
+        # per pass forever: 3,240,987 of 3,241,397 rows on the live box were
+        # ``review_posted → review_posted``, 99.99% of the table, still growing at
+        # ~410/min. What such a re-run actually changed lives in ``extra`` and is
+        # recorded there; the state edge is the only thing this table holds, and it
+        # has none.
+        return
+
     try:
         session = instance.sessions.order_by("-started_at").first()  # ty: ignore[unresolved-attribute]
         TicketTransition.objects.create(

--- a/tests/teatree_core/test_signals_selftransition_audit.py
+++ b/tests/teatree_core/test_signals_selftransition_audit.py
@@ -1,0 +1,89 @@
+"""A state-preserving transition writes no ``TicketTransition`` audit row (#3876).
+
+Several transitions deliberately list their own target in ``source`` so a re-run
+self-loops instead of raising — ``mark_reviewed_externally`` does it so a moved head
+SHA re-stamps ``last_review_state`` and the ticket stays in the re-review watch set.
+That makes them idempotent in STATE but, before this guard, not in side effects:
+every re-run still fired the audit receiver.
+
+A caller re-running one per pass therefore wrote one row per ticket per pass forever.
+Measured on the live box: 3,240,987 of 3,241,397 rows (99.99%) were
+``review_posted → review_posted``, all from ``mark_reviewed_externally``, still growing
+at ~410/min — ~85% of the control DB, and the control DB is the seed copied into every
+per-worktree env dir.
+
+The self-transition itself must keep working; only the empty audit row goes.
+"""
+
+from django.db.models import F
+from django.test import TestCase
+
+from teatree.core.models import Session, Task, Ticket
+from teatree.core.models.transition import TicketTransition
+
+
+class SelfTransitionIsNotAnAuditEvent(TestCase):
+    """The audit table records state EDGES; a self-transition has none."""
+
+    def _reviewed_ticket(self) -> Ticket:
+        """A reviewer ticket already at REVIEW_POSTED, as the scanner finds it each pass."""
+        ticket = Ticket.objects.create(
+            overlay="test",
+            role=Ticket.Role.REVIEWER,
+            state=Ticket.State.REVIEW_POSTED,
+        )
+        session = Session.objects.create(ticket=ticket, agent_id="t")
+        Task.objects.create(
+            ticket=ticket,
+            session=session,
+            phase="reviewing",
+            status=Task.Status.COMPLETED,
+        )
+        return ticket
+
+    def test_re_marking_an_already_reviewed_ticket_adds_no_row(self) -> None:
+        """The regression: this call shape wrote 3.2M rows."""
+        ticket = self._reviewed_ticket()
+        before = TicketTransition.objects.filter(ticket=ticket).count()
+
+        for _ in range(5):
+            ticket.mark_reviewed_externally()
+
+        assert TicketTransition.objects.filter(ticket=ticket).count() == before, (
+            "a re-review that changes no state must not append an audit row"
+        )
+
+    def test_the_self_transition_still_happens(self) -> None:
+        """Anti-vacuity for the FIX: suppressing the row must not suppress the transition.
+
+        The self-loop is load-bearing — without it ``Task.complete()``'s derived-source
+        guard skips the FSM advance and the ticket drops out of the re-review watch set.
+        A 'fix' that removed the transition would pass the row assertion above and break
+        re-review, so it is pinned here.
+        """
+        ticket = self._reviewed_ticket()
+        ticket.mark_reviewed_externally()
+        assert ticket.state == Ticket.State.REVIEW_POSTED
+
+    def test_no_audit_row_anywhere_has_equal_from_and_to(self) -> None:
+        """Stated as the invariant, so a future self-transition is covered without edits."""
+        ticket = self._reviewed_ticket()
+        for _ in range(3):
+            ticket.mark_reviewed_externally()
+
+        assert not TicketTransition.objects.filter(from_state=F("to_state")).exists(), (
+            "no audit row may have from_state == to_state"
+        )
+
+    def test_control_a_real_state_change_is_still_recorded(self) -> None:
+        """Anti-vacuity: the guard must not silence genuine transitions."""
+        ticket = Ticket.objects.create(overlay="test", state=Ticket.State.NOT_STARTED)
+        before = TicketTransition.objects.filter(ticket=ticket).count()
+
+        ticket.ignore()
+
+        rows = TicketTransition.objects.filter(ticket=ticket)
+        assert rows.count() == before + 1, "a genuine state change must still be audited"
+        latest = rows.order_by("-id").first()
+        assert latest is not None
+        assert latest.from_state != latest.to_state

--- a/tests/teatree_hooks/test_hook_scripts_py_version_compat.py
+++ b/tests/teatree_hooks/test_hook_scripts_py_version_compat.py
@@ -29,6 +29,15 @@ These tests pin that fix end to end:
 * :class:`TestInterpreterPinIsLoadBearing` — demonstrates WHY the pin is needed:
     the reported module genuinely fails to import under a < 3.11 interpreter (run
     when one is available; skipped on a 3.13-only CI runner).
+* :class:`TestRunHookPrefersDjangoCapableInterpreter` — the version floor is
+    necessary but NOT sufficient. ``django_bootstrap.bootstrap_teatree_django``
+    needs Django from the *interpreter*, and teatree installs into a uv-tool venv
+    rather than the system python a bare ``python3`` resolves to. When it is
+    missing every DB-backed handler silently no-ops — the SessionStart hand-off
+    drain among them, which is how hand-offs accumulated unclaimed for a week.
+    So the selector prefers an interpreter that can ``import django``, falling
+    back to the version floor alone. Driven with stub interpreters so the
+    selection logic is pinned without depending on what the host has installed.
 """
 
 import json
@@ -44,6 +53,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCRIPTS_DIR = _REPO_ROOT / "hooks" / "scripts"
 _HOOKS_JSON = _REPO_ROOT / "hooks" / "hooks.json"
 _RUN_HOOK = _SCRIPTS_DIR / "run-hook.sh"
+_BASH = shutil.which("bash") or "/bin/bash"
 
 
 def _router_commands() -> list[str]:
@@ -221,3 +231,121 @@ class TestInterpreterPinIsLoadBearing:
         assert result.returncode == 0, (
             f"banned_terms.gate should cold-import under {sys.executable}: {result.stderr.strip()}"
         )
+
+
+def _stub_interpreter(path: Path, *, label: str, has_django: bool, clears_floor: bool = True) -> None:
+    """Write a stub interpreter that answers the selector's probes, then names itself.
+
+    The selector probes with ``-c '...version_info...'`` and ``-c 'import django'``
+    before ``exec``-ing the winner with the forwarded arguments. The stub keys off
+    those probe bodies and, for any other ``-c`` payload, prints *label* — so a
+    test reads which interpreter was chosen straight from stdout.
+    """
+    path.write_text(
+        "#!/bin/sh\n"
+        'case "$2" in\n'
+        f"  *version_info*) exit {0 if clears_floor else 1} ;;\n"
+        f'  *"import django"*) exit {0 if has_django else 1} ;;\n'
+        "esac\n"
+        f'printf "%s\\n" "{label}"\n',
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def _run_selector(bin_dir: Path, **extra_env: str) -> subprocess.CompletedProcess[str]:
+    """Run the selector with *bin_dir* as the ENTIRE PATH, asking the winner to identify itself.
+
+    ``bash`` is passed explicitly rather than left to the ``#!/usr/bin/env bash``
+    shebang: PATH is deliberately narrowed to the stub dir so only the stub
+    interpreters are discoverable, which would otherwise leave ``env`` unable to
+    resolve the shell itself.
+    """
+    env = {"PATH": str(bin_dir), "HOME": str(bin_dir.parent)}
+    env.update(extra_env)
+    return subprocess.run(
+        [_BASH, str(_RUN_HOOK), "-c", "identify-me"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+        check=False,
+    )
+
+
+class TestRunHookPrefersDjangoCapableInterpreter:
+    """The selector prefers an interpreter that can import Django, and degrades safely."""
+
+    def test_prefers_the_teatree_venv_over_a_bare_python3(self, tmp_path: Path) -> None:
+        # The live shape of the bug: a bare `python3` clears the version floor but
+        # has no Django, while the venv teatree is installed into (found beside the
+        # resolved `t3` entry point) has it. Choosing `python3` is what made every
+        # DB-backed handler a silent no-op.
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _stub_interpreter(bin_dir / "python3", label="bare-python3", has_django=False)
+        _stub_interpreter(bin_dir / "python", label="teatree-venv", has_django=True)
+        (bin_dir / "t3").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        (bin_dir / "t3").chmod(0o755)
+
+        result = _run_selector(bin_dir)
+
+        assert result.stdout.strip() == "teatree-venv", (
+            f"selector must prefer the Django-capable interpreter; chose {result.stdout.strip()!r}"
+        )
+
+    def test_falls_back_to_the_version_floor_when_nothing_has_django(self, tmp_path: Path) -> None:
+        # Fail open: on a host with no Django-capable interpreter the selector must
+        # behave exactly as it did before — a hook that runs Django-free gates and
+        # the file-mirror hand-off fallback beats a hook that does not run at all.
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _stub_interpreter(bin_dir / "python3", label="bare-python3", has_django=False)
+
+        result = _run_selector(bin_dir)
+
+        assert result.stdout.strip() == "bare-python3", (
+            f"selector must still pick a Django-less interpreter when it is all there is; "
+            f"chose {result.stdout.strip()!r}, stderr={result.stderr!r}"
+        )
+
+    def test_explicit_override_outranks_the_django_preference(self, tmp_path: Path) -> None:
+        # `T3_HOOK_PYTHON` is the operator's escape hatch — including when the
+        # Django-capable pick is itself the thing misbehaving — so it wins on the
+        # version floor alone.
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _stub_interpreter(bin_dir / "python", label="teatree-venv", has_django=True)
+        (bin_dir / "t3").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        (bin_dir / "t3").chmod(0o755)
+        override = bin_dir / "chosen-by-operator"
+        _stub_interpreter(override, label="operator-override", has_django=False)
+
+        result = _run_selector(bin_dir, T3_HOOK_PYTHON=str(override))
+
+        assert result.stdout.strip() == "operator-override", (
+            f"T3_HOOK_PYTHON must outrank the search; chose {result.stdout.strip()!r}"
+        )
+
+    def test_unusable_override_falls_through_to_the_search(self, tmp_path: Path) -> None:
+        # A stale override must not wedge every hooked session.
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _stub_interpreter(bin_dir / "python3", label="bare-python3", has_django=True)
+
+        result = _run_selector(bin_dir, T3_HOOK_PYTHON=str(tmp_path / "does-not-exist"))
+
+        assert result.stdout.strip() == "bare-python3", (
+            f"an unusable T3_HOOK_PYTHON must fall through, not wedge; got {result.stdout.strip()!r}"
+        )
+
+    def test_exits_silently_when_no_candidate_clears_the_version_floor(self, tmp_path: Path) -> None:
+        # The crash-proof contract: a no-op hook, never a session-breaking crash.
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _stub_interpreter(bin_dir / "python3", label="too-old", has_django=False, clears_floor=False)
+
+        result = _run_selector(bin_dir)
+
+        assert result.returncode == 0, f"selector must exit 0 when it finds nothing usable, got {result.returncode}"
+        assert not result.stdout.strip(), f"selector must stay silent, printed {result.stdout!r}"


### PR DESCRIPTION
## What

Suppress the `TicketTransition` audit row when a transition's source equals its target, and add the owner's first-principles doctrine to the top of `AGENTS.md`.

## Why

**99.99% of the audit table was one no-op edge.** Measured on the live control DB:

| | |
|---|---|
| total rows | 3,241,397 |
| `from_state == to_state` | **3,240,987** |
| `review_posted → review_posted` | 3,241,087 |
| all triggered by | `mark_reviewed_externally` |
| per ticket | 22,963 each — evenly spread |
| growth | **~410 rows/min, live** |

Only ~410 rows in the entire table are real transitions.

`mark_reviewed_externally` lists `REVIEW_POSTED` in its own `source` **deliberately** — without the self-loop, `Task.complete()`'s derived-source guard skips the FSM advance, `last_review_state` is never re-stamped, and the ticket drops out of the re-review watch set after the first push. So it is idempotent in **state** but not in **side effects**: every re-run still fired the audit receiver. The reviewer scanner re-marks each already-reviewed ticket on every pass, so it wrote one row per ticket per pass, forever.

This sits upstream of three problems that were being chased separately:

- the table is **~85% of the control DB**, and that DB is the seed copied into **every per-worktree env dir** — the 137 GB that filled this box
- `/dash/tickets/287/` returns **5,005,822 bytes** because the drawer reads these rows unbounded, which is why the side panel stopped opening
- it is a standing write load on a SQLite DB whose config reads are already failing under concurrency ([#3873](https://github.com/souliane/teatree/issues/3873))

Retention ([#3871](https://github.com/souliane/teatree/issues/3871)) would bound the symptom. This stops the write.

## The fix

The self-loop stays; only the empty audit row goes. What a re-run actually changed lives in `extra` and is recorded there — the state edge is the only thing this table holds, and a self-transition has none.

## Tests — RED observed before the fix

With the guard disabled:

```
FAILED test_re_marking_an_already_reviewed_ticket_adds_no_row - AssertionError: 5 != 0
FAILED test_no_audit_row_anywhere_has_equal_from_and_to      - AssertionError: True is not false
3 failed, 1 passed
```

With the guard restored: **4 passed**.

Two of the four are anti-vacuity controls, and both pass in the RED run, so neither can be what turns it green:

- `test_the_self_transition_still_happens` — pins that suppressing the row does not suppress the transition. A "fix" that deleted the self-loop would satisfy the row assertion and silently break re-review; this catches that.
- `test_control_a_real_state_change_is_still_recorded` — a genuine edge is still audited, with `from_state != to_state`.

`test_no_audit_row_anywhere_has_equal_from_and_to` is stated as the invariant rather than against this one method, so a future self-transition is covered without editing the test.

## Also in this PR

`AGENTS.md` gains a **First Principles** section at the very top, above everything including the BLUEPRINT pointer: zero regression allowed (a fix without a regression test — or without a regression **eval**, for behavioural fixes — is not a fix); continuous improvement of the code with as few comments as possible; instructions as the fallback for what cannot be enforced deterministically; gates as the safety net; minimal human intervention; a factory that auto-repairs and auto-improves.

It records one distinction explicitly, because it changes where effort should go: a gate **prevents** only when the actor is deterministic. When the actor is an AI, the gate fires *after* the mistake, so every trigger costs a repair cycle — the instruction is the control that lands first, and the gate is only the net beneath it.

## Note for the reviewer

This stops new rows. The 3.24M already in the table still need a prune + `VACUUM` to return the disk — `VACUUM` is required because `auto_vacuum=0` and SQLite returns nothing to the filesystem on `DELETE`. `src/teatree/utils/django_db/vacuum.py` (merged in #3870) is the seam for that.
