### PR TITLE
fix(config): a stored row's label claims only what the classifier can prove (#3862)

### DIFF
--- a/src/teatree/config/stored_row_health.py
+++ b/src/teatree/config/stored_row_health.py
@@ -14,11 +14,18 @@ and each needs its own answer:
 
 *   a RENAMED key's value still resolves, onto the replacement field, so it is told
     where its value goes rather than reported out of effect;
-*   an :data:`INTERNAL_STATE_KEYS` row is live runtime state a module reads and
-    writes, deliberately kept in ``ConfigSetting`` rather than its own table — the
-    "clear this" remedy would destroy working state, so it is never offered;
+*   an :data:`INTERNAL_STATE_KEYS` row has a live owner module that reads and writes
+    it, deliberately kept in ``ConfigSetting`` rather than a declared setting field —
+    the "clear this" remedy would destroy working state, so it is never offered;
 *   everything else is an orphan: the removal was never recorded in
     ``RETIRED_SETTINGS``, so the row is named unknown and the remedy is offered.
+
+The negative bucket says only what the classifier can support. Membership in
+:data:`ALL_KNOWN_CONFIG_SETTINGS` answers "is this a DECLARED setting", never "does
+anything read it", and #3867 shipped it claiming the latter: three keys with live
+consumers — ``approval_dial``, ``default_mode``, ``presence_upgrade_mode`` — rendered
+as "no live consumer" beside a destructive remedy, and following it un-graduates every
+approval class and resets the mode ladder.
 """
 
 import dataclasses
@@ -29,13 +36,19 @@ from teatree.config.retired_settings import CLEAR_REMEDY, RENAMED_SETTING_KEYS, 
 
 @dataclasses.dataclass(frozen=True, slots=True)
 class InternalStateKey:
-    """A ``ConfigSetting`` row that is runtime STATE, not an operator-facing setting.
+    """A ``ConfigSetting`` row a live module owns, rather than a declared setting.
 
     *owner* is a dotted module path held as a STRING: the config layer sits below
     every module that keeps state this way, so importing one would be a backwards
     edge. ``tests/teatree_config/test_stored_row_health.py`` reads the named module
     and fails if the key no longer appears in it, so the carve-out cannot rot into
-    the dead config it exists to prevent.
+    the dead config it exists to prevent; ``tests/conformance/
+    test_config_key_classification.py`` walks the inverse direction, failing when a
+    key ``src/`` stores lands in no bucket at all.
+
+    The owner is the module the key BELONGS to — the one carrying its constant. A
+    different module may do the writing (an operator command, an admin action), which
+    is why the note names an owner rather than a writer.
     """
 
     key: str
@@ -48,6 +61,21 @@ INTERNAL_STATE_KEYS: tuple[InternalStateKey, ...] = (
         key="loop_preset_transition_stamp",
         owner="teatree.loops.preset_transitions",
         purpose="the last-applied mode name each transition pass compares against",
+    ),
+    InternalStateKey(
+        key="approval_dial",
+        owner="teatree.core.models.approval_dial",
+        purpose="the per-action-class approval trust table `effective_decision` reads at ask-time",
+    ),
+    InternalStateKey(
+        key="default_mode",
+        owner="teatree.core.mode_resolution",
+        purpose="the preset the L0 mode layer resolves when no override or schedule applies",
+    ),
+    InternalStateKey(
+        key="presence_upgrade_mode",
+        owner="teatree.core.mode_resolution",
+        purpose="the preset a fresh presence signal upgrades a schedule/default mode to",
     ),
 )
 
@@ -66,19 +94,23 @@ def stored_row_note(key: str) -> str:
     orphaned key. Naming a live internal-state row "clearable" would hand the operator
     a destructive instruction — clearing the mode stamp makes the next transition pass
     read a switch that never happened.
+
+    The final bucket claims only undeclaredness. The classifier reads registries, so
+    "no declaration owns this key" is everything it can prove; "nothing reads it" is a
+    claim about the call graph it never consults.
     """
     if key in ALL_KNOWN_CONFIG_SETTINGS:
         return ""
     state = internal_state_key(key)
     if state is not None:
-        return f"[internal state — {state.purpose}, written by {state.owner}]"
+        return f"[internal state — {state.purpose}, owned by {state.owner}]"
     replacement = RENAMED_SETTING_KEYS.get(key)
     if replacement is not None:
         return f"[retired alias — resolves onto {replacement}]"
     remedy = CLEAR_REMEDY.format(key=key)
     if removed_setting(key) is not None:
         return f"[retired — not in effect; clear with `{remedy}`]"
-    return f"[unknown — no live consumer; clear with `{remedy}`]"
+    return f"[unknown — not a declared setting; clear with `{remedy}`]"
 
 
 __all__ = ["INTERNAL_STATE_KEYS", "InternalStateKey", "internal_state_key", "stored_row_note"]

--- a/tests/conformance/test_config_key_classification.py
+++ b/tests/conformance/test_config_key_classification.py
@@ -1,0 +1,231 @@
+"""Every ``ConfigSetting`` key ``src/`` names is CLASSIFIED — the inverse walk (#3862/#3867).
+
+``tests/teatree_config/test_stored_row_health.py`` guards the carve-out in ONE
+direction: an :data:`INTERNAL_STATE_KEYS` entry whose owner module stopped carrying
+its key fails, so an exemption cannot rot into the dead config it exists to prevent.
+Nothing guarded the other direction, and that is where the #3867 regression lived: a
+key a live module reads and writes but nobody DECLARED falls through every bucket and
+renders as ``[unknown — not a declared setting; clear with …]`` — a destructive remedy
+printed beside a security-relevant row. ``approval_dial``, ``default_mode`` and
+``presence_upgrade_mode`` all shipped with that label; following it un-graduates every
+approval class and resets the mode ladder.
+
+The walk derives the key set from the code, never a hand-list, so a NEW undeclared key
+fails the PR that introduces it. A key counts when a literal reaches the store's
+read/write API — :class:`~teatree.core.models.config_setting.ConfigSettingManager`'s
+``get_effective`` / ``set_value`` / ``seed`` / ``clear``, or the cold reader's
+``read_setting`` — through one of three resolutions: the literal itself, a module-level
+constant (in that module or imported from another), or a same-module helper's parameter
+whose callers pass such a constant. A key assembled at runtime from a model field, a
+dataclass attribute or operator input is dynamic and out of scope; those surfaces render
+the note for whatever row they find rather than naming a key of their own.
+"""
+
+import ast
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+from teatree.config import ALL_KNOWN_CONFIG_SETTINGS
+from teatree.config.retired_settings import REMOVED_SETTING_KEYS, RENAMED_SETTING_KEYS
+from teatree.config.stored_row_health import INTERNAL_STATE_KEYS
+
+_SRC_DIR = Path(__file__).resolve().parents[2] / "src" / "teatree"
+
+#: The store's read/write API. A literal reaching any of these IS a stored-row key.
+_ACCESSORS = frozenset({"get_effective", "set_value", "seed", "clear", "read_setting"})
+
+#: The modules DEFINING those accessors — their own ``key`` parameter is the API's
+#: signature, not a key this tree names.
+_ACCESSOR_DEFINITIONS = frozenset({"teatree.config.cold_reader", "teatree.core.models.config_setting"})
+
+#: How far a constant may be chased through re-exporting modules before the scan gives
+#: up. Deep enough for the deepest real chain (a key defined once and imported twice).
+_MAX_IMPORT_HOPS = 4
+
+type _Sites = dict[str, set[str]]
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigKeyScan:
+    """The ``ConfigSetting`` keys ``src/teatree`` names, and the ``module:line`` naming each."""
+
+    trees: dict[str, ast.Module]
+    constants: dict[str, dict[str, str]]
+    imports: dict[str, dict[str, tuple[str, str]]]
+
+    @classmethod
+    def of_src(cls) -> "ConfigKeyScan":
+        trees = {
+            _dotted_path(path): ast.parse(path.read_text(encoding="utf-8")) for path in sorted(_SRC_DIR.rglob("*.py"))
+        }
+        return cls(
+            trees=trees,
+            constants={module: _module_constants(tree) for module, tree in trees.items()},
+            imports={module: _module_imports(tree) for module, tree in trees.items()},
+        )
+
+    def resolve_constant(self, module: str, name: str, hops: int = 0) -> str | None:
+        """The string *name* holds in *module*, chased through re-exporting imports."""
+        own = self.constants.get(module, {}).get(name)
+        if own is not None:
+            return own
+        source = self.imports.get(module, {}).get(name)
+        if source is None or hops >= _MAX_IMPORT_HOPS:
+            return None
+        return self.resolve_constant(source[0], source[1], hops + 1)
+
+    def keys(self) -> _Sites:
+        sites: _Sites = {}
+        for module, tree in self.trees.items():
+            if module in _ACCESSOR_DEFINITIONS:
+                continue
+            for call in _accessor_calls(tree):
+                for key in self._resolve_key(module, tree, call):
+                    sites.setdefault(key, set()).add(f"{module}:{call.lineno}")
+        return sites
+
+    def _resolve_key(self, module: str, tree: ast.Module, call: ast.Call) -> set[str]:
+        argument = _key_argument(call)
+        if isinstance(argument, ast.Constant) and isinstance(argument.value, str):
+            return {argument.value}
+        if not isinstance(argument, ast.Name):
+            return set()
+        direct = self.resolve_constant(module, argument.id)
+        if direct is not None:
+            return {direct}
+        return self._resolve_through_callers(module, tree, call, argument.id)
+
+    def _resolve_through_callers(self, module: str, tree: ast.Module, call: ast.Call, name: str) -> set[str]:
+        """The constants same-module callers bind to the enclosing helper's *name* parameter.
+
+        ``mode_resolution._setting_name(DEFAULT_MODE_SETTING, …)`` is the shape: the
+        helper reads whatever key it is handed, so the keys live at its call sites.
+        """
+        helper = _enclosing_function(tree, call)
+        if helper is None:
+            return set()
+        position = _parameter_position(helper, name)
+        if position is None:
+            return set()
+        resolved: set[str] = set()
+        for bound in _arguments_bound_to(tree, helper.name, position=position, keyword=name):
+            if isinstance(bound, ast.Constant) and isinstance(bound.value, str):
+                resolved.add(bound.value)
+            elif isinstance(bound, ast.Name):
+                value = self.resolve_constant(module, bound.id)
+                if value is not None:
+                    resolved.add(value)
+        return resolved
+
+
+def _dotted_path(path: Path) -> str:
+    parts = list(path.relative_to(_SRC_DIR.parent).with_suffix("").parts)
+    return ".".join(parts[:-1] if parts[-1] == "__init__" else parts)
+
+
+def _module_constants(tree: ast.Module) -> dict[str, str]:
+    constants: dict[str, str] = {}
+    for node in tree.body:
+        value = node.value if isinstance(node, ast.Assign | ast.AnnAssign) else None
+        if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        for target in targets:
+            if isinstance(target, ast.Name):
+                constants[target.id] = value.value
+    return constants
+
+
+def _module_imports(tree: ast.Module) -> dict[str, tuple[str, str]]:
+    """``{local_name: (source_module, original_name)}`` for every absolute ``from`` import.
+
+    Walks the whole tree, not just its body: teatree defers ORM imports into function
+    bodies, and those are exactly the modules that read the store.
+    """
+    imports: dict[str, tuple[str, str]] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            for alias in node.names:
+                imports[alias.asname or alias.name] = (node.module, alias.name)
+    return imports
+
+
+def _accessor_calls(tree: ast.Module) -> Iterator[ast.Call]:
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        callee = node.func
+        if (
+            isinstance(callee, ast.Attribute)
+            and callee.attr in _ACCESSORS
+            and "ConfigSetting" in ast.unparse(callee.value)
+        ) or (isinstance(callee, ast.Name) and callee.id in _ACCESSORS):
+            yield node
+
+
+def _key_argument(call: ast.Call) -> ast.expr | None:
+    if call.args:
+        return call.args[0]
+    return next((keyword.value for keyword in call.keywords if keyword.arg == "key"), None)
+
+
+def _enclosing_function(tree: ast.Module, target: ast.AST) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and any(
+            child is target for child in ast.walk(node)
+        ):
+            return node
+    return None
+
+
+def _parameter_position(function: ast.FunctionDef | ast.AsyncFunctionDef, name: str) -> int | None:
+    positional = [argument.arg for argument in function.args.args]
+    if name in positional:
+        return positional.index(name)
+    return -1 if any(argument.arg == name for argument in function.args.kwonlyargs) else None
+
+
+def _arguments_bound_to(tree: ast.Module, function: str, *, position: int, keyword: str) -> Iterator[ast.expr]:
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name) or node.func.id != function:
+            continue
+        if 0 <= position < len(node.args):
+            yield node.args[position]
+        yield from (bound.value for bound in node.keywords if bound.arg == keyword)
+
+
+class TestEveryConfigSettingKeyIsClassified:
+    """A key the tree stores must land in a bucket — the exemption cannot be INCOMPLETE."""
+
+    SCAN = ConfigKeyScan.of_src().keys()
+
+    @staticmethod
+    def _classified() -> set[str]:
+        return (
+            set(ALL_KNOWN_CONFIG_SETTINGS)
+            | set(REMOVED_SETTING_KEYS)
+            | set(RENAMED_SETTING_KEYS)
+            | {entry.key for entry in INTERNAL_STATE_KEYS}
+        )
+
+    def test_no_key_src_stores_falls_through_every_bucket(self) -> None:
+        classified = self._classified()
+        unclassified = {key: sorted(sites) for key, sites in self.SCAN.items() if key not in classified}
+        assert not unclassified, (
+            "these keys are read/written as ConfigSetting rows but declared nowhere, so a stored row "
+            f"renders as 'not a declared setting' with a destructive clear remedy: {unclassified}"
+        )
+
+    def test_the_walk_resolves_all_three_constant_shapes(self) -> None:
+        # Anti-vacuous control: an empty or crippled walk satisfies the assertion above
+        # for free. One key per resolution shape the scan claims to cover.
+        assert "low_power_preset_name" in self.SCAN, "module-constant resolution is broken"
+        assert "approval_dial" in self.SCAN, "cross-module import resolution is broken"
+        assert "default_mode" in self.SCAN, "helper-parameter resolution is broken"
+
+    def test_a_dynamic_key_is_not_mistaken_for_a_declared_one(self) -> None:
+        # The operator-facing surfaces pass whatever row they were handed; naming their
+        # parameter as a key would demand a declaration for the string "key" itself.
+        assert "key" not in self.SCAN
+        assert "setting" not in self.SCAN

--- a/tests/teatree_config/test_stored_row_health.py
+++ b/tests/teatree_config/test_stored_row_health.py
@@ -3,6 +3,8 @@
 from importlib import import_module
 from pathlib import Path
 
+import pytest
+
 from teatree.config import ALL_KNOWN_CONFIG_SETTINGS
 from teatree.config.retired_settings import REMOVED_SETTING_KEYS, RENAMED_SETTING_KEYS
 from teatree.config.stored_row_health import INTERNAL_STATE_KEYS, internal_state_key, stored_row_note
@@ -36,15 +38,26 @@ class TestStoredRowNote:
         # The class fix, not the one-key fix: a removal nobody recorded in
         # RETIRED_SETTINGS must not render as an ordinary setting either.
         note = stored_row_note("a_key_no_registry_and_no_retirement_carries")
-        assert "no live consumer" in note
+        assert "not a declared setting" in note
         assert "config_setting clear" in note
 
-    def test_the_retired_intake_gate_is_marked(self) -> None:
-        assert stored_row_note("issue_implementer_require_label")
+    def test_the_negative_bucket_claims_undeclaredness_not_absence_of_readers(self) -> None:
+        # The classifier reads registries; "nothing reads it" is a claim about the call
+        # graph it never consults, and #3867 printed it beside three keys with live
+        # consumers. Only what a registry lookup can support may be said.
+        assert "no live consumer" not in stored_row_note("a_key_no_registry_and_no_retirement_carries")
+
+    def test_the_retired_intake_gate_lands_in_the_retired_bucket_not_the_unknown_one(self) -> None:
+        # Asserting only that the note is non-empty passes for EVERY bucket, so it
+        # never noticed a key classified as unknown-orphan rather than retired.
+        note = stored_row_note("issue_implementer_require_label")
+        assert "retired — not in effect" in note
+        assert "config_setting clear issue_implementer_require_label" in note
+        assert "not a declared setting" not in note
 
 
 class TestInternalStateKeysAreNotCalledDead:
-    """A deliberate non-setting row is state, not a corpse.
+    """A deliberate non-setting row has an owner, not a corpse.
 
     A ``ConfigSetting`` row is not always a setting: ``loop_preset_transition_stamp``
     is runtime state ``teatree.loops.preset_transitions`` rewrites every pass, absent
@@ -58,7 +71,7 @@ class TestInternalStateKeysAreNotCalledDead:
 
     def test_the_stamp_row_is_not_reported_dead_nor_offered_the_clear_remedy(self) -> None:
         note = stored_row_note(self.STAMP)
-        assert "no live consumer" not in note
+        assert "not a declared setting" not in note
         assert "config_setting clear" not in note
 
     def test_the_stamp_row_names_the_module_that_owns_it(self) -> None:
@@ -71,6 +84,23 @@ class TestInternalStateKeysAreNotCalledDead:
     def test_no_registered_key_is_also_a_live_setting(self) -> None:
         registered = {entry.key for entry in INTERNAL_STATE_KEYS}
         assert not registered & ALL_KNOWN_CONFIG_SETTINGS.keys()
+
+    @pytest.mark.parametrize(
+        ("key", "owner"),
+        [
+            ("approval_dial", "teatree.core.models.approval_dial"),
+            ("default_mode", "teatree.core.mode_resolution"),
+            ("presence_upgrade_mode", "teatree.core.mode_resolution"),
+        ],
+    )
+    def test_a_security_relevant_live_key_is_never_offered_the_clear_remedy(self, key: str, owner: str) -> None:
+        # #3867 printed the destructive remedy beside all three. Following it on
+        # `approval_dial` un-graduates every approval class back to ASK; on the two mode
+        # keys it drops the operator's ladder back to the compiled fallback.
+        note = stored_row_note(key)
+        assert "config_setting clear" not in note
+        assert "not a declared setting" not in note
+        assert owner in note
 
     def test_every_registered_key_still_appears_in_the_module_it_names(self) -> None:
         # The carve-out must not become the dead config it exists to prevent: an owner

--- a/tests/teatree_core/management/test_config_setting_command.py
+++ b/tests/teatree_core/management/test_config_setting_command.py
@@ -235,7 +235,7 @@ class TestConfigSettingListMarksDeadRows(TestCase):
 
     def test_an_unrecorded_stale_row_is_marked_too(self) -> None:
         ConfigSetting.objects.create(key="a_key_no_declaration_base_carries", value=True, scope="")
-        assert "no live consumer" in self._row_line("a_key_no_declaration_base_carries")
+        assert "not a declared setting" in self._row_line("a_key_no_declaration_base_carries")
 
     def test_an_internal_state_row_is_named_state_not_offered_the_clear_remedy(self) -> None:
         # The stamp row is live state the transition chain rewrites every pass; telling
@@ -251,7 +251,7 @@ class TestConfigSettingListMarksDeadRows(TestCase):
         ConfigSetting.objects.set_value("issue_implementer_enabled", value=True)
         line = self._row_line("issue_implementer_enabled")
         assert "retired" not in line
-        assert "no live consumer" not in line
+        assert "not a declared setting" not in line
 
 
 class TestConfigSettingGet(TestCase):


### PR DESCRIPTION
Discharges acceptance criterion 2 of #3862 and fixes the regression #3867 shipped.

## What

- `approval_dial`, `default_mode` and `presence_upgrade_mode` join `INTERNAL_STATE_KEYS`, so none of them is offered a clear remedy any more. The note names an **owner** rather than a writer — for two of the three a different module does the writing.
- The negative bucket now says **`not a declared setting`** instead of `no live consumer`.
- New inverse conformance walk `tests/conformance/test_config_key_classification.py`: every `ConfigSetting` key `src/` stores must land in the union (declared / removed / renamed) or in the carve-out.
- `test_the_retired_intake_gate_is_marked` asserted only that the note was non-empty — every bucket satisfies that — so it is re-pointed at the retired bucket by name.

## Why

`stored_row_health` decided the label from `ALL_KNOWN_CONFIG_SETTINGS` membership, which answers *"is this a declared setting"*. The label claimed *"no live consumer"* — a statement about the call graph the classifier never consults. Three keys with live consumers therefore rendered as dead, each beside a destructive remedy:

- **`approval_dial`** is the per-action-class approval trust table, read via `core/on_behalf_gate_recorded.py:249`, `loops/directive_loop/ratify.py` and `loops/outer_loop/keep.py`, written by its own `core/management/commands/approval_dial.py`. Clearing it un-graduates every approval class back to ASK.
- **`default_mode`** / **`presence_upgrade_mode`** are read by `mode_resolution._setting_name()` and `config/cold_mode.py`, written by `loops/preset_admin.rename_preset`. Clearing them drops the operator's mode ladder to the compiled fallback. Their sibling `low_power_preset_name` IS declared (`registries.py:109`), so the omission was an inconsistency, not a convention.

The existing rot guard runs one way only: it catches an exemption whose owner module stopped carrying its key. It cannot catch an exemption that is **incomplete** — which is exactly where this regression lived. The new walk closes that direction and derives its key set from the code rather than a hand-list, so a future undeclared key fails the PR that introduces it.

A key counts when a literal reaches the store's read/write API (`get_effective` / `set_value` / `seed` / `clear`, or the cold reader's `read_setting`), resolved through the literal itself, a module constant (including one imported from another module), or a same-module helper's parameter — the `mode_resolution._setting_name(DEFAULT_MODE_SETTING, …)` shape two of the three keys are reached through.

## Evidence — RED before GREEN

The inverse walk against the classifier as it stands on `main`:

```
AssertionError: these keys are read/written as ConfigSetting rows but declared nowhere,
so a stored row renders as 'not a declared setting' with a destructive clear remedy:
{'default_mode': ['teatree.config.cold_mode:247', 'teatree.core.mode_resolution:173'],
 'presence_upgrade_mode': ['teatree.config.cold_mode:247', 'teatree.core.mode_resolution:173'],
 'approval_dial': ['teatree.core.management.commands.approval_dial:40',
                   'teatree.core.models.approval_dial:100', ...]}
1 failed, 2 passed
```

Exactly the three keys, with their call sites. After the fix: `81 passed` across the three affected test modules.

The walk carries its own anti-vacuity control (`test_the_walk_resolves_all_three_constant_shapes`) — one key per resolution shape it claims to cover, so a crippled or empty walk fails rather than passing the main assertion for free.

**The weak test.** `test_the_retired_intake_gate_is_marked` was `assert stored_row_note(key)`. Under a forced misclassification of that same key:

```
note: [unknown — not a declared setting; clear with `t3 <overlay> config_setting clear ...`]
OLD weak assertion  `assert stored_row_note(key)`        -> PASS
NEW assertion       `'retired — not in effect' in note`  -> FAIL
```

The old assertion certified a key in the wrong bucket; the new one does not.

**Suite:** `bash dev/ci-parity-fast.sh` exit 0 — `28686 passed, 63 skipped, 5 xfailed`, zero failures.

## Architecture pre-check — #3862 / #3867

1. **BLUEPRINT § alignment** — no contract change; this corrects a classifier label and widens the #3862 carve-out registry it already defines.
2. **FSM phase boundaries** — n/a, no `Ticket.State` / `Worktree.State` transition touched.
3. **Extension-point contracts** — none. No `OverlayBase` hook, scanner registration or `*Backend` Protocol touched.
4. **Component boundaries** — the classifier stays in `src/teatree/config/`; the walk is a `tests/conformance/` AST test, matching its siblings (`test_consumer_caller_walk.py`, `test_capability_surface_walk.py`) which keep their walk inline.
5. **Dependency direction** — no production import added. `uv run tach check` → `All modules validated!`
6. **Test surface** — bucket membership and the three keys' notes in `tests/teatree_config/test_stored_row_health.py`; the rendered operator line in `tests/teatree_core/management/test_config_setting_command.py`; the inverse direction in `tests/conformance/test_config_key_classification.py`.
7. **Resilience invariants** — n/a, no external write; `stored_row_note` is a pure function of two registries.
8. **Identity and key normalization** — the key IS the identity and is used verbatim at every boundary; no strip/split introduced.
9. **Behavior preservation / capability deletion** — additive on the carve-out; no key loses its note, and no must-block test was inverted. The one label change (`no live consumer` → `not a declared setting`) narrows a CLAIM, not a guard: the remedy is still offered for exactly the same set of keys as before, minus the three that should never have been in it. `test_the_retired_intake_gate_is_marked` was strengthened, not relaxed — proven above by the misclassification control.
10. **Removability / harness-vs-data** — the three additions are data rows in `INTERNAL_STATE_KEYS`, not harness logic; deleting a row reverts that key to the previous label with no call site touched. The conformance walk is a self-contained test file whose deletion removes only the check.

## Open questions & assumptions

- The three keys are registered in `INTERNAL_STATE_KEYS` rather than declared as schema settings. Both satisfy the rot guard; the carve-out was the smaller change and matches how `loop_preset_transition_stamp` is handled.
- The walk treats a key assembled at runtime from a model field or operator input as dynamic and out of scope — those surfaces render the note for whatever row they are handed rather than naming a key of their own.
