### PR TITLE
fix(loop): stop the review loop reaping the ship loop's armed review (#3910)

### DIFF
--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -65,6 +65,7 @@ graph TD
     teatree.core.managers --> teatree.core.modelkit
     teatree.core.managers --> teatree.core.models.errors
     teatree.core.managers --> teatree.core.loop_lease_manager
+    teatree.core.managers --> teatree.core.managers_inbound
     teatree.core.managers --> teatree.core.managers_issue_match
     teatree.core.managers --> teatree.core.managers_overlay
     teatree.core.managers --> teatree.core.managers_phase_cadence
@@ -382,6 +383,7 @@ graph TD
     teatree.core.repair_loop
     teatree.core.managers_overlay
     teatree.core.managers_task_claim
+    teatree.core.managers_inbound
     teatree.core.managers_issue_match
     teatree.core.managers_phase_cadence
     teatree.backends.errors

--- a/src/teatree/core/managers.py
+++ b/src/teatree/core/managers.py
@@ -17,6 +17,7 @@ from teatree.core.loop_lease_manager import (
     is_per_loop_owner_slot,
     per_loop_owner_slot,
 )
+from teatree.core.managers_inbound import IncomingEventQuerySet, ReplyDispatchQuerySet
 from teatree.core.managers_issue_match import matching_issue_q
 from teatree.core.managers_overlay import for_overlay as _for_overlay
 from teatree.core.managers_overlay import overlay_scope_q
@@ -28,8 +29,6 @@ from teatree.core.repair_loop import IterationStalled, MaxIterationsExceeded
 from teatree.core.session_handover_manager import SessionHandoverManager, SessionHandoverQuerySet
 
 if TYPE_CHECKING:
-    from teatree.core.models.incoming_event import IncomingEvent
-    from teatree.core.models.reply_dispatch import ReplyDispatch
     from teatree.core.models.task import Task
     from teatree.core.models.ticket import Ticket
     from teatree.core.models.worktree import Worktree
@@ -151,63 +150,6 @@ class WorktreeQuerySet(models.QuerySet):
         ).update(last_e2e_run=now or timezone.now())
 
 
-# The settled/in-flight boundary, defined ONCE (#3693): an event is UNSETTLED until it is
-# drained (``processed_at``) or dead-lettered. ``unprocessed()`` filters this in (plus a
-# due clause); ``prunable()`` excludes it (the exact settled complement). Deriving both
-# from this one Q keeps the boundary from drifting between the two call sites.
-_UNSETTLED = Q(processed_at__isnull=True, dead_lettered_at__isnull=True)
-
-
-class IncomingEventQuerySet(models.QuerySet):
-    def unprocessed(self, now: datetime | None = None) -> models.QuerySet:
-        """Events still awaiting a drain: un-processed, not dead-lettered, and due (#673).
-
-        A failed drain (:meth:`IncomingEvent.record_failure`) leaves the event
-        un-processed but stamps a backoff ``next_retry_at`` and, past the attempt
-        cap, a ``dead_lettered_at``. Excluding both here is what lets the scanner
-        retry a transient failure without re-firing it every tick and drop a
-        dead-lettered poison out of the queue rather than block behind it.
-        """
-        moment = now or timezone.now()
-        return self.filter(_UNSETTLED).filter(Q(next_retry_at__isnull=True) | Q(next_retry_at__lte=moment))
-
-    def prunable(self, cutoff: datetime) -> models.QuerySet:
-        # Settled events before *cutoff*, safe to delete (#3693). Excludes the _UNSETTLED
-        # boundary itself (drained/dead-lettered) — NOT unprocessed(): a not-yet-due backoff
-        # row is still in-flight and must never be pruned however old.
-        return self.exclude(_UNSETTLED).filter(received_at__lt=cutoff)
-
-    def dead_lettered(self) -> models.QuerySet:
-        """Poisoned events that exhausted their retries — the dead-letter view (#673)."""
-        return self.filter(dead_lettered_at__isnull=False).order_by("-dead_lettered_at", "-pk")
-
-    def active_dm_thread(self, *, channel: str) -> str:
-        incoming_event_model = cast("type[IncomingEvent]", apps.get_model("core", "IncomingEvent"))
-
-        if not channel:
-            return ""
-        latest = (
-            self.filter(source=incoming_event_model.Source.SLACK, channel_ref=channel)
-            .order_by("-received_at", "-pk")
-            .values_list("thread_ref", flat=True)
-            .first()
-        )
-        return latest or ""
-
-
-class ReplyDispatchQuerySet(models.QuerySet):
-    def due_for_retry(self, now: datetime | None = None) -> models.QuerySet:
-        reply_dispatch_model = cast("type[ReplyDispatch]", apps.get_model("core", "ReplyDispatch"))
-
-        moment = now or timezone.now()
-        return (
-            self.filter(status=reply_dispatch_model.Status.FAILED)
-            .exclude(action_name="dead_letter_alert")
-            .filter(models.Q(next_retry_at__isnull=True) | models.Q(next_retry_at__lte=moment))
-            .order_by("next_retry_at", "pk")
-        )
-
-
 class TaskQuerySet(models.QuerySet):
     def for_overlay(self, overlay: str | None = None) -> models.QuerySet:
         """Tasks scoped to an overlay through the ticket OR the session.
@@ -267,6 +209,14 @@ class TaskQuerySet(models.QuerySet):
             phase__in=phase_spellings(phase),
             status__in=task_model.Status.active(),
         )
+
+    def not_auto_review_armed(self) -> models.QuerySet:
+        """Tasks the #68 auto-review dispatch did NOT arm — the stray/armed discriminator (#3910).
+
+        Reaping an armed task deadlocks its PR permanently: the dispatch dedups
+        per ``(slug, pr_id, head_sha)``, so no later tick re-arms it.
+        """
+        return self.filter(auto_review_dispatches__isnull=True)
 
     def in_flight_for_phase(self, overlay: str, phase: str) -> models.QuerySet:
         """Pending/claimed tasks for one overlay+phase — the periodic scanners' dedupe lock (SSOT)."""

--- a/src/teatree/core/managers_inbound.py
+++ b/src/teatree/core/managers_inbound.py
@@ -1,0 +1,74 @@
+"""Inbound-event queue predicates — the drain, retry, prune and dead-letter views.
+
+Split out of :mod:`teatree.core.managers` (which holds the ticket / worktree /
+task lifecycle) because the inbound queue is a separate concern: it answers
+"what is still owed a drain" rather than "where is this unit of work".
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING, cast
+
+from django.apps import apps
+from django.db import models
+from django.db.models import Q
+from django.utils import timezone
+
+if TYPE_CHECKING:
+    from teatree.core.models.incoming_event import IncomingEvent
+    from teatree.core.models.reply_dispatch import ReplyDispatch
+
+__all__ = ["IncomingEventQuerySet", "ReplyDispatchQuerySet"]
+
+#: Neither drained nor poisoned — the in-flight boundary both the drain and the
+#: pruner key on, so they can never disagree about what is still owed.
+_UNSETTLED = Q(processed_at__isnull=True, dead_lettered_at__isnull=True)
+
+
+class IncomingEventQuerySet(models.QuerySet):
+    def unprocessed(self, now: datetime | None = None) -> models.QuerySet:
+        """Events still awaiting a drain: un-processed, not dead-lettered, and due (#673).
+
+        A failed drain (:meth:`IncomingEvent.record_failure`) leaves the event
+        un-processed but stamps a backoff ``next_retry_at`` and, past the attempt
+        cap, a ``dead_lettered_at``. Excluding both here is what lets the scanner
+        retry a transient failure without re-firing it every tick and drop a
+        dead-lettered poison out of the queue rather than block behind it.
+        """
+        moment = now or timezone.now()
+        return self.filter(_UNSETTLED).filter(Q(next_retry_at__isnull=True) | Q(next_retry_at__lte=moment))
+
+    def prunable(self, cutoff: datetime) -> models.QuerySet:
+        # Settled events before *cutoff*, safe to delete (#3693). Excludes the _UNSETTLED
+        # boundary itself (drained/dead-lettered) — NOT unprocessed(): a not-yet-due backoff
+        # row is still in-flight and must never be pruned however old.
+        return self.exclude(_UNSETTLED).filter(received_at__lt=cutoff)
+
+    def dead_lettered(self) -> models.QuerySet:
+        """Poisoned events that exhausted their retries — the dead-letter view (#673)."""
+        return self.filter(dead_lettered_at__isnull=False).order_by("-dead_lettered_at", "-pk")
+
+    def active_dm_thread(self, *, channel: str) -> str:
+        incoming_event_model = cast("type[IncomingEvent]", apps.get_model("core", "IncomingEvent"))
+
+        if not channel:
+            return ""
+        latest = (
+            self.filter(source=incoming_event_model.Source.SLACK, channel_ref=channel)
+            .order_by("-received_at", "-pk")
+            .values_list("thread_ref", flat=True)
+            .first()
+        )
+        return latest or ""
+
+
+class ReplyDispatchQuerySet(models.QuerySet):
+    def due_for_retry(self, now: datetime | None = None) -> models.QuerySet:
+        reply_dispatch_model = cast("type[ReplyDispatch]", apps.get_model("core", "ReplyDispatch"))
+
+        moment = now or timezone.now()
+        return (
+            self.filter(status=reply_dispatch_model.Status.FAILED)
+            .exclude(action_name="dead_letter_alert")
+            .filter(models.Q(next_retry_at__isnull=True) | models.Q(next_retry_at__lte=moment))
+            .order_by("next_retry_at", "pk")
+        )

--- a/src/teatree/loop/mechanical.py
+++ b/src/teatree/loop/mechanical.py
@@ -21,6 +21,8 @@ from teatree.loop.mechanical_snapshot_warmer import refresh_snapshot
 from teatree.utils.url_slug import pr_ref_from_url
 
 if TYPE_CHECKING:
+    from django.db.models import QuerySet
+
     from teatree.core.backend_protocols import CodeHostBackend
     from teatree.core.models.task import Task
 
@@ -118,11 +120,17 @@ def reopen_ticket(payload: ActionPayload) -> None:
 def reviewer_task_orphaned(payload: ActionPayload) -> None:
     """Complete every open reviewing task on the orphaned reviewer ticket (#998).
 
-    The scanner emits this signal ONLY after ``host.get_pr_open_state``
-    confirmed the PR is genuinely MERGED or CLOSED (#1074) — never on mere
-    absence from the reviewer-assignment scan. Without this sweep the
-    PENDING task for a truly-merged PR lingers forever, surfacing on every
-    ``pending-spawn`` and dispatching a reviewer sub-agent for nothing.
+    The scanner emits this signal on either of two proofs, never on mere
+    absence from the reviewer-assignment scan: ``host.get_pr_open_state``
+    confirmed the PR is genuinely MERGED or CLOSED (#1074), or the local FSM
+    already reached a terminal state (#1431). Without this sweep the PENDING
+    task lingers forever, surfacing on every ``pending-spawn`` and dispatching
+    a reviewer sub-agent for nothing.
+
+    The two grounds are NOT interchangeable in a log (#3910): a terminal ticket
+    on a still-OPEN PR is a correct reap, so crediting it to the forge-state
+    proof reads as a forge bug and sends the operator hunting a phantom. The
+    signal carries the ground it actually used in ``payload["reason"]``.
 
     The handler is intentionally narrow: it operates by ticket id and only
     completes tasks in ``phase=reviewing`` with non-terminal status. Other
@@ -142,10 +150,11 @@ def reviewer_task_orphaned(payload: ActionPayload) -> None:
     completed = _complete_open_reviewing_tasks(ticket)
     if completed:
         logger.info(
-            "Auto-completed %d orphaned reviewing task(s) on ticket %s (PR %s confirmed merged/closed)",
+            "Auto-completed %d orphaned reviewing task(s) on ticket %s (%s: %s)",
             completed,
             ticket_id,
             payload.get("url", "?"),
+            payload.get("reason", "orphaned"),
         )
 
 
@@ -163,6 +172,13 @@ def reviewer_task_self_authored(payload: ActionPayload) -> None:
     Narrow and best-effort, mirroring :func:`reviewer_task_orphaned`: by
     ticket id, only ``phase=reviewing`` non-terminal tasks; a missing
     ticket no-ops silently.
+
+    Narrower than :func:`reviewer_task_orphaned` in one way (#3910): a task the
+    #68 auto-review dispatch armed is skipped. That premise — own MR means a
+    colleague review-request — does not hold on a solo overlay, where the agent
+    cold-reviewer IS the checker and the armed task is the only route to a
+    merge. :func:`reviewer_task_orphaned` reaps it regardless, because a
+    merged/closed PR makes even an armed review dead work.
     """
     from django.apps import apps  # noqa: PLC0415 — deferred: app registry read at call time
 
@@ -186,7 +202,7 @@ def reviewer_task_self_authored(payload: ActionPayload) -> None:
         ticket = ticket_model.objects.get(pk=ticket_id)
     except ticket_model.DoesNotExist:
         return
-    completed = _complete_open_reviewing_tasks(ticket)
+    completed = _complete_tasks(_open_reviewing_tasks(ticket).not_auto_review_armed())
     if completed:
         logger.info(
             "Auto-completed %d reviewing task(s) on ticket %s (self-authored MR %s — no self-review)",
@@ -196,13 +212,21 @@ def reviewer_task_self_authored(payload: ActionPayload) -> None:
         )
 
 
-def _complete_open_reviewing_tasks(ticket: object) -> int:
-    """Complete every non-terminal ``phase=reviewing`` task on *ticket*; return the count."""
+def _open_reviewing_tasks(ticket: object) -> "QuerySet":
+    """Every non-terminal ``phase=reviewing`` task on *ticket*."""
     from teatree.core.models.task import Task  # noqa: PLC0415 — deferred: ORM import needs the app registry
 
-    open_tasks = Task.objects.pending_in_phase("reviewing").filter(ticket=ticket)
+    return Task.objects.pending_in_phase("reviewing").filter(ticket=ticket)
+
+
+def _complete_open_reviewing_tasks(ticket: object) -> int:
+    """Complete every non-terminal ``phase=reviewing`` task on *ticket*; return the count."""
+    return _complete_tasks(_open_reviewing_tasks(ticket))
+
+
+def _complete_tasks(tasks: "QuerySet") -> int:
     completed = 0
-    for task in open_tasks:
+    for task in tasks:
         task.complete()
         completed += 1
     return completed

--- a/src/teatree/loop/scanners/reviewer_prs.py
+++ b/src/teatree/loop/scanners/reviewer_prs.py
@@ -207,6 +207,16 @@ def _orphaned_task_signals(
     if overlay:
         candidates = candidates.filter(overlay=overlay)
     candidates = candidates.exclude(issue_url="").exclude(issue_url__in=scanned_urls).distinct()
+    # One query for the whole sweep — this walks every reviewer ticket per tick,
+    # so the armed check must not become a per-ticket round trip.
+    armed_ticket_ids = set(
+        ticket_model.objects.filter(
+            tasks__phase="reviewing",
+            tasks__status__in=open_statuses,
+        )
+        .exclude(tasks__auto_review_dispatches__isnull=True)
+        .values_list("pk", flat=True)
+    )
     signals: list[ScanSignal] = []
     for ticket in candidates:
         # #1431: the LOCAL FSM is authoritative for the user's own
@@ -216,14 +226,18 @@ def _orphaned_task_signals(
         # regardless of forge state (a self-authored MR with no review owed
         # legitimately stays OPEN). This is terminal-LOCAL-FSM *proof*, not
         # absence/UNKNOWN doubt — the fail-open default below is untouched.
-        if ticket.is_terminal:
-            signals.append(
-                ScanSignal(
-                    kind="reviewer_pr.task_orphaned",
-                    summary=f"Reviewing task orphaned (ticket terminal: {ticket.state}): {ticket.issue_url}",
-                    payload={"url": ticket.issue_url, "ticket_id": ticket.pk},
-                ),
-            )
+        #
+        # #3910: EXCEPT when ``pr_sweep`` armed a cold review on this ticket. A
+        # reviewer ticket goes terminal (``review_posted``) after ANY review of
+        # the PR, so the ship loop routinely arms its own-PR review on a ticket
+        # that is ALREADY terminal — and reaping on local state alone killed
+        # that review while the PR was still open and still unmergeable without
+        # a verdict. An armed ticket falls through to the forge check below, so
+        # a genuinely merged/closed PR still reaps (an armed review on dead work
+        # is still dead work) and only STALE LOCAL state stops killing a
+        # deliberately-scheduled review.
+        if ticket.is_terminal and ticket.pk not in armed_ticket_ids:
+            signals.append(_orphan_signal(ticket, f"ticket terminal: {ticket.state}"))
             continue
         try:
             state = host.get_pr_open_state(pr_url=ticket.issue_url)
@@ -233,14 +247,24 @@ def _orphaned_task_signals(
         if state not in {PrOpenState.MERGED, PrOpenState.CLOSED}:
             # OPEN → live review still owed; UNKNOWN → fail open. Never reap.
             continue
-        signals.append(
-            ScanSignal(
-                kind="reviewer_pr.task_orphaned",
-                summary=f"Reviewing task orphaned (PR {state.value}): {ticket.issue_url}",
-                payload={"url": ticket.issue_url, "ticket_id": ticket.pk},
-            ),
-        )
+        signals.append(_orphan_signal(ticket, f"PR {state.value}"))
     return signals
+
+
+def _orphan_signal(ticket: "_Ticket", reason: str) -> ScanSignal:
+    """One ``reviewer_pr.task_orphaned`` signal carrying the ground it was reaped on (#3910).
+
+    The sweep reaps on two non-interchangeable grounds — terminal local FSM
+    (#1431) and forge state MERGED/CLOSED (#1074). ``reason`` travels in the
+    payload so the handler logs the one actually used: a terminal ticket on a
+    still-OPEN PR is a correct reap, and crediting it to the forge proof reads
+    as a forge bug.
+    """
+    return ScanSignal(
+        kind="reviewer_pr.task_orphaned",
+        summary=f"Reviewing task orphaned ({reason}): {ticket.issue_url}",
+        payload={"url": ticket.issue_url, "ticket_id": ticket.pk, "reason": reason},
+    )
 
 
 def _is_dismissed_from_approved(previous: str, current: ReviewState) -> bool:
@@ -373,17 +397,20 @@ class ReviewerPrsScanner:
         debugger + a colleague review-request, never a ``t3:reviewer``
         sub-agent. The mechanical handler completes the task so
         ``pending-spawn`` stops surfacing it.
+
+        A task the #68 auto-review dispatch armed is exempt (#3910): on a solo
+        overlay the agent cold-reviewer IS the checker, so that task is the
+        only route to a merge, not a stray.
         """
         if ticket_model is None or not url:
             return []
         from teatree.core.models.task import Task  # noqa: PLC0415 — deferred: ORM import needs the app registry
 
-        open_statuses = Task.Status.active()
+        strays = Task.objects.filter(phase="reviewing", status__in=Task.Status.active()).not_auto_review_armed()
         candidates = ticket_model.objects.filter(
             role="reviewer",
             issue_url=url,
-            tasks__phase="reviewing",
-            tasks__status__in=open_statuses,
+            tasks__in=strays,
         )
         if self.overlay_name:
             candidates = candidates.filter(overlay=self.overlay_name)

--- a/src/teatree/loop/scanners/reviewer_prs.py
+++ b/src/teatree/loop/scanners/reviewer_prs.py
@@ -209,13 +209,18 @@ def _orphaned_task_signals(
     candidates = candidates.exclude(issue_url="").exclude(issue_url__in=scanned_urls).distinct()
     # One query for the whole sweep — this walks every reviewer ticket per tick,
     # so the armed check must not become a per-ticket round trip.
+    # A POSITIVE filter, so all three conditions bind to the same joined task row.
+    # `.exclude(tasks__auto_review_dispatches__isnull=True)` reads like the same
+    # thing but compiles to an UNCORRELATED `NOT EXISTS` over every task on the
+    # ticket in any phase — it means "every task is armed", so one ordinary
+    # sibling task empties this set and the terminal branch reaps the armed
+    # review again.
     armed_ticket_ids = set(
         ticket_model.objects.filter(
             tasks__phase="reviewing",
             tasks__status__in=open_statuses,
-        )
-        .exclude(tasks__auto_review_dispatches__isnull=True)
-        .values_list("pk", flat=True)
+            tasks__auto_review_dispatches__isnull=False,
+        ).values_list("pk", flat=True)
     )
     signals: list[ScanSignal] = []
     for ticket in candidates:

--- a/tach.toml
+++ b/tach.toml
@@ -243,6 +243,11 @@ layer = "domain"
 depends_on = []
 
 [[modules]]
+path = "teatree.core.managers_inbound"
+layer = "domain"
+depends_on = []
+
+[[modules]]
 path = "teatree.core.managers_issue_match"
 layer = "domain"
 depends_on = []
@@ -266,6 +271,7 @@ depends_on = [
   "teatree.core.modelkit",
   "teatree.core.models.errors",
   "teatree.core.loop_lease_manager",
+  "teatree.core.managers_inbound",
   "teatree.core.managers_issue_match",
   "teatree.core.managers_overlay",
   "teatree.core.managers_phase_cadence",

--- a/tests/quality/test_no_flat_core_regrowth.py
+++ b/tests/quality/test_no_flat_core_regrowth.py
@@ -145,7 +145,14 @@ _CORE_DIR = Path(__file__).resolve().parents[2] / "src" / "teatree" / "core"
 # django_tasks_db's own shipped prune is retention/task_results.py, kept apart so the
 # orchestrator never imports a third-party table's library directly. Two root leaves collapse
 # to one package entry, mirroring cleanup/ and evidence/.
-PINNED_FLAT_CORE_MODULES = 102
+# 103: +managers_inbound.py (#3910) — the IncomingEvent/ReplyDispatch queryset predicates carved
+# out of managers.py, which had reached the 500-LOC module-health ceiling and could not take
+# another method. The inbound queue answers "what is still owed a drain", a different question
+# from the ticket/worktree/task lifecycle the hub keeps. It lands at the root beside the four
+# managers_* leaves it belongs with (managers_overlay, managers_issue_match,
+# managers_phase_cadence, managers_task_claim); filing it under a subpackage would separate it
+# from its siblings to satisfy a counter.
+PINNED_FLAT_CORE_MODULES = 103
 
 
 def _flat_core_modules() -> list[str]:

--- a/tests/teatree_core/test_managers.py
+++ b/tests/teatree_core/test_managers.py
@@ -5,6 +5,7 @@ import pytest
 from django.test import TestCase
 from django.utils import timezone
 
+from teatree.core.managers_inbound import IncomingEventQuerySet, ReplyDispatchQuerySet
 from teatree.core.managers_phase_cadence import in_flight_for_phase, last_run_at_for_phase
 from teatree.core.models import IncomingEvent, ReplyDispatch, Session, Task, Ticket, Worktree
 
@@ -61,6 +62,21 @@ class TestWorktreeQuerySet(TestCase):
         Worktree.objects.create(ticket=other_ticket, repo_path="/tmp/other", branch="other")
 
         assert list(Worktree.objects.for_ticket(wanted_ticket).order_by("pk")) == [mine, also_mine]
+
+
+class TestInboundManagersStayWired(TestCase):
+    """The inbound querysets still back their models after moving to `managers_inbound`.
+
+    The move is a pure relocation, so nothing below asserts behaviour — it pins
+    the wiring, which is the only thing a relocation can break. Every predicate
+    test in this module reaches these classes through `Model.objects`, so a
+    manager silently rebuilt from a plain `QuerySet` would leave them all
+    passing while `unprocessed()` and `due_for_retry()` vanish at runtime.
+    """
+
+    def test_managers_are_built_from_the_relocated_querysets(self) -> None:
+        assert isinstance(IncomingEvent.objects.all(), IncomingEventQuerySet)
+        assert isinstance(ReplyDispatch.objects.all(), ReplyDispatchQuerySet)
 
 
 class TestIncomingEventQuerySet(TestCase):

--- a/tests/teatree_loop/test_auto_review_armed_not_reaped_3910.py
+++ b/tests/teatree_loop/test_auto_review_armed_not_reaped_3910.py
@@ -1,0 +1,225 @@
+"""The #1321 self-authored sweep must not reap a #68 auto-review-armed task (#3910).
+
+Deadlock observed on a solo overlay with ``autonomy=full``: no PR merged for a day
+because two loops cancelled each other on every own, CI-green PR.
+
+- ``ship`` / ``PrSweepScanner._flag_no_review`` arms exactly ONE claimable
+    ``Task(phase=reviewing)`` per head via ``AutoReviewDispatch.enqueue`` — on a solo
+    overlay that is the only path by which an own PR can ever merge, because
+    maker≠checker forbids the self-merge.
+- ``review`` / ``ReviewerPrsScanner._self_authored_reconcile_signals`` saw the same task
+    as a #1321 stray (reviewer-role ticket, non-terminal reviewing task, self-authored MR)
+    and completed it within 5 minutes, before any attempt ran.
+
+``AutoReviewDispatch.enqueue`` dedups per ``(slug, pr_id, head_sha)``, so the re-arm on
+every later tick returns ``None`` and the PR sits at ``no_independent_review`` for that
+head forever. Measured: tasks 683/684/685 completed with ZERO ``TaskAttempt`` rows and no
+``ReviewVerdict``, while task 682 won the race and produced a ``merge_safe`` verdict.
+
+The armed task carries its own evidence — an ``AutoReviewDispatch`` row through the
+``auto_review_dispatches`` reverse accessor — so the sweep can tell a deliberately armed
+review from a genuine stray.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from django.test import TestCase
+
+from teatree.core.backend_protocols import PrOpenState, ReviewState
+from teatree.core.models.auto_review_dispatch import AutoReviewDispatch
+from teatree.core.models.task import Task
+from teatree.core.models.ticket import Ticket
+from teatree.core.models.ticket_external_review import schedule_external_review
+from teatree.loop.mechanical import reviewer_task_orphaned, reviewer_task_self_authored
+from teatree.loop.scanners.reviewer_prs import ReviewerPrsScanner
+from teatree.types import RawAPIDict
+
+_IDENTITIES = ("user-gl", "user-gh-a", "user-gh-b")
+_SLUG = "souliane/teatree"
+_HEAD = "bd43b8d1c0ffee0000000000000000000000dead"
+
+
+@dataclass
+class FakeCodeHost:
+    """In-memory ``CodeHostBackend`` — mirrors the #1321 fake, scoped to this gate."""
+
+    user: str = ""
+    review_requested_by_reviewer: dict[str, list[RawAPIDict]] = field(default_factory=dict)
+    pr_open_state_default: PrOpenState = PrOpenState.OPEN
+
+    def current_user(self) -> str:
+        return self.user
+
+    def list_my_prs(self, *, author: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = (author, updated_after)
+        return []
+
+    def list_review_requested_prs(self, *, reviewer: str, updated_after: str | None = None) -> list[RawAPIDict]:
+        _ = updated_after
+        return list(self.review_requested_by_reviewer.get(reviewer, ()))
+
+    def list_assigned_issues(self, *, assignee: str) -> list[RawAPIDict]:
+        _ = assignee
+        return []
+
+    def get_review_state(self, *, pr_url: str, reviewer: str) -> ReviewState:
+        _ = (pr_url, reviewer)
+        return ReviewState.NONE
+
+    def get_pr_open_state(self, *, pr_url: str) -> PrOpenState:
+        _ = pr_url
+        return self.pr_open_state_default
+
+    def create_pr(self, spec: Any) -> RawAPIDict:
+        _ = spec
+        return {}
+
+    def post_pr_comment(self, *, repo: str, pr_iid: int, body: str) -> RawAPIDict:
+        _ = (repo, pr_iid, body)
+        return {}
+
+    def update_pr_comment(self, *, repo: str, pr_iid: int, comment_id: int, body: str) -> RawAPIDict:
+        _ = (repo, pr_iid, comment_id, body)
+        return {}
+
+    def list_pr_comments(self, *, repo: str, pr_iid: int) -> list[RawAPIDict]:
+        _ = (repo, pr_iid)
+        return []
+
+    def upload_file(self, *, repo: str, filepath: str) -> RawAPIDict:
+        _ = (repo, filepath)
+        return {}
+
+    def get_issue(self, issue_url: str) -> RawAPIDict:
+        _ = issue_url
+        return {}
+
+
+def _self_authored_host(url: str) -> FakeCodeHost:
+    return FakeCodeHost(
+        user="user-gl",
+        review_requested_by_reviewer={
+            "user-gl": [
+                {"web_url": url, "sha": _HEAD, "author": {"username": "user-gl"}, "state": "opened"},
+            ],
+        },
+    )
+
+
+def _arm_auto_review(pr_id: int) -> tuple[str, Ticket, Task]:
+    """Arm a review exactly as ``PrSweepScanner._flag_no_review`` does — real rows, no stubs."""
+    url = f"https://github.com/{_SLUG}/pull/{pr_id}"
+    dispatch = AutoReviewDispatch.enqueue(slug=_SLUG, pr_id=pr_id, head_sha=_HEAD, pr_url=url)
+    assert dispatch is not None, "enqueue must arm on first dispatch for this head"
+    task = dispatch.task
+    assert task is not None
+    return url, task.ticket, task
+
+
+class TestArmedReviewSurvivesSelfAuthoredSweep(TestCase):
+    def test_armed_reviewing_task_emits_no_reconcile_signal(self) -> None:
+        """The scanner must not flag the ship loop's armed review as a #1321 stray."""
+        url, _ticket, task = _arm_auto_review(3894)
+
+        signals = ReviewerPrsScanner(host=_self_authored_host(url), identities=_IDENTITIES).scan()
+
+        reconcile = [s for s in signals if s.kind == "reviewer_pr.task_self_authored"]
+        assert reconcile == [], f"armed auto-review must not be reconciled as a stray; got {reconcile!r}"
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING
+
+    def test_armed_reviewing_task_survives_the_mechanical_handler(self) -> None:
+        """Defence in depth: the reaper itself must skip an armed task, whoever emitted the signal."""
+        url, ticket, task = _arm_auto_review(3893)
+
+        reviewer_task_self_authored({"ticket_id": ticket.pk, "url": url})
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING
+
+    def test_unarmed_stray_is_still_reaped(self) -> None:
+        """#1321 non-regression — a reviewing task with no dispatch row is still a stray."""
+        url = "https://github.com/souliane/teatree/pull/3800"
+        ticket = Ticket.objects.create(issue_url=url, role=Ticket.Role.REVIEWER)
+        stray = schedule_external_review(ticket)
+
+        signals = ReviewerPrsScanner(host=_self_authored_host(url), identities=_IDENTITIES).scan()
+        assert [s.kind for s in signals if s.kind == "reviewer_pr.task_self_authored"], (
+            f"an unarmed self-authored reviewing task must still reconcile; got {[s.kind for s in signals]!r}"
+        )
+
+        reviewer_task_self_authored({"ticket_id": ticket.pk, "url": url})
+        stray.refresh_from_db()
+        assert stray.status == Task.Status.COMPLETED
+
+    def test_mixed_ticket_reaps_only_the_stray(self) -> None:
+        """Granularity is per task, not per ticket — the stray goes, the armed review stays."""
+        url, ticket, armed = _arm_auto_review(3887)
+        stray = schedule_external_review(ticket)
+
+        reviewer_task_self_authored({"ticket_id": ticket.pk, "url": url})
+
+        armed.refresh_from_db()
+        stray.refresh_from_db()
+        assert armed.status == Task.Status.PENDING
+        assert stray.status == Task.Status.COMPLETED
+
+    def test_orphaned_handler_still_reaps_an_armed_task(self) -> None:
+        """Behaviour preservation (#998/#1074): once the PR is merged/closed the armed review IS dead work."""
+        url, ticket, armed = _arm_auto_review(3899)
+
+        reviewer_task_orphaned({"ticket_id": ticket.pk, "url": url})
+
+        armed.refresh_from_db()
+        assert armed.status == Task.Status.COMPLETED
+
+
+class TestOrphanReasonIsReportedHonestly(TestCase):
+    """The orphan sweep has two reap grounds; the log must not report the wrong one (#3910).
+
+    Observed: ``reviewer_task_orphaned`` logged PR 3895 as "confirmed merged/closed" for a
+    PR that is in fact OPEN. The #1431 branch reaps on terminal-LOCAL-FSM proof — a
+    self-authored MR the user already concluded on legitimately stays open — but the
+    handler credited the #1074 forge-state branch either way, so a correct reap read as a
+    forge-state bug and sent the operator hunting a phantom.
+    """
+
+    def test_terminal_ticket_orphan_signal_carries_its_own_reason(self) -> None:
+        url = "https://github.com/souliane/teatree/pull/3895"
+        ticket = Ticket.objects.create(issue_url=url, role=Ticket.Role.REVIEWER, state=Ticket.State.REVIEW_POSTED)
+        schedule_external_review(ticket)
+        assert ticket.is_terminal
+
+        host = FakeCodeHost(user="user-gl", pr_open_state_default=PrOpenState.OPEN)
+        signals = ReviewerPrsScanner(host=host, identities=_IDENTITIES).scan()
+
+        orphan = [s for s in signals if s.kind == "reviewer_pr.task_orphaned" and s.payload.get("url") == url]
+        assert orphan, f"a terminal reviewer ticket must still be reaped; got {[s.kind for s in signals]!r}"
+        assert orphan[0].payload.get("reason") == f"ticket terminal: {ticket.state}"
+
+    def test_merged_pr_orphan_signal_carries_the_forge_reason(self) -> None:
+        url = "https://github.com/souliane/teatree/pull/3896"
+        ticket = Ticket.objects.create(issue_url=url, role=Ticket.Role.REVIEWER)
+        schedule_external_review(ticket)
+
+        host = FakeCodeHost(user="user-gl", pr_open_state_default=PrOpenState.MERGED)
+        signals = ReviewerPrsScanner(host=host, identities=_IDENTITIES).scan()
+
+        orphan = [s for s in signals if s.kind == "reviewer_pr.task_orphaned" and s.payload.get("url") == url]
+        assert orphan, f"a merged PR's reviewing task must be reaped; got {[s.kind for s in signals]!r}"
+        assert orphan[0].payload.get("reason") == "PR merged"
+
+    def test_handler_logs_the_signal_reason_not_a_hardcoded_one(self) -> None:
+        url = "https://github.com/souliane/teatree/pull/3897"
+        ticket = Ticket.objects.create(issue_url=url, role=Ticket.Role.REVIEWER, state=Ticket.State.REVIEW_POSTED)
+        task = schedule_external_review(ticket)
+
+        with self.assertLogs("teatree.loop.mechanical", level="INFO") as captured:
+            reviewer_task_orphaned({"ticket_id": ticket.pk, "url": url, "reason": "ticket terminal: review_posted"})
+
+        task.refresh_from_db()
+        assert task.status == Task.Status.COMPLETED
+        logged = "\n".join(captured.output)
+        assert "ticket terminal: review_posted" in logged
+        assert "merged/closed" not in logged

--- a/tests/teatree_loop/test_reviewer_prs_self_authored_1321.py
+++ b/tests/teatree_loop/test_reviewer_prs_self_authored_1321.py
@@ -286,6 +286,32 @@ class TestTerminalTicketDoesNotReapArmedReview(TestCase):
         AutoReviewDispatch.objects.create(slug="x", pr_id=400, head_sha="abc", pr_url=url, task=task)
         return ticket, task
 
+    def test_armed_review_survives_alongside_an_unarmed_sibling_task(self) -> None:
+        """A ticket is exempt when it carries an armed review, not only when EVERY task is armed.
+
+        The reason this case is spelled out rather than folded into the test
+        above: a single-task ticket passes under `.exclude(...__isnull=True)`,
+        which compiles to an UNCORRELATED `NOT EXISTS` over every task on the
+        ticket in any phase, and so silently means "all tasks are armed". A
+        terminal reviewer ticket almost always carries a completed earlier
+        review — that is WHY it went terminal — so the single-task shape is the
+        rare one and this is the shape the factory actually deadlocked in.
+        """
+        url = "https://github.com/souliane/teatree/pull/402"
+        ticket, task = self._armed(url, Ticket.State.REVIEW_POSTED)
+        schedule_external_review(ticket)
+        host = FakeCodeHost(user="user-gl", pr_open_state_by_url={url: PrOpenState.OPEN})
+        scanner = ReviewerPrsScanner(host=host, identities=_IDENTITIES)
+
+        signals = [s for s in scanner.scan() if s.kind == "reviewer_pr.task_orphaned"]
+
+        assert signals == [], (
+            "one ordinary sibling task made the ticket look unarmed, so the terminal branch "
+            "reaped the armed review and the open PR is deadlocked again"
+        )
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING
+
     def test_armed_review_on_a_terminal_ticket_survives_while_the_pr_is_open(self) -> None:
         url = "https://github.com/souliane/teatree/pull/400"
         _ticket, task = self._armed(url, Ticket.State.REVIEW_POSTED)

--- a/tests/teatree_loop/test_reviewer_prs_self_authored_1321.py
+++ b/tests/teatree_loop/test_reviewer_prs_self_authored_1321.py
@@ -30,6 +30,7 @@ from typing import Any
 from django.test import TestCase
 
 from teatree.core.backend_protocols import PrOpenState, ReviewState
+from teatree.core.models.auto_review_dispatch import AutoReviewDispatch
 from teatree.core.models.task import Task
 from teatree.core.models.ticket import Ticket
 from teatree.core.models.ticket_external_review import schedule_external_review
@@ -193,3 +194,120 @@ class TestReconcileExistingSelfAuthoredReviewingTask(TestCase):
         assert [s.kind for s in signals if s.kind == "reviewer_pr.task_self_authored"] == []
         task.refresh_from_db()
         assert task.status == Task.Status.PENDING
+
+
+class TestSoloOverlayArmedReviewIsNotReaped(TestCase):
+    """The #1321 reconcile must not reap the review the ship loop armed (#3910).
+
+    On a solo overlay the ship loop's ``pr_sweep`` is the ONLY path by which
+    the operator's own PR can merge: ``_evaluate_solo_overlay`` refuses to
+    self-merge, arms exactly one claimable reviewing task, and waits for its
+    ``merge_safe`` verdict. That task sits on a reviewer-role ticket whose MR
+    is, by construction, self-authored — precisely the shape #1321 reaps.
+
+    The two sweeps therefore cancel: ship arms the review, this scanner
+    completes it minutes later, and because ``AutoReviewDispatch`` dedups per
+    head the sweep never re-arms it. The PR is stuck at
+    ``no_independent_review`` for that head until someone force-pushes.
+
+    The dispatch row is what distinguishes a deliberately-armed review from
+    the stray #1321 was written to reap, so it is the discriminator here.
+    """
+
+    def test_reviewing_task_with_an_auto_review_dispatch_survives(self) -> None:
+        url = "https://gitlab/x/-/merge_requests/302"
+        ticket = Ticket.objects.create(issue_url=url, role=Ticket.Role.REVIEWER)
+        task = schedule_external_review(ticket)
+        AutoReviewDispatch.objects.create(
+            slug="x",
+            pr_id=302,
+            head_sha="abc",
+            pr_url=url,
+            task=task,
+        )
+        host = FakeCodeHost(
+            user="user-gl",
+            review_requested_by_reviewer={
+                "user-gl": [
+                    {"web_url": url, "sha": "abc", "author": {"username": "user-gl"}, "state": "opened"},
+                ],
+            },
+        )
+        scanner = ReviewerPrsScanner(host=host, identities=_IDENTITIES)
+
+        signals = [s for s in scanner.scan() if s.kind == "reviewer_pr.task_self_authored"]
+
+        assert signals == [], (
+            "the ship loop's armed cold review was reaped as a self-authored stray — "
+            "the own PR can never reach an independent verdict, so it can never merge"
+        )
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING
+
+    def test_stray_self_authored_task_without_a_dispatch_is_still_reaped(self) -> None:
+        """The control: #1321's own behaviour is unchanged for a genuine stray."""
+        url = "https://gitlab/x/-/merge_requests/303"
+        ticket = Ticket.objects.create(issue_url=url, role=Ticket.Role.REVIEWER)
+        task = schedule_external_review(ticket)
+        host = FakeCodeHost(
+            user="user-gl",
+            review_requested_by_reviewer={
+                "user-gl": [
+                    {"web_url": url, "sha": "abc", "author": {"username": "user-gl"}, "state": "opened"},
+                ],
+            },
+        )
+        scanner = ReviewerPrsScanner(host=host, identities=_IDENTITIES)
+
+        signals = [s for s in scanner.scan() if s.kind == "reviewer_pr.task_self_authored"]
+
+        assert [s.payload["ticket_id"] for s in signals] == [ticket.pk]
+        _ = task
+
+
+class TestTerminalTicketDoesNotReapArmedReview(TestCase):
+    """The #1431 terminal-FSM reap must also spare a deliberately-armed review (#3910).
+
+    This is the branch that actually stalled the factory. ``pr_sweep`` arms its
+    cold review on the reviewer-role ticket for the PR — and that ticket is
+    routinely ALREADY terminal (``review_posted``) from an earlier review of the
+    same PR. ``_orphaned_task_signals`` reaps a non-terminal reviewing task on a
+    terminal ticket *regardless of forge state*, so the freshly-armed review died
+    on the next tick while the PR was still open and still needed a verdict.
+
+    Forge truth is left fully in charge: a genuinely merged/closed PR still reaps
+    its armed review below. Only stale LOCAL FSM state stops being a reason to
+    kill work that was deliberately scheduled.
+    """
+
+    def _armed(self, url: str, state: str) -> tuple[Ticket, Task]:
+        ticket = Ticket.objects.create(issue_url=url, role=Ticket.Role.REVIEWER, state=state)
+        task = schedule_external_review(ticket)
+        AutoReviewDispatch.objects.create(slug="x", pr_id=400, head_sha="abc", pr_url=url, task=task)
+        return ticket, task
+
+    def test_armed_review_on_a_terminal_ticket_survives_while_the_pr_is_open(self) -> None:
+        url = "https://github.com/souliane/teatree/pull/400"
+        _ticket, task = self._armed(url, Ticket.State.REVIEW_POSTED)
+        host = FakeCodeHost(user="user-gl", pr_open_state_by_url={url: PrOpenState.OPEN})
+        scanner = ReviewerPrsScanner(host=host, identities=_IDENTITIES)
+
+        signals = [s for s in scanner.scan() if s.kind == "reviewer_pr.task_orphaned"]
+
+        assert signals == [], (
+            "a stale terminal reviewer ticket reaped the cold review the ship loop just armed, "
+            "so the open PR can never reach an independent verdict"
+        )
+        task.refresh_from_db()
+        assert task.status == Task.Status.PENDING
+
+    def test_forge_truth_still_reaps_an_armed_review_on_a_merged_pr(self) -> None:
+        """The control: forge state remains authoritative, so real orphans still die."""
+        url = "https://github.com/souliane/teatree/pull/401"
+        ticket, _task = self._armed(url, Ticket.State.STARTED)
+        host = FakeCodeHost(user="user-gl", pr_open_state_by_url={url: PrOpenState.MERGED})
+        scanner = ReviewerPrsScanner(host=host, identities=_IDENTITIES)
+
+        signals = [s for s in scanner.scan() if s.kind == "reviewer_pr.task_orphaned"]
+
+        assert [s.payload["ticket_id"] for s in signals] == [ticket.pk]


### PR DESCRIPTION
fix(loop): stop the review sweeps reaping the cold review ship just armed

## Why

No PR merged for a day. Nothing alarmed because nothing was down: the worker was `RUNNING`, 17 loops enabled, `ship` sweeping every 5 minutes on cadence. Two sweeps were simply cancelling each other.

`pr_sweep._flag_no_review` (#68) refuses to self-merge the operator's own green PR and arms exactly one claimable reviewing task. Its `merge_safe` verdict is the only route by which that PR can merge on a solo overlay. `ReviewerPrsScanner` then reaped that task by two paths:

- `_self_authored_reconcile_signals` (#1321) treats a reviewing task on a self-authored MR as a stray, on the premise that own MRs go to a human colleague. On a solo overlay there is no colleague — the agent cold-reviewer IS the checker, and `has_independent_cold_review` already enforces reviewer is not maker.
- `_orphaned_task_signals` (#1431) reaps on a terminal ticket regardless of forge state. A reviewer ticket goes terminal (`review_posted`) after ANY review of the PR, so the armed review landed on an already-terminal ticket and died on the next tick while the PR was still open. This was the dominant killer.

`AutoReviewDispatch` dedups per head, so a reaped review is never re-armed — the PR sits at `no_independent_review` until someone force-pushes.

### Evidence

| task | PR | ticket | status | TaskAttempt | ReviewVerdict |
|---|---|---|---|---|---|
| 683 | #3894 | 437 | completed | **0** | none |
| 684 | #3893 | 436 | completed | **0** | none |
| 685 | #3887 | 428 | completed | **0** | none |
| 682 | #3902 | 445 | completed | 1 | `merge_safe` |

All four armed within 4 seconds at 10:38 UTC. Task 682 won the race and produced the only verdict in the batch; the other three never ran.

## What

`Task.objects.not_auto_review_armed()` names the stray/armed discriminator once so both sweeps reach the same predicate.

- The self-authored handler completes only the strays, instead of every open reviewing task on the ticket.
- The terminal-FSM branch skips a ticket carrying an armed review, falling through to the forge check.

Forge truth stays fully authoritative — a merged/closed PR still reaps even an armed review, because that is dead work. Only STALE LOCAL state stops killing a deliberately-scheduled review.

Also in this PR:

- The reap handler hardcoded a single forge-state phrase for both branches, so a terminal-ticket reap claimed forge proof it never had — it reported PR 3895 as no longer open while that PR was demonstrably open. That is what made the root cause read as a forge-state bug. `_orphan_signal` now carries the ground actually used and the handler logs it.
- `IncomingEventQuerySet` / `ReplyDispatchQuerySet` move to `core/managers_inbound.py`. `managers.py` was at the 500-LOC ceiling, so the new predicate broke module-health; the inbound queue is a separate concern from the ticket/worktree/task lifecycle, and the split follows the existing `managers_*` pattern.

### Verification

`tests/teatree_loop/test_auto_review_armed_not_reaped_3910.py` and the new classes in `test_reviewer_prs_self_authored_1321.py` were observed RED before the fix. Both control tests pin that the existing sweeps still reap what they should: a genuine self-authored stray, and an armed review whose PR the forge confirms merged.

109 passed across `test_managers.py`, `test_reviewer_prs_self_authored_1321.py`, `test_auto_review_armed_not_reaped_3910.py` and `test_mechanical.py`.

### Note for the reviewer

This PR is subject to the deadlock it fixes, so it cannot merge by the normal loop path — it needs an independent cold review recorded at the live head. After it lands, the stale `AutoReviewDispatch` rows for #3887/#3893/#3894 must be cleared so `ship` re-arms; the dedup rows outlive the code fix and those PRs stay stuck otherwise.

Closes #3910
