### PR TITLE
fix(workspace): reap broken worktree checkouts + doctor FAIL on registered non-checkouts (#3583)

### DIFF
--- a/src/teatree/cli/doctor/checks_bootstrap.py
+++ b/src/teatree/cli/doctor/checks_bootstrap.py
@@ -1,6 +1,6 @@
 """Fresh-box bootstrap-hardening doctor checks (umbrella #3404).
 
-Four gates that turn silent late failures on a freshly-provisioned or migrated
+Five gates that turn silent late failures on a freshly-provisioned or migrated
 box into loud, up-front ones:
 
 - :func:`_check_gh_token_permissions` (#3405/#3477) — a missing REQUIRED permission
@@ -9,6 +9,9 @@ box into loud, up-front ones:
 - :func:`_check_git_hooks_installed` — a checkout whose git hooks were never
     installed pushes with the whole local gate layer absent. A hard FAIL naming the
     missing hooks; a deliberate ``core.hooksPath`` override only WARNs.
+- :func:`_check_registered_worktree_checkouts` (#3583) — a registered ``Worktree``
+    dir that is present on disk but fails ``git rev-parse`` is a broken checkout the
+    reconciler's missing-dir finding never catches. A hard FAIL naming its removal.
 - :func:`_check_provision_concurrency_from_host` (#3409/#3434) — a stale small-box
     ``provision_max_concurrency`` pin throttling a more capable host. It only
     auto-clears a pin the ENTRYPOINT seeded (never an operator's deliberate one),
@@ -159,6 +162,36 @@ def _check_git_hooks_installed() -> bool:
     return ok
 
 
+def _check_registered_worktree_checkouts() -> bool:
+    """FAIL when a registered ``Worktree`` dir exists but is not a git checkout (#3583).
+
+    A row whose ``worktree_path`` is present on disk yet fails ``git rev-parse`` is
+    a broken checkout: the reconciler's missing-dir finding never fires (the dir is
+    there), so it lingers registered and scanned, spamming the setup git-hooks
+    preflight and splitting the reaper's namespace. It holds no git-recoverable
+    work, so each one is a hard FAIL naming its remediation. Reads the ORM
+    (post-``ensure_django``); crash-proof — a probe fault WARNs and passes.
+    """
+    from teatree.core.gates.worktree_checkout_integrity import (  # noqa: PLC0415 — deferred (ORM)
+        find_broken_registered_checkouts,
+    )
+
+    try:
+        broken = find_broken_registered_checkouts()
+    except Exception as exc:  # noqa: BLE001 — a probe failure warns and passes, never blocks doctor
+        typer.echo(f"WARN  Could not probe registered worktree checkouts: {exc.__class__.__name__}: {exc}")
+        return True
+
+    for finding in broken:
+        typer.echo(
+            f"FAIL  Registered worktree wt#{finding.worktree_pk} at {finding.path} exists but is not a git "
+            f"checkout (git rev-parse failed) — a broken checkout holds no live work and splits the reaper's "
+            f"namespace. Remove it with `t3 <overlay> workspace clean-all` or `git worktree remove`, then "
+            f"re-run `t3 doctor check`."
+        )
+    return not broken
+
+
 def _check_provision_concurrency_from_host(*, repair: bool = False) -> bool:
     """Surface — and under ``--repair`` clear — a stale entrypoint-seeded concurrency pin (#3409/#3434).
 
@@ -258,19 +291,21 @@ def _check_claude_settings_drift() -> bool:
 def run_bootstrap_checks(*, repair: bool = False) -> bool:
     """Run every bootstrap-hardening check; return ``False`` iff a hard gate fails.
 
-    Only the token-permission gate (#3405) and the git-hooks gate affect the
-    verdict — the concurrency autofix (#3409/#3434) and the settings-drift check
-    (#3410) are surfacing-only and always pass. Every check runs before the verdict
-    is returned, so one failure never masks another's output. Runs
-    post-``ensure_django`` (the concurrency autofix reads the
-    ORM). ``repair`` gates the concurrency autofix's one mutation: a plain
-    ``t3 doctor`` (``repair=False``) inspects and WARNs but NEVER writes.
+    The token-permission gate (#3405), the git-hooks gate, and the
+    registered-worktree-checkout gate (#3583) affect the verdict — the concurrency
+    autofix (#3409/#3434) and the settings-drift check (#3410) are surfacing-only
+    and always pass. Every check runs before the verdict is returned, so one
+    failure never masks another's output. Runs post-``ensure_django`` (the
+    concurrency autofix and the worktree gate read the ORM). ``repair`` gates the
+    concurrency autofix's one mutation: a plain ``t3 doctor`` (``repair=False``)
+    inspects and WARNs but NEVER writes.
     """
     ok = _check_gh_token_permissions()
     hooks_ok = _check_git_hooks_installed()
+    worktrees_ok = _check_registered_worktree_checkouts()
     _check_provision_concurrency_from_host(repair=repair)
     _check_claude_settings_drift()
-    return ok and hooks_ok
+    return ok and hooks_ok and worktrees_ok
 
 
 __all__ = [
@@ -278,5 +313,6 @@ __all__ = [
     "_check_gh_token_permissions",
     "_check_git_hooks_installed",
     "_check_provision_concurrency_from_host",
+    "_check_registered_worktree_checkouts",
     "run_bootstrap_checks",
 ]

--- a/src/teatree/core/gates/worktree_checkout_integrity.py
+++ b/src/teatree/core/gates/worktree_checkout_integrity.py
@@ -1,0 +1,46 @@
+"""Registered worktrees whose recorded dir exists but is not a functional checkout.
+
+A ``Worktree`` row's ``extra['worktree_path']`` should point at a live git
+checkout. The reconciler's ``missing_worktree_dirs`` finding only fires when the
+dir is GONE; a dir that is still present but whose ``.git`` linkage is severed
+(``git rev-parse`` fails) slips past it silently. Such a broken checkout holds no
+git-recoverable work and splits the reaper/doctor namespace, so ``t3 doctor``
+FAILs on it (#3583). Pure discovery — the CLI layer prints the verdict.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from teatree.utils.git_worktree_query import is_broken_checkout
+
+
+@dataclass(frozen=True)
+class BrokenRegisteredCheckout:
+    """A ``Worktree`` row whose recorded dir exists but is a broken checkout."""
+
+    worktree_pk: int
+    path: Path
+
+
+def find_broken_registered_checkouts() -> list[BrokenRegisteredCheckout]:
+    """Every ``Worktree`` row whose recorded dir is present but a broken checkout.
+
+    A row with no recorded ``worktree_path`` (nothing to probe) or whose dir is
+    gone (the reconciler's missing-dir finding owns that) is skipped: this gate
+    fires only on the present-but-broken case nothing else surfaces.
+    """
+    from teatree.core.models import Worktree  # noqa: PLC0415 — deferred: ORM import at call time
+
+    findings: list[BrokenRegisteredCheckout] = []
+    for worktree in Worktree.objects.all():
+        extra = worktree.extra if isinstance(worktree.extra, dict) else {}
+        path_str = str(extra.get("worktree_path", ""))
+        if not path_str:
+            continue
+        path = Path(path_str)
+        if path.is_dir() and is_broken_checkout(path):
+            findings.append(BrokenRegisteredCheckout(worktree_pk=worktree.pk, path=path))
+    return findings
+
+
+__all__ = ["BrokenRegisteredCheckout", "find_broken_registered_checkouts"]

--- a/src/teatree/core/management/commands/_workspace/isolated_roots.py
+++ b/src/teatree/core/management/commands/_workspace/isolated_roots.py
@@ -5,8 +5,15 @@ stays under the module-health LOC + function caps (mirrors
 ``_workspace_docker``). A git worktree's auto-isolated env dir
 (``~/.local/share/teatree-worktrees/<slug>`` holding a per-worktree
 ``db.sqlite3`` + ``logs/``) lingers after the checkout is gone; this reaps the
-dirs no live ``Worktree`` row references, never one holding a git checkout
-(#291, mirroring the #706/#835 data-loss discipline).
+dirs no live ``Worktree`` row references, never one holding a HEALTHY git
+checkout (#291, mirroring the #706/#835 data-loss discipline).
+
+The same root accumulates BROKEN checkouts from ad-hoc ``git worktree add`` (a
+``.git`` whose linkage is severed, so ``git rev-parse`` fails). A broken checkout
+holds no git-recoverable work — its branch ref lived in the now-unreachable
+common dir — and only spams the setup git-hooks preflight, so it is dropped
+(#3583). The ``git rev-parse`` probe (:func:`is_broken_checkout`) is the whole
+distinction between a broken checkout (reaped) and a healthy one (kept).
 """
 
 import shutil
@@ -16,6 +23,7 @@ from teatree import paths
 from teatree.core.cleanup.clean_ignore import is_clean_ignored
 from teatree.core.gates.idle_stack import worktree_protects_against_reap
 from teatree.core.models import Worktree
+from teatree.utils.git_worktree_query import is_broken_checkout
 
 
 def _has_unmappable_live_worktree() -> bool:
@@ -61,19 +69,18 @@ def _referenced_isolated_slugs() -> set[str]:
     return referenced
 
 
-def _holds_git_checkout(env_dir: Path) -> bool:
-    """Whether *env_dir* holds a git checkout — never reap one if so (#291).
+def _holds_healthy_git_checkout(env_dir: Path) -> bool:
+    """Whether *env_dir* holds a HEALTHY git checkout — never reap one if so (#291).
 
     A managed auto-isolated env dir holds only a sqlite DB + ``logs/`` and is
-    never a git checkout. A ``.git`` entry — a dir (real repo) or a file (linked
-    worktree) — means an unexpected checkout landed here, where uncommitted or
-    unpushed work could live. Such a dir is kept defensively, mirroring the
-    #706/#835 data-loss discipline: only no-checkout dirs are ever reaped. The
-    ``.git`` presence is the precise signal — working-tree state only exists when
-    a ``.git`` is present, so this one check covers both "real checkout" and "any
-    uncommitted/unpushed work".
+    never a git checkout. A ``.git`` entry that ``git rev-parse`` can resolve — a
+    dir (real repo) or a file (a live linked worktree) — means an unexpected
+    checkout landed here, where uncommitted or unpushed work could live. Such a
+    dir is kept defensively, mirroring the #706/#835 data-loss discipline. A
+    ``.git`` present but with severed linkage is a BROKEN checkout, handled
+    separately (:func:`is_broken_checkout`, #3583) — it holds no recoverable work.
     """
-    return (env_dir / ".git").exists()
+    return (env_dir / ".git").exists() and not is_broken_checkout(env_dir)
 
 
 def reap_orphan_isolated_worktree_roots() -> list[str]:
@@ -84,16 +91,19 @@ def reap_orphan_isolated_worktree_roots() -> list[str]:
     the checkout is gone but its env dir lingers, the dir is an orphan: no live
     ``Worktree`` row's checkout (its DB-backed sqlite path) hashes to its slug.
 
-    Reaps only the unreferenced dirs that hold no git checkout — a dir matching
-    a live row's slug, a ``clean_ignore`` glob, or any git work is skipped with
-    a one-line outcome. Only immediate child *directories* of the root are
-    considered; loose files (seed locks) are ignored.
+    Reaps the unreferenced dirs that hold no HEALTHY git checkout — a dir matching
+    a live row's slug, a ``clean_ignore`` glob, or any live git work is skipped
+    with a one-line outcome. A BROKEN checkout (``.git`` present but ``git
+    rev-parse`` fails) is reaped: it holds no git-recoverable work (#3583). Only
+    immediate child *directories* of the root are considered; loose files (seed
+    locks) are ignored.
 
     Liveness guard (#291/#2243): when a BUSY worktree row has no recorded
     checkout path (:func:`_has_unmappable_live_worktree`), its in-use isolated DB
     cannot be mapped to a slug, so no unreferenced dir can be proven dead. Every
     such dir is then KEPT — fail safe rather than reap a live isolated DB out
-    from under a mid-task agent.
+    from under a mid-task agent. A broken checkout is exempt from this keep — its
+    severed linkage is definitive proof it is not a live isolated DB.
     """
     root = paths.auto_isolated_worktrees_dir()
     if not root.is_dir():
@@ -108,7 +118,11 @@ def reap_orphan_isolated_worktree_roots() -> list[str]:
         if is_clean_ignored(slug):
             outcomes.append(f"SKIPPED '{slug}': matches clean_ignore — keeping")
             continue
-        if _holds_git_checkout(env_dir):
+        if is_broken_checkout(env_dir):
+            shutil.rmtree(env_dir)
+            outcomes.append(f"Removed broken worktree checkout '{slug}': git rev-parse failed — no recoverable work")
+            continue
+        if _holds_healthy_git_checkout(env_dir):
             outcomes.append(f"SKIPPED '{slug}': holds a git checkout (uncommitted/unpushed work) — keeping")
             continue
         if keep_unmappable_live:

--- a/src/teatree/utils/git_worktree_query.py
+++ b/src/teatree/utils/git_worktree_query.py
@@ -60,6 +60,21 @@ def is_git_checkout(path: str | Path) -> bool:
     return (Path(path) / ".git").exists()
 
 
+def is_broken_checkout(path: str | Path) -> bool:
+    """*path* LOOKS like a checkout (has ``.git``) but its git linkage is severed.
+
+    ``.git`` is present yet ``git rev-parse`` cannot resolve the repo — the linked
+    worktree's admin entry was pruned, or the clone it pointed at is gone. Such a
+    dir holds no git-recoverable work: its branch ref lived in the now-unreachable
+    common dir. Distinct from a hollow torn-down dir (no ``.git``, so
+    :func:`is_git_checkout` is already ``False``) and from a healthy checkout
+    (``git rev-parse`` resolves the common dir). The single source of truth for
+    "broken checkout" the #3583 reaper and doctor gate share.
+    """
+    p = Path(path)
+    return (p / ".git").exists() and git_common_dir(p) is None
+
+
 @dataclass(frozen=True, slots=True)
 class WorktreeRecord:
     """One record parsed from ``git worktree list --porcelain``."""

--- a/tests/teatree_cli/doctor/test_bootstrap_checks.py
+++ b/tests/teatree_cli/doctor/test_bootstrap_checks.py
@@ -13,12 +13,16 @@ from teatree.cli.doctor.checks_bootstrap import (
     _check_gh_token_permissions,
     _check_git_hooks_installed,
     _check_provision_concurrency_from_host,
+    _check_registered_worktree_checkouts,
     _resolve_projects_config,
     _slug_from_repo_url,
 )
 from teatree.core.gates.gh_token_preflight import GhTokenProbe
+from teatree.core.gates.worktree_checkout_integrity import BrokenRegisteredCheckout
 from teatree.core.models.config_setting import ConfigSetting
 from tests._git_repo import make_git_repo, run_git
+
+_INTEGRITY = "teatree.core.gates.worktree_checkout_integrity.find_broken_registered_checkouts"
 
 
 class TestSlugFromRepoUrl:
@@ -270,3 +274,27 @@ class TestClaudeSettingsDrift:
         monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path / "home"))
         with patch("teatree.cli.doctor.checks_bootstrap._teatree_repo_root", return_value=repo):
             assert _check_claude_settings_drift() is True
+
+
+class TestRegisteredWorktreeCheckoutsCheck(TestCase):
+    def test_passes_when_no_broken_checkouts(self) -> None:
+        with patch(_INTEGRITY, return_value=[]):
+            assert _check_registered_worktree_checkouts() is True
+
+    def test_fails_loud_on_a_broken_registered_checkout(self) -> None:
+        finding = BrokenRegisteredCheckout(worktree_pk=7, path=Path("/wt/broken"))
+        out = io.StringIO()
+        with patch(_INTEGRITY, return_value=[finding]), contextlib.redirect_stdout(out):
+            ok = _check_registered_worktree_checkouts()
+        assert ok is False
+        printed = out.getvalue()
+        assert "FAIL" in printed
+        assert "wt#7" in printed
+        assert "/wt/broken" in printed
+
+    def test_crash_proof_probe_warns_and_passes(self) -> None:
+        out = io.StringIO()
+        with patch(_INTEGRITY, side_effect=RuntimeError("boom")), contextlib.redirect_stdout(out):
+            ok = _check_registered_worktree_checkouts()
+        assert ok is True
+        assert "WARN" in out.getvalue()

--- a/tests/teatree_core/gates/test_worktree_checkout_integrity.py
+++ b/tests/teatree_core/gates/test_worktree_checkout_integrity.py
@@ -1,0 +1,61 @@
+"""``find_broken_registered_checkouts`` — registered rows whose dir is a broken checkout.
+
+A ``Worktree`` row's ``extra['worktree_path']`` should point at a live git
+checkout. A dir that EXISTS but fails ``git rev-parse`` is a broken checkout the
+reconciler's missing-dir finding never fires on (the dir is present), so nothing
+surfaces it. This gate names each one for the ``t3 doctor`` FAIL (#3583).
+"""
+
+import tempfile
+from pathlib import Path
+
+from django.test import TestCase
+
+from teatree.core.gates.worktree_checkout_integrity import find_broken_registered_checkouts
+from teatree.core.models import Ticket, Worktree
+from tests._git_repo import make_git_repo, run_git
+
+
+class TestFindBrokenRegisteredCheckouts(TestCase):
+    def setUp(self) -> None:
+        self.root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+
+    def _register(self, checkout: Path | None, *, branch: str = "b") -> Worktree:
+        ticket = Ticket.objects.create(overlay="test", issue_url=f"https://example.com/i/{branch}")
+        extra = {"worktree_path": str(checkout)} if checkout is not None else {}
+        return Worktree.objects.create(ticket=ticket, overlay="test", repo_path="org/repo", branch=branch, extra=extra)
+
+    def test_broken_registered_checkout_is_reported(self) -> None:
+        broken = self.root / "broken"
+        broken.mkdir()
+        (broken / ".git").write_text("gitdir: /gone/.git/worktrees/x\n", encoding="utf-8")
+        wt = self._register(broken, branch="broken")
+
+        findings = find_broken_registered_checkouts()
+
+        assert [f.worktree_pk for f in findings] == [wt.pk]
+        assert findings[0].path == broken
+
+    def test_healthy_registered_checkout_is_not_reported(self) -> None:
+        healthy = make_git_repo(self.root / "healthy")
+        self._register(healthy, branch="healthy")
+
+        assert find_broken_registered_checkouts() == []
+
+    def test_healthy_linked_worktree_is_not_reported(self) -> None:
+        clone = make_git_repo(self.root / "clone")
+        wt_dir = self.root / "linked"
+        run_git(clone, "worktree", "add", str(wt_dir))
+        self._register(wt_dir, branch="linked")
+
+        assert find_broken_registered_checkouts() == []
+
+    def test_missing_dir_is_not_reported(self) -> None:
+        self._register(self.root / "never-created", branch="gone")
+
+        assert find_broken_registered_checkouts() == []
+
+    def test_pathless_row_is_skipped(self) -> None:
+        self._register(None, branch="pathless")
+
+        assert find_broken_registered_checkouts() == []

--- a/tests/teatree_core/management/commands/test__workspace_isolated_roots.py
+++ b/tests/teatree_core/management/commands/test__workspace_isolated_roots.py
@@ -3,8 +3,13 @@
 A git worktree's auto-isolated env dir (``~/.local/share/teatree-worktrees/
 <slug>``, holding ``db.sqlite3`` + ``logs/``) lingers after the checkout is
 gone, so clean-all reaps the dirs no live ``Worktree`` row references — but
-never one that still holds a git checkout or any uncommitted/unpushed work
-(#291, mirroring the #706/#835 data-loss discipline).
+never one that still holds a HEALTHY git checkout or any uncommitted/unpushed
+work (#291, mirroring the #706/#835 data-loss discipline).
+
+The same root also accumulates BROKEN checkouts left by ad-hoc ``git worktree
+add`` (a ``.git`` whose linkage is severed, so ``git rev-parse`` fails). A broken
+checkout holds no git-recoverable work, so the reaper drops it (#3583) — the
+distinction from a healthy checkout is the ``git rev-parse`` probe.
 """
 
 import shutil
@@ -19,7 +24,7 @@ from teatree import paths
 from teatree.core.management.commands._workspace import isolated_roots as reaper
 from teatree.core.models import Session, Task, Ticket, Worktree
 from teatree.core.models.external_delivery import mark_external_delivery
-from tests._git_repo import make_git_repo
+from tests._git_repo import make_git_repo, run_git
 
 _REAP = "teatree.core.management.commands._workspace.isolated_roots"
 
@@ -69,7 +74,7 @@ class TestReapOrphanIsolatedWorktreeRoots(TestCase):
         assert referenced.exists()
         assert not any("Removed orphan isolated worktree root" in line for line in result)
 
-    def test_dir_holding_a_git_checkout_is_skipped(self) -> None:
+    def test_dir_holding_a_healthy_git_checkout_is_kept(self) -> None:
         slug = paths.isolated_slug(Path("/gone/with/git"))
         env_dir = make_git_repo(self.root / slug, initial_commit=False)
 
@@ -78,15 +83,61 @@ class TestReapOrphanIsolatedWorktreeRoots(TestCase):
         assert env_dir.exists()
         assert any("SKIPPED" in line and slug in line for line in result)
 
-    def test_dir_with_a_git_file_worktree_pointer_is_skipped(self) -> None:
-        slug = paths.isolated_slug(Path("/gone/linked/wt"))
-        env_dir = _make_env_dir(self.root, slug)
+    def test_healthy_linked_worktree_is_kept(self) -> None:
+        clone = make_git_repo(Path(self.enterContext(tempfile.TemporaryDirectory())) / "clone")
+        wt = self.root / "live-linked"
+        run_git(clone, "worktree", "add", str(wt))
+
+        result = reaper.reap_orphan_isolated_worktree_roots()
+
+        assert wt.exists()
+        assert any("SKIPPED" in line and "live-linked" in line for line in result)
+
+    def test_broken_worktree_checkout_is_reaped(self) -> None:
+        """A ``.git`` whose linkage is severed (``git rev-parse`` fails) is dropped (#3583).
+
+        Documented red-first inversion: the prior test asserted this dir is
+        SKIPPED (kept) — but a broken checkout holds no git-recoverable work and
+        only spams the setup git-hooks preflight, so it must be reaped.
+        """
+        env_dir = self.root / "bench-guard"
+        env_dir.mkdir()
         (env_dir / ".git").write_text("gitdir: /elsewhere/.git/worktrees/x\n")
 
         result = reaper.reap_orphan_isolated_worktree_roots()
 
+        assert not env_dir.exists()
+        assert any("Removed broken worktree checkout" in line and "bench-guard" in line for line in result)
+
+    def test_clean_ignored_broken_checkout_is_kept(self) -> None:
+        """clean_ignore is the operator escape hatch — it protects even a broken checkout."""
+        env_dir = self.root / "keepme"
+        env_dir.mkdir()
+        (env_dir / ".git").write_text("gitdir: /elsewhere/.git/worktrees/x\n")
+        with patch(f"{_REAP}.is_clean_ignored", return_value=True):
+            result = reaper.reap_orphan_isolated_worktree_roots()
+
         assert env_dir.exists()
-        assert any("SKIPPED" in line and slug in line for line in result)
+        assert any("SKIPPED" in line and "keepme" in line for line in result)
+
+    def test_broken_checkout_reaped_despite_unmappable_live_keep(self) -> None:
+        """A broken checkout is reaped even when a pathless live row keeps the env dirs (#3583).
+
+        The global keep-set (a live worktree with no recorded checkout path)
+        protects env dirs that MIGHT be its isolated DB — but a broken checkout's
+        severed ``.git`` is definitive proof it is not one, so it is still dropped.
+        """
+        ticket = Ticket.objects.create(overlay="test", issue_url="https://example.com/issues/3583")
+        Worktree.objects.create(ticket=ticket, overlay="test", repo_path="org/repo", branch="busy-no-path", extra={})
+        Session.objects.create(ticket=ticket, overlay="test")  # live: keep_unmappable_live is set
+        broken = self.root / "broken-sibling"
+        broken.mkdir()
+        (broken / ".git").write_text("gitdir: /elsewhere/.git/worktrees/x\n")
+
+        result = reaper.reap_orphan_isolated_worktree_roots()
+
+        assert not broken.exists()
+        assert any("Removed broken worktree checkout" in line and "broken-sibling" in line for line in result)
 
     def test_clean_ignored_slug_is_skipped(self) -> None:
         slug = paths.isolated_slug(Path("/gone/ignored"))

--- a/tests/teatree_utils/test_git_worktree.py
+++ b/tests/teatree_utils/test_git_worktree.py
@@ -6,6 +6,7 @@ the checkout / hollow-directory guard. Exercised against real ``git`` under
 details a mock would paper over.
 """
 
+import shutil
 from pathlib import Path
 
 import pytest
@@ -15,6 +16,7 @@ from teatree.utils.git_worktree_query import (
     WorktreeRecord,
     canonical_repo_root,
     git_common_dir,
+    is_broken_checkout,
     is_git_checkout,
     list_worktrees,
     worktree_for_branch,
@@ -78,6 +80,33 @@ class TestIsGitCheckout:
         hollow = tmp_path / "hollow"
         (hollow / "staticfiles").mkdir(parents=True)  # generated artifacts, no .git
         assert is_git_checkout(hollow) is False
+
+
+class TestIsBrokenCheckout:
+    def test_false_for_a_healthy_clone(self, repo: Path) -> None:
+        assert is_broken_checkout(repo) is False
+
+    def test_false_for_a_healthy_linked_worktree(self, repo: Path, tmp_path: Path) -> None:
+        wt = tmp_path / "wt"
+        _git(repo, "worktree", "add", str(wt))
+        assert is_broken_checkout(wt) is False
+
+    def test_false_for_a_hollow_directory(self, tmp_path: Path) -> None:
+        hollow = tmp_path / "hollow"
+        hollow.mkdir()  # no .git at all — a torn-down dir, not a broken checkout
+        assert is_broken_checkout(hollow) is False
+
+    def test_true_for_a_severed_worktree_pointer(self, tmp_path: Path) -> None:
+        severed = tmp_path / "severed"
+        severed.mkdir()
+        (severed / ".git").write_text("gitdir: /gone/.git/worktrees/x\n", encoding="utf-8")
+        assert is_broken_checkout(severed) is True
+
+    def test_true_when_the_owning_clone_is_removed(self, repo: Path, tmp_path: Path) -> None:
+        wt = tmp_path / "orphaned"
+        _git(repo, "worktree", "add", str(wt))
+        shutil.rmtree(repo)  # the clone holding the shared .git is gone
+        assert is_broken_checkout(wt) is True
 
 
 class TestListWorktrees:


### PR DESCRIPTION
fix(workspace): reap broken worktree checkouts + doctor FAIL on registered non-checkouts (#3583)

## What
- reap `teatree-worktrees/*` dirs whose `.git` fails `git rev-parse` in
  `reap_orphan_isolated_worktree_roots` (folded into the existing clean-all
  reaper) — a broken checkout holds no git-recoverable work (its branch ref
  lived in the now-unreachable common dir), so it is dropped, not kept
- `t3 doctor` hard FAIL on a registered `Worktree` dir that exists but is not a
  git checkout (`_check_registered_worktree_checkouts`) — the reconciler's
  missing-dir finding never fires on present-but-broken, so it lingered silent
- shared `is_broken_checkout` predicate: single source of truth for reaper + doctor
- safety: a HEALTHY checkout and the unmappable-live keep are untouched

Scope vs #3583:
- done #1 periodic broken-worktree reaper (folded into clean-all; doctor surfaces each run)
- done #3 doctor FAIL on a present-but-not-a-checkout registered dir
- NOT done #2 collapse the alternate worktree root into one canonical dir

Open questions & assumptions:
- open: #2 (single worktree root) not implemented — needs an owner call on which
  root is canonical (the DB-isolation root vs config `worktree_root()`, which are
  deliberately separate) and whether to migrate live worktrees (high blast radius).
  Recommend a dedicated follow-up ticket.
- assumed: "periodic" is satisfied by the doctor FAIL (doctor/self-heal cadence)
  plus the existing clean-all reaper, per the ticket's "fold into the existing
  reaper or t3 doctor".
- assumed: adopted a prior session's uncommitted in-flight work in wt-3583 (no
  live sibling; ~8h stale) and committed it to make it durable.

docs: n/a — internal reaper/doctor hardening, no user-facing command or flag added

Relates to #3583

## Why
TODO — opened automatically by the no-orphan pre-push hook, which sees only the commit. Replace this line with the rationale before requesting review.