### PR TITLE
fix(cli): warn only when an overlay actually declares tool commands

### DIFF
--- a/docs/overlay-api.md
+++ b/docs/overlay-api.md
@@ -87,7 +87,7 @@ Project metadata, CI integration, MR validation, and skill registration live on 
 | `get_ci_project_path()` | `""` | CI project path for pipeline triggers and evidence posting |
 | `get_e2e_config()` | `{}` | E2E runner config: `runner` (`"project"` / `"external"`), plus `test_dir` / `settings_module` (project runner) or `project_path` / `ref` (external runner) |
 | `detect_variant()` | `""` | Detect the current tenant variant from project context |
-| `get_tool_commands()` | `[]` | Custom tool commands exposed via `t3 <overlay> tool run` |
+| `get_tool_commands()` | `[]` | Custom tool commands exposed via `t3 <overlay> tool run`. Declaring the surface is separate from declaring where skills live (`get_skill_metadata()`'s `skill_root`): the CLI group itself registers from the skill tree's `*/hook-config/tool-commands.json`, and a non-empty declaration with no such manifest is the one warned misconfiguration. Leaving this at `[]` is the ordinary case for an overlay that ships skills and no tools — it is silent |
 | `get_issue_title(url)` | `""` | Fetch the title of an issue from its URL |
 
 ## `OverlayBase`

--- a/src/teatree/cli/overlay.py
+++ b/src/teatree/cli/overlay.py
@@ -536,28 +536,30 @@ class OverlayAppBuilder:
         back to ``<project>/skills`` — the documented per-overlay layout (one skill
         dir per package), which is fast and side-steps an unbounded ``rglob`` over
         the whole project tree (``.venv/``, ``__pycache__/``, ``node_modules/``).
-        """
-        from teatree.core.overlay_skills import (  # noqa: PLC0415 — deferred: keeps CLI startup light
-            overlay_skill_metadata,
-            overlay_skills_root,
-        )
 
-        metadata = overlay_skill_metadata(self.overlay_name)
-        skills_root = overlay_skills_root(metadata, self.project_path)
+        The manifest REGISTERS the group; ``get_tool_commands()`` DECLARES the
+        surface. The two disagreeing is the warned condition (#3904, #3915) —
+        never the mere presence of a skills root.
+        """
+        from teatree.core import overlay_skills  # noqa: PLC0415 — deferred: keeps CLI startup light
+
+        metadata = overlay_skills.overlay_skill_metadata(self.overlay_name)
+        skills_root = overlay_skills.overlay_skills_root(metadata, self.project_path)
         if skills_root is None:
             return
 
         tool_commands = self._read_tool_commands(skills_root)
         if not tool_commands:
-            # A declared root that yields nothing is a real misconfiguration — the
-            # operator has a documented tool surface that would silently not exist.
-            # Name the searched path instead of returning silently (#3355). The
-            # default ``<project>/skills`` fallback stays quiet: an overlay that
-            # simply ships no tools is not a misconfiguration.
-            if metadata.get("skill_root"):
+            # A DECLARED tool surface that yields no manifest is the real
+            # misconfiguration — the operator has documented commands that would
+            # silently not exist. Name the searched path instead of returning
+            # silently (#3355). Keying this on ``skill_root`` instead fired on
+            # every invocation of every overlay that merely ships skills (#3904,
+            # #3915) — the same judgement the ``<project>/skills`` fallback got.
+            if overlay_skills.overlay_declares_tool_commands(self.overlay_name):
                 logger.warning(
-                    "overlay %r declares a skills root (%s) but no */hook-config/tool-commands.json "
-                    "was found there — the `t3 %s tool` command group is not registered.",
+                    "overlay %r declares tool commands but no */hook-config/tool-commands.json "
+                    "was found under %s — the `t3 %s tool` command group is not registered.",
                     self.overlay_name,
                     skills_root,
                     self.overlay_name,

--- a/src/teatree/core/overlay_skills.py
+++ b/src/teatree/core/overlay_skills.py
@@ -14,6 +14,12 @@ skills root via ``SkillMetadata['skill_root']``
 (:meth:`teatree.core.overlay_metadata.OverlayMetadata.get_skill_metadata`); the
 resolver falls back to ``<project>/skills`` when it is unset, so every overlay
 that works today keeps working unchanged.
+
+``skill_root`` locates skills and nothing else — it is never a claim to expose
+``t3 <overlay> tool`` commands. That claim is the separate, optional
+``get_tool_commands()`` hook, which :func:`overlay_declares_tool_commands`
+reads so the registrar's missing-manifest warning fires on a real mismatch
+rather than on every invocation of every skill-shipping overlay (#3904, #3915).
 """
 
 import logging
@@ -44,6 +50,27 @@ def overlay_skills_root(skill_metadata: "SkillMetadata", project_path: Path | No
     return None
 
 
+def overlay_declares_tool_commands(overlay_name: str) -> bool:
+    """Whether *overlay_name* claims a ``t3 <overlay> tool`` surface.
+
+    ``skill_root`` says where an overlay's SKILLS live; exposing tool commands is
+    the separate, optional ``get_tool_commands()`` extension point. The tool
+    registrar keys its missing-manifest warning on THIS, so an overlay that ships
+    skills and no tools — the common, correct case — stays silent (#3904, #3915).
+
+    Guarded exactly like :func:`overlay_skill_metadata`: at CLI-BUILD time the
+    overlay is unavailable, and a declaration that cannot be read is not a
+    misconfiguration worth warning about on every invocation.
+    """
+    from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415 — deferred: keeps CLI/build startup light
+
+    try:
+        return bool(get_overlay(overlay_name or None).metadata.get_tool_commands())
+    except ImproperlyConfigured:
+        logger.debug("tool-command declaration unavailable for overlay %r; assuming none", overlay_name)
+        return False
+
+
 def overlay_skill_metadata(overlay_name: str) -> "SkillMetadata":
     """Best-effort :class:`SkillMetadata` for *overlay_name*; ``{}`` when unavailable.
 
@@ -63,4 +90,4 @@ def overlay_skill_metadata(overlay_name: str) -> "SkillMetadata":
         return {}
 
 
-__all__ = ["overlay_skill_metadata", "overlay_skills_root"]
+__all__ = ["overlay_declares_tool_commands", "overlay_skill_metadata", "overlay_skills_root"]

--- a/src/teatree/core/overlay_skills.py
+++ b/src/teatree/core/overlay_skills.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING
 from django.core.exceptions import ImproperlyConfigured
 
 if TYPE_CHECKING:
+    from teatree.core.overlay import OverlayBase
     from teatree.types import SkillMetadata
 
 logger = logging.getLogger(__name__)
@@ -50,6 +51,24 @@ def overlay_skills_root(skill_metadata: "SkillMetadata", project_path: Path | No
     return None
 
 
+def _overlay_or_none(overlay_name: str) -> "OverlayBase | None":
+    """The registered overlay for *overlay_name*, or ``None`` when unavailable.
+
+    The single guarded load both resolvers below share. It is guarded because
+    they run at CLI-BUILD time — before Django is configured — where
+    :func:`teatree.core.overlay_loader.get_overlay` raises
+    :class:`~django.core.exceptions.ImproperlyConfigured`. Each caller then
+    answers with its neutral default, so a build-time caller never regresses.
+    """
+    from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415 — deferred: keeps CLI/build startup light
+
+    try:
+        return get_overlay(overlay_name or None)
+    except ImproperlyConfigured:
+        logger.debug("overlay %r unavailable; answering with the neutral default", overlay_name)
+        return None
+
+
 def overlay_declares_tool_commands(overlay_name: str) -> bool:
     """Whether *overlay_name* claims a ``t3 <overlay> tool`` surface.
 
@@ -57,37 +76,22 @@ def overlay_declares_tool_commands(overlay_name: str) -> bool:
     the separate, optional ``get_tool_commands()`` extension point. The tool
     registrar keys its missing-manifest warning on THIS, so an overlay that ships
     skills and no tools — the common, correct case — stays silent (#3904, #3915).
-
-    Guarded exactly like :func:`overlay_skill_metadata`: at CLI-BUILD time the
-    overlay is unavailable, and a declaration that cannot be read is not a
-    misconfiguration worth warning about on every invocation.
+    A declaration that cannot be read is not a misconfiguration to warn about.
     """
-    from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415 — deferred: keeps CLI/build startup light
-
-    try:
-        return bool(get_overlay(overlay_name or None).metadata.get_tool_commands())
-    except ImproperlyConfigured:
-        logger.debug("tool-command declaration unavailable for overlay %r; assuming none", overlay_name)
-        return False
+    overlay = _overlay_or_none(overlay_name)
+    return bool(overlay.metadata.get_tool_commands()) if overlay is not None else False
 
 
 def overlay_skill_metadata(overlay_name: str) -> "SkillMetadata":
     """Best-effort :class:`SkillMetadata` for *overlay_name*; ``{}`` when unavailable.
 
-    Guarded because the overlay-tool registrar runs at CLI-BUILD time — before
-    Django is configured — where :func:`teatree.core.overlay_loader.get_overlay`
-    raises :class:`~django.core.exceptions.ImproperlyConfigured`. The resolver
-    then falls back to ``<project>/skills`` exactly as before, so a build-time
-    caller never regresses; a caller that runs with Django up (doctor,
-    skill-preamble) gets the overlay's declared root.
+    Unavailable is the CLI-BUILD-time case (see :func:`_overlay_or_none`), where
+    ``{}`` falls the root back to ``<project>/skills``, so a build-time caller
+    never regresses; a caller that runs with Django up (doctor, skill-preamble)
+    gets the overlay's declared root.
     """
-    from teatree.core.overlay_loader import get_overlay  # noqa: PLC0415 — deferred: keeps CLI/build startup light
-
-    try:
-        return get_overlay(overlay_name or None).metadata.get_skill_metadata()
-    except ImproperlyConfigured:
-        logger.debug("skill metadata unavailable for overlay %r; using the default root", overlay_name)
-        return {}
+    overlay = _overlay_or_none(overlay_name)
+    return overlay.metadata.get_skill_metadata() if overlay is not None else {}
 
 
 __all__ = ["overlay_declares_tool_commands", "overlay_skill_metadata", "overlay_skills_root"]

--- a/tests/teatree_cli/test_overlay_tool_registration.py
+++ b/tests/teatree_cli/test_overlay_tool_registration.py
@@ -1,9 +1,10 @@
 """Overlay ``tool`` group registration resolves its root through the seam (#3355).
 
-Before the fix a non-``<project>/skills`` layout matched zero files and the whole
-``t3 <overlay> tool`` group vanished with no diagnostic. These prove the tool
-group registers from a declared ``skill_root``, and that a declared-but-empty root
-warns instead of returning silently.
+A non-``<project>/skills`` layout matched zero files and the whole ``t3 <overlay>
+tool`` group vanished with no diagnostic. These prove the tool group registers
+from a declared ``skill_root``, and that the missing-manifest warning is keyed on
+the overlay DECLARING tool commands (``get_tool_commands()``) rather than on
+``skill_root`` — which says only where an overlay's skills live (#3904, #3915).
 """
 
 import json
@@ -14,6 +15,7 @@ import pytest
 import typer
 
 from teatree.cli.overlay import OverlayAppBuilder
+from teatree.types import SkillMetadata, ToolCommand
 
 
 def _write_tool_commands(skills_root: Path) -> None:
@@ -23,6 +25,27 @@ def _write_tool_commands(skills_root: Path) -> None:
         json.dumps([{"name": "widget", "help": "Do a thing", "command": "widget_cmd"}]),
         encoding="utf-8",
     )
+
+
+def _patch_overlay(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    skill_metadata: SkillMetadata,
+    tool_commands: list[ToolCommand],
+) -> None:
+    """Stand a stub overlay behind ``get_overlay`` — the one seam both resolvers use."""
+
+    class _Metadata:
+        def get_skill_metadata(self) -> SkillMetadata:
+            return skill_metadata
+
+        def get_tool_commands(self) -> list[ToolCommand]:
+            return tool_commands
+
+    class _Overlay:
+        metadata = _Metadata()
+
+    monkeypatch.setattr("teatree.core.overlay_loader.get_overlay", lambda _name=None: _Overlay())
 
 
 def _group_names(app: typer.Typer) -> set[str]:
@@ -35,27 +58,46 @@ def test_tool_group_registers_from_a_declared_skill_root(tmp_path: Path, monkeyp
     custom_root = tmp_path / "packaged" / "skills"
     _write_tool_commands(custom_root)
 
-    monkeypatch.setattr(
-        "teatree.core.overlay_skills.overlay_skill_metadata",
-        lambda _name: {"skill_root": str(custom_root)},
-    )
+    _patch_overlay(monkeypatch, skill_metadata={"skill_root": str(custom_root)}, tool_commands=[])
 
     builder = OverlayAppBuilder("t3-demo", project)
     builder._register_overlay_tools()
     assert "tool" in _group_names(builder.overlay_app)
 
 
-def test_declared_root_without_tool_commands_warns(
+def test_declared_skill_root_without_tool_commands_stays_quiet(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
+    # The shipped shape: an overlay declares where its SKILLS live and exposes no
+    # tool commands. That is not a misconfiguration, so it must not warn on every
+    # single CLI invocation (#3904, #3915).
     project = tmp_path / "project"
     project.mkdir()
-    empty_root = tmp_path / "packaged" / "skills"
-    empty_root.mkdir(parents=True)
+    skills_root = tmp_path / "packaged" / "skills"
+    skills_root.mkdir(parents=True)
 
-    monkeypatch.setattr(
-        "teatree.core.overlay_skills.overlay_skill_metadata",
-        lambda _name: {"skill_root": str(empty_root)},
+    _patch_overlay(monkeypatch, skill_metadata={"skill_root": str(skills_root)}, tool_commands=[])
+
+    builder = OverlayAppBuilder("t3-demo", project)
+    with caplog.at_level(logging.WARNING, logger="teatree.cli.overlay"):
+        builder._register_overlay_tools()
+
+    assert "tool" not in _group_names(builder.overlay_app)
+    assert caplog.records == []
+
+
+def test_declared_tool_commands_without_manifest_warns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # The genuine misconfiguration: the overlay declares a tool surface, but no
+    # manifest registers it, so the documented commands silently do not exist.
+    project = tmp_path / "project"
+    (project / "skills").mkdir(parents=True)
+
+    _patch_overlay(
+        monkeypatch,
+        skill_metadata={},
+        tool_commands=[{"name": "widget", "help": "Do a thing", "command": "widget_cmd"}],
     )
 
     builder = OverlayAppBuilder("t3-demo", project)
@@ -63,7 +105,8 @@ def test_declared_root_without_tool_commands_warns(
         builder._register_overlay_tools()
 
     assert "tool" not in _group_names(builder.overlay_app)
-    assert any("skills root" in rec.message and str(empty_root) in rec.getMessage() for rec in caplog.records)
+    assert any("declares tool commands" in rec.getMessage() for rec in caplog.records)
+    assert any(str(project / "skills") in rec.getMessage() for rec in caplog.records)
 
 
 def test_default_layout_without_tools_stays_quiet(
@@ -74,7 +117,7 @@ def test_default_layout_without_tools_stays_quiet(
     project = tmp_path / "project"
     (project / "skills").mkdir(parents=True)
 
-    monkeypatch.setattr("teatree.core.overlay_skills.overlay_skill_metadata", lambda _name: {})
+    _patch_overlay(monkeypatch, skill_metadata={}, tool_commands=[])
 
     builder = OverlayAppBuilder("t3-demo", project)
     with caplog.at_level(logging.WARNING, logger="teatree.cli.overlay"):

--- a/tests/teatree_core/test_overlay_skills.py
+++ b/tests/teatree_core/test_overlay_skills.py
@@ -6,7 +6,7 @@ import pytest
 from django.core.exceptions import ImproperlyConfigured
 
 from teatree.core import overlay_skills
-from teatree.core.overlay_skills import overlay_skill_metadata, overlay_skills_root
+from teatree.core.overlay_skills import overlay_declares_tool_commands, overlay_skill_metadata, overlay_skills_root
 
 
 class TestOverlaySkillsRoot:
@@ -51,4 +51,41 @@ class TestOverlaySkillMetadata:
         assert overlay_skill_metadata("anything") == {}
 
     def test_module_exports_resolver(self) -> None:
-        assert set(overlay_skills.__all__) == {"overlay_skill_metadata", "overlay_skills_root"}
+        assert set(overlay_skills.__all__) == {
+            "overlay_declares_tool_commands",
+            "overlay_skill_metadata",
+            "overlay_skills_root",
+        }
+
+
+class TestOverlayDeclaresToolCommands:
+    """``skill_root`` is not a tool claim; ``get_tool_commands()`` is (#3904, #3915)."""
+
+    @staticmethod
+    def _patch(monkeypatch: pytest.MonkeyPatch, tool_commands: list[dict[str, str]]) -> None:
+        class _Meta:
+            @staticmethod
+            def get_tool_commands() -> list[dict[str, str]]:
+                return tool_commands
+
+        class _Overlay:
+            metadata = _Meta()
+
+        monkeypatch.setattr("teatree.core.overlay_loader.get_overlay", lambda _name: _Overlay())
+
+    def test_true_when_the_overlay_declares_commands(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch(monkeypatch, [{"name": "widget", "command": "widget_cmd"}])
+        assert overlay_declares_tool_commands("t3-teatree") is True
+
+    def test_false_for_an_overlay_that_ships_only_skills(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._patch(monkeypatch, [])
+        assert overlay_declares_tool_commands("t3-teatree") is False
+
+    def test_false_when_overlay_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Build time again: an unreadable declaration is not a misconfiguration.
+        def _raise(_name: str | None) -> object:
+            msg = "settings are not configured"
+            raise ImproperlyConfigured(msg)
+
+        monkeypatch.setattr("teatree.core.overlay_loader.get_overlay", _raise)
+        assert overlay_declares_tool_commands("anything") is False


### PR DESCRIPTION
## What

`_register_tool_commands` warned whenever an overlay set `skill_root` in its skill
metadata and no `*/hook-config/tool-commands.json` was found under it. `skill_root`
declares where an overlay's SKILLS live — it is not a claim to expose tool commands.
Exposing those is a separate, optional extension point (`get_tool_commands()`,
documented as defaulting to `[]`), so an overlay that ships skills and no tools —
the common, correct case — tripped the warning on every command.

The warning is now keyed on the overlay actually declaring tool commands while the
manifest that would register them is missing. That is the real misconfiguration: a
documented tool surface that silently does not exist. It is the same judgement the
`<project>/skills` fallback path already applied a few lines above.

- `overlay_declares_tool_commands()` joins the existing resolvers in
  `teatree.core.overlay_skills`, guarded exactly like `overlay_skill_metadata()` —
  at CLI-build time the overlay is unreadable, and a declaration that cannot be read
  is not a misconfiguration worth warning about.
- The warning text now names the declaration, not the skills root.
- `docs/overlay-api.md` states that declaring the surface and declaring where skills
  live are separate, and that leaving `get_tool_commands()` at `[]` is silent.

## Why

The warning fired on 100% of invocations. A warning that always fires trains every
reader — human and agent — to skim the log preamble, which is exactly where a real,
occasional warning then gets missed. It also pollutes every captured command output,
making transcripts and issue evidence harder to read.

Either a condition is actionable and should be fixed, or it is not and should not
warn. This one was not actionable, because nothing was misconfigured.

## Tests

Both new tests were observed RED before the fix:

- `test_declared_skill_root_without_tool_commands_stays_quiet` — failed with the
  false-positive warning present in `caplog`.
- `test_declared_tool_commands_without_manifest_warns` — failed because the genuine
  misconfiguration produced no warning at all.

`tests/teatree_core/test_overlay_skills.py` gains direct coverage of the new
resolver, including the build-time unreadable-overlay path.

Closes #3904
Closes #3915
